### PR TITLE
Configurations/10-main.conf: Don't inherit assembler in Cygwin-common

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1431,7 +1431,7 @@ my %targets = (
 
 #### Cygwin
     "Cygwin-common" => {
-        inherit_from     => [ "BASE_unix", asm("x86_asm") ],
+        inherit_from     => [ "BASE_unix" ],
         template         => 1,
 
         CC               => "gcc",


### PR DESCRIPTION
The targets Cygwin-x86 and Cygwin-x86_64 are the ones that should do
this.

Fixes #8684
