### PR TITLE
Fix crash in X509_STORE_CTX_get_by_subject

### DIFF
--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -297,6 +297,9 @@ int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, X509_LOOKUP_TYPE type,
     if (ctx == NULL)
         return 0;
 
+    stmp.type = X509_LU_NONE;
+    stmp.data.ptr = NULL;
+
     CRYPTO_THREAD_write_lock(ctx->lock);
     tmp = X509_OBJECT_retrieve_by_subject(ctx->objs, type, name);
     CRYPTO_THREAD_unlock(ctx->lock);


### PR DESCRIPTION
If using a custom X509_LOOKUP_METHOD then calls to
X509_STORE_CTX_get_by_subject may crash due to an incorrectly initialised
X509_OBJECT being passed to the callback get_by_subject function.

Fixes #8673

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
