### PR TITLE
Load the config file by default on libcrypto initialization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Automatic libcrypto initialization now loads the config file by default.
+     [Richard Levitte]
+
   *) Limit the number of blocks in a data unit for AES-XTS to 2^20 as
      mandated by IEEE Std 1619-2018.
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -83,8 +83,7 @@ static int apps_startup(void)
 #endif
 
     /* Set non-default library initialisation settings */
-    if (!OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN
-                          | OPENSSL_INIT_LOAD_CONFIG, NULL))
+    if (!OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL))
         return 0;
 
     setup_ui_method();

--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -60,10 +60,6 @@ int openssl_config_int(const OPENSSL_INIT_SETTINGS *settings)
 #endif
 
     OPENSSL_load_builtin_modules();
-#ifndef OPENSSL_NO_ENGINE
-    /* Need to load ENGINEs */
-    ENGINE_load_builtin_engines();
-#endif
     ERR_clear_error();
 #ifndef OPENSSL_SYS_UEFI
     ret = CONF_modules_load_file(filename, appname, flags);

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -38,8 +38,7 @@ static void do_default_context_deinit(void)
 }
 DEFINE_RUN_ONCE_STATIC(do_default_context_init)
 {
-    return OPENSSL_init_crypto(0, NULL)
-        && context_init(&default_context)
+    return context_init(&default_context)
         && OPENSSL_atexit(do_default_context_deinit);
 }
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -589,6 +589,8 @@ void ERR_error_string_n(unsigned long e, char *buf, size_t len)
     if (len == 0)
         return;
 
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+
     l = ERR_GET_LIB(e);
     ls = ERR_lib_error_string(e);
     if (ls == NULL) {

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -293,8 +293,6 @@ static void ERR_STATE_free(ERR_STATE *s)
 
 DEFINE_RUN_ONCE_STATIC(do_err_strings_init)
 {
-    if (!OPENSSL_init_crypto(0, NULL))
-        return 0;
     err_string_lock = CRYPTO_THREAD_lock_new();
     if (err_string_lock == NULL)
         return 0;
@@ -742,9 +740,6 @@ ERR_STATE *ERR_get_state(void)
             CRYPTO_THREAD_set_local(&err_thread_local, NULL);
             return NULL;
         }
-
-        /* Ignore failures from these */
-        OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     }
 
     set_sys_error(saveerrno);

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -37,8 +37,6 @@ static CRYPTO_ONCE ex_data_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE_STATIC(do_ex_data_init)
 {
-    if (!OPENSSL_init_crypto(0, NULL))
-        return 0;
     ex_data_lock = CRYPTO_THREAD_lock_new();
     return ex_data_lock != NULL;
 }

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -663,7 +663,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             && !RUN_ONCE_ALT(&config, ossl_init_no_config, ossl_init_config)) {
         return 0;
     } else
-#ifndef OPENSSL_NO_AUTOLOAD_CONFIG
+#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
         if ((opts & OPENSSL_INIT_LOAD_CONFIG))
 #endif
             {

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -431,9 +431,6 @@ int ossl_init_thread_start(uint64_t opts)
 {
     struct thread_local_inits_st *locals;
 
-    if (!OPENSSL_init_crypto(0, NULL))
-        return 0;
-
     locals = ossl_init_get_thread_local(1);
 
     if (locals == NULL)

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -659,24 +659,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             && !openssl_init_fork_handlers())
         return 0;
 
-    if ((opts & OPENSSL_INIT_NO_LOAD_CONFIG)
-            && !RUN_ONCE_ALT(&config, ossl_init_no_config, ossl_init_config)) {
-        return 0;
-    } else
-#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
-        if ((opts & OPENSSL_INIT_LOAD_CONFIG))
-#endif
-            {
-                int ret;
-                CRYPTO_THREAD_write_lock(init_lock);
-                conf_settings = settings;
-                ret = RUN_ONCE(&config, ossl_init_config);
-                conf_settings = NULL;
-                CRYPTO_THREAD_unlock(init_lock);
-                if (ret <= 0)
-                    return 0;
-            }
-
     if ((opts & OPENSSL_INIT_ASYNC)
             && !RUN_ONCE(&async, ossl_init_async))
         return 0;
@@ -727,6 +709,24 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             && !RUN_ONCE(&zlib, ossl_init_zlib))
         return 0;
 #endif
+
+    if ((opts & OPENSSL_INIT_NO_LOAD_CONFIG)
+            && !RUN_ONCE_ALT(&config, ossl_init_no_config, ossl_init_config)) {
+        return 0;
+    } else
+#ifdef OPENSSL_NO_AUTOLOAD_CONFIG
+        if ((opts & OPENSSL_INIT_LOAD_CONFIG))
+#endif
+            {
+                int ret;
+                CRYPTO_THREAD_write_lock(init_lock);
+                conf_settings = settings;
+                ret = RUN_ONCE(&config, ossl_init_config);
+                conf_settings = NULL;
+                CRYPTO_THREAD_unlock(init_lock);
+                if (ret <= 0)
+                    return 0;
+            }
 
     return 1;
 }

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -707,9 +707,9 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
 #endif
 
-    if ((opts & OPENSSL_INIT_NO_LOAD_CONFIG)
-            && !RUN_ONCE_ALT(&config, ossl_init_no_config, ossl_init_config)) {
-        return 0;
+    if ((opts & OPENSSL_INIT_NO_LOAD_CONFIG)) {
+        if (!RUN_ONCE_ALT(&config, ossl_init_no_config, ossl_init_config))
+            return 0;
     } else
 #ifdef OPENSSL_NO_AUTOLOAD_CONFIG
         if ((opts & OPENSSL_INIT_LOAD_CONFIG))

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -134,8 +134,7 @@ static const OPENSSL_CTX_METHOD provider_store_method = {
 static CRYPTO_ONCE provider_store_init_flag = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(do_provider_store_init)
 {
-    return OPENSSL_init_crypto(0, NULL)
-        && (provider_store_index =
+    return (provider_store_index =
             openssl_ctx_new_index(&provider_store_method)) != -1;
 }
 

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -100,10 +100,8 @@ B<OPENSSL_INIT_ADD_ALL_DIGESTS> will be ignored.
 =item OPENSSL_INIT_LOAD_CONFIG
 
 With this option an OpenSSL configuration file will be automatically loaded and
-used by calling OPENSSL_config(). This is not a default option for libcrypto.
-As of OpenSSL 1.1.1 this is a default option for libssl (see
-L<OPENSSL_init_ssl(3)> for further details about libssl initialisation). See the
-description of OPENSSL_INIT_new(), below.
+used by calling OPENSSL_config().
+Since OpenSSL 3.0, this is a default option.
 
 =item OPENSSL_INIT_NO_LOAD_CONFIG
 
@@ -261,6 +259,9 @@ L<OPENSSL_init_ssl(3)>
 The OPENSSL_init_crypto(), OPENSSL_cleanup(), OPENSSL_atexit(),
 OPENSSL_thread_stop(), OPENSSL_INIT_new(), OPENSSL_INIT_set_config_appname()
 and OPENSSL_INIT_free() functions were added in OpenSSL 1.1.0.
+
+OPENSSL_init_crypto() changed behavior in OpenSSL 3.0, to load the
+config file by default.
 
 =head1 COPYRIGHT
 

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -183,10 +183,6 @@ int OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS * settings)
     opts |= OPENSSL_INIT_ADD_ALL_CIPHERS
          |  OPENSSL_INIT_ADD_ALL_DIGESTS
          |  OPENSSL_INIT_ADD_ALL_MACS;
-#ifndef OPENSSL_NO_AUTOLOAD_CONFIG
-    if ((opts & OPENSSL_INIT_NO_LOAD_CONFIG) == 0)
-        opts |= OPENSSL_INIT_LOAD_CONFIG;
-#endif
 
     if (!OPENSSL_init_crypto(opts, settings))
         return 0;


### PR DESCRIPTION
As specified in the 3.0.0 design document:

> By default, OpenSSL 3.0 will load a configuration file (which
> contains global properties and other settings) automatically without
> explicit application API calls. This will occur in libcrypto. Note
> that in OpenSSL 1.1.1 the configuration file is automatically loaded
> only by the default (automatic) initialisation of libssl.

Ref: https://www.openssl.org/docs/OpenSSL300Design.html#property-based-algorithmselection
