### PR TITLE
ts(1): digest option is mandatory

### DIFF
--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -262,7 +262,7 @@ specified, the argument is given to the engine as a key identifier.
 =item B<-I<digest>>
 
 Signing digest to use. Overrides the B<signer_digest> config file
-option. (Optional)
+option. (Mandatory unless specified in the config file)
 
 =item B<-chain> certs_file.pem
 
@@ -460,7 +460,8 @@ command line option. (Optional)
 =item B<signer_digest>
 
 Signing digest to use. The same as the
-B<-I<digest>> command line option. (Optional)
+B<-I<digest>> command line option. (Mandatory unless specified on the command
+line)
 
 =item B<default_policy>
 


### PR DESCRIPTION
not specifying the digest both on command line and in the config file
will lead to response generation aborting with

140617514493760:error:2F098088:time stamp routines:ts_CONF_lookup_fail:cannot find config variable:crypto/ts/ts_conf.c:106:tsr_test::signer_digest

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
