### PR TITLE
Allow the syntax of the .include directive to optionally have '='

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -348,7 +348,8 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 psection = section;
             }
             p = eat_ws(conf, end);
-            if (strncmp(pname, ".include", 8) == 0 && p != pname + 8) {
+            if (strncmp(pname, ".include", 8) == 0
+                && (p != pname + 8 || *p == '=')) {
                 char *include = NULL;
                 BIO *next;
 

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -352,6 +352,10 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 char *include = NULL;
                 BIO *next;
 
+                if (*p == '=') {
+                    p++;
+                    p = eat_ws(conf, p);
+                }
                 trim_ws(conf, p);
                 if (!str_copy(conf, psection, &include, p))
                     goto err;

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -42,6 +42,13 @@ working directory so unless the configuration file containing the
 B<.include> directive is application specific the inclusion will not
 work as expected.
 
+There can be optional B<=> character and whitespace characters between
+B<.include> directive and the path which can be useful in cases the
+configuration file needs to be loaded by old OpenSSL versions which do
+not support the B<.include> syntax. They would bail out with error
+if the B<=> character is not present but with it they just ignore
+the include.
+
 Each section in a configuration file consists of a number of name and
 value pairs of the form B<name=value>
 

--- a/test/recipes/90-test_includes.t
+++ b/test/recipes/90-test_includes.t
@@ -11,11 +11,13 @@ plan skip_all => "test_includes doesn't work without posix-io"
     if disabled("posix-io");
 
 plan tests =>                   # The number of tests being performed
-    3
+    5
     + ($^O eq "VMS" ? 2 : 0);
 
 ok(run(test(["conf_include_test", data_file("includes.cnf")])), "test directory includes");
 ok(run(test(["conf_include_test", data_file("includes-file.cnf")])), "test file includes");
+ok(run(test(["conf_include_test", data_file("includes-eq.cnf")])), "test includes with equal character");
+ok(run(test(["conf_include_test", data_file("includes-eq-ws.cnf")])), "test includes with equal and whitespaces");
 if ($^O eq "VMS") {
     ok(run(test(["conf_include_test", data_file("vms-includes.cnf")])),
        "test directory includes, VMS syntax");

--- a/test/recipes/90-test_includes_data/includes-eq-ws.cnf
+++ b/test/recipes/90-test_includes_data/includes-eq-ws.cnf
@@ -1,0 +1,5 @@
+#
+# Example configuration file using includes.
+#
+
+.include = conf-includes

--- a/test/recipes/90-test_includes_data/includes-eq.cnf
+++ b/test/recipes/90-test_includes_data/includes-eq.cnf
@@ -1,0 +1,5 @@
+#
+# Example configuration file using includes.
+#
+
+.include=conf-includes


### PR DESCRIPTION
If the old openssl versions not supporting the .include directive
load a config file with it, they will bail out with error.

This change allows using the .include = <filename> syntax which
is interpreted as variable assignment by the old openssl
config file parser.

I can add a test case if you think it is worth it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
