### PR TITLE
Windows, VMS: build fixes

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -846,9 +846,15 @@ EOF
   }
 
   sub src2obj {
+      my $asmext = platform->asmext();
       my %args = @_;
-      my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x } ( @{$args{srcs}} );
+      my @srcs =
+          map { my $x = $_;
+                (platform->isasm($x) && grep { $x eq $_ } @generated)
+                ? platform->asm($x) : $x }
+          ( @{$args{srcs}} );
       my $obj = platform->obj($args{obj});
+      my $dep = platform->dep($args{obj});
       my $deps = join(", -\n\t\t", @srcs, @{$args{deps}});
 
       # Because VMS C isn't very good at combining a /INCLUDE path with
@@ -860,25 +866,13 @@ EOF
       my $forward = dirname($args{srcs}->[0]);
       my $backward = abs2rel(rel2abs("."), rel2abs($forward));
       my $objd = abs2rel(rel2abs(dirname($obj)), rel2abs($forward));
-      my $objn = basename($obj, platform->objext());
+      my $objn = basename($obj);
+      my $depd = abs2rel(rel2abs(dirname($dep)), rel2abs($forward));
+      my $depn = basename($dep);
       my $srcs =
           join(", ", map { abs2rel(rel2abs($_), rel2abs($forward)) } @srcs);
       my $before = $unified_info{before}->{$obj} || "\@ !";
       my $after = $unified_info{after}->{$obj} || "\@ !";
-
-      if ($srcs[0] =~ /\.asm$/) {
-          my $asflags = { shlib => ' $(LIB_ASFLAGS)',
-		          lib => ' $(LIB_ASFLAGS)',
-		          dso => ' $(DSO_ASFLAGS)',
-		          bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
-          return <<"EOF";
-$obj : $deps
-        ${before}
-        SET DEFAULT $forward
-        \$(AS) $asflags \$(ASOUTFLAG)${objd}${objn}.OBJ $srcs
-        SET DEFAULT $backward
-EOF
-      }
 
       my $cflags;
       if ($args{attrs}->{noinst}) {
@@ -914,37 +908,37 @@ EOF
       my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
       my $incs_off = join("\n\t\@ ", @{$incs_cmds[1]}) || '!';
 
-      if ($srcs[0] =~ /\.asm$/) {
+      if ($srcs[0] =~ /\Q${asmext}\E$/) {
           return <<"EOF";
-$obj.OBJ : $deps
+$obj : $deps
         ${before}
         SET DEFAULT $forward
-        \$(AS) $asflags \$(ASOUTFLAG)${objd}${objn}.OBJ $srcs
+        \$(AS) $asflags \$(ASOUTFLAG)${objd}${objn} $srcs
         SET DEFAULT $backward
         ${after}
-        - PURGE $obj.OBJ
+        - PURGE $obj
 EOF
       } elsif ($srcs[0] =~ /.S$/) {
          return <<"EOF";
-$obj.OBJ : $deps
+$obj : $deps
         ${before}
         SET DEFAULT $forward
         \@ $incs_on
         \@ extradefines = "$defs"
         PIPE \$(CPP) ${cflags} $srcs | -
              \$(PERL) -ne "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" -
-             > ${objd}${objn}.asm
+             > ${objd}${objn}-asm
         \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
         SET DEFAULT $backward
         ${after}
-        \$(AS) $asflags \$(ASOUTFLAG)$obj.OBJ $obj.asm
-        - PURGE $obj.OBJ
+        \$(AS) $asflags \$(ASOUTFLAG)$obj $obj-asm
+        - PURGE $obj
 EOF
       }
 
       my $depbuild = $disabled{makedepend} ? ""
-          : " /MMS=(FILE=${objd}${objn}.D,TARGET=$obj)";
+          : " /MMS=(FILE=${depd}${depn},TARGET=$obj)";
 
       return <<"EOF";
 $obj : $deps
@@ -952,7 +946,7 @@ $obj : $deps
         SET DEFAULT $forward
         \@ $incs_on
         \@ extradefines = "$defs"
-        \$(CC) ${cflags}${depbuild} /OBJECT=${objd}${objn}.OBJ /REPOSITORY=$backward $srcs
+        \$(CC) ${cflags}${depbuild} /OBJECT=${objd}${objn} /REPOSITORY=$backward $srcs
         \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
         SET DEFAULT $backward

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -601,8 +601,13 @@ EOF
   }
 
  sub src2obj {
+     my $asmext = platform->asmext();
      my %args = @_;
-     my @srcs = map { (my $x = $_) =~ s/\.s$/.asm/; $x } ( @{$args{srcs}} );
+     my @srcs =
+         map { my $x = $_;
+               (platform->isasm($x) && grep { $x eq $_ } @generated)
+               ? platform->asm($x) : $x }
+         ( @{$args{srcs}} );
      my $srcs = '"'.join('" "',  @srcs).'"';
      my $deps = '"'.join('" "', @srcs, @{$args{deps}}).'"';
      my $incs = join("", map { ' /I "'.$_.'"' } @{$args{incs}});
@@ -630,7 +635,7 @@ EOF
      }
      my $obj = platform->obj($args{obj});
      my $dep = platform->dep($args{obj});
-     if ($srcs[0] =~ /\.asm$/) {
+     if ($srcs[0] =~ /\Q${asmext}\E$/) {
          return <<"EOF";
 $obj: $deps
 	\$(AS) $asflags \$(ASOUTFLAG)\$\@ $srcs

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -161,7 +161,14 @@ struct ossl_param_st {
 typedef int (OSSL_provider_init_fn)(const OSSL_PROVIDER *provider,
                                     const OSSL_DISPATCH *in,
                                     const OSSL_DISPATCH **out);
+# ifdef __VMS
+#  pragma names save
+#  pragma names uppercase,truncated
+# endif
 extern OSSL_provider_init_fn OSSL_provider_init;
+# ifdef __VMS
+#  pragma names restore
+# endif
 
 # ifdef __cplusplus
 }


### PR DESCRIPTION
The naming of generated assembler wasn't done quite right.  There are
assembler files that are generated from a perl script, and there are
those who are not.  Only the former must be renamed to the platform
specific asm extension.

Furthermore, we need to make sure that 'OSSL_provider_init' isn't case
sensitive on VMS, to allow for the least surprise for provider
builders.
