### PR TITLE
Support SM2 in apps/pkeyutil

### DIFF
--- a/crypto/sm2/sm2_pmeth.c
+++ b/crypto/sm2/sm2_pmeth.c
@@ -248,6 +248,9 @@ static int pkey_sm2_ctrl_str(EVP_PKEY_CTX *ctx,
         else
             return -2;
         return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
+    } else if (strcmp(type, "sm2_id") == 0) {
+        return pkey_sm2_ctrl(ctx, EVP_PKEY_CTRL_SET1_ID,
+                             (int)strlen(value), (void *)value);
     }
 
     return -2;

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -300,6 +300,22 @@ this digest is assumed by default.
 The X25519 and X448 algorithms support key derivation only. Currently there are
 no additional options.
 
+=head1 SM2
+
+The SM2 algorithm supports sign, verify, encrypt and decrypt operations. For
+the sign and verify operations, SM2 requires an ID string to be passed in. The
+following B<pkeyopt> value is supported:
+
+=over 4
+
+=item B<sm2_id:string>
+
+This sets the ID string used in SM2 sign or verify operations. While verifying
+an SM2 signature, the ID string must be the same one when signing the data.
+Otherwise the verification will fail.
+
+=back
+
 =head1 EXAMPLES
 
 Sign some data using a private key:
@@ -337,6 +353,10 @@ Derive using the same algorithm, but read key from environment variable MYPASS:
 
  openssl pkeyutl -kdf scrypt -kdflen 16 -pkeyopt_passin pass:env:MYPASS \
     -pkeyopt hexsalt:aabbcc -pkeyopt N:16384 -pkeyopt r:8 -pkeyopt p:1
+
+Sign some data using an SM2 privated and a specific ID:
+
+ openssl pkeyutl -sign -in file -inkey sm2.key -out sig -pkeyopt sm2_id:someid
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
SM2 requires an ID string when signing or verifying a piece of data, this patch add the ability for apps/pkeyutil to use SM2 signature algorithm.

This is one of possible ways that can do this, and I guess this could be the convenient one for the users to use with apps/pkeyutil command.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
