### PR TITLE
crypto/uid.c: use own macro as guard rather than AT_SECURE

### DIFF
--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -34,12 +34,13 @@ int OPENSSL_issetugid(void)
 # if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #  if __GLIBC_PREREQ(2, 16)
 #   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
 #  endif
 # endif
 
 int OPENSSL_issetugid(void)
 {
-# ifdef AT_SECURE
+# ifdef OSSL_IMPLEMENT_GETAUXVAL
     return getauxval(AT_SECURE) != 0;
 # else
     return getuid() != geteuid() || getgid() != getegid();


### PR DESCRIPTION
It turns out that AT_SECURE may be defined through other means than
our inclusion of sys/auxv.h, so to be on the safe side, we define our
own guard and use that to determine if getauxval() should be used or
not.

Fixes #7932
