### PR TITLE
Fix calling convention bug in ecp_nistz256_ord_sqr_mont

### DIFF
--- a/crypto/ec/asm/ecp_nistz256-armv8.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv8.pl
@@ -1462,7 +1462,7 @@ $code.=<<___;
 
 ////////////////////////////////////////////////////////////////////////
 // void ecp_nistz256_ord_sqr_mont(uint64_t res[4], uint64_t a[4],
-//                                int rep);
+//                                uint64_t rep);
 .globl	ecp_nistz256_ord_sqr_mont
 .type	ecp_nistz256_ord_sqr_mont,%function
 .align	4

--- a/crypto/ec/asm/ecp_nistz256-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistz256-ppc64.pl
@@ -1919,7 +1919,7 @@ $code.=<<___;
 
 ################################################################################
 # void ecp_nistz256_ord_sqr_mont(uint64_t res[4], uint64_t a[4],
-#                                int rep);
+#                                uint64_t rep);
 .globl	ecp_nistz256_ord_sqr_mont
 .align	5
 ecp_nistz256_ord_sqr_mont:

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -826,7 +826,7 @@ $code.=<<___;
 # void ecp_nistz256_ord_sqr_mont(
 #   uint64_t res[4],
 #   uint64_t a[4],
-#   int rep);
+#   uint64_t rep);
 
 .globl	ecp_nistz256_ord_sqr_mont
 .type	ecp_nistz256_ord_sqr_mont,\@function,3

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1468,7 +1468,7 @@ void ecp_nistz256_ord_mul_mont(BN_ULONG res[P256_LIMBS],
                                const BN_ULONG b[P256_LIMBS]);
 void ecp_nistz256_ord_sqr_mont(BN_ULONG res[P256_LIMBS],
                                const BN_ULONG a[P256_LIMBS],
-                               int rep);
+                               BN_ULONG rep);
 
 static int ecp_nistz256_inv_mod_ord(const EC_GROUP *group, BIGNUM *r,
                                     const BIGNUM *x, BN_CTX *ctx)


### PR DESCRIPTION
The rep parameter takes an int in C, but the assembly implementation
looks at the upper bits. While it's unlikely to happen here, where all
calls pass a constant, in other scenarios x86_64 compilers will leave
arbitrary values in the upper half.

Fix this by making the C prototype match the assembly. (This aspect of
the calling convention implies smaller-than-word arguments in assembly
functions should be avoided. There are far fewer things to test if everything
consistently takes word-sized arguments.)

This was found as part of ABI testing work in BoringSSL.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated
(While the bug is, in theory, reachable from C, it's heavily dependent on compiler behavior. We have an ABI-testing framework, but it's [a](https://boringssl.googlesource.com/boringssl/+/master/crypto/test/abi_test.h) [lot](https://boringssl.googlesource.com/boringssl/+/master/crypto/test/abi_test.cc) [of](https://boringssl.googlesource.com/boringssl/+/master/crypto/test/asm/trampoline-x86.pl) [code](https://boringssl.googlesource.com/boringssl/+/master/crypto/test/asm/trampoline-x86_64.pl), uses C++ templates, and is still being iterated on.)