### PR TITLE
FIPS AES_GCM IV gen changes

### DIFF
--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/evp.h>
+#include "testutil.h"
+
+static const unsigned char gcm_key[] = {
+    0xee, 0xbc, 0x1f, 0x57, 0x48, 0x7f, 0x51, 0x92, 0x1c, 0x04, 0x65, 0x66,
+    0x5f, 0x8a, 0xe6, 0xd1, 0x65, 0x8b, 0xb2, 0x6d, 0xe6, 0xf8, 0xa0, 0x69,
+    0xa3, 0x52, 0x02, 0x93, 0xa5, 0x72, 0x07, 0x8f
+};
+static const unsigned char gcm_iv[] = {
+    0x99, 0xaa, 0x3e, 0x68, 0xed, 0x81, 0x73, 0xa0, 0xee, 0xd0, 0x66, 0x84
+};
+static const unsigned char gcm_pt[] = {
+    0xf5, 0x6e, 0x87, 0x05, 0x5b, 0xc3, 0x2d, 0x0e, 0xeb, 0x31, 0xb2, 0xea,
+    0xcc, 0x2b, 0xf2, 0xa5
+};
+static const unsigned char gcm_aad[] = {
+    0x4d, 0x23, 0xc3, 0xce, 0xc3, 0x34, 0xb4, 0x9b, 0xdb, 0x37, 0x0c, 0x43,
+    0x7f, 0xec, 0x78, 0xde
+};
+static const unsigned char gcm_ct[] = {
+    0xf7, 0x26, 0x44, 0x13, 0xa8, 0x4c, 0x0e, 0x7c, 0xd5, 0x36, 0x86, 0x7e,
+    0xb9, 0xf2, 0x17, 0x36
+};
+static const unsigned char gcm_tag[] = {
+    0x67, 0xba, 0x05, 0x10, 0x26, 0x2a, 0xe4, 0x87, 0xd7, 0x37, 0xee, 0x62,
+    0x98, 0xf7, 0x7e, 0x0c
+};
+
+static int do_encrypt(unsigned char *iv_gen, unsigned char *ct, int *ct_len,
+                      unsigned char *tag, int *tag_len)
+{
+    int ret = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
+    int outlen;
+    unsigned char outbuf[64];
+
+    *tag_len = 16;
+    ret = TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+          && TEST_true(EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL,
+                                          NULL) > 0)
+          && TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, gcm_key,
+                                          iv_gen != NULL ? NULL : gcm_iv) > 0)
+          && TEST_true(EVP_EncryptUpdate(ctx, NULL, &outlen, gcm_aad,
+                                         sizeof(gcm_aad)) > 0)
+          && TEST_true(EVP_EncryptUpdate(ctx, ct, ct_len, gcm_pt,
+                                         sizeof(gcm_pt)) > 0)
+          && TEST_true(EVP_EncryptFinal_ex(ctx, outbuf, &outlen) > 0)
+          && TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, 16,
+                                           tag) > 0)
+          && TEST_true(iv_gen == NULL
+                  || EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GET_IV, 12, iv_gen) > 0);
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
+static int do_decrypt(const unsigned char *iv, const unsigned char *ct,
+                      int ct_len, const unsigned char *tag, int tag_len)
+{
+    int ret = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
+    int outlen, ptlen;
+    unsigned char pt[32];
+    unsigned char outbuf[32];
+
+    ret = TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+              && TEST_true(EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL,
+                                              NULL, NULL) > 0)
+              && TEST_true(EVP_DecryptInit_ex(ctx, NULL, NULL, gcm_key, iv) > 0)
+              && TEST_true(EVP_DecryptUpdate(ctx, NULL, &outlen, gcm_aad,
+                                             sizeof(gcm_aad)) > 0)
+              && TEST_true(EVP_DecryptUpdate(ctx, pt, &ptlen, ct,
+                                             ct_len) > 0)
+              && TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
+                                               tag_len, (void *)tag) > 0)
+              && TEST_true(EVP_DecryptFinal_ex(ctx, outbuf, &outlen) > 0)
+              && TEST_mem_eq(gcm_pt, sizeof(gcm_pt), pt, ptlen);
+
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
+static int kat_test(void)
+{
+    unsigned char tag[32];
+    unsigned char ct[32];
+    int ctlen = 0, taglen = 0;
+
+    return do_encrypt(NULL, ct, &ctlen, tag, &taglen)
+           && TEST_mem_eq(gcm_ct, sizeof(gcm_ct), ct, ctlen)
+           && TEST_mem_eq(gcm_tag, sizeof(gcm_tag), tag, taglen)
+           && do_decrypt(gcm_iv, ct, ctlen, tag, taglen);
+}
+
+#ifdef FIPS_MODE
+static int ivgen_test(void)
+{
+    unsigned char iv_gen[16];
+    unsigned char tag[32];
+    unsigned char ct[32];
+    int ctlen = 0, taglen = 0;
+
+    return do_encrypt(iv_gen, ct, &ctlen, tag, &taglen)
+           && do_decrypt(iv_gen, ct, ctlen, tag, taglen);
+}
+#endif /* FIPS_MODE */
+
+int setup_tests(void)
+{
+    ADD_TEST(kat_test);
+#ifdef FIPS_MODE
+    ADD_TEST(ivgen_test);
+#endif /* FIPS_MODE */
+    return 1;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -50,7 +50,7 @@ IF[{- !$disabled{tests} -}]
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           servername_test ocspapitest rsa_mp_test fatalerrtest tls13ccstest \
           sysdefaulttest errtest gosttest \
-          context_internal_test
+          context_internal_test aesgcmtest
 
   SOURCE[versions]=versions.c
   INCLUDE[versions]=../include ../apps/include
@@ -569,6 +569,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[gosttest]=gosttest.c ssltestlib.c
   INCLUDE[gosttest]=../include ../apps/include ..
   DEPEND[gosttest]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[aesgcmtest]=aesgcmtest.c
+  INCLUDE[aesgcmtest]=../include ../apps/include ..
+  DEPEND[aesgcmtest]=../libcrypto libtestutil.a
 
   PROGRAMS{noinst}=context_internal_test
   SOURCE[context_internal_test]=context_internal_test.c

--- a/test/recipes/30-test_aesgcm.t
+++ b/test/recipes/30-test_aesgcm.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_aesgcm", "aesgcmtest", "aesgcm");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

In FIPS mode the IV for AES_GCM must be generated inside the fips module boundary.
Note it has not been enforced in the code, because there are cases where it must still be passed in.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
