### PR TITLE
Fixes of the provider digest interface

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -295,6 +295,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize)
 {
     int ret;
     size_t size = 0;
+    size_t mdsize = EVP_MD_size(ctx->digest);
 
     if (ctx->digest == NULL || ctx->digest->prov == NULL)
         goto legacy;
@@ -304,7 +305,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize)
         return 0;
     }
 
-    ret = ctx->digest->dfinal(ctx->provctx, md, &size);
+    ret = ctx->digest->dfinal(ctx->provctx, md, &size, mdsize);
 
     if (isize != NULL) {
         if (size <= UINT_MAX) {
@@ -321,10 +322,10 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize)
 
     /* TODO(3.0): Remove legacy code below */
  legacy:
-    OPENSSL_assert(ctx->digest->md_size <= EVP_MAX_MD_SIZE);
+    OPENSSL_assert(mdsize <= EVP_MAX_MD_SIZE);
     ret = ctx->digest->final(ctx, md);
     if (isize != NULL)
-        *isize = ctx->digest->md_size;
+        *isize = mdsize;
     if (ctx->digest->cleanup) {
         ctx->digest->cleanup(ctx);
         EVP_MD_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_CLEANED);

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -91,10 +91,10 @@ OSSL_CORE_MAKE_FUNC(int, OP_digest_init, (void *vctx))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_update,
                     (void *, const unsigned char *in, size_t inl))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_final,
-                    (void *, unsigned char *out, size_t *outl))
+                    (void *, unsigned char *out, size_t *outl, size_t outsz))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_digest,
                     (const unsigned char *in, size_t inl, unsigned char *out,
-                     size_t *out_l))
+                     size_t *out_l, size_t outsz))
 OSSL_CORE_MAKE_FUNC(void, OP_digest_cleanctx, (void *vctx))
 OSSL_CORE_MAKE_FUNC(void, OP_digest_freectx, (void *vctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_digest_dupctx, (void *vctx))

--- a/providers/common/digests/sha2.c
+++ b/providers/common/digests/sha2.c
@@ -11,10 +11,12 @@
 #include <openssl/crypto.h>
 #include <openssl/core_numbers.h>
 
-static int sha256_final(void *ctx, unsigned char *md, size_t *size)
+static int sha256_final(void *ctx,
+                        unsigned char *md, size_t *mdl, size_t mdsz)
 {
-    if (SHA256_Final(md, ctx)) {
-        *size = SHA256_DIGEST_LENGTH;
+    if (mdsz >= SHA256_DIGEST_LENGTH
+        && SHA256_Final(md, ctx)) {
+        *mdl = SHA256_DIGEST_LENGTH;
         return 1;
     }
 

--- a/providers/common/digests/sha2.c
+++ b/providers/common/digests/sha2.c
@@ -11,6 +11,22 @@
 #include <openssl/crypto.h>
 #include <openssl/core_numbers.h>
 
+/*
+ * Forward declaration of everything implemented here.  This is not strictly
+ * necessary for the compiler, but provides an assurance that the signatures
+ * of the functions in the dispatch table are correct.
+ */
+static OSSL_OP_digest_newctx_fn sha256_newctx;
+#if 0                           /* Not defined here */
+static OSSL_OP_digest_init_fn sha256_init;
+static OSSL_OP_digest_update_fn sha256_update;
+#endif
+static OSSL_OP_digest_final_fn sha256_final;
+static OSSL_OP_digest_freectx_fn sha256_freectx;
+static OSSL_OP_digest_dupctx_fn sha256_dupctx;
+static OSSL_OP_digest_size_fn sha256_size;
+static OSSL_OP_digest_block_size_fn sha256_size;
+
 static int sha256_final(void *ctx,
                         unsigned char *md, size_t *mdl, size_t mdsz)
 {


### PR DESCRIPTION
## Providers: for the digest_final operation, pass a output buffer size

This allows the provider digest_final operation to check that it
doesn't over-run the output buffer.

The EVP_DigestFinal_ex function doesn't take that same parameter, so
it will have to assume that the user provided a properly sized buffer,
but this leaves better room for future enhancements of the public API.

## providers/common/digests/sha2.c: forward declare all dispatched functions

Forward declare the dispatched functions using typedefs from
core_numbers.h.  This will ensure that they have correct signatures.