### PR TITLE
Fixed d2i_X509 in-place not re-hashing the ex_flags

### DIFF
--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -40,12 +40,35 @@ static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 
     switch (operation) {
 
+    case ASN1_OP_D2I_PRE:
+        CRYPTO_free_ex_data(CRYPTO_EX_INDEX_X509, ret, &ret->ex_data);
+        X509_CERT_AUX_free(ret->aux);
+        ASN1_OCTET_STRING_free(ret->skid);
+        AUTHORITY_KEYID_free(ret->akid);
+        CRL_DIST_POINTS_free(ret->crldp);
+        policy_cache_free(ret->policy_cache);
+        GENERAL_NAMES_free(ret->altname);
+        NAME_CONSTRAINTS_free(ret->nc);
+#ifndef OPENSSL_NO_RFC3779
+        sk_IPAddressFamily_pop_free(ret->rfc3779_addr, IPAddressFamily_free);
+        ASIdentifiers_free(ret->rfc3779_asid);
+#endif
+
+        /* fall thru */
+
     case ASN1_OP_NEW_POST:
+        ret->ex_cached = 0;
+        ret->ex_kusage = 0;
+        ret->ex_xkusage = 0;
+        ret->ex_nscert = 0;
         ret->ex_flags = 0;
         ret->ex_pathlen = -1;
         ret->ex_pcpathlen = -1;
         ret->skid = NULL;
         ret->akid = NULL;
+        ret->policy_cache = NULL;
+        ret->altname = NULL;
+        ret->nc = NULL;
 #ifndef OPENSSL_NO_RFC3779
         ret->rfc3779_addr = NULL;
         ret->rfc3779_asid = NULL;

--- a/test/x509aux.c
+++ b/test/x509aux.c
@@ -30,6 +30,7 @@ static int test_certs(int num)
     typedef int (*i2d_X509_t)(X509 *, unsigned char **);
     int err = 0;
     BIO *fp = BIO_new_file(test_get_argument(num), "r");
+    X509 *reuse = NULL;
 
     if (!TEST_ptr(fp))
         return 0;
@@ -91,6 +92,13 @@ static int test_certs(int num)
             err = 1;
             goto next;
         }
+        p = buf;
+        reuse = d2i(&reuse, &p, enclen);
+        if (reuse == NULL || X509_cmp (reuse, cert)) {
+            TEST_error("X509_cmp does not work with %s", name);
+            err = 1;
+            goto next;
+        }
         OPENSSL_free(buf);
         buf = NULL;
 
@@ -139,6 +147,7 @@ static int test_certs(int num)
         OPENSSL_free(data);
     }
     BIO_free(fp);
+    X509_free(reuse);
 
     if (ERR_GET_REASON(ERR_peek_last_error()) == PEM_R_NO_START_LINE) {
         /* Reached end of PEM file */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
