### PR TITLE
Fixes #8645: s_client starttls bug handling multiline reply

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2277,7 +2277,7 @@ int s_client_main(int argc, char **argv)
             do {
                 mbuf_len = BIO_gets(fbio, mbuf, BUFSIZZ);
             }
-            while (mbuf_len > 3 && mbuf[3] == '-');
+            while (mbuf_len > 3 && (!isdigit(mbuf[0]) || !isdigit(mbuf[1]) || !isdigit(mbuf[2]) || mbuf[3] != ' '));
             (void)BIO_flush(fbio);
             BIO_pop(fbio);
             BIO_free(fbio);


### PR DESCRIPTION
Fixes #8645: s_client starttls bug handling multiline reply

No documentation has changed.
No tests added.