### PR TITLE
RSA FIPS test fixes

### DIFF
--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -7,6 +7,8 @@ SOURCE[../../libcrypto]=\
         bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c \
         bn_depr.c bn_const.c bn_x931p.c bn_intern.c bn_dh.c bn_srp.c \
         bn_rsa_fips186_4.c
+SOURCE[../../providers/fips]=\
+        bn_lib.c
 INCLUDE[../../libcrypto]=../../crypto/include
 
 INCLUDE[bn_exp.o]=..

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -348,7 +348,6 @@ OSSL_PARAM OSSL_PARAM_construct_size_t(const char *key, size_t *buf,
     return ossl_param_construct(key, OSSL_PARAM_UNSIGNED_INTEGER, buf,
                                 sizeof(size_t), rsize); }
 
-#ifndef FIPS_MODE
 /*
  * TODO(3.0): Make this available in FIPS mode.
  *
@@ -398,7 +397,6 @@ OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
     return ossl_param_construct(key, OSSL_PARAM_UNSIGNED_INTEGER,
                                 buf, bsize, rsize);
 }
-#endif
 
 int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
 {

--- a/crypto/rsa/rsa_chk.c
+++ b/crypto/rsa/rsa_chk.c
@@ -25,11 +25,9 @@ int RSA_check_key(const RSA *key)
 int RSA_check_key_ex(const RSA *key, BN_GENCB *cb)
 {
 #ifdef FIPS_MODE
-    if (!(rsa_sp800_56b_check_public(key)
-            && rsa_sp800_56b_check_private(key)
-            && rsa_sp800_56b_check_keypair(key, NULL, -1, RSA_bits(key))
-        return 0;
-
+    return rsa_sp800_56b_check_public(key)
+           && rsa_sp800_56b_check_private(key)
+           && rsa_sp800_56b_check_keypair(key, NULL, -1, RSA_bits(key));
 #else
     BIGNUM *i, *j, *k, *l, *m;
     BN_CTX *ctx;

--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -56,7 +56,12 @@ static int pkey_rsa_init(EVP_PKEY_CTX *ctx)
 
     if (rctx == NULL)
         return 0;
+#ifdef FIPS_MODE
+    rctx->nbits = 2048;
+#else
     rctx->nbits = 1024;
+#endif /* FIPS_MODE */
+
     rctx->primes = RSA_DEFAULT_PRIME_NUM;
     if (pkey_ctx_is_pss(ctx))
         rctx->pad_mode = RSA_PKCS1_PSS_PADDING;

--- a/crypto/rsa/rsa_sp800_56b_check.c
+++ b/crypto/rsa/rsa_sp800_56b_check.c
@@ -244,13 +244,11 @@ int rsa_sp800_56b_check_public(const RSA *rsa)
 
     /*
      * (Step a): modulus must be 2048 or 3072 (caveat from SP800-56Br1)
-     * NOTE: changed to allow keys >= 2048
+     * NOTE: changed to allow keys >= 2048.
+     * This will be noted in the security policy only.
      */
     nbits = BN_num_bits(rsa->n);
-    if (!rsa_sp800_56b_validate_strength(nbits, -1)) {
-        RSAerr(RSA_F_RSA_SP800_56B_CHECK_PUBLIC, RSA_R_INVALID_KEY_LENGTH);
-        return 0;
-    }
+
     if (!BN_is_odd(rsa->n)) {
         RSAerr(RSA_F_RSA_SP800_56B_CHECK_PUBLIC, RSA_R_INVALID_MODULUS);
         return 0;
@@ -328,9 +326,7 @@ int rsa_sp800_56b_check_keypair(const RSA *rsa, const BIGNUM *efixed,
         RSAerr(RSA_F_RSA_SP800_56B_CHECK_KEYPAIR, RSA_R_INVALID_REQUEST);
         return 0;
     }
-    /* (Step 1): Check Ranges */
-    if (!rsa_sp800_56b_validate_strength(nbits, strength))
-        return 0;
+    /* (Step 1): Check Ranges  - this is noted in the security policy only. */
 
     /* If the exponent is known */
     if (efixed != NULL) {

--- a/providers/fips/build.info
+++ b/providers/fips/build.info
@@ -1,2 +1,2 @@
 
-SOURCE[../fips]=fipsprov.c
+SOURCE[../fips]=fipsprov.c stubs.c

--- a/providers/fips/stubs.c
+++ b/providers/fips/stubs.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <stddef.h>
+#include <openssl/ossl_typ.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+
+void ERR_put_error(int lib, int func, int reason, const char *file, int line)
+{
+}
+
+void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
+{
+    return NULL;
+}
+
+void CRYPTO_secure_free(void *ptr, const char *file, int line)
+{
+}
+
+int BN_mod_mul_montgomery(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
+                          BN_MONT_CTX *mont, BN_CTX *ctx)
+{
+    return 0;
+}

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips/;
 use OpenSSL::Test::Utils;
 
 setup("test_genrsa");
@@ -44,9 +44,9 @@ $good++ if $good == $bad;
 $good = 2 ** $good;
 note "Found lowest allowed amount of bits to be $good";
 
-ok(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', $good ])),
-   "genrsa -3 $good");
-ok(run(app([ 'openssl', 'rsa', '-check', '-in', 'genrsatest.pem', '-noout' ])),
+ok_nofips(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', $good ])),
+          "genrsa -3 $good");
+ok_nofips(run(app([ 'openssl', 'rsa', '-check', '-in', 'genrsatest.pem', '-noout' ])),
    "rsa -check");
 ok(run(app([ 'openssl', 'genrsa', '-f4', '-out', 'genrsatest.pem', $good ])),
    "genrsa -f4 $good");

--- a/test/recipes/15-test_mp_rsa.t
+++ b/test/recipes/15-test_mp_rsa.t
@@ -12,14 +12,14 @@ use strict;
 use warnings;
 
 use File::Spec;
-use OpenSSL::Test qw/:DEFAULT data_file/;
+use OpenSSL::Test qw/:DEFAULT data_file ok_nofips/;
 use OpenSSL::Test::Utils;
 
 setup("test_mp_rsa");
 
 plan tests => 31;
 
-ok(run(test(["rsa_mp_test"])), "running rsa multi prime test");
+ok_nofips(run(test(["rsa_mp_test"])), "running rsa multi prime test");
 
 my $cleartext = data_file("plain_text");
 
@@ -55,33 +55,35 @@ sub run_mp_tests {
         my $name = ($evp ? "evp" : "") . "${bits}p${primes}";
 
         if ($evp) {
-            ok(run(app([ 'openssl', 'genpkey', '-out', 'rsamptest.pem',
-                         '-algorithm', 'RSA', '-pkeyopt', "rsa_keygen_primes:$primes",
-                         '-pkeyopt', "rsa_keygen_bits:$bits"])), "genrsa $name");
+            ok_nofips(run(app([ 'openssl', 'genpkey', '-out', 'rsamptest.pem',
+                                '-algorithm', 'RSA',
+                                '-pkeyopt', "rsa_keygen_primes:$primes",
+                                '-pkeyopt', "rsa_keygen_bits:$bits"])),
+               "genrsa $name");
         } else {
-            ok(run(app([ 'openssl', 'genrsa', '-out', 'rsamptest.pem',
-                         '-primes', $primes, $bits])), "genrsa $name");
+            ok_nofips(run(app([ 'openssl', 'genrsa', '-out', 'rsamptest.pem',
+                                '-primes', $primes, $bits])), "genrsa $name");
         }
 
-        ok(run(app([ 'openssl', 'rsa', '-check', '-in', 'rsamptest.pem',
-                     '-noout'])), "rsa -check $name");
+        ok_nofips(run(app([ 'openssl', 'rsa', '-check', '-in', 'rsamptest.pem',
+                            '-noout'])), "rsa -check $name");
         if ($evp) {
-            ok(run(app([ 'openssl', 'pkeyutl', '-inkey', 'rsamptest.pem',
-                         '-encrypt', '-in', $cleartext,
-                         '-out', 'rsamptest.enc' ])), "rsa $name encrypt");
-            ok(run(app([ 'openssl', 'pkeyutl', '-inkey', 'rsamptest.pem',
-                         '-decrypt', '-in', 'rsamptest.enc',
-                         '-out', 'rsamptest.dec' ])), "rsa $name decrypt");
+            ok_nofips(run(app([ 'openssl', 'pkeyutl', '-inkey', 'rsamptest.pem',
+                                '-encrypt', '-in', $cleartext,
+                                '-out', 'rsamptest.enc' ])), "rsa $name encrypt");
+            ok_nofips(run(app([ 'openssl', 'pkeyutl', '-inkey', 'rsamptest.pem',
+                                '-decrypt', '-in', 'rsamptest.enc',
+                                '-out', 'rsamptest.dec' ])), "rsa $name decrypt");
         } else {
-            ok(run(app([ 'openssl', 'rsautl', '-inkey', 'rsamptest.pem',
-                         '-encrypt', '-in', $cleartext,
-                         '-out', 'rsamptest.enc' ])), "rsa $name encrypt");
-            ok(run(app([ 'openssl', 'rsautl', '-inkey', 'rsamptest.pem',
-                         '-decrypt', '-in', 'rsamptest.enc',
-                         '-out', 'rsamptest.dec' ])), "rsa $name decrypt");
+            ok_nofips(run(app([ 'openssl', 'rsautl', '-inkey', 'rsamptest.pem',
+                                '-encrypt', '-in', $cleartext,
+                                '-out', 'rsamptest.enc' ])), "rsa $name encrypt");
+            ok_nofips(run(app([ 'openssl', 'rsautl', '-inkey', 'rsamptest.pem',
+                                '-decrypt', '-in', 'rsamptest.enc',
+                                '-out', 'rsamptest.dec' ])), "rsa $name decrypt");
         }
 
-        ok(check_msg(), "rsa $name check result");
+        ok_nofips(check_msg(), "rsa $name check result");
 
         # clean up temp files
         unlink 'rsamptest.pem';

--- a/test/rsa_sp800_56b_test.c
+++ b/test/rsa_sp800_56b_test.c
@@ -461,14 +461,9 @@ static int test_invalid_keypair(void)
         BN_free(d);
         goto end;
     }
-          /* bad strength/key size */
-    ret = TEST_false(rsa_sp800_56b_check_keypair(key, NULL, 100, 2048))
-          && TEST_false(rsa_sp800_56b_check_keypair(key, NULL, 112, 1024))
-          && TEST_false(rsa_sp800_56b_check_keypair(key, NULL, 128, 2048))
-          && TEST_false(rsa_sp800_56b_check_keypair(key, NULL, 140, 3072))
-          /* mismatching exponent */
-          && TEST_false(rsa_sp800_56b_check_keypair(key, BN_value_one(), -1,
-                        2048))
+
+    /* mismatching exponent */
+    ret = TEST_false(rsa_sp800_56b_check_keypair(key, BN_value_one(), -1, 2048))
           /* bad exponent */
           && TEST_true(BN_add_word(e, 1))
           && TEST_false(rsa_sp800_56b_check_keypair(key, NULL, -1,


### PR DESCRIPTION
All rsa tests should PASS in FIPS_MODE now. (i.e build with option -DFIPS_MODE=1, and then set the environment variable before running the tests).
removed the strength/keylength checks from the rsa check() methods
(the keysizes will be stated in the security policy)

depends on https://github.com/openssl/openssl/pull/8661

FIPS_MODE was no longer linking due to an #ifdef in params.c that did not want to pull in the entire BIGNUM lib and all its dependencies. The workaround for now was to pull in bn_lib.c only into the fips provider and to define any unused functions that it references as stubs for now.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
