### PR TITLE
Ensure that static libraries are included in the installation on windows

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -98,7 +98,7 @@ GENERATED={- # common0.tmpl provides @generated
                              $x }
                        @generated) -}
 
-INSTALL_LIBS={- join(" ", map { quotify1(shlib_import($_) or lib($_)) } @{$unified_info{install}->{libraries}}) -}
+INSTALL_LIBS={- join(" ", map { ( shlib_import($_), lib($_) ) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBS={- join(" ", map { quotify_l(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_SHLIBPDBS={- join(" ", map { local $shlibext = ".pdb"; quotify_l(shlib($_)) } @{$unified_info{install}->{libraries}}) -}
 INSTALL_ENGINES={- join(" ", map { quotify1(dso($_)) } @{$unified_info{install}->{engines}}) -}


### PR DESCRIPTION
On all other platforms, both the static libraries and the shared libraries (if 'shared' is enabled) are part of the install. Due to the unique nature of windows, both .lib and .dll files are required for dynamic (shared) builds. The install step then ignores the '_static.lib' static libraries.

I've modified the windows makefile template to include these crypto/ssl static libraries in the installation steps.

Tested using both 'shared' and 'no-shared' builds.

CLA: trivial
