### PR TITLE
internal/refcount.h: allow non-atomic build

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -16,16 +16,17 @@
 #  endif
 # endif
 
-# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
-     && !defined(__STDC_NO_ATOMICS__)
-#  include <stdatomic.h>
-#  define HAVE_C11_ATOMICS
-# endif
+# ifndef OPENSSL_DEV_NO_ATOMICS
+#  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+      && !defined(__STDC_NO_ATOMICS__)
+#   include <stdatomic.h>
+#   define HAVE_C11_ATOMICS
+#  endif
 
-# if defined(HAVE_C11_ATOMICS) && defined(ATOMIC_INT_LOCK_FREE) \
-     && ATOMIC_INT_LOCK_FREE > 0
+#  if defined(HAVE_C11_ATOMICS) && defined(ATOMIC_INT_LOCK_FREE) \
+      && ATOMIC_INT_LOCK_FREE > 0
 
-#  define HAVE_ATOMICS 1
+#   define HAVE_ATOMICS 1
 
 typedef _Atomic int CRYPTO_REF_COUNT;
 
@@ -53,9 +54,9 @@ static inline int CRYPTO_DOWN_REF(_Atomic int *val, int *ret, void *lock)
     return 1;
 }
 
-# elif defined(__GNUC__) && defined(__ATOMIC_RELAXED) && __GCC_ATOMIC_INT_LOCK_FREE > 0
+#  elif defined(__GNUC__) && defined(__ATOMIC_RELAXED) && __GCC_ATOMIC_INT_LOCK_FREE > 0
 
-#  define HAVE_ATOMICS 1
+#   define HAVE_ATOMICS 1
 
 typedef int CRYPTO_REF_COUNT;
 
@@ -73,17 +74,17 @@ static __inline__ int CRYPTO_DOWN_REF(int *val, int *ret, void *lock)
     return 1;
 }
 
-# elif defined(_MSC_VER) && _MSC_VER>=1200
+#  elif defined(_MSC_VER) && _MSC_VER>=1200
 
-#  define HAVE_ATOMICS 1
+#   define HAVE_ATOMICS 1
 
 typedef volatile int CRYPTO_REF_COUNT;
 
-#  if (defined(_M_ARM) && _M_ARM>=7) || defined(_M_ARM64)
-#   include <intrin.h>
-#   if defined(_M_ARM64) && !defined(_ARM_BARRIER_ISH)
-#    define _ARM_BARRIER_ISH _ARM64_BARRIER_ISH
-#   endif
+#   if (defined(_M_ARM) && _M_ARM>=7) || defined(_M_ARM64)
+#    include <intrin.h>
+#    if defined(_M_ARM64) && !defined(_ARM_BARRIER_ISH)
+#     define _ARM_BARRIER_ISH _ARM64_BARRIER_ISH
+#    endif
 
 static __inline int CRYPTO_UP_REF(volatile int *val, int *ret, void *lock)
 {
@@ -98,8 +99,8 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret, void *lock)
         __dmb(_ARM_BARRIER_ISH);
     return 1;
 }
-#  else
-#   pragma intrinsic(_InterlockedExchangeAdd)
+#   else
+#    pragma intrinsic(_InterlockedExchangeAdd)
 
 static __inline int CRYPTO_UP_REF(volatile int *val, int *ret, void *lock)
 {
@@ -112,9 +113,12 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret, void *lock)
     *ret = _InterlockedExchangeAdd(val, -1) - 1;
     return 1;
 }
-#  endif
+#   endif
 
-# else
+#  endif
+# endif
+
+# ifndef HAVE_ATOMICS
 
 typedef int CRYPTO_REF_COUNT;
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -116,8 +116,13 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret, void *lock)
 #   endif
 
 #  endif
-# endif
+# endif  /* !OPENSSL_DEV_NO_ATOMICS */
 
+/*
+ * All the refcounting implementations above define HAVE_ATOMICS, so if it's
+ * still undefined here (such as when OPENSSL_DEV_NO_ATMOICS is defined), it
+ * means we need to implement a fallback.  This fallback uses locks.
+ */
 # ifndef HAVE_ATOMICS
 
 typedef int CRYPTO_REF_COUNT;


### PR DESCRIPTION
Configure with -DOPENSSL_DEV_NO_ATOMICS and you get refcount without
atomics.  This is intended for internal development only, to check the
refcounting is properly coded.  It should never become a configuration
option, hence the name of the macro.
