### PR TITLE
TLSProxy: Fix Invalid Argument return code from IP_Factory

### DIFF
--- a/util/perl/TLSProxy/Proxy.pm
+++ b/util/perl/TLSProxy/Proxy.pm
@@ -44,7 +44,7 @@ BEGIN
         $s->close();
     };
     if ($@ eq "") {
-        $IP_factory = sub { IO::Socket::INET6->new(@_); };
+        $IP_factory = sub { IO::Socket::INET6->new(Domain => AF_INET6, @_); };
         $have_IPv6 = 1;
     } else {
         eval {


### PR DESCRIPTION
... in connect_to_server() when testing on AIX with Perl 5.10.1 and using IPv6.

Fixes #7732 