### PR TITLE
For provider tests, don't define a OPENSSL_NO_ macro

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -613,8 +613,8 @@ IF[{- !$disabled{tests} -}]
     ENDIF
   ENDIF
   IF[{- $disabled{module} || !$target{dso_scheme} -}]
-    DEFINE[provider_test]=OPENSSL_NO_MODULE
-    DEFINE[provider_internal_test]=OPENSSL_NO_MODULE
+    DEFINE[provider_test]=NO_PROVIDER_MODULE
+    DEFINE[provider_internal_test]=NO_PROVIDER_MODULE
   ENDIF
   DEPEND[]=provider_internal_test.conf
   GENERATE[provider_internal_test.conf]=provider_internal_test.conf.in

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -60,7 +60,7 @@ static int test_builtin_provider(void)
         && test_provider(prov, expected_greeting1(name));
 }
 
-#ifndef OPENSSL_NO_MODULE
+#ifndef NO_PROVIDER_MODULE
 static int test_loaded_provider(void)
 {
     const char *name = "p_test";
@@ -89,7 +89,7 @@ static int test_configured_provider(void)
 int setup_tests(void)
 {
     ADD_TEST(test_builtin_provider);
-#ifndef OPENSSL_NO_MODULE
+#ifndef NO_PROVIDER_MODULE
     ADD_TEST(test_loaded_provider);
     ADD_TEST(test_configured_provider);
 #endif

--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -49,7 +49,7 @@ static int test_builtin_provider(void)
         && test_provider(name);
 }
 
-#ifndef OPENSSL_NO_MODULE
+#ifndef NO_PROVIDER_MODULE
 static int test_loaded_provider(void)
 {
     const char *name = "p_test";
@@ -61,7 +61,7 @@ static int test_loaded_provider(void)
 int setup_tests(void)
 {
     ADD_TEST(test_builtin_provider);
-#ifndef OPENSSL_NO_MODULE
+#ifndef NO_PROVIDER_MODULE
     ADD_TEST(test_loaded_provider);
 #endif
     return 1;


### PR DESCRIPTION
Since the macro to indicate if the test provider module is available
is local to the test programs, it's better to use a name that isn't
as easily confused with a library feature disabling macro that one
would expect to find in opensslconf.h.
