### PR TITLE
apps/speed: fix segfault while looking up algorithm name

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -537,7 +537,6 @@ static const OPT_PAIR ecdh_choices[] = {
     {"ecdhb409", R_EC_B409},
     {"ecdhb571", R_EC_B571},
     {"ecdhx25519", R_EC_X25519},
-    {NULL}
 };
 # define EC_NUM       OSSL_NELEM(ecdh_choices)
 


### PR DESCRIPTION
The backport of master commit 5c6a69f539a (apps/speed: fix possible OOB
access in some EC arrays) as 1.1.0 commit 4e07941373a introduced a
regression.  The ecdh_choices array is iterated using an element count
but is NULL terminated.  This means that running 'openssl speed somealgo'
will result in a segfault when opt_found hits the NULL entry.

Fixes #8243

CLA: trivial

Signed-off-by: Jeff Mahoney <jeffm@suse.com>
