### PR TITLE
Fix strict-warnings build on FreeBSD

### DIFF
--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -353,7 +353,7 @@ static int cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void* p2)
         to_cipher_ctx =
             (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(to_ctx);
         memset(&to_cipher_ctx->sess, 0, sizeof(to_cipher_ctx->sess));
-        return cipher_init(to_ctx, cipher_ctx->sess.key, EVP_CIPHER_CTX_iv(ctx),
+        return cipher_init(to_ctx, (void *)cipher_ctx->sess.key, EVP_CIPHER_CTX_iv(ctx),
                            (cipher_ctx->op == COP_ENCRYPT));
 
     case EVP_CTRL_INIT:


### PR DESCRIPTION
The 'key' member of the (system-defined!) struct session op is of
type c_caddr_t, which can be (signed) char, so inter-casting with the
unsigned char* input to cipher_init() causes -Wpointer-sign errors, and we
can't change the signature of cipher_init() due to the function pointer
type required by EVP_CIPHER_meth_set_init().

As the least-bad option, introduce a void* cast to quell the following
warning:
engines/e_devcrypto.c:356:36: error: passing 'c_caddr_t' (aka 'const char *') to
      parameter of type 'const unsigned char *' converts between pointers to integer
      types with different sign [-Werror,-Wpointer-sign]
        return cipher_init(to_ctx, cipher_ctx->sess.key, EVP_CIPHER_CTX_iv(ctx),
                                   ^~~~~~~~~~~~~~~~~~~~
engines/e_devcrypto.c:191:66: note: passing argument to parameter 'key' here
static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
