### PR TITLE
Update pkeyutl documentation about the digest option

### DIFF
--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -299,18 +299,19 @@ value less than the minimum restriction.
 =head1 DSA ALGORITHM
 
 The DSA algorithm supports signing and verification operations only. Currently
-there are no additional options other than B<digest>. The SHA1 digest is assumed
-by default.
+there are no additional B<-pkeyopt> options other than B<digest>. The SHA1
+digest is assumed by default.
 
 =head1 DH ALGORITHM
 
 The DH algorithm only supports the derivation operation and no additional
-options.
+B<-pkeyopt> options.
 
 =head1 EC ALGORITHM
 
 The EC algorithm supports sign, verify and derive operations. The sign and
-verify operations use ECDSA and derive uses ECDH.
+verify operations use ECDSA and derive uses ECDH. SHA1 is assumed by default for
+the B<-pkeyopt> B<digest> option.
 
 =head1 X25519 and X448 ALGORITHMS
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -299,8 +299,8 @@ value less than the minimum restriction.
 =head1 DSA ALGORITHM
 
 The DSA algorithm supports signing and verification operations only. Currently
-there are no additional options other than B<digest>. Only the SHA1
-digest can be used and this digest is assumed by default.
+there are no additional options other than B<digest>. The SHA1 digest is assumed
+by default.
 
 =head1 DH ALGORITHM
 
@@ -310,9 +310,7 @@ options.
 =head1 EC ALGORITHM
 
 The EC algorithm supports sign, verify and derive operations. The sign and
-verify operations use ECDSA and derive uses ECDH. Currently there are no
-additional options other than B<digest>. Only the SHA1 digest can be used and
-this digest is assumed by default.
+verify operations use ECDSA and derive uses ECDH.
 
 =head1 X25519 and X448 ALGORITHMS
 


### PR DESCRIPTION
DSA can accept other digests other than SHA1. EC ignores the digest option
altogether.

Fixes #8425
