### PR TITLE
cygwin: drop explicit O_TEXT [1.0.2]

### DIFF
--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -361,11 +361,15 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
                 } else
                     _setmode(fd, _O_BINARY);
             }
-#  elif defined(OPENSSL_SYS_OS2) || defined(OPENSSL_SYS_WIN32_CYGWIN)
+#  elif defined(OPENSSL_SYS_OS2)
             int fd = fileno((FILE *)ptr);
             if (num & BIO_FP_TEXT)
                 setmode(fd, O_TEXT);
             else
+                setmode(fd, O_BINARY);
+#  elif defined(OPENSSL_SYS_WIN32_CYGWIN)
+            int fd = fileno((FILE *)ptr);
+            if (!(num & BIO_FP_TEXT))
                 setmode(fd, O_BINARY);
 #  endif
         }
@@ -389,11 +393,14 @@ static long MS_CALLBACK file_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = 0;
             break;
         }
-#  if defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_OS2) || defined(OPENSSL_SYS_WIN32_CYGWIN)
+#  if defined(OPENSSL_SYS_MSDOS) || defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_OS2)
         if (!(num & BIO_FP_TEXT))
             strcat(p, "b");
         else
             strcat(p, "t");
+#  elif defined(OPENSSL_SYS_WIN32_CYGWIN)
+        if (!(num & BIO_FP_TEXT))
+            strcat(p, "b");
 #  endif
 #  if defined(OPENSSL_SYS_NETWARE)
         if (!(num & BIO_FP_TEXT))


### PR DESCRIPTION
Cygwin binaries should not enforce text mode these days, just
use text mode if the underlying mount point requests it

Signed-off-by: Corinna Vinschen <vinschen@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
