### PR TITLE
Don't use coordinate blinding when scalar is group order

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -441,7 +441,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
          * scalar multiplication implementation based on a Montgomery ladder,
          * with various timing attack defenses.
          */
-        if ((scalar != NULL) && (num == 0)) {
+        if ((scalar != group->order) && (scalar != NULL) && (num == 0)) {
             /*-
              * In this case we want to compute scalar * GeneratorPoint: this
              * codepath is reached most prominently by (ephemeral) key
@@ -452,7 +452,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
              */
             return ec_scalar_mul_ladder(group, r, scalar, NULL, ctx);
         }
-        if ((scalar == NULL) && (num == 1)) {
+        if ((scalar == NULL) && (num == 1) && (scalars[0] != group->order)) {
             /*-
              * In this case we want to compute scalar * VariablePoint: this
              * codepath is reached most prominently by the second half of ECDH,


### PR DESCRIPTION
This happens in ec_key_simple_check_key and EC_GROUP_check.
Since the the group order is not a secret scalar, it is
unnecessary to use coordinate blinding.

Fixes: #8731
