### PR TITLE
 Android build: fix usage of NDK home variable ($ndk_var)

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -26,7 +26,7 @@
             my $ndk;
             foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
                 $ndk_var = $_;
-				$ndk = $ENV{$ndk_var};
+                $ndk = $ENV{$ndk_var};
                 last if defined $ndk;
             }
             die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);

--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -24,8 +24,9 @@
 
             my $ndk_var;
             my $ndk;
-            foreach $ndk_var (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
-                $ndk = $ENV{$ndk_var};
+            foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
+                $ndk_var = $_;
+				$ndk = $ENV{$ndk_var};
                 last if defined $ndk;
             }
             die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);


### PR DESCRIPTION
My fix for the issue #8152.

Set value to the $ndk_var variable via $_ variable, so $ndk_var can be used after foreach loop.