### PR TITLE
Detect endian without relying on defined symbols.

### DIFF
--- a/test/endian.h
+++ b/test/endian.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_INTERNAL_ENDIAN_H
+# define HEADER_INTERNAL_ENDIAN_H
+
+# define DECLARE_IS_ENDIAN \
+    const union { \
+        long one; \
+        char little; \
+    } ossl_is_endian = { 1 }
+
+# define IS_LITTLE_ENDIAN (ossl_is_endian.little != 0)
+# define IS_BIG_ENDIAN    (ossl_is_endian.little == 0)
+
+#endif

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include "testutil.h"
 #include "internal/nelem.h"
+#include "endian.h"
 #include <openssl/params.h>
 #include <openssl/bn.h>
 
@@ -27,20 +28,22 @@ static void swap_copy(unsigned char *out, const void *in, size_t len)
 
 static void copy_to_le(unsigned char *out, const void *in, size_t len)
 {
-#ifdef B_ENDIAN
-    swap_copy(out, in, len);
-#else
-    memcpy(out, in, len);
-#endif
+    DECLARE_IS_ENDIAN;
+
+    if (IS_LITTLE_ENDIAN)
+        memcpy(out, in, len);
+    else
+        swap_copy(out, in, len);
 }
 
 static void copy_be_to_native(unsigned char *out, const void *in, size_t len)
 {
-#ifdef B_ENDIAN
-    memcpy(out, in, len);
-#else
-    swap_copy(out, in, len);
-#endif
+    DECLARE_IS_ENDIAN;
+
+    if (IS_LITTLE_ENDIAN)
+        swap_copy(out, in, len);
+    else
+        memcpy(out, in, len);
 }
 
 static const struct {


### PR DESCRIPTION
Avoid using the B_ENDIAN define to determine host endianness.


Fixes #8570 

- [x] tests are added or updated