### PR TITLE
Restore the "heartbeats" configuration option among the deprecated

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@
 
   *) Removed the heartbeat message in DTLS feature, as it has very
      little usage and doesn't seem to fulfill a valuable purpose.
+     The configuration option is now deprecated.
      [Richard Levitte]
 
   *) Changed the output of 'openssl {digestname} < file' to display the

--- a/Configure
+++ b/Configure
@@ -438,6 +438,7 @@ my %deprecated_disablables = (
     "ripemd" => "rmd160",
     "ui" => "ui-console",
     "dso" => undef,
+    "heartbeats" => undef,
     );
 
 # All of the following are disabled by default:


### PR DESCRIPTION
Removing the option entirely would break builds unnecessarily, so
let's make it deprecated.
