### PR TITLE
x509 certificate should verify even when public key cannot be accessed

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3232,12 +3232,12 @@ static int check_key_level(X509_STORE_CTX *ctx, X509 *cert)
     EVP_PKEY *pkey = X509_get0_pubkey(cert);
     int level = ctx->param->auth_level;
 
+    if (level <= 0)
+        return 1;
     /* Unsupported or malformed keys are not secure */
     if (pkey == NULL)
         return 0;
 
-    if (level <= 0)
-        return 1;
     if (level > NUM_AUTH_LEVELS)
         level = NUM_AUTH_LEVELS;
 

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3232,6 +3232,9 @@ static int check_key_level(X509_STORE_CTX *ctx, X509 *cert)
     EVP_PKEY *pkey = X509_get0_pubkey(cert);
     int level = ctx->param->auth_level;
 
+    /* Do the level check first.  If it succeeds, return.  This permits
+       a certificate chain to be verified even if the algorithm is such
+       that the pkey cannot be extracted. */
     if (level <= 0)
         return 1;
     /* Unsupported or malformed keys are not secure */


### PR DESCRIPTION
The check_key_level() function currently fails when the public key
cannot be extracted from the certificate because its algorithm is not
supported.  However, the public key is not needed for the last
certificate in the chain.

This change moves the check for level 0 before the check for a
non-NULL public key.

For background, this is the TPM 1.2 endorsement key certificate.
I.e., this is a real application with millions of certificates issued.
The key is an RSA-2048 key.

The TCG (for a while) specified

     Public Key Algorithm: rsaesOaep

rather than the commonly used

     Public Key Algorithm: rsaEncryption

because the key is an encryption key rather than a signing key.
The X509 certificate parser fails to get the public key.

Signed-off-by: Ken Goldman <kgoldman@us.ibm.com>
Suggested-by: Viktor Dukhovni <openssl-users@dukhovni.org>



