### PR TITLE
WIP: Fix keyCertSign checks

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -336,14 +336,6 @@ static void setup_crldp(X509 *x)
         setup_dp(x, sk_DIST_POINT_value(x->crldp, i));
 }
 
-#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
-#define ku_reject(x, usage) \
-        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
-#define xku_reject(x, usage) \
-        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
-#define ns_reject(x, usage) \
-        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
-
 static void x509v3_cache_extensions(X509 *x)
 {
     BASIC_CONSTRAINTS *bs;
@@ -471,8 +463,7 @@ static void x509v3_cache_extensions(X509 *x)
     if (!X509_NAME_cmp(X509_get_subject_name(x), X509_get_issuer_name(x))) {
         x->ex_flags |= EXFLAG_SI;
         /* If SKID matches AKID also indicate self signed */
-        if (X509_check_akid(x, x->akid) == X509_V_OK &&
-            !ku_reject(x, KU_KEY_CERT_SIGN))
+        if (X509_check_akid(x, x->akid) == X509_V_OK)
             x->ex_flags |= EXFLAG_SS;
     }
     x->altname = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
@@ -520,6 +511,14 @@ static void x509v3_cache_extensions(X509 *x)
  * 3 basicConstraints absent but self signed V1.
  * 4 basicConstraints absent but keyUsage present and keyCertSign asserted.
  */
+
+#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
+#define ku_reject(x, usage) \
+        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
+#define xku_reject(x, usage) \
+        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
+#define ns_reject(x, usage) \
+        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
 
 static int check_ca(const X509 *x)
 {

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -522,9 +522,14 @@ static void x509v3_cache_extensions(X509 *x)
 
 static int check_ca(const X509 *x)
 {
-    /* keyUsage if present should allow cert signing */
-    if (ku_reject(x, KU_KEY_CERT_SIGN))
-        return 0;
+    if (x->ex_flags & EXFLAG_KUSAGE) {
+        /* keyUsage if present should allow cert signing */
+        if (ku_reject(x, KU_KEY_CERT_SIGN))
+            return 0;
+        /* CA bit in basicConstraints must also be set */
+        if (!(x->ex_flags & EXFLAG_BCONS) || !(x->ex_flags & EXFLAG_CA))
+            return 0;
+    }
     if (x->ex_flags & EXFLAG_BCONS) {
         if (x->ex_flags & EXFLAG_CA)
             return 1;


### PR DESCRIPTION
Trying to check CA usage in x509v3_cache_extensions wasn't a good idea.

However, the keyCertSign check in check_ca wasn't quite right either

RFC 5280 says this in 4.2.1.3 "Key Usage":

> The keyCertSign bit is asserted when the subject public key is
> used for verifying signatures on public key certificates.  If the
> keyCertSign bit is asserted, then the cA bit in the basic
> constraints extension (Section 4.2.1.9) MUST also be asserted.

check_ca did check these relevant combinations:

1. keyCertSign bit set in keyUsage, no check of basicConstraints.
2. cA bit set in basicConstraints, no check of keyUsage.
3. basicConstraints not present => keyCertSign bit set in keyUsage.

Now we change 1 to:

1. keyCertSign bit set in keyUsage => cA bit set in basicConstraints.

Fixes #1418
