### PR TITLE
Build: correct assembler generation in crypto/rc4/build.info

### DIFF
--- a/crypto/rc4/build.info
+++ b/crypto/rc4/build.info
@@ -10,5 +10,5 @@ GENERATE[rc4-x86_64.s]=asm/rc4-x86_64.pl $(PERLASM_SCHEME)
 GENERATE[rc4-md5-x86_64.s]=asm/rc4-md5-x86_64.pl $(PERLASM_SCHEME)
 
 GENERATE[rc4-parisc.s]=asm/rc4-parisc.pl $(PERLASM_SCHEME)
-GENERATE[rc4-c64xplus.S]=asm/rc4-c64xplus.pl $(PERLASM_SCHEME)
-GENERATE[rc4-s390x.S]=asm/rc4-s390x.pl $(PERLASM_SCHEME)
+GENERATE[rc4-c64xplus.s]=asm/rc4-c64xplus.pl $(PERLASM_SCHEME)
+GENERATE[rc4-s390x.s]=asm/rc4-s390x.pl $(PERLASM_SCHEME)


### PR DESCRIPTION
In the removal of BEGINRAW / ENDRAW, attention to the difference
between capital .S and lowercase .s wasn't duly paid.  This corrects
the error.

Fixes #8155
