### PR TITLE
OPENSSL_config(): restore error agnosticism

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -35,6 +35,7 @@ void OPENSSL_config(const char *appname)
     memset(&settings, 0, sizeof(settings));
     if (appname != NULL)
         settings.appname = strdup(appname);
+    settings.flags = DEFAULT_CONF_MFLAGS;
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, &settings);
 }
 #endif


### PR DESCRIPTION
Great effort has been made to make initialization more configurable.
However, the behavior of OPENSSL_config() was lost in the process,
having it suddenly generate errors it didn't previously, which is not
how it's documented to behave.

A simple setting of default flags fixes this problem.

Fixes #8528
