### PR TITLE
CAdES: Fix SignerInfo attribute construction order.

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -603,6 +603,14 @@ int cms_main(int argc, char **argv)
         goto opthelp;
     }
 
+    if (flags & CMS_CADES) {
+        if (flags & CMS_NOATTR) {
+            BIO_puts(bio_err, "Incompatible options: "
+                     "CAdES required signed attributes\n");
+            goto opthelp;
+        }
+    }
+
     if (operation & SMIME_SIGNERS) {
         if (keyfile != NULL && signerfile == NULL) {
             BIO_puts(bio_err, "Illegal -inkey without -signer\n");

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -325,13 +325,6 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
             if (!i)
                 goto merr;
         }
-        if (flags & CMS_REUSE_DIGEST) {
-            if (!cms_copy_messageDigest(cms, si))
-                goto err;
-            if (!(flags & (CMS_PARTIAL | CMS_KEY_PARAM)) &&
-                !CMS_SignerInfo_sign(si))
-                goto err;
-        }
         if (flags & CMS_CADES) {
             ESS_SIGNING_CERT *sc = NULL;
             ESS_SIGNING_CERT_V2 *sc2 = NULL;
@@ -353,6 +346,13 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
             if (!add_sc)
                 goto err;
         }
+        if (flags & CMS_REUSE_DIGEST) {
+            if (!cms_copy_messageDigest(cms, si))
+                goto err;
+            if (!(flags & (CMS_PARTIAL | CMS_KEY_PARAM)) &&
+                !CMS_SignerInfo_sign(si))
+                goto err;
+        }
     }
 
     if (!(flags & CMS_NOCERTS)) {
@@ -370,8 +370,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
                 goto err;
             if (EVP_PKEY_CTX_set_signature_md(si->pctx, md) <= 0)
                 goto err;
-        } else if (EVP_DigestSignInit(si->mctx, &si->pctx, md, NULL, pk) <=
-                   0)
+        } else if (EVP_DigestSignInit(si->mctx, &si->pctx, md, NULL, pk) <= 0)
             goto err;
     }
 

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,13 @@
 #include <openssl/ts.h>
 #include <openssl/x509v3.h>
 #include <openssl/cms.h>
+#include <openssl/ess.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
+#include <internal/nelem.h>
 #include "fuzzer.h"
 
 #include "rand.inc"
@@ -317,10 +319,12 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     DO_TEST(TS_STATUS_INFO, d2i_TS_STATUS_INFO, i2d_TS_STATUS_INFO, TS_STATUS_INFO_print_bio);
     DO_TEST(TS_TST_INFO, d2i_TS_TST_INFO, i2d_TS_TST_INFO, TS_TST_INFO_print_bio);
     DO_TEST_NO_PRINT(TS_ACCURACY, d2i_TS_ACCURACY, i2d_TS_ACCURACY);
+#endif
     DO_TEST_NO_PRINT(ESS_ISSUER_SERIAL, d2i_ESS_ISSUER_SERIAL, i2d_ESS_ISSUER_SERIAL);
     DO_TEST_NO_PRINT(ESS_CERT_ID, d2i_ESS_CERT_ID, i2d_ESS_CERT_ID);
     DO_TEST_NO_PRINT(ESS_SIGNING_CERT, d2i_ESS_SIGNING_CERT, i2d_ESS_SIGNING_CERT);
-#endif
+    DO_TEST_NO_PRINT(ESS_CERT_ID_V2, d2i_ESS_CERT_ID_V2, i2d_ESS_CERT_ID_V2);
+    DO_TEST_NO_PRINT(ESS_SIGNING_CERT_V2, d2i_ESS_SIGNING_CERT_V2, i2d_ESS_SIGNING_CERT_V2);
 #ifndef OPENSSL_NO_DH
     DO_TEST(DH, d2i_DHparams, i2d_DHparams, DHparams_print);
     DO_TEST(DH, d2i_DHxparams, i2d_DHxparams, DHparams_print);


### PR DESCRIPTION
Small fixup on the recent CAdES contribution.
Can be trigger if someone is using CMS_REUSE_DIGEST flag value.
Not a big issue, just a lack of logic ;)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
