### PR TITLE
Fix null pointer dereference in ssl_module_init

### DIFF
--- a/crypto/conf/conf_ssl.c
+++ b/crypto/conf/conf_ssl.c
@@ -78,6 +78,8 @@ static int ssl_module_init(CONF_IMODULE *md, const CONF *cnf)
     cnt = sk_CONF_VALUE_num(cmd_lists);
     ssl_module_free(md);
     ssl_names = OPENSSL_zalloc(sizeof(*ssl_names) * cnt);
+    if (ssl_names == NULL)
+        goto err;
     ssl_names_count = cnt;
     for (i = 0; i < ssl_names_count; i++) {
         struct ssl_conf_name_st *ssl_name = ssl_names + i;


### PR DESCRIPTION
`OPENSSL_zalloc` can return a NULL pointer on memory allocation failure. 

The null pointer is used as a base address for `ssl_name` at https://github.com/openssl/openssl/blob/ef45aa14c5af024fcb8bef1c9007f3d1c115bd85/crypto/conf/conf_ssl.c#L83

The `ssl_name` struct is accessed at https://github.com/openssl/openssl/blob/ef45aa14c5af024fcb8bef1c9007f3d1c115bd85/crypto/conf/conf_ssl.c#L97