### PR TITLE
VMS: disable the shlibload test for now

### DIFF
--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -20,6 +20,7 @@ use configdata;
 
 plan skip_all => "Test only supported in a shared build" if disabled("shared");
 plan skip_all => "Test is disabled on AIX" if config('target') =~ m|^aix|;
+plan skip_all => "Test is disabled on VMS" if config('target') =~ m|^vms|;
 plan skip_all => "Test only supported in a dso build" if disabled("dso");
 
 plan tests => 10;


### PR DESCRIPTION
test/shlibloadtest.c needs added code for VMS shared libraries
