### PR TITLE
Fixed typo in doc

### DIFF
--- a/doc/man3/RIPEMD160_Init.pod
+++ b/doc/man3/RIPEMD160_Init.pod
@@ -13,7 +13,7 @@ RIPEMD-160 hash function
                           unsigned char *md);
 
  int RIPEMD160_Init(RIPEMD160_CTX *c);
- int RIPEMD160_Update(RIPEMD_CTX *c, const void *data, unsigned long len);
+ int RIPEMD160_Update(RIPEMD160_CTX *c, const void *data, unsigned long len);
  int RIPEMD160_Final(unsigned char *md, RIPEMD160_CTX *c);
 
 =head1 DESCRIPTION


### PR DESCRIPTION
Pull request to fix small typo in `RIPEMD160_Init` documentation.

CLA: trivial
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
