### PR TITLE
test/drbgtest.c: call OPENSSL_thread_stop() explicitly

### DIFF
--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -839,6 +839,11 @@ typedef HANDLE thread_t;
 static DWORD WINAPI thread_run(LPVOID arg)
 {
     run_multi_thread_test();
+    /*
+     * Because we're linking with a static library, we must stop each
+     * thread explicitly, or so says OPENSSL_thread_stop(3)
+     */
+    OPENSSL_thread_stop();
     return 0;
 }
 
@@ -860,6 +865,11 @@ typedef pthread_t thread_t;
 static void *thread_run(void *arg)
 {
     run_multi_thread_test();
+    /*
+     * Because we're linking with a static library, we must stop each
+     * thread explicitly, or so says OPENSSL_thread_stop(3)
+     */
+    OPENSSL_thread_stop();
     return NULL;
 }
 


### PR DESCRIPTION
The manual says this in its notes:

    ... and therefore applications using static linking should also call
    OPENSSL_thread_stop() on each thread. ...

Fixes #8171
