### PR TITLE
Support `-modulus` option for EC keys in ec and x509 commands

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -27,6 +27,9 @@
 #ifndef OPENSSL_NO_DSA
 # include <openssl/dsa.h>
 #endif
+#ifndef OPENSSL_NO_EC
+# include <openssl/ec.h>
+#endif
 
 #undef POSTFIX
 #define POSTFIX ".srl"
@@ -720,6 +723,23 @@ int x509_main(int argc, char **argv)
                     const BIGNUM *dsapub = NULL;
                     DSA_get0_key(EVP_PKEY_get0_DSA(pkey), &dsapub, NULL);
                     BN_print(out, dsapub);
+                } else
+#endif
+#ifndef OPENSSL_NO_EC
+                if (EVP_PKEY_id(pkey) == EVP_PKEY_EC) {
+                    EC_KEY *ec = EVP_PKEY_get1_EC_KEY(pkey);
+                    const EC_GROUP *group = EC_KEY_get0_group(ec);
+
+                    if (group != NULL) {
+                        const EC_POINT *public_key = EC_KEY_get0_public_key(ec);
+                        const BIGNUM *pub_key;
+
+                        pub_key = EC_POINT_point2bn(group, public_key,
+						    EC_KEY_get_conv_form(ec),
+						    NULL, NULL);
+                        if (pub_key != NULL)
+                            BN_print(out, pub_key);
+                    }
                 } else
 #endif
                 {

--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -20,6 +20,7 @@ B<openssl> B<ec>
 [B<-idea>]
 [B<-text>]
 [B<-noout>]
+[B<-modulus>]
 [B<-param_out>]
 [B<-pubin>]
 [B<-pubout>]


### PR DESCRIPTION
Support `-modulus` option for EC keys in ec and x509 commands for feature parity with RSA and DSA.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated (No tests found for existing -modulus option)
