### PR TITLE
 asn1parse: avoid double free

### DIFF
--- a/apps/asn1pars.c
+++ b/apps/asn1pars.c
@@ -170,17 +170,17 @@ int asn1parse_main(int argc, char **argv)
     if (derfile && (derout = bio_open_default(derfile, 'w', FORMAT_ASN1)) == NULL)
         goto end;
 
+    if ((buf = BUF_MEM_new()) == NULL)
+        goto end;
     if (strictpem) {
-        if (PEM_read_bio(in, &name, &header, &str, &num) !=
-            1) {
+        if (PEM_read_bio(in, &name, &header, &str, &num) != 1) {
             BIO_printf(bio_err, "Error reading PEM file\n");
             ERR_print_errors(bio_err);
             goto end;
         }
+        buf->data = (char *)str;
+        buf->length = buf->max = num;
     } else {
-
-        if ((buf = BUF_MEM_new()) == NULL)
-            goto end;
         if (!BUF_MEM_grow(buf, BUFSIZ * 8))
             goto end;           /* Pre-allocate :-) */
 
@@ -303,8 +303,6 @@ int asn1parse_main(int argc, char **argv)
     BUF_MEM_free(buf);
     OPENSSL_free(name);
     OPENSSL_free(header);
-    if (strictpem)
-        OPENSSL_free(str);
     ASN1_TYPE_free(at);
     sk_OPENSSL_STRING_free(osk);
     return ret;


### PR DESCRIPTION
|str| was used for multiple conflicting purposes.  When '-strictpem',
it's used to uniquely hold a reference to the loaded payload.
However, when using '-strparse', |str| was re-used to hold the
position from where to start parsing.

So when '-strparse' and '-strictpem' are used together, |str| ends up
pointing into data pointed at by |at|, and is yet being freed, with
the result that the payload it held a reference to becomes a memory
leak, and there's a double free conflict when both |str| and |at| are
being freed.

The situation is resolved by always having |buf| hold the pointer to
the file data, and always and only use |str| to hold the position to
start parsing from.  Now, we only need to free |buf| properly and not
|str|.

Fixes #8752
