### PR TITLE
Configuration: make Solaris builds with gcc recognise GNU ld

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -211,17 +211,28 @@ my %targets = (
         ex_libs          => add("-lsocket -lnsl -ldl"),
         dso_scheme       => "dlfcn",
         thread_scheme    => "pthreads",
+    },
+#### Solaris common with Sun C setups
+    "solaris-common-cc" => {
+        inherit_from     => [ "solaris-common" ],
+        template         => 1,
         shared_target    => "solaris",
         shared_ldflag    => "-Wl,-Bsymbolic",
         shared_defflag   => "-Wl,-M,",
         shared_sonameflag=> "-Wl,-h,",
+    },
+#### Solaris common with GNU C setups
+    "solaris-common-gcc" => {
+        inherit_from     => [ "solaris-common" ],
+        template         => 1,
+        shared_target    => "solaris-gcc", # The rest is on shared_info.pl
     },
 #### Solaris x86 with GNU C setups
     "solaris-x86-gcc" => {
         # NB. GNU C has to be configured to use GNU assembler, and not
         # /usr/ccs/bin/as. Failure to comply will result in compile
         # failures [at least] in 32-bit build.
-        inherit_from     => [ "solaris-common" ],
+        inherit_from     => [ "solaris-common-gcc" ],
         CC               => "gcc",
         CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
@@ -244,7 +255,7 @@ my %targets = (
         # code [thanks to inline assembler], I would actually recommend
         # to consider using gcc shared build even with vendor compiler:-)
         #                        -- <appro@openssl.org>
-        inherit_from     => [ "solaris-common" ],
+        inherit_from     => [ "solaris-common-gcc" ],
         CC               => "gcc",
         CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
@@ -274,7 +285,7 @@ my %targets = (
     # Consider switching to solaris64-x86_64-gcc even here...
     #
     "solaris64-x86_64-cc" => {
-        inherit_from     => [ "solaris-common" ],
+        inherit_from     => [ "solaris-common-cc" ],
         CC               => "cc",
         CFLAGS           => add_before(picker(debug   => "-g",
                                               release => "-xO5 -xdepend -xbuiltin")),
@@ -294,7 +305,7 @@ my %targets = (
 
 #### SPARC Solaris with GNU C setups
     "solaris-sparcv7-gcc" => {
-        inherit_from     => [ "solaris-common" ],
+        inherit_from     => [ "solaris-common-gcc" ],
         CC               => "gcc",
         CFLAGS           => add_before(picker(default => "-Wall",
                                               debug   => "-O0 -g",
@@ -332,7 +343,7 @@ my %targets = (
 # SC4.2 is ok, better than gcc even on bn as long as you tell it -xarch=v8
 # SC5.0 note: Compiler common patch 107357-01 or later is required!
     "solaris-sparcv7-cc" => {
-        inherit_from     => [ "solaris-common" ],
+        inherit_from     => [ "solaris-common-cc" ],
         CC               => "cc",
         CFLAGS           => add_before(picker(debug   => "-g",
                                               release => "-xO5 -xdepend")),

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -84,4 +84,16 @@ my %shared_info;
             shared_sonameflag => '-h ',
         };
     },
+    'solaris-gcc-shared' => sub {
+        return $shared_info{'linux-shared'} if detect_gnu_ld();
+        return {
+            # Note: we should also have -shared here, but because some
+            # config targets define it with an added -static-libgcc
+            # following it, we don't want to change the order.  This
+            # forces all solaris gcc config targets to define shared_ldflag
+            shared_ldflag     => '-Wl,-Bsymbolic',
+            shared_defflag    => "-Wl,-M,",
+            shared_sonameflag => "-Wl,-h,",
+        };
+    },
 );


### PR DESCRIPTION
The solaris config targets assumed that GNU cc used Sun ld at all
times.  However, there are setups where GNU ld is used instead, so we
adapt the Solaris gcc config targets to use the mechanism introduced
with Configurations/shared_info.pl to try to detect what ld flavor is
being used and set the diverse ld flags accordingly.

Fixes #8547
