### PR TITLE
Reduce params.c code size.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -41,50 +41,22 @@ static OSSL_PARAM ossl_param_construct(const char *key, unsigned int data_type,
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val)
 {
-    if (val == NULL || p == NULL || p->data_type != OSSL_PARAM_INTEGER)
-        return 0;
-
-    switch (p->data_size) {
+    switch (sizeof(int)) {
     case sizeof(int32_t):
-        if (sizeof(int) >= sizeof(int32_t)) {
-            *val = (int)*(const int32_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_int32(p, (int32_t *)val);
     case sizeof(int64_t):
-        if (sizeof(int) >= sizeof(int64_t)) {
-            *val = (int)*(const int64_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_int64(p, (int64_t *)val);
     }
     return 0;
 }
 
 int OSSL_PARAM_set_int(const OSSL_PARAM *p, int val)
 {
-    if (p == NULL)
-        return 0;
-    SET_RETURN_SIZE(p, 0);
-    if (p->data_type != OSSL_PARAM_INTEGER)
-        return 0;
-
-    SET_RETURN_SIZE(p, sizeof(int)); /* Minimum expected size */
-    switch (p->data_size) {
+    switch (sizeof(int)) {
     case sizeof(int32_t):
-        if (sizeof(int32_t) >= sizeof(int)) {
-            SET_RETURN_SIZE(p, sizeof(int32_t));
-            *(int32_t *)p->data = (int32_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_int32(p, (int32_t)val);
     case sizeof(int64_t):
-        if (sizeof(int64_t) >= sizeof(int)) {
-            SET_RETURN_SIZE(p, sizeof(int64_t));
-            *(int64_t *)p->data = (int64_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_int64(p, (int64_t)val);
     }
     return 0;
 }
@@ -97,52 +69,22 @@ OSSL_PARAM OSSL_PARAM_construct_int(const char *key, int *buf, size_t *rsize)
 
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val)
 {
-    if (val == NULL
-        || p == NULL
-        || (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER))
-        return 0;
-
-    switch (p->data_size) {
+    switch (sizeof(unsigned int)) {
     case sizeof(uint32_t):
-        if (sizeof(unsigned int) >= sizeof(uint32_t)) {
-            *val = (unsigned int)*(const uint32_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_uint32(p, (uint32_t *)val);
     case sizeof(uint64_t):
-        if (sizeof(unsigned int) >= sizeof(uint64_t)) {
-            *val = (unsigned int)*(const uint64_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
     }
     return 0;
 }
 
 int OSSL_PARAM_set_uint(const OSSL_PARAM *p, unsigned int val)
 {
-    if (p == NULL)
-        return 0;
-    SET_RETURN_SIZE(p, 0);
-    if (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
-        return 0;
-
-    SET_RETURN_SIZE(p, sizeof(unsigned int)); /* Minimum expected size */
-    switch (p->data_size) {
+    switch (sizeof(unsigned int)) {
     case sizeof(uint32_t):
-        if (sizeof(uint32_t) >= sizeof(unsigned int)) {
-            SET_RETURN_SIZE(p, sizeof(uint32_t));
-            *(uint32_t *)p->data = (uint32_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_uint32(p, (uint32_t)val);
     case sizeof(uint64_t):
-        if (sizeof(uint64_t) >= sizeof(unsigned int)) {
-            SET_RETURN_SIZE(p, sizeof(uint64_t));
-            *(uint64_t *)p->data = (uint64_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_uint64(p, (uint64_t)val);
     }
     return 0;
 }
@@ -156,49 +98,22 @@ OSSL_PARAM OSSL_PARAM_construct_uint(const char *key, unsigned int *buf,
 
 int OSSL_PARAM_get_long(const OSSL_PARAM *p, long int *val)
 {
-    if (val == NULL || p == NULL || (p->data_type != OSSL_PARAM_INTEGER))
-        return 0;
-
-    switch (p->data_size) {
+    switch (sizeof(long int)) {
     case sizeof(int32_t):
-        if (sizeof(long int) >= sizeof(int32_t)) {
-            *val = (long int)*(const int32_t *)p->data;
-            return 1;
-        } break;
+        return OSSL_PARAM_get_int32(p, (int32_t *)val);
     case sizeof(int64_t):
-        if (sizeof(long int) >= sizeof(int64_t)) {
-            *val = (long int)*(const int64_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_int64(p, (int64_t *)val);
     }
     return 0;
 }
 
 int OSSL_PARAM_set_long(const OSSL_PARAM *p, long int val)
 {
-    if (p == NULL)
-        return 0;
-    SET_RETURN_SIZE(p, 0);
-    if (p->data_type != OSSL_PARAM_INTEGER)
-        return 0;
-
-    SET_RETURN_SIZE(p, sizeof(long int)); /* Minimum expected size */
-    switch (p->data_size) {
+    switch (sizeof(long int)) {
     case sizeof(int32_t):
-        if (sizeof(int32_t) >= sizeof(long int)) {
-            SET_RETURN_SIZE(p, sizeof(int32_t));
-            *(int32_t *)p->data = (int32_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_int32(p, (int32_t)val);
     case sizeof(int64_t):
-        if (sizeof(int64_t) >= sizeof(long int)) {
-            SET_RETURN_SIZE(p, sizeof(int64_t));
-            *(int64_t *)p->data = (int64_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_int64(p, (int64_t)val);
     }
     return 0;
 }
@@ -212,52 +127,22 @@ OSSL_PARAM OSSL_PARAM_construct_long(const char *key, long int *buf,
 
 int OSSL_PARAM_get_ulong(const OSSL_PARAM *p, unsigned long int *val)
 {
-    if (val == NULL
-        || p == NULL
-        || (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER))
-        return 0;
-
-    switch (p->data_size) {
+    switch (sizeof(unsigned long int)) {
     case sizeof(uint32_t):
-        if (sizeof(unsigned long int) >= sizeof(uint32_t)) {
-            *val = (unsigned long int)*(const uint32_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_uint32(p, (uint32_t *)val);
     case sizeof(uint64_t):
-        if (sizeof(unsigned long int) >= sizeof(uint64_t)) {
-            *val = (unsigned long int)*(const uint64_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
     }
     return 0;
 }
 
 int OSSL_PARAM_set_ulong(const OSSL_PARAM *p, unsigned long int val)
 {
-    if (p == NULL)
-        return 0;
-    SET_RETURN_SIZE(p, 0);
-    if (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
-        return 0;
-
-    SET_RETURN_SIZE(p, sizeof(unsigned long int)); /* Minimum exp size */
-    switch (p->data_size) {
+    switch (sizeof(unsigned long int)) {
     case sizeof(uint32_t):
-        if (sizeof(uint32_t) >= sizeof(unsigned long int)) {
-            SET_RETURN_SIZE(p, sizeof(uint32_t));
-            *(uint32_t *)p->data = (uint32_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_uint32(p, (uint32_t)val);
     case sizeof(uint64_t):
-        if (sizeof(uint64_t) >= sizeof(unsigned long int)) {
-            SET_RETURN_SIZE(p, sizeof(uint64_t));
-            *(uint64_t *)p->data = (uint64_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_uint64(p, (uint64_t)val);
     }
     return 0;
 }
@@ -437,52 +322,22 @@ OSSL_PARAM OSSL_PARAM_construct_uint64(const char *key, uint64_t *buf,
 
 int OSSL_PARAM_get_size_t(const OSSL_PARAM *p, size_t *val)
 {
-    if (val == NULL
-        || p == NULL
-        || p->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
-        return 0;
-
-    switch (p->data_size) {
+    switch (sizeof(size_t)) {
     case sizeof(uint32_t):
-        if (sizeof(size_t) >= sizeof(uint32_t)) {
-            *val = (size_t)*(const uint32_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_uint32(p, (uint32_t *)val);
     case sizeof(uint64_t):
-        if (sizeof(size_t) >= sizeof(uint64_t)) {
-            *val = (size_t)*(const uint64_t *)p->data;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
     }
     return 0;
 }
 
 int OSSL_PARAM_set_size_t(const OSSL_PARAM *p, size_t val)
 {
-    if (p == NULL)
-        return 0;
-    SET_RETURN_SIZE(p, 0);
-    if (p->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
-        return 0;
-
-    SET_RETURN_SIZE(p, sizeof(size_t)); /* Minimum expected size */
-    switch (p->data_size) {
+    switch (sizeof(size_t)) {
     case sizeof(uint32_t):
-        if (sizeof(uint32_t) >= sizeof(size_t)) {
-            SET_RETURN_SIZE(p, sizeof(uint32_t));
-            *(uint32_t *)p->data = (uint32_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_uint32(p, (uint32_t)val);
     case sizeof(uint64_t):
-        SET_RETURN_SIZE(p, sizeof(uint64_t));
-        if (sizeof(uint64_t) >= sizeof(size_t)) {
-            *(uint64_t *)p->data = (uint64_t)val;
-            return 1;
-        }
-        break;
+        return OSSL_PARAM_set_uint64(p, (uint64_t)val);
     }
     return 0;
 }


### PR DESCRIPTION
Implement the param types that aren't explicitly lengthened (e.g. int) in terms of those that are (e.g. int32_t).

The switch statements should resolve at compile time into a branch to the appropriate function.
