### PR TITLE
doc/man3/X509_LOOKUP_meth_new.pod: clarify the requirements

### DIFF
--- a/doc/man3/X509_LOOKUP_meth_new.pod
+++ b/doc/man3/X509_LOOKUP_meth_new.pod
@@ -150,17 +150,17 @@ the X509_LOOKUP context, the type of the X509_OBJECT being requested, parameters
 related to the lookup, and an X509_OBJECT that will receive the requested
 object.
 
-Implementations must add objects it finds to the B<X509_STORE> object
-using X509_STORE_add_cert() or X509_STORE_add_crl().  This "duplicates"
-the object by incrementing its reference counter.  However, the
-X509_STORE_CTX_get_by_subject() function also increases the reference
-count which leads to one too many references being held.  Therefore
-applications should additionally call X509_free() or X509_CRL_free()
-to decrement the reference count again.
+Implementations must add objects they find to the B<X509_STORE> object
+using X509_STORE_add_cert() or X509_STORE_add_crl().  This increments
+its reference counter.  However, the X509_STORE_CTX_get_by_subject()
+function also increases the reference count which leads to one too
+many references being held.  Therefore applications should
+additionally call X509_free() or X509_CRL_free() to decrement the
+reference count again.
 
 Implementations should also use either X509_OBJECT_set1_X509() or
-X509_OBJECT_set1_X509_CRL() to set the result.  This also "duplicates"
-the object by incrementing its reference counter.
+X509_OBJECT_set1_X509_CRL() to set the result.  Note that this also
+increments the result's reference counter.
 
 Any method data that was created as a result of the new_item function
 set by X509_LOOKUP_meth_set_new_item() can be accessed with

--- a/doc/man3/X509_LOOKUP_meth_new.pod
+++ b/doc/man3/X509_LOOKUP_meth_new.pod
@@ -152,7 +152,7 @@ object.
 
 Implementations must add objects they find to the B<X509_STORE> object
 using X509_STORE_add_cert() or X509_STORE_add_crl().  This increments
-its reference counter.  However, the X509_STORE_CTX_get_by_subject()
+its reference count.  However, the X509_STORE_CTX_get_by_subject()
 function also increases the reference count which leads to one too
 many references being held.  Therefore applications should
 additionally call X509_free() or X509_CRL_free() to decrement the
@@ -160,7 +160,7 @@ reference count again.
 
 Implementations should also use either X509_OBJECT_set1_X509() or
 X509_OBJECT_set1_X509_CRL() to set the result.  Note that this also
-increments the result's reference counter.
+increments the result's reference count.
 
 Any method data that was created as a result of the new_item function
 set by X509_LOOKUP_meth_set_new_item() can be accessed with

--- a/doc/man3/X509_LOOKUP_meth_new.pod
+++ b/doc/man3/X509_LOOKUP_meth_new.pod
@@ -150,10 +150,20 @@ the X509_LOOKUP context, the type of the X509_OBJECT being requested, parameters
 related to the lookup, and an X509_OBJECT that will receive the requested
 object.
 
-Implementations should use either X509_OBJECT_set1_X509() or
-X509_OBJECT_set1_X509_CRL() to set the result. Any method data that was
-created as a result of the new_item function set by
-X509_LOOKUP_meth_set_new_item() can be accessed with
+Implementations must add objects it finds to the B<X509_STORE> object
+using X509_STORE_add_cert() or X509_STORE_add_crl().  This "duplicates"
+the object by incrementing its reference counter.  However, the
+X509_STORE_CTX_get_by_subject() function also increases the reference
+count which leads to one too many references being held.  Therefore
+applications should additionally call X509_free() or X509_CRL_free()
+to decrement the reference count again.
+
+Implementations should also use either X509_OBJECT_set1_X509() or
+X509_OBJECT_set1_X509_CRL() to set the result.  This also "duplicates"
+the object by incrementing its reference counter.
+
+Any method data that was created as a result of the new_item function
+set by X509_LOOKUP_meth_set_new_item() can be accessed with
 X509_LOOKUP_get_method_data(). The B<X509_STORE> object that owns the
 X509_LOOKUP may be accessed with X509_LOOKUP_get_store(). Successful lookups
 should return 1, and unsuccessful lookups should return 0.


### PR DESCRIPTION
The documentation of what a X509_LOOKUP implementation must do was
unclear and confusing.  Most of all, clarification was needed that it
must store away the found objects in the X509_STORE.

Fixes #8707
