### PR TITLE
Add a top-level Makefile for the demos

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,0 +1,13 @@
+SUBDIRS = bio cms evp pkcs12 smime
+
+all: subdirs
+
+subdirs:
+	for dir in $(SUBDIRS); do \
+		( cd $$dir; $(MAKE) OPENSSL_INCS_LOCATION=-I../../include OPENSSL_LIBS_LOCATION=-L../.. ); \
+	done
+
+clean:
+	for dir in $(SUBDIRS); do \
+		( cd $$dir; $(MAKE) clean ); \
+	done

--- a/demos/bio/Makefile
+++ b/demos/bio/Makefile
@@ -28,3 +28,6 @@ server-conf: server-conf.o
 
 client-arg client-conf saccept sconnect server-arg server-cmod server-conf:
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) client-arg client-conf saccept sconnect server-arg server-cmod server-conf *.o

--- a/demos/cms/Makefile
+++ b/demos/cms/Makefile
@@ -1,0 +1,37 @@
+# Quick instruction:
+# To build against an OpenSSL built in the source tree, do this:
+#
+#    make OPENSSL_INCS_LOCATION=-I../../include OPENSSL_LIBS_LOCATION=-L../..
+#
+# To run the demos when linked with a shared library (default):
+#
+#    LD_LIBRARY_PATH=../.. ./cms_comp
+#    LD_LIBRARY_PATH=../.. ./cms_ddec
+#    LD_LIBRARY_PATH=../.. ./cms_dec
+#    LD_LIBRARY_PATH=../.. ./cms_denc
+#    LD_LIBRARY_PATH=../.. ./cms_enc
+#    LD_LIBRARY_PATH=../.. ./cms_sign
+#    LD_LIBRARY_PATH=../.. ./cms_sign2
+#    LD_LIBRARY_PATH=../.. ./cms_uncomp
+#    LD_LIBRARY_PATH=../.. ./cms_ver
+
+CFLAGS = $(OPENSSL_INCS_LOCATION)
+LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto $(EX_LIBS)
+
+all: cms_comp cms_ddec cms_dec cms_denc cms_enc cms_sign cms_sign2 cms_uncomp cms_ver
+
+cms_comp: cms_comp.o
+cms_ddec: cms_ddec.o
+cms_dec: cms_dec.o
+cms_denc: cms_denc.o
+cms_enc: cms_enc.o
+cms_sign: cms_sign.o
+cms_sign2: cms_sign2.o
+cms_uncomp: cms_uncomp.o
+cms_ver: cms_ver.o
+
+cms_comp cms_ddec cms_dec cms_denc cms_enc cms_sign cms_sign2 cms_uncomp cms_ver:
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) cms_comp cms_ddec cms_dec cms_denc cms_enc cms_sign cms_sign2 cms_uncomp cms_ver *.o

--- a/demos/pkcs12/Makefile
+++ b/demos/pkcs12/Makefile
@@ -1,0 +1,23 @@
+# Quick instruction:
+# To build against an OpenSSL built in the source tree, do this:
+#
+#    make OPENSSL_INCS_LOCATION=-I../../include OPENSSL_LIBS_LOCATION=-L../..
+#
+# To run the demos when linked with a shared library (default):
+#
+#    LD_LIBRARY_PATH=../.. ./pkread
+#    LD_LIBRARY_PATH=../.. ./pkwrite
+
+CFLAGS = $(OPENSSL_INCS_LOCATION)
+LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto $(EX_LIBS)
+
+all: pkread pkwrite
+
+pkread: pkread.o
+pkwrite: pkwrite.o
+
+pkread pkwrite:
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+	$(RM) pkread pkwrite *.o

--- a/demos/smime/Makefile
+++ b/demos/smime/Makefile
@@ -1,0 +1,29 @@
+# Quick instruction:
+# To build against an OpenSSL built in the source tree, do this:
+#
+#    make OPENSSL_INCS_LOCATION=-I../../include OPENSSL_LIBS_LOCATION=-L../..
+#
+# To run the demos when linked with a shared library (default):
+#
+#    LD_LIBRARY_PATH=../.. ./smdec
+#    LD_LIBRARY_PATH=../.. ./smenc
+#    LD_LIBRARY_PATH=../.. ./smsign
+#    LD_LIBRARY_PATH=../.. ./smsign2
+#    LD_LIBRARY_PATH=../.. ./smver
+
+CFLAGS = $(OPENSSL_INCS_LOCATION)
+LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto $(EX_LIBS)
+
+all: smdec smenc smsign smsign2 smver
+
+smdec: smdec.o
+smenc: smenc.o
+smsign: smsign.o
+smsign2: smsign2.o
+smver: smver.o
+
+smdec smenc smsign smsign2 smver:
+        $(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+clean:
+        $(RM) smdec smenc smsign smsign2 smver *.o


### PR DESCRIPTION
The demos/ directory contains many examples which may or may not
compile properly.  By adding a top-level Makefile to the demos
directory we can start testing them with each build to ensure
they still function.

Fixes #5053

Signed-off-by: Eric Brown <browne@vmware.com>