### PR TITLE
 Fix a memory leak if using a custom X509_LOOKUP_METHOD

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -374,6 +374,11 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
             ok = 1;
             ret->type = tmp->type;
             memcpy(&ret->data, &tmp->data, sizeof(ret->data));
+            /*
+             * Up the ref count of the contained object (note X509_OBJECT itself
+             * is not ref counted).
+             */
+            X509_OBJECT_up_ref_count(ret);
 
             /*
              * Clear any errors that might have been raised processing empty

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -320,7 +320,12 @@ int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, X509_LOOKUP_TYPE type,
     ret->type = tmp->type;
     ret->data.ptr = tmp->data.ptr;
 
-    X509_OBJECT_up_ref_count(ret);
+    /*
+     * If we got this via X509_LOOKUP_by subject then the ref count of the
+     * contained object is already correct.
+     */
+    if (tmp != &stmp)
+         X509_OBJECT_up_ref_count(ret);
 
     return 1;
 }


### PR DESCRIPTION
I also add a test for this leak - the test will fail prior to the patch in this PR being applied if OpenSSL is configured with `enable-crypto-mdebug`.

Fixes #8707