### PR TITLE
crypto/rand/rand_win.c: include "e_os.h" to get the default _WIN32_WINNT

### DIFF
--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -11,6 +11,7 @@
 #include <openssl/rand.h>
 #include "rand_lcl.h"
 #include "internal/rand_int.h"
+#include "e_os.h"                /* For a default _WIN32_WINNT */
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
 
 # ifndef OPENSSL_RAND_SEED_OS


### PR DESCRIPTION
This helps decide if the BCrypt API should be used or not.

Fixes #8635
