### PR TITLE
Make OPENSSL_malloc_init() a no-op

### DIFF
--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -90,10 +90,8 @@ generally macro's that add the standard C B<__FILE__> and B<__LINE__>
 parameters and call a lower-level B<CRYPTO_xxx> API.
 Some functions do not add those parameters, but exist for consistency.
 
-OPENSSL_malloc_init() sets the lower-level memory allocation functions
-to their default implementation.
-It is generally not necessary to call this, except perhaps in certain
-shared-library situations.
+OPENSSL_malloc_init() does nothing and does not need to be called. It is
+included for compatibility with older versions of OpenSSL.
 
 OPENSSL_malloc(), OPENSSL_realloc(), and OPENSSL_free() are like the
 C malloc(), realloc(), and free() functions.

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -109,13 +109,8 @@ DEFINE_STACK_OF(void)
 # define CRYPTO_EX_INDEX_DRBG            15
 # define CRYPTO_EX_INDEX__COUNT          16
 
-/*
- * This is the default callbacks, but we can have others as well: this is
- * needed in Win32 where the application malloc and the library malloc may
- * not be the same.
- */
-#define OPENSSL_malloc_init() \
-    CRYPTO_set_mem_functions(CRYPTO_malloc, CRYPTO_realloc, CRYPTO_free)
+/* No longer needed, so this is a no-op */
+#define OPENSSL_malloc_init() while(0) continue
 
 int CRYPTO_mem_ctrl(int mode);
 


### PR DESCRIPTION
Making this a no-op removes a potential infinite loop than can occur in
some situations.

Fixes #2865