### PR TITLE
Fix memory leak in ectest

### DIFF
--- a/test/ectest.c
+++ b/test/ectest.c
@@ -1503,6 +1503,7 @@ static int underflow_test(void)
     BN_CTX_end(ctx);
     EC_POINT_free(P);
     EC_POINT_free(Q);
+    EC_POINT_free(R);
     EC_GROUP_free(grp);
     BN_CTX_free(ctx);
 


### PR DESCRIPTION
We forgot a `free()` in the test introduced with #8405, this fixes #8462 (thanks @richsalz !).

This should be cherry-picked to 1.1.1 as well.

Ping @mattcaswell as he was the original committer.
