### PR TITLE
Make OCSP_id_cmp and OCSP_id_issuer_cmp accept const params

### DIFF
--- a/crypto/ocsp/ocsp_lib.c
+++ b/crypto/ocsp/ocsp_lib.c
@@ -88,7 +88,7 @@ OCSP_CERTID *OCSP_cert_id_new(const EVP_MD *dgst,
     return NULL;
 }
 
-int OCSP_id_issuer_cmp(OCSP_CERTID *a, OCSP_CERTID *b)
+int OCSP_id_issuer_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b)
 {
     int ret;
     ret = OBJ_cmp(a->hashAlgorithm.algorithm, b->hashAlgorithm.algorithm);
@@ -100,7 +100,7 @@ int OCSP_id_issuer_cmp(OCSP_CERTID *a, OCSP_CERTID *b)
     return ASN1_OCTET_STRING_cmp(&a->issuerKeyHash, &b->issuerKeyHash);
 }
 
-int OCSP_id_cmp(OCSP_CERTID *a, OCSP_CERTID *b)
+int OCSP_id_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b)
 {
     int ret;
     ret = OCSP_id_issuer_cmp(a, b);

--- a/doc/man3/OCSP_cert_to_id.pod
+++ b/doc/man3/OCSP_cert_to_id.pod
@@ -19,8 +19,8 @@ OCSP_id_cmp, OCSP_id_get0_info - OCSP certificate ID utility functions
 
  void OCSP_CERTID_free(OCSP_CERTID *id);
 
- int OCSP_id_issuer_cmp(OCSP_CERTID *a, OCSP_CERTID *b);
- int OCSP_id_cmp(OCSP_CERTID *a, OCSP_CERTID *b);
+ int OCSP_id_issuer_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);
+ int OCSP_id_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);
 
  int OCSP_id_get0_info(ASN1_OCTET_STRING **piNameHash, ASN1_OBJECT **pmd,
                        ASN1_OCTET_STRING **pikeyHash,

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -229,8 +229,8 @@ int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
 int OCSP_parse_url(const char *url, char **phost, char **pport, char **ppath,
                    int *pssl);
 
-int OCSP_id_issuer_cmp(OCSP_CERTID *a, OCSP_CERTID *b);
-int OCSP_id_cmp(OCSP_CERTID *a, OCSP_CERTID *b);
+int OCSP_id_issuer_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);
+int OCSP_id_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);
 
 int OCSP_request_onereq_count(OCSP_REQUEST *req);
 OCSP_ONEREQ *OCSP_request_onereq_get0(OCSP_REQUEST *req, int i);


### PR DESCRIPTION
Fixes #8589

