### PR TITLE
ts: Use sha256 as default digest for TS query

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Use SHA256 as the default digest for TS query in the ts app.
+     [Tomas Mraz]
+
   *) Change PBKDF2 to conform to SP800-132 instead of the older PKCS5 RFC2898.
      This checks that the salt length is at least 128 bits, the derived key
      length is at least 112 bits, and that the iteration count is at least 1000.

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -425,7 +425,7 @@ static TS_REQ *create_query(BIO *data_bio, const char *digest, const EVP_MD *md,
     ASN1_OBJECT *policy_obj = NULL;
     ASN1_INTEGER *nonce_asn1 = NULL;
 
-    if (md == NULL && (md = EVP_get_digestbyname("sha1")) == NULL)
+    if (md == NULL && (md = EVP_get_digestbyname("sha256")) == NULL)
         goto err;
     if ((ts_req = TS_REQ_new()) == NULL)
         goto err;

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -518,7 +518,7 @@ included. Default is no. (Optional)
 =item B<ess_cert_id_alg>
 
 This option specifies the hash function to be used to calculate the TSA's
-public key certificate identifier. Default is sha1. (Optional)
+public key certificate identifier. Default is sha256. (Optional)
 
 =back
 
@@ -530,7 +530,7 @@ openssl/apps/openssl.cnf will do.
 
 =head2 Time Stamp Request
 
-To create a time stamp request for design1.txt with SHA-1
+To create a time stamp request for design1.txt with SHA-256
 without nonce and policy and no certificate is required in the response:
 
   openssl ts -query -data design1.txt -no_nonce \
@@ -546,12 +546,12 @@ To print the content of the previous request in human readable format:
 
   openssl ts -query -in design1.tsq -text
 
-To create a time stamp request which includes the MD-5 digest
+To create a time stamp request which includes the SHA-512 digest
 of design2.txt, requests the signer certificate and nonce,
 specifies a policy id (assuming the tsa_policy1 name is defined in the
 OID section of the config file):
 
-  openssl ts -query -data design2.txt -md5 \
+  openssl ts -query -data design2.txt -sha512 \
         -tspolicy tsa_policy1 -cert -out design2.tsq
 
 =head2 Time Stamp Response


### PR DESCRIPTION
This just changes the hardcoded default from the weak SHA-1 to SHA-256.

##### Checklist
- [x] documentation is added or updated
