### PR TITLE
Configure: stop forcing use of DEFINE macros in headers

### DIFF
--- a/Configure
+++ b/Configure
@@ -145,6 +145,8 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 #       -Wlanguage-extension-token -- no, we use asm()
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
+#       -Wunused-function -- no, it forces header use of safestack et al
+#                            DEFINE macros
 my $clang_devteam_warn = ""
         . " -Wswitch-default"
         . " -Wno-parentheses-equality"
@@ -154,6 +156,7 @@ my $clang_devteam_warn = ""
         . " -Wincompatible-pointer-types-discards-qualifiers"
         . " -Wmissing-variable-declarations"
         . " -Wno-unknown-warning-option"
+        . " -Wno-unused-function"
         ;
 
 # This adds backtrace information to the memory leak info.  Is only used


### PR DESCRIPTION
There are times when one might want to use something like
DEFINE_STACK_OF in a .c file, because it defines a stack for a type
defined in that .c file.  Unfortunately, when configuring with
`--strict-warnings`, clang aggressively warn about unused functions in
such cases, which forces the use of such DEFINE macros to header
files.

We therefore disable this warning from the `--strict-warnings`
definition for clang.

(note for the curious: `-Wunused-function` is enabled via `-Wall`)
