### PR TITLE
Fix a memory leak with di2_X509_CRL reuse

### DIFF
--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -158,6 +158,18 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     int idx;
 
     switch (operation) {
+    case ASN1_OP_D2I_PRE:
+        if (crl->meth->crl_free) {
+            if (!crl->meth->crl_free(crl))
+                return 0;
+        }
+        AUTHORITY_KEYID_free(crl->akid);
+        ISSUING_DIST_POINT_free(crl->idp);
+        ASN1_INTEGER_free(crl->crl_number);
+        ASN1_INTEGER_free(crl->base_crl_number);
+        sk_GENERAL_NAMES_pop_free(crl->issuers, GENERAL_NAMES_free);
+        /* fall thru */
+
     case ASN1_OP_NEW_POST:
         crl->idp = NULL;
         crl->akid = NULL;

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -357,6 +357,20 @@ static int test_unknown_critical_crl(int n)
     return r;
 }
 
+static int test_reuse_crl(void)
+{
+    X509_CRL *reused_crl = CRL_from_strings(kBasicCRL);
+    char *p;
+    BIO *b = glue2bio(kRevokedCRL, &p);
+
+    reused_crl = PEM_read_bio_X509_CRL(b, &reused_crl, NULL, NULL);
+
+    OPENSSL_free(p);
+    BIO_free(b);
+    X509_CRL_free(reused_crl);
+    return 1;
+}
+
 int setup_tests(void)
 {
     if (!TEST_ptr(test_root = X509_from_strings(kCRLTestRoot))
@@ -368,6 +382,7 @@ int setup_tests(void)
     ADD_TEST(test_bad_issuer_crl);
     ADD_TEST(test_known_critical_crl);
     ADD_ALL_TESTS(test_unknown_critical_crl, OSSL_NELEM(unknown_critical_crls));
+    ADD_TEST(test_reuse_crl);
     return 1;
 }
 


### PR DESCRIPTION
Additionally avoid undefined behavior with
in-place memcpy in X509_CRL_digest.

Fixes #8099

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
