### PR TITLE
Fix d2i_PublicKey() for EC keys

### DIFF
--- a/crypto/asn1/d2i_pu.c
+++ b/crypto/asn1/d2i_pu.c
@@ -32,7 +32,7 @@ EVP_PKEY *d2i_PublicKey(int type, EVP_PKEY **a, const unsigned char **pp,
     } else
         ret = *a;
 
-    if (!EVP_PKEY_set_type(ret, type)) {
+    if (type != EVP_PKEY_id(ret) && !EVP_PKEY_set_type(ret, type)) {
         ASN1err(ASN1_F_D2I_PUBLICKEY, ERR_R_EVP_LIB);
         goto err;
     }

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -50,8 +50,9 @@ If the B<*a> is not NULL when calling d2i_PrivateKey() or d2i_AutoPrivateKey()
 (i.e. an existing structure is being reused) and the key format is PKCS#8
 then B<*a> will be freed and replaced on a successful call.
 
-To decode a key with type B<EVP_PKEY_EC>, d2i_PublicKey() requires B<*a> to not be
-NULL and contain an EC_KEY structure referencing the proper EC_GROUP.
+To decode a key with type B<EVP_PKEY_EC>, d2i_PublicKey() requires B<*a> to be
+a non-NULL EVP_PKEY structure assigned an EC_KEY structure referencing the proper
+EC_GROUP.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -50,15 +50,18 @@ If the B<*a> is not NULL when calling d2i_PrivateKey() or d2i_AutoPrivateKey()
 (i.e. an existing structure is being reused) and the key format is PKCS#8
 then B<*a> will be freed and replaced on a successful call.
 
+To decode a key with type B<EVP_PKEY_EC>, d2i_PublicKey() requires B<*a> to not be
+NULL and contain an EC_KEY structure referencing the proper EC_GROUP.
+
 =head1 RETURN VALUES
 
-d2i_PrivateKey() and d2i_AutoPrivateKey() return a valid B<EVP_KEY> structure
-or B<NULL> if an error occurs. The error code can be obtained by calling
-L<ERR_get_error(3)>.
+The d2i_PrivateKey(), d2i_AutoPrivateKey(), d2i_PrivateKey_bio(), d2i_PrivateKey_fp(),
+and d2i_PublicKey() functions return a valid B<EVP_KEY> structure or B<NULL> if an
+error occurs. The error code can be obtained by calling L<ERR_get_error(3)>.
 
-i2d_PrivateKey() returns the number of bytes successfully encoded or a
-negative value if an error occurs. The error code can be obtained by calling
-L<ERR_get_error(3)>.
+i2d_PrivateKey() and i2d_PublicKey() return the number of bytes successfully
+encoded or a negative value if an error occurs. The error code can be obtained
+by calling L<ERR_get_error(3)>.
 
 =head1 SEE ALSO
 
@@ -67,7 +70,7 @@ L<d2i_PKCS8PrivateKey_bio(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the OpenSSL license (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
o2i_ECPublicKey() requires an EC_KEY structure filled with an EC_GROUP.

o2i_ECPublicKey() is called by d2i_PublicKey(). In order to fulfill the
o2i_ECPublicKey()'s requirement, d2i_PublicKey() needs to be called with
an EVP_PKEY with an EC_KEY containing an EC_GROUP.

However, the call to EVP_PKEY_set_type() frees any existing key structure
inside the EVP_PKEY, thus freeing the EC_KEY with the EC_GROUP that
o2i_ECPublicKey() needs.

This means you can't d2i_PublicKey() for an EC key...

The fix is to check to see if the type is already set appropriately, and
if so, not call EVP_PKEY_set_type().

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
