### PR TITLE
Fix memory overrun in rsa padding check functions

### DIFF
--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -229,7 +229,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     mlen = dblen - msg_index;
 
     /*
-     * For good measure, do this check in constant tine as well.
+     * For good measure, do this check in constant time as well.
      */
     good &= constant_time_ge(tlen, mlen);
 

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -250,7 +250,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     for (mask = good, i = 0; i < tlen; i++) {
         unsigned int equals = constant_time_eq(msg_index, dblen);
 
-        msg_index -= (dblen - mdlen - 1) & equals;  /* rewind at EOF */
+        msg_index -= tlen & equals;  /* rewind at EOF */
         mask &= ~equals;  /* mask = 0 at EOF */
         to[i] = constant_time_select_8(mask, db[msg_index++], to[i]);
     }

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -248,10 +248,10 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     msg_index = constant_time_select_int(good, msg_index, dblen - tlen);
     mlen = dblen - msg_index;
     for (mask = good, i = 0; i < tlen; i++) {
-        unsigned int equals = constant_time_eq(i, mlen);
+        unsigned int equals = constant_time_eq(msg_index, dblen);
 
-        msg_index -= dblen & equals; /* if (i == dblen) rewind */
-        mask &= mask ^ equals;  /* if (i == dblen) mask = 0 */
+        msg_index -= (dblen - mdlen - 1) & equals;  /* rewind at EOF */
+        mask &= ~equals;  /* mask = 0 at EOF */
         to[i] = constant_time_select_8(mask, db[msg_index++], to[i]);
     }
 

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -143,7 +143,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
      * |num| is the length of the modulus; |flen| is the length of the
      * encoded message. Therefore, for any |from| that was obtained by
      * decrypting a ciphertext, we must have |flen| <= |num|. Similarly,
-     * num < 2 * mdlen + 2 must hold for the modulus irrespective of
+     * |num| >= 2 * |mdlen| + 2 must hold for the modulus irrespective of
      * the ciphertext, see PKCS #1 v2.2, section 7.1.2.
      * This does not leak any side-channel information.
      */

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -137,7 +137,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
 
     mdlen = EVP_MD_size(md);
 
-    if (flen <= 0)
+    if (tlen <= 0 || flen <= 0)
         return -1;
     /*
      * |num| is the length of the modulus; |flen| is the length of the
@@ -147,14 +147,13 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
      * the ciphertext, see PKCS #1 v2.2, section 7.1.2.
      * This does not leak any side-channel information.
      */
-    if (num < flen || num < 2 * mdlen + 2 || tlen < num - 2 * mdlen - 2) {
+    if (num < flen || num < 2 * mdlen + 2) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1,
                RSA_R_OAEP_DECODING_ERROR);
         return -1;
     }
 
     dblen = num - mdlen - 1;
-    tlen = dblen - mdlen - 1;
     db = OPENSSL_malloc(dblen);
     if (db == NULL) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1, ERR_R_MALLOC_FAILURE);
@@ -230,6 +229,11 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     mlen = dblen - msg_index;
 
     /*
+     * For good measure, do this check in constant time as well.
+     */
+    good &= constant_time_ge(tlen, mlen);
+
+    /*
      * Even though we can't fake result's length, we can pretend copying
      * |tlen| bytes where |mlen| bytes would be real. Last |tlen| of |dblen|
      * bytes are viewed as circular buffer with start at |tlen|-|mlen'|,
@@ -239,6 +243,8 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
      * should be noted that failure is indistinguishable from normal
      * operation if |tlen| is fixed by protocol.
      */
+    tlen = constant_time_select_int(constant_time_lt(dblen - mdlen - 1, tlen),
+                                    dblen - mdlen - 1, tlen);
     msg_index = constant_time_select_int(good, msg_index, dblen - tlen);
     mlen = dblen - msg_index;
     for (mask = good, i = 0; i < tlen; i++) {

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -244,7 +244,8 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
      * should be noted that failure is indistinguishable from normal
      * operation if |tlen| is fixed by protocol.
      */
-    tlen = constant_time_select_int(constant_time_lt(dblen, tlen), dblen, tlen);
+    tlen = constant_time_select_int(constant_time_lt(dblen - mdlen - 1, tlen),
+                                    dblen - mdlen - 1, tlen);
     msg_index = constant_time_select_int(good, msg_index, dblen - tlen);
     mlen = dblen - msg_index;
     for (from = db + msg_index, mask = good, i = 0; i < tlen; i++) {

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -242,7 +242,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     for (mask = good, i = 0; i < tlen; i++) {
         unsigned int equals = constant_time_eq(msg_index, num);
 
-        msg_index -= (num - 11) & equals;  /* rewind at EOF */
+        msg_index -= tlen & equals;  /* rewind at EOF */
         mask &= ~equals;  /* mask = 0 at EOF */
         to[i] = constant_time_select_8(mask, em[msg_index++], to[i]);
     }

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -240,10 +240,10 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     msg_index = constant_time_select_int(good, msg_index, num - tlen);
     mlen = num - msg_index;
     for (mask = good, i = 0; i < tlen; i++) {
-        unsigned int equals = constant_time_eq(i, mlen);
+        unsigned int equals = constant_time_eq(msg_index, num);
 
-        msg_index -= tlen & equals;  /* if (i == mlen) rewind */
-        mask &= mask ^ equals;  /* if (i == mlen) mask = 0 */
+        msg_index -= (num - 11) & equals;  /* rewind at EOF */
+        mask &= ~equals;  /* mask = 0 at EOF */
         to[i] = constant_time_select_8(mask, em[msg_index++], to[i]);
     }
 

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -161,7 +161,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     unsigned int good, found_zero_byte, mask;
     int zero_index = 0, msg_index, mlen = -1;
 
-    if (flen <= 0)
+    if (tlen <= 0 || flen <= 0)
         return -1;
 
     /*
@@ -169,13 +169,12 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
      * section 7.2.2.
      */
 
-    if (flen > num || num < 11 || tlen < num - 11) {
+    if (flen > num || num < 11) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_2,
                RSA_R_PKCS_DECODING_ERROR);
         return -1;
     }
 
-    tlen = num - 11;
     em = OPENSSL_malloc(num);
     if (em == NULL) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_2, ERR_R_MALLOC_FAILURE);
@@ -222,6 +221,11 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     mlen = num - msg_index;
 
     /*
+     * For good measure, do this check in constant time as well.
+     */
+    good &= constant_time_ge(tlen, mlen);
+
+    /*
      * Even though we can't fake result's length, we can pretend copying
      * |tlen| bytes where |mlen| bytes would be real. Last |tlen| of |num|
      * bytes are viewed as circular buffer with start at |tlen|-|mlen'|,
@@ -231,6 +235,8 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
      * should be noted that failure is indistinguishable from normal
      * operation if |tlen| is fixed by protocol.
      */
+    tlen = constant_time_select_int(constant_time_lt(num - 11, tlen),
+                                    num - 11, tlen);
     msg_index = constant_time_select_int(good, msg_index, num - tlen);
     mlen = num - msg_index;
     for (mask = good, i = 0; i < tlen; i++) {

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -236,7 +236,8 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
      * should be noted that failure is indistinguishable from normal
      * operation if |tlen| is fixed by protocol.
      */
-    tlen = constant_time_select_int(constant_time_lt(num, tlen), num, tlen);
+    tlen = constant_time_select_int(constant_time_lt(num - 11, tlen),
+                                    num - 11, tlen);
     msg_index = constant_time_select_int(good, msg_index, num - tlen);
     mlen = num - msg_index;
     for (from += msg_index, mask = good, i = 0; i < tlen; i++) {

--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -1,11 +1,13 @@
 /*
- * Copyright 2006-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2006-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+
+#include "internal/constant_time_locl.h"
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
@@ -340,10 +342,9 @@ static int pkey_rsa_decrypt(EVP_PKEY_CTX *ctx,
         ret = RSA_private_decrypt(inlen, in, out, ctx->pkey->pkey.rsa,
                                   rctx->pad_mode);
     }
-    if (ret < 0)
-        return ret;
-    *outlen = ret;
-    return 1;
+    *outlen = constant_time_select_s(constant_time_msb_s(ret), *outlen, ret);
+    ret = constant_time_select_int(constant_time_msb(ret), ret, 1);
+    return ret;
 }
 
 static int check_padding_md(const EVP_MD *md, int padding)

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -67,7 +67,10 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
     unsigned int good, found_zero_byte, mask, threes_in_row;
     int zero_index = 0, msg_index, mlen = -1, err;
 
-    if (flen < 10) {
+    if (tlen <= 0 || flen <= 0)
+        return -1;
+
+    if (flen > num || num < 11) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, RSA_R_DATA_TOO_SMALL);
         return -1;
     }

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -148,7 +148,8 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
      * should be noted that failure is indistinguishable from normal
      * operation if |tlen| is fixed by protocol.
      */
-    tlen = constant_time_select_int(constant_time_lt(num, tlen), num, tlen);
+    tlen = constant_time_select_int(constant_time_lt(num - 11, tlen),
+                                    num - 11, tlen);
     msg_index = constant_time_select_int(good, msg_index, num - tlen);
     mlen = num - msg_index;
     for (from += msg_index, mask = good, i = 0; i < tlen; i++) {

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -157,7 +157,7 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
     for (mask = good, i = 0; i < tlen; i++) {
         unsigned int equals = constant_time_eq(msg_index, num);
 
-        msg_index -= (num - 11) & equals;  /* rewind at EOF */
+        msg_index -= tlen & equals;  /* rewind at EOF */
         mask &= ~equals;  /* mask = 0 at EOF */
         to[i] = constant_time_select_8(mask, em[msg_index++], to[i]);
     }

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -155,10 +155,10 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
     msg_index = constant_time_select_int(good, msg_index, num - tlen);
     mlen = num - msg_index;
     for (mask = good, i = 0; i < tlen; i++) {
-        unsigned int equals = constant_time_eq(i, mlen);
+        unsigned int equals = constant_time_eq(msg_index, num);
 
-        msg_index -= tlen & equals;  /* if (i == mlen) rewind */
-        mask &= mask ^ equals;  /* if (i == mlen) mask = 0 */
+        msg_index -= (num - 11) & equals;  /* rewind at EOF */
+        mask &= ~equals;  /* mask = 0 at EOF */
         to[i] = constant_time_select_8(mask, em[msg_index++], to[i]);
     }
 

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -109,14 +109,15 @@ B<tlen> must be large enough to hold the maximal possible plaintext
 length for the used padding mode, which is B<rsa_len> - 11 for
 RSA_padding_check_PKCS1_type_2() and RSA_padding_check_SSLv23(),
 B<rsa_len> - 42 for RSA_padding_check_PKCS1_OAEP()
-and B<rsa_len> - 2 * EVP_MD_size(B<md>) - 2 for
-RSA_padding_check_PKCS1_OAEP_mgf1().
+and B<rsa_len> - 2 * EVP_MD_size(B<md>) - 2
+for RSA_padding_check_PKCS1_OAEP_mgf1().
 
 For RSA_padding_xxx_OAEP(), B<p> points to the encoding parameter
 of length B<pl>. B<p> may be B<NULL> if B<pl> is 0.
+
 For RSA_padding_xxx_OAEP_mgf1(), B<md> points to the md hash,
-B<md> = B<NULL> means use md=sha1, and B<mgf1md> points to the
-mgf1 hash, B<mgf1md> = B<NULL> means mfg1md=md.
+if B<md> is B<NULL> that means use md=sha1, and B<mgf1md> points to
+the mgf1 hash, if B<mgf1md> is B<NULL> that means mfg1md=md.
 
 =head1 RETURN VALUES
 
@@ -133,8 +134,8 @@ padding oracle attack. This is an inherent weakness in the PKCS #1
 v1.5 padding design. Prefer PKCS1_OAEP padding. If that is not
 possible, the result of RSA_padding_check_PKCS1_type_2() should be
 checked in constant time if it matches the expected length of the
-plain text and additionally some application specific consistency
-checks on the plain text need to be performed in constant time.
+plaintext and additionally some application specific consistency
+checks on the plaintext need to be performed in constant time.
 If the plaintext is rejected it must be kept secret with of the
 checks caused the application to reject the message.
 

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -113,8 +113,9 @@ RSA_padding_check_PKCS1_OAEP_mgf1().
 
 For RSA_padding_xxx_OAEP(), B<p> points to the encoding parameter
 of length B<pl>. B<p> may be B<NULL> if B<pl> is 0.
-For RSA_paddint_xxx_OAEP_mgf1() if B<md> is B<NULL> means use
-md=sha1, and B<mgf1md> is B<NULL> means mfg1md=md.
+For RSA_padding_xxx_OAEP_mgf1(), B<md> points to the md hash,
+B<md> = B<NULL> means use md=sha1, and B<mgf1md> points to the
+mgf1 hash, B<mgf1md> = B<NULL> means mfg1md=md.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -5,6 +5,7 @@
 RSA_padding_add_PKCS1_type_1, RSA_padding_check_PKCS1_type_1,
 RSA_padding_add_PKCS1_type_2, RSA_padding_check_PKCS1_type_2,
 RSA_padding_add_PKCS1_OAEP, RSA_padding_check_PKCS1_OAEP,
+RSA_padding_add_PKCS1_OAEP_mgf1, RSA_padding_check_PKCS1_OAEP_mgf1,
 RSA_padding_add_SSLv23, RSA_padding_check_SSLv23,
 RSA_padding_add_none, RSA_padding_check_none - asymmetric encryption
 padding
@@ -14,23 +15,33 @@ padding
  #include <openssl/rsa.h>
 
  int RSA_padding_add_PKCS1_type_1(unsigned char *to, int tlen,
-                                  unsigned char *f, int fl);
+                                  const unsigned char *f, int fl);
 
  int RSA_padding_check_PKCS1_type_1(unsigned char *to, int tlen,
-                                    unsigned char *f, int fl, int rsa_len);
+                                    const unsigned char *f, int fl, int rsa_len);
 
  int RSA_padding_add_PKCS1_type_2(unsigned char *to, int tlen,
-                                  unsigned char *f, int fl);
+                                  const unsigned char *f, int fl);
 
  int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
-                                    unsigned char *f, int fl, int rsa_len);
+                                    const unsigned char *f, int fl, int rsa_len);
 
  int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
-                                unsigned char *f, int fl, unsigned char *p, int pl);
+                                const unsigned char *f, int fl,
+                                const unsigned char *p, int pl);
 
  int RSA_padding_check_PKCS1_OAEP(unsigned char *to, int tlen,
-                                  unsigned char *f, int fl, int rsa_len,
-                                  unsigned char *p, int pl);
+                                  const unsigned char *f, int fl, int rsa_len,
+                                  const unsigned char *p, int pl);
+
+ int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+                                     const unsigned char *f, int fl, unsigned char *p, int pl,
+                                     const EVP_MD *md, const EVP_MD *mgf1md);
+
+ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+                                      const unsigned char *f, int fl, int rsa_len,
+                                      const unsigned char *p, int pl);
+                                      const EVP_MD *md, const EVP_MD *mgf1md);
 
  int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
                             unsigned char *f, int fl);
@@ -92,11 +103,18 @@ RSA_padding_add_xxx().
 RSA_padding_check_xxx() verifies that the B<fl> bytes at B<f> contain
 a valid encoding for a B<rsa_len> byte RSA key in the respective
 encoding method and stores the recovered data of at most B<tlen> bytes
-(for B<RSA_NO_PADDING>: of size B<tlen>)
-at B<to>.
+(for B<RSA_NO_PADDING>: of size B<tlen>) at B<to>.
+B<tlen> must be large enough to hold the maximal possible plaintext
+length for the used padding mode, which is B<rsa_len> - 11 for
+RSA_padding_check_PKCS1_type_2() and RSA_padding_check_SSLv23(),
+B<rsa_len> - 42 for RSA_padding_check_PKCS1_OAEP()
+and B<rsa_len> - 2 * EVP_MD_size(B<md>) - 2 for
+RSA_padding_check_PKCS1_OAEP_mgf1().
 
 For RSA_padding_xxx_OAEP(), B<p> points to the encoding parameter
 of length B<pl>. B<p> may be B<NULL> if B<pl> is 0.
+For RSA_paddint_xxx_OAEP_mgf1() if B<md> is B<NULL> means use
+md=sha1, and B<mgf1md> is B<NULL> means mfg1md=md.
 
 =head1 RETURN VALUES
 
@@ -107,15 +125,16 @@ L<ERR_get_error(3)>.
 
 =head1 WARNING
 
-The RSA_padding_check_PKCS1_type_2() padding check leaks timing
+The result of RSA_padding_check_PKCS1_type_2() is a very sensitive
 information which can potentially be used to mount a Bleichenbacher
 padding oracle attack. This is an inherent weakness in the PKCS #1
-v1.5 padding design. Prefer PKCS1_OAEP padding. Otherwise it can
-be recommended to pass zero-padded B<f>, so that B<fl> equals to
-B<rsa_len>, and if fixed by protocol, B<tlen> being set to the
-expected length. In such case leakage would be minimal, it would
-take attacker's ability to observe memory access pattern with byte
-granilarity as it occurs, post-factum timing analysis won't do.
+v1.5 padding design. Prefer PKCS1_OAEP padding. If that is not
+possible, the result of RSA_padding_check_PKCS1_type_2() should be
+checked in constant time if it matches the expected length of the
+plain text and additionally some application specific consistency
+checks on the plain text need to be performed in constant time.
+If the plaintext is rejected it must be kept secret with of the
+checks caused the application to reject the message.
 
 =head1 SEE ALSO
 
@@ -125,7 +144,7 @@ L<RSA_sign(3)>, L<RSA_verify(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -116,8 +116,8 @@ For RSA_padding_xxx_OAEP(), B<p> points to the encoding parameter
 of length B<pl>. B<p> may be B<NULL> if B<pl> is 0.
 
 For RSA_padding_xxx_OAEP_mgf1(), B<md> points to the md hash,
-if B<md> is B<NULL> that means use md=sha1, and B<mgf1md> points to
-the mgf1 hash, if B<mgf1md> is B<NULL> that means mfg1md=md.
+if B<md> is B<NULL> that means md=sha1, and B<mgf1md> points to
+the mgf1 hash, if B<mgf1md> is B<NULL> that means mgf1md=md.
 
 =head1 RETURN VALUES
 
@@ -136,7 +136,7 @@ possible, the result of RSA_padding_check_PKCS1_type_2() should be
 checked in constant time if it matches the expected length of the
 plaintext and additionally some application specific consistency
 checks on the plaintext need to be performed in constant time.
-If the plaintext is rejected it must be kept secret with of the
+If the plaintext is rejected it must be kept secret which of the
 checks caused the application to reject the message.
 
 =head1 SEE ALSO

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -104,13 +104,8 @@ RSA_padding_add_xxx().
 RSA_padding_check_xxx() verifies that the B<fl> bytes at B<f> contain
 a valid encoding for a B<rsa_len> byte RSA key in the respective
 encoding method and stores the recovered data of at most B<tlen> bytes
-(for B<RSA_NO_PADDING>: of size B<tlen>) at B<to>.
-B<tlen> must be large enough to hold the maximal possible plaintext
-length for the used padding mode, which is B<rsa_len> - 11 for
-RSA_padding_check_PKCS1_type_2() and RSA_padding_check_SSLv23(),
-B<rsa_len> - 42 for RSA_padding_check_PKCS1_OAEP()
-and B<rsa_len> - 2 * EVP_MD_size(B<md>) - 2
-for RSA_padding_check_PKCS1_OAEP_mgf1().
+(for B<RSA_NO_PADDING>: of size B<tlen>)
+at B<to>.
 
 For RSA_padding_xxx_OAEP(), B<p> points to the encoding parameter
 of length B<pl>. B<p> may be B<NULL> if B<pl> is 0.

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -133,6 +133,11 @@ plaintext and additionally some application specific consistency
 checks on the plaintext need to be performed in constant time.
 If the plaintext is rejected it must be kept secret which of the
 checks caused the application to reject the message.
+Do not remove the zero-padding from the decrypted raw RSA data
+which was computed by RSA_private_decrypt() with B<RSA_NO_PADDING>,
+as this would create a small timing side channel which could be
+used to mount a Bleichenbacher attack against any padding mode
+including PKCS1_OAEP.
 
 =head1 SEE ALSO
 

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -35,25 +35,26 @@ padding
                                   const unsigned char *p, int pl);
 
  int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
-                                     const unsigned char *f, int fl, unsigned char *p, int pl,
+                                     const unsigned char *f, int fl,
+                                     const unsigned char *p, int pl,
                                      const EVP_MD *md, const EVP_MD *mgf1md);
 
  int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
-                                      const unsigned char *f, int fl, int rsa_len,
-                                      const unsigned char *p, int pl);
-                                      const EVP_MD *md, const EVP_MD *mgf1md);
+                                       const unsigned char *f, int fl, int rsa_len,
+                                       const unsigned char *p, int pl,
+                                       const EVP_MD *md, const EVP_MD *mgf1md);
 
  int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
-                            unsigned char *f, int fl);
+                            const unsigned char *f, int fl);
 
  int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
-                              unsigned char *f, int fl, int rsa_len);
+                              const unsigned char *f, int fl, int rsa_len);
 
  int RSA_padding_add_none(unsigned char *to, int tlen,
-                          unsigned char *f, int fl);
+                          const unsigned char *f, int fl);
 
  int RSA_padding_check_none(unsigned char *to, int tlen,
-                            unsigned char *f, int fl, int rsa_len);
+                            const unsigned char *f, int fl, int rsa_len);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/RSA_private_encrypt.pod
+++ b/doc/man3/RSA_private_encrypt.pod
@@ -64,7 +64,7 @@ L<RSA_sign(3)>, L<RSA_verify(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RSA_private_encrypt.pod
+++ b/doc/man3/RSA_private_encrypt.pod
@@ -64,7 +64,7 @@ L<RSA_sign(3)>, L<RSA_verify(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -99,7 +99,7 @@ L<RSA_size(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -55,6 +55,8 @@ When a padding mode other than RSA_NO_PADDING is in use, then
 RSA_public_encrypt() will include some random bytes into the ciphertext
 and therefore the ciphertext will be different each time, even if the
 plaintext and the public key are exactly identical.
+The returned ciphertext in B<to> will always be zero padded to exactly
+RSA_size(B<rsa>) bytes.
 B<to> and B<from> may overlap.
 
 RSA_private_decrypt() decrypts the B<flen> bytes at B<from> using the

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -51,12 +51,16 @@ Encrypting user data directly with RSA is insecure.
 B<flen> must not be more than RSA_size(B<rsa>) - 11 for the PKCS #1 v1.5
 based padding modes, not more than RSA_size(B<rsa>) - 42 for
 RSA_PKCS1_OAEP_PADDING and exactly RSA_size(B<rsa>) for RSA_NO_PADDING.
-The random number generator must be seeded prior to calling
-RSA_public_encrypt().
+When a padding mode other than RSA_NO_PADDING is in use, then
+RSA_public_encrypt() will include some random bytes into the ciphertext
+and therefore the ciphertext will be different each time, even if the
+plaintext and the public key are exactly identical.
 B<to> and B<from> may overlap.
 
 RSA_private_decrypt() decrypts the B<flen> bytes at B<from> using the
-private key B<rsa> and stores the plaintext in B<to>. B<to> must point
+private key B<rsa> and stores the plaintext in B<to>. B<flen> should
+be equal to RSA_size(B<rsa>) but may be smaller, when leading zero bytes
+are in the ciphertext. However this is not recommended. B<to> must point
 to a memory section large enough to hold the maximal possible decrypted
 data (which is equal to RSA_size(B<rsa>) for RSA_NO_PADDING,
 RSA_size(B<rsa>) - 11 for the PKCS #1 v1.5 based padding modes and
@@ -68,7 +72,8 @@ B<to> and B<from> may overlap.
 
 RSA_public_encrypt() returns the size of the encrypted data (i.e.,
 RSA_size(B<rsa>)). RSA_private_decrypt() returns the size of the
-recovered plaintext.
+recovered plaintext. A return value of 0 is not an error and
+means only that the plaintext was empty.
 
 On error, -1 is returned; the error codes can be
 obtained by L<ERR_get_error(3)>.

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -27,6 +27,8 @@ B<padding> denotes one of the following modes:
 =item RSA_PKCS1_PADDING
 
 PKCS #1 v1.5 padding. This currently is the most widely used mode.
+However, it is highly recommended to use RSA_PKCS1_OAEP_PADDING in
+new applications. SEE WARNING BELOW.
 
 =item RSA_PKCS1_OAEP_PADDING
 
@@ -46,17 +48,21 @@ Encrypting user data directly with RSA is insecure.
 
 =back
 
-B<flen> must be less than RSA_size(B<rsa>) - 11 for the PKCS #1 v1.5
-based padding modes, less than RSA_size(B<rsa>) - 41 for
+B<flen> must not be more than RSA_size(B<rsa>) - 11 for the PKCS #1 v1.5
+based padding modes, not more than RSA_size(B<rsa>) - 42 for
 RSA_PKCS1_OAEP_PADDING and exactly RSA_size(B<rsa>) for RSA_NO_PADDING.
 The random number generator must be seeded prior to calling
 RSA_public_encrypt().
+B<to> and B<from> may overlap.
 
 RSA_private_decrypt() decrypts the B<flen> bytes at B<from> using the
 private key B<rsa> and stores the plaintext in B<to>. B<to> must point
-to a memory section large enough to hold the decrypted data (which is
-smaller than RSA_size(B<rsa>)). B<padding> is the padding mode that
-was used to encrypt the data.
+to a memory section large enough to hold the maximal possible decrypted
+data (which is equal to RSA_size(B<rsa>) for RSA_NO_PADDING,
+RSA_size(B<rsa>) - 11 for the PKCS #1 v1.5 based padding modes and
+RSA_size(B<rsa>) - 42 for RSA_PKCS1_OAEP_PADDING).
+B<padding> is the padding mode that was used to encrypt the data.
+B<to> and B<from> may overlap.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -59,8 +59,9 @@ B<to> and B<from> may overlap.
 
 RSA_private_decrypt() decrypts the B<flen> bytes at B<from> using the
 private key B<rsa> and stores the plaintext in B<to>. B<flen> should
-be equal to RSA_size(B<rsa>) but may be smaller, when leading zero bytes
-are in the ciphertext. However this is not recommended. B<to> must point
+be equal to RSA_size(B<rsa>) but may be smaller, when leading zero
+bytes are in the ciphertext. Those are not important and may be removed,
+but RSA_public_encrypt() does not do that. B<to> must point
 to a memory section large enough to hold the maximal possible decrypted
 data (which is equal to RSA_size(B<rsa>) for RSA_NO_PADDING,
 RSA_size(B<rsa>) - 11 for the PKCS #1 v1.5 based padding modes and

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -8,10 +8,10 @@ RSA_public_encrypt, RSA_private_decrypt - RSA public key cryptography
 
  #include <openssl/rsa.h>
 
- int RSA_public_encrypt(int flen, unsigned char *from,
+ int RSA_public_encrypt(int flen, const unsigned char *from,
                         unsigned char *to, RSA *rsa, int padding);
 
- int RSA_private_decrypt(int flen, unsigned char *from,
+ int RSA_private_decrypt(int flen, const unsigned char *from,
                          unsigned char *to, RSA *rsa, int padding);
 
 =head1 DESCRIPTION

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1999-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -268,6 +268,36 @@ err:
     return ret;
 }
 
+static int test_rsa_sslv23(int idx)
+{
+    int ret = 0;
+    RSA *key;
+    unsigned char ptext[256];
+    unsigned char ctext[256];
+    static unsigned char ptext_ex[] = "\x54\x85\x9b\x34\x2c\x49\xea\x2a";
+    unsigned char ctext_ex[256];
+    int plen;
+    int clen = 0;
+    int num;
+
+    plen = sizeof(ptext_ex) - 1;
+    clen = rsa_setkey(&key, ctext_ex, idx);
+
+    num = RSA_public_encrypt(plen, ptext_ex, ctext, key,
+                             RSA_SSLV23_PADDING);
+    if (!TEST_int_eq(num, clen))
+        goto err;
+
+    num = RSA_private_decrypt(num, ctext, ptext, key, RSA_SSLV23_PADDING);
+    if (!TEST_mem_eq(ptext, num, ptext_ex, plen))
+        goto err;
+
+    ret = 1;
+err:
+    RSA_free(key);
+    return ret;
+}
+
 static int test_rsa_oaep(int idx)
 {
     int ret = 0;
@@ -391,6 +421,7 @@ err:
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_rsa_pkcs1, 3);
+    ADD_ALL_TESTS(test_rsa_sslv23, 3);
     ADD_ALL_TESTS(test_rsa_oaep, 3);
     ADD_ALL_TESTS(test_rsa_security_bit, OSSL_NELEM(rsa_security_bits_cases));
     return 1;


### PR DESCRIPTION
Fixes #8364 and #8357

There is no reason to modify more bytes than the maximum possible
PKCS1 or OAEP message length.