### PR TITLE
[backport 1.1.0] Fix for BN_FLG_CONSTTIME leakage in BN_CTX

### DIFF
--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -227,6 +227,8 @@ BIGNUM *BN_CTX_get(BN_CTX *ctx)
     }
     /* OK, make sure the returned bignum is "zero" */
     BN_zero(ret);
+    /* clear BN_FLG_CONSTTIME if leaked from previous frames */
+    ret->flags &= (~BN_FLG_CONSTTIME);
     ctx->used++;
     CTXDBG_RET(ctx, ret);
     return ret;

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the OpenSSL license (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -85,6 +85,7 @@ int test_sqrt(BIO *bp, BN_CTX *ctx);
 int test_small_prime(BIO *bp, BN_CTX *ctx);
 int test_bn2dec(BIO *bp);
 int rand_neg(void);
+static int test_ctx_consttime_flag(void);
 static int results = 0;
 
 static unsigned char lst[] =
@@ -312,6 +313,15 @@ int main(int argc, char *argv[])
         goto err;
     (void)BIO_flush(out);
 #endif
+
+    /* print any pre-existing error on the stack */
+    ERR_print_errors_fp(stderr);
+
+    message(out, "BN_CTX_get BN_FLG_CONSTTIME");
+    if (!test_ctx_consttime_flag())
+        goto err;
+    (void)BIO_flush(out);
+
     BN_CTX_free(ctx);
     BIO_free(out);
 
@@ -2091,4 +2101,101 @@ int rand_neg(void)
     static int sign[8] = { 0, 0, 0, 1, 1, 0, 1, 1 };
 
     return (sign[(neg++) % 8]);
+}
+
+static int test_ctx_set_ct_flag(BN_CTX *c)
+{
+    int st = 0;
+    size_t i;
+    BIGNUM *b[15];
+
+    BN_CTX_start(c);
+    for (i = 0; i < OSSL_NELEM(b); i++) {
+        if (NULL == (b[i] = BN_CTX_get(c))) {
+            fprintf(stderr, "ERROR: BN_CTX_get() failed.\n");
+            goto err;
+        }
+        if (i % 2 == 1)
+            BN_set_flags(b[i], BN_FLG_CONSTTIME);
+    }
+
+    st = 1;
+ err:
+    BN_CTX_end(c);
+    return st;
+}
+
+static int test_ctx_check_ct_flag(BN_CTX *c)
+{
+    int st = 0;
+    size_t i;
+    BIGNUM *b[30];
+
+    BN_CTX_start(c);
+    for (i = 0; i < OSSL_NELEM(b); i++) {
+        if (NULL == (b[i] = BN_CTX_get(c))) {
+            fprintf(stderr, "ERROR: BN_CTX_get() failed.\n");
+            goto err;
+        }
+        if (BN_get_flags(b[i], BN_FLG_CONSTTIME) != 0) {
+            fprintf(stderr, "ERROR: BN_FLG_CONSTTIME should not be set.\n");
+            goto err;
+        }
+    }
+
+    st = 1;
+ err:
+    BN_CTX_end(c);
+    return st;
+}
+
+static int test_ctx_consttime_flag(void)
+{
+    /*-
+     * The constant-time flag should not "leak" among BN_CTX frames:
+     *
+     * - test_ctx_set_ct_flag() starts a frame in the given BN_CTX and
+     *   sets the BN_FLG_CONSTTIME flag on some of the BIGNUMs obtained
+     *   from the frame before ending it.
+     * - test_ctx_check_ct_flag() then starts a new frame and gets a
+     *   number of BIGNUMs from it. In absence of leaks, none of the
+     *   BIGNUMs in the new frame should have BN_FLG_CONSTTIME set.
+     *
+     * In actual BN_CTX usage inside libcrypto the leak could happen at
+     * any depth level in the BN_CTX stack, with varying results
+     * depending on the patterns of sibling trees of nested function
+     * calls sharing the same BN_CTX object, and the effect of
+     * unintended BN_FLG_CONSTTIME on the called BN_* functions.
+     *
+     * This simple unit test abstracts away this complexity and verifies
+     * that the leak does not happen between two sibling functions
+     * sharing the same BN_CTX object at the same level of nesting.
+     *
+     */
+    BN_CTX *nctx = NULL;
+    BN_CTX *sctx = NULL;
+    size_t i = 0;
+    int st = 0;
+
+    if (NULL == (nctx = BN_CTX_new())) {
+        fprintf(stderr, "ERROR: BN_CTX_new() failed.\n");
+        goto err;
+    }
+    if (NULL == (sctx = BN_CTX_secure_new())) {
+        fprintf(stderr, "ERROR: BN_CTX_secure_new() failed.\n");
+        goto err;
+    }
+
+    for (i = 0; i < 2; i++) {
+        BN_CTX *c = i == 0 ? nctx : sctx;
+        if (!test_ctx_set_ct_flag(c)
+                || !test_ctx_check_ct_flag(c))
+            goto err;
+    }
+
+    st = 1;
+ err:
+    BN_CTX_free(nctx);
+    BN_CTX_free(sctx);
+    return st;
 }

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -314,8 +314,8 @@ int main(int argc, char *argv[])
     (void)BIO_flush(out);
 #endif
 
-    /* print any pre-existing error on the stack */
-    ERR_print_errors_fp(stderr);
+    /* silently flush any pre-existing error on the stack */
+    ERR_clear_error();
 
     message(out, "BN_CTX_get BN_FLG_CONSTTIME");
     if (!test_ctx_consttime_flag())
@@ -324,8 +324,6 @@ int main(int argc, char *argv[])
 
     BN_CTX_free(ctx);
     BIO_free(out);
-
-    ERR_print_errors_fp(stderr);
 
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
     if (CRYPTO_mem_leaks_fp(stderr) <= 0)


### PR DESCRIPTION
This is a backport of #8253 to `1.1.0-stable`:
- editing of `crypto/bn/bn_ctx.c` during cherry-picking was trivial;
- `test/bntest.c` required major changes to integrate in the older testing framework

## Checklist
- [x] tests are added or updated
