### PR TITLE
[test] ASN1 BIGNUM encoding can expand the byte length by 1

### DIFF
--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -272,7 +272,7 @@ static int test_builtin(void)
             goto builtin_err;
 
         /* create signature */
-        sig_len = ECDSA_size(eckey);
+        sig_len = ECDSA_size(eckey)+2;
         if (!TEST_ptr(signature = OPENSSL_malloc(sig_len))
                 || !TEST_true(ECDSA_sign(0, digest, SHA512_DIGEST_LENGTH,
                                          signature, &sig_len, eckey)))

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -344,6 +344,8 @@ static int test_builtin(void)
             goto builtin_err;
         }
         sig_ptr2 = signature;
+        if (!TEST_int_le(i2d_ECDSA_SIG(modified_sig, NULL), ECDSA_size(eckey)+2))
+            goto builtin_err;
         sig_len = i2d_ECDSA_SIG(modified_sig, &sig_ptr2);
         if (!TEST_false(ECDSA_verify(0, digest, SHA512_DIGEST_LENGTH,
                                      signature, sig_len, eckey)))
@@ -362,6 +364,8 @@ static int test_builtin(void)
         }
 
         sig_ptr2 = signature;
+        if (!TEST_int_le(i2d_ECDSA_SIG(modified_sig, NULL), ECDSA_size(eckey)+2))
+            goto builtin_err;
         sig_len = i2d_ECDSA_SIG(modified_sig, &sig_ptr2);
         if (!TEST_true(ECDSA_verify(0, digest, SHA512_DIGEST_LENGTH,
                                     signature, sig_len, eckey)))


### PR DESCRIPTION
Fixes #8209 .

Here is the assert that caches it:

```
diff --git a/test/ecdsatest.c b/test/ecdsatest.c
index 004f39eb5b..9e89c225f9 100644
--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -344,6 +344,8 @@ static int test_builtin(void)
             goto builtin_err;
         }
         sig_ptr2 = signature;
+#include <assert.h>
+assert(i2d_ECDSA_SIG(modified_sig, NULL) <= ECDSA_size(eckey));
         sig_len = i2d_ECDSA_SIG(modified_sig, &sig_ptr2);
         if (!TEST_false(ECDSA_verify(0, digest, SHA512_DIGEST_LENGTH,
                                      signature, sig_len, eckey)))
```

While `sig_ptr2` points to an `ECDSA_size(eckey)` length buffer, i.e. "max" ECDSA signature size, when the test mucks with the BIGNUM bytes in `raw_buff` it can push `r` or `s` beyond that "max" because ... ASN1. Or is it DER. One of those.

It takes `ecdsatest` a minute or two to hit the assert.

To test the test, I changed the assert to

    assert(i2d_ECDSA_SIG(modified_sig, NULL) <= ECDSA_size(eckey)+2);

and it's been running half an hour or so just fine. _shrug_.

Tagging @paulidale @mattcaswell 