### PR TITLE
Clear the point S before freeing in ec_mul_consttime [1.1.0/1.0.2]

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -325,7 +325,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
     ret = 1;
 
  err:
-    EC_POINT_free(s);
+    EC_POINT_clear_free(s);
     BN_CTX_end(ctx);
     BN_CTX_free(new_ctx);
 


### PR DESCRIPTION
The secret point R can be recovered from S using the equation R = S - P.
The X and Z coordinates should be sufficient for that.
