### PR TITLE
Fix compiling error for mips32r6 and mips64r6

### DIFF
--- a/crypto/bn/asm/mips.pl
+++ b/crypto/bn/asm/mips.pl
@@ -88,7 +88,7 @@ if ($flavour =~ /64|n32/i) {
 	$SZREG=4;
 	$REG_S="sw";
 	$REG_L="lw";
-	$code=".set	mips2\n";
+	$code="#if !(defined (__mips_isa_rev) && (__mips_isa_rev >= 6))\n.set     mips2\n#endif\n";
 }
 
 # Below is N32/64 register layout used in the original module.

--- a/crypto/mips_arch.h
+++ b/crypto/mips_arch.h
@@ -11,7 +11,7 @@
 # define __MIPS_ARCH_H__
 
 # if (defined(__mips_smartmips) || defined(_MIPS_ARCH_MIPS32R3) || \
-      defined(_MIPS_ARCH_MIPS32R5) || defined(_MIPS_ARCH_MIPS32R6))
+      defined(_MIPS_ARCH_MIPS32R5) || defined(_MIPS_ARCH_MIPS32R6)) \
       && !defined(_MIPS_ARCH_MIPS32R2)
 #  define _MIPS_ARCH_MIPS32R2
 # endif


### PR DESCRIPTION
There are some compiling errors for mips32r6 and mips64r6:

crypto/bn/bn-mips.S:56: Error: opcode not supported on this processor: mips2 (mips2) `mulu $1,$12,$7'
crypto/mips_arch.h: Assembler messages:
crypto/mips_arch.h:15: Error: junk at end of line, first unrecognized character is `&'

Signed-off-by: Hua Zhang <hua.zhang1974@hotmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
