### PR TITLE
Complain if -twopass is used incorrectly

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -311,6 +311,13 @@ int pkcs12_main(int argc, char **argv)
     if (cpass != NULL) {
         mpass = cpass;
         noprompt = 1;
+        if (twopass) {
+            if (export_cert)
+                BIO_printf(bio_err, "Option -twopass cannot be used with -passout or -password\n");
+            else
+                BIO_printf(bio_err, "Option -twopass cannot be used with -passin or -password\n");
+            goto end;
+        }
     } else {
         cpass = pass;
         mpass = macpass;

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -154,7 +154,8 @@ Don't attempt to verify the integrity MAC before reading the file.
 
 Prompt for separate integrity and encryption passwords: most software
 always assumes these are the same so this option will render such
-PKCS#12 files unreadable.
+PKCS#12 files unreadable. Cannot be used in combination with the options
+-password, -passin (if importing) or -passout (if exporting).
 
 =back
 


### PR DESCRIPTION
The option -twopass to the pkcs12 app is ignored if -passin, -passout
or -password is used. We should complain if an attempt is made to use
it in combination with those options.

Fixes #8107