### PR TITLE
clarify which functions are the CMS functions which must have CMS_PAR…

### DIFF
--- a/doc/man3/CMS_get0_type.pod
+++ b/doc/man3/CMS_get0_type.pod
@@ -20,7 +20,8 @@ and ASN1_OBJECT pointer. An application can then decide how to process the
 CMS_ContentInfo structure based on this value.
 
 CMS_set1_eContentType() sets the embedded content type of a CMS_ContentInfo
-structure. It should be called with CMS functions with the B<CMS_PARTIAL>
+structure. It should be called with CMS functions (such as L<CMS_sign>, L<CMS_encrypt>)
+with the B<CMS_PARTIAL>
 flag and B<before> the structure is finalised, otherwise the results are
 undefined.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x] documentation is added or updated
- [ ] tests are added or updated

This adds a link to CMS_sign and CMS_encrypt() which would be the two functions that CMS_set1_content_type() would affect.
