### PR TITLE
Configure: make --strict-warnings a regular user provided compiler option

### DIFF
--- a/Configure
+++ b/Configure
@@ -752,7 +752,11 @@ while (@argvcopy)
 		}
 	elsif (/^--strict-warnings$/)
 		{
-		$strict_warnings = 1;
+		# Pretend that our strict flags is a C flag, and replace it
+		# with the proper flags later on
+		push @{$useradd{CFLAGS}}, '--ossl-strict-warnings';
+		push @{$useradd{CXXFLAGS}}, '--ossl-strict-warnings';
+		$strict_warnings=1;
 		}
 	elsif (/^--debug$/)
 		{
@@ -1503,6 +1507,7 @@ $config{openssl_api_defines} = [
     "OPENSSL_MIN_API=".($apitable->{$config{api} // ""} // -1)
 ];
 
+my @strict_warnings_collection=();
 if ($strict_warnings)
 	{
 	my $wopt;
@@ -1510,26 +1515,17 @@ if ($strict_warnings)
 
 	die "ERROR --strict-warnings requires gcc[>=4] or gcc-alike"
             unless $gccver >= 4;
-	foreach $wopt (split /\s+/, $gcc_devteam_warn)
-		{
-		push @{$config{cflags}}, $wopt
-			unless grep { $_ eq $wopt } @{$config{cflags}};
-		push @{$config{cxxflags}}, $wopt
-			if ($config{CXX}
-			    && !grep { $_ eq $wopt } @{$config{cxxflags}});
-		}
-	if (defined($predefined{__clang__}))
-		{
-		foreach $wopt (split /\s+/, $clang_devteam_warn)
-			{
-			push @{$config{cflags}}, $wopt
-				unless grep { $_ eq $wopt } @{$config{cflags}};
-			push @{$config{cxxflags}}, $wopt
-				if ($config{CXX}
-				    && !grep { $_ eq $wopt } @{$config{cxxflags}});
-			}
-		}
+	push @strict_warnings_collection, (split /\s+/, $gcc_devteam_warn);
+	push @strict_warnings_collection, (split /\s+/, $clang_devteam_warn)
+		if (defined($predefined{__clang__}));
 	}
+foreach (qw(CFLAGS CXXFLAGS))
+        {
+        $useradd{$_} = [ map { $_ eq '--ossl-strict-warnings'
+                                  ? @strict_warnings_collection
+                                  : ( $_ ) }
+                            @{$useradd{$_}} ];
+        }
 
 unless ($disabled{"crypto-mdebug-backtrace"})
 	{


### PR DESCRIPTION
This makes `--strict-warnings` into a compiler pseudo-option, i.e. it
gets treated the same way as any other compiler option given on the
configuration command line, but is retroactively replaced by actual
compiler warning options, depending on what compiler is used.

This makes it easier to see in what order options are given to the
compiler from the configuration command line, i.e. this:

    ./config -Wall --strict-warnings

would give the compiler flags in the same order as they're given,
i.e.:

    -Wall -Werror -Wno-whatever ...

instead of what we got previously:

    -Werror -Wno-whatever ... -Wall
