### PR TITLE
Fix the generic EVP algorithm fetch to actually cache them

### DIFF
--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -203,6 +203,8 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
                                        properties, 0 /* !force_cache */,
                                        &mcm, &mcmdata);
         ossl_method_store_cache_set(store, nid, properties, method);
+    } else {
+        upref_method(method);
     }
 
     return method;

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -173,11 +173,15 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
                         void (*free_method)(void *),
                         int (*nid_method)(void *))
 {
+    OSSL_METHOD_STORE *store = get_default_method_store(libctx);
     int nid = OBJ_sn2nid(algorithm);
     void *method = NULL;
 
+    if (store == NULL)
+        return NULL;
+
     if (nid == NID_undef
-        || !ossl_method_store_cache_get(NULL, nid, properties, &method)) {
+        || !ossl_method_store_cache_get(store, nid, properties, &method)) {
         OSSL_METHOD_CONSTRUCT_METHOD mcm = {
             alloc_tmp_method_store,
             dealloc_tmp_method_store,
@@ -198,7 +202,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
         method = ossl_method_construct(libctx, operation_id, algorithm,
                                        properties, 0 /* !force_cache */,
                                        &mcm, &mcmdata);
-        ossl_method_store_cache_set(NULL, nid, properties, method);
+        ossl_method_store_cache_set(store, nid, properties, method);
     }
 
     return method;

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -98,6 +98,7 @@ void OPENSSL_LH_flush(OPENSSL_LHASH *lh)
             OPENSSL_free(n);
             n = nn;
         }
+        lh->b[i] = NULL;
     }
 }
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -450,7 +450,7 @@ int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, int nid,
         return 0;
     }
 
-    elem.query = prop_query;
+    elem.query = prop_query != NULL ? prop_query : "";
     r = lh_QUERY_retrieve(alg->cache, &elem);
     if (r == NULL) {
         ossl_property_unlock(store);


### PR DESCRIPTION
ossl_method_store_cache_get() and ossl_method_store_cache_set() were
called with a NULL argument for store, which means no caching is
done.  Give them a real store instead.
