### PR TITLE
Avoid creating invalid rsa pss params

### DIFF
--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -583,10 +583,12 @@ static RSA_PSS_PARAMS *rsa_ctx_to_pss(EVP_PKEY_CTX *pkctx)
         return NULL;
     if (saltlen == -1) {
         saltlen = EVP_MD_size(sigmd);
-    } else if (saltlen == -2) {
+    } else if (saltlen == -2 || saltlen == -3) {
         saltlen = EVP_PKEY_size(pk) - EVP_MD_size(sigmd) - 2;
         if ((EVP_PKEY_bits(pk) & 0x7) == 1)
             saltlen--;
+        if (saltlen < 0)
+            return NULL;
     }
 
     return rsa_pss_params_create(sigmd, mgf1md, saltlen);

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -324,6 +324,14 @@ my @smime_cms_param_tests = (
 	"-CAfile", catfile($smdir, "smroot.pem"), "-out", "smtst.txt" ]
     ],
 
+    [ "signed content test streaming PEM format, RSA keys, PSS signature, saltlen=-3",
+      [ "-sign", "-in", $smcont, "-outform", "PEM", "-nodetach",
+	"-signer", catfile($smdir, "smrsa1.pem"), "-keyopt", "rsa_padding_mode:pss",
+	"-keyopt", "rsa_pss_saltlen:-3", "-out", "test.cms" ],
+      [ "-verify", "-in", "test.cms", "-inform", "PEM",
+	"-CAfile", catfile($smdir, "smroot.pem"), "-out", "smtst.txt" ]
+    ],
+
     [ "signed content test streaming PEM format, RSA keys, PSS signature, no attributes",
       [ "-sign", "-in", $smcont, "-outform", "PEM", "-nodetach", "-noattr",
 	"-signer", catfile($smdir, "smrsa1.pem"), "-keyopt", "rsa_padding_mode:pss",


### PR DESCRIPTION
salt length -3 means use maximized salt length on signing and verification
salt lenght -2 means adjust to the salt length from the signature on verification, which is not
exactly representable by the RSA_PSS_PARAMS.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
