### PR TITLE
Clear seed source structures.

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -615,7 +615,10 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
         pid_t pid;
         CRYPTO_THREAD_ID tid;
         uint64_t time;
-    } data = { 0 };
+    } data;
+
+    /* Erase the entire structure including any padding */
+    memset(&data, 0, sizeof(data));
 
     /*
      * Add process id, thread id, and a high resolution timestamp to
@@ -634,7 +637,10 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     struct {
         CRYPTO_THREAD_ID tid;
         uint64_t time;
-    } data = { 0 };
+    } data;
+
+    /* Erase the entire structure including any padding */
+    memset(&data, 0, sizeof(data));
 
     /*
      * Add some noise from the thread id and a high resolution timer.

--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -475,7 +475,10 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
         pid_t pid;
         CRYPTO_THREAD_ID tid;
         uint64_t time;
-    } data = { 0 };
+    } data;
+
+    /* Erase the entire structure including any padding */
+    memset(&data, 0, sizeof(data));
 
     /*
      * Add process id, thread id, and a high resolution timestamp
@@ -499,7 +502,10 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     struct {
         CRYPTO_THREAD_ID tid;
         uint64_t time;
-    } data = { 0 };
+    } data;
+
+    /* Erase the entire structure including any padding */
+    memset(&data, 0, sizeof(data));
 
     /*
      * Add some noise from the thread id and a high resolution timer.

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -125,7 +125,10 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
         DWORD pid;
         DWORD tid;
         FILETIME time;
-    } data = { 0 };
+    } data;
+
+    /* Erase the entire structure including any padding */
+    memset(&data, 0, sizeof(data));
 
     /*
      * Add process id, thread id, and a high resolution timestamp to
@@ -144,7 +147,10 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     struct {
         DWORD tid;
         LARGE_INTEGER time;
-    } data = { 0 };
+    } data;
+
+    /* Erase the entire structure including any padding */
+    memset(&data, 0, sizeof(data));
 
     /*
      * Add some noise from the thread id and a high resolution timer.


### PR DESCRIPTION
If the structures have empty padding bytes, ensure they are zeroed.  These structures are added to seed pools as complete blocks including any padding and alignment bytes.

See #8603 for some discussion.

Note that the use of any uninitialised padding bytes in these structures would be harmless.  They are used as RNG personalisation material.  However, using uninitialised values is bad practice and triggers checkers like valgrind.
