### PR TITLE
Coverity Fixes : RSA code 

### DIFF
--- a/test/bn_internal_test.c
+++ b/test/bn_internal_test.c
@@ -73,8 +73,8 @@ static int test_bn_small_factors(void)
 
     for (i = 1; i < NUMPRIMES; i++) {
         prime_t p = primes[i];
-        if (p > 3 && p <= 751)
-            BN_mul_word(b, p);
+        if (p > 3 && p <= 751 && !BN_mul_word(b, p))
+            goto err;
         if (p > 751)
             break;
     }


### PR DESCRIPTION
The missing NULL checks in BN_clear, BN_CTX_end() are now handled by this PR:
https://github.com/openssl/openssl/pull/8518.
So this now just fixes coverity issues in the tests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
