### PR TITLE
Don't use '-z defs' with Clang's sanitizers

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -32,7 +32,10 @@ my %shared_info;
         return {
             %{$shared_info{'gnu-shared'}},
             shared_defflag    => '-Wl,--version-script=',
-            dso_ldflags       => '-z defs',
+            dso_ldflags       =>
+                $disabled{asan} && $disabled{msan} && $disabled{ubsan}
+                ? '-z defs'
+                : '',
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },


### PR DESCRIPTION
The clang documentation in all sanitizers we currently use says this:

    When linking shared libraries, the {flavor}Sanitizer run-time is
    not linked, so -Wl,-z,defs may cause link errors (don’t use it
    with {flavor}Sanitizer)

(in our case, {flavor} is one of Address, Memory, or UndefinedBehavior)

Therefore, we turn off that particular flag specifically when using
the sanitizers.

Fixes #8735
