### PR TITLE
Add a FIPS provider and implement SHA256 in it

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -32,6 +32,7 @@ my %shared_info;
         return {
             %{$shared_info{'gnu-shared'}},
             shared_defflag    => '-Wl,--version-script=',
+            dso_ldflags       => '-z defs',
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },

--- a/Configure
+++ b/Configure
@@ -369,6 +369,7 @@ my @disablables = (
     "err",
     "external-tests",
     "filenames",
+    "fips",
     "fuzz-libfuzzer",
     "fuzz-afl",
     "gost",
@@ -511,6 +512,8 @@ my @disable_cascades = (
     # Without position independent code, there can be no shared libraries
     # or modules.
     "pic"               => [ "shared", "module" ],
+
+    "dynamic-engine"    => [ "fips" ],
 
     "engine"            => [ grep /eng$/, @disablables ],
     "hw"                => [ "padlockeng" ],

--- a/Configure
+++ b/Configure
@@ -513,7 +513,7 @@ my @disable_cascades = (
     # or modules.
     "pic"               => [ "shared", "module" ],
 
-    "dynamic-engine"    => [ "fips" ],
+    "module"            => [ "fips" ],
 
     "engine"            => [ grep /eng$/, @disablables ],
     "hw"                => [ "padlockeng" ],
@@ -1224,8 +1224,8 @@ foreach my $what (sort keys %disabled) {
 
     $config{options} .= " no-$what";
 
-    if (!grep { $what eq $_ } ( 'buildtest-c++', 'threads', 'shared', 'module',
-                                'pic', 'dynamic-engine', 'makedepend',
+    if (!grep { $what eq $_ } ( 'buildtest-c++', 'fips', 'threads', 'shared',
+                                'module', 'pic', 'dynamic-engine', 'makedepend',
                                 'zlib-dynamic', 'zlib', 'sse2' )) {
         (my $WHAT = uc $what) =~ s|-|_|g;
         my $skipdir = $what;

--- a/INSTALL
+++ b/INSTALL
@@ -394,6 +394,9 @@
                    Don't compile in filename and line number information (e.g.
                    for errors and memory allocation).
 
+  no-fips
+                   Don't compile the FIPS module
+
   enable-fuzz-libfuzzer, enable-fuzz-afl
                    Build with support for fuzzing using either libfuzzer or AFL.
                    These are developer options only. They may not work on all

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -23,7 +23,7 @@ SOURCE[../libcrypto]=\
 
 # FIPS module
 SOURCE[../providers/fips]=\
-        cryptlib.c mem.c mem_clr.c mem_dbg.c params.c
+        cryptlib.c mem.c mem_clr.c params.c
 
 
 DEPEND[cversion.o]=buildinf.h

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -21,6 +21,11 @@ SOURCE[../libcrypto]=\
         trace.c provider.c params.c \
         {- $target{cpuid_asm_src} -} {- $target{uplink_aux_src} -}
 
+# FIPS module
+SOURCE[../providers/fips]=\
+        cryptlib.c mem.c mem_clr.c mem_dbg.c params.c
+
+
 DEPEND[cversion.o]=buildinf.h
 GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
 DEPEND[buildinf.h]=../configdata.pm

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <openssl/crypto.h>
-#ifndef OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG_BACKTRACE) && !defined(FIPS_MODE)
 # include <execinfo.h>
 #endif
 
@@ -30,7 +30,7 @@ static void *(*realloc_impl)(void *, size_t, const char *, int)
 static void (*free_impl)(void *, const char *, int)
     = CRYPTO_free;
 
-#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
 # include "internal/tsan_assist.h"
 
 static TSAN_QUALIFIER int malloc_count;
@@ -94,7 +94,7 @@ void CRYPTO_get_mem_functions(
         *f = free_impl;
 }
 
-#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
 void CRYPTO_get_alloc_counts(int *mcount, int *rcount, int *fcount)
 {
     if (mcount != NULL)
@@ -209,7 +209,7 @@ void *CRYPTO_malloc(size_t num, const char *file, int line)
          */
         allow_customize = 0;
     }
-#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
     if (call_malloc_debug) {
         CRYPTO_mem_debug_malloc(NULL, num, 0, file, line);
         ret = malloc(num);
@@ -250,7 +250,7 @@ void *CRYPTO_realloc(void *str, size_t num, const char *file, int line)
         return NULL;
     }
 
-#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
     if (call_malloc_debug) {
         void *ret;
         CRYPTO_mem_debug_realloc(str, NULL, num, 0, file, line);
@@ -300,7 +300,7 @@ void CRYPTO_free(void *str, const char *file, int line)
         return;
     }
 
-#ifndef OPENSSL_NO_CRYPTO_MDEBUG
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
     if (call_malloc_debug) {
         CRYPTO_mem_debug_free(str, 0, file, line);
         free(str);

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -348,6 +348,13 @@ OSSL_PARAM OSSL_PARAM_construct_size_t(const char *key, size_t *buf,
     return ossl_param_construct(key, OSSL_PARAM_UNSIGNED_INTEGER, buf,
                                 sizeof(size_t), rsize); }
 
+#ifndef FIPS_MODE
+/*
+ * TODO(3.0): Make this available in FIPS mode.
+ *
+ * Temporarily we don't include these functions in FIPS mode to avoid pulling
+ * in the entire BN sub-library into the module at this point.
+ */
 int OSSL_PARAM_get_BN(const OSSL_PARAM *p, BIGNUM **val)
 {
     BIGNUM *b;
@@ -387,6 +394,7 @@ OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
     return ossl_param_construct(key, OSSL_PARAM_UNSIGNED_INTEGER,
                                 buf, bsize, rsize);
 }
+#endif
 
 int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
 {

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -3,6 +3,8 @@ SOURCE[../../libcrypto]=\
         sha1dgst.c sha1_one.c sha256.c sha512.c {- $target{sha1_asm_src} -} \
         {- $target{keccak1600_asm_src} -}
 
+SOURCE[../../providers/fips]= sha256.c
+
 GENERATE[sha1-586.s]=asm/sha1-586.pl \
         $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
 DEPEND[sha1-586.s]=../perlasm/x86asm.pl

--- a/providers/build.info
+++ b/providers/build.info
@@ -9,7 +9,4 @@ IF[{- !$disabled{fips} -}]
   ENDIF
   INCLUDE[fips]=.. ../include ../crypto/include
   DEFINE[fips]=FIPS_MODE
-  SOURCE[fips]=\
-    ../crypto/cryptlib.c ../crypto/mem.c ../crypto/mem_clr.c \
-    ../crypto/sha/sha256.c ../crypto/params.c
 ENDIF

--- a/providers/build.info
+++ b/providers/build.info
@@ -4,7 +4,7 @@ IF[{- !$disabled{fips} -}]
   SUBDIRS=fips
   MODULES=fips
   IF[{- defined $target{shared_defflag} -}]
-    SHARED_SOURCE[fips]=fips.ld
+    SOURCE[fips]=fips.ld
     GENERATE[fips.ld]=../util/providers.num
   ENDIF
   INCLUDE[fips]=.. ../include ../crypto/include

--- a/providers/build.info
+++ b/providers/build.info
@@ -5,7 +5,7 @@ IF[{- !$disabled{fips} -}]
   MODULES=fips
   IF[{- defined $target{shared_defflag} -}]
     SHARED_SOURCE[fips]=fips.ld
-    GENERATE[fips.ld]=provider.num
+    GENERATE[fips.ld]=../util/providers.num
   ENDIF
   INCLUDE[fips]=.. ../include ../crypto/include
   DEFINE[fips]=FIPS_MODE

--- a/providers/build.info
+++ b/providers/build.info
@@ -1,1 +1,15 @@
 SUBDIRS=common default
+
+IF[{- !$disabled{fips} -}]
+  SUBDIRS=fips
+  MODULES=fips
+  IF[{- defined $target{shared_defflag} -}]
+    SHARED_SOURCE[fips]=fips.ld
+    GENERATE[fips.ld]=provider.num
+  ENDIF
+  INCLUDE[fips]=.. ../include ../crypto/include
+  DEFINE[fips]=FIPS_MODE
+  SOURCE[fips]=\
+    ../crypto/cryptlib.c ../crypto/mem.c ../crypto/mem_clr.c \
+    ../crypto/sha/sha256.c ../crypto/params.c
+ENDIF

--- a/providers/common/digests/build.info
+++ b/providers/common/digests/build.info
@@ -1,3 +1,5 @@
-LIBS=../../../libcrypto
 SOURCE[../../../libcrypto]=\
+        sha2.c
+
+SOURCE[../../fips]=\
         sha2.c

--- a/providers/fips/build.info
+++ b/providers/fips/build.info
@@ -1,0 +1,2 @@
+
+SOURCE[../fips]=fipsprov.c

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -88,8 +88,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);
             break;
+        /* Just ignore anything we don't understand */
         default:
-            /* Just ignore anything we don't understand */
             break;
         }
     }

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <openssl/core.h>
+#include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+
+/* Functions provided by the core */
+static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
+static OSSL_core_get_params_fn *c_get_params = NULL;
+
+/* Parameters we provide to the core */
+static const OSSL_ITEM fips_param_types[] = {
+    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
+    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
+    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
+    { 0, NULL }
+};
+
+static const OSSL_ITEM *fips_get_param_types(const OSSL_PROVIDER *prov)
+{
+    return fips_param_types;
+}
+
+static int fips_get_params(const OSSL_PROVIDER *prov,
+                            const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL FIPS Provider"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+        return 0;
+
+    return 1;
+}
+
+extern const OSSL_DISPATCH sha256_functions[];
+
+static const OSSL_ALGORITHM fips_digests[] = {
+    { "SHA256", "fips=yes", sha256_functions },
+    { NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM *fips_query(OSSL_PROVIDER *prov,
+                                         int operation_id,
+                                         int *no_cache)
+{
+    *no_cache = 0;
+    switch (operation_id) {
+    case OSSL_OP_DIGEST:
+        return fips_digests;
+    }
+    return NULL;
+}
+
+/* Functions we provide to the core */
+static const OSSL_DISPATCH fips_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_GET_PARAM_TYPES, (void (*)(void))fips_get_param_types },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))fips_get_params },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fips_query },
+    { 0, NULL }
+};
+
+int OSSL_provider_init(const OSSL_PROVIDER *provider,
+                       const OSSL_DISPATCH *in,
+                       const OSSL_DISPATCH **out)
+{
+    for (; in->function_id != 0; in++) {
+        switch (in->function_id) {
+        case OSSL_FUNC_CORE_GET_PARAM_TYPES:
+            c_get_param_types = OSSL_get_core_get_param_types(in);
+            break;
+        case OSSL_FUNC_CORE_GET_PARAMS:
+            c_get_params = OSSL_get_core_get_params(in);
+            break;
+        default:
+            /* Just ignore anything we don't understand */
+            break;
+        }
+    }
+
+    *out = fips_dispatch_table;
+    return 1;
+}

--- a/providers/provider.num
+++ b/providers/provider.num
@@ -1,0 +1,1 @@
+OSSL_provider_init                     1	*	EXIST::FUNCTION:

--- a/providers/provider.num
+++ b/providers/provider.num
@@ -1,1 +1,0 @@
-OSSL_provider_init                     1	*	EXIST::FUNCTION:

--- a/test/build.info
+++ b/test/build.info
@@ -186,6 +186,9 @@ IF[{- !$disabled{tests} -}]
   SOURCE[evp_extra_test]=evp_extra_test.c
   INCLUDE[evp_extra_test]=../include ../apps/include ../crypto/include
   DEPEND[evp_extra_test]=../libcrypto libtestutil.a
+  IF[{- $disabled{fips} || !$target{dso_scheme} -}]
+    DEFINE[evp_extra_test]=NO_FIPS_MODULE
+  ENDIF
 
   SOURCE[igetest]=igetest.c
   INCLUDE[igetest]=../include ../apps/include

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1174,6 +1174,9 @@ static int test_EVP_MD_fetch(int tst)
             goto err;
     }
 
+    EVP_MD_meth_free(md);
+    md = NULL;
+
     /*
      * Explicitly asking for the default implementation should succeeed except
      * in test 4 where the default provider is not loaded.

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1250,7 +1250,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_invalide_ec_char2_pub_range_decode,
                   OSSL_NELEM(ec_der_pub_keys));
 #endif
-#ifdef OPENSSL_NO_FIPS
+#ifdef NO_FIPS_MODULE
     ADD_ALL_TESTS(test_EVP_MD_fetch, 3);
 #else
     ADD_ALL_TESTS(test_EVP_MD_fetch, 5);

--- a/test/recipes/30-test_evp_extra.t
+++ b/test/recipes/30-test_evp_extra.t
@@ -10,9 +10,12 @@
 use strict;
 use warnings;
 
-use OpenSSL::Test;
+use OpenSSL::Test qw/:DEFAULT bldtop_dir/;
 
 setup("test_evp_extra");
 
 plan tests => 1;
+
+$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
+
 ok(run(test(["evp_extra_test"])), "running evp_extra_test");


### PR DESCRIPTION
This PR is built on top of #8513. It creates the FIPS provider and implements SHA256 within it.

So far this only includes the C implementation of SHA256. Adding the assembler modules is a bit trickier so that is deferred for a later time. A consequence of that is that (AFAICT) OPENSSL_cleanse is only implemented in assembler so (for now) I have implemented a very simple C version of OPENSSL_cleanse. It's totally unsafe to use in production so will need to be removed before too long, but it gets things working for now.

I encountered some unexpected behaviour during the implementation of this. At one point I had created the FIPS provider but not yet added all the files I needed for SHA256. Therefore I was expecting the test I had written to use the new provider to fail due to some symbols not being present. To my surprise the test passed - the module loaded and performed SHA256 sucessfully. It seems that, when building the FIPS provider, if there are symbols from libcrypto that it needs but that aren't present, those symbols are resolved automatically if the provider is loaded by an application linked against libcrypto. This is not desirable behaviour since the FIPS module must be entirely self-contained. To detect this problem I created a new test in shlibloadtest that simply loads the FIPS module from an application that isn't linked with libcrypto. If there are no missing symbols then this should work and will fail otherwise.

Finally, this PR also implements a "no-fips" Configure option.
