### PR TITLE
apps/verify.c: Change an old comment to clarify what the callback does

### DIFF
--- a/apps/verify.c
+++ b/apps/verify.c
@@ -289,13 +289,19 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         switch (cert_error) {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
-            break;
+            /* fall thru */
 
             /*
              * since we are just checking the certificates, it is ok if they
              * are self signed. But we should still warn the user.
              */
         case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+            /* Continue after extension errors too */
+        case X509_V_ERR_INVALID_NON_CA:
+        case X509_V_ERR_PATH_LENGTH_EXCEEDED:
+        case X509_V_ERR_CRL_HAS_EXPIRED:
+        case X509_V_ERR_CRL_NOT_YET_VALID:
+        case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
             ok = 1;
         }
 

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -281,31 +281,22 @@ static int cb(int ok, X509_STORE_CTX *ctx)
                             0, get_nameopt());
             BIO_printf(bio_err, "\n");
         }
-
-        /*
-         * See if there are some errors that we want to ignore
-         * (We make into warnings, still, so the user can see)
-         */
-        switch (cert_error) {
-        case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
-            /*
-             * since we are just checking the certificates, it is ok if
-             * they are self signed.
-             */
-            ok = 1;
-        }
-        BIO_printf(bio_err, "%s%s %d at %d depth lookup: %s\n",
-                   X509_STORE_CTX_get0_parent_ctx(ctx) ? "[CRL path] " : "",
-                   ok ? "warning" : "error",
-                   cert_error,
-                   X509_STORE_CTX_get_error_depth(ctx),
-                   X509_verify_cert_error_string(cert_error));
-
-        /* Print out extra stuff if applicable */
+        BIO_printf(bio_err, "%serror %d at %d depth lookup: %s\n",
+               X509_STORE_CTX_get0_parent_ctx(ctx) ? "[CRL path] " : "",
+               cert_error,
+               X509_STORE_CTX_get_error_depth(ctx),
+               X509_verify_cert_error_string(cert_error));
         switch (cert_error) {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
             break;
+
+            /*
+             * since we are just checking the certificates, it is ok if they
+             * are self signed. But we should still warn the user.
+             */
+        case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+            ok = 1;
         }
 
         return ok;

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -289,19 +289,13 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         switch (cert_error) {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
-            /* fall thru */
+            break;
 
             /*
              * since we are just checking the certificates, it is ok if they
              * are self signed. But we should still warn the user.
              */
         case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
-            /* Continue after extension errors too */
-        case X509_V_ERR_INVALID_NON_CA:
-        case X509_V_ERR_PATH_LENGTH_EXCEEDED:
-        case X509_V_ERR_CRL_HAS_EXPIRED:
-        case X509_V_ERR_CRL_NOT_YET_VALID:
-        case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:
             ok = 1;
         }
 

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -235,7 +235,7 @@ static int check(X509_STORE *ctx, const char *file,
     if (crls != NULL)
         X509_STORE_CTX_set0_crls(csc, crls);
     i = X509_verify_cert(csc);
-    if (i > 0) {
+    if (i > 0 && X509_STORE_CTX_get_error(csc) == X509_V_OK) {
         printf("%s: OK\n", (file == NULL) ? "stdin" : file);
         ret = 1;
         if (show_chain) {
@@ -290,6 +290,7 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
             /* fall thru */
+        case X509_V_ERR_CERT_HAS_EXPIRED:
 
             /*
              * since we are just checking the certificates, it is ok if they
@@ -297,8 +298,10 @@ static int cb(int ok, X509_STORE_CTX *ctx)
              */
         case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
             /* Continue after extension errors too */
+        case X509_V_ERR_INVALID_CA:
         case X509_V_ERR_INVALID_NON_CA:
         case X509_V_ERR_PATH_LENGTH_EXCEEDED:
+        case X509_V_ERR_INVALID_PURPOSE:
         case X509_V_ERR_CRL_HAS_EXPIRED:
         case X509_V_ERR_CRL_NOT_YET_VALID:
         case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -281,22 +281,31 @@ static int cb(int ok, X509_STORE_CTX *ctx)
                             0, get_nameopt());
             BIO_printf(bio_err, "\n");
         }
-        BIO_printf(bio_err, "%serror %d at %d depth lookup: %s\n",
-               X509_STORE_CTX_get0_parent_ctx(ctx) ? "[CRL path] " : "",
-               cert_error,
-               X509_STORE_CTX_get_error_depth(ctx),
-               X509_verify_cert_error_string(cert_error));
+
+        /*
+         * See if there are some errors that we want to ignore
+         * (We make into warnings, still, so the user can see)
+         */
+        switch (cert_error) {
+        case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+            /*
+             * since we are just checking the certificates, it is ok if
+             * they are self signed.
+             */
+            ok = 1;
+        }
+        BIO_printf(bio_err, "%s%s %d at %d depth lookup: %s\n",
+                   X509_STORE_CTX_get0_parent_ctx(ctx) ? "[CRL path] " : "",
+                   ok ? "warning" : "error",
+                   cert_error,
+                   X509_STORE_CTX_get_error_depth(ctx),
+                   X509_verify_cert_error_string(cert_error));
+
+        /* Print out extra stuff if applicable */
         switch (cert_error) {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
             break;
-
-            /*
-             * since we are just checking the certificates, it is ok if they
-             * are self signed. But we should still warn the user.
-             */
-        case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
-            ok = 1;
         }
 
         return ok;

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -235,7 +235,7 @@ static int check(X509_STORE *ctx, const char *file,
     if (crls != NULL)
         X509_STORE_CTX_set0_crls(csc, crls);
     i = X509_verify_cert(csc);
-    if (i > 0 && X509_STORE_CTX_get_error(csc) == X509_V_OK) {
+    if (i > 0) {
         printf("%s: OK\n", (file == NULL) ? "stdin" : file);
         ret = 1;
         if (show_chain) {
@@ -290,7 +290,6 @@ static int cb(int ok, X509_STORE_CTX *ctx)
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
             /* fall thru */
-        case X509_V_ERR_CERT_HAS_EXPIRED:
 
             /*
              * since we are just checking the certificates, it is ok if they
@@ -298,10 +297,8 @@ static int cb(int ok, X509_STORE_CTX *ctx)
              */
         case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
             /* Continue after extension errors too */
-        case X509_V_ERR_INVALID_CA:
         case X509_V_ERR_INVALID_NON_CA:
         case X509_V_ERR_PATH_LENGTH_EXCEEDED:
-        case X509_V_ERR_INVALID_PURPOSE:
         case X509_V_ERR_CRL_HAS_EXPIRED:
         case X509_V_ERR_CRL_NOT_YET_VALID:
         case X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION:

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -286,16 +286,19 @@ static int cb(int ok, X509_STORE_CTX *ctx)
                cert_error,
                X509_STORE_CTX_get_error_depth(ctx),
                X509_verify_cert_error_string(cert_error));
+
+        /*
+         * Pretend that some errors are ok, so they don't stop further
+         * processing of the certificate chain.  Setting ok = 1 does this.
+         * After X509_verify_cert() is done, we verify that there were
+         * no actual errors, even if the returned value was positive.
+         */
         switch (cert_error) {
         case X509_V_ERR_NO_EXPLICIT_POLICY:
             policies_print(ctx);
             /* fall thru */
         case X509_V_ERR_CERT_HAS_EXPIRED:
-
-            /*
-             * since we are just checking the certificates, it is ok if they
-             * are self signed. But we should still warn the user.
-             */
+            /* Continue even if the leaf is a self signed cert */
         case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
             /* Continue after extension errors too */
         case X509_V_ERR_INVALID_CA:


### PR DESCRIPTION
~~X509_verify_cert() returns 1 if the certificate validated ok.
However, the verify command would then check if there was any error
that got ignored by the verify callback (in this file, that's cb()),
and does in essence say that these errors shouldn't have been ignored.~~

~~We now change to trust the return value from X509_verify_cert(), and
ignore less errors in cb() instead.~~