### PR TITLE
conn_is_closed should return 1 if get_last_sys_error is WSAECONNRESET

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -776,6 +776,10 @@ static ossl_inline int conn_is_closed(void)
     case ECONNRESET:
         return 1;
 #endif
+#if defined(WSAECONNRESET)
+    case WSAECONNRESET:
+        return 1;
+#endif
     default:
         return 0;
     }


### PR DESCRIPTION
CLA: trivial

conn_is_closed should check for WSAECONNRESET  on Windows because it has a different value than ECONNRESET.  Without this check ssl tests fail in the Python standard tests because the SSL_do_handshake() on the server side returns an error if the client closes the socket too quickly.