### PR TITLE
OPENSSL_init_crypto(): check config return code correctly

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -670,7 +670,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         ret = RUN_ONCE(&config, ossl_init_config);
         conf_settings = NULL;
         CRYPTO_THREAD_unlock(init_lock);
-        if (!ret)
+        if (ret <= 0)
             return 0;
     }
 


### PR DESCRIPTION
It was assumed that the config functionality returned a boolean.
However, it may return a negative number on error, so we need to take
that into account.
