### PR TITLE
Increase minimal Windows target version from XP to Vista

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,15 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Increase minimal Windows target version from XP to Vista, since
+     support for Windows XP ended in April 2014 and leaving Windows XP
+     as default target version would prevent BCryptGenRandom() from being
+     used when seeding the CSPRNG. As a consequence, libcrypto.dll will fail
+     to load on Windows XP because `bcrypt.dll` is missing. To build OpenSSL
+     for Windows XP (if necessary) add the -D_WIN32_WINNT=0x501 as Configure
+     argument.
+     [Matthias St. Pierre]
+
   *) Added newline escaping functionality to a filename when using openssl dgst.
      This output format is to replicate the output format found in the '*sum'
      checksum programs. This aims to preserve backward compatibility.

--- a/e_os.h
+++ b/e_os.h
@@ -116,7 +116,7 @@
         * might be possible to achieve the goal by /DELAYLOAD-ing .DLLs
         * and check for current OS version instead.
         */
-#    define _WIN32_WINNT 0x0501
+#    define _WIN32_WINNT 0x0600
 #   endif
 #   if defined(_WIN32_WINNT) || defined(_WIN32_WCE)
        /*


### PR DESCRIPTION
Support for Windows XP ended long time ago in April 2014.
Leaving Windows XP as default target version prevents
BCryptGenRandom() from being used when seeding the CSPRNG.

Although Windows Vista support ended as well in April 2017,
support for it is not dropped yet for the sake of compatibility,
because the distinction currently does not make a difference
in the code.

Note that it is still possible to build OpenSSL for Windows XP
(if necessary) by adding the -D_WIN32_WINNT=0x501 Configure argument.

See also #8639

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
