### PR TITLE
VMS: force 'pinshared'

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1724,6 +1724,8 @@ my %targets = (
         asflags          => sub { vms_info()->{asflags} },
         perlasm_scheme   => sub { vms_info()->{perlasm_scheme} },
 
+        disable          => add('pinshared'),
+
         apps_aux_src     => "vms_term_sock.c",
         apps_init_src    => "vms_decc_init.c",
     },


### PR DESCRIPTION
VMS doesn't currently support unloading of shared object, and we need
to reflect that.  Without this, the shlibload test fails
