### PR TITLE
Providing missing accessor to EVP_PKEY.engine

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -394,6 +394,11 @@ int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e)
     pkey->pmeth_engine = e;
     return 1;
 }
+
+ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey)
+{
+    return pkey->engine;
+}
 #endif
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key)
 {

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -9,7 +9,7 @@ EVP_PKEY_assign_RSA, EVP_PKEY_assign_DSA, EVP_PKEY_assign_DH,
 EVP_PKEY_assign_EC_KEY, EVP_PKEY_assign_POLY1305, EVP_PKEY_assign_SIPHASH,
 EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305, EVP_PKEY_get0_siphash,
 EVP_PKEY_type, EVP_PKEY_id, EVP_PKEY_base_id, EVP_PKEY_set_alias_type,
-EVP_PKEY_set1_engine - EVP_PKEY assignment functions
+EVP_PKEY_set1_engine, EVP_PKEY_get0_engine - EVP_PKEY assignment functions
 
 =head1 SYNOPSIS
 
@@ -45,6 +45,7 @@ EVP_PKEY_set1_engine - EVP_PKEY assignment functions
  int EVP_PKEY_type(int type);
  int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 
+ ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
  int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *engine);
 
 =head1 DESCRIPTION
@@ -80,6 +81,8 @@ often seen in practice.
 
 EVP_PKEY_type() returns the underlying type of the NID B<type>. For example
 EVP_PKEY_type(EVP_PKEY_RSA2) will return B<EVP_PKEY_RSA>.
+
+EVP_PKEY_get0_engine() returns a reference to the ENGINE handling B<pkey>.
 
 EVP_PKEY_set1_engine() sets the ENGINE handling B<pkey> to B<engine>. It
 must be called after the key algorithm and components are set up.

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -995,6 +995,7 @@ int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len);
 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 # ifndef OPENSSL_NO_ENGINE
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e);
+ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
 # endif
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
 void *EVP_PKEY_get0(const EVP_PKEY *pkey);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4579,3 +4579,4 @@ EVP_PKEY_meth_set_digest_custom         4532	1_1_1	EXIST::FUNCTION:
 EVP_PKEY_meth_get_digest_custom         4533	1_1_1	EXIST::FUNCTION:
 OPENSSL_INIT_set_config_filename        4534	1_1_1b	EXIST::FUNCTION:STDIO
 OPENSSL_INIT_set_config_file_flags      4535	1_1_1b	EXIST::FUNCTION:STDIO
+EVP_PKEY_get0_engine                    4536	1_1_1c	EXIST::FUNCTION:ENGINE


### PR DESCRIPTION
The accessor to the engine field of EVP_PKEY structure was missing on making internal structures opaque. This patch is designed to provide it and documentation.

Backport to 1.1.1 of the #8329 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
