### PR TITLE
Rework build: add special cases for AIX

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1100,8 +1100,7 @@ my %targets = (
         module_ldflags   => "-Wl,-G,-bsymbolic,-bexpall",
         shared_ldflag    => "-Wl,-G,-bsymbolic",
         shared_defflag   => "-Wl,-bE:",
-        lib_extension    => shared("_a.a"),
-        shared_extension_simple => shared(".a"),
+        perl_platform    => 'AIX',
     },
     "aix-gcc" => {
         inherit_from     => [ "aix-common", asm("ppc32_asm") ],

--- a/Configurations/platform/AIX.pm
+++ b/Configurations/platform/AIX.pm
@@ -1,0 +1,27 @@
+package platform::AIX;
+
+use strict;
+use warnings;
+use Carp;
+
+use vars qw(@ISA);
+
+require platform::Unix;
+@ISA = qw(platform::Unix);
+
+# Assume someone set @INC right before loading this module
+use configdata;
+
+sub shlibextsimple      { '.a' }
+
+# In shared mode, the default static library names clashes with the final
+# "simple" full shared library name, so we add '_a' to the basename of the
+# static libraries in that case.
+sub staticname {
+    # Non-installed libraries are *always* static, and their names remain
+    # the same, except for the mandatory extension
+    my $in_libname = platform::BASE->staticname($_[1]);
+    return $in_libname if $unified_info{attributes}->{$_[1]}->{noinst};
+
+    return platform::BASE->staticname($_[1]) . '_a';
+}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1193,7 +1193,7 @@ EOF
           push @linkdirs, $d unless grep { $d eq $_ } @linkdirs;
       }
       my $linkflags = join("", map { "-L$_ " } @linkdirs);
-      my $linklibs = join("", map { if ($_ =~ s/\.a$//) {
+      my $linklibs = join("", map { if ($_ =~ m/\.a$/) {
                                         " ".platform->staticlib($_);
                                     } else {
                                         my $f = basename($_);


### PR DESCRIPTION
When reworking the way library file names and extensions were formed,
AIX was lost in the process.  This restores the previous
functionality.

Fixes #8156
