### PR TITLE
openssl_strerror_r: Fix handling of GNU strerror_r

### DIFF
--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -230,13 +230,18 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
      * It can return a pointer to some (immutable) static string in which case
      * buf is left unused.
      */
-    *buf = '\0';
     err = strerror_r(errnum, buf, buflen);
     if (err == NULL)
         return 0;
-    if (*buf == '\0') {
+    /*
+     * If err is statically allocated, err != buf and we need to copy the data.
+     * If err points somewhere inside buf, OPENSSL_strlcpy can handle this,
+     * since src and dest are not annotated with __restrict and the function
+     * reads src byte for byte and writes to dest.
+     * If err == buf we do not have to copy anything.
+     */
+    if (err != buf)
         OPENSSL_strlcpy(buf, err, buflen);
-    }
     return 1;
 #elif (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || \
       (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600)

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -235,8 +235,7 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
     if (err == NULL)
         return 0;
     if (*buf == '\0') {
-        strncpy(buf, err, buflen - 1);
-        buf[buflen - 1] = '\0';
+        OPENSSL_strlcpy(buf, err, buflen);
     }
     return 1;
 #elif (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || \
@@ -257,8 +256,7 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
     /* Can this ever happen? */
     if (err == NULL)
         return 0;
-    strncpy(buf, err, buflen - 1);
-    buf[buflen - 1] = '\0';
+    OPENSSL_strlcpy(buf, err, buflen);
     return 1;
 #endif
 }

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -223,14 +223,18 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 #if defined(_MSC_VER) && _MSC_VER>=1400
     return !strerror_s(buf, buflen, errnum);
 #elif defined(_GNU_SOURCE)
-    /* GNU strerror_r may not actually set buf.
-     * It may return a pointer to some (immutable) static string in which case
+    char *err;
+
+    /*
+     * GNU strerror_r may not actually set buf.
+     * It can return a pointer to some (immutable) static string in which case
      * buf is left unused.
      */
-    char *err = strerror_r(errnum, buf, buflen);
+    *buf = '\0';
+    err = strerror_r(errnum, buf, buflen);
     if (err == NULL)
         return 0;
-    if (!*buf) {
+    if (*buf == '\0') {
         strncpy(buf, err, buflen - 1);
         buf[buflen - 1] = '\0';
     }
@@ -245,6 +249,7 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
     return !strerror_r(errnum, buf, buflen);
 #else
     char *err;
+
     /* Fall back to non-thread safe strerror()...its all we can do */
     if (buflen < 2)
         return 0;


### PR DESCRIPTION
GNU strerror_r may return either a pointer to a string that the function
stores in buf, or a pointer to some (immutable) static string in which case
buf is left unused.

In such a case we need to set buf manually.

This got exposed by the introduction of 02-test_errstr.t.
Because of the above mentioned GNU strerror_r issue, the SYS_str_reasons table was left empty, causing "openssl errstr" to return the error message without the reason and thus breaking the 02-test_errstr.t test.

$ openssl errstr 2000002
error:02000002:system library:system library:

Affects 1.1.0, 1.1.1, and master.