### PR TITLE
Providing missing accessor to EVP_PKEY.engine

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -396,6 +396,11 @@ int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e)
     pkey->pmeth_engine = e;
     return 1;
 }
+
+ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey)
+{
+    return pkey->engine;
+}
 #endif
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key)
 {

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -9,7 +9,7 @@ EVP_PKEY_assign_RSA, EVP_PKEY_assign_DSA, EVP_PKEY_assign_DH,
 EVP_PKEY_assign_EC_KEY, EVP_PKEY_assign_POLY1305, EVP_PKEY_assign_SIPHASH,
 EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305, EVP_PKEY_get0_siphash,
 EVP_PKEY_type, EVP_PKEY_id, EVP_PKEY_base_id, EVP_PKEY_set_alias_type,
-EVP_PKEY_set1_engine - EVP_PKEY assignment functions
+EVP_PKEY_set1_engine, EVP_PKEY_get0_engine - EVP_PKEY assignment functions
 
 =head1 SYNOPSIS
 
@@ -45,6 +45,7 @@ EVP_PKEY_set1_engine - EVP_PKEY assignment functions
  int EVP_PKEY_type(int type);
  int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 
+ ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
  int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *engine);
 
 =head1 DESCRIPTION
@@ -80,6 +81,8 @@ often seen in practice.
 
 EVP_PKEY_type() returns the underlying type of the NID B<type>. For example
 EVP_PKEY_type(EVP_PKEY_RSA2) will return B<EVP_PKEY_RSA>.
+
+EVP_PKEY_get0_engine() returns a reference to the ENGINE handling B<pkey>.
 
 EVP_PKEY_set1_engine() sets the ENGINE handling B<pkey> to B<engine>. It
 must be called after the key algorithm and components are set up.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1059,6 +1059,7 @@ int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len);
 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 # ifndef OPENSSL_NO_ENGINE
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e);
+ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
 # endif
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
 void *EVP_PKEY_get0(const EVP_PKEY *pkey);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4644,3 +4644,4 @@ CRYPTO_alloc_ex_data                    4599	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_new                         4600	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_free                        4601	3_0_0	EXIST::FUNCTION:
 OPENSSL_LH_flush                        4602	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_get0_engine                    4603	3_0_0	EXIST::FUNCTION:ENGINE


### PR DESCRIPTION
The accessor to the engine field of EVP_PKEY structure was missing on making internal structures opaque. This patch is designed to provide it.