### PR TITLE
Use AI_ADDRCONFIG hint with getaddrinfo if available.

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -683,6 +683,12 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         hints.ai_family = family;
         hints.ai_socktype = socktype;
         hints.ai_protocol = protocol;
+#ifdef AI_ADDRCONFIG
+#ifdef AF_UNSPEC
+        if (family == AF_UNSPEC)
+#endif
+            hints.ai_flags |= AI_ADDRCONFIG;
+#endif
 
         if (lookup_type == BIO_LOOKUP_SERVER)
             hints.ai_flags |= AI_PASSIVE;


### PR DESCRIPTION
This prevents failure of openssl s_server socket binding to wildcard
address on hosts with disabled IPv6.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
