### PR TITLE
Android build: avoid using variable to access variable.

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -96,7 +96,7 @@
                 (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
                 (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
                 $cflags .= " -target $tridefault "
-                        .  "-gcc-toolchain \$($ndk_var)/toolchains"
+                        .  "-gcc-toolchain \"$ndk/toolchains\""
                         .  "/$tritools-4.9/prebuilt/$host";
                 $user{CC} = "clang" if ($user{CC} !~ m|clang|);
                 $user{CROSS_COMPILE} = undef;
@@ -133,13 +133,13 @@
                 die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
                 $incroot =~ s|^$ndk/||;
                 $cppflags  = "-D__ANDROID_API__=$api";
-                $cppflags .= " -isystem \$($ndk_var)/$incroot/$triarch";
-                $cppflags .= " -isystem \$($ndk_var)/$incroot";
+                $cppflags .= " -isystem \"$ndk/$incroot/$triarch\"";
+                $cppflags .= " -isystem \"$ndk/$incroot\"";
             }
 
             $sysroot =~ s|^$ndk/||;
             $android_ndk = {
-                cflags   => "$cflags --sysroot=\$($ndk_var)/$sysroot",
+                cflags   => "$cflags --sysroot=\"$ndk/$sysroot\"",
                 cppflags => $cppflags,
                 bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
                                             : "BN_LLONG",


### PR DESCRIPTION
It returns empty path on Ubuntu 18.04 and it seems that the only reason to use it was to make sure that it will work for paths with spaces.