### PR TITLE
Add BN_native2bn and BN_bn2nativepad, for native BIGNUM import/export

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -536,6 +536,24 @@ int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen)
     return tolen;
 }
 
+BIGNUM *BN_native2bn(const unsigned char *s, int len, BIGNUM *ret)
+{
+#ifdef B_ENDIAN
+    return BN_bin2bn(s, len, ret);
+#else
+    return BN_lebin2bn(s, len, ret);
+#endif
+}
+
+int BN_bn2nativepad(const BIGNUM *a, unsigned char *to, int tolen)
+{
+#ifdef B_ENDIAN
+    return BN_bn2binpad(s, len, ret);
+#else
+    return BN_bn2lebinpad(s, len, ret);
+#endif
+}
+
 int BN_ucmp(const BIGNUM *a, const BIGNUM *b)
 {
     int i;

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -548,9 +548,9 @@ BIGNUM *BN_native2bn(const unsigned char *s, int len, BIGNUM *ret)
 int BN_bn2nativepad(const BIGNUM *a, unsigned char *to, int tolen)
 {
 #ifdef B_ENDIAN
-    return BN_bn2binpad(s, len, ret);
+    return BN_bn2binpad(a, to, tolen);
 #else
-    return BN_bn2lebinpad(s, len, ret);
+    return BN_bn2lebinpad(a, to, tolen);
 #endif
 }
 

--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -3,9 +3,9 @@
 =head1 NAME
 
 BN_bn2binpad,
-BN_bn2bin, BN_bin2bn, BN_bn2lebinpad, BN_lebin2bn, BN_bn2hex, BN_bn2dec,
-BN_hex2bn, BN_dec2bn, BN_print, BN_print_fp, BN_bn2mpi,
-BN_mpi2bn - format conversions
+BN_bn2bin, BN_bin2bn, BN_bn2lebinpad, BN_lebin2bn,
+BN_bn2nativepad, BN_native2bn, BN_bn2hex, BN_bn2dec, BN_hex2bn, BN_dec2bn,
+BN_print, BN_print_fp, BN_bn2mpi, BN_mpi2bn - format conversions
 
 =head1 SYNOPSIS
 

--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -18,6 +18,9 @@ BN_mpi2bn - format conversions
  int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen);
  BIGNUM *BN_lebin2bn(const unsigned char *s, int len, BIGNUM *ret);
 
+ int BN_bn2nativepad(const BIGNUM *a, unsigned char *to, int tolen);
+ BIGNUM *BN_native2bn(const unsigned char *s, int len, BIGNUM *ret);
+
  char *BN_bn2hex(const BIGNUM *a);
  char *BN_bn2dec(const BIGNUM *a);
  int BN_hex2bn(BIGNUM **a, const char *str);
@@ -46,6 +49,11 @@ NULL, a new B<BIGNUM> is created.
 
 BN_bn2lebinpad() and BN_lebin2bn() are identical to BN_bn2binpad() and
 BN_bin2bn() except the buffer is in little-endian format.
+
+BN_bn2nativepad() and BN_native2bn() are identical to BN_bn2binpad() and
+BN_bin2bn() except the buffer is in native format, i.e. most significant
+byte first on big-endian platforms, and least significant byte first on
+little-endian platforms.
 
 BN_bn2hex() and BN_bn2dec() return printable strings containing the
 hexadecimal and decimal encoding of B<a> respectively. For negative

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -223,6 +223,8 @@ int BN_bn2bin(const BIGNUM *a, unsigned char *to);
 int BN_bn2binpad(const BIGNUM *a, unsigned char *to, int tolen);
 BIGNUM *BN_lebin2bn(const unsigned char *s, int len, BIGNUM *ret);
 int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen);
+BIGNUM *BN_native2bn(const unsigned char *s, int len, BIGNUM *ret);
+int BN_bn2nativepad(const BIGNUM *a, unsigned char *to, int tolen);
 BIGNUM *BN_mpi2bn(const unsigned char *s, int len, BIGNUM *ret);
 int BN_bn2mpi(const BIGNUM *a, unsigned char *to);
 int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4644,3 +4644,5 @@ CRYPTO_alloc_ex_data                    4599	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_new                         4600	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_free                        4601	3_0_0	EXIST::FUNCTION:
 OPENSSL_LH_flush                        4602	3_0_0	EXIST::FUNCTION:
+BN_native2bn                            4603	3_0_0	EXIST::FUNCTION:
+BN_bn2nativepad                         4604	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
These are a couple of utility functions, to make import and export of
BIGNUMs to byte strings in platform native for (little-endian or
big-endian) easier.
