### PR TITLE
apps x509: allow "-keyform engine" and passing PKCS#11 URL as -signkey

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -130,7 +130,7 @@ const OPTIONS x509_options[] = {
     {"checkemail", OPT_CHECKEMAIL, 's', "Check certificate matches email"},
     {"checkip", OPT_CHECKIP, 's', "Check certificate matches ipaddr"},
     {"CAform", OPT_CAFORM, 'F', "CA format - default PEM"},
-    {"CAkeyform", OPT_CAKEYFORM, 'f', "CA key format - default PEM"},
+    {"CAkeyform", OPT_CAKEYFORM, 'E', "CA key format - default PEM"},
     {"sigopt", OPT_SIGOPT, 's', "Signature parameter in n:v form"},
     {"force_pubkey", OPT_FORCE_PUBKEY, '<', "Force the Key to put inside certificate"},
     {"next_serial", OPT_NEXT_SERIAL, '-', "Increment current certificate serial number"},
@@ -225,7 +225,7 @@ int x509_main(int argc, char **argv)
                 goto opthelp;
             break;
         case OPT_CAKEYFORM:
-            if (!opt_format(opt_arg(), OPT_FMT_ANY, &CAkeyformat))
+            if (!opt_format(opt_arg(), OPT_FMT_PDE, &CAkeyformat))
                 goto opthelp;
             break;
         case OPT_OUT:

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -72,7 +72,7 @@ const OPTIONS x509_options[] = {
     {"outform", OPT_OUTFORM, 'f',
      "Output format - default PEM (one of DER or PEM)"},
     {"out", OPT_OUT, '>', "Output file - default stdout"},
-    {"keyform", OPT_KEYFORM, 'F', "Private key format - default PEM"},
+    {"keyform", OPT_KEYFORM, 'E', "Private key format - default PEM"},
     {"passin", OPT_PASSIN, 's', "Private key password/pass-phrase source"},
     {"serial", OPT_SERIAL, '-', "Print serial number value"},
     {"subject_hash", OPT_HASH, '-', "Print subject hash value"},
@@ -107,7 +107,7 @@ const OPTIONS x509_options[] = {
     {"checkend", OPT_CHECKEND, 'M',
      "Check whether the cert expires in the next arg seconds"},
     {OPT_MORE_STR, 1, 1, "Exit 1 if so, 0 if not"},
-    {"signkey", OPT_SIGNKEY, '<', "Self sign cert with arg"},
+    {"signkey", OPT_SIGNKEY, 's', "Self sign cert with arg"},
     {"x509toreq", OPT_X509TOREQ, '-',
      "Output a certification request object"},
     {"req", OPT_REQ, '-', "Input is a certificate request, sign and output"},
@@ -217,7 +217,7 @@ int x509_main(int argc, char **argv)
                 goto opthelp;
             break;
         case OPT_KEYFORM:
-            if (!opt_format(opt_arg(), OPT_FMT_PEMDER, &keyformat))
+            if (!opt_format(opt_arg(), OPT_FMT_PDE, &keyformat))
                 goto opthelp;
             break;
         case OPT_CAFORM:

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -11,7 +11,7 @@ B<openssl> B<x509>
 [B<-help>]
 [B<-inform DER|PEM>]
 [B<-outform DER|PEM>]
-[B<-keyform DER|PEM>]
+[B<-keyform DER|PEM|ENGINE>]
 [B<-CAform DER|PEM>]
 [B<-CAkeyform DER|PEM>]
 [B<-in filename>]
@@ -378,9 +378,9 @@ certificate is being created from another certificate (for example with
 the B<-signkey> or the B<-CA> options). Normally all extensions are
 retained.
 
-=item B<-keyform PEM|DER>
+=item B<-keyform PEM|DER|ENGINE>
 
-Specifies the format (DER or PEM) of the private key file used in the
+Specifies the format (DER, PEM or ENGINE) of the private key file used in the
 B<-signkey> option.
 
 =item B<-days arg>

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -13,7 +13,7 @@ B<openssl> B<x509>
 [B<-outform DER|PEM>]
 [B<-keyform DER|PEM|ENGINE>]
 [B<-CAform DER|PEM>]
-[B<-CAkeyform DER|PEM>]
+[B<-CAkeyform DER|PEM|ENGINE>]
 [B<-in filename>]
 [B<-out filename>]
 [B<-serial>]


### PR DESCRIPTION
openssl-1.1.0 has extended option checking, and rejects -keyform engine
and passing a PKCS#11 url to "-signkey" option. The actual code is ready
to take these.

Fixup the relevant Fields in x509_options[], and also fix the
optformat check in x509_main()
This is similar to bd6eba79d706 ("Fix small but important regression")
which does the same for CAkeyform.

Signed-off-by: Torben Hohn <torben.hohn@linutronix.de>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
