### PR TITLE
Fix seeding from random device w/o getrandom syscall

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include "internal/dso.h"
 #if defined(__linux)
-# include <sys/syscall.h>
+# include <asm/unistd.h>
 #endif
 #if defined(__FreeBSD__)
 # include <sys/types.h>
@@ -324,8 +324,8 @@ static ssize_t syscall_random(void *buf, size_t buflen)
 #  endif
 
     /* Linux supports this since version 3.17 */
-#  if defined(__linux) && defined(SYS_getrandom)
-    return syscall(SYS_getrandom, buf, buflen, 0);
+#  if defined(__linux) && defined(__NR_getrandom)
+    return syscall(__NR_getrandom, buf, buflen, 0);
 #  elif (defined(__FreeBSD__) || defined(__NetBSD__)) && defined(KERN_ARND)
     return sysctl_random(buf, buflen);
 #  else
@@ -510,6 +510,24 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
     bytes_needed = rand_pool_bytes_needed(pool, 1 /*entropy_factor*/);
     {
         size_t i;
+#ifdef DEVRANDOM_WAIT
+        static int wait_done = 0;
+
+        if (!wait_done && bytes_needed > 0) {
+             int f = open(DEVRANDOM_WAIT, O_RDONLY);
+
+             if (f >= 0) {
+                 fd_set fds;
+
+                 FD_ZERO(&fds);
+                 FD_SET(f, &fds);
+                 while (select(f+1, &fds, NULL, NULL, NULL) < 0
+                        && errno == EINTR);
+                 close(f);
+                 wait_done = 1;
+             }
+        }
+#endif
 
         for (i = 0; bytes_needed > 0 && i < OSSL_NELEM(random_device_paths); i++) {
             ssize_t bytes = 0;

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -514,13 +514,9 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
         static int wait_done = 0;
 
         /*
-         * Ideally we would always pull entropy out of /dev/random,
-         * but that would quickly start to block if many prcesses
-         * compete for entropy. On the other hand, /dev/urandom
-         * is not guaranteed to be properly seeded when used too
-         * early after boot. So we use select to wait for /dev/random
-         * to be in readable state but do not read anything out of
-         * /dev/random. This has to be done only once.
+         * On some implementations reading from /dev/urandom is possible
+         * before it is initialized. Therefore we wait for /dev/random
+         * to be readable to make sure /dev/urandom is initialized.
          */
         if (!wait_done && bytes_needed > 0) {
              int f = open(DEVRANDOM_WAIT, O_RDONLY);

--- a/e_os.h
+++ b/e_os.h
@@ -27,11 +27,8 @@
  * set this to a comma-separated list of 'random' device files to try out. By
  * default, we will try to read at least one of these files
  */
-#  if defined(__s390__)
-#   define DEVRANDOM "/dev/prandom","/dev/urandom","/dev/hwrng","/dev/random"
-#  else
-#   define DEVRANDOM "/dev/urandom","/dev/random","/dev/srandom"
-#  endif
+#  define DEVRANDOM "/dev/urandom", "/dev/random","/dev/hwrng", "/dev/srandom"
+#  define DEVRANDOM_WAIT "/dev/random"
 # endif
 # if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
 /*

--- a/e_os.h
+++ b/e_os.h
@@ -27,7 +27,7 @@
  * set this to a comma-separated list of 'random' device files to try out. By
  * default, we will try to read at least one of these files
  */
-#  define DEVRANDOM "/dev/urandom", "/dev/random","/dev/hwrng", "/dev/srandom"
+#  define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
 #  define DEVRANDOM_WAIT "/dev/random"
 # endif
 # if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
@@ -36,7 +36,7 @@
  * sockets will be tried in the order listed in case accessing the device
  * files listed in DEVRANDOM did not return enough randomness.
  */
-#  define DEVRANDOM_EGD "/var/run/egd-pool","/dev/egd-pool","/etc/egd-pool","/etc/entropy"
+#  define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
 # endif
 
 # if defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)


### PR DESCRIPTION
Use select to wait for /dev/random in readable state,
but do not actually read anything from /dev/random,
use /dev/urandom first.

Use linux define __NR_getrandom instead of the
glibc define SYS_getrandom, in case the kernel headers
are more current than the glibc headers.

Fixes #8215

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
