### PR TITLE
Added Test::ok_nofips method. 

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -14,7 +14,7 @@ use Test::More 0.96;
 
 use Exporter;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
-$VERSION = "0.8";
+$VERSION = "1.0";
 @ISA = qw(Exporter);
 @EXPORT = (@Test::More::EXPORT, qw(setup run indir cmd app fuzz test
                                    perlapp perltest subtest));
@@ -834,27 +834,41 @@ sub openssl_versions {
 
 =over 4
 
-=item B<ok_nofips test>
+=item B<ok_nofips EXPR, TEST_NAME>
 
-Returns ok(test) if the environment variable FIPS_MODE is undefined,
-otherwise it returns ok(!test). This can be used for ok tests that will
-fail in FIPS mode only.
+C<ok_nofips> is equivalent to using C<ok> when the environment variable
+C<FIPS_MODE> is undefined, otherwise it is equivalent to C<not ok>. This can be
+used for C<ok> tests that must fail when testing a FIPS provider. The parameters
+are the same as used by C<ok> which is an expression EXPR followed by the test
+description TEST_NAME.
 
 An example:
 
-  ok_nofips(run(app(["md5.pl"])));
+  ok_nofips(run(app(["md5.pl"])), "md5 should fail in fips mode");
 
-=item B<is_nofips test>
+=item B<is_nofips EXPR1, EXPR2, TEST_NAME>
 
-Returns is(test) if the environment variable FIPS_MODE is undefined,
-otherwise it returns is(test). This can be used for is tests that will
-fail in FIPS mode only.
+C<is_nofips> is equivalent to using C<is> when the environment variable
+C<FIPS_MODE> is undefined, otherwise it is equivalent to C<isnt>. This can be
+used for C<is> tests that must fail when testing a FIPS provider. The parameters
+are the same as used by C<is> which has 2 arguments EXPR1 and EXPR2 that can be
+compared using eq or ne, followed by a test description TEST_NAME.
 
-=item B<isnt_nofips test>
+An example:
 
-Returns isnt(test) if the environment variable FIPS_MODE is undefined,
-otherwise it returns is(test). This can be used for is tests that will
-pass in FIPS mode only.
+  is_nofips(ultimate_answer(), 42,  "Meaning of Life");
+
+=item B<isnt_nofips EXPR1, EXPR2, TEST_NAME>
+
+C<isnt_nofips> is equivalent to using C<isnt> when the environment variable
+C<FIPS_MODE> is undefined, otherwise it is equivalent to C<is>. This can be
+used for C<isnt> tests that must fail when testing a FIPS provider. The
+parameters are the same as used by C<isnt> which has 2 arguments EXPR1 and EXPR2
+that can be compared using ne or eq, followed by a test description TEST_NAME.
+
+An example:
+
+  isnt_nofips($foo, '',  "Got some foo");
 
 =back
 

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -22,7 +22,8 @@ $VERSION = "0.8";
                                          srctop_dir srctop_file
                                          data_file data_dir
                                          pipe with cmdstr quotify
-                                         openssl_versions));
+                                         openssl_versions
+                                         ok_nofips is_nofips isnt_nofips));
 
 =head1 NAME
 
@@ -831,6 +832,49 @@ sub openssl_versions {
     return @versions;
 }
 
+=over 4
+
+=item B<ok_nofips test>
+
+Returns ok(test) if the environment variable FIPS_MODE is undefined,
+otherwise it returns ok(!test). This can be used for ok tests that will
+fail in FIPS mode only.
+
+An example:
+
+  ok_nofips(run(app(["md5.pl"])));
+
+=item B<is_nofips test>
+
+Returns is(test) if the environment variable FIPS_MODE is undefined,
+otherwise it returns is(test). This can be used for is tests that will
+fail in FIPS mode only.
+
+=item B<isnt_nofips test>
+
+Returns isnt(test) if the environment variable FIPS_MODE is undefined,
+otherwise it returns is(test). This can be used for is tests that will
+pass in FIPS mode only.
+
+=back
+
+=cut
+
+sub ok_nofips {
+    return ok(!$_[0], @_[1..$#_]) if defined $ENV{FIPS_MODE};
+    return ok($_[0], @_[1..$#_]);
+}
+
+sub is_nofips {
+    return isnt($_[0], $_[1], @_[2..$#_]) if defined $ENV{FIPS_MODE};
+    return is($_[0], $_[1], @_[2..$#_]);
+}
+
+sub isnt_nofips {
+    return is($_[0], $_[1], @_[2..$#_]) if defined $ENV{FIPS_MODE};
+    return isnt($_[0], $_[1], @_[2..$#_]);
+}
+
 ######################################################################
 # private functions.  These are never exported.
 
@@ -860,6 +904,12 @@ are located.  Defaults to C<$TOP/test> (adapted to the operating system).
 
 If defined, it puts testing in a different mode, where a recipe with
 failures will result in a C<BAIL_OUT> at the end of its run.
+
+=item B<FIPS_MODE>
+
+If defined it indicates that the FIPS provider is being tested. Tests may use
+B<ok_nofips>, B<is_nofips> and B<isnt_nofips> to invert test results
+i.e. Some tests may only work in non FIPS mode.
 
 =back
 

--- a/util/perl/OpenSSL/Test/Utils.pm
+++ b/util/perl/OpenSSL/Test/Utils.pm
@@ -1,4 +1,4 @@
-# Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -53,6 +53,7 @@ STRING is "tls", or for all the available DTLS versions if STRING is
 returned list can be used with B<alldisabled> and B<anydisabled>.
 
 =item B<alldisabled ARRAY>
+
 =item B<anydisabled ARRAY>
 
 In an array context returns an array with each element set to 1 if the
@@ -67,6 +68,7 @@ disabled.
 Returns an item from the %config hash in \$TOP/configdata.pm.
 
 =item B<have_IPv4>
+
 =item B<have_IPv6>
 
 Return true if IPv4 / IPv6 is possible to use on the current system.
@@ -224,7 +226,6 @@ sub have_IPv6 {
     }
     return $have_IPv6;
 }
-
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Used to check that a test fails in fips mode
i.e. ok_nofips(run(...)))

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
