### PR TITLE
Remove unused variables from tls1_change_cipher_state

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -85,10 +85,6 @@ static int tls1_generate_key_block(SSL *s, unsigned char *km, size_t num)
 int tls1_change_cipher_state(SSL *s, int which)
 {
     unsigned char *p, *mac_secret;
-    unsigned char tmp1[EVP_MAX_KEY_LENGTH];
-    unsigned char tmp2[EVP_MAX_KEY_LENGTH];
-    unsigned char iv1[EVP_MAX_IV_LENGTH * 2];
-    unsigned char iv2[EVP_MAX_IV_LENGTH * 2];
     unsigned char *ms, *key, *iv;
     EVP_CIPHER_CTX *dd;
     const EVP_CIPHER *c;
@@ -408,16 +404,8 @@ int tls1_change_cipher_state(SSL *s, int which)
     printf("\n");
 #endif
 
-    OPENSSL_cleanse(tmp1, sizeof(tmp1));
-    OPENSSL_cleanse(tmp2, sizeof(tmp1));
-    OPENSSL_cleanse(iv1, sizeof(iv1));
-    OPENSSL_cleanse(iv2, sizeof(iv2));
     return 1;
  err:
-    OPENSSL_cleanse(tmp1, sizeof(tmp1));
-    OPENSSL_cleanse(tmp2, sizeof(tmp1));
-    OPENSSL_cleanse(iv1, sizeof(iv1));
-    OPENSSL_cleanse(iv2, sizeof(iv2));
     return 0;
 }
 


### PR DESCRIPTION
Removing some stale variables from the function tls1_change_cipher_state.
They are unused in the current code, so let's eliminate them for clarity.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
