### PR TITLE
WIP: Make most perl script have a common style

### DIFF
--- a/Configure
+++ b/Configure
@@ -427,12 +427,11 @@ my @disablables = (
     "weak-ssl-ciphers",
     "zlib",
     "zlib-dynamic",
-    );
-foreach my $proto ((@tls, @dtls))
-        {
-        push(@disablables, $proto);
-        push(@disablables, "$proto-method") unless $proto eq "tls1_3";
-        }
+);
+foreach my $proto ((@tls, @dtls)) {
+    push(@disablables, $proto);
+    push(@disablables, "$proto-method") unless $proto eq "tls1_3";
+}
 
 my %deprecated_disablables = (
     "ssl2" => undef,
@@ -441,85 +440,87 @@ my %deprecated_disablables = (
     "hw-padlock" => "padlockeng",
     "ripemd" => "rmd160",
     "ui" => "ui-console",
-    );
+);
 
 # All of the following are disabled by default:
 
-our %disabled = ( # "what"         => "comment"
-                  "asan"                => "default",
-                  "buildtest-c++"       => "default",
-                  "crypto-mdebug"       => "default",
-                  "crypto-mdebug-backtrace" => "default",
-                  "devcryptoeng"        => "default",
-                  "ec_nistp_64_gcc_128" => "default",
-                  "egd"                 => "default",
-                  "external-tests"      => "default",
-                  "fuzz-libfuzzer"      => "default",
-                  "fuzz-afl"            => "default",
-                  "heartbeats"          => "default",
-                  "md2"                 => "default",
-                  "msan"                => "default",
-                  "rc5"                 => "default",
-                  "sctp"                => "default",
-                  "ssl-trace"           => "default",
-                  "ssl3"                => "default",
-                  "ssl3-method"         => "default",
-                  "trace"               => "default",
-                  "ubsan"               => "default",
-                  "unit-test"           => "default",
-                  "weak-ssl-ciphers"    => "default",
-                  "zlib"                => "default",
-                  "zlib-dynamic"        => "default",
-                  "ktls"                => "default",
-                );
+our %disabled = (
+    # "what"                    => "comment"
+    "asan"                      => "default",
+    "buildtest-c++"             => "default",
+    "crypto-mdebug"             => "default",
+    "crypto-mdebug-backtrace"   => "default",
+    "devcryptoeng"              => "default",
+    "ec_nistp_64_gcc_128"       => "default",
+    "egd"                       => "default",
+    "external-tests"            => "default",
+    "fuzz-libfuzzer"            => "default",
+    "fuzz-afl"                  => "default",
+    "heartbeats"                => "default",
+    "md2"                       => "default",
+    "msan"                      => "default",
+    "rc5"                       => "default",
+    "sctp"                      => "default",
+    "ssl-trace"                 => "default",
+    "ssl3"                      => "default",
+    "ssl3-method"               => "default",
+    "trace"                     => "default",
+    "ubsan"                     => "default",
+    "unit-test"                 => "default",
+    "weak-ssl-ciphers"          => "default",
+    "zlib"                      => "default",
+    "zlib-dynamic"              => "default",
+    "ktls"                      => "default",
+);
 
 # Note: => pair form used for aesthetics, not to truly make a hash table
 my @disable_cascades = (
-    # "what"            => [ "cascade", ... ]
+    # "what"                   => [ "cascade", ... ]
     sub { $config{processor} eq "386" }
-                        => [ "sse2" ],
-    "ssl"               => [ "ssl3" ],
-    "ssl3-method"       => [ "ssl3" ],
-    "zlib"              => [ "zlib-dynamic" ],
-    "des"               => [ "mdc2" ],
-    "ec"                => [ "ecdsa", "ecdh" ],
+                               => [ "sse2" ],
+    "ssl"                      => [ "ssl3" ],
+    "ssl3-method"              => [ "ssl3" ],
+    "zlib"                     => [ "zlib-dynamic" ],
+    "des"                      => [ "mdc2" ],
+    "ec"                       => [ "ecdsa", "ecdh" ],
 
-    "dgram"             => [ "dtls", "sctp" ],
-    "sock"              => [ "dgram" ],
-    "dtls"              => [ @dtls ],
+    "dgram"                    => [ "dtls", "sctp" ],
+    "sock"                     => [ "dgram" ],
+    "dtls"                     => [ @dtls ],
     sub { 0 == scalar grep { !$disabled{$_} } @dtls }
-                        => [ "dtls" ],
+                               => [ "dtls" ],
 
-    "tls"               => [ @tls ],
+    "tls"                      => [ @tls ],
     sub { 0 == scalar grep { !$disabled{$_} } @tls }
-                        => [ "tls" ],
+                               => [ "tls" ],
 
-    "crypto-mdebug"     => [ "crypto-mdebug-backtrace" ],
+    "crypto-mdebug"            => [ "crypto-mdebug-backtrace" ],
 
     # Without DSO, we can't load dynamic engines, so don't build them dynamic
-    "dso"               => [ "dynamic-engine" ],
+    "dso"                      => [ "dynamic-engine" ],
 
     # Without position independent code, there can be no shared libraries or DSOs
-    "pic"               => [ "shared" ],
-    "shared"            => [ "dynamic-engine" ],
+    "pic"                      => [ "shared" ],
+    "shared"                   => [ "dynamic-engine" ],
 
-    "engine"            => [ grep /eng$/, @disablables ],
-    "hw"                => [ "padlockeng" ],
+    "engine"                   => [ grep /eng$/, @disablables ],
+    "hw"                       => [ "padlockeng" ],
 
     # no-autoalginit is only useful when building non-shared
-    "autoalginit"       => [ "shared", "apps" ],
+    "autoalginit"              => [ "shared", "apps" ],
 
-    "stdio"             => [ "apps", "capieng", "egd" ],
-    "apps"              => [ "tests" ],
-    "tests"             => [ "external-tests" ],
-    "comp"              => [ "zlib" ],
-    "ec"                => [ "tls1_3", "sm2" ],
-    "sm3"               => [ "sm2" ],
-    sub { !$disabled{"unit-test"} } => [ "heartbeats" ],
+    "stdio"                    => [ "apps", "capieng", "egd" ],
+    "apps"                     => [ "tests" ],
+    "tests"                    => [ "external-tests" ],
+    "comp"                     => [ "zlib" ],
+    "ec"                       => [ "tls1_3", "sm2" ],
+    "sm3"                      => [ "sm2" ],
+    sub { !$disabled{"unit-test"} }
+                               => [ "heartbeats" ],
 
     sub { !$disabled{"msan"} } => [ "asm" ],
 
-    sub { $disabled{cmac}; } => [ "siv" ],
+    sub { $disabled{cmac}; }   => [ "siv" ],
     );
 
 # Avoid protocol support holes.  Also disable all versions below N, if version
@@ -558,30 +559,30 @@ my $list_separator_re =
 # Some get pre-populated for the sake of backward compatibility
 # (we supported those before the change to "make variable" support.
 my %user = (
-    AR          => env('AR'),
-    ARFLAGS     => [],
-    AS          => undef,
-    ASFLAGS     => [],
-    CC          => env('CC'),
-    CFLAGS      => [ env('CFLAGS') || () ],
-    CXX         => env('CXX'),
-    CXXFLAGS    => [ env('CXXFLAGS') || () ],
-    CPP         => undef,
-    CPPFLAGS    => [ env('CPPFLAGS') || () ],  # -D, -I, -Wp,
-    CPPDEFINES  => [],  # Alternative for -D
-    CPPINCLUDES => [],  # Alternative for -I
-    CROSS_COMPILE => env('CROSS_COMPILE'),
-    HASHBANGPERL=> env('HASHBANGPERL') || env('PERL'),
-    LD          => undef,
-    LDFLAGS     => [ env('LDFLAGS') || () ],  # -L, -Wl,
-    LDLIBS      => [ env('LDLIBS') || () ],  # -l
-    MT          => undef,
-    MTFLAGS     => [],
-    PERL        => env('PERL') || ($^O ne "VMS" ? $^X : "perl"),
-    RANLIB      => env('RANLIB'),
-    RC          => env('RC') || env('WINDRES'),
-    RCFLAGS     => [],
-    RM          => undef,
+    AR                  => env('AR'),
+    ARFLAGS             => [],
+    AS                  => undef,
+    ASFLAGS             => [],
+    CC                  => env('CC'),
+    CFLAGS              => [ env('CFLAGS') || () ],
+    CXX                 => env('CXX'),
+    CXXFLAGS            => [ env('CXXFLAGS') || () ],
+    CPP                 => undef,
+    CPPFLAGS            => [ env('CPPFLAGS') || () ],  # -D, -I, -Wp,
+    CPPDEFINES          => [],  # Alternative for -D
+    CPPINCLUDES         => [],  # Alternative for -I
+    CROSS_COMPILE       => env('CROSS_COMPILE'),
+    HASHBANGPERL        => env('HASHBANGPERL') || env('PERL'),
+    LD                  => undef,
+    LDFLAGS             => [ env('LDFLAGS') || () ],  # -L, -Wl,
+    LDLIBS              => [ env('LDLIBS') || () ],  # -l
+    MT                  => undef,
+    MTFLAGS             => [],
+    PERL                => env('PERL') || ($^O ne "VMS" ? $^X : "perl"),
+    RANLIB              => env('RANLIB'),
+    RC                  => env('RC') || env('WINDRES'),
+    RCFLAGS             => [],
+    RM                  => undef,
    );
 # Info about what "make variables" may be prefixed with the cross compiler
 # prefix.  This should NEVER mention any such variable with a list for value.
@@ -590,33 +591,33 @@ my @user_crossable = qw ( AR AS CC CXX CPP LD MT RANLIB RC );
 # input, as opposed to the VAR=string option that override the corresponding
 # config target attributes
 my %useradd = (
-    CPPDEFINES  => [],
-    CPPINCLUDES => [],
-    CPPFLAGS    => [],
-    CFLAGS      => [],
-    CXXFLAGS    => [],
-    LDFLAGS     => [],
-    LDLIBS      => [],
+    CPPDEFINES          => [],
+    CPPINCLUDES         => [],
+    CPPFLAGS            => [],
+    CFLAGS              => [],
+    CXXFLAGS            => [],
+    LDFLAGS             => [],
+    LDLIBS              => [],
    );
 
 my %user_synonyms = (
-    HASHBANGPERL=> 'PERL',
-    RC          => 'WINDRES',
+    HASHBANGPERL        => 'PERL',
+    RC                  => 'WINDRES',
    );
 
 # Some target attributes have been renamed, this is the translation table
 my %target_attr_translate =(
-    ar          => 'AR',
-    as          => 'AS',
-    cc          => 'CC',
-    cxx         => 'CXX',
-    cpp         => 'CPP',
-    hashbangperl => 'HASHBANGPERL',
-    ld          => 'LD',
-    mt          => 'MT',
-    ranlib      => 'RANLIB',
-    rc          => 'RC',
-    rm          => 'RM',
+    ar                  => 'AR',
+    as                  => 'AS',
+    cc                  => 'CC',
+    cxx                 => 'CXX',
+    cpp                 => 'CPP',
+    hashbangperl        => 'HASHBANGPERL',
+    ld                  => 'LD',
+    mt                  => 'MT',
+    ranlib              => 'RANLIB',
+    rc                  => 'RC',
+    rm                  => 'RM',
    );
 
 # Initialisers coming from 'config' scripts
@@ -641,300 +642,206 @@ my %deprecated_options = ();
 # If you change this, update apps/version.c
 my @known_seed_sources = qw(getrandom devrandom os egd none rdcpu librandom);
 my @seed_sources = ();
-while (@argvcopy)
-        {
-        $_ = shift @argvcopy;
+while (@argvcopy) {
+    $_ = shift @argvcopy;
 
-        # Support env variable assignments among the options
-        if (m|^(\w+)=(.+)?$|)
-                {
-                $cmdvars{$1} = $2;
-                # Every time a variable is given as a configuration argument,
-                # it acts as a reset if the variable.
-                if (exists $user{$1})
-                        {
-                        $user{$1} = ref $user{$1} eq "ARRAY" ? [] : undef;
-                        }
-                #if (exists $useradd{$1})
-                #       {
-                #       $useradd{$1} = [];
-                #       }
-                next;
-                }
-
-        # VMS is a case insensitive environment, and depending on settings
-        # out of our control, we may receive options uppercased.  Let's
-        # downcase at least the part before any equal sign.
-        if ($^O eq "VMS")
-                {
-                s/^([^=]*)/lc($1)/e;
-                }
-
-        # some people just can't read the instructions, clang people have to...
-        s/^-no-(?!integrated-as)/no-/;
-
-        # rewrite some options in "enable-..." form
-        s /^-?-?shared$/enable-shared/;
-        s /^sctp$/enable-sctp/;
-        s /^threads$/enable-threads/;
-        s /^zlib$/enable-zlib/;
-        s /^zlib-dynamic$/enable-zlib-dynamic/;
-
-        if (/^(no|disable|enable)-(.+)$/)
-                {
-                my $word = $2;
-                if ($word !~ m|hw(?:-.+)| # special treatment for hw regexp opt
-                        && !exists $deprecated_disablables{$word}
-                        && !grep { $word eq $_ } @disablables)
-                        {
-                        $unsupported_options{$_} = 1;
-                        next;
-                        }
-                }
-        if (/^no-(.+)$/ || /^disable-(.+)$/)
-                {
-                foreach my $proto ((@tls, @dtls))
-                        {
-                        if ($1 eq "$proto-method")
-                                {
-                                $disabled{"$proto"} = "option($proto-method)";
-                                last;
-                                }
-                        }
-                if ($1 eq "dtls")
-                        {
-                        foreach my $proto (@dtls)
-                                {
-                                $disabled{$proto} = "option(dtls)";
-                                }
-                        $disabled{"dtls"} = "option(dtls)";
-                        }
-                elsif ($1 eq "ssl")
-                        {
-                        # Last one of its kind
-                        $disabled{"ssl3"} = "option(ssl)";
-                        }
-                elsif ($1 eq "tls")
-                        {
-                        # XXX: Tests will fail if all SSL/TLS
-                        # protocols are disabled.
-                        foreach my $proto (@tls)
-                                {
-                                $disabled{$proto} = "option(tls)";
-                                }
-                        }
-                elsif ($1 eq "static-engine")
-                        {
-                        delete $disabled{"dynamic-engine"};
-                        }
-                elsif ($1 eq "dynamic-engine")
-                        {
-                        $disabled{"dynamic-engine"} = "option";
-                        }
-                elsif (exists $deprecated_disablables{$1})
-                        {
-                        $deprecated_options{$_} = 1;
-                        if (defined $deprecated_disablables{$1})
-                                {
-                                $disabled{$deprecated_disablables{$1}} = "option";
-                                }
-                        }
-                elsif ($1 =~ m|hw(?:-.+)|) # deprecate hw options in regexp form
-                        {
-                        $deprecated_options{$_} = 1;
-                        }
-                else
-                        {
-                        $disabled{$1} = "option";
-                        }
-                # No longer an automatic choice
-                $auto_threads = 0 if ($1 eq "threads");
-                }
-        elsif (/^enable-(.+)$/)
-                {
-                if ($1 eq "static-engine")
-                        {
-                        $disabled{"dynamic-engine"} = "option";
-                        }
-                elsif ($1 eq "dynamic-engine")
-                        {
-                        delete $disabled{"dynamic-engine"};
-                        }
-                elsif ($1 eq "zlib-dynamic")
-                        {
-                        delete $disabled{"zlib"};
-                        }
-                my $algo = $1;
-                delete $disabled{$algo};
-
-                # No longer an automatic choice
-                $auto_threads = 0 if ($1 eq "threads");
-                }
-        elsif (/^--strict-warnings$/)
-                {
-                # Pretend that our strict flags is a C flag, and replace it
-                # with the proper flags later on
-                push @{$useradd{CFLAGS}}, '--ossl-strict-warnings';
-                push @{$useradd{CXXFLAGS}}, '--ossl-strict-warnings';
-                $strict_warnings=1;
-                }
-        elsif (/^--debug$/)
-                {
-                $config{build_type} = "debug";
-                }
-        elsif (/^--release$/)
-                {
-                $config{build_type} = "release";
-                }
-        elsif (/^386$/)
-                { $config{processor}=386; }
-        elsif (/^fips$/)
-                {
-                die "FIPS mode not supported\n";
-                }
-        elsif (/^rsaref$/)
-                {
-                # No RSAref support any more since it's not needed.
-                # The check for the option is there so scripts aren't
-                # broken
-                }
-        elsif (/^nofipscanistercheck$/)
-                {
-                die "FIPS mode not supported\n";
-                }
-        elsif (/^[-+]/)
-                {
-                if (/^--prefix=(.*)$/)
-                        {
-                        $config{prefix}=$1;
-                        die "Directory given with --prefix MUST be absolute\n"
-                                unless file_name_is_absolute($config{prefix});
-                        }
-                elsif (/^--api=(.*)$/)
-                        {
-                        $config{api}=$1;
-                        }
-                elsif (/^--libdir=(.*)$/)
-                        {
-                        $config{libdir}=$1;
-                        }
-                elsif (/^--openssldir=(.*)$/)
-                        {
-                        $config{openssldir}=$1;
-                        }
-                elsif (/^--with-zlib-lib=(.*)$/)
-                        {
-                        $withargs{zlib_lib}=$1;
-                        }
-                elsif (/^--with-zlib-include=(.*)$/)
-                        {
-                        $withargs{zlib_include}=$1;
-                        }
-                elsif (/^--with-fuzzer-lib=(.*)$/)
-                        {
-                        $withargs{fuzzer_lib}=$1;
-                        }
-                elsif (/^--with-fuzzer-include=(.*)$/)
-                        {
-                        $withargs{fuzzer_include}=$1;
-                        }
-                elsif (/^--with-rand-seed=(.*)$/)
-                        {
-                        foreach my $x (split(m|,|, $1))
-                            {
-                            die "Unknown --with-rand-seed choice $x\n"
-                                if ! grep { $x eq $_ } @known_seed_sources;
-                            push @seed_sources, $x;
-                            }
-                        }
-                elsif (/^--cross-compile-prefix=(.*)$/)
-                        {
-                        $user{CROSS_COMPILE}=$1;
-                        }
-                elsif (/^--config=(.*)$/)
-                        {
-                        read_config $1;
-                        }
-                elsif (/^-l(.*)$/)
-                        {
-                        push @{$useradd{LDLIBS}}, $_;
-                        }
-                elsif (/^-framework$/)
-                        {
-                        push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
-                        }
-                elsif (/^-L(.*)$/ or /^-Wl,/)
-                        {
-                        push @{$useradd{LDFLAGS}}, $_;
-                        }
-                elsif (/^-rpath$/ or /^-R$/)
-                        # -rpath is the OSF1 rpath flag
-                        # -R is the old Solaris rpath flag
-                        {
-                        my $rpath = shift(@argvcopy) || "";
-                        $rpath .= " " if $rpath ne "";
-                        push @{$useradd{LDFLAGS}}, $_, $rpath;
-                        }
-                elsif (/^-static$/)
-                        {
-                        push @{$useradd{LDFLAGS}}, $_;
-                        $disabled{"dso"} = "forced";
-                        $disabled{"pic"} = "forced";
-                        $disabled{"shared"} = "forced";
-                        $disabled{"threads"} = "forced";
-                        }
-                elsif (/^-D(.*)$/)
-                        {
-                        push @{$useradd{CPPDEFINES}}, $1;
-                        }
-                elsif (/^-I(.*)$/)
-                        {
-                        push @{$useradd{CPPINCLUDES}}, $1;
-                        }
-                elsif (/^-Wp,$/)
-                        {
-                        push @{$useradd{CPPFLAGS}}, $1;
-                        }
-                else    # common if (/^[-+]/), just pass down...
-                        {
-                        $_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
-                        push @{$useradd{CFLAGS}}, $_;
-                        push @{$useradd{CXXFLAGS}}, $_;
-                        }
-                }
-        else
-                {
-                die "target already defined - $target (offending arg: $_)\n" if ($target ne "");
-                $target=$_;
-                }
-        unless ($_ eq $target || /^no-/ || /^disable-/)
-                {
-                # "no-..." follows later after implied deactivations
-                # have been derived.  (Don't take this too seriously,
-                # we really only write OPTIONS to the Makefile out of
-                # nostalgia.)
-
-                if ($config{options} eq "")
-                        { $config{options} = $_; }
-                else
-                        { $config{options} .= " ".$_; }
-                }
+    # Support env variable assignments among the options
+    if (m|^(\w+)=(.+)?$|) {
+        $cmdvars{$1} = $2;
+        # Every time a variable is given as a configuration argument,
+        # it acts as a reset if the variable.
+        if (exists $user{$1}) {
+            $user{$1} = ref $user{$1} eq "ARRAY" ? [] : undef;
         }
+        next;
+    }
 
-if (defined($config{api}) && !exists $apitable->{$config{api}}) {
-        die "***** Unsupported api compatibility level: $config{api}\n",
+    # VMS is a case insensitive environment, and depending on settings
+    # out of our control, we may receive options uppercased.  Let's
+    # downcase at least the part before any equal sign.
+    if ($^O eq "VMS") {
+        s/^([^=]*)/lc($1)/e;
+    }
+
+    # some people just can't read the instructions, clang people have to...
+    s/^-no-(?!integrated-as)/no-/;
+
+    # rewrite some options in "enable-..." form
+    s /^-?-?shared$/enable-shared/;
+    s /^sctp$/enable-sctp/;
+    s /^threads$/enable-threads/;
+    s /^zlib$/enable-zlib/;
+    s /^zlib-dynamic$/enable-zlib-dynamic/;
+
+    if (/^(no|disable|enable)-(.+)$/) {
+        my $word = $2;
+        if ($word !~ m|hw(?:-.+)| # special treatment for hw regexp opt
+                && !exists $deprecated_disablables{$word}
+                && !grep { $word eq $_ } @disablables) {
+            $unsupported_options{$_} = 1;
+            next;
+        }
+    }
+    if (/^no-(.+)$/ || /^disable-(.+)$/) {
+        foreach my $proto ((@tls, @dtls)) {
+            if ($1 eq "$proto-method") {
+                $disabled{"$proto"} = "option($proto-method)";
+                last;
+            }
+        }
+        if ($1 eq "dtls") {
+            foreach my $proto (@dtls) {
+                $disabled{$proto} = "option(dtls)";
+            }
+            $disabled{"dtls"} = "option(dtls)";
+        } elsif ($1 eq "ssl") {
+            # Last one of its kind
+            $disabled{"ssl3"} = "option(ssl)";
+        } elsif ($1 eq "tls") {
+            # XXX: Tests will fail if all SSL/TLS
+            # protocols are disabled.
+            foreach my $proto (@tls) {
+                $disabled{$proto} = "option(tls)";
+            }
+        } elsif ($1 eq "static-engine") {
+            delete $disabled{"dynamic-engine"};
+        } elsif ($1 eq "dynamic-engine") {
+            $disabled{"dynamic-engine"} = "option";
+        } elsif (exists $deprecated_disablables{$1}) {
+            $deprecated_options{$_} = 1;
+            if (defined $deprecated_disablables{$1}) {
+                $disabled{$deprecated_disablables{$1}} = "option";
+            }
+        } elsif ($1 =~ m|hw(?:-.+)|) { # deprecate hw options in regexp form
+            $deprecated_options{$_} = 1;
+        } else {
+            $disabled{$1} = "option";
+        }
+        # No longer an automatic choice
+        $auto_threads = 0 if ($1 eq "threads");
+    } elsif (/^enable-(.+)$/) {
+        if ($1 eq "static-engine") {
+            $disabled{"dynamic-engine"} = "option";
+        } elsif ($1 eq "dynamic-engine") {
+            delete $disabled{"dynamic-engine"};
+        } elsif ($1 eq "zlib-dynamic") {
+            delete $disabled{"zlib"};
+        }
+        my $algo = $1;
+        delete $disabled{$algo};
+
+        # No longer an automatic choice
+        $auto_threads = 0 if ($1 eq "threads");
+    } elsif (/^--strict-warnings$/) {
+        # Pretend that our strict flags is a C flag, and replace it
+        # with the proper flags later on
+        push @{$useradd{CFLAGS}}, '--ossl-strict-warnings';
+        push @{$useradd{CXXFLAGS}}, '--ossl-strict-warnings';
+        $strict_warnings=1;
+    } elsif (/^--debug$/) {
+        $config{build_type} = "debug";
+    } elsif (/^--release$/) {
+        $config{build_type} = "release";
+    } elsif (/^386$/) {
+        $config{processor}=386;
+    } elsif (/^fips$/) {
+        die "FIPS mode not supported\n";
+    } elsif (/^rsaref$/) {
+        # No RSAref support any more since it's not needed.
+        # The check for the option is there so scripts aren't
+        # broken
+    } elsif (/^nofipscanistercheck$/) {
+        die "FIPS mode not supported\n";
+    } elsif (/^[-+]/) {
+        if (/^--prefix=(.*)$/) {
+            $config{prefix}=$1;
+            die "Directory given with --prefix MUST be absolute\n"
+                unless file_name_is_absolute($config{prefix});
+        } elsif (/^--api=(.*)$/) {
+            $config{api}=$1;
+        } elsif (/^--libdir=(.*)$/) {
+            $config{libdir}=$1;
+        } elsif (/^--openssldir=(.*)$/) {
+            $config{openssldir}=$1;
+        } elsif (/^--with-zlib-lib=(.*)$/) {
+            $withargs{zlib_lib}=$1;
+        } elsif (/^--with-zlib-include=(.*)$/) {
+            $withargs{zlib_include}=$1;
+        } elsif (/^--with-fuzzer-lib=(.*)$/) {
+            $withargs{fuzzer_lib}=$1;
+        } elsif (/^--with-fuzzer-include=(.*)$/) {
+            $withargs{fuzzer_include}=$1;
+        } elsif (/^--with-rand-seed=(.*)$/) {
+            foreach my $x (split(m|,|, $1)) {
+                die "Unknown --with-rand-seed choice $x\n"
+                    if ! grep { $x eq $_ } @known_seed_sources;
+                push @seed_sources, $x;
+            }
+        } elsif (/^--cross-compile-prefix=(.*)$/) {
+            $user{CROSS_COMPILE}=$1;
+        } elsif (/^--config=(.*)$/) {
+            read_config $1;
+        } elsif (/^-l(.*)$/) {
+            push @{$useradd{LDLIBS}}, $_;
+        } elsif (/^-framework$/) {
+            push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
+        } elsif (/^-L(.*)$/ or /^-Wl,/) {
+            push @{$useradd{LDFLAGS}}, $_;
+        } elsif (/^-rpath$/ or /^-R$/) {
+            # -rpath is the OSF1 rpath flag
+            # -R is the old Solaris rpath flag
+            my $rpath = shift(@argvcopy) || "";
+            $rpath .= " " if $rpath ne "";
+            push @{$useradd{LDFLAGS}}, $_, $rpath;
+        } elsif (/^-static$/) {
+            push @{$useradd{LDFLAGS}}, $_;
+            $disabled{"dso"} = "forced";
+            $disabled{"pic"} = "forced";
+            $disabled{"shared"} = "forced";
+            $disabled{"threads"} = "forced";
+        } elsif (/^-D(.*)$/) {
+            push @{$useradd{CPPDEFINES}}, $1;
+        } elsif (/^-I(.*)$/) {
+            push @{$useradd{CPPINCLUDES}}, $1;
+        } elsif (/^-Wp,$/) {
+            push @{$useradd{CPPFLAGS}}, $1;
+        } else {
+            # common if (/^[-+]/), just pass down...
+            $_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
+            push @{$useradd{CFLAGS}}, $_;
+            push @{$useradd{CXXFLAGS}}, $_;
+        }
+    } else {
+        die "target already defined - $target (offending arg: $_)\n" if ($target ne "");
+        $target=$_;
+    }
+
+    unless ($_ eq $target || /^no-/ || /^disable-/) {
+        # "no-..." follows later after implied deactivations
+        # have been derived.  (Don't take this too seriously,
+        # we really only write OPTIONS to the Makefile out of
+        # nostalgia.)
+
+        if ($config{options} eq "") {
+            $config{options} = $_;
+        } else {
+            $config{options} .= " ".$_;
+        }
+    }
 }
 
-if (keys %deprecated_options)
-        {
-        warn "***** Deprecated options: ",
-                join(", ", keys %deprecated_options), "\n";
-        }
-if (keys %unsupported_options)
-        {
-        die "***** Unsupported options: ",
-                join(", ", keys %unsupported_options), "\n";
-        }
+if (defined($config{api}) && !exists $apitable->{$config{api}}) {
+    die "***** Unsupported api compatibility level: $config{api}\n",
+}
+
+if (keys %deprecated_options) {
+    warn "***** Deprecated options: ",
+        join(", ", keys %deprecated_options), "\n";
+}
+if (keys %unsupported_options) {
+    die "***** Unsupported options: ",
+        join(", ", keys %unsupported_options), "\n";
+}
 
 # If any %useradd entry has been set, we must check that the "make
 # variables" haven't been set.  We start by checking of any %useradd entry
@@ -1260,22 +1167,22 @@ foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
 
 push @{$config{defines}}, "NDEBUG"    if $config{build_type} eq "release";
 
-if ($target =~ /^mingw/ && `$config{CC} --target-help 2>&1` =~ m/-mno-cygwin/m)
-        {
-        push @{$config{cflags}}, "-mno-cygwin";
-        push @{$config{cxxflags}}, "-mno-cygwin" if $config{CXX};
-        push @{$config{shared_ldflag}}, "-mno-cygwin";
-        }
+if ($target =~ /^mingw/
+        && `$config{CC} --target-help 2>&1` =~ m/-mno-cygwin/m) {
+    push @{$config{cflags}}, "-mno-cygwin";
+    push @{$config{cxxflags}}, "-mno-cygwin" if $config{CXX};
+    push @{$config{shared_ldflag}}, "-mno-cygwin";
+}
 
 if ($target =~ /linux.*-mips/ && !$disabled{asm}
         && !grep { $_ !~ /-m(ips|arch=)/ } (@{$user{CFLAGS}},
                                             @{$useradd{CFLAGS}})) {
-        # minimally required architecture flags for assembly modules
-        my $value;
-        $value = '-mips2' if ($target =~ /mips32/);
-        $value = '-mips3' if ($target =~ /mips64/);
-        unshift @{$config{cflags}}, $value;
-        unshift @{$config{cxxflags}}, $value if $config{CXX};
+    # minimally required architecture flags for assembly modules
+    my $value;
+    $value = '-mips2' if ($target =~ /mips32/);
+    $value = '-mips3' if ($target =~ /mips64/);
+    unshift @{$config{cflags}}, $value;
+    unshift @{$config{cxxflags}}, $value if $config{CXX};
 }
 
 # If threads aren't disabled, check how possible they are
@@ -1311,25 +1218,24 @@ unless($disabled{threads}) {
 
 # With "deprecated" disable all deprecated features.
 if (defined($disabled{"deprecated"})) {
-        $config{api} = $maxapi;
+    $config{api} = $maxapi;
 }
 
 my $no_shared_warn=0;
-if ($target{shared_target} eq "")
-        {
-        $no_shared_warn = 1
-            if (!$disabled{shared} || !$disabled{"dynamic-engine"});
-        $disabled{shared} = "no-shared-target";
-        $disabled{pic} = $disabled{shared} = $disabled{"dynamic-engine"} =
-            "no-shared-target";
-        }
+if ($target{shared_target} eq "") {
+    $no_shared_warn = 1
+        if (!$disabled{shared} || !$disabled{"dynamic-engine"});
+    $disabled{shared} = "no-shared-target";
+    $disabled{pic} = $disabled{shared} = $disabled{"dynamic-engine"} =
+        "no-shared-target";
+}
 
 if ($disabled{"dynamic-engine"}) {
-        push @{$config{openssl_feature_defines}}, "OPENSSL_NO_DYNAMIC_ENGINE";
-        $config{dynamic_engines} = 0;
+    push @{$config{openssl_feature_defines}}, "OPENSSL_NO_DYNAMIC_ENGINE";
+    $config{dynamic_engines} = 0;
 } else {
-        push @{$config{openssl_feature_defines}}, "OPENSSL_NO_STATIC_ENGINE";
-        $config{dynamic_engines} = 1;
+    push @{$config{openssl_feature_defines}}, "OPENSSL_NO_STATIC_ENGINE";
+    $config{dynamic_engines} = 1;
 }
 
 unless ($disabled{asan}) {
@@ -1346,8 +1252,8 @@ unless ($disabled{ubsan}) {
 }
 
 unless ($disabled{msan}) {
-  push @{$config{cflags}}, "-fsanitize=memory";
-  push @{$config{cxxflags}}, "-fsanitize=memory" if $config{CXX};
+    push @{$config{cflags}}, "-fsanitize=memory";
+    push @{$config{cxxflags}}, "-fsanitize=memory" if $config{CXX};
 }
 
 unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
@@ -1360,46 +1266,53 @@ unless ($disabled{"fuzz-libfuzzer"} && $disabled{"fuzz-afl"}
 #
 
 # This saves the build files from having to check
-if ($disabled{pic})
-        {
-        foreach (qw(shared_cflag shared_cxxflag shared_cppflag
-                    shared_defines shared_includes shared_ldflag
-                    module_cflags module_cxxflags module_cppflags
-                    module_defines module_includes module_lflags))
-                {
-                delete $config{$_};
-                $target{$_} = "";
-                }
-        }
-else
-        {
-        push @{$config{lib_defines}}, "OPENSSL_PIC";
-        }
+if ($disabled{pic}) {
+    foreach (qw(shared_cflag shared_cxxflag shared_cppflag
+                shared_defines shared_includes shared_ldflag
+                module_cflags module_cxxflags module_cppflags
+                module_defines module_includes module_lflags)) {
+        delete $config{$_};
+        $target{$_} = "";
+    }
+} else {
+    push @{$config{lib_defines}}, "OPENSSL_PIC";
+}
 
-if ($target{sys_id} ne "")
-        {
-        push @{$config{openssl_sys_defines}}, "OPENSSL_SYS_$target{sys_id}";
-        }
+if ($target{sys_id} ne "") {
+    push @{$config{openssl_sys_defines}}, "OPENSSL_SYS_$target{sys_id}";
+}
 
 unless ($disabled{asm}) {
-    $target{cpuid_asm_src}=$table{DEFAULTS}->{cpuid_asm_src} if ($config{processor} eq "386");
-    push @{$config{lib_defines}}, "OPENSSL_CPUID_OBJ" if ($target{cpuid_asm_src} ne "mem_clr.c");
+    $target{cpuid_asm_src}=$table{DEFAULTS}->{cpuid_asm_src}
+        if ($config{processor} eq "386");
+    push @{$config{lib_defines}}, "OPENSSL_CPUID_OBJ"
+        if ($target{cpuid_asm_src} ne "mem_clr.c");
 
-    $target{bn_asm_src} =~ s/\w+-gf2m.c// if (defined($disabled{ec2m}));
+    $target{bn_asm_src} =~ s/\w+-gf2m.c//
+        if (defined($disabled{ec2m}));
 
     # bn-586 is the only one implementing bn_*_part_words
-    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_PART_WORDS" if ($target{bn_asm_src} =~ /bn-586/);
-    push @{$config{lib_defines}}, "OPENSSL_IA32_SSE2" if (!$disabled{sse2} && $target{bn_asm_src} =~ /86/);
+    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_PART_WORDS"
+        if ($target{bn_asm_src} =~ /bn-586/);
+    push @{$config{lib_defines}}, "OPENSSL_IA32_SSE2"
+        if (!$disabled{sse2} && $target{bn_asm_src} =~ /86/);
 
-    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_MONT" if ($target{bn_asm_src} =~ /-mont/);
-    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_MONT5" if ($target{bn_asm_src} =~ /-mont5/);
-    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_GF2m" if ($target{bn_asm_src} =~ /-gf2m/);
-    push @{$config{lib_defines}}, "BN_DIV3W" if ($target{bn_asm_src} =~ /-div3w/);
+    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_MONT"
+        if ($target{bn_asm_src} =~ /-mont/);
+    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_MONT5"
+        if ($target{bn_asm_src} =~ /-mont5/);
+    push @{$config{lib_defines}}, "OPENSSL_BN_ASM_GF2m"
+        if ($target{bn_asm_src} =~ /-gf2m/);
+    push @{$config{lib_defines}}, "BN_DIV3W"
+        if ($target{bn_asm_src} =~ /-div3w/);
 
     if ($target{sha1_asm_src}) {
-        push @{$config{lib_defines}}, "SHA1_ASM"   if ($target{sha1_asm_src} =~ /sx86/ || $target{sha1_asm_src} =~ /sha1/);
-        push @{$config{lib_defines}}, "SHA256_ASM" if ($target{sha1_asm_src} =~ /sha256/);
-        push @{$config{lib_defines}}, "SHA512_ASM" if ($target{sha1_asm_src} =~ /sha512/);
+        push @{$config{lib_defines}}, "SHA1_ASM"
+            if ($target{sha1_asm_src} =~ /sx86/ || $target{sha1_asm_src} =~ /sha1/);
+        push @{$config{lib_defines}}, "SHA256_ASM"
+            if ($target{sha1_asm_src} =~ /sha256/);
+        push @{$config{lib_defines}}, "SHA512_ASM"
+            if ($target{sha1_asm_src} =~ /sha512/);
     }
     if ($target{keccak1600_asm_src} ne $table{DEFAULTS}->{keccak1600_asm_src}) {
         push @{$config{lib_defines}}, "KECCAK1600_ASM";
@@ -1410,20 +1323,27 @@ unless ($disabled{asm}) {
     if ($target{md5_asm_src}) {
         push @{$config{lib_defines}}, "MD5_ASM";
     }
-    $target{cast_asm_src}=$table{DEFAULTS}->{cast_asm_src} unless $disabled{pic}; # CAST assembler is not PIC
+    $target{cast_asm_src}=$table{DEFAULTS}->{cast_asm_src}
+        unless $disabled{pic}; # CAST assembler is not PIC
     if ($target{rmd160_asm_src}) {
         push @{$config{lib_defines}}, "RMD160_ASM";
     }
     if ($target{aes_asm_src}) {
-        push @{$config{lib_defines}}, "AES_ASM" if ($target{aes_asm_src} =~ m/\baes-/);;
+        push @{$config{lib_defines}}, "AES_ASM"
+            if ($target{aes_asm_src} =~ m/\baes-/);;
         # aes-ctr.fake is not a real file, only indication that assembler
         # module implements AES_ctr32_encrypt...
-        push @{$config{lib_defines}}, "AES_CTR_ASM" if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//);
+        push @{$config{lib_defines}}, "AES_CTR_ASM"
+            if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//);
         # aes-xts.fake indicates presence of AES_xts_[en|de]crypt...
-        push @{$config{lib_defines}}, "AES_XTS_ASM" if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//);
-        $target{aes_asm_src} =~ s/\s*(vpaes|aesni)-x86\.s//g if ($disabled{sse2});
-        push @{$config{lib_defines}}, "VPAES_ASM" if ($target{aes_asm_src} =~ m/vpaes/);
-        push @{$config{lib_defines}}, "BSAES_ASM" if ($target{aes_asm_src} =~ m/bsaes/);
+        push @{$config{lib_defines}}, "AES_XTS_ASM"
+            if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//);
+        $target{aes_asm_src} =~ s/\s*(vpaes|aesni)-x86\.s//g
+            if ($disabled{sse2});
+        push @{$config{lib_defines}}, "VPAES_ASM"
+            if ($target{aes_asm_src} =~ m/vpaes/);
+        push @{$config{lib_defines}}, "BSAES_ASM"
+            if ($target{aes_asm_src} =~ m/bsaes/);
     }
     if ($target{wp_asm_src} =~ /mmx/) {
         if ($config{processor} eq "386") {
@@ -1535,51 +1455,45 @@ $config{openssl_api_defines} = [
 ];
 
 my %strict_warnings_collection=( CFLAGS => [], CXXFLAGS => []);
-if ($strict_warnings)
-        {
-        my $wopt;
-        my $gccver = $predefined_C{__GNUC__} // -1;
-        my $gxxver = $predefined_CXX{__GNUC__} // -1;
+if ($strict_warnings) {
+    my $wopt;
+    my $gccver = $predefined_C{__GNUC__} // -1;
+    my $gxxver = $predefined_CXX{__GNUC__} // -1;
 
-        warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike"
-            unless $gccver >= 4;
-        warn "WARNING --strict-warnings requires g++[>=4] or g++-alike"
-            unless $gxxver >= 4;
-        foreach (qw(CFLAGS CXXFLAGS))
-                {
-                push @{$strict_warnings_collection{$_}},
-                        @{$gcc_devteam_warn{$_}};
-                }
-        push @{$strict_warnings_collection{CFLAGS}},
-                @{$clang_devteam_warn{CFLAGS}}
-                        if (defined($predefined_C{__clang__}));
-        push @{$strict_warnings_collection{CXXFLAGS}},
-                @{$clang_devteam_warn{CXXFLAGS}}
-                        if (defined($predefined_CXX{__clang__}));
-        }
-foreach my $idx (qw(CFLAGS CXXFLAGS))
-        {
-        $useradd{$idx} = [ map { $_ eq '--ossl-strict-warnings'
-                                     ? @{$strict_warnings_collection{$idx}}
-                                     : ( $_ ) }
-                               @{$useradd{$idx}} ];
-        }
+    warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike"
+        unless $gccver >= 4;
+    warn "WARNING --strict-warnings requires g++[>=4] or g++-alike"
+        unless $gxxver >= 4;
+    foreach (qw(CFLAGS CXXFLAGS)) {
+        push @{$strict_warnings_collection{$_}},
+            @{$gcc_devteam_warn{$_}};
+    }
+    push @{$strict_warnings_collection{CFLAGS}},
+        @{$clang_devteam_warn{CFLAGS}}
+        if (defined($predefined_C{__clang__}));
+    push @{$strict_warnings_collection{CXXFLAGS}},
+        @{$clang_devteam_warn{CXXFLAGS}}
+        if (defined($predefined_CXX{__clang__}));
+}
+foreach my $idx (qw(CFLAGS CXXFLAGS)) {
+    $useradd{$idx} = [ map { $_ eq '--ossl-strict-warnings'
+                                 ? @{$strict_warnings_collection{$idx}}
+                                 : ( $_ ) }
+                           @{$useradd{$idx}} ];
+}
 
-unless ($disabled{"crypto-mdebug-backtrace"})
-        {
-        foreach my $wopt (split /\s+/, $memleak_devteam_backtrace)
-                {
-                push @{$config{cflags}}, $wopt
-                        unless grep { $_ eq $wopt } @{$config{cflags}};
-                push @{$config{cxxflags}}, $wopt
-                        if ($config{CXX}
-                            && !grep { $_ eq $wopt } @{$config{cxxflags}});
-                }
-        if ($target =~ /^BSD-/)
-                {
-                push @{$config{ex_libs}}, "-lexecinfo";
-                }
-        }
+unless ($disabled{"crypto-mdebug-backtrace"}) {
+    foreach my $wopt (split /\s+/, $memleak_devteam_backtrace) {
+        push @{$config{cflags}}, $wopt
+            unless grep { $_ eq $wopt } @{$config{cflags}};
+        push @{$config{cxxflags}}, $wopt
+            if ($config{CXX}
+                && !grep { $_ eq $wopt } @{$config{cxxflags}});
+    }
+    if ($target =~ /^BSD-/) {
+        push @{$config{ex_libs}}, "-lexecinfo";
+    }
+}
 
 unless ($disabled{afalgeng}) {
     $config{afalgeng}="";
@@ -1603,7 +1517,8 @@ unless ($disabled{afalgeng}) {
     }
 }
 
-push @{$config{openssl_feature_defines}}, "OPENSSL_NO_AFALGENG" if ($disabled{afalgeng});
+push @{$config{openssl_feature_defines}}, "OPENSSL_NO_AFALGENG"
+    if ($disabled{afalgeng});
 
 unless ($disabled{ktls}) {
     $config{ktls}="";
@@ -3156,43 +3071,37 @@ sub resolve_config {
     return %{$table{$target}};
 }
 
-sub usage
-        {
-        print STDERR $usage;
-        print STDERR "\npick os/compiler from:\n";
-        my $j=0;
-        my $i;
-        my $k=0;
-        foreach $i (sort keys %table)
-                {
-                next if $table{$i}->{template};
-                next if $i =~ /^debug/;
-                $k += length($i) + 1;
-                if ($k > 78)
-                        {
-                        print STDERR "\n";
-                        $k=length($i);
-                        }
-                print STDERR $i . " ";
-                }
-        foreach $i (sort keys %table)
-                {
-                next if $table{$i}->{template};
-                next if $i !~ /^debug/;
-                $k += length($i) + 1;
-                if ($k > 78)
-                        {
-                        print STDERR "\n";
-                        $k=length($i);
-                        }
-                print STDERR $i . " ";
-                }
-        print STDERR "\n\nNOTE: If in doubt, on Unix-ish systems use './config'.\n";
-        exit(1);
+sub usage {
+    print STDERR $usage;
+    print STDERR "\npick os/compiler from:\n";
+    my $j=0;
+    my $i;
+    my $k=0;
+    foreach $i (sort keys %table) {
+        next if $table{$i}->{template};
+        next if $i =~ /^debug/;
+        $k += length($i) + 1;
+        if ($k > 78) {
+            print STDERR "\n";
+            $k=length($i);
         }
+        print STDERR $i . " ";
+    }
+    foreach $i (sort keys %table) {
+        next if $table{$i}->{template};
+        next if $i !~ /^debug/;
+        $k += length($i) + 1;
+        if ($k > 78) {
+            print STDERR "\n";
+            $k=length($i);
+        }
+        print STDERR $i . " ";
+    }
+    print STDERR "\n\nNOTE: If in doubt, on Unix-ish systems use './config'.\n";
+    exit(1);
+}
 
-sub run_dofile
-{
+sub run_dofile {
     my $out = shift;
     my @templates = @_;
 

--- a/crypto/objects/objects.pl
+++ b/crypto/objects/objects.pl
@@ -21,118 +21,115 @@ $YEAR = $iYEAR if $iYEAR > $YEAR;
 open (NUMIN,"$ARGV[1]") || die "Can't open number file $ARGV[1]";
 $max_nid=0;
 $o=0;
-while(<NUMIN>)
-	{
-	s|\R$||;
-	$o++;
-	s/#.*$//;
-	next if /^\s*$/;
-	$_ = 'X'.$_;
-	($Cname,$mynum) = split;
-	$Cname =~ s/^X//;
-	if (defined($nidn{$mynum}))
-		{ die "$ARGV[1]:$o:There's already an object with NID ",$mynum," on line ",$order{$mynum},"\n"; }
-	if (defined($nid{$Cname}))
-		{ die "$ARGV[1]:$o:There's already an object with name ",$Cname," on line ",$order{$nid{$Cname}},"\n"; }
-	$nid{$Cname} = $mynum;
-	$nidn{$mynum} = $Cname;
-	$order{$mynum} = $o;
-	$max_nid = $mynum if $mynum > $max_nid;
-	}
+while(<NUMIN>) {
+    s|\R$||;
+    $o++;
+    s/#.*$//;
+    next if /^\s*$/;
+    $_ = 'X'.$_;
+    ($Cname,$mynum) = split;
+    $Cname =~ s/^X//;
+    if (defined($nidn{$mynum})) {
+        die "$ARGV[1]:$o:There's already an object with NID ",$mynum," on line ",$order{$mynum},"\n";
+    }
+    if (defined($nid{$Cname})) {
+        die "$ARGV[1]:$o:There's already an object with name ",$Cname," on line ",$order{$nid{$Cname}},"\n";
+    }
+    $nid{$Cname} = $mynum;
+    $nidn{$mynum} = $Cname;
+    $order{$mynum} = $o;
+    $max_nid = $mynum if $mynum > $max_nid;
+}
 close NUMIN;
 
 open (IN,"$ARGV[0]") || die "Can't open input file $ARGV[0]";
 $Cname="";
 $o=0;
-while (<IN>)
-	{
-	s|\R$||;
-	$o++;
-        if (/^!module\s+(.*)$/)
-		{
-		$module = $1."-";
-		$module =~ s/\./_/g;
-		$module =~ s/-/_/g;
-		}
-        if (/^!global$/)
-		{ $module = ""; }
-	if (/^!Cname\s+(.*)$/)
-		{ $Cname = $1; }
-	if (/^!Alias\s+(.+?)\s+(.*)$/)
-		{
-		$Cname = $module.$1;
-		$myoid = $2;
-		$myoid = &process_oid($myoid);
-		$Cname =~ s/-/_/g;
-		$ordern{$o} = $Cname;
-		$order{$Cname} = $o;
-		$obj{$Cname} = $myoid;
-		$_ = "";
-		$Cname = "";
-		}
-	s/!.*$//;
-	s/#.*$//;
-	next if /^\s*$/;
-	($myoid,$mysn,$myln) = split ':';
-	$mysn =~ s/^\s*//;
-	$mysn =~ s/\s*$//;
-	$myln =~ s/^\s*//;
-	$myln =~ s/\s*$//;
-	$myoid =~ s/^\s*//;
-	$myoid =~ s/\s*$//;
-	if ($myoid ne "")
-		{
-		$myoid = &process_oid($myoid);
-		}
+while (<IN>) {
+    s|\R$||;
+    $o++;
+    if (/^!module\s+(.*)$/) {
+        $module = $1."-";
+        $module =~ s/\./_/g;
+        $module =~ s/-/_/g;
+    }
+    if (/^!global$/) {
+        $module = "";
+    }
+    if (/^!Cname\s+(.*)$/) {
+        $Cname = $1;
+    }
+    if (/^!Alias\s+(.+?)\s+(.*)$/) {
+        $Cname = $module.$1;
+        $myoid = $2;
+        $myoid = &process_oid($myoid);
+        $Cname =~ s/-/_/g;
+        $ordern{$o} = $Cname;
+        $order{$Cname} = $o;
+        $obj{$Cname} = $myoid;
+        $_ = "";
+        $Cname = "";
+    }
+    s/!.*$//;
+    s/#.*$//;
+    next if /^\s*$/;
+    ($myoid,$mysn,$myln) = split ':';
+    $mysn =~ s/^\s*//;
+    $mysn =~ s/\s*$//;
+    $myln =~ s/^\s*//;
+    $myln =~ s/\s*$//;
+    $myoid =~ s/^\s*//;
+    $myoid =~ s/\s*$//;
+    if ($myoid ne "") {
+        $myoid = &process_oid($myoid);
+    }
 
-	if ($Cname eq "" && ($myln =~ /^[_A-Za-z][\w.-]*$/ ))
-		{
-		$Cname = $myln;
-		$Cname =~ s/\./_/g;
-		$Cname =~ s/-/_/g;
-		if ($Cname ne "" && defined($ln{$module.$Cname}))
-			{ die "objects.txt:$o:There's already an object with long name ",$ln{$module.$Cname}," on line ",$order{$module.$Cname},"\n"; }
-		}
-	if ($Cname eq "")
-		{
-		$Cname = $mysn;
-		$Cname =~ s/-/_/g;
-		if ($Cname ne "" && defined($sn{$module.$Cname}))
-			{ die "objects.txt:$o:There's already an object with short name ",$sn{$module.$Cname}," on line ",$order{$module.$Cname},"\n"; }
-		}
-	if ($Cname eq "")
-		{
-		$Cname = $myln;
-		$Cname =~ s/-/_/g;
-		$Cname =~ s/\./_/g;
-		$Cname =~ s/ /_/g;
-		if ($Cname ne "" && defined($ln{$module.$Cname}))
-			{ die "objects.txt:$o:There's already an object with long name ",$ln{$module.$Cname}," on line ",$order{$module.$Cname},"\n"; }
-		}
-	$Cname =~ s/\./_/g;
-	$Cname =~ s/-/_/g;
-	$Cname = $module.$Cname;
-	$ordern{$o} = $Cname;
-	$order{$Cname} = $o;
-	$sn{$Cname} = $mysn;
-	$ln{$Cname} = $myln;
-	$obj{$Cname} = $myoid;
-	if (!defined($nid{$Cname}))
-		{
-		$max_nid++;
-		$nid{$Cname} = $max_nid;
-		$nidn{$max_nid} = $Cname;
-print STDERR "Added OID $Cname\n";
-		}
-	$Cname="";
-	}
+    if ($Cname eq "" && ($myln =~ /^[_A-Za-z][\w.-]*$/ )) {
+        $Cname = $myln;
+        $Cname =~ s/\./_/g;
+        $Cname =~ s/-/_/g;
+        if ($Cname ne "" && defined($ln{$module.$Cname})) {
+            die "objects.txt:$o:There's already an object with long name ",$ln{$module.$Cname}," on line ",$order{$module.$Cname},"\n";
+        }
+    }
+    if ($Cname eq "") {
+        $Cname = $mysn;
+        $Cname =~ s/-/_/g;
+        if ($Cname ne "" && defined($sn{$module.$Cname})) {
+            die "objects.txt:$o:There's already an object with short name ",$sn{$module.$Cname}," on line ",$order{$module.$Cname},"\n";
+        }
+    }
+    if ($Cname eq "") {
+        $Cname = $myln;
+        $Cname =~ s/-/_/g;
+        $Cname =~ s/\./_/g;
+        $Cname =~ s/ /_/g;
+        if ($Cname ne "" && defined($ln{$module.$Cname})) {
+            die "objects.txt:$o:There's already an object with long name ",$ln{$module.$Cname}," on line ",$order{$module.$Cname},"\n";
+        }
+    }
+    $Cname =~ s/\./_/g;
+    $Cname =~ s/-/_/g;
+    $Cname = $module.$Cname;
+    $ordern{$o} = $Cname;
+    $order{$Cname} = $o;
+    $sn{$Cname} = $mysn;
+    $ln{$Cname} = $myln;
+    $obj{$Cname} = $myoid;
+    if (!defined($nid{$Cname})) {
+        $max_nid++;
+        $nid{$Cname} = $max_nid;
+        $nidn{$max_nid} = $Cname;
+        print STDERR "Added OID $Cname\n";
+    }
+    $Cname="";
+}
 close IN;
 
 if ( $opt_n ) {
-    foreach (sort { $a <=> $b } keys %nidn)
-            {
-            print $nidn{$_},"\t\t",$_,"\n";
-            }
+    foreach (sort { $a <=> $b } keys %nidn) {
+        print $nidn{$_},"\t\t",$_,"\n";
+    }
     exit;
 }
 
@@ -154,50 +151,44 @@ print <<"EOF";
 #define OBJ_undef                       0L
 EOF
 
-sub expand
-	{
-	my $string = shift;
+sub expand {
+    my $string = shift;
 
-	1 while $string =~ s/\t+/' ' x (length($&) * 8 - length($`) % 8)/e;
+    1 while $string =~ s/\t+/' ' x (length($&) * 8 - length($`) % 8)/e;
 
-	return $string;
-	}
+    return $string;
+}
 
-foreach (sort { $a <=> $b } keys %ordern)
-	{
-	$Cname=$ordern{$_};
-	print "\n";
-	print expand("#define SN_$Cname\t\t\"$sn{$Cname}\"\n") if $sn{$Cname} ne "";
-	print expand("#define LN_$Cname\t\t\"$ln{$Cname}\"\n") if $ln{$Cname} ne "";
-	print expand("#define NID_$Cname\t\t$nid{$Cname}\n") if $nid{$Cname} ne "";
-	print expand("#define OBJ_$Cname\t\t$obj{$Cname}\n") if $obj{$Cname} ne "";
-	}
+foreach (sort { $a <=> $b } keys %ordern) {
+    $Cname=$ordern{$_};
+    print "\n";
+    print expand("#define SN_$Cname\t\t\"$sn{$Cname}\"\n") if $sn{$Cname} ne "";
+    print expand("#define LN_$Cname\t\t\"$ln{$Cname}\"\n") if $ln{$Cname} ne "";
+    print expand("#define NID_$Cname\t\t$nid{$Cname}\n") if $nid{$Cname} ne "";
+    print expand("#define OBJ_$Cname\t\t$obj{$Cname}\n") if $obj{$Cname} ne "";
+}
 
-sub process_oid
-	{
-	local($oid)=@_;
-	local(@a,$oid_pref);
+sub process_oid {
+    local($oid)=@_;
+    local(@a,$oid_pref);
 
-	@a = split(/\s+/,$myoid);
-	$pref_oid = "";
-	$pref_sep = "";
-	if (!($a[0] =~ /^[0-9]+$/))
-		{
-		$a[0] =~ s/-/_/g;
-		if (!defined($obj{$a[0]}))
-			{ die "$ARGV[0]:$o:Undefined identifier ",$a[0],"\n"; }
-		$pref_oid = "OBJ_" . $a[0];
-		$pref_sep = ",";
-		shift @a;
-		}
-	$oids = join('L,',@a) . "L";
-	if ($oids ne "L")
-		{
-		$oids = $pref_oid . $pref_sep . $oids;
-		}
-	else
-		{
-		$oids = $pref_oid;
-		}
-	return($oids);
-	}
+    @a = split(/\s+/,$myoid);
+    $pref_oid = "";
+    $pref_sep = "";
+    if (!($a[0] =~ /^[0-9]+$/)) {
+        $a[0] =~ s/-/_/g;
+        if (!defined($obj{$a[0]})) {
+            die "$ARGV[0]:$o:Undefined identifier ",$a[0],"\n";
+        }
+        $pref_oid = "OBJ_" . $a[0];
+        $pref_sep = ",";
+        shift @a;
+    }
+    $oids = join('L,',@a) . "L";
+    if ($oids ne "L") {
+        $oids = $pref_oid . $pref_sep . $oids;
+    } else {
+        $oids = $pref_oid;
+    }
+    return($oids);
+}

--- a/crypto/objects/objxref.pl
+++ b/crypto/objects/objxref.pl
@@ -25,50 +25,46 @@ open(IN, $mac_file) || die "Can't open $mac_file, $!\n";
 
 # Read in OID nid values for a lookup table.
 
-while (<IN>)
-	{
-	s|\R$||;                # Better chomp
-	my ($name, $num) = /^(\S+)\s+(\S+)$/;
-	$oid_tbl{$name} = $num;
-	}
+while (<IN>) {
+    s|\R$||;                # Better chomp
+    my ($name, $num) = /^(\S+)\s+(\S+)$/;
+    $oid_tbl{$name} = $num;
+}
 close IN;
 
 open(IN, $xref_file) || die "Can't open $xref_file, $!\n";
 
 my $ln = 1;
 
-while (<IN>)
-	{
-	s|\R$||;                # Better chomp
-	s/#.*$//;
-	next if (/^\S*$/);
-	my ($xr, $p1, $p2) = /^(\S+)\s+(\S+)\s+(\S+)/;
-	check_oid($xr);
-	check_oid($p1);
-	check_oid($p2);
-	$xref_tbl{$xr} = [$p1, $p2, $ln];
-	}
+while (<IN>) {
+    s|\R$||;                # Better chomp
+    s/#.*$//;
+    next if (/^\S*$/);
+    my ($xr, $p1, $p2) = /^(\S+)\s+(\S+)\s+(\S+)/;
+    check_oid($xr);
+    check_oid($p1);
+    check_oid($p2);
+    $xref_tbl{$xr} = [$p1, $p2, $ln];
+}
 
 my @xrkeys = keys %xref_tbl;
 
 my @srt1 = sort { $oid_tbl{$a} <=> $oid_tbl{$b}} @xrkeys;
 
 my $i;
-for($i = 0; $i <= $#srt1; $i++)
-	{
-	$xref_tbl{$srt1[$i]}[2] = $i;
-	}
+for($i = 0; $i <= $#srt1; $i++) {
+    $xref_tbl{$srt1[$i]}[2] = $i;
+}
 
-my @srt2 = sort
-	{
-	my$ap1 = $oid_tbl{$xref_tbl{$a}[0]};
-	my$bp1 = $oid_tbl{$xref_tbl{$b}[0]};
-	return $ap1 - $bp1 if ($ap1 != $bp1);
-	my$ap2 = $oid_tbl{$xref_tbl{$a}[1]};
-	my$bp2 = $oid_tbl{$xref_tbl{$b}[1]};
+my @srt2 = sort {
+    my$ap1 = $oid_tbl{$xref_tbl{$a}[0]};
+    my$bp1 = $oid_tbl{$xref_tbl{$b}[0]};
+    return $ap1 - $bp1 if ($ap1 != $bp1);
+    my$ap2 = $oid_tbl{$xref_tbl{$a}[1]};
+    my$bp2 = $oid_tbl{$xref_tbl{$b}[1]};
 
-	return $ap2 - $bp2;
-	} @xrkeys;
+    return $ap2 - $bp2;
+} @xrkeys;
 
 my $pname = $0;
 $pname =~ s|.*/||;
@@ -98,21 +94,17 @@ DEFINE_STACK_OF(nid_triple)
 static const nid_triple sigoid_srt[] = {
 EOF
 
-foreach (@srt1)
-	{
-	my $xr = $_;
-	my ($p1, $p2) = @{$xref_tbl{$_}};
-	my $o1 = "    {NID_$xr, NID_$p1,";
-	my $o2 = "NID_$p2},";
-        if (length("$o1 $o2") < 78)
-		{
-		print "$o1 $o2\n";
-		}
-	else
-		{
-		print "$o1\n     $o2\n";
-		}
-        }
+foreach (@srt1) {
+    my $xr = $_;
+    my ($p1, $p2) = @{$xref_tbl{$_}};
+    my $o1 = "    {NID_$xr, NID_$p1,";
+    my $o2 = "NID_$p2},";
+    if (length("$o1 $o2") < 78) {
+        print "$o1 $o2\n";
+    } else {
+        print "$o1\n     $o2\n";
+    }
+}
 
 print "};";
 print <<EOF;
@@ -121,22 +113,19 @@ print <<EOF;
 static const nid_triple *const sigoid_srt_xref[] = {
 EOF
 
-foreach (@srt2)
-	{
-	my ($p1, $p2, $x) = @{$xref_tbl{$_}};
-	# If digest or signature algorithm is "undef" then the algorithm
-	# needs special handling and is excluded from the cross reference table.
-	next if $p1 eq "undef" || $p2 eq "undef";
-	print "    \&sigoid_srt\[$x\],\n";
-	}
+foreach (@srt2) {
+    my ($p1, $p2, $x) = @{$xref_tbl{$_}};
+    # If digest or signature algorithm is "undef" then the algorithm
+    # needs special handling and is excluded from the cross reference table.
+    next if $p1 eq "undef" || $p2 eq "undef";
+    print "    \&sigoid_srt\[$x\],\n";
+}
 
 print "};\n";
 
-sub check_oid
-	{
-	my ($chk) = @_;
-	if (!exists $oid_tbl{$chk})
-		{
-		die "Can't find \"$chk\"\n";
-		}
-	}
+sub check_oid {
+    my ($chk) = @_;
+    if (!exists $oid_tbl{$chk}) {
+        die "Can't find \"$chk\"\n";
+    }
+}

--- a/ms/cmp.pl
+++ b/ms/cmp.pl
@@ -15,8 +15,7 @@ binmode IN1;
 
 $tot=0;
 $ret=1;
-for (;;)
-{
+for (;;) {
     $n1=sysread(IN0,$b1,4096);
     $n2=sysread(IN1,$b2,4096);
 
@@ -33,15 +32,12 @@ for (;;)
 
 close(IN0);
 close(IN1);
-if ($ret)
-{
+if ($ret) {
     printf STDERR "$ARGV[0] and $ARGV[1] are different\n";
     @a1=unpack("C*",$b1);
     @a2=unpack("C*",$b2);
-    for ($i=0; $i<=$#a1; $i++)
-    {
-        if ($a1[$i] ne $a2[$i])
-        {
+    for ($i=0; $i<=$#a1; $i++) {
+        if ($a1[$i] ne $a2[$i]) {
             printf "%02X %02X <<\n",$a1[$i],$a2[$i];
             last;
         }

--- a/ms/uplink-common.pl
+++ b/ms/uplink-common.pl
@@ -16,8 +16,8 @@ close(INPUT);
 ($#max==0) or die "can't find APPLINK_MAX in $applink_c";
 
 $max[0]=~/APPLINK_MAX\s+(\d+)/;
-$N=$1;	# number of entries in OPENSSL_UplinkTable not including
-	# OPENSSL_UplinkTable[0], which contains this value...
+$N=$1;  # number of entries in OPENSSL_UplinkTable not including
+        # OPENSSL_UplinkTable[0], which contains this value...
 
 1;
 

--- a/test/bntests.pl
+++ b/test/bntests.pl
@@ -14,8 +14,7 @@ use Math::BigInt;
 my $EXPECTED_FAILURES = 0;
 my $failures = 0;
 
-sub bn
-{
+sub bn {
     my $x = shift;
     my ($sign, $hex) = ($x =~ /^([+\-]?)(.*)$/);
 
@@ -23,8 +22,7 @@ sub bn
     return Math::BigInt->from_hex($sign.$hex);
 }
 
-sub evaluate
-{
+sub evaluate {
     my $lineno = shift;
     my %s = @_;
 

--- a/test/cms-examples.pl
+++ b/test/cms-examples.pl
@@ -18,18 +18,13 @@ my $cmscmd;
 my $exdir  = "./";
 my $exfile = "./rfc4134.txt";
 
-if (-f "../apps/openssl")
-	{
-	$cmscmd = "../util/shlib_wrap.sh ../apps/openssl cms";
-	}
-elsif (-f "..\\out32dll\\openssl.exe")
-	{
-	$cmscmd = "..\\out32dll\\openssl.exe cms";
-	}
-elsif (-f "..\\out32\\openssl.exe")
-	{
-	$cmscmd = "..\\out32\\openssl.exe cms";
-	}
+if (-f "../apps/openssl") {
+    $cmscmd = "../util/shlib_wrap.sh ../apps/openssl cms";
+} elsif (-f "..\\out32dll\\openssl.exe") {
+    $cmscmd = "..\\out32dll\\openssl.exe cms";
+} elsif (-f "..\\out32\\openssl.exe") {
+    $cmscmd = "..\\out32\\openssl.exe cms";
+}
 
 my @test_list = (
     [ "3.1.bin"  => "dataout" ],
@@ -134,8 +129,7 @@ foreach (@cleanup) {
 
 if ($badtest) {
     print "\n$badtest TESTS FAILED!!\n";
-}
-else {
+} else {
     print "\n***All tests successful***\n";
 }
 
@@ -165,12 +159,10 @@ sub run_reencode_test {
     if ($?) {
         print "\tReencode command FAILED!!\n";
         $badtest++;
-    }
-    elsif ( !cmp_files( "$cmsdir/$tfile", "tmp.der" ) ) {
+    } elsif ( !cmp_files( "$cmsdir/$tfile", "tmp.der" ) ) {
         print "\tReencode FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tReencode passed\n" if $verbose;
     }
 }
@@ -186,8 +178,7 @@ sub run_certsout_test {
     if ($?) {
         print "\tCertificate output command FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tCertificate output passed\n" if $verbose;
     }
 }
@@ -202,12 +193,10 @@ sub run_dataout_test {
     if ($?) {
         print "\tDataout command FAILED!!\n";
         $badtest++;
-    }
-    elsif ( !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) ) {
+    } elsif ( !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) ) {
         print "\tDataout compare FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tDataout passed\n" if $verbose;
     }
 }
@@ -233,14 +222,11 @@ sub run_verify_test {
     if ($?) {
         print "\tVerify command FAILED!!\n";
         $badtest++;
-    }
-    elsif ( $tlist =~ /cont/
-        && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) )
-    {
+    } elsif ( $tlist =~ /cont/
+                  && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) ) {
         print "\tVerify content compare FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tVerify passed\n" if $verbose;
     }
 }
@@ -263,14 +249,11 @@ sub run_envelope_test {
     if ($?) {
         print "\tDecrypt command FAILED!!\n";
         $badtest++;
-    }
-    elsif ( $tlist =~ /cont/
-        && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) )
-    {
+    } elsif ( $tlist =~ /cont/
+                  && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) ) {
         print "\tDecrypt content compare FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tDecrypt passed\n" if $verbose;
     }
 }
@@ -287,14 +270,11 @@ sub run_digest_test {
     if ($?) {
         print "\tDigest verify command FAILED!!\n";
         $badtest++;
-    }
-    elsif ( $tlist =~ /cont/
-        && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) )
-    {
+    } elsif ( $tlist =~ /cont/
+                  && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) ) {
         print "\tDigest verify content compare FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tDigest verify passed\n" if $verbose;
     }
 }
@@ -310,14 +290,11 @@ sub run_encrypted_test {
     if ($?) {
         print "\tEncrypted Data command FAILED!!\n";
         $badtest++;
-    }
-    elsif ( $tlist =~ /cont/
-        && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) )
-    {
+    } elsif ( $tlist =~ /cont/
+                  && !cmp_files( "$cmsdir/ExContent.bin", "tmp.txt" ) ) {
         print "\tEncrypted Data content compare FAILED!!\n";
         $badtest++;
-    }
-    else {
+    } else {
         print "\tEncryptedData verify passed\n" if $verbose;
     }
 }
@@ -353,7 +330,6 @@ sub cmp_files {
             $ret = 1;
             last;
         }
-
     }
 
     close $fp1;

--- a/test/pkits-test.pl
+++ b/test/pkits-test.pl
@@ -12,14 +12,11 @@ my $ossl_path;
 
 if ( -f "../apps/openssl" ) {
     $ossl_path = "../util/shlib_wrap.sh ../apps/openssl";
-}
-elsif ( -f "..\\out32dll\\openssl.exe" ) {
+} elsif ( -f "..\\out32dll\\openssl.exe" ) {
     $ossl_path = "..\\out32dll\\openssl.exe";
-}
-elsif ( -f "..\\out32\\openssl.exe" ) {
+} elsif ( -f "..\\out32\\openssl.exe" ) {
     $ossl_path = "..\\out32\\openssl.exe";
-}
-else {
+} else {
     die "Can't find OpenSSL executable";
 }
 
@@ -743,11 +740,10 @@ $ossl_cmd .= "-CAfile pkitsta.pem -crl_check_all -x509_strict ";
 
 # Check for expiry of trust anchor
 system "$ossl_path x509 -inform DER -in $pkitsta -checkend 0";
-if ($? == 256)
-	{
-	print STDERR "WARNING: using older expired data\n";
-	$ossl_cmd .= "-attime 1291940972 ";
-	}
+if ($? == 256) {
+    print STDERR "WARNING: using older expired data\n";
+    $ossl_cmd .= "-attime 1291940972 ";
+}
 
 $ossl_cmd .= "-policy_check -extended_crl -use_deltas -out /dev/null 2>&1 ";
 
@@ -762,8 +758,7 @@ foreach (@testlists) {
     if ( $argnum == 2 ) {
         my ( $tnum, $title ) = @$_;
         print "$tnum $title\n" if $verbose;
-    }
-    elsif ( $argnum == 3 ) {
+    } elsif ( $argnum == 3 ) {
         my ( $tnum, $title, $exp_ret ) = @$_;
         my $filename = $title;
         $exp_ret += 32 if $exp_ret;
@@ -771,8 +766,7 @@ foreach (@testlists) {
         $filename = "Signed${filename}.eml";
         if ( !-f "$pkitsdir/$filename" ) {
             print "\"$filename\" not found\n";
-        }
-        else {
+        } else {
             my $ret;
             my $test_fail = 0;
             my $errmsg    = "";
@@ -798,8 +792,7 @@ foreach (@testlists) {
             }
             $numtest++;
         }
-    }
-    elsif ( $argnum == 7 ) {
+    } elsif ( $argnum == 7 ) {
         my ( $tnum, $title, $exargs, $exp_epol, $exp_aset, $exp_uset, $exp_ret )
           = @$_;
         my $filename = $title;
@@ -808,8 +801,7 @@ foreach (@testlists) {
         $filename = "Signed${filename}.eml";
         if ( !-f "$pkitsdir/$filename" ) {
             print "\"$filename\" not found\n";
-        }
-        else {
+        } else {
             my $ret;
             my $cmdout    = "";
             my $errmsg    = "";
@@ -836,8 +828,7 @@ foreach (@testlists) {
                 if (/^Authority Policies/) {
                     if (/empty/) {
                         $aset = "<empty>";
-                    }
-                    else {
+                    } else {
                         $pol = 1;
                     }
                 }
@@ -845,8 +836,7 @@ foreach (@testlists) {
                 if (/^User Policies/) {
                     if (/empty/) {
                         $uset = "<empty>";
-                    }
-                    else {
+                    } else {
                         $pol = 2;
                     }
                 }
@@ -854,8 +844,7 @@ foreach (@testlists) {
                     if ( $pol == 1 ) {
                         $aset .= ":" if $aset ne "";
                         $aset .= $1;
-                    }
-                    elsif ( $pol == 2 ) {
+                    } elsif ( $pol == 2 ) {
                         $uset .= ":" if $uset ne "";
                         $uset .= $1;
                     }
@@ -896,8 +885,7 @@ foreach (@testlists) {
 
 if ($numfail) {
     print "$numfail tests failed out of $numtest\n";
-}
-else {
+} else {
     print "All Tests Successful.\n";
 }
 

--- a/test/recipes/tconversion.pl
+++ b/test/recipes/tconversion.pl
@@ -17,26 +17,26 @@ use OpenSSL::Test qw/:DEFAULT/;
 my %conversionforms = (
     # Default conversion forms.  Other series may be added with
     # specific test types as key.
-    "*"		=> [ "d", "p" ],
-    "msb"	=> [ "d", "p", "msblob" ],
+    "*"         => [ "d", "p" ],
+    "msb"       => [ "d", "p", "msblob" ],
     );
 sub tconversion {
     my $testtype = shift;
     my $t = shift;
     my @conversionforms =
-	defined($conversionforms{$testtype}) ?
-	@{$conversionforms{$testtype}} :
-	@{$conversionforms{"*"}};
+        defined($conversionforms{$testtype}) ?
+        @{$conversionforms{$testtype}} :
+        @{$conversionforms{"*"}};
     my @openssl_args = @_;
     if (!@openssl_args) { @openssl_args = ($testtype); }
 
     my $n = scalar @conversionforms;
     my $totaltests =
-	1			# for initializing
-	+ $n			# initial conversions from p to all forms (A)
-	+ $n*$n			# conversion from result of A to all forms (B)
-	+ 1			# comparing original test file to p form of A
-	+ $n*($n-1);		# comparing first conversion to each fom in A with B
+        1                       # for initializing
+        + $n                    # initial conversions from p to all forms (A)
+        + $n*$n                 # conversion from result of A to all forms (B)
+        + 1                     # comparing original test file to p form of A
+        + $n*($n-1);            # comparing first conversion to each fom in A with B
     $totaltests-- if ($testtype eq "p7d"); # no comparison of original test file
     plan tests => $totaltests;
 
@@ -44,49 +44,49 @@ sub tconversion {
 
     my $init;
     if (scalar @openssl_args > 0 && $openssl_args[0] eq "pkey") {
-	$init = ok(run(app([@cmd, "-in", $t, "-out", "$testtype-fff.p"])),
-		   'initializing');
+        $init = ok(run(app([@cmd, "-in", $t, "-out", "$testtype-fff.p"])),
+                   'initializing');
     } else {
-	$init = ok(copy($t, "$testtype-fff.p"), 'initializing');
+        $init = ok(copy($t, "$testtype-fff.p"), 'initializing');
     }
     if (!$init) {
-	diag("Trying to copy $t to $testtype-fff.p : $!");
+        diag("Trying to copy $t to $testtype-fff.p : $!");
     }
 
   SKIP: {
       skip "Not initialized, skipping...", 22 unless $init;
 
       foreach my $to (@conversionforms) {
-	  ok(run(app([@cmd,
-		      "-in", "$testtype-fff.p",
-		      "-inform", "p",
-		      "-out", "$testtype-f.$to",
-		      "-outform", $to])),
-	     "p -> $to");
+          ok(run(app([@cmd,
+                      "-in", "$testtype-fff.p",
+                      "-inform", "p",
+                      "-out", "$testtype-f.$to",
+                      "-outform", $to])),
+             "p -> $to");
       }
 
       foreach my $to (@conversionforms) {
-	  foreach my $from (@conversionforms) {
-	      ok(run(app([@cmd,
-			  "-in", "$testtype-f.$from",
-			  "-inform", $from,
-			  "-out", "$testtype-ff.$from$to",
-			  "-outform", $to])),
-		 "$from -> $to");
-	  }
+          foreach my $from (@conversionforms) {
+              ok(run(app([@cmd,
+                          "-in", "$testtype-f.$from",
+                          "-inform", $from,
+                          "-out", "$testtype-ff.$from$to",
+                          "-outform", $to])),
+                 "$from -> $to");
+          }
       }
 
       if ($testtype ne "p7d") {
-	  is(cmp_text("$testtype-fff.p", "$testtype-f.p"), 0,
-	     'comparing orig to p');
+          is(cmp_text("$testtype-fff.p", "$testtype-f.p"), 0,
+             'comparing orig to p');
       }
 
       foreach my $to (@conversionforms) {
-	  next if $to eq "d";
-	  foreach my $from (@conversionforms) {
-	      is(cmp_text("$testtype-f.$to", "$testtype-ff.$from$to"), 0,
-		 "comparing $to to $from$to");
-	  }
+          next if $to eq "d";
+          foreach my $from (@conversionforms) {
+              is(cmp_text("$testtype-f.$to", "$testtype-ff.$from$to"), 0,
+                 "comparing $to to $from$to");
+          }
       }
     }
     unlink glob "$testtype-f.*";

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -43,41 +43,41 @@ my %tests = ();
 my $initial_arg = 1;
 foreach my $arg (@ARGV ? @ARGV : ('alltests')) {
     if ($arg eq 'list') {
-	foreach (@alltests) {
-	    (my $x = basename($_)) =~ s|^[0-9][0-9]-(.*)\.t$|$1|;
-	    print $x,"\n";
-	}
-	exit 0;
+        foreach (@alltests) {
+            (my $x = basename($_)) =~ s|^[0-9][0-9]-(.*)\.t$|$1|;
+            print $x,"\n";
+        }
+        exit 0;
     }
     if ($arg eq 'alltests') {
-	warn "'alltests' encountered, ignoring everything before that...\n"
-	    unless $initial_arg;
-	%tests = map { $_ => 1 } @alltests;
+        warn "'alltests' encountered, ignoring everything before that...\n"
+            unless $initial_arg;
+        %tests = map { $_ => 1 } @alltests;
     } elsif ($arg =~ m/^(-?)(.*)/) {
-	my $sign = $1;
-	my $test = $2;
-	my @matches = find_matching_tests($test);
+        my $sign = $1;
+        my $test = $2;
+        my @matches = find_matching_tests($test);
 
-	# If '-foo' is the first arg, it's short for 'alltests -foo'
-	if ($sign eq '-' && $initial_arg) {
-	    %tests = map { $_ => 1 } @alltests;
-	}
+        # If '-foo' is the first arg, it's short for 'alltests -foo'
+        if ($sign eq '-' && $initial_arg) {
+            %tests = map { $_ => 1 } @alltests;
+        }
 
-	if (scalar @matches == 0) {
-	    warn "Test $test found no match, skipping ",
-		($sign eq '-' ? "removal" : "addition"),
-		"...\n";
-	} else {
-	    foreach $test (@matches) {
-		if ($sign eq '-') {
-		    delete $tests{$test};
-		} else {
-		    $tests{$test} = 1;
-		}
-	    }
-	}
+        if (scalar @matches == 0) {
+            warn "Test $test found no match, skipping ",
+                ($sign eq '-' ? "removal" : "addition"),
+                "...\n";
+        } else {
+            foreach $test (@matches) {
+                if ($sign eq '-') {
+                    delete $tests{$test};
+                } else {
+                    $tests{$test} = 1;
+                }
+            }
+        }
     } else {
-	warn "I don't know what '$arg' is about, ignoring...\n";
+        warn "I don't know what '$arg' is about, ignoring...\n";
     }
 
     $initial_arg = 0;
@@ -124,18 +124,18 @@ sub runtests {
 
     my @switches = ();
     if ($self->{switches}) {
-	push @switches, $self->{switches};
+        push @switches, $self->{switches};
     }
     if ($self->{lib}) {
-	foreach (@{$self->{lib}}) {
-	    my $l = $_;
+        foreach (@{$self->{lib}}) {
+            my $l = $_;
 
-	    # It seems that $switches is getting interpreted with 'eval' or
-	    # something like that, and that we need to take care of backslashes
-	    # or they will disappear along the way.
-	    $l =~ s|\\|\\\\|g if $^O eq "MSWin32";
-	    push @switches, "-I$l";
-	}
+            # It seems that $switches is getting interpreted with 'eval' or
+            # something like that, and that we need to take care of backslashes
+            # or they will disappear along the way.
+            $l =~ s|\\|\\\\|g if $^O eq "MSWin32";
+            push @switches, "-I$l";
+        }
     }
 
     $Test::Harness::switches = join(' ', @switches);

--- a/util/copy.pl
+++ b/util/copy.pl
@@ -21,64 +21,53 @@ my $arg;
 my @excludes = ();
 
 foreach $arg (@ARGV) {
-	if ($arg eq "-stripcr")
-		{
-		$stripcr = 1;
-		next;
-		}
-	if ($arg =~ /^-exclude_re=(.*)$/)
-		{
-		push @excludes, $1;
-		next;
-		}
-	$arg =~ s|\\|/|g;	# compensate for bug/feature in cygwin glob...
-	$arg = qq("$arg") if ($arg =~ /\s/);	# compensate for bug in 5.10...
-	foreach my $f (glob $arg)
-		{
-		push @filelist, $f unless grep { $f =~ /$_/ } @excludes;
-		}
+    if ($arg eq "-stripcr") {
+        $stripcr = 1;
+        next;
+    }
+    if ($arg =~ /^-exclude_re=(.*)$/) {
+        push @excludes, $1;
+        next;
+    }
+    $arg =~ s|\\|/|g;   # compensate for bug/feature in cygwin glob...
+    $arg = qq("$arg") if ($arg =~ /\s/); # compensate for bug in 5.10...
+    foreach my $f (glob $arg) {
+        push @filelist, $f unless grep { $f =~ /$_/ } @excludes;
+    }
 }
 
 $fnum = @filelist;
 
-if ($fnum <= 1)
-	{
-	die "Need at least two filenames";
-	}
+if ($fnum <= 1) {
+    die "Need at least two filenames";
+}
 
 $dest = pop @filelist;
 
-if ($fnum > 2 && ! -d $dest)
-	{
-	die "Destination must be a directory";
-	}
+if ($fnum > 2 && ! -d $dest) {
+    die "Destination must be a directory";
+}
 
-foreach (@filelist)
-	{
-	if (-d $dest)
-		{
-		$dfile = $_;
-		$dfile =~ s|^.*[/\\]([^/\\]*)$|$1|;
-		$dfile = "$dest/$dfile";
-		}
-	else
-		{
-		$dfile = $dest;
-		}
-	sysopen(IN, $_, O_RDONLY|O_BINARY) || die "Can't Open $_";
-	sysopen(OUT, $dfile, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY)
-					|| die "Can't Open $dfile";
-	while (sysread IN, $buf, 10240)
-		{
-		if ($stripcr)
-			{
-			$buf =~ tr/\015//d;
-			}
-		syswrite(OUT, $buf, length($buf));
-		}
-	close(IN);
-	close(OUT);
-	print "Copying: $_ to $dfile\n";
-	}
+foreach (@filelist) {
+    if (-d $dest) {
+        $dfile = $_;
+        $dfile =~ s|^.*[/\\]([^/\\]*)$|$1|;
+        $dfile = "$dest/$dfile";
+    } else {
+        $dfile = $dest;
+    }
+    sysopen(IN, $_, O_RDONLY|O_BINARY) || die "Can't Open $_";
+    sysopen(OUT, $dfile, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY)
+        || die "Can't Open $dfile";
+    while (sysread IN, $buf, 10240) {
+        if ($stripcr) {
+            $buf =~ tr/\015//d;
+        }
+        syswrite(OUT, $buf, length($buf));
+    }
+    close(IN);
+    close(OUT);
+    print "Copying: $_ to $dfile\n";
+}
 
 

--- a/util/mkdir-p.pl
+++ b/util/mkdir-p.pl
@@ -12,33 +12,33 @@
 my $arg;
 
 foreach $arg (@ARGV) {
-  $arg =~ tr|\\|/|;
-  &do_mkdir_p($arg);
+    $arg =~ tr|\\|/|;
+    &do_mkdir_p($arg);
 }
 
 
 sub do_mkdir_p {
-  local($dir) = @_;
+    local($dir) = @_;
 
-  $dir =~ s|/*\Z(?!\n)||s;
+    $dir =~ s|/*\Z(?!\n)||s;
 
-  if (-d $dir) {
-    return;
-  }
-
-  if ($dir =~ m|[^/]/|s) {
-    local($parent) = $dir;
-    $parent =~ s|[^/]*\Z(?!\n)||s;
-
-    do_mkdir_p($parent);
-  }
-
-  unless (mkdir($dir, 0777)) {
     if (-d $dir) {
-      # We raced against another instance doing the same thing.
-      return;
+        return;
     }
-    die "Cannot create directory $dir: $!\n";
-  }
-  print "created directory `$dir'\n";
+
+    if ($dir =~ m|[^/]/|s) {
+        local($parent) = $dir;
+        $parent =~ s|[^/]*\Z(?!\n)||s;
+
+        do_mkdir_p($parent);
+    }
+
+    unless (mkdir($dir, 0777)) {
+        if (-d $dir) {
+            # We raced against another instance doing the same thing.
+            return;
+        }
+        die "Cannot create directory $dir: $!\n";
+    }
+    print "created directory `$dir'\n";
 }


### PR DESCRIPTION
We had a mixture of perl styles, some of it being 8-column indent
Whitesmiths style, a little bit of GNU style (i.e. 2-column indent),
and the majority close to the perl style as described in 'man perlstyle'.

The work done in this change is to remove tabs, change the Whitesmiths
style brace position to the default perl style, adjust indentation to
4 columns where needed, and cleaning up some oddities left by earlier
'perltidy' runs, most notably this construct:

    }
    else {
