### PR TITLE
Fix compilation on sparc

### DIFF
--- a/crypto/des/asm/des_enc.m4
+++ b/crypto/des/asm/des_enc.m4
@@ -29,8 +29,6 @@
 .ident "des_enc.m4 2.1"
 .file  "des_enc-sparc.S"
 
-#include <openssl/opensslconf.h>
-
 #if defined(__SUNPRO_C) && defined(__sparcv9)
 # define ABI64  /* They've said -xarch=v9 at command line */
 #elif defined(__GNUC__) && defined(__arch64__)

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -927,6 +927,11 @@ static int aes_t4_ocb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                              const unsigned char *in, size_t len);
 # endif                        /* OPENSSL_NO_OCB */
 
+# ifndef OPENSSL_NO_SIV
+#  define aes_t4_siv_init_key aes_siv_init_key
+#  define aes_t4_siv_cipher aes_siv_cipher
+# endif /* OPENSSL_NO_SIV */
+
 # define BLOCK_CIPHER_generic(nid,keylen,blocksize,ivlen,nmode,mode,MODE,flags) \
 static const EVP_CIPHER aes_t4_##keylen##_##mode = { \
         nid##_##keylen##_##nmode,blocksize,keylen/8,ivlen, \


### PR DESCRIPTION
Fixes #7966

Compilation on sparc fails for 2 reasons:

1) An include of opensslconf.h from des_enc.m4. This doesn't seem to like the latest version related changes to that header. I can't see why the file needs that include and removing it doesn't seem to cause a problem.

2) The new SIV support fails due to some missing definitions of init_key and cipher functions for sparc.

I've fixed both of those things and it now compiles using a cross compiler. I don't have access to a sparc environment and qemu is failing me (probably due to something I'm not doing right) - so I can't check that "make test" works properly.

@slontis - please can you confirm this builds and tests pass on real hardware?