### PR TITLE
padlock: generate assembler source for static libraries too

### DIFF
--- a/engines/build.info
+++ b/engines/build.info
@@ -20,9 +20,6 @@ IF[{- !$disabled{"engine"} -}]
       SOURCE[padlock]=e_padlock.c {- $target{padlock_asm_src} -}
       DEPEND[padlock]=../libcrypto
       INCLUDE[padlock]=../include
-      GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl \
-        $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
-      GENERATE[e_padlock-x86_64.s]=asm/e_padlock-x86_64.pl $(PERLASM_SCHEME)
       IF[{- defined $target{shared_defflag} -}]
         SHARED_SOURCE[padlock]=padlock.ld
         GENERATE[padlock.ld]=../util/engines.num
@@ -75,4 +72,7 @@ IF[{- !$disabled{"engine"} -}]
       GENERATE[ossltest.ld]=../util/engines.num
     ENDIF
   ENDIF
+  GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl \
+    $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
+  GENERATE[e_padlock-x86_64.s]=asm/e_padlock-x86_64.pl $(PERLASM_SCHEME)
 ENDIF


### PR DESCRIPTION
The GENERATE lines for generating the padlock assembler source were
wrongly placed in such a way that they only applied to the shared
library build.
