### PR TITLE
Change default RSA key size to 2048 bit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Change the default RSA, DSA and DH size to 2048 bit instead of 1024.
+     This changes the size when using the genpkey app when no size is given. It
+     fixes an omission in earlier changes that changed all RSA, DSA and DH
+     generation apps to use 2048 bits by default.
+     [Kurt Roeckx]
+
   *) The functions AES_ige_encrypt() and AES_bi_ige_encrypt() have been
      deprecated. These undocumented functions were never integrated into the EVP
      layer and implement the AES Infinite Garble Extension (IGE) mode and AES

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -54,7 +54,7 @@ static int pkey_dh_init(EVP_PKEY_CTX *ctx)
         DHerr(DH_F_PKEY_DH_INIT, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    dctx->prime_len = 1024;
+    dctx->prime_len = 2048;
     dctx->subprime_len = -1;
     dctx->generator = 2;
     dctx->kdf_type = EVP_PKEY_DH_KDF_NONE;

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -20,7 +20,7 @@
 
 typedef struct {
     /* Parameter gen parameters */
-    int nbits;                  /* size of p in bits (default: 1024) */
+    int nbits;                  /* size of p in bits (default: 2048) */
     int qbits;                  /* size of q in bits (default: 160) */
     const EVP_MD *pmd;          /* MD for parameter generation */
     /* Keygen callback info */
@@ -35,8 +35,8 @@ static int pkey_dsa_init(EVP_PKEY_CTX *ctx)
 
     if (dctx == NULL)
         return 0;
-    dctx->nbits = 1024;
-    dctx->qbits = 160;
+    dctx->nbits = 2048;
+    dctx->qbits = 224;
     dctx->pmd = NULL;
     dctx->md = NULL;
 

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -21,7 +21,7 @@
 typedef struct {
     /* Parameter gen parameters */
     int nbits;                  /* size of p in bits (default: 2048) */
-    int qbits;                  /* size of q in bits (default: 160) */
+    int qbits;                  /* size of q in bits (default: 224) */
     const EVP_MD *pmd;          /* MD for parameter generation */
     /* Keygen callback info */
     int gentmp[2];

--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -56,7 +56,7 @@ static int pkey_rsa_init(EVP_PKEY_CTX *ctx)
 
     if (rctx == NULL)
         return 0;
-    rctx->nbits = 1024;
+    rctx->nbits = 2048;
     rctx->primes = RSA_DEFAULT_PRIME_NUM;
     if (pkey_ctx_is_pss(ctx))
         rctx->pad_mode = RSA_PKCS1_PSS_PADDING;

--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -118,7 +118,7 @@ or ED448 algorithms.
 
 =item B<rsa_keygen_bits:numbits>
 
-The number of bits in the generated key. If not specified 1024 is used.
+The number of bits in the generated key. If not specified 2048 is used.
 
 =item B<rsa_keygen_primes:numprimes>
 
@@ -185,12 +185,12 @@ below.
 
 =item B<dsa_paramgen_bits:numbits>
 
-The number of bits in the generated prime. If not specified 1024 is used.
+The number of bits in the generated prime. If not specified 2048 is used.
 
 =item B<dsa_paramgen_q_bits:numbits>
 
 The number of bits in the q parameter. Must be one of 160, 224 or 256. If not
-specified 160 is used.
+specified 224 is used.
 
 =item B<dsa_paramgen_md:digest>
 
@@ -209,7 +209,7 @@ or B<sha256> if it is 256.
 
 =item B<dh_paramgen_prime_len:numbits>
 
-The number of bits in the prime parameter B<p>. The default is 1024.
+The number of bits in the prime parameter B<p>. The default is 2048.
 
 =item B<dh_paramgen_subprime_len:numbits>
 


### PR DESCRIPTION
Fixes: #8737
