### PR TITLE
Params: add OSSL_PARAM_construct_end()

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -586,3 +586,10 @@ OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
 {
     return ossl_param_construct(key, OSSL_PARAM_OCTET_PTR, buf, 0, rsize);
 }
+
+OSSL_PARAM OSSL_PARAM_construct_end(void)
+{
+    OSSL_PARAM end = OSSL_PARAM_END;
+
+    return end;
+}

--- a/doc/man3/OSSL_PARAM_TYPE.pod
+++ b/doc/man3/OSSL_PARAM_TYPE.pod
@@ -10,7 +10,8 @@ OSSL_PARAM_SIZED_octet_ptr, OSSL_PARAM_END, OSSL_PARAM_construct_TYPE,
 OSSL_PARAM_END,
 OSSL_PARAM_construct_BN, OSSL_PARAM_construct_utf8_string,
 OSSL_PARAM_construct_utf8_ptr, OSSL_PARAM_construct_octet_string,
-OSSL_PARAM_construct_octet_ptr, OSSL_PARAM_locate, OSSL_PARAM_get_TYPE,
+OSSL_PARAM_construct_octet_ptr, OSSL_PARAM_construct_end,
+OSSL_PARAM_locate, OSSL_PARAM_get_TYPE,
 OSSL_PARAM_set_TYPE, OSSL_PARAM_get_BN, OSSL_PARAM_set_BN,
 OSSL_PARAM_get_utf8_string, OSSL_PARAM_set_utf8_string,
 OSSL_PARAM_get_octet_string, OSSL_PARAM_set_octet_string,
@@ -46,6 +47,7 @@ OSSL_PARAM_set_octet_ptr
                                           size_t *rsize);
  OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
                                            size_t *rsize);
+ OSSL_PARAM OSSL_PARAM_construct_end(void);
 
  OSSL_PARAM *OSSL_PARAM_locate(OSSL_PARAM *array, const char *key);
 
@@ -178,6 +180,9 @@ OSSL_PARAM_construct_octet_ptr() is a function that constructes an OCTET string
 pointer OSSL_PARAM structure.
 A parameter with name B<key>, storage pointer B<*buf> and return size B<rsize>
 is created.
+
+OSSL_PARAM_construct_end() is a function that constructs the terminating
+OSSL_PARAM structure.
 
 OSSL_PARAM_locate() is a function that searches an B<array> of parameters for
 the one matching the B<key> name.

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -137,6 +137,7 @@ OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
                                              size_t bsize, size_t *rsize);
 OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
                                           size_t *rsize);
+OSSL_PARAM OSSL_PARAM_construct_end(void);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val);

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -471,7 +471,6 @@ static int test_param_construct(void)
     void *vp, *vpn = NULL, *vp2;
     OSSL_PARAM *p;
     const OSSL_PARAM *cp;
-    static const OSSL_PARAM pend = OSSL_PARAM_END;
     int i, n = 0, ret = 0;
     unsigned int u;
     long int l;
@@ -501,7 +500,7 @@ static int test_param_construct(void)
                                                     &sz);
     params[n++] = OSSL_PARAM_construct_utf8_ptr("utf8ptr", &bufp, &sz);
     params[n++] = OSSL_PARAM_construct_octet_ptr("octptr", &vp, &sz);
-    params[n] = pend;
+    params[n] = OSSL_PARAM_construct_end();
 
     /* Search failure */
     if (!TEST_ptr_null(OSSL_PARAM_locate(params, "fnord")))

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -391,7 +391,6 @@ static OSSL_PARAM *construct_api_params(void)
 {
     size_t n = 0;
     static OSSL_PARAM params[10];
-    OSSL_PARAM param_end = OSSL_PARAM_END;
 
     params[n++] = OSSL_PARAM_construct_int("p1", &app_p1, NULL);
     params[n++] = OSSL_PARAM_construct_BN("p3", bignumbin, sizeof(bignumbin),
@@ -404,7 +403,7 @@ static OSSL_PARAM *construct_api_params(void)
                                                 &app_p6_l);
     params[n++] = OSSL_PARAM_construct_octet_string("foo", &foo, sizeof(foo),
                                                     &foo_l);
-    params[n++] = param_end;
+    params[n++] = OSSL_PARAM_construct_end();
 
     return params;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4794,3 +4794,4 @@ EVP_PKEY_get0_engine                    4741	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_MD_upref                            4742	3_0_0	EXIST::FUNCTION:
 EVP_MD_fetch                            4743	3_0_0	EXIST::FUNCTION:
 EVP_set_default_properties              4744	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_construct_end                4745	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
OSSL_PARAM_END is a macro that can only be used to initialize an
OSSL_PARAM array, not to assign an array element later on.  For
completion, we add an end constructor to facilitate that kind of
assignment.
