### PR TITLE
Add EC_GROUP_get0_field

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -364,6 +364,11 @@ int EC_GROUP_get_curve_name(const EC_GROUP *group)
     return group->curve_name;
 }
 
+const BIGNUM *EC_GROUP_get0_field(const EC_GROUP *group)
+{
+    return group->field;
+}
+
 void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag)
 {
     group->asn1_flag = flag;

--- a/doc/man3/EC_GROUP_copy.pod
+++ b/doc/man3/EC_GROUP_copy.pod
@@ -11,7 +11,7 @@ EC_GROUP_get_point_conversion_form, EC_GROUP_get0_seed,
 EC_GROUP_get_seed_len, EC_GROUP_set_seed, EC_GROUP_get_degree,
 EC_GROUP_check, EC_GROUP_check_discriminant, EC_GROUP_cmp,
 EC_GROUP_get_basis_type, EC_GROUP_get_trinomial_basis,
-EC_GROUP_get_pentanomial_basis
+EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field
 - Functions for manipulating EC_GROUP objects
 
 =head1 SYNOPSIS
@@ -32,6 +32,7 @@ EC_GROUP_get_pentanomial_basis
  int EC_GROUP_order_bits(const EC_GROUP *group);
  int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor, BN_CTX *ctx);
  const BIGNUM *EC_GROUP_get0_cofactor(const EC_GROUP *group);
+ const BIGNUM *EC_GROUP_get0_field(const EC_GROUP *group);
 
  void EC_GROUP_set_curve_name(EC_GROUP *group, int nid);
  int EC_GROUP_get_curve_name(const EC_GROUP *group);
@@ -177,6 +178,8 @@ specified curve respectively. If there is no curve name associated with a curve 
 EC_GROUP_get0_order() returns an internal pointer to the group order.
 EC_GROUP_order_bits() returns the number of bits in the group order.
 EC_GROUP_get0_cofactor() returns an internal pointer to the group cofactor.
+EC_GROUP_get0_field() returns an internal pointer to the group field. For curves over GF(p), this is the modulus; for curves
+over GF(2^m), this is the irreducible polynomial defining the field.
 
 EC_GROUP_get0_seed returns a pointer to the seed that was used to generate the parameter b, or NULL if the seed is not
 specified. EC_GROUP_get_seed_len returns the length of the seed or 0 if the seed is not specified.

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -212,6 +212,12 @@ void EC_GROUP_set_curve_name(EC_GROUP *group, int nid);
  */
 int EC_GROUP_get_curve_name(const EC_GROUP *group);
 
+/** Gets the field of an EC_GROUP
+ *  \param  group  EC_GROUP object
+ *  \return the group field
+ */
+const BIGNUM *EC_GROUP_get0_field(const EC_GROUP *group);
+
 void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag);
 int EC_GROUP_get_asn1_flag(const EC_GROUP *group);
 

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -1159,6 +1159,43 @@ static int internal_curve_test_method(int n)
     return r;
 }
 
+static int group_field_test(void)
+{
+    int r = 1;
+    BIGNUM *secp521r1_field = NULL;
+    BIGNUM *sect163r2_field = NULL;
+    EC_GROUP *secp521r1_group = NULL;
+    EC_GROUP *sect163r2_group = NULL;
+
+    BN_hex2bn(&secp521r1_field,
+                "01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                "FFFF");
+
+
+    BN_hex2bn(&sect163r2_field,
+                "08000000000000000000000000000000"
+                "00000000C9");
+
+    secp521r1_group = EC_GROUP_new_by_curve_name(NID_secp521r1);
+    if (BN_cmp(secp521r1_field, EC_GROUP_get0_field(secp521r1_group)))
+      r = 0;
+
+    # ifndef OPENSSL_NO_EC2M
+    sect163r2_group = EC_GROUP_new_by_curve_name(NID_sect163r2);
+    if (BN_cmp(sect163r2_field, EC_GROUP_get0_field(sect163r2_group)))
+      r = 0;
+    # endif
+
+    EC_GROUP_free(secp521r1_group);
+    EC_GROUP_free(sect163r2_group);
+    BN_free(secp521r1_field);
+    BN_free(sect163r2_field);
+    return r;
+}
+
 # ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
 /*
  * nistp_test_params contains magic numbers for testing our optimized
@@ -1513,6 +1550,7 @@ int setup_tests(void)
 # endif
     ADD_ALL_TESTS(internal_curve_test, crv_len);
     ADD_ALL_TESTS(internal_curve_test_method, crv_len);
+    ADD_TEST(group_field_test);
 #endif
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4639,3 +4639,4 @@ EVP_KDF_vctrl                           4594	3_0_0	EXIST::FUNCTION:
 EVP_KDF_ctrl_str                        4595	3_0_0	EXIST::FUNCTION:
 EVP_KDF_size                            4596	3_0_0	EXIST::FUNCTION:
 EVP_KDF_derive                          4597	3_0_0	EXIST::FUNCTION:
+EC_GROUP_get0_field                     4598	3_0_0	EXIST::FUNCTION:EC


### PR DESCRIPTION
I want to add an API to get EC_GROUP field value.
The reason I need it is to preform a validation similar to the validation in EC_KEY_set_public_key_affine_coordinates function.
I want to check after the fact whether or not my public_key coordinates are caped by the field value.
I'm referring to this validation: "(BN_cmp(x, key->group->field) >= 0)".

Is there a reason why not to add a EC_GROUP_get0_field();
If we don't want someone to change the value maybe I can return a duplicate. 

Thanks.

New function to return internal pointer for field.

- [x] documentation is added or updated
