### PR TITLE
Fix no-dso

### DIFF
--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -11,6 +11,11 @@
 #include "internal/provider.h"
 #include "testutil.h"
 
+#if !defined(DSO_VMS) && !defined(DSO_DLCFN) && !defined(DSO_DL) \
+    && !defined(DSO_WIN32) && !defined(DSO_DLFCN)
+# define OPENSSL_NO_DSO
+#endif
+
 extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
 
 static char buf[256];
@@ -56,7 +61,7 @@ static int test_builtin_provider(void)
         && test_provider(prov);
 }
 
-#ifndef OPENSSL_NO_SHARED
+#ifndef OPENSSL_NO_DSO
 static int test_loaded_provider(void)
 {
     const char *name = "p_test";
@@ -71,7 +76,7 @@ static int test_loaded_provider(void)
 int setup_tests(void)
 {
     ADD_TEST(test_builtin_provider);
-#ifndef OPENSSL_NO_SHARED
+#ifndef OPENSSL_NO_DSO
     ADD_TEST(test_loaded_provider);
 #endif
     return 1;

--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -11,6 +11,12 @@
 #include <openssl/provider.h>
 #include "testutil.h"
 
+#if !defined(DSO_VMS) && !defined(DSO_DLCFN) && !defined(DSO_DL) \
+    && !defined(DSO_WIN32) && !defined(DSO_DLFCN)
+# define OPENSSL_NO_DSO
+#endif
+
+
 extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
 
 static char buf[256];
@@ -45,11 +51,11 @@ static int test_builtin_provider(void)
 
     return
         TEST_true(OSSL_PROVIDER_add_builtin(NULL, name,
-					    PROVIDER_INIT_FUNCTION_NAME))
+                                            PROVIDER_INIT_FUNCTION_NAME))
         && test_provider(name);
 }
 
-#ifndef OPENSSL_NO_SHARED
+#ifndef OPENSSL_NO_DSO
 static int test_loaded_provider(void)
 {
     const char *name = "p_test";
@@ -61,7 +67,7 @@ static int test_loaded_provider(void)
 int setup_tests(void)
 {
     ADD_TEST(test_builtin_provider);
-#ifndef OPENSSL_NO_SHARED
+#ifndef OPENSSL_NO_DSO
     ADD_TEST(test_loaded_provider);
 #endif
     return 1;


### PR DESCRIPTION
Don't try to load external provider modules in tests if we don't have DSO
capability