### PR TITLE
eng_devcrypto.c: close open cipher session on init

### DIFF
--- a/engines/build.info
+++ b/engines/build.info
@@ -43,7 +43,7 @@ IF[{- !$disabled{"engine"} -}]
       ENDIF
     ENDIF
     IF[{- !$disabled{"devcryptoeng"} -}]
-      MODULES=devcrypto
+      MODULES{engine}=devcrypto
       SOURCE[devcrypto]=e_devcrypto.c
       DEPEND[devcrypto]=../libcrypto
       INCLUDE[devcrypto]=../include

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -1183,10 +1183,13 @@ static int open_devcrypto(void)
 
 static int close_devcrypto(void)
 {
+    int ret;
+
     if (cfd < 0)
         return 1;
+    ret = close(cfd);
     cfd = -1;
-    if (close(cfd) == 0) {
+    if (ret != 0) {
         fprintf(stderr, "Error closing /dev/crypto: %s\n", strerror(errno));
         return 0;
     }

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -629,29 +629,30 @@ struct digest_ctx {
 
 static const struct digest_data_st {
     int nid;
+    int blocksize;
     int digestlen;
     int devcryptoid;
 } digest_data[] = {
 #ifndef OPENSSL_NO_MD5
-    { NID_md5, 16, CRYPTO_MD5 },
+    { NID_md5, /* MD5_CBLOCK */ 64, 16, CRYPTO_MD5 },
 #endif
-    { NID_sha1, 20, CRYPTO_SHA1 },
+    { NID_sha1, SHA_CBLOCK, 20, CRYPTO_SHA1 },
 #ifndef OPENSSL_NO_RMD160
 # if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_RIPEMD160)
-    { NID_ripemd160, 20, CRYPTO_RIPEMD160 },
+    { NID_ripemd160, /* RIPEMD160_CBLOCK */ 64, 20, CRYPTO_RIPEMD160 },
 # endif
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_SHA2_224)
-    { NID_sha224, 224 / 8, CRYPTO_SHA2_224 },
+    { NID_sha224, SHA256_CBLOCK, 224 / 8, CRYPTO_SHA2_224 },
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_SHA2_256)
-    { NID_sha256, 256 / 8, CRYPTO_SHA2_256 },
+    { NID_sha256, SHA256_CBLOCK, 256 / 8, CRYPTO_SHA2_256 },
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_SHA2_384)
-    { NID_sha384, 384 / 8, CRYPTO_SHA2_384 },
+    { NID_sha384, SHA512_CBLOCK, 384 / 8, CRYPTO_SHA2_384 },
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_SHA2_512)
-    { NID_sha512, 512 / 8, CRYPTO_SHA2_512 },
+    { NID_sha512, SHA512_CBLOCK, 512 / 8, CRYPTO_SHA2_512 },
 #endif
 };
 
@@ -706,7 +707,6 @@ static int digest_init(EVP_MD_CTX *ctx)
         SYSerr(SYS_F_IOCTL, errno);
         return 0;
     }
-
     return 1;
 }
 
@@ -896,6 +896,8 @@ static void prepare_digest_methods(void)
         }
         if ((known_digest_methods[i] = EVP_MD_meth_new(digest_data[i].nid,
                                                        NID_undef)) == NULL
+            || !EVP_MD_meth_set_input_blocksize(known_digest_methods[i],
+                                                digest_data[i].blocksize)
             || !EVP_MD_meth_set_result_size(known_digest_methods[i],
                                             digest_data[i].digestlen)
             || !EVP_MD_meth_set_init(known_digest_methods[i], digest_init)


### PR DESCRIPTION
`cipher_init` may be called on an already initialized context, without a
necessary cleanup.  This separates cleanup from initialization, closing
an eventual open session before creating a new one.

Move the /dev/crypto session cleanup code to its own function, and fix
a typo in `DEVCRYPTO_DEFAULT_USE_SOFTDRIVERS`.

This is a clear bug fix, so it should go to 1.1.1.  Without this change, the open sessions would accumulate until the engine was no longer able to operate, as shown in openwrt/openwrt#1547, in the discussion about broken pipes in unbound with TLS.

@levitte, please take a look at this.

Before deciding to always cleanup, I did try to reuse the same session, just changing the key & IV, but cryptodev would still create a new session.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
