### PR TITLE
s390x assembly pack: fix formal interface bug in chacha module

### DIFF
--- a/crypto/chacha/asm/chacha-s390x.pl
+++ b/crypto/chacha/asm/chacha-s390x.pl
@@ -225,7 +225,7 @@ LABEL	("ChaCha20_ctr32");
 	larl	("%r1","OPENSSL_s390xcap_P");
 
 	lghi	("%r0",64);
-&{$z?	\&cgr:\&cr}	($len,"%r0");
+&{$z?	\&clgr:\&clr}	($len,"%r0");
 	jle	("_s390x_chacha_novx");
 
 	lg	("%r0","S390X_STFLE+16(%r1)");


### PR DESCRIPTION
size_t is an unsigned type. Well, *formal bug* because it only affects message lenghts exceeding 2^63-1 bytes, which is impossible.

edit: thanks @dot-asm for reporting.