### PR TITLE
crypto/bn: fix return value in BN_generate_prime

### DIFF
--- a/crypto/bn/bn_depr.c
+++ b/crypto/bn/bn_depr.c
@@ -40,7 +40,7 @@ BIGNUM *BN_generate_prime(BIGNUM *ret, int bits, int safe,
         goto err;
 
     /* we have a prime :-) */
-    return ret;
+    return rnd;
  err:
     BN_free(rnd);
     return NULL;


### PR DESCRIPTION
When the ret parameter is NULL the generated prime
is in rnd variable and not in ret.

CLA: trivial
