### PR TITLE
Fixes for EVP_MAC

### DIFF
--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -87,8 +87,14 @@ void CMAC_CTX_free(CMAC_CTX *ctx)
 int CMAC_CTX_copy(CMAC_CTX *out, const CMAC_CTX *in)
 {
     int bl;
-    if (in->nlast_block == -1)
-        return 0;
+    if (in->nlast_block == -1) {
+        out->nlast_block = -1;
+        OPENSSL_cleanse(out->tbl, EVP_MAX_BLOCK_LENGTH);
+        OPENSSL_cleanse(out->k1, EVP_MAX_BLOCK_LENGTH);
+        OPENSSL_cleanse(out->k2, EVP_MAX_BLOCK_LENGTH);
+        OPENSSL_cleanse(out->last_block, EVP_MAX_BLOCK_LENGTH);
+        return 1;
+    }
     if (!EVP_CIPHER_CTX_copy(out->cctx, in->cctx))
         return 0;
     bl = EVP_CIPHER_CTX_block_size(in->cctx);

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2018-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -52,7 +52,8 @@ int EVP_MAC_CTX_copy(EVP_MAC_CTX *dst, EVP_MAC_CTX *src)
 {
     EVP_MAC_IMPL *macdata;
 
-    if (src->data != NULL && !dst->meth->copy(dst->data, src->data))
+    if (src->meth != dst->meth
+            || (src->data != NULL && !dst->meth->copy(dst->data, src->data)))
         return 0;
 
     macdata = dst->data;

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -50,17 +50,15 @@ void EVP_MAC_CTX_free(EVP_MAC_CTX *ctx)
 
 int EVP_MAC_CTX_copy(EVP_MAC_CTX *dst, EVP_MAC_CTX *src)
 {
-    EVP_MAC_IMPL *macdata;
-
-    if (src->meth != dst->meth
-            || (src->data != NULL && !dst->meth->copy(dst->data, src->data)))
-        return 0;
-
-    macdata = dst->data;
-    *dst = *src;
-    dst->data = macdata;
-
-    return 1;
+    /* If the mac's are different, remove the old implementation and replace */
+    if (src->meth != dst->meth) {
+        dst->meth->free(dst->data);
+        dst->meth = src->meth;
+        dst->data = src->meth->new();
+        if (dst->data == NULL)
+            return 0;
+    }
+    return src->meth->copy(dst->data, src->data);
 }
 
 const EVP_MAC *EVP_MAC_CTX_mac(EVP_MAC_CTX *ctx)

--- a/crypto/gmac/gmac.c
+++ b/crypto/gmac/gmac.c
@@ -50,14 +50,26 @@ static int gmac_copy(EVP_MAC_IMPL *gdst, EVP_MAC_IMPL *gsrc)
     gdst->cipher = gsrc->cipher;
     gdst->engine = gsrc->engine;
     OPENSSL_clear_free(gdst->key, gdst->key_len);
-    gdst->key = OPENSSL_memdup(gsrc->key, gsrc->key_len);
-    gdst->key_len = gsrc->key_len;
+    gdst->key = NULL;
+    gdst->key_len = 0;
+    if (gsrc->key != NULL) {
+        gdst->key = OPENSSL_memdup(gsrc->key, gsrc->key_len);
+        gdst->key_len = gsrc->key_len;
+        if (gdst->key == NULL)
+            return 0;
+    }
     OPENSSL_clear_free(gdst->iv, gdst->iv_len);
-    gdst->iv = OPENSSL_memdup(gsrc->iv, gsrc->iv_len);
-    gdst->iv_len = gsrc->iv_len;
-    if (gdst->key == NULL || gdst->iv == NULL)
-        return 0;
-    return EVP_CIPHER_CTX_copy(gdst->ctx, gsrc->ctx);
+    gdst->iv = NULL;
+    gdst->iv_len = 0;
+    if (gsrc->iv != NULL) {
+        gdst->iv = OPENSSL_memdup(gsrc->iv, gsrc->iv_len);
+        gdst->iv_len = gsrc->iv_len;
+        if (gdst->iv == NULL)
+            return 0;
+    }
+    if (EVP_CIPHER_CTX_cipher(gsrc->ctx) != NULL)
+        return EVP_CIPHER_CTX_copy(gdst->ctx, gsrc->ctx);
+    return 1;
 }
 
 static size_t gmac_size(EVP_MAC_IMPL *gctx)

--- a/crypto/hmac/hm_meth.c
+++ b/crypto/hmac/hm_meth.c
@@ -55,11 +55,15 @@ static int hmac_copy(EVP_MAC_IMPL *hdst, EVP_MAC_IMPL *hsrc)
 
     hdst->engine = hsrc->engine;
     hdst->md = hsrc->md;
-
     OPENSSL_clear_free(hdst->key, hdst->key_len);
-    hdst->key = OPENSSL_memdup(hsrc->key, hsrc->key_len);
-    hdst->key_len = hsrc->key_len;
-    return hdst->key != NULL;
+    hdst->key = NULL;
+    hdst->key_len = 0;
+    if (hsrc->key != NULL) {
+        hdst->key = OPENSSL_memdup(hsrc->key, hsrc->key_len);
+        hdst->key_len = hsrc->key_len;
+        return hdst->key != NULL;
+    }
+    return 1;
 }
 
 static size_t hmac_size(EVP_MAC_IMPL *hctx)

--- a/crypto/kmac/kmac.c
+++ b/crypto/kmac/kmac.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2018-2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright (c) 2018-2019, Oracle and/or its affiliates.  All rights reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -82,7 +83,6 @@ static const unsigned char kmac_string[] = {
     0x01, 0x20, 0x4B, 0x4D, 0x41, 0x43
 };
 
-
 #define KMAC_FLAG_XOF_MODE          1
 
 /* typedef EVP_MAC_IMPL */
@@ -111,7 +111,6 @@ static int kmac_bytepad_encode_key(unsigned char *out, int *out_len,
                                    int w);
 static int kmac_ctrl_str(EVP_MAC_IMPL *kctx, const char *type,
                          const char *value);
-
 
 static void kmac_free(EVP_MAC_IMPL *kctx)
 {
@@ -157,7 +156,9 @@ static int kmac_copy(EVP_MAC_IMPL *gdst, EVP_MAC_IMPL *gsrc)
     memcpy(gdst->key, gsrc->key, gsrc->key_len);
     memcpy(gdst->custom, gsrc->custom, gdst->custom_len);
 
-    return EVP_MD_CTX_copy(gdst->ctx, gsrc->ctx);
+    if (EVP_MD_CTX_md(gsrc->ctx) != NULL)
+        return EVP_MD_CTX_copy(gdst->ctx, gsrc->ctx);
+    return 1;
 }
 
 /*

--- a/crypto/poly1305/poly1305_meth.c
+++ b/crypto/poly1305/poly1305_meth.c
@@ -44,9 +44,14 @@ static int poly1305_copy(EVP_MAC_IMPL *dst, EVP_MAC_IMPL *src)
 {
     *dst->ctx = *src->ctx;
     OPENSSL_clear_free(dst->key, dst->key_len);
-    dst->key = OPENSSL_memdup(src->key, src->key_len);
-    dst->key_len = src->key_len;
-    return dst->key != NULL;
+    dst->key = NULL;
+    dst->key_len = 0;
+    if (src->key != NULL) {
+        dst->key = OPENSSL_memdup(src->key, src->key_len);
+        dst->key_len = src->key_len;
+        return dst->key != NULL;
+    }
+    return 1;
 }
 
 static size_t poly1305_size(EVP_MAC_IMPL *ctx)

--- a/crypto/siphash/siphash_meth.c
+++ b/crypto/siphash/siphash_meth.c
@@ -37,9 +37,15 @@ static void siphash_free(EVP_MAC_IMPL *sctx)
 static int siphash_copy(EVP_MAC_IMPL *sdst, EVP_MAC_IMPL *ssrc)
 {
     sdst->ctx = ssrc->ctx;
-    sdst->key = OPENSSL_memdup(ssrc->key, ssrc->key_len);
-    sdst->key_len = ssrc->key_len;
-    return sdst->key != NULL;
+    OPENSSL_clear_free(sdst->key, sdst->key_len);
+    sdst->key = NULL;
+    sdst->key_len  = 0;
+    if (ssrc->key != NULL) {
+        sdst->key = OPENSSL_memdup(ssrc->key, ssrc->key_len);
+        sdst->key_len = ssrc->key_len;
+        return sdst->key != NULL;
+    }
+    return 1;
 }
 
 static size_t siphash_size(EVP_MAC_IMPL *sctx)

--- a/test/build.info
+++ b/test/build.info
@@ -47,7 +47,7 @@ IF[{- !$disabled{tests} -}]
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest \
           sysdefaulttest errtest gosttest \
-          context_internal_test
+          context_internal_test evp_mac_test
 
   SOURCE[versions]=versions.c
   INCLUDE[versions]=../include ../apps/include
@@ -335,6 +335,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[evp_kdf_test]=evp_kdf_test.c
   INCLUDE[evp_kdf_test]=../include ../apps/include
   DEPEND[evp_kdf_test]=../libcrypto libtestutil.a
+
+  SOURCE[evp_mac_test]=evp_mac_test.c
+  INCLUDE[evp_mac_test]=../include ../apps/include
+  DEPEND[evp_mac_test]=../libcrypto libtestutil.a
 
   SOURCE[x509_time_test]=x509_time_test.c
   INCLUDE[x509_time_test]=../include ../apps/include

--- a/test/evp_mac_test.c
+++ b/test/evp_mac_test.c
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/* Tests the EVP_MAC APIs */
+
+#include <stdio.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include "internal/nelem.h"
+#include "testutil.h"
+
+static const unsigned char hmac_input[] = "Sample message for keylen<blocklen";
+static const unsigned char hmac_sha224_key[] = {
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,
+    0x0F,0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,0x19,0x1A,0x1B
+};
+static const unsigned char hmac_sha224_expected[] = {
+    0xE3,0xD2,0x49,0xA8,0xCF,0xB6,0x7E,0xF8,0xB7,0xA1,0x69,0xE9,0xA0,0xA5,0x99,
+    0x71,0x4A,0x2C,0xEC,0xBA,0x65,0x99,0x9A,0x51,0xBE,0xB8,0xFB,0xBE
+};
+
+static const unsigned char kmac128_input[] = { 0x00, 0x01, 0x02, 0x03 };
+static const unsigned char kmac128_key[] = {
+    0x40,0x41,0x42,0x43,0x44,0x45,0x46,0x47,0x48,0x49,0x4A,0x4B,0x4C,0x4D,0x4E,
+    0x4F,0x50,0x51,0x52,0x53,0x54,0x55,0x56,0x57,0x58,0x59,0x5A,0x5B,0x5C,0x5D,
+    0x5E,0x5F
+};
+static const unsigned char kmac128_expected[] = {
+    0xE5,0x78,0x0B,0x0D,0x3E,0xA6,0xF7,0xD3,0xA4,0x29,0xC5,0x70,0x6A,0xA4,0x3A,
+    0x00,0xFA,0xDB,0xD7,0xD4,0x96,0x28,0x83,0x9E,0x31,0x87,0x24,0x3F,0x45,0x6E,
+    0xE1,0x4E
+};
+
+static const unsigned char cmac_input[] = {
+    0x02,0x06,0x83,0xE1,0xF0,0x39,0x2F,0x4C,0xAC,0x54,0x31,0x8B,0x60,0x29,0x25,
+    0x9E,0x9C,0x55,0x3D,0xBC,0x4B,0x6A,0xD9,0x98,0xE6,0x4D,0x58,0xE4,0xE7,0xDC,
+    0x2E,0x13
+};
+static const unsigned char cmac_key[] = {
+    0x77,0xA7,0x7F,0xAF,0x29,0x0C,0x1F,0xA3,0x0C,0x68,0x3D,0xF1,0x6B,0xA7,0xA7,
+    0x7B
+};
+static const unsigned char cmac_expected[] = {
+    0xFB,0xFE,0xA4,0x1B,0xF9,0x74,0x0C,0xB5,0x01,0xF1,0x29,0x2C,0x21,0xCE,0xBB,
+    0x40
+};
+
+static const unsigned char gmac_key[] = {
+    0x77,0xBE,0x63,0x70,0x89,0x71,0xC4,0xE2,0x40,0xD1,0xCB,0x79,0xE8,0xD7,0x7F,
+    0xEB
+};
+static const unsigned char gmac_iv[] = {
+    0xE0,0xE0,0x0F,0x19,0xFE,0xD7,0xBA,0x01,0x36,0xA7,0x97,0xF3
+};
+static const unsigned char gmac_input[] = {
+    0x7A,0x43,0xEC,0x1D,0x9C,0x0A,0x5A,0x78,0xA0,0xB1,0x65,0x33,0xA6,0x21,0x3C,
+    0xAB
+};
+static const unsigned char gmac_expected[] = {
+    0x20,0x9F,0xCC,0x8D,0x36,0x75,0xED,0x93,0x8E,0x9C,0x71,0x66,0x70,0x9D,0xD9,
+    0x46
+};
+
+static const unsigned char siphash_key[] = {
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,
+    0x0F
+};
+static const unsigned char siphash_input[] = { 00 };
+static const unsigned char siphash_expected[] = {
+    0xda,0x87,0xc1,0xd8,0x6b,0x99,0xaf,0x44,0x34,0x76,0x59,0x11,0x9b,0x22,0xfc,
+    0x45
+};
+
+static const unsigned char poly1305_input[] = {
+    0x48,0x65,0x6c,0x6c,0x6f,0x20,0x77,0x6f,0x72,0x6c,0x64,0x21
+};
+static const unsigned char poly1305_key[] = {
+    0x74,0x68,0x69,0x73,0x20,0x69,0x73,0x20,0x33,0x32,0x2d,0x62,0x79,0x74,0x65,
+    0x20,0x6b,0x65,0x79,0x20,0x66,0x6f,0x72,0x20,0x50,0x6f,0x6c,0x79,0x31,0x33,
+    0x30,0x35
+};
+static const unsigned char poly1305_expected[] = {
+    0xa6,0xf7,0x45,0x00,0x8f,0x81,0xc9,0x16,0xa2,0x0d,0xcc,0x74,0xee,0xf2,0xb2,
+    0xf0
+};
+
+static const unsigned char blake2s_input[] = { 00 };
+static const unsigned char blake2s_key[] = {
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,
+    0x0F,0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,0x19,0x1A,0x1B,0x1C,0x1D,
+    0x1E,0x1F
+};
+static const unsigned char blake2s_expected[] = {
+    0x40,0xd1,0x5f,0xee,0x7c,0x32,0x88,0x30,0x16,0x6a,0xc3,0xf9,0x18,0x65,0x0f,
+    0x80,0x7e,0x7e,0x01,0xe1,0x77,0x25,0x8c,0xdc,0x0a,0x39,0xb1,0x1f,0x59,0x80,
+    0x66,0xf1
+};
+
+static const unsigned char blake2b_input[] = { 0x00,0x01,0x02 };
+static const unsigned char blake2b_key[] = {
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,
+    0x0F,0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,0x19,0x1A,0x1B,0x1C,0x1D,
+    0x1E,0x1F,0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x2a,0x2b,0x2c,
+    0x2d,0x2e,0x2f,0x30,0x31,0x32,0x33,0x34,0x35,0x36,0x37,0x38,0x39,0x3a,0x3b,
+    0x3c,0x3d,0x3e,0x3f
+};
+static const unsigned char blake2b_expected[] = {
+    0x33,0xd0,0x82,0x5d,0xdd,0xf7,0xad,0xa9,0x9b,0x0e,0x7e,0x30,0x71,0x04,0xad,
+    0x07,0xca,0x9c,0xfd,0x96,0x92,0x21,0x4f,0x15,0x61,0x35,0x63,0x15,0xe7,0x84,
+    0xf3,0xe5,0xa1,0x7e,0x36,0x4a,0xe9,0xdb,0xb1,0x4c,0xb2,0x03,0x6d,0xf9,0x32,
+    0xb7,0x7f,0x4b,0x29,0x27,0x61,0x36,0x5f,0xb3,0x28,0xde,0x7a,0xfd,0xc6,0xd8,
+    0x99,0x8f,0x5f,0xc1
+};
+
+static const struct TEST_DATA {
+    int mac_id;
+    const unsigned char *in;
+    size_t in_len;
+    const unsigned char *key;
+    size_t key_len;
+    const unsigned char *expect;
+    size_t expect_len;
+    const char *cipher_name;
+    const char *md_name;
+    const unsigned char *iv;
+    size_t iv_len;
+} test_data[] = {
+    {
+        EVP_MAC_HMAC,
+        hmac_input, sizeof(hmac_input) - 1,
+        hmac_sha224_key, sizeof(hmac_sha224_key),
+        hmac_sha224_expected, sizeof(hmac_sha224_expected),
+        NULL, "SHA224",
+    },
+    {
+        EVP_MAC_CMAC,
+        cmac_input, sizeof(cmac_input),
+        cmac_key, sizeof(cmac_key),
+        cmac_expected, sizeof(cmac_expected),
+        "AES-128-CBC"
+    },
+    {
+        EVP_MAC_GMAC,
+        gmac_input, sizeof(gmac_input),
+        gmac_key, sizeof(gmac_key),
+        gmac_expected, sizeof(gmac_expected),
+        "AES-128-GCM", NULL,
+        gmac_iv, sizeof(gmac_iv),
+    },
+    {
+        EVP_MAC_KMAC128,
+        kmac128_input, sizeof(kmac128_input),
+        kmac128_key, sizeof(kmac128_key),
+        kmac128_expected, sizeof(kmac128_expected)
+    },
+    {
+        EVP_MAC_SIPHASH,
+        siphash_input, sizeof(siphash_input),
+        siphash_key, sizeof(siphash_key),
+        siphash_expected, sizeof(siphash_expected)
+    },
+    {
+        EVP_MAC_POLY1305,
+        poly1305_input, sizeof(poly1305_input),
+        poly1305_key, sizeof(poly1305_key),
+        poly1305_expected, sizeof(poly1305_expected)
+    },
+    {
+        EVP_MAC_BLAKE2S,
+        blake2s_input, sizeof(blake2s_input),
+        blake2s_key, sizeof(blake2s_key),
+        blake2s_expected, sizeof(blake2s_expected)
+    },
+    {
+        EVP_MAC_BLAKE2B,
+        blake2b_input, sizeof(blake2b_input),
+        blake2b_key, sizeof(blake2b_key),
+        blake2b_expected, sizeof(blake2b_expected)
+    }
+};
+
+static int do_test_copy_ctx(EVP_MAC_CTX *ctx, int mac_id,
+                            const unsigned char *in, size_t in_len,
+                            const unsigned char *expect, size_t expect_len)
+{
+    int ret = 0;
+    EVP_MAC_CTX *ctx_pre_init = NULL;
+    EVP_MAC_CTX *ctx_post_init = NULL;
+    EVP_MAC_CTX *ctx_post_update = NULL;
+    unsigned char out[EVP_MAX_MD_SIZE];
+    size_t len = 0;
+
+    if (!TEST_ptr(ctx_pre_init = EVP_MAC_CTX_new_id(mac_id))
+            || !TEST_ptr(ctx_post_init = EVP_MAC_CTX_new_id(mac_id))
+            || !TEST_ptr(ctx_post_update = EVP_MAC_CTX_new_id(mac_id)))
+        goto err;
+
+    if (!TEST_true(EVP_MAC_CTX_copy(ctx_pre_init, ctx))
+            || !TEST_true(EVP_MAC_init(ctx))
+            || !TEST_true(EVP_MAC_CTX_copy(ctx_post_init, ctx))
+            || !TEST_true(EVP_MAC_update(ctx, in, in_len))
+            || !TEST_true(EVP_MAC_CTX_copy(ctx_post_update, ctx))
+            || !TEST_true(EVP_MAC_final(ctx, out, &len)))
+        goto err;
+    if (!TEST_mem_eq(out, len, expect, expect_len))
+        goto err;
+    memset(out, 0, sizeof(out));
+
+    if (!TEST_true(EVP_MAC_init(ctx_pre_init))
+            || !TEST_true(EVP_MAC_update(ctx_pre_init, in, in_len))
+            || !TEST_true(EVP_MAC_final(ctx_pre_init, out, &len)))
+        goto err;
+    if (!TEST_mem_eq(out, len, expect, expect_len))
+        goto err;
+    memset(out, 0, sizeof(out));
+
+    if (!TEST_true(EVP_MAC_update(ctx_post_init, in, in_len))
+            || !TEST_true(EVP_MAC_final(ctx_post_init, out, &len)))
+        goto err;
+    if (!TEST_mem_eq(out, len, expect, expect_len))
+        goto err;
+    memset(out, 0, sizeof(out));
+
+    if (!TEST_true(EVP_MAC_final(ctx_post_update, out, &len)))
+        goto err;
+    if (!TEST_mem_eq(out, len, expect, expect_len))
+        goto err;
+    memset(out, 0, sizeof(out));
+
+    /* Calling Init/Update/Final multiple times should work */
+    if (!TEST_true(EVP_MAC_init(ctx))
+            || !TEST_true(EVP_MAC_update(ctx, in, in_len))
+            || !TEST_true(EVP_MAC_final(ctx, out, &len)))
+        goto err;
+    if (!TEST_mem_eq(out, len, expect, expect_len))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_MAC_CTX_free(ctx_post_update);
+    EVP_MAC_CTX_free(ctx_post_init);
+    EVP_MAC_CTX_free(ctx_pre_init);
+    return ret;
+}
+
+static int test_mac_copy(int id)
+{
+    const struct TEST_DATA *t = &test_data[id];
+    int ret = 0;
+    EVP_MAC_CTX *ctx = NULL;
+    const EVP_CIPHER *cipher = NULL;
+
+    TEST_note("%s:", OBJ_nid2sn(t->mac_id));
+
+    if (!TEST_ptr(ctx = EVP_MAC_CTX_new_id(t->mac_id)))
+        goto err;
+
+    if (t->cipher_name != NULL) {
+        /* Used by CMAC and GMAC */
+        if (!TEST_ptr(cipher = EVP_get_cipherbyname(t->cipher_name)))
+            goto err;
+        if (!TEST_true(EVP_MAC_init(ctx) <= 0))
+            goto err;
+        if (!TEST_true(EVP_MAC_ctrl(ctx, EVP_MAC_CTRL_SET_CIPHER, cipher) > 0))
+            goto err;
+    }
+
+    if (t->md_name != NULL) {
+        /* Used by HMAC */
+        if (!TEST_true(EVP_MAC_init(ctx) <= 0))
+            goto err;
+        if (!TEST_true(EVP_MAC_ctrl(ctx, EVP_MAC_CTRL_SET_MD,
+                                    EVP_get_digestbyname(t->md_name)) > 0))
+            goto err;
+        if (!TEST_true(EVP_MAC_init(ctx) <= 0))
+            goto err;
+    }
+
+    if (!TEST_true(EVP_MAC_ctrl(ctx, EVP_MAC_CTRL_SET_KEY, t->key,
+                                t->key_len) > 0))
+        goto err;
+
+    if (t->iv != NULL) {
+        /* Used by GMAC */
+        if (!TEST_true(EVP_MAC_ctrl(ctx, EVP_MAC_CTRL_SET_IV, t->iv,
+                                    t->iv_len) > 0))
+            goto err;
+    }
+
+    if (!do_test_copy_ctx(ctx, t->mac_id, t->in, t->in_len, t->expect,
+                          t->expect_len))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_MAC_CTX_free(ctx);
+    return ret;
+}
+
+static int test_invalid_copy(void)
+{
+    int ret = 0;
+    EVP_MAC_CTX *ctx_hmac = NULL, *ctx_kmac = NULL;
+
+    if (!TEST_ptr(ctx_hmac = EVP_MAC_CTX_new_id(EVP_MAC_CMAC)))
+        goto err;
+    if (!TEST_ptr(ctx_kmac = EVP_MAC_CTX_new_id(EVP_MAC_KMAC128)))
+        goto err;
+    if (!TEST_true(EVP_MAC_CTX_copy(ctx_hmac, ctx_kmac) <= 0))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_MAC_CTX_free(ctx_hmac);
+    EVP_MAC_CTX_free(ctx_kmac);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(test_mac_copy, OSSL_NELEM(test_data));
+    ADD_TEST(test_invalid_copy);
+    return 1;
+}

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1052,10 +1052,7 @@ static int mac_test_run_pkey(EVP_TEST *t)
         t->err = "INTERNAL_ERROR";
         goto err;
     }
-    if (!EVP_DigestSignInit(mctx, &pctx, md, NULL, key)) {
-        t->err = "DIGESTSIGNINIT_ERROR";
-        goto err;
-    }
+
     for (i = 0; i < sk_OPENSSL_STRING_num(expected->controls); i++)
         if (!mac_test_ctrl_pkey(t, pctx,
                                 sk_OPENSSL_STRING_value(expected->controls,
@@ -1063,6 +1060,12 @@ static int mac_test_run_pkey(EVP_TEST *t)
             t->err = "EVPPKEYCTXCTRL_ERROR";
             goto err;
         }
+
+    if (!EVP_DigestSignInit(mctx, &pctx, md, NULL, key)) {
+        t->err = "DIGESTSIGNINIT_ERROR";
+        goto err;
+    }
+
     if (!EVP_DigestSignUpdate(mctx, expected->input, expected->input_len)) {
         t->err = "DIGESTSIGNUPDATE_ERROR";
         goto err;

--- a/test/recipes/30-test_evp_mac.t
+++ b/test/recipes/30-test_evp_mac.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_evp_mac", "evp_mac_test");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

* Trying to copy one MAC type to another now results in an error instead of crashing.
* Some EVP_MAC methods now buffer data such as key or iv instead of setting them directly. This solves the following issues:-
   (1) Calling the sequence Init(),Update(),Final() multiple times now produces a consistent result and    does not crash for the EVP_MAC's.
   (2) Copy methods for all EVP_MAC's can now be called at anytime without causing an error.
   (3) For EVP_PKEY using a mac it was discovered that the mac init method was not being called in one case, and in the other case the init was being called before the key was set (so the order was changed).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
