### PR TITLE
Avoid memcpy undefined behaviour

### DIFF
--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -380,7 +380,8 @@ int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,
         /* Asking for SHA1; always computed in CRL d2i. */
         if (len != NULL)
             *len = sizeof(data->sha1_hash);
-        memcpy(md, data->sha1_hash, sizeof(data->sha1_hash));
+        if (md != data->sha1_hash)
+            memcpy(md, data->sha1_hash, sizeof(data->sha1_hash));
         return 1;
     }
     return (ASN1_item_digest


### PR DESCRIPTION
The function X509_CRL_digest() may perform a memcpy in some situations.
At least one internal caller (crl_cb in x_crl.c) may cause the desitation
pointer for the memcpy to be the same as the source. This is undefined
behaviour so we add an explicit check for this.

Fixes #8099

