### PR TITLE
prefer ERR_set_mark() and ERR_pop_to_mark() over ERR_clear_error() in SSL code

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -465,7 +465,7 @@ int DTLSv1_listen(SSL *s, BIO_ADDR *client)
     if (!SSL_clear(s))
         return -1;
 
-    ERR_clear_error();
+    ERR_clear_error(); /* TODO replace using ERR_pop_to_mark() if possible */
 
     rbio = SSL_get_rbio(s);
     wbio = SSL_get_wbio(s);

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -620,6 +620,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file)
     STACK_OF(X509_NAME) *ret = NULL;
     LHASH_OF(X509_NAME) *name_hash = lh_X509_NAME_new(xname_hash, xname_cmp);
 
+    (void)ERR_set_mark();
     if ((name_hash == NULL) || (in == NULL)) {
         SSLerr(SSL_F_SSL_LOAD_CLIENT_CA_FILE, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -664,8 +665,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file)
     BIO_free(in);
     X509_free(x);
     lh_X509_NAME_free(name_hash);
-    if (ret != NULL)
-        ERR_clear_error();
+    (void)ERR_pop_to_mark();
     return ret;
 }
 
@@ -687,6 +687,7 @@ int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     int ret = 1;
     int (*oldcmp) (const X509_NAME *const *a, const X509_NAME *const *b);
 
+    (void)ERR_set_mark();
     oldcmp = sk_X509_NAME_set_cmp_func(stack, xname_sk_cmp);
 
     in = BIO_new(BIO_s_file());
@@ -716,7 +717,7 @@ int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
         }
     }
 
-    ERR_clear_error();
+    (void)ERR_pop_to_mark();
     goto done;
 
  err:

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -308,7 +308,7 @@ static int state_machine(SSL *s, int server)
         return -1;
     }
 
-    ERR_clear_error();
+    ERR_clear_error(); /* TODO replace using ERR_pop_to_mark() if possible */
     clear_sys_error();
 
     cb = get_callback(s);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1901,6 +1901,7 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt)
         x = NULL;
     }
 
+    (void)ERR_set_mark();
     i = ssl_verify_cert_chain(s, sk);
     /*
      * The documented interface is that SSL_VERIFY_PEER should be set in order
@@ -1922,7 +1923,8 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt)
                  SSL_R_CERTIFICATE_VERIFY_FAILED);
         goto err;
     }
-    ERR_clear_error();          /* but we keep s->verify_result */
+    (void)ERR_pop_to_mark(); /* Don't leave any new errors in the queue */
+    /* but we keep s->verify_result */
     if (i > 1) {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
                  SSL_F_TLS_PROCESS_SERVER_CERTIFICATE, i);

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -945,9 +945,9 @@ static int ssl_add_cert_chain(SSL *s, WPACKET *pkt, CERT_PKEY *cpk)
          * ignore the error return from this call. We're not actually verifying
          * the cert - we're just building as much of the chain as we can
          */
+        (void)ERR_set_mark();
         (void)X509_verify_cert(xs_ctx);
-        /* Don't leave errors in the queue */
-        ERR_clear_error();
+        (void)ERR_pop_to_mark(); /* Don't leave any new errors in the queue */
         chain = X509_STORE_CTX_get0_chain(xs_ctx);
         i = ssl_security_cert_chain(s, chain, NULL, 0);
         if (i != 1) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3371,8 +3371,9 @@ static int tls_process_cke_gost(SSL *s, PACKET *pkt)
      */
     client_pub_pkey = X509_get0_pubkey(s->session->peer);
     if (client_pub_pkey) {
-        if (EVP_PKEY_derive_set_peer(pkey_ctx, client_pub_pkey) <= 0)
-            ERR_clear_error();
+        (void)ERR_set_mark();
+        (void)EVP_PKEY_derive_set_peer(pkey_ctx, client_pub_pkey);
+        (void)ERR_pop_to_mark();
     }
     /* Decrypt session key */
     if (!PACKET_get_1(pkt, &asn1id)

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1477,7 +1477,7 @@ SSL_TICKET_STATUS tls_decrypt_ticket(SSL *s, const unsigned char *etick,
             ret = SSL_TICKET_SUCCESS;
         goto end;
     }
-    ERR_clear_error();
+    ERR_clear_error(); /* TODO replace using ERR_pop_to_mark() if possible */
     /*
      * For session parse failure, indicate that we need to send a new ticket.
      */
@@ -2576,12 +2576,13 @@ static int has_usable_cert(SSL *s, const SIGALG_LOOKUP *sig, int idx)
         }
         return 0;
     }
+    (void)ERR_set_mark();
     supported = EVP_PKEY_supports_digest_nid(s->cert->pkeys[idx].privatekey,
                                              sig->hash);
     if (supported == 0)
         return 0;
     else if (supported < 0)
-        ERR_clear_error();
+        (void)ERR_pop_to_mark();
 
     return 1;
 }


### PR DESCRIPTION
In the SSL code there are still many occurrences of `ERR_clear_error()`. Their intention is to remove any local additions to the error queue in case an intermediate lower-level error needs to be ignored, but they do too much: they kill everything in the error queue. This is pretty unfortunate in case higher-level (library or application) code has produced beforehand some (preliminary) error queue entries that should possibly be printed later, after calls to SSL code, as helpful error diagnostics.

This PR aims at preserving any pre-existing error queue entries, by replacing `ERR_clear_error()` by a combination of `ERR_set_mark()` and `ERR_pop_to_mark()`. 

For many occurrences this is more or less straightforward, while I found a couple of places where it is not clear to me where the `ERR_set_mark()` should be placed. In such cases, I've kept the `ERR_clear_error()` (i.e., did not replace it by `ERR_pop_to_mark()`) but added a comment:
`/* TODO replace using ERR_pop_to_mark() if possible */`

For these cases I hope that anyone with deeper knowledge of the SSL code can take over, either continuing with the replacement or removing the `TODO` comment again where it is not appropriate/possible to replace the `ERR_clear_error()`. I can also continue enhancing this PR as far as I get respective hints.