### PR TITLE
Do not complain when /dev/crypto does not exist

### DIFF
--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -1161,7 +1161,7 @@ void engine_load_devcrypto_int()
 #ifndef ENGINE_DEVCRYPTO_DEBUG
         if (errno != ENOENT)
 #endif
-        fprintf(stderr, "Could not open /dev/crypto: %s\n", strerror(errno));
+            fprintf(stderr, "Could not open /dev/crypto: %s\n", strerror(errno));
         return;
     }
 

--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -25,6 +25,8 @@
 
 #include "internal/engine.h"
 
+/* #define ENGINE_DEVCRYPTO_DEBUG */
+
 #ifdef CRYPTO_ALGORITHM_MIN
 # define CHECK_BSD_STYLE_MACROS
 #endif
@@ -1156,6 +1158,9 @@ void engine_load_devcrypto_int()
     ENGINE *e = NULL;
 
     if ((cfd = open("/dev/crypto", O_RDWR, 0)) < 0) {
+#ifndef ENGINE_DEVCRYPTO_DEBUG
+        if (errno != ENOENT)
+#endif
         fprintf(stderr, "Could not open /dev/crypto: %s\n", strerror(errno));
         return;
     }


### PR DESCRIPTION
FreeBSD does not enable cryptodev(4) by default.  OpenBSD disabled support
for /dev/crypto by default from 4.9 and removed it from 5.7.  Now the engine
is properly enabled by default on BSD platforms (see #7885), it continuously
complains:

Could not open /dev/crypto: No such file or directory

Hide the nagging error message behind ENGINE_DEVCRYPTO_DEBUG.

CLA: trivial


_[Note: the commit message refers to the wrong commit, it should be #7585 instead of #7885]_