### PR TITLE
util/process_docs.pl: handle multiple source directories correctly

### DIFF
--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -84,114 +84,123 @@ my $symlink_exists = eval { symlink("",""); 1 };
 
 foreach my $section (sort @{$options{section}}) {
     my $subdir = "man$section";
-    my @podsourcedirs = map { catfile($_, $subdir); } @{$options{sourcedir}};
-    my @podglobs = map { catfile($_, "*.pod"); } @podsourcedirs;
+    foreach my $sourcedir (@{$options{sourcedir}}) {
+        my $podsourcedir = catfile($sourcedir, $subdir);
+        my $podglob = catfile($podsourcedir, "*.pod");
 
-    foreach my $podfile (map { glob $_ } @podglobs) {
-        my $podname = basename($podfile, ".pod");
-        my $podpath = catfile($podfile);
-        my %podinfo = extract_pod_info($podpath,
-                                       { debug => $options{debug},
-                                         section => $section });
-        my @podfiles = grep { $_ ne $podname } @{$podinfo{names}};
+        foreach my $podfile (glob $podglob) {
+            my $podname = basename($podfile, ".pod");
+            my $podpath = catfile($podfile);
+            my %podinfo = extract_pod_info($podpath,
+                                           { debug => $options{debug},
+                                             section => $section });
+            my @podfiles = grep { $_ ne $podname } @{$podinfo{names}};
 
-        my $updir = updir();
-        my $name = uc $podname;
-        my $suffix = { man  => ".$podinfo{section}".($options{suffix} // ""),
-                       html => ".html" } -> {$options{type}};
-        my $generate = { man  => "pod2man --name=$name --section=$podinfo{section} --center=OpenSSL --release=$config{version} \"$podpath\"",
-                         html => "pod2html \"--podroot=$options{sourcedir}\" --htmldir=$updir --podpath=man1:man3:man5:man7 \"--infile=$podpath\" \"--title=$podname\" --quiet"
-                         } -> {$options{type}};
-        my $output_dir = catdir($options{destdir}, "man$podinfo{section}");
-        my $output_file = $podname . $suffix;
-        my $output_path = catfile($output_dir, $output_file);
+            my $updir = updir();
+            my $name = uc $podname;
+            my $suffix =
+                { man  => ".$podinfo{section}".($options{suffix} // ""),
+                  html => ".html" } -> {$options{type}};
+            my $generate =
+                { man  => <<"_____",
+pod2man --name=$name --section=$podinfo{section}  --center=OpenSSL --release=$config{version}  "$podpath"
+_____
+                  html => <<"_____",
+pod2html "--podroot=$sourcedir" --htmldir=$updir --podpath=man1:man3:man5:man7 "--infile=$podpath" "--title=$podname" --quiet
+_____
+                } -> {$options{type}};
+            my $output_dir = catdir($options{destdir}, "man$podinfo{section}");
+            my $output_file = $podname . $suffix;
+            my $output_path = catfile($output_dir, $output_file);
 
-        if (! $options{remove}) {
-            my @output;
-            print STDERR "DEBUG: Processing, using \"$generate\"\n"
-                if $options{debug};
-            unless ($options{"dry-run"}) {
-                @output = `$generate`;
-                map { s|href="http://man\.he\.net/(man\d/[^"]+)(?:\.html)?"|href="../$1.html"|g; } @output
-                    if $options{type} eq "html";
-                if ($options{type} eq "man") {
-                    # Because some *roff parsers are more strict than others,
-                    # multiple lines in the NAME section must be merged into
-                    # one.
-                    my $in_name = 0;
-                    my $name_line = "";
-                    my @newoutput = ();
-                    foreach (@output) {
-                        if ($in_name) {
-                            if (/^\.SH "/) {
-                                $in_name = 0;
-                                push @newoutput, $name_line."\n";
-                            } else {
-                                chomp (my $x = $_);
-                                $name_line .= " " if $name_line;
-                                $name_line .= $x;
-                                next;
-                            }
-                        }
-                        if (/^\.SH +"NAME" *$/) {
-                            $in_name = 1;
-                        }
-                        push @newoutput, $_;
-                    }
-                    @output = @newoutput;
-                }
-            }
-            print STDERR "DEBUG: Done processing\n" if $options{debug};
-
-            if (! -d $output_dir) {
-                print STDERR "DEBUG: Creating directory $output_dir\n" if $options{debug};
-                unless ($options{"dry-run"}) {
-                    mkpath $output_dir
-                        or die "Trying to create directory $output_dir: $!\n";
-                }
-            }
-            print STDERR "DEBUG: Writing $output_path\n" if $options{debug};
-            unless ($options{"dry-run"}) {
-                open my $output_fh, '>', $output_path
-                    or die "Trying to write to $output_path: $!\n";
-                foreach (@output) {
-                    print $output_fh $_;
-                }
-                close $output_fh;
-            }
-            print STDERR "DEBUG: Done writing $output_path\n" if $options{debug};
-        } else {
-            print STDERR "DEBUG: Removing $output_path\n" if $options{debug};
-            unless ($options{"dry-run"}) {
-                while (unlink $output_path) {}
-            }
-        }
-        print "$output_path\n";
-
-        foreach (@podfiles) {
-            my $link_file = $_ . $suffix;
-            my $link_path = catfile($output_dir, $link_file);
             if (! $options{remove}) {
-                if ($symlink_exists) {
-                    print STDERR "DEBUG: Linking $link_path -> $output_file\n"
+                my @output;
+                print STDERR "DEBUG: Processing, using \"$generate\"\n"
+                    if $options{debug};
+                unless ($options{"dry-run"}) {
+                    @output = `$generate`;
+                    map { s|href="http://man\.he\.net/(man\d/[^"]+)(?:\.html)?"|href="../$1.html"|g; } @output
+                        if $options{type} eq "html";
+                    if ($options{type} eq "man") {
+                        # Because some *roff parsers are more strict than
+                        # others, multiple lines in the NAME section must
+                        # be merged into one.
+                        my $in_name = 0;
+                        my $name_line = "";
+                        my @newoutput = ();
+                        foreach (@output) {
+                            if ($in_name) {
+                                if (/^\.SH "/) {
+                                    $in_name = 0;
+                                    push @newoutput, $name_line."\n";
+                                } else {
+                                    chomp (my $x = $_);
+                                    $name_line .= " " if $name_line;
+                                    $name_line .= $x;
+                                    next;
+                                }
+                            }
+                            if (/^\.SH +"NAME" *$/) {
+                                $in_name = 1;
+                            }
+                            push @newoutput, $_;
+                        }
+                        @output = @newoutput;
+                    }
+                }
+                print STDERR "DEBUG: Done processing\n" if $options{debug};
+
+                if (! -d $output_dir) {
+                    print STDERR "DEBUG: Creating directory $output_dir\n"
                         if $options{debug};
                     unless ($options{"dry-run"}) {
-                        symlink $output_file, $link_path;
+                        mkpath $output_dir
+                            or die "Trying to create directory $output_dir: $!\n";
+                    }
+                }
+                print STDERR "DEBUG: Writing $output_path\n" if $options{debug};
+                unless ($options{"dry-run"}) {
+                    open my $output_fh, '>', $output_path
+                        or die "Trying to write to $output_path: $!\n";
+                    foreach (@output) {
+                        print $output_fh $_;
+                    }
+                    close $output_fh;
+                }
+                print STDERR "DEBUG: Done writing $output_path\n" if $options{debug};
+            } else {
+                print STDERR "DEBUG: Removing $output_path\n" if $options{debug};
+                unless ($options{"dry-run"}) {
+                    while (unlink $output_path) {}
+                }
+            }
+            print "$output_path\n";
+
+            foreach (@podfiles) {
+                my $link_file = $_ . $suffix;
+                my $link_path = catfile($output_dir, $link_file);
+                if (! $options{remove}) {
+                    if ($symlink_exists) {
+                        print STDERR "DEBUG: Linking $link_path -> $output_file\n"
+                            if $options{debug};
+                        unless ($options{"dry-run"}) {
+                            symlink $output_file, $link_path;
+                        }
+                    } else {
+                        print STDERR "DEBUG: Copying $output_path to link_path\n"
+                            if $options{debug};
+                        unless ($options{"dry-run"}) {
+                            copy $output_path, $link_path;
+                        }
                     }
                 } else {
-                    print STDERR "DEBUG: Copying $output_path to link_path\n"
-                        if $options{debug};
+                    print STDERR "DEBUG: Removing $link_path\n" if $options{debug};
                     unless ($options{"dry-run"}) {
-                        copy $output_path, $link_path;
+                        while (unlink $link_path) {}
                     }
                 }
-            } else {
-                print STDERR "DEBUG: Removing $link_path\n" if $options{debug};
-                unless ($options{"dry-run"}) {
-                    while (unlink $link_path) {}
-                }
+                print "$link_path -> $output_path\n";
             }
-            print "$link_path -> $output_path\n";
         }
     }
 }


### PR DESCRIPTION
The way this script handled multiple source directories wasn't quite
right, it ended up giving pod2html 'ARRAY(0xXXXXXXXXX)' as a source
directory.

This corrects the mistake.

Fixes #7742
Fixes #7939