### PR TITLE
Don't set SNI by default if hostname is not dNS name; fixes #8083

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3575,9 +3575,7 @@ static int is_dNS_name(const char *host)
      * Check DNS name syntax, any '-' or '.' must be internal,
      * and on either side of each '.' we can't have a '-' or '.'.
      *
-     * If the name has just one label, we don't consider it a DNS name.  This
-     * means that "CN=sometld" cannot be precluded by DNS name constraints, but
-     * that is not a problem.
+     * If the name has just one label, we don't consider it a DNS name.
      */
     for (i = 0; i < length && label_length < MAX_LABEL_LENGTH; ++i) {
         char c = host[i];

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3562,16 +3562,16 @@ static char *base64encode (const void *buf, size_t len)
  */
 static int is_dNS_name(const char *host)
 {
-    const int MAX_LABEL_LENGTH = 63;
+    const size_t MAX_LABEL_LENGTH = 63;
 
-    int i;
+    size_t i;
     int isdnsname = 0;
-    int length = strlen(host);
-    int label_length = 0;
+    size_t length = strlen(host);
+    size_t label_length = 0;
     int all_numeric = 1;
 
     /*
-     * XXX: Deviation from strict DNS name syntax, also check names with '_'
+     * Deviation from strict DNS name syntax, also check names with '_'
      * Check DNS name syntax, any '-' or '.' must be internal,
      * and on either side of each '.' we can't have a '-' or '.'.
      *

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3563,7 +3563,6 @@ static char *base64encode (const void *buf, size_t len)
 static int is_dNS_name(const char *host)
 {
     const size_t MAX_LABEL_LENGTH = 63;
-
     size_t i;
     int isdnsname = 0;
     size_t length = strlen(host);

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -208,14 +208,17 @@ Use IPv6 only.
 =item B<-servername name>
 
 Set the TLS SNI (Server Name Indication) extension in the ClientHello message to
-the given value. If neither this option nor the B<-noservername> are given, the
-TLS SNI extension is still set to the hostname provided to the B<-connect> option
-if the hostname is a valid DNS name (i.e. not an IP address), or "localhost" if 
-B<-connect> has not been supplied. This is default since OpenSSL 1.1.1.
+the given value. 
+If B<-servername> is not provided, the TLS SNI extension will be populated with 
+the name given to B<-connect> if it follows a DNS name format. If B<-connect> is 
+not provided either, the SNI is set to "localhost".
+This is the default since OpenSSL 1.1.1.
 
-Even though SNI name should normally be a DNS name and not an IP address, if 
-B<-servername> is given then the name provided to B<-connect> will be sent 
-regardless if it is a DNS name or not.
+Even though SNI should normally be a DNS name and not an IP address, if 
+B<-servername> is provided then that name will be sent, regardless of whether 
+it is a DNS name or not.
+
+This option cannot be used in conjuction with B<-noservername>.
 
 =item B<-noservername>
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -208,14 +208,14 @@ Use IPv6 only.
 =item B<-servername name>
 
 Set the TLS SNI (Server Name Indication) extension in the ClientHello message to
-the given value. If both this option and the B<-noservername> are not given, the
-TLS SNI extension is still set to the hostname provided to the B<-connect> option,
-or "localhost" if B<-connect> has not been supplied. This is default since OpenSSL
-1.1.1.
+the given value. If neither this option nor the B<-noservername> are given, the
+TLS SNI extension is still set to the hostname provided to the B<-connect> option
+if the hostname is a valid DNS name (i.e. not an IP address), or "localhost" if 
+B<-connect> has not been supplied. This is default since OpenSSL 1.1.1.
 
-Even though SNI name should normally be a DNS name and not an IP address, this
-option will not make the distinction when parsing B<-connect> and will send
-IP address if one passed.
+Even though SNI name should normally be a DNS name and not an IP address, if 
+B<-servername> is given then the name provided to B<-connect> will be sent 
+regardless if it is a DNS name or not.
 
 =item B<-noservername>
 


### PR DESCRIPTION
Don't set SNI by default (i.e. when -servername is not set) in clientHello if hostname is not dNS name

CLA not yet completed, will do asap

Fixes #8083

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
