### PR TITLE
apps/ca.c: only output DER with SPKAC input and when -out is chosen

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -722,7 +722,7 @@ end_of_options:
 
     /*****************************************************************/
     if (req || gencrl) {
-        if (spkac_file != NULL) {
+        if (spkac_file != NULL && outfile != NULL) {
             output_der = 1;
             batch = 1;
         }


### PR DESCRIPTION
So say the docs

Fixes #8055