### PR TITLE
Sparse array limit testing.

### DIFF
--- a/crypto/sparse_array.c
+++ b/crypto/sparse_array.c
@@ -37,7 +37,7 @@
 # else
 #  define OPENSSL_SA_BLOCK_BITS           12
 # endif
-#elif OPENSSL_SA_BLOCK_BITS < 2 || OPENSSL_SA_BLOCK_BITS > BN_BITS2
+#elif OPENSSL_SA_BLOCK_BITS < 2 || OPENSSL_SA_BLOCK_BITS > (BN_BITS2 - 1)
 # error OPENSSL_SA_BLOCK_BITS is out of range
 #endif
 


### PR DESCRIPTION
Reduce the range limit for the number of bits in a sparse array pointer block.

There is no point supporting the full size_t width as a node size in a sparse array.  It defeats the point of being sparse.