### PR TITLE
Correct the documentation about SSL_CIPHER_description()

### DIFF
--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -124,7 +124,10 @@ Textual representation of the cipher name.
 
 =item <protocol version>
 
-Protocol version, such as B<TLSv1.2>, when the cipher was first defined.
+The minimum protocol version that the ciphersuite supports, such as B<TLSv1.2>.
+Note that this is not always the same as the protocol version in which the
+ciphersuite was first defined because some ciphersuites are backwards compatible
+with earlier protocol versions.
 
 =item Kx=<key exchange>
 


### PR DESCRIPTION
There are some ciphersuites that were introduced in TLSv1.0/TLSv1.1 but
are backwards compatible with SSLv3.

Fixes #8655

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
