### PR TITLE
Add an OpenSSL library context

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -12,7 +12,7 @@ SOURCE[../libcrypto]=\
         cryptlib.c mem.c mem_dbg.c cversion.c ex_data.c cpt_err.c \
         ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c ctype.c \
         threads_pthread.c threads_win.c threads_none.c getenv.c \
-        o_init.c o_fips.c mem_sec.c init.c sparse_array.c \
+        o_init.c o_fips.c mem_sec.c init.c context.c sparse_array.c \
         {- $target{cpuid_asm_src} -} {- $target{uplink_aux_src} -}
 
 DEPEND[cversion.o]=buildinf.h

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/cryptlib.h"
+#include "internal/thread_once.h"
+
+struct openssl_ctx_st {
+    CRYPTO_RWLOCK *lock;
+    CRYPTO_EX_DATA data;
+};
+
+static OPENSSL_CTX default_context;
+
+static int context_init(OPENSSL_CTX *ctx)
+{
+    return (ctx->lock = CRYPTO_THREAD_lock_new()) != NULL
+        && CRYPTO_new_ex_data(CRYPTO_EX_INDEX_OPENSSL_CTX, NULL,
+                              &ctx->data);
+}
+
+static int context_deinit(OPENSSL_CTX *ctx)
+{
+    CRYPTO_free_ex_data(CRYPTO_EX_INDEX_OPENSSL_CTX, NULL, &ctx->data);
+    CRYPTO_THREAD_lock_free(ctx->lock);
+    return 1;
+}
+
+static CRYPTO_ONCE default_context_init = CRYPTO_ONCE_STATIC_INIT;
+static void do_default_context_deinit(void)
+{
+    context_deinit(&default_context);
+}
+DEFINE_RUN_ONCE_STATIC(do_default_context_init)
+{
+    return OPENSSL_init_crypto(0, NULL)
+        && context_init(&default_context)
+        && OPENSSL_atexit(do_default_context_deinit);
+}
+
+OPENSSL_CTX *OPENSSL_CTX_new(void)
+{
+    OPENSSL_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+
+    if (ctx != NULL && !context_init(ctx)) {
+        OPENSSL_CTX_free(ctx);
+        ctx = NULL;
+    }
+    return ctx;
+}
+
+void OPENSSL_CTX_free(OPENSSL_CTX *ctx)
+{
+    if (ctx != NULL)
+        context_deinit(ctx);
+    OPENSSL_free(ctx);
+}
+
+static void openssl_ctx_generic_new(void *parent_ign, void *ptr_ign,
+                                    CRYPTO_EX_DATA *ad, int index,
+                                    long argl_ign, void *argp)
+{
+    const OPENSSL_CTX_METHOD *meth = argp;
+    void *ptr = meth->new_func();
+
+    if (ptr != NULL)
+        CRYPTO_set_ex_data(ad, index, ptr);
+}
+static void openssl_ctx_generic_free(void *parent_ign, void *ptr,
+                                     CRYPTO_EX_DATA *ad, int index,
+                                     long argl_ign, void *argp)
+{
+    const OPENSSL_CTX_METHOD *meth = argp;
+
+    meth->free_func(ptr);
+}
+int openssl_ctx_new_index(const OPENSSL_CTX_METHOD *meth)
+{
+    return CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_OPENSSL_CTX, 0, (void *)meth,
+                                   openssl_ctx_generic_new, NULL,
+                                   openssl_ctx_generic_free);
+}
+
+void *openssl_ctx_get_data(OPENSSL_CTX *ctx, int index)
+{
+    void *data = NULL;
+
+    if (ctx == NULL) {
+        if (!RUN_ONCE(&default_context_init, do_default_context_init))
+            return 0;
+        ctx = &default_context;
+    }
+
+    CRYPTO_THREAD_read_lock(ctx->lock);
+
+    /* The alloc call ensures there's a value there */
+    if (CRYPTO_alloc_ex_data(CRYPTO_EX_INDEX_OPENSSL_CTX, NULL,
+                             &ctx->data, index))
+        data = CRYPTO_get_ex_data(&ctx->data, index);
+
+    CRYPTO_THREAD_unlock(ctx->lock);
+
+    return data;
+}
+

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -363,6 +363,36 @@ void CRYPTO_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
 }
 
 /*
+ * Allocate a given CRYPTO_EX_DATA item using the class specific allocation
+ * function
+ */
+int CRYPTO_alloc_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad,
+                         int idx)
+{
+    EX_CALLBACK *f;
+    EX_CALLBACKS *ip;
+    void *curval;
+
+    curval = CRYPTO_get_ex_data(ad, idx);
+
+    /* Already there, no need to allocate */
+    if (curval != NULL)
+        return 1;
+
+    ip = get_and_lock(class_index);
+    f = sk_EX_CALLBACK_value(ip->meth, idx);
+    CRYPTO_THREAD_unlock(ex_data_lock);
+
+    /*
+     * This should end up calling CRYPTO_set_ex_data(), which allocates
+     * everything necessary to support placing the new data in the right spot.
+     */
+    f->new_func(obj, curval, ad, idx, f->argl, f->argp);
+
+    return 1;
+}
+
+/*
  * For a given CRYPTO_EX_DATA variable, set the value corresponding to a
  * particular index in the class used by this variable
  */

--- a/doc/internal/man3/openssl_ctx_get_data.pod
+++ b/doc/internal/man3/openssl_ctx_get_data.pod
@@ -1,0 +1,116 @@
+=pod
+
+=head1 NAME
+
+openssl_ctx_new_index, openssl_ctx_free_index,
+openssl_ctx_new_fn, openssl_ctx_free_fn,
+openssl_ctx_set_data, openssl_ctx_get_data - internal OPENSSL_CTX routines
+
+=head1 SYNOPSIS
+
+ #include <openssl/ossl_typ.h>
+ #include "internal/cryptlib.h"
+
+ typedef CRYPTO_EX_new openssl_ctx_new_fn;
+ typedef CRYPTO_EX_free openssl_ctx_free_fn;
+
+ typedef struct openssl_ctx_method {
+     void *(*new_func)(void);
+     void (*free_func)(void *);
+ } OPENSSL_CTX_METHOD;
+
+ int openssl_ctx_new_index(const OPENSSL_CTX_METHOD *meth);
+ void *openssl_ctx_get_data(OPENSSL_CTX *ctx, int index);
+
+=head1 DESCRIPTION
+
+Internally, the OpenSSL library context C<OPENSSL_CTX> is implemented
+as a C<CRYPTO_EX_DATA>, which allows data from diverse parts of the
+library to be added and removed dynamically.
+Each such data item must have a corresponding CRYPTO_EX_DATA index
+associated with it.
+See the example further down to see how that's done.
+
+openssl_ctx_new_index() allocates a new library context index, and
+associates it with the functions given through C<meth>.
+The functions given through that method are used to create or free
+items that are stored at that index whenever a library context is
+created or freed, meaning that the code that use a data item of that
+index doesn't have to worry about that, just use the data available.
+
+Deallocation of an index happens automatically when the library
+context is freed.
+
+openssl_ctx_get_data() is used to retrieve a pointer to the data in
+the library context C<ctx> associated with the given C<index>.
+
+=head1 EXAMPLES
+
+=head2 Initialization
+
+For a type C<FOO> that should end up in the OpenSSL library context, a
+small bit of initialization is needed, i.e. to associate a constructor
+and a destructor to a new index.
+
+ /* The index will always be entirely global, and dynamically allocated */
+ static int foo_index = -1;
+
+ typedef struct foo_st {
+     int i;
+     void *data;
+ } FOO;
+
+ static void *foo_new(void)
+ {
+     FOO *ptr = OPENSSL_zalloc(sizeof(*foo));
+     if (ptr != NULL)
+         ptr->i = 42;
+     return ptr;
+ }
+ static void foo_free(void *ptr)
+ {
+     OPENSSL_free(ptr);
+ }
+ static const OPENSSL_CTX_METHOD foo_method = {
+     foo_new,
+     foo_free
+ };
+
+ static int foo_init(void) {
+     foo_index = openssl_ctx_new_index(foo_method);
+
+     return foo_index != -1;
+ }
+
+=head2 Usage
+
+To get and use the data stored in the library context, simply do this:
+
+ /*
+  * ctx is received from a caller,
+  * foo_index comes from the example above
+  */
+ FOO *data = openssl_ctx_get_data(ctx, foo_index);
+
+=head1 RETURN VALUES
+
+openssl_ctx_new_index() returns -1 on error, otherwise the allocated
+index number.
+
+openssl_ctx_get_data() returns a pointer on success, or C<NULL> on
+failure.
+
+=head1 SEE ALSO
+
+L<OPENSSL_CTX(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/internal/man3/openssl_ctx_get_data.pod
+++ b/doc/internal/man3/openssl_ctx_get_data.pod
@@ -76,7 +76,8 @@ and a destructor to a new index.
      foo_free
  };
 
- static int foo_init(void) {
+ static int foo_init(void)
+ {
      foo_index = openssl_ctx_new_index(foo_method);
 
      return foo_index != -1;

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -26,6 +26,9 @@ CRYPTO_get_ex_data, CRYPTO_free_ex_data, CRYPTO_new_ex_data
 
  int CRYPTO_new_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
 
+ int CRYPTO_alloc_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad,
+                          int idx);
+
  int CRYPTO_set_ex_data(CRYPTO_EX_DATA *r, int idx, void *arg);
 
  void *CRYPTO_get_ex_data(CRYPTO_EX_DATA *r, int idx);
@@ -114,7 +117,8 @@ new_func() is called for every defined index. There is no requirement
 that the entire parent, or containing, structure has been set up.
 The new_func() is typically used only to allocate memory to store the
 exdata, and perhaps an "initialized" flag within that memory.
-The exdata value should be set by calling CRYPTO_set_ex_data().
+The exdata value may be allocated later on with CRYPTO_alloc_ex_data(),
+or may be set by calling CRYPTO_set_ex_data().
 
 When a structure is free'd (such as SSL_CTX_free()) then the
 free_func() is called for every defined index.  Again, the state of the
@@ -147,13 +151,17 @@ will fail.
 
 CRYPTO_get_ex_new_index() returns a new index or -1 on failure.
 
-CRYPTO_free_ex_index() and
-CRYPTO_set_ex_data() return 1 on success or 0 on failure.
+CRYPTO_free_ex_index(), CRYPTO_alloc_ex_data() and CRYPTO_set_ex_data()
+return 1 on success or 0 on failure. 
 
 CRYPTO_get_ex_data() returns the application data or NULL on failure;
 note that NULL may be a valid value.
 
 dup_func() should return 0 for failure and 1 for success.
+
+=head1 HISTORY
+
+CRYPTO_alloc_ex_data() was added in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -3,8 +3,9 @@
 =head1 NAME
 
 CRYPTO_EX_new, CRYPTO_EX_free, CRYPTO_EX_dup,
-CRYPTO_free_ex_index, CRYPTO_get_ex_new_index, CRYPTO_set_ex_data,
-CRYPTO_get_ex_data, CRYPTO_free_ex_data, CRYPTO_new_ex_data
+CRYPTO_free_ex_index, CRYPTO_get_ex_new_index,
+CRYPTO_alloc_ex_data, CRYPTO_set_ex_data, CRYPTO_get_ex_data,
+CRYPTO_free_ex_data, CRYPTO_new_ex_data
 - functions supporting application-specific data
 
 =head1 SYNOPSIS

--- a/doc/man3/OPENSSL_CTX.pod
+++ b/doc/man3/OPENSSL_CTX.pod
@@ -1,0 +1,41 @@
+=pod
+
+=head1 NAME
+
+OPENSSL_CTX, OPENSSL_CTX_new, OPENSSL_CTX_free - OpenSSL library context
+
+=head1 SYNOPSIS
+
+ #include <openssl/crypto.h>
+
+ OPENSSL_CTX *OPENSSL_CTX_new(void);
+ void OPENSSL_CTX_free(OPENSSL_CTX *ctx);
+
+=head1 DESCRIPTION
+
+C<OPENSSL_CTX> is an internal OpenSSL library context type.
+Applications may allocate their own, but may also use C<NULL> to use
+the internal default context with functions that take a C<OPENSSL_CTX>
+argument.
+
+OPENSSL_CTX_new() creates a new OpenSSL library context.
+
+OPENSSL_CTX_free() frees the given C<ctx>.
+
+=head1 RETURN VALUES
+
+OPENSSL_CTX_new() return a library context pointer on success, or
+C<NULL> on error.
+
+OPENSSL_CTX_free() doesn't return any value.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OPENSSL_CTX.pod
+++ b/doc/man3/OPENSSL_CTX.pod
@@ -8,6 +8,8 @@ OPENSSL_CTX, OPENSSL_CTX_new, OPENSSL_CTX_free - OpenSSL library context
 
  #include <openssl/crypto.h>
 
+ typedef struct openssl_ctx_st OPENSSL_CTX;
+
  OPENSSL_CTX *OPENSSL_CTX_new(void);
  void OPENSSL_CTX_free(OPENSSL_CTX *ctx);
 

--- a/doc/man3/OPENSSL_CTX.pod
+++ b/doc/man3/OPENSSL_CTX.pod
@@ -29,6 +29,11 @@ C<NULL> on error.
 
 OPENSSL_CTX_free() doesn't return any value.
 
+=head1 HISTORY
+
+OPENSSL_CTX, OPENSSL_CTX_new() and OPENSSL_CTX_free()
+were added in OpenSSL 3.0.0.
+
 =head1 COPYRIGHT
 
 Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -95,4 +95,13 @@ uint32_t OPENSSL_rdtsc(void);
 size_t OPENSSL_instrument_bus(unsigned int *, size_t);
 size_t OPENSSL_instrument_bus2(unsigned int *, size_t, size_t);
 
+typedef struct openssl_ctx_method {
+    void *(*new_func)(void);
+    void (*free_func)(void *);
+} OPENSSL_CTX_METHOD;
+/* For each type of data to store in the context, an index must be created */
+int openssl_ctx_new_index(const OPENSSL_CTX_METHOD *);
+/* Functions to retrieve pointers to data by index */
+void *openssl_ctx_get_data(OPENSSL_CTX *, int /* index */);
+
 #endif

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -107,7 +107,8 @@ DEFINE_STACK_OF(void)
 # define CRYPTO_EX_INDEX_APP             13
 # define CRYPTO_EX_INDEX_UI_METHOD       14
 # define CRYPTO_EX_INDEX_DRBG            15
-# define CRYPTO_EX_INDEX__COUNT          16
+# define CRYPTO_EX_INDEX_OPENSSL_CTX     16
+# define CRYPTO_EX_INDEX__COUNT          17
 
 /* No longer needed, so this is a no-op */
 #define OPENSSL_malloc_init() while(0) continue
@@ -450,6 +451,8 @@ int CRYPTO_THREAD_cleanup_local(CRYPTO_THREAD_LOCAL *key);
 CRYPTO_THREAD_ID CRYPTO_THREAD_get_current_id(void);
 int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b);
 
+OPENSSL_CTX *OPENSSL_CTX_new(void);
+void OPENSSL_CTX_free(OPENSSL_CTX *);
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -187,6 +187,10 @@ int CRYPTO_dup_ex_data(int class_index, CRYPTO_EX_DATA *to,
 
 void CRYPTO_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad);
 
+/* Allocate a single item in the CRYPTO_EX_DATA variable */
+int CRYPTO_alloc_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad,
+                         int idx);
+
 /*
  * Get/set data in a CRYPTO_EX_DATA variable corresponding to a particular
  * index (relative to the class type involved)

--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -179,6 +179,8 @@ typedef struct ct_policy_eval_ctx_st CT_POLICY_EVAL_CTX;
 typedef struct ossl_store_info_st OSSL_STORE_INFO;
 typedef struct ossl_store_search_st OSSL_STORE_SEARCH;
 
+typedef struct openssl_ctx_st OPENSSL_CTX;
+
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
     defined(INTMAX_MAX) && defined(UINTMAX_MAX)
 typedef intmax_t ossl_intmax_t;

--- a/test/build.info
+++ b/test/build.info
@@ -561,7 +561,7 @@ IF[{- !$disabled{tests} -}]
 
   PROGRAMS{noinst}=context_internal_test
   SOURCE[context_internal_test]=context_internal_test.c
-  INCLUDE[context_internal_test]=../include ../apps/include
+  INCLUDE[context_internal_test]=.. ../include ../apps/include
   DEPEND[context_internal_test]=../libcrypto.a libtestutil.a
 ENDIF
 

--- a/test/build.info
+++ b/test/build.info
@@ -561,7 +561,7 @@ IF[{- !$disabled{tests} -}]
 
   PROGRAMS{noinst}=context_internal_test
   SOURCE[context_internal_test]=context_internal_test.c
-  INCLUDE[context_internal_test]=../include
+  INCLUDE[context_internal_test]=../include ../apps/include
   DEPEND[context_internal_test]=../libcrypto.a libtestutil.a
 ENDIF
 

--- a/test/build.info
+++ b/test/build.info
@@ -46,7 +46,8 @@ IF[{- !$disabled{tests} -}]
           recordlentest drbgtest drbg_cavs_test sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest \
-          sysdefaulttest errtest gosttest
+          sysdefaulttest errtest gosttest \
+          context_internal_test
 
   SOURCE[versions]=versions.c
   INCLUDE[versions]=../include ../apps/include
@@ -557,6 +558,11 @@ IF[{- !$disabled{tests} -}]
   SOURCE[gosttest]=gosttest.c ssltestlib.c
   INCLUDE[gosttest]=../include ../apps/include ..
   DEPEND[gosttest]=../libcrypto ../libssl libtestutil.a
+
+  PROGRAMS{noinst}=context_internal_test
+  SOURCE[context_internal_test]=context_internal_test.c
+  INCLUDE[context_internal_test]=../include
+  DEPEND[context_internal_test]=../libcrypto.a libtestutil.a
 ENDIF
 
 {-

--- a/test/context_internal_test.c
+++ b/test/context_internal_test.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Internal tests for the OpenSSL library context */
+
+#include "internal/cryptlib.h"
+#include "testutil.h"
+
+/*
+ * Everything between BEGIN EXAMPLE and END EXAMPLE is copied from
+ * doc/internal/man3/openssl_ctx_get_data.pod
+ */
+
+/*
+ * ======================================================================
+ * BEGIN EXAMPLE
+ */
+
+/* The index will always be entirely global, and dynamically allocated */
+static int foo_index = -1;
+
+typedef struct foo_st {
+    int i;
+    void *data;
+} FOO;
+
+static void *foo_new(void)
+{
+    FOO *ptr = OPENSSL_zalloc(sizeof(*ptr));
+    if (ptr != NULL)
+        ptr->i = 42;
+    return ptr;
+}
+static void foo_free(void *ptr)
+{
+    OPENSSL_free(ptr);
+}
+static const OPENSSL_CTX_METHOD foo_method = {
+    foo_new,
+    foo_free
+};
+
+static int foo_init(void) {
+    foo_index = openssl_ctx_new_index(&foo_method);
+
+    return foo_index != -1;
+}
+
+/*
+ * END EXAMPLE
+ * ======================================================================
+ */
+
+static int test_context(OPENSSL_CTX *ctx)
+{
+    FOO *data = NULL;
+
+    return (TEST_ptr(data = openssl_ctx_get_data(ctx, foo_index))
+            /* OPENSSL_zalloc in foo_new() initialized it to zero */
+            && TEST_int_eq(data->i, 42));
+}
+
+static int test_app_context(void)
+{
+    OPENSSL_CTX *ctx = NULL;
+    int result = (TEST_ptr(ctx = OPENSSL_CTX_new()) && test_context(ctx));
+
+    OPENSSL_CTX_free(ctx);
+    return result;
+}
+
+static int test_def_context(void)
+{
+    return test_context(NULL);
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(foo_init);
+    ADD_TEST(test_app_context);
+    ADD_TEST(test_def_context);
+    return 1;
+}

--- a/test/exdatatest.c
+++ b/test/exdatatest.c
@@ -18,6 +18,7 @@ static long saved_argl;
 static void *saved_argp;
 static int saved_idx;
 static int saved_idx2;
+static int saved_idx3;
 static int gbl_result;
 
 /*
@@ -71,12 +72,13 @@ static void exnew2(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
           int idx, long argl, void *argp)
 {
     MYOBJ_EX_DATA *ex_data = OPENSSL_zalloc(sizeof(*ex_data));
-    if (!TEST_int_eq(idx, saved_idx2)
+
+    if (!TEST_true(idx == saved_idx2 || idx == saved_idx3)
         || !TEST_long_eq(argl, saved_argl)
         || !TEST_ptr_eq(argp, saved_argp)
         || !TEST_ptr_null(ptr)
         || !TEST_ptr(ex_data)
-        || !TEST_true(CRYPTO_set_ex_data(ad, saved_idx2, ex_data))) {
+        || !TEST_true(CRYPTO_set_ex_data(ad, idx, ex_data))) {
         gbl_result = 0;
         OPENSSL_free(ex_data);
     } else {
@@ -88,13 +90,14 @@ static int exdup2(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
           void *from_d, int idx, long argl, void *argp)
 {
     MYOBJ_EX_DATA **update_ex_data = (MYOBJ_EX_DATA**)from_d;
-    MYOBJ_EX_DATA *ex_data = CRYPTO_get_ex_data(to, saved_idx2);
-    if (!TEST_int_eq(idx, saved_idx2)
+    MYOBJ_EX_DATA *ex_data = NULL;
+
+    if (!TEST_true(idx == saved_idx2 || idx == saved_idx3)
         || !TEST_long_eq(argl, saved_argl)
         || !TEST_ptr_eq(argp, saved_argp)
         || !TEST_ptr(from_d)
         || !TEST_ptr(*update_ex_data)
-        || !TEST_ptr(ex_data)
+        || !TEST_ptr(ex_data = CRYPTO_get_ex_data(to, idx))
         || !TEST_true(ex_data->new)) {
         gbl_result = 0;
     } else {
@@ -111,14 +114,14 @@ static int exdup2(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
 static void exfree2(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
             int idx, long argl, void *argp)
 {
-    MYOBJ_EX_DATA *ex_data = CRYPTO_get_ex_data(ad, saved_idx2);
-    OPENSSL_free(ex_data);
-    if (!TEST_int_eq(idx, saved_idx2)
+    MYOBJ_EX_DATA *ex_data = CRYPTO_get_ex_data(ad, idx);
+
+    if (!TEST_true(idx == saved_idx2 || idx == saved_idx3)
         || !TEST_long_eq(argl, saved_argl)
         || !TEST_ptr_eq(argp, saved_argp)
-        || !TEST_ptr(ex_data)
-        || !TEST_true(CRYPTO_set_ex_data(ad, saved_idx2, NULL)))
+        || !TEST_true(CRYPTO_set_ex_data(ad, idx, NULL)))
         gbl_result = 0;
+    OPENSSL_free(ex_data);
 }
 
 typedef struct myobj_st {
@@ -152,6 +155,7 @@ static char *MYOBJ_gethello(MYOBJ *obj)
 static void MYOBJ_sethello2(MYOBJ *obj, char *cp)
 {
     MYOBJ_EX_DATA* ex_data = CRYPTO_get_ex_data(&obj->ex_data, saved_idx2);
+
     if (TEST_ptr(ex_data))
         ex_data->hello = cp;
     else
@@ -161,6 +165,31 @@ static void MYOBJ_sethello2(MYOBJ *obj, char *cp)
 static char *MYOBJ_gethello2(MYOBJ *obj)
 {
     MYOBJ_EX_DATA* ex_data = CRYPTO_get_ex_data(&obj->ex_data, saved_idx2);
+
+    if (TEST_ptr(ex_data))
+        return ex_data->hello;
+
+    obj->st = gbl_result = 0;
+    return NULL;
+}
+
+static void MYOBJ_allochello3(MYOBJ *obj, char *cp)
+{
+    MYOBJ_EX_DATA* ex_data = NULL;
+
+    if (TEST_ptr_null(ex_data = CRYPTO_get_ex_data(&obj->ex_data, saved_idx3))
+        && TEST_true(CRYPTO_alloc_ex_data(CRYPTO_EX_INDEX_APP, obj,
+                                          &obj->ex_data, saved_idx3))
+        && TEST_ptr(ex_data = CRYPTO_get_ex_data(&obj->ex_data, saved_idx3)))
+        ex_data->hello = cp;
+    else
+        obj->st = gbl_result = 0;
+}
+
+static char *MYOBJ_gethello3(MYOBJ *obj)
+{
+    MYOBJ_EX_DATA* ex_data = CRYPTO_get_ex_data(&obj->ex_data, saved_idx3);
+
     if (TEST_ptr(ex_data))
         return ex_data->hello;
 
@@ -207,7 +236,11 @@ static int test_exdata(void)
         return 0;
     if (!TEST_ptr(CRYPTO_get_ex_data(&t1->ex_data, saved_idx2)))
         return 0;
-    if (!TEST_ptr(CRYPTO_get_ex_data(&t2->ex_data, saved_idx2)))
+
+    saved_idx3 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_APP,
+                                         saved_argl, saved_argp,
+                                         exnew2, exdup2, exfree2);
+    if (!TEST_ptr_null(CRYPTO_get_ex_data(&t1->ex_data, saved_idx3)))
         return 0;
 
     MYOBJ_sethello(t1, p);
@@ -217,6 +250,11 @@ static int test_exdata(void)
 
     MYOBJ_sethello2(t1, p);
     cp = MYOBJ_gethello2(t1);
+    if (!TEST_ptr_eq(cp, p))
+        return 0;
+
+    MYOBJ_allochello3(t1, p);
+    cp = MYOBJ_gethello3(t1);
     if (!TEST_ptr_eq(cp, p))
         return 0;
 
@@ -243,6 +281,10 @@ static int test_exdata(void)
         return 0;
 
     cp = MYOBJ_gethello2(t3);
+    if (!TEST_ptr_eq(cp, p))
+        return 0;
+
+    cp = MYOBJ_gethello3(t3);
     if (!TEST_ptr_eq(cp, p))
         return 0;
 

--- a/test/exdatatest.c
+++ b/test/exdatatest.c
@@ -237,6 +237,10 @@ static int test_exdata(void)
     if (!TEST_ptr(CRYPTO_get_ex_data(&t1->ex_data, saved_idx2)))
         return 0;
 
+    /*
+     * saved_idx3 differs from other indexes by being created after the exdata
+     * was initialized.
+     */
     saved_idx3 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_APP,
                                          saved_argl, saved_argp,
                                          exnew2, exdup2, exfree2);

--- a/test/recipes/02-test_internal_context.t
+++ b/test/recipes/02-test_internal_context.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;              # get 'plan'
+use OpenSSL::Test::Simple;
+use OpenSSL::Test::Utils;
+
+setup("test_internal_context");
+
+simple_test("test_internal_context", "context_internal_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4639,3 +4639,5 @@ EVP_KDF_vctrl                           4594	3_0_0	EXIST::FUNCTION:
 EVP_KDF_ctrl_str                        4595	3_0_0	EXIST::FUNCTION:
 EVP_KDF_size                            4596	3_0_0	EXIST::FUNCTION:
 EVP_KDF_derive                          4597	3_0_0	EXIST::FUNCTION:
+OPENSSL_CTX_new                         4598	3_0_0	EXIST::FUNCTION:
+OPENSSL_CTX_free                        4599	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4641,3 +4641,4 @@ EVP_KDF_size                            4596	3_0_0	EXIST::FUNCTION:
 EVP_KDF_derive                          4597	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_new                         4598	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_free                        4599	3_0_0	EXIST::FUNCTION:
+CRYPTO_alloc_ex_data                    4600	3_0_0	EXIST::FUNCTION:

--- a/util/private.num
+++ b/util/private.num
@@ -30,6 +30,7 @@ EVP_PKEY_METHOD                         datatype
 EVP_PKEY_ASN1_METHOD                    datatype
 GEN_SESSION_CB                          datatype
 OPENSSL_Applink                         external
+OPENSSL_CTX                             datatype
 NAMING_AUTHORITY                        datatype
 OSSL_STORE_CTX                          datatype
 OSSL_STORE_INFO                         datatype


### PR DESCRIPTION
The context builds on CRYPTO_EX_DATA, allowing it to be dynamically
extended with new data from the different parts of libcrypto.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
