### PR TITLE
Rename the PROVIDER_CONF trace to CONF

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -14,6 +14,7 @@
 #include "internal/conf.h"
 #include "internal/dso.h"
 #include <openssl/x509.h>
+#include <openssl/trace.h>
 
 #define DSO_mod_init_name "OPENSSL_init"
 #define DSO_mod_finish_name "OPENSSL_finish"
@@ -92,6 +93,7 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
         return 1;
     }
 
+    OSSL_TRACE1(CONF, "Configuration in section %s\n", vsection);
     values = NCONF_get_section(cnf, vsection);
 
     if (!values)
@@ -100,6 +102,8 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
     for (i = 0; i < sk_CONF_VALUE_num(values); i++) {
         vl = sk_CONF_VALUE_value(values, i);
         ret = module_run(cnf, vl->name, vl->value, flags);
+        OSSL_TRACE3(CONF, "Running module %s (%s) returned %d\n",
+                    vl->name, vl->value, ret);
         if (ret <= 0)
             if (!(flags & CONF_MFLAGS_IGNORE_ERRORS))
                 return ret;

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -49,7 +49,7 @@ static int int_engine_configure(const char *name, const char *value, const CONF 
     int soft = 0;
 
     name = skip_dot(name);
-    OSSL_TRACE1(ENGINE_CONF, "Configuring engine %s\n", name);
+    OSSL_TRACE1(CONF, "Configuring engine %s\n", name);
     /* Value is a section containing ENGINE commands */
     ecmds = NCONF_get_section(cnf, value);
 
@@ -63,7 +63,7 @@ static int int_engine_configure(const char *name, const char *value, const CONF 
         ecmd = sk_CONF_VALUE_value(ecmds, i);
         ctrlname = skip_dot(ecmd->name);
         ctrlvalue = ecmd->value;
-        OSSL_TRACE2(ENGINE_CONF, "ENGINE conf: doing ctrl(%s,%s)\n",
+        OSSL_TRACE2(CONF, "ENGINE conf: doing ctrl(%s,%s)\n",
                     ctrlname, ctrlvalue);
 
         /* First handle some special pseudo ctrls */
@@ -148,7 +148,7 @@ static int int_engine_module_init(CONF_IMODULE *md, const CONF *cnf)
     STACK_OF(CONF_VALUE) *elist;
     CONF_VALUE *cval;
     int i;
-    OSSL_TRACE2(ENGINE_CONF, "Called engine module: name %s, value %s\n",
+    OSSL_TRACE2(CONF, "Called engine module: name %s, value %s\n",
                 CONF_imodule_get_name(md), CONF_imodule_get_value(md));
     /* Value is a section containing ENGINEs to configure */
     elist = NCONF_get_section(cnf, CONF_imodule_get_value(md));

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -63,7 +63,7 @@ static int int_engine_configure(const char *name, const char *value, const CONF 
         ecmd = sk_CONF_VALUE_value(ecmds, i);
         ctrlname = skip_dot(ecmd->name);
         ctrlvalue = ecmd->value;
-        OSSL_TRACE2(CONF, "ENGINE conf: doing ctrl(%s,%s)\n",
+        OSSL_TRACE2(CONF, "ENGINE: doing ctrl(%s,%s)\n",
                     ctrlname, ctrlvalue);
 
         /* First handle some special pseudo ctrls */

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -41,7 +41,7 @@ static int provider_conf_params(OSSL_PROVIDER *prov,
         char buffer[512];
         size_t buffer_len = 0;
 
-        OSSL_TRACE1(CONF, "PROVIDER conf: start section %s\n", value);
+        OSSL_TRACE1(CONF, "Provider params: start section %s\n", value);
 
         if (name != NULL) {
             OPENSSL_strlcpy(buffer, name, sizeof(buffer));
@@ -60,9 +60,9 @@ static int provider_conf_params(OSSL_PROVIDER *prov,
                 return 0;
         }
 
-        OSSL_TRACE1(CONF, "PROVIDER conf: finish section %s\n", value);
+        OSSL_TRACE1(CONF, "Provider params: finish section %s\n", value);
     } else {
-        OSSL_TRACE2(CONF, "PROVIDER conf: %s = %s\n", name, value);
+        OSSL_TRACE2(CONF, "Provider params: %s = %s\n", name, value);
         ok = ossl_provider_add_parameter(prov, name, value);
     }
 
@@ -96,7 +96,7 @@ static int provider_conf_load(OPENSSL_CTX *libctx, const char *name,
         const char *confname = skip_dot(ecmd->name);
         const char *confvalue = ecmd->value;
 
-        OSSL_TRACE2(CONF, "PROVIDER conf: %s = %s\n",
+        OSSL_TRACE2(CONF, "Provider command: %s = %s\n",
                     confname, confvalue);
 
         /* First handle some special pseudo confs */

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -132,7 +132,7 @@ static const struct trace_category_st trace_categories[] = {
     TRACE_CATEGORY_(PKCS12_DECRYPT),
     TRACE_CATEGORY_(X509V3_POLICY),
     TRACE_CATEGORY_(BN_CTX),
-    TRACE_CATEGORY_(PROVIDER_CONF),
+    TRACE_CATEGORY_(CONF),
 };
 
 const char *OSSL_trace_get_category_name(int num)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -124,7 +124,7 @@ static const struct trace_category_st trace_categories[] = {
     TRACE_CATEGORY_(INIT),
     TRACE_CATEGORY_(TLS),
     TRACE_CATEGORY_(TLS_CIPHER),
-    TRACE_CATEGORY_(ENGINE_CONF),
+    TRACE_CATEGORY_(CONF),
     TRACE_CATEGORY_(ENGINE_TABLE),
     TRACE_CATEGORY_(ENGINE_REF_COUNT),
     TRACE_CATEGORY_(PKCS5V2),
@@ -132,7 +132,6 @@ static const struct trace_category_st trace_categories[] = {
     TRACE_CATEGORY_(PKCS12_DECRYPT),
     TRACE_CATEGORY_(X509V3_POLICY),
     TRACE_CATEGORY_(BN_CTX),
-    TRACE_CATEGORY_(CONF),
 };
 
 const char *OSSL_trace_get_category_name(int num)

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -41,7 +41,7 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_INIT                2
 # define OSSL_TRACE_CATEGORY_TLS                 3
 # define OSSL_TRACE_CATEGORY_TLS_CIPHER          4
-# define OSSL_TRACE_CATEGORY_ENGINE_CONF         5
+# define OSSL_TRACE_CATEGORY_CONF                5
 # define OSSL_TRACE_CATEGORY_ENGINE_TABLE        6
 # define OSSL_TRACE_CATEGORY_ENGINE_REF_COUNT    7
 # define OSSL_TRACE_CATEGORY_PKCS5V2             8
@@ -49,7 +49,6 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_PKCS12_DECRYPT     10
 # define OSSL_TRACE_CATEGORY_X509V3_POLICY      11
 # define OSSL_TRACE_CATEGORY_BN_CTX             12
-# define OSSL_TRACE_CATEGORY_CONF               13
 # define OSSL_TRACE_CATEGORY_NUM                14
 
 /* Returns the trace category number for the given |name| */

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -49,7 +49,7 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_PKCS12_DECRYPT     10
 # define OSSL_TRACE_CATEGORY_X509V3_POLICY      11
 # define OSSL_TRACE_CATEGORY_BN_CTX             12
-# define OSSL_TRACE_CATEGORY_PROVIDER_CONF      13
+# define OSSL_TRACE_CATEGORY_CONF               13
 # define OSSL_TRACE_CATEGORY_NUM                14
 
 /* Returns the trace category number for the given |name| */

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -49,7 +49,7 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_PKCS12_DECRYPT     10
 # define OSSL_TRACE_CATEGORY_X509V3_POLICY      11
 # define OSSL_TRACE_CATEGORY_BN_CTX             12
-# define OSSL_TRACE_CATEGORY_NUM                14
+# define OSSL_TRACE_CATEGORY_NUM                13
 
 /* Returns the trace category number for the given |name| */
 int OSSL_trace_get_category_num(const char *name);


### PR DESCRIPTION
Other configuration modules may have use for tracing, and having one
tracing category for each of them is a bit much.  Instead, we make one
category for them all.
