### PR TITLE
test/params_api_test.c: fix size_t assumptions

### DIFF
--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -103,12 +103,12 @@ static int test_param_type_extra(const OSSL_PARAM *param, unsigned char *cmp,
         if (signd) {
             if (!TEST_true(OSSL_PARAM_set_int32(param, 12345))
                 || !TEST_true(OSSL_PARAM_get_int64(param, &i64))
-                || !TEST_size_t_eq(i64, 12345))
+                || !TEST_size_t_eq((size_t)i64, 12345))
                 return 0;
         } else {
             if (!TEST_true(OSSL_PARAM_set_uint32(param, 12345))
                 || !TEST_true(OSSL_PARAM_get_uint64(param, (uint64_t *)&i64))
-                || !TEST_size_t_eq(i64, 12345))
+                || !TEST_size_t_eq((size_t)i64, 12345))
                 return 0;
         }
     }


### PR DESCRIPTION
size_t isn't always as large as a int64_t, so the compiler complains
about possible data loss.  In this case, we are in control, so a
simple cast will do.
