### PR TITLE
testutil: ensure good treatment of argv on non-Unix platforms

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1725,7 +1725,7 @@ my %targets = (
 
         disable          => add('pinshared'),
 
-        apps_aux_src     => "vms_term_sock.c",
+        apps_aux_src     => "vms_term_sock.c vms_decc_argv.c",
         apps_init_src    => "vms_decc_init.c",
     },
 

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -32,6 +32,7 @@
 # include "apps_ui.h"
 # include "opt.h"
 # include "fmt.h"
+# include "platform.h"
 
 # if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WINCE)
 #  define openssl_fdset(a,b) FD_SET((unsigned int)a, b)
@@ -96,18 +97,6 @@ typedef struct args_st {
     int argc;
     char **argv;
 } ARGS;
-
-/*
- * VMS C only for now, implemented in vms_decc_init.c
- * If other C compilers forget to terminate argv with NULL, this function
- * can be re-used.
- */
-char **copy_argv(int *argc, char *argv[]);
-/*
- * Win32-specific argv initialization that splits OS-supplied UNICODE
- * command line string to array of UTF8-encoded strings.
- */
-void win32_utf8argv(int *argc, char **argv[]);
 
 /* We need both wrap and the "real" function because libcrypto uses both. */
 int wrap_password_callback(char *buf, int bufsiz, int verify, void *cb_data);

--- a/apps/include/platform.h
+++ b/apps/include/platform.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_PLATFORM_H
+# define HEADER_PLATFORM_H
+
+# include <openssl/e_os2.h>
+
+# if defined(OPENSSL_SYS_VMS) && defined(__DECC)
+/*
+ * VMS C only for now, implemented in vms_decc_init.c
+ * If other C compilers forget to terminate argv with NULL, this function
+ * can be re-used.
+ */
+char **copy_argv(int *argc, char *argv[]);
+# endif
+
+# ifdef _WIN32
+/*
+ * Win32-specific argv initialization that splits OS-supplied UNICODE
+ * command line string to array of UTF8-encoded strings.
+ */
+void win32_utf8argv(int *argc, char **argv[]);
+# endif
+
+#endif

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -121,7 +121,6 @@ int main(int argc, char *argv[])
 {
     FUNCTION f, *fp;
     LHASH_OF(FUNCTION) *prog = NULL;
-    char **copied_argv = NULL;
     char *p, *pname;
     char buf[1024];
     const char *prompt;
@@ -138,7 +137,7 @@ int main(int argc, char *argv[])
     bio_err = dup_bio_err(FORMAT_TEXT);
 
 #if defined(OPENSSL_SYS_VMS) && defined(__DECC)
-    copied_argv = argv = copy_argv(&argc, argv);
+    argv = copy_argv(&argc, argv);
 #elif defined(_WIN32)
     /*
      * Replace argv[] with UTF-8 encoded strings.
@@ -252,7 +251,6 @@ int main(int argc, char *argv[])
     }
     ret = 1;
  end:
-    OPENSSL_free(copied_argv);
     OPENSSL_free(default_config_file);
     lh_FUNCTION_free(prog);
     OPENSSL_free(arg.argv);

--- a/apps/vms_decc_argv.c
+++ b/apps/vms_decc_argv.c
@@ -9,7 +9,8 @@
 
 #include <stdlib.h>
 #include <openssl/crypto.h>
-#include "apps.h"                /* for app_malloc() and copy_argv() */
+#include "platform.h"            /* for copy_argv() */
+#include "apps.h"                /* for app_malloc() */
 
 char **newargv = NULL;
 

--- a/apps/vms_decc_argv.c
+++ b/apps/vms_decc_argv.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <openssl/crypto.h>
+#include "apps.h"                /* for app_malloc() and copy_argv() */
+
+char **newargv = NULL;
+
+static void cleanup_argv(void)
+{
+    OPENSSL_free(newargv);
+    newargv = NULL;
+}
+
+char **copy_argv(int *argc, char *argv[])
+{
+    /*-
+     * The note below is for historical purpose.  On VMS now we always
+     * copy argv "safely."
+     *
+     * 2011-03-22 SMS.
+     * If we have 32-bit pointers everywhere, then we're safe, and
+     * we bypass this mess, as on non-VMS systems.
+     * Problem 1: Compaq/HP C before V7.3 always used 32-bit
+     * pointers for argv[].
+     * Fix 1: For a 32-bit argv[], when we're using 64-bit pointers
+     * everywhere else, we always allocate and use a 64-bit
+     * duplicate of argv[].
+     * Problem 2: Compaq/HP C V7.3 (Alpha, IA64) before ECO1 failed
+     * to NULL-terminate a 64-bit argv[].  (As this was written, the
+     * compiler ECO was available only on IA64.)
+     * Fix 2: Unless advised not to (VMS_TRUST_ARGV), we test a
+     * 64-bit argv[argc] for NULL, and, if necessary, use a
+     * (properly) NULL-terminated (64-bit) duplicate of argv[].
+     * The same code is used in either case to duplicate argv[].
+     * Some of these decisions could be handled in preprocessing,
+     * but the code tends to get even uglier, and the penalty for
+     * deciding at compile- or run-time is tiny.
+     */
+
+    int i, count = *argc;
+    char **p = newargv;
+
+    cleanup_argv();
+
+    newargv = app_malloc(sizeof(*newargv) * (count + 1), "argv copy");
+    if (newargv == NULL)
+        return NULL;
+
+    /* Register automatic cleanup on first use */
+    if (p == NULL)
+        OPENSSL_atexit(cleanup_argv);
+
+    for (i = 0; i < count; i++)
+        newargv[i] = argv[i];
+    newargv[i] = NULL;
+    *argc = i;
+    return newargv;
+}

--- a/apps/vms_decc_init.c
+++ b/apps/vms_decc_init.c
@@ -25,8 +25,6 @@
 # include <stdlib.h>
 # include <unixlib.h>
 
-# include "apps.h"
-
 /* Global storage. */
 
 /* Flag to sense if decc_init() was called. */
@@ -62,42 +60,6 @@ decc_feat_t decc_feat_array[] = {
     {(char *)NULL, 0}
 };
 
-
-char **copy_argv(int *argc, char *argv[])
-{
-    /*-
-     * The note below is for historical purpose.  On VMS now we always
-     * copy argv "safely."
-     *
-     * 2011-03-22 SMS.
-     * If we have 32-bit pointers everywhere, then we're safe, and
-     * we bypass this mess, as on non-VMS systems.
-     * Problem 1: Compaq/HP C before V7.3 always used 32-bit
-     * pointers for argv[].
-     * Fix 1: For a 32-bit argv[], when we're using 64-bit pointers
-     * everywhere else, we always allocate and use a 64-bit
-     * duplicate of argv[].
-     * Problem 2: Compaq/HP C V7.3 (Alpha, IA64) before ECO1 failed
-     * to NULL-terminate a 64-bit argv[].  (As this was written, the
-     * compiler ECO was available only on IA64.)
-     * Fix 2: Unless advised not to (VMS_TRUST_ARGV), we test a
-     * 64-bit argv[argc] for NULL, and, if necessary, use a
-     * (properly) NULL-terminated (64-bit) duplicate of argv[].
-     * The same code is used in either case to duplicate argv[].
-     * Some of these decisions could be handled in preprocessing,
-     * but the code tends to get even uglier, and the penalty for
-     * deciding at compile- or run-time is tiny.
-     */
-
-    int i, count = *argc;
-    char **newargv = app_malloc(sizeof(*newargv) * (count + 1), "argv copy");
-
-    for (i = 0; i < count; i++)
-        newargv[i] = argv[i];
-    newargv[i] = NULL;
-    *argc = i;
-    return newargv;
-}
 
 /* LIB$INITIALIZE initialization function. */
 

--- a/test/build.info
+++ b/test/build.info
@@ -6,6 +6,8 @@ SUBDIRS=ossl_shim
          my ($base, $files) = @_;
          return join(" ", map { "$base/$_" } split(/\s+/, $files));
      }
+     our $apps_aux_src =
+         join(' ', map { "../apps/$_" } split(/\s+/, $target{apps_aux_src}));
      ""
 -}
 IF[{- !$disabled{tests} -}]
@@ -14,7 +16,8 @@ IF[{- !$disabled{tests} -}]
           testutil/driver.c testutil/tests.c testutil/cb.c testutil/stanza.c \
           testutil/format_output.c testutil/tap_bio.c \
           testutil/test_cleanup.c testutil/main.c testutil/init.c \
-          testutil/options.c testutil/test_options.c ../apps/opt.c
+          testutil/options.c testutil/test_options.c \
+          testutil/apps_mem.c ../apps/opt.c {- $apps_aux_src; -}
   INCLUDE[libtestutil.a]=../include ../apps/include ..
   DEPEND[libtestutil.a]=../libcrypto
 

--- a/test/testutil/apps_mem.c
+++ b/test/testutil/apps_mem.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "apps.h"
+
+/* shim that avoids sucking in too much from apps/apps.c */
+
+void* app_malloc(int sz, const char *what)
+{
+    void *vp = OPENSSL_malloc(sz);
+
+    return vp;
+}

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -17,6 +17,8 @@
 #include "internal/nelem.h"
 #include <openssl/bio.h>
 
+#include "platform.h"            /* From libapps */
+
 #ifdef _WIN32
 # define strdup _strdup
 #endif
@@ -132,6 +134,16 @@ int setup_test_framework(int argc, char *argv[])
         CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
     }
 #endif
+
+#if defined(OPENSSL_SYS_VMS) && defined(__DECC)
+    argv = copy_argv(&argc, argv);
+#elif defined(_WIN32)
+    /*
+     * Replace argv[] with UTF-8 encoded strings.
+     */
+    win32_utf8argv(&argc, &argv);
+#endif
+
     if (!opt_init(argc, argv, test_get_options()))
         return 0;
     return 1;


### PR DESCRIPTION
From a Unix point of view, some other platform families have certain
quirks.  Windows command prompt doesn't expand globs into actual file
names, so we must do this.  VMS has some oddity with argv pointer size
that can cause crashes if you're not careful (by copying it to a less
surprising pointer size array).

The fixups already exist and are used in the apps/ code.  However, the
testutil code started using the opt routines from apps/ without
including the non-Unix fixups.  This change fixes that.
