### PR TITLE
Revert "crypto/rand/rand_win.c: include "e_os.h" to get the default _WIN32_WINNT

### DIFF
--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -11,7 +11,6 @@
 #include <openssl/rand.h>
 #include "rand_lcl.h"
 #include "internal/rand_int.h"
-#include "e_os.h"                /* For a default _WIN32_WINNT */
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_WIN32)
 
 # ifndef OPENSSL_RAND_SEED_OS


### PR DESCRIPTION
I turns out that this made crypto/rand/rand_win.c to never build with
BCrypt support unless the user sets _WIN32_WINNT.  That wasn't the
intent.

This reverts commit cc8926ec8fcecae89ceab91ef753de93e49568f9.
