### PR TITLE
Fix no-posix-io

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -13,9 +13,7 @@
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/evp.h>
-#ifndef OPENSSL_NO_POSIX_IO
-# include <sys/stat.h>
-#endif
+#include <sys/stat.h>
 
 #define KEY_NONE        0
 #define KEY_PRIVKEY     1
@@ -348,15 +346,12 @@ int pkeyutl_main(int argc, char **argv)
 
     if (pkey_op != EVP_PKEY_OP_DERIVE) {
         in = bio_open_default(infile, 'r', FORMAT_BINARY);
-#ifndef OPENSSL_NO_POSIX_IO
-        if (infile != NULL)
-        {
+        if (infile != NULL) {
             struct stat st;
 
             if (stat(infile, &st) == 0 && st.st_size <= INT_MAX)
                 filesize = (int)st.st_size;
         }
-#endif
         if (in == NULL)
             goto end;
     }


### PR DESCRIPTION
'openssl pkeyutl' uses stat() to determine the file size when signing using
Ed25519/Ed448, and this was guarded with OPENSSL_NO_POSIX_IO.

It is however arguable if stat() is a POSIX IO function, considering
that it doesn't use file descriptors, and even more so since we use
stat() elsewhere without that guard.

This will allow test/recipes/20-test_pkeyutl.t to be able to do its
work for Ed25519/Ed448 signature tests.

-----

This is an alternative to #8489