### PR TITLE
crypto/bio/b_dump.c: change all char* to void*, and constify

### DIFF
--- a/crypto/bio/b_dump.c
+++ b/crypto/bio/b_dump.c
@@ -20,14 +20,15 @@
 #define SPACE(buf, pos, n)   (sizeof(buf) - (pos) > (n))
 
 int BIO_dump_cb(int (*cb) (const void *data, size_t len, void *u),
-                void *u, const char *s, int len)
+                void *u, const void *s, int len)
 {
     return BIO_dump_indent_cb(cb, u, s, len, 0);
 }
 
 int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
-                       void *u, const char *s, int len, int indent)
+                       void *u, const void *v, int len, int indent)
 {
+    const unsigned char *s = v;
     int ret = 0;
     char buf[288 + 1];
     int i, j, rows, n;
@@ -51,7 +52,7 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
                 if (((i * dump_width) + j) >= len) {
                     strcpy(buf + n, "   ");
                 } else {
-                    ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
+                    ch = *(s + i * dump_width + j) & 0xff;
                     BIO_snprintf(buf + n, 4, "%02x%c", ch,
                                  j == 7 ? '-' : ' ');
                 }
@@ -66,7 +67,7 @@ int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
             if (((i * dump_width) + j) >= len)
                 break;
             if (SPACE(buf, n, 1)) {
-                ch = ((unsigned char)*(s + i * dump_width + j)) & 0xff;
+                ch = *(s + i * dump_width + j) & 0xff;
 #ifndef CHARSET_EBCDIC
                 buf[n++] = ((ch >= ' ') && (ch <= '~')) ? ch : '.';
 #else
@@ -96,12 +97,12 @@ static int write_fp(const void *data, size_t len, void *fp)
     return UP_fwrite(data, len, 1, fp);
 }
 
-int BIO_dump_fp(FILE *fp, const char *s, int len)
+int BIO_dump_fp(FILE *fp, const void *s, int len)
 {
     return BIO_dump_cb(write_fp, fp, s, len);
 }
 
-int BIO_dump_indent_fp(FILE *fp, const char *s, int len, int indent)
+int BIO_dump_indent_fp(FILE *fp, const void *s, int len, int indent)
 {
     return BIO_dump_indent_cb(write_fp, fp, s, len, indent);
 }
@@ -112,19 +113,20 @@ static int write_bio(const void *data, size_t len, void *bp)
     return BIO_write((BIO *)bp, (const char *)data, len);
 }
 
-int BIO_dump(BIO *bp, const char *s, int len)
+int BIO_dump(BIO *bp, const void *s, int len)
 {
     return BIO_dump_cb(write_bio, bp, s, len);
 }
 
-int BIO_dump_indent(BIO *bp, const char *s, int len, int indent)
+int BIO_dump_indent(BIO *bp, const void *s, int len, int indent)
 {
     return BIO_dump_indent_cb(write_bio, bp, s, len, indent);
 }
 
-int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
+int BIO_hex_string(BIO *out, int indent, int width, const void *data,
                    int datalen)
 {
+    const unsigned char *d = data;
     int i, j = 0;
 
     if (datalen < 1)
@@ -134,7 +136,7 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
         if (i && !j)
             BIO_printf(out, "%*s", indent, "");
 
-        BIO_printf(out, "%02X:", data[i]);
+        BIO_printf(out, "%02X:", d[i]);
 
         j = (j + 1) % width;
         if (!j)
@@ -143,6 +145,6 @@ int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
 
     if (i && !j)
         BIO_printf(out, "%*s", indent, "");
-    BIO_printf(out, "%02X", data[datalen - 1]);
+    BIO_printf(out, "%02X", d[datalen - 1]);
     return 1;
 }

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -641,16 +641,16 @@ int BIO_sock_non_fatal_error(int error);
 int BIO_fd_should_retry(int i);
 int BIO_fd_non_fatal_error(int error);
 int BIO_dump_cb(int (*cb) (const void *data, size_t len, void *u),
-                void *u, const char *s, int len);
+                void *u, const void *s, int len);
 int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
-                       void *u, const char *s, int len, int indent);
-int BIO_dump(BIO *b, const char *bytes, int len);
-int BIO_dump_indent(BIO *b, const char *bytes, int len, int indent);
+                       void *u, const void *s, int len, int indent);
+int BIO_dump(BIO *b, const void *bytes, int len);
+int BIO_dump_indent(BIO *b, const void *bytes, int len, int indent);
 # ifndef OPENSSL_NO_STDIO
-int BIO_dump_fp(FILE *fp, const char *s, int len);
-int BIO_dump_indent_fp(FILE *fp, const char *s, int len, int indent);
+int BIO_dump_fp(FILE *fp, const void *s, int len);
+int BIO_dump_indent_fp(FILE *fp, const void *s, int len, int indent);
 # endif
-int BIO_hex_string(BIO *out, int indent, int width, unsigned char *data,
+int BIO_hex_string(BIO *out, int indent, int width, const void *data,
                    int datalen);
 
 # ifndef OPENSSL_NO_SOCK


### PR DESCRIPTION
Some of these functions take char*, which is seldom right, they should
have been unsigned char*, because the content isn't expected to be
text.

Even better is to simply take void* as data type, which also happens
to be transparent for any type these functions are called with, be it
char* or unsigned char*.  This shouldn't break anything.

While we're at it, constify the input data parameters.
