### PR TITLE
[1.0.2][backport] Fix --strict-warnings for arm

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -64,7 +64,7 @@
 #  endif
 # endif
 
-# if !__ASSEMBLER__
+# ifndef __ASSEMBLER__
 extern unsigned int OPENSSL_armcap_P;
 # endif
 

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -5,6 +5,7 @@
 #include <signal.h>
 #include <crypto.h>
 
+#include "cryptlib.h"
 #include "arm_arch.h"
 
 unsigned int OPENSSL_armcap_P = 0;

--- a/crypto/cryptlib.h
+++ b/crypto/cryptlib.h
@@ -106,6 +106,8 @@ extern int OPENSSL_NONPIC_relocated;
 
 char *ossl_safe_getenv(const char *);
 
+unsigned long OPENSSL_rdtsc(void);
+
 #ifdef  __cplusplus
 }
 #endif


### PR DESCRIPTION
Backport of #6026 and #6028 to 1.0.2.

I am testing the 1.0.2 branch on aarch64 and noticed that I cannot turn on `--strict-warnings` without these 2 patches.

Cherry-picking #6028 required manual intervention, while #6026 was trivial.

Ping @bernd-edlinger as he is the original author.