### PR TITLE
Android build: use ANDROID_NDK_HOME rather than ANDROID_NDK

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -22,13 +22,18 @@
                 return $android_ndk = { bn_ops => "BN_AUTO" };
             }
 
-            my $ndk = $ENV{ANDROID_NDK};
-            die "\$ANDROID_NDK is not defined"  if (!$ndk);
+            my $ndk_var;
+            my $ndk;
+            foreach $ndk_var (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
+                $ndk = $ENV{$ndk_var};
+                last if defined $ndk;
+            }
+            die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);
             if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
                 # $ndk/platforms is traditional "all-inclusive" NDK, while
                 # $ndk/AndroidVersion.txt is so-called standalone toolchain
                 # tailored for specific target down to API level.
-                die "\$ANDROID_NDK=$ndk is invalid";
+                die "\$ANDROID_NDK_HOME=$ndk is invalid";
             }
             $ndk = canonpath($ndk);
 
@@ -90,7 +95,7 @@
                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
                 $cflags .= " -target $tridefault "
-                        .  "-gcc-toolchain \$(ANDROID_NDK)/toolchains"
+                        .  "-gcc-toolchain \$($ndk_var)/toolchains"
                         .  "/$tritools-4.9/prebuilt/$host";
                 $user{CC} = "clang" if ($user{CC} !~ m|clang|);
                 $user{CROSS_COMPILE} = undef;
@@ -127,13 +132,13 @@
                 die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
                 $incroot =~ s|^$ndk/||;
                 $cppflags  = "-D__ANDROID_API__=$api";
-                $cppflags .= " -isystem \$(ANDROID_NDK)/$incroot/$triarch";
-                $cppflags .= " -isystem \$(ANDROID_NDK)/$incroot";
+                $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
+                $cppflags .= " -isystem \$($ndk_var)/$incroot";
             }
 
             $sysroot =~ s|^$ndk/||;
             $android_ndk = {
-                cflags   => "$cflags --sysroot=\$(ANDROID_NDK)/$sysroot",
+                cflags   => "$cflags --sysroot=\$($ndk_var)/$sysroot",
                 cppflags => $cppflags,
                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
                                             : "BN_LLONG",

--- a/NOTES.ANDROID
+++ b/NOTES.ANDROID
@@ -23,7 +23,7 @@
  platform. Though you still need to know the prefix to extend your PATH,
  in order to invoke $(CROSS_COMPILE)gcc and company. (Configure will fail
  and give you a hint if you get it wrong.) Apart from PATH adjustment
- you need to set ANDROID_NDK environment to point at NDK directory
+ you need to set ANDROID_NDK_HOME environment to point at NDK directory
  as /some/where/android-ndk-<ver>. Both variables are significant at both
  configuration and compilation times. NDK customarily supports multiple
  Android API levels, e.g. android-14, android-21, etc. By default latest 
@@ -32,13 +32,13 @@
  target platform version. For example, to compile for ICS on ARM with
  NDK 10d:
 
-    export ANDROID_NDK=/some/where/android-ndk-10d
-    PATH=$ANDROID_NDK/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin:$PATH
+    export ANDROID_NDK_HOME=/some/where/android-ndk-10d
+    PATH=$ANDROID_NDK_HOME/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin:$PATH
     ./Configure android-arm -D__ANDROID_API__=14
     make
 
  Caveat lector! Earlier OpenSSL versions relied on additional CROSS_SYSROOT
- variable set to $ANDROID_NDK/platforms/android-<api>/arch-<arch> to
+ variable set to $ANDROID_NDK_HOME/platforms/android-<api>/arch-<arch> to
  appoint headers-n-libraries' location. It's still recognized in order
  to facilitate migration from older projects. However, since API level
  appears in CROSS_SYSROOT value, passing -D__ANDROID_API__=N can be in
@@ -53,9 +53,9 @@
 
  Another option is to create so called "standalone toolchain" tailored
  for single specific platform including Android API level, and assign its
- location to ANDROID_NDK. In such case you have to pass matching target
- name to Configure and shouldn't use -D__ANDROID_API__=N. PATH adjustment
- becomes simpler, $ANDROID_NDK/bin:$PATH suffices.
+ location to ANDROID_NDK_HOME. In such case you have to pass matching
+ target name to Configure and shouldn't use -D__ANDROID_API__=N. PATH
+ adjustment becomes simpler, $ANDROID_NDK_HOME/bin:$PATH suffices.
 
  Running tests (on Linux)
  ------------------------


### PR DESCRIPTION
It apepars that ANDROID_NDK_HOME is the recommended standard
environment variable for the NDK.

We retain ANDROID_NDK as a fallback.

Fixes #8101
