### PR TITLE
The use of the likes of UINT32_MAX requires internal/numbers.h

### DIFF
--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -12,6 +12,7 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/kdf.h>
+#include "internal/numbers.h"
 #include "internal/evp_int.h"
 
 static int pkey_kdf_init(EVP_PKEY_CTX *ctx)

--- a/crypto/kdf/hkdf.c
+++ b/crypto/kdf/hkdf.c
@@ -14,6 +14,7 @@
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 #include "internal/cryptlib.h"
+#include "internal/numbers.h"
 #include "internal/evp_int.h"
 #include "kdf_local.h"
 

--- a/crypto/kdf/sshkdf.c
+++ b/crypto/kdf/sshkdf.c
@@ -13,6 +13,7 @@
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 #include "internal/cryptlib.h"
+#include "internal/numbers.h"
 #include "internal/evp_int.h"
 #include "kdf_local.h"
 


### PR DESCRIPTION
Found a few more cases.
