### PR TITLE
doc/man1/x509.pod: fix typo

### DIFF
--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -173,7 +173,7 @@ options. See the B<TEXT OPTIONS> section for more information.
 
 =item B<-noout>
 
-This option prevents output of the encoded version of the request.
+This option prevents output of the encoded version of the certificate.
 
 =item B<-pubkey>
 


### PR DESCRIPTION
This looks like a copy&paste error from req.pod to x509.pod.
