### PR TITLE
Fixed unmatched BN_CTX_start/end if an invalid exponent is used.

### DIFF
--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -71,7 +71,7 @@ int rsa_fips186_4_gen_prob_primes(RSA *rsa, BIGNUM *p1, BIGNUM *p2,
     if (!rsa_check_public_exponent(e)) {
         RSAerr(RSA_F_RSA_FIPS186_4_GEN_PROB_PRIMES,
                RSA_R_PUB_EXPONENT_OUT_OF_RANGE);
-        goto err;
+        return 0;
     }
 
     /* (Step 3) Determine strength and check rand generator strength is ok -


### PR DESCRIPTION
Fixed unmatched BN_CTX_start/end if an invalid exponent is used.
 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
