### PR TITLE
Alternative fix for BIO_get_mem_ptr

### DIFF
--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -279,7 +279,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_C_GET_BUF_MEM_PTR:
         if (ptr != NULL) {
             mem_buf_sync(b);
-            bm = bbm->readp;
+            bm = bbm->buf;
             pptr = (char **)ptr;
             *pptr = (char *)bm;
         }

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -40,9 +40,8 @@ Memory BIOs support BIO_gets() and BIO_puts().
 If the BIO_CLOSE flag is set when a memory BIO is freed then the underlying
 BUF_MEM structure is also freed.
 
-Calling BIO_reset() on a read write memory BIO clears any data in it if the
-flag BIO_FLAGS_NONCLEAR_RST is not set. On a read only BIO or if the flag
-BIO_FLAGS_NONCLEAR_RST is set it restores the BIO to its original state and
+Calling BIO_reset() on a read write memory BIO clears any data in it.
+On a read only BIO  it restores the BIO to its original state and
 the data can be read again.
 
 BIO_eof() is true if no data is in the BIO.
@@ -64,7 +63,8 @@ close flag to B<c>, that is B<c> should be either BIO_CLOSE or BIO_NOCLOSE.
 It is a macro.
 
 BIO_get_mem_ptr() places the underlying BUF_MEM structure in *B<pp>. It is
-a macro.
+a macro. It is not supported on read only BIOis, only read write BIOs support
+this function.
 
 BIO_new_mem_buf() creates a memory BIO using B<len> bytes of data at B<buf>,
 if B<len> is -1 then the B<buf> is assumed to be nul terminated and its

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -179,10 +179,8 @@ extern "C" {
 /*
  * This is used with memory BIOs:
  * BIO_FLAGS_MEM_RDONLY means we shouldn't free up or change the data in any way;
- * BIO_FLAGS_NONCLEAR_RST means we shouldn't clear data on reset.
  */
 # define BIO_FLAGS_MEM_RDONLY    0x200
-# define BIO_FLAGS_NONCLEAR_RST  0x400
 
 typedef union bio_addr_st BIO_ADDR;
 typedef struct bio_addrinfo_st BIO_ADDRINFO;

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -18,25 +18,53 @@ static int test_bio_memleak(void)
     int ok = 0;
     BIO *bio;
     BUF_MEM bufmem;
-    const char *str = "BIO test\n";
+    static const char str[] = "BIO test\n";
     char buf[100];
 
     bio = BIO_new(BIO_s_mem());
-    if (bio == NULL)
+    if (!TEST_ptr(bio))
         goto finish;
-    bufmem.length = strlen(str) + 1;
+    bufmem.length = sizeof(str);
     bufmem.data = (char *) str;
     bufmem.max = bufmem.length;
     BIO_set_mem_buf(bio, &bufmem, BIO_NOCLOSE);
     BIO_set_flags(bio, BIO_FLAGS_MEM_RDONLY);
-
-    if (BIO_read(bio, buf, sizeof(buf)) <= 0)
-	goto finish;
-
-    ok = strcmp(buf, str) == 0;
+    if (!TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(str)))
+        goto finish;
+    if (!TEST_mem_eq(buf, sizeof(str), str, sizeof(str)))
+        goto finish;
+    ok = 1;
 
 finish:
     BIO_free(bio);
+    return ok;
+}
+
+static int test_bio_get_mem(void)
+{
+    int ok = 0;
+    BIO *bio = NULL;
+    BUF_MEM *bufmem = NULL;
+
+    bio = BIO_new(BIO_s_mem());
+    if (!TEST_ptr(bio))
+        goto finish;
+    if (!TEST_int_eq(BIO_puts(bio, "Hello World\n"), 12))
+        goto finish;
+    BIO_get_mem_ptr(bio, &bufmem);
+    if (!TEST_ptr(bufmem))
+        goto finish;
+    if (!TEST_int_gt(BIO_set_close(bio, BIO_NOCLOSE), 0))
+        goto finish;
+    BIO_free(bio);
+    bio = NULL;
+    if (!TEST_mem_eq(bufmem->data, bufmem->length, "Hello World\n", 12))
+        goto finish;
+    ok = 1;
+
+finish:
+    BIO_free(bio);
+    BUF_MEM_free(bufmem);
     return ok;
 }
 
@@ -50,5 +78,6 @@ int global_init(void)
 int setup_tests(void)
 {
     ADD_TEST(test_bio_memleak);
+    ADD_TEST(test_bio_get_mem);
     return 1;
 }

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -68,6 +68,41 @@ finish:
     return ok;
 }
 
+static int test_bio_new_mem_buf(void)
+{
+    int ok = 0;
+    BIO *bio;
+    BUF_MEM *bufmem;
+    char data[16];
+
+    bio = BIO_new_mem_buf("Hello World\n", 12);
+    if (!TEST_ptr(bio))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 5), 5))
+        goto finish;
+    if (!TEST_mem_eq(data, 5, "Hello", 5))
+        goto finish;
+    if (!TEST_int_eq(BIO_get_mem_ptr(bio, &bufmem), 0))
+        goto finish;
+    if (!TEST_int_lt(BIO_write(bio, "test", 4), 0))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 16), 7))
+        goto finish;
+    if (!TEST_mem_eq(data, 7, " World\n", 7))
+        goto finish;
+    if (!TEST_int_gt(BIO_reset(bio), 0))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 16), 12))
+        goto finish;
+    if (!TEST_mem_eq(data, 7, "Hello World\n", 7))
+        goto finish;
+    ok = 1;
+
+finish:
+    BIO_free(bio);
+    return ok;
+}
+
 int global_init(void)
 {
     CRYPTO_set_mem_debug(1);
@@ -79,5 +114,6 @@ int setup_tests(void)
 {
     ADD_TEST(test_bio_memleak);
     ADD_TEST(test_bio_get_mem);
+    ADD_TEST(test_bio_new_mem_buf);
     return 1;
 }


### PR DESCRIPTION
Alternative to #8378 removing BIO_FLAGS_NONCLEAR_RST which did never work.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
