### PR TITLE
Fixed typo in enc.c warning

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -500,7 +500,7 @@ int enc_main(int argc, char **argv)
         if (hiv != NULL) {
             int siz = EVP_CIPHER_iv_length(cipher);
             if (siz == 0) {
-                BIO_printf(bio_err, "warning: iv not use by this cipher\n");
+                BIO_printf(bio_err, "warning: iv not used by this cipher\n");
             } else if (!set_hex(hiv, iv, siz)) {
                 BIO_printf(bio_err, "invalid hex iv value\n");
                 goto end;


### PR DESCRIPTION
"warning: iv not use by this cipher" -> "warning: iv not used by this cipher"
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
