### PR TITLE
Fixed linux_x86_icc compiler errors in EC code related to __uint128_ &  __int128_t

### DIFF
--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -254,6 +254,7 @@ static void x25519_scalar_mulx(uint8_t out[32], const uint8_t scalar[32],
 #if defined(X25519_ASM) \
     || ( (defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16) \
          && !defined(__sparc__) \
+         && (!defined(__SIZEOF_LONG__) || (__SIZEOF_LONG__ == 8)) \
          && !(defined(__ANDROID__) && !defined(__clang__)) )
 /*
  * Base 2^51 implementation. It's virtually no different from reference

--- a/crypto/ec/curve448/curve448utils.h
+++ b/crypto/ec/curve448/curve448utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright 2015 Cryptography Research, Inc.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -24,7 +24,9 @@
  */
 # ifndef C448_WORD_BITS
 #  if (defined(__SIZEOF_INT128__) && (__SIZEOF_INT128__ == 16)) \
-      && !defined(__sparc__)
+      && !defined(__sparc__) \
+      && (!defined(__SIZEOF_LONG__) || (__SIZEOF_LONG__ == 8))
+
 #   define C448_WORD_BITS 64      /* The number of bits in a word */
 #  else
 #   define C448_WORD_BITS 32      /* The number of bits in a word */


### PR DESCRIPTION
Performing the following operation

> `icc -m32 -dM -E -o main.P main.c`

Showed that  `__SIZEOF_INT128__ == 16 ` (32 bit build on a 64 bit machine).
So another define also needs to be used. I chose `__SIZEOF_POINTER__` initially but then changed it to match the code in poly1305.c

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
