### PR TITLE
Disable 02-test_errstr.t on msys/mingw as well as MSWin32

### DIFF
--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -31,6 +31,12 @@ setup('test_errstr');
 plan skip_all => 'This is unsupported for cross compiled configurations'
     if config('CROSS_COMPILE');
 
+# The same can be said when compiling OpenSSL with mingw configuration
+# on Windows when built with msys perl.  Similar problems are also observed
+# in MSVC builds, depending on the perl implementation used.
+plan skip_all => 'This is unsupported on MSYS/MinGW or MSWin32'
+    if $^O eq 'msys' or $^O eq 'MSWin32';
+
 plan skip_all => 'OpenSSL is configured "no-autoerrinit" or "no-err"'
     if disabled('autoerrinit') || disabled('err');
 


### PR DESCRIPTION
There is too high a risk that perl and OpenSSL are linked with
different C RTLs, and thereby get different messages for even the most
mundane error numbers.
