### PR TITLE
Fix reference to symbol 'main'.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1098,7 +1098,7 @@ my %targets = (
         dso_scheme       => "dlfcn",
         shared_target    => "aix",
         module_ldflags   => "-Wl,-G,-bsymbolic,-bexpall",
-        shared_ldflag    => "-Wl,-G,-bsymbolic",
+        shared_ldflag    => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_defflag   => "-Wl,-bE:",
         perl_platform    => 'AIX',
     },


### PR DESCRIPTION
The AIX binder needs to be instructed that the output will have no entry
point (see AIX' ld manual: -e in the Flags section; autoexp and noentry
in the Binder section).

Fixes #8266 
