### PR TITLE
Don't turn undefined symbols into an error

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -32,7 +32,6 @@ my %shared_info;
         return {
             %{$shared_info{'gnu-shared'}},
             shared_defflag    => '-Wl,--version-script=',
-            dso_ldflags       => '-z defs',
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },


### PR DESCRIPTION
Clang does not seem to link to libasan when creating shared libraries.

Fixes: #8735

[extended tests]
