### PR TITLE
Build: correct BASE shlib_version_as_filename

### DIFF
--- a/Configurations/platform/BASE.pm
+++ b/Configurations/platform/BASE.pm
@@ -28,8 +28,8 @@ sub sharedname  { return __isshared($_[1]) ? $_[1] : undef } # Name of shared li
 sub staticname  { return __base($_[1], '.a') } # Name of static lib
 
 # Convenience function to convert the shlib version to an acceptable part
-# of a file or directory name.
-sub shlib_version_as_filename { return $_[1] }
+# of a file or directory name.  By default, we consider it acceptable as is.
+sub shlib_version_as_filename { return $config{shlib_version} }
 
 # Convenience functions to convert the possible extension of an input file name
 sub bin         { return $_[0]->binname($_[1]) . $_[0]->binext() }


### PR DESCRIPTION
This function is designed to use $config{shlib_version} directly
instead of taking an input argument, yet the BASE variant didn't do
this.
