### PR TITLE
EVP_*Update: ensure that input NULL with length 0 isn't passed

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -306,6 +306,12 @@ static int evp_EncryptDecryptUpdate(EVP_CIPHER_CTX *ctx,
     bl = ctx->cipher->block_size;
 
     if (ctx->cipher->flags & EVP_CIPH_FLAG_CUSTOM_CIPHER) {
+        /* Prevent accidental "final" call */
+        if (inl <= 0 && in == NULL) {
+            *outl = 0;
+            return inl == 0;
+        }
+
         /* If block size > 1 then the cipher will have to do this check */
         if (bl == 1 && is_partially_overlapping(out, in, cmpl)) {
             EVPerr(EVP_F_EVP_ENCRYPTDECRYPTUPDATE, EVP_R_PARTIALLY_OVERLAPPING);
@@ -458,6 +464,12 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         cmpl = (cmpl + 7) / 8;
 
     if (ctx->cipher->flags & EVP_CIPH_FLAG_CUSTOM_CIPHER) {
+        /* Prevent accidental "final" call */
+        if (inl <= 0 && in == NULL) {
+            *outl = 0;
+            return inl == 0;
+        }
+
         if (b == 1 && is_partially_overlapping(out, in, cmpl)) {
             EVPerr(EVP_F_EVP_DECRYPTUPDATE, EVP_R_PARTIALLY_OVERLAPPING);
             return 0;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -305,13 +305,12 @@ static int evp_EncryptDecryptUpdate(EVP_CIPHER_CTX *ctx,
 
     bl = ctx->cipher->block_size;
 
-    if (ctx->cipher->flags & EVP_CIPH_FLAG_CUSTOM_CIPHER) {
-        /* Prevent accidental "final" call */
-        if (inl <= 0 && in == NULL) {
-            *outl = 0;
-            return inl == 0;
-        }
+    if (inl <= 0) {
+        *outl = 0;
+        return inl == 0;
+    }
 
+    if (ctx->cipher->flags & EVP_CIPH_FLAG_CUSTOM_CIPHER) {
         /* If block size > 1 then the cipher will have to do this check */
         if (bl == 1 && is_partially_overlapping(out, in, cmpl)) {
             EVPerr(EVP_F_EVP_ENCRYPTDECRYPTUPDATE, EVP_R_PARTIALLY_OVERLAPPING);
@@ -326,10 +325,6 @@ static int evp_EncryptDecryptUpdate(EVP_CIPHER_CTX *ctx,
         return 1;
     }
 
-    if (inl <= 0) {
-        *outl = 0;
-        return inl == 0;
-    }
     if (is_partially_overlapping(out + ctx->buf_len, in, cmpl)) {
         EVPerr(EVP_F_EVP_ENCRYPTDECRYPTUPDATE, EVP_R_PARTIALLY_OVERLAPPING);
         return 0;
@@ -463,13 +458,12 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     if (EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_FLAG_LENGTH_BITS))
         cmpl = (cmpl + 7) / 8;
 
-    if (ctx->cipher->flags & EVP_CIPH_FLAG_CUSTOM_CIPHER) {
-        /* Prevent accidental "final" call */
-        if (inl <= 0 && in == NULL) {
-            *outl = 0;
-            return inl == 0;
-        }
+    if (inl <= 0) {
+        *outl = 0;
+        return inl == 0;
+    }
 
+    if (ctx->cipher->flags & EVP_CIPH_FLAG_CUSTOM_CIPHER) {
         if (b == 1 && is_partially_overlapping(out, in, cmpl)) {
             EVPerr(EVP_F_EVP_DECRYPTUPDATE, EVP_R_PARTIALLY_OVERLAPPING);
             return 0;
@@ -482,11 +476,6 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
         } else
             *outl = fix_len;
         return 1;
-    }
-
-    if (inl <= 0) {
-        *outl = 0;
-        return inl == 0;
     }
 
     if (ctx->flags & EVP_CIPH_NO_PADDING)


### PR DESCRIPTION
Even with custom ciphers, the combination in == NULL && inl == 0
should not be passed down to the backend cipher function.  The reason
is that these are the values passed by EVP_*Final, and some of the
backend cipher functions do check for these to see if a "final" call
is made.

Fixes #8675
