### PR TITLE
DRBG reseed from parent with lower security strength.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,8 +9,12 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Add prediction resistance to the DRBG reseeding process.
+     [Paul Dale]
+
   *) Limit the number of blocks in a data unit for AES-XTS to 2^20 as
      mandated by IEEE Std 1619-2018.
+     [Paul Dale]
 
   *) Added newline escaping functionality to a filename when using openssl dgst.
      This output format is to replicate the output format found in the '*sum'

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -283,20 +283,6 @@ static RAND_DRBG *rand_drbg_new(int secure,
     if (RAND_DRBG_set(drbg, type, flags) == 0)
         goto err;
 
-    if (parent != NULL) {
-        rand_drbg_lock(parent);
-        if (drbg->strength > parent->strength) {
-            /*
-             * We currently don't support the algorithm from NIST SP 800-90C
-             * 10.1.2 to use a weaker DRBG as source
-             */
-            rand_drbg_unlock(parent);
-            RANDerr(RAND_F_RAND_DRBG_NEW, RAND_R_PARENT_STRENGTH_TOO_WEAK);
-            goto err;
-        }
-        rand_drbg_unlock(parent);
-    }
-
     return drbg;
 
  err:

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -152,7 +152,7 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
     } else {
         pool = rand_pool_new(entropy, min_len, max_len);
         if (pool == NULL)
-            return 0;
+            goto err;
     }
 
     if (drbg->parent != NULL) {
@@ -183,6 +183,7 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
         }
 
     } else {
+#if defined(OPENSSL_RAND_SEED_NONE)
         if (prediction_resistance) {
             /*
              * We don't have any entropy sources that comply with the NIST
@@ -193,6 +194,7 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
                     RAND_R_PREDICTION_RESISTANCE_NOT_SUPPORTED);
             goto err;
         }
+#endif
 
         /* Get entropy by polling system entropy sources. */
         entropy_available = rand_pool_acquire_entropy(pool);

--- a/doc/man3/RAND_DRBG_generate.pod
+++ b/doc/man3/RAND_DRBG_generate.pod
@@ -29,7 +29,9 @@ number of generate requests (I<reseed interval>) or the maximum timespan
 (I<reseed time interval>) since its last seeding have been reached.
 If this is the case, the DRBG reseeds automatically.
 Additionally, an immediate reseeding can be requested by setting the
-B<prediction_resistance> flag to 1. See NOTES section for more details.
+B<prediction_resistance> flag to 1.
+Requesting prediction resistance is a relative expensive operation.
+See NOTES section for more details.
 
 The caller can optionally provide additional data to be used for reseeding
 by passing a pointer B<adin> to a buffer of length B<adinlen>.
@@ -59,15 +61,17 @@ If necessary, they can be changed using L<RAND_DRBG_set_reseed_interval(3)>
 and L<RAND_DRBG_set_reseed_time_interval(3)>, respectively.
 
 A request for prediction resistance can only be satisfied by pulling fresh
-entropy from one of the approved entropy sources listed in section 5.5.2 of
-[NIST SP 800-90C].
-Since the default DRBG implementation does not have access to such an approved
-entropy source, a request for prediction resistance will always fail.
-In other words, prediction resistance is currently not supported yet by the DRBG.
+entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
+Some random seed sources are not live entropy sources and a request
+for prediction resistance with such a source configured will always fail.
+For example, configuring with I<--with-rand-seed=none> will ensure that
+prediction resistance always fails.
 
 =head1 HISTORY
 
 The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
+Prediction resistance is supported from OpenSSL 3.0.0.
 
 =head1 SEE ALSO
 

--- a/doc/man3/RAND_DRBG_reseed.pod
+++ b/doc/man3/RAND_DRBG_reseed.pod
@@ -40,7 +40,7 @@ The additional data can be omitted by setting B<adin> to NULL and B<adinlen>
 to 0.
 An immediate reseeding from a live entropy source can be requested by setting
 the B<prediction_resistance> flag to 1.
-Requesting prediction resistance is a relative expensive operation.
+Requesting prediction resistance is a relatively expensive operation.
 See NOTES section for more details.
 
 RAND_DRBG_set_reseed_interval()

--- a/doc/man3/RAND_DRBG_reseed.pod
+++ b/doc/man3/RAND_DRBG_reseed.pod
@@ -13,7 +13,8 @@ RAND_DRBG_set_reseed_defaults
  #include <openssl/rand_drbg.h>
 
  int RAND_DRBG_reseed(RAND_DRBG *drbg,
-                      const unsigned char *adin, size_t adinlen);
+                      const unsigned char *adin, size_t adinlen,
+                      int prediction_resistance);
 
  int RAND_DRBG_set_reseed_interval(RAND_DRBG *drbg,
                                    unsigned int interval);
@@ -37,6 +38,10 @@ and mixing in the specified additional data provided in the buffer B<adin>
 of length B<adinlen>.
 The additional data can be omitted by setting B<adin> to NULL and B<adinlen>
 to 0.
+An immediate reseeding from a live entropy source can be requested by setting
+the B<prediction_resistance> flag to 1.
+Requesting prediction resistance is a relative expensive operation.
+See NOTES section for more details.
 
 RAND_DRBG_set_reseed_interval()
 sets the reseed interval of the B<drbg>, which is the maximum allowed number
@@ -88,9 +93,18 @@ To ensure that they are applied to the global and thread-local DRBG instances
 RAND_DRBG_set_reseed_defaults() before creating any thread and before calling any
  cryptographic routines that obtain random data directly or indirectly.
 
+A request for prediction resistance can only be satisfied by pulling fresh
+entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
+Some random seed sources are not live entropy sources and a request
+for prediction resistance with such a source configured will always fail.
+For example, configuring with I<--with-rand-seed=none> will ensure that
+prediction resistance always fails.
+
 =head1 HISTORY
 
 The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
+Prediction resistance is supported from OpenSSL 3.0.0.
 
 =head1 SEE ALSO
 

--- a/doc/man3/RAND_DRBG_set_callbacks.pod
+++ b/doc/man3/RAND_DRBG_set_callbacks.pod
@@ -104,12 +104,11 @@ contents safely before freeing it, in order not to leave sensitive information
 about the DRBG's state in memory.
 
 A request for prediction resistance can only be satisfied by pulling fresh
-entropy from one of the approved entropy sources listed in section 5.5.2 of
-[NIST SP 800-90C].
-Since the default implementation of the get_entropy callback does not have access
-to such an approved entropy source, a request for prediction resistance will
-always fail.
-In other words, prediction resistance is currently not supported yet by the DRBG.
+entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
+Some random seed sources are not live entropy sources and a request
+for prediction resistance with such a source configured will always fail.
+For example, configuring with I<--with-rand-seed=none> will ensure that
+prediction resistance always fails.
 
 The derivation function is disabled during initialization by calling the
 RAND_DRBG_set() function with the RAND_DRBG_FLAG_CTR_NO_DF flag.

--- a/doc/man7/RAND_DRBG.pod
+++ b/doc/man7/RAND_DRBG.pod
@@ -192,9 +192,12 @@ I<prediction resistance> parameter to 1 when calling L<RAND_DRBG_generate(3)>.
 The document [NIST SP 800-90C] describes prediction resistance requests
 in detail and imposes strict conditions on the entropy sources that are
 approved for providing prediction resistance.
-Since the default DRBG implementation does not have access to such an approved
-entropy source, a request for prediction resistance will currently always fail.
-In other words, prediction resistance is currently not supported yet by the DRBG.
+A request for prediction resistance can only be satisfied by pulling fresh
+entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
+Some random seed sources are not live entropy sources and a request
+for prediction resistance with such a source configured will always fail.
+For example, configuring with I<--with-rand-seed=none> will ensure that
+prediction resistance always fails.
 
 
 For the three shared DRBGs (and only for these) there is another way to


### PR DESCRIPTION
This implements the algorithm in NIST SP 800-90C section 10.1.2 _"Accessing a Source DRBG with Prediction Resistance to Obtain any Security Strength"_.  Apart from step 6.  This permits a DRBG to be seeded from a parent DRBG of lower security strength so long as the parent has access to a live entropy source.

The missing step 6 runs the appropriate generating function over the collected seed material if what was collected was too large.  The size limit used is (at least) 2³¹-1 bytes which is significantly more than we'll ever collect even under our worst quality assumptions.


- [ ] documentation is added or updated
- [x] tests are added or updated

Based upon #8647 
Fixes #7118 
