### PR TITLE
Params API: {utf8,octet}_ptr need to know the data size

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -580,15 +580,15 @@ int OSSL_PARAM_set_octet_ptr(const OSSL_PARAM *p, const void *val,
 }
 
 OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
-                                         size_t *rsize)
+                                         size_t bsize, size_t *rsize)
 {
-    return ossl_param_construct(key, OSSL_PARAM_UTF8_PTR, buf, 0, rsize);
+    return ossl_param_construct(key, OSSL_PARAM_UTF8_PTR, buf, bsize, rsize);
 }
 
 OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
-                                          size_t *rsize)
+                                          size_t bsize, size_t *rsize)
 {
-    return ossl_param_construct(key, OSSL_PARAM_OCTET_PTR, buf, 0, rsize);
+    return ossl_param_construct(key, OSSL_PARAM_OCTET_PTR, buf, bsize, rsize);
 }
 
 OSSL_PARAM OSSL_PARAM_construct_end(void)

--- a/doc/man3/OSSL_PARAM_TYPE.pod
+++ b/doc/man3/OSSL_PARAM_TYPE.pod
@@ -44,9 +44,9 @@ OSSL_PARAM_set_octet_ptr
  OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
                                               size_t bsize, size_t *rsize);
  OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
-                                          size_t *rsize);
+                                          size_t bsize, size_t *rsize);
  OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
-                                           size_t *rsize);
+                                           size_t bsize, size_t *rsize);
  OSSL_PARAM OSSL_PARAM_construct_end(void);
 
  OSSL_PARAM *OSSL_PARAM_locate(OSSL_PARAM *array, const char *key);
@@ -173,13 +173,13 @@ size B<rsize> is created.
 
 OSSL_PARAM_construct_utf8_ptr() is a function that constructes a UTF string
 pointer OSSL_PARAM structure.
-A parameter with name B<key>, storage pointer B<*buf> and return size B<rsize>
-is created.
+A parameter with name B<key>, storage pointer B<*buf>, size B<bsize> and
+return size B<rsize> is created.
 
 OSSL_PARAM_construct_octet_ptr() is a function that constructes an OCTET string
 pointer OSSL_PARAM structure.
-A parameter with name B<key>, storage pointer B<*buf> and return size B<rsize>
-is created.
+A parameter with name B<key>, storage pointer B<*buf>, size B<bsize> and
+return size B<rsize> is created.
 
 OSSL_PARAM_construct_end() is a function that constructs the terminating
 OSSL_PARAM structure.
@@ -253,6 +253,13 @@ All other functions return B<1> on success and B<0> on failure.
 Integral types will be widened and sign extended as required.
 Apart from that, the functions must be used appropriately for the
 expected type of the parameter.
+
+For OSSL_PARAM_get_utf8_ptr() and OSSL_PARAM_get_octet_ptr(), B<bsize>
+is not relevant if the purpose is to send the B<OSSL_PARAM> array to a
+I<responder>, i.e. to get parameter data back.
+In that case, B<bsize> can safely be given zero.
+See L<OSSL_PARAM(3)/DESCRIPTION> for further information on the
+possible purposes.
 
 =head1 EXAMPLES
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -132,11 +132,11 @@ OSSL_PARAM OSSL_PARAM_construct_double(const char *key, double *buf,
 OSSL_PARAM OSSL_PARAM_construct_utf8_string(const char *key, char *buf,
                                             size_t bsize, size_t *rsize);
 OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
-                                         size_t *rsize);
+                                         size_t bsize, size_t *rsize);
 OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
                                              size_t bsize, size_t *rsize);
 OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
-                                          size_t *rsize);
+                                          size_t bsize, size_t *rsize);
 OSSL_PARAM OSSL_PARAM_construct_end(void);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -475,8 +475,8 @@ static int test_param_construct(void)
                                                    &sz);
     params[n++] = OSSL_PARAM_construct_octet_string("octstr", buf, sizeof(buf),
                                                     &sz);
-    params[n++] = OSSL_PARAM_construct_utf8_ptr("utf8ptr", &bufp, &sz);
-    params[n++] = OSSL_PARAM_construct_octet_ptr("octptr", &vp, &sz);
+    params[n++] = OSSL_PARAM_construct_utf8_ptr("utf8ptr", &bufp, 0, &sz);
+    params[n++] = OSSL_PARAM_construct_octet_ptr("octptr", &vp, 0, &sz);
     params[n] = OSSL_PARAM_construct_end();
 
     /* Search failure */

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -400,7 +400,7 @@ static OSSL_PARAM *construct_api_params(void)
     params[n++] = OSSL_PARAM_construct_utf8_string("p5", app_p5,
                                                    sizeof(app_p5), &app_p5_l);
     params[n++] = OSSL_PARAM_construct_utf8_ptr("p6", (char **)&app_p6,
-                                                &app_p6_l);
+                                                sizeof(app_p6), &app_p6_l);
     params[n++] = OSSL_PARAM_construct_octet_string("foo", &foo, sizeof(foo),
                                                     &foo_l);
     params[n++] = OSSL_PARAM_construct_end();

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -143,8 +143,10 @@ static int raw_set_params(void *vobj, const OSSL_PARAM *params)
                 return 0;
         } else if (strcmp(params->key, "p5") == 0) {
             strncpy(obj->p5, params->data, params->data_size);
+            obj->p5_l = strlen(obj->p5) + 1;
         } else if (strcmp(params->key, "p6") == 0) {
             obj->p6 = *(const char **)params->data;
+            obj->p6_l = params->data_size;
         }
 
     return 1;
@@ -233,10 +235,13 @@ static int api_set_params(void *vobj, const OSSL_PARAM *params)
         char *p5_ptr = obj->p5;
         if (!TEST_true(OSSL_PARAM_get_utf8_string(p, &p5_ptr, sizeof(obj->p5))))
             return 0;
+        obj->p5_l = strlen(obj->p5) + 1;
     }
-    if ((p = OSSL_PARAM_locate(params, "p6")) != NULL
-        && !TEST_true(OSSL_PARAM_get_utf8_ptr(p, &obj->p6)))
-        return 0;
+    if ((p = OSSL_PARAM_locate(params, "p6")) != NULL) {
+        if (!TEST_true(OSSL_PARAM_get_utf8_ptr(p, &obj->p6)))
+            return 0;
+        obj->p6_l = strlen(obj->p6) + 1;
+    }
 
     return 1;
 }
@@ -364,7 +369,8 @@ static const OSSL_PARAM static_raw_params[] = {
       &bignumbin_l },
     { "p4", OSSL_PARAM_UTF8_STRING, &app_p4, sizeof(app_p4), &app_p4_l },
     { "p5", OSSL_PARAM_UTF8_STRING, &app_p5, sizeof(app_p5), &app_p5_l },
-    { "p6", OSSL_PARAM_UTF8_PTR, &app_p6, sizeof(app_p6), &app_p6_l },
+    /* sizeof(app_p6_init), because we know that's what we're using */
+    { "p6", OSSL_PARAM_UTF8_PTR, &app_p6, sizeof(app_p6_init), &app_p6_l },
     { "foo", OSSL_PARAM_OCTET_STRING, &foo, sizeof(foo), &foo_l },
     { NULL, 0, NULL, 0, NULL }
 };
@@ -377,8 +383,9 @@ static const OSSL_PARAM static_api_params[] = {
                     &app_p4, sizeof(app_p4), &app_p4_l),
     OSSL_PARAM_DEFN("p5", OSSL_PARAM_UTF8_STRING,
                     &app_p5, sizeof(app_p5), &app_p5_l),
+    /* sizeof(app_p6_init), because we know that's what we're using */
     OSSL_PARAM_DEFN("p6", OSSL_PARAM_UTF8_PTR,
-                    &app_p6, sizeof(app_p6), &app_p6_l),
+                    &app_p6, sizeof(app_p6_init), &app_p6_l),
     OSSL_PARAM_DEFN("foo", OSSL_PARAM_OCTET_STRING, &foo, sizeof(foo), &foo_l),
     OSSL_PARAM_END
 };
@@ -399,8 +406,9 @@ static OSSL_PARAM *construct_api_params(void)
                                                    &app_p4_l);
     params[n++] = OSSL_PARAM_construct_utf8_string("p5", app_p5,
                                                    sizeof(app_p5), &app_p5_l);
+    /* sizeof(app_p6_init), because we know that's what we're using */
     params[n++] = OSSL_PARAM_construct_utf8_ptr("p6", (char **)&app_p6,
-                                                sizeof(app_p6), &app_p6_l);
+                                                sizeof(app_p6_init), &app_p6_l);
     params[n++] = OSSL_PARAM_construct_octet_string("foo", &foo, sizeof(foo),
                                                     &foo_l);
     params[n++] = OSSL_PARAM_construct_end();
@@ -472,7 +480,9 @@ static int test_case_variant(const OSSL_PARAM *params,
         || !TEST_ptr(BN_native2bn(bignumbin, bignumbin_l, app_p3))
         || !TEST_BN_eq(app_p3, verify_p3)       /* "provider" value */
         || !TEST_str_eq(app_p4, p4_init)        /* "provider" value */
+        || !TEST_size_t_eq(app_p5_l, sizeof(p5_init)) /* "provider" value */
         || !TEST_str_eq(app_p5, p5_init)        /* "provider" value */
+        || !TEST_size_t_eq(app_p6_l, sizeof(p6_init)) /* "provider" value */
         || !TEST_str_eq(app_p6, p6_init)        /* "provider" value */
         || !TEST_char_eq(foo[0], app_foo_init)  /* Should remain untouched */
         || !TEST_int_eq(foo_l, sizeof(app_foo_init)))
@@ -493,7 +503,11 @@ static int test_case_variant(const OSSL_PARAM *params,
             || !TEST_double_eq(sneakpeek->p2, p2_init)  /* Should remain untouched */
             || !TEST_BN_eq(sneakpeek->p3, app_p3)       /* app value set */
             || !TEST_str_eq(sneakpeek->p4, app_p4)      /* app value set */
-            || !TEST_str_eq(sneakpeek->p5, app_p5))     /* app value set */
+            || !TEST_size_t_eq(sneakpeek->p5_l, app_p5_l) /* app value set */
+            || !TEST_str_eq(sneakpeek->p5, app_p5)      /* app value set */
+            || !TEST_size_t_eq(sneakpeek->p6_l,
+                               sizeof(app_p6_init))     /* app value set */
+            || !TEST_str_eq(sneakpeek->p6, app_p6))     /* app value set */
             errcnt++;
     }
 
@@ -515,7 +529,11 @@ static int test_case_variant(const OSSL_PARAM *params,
         || !TEST_ptr(BN_native2bn(bignumbin, bignumbin_l, app_p3))
         || !TEST_BN_eq(app_p3, verify_p3)       /* app value */
         || !TEST_str_eq(app_p4, app_p4_init)    /* app value */
+        || !TEST_size_t_eq(app_p5_l,
+                           sizeof(app_p5_init)) /* app value */
         || !TEST_str_eq(app_p5, app_p5_init)    /* app value */
+        || !TEST_size_t_eq(app_p6_l,
+                           sizeof(app_p6_init)) /* app value */
         || !TEST_str_eq(app_p6, app_p6_init)    /* app value */
         || !TEST_char_eq(foo[0], app_foo_init)  /* Should remain untouched */
         || !TEST_int_eq(foo_l, sizeof(app_foo_init)))


### PR DESCRIPTION
When the purpose is to pass parameters to a setter function, that
setter function needs to know the size of the data passed.  This
remains true for the pointer data types as well.
