### PR TITLE
Introduce the OPENSSL_NO_MADVISE to disable call to madvise()

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -485,7 +485,7 @@ static int sh_init(size_t size, int minsize)
     if (mlock(sh.arena, sh.arena_size) < 0)
         ret = 2;
 #endif
-#ifdef MADV_DONTDUMP
+#if defined(MADV_DONTDUMP) && !defined(OPENSSL_NO_MADVISE)
     if (madvise(sh.arena, sh.arena_size, MADV_DONTDUMP) < 0)
         ret = 2;
 #endif


### PR DESCRIPTION
This macro is used to disable call to madvise (in case of no MMU for example).
The original openssl code checks if a macro used in the madvise call is defined.
The problem comes from the fact that the code in crypto/mem_sec.c also includes a kernel header defining the same macro unconditionally, even for noMMU platforms. Thus the check is always true in that case and compilation fails.

```c
# if defined(OPENSSL_SYS_LINUX)
#  include <sys/syscall.h>
#  if defined(SYS_mlock2)
#   include <linux/mman.h>
```

I think the proper fix is to separate the code that wraps the mlock2 syscall and includes linux/mman.h in a separate compilation unit, so that the code calling madvise only sees the toolchain wrapper and not the kernel uapi directly.

Signed-off-by: Patrick Havelange <patrick.havelange@essensium.com>
Signed-off-by: Arnout Vandecappelle <arnout@mind.be>
