### PR TITLE
Add PADLOCK_ASM to dso_defines rather than lib_defines

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -231,8 +231,8 @@ LIB_CPPFLAGS={- our $lib_cppflags =
                 join(' ', $target{lib_cppflags} || (),
                           $target{shared_cppflag} || (),
                           (map { '-D'.$_ }
-                               @{$config{lib_defines}},
-                               @{$config{shared_defines}}),
+                               @{$config{lib_defines} || ()},
+                               @{$config{shared_defines} || ()}),
                           @{$config{lib_cppflags}},
                           @{$config{shared_cppflag}});
                 join(' ', $lib_cppflags,
@@ -256,6 +256,9 @@ LIB_LDFLAGS={- join(' ', $target{shared_ldflag} || (),
 LIB_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
 DSO_CPPFLAGS={- join(' ', $target{dso_cppflags} || (),
                           $target{module_cppflags} || (),
+                          (map { '-D'.$_ }
+                               @{$config{dso_defines} || ()},
+                               @{$config{module_defines} || ()}),
                           @{$config{dso_cppflags}},
                           @{$config{module_cppflags}},
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
@@ -276,6 +279,7 @@ DSO_LDFLAGS={- join(' ', $target{dso_ldflags} || (),
                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
 DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
 BIN_CPPFLAGS={- join(' ', $target{bin_cppflags} || (),
+                          (map { '-D'.$_ } @{$config{bin_defines} || ()}),
                           @{$config{bin_cppflags}},
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
 BIN_CFLAGS={- join(' ', $target{bin_cflags} || (),

--- a/Configure
+++ b/Configure
@@ -1411,7 +1411,7 @@ unless ($disabled{asm}) {
 	push @{$config{lib_defines}}, "X25519_ASM";
     }
     if ($target{padlock_asm_src} ne $table{DEFAULTS}->{padlock_asm_src}) {
-	push @{$config{lib_defines}}, "PADLOCK_ASM";
+	push @{$config{dso_defines}}, "PADLOCK_ASM";
     }
     if ($target{poly1305_asm_src} ne "") {
 	push @{$config{lib_defines}}, "POLY1305_ASM";

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -28,7 +28,7 @@
  */
 
 #  undef COMPILE_HW_PADLOCK
-#  if !defined(I386_ONLY) && defined(PADLOCK_ASM)
+#  if defined(PADLOCK_ASM)
 #   define COMPILE_HW_PADLOCK
 #   ifdef OPENSSL_NO_DYNAMIC_ENGINE
 static ENGINE *ENGINE_padlock(void);
@@ -135,7 +135,7 @@ static int padlock_init(ENGINE *e)
  * This stuff is needed if this ENGINE is being compiled into a
  * self-contained shared-library.
  */
-#   ifdef DYNAMIC_ENGINE
+#   ifndef OPENSSL_NO_DYNAMIC_ENGINE
 static int padlock_bind_fn(ENGINE *e, const char *id)
 {
     if (id && (strcmp(id, padlock_id) != 0)) {
@@ -151,7 +151,7 @@ static int padlock_bind_fn(ENGINE *e, const char *id)
 
 IMPLEMENT_DYNAMIC_CHECK_FN()
 IMPLEMENT_DYNAMIC_BIND_FN(padlock_bind_fn)
-#   endif                       /* DYNAMIC_ENGINE */
+#   endif                       /* !OPENSSL_NO_DYNAMIC_ENGINE */
 /* ===== Here comes the "real" engine ===== */
 
 /* Some AES-related constants */


### PR DESCRIPTION
Since the padlock code is an engine, the assembler is for a module,
not a library link to when building a program...  there's a
distinction.

Fixes #2311
