### PR TITLE
Test skip option.

### DIFF
--- a/test/drbg_cavs_test.c
+++ b/test/drbg_cavs_test.c
@@ -257,7 +257,8 @@ static int test_cavs_kats(const struct drbg_kat *test[], int i)
 #ifdef FIPS_MODE
     /* FIPS mode doesn't support instantiating without a derivation function */
     if ((td->flags & USE_DF) == 0)
-        return 1;
+        return TEST_skip("instantiating without derivation function "
+                         "is not supported in FIPS mode");
 #endif
     switch (td->type) {
     case NO_RESEED:

--- a/test/test_test.c
+++ b/test/test_test.c
@@ -531,6 +531,25 @@ static int test_bn_output(int n)
     return 1;
 }
 
+static int test_skip_one(void)
+{
+    return TEST_skip("skip test");
+}
+
+static int test_skip_many(int n)
+{
+    return TEST_skip("skip tests: %d", n);
+}
+
+static int test_skip_null(void)
+{
+    /*
+     * This is not a recommended way of skipping a test, a reason or
+     * description should be included.
+     */
+    return TEST_skip(NULL);
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_int);
@@ -553,5 +572,8 @@ int setup_tests(void)
     ADD_TEST(test_single_eval);
     ADD_TEST(test_output);
     ADD_ALL_TESTS(test_bn_output, OSSL_NELEM(bn_output_tests));
+    ADD_TEST(test_skip_one);
+    ADD_TEST(test_skip_null);
+    ADD_ALL_TESTS(test_skip_many, 3);
     return 1;
 }

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -346,6 +346,9 @@ void test_info(const char *file, int line, const char *desc, ...)
     PRINTF_FORMAT(3, 4);
 void test_info_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 void test_note(const char *desc, ...) PRINTF_FORMAT(1, 2);
+int test_skip(const char *file, int line, const char *desc, ...)
+    PRINTF_FORMAT(3, 4);
+int test_skip_c90(const char *desc, ...) PRINTF_FORMAT(1, 2);
 void test_openssl_errors(void);
 void test_perror(const char *s);
 
@@ -463,9 +466,11 @@ void test_perror(const char *s);
 # if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L
 #  define TEST_error         test_error_c90
 #  define TEST_info          test_info_c90
+#  define TEST_skip          test_skip_c90
 # else
 #  define TEST_error(...)    test_error(__FILE__, __LINE__, __VA_ARGS__)
 #  define TEST_info(...)     test_info(__FILE__, __LINE__, __VA_ARGS__)
+#  define TEST_skip(...)     test_skip(__FILE__, __LINE__, __VA_ARGS__)
 # endif
 # define TEST_note           test_note
 # define TEST_openssl_errors test_openssl_errors

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -157,6 +157,29 @@ void test_note(const char *fmt, ...)
     test_flush_stderr();
 }
 
+
+int test_skip(const char *file, int line, const char *desc, ...)
+{
+    va_list ap;
+
+    va_start(ap, desc);
+    test_fail_message_va("SKIP", file, line, NULL, NULL, NULL, NULL, desc, ap);
+    va_end(ap);
+    return TEST_SKIP_CODE;
+}
+
+int test_skip_c90(const char *desc, ...)
+{
+    va_list ap;
+
+    va_start(ap, desc);
+    test_fail_message_va("SKIP", NULL, -1, NULL, NULL, NULL, NULL, desc, ap);
+    va_end(ap);
+    test_printf_stderr("\n");
+    return TEST_SKIP_CODE;
+}
+
+
 void test_openssl_errors(void)
 {
     ERR_print_errors_cb(openssl_error_cb, NULL);

--- a/test/testutil/tu_local.h
+++ b/test/testutil/tu_local.h
@@ -12,6 +12,8 @@
 #include <openssl/bio.h>
 #include "../testutil.h"
 
+#define TEST_SKIP_CODE  123
+
 int subtest_level(void);
 int openssl_error_cb(const char *str, size_t len, void *u);
 const BIO_METHOD *BIO_f_tap(void);


### PR DESCRIPTION
Allow tests to return a skip result.

This is treated as a success but with a skip directive added to the TAP output.

- [ ] documentation is added or updated
- [x] tests are added or updated
