### PR TITLE
Configure: untabify indentation

### DIFF
--- a/Configure
+++ b/Configure
@@ -55,7 +55,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # [no-]threads  [don't] try to create a library that is suitable for
 #               multithreaded applications (default is "threads" if we
 #               know how to do it)
-# [no-]shared	[don't] try to create shared libraries when supported.
+# [no-]shared   [don't] try to create shared libraries when supported.
 # [no-]pic      [don't] try to build position independent code when supported.
 #               If disabled, it also disables shared and dynamic-engine.
 # no-asm        do not use assembler
@@ -63,8 +63,8 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 #               will ensure that all methods just return NULL.
 # no-egd        do not compile support for the entropy-gathering daemon APIs
 # [no-]zlib     [don't] compile support for zlib compression.
-# zlib-dynamic	Like "zlib", but the zlib library is expected to be a shared
-#		library and will be loaded in run-time by the OpenSSL library.
+# zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
+#               library and will be loaded in run-time by the OpenSSL library.
 # sctp          include SCTP support
 # enable-weak-ssl-ciphers
 #               Enable weak ciphers that are disabled by default.
@@ -91,18 +91,18 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 #               production quality.
 #
 # DEBUG_SAFESTACK use type-safe stacks to enforce type-safety on stack items
-#		provided to stack calls. Generates unique stack functions for
-#		each possible stack type.
-# BN_LLONG	use the type 'long long' in crypto/bn/bn.h
-# RC4_CHAR	use 'char' instead of 'int' for RC4_INT in crypto/rc4/rc4.h
+#               provided to stack calls. Generates unique stack functions for
+#               each possible stack type.
+# BN_LLONG      use the type 'long long' in crypto/bn/bn.h
+# RC4_CHAR      use 'char' instead of 'int' for RC4_INT in crypto/rc4/rc4.h
 # Following are set automatically by this script
 #
-# MD5_ASM	use some extra md5 assembler,
-# SHA1_ASM	use some extra sha1 assembler, must define L_ENDIAN for x86
-# RMD160_ASM	use some extra ripemd160 assembler,
-# SHA256_ASM	sha256_block is implemented in assembler
-# SHA512_ASM	sha512_block is implemented in assembler
-# AES_ASM	AES_[en|de]crypt is implemented in assembler
+# MD5_ASM       use some extra md5 assembler,
+# SHA1_ASM      use some extra sha1 assembler, must define L_ENDIAN for x86
+# RMD160_ASM    use some extra ripemd160 assembler,
+# SHA256_ASM    sha256_block is implemented in assembler
+# SHA512_ASM    sha512_block is implemented in assembler
+# AES_ASM       AES_[en|de]crypt is implemented in assembler
 
 # Minimum warning options... any contributions to OpenSSL should at least get
 # past these.
@@ -236,20 +236,20 @@ if (grep /^reconf(igure)?$/, @argvcopy) {
     die "reconfiguring with other arguments present isn't supported"
         if scalar @argvcopy > 1;
     if (-f "./configdata.pm") {
-	my $file = "./configdata.pm";
-	unless (my $return = do $file) {
-	    die "couldn't parse $file: $@" if $@;
+        my $file = "./configdata.pm";
+        unless (my $return = do $file) {
+            die "couldn't parse $file: $@" if $@;
             die "couldn't do $file: $!"    unless defined $return;
             die "couldn't run $file"       unless $return;
-	}
+        }
 
-	@argvcopy = defined($configdata::config{perlargv}) ?
-	    @{$configdata::config{perlargv}} : ();
-	die "Incorrect data to reconfigure, please do a normal configuration\n"
-	    if (grep(/^reconf/,@argvcopy));
-	$config{perlenv} = $configdata::config{perlenv} // {};
+        @argvcopy = defined($configdata::config{perlargv}) ?
+            @{$configdata::config{perlargv}} : ();
+        die "Incorrect data to reconfigure, please do a normal configuration\n"
+            if (grep(/^reconf/,@argvcopy));
+        $config{perlenv} = $configdata::config{perlenv} // {};
     } else {
-	die "Insufficient data to reconfigure, please do a normal configuration\n";
+        die "Insufficient data to reconfigure, please do a normal configuration\n";
     }
 }
 
@@ -429,10 +429,10 @@ my @disablables = (
     "zlib-dynamic",
     );
 foreach my $proto ((@tls, @dtls))
-	{
-	push(@disablables, $proto);
-	push(@disablables, "$proto-method") unless $proto eq "tls1_3";
-	}
+        {
+        push(@disablables, $proto);
+        push(@disablables, "$proto-method") unless $proto eq "tls1_3";
+        }
 
 my %deprecated_disablables = (
     "ssl2" => undef,
@@ -446,53 +446,53 @@ my %deprecated_disablables = (
 # All of the following are disabled by default:
 
 our %disabled = ( # "what"         => "comment"
-		  "asan"		=> "default",
-		  "buildtest-c++"	=> "default",
-		  "crypto-mdebug"       => "default",
-		  "crypto-mdebug-backtrace" => "default",
-		  "devcryptoeng"	=> "default",
-		  "ec_nistp_64_gcc_128" => "default",
-		  "egd"                 => "default",
-		  "external-tests"	=> "default",
-		  "fuzz-libfuzzer"	=> "default",
-		  "fuzz-afl"		=> "default",
-		  "heartbeats"          => "default",
-		  "md2"                 => "default",
+                  "asan"                => "default",
+                  "buildtest-c++"       => "default",
+                  "crypto-mdebug"       => "default",
+                  "crypto-mdebug-backtrace" => "default",
+                  "devcryptoeng"        => "default",
+                  "ec_nistp_64_gcc_128" => "default",
+                  "egd"                 => "default",
+                  "external-tests"      => "default",
+                  "fuzz-libfuzzer"      => "default",
+                  "fuzz-afl"            => "default",
+                  "heartbeats"          => "default",
+                  "md2"                 => "default",
                   "msan"                => "default",
-		  "rc5"                 => "default",
-		  "sctp"                => "default",
-		  "ssl-trace"           => "default",
-		  "ssl3"                => "default",
-		  "ssl3-method"         => "default",
-		  "trace"               => "default",
-                  "ubsan"		=> "default",
-		  "unit-test"           => "default",
-		  "weak-ssl-ciphers"    => "default",
-		  "zlib"                => "default",
-		  "zlib-dynamic"        => "default",
-		  "ktls"                => "default",
-		);
+                  "rc5"                 => "default",
+                  "sctp"                => "default",
+                  "ssl-trace"           => "default",
+                  "ssl3"                => "default",
+                  "ssl3-method"         => "default",
+                  "trace"               => "default",
+                  "ubsan"               => "default",
+                  "unit-test"           => "default",
+                  "weak-ssl-ciphers"    => "default",
+                  "zlib"                => "default",
+                  "zlib-dynamic"        => "default",
+                  "ktls"                => "default",
+                );
 
 # Note: => pair form used for aesthetics, not to truly make a hash table
 my @disable_cascades = (
-    # "what"		=> [ "cascade", ... ]
+    # "what"            => [ "cascade", ... ]
     sub { $config{processor} eq "386" }
-			=> [ "sse2" ],
-    "ssl"		=> [ "ssl3" ],
-    "ssl3-method"	=> [ "ssl3" ],
-    "zlib"		=> [ "zlib-dynamic" ],
-    "des"		=> [ "mdc2" ],
-    "ec"		=> [ "ecdsa", "ecdh" ],
+                        => [ "sse2" ],
+    "ssl"               => [ "ssl3" ],
+    "ssl3-method"       => [ "ssl3" ],
+    "zlib"              => [ "zlib-dynamic" ],
+    "des"               => [ "mdc2" ],
+    "ec"                => [ "ecdsa", "ecdh" ],
 
-    "dgram"		=> [ "dtls", "sctp" ],
-    "sock"		=> [ "dgram" ],
-    "dtls"		=> [ @dtls ],
+    "dgram"             => [ "dtls", "sctp" ],
+    "sock"              => [ "dgram" ],
+    "dtls"              => [ @dtls ],
     sub { 0 == scalar grep { !$disabled{$_} } @dtls }
-			=> [ "dtls" ],
+                        => [ "dtls" ],
 
-    "tls"		=> [ @tls ],
+    "tls"               => [ @tls ],
     sub { 0 == scalar grep { !$disabled{$_} } @tls }
-			=> [ "tls" ],
+                        => [ "tls" ],
 
     "crypto-mdebug"     => [ "crypto-mdebug-backtrace" ],
 
@@ -529,14 +529,14 @@ my @list = (reverse @tls);
 while ((my $first, my $second) = (shift @list, shift @list)) {
     last unless @list;
     push @disable_cascades, ( sub { !$disabled{$first} && $disabled{$second} }
-			      => [ @list ] );
+                              => [ @list ] );
     unshift @list, $second;
 }
 my @list = (reverse @dtls);
 while ((my $first, my $second) = (shift @list, shift @list)) {
     last unless @list;
     push @disable_cascades, ( sub { !$disabled{$first} && $disabled{$second} }
-			      => [ @list ] );
+                              => [ @list ] );
     unshift @list, $second;
 }
 
@@ -642,43 +642,43 @@ my %deprecated_options = ();
 my @known_seed_sources = qw(getrandom devrandom os egd none rdcpu librandom);
 my @seed_sources = ();
 while (@argvcopy)
-	{
-	$_ = shift @argvcopy;
+        {
+        $_ = shift @argvcopy;
 
-	# Support env variable assignments among the options
-	if (m|^(\w+)=(.+)?$|)
-		{
-		$cmdvars{$1} = $2;
-		# Every time a variable is given as a configuration argument,
-		# it acts as a reset if the variable.
-		if (exists $user{$1})
-			{
-			$user{$1} = ref $user{$1} eq "ARRAY" ? [] : undef;
-			}
-		#if (exists $useradd{$1})
-		#	{
-		#	$useradd{$1} = [];
-		#	}
-		next;
-		}
+        # Support env variable assignments among the options
+        if (m|^(\w+)=(.+)?$|)
+                {
+                $cmdvars{$1} = $2;
+                # Every time a variable is given as a configuration argument,
+                # it acts as a reset if the variable.
+                if (exists $user{$1})
+                        {
+                        $user{$1} = ref $user{$1} eq "ARRAY" ? [] : undef;
+                        }
+                #if (exists $useradd{$1})
+                #       {
+                #       $useradd{$1} = [];
+                #       }
+                next;
+                }
 
-	# VMS is a case insensitive environment, and depending on settings
-	# out of our control, we may receive options uppercased.  Let's
-	# downcase at least the part before any equal sign.
-	if ($^O eq "VMS")
-		{
-		s/^([^=]*)/lc($1)/e;
-		}
+        # VMS is a case insensitive environment, and depending on settings
+        # out of our control, we may receive options uppercased.  Let's
+        # downcase at least the part before any equal sign.
+        if ($^O eq "VMS")
+                {
+                s/^([^=]*)/lc($1)/e;
+                }
 
-	# some people just can't read the instructions, clang people have to...
-	s/^-no-(?!integrated-as)/no-/;
+        # some people just can't read the instructions, clang people have to...
+        s/^-no-(?!integrated-as)/no-/;
 
-	# rewrite some options in "enable-..." form
-	s /^-?-?shared$/enable-shared/;
-	s /^sctp$/enable-sctp/;
-	s /^threads$/enable-threads/;
-	s /^zlib$/enable-zlib/;
-	s /^zlib-dynamic$/enable-zlib-dynamic/;
+        # rewrite some options in "enable-..." form
+        s /^-?-?shared$/enable-shared/;
+        s /^sctp$/enable-sctp/;
+        s /^threads$/enable-threads/;
+        s /^zlib$/enable-zlib/;
+        s /^zlib-dynamic$/enable-zlib-dynamic/;
 
         if (/^(no|disable|enable)-(.+)$/)
                 {
@@ -747,11 +747,11 @@ while (@argvcopy)
                         {
                         $disabled{$1} = "option";
                         }
-		# No longer an automatic choice
-		$auto_threads = 0 if ($1 eq "threads");
-		}
-	elsif (/^enable-(.+)$/)
-		{
+                # No longer an automatic choice
+                $auto_threads = 0 if ($1 eq "threads");
+                }
+        elsif (/^enable-(.+)$/)
+                {
                 if ($1 eq "static-engine")
                         {
                         $disabled{"dynamic-engine"} = "option";
@@ -764,177 +764,177 @@ while (@argvcopy)
                         {
                         delete $disabled{"zlib"};
                         }
-		my $algo = $1;
-		delete $disabled{$algo};
+                my $algo = $1;
+                delete $disabled{$algo};
 
-		# No longer an automatic choice
-		$auto_threads = 0 if ($1 eq "threads");
-		}
-	elsif (/^--strict-warnings$/)
-		{
-		# Pretend that our strict flags is a C flag, and replace it
-		# with the proper flags later on
-		push @{$useradd{CFLAGS}}, '--ossl-strict-warnings';
-		push @{$useradd{CXXFLAGS}}, '--ossl-strict-warnings';
-		$strict_warnings=1;
-		}
-	elsif (/^--debug$/)
-		{
-		$config{build_type} = "debug";
-		}
-	elsif (/^--release$/)
-		{
-		$config{build_type} = "release";
-		}
-	elsif (/^386$/)
-		{ $config{processor}=386; }
-	elsif (/^fips$/)
-		{
-		die "FIPS mode not supported\n";
-		}
-	elsif (/^rsaref$/)
-		{
-		# No RSAref support any more since it's not needed.
-		# The check for the option is there so scripts aren't
-		# broken
-		}
-	elsif (/^nofipscanistercheck$/)
-		{
-		die "FIPS mode not supported\n";
-		}
-	elsif (/^[-+]/)
-		{
-		if (/^--prefix=(.*)$/)
-			{
-			$config{prefix}=$1;
-			die "Directory given with --prefix MUST be absolute\n"
-				unless file_name_is_absolute($config{prefix});
-			}
-		elsif (/^--api=(.*)$/)
-			{
-			$config{api}=$1;
-			}
-		elsif (/^--libdir=(.*)$/)
-			{
-			$config{libdir}=$1;
-			}
-		elsif (/^--openssldir=(.*)$/)
-			{
-			$config{openssldir}=$1;
-			}
-		elsif (/^--with-zlib-lib=(.*)$/)
-			{
-			$withargs{zlib_lib}=$1;
-			}
-		elsif (/^--with-zlib-include=(.*)$/)
-			{
-			$withargs{zlib_include}=$1;
-			}
-		elsif (/^--with-fuzzer-lib=(.*)$/)
-			{
-			$withargs{fuzzer_lib}=$1;
-			}
-		elsif (/^--with-fuzzer-include=(.*)$/)
-			{
-			$withargs{fuzzer_include}=$1;
-			}
-		elsif (/^--with-rand-seed=(.*)$/)
-			{
-			foreach my $x (split(m|,|, $1))
-			    {
-			    die "Unknown --with-rand-seed choice $x\n"
-				if ! grep { $x eq $_ } @known_seed_sources;
-			    push @seed_sources, $x;
-			    }
+                # No longer an automatic choice
+                $auto_threads = 0 if ($1 eq "threads");
+                }
+        elsif (/^--strict-warnings$/)
+                {
+                # Pretend that our strict flags is a C flag, and replace it
+                # with the proper flags later on
+                push @{$useradd{CFLAGS}}, '--ossl-strict-warnings';
+                push @{$useradd{CXXFLAGS}}, '--ossl-strict-warnings';
+                $strict_warnings=1;
+                }
+        elsif (/^--debug$/)
+                {
+                $config{build_type} = "debug";
+                }
+        elsif (/^--release$/)
+                {
+                $config{build_type} = "release";
+                }
+        elsif (/^386$/)
+                { $config{processor}=386; }
+        elsif (/^fips$/)
+                {
+                die "FIPS mode not supported\n";
+                }
+        elsif (/^rsaref$/)
+                {
+                # No RSAref support any more since it's not needed.
+                # The check for the option is there so scripts aren't
+                # broken
+                }
+        elsif (/^nofipscanistercheck$/)
+                {
+                die "FIPS mode not supported\n";
+                }
+        elsif (/^[-+]/)
+                {
+                if (/^--prefix=(.*)$/)
+                        {
+                        $config{prefix}=$1;
+                        die "Directory given with --prefix MUST be absolute\n"
+                                unless file_name_is_absolute($config{prefix});
                         }
-		elsif (/^--cross-compile-prefix=(.*)$/)
-			{
-			$user{CROSS_COMPILE}=$1;
-			}
-		elsif (/^--config=(.*)$/)
-			{
-			read_config $1;
-			}
-		elsif (/^-l(.*)$/)
-			{
-			push @{$useradd{LDLIBS}}, $_;
-			}
-		elsif (/^-framework$/)
-			{
-			push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
-			}
-		elsif (/^-L(.*)$/ or /^-Wl,/)
-			{
-			push @{$useradd{LDFLAGS}}, $_;
-			}
-		elsif (/^-rpath$/ or /^-R$/)
-			# -rpath is the OSF1 rpath flag
-			# -R is the old Solaris rpath flag
-			{
-			my $rpath = shift(@argvcopy) || "";
-			$rpath .= " " if $rpath ne "";
-			push @{$useradd{LDFLAGS}}, $_, $rpath;
-			}
-		elsif (/^-static$/)
-			{
-			push @{$useradd{LDFLAGS}}, $_;
-			$disabled{"dso"} = "forced";
-			$disabled{"pic"} = "forced";
-			$disabled{"shared"} = "forced";
-			$disabled{"threads"} = "forced";
-			}
-		elsif (/^-D(.*)$/)
-			{
-			push @{$useradd{CPPDEFINES}}, $1;
-			}
-		elsif (/^-I(.*)$/)
-			{
-			push @{$useradd{CPPINCLUDES}}, $1;
-			}
-		elsif (/^-Wp,$/)
-			{
-			push @{$useradd{CPPFLAGS}}, $1;
-			}
-		else	# common if (/^[-+]/), just pass down...
-			{
-			$_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
-			push @{$useradd{CFLAGS}}, $_;
-			push @{$useradd{CXXFLAGS}}, $_;
-			}
-		}
-	else
-		{
-		die "target already defined - $target (offending arg: $_)\n" if ($target ne "");
-		$target=$_;
-		}
-	unless ($_ eq $target || /^no-/ || /^disable-/)
-		{
-		# "no-..." follows later after implied deactivations
-		# have been derived.  (Don't take this too seriously,
-		# we really only write OPTIONS to the Makefile out of
-		# nostalgia.)
+                elsif (/^--api=(.*)$/)
+                        {
+                        $config{api}=$1;
+                        }
+                elsif (/^--libdir=(.*)$/)
+                        {
+                        $config{libdir}=$1;
+                        }
+                elsif (/^--openssldir=(.*)$/)
+                        {
+                        $config{openssldir}=$1;
+                        }
+                elsif (/^--with-zlib-lib=(.*)$/)
+                        {
+                        $withargs{zlib_lib}=$1;
+                        }
+                elsif (/^--with-zlib-include=(.*)$/)
+                        {
+                        $withargs{zlib_include}=$1;
+                        }
+                elsif (/^--with-fuzzer-lib=(.*)$/)
+                        {
+                        $withargs{fuzzer_lib}=$1;
+                        }
+                elsif (/^--with-fuzzer-include=(.*)$/)
+                        {
+                        $withargs{fuzzer_include}=$1;
+                        }
+                elsif (/^--with-rand-seed=(.*)$/)
+                        {
+                        foreach my $x (split(m|,|, $1))
+                            {
+                            die "Unknown --with-rand-seed choice $x\n"
+                                if ! grep { $x eq $_ } @known_seed_sources;
+                            push @seed_sources, $x;
+                            }
+                        }
+                elsif (/^--cross-compile-prefix=(.*)$/)
+                        {
+                        $user{CROSS_COMPILE}=$1;
+                        }
+                elsif (/^--config=(.*)$/)
+                        {
+                        read_config $1;
+                        }
+                elsif (/^-l(.*)$/)
+                        {
+                        push @{$useradd{LDLIBS}}, $_;
+                        }
+                elsif (/^-framework$/)
+                        {
+                        push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
+                        }
+                elsif (/^-L(.*)$/ or /^-Wl,/)
+                        {
+                        push @{$useradd{LDFLAGS}}, $_;
+                        }
+                elsif (/^-rpath$/ or /^-R$/)
+                        # -rpath is the OSF1 rpath flag
+                        # -R is the old Solaris rpath flag
+                        {
+                        my $rpath = shift(@argvcopy) || "";
+                        $rpath .= " " if $rpath ne "";
+                        push @{$useradd{LDFLAGS}}, $_, $rpath;
+                        }
+                elsif (/^-static$/)
+                        {
+                        push @{$useradd{LDFLAGS}}, $_;
+                        $disabled{"dso"} = "forced";
+                        $disabled{"pic"} = "forced";
+                        $disabled{"shared"} = "forced";
+                        $disabled{"threads"} = "forced";
+                        }
+                elsif (/^-D(.*)$/)
+                        {
+                        push @{$useradd{CPPDEFINES}}, $1;
+                        }
+                elsif (/^-I(.*)$/)
+                        {
+                        push @{$useradd{CPPINCLUDES}}, $1;
+                        }
+                elsif (/^-Wp,$/)
+                        {
+                        push @{$useradd{CPPFLAGS}}, $1;
+                        }
+                else    # common if (/^[-+]/), just pass down...
+                        {
+                        $_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
+                        push @{$useradd{CFLAGS}}, $_;
+                        push @{$useradd{CXXFLAGS}}, $_;
+                        }
+                }
+        else
+                {
+                die "target already defined - $target (offending arg: $_)\n" if ($target ne "");
+                $target=$_;
+                }
+        unless ($_ eq $target || /^no-/ || /^disable-/)
+                {
+                # "no-..." follows later after implied deactivations
+                # have been derived.  (Don't take this too seriously,
+                # we really only write OPTIONS to the Makefile out of
+                # nostalgia.)
 
-		if ($config{options} eq "")
-			{ $config{options} = $_; }
-		else
-			{ $config{options} .= " ".$_; }
-		}
-	}
+                if ($config{options} eq "")
+                        { $config{options} = $_; }
+                else
+                        { $config{options} .= " ".$_; }
+                }
+        }
 
 if (defined($config{api}) && !exists $apitable->{$config{api}}) {
-	die "***** Unsupported api compatibility level: $config{api}\n",
+        die "***** Unsupported api compatibility level: $config{api}\n",
 }
 
 if (keys %deprecated_options)
-	{
-	warn "***** Deprecated options: ",
-		join(", ", keys %deprecated_options), "\n";
-	}
+        {
+        warn "***** Deprecated options: ",
+                join(", ", keys %deprecated_options), "\n";
+        }
 if (keys %unsupported_options)
-	{
-	die "***** Unsupported options: ",
-		join(", ", keys %unsupported_options), "\n";
-	}
+        {
+        die "***** Unsupported options: ",
+                join(", ", keys %unsupported_options), "\n";
+        }
 
 # If any %useradd entry has been set, we must check that the "make
 # variables" haven't been set.  We start by checking of any %useradd entry
@@ -990,7 +990,7 @@ if (grep { /-rpath\b/ } ($user{LDFLAGS} ? @{$user{LDFLAGS}} : ())
     && !$disabled{shared}
     && !($disabled{asan} && $disabled{msan} && $disabled{ubsan})) {
     die "***** Cannot simultaneously use -rpath, shared libraries, and\n",
-	"***** any of asan, msan or ubsan\n";
+        "***** any of asan, msan or ubsan\n";
 }
 
 my @tocheckfor = (keys %disabled);
@@ -998,12 +998,12 @@ while (@tocheckfor) {
     my %new_tocheckfor = ();
     my @cascade_copy = (@disable_cascades);
     while (@cascade_copy) {
-	my ($test, $descendents) = (shift @cascade_copy, shift @cascade_copy);
-	if (ref($test) eq "CODE" ? $test->() : defined($disabled{$test})) {
-	    foreach(grep { !defined($disabled{$_}) } @$descendents) {
-		$new_tocheckfor{$_} = 1; $disabled{$_} = "forced";
-	    }
-	}
+        my ($test, $descendents) = (shift @cascade_copy, shift @cascade_copy);
+        if (ref($test) eq "CODE" ? $test->() : defined($disabled{$test})) {
+            foreach(grep { !defined($disabled{$_}) } @$descendents) {
+                $new_tocheckfor{$_} = 1; $disabled{$_} = "forced";
+            }
+        }
     }
     @tocheckfor = (keys %new_tocheckfor);
 }
@@ -1012,14 +1012,14 @@ our $die = sub { die @_; };
 if ($target eq "TABLE") {
     local $die = sub { warn @_; };
     foreach (sort keys %table) {
-	print_table_entry($_, "TABLE");
+        print_table_entry($_, "TABLE");
     }
     exit 0;
 }
 
 if ($target eq "LIST") {
     foreach (sort keys %table) {
-	print $_,"\n" unless $table{$_}->{template};
+        print $_,"\n" unless $table{$_}->{template};
     }
     exit 0;
 }
@@ -1028,7 +1028,7 @@ if ($target eq "HASH") {
     local $die = sub { warn @_; };
     print "%table = (\n";
     foreach (sort keys %table) {
-	print_table_entry($_, "HASH");
+        print_table_entry($_, "HASH");
     }
     exit 0;
 }
@@ -1059,7 +1059,7 @@ _____
 }
 push @{$config{openssl_feature_defines}},
      map { (my $x = $_) =~ tr|[\-a-z]|[_A-Z]|; "OPENSSL_RAND_SEED_$x" }
-	@seed_sources;
+        @seed_sources;
 
 # Backward compatibility?
 if ($target =~ m/^CygWin32(-.*)$/) {
@@ -1073,7 +1073,7 @@ if ($d) {
 
     # If we do not find debug-foo in the table, the target is set to foo.
     if (!$table{$target}) {
-	$target = $t;
+        $target = $t;
     }
 }
 
@@ -1261,21 +1261,21 @@ foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
 push @{$config{defines}}, "NDEBUG"    if $config{build_type} eq "release";
 
 if ($target =~ /^mingw/ && `$config{CC} --target-help 2>&1` =~ m/-mno-cygwin/m)
-	{
-	push @{$config{cflags}}, "-mno-cygwin";
-	push @{$config{cxxflags}}, "-mno-cygwin" if $config{CXX};
-	push @{$config{shared_ldflag}}, "-mno-cygwin";
-	}
+        {
+        push @{$config{cflags}}, "-mno-cygwin";
+        push @{$config{cxxflags}}, "-mno-cygwin" if $config{CXX};
+        push @{$config{shared_ldflag}}, "-mno-cygwin";
+        }
 
 if ($target =~ /linux.*-mips/ && !$disabled{asm}
         && !grep { $_ !~ /-m(ips|arch=)/ } (@{$user{CFLAGS}},
                                             @{$useradd{CFLAGS}})) {
-	# minimally required architecture flags for assembly modules
-	my $value;
-	$value = '-mips2' if ($target =~ /mips32/);
-	$value = '-mips3' if ($target =~ /mips64/);
-	unshift @{$config{cflags}}, $value;
-	unshift @{$config{cxxflags}}, $value if $config{CXX};
+        # minimally required architecture flags for assembly modules
+        my $value;
+        $value = '-mips2' if ($target =~ /mips32/);
+        $value = '-mips3' if ($target =~ /mips64/);
+        unshift @{$config{cflags}}, $value;
+        unshift @{$config{cxxflags}}, $value if $config{CXX};
 }
 
 # If threads aren't disabled, check how possible they are
@@ -1316,13 +1316,13 @@ if (defined($disabled{"deprecated"})) {
 
 my $no_shared_warn=0;
 if ($target{shared_target} eq "")
-	{
-	$no_shared_warn = 1
-	    if (!$disabled{shared} || !$disabled{"dynamic-engine"});
-	$disabled{shared} = "no-shared-target";
-	$disabled{pic} = $disabled{shared} = $disabled{"dynamic-engine"} =
-	    "no-shared-target";
-	}
+        {
+        $no_shared_warn = 1
+            if (!$disabled{shared} || !$disabled{"dynamic-engine"});
+        $disabled{shared} = "no-shared-target";
+        $disabled{pic} = $disabled{shared} = $disabled{"dynamic-engine"} =
+            "no-shared-target";
+        }
 
 if ($disabled{"dynamic-engine"}) {
         push @{$config{openssl_feature_defines}}, "OPENSSL_NO_DYNAMIC_ENGINE";
@@ -1361,25 +1361,25 @@ unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
 
 # This saves the build files from having to check
 if ($disabled{pic})
-	{
-	foreach (qw(shared_cflag shared_cxxflag shared_cppflag
-		    shared_defines shared_includes shared_ldflag
-		    module_cflags module_cxxflags module_cppflags
-		    module_defines module_includes module_lflags))
-		{
-		delete $config{$_};
-		$target{$_} = "";
-		}
-	}
+        {
+        foreach (qw(shared_cflag shared_cxxflag shared_cppflag
+                    shared_defines shared_includes shared_ldflag
+                    module_cflags module_cxxflags module_cppflags
+                    module_defines module_includes module_lflags))
+                {
+                delete $config{$_};
+                $target{$_} = "";
+                }
+        }
 else
-	{
-	push @{$config{lib_defines}}, "OPENSSL_PIC";
-	}
+        {
+        push @{$config{lib_defines}}, "OPENSSL_PIC";
+        }
 
 if ($target{sys_id} ne "")
-	{
-	push @{$config{openssl_sys_defines}}, "OPENSSL_SYS_$target{sys_id}";
-	}
+        {
+        push @{$config{openssl_sys_defines}}, "OPENSSL_SYS_$target{sys_id}";
+        }
 
 unless ($disabled{asm}) {
     $target{cpuid_asm_src}=$table{DEFAULTS}->{cpuid_asm_src} if ($config{processor} eq "386");
@@ -1397,55 +1397,55 @@ unless ($disabled{asm}) {
     push @{$config{lib_defines}}, "BN_DIV3W" if ($target{bn_asm_src} =~ /-div3w/);
 
     if ($target{sha1_asm_src}) {
-	push @{$config{lib_defines}}, "SHA1_ASM"   if ($target{sha1_asm_src} =~ /sx86/ || $target{sha1_asm_src} =~ /sha1/);
-	push @{$config{lib_defines}}, "SHA256_ASM" if ($target{sha1_asm_src} =~ /sha256/);
-	push @{$config{lib_defines}}, "SHA512_ASM" if ($target{sha1_asm_src} =~ /sha512/);
+        push @{$config{lib_defines}}, "SHA1_ASM"   if ($target{sha1_asm_src} =~ /sx86/ || $target{sha1_asm_src} =~ /sha1/);
+        push @{$config{lib_defines}}, "SHA256_ASM" if ($target{sha1_asm_src} =~ /sha256/);
+        push @{$config{lib_defines}}, "SHA512_ASM" if ($target{sha1_asm_src} =~ /sha512/);
     }
     if ($target{keccak1600_asm_src} ne $table{DEFAULTS}->{keccak1600_asm_src}) {
-	push @{$config{lib_defines}}, "KECCAK1600_ASM";
+        push @{$config{lib_defines}}, "KECCAK1600_ASM";
     }
     if ($target{rc4_asm_src} ne $table{DEFAULTS}->{rc4_asm_src}) {
-	push @{$config{lib_defines}}, "RC4_ASM";
+        push @{$config{lib_defines}}, "RC4_ASM";
     }
     if ($target{md5_asm_src}) {
-	push @{$config{lib_defines}}, "MD5_ASM";
+        push @{$config{lib_defines}}, "MD5_ASM";
     }
     $target{cast_asm_src}=$table{DEFAULTS}->{cast_asm_src} unless $disabled{pic}; # CAST assembler is not PIC
     if ($target{rmd160_asm_src}) {
-	push @{$config{lib_defines}}, "RMD160_ASM";
+        push @{$config{lib_defines}}, "RMD160_ASM";
     }
     if ($target{aes_asm_src}) {
-	push @{$config{lib_defines}}, "AES_ASM" if ($target{aes_asm_src} =~ m/\baes-/);;
-	# aes-ctr.fake is not a real file, only indication that assembler
-	# module implements AES_ctr32_encrypt...
-	push @{$config{lib_defines}}, "AES_CTR_ASM" if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//);
-	# aes-xts.fake indicates presence of AES_xts_[en|de]crypt...
-	push @{$config{lib_defines}}, "AES_XTS_ASM" if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//);
-	$target{aes_asm_src} =~ s/\s*(vpaes|aesni)-x86\.s//g if ($disabled{sse2});
-	push @{$config{lib_defines}}, "VPAES_ASM" if ($target{aes_asm_src} =~ m/vpaes/);
-	push @{$config{lib_defines}}, "BSAES_ASM" if ($target{aes_asm_src} =~ m/bsaes/);
+        push @{$config{lib_defines}}, "AES_ASM" if ($target{aes_asm_src} =~ m/\baes-/);;
+        # aes-ctr.fake is not a real file, only indication that assembler
+        # module implements AES_ctr32_encrypt...
+        push @{$config{lib_defines}}, "AES_CTR_ASM" if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//);
+        # aes-xts.fake indicates presence of AES_xts_[en|de]crypt...
+        push @{$config{lib_defines}}, "AES_XTS_ASM" if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//);
+        $target{aes_asm_src} =~ s/\s*(vpaes|aesni)-x86\.s//g if ($disabled{sse2});
+        push @{$config{lib_defines}}, "VPAES_ASM" if ($target{aes_asm_src} =~ m/vpaes/);
+        push @{$config{lib_defines}}, "BSAES_ASM" if ($target{aes_asm_src} =~ m/bsaes/);
     }
     if ($target{wp_asm_src} =~ /mmx/) {
         if ($config{processor} eq "386") {
-	    $target{wp_asm_src}=$table{DEFAULTS}->{wp_asm_src};
-	} elsif (!$disabled{"whirlpool"}) {
-	    push @{$config{lib_defines}}, "WHIRLPOOL_ASM";
-	}
+            $target{wp_asm_src}=$table{DEFAULTS}->{wp_asm_src};
+        } elsif (!$disabled{"whirlpool"}) {
+            push @{$config{lib_defines}}, "WHIRLPOOL_ASM";
+        }
     }
     if ($target{modes_asm_src} =~ /ghash-/) {
-	push @{$config{lib_defines}}, "GHASH_ASM";
+        push @{$config{lib_defines}}, "GHASH_ASM";
     }
     if ($target{ec_asm_src} =~ /ecp_nistz256/) {
-	push @{$config{lib_defines}}, "ECP_NISTZ256_ASM";
+        push @{$config{lib_defines}}, "ECP_NISTZ256_ASM";
     }
     if ($target{ec_asm_src} =~ /x25519/) {
-	push @{$config{lib_defines}}, "X25519_ASM";
+        push @{$config{lib_defines}}, "X25519_ASM";
     }
     if ($target{padlock_asm_src} ne $table{DEFAULTS}->{padlock_asm_src}) {
-	push @{$config{dso_defines}}, "PADLOCK_ASM";
+        push @{$config{dso_defines}}, "PADLOCK_ASM";
     }
     if ($target{poly1305_asm_src} ne "") {
-	push @{$config{lib_defines}}, "POLY1305_ASM";
+        push @{$config{lib_defines}}, "POLY1305_ASM";
     }
 }
 
@@ -1461,7 +1461,7 @@ if (!$disabled{makedepend}) {
         # functionality is hard coded in the corresponding build files for
         # cl (Windows) and CC/DECC (VMS).
     } elsif (($predefined_C{__GNUC__} // -1) >= 3
-	     && !($predefined_C{__APPLE_CC__} && !$predefined_C{__clang__})) {
+             && !($predefined_C{__APPLE_CC__} && !$predefined_C{__clang__})) {
         # We know that GNU C version 3 and up as well as all clang
         # versions support dependency generation, but Xcode did not
         # handle $cc -M before clang support (but claims __GNUC__ = 3)
@@ -1498,24 +1498,24 @@ if (!$disabled{asm} && !$predefined_C{__MACH__} && $^O ne 'VMS') {
 
 # Deal with bn_ops ###################################################
 
-$config{bn_ll}			=0;
-$config{export_var_as_fn}	=0;
+$config{bn_ll}                  =0;
+$config{export_var_as_fn}       =0;
 my $def_int="unsigned int";
-$config{rc4_int}		=$def_int;
+$config{rc4_int}                =$def_int;
 ($config{b64l},$config{b64},$config{b32})=(0,0,1);
 
 my $count = 0;
 foreach (sort split(/\s+/,$target{bn_ops})) {
     $count++ if /SIXTY_FOUR_BIT|SIXTY_FOUR_BIT_LONG|THIRTY_TWO_BIT/;
     $config{export_var_as_fn}=1                 if $_ eq 'EXPORT_VAR_AS_FN';
-    $config{bn_ll}=1				if $_ eq 'BN_LLONG';
-    $config{rc4_int}="unsigned char"		if $_ eq 'RC4_CHAR';
+    $config{bn_ll}=1                            if $_ eq 'BN_LLONG';
+    $config{rc4_int}="unsigned char"            if $_ eq 'RC4_CHAR';
     ($config{b64l},$config{b64},$config{b32})
-	=(0,1,0)				if $_ eq 'SIXTY_FOUR_BIT';
+        =(0,1,0)                                if $_ eq 'SIXTY_FOUR_BIT';
     ($config{b64l},$config{b64},$config{b32})
-	=(1,0,0)				if $_ eq 'SIXTY_FOUR_BIT_LONG';
+        =(1,0,0)                                if $_ eq 'SIXTY_FOUR_BIT_LONG';
     ($config{b64l},$config{b64},$config{b32})
-	=(0,0,1)				if $_ eq 'THIRTY_TWO_BIT';
+        =(0,0,1)                                if $_ eq 'THIRTY_TWO_BIT';
 }
 die "Exactly one of SIXTY_FOUR_BIT|SIXTY_FOUR_BIT_LONG|THIRTY_TWO_BIT can be set in bn_ops\n"
     if $count > 1;
@@ -1536,27 +1536,27 @@ $config{openssl_api_defines} = [
 
 my %strict_warnings_collection=( CFLAGS => [], CXXFLAGS => []);
 if ($strict_warnings)
-	{
-	my $wopt;
-	my $gccver = $predefined_C{__GNUC__} // -1;
-	my $gxxver = $predefined_CXX{__GNUC__} // -1;
+        {
+        my $wopt;
+        my $gccver = $predefined_C{__GNUC__} // -1;
+        my $gxxver = $predefined_CXX{__GNUC__} // -1;
 
-	warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike"
+        warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike"
             unless $gccver >= 4;
-	warn "WARNING --strict-warnings requires g++[>=4] or g++-alike"
+        warn "WARNING --strict-warnings requires g++[>=4] or g++-alike"
             unless $gxxver >= 4;
-	foreach (qw(CFLAGS CXXFLAGS))
-		{
-		push @{$strict_warnings_collection{$_}},
-			@{$gcc_devteam_warn{$_}};
-		}
-	push @{$strict_warnings_collection{CFLAGS}},
-		@{$clang_devteam_warn{CFLAGS}}
-			if (defined($predefined_C{__clang__}));
-	push @{$strict_warnings_collection{CXXFLAGS}},
-		@{$clang_devteam_warn{CXXFLAGS}}
-			if (defined($predefined_CXX{__clang__}));
-	}
+        foreach (qw(CFLAGS CXXFLAGS))
+                {
+                push @{$strict_warnings_collection{$_}},
+                        @{$gcc_devteam_warn{$_}};
+                }
+        push @{$strict_warnings_collection{CFLAGS}},
+                @{$clang_devteam_warn{CFLAGS}}
+                        if (defined($predefined_C{__clang__}));
+        push @{$strict_warnings_collection{CXXFLAGS}},
+                @{$clang_devteam_warn{CXXFLAGS}}
+                        if (defined($predefined_CXX{__clang__}));
+        }
 foreach my $idx (qw(CFLAGS CXXFLAGS))
         {
         $useradd{$idx} = [ map { $_ eq '--ossl-strict-warnings'
@@ -1566,20 +1566,20 @@ foreach my $idx (qw(CFLAGS CXXFLAGS))
         }
 
 unless ($disabled{"crypto-mdebug-backtrace"})
-	{
-	foreach my $wopt (split /\s+/, $memleak_devteam_backtrace)
-		{
-		push @{$config{cflags}}, $wopt
-			unless grep { $_ eq $wopt } @{$config{cflags}};
-		push @{$config{cxxflags}}, $wopt
-			if ($config{CXX}
-			    && !grep { $_ eq $wopt } @{$config{cxxflags}});
-		}
-	if ($target =~ /^BSD-/)
-		{
-		push @{$config{ex_libs}}, "-lexecinfo";
-		}
-	}
+        {
+        foreach my $wopt (split /\s+/, $memleak_devteam_backtrace)
+                {
+                push @{$config{cflags}}, $wopt
+                        unless grep { $_ eq $wopt } @{$config{cflags}};
+                push @{$config{cxxflags}}, $wopt
+                        if ($config{CXX}
+                            && !grep { $_ eq $wopt } @{$config{cxxflags}});
+                }
+        if ($target =~ /^BSD-/)
+                {
+                push @{$config{ex_libs}}, "-lexecinfo";
+                }
+        }
 
 unless ($disabled{afalgeng}) {
     $config{afalgeng}="";
@@ -1685,38 +1685,38 @@ if ($builder eq "unified") {
     # Store the name of the template file we will build the build file from
     # in %config.  This may be useful for the build file itself.
     my @build_file_template_names =
-	( $builder_platform."-".$target{build_file}.".tmpl",
-	  $target{build_file}.".tmpl" );
+        ( $builder_platform."-".$target{build_file}.".tmpl",
+          $target{build_file}.".tmpl" );
     my @build_file_templates = ();
 
     # First, look in the user provided directory, if given
     if (defined env($local_config_envname)) {
-	@build_file_templates =
-	    map {
-		if ($^O eq 'VMS') {
-		    # VMS environment variables are logical names,
-		    # which can be used as is
-		    $local_config_envname . ':' . $_;
-		} else {
-		    catfile(env($local_config_envname), $_);
-		}
-	    }
-	    @build_file_template_names;
+        @build_file_templates =
+            map {
+                if ($^O eq 'VMS') {
+                    # VMS environment variables are logical names,
+                    # which can be used as is
+                    $local_config_envname . ':' . $_;
+                } else {
+                    catfile(env($local_config_envname), $_);
+                }
+            }
+            @build_file_template_names;
     }
     # Then, look in our standard directory
     push @build_file_templates,
-	( map { cleanfile($srcdir, catfile("Configurations", $_), $blddir) }
-	  @build_file_template_names );
+        ( map { cleanfile($srcdir, catfile("Configurations", $_), $blddir) }
+          @build_file_template_names );
 
     my $build_file_template;
     for $_ (@build_file_templates) {
-	$build_file_template = $_;
+        $build_file_template = $_;
         last if -f $build_file_template;
 
         $build_file_template = undef;
     }
     if (!defined $build_file_template) {
-	die "*** Couldn't find any of:\n", join("\n", @build_file_templates), "\n";
+        die "*** Couldn't find any of:\n", join("\n", @build_file_templates), "\n";
     }
     $config{build_file_templates}
       = [ cleanfile($srcdir, catfile("Configurations", "common0.tmpl"),
@@ -2371,11 +2371,11 @@ EOF
 print OUT "our %config = (\n";
 foreach (sort keys %config) {
     if (ref($config{$_}) eq "ARRAY") {
-	print OUT "  ", $_, " => [ ", join(", ",
-					   map { quotify("perl", $_) }
-					   @{$config{$_}}), " ],\n";
+        print OUT "  ", $_, " => [ ", join(", ",
+                                           map { quotify("perl", $_) }
+                                           @{$config{$_}}), " ],\n";
     } elsif (ref($config{$_}) eq "HASH") {
-	print OUT "  ", $_, " => {";
+        print OUT "  ", $_, " => {";
         if (scalar keys %{$config{$_}} > 0) {
             print OUT "\n";
             foreach my $key (sort keys %{$config{$_}}) {
@@ -2391,7 +2391,7 @@ foreach (sort keys %config) {
         }
         print OUT "},\n";
     } else {
-	print OUT "  ", $_, " => ", quotify("perl", $config{$_}), ",\n"
+        print OUT "  ", $_, " => ", quotify("perl", $config{$_}), ",\n"
     }
 }
 print OUT <<"EOF";
@@ -2401,11 +2401,11 @@ EOF
 print OUT "our %target = (\n";
 foreach (sort keys %target) {
     if (ref($target{$_}) eq "ARRAY") {
-	print OUT "  ", $_, " => [ ", join(", ",
-					   map { quotify("perl", $_) }
-					   @{$target{$_}}), " ],\n";
+        print OUT "  ", $_, " => [ ", join(", ",
+                                           map { quotify("perl", $_) }
+                                           @{$target{$_}}), " ],\n";
     } else {
-	print OUT "  ", $_, " => ", quotify("perl", $target{$_}), ",\n"
+        print OUT "  ", $_, " => ", quotify("perl", $target{$_}), ",\n"
     }
 }
 print OUT <<"EOF";
@@ -2438,11 +2438,11 @@ EOF
 print OUT "our %withargs = (\n";
 foreach (sort keys %withargs) {
     if (ref($withargs{$_}) eq "ARRAY") {
-	print OUT "  ", $_, " => [ ", join(", ",
-					   map { quotify("perl", $_) }
-					   @{$withargs{$_}}), " ],\n";
+        print OUT "  ", $_, " => [ ", join(", ",
+                                           map { quotify("perl", $_) }
+                                           @{$withargs{$_}}), " ],\n";
     } else {
-	print OUT "  ", $_, " => ", quotify("perl", $withargs{$_}), ",\n"
+        print OUT "  ", $_, " => ", quotify("perl", $withargs{$_}), ",\n"
     }
 }
 print OUT <<"EOF";
@@ -2669,9 +2669,9 @@ _____
     if ($reconf) {
         if ($verbose) {
             print 'Reconfiguring with: ', join(' ',@{$config{perlargv}}), "\n";
-	    foreach (sort keys %{$config{perlenv}}) {
-	        print '    ',$_,' = ',($config{perlenv}->{$_} || ""),"\n";
-	    }
+            foreach (sort keys %{$config{perlenv}}) {
+                print '    ',$_,' = ',($config{perlenv}->{$_} || ""),"\n";
+            }
         }
 
         chdir $here;
@@ -2866,7 +2866,7 @@ _____
 sub asm {
     my @x = @_;
     sub {
-	$disabled{asm} ? () : @x;
+        $disabled{asm} ? () : @x;
     }
 }
 
@@ -2932,29 +2932,29 @@ sub _add {
     my $found_array = !defined($separator);
 
     my @values =
-	map {
-	    my $res = $_;
-	    while (ref($res) eq "CODE") {
-		$res = $res->();
-	    }
-	    if (defined($res)) {
-		if (ref($res) eq "ARRAY") {
-		    $found_array = 1;
-		    @$res;
-		} else {
-		    $res;
-		}
-	    } else {
-		();
-	    }
+        map {
+            my $res = $_;
+            while (ref($res) eq "CODE") {
+                $res = $res->();
+            }
+            if (defined($res)) {
+                if (ref($res) eq "ARRAY") {
+                    $found_array = 1;
+                    @$res;
+                } else {
+                    $res;
+                }
+            } else {
+                ();
+            }
     } (@_);
 
     $add_called = 1;
 
     if ($found_array) {
-	[ @values ];
+        [ @values ];
     } else {
-	join($separator, grep { defined($_) && $_ ne "" } @values);
+        join($separator, grep { defined($_) && $_ ne "" } @values);
     }
 }
 sub add_before {
@@ -3004,10 +3004,10 @@ sub read_config {
     my %targets;
 
     {
-	# Protect certain tables from tampering
-	local %table = ();
+        # Protect certain tables from tampering
+        local %table = ();
 
-	%targets = read_eval_file($fname);
+        %targets = read_eval_file($fname);
     }
     my %preexisting = ();
     foreach (sort keys %targets) {
@@ -3023,14 +3023,14 @@ EOF
 
     # For each target, check that it's configured with a hash table.
     foreach (keys %targets) {
-	if (ref($targets{$_}) ne "HASH") {
-	    if (ref($targets{$_}) eq "") {
-		warn "Deprecated target configuration for $_, ignoring...\n";
-	    } else {
-		warn "Misconfigured target configuration for $_ (should be a hash table), ignoring...\n";
-	    }
-	    delete $targets{$_};
-	} else {
+        if (ref($targets{$_}) ne "HASH") {
+            if (ref($targets{$_}) eq "") {
+                warn "Deprecated target configuration for $_, ignoring...\n";
+            } else {
+                warn "Misconfigured target configuration for $_ (should be a hash table), ignoring...\n";
+            }
+            delete $targets{$_};
+        } else {
             $targets{$_}->{_conf_fname_int} = add([ $fname ]);
         }
     }
@@ -3049,13 +3049,13 @@ sub resolve_config {
 #    my $extra_checks = defined($ENV{CONFIGURE_EXTRA_CHECKS});
 
     if (grep { $_ eq $target } @breadcrumbs) {
-	die "inherit_from loop!  target backtrace:\n  "
-	    ,$target,"\n  ",join("\n  ", @breadcrumbs),"\n";
+        die "inherit_from loop!  target backtrace:\n  "
+            ,$target,"\n  ",join("\n  ", @breadcrumbs),"\n";
     }
 
     if (!defined($table{$target})) {
-	warn "Warning! target $target doesn't exist!\n";
-	return ();
+        warn "Warning! target $target doesn't exist!\n";
+        return ();
     }
     # Recurse through all inheritances.  They will be resolved on the
     # fly, so when this operation is done, they will all just be a
@@ -3065,22 +3065,22 @@ sub resolve_config {
     # this stage is done.
     my %combined_inheritance = ();
     if ($table{$target}->{inherit_from}) {
-	my @inherit_from =
-	    map { ref($_) eq "CODE" ? $_->() : $_ } @{$table{$target}->{inherit_from}};
-	foreach (@inherit_from) {
-	    my %inherited_config = resolve_config($_, $target, @breadcrumbs);
+        my @inherit_from =
+            map { ref($_) eq "CODE" ? $_->() : $_ } @{$table{$target}->{inherit_from}};
+        foreach (@inherit_from) {
+            my %inherited_config = resolve_config($_, $target, @breadcrumbs);
 
-	    # 'template' is a marker that's considered private to
-	    # the config that had it.
-	    delete $inherited_config{template};
+            # 'template' is a marker that's considered private to
+            # the config that had it.
+            delete $inherited_config{template};
 
-	    foreach (keys %inherited_config) {
-		if (!$combined_inheritance{$_}) {
-		    $combined_inheritance{$_} = [];
-		}
-		push @{$combined_inheritance{$_}}, $inherited_config{$_};
-	    }
-	}
+            foreach (keys %inherited_config) {
+                if (!$combined_inheritance{$_}) {
+                    $combined_inheritance{$_} = [];
+                }
+                push @{$combined_inheritance{$_}}, $inherited_config{$_};
+            }
+        }
     }
 
     # We won't need inherit_from in this target any more, since we've
@@ -3101,14 +3101,14 @@ sub resolve_config {
     my $default_combiner = add();
 
     my %all_keys =
-	map { $_ => 1 } (keys %combined_inheritance,
-			 keys %{$table{$target}});
+        map { $_ => 1 } (keys %combined_inheritance,
+                         keys %{$table{$target}});
 
     sub process_values {
-	my $object    = shift;
-	my $inherited = shift;  # Always a [ list ]
-	my $target    = shift;
-	my $entry     = shift;
+        my $object    = shift;
+        my $inherited = shift;  # Always a [ list ]
+        my $target    = shift;
+        my $entry     = shift;
 
         $add_called = 0;
 
@@ -3133,16 +3133,16 @@ sub resolve_config {
     foreach (sort keys %all_keys) {
         my $previous = $combined_inheritance{$_};
 
-	# Current target doesn't have a value for the current key?
-	# Assign it the default combiner, the rest of this loop body
-	# will handle it just like any other coderef.
-	if (!exists $table{$target}->{$_}) {
-	    $table{$target}->{$_} = $default_combiner;
-	}
+        # Current target doesn't have a value for the current key?
+        # Assign it the default combiner, the rest of this loop body
+        # will handle it just like any other coderef.
+        if (!exists $table{$target}->{$_}) {
+            $table{$target}->{$_} = $default_combiner;
+        }
 
-	$table{$target}->{$_} = process_values($table{$target}->{$_},
-					       $combined_inheritance{$_},
-					       $target, $_);
+        $table{$target}->{$_} = process_values($table{$target}->{$_},
+                                               $combined_inheritance{$_},
+                                               $target, $_);
         unless(defined($table{$target}->{$_})) {
             delete $table{$target}->{$_};
         }
@@ -3157,39 +3157,39 @@ sub resolve_config {
 }
 
 sub usage
-	{
-	print STDERR $usage;
-	print STDERR "\npick os/compiler from:\n";
-	my $j=0;
-	my $i;
+        {
+        print STDERR $usage;
+        print STDERR "\npick os/compiler from:\n";
+        my $j=0;
+        my $i;
         my $k=0;
-	foreach $i (sort keys %table)
-		{
-		next if $table{$i}->{template};
-		next if $i =~ /^debug/;
-		$k += length($i) + 1;
-		if ($k > 78)
-			{
-			print STDERR "\n";
-			$k=length($i);
-			}
-		print STDERR $i . " ";
-		}
-	foreach $i (sort keys %table)
-		{
-		next if $table{$i}->{template};
-		next if $i !~ /^debug/;
-		$k += length($i) + 1;
-		if ($k > 78)
-			{
-			print STDERR "\n";
-			$k=length($i);
-			}
-		print STDERR $i . " ";
-		}
-	print STDERR "\n\nNOTE: If in doubt, on Unix-ish systems use './config'.\n";
-	exit(1);
-	}
+        foreach $i (sort keys %table)
+                {
+                next if $table{$i}->{template};
+                next if $i =~ /^debug/;
+                $k += length($i) + 1;
+                if ($k > 78)
+                        {
+                        print STDERR "\n";
+                        $k=length($i);
+                        }
+                print STDERR $i . " ";
+                }
+        foreach $i (sort keys %table)
+                {
+                next if $table{$i}->{template};
+                next if $i !~ /^debug/;
+                $k += length($i) + 1;
+                if ($k > 78)
+                        {
+                        print STDERR "\n";
+                        $k=length($i);
+                        }
+                print STDERR $i . " ";
+                }
+        print STDERR "\n\nNOTE: If in doubt, on Unix-ish systems use './config'.\n";
+        exit(1);
+        }
 
 sub run_dofile
 {
@@ -3283,69 +3283,69 @@ sub print_table_entry
     return if $target{template};
 
     my @sequence = (
-	"sys_id",
-	"cpp",
-	"cppflags",
-	"defines",
-	"includes",
-	"cc",
-	"cflags",
-	"unistd",
-	"ld",
-	"lflags",
-	"loutflag",
-	"ex_libs",
-	"bn_ops",
-	"apps_aux_src",
-	"cpuid_asm_src",
-	"uplink_aux_src",
-	"bn_asm_src",
-	"ec_asm_src",
-	"des_asm_src",
-	"aes_asm_src",
-	"bf_asm_src",
-	"md5_asm_src",
-	"cast_asm_src",
-	"sha1_asm_src",
-	"rc4_asm_src",
-	"rmd160_asm_src",
-	"rc5_asm_src",
-	"wp_asm_src",
-	"cmll_asm_src",
-	"modes_asm_src",
-	"padlock_asm_src",
-	"chacha_asm_src",
-	"poly1035_asm_src",
-	"thread_scheme",
-	"perlasm_scheme",
-	"dso_scheme",
-	"shared_target",
-	"shared_cflag",
-	"shared_defines",
-	"shared_ldflag",
-	"shared_rcflag",
-	"shared_extension",
-	"dso_extension",
-	"obj_extension",
-	"exe_extension",
-	"ranlib",
-	"ar",
-	"arflags",
-	"aroutflag",
-	"rc",
-	"rcflags",
-	"rcoutflag",
-	"mt",
-	"mtflags",
-	"mtinflag",
-	"mtoutflag",
-	"multilib",
-	"build_scheme",
-	);
+        "sys_id",
+        "cpp",
+        "cppflags",
+        "defines",
+        "includes",
+        "cc",
+        "cflags",
+        "unistd",
+        "ld",
+        "lflags",
+        "loutflag",
+        "ex_libs",
+        "bn_ops",
+        "apps_aux_src",
+        "cpuid_asm_src",
+        "uplink_aux_src",
+        "bn_asm_src",
+        "ec_asm_src",
+        "des_asm_src",
+        "aes_asm_src",
+        "bf_asm_src",
+        "md5_asm_src",
+        "cast_asm_src",
+        "sha1_asm_src",
+        "rc4_asm_src",
+        "rmd160_asm_src",
+        "rc5_asm_src",
+        "wp_asm_src",
+        "cmll_asm_src",
+        "modes_asm_src",
+        "padlock_asm_src",
+        "chacha_asm_src",
+        "poly1035_asm_src",
+        "thread_scheme",
+        "perlasm_scheme",
+        "dso_scheme",
+        "shared_target",
+        "shared_cflag",
+        "shared_defines",
+        "shared_ldflag",
+        "shared_rcflag",
+        "shared_extension",
+        "dso_extension",
+        "obj_extension",
+        "exe_extension",
+        "ranlib",
+        "ar",
+        "arflags",
+        "aroutflag",
+        "rc",
+        "rcflags",
+        "rcoutflag",
+        "mt",
+        "mtflags",
+        "mtinflag",
+        "mtoutflag",
+        "multilib",
+        "build_scheme",
+        );
 
     if ($type eq "TABLE") {
-	print "\n";
-	print "*** $now_printing\n";
+        print "\n";
+        print "*** $now_printing\n";
         foreach (@sequence) {
             if (ref($target{$_}) eq "ARRAY") {
                 printf "\$%-12s = %s\n", $_, join(" ", @{$target{$_}});
@@ -3354,19 +3354,19 @@ sub print_table_entry
             }
         }
     } elsif ($type eq "HASH") {
-	my $largest =
-	    length((sort { length($a) <=> length($b) } @sequence)[-1]);
-	print "    '$now_printing' => {\n";
-	foreach (@sequence) {
-	    if ($target{$_}) {
+        my $largest =
+            length((sort { length($a) <=> length($b) } @sequence)[-1]);
+        print "    '$now_printing' => {\n";
+        foreach (@sequence) {
+            if ($target{$_}) {
                 if (ref($target{$_}) eq "ARRAY") {
                     print "      '",$_,"'"," " x ($largest - length($_))," => [ ",join(", ", map { "'$_'" } @{$target{$_}})," ],\n";
                 } else {
                     print "      '",$_,"'"," " x ($largest - length($_))," => '",$target{$_},"',\n";
                 }
-	    }
-	}
-	print "    },\n";
+            }
+        }
+        print "    },\n";
     }
 }
 
@@ -3414,21 +3414,21 @@ sub absolutedir {
 
 sub quotify {
     my %processors = (
-	perl    => sub { my $x = shift;
-			 $x =~ s/([\\\$\@"])/\\$1/g;
-			 return '"'.$x.'"'; },
-	maybeshell => sub { my $x = shift;
-			    (my $y = $x) =~ s/([\\\"])/\\$1/g;
-			    if ($x ne $y || $x =~ m|\s|) {
-				return '"'.$y.'"';
-			    } else {
-				return $x;
-			    }
-			},
-	);
+        perl    => sub { my $x = shift;
+                         $x =~ s/([\\\$\@"])/\\$1/g;
+                         return '"'.$x.'"'; },
+        maybeshell => sub { my $x = shift;
+                            (my $y = $x) =~ s/([\\\"])/\\$1/g;
+                            if ($x ne $y || $x =~ m|\s|) {
+                                return '"'.$y.'"';
+                            } else {
+                                return $x;
+                            }
+                        },
+        );
     my $for = shift;
     my $processor =
-	defined($processors{$for}) ? $processors{$for} : sub { shift; };
+        defined($processors{$for}) ? $processors{$for} : sub { shift; };
 
     return map { $processor->($_); } @_;
 }


### PR DESCRIPTION
The indentation in the Configure file is currently very strange when
viewed in an editor with a tab width of four spaces, because it has
mixed tab-and-whitespace indentation, which was apparently done with
a tab width of eight spaces.

This commit converts all tabs to spaces in a reproducible way using
emacs and the following lisp function.
```lisp
    (defun ossl-whitespace-cleanup ()
      "Run whitespace cleanup on current buffer"
      (interactive)
      (set-variable 'tab-width 8)
      (set-variable 'indent-tabs-mode nil)
      (whitespace-cleanup))
```
To verify that there are only whitespace changes, use
```
   git show --ignore-space-change  <this commit>
```

To make future merging from `master` to `1.1.1` feasible, the same
cleanup needs to be done synchonously on the OpenSSL_1_1_1-stable
branch. I'll create the pull request for it, as soon as I get
your consent.
