### PR TITLE
WIP: Check for compatible signature vs. key on ss cert

### DIFF
--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -336,14 +336,6 @@ static void setup_crldp(X509 *x)
         setup_dp(x, sk_DIST_POINT_value(x->crldp, i));
 }
 
-#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
-#define ku_reject(x, usage) \
-        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
-#define xku_reject(x, usage) \
-        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
-#define ns_reject(x, usage) \
-        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
-
 static void x509v3_cache_extensions(X509 *x)
 {
     BASIC_CONSTRAINTS *bs;
@@ -471,8 +463,7 @@ static void x509v3_cache_extensions(X509 *x)
     if (!X509_NAME_cmp(X509_get_subject_name(x), X509_get_issuer_name(x))) {
         x->ex_flags |= EXFLAG_SI;
         /* If SKID matches AKID also indicate self signed */
-        if (X509_check_akid(x, x->akid) == X509_V_OK &&
-            !ku_reject(x, KU_KEY_CERT_SIGN))
+        if (X509_check_akid(x, x->akid) == X509_V_OK)
             x->ex_flags |= EXFLAG_SS;
     }
     x->altname = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
@@ -520,6 +511,14 @@ static void x509v3_cache_extensions(X509 *x)
  * 3 basicConstraints absent but self signed V1.
  * 4 basicConstraints absent but keyUsage present and keyCertSign asserted.
  */
+
+#define V1_ROOT (EXFLAG_V1|EXFLAG_SS)
+#define ku_reject(x, usage) \
+        (((x)->ex_flags & EXFLAG_KUSAGE) && !((x)->ex_kusage & (usage)))
+#define xku_reject(x, usage) \
+        (((x)->ex_flags & EXFLAG_XKUSAGE) && !((x)->ex_xkusage & (usage)))
+#define ns_reject(x, usage) \
+        (((x)->ex_flags & EXFLAG_NSCERT) && !((x)->ex_nscert & (usage)))
 
 static int check_ca(const X509 *x)
 {

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -522,9 +522,14 @@ static void x509v3_cache_extensions(X509 *x)
 
 static int check_ca(const X509 *x)
 {
-    /* keyUsage if present should allow cert signing */
-    if (ku_reject(x, KU_KEY_CERT_SIGN))
-        return 0;
+    if (x->ex_flags & EXFLAG_KUSAGE) {
+        /* keyUsage if present should allow cert signing */
+        if (ku_reject(x, KU_KEY_CERT_SIGN))
+            return 0;
+        /* CA bit in basicConstraints must also be set */
+        if (!(x->ex_flags & EXFLAG_BCONS) || !(x->ex_flags & EXFLAG_CA))
+            return 0;
+    }
     if (x->ex_flags & EXFLAG_BCONS) {
         if (x->ex_flags & EXFLAG_CA)
             return 1;


### PR DESCRIPTION
@levitte  I played a bit with your pull request. I don't know if it is too much of a hack,
but I think I have a fairly general check which does not only cover X25519 vs. ED25519
but also RSA key vs. ECDSA signature, etc.

This is based on PR #7918