### PR TITLE
X509_check_issued: check that signature algo matches signing key algo

### DIFF
--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -174,6 +174,10 @@ const char *X509_verify_cert_error_string(long n)
         return "OCSP verification failed";
     case X509_V_ERR_OCSP_CERT_UNKNOWN:
         return "OCSP unknown cert";
+    case X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH:
+        return "Subject signature algorithm and issuer public key algorithm mismatch";
+    case X509_V_ERR_NO_ISSUER_PUBLIC_KEY:
+        return "Issuer certificate doesn't have a public key";
 
     default:
         /* Printing an error number into a static buffer is not thread-safe */

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -766,7 +766,7 @@ static int no_check(const X509_PURPOSE *xp, const X509 *x, int ca)
  * 1. Check issuer_name(subject) == subject_name(issuer)
  * 2. If akid(subject) exists check it matches issuer
  * 3. Check that signing algorithm matches signature algorithm
- * 3. If key_usage(issuer) exists check it supports certificate signing
+ * 4. If key_usage(issuer) exists check it supports certificate signing
  * returns 0 for OK, positive for reason for mismatch, reasons match
  * codes for X509_verify_cert()
  */
@@ -794,6 +794,9 @@ int X509_check_issued(X509 *issuer, X509 *subject)
         EVP_PKEY *i_pkey = X509_get0_pubkey(issuer);
         X509_ALGOR *s_algor = &subject->cert_info.signature;
         int s_pknid = NID_undef, s_mdnid = NID_undef;
+
+        if (i_pkey == NULL)
+            return X509_V_ERR_NO_ISSUER_PUBLIC_KEY;
 
         if (!OBJ_find_sigid_algs(OBJ_obj2nid(s_algor->algorithm),
                                  &s_mdnid, &s_pknid)

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -764,9 +764,9 @@ static int no_check(const X509_PURPOSE *xp, const X509 *x, int ca)
  * subject name.
  * These are:
  * 1. Check issuer_name(subject) == subject_name(issuer)
- * 2. If akid(subject) exists check it matches issuer
- * 3. Check that signing algorithm matches signature algorithm
- * 4. If key_usage(issuer) exists check it supports certificate signing
+ * 2. If akid(subject) exists, check that it matches issuer
+ * 3. Check that issuer public key algorithm matches subject signature algorithm
+ * 4. If key_usage(issuer) exists, check that it supports certificate signing
  * returns 0 for OK, positive for reason for mismatch, reasons match
  * codes for X509_verify_cert()
  */
@@ -788,7 +788,7 @@ int X509_check_issued(X509 *issuer, X509 *subject)
 
     {
         /*
-         * Check if the subject signature algorithm matches the issue PUBKEY
+         * Check if the subject signature algorithm matches the issuer's PUBKEY
          * algorithm
          */
         EVP_PKEY *i_pkey = X509_get0_pubkey(issuer);

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -765,6 +765,7 @@ static int no_check(const X509_PURPOSE *xp, const X509 *x, int ca)
  * These are:
  * 1. Check issuer_name(subject) == subject_name(issuer)
  * 2. If akid(subject) exists check it matches issuer
+ * 3. Check that signing algorithm matches signature algorithm
  * 3. If key_usage(issuer) exists check it supports certificate signing
  * returns 0 for OK, positive for reason for mismatch, reasons match
  * codes for X509_verify_cert()
@@ -783,6 +784,21 @@ int X509_check_issued(X509 *issuer, X509 *subject)
         int ret = X509_check_akid(issuer, subject->akid);
         if (ret != X509_V_OK)
             return ret;
+    }
+
+    {
+        /*
+         * Check if the subject signature algorithm matches the issue PUBKEY
+         * algorithm
+         */
+        EVP_PKEY *i_pkey = X509_get0_pubkey(issuer);
+        X509_ALGOR *s_algor = &subject->cert_info.signature;
+        int s_pknid = NID_undef, s_mdnid = NID_undef;
+
+        if (!OBJ_find_sigid_algs(OBJ_obj2nid(s_algor->algorithm),
+                                 &s_mdnid, &s_pknid)
+            || EVP_PKEY_type(s_pknid) != EVP_PKEY_base_id(i_pkey))
+            return X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH;
     }
 
     if (subject->ex_flags & EXFLAG_PROXY) {

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -184,6 +184,8 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 # define         X509_V_ERR_OCSP_VERIFY_NEEDED                   73  /* Need OCSP verification */
 # define         X509_V_ERR_OCSP_VERIFY_FAILED                   74  /* Couldn't verify cert through OCSP */
 # define         X509_V_ERR_OCSP_CERT_UNKNOWN                    75  /* Certificate wasn't recognized by the OCSP responder */
+/* More 'informational' when looking for issuer cert */
+# define         X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH         76
 
 /* Certificate verify flags */
 

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -186,6 +186,8 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 # define         X509_V_ERR_OCSP_CERT_UNKNOWN                    75  /* Certificate wasn't recognized by the OCSP responder */
 /* More 'informational' when looking for issuer cert */
 # define         X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH         76
+/* When the issuer certificate doesn't have a public key */
+# define         X509_V_ERR_NO_ISSUER_PUBLIC_KEY                 77
 
 /* Certificate verify flags */
 

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -184,10 +184,10 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 # define         X509_V_ERR_OCSP_VERIFY_NEEDED                   73  /* Need OCSP verification */
 # define         X509_V_ERR_OCSP_VERIFY_FAILED                   74  /* Couldn't verify cert through OCSP */
 # define         X509_V_ERR_OCSP_CERT_UNKNOWN                    75  /* Certificate wasn't recognized by the OCSP responder */
-/* More 'informational' when looking for issuer cert */
+
 # define         X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH         76
-/* When the issuer certificate doesn't have a public key */
 # define         X509_V_ERR_NO_ISSUER_PUBLIC_KEY                 77
+
 
 /* Certificate verify flags */
 


### PR DESCRIPTION
This implements 3.5.18 "Consistent Public Key and Signature Algorithms"
from RFC 4158 "Internet X.509 Public Key Infrastructure: Certification
Path Building"

Ref: https://tools.ietf.org/html/rfc4158#section-3.5.18

Fixes #7899
