### PR TITLE
WIP: When calling CRYPTO_mem_leak() et al, call OPENSSL_cleanup() first

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -261,11 +261,12 @@ int main(int argc, char *argv[])
     BIO_free(bio_in);
     BIO_free_all(bio_out);
     apps_shutdown();
+    BIO_free(bio_err);
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
-    if (CRYPTO_mem_leaks(bio_err) <= 0)
+    OPENSSL_cleanup();
+    if (CRYPTO_mem_leaks_fp(stderr) <= 0)
         ret = 1;
 #endif
-    BIO_free(bio_err);
     EXIT(ret);
 }
 

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -174,6 +174,11 @@ of writing to a given BIO, the callback function is called for each
 output string with the string, length, and userdata B<u> as the callback
 parameters.
 
+Before calling any of CRYPTO_mem_leaks(), CRYPTO_mem_leaks_fp(), or
+CRYPTO_mem_leaks_cb(), it is I<strongly> recommended to call
+OPENSSL_cleanup(), to make sure the libraries release any internal
+store and thereby avoid false positives.
+
 If the library is built with the C<crypto-mdebug> option, then one
 function, CRYPTO_get_alloc_counts(), and two additional environment
 variables, B<OPENSSL_MALLOC_FAILURES> and B<OPENSSL_MALLOC_FD>,

--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
         lost = NULL;
     }
 
+    OPENSSL_cleanup();           /* Avoid false positives */
     noleak = CRYPTO_mem_leaks_fp(stderr);
     /* If -1 return value something bad happened */
     if (!TEST_int_ne(noleak, -1))

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -1857,11 +1857,13 @@ int main(int argc, char *argv[])
     SSL_SESSION_free(server_sess);
     SSL_SESSION_free(client_sess);
 
+    BIO_free(bio_err);
+
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
-    if (CRYPTO_mem_leaks(bio_err) <= 0)
+    OPENSSL_cleanup();
+    if (CRYPTO_mem_leaks_fp(stderr) <= 0)
         ret = EXIT_FAILURE;
 #endif
-    BIO_free(bio_err);
     EXIT(ret);
 }
 

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -245,6 +245,7 @@ int pulldown_test_framework(int ret)
 {
     set_test_title(NULL);
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG
+    OPENSSL_cleanup();
     if (should_report_leaks()
         && CRYPTO_mem_leaks_cb(openssl_error_cb, NULL) <= 0)
         return EXIT_FAILURE;


### PR DESCRIPTION
This is to remove false positives caused by internal library stores.

Fixes #8322
