### PR TITLE
EVP_PBE_scrypt() handles salt=NULL as salt=""

### DIFF
--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -52,6 +52,10 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
         pass = empty;
         passlen = 0;
     }
+    if (salt == NULL) {
+        salt = (const unsigned char *)empty;
+        saltlen = 0;
+    }
     if (maxmem == 0)
         maxmem = SCRYPT_MAX_MEM;
 


### PR DESCRIPTION
Modify EVP_PBE_scrypt() to maintain OpenSSL 1.1.1 behavior: salt=NULL
is now handled as salt="" (and saltlen=0).

Commit 5a285addbf39f91d567f95f04b2b41764127950d changed the behavior
of EVP_PBE_scrypt(salt=NULL). Previously, salt=NULL was accepted, but
the function now fails with KDF_R_MISSING_SALT.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
