### PR TITLE
Check some SRP return values

### DIFF
--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -26,6 +26,7 @@ static BIGNUM *srp_Calc_xy(const BIGNUM *x, const BIGNUM *y, const BIGNUM *N)
     unsigned char *tmp = NULL;
     int numN = BN_num_bytes(N);
     BIGNUM *res = NULL;
+
     if (x != N && BN_ucmp(x, N) >= 0)
         return NULL;
     if (y != N && BN_ucmp(y, N) >= 0)
@@ -139,7 +140,8 @@ BIGNUM *SRP_Calc_x(const BIGNUM *s, const char *user, const char *pass)
         || !EVP_DigestFinal_ex(ctxt, dig, NULL)
         || !EVP_DigestInit_ex(ctxt, EVP_sha1(), NULL))
         goto err;
-    BN_bn2bin(s, cs);
+    if (BN_bn2bin(s, cs) < 0)
+        goto err;
     if (!EVP_DigestUpdate(ctxt, cs, BN_num_bytes(s)))
         goto err;
 

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -707,6 +707,8 @@ int SRP_create_verifier_BN(const char *user, const char *pass, BIGNUM **salt,
     }
 
     x = SRP_Calc_x(salttmp, user, pass);
+    if (x == NULL)
+        goto err;
 
     *verifier = BN_new();
     if (*verifier == NULL)

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -614,10 +614,14 @@ char *SRP_create_verifier(const char *user, const char *pass, char **salt,
         if ((len = t_fromb64(tmp, sizeof(tmp), N)) <= 0)
             goto err;
         N_bn_alloc = BN_bin2bn(tmp, len, NULL);
+        if (N_bn_alloc == NULL)
+            goto err;
         N_bn = N_bn_alloc;
         if ((len = t_fromb64(tmp, sizeof(tmp) ,g)) <= 0)
             goto err;
         g_bn_alloc = BN_bin2bn(tmp, len, NULL);
+        if (g_bn_alloc == NULL)
+            goto err;
         g_bn = g_bn_alloc;
         defgNid = "*";
     } else {
@@ -639,15 +643,19 @@ char *SRP_create_verifier(const char *user, const char *pass, char **salt,
             goto err;
         s = BN_bin2bn(tmp2, len, NULL);
     }
+    if (s == NULL)
+        goto err;
 
     if (!SRP_create_verifier_BN(user, pass, &s, &v, N_bn, g_bn))
         goto err;
 
-    BN_bn2bin(v, tmp);
+    if (BN_bn2bin(v, tmp) < 0)
+        goto err;
     vfsize = BN_num_bytes(v) * 2;
     if (((vf = OPENSSL_malloc(vfsize)) == NULL))
         goto err;
-    t_tob64(vf, tmp, BN_num_bytes(v));
+    if (!t_tob64(vf, tmp, BN_num_bytes(v)))
+        goto err;
 
     if (*salt == NULL) {
         char *tmp_salt;
@@ -655,7 +663,10 @@ char *SRP_create_verifier(const char *user, const char *pass, char **salt,
         if ((tmp_salt = OPENSSL_malloc(SRP_RANDOM_SALT_LEN * 2)) == NULL) {
             goto err;
         }
-        t_tob64(tmp_salt, tmp2, SRP_RANDOM_SALT_LEN);
+        if (!t_tob64(tmp_salt, tmp2, SRP_RANDOM_SALT_LEN)) {
+            OPENSSL_free(tmp_salt);
+            goto err;
+        }
         *salt = tmp_salt;
     }
 
@@ -702,6 +713,8 @@ int SRP_create_verifier_BN(const char *user, const char *pass, BIGNUM **salt,
             goto err;
 
         salttmp = BN_bin2bn(tmp2, SRP_RANDOM_SALT_LEN, NULL);
+        if (salttmp == NULL)
+            goto err;
     } else {
         salttmp = *salt;
     }


### PR DESCRIPTION
The first commit fixes a missing return value spotted by the OSTIF audit.

The second commit fixes a number of other missing return checks in the SRP code.
