### PR TITLE
Tolerate 0 byte input length for Update functions

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -259,6 +259,9 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 
 int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
 {
+    if (count == 0)
+        return 1;
+
     if (ctx->digest == NULL || ctx->digest->prov == NULL)
         goto legacy;
 

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -82,6 +82,8 @@ int EVP_MAC_init(EVP_MAC_CTX *ctx)
 
 int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen)
 {
+    if (datalen == 0)
+        return 1;
     return ctx->meth->update(ctx->data, data, datalen);
 }
 


### PR DESCRIPTION
We treat that as automatic success. Other EVP_*Update functions already to
this (e.g. EVP_EncryptUpdate, EVP_DecryptUpdate etc). EVP_EncodeUpdate is
a bit of an anomoly. That treats 0 byte input length as an error.

IMO this should go to both master and 1.1.1

Fixes #8576

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
