### PR TITLE
Add Windows 10 on ARM build configuration

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1330,6 +1330,14 @@ sub vms_info {
         bn_ops           => "SIXTY_FOUR_BIT EXPORT_VAR_AS_FN",
         build_scheme     => add("VC-W64", { separator => undef }),
     },
+    "VC-WIN64-ARM" => {
+        inherit_from     => [ "VC-WIN64-common" ],
+        as               => "armasm64",
+        asoutflag        => "-o",
+        sys_id           => "WIN64_ARM",
+        perlasm_scheme   => "auto",
+        multilib         => "-arm64",
+    },
     "VC-WIN64I" => {
         inherit_from     => [ "VC-WIN64-common", asm("ia64_asm"),
                               sub { $disabled{shared} ? () : "ia64_uplink" } ],


### PR DESCRIPTION
This change adds the build configuration entry to enable building OpenSSL 1.1.0 for Windows 10 on ARM (ARM64 desktop/win32 Windows) without code changes.

Since ARM64 assembly is not supported on OpenSSL at this time ), support for it on the new platform is omitted.

@dot-asm, I see Issue #6856 and PR [#5502](https://github.com/openssl/openssl/pull/5502). My goal is to get an OpenSSL with ARM64 Windows support into Node.js as simply as possible, and this seems a step easier than asking Node.js to pick up 1.1.1. It's also usable by other win32 projects. At the very least, others can see my rejected PR and understand that they really should just use 1.1.1. :)

CLA: trivial
