### PR TITLE
Document and add macros for additional DSA options

### DIFF
--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -174,9 +174,7 @@ static int pkey_dsa_ctrl_str(EVP_PKEY_CTX *ctx,
     }
     if (strcmp(type, "dsa_paramgen_q_bits") == 0) {
         int qbits = atoi(value);
-        return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN,
-                                 EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, qbits,
-                                 NULL);
+        return EVP_PKEY_CTX_set_dsa_paramgen_q_bits(ctx, qbits);
     }
     if (strcmp(type, "dsa_paramgen_md") == 0) {
         const EVP_MD *md = EVP_get_digestbyname(value);
@@ -185,9 +183,7 @@ static int pkey_dsa_ctrl_str(EVP_PKEY_CTX *ctx,
             DSAerr(DSA_F_PKEY_DSA_CTRL_STR, DSA_R_INVALID_DIGEST_TYPE);
             return 0;
         }
-        return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN,
-                                 EVP_PKEY_CTRL_DSA_PARAMGEN_MD, 0,
-                                 (void *)md);
+        return EVP_PKEY_CTX_set_dsa_paramgen_md(ctx, md);
     }
     return -2;
 }

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -23,6 +23,8 @@ EVP_PKEY_CTX_get_rsa_oaep_md,
 EVP_PKEY_CTX_set0_rsa_oaep_label,
 EVP_PKEY_CTX_get0_rsa_oaep_label,
 EVP_PKEY_CTX_set_dsa_paramgen_bits,
+EVP_PKEY_CTX_set_dsa_paramgen_q_bits,
+EVP_PKEY_CTX_set_dsa_paramgen_md,
 EVP_PKEY_CTX_set_dh_paramgen_prime_len,
 EVP_PKEY_CTX_set_dh_paramgen_subprime_len,
 EVP_PKEY_CTX_set_dh_paramgen_generator,
@@ -93,6 +95,8 @@ EVP_PKEY_CTX_set1_id, EVP_PKEY_CTX_get1_id, EVP_PKEY_CTX_get1_id_len
  #include <openssl/dsa.h>
 
  int EVP_PKEY_CTX_set_dsa_paramgen_bits(EVP_PKEY_CTX *ctx, int nbits);
+ int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx, int qbits);
+ int EVP_PKEY_CTX_set_dsa_paramgen_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 
  #include <openssl/dh.h>
 
@@ -255,7 +259,17 @@ by the library and should not be freed by the caller.
 =head2 DSA parameters
 
 The EVP_PKEY_CTX_set_dsa_paramgen_bits() macro sets the number of bits used
-for DSA parameter generation to B<bits>. If not specified 1024 is used.
+for DSA parameter generation to B<nbits>. If not specified, 1024 is used.
+
+The EVP_PKEY_CTX_set_dsa_paramgen_q_bits() macro sets the number of bits in the
+subprime parameter B<q> for DSA parameter generation to B<qbits>. If not
+specified, 160 is used. If a digest function is specified below, this parameter
+is ignored and instead, the number of bits in B<q> matches the size of the
+digest.
+
+The EVP_PKEY_CTX_set_dsa_paramgen_md() macro sets the digest function used for
+DSA parameter generation to B<md>. If not specified, one of SHA-1, SHA-224, or
+SHA-256 is selected to match the bit length of B<q> above.
 
 =head2 DH parameters
 

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -162,6 +162,12 @@ DH *DSA_dup_DH(const DSA *r);
 # define EVP_PKEY_CTX_set_dsa_paramgen_bits(ctx, nbits) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN, \
                                 EVP_PKEY_CTRL_DSA_PARAMGEN_BITS, nbits, NULL)
+# define EVP_PKEY_CTX_set_dsa_paramgen_q_bits(ctx, qbits) \
+        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN, \
+                                EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, qbits, NULL)
+# define EVP_PKEY_CTX_set_dsa_paramgen_md(ctx, md) \
+        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN, \
+                                EVP_PKEY_CTRL_DSA_PARAMGEN_MD, 0, (void *)(md))
 
 # define EVP_PKEY_CTRL_DSA_PARAMGEN_BITS         (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS       (EVP_PKEY_ALG_CTRL + 2)

--- a/util/private.num
+++ b/util/private.num
@@ -233,6 +233,8 @@ EVP_PKEY_CTX_set_dh_pad                 define
 EVP_PKEY_CTX_set_dh_rfc5114             define
 EVP_PKEY_CTX_set_dhx_rfc5114            define
 EVP_PKEY_CTX_set_dsa_paramgen_bits      define
+EVP_PKEY_CTX_set_dsa_paramgen_q_bits    define
+EVP_PKEY_CTX_set_dsa_paramgen_md        define
 EVP_PKEY_CTX_set_ec_param_enc           define
 EVP_PKEY_CTX_set_ec_paramgen_curve_nid  define
 EVP_PKEY_CTX_set_ecdh_cofactor_mode     define


### PR DESCRIPTION
EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS and EVP_PKEY_CTRL_DSA_PARAMGEN_MD are only
exposed from EVP_PKEY_CTX_ctrl, which means callers must write more error-prone
code (see also issue #1319). Add the missing wrapper macros and document them.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
