### PR TITLE
Mark generated functions unused (applies to safestack, lhash, sparse_array)

### DIFF
--- a/crypto/include/internal/sparse_array.h
+++ b/crypto/include/internal/sparse_array.h
@@ -11,6 +11,8 @@
 #ifndef HEADER_SPARSE_ARRAY_H
 # define HEADER_SPARSE_ARRAY_H
 
+# include <openssl/e_os2.h>
+
 # ifdef __cplusplus
 extern "C" {
 # endif
@@ -19,43 +21,42 @@ extern "C" {
 
 # define DEFINE_SPARSE_ARRAY_OF(type) \
     SPARSE_ARRAY_OF(type); \
-    static ossl_inline SPARSE_ARRAY_OF(type) * \
+    static ossl_unused ossl_inline SPARSE_ARRAY_OF(type) * \
         ossl_sa_##type##_new(void) \
     { \
         return (SPARSE_ARRAY_OF(type) *)OPENSSL_SA_new(); \
     } \
-    static ossl_inline void ossl_sa_##type##_free(SPARSE_ARRAY_OF(type) *sa) \
+    static ossl_unused ossl_inline void ossl_sa_##type##_free(SPARSE_ARRAY_OF(type) *sa) \
     { \
         OPENSSL_SA_free((OPENSSL_SA *)sa); \
     } \
-    static ossl_inline void ossl_sa_##type##_free_leaves(SPARSE_ARRAY_OF(type) *sa) \
+    static ossl_unused ossl_inline void ossl_sa_##type##_free_leaves(SPARSE_ARRAY_OF(type) *sa) \
     { \
         OPENSSL_SA_free_leaves((OPENSSL_SA *)sa); \
     } \
-    static ossl_inline size_t ossl_sa_##type##_num(const SPARSE_ARRAY_OF(type) *sa) \
+    static ossl_unused ossl_inline size_t ossl_sa_##type##_num(const SPARSE_ARRAY_OF(type) *sa) \
     { \
         return OPENSSL_SA_num((OPENSSL_SA *)sa); \
     } \
-    static ossl_inline void ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) *sa, \
+    static ossl_unused ossl_inline void ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) *sa, \
                                                    void (*leaf)(size_t, type *)) \
     { \
         OPENSSL_SA_doall((OPENSSL_SA *)sa, (void (*)(size_t, void *))leaf); \
     } \
-    static ossl_inline void ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa, \
-                                                       void (*leaf)(size_t, \
-                                                                    type *, \
-						                    void *),\
-                                                       void *arg) \
+    static ossl_unused ossl_inline void \
+    ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa, \
+                               void (*leaf)(size_t, type *, void *), \
+                               void *arg) \
     { \
         OPENSSL_SA_doall_arg((OPENSSL_SA *)sa, (void (*)(size_t, void *, void *))leaf, \
                              arg); \
     } \
-    static ossl_inline type *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, \
+    static ossl_unused ossl_inline type *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, \
                                                   size_t n) \
     { \
         return (type *)OPENSSL_SA_get((OPENSSL_SA *)sa, n); \
     } \
-    static ossl_inline int ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) *sa, \
+    static ossl_unused ossl_inline int ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) *sa, \
                                                 size_t n, type *val) \
     { \
         return OPENSSL_SA_set((OPENSSL_SA *)sa, n, (void *)val); \

--- a/crypto/include/internal/sparse_array.h
+++ b/crypto/include/internal/sparse_array.h
@@ -43,10 +43,10 @@ extern "C" {
     { \
         OPENSSL_SA_doall((OPENSSL_SA *)sa, (void (*)(size_t, void *))leaf); \
     } \
-    static ossl_unused ossl_inline void \
-    ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa, \
-                               void (*leaf)(size_t, type *, void *), \
-                               void *arg) \
+    static ossl_unused ossl_inline \
+    void ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa, \
+                                    void (*leaf)(size_t, type *, void *), \
+                                    void *arg) \
     { \
         OPENSSL_SA_doall_arg((OPENSSL_SA *)sa, (void (*)(size_t, void *, void *))leaf, \
                              arg); \

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -287,6 +287,13 @@ typedef unsigned __int64 uint64_t;
 #  define ossl_noreturn
 # endif
 
+/* ossl_unused: portable unused attribute for use in public headers */
+# if defined(__GNUC__)
+#  define ossl_unused __attribute__((unused))
+# else
+#  define ossl_unused
+# endif
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -127,52 +127,52 @@ void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
         return (LHASH_OF(type) *) \
             OPENSSL_LH_new((OPENSSL_LH_HASHFUNC)hfn, (OPENSSL_LH_COMPFUNC)cfn); \
     } \
-    static ossl_inline void lh_##type##_free(LHASH_OF(type) *lh) \
+    static ossl_unused ossl_inline void lh_##type##_free(LHASH_OF(type) *lh) \
     { \
         OPENSSL_LH_free((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_inline type *lh_##type##_insert(LHASH_OF(type) *lh, type *d) \
+    static ossl_unused ossl_inline type *lh_##type##_insert(LHASH_OF(type) *lh, type *d) \
     { \
         return (type *)OPENSSL_LH_insert((OPENSSL_LHASH *)lh, d); \
     } \
-    static ossl_inline type *lh_##type##_delete(LHASH_OF(type) *lh, const type *d) \
+    static ossl_unused ossl_inline type *lh_##type##_delete(LHASH_OF(type) *lh, const type *d) \
     { \
         return (type *)OPENSSL_LH_delete((OPENSSL_LHASH *)lh, d); \
     } \
-    static ossl_inline type *lh_##type##_retrieve(LHASH_OF(type) *lh, const type *d) \
+    static ossl_unused ossl_inline type *lh_##type##_retrieve(LHASH_OF(type) *lh, const type *d) \
     { \
         return (type *)OPENSSL_LH_retrieve((OPENSSL_LHASH *)lh, d); \
     } \
-    static ossl_inline int lh_##type##_error(LHASH_OF(type) *lh) \
+    static ossl_unused ossl_inline int lh_##type##_error(LHASH_OF(type) *lh) \
     { \
         return OPENSSL_LH_error((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_inline unsigned long lh_##type##_num_items(LHASH_OF(type) *lh) \
+    static ossl_unused ossl_inline unsigned long lh_##type##_num_items(LHASH_OF(type) *lh) \
     { \
         return OPENSSL_LH_num_items((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_inline void lh_##type##_node_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
+    static ossl_unused ossl_inline void lh_##type##_node_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_node_stats_bio((const OPENSSL_LHASH *)lh, out); \
     } \
-    static ossl_inline void lh_##type##_node_usage_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
+    static ossl_unused ossl_inline void lh_##type##_node_usage_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_node_usage_stats_bio((const OPENSSL_LHASH *)lh, out); \
     } \
-    static ossl_inline void lh_##type##_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
+    static ossl_unused ossl_inline void lh_##type##_stats_bio(const LHASH_OF(type) *lh, BIO *out) \
     { \
         OPENSSL_LH_stats_bio((const OPENSSL_LHASH *)lh, out); \
     } \
-    static ossl_inline unsigned long lh_##type##_get_down_load(LHASH_OF(type) *lh) \
+    static ossl_unused ossl_inline unsigned long lh_##type##_get_down_load(LHASH_OF(type) *lh) \
     { \
         return OPENSSL_LH_get_down_load((OPENSSL_LHASH *)lh); \
     } \
-    static ossl_inline void lh_##type##_set_down_load(LHASH_OF(type) *lh, unsigned long dl) \
+    static ossl_unused ossl_inline void lh_##type##_set_down_load(LHASH_OF(type) *lh, unsigned long dl) \
     { \
         OPENSSL_LH_set_down_load((OPENSSL_LHASH *)lh, dl); \
     } \
-    static ossl_inline void lh_##type##_doall(LHASH_OF(type) *lh, \
-                                         void (*doall)(type *)) \
+    static ossl_unused ossl_inline void lh_##type##_doall(LHASH_OF(type) *lh, \
+                                                          void (*doall)(type *)) \
     { \
         OPENSSL_LH_doall((OPENSSL_LHASH *)lh, (OPENSSL_LH_DOALL_FUNC)doall); \
     } \
@@ -185,7 +185,7 @@ void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
     int_implement_lhash_doall(type, argtype, type)
 
 #define int_implement_lhash_doall(type, argtype, cbargtype) \
-    static ossl_inline void \
+    static ossl_unused ossl_inline void \
         lh_##type##_doall_##argtype(LHASH_OF(type) *lh, \
                                    void (*fn)(cbargtype *, argtype *), \
                                    argtype *arg) \

--- a/include/openssl/safestack.h
+++ b/include/openssl/safestack.h
@@ -24,96 +24,96 @@ extern "C" {
     typedef int (*sk_##t1##_compfunc)(const t3 * const *a, const t3 *const *b); \
     typedef void (*sk_##t1##_freefunc)(t3 *a); \
     typedef t3 * (*sk_##t1##_copyfunc)(const t3 *a); \
-    static ossl_inline int sk_##t1##_num(const STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline int sk_##t1##_num(const STACK_OF(t1) *sk) \
     { \
         return OPENSSL_sk_num((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline t2 *sk_##t1##_value(const STACK_OF(t1) *sk, int idx) \
+    static ossl_unused ossl_inline t2 *sk_##t1##_value(const STACK_OF(t1) *sk, int idx) \
     { \
         return (t2 *)OPENSSL_sk_value((const OPENSSL_STACK *)sk, idx); \
     } \
-    static ossl_inline STACK_OF(t1) *sk_##t1##_new(sk_##t1##_compfunc compare) \
+    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_new(sk_##t1##_compfunc compare) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_new((OPENSSL_sk_compfunc)compare); \
     } \
-    static ossl_inline STACK_OF(t1) *sk_##t1##_new_null(void) \
+    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_new_null(void) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_new_null(); \
     } \
-    static ossl_inline STACK_OF(t1) *sk_##t1##_new_reserve(sk_##t1##_compfunc compare, int n) \
+    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_new_reserve(sk_##t1##_compfunc compare, int n) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_new_reserve((OPENSSL_sk_compfunc)compare, n); \
     } \
-    static ossl_inline int sk_##t1##_reserve(STACK_OF(t1) *sk, int n) \
+    static ossl_unused ossl_inline int sk_##t1##_reserve(STACK_OF(t1) *sk, int n) \
     { \
         return OPENSSL_sk_reserve((OPENSSL_STACK *)sk, n); \
     } \
-    static ossl_inline void sk_##t1##_free(STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline void sk_##t1##_free(STACK_OF(t1) *sk) \
     { \
         OPENSSL_sk_free((OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline void sk_##t1##_zero(STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline void sk_##t1##_zero(STACK_OF(t1) *sk) \
     { \
         OPENSSL_sk_zero((OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline t2 *sk_##t1##_delete(STACK_OF(t1) *sk, int i) \
+    static ossl_unused ossl_inline t2 *sk_##t1##_delete(STACK_OF(t1) *sk, int i) \
     { \
         return (t2 *)OPENSSL_sk_delete((OPENSSL_STACK *)sk, i); \
     } \
-    static ossl_inline t2 *sk_##t1##_delete_ptr(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused ossl_inline t2 *sk_##t1##_delete_ptr(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return (t2 *)OPENSSL_sk_delete_ptr((OPENSSL_STACK *)sk, \
                                            (const void *)ptr); \
     } \
-    static ossl_inline int sk_##t1##_push(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused ossl_inline int sk_##t1##_push(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_push((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_inline int sk_##t1##_unshift(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused ossl_inline int sk_##t1##_unshift(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_unshift((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_inline t2 *sk_##t1##_pop(STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline t2 *sk_##t1##_pop(STACK_OF(t1) *sk) \
     { \
         return (t2 *)OPENSSL_sk_pop((OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline t2 *sk_##t1##_shift(STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline t2 *sk_##t1##_shift(STACK_OF(t1) *sk) \
     { \
         return (t2 *)OPENSSL_sk_shift((OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline void sk_##t1##_pop_free(STACK_OF(t1) *sk, sk_##t1##_freefunc freefunc) \
+    static ossl_unused ossl_inline void sk_##t1##_pop_free(STACK_OF(t1) *sk, sk_##t1##_freefunc freefunc) \
     { \
         OPENSSL_sk_pop_free((OPENSSL_STACK *)sk, (OPENSSL_sk_freefunc)freefunc); \
     } \
-    static ossl_inline int sk_##t1##_insert(STACK_OF(t1) *sk, t2 *ptr, int idx) \
+    static ossl_unused ossl_inline int sk_##t1##_insert(STACK_OF(t1) *sk, t2 *ptr, int idx) \
     { \
         return OPENSSL_sk_insert((OPENSSL_STACK *)sk, (const void *)ptr, idx); \
     } \
-    static ossl_inline t2 *sk_##t1##_set(STACK_OF(t1) *sk, int idx, t2 *ptr) \
+    static ossl_unused ossl_inline t2 *sk_##t1##_set(STACK_OF(t1) *sk, int idx, t2 *ptr) \
     { \
         return (t2 *)OPENSSL_sk_set((OPENSSL_STACK *)sk, idx, (const void *)ptr); \
     } \
-    static ossl_inline int sk_##t1##_find(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused ossl_inline int sk_##t1##_find(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_find((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_inline int sk_##t1##_find_ex(STACK_OF(t1) *sk, t2 *ptr) \
+    static ossl_unused ossl_inline int sk_##t1##_find_ex(STACK_OF(t1) *sk, t2 *ptr) \
     { \
         return OPENSSL_sk_find_ex((OPENSSL_STACK *)sk, (const void *)ptr); \
     } \
-    static ossl_inline void sk_##t1##_sort(STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline void sk_##t1##_sort(STACK_OF(t1) *sk) \
     { \
         OPENSSL_sk_sort((OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline int sk_##t1##_is_sorted(const STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline int sk_##t1##_is_sorted(const STACK_OF(t1) *sk) \
     { \
         return OPENSSL_sk_is_sorted((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline STACK_OF(t1) * sk_##t1##_dup(const STACK_OF(t1) *sk) \
+    static ossl_unused ossl_inline STACK_OF(t1) * sk_##t1##_dup(const STACK_OF(t1) *sk) \
     { \
         return (STACK_OF(t1) *)OPENSSL_sk_dup((const OPENSSL_STACK *)sk); \
     } \
-    static ossl_inline STACK_OF(t1) *sk_##t1##_deep_copy(const STACK_OF(t1) *sk, \
+    static ossl_unused ossl_inline STACK_OF(t1) *sk_##t1##_deep_copy(const STACK_OF(t1) *sk, \
                                                     sk_##t1##_copyfunc copyfunc, \
                                                     sk_##t1##_freefunc freefunc) \
     { \
@@ -121,7 +121,7 @@ extern "C" {
                                             (OPENSSL_sk_copyfunc)copyfunc, \
                                             (OPENSSL_sk_freefunc)freefunc); \
     } \
-    static ossl_inline sk_##t1##_compfunc sk_##t1##_set_cmp_func(STACK_OF(t1) *sk, sk_##t1##_compfunc compare) \
+    static ossl_unused ossl_inline sk_##t1##_compfunc sk_##t1##_set_cmp_func(STACK_OF(t1) *sk, sk_##t1##_compfunc compare) \
     { \
         return (sk_##t1##_compfunc)OPENSSL_sk_set_cmp_func((OPENSSL_STACK *)sk, (OPENSSL_sk_compfunc)compare); \
     }


### PR DESCRIPTION
safestack.h, lhash.h and sparse_array.h all define macros to generate
a full API for the containers as static inline functions.  This
potentially generates unused code, which some compilers may complain
about.

We therefore need to mark those generated functions as unused, so the
compiler knows that we know, and stops complaining about it.
