### PR TITLE
Add a legacy provider and put MD2 in it

### DIFF
--- a/Configure
+++ b/Configure
@@ -374,6 +374,7 @@ my @disablables = (
     "fuzz-afl",
     "gost",
     "idea",
+    "legacy",
     "makedepend",
     "md2",
     "md4",
@@ -513,7 +514,7 @@ my @disable_cascades = (
     # or modules.
     "pic"               => [ "shared", "module" ],
 
-    "module"            => [ "fips" ],
+    "module"            => [ "fips", "legacy" ],
 
     "engine"            => [ grep /eng$/, @disablables ],
     "hw"                => [ "padlockeng" ],
@@ -532,6 +533,7 @@ my @disable_cascades = (
     sub { !$disabled{"msan"} } => [ "asm" ],
 
     sub { $disabled{cmac}; } => [ "siv" ],
+    "legacy"                 => [ "md2" ],
     );
 
 # Avoid protocol support holes.  Also disable all versions below N, if version
@@ -1226,7 +1228,7 @@ foreach my $what (sort keys %disabled) {
 
     if (!grep { $what eq $_ } ( 'buildtest-c++', 'fips', 'threads', 'shared',
                                 'module', 'pic', 'dynamic-engine', 'makedepend',
-                                'zlib-dynamic', 'zlib', 'sse2' )) {
+                                'zlib-dynamic', 'zlib', 'sse2', 'legacy' )) {
         (my $WHAT = uc $what) =~ s|-|_|g;
         my $skipdir = $what;
 

--- a/INSTALL
+++ b/INSTALL
@@ -409,6 +409,10 @@
                    available if the GOST algorithms are also available through
                    loading an externally supplied engine.
 
+  no-legacy
+                   Don't build the legacy provider. Disabling this also disables
+                   the legacy algorithms: MD2 (already disabled by default).
+
   no-makedepend
                    Don't generate dependencies.
 

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -35,8 +35,9 @@ static int ossl_method_construct_this(OSSL_PROVIDER *provider, void *cbdata)
         const OSSL_ALGORITHM *thismap = map++;
         void *method = NULL;
 
-        if ((method = data->mcm->construct(thismap->implementation, provider,
-                                            data->mcm_data)) == NULL)
+        if ((method = data->mcm->construct(thismap->algorithm_name,
+                                           thismap->implementation, provider,
+                                           data->mcm_data)) == NULL)
             continue;
 
         /*

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -145,6 +145,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
     if (type->prov == NULL) {
         switch(type->type) {
         case NID_sha256:
+        case NID_md2:
             break;
         default:
             goto legacy;

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -585,10 +585,17 @@ static void evp_md_free(void *md)
     EVP_MD_meth_free(md);
 }
 
+static int evp_md_nid(void *vmd)
+{
+    EVP_MD *md = vmd;
+
+    return md->type;
+}
+
 EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                      const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
                              evp_md_from_dispatch, evp_md_upref,
-                             evp_md_free);
+                             evp_md_free, evp_md_nid);
 }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -62,6 +62,7 @@ struct method_data_st {
                                   OSSL_PROVIDER *);
     int (*refcnt_up_method)(void *method);
     void (*destruct_method)(void *method);
+    int (*nid_method)(void *method);
 };
 
 /*
@@ -107,29 +108,35 @@ static void *get_method_from_store(OPENSSL_CTX *libctx, void *store,
 }
 
 static int put_method_in_store(OPENSSL_CTX *libctx, void *store,
-                               const char *propdef, void *method,
-                               void *data)
+                               const char *propdef,
+                               void *method, void *data)
 {
     struct method_data_st *methdata = data;
+    int nid = methdata->nid_method(method);
+
+    if (nid == NID_undef)
+        return 0;
 
     if (store == NULL
         && (store = get_default_method_store(libctx)) == NULL)
         return 0;
 
     if (methdata->refcnt_up_method(method)
-        && ossl_method_store_add(store, methdata->nid, propdef, method,
+        && ossl_method_store_add(store, nid, propdef, method,
                                  methdata->destruct_method))
         return 1;
     return 0;
 }
 
-static void *construct_method(const OSSL_DISPATCH *fns, OSSL_PROVIDER *prov,
+static void *construct_method(const char *algorithm_name,
+                              const OSSL_DISPATCH *fns, OSSL_PROVIDER *prov,
                               void *data)
 {
     struct method_data_st *methdata = data;
     void *method = NULL;
+    int nid = OBJ_sn2nid(algorithm_name);
 
-    if (methdata->nid == NID_undef) {
+    if (nid == NID_undef) {
         /* Create a new NID for that name on the fly */
         ASN1_OBJECT tmpobj;
 
@@ -140,13 +147,13 @@ static void *construct_method(const OSSL_DISPATCH *fns, OSSL_PROVIDER *prov,
         tmpobj.length = 0;
         tmpobj.data = NULL;
 
-        methdata->nid = OBJ_add_object(&tmpobj);
+        nid = OBJ_add_object(&tmpobj);
     }
 
-    if (methdata->nid == NID_undef)
+    if (nid == NID_undef)
         return NULL;
 
-    method = methdata->method_from_dispatch(methdata->nid, fns, prov);
+    method = methdata->method_from_dispatch(nid, fns, prov);
     if (method == NULL)
         return NULL;
     return method;
@@ -164,7 +171,8 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
                         void *(*new_method)(int nid, const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
                         int (*upref_method)(void *),
-                        void (*free_method)(void *))
+                        void (*free_method)(void *),
+                        int (*nid_method)(void *))
 {
     int nid = OBJ_sn2nid(algorithm);
     void *method = NULL;
@@ -187,6 +195,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
         mcmdata.destruct_method = free_method;
         mcmdata.refcnt_up_method = upref_method;
         mcmdata.destruct_method = free_method;
+        mcmdata.nid_method = nid_method;
         method = ossl_method_construct(libctx, operation_id, algorithm,
                                        properties, 0 /* !force_cache */,
                                        &mcm, &mcmdata);

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -90,4 +90,5 @@ void *evp_generic_fetch(OPENSSL_CTX *ctx, int operation_id,
                         void *(*new_method)(int nid, const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
                         int (*upref_method)(void *),
-                        void (*free_method)(void *));
+                        void (*free_method)(void *),
+                        int (*nid_method)(void *));

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -523,6 +523,7 @@ int ossl_property_parse_init(void)
 {
     static const char *const predefined_names[] = {
         "default",      /* Being provided by the default built-in provider */
+        "legacy",       /* Provided by the legacy provider */
         "provider",     /* Name of provider (default, fips) */
         "version",      /* Version number of this provider */
         "fips",         /* FIPS supporting provider */

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -14,7 +14,8 @@ evp_generic_fetch - generic algorithm fetcher and method creator for EVP
                          void *(*new_method)(int nid, const OSSL_DISPATCH *fns,
                                              OSSL_PROVIDER *prov),
                          int (*upref_method)(void *),
-                         void (*free_method)(void *));
+                         void (*free_method)(void *),
+                         int (*nid_method)(void *));
 
 =head1 DESCRIPTION
 
@@ -40,6 +41,10 @@ one.
 =item free_method()
 
 frees the given method.
+
+=item nid_method()
+
+returns the nid associated with the given method.
 
 =back
 

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -21,8 +21,8 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
      int (*put)(OPENSSL_CTX *libctx, void *store, const char *propdef,
                 void *method, void *data);
      /* Construct a new method */
-     void *(*construct)(const OSSL_DISPATCH *fns, OSSL_PROVIDER *prov,
-                        void *data);
+     void *(*construct)(const char *algorithm_name, const OSSL_DISPATCH *fns,
+                        OSSL_PROVIDER *prov, void *data);
      /* Destruct a method */
      void (*destruct)(void *method);
  };
@@ -107,7 +107,8 @@ This function is expected to increment the C<method>'s reference count.
 
 =item construct()
 
-Constructs a sub-system method given a dispatch table C<fns>.
+Constructs a sub-system method for the given C<algorithm_name> and the given
+dispatch table C<fns>.
 
 The associated I<provider object> C<prov> is passed as well, to make
 it possible for the sub-system constructor to keep a reference, which

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -38,8 +38,8 @@ typedef struct ossl_method_construct_method_st {
     int (*put)(OPENSSL_CTX *libctx, void *store, const char *propdef,
                void *method, void *data);
     /* Construct a new method */
-    void *(*construct)(const OSSL_DISPATCH *fns, OSSL_PROVIDER *prov,
-                       void *data);
+    void *(*construct)(const char *algorithm_name, const OSSL_DISPATCH *fns,
+                       OSSL_PROVIDER *prov, void *data);
     /* Destruct a method */
     void (*destruct)(void *method, void *data);
 } OSSL_METHOD_CONSTRUCT_METHOD;

--- a/providers/build.info
+++ b/providers/build.info
@@ -10,3 +10,14 @@ IF[{- !$disabled{fips} -}]
   INCLUDE[fips]=.. ../include ../crypto/include
   DEFINE[fips]=FIPS_MODE
 ENDIF
+
+IF[{- !$disabled{legacy} -}]
+  SUBDIRS=legacy
+  MODULES=legacy
+  IF[{- defined $target{shared_defflag} -}]
+    SOURCE[legacy]=legacy.ld
+    GENERATE[legacy.ld]=../util/providers.num
+  ENDIF
+  INCLUDE[legacy]=.. ../include ../crypto/include
+  DEPEND[legacy]=../libcrypto
+ENDIF

--- a/providers/legacy/build.info
+++ b/providers/legacy/build.info
@@ -1,0 +1,4 @@
+SUBDIRS=digests
+
+SOURCE[../legacy]=\
+        legacyprov.c

--- a/providers/legacy/digests/build.info
+++ b/providers/legacy/digests/build.info
@@ -1,0 +1,4 @@
+IF[{- !$disabled{md2} -}]
+  SOURCE[../../legacy]=\
+          md2.c
+ENDIF

--- a/providers/legacy/digests/md2.c
+++ b/providers/legacy/digests/md2.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/md2.h>
+#include <openssl/crypto.h>
+#include <openssl/core_numbers.h>
+
+static int md2_final(void *ctx, unsigned char *md, size_t *size)
+{
+    if (MD2_Final(md, ctx)) {
+        *size = MD2_DIGEST_LENGTH;
+        return 1;
+    }
+
+    return 0;
+}
+
+static void *md2_newctx(void)
+{
+    MD2_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+
+    return ctx;
+}
+
+static void md2_freectx(void *vctx)
+{
+    MD2_CTX *ctx = (MD2_CTX *)vctx;
+
+    OPENSSL_clear_free(ctx,  sizeof(*ctx));
+}
+
+static void *md2_dupctx(void *ctx)
+{
+    MD2_CTX *in = (MD2_CTX *)ctx;
+    MD2_CTX *ret = OPENSSL_malloc(sizeof(*ret));
+
+    *ret = *in;
+
+    return ret;
+}
+
+static size_t md2_size(void)
+{
+    return MD2_DIGEST_LENGTH;
+}
+
+extern const OSSL_DISPATCH md2_functions[];
+const OSSL_DISPATCH md2_functions[] = {
+    { OSSL_FUNC_DIGEST_NEWCTX, (void (*)(void))md2_newctx },
+    { OSSL_FUNC_DIGEST_INIT, (void (*)(void))MD2_Init },
+    { OSSL_FUNC_DIGEST_UPDDATE, (void (*)(void))MD2_Update },
+    { OSSL_FUNC_DIGEST_FINAL, (void (*)(void))md2_final },
+    { OSSL_FUNC_DIGEST_FREECTX, (void (*)(void))md2_freectx },
+    { OSSL_FUNC_DIGEST_DUPCTX, (void (*)(void))md2_dupctx },
+    { OSSL_FUNC_DIGEST_SIZE, (void (*)(void))md2_size },
+    { 0, NULL }
+};

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <openssl/core.h>
+#include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+
+/* Functions provided by the core */
+static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
+static OSSL_core_get_params_fn *c_get_params = NULL;
+
+/* Parameters we provide to the core */
+static const OSSL_ITEM legacy_param_types[] = {
+    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
+    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
+    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
+    { 0, NULL }
+};
+
+static const OSSL_ITEM *legacy_get_param_types(const OSSL_PROVIDER *prov)
+{
+    return legacy_param_types;
+}
+
+static int legacy_get_params(const OSSL_PROVIDER *prov,
+                            const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL Legacy Provider"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+        return 0;
+
+    return 1;
+}
+
+extern const OSSL_DISPATCH md2_functions[];
+
+static const OSSL_ALGORITHM legacy_digests[] = {
+#ifndef OPENSSL_NO_MD2
+    { "MD2", "legacy=yes", md2_functions },
+#endif
+    { NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM *legacy_query(OSSL_PROVIDER *prov,
+                                          int operation_id,
+                                          int *no_cache)
+{
+    *no_cache = 0;
+    switch (operation_id) {
+    case OSSL_OP_DIGEST:
+        return legacy_digests;
+    }
+    return NULL;
+}
+
+/* Functions we provide to the core */
+static const OSSL_DISPATCH legacy_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_GET_PARAM_TYPES, (void (*)(void))legacy_get_param_types },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))legacy_get_params },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))legacy_query },
+    { 0, NULL }
+};
+
+int OSSL_provider_init(const OSSL_PROVIDER *provider,
+                       const OSSL_DISPATCH *in,
+                       const OSSL_DISPATCH **out)
+{
+    for (; in->function_id != 0; in++) {
+        switch (in->function_id) {
+        case OSSL_FUNC_CORE_GET_PARAM_TYPES:
+            c_get_param_types = OSSL_get_core_get_param_types(in);
+            break;
+        case OSSL_FUNC_CORE_GET_PARAMS:
+            c_get_params = OSSL_get_core_get_params(in);
+            break;
+        /* Just ignore anything we don't understand */
+        default:
+            break;
+        }
+    }
+
+    *out = legacy_dispatch_table;
+    return 1;
+}

--- a/test/md2test.c
+++ b/test/md2test.c
@@ -9,8 +9,11 @@
 
 #include <string.h>
 
+#include <openssl/provider.h>
 #include "internal/nelem.h"
 #include "testutil.h"
+
+static OSSL_PROVIDER *prov = NULL;
 
 #ifndef OPENSSL_NO_MD2
 # include <openssl/evp.h>
@@ -57,6 +60,17 @@ static int test_md2(int n)
     return 1;
 }
 #endif
+
+int global_init(void)
+{
+    prov = OSSL_PROVIDER_load(NULL, "legacy");
+
+    return prov != NULL;
+}
+void cleanup_tests(void)
+{
+    OSSL_PROVIDER_unload(prov);
+}
 
 int setup_tests(void)
 {

--- a/test/recipes/05-test_md2.t
+++ b/test/recipes/05-test_md2.t
@@ -8,5 +8,10 @@
 
 
 use OpenSSL::Test::Simple;
+use OpenSSL::Test qw/:DEFAULT bldtop_dir/;
+
+setup("test_md2");
+
+$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
 
 simple_test("test_md2", "md2test", "md2");


### PR DESCRIPTION
This PR is built on top of #8513. It creates the legacy provider and implements MD2 within it.

While implementing this I discovered a bug in the fetching code which I also fixed. When we attempt to fetch a method with a given NID we will ask the providers for it if we don't already know about it. During that process we may be told about other methods with a different NID. We need to make sure we don't confuse the two.