### PR TITLE
Sparse array code using ossl_uintmax_t index.

### DIFF
--- a/crypto/include/internal/sparse_array.h
+++ b/crypto/include/internal/sparse_array.h
@@ -39,25 +39,27 @@ extern "C" {
         return OPENSSL_SA_num((OPENSSL_SA *)sa); \
     } \
     static ossl_unused ossl_inline void ossl_sa_##type##_doall(const SPARSE_ARRAY_OF(type) *sa, \
-                                                   void (*leaf)(size_t, type *)) \
+                                                   void (*leaf)(ossl_uintmax_t, \
+                                                                type *)) \
     { \
-        OPENSSL_SA_doall((OPENSSL_SA *)sa, (void (*)(size_t, void *))leaf); \
+        OPENSSL_SA_doall((OPENSSL_SA *)sa, (void (*)(ossl_uintmax_t, void *))leaf); \
     } \
     static ossl_unused ossl_inline \
     void ossl_sa_##type##_doall_arg(const SPARSE_ARRAY_OF(type) *sa, \
-                                    void (*leaf)(size_t, type *, void *), \
+                                    void (*leaf)(ossl_uintmax_t, type *, void *), \
                                     void *arg) \
     { \
-        OPENSSL_SA_doall_arg((OPENSSL_SA *)sa, (void (*)(size_t, void *, void *))leaf, \
+        OPENSSL_SA_doall_arg((OPENSSL_SA *)sa, (void (*)(ossl_uintmax_t, void *, \
+                                                void *))leaf, \
                              arg); \
     } \
     static ossl_unused ossl_inline type *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, \
-                                                  size_t n) \
+                                                  ossl_uintmax_t n) \
     { \
         return (type *)OPENSSL_SA_get((OPENSSL_SA *)sa, n); \
     } \
     static ossl_unused ossl_inline int ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) *sa, \
-                                                size_t n, type *val) \
+                                                ossl_uintmax_t n, type *val) \
     { \
         return OPENSSL_SA_set((OPENSSL_SA *)sa, n, (void *)val); \
     } \
@@ -68,11 +70,12 @@ OPENSSL_SA *OPENSSL_SA_new(void);
 void OPENSSL_SA_free(OPENSSL_SA *sa);
 void OPENSSL_SA_free_leaves(OPENSSL_SA *sa);
 size_t OPENSSL_SA_num(const OPENSSL_SA *sa);
-void OPENSSL_SA_doall(const OPENSSL_SA *sa, void (*leaf)(size_t, void *));
+void OPENSSL_SA_doall(const OPENSSL_SA *sa,
+                      void (*leaf)(ossl_uintmax_t, void *));
 void OPENSSL_SA_doall_arg(const OPENSSL_SA *sa,
-                          void (*leaf)(size_t, void *, void *), void *);
-void *OPENSSL_SA_get(const OPENSSL_SA *sa, size_t n);
-int OPENSSL_SA_set(OPENSSL_SA *sa, size_t n, void *val);
+                          void (*leaf)(ossl_uintmax_t, void *, void *), void *);
+void *OPENSSL_SA_get(const OPENSSL_SA *sa, ossl_uintmax_t n);
+int OPENSSL_SA_set(OPENSSL_SA *sa, ossl_uintmax_t n, void *val);
 
 # ifdef  __cplusplus
 }

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -131,7 +131,7 @@ static void impl_cache_free(QUERY *elem)
     OPENSSL_free(elem);
 }
 
-static void alg_cleanup(size_t idx, ALGORITHM *a)
+static void alg_cleanup(ossl_uintmax_t idx, ALGORITHM *a)
 {
     if (a != NULL) {
         sk_IMPLEMENTATION_pop_free(a->impls, &impl_free);
@@ -356,7 +356,7 @@ int ossl_method_store_set_global_properties(OSSL_METHOD_STORE *store,
     return ret;
 }
 
-static void impl_cache_flush_alg(size_t idx, ALGORITHM *alg)
+static void impl_cache_flush_alg(ossl_uintmax_t idx, ALGORITHM *alg)
 {
     lh_QUERY_doall(alg->cache, &impl_cache_free);
     lh_QUERY_flush(alg->cache);
@@ -413,7 +413,8 @@ static void impl_cache_flush_cache(QUERY *c, IMPL_CACHE_FLUSH *state)
         state->nelem++;
 }
 
-static void impl_cache_flush_one_alg(size_t idx, ALGORITHM *alg, void *v)
+static void impl_cache_flush_one_alg(ossl_uintmax_t idx, ALGORITHM *alg,
+                                     void *v)
 {
     IMPL_CACHE_FLUSH *state = (IMPL_CACHE_FLUSH *)v;
 

--- a/crypto/sparse_array.c
+++ b/crypto/sparse_array.c
@@ -29,7 +29,7 @@
  * at a cost in time.
  *
  * The library builder is also permitted to define other sizes in the closed
- * interval [2, sizeof(size_t) * 8].
+ * interval [2, sizeof(ossl_uintmax_t) * 8].
  */
 #ifndef OPENSSL_SA_BLOCK_BITS
 # ifdef OPENSSL_SMALL_FOOTPRINT
@@ -49,13 +49,13 @@
   */
 #define SA_BLOCK_MAX            (1 << OPENSSL_SA_BLOCK_BITS)
 #define SA_BLOCK_MASK           (SA_BLOCK_MAX - 1)
-#define SA_BLOCK_MAX_LEVELS     (((int)sizeof(size_t) * 8 \
+#define SA_BLOCK_MAX_LEVELS     (((int)sizeof(ossl_uintmax_t) * 8 \
                                   + OPENSSL_SA_BLOCK_BITS - 1) \
                                  / OPENSSL_SA_BLOCK_BITS)
 
 struct sparse_array_st {
     int levels;
-    size_t top;
+    ossl_uintmax_t top;
     size_t nelem;
     void **nodes;
 };
@@ -68,11 +68,11 @@ OPENSSL_SA *OPENSSL_SA_new(void)
 }
 
 static void sa_doall(const OPENSSL_SA *sa, void (*node)(void **),
-                     void (*leaf)(size_t, void *, void *), void *arg)
+                     void (*leaf)(ossl_uintmax_t, void *, void *), void *arg)
 {
     int i[SA_BLOCK_MAX_LEVELS];
     void *nodes[SA_BLOCK_MAX_LEVELS];
-    size_t idx = 0;
+    ossl_uintmax_t idx = 0;
     int l = 0;
 
     i[0] = 0;
@@ -107,7 +107,7 @@ static void sa_free_node(void **p)
     OPENSSL_free(p);
 }
 
-static void sa_free_leaf(size_t n, void *p, void *arg)
+static void sa_free_leaf(ossl_uintmax_t n, void *p, void *arg)
 {
     OPENSSL_free(p);
 }
@@ -126,15 +126,16 @@ void OPENSSL_SA_free_leaves(OPENSSL_SA *sa)
 
 /* Wrap this in a structure to avoid compiler warnings */
 struct trampoline_st {
-    void (*func)(size_t, void *);
+    void (*func)(ossl_uintmax_t, void *);
 };
 
-static void trampoline(size_t n, void *l, void *arg)
+static void trampoline(ossl_uintmax_t n, void *l, void *arg)
 {
     ((const struct trampoline_st *)arg)->func(n, l);
 }
 
-void OPENSSL_SA_doall(const OPENSSL_SA *sa, void (*leaf)(size_t, void *))
+void OPENSSL_SA_doall(const OPENSSL_SA *sa, void (*leaf)(ossl_uintmax_t,
+                                                         void *))
 {
     struct trampoline_st tramp;
 
@@ -144,7 +145,8 @@ void OPENSSL_SA_doall(const OPENSSL_SA *sa, void (*leaf)(size_t, void *))
 }
 
 void OPENSSL_SA_doall_arg(const OPENSSL_SA *sa,
-                          void (*leaf)(size_t, void *, void *), void *arg)
+                          void (*leaf)(ossl_uintmax_t, void *, void *),
+                          void *arg)
 {
     if (sa != NULL)
         sa_doall(sa, NULL, leaf, arg);
@@ -155,7 +157,7 @@ size_t OPENSSL_SA_num(const OPENSSL_SA *sa)
     return sa == NULL ? 0 : sa->nelem;
 }
 
-void *OPENSSL_SA_get(const OPENSSL_SA *sa, size_t n)
+void *OPENSSL_SA_get(const OPENSSL_SA *sa, ossl_uintmax_t n)
 {
     int level;
     void **p, *r = NULL;
@@ -178,10 +180,10 @@ static ossl_inline void **alloc_node(void)
     return OPENSSL_zalloc(SA_BLOCK_MAX * sizeof(void *));
 }
 
-int OPENSSL_SA_set(OPENSSL_SA *sa, size_t posn, void *val)
+int OPENSSL_SA_set(OPENSSL_SA *sa, ossl_uintmax_t posn, void *val)
 {
     int i, level = 1;
-    size_t n = posn;
+    ossl_uintmax_t n = posn;
     void **p;
 
     if (sa == NULL)

--- a/doc/internal/man3/DEFINE_SPARSE_ARRAY_OF.pod
+++ b/doc/internal/man3/DEFINE_SPARSE_ARRAY_OF.pod
@@ -21,12 +21,15 @@ ossl_sa_TYPE_doall_arg, ossl_sa_TYPE_get, ossl_sa_TYPE_set
  SPARSE_ARRAY_OF(TYPE) *ossl_sa_TYPE_new(void);
  void ossl_sa_TYPE_free(const SPARSE_ARRAY_OF(TYPE) *sa);
  void ossl_sa_TYPE_free_leaves(const SPARSE_ARRAY_OF(TYPE) *sa);
- int ossl_sa_TYPE_num(const SPARSE_ARRAY_OF(TYPE) *sa);
- void ossl_sa_TYPE_doall(const OPENSSL_SA *sa, void (*leaf)(size_t, void *));
+ size_t ossl_sa_TYPE_num(const SPARSE_ARRAY_OF(TYPE) *sa);
+ void ossl_sa_TYPE_doall(const OPENSSL_SA *sa, void (*leaf)(ossl_uintmax_t,
+                                                            void *));
  void ossl_sa_TYPE_doall_arg(const OPENSSL_SA *sa,
-                             void (*leaf)(size_t, void *, void *), void *arg);
- TYPE *ossl_sa_TYPE_get(const SPARSE_ARRAY_OF(TYPE) *sa, size_t idx);
- int ossl_sa_TYPE_set(SPARSE_ARRAY_OF(TYPE) *sa, size_t idx, TYPE *value);
+                             void (*leaf)(ossl_uintmax_t, void *, void *),
+                             void *arg);
+ TYPE *ossl_sa_TYPE_get(const SPARSE_ARRAY_OF(TYPE) *sa, ossl_uintmax_t idx);
+ int ossl_sa_TYPE_set(SPARSE_ARRAY_OF(TYPE) *sa, ossl_uintmax_t idx,
+                      TYPE *value);
 
 =head1 DESCRIPTION
 
@@ -36,7 +39,7 @@ B<TYPE>. This will mean that a pointer to type B<TYPE> is stored in each
 element of a sparse array, the type is referenced by SPARSE_ARRAY_OF(TYPE) and
 each function name begins with I<ossl_sa_TYPE_>. For example:
 
- TYPE *ossl_sa_TYPE_get(SPARSE_ARRAY_OF(TYPE) *sa, size_t idx);
+ TYPE *ossl_sa_TYPE_get(SPARSE_ARRAY_OF(TYPE) *sa, ossl_uintmax_t idx);
 
 ossl_sa_TYPE_num() returns the number of elements in B<sa> or 0 if B<sa> is
 B<NULL>.

--- a/test/sparse_array_test.c
+++ b/test/sparse_array_test.c
@@ -30,11 +30,11 @@ DEFINE_SPARSE_ARRAY_OF(char);
 static int test_sparse_array(void)
 {
     static const struct {
-        size_t n;
+        ossl_uintmax_t n;
         char *v;
     } cases[] = {
         { 22, "a" }, { 0, "z" }, { 1, "b" }, { 290, "c" },
-        { INT_MAX, "m" }, { 6666666, "d" }, { (size_t)-1, "H" },
+        { INT_MAX, "m" }, { 6666666, "d" }, { (ossl_uintmax_t)-1, "H" },
         { 99, "e" }
     };
     SPARSE_ARRAY_OF(char) *sa;
@@ -69,7 +69,7 @@ static int test_sparse_array_num(void)
 {
     static const struct {
         size_t num;
-        size_t n;
+        ossl_uintmax_t n;
         char *v;
     } cases[] = {
         { 1, 22, "a" }, { 2, 1021, "b" }, { 3, 3, "c" }, { 2, 22, NULL },
@@ -96,7 +96,7 @@ err:
 }
 
 struct index_cases_st {
-    size_t n;
+    ossl_uintmax_t n;
     char *v;
     int del;
 };
@@ -109,7 +109,7 @@ struct doall_st {
     int all;
 };
 
-static void leaf_check_all(size_t n, char *value, void *arg)
+static void leaf_check_all(ossl_uintmax_t n, char *value, void *arg)
 {
     struct doall_st *doall_data = (struct doall_st *)arg;
     const struct index_cases_st *cases = doall_data->cases;
@@ -125,7 +125,7 @@ static void leaf_check_all(size_t n, char *value, void *arg)
     TEST_error("Index %zu with value %s not found", n, value);
 }
 
-static void leaf_delete(size_t n, char *value, void *arg)
+static void leaf_delete(ossl_uintmax_t n, char *value, void *arg)
 {
     struct doall_st *doall_data = (struct doall_st *)arg;
     const struct index_cases_st *cases = doall_data->cases;
@@ -145,8 +145,8 @@ static int test_sparse_array_doall(void)
 {
     static const struct index_cases_st cases[] = {
         { 22, "A", 1 }, { 1021, "b", 0 }, { 3, "c", 0 }, { INT_MAX, "d", 1 },
-        { (size_t)-1, "H", 0 }, { (size_t)-2, "i", 1 }, { 666666666, "s", 1 },
-        { 1234567890, "t", 0 },
+        { (ossl_uintmax_t)-1, "H", 0 }, { (ossl_uintmax_t)-2, "i", 1 },
+        { 666666666, "s", 1 }, { 1234567890, "t", 0 },
     };
     struct doall_st doall_data;
     size_t i;


### PR DESCRIPTION
It previously used `size_t`.  The difference is slight but it should never reduce the range covered and might increase it on some platforms.

- [x] documentation is added or updated
- [x] tests are added or updated
