### PR TITLE
Fix a test ordering issue.

### DIFF
--- a/test/property_test.c
+++ b/test/property_test.c
@@ -45,7 +45,7 @@ static int test_property_string(void)
         && TEST_int_ne(i, j)
         && TEST_int_eq(ossl_property_value("yes", 1), j)
         && TEST_int_eq(ossl_property_value("no", 1), i)
-        && TEST_int_ne(i = ossl_property_value("green", 1), 0)
+        && TEST_int_ne(i = ossl_property_value("illuminati", 1), 0)
         && TEST_int_eq(j = ossl_property_value("fnord", 1), i + 1)
         && TEST_int_eq(ossl_property_value("fnord", 1), j)
         /* Check name and values are distinct */


### PR DESCRIPTION
A randomised order causes failure due to unintentional dependencies between
two of the test cases.

Fixes #8276

- [x] tests are added or updated

