### PR TITLE
Fix trivial typo in EVP_DigestVerifyInit doc

### DIFF
--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -28,8 +28,8 @@ EVP_PKEY_CTX of the verification operation will be written to B<*pctx>: this
 can be used to set alternative verification options. Note that any existing
 value in B<*pctx> is overwritten. The EVP_PKEY_CTX value returned must not be freed
 directly by the application if B<ctx> is not assigned an EVP_PKEY_CTX value before
-being passed to EVP_DigestSignInit() (which means the EVP_PKEY_CTX is created
-inside EVP_DigestSignInit() and it will be freed automatically when the
+being passed to EVP_DigestVerifyInit() (which means the EVP_PKEY_CTX is created
+inside EVP_DigestVerifyInit() and it will be freed automatically when the
 EVP_MD_CTX is freed).
 
 No B<EVP_PKEY_CTX> will be created by EVP_DigsetSignInit() if the passed B<ctx>


### PR DESCRIPTION
While discussing #8314 I noticed small inconsistencies in the doc of `EVP_DigestVerifyInit`, that mentioned `EVP_DigestSignInit` as they share exactly the same functionality regarding the `pctx` behaviour.

It affects both `1.1.1` and `master`.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is updated
