### PR TITLE
crypto/armcap.c, crypto/ppccap.c: stricter use of getauxval()

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -62,13 +62,14 @@ uint32_t OPENSSL_rdtsc(void)
 # if defined(__GNUC__) && __GNUC__>=2
 void OPENSSL_cpuid_setup(void) __attribute__ ((constructor));
 # endif
-/*
- * Use a weak reference to getauxval() so we can use it if it is available but
- * don't break the build if it is not.
- */
-# if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__)
-extern unsigned long getauxval(unsigned long type) __attribute__ ((weak));
-# else
+
+# if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#  if __GLIBC_PREREQ(2, 16)
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
+# endif
+# ifndef OSSL_IMPLEMENT_GETAUXVAL
 static unsigned long (*getauxval) (unsigned long) = NULL;
 # endif
 

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -168,17 +168,15 @@ void OPENSSL_altivec_probe(void);
 void OPENSSL_crypto207_probe(void);
 void OPENSSL_madd300_probe(void);
 
-/*
- * Use a weak reference to getauxval() so we can use it if it is available
- * but don't break the build if it is not. Note that this is *link-time*
- * feature detection, not *run-time*. In other words if we link with
- * symbol present, it's expected to be present even at run-time.
- */
-#if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__)
-extern unsigned long getauxval(unsigned long type) __attribute__ ((weak));
-#else
+# if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#  if __GLIBC_PREREQ(2, 16)
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
+# endif
+# ifndef OSSL_IMPLEMENT_GETAUXVAL
 static unsigned long (*getauxval) (unsigned long) = NULL;
-#endif
+# endif
 
 /* I wish <sys/auxv.h> was universally available */
 #define HWCAP                   16      /* AT_HWCAP */

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -168,15 +168,12 @@ void OPENSSL_altivec_probe(void);
 void OPENSSL_crypto207_probe(void);
 void OPENSSL_madd300_probe(void);
 
-# if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#  if __GLIBC_PREREQ(2, 16)
-#   include <sys/auxv.h>
-#   define OSSL_IMPLEMENT_GETAUXVAL
-#  endif
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+# if __GLIBC_PREREQ(2, 16)
+#  include <sys/auxv.h>
+#  define OSSL_IMPLEMENT_GETAUXVAL
 # endif
-# ifndef OSSL_IMPLEMENT_GETAUXVAL
-static unsigned long (*getauxval) (unsigned long) = NULL;
-# endif
+#endif
 
 /* I wish <sys/auxv.h> was universally available */
 #define HWCAP                   16      /* AT_HWCAP */
@@ -275,7 +272,8 @@ void OPENSSL_cpuid_setup(void)
     }
 #endif
 
-    if (getauxval != NULL) {
+#ifdef OSSL_IMPLEMENT_GETAUXVAL
+    {
         unsigned long hwcap = getauxval(HWCAP);
 
         if (hwcap & HWCAP_FPU) {
@@ -305,6 +303,7 @@ void OPENSSL_cpuid_setup(void)
 
         return;
     }
+#endif
 
     sigfillset(&all_masked);
     sigdelset(&all_masked, SIGILL);


### PR DESCRIPTION
Having a weak getauxval() and only depending on GNU C without looking
at the library we build against meant that it got picked up where not
really expected.

So we change this to check for the glibc version, and since we know it
exists from that version, there's no real need to make it weak.

When we don't pick up a library getauxval(), we still define our own
NULL function pointer, to minimize the impact of this change on the
code.
