### PR TITLE
Fix for BIO_get_mem_ptr and related regressions

### DIFF
--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -205,6 +205,7 @@ static int mem_read(BIO *b, char *out, int outl)
     if ((out != NULL) && (ret > 0)) {
         memcpy(out, bm->data, ret);
         bm->length -= ret;
+        bm->max -= ret;
         bm->data += ret;
     } else if (bm->length == 0) {
         ret = b->num;

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -57,7 +57,12 @@ static const BIO_METHOD secmem_method = {
     NULL,                      /* mem_callback_ctrl */
 };
 
-/* BIO memory stores buffer and read pointer  */
+/*
+ * BIO memory stores buffer and read pointer
+ * however the roles are different for read only BIOs.
+ * In that case the readp just stores the original state
+ * to be used for reset.
+ */
 typedef struct bio_buf_mem_st {
     struct buf_mem_st *buf;   /* allocated buffer */
     struct buf_mem_st *readp; /* read pointer */
@@ -192,6 +197,9 @@ static int mem_read(BIO *b, char *out, int outl)
     BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)b->ptr;
     BUF_MEM *bm = bbm->readp;
 
+    if (b->flags & BIO_FLAGS_MEM_RDONLY) {
+        bm = bbm->buf;
+    }
     BIO_clear_retry_flags(b);
     ret = (outl >= 0 && (size_t)outl > bm->length) ? (int)bm->length : outl;
     if ((out != NULL) && (ret > 0)) {
@@ -241,29 +249,36 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)b->ptr;
     BUF_MEM *bm;
 
+    if (b->flags & BIO_FLAGS_MEM_RDONLY)
+        bm = bbm->buf;
+    else
+        bm = bbm->readp;
+
     switch (cmd) {
     case BIO_CTRL_RESET:
         bm = bbm->buf;
         if (bm->data != NULL) {
-            /* For read only case reset to the start again */
-            if ((b->flags & BIO_FLAGS_MEM_RDONLY) || (b->flags & BIO_FLAGS_NONCLEAR_RST)) {
-                bm->length = bm->max;
+            /* For read only case just reset to the start again */
+            if (!(b->flags & BIO_FLAGS_MEM_RDONLY)) {
+                if (b->flags & BIO_FLAGS_NONCLEAR_RST) {
+                    bm->length = bm->max;
+                } else {
+                    memset(bm->data, 0, bm->max);
+                    bm->length = 0;
+                }
+                *bbm->readp = *bbm->buf;
             } else {
-                memset(bm->data, 0, bm->max);
-                bm->length = 0;
+                *bbm->buf = *bbm->readp;
             }
-            *bbm->readp = *bbm->buf;
         }
         break;
     case BIO_CTRL_EOF:
-        bm = bbm->readp;
         ret = (long)(bm->length == 0);
         break;
     case BIO_C_SET_BUF_MEM_EOF_RETURN:
         b->num = (int)num;
         break;
     case BIO_CTRL_INFO:
-        bm = bbm->readp;
         ret = (long)bm->length;
         if (ptr != NULL) {
             pptr = (char **)ptr;
@@ -278,8 +293,9 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_C_GET_BUF_MEM_PTR:
         if (ptr != NULL) {
-            mem_buf_sync(b);
-            bm = bbm->readp;
+            if (!(b->flags & BIO_FLAGS_MEM_RDONLY))
+                mem_buf_sync(b);
+            bm = bbm->buf;
             pptr = (char **)ptr;
             *pptr = (char *)bm;
         }
@@ -294,7 +310,6 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0L;
         break;
     case BIO_CTRL_PENDING:
-        bm = bbm->readp;
         ret = (long)bm->length;
         break;
     case BIO_CTRL_DUP:
@@ -318,6 +333,9 @@ static int mem_gets(BIO *bp, char *buf, int size)
     BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)bp->ptr;
     BUF_MEM *bm = bbm->readp;
 
+    if (bp->flags & BIO_FLAGS_MEM_RDONLY) {
+        bm = bbm->buf;
+    }
     BIO_clear_retry_flags(bp);
     j = bm->length;
     if ((size - 1) < j)

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -197,9 +197,8 @@ static int mem_read(BIO *b, char *out, int outl)
     BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)b->ptr;
     BUF_MEM *bm = bbm->readp;
 
-    if (b->flags & BIO_FLAGS_MEM_RDONLY) {
+    if (b->flags & BIO_FLAGS_MEM_RDONLY)
         bm = bbm->buf;
-    }
     BIO_clear_retry_flags(b);
     ret = (outl >= 0 && (size_t)outl > bm->length) ? (int)bm->length : outl;
     if ((out != NULL) && (ret > 0)) {
@@ -334,9 +333,8 @@ static int mem_gets(BIO *bp, char *buf, int size)
     BIO_BUF_MEM *bbm = (BIO_BUF_MEM *)bp->ptr;
     BUF_MEM *bm = bbm->readp;
 
-    if (bp->flags & BIO_FLAGS_MEM_RDONLY) {
+    if (bp->flags & BIO_FLAGS_MEM_RDONLY)
         bm = bbm->buf;
-    }
     BIO_clear_retry_flags(bp);
     j = bm->length;
     if ((size - 1) < j)

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -259,7 +259,6 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_RESET:
         bm = bbm->buf;
         if (bm->data != NULL) {
-            /* For read only case just reset to the start again */
             if (!(b->flags & BIO_FLAGS_MEM_RDONLY)) {
                 if (b->flags & BIO_FLAGS_NONCLEAR_RST) {
                     bm->length = bm->max;
@@ -269,6 +268,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
                 }
                 *bbm->readp = *bbm->buf;
             } else {
+                /* For read only case just reset to the start again */
                 *bbm->buf = *bbm->readp;
             }
         }

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -88,6 +88,22 @@ a buffering BIO to the chain will speed up the process.
 Calling BIO_set_mem_buf() on a BIO created with BIO_new_secmem() will
 give undefined results, including perhaps a program crash.
 
+Switching the memory BIO from read write to read only is not supported and
+can give undefined results including a program crash. There are two notable
+exceptions to the rule. The first one is to assign a static memory buffer
+immediately after BIO creation and set the BIO as read only.
+
+The other supported sequence is to start with read write BIO then temporarily
+switch it to read only and call BIO_reset() on the read only BIO immediately
+before switching it back to read write. Before the BIO is freed it must be
+switched back to the read write mode.
+
+Calling BIO_get_mem_ptr() on read only BIO will return a BUF_MEM that
+contains only the remaining data to be read. If the close status of the
+BIO is set to BIO_NOCLOSE, before freeing the BUF_MEM the data pointer
+in it must be set to NULL as the data pointer does not point to an
+allocated memory.
+
 =head1 BUGS
 
 There should be an option to set the maximum size of a memory BIO.

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -145,6 +145,43 @@ finish:
     return ok;
 }
 
+static int test_bio_rdwr_rdonly(void)
+{
+    int ok = 0;
+    BIO *bio = NULL;
+    char data[16];
+
+    bio = BIO_new(BIO_s_mem());
+    if (!TEST_ptr(bio))
+        goto finish;
+    if (!TEST_int_eq(BIO_puts(bio, "Hello World\n"), 12))
+        goto finish;
+
+    BIO_set_flags(bio, BIO_FLAGS_MEM_RDONLY);
+    if (!TEST_int_eq(BIO_read(bio, data, 16), 12))
+        goto finish;
+    if (!TEST_mem_eq(data, 12, "Hello World\n", 12))
+        goto finish;
+    if (!TEST_int_gt(BIO_reset(bio), 0))
+        goto finish;
+
+    BIO_clear_flags(bio, BIO_FLAGS_MEM_RDONLY);
+    if (!TEST_int_eq(BIO_puts(bio, "Hi!\n"), 4))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 16), 16))
+        goto finish;
+
+    if (!TEST_mem_eq(data, 16, "Hello World\nHi!\n", 16))
+        goto finish;
+
+    ok = 1;
+
+finish:
+    BIO_free(bio);
+    return ok;
+}
+
+
 int global_init(void)
 {
     CRYPTO_set_mem_debug(1);
@@ -158,5 +195,6 @@ int setup_tests(void)
     ADD_TEST(test_bio_get_mem);
     ADD_TEST(test_bio_new_mem_buf);
     ADD_TEST(test_bio_rdonly_mem_buf);
+    ADD_TEST(test_bio_rdwr_rdonly);
     return 1;
 }

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -119,7 +119,7 @@ static int test_bio_rdonly_mem_buf(void)
         goto finish;
     if (!TEST_int_gt(BIO_get_mem_ptr(bio, &bufmem), 0))
         goto finish;
-    BIO_set_close(bio, BIO_NOCLOSE);
+    (void)BIO_set_close(bio, BIO_NOCLOSE);
 
     bio2 = BIO_new(BIO_s_mem());
     if (!TEST_ptr(bio2))

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -18,25 +18,53 @@ static int test_bio_memleak(void)
     int ok = 0;
     BIO *bio;
     BUF_MEM bufmem;
-    const char *str = "BIO test\n";
+    static const char str[] = "BIO test\n";
     char buf[100];
 
     bio = BIO_new(BIO_s_mem());
-    if (bio == NULL)
+    if (!TEST_ptr(bio))
         goto finish;
-    bufmem.length = strlen(str) + 1;
+    bufmem.length = sizeof(str);
     bufmem.data = (char *) str;
     bufmem.max = bufmem.length;
     BIO_set_mem_buf(bio, &bufmem, BIO_NOCLOSE);
     BIO_set_flags(bio, BIO_FLAGS_MEM_RDONLY);
-
-    if (BIO_read(bio, buf, sizeof(buf)) <= 0)
-	goto finish;
-
-    ok = strcmp(buf, str) == 0;
+    if (!TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(str)))
+        goto finish;
+    if (!TEST_mem_eq(buf, sizeof(str), str, sizeof(str)))
+        goto finish;
+    ok = 1;
 
 finish:
     BIO_free(bio);
+    return ok;
+}
+
+static int test_bio_get_mem(void)
+{
+    int ok = 0;
+    BIO *bio = NULL;
+    BUF_MEM *bufmem = NULL;
+
+    bio = BIO_new(BIO_s_mem());
+    if (!TEST_ptr(bio))
+        goto finish;
+    if (!TEST_int_eq(BIO_puts(bio, "Hello World\n"), 12))
+        goto finish;
+    BIO_get_mem_ptr(bio, &bufmem);
+    if (!TEST_ptr(bufmem))
+        goto finish;
+    if (!TEST_int_gt(BIO_set_close(bio, BIO_NOCLOSE), 0))
+        goto finish;
+    BIO_free(bio);
+    bio = NULL;
+    if (!TEST_mem_eq(bufmem->data, bufmem->length, "Hello World\n", 12))
+        goto finish;
+    ok = 1;
+
+finish:
+    BIO_free(bio);
+    BUF_MEM_free(bufmem);
     return ok;
 }
 
@@ -50,5 +78,6 @@ int global_init(void)
 int setup_tests(void)
 {
     ADD_TEST(test_bio_memleak);
+    ADD_TEST(test_bio_get_mem);
     return 1;
 }

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -124,7 +124,7 @@ static int test_bio_rdonly_mem_buf(void)
     bio2 = BIO_new(BIO_s_mem());
     if (!TEST_ptr(bio2))
         goto finish;
-    BIO_set_mem_buf(bio2, bufmem, BIO_NOCLOSE);
+    BIO_set_mem_buf(bio2, bufmem, BIO_CLOSE);
     BIO_set_flags(bio2, BIO_FLAGS_MEM_RDONLY);
 
     if (!TEST_int_eq(BIO_read(bio2, data, 16), 7))

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -68,6 +68,83 @@ finish:
     return ok;
 }
 
+static int test_bio_new_mem_buf(void)
+{
+    int ok = 0;
+    BIO *bio;
+    BUF_MEM *bufmem;
+    char data[16];
+
+    bio = BIO_new_mem_buf("Hello World\n", 12);
+    if (!TEST_ptr(bio))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 5), 5))
+        goto finish;
+    if (!TEST_mem_eq(data, 5, "Hello", 5))
+        goto finish;
+    if (!TEST_int_gt(BIO_get_mem_ptr(bio, &bufmem), 0))
+        goto finish;
+    if (!TEST_int_lt(BIO_write(bio, "test", 4), 0))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 16), 7))
+        goto finish;
+    if (!TEST_mem_eq(data, 7, " World\n", 7))
+        goto finish;
+    if (!TEST_int_gt(BIO_reset(bio), 0))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 16), 12))
+        goto finish;
+    if (!TEST_mem_eq(data, 12, "Hello World\n", 12))
+        goto finish;
+    ok = 1;
+
+finish:
+    BIO_free(bio);
+    return ok;
+}
+
+static int test_bio_rdonly_mem_buf(void)
+{
+    int ok = 0;
+    BIO *bio, *bio2 = NULL;
+    BUF_MEM *bufmem;
+    char data[16];
+
+    bio = BIO_new_mem_buf("Hello World\n", 12);
+    if (!TEST_ptr(bio))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio, data, 5), 5))
+        goto finish;
+    if (!TEST_mem_eq(data, 5, "Hello", 5))
+        goto finish;
+    if (!TEST_int_gt(BIO_get_mem_ptr(bio, &bufmem), 0))
+        goto finish;
+    BIO_set_close(bio, BIO_NOCLOSE);
+
+    bio2 = BIO_new(BIO_s_mem());
+    if (!TEST_ptr(bio2))
+        goto finish;
+    BIO_set_mem_buf(bio2, bufmem, BIO_NOCLOSE);
+    BIO_set_flags(bio2, BIO_FLAGS_MEM_RDONLY);
+
+    if (!TEST_int_eq(BIO_read(bio2, data, 16), 7))
+        goto finish;
+    if (!TEST_mem_eq(data, 7, " World\n", 7))
+        goto finish;
+    if (!TEST_int_gt(BIO_reset(bio2), 0))
+        goto finish;
+    if (!TEST_int_eq(BIO_read(bio2, data, 16), 7))
+        goto finish;
+    if (!TEST_mem_eq(data, 7, " World\n", 7))
+        goto finish;
+    ok = 1;
+
+finish:
+    BIO_free(bio);
+    BIO_free(bio2);
+    return ok;
+}
+
 int global_init(void)
 {
     CRYPTO_set_mem_debug(1);
@@ -79,5 +156,7 @@ int setup_tests(void)
 {
     ADD_TEST(test_bio_memleak);
     ADD_TEST(test_bio_get_mem);
+    ADD_TEST(test_bio_new_mem_buf);
+    ADD_TEST(test_bio_rdonly_mem_buf);
     return 1;
 }


### PR DESCRIPTION
This is another attempt at fix for BIO_get_mem_ptr and related regressions.

Fixes #8375
In this patch the readp and buf use is modified for read only BIOs - the readp is used
just for storing the original state for BIO_reset() handling.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
