### PR TITLE
Change cipher default strings to a function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Default cipher lists/suites are now avaialble via a function, the
+     #defines are deprecated.
+     [Todd Short]
+
   *) Join the directories crypto/x509 and crypto/x509v3
      [Richard Levitte]
 

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -5,7 +5,9 @@
 SSL_CTX_set_cipher_list,
 SSL_set_cipher_list,
 SSL_CTX_set_ciphersuites,
-SSL_set_ciphersuites
+SSL_set_ciphersuites,
+OSSL_default_cipher_list,
+OSSL_default_ciphersuites
 - choose list of available SSL_CIPHERs
 
 =head1 SYNOPSIS
@@ -17,6 +19,9 @@ SSL_set_ciphersuites
 
  int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str);
  int SSL_set_ciphersuites(SSL *s, const char *str);
+
+ const char *OSSL_default_cipher_list(void);
+ const char *OSSL_default_ciphersuites(void);
 
 =head1 DESCRIPTION
 
@@ -54,6 +59,10 @@ An empty list is permissible. The default value for the this setting is:
 SSL_set_ciphersuites() is the same as SSL_CTX_set_ciphersuites() except it
 configures the ciphersuites for B<ssl>.
 
+OSSL_default_cipher_list() returns the default cipher string for TLSv1.2
+(and earlier) ciphers. OSSL_default_ciphersuites() returns the default
+cipher string for TLSv1.3 ciphersuites.
+
 =head1 NOTES
 
 The control string B<str> for SSL_CTX_set_cipher_list() and
@@ -85,6 +94,10 @@ of 512 bits and the server is not configured to use temporary RSA
 keys), the "no shared cipher" (SSL_R_NO_SHARED_CIPHER) error is generated
 and the handshake will fail.
 
+OSSL_default_cipher_list() and OSSL_default_ciphersuites() replace
+SSL_DEFAULT_CIPHER_LIST and TLS_DEFAULT_CIPHERSUITES, respectively. The
+cipher list defines are deprecated as of 3.0.0.
+
 =head1 RETURN VALUES
 
 SSL_CTX_set_cipher_list() and SSL_set_cipher_list() return 1 if any cipher
@@ -99,6 +112,10 @@ L<ssl(7)>, L<SSL_get_ciphers(3)>,
 L<SSL_CTX_use_certificate(3)>,
 L<SSL_CTX_set_tmp_dh_callback(3)>,
 L<ciphers(1)>
+
+=head1 HISTORY
+
+OSSL_default_cipher_list() and OSSL_default_ciphersites() are new in 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -172,7 +172,7 @@ extern "C" {
  * DEPRECATED IN 3.0.0, in favor of OSSL_default_cipher_list()
  * Update both macro and function simultaneously
  */
-# if OPENSSL_API_LEVEL < 4
+# if !OPENSSL_API_3
 #  define SSL_DEFAULT_CIPHER_LIST "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
 /*
  * This is the default set of TLSv1.3 ciphersuites

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -169,17 +169,25 @@ extern "C" {
  * The following cipher list is used by default. It also is substituted when
  * an application-defined cipher list string starts with 'DEFAULT'.
  * This applies to ciphersuites for TLSv1.2 and below.
+ * DEPRECATED IN 3.0.0, in favor of OSSL_default_cipher_list()
+ * Update both macro and function simultaneously
  */
-# define SSL_DEFAULT_CIPHER_LIST "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
-/* This is the default set of TLSv1.3 ciphersuites */
-# if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
-#  define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
-                                   "TLS_CHACHA20_POLY1305_SHA256:" \
+# if OPENSSL_API_LEVEL < 4
+#  define SSL_DEFAULT_CIPHER_LIST "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
+/*
+ * This is the default set of TLSv1.3 ciphersuites
+ * DEPRECATED IN 3.0.0, in favor of OSSL_default_ciphersuites()
+ * Update both macro and function simultaneously
+ */
+#  if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+#   define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
+                                    "TLS_CHACHA20_POLY1305_SHA256:" \
+                                    "TLS_AES_128_GCM_SHA256"
+#  else
+#   define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
                                    "TLS_AES_128_GCM_SHA256"
-# else
-#  define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
-                                   "TLS_AES_128_GCM_SHA256"
-#endif
+#  endif
+# endif
 /*
  * As of OpenSSL 1.0.0, ssl_create_cipher_list() in ssl/ssl_ciph.c always
  * starts with a reasonable order, and all we have to do for DEFAULT is
@@ -2442,6 +2450,10 @@ void SSL_CTX_set_allow_early_data_cb(SSL_CTX *ctx,
 void SSL_set_allow_early_data_cb(SSL *s,
                                  SSL_allow_early_data_cb_fn cb,
                                  void *arg);
+
+/* store the default cipher strings inside the library */
+const char *OSSL_default_cipher_list(void);
+const char *OSSL_default_ciphersuites(void);
 
 # ifdef  __cplusplus
 }

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1573,7 +1573,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *ssl_method,
     ok = 1;
     rule_p = rule_str;
     if (strncmp(rule_str, "DEFAULT", 7) == 0) {
-        ok = ssl_cipher_process_rulestr(SSL_DEFAULT_CIPHER_LIST,
+        ok = ssl_cipher_process_rulestr(OSSL_default_cipher_list(),
                                         &head, &tail, ca_list, c);
         rule_p += 7;
         if (*rule_p == ':')
@@ -2167,4 +2167,28 @@ int ssl_cert_is_disabled(size_t idx)
     if (cl == NULL || (cl->amask & disabled_auth_mask) != 0)
         return 1;
     return 0;
+}
+
+/*
+ * Default list of TLSv1.2 (and earlier) ciphers
+ * SSL_DEFAULT_CIPHER_LIST deprecated in 3.0.0
+ * Update both macro and function simultaneously
+ */
+const char *OSSL_default_cipher_list(void)
+{
+    return "ALL:!COMPLEMENTOFDEFAULT:!eNULL";
+}
+
+/*
+ * Default list of TLSv1.3 (and later) ciphers
+ * TLS_DEFAULT_CIPHERSUITES deprecated in 3.0.0
+ * Update both macro and function simultaneously
+ */
+const char *OSSL_default_ciphersuites(void)
+{
+    return "TLS_AES_256_GCM_SHA384:"
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+           "TLS_CHACHA20_POLY1305_SHA256:"
+#endif
+           "TLS_AES_128_GCM_SHA256";
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -655,7 +655,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth)
 
     ctx->method = meth;
 
-    if (!SSL_CTX_set_ciphersuites(ctx, TLS_DEFAULT_CIPHERSUITES)) {
+    if (!SSL_CTX_set_ciphersuites(ctx, OSSL_default_ciphersuites())) {
         SSLerr(SSL_F_SSL_CTX_SET_SSL_VERSION, SSL_R_SSL_LIBRARY_HAS_NO_CIPHERS);
         return 0;
     }
@@ -663,7 +663,7 @@ int SSL_CTX_set_ssl_version(SSL_CTX *ctx, const SSL_METHOD *meth)
                                 ctx->tls13_ciphersuites,
                                 &(ctx->cipher_list),
                                 &(ctx->cipher_list_by_id),
-                                SSL_DEFAULT_CIPHER_LIST, ctx->cert);
+                                OSSL_default_cipher_list(), ctx->cert);
     if ((sk == NULL) || (sk_SSL_CIPHER_num(sk) <= 0)) {
         SSLerr(SSL_F_SSL_CTX_SET_SSL_VERSION, SSL_R_SSL_LIBRARY_HAS_NO_CIPHERS);
         return 0;
@@ -3078,13 +3078,13 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         goto err;
 #endif
 
-    if (!SSL_CTX_set_ciphersuites(ret, TLS_DEFAULT_CIPHERSUITES))
+    if (!SSL_CTX_set_ciphersuites(ret, OSSL_default_ciphersuites()))
         goto err;
 
     if (!ssl_create_cipher_list(ret->method,
                                 ret->tls13_ciphersuites,
                                 &ret->cipher_list, &ret->cipher_list_by_id,
-                                SSL_DEFAULT_CIPHER_LIST, ret->cert)
+                                OSSL_default_cipher_list(), ret->cert)
         || sk_SSL_CIPHER_num(ret->cipher_list) <= 0) {
         SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_LIBRARY_HAS_NO_CIPHERS);
         goto err2;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -504,3 +504,5 @@ SSL_set_async_callback                  504	3_0_0	EXIST::FUNCTION:
 SSL_set_async_callback_arg              505	3_0_0	EXIST::FUNCTION:
 SSL_get_async_status                    506	3_0_0	EXIST::FUNCTION:
 SSL_sendfile                            507	3_0_0	EXIST::FUNCTION:
+OSSL_default_cipher_list                508	3_0_0	EXIST::FUNCTION:
+OSSL_default_ciphersuites               509	3_0_0	EXIST::FUNCTION:

--- a/util/private.num
+++ b/util/private.num
@@ -421,6 +421,7 @@ SSL_CTX_set_tlsext_status_type          define
 SSL_CTX_set_tlsext_ticket_key_cb        define
 SSL_CTX_set_tmp_dh                      define
 SSL_CTX_set_tmp_ecdh                    define
+SSL_DEFAULT_CIPHER_LIST                 define deprecated 3.0.0
 SSL_add0_chain_cert                     define
 SSL_add1_chain_cert                     define
 SSL_build_cert_chain                    define
@@ -499,6 +500,7 @@ SSL_want_x509_lookup                    define
 SSLv23_client_method                    define
 SSLv23_method                           define
 SSLv23_server_method                    define
+TLS_DEFAULT_CIPHERSUITES                define deprecated 3.0.0
 X509_STORE_set_lookup_crls_cb           define
 X509_STORE_set_verify_func              define
 EVP_PKEY_CTX_set1_id                    define


### PR DESCRIPTION
Making the default cipher strings a function gives the library more
control over the defaults. Potentially allowing a change in the
future as ciphers become deprecated or dangerous.
Also allows third party distributors to change the defaults for their
installations.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated - existing tests are sufficient
