### PR TITLE
DTLS timer fix

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -440,19 +440,6 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             && SSL3_RECORD_get_length(rr) != 0)
         s->rlayer.alert_count = 0;
 
-    if (SSL3_RECORD_get_type(rr) != SSL3_RT_HANDSHAKE
-            && SSL3_RECORD_get_type(rr) != SSL3_RT_CHANGE_CIPHER_SPEC
-            && !SSL_in_init(s)
-            && (s->d1->next_timeout.tv_sec != 0
-                || s->d1->next_timeout.tv_usec != 0)) {
-        /*
-         * The timer is still running but we've received something that isn't
-         * handshake data - so the peer must have finished processing our
-         * last handshake flight. Stop the timer.
-         */
-        dtls1_stop_timer(s);
-    }
-
     /* we now have a packet which can be read and processed */
 
     if (s->s3->change_cipher_spec /* set when we receive ChangeCipherSpec,

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1076,15 +1076,6 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs, int stop)
             /* N.B. s->ctx may not equal s->session_ctx */
             tsan_counter(&s->ctx->stats.sess_accept_good);
             s->handshake_func = ossl_statem_accept;
-
-            if (SSL_IS_DTLS(s) && !s->hit) {
-                /*
-                 * We are finishing after the client. We start the timer going
-                 * in case there are any retransmits of our final flight
-                 * required.
-                 */
-                dtls1_start_timer(s);
-            }
         } else {
             if (SSL_IS_TLS13(s)) {
                 /*
@@ -1106,15 +1097,6 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs, int stop)
 
             s->handshake_func = ossl_statem_connect;
             tsan_counter(&s->session_ctx->stats.sess_connect_good);
-
-            if (SSL_IS_DTLS(s) && s->hit) {
-                /*
-                 * We are finishing after the server. We start the timer going
-                 * in case there are any retransmits of our final flight
-                 * required.
-                 */
-                dtls1_start_timer(s);
-            }
         }
 
         if (SSL_IS_DTLS(s)) {

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -87,17 +87,21 @@ static int test_dtls_unprocessed(int testidx)
     /*
      * Inject a dummy record from the next epoch. In test 0, this should never
      * get used because the message sequence number is too big. In test 1 we set
-     * the record sequence number to be way off in the future. This should not
-     * have an impact on the record replay protection because the record should
-     * be dropped before it is marked as arrived
+     * the record sequence number to be way off in the future.
      */
     c_to_s_mempacket = SSL_get_wbio(clientssl1);
     c_to_s_mempacket = BIO_next(c_to_s_mempacket);
     mempacket_test_inject(c_to_s_mempacket, (char *)certstatus,
                           sizeof(certstatus), 1, INJECT_PACKET_IGNORE_REC_SEQ);
 
-    if (!TEST_true(create_ssl_connection(serverssl1, clientssl1,
-                                         SSL_ERROR_NONE)))
+    /*
+     * Create the connection. We use "create_bare_ssl_connection" here so that
+     * we can force the connection to not do "SSL_read" once partly conencted.
+     * We don't want to accidentally read the dummy records we injected because
+     * they will fail to decrypt.
+     */
+    if (!TEST_true(create_bare_ssl_connection(serverssl1, clientssl1,
+                                              SSL_ERROR_NONE, 0)))
         goto end;
 
     if (timer_cb_count == 0) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5593,7 +5593,7 @@ static int test_shutdown(int tst)
 
     if (tst == 3) {
         if (!TEST_true(create_bare_ssl_connection(serverssl, clientssl,
-                                                  SSL_ERROR_NONE))
+                                                  SSL_ERROR_NONE, 1))
                 || !TEST_ptr_ne(sess = SSL_get_session(clientssl), NULL)
                 || !TEST_false(SSL_SESSION_is_resumable(sess)))
             goto end;

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -383,9 +383,6 @@ static int mempacket_test_read(BIO *bio, char *out, int outl)
     if (outl > thispkt->len)
         outl = thispkt->len;
 
-    if (thispkt->type == INJECT_PACKET_IGNORE_REC_SEQ)
-        printf("Ignore rec seq found\n");
-
     if (thispkt->type != INJECT_PACKET_IGNORE_REC_SEQ
             && (ctx->injected || ctx->droprec >= 0)) {
         /*
@@ -393,7 +390,7 @@ static int mempacket_test_read(BIO *bio, char *out, int outl)
          * the order received. Since we are actually a reliable transport
          * we know that there won't be any re-ordering. We overwrite to deal
          * with any packets that have been injected
-    -     */
+         */
         for (rem = thispkt->len, rec = thispkt->data; rem > 0; rem -= len) {
             if (rem < DTLS1_RT_HEADER_LENGTH)
                 return -1;

--- a/test/ssltestlib.h
+++ b/test/ssltestlib.h
@@ -18,7 +18,8 @@ int create_ssl_ctx_pair(const SSL_METHOD *sm, const SSL_METHOD *cm,
                         char *privkeyfile);
 int create_ssl_objects(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
                        SSL **cssl, BIO *s_to_c_fbio, BIO *c_to_s_fbio);
-int create_bare_ssl_connection(SSL *serverssl, SSL *clientssl, int want);
+int create_bare_ssl_connection(SSL *serverssl, SSL *clientssl, int want,
+                               int read);
 int create_ssl_objects2(SSL_CTX *serverctx, SSL_CTX *clientctx, SSL **sssl,
                        SSL **cssl, int sfd, int cfd);
 int create_test_sockets(int *cfd, int *sfd);


### PR DESCRIPTION
The DTLS timer should not run after then end of the handshake. Commit f750641 erroneously made that happen and needs to be reverted. Doing so however causes some test failures due to problems with the way retransmits are handled in the test suite.

During a DTLS handshake we may need to periodically handle timeouts in the DTLS timer to ensure retransmits due to lost packets are performed. However, one peer will always complete a handshake before the other. The DTLS timer stops once the handshake has finished so any handshake messages lost after that point will not automatically get retransmitted simply by calling DTLSv1_handle_timeout(). However attempting an SSL_read implies a DTLSv1_handle_timeout() and additionally will process records received from the peer. If those records are themselves retransmits then we know that the peer has not completed its handshake yet and a retransmit of our final flight automatically occurs.

Fixes #7998