### PR TITLE
Fix error message for s_server -psk option

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1407,7 +1407,7 @@ int s_server_main(int argc, char *argv[])
             for (p = psk_key = opt_arg(); *p; p++) {
                 if (isxdigit(_UC(*p)))
                     continue;
-                BIO_printf(bio_err, "Not a hex number '%s'\n", *argv);
+                BIO_printf(bio_err, "Not a hex number '%s'\n", psk_key);
                 goto end;
             }
             break;


### PR DESCRIPTION
Previously if -psk was given a bad key it would print `Not a hex number 's_server'`.
