### PR TITLE
fix spelling error

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -218,7 +218,7 @@ Even though SNI should normally be a DNS name and not an IP address, if
 B<-servername> is provided then that name will be sent, regardless of whether 
 it is a DNS name or not.
 
-This option cannot be used in conjuction with B<-noservername>.
+This option cannot be used in conjunction with B<-noservername>.
 
 =item B<-noservername>
 

--- a/doc/man3/SSL_CTX_set_read_ahead.pod
+++ b/doc/man3/SSL_CTX_set_read_ahead.pod
@@ -46,7 +46,7 @@ records, and SSL_has_pending() can't tell the difference between processed and
 unprocessed data, it's recommended that if read ahead is turned on that
 B<SSL_MODE_AUTO_RETRY> is not turned off using SSL_CTX_clear_mode().
 That will prevent getting B<SSL_ERROR_WANT_READ> when there is still a complete
-record availale that hasn't been processed.
+record available that hasn't been processed.
 
 If the application wants to continue to use the underlying transport (e.g. TCP
 connection) after the SSL connection is finished using SSL_shutdown() reading


### PR DESCRIPTION
- [x] documentation is added or updated

trivial fix for a spelling error in a manpage
CLA: trivial