### PR TITLE
data race in x509 check code #7656

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -1036,7 +1036,9 @@ static int drbg_bytes(unsigned char *out, int count)
     if (drbg == NULL)
         return 0;
 
+    rand_drbg_lock(drbg->parent);
     ret = RAND_DRBG_bytes(drbg, out, count);
+    rand_drbg_unlock(drbg->parent);
 
     return ret;
 }

--- a/crypto/x509v3/v3_addr.c
+++ b/crypto/x509v3/v3_addr.c
@@ -1201,7 +1201,10 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
     } else {
         i = 0;
         x = sk_X509_value(chain, i);
-        if ((ext = x->rfc3779_addr) == NULL)
+        CRYPTO_THREAD_read_lock(x->lock);
+        ext = x->rfc3779_addr;
+        CRYPTO_THREAD_unlock(x->lock);
+        if (ext == NULL)
             goto done;
     }
     if (!X509v3_addr_is_canonical(ext))

--- a/crypto/x509v3/v3_asid.c
+++ b/crypto/x509v3/v3_asid.c
@@ -745,7 +745,10 @@ static int asid_validate_path_internal(X509_STORE_CTX *ctx,
     } else {
         i = 0;
         x = sk_X509_value(chain, i);
-        if ((ext = x->rfc3779_asid) == NULL)
+        CRYPTO_THREAD_read_lock(x->lock);
+        ext = x->rfc3779_asid;
+        CRYPTO_THREAD_unlock(x->lock);
+        if (ext == NULL)
             goto done;
     }
     if (!X509v3_asid_is_canonical(ext))

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -811,7 +811,7 @@ int X509_check_issued(X509 *issuer, X509 *subject)
                 ret = X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH;
     }
 
-    if (ret == X509_OK) {
+    if (ret == X509_V_OK) {
         if (subject->ex_flags & EXFLAG_PROXY) {
             if (ku_reject(issuer, KU_DIGITAL_SIGNATURE))
                 ret = X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE;


### PR DESCRIPTION
I've used Intel Inspector to identify race conditions in OpenSSL that caused problems in our multi-threaded Windows-based login service.
The fixed version has been running without problems for over 3 weeks now, and Intel thread Inspector no longer reports any issues (see issue #7656).
So I offer this fix as pull request (1st time contributer to OpenSSL, if I've violated procedures, apologies).

I consider this a trivial change, so I've not submitted a CLA (but if the policy is to require an official CLA, I'm willing to provide one).