### PR TITLE
Build cleanups

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -151,9 +151,9 @@
      return "" if $cache{$lib};
      $OUT .= obj2dso(lib => $lib,
                      attrs => $unified_info{attributes}->{$lib},
-                     objs => $unified_info{shared_sources}->{$lib},
+                     objs => $unified_info{sources}->{$lib},
                      deps => [ resolvedepends($lib) ]);
-     foreach (@{$unified_info{shared_sources}->{$lib}}) {
+     foreach (@{$unified_info{sources}->{$lib}}) {
          # If this is somehow a compiled object, take care of it that way
          # Otherwise, it might simply be generated
          if (defined $unified_info{sources}->{$_}) {

--- a/Configure
+++ b/Configure
@@ -377,6 +377,7 @@ my @disablables = (
     "md2",
     "md4",
     "mdc2",
+    "module",
     "msan",
     "multiblock",
     "nextprotoneg",
@@ -492,9 +493,23 @@ my @disable_cascades = (
 
     "crypto-mdebug"     => [ "crypto-mdebug-backtrace" ],
 
-    # Without position independent code, there can be no shared libraries or DSOs
-    "pic"               => [ "shared" ],
+    # If no modules, then no dynamic engines either
+    "module"            => [ "dynamic-engine" ],
+
+    # Without shared libraries, dynamic engines aren't possible.
+    # This is due to them having to link with libcrypto and register features
+    # using the ENGINE functionality, and since that relies on global tables,
+    # those *have* to be exacty the same as the ones accessed from the app,
+    # which cannot be guaranteed if shared libraries aren't present.
+    # (note that even with shared libraries, both the app and dynamic engines
+    # must be linked with the same)
     "shared"            => [ "dynamic-engine" ],
+    # Other modules don't necessarily have to link with libcrypto, so shared
+    # libraries do not have to be a condition to produce those.
+
+    # Without position independent code, there can be no shared libraries
+    # or modules.
+    "pic"               => [ "shared", "module" ],
 
     "engine"            => [ grep /eng$/, @disablables ],
     "hw"                => [ "padlockeng" ],
@@ -1205,7 +1220,7 @@ foreach my $what (sort keys %disabled) {
 
     $config{options} .= " no-$what";
 
-    if (!grep { $what eq $_ } ( 'buildtest-c++', 'threads', 'shared',
+    if (!grep { $what eq $_ } ( 'buildtest-c++', 'threads', 'shared', 'module',
                                 'pic', 'dynamic-engine', 'makedepend',
                                 'zlib-dynamic', 'zlib', 'sse2' )) {
         (my $WHAT = uc $what) =~ s|-|_|g;
@@ -1311,9 +1326,8 @@ if ($target{shared_target} eq "")
         {
         $no_shared_warn = 1
             if (!$disabled{shared} || !$disabled{"dynamic-engine"});
-        $disabled{shared} = "no-shared-target";
         $disabled{pic} = $disabled{shared} = $disabled{"dynamic-engine"} =
-            "no-shared-target";
+            $disabled{module} = "no-shared-target";
         }
 
 if ($disabled{"dynamic-engine"}) {

--- a/Configure
+++ b/Configure
@@ -2190,9 +2190,8 @@ EOF
                                            src => [ 'sources',
                                                     'shared_sources' ],
                                            dst => 'shared_sources' } },
-                modules   => { dso    => { src => [ 'sources',
-                                                    'shared_sources' ],
-                                           dst => 'shared_sources' } },
+                modules   => { dso    => { src => [ 'sources' ],
+                                           dst => 'sources' } },
                 scripts   => { script => { src => [ 'sources' ],
                                            dst => 'sources' } }
                } -> {$prodtype};

--- a/engines/build.info
+++ b/engines/build.info
@@ -21,7 +21,7 @@ IF[{- !$disabled{"engine"} -}]
       DEPEND[padlock]=../libcrypto
       INCLUDE[padlock]=../include
       IF[{- defined $target{shared_defflag} -}]
-        SHARED_SOURCE[padlock]=padlock.ld
+        SOURCE[padlock]=padlock.ld
         GENERATE[padlock.ld]=../util/engines.num
       ENDIF
     ENDIF
@@ -31,7 +31,7 @@ IF[{- !$disabled{"engine"} -}]
       DEPEND[capi]=../libcrypto
       INCLUDE[capi]=../include
       IF[{- defined $target{shared_defflag} -}]
-        SHARED_SOURCE[capi]=capi.ld
+        SOURCE[capi]=capi.ld
         GENERATE[capi.ld]=../util/engines.num
       ENDIF
     ENDIF
@@ -41,7 +41,7 @@ IF[{- !$disabled{"engine"} -}]
       DEPEND[afalg]=../libcrypto
       INCLUDE[afalg]= ../include
       IF[{- defined $target{shared_defflag} -}]
-        SHARED_SOURCE[afalg]=afalg.ld
+        SOURCE[afalg]=afalg.ld
         GENERATE[afalg.ld]=../util/engines.num
       ENDIF
     ENDIF
@@ -51,7 +51,7 @@ IF[{- !$disabled{"engine"} -}]
       DEPEND[devcrypto]=../libcrypto
       INCLUDE[devcrypto]=../include
       IF[{- defined $target{shared_defflag} -}]
-        SHARED_SOURCE[devcrypto]=devcrypto.ld
+        SOURCE[devcrypto]=devcrypto.ld
         GENERATE[devcrypto.ld]=../util/engines.num
       ENDIF
     ENDIF
@@ -61,14 +61,14 @@ IF[{- !$disabled{"engine"} -}]
     DEPEND[dasync]=../libcrypto
     INCLUDE[dasync]=../include
     IF[{- defined $target{shared_defflag} -}]
-      SHARED_SOURCE[dasync]=dasync.ld
+      SOURCE[dasync]=dasync.ld
       GENERATE[dasync.ld]=../util/engines.num
     ENDIF
     SOURCE[ossltest]=e_ossltest.c
     DEPEND[ossltest]=../libcrypto
     INCLUDE[ossltest]=../include
     IF[{- defined $target{shared_defflag} -}]
-      SHARED_SOURCE[ossltest]=ossltest.ld
+      SOURCE[ossltest]=ossltest.ld
       GENERATE[ossltest.ld]=../util/engines.num
     ENDIF
   ENDIF

--- a/test/build.info
+++ b/test/build.info
@@ -603,7 +603,7 @@ IF[{- !$disabled{tests} -}]
   SOURCE[provider_test]=provider_test.c p_test.c
   INCLUDE[provider_test]=../include ../apps/include
   DEPEND[provider_test]=../libcrypto.a libtestutil.a
-  IF[{- !$disabled{shared} -}]
+  IF[{- !$disabled{module} -}]
     MODULES{noinst}=p_test
     SOURCE[p_test]=p_test.c
     INCLUDE[p_test]=../include

--- a/test/build.info
+++ b/test/build.info
@@ -611,9 +611,10 @@ IF[{- !$disabled{tests} -}]
       SOURCE[p_test]=p_test.ld
       GENERATE[p_test.ld]=../util/providers.num
     ENDIF
-  ELSE
-    DEFINE[provider_test]=OPENSSL_NO_SHARED
-    DEFINE[provider_internal_test]=OPENSSL_NO_SHARED
+  ENDIF
+  IF[{- $disabled{module} || !$target{dso_scheme} -}]
+    DEFINE[provider_test]=OPENSSL_NO_MODULE
+    DEFINE[provider_internal_test]=OPENSSL_NO_MODULE
   ENDIF
 
   PROGRAMS{noinst}=params_test

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -11,11 +11,6 @@
 #include "internal/provider.h"
 #include "testutil.h"
 
-#if !defined(DSO_VMS) && !defined(DSO_DLCFN) && !defined(DSO_DL) \
-    && !defined(DSO_WIN32) && !defined(DSO_DLFCN)
-# define OPENSSL_NO_DSO
-#endif
-
 extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
 
 static char buf[256];
@@ -61,7 +56,7 @@ static int test_builtin_provider(void)
         && test_provider(prov);
 }
 
-#ifndef OPENSSL_NO_DSO
+#ifndef OPENSSL_NO_MODULE
 static int test_loaded_provider(void)
 {
     const char *name = "p_test";
@@ -76,7 +71,7 @@ static int test_loaded_provider(void)
 int setup_tests(void)
 {
     ADD_TEST(test_builtin_provider);
-#ifndef OPENSSL_NO_DSO
+#ifndef OPENSSL_NO_MODULE
     ADD_TEST(test_loaded_provider);
 #endif
     return 1;

--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -11,12 +11,6 @@
 #include <openssl/provider.h>
 #include "testutil.h"
 
-#if !defined(DSO_VMS) && !defined(DSO_DLCFN) && !defined(DSO_DL) \
-    && !defined(DSO_WIN32) && !defined(DSO_DLFCN)
-# define OPENSSL_NO_DSO
-#endif
-
-
 extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
 
 static char buf[256];
@@ -55,7 +49,7 @@ static int test_builtin_provider(void)
         && test_provider(name);
 }
 
-#ifndef OPENSSL_NO_DSO
+#ifndef OPENSSL_NO_MODULE
 static int test_loaded_provider(void)
 {
     const char *name = "p_test";
@@ -67,7 +61,7 @@ static int test_loaded_provider(void)
 int setup_tests(void)
 {
     ADD_TEST(test_builtin_provider);
-#ifndef OPENSSL_NO_DSO
+#ifndef OPENSSL_NO_MODULE
     ADD_TEST(test_loaded_provider);
 #endif
     return 1;


### PR DESCRIPTION
## Build cleanup: don't use SHARED_SOURCE with modules

SHARED_SOURCE is reserved for products that are expected to come in
dual shared / non-shared form, i.e. the routine libraries like
libcrypto and libssl, to distinguish source that should only appear in
their shared form.

Modules are always shared, so there's no need for them to have this
type of distinction.

## Configuration / build: make it possible to disable building of modules

While we're at it, sort out inconsistencies with the build of modules:
- not building shared libraries means not building dynamic engines.
  However, other modules may still be built.
- not having DSO functionality doesn't mean not to build modules (even
  though we can't use them from apps linked with libraries that are
  built this way).

## Correct the checks of module availability in provider test programs

Previously, the macro OPENSSL_NO_SHARED was defined of the test/p_test
module wasn't built, but the provider test programs didn't check that
macro.  We rename it to OPENSSL_NO_MODULE, since that name describes
the situation more than OPENSSL_NO_SHARED does, and use it.