### PR TITLE
Fix inconsistent manual section order; HISTORY

### DIFF
--- a/doc/man3/BIO_connect.pod
+++ b/doc/man3/BIO_connect.pod
@@ -102,8 +102,8 @@ L<BIO_ADDR(3)>
 =head1 HISTORY
 
 BIO_gethostname(), BIO_get_port(), BIO_get_host_ip(),
-BIO_get_accept_socket() and BIO_accept() were deprecated in
-OpenSSL 1.1.0.  Use the functions described above instead.
+BIO_get_accept_socket() and BIO_accept() were deprecated in OpenSSL 1.1.0.
+Use the functions described above instead.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BIO_connect.pod
+++ b/doc/man3/BIO_connect.pod
@@ -95,19 +95,19 @@ B<INVALID_SOCKET> (-1) on error.  When an error has occurred, the
 OpenSSL error stack will hold the error data and errno has the system
 error.
 
+=head1 SEE ALSO
+
+L<BIO_ADDR(3)>
+
 =head1 HISTORY
 
 BIO_gethostname(), BIO_get_port(), BIO_get_host_ip(),
 BIO_get_accept_socket() and BIO_accept() were deprecated in
 OpenSSL 1.1.0.  Use the functions described above instead.
 
-=head1 SEE ALSO
-
-L<BIO_ADDR(3)>
-
 =head1 COPYRIGHT
 
-Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -59,6 +59,15 @@ seeded with enough randomness to ensure an unpredictable byte sequence.
 The functions return 1 on success, 0 on error.
 The error codes can be obtained by L<ERR_get_error(3)>.
 
+=head1 SEE ALSO
+
+L<ERR_get_error(3)>,
+L<RAND_add(3)>,
+L<RAND_bytes(3)>,
+L<RAND_priv_bytes(3)>,
+L<RAND(7)>,
+L<RAND_DRBG(7)>
+
 =head1 HISTORY
 
 =over 2
@@ -78,18 +87,9 @@ BN_priv_rand() and BN_priv_rand_range() functions were added in OpenSSL 1.1.1.
 
 =back
 
-=head1 SEE ALSO
-
-L<ERR_get_error(3)>,
-L<RAND_add(3)>,
-L<RAND_bytes(3)>,
-L<RAND_priv_bytes(3)>,
-L<RAND(7)>,
-L<RAND_DRBG(7)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/BN_security_bits.pod
+++ b/doc/man3/BN_security_bits.pod
@@ -31,17 +31,17 @@ Number of security bits.
 ECC (Elliptic Curve Cryptography) is not covered by the BN_security_bits()
 function. The symmetric algorithms are not covered neither.
 
-=head1 HISTORY
-
-The BN_security_bits() function was added in OpenSSL 1.1.0.
-
 =head1 SEE ALSO
 
 L<DH_security_bits(3)>, L<DSA_security_bits(3)>, L<RSA_security_bits(3)>
 
+=head1 HISTORY
+
+The BN_security_bits() function was added in OpenSSL 1.1.0.
+
 =head1 COPYRIGHT
 
-Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/DES_random_key.pod
+++ b/doc/man3/DES_random_key.pod
@@ -296,6 +296,11 @@ last 4 bytes of the checksum of the input.
 DES_fcrypt() returns a pointer to the caller-provided buffer and DES_crypt() -
 to a static buffer on success; otherwise they return NULL.
 
+=head1 SEE ALSO
+
+L<des_modes(7)>,
+L<EVP_EncryptInit(3)>
+
 =head1 HISTORY
 
 The requirement that the B<salt> parameter to DES_crypt() and DES_fcrypt()
@@ -304,14 +309,9 @@ OpenSSL 1.1.0.  Previous versions tried to use the letter uppercase B<A>
 if both character were not present, and could crash when given non-ASCII
 on some platforms.
 
-=head1 SEE ALSO
-
-L<des_modes(7)>,
-L<EVP_EncryptInit(3)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -459,20 +459,20 @@ Skeleton pass phrase callback:
      return len;
  }
 
+=head1 SEE ALSO
+
+L<EVP_EncryptInit(3)>, L<EVP_BytesToKey(3)>,
+L<passphrase-encoding(7)>
+
 =head1 HISTORY
 
 The old Netscape certificate sequences were no longer documented
 in OpenSSL 1.1.0; applications should use the PKCS7 standard instead
 as they will be formally deprecated in a future releases.
 
-=head1 SEE ALSO
-
-L<EVP_EncryptInit(3)>, L<EVP_BytesToKey(3)>,
-L<passphrase-encoding(7)>
-
 =head1 COPYRIGHT
 
-Copyright 2001-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_DRBG_generate.pod
+++ b/doc/man3/RAND_DRBG_generate.pod
@@ -65,12 +65,6 @@ entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
 It is up to the user to ensure that a live entropy source is configured
 and is being used.
 
-=head1 HISTORY
-
-The RAND_DRBG functions were added in OpenSSL 1.1.1.
-
-Prediction resistance is supported from OpenSSL 3.0.0.
-
 =head1 SEE ALSO
 
 L<RAND_bytes(3)>,
@@ -78,9 +72,15 @@ L<RAND_DRBG_set_reseed_interval(3)>,
 L<RAND_DRBG_set_reseed_time_interval(3)>,
 L<RAND_DRBG(7)>
 
+=head1 HISTORY
+
+The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
+Prediction resistance is supported from OpenSSL 3.0.0.
+
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_DRBG_get0_master.pod
+++ b/doc/man3/RAND_DRBG_get0_master.pod
@@ -53,11 +53,6 @@ During initialization, it is possible to change the reseed interval
 and reseed time interval.
 It is also possible to exchange the reseeding callbacks entirely.
 
-
-=head1 HISTORY
-
-The RAND_DRBG functions were added in OpenSSL 1.1.1.
-
 =head1 SEE ALSO
 
 L<RAND_DRBG_set_callbacks(3)>,
@@ -68,9 +63,13 @@ L<RAND_DRBG_set_callbacks(3)>,
 L<RAND_DRBG_generate(3)>,
 L<RAND_DRBG(7)>
 
+=head1 HISTORY
+
+The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_DRBG_new.pod
+++ b/doc/man3/RAND_DRBG_new.pod
@@ -134,10 +134,6 @@ To ensure that they are applied to the global and thread-local DRBG instances
 RAND_DRBG_set_defaults() before creating any thread and before calling any
 cryptographic routines that obtain random data directly or indirectly.
 
-=head1 HISTORY
-
-The RAND_DRBG functions were added in OpenSSL 1.1.1.
-
 =head1 SEE ALSO
 
 L<OPENSSL_zalloc(3)>,
@@ -145,9 +141,13 @@ L<OPENSSL_secure_zalloc(3)>,
 L<RAND_DRBG_generate(3)>,
 L<RAND_DRBG(7)>
 
+=head1 HISTORY
+
+The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_DRBG_reseed.pod
+++ b/doc/man3/RAND_DRBG_reseed.pod
@@ -93,17 +93,6 @@ To ensure that they are applied to the global and thread-local DRBG instances
 RAND_DRBG_set_reseed_defaults() before creating any thread and before calling any
  cryptographic routines that obtain random data directly or indirectly.
 
-A request for prediction resistance can only be satisfied by pulling fresh
-entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
-It is up to the user to ensure that a live entropy source is configured
-and is being used.
-
-=head1 HISTORY
-
-The RAND_DRBG functions were added in OpenSSL 1.1.1.
-
-Prediction resistance is supported from OpenSSL 3.0.0.
-
 =head1 SEE ALSO
 
 L<RAND_DRBG_generate(3)>,
@@ -111,9 +100,15 @@ L<RAND_DRBG_bytes(3)>,
 L<RAND_DRBG_set_callbacks(3)>.
 L<RAND_DRBG(7)>
 
+=head1 HISTORY
+
+The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
+Prediction resistance is supported from OpenSSL 3.0.0.
+
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_DRBG_set_callbacks.pod
+++ b/doc/man3/RAND_DRBG_set_callbacks.pod
@@ -121,20 +121,19 @@ In this case the DRBG will automatically request an extra amount of entropy
 utilize for the nonce, following the recommendations of [NIST SP 800-90A Rev. 1],
 section 8.6.7.
 
-
-=head1 HISTORY
-
-The RAND_DRBG functions were added in OpenSSL 1.1.1.
-
 =head1 SEE ALSO
 
 L<RAND_DRBG_new(3)>,
 L<RAND_DRBG_reseed(3)>,
 L<RAND_DRBG(7)>
 
+=head1 HISTORY
+
+The RAND_DRBG functions were added in OpenSSL 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -80,11 +80,6 @@ RAND_event() returns RAND_status().
 
 The other functions do not return values.
 
-=head1 HISTORY
-
-RAND_event() and RAND_screen() were deprecated in OpenSSL 1.1.0 and should
-not be used.
-
 =head1 SEE ALSO
 
 L<RAND_bytes(3)>,
@@ -92,9 +87,14 @@ L<RAND_egd(3)>,
 L<RAND_load_file(3)>,
 L<RAND(7)>
 
+=head1 HISTORY
+
+RAND_event() and RAND_screen() were deprecated in OpenSSL 1.1.0 and should
+not be used.
+
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -43,6 +43,15 @@ return 1 on success, -1 if not supported by the current
 RAND method, or 0 on other failure. The error code can be
 obtained by L<ERR_get_error(3)>.
 
+=head1 SEE ALSO
+
+L<RAND_add(3)>,
+L<RAND_bytes(3)>,
+L<RAND_priv_bytes(3)>,
+L<ERR_get_error(3)>,
+L<RAND(7)>,
+L<RAND_DRBG(7)>
+
 =head1 HISTORY
 
 =over 2
@@ -57,18 +66,9 @@ The RAND_priv_bytes() function was added in OpenSSL 1.1.1.
 
 =back
 
-=head1 SEE ALSO
-
-L<RAND_add(3)>,
-L<RAND_bytes(3)>,
-L<RAND_priv_bytes(3)>,
-L<ERR_get_error(3)>,
-L<RAND(7)>,
-L<RAND_DRBG(7)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/RAND_cleanup.pod
+++ b/doc/man3/RAND_cleanup.pod
@@ -25,18 +25,18 @@ L<OPENSSL_init_crypto(3)>.
 
 RAND_cleanup() returns no value.
 
+=head1 SEE ALSO
+
+L<RAND(7)>
+
 =head1 HISTORY
 
 RAND_cleanup() was deprecated in OpenSSL 1.1.0; do not use it.
 See L<OPENSSL_init_crypto(3)>
 
-=head1 SEE ALSO
-
-L<RAND(7)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -180,6 +180,11 @@ SSL_CIPHER_get_id() returns a 4-byte integer representing the OpenSSL-specific I
 SSL_CIPHER_get_protocol_id() returns a 2-byte integer representing the TLS
 protocol-specific ID.
 
+=head1 SEE ALSO
+
+L<ssl(7)>, L<SSL_get_current_cipher(3)>,
+L<SSL_get_ciphers(3)>, L<ciphers(1)>
+
 =head1 HISTORY
 
 The SSL_CIPHER_get_version() function was updated to always return the
@@ -196,14 +201,9 @@ required to enable this function.
 
 The OPENSSL_cipher_name() function was added in OpenSSL 1.1.1.
 
-=head1 SEE ALSO
-
-L<ssl(7)>, L<SSL_get_current_cipher(3)>,
-L<SSL_get_ciphers(3)>, L<ciphers(1)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -203,7 +203,7 @@ removed in OpenSSL 1.1.0.
 
 SSLv23_method(), SSLv23_server_method() and SSLv23_client_method()
 were deprecated and the preferred TLS_method(), TLS_server_method()
-and TLS_client_method() functions were introduced in OpenSSL 1.1.0.
+and TLS_client_method() functions were added in OpenSSL 1.1.0.
 
 All version-specific methods were deprecated in OpenSSL 1.1.0.
 

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -190,6 +190,11 @@ SSL_CTX_up_ref() returns 1 for success and 0 for failure.
 
 =back
 
+=head1 SEE ALSO
+
+L<SSL_CTX_set_options(3)>, L<SSL_CTX_free(3)>, L<SSL_accept(3)>,
+L<SSL_CTX_set_min_proto_version(3)>, L<ssl(7)>, L<SSL_set_connect_state(3)>
+
 =head1 HISTORY
 
 Support for SSLv2 and the corresponding SSLv2_method(),
@@ -202,14 +207,9 @@ and TLS_client_method() functions were introduced in OpenSSL 1.1.0.
 
 All version-specific methods were deprecated in OpenSSL 1.1.0.
 
-=head1 SEE ALSO
-
-L<SSL_CTX_set_options(3)>, L<SSL_CTX_free(3)>, L<SSL_accept(3)>,
-L<SSL_CTX_set_min_proto_version(3)>, L<ssl(7)>, L<SSL_set_connect_state(3)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CTX_set_default_passwd_cb.pod
+++ b/doc/man3/SSL_CTX_set_default_passwd_cb.pod
@@ -90,20 +90,20 @@ truncated.
      return strlen(buf);
  }
 
+=head1 SEE ALSO
+
+L<ssl(7)>,
+L<SSL_CTX_use_certificate(3)>
+
 =head1 HISTORY
 
 SSL_CTX_get_default_passwd_cb(), SSL_CTX_get_default_passwd_cb_userdata(),
 SSL_set_default_passwd_cb() and SSL_set_default_passwd_cb_userdata() were
 added in OpenSSL 1.1.0.
 
-=head1 SEE ALSO
-
-L<ssl(7)>,
-L<SSL_CTX_use_certificate(3)>
-
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -52,18 +52,18 @@ lowest or highest protocol, respectively.
 
 All these functions are implemented using macros.
 
+=head1 SEE ALSO
+
+L<SSL_CTX_set_options(3)>, L<SSL_CONF_cmd(3)>
+
 =head1 HISTORY
 
 The setter functions were added in OpenSSL 1.1.0. The getter functions
 were added in OpenSSL 1.1.1.
 
-=head1 SEE ALSO
-
-L<SSL_CTX_set_options(3)>, L<SSL_CONF_cmd(3)>
-
 =head1 COPYRIGHT
 
-Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_CTX_set_split_send_fragment.pod
+++ b/doc/man3/SSL_CTX_set_split_send_fragment.pod
@@ -162,6 +162,10 @@ SSL_set_default_read_buffer_len(), SSL_CTX_set_tlsext_max_fragment_length(),
 SSL_set_tlsext_max_fragment_length() and SSL_SESSION_get_max_fragment_length()
 all these functions are implemented using macros.
 
+=head1 SEE ALSO
+
+L<SSL_CTX_set_read_ahead(3)>, L<SSL_pending(3)>
+
 =head1 HISTORY
 
 The SSL_CTX_set_max_pipelines(), SSL_set_max_pipelines(),
@@ -172,13 +176,9 @@ functions were added in OpenSSL 1.1.0.
 The SSL_CTX_set_tlsext_max_fragment_length(), SSL_set_tlsext_max_fragment_length()
 and SSL_SESSION_get_max_fragment_length() functions were added in OpenSSL 1.1.1.
 
-=head1 SEE ALSO
-
-L<SSL_CTX_set_read_ahead(3)>, L<SSL_pending(3)>
-
 =head1 COPYRIGHT
 
-Copyright 2016-2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_read.pod
+++ b/doc/man3/SSL_read.pod
@@ -126,10 +126,6 @@ You should instead call SSL_get_error() to find out if it's retryable.
 
 =back
 
-=head1 HISTORY
-
-The SSL_read_ex() and SSL_peek_ex() functions were added in OpenSSL 1.1.1.
-
 =head1 SEE ALSO
 
 L<SSL_get_error(3)>, L<SSL_write_ex(3)>,
@@ -140,9 +136,13 @@ L<SSL_pending(3)>,
 L<SSL_shutdown(3)>, L<SSL_set_shutdown(3)>,
 L<ssl(7)>, L<bio(7)>
 
+=head1 HISTORY
+
+The SSL_read_ex() and SSL_peek_ex() functions were added in OpenSSL 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -104,10 +104,6 @@ You should instead call SSL_get_error() to find out if it's retryable.
 
 =back
 
-=head1 HISTORY
-
-The SSL_write_ex() function was added in OpenSSL 1.1.1.
-
 =head1 SEE ALSO
 
 L<SSL_get_error(3)>, L<SSL_read_ex(3)>, L<SSL_read(3)>
@@ -116,9 +112,13 @@ L<SSL_connect(3)>, L<SSL_accept(3)>
 L<SSL_set_connect_state(3)>,
 L<ssl(7)>, L<bio(7)>
 
+=head1 HISTORY
+
+The SSL_write_ex() function was added in OpenSSL 1.1.1.
+
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/X509_get_subject_name.pod
+++ b/doc/man3/X509_get_subject_name.pod
@@ -48,14 +48,6 @@ and X509_CRL_get_issuer() return an B<X509_NAME> pointer.
 X509_set_subject_name(), X509_set_issuer_name(), X509_REQ_set_subject_name()
 and X509_CRL_set_issuer_name() return 1 for success and 0 for failure.
 
-=head1 HISTORY
-
-X509_REQ_get_subject_name() is a function in OpenSSL 1.1.0 and a macro in
-earlier versions.
-
-X509_CRL_get_issuer() is a function in OpenSSL 1.1.0. It was previously
-added in OpenSSL 1.0.0 as a macro.
-
 =head1 SEE ALSO
 
 L<d2i_X509(3)>,
@@ -74,9 +66,17 @@ L<X509_sign(3)>,
 L<X509V3_get_d2i(3)>,
 L<X509_verify_cert(3)>
 
+=head1 HISTORY
+
+X509_REQ_get_subject_name() is a function in OpenSSL 1.1.0 and a macro in
+earlier versions.
+
+X509_CRL_get_issuer() is a function in OpenSSL 1.1.0. It was previously
+added in OpenSSL 1.0.0 as a macro.
+
 =head1 COPYRIGHT
 
-Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2015-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2002-2018 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -142,16 +142,18 @@ sub name_synopsis()
     }
 }
 
-# Check if EXAMPLES is located after RETURN VALUES section.
-sub check_example_location()
+# Check if SECTION is located before BEFORE
+sub check_section_location()
 {
     my $filename = shift;
     my $contents = shift;
+    my $section = shift;
+    my $before = shift;
 
-    return unless $contents =~ /=head1 RETURN VALUES/
-        and $contents =~ /=head1 EXAMPLES/;
-    print "$filename: RETURN VAULES should be placed before EXAMPLES section\n"
-        if $contents =~ /=head1 EXAMPLES.*=head1 RETURN VALUES/ms;
+    return unless $contents =~ /=head1 $section/
+        and $contents =~ /=head1 $before/;
+    print "$filename: $section should be placed before $before section\n"
+        if $contents =~ /=head1 $before.*=head1 $section/ms;
 }
 
 sub check()
@@ -167,7 +169,8 @@ sub check()
         close POD;
     }
 
-    &check_example_location($filename, $contents) if $filename =~ m|man3/|;
+    # Check if EXAMPLES is located after RETURN VALUES section.
+    &check_section_location($filename, $contents, "RETURN VALUES", "EXAMPLES") if $filename =~ m|man3/|;
 
     my $id = "${filename}:1:";
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -173,6 +173,8 @@ sub check()
     &check_section_location($filename, $contents, "RETURN VALUES", "EXAMPLES") if $filename =~ m|man3/|;
     # Check if HISTORY is located after SEE ALSO
     &check_section_location($filename, $contents, "SEE ALSO", "HISTORY") if $filename =~ m|man3/|;
+    # Check if SEE ALSO is located after EXAMPLES
+    &check_section_location($filename, $contents, "EXAMPLES", "SEE ALSO") if $filename =~ m|man3/|;
 
     my $id = "${filename}:1:";
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -171,6 +171,8 @@ sub check()
 
     # Check if EXAMPLES is located after RETURN VALUES section.
     &check_section_location($filename, $contents, "RETURN VALUES", "EXAMPLES") if $filename =~ m|man3/|;
+    # Check if HISTORY is located after SEE ALSO
+    &check_section_location($filename, $contents, "SEE ALSO", "HISTORY") if $filename =~ m|man3/|;
 
     my $id = "${filename}:1:";
 


### PR DESCRIPTION
# TODO from issue #8631
* [x]  _(optional)_ expand #8338 `util/find-doc-nits` changes to detect out of order sections - in de46dc83 and fabf65a9
* [x]  reorder `HISTORY` sections across all `.pod` files - in 6d7fd68a
* [x]  _(optional)_ edit where necessary to conform to #7854 style for `HISTORY` sections - in 43cd239a