### PR TITLE
Fix three identical grammatical errors

### DIFF
--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -559,7 +559,7 @@ further information).
 
 =item B<-bugs>
 
-There are several known bug in SSL and TLS implementations. Adding this
+There are several known bugs in SSL and TLS implementations. Adding this
 option enables various workarounds.
 
 =item B<-comp>

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -542,7 +542,7 @@ OpenSSL was built.
 
 =item B<-bugs>
 
-There are several known bug in SSL and TLS implementations. Adding this
+There are several known bugs in SSL and TLS implementations. Adding this
 option enables various workarounds.
 
 =item B<-no_comp>

--- a/doc/man1/s_time.pod
+++ b/doc/man1/s_time.pod
@@ -127,7 +127,7 @@ OpenSSL was built.
 
 =item B<-bugs>
 
-There are several known bug in SSL and TLS implementations. Adding this
+There are several known bugs in SSL and TLS implementations. Adding this
 option enables various workarounds.
 
 =item B<-cipher cipherlist>


### PR DESCRIPTION
Reported by Mak Kolybabi

The patch applies cleanly to 1.1.1 as well.
