### PR TITLE
ENGINE modules aren't special, so call them MODULES

### DIFF
--- a/Configurations/README
+++ b/Configurations/README
@@ -159,7 +159,7 @@ In each table entry, the following keys are significant:
                            below [2].
         dso_scheme      => The type of dynamic shared objects to build
                            for.  This mostly comes into play with
-                           engines, but can be used for other purposes
+                           modules, but can be used for other purposes
                            as well.  Valid values are "DLFCN"
                            (dlopen() et al), "DLFCN_NO_H" (for systems
                            that use dlopen() et al but do not have
@@ -350,7 +350,7 @@ In each table entry, the following keys are significant:
 
     - shared libraries; that would be libcrypto and libssl.
     - shared objects (sometimes called dynamic libraries);  that would
-      be the engines.
+      be the modules.
     - applications; those are apps/openssl and all the test apps.
 
     Very roughly speaking, linking is done like this (words in braces
@@ -411,10 +411,10 @@ variables:
 
     PROGRAMS=foo bar
     LIBS=libsomething
-    ENGINES=libeng
+    MODULES=libeng
     SCRIPTS=myhack
 
-Note that the files mentioned for PROGRAMS, LIBS and ENGINES *must* be
+Note that the files mentioned for PROGRAMS, LIBS and MODULES *must* be
 without extensions.  The build file templates will figure them out.
 
 For each thing to be built, it is then possible to say what sources

--- a/Configurations/README.design
+++ b/Configurations/README.design
@@ -36,7 +36,7 @@ in build.info.  Their file name extensions will be inferred by the
 build-file templates, adapted for the platform they are meant for (see
 sections on %unified_info and build-file templates further down).
 
-The variables PROGRAMS, LIBS, ENGINES and SCRIPTS are used to declare
+The variables PROGRAMS, LIBS, MODULES and SCRIPTS are used to declare
 end products.  There are variants for them with '_NO_INST' as suffix
 (PROGRAM_NO_INST etc) to specify end products that shouldn't get
 installed.
@@ -47,12 +47,12 @@ particular produced file, extra dependencies, include directories
 needed, or C macros to be defined.
 
 All their values in all the build.info throughout the source tree are
-collected together and form a set of programs, libraries, engines and
+collected together and form a set of programs, libraries, modules and
 scripts to be produced, source files, dependencies, etc etc etc.
 
 Let's have a pretend example, a very limited contraption of OpenSSL,
 composed of the program 'apps/openssl', the libraries 'libssl' and
-'libcrypto', an engine 'engines/ossltest' and their sources and
+'libcrypto', an module 'engines/ossltest' and their sources and
 dependencies.
 
     # build.info
@@ -120,22 +120,22 @@ This is the build.info file in 'ssl/', and it tells us that the
 library 'libssl' is built from the source file 'ssl/tls.c'.
 
     # engines/build.info
-    ENGINES=dasync
+    MODULES=dasync
     SOURCE[dasync]=e_dasync.c
     DEPEND[dasync]=../libcrypto
     INCLUDE[dasync]=../include
 
-    ENGINES_NO_INST=ossltest
+    MODULES_NO_INST=ossltest
     SOURCE[ossltest]=e_ossltest.c
     DEPEND[ossltest]=../libcrypto.a
     INCLUDE[ossltest]=../include
 
-This is the build.info file in 'engines/', telling us that two engines
+This is the build.info file in 'engines/', telling us that two modules
 called 'engines/dasync' and 'engines/ossltest' shall be built, that
 dasync's source is 'engines/e_dasync.c' and ossltest's source is
 'engines/e_ossltest.c' and that the include directory 'include/' may
-be used when building anything that will be part of these engines.
-Also, both engines depend on the library 'libcrypto' to function
+be used when building anything that will be part of these modules.
+Also, both modules depend on the library 'libcrypto' to function
 properly.  ossltest is explicitly linked with the static variant of
 the library 'libcrypto'.  Finally, only dasync is being installed, as
 ossltest is only for internal testing.
@@ -156,12 +156,12 @@ information comes down to this:
     INCLUDE[apps/openssl]=. include
     DEPEND[apps/openssl]=libssl
 
-    ENGINES=engines/dasync
+    MODULES=engines/dasync
     SOURCE[engines/dasync]=engines/e_dasync.c
     DEPEND[engines/dasync]=libcrypto
     INCLUDE[engines/dasync]=include
 
-    ENGINES_NO_INST=engines/ossltest
+    MODULES_NO_INST=engines/ossltest
     SOURCE[engines/ossltest]=engines/e_ossltest.c
     DEPEND[engines/ossltest]=libcrypto.a
     INCLUDE[engines/ossltest]=include
@@ -177,10 +177,10 @@ LIBS may be used to declare routine libraries only.
 
 PROGRAMS may be used to declare programs only.
 
-ENGINES may be used to declare engines only.
+MODULES may be used to declare modules only.
 
 The indexes for SOURCE must only be end product files, such as
-libraries, programs or engines.  The values of SOURCE variables must
+libraries, programs or modules.  The values of SOURCE variables must
 only be source files (possibly generated).
 
 INCLUDE and DEPEND shows a relationship between different files
@@ -209,8 +209,8 @@ indexes:
                pairs.  These are directly inferred from the DEPEND
                variables in build.info files.
 
-  engines   => a list of engines.  These are directly inferred from
-               the ENGINES variable in build.info files.
+  modules   => a list of modules.  These are directly inferred from
+               the MODULES variable in build.info files.
 
   generate  => a hash table containing 'file' => [ 'generator' ... ]
                pairs.  These are directly inferred from the GENERATE
@@ -221,7 +221,7 @@ indexes:
                variables in build.info files.
 
   install   => a hash table containing 'type' => [ 'file' ... ] pairs.
-               The types are 'programs', 'libraries', 'engines' and
+               The types are 'programs', 'libraries', 'modules' and
                'scripts', and the array of files list the files of
                that type that should be installed.
 
@@ -280,7 +280,7 @@ section above would be digested into a %unified_info table:
                         "util/Foo.pm",
                     ],
             },
-        "engines" =>
+        "modules" =>
             [
                 "engines/dasync",
                 "engines/ossltest",
@@ -321,7 +321,7 @@ section above would be digested into a %unified_info table:
             }
         "install" =>
             {
-                "engines" =>
+                "modules" =>
                     [
                         "engines/dasync",
                     ],
@@ -556,7 +556,7 @@ etc.
                   'sources' has the list of source files to build the
                   resulting script from.
 
-Along with the build-file templates is the driving engine
+Along with the build-file templates is the driving template
 Configurations/common.tmpl, which looks through all the information in
 %unified_info and generates all the rulesets to build libraries,
 programs and all intermediate files, using the rule generating

--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -143,10 +143,10 @@
      $cache{$lib} = 1;
  }
 
- # doengine is responsible for building engines.  It will call
+ # domodule is responsible for building modules.  It will call
  # obj2dso, and also makes sure all object files for the library
  # are built.
- sub doengine {
+ sub domodule {
      my $lib = shift;
      return "" if $cache{$lib};
      $OUT .= obj2dso(lib => $lib,
@@ -209,10 +209,10 @@
  # Build mandatory generated headers
  foreach (@{$unified_info{depends}->{""}}) { dogenerate($_); }
 
- # Build all known libraries, engines, programs and scripts.
+ # Build all known libraries, modules, programs and scripts.
  # Everything else will be handled as a consequence.
  foreach (@{$unified_info{libraries}}) { dolib($_);    }
- foreach (@{$unified_info{engines}})   { doengine($_); }
+ foreach (@{$unified_info{modules}})   { domodule($_); }
  foreach (@{$unified_info{programs}})  { dobin($_);    }
  foreach (@{$unified_info{scripts}})   { doscript($_); }
 

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -55,8 +55,9 @@
       grep { !$unified_info{attributes}->{$_}->{noinst} }
       @{$unified_info{libraries}};
   our @install_engines =
-      grep { !$unified_info{attributes}->{$_}->{noinst} }
-      @{$unified_info{engines}};
+      grep { !$unified_info{attributes}->{$_}->{noinst}
+             && $unified_info{attributes}->{$_}->{engine} }
+      @{$unified_info{modules}};
   our @install_programs =
       grep { !$unified_info{attributes}->{$_}->{noinst} }
       @{$unified_info{programs}};
@@ -122,7 +123,7 @@ SHLIB_TARGET={- $target{shared_target} -}
 
 LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @libs) -}
 SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @shlibs) -}
-ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{engines}}) -}
+MODULES={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{modules}}) -}
 PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(", ", map { "-\n\t".$_ } @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}
@@ -164,7 +165,7 @@ OPENSSLDIR={- catdir($config{openssldir}) or
                               : "SYS\$COMMON:[OPENSSL-COMMON]" -}
 # The same, but for C
 OPENSSLDIR_C={- platform->osslprefix() -}DATAROOT:[000000]
-# Where installed engines reside, for C
+# Where installed ENGINE modules reside, for C
 ENGINESDIR_C={- platform->osslprefix() -}ENGINES{- $sover_dirname.$target{pointer_size} -}:
 
 ##### User defined commands and flags ################################
@@ -400,14 +401,14 @@ NODEBUG=@
 
 # The main targets ###################################################
 
-{- dependmagic('all'); -} : build_libs_nodep, build_engines_nodep, build_programs_nodep
+{- dependmagic('all'); -} : build_libs_nodep, build_modules_nodep, build_programs_nodep
 {- dependmagic('build_libs'); -} : build_libs_nodep
-{- dependmagic('build_engines'); -} : build_engines_nodep
+{- dependmagic('build_modules'); -} : build_modules_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
 
 build_generated : $(GENERATED_MANDATORY)
 build_libs_nodep : $(LIBS), $(SHLIBS)
-build_engines_nodep : $(ENGINES)
+build_modules_nodep : $(MODULES)
 build_programs_nodep : $(PROGRAMS), $(SCRIPTS)
 
 # Kept around for backward compatibility
@@ -423,7 +424,7 @@ build_all_generated : $(GENERATED_MANDATORY) $(GENERATED)
 	@ ! {- output_on() if $disabled{makedepend}; "" -}
 
 test : tests
-{- dependmagic('tests'); -} : build_programs_nodep, build_engines_nodep
+{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep
         @ ! {- output_off() if $disabled{tests}; "" -}
         SET DEFAULT [.test]{- move("test") -}
         CREATE/DIR [.test-runs]
@@ -483,14 +484,14 @@ check_install :
 uninstall : uninstall_docs uninstall_sw
 
 # Because VMS wants the generation number (or *) to delete files, we can't
-# use $(LIBS), $(PROGRAMS), $(GENERATED) and $(ENGINES)directly.
+# use $(LIBS), $(PROGRAMS), $(GENERATED) and $(MODULES) directly.
 libclean :
         {- join("\n\t", map { "- DELETE $_.OLB;*" } @libs) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_.EXE;*,$_.MAP;*" } @shlibs) || "@ !" -}
 
 clean : libclean
         {- join("\n\t", map { "- DELETE $_.EXE;*,$_.OPT;*" } @{$unified_info{programs}}) || "@ !" -}
-        {- join("\n\t", map { "- DELETE $_.EXE;*,$_.OPT;*" } @{$unified_info{engines}}) || "@ !" -}
+        {- join("\n\t", map { "- DELETE $_.EXE;*,$_.OPT;*" } @{$unified_info{modules}}) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_;*" } @{$unified_info{scripts}}) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_;*" } @{$unified_info{depends}->{""}}) || "@ !" -}
         {- join("\n\t", map { "- DELETE $_;*" } @generated) || "@ !" -}
@@ -557,14 +558,14 @@ install_dev : check_INSTALLTOP install_runtime_libs
                 map { "COPY/PROT=W:R $_.OLB ossl_installroot:[LIB.'arch']" }
                 @install_libs) -}
 
-install_engines : check_INSTALLTOP install_runtime_libs build_engines
-        @ {- output_off() unless scalar @{$unified_info{engines}}; "" -} !
-        @ WRITE SYS$OUTPUT "*** Installing engines"
+install_engines : check_INSTALLTOP install_runtime_libs build_modules
+        @ {- output_off() unless scalar @install_engines; "" -} !
+        @ WRITE SYS$OUTPUT "*** Installing ENGINE modules"
         - CREATE/DIR ossl_installroot:[ENGINES{- $sover_dirname.$target{pointer_size} -}.'arch']
         {- join("\n        ",
                 map { "COPY/PROT=W:RE $_.EXE ossl_installroot:[ENGINES$sover_dirname$target{pointer_size}.'arch']" }
                 @install_engines) -}
-        @ {- output_on() unless scalar @{$unified_info{engines}}; "" -} !
+        @ {- output_on() unless scalar @install_engines; "" -} !
 
 install_runtime : install_programs
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -40,7 +40,7 @@ SHLIB_INFO={- join(" ", map { my $x = platform->sharedlib($_);
                               my $y = platform->sharedlib_simple($_);
                               $x ? "\"$x;$y\"" : () }
                         @{$unified_info{libraries}}) -}
-ENGINES={- join(" ", map { platform->dso($_) } @{$unified_info{engines}}) -}
+MODULES={- join(" ", map { platform->dso($_) } @{$unified_info{modules}}) -}
 PROGRAMS={- join(" ", map { platform->bin($_) } @{$unified_info{programs}}) -}
 SCRIPTS={- join(" ", @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}
@@ -71,8 +71,9 @@ INSTALL_SHLIB_INFO={-
 -}
 INSTALL_ENGINES={-
         join(" ", map { platform->dso($_) }
-                  grep { !$unified_info{attributes}->{$_}->{noinst} }
-                  @{$unified_info{engines}})
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && $unified_info{attributes}->{$_}->{engine} }
+                  @{$unified_info{modules}})
 -}
 INSTALL_PROGRAMS={-
         join(" ", map { platform->bin($_) }
@@ -312,14 +313,14 @@ LANG=C
 
 # The main targets ###################################################
 
-{- dependmagic('all'); -}: build_libs_nodep build_engines_nodep build_programs_nodep link-utils
+{- dependmagic('all'); -}: build_libs_nodep build_modules_nodep build_programs_nodep link-utils
 {- dependmagic('build_libs'); -}: build_libs_nodep
-{- dependmagic('build_engines'); -}: build_engines_nodep
+{- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
 
 build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: libcrypto.pc libssl.pc openssl.pc
-build_engines_nodep: $(ENGINES)
+build_modules_nodep: $(MODULES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
 
 # Kept around for backward compatibility
@@ -335,7 +336,7 @@ build_all_generated: $(GENERATED_MANDATORY) $(GENERATED)
 	@ : {- output_on() if $disabled{makedepend}; "" -}
 
 test: tests
-{- dependmagic('tests'); -}: build_programs_nodep build_engines_nodep link-utils
+{- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep link-utils
 	@ : {- output_off() if $disabled{tests}; "" -}
 	( cd test; \
 	  mkdir -p test-runs; \
@@ -382,7 +383,7 @@ libclean:
 	$(RM) *{- platform->defext() -}
 
 clean: libclean
-	$(RM) $(PROGRAMS) $(TESTPROGS) $(ENGINES) $(SCRIPTS)
+	$(RM) $(PROGRAMS) $(TESTPROGS) $(MODULES) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
 	-$(RM) `find . -name .git -prune -o -name '*{- platform->depext() -}' -print`
 	-$(RM) `find . -name .git -prune -o -name '*{- platform->objext() -}' -print`
@@ -578,10 +579,10 @@ uninstall_dev: uninstall_runtime_libs
 	-$(RMDIR) $(DESTDIR)$(libdir)/pkgconfig
 	-$(RMDIR) $(DESTDIR)$(libdir)
 
-install_engines: install_runtime_libs build_engines
+install_engines: install_runtime_libs build_modules
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(ENGINESDIR)/
-	@$(ECHO) "*** Installing engines"
+	@$(ECHO) "*** Installing ENGINE modules"
 	@set -e; for e in dummy $(INSTALL_ENGINES); do \
 		if [ "$$e" = "dummy" ]; then continue; fi; \
 		fn=`basename $$e`; \
@@ -593,7 +594,7 @@ install_engines: install_runtime_libs build_engines
 	done
 
 uninstall_engines:
-	@$(ECHO) "*** Uninstalling engines"
+	@$(ECHO) "*** Uninstalling ENGINE modules"
 	@set -e; for e in dummy $(INSTALL_ENGINES); do \
 		if [ "$$e" = "dummy" ]; then continue; fi; \
 		fn=`basename $$e`; \

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -45,8 +45,8 @@ SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
 LIBS={- join(" ", map { ( platform->sharedlib_import($_), platform->staticlib($_) ) } @{$unified_info{libraries}}) -}
 SHLIBS={- join(" ", map { platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
 SHLIBPDBS={- join(" ", map { platform->sharedlibpdb($_) // () } @{$unified_info{libraries}}) -}
-ENGINES={- join(" ", map { platform->dso($_) } @{$unified_info{engines}}) -}
-ENGINEPDBS={- join(" ", map { platform->dsopdb($_) } @{$unified_info{engines}}) -}
+MODULES={- join(" ", map { platform->dso($_) } @{$unified_info{modules}}) -}
+MODULEPDBS={- join(" ", map { platform->dsopdb($_) } @{$unified_info{modules}}) -}
 PROGRAMS={- our @PROGRAMS = map { platform->bin($_) } @{$unified_info{programs}}; join(" ", @PROGRAMS) -}
 PROGRAMPDBS={- join(" ", map { $_.".pdb" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(" ", @{$unified_info{scripts}}) -}
@@ -79,13 +79,15 @@ INSTALL_SHLIBPDBS={-
 -}
 INSTALL_ENGINES={-
         join(" ", map { quotify1(platform->dso($_)) }
-                  grep { !$unified_info{attributes}->{$_}->{noinst} }
-                  @{$unified_info{engines}})
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && $unified_info{attributes}->{$_}->{engine} }
+                  @{$unified_info{modules}})
 -}
 INSTALL_ENGINEPDBS={-
         join(" ", map { quotify1(platform->dsopdb($_)) }
-                  grep { !$unified_info{attributes}->{$_}->{noinst} }
-                  @{$unified_info{engines}})
+                  grep { !$unified_info{attributes}->{$_}->{noinst}
+                         && $unified_info{attributes}->{$_}->{engine} }
+                  @{$unified_info{modules}})
 -}
 INSTALL_PROGRAMS={-
         join(" ", map { quotify1(platform->bin($_)) }
@@ -311,14 +313,14 @@ PROCESSOR= {- $config{processor} -}
 
 # The main targets ###################################################
 
-{- dependmagic('all'); -}: build_libs_nodep build_engines_nodep build_programs_nodep
+{- dependmagic('all'); -}: build_libs_nodep build_modules_nodep build_programs_nodep
 {- dependmagic('build_libs'); -}: build_libs_nodep
-{- dependmagic('build_engines'); -}: build_engines_nodep
+{- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
 
 build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: $(LIBS) {- join(" ",map { platform->sharedlib_import($_) // () } @{$unified_info{libraries}}) -}
-build_engines_nodep: $(ENGINES)
+build_modules_nodep: $(MODULES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
 
 # Kept around for backward compatibility
@@ -334,7 +336,7 @@ build_all_generated: $(GENERATED_MANDATORY) $(GENERATED)
 	@{- output_on() if $disabled{makedepend}; "" -}
 
 test: tests
-{- dependmagic('tests'); -}: build_programs_nodep build_engines_nodep
+{- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep
 	@{- output_off() if $disabled{tests}; "" -}
 	-mkdir $(BLDDIR)\test\test-runs
 	set SRCTOP=$(SRCDIR)
@@ -366,7 +368,7 @@ libclean:
 
 clean: libclean
 	{- join("\n\t", map { "-del /Q /F $_" } @PROGRAMS) -}
-	-del /Q /F $(ENGINES)
+	-del /Q /F $(MODULES)
 	-del /Q /F $(SCRIPTS)
 	-del /Q /F $(GENERATED_MANDATORY)
 	-del /Q /F $(GENERATED)
@@ -432,13 +434,13 @@ install_dev: install_runtime_libs
 
 uninstall_dev:
 
-install_engines: install_runtime_libs build_engines
+install_engines: install_runtime_libs build_modules
 	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
-	@$(ECHO) "*** Installing engines"
+	@$(ECHO) "*** Installing ENGINE modules"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(ENGINESDIR)"
-	@if not "$(ENGINES)"=="" \
+	@if not "$(INSTALL_ENGINES)"=="" \
 	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_ENGINES) "$(ENGINESDIR)"
-	@if not "$(ENGINES)"=="" \
+	@if not "$(INSTALL_ENGINES)"=="" \
 	 "$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_ENGINEPDBS) "$(ENGINESDIR)"
 
 uninstall_engines:

--- a/Configure
+++ b/Configure
@@ -1711,7 +1711,7 @@ if ($builder eq "unified") {
         # The basic things we're trying to build
         my @programs = ();
         my @libraries = ();
-        my @engines = ();
+        my @modules = ();
         my @scripts = ();
 
         my %attributes = ();
@@ -1823,12 +1823,12 @@ if ($builder eq "unified") {
                     }
                 }
             },
-            qr/^\s*ENGINES(?:{([\w=]+(?:\s*,\s*[\w=]+)*)})?\s*=\s*(.*)\s*$/
+            qr/^\s*MODULES(?:{([\w=]+(?:\s*,\s*[\w=]+)*)})?\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
                     my @a = tokenize($1, qr|\s*,\s*|);
-                    my @e = tokenize($2);
-                    push @engines, @e;
+                    my @m = tokenize($2);
+                    push @modules, @m;
                     foreach my $a (@a) {
                         my $ak = $a;
                         my $av = 1;
@@ -1836,8 +1836,8 @@ if ($builder eq "unified") {
                             $ak = $1;
                             $av = $2;
                         }
-                        foreach my $e (@e) {
-                            $attributes{$e}->{$ak} = $av;
+                        foreach my $m (@m) {
+                            $attributes{$m}->{$ak} = $av;
                         }
                     }
                 }
@@ -1899,10 +1899,13 @@ if ($builder eq "unified") {
             );
         die "runaway IF?" if (@skip);
 
-        die <<"EOF" if scalar @engines and !$config{dynamic_engines};
+        if (grep { defined $attributes{$_}->{engine} } keys %attributes
+                and !$config{dynamic_engines}) {
+            die <<"EOF"
 ENGINES can only be used if configured with 'dynamic-engine'.
 This is usually a fault in a build.info file.
 EOF
+        }
 
         foreach (keys %attributes) {
             my $dest = $_;
@@ -1916,7 +1919,7 @@ EOF
         {
             my %infos = ( programs  => [ @programs  ],
                           libraries => [ @libraries ],
-                          engines   => [ @engines   ],
+                          modules   => [ @modules   ],
                           scripts   => [ @scripts   ] );
             foreach my $k (keys %infos) {
                 foreach (@{$infos{$k}}) {
@@ -2142,7 +2145,7 @@ EOF
                 if defined($unified_info{$_});
             delete $unified_info{$_};
         }
-        foreach my $prodtype (('programs', 'libraries', 'engines', 'scripts')) {
+        foreach my $prodtype (('programs', 'libraries', 'modules', 'scripts')) {
             # $intent serves multi purposes:
             # - give a prefix for the new object files names
             # - in the case of libraries, rearrange the object files so static
@@ -2158,7 +2161,7 @@ EOF
                                            src => [ 'sources',
                                                     'shared_sources' ],
                                            dst => 'shared_sources' } },
-                engines   => { dso    => { src => [ 'sources',
+                modules   => { dso    => { src => [ 'sources',
                                                     'shared_sources' ],
                                            dst => 'shared_sources' } },
                 scripts   => { script => { src => [ 'sources' ],
@@ -2220,7 +2223,7 @@ EOF
 
     ### Make unified_info a bit more efficient
     # One level structures
-    foreach (("programs", "libraries", "engines", "scripts")) {
+    foreach (("programs", "libraries", "modules", "scripts")) {
         $unified_info{$_} = [ sort keys %{$unified_info{$_}} ];
     }
     # Two level structures
@@ -2268,7 +2271,7 @@ EOF
     # they end up in where applicable.  Then, add build rules for those
     # directories
     my %loopinfo = ( "lib" => [ @{$unified_info{libraries}} ],
-                     "dso" => [ @{$unified_info{engines}} ],
+                     "dso" => [ @{$unified_info{modules}} ],
                      "bin" => [ @{$unified_info{programs}} ],
                      "script" => [ @{$unified_info{scripts}} ] );
     foreach my $type (keys %loopinfo) {

--- a/doc/man1/version.pod
+++ b/doc/man1/version.pod
@@ -60,7 +60,7 @@ OPENSSLDIR setting.
 
 =item B<-e>
 
-ENGINESDIR setting.
+ENGINESDIR settings.
 
 =back
 

--- a/engines/build.info
+++ b/engines/build.info
@@ -11,7 +11,7 @@ IF[{- !$disabled{"engine"} -}]
       SOURCE[../libcrypto]=e_afalg.c
     ENDIF
   ELSE
-    ENGINES=padlock
+    MODULES{engine}=padlock
     SOURCE[padlock]=e_padlock.c {- $target{padlock_asm_src} -}
     DEPEND[padlock]=../libcrypto
     INCLUDE[padlock]=../include
@@ -20,7 +20,7 @@ IF[{- !$disabled{"engine"} -}]
       GENERATE[padlock.ld]=../util/engines.num
     ENDIF
     IF[{- !$disabled{capieng} -}]
-      ENGINES=capi
+      MODULES{engine}=capi
       SOURCE[capi]=e_capi.c
       DEPEND[capi]=../libcrypto
       INCLUDE[capi]=../include
@@ -30,7 +30,7 @@ IF[{- !$disabled{"engine"} -}]
       ENDIF
     ENDIF
     IF[{- !$disabled{afalgeng} -}]
-      ENGINES=afalg
+      MODULES{engine}=afalg
       SOURCE[afalg]=e_afalg.c
       DEPEND[afalg]=../libcrypto
       INCLUDE[afalg]= ../include
@@ -40,7 +40,7 @@ IF[{- !$disabled{"engine"} -}]
       ENDIF
     ENDIF
 
-    ENGINES{noinst}=ossltest dasync
+    MODULES{noinst,engine}=ossltest dasync
     SOURCE[dasync]=e_dasync.c
     DEPEND[dasync]=../libcrypto
     INCLUDE[dasync]=../include


### PR DESCRIPTION
The only thing that makes an ENGINE module special is its entry
points.  Other than that, it's a normal dynamically loadable module,
nothing special about it.  This change has us stop pretending anything
else.

We retain using ENGINE as a term for installation, because it's
related to a specific installation directory, and we therefore also
mark ENGINE modules specifically as such with an attribute in the
build.info files.
