### PR TITLE
Macro typo fix not propagated

### DIFF
--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -1048,7 +1048,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
         OPENSSL_MSTR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
         OPENSSL_MSTR(DEVCRYPTO_REJECT_SOFTWARE)
         "=use if acceleration can't be determined) [default="
-        OPENSSL_MSTR(DEVCRYPTO_DEFAULT_USE_SOFDTRIVERS) "]",
+        OPENSSL_MSTR(DEVCRYPTO_DEFAULT_USE_SOFTDRIVERS) "]",
     ENGINE_CMD_FLAG_NUMERIC},
 #endif
 


### PR DESCRIPTION
A typo in some of the macros in this file was fixed but not propagated properly.
This fixes the rest.

