### PR TITLE
Reorganized signature-scheme detection in 'apps/s_cb.c:security_callback_debug' function

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1431,7 +1431,8 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
             int raw_sig_code= (salg[0]<<8) + salg[1]; /* always big endian (msb, lsb) */
                 /* raw_sig_code: signature_scheme from tls1.3, or signature_and_hash from tls1.2 */
 
-            BIO_printf(sdb->out, "%s", nm);
+            if (nm != NULL) BIO_printf(sdb->out, "%s", nm);
+            else            BIO_printf(sdb->out, "s_cb.c:security_callback_debug op=0x%x", op);
 
             sname= lookup(raw_sig_code, signature_tls13_scheme_list, NULL);
             if (sname != NULL) {

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1434,7 +1434,7 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
             BIO_printf(sdb->out, "%s", nm);
 
             sname= lookup(raw_sig_code, signature_tls13_scheme_list, NULL);
-            if (sname) {
+            if (sname != NULL) {
                 BIO_printf(sdb->out, " scheme=%s", sname);
             } else {
                 int alg_code= salg[1];
@@ -1442,7 +1442,7 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
                 const char *alg_str= lookup(alg_code, signature_tls12_alg_list, NULL);
                 const char *hash_str= lookup(hash_code, signature_tls12_hash_list, NULL);
 
-                if (alg_str && hash_str) {
+                if (alg_str != NULL && hash_str != NULL) {
                     BIO_printf(sdb->out, " digest=%s, algorithm=%s", hash_str, alg_str);
                 } else {
                     BIO_printf(sdb->out, " scheme=unknown(0x%04x)", raw_sig_code);

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1428,20 +1428,22 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
         {
             const unsigned char *salg = other;
             const char *sname = NULL;
-            int raw_sig_code= (salg[0]<<8) + salg[1]; /* always big endian (msb, lsb) */
+            int raw_sig_code = (salg[0]<<8) + salg[1]; /* always big endian (msb, lsb) */
                 /* raw_sig_code: signature_scheme from tls1.3, or signature_and_hash from tls1.2 */
 
-            if (nm != NULL) BIO_printf(sdb->out, "%s", nm);
-            else            BIO_printf(sdb->out, "s_cb.c:security_callback_debug op=0x%x", op);
+            if (nm != NULL)
+                BIO_printf(sdb->out, "%s", nm);
+            else
+                BIO_printf(sdb->out, "s_cb.c:security_callback_debug op=0x%x", op);
 
-            sname= lookup(raw_sig_code, signature_tls13_scheme_list, NULL);
+            sname = lookup(raw_sig_code, signature_tls13_scheme_list, NULL);
             if (sname != NULL) {
                 BIO_printf(sdb->out, " scheme=%s", sname);
             } else {
-                int alg_code= salg[1];
-                int hash_code= salg[0];
-                const char *alg_str= lookup(alg_code, signature_tls12_alg_list, NULL);
-                const char *hash_str= lookup(hash_code, signature_tls12_hash_list, NULL);
+                int alg_code = salg[1];
+                int hash_code = salg[0];
+                const char *alg_str = lookup(alg_code, signature_tls12_alg_list, NULL);
+                const char *hash_str = lookup(hash_code, signature_tls12_hash_list, NULL);
 
                 if (alg_str != NULL && hash_str != NULL) {
                     BIO_printf(sdb->out, " digest=%s, algorithm=%s", hash_str, alg_str);

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -683,6 +683,53 @@ static STRINT_PAIR tlsext_types[] = {
     {NULL}
 };
 
+/* from rfc8446 4.2.3. + gost(source?) */
+static STRINT_PAIR signature_tls13_scheme_list[] = {
+    {"rsa_pkcs1_sha1",         0x0201 /* TLSEXT_SIGALG_rsa_pkcs1_sha1 */},
+    {"ecdsa_sha1",             0x0203 /* TLSEXT_SIGALG_ecdsa_sha1 */},
+/*  {"rsa_pkcs1_sha224",       0x0301    TLSEXT_SIGALG_rsa_pkcs1_sha224}, not in rfc8446 */
+/*  {"ecdsa_sha224",           0x0303    TLSEXT_SIGALG_ecdsa_sha224}      not in rfc8446 */
+    {"rsa_pkcs1_sha256",       0x0401 /* TLSEXT_SIGALG_rsa_pkcs1_sha256 */},
+    {"ecdsa_secp256r1_sha256", 0x0403 /* TLSEXT_SIGALG_ecdsa_secp256r1_sha256 */},
+    {"rsa_pkcs1_sha384",       0x0501 /* TLSEXT_SIGALG_rsa_pkcs1_sha384 */},
+    {"ecdsa_secp384r1_sha384", 0x0503 /* TLSEXT_SIGALG_ecdsa_secp384r1_sha384 */},
+    {"rsa_pkcs1_sha512",       0x0601 /* TLSEXT_SIGALG_rsa_pkcs1_sha512 */},
+    {"ecdsa_secp521r1_sha512", 0x0603 /* TLSEXT_SIGALG_ecdsa_secp521r1_sha512 */},
+    {"rsa_pss_rsae_sha256",    0x0804 /* TLSEXT_SIGALG_rsa_pss_rsae_sha256 */},
+    {"rsa_pss_rsae_sha384",    0x0805 /* TLSEXT_SIGALG_rsa_pss_rsae_sha384 */},
+    {"rsa_pss_rsae_sha512",    0x0806 /* TLSEXT_SIGALG_rsa_pss_rsae_sha512 */},
+    {"ed25519",                0x0807 /* TLSEXT_SIGALG_ed25519 */},
+    {"ed448",                  0x0808 /* TLSEXT_SIGALG_ed448 */},
+    {"rsa_pss_pss_sha256",     0x0809 /* TLSEXT_SIGALG_rsa_pss_pss_sha256 */},
+    {"rsa_pss_pss_sha384",     0x080a /* TLSEXT_SIGALG_rsa_pss_pss_sha384 */},
+    {"rsa_pss_pss_sha512",     0x080b /* TLSEXT_SIGALG_rsa_pss_pss_sha512 */},
+    {"gostr34102001",          0xeded /* TLSEXT_SIGALG_gostr34102001_gostr3411 */},
+    {"gostr34102012_256",      0xeeee /* TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256 */},
+    {"gostr34102012_512",      0xefef /* TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512 */},
+    {NULL}
+};
+
+/* from rfc5246 7.4.1.4.1. */
+static STRINT_PAIR signature_tls12_alg_list[] = {
+    {"anonymous", TLSEXT_signature_anonymous /* 0 */},
+    {"RSA",       TLSEXT_signature_rsa       /* 1 */},
+    {"DSA",       TLSEXT_signature_dsa       /* 2 */},
+    {"ECDSA",     TLSEXT_signature_ecdsa     /* 3 */},
+    {NULL}
+};
+
+/* from rfc5246 7.4.1.4.1. */
+static STRINT_PAIR signature_tls12_hash_list[] = {
+    {"none",   TLSEXT_hash_none   /* 0 */},
+    {"MD5",    TLSEXT_hash_md5    /* 1 */},
+    {"SHA1",   TLSEXT_hash_sha1   /* 2 */},
+    {"SHA224", TLSEXT_hash_sha224 /* 3 */},
+    {"SHA256", TLSEXT_hash_sha256 /* 4 */},
+    {"SHA384", TLSEXT_hash_sha384 /* 5 */},
+    {"SHA512", TLSEXT_hash_sha512 /* 6 */},
+    {NULL}
+};
+
 void tlsext_cb(SSL *s, int client_server, int type,
                const unsigned char *data, int len, void *arg)
 {
@@ -1282,9 +1329,9 @@ static STRINT_PAIR callback_types[] = {
     {"Supported Curve", SSL_SECOP_CURVE_SUPPORTED},
     {"Shared Curve", SSL_SECOP_CURVE_SHARED},
     {"Check Curve", SSL_SECOP_CURVE_CHECK},
-    {"Supported Signature Algorithm digest", SSL_SECOP_SIGALG_SUPPORTED},
-    {"Shared Signature Algorithm digest", SSL_SECOP_SIGALG_SHARED},
-    {"Check Signature Algorithm digest", SSL_SECOP_SIGALG_CHECK},
+    {"Supported Signature Algorithm", SSL_SECOP_SIGALG_SUPPORTED},
+    {"Shared Signature Algorithm", SSL_SECOP_SIGALG_SHARED},
+    {"Check Signature Algorithm", SSL_SECOP_SIGALG_CHECK},
     {"Signature Algorithm mask", SSL_SECOP_SIGALG_MASK},
     {"Certificate chain EE key", SSL_SECOP_EE_KEY},
     {"Certificate chain CA key", SSL_SECOP_CA_KEY},
@@ -1304,29 +1351,37 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
     security_debug_ex *sdb = ex;
     int rv, show_bits = 1, cert_md = 0;
     const char *nm;
+    int show_nm;
     rv = sdb->old_cb(s, ctx, op, bits, nid, other, ex);
     if (rv == 1 && sdb->verbose < 2)
         return 1;
     BIO_puts(sdb->out, "Security callback: ");
 
     nm = lookup(op, callback_types, NULL);
+    show_nm = nm!=NULL;
     switch (op) {
     case SSL_SECOP_TICKET:
     case SSL_SECOP_COMPRESSION:
         show_bits = 0;
-        nm = NULL;
+        show_nm = 0;
         break;
     case SSL_SECOP_VERSION:
         BIO_printf(sdb->out, "Version=%s", lookup(nid, ssl_versions, "???"));
         show_bits = 0;
-        nm = NULL;
+        show_nm = 0;
         break;
     case SSL_SECOP_CA_MD:
     case SSL_SECOP_PEER_CA_MD:
         cert_md = 1;
         break;
+    case SSL_SECOP_SIGALG_SUPPORTED:
+    case SSL_SECOP_SIGALG_SHARED:
+    case SSL_SECOP_SIGALG_CHECK:
+    case SSL_SECOP_SIGALG_MASK:
+        show_nm = 0;
+        break;
     }
-    if (nm != NULL)
+    if (show_nm)
         BIO_printf(sdb->out, "%s=", nm);
 
     switch (op & SSL_SECOP_OTHER_TYPE) {
@@ -1373,27 +1428,26 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
         {
             const unsigned char *salg = other;
             const char *sname = NULL;
-            switch (salg[1]) {
-            case TLSEXT_signature_anonymous:
-                sname = "anonymous";
-                break;
-            case TLSEXT_signature_rsa:
-                sname = "RSA";
-                break;
-            case TLSEXT_signature_dsa:
-                sname = "DSA";
-                break;
-            case TLSEXT_signature_ecdsa:
-                sname = "ECDSA";
-                break;
-            }
+            int raw_sig_code= (salg[0]<<8) + salg[1]; /* always big endian (msb, lsb) */
+                /* raw_sig_code: signature_scheme from tls1.3, or signature_and_hash from tls1.2 */
 
-            BIO_puts(sdb->out, OBJ_nid2sn(nid));
-            if (sname)
-                BIO_printf(sdb->out, ", algorithm=%s", sname);
-            else
-                BIO_printf(sdb->out, ", algid=%d", salg[1]);
-            break;
+            BIO_printf(sdb->out, "%s", nm);
+
+            sname= lookup(raw_sig_code, signature_tls13_scheme_list, NULL);
+            if (sname) {
+                BIO_printf(sdb->out, " scheme=%s", sname);
+            } else {
+                int alg_code= salg[1];
+                int hash_code= salg[0];
+                const char *alg_str= lookup(alg_code, signature_tls12_alg_list, NULL);
+                const char *hash_str= lookup(hash_code, signature_tls12_hash_list, NULL);
+
+                if (alg_str && hash_str) {
+                    BIO_printf(sdb->out, " digest=%s, algorithm=%s", hash_str, alg_str);
+                } else {
+                    BIO_printf(sdb->out, " scheme=unknown(0x%04x)", raw_sig_code);
+                }
+            }
         }
 
     }

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1445,11 +1445,10 @@ static int security_callback_debug(const SSL *s, const SSL_CTX *ctx,
                 const char *alg_str = lookup(alg_code, signature_tls12_alg_list, NULL);
                 const char *hash_str = lookup(hash_code, signature_tls12_hash_list, NULL);
 
-                if (alg_str != NULL && hash_str != NULL) {
+                if (alg_str != NULL && hash_str != NULL)
                     BIO_printf(sdb->out, " digest=%s, algorithm=%s", hash_str, alg_str);
-                } else {
+                else
                     BIO_printf(sdb->out, " scheme=unknown(0x%04x)", raw_sig_code);
-                }
             }
         }
 


### PR DESCRIPTION
Reorganized signature-scheme detection in 'apps/s_cb.c:security_callback_debug' callback-function.

So far, it only handled hash-and-algorithm pairs from TLS1.2,
now it also handles 'schemes' defined in TLS1.3 like 0x0807=ed25519 or
0x0809=rsa_pss_pss_sha256

Now it prints information in one of these formats:
```
... Algorithm scheme=ecdsa_secp256r1_sha256, security bits=128 ... TLS1.3
... Algorithm digest=SHA384, algorithm=DSA, security bits=192  ... TLS1.2
... Algorithm scheme=unknown(0x0e01), security bits=128        ... unhandled case
```
To implement this added three new lookup-tables: signature_tls13_scheme_list,
signature_tls12_alg_list, signature_tls12_hash_list.

Also minor changes in 'security_callback_debug', eg adding variable 'show_nm'
to indicate if we should show 'nm'.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
