### PR TITLE
Fix broken change from b3d113e.

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -235,8 +235,9 @@ size_t rand_drbg_get_nonce(RAND_DRBG *drbg,
     struct {
         void * instance;
         int count;
-    } data = { NULL, 0 };
+    } data;
 
+    memset(&data, 0, sizeof(data));
     pool = rand_pool_new(0, min_len, max_len);
     if (pool == NULL)
         return 0;


### PR DESCRIPTION
Alternative to #8603 
Fixing the problem introduced in b3d113e using memset(3).

The underlying issue is that, on my machine, the size of data is 16 bytes, but the sizes of it's two feilds are 8 and 4 respectively.  This leaves 4 bytes of padding.  I don't think C guarantees to initialise this to zero in either of the assignment cases.

All of the data structure is added to the entropy pool (counting as zero entropy).