### PR TITLE
Skip the correct number of tests if SM2 is disabled

### DIFF
--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -375,7 +375,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip "SM2 is not supported by this OpenSSL build", 1
+    skip "SM2 is not supported by this OpenSSL build", 2
 	      if disabled("sm2");
 
    # Test '-sm2-id' and '-sm2-hex-id'  option


### PR DESCRIPTION
Fixes no-sm2 (and also no-sm3 and no-ec)

