### PR TITLE
Rework DSO API conditions and configuration option

### DIFF
--- a/Configure
+++ b/Configure
@@ -492,9 +492,6 @@ my @disable_cascades = (
 
     "crypto-mdebug"     => [ "crypto-mdebug-backtrace" ],
 
-    # Without DSO, we can't load dynamic engines, so don't build them dynamic
-    "dso"               => [ "dynamic-engine" ],
-
     # Without position independent code, there can be no shared libraries or DSOs
     "pic"               => [ "shared" ],
     "shared"            => [ "dynamic-engine" ],

--- a/Configure
+++ b/Configure
@@ -24,7 +24,7 @@ use OpenSSL::Glob;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-dso] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
 
 # Options:
 #
@@ -59,8 +59,6 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # [no-]pic      [don't] try to build position independent code when supported.
 #               If disabled, it also disables shared and dynamic-engine.
 # no-asm        do not use assembler
-# no-dso        do not compile in any native shared-library methods. This
-#               will ensure that all methods just return NULL.
 # no-egd        do not compile support for the entropy-gathering daemon APIs
 # [no-]zlib     [don't] compile support for zlib compression.
 # zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
@@ -76,7 +74,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # -static       while -static is also a pass-through compiler option (and
 #               as such is limited to environments where it's actually
 #               meaningful), it triggers a number configuration options,
-#               namely no-dso, no-pic, no-shared and no-threads. It is
+#               namely no-pic, no-shared and no-threads. It is
 #               argued that the only reason to produce statically linked
 #               binaries (and in context it means executables linked with
 #               -static flag, and not just executables linked with static
@@ -359,7 +357,6 @@ my @disablables = (
     "dgram",
     "dh",
     "dsa",
-    "dso",
     "dtls",
     "dynamic-engine",
     "ec",
@@ -876,7 +873,6 @@ while (@argvcopy)
                 elsif (/^-static$/)
                         {
                         push @{$useradd{LDFLAGS}}, $_;
-                        $disabled{"dso"} = "forced";
                         $disabled{"pic"} = "forced";
                         $disabled{"shared"} = "forced";
                         $disabled{"threads"} = "forced";
@@ -1211,7 +1207,7 @@ foreach my $what (sort keys %disabled) {
 
     $config{options} .= " no-$what";
 
-    if (!grep { $what eq $_ } ( 'buildtest-c++', 'dso', 'threads', 'shared',
+    if (!grep { $what eq $_ } ( 'buildtest-c++', 'threads', 'shared',
                                 'pic', 'dynamic-engine', 'makedepend',
                                 'zlib-dynamic', 'zlib', 'sse2' )) {
         (my $WHAT = uc $what) =~ s|-|_|g;

--- a/Configure
+++ b/Configure
@@ -437,6 +437,7 @@ my %deprecated_disablables = (
     "hw-padlock" => "padlockeng",
     "ripemd" => "rmd160",
     "ui" => "ui-console",
+    "dso" => undef,
     );
 
 # All of the following are disabled by default:

--- a/INSTALL
+++ b/INSTALL
@@ -353,9 +353,6 @@
                    on BSD implementations, in which case it can be disabled with
                    no-devcryptoeng.
 
-  no-dso
-                   Don't build support for loading Dynamic Shared Objects.
-
   no-dynamic-engine
                    Don't build the dynamically loaded engines. This only has an
                    effect in a "shared" build

--- a/crypto/dso/dso_openssl.c
+++ b/crypto/dso/dso_openssl.c
@@ -9,7 +9,7 @@
 
 #include "dso_locl.h"
 
-#if !defined(DSO_VMS) && !defined(DSO_DLCFN) && !defined(DSO_DL) && !defined(DSO_WIN32) && !defined(DSO_DLFCN)
+#ifdef DSO_NONE
 
 static DSO_METHOD dso_meth_null = {
     "NULL shared library method"

--- a/crypto/include/internal/dso_conf.h.in
+++ b/crypto/include/internal/dso_conf.h.in
@@ -10,7 +10,6 @@
 
 #ifndef HEADER_DSO_CONF_H
 # define HEADER_DSO_CONF_H
-{- output_off() if $disabled{dso} -}
 {-  # The DSO code currently always implements all functions so that no
     # applications will have to worry about that from a compilation point
     # of view. However, the "method"s may return zero unless that platform
@@ -18,6 +17,8 @@
     # by a define "DSO_<name>" ... we translate the "dso_scheme" config
     # string entry into using the following logic;
     my $scheme = uc $target{dso_scheme};
+    if (!$scheme)
+        $scheme = "NONE";
     my @macros = ( "DSO_$scheme" );
     if ($scheme eq 'DLFCN') {
         @macros = ( "DSO_DLFCN", "HAVE_DLFCN_H" );
@@ -26,5 +27,4 @@
     }
     join("\n", map { "# define $_" } @macros); -}
 # define DSO_EXTENSION "{- platform->dsoext() -}"
-{- output_on() if $disabled{dso} -}
 #endif

--- a/crypto/include/internal/dso_conf.h.in
+++ b/crypto/include/internal/dso_conf.h.in
@@ -17,8 +17,9 @@
     # by a define "DSO_<name>" ... we translate the "dso_scheme" config
     # string entry into using the following logic;
     my $scheme = uc $target{dso_scheme};
-    if (!$scheme)
+    if (!$scheme) {
         $scheme = "NONE";
+    }
     my @macros = ( "DSO_$scheme" );
     if ($scheme eq 'DLFCN') {
         @macros = ( "DSO_DLFCN", "HAVE_DLFCN_H" );

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -160,8 +160,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
 {
     OSSL_TRACE(INIT, "ossl_init_load_crypto_nodelete()\n");
 
-#if !defined(OPENSSL_NO_DSO) \
-    && !defined(OPENSSL_USE_NODELETE) \
+#if !defined(OPENSSL_USE_NODELETE) \
     && !defined(OPENSSL_NO_PINSHARED)
 # if defined(DSO_WIN32) && !defined(_WIN32_WCE)
     {
@@ -179,7 +178,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_nodelete)
                     (ret == TRUE ? "No!" : "Yes."));
         return (ret == TRUE) ? 1 : 0;
     }
-# else
+# elif !defined(DSO_NONE)
     /*
      * Deliberately leak a reference to ourselves. This will force the library
      * to remain loaded until the atexit() handler is run at process exit.
@@ -733,8 +732,7 @@ int OPENSSL_atexit(void (*handler)(void))
 {
     OPENSSL_INIT_STOP *newhand;
 
-#if !defined(OPENSSL_NO_DSO) \
-    && !defined(OPENSSL_USE_NODELETE)\
+#if !defined(OPENSSL_USE_NODELETE)\
     && !defined(OPENSSL_NO_PINSHARED)
     {
         union {
@@ -759,7 +757,7 @@ int OPENSSL_atexit(void (*handler)(void))
             if (!ret)
                 return 0;
         }
-# else
+# elif !defined(DSO_NONE)
         /*
          * Deliberately leak a reference to the handler. This will force the
          * library/code containing the handler to remain loaded until we run the

--- a/include/internal/dsoerr.h
+++ b/include/internal/dsoerr.h
@@ -17,11 +17,9 @@
 
 # include <openssl/opensslconf.h>
 
-# ifndef OPENSSL_NO_DSO
-
-#  ifdef  __cplusplus
+# ifdef  __cplusplus
 extern "C"
-#  endif
+# endif
 int ERR_load_DSO_strings(void);
 
 /*

--- a/include/internal/dsoerr.h
+++ b/include/internal/dsoerr.h
@@ -81,5 +81,4 @@ int ERR_load_DSO_strings(void);
 #  define DSO_R_UNLOAD_FAILED                              107
 #  define DSO_R_UNSUPPORTED                                108
 
-# endif
 #endif


### PR DESCRIPTION
'no-dso' is meaningless, as it doesn't get any macro defined.
Therefore, we remove all checks of OPENSSL_NO_DSO.  However, there may
be some odd platforms with no DSO scheme.  For those, we generate the
internal macro DSO_NONE and use it.
