### PR TITLE
Fix the allocation size in EVP_OpenInit and PEM_SignFinal

### DIFF
--- a/crypto/evp/p_open.c
+++ b/crypto/evp/p_open.c
@@ -40,7 +40,7 @@ int EVP_OpenInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
     }
 
     size = EVP_PKEY_size(priv);
-    key = OPENSSL_malloc(size + 2);
+    key = OPENSSL_malloc(size);
     if (key == NULL) {
         /* ERROR */
         EVPerr(EVP_F_EVP_OPENINIT, ERR_R_MALLOC_FAILURE);

--- a/crypto/pem/pem_sign.c
+++ b/crypto/pem/pem_sign.c
@@ -31,7 +31,7 @@ int PEM_SignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
     int i, ret = 0;
     unsigned int m_len;
 
-    m = OPENSSL_malloc(EVP_PKEY_size(pkey) + 2);
+    m = OPENSSL_malloc(EVP_PKEY_size(pkey));
     if (m == NULL) {
         PEMerr(PEM_F_PEM_SIGNFINAL, ERR_R_MALLOC_FAILURE);
         goto err;


### PR DESCRIPTION
It came to my attention that sometimes two bytes more are allocated than necessary