### PR TITLE
Fix error handling in X509_chain_up_ref (attempt 2)

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -456,7 +456,13 @@ static X509 *x509upref(X509 *x)
  */
 STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *chain)
 {
-    /* We upref each element rather than actually copying */
+    /*
+     * We upref each element rather than actually copying. We're "misusing"
+     * sk_X509_deep_copy a little here since we're not actually dong a "deep"
+     * copy. Note that we're casting the "copy" function to one that takes a
+     * const parameter, even though in reality it doesn't (because we need to
+     * modify the argument in order to upref it).
+     */
     return sk_X509_deep_copy(chain, (X509 *(*)(const X509 *))x509upref,
                              X509_free);
 }

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -441,14 +441,8 @@ int X509_CRL_check_suiteb(X509_CRL *crl, EVP_PKEY *pk, unsigned long flags)
 
 #endif
 
-static X509 *x509upref(const X509 *cx)
+static X509 *x509upref(X509 *x)
 {
-    /*
-     * Only used by X509_chain_up_ref where we know that its not really const,
-     * so this is safe
-     */
-    X509 *x = (X509 *)cx;
-
     if (!X509_up_ref(x))
         return NULL;
 
@@ -463,5 +457,6 @@ static X509 *x509upref(const X509 *cx)
 STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *chain)
 {
     /* We upref each element rather than actually copying */
-    return sk_X509_deep_copy(chain, x509upref, X509_free);
+    return sk_X509_deep_copy(chain, (X509 *(*)(const X509 *))x509upref,
+                             X509_free);
 }


### PR DESCRIPTION
We were ignoring the return value from  X509_up_ref. This rewrites the function and handles errors from X509_up_ref correctly.

It also adds a test.

Fixes #8592

This is an alternative approach to that given in #8598.