### PR TITLE
Ignore entropy from RAND_add()/RAND_seed() in FIPS mode

### DIFF
--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -18,6 +18,8 @@
 #ifndef HEADER_RAND_INT_H
 # define HEADER_RAND_INT_H
 
+#define FIPS_MODE /* Testing only; to be removed */
+
 # include <openssl/rand.h>
 
 /* forward declaration */

--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -18,8 +18,6 @@
 #ifndef HEADER_RAND_INT_H
 # define HEADER_RAND_INT_H
 
-#define FIPS_MODE /* Testing only; to be removed */
-
 # include <openssl/rand.h>
 
 /* forward declaration */

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -1104,17 +1104,16 @@ static int drbg_add(const void *buf, int num, double randomness)
 #ifdef FIPS_MODE
     /*
      * NIST SP-800-90A mandates that entropy *shall not* be provided
-     * by the consuming application, neither for instantiation, nor
-     * for reseeding. By setting the randomness to zero, we ensured
-     * that the buffer contents will be added to the internal state
-     * of the DRBG only as additional data.
+     * by the consuming application. By setting the randomness to zero,
+     * we ensure that the buffer contents will be added to the internal
+     * state of the DRBG only as additional data.
      *
      * (NIST SP-800-90Ar1, Sections 9.1 and 9.2)
      */
     randomness = 0.0;
 #endif
     if (buflen < seedlen || randomness < (double) seedlen) {
-# if defined(OPENSSL_RAND_SEED_NONE)
+#if defined(OPENSSL_RAND_SEED_NONE)
         /*
          * If no os entropy source is available, a reseeding will fail
          * inevitably. So we use a trick to mix the buffer contents into
@@ -1127,14 +1126,14 @@ static int drbg_add(const void *buf, int num, double randomness)
         ret = RAND_DRBG_generate(drbg, dummy, sizeof(dummy), 0, buf, buflen);
         rand_drbg_unlock(drbg);
         return ret;
-# else
+#else
         /*
          * If an os entropy source is available then we declare the buffer content
          * as additional data by setting randomness to zero and trigger a regular
          * reseeding.
          */
         randomness = 0.0;
-# endif
+#endif
     }
 
     if (randomness > (double)seedlen) {

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -55,6 +55,11 @@ The content of B<buf> cannot be recovered from subsequent random generator outpu
 Applications that intend to save and restore random state in an external file
 should consider using L<RAND_load_file(3)> instead.
 
+NOTE: In FIPS mode, random data provided by the application is not considered to
+be a trusted entropy source. It is mixed into the internal state of the RNG as
+additional data only and this does not count as a full reseed.
+For more details, see L<RAND_DRBG(7)>.
+
 RAND_seed() is equivalent to RAND_add() with B<randomness> set to B<num>.
 
 RAND_keep_random_devices_open() is used to control file descriptor
@@ -86,6 +91,7 @@ L<RAND_bytes(3)>,
 L<RAND_egd(3)>,
 L<RAND_load_file(3)>,
 L<RAND(7)>
+L<RAND_DRBG(7)>
 
 =head1 HISTORY
 

--- a/doc/man7/RAND_DRBG.pod
+++ b/doc/man7/RAND_DRBG.pod
@@ -264,6 +264,14 @@ from the trusted entropy sources.
 
 =back
 
+NOTE: Manual reseeding is *not allowed* in FIPS mode, because
+NIST SP-800-90A mandates that entropy *shall not* be provided by the
+consuming application, neither for instantiation, nor for reseeding.
+[NIST SP 800-90Ar1, Sections 9.1 and 9.2]. For that reason the B<randomness>
+argument is ignored and the random bytes provided by the L<RAND_add(3)> and
+L<RAND_seed(3)> calls are treated as additional data. (In other words, the
+B<randomness> parameter is set to zero internally.)
+
 =head2 Reseeding the master DRBG with automatic seeding disabled
 
 Calling RAND_poll() will always fail.

--- a/doc/man7/RAND_DRBG.pod
+++ b/doc/man7/RAND_DRBG.pod
@@ -269,8 +269,7 @@ NIST SP-800-90A mandates that entropy *shall not* be provided by the
 consuming application, neither for instantiation, nor for reseeding.
 [NIST SP 800-90Ar1, Sections 9.1 and 9.2]. For that reason the B<randomness>
 argument is ignored and the random bytes provided by the L<RAND_add(3)> and
-L<RAND_seed(3)> calls are treated as additional data. (In other words, the
-B<randomness> parameter is set to zero internally.)
+L<RAND_seed(3)> calls are treated as additional data.
 
 =head2 Reseeding the master DRBG with automatic seeding disabled
 

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -802,6 +802,7 @@ static int test_rand_drbg_reseed(void)
     /* fill 'randomness' buffer with some arbitrary data */
     memset(rand_add_buf, 'r', sizeof(rand_add_buf));
 
+#ifndef FIPS_MODE
     /*
      * Test whether all three DRBGs are reseeded by RAND_add().
      * The before_reseed time has to be measured here and passed into the
@@ -827,6 +828,20 @@ static int test_rand_drbg_reseed(void)
     if (!TEST_true(test_drbg_reseed(0, master, public, private, 0, 0, 0, 0)))
         goto error;
     reset_drbg_hook_ctx();
+#else /* FIPS_MODE */
+    /*
+     * In FIPS mode, random data provided by the application via RAND_add()
+     * is not considered a trusted entropy source. It is only treated as
+     * additional_data and no reseeding is forced. This test assures that
+     * no reseeding occurs.
+     */
+    before_reseed = time(NULL);
+    RAND_add(rand_add_buf, sizeof(rand_add_buf), sizeof(rand_add_buf));
+    if (!TEST_true(test_drbg_reseed(1, master, public, private, 0, 0, 0,
+                                    before_reseed)))
+        goto error;
+    reset_drbg_hook_ctx();
+#endif
 
     rv = 1;
 


### PR DESCRIPTION
The functions RAND_add() and RAND_seed() provide a legacy API which
enables the application to seed the CSPRNG.

But NIST SP-800-90A clearly mandates that entropy *shall not* be provided
by the consuming application, neither for instantiation, nor for reseeding.

The provided random data will be mixed into the DRBG state as additional
data only, and no entropy will accounted for it.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
