### PR TITLE
Fixes #7879: AES-SIV to use EVP_MAC APIs

### DIFF
--- a/crypto/modes/modes_lcl.h
+++ b/crypto/modes/modes_lcl.h
@@ -206,8 +206,8 @@ struct siv128_context {
     SIV_BLOCK d;
     SIV_BLOCK tag;
     EVP_CIPHER_CTX *cipher_ctx;
-    CMAC_CTX *cmac_ctx_init;
-    CMAC_CTX *cmac_ctx;
+    EVP_MAC_CTX *mac_ctx_init;
+    EVP_MAC_CTX *mac_ctx;
     int final_ret;
     int crypto_ok;
 };


### PR DESCRIPTION
Convert CMAC APIs to EVP_MAC APIs

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
