### PR TITLE
Correctly zero structures.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -715,8 +715,9 @@ static void list_type(FUNC_TYPE ft, int one)
 {
     FUNCTION *fp;
     int i = 0;
-    DISPLAY_COLUMNS dc = {0};
+    DISPLAY_COLUMNS dc;
 
+    memset(&dc, 0, sizeof(dc));
     if (!one)
         calculate_columns(&dc);
 

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -669,7 +669,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
 static BIO *process_include(char *include, OPENSSL_DIR_CTX **dirctx,
                             char **dirpath)
 {
-    struct stat st = { 0 };
+    struct stat st;
     BIO *next;
 
     if (stat(include, &st) < 0) {

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -676,7 +676,9 @@ static void felem_contract(felem out, const felem in)
  */
 static void felem_neg(felem out, const felem in)
 {
-    widefelem tmp = {0};
+    widefelem tmp;
+
+    memset(tmp, 0, sizeof(tmp));
     felem_diff_128_64(tmp, in);
     felem_reduce(out, tmp);
 }

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -412,7 +412,7 @@ static int afalg_start_cipher_sk(afalg_ctx *actx, const unsigned char *in,
                                  size_t inl, const unsigned char *iv,
                                  unsigned int enc)
 {
-    struct msghdr msg = { 0 };
+    struct msghdr msg;
     struct cmsghdr *cmsg;
     struct iovec iov;
     ssize_t sbytes;
@@ -421,6 +421,7 @@ static int afalg_start_cipher_sk(afalg_ctx *actx, const unsigned char *in,
 # endif
     char cbuf[CMSG_SPACE(ALG_IV_LEN(ALG_AES_IV_LEN)) + CMSG_SPACE(ALG_OP_LEN)];
 
+    memset(&msg, 0, sizeof(msg));
     memset(cbuf, 0, sizeof(cbuf));
     msg.msg_control = cbuf;
     msg.msg_controllen = sizeof(cbuf);

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -118,12 +118,13 @@ static ossl_inline int ktls_start(int fd,
 static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
                                               const void *data, size_t length)
 {
-    struct msghdr msg = { 0 };
+    struct msghdr msg;
     int cmsg_len = sizeof(record_type);
     struct cmsghdr *cmsg;
     char buf[CMSG_SPACE(cmsg_len)];
     struct iovec msg_iov;       /* Vector of data to send/receive into */
 
+    memset(&msg, 0, sizeof(msg));
     msg.msg_control = buf;
     msg.msg_controllen = sizeof(buf);
     cmsg = CMSG_FIRSTHDR(&msg);

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -58,7 +58,7 @@ static int test_client_hello(int currtest)
     BIO *wbio;
     long len;
     unsigned char *data;
-    PACKET pkt = {0}, pkt2 = {0}, pkt3 = {0};
+    PACKET pkt, pkt2, pkt3;
     char *dummytick = "Hello World!";
     unsigned int type = 0;
     int testresult = 0;
@@ -70,6 +70,10 @@ static int test_client_hello(int currtest)
     if (currtest == TEST_ADD_PADDING_AND_PSK)
         return 1;
 #endif
+
+    memset(&pkt, 0, sizeof(pkt));
+    memset(&pkt2, 0, sizeof(pkt2));
+    memset(&pkt3, 0, sizeof(pkt3));
 
     /*
      * For each test set up an SSL_CTX and SSL and see what ClientHello gets

--- a/test/packettest.c
+++ b/test/packettest.c
@@ -350,8 +350,9 @@ static int test_PACKET_get_length_prefixed_1(void)
     unsigned char buf1[BUF_LEN];
     const size_t len = 16;
     unsigned int i;
-    PACKET pkt, short_pkt, subpkt = {0};
+    PACKET pkt, short_pkt, subpkt;
 
+    memset(&subpkt, 0, sizeof(subpkt));
     buf1[0] = (unsigned char)len;
     for (i = 1; i < BUF_LEN; i++)
         buf1[i] = (i * 2) & 0xff;
@@ -374,8 +375,9 @@ static int test_PACKET_get_length_prefixed_2(void)
     unsigned char buf1[1024];
     const size_t len = 516;  /* 0x0204 */
     unsigned int i;
-    PACKET pkt, short_pkt, subpkt = {0};
+    PACKET pkt, short_pkt, subpkt;
 
+    memset(&subpkt, 0, sizeof(subpkt));
     for (i = 1; i <= 1024; i++)
         buf1[i - 1] = (i * 2) & 0xff;
 
@@ -397,8 +399,9 @@ static int test_PACKET_get_length_prefixed_3(void)
     unsigned char buf1[1024];
     const size_t len = 516;  /* 0x000204 */
     unsigned int i;
-    PACKET pkt, short_pkt, subpkt = {0};
+    PACKET pkt, short_pkt, subpkt;
 
+    memset(&subpkt, 0, sizeof(subpkt));
     for (i = 0; i < 1024; i++)
         buf1[i] = (i * 2) & 0xff;
 
@@ -420,8 +423,9 @@ static int test_PACKET_as_length_prefixed_1(void)
     unsigned char buf1[BUF_LEN];
     const size_t len = 16;
     unsigned int i;
-    PACKET pkt, exact_pkt, subpkt = {0};
+    PACKET pkt, exact_pkt, subpkt;
 
+    memset(&subpkt, 0, sizeof(subpkt));
     buf1[0] = (unsigned char)len;
     for (i = 1; i < BUF_LEN; i++)
         buf1[i] = (i * 2) & 0xff;
@@ -443,8 +447,9 @@ static int test_PACKET_as_length_prefixed_2(void)
     unsigned char buf[1024];
     const size_t len = 516;  /* 0x0204 */
     unsigned int i;
-    PACKET pkt, exact_pkt, subpkt = {0};
+    PACKET pkt, exact_pkt, subpkt;
 
+    memset(&subpkt, 0, sizeof(subpkt));
     for (i = 1; i <= 1024; i++)
         buf[i-1] = (i * 2) & 0xff;
 

--- a/test/servername_test.c
+++ b/test/servername_test.c
@@ -35,9 +35,15 @@ static int get_sni_from_client_hello(BIO *bio, char **sni)
 {
     long len;
     unsigned char *data;
-    PACKET pkt = {0}, pkt2 = {0}, pkt3 = {0}, pkt4 = {0}, pkt5 = {0};
+    PACKET pkt, pkt2, pkt3, pkt4, pkt5;
     unsigned int servname_type = 0, type = 0;
     int ret = 0;
+
+    memset(&pkt, 0, sizeof(pkt));
+    memset(&pkt2, 0, sizeof(pkt2));
+    memset(&pkt3, 0, sizeof(pkt3));
+    memset(&pkt4, 0, sizeof(pkt4));
+    memset(&pkt5, 0, sizeof(pkt5));
 
     len = BIO_get_mem_data(bio, (char **)&data);
     if (!TEST_true(PACKET_buf_init(&pkt, data, len))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -306,9 +306,10 @@ static int test_keylog(void)
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
-    struct sslapitest_log_counts expected = {0};
+    struct sslapitest_log_counts expected;
 
     /* Clean up logging space */
+    memset(&expected, 0, sizeof(expected));
     memset(client_log_buffer, 0, sizeof(client_log_buffer));
     memset(server_log_buffer, 0, sizeof(server_log_buffer));
     client_log_buffer_index = 0;
@@ -387,11 +388,12 @@ static int test_keylog_no_master_key(void)
     SSL *clientssl = NULL, *serverssl = NULL;
     SSL_SESSION *sess = NULL;
     int testresult = 0;
-    struct sslapitest_log_counts expected = {0};
+    struct sslapitest_log_counts expected;
     unsigned char buf[1];
     size_t readbytes, written;
 
     /* Clean up logging space */
+    memset(&expected, 0, sizeof(expected));
     memset(client_log_buffer, 0, sizeof(client_log_buffer));
     memset(server_log_buffer, 0, sizeof(server_log_buffer));
     client_log_buffer_index = 0;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4595,11 +4595,15 @@ static int get_MFL_from_client_hello(BIO *bio, int *mfl_codemfl_code)
 {
     long len;
     unsigned char *data;
-    PACKET pkt = {0}, pkt2 = {0}, pkt3 = {0};
+    PACKET pkt, pkt2, pkt3;
     unsigned int MFL_code = 0, type = 0;
 
     if (!TEST_uint_gt( len = BIO_get_mem_data( bio, (char **) &data ), 0 ) )
         goto end;
+
+    memset(&pkt, 0, sizeof(pkt));
+    memset(&pkt2, 0, sizeof(pkt2));
+    memset(&pkt3, 0, sizeof(pkt3));
 
     if (!TEST_true( PACKET_buf_init( &pkt, data, len ) )
                /* Skip the record header */


### PR DESCRIPTION
Structures that are initialised using `= { 0 }` do not necessarily get fully initialised.  Padding and alignment bytes can be skipped and the C89 standard is ambiguous about fields apart from the first.  Instead, initialise using `memset(3)` to be certain.

Refer to discussion in #8603 for details.

- [x] tests are added or updated