### PR TITLE
'several known bug' -> 'several known bug[s]'

### DIFF
--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -542,7 +542,7 @@ OpenSSL was built.
 
 =item B<-bugs>
 
-There are several known bug in SSL and TLS implementations. Adding this
+There are several known bugs in SSL and TLS implementations. Adding this
 option enables various workarounds.
 
 =item B<-no_comp>


### PR DESCRIPTION
Correct a trivial grammatical error -- singular vs. plural -- in the `s_server` man page.

##### Checklist
- [x] documentation is added or updated
