### PR TITLE
Revert one change from b3d113e

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -235,7 +235,7 @@ size_t rand_drbg_get_nonce(RAND_DRBG *drbg,
     struct {
         void * instance;
         int count;
-    } data = { NULL, 0 };
+    } data = { 0 };
 
     pool = rand_pool_new(0, min_len, max_len);
     if (pool == NULL)


### PR DESCRIPTION
Valgrind complains due to the uninitialized memory
between the struct members, assigning { 0 } was zeroing the memory
assigning { NULL, 0 } is like assigning member-wise, leaving
some bytes uninitialized.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
