### PR TITLE
apps/speed.c: skip binary curves when compiling with NO_EC2M

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -518,7 +518,7 @@ enum {
     R_EC_BRP512R1,
     R_EC_BRP512T1,
     R_EC_X25519,
-    R_EC_X448,
+    R_EC_X448
 };
 
 #ifndef OPENSSL_NO_EC

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -492,30 +492,35 @@ static const OPT_PAIR rsa_choices[] = {
 static double rsa_results[RSA_NUM][2];  /* 2 ops: sign then verify */
 #endif /* OPENSSL_NO_RSA */
 
-#define R_EC_P160    0
-#define R_EC_P192    1
-#define R_EC_P224    2
-#define R_EC_P256    3
-#define R_EC_P384    4
-#define R_EC_P521    5
-#define R_EC_K163    6
-#define R_EC_K233    7
-#define R_EC_K283    8
-#define R_EC_K409    9
-#define R_EC_K571    10
-#define R_EC_B163    11
-#define R_EC_B233    12
-#define R_EC_B283    13
-#define R_EC_B409    14
-#define R_EC_B571    15
-#define R_EC_BRP256R1  16
-#define R_EC_BRP256T1  17
-#define R_EC_BRP384R1  18
-#define R_EC_BRP384T1  19
-#define R_EC_BRP512R1  20
-#define R_EC_BRP512T1  21
-#define R_EC_X25519  22
-#define R_EC_X448    23
+enum {
+    R_EC_P160,
+    R_EC_P192,
+    R_EC_P224,
+    R_EC_P256,
+    R_EC_P384,
+    R_EC_P521,
+#ifndef OPENSSL_NO_EC2M
+    R_EC_K163,
+    R_EC_K233,
+    R_EC_K283,
+    R_EC_K409,
+    R_EC_K571,
+    R_EC_B163,
+    R_EC_B233,
+    R_EC_B283,
+    R_EC_B409,
+    R_EC_B571,
+#endif
+    R_EC_BRP256R1,
+    R_EC_BRP256T1,
+    R_EC_BRP384R1,
+    R_EC_BRP384T1,
+    R_EC_BRP512R1,
+    R_EC_BRP512T1,
+    R_EC_X25519,
+    R_EC_X448,
+};
+
 #ifndef OPENSSL_NO_EC
 static OPT_PAIR ecdsa_choices[] = {
     {"ecdsap160", R_EC_P160},
@@ -524,7 +529,7 @@ static OPT_PAIR ecdsa_choices[] = {
     {"ecdsap256", R_EC_P256},
     {"ecdsap384", R_EC_P384},
     {"ecdsap521", R_EC_P521},
-#ifndef OPENSSL_NO_EC2M
+# ifndef OPENSSL_NO_EC2M
     {"ecdsak163", R_EC_K163},
     {"ecdsak233", R_EC_K233},
     {"ecdsak283", R_EC_K283},
@@ -535,7 +540,7 @@ static OPT_PAIR ecdsa_choices[] = {
     {"ecdsab283", R_EC_B283},
     {"ecdsab409", R_EC_B409},
     {"ecdsab571", R_EC_B571},
-#endif
+# endif
     {"ecdsabrp256r1", R_EC_BRP256R1},
     {"ecdsabrp256t1", R_EC_BRP256T1},
     {"ecdsabrp384r1", R_EC_BRP384R1},
@@ -554,7 +559,7 @@ static const OPT_PAIR ecdh_choices[] = {
     {"ecdhp256", R_EC_P256},
     {"ecdhp384", R_EC_P384},
     {"ecdhp521", R_EC_P521},
-#ifndef OPENSSL_NO_EC2M
+# ifndef OPENSSL_NO_EC2M
     {"ecdhk163", R_EC_K163},
     {"ecdhk233", R_EC_K233},
     {"ecdhk283", R_EC_K283},
@@ -565,7 +570,7 @@ static const OPT_PAIR ecdh_choices[] = {
     {"ecdhb283", R_EC_B283},
     {"ecdhb409", R_EC_B409},
     {"ecdhb571", R_EC_B571},
-#endif
+# endif
     {"ecdhbrp256r1", R_EC_BRP256R1},
     {"ecdhbrp256t1", R_EC_BRP256T1},
     {"ecdhbrp384r1", R_EC_BRP384R1},
@@ -1528,7 +1533,7 @@ int speed_main(int argc, char **argv)
         {"nistp256", NID_X9_62_prime256v1, 256},
         {"nistp384", NID_secp384r1, 384},
         {"nistp521", NID_secp521r1, 521},
-#ifndef OPENSSL_NO_EC2M
+# ifndef OPENSSL_NO_EC2M
         /* Binary Curves */
         {"nistk163", NID_sect163k1, 163},
         {"nistk233", NID_sect233k1, 233},
@@ -1540,7 +1545,7 @@ int speed_main(int argc, char **argv)
         {"nistb283", NID_sect283r1, 283},
         {"nistb409", NID_sect409r1, 409},
         {"nistb571", NID_sect571r1, 571},
-#endif
+# endif
         {"brainpoolP256r1", NID_brainpoolP256r1, 256},
         {"brainpoolP256t1", NID_brainpoolP256t1, 256},
         {"brainpoolP384r1", NID_brainpoolP384r1, 384},
@@ -2069,6 +2074,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
+#   ifndef OPENSSL_NO_EC2M
     ecdsa_c[R_EC_K163][0] = count / 1000;
     ecdsa_c[R_EC_K163][1] = count / 1000 / 2;
     for (i = R_EC_K233; i <= R_EC_K571; i++) {
@@ -2097,6 +2103,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
+#   endif
 
     ecdh_c[R_EC_P160][0] = count / 1000;
     for (i = R_EC_P192; i <= R_EC_P521; i++) {
@@ -2109,6 +2116,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
+#   ifndef OPENSSL_NO_EC2M
     ecdh_c[R_EC_K163][0] = count / 1000;
     for (i = R_EC_K233; i <= R_EC_K571; i++) {
         ecdh_c[i][0] = ecdh_c[i - 1][0] / 2;
@@ -2131,6 +2139,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
+#   endif
     /* repeated code good to factorize */
     ecdh_c[R_EC_BRP256R1][0] = count / 1000;
     for (i = R_EC_BRP384R1; i <= R_EC_BRP512R1; i += 2) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -524,6 +524,7 @@ static OPT_PAIR ecdsa_choices[] = {
     {"ecdsap256", R_EC_P256},
     {"ecdsap384", R_EC_P384},
     {"ecdsap521", R_EC_P521},
+#ifndef OPENSSL_NO_EC2M
     {"ecdsak163", R_EC_K163},
     {"ecdsak233", R_EC_K233},
     {"ecdsak283", R_EC_K283},
@@ -534,6 +535,7 @@ static OPT_PAIR ecdsa_choices[] = {
     {"ecdsab283", R_EC_B283},
     {"ecdsab409", R_EC_B409},
     {"ecdsab571", R_EC_B571},
+#endif
     {"ecdsabrp256r1", R_EC_BRP256R1},
     {"ecdsabrp256t1", R_EC_BRP256T1},
     {"ecdsabrp384r1", R_EC_BRP384R1},
@@ -552,6 +554,7 @@ static const OPT_PAIR ecdh_choices[] = {
     {"ecdhp256", R_EC_P256},
     {"ecdhp384", R_EC_P384},
     {"ecdhp521", R_EC_P521},
+#ifndef OPENSSL_NO_EC2M
     {"ecdhk163", R_EC_K163},
     {"ecdhk233", R_EC_K233},
     {"ecdhk283", R_EC_K283},
@@ -562,6 +565,7 @@ static const OPT_PAIR ecdh_choices[] = {
     {"ecdhb283", R_EC_B283},
     {"ecdhb409", R_EC_B409},
     {"ecdhb571", R_EC_B571},
+#endif
     {"ecdhbrp256r1", R_EC_BRP256R1},
     {"ecdhbrp256t1", R_EC_BRP256T1},
     {"ecdhbrp384r1", R_EC_BRP384R1},
@@ -1524,6 +1528,7 @@ int speed_main(int argc, char **argv)
         {"nistp256", NID_X9_62_prime256v1, 256},
         {"nistp384", NID_secp384r1, 384},
         {"nistp521", NID_secp521r1, 521},
+#ifndef OPENSSL_NO_EC2M
         /* Binary Curves */
         {"nistk163", NID_sect163k1, 163},
         {"nistk233", NID_sect233k1, 233},
@@ -1535,6 +1540,7 @@ int speed_main(int argc, char **argv)
         {"nistb283", NID_sect283r1, 283},
         {"nistb409", NID_sect409r1, 409},
         {"nistb571", NID_sect571r1, 571},
+#endif
         {"brainpoolP256r1", NID_brainpoolP256r1, 256},
         {"brainpoolP256t1", NID_brainpoolP256t1, 256},
         {"brainpoolP384r1", NID_brainpoolP384r1, 384},


### PR DESCRIPTION
openssl speed doesn't take into account that the library could be compiled without the support for the binary curves and will happily uses them, which will results in EC_GROUP_new_by_curve_name() errors.

$ openssl speed -seconds 1 ecdh
[...]
Doing 521 bits  ecdh's for 1s: 2355 521-bits ECDH ops in 1.00s
ECDH EC params init failure.
140292076904960:error:100AE081:elliptic curve routines:EC_GROUP_new_by_curve_name:unknown group:crypto/ec/ec_curve.c:3132:
140292076904960:error:100C508D:elliptic curve routines:pkey_ec_ctrl:invalid curve:crypto/ec/ec_pmeth.c:231:

The switch to enum from macros for defining constants is needed because of the following reason:

Just adding ifdefs isn't enough. Systems without SIGALRM need special care.
The ecdh_c array is allocated of the same size as ecdh_choices, whose size depends on whether the support for binary curves is enabled or not.  (The same goes for ecdsa_c).
On systems without SIGALRM, ecdh_c is indexed by predefined constants (eg. R_EC_BRP256R1) intended for representing the index of the ciphers in the ecdh_choices array.
However, in case of NO_EC2M some of the #defined constants would become invalid because the size of the array shrunk. They would point after the ecdh_c array causing an out-of-bounds access.

Using enum instead of the macros to define the curve indexes will prevent the invalid access.
    

