### PR TITLE
Fix no-posix-io

### DIFF
--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -39,8 +39,8 @@ SKIP: {
 }
 
 SKIP: {
-    skip "Skipping tests that require EC", 4
-        if disabled("ec");
+    skip "Skipping tests that require EC or posix-io", 4
+        if disabled("ec") || disabled("posix-io");
 
     # Ed25519
     ok(run(app(([ 'openssl', 'pkeyutl', '-sign', '-in',


### PR DESCRIPTION
pkeyutl uses posix-io to determine the file size when signing using
Ed25519/Ed448. Therefore we should not attempt to test signing using
those algorithms with pkeyutl if posix-io has been disabled.