### PR TITLE
cfi build fixes in x86-64 ghash assembly

### DIFF
--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -1155,6 +1155,7 @@ ___
 } else {
 $code.=<<___;
 	jmp	.L_init_clmul
+.cfi_endproc
 .size	gcm_init_avx,.-gcm_init_avx
 ___
 }
@@ -1594,6 +1595,7 @@ ___
 } else {
 $code.=<<___;
 	jmp	.L_ghash_clmul
+.cfi_endproc
 .size	gcm_ghash_avx,.-gcm_ghash_avx
 ___
 }


### PR DESCRIPTION
There were some 'else' branch paths that were missing .cfi_endproc 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
