### PR TITLE
WIP: Restore BN_copy() propagation of the CT flag

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -292,7 +292,7 @@ BIGNUM *BN_copy(BIGNUM *a, const BIGNUM *b)
 
     a->neg = b->neg;
     a->top = b->top;
-    a->flags |= b->flags & BN_FLG_FIXED_TOP;
+    a->flags |= b->flags & (BN_FLG_FIXED_TOP | BN_FLG_CONSTTIME);
     bn_check_top(a);
     return a;
 }

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -274,8 +274,6 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
     R = &(mont->RR);            /* grab RR as a temp */
     if (!BN_copy(&(mont->N), mod))
         goto err;               /* Set N */
-    if (BN_get_flags(mod, BN_FLG_CONSTTIME) != 0)
-        BN_set_flags(&(mont->N), BN_FLG_CONSTTIME);
     mont->N.neg = 0;
 
 #ifdef MONT_WORD


### PR DESCRIPTION
# Restore `BN_copy()` propagation of BN_FLG_CONSTTIME

This builds on top of PR #8253 .

Ideally, in a secure-by-default design, we want the `BN_FLG_CONSTTIME` flag to stick to `BIGNUM` values and taint copies of it, as not propagating `BN_FLG_CONSTTIME` on `BN_copy()` forces the developers to always remember to set it manually when needed and we have a history of security issues caused by this flag occasionally not being properly set.

Unfortunately this can have undesired consequences as detailed by @mattcaswell here for example: https://github.com/openssl/openssl/pull/8253#issuecomment-464108052

This PR is meant to discuss this and other unintended consequences of the `BN_copy()` propagation of `BN_FLG_CONSTTIME`.

I expect some of the PRs sprouting from this discussion to potentially alter some of the existing functionality, i.e. we might end up raising an error when a function `BN_do_something_vartime()` ends up being called with a `BN_FLG_CONSTTIME` input, whereas previous versions allowed external applications to do it without any warning.
Thus this and related PRs will target primarily the next major release, and will require careful separate discussion when considering backporting to the other active branches.

## Checklist
- [ ] rebase once #8253 is merged
