### PR TITLE
Fix function names in ct(7) documentation

### DIFF
--- a/doc/man7/ct.pod
+++ b/doc/man7/ct.pod
@@ -15,7 +15,7 @@ clients, as defined in RFC 6962. This verification can provide some confidence
 that a certificate has been publicly logged in a set of CT logs.
 
 By default, these checks are disabled. They can be enabled using
-SSL_CTX_ct_enable() or SSL_ct_enable().
+L<SSL_CTX_enable_ct(3)> or L<SSL_enable_ct(3)>.
 
 This library can also be used to parse and examine CT data structures, such as
 Signed Certificate Timestamps (SCTs), or to read a list of CT logs. There are


### PR DESCRIPTION
The correct function name is SSL_CTX_enable_ct, not SSL_CTX_ct_enable.
