### PR TITLE
trace: don't leak the line prefix and other enhancements

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -126,30 +126,17 @@ typedef struct tracedata_st {
 static size_t internal_trace_cb(const char *buf, size_t cnt,
                                 int category, int cmd, void *vdata)
 {
-    int ret;
+    int ret = 0;
     tracedata *trace_data = vdata;
-    int set_prefix = 0;
+    union {
+        CRYPTO_THREAD_ID tid;
+        unsigned long ltid;
+    } tid;
+    char buffer[256];
 
     switch (cmd) {
     case OSSL_TRACE_CTRL_BEGIN:
         trace_data->ingroup = 1;
-        set_prefix = 1;
-        break;
-    case OSSL_TRACE_CTRL_DURING:
-        if (!trace_data->ingroup)
-            set_prefix = 1;
-        break;
-    case OSSL_TRACE_CTRL_END:
-        trace_data->ingroup = 0;
-        break;
-    }
-
-    if (set_prefix) {
-        union {
-            CRYPTO_THREAD_ID tid;
-            unsigned long ltid;
-        } tid;
-        char buffer[256];
 
         tid.ltid = 0;
         tid.tid = CRYPTO_THREAD_get_current_id();
@@ -158,8 +145,17 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
                      OSSL_trace_get_category_name(category));
         BIO_ctrl(trace_data->bio, PREFIX_CTRL_SET_PREFIX,
                  strlen(buffer), buffer);
+        break;
+    case OSSL_TRACE_CTRL_WRITE:
+        ret = BIO_write(trace_data->bio, buf, cnt);
+        break;
+    case OSSL_TRACE_CTRL_END:
+        trace_data->ingroup = 0;
+
+        BIO_ctrl(trace_data->bio, PREFIX_CTRL_SET_PREFIX, 0, NULL);
+
+        break;
     }
-    ret = BIO_write(trace_data->bio, buf, cnt);
 
     return ret < 0 ? 0 : ret;
 }

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -136,6 +136,8 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
 
     switch (cmd) {
     case OSSL_TRACE_CTRL_BEGIN:
+        if (!ossl_assert(!trace_data->ingroup))
+            return 0;
         trace_data->ingroup = 1;
 
         tid.ltid = 0;
@@ -147,9 +149,14 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
                  strlen(buffer), buffer);
         break;
     case OSSL_TRACE_CTRL_WRITE:
+        if (!ossl_assert(trace_data->ingroup))
+            return 0;
+
         ret = BIO_write(trace_data->bio, buf, cnt);
         break;
     case OSSL_TRACE_CTRL_END:
+        if (!ossl_assert(trace_data->ingroup))
+            return 0;
         trace_data->ingroup = 0;
 
         BIO_ctrl(trace_data->bio, PREFIX_CTRL_SET_PREFIX, 0, NULL);

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -169,18 +169,25 @@ static struct {
 #endif
 
 #ifndef OPENSSL_NO_TRACE
+
+enum {
+    CHANNEL,
+    PREFIX,
+    SUFFIX
+};
+
 static int trace_attach_cb(int category, int type, const void *data)
 {
     switch (type) {
-    case 0:                      /* Channel */
+    case CHANNEL:
         OSSL_TRACE2(TRACE, "Attach channel %p to category '%s'\n",
                     data, trace_categories[category].name);
         break;
-    case 1:                      /* Prefix */
+    case PREFIX:
         OSSL_TRACE2(TRACE, "Attach prefix \"%s\" to category '%s'\n",
                     (const char *)data, trace_categories[category].name);
         break;
-    case 2:                      /* Suffix */
+    case SUFFIX:
         OSSL_TRACE2(TRACE, "Attach suffix \"%s\" to category '%s'\n",
                     (const char *)data, trace_categories[category].name);
         break;
@@ -193,15 +200,15 @@ static int trace_attach_cb(int category, int type, const void *data)
 static int trace_detach_cb(int category, int type, const void *data)
 {
     switch (type) {
-    case 0:                      /* Channel */
+    case CHANNEL:
         OSSL_TRACE2(TRACE, "Detach channel %p from category '%s'\n",
                     data, trace_categories[category].name);
         break;
-    case 1:                      /* Prefix */
+    case PREFIX:
         OSSL_TRACE2(TRACE, "Detach prefix \"%s\" from category '%s'\n",
                     (const char *)data, trace_categories[category].name);
         break;
-    case 2:                      /* Suffix */
+    case SUFFIX:
         OSSL_TRACE2(TRACE, "Detach suffix \"%s\" from category '%s'\n",
                     (const char *)data, trace_categories[category].name);
         break;
@@ -222,15 +229,15 @@ static int set_trace_data(int category, BIO **channel,
 
     /* Make sure to run the detach callback first on all data */
     if (prefix != NULL && curr_prefix != NULL) {
-        detach_cb(category, 1, curr_prefix);
+        detach_cb(category, PREFIX, curr_prefix);
     }
 
     if (suffix != NULL && curr_suffix != NULL) {
-        detach_cb(category, 2, curr_suffix);
+        detach_cb(category, SUFFIX, curr_suffix);
     }
 
     if (channel != NULL && curr_channel != NULL) {
-        detach_cb(category, 0, curr_channel);
+        detach_cb(category, CHANNEL, curr_channel);
     }
 
     /* After detach callbacks are done, clear data where appropriate */
@@ -268,15 +275,15 @@ static int set_trace_data(int category, BIO **channel,
 
     /* Finally, run the attach callback on the new data */
     if (channel != NULL && *channel != NULL) {
-        attach_cb(category, 0, *channel);
+        attach_cb(category, CHANNEL, *channel);
     }
 
     if (prefix != NULL && *prefix != NULL) {
-        attach_cb(category, 1, *prefix);
+        attach_cb(category, PREFIX, *prefix);
     }
 
     if (suffix != NULL && *suffix != NULL) {
-        attach_cb(category, 2, *suffix);
+        attach_cb(category, SUFFIX, *suffix);
     }
 
     return 1;
@@ -332,16 +339,16 @@ int OSSL_trace_set_channel(int category, BIO *channel)
 static int trace_attach_w_callback_cb(int category, int type, const void *data)
 {
     switch (type) {
-    case 0:                      /* Channel */
+    case CHANNEL:
         OSSL_TRACE2(TRACE,
                     "Attach channel %p to category '%s' (with callback)\n",
                     data, trace_categories[category].name);
         break;
-    case 1:                      /* Prefix */
+    case PREFIX:
         OSSL_TRACE2(TRACE, "Attach prefix \"%s\" to category '%s'\n",
                     (const char *)data, trace_categories[category].name);
         break;
-    case 2:                      /* Suffix */
+    case SUFFIX:
         OSSL_TRACE2(TRACE, "Attach suffix \"%s\" to category '%s'\n",
                     (const char *)data, trace_categories[category].name);
         break;

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -65,7 +65,7 @@ static int trace_write(BIO *channel,
                        const char *buf, size_t num, size_t *written)
 {
     struct trace_data_st *ctx = BIO_get_data(channel);
-    size_t cnt = ctx->callback(buf, num, ctx->category, OSSL_TRACE_CTRL_DURING,
+    size_t cnt = ctx->callback(buf, num, ctx->category, OSSL_TRACE_CTRL_WRITE,
                                ctx->data);
 
     *written = cnt;

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-OSSL_trace_enabled, OSSL_trace_begin, OSSL_trace_end
+OSSL_trace_enabled, OSSL_trace_begin, OSSL_trace_end,
+OSSL_TRACE_BEGIN, OSSL_TRACE_END, OSSL_TRACE1, OSSL_TRACE2, OSSL_TRACE9
 - OpenSSL Tracing API
 
 =head1 SYNOPSIS
@@ -13,6 +14,18 @@ OSSL_trace_enabled, OSSL_trace_begin, OSSL_trace_end
 
  BIO *OSSL_trace_begin(int category);
  void OSSL_trace_end(int category, BIO *channel);
+
+ /* trace group macros */
+ OSSL_TRACE_BEGIN(category) {
+    ...
+ } OSSL_TRACE_END(category);
+
+ /* one-shot trace macros */
+ OSSL_TRACE1(category, format, arg1)
+ OSSL_TRACE2(category, format, arg1, arg2)
+ ...
+ OSSL_TRACE9(category, format, arg1, ..., arg9)
+
 
 =head1 DESCRIPTION
 
@@ -30,6 +43,30 @@ L<OSSL_trace_set_callback(3)/Trace types>.
 The fallback type C<OSSL_TRACE_CATEGORY_ANY> should I<not> be used
 with the functions described here.
 
+Tracing for a specific category is enabled if a so called
+I<trace channel> is attached to it. A trace channel is simply a
+BIO object to which the application can write its trace output.
+
+The application has two different ways of registering a trace channel,
+either by directly providing a BIO object using OSSL_trace_set_channel(),
+or by providing a callback routine using OSSL_trace_set_callback().
+The latter is wrapped internally by a dedicated BIO object, so for the
+tracing code both channel types are effectively indistinguishable.
+We call them a I<simple trace channel> and a I<callback trace channel>,
+respectively.
+
+To produce trace output, it is necessary to obtain a pointer to the
+trace channel (i.e., the BIO object) using OSSL_trace_begin(), write
+to it using arbitrary BIO output routines, and finally releases the
+channel using OSSL_trace_end(). The OSSL_trace_begin()/OSSL_trace_end()
+calls surrounding the trace output create a group, which acts as a
+critical section (guarded by a mutex) to ensure that the trace output
+of different threads does not get mixed up.
+
+The tracing code normally does not call OSSL_trace_{begin,end}() directly,
+but rather uses a set of convenience macros, see the L</Macros> section below.
+
+
 =head2 Functions
 
 OSSL_trace_enabled() can be used to check if tracing for the given
@@ -46,7 +83,7 @@ is I<mandatory>.
 The result of trying to produce tracing output outside of such
 sections is undefined.
 
-=head2 Convenience Macros
+=head2 Macros
 
 There are a number of convenience macros defined, to make tracing
 easy and consistent.
@@ -60,7 +97,7 @@ the B<BIO> C<trc_out> and are used as follows to wrap a trace section:
 
  } OSSL_TRACE_END(TLS);
 
-This will normally expands to:
+This will normally expand to:
 
  do {
      BIO *trc_out = OSSL_trace_begin(OSSL_TRACE_CATEGORY_TLS);
@@ -98,6 +135,16 @@ This will normally expand to:
      OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
  } while (0);
 
+
+C<OSSL_TRACE1()>, ... C<OSSL_TRACE9()> are one-shot macros which essentially wrap
+a single BIO_printf() into a tracing group.
+
+The call OSSL_TRACEn(category, format, arg1, ..., argN) expands to:
+
+  OSSL_TRACE_BEGIN(category) {
+    BIO_printf(trc_out, format, arg1, ..., argN)
+  } OSSL_TRACE_END(category)
+
 =head1 NOTES
 
 It is advisable to always check that a trace type is enabled with
@@ -133,7 +180,7 @@ nothing.
 =item *
 
 the convenience macros are defined to produce dead code.
-For example, take this example from L</Convenience Macros> above:
+For example, take this example from L</Macros> section above:
 
  OSSL_TRACE_BEGIN(TLS) {
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -25,14 +25,21 @@ This output comes in form of free text for humans to read.
 
 The trace output is divided into categories which can be
 enabled individually.
-They are enabled by giving them a channel in form of a BIO, or a
-tracer callback, which is responsible for performing the actual
-output.
+Every category can be enabled individually by attaching a so called
+I<trace channel> to it, which in the simplest case is just a BIO object
+to which the application can write the tracing output for this category.
+Alternatively, the application can provide a tracer callback in order to
+get more finegrained trace information. This callback will be wrapped
+internally by a dedicated BIO object.
+
+For the tracing code, both trace channel types are indistinguishable.
+These are called a I<simple trace channel> and a I<callback trace channel>,
+respectively.
 
 =head2 Functions
 
 OSSL_trace_set_channel() is used to enable the given trace C<category>
-by giving it the B<BIO> C<bio>.
+by attaching the B<BIO> C<bio> object as (simple) trace channel.
 
 OSSL_trace_set_prefix() and OSSL_trace_set_suffix() can be used to add
 an extra line for each channel, to be output before and after group of
@@ -46,7 +53,8 @@ OSSL_trace_set_callback() instead.
 OSSL_trace_set_callback() is used to enable the given trace
 C<category> by giving it the tracer callback C<cb> with the associated
 data C<data>, which will simply be passed through to C<cb> whenever
-it's called.
+it's called. The callback function is internally wrapped by a
+dedicated BIO object, the so called I<callback trace channel>.
 This should be used when it's desirable to do form the trace output to
 something suitable for application needs where a prefix and suffix
 line aren't enough.
@@ -78,9 +86,13 @@ callback the possibility to output a dynamic starting line, or set a
 prefix that should be output at the beginning of each line, or
 something other.
 
-=item C<OSSL_TRACE_CTRL_DURING>
+=item C<OSSL_TRACE_CTRL_WRITE>
 
-The callback is called from any regular BIO output routine.
+This callback is called whenever data is written to the BIO by some
+regular BIO output routine.
+An arbitrary number of C<OSSL_TRACE_CTRL_WRITE> callbacks can occur
+inside a group marked by a pair of C<OSSL_TRACE_CTRL_BEGIN> and
+C<OSSL_TRACE_CTRL_END> calls, but never outside such a group.
 
 =item C<OSSL_TRACE_CTRL_END>
 
@@ -177,8 +189,8 @@ success, or 0 on failure.
 
 =head1 EXAMPLES
 
-In all examples below, we assume that the trace producing code is
-this:
+In all examples below, the trace producing code is assumed to be
+the following:
 
  int foo = 42;
  const char bar[] = { 0,  1,  2,  3,  4,  5,  6,  7,

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -95,7 +95,7 @@ typedef size_t (*OSSL_trace_cb)(const char *buffer, size_t count,
  * Possible |cmd| numbers.
  */
 # define OSSL_TRACE_CTRL_BEGIN  0
-# define OSSL_TRACE_CTRL_DURING 1
+# define OSSL_TRACE_CTRL_WRITE  1
 # define OSSL_TRACE_CTRL_END    2
 
 /*

--- a/util/private.num
+++ b/util/private.num
@@ -503,3 +503,9 @@ ASYNC_STATUS_EAGAIN                     define
 ASYNC_STATUS_OK                         define
 ASYNC_STATUS_ERR                        define
 ASYNC_STATUS_UNSUPPORTED                define
+OSSL_TRACE_BEGIN                        define
+OSSL_TRACE_END                          define
+OSSL_TRACE_CANCEL                       define
+OSSL_TRACE1                             define
+OSSL_TRACE2                             define
+OSSL_TRACE9                             define


### PR DESCRIPTION
This pull request started as an attempt to fix the testsuite failures that occurred with the new tracing routines enabled.

```
  make V=1 OPENSSL_TRACE=ANY tests
```

It turned out that the bulk of failures was caused by the fact that the line prefix was leaked, which was detected and reported by `crypto-mdebug`. This issue not only occurs in the testsuite but in any openssl command that produces trace output, for example

```
      OPENSSL_TRACE=ANY util/shlib_wrap.sh  apps/openssl version
      ...
      [00:19:14]  4061 file=apps/bf_prefix.c, line=152, ...
      26 bytes leaked in 1 chunks
```

While fixing this leak, the pull request slowly grew and grew around the line prefix fix. So here is a complete list  of the changes, please consult the respective commit messages (from bottom upwards).

fd55c09640 trace: update the documentation
251afd15f5 trace: ensure correct grouping (2/2)
1faa37ac18 trace: ensure correct grouping (1/2)
6cea628ba0 trace: don't leak the line prefix
7ca677e475 trace: rename the trace channel types
4d430f5f42 trace: remove some magic numbers

The commits 1faa37ac18 and ~~1faa37ac18~~ 251afd15f5 are intended to be joined. Part 1 introduces some assertions which initially fail, and part 2 fixes the problem. (Just in case some of you wants to reproduce the failure. You can use the `openssl version` command from above.)

##### Checklist
- [x] documentation is added or updated
