### PR TITLE
Guard some SM2 functions with OPENSSL_NO_SM2

### DIFF
--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -566,8 +566,10 @@ void X509_get0_signature(const ASN1_BIT_STRING **psig,
                          const X509_ALGOR **palg, const X509 *x);
 int X509_get_signature_nid(const X509 *x);
 
+# ifndef OPENSSL_NO_SM2
 void X509_set_sm2_id(X509 *x, ASN1_OCTET_STRING *sm2_id);
 ASN1_OCTET_STRING *X509_get0_sm2_id(X509 *x);
+# endif
 
 int X509_trusted(const X509 *x);
 int X509_alias_set1(X509 *x, const unsigned char *name, int len);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4788,5 +4788,5 @@ OSSL_PARAM_get_utf8_ptr                 4735	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_set_utf8_ptr                 4736	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_get_octet_ptr                4737	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_set_octet_ptr                4738	3_0_0	EXIST::FUNCTION:
-X509_set_sm2_id                         4739	3_0_0	EXIST::FUNCTION:
-X509_get0_sm2_id                        4740	3_0_0	EXIST::FUNCTION:
+X509_set_sm2_id                         4739	3_0_0	EXIST::FUNCTION:SM2
+X509_get0_sm2_id                        4740	3_0_0	EXIST::FUNCTION:SM2


### PR DESCRIPTION
Fixes the no-ec build

