### PR TITLE
cygwin: drop explicit O_TEXT [master & 1.1.1]

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -253,9 +253,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
             }
 #  elif defined(OPENSSL_SYS_WIN32_CYGWIN)
             int fd = fileno((FILE *)ptr);
-            if (num & BIO_FP_TEXT)
-                setmode(fd, O_TEXT);
-            else
+            if (!(num & BIO_FP_TEXT))
                 setmode(fd, O_BINARY);
 #  endif
         }
@@ -279,11 +277,14 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = 0;
             break;
         }
-#  if defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32_CYGWIN)
+#  if defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_WINDOWS)
         if (!(num & BIO_FP_TEXT))
             OPENSSL_strlcat(p, "b", sizeof(p));
         else
             OPENSSL_strlcat(p, "t", sizeof(p));
+#  elif defined(OPENSSL_SYS_WIN32_CYGWIN)
+        if (!(num & BIO_FP_TEXT))
+            OPENSSL_strlcat(p, "b", sizeof(p));
 #  endif
         fp = openssl_fopen(ptr, p);
         if (fp == NULL) {


### PR DESCRIPTION
Cygwin binaries should not enforce text mode these days, just
use text mode if the underlying mount point requests it

Signed-off-by: Corinna Vinschen <vinschen@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
