### PR TITLE
Remove stray -modulus option from the ec manual page.

### DIFF
--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -101,10 +101,6 @@ Prints out the public, private key components and parameters.
 
 This option prevents output of the encoded version of the key.
 
-=item B<-modulus>
-
-This option prints out the value of the public key component of the key.
-
 =item B<-pubin>
 
 By default, a private key is read from the input file. With this option a


### PR DESCRIPTION
There is a stray option -modulus in the manual page which is not present in the ec command.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
