### PR TITLE
Revert "Configure: stop forcing use of DEFINE macros in headers"

### DIFF
--- a/Configure
+++ b/Configure
@@ -145,8 +145,6 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 #       -Wlanguage-extension-token -- no, we use asm()
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
-#       -Wunused-function -- no, it forces header use of safestack et al
-#                            DEFINE macros
 my $clang_devteam_warn = ""
         . " -Wswitch-default"
         . " -Wno-parentheses-equality"
@@ -156,7 +154,6 @@ my $clang_devteam_warn = ""
         . " -Wincompatible-pointer-types-discards-qualifiers"
         . " -Wmissing-variable-declarations"
         . " -Wno-unknown-warning-option"
-        . " -Wno-unused-function"
         ;
 
 # This adds backtrace information to the memory leak info.  Is only used


### PR DESCRIPTION
Github PR #8246 provides a better solution to the problem.

This reverts commit f11ffa505f8a9345145a26a05bf77b012b6941bd.
