### PR TITLE
Change the digest string from "md" to "digest"

### DIFF
--- a/crypto/kdf/sshkdf.c
+++ b/crypto/kdf/sshkdf.c
@@ -125,6 +125,9 @@ static int kdf_sshkdf_ctrl_str(EVP_KDF_IMPL *impl, const char *type,
         return 0;
     }
 
+    if (strcmp(type, "digest") == 0)
+        return kdf_md2ctrl(impl, kdf_sshkdf_ctrl, EVP_KDF_CTRL_SET_MD, value);
+    /* alias, for historical reasons */
     if (strcmp(type, "md") == 0)
         return kdf_md2ctrl(impl, kdf_sshkdf_ctrl, EVP_KDF_CTRL_SET_MD, value);
 

--- a/test/recipes/20-test_kdf.t
+++ b/test/recipes/20-test_kdf.t
@@ -37,7 +37,7 @@ my @kdf_tests = (
     { cmd => [qw{openssl kdf -keylen 14 -kdfopt digest:SHA224 -kdfopt hexkey:6dbdc23f045488e4062757b06b9ebae183fc5a5946d80db93fec6f62ec07e3727f0126aed12ce4b262f47d48d54287f81d474c7c3b1850e9 -kdfopt hexinfo:a1b2c3d4e54341565369643c832e9849dcdba71e9a3139e606e095de3c264a66e98a165854cd07989b1ee0ec3f8dbe SSKDF}],
       expected => 'a4:62:de:16:a8:9d:e8:46:6e:f5:46:0b:47:b8',
       desc => 'SSKDF HASH SHA224'},
-    { cmd => [qw{openssl kdf -keylen 16 -kdfopt md:SHA256 -kdfopt hexkey:0102030405 -kdfopt hexxcghash:06090A -kdfopt hexsession_id:01020304 -kdfopt type:A SSHKDF}],
+    { cmd => [qw{openssl kdf -keylen 16 -kdfopt digest:SHA256 -kdfopt hexkey:0102030405 -kdfopt hexxcghash:06090A -kdfopt hexsession_id:01020304 -kdfopt type:A SSHKDF}],
     expected => '5C:49:94:47:3B:B1:53:3A:58:EB:19:42:04:D3:78:16',
     desc => 'SSHKDF SHA256'},
 );

--- a/test/recipes/30-test_evp_data/evpkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf.txt
@@ -434,6 +434,7 @@ Ctrl.digest = digest:sha512
 Output = 00ef42cdbfc98d29db20976608e455567fdddf14
 
 Title = SSHKDF tests (from NIST CAVS 14.1 test vectors)
+# The first one uses md instead of digest to test alias works
 
 KDF = SSHKDF
 Ctrl.md = md:SHA1
@@ -444,7 +445,7 @@ Ctrl.type = type:A
 Output = e2f627c0b43f1ac1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -452,7 +453,7 @@ Ctrl.type = type:B
 Output = 58471445f342b181
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -460,7 +461,7 @@ Ctrl.type = type:C
 Output = 1ca9d310f86d51f6cb8e7007cb2b220d55c5281ce680b533
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -468,7 +469,7 @@ Ctrl.type = type:D
 Output = 2c60df8603d34cc1dbb03c11f725a44b44008851c73d6844
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -476,7 +477,7 @@ Ctrl.type = type:E
 Output = 472eb8a26166ae6aa8e06868e45c3b26e6eeed06
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -484,7 +485,7 @@ Ctrl.type = type:F
 Output = e3e2fdb9d7bc21165a3dbe47e1eceb7764390bab
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100ec6f2c5f0517fd92f730567bd783138302917c277552b1b3fdf2b67d6edb6fa81bd17f7ebbe339b54b171341e6522b91611f8274cc88652a458f8041261040818a268497e949e12f57271318b2b3194c29760cbb767c0fc8833b272994e18682da807e6c9f235d88ef89c203c6f756d25cc2bea199b02c955b8b40cbc04f9208
 Ctrl.hexxcghash = hexxcghash:ee40eef61bea3da8c2b1cec40fc4cdac892a2626
 Ctrl.hexsession_id = hexsession_id:ca9aad244e24797fd348d1250387c8aa45a0110a
@@ -492,7 +493,7 @@ Ctrl.type = type:A
 Output = 55a1015757de84cb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100ec6f2c5f0517fd92f730567bd783138302917c277552b1b3fdf2b67d6edb6fa81bd17f7ebbe339b54b171341e6522b91611f8274cc88652a458f8041261040818a268497e949e12f57271318b2b3194c29760cbb767c0fc8833b272994e18682da807e6c9f235d88ef89c203c6f756d25cc2bea199b02c955b8b40cbc04f9208
 Ctrl.hexxcghash = hexxcghash:ee40eef61bea3da8c2b1cec40fc4cdac892a2626
 Ctrl.hexsession_id = hexsession_id:ca9aad244e24797fd348d1250387c8aa45a0110a
@@ -500,7 +501,7 @@ Ctrl.type = type:B
 Output = 7e57f61d5735f4fb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100ec6f2c5f0517fd92f730567bd783138302917c277552b1b3fdf2b67d6edb6fa81bd17f7ebbe339b54b171341e6522b91611f8274cc88652a458f8041261040818a268497e949e12f57271318b2b3194c29760cbb767c0fc8833b272994e18682da807e6c9f235d88ef89c203c6f756d25cc2bea199b02c955b8b40cbc04f9208
 Ctrl.hexxcghash = hexxcghash:ee40eef61bea3da8c2b1cec40fc4cdac892a2626
 Ctrl.hexsession_id = hexsession_id:ca9aad244e24797fd348d1250387c8aa45a0110a
@@ -508,7 +509,7 @@ Ctrl.type = type:C
 Output = dd1c24bde1af845e82207541e3e173aec822fb904a94ae3c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100ec6f2c5f0517fd92f730567bd783138302917c277552b1b3fdf2b67d6edb6fa81bd17f7ebbe339b54b171341e6522b91611f8274cc88652a458f8041261040818a268497e949e12f57271318b2b3194c29760cbb767c0fc8833b272994e18682da807e6c9f235d88ef89c203c6f756d25cc2bea199b02c955b8b40cbc04f9208
 Ctrl.hexxcghash = hexxcghash:ee40eef61bea3da8c2b1cec40fc4cdac892a2626
 Ctrl.hexsession_id = hexsession_id:ca9aad244e24797fd348d1250387c8aa45a0110a
@@ -516,7 +517,7 @@ Ctrl.type = type:D
 Output = cbbfdc9442af6db7f8c4dcaa4b0b5d0163e0e204476aa2a0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100ec6f2c5f0517fd92f730567bd783138302917c277552b1b3fdf2b67d6edb6fa81bd17f7ebbe339b54b171341e6522b91611f8274cc88652a458f8041261040818a268497e949e12f57271318b2b3194c29760cbb767c0fc8833b272994e18682da807e6c9f235d88ef89c203c6f756d25cc2bea199b02c955b8b40cbc04f9208
 Ctrl.hexxcghash = hexxcghash:ee40eef61bea3da8c2b1cec40fc4cdac892a2626
 Ctrl.hexsession_id = hexsession_id:ca9aad244e24797fd348d1250387c8aa45a0110a
@@ -524,7 +525,7 @@ Ctrl.type = type:E
 Output = e153e04886c0dc446dde9a9b3b13efb77151764d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100ec6f2c5f0517fd92f730567bd783138302917c277552b1b3fdf2b67d6edb6fa81bd17f7ebbe339b54b171341e6522b91611f8274cc88652a458f8041261040818a268497e949e12f57271318b2b3194c29760cbb767c0fc8833b272994e18682da807e6c9f235d88ef89c203c6f756d25cc2bea199b02c955b8b40cbc04f9208
 Ctrl.hexxcghash = hexxcghash:ee40eef61bea3da8c2b1cec40fc4cdac892a2626
 Ctrl.hexsession_id = hexsession_id:ca9aad244e24797fd348d1250387c8aa45a0110a
@@ -532,7 +533,7 @@ Ctrl.type = type:F
 Output = c8e4f61bd6b5abb2c6e06eca7b302349435e4842
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100a3beebff410a7cdc0ac56dad0152a7f6da6b1d4195285ce96f8b59930d8c3ccbc518bc043eb60362388ea87c20db3b490b490ba9b90f086004ba3e389cb3a715d477c2b1e480e3419c36cd83e237e241462ee79758f4ff5bf7a5e1eae58a6834778a658c60b2e157d36b16371f97660ad4abfd4a2703dba7cab055be4c778b62
 Ctrl.hexxcghash = hexxcghash:b81915a9656128d2add5e5741914d765226f93e2
 Ctrl.hexsession_id = hexsession_id:2872e0c92fc3074d4f40e408a2ebd83e2fc7bccd
@@ -540,7 +541,7 @@ Ctrl.type = type:A
 Output = 054eaf5d7dea31e7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100a3beebff410a7cdc0ac56dad0152a7f6da6b1d4195285ce96f8b59930d8c3ccbc518bc043eb60362388ea87c20db3b490b490ba9b90f086004ba3e389cb3a715d477c2b1e480e3419c36cd83e237e241462ee79758f4ff5bf7a5e1eae58a6834778a658c60b2e157d36b16371f97660ad4abfd4a2703dba7cab055be4c778b62
 Ctrl.hexxcghash = hexxcghash:b81915a9656128d2add5e5741914d765226f93e2
 Ctrl.hexsession_id = hexsession_id:2872e0c92fc3074d4f40e408a2ebd83e2fc7bccd
@@ -548,7 +549,7 @@ Ctrl.type = type:B
 Output = 6ce586c127da010f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100a3beebff410a7cdc0ac56dad0152a7f6da6b1d4195285ce96f8b59930d8c3ccbc518bc043eb60362388ea87c20db3b490b490ba9b90f086004ba3e389cb3a715d477c2b1e480e3419c36cd83e237e241462ee79758f4ff5bf7a5e1eae58a6834778a658c60b2e157d36b16371f97660ad4abfd4a2703dba7cab055be4c778b62
 Ctrl.hexxcghash = hexxcghash:b81915a9656128d2add5e5741914d765226f93e2
 Ctrl.hexsession_id = hexsession_id:2872e0c92fc3074d4f40e408a2ebd83e2fc7bccd
@@ -556,7 +557,7 @@ Ctrl.type = type:C
 Output = 7907bf3d7c58ce72714b2adb1a14f156194b14378a4a7c49
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100a3beebff410a7cdc0ac56dad0152a7f6da6b1d4195285ce96f8b59930d8c3ccbc518bc043eb60362388ea87c20db3b490b490ba9b90f086004ba3e389cb3a715d477c2b1e480e3419c36cd83e237e241462ee79758f4ff5bf7a5e1eae58a6834778a658c60b2e157d36b16371f97660ad4abfd4a2703dba7cab055be4c778b62
 Ctrl.hexxcghash = hexxcghash:b81915a9656128d2add5e5741914d765226f93e2
 Ctrl.hexsession_id = hexsession_id:2872e0c92fc3074d4f40e408a2ebd83e2fc7bccd
@@ -564,7 +565,7 @@ Ctrl.type = type:D
 Output = c34757dc104e7b811f6550bbc3888e1d4297578fd88b2ca5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100a3beebff410a7cdc0ac56dad0152a7f6da6b1d4195285ce96f8b59930d8c3ccbc518bc043eb60362388ea87c20db3b490b490ba9b90f086004ba3e389cb3a715d477c2b1e480e3419c36cd83e237e241462ee79758f4ff5bf7a5e1eae58a6834778a658c60b2e157d36b16371f97660ad4abfd4a2703dba7cab055be4c778b62
 Ctrl.hexxcghash = hexxcghash:b81915a9656128d2add5e5741914d765226f93e2
 Ctrl.hexsession_id = hexsession_id:2872e0c92fc3074d4f40e408a2ebd83e2fc7bccd
@@ -572,7 +573,7 @@ Ctrl.type = type:E
 Output = e463e05ef70e61f994ee3cd20d504cb6eddb9b1a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100a3beebff410a7cdc0ac56dad0152a7f6da6b1d4195285ce96f8b59930d8c3ccbc518bc043eb60362388ea87c20db3b490b490ba9b90f086004ba3e389cb3a715d477c2b1e480e3419c36cd83e237e241462ee79758f4ff5bf7a5e1eae58a6834778a658c60b2e157d36b16371f97660ad4abfd4a2703dba7cab055be4c778b62
 Ctrl.hexxcghash = hexxcghash:b81915a9656128d2add5e5741914d765226f93e2
 Ctrl.hexsession_id = hexsession_id:2872e0c92fc3074d4f40e408a2ebd83e2fc7bccd
@@ -580,7 +581,7 @@ Ctrl.type = type:F
 Output = 676cf1dfc887e122353eead2b1e644f9d9def944
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008017357de60344a125ca41d9ea51eb304a571d7f0aa37a5e36d4b7a5473546f7226583cefe7c06f6f94b97da0da2517190fa02a0337a3bc9ddfeeb68b953613d4d5e473783f137a82246b8260fb3451363adda1813acdf6b10861e022e23a00db9b5a893fcefd6b647f6a73904aa9c3b53e5d879d7e84f052dfabe15a27c1f3aa9
 Ctrl.hexxcghash = hexxcghash:28fcf3bc600f6bb0b9594b01283d085e149b2586
 Ctrl.hexsession_id = hexsession_id:4d6b90988de45dfd08e8167504a6253a8552c200
@@ -588,7 +589,7 @@ Ctrl.type = type:A
 Output = bc4b5164911bc87b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008017357de60344a125ca41d9ea51eb304a571d7f0aa37a5e36d4b7a5473546f7226583cefe7c06f6f94b97da0da2517190fa02a0337a3bc9ddfeeb68b953613d4d5e473783f137a82246b8260fb3451363adda1813acdf6b10861e022e23a00db9b5a893fcefd6b647f6a73904aa9c3b53e5d879d7e84f052dfabe15a27c1f3aa9
 Ctrl.hexxcghash = hexxcghash:28fcf3bc600f6bb0b9594b01283d085e149b2586
 Ctrl.hexsession_id = hexsession_id:4d6b90988de45dfd08e8167504a6253a8552c200
@@ -596,7 +597,7 @@ Ctrl.type = type:B
 Output = d791c5986b27257e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008017357de60344a125ca41d9ea51eb304a571d7f0aa37a5e36d4b7a5473546f7226583cefe7c06f6f94b97da0da2517190fa02a0337a3bc9ddfeeb68b953613d4d5e473783f137a82246b8260fb3451363adda1813acdf6b10861e022e23a00db9b5a893fcefd6b647f6a73904aa9c3b53e5d879d7e84f052dfabe15a27c1f3aa9
 Ctrl.hexxcghash = hexxcghash:28fcf3bc600f6bb0b9594b01283d085e149b2586
 Ctrl.hexsession_id = hexsession_id:4d6b90988de45dfd08e8167504a6253a8552c200
@@ -604,7 +605,7 @@ Ctrl.type = type:C
 Output = de8e99bb3f60ccf0583712528aa3dd0418fdb90d0a588012
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008017357de60344a125ca41d9ea51eb304a571d7f0aa37a5e36d4b7a5473546f7226583cefe7c06f6f94b97da0da2517190fa02a0337a3bc9ddfeeb68b953613d4d5e473783f137a82246b8260fb3451363adda1813acdf6b10861e022e23a00db9b5a893fcefd6b647f6a73904aa9c3b53e5d879d7e84f052dfabe15a27c1f3aa9
 Ctrl.hexxcghash = hexxcghash:28fcf3bc600f6bb0b9594b01283d085e149b2586
 Ctrl.hexsession_id = hexsession_id:4d6b90988de45dfd08e8167504a6253a8552c200
@@ -612,7 +613,7 @@ Ctrl.type = type:D
 Output = f37f75a685f1eaf4fd270b946d84734e96aa3b4ed130afc6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008017357de60344a125ca41d9ea51eb304a571d7f0aa37a5e36d4b7a5473546f7226583cefe7c06f6f94b97da0da2517190fa02a0337a3bc9ddfeeb68b953613d4d5e473783f137a82246b8260fb3451363adda1813acdf6b10861e022e23a00db9b5a893fcefd6b647f6a73904aa9c3b53e5d879d7e84f052dfabe15a27c1f3aa9
 Ctrl.hexxcghash = hexxcghash:28fcf3bc600f6bb0b9594b01283d085e149b2586
 Ctrl.hexsession_id = hexsession_id:4d6b90988de45dfd08e8167504a6253a8552c200
@@ -620,7 +621,7 @@ Ctrl.type = type:E
 Output = 658f04b0f59aab071b9e11ec9ff187ee10e80254
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008017357de60344a125ca41d9ea51eb304a571d7f0aa37a5e36d4b7a5473546f7226583cefe7c06f6f94b97da0da2517190fa02a0337a3bc9ddfeeb68b953613d4d5e473783f137a82246b8260fb3451363adda1813acdf6b10861e022e23a00db9b5a893fcefd6b647f6a73904aa9c3b53e5d879d7e84f052dfabe15a27c1f3aa9
 Ctrl.hexxcghash = hexxcghash:28fcf3bc600f6bb0b9594b01283d085e149b2586
 Ctrl.hexsession_id = hexsession_id:4d6b90988de45dfd08e8167504a6253a8552c200
@@ -628,7 +629,7 @@ Ctrl.type = type:F
 Output = b030809222ff7a12b0df35072d67f314ab1d5eda
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000000803c3ce2b19e0cadf8ad02438c695efcd3018c833657318bfaef7b9c278cd7e8d7b3a2249f9d586832c3dee727ada167056ff1febc9210186ba47cc1dfaaf08101fb89742ebf4f3e291a20c94a7a6f7877799151d177e163ce3e57ef863c0cda0311265fbac157879150a715e309392b3e521dcf03224717ff5e0030e480f20dff
 Ctrl.hexxcghash = hexxcghash:46a674c532460a80cdc5c6da9a8c3bdf4f3ff614
 Ctrl.hexsession_id = hexsession_id:aedeb64df7119db53202e959dc84be3e5285512d
@@ -636,7 +637,7 @@ Ctrl.type = type:A
 Output = 7a74ec799ef16865
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000000803c3ce2b19e0cadf8ad02438c695efcd3018c833657318bfaef7b9c278cd7e8d7b3a2249f9d586832c3dee727ada167056ff1febc9210186ba47cc1dfaaf08101fb89742ebf4f3e291a20c94a7a6f7877799151d177e163ce3e57ef863c0cda0311265fbac157879150a715e309392b3e521dcf03224717ff5e0030e480f20dff
 Ctrl.hexxcghash = hexxcghash:46a674c532460a80cdc5c6da9a8c3bdf4f3ff614
 Ctrl.hexsession_id = hexsession_id:aedeb64df7119db53202e959dc84be3e5285512d
@@ -644,7 +645,7 @@ Ctrl.type = type:B
 Output = 6e544fc6db0ca1ba
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000000803c3ce2b19e0cadf8ad02438c695efcd3018c833657318bfaef7b9c278cd7e8d7b3a2249f9d586832c3dee727ada167056ff1febc9210186ba47cc1dfaaf08101fb89742ebf4f3e291a20c94a7a6f7877799151d177e163ce3e57ef863c0cda0311265fbac157879150a715e309392b3e521dcf03224717ff5e0030e480f20dff
 Ctrl.hexxcghash = hexxcghash:46a674c532460a80cdc5c6da9a8c3bdf4f3ff614
 Ctrl.hexsession_id = hexsession_id:aedeb64df7119db53202e959dc84be3e5285512d
@@ -652,7 +653,7 @@ Ctrl.type = type:C
 Output = 658226b1b10b2033fa88838b619572b18e81e80c76507918
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000000803c3ce2b19e0cadf8ad02438c695efcd3018c833657318bfaef7b9c278cd7e8d7b3a2249f9d586832c3dee727ada167056ff1febc9210186ba47cc1dfaaf08101fb89742ebf4f3e291a20c94a7a6f7877799151d177e163ce3e57ef863c0cda0311265fbac157879150a715e309392b3e521dcf03224717ff5e0030e480f20dff
 Ctrl.hexxcghash = hexxcghash:46a674c532460a80cdc5c6da9a8c3bdf4f3ff614
 Ctrl.hexsession_id = hexsession_id:aedeb64df7119db53202e959dc84be3e5285512d
@@ -660,7 +661,7 @@ Ctrl.type = type:D
 Output = 327298c8660685efcb01c5c0df49faebb15c0e93b0f6c65d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000000803c3ce2b19e0cadf8ad02438c695efcd3018c833657318bfaef7b9c278cd7e8d7b3a2249f9d586832c3dee727ada167056ff1febc9210186ba47cc1dfaaf08101fb89742ebf4f3e291a20c94a7a6f7877799151d177e163ce3e57ef863c0cda0311265fbac157879150a715e309392b3e521dcf03224717ff5e0030e480f20dff
 Ctrl.hexxcghash = hexxcghash:46a674c532460a80cdc5c6da9a8c3bdf4f3ff614
 Ctrl.hexsession_id = hexsession_id:aedeb64df7119db53202e959dc84be3e5285512d
@@ -668,7 +669,7 @@ Ctrl.type = type:E
 Output = 6b618a10aeaa12c9a8d2bcb10e975605582c00e5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000000803c3ce2b19e0cadf8ad02438c695efcd3018c833657318bfaef7b9c278cd7e8d7b3a2249f9d586832c3dee727ada167056ff1febc9210186ba47cc1dfaaf08101fb89742ebf4f3e291a20c94a7a6f7877799151d177e163ce3e57ef863c0cda0311265fbac157879150a715e309392b3e521dcf03224717ff5e0030e480f20dff
 Ctrl.hexxcghash = hexxcghash:46a674c532460a80cdc5c6da9a8c3bdf4f3ff614
 Ctrl.hexsession_id = hexsession_id:aedeb64df7119db53202e959dc84be3e5285512d
@@ -676,7 +677,7 @@ Ctrl.type = type:F
 Output = 6d4ce50da9de90d6f746e812a2e74bcd921f5612
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008075957f464f5a7985e1a3ffb7d5814ff9ceb8fb1584a3f5cc454c37139e9b880940442cce2aef94d9d0462c4dc313ed7a8cc3f9a58c38a98ef0236e3cc78fb63b6f82e9c503097b7a08ef2261dda68c7bfe9f83ac790d1f9ff57605d24f4bdfedde23cc5aabba248bc91d3fe1d4394485bc4421730a297694c09bdf024ac2eac3
 Ctrl.hexxcghash = hexxcghash:0a70b4f26b1985d48ece540f1de6304fdb38212f
 Ctrl.hexsession_id = hexsession_id:2f0ce0e2da2e2bf11eae2ab98e9734412d47a19a
@@ -684,7 +685,7 @@ Ctrl.type = type:A
 Output = b655839abcb1a7b8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008075957f464f5a7985e1a3ffb7d5814ff9ceb8fb1584a3f5cc454c37139e9b880940442cce2aef94d9d0462c4dc313ed7a8cc3f9a58c38a98ef0236e3cc78fb63b6f82e9c503097b7a08ef2261dda68c7bfe9f83ac790d1f9ff57605d24f4bdfedde23cc5aabba248bc91d3fe1d4394485bc4421730a297694c09bdf024ac2eac3
 Ctrl.hexxcghash = hexxcghash:0a70b4f26b1985d48ece540f1de6304fdb38212f
 Ctrl.hexsession_id = hexsession_id:2f0ce0e2da2e2bf11eae2ab98e9734412d47a19a
@@ -692,7 +693,7 @@ Ctrl.type = type:B
 Output = 98f9ec980831a8bc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008075957f464f5a7985e1a3ffb7d5814ff9ceb8fb1584a3f5cc454c37139e9b880940442cce2aef94d9d0462c4dc313ed7a8cc3f9a58c38a98ef0236e3cc78fb63b6f82e9c503097b7a08ef2261dda68c7bfe9f83ac790d1f9ff57605d24f4bdfedde23cc5aabba248bc91d3fe1d4394485bc4421730a297694c09bdf024ac2eac3
 Ctrl.hexxcghash = hexxcghash:0a70b4f26b1985d48ece540f1de6304fdb38212f
 Ctrl.hexsession_id = hexsession_id:2f0ce0e2da2e2bf11eae2ab98e9734412d47a19a
@@ -700,7 +701,7 @@ Ctrl.type = type:C
 Output = 31a63b64cfa8b6a12ba165096dad8d127cd3f3b67698b670
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008075957f464f5a7985e1a3ffb7d5814ff9ceb8fb1584a3f5cc454c37139e9b880940442cce2aef94d9d0462c4dc313ed7a8cc3f9a58c38a98ef0236e3cc78fb63b6f82e9c503097b7a08ef2261dda68c7bfe9f83ac790d1f9ff57605d24f4bdfedde23cc5aabba248bc91d3fe1d4394485bc4421730a297694c09bdf024ac2eac3
 Ctrl.hexxcghash = hexxcghash:0a70b4f26b1985d48ece540f1de6304fdb38212f
 Ctrl.hexsession_id = hexsession_id:2f0ce0e2da2e2bf11eae2ab98e9734412d47a19a
@@ -708,7 +709,7 @@ Ctrl.type = type:D
 Output = 8bd79633967b92f0039a38a2d421e12840ea5c31b43c4e90
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008075957f464f5a7985e1a3ffb7d5814ff9ceb8fb1584a3f5cc454c37139e9b880940442cce2aef94d9d0462c4dc313ed7a8cc3f9a58c38a98ef0236e3cc78fb63b6f82e9c503097b7a08ef2261dda68c7bfe9f83ac790d1f9ff57605d24f4bdfedde23cc5aabba248bc91d3fe1d4394485bc4421730a297694c09bdf024ac2eac3
 Ctrl.hexxcghash = hexxcghash:0a70b4f26b1985d48ece540f1de6304fdb38212f
 Ctrl.hexsession_id = hexsession_id:2f0ce0e2da2e2bf11eae2ab98e9734412d47a19a
@@ -716,7 +717,7 @@ Ctrl.type = type:E
 Output = 37eccade73b422d1108e390eaa28c646b554a721
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008075957f464f5a7985e1a3ffb7d5814ff9ceb8fb1584a3f5cc454c37139e9b880940442cce2aef94d9d0462c4dc313ed7a8cc3f9a58c38a98ef0236e3cc78fb63b6f82e9c503097b7a08ef2261dda68c7bfe9f83ac790d1f9ff57605d24f4bdfedde23cc5aabba248bc91d3fe1d4394485bc4421730a297694c09bdf024ac2eac3
 Ctrl.hexxcghash = hexxcghash:0a70b4f26b1985d48ece540f1de6304fdb38212f
 Ctrl.hexsession_id = hexsession_id:2f0ce0e2da2e2bf11eae2ab98e9734412d47a19a
@@ -724,7 +725,7 @@ Ctrl.type = type:F
 Output = 013a20fc8f53ef08aae0a836b9410153a877983a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100c050aa3d848750af69d1c04d6cb0a1ef8a4f25be4b16c927ff7313e83680b1b7a92b6100fa773cea9958fc7efb1a475fc71eda8be8efc92ad198a34d6ae017f12b76f39c82b741994b0d42ada1807fa7803876d21d93b129d75dc9aba4811ef51925e49e4bf4f5313e8fee0625d8727da8bcb15eb15da2d237082fc5499621ef
 Ctrl.hexxcghash = hexxcghash:5ea2568ee7ddcdb3260dfdf54e15e4d494ca9023
 Ctrl.hexsession_id = hexsession_id:bc8988ac5f9058ee76536472b1706c5c338bd114
@@ -732,7 +733,7 @@ Ctrl.type = type:A
 Output = 12f6c3ac60d6ee3b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100c050aa3d848750af69d1c04d6cb0a1ef8a4f25be4b16c927ff7313e83680b1b7a92b6100fa773cea9958fc7efb1a475fc71eda8be8efc92ad198a34d6ae017f12b76f39c82b741994b0d42ada1807fa7803876d21d93b129d75dc9aba4811ef51925e49e4bf4f5313e8fee0625d8727da8bcb15eb15da2d237082fc5499621ef
 Ctrl.hexxcghash = hexxcghash:5ea2568ee7ddcdb3260dfdf54e15e4d494ca9023
 Ctrl.hexsession_id = hexsession_id:bc8988ac5f9058ee76536472b1706c5c338bd114
@@ -740,7 +741,7 @@ Ctrl.type = type:B
 Output = 536d106e00aec6fd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100c050aa3d848750af69d1c04d6cb0a1ef8a4f25be4b16c927ff7313e83680b1b7a92b6100fa773cea9958fc7efb1a475fc71eda8be8efc92ad198a34d6ae017f12b76f39c82b741994b0d42ada1807fa7803876d21d93b129d75dc9aba4811ef51925e49e4bf4f5313e8fee0625d8727da8bcb15eb15da2d237082fc5499621ef
 Ctrl.hexxcghash = hexxcghash:5ea2568ee7ddcdb3260dfdf54e15e4d494ca9023
 Ctrl.hexsession_id = hexsession_id:bc8988ac5f9058ee76536472b1706c5c338bd114
@@ -748,7 +749,7 @@ Ctrl.type = type:C
 Output = 26b8ec66854d0f0aa98f6888be628ebc75900c3738d47894
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100c050aa3d848750af69d1c04d6cb0a1ef8a4f25be4b16c927ff7313e83680b1b7a92b6100fa773cea9958fc7efb1a475fc71eda8be8efc92ad198a34d6ae017f12b76f39c82b741994b0d42ada1807fa7803876d21d93b129d75dc9aba4811ef51925e49e4bf4f5313e8fee0625d8727da8bcb15eb15da2d237082fc5499621ef
 Ctrl.hexxcghash = hexxcghash:5ea2568ee7ddcdb3260dfdf54e15e4d494ca9023
 Ctrl.hexsession_id = hexsession_id:bc8988ac5f9058ee76536472b1706c5c338bd114
@@ -756,7 +757,7 @@ Ctrl.type = type:D
 Output = d5d3b3817214eeb3bf292dffc77daeab062ac7fcd2e3a2bd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100c050aa3d848750af69d1c04d6cb0a1ef8a4f25be4b16c927ff7313e83680b1b7a92b6100fa773cea9958fc7efb1a475fc71eda8be8efc92ad198a34d6ae017f12b76f39c82b741994b0d42ada1807fa7803876d21d93b129d75dc9aba4811ef51925e49e4bf4f5313e8fee0625d8727da8bcb15eb15da2d237082fc5499621ef
 Ctrl.hexxcghash = hexxcghash:5ea2568ee7ddcdb3260dfdf54e15e4d494ca9023
 Ctrl.hexsession_id = hexsession_id:bc8988ac5f9058ee76536472b1706c5c338bd114
@@ -764,7 +765,7 @@ Ctrl.type = type:E
 Output = 014613aef22194307bc0678f6edd1ccff240adfa
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100c050aa3d848750af69d1c04d6cb0a1ef8a4f25be4b16c927ff7313e83680b1b7a92b6100fa773cea9958fc7efb1a475fc71eda8be8efc92ad198a34d6ae017f12b76f39c82b741994b0d42ada1807fa7803876d21d93b129d75dc9aba4811ef51925e49e4bf4f5313e8fee0625d8727da8bcb15eb15da2d237082fc5499621ef
 Ctrl.hexxcghash = hexxcghash:5ea2568ee7ddcdb3260dfdf54e15e4d494ca9023
 Ctrl.hexsession_id = hexsession_id:bc8988ac5f9058ee76536472b1706c5c338bd114
@@ -772,7 +773,7 @@ Ctrl.type = type:F
 Output = 5057b4cc2c300f7546d358a75daf58233b71da1a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100f00388418be28ae3235c5b640d000df44f6e65782cad783726a507e2c645a056307f1ab7b4cd24d38640118105d7415c2ecea77e33e7b8a9dc9d205e3fdfb718769754213c0782ee18c7db1408e780369bccfb8233581cda4fbb133b3c41d0a7afa6996f31f8dd36fa3dd82efb23dcaa1ec5e37caae3af639123190fe7795983
 Ctrl.hexxcghash = hexxcghash:fc48c85ac48ee97be3ce45c10807a666e8e9b639
 Ctrl.hexsession_id = hexsession_id:d36e8c070b97795dfb10a3c2e41e4d0d70382606
@@ -780,7 +781,7 @@ Ctrl.type = type:A
 Output = d160f91f36027ff9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100f00388418be28ae3235c5b640d000df44f6e65782cad783726a507e2c645a056307f1ab7b4cd24d38640118105d7415c2ecea77e33e7b8a9dc9d205e3fdfb718769754213c0782ee18c7db1408e780369bccfb8233581cda4fbb133b3c41d0a7afa6996f31f8dd36fa3dd82efb23dcaa1ec5e37caae3af639123190fe7795983
 Ctrl.hexxcghash = hexxcghash:fc48c85ac48ee97be3ce45c10807a666e8e9b639
 Ctrl.hexsession_id = hexsession_id:d36e8c070b97795dfb10a3c2e41e4d0d70382606
@@ -788,7 +789,7 @@ Ctrl.type = type:B
 Output = 0d02ec310663bbcc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100f00388418be28ae3235c5b640d000df44f6e65782cad783726a507e2c645a056307f1ab7b4cd24d38640118105d7415c2ecea77e33e7b8a9dc9d205e3fdfb718769754213c0782ee18c7db1408e780369bccfb8233581cda4fbb133b3c41d0a7afa6996f31f8dd36fa3dd82efb23dcaa1ec5e37caae3af639123190fe7795983
 Ctrl.hexxcghash = hexxcghash:fc48c85ac48ee97be3ce45c10807a666e8e9b639
 Ctrl.hexsession_id = hexsession_id:d36e8c070b97795dfb10a3c2e41e4d0d70382606
@@ -796,7 +797,7 @@ Ctrl.type = type:C
 Output = 03b66f451ad93a01914dd3372d980bea3de94993e176ea01
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100f00388418be28ae3235c5b640d000df44f6e65782cad783726a507e2c645a056307f1ab7b4cd24d38640118105d7415c2ecea77e33e7b8a9dc9d205e3fdfb718769754213c0782ee18c7db1408e780369bccfb8233581cda4fbb133b3c41d0a7afa6996f31f8dd36fa3dd82efb23dcaa1ec5e37caae3af639123190fe7795983
 Ctrl.hexxcghash = hexxcghash:fc48c85ac48ee97be3ce45c10807a666e8e9b639
 Ctrl.hexsession_id = hexsession_id:d36e8c070b97795dfb10a3c2e41e4d0d70382606
@@ -804,7 +805,7 @@ Ctrl.type = type:D
 Output = c2db767cbbdf2f839eb2f37ada87a041d220b9f58842d0db
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100f00388418be28ae3235c5b640d000df44f6e65782cad783726a507e2c645a056307f1ab7b4cd24d38640118105d7415c2ecea77e33e7b8a9dc9d205e3fdfb718769754213c0782ee18c7db1408e780369bccfb8233581cda4fbb133b3c41d0a7afa6996f31f8dd36fa3dd82efb23dcaa1ec5e37caae3af639123190fe7795983
 Ctrl.hexxcghash = hexxcghash:fc48c85ac48ee97be3ce45c10807a666e8e9b639
 Ctrl.hexsession_id = hexsession_id:d36e8c070b97795dfb10a3c2e41e4d0d70382606
@@ -812,7 +813,7 @@ Ctrl.type = type:E
 Output = 0b2944c26dcf4cc877cdc55c4e9b1b8155e3874b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100f00388418be28ae3235c5b640d000df44f6e65782cad783726a507e2c645a056307f1ab7b4cd24d38640118105d7415c2ecea77e33e7b8a9dc9d205e3fdfb718769754213c0782ee18c7db1408e780369bccfb8233581cda4fbb133b3c41d0a7afa6996f31f8dd36fa3dd82efb23dcaa1ec5e37caae3af639123190fe7795983
 Ctrl.hexxcghash = hexxcghash:fc48c85ac48ee97be3ce45c10807a666e8e9b639
 Ctrl.hexsession_id = hexsession_id:d36e8c070b97795dfb10a3c2e41e4d0d70382606
@@ -820,7 +821,7 @@ Ctrl.type = type:F
 Output = f7977d574c7d9e4f34ecd6b405c765963f0dfe57
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:00000081009dc61278a79fdb00ee937c0418668ac0176fdfd0297ebc86ee391e3e8db147f01d782650f1e30391d3c1fe62425842119fe41b76243ed47f6c30370dd1cc1b10e3bdac2730287b0e5901e487563d700d56078ed88d20c300250a3da5f2128db56230d90bb99e90aca80da446d8dddac49e2f2db1b37f9e1b65834adf8fdbcd31
 Ctrl.hexxcghash = hexxcghash:3c63a552ac5313d219ec30f1e926e2c52e992929
 Ctrl.hexsession_id = hexsession_id:a17e0e9cc2741d861f4c7195c29c75e4c38e9ba0
@@ -828,7 +829,7 @@ Ctrl.type = type:A
 Output = e4387818ab7f4fa6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:00000081009dc61278a79fdb00ee937c0418668ac0176fdfd0297ebc86ee391e3e8db147f01d782650f1e30391d3c1fe62425842119fe41b76243ed47f6c30370dd1cc1b10e3bdac2730287b0e5901e487563d700d56078ed88d20c300250a3da5f2128db56230d90bb99e90aca80da446d8dddac49e2f2db1b37f9e1b65834adf8fdbcd31
 Ctrl.hexxcghash = hexxcghash:3c63a552ac5313d219ec30f1e926e2c52e992929
 Ctrl.hexsession_id = hexsession_id:a17e0e9cc2741d861f4c7195c29c75e4c38e9ba0
@@ -836,7 +837,7 @@ Ctrl.type = type:B
 Output = 1daabebcc8a064df
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:00000081009dc61278a79fdb00ee937c0418668ac0176fdfd0297ebc86ee391e3e8db147f01d782650f1e30391d3c1fe62425842119fe41b76243ed47f6c30370dd1cc1b10e3bdac2730287b0e5901e487563d700d56078ed88d20c300250a3da5f2128db56230d90bb99e90aca80da446d8dddac49e2f2db1b37f9e1b65834adf8fdbcd31
 Ctrl.hexxcghash = hexxcghash:3c63a552ac5313d219ec30f1e926e2c52e992929
 Ctrl.hexsession_id = hexsession_id:a17e0e9cc2741d861f4c7195c29c75e4c38e9ba0
@@ -844,7 +845,7 @@ Ctrl.type = type:C
 Output = 9fffad3aec53cd719c1d500850c2f38d8eea04606f78b402
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:00000081009dc61278a79fdb00ee937c0418668ac0176fdfd0297ebc86ee391e3e8db147f01d782650f1e30391d3c1fe62425842119fe41b76243ed47f6c30370dd1cc1b10e3bdac2730287b0e5901e487563d700d56078ed88d20c300250a3da5f2128db56230d90bb99e90aca80da446d8dddac49e2f2db1b37f9e1b65834adf8fdbcd31
 Ctrl.hexxcghash = hexxcghash:3c63a552ac5313d219ec30f1e926e2c52e992929
 Ctrl.hexsession_id = hexsession_id:a17e0e9cc2741d861f4c7195c29c75e4c38e9ba0
@@ -852,7 +853,7 @@ Ctrl.type = type:D
 Output = 6b196bce2aa2bd912ffd67a94fc42dec1051376f73ec3ce2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:00000081009dc61278a79fdb00ee937c0418668ac0176fdfd0297ebc86ee391e3e8db147f01d782650f1e30391d3c1fe62425842119fe41b76243ed47f6c30370dd1cc1b10e3bdac2730287b0e5901e487563d700d56078ed88d20c300250a3da5f2128db56230d90bb99e90aca80da446d8dddac49e2f2db1b37f9e1b65834adf8fdbcd31
 Ctrl.hexxcghash = hexxcghash:3c63a552ac5313d219ec30f1e926e2c52e992929
 Ctrl.hexsession_id = hexsession_id:a17e0e9cc2741d861f4c7195c29c75e4c38e9ba0
@@ -860,7 +861,7 @@ Ctrl.type = type:E
 Output = beab583906e6bed005558c102a5b5fd6ee71485f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:00000081009dc61278a79fdb00ee937c0418668ac0176fdfd0297ebc86ee391e3e8db147f01d782650f1e30391d3c1fe62425842119fe41b76243ed47f6c30370dd1cc1b10e3bdac2730287b0e5901e487563d700d56078ed88d20c300250a3da5f2128db56230d90bb99e90aca80da446d8dddac49e2f2db1b37f9e1b65834adf8fdbcd31
 Ctrl.hexxcghash = hexxcghash:3c63a552ac5313d219ec30f1e926e2c52e992929
 Ctrl.hexsession_id = hexsession_id:a17e0e9cc2741d861f4c7195c29c75e4c38e9ba0
@@ -868,7 +869,7 @@ Ctrl.type = type:F
 Output = 105140594b5b9061de7ff2afac09bce81b75d6c6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100df75bb7ce0b66431ca073a5768dbc6930b024b8d6804a5ef9f3f3c9341b8c8b7216eaf26536ac671ab360eff568502e596adbf41b795d329d136ebe44c60ff4ffd58ed99b40a228cab6c8ed9733702e75f7750e58f04cbb78402eec2877205a0ba3f48318543489dc4885dcdc51c4658acbc28f9a82c563ac20b582cff8c432d
 Ctrl.hexxcghash = hexxcghash:c08ddd40832cc96fe373b67a4850b86848e48f70
 Ctrl.hexsession_id = hexsession_id:477c8d32e73a475707e0085cf235d605ed564a1c
@@ -876,7 +877,7 @@ Ctrl.type = type:A
 Output = ef982c8fd0fd464f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100df75bb7ce0b66431ca073a5768dbc6930b024b8d6804a5ef9f3f3c9341b8c8b7216eaf26536ac671ab360eff568502e596adbf41b795d329d136ebe44c60ff4ffd58ed99b40a228cab6c8ed9733702e75f7750e58f04cbb78402eec2877205a0ba3f48318543489dc4885dcdc51c4658acbc28f9a82c563ac20b582cff8c432d
 Ctrl.hexxcghash = hexxcghash:c08ddd40832cc96fe373b67a4850b86848e48f70
 Ctrl.hexsession_id = hexsession_id:477c8d32e73a475707e0085cf235d605ed564a1c
@@ -884,7 +885,7 @@ Ctrl.type = type:B
 Output = 845ad3ba4d359326
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100df75bb7ce0b66431ca073a5768dbc6930b024b8d6804a5ef9f3f3c9341b8c8b7216eaf26536ac671ab360eff568502e596adbf41b795d329d136ebe44c60ff4ffd58ed99b40a228cab6c8ed9733702e75f7750e58f04cbb78402eec2877205a0ba3f48318543489dc4885dcdc51c4658acbc28f9a82c563ac20b582cff8c432d
 Ctrl.hexxcghash = hexxcghash:c08ddd40832cc96fe373b67a4850b86848e48f70
 Ctrl.hexsession_id = hexsession_id:477c8d32e73a475707e0085cf235d605ed564a1c
@@ -892,7 +893,7 @@ Ctrl.type = type:C
 Output = d9e516001b6b1a17268e507fa6e13f6bc9c3ded0020ef841
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100df75bb7ce0b66431ca073a5768dbc6930b024b8d6804a5ef9f3f3c9341b8c8b7216eaf26536ac671ab360eff568502e596adbf41b795d329d136ebe44c60ff4ffd58ed99b40a228cab6c8ed9733702e75f7750e58f04cbb78402eec2877205a0ba3f48318543489dc4885dcdc51c4658acbc28f9a82c563ac20b582cff8c432d
 Ctrl.hexxcghash = hexxcghash:c08ddd40832cc96fe373b67a4850b86848e48f70
 Ctrl.hexsession_id = hexsession_id:477c8d32e73a475707e0085cf235d605ed564a1c
@@ -900,7 +901,7 @@ Ctrl.type = type:D
 Output = d57d2f3c25b536442d8c7f36d62778d06fb6e7d4b5c7ab76
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100df75bb7ce0b66431ca073a5768dbc6930b024b8d6804a5ef9f3f3c9341b8c8b7216eaf26536ac671ab360eff568502e596adbf41b795d329d136ebe44c60ff4ffd58ed99b40a228cab6c8ed9733702e75f7750e58f04cbb78402eec2877205a0ba3f48318543489dc4885dcdc51c4658acbc28f9a82c563ac20b582cff8c432d
 Ctrl.hexxcghash = hexxcghash:c08ddd40832cc96fe373b67a4850b86848e48f70
 Ctrl.hexsession_id = hexsession_id:477c8d32e73a475707e0085cf235d605ed564a1c
@@ -908,7 +909,7 @@ Ctrl.type = type:E
 Output = f0b75425b271eb82645b1f1424b2a838dbcf6f98
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008100df75bb7ce0b66431ca073a5768dbc6930b024b8d6804a5ef9f3f3c9341b8c8b7216eaf26536ac671ab360eff568502e596adbf41b795d329d136ebe44c60ff4ffd58ed99b40a228cab6c8ed9733702e75f7750e58f04cbb78402eec2877205a0ba3f48318543489dc4885dcdc51c4658acbc28f9a82c563ac20b582cff8c432d
 Ctrl.hexxcghash = hexxcghash:c08ddd40832cc96fe373b67a4850b86848e48f70
 Ctrl.hexsession_id = hexsession_id:477c8d32e73a475707e0085cf235d605ed564a1c
@@ -916,7 +917,7 @@ Ctrl.type = type:F
 Output = cdf59b2327588ffd18becfc0e5bb526014101401
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001010085a60bcca88b096c418e825f3de4fd8920ecce617afadda2ca8001e8eba07e58e60e70a9a05b8ddc29d5636d33c407d5f23952b65326e113f28d89bc6ba3a4c3b71ae239d6d1bd295466682d1c675bdb88a3259f474fe54a0f4004ddc46b442451654e1e66d0c93d7b310f28a8db7b95eee7abc61e71dee322b4e732baf9ec7ce189b889d536da1a55a2cc29e1666aa9c0e702f4412206bd207302fe84043c664394bde0e0a47d0a7a947c95997e1dbaeecd2efae12cacef8eab2f6b2478dedcebb3264827cf226e13f8082931db410fbc03352e7dde82fd1f58caab3115aa065ac6e2a1c7b1c1b2d5fa3447bf9839d76cfa5822b097bff9106f37eba1250145
 Ctrl.hexxcghash = hexxcghash:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
 Ctrl.hexsession_id = hexsession_id:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
@@ -924,7 +925,7 @@ Ctrl.type = type:A
 Output = 79c9195e683ae10750960cb55c4d4c0b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001010085a60bcca88b096c418e825f3de4fd8920ecce617afadda2ca8001e8eba07e58e60e70a9a05b8ddc29d5636d33c407d5f23952b65326e113f28d89bc6ba3a4c3b71ae239d6d1bd295466682d1c675bdb88a3259f474fe54a0f4004ddc46b442451654e1e66d0c93d7b310f28a8db7b95eee7abc61e71dee322b4e732baf9ec7ce189b889d536da1a55a2cc29e1666aa9c0e702f4412206bd207302fe84043c664394bde0e0a47d0a7a947c95997e1dbaeecd2efae12cacef8eab2f6b2478dedcebb3264827cf226e13f8082931db410fbc03352e7dde82fd1f58caab3115aa065ac6e2a1c7b1c1b2d5fa3447bf9839d76cfa5822b097bff9106f37eba1250145
 Ctrl.hexxcghash = hexxcghash:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
 Ctrl.hexsession_id = hexsession_id:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
@@ -932,7 +933,7 @@ Ctrl.type = type:B
 Output = ef00b448ab9fd6523bb5143a0a818750
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001010085a60bcca88b096c418e825f3de4fd8920ecce617afadda2ca8001e8eba07e58e60e70a9a05b8ddc29d5636d33c407d5f23952b65326e113f28d89bc6ba3a4c3b71ae239d6d1bd295466682d1c675bdb88a3259f474fe54a0f4004ddc46b442451654e1e66d0c93d7b310f28a8db7b95eee7abc61e71dee322b4e732baf9ec7ce189b889d536da1a55a2cc29e1666aa9c0e702f4412206bd207302fe84043c664394bde0e0a47d0a7a947c95997e1dbaeecd2efae12cacef8eab2f6b2478dedcebb3264827cf226e13f8082931db410fbc03352e7dde82fd1f58caab3115aa065ac6e2a1c7b1c1b2d5fa3447bf9839d76cfa5822b097bff9106f37eba1250145
 Ctrl.hexxcghash = hexxcghash:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
 Ctrl.hexsession_id = hexsession_id:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
@@ -940,7 +941,7 @@ Ctrl.type = type:C
 Output = 51c8b4aaf5e42443be0aa3c50aa7e1dd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001010085a60bcca88b096c418e825f3de4fd8920ecce617afadda2ca8001e8eba07e58e60e70a9a05b8ddc29d5636d33c407d5f23952b65326e113f28d89bc6ba3a4c3b71ae239d6d1bd295466682d1c675bdb88a3259f474fe54a0f4004ddc46b442451654e1e66d0c93d7b310f28a8db7b95eee7abc61e71dee322b4e732baf9ec7ce189b889d536da1a55a2cc29e1666aa9c0e702f4412206bd207302fe84043c664394bde0e0a47d0a7a947c95997e1dbaeecd2efae12cacef8eab2f6b2478dedcebb3264827cf226e13f8082931db410fbc03352e7dde82fd1f58caab3115aa065ac6e2a1c7b1c1b2d5fa3447bf9839d76cfa5822b097bff9106f37eba1250145
 Ctrl.hexxcghash = hexxcghash:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
 Ctrl.hexsession_id = hexsession_id:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
@@ -948,7 +949,7 @@ Ctrl.type = type:D
 Output = 4153a587397fb14dc3faad028fdb7ecc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001010085a60bcca88b096c418e825f3de4fd8920ecce617afadda2ca8001e8eba07e58e60e70a9a05b8ddc29d5636d33c407d5f23952b65326e113f28d89bc6ba3a4c3b71ae239d6d1bd295466682d1c675bdb88a3259f474fe54a0f4004ddc46b442451654e1e66d0c93d7b310f28a8db7b95eee7abc61e71dee322b4e732baf9ec7ce189b889d536da1a55a2cc29e1666aa9c0e702f4412206bd207302fe84043c664394bde0e0a47d0a7a947c95997e1dbaeecd2efae12cacef8eab2f6b2478dedcebb3264827cf226e13f8082931db410fbc03352e7dde82fd1f58caab3115aa065ac6e2a1c7b1c1b2d5fa3447bf9839d76cfa5822b097bff9106f37eba1250145
 Ctrl.hexxcghash = hexxcghash:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
 Ctrl.hexsession_id = hexsession_id:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
@@ -956,7 +957,7 @@ Ctrl.type = type:E
 Output = d23e36347052a1cfb4a7789df48627e8a31345c7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001010085a60bcca88b096c418e825f3de4fd8920ecce617afadda2ca8001e8eba07e58e60e70a9a05b8ddc29d5636d33c407d5f23952b65326e113f28d89bc6ba3a4c3b71ae239d6d1bd295466682d1c675bdb88a3259f474fe54a0f4004ddc46b442451654e1e66d0c93d7b310f28a8db7b95eee7abc61e71dee322b4e732baf9ec7ce189b889d536da1a55a2cc29e1666aa9c0e702f4412206bd207302fe84043c664394bde0e0a47d0a7a947c95997e1dbaeecd2efae12cacef8eab2f6b2478dedcebb3264827cf226e13f8082931db410fbc03352e7dde82fd1f58caab3115aa065ac6e2a1c7b1c1b2d5fa3447bf9839d76cfa5822b097bff9106f37eba1250145
 Ctrl.hexxcghash = hexxcghash:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
 Ctrl.hexsession_id = hexsession_id:dde6f8e070ef32a27ff04ad1045c65b2dfa33e03
@@ -964,7 +965,7 @@ Ctrl.type = type:F
 Output = c1286e92655912d923154c460702a31424bd6b01
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100c0724e077d7237441eb79039debaa851c0bf411e69cd5314f3c72aa45760c9969985b34291fb64bf964b719d2b989e40a0e9fbccdb23536a78f1b55ebbda809f862e8ec3561c15c4288595546e09789cbc2491050073222397957c9090b7f8f96e3fefbc5f438c72ca8bb48f6337e208ee9b3f630a8c5b40b9fafca8e55be0a0cf4046884a0a049b4557da4ddb7a344226f4707c706e96467b1568ad4d10363aa9eb04b91efbada0c1c292475ce9893a27d4a1deb4a262d980141e63756adf3d5fbcf6ebde919cfd44052984704af6ba360e190fecfc730a5e470785d3061ee5f495cd697af97f90bbc11f2e4e41e57ce25f34b9c4ec9f3c051d964ad0c036b4
 Ctrl.hexxcghash = hexxcghash:5ae93beda675546c8a783974925aca9b365a6d8e
 Ctrl.hexsession_id = hexsession_id:bb0bfeb33b78474b2d53232b3122506992c0cae4
@@ -972,7 +973,7 @@ Ctrl.type = type:A
 Output = 739ad52e454ba3457735b7c5304c6578
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100c0724e077d7237441eb79039debaa851c0bf411e69cd5314f3c72aa45760c9969985b34291fb64bf964b719d2b989e40a0e9fbccdb23536a78f1b55ebbda809f862e8ec3561c15c4288595546e09789cbc2491050073222397957c9090b7f8f96e3fefbc5f438c72ca8bb48f6337e208ee9b3f630a8c5b40b9fafca8e55be0a0cf4046884a0a049b4557da4ddb7a344226f4707c706e96467b1568ad4d10363aa9eb04b91efbada0c1c292475ce9893a27d4a1deb4a262d980141e63756adf3d5fbcf6ebde919cfd44052984704af6ba360e190fecfc730a5e470785d3061ee5f495cd697af97f90bbc11f2e4e41e57ce25f34b9c4ec9f3c051d964ad0c036b4
 Ctrl.hexxcghash = hexxcghash:5ae93beda675546c8a783974925aca9b365a6d8e
 Ctrl.hexsession_id = hexsession_id:bb0bfeb33b78474b2d53232b3122506992c0cae4
@@ -980,7 +981,7 @@ Ctrl.type = type:B
 Output = 3bd9f9d9f06aa521d2f53e40fc5d9f90
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100c0724e077d7237441eb79039debaa851c0bf411e69cd5314f3c72aa45760c9969985b34291fb64bf964b719d2b989e40a0e9fbccdb23536a78f1b55ebbda809f862e8ec3561c15c4288595546e09789cbc2491050073222397957c9090b7f8f96e3fefbc5f438c72ca8bb48f6337e208ee9b3f630a8c5b40b9fafca8e55be0a0cf4046884a0a049b4557da4ddb7a344226f4707c706e96467b1568ad4d10363aa9eb04b91efbada0c1c292475ce9893a27d4a1deb4a262d980141e63756adf3d5fbcf6ebde919cfd44052984704af6ba360e190fecfc730a5e470785d3061ee5f495cd697af97f90bbc11f2e4e41e57ce25f34b9c4ec9f3c051d964ad0c036b4
 Ctrl.hexxcghash = hexxcghash:5ae93beda675546c8a783974925aca9b365a6d8e
 Ctrl.hexsession_id = hexsession_id:bb0bfeb33b78474b2d53232b3122506992c0cae4
@@ -988,7 +989,7 @@ Ctrl.type = type:C
 Output = 335cd2813bebd3d5e1dda4c1e14c23de
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100c0724e077d7237441eb79039debaa851c0bf411e69cd5314f3c72aa45760c9969985b34291fb64bf964b719d2b989e40a0e9fbccdb23536a78f1b55ebbda809f862e8ec3561c15c4288595546e09789cbc2491050073222397957c9090b7f8f96e3fefbc5f438c72ca8bb48f6337e208ee9b3f630a8c5b40b9fafca8e55be0a0cf4046884a0a049b4557da4ddb7a344226f4707c706e96467b1568ad4d10363aa9eb04b91efbada0c1c292475ce9893a27d4a1deb4a262d980141e63756adf3d5fbcf6ebde919cfd44052984704af6ba360e190fecfc730a5e470785d3061ee5f495cd697af97f90bbc11f2e4e41e57ce25f34b9c4ec9f3c051d964ad0c036b4
 Ctrl.hexxcghash = hexxcghash:5ae93beda675546c8a783974925aca9b365a6d8e
 Ctrl.hexsession_id = hexsession_id:bb0bfeb33b78474b2d53232b3122506992c0cae4
@@ -996,7 +997,7 @@ Ctrl.type = type:D
 Output = fd25c5ae649645d8c0cfff0d4d8e7a47
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100c0724e077d7237441eb79039debaa851c0bf411e69cd5314f3c72aa45760c9969985b34291fb64bf964b719d2b989e40a0e9fbccdb23536a78f1b55ebbda809f862e8ec3561c15c4288595546e09789cbc2491050073222397957c9090b7f8f96e3fefbc5f438c72ca8bb48f6337e208ee9b3f630a8c5b40b9fafca8e55be0a0cf4046884a0a049b4557da4ddb7a344226f4707c706e96467b1568ad4d10363aa9eb04b91efbada0c1c292475ce9893a27d4a1deb4a262d980141e63756adf3d5fbcf6ebde919cfd44052984704af6ba360e190fecfc730a5e470785d3061ee5f495cd697af97f90bbc11f2e4e41e57ce25f34b9c4ec9f3c051d964ad0c036b4
 Ctrl.hexxcghash = hexxcghash:5ae93beda675546c8a783974925aca9b365a6d8e
 Ctrl.hexsession_id = hexsession_id:bb0bfeb33b78474b2d53232b3122506992c0cae4
@@ -1004,7 +1005,7 @@ Ctrl.type = type:E
 Output = 90e89773d04623553d4d298e6aa75781d8a6544b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100c0724e077d7237441eb79039debaa851c0bf411e69cd5314f3c72aa45760c9969985b34291fb64bf964b719d2b989e40a0e9fbccdb23536a78f1b55ebbda809f862e8ec3561c15c4288595546e09789cbc2491050073222397957c9090b7f8f96e3fefbc5f438c72ca8bb48f6337e208ee9b3f630a8c5b40b9fafca8e55be0a0cf4046884a0a049b4557da4ddb7a344226f4707c706e96467b1568ad4d10363aa9eb04b91efbada0c1c292475ce9893a27d4a1deb4a262d980141e63756adf3d5fbcf6ebde919cfd44052984704af6ba360e190fecfc730a5e470785d3061ee5f495cd697af97f90bbc11f2e4e41e57ce25f34b9c4ec9f3c051d964ad0c036b4
 Ctrl.hexxcghash = hexxcghash:5ae93beda675546c8a783974925aca9b365a6d8e
 Ctrl.hexsession_id = hexsession_id:bb0bfeb33b78474b2d53232b3122506992c0cae4
@@ -1012,7 +1013,7 @@ Ctrl.type = type:F
 Output = 86a3f05a5f844b23d787cccbda37a3d773a4d049
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001004c48728c828a34a5ff90188cd749d5ccf849d8f96d78072bc8c3a766e4be2c4bfdb8d0310225f05b0373fa582b5a9e78b6a05d958a7b82d944d00697a1ef2119e7545bdf2c6dc2e8cb2215ff58a0163c116b0b326caa50e6384e4e4ab424bfada5d15af1d22f34dc5f8bfd5c823c4b9253fe858a9d7f17bf0be17951bce751b8c2f0b3be25bad6054b39fb2d687d4e69c07d79f4952e65315b1f712cee11707a4984f29df9aac7a7274772f60a2f207ec6a35e1478aa9ae8045dc53417b220bf60124d988e376bf18414400bbe2ac4654716fd26b3a90ae53215ff906364ef82a08686a1977126c64d6d3f381e8477d55f8e79a0e0719089e073fffdbf828cde
 Ctrl.hexxcghash = hexxcghash:edeac369fd19f7dd1e8e48d0c69f9df5fe5475b4
 Ctrl.hexsession_id = hexsession_id:30d9cd8d63a203aeff4a99d8c299676f21a2c74e
@@ -1020,7 +1021,7 @@ Ctrl.type = type:A
 Output = d2d06d589e6e696556e3d44d7d05decb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001004c48728c828a34a5ff90188cd749d5ccf849d8f96d78072bc8c3a766e4be2c4bfdb8d0310225f05b0373fa582b5a9e78b6a05d958a7b82d944d00697a1ef2119e7545bdf2c6dc2e8cb2215ff58a0163c116b0b326caa50e6384e4e4ab424bfada5d15af1d22f34dc5f8bfd5c823c4b9253fe858a9d7f17bf0be17951bce751b8c2f0b3be25bad6054b39fb2d687d4e69c07d79f4952e65315b1f712cee11707a4984f29df9aac7a7274772f60a2f207ec6a35e1478aa9ae8045dc53417b220bf60124d988e376bf18414400bbe2ac4654716fd26b3a90ae53215ff906364ef82a08686a1977126c64d6d3f381e8477d55f8e79a0e0719089e073fffdbf828cde
 Ctrl.hexxcghash = hexxcghash:edeac369fd19f7dd1e8e48d0c69f9df5fe5475b4
 Ctrl.hexsession_id = hexsession_id:30d9cd8d63a203aeff4a99d8c299676f21a2c74e
@@ -1028,7 +1029,7 @@ Ctrl.type = type:B
 Output = 14e3a886b715206e837b70fe7c02b941
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001004c48728c828a34a5ff90188cd749d5ccf849d8f96d78072bc8c3a766e4be2c4bfdb8d0310225f05b0373fa582b5a9e78b6a05d958a7b82d944d00697a1ef2119e7545bdf2c6dc2e8cb2215ff58a0163c116b0b326caa50e6384e4e4ab424bfada5d15af1d22f34dc5f8bfd5c823c4b9253fe858a9d7f17bf0be17951bce751b8c2f0b3be25bad6054b39fb2d687d4e69c07d79f4952e65315b1f712cee11707a4984f29df9aac7a7274772f60a2f207ec6a35e1478aa9ae8045dc53417b220bf60124d988e376bf18414400bbe2ac4654716fd26b3a90ae53215ff906364ef82a08686a1977126c64d6d3f381e8477d55f8e79a0e0719089e073fffdbf828cde
 Ctrl.hexxcghash = hexxcghash:edeac369fd19f7dd1e8e48d0c69f9df5fe5475b4
 Ctrl.hexsession_id = hexsession_id:30d9cd8d63a203aeff4a99d8c299676f21a2c74e
@@ -1036,7 +1037,7 @@ Ctrl.type = type:C
 Output = 98625cf9741819273a0d6852ca7ab592
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001004c48728c828a34a5ff90188cd749d5ccf849d8f96d78072bc8c3a766e4be2c4bfdb8d0310225f05b0373fa582b5a9e78b6a05d958a7b82d944d00697a1ef2119e7545bdf2c6dc2e8cb2215ff58a0163c116b0b326caa50e6384e4e4ab424bfada5d15af1d22f34dc5f8bfd5c823c4b9253fe858a9d7f17bf0be17951bce751b8c2f0b3be25bad6054b39fb2d687d4e69c07d79f4952e65315b1f712cee11707a4984f29df9aac7a7274772f60a2f207ec6a35e1478aa9ae8045dc53417b220bf60124d988e376bf18414400bbe2ac4654716fd26b3a90ae53215ff906364ef82a08686a1977126c64d6d3f381e8477d55f8e79a0e0719089e073fffdbf828cde
 Ctrl.hexxcghash = hexxcghash:edeac369fd19f7dd1e8e48d0c69f9df5fe5475b4
 Ctrl.hexsession_id = hexsession_id:30d9cd8d63a203aeff4a99d8c299676f21a2c74e
@@ -1044,7 +1045,7 @@ Ctrl.type = type:D
 Output = a7b273f04d537856015e06075c94c398
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001004c48728c828a34a5ff90188cd749d5ccf849d8f96d78072bc8c3a766e4be2c4bfdb8d0310225f05b0373fa582b5a9e78b6a05d958a7b82d944d00697a1ef2119e7545bdf2c6dc2e8cb2215ff58a0163c116b0b326caa50e6384e4e4ab424bfada5d15af1d22f34dc5f8bfd5c823c4b9253fe858a9d7f17bf0be17951bce751b8c2f0b3be25bad6054b39fb2d687d4e69c07d79f4952e65315b1f712cee11707a4984f29df9aac7a7274772f60a2f207ec6a35e1478aa9ae8045dc53417b220bf60124d988e376bf18414400bbe2ac4654716fd26b3a90ae53215ff906364ef82a08686a1977126c64d6d3f381e8477d55f8e79a0e0719089e073fffdbf828cde
 Ctrl.hexxcghash = hexxcghash:edeac369fd19f7dd1e8e48d0c69f9df5fe5475b4
 Ctrl.hexsession_id = hexsession_id:30d9cd8d63a203aeff4a99d8c299676f21a2c74e
@@ -1052,7 +1053,7 @@ Ctrl.type = type:E
 Output = 3e1afa980d05ec30e9a55331ac301c10305999e2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001004c48728c828a34a5ff90188cd749d5ccf849d8f96d78072bc8c3a766e4be2c4bfdb8d0310225f05b0373fa582b5a9e78b6a05d958a7b82d944d00697a1ef2119e7545bdf2c6dc2e8cb2215ff58a0163c116b0b326caa50e6384e4e4ab424bfada5d15af1d22f34dc5f8bfd5c823c4b9253fe858a9d7f17bf0be17951bce751b8c2f0b3be25bad6054b39fb2d687d4e69c07d79f4952e65315b1f712cee11707a4984f29df9aac7a7274772f60a2f207ec6a35e1478aa9ae8045dc53417b220bf60124d988e376bf18414400bbe2ac4654716fd26b3a90ae53215ff906364ef82a08686a1977126c64d6d3f381e8477d55f8e79a0e0719089e073fffdbf828cde
 Ctrl.hexxcghash = hexxcghash:edeac369fd19f7dd1e8e48d0c69f9df5fe5475b4
 Ctrl.hexsession_id = hexsession_id:30d9cd8d63a203aeff4a99d8c299676f21a2c74e
@@ -1060,7 +1061,7 @@ Ctrl.type = type:F
 Output = b993c4254669c7a51ed713ddaf7174fd5296fe57
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100f6fa934f303a9db720352fca5a6bae671857d44053d61132a6d36d76cee686fd31ea796407306ad3cb500f99b8881641ce304217910179ca03d3638c89419127542d2f6eea999c637070a3a2e2d17419fd2d53a23dc0bbad1333089a64c232c4328ca5d6db233777a93932407741a9fe4c8efd13e9f2f411368fd2035d05175f8710b79a77bd4749df3027eef44f1d050fd01458cd1c6d1fe67d774f4e056533305ad39ecf5a6e4898186b8b66e95c9546081c7df6df7a433887bb0333d0fb16418bb2d399b2be0b02978e5bbc97b57e67e88aa073ba3280a386209029bdc3d8f448eb18e29c87811142629827c54aa19d150b6eb6fb7a33d746b11d27d9d474
 Ctrl.hexxcghash = hexxcghash:6dffed964fd4044cb99b5f8770abef82d02c1cd1
 Ctrl.hexsession_id = hexsession_id:d98f1e884633c4632568e1dd0a54e4c8508c279d
@@ -1068,7 +1069,7 @@ Ctrl.type = type:A
 Output = d9c0ed6b7fbf066d4f3cff7d2585ef5b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100f6fa934f303a9db720352fca5a6bae671857d44053d61132a6d36d76cee686fd31ea796407306ad3cb500f99b8881641ce304217910179ca03d3638c89419127542d2f6eea999c637070a3a2e2d17419fd2d53a23dc0bbad1333089a64c232c4328ca5d6db233777a93932407741a9fe4c8efd13e9f2f411368fd2035d05175f8710b79a77bd4749df3027eef44f1d050fd01458cd1c6d1fe67d774f4e056533305ad39ecf5a6e4898186b8b66e95c9546081c7df6df7a433887bb0333d0fb16418bb2d399b2be0b02978e5bbc97b57e67e88aa073ba3280a386209029bdc3d8f448eb18e29c87811142629827c54aa19d150b6eb6fb7a33d746b11d27d9d474
 Ctrl.hexxcghash = hexxcghash:6dffed964fd4044cb99b5f8770abef82d02c1cd1
 Ctrl.hexsession_id = hexsession_id:d98f1e884633c4632568e1dd0a54e4c8508c279d
@@ -1076,7 +1077,7 @@ Ctrl.type = type:B
 Output = da13833aa2c086e5d76595132f4e5fc6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100f6fa934f303a9db720352fca5a6bae671857d44053d61132a6d36d76cee686fd31ea796407306ad3cb500f99b8881641ce304217910179ca03d3638c89419127542d2f6eea999c637070a3a2e2d17419fd2d53a23dc0bbad1333089a64c232c4328ca5d6db233777a93932407741a9fe4c8efd13e9f2f411368fd2035d05175f8710b79a77bd4749df3027eef44f1d050fd01458cd1c6d1fe67d774f4e056533305ad39ecf5a6e4898186b8b66e95c9546081c7df6df7a433887bb0333d0fb16418bb2d399b2be0b02978e5bbc97b57e67e88aa073ba3280a386209029bdc3d8f448eb18e29c87811142629827c54aa19d150b6eb6fb7a33d746b11d27d9d474
 Ctrl.hexxcghash = hexxcghash:6dffed964fd4044cb99b5f8770abef82d02c1cd1
 Ctrl.hexsession_id = hexsession_id:d98f1e884633c4632568e1dd0a54e4c8508c279d
@@ -1084,7 +1085,7 @@ Ctrl.type = type:C
 Output = 9e27400587b646397a7655be0e5763ec
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100f6fa934f303a9db720352fca5a6bae671857d44053d61132a6d36d76cee686fd31ea796407306ad3cb500f99b8881641ce304217910179ca03d3638c89419127542d2f6eea999c637070a3a2e2d17419fd2d53a23dc0bbad1333089a64c232c4328ca5d6db233777a93932407741a9fe4c8efd13e9f2f411368fd2035d05175f8710b79a77bd4749df3027eef44f1d050fd01458cd1c6d1fe67d774f4e056533305ad39ecf5a6e4898186b8b66e95c9546081c7df6df7a433887bb0333d0fb16418bb2d399b2be0b02978e5bbc97b57e67e88aa073ba3280a386209029bdc3d8f448eb18e29c87811142629827c54aa19d150b6eb6fb7a33d746b11d27d9d474
 Ctrl.hexxcghash = hexxcghash:6dffed964fd4044cb99b5f8770abef82d02c1cd1
 Ctrl.hexsession_id = hexsession_id:d98f1e884633c4632568e1dd0a54e4c8508c279d
@@ -1092,7 +1093,7 @@ Ctrl.type = type:D
 Output = 91b95d5cce7f2aec14776f49f652a305
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100f6fa934f303a9db720352fca5a6bae671857d44053d61132a6d36d76cee686fd31ea796407306ad3cb500f99b8881641ce304217910179ca03d3638c89419127542d2f6eea999c637070a3a2e2d17419fd2d53a23dc0bbad1333089a64c232c4328ca5d6db233777a93932407741a9fe4c8efd13e9f2f411368fd2035d05175f8710b79a77bd4749df3027eef44f1d050fd01458cd1c6d1fe67d774f4e056533305ad39ecf5a6e4898186b8b66e95c9546081c7df6df7a433887bb0333d0fb16418bb2d399b2be0b02978e5bbc97b57e67e88aa073ba3280a386209029bdc3d8f448eb18e29c87811142629827c54aa19d150b6eb6fb7a33d746b11d27d9d474
 Ctrl.hexxcghash = hexxcghash:6dffed964fd4044cb99b5f8770abef82d02c1cd1
 Ctrl.hexsession_id = hexsession_id:d98f1e884633c4632568e1dd0a54e4c8508c279d
@@ -1100,7 +1101,7 @@ Ctrl.type = type:E
 Output = a97dc9a99e37c983a4922cd2ecdfa394b71141ce
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010100f6fa934f303a9db720352fca5a6bae671857d44053d61132a6d36d76cee686fd31ea796407306ad3cb500f99b8881641ce304217910179ca03d3638c89419127542d2f6eea999c637070a3a2e2d17419fd2d53a23dc0bbad1333089a64c232c4328ca5d6db233777a93932407741a9fe4c8efd13e9f2f411368fd2035d05175f8710b79a77bd4749df3027eef44f1d050fd01458cd1c6d1fe67d774f4e056533305ad39ecf5a6e4898186b8b66e95c9546081c7df6df7a433887bb0333d0fb16418bb2d399b2be0b02978e5bbc97b57e67e88aa073ba3280a386209029bdc3d8f448eb18e29c87811142629827c54aa19d150b6eb6fb7a33d746b11d27d9d474
 Ctrl.hexxcghash = hexxcghash:6dffed964fd4044cb99b5f8770abef82d02c1cd1
 Ctrl.hexsession_id = hexsession_id:d98f1e884633c4632568e1dd0a54e4c8508c279d
@@ -1108,7 +1109,7 @@ Ctrl.type = type:F
 Output = 173d846f9790c742ca86af4bff5f965c6088a05b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001000a341cb148554046ac79686473c7e924486ae79c9dd1878a647687d3562cc81e5379c20df44edd6bfa8b9a26cdc06c6eb5f02272f90992ef58c65fe3e98725e9434a8512aef4c2093d27c57a1aee5f5b6861025001d20b5bc8666c4930107f563035bca6ddc91ff9d15ebb56d2628146d3baa3c6f81dc73602518c2aef4906e08b2ffa67e4528d92b1b3bcbd3a9e421d86413bb355574bb68f94bf75221918ca4f6624445b0afa0c26e270788490cbab1abd41a42200ab9e76a2f8b8ffbe0c5ef7a230b5bf7018cfd170ccd009058092d2446ebe73c5f0bf2d9ceca311502af621880eb18e46edc7832765c00e2599fbb82402b039eb5c5ae376690a717c0344
 Ctrl.hexxcghash = hexxcghash:4cee9b1867e94911e8f9fbd9ec3375d25c955f97
 Ctrl.hexsession_id = hexsession_id:2aefdaa6f14ac3ec200a951fd74433cddc01193a
@@ -1116,7 +1117,7 @@ Ctrl.type = type:A
 Output = 6fa496847cda7367cb32b8be9aae3f85
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001000a341cb148554046ac79686473c7e924486ae79c9dd1878a647687d3562cc81e5379c20df44edd6bfa8b9a26cdc06c6eb5f02272f90992ef58c65fe3e98725e9434a8512aef4c2093d27c57a1aee5f5b6861025001d20b5bc8666c4930107f563035bca6ddc91ff9d15ebb56d2628146d3baa3c6f81dc73602518c2aef4906e08b2ffa67e4528d92b1b3bcbd3a9e421d86413bb355574bb68f94bf75221918ca4f6624445b0afa0c26e270788490cbab1abd41a42200ab9e76a2f8b8ffbe0c5ef7a230b5bf7018cfd170ccd009058092d2446ebe73c5f0bf2d9ceca311502af621880eb18e46edc7832765c00e2599fbb82402b039eb5c5ae376690a717c0344
 Ctrl.hexxcghash = hexxcghash:4cee9b1867e94911e8f9fbd9ec3375d25c955f97
 Ctrl.hexsession_id = hexsession_id:2aefdaa6f14ac3ec200a951fd74433cddc01193a
@@ -1124,7 +1125,7 @@ Ctrl.type = type:B
 Output = 702ac8636520b7c6169ddc660781de9f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001000a341cb148554046ac79686473c7e924486ae79c9dd1878a647687d3562cc81e5379c20df44edd6bfa8b9a26cdc06c6eb5f02272f90992ef58c65fe3e98725e9434a8512aef4c2093d27c57a1aee5f5b6861025001d20b5bc8666c4930107f563035bca6ddc91ff9d15ebb56d2628146d3baa3c6f81dc73602518c2aef4906e08b2ffa67e4528d92b1b3bcbd3a9e421d86413bb355574bb68f94bf75221918ca4f6624445b0afa0c26e270788490cbab1abd41a42200ab9e76a2f8b8ffbe0c5ef7a230b5bf7018cfd170ccd009058092d2446ebe73c5f0bf2d9ceca311502af621880eb18e46edc7832765c00e2599fbb82402b039eb5c5ae376690a717c0344
 Ctrl.hexxcghash = hexxcghash:4cee9b1867e94911e8f9fbd9ec3375d25c955f97
 Ctrl.hexsession_id = hexsession_id:2aefdaa6f14ac3ec200a951fd74433cddc01193a
@@ -1132,7 +1133,7 @@ Ctrl.type = type:C
 Output = 6ffd703180af7c2207d5fa9e467272e3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001000a341cb148554046ac79686473c7e924486ae79c9dd1878a647687d3562cc81e5379c20df44edd6bfa8b9a26cdc06c6eb5f02272f90992ef58c65fe3e98725e9434a8512aef4c2093d27c57a1aee5f5b6861025001d20b5bc8666c4930107f563035bca6ddc91ff9d15ebb56d2628146d3baa3c6f81dc73602518c2aef4906e08b2ffa67e4528d92b1b3bcbd3a9e421d86413bb355574bb68f94bf75221918ca4f6624445b0afa0c26e270788490cbab1abd41a42200ab9e76a2f8b8ffbe0c5ef7a230b5bf7018cfd170ccd009058092d2446ebe73c5f0bf2d9ceca311502af621880eb18e46edc7832765c00e2599fbb82402b039eb5c5ae376690a717c0344
 Ctrl.hexxcghash = hexxcghash:4cee9b1867e94911e8f9fbd9ec3375d25c955f97
 Ctrl.hexsession_id = hexsession_id:2aefdaa6f14ac3ec200a951fd74433cddc01193a
@@ -1140,7 +1141,7 @@ Ctrl.type = type:D
 Output = 7ae5281e377f230dcc9854cf995f663d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001000a341cb148554046ac79686473c7e924486ae79c9dd1878a647687d3562cc81e5379c20df44edd6bfa8b9a26cdc06c6eb5f02272f90992ef58c65fe3e98725e9434a8512aef4c2093d27c57a1aee5f5b6861025001d20b5bc8666c4930107f563035bca6ddc91ff9d15ebb56d2628146d3baa3c6f81dc73602518c2aef4906e08b2ffa67e4528d92b1b3bcbd3a9e421d86413bb355574bb68f94bf75221918ca4f6624445b0afa0c26e270788490cbab1abd41a42200ab9e76a2f8b8ffbe0c5ef7a230b5bf7018cfd170ccd009058092d2446ebe73c5f0bf2d9ceca311502af621880eb18e46edc7832765c00e2599fbb82402b039eb5c5ae376690a717c0344
 Ctrl.hexxcghash = hexxcghash:4cee9b1867e94911e8f9fbd9ec3375d25c955f97
 Ctrl.hexsession_id = hexsession_id:2aefdaa6f14ac3ec200a951fd74433cddc01193a
@@ -1148,7 +1149,7 @@ Ctrl.type = type:E
 Output = fbcb152df7a3f12a8f174f9ca31bb31b124ae3c2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001000a341cb148554046ac79686473c7e924486ae79c9dd1878a647687d3562cc81e5379c20df44edd6bfa8b9a26cdc06c6eb5f02272f90992ef58c65fe3e98725e9434a8512aef4c2093d27c57a1aee5f5b6861025001d20b5bc8666c4930107f563035bca6ddc91ff9d15ebb56d2628146d3baa3c6f81dc73602518c2aef4906e08b2ffa67e4528d92b1b3bcbd3a9e421d86413bb355574bb68f94bf75221918ca4f6624445b0afa0c26e270788490cbab1abd41a42200ab9e76a2f8b8ffbe0c5ef7a230b5bf7018cfd170ccd009058092d2446ebe73c5f0bf2d9ceca311502af621880eb18e46edc7832765c00e2599fbb82402b039eb5c5ae376690a717c0344
 Ctrl.hexxcghash = hexxcghash:4cee9b1867e94911e8f9fbd9ec3375d25c955f97
 Ctrl.hexsession_id = hexsession_id:2aefdaa6f14ac3ec200a951fd74433cddc01193a
@@ -1156,7 +1157,7 @@ Ctrl.type = type:F
 Output = 3f0c57fbccfb7306cff23bdaf69d70a8a394b34b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010011afb59055b4e8e0840d76a2d28a3ec1cf3fe7e436b585eab29cc3149e1fa610d979fcc1483a0ea2b426f8e25bc87bae94bdcbeaa80501a3c554d996f1656ac9be75ecefa46273b3ab8a66468cb4a16b3630cbc41df49ebe3917b5afba24d669264e11689f1a401abc557a0c4cf22ad9323056642c2bf7fea0907ba2274b7666dd144e66e1f39371a14ccafa030bad4c6e04f7b22f1e14f9a37ad6aaa3642f66068863a74ed4a07e87494f0ace772b682845fb27efd7f1a99f09b419f43d8443302534e4c59c0d3c59736e47375ff6e96c167247c5196a7c8849adb527e9ccbfae797ea311181978197f924dcf0db7367f84baa27db6e554ba6b764550d2834f
 Ctrl.hexxcghash = hexxcghash:7ced7b72644be681615e503ecafe0c8f7124c85b
 Ctrl.hexsession_id = hexsession_id:95d4ca5b0107d3d9f94ef857d7a64f685d3fecdc
@@ -1164,7 +1165,7 @@ Ctrl.type = type:A
 Output = 7e37ea52156fad1903709e1d3229721f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010011afb59055b4e8e0840d76a2d28a3ec1cf3fe7e436b585eab29cc3149e1fa610d979fcc1483a0ea2b426f8e25bc87bae94bdcbeaa80501a3c554d996f1656ac9be75ecefa46273b3ab8a66468cb4a16b3630cbc41df49ebe3917b5afba24d669264e11689f1a401abc557a0c4cf22ad9323056642c2bf7fea0907ba2274b7666dd144e66e1f39371a14ccafa030bad4c6e04f7b22f1e14f9a37ad6aaa3642f66068863a74ed4a07e87494f0ace772b682845fb27efd7f1a99f09b419f43d8443302534e4c59c0d3c59736e47375ff6e96c167247c5196a7c8849adb527e9ccbfae797ea311181978197f924dcf0db7367f84baa27db6e554ba6b764550d2834f
 Ctrl.hexxcghash = hexxcghash:7ced7b72644be681615e503ecafe0c8f7124c85b
 Ctrl.hexsession_id = hexsession_id:95d4ca5b0107d3d9f94ef857d7a64f685d3fecdc
@@ -1172,7 +1173,7 @@ Ctrl.type = type:B
 Output = c15569583de413e08293bf1689a9afe8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010011afb59055b4e8e0840d76a2d28a3ec1cf3fe7e436b585eab29cc3149e1fa610d979fcc1483a0ea2b426f8e25bc87bae94bdcbeaa80501a3c554d996f1656ac9be75ecefa46273b3ab8a66468cb4a16b3630cbc41df49ebe3917b5afba24d669264e11689f1a401abc557a0c4cf22ad9323056642c2bf7fea0907ba2274b7666dd144e66e1f39371a14ccafa030bad4c6e04f7b22f1e14f9a37ad6aaa3642f66068863a74ed4a07e87494f0ace772b682845fb27efd7f1a99f09b419f43d8443302534e4c59c0d3c59736e47375ff6e96c167247c5196a7c8849adb527e9ccbfae797ea311181978197f924dcf0db7367f84baa27db6e554ba6b764550d2834f
 Ctrl.hexxcghash = hexxcghash:7ced7b72644be681615e503ecafe0c8f7124c85b
 Ctrl.hexsession_id = hexsession_id:95d4ca5b0107d3d9f94ef857d7a64f685d3fecdc
@@ -1180,7 +1181,7 @@ Ctrl.type = type:C
 Output = 0c85227539f5e328c64172280759d9bf
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010011afb59055b4e8e0840d76a2d28a3ec1cf3fe7e436b585eab29cc3149e1fa610d979fcc1483a0ea2b426f8e25bc87bae94bdcbeaa80501a3c554d996f1656ac9be75ecefa46273b3ab8a66468cb4a16b3630cbc41df49ebe3917b5afba24d669264e11689f1a401abc557a0c4cf22ad9323056642c2bf7fea0907ba2274b7666dd144e66e1f39371a14ccafa030bad4c6e04f7b22f1e14f9a37ad6aaa3642f66068863a74ed4a07e87494f0ace772b682845fb27efd7f1a99f09b419f43d8443302534e4c59c0d3c59736e47375ff6e96c167247c5196a7c8849adb527e9ccbfae797ea311181978197f924dcf0db7367f84baa27db6e554ba6b764550d2834f
 Ctrl.hexxcghash = hexxcghash:7ced7b72644be681615e503ecafe0c8f7124c85b
 Ctrl.hexsession_id = hexsession_id:95d4ca5b0107d3d9f94ef857d7a64f685d3fecdc
@@ -1188,7 +1189,7 @@ Ctrl.type = type:D
 Output = 3dbc42d9e7128e861b87781546cedc8e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010011afb59055b4e8e0840d76a2d28a3ec1cf3fe7e436b585eab29cc3149e1fa610d979fcc1483a0ea2b426f8e25bc87bae94bdcbeaa80501a3c554d996f1656ac9be75ecefa46273b3ab8a66468cb4a16b3630cbc41df49ebe3917b5afba24d669264e11689f1a401abc557a0c4cf22ad9323056642c2bf7fea0907ba2274b7666dd144e66e1f39371a14ccafa030bad4c6e04f7b22f1e14f9a37ad6aaa3642f66068863a74ed4a07e87494f0ace772b682845fb27efd7f1a99f09b419f43d8443302534e4c59c0d3c59736e47375ff6e96c167247c5196a7c8849adb527e9ccbfae797ea311181978197f924dcf0db7367f84baa27db6e554ba6b764550d2834f
 Ctrl.hexxcghash = hexxcghash:7ced7b72644be681615e503ecafe0c8f7124c85b
 Ctrl.hexsession_id = hexsession_id:95d4ca5b0107d3d9f94ef857d7a64f685d3fecdc
@@ -1196,7 +1197,7 @@ Ctrl.type = type:E
 Output = 1ec0d15e38ea1b48da963837dbf30cef855a92c7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010011afb59055b4e8e0840d76a2d28a3ec1cf3fe7e436b585eab29cc3149e1fa610d979fcc1483a0ea2b426f8e25bc87bae94bdcbeaa80501a3c554d996f1656ac9be75ecefa46273b3ab8a66468cb4a16b3630cbc41df49ebe3917b5afba24d669264e11689f1a401abc557a0c4cf22ad9323056642c2bf7fea0907ba2274b7666dd144e66e1f39371a14ccafa030bad4c6e04f7b22f1e14f9a37ad6aaa3642f66068863a74ed4a07e87494f0ace772b682845fb27efd7f1a99f09b419f43d8443302534e4c59c0d3c59736e47375ff6e96c167247c5196a7c8849adb527e9ccbfae797ea311181978197f924dcf0db7367f84baa27db6e554ba6b764550d2834f
 Ctrl.hexxcghash = hexxcghash:7ced7b72644be681615e503ecafe0c8f7124c85b
 Ctrl.hexsession_id = hexsession_id:95d4ca5b0107d3d9f94ef857d7a64f685d3fecdc
@@ -1204,7 +1205,7 @@ Ctrl.type = type:F
 Output = eea8ea042a079fcf8416a8b244fafab35adeca8a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001002f14b1acdf871bec4ea5720a3e921cf16a796559b2a094a0d1e45021dcabff152a0e3dca4115239454dc407a6474c8fcd395273a6487c6736710610aeb607707b7ef87203a081646af53ba037f29316a3dec4ce80ec04775b8697db46f7e4f4b38d69de832a25cf0a5484c9b36a48950d50dfe77ac5da63a1c2314ffa8cb68f0c201bbfb7a1a89837b9f57465d14635bda2abf601a06bbd8f70af0169c39209dcda9fb1416a9eadb5ea4deb358566190a62a44d6765d9a25b5157ed5e0f5317f0ed3f6eacebe07ba214e2ef9f654dbc2fa3dc2f227124a3f56a40905c9c86cd64b0ed80c4299d86f59d5f06b9c026a28feea5c5fafbe7ba90283de867dd55858
 Ctrl.hexxcghash = hexxcghash:5fb6dff3272cb949856a57f2645a56d957dc4606
 Ctrl.hexsession_id = hexsession_id:5160cab836d899193077dc67485ef41669ec5d8a
@@ -1212,7 +1213,7 @@ Ctrl.type = type:A
 Output = f2faef6e274814ed7ca544484ac21a3a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001002f14b1acdf871bec4ea5720a3e921cf16a796559b2a094a0d1e45021dcabff152a0e3dca4115239454dc407a6474c8fcd395273a6487c6736710610aeb607707b7ef87203a081646af53ba037f29316a3dec4ce80ec04775b8697db46f7e4f4b38d69de832a25cf0a5484c9b36a48950d50dfe77ac5da63a1c2314ffa8cb68f0c201bbfb7a1a89837b9f57465d14635bda2abf601a06bbd8f70af0169c39209dcda9fb1416a9eadb5ea4deb358566190a62a44d6765d9a25b5157ed5e0f5317f0ed3f6eacebe07ba214e2ef9f654dbc2fa3dc2f227124a3f56a40905c9c86cd64b0ed80c4299d86f59d5f06b9c026a28feea5c5fafbe7ba90283de867dd55858
 Ctrl.hexxcghash = hexxcghash:5fb6dff3272cb949856a57f2645a56d957dc4606
 Ctrl.hexsession_id = hexsession_id:5160cab836d899193077dc67485ef41669ec5d8a
@@ -1220,7 +1221,7 @@ Ctrl.type = type:B
 Output = 3ca9bc0f3c65c257fa160a4d1c5e3520
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001002f14b1acdf871bec4ea5720a3e921cf16a796559b2a094a0d1e45021dcabff152a0e3dca4115239454dc407a6474c8fcd395273a6487c6736710610aeb607707b7ef87203a081646af53ba037f29316a3dec4ce80ec04775b8697db46f7e4f4b38d69de832a25cf0a5484c9b36a48950d50dfe77ac5da63a1c2314ffa8cb68f0c201bbfb7a1a89837b9f57465d14635bda2abf601a06bbd8f70af0169c39209dcda9fb1416a9eadb5ea4deb358566190a62a44d6765d9a25b5157ed5e0f5317f0ed3f6eacebe07ba214e2ef9f654dbc2fa3dc2f227124a3f56a40905c9c86cd64b0ed80c4299d86f59d5f06b9c026a28feea5c5fafbe7ba90283de867dd55858
 Ctrl.hexxcghash = hexxcghash:5fb6dff3272cb949856a57f2645a56d957dc4606
 Ctrl.hexsession_id = hexsession_id:5160cab836d899193077dc67485ef41669ec5d8a
@@ -1228,7 +1229,7 @@ Ctrl.type = type:C
 Output = fcdf0545b51aca6515bccf6ed0ecb582
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001002f14b1acdf871bec4ea5720a3e921cf16a796559b2a094a0d1e45021dcabff152a0e3dca4115239454dc407a6474c8fcd395273a6487c6736710610aeb607707b7ef87203a081646af53ba037f29316a3dec4ce80ec04775b8697db46f7e4f4b38d69de832a25cf0a5484c9b36a48950d50dfe77ac5da63a1c2314ffa8cb68f0c201bbfb7a1a89837b9f57465d14635bda2abf601a06bbd8f70af0169c39209dcda9fb1416a9eadb5ea4deb358566190a62a44d6765d9a25b5157ed5e0f5317f0ed3f6eacebe07ba214e2ef9f654dbc2fa3dc2f227124a3f56a40905c9c86cd64b0ed80c4299d86f59d5f06b9c026a28feea5c5fafbe7ba90283de867dd55858
 Ctrl.hexxcghash = hexxcghash:5fb6dff3272cb949856a57f2645a56d957dc4606
 Ctrl.hexsession_id = hexsession_id:5160cab836d899193077dc67485ef41669ec5d8a
@@ -1236,7 +1237,7 @@ Ctrl.type = type:D
 Output = 86ea895a310c3bbd1aac209b2362d58a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001002f14b1acdf871bec4ea5720a3e921cf16a796559b2a094a0d1e45021dcabff152a0e3dca4115239454dc407a6474c8fcd395273a6487c6736710610aeb607707b7ef87203a081646af53ba037f29316a3dec4ce80ec04775b8697db46f7e4f4b38d69de832a25cf0a5484c9b36a48950d50dfe77ac5da63a1c2314ffa8cb68f0c201bbfb7a1a89837b9f57465d14635bda2abf601a06bbd8f70af0169c39209dcda9fb1416a9eadb5ea4deb358566190a62a44d6765d9a25b5157ed5e0f5317f0ed3f6eacebe07ba214e2ef9f654dbc2fa3dc2f227124a3f56a40905c9c86cd64b0ed80c4299d86f59d5f06b9c026a28feea5c5fafbe7ba90283de867dd55858
 Ctrl.hexxcghash = hexxcghash:5fb6dff3272cb949856a57f2645a56d957dc4606
 Ctrl.hexsession_id = hexsession_id:5160cab836d899193077dc67485ef41669ec5d8a
@@ -1244,7 +1245,7 @@ Ctrl.type = type:E
 Output = 12a4f2b749e2bf88c1f8437e5ff61de761fd48b3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001002f14b1acdf871bec4ea5720a3e921cf16a796559b2a094a0d1e45021dcabff152a0e3dca4115239454dc407a6474c8fcd395273a6487c6736710610aeb607707b7ef87203a081646af53ba037f29316a3dec4ce80ec04775b8697db46f7e4f4b38d69de832a25cf0a5484c9b36a48950d50dfe77ac5da63a1c2314ffa8cb68f0c201bbfb7a1a89837b9f57465d14635bda2abf601a06bbd8f70af0169c39209dcda9fb1416a9eadb5ea4deb358566190a62a44d6765d9a25b5157ed5e0f5317f0ed3f6eacebe07ba214e2ef9f654dbc2fa3dc2f227124a3f56a40905c9c86cd64b0ed80c4299d86f59d5f06b9c026a28feea5c5fafbe7ba90283de867dd55858
 Ctrl.hexxcghash = hexxcghash:5fb6dff3272cb949856a57f2645a56d957dc4606
 Ctrl.hexsession_id = hexsession_id:5160cab836d899193077dc67485ef41669ec5d8a
@@ -1252,7 +1253,7 @@ Ctrl.type = type:F
 Output = a3a9276a120db379ec780e434879a54935db954d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010060cc18ebbeb9b25cb16a58bfa47644110ceab67f274daf67157e923b70f775a4168bb7911d0e53075044366e503fbffcf3fcf9249e551d69211715b681ba3a28dd133dbada24dcf80d2bf67a1d6c0477f108f8763b30fe28c6d0b54e59e7e580692453d05a30d38e134d6117ca999ace80a57d088228b2a9f001e57d3a8b1cdffe55fda194f01189ec2bb0d99fc8570a9d822a94dddb22f4ba3c88f2ee1045dafa2d106e5c2c09519e47ad9eaf2301569c9258a2deda9d3ea5b0c73f00d8d12579e5931d5253220d60eeb12fcefc98bc8f390e52b3b407280a31283628963c1131b6fd584be948c3fb4d316fa4a1b135513a174cafb0d394bb4afbee6cbe796e
 Ctrl.hexxcghash = hexxcghash:501c76e6b5791e343fb6e7597e890c7dea7f04e5
 Ctrl.hexsession_id = hexsession_id:68e1f225f2e63df7bedbab15112b3670f03eed56
@@ -1260,7 +1261,7 @@ Ctrl.type = type:A
 Output = e53f2f61d8919e097cb99627fe668385
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010060cc18ebbeb9b25cb16a58bfa47644110ceab67f274daf67157e923b70f775a4168bb7911d0e53075044366e503fbffcf3fcf9249e551d69211715b681ba3a28dd133dbada24dcf80d2bf67a1d6c0477f108f8763b30fe28c6d0b54e59e7e580692453d05a30d38e134d6117ca999ace80a57d088228b2a9f001e57d3a8b1cdffe55fda194f01189ec2bb0d99fc8570a9d822a94dddb22f4ba3c88f2ee1045dafa2d106e5c2c09519e47ad9eaf2301569c9258a2deda9d3ea5b0c73f00d8d12579e5931d5253220d60eeb12fcefc98bc8f390e52b3b407280a31283628963c1131b6fd584be948c3fb4d316fa4a1b135513a174cafb0d394bb4afbee6cbe796e
 Ctrl.hexxcghash = hexxcghash:501c76e6b5791e343fb6e7597e890c7dea7f04e5
 Ctrl.hexsession_id = hexsession_id:68e1f225f2e63df7bedbab15112b3670f03eed56
@@ -1268,7 +1269,7 @@ Ctrl.type = type:B
 Output = cea80fd8dc06654ed80b0ec150835537
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010060cc18ebbeb9b25cb16a58bfa47644110ceab67f274daf67157e923b70f775a4168bb7911d0e53075044366e503fbffcf3fcf9249e551d69211715b681ba3a28dd133dbada24dcf80d2bf67a1d6c0477f108f8763b30fe28c6d0b54e59e7e580692453d05a30d38e134d6117ca999ace80a57d088228b2a9f001e57d3a8b1cdffe55fda194f01189ec2bb0d99fc8570a9d822a94dddb22f4ba3c88f2ee1045dafa2d106e5c2c09519e47ad9eaf2301569c9258a2deda9d3ea5b0c73f00d8d12579e5931d5253220d60eeb12fcefc98bc8f390e52b3b407280a31283628963c1131b6fd584be948c3fb4d316fa4a1b135513a174cafb0d394bb4afbee6cbe796e
 Ctrl.hexxcghash = hexxcghash:501c76e6b5791e343fb6e7597e890c7dea7f04e5
 Ctrl.hexsession_id = hexsession_id:68e1f225f2e63df7bedbab15112b3670f03eed56
@@ -1276,7 +1277,7 @@ Ctrl.type = type:C
 Output = d5ba475e737bed349b8931ba38d426e9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010060cc18ebbeb9b25cb16a58bfa47644110ceab67f274daf67157e923b70f775a4168bb7911d0e53075044366e503fbffcf3fcf9249e551d69211715b681ba3a28dd133dbada24dcf80d2bf67a1d6c0477f108f8763b30fe28c6d0b54e59e7e580692453d05a30d38e134d6117ca999ace80a57d088228b2a9f001e57d3a8b1cdffe55fda194f01189ec2bb0d99fc8570a9d822a94dddb22f4ba3c88f2ee1045dafa2d106e5c2c09519e47ad9eaf2301569c9258a2deda9d3ea5b0c73f00d8d12579e5931d5253220d60eeb12fcefc98bc8f390e52b3b407280a31283628963c1131b6fd584be948c3fb4d316fa4a1b135513a174cafb0d394bb4afbee6cbe796e
 Ctrl.hexxcghash = hexxcghash:501c76e6b5791e343fb6e7597e890c7dea7f04e5
 Ctrl.hexsession_id = hexsession_id:68e1f225f2e63df7bedbab15112b3670f03eed56
@@ -1284,7 +1285,7 @@ Ctrl.type = type:D
 Output = f3ea92b4f365ab2fb8403ad8ecd2d17c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010060cc18ebbeb9b25cb16a58bfa47644110ceab67f274daf67157e923b70f775a4168bb7911d0e53075044366e503fbffcf3fcf9249e551d69211715b681ba3a28dd133dbada24dcf80d2bf67a1d6c0477f108f8763b30fe28c6d0b54e59e7e580692453d05a30d38e134d6117ca999ace80a57d088228b2a9f001e57d3a8b1cdffe55fda194f01189ec2bb0d99fc8570a9d822a94dddb22f4ba3c88f2ee1045dafa2d106e5c2c09519e47ad9eaf2301569c9258a2deda9d3ea5b0c73f00d8d12579e5931d5253220d60eeb12fcefc98bc8f390e52b3b407280a31283628963c1131b6fd584be948c3fb4d316fa4a1b135513a174cafb0d394bb4afbee6cbe796e
 Ctrl.hexxcghash = hexxcghash:501c76e6b5791e343fb6e7597e890c7dea7f04e5
 Ctrl.hexsession_id = hexsession_id:68e1f225f2e63df7bedbab15112b3670f03eed56
@@ -1292,7 +1293,7 @@ Ctrl.type = type:E
 Output = 41fa718884738fd6fd9ee9fd5af05f0de9400952
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010060cc18ebbeb9b25cb16a58bfa47644110ceab67f274daf67157e923b70f775a4168bb7911d0e53075044366e503fbffcf3fcf9249e551d69211715b681ba3a28dd133dbada24dcf80d2bf67a1d6c0477f108f8763b30fe28c6d0b54e59e7e580692453d05a30d38e134d6117ca999ace80a57d088228b2a9f001e57d3a8b1cdffe55fda194f01189ec2bb0d99fc8570a9d822a94dddb22f4ba3c88f2ee1045dafa2d106e5c2c09519e47ad9eaf2301569c9258a2deda9d3ea5b0c73f00d8d12579e5931d5253220d60eeb12fcefc98bc8f390e52b3b407280a31283628963c1131b6fd584be948c3fb4d316fa4a1b135513a174cafb0d394bb4afbee6cbe796e
 Ctrl.hexxcghash = hexxcghash:501c76e6b5791e343fb6e7597e890c7dea7f04e5
 Ctrl.hexsession_id = hexsession_id:68e1f225f2e63df7bedbab15112b3670f03eed56
@@ -1300,7 +1301,7 @@ Ctrl.type = type:F
 Output = 91395bbd90abb140d0984ed5e77836590bf44695
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010072a106d13e5148877457b7a8c853cfabd151d1b1acde6d776b7affc23c653a3b1c893398c7d83e039fbea9dc739dc14f3a9348af154f840d2f88e3c1982758adeaeb78cff050046d26a9a13391099eea03e9fb853e95c117edaac5b36736e63cb5ad72b346cf1fb342169f5e538591988daec82e0e9a2f4a57db22df8af92424f63111d87991345fd4458abab42cdbfcb84abb222701575a50274a7c6cc38355740cc04bfaff33467c816a70242142fd5467b1713eeec1e0d0f2fcfaf66602dcc31c4105d928a7185ebf53a6e792f419f57573e6dc6d1221e6907f6ad958d2a0c8fe096ce43e403316ae92f93acd1cac7878c9011bc71eff81d4353d7b0c13b1
 Ctrl.hexxcghash = hexxcghash:9acf1f808aeac5b11460192c8f191491b62fc66a
 Ctrl.hexsession_id = hexsession_id:4c662e4dc764cbcb1b3eed4de4375f85c8b2f56c
@@ -1308,7 +1309,7 @@ Ctrl.type = type:A
 Output = 04d3c0a3f5e33ae373c637ef45897779
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010072a106d13e5148877457b7a8c853cfabd151d1b1acde6d776b7affc23c653a3b1c893398c7d83e039fbea9dc739dc14f3a9348af154f840d2f88e3c1982758adeaeb78cff050046d26a9a13391099eea03e9fb853e95c117edaac5b36736e63cb5ad72b346cf1fb342169f5e538591988daec82e0e9a2f4a57db22df8af92424f63111d87991345fd4458abab42cdbfcb84abb222701575a50274a7c6cc38355740cc04bfaff33467c816a70242142fd5467b1713eeec1e0d0f2fcfaf66602dcc31c4105d928a7185ebf53a6e792f419f57573e6dc6d1221e6907f6ad958d2a0c8fe096ce43e403316ae92f93acd1cac7878c9011bc71eff81d4353d7b0c13b1
 Ctrl.hexxcghash = hexxcghash:9acf1f808aeac5b11460192c8f191491b62fc66a
 Ctrl.hexsession_id = hexsession_id:4c662e4dc764cbcb1b3eed4de4375f85c8b2f56c
@@ -1316,7 +1317,7 @@ Ctrl.type = type:B
 Output = c5a45bfbf6d7c14c5d3a953b4848e433
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010072a106d13e5148877457b7a8c853cfabd151d1b1acde6d776b7affc23c653a3b1c893398c7d83e039fbea9dc739dc14f3a9348af154f840d2f88e3c1982758adeaeb78cff050046d26a9a13391099eea03e9fb853e95c117edaac5b36736e63cb5ad72b346cf1fb342169f5e538591988daec82e0e9a2f4a57db22df8af92424f63111d87991345fd4458abab42cdbfcb84abb222701575a50274a7c6cc38355740cc04bfaff33467c816a70242142fd5467b1713eeec1e0d0f2fcfaf66602dcc31c4105d928a7185ebf53a6e792f419f57573e6dc6d1221e6907f6ad958d2a0c8fe096ce43e403316ae92f93acd1cac7878c9011bc71eff81d4353d7b0c13b1
 Ctrl.hexxcghash = hexxcghash:9acf1f808aeac5b11460192c8f191491b62fc66a
 Ctrl.hexsession_id = hexsession_id:4c662e4dc764cbcb1b3eed4de4375f85c8b2f56c
@@ -1324,7 +1325,7 @@ Ctrl.type = type:C
 Output = 3a16d0da2f785e2c325b45109778910a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010072a106d13e5148877457b7a8c853cfabd151d1b1acde6d776b7affc23c653a3b1c893398c7d83e039fbea9dc739dc14f3a9348af154f840d2f88e3c1982758adeaeb78cff050046d26a9a13391099eea03e9fb853e95c117edaac5b36736e63cb5ad72b346cf1fb342169f5e538591988daec82e0e9a2f4a57db22df8af92424f63111d87991345fd4458abab42cdbfcb84abb222701575a50274a7c6cc38355740cc04bfaff33467c816a70242142fd5467b1713eeec1e0d0f2fcfaf66602dcc31c4105d928a7185ebf53a6e792f419f57573e6dc6d1221e6907f6ad958d2a0c8fe096ce43e403316ae92f93acd1cac7878c9011bc71eff81d4353d7b0c13b1
 Ctrl.hexxcghash = hexxcghash:9acf1f808aeac5b11460192c8f191491b62fc66a
 Ctrl.hexsession_id = hexsession_id:4c662e4dc764cbcb1b3eed4de4375f85c8b2f56c
@@ -1332,7 +1333,7 @@ Ctrl.type = type:D
 Output = 902b38dd6c759945e671c1de7d99e918
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010072a106d13e5148877457b7a8c853cfabd151d1b1acde6d776b7affc23c653a3b1c893398c7d83e039fbea9dc739dc14f3a9348af154f840d2f88e3c1982758adeaeb78cff050046d26a9a13391099eea03e9fb853e95c117edaac5b36736e63cb5ad72b346cf1fb342169f5e538591988daec82e0e9a2f4a57db22df8af92424f63111d87991345fd4458abab42cdbfcb84abb222701575a50274a7c6cc38355740cc04bfaff33467c816a70242142fd5467b1713eeec1e0d0f2fcfaf66602dcc31c4105d928a7185ebf53a6e792f419f57573e6dc6d1221e6907f6ad958d2a0c8fe096ce43e403316ae92f93acd1cac7878c9011bc71eff81d4353d7b0c13b1
 Ctrl.hexxcghash = hexxcghash:9acf1f808aeac5b11460192c8f191491b62fc66a
 Ctrl.hexsession_id = hexsession_id:4c662e4dc764cbcb1b3eed4de4375f85c8b2f56c
@@ -1340,7 +1341,7 @@ Ctrl.type = type:E
 Output = b573244de3127f6aa5457e792219dc89defaaecd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000010072a106d13e5148877457b7a8c853cfabd151d1b1acde6d776b7affc23c653a3b1c893398c7d83e039fbea9dc739dc14f3a9348af154f840d2f88e3c1982758adeaeb78cff050046d26a9a13391099eea03e9fb853e95c117edaac5b36736e63cb5ad72b346cf1fb342169f5e538591988daec82e0e9a2f4a57db22df8af92424f63111d87991345fd4458abab42cdbfcb84abb222701575a50274a7c6cc38355740cc04bfaff33467c816a70242142fd5467b1713eeec1e0d0f2fcfaf66602dcc31c4105d928a7185ebf53a6e792f419f57573e6dc6d1221e6907f6ad958d2a0c8fe096ce43e403316ae92f93acd1cac7878c9011bc71eff81d4353d7b0c13b1
 Ctrl.hexxcghash = hexxcghash:9acf1f808aeac5b11460192c8f191491b62fc66a
 Ctrl.hexsession_id = hexsession_id:4c662e4dc764cbcb1b3eed4de4375f85c8b2f56c
@@ -1348,7 +1349,7 @@ Ctrl.type = type:F
 Output = 6cd221005dd1f0de4f472f48d15e61dcc2e91e99
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001003644f9ee24c3ec2e2fe16cdece326cdf5c1309e931bc41f245d3b76f2bdbef0bae58e850e10dcbd0d18356b4f98957a3b95f64c85d1af12ab01fe967e52a632761074f27406a29618192f1cbebae2c25e42f6e9fc00a737e4c92398403ab946a6c33e675e529b5c7364f36d64f07ff65889866dee99293bd5bb5f6454a77bbe0cbfd746d54e5bc948c617c5a1d5d3d2b65fa6a86c5f42c5e01f92a8e97a96f848e50ecb1b495a0e87323b44f5b9dd25ab34a94c077b7490657d1d8f9a9acef2785de82b02ef9fb670faf841ae9b479d2d538ae8e38eaf6e74b884c18c9dafc19b6c9728ff3411537555b3b3b69f6f039958ffb0790e58b09bd8c63819ee50ea5
 Ctrl.hexxcghash = hexxcghash:4d31fdb68c8f42f38cae260bf6402e47de93aac7
 Ctrl.hexsession_id = hexsession_id:47caa2c09bb4dc9d6aeb697a76046bdf1fcd879b
@@ -1356,7 +1357,7 @@ Ctrl.type = type:A
 Output = 5f9deaf2ee4f05af0a8a813ef6bb9549
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001003644f9ee24c3ec2e2fe16cdece326cdf5c1309e931bc41f245d3b76f2bdbef0bae58e850e10dcbd0d18356b4f98957a3b95f64c85d1af12ab01fe967e52a632761074f27406a29618192f1cbebae2c25e42f6e9fc00a737e4c92398403ab946a6c33e675e529b5c7364f36d64f07ff65889866dee99293bd5bb5f6454a77bbe0cbfd746d54e5bc948c617c5a1d5d3d2b65fa6a86c5f42c5e01f92a8e97a96f848e50ecb1b495a0e87323b44f5b9dd25ab34a94c077b7490657d1d8f9a9acef2785de82b02ef9fb670faf841ae9b479d2d538ae8e38eaf6e74b884c18c9dafc19b6c9728ff3411537555b3b3b69f6f039958ffb0790e58b09bd8c63819ee50ea5
 Ctrl.hexxcghash = hexxcghash:4d31fdb68c8f42f38cae260bf6402e47de93aac7
 Ctrl.hexsession_id = hexsession_id:47caa2c09bb4dc9d6aeb697a76046bdf1fcd879b
@@ -1364,7 +1365,7 @@ Ctrl.type = type:B
 Output = a2ea4b795f9c9de1d786d0c771df2b84
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001003644f9ee24c3ec2e2fe16cdece326cdf5c1309e931bc41f245d3b76f2bdbef0bae58e850e10dcbd0d18356b4f98957a3b95f64c85d1af12ab01fe967e52a632761074f27406a29618192f1cbebae2c25e42f6e9fc00a737e4c92398403ab946a6c33e675e529b5c7364f36d64f07ff65889866dee99293bd5bb5f6454a77bbe0cbfd746d54e5bc948c617c5a1d5d3d2b65fa6a86c5f42c5e01f92a8e97a96f848e50ecb1b495a0e87323b44f5b9dd25ab34a94c077b7490657d1d8f9a9acef2785de82b02ef9fb670faf841ae9b479d2d538ae8e38eaf6e74b884c18c9dafc19b6c9728ff3411537555b3b3b69f6f039958ffb0790e58b09bd8c63819ee50ea5
 Ctrl.hexxcghash = hexxcghash:4d31fdb68c8f42f38cae260bf6402e47de93aac7
 Ctrl.hexsession_id = hexsession_id:47caa2c09bb4dc9d6aeb697a76046bdf1fcd879b
@@ -1372,7 +1373,7 @@ Ctrl.type = type:C
 Output = 13f828f8f1e5532a04f138681bc8259d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001003644f9ee24c3ec2e2fe16cdece326cdf5c1309e931bc41f245d3b76f2bdbef0bae58e850e10dcbd0d18356b4f98957a3b95f64c85d1af12ab01fe967e52a632761074f27406a29618192f1cbebae2c25e42f6e9fc00a737e4c92398403ab946a6c33e675e529b5c7364f36d64f07ff65889866dee99293bd5bb5f6454a77bbe0cbfd746d54e5bc948c617c5a1d5d3d2b65fa6a86c5f42c5e01f92a8e97a96f848e50ecb1b495a0e87323b44f5b9dd25ab34a94c077b7490657d1d8f9a9acef2785de82b02ef9fb670faf841ae9b479d2d538ae8e38eaf6e74b884c18c9dafc19b6c9728ff3411537555b3b3b69f6f039958ffb0790e58b09bd8c63819ee50ea5
 Ctrl.hexxcghash = hexxcghash:4d31fdb68c8f42f38cae260bf6402e47de93aac7
 Ctrl.hexsession_id = hexsession_id:47caa2c09bb4dc9d6aeb697a76046bdf1fcd879b
@@ -1380,7 +1381,7 @@ Ctrl.type = type:D
 Output = 7231ce5fd725391e058cd78815f44625
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001003644f9ee24c3ec2e2fe16cdece326cdf5c1309e931bc41f245d3b76f2bdbef0bae58e850e10dcbd0d18356b4f98957a3b95f64c85d1af12ab01fe967e52a632761074f27406a29618192f1cbebae2c25e42f6e9fc00a737e4c92398403ab946a6c33e675e529b5c7364f36d64f07ff65889866dee99293bd5bb5f6454a77bbe0cbfd746d54e5bc948c617c5a1d5d3d2b65fa6a86c5f42c5e01f92a8e97a96f848e50ecb1b495a0e87323b44f5b9dd25ab34a94c077b7490657d1d8f9a9acef2785de82b02ef9fb670faf841ae9b479d2d538ae8e38eaf6e74b884c18c9dafc19b6c9728ff3411537555b3b3b69f6f039958ffb0790e58b09bd8c63819ee50ea5
 Ctrl.hexxcghash = hexxcghash:4d31fdb68c8f42f38cae260bf6402e47de93aac7
 Ctrl.hexsession_id = hexsession_id:47caa2c09bb4dc9d6aeb697a76046bdf1fcd879b
@@ -1388,7 +1389,7 @@ Ctrl.type = type:E
 Output = 937b7e16ed0b2324203cdae904fc55cbe25067a1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:000001003644f9ee24c3ec2e2fe16cdece326cdf5c1309e931bc41f245d3b76f2bdbef0bae58e850e10dcbd0d18356b4f98957a3b95f64c85d1af12ab01fe967e52a632761074f27406a29618192f1cbebae2c25e42f6e9fc00a737e4c92398403ab946a6c33e675e529b5c7364f36d64f07ff65889866dee99293bd5bb5f6454a77bbe0cbfd746d54e5bc948c617c5a1d5d3d2b65fa6a86c5f42c5e01f92a8e97a96f848e50ecb1b495a0e87323b44f5b9dd25ab34a94c077b7490657d1d8f9a9acef2785de82b02ef9fb670faf841ae9b479d2d538ae8e38eaf6e74b884c18c9dafc19b6c9728ff3411537555b3b3b69f6f039958ffb0790e58b09bd8c63819ee50ea5
 Ctrl.hexxcghash = hexxcghash:4d31fdb68c8f42f38cae260bf6402e47de93aac7
 Ctrl.hexsession_id = hexsession_id:47caa2c09bb4dc9d6aeb697a76046bdf1fcd879b
@@ -1396,7 +1397,7 @@ Ctrl.type = type:F
 Output = d7536b911dc79d5953455ba6e15cb5fec7c14025
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008de60df019c23966d215d9b8490ac493dfae59b99dbefdad81d2c9e761205c93a696dbd9e538cc57cd3e24c2798d2c56561d6803e8ee24e112babef84ad5a2c571c572339f2b38f1345164314f8f4714047f0c66650f10051044f8dcd256bfe8171302a81ce13f47f7375db80a6bbf8ce7d8f96e03fc6275fd5dacfbdd166792
 Ctrl.hexxcghash = hexxcghash:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
 Ctrl.hexsession_id = hexsession_id:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
@@ -1404,7 +1405,7 @@ Ctrl.type = type:A
 Output = 9fff6c6a6d1f5c31
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008de60df019c23966d215d9b8490ac493dfae59b99dbefdad81d2c9e761205c93a696dbd9e538cc57cd3e24c2798d2c56561d6803e8ee24e112babef84ad5a2c571c572339f2b38f1345164314f8f4714047f0c66650f10051044f8dcd256bfe8171302a81ce13f47f7375db80a6bbf8ce7d8f96e03fc6275fd5dacfbdd166792
 Ctrl.hexxcghash = hexxcghash:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
 Ctrl.hexsession_id = hexsession_id:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
@@ -1412,7 +1413,7 @@ Ctrl.type = type:B
 Output = 8e0ae78c64d2fe2a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008de60df019c23966d215d9b8490ac493dfae59b99dbefdad81d2c9e761205c93a696dbd9e538cc57cd3e24c2798d2c56561d6803e8ee24e112babef84ad5a2c571c572339f2b38f1345164314f8f4714047f0c66650f10051044f8dcd256bfe8171302a81ce13f47f7375db80a6bbf8ce7d8f96e03fc6275fd5dacfbdd166792
 Ctrl.hexxcghash = hexxcghash:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
 Ctrl.hexsession_id = hexsession_id:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
@@ -1420,7 +1421,7 @@ Ctrl.type = type:C
 Output = 9044f963ffb56b94556a38aac5398a7072ffba60258500be
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008de60df019c23966d215d9b8490ac493dfae59b99dbefdad81d2c9e761205c93a696dbd9e538cc57cd3e24c2798d2c56561d6803e8ee24e112babef84ad5a2c571c572339f2b38f1345164314f8f4714047f0c66650f10051044f8dcd256bfe8171302a81ce13f47f7375db80a6bbf8ce7d8f96e03fc6275fd5dacfbdd166792
 Ctrl.hexxcghash = hexxcghash:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
 Ctrl.hexsession_id = hexsession_id:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
@@ -1428,7 +1429,7 @@ Ctrl.type = type:D
 Output = a861a317ea42b050901aff367b5a1d0abd5c497c77311ba2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008de60df019c23966d215d9b8490ac493dfae59b99dbefdad81d2c9e761205c93a696dbd9e538cc57cd3e24c2798d2c56561d6803e8ee24e112babef84ad5a2c571c572339f2b38f1345164314f8f4714047f0c66650f10051044f8dcd256bfe8171302a81ce13f47f7375db80a6bbf8ce7d8f96e03fc6275fd5dacfbdd166792
 Ctrl.hexxcghash = hexxcghash:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
 Ctrl.hexsession_id = hexsession_id:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
@@ -1436,7 +1437,7 @@ Ctrl.type = type:E
 Output = 43225d64b6da6f070925ad1c8b7ac88893f9a7cba0dfc55ddea42eec
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008de60df019c23966d215d9b8490ac493dfae59b99dbefdad81d2c9e761205c93a696dbd9e538cc57cd3e24c2798d2c56561d6803e8ee24e112babef84ad5a2c571c572339f2b38f1345164314f8f4714047f0c66650f10051044f8dcd256bfe8171302a81ce13f47f7375db80a6bbf8ce7d8f96e03fc6275fd5dacfbdd166792
 Ctrl.hexxcghash = hexxcghash:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
 Ctrl.hexsession_id = hexsession_id:e69fbbee90f0cb7c57996c6f3f9ec4c7de9f0c43b7c993ec3ec1d4ca
@@ -1444,7 +1445,7 @@ Ctrl.type = type:F
 Output = eb31db29bbafca2773f815fa478d927943288588e371ae9ba0414d98
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100a03d807fef48a50d8a04d9b6721979c5904412c3bcfe69ebd4c2554debe82a695a66fb9d844c6ef3aa4b745c2a4c8dbc4ba26742e0d1159ded83edca0bec61c7303e81f9d7f3169b7c97573b9184ec3c5286d9646e96595f064d61013431628f5c57bcb1bf79bcd1b0177ab4520c1a1a9b34b5067d9f465c9b03154d57f1b42f
 Ctrl.hexxcghash = hexxcghash:03af4bd15a37aa7816d826332dcd9daa1537770fd0bcafbafe30033d
 Ctrl.hexsession_id = hexsession_id:36084ca3dc535b37d533d034d891fabc20e3b0270bb8c008066bfac8
@@ -1452,7 +1453,7 @@ Ctrl.type = type:A
 Output = bf2d6e03ba930c71
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100a03d807fef48a50d8a04d9b6721979c5904412c3bcfe69ebd4c2554debe82a695a66fb9d844c6ef3aa4b745c2a4c8dbc4ba26742e0d1159ded83edca0bec61c7303e81f9d7f3169b7c97573b9184ec3c5286d9646e96595f064d61013431628f5c57bcb1bf79bcd1b0177ab4520c1a1a9b34b5067d9f465c9b03154d57f1b42f
 Ctrl.hexxcghash = hexxcghash:03af4bd15a37aa7816d826332dcd9daa1537770fd0bcafbafe30033d
 Ctrl.hexsession_id = hexsession_id:36084ca3dc535b37d533d034d891fabc20e3b0270bb8c008066bfac8
@@ -1460,7 +1461,7 @@ Ctrl.type = type:B
 Output = ff14fadc19a0bd8a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100a03d807fef48a50d8a04d9b6721979c5904412c3bcfe69ebd4c2554debe82a695a66fb9d844c6ef3aa4b745c2a4c8dbc4ba26742e0d1159ded83edca0bec61c7303e81f9d7f3169b7c97573b9184ec3c5286d9646e96595f064d61013431628f5c57bcb1bf79bcd1b0177ab4520c1a1a9b34b5067d9f465c9b03154d57f1b42f
 Ctrl.hexxcghash = hexxcghash:03af4bd15a37aa7816d826332dcd9daa1537770fd0bcafbafe30033d
 Ctrl.hexsession_id = hexsession_id:36084ca3dc535b37d533d034d891fabc20e3b0270bb8c008066bfac8
@@ -1468,7 +1469,7 @@ Ctrl.type = type:C
 Output = 34a70734eaebeb8608cbb91098fa13326f37ccc5d408584d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100a03d807fef48a50d8a04d9b6721979c5904412c3bcfe69ebd4c2554debe82a695a66fb9d844c6ef3aa4b745c2a4c8dbc4ba26742e0d1159ded83edca0bec61c7303e81f9d7f3169b7c97573b9184ec3c5286d9646e96595f064d61013431628f5c57bcb1bf79bcd1b0177ab4520c1a1a9b34b5067d9f465c9b03154d57f1b42f
 Ctrl.hexxcghash = hexxcghash:03af4bd15a37aa7816d826332dcd9daa1537770fd0bcafbafe30033d
 Ctrl.hexsession_id = hexsession_id:36084ca3dc535b37d533d034d891fabc20e3b0270bb8c008066bfac8
@@ -1476,7 +1477,7 @@ Ctrl.type = type:D
 Output = f993da8f2e840b836c8980fa2d780a1b4eeef77046988eed
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100a03d807fef48a50d8a04d9b6721979c5904412c3bcfe69ebd4c2554debe82a695a66fb9d844c6ef3aa4b745c2a4c8dbc4ba26742e0d1159ded83edca0bec61c7303e81f9d7f3169b7c97573b9184ec3c5286d9646e96595f064d61013431628f5c57bcb1bf79bcd1b0177ab4520c1a1a9b34b5067d9f465c9b03154d57f1b42f
 Ctrl.hexxcghash = hexxcghash:03af4bd15a37aa7816d826332dcd9daa1537770fd0bcafbafe30033d
 Ctrl.hexsession_id = hexsession_id:36084ca3dc535b37d533d034d891fabc20e3b0270bb8c008066bfac8
@@ -1484,7 +1485,7 @@ Ctrl.type = type:E
 Output = a274441c86dd146cfab25d87344bd5a880d374d300aa8e1fe4919378
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100a03d807fef48a50d8a04d9b6721979c5904412c3bcfe69ebd4c2554debe82a695a66fb9d844c6ef3aa4b745c2a4c8dbc4ba26742e0d1159ded83edca0bec61c7303e81f9d7f3169b7c97573b9184ec3c5286d9646e96595f064d61013431628f5c57bcb1bf79bcd1b0177ab4520c1a1a9b34b5067d9f465c9b03154d57f1b42f
 Ctrl.hexxcghash = hexxcghash:03af4bd15a37aa7816d826332dcd9daa1537770fd0bcafbafe30033d
 Ctrl.hexsession_id = hexsession_id:36084ca3dc535b37d533d034d891fabc20e3b0270bb8c008066bfac8
@@ -1492,7 +1493,7 @@ Ctrl.type = type:F
 Output = 7774dc48324cca24901bedc37224cb291d6202fb6b5e1d9315a9bd10
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d09e300c8b93b8c759f96910b319b8fd9c9c8c1b704b65649f525b6c16732ee37f499ac729bdce9ea493811954849e8eeb449cb2f4485fe78b0f538038178ad3e1b95ef13fcf0134f1199ad742b31d5f222ed7927283a008c970143af46965acde32139c2448db5cc11fd55e534779f1b5d7757b27e3a3881a3596b0b002ff7e
 Ctrl.hexxcghash = hexxcghash:be8559339a1b231a59a8feae904c00decaf970ff8e83018662c65fa8
 Ctrl.hexsession_id = hexsession_id:a8378fd158677fac292c5cce8a9efdbd5c5c98ee6f056a5e6e771b6b
@@ -1500,7 +1501,7 @@ Ctrl.type = type:A
 Output = 75bc82b271311f53
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d09e300c8b93b8c759f96910b319b8fd9c9c8c1b704b65649f525b6c16732ee37f499ac729bdce9ea493811954849e8eeb449cb2f4485fe78b0f538038178ad3e1b95ef13fcf0134f1199ad742b31d5f222ed7927283a008c970143af46965acde32139c2448db5cc11fd55e534779f1b5d7757b27e3a3881a3596b0b002ff7e
 Ctrl.hexxcghash = hexxcghash:be8559339a1b231a59a8feae904c00decaf970ff8e83018662c65fa8
 Ctrl.hexsession_id = hexsession_id:a8378fd158677fac292c5cce8a9efdbd5c5c98ee6f056a5e6e771b6b
@@ -1508,7 +1509,7 @@ Ctrl.type = type:B
 Output = 602d69e77b8c30b3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d09e300c8b93b8c759f96910b319b8fd9c9c8c1b704b65649f525b6c16732ee37f499ac729bdce9ea493811954849e8eeb449cb2f4485fe78b0f538038178ad3e1b95ef13fcf0134f1199ad742b31d5f222ed7927283a008c970143af46965acde32139c2448db5cc11fd55e534779f1b5d7757b27e3a3881a3596b0b002ff7e
 Ctrl.hexxcghash = hexxcghash:be8559339a1b231a59a8feae904c00decaf970ff8e83018662c65fa8
 Ctrl.hexsession_id = hexsession_id:a8378fd158677fac292c5cce8a9efdbd5c5c98ee6f056a5e6e771b6b
@@ -1516,7 +1517,7 @@ Ctrl.type = type:C
 Output = e0c8856a26b2f4804e98809d5b81cdb360b43884a33d4fef
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d09e300c8b93b8c759f96910b319b8fd9c9c8c1b704b65649f525b6c16732ee37f499ac729bdce9ea493811954849e8eeb449cb2f4485fe78b0f538038178ad3e1b95ef13fcf0134f1199ad742b31d5f222ed7927283a008c970143af46965acde32139c2448db5cc11fd55e534779f1b5d7757b27e3a3881a3596b0b002ff7e
 Ctrl.hexxcghash = hexxcghash:be8559339a1b231a59a8feae904c00decaf970ff8e83018662c65fa8
 Ctrl.hexsession_id = hexsession_id:a8378fd158677fac292c5cce8a9efdbd5c5c98ee6f056a5e6e771b6b
@@ -1524,7 +1525,7 @@ Ctrl.type = type:D
 Output = e661555415bcab0b1f2d4b4387cda213cdd93f8458a2ace4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d09e300c8b93b8c759f96910b319b8fd9c9c8c1b704b65649f525b6c16732ee37f499ac729bdce9ea493811954849e8eeb449cb2f4485fe78b0f538038178ad3e1b95ef13fcf0134f1199ad742b31d5f222ed7927283a008c970143af46965acde32139c2448db5cc11fd55e534779f1b5d7757b27e3a3881a3596b0b002ff7e
 Ctrl.hexxcghash = hexxcghash:be8559339a1b231a59a8feae904c00decaf970ff8e83018662c65fa8
 Ctrl.hexsession_id = hexsession_id:a8378fd158677fac292c5cce8a9efdbd5c5c98ee6f056a5e6e771b6b
@@ -1532,7 +1533,7 @@ Ctrl.type = type:E
 Output = a368f66127573c79e2d936032f75c3d11c0131455eb9b6c5384582de
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d09e300c8b93b8c759f96910b319b8fd9c9c8c1b704b65649f525b6c16732ee37f499ac729bdce9ea493811954849e8eeb449cb2f4485fe78b0f538038178ad3e1b95ef13fcf0134f1199ad742b31d5f222ed7927283a008c970143af46965acde32139c2448db5cc11fd55e534779f1b5d7757b27e3a3881a3596b0b002ff7e
 Ctrl.hexxcghash = hexxcghash:be8559339a1b231a59a8feae904c00decaf970ff8e83018662c65fa8
 Ctrl.hexsession_id = hexsession_id:a8378fd158677fac292c5cce8a9efdbd5c5c98ee6f056a5e6e771b6b
@@ -1540,7 +1541,7 @@ Ctrl.type = type:F
 Output = 779f09f514bdf7ed4a01788f10146367ce2ddf2aacebb961524c002a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008057352c4a26aa011e9b9e101736ab6b1369c73f553848d159b01bf2c7671074cdcdc73b8c697649dc7465197c2f17560d0045246410063f20d8d29518e7b25d871886346acccd9ec1b2d74b19b4aff16953714266d1440247859958f010f3fe616859c07315169c5bb5547c6dfdaf4a219daa3a78f546958f56e14fdf64c3b26e
 Ctrl.hexxcghash = hexxcghash:dca302cd4ee29d88b3f909f73e19d920099b8c18062e875cb762257b
 Ctrl.hexsession_id = hexsession_id:2f6368dd5f1a6a8db98f74331850c110aa0e58f06a10ca8178171d95
@@ -1548,7 +1549,7 @@ Ctrl.type = type:A
 Output = 386bc0b99215c8fa
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008057352c4a26aa011e9b9e101736ab6b1369c73f553848d159b01bf2c7671074cdcdc73b8c697649dc7465197c2f17560d0045246410063f20d8d29518e7b25d871886346acccd9ec1b2d74b19b4aff16953714266d1440247859958f010f3fe616859c07315169c5bb5547c6dfdaf4a219daa3a78f546958f56e14fdf64c3b26e
 Ctrl.hexxcghash = hexxcghash:dca302cd4ee29d88b3f909f73e19d920099b8c18062e875cb762257b
 Ctrl.hexsession_id = hexsession_id:2f6368dd5f1a6a8db98f74331850c110aa0e58f06a10ca8178171d95
@@ -1556,7 +1557,7 @@ Ctrl.type = type:B
 Output = c793dba9a68f70a4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008057352c4a26aa011e9b9e101736ab6b1369c73f553848d159b01bf2c7671074cdcdc73b8c697649dc7465197c2f17560d0045246410063f20d8d29518e7b25d871886346acccd9ec1b2d74b19b4aff16953714266d1440247859958f010f3fe616859c07315169c5bb5547c6dfdaf4a219daa3a78f546958f56e14fdf64c3b26e
 Ctrl.hexxcghash = hexxcghash:dca302cd4ee29d88b3f909f73e19d920099b8c18062e875cb762257b
 Ctrl.hexsession_id = hexsession_id:2f6368dd5f1a6a8db98f74331850c110aa0e58f06a10ca8178171d95
@@ -1564,7 +1565,7 @@ Ctrl.type = type:C
 Output = 3dcaea7c946c2de76811482556299aa9bf96c8eef11fb2d6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008057352c4a26aa011e9b9e101736ab6b1369c73f553848d159b01bf2c7671074cdcdc73b8c697649dc7465197c2f17560d0045246410063f20d8d29518e7b25d871886346acccd9ec1b2d74b19b4aff16953714266d1440247859958f010f3fe616859c07315169c5bb5547c6dfdaf4a219daa3a78f546958f56e14fdf64c3b26e
 Ctrl.hexxcghash = hexxcghash:dca302cd4ee29d88b3f909f73e19d920099b8c18062e875cb762257b
 Ctrl.hexsession_id = hexsession_id:2f6368dd5f1a6a8db98f74331850c110aa0e58f06a10ca8178171d95
@@ -1572,7 +1573,7 @@ Ctrl.type = type:D
 Output = fd078ef65922006809729f9533c8742e9f973f7ff37ba987
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008057352c4a26aa011e9b9e101736ab6b1369c73f553848d159b01bf2c7671074cdcdc73b8c697649dc7465197c2f17560d0045246410063f20d8d29518e7b25d871886346acccd9ec1b2d74b19b4aff16953714266d1440247859958f010f3fe616859c07315169c5bb5547c6dfdaf4a219daa3a78f546958f56e14fdf64c3b26e
 Ctrl.hexxcghash = hexxcghash:dca302cd4ee29d88b3f909f73e19d920099b8c18062e875cb762257b
 Ctrl.hexsession_id = hexsession_id:2f6368dd5f1a6a8db98f74331850c110aa0e58f06a10ca8178171d95
@@ -1580,7 +1581,7 @@ Ctrl.type = type:E
 Output = 83a1924fa5f7ceffeba7f519ac51a86a2746a93eb194db51a4596ca1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008057352c4a26aa011e9b9e101736ab6b1369c73f553848d159b01bf2c7671074cdcdc73b8c697649dc7465197c2f17560d0045246410063f20d8d29518e7b25d871886346acccd9ec1b2d74b19b4aff16953714266d1440247859958f010f3fe616859c07315169c5bb5547c6dfdaf4a219daa3a78f546958f56e14fdf64c3b26e
 Ctrl.hexxcghash = hexxcghash:dca302cd4ee29d88b3f909f73e19d920099b8c18062e875cb762257b
 Ctrl.hexsession_id = hexsession_id:2f6368dd5f1a6a8db98f74331850c110aa0e58f06a10ca8178171d95
@@ -1588,7 +1589,7 @@ Ctrl.type = type:F
 Output = e16507d1bbd53b41f9bb2f0f21b5112eb6cd1eb0489fb5e754212390
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008d372970f67a75a1748e6967c67a1f5665a3d6f71d6d24ab113bedb42ad544de34e67df7f644f78e5dcfd12e25b7cb8655aa9f07fef59058e42450aee5d4a733887535313e06c7e6426598284fdaa33ff88e1b6174c33199f2630ec42c8d7d9b92ea3d83a1bf8514b153fd9cf9c520636a0de9c6ba8b9318465ddcaa293367e5
 Ctrl.hexxcghash = hexxcghash:683a0b23e8bf98e03178a032a65e743e429c805b8de04407f73ab21b
 Ctrl.hexsession_id = hexsession_id:0e9de6ef124b670db44ade438920db01b5e6fb69a482816a303fcef7
@@ -1596,7 +1597,7 @@ Ctrl.type = type:A
 Output = 0e764ebe0d523aae
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008d372970f67a75a1748e6967c67a1f5665a3d6f71d6d24ab113bedb42ad544de34e67df7f644f78e5dcfd12e25b7cb8655aa9f07fef59058e42450aee5d4a733887535313e06c7e6426598284fdaa33ff88e1b6174c33199f2630ec42c8d7d9b92ea3d83a1bf8514b153fd9cf9c520636a0de9c6ba8b9318465ddcaa293367e5
 Ctrl.hexxcghash = hexxcghash:683a0b23e8bf98e03178a032a65e743e429c805b8de04407f73ab21b
 Ctrl.hexsession_id = hexsession_id:0e9de6ef124b670db44ade438920db01b5e6fb69a482816a303fcef7
@@ -1604,7 +1605,7 @@ Ctrl.type = type:B
 Output = 24bd2eff86c2a8dc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008d372970f67a75a1748e6967c67a1f5665a3d6f71d6d24ab113bedb42ad544de34e67df7f644f78e5dcfd12e25b7cb8655aa9f07fef59058e42450aee5d4a733887535313e06c7e6426598284fdaa33ff88e1b6174c33199f2630ec42c8d7d9b92ea3d83a1bf8514b153fd9cf9c520636a0de9c6ba8b9318465ddcaa293367e5
 Ctrl.hexxcghash = hexxcghash:683a0b23e8bf98e03178a032a65e743e429c805b8de04407f73ab21b
 Ctrl.hexsession_id = hexsession_id:0e9de6ef124b670db44ade438920db01b5e6fb69a482816a303fcef7
@@ -1612,7 +1613,7 @@ Ctrl.type = type:C
 Output = 26c01e3d56c1b928f65aaa1b6a15f5b8d41de187b4bb5fdc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008d372970f67a75a1748e6967c67a1f5665a3d6f71d6d24ab113bedb42ad544de34e67df7f644f78e5dcfd12e25b7cb8655aa9f07fef59058e42450aee5d4a733887535313e06c7e6426598284fdaa33ff88e1b6174c33199f2630ec42c8d7d9b92ea3d83a1bf8514b153fd9cf9c520636a0de9c6ba8b9318465ddcaa293367e5
 Ctrl.hexxcghash = hexxcghash:683a0b23e8bf98e03178a032a65e743e429c805b8de04407f73ab21b
 Ctrl.hexsession_id = hexsession_id:0e9de6ef124b670db44ade438920db01b5e6fb69a482816a303fcef7
@@ -1620,7 +1621,7 @@ Ctrl.type = type:D
 Output = e0cc3bdb6d69d10893eeb73b892d746acea151f24247fd9c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008d372970f67a75a1748e6967c67a1f5665a3d6f71d6d24ab113bedb42ad544de34e67df7f644f78e5dcfd12e25b7cb8655aa9f07fef59058e42450aee5d4a733887535313e06c7e6426598284fdaa33ff88e1b6174c33199f2630ec42c8d7d9b92ea3d83a1bf8514b153fd9cf9c520636a0de9c6ba8b9318465ddcaa293367e5
 Ctrl.hexxcghash = hexxcghash:683a0b23e8bf98e03178a032a65e743e429c805b8de04407f73ab21b
 Ctrl.hexsession_id = hexsession_id:0e9de6ef124b670db44ade438920db01b5e6fb69a482816a303fcef7
@@ -1628,7 +1629,7 @@ Ctrl.type = type:E
 Output = bf442ba6ec794f20584528686cedbaa568c13b895f642fe5cb3542bb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:00000081008d372970f67a75a1748e6967c67a1f5665a3d6f71d6d24ab113bedb42ad544de34e67df7f644f78e5dcfd12e25b7cb8655aa9f07fef59058e42450aee5d4a733887535313e06c7e6426598284fdaa33ff88e1b6174c33199f2630ec42c8d7d9b92ea3d83a1bf8514b153fd9cf9c520636a0de9c6ba8b9318465ddcaa293367e5
 Ctrl.hexxcghash = hexxcghash:683a0b23e8bf98e03178a032a65e743e429c805b8de04407f73ab21b
 Ctrl.hexsession_id = hexsession_id:0e9de6ef124b670db44ade438920db01b5e6fb69a482816a303fcef7
@@ -1636,7 +1637,7 @@ Ctrl.type = type:F
 Output = 65ab453e5ffd1b5e1540aa547766d7c177204c319642f93059bdf257
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008004a70cf5e546c0920433bf16dcda3076d9195b5c35ad6b83b6a51e880f22fddaae0d358e35037bbe1e66f2422c29ff30a39822e067930b9faf59f844441dee6f233635a00c7cb71596f8589194016132ebbe204d98fc7f9bb0b7f4e6b6a68f488a59138d9859729d938de6ace9d08be86301bbd4e80d4650391ef3599a6f0bc0
 Ctrl.hexxcghash = hexxcghash:a05a5c2d8beb394b7befaecfe3f4227cd81a28d90ac64ec78ce170b6
 Ctrl.hexsession_id = hexsession_id:1380b38f6b6997a47ce234b7d3d6afb5960e721a348a725704c19cff
@@ -1644,7 +1645,7 @@ Ctrl.type = type:A
 Output = 45799bbb09fd8804
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008004a70cf5e546c0920433bf16dcda3076d9195b5c35ad6b83b6a51e880f22fddaae0d358e35037bbe1e66f2422c29ff30a39822e067930b9faf59f844441dee6f233635a00c7cb71596f8589194016132ebbe204d98fc7f9bb0b7f4e6b6a68f488a59138d9859729d938de6ace9d08be86301bbd4e80d4650391ef3599a6f0bc0
 Ctrl.hexxcghash = hexxcghash:a05a5c2d8beb394b7befaecfe3f4227cd81a28d90ac64ec78ce170b6
 Ctrl.hexsession_id = hexsession_id:1380b38f6b6997a47ce234b7d3d6afb5960e721a348a725704c19cff
@@ -1652,7 +1653,7 @@ Ctrl.type = type:B
 Output = b787b009f3313be0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008004a70cf5e546c0920433bf16dcda3076d9195b5c35ad6b83b6a51e880f22fddaae0d358e35037bbe1e66f2422c29ff30a39822e067930b9faf59f844441dee6f233635a00c7cb71596f8589194016132ebbe204d98fc7f9bb0b7f4e6b6a68f488a59138d9859729d938de6ace9d08be86301bbd4e80d4650391ef3599a6f0bc0
 Ctrl.hexxcghash = hexxcghash:a05a5c2d8beb394b7befaecfe3f4227cd81a28d90ac64ec78ce170b6
 Ctrl.hexsession_id = hexsession_id:1380b38f6b6997a47ce234b7d3d6afb5960e721a348a725704c19cff
@@ -1660,7 +1661,7 @@ Ctrl.type = type:C
 Output = c4cbb547c997e8fddb9e56ef5df91327766668a43a958a8e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008004a70cf5e546c0920433bf16dcda3076d9195b5c35ad6b83b6a51e880f22fddaae0d358e35037bbe1e66f2422c29ff30a39822e067930b9faf59f844441dee6f233635a00c7cb71596f8589194016132ebbe204d98fc7f9bb0b7f4e6b6a68f488a59138d9859729d938de6ace9d08be86301bbd4e80d4650391ef3599a6f0bc0
 Ctrl.hexxcghash = hexxcghash:a05a5c2d8beb394b7befaecfe3f4227cd81a28d90ac64ec78ce170b6
 Ctrl.hexsession_id = hexsession_id:1380b38f6b6997a47ce234b7d3d6afb5960e721a348a725704c19cff
@@ -1668,7 +1669,7 @@ Ctrl.type = type:D
 Output = b55b7cca0a0363b84b40b79366b87db7c440dec5bf89e952
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008004a70cf5e546c0920433bf16dcda3076d9195b5c35ad6b83b6a51e880f22fddaae0d358e35037bbe1e66f2422c29ff30a39822e067930b9faf59f844441dee6f233635a00c7cb71596f8589194016132ebbe204d98fc7f9bb0b7f4e6b6a68f488a59138d9859729d938de6ace9d08be86301bbd4e80d4650391ef3599a6f0bc0
 Ctrl.hexxcghash = hexxcghash:a05a5c2d8beb394b7befaecfe3f4227cd81a28d90ac64ec78ce170b6
 Ctrl.hexsession_id = hexsession_id:1380b38f6b6997a47ce234b7d3d6afb5960e721a348a725704c19cff
@@ -1676,7 +1677,7 @@ Ctrl.type = type:E
 Output = 9c6399e5f4db0fc7652268d7423230ee5ffc0a210c26568dc5c0ab7d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008004a70cf5e546c0920433bf16dcda3076d9195b5c35ad6b83b6a51e880f22fddaae0d358e35037bbe1e66f2422c29ff30a39822e067930b9faf59f844441dee6f233635a00c7cb71596f8589194016132ebbe204d98fc7f9bb0b7f4e6b6a68f488a59138d9859729d938de6ace9d08be86301bbd4e80d4650391ef3599a6f0bc0
 Ctrl.hexxcghash = hexxcghash:a05a5c2d8beb394b7befaecfe3f4227cd81a28d90ac64ec78ce170b6
 Ctrl.hexsession_id = hexsession_id:1380b38f6b6997a47ce234b7d3d6afb5960e721a348a725704c19cff
@@ -1684,7 +1685,7 @@ Ctrl.type = type:F
 Output = 9824301c33daae0f1b75eb472d6f0b4ef2cea0b2f61e204b6aefb0bd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d07c8a0c16c5f000ff00db6161555ea6b6b400803fe250288a9b88b48ced381de3f46982210216dff4defdbb007e98ea47f891ae3f38e09f56c96913406c13ed35cade3f2f80c6c6402e7ab097decc9e7ecc377b9965991422b54b8fcf34b9635cdc6b1cb698c61cd8377f3fadf1ba9e289d83767ca24370661085461a0b348e
 Ctrl.hexxcghash = hexxcghash:45dfee14ec8160cb1ccd769d2db4785b9773aeedde0c6ca0f75324df
 Ctrl.hexsession_id = hexsession_id:0f15315853288a987cec1e0668f34fa54537304f7082673d74d4f970
@@ -1692,7 +1693,7 @@ Ctrl.type = type:A
 Output = 2958928e5fd3c6e4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d07c8a0c16c5f000ff00db6161555ea6b6b400803fe250288a9b88b48ced381de3f46982210216dff4defdbb007e98ea47f891ae3f38e09f56c96913406c13ed35cade3f2f80c6c6402e7ab097decc9e7ecc377b9965991422b54b8fcf34b9635cdc6b1cb698c61cd8377f3fadf1ba9e289d83767ca24370661085461a0b348e
 Ctrl.hexxcghash = hexxcghash:45dfee14ec8160cb1ccd769d2db4785b9773aeedde0c6ca0f75324df
 Ctrl.hexsession_id = hexsession_id:0f15315853288a987cec1e0668f34fa54537304f7082673d74d4f970
@@ -1700,7 +1701,7 @@ Ctrl.type = type:B
 Output = aa91bee1a3b3374c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d07c8a0c16c5f000ff00db6161555ea6b6b400803fe250288a9b88b48ced381de3f46982210216dff4defdbb007e98ea47f891ae3f38e09f56c96913406c13ed35cade3f2f80c6c6402e7ab097decc9e7ecc377b9965991422b54b8fcf34b9635cdc6b1cb698c61cd8377f3fadf1ba9e289d83767ca24370661085461a0b348e
 Ctrl.hexxcghash = hexxcghash:45dfee14ec8160cb1ccd769d2db4785b9773aeedde0c6ca0f75324df
 Ctrl.hexsession_id = hexsession_id:0f15315853288a987cec1e0668f34fa54537304f7082673d74d4f970
@@ -1708,7 +1709,7 @@ Ctrl.type = type:C
 Output = 6fdac559eb1d6af7fc7fbaa4f9a15fd4145b97b9418518d9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d07c8a0c16c5f000ff00db6161555ea6b6b400803fe250288a9b88b48ced381de3f46982210216dff4defdbb007e98ea47f891ae3f38e09f56c96913406c13ed35cade3f2f80c6c6402e7ab097decc9e7ecc377b9965991422b54b8fcf34b9635cdc6b1cb698c61cd8377f3fadf1ba9e289d83767ca24370661085461a0b348e
 Ctrl.hexxcghash = hexxcghash:45dfee14ec8160cb1ccd769d2db4785b9773aeedde0c6ca0f75324df
 Ctrl.hexsession_id = hexsession_id:0f15315853288a987cec1e0668f34fa54537304f7082673d74d4f970
@@ -1716,7 +1717,7 @@ Ctrl.type = type:D
 Output = 5a8271402756f7eac59f09b5020f7b05f6475fc3a2e2b482
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d07c8a0c16c5f000ff00db6161555ea6b6b400803fe250288a9b88b48ced381de3f46982210216dff4defdbb007e98ea47f891ae3f38e09f56c96913406c13ed35cade3f2f80c6c6402e7ab097decc9e7ecc377b9965991422b54b8fcf34b9635cdc6b1cb698c61cd8377f3fadf1ba9e289d83767ca24370661085461a0b348e
 Ctrl.hexxcghash = hexxcghash:45dfee14ec8160cb1ccd769d2db4785b9773aeedde0c6ca0f75324df
 Ctrl.hexsession_id = hexsession_id:0f15315853288a987cec1e0668f34fa54537304f7082673d74d4f970
@@ -1724,7 +1725,7 @@ Ctrl.type = type:E
 Output = 910de4a4a437cab056f7c38037f0196c524464237c5e332e79564a90
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100d07c8a0c16c5f000ff00db6161555ea6b6b400803fe250288a9b88b48ced381de3f46982210216dff4defdbb007e98ea47f891ae3f38e09f56c96913406c13ed35cade3f2f80c6c6402e7ab097decc9e7ecc377b9965991422b54b8fcf34b9635cdc6b1cb698c61cd8377f3fadf1ba9e289d83767ca24370661085461a0b348e
 Ctrl.hexxcghash = hexxcghash:45dfee14ec8160cb1ccd769d2db4785b9773aeedde0c6ca0f75324df
 Ctrl.hexsession_id = hexsession_id:0f15315853288a987cec1e0668f34fa54537304f7082673d74d4f970
@@ -1732,7 +1733,7 @@ Ctrl.type = type:F
 Output = 0bfa6ed5dc8ab0fc1bb9feb966d7107137ebf3f754ac71c2a16a9c22
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000807f046e0e1a0050fe544cd0bf194fdb0a07efe7708498a1b25aad90641e8befdef8f4aacb538ccc446d02d3896e1cc34d9a8becdcc48d10e73460f7c0c58eb51707d37f1eaa0008cb21c89e8b226a3e60c76f9f9f5af2a16abca346a81c66ec0199167b17e0d8cb3baea9a9c700632f585e0cd467e779eba02bc24eff22b6425c
 Ctrl.hexxcghash = hexxcghash:b63c992199e370cde19b640077bbbac92c6a8a0f206b4d560935cee5
 Ctrl.hexsession_id = hexsession_id:ee00f86c7ecc4ce74a3ece1699802b7420ca4d49cc74b23399c23545
@@ -1740,7 +1741,7 @@ Ctrl.type = type:A
 Output = 82204d79e13252f1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000807f046e0e1a0050fe544cd0bf194fdb0a07efe7708498a1b25aad90641e8befdef8f4aacb538ccc446d02d3896e1cc34d9a8becdcc48d10e73460f7c0c58eb51707d37f1eaa0008cb21c89e8b226a3e60c76f9f9f5af2a16abca346a81c66ec0199167b17e0d8cb3baea9a9c700632f585e0cd467e779eba02bc24eff22b6425c
 Ctrl.hexxcghash = hexxcghash:b63c992199e370cde19b640077bbbac92c6a8a0f206b4d560935cee5
 Ctrl.hexsession_id = hexsession_id:ee00f86c7ecc4ce74a3ece1699802b7420ca4d49cc74b23399c23545
@@ -1748,7 +1749,7 @@ Ctrl.type = type:B
 Output = a76ff923488c7bd3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000807f046e0e1a0050fe544cd0bf194fdb0a07efe7708498a1b25aad90641e8befdef8f4aacb538ccc446d02d3896e1cc34d9a8becdcc48d10e73460f7c0c58eb51707d37f1eaa0008cb21c89e8b226a3e60c76f9f9f5af2a16abca346a81c66ec0199167b17e0d8cb3baea9a9c700632f585e0cd467e779eba02bc24eff22b6425c
 Ctrl.hexxcghash = hexxcghash:b63c992199e370cde19b640077bbbac92c6a8a0f206b4d560935cee5
 Ctrl.hexsession_id = hexsession_id:ee00f86c7ecc4ce74a3ece1699802b7420ca4d49cc74b23399c23545
@@ -1756,7 +1757,7 @@ Ctrl.type = type:C
 Output = 8ba3bd224890bdd4dd07d2a5a98e5efcd95d82c66583d098
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000807f046e0e1a0050fe544cd0bf194fdb0a07efe7708498a1b25aad90641e8befdef8f4aacb538ccc446d02d3896e1cc34d9a8becdcc48d10e73460f7c0c58eb51707d37f1eaa0008cb21c89e8b226a3e60c76f9f9f5af2a16abca346a81c66ec0199167b17e0d8cb3baea9a9c700632f585e0cd467e779eba02bc24eff22b6425c
 Ctrl.hexxcghash = hexxcghash:b63c992199e370cde19b640077bbbac92c6a8a0f206b4d560935cee5
 Ctrl.hexsession_id = hexsession_id:ee00f86c7ecc4ce74a3ece1699802b7420ca4d49cc74b23399c23545
@@ -1764,7 +1765,7 @@ Ctrl.type = type:D
 Output = a04a3844933ca1bb45848bc1a7626e4c50dc46aa5376d027
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000807f046e0e1a0050fe544cd0bf194fdb0a07efe7708498a1b25aad90641e8befdef8f4aacb538ccc446d02d3896e1cc34d9a8becdcc48d10e73460f7c0c58eb51707d37f1eaa0008cb21c89e8b226a3e60c76f9f9f5af2a16abca346a81c66ec0199167b17e0d8cb3baea9a9c700632f585e0cd467e779eba02bc24eff22b6425c
 Ctrl.hexxcghash = hexxcghash:b63c992199e370cde19b640077bbbac92c6a8a0f206b4d560935cee5
 Ctrl.hexsession_id = hexsession_id:ee00f86c7ecc4ce74a3ece1699802b7420ca4d49cc74b23399c23545
@@ -1772,7 +1773,7 @@ Ctrl.type = type:E
 Output = 393f2f152d6c6d063f284cadd1fd9d700928188b7fea31f74b44fbc6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000807f046e0e1a0050fe544cd0bf194fdb0a07efe7708498a1b25aad90641e8befdef8f4aacb538ccc446d02d3896e1cc34d9a8becdcc48d10e73460f7c0c58eb51707d37f1eaa0008cb21c89e8b226a3e60c76f9f9f5af2a16abca346a81c66ec0199167b17e0d8cb3baea9a9c700632f585e0cd467e779eba02bc24eff22b6425c
 Ctrl.hexxcghash = hexxcghash:b63c992199e370cde19b640077bbbac92c6a8a0f206b4d560935cee5
 Ctrl.hexsession_id = hexsession_id:ee00f86c7ecc4ce74a3ece1699802b7420ca4d49cc74b23399c23545
@@ -1780,7 +1781,7 @@ Ctrl.type = type:F
 Output = f27f2cd72b22e1719f91b912d6c9d180985121d32bd217e348cd2003
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100b51d0e3d21612b3bde548bf3da6d474166972f602beb1b876b7045a595483ec0bfb707eaf7c0d416d028a3ed7cff460cad66e2284e3190a746d3304678c91b2654b3ab147aece57e3bb5f4d30d4d7c01e065f70b12b9270ebec306a178870d1fd814806c3dbdc16d4bd7e843de8e5414ff336e735bc5c8241ab0ae08197159d6
 Ctrl.hexxcghash = hexxcghash:1eacc2c8e8ec2c3a5af31c6d498301e82664f60899223ef4348f4467
 Ctrl.hexsession_id = hexsession_id:ddc879c0f221147bd70a1cedf5578fd8f196290357945fe75e551262
@@ -1788,7 +1789,7 @@ Ctrl.type = type:A
 Output = f843e3c6a1621998
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100b51d0e3d21612b3bde548bf3da6d474166972f602beb1b876b7045a595483ec0bfb707eaf7c0d416d028a3ed7cff460cad66e2284e3190a746d3304678c91b2654b3ab147aece57e3bb5f4d30d4d7c01e065f70b12b9270ebec306a178870d1fd814806c3dbdc16d4bd7e843de8e5414ff336e735bc5c8241ab0ae08197159d6
 Ctrl.hexxcghash = hexxcghash:1eacc2c8e8ec2c3a5af31c6d498301e82664f60899223ef4348f4467
 Ctrl.hexsession_id = hexsession_id:ddc879c0f221147bd70a1cedf5578fd8f196290357945fe75e551262
@@ -1796,7 +1797,7 @@ Ctrl.type = type:B
 Output = 128b2d8968cfaad5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100b51d0e3d21612b3bde548bf3da6d474166972f602beb1b876b7045a595483ec0bfb707eaf7c0d416d028a3ed7cff460cad66e2284e3190a746d3304678c91b2654b3ab147aece57e3bb5f4d30d4d7c01e065f70b12b9270ebec306a178870d1fd814806c3dbdc16d4bd7e843de8e5414ff336e735bc5c8241ab0ae08197159d6
 Ctrl.hexxcghash = hexxcghash:1eacc2c8e8ec2c3a5af31c6d498301e82664f60899223ef4348f4467
 Ctrl.hexsession_id = hexsession_id:ddc879c0f221147bd70a1cedf5578fd8f196290357945fe75e551262
@@ -1804,7 +1805,7 @@ Ctrl.type = type:C
 Output = d6c4d2685753580dea2c6a6eb6add592011356eb9e868d44
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100b51d0e3d21612b3bde548bf3da6d474166972f602beb1b876b7045a595483ec0bfb707eaf7c0d416d028a3ed7cff460cad66e2284e3190a746d3304678c91b2654b3ab147aece57e3bb5f4d30d4d7c01e065f70b12b9270ebec306a178870d1fd814806c3dbdc16d4bd7e843de8e5414ff336e735bc5c8241ab0ae08197159d6
 Ctrl.hexxcghash = hexxcghash:1eacc2c8e8ec2c3a5af31c6d498301e82664f60899223ef4348f4467
 Ctrl.hexsession_id = hexsession_id:ddc879c0f221147bd70a1cedf5578fd8f196290357945fe75e551262
@@ -1812,7 +1813,7 @@ Ctrl.type = type:D
 Output = 92af60f4858f3d14efaac039130389ab9ae1237f0da09a29
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100b51d0e3d21612b3bde548bf3da6d474166972f602beb1b876b7045a595483ec0bfb707eaf7c0d416d028a3ed7cff460cad66e2284e3190a746d3304678c91b2654b3ab147aece57e3bb5f4d30d4d7c01e065f70b12b9270ebec306a178870d1fd814806c3dbdc16d4bd7e843de8e5414ff336e735bc5c8241ab0ae08197159d6
 Ctrl.hexxcghash = hexxcghash:1eacc2c8e8ec2c3a5af31c6d498301e82664f60899223ef4348f4467
 Ctrl.hexsession_id = hexsession_id:ddc879c0f221147bd70a1cedf5578fd8f196290357945fe75e551262
@@ -1820,7 +1821,7 @@ Ctrl.type = type:E
 Output = a37af93c8f25e145def1c5397bec2ee2119cc0e0bd4854fe23b2e3d1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000008100b51d0e3d21612b3bde548bf3da6d474166972f602beb1b876b7045a595483ec0bfb707eaf7c0d416d028a3ed7cff460cad66e2284e3190a746d3304678c91b2654b3ab147aece57e3bb5f4d30d4d7c01e065f70b12b9270ebec306a178870d1fd814806c3dbdc16d4bd7e843de8e5414ff336e735bc5c8241ab0ae08197159d6
 Ctrl.hexxcghash = hexxcghash:1eacc2c8e8ec2c3a5af31c6d498301e82664f60899223ef4348f4467
 Ctrl.hexsession_id = hexsession_id:ddc879c0f221147bd70a1cedf5578fd8f196290357945fe75e551262
@@ -1828,7 +1829,7 @@ Ctrl.type = type:F
 Output = d44def5fcec300da5913ca109c0fd7a2c2cbcedd2c3e3216c5cb0d95
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000810088a2add0cc5918c649c6bbc82930ae99326188faa20e2cfc8f819cc44bdd99d1638fbbd380197beda58c039c239fdcced533db7ea31635b835f5f92725490e7638d40a017b89f48406faab653aa03721af5d7c5c61d4519e7c07f99974c1f715b1ce3fcffc50b2a6cc9b4e45a76791b862ac87524d2b52fe6c706f5a73e5dc0a
 Ctrl.hexxcghash = hexxcghash:321ef6b92cae9df351c1b7d2253325536e659df52acd4a8787b45217
 Ctrl.hexsession_id = hexsession_id:340edbc8aeec53501158ad2ea7650abcbb906348d57b14b61524469e
@@ -1836,7 +1837,7 @@ Ctrl.type = type:A
 Output = 4276fab65090b420
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000810088a2add0cc5918c649c6bbc82930ae99326188faa20e2cfc8f819cc44bdd99d1638fbbd380197beda58c039c239fdcced533db7ea31635b835f5f92725490e7638d40a017b89f48406faab653aa03721af5d7c5c61d4519e7c07f99974c1f715b1ce3fcffc50b2a6cc9b4e45a76791b862ac87524d2b52fe6c706f5a73e5dc0a
 Ctrl.hexxcghash = hexxcghash:321ef6b92cae9df351c1b7d2253325536e659df52acd4a8787b45217
 Ctrl.hexsession_id = hexsession_id:340edbc8aeec53501158ad2ea7650abcbb906348d57b14b61524469e
@@ -1844,7 +1845,7 @@ Ctrl.type = type:B
 Output = 00303ca4f9a5a6f8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000810088a2add0cc5918c649c6bbc82930ae99326188faa20e2cfc8f819cc44bdd99d1638fbbd380197beda58c039c239fdcced533db7ea31635b835f5f92725490e7638d40a017b89f48406faab653aa03721af5d7c5c61d4519e7c07f99974c1f715b1ce3fcffc50b2a6cc9b4e45a76791b862ac87524d2b52fe6c706f5a73e5dc0a
 Ctrl.hexxcghash = hexxcghash:321ef6b92cae9df351c1b7d2253325536e659df52acd4a8787b45217
 Ctrl.hexsession_id = hexsession_id:340edbc8aeec53501158ad2ea7650abcbb906348d57b14b61524469e
@@ -1852,7 +1853,7 @@ Ctrl.type = type:C
 Output = 3d67892281e9c6ed6535d7ae69e832f6723afd545763bd3d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000810088a2add0cc5918c649c6bbc82930ae99326188faa20e2cfc8f819cc44bdd99d1638fbbd380197beda58c039c239fdcced533db7ea31635b835f5f92725490e7638d40a017b89f48406faab653aa03721af5d7c5c61d4519e7c07f99974c1f715b1ce3fcffc50b2a6cc9b4e45a76791b862ac87524d2b52fe6c706f5a73e5dc0a
 Ctrl.hexxcghash = hexxcghash:321ef6b92cae9df351c1b7d2253325536e659df52acd4a8787b45217
 Ctrl.hexsession_id = hexsession_id:340edbc8aeec53501158ad2ea7650abcbb906348d57b14b61524469e
@@ -1860,7 +1861,7 @@ Ctrl.type = type:D
 Output = 5a5844e6c47eacc172e0012044037668a653758b96310350
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000810088a2add0cc5918c649c6bbc82930ae99326188faa20e2cfc8f819cc44bdd99d1638fbbd380197beda58c039c239fdcced533db7ea31635b835f5f92725490e7638d40a017b89f48406faab653aa03721af5d7c5c61d4519e7c07f99974c1f715b1ce3fcffc50b2a6cc9b4e45a76791b862ac87524d2b52fe6c706f5a73e5dc0a
 Ctrl.hexxcghash = hexxcghash:321ef6b92cae9df351c1b7d2253325536e659df52acd4a8787b45217
 Ctrl.hexsession_id = hexsession_id:340edbc8aeec53501158ad2ea7650abcbb906348d57b14b61524469e
@@ -1868,7 +1869,7 @@ Ctrl.type = type:E
 Output = 4783fb6e98db788f6594c2b82e751528590c41780adce2ffba234290
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000000810088a2add0cc5918c649c6bbc82930ae99326188faa20e2cfc8f819cc44bdd99d1638fbbd380197beda58c039c239fdcced533db7ea31635b835f5f92725490e7638d40a017b89f48406faab653aa03721af5d7c5c61d4519e7c07f99974c1f715b1ce3fcffc50b2a6cc9b4e45a76791b862ac87524d2b52fe6c706f5a73e5dc0a
 Ctrl.hexxcghash = hexxcghash:321ef6b92cae9df351c1b7d2253325536e659df52acd4a8787b45217
 Ctrl.hexsession_id = hexsession_id:340edbc8aeec53501158ad2ea7650abcbb906348d57b14b61524469e
@@ -1876,7 +1877,7 @@ Ctrl.type = type:F
 Output = 7c60752b0b5a0f0027507ecd88e6af2b78e462a98459bf0511152663
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d62744a1ee5a4d03d761f48fb63ece42d9204e00016dad042ae7cbe600cb9e93535bc36d2f94d715cf8c2cd948caf876b4948429cb85ac73765949495af8380a56b68d1d3eeb4d9b310e2c53db5f51a7b8382759273c0be30862df81ca420f414c3ea8e6a1fb4875257ccc536e971c8dc07e600e265e642489266604f94ee995f96ef02eac771bb88bc66c57d229edfba1e484fd1c8b49e11e594aefa681f26ea28c348615d3e0a2dc76845d2d19543751ce444c7b65fa449a74639fa13c123d025200efa7012b209400746e03bd6a7bc938b926107da0491407bd952602d14a7fa743cbd51d5090a22c76a336f06b5e6dc5ecf70c803da8dcbff149c5013c36
 Ctrl.hexxcghash = hexxcghash:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
 Ctrl.hexsession_id = hexsession_id:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
@@ -1884,7 +1885,7 @@ Ctrl.type = type:A
 Output = 2512664639690af9f64afd16d9ccf3d3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d62744a1ee5a4d03d761f48fb63ece42d9204e00016dad042ae7cbe600cb9e93535bc36d2f94d715cf8c2cd948caf876b4948429cb85ac73765949495af8380a56b68d1d3eeb4d9b310e2c53db5f51a7b8382759273c0be30862df81ca420f414c3ea8e6a1fb4875257ccc536e971c8dc07e600e265e642489266604f94ee995f96ef02eac771bb88bc66c57d229edfba1e484fd1c8b49e11e594aefa681f26ea28c348615d3e0a2dc76845d2d19543751ce444c7b65fa449a74639fa13c123d025200efa7012b209400746e03bd6a7bc938b926107da0491407bd952602d14a7fa743cbd51d5090a22c76a336f06b5e6dc5ecf70c803da8dcbff149c5013c36
 Ctrl.hexxcghash = hexxcghash:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
 Ctrl.hexsession_id = hexsession_id:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
@@ -1892,7 +1893,7 @@ Ctrl.type = type:B
 Output = c13223796f394c6d1ffd18c22c09f27a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d62744a1ee5a4d03d761f48fb63ece42d9204e00016dad042ae7cbe600cb9e93535bc36d2f94d715cf8c2cd948caf876b4948429cb85ac73765949495af8380a56b68d1d3eeb4d9b310e2c53db5f51a7b8382759273c0be30862df81ca420f414c3ea8e6a1fb4875257ccc536e971c8dc07e600e265e642489266604f94ee995f96ef02eac771bb88bc66c57d229edfba1e484fd1c8b49e11e594aefa681f26ea28c348615d3e0a2dc76845d2d19543751ce444c7b65fa449a74639fa13c123d025200efa7012b209400746e03bd6a7bc938b926107da0491407bd952602d14a7fa743cbd51d5090a22c76a336f06b5e6dc5ecf70c803da8dcbff149c5013c36
 Ctrl.hexxcghash = hexxcghash:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
 Ctrl.hexsession_id = hexsession_id:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
@@ -1900,7 +1901,7 @@ Ctrl.type = type:C
 Output = 7be659a7cbeda28722315d96444a5c98
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d62744a1ee5a4d03d761f48fb63ece42d9204e00016dad042ae7cbe600cb9e93535bc36d2f94d715cf8c2cd948caf876b4948429cb85ac73765949495af8380a56b68d1d3eeb4d9b310e2c53db5f51a7b8382759273c0be30862df81ca420f414c3ea8e6a1fb4875257ccc536e971c8dc07e600e265e642489266604f94ee995f96ef02eac771bb88bc66c57d229edfba1e484fd1c8b49e11e594aefa681f26ea28c348615d3e0a2dc76845d2d19543751ce444c7b65fa449a74639fa13c123d025200efa7012b209400746e03bd6a7bc938b926107da0491407bd952602d14a7fa743cbd51d5090a22c76a336f06b5e6dc5ecf70c803da8dcbff149c5013c36
 Ctrl.hexxcghash = hexxcghash:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
 Ctrl.hexsession_id = hexsession_id:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
@@ -1908,7 +1909,7 @@ Ctrl.type = type:D
 Output = bdfbd698c518aa45c35d7afd7bd91150
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d62744a1ee5a4d03d761f48fb63ece42d9204e00016dad042ae7cbe600cb9e93535bc36d2f94d715cf8c2cd948caf876b4948429cb85ac73765949495af8380a56b68d1d3eeb4d9b310e2c53db5f51a7b8382759273c0be30862df81ca420f414c3ea8e6a1fb4875257ccc536e971c8dc07e600e265e642489266604f94ee995f96ef02eac771bb88bc66c57d229edfba1e484fd1c8b49e11e594aefa681f26ea28c348615d3e0a2dc76845d2d19543751ce444c7b65fa449a74639fa13c123d025200efa7012b209400746e03bd6a7bc938b926107da0491407bd952602d14a7fa743cbd51d5090a22c76a336f06b5e6dc5ecf70c803da8dcbff149c5013c36
 Ctrl.hexxcghash = hexxcghash:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
 Ctrl.hexsession_id = hexsession_id:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
@@ -1916,7 +1917,7 @@ Ctrl.type = type:E
 Output = dd38b79b081713ac3007ffd88d5cd67f43fbb36c983e0fc1cd273d84
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d62744a1ee5a4d03d761f48fb63ece42d9204e00016dad042ae7cbe600cb9e93535bc36d2f94d715cf8c2cd948caf876b4948429cb85ac73765949495af8380a56b68d1d3eeb4d9b310e2c53db5f51a7b8382759273c0be30862df81ca420f414c3ea8e6a1fb4875257ccc536e971c8dc07e600e265e642489266604f94ee995f96ef02eac771bb88bc66c57d229edfba1e484fd1c8b49e11e594aefa681f26ea28c348615d3e0a2dc76845d2d19543751ce444c7b65fa449a74639fa13c123d025200efa7012b209400746e03bd6a7bc938b926107da0491407bd952602d14a7fa743cbd51d5090a22c76a336f06b5e6dc5ecf70c803da8dcbff149c5013c36
 Ctrl.hexxcghash = hexxcghash:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
 Ctrl.hexsession_id = hexsession_id:273ab849318045321f672fdf9b4bc250c4b46717374bfb3322bc7701
@@ -1924,7 +1925,7 @@ Ctrl.type = type:F
 Output = edf713ecfb21b9e9c2d9d04c882d5ded433dcf459ff5b0fe7cd45bb1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d9b92844753a5eadc2ef7e84372a56bd096cc1d57a5c282811658d7df87564f202e800c774e75bbb53f47e835f207300ccd4661fd8a73b6ff87770c2c036346e99fadc5193171e1e732f3b6a017808a150ee02c4b6e70d87462e51825a94bda27fa9cbe18c7ef20d0b0201cb7526e0e9bac21b877e5064000290424387a9aa98da563ee2a5ef36af4b442a69eb631b88b8e3a0f073aa5dda589c4aa0e4e007e0d0036a231d52137d724fd60d41f42512214853e7acf8bde77e377842468f4216a15d0c8fe033c2b133bf651c82fda6d227e3c3f0cb7d0a9eba7c35eeefcf683ddde696fdeba5ec124e701f01bf5b0d59a667c75633dea07670b07baa20f313c3
 Ctrl.hexxcghash = hexxcghash:a510774a9b07b05e4e0eaf9409d77028a511a9565784b69ab3c03ffc
 Ctrl.hexsession_id = hexsession_id:49c4ad412d13870d0e9c6855e2881fc032aab36fa3ab3598a7f1153e
@@ -1932,7 +1933,7 @@ Ctrl.type = type:A
 Output = f3064d3f3ed09eefd34731a2c60c1a80
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d9b92844753a5eadc2ef7e84372a56bd096cc1d57a5c282811658d7df87564f202e800c774e75bbb53f47e835f207300ccd4661fd8a73b6ff87770c2c036346e99fadc5193171e1e732f3b6a017808a150ee02c4b6e70d87462e51825a94bda27fa9cbe18c7ef20d0b0201cb7526e0e9bac21b877e5064000290424387a9aa98da563ee2a5ef36af4b442a69eb631b88b8e3a0f073aa5dda589c4aa0e4e007e0d0036a231d52137d724fd60d41f42512214853e7acf8bde77e377842468f4216a15d0c8fe033c2b133bf651c82fda6d227e3c3f0cb7d0a9eba7c35eeefcf683ddde696fdeba5ec124e701f01bf5b0d59a667c75633dea07670b07baa20f313c3
 Ctrl.hexxcghash = hexxcghash:a510774a9b07b05e4e0eaf9409d77028a511a9565784b69ab3c03ffc
 Ctrl.hexsession_id = hexsession_id:49c4ad412d13870d0e9c6855e2881fc032aab36fa3ab3598a7f1153e
@@ -1940,7 +1941,7 @@ Ctrl.type = type:B
 Output = 1f7f508d9c4cf1004a220f26e0e6c184
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d9b92844753a5eadc2ef7e84372a56bd096cc1d57a5c282811658d7df87564f202e800c774e75bbb53f47e835f207300ccd4661fd8a73b6ff87770c2c036346e99fadc5193171e1e732f3b6a017808a150ee02c4b6e70d87462e51825a94bda27fa9cbe18c7ef20d0b0201cb7526e0e9bac21b877e5064000290424387a9aa98da563ee2a5ef36af4b442a69eb631b88b8e3a0f073aa5dda589c4aa0e4e007e0d0036a231d52137d724fd60d41f42512214853e7acf8bde77e377842468f4216a15d0c8fe033c2b133bf651c82fda6d227e3c3f0cb7d0a9eba7c35eeefcf683ddde696fdeba5ec124e701f01bf5b0d59a667c75633dea07670b07baa20f313c3
 Ctrl.hexxcghash = hexxcghash:a510774a9b07b05e4e0eaf9409d77028a511a9565784b69ab3c03ffc
 Ctrl.hexsession_id = hexsession_id:49c4ad412d13870d0e9c6855e2881fc032aab36fa3ab3598a7f1153e
@@ -1948,7 +1949,7 @@ Ctrl.type = type:C
 Output = 2ad48a77fa12fcb5d3d3e98d5bb87d76
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d9b92844753a5eadc2ef7e84372a56bd096cc1d57a5c282811658d7df87564f202e800c774e75bbb53f47e835f207300ccd4661fd8a73b6ff87770c2c036346e99fadc5193171e1e732f3b6a017808a150ee02c4b6e70d87462e51825a94bda27fa9cbe18c7ef20d0b0201cb7526e0e9bac21b877e5064000290424387a9aa98da563ee2a5ef36af4b442a69eb631b88b8e3a0f073aa5dda589c4aa0e4e007e0d0036a231d52137d724fd60d41f42512214853e7acf8bde77e377842468f4216a15d0c8fe033c2b133bf651c82fda6d227e3c3f0cb7d0a9eba7c35eeefcf683ddde696fdeba5ec124e701f01bf5b0d59a667c75633dea07670b07baa20f313c3
 Ctrl.hexxcghash = hexxcghash:a510774a9b07b05e4e0eaf9409d77028a511a9565784b69ab3c03ffc
 Ctrl.hexsession_id = hexsession_id:49c4ad412d13870d0e9c6855e2881fc032aab36fa3ab3598a7f1153e
@@ -1956,7 +1957,7 @@ Ctrl.type = type:D
 Output = 0433db7fd40d9d0dc9df6e9eed8059e4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d9b92844753a5eadc2ef7e84372a56bd096cc1d57a5c282811658d7df87564f202e800c774e75bbb53f47e835f207300ccd4661fd8a73b6ff87770c2c036346e99fadc5193171e1e732f3b6a017808a150ee02c4b6e70d87462e51825a94bda27fa9cbe18c7ef20d0b0201cb7526e0e9bac21b877e5064000290424387a9aa98da563ee2a5ef36af4b442a69eb631b88b8e3a0f073aa5dda589c4aa0e4e007e0d0036a231d52137d724fd60d41f42512214853e7acf8bde77e377842468f4216a15d0c8fe033c2b133bf651c82fda6d227e3c3f0cb7d0a9eba7c35eeefcf683ddde696fdeba5ec124e701f01bf5b0d59a667c75633dea07670b07baa20f313c3
 Ctrl.hexxcghash = hexxcghash:a510774a9b07b05e4e0eaf9409d77028a511a9565784b69ab3c03ffc
 Ctrl.hexsession_id = hexsession_id:49c4ad412d13870d0e9c6855e2881fc032aab36fa3ab3598a7f1153e
@@ -1964,7 +1965,7 @@ Ctrl.type = type:E
 Output = b07884f15910c6a083143ef9bda115d05c9e4c4057c1987c4f78a1b6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100d9b92844753a5eadc2ef7e84372a56bd096cc1d57a5c282811658d7df87564f202e800c774e75bbb53f47e835f207300ccd4661fd8a73b6ff87770c2c036346e99fadc5193171e1e732f3b6a017808a150ee02c4b6e70d87462e51825a94bda27fa9cbe18c7ef20d0b0201cb7526e0e9bac21b877e5064000290424387a9aa98da563ee2a5ef36af4b442a69eb631b88b8e3a0f073aa5dda589c4aa0e4e007e0d0036a231d52137d724fd60d41f42512214853e7acf8bde77e377842468f4216a15d0c8fe033c2b133bf651c82fda6d227e3c3f0cb7d0a9eba7c35eeefcf683ddde696fdeba5ec124e701f01bf5b0d59a667c75633dea07670b07baa20f313c3
 Ctrl.hexxcghash = hexxcghash:a510774a9b07b05e4e0eaf9409d77028a511a9565784b69ab3c03ffc
 Ctrl.hexsession_id = hexsession_id:49c4ad412d13870d0e9c6855e2881fc032aab36fa3ab3598a7f1153e
@@ -1972,7 +1973,7 @@ Ctrl.type = type:F
 Output = f838da7b26311dbd529f742d901709229482cea9d7ac9f0c2cd14200
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010012641156f363edf89c1824532fcf379a846dd042ac173d6b9b75651d7aa911ebe75f5dd3b502a7d6ec331f095ed08505e86f51008242357b3d29d75db82619066c2ecb3ba78e8de8fceeb206bfa39ef3e6617d1f20e4a092ac6bd589904fe0ce4fac2d73c7396a54084bf71e929ae0c5c7e67e1795e73f9fab8c6ee90254f27dae6750e1f8769af5b235f9f7aef302f1fc4015f60af34656a1a8187159a4d6c4b3be40abe9ad5cb56a52f5407186b42fdce7a691b917550719fc7eef858030dcb2829a07a39ca279d9deb0487b893d4c7bbc41cde4eb366188f38bdb4289b8a95ae757864e963cbe4f5eced9aebf3b33ebb3c75b7e405816366e609e16f8bc56
 Ctrl.hexxcghash = hexxcghash:d041364fa73e42f0c9c49d2ad25a758c3f4691761d9caf6dfd2ad690
 Ctrl.hexsession_id = hexsession_id:1fea0e79508d3b2caf0e275c463626ad7d57c6cfc1da79a5bce2fa53
@@ -1980,7 +1981,7 @@ Ctrl.type = type:A
 Output = d8c60bf582892d2cd03956774614b9f1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010012641156f363edf89c1824532fcf379a846dd042ac173d6b9b75651d7aa911ebe75f5dd3b502a7d6ec331f095ed08505e86f51008242357b3d29d75db82619066c2ecb3ba78e8de8fceeb206bfa39ef3e6617d1f20e4a092ac6bd589904fe0ce4fac2d73c7396a54084bf71e929ae0c5c7e67e1795e73f9fab8c6ee90254f27dae6750e1f8769af5b235f9f7aef302f1fc4015f60af34656a1a8187159a4d6c4b3be40abe9ad5cb56a52f5407186b42fdce7a691b917550719fc7eef858030dcb2829a07a39ca279d9deb0487b893d4c7bbc41cde4eb366188f38bdb4289b8a95ae757864e963cbe4f5eced9aebf3b33ebb3c75b7e405816366e609e16f8bc56
 Ctrl.hexxcghash = hexxcghash:d041364fa73e42f0c9c49d2ad25a758c3f4691761d9caf6dfd2ad690
 Ctrl.hexsession_id = hexsession_id:1fea0e79508d3b2caf0e275c463626ad7d57c6cfc1da79a5bce2fa53
@@ -1988,7 +1989,7 @@ Ctrl.type = type:B
 Output = bac1bef6d6dd92de55bc174c9db77a54
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010012641156f363edf89c1824532fcf379a846dd042ac173d6b9b75651d7aa911ebe75f5dd3b502a7d6ec331f095ed08505e86f51008242357b3d29d75db82619066c2ecb3ba78e8de8fceeb206bfa39ef3e6617d1f20e4a092ac6bd589904fe0ce4fac2d73c7396a54084bf71e929ae0c5c7e67e1795e73f9fab8c6ee90254f27dae6750e1f8769af5b235f9f7aef302f1fc4015f60af34656a1a8187159a4d6c4b3be40abe9ad5cb56a52f5407186b42fdce7a691b917550719fc7eef858030dcb2829a07a39ca279d9deb0487b893d4c7bbc41cde4eb366188f38bdb4289b8a95ae757864e963cbe4f5eced9aebf3b33ebb3c75b7e405816366e609e16f8bc56
 Ctrl.hexxcghash = hexxcghash:d041364fa73e42f0c9c49d2ad25a758c3f4691761d9caf6dfd2ad690
 Ctrl.hexsession_id = hexsession_id:1fea0e79508d3b2caf0e275c463626ad7d57c6cfc1da79a5bce2fa53
@@ -1996,7 +1997,7 @@ Ctrl.type = type:C
 Output = bdf96d88d7ac4f0daa62d29948a5c891
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010012641156f363edf89c1824532fcf379a846dd042ac173d6b9b75651d7aa911ebe75f5dd3b502a7d6ec331f095ed08505e86f51008242357b3d29d75db82619066c2ecb3ba78e8de8fceeb206bfa39ef3e6617d1f20e4a092ac6bd589904fe0ce4fac2d73c7396a54084bf71e929ae0c5c7e67e1795e73f9fab8c6ee90254f27dae6750e1f8769af5b235f9f7aef302f1fc4015f60af34656a1a8187159a4d6c4b3be40abe9ad5cb56a52f5407186b42fdce7a691b917550719fc7eef858030dcb2829a07a39ca279d9deb0487b893d4c7bbc41cde4eb366188f38bdb4289b8a95ae757864e963cbe4f5eced9aebf3b33ebb3c75b7e405816366e609e16f8bc56
 Ctrl.hexxcghash = hexxcghash:d041364fa73e42f0c9c49d2ad25a758c3f4691761d9caf6dfd2ad690
 Ctrl.hexsession_id = hexsession_id:1fea0e79508d3b2caf0e275c463626ad7d57c6cfc1da79a5bce2fa53
@@ -2004,7 +2005,7 @@ Ctrl.type = type:D
 Output = ef0dbe568b4f3fbcb8b2665ed7ed0f8d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010012641156f363edf89c1824532fcf379a846dd042ac173d6b9b75651d7aa911ebe75f5dd3b502a7d6ec331f095ed08505e86f51008242357b3d29d75db82619066c2ecb3ba78e8de8fceeb206bfa39ef3e6617d1f20e4a092ac6bd589904fe0ce4fac2d73c7396a54084bf71e929ae0c5c7e67e1795e73f9fab8c6ee90254f27dae6750e1f8769af5b235f9f7aef302f1fc4015f60af34656a1a8187159a4d6c4b3be40abe9ad5cb56a52f5407186b42fdce7a691b917550719fc7eef858030dcb2829a07a39ca279d9deb0487b893d4c7bbc41cde4eb366188f38bdb4289b8a95ae757864e963cbe4f5eced9aebf3b33ebb3c75b7e405816366e609e16f8bc56
 Ctrl.hexxcghash = hexxcghash:d041364fa73e42f0c9c49d2ad25a758c3f4691761d9caf6dfd2ad690
 Ctrl.hexsession_id = hexsession_id:1fea0e79508d3b2caf0e275c463626ad7d57c6cfc1da79a5bce2fa53
@@ -2012,7 +2013,7 @@ Ctrl.type = type:E
 Output = 315d50a1b29f9d556c983432b98bf437893c1a892cf69880353d9797
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010012641156f363edf89c1824532fcf379a846dd042ac173d6b9b75651d7aa911ebe75f5dd3b502a7d6ec331f095ed08505e86f51008242357b3d29d75db82619066c2ecb3ba78e8de8fceeb206bfa39ef3e6617d1f20e4a092ac6bd589904fe0ce4fac2d73c7396a54084bf71e929ae0c5c7e67e1795e73f9fab8c6ee90254f27dae6750e1f8769af5b235f9f7aef302f1fc4015f60af34656a1a8187159a4d6c4b3be40abe9ad5cb56a52f5407186b42fdce7a691b917550719fc7eef858030dcb2829a07a39ca279d9deb0487b893d4c7bbc41cde4eb366188f38bdb4289b8a95ae757864e963cbe4f5eced9aebf3b33ebb3c75b7e405816366e609e16f8bc56
 Ctrl.hexxcghash = hexxcghash:d041364fa73e42f0c9c49d2ad25a758c3f4691761d9caf6dfd2ad690
 Ctrl.hexsession_id = hexsession_id:1fea0e79508d3b2caf0e275c463626ad7d57c6cfc1da79a5bce2fa53
@@ -2020,7 +2021,7 @@ Ctrl.type = type:F
 Output = 612e3ac6651f9c7d99c532da0820f079292d9b33d36b684198665f5e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100ecfd38c0707d59db0b361a449a22ddc63f055678e253ffbc8324a306ff06e31590fcdf6fc271665335f01af804619f4367489d7829ca756cd14d2147f2c6b2c0355847955ebe89ed2133dc74283732c4f821a7cadcaa9abf661fa9fcf81b0596c454fdac23d79267c5a832979217df61f9bb04c0fa69f5fdae2407da763210f0b7c1097463505b0da86ad71c20c1c57accaae353919cb2708aa378a5ff598d0a4b21b7527b2dbd271957fbbf04f5787076fb7f8afdfb75ddb5fa142ab427e026c87033fe2c6f22454ebace3f77646d0ee447cd1d339c9a21ce86c0b233c7fcbd6d1d165e14d57908777cde654b7fc3c3db7e62951b359ec71fe475356dc6a58b
 Ctrl.hexxcghash = hexxcghash:7af5885d52c4173000c45dd2b0fbeb21fa5722aa65eecb1bf977248a
 Ctrl.hexsession_id = hexsession_id:122e2d181cca7dcec6f30a8b027b4d29275d342af5fd82794b24560f
@@ -2028,7 +2029,7 @@ Ctrl.type = type:A
 Output = e0d36ac1de6cc8514d25ff824bfaaa37
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100ecfd38c0707d59db0b361a449a22ddc63f055678e253ffbc8324a306ff06e31590fcdf6fc271665335f01af804619f4367489d7829ca756cd14d2147f2c6b2c0355847955ebe89ed2133dc74283732c4f821a7cadcaa9abf661fa9fcf81b0596c454fdac23d79267c5a832979217df61f9bb04c0fa69f5fdae2407da763210f0b7c1097463505b0da86ad71c20c1c57accaae353919cb2708aa378a5ff598d0a4b21b7527b2dbd271957fbbf04f5787076fb7f8afdfb75ddb5fa142ab427e026c87033fe2c6f22454ebace3f77646d0ee447cd1d339c9a21ce86c0b233c7fcbd6d1d165e14d57908777cde654b7fc3c3db7e62951b359ec71fe475356dc6a58b
 Ctrl.hexxcghash = hexxcghash:7af5885d52c4173000c45dd2b0fbeb21fa5722aa65eecb1bf977248a
 Ctrl.hexsession_id = hexsession_id:122e2d181cca7dcec6f30a8b027b4d29275d342af5fd82794b24560f
@@ -2036,7 +2037,7 @@ Ctrl.type = type:B
 Output = 58c896b4d1a9507e7da2234a1a538d78
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100ecfd38c0707d59db0b361a449a22ddc63f055678e253ffbc8324a306ff06e31590fcdf6fc271665335f01af804619f4367489d7829ca756cd14d2147f2c6b2c0355847955ebe89ed2133dc74283732c4f821a7cadcaa9abf661fa9fcf81b0596c454fdac23d79267c5a832979217df61f9bb04c0fa69f5fdae2407da763210f0b7c1097463505b0da86ad71c20c1c57accaae353919cb2708aa378a5ff598d0a4b21b7527b2dbd271957fbbf04f5787076fb7f8afdfb75ddb5fa142ab427e026c87033fe2c6f22454ebace3f77646d0ee447cd1d339c9a21ce86c0b233c7fcbd6d1d165e14d57908777cde654b7fc3c3db7e62951b359ec71fe475356dc6a58b
 Ctrl.hexxcghash = hexxcghash:7af5885d52c4173000c45dd2b0fbeb21fa5722aa65eecb1bf977248a
 Ctrl.hexsession_id = hexsession_id:122e2d181cca7dcec6f30a8b027b4d29275d342af5fd82794b24560f
@@ -2044,7 +2045,7 @@ Ctrl.type = type:C
 Output = 5966df5cb582234585b4c4312318f829
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100ecfd38c0707d59db0b361a449a22ddc63f055678e253ffbc8324a306ff06e31590fcdf6fc271665335f01af804619f4367489d7829ca756cd14d2147f2c6b2c0355847955ebe89ed2133dc74283732c4f821a7cadcaa9abf661fa9fcf81b0596c454fdac23d79267c5a832979217df61f9bb04c0fa69f5fdae2407da763210f0b7c1097463505b0da86ad71c20c1c57accaae353919cb2708aa378a5ff598d0a4b21b7527b2dbd271957fbbf04f5787076fb7f8afdfb75ddb5fa142ab427e026c87033fe2c6f22454ebace3f77646d0ee447cd1d339c9a21ce86c0b233c7fcbd6d1d165e14d57908777cde654b7fc3c3db7e62951b359ec71fe475356dc6a58b
 Ctrl.hexxcghash = hexxcghash:7af5885d52c4173000c45dd2b0fbeb21fa5722aa65eecb1bf977248a
 Ctrl.hexsession_id = hexsession_id:122e2d181cca7dcec6f30a8b027b4d29275d342af5fd82794b24560f
@@ -2052,7 +2053,7 @@ Ctrl.type = type:D
 Output = 40d8bdab78c9dac2b2d14d1c8bd41405
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100ecfd38c0707d59db0b361a449a22ddc63f055678e253ffbc8324a306ff06e31590fcdf6fc271665335f01af804619f4367489d7829ca756cd14d2147f2c6b2c0355847955ebe89ed2133dc74283732c4f821a7cadcaa9abf661fa9fcf81b0596c454fdac23d79267c5a832979217df61f9bb04c0fa69f5fdae2407da763210f0b7c1097463505b0da86ad71c20c1c57accaae353919cb2708aa378a5ff598d0a4b21b7527b2dbd271957fbbf04f5787076fb7f8afdfb75ddb5fa142ab427e026c87033fe2c6f22454ebace3f77646d0ee447cd1d339c9a21ce86c0b233c7fcbd6d1d165e14d57908777cde654b7fc3c3db7e62951b359ec71fe475356dc6a58b
 Ctrl.hexxcghash = hexxcghash:7af5885d52c4173000c45dd2b0fbeb21fa5722aa65eecb1bf977248a
 Ctrl.hexsession_id = hexsession_id:122e2d181cca7dcec6f30a8b027b4d29275d342af5fd82794b24560f
@@ -2060,7 +2061,7 @@ Ctrl.type = type:E
 Output = 1af4707570794ff6c718c817ccb9fca5edf22a3a8d493a861633fb7a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100ecfd38c0707d59db0b361a449a22ddc63f055678e253ffbc8324a306ff06e31590fcdf6fc271665335f01af804619f4367489d7829ca756cd14d2147f2c6b2c0355847955ebe89ed2133dc74283732c4f821a7cadcaa9abf661fa9fcf81b0596c454fdac23d79267c5a832979217df61f9bb04c0fa69f5fdae2407da763210f0b7c1097463505b0da86ad71c20c1c57accaae353919cb2708aa378a5ff598d0a4b21b7527b2dbd271957fbbf04f5787076fb7f8afdfb75ddb5fa142ab427e026c87033fe2c6f22454ebace3f77646d0ee447cd1d339c9a21ce86c0b233c7fcbd6d1d165e14d57908777cde654b7fc3c3db7e62951b359ec71fe475356dc6a58b
 Ctrl.hexxcghash = hexxcghash:7af5885d52c4173000c45dd2b0fbeb21fa5722aa65eecb1bf977248a
 Ctrl.hexsession_id = hexsession_id:122e2d181cca7dcec6f30a8b027b4d29275d342af5fd82794b24560f
@@ -2068,7 +2069,7 @@ Ctrl.type = type:F
 Output = 4e6edd5d86f0a3b92595fb2d4f0f9b0f0ed1e850c84014224270bcbc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001002dde91723fa969756f5a597683fa0ef938423ffcf3b3d0262f9ba0d69d72ffc3afbf2ccb9bbc42332f97d3857b44575e30849fe19e77688e9102d9909585d9e53835eee4127aee038deaf8501c70cfd209ef755f84613365d9b2150009f9055300b74c593f8204b84c7faaac87c781e7bdda8c54bf0ec170e4dbf71cd15825c949ebaa934797333124e63db50efe0f33f5224687c097b22d52de36045659622dd214effab378b6bff298c84436831f85540a5eac0b68d51fa1abd18d19ce5452aefe729b7d384e038927ee8f0c2ddffd1cb6ea537a90d9b06bce3bd01fdf4370d62d985ab80417d1256d38ab3874297163a020052b42e73e8ef64950851e7da2
 Ctrl.hexxcghash = hexxcghash:590c8e3800ddfd382f0b3023c7a8753bd013e756855ffbca1dee0f01
 Ctrl.hexsession_id = hexsession_id:5e4528c7ff85f2ed7d632c4355e2524438ee83ef0e1695524921408d
@@ -2076,7 +2077,7 @@ Ctrl.type = type:A
 Output = d30b7efda77a1008d78487fb1c9df511
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001002dde91723fa969756f5a597683fa0ef938423ffcf3b3d0262f9ba0d69d72ffc3afbf2ccb9bbc42332f97d3857b44575e30849fe19e77688e9102d9909585d9e53835eee4127aee038deaf8501c70cfd209ef755f84613365d9b2150009f9055300b74c593f8204b84c7faaac87c781e7bdda8c54bf0ec170e4dbf71cd15825c949ebaa934797333124e63db50efe0f33f5224687c097b22d52de36045659622dd214effab378b6bff298c84436831f85540a5eac0b68d51fa1abd18d19ce5452aefe729b7d384e038927ee8f0c2ddffd1cb6ea537a90d9b06bce3bd01fdf4370d62d985ab80417d1256d38ab3874297163a020052b42e73e8ef64950851e7da2
 Ctrl.hexxcghash = hexxcghash:590c8e3800ddfd382f0b3023c7a8753bd013e756855ffbca1dee0f01
 Ctrl.hexsession_id = hexsession_id:5e4528c7ff85f2ed7d632c4355e2524438ee83ef0e1695524921408d
@@ -2084,7 +2085,7 @@ Ctrl.type = type:B
 Output = 498b3d9f14446a028d1aed8bc4748e34
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001002dde91723fa969756f5a597683fa0ef938423ffcf3b3d0262f9ba0d69d72ffc3afbf2ccb9bbc42332f97d3857b44575e30849fe19e77688e9102d9909585d9e53835eee4127aee038deaf8501c70cfd209ef755f84613365d9b2150009f9055300b74c593f8204b84c7faaac87c781e7bdda8c54bf0ec170e4dbf71cd15825c949ebaa934797333124e63db50efe0f33f5224687c097b22d52de36045659622dd214effab378b6bff298c84436831f85540a5eac0b68d51fa1abd18d19ce5452aefe729b7d384e038927ee8f0c2ddffd1cb6ea537a90d9b06bce3bd01fdf4370d62d985ab80417d1256d38ab3874297163a020052b42e73e8ef64950851e7da2
 Ctrl.hexxcghash = hexxcghash:590c8e3800ddfd382f0b3023c7a8753bd013e756855ffbca1dee0f01
 Ctrl.hexsession_id = hexsession_id:5e4528c7ff85f2ed7d632c4355e2524438ee83ef0e1695524921408d
@@ -2092,7 +2093,7 @@ Ctrl.type = type:C
 Output = f4909273c39ef8819b353cde80f57cc9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001002dde91723fa969756f5a597683fa0ef938423ffcf3b3d0262f9ba0d69d72ffc3afbf2ccb9bbc42332f97d3857b44575e30849fe19e77688e9102d9909585d9e53835eee4127aee038deaf8501c70cfd209ef755f84613365d9b2150009f9055300b74c593f8204b84c7faaac87c781e7bdda8c54bf0ec170e4dbf71cd15825c949ebaa934797333124e63db50efe0f33f5224687c097b22d52de36045659622dd214effab378b6bff298c84436831f85540a5eac0b68d51fa1abd18d19ce5452aefe729b7d384e038927ee8f0c2ddffd1cb6ea537a90d9b06bce3bd01fdf4370d62d985ab80417d1256d38ab3874297163a020052b42e73e8ef64950851e7da2
 Ctrl.hexxcghash = hexxcghash:590c8e3800ddfd382f0b3023c7a8753bd013e756855ffbca1dee0f01
 Ctrl.hexsession_id = hexsession_id:5e4528c7ff85f2ed7d632c4355e2524438ee83ef0e1695524921408d
@@ -2100,7 +2101,7 @@ Ctrl.type = type:D
 Output = b31337a6ecd02f4beb9bf4af12ea4e11
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001002dde91723fa969756f5a597683fa0ef938423ffcf3b3d0262f9ba0d69d72ffc3afbf2ccb9bbc42332f97d3857b44575e30849fe19e77688e9102d9909585d9e53835eee4127aee038deaf8501c70cfd209ef755f84613365d9b2150009f9055300b74c593f8204b84c7faaac87c781e7bdda8c54bf0ec170e4dbf71cd15825c949ebaa934797333124e63db50efe0f33f5224687c097b22d52de36045659622dd214effab378b6bff298c84436831f85540a5eac0b68d51fa1abd18d19ce5452aefe729b7d384e038927ee8f0c2ddffd1cb6ea537a90d9b06bce3bd01fdf4370d62d985ab80417d1256d38ab3874297163a020052b42e73e8ef64950851e7da2
 Ctrl.hexxcghash = hexxcghash:590c8e3800ddfd382f0b3023c7a8753bd013e756855ffbca1dee0f01
 Ctrl.hexsession_id = hexsession_id:5e4528c7ff85f2ed7d632c4355e2524438ee83ef0e1695524921408d
@@ -2108,7 +2109,7 @@ Ctrl.type = type:E
 Output = 6f3da7bb4b64ad3e1171083a62eca5e755563e639594b848243760d8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001002dde91723fa969756f5a597683fa0ef938423ffcf3b3d0262f9ba0d69d72ffc3afbf2ccb9bbc42332f97d3857b44575e30849fe19e77688e9102d9909585d9e53835eee4127aee038deaf8501c70cfd209ef755f84613365d9b2150009f9055300b74c593f8204b84c7faaac87c781e7bdda8c54bf0ec170e4dbf71cd15825c949ebaa934797333124e63db50efe0f33f5224687c097b22d52de36045659622dd214effab378b6bff298c84436831f85540a5eac0b68d51fa1abd18d19ce5452aefe729b7d384e038927ee8f0c2ddffd1cb6ea537a90d9b06bce3bd01fdf4370d62d985ab80417d1256d38ab3874297163a020052b42e73e8ef64950851e7da2
 Ctrl.hexxcghash = hexxcghash:590c8e3800ddfd382f0b3023c7a8753bd013e756855ffbca1dee0f01
 Ctrl.hexsession_id = hexsession_id:5e4528c7ff85f2ed7d632c4355e2524438ee83ef0e1695524921408d
@@ -2116,7 +2117,7 @@ Ctrl.type = type:F
 Output = e88506aa4a4ffa33675c4a296abf91e24450a496e56f8465e9a7525c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100be7e6428be4ff862e2b9fe69f055bbbeaa51b7666d51e1ad2e5fe12e2f7a171121147311780840e5d1345c6a24eb3e2d7bace8c88cddae9a062c7aacc7ae87d31ef7d4c52dc2e35f364266c9c34e1ff703a61a8fb39397344ac94e75a42fc956dcc887e50e67018d5a74c89c1a8555ebff4a4baf5b4916aea1dd95c126df390882143908821ecf68511e986bd379cf0871fe1a2679241b339f3317f76c65dc2b121e15a0b8891d9c0120b8a8a383a1dd5eb6fbd65d22a03b7987f843d454e4e1f09b9e2d37ef2be72b7f8accade301c772f74a582afab960dfa43a167275771f6a9be5a9f275cea55e9661a54b1c3210042f824fe783969fa60ad23b748a6b56
 Ctrl.hexxcghash = hexxcghash:97e793420ceda1730dac88f0d7dc52d8713a79a0b48ddb2af45dd143
 Ctrl.hexsession_id = hexsession_id:16dd0d6aca3757eec6e9dc3c4a5f590cb7911cd3cabc80815527b73c
@@ -2124,7 +2125,7 @@ Ctrl.type = type:A
 Output = c5cbb653102d99457c33c88921b5dbe4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100be7e6428be4ff862e2b9fe69f055bbbeaa51b7666d51e1ad2e5fe12e2f7a171121147311780840e5d1345c6a24eb3e2d7bace8c88cddae9a062c7aacc7ae87d31ef7d4c52dc2e35f364266c9c34e1ff703a61a8fb39397344ac94e75a42fc956dcc887e50e67018d5a74c89c1a8555ebff4a4baf5b4916aea1dd95c126df390882143908821ecf68511e986bd379cf0871fe1a2679241b339f3317f76c65dc2b121e15a0b8891d9c0120b8a8a383a1dd5eb6fbd65d22a03b7987f843d454e4e1f09b9e2d37ef2be72b7f8accade301c772f74a582afab960dfa43a167275771f6a9be5a9f275cea55e9661a54b1c3210042f824fe783969fa60ad23b748a6b56
 Ctrl.hexxcghash = hexxcghash:97e793420ceda1730dac88f0d7dc52d8713a79a0b48ddb2af45dd143
 Ctrl.hexsession_id = hexsession_id:16dd0d6aca3757eec6e9dc3c4a5f590cb7911cd3cabc80815527b73c
@@ -2132,7 +2133,7 @@ Ctrl.type = type:B
 Output = dd9b1c786c7f739832629f7666e4e21e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100be7e6428be4ff862e2b9fe69f055bbbeaa51b7666d51e1ad2e5fe12e2f7a171121147311780840e5d1345c6a24eb3e2d7bace8c88cddae9a062c7aacc7ae87d31ef7d4c52dc2e35f364266c9c34e1ff703a61a8fb39397344ac94e75a42fc956dcc887e50e67018d5a74c89c1a8555ebff4a4baf5b4916aea1dd95c126df390882143908821ecf68511e986bd379cf0871fe1a2679241b339f3317f76c65dc2b121e15a0b8891d9c0120b8a8a383a1dd5eb6fbd65d22a03b7987f843d454e4e1f09b9e2d37ef2be72b7f8accade301c772f74a582afab960dfa43a167275771f6a9be5a9f275cea55e9661a54b1c3210042f824fe783969fa60ad23b748a6b56
 Ctrl.hexxcghash = hexxcghash:97e793420ceda1730dac88f0d7dc52d8713a79a0b48ddb2af45dd143
 Ctrl.hexsession_id = hexsession_id:16dd0d6aca3757eec6e9dc3c4a5f590cb7911cd3cabc80815527b73c
@@ -2140,7 +2141,7 @@ Ctrl.type = type:C
 Output = c33d08d706ffac1811f157526b08086f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100be7e6428be4ff862e2b9fe69f055bbbeaa51b7666d51e1ad2e5fe12e2f7a171121147311780840e5d1345c6a24eb3e2d7bace8c88cddae9a062c7aacc7ae87d31ef7d4c52dc2e35f364266c9c34e1ff703a61a8fb39397344ac94e75a42fc956dcc887e50e67018d5a74c89c1a8555ebff4a4baf5b4916aea1dd95c126df390882143908821ecf68511e986bd379cf0871fe1a2679241b339f3317f76c65dc2b121e15a0b8891d9c0120b8a8a383a1dd5eb6fbd65d22a03b7987f843d454e4e1f09b9e2d37ef2be72b7f8accade301c772f74a582afab960dfa43a167275771f6a9be5a9f275cea55e9661a54b1c3210042f824fe783969fa60ad23b748a6b56
 Ctrl.hexxcghash = hexxcghash:97e793420ceda1730dac88f0d7dc52d8713a79a0b48ddb2af45dd143
 Ctrl.hexsession_id = hexsession_id:16dd0d6aca3757eec6e9dc3c4a5f590cb7911cd3cabc80815527b73c
@@ -2148,7 +2149,7 @@ Ctrl.type = type:D
 Output = 5750b617b71a239d99fc412796f6d986
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100be7e6428be4ff862e2b9fe69f055bbbeaa51b7666d51e1ad2e5fe12e2f7a171121147311780840e5d1345c6a24eb3e2d7bace8c88cddae9a062c7aacc7ae87d31ef7d4c52dc2e35f364266c9c34e1ff703a61a8fb39397344ac94e75a42fc956dcc887e50e67018d5a74c89c1a8555ebff4a4baf5b4916aea1dd95c126df390882143908821ecf68511e986bd379cf0871fe1a2679241b339f3317f76c65dc2b121e15a0b8891d9c0120b8a8a383a1dd5eb6fbd65d22a03b7987f843d454e4e1f09b9e2d37ef2be72b7f8accade301c772f74a582afab960dfa43a167275771f6a9be5a9f275cea55e9661a54b1c3210042f824fe783969fa60ad23b748a6b56
 Ctrl.hexxcghash = hexxcghash:97e793420ceda1730dac88f0d7dc52d8713a79a0b48ddb2af45dd143
 Ctrl.hexsession_id = hexsession_id:16dd0d6aca3757eec6e9dc3c4a5f590cb7911cd3cabc80815527b73c
@@ -2156,7 +2157,7 @@ Ctrl.type = type:E
 Output = 4c2edee4688119e17723fede94d81c141cb2dd632dde5e223fcd12c2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100be7e6428be4ff862e2b9fe69f055bbbeaa51b7666d51e1ad2e5fe12e2f7a171121147311780840e5d1345c6a24eb3e2d7bace8c88cddae9a062c7aacc7ae87d31ef7d4c52dc2e35f364266c9c34e1ff703a61a8fb39397344ac94e75a42fc956dcc887e50e67018d5a74c89c1a8555ebff4a4baf5b4916aea1dd95c126df390882143908821ecf68511e986bd379cf0871fe1a2679241b339f3317f76c65dc2b121e15a0b8891d9c0120b8a8a383a1dd5eb6fbd65d22a03b7987f843d454e4e1f09b9e2d37ef2be72b7f8accade301c772f74a582afab960dfa43a167275771f6a9be5a9f275cea55e9661a54b1c3210042f824fe783969fa60ad23b748a6b56
 Ctrl.hexxcghash = hexxcghash:97e793420ceda1730dac88f0d7dc52d8713a79a0b48ddb2af45dd143
 Ctrl.hexsession_id = hexsession_id:16dd0d6aca3757eec6e9dc3c4a5f590cb7911cd3cabc80815527b73c
@@ -2164,7 +2165,7 @@ Ctrl.type = type:F
 Output = b48103cd81397bed3bf618b2ef30a44ea806b0ad07aa098a8a33273e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100c810e36b6ae23b2dac234f36b4ddfe820762b53478eaea205cdab848c384f2c5fe262bc471971ff42a1ff8fdfff81cdc66371a75e9fda5d7d0bd656523603255c3e0970435f995948ec98d87942cefe2194e475a507e2928e0cfbba63962c75794aa53e8a385a5d1599d88dd1684a827914da576f9e06caaecc586bb98425621a5afaf86003cabe86fcd3964a390f47302bbbee8536f24024c5c31f031e80e6bcf2a3e24d4f0b6bd42250996f12a8a5c99b09a42a737e3cbf481e002c334fe3b7626419266e0036339b1592d3bf43245c449a65e43946e60112c1f8aff8963ff56e365c6f56c36b2208eadf591360554d2b116d3374341bd5779ebcdf7ba93de
 Ctrl.hexxcghash = hexxcghash:f8a7854ec21f252f679b924f0f3d34639fe976de146ddb8e93c4e4d9
 Ctrl.hexsession_id = hexsession_id:6bebea19564c0f65dd96446496f7d7c7198a5b08bcdacf29449808ba
@@ -2172,7 +2173,7 @@ Ctrl.type = type:A
 Output = c8bc1d232edd620e0282af630d596a6c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100c810e36b6ae23b2dac234f36b4ddfe820762b53478eaea205cdab848c384f2c5fe262bc471971ff42a1ff8fdfff81cdc66371a75e9fda5d7d0bd656523603255c3e0970435f995948ec98d87942cefe2194e475a507e2928e0cfbba63962c75794aa53e8a385a5d1599d88dd1684a827914da576f9e06caaecc586bb98425621a5afaf86003cabe86fcd3964a390f47302bbbee8536f24024c5c31f031e80e6bcf2a3e24d4f0b6bd42250996f12a8a5c99b09a42a737e3cbf481e002c334fe3b7626419266e0036339b1592d3bf43245c449a65e43946e60112c1f8aff8963ff56e365c6f56c36b2208eadf591360554d2b116d3374341bd5779ebcdf7ba93de
 Ctrl.hexxcghash = hexxcghash:f8a7854ec21f252f679b924f0f3d34639fe976de146ddb8e93c4e4d9
 Ctrl.hexsession_id = hexsession_id:6bebea19564c0f65dd96446496f7d7c7198a5b08bcdacf29449808ba
@@ -2180,7 +2181,7 @@ Ctrl.type = type:B
 Output = 6a90269aab1a3e3612eec97a45db11e1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100c810e36b6ae23b2dac234f36b4ddfe820762b53478eaea205cdab848c384f2c5fe262bc471971ff42a1ff8fdfff81cdc66371a75e9fda5d7d0bd656523603255c3e0970435f995948ec98d87942cefe2194e475a507e2928e0cfbba63962c75794aa53e8a385a5d1599d88dd1684a827914da576f9e06caaecc586bb98425621a5afaf86003cabe86fcd3964a390f47302bbbee8536f24024c5c31f031e80e6bcf2a3e24d4f0b6bd42250996f12a8a5c99b09a42a737e3cbf481e002c334fe3b7626419266e0036339b1592d3bf43245c449a65e43946e60112c1f8aff8963ff56e365c6f56c36b2208eadf591360554d2b116d3374341bd5779ebcdf7ba93de
 Ctrl.hexxcghash = hexxcghash:f8a7854ec21f252f679b924f0f3d34639fe976de146ddb8e93c4e4d9
 Ctrl.hexsession_id = hexsession_id:6bebea19564c0f65dd96446496f7d7c7198a5b08bcdacf29449808ba
@@ -2188,7 +2189,7 @@ Ctrl.type = type:C
 Output = ebb8a6227e789d33fa072355cb2851ac
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100c810e36b6ae23b2dac234f36b4ddfe820762b53478eaea205cdab848c384f2c5fe262bc471971ff42a1ff8fdfff81cdc66371a75e9fda5d7d0bd656523603255c3e0970435f995948ec98d87942cefe2194e475a507e2928e0cfbba63962c75794aa53e8a385a5d1599d88dd1684a827914da576f9e06caaecc586bb98425621a5afaf86003cabe86fcd3964a390f47302bbbee8536f24024c5c31f031e80e6bcf2a3e24d4f0b6bd42250996f12a8a5c99b09a42a737e3cbf481e002c334fe3b7626419266e0036339b1592d3bf43245c449a65e43946e60112c1f8aff8963ff56e365c6f56c36b2208eadf591360554d2b116d3374341bd5779ebcdf7ba93de
 Ctrl.hexxcghash = hexxcghash:f8a7854ec21f252f679b924f0f3d34639fe976de146ddb8e93c4e4d9
 Ctrl.hexsession_id = hexsession_id:6bebea19564c0f65dd96446496f7d7c7198a5b08bcdacf29449808ba
@@ -2196,7 +2197,7 @@ Ctrl.type = type:D
 Output = 9662ff73b11bd2978ffceb7545f6054e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100c810e36b6ae23b2dac234f36b4ddfe820762b53478eaea205cdab848c384f2c5fe262bc471971ff42a1ff8fdfff81cdc66371a75e9fda5d7d0bd656523603255c3e0970435f995948ec98d87942cefe2194e475a507e2928e0cfbba63962c75794aa53e8a385a5d1599d88dd1684a827914da576f9e06caaecc586bb98425621a5afaf86003cabe86fcd3964a390f47302bbbee8536f24024c5c31f031e80e6bcf2a3e24d4f0b6bd42250996f12a8a5c99b09a42a737e3cbf481e002c334fe3b7626419266e0036339b1592d3bf43245c449a65e43946e60112c1f8aff8963ff56e365c6f56c36b2208eadf591360554d2b116d3374341bd5779ebcdf7ba93de
 Ctrl.hexxcghash = hexxcghash:f8a7854ec21f252f679b924f0f3d34639fe976de146ddb8e93c4e4d9
 Ctrl.hexsession_id = hexsession_id:6bebea19564c0f65dd96446496f7d7c7198a5b08bcdacf29449808ba
@@ -2204,7 +2205,7 @@ Ctrl.type = type:E
 Output = 9eb35f9a8a6155b81b8dda117f5d631cc4eddea4b4912147513bc4ec
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100c810e36b6ae23b2dac234f36b4ddfe820762b53478eaea205cdab848c384f2c5fe262bc471971ff42a1ff8fdfff81cdc66371a75e9fda5d7d0bd656523603255c3e0970435f995948ec98d87942cefe2194e475a507e2928e0cfbba63962c75794aa53e8a385a5d1599d88dd1684a827914da576f9e06caaecc586bb98425621a5afaf86003cabe86fcd3964a390f47302bbbee8536f24024c5c31f031e80e6bcf2a3e24d4f0b6bd42250996f12a8a5c99b09a42a737e3cbf481e002c334fe3b7626419266e0036339b1592d3bf43245c449a65e43946e60112c1f8aff8963ff56e365c6f56c36b2208eadf591360554d2b116d3374341bd5779ebcdf7ba93de
 Ctrl.hexxcghash = hexxcghash:f8a7854ec21f252f679b924f0f3d34639fe976de146ddb8e93c4e4d9
 Ctrl.hexsession_id = hexsession_id:6bebea19564c0f65dd96446496f7d7c7198a5b08bcdacf29449808ba
@@ -2212,7 +2213,7 @@ Ctrl.type = type:F
 Output = 3e137e015973e21c37a8de81cc812683d506fc35699114b31c06797e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100940a3535b876a90210236f8571e20cb04d287ae7217b95d75c4170e8afea4d290bc41e736cdd1b470b02ce8b74ca4cdaa121bbb3b31df3f2c847455ef21b61e0c966bdb8cf58fb94819108c7feb9551c5dcacc37fec5fe4e9a59818e93ed08f3477632c62304fb2ba05f7fa8611970adb39379ab7159baa3731fb1fceba201a1858635b92d938b195a44612ffddac3f2b5db59b47c9f90b66e76b3e901887b27312e1043b000b5ff21d4fff4b5fc06203403387fe28837c4d367dbe2c73e1ec5c4e867cc99dca2bf8171aad1498b37bf0d17e5fd64e411386df72667d824e4514530cf6021ca8880154212884f5fdb44a0c8745a4049971de370eb31c959dac4
 Ctrl.hexxcghash = hexxcghash:4688aa9bceb36ddab933675e6963357b2bd0daa5e1984a06fc7f3ff3
 Ctrl.hexsession_id = hexsession_id:fb72bca26e61577066d7c5093ac9281fcf06ae3250b43228b067b86e
@@ -2220,7 +2221,7 @@ Ctrl.type = type:A
 Output = cc22a730c15abf9628f749fac9d3f935
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100940a3535b876a90210236f8571e20cb04d287ae7217b95d75c4170e8afea4d290bc41e736cdd1b470b02ce8b74ca4cdaa121bbb3b31df3f2c847455ef21b61e0c966bdb8cf58fb94819108c7feb9551c5dcacc37fec5fe4e9a59818e93ed08f3477632c62304fb2ba05f7fa8611970adb39379ab7159baa3731fb1fceba201a1858635b92d938b195a44612ffddac3f2b5db59b47c9f90b66e76b3e901887b27312e1043b000b5ff21d4fff4b5fc06203403387fe28837c4d367dbe2c73e1ec5c4e867cc99dca2bf8171aad1498b37bf0d17e5fd64e411386df72667d824e4514530cf6021ca8880154212884f5fdb44a0c8745a4049971de370eb31c959dac4
 Ctrl.hexxcghash = hexxcghash:4688aa9bceb36ddab933675e6963357b2bd0daa5e1984a06fc7f3ff3
 Ctrl.hexsession_id = hexsession_id:fb72bca26e61577066d7c5093ac9281fcf06ae3250b43228b067b86e
@@ -2228,7 +2229,7 @@ Ctrl.type = type:B
 Output = 188c477061a597384b1d1e417dc04f7d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100940a3535b876a90210236f8571e20cb04d287ae7217b95d75c4170e8afea4d290bc41e736cdd1b470b02ce8b74ca4cdaa121bbb3b31df3f2c847455ef21b61e0c966bdb8cf58fb94819108c7feb9551c5dcacc37fec5fe4e9a59818e93ed08f3477632c62304fb2ba05f7fa8611970adb39379ab7159baa3731fb1fceba201a1858635b92d938b195a44612ffddac3f2b5db59b47c9f90b66e76b3e901887b27312e1043b000b5ff21d4fff4b5fc06203403387fe28837c4d367dbe2c73e1ec5c4e867cc99dca2bf8171aad1498b37bf0d17e5fd64e411386df72667d824e4514530cf6021ca8880154212884f5fdb44a0c8745a4049971de370eb31c959dac4
 Ctrl.hexxcghash = hexxcghash:4688aa9bceb36ddab933675e6963357b2bd0daa5e1984a06fc7f3ff3
 Ctrl.hexsession_id = hexsession_id:fb72bca26e61577066d7c5093ac9281fcf06ae3250b43228b067b86e
@@ -2236,7 +2237,7 @@ Ctrl.type = type:C
 Output = b309760dd9f0d65c6edcdee3a3457c33
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100940a3535b876a90210236f8571e20cb04d287ae7217b95d75c4170e8afea4d290bc41e736cdd1b470b02ce8b74ca4cdaa121bbb3b31df3f2c847455ef21b61e0c966bdb8cf58fb94819108c7feb9551c5dcacc37fec5fe4e9a59818e93ed08f3477632c62304fb2ba05f7fa8611970adb39379ab7159baa3731fb1fceba201a1858635b92d938b195a44612ffddac3f2b5db59b47c9f90b66e76b3e901887b27312e1043b000b5ff21d4fff4b5fc06203403387fe28837c4d367dbe2c73e1ec5c4e867cc99dca2bf8171aad1498b37bf0d17e5fd64e411386df72667d824e4514530cf6021ca8880154212884f5fdb44a0c8745a4049971de370eb31c959dac4
 Ctrl.hexxcghash = hexxcghash:4688aa9bceb36ddab933675e6963357b2bd0daa5e1984a06fc7f3ff3
 Ctrl.hexsession_id = hexsession_id:fb72bca26e61577066d7c5093ac9281fcf06ae3250b43228b067b86e
@@ -2244,7 +2245,7 @@ Ctrl.type = type:D
 Output = 1b8674f603a78f16fb979d6db70f6795
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100940a3535b876a90210236f8571e20cb04d287ae7217b95d75c4170e8afea4d290bc41e736cdd1b470b02ce8b74ca4cdaa121bbb3b31df3f2c847455ef21b61e0c966bdb8cf58fb94819108c7feb9551c5dcacc37fec5fe4e9a59818e93ed08f3477632c62304fb2ba05f7fa8611970adb39379ab7159baa3731fb1fceba201a1858635b92d938b195a44612ffddac3f2b5db59b47c9f90b66e76b3e901887b27312e1043b000b5ff21d4fff4b5fc06203403387fe28837c4d367dbe2c73e1ec5c4e867cc99dca2bf8171aad1498b37bf0d17e5fd64e411386df72667d824e4514530cf6021ca8880154212884f5fdb44a0c8745a4049971de370eb31c959dac4
 Ctrl.hexxcghash = hexxcghash:4688aa9bceb36ddab933675e6963357b2bd0daa5e1984a06fc7f3ff3
 Ctrl.hexsession_id = hexsession_id:fb72bca26e61577066d7c5093ac9281fcf06ae3250b43228b067b86e
@@ -2252,7 +2253,7 @@ Ctrl.type = type:E
 Output = d881ac0cf62ecff2eb7d3c8284cfd4b95e003c435f6a3121ab0c65b0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100940a3535b876a90210236f8571e20cb04d287ae7217b95d75c4170e8afea4d290bc41e736cdd1b470b02ce8b74ca4cdaa121bbb3b31df3f2c847455ef21b61e0c966bdb8cf58fb94819108c7feb9551c5dcacc37fec5fe4e9a59818e93ed08f3477632c62304fb2ba05f7fa8611970adb39379ab7159baa3731fb1fceba201a1858635b92d938b195a44612ffddac3f2b5db59b47c9f90b66e76b3e901887b27312e1043b000b5ff21d4fff4b5fc06203403387fe28837c4d367dbe2c73e1ec5c4e867cc99dca2bf8171aad1498b37bf0d17e5fd64e411386df72667d824e4514530cf6021ca8880154212884f5fdb44a0c8745a4049971de370eb31c959dac4
 Ctrl.hexxcghash = hexxcghash:4688aa9bceb36ddab933675e6963357b2bd0daa5e1984a06fc7f3ff3
 Ctrl.hexsession_id = hexsession_id:fb72bca26e61577066d7c5093ac9281fcf06ae3250b43228b067b86e
@@ -2260,7 +2261,7 @@ Ctrl.type = type:F
 Output = 9a7560e7976c7fb0153fc94e51a7dead3b7f8954d1efa7ed6be77858
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001004b9f55f17de634edb39218b30f224ae8ec64edd6e0c49dd00a52ac11e0a4089ccff931838ce5c02f449ffe33c14fd0a9f11da7d783787a03defc7931ce638a31aa11ddc4351e54480bea637857cae6cf30e03d392737fe2b3f234115903ab43f97d4fdb49fb987650610d9a0ca51b70839d0fc9980de371acc78ac6eaf5f5ac5008eec0f5aedd0f95496f27d2858477fc54d3113fe7884047596d5705d1dd974875872fc7c9111bdc5da73b317331c543f60687fc1ecb3f3853787a64fd94335b570a99fe2544acde49f99b96ef473dbcb16315b9e7ee8c3a20feb36636c1fa39567c2efd2b7827e38ab31607f6a3cff1fc7edf8612380e4af93c620bcd6ac36
 Ctrl.hexxcghash = hexxcghash:0d18d069225d0db81b8bb979635dc9e89999a74ad6b02022189150fd
 Ctrl.hexsession_id = hexsession_id:1f42aa7a240d8b412fc26bd18f85ebefe59641d19a1e5e3681560a2c
@@ -2268,7 +2269,7 @@ Ctrl.type = type:A
 Output = b842e2900a8c1f7d7c3fa465d46142fa
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001004b9f55f17de634edb39218b30f224ae8ec64edd6e0c49dd00a52ac11e0a4089ccff931838ce5c02f449ffe33c14fd0a9f11da7d783787a03defc7931ce638a31aa11ddc4351e54480bea637857cae6cf30e03d392737fe2b3f234115903ab43f97d4fdb49fb987650610d9a0ca51b70839d0fc9980de371acc78ac6eaf5f5ac5008eec0f5aedd0f95496f27d2858477fc54d3113fe7884047596d5705d1dd974875872fc7c9111bdc5da73b317331c543f60687fc1ecb3f3853787a64fd94335b570a99fe2544acde49f99b96ef473dbcb16315b9e7ee8c3a20feb36636c1fa39567c2efd2b7827e38ab31607f6a3cff1fc7edf8612380e4af93c620bcd6ac36
 Ctrl.hexxcghash = hexxcghash:0d18d069225d0db81b8bb979635dc9e89999a74ad6b02022189150fd
 Ctrl.hexsession_id = hexsession_id:1f42aa7a240d8b412fc26bd18f85ebefe59641d19a1e5e3681560a2c
@@ -2276,7 +2277,7 @@ Ctrl.type = type:B
 Output = 5e96f771c176fafd18d4aa0bc07dc5d5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001004b9f55f17de634edb39218b30f224ae8ec64edd6e0c49dd00a52ac11e0a4089ccff931838ce5c02f449ffe33c14fd0a9f11da7d783787a03defc7931ce638a31aa11ddc4351e54480bea637857cae6cf30e03d392737fe2b3f234115903ab43f97d4fdb49fb987650610d9a0ca51b70839d0fc9980de371acc78ac6eaf5f5ac5008eec0f5aedd0f95496f27d2858477fc54d3113fe7884047596d5705d1dd974875872fc7c9111bdc5da73b317331c543f60687fc1ecb3f3853787a64fd94335b570a99fe2544acde49f99b96ef473dbcb16315b9e7ee8c3a20feb36636c1fa39567c2efd2b7827e38ab31607f6a3cff1fc7edf8612380e4af93c620bcd6ac36
 Ctrl.hexxcghash = hexxcghash:0d18d069225d0db81b8bb979635dc9e89999a74ad6b02022189150fd
 Ctrl.hexsession_id = hexsession_id:1f42aa7a240d8b412fc26bd18f85ebefe59641d19a1e5e3681560a2c
@@ -2284,7 +2285,7 @@ Ctrl.type = type:C
 Output = fe5fca0a03e6f8ac95ba4e882c64fb8c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001004b9f55f17de634edb39218b30f224ae8ec64edd6e0c49dd00a52ac11e0a4089ccff931838ce5c02f449ffe33c14fd0a9f11da7d783787a03defc7931ce638a31aa11ddc4351e54480bea637857cae6cf30e03d392737fe2b3f234115903ab43f97d4fdb49fb987650610d9a0ca51b70839d0fc9980de371acc78ac6eaf5f5ac5008eec0f5aedd0f95496f27d2858477fc54d3113fe7884047596d5705d1dd974875872fc7c9111bdc5da73b317331c543f60687fc1ecb3f3853787a64fd94335b570a99fe2544acde49f99b96ef473dbcb16315b9e7ee8c3a20feb36636c1fa39567c2efd2b7827e38ab31607f6a3cff1fc7edf8612380e4af93c620bcd6ac36
 Ctrl.hexxcghash = hexxcghash:0d18d069225d0db81b8bb979635dc9e89999a74ad6b02022189150fd
 Ctrl.hexsession_id = hexsession_id:1f42aa7a240d8b412fc26bd18f85ebefe59641d19a1e5e3681560a2c
@@ -2292,7 +2293,7 @@ Ctrl.type = type:D
 Output = b952b4e6f2010ebdac7ee10adb90f9ef
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001004b9f55f17de634edb39218b30f224ae8ec64edd6e0c49dd00a52ac11e0a4089ccff931838ce5c02f449ffe33c14fd0a9f11da7d783787a03defc7931ce638a31aa11ddc4351e54480bea637857cae6cf30e03d392737fe2b3f234115903ab43f97d4fdb49fb987650610d9a0ca51b70839d0fc9980de371acc78ac6eaf5f5ac5008eec0f5aedd0f95496f27d2858477fc54d3113fe7884047596d5705d1dd974875872fc7c9111bdc5da73b317331c543f60687fc1ecb3f3853787a64fd94335b570a99fe2544acde49f99b96ef473dbcb16315b9e7ee8c3a20feb36636c1fa39567c2efd2b7827e38ab31607f6a3cff1fc7edf8612380e4af93c620bcd6ac36
 Ctrl.hexxcghash = hexxcghash:0d18d069225d0db81b8bb979635dc9e89999a74ad6b02022189150fd
 Ctrl.hexsession_id = hexsession_id:1f42aa7a240d8b412fc26bd18f85ebefe59641d19a1e5e3681560a2c
@@ -2300,7 +2301,7 @@ Ctrl.type = type:E
 Output = 819db930507c1f8e1617dc74e78de9f4abb02b7089d764cb20d14c56
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:000001004b9f55f17de634edb39218b30f224ae8ec64edd6e0c49dd00a52ac11e0a4089ccff931838ce5c02f449ffe33c14fd0a9f11da7d783787a03defc7931ce638a31aa11ddc4351e54480bea637857cae6cf30e03d392737fe2b3f234115903ab43f97d4fdb49fb987650610d9a0ca51b70839d0fc9980de371acc78ac6eaf5f5ac5008eec0f5aedd0f95496f27d2858477fc54d3113fe7884047596d5705d1dd974875872fc7c9111bdc5da73b317331c543f60687fc1ecb3f3853787a64fd94335b570a99fe2544acde49f99b96ef473dbcb16315b9e7ee8c3a20feb36636c1fa39567c2efd2b7827e38ab31607f6a3cff1fc7edf8612380e4af93c620bcd6ac36
 Ctrl.hexxcghash = hexxcghash:0d18d069225d0db81b8bb979635dc9e89999a74ad6b02022189150fd
 Ctrl.hexsession_id = hexsession_id:1f42aa7a240d8b412fc26bd18f85ebefe59641d19a1e5e3681560a2c
@@ -2308,7 +2309,7 @@ Ctrl.type = type:F
 Output = 79be1ec6ce722e98bca50a25bbca581318b6227c9fd346d67602958f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100a0216e73007c1b53dba18acb5592ea68ab7719d9fd2f24af3e2968024933a5e68fcb1aa8b187f42972815f12d5f995c15d2d3eab84cfb869db413dcb328d045df23646e65179a53e3cbe1babcd6e6a5e300e33be1f5ed5d7eb1661a0ae6d8e6dd8f156eed726b30df6b9eee7e9457189b140de7671a1c7790938617e1bc95b8ee8bb9229f98be158a569bcb799869c445484d30d6019db44d97dcfd9b47f5a36418e3d5ec88037c172104d44ac6e770cbec415fbfce8ac9257074ca5fe003a4836001c8331f1845c1069d0610a62378e1c32ae512ffa22032f28245ee7ae957348a484bef3d295463b293975d787d45c480903f3eb35dcfd140161606f270177
 Ctrl.hexxcghash = hexxcghash:0f85b7ee92fe1a95c0aa0103f10092f04ba613a37e118f8fbb43e308
 Ctrl.hexsession_id = hexsession_id:25d9a92c96b98ecc31e6aca945899e93607848caf2c332efc03f9a0c
@@ -2316,7 +2317,7 @@ Ctrl.type = type:A
 Output = 4d40be7041ac4c74d56d53855fead94f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100a0216e73007c1b53dba18acb5592ea68ab7719d9fd2f24af3e2968024933a5e68fcb1aa8b187f42972815f12d5f995c15d2d3eab84cfb869db413dcb328d045df23646e65179a53e3cbe1babcd6e6a5e300e33be1f5ed5d7eb1661a0ae6d8e6dd8f156eed726b30df6b9eee7e9457189b140de7671a1c7790938617e1bc95b8ee8bb9229f98be158a569bcb799869c445484d30d6019db44d97dcfd9b47f5a36418e3d5ec88037c172104d44ac6e770cbec415fbfce8ac9257074ca5fe003a4836001c8331f1845c1069d0610a62378e1c32ae512ffa22032f28245ee7ae957348a484bef3d295463b293975d787d45c480903f3eb35dcfd140161606f270177
 Ctrl.hexxcghash = hexxcghash:0f85b7ee92fe1a95c0aa0103f10092f04ba613a37e118f8fbb43e308
 Ctrl.hexsession_id = hexsession_id:25d9a92c96b98ecc31e6aca945899e93607848caf2c332efc03f9a0c
@@ -2324,7 +2325,7 @@ Ctrl.type = type:B
 Output = 501781a04c919226a9e2dd6d7a880568
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100a0216e73007c1b53dba18acb5592ea68ab7719d9fd2f24af3e2968024933a5e68fcb1aa8b187f42972815f12d5f995c15d2d3eab84cfb869db413dcb328d045df23646e65179a53e3cbe1babcd6e6a5e300e33be1f5ed5d7eb1661a0ae6d8e6dd8f156eed726b30df6b9eee7e9457189b140de7671a1c7790938617e1bc95b8ee8bb9229f98be158a569bcb799869c445484d30d6019db44d97dcfd9b47f5a36418e3d5ec88037c172104d44ac6e770cbec415fbfce8ac9257074ca5fe003a4836001c8331f1845c1069d0610a62378e1c32ae512ffa22032f28245ee7ae957348a484bef3d295463b293975d787d45c480903f3eb35dcfd140161606f270177
 Ctrl.hexxcghash = hexxcghash:0f85b7ee92fe1a95c0aa0103f10092f04ba613a37e118f8fbb43e308
 Ctrl.hexsession_id = hexsession_id:25d9a92c96b98ecc31e6aca945899e93607848caf2c332efc03f9a0c
@@ -2332,7 +2333,7 @@ Ctrl.type = type:C
 Output = fe183f0e31d4bf9ebc9364e19e422385
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100a0216e73007c1b53dba18acb5592ea68ab7719d9fd2f24af3e2968024933a5e68fcb1aa8b187f42972815f12d5f995c15d2d3eab84cfb869db413dcb328d045df23646e65179a53e3cbe1babcd6e6a5e300e33be1f5ed5d7eb1661a0ae6d8e6dd8f156eed726b30df6b9eee7e9457189b140de7671a1c7790938617e1bc95b8ee8bb9229f98be158a569bcb799869c445484d30d6019db44d97dcfd9b47f5a36418e3d5ec88037c172104d44ac6e770cbec415fbfce8ac9257074ca5fe003a4836001c8331f1845c1069d0610a62378e1c32ae512ffa22032f28245ee7ae957348a484bef3d295463b293975d787d45c480903f3eb35dcfd140161606f270177
 Ctrl.hexxcghash = hexxcghash:0f85b7ee92fe1a95c0aa0103f10092f04ba613a37e118f8fbb43e308
 Ctrl.hexsession_id = hexsession_id:25d9a92c96b98ecc31e6aca945899e93607848caf2c332efc03f9a0c
@@ -2340,7 +2341,7 @@ Ctrl.type = type:D
 Output = f12c0da703e5bedb2921a0e1795eb62f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100a0216e73007c1b53dba18acb5592ea68ab7719d9fd2f24af3e2968024933a5e68fcb1aa8b187f42972815f12d5f995c15d2d3eab84cfb869db413dcb328d045df23646e65179a53e3cbe1babcd6e6a5e300e33be1f5ed5d7eb1661a0ae6d8e6dd8f156eed726b30df6b9eee7e9457189b140de7671a1c7790938617e1bc95b8ee8bb9229f98be158a569bcb799869c445484d30d6019db44d97dcfd9b47f5a36418e3d5ec88037c172104d44ac6e770cbec415fbfce8ac9257074ca5fe003a4836001c8331f1845c1069d0610a62378e1c32ae512ffa22032f28245ee7ae957348a484bef3d295463b293975d787d45c480903f3eb35dcfd140161606f270177
 Ctrl.hexxcghash = hexxcghash:0f85b7ee92fe1a95c0aa0103f10092f04ba613a37e118f8fbb43e308
 Ctrl.hexsession_id = hexsession_id:25d9a92c96b98ecc31e6aca945899e93607848caf2c332efc03f9a0c
@@ -2348,7 +2349,7 @@ Ctrl.type = type:E
 Output = 1d34b1ae23af48c25db971fe0f95c2fdb4e269ca435b90e0e22ee720
 
 KDF = SSHKDF
-Ctrl.md = md:SHA224
+Ctrl.digest = digest:SHA224
 Ctrl.hexkey = hexkey:0000010100a0216e73007c1b53dba18acb5592ea68ab7719d9fd2f24af3e2968024933a5e68fcb1aa8b187f42972815f12d5f995c15d2d3eab84cfb869db413dcb328d045df23646e65179a53e3cbe1babcd6e6a5e300e33be1f5ed5d7eb1661a0ae6d8e6dd8f156eed726b30df6b9eee7e9457189b140de7671a1c7790938617e1bc95b8ee8bb9229f98be158a569bcb799869c445484d30d6019db44d97dcfd9b47f5a36418e3d5ec88037c172104d44ac6e770cbec415fbfce8ac9257074ca5fe003a4836001c8331f1845c1069d0610a62378e1c32ae512ffa22032f28245ee7ae957348a484bef3d295463b293975d787d45c480903f3eb35dcfd140161606f270177
 Ctrl.hexxcghash = hexxcghash:0f85b7ee92fe1a95c0aa0103f10092f04ba613a37e118f8fbb43e308
 Ctrl.hexsession_id = hexsession_id:25d9a92c96b98ecc31e6aca945899e93607848caf2c332efc03f9a0c
@@ -2356,7 +2357,7 @@ Ctrl.type = type:F
 Output = b77dce4e2211c8e2b4fba841ba45d7f136323999ed9a4d306fa411a8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100875c551cef526a4a8be1a7df27e9ed354bac9afb71f53dbae905679d14f9faf2469c53457cf80a366be278965ba6255276ca2d9f4a97d271f71e50d8a9ec46253a6a906ac2c5e4f48b27a63ce08d80390a492aa43bad9d882ccac23dac88bcada4b4d426a362083dab6569c54c224dd2d87643aa227693e141ad1630ce13144e
 Ctrl.hexxcghash = hexxcghash:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
 Ctrl.hexsession_id = hexsession_id:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
@@ -2364,7 +2365,7 @@ Ctrl.type = type:A
 Output = 41ff2ead1683f1e6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100875c551cef526a4a8be1a7df27e9ed354bac9afb71f53dbae905679d14f9faf2469c53457cf80a366be278965ba6255276ca2d9f4a97d271f71e50d8a9ec46253a6a906ac2c5e4f48b27a63ce08d80390a492aa43bad9d882ccac23dac88bcada4b4d426a362083dab6569c54c224dd2d87643aa227693e141ad1630ce13144e
 Ctrl.hexxcghash = hexxcghash:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
 Ctrl.hexsession_id = hexsession_id:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
@@ -2372,7 +2373,7 @@ Ctrl.type = type:B
 Output = e619ecfd9edb50cd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100875c551cef526a4a8be1a7df27e9ed354bac9afb71f53dbae905679d14f9faf2469c53457cf80a366be278965ba6255276ca2d9f4a97d271f71e50d8a9ec46253a6a906ac2c5e4f48b27a63ce08d80390a492aa43bad9d882ccac23dac88bcada4b4d426a362083dab6569c54c224dd2d87643aa227693e141ad1630ce13144e
 Ctrl.hexxcghash = hexxcghash:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
 Ctrl.hexsession_id = hexsession_id:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
@@ -2380,7 +2381,7 @@ Ctrl.type = type:C
 Output = 4a6314d2f7511bf88fad39fb6892f3f218cafd530e72fe43
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100875c551cef526a4a8be1a7df27e9ed354bac9afb71f53dbae905679d14f9faf2469c53457cf80a366be278965ba6255276ca2d9f4a97d271f71e50d8a9ec46253a6a906ac2c5e4f48b27a63ce08d80390a492aa43bad9d882ccac23dac88bcada4b4d426a362083dab6569c54c224dd2d87643aa227693e141ad1630ce13144e
 Ctrl.hexxcghash = hexxcghash:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
 Ctrl.hexsession_id = hexsession_id:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
@@ -2388,7 +2389,7 @@ Ctrl.type = type:D
 Output = 084c15fb7f99c65ff134eeb407cee5d540c341dea45a42a5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100875c551cef526a4a8be1a7df27e9ed354bac9afb71f53dbae905679d14f9faf2469c53457cf80a366be278965ba6255276ca2d9f4a97d271f71e50d8a9ec46253a6a906ac2c5e4f48b27a63ce08d80390a492aa43bad9d882ccac23dac88bcada4b4d426a362083dab6569c54c224dd2d87643aa227693e141ad1630ce13144e
 Ctrl.hexxcghash = hexxcghash:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
 Ctrl.hexsession_id = hexsession_id:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
@@ -2396,7 +2397,7 @@ Ctrl.type = type:E
 Output = 41ec5a94fecce7707ea156a6ad29239a891621adacbedb8be70675008d6f9274
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100875c551cef526a4a8be1a7df27e9ed354bac9afb71f53dbae905679d14f9faf2469c53457cf80a366be278965ba6255276ca2d9f4a97d271f71e50d8a9ec46253a6a906ac2c5e4f48b27a63ce08d80390a492aa43bad9d882ccac23dac88bcada4b4d426a362083dab6569c54c224dd2d87643aa227693e141ad1630ce13144e
 Ctrl.hexxcghash = hexxcghash:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
 Ctrl.hexsession_id = hexsession_id:0e683fc8a9ed7c2ff02def23b2745ebc99b267daa86a4aa7697239088253f642
@@ -2404,7 +2405,7 @@ Ctrl.type = type:F
 Output = 47d3c20aba60981e47b30533623613ff1cacbcf1642fb4ad86ee712f2aed9af8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000800faa172b8c287e372bb236ad34c733695c13d77f882adc0f47e5a7f6a3de07efb101207aa5d665b619826f756591f65310bbd2c92c9384e6c6a67b42dec382fdb24c591d79ff5e47737b0f5b8479694c3adc19401704912bbfec2704d4d5bebbfc1a7fc796e277634e40851851a187ec2d37ed3f351c4596a5a0892916b4c55f
 Ctrl.hexxcghash = hexxcghash:a347f5f1e191c35f212c9324d5867efdf83026be62c2b16ae006edb3378d4006
 Ctrl.hexsession_id = hexsession_id:90befcef3ff8f920674a9fab94198cf3fd9dca24a21d3c9dba394daafbc621ed
@@ -2412,7 +2413,7 @@ Ctrl.type = type:A
 Output = 99bae6531508705f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000800faa172b8c287e372bb236ad34c733695c13d77f882adc0f47e5a7f6a3de07efb101207aa5d665b619826f756591f65310bbd2c92c9384e6c6a67b42dec382fdb24c591d79ff5e47737b0f5b8479694c3adc19401704912bbfec2704d4d5bebbfc1a7fc796e277634e40851851a187ec2d37ed3f351c4596a5a0892916b4c55f
 Ctrl.hexxcghash = hexxcghash:a347f5f1e191c35f212c9324d5867efdf83026be62c2b16ae006edb3378d4006
 Ctrl.hexsession_id = hexsession_id:90befcef3ff8f920674a9fab94198cf3fd9dca24a21d3c9dba394daafbc621ed
@@ -2420,7 +2421,7 @@ Ctrl.type = type:B
 Output = f25786f02f199737
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000800faa172b8c287e372bb236ad34c733695c13d77f882adc0f47e5a7f6a3de07efb101207aa5d665b619826f756591f65310bbd2c92c9384e6c6a67b42dec382fdb24c591d79ff5e47737b0f5b8479694c3adc19401704912bbfec2704d4d5bebbfc1a7fc796e277634e40851851a187ec2d37ed3f351c4596a5a0892916b4c55f
 Ctrl.hexxcghash = hexxcghash:a347f5f1e191c35f212c9324d5867efdf83026be62c2b16ae006edb3378d4006
 Ctrl.hexsession_id = hexsession_id:90befcef3ff8f920674a9fab94198cf3fd9dca24a21d3c9dba394daafbc621ed
@@ -2428,7 +2429,7 @@ Ctrl.type = type:C
 Output = 97621bf882266f905da78cf193fc31f642acbb60957c41b7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000800faa172b8c287e372bb236ad34c733695c13d77f882adc0f47e5a7f6a3de07efb101207aa5d665b619826f756591f65310bbd2c92c9384e6c6a67b42dec382fdb24c591d79ff5e47737b0f5b8479694c3adc19401704912bbfec2704d4d5bebbfc1a7fc796e277634e40851851a187ec2d37ed3f351c4596a5a0892916b4c55f
 Ctrl.hexxcghash = hexxcghash:a347f5f1e191c35f212c9324d5867efdf83026be62c2b16ae006edb3378d4006
 Ctrl.hexsession_id = hexsession_id:90befcef3ff8f920674a9fab94198cf3fd9dca24a21d3c9dba394daafbc621ed
@@ -2436,7 +2437,7 @@ Ctrl.type = type:D
 Output = ad98a86a2386280912efea50f790e800a7758f7dade5d77e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000800faa172b8c287e372bb236ad34c733695c13d77f882adc0f47e5a7f6a3de07efb101207aa5d665b619826f756591f65310bbd2c92c9384e6c6a67b42dec382fdb24c591d79ff5e47737b0f5b8479694c3adc19401704912bbfec2704d4d5bebbfc1a7fc796e277634e40851851a187ec2d37ed3f351c4596a5a0892916b4c55f
 Ctrl.hexxcghash = hexxcghash:a347f5f1e191c35f212c9324d5867efdf83026be62c2b16ae006edb3378d4006
 Ctrl.hexsession_id = hexsession_id:90befcef3ff8f920674a9fab94198cf3fd9dca24a21d3c9dba394daafbc621ed
@@ -2444,7 +2445,7 @@ Ctrl.type = type:E
 Output = f92d052d3cdf34dfc69bc60a489c3a3553f4356596c191931d08fa20551273b3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000800faa172b8c287e372bb236ad34c733695c13d77f882adc0f47e5a7f6a3de07efb101207aa5d665b619826f756591f65310bbd2c92c9384e6c6a67b42dec382fdb24c591d79ff5e47737b0f5b8479694c3adc19401704912bbfec2704d4d5bebbfc1a7fc796e277634e40851851a187ec2d37ed3f351c4596a5a0892916b4c55f
 Ctrl.hexxcghash = hexxcghash:a347f5f1e191c35f212c9324d5867efdf83026be62c2b16ae006edb3378d4006
 Ctrl.hexsession_id = hexsession_id:90befcef3ff8f920674a9fab94198cf3fd9dca24a21d3c9dba394daafbc621ed
@@ -2452,7 +2453,7 @@ Ctrl.type = type:F
 Output = 147a771445123f846d8ae514d7ff9b3c93b2bceb7c7c9500942161b8e2d0110f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100db8205ad53a96bd4c111ad8dc8dab8196f04557d87a5ac90b1013eec71456ca80f0a59af26f9ac6eb91ee51cd601602fe9467550d1f09f417f94e4df2aa5fb941a33ff7764b4d57bcba77f549959ca4fe5d568ff5d20702fcfef904d07f9182bd9936da1fc63d0b11cd573bc0ed9c4e7bb07b5c77c4214d457ca5b0a4410d7b0
 Ctrl.hexxcghash = hexxcghash:a85aa36aeae3f8a948ffa077509f183f2894b52930a79a06bf8783e501d9cae3
 Ctrl.hexsession_id = hexsession_id:6629bb9f32e259935f946e73543bf65830e78ddab691a8b885f3444f976fd655
@@ -2460,7 +2461,7 @@ Ctrl.type = type:A
 Output = 93da642974d71e52
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100db8205ad53a96bd4c111ad8dc8dab8196f04557d87a5ac90b1013eec71456ca80f0a59af26f9ac6eb91ee51cd601602fe9467550d1f09f417f94e4df2aa5fb941a33ff7764b4d57bcba77f549959ca4fe5d568ff5d20702fcfef904d07f9182bd9936da1fc63d0b11cd573bc0ed9c4e7bb07b5c77c4214d457ca5b0a4410d7b0
 Ctrl.hexxcghash = hexxcghash:a85aa36aeae3f8a948ffa077509f183f2894b52930a79a06bf8783e501d9cae3
 Ctrl.hexsession_id = hexsession_id:6629bb9f32e259935f946e73543bf65830e78ddab691a8b885f3444f976fd655
@@ -2468,7 +2469,7 @@ Ctrl.type = type:B
 Output = df2035ad67457151
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100db8205ad53a96bd4c111ad8dc8dab8196f04557d87a5ac90b1013eec71456ca80f0a59af26f9ac6eb91ee51cd601602fe9467550d1f09f417f94e4df2aa5fb941a33ff7764b4d57bcba77f549959ca4fe5d568ff5d20702fcfef904d07f9182bd9936da1fc63d0b11cd573bc0ed9c4e7bb07b5c77c4214d457ca5b0a4410d7b0
 Ctrl.hexxcghash = hexxcghash:a85aa36aeae3f8a948ffa077509f183f2894b52930a79a06bf8783e501d9cae3
 Ctrl.hexsession_id = hexsession_id:6629bb9f32e259935f946e73543bf65830e78ddab691a8b885f3444f976fd655
@@ -2476,7 +2477,7 @@ Ctrl.type = type:C
 Output = 42067bb0535da6701232a0f39ac7f436535af346c4786af5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100db8205ad53a96bd4c111ad8dc8dab8196f04557d87a5ac90b1013eec71456ca80f0a59af26f9ac6eb91ee51cd601602fe9467550d1f09f417f94e4df2aa5fb941a33ff7764b4d57bcba77f549959ca4fe5d568ff5d20702fcfef904d07f9182bd9936da1fc63d0b11cd573bc0ed9c4e7bb07b5c77c4214d457ca5b0a4410d7b0
 Ctrl.hexxcghash = hexxcghash:a85aa36aeae3f8a948ffa077509f183f2894b52930a79a06bf8783e501d9cae3
 Ctrl.hexsession_id = hexsession_id:6629bb9f32e259935f946e73543bf65830e78ddab691a8b885f3444f976fd655
@@ -2484,7 +2485,7 @@ Ctrl.type = type:D
 Output = 08a0181a6c373d39540409dafb1b4e2359bc249af33bcfe0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100db8205ad53a96bd4c111ad8dc8dab8196f04557d87a5ac90b1013eec71456ca80f0a59af26f9ac6eb91ee51cd601602fe9467550d1f09f417f94e4df2aa5fb941a33ff7764b4d57bcba77f549959ca4fe5d568ff5d20702fcfef904d07f9182bd9936da1fc63d0b11cd573bc0ed9c4e7bb07b5c77c4214d457ca5b0a4410d7b0
 Ctrl.hexxcghash = hexxcghash:a85aa36aeae3f8a948ffa077509f183f2894b52930a79a06bf8783e501d9cae3
 Ctrl.hexsession_id = hexsession_id:6629bb9f32e259935f946e73543bf65830e78ddab691a8b885f3444f976fd655
@@ -2492,7 +2493,7 @@ Ctrl.type = type:E
 Output = c043b5aece7cd2685c6dfb3788d7a562d6622d20f6d7e07b38aeb47c649dd99c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100db8205ad53a96bd4c111ad8dc8dab8196f04557d87a5ac90b1013eec71456ca80f0a59af26f9ac6eb91ee51cd601602fe9467550d1f09f417f94e4df2aa5fb941a33ff7764b4d57bcba77f549959ca4fe5d568ff5d20702fcfef904d07f9182bd9936da1fc63d0b11cd573bc0ed9c4e7bb07b5c77c4214d457ca5b0a4410d7b0
 Ctrl.hexxcghash = hexxcghash:a85aa36aeae3f8a948ffa077509f183f2894b52930a79a06bf8783e501d9cae3
 Ctrl.hexsession_id = hexsession_id:6629bb9f32e259935f946e73543bf65830e78ddab691a8b885f3444f976fd655
@@ -2500,7 +2501,7 @@ Ctrl.type = type:F
 Output = cbe67a93ac758d9f2a6ff580bad5a44bb1a1062c9e20d5c974decb7aa2b0faa0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100d97164957831bbc57c91e0a5c9ece230b4625d14b9d07decdc971cee28d28c2938d2f8b682bc33bd67458fb90120dd6a2ca5255fbe3daeb0325029e15b5e3135aae5081894da98fb4e4d578890c5a4b6a359097bf5e2c403f77b0398d12795d6c895ed979e792d13f5aeb3cd62799d9a509cb4bd8e2bf5d8b08498abccc0790c
 Ctrl.hexxcghash = hexxcghash:81c3e6d1a6aeb3f3fc111a9e1467a7e569b9debbfef48fd31acd0d8b9b50a647
 Ctrl.hexsession_id = hexsession_id:068d4a2ebf66a0a6f75d3e76659c72a7f70630f98872e6f48c45ad862fd9b2a4
@@ -2508,7 +2509,7 @@ Ctrl.type = type:A
 Output = 320e807fab2b10f0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100d97164957831bbc57c91e0a5c9ece230b4625d14b9d07decdc971cee28d28c2938d2f8b682bc33bd67458fb90120dd6a2ca5255fbe3daeb0325029e15b5e3135aae5081894da98fb4e4d578890c5a4b6a359097bf5e2c403f77b0398d12795d6c895ed979e792d13f5aeb3cd62799d9a509cb4bd8e2bf5d8b08498abccc0790c
 Ctrl.hexxcghash = hexxcghash:81c3e6d1a6aeb3f3fc111a9e1467a7e569b9debbfef48fd31acd0d8b9b50a647
 Ctrl.hexsession_id = hexsession_id:068d4a2ebf66a0a6f75d3e76659c72a7f70630f98872e6f48c45ad862fd9b2a4
@@ -2516,7 +2517,7 @@ Ctrl.type = type:B
 Output = 7b8f91be4dcd59b1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100d97164957831bbc57c91e0a5c9ece230b4625d14b9d07decdc971cee28d28c2938d2f8b682bc33bd67458fb90120dd6a2ca5255fbe3daeb0325029e15b5e3135aae5081894da98fb4e4d578890c5a4b6a359097bf5e2c403f77b0398d12795d6c895ed979e792d13f5aeb3cd62799d9a509cb4bd8e2bf5d8b08498abccc0790c
 Ctrl.hexxcghash = hexxcghash:81c3e6d1a6aeb3f3fc111a9e1467a7e569b9debbfef48fd31acd0d8b9b50a647
 Ctrl.hexsession_id = hexsession_id:068d4a2ebf66a0a6f75d3e76659c72a7f70630f98872e6f48c45ad862fd9b2a4
@@ -2524,7 +2525,7 @@ Ctrl.type = type:C
 Output = dec6e67a94b3ddfcd32a24d6026c6951d00b6f4402d32c1a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100d97164957831bbc57c91e0a5c9ece230b4625d14b9d07decdc971cee28d28c2938d2f8b682bc33bd67458fb90120dd6a2ca5255fbe3daeb0325029e15b5e3135aae5081894da98fb4e4d578890c5a4b6a359097bf5e2c403f77b0398d12795d6c895ed979e792d13f5aeb3cd62799d9a509cb4bd8e2bf5d8b08498abccc0790c
 Ctrl.hexxcghash = hexxcghash:81c3e6d1a6aeb3f3fc111a9e1467a7e569b9debbfef48fd31acd0d8b9b50a647
 Ctrl.hexsession_id = hexsession_id:068d4a2ebf66a0a6f75d3e76659c72a7f70630f98872e6f48c45ad862fd9b2a4
@@ -2532,7 +2533,7 @@ Ctrl.type = type:D
 Output = 2ef3cea4588ad928ac3e8874f3e1f613f2d50787495acc32
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100d97164957831bbc57c91e0a5c9ece230b4625d14b9d07decdc971cee28d28c2938d2f8b682bc33bd67458fb90120dd6a2ca5255fbe3daeb0325029e15b5e3135aae5081894da98fb4e4d578890c5a4b6a359097bf5e2c403f77b0398d12795d6c895ed979e792d13f5aeb3cd62799d9a509cb4bd8e2bf5d8b08498abccc0790c
 Ctrl.hexxcghash = hexxcghash:81c3e6d1a6aeb3f3fc111a9e1467a7e569b9debbfef48fd31acd0d8b9b50a647
 Ctrl.hexsession_id = hexsession_id:068d4a2ebf66a0a6f75d3e76659c72a7f70630f98872e6f48c45ad862fd9b2a4
@@ -2540,7 +2541,7 @@ Ctrl.type = type:E
 Output = 72f93537328eebeec1b5ca88fedb41bf4d9c6279e4fe8d13c38da72a39739ed8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100d97164957831bbc57c91e0a5c9ece230b4625d14b9d07decdc971cee28d28c2938d2f8b682bc33bd67458fb90120dd6a2ca5255fbe3daeb0325029e15b5e3135aae5081894da98fb4e4d578890c5a4b6a359097bf5e2c403f77b0398d12795d6c895ed979e792d13f5aeb3cd62799d9a509cb4bd8e2bf5d8b08498abccc0790c
 Ctrl.hexxcghash = hexxcghash:81c3e6d1a6aeb3f3fc111a9e1467a7e569b9debbfef48fd31acd0d8b9b50a647
 Ctrl.hexsession_id = hexsession_id:068d4a2ebf66a0a6f75d3e76659c72a7f70630f98872e6f48c45ad862fd9b2a4
@@ -2548,7 +2549,7 @@ Ctrl.type = type:F
 Output = 55dcf2c322b9c94686edbf9314d7c93bd9651e2ebc64f1a299d7176577d65b32
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008001223839219fa4dbaf2b88deaa058bed95793bd6079e670e88eecf0a391ae7ce2d3bf129e11273aad0d0047b84960e6f73fa3de394042b4254c7850fddc7525dcf27fb9bdcafc604626aa25e08c938a27c80ca97a4c1a2662f4e8485e016c75e4f4e6861f5bbd694bbd6492cbffa95128dab52d8a3d0316bcabd5da2c789dd62
 Ctrl.hexxcghash = hexxcghash:7817d37fe11f3499feda39bf21ce7755040a0091e61e8eb585e6299c6673db81
 Ctrl.hexsession_id = hexsession_id:2b7ef879949594c35dbccdba0ba4959e3a2fad446c5ce35666e400b7214fe69e
@@ -2556,7 +2557,7 @@ Ctrl.type = type:A
 Output = f4dbc41aa23e1621
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008001223839219fa4dbaf2b88deaa058bed95793bd6079e670e88eecf0a391ae7ce2d3bf129e11273aad0d0047b84960e6f73fa3de394042b4254c7850fddc7525dcf27fb9bdcafc604626aa25e08c938a27c80ca97a4c1a2662f4e8485e016c75e4f4e6861f5bbd694bbd6492cbffa95128dab52d8a3d0316bcabd5da2c789dd62
 Ctrl.hexxcghash = hexxcghash:7817d37fe11f3499feda39bf21ce7755040a0091e61e8eb585e6299c6673db81
 Ctrl.hexsession_id = hexsession_id:2b7ef879949594c35dbccdba0ba4959e3a2fad446c5ce35666e400b7214fe69e
@@ -2564,7 +2565,7 @@ Ctrl.type = type:B
 Output = e53b40c511180817
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008001223839219fa4dbaf2b88deaa058bed95793bd6079e670e88eecf0a391ae7ce2d3bf129e11273aad0d0047b84960e6f73fa3de394042b4254c7850fddc7525dcf27fb9bdcafc604626aa25e08c938a27c80ca97a4c1a2662f4e8485e016c75e4f4e6861f5bbd694bbd6492cbffa95128dab52d8a3d0316bcabd5da2c789dd62
 Ctrl.hexxcghash = hexxcghash:7817d37fe11f3499feda39bf21ce7755040a0091e61e8eb585e6299c6673db81
 Ctrl.hexsession_id = hexsession_id:2b7ef879949594c35dbccdba0ba4959e3a2fad446c5ce35666e400b7214fe69e
@@ -2572,7 +2573,7 @@ Ctrl.type = type:C
 Output = 70fed9412989cf5de908ad429cb92065fd5ccc081477abba
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008001223839219fa4dbaf2b88deaa058bed95793bd6079e670e88eecf0a391ae7ce2d3bf129e11273aad0d0047b84960e6f73fa3de394042b4254c7850fddc7525dcf27fb9bdcafc604626aa25e08c938a27c80ca97a4c1a2662f4e8485e016c75e4f4e6861f5bbd694bbd6492cbffa95128dab52d8a3d0316bcabd5da2c789dd62
 Ctrl.hexxcghash = hexxcghash:7817d37fe11f3499feda39bf21ce7755040a0091e61e8eb585e6299c6673db81
 Ctrl.hexsession_id = hexsession_id:2b7ef879949594c35dbccdba0ba4959e3a2fad446c5ce35666e400b7214fe69e
@@ -2580,7 +2581,7 @@ Ctrl.type = type:D
 Output = 3afdb0b4b4bc13e8731bb92e541b7d82a0b20d8878ce184b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008001223839219fa4dbaf2b88deaa058bed95793bd6079e670e88eecf0a391ae7ce2d3bf129e11273aad0d0047b84960e6f73fa3de394042b4254c7850fddc7525dcf27fb9bdcafc604626aa25e08c938a27c80ca97a4c1a2662f4e8485e016c75e4f4e6861f5bbd694bbd6492cbffa95128dab52d8a3d0316bcabd5da2c789dd62
 Ctrl.hexxcghash = hexxcghash:7817d37fe11f3499feda39bf21ce7755040a0091e61e8eb585e6299c6673db81
 Ctrl.hexsession_id = hexsession_id:2b7ef879949594c35dbccdba0ba4959e3a2fad446c5ce35666e400b7214fe69e
@@ -2588,7 +2589,7 @@ Ctrl.type = type:E
 Output = 59937f257aeef0806038543ced541990e5c2243881818edf2c522a54b64e9e93
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008001223839219fa4dbaf2b88deaa058bed95793bd6079e670e88eecf0a391ae7ce2d3bf129e11273aad0d0047b84960e6f73fa3de394042b4254c7850fddc7525dcf27fb9bdcafc604626aa25e08c938a27c80ca97a4c1a2662f4e8485e016c75e4f4e6861f5bbd694bbd6492cbffa95128dab52d8a3d0316bcabd5da2c789dd62
 Ctrl.hexxcghash = hexxcghash:7817d37fe11f3499feda39bf21ce7755040a0091e61e8eb585e6299c6673db81
 Ctrl.hexsession_id = hexsession_id:2b7ef879949594c35dbccdba0ba4959e3a2fad446c5ce35666e400b7214fe69e
@@ -2596,7 +2597,7 @@ Ctrl.type = type:F
 Output = 187532105293274b841918e3ab51f5dd0453d4331e85f4e06b775dbce4979cdd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000807d3783ce1f598c3279e8a33f3e8bfe9c255979034f43d107bb3dd6cb21ff67d945594929f2fd7bef74679be81d3ad6c1b472293d1060242d720ed2fb250fde838064eec64d75cb9d5d2ec09c9e67e3bf48c0d0a92577f8bf6e05cfcbaafcd243369f30f14d24a4ad2c1aaff528e03198227135d26839fd45cd60678ae41307c2
 Ctrl.hexxcghash = hexxcghash:2efc2c1be24e1259105757bbd2c518d62ae52400451347aa90e2aab00bc58864
 Ctrl.hexsession_id = hexsession_id:2df7d0dbcb1beb17ef1a8b9884c9d6d8833b5039797a5fce61e7a2490405b323
@@ -2604,7 +2605,7 @@ Ctrl.type = type:A
 Output = 3cc220d5bb9b5346
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000807d3783ce1f598c3279e8a33f3e8bfe9c255979034f43d107bb3dd6cb21ff67d945594929f2fd7bef74679be81d3ad6c1b472293d1060242d720ed2fb250fde838064eec64d75cb9d5d2ec09c9e67e3bf48c0d0a92577f8bf6e05cfcbaafcd243369f30f14d24a4ad2c1aaff528e03198227135d26839fd45cd60678ae41307c2
 Ctrl.hexxcghash = hexxcghash:2efc2c1be24e1259105757bbd2c518d62ae52400451347aa90e2aab00bc58864
 Ctrl.hexsession_id = hexsession_id:2df7d0dbcb1beb17ef1a8b9884c9d6d8833b5039797a5fce61e7a2490405b323
@@ -2612,7 +2613,7 @@ Ctrl.type = type:B
 Output = 051e3c79aede7e41
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000807d3783ce1f598c3279e8a33f3e8bfe9c255979034f43d107bb3dd6cb21ff67d945594929f2fd7bef74679be81d3ad6c1b472293d1060242d720ed2fb250fde838064eec64d75cb9d5d2ec09c9e67e3bf48c0d0a92577f8bf6e05cfcbaafcd243369f30f14d24a4ad2c1aaff528e03198227135d26839fd45cd60678ae41307c2
 Ctrl.hexxcghash = hexxcghash:2efc2c1be24e1259105757bbd2c518d62ae52400451347aa90e2aab00bc58864
 Ctrl.hexsession_id = hexsession_id:2df7d0dbcb1beb17ef1a8b9884c9d6d8833b5039797a5fce61e7a2490405b323
@@ -2620,7 +2621,7 @@ Ctrl.type = type:C
 Output = 44c2b4725965ee9a2bce58d38e2e9a778263c415b21a25be
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000807d3783ce1f598c3279e8a33f3e8bfe9c255979034f43d107bb3dd6cb21ff67d945594929f2fd7bef74679be81d3ad6c1b472293d1060242d720ed2fb250fde838064eec64d75cb9d5d2ec09c9e67e3bf48c0d0a92577f8bf6e05cfcbaafcd243369f30f14d24a4ad2c1aaff528e03198227135d26839fd45cd60678ae41307c2
 Ctrl.hexxcghash = hexxcghash:2efc2c1be24e1259105757bbd2c518d62ae52400451347aa90e2aab00bc58864
 Ctrl.hexsession_id = hexsession_id:2df7d0dbcb1beb17ef1a8b9884c9d6d8833b5039797a5fce61e7a2490405b323
@@ -2628,7 +2629,7 @@ Ctrl.type = type:D
 Output = d5de7a801956b934d820f9aa51bf1dae2a7aec7ce5ce4e50
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000807d3783ce1f598c3279e8a33f3e8bfe9c255979034f43d107bb3dd6cb21ff67d945594929f2fd7bef74679be81d3ad6c1b472293d1060242d720ed2fb250fde838064eec64d75cb9d5d2ec09c9e67e3bf48c0d0a92577f8bf6e05cfcbaafcd243369f30f14d24a4ad2c1aaff528e03198227135d26839fd45cd60678ae41307c2
 Ctrl.hexxcghash = hexxcghash:2efc2c1be24e1259105757bbd2c518d62ae52400451347aa90e2aab00bc58864
 Ctrl.hexsession_id = hexsession_id:2df7d0dbcb1beb17ef1a8b9884c9d6d8833b5039797a5fce61e7a2490405b323
@@ -2636,7 +2637,7 @@ Ctrl.type = type:E
 Output = 7d2039a6505e3220535fde0ff71464f3971580f50711356760b225fc3053fc19
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000000807d3783ce1f598c3279e8a33f3e8bfe9c255979034f43d107bb3dd6cb21ff67d945594929f2fd7bef74679be81d3ad6c1b472293d1060242d720ed2fb250fde838064eec64d75cb9d5d2ec09c9e67e3bf48c0d0a92577f8bf6e05cfcbaafcd243369f30f14d24a4ad2c1aaff528e03198227135d26839fd45cd60678ae41307c2
 Ctrl.hexxcghash = hexxcghash:2efc2c1be24e1259105757bbd2c518d62ae52400451347aa90e2aab00bc58864
 Ctrl.hexsession_id = hexsession_id:2df7d0dbcb1beb17ef1a8b9884c9d6d8833b5039797a5fce61e7a2490405b323
@@ -2644,7 +2645,7 @@ Ctrl.type = type:F
 Output = b0972348a031ef2e87d42611e53cf0c4782d759ecdcc1390318eb11e1925ac35
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b44b386751753bf1fbfe100b11761766aaef16b2786462ba9561d3b493581254a1c1556ef611fec70146a864f8860c6317f294d06aec94129740c78035411992492825554362d25bf2c43a2e8a4d22e5d4777c593c8686966684b95e8e4535fc0b4a0e53264f22cf568469e829a303cdd06c09d8f74ccef6b6028fde782a7285
 Ctrl.hexxcghash = hexxcghash:8c691585cffd38a6ad0fd751da66c1a0f2b46ad6c12348b5a89cd24f39e76517
 Ctrl.hexsession_id = hexsession_id:2d93238fe20a860db2fb8fb4c5a0525a2f8817abbb53773e4af9fb366a213506
@@ -2652,7 +2653,7 @@ Ctrl.type = type:A
 Output = cdb047beecd92d84
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b44b386751753bf1fbfe100b11761766aaef16b2786462ba9561d3b493581254a1c1556ef611fec70146a864f8860c6317f294d06aec94129740c78035411992492825554362d25bf2c43a2e8a4d22e5d4777c593c8686966684b95e8e4535fc0b4a0e53264f22cf568469e829a303cdd06c09d8f74ccef6b6028fde782a7285
 Ctrl.hexxcghash = hexxcghash:8c691585cffd38a6ad0fd751da66c1a0f2b46ad6c12348b5a89cd24f39e76517
 Ctrl.hexsession_id = hexsession_id:2d93238fe20a860db2fb8fb4c5a0525a2f8817abbb53773e4af9fb366a213506
@@ -2660,7 +2661,7 @@ Ctrl.type = type:B
 Output = ef378e894d8f675e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b44b386751753bf1fbfe100b11761766aaef16b2786462ba9561d3b493581254a1c1556ef611fec70146a864f8860c6317f294d06aec94129740c78035411992492825554362d25bf2c43a2e8a4d22e5d4777c593c8686966684b95e8e4535fc0b4a0e53264f22cf568469e829a303cdd06c09d8f74ccef6b6028fde782a7285
 Ctrl.hexxcghash = hexxcghash:8c691585cffd38a6ad0fd751da66c1a0f2b46ad6c12348b5a89cd24f39e76517
 Ctrl.hexsession_id = hexsession_id:2d93238fe20a860db2fb8fb4c5a0525a2f8817abbb53773e4af9fb366a213506
@@ -2668,7 +2669,7 @@ Ctrl.type = type:C
 Output = 23ee42a437801e87348b3999bde76147a8731e318db57752
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b44b386751753bf1fbfe100b11761766aaef16b2786462ba9561d3b493581254a1c1556ef611fec70146a864f8860c6317f294d06aec94129740c78035411992492825554362d25bf2c43a2e8a4d22e5d4777c593c8686966684b95e8e4535fc0b4a0e53264f22cf568469e829a303cdd06c09d8f74ccef6b6028fde782a7285
 Ctrl.hexxcghash = hexxcghash:8c691585cffd38a6ad0fd751da66c1a0f2b46ad6c12348b5a89cd24f39e76517
 Ctrl.hexsession_id = hexsession_id:2d93238fe20a860db2fb8fb4c5a0525a2f8817abbb53773e4af9fb366a213506
@@ -2676,7 +2677,7 @@ Ctrl.type = type:D
 Output = a3f50e3d14498f15e1f111cc929648011d6abfb58e90df1c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b44b386751753bf1fbfe100b11761766aaef16b2786462ba9561d3b493581254a1c1556ef611fec70146a864f8860c6317f294d06aec94129740c78035411992492825554362d25bf2c43a2e8a4d22e5d4777c593c8686966684b95e8e4535fc0b4a0e53264f22cf568469e829a303cdd06c09d8f74ccef6b6028fde782a7285
 Ctrl.hexxcghash = hexxcghash:8c691585cffd38a6ad0fd751da66c1a0f2b46ad6c12348b5a89cd24f39e76517
 Ctrl.hexsession_id = hexsession_id:2d93238fe20a860db2fb8fb4c5a0525a2f8817abbb53773e4af9fb366a213506
@@ -2684,7 +2685,7 @@ Ctrl.type = type:E
 Output = fb6a020561e46e521344cb671a50175afd63ded91eedaa1b2879c3a63761674d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b44b386751753bf1fbfe100b11761766aaef16b2786462ba9561d3b493581254a1c1556ef611fec70146a864f8860c6317f294d06aec94129740c78035411992492825554362d25bf2c43a2e8a4d22e5d4777c593c8686966684b95e8e4535fc0b4a0e53264f22cf568469e829a303cdd06c09d8f74ccef6b6028fde782a7285
 Ctrl.hexxcghash = hexxcghash:8c691585cffd38a6ad0fd751da66c1a0f2b46ad6c12348b5a89cd24f39e76517
 Ctrl.hexsession_id = hexsession_id:2d93238fe20a860db2fb8fb4c5a0525a2f8817abbb53773e4af9fb366a213506
@@ -2692,7 +2693,7 @@ Ctrl.type = type:F
 Output = 567a79e7c4b10d62a420ce2ea740661c08d9459ed636ecb4edebcedb17b0baba
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b3462ee942f026de0922ab88b6ebf5ee2c968a4e12cbf374593f3542c6eb619ea1ec29b958c65a83305c37008de3b691ec020cc989e6c5393dae36bbb3bf0d1a29ed0bab6d23f60e63e277119b7a4c0a5fa96d9c043a5ace58034052ffb71b8bf0eaea8a6bc9a9834c512d7470122c71908a44ef7f3227b512f6971c82436e96
 Ctrl.hexxcghash = hexxcghash:3d5d7f742b08976755e2eb8457f1d9401d918bbf7e201fe0742f00ae799082df
 Ctrl.hexsession_id = hexsession_id:50bcad2970e07c3ad3f14db05d451d77304fe70927ba26815fcaf1f3a723af91
@@ -2700,7 +2701,7 @@ Ctrl.type = type:A
 Output = 1f9e7ad5592ac73d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b3462ee942f026de0922ab88b6ebf5ee2c968a4e12cbf374593f3542c6eb619ea1ec29b958c65a83305c37008de3b691ec020cc989e6c5393dae36bbb3bf0d1a29ed0bab6d23f60e63e277119b7a4c0a5fa96d9c043a5ace58034052ffb71b8bf0eaea8a6bc9a9834c512d7470122c71908a44ef7f3227b512f6971c82436e96
 Ctrl.hexxcghash = hexxcghash:3d5d7f742b08976755e2eb8457f1d9401d918bbf7e201fe0742f00ae799082df
 Ctrl.hexsession_id = hexsession_id:50bcad2970e07c3ad3f14db05d451d77304fe70927ba26815fcaf1f3a723af91
@@ -2708,7 +2709,7 @@ Ctrl.type = type:B
 Output = 15b254fe3510dd77
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b3462ee942f026de0922ab88b6ebf5ee2c968a4e12cbf374593f3542c6eb619ea1ec29b958c65a83305c37008de3b691ec020cc989e6c5393dae36bbb3bf0d1a29ed0bab6d23f60e63e277119b7a4c0a5fa96d9c043a5ace58034052ffb71b8bf0eaea8a6bc9a9834c512d7470122c71908a44ef7f3227b512f6971c82436e96
 Ctrl.hexxcghash = hexxcghash:3d5d7f742b08976755e2eb8457f1d9401d918bbf7e201fe0742f00ae799082df
 Ctrl.hexsession_id = hexsession_id:50bcad2970e07c3ad3f14db05d451d77304fe70927ba26815fcaf1f3a723af91
@@ -2716,7 +2717,7 @@ Ctrl.type = type:C
 Output = 88eadd5802e1a748284684438eb1b1bdc9b20ea30c59950d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b3462ee942f026de0922ab88b6ebf5ee2c968a4e12cbf374593f3542c6eb619ea1ec29b958c65a83305c37008de3b691ec020cc989e6c5393dae36bbb3bf0d1a29ed0bab6d23f60e63e277119b7a4c0a5fa96d9c043a5ace58034052ffb71b8bf0eaea8a6bc9a9834c512d7470122c71908a44ef7f3227b512f6971c82436e96
 Ctrl.hexxcghash = hexxcghash:3d5d7f742b08976755e2eb8457f1d9401d918bbf7e201fe0742f00ae799082df
 Ctrl.hexsession_id = hexsession_id:50bcad2970e07c3ad3f14db05d451d77304fe70927ba26815fcaf1f3a723af91
@@ -2724,7 +2725,7 @@ Ctrl.type = type:D
 Output = 277c2c4ad3d4a3bec4bdc5329bb5f9d4e39aa06b1e115e77
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b3462ee942f026de0922ab88b6ebf5ee2c968a4e12cbf374593f3542c6eb619ea1ec29b958c65a83305c37008de3b691ec020cc989e6c5393dae36bbb3bf0d1a29ed0bab6d23f60e63e277119b7a4c0a5fa96d9c043a5ace58034052ffb71b8bf0eaea8a6bc9a9834c512d7470122c71908a44ef7f3227b512f6971c82436e96
 Ctrl.hexxcghash = hexxcghash:3d5d7f742b08976755e2eb8457f1d9401d918bbf7e201fe0742f00ae799082df
 Ctrl.hexsession_id = hexsession_id:50bcad2970e07c3ad3f14db05d451d77304fe70927ba26815fcaf1f3a723af91
@@ -2732,7 +2733,7 @@ Ctrl.type = type:E
 Output = 090d2f273a690ed1d67dd9919c34385b18a661f8657b84bef6832f2396771979
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100b3462ee942f026de0922ab88b6ebf5ee2c968a4e12cbf374593f3542c6eb619ea1ec29b958c65a83305c37008de3b691ec020cc989e6c5393dae36bbb3bf0d1a29ed0bab6d23f60e63e277119b7a4c0a5fa96d9c043a5ace58034052ffb71b8bf0eaea8a6bc9a9834c512d7470122c71908a44ef7f3227b512f6971c82436e96
 Ctrl.hexxcghash = hexxcghash:3d5d7f742b08976755e2eb8457f1d9401d918bbf7e201fe0742f00ae799082df
 Ctrl.hexsession_id = hexsession_id:50bcad2970e07c3ad3f14db05d451d77304fe70927ba26815fcaf1f3a723af91
@@ -2740,7 +2741,7 @@ Ctrl.type = type:F
 Output = 1f3082fa5ac8ec565595c4c5b8a7ddbba88ed4936fca913bba6a8715dc856f30
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100831889c603d4dc01d0d9f19f07ccadb6a9fa7662305277d59efbc872f38325de2ec2151f58649f5fd15ff3a099f0191dca69be0b9c88ef729fe74af849cc8e7479f8a5406842af88e12167607103cda449a1394c86b2c21d4083cdee216f74078d4e878b352df901727870815528ae99f74f25c21a8a39772940d871badb39a6
 Ctrl.hexxcghash = hexxcghash:f77992d066bc305419a6c1b0879008856287b95ec20c2b1be5a5c8189cadbbb1
 Ctrl.hexsession_id = hexsession_id:15bd2e8c86d23eace4a581377ef8a3f5266dbd081cfcd01ab2b68506438228a2
@@ -2748,7 +2749,7 @@ Ctrl.type = type:A
 Output = 3aa08d67c81310b7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100831889c603d4dc01d0d9f19f07ccadb6a9fa7662305277d59efbc872f38325de2ec2151f58649f5fd15ff3a099f0191dca69be0b9c88ef729fe74af849cc8e7479f8a5406842af88e12167607103cda449a1394c86b2c21d4083cdee216f74078d4e878b352df901727870815528ae99f74f25c21a8a39772940d871badb39a6
 Ctrl.hexxcghash = hexxcghash:f77992d066bc305419a6c1b0879008856287b95ec20c2b1be5a5c8189cadbbb1
 Ctrl.hexsession_id = hexsession_id:15bd2e8c86d23eace4a581377ef8a3f5266dbd081cfcd01ab2b68506438228a2
@@ -2756,7 +2757,7 @@ Ctrl.type = type:B
 Output = cf46596878a17a87
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100831889c603d4dc01d0d9f19f07ccadb6a9fa7662305277d59efbc872f38325de2ec2151f58649f5fd15ff3a099f0191dca69be0b9c88ef729fe74af849cc8e7479f8a5406842af88e12167607103cda449a1394c86b2c21d4083cdee216f74078d4e878b352df901727870815528ae99f74f25c21a8a39772940d871badb39a6
 Ctrl.hexxcghash = hexxcghash:f77992d066bc305419a6c1b0879008856287b95ec20c2b1be5a5c8189cadbbb1
 Ctrl.hexsession_id = hexsession_id:15bd2e8c86d23eace4a581377ef8a3f5266dbd081cfcd01ab2b68506438228a2
@@ -2764,7 +2765,7 @@ Ctrl.type = type:C
 Output = 871db438b8b33c2102ddab0c1f7be51ee4c2cbdf52a01a58
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100831889c603d4dc01d0d9f19f07ccadb6a9fa7662305277d59efbc872f38325de2ec2151f58649f5fd15ff3a099f0191dca69be0b9c88ef729fe74af849cc8e7479f8a5406842af88e12167607103cda449a1394c86b2c21d4083cdee216f74078d4e878b352df901727870815528ae99f74f25c21a8a39772940d871badb39a6
 Ctrl.hexxcghash = hexxcghash:f77992d066bc305419a6c1b0879008856287b95ec20c2b1be5a5c8189cadbbb1
 Ctrl.hexsession_id = hexsession_id:15bd2e8c86d23eace4a581377ef8a3f5266dbd081cfcd01ab2b68506438228a2
@@ -2772,7 +2773,7 @@ Ctrl.type = type:D
 Output = 04ac13599b84c22be0f1e5f7b96def31598e6ad36be412e8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100831889c603d4dc01d0d9f19f07ccadb6a9fa7662305277d59efbc872f38325de2ec2151f58649f5fd15ff3a099f0191dca69be0b9c88ef729fe74af849cc8e7479f8a5406842af88e12167607103cda449a1394c86b2c21d4083cdee216f74078d4e878b352df901727870815528ae99f74f25c21a8a39772940d871badb39a6
 Ctrl.hexxcghash = hexxcghash:f77992d066bc305419a6c1b0879008856287b95ec20c2b1be5a5c8189cadbbb1
 Ctrl.hexsession_id = hexsession_id:15bd2e8c86d23eace4a581377ef8a3f5266dbd081cfcd01ab2b68506438228a2
@@ -2780,7 +2781,7 @@ Ctrl.type = type:E
 Output = f00c83a8afb5d1793749d4aae825b80e67ccd7f67e08f572222ccf42126ea2f0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000008100831889c603d4dc01d0d9f19f07ccadb6a9fa7662305277d59efbc872f38325de2ec2151f58649f5fd15ff3a099f0191dca69be0b9c88ef729fe74af849cc8e7479f8a5406842af88e12167607103cda449a1394c86b2c21d4083cdee216f74078d4e878b352df901727870815528ae99f74f25c21a8a39772940d871badb39a6
 Ctrl.hexxcghash = hexxcghash:f77992d066bc305419a6c1b0879008856287b95ec20c2b1be5a5c8189cadbbb1
 Ctrl.hexsession_id = hexsession_id:15bd2e8c86d23eace4a581377ef8a3f5266dbd081cfcd01ab2b68506438228a2
@@ -2788,7 +2789,7 @@ Ctrl.type = type:F
 Output = df0570749d67136095b0dda6d461676b7eeb9a386f126306d436cab16dfd1b3c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000081008fa89f9f89a2a2417a9461451a4b97343afd46552a8700e588638b0ef0ae568ffbaee2727ae3ae96271aa33b8439c1a4bad313ea42605ae0902817d91577b6a3c72fc576ee29544c1d6323bad205317d2265c533d82ed27a2dea64a8545c64e9772e81ce1cbfe265a51acfae74b72d5365366263541e50a567c3ffa594eac071
 Ctrl.hexxcghash = hexxcghash:4d071ee398757c548fa72f77ed94d5b158a311d3655bb7a6e324c4e2a26be84f
 Ctrl.hexsession_id = hexsession_id:d1d34becf667002ace16be10726cab3c7d18ce7414759f62a83cb4cfaaed77f4
@@ -2796,7 +2797,7 @@ Ctrl.type = type:A
 Output = fad800cbf8975a01
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000081008fa89f9f89a2a2417a9461451a4b97343afd46552a8700e588638b0ef0ae568ffbaee2727ae3ae96271aa33b8439c1a4bad313ea42605ae0902817d91577b6a3c72fc576ee29544c1d6323bad205317d2265c533d82ed27a2dea64a8545c64e9772e81ce1cbfe265a51acfae74b72d5365366263541e50a567c3ffa594eac071
 Ctrl.hexxcghash = hexxcghash:4d071ee398757c548fa72f77ed94d5b158a311d3655bb7a6e324c4e2a26be84f
 Ctrl.hexsession_id = hexsession_id:d1d34becf667002ace16be10726cab3c7d18ce7414759f62a83cb4cfaaed77f4
@@ -2804,7 +2805,7 @@ Ctrl.type = type:B
 Output = 679a118bda1f15a9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000081008fa89f9f89a2a2417a9461451a4b97343afd46552a8700e588638b0ef0ae568ffbaee2727ae3ae96271aa33b8439c1a4bad313ea42605ae0902817d91577b6a3c72fc576ee29544c1d6323bad205317d2265c533d82ed27a2dea64a8545c64e9772e81ce1cbfe265a51acfae74b72d5365366263541e50a567c3ffa594eac071
 Ctrl.hexxcghash = hexxcghash:4d071ee398757c548fa72f77ed94d5b158a311d3655bb7a6e324c4e2a26be84f
 Ctrl.hexsession_id = hexsession_id:d1d34becf667002ace16be10726cab3c7d18ce7414759f62a83cb4cfaaed77f4
@@ -2812,7 +2813,7 @@ Ctrl.type = type:C
 Output = 5193e9b3b10b7939b79b967b98e6cf3396758eaf8263edf2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000081008fa89f9f89a2a2417a9461451a4b97343afd46552a8700e588638b0ef0ae568ffbaee2727ae3ae96271aa33b8439c1a4bad313ea42605ae0902817d91577b6a3c72fc576ee29544c1d6323bad205317d2265c533d82ed27a2dea64a8545c64e9772e81ce1cbfe265a51acfae74b72d5365366263541e50a567c3ffa594eac071
 Ctrl.hexxcghash = hexxcghash:4d071ee398757c548fa72f77ed94d5b158a311d3655bb7a6e324c4e2a26be84f
 Ctrl.hexsession_id = hexsession_id:d1d34becf667002ace16be10726cab3c7d18ce7414759f62a83cb4cfaaed77f4
@@ -2820,7 +2821,7 @@ Ctrl.type = type:D
 Output = 3f5de8bec6d737836d3a91480ac76c19d0a90bc146f02d5c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000081008fa89f9f89a2a2417a9461451a4b97343afd46552a8700e588638b0ef0ae568ffbaee2727ae3ae96271aa33b8439c1a4bad313ea42605ae0902817d91577b6a3c72fc576ee29544c1d6323bad205317d2265c533d82ed27a2dea64a8545c64e9772e81ce1cbfe265a51acfae74b72d5365366263541e50a567c3ffa594eac071
 Ctrl.hexxcghash = hexxcghash:4d071ee398757c548fa72f77ed94d5b158a311d3655bb7a6e324c4e2a26be84f
 Ctrl.hexsession_id = hexsession_id:d1d34becf667002ace16be10726cab3c7d18ce7414759f62a83cb4cfaaed77f4
@@ -2828,7 +2829,7 @@ Ctrl.type = type:E
 Output = ce7be4fffd0ffd09ff45889d10c7be0edf922422d01cb71b737c6149bb1a2d05
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000081008fa89f9f89a2a2417a9461451a4b97343afd46552a8700e588638b0ef0ae568ffbaee2727ae3ae96271aa33b8439c1a4bad313ea42605ae0902817d91577b6a3c72fc576ee29544c1d6323bad205317d2265c533d82ed27a2dea64a8545c64e9772e81ce1cbfe265a51acfae74b72d5365366263541e50a567c3ffa594eac071
 Ctrl.hexxcghash = hexxcghash:4d071ee398757c548fa72f77ed94d5b158a311d3655bb7a6e324c4e2a26be84f
 Ctrl.hexsession_id = hexsession_id:d1d34becf667002ace16be10726cab3c7d18ce7414759f62a83cb4cfaaed77f4
@@ -2836,7 +2837,7 @@ Ctrl.type = type:F
 Output = 60f413c9bcc42dcf0acc53d513dd8bc703f7e5d668f4e043f13028dcf40880b2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001006ac382eaaca093e125e25c24bebc84640c11987507344b5c739ceb84a9e0b222b9a8b51c839e5ebe49cfadbfb39599764ed522099dc912751950dc7dc97fbdc06328b68f22781fd315af568009a5509e5b87a11bf527c056daffd82ab6cbc25cca37143459e7bc63bcde52757adeb7df01cf12173f1fef8102ec5ab142c213dd9d30696278a8d8bc32dde9592d28c078c6d92b947d825acaab6494846a49de24b9623f4889e8adc38e8c669effef176040ad945e90a7d3eec15efeee78ae71043c96511103a16ba7caf0acd0642efdbe809934faa1a5f1bd11043649b25ccd1fee2e38815d4d5f5fc6b4102969f21c22ae1b0e7d3603a556a13262ff628de222
 Ctrl.hexxcghash = hexxcghash:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
 Ctrl.hexsession_id = hexsession_id:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
@@ -2844,7 +2845,7 @@ Ctrl.type = type:A
 Output = 81f0330ef6f05361b3823bfded6e1de9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001006ac382eaaca093e125e25c24bebc84640c11987507344b5c739ceb84a9e0b222b9a8b51c839e5ebe49cfadbfb39599764ed522099dc912751950dc7dc97fbdc06328b68f22781fd315af568009a5509e5b87a11bf527c056daffd82ab6cbc25cca37143459e7bc63bcde52757adeb7df01cf12173f1fef8102ec5ab142c213dd9d30696278a8d8bc32dde9592d28c078c6d92b947d825acaab6494846a49de24b9623f4889e8adc38e8c669effef176040ad945e90a7d3eec15efeee78ae71043c96511103a16ba7caf0acd0642efdbe809934faa1a5f1bd11043649b25ccd1fee2e38815d4d5f5fc6b4102969f21c22ae1b0e7d3603a556a13262ff628de222
 Ctrl.hexxcghash = hexxcghash:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
 Ctrl.hexsession_id = hexsession_id:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
@@ -2852,7 +2853,7 @@ Ctrl.type = type:B
 Output = 3f6fd2065eeb2b0b1d93195a1fed48a5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001006ac382eaaca093e125e25c24bebc84640c11987507344b5c739ceb84a9e0b222b9a8b51c839e5ebe49cfadbfb39599764ed522099dc912751950dc7dc97fbdc06328b68f22781fd315af568009a5509e5b87a11bf527c056daffd82ab6cbc25cca37143459e7bc63bcde52757adeb7df01cf12173f1fef8102ec5ab142c213dd9d30696278a8d8bc32dde9592d28c078c6d92b947d825acaab6494846a49de24b9623f4889e8adc38e8c669effef176040ad945e90a7d3eec15efeee78ae71043c96511103a16ba7caf0acd0642efdbe809934faa1a5f1bd11043649b25ccd1fee2e38815d4d5f5fc6b4102969f21c22ae1b0e7d3603a556a13262ff628de222
 Ctrl.hexxcghash = hexxcghash:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
 Ctrl.hexsession_id = hexsession_id:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
@@ -2860,7 +2861,7 @@ Ctrl.type = type:C
 Output = c35471034e6fd6547613178e23435f21
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001006ac382eaaca093e125e25c24bebc84640c11987507344b5c739ceb84a9e0b222b9a8b51c839e5ebe49cfadbfb39599764ed522099dc912751950dc7dc97fbdc06328b68f22781fd315af568009a5509e5b87a11bf527c056daffd82ab6cbc25cca37143459e7bc63bcde52757adeb7df01cf12173f1fef8102ec5ab142c213dd9d30696278a8d8bc32dde9592d28c078c6d92b947d825acaab6494846a49de24b9623f4889e8adc38e8c669effef176040ad945e90a7d3eec15efeee78ae71043c96511103a16ba7caf0acd0642efdbe809934faa1a5f1bd11043649b25ccd1fee2e38815d4d5f5fc6b4102969f21c22ae1b0e7d3603a556a13262ff628de222
 Ctrl.hexxcghash = hexxcghash:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
 Ctrl.hexsession_id = hexsession_id:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
@@ -2868,7 +2869,7 @@ Ctrl.type = type:D
 Output = 7e9d79032090d99f98b015634dd9f462
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001006ac382eaaca093e125e25c24bebc84640c11987507344b5c739ceb84a9e0b222b9a8b51c839e5ebe49cfadbfb39599764ed522099dc912751950dc7dc97fbdc06328b68f22781fd315af568009a5509e5b87a11bf527c056daffd82ab6cbc25cca37143459e7bc63bcde52757adeb7df01cf12173f1fef8102ec5ab142c213dd9d30696278a8d8bc32dde9592d28c078c6d92b947d825acaab6494846a49de24b9623f4889e8adc38e8c669effef176040ad945e90a7d3eec15efeee78ae71043c96511103a16ba7caf0acd0642efdbe809934faa1a5f1bd11043649b25ccd1fee2e38815d4d5f5fc6b4102969f21c22ae1b0e7d3603a556a13262ff628de222
 Ctrl.hexxcghash = hexxcghash:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
 Ctrl.hexsession_id = hexsession_id:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
@@ -2876,7 +2877,7 @@ Ctrl.type = type:E
 Output = 24ee559ad7ce712b685d0b2271e443c17ab1d1dceb5a360569d25d5dc243002f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001006ac382eaaca093e125e25c24bebc84640c11987507344b5c739ceb84a9e0b222b9a8b51c839e5ebe49cfadbfb39599764ed522099dc912751950dc7dc97fbdc06328b68f22781fd315af568009a5509e5b87a11bf527c056daffd82ab6cbc25cca37143459e7bc63bcde52757adeb7df01cf12173f1fef8102ec5ab142c213dd9d30696278a8d8bc32dde9592d28c078c6d92b947d825acaab6494846a49de24b9623f4889e8adc38e8c669effef176040ad945e90a7d3eec15efeee78ae71043c96511103a16ba7caf0acd0642efdbe809934faa1a5f1bd11043649b25ccd1fee2e38815d4d5f5fc6b4102969f21c22ae1b0e7d3603a556a13262ff628de222
 Ctrl.hexxcghash = hexxcghash:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
 Ctrl.hexsession_id = hexsession_id:7b7001185e256d4493445f39a55fb905e6321f4b5dd8bbf3100d51ba0bda3d2d
@@ -2884,7 +2885,7 @@ Ctrl.type = type:F
 Output = c3419c2b966235869d714ba5ac48ddb7d9e35c8c19aac73422337a373453607e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010044708c76616f700bd31b0c155ef74e36390eeb39bc5c32cdc90e21922b0ed930b5b519c8afebef0f4e4fb5b41b81d649d2127506620b594e9899f7f0d442ecddd68308307b82f00065e9d75220a5a6f5641795772132215a236064ea965c6493c21f89879730ebbc3c20a22d8f5bfd07b525b194323b22d8a49944d1aa58502e756101ef1e8a91c9310e71f6db65a3ad0a542cfa751f83721a99e89f1dbe54971a3620ecffc967aa55eed1a42d6e7a138b853557ac84689889f6d0c8553575fb89b4e13eab5537da72ef16f0d72f5e8505d97f110745193d550fa315fe88f672db90d73843e97ba1f3d087ba8eb39025bbffad37589a6199227303d9d8e7f1e3
 Ctrl.hexxcghash = hexxcghash:fe3727fd99a5ac7987c2cfbe062129e3027bf5e10310c6bccde9c916c8329dc2
 Ctrl.hexsession_id = hexsession_id:fffa598bc0ad2ae84dc8dc05b1f72c5b0134025ae7edf8a2e8db11472e18e1fc
@@ -2892,7 +2893,7 @@ Ctrl.type = type:A
 Output = 36730bae8de5cb98898d6b4a00b37058
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010044708c76616f700bd31b0c155ef74e36390eeb39bc5c32cdc90e21922b0ed930b5b519c8afebef0f4e4fb5b41b81d649d2127506620b594e9899f7f0d442ecddd68308307b82f00065e9d75220a5a6f5641795772132215a236064ea965c6493c21f89879730ebbc3c20a22d8f5bfd07b525b194323b22d8a49944d1aa58502e756101ef1e8a91c9310e71f6db65a3ad0a542cfa751f83721a99e89f1dbe54971a3620ecffc967aa55eed1a42d6e7a138b853557ac84689889f6d0c8553575fb89b4e13eab5537da72ef16f0d72f5e8505d97f110745193d550fa315fe88f672db90d73843e97ba1f3d087ba8eb39025bbffad37589a6199227303d9d8e7f1e3
 Ctrl.hexxcghash = hexxcghash:fe3727fd99a5ac7987c2cfbe062129e3027bf5e10310c6bccde9c916c8329dc2
 Ctrl.hexsession_id = hexsession_id:fffa598bc0ad2ae84dc8dc05b1f72c5b0134025ae7edf8a2e8db11472e18e1fc
@@ -2900,7 +2901,7 @@ Ctrl.type = type:B
 Output = 5dfe446a83f40e8358d28cb97df8f340
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010044708c76616f700bd31b0c155ef74e36390eeb39bc5c32cdc90e21922b0ed930b5b519c8afebef0f4e4fb5b41b81d649d2127506620b594e9899f7f0d442ecddd68308307b82f00065e9d75220a5a6f5641795772132215a236064ea965c6493c21f89879730ebbc3c20a22d8f5bfd07b525b194323b22d8a49944d1aa58502e756101ef1e8a91c9310e71f6db65a3ad0a542cfa751f83721a99e89f1dbe54971a3620ecffc967aa55eed1a42d6e7a138b853557ac84689889f6d0c8553575fb89b4e13eab5537da72ef16f0d72f5e8505d97f110745193d550fa315fe88f672db90d73843e97ba1f3d087ba8eb39025bbffad37589a6199227303d9d8e7f1e3
 Ctrl.hexxcghash = hexxcghash:fe3727fd99a5ac7987c2cfbe062129e3027bf5e10310c6bccde9c916c8329dc2
 Ctrl.hexsession_id = hexsession_id:fffa598bc0ad2ae84dc8dc05b1f72c5b0134025ae7edf8a2e8db11472e18e1fc
@@ -2908,7 +2909,7 @@ Ctrl.type = type:C
 Output = 495b7afed0872b761437728e9e94e2b8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010044708c76616f700bd31b0c155ef74e36390eeb39bc5c32cdc90e21922b0ed930b5b519c8afebef0f4e4fb5b41b81d649d2127506620b594e9899f7f0d442ecddd68308307b82f00065e9d75220a5a6f5641795772132215a236064ea965c6493c21f89879730ebbc3c20a22d8f5bfd07b525b194323b22d8a49944d1aa58502e756101ef1e8a91c9310e71f6db65a3ad0a542cfa751f83721a99e89f1dbe54971a3620ecffc967aa55eed1a42d6e7a138b853557ac84689889f6d0c8553575fb89b4e13eab5537da72ef16f0d72f5e8505d97f110745193d550fa315fe88f672db90d73843e97ba1f3d087ba8eb39025bbffad37589a6199227303d9d8e7f1e3
 Ctrl.hexxcghash = hexxcghash:fe3727fd99a5ac7987c2cfbe062129e3027bf5e10310c6bccde9c916c8329dc2
 Ctrl.hexsession_id = hexsession_id:fffa598bc0ad2ae84dc8dc05b1f72c5b0134025ae7edf8a2e8db11472e18e1fc
@@ -2916,7 +2917,7 @@ Ctrl.type = type:D
 Output = c1474b3925bec36f0b7f6cc698e949c8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010044708c76616f700bd31b0c155ef74e36390eeb39bc5c32cdc90e21922b0ed930b5b519c8afebef0f4e4fb5b41b81d649d2127506620b594e9899f7f0d442ecddd68308307b82f00065e9d75220a5a6f5641795772132215a236064ea965c6493c21f89879730ebbc3c20a22d8f5bfd07b525b194323b22d8a49944d1aa58502e756101ef1e8a91c9310e71f6db65a3ad0a542cfa751f83721a99e89f1dbe54971a3620ecffc967aa55eed1a42d6e7a138b853557ac84689889f6d0c8553575fb89b4e13eab5537da72ef16f0d72f5e8505d97f110745193d550fa315fe88f672db90d73843e97ba1f3d087ba8eb39025bbffad37589a6199227303d9d8e7f1e3
 Ctrl.hexxcghash = hexxcghash:fe3727fd99a5ac7987c2cfbe062129e3027bf5e10310c6bccde9c916c8329dc2
 Ctrl.hexsession_id = hexsession_id:fffa598bc0ad2ae84dc8dc05b1f72c5b0134025ae7edf8a2e8db11472e18e1fc
@@ -2924,7 +2925,7 @@ Ctrl.type = type:E
 Output = b730f8df6a0697645be261169486c32a11612229276cbac5d8b3669afb2e4262
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010044708c76616f700bd31b0c155ef74e36390eeb39bc5c32cdc90e21922b0ed930b5b519c8afebef0f4e4fb5b41b81d649d2127506620b594e9899f7f0d442ecddd68308307b82f00065e9d75220a5a6f5641795772132215a236064ea965c6493c21f89879730ebbc3c20a22d8f5bfd07b525b194323b22d8a49944d1aa58502e756101ef1e8a91c9310e71f6db65a3ad0a542cfa751f83721a99e89f1dbe54971a3620ecffc967aa55eed1a42d6e7a138b853557ac84689889f6d0c8553575fb89b4e13eab5537da72ef16f0d72f5e8505d97f110745193d550fa315fe88f672db90d73843e97ba1f3d087ba8eb39025bbffad37589a6199227303d9d8e7f1e3
 Ctrl.hexxcghash = hexxcghash:fe3727fd99a5ac7987c2cfbe062129e3027bf5e10310c6bccde9c916c8329dc2
 Ctrl.hexsession_id = hexsession_id:fffa598bc0ad2ae84dc8dc05b1f72c5b0134025ae7edf8a2e8db11472e18e1fc
@@ -2932,7 +2933,7 @@ Ctrl.type = type:F
 Output = 14a5ea98245fb058978b82a3cb092b1cca7ce0109a4f98c16e1529579d58b819
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b1c637286720d11a9030260e35726621f54115560c443ded98d5622f4007cb65427ba8ae0831f34452349993c74933466f3307e11452150f4640010ed7d1ab87656232d9659d9982e8227c25d648189d2bdda3283aa5dec8a2105af0fa840592a21d96eebb932f8ff36f94a2e4fc3819d7c9f0d26a472fb5ae5a43a2d4906247d59c42512dda252205f60042e1900e1581127f25ace253b62a83f62d4703281a294f240df2aa34ddf437c9f278278120bc10e2cb99f7804ecd6741b1be5520c553cb89747f79b4e4efd3cf09b484eb1eb034d220da457546a2ebb28d7f2faf67de0630757b8ae05e27a761956d2e190fe3fb93b1c7c142f62baeb089721cedc
 Ctrl.hexxcghash = hexxcghash:cad407a823551726f9bdcb78e8f351536e4406e8ee64947ecc0074662c7c0462
 Ctrl.hexsession_id = hexsession_id:a9c8207642627e6ee872999123b29e36abfdd071dba36ea6f0c11dd59ea46410
@@ -2940,7 +2941,7 @@ Ctrl.type = type:A
 Output = 32d20a3f5e92b20fe100f4f41a1ad53c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b1c637286720d11a9030260e35726621f54115560c443ded98d5622f4007cb65427ba8ae0831f34452349993c74933466f3307e11452150f4640010ed7d1ab87656232d9659d9982e8227c25d648189d2bdda3283aa5dec8a2105af0fa840592a21d96eebb932f8ff36f94a2e4fc3819d7c9f0d26a472fb5ae5a43a2d4906247d59c42512dda252205f60042e1900e1581127f25ace253b62a83f62d4703281a294f240df2aa34ddf437c9f278278120bc10e2cb99f7804ecd6741b1be5520c553cb89747f79b4e4efd3cf09b484eb1eb034d220da457546a2ebb28d7f2faf67de0630757b8ae05e27a761956d2e190fe3fb93b1c7c142f62baeb089721cedc
 Ctrl.hexxcghash = hexxcghash:cad407a823551726f9bdcb78e8f351536e4406e8ee64947ecc0074662c7c0462
 Ctrl.hexsession_id = hexsession_id:a9c8207642627e6ee872999123b29e36abfdd071dba36ea6f0c11dd59ea46410
@@ -2948,7 +2949,7 @@ Ctrl.type = type:B
 Output = c3a3ff57f99187ba011fd422100af577
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b1c637286720d11a9030260e35726621f54115560c443ded98d5622f4007cb65427ba8ae0831f34452349993c74933466f3307e11452150f4640010ed7d1ab87656232d9659d9982e8227c25d648189d2bdda3283aa5dec8a2105af0fa840592a21d96eebb932f8ff36f94a2e4fc3819d7c9f0d26a472fb5ae5a43a2d4906247d59c42512dda252205f60042e1900e1581127f25ace253b62a83f62d4703281a294f240df2aa34ddf437c9f278278120bc10e2cb99f7804ecd6741b1be5520c553cb89747f79b4e4efd3cf09b484eb1eb034d220da457546a2ebb28d7f2faf67de0630757b8ae05e27a761956d2e190fe3fb93b1c7c142f62baeb089721cedc
 Ctrl.hexxcghash = hexxcghash:cad407a823551726f9bdcb78e8f351536e4406e8ee64947ecc0074662c7c0462
 Ctrl.hexsession_id = hexsession_id:a9c8207642627e6ee872999123b29e36abfdd071dba36ea6f0c11dd59ea46410
@@ -2956,7 +2957,7 @@ Ctrl.type = type:C
 Output = 8517903c49d5a59ad8ef7cd8591c6b5e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b1c637286720d11a9030260e35726621f54115560c443ded98d5622f4007cb65427ba8ae0831f34452349993c74933466f3307e11452150f4640010ed7d1ab87656232d9659d9982e8227c25d648189d2bdda3283aa5dec8a2105af0fa840592a21d96eebb932f8ff36f94a2e4fc3819d7c9f0d26a472fb5ae5a43a2d4906247d59c42512dda252205f60042e1900e1581127f25ace253b62a83f62d4703281a294f240df2aa34ddf437c9f278278120bc10e2cb99f7804ecd6741b1be5520c553cb89747f79b4e4efd3cf09b484eb1eb034d220da457546a2ebb28d7f2faf67de0630757b8ae05e27a761956d2e190fe3fb93b1c7c142f62baeb089721cedc
 Ctrl.hexxcghash = hexxcghash:cad407a823551726f9bdcb78e8f351536e4406e8ee64947ecc0074662c7c0462
 Ctrl.hexsession_id = hexsession_id:a9c8207642627e6ee872999123b29e36abfdd071dba36ea6f0c11dd59ea46410
@@ -2964,7 +2965,7 @@ Ctrl.type = type:D
 Output = a5ad201101a617f1cd5b3a2baa3b27f7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b1c637286720d11a9030260e35726621f54115560c443ded98d5622f4007cb65427ba8ae0831f34452349993c74933466f3307e11452150f4640010ed7d1ab87656232d9659d9982e8227c25d648189d2bdda3283aa5dec8a2105af0fa840592a21d96eebb932f8ff36f94a2e4fc3819d7c9f0d26a472fb5ae5a43a2d4906247d59c42512dda252205f60042e1900e1581127f25ace253b62a83f62d4703281a294f240df2aa34ddf437c9f278278120bc10e2cb99f7804ecd6741b1be5520c553cb89747f79b4e4efd3cf09b484eb1eb034d220da457546a2ebb28d7f2faf67de0630757b8ae05e27a761956d2e190fe3fb93b1c7c142f62baeb089721cedc
 Ctrl.hexxcghash = hexxcghash:cad407a823551726f9bdcb78e8f351536e4406e8ee64947ecc0074662c7c0462
 Ctrl.hexsession_id = hexsession_id:a9c8207642627e6ee872999123b29e36abfdd071dba36ea6f0c11dd59ea46410
@@ -2972,7 +2973,7 @@ Ctrl.type = type:E
 Output = 16747a23fddd72f785c5d61dfb81a5a38555f5d8ff1dc5ae4fb423b82adfe05b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b1c637286720d11a9030260e35726621f54115560c443ded98d5622f4007cb65427ba8ae0831f34452349993c74933466f3307e11452150f4640010ed7d1ab87656232d9659d9982e8227c25d648189d2bdda3283aa5dec8a2105af0fa840592a21d96eebb932f8ff36f94a2e4fc3819d7c9f0d26a472fb5ae5a43a2d4906247d59c42512dda252205f60042e1900e1581127f25ace253b62a83f62d4703281a294f240df2aa34ddf437c9f278278120bc10e2cb99f7804ecd6741b1be5520c553cb89747f79b4e4efd3cf09b484eb1eb034d220da457546a2ebb28d7f2faf67de0630757b8ae05e27a761956d2e190fe3fb93b1c7c142f62baeb089721cedc
 Ctrl.hexxcghash = hexxcghash:cad407a823551726f9bdcb78e8f351536e4406e8ee64947ecc0074662c7c0462
 Ctrl.hexsession_id = hexsession_id:a9c8207642627e6ee872999123b29e36abfdd071dba36ea6f0c11dd59ea46410
@@ -2980,7 +2981,7 @@ Ctrl.type = type:F
 Output = b1b1bba896b0fd75a90187eae6cdf744d23884caa5f4ca979ced327ca1239771
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101008cd7061a3591b477989a4deb1bfc6debe874f753a4686eef11d1fa0e6796800db97c38497992b220d6e40d8f9154743b533666c8689db8cdffd38ac4009f85cfc6e48dc2fe94f78870138994ab4189e8d461a00b03425d8d838061b44e7ccd41e3a0332ab68afbf2919763c9f03747637db87a50d766504199fba6c34d216580fcd77756a6004ff485a79cdb646f0adde47a727e028261c808e0cb31928071701a0f2d2d237c293b93e80854f4e43243eaeb96cc25e00f74e2cd414c72774c7995757e93c0a9aac5ef5b0d23bef9ce475bfe697d14b815eeb0535d6e7e438bdb54aa2d8f50d05564d17c3ff2bc3451ca5b932f320c20f1c256c61ed503be2528
 Ctrl.hexxcghash = hexxcghash:53fc521edf6dea9daf619676276766508d32c1964943e9bd40b4ed2cdefa7c20
 Ctrl.hexsession_id = hexsession_id:14c6727d8e211c7632f930e716ab360e0916b1da3409367ef52d9e21512c700d
@@ -2988,7 +2989,7 @@ Ctrl.type = type:A
 Output = b5c636c93e002f1fac0b78eb423d92cf
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101008cd7061a3591b477989a4deb1bfc6debe874f753a4686eef11d1fa0e6796800db97c38497992b220d6e40d8f9154743b533666c8689db8cdffd38ac4009f85cfc6e48dc2fe94f78870138994ab4189e8d461a00b03425d8d838061b44e7ccd41e3a0332ab68afbf2919763c9f03747637db87a50d766504199fba6c34d216580fcd77756a6004ff485a79cdb646f0adde47a727e028261c808e0cb31928071701a0f2d2d237c293b93e80854f4e43243eaeb96cc25e00f74e2cd414c72774c7995757e93c0a9aac5ef5b0d23bef9ce475bfe697d14b815eeb0535d6e7e438bdb54aa2d8f50d05564d17c3ff2bc3451ca5b932f320c20f1c256c61ed503be2528
 Ctrl.hexxcghash = hexxcghash:53fc521edf6dea9daf619676276766508d32c1964943e9bd40b4ed2cdefa7c20
 Ctrl.hexsession_id = hexsession_id:14c6727d8e211c7632f930e716ab360e0916b1da3409367ef52d9e21512c700d
@@ -2996,7 +2997,7 @@ Ctrl.type = type:B
 Output = 64d82bef35e924abf030fe42cda10e81
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101008cd7061a3591b477989a4deb1bfc6debe874f753a4686eef11d1fa0e6796800db97c38497992b220d6e40d8f9154743b533666c8689db8cdffd38ac4009f85cfc6e48dc2fe94f78870138994ab4189e8d461a00b03425d8d838061b44e7ccd41e3a0332ab68afbf2919763c9f03747637db87a50d766504199fba6c34d216580fcd77756a6004ff485a79cdb646f0adde47a727e028261c808e0cb31928071701a0f2d2d237c293b93e80854f4e43243eaeb96cc25e00f74e2cd414c72774c7995757e93c0a9aac5ef5b0d23bef9ce475bfe697d14b815eeb0535d6e7e438bdb54aa2d8f50d05564d17c3ff2bc3451ca5b932f320c20f1c256c61ed503be2528
 Ctrl.hexxcghash = hexxcghash:53fc521edf6dea9daf619676276766508d32c1964943e9bd40b4ed2cdefa7c20
 Ctrl.hexsession_id = hexsession_id:14c6727d8e211c7632f930e716ab360e0916b1da3409367ef52d9e21512c700d
@@ -3004,7 +3005,7 @@ Ctrl.type = type:C
 Output = 76a1b8b85d0ea49c68f30d7448155901
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101008cd7061a3591b477989a4deb1bfc6debe874f753a4686eef11d1fa0e6796800db97c38497992b220d6e40d8f9154743b533666c8689db8cdffd38ac4009f85cfc6e48dc2fe94f78870138994ab4189e8d461a00b03425d8d838061b44e7ccd41e3a0332ab68afbf2919763c9f03747637db87a50d766504199fba6c34d216580fcd77756a6004ff485a79cdb646f0adde47a727e028261c808e0cb31928071701a0f2d2d237c293b93e80854f4e43243eaeb96cc25e00f74e2cd414c72774c7995757e93c0a9aac5ef5b0d23bef9ce475bfe697d14b815eeb0535d6e7e438bdb54aa2d8f50d05564d17c3ff2bc3451ca5b932f320c20f1c256c61ed503be2528
 Ctrl.hexxcghash = hexxcghash:53fc521edf6dea9daf619676276766508d32c1964943e9bd40b4ed2cdefa7c20
 Ctrl.hexsession_id = hexsession_id:14c6727d8e211c7632f930e716ab360e0916b1da3409367ef52d9e21512c700d
@@ -3012,7 +3013,7 @@ Ctrl.type = type:D
 Output = f136e09324b1ef12b92bf35d5b3dd8e2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101008cd7061a3591b477989a4deb1bfc6debe874f753a4686eef11d1fa0e6796800db97c38497992b220d6e40d8f9154743b533666c8689db8cdffd38ac4009f85cfc6e48dc2fe94f78870138994ab4189e8d461a00b03425d8d838061b44e7ccd41e3a0332ab68afbf2919763c9f03747637db87a50d766504199fba6c34d216580fcd77756a6004ff485a79cdb646f0adde47a727e028261c808e0cb31928071701a0f2d2d237c293b93e80854f4e43243eaeb96cc25e00f74e2cd414c72774c7995757e93c0a9aac5ef5b0d23bef9ce475bfe697d14b815eeb0535d6e7e438bdb54aa2d8f50d05564d17c3ff2bc3451ca5b932f320c20f1c256c61ed503be2528
 Ctrl.hexxcghash = hexxcghash:53fc521edf6dea9daf619676276766508d32c1964943e9bd40b4ed2cdefa7c20
 Ctrl.hexsession_id = hexsession_id:14c6727d8e211c7632f930e716ab360e0916b1da3409367ef52d9e21512c700d
@@ -3020,7 +3021,7 @@ Ctrl.type = type:E
 Output = 77abc45165b126f9127d59fbe655140cd3f768cd0498c29aa69cb5d65f7b0d50
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101008cd7061a3591b477989a4deb1bfc6debe874f753a4686eef11d1fa0e6796800db97c38497992b220d6e40d8f9154743b533666c8689db8cdffd38ac4009f85cfc6e48dc2fe94f78870138994ab4189e8d461a00b03425d8d838061b44e7ccd41e3a0332ab68afbf2919763c9f03747637db87a50d766504199fba6c34d216580fcd77756a6004ff485a79cdb646f0adde47a727e028261c808e0cb31928071701a0f2d2d237c293b93e80854f4e43243eaeb96cc25e00f74e2cd414c72774c7995757e93c0a9aac5ef5b0d23bef9ce475bfe697d14b815eeb0535d6e7e438bdb54aa2d8f50d05564d17c3ff2bc3451ca5b932f320c20f1c256c61ed503be2528
 Ctrl.hexxcghash = hexxcghash:53fc521edf6dea9daf619676276766508d32c1964943e9bd40b4ed2cdefa7c20
 Ctrl.hexsession_id = hexsession_id:14c6727d8e211c7632f930e716ab360e0916b1da3409367ef52d9e21512c700d
@@ -3028,7 +3029,7 @@ Ctrl.type = type:F
 Output = d43f93faf692f59bc96fd480fb336033c94ee237ceece69691ffaa64bdd7fcc1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b0b6fe41d565564f87ae984aadc75902d95828bdee0bba0ecc176afd5cc9c3ec79a34a9f7cf44ee6cbdcb5d8f027bb64c4c3b73e2f891ee06b781f3d7f02b59f95cbbfb2725b208856f3ebb8195fef1596248d56a371ed7acf3b973c627976e0cf156f340aa01acfbe9b574d4dedd4cbb66cb6ca5d9e76f16385be532fed8dd65735a3ecddeeb295133bb8a59499b4777242a4a7e463481d26baece4c7ef224aaf40af4d5108d024f5dd174cfdb91213939e355b0a1ca51ed6f7f584a4e47a0f1482d6a5768b1236e25d837cc8a2b49b2176bb54b2f77f4212ba394336e6a6046def9205fe482d98fcdd8d0a2643a39d753d2d481fe6689b0dc0d1c078335b7
 Ctrl.hexxcghash = hexxcghash:27faf1b9a15e505a0b46c47e2bf6ab5fff37a6dadb09e96ea9562091f1d88ce0
 Ctrl.hexsession_id = hexsession_id:6b52ddb87a66f0f1bb0dad39b462e7bd42bdeb99049d5a3581ca6f056c398228
@@ -3036,7 +3037,7 @@ Ctrl.type = type:A
 Output = 3b3c4416d3121a6838dd3f94a84b6ec6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b0b6fe41d565564f87ae984aadc75902d95828bdee0bba0ecc176afd5cc9c3ec79a34a9f7cf44ee6cbdcb5d8f027bb64c4c3b73e2f891ee06b781f3d7f02b59f95cbbfb2725b208856f3ebb8195fef1596248d56a371ed7acf3b973c627976e0cf156f340aa01acfbe9b574d4dedd4cbb66cb6ca5d9e76f16385be532fed8dd65735a3ecddeeb295133bb8a59499b4777242a4a7e463481d26baece4c7ef224aaf40af4d5108d024f5dd174cfdb91213939e355b0a1ca51ed6f7f584a4e47a0f1482d6a5768b1236e25d837cc8a2b49b2176bb54b2f77f4212ba394336e6a6046def9205fe482d98fcdd8d0a2643a39d753d2d481fe6689b0dc0d1c078335b7
 Ctrl.hexxcghash = hexxcghash:27faf1b9a15e505a0b46c47e2bf6ab5fff37a6dadb09e96ea9562091f1d88ce0
 Ctrl.hexsession_id = hexsession_id:6b52ddb87a66f0f1bb0dad39b462e7bd42bdeb99049d5a3581ca6f056c398228
@@ -3044,7 +3045,7 @@ Ctrl.type = type:B
 Output = e0af22a9184e5cea74f3e90faf5212ba
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b0b6fe41d565564f87ae984aadc75902d95828bdee0bba0ecc176afd5cc9c3ec79a34a9f7cf44ee6cbdcb5d8f027bb64c4c3b73e2f891ee06b781f3d7f02b59f95cbbfb2725b208856f3ebb8195fef1596248d56a371ed7acf3b973c627976e0cf156f340aa01acfbe9b574d4dedd4cbb66cb6ca5d9e76f16385be532fed8dd65735a3ecddeeb295133bb8a59499b4777242a4a7e463481d26baece4c7ef224aaf40af4d5108d024f5dd174cfdb91213939e355b0a1ca51ed6f7f584a4e47a0f1482d6a5768b1236e25d837cc8a2b49b2176bb54b2f77f4212ba394336e6a6046def9205fe482d98fcdd8d0a2643a39d753d2d481fe6689b0dc0d1c078335b7
 Ctrl.hexxcghash = hexxcghash:27faf1b9a15e505a0b46c47e2bf6ab5fff37a6dadb09e96ea9562091f1d88ce0
 Ctrl.hexsession_id = hexsession_id:6b52ddb87a66f0f1bb0dad39b462e7bd42bdeb99049d5a3581ca6f056c398228
@@ -3052,7 +3053,7 @@ Ctrl.type = type:C
 Output = a3a7a9e48cc09a927e2d6eddd7647368
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b0b6fe41d565564f87ae984aadc75902d95828bdee0bba0ecc176afd5cc9c3ec79a34a9f7cf44ee6cbdcb5d8f027bb64c4c3b73e2f891ee06b781f3d7f02b59f95cbbfb2725b208856f3ebb8195fef1596248d56a371ed7acf3b973c627976e0cf156f340aa01acfbe9b574d4dedd4cbb66cb6ca5d9e76f16385be532fed8dd65735a3ecddeeb295133bb8a59499b4777242a4a7e463481d26baece4c7ef224aaf40af4d5108d024f5dd174cfdb91213939e355b0a1ca51ed6f7f584a4e47a0f1482d6a5768b1236e25d837cc8a2b49b2176bb54b2f77f4212ba394336e6a6046def9205fe482d98fcdd8d0a2643a39d753d2d481fe6689b0dc0d1c078335b7
 Ctrl.hexxcghash = hexxcghash:27faf1b9a15e505a0b46c47e2bf6ab5fff37a6dadb09e96ea9562091f1d88ce0
 Ctrl.hexsession_id = hexsession_id:6b52ddb87a66f0f1bb0dad39b462e7bd42bdeb99049d5a3581ca6f056c398228
@@ -3060,7 +3061,7 @@ Ctrl.type = type:D
 Output = b9411d2870e885e223a6b414ae6ac813
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b0b6fe41d565564f87ae984aadc75902d95828bdee0bba0ecc176afd5cc9c3ec79a34a9f7cf44ee6cbdcb5d8f027bb64c4c3b73e2f891ee06b781f3d7f02b59f95cbbfb2725b208856f3ebb8195fef1596248d56a371ed7acf3b973c627976e0cf156f340aa01acfbe9b574d4dedd4cbb66cb6ca5d9e76f16385be532fed8dd65735a3ecddeeb295133bb8a59499b4777242a4a7e463481d26baece4c7ef224aaf40af4d5108d024f5dd174cfdb91213939e355b0a1ca51ed6f7f584a4e47a0f1482d6a5768b1236e25d837cc8a2b49b2176bb54b2f77f4212ba394336e6a6046def9205fe482d98fcdd8d0a2643a39d753d2d481fe6689b0dc0d1c078335b7
 Ctrl.hexxcghash = hexxcghash:27faf1b9a15e505a0b46c47e2bf6ab5fff37a6dadb09e96ea9562091f1d88ce0
 Ctrl.hexsession_id = hexsession_id:6b52ddb87a66f0f1bb0dad39b462e7bd42bdeb99049d5a3581ca6f056c398228
@@ -3068,7 +3069,7 @@ Ctrl.type = type:E
 Output = 7f11812c28229fd8e39367b8885045313fea6322f22a69b6436caa4fb6c2d915
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000101009b0b6fe41d565564f87ae984aadc75902d95828bdee0bba0ecc176afd5cc9c3ec79a34a9f7cf44ee6cbdcb5d8f027bb64c4c3b73e2f891ee06b781f3d7f02b59f95cbbfb2725b208856f3ebb8195fef1596248d56a371ed7acf3b973c627976e0cf156f340aa01acfbe9b574d4dedd4cbb66cb6ca5d9e76f16385be532fed8dd65735a3ecddeeb295133bb8a59499b4777242a4a7e463481d26baece4c7ef224aaf40af4d5108d024f5dd174cfdb91213939e355b0a1ca51ed6f7f584a4e47a0f1482d6a5768b1236e25d837cc8a2b49b2176bb54b2f77f4212ba394336e6a6046def9205fe482d98fcdd8d0a2643a39d753d2d481fe6689b0dc0d1c078335b7
 Ctrl.hexxcghash = hexxcghash:27faf1b9a15e505a0b46c47e2bf6ab5fff37a6dadb09e96ea9562091f1d88ce0
 Ctrl.hexsession_id = hexsession_id:6b52ddb87a66f0f1bb0dad39b462e7bd42bdeb99049d5a3581ca6f056c398228
@@ -3076,7 +3077,7 @@ Ctrl.type = type:F
 Output = 4fc39e2a1e7038f2664a48986e8227c213e577eafea082f46cb08d087e642fe4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100435266668e94e5f35d31f10f7b486bed8a88465cf30711e54f8c6550a917916fb7160c41880d364df5084446d7834e32917882c10eef49f8192fa6ff4c9498a12d87bbf710d4bba3e76a6681c7ac3470e6f5e80c55851dcca38a9ce48b015ab73b24e28e0553f3a1bbe1dfa9b67bb9cb9372ad0fb0aaf443c3a8927d00b9b2705f4d1b219c80f7caa637c986de79410c5924943128e64cf869491f19c1646cb403d8543d5aaaea7fbaaaa1a846b9851f4f708b14266e55839e1d61b67a60359c2c111841839225c0f940252506be02ba43fcc7c4be7cb01c64094fbd9a78cc331c6e7809e0be3a4b693adfeedd1b20ad36d321498b396fce7cf169b2fb10e54b
 Ctrl.hexxcghash = hexxcghash:d7303e57a2bf969f815c1b2fd08a879226c0e95c9897fb5586200c0f5e0a8a23
 Ctrl.hexsession_id = hexsession_id:20ace711e8190f5bbd2168bc93061c903899acd41697b76d0f6667d2bf345725
@@ -3084,7 +3085,7 @@ Ctrl.type = type:A
 Output = b71bd280b230b6fb9b326a3544ab9c90
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100435266668e94e5f35d31f10f7b486bed8a88465cf30711e54f8c6550a917916fb7160c41880d364df5084446d7834e32917882c10eef49f8192fa6ff4c9498a12d87bbf710d4bba3e76a6681c7ac3470e6f5e80c55851dcca38a9ce48b015ab73b24e28e0553f3a1bbe1dfa9b67bb9cb9372ad0fb0aaf443c3a8927d00b9b2705f4d1b219c80f7caa637c986de79410c5924943128e64cf869491f19c1646cb403d8543d5aaaea7fbaaaa1a846b9851f4f708b14266e55839e1d61b67a60359c2c111841839225c0f940252506be02ba43fcc7c4be7cb01c64094fbd9a78cc331c6e7809e0be3a4b693adfeedd1b20ad36d321498b396fce7cf169b2fb10e54b
 Ctrl.hexxcghash = hexxcghash:d7303e57a2bf969f815c1b2fd08a879226c0e95c9897fb5586200c0f5e0a8a23
 Ctrl.hexsession_id = hexsession_id:20ace711e8190f5bbd2168bc93061c903899acd41697b76d0f6667d2bf345725
@@ -3092,7 +3093,7 @@ Ctrl.type = type:B
 Output = ca38c1b5940e1417fb8caa6ab6deaf18
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100435266668e94e5f35d31f10f7b486bed8a88465cf30711e54f8c6550a917916fb7160c41880d364df5084446d7834e32917882c10eef49f8192fa6ff4c9498a12d87bbf710d4bba3e76a6681c7ac3470e6f5e80c55851dcca38a9ce48b015ab73b24e28e0553f3a1bbe1dfa9b67bb9cb9372ad0fb0aaf443c3a8927d00b9b2705f4d1b219c80f7caa637c986de79410c5924943128e64cf869491f19c1646cb403d8543d5aaaea7fbaaaa1a846b9851f4f708b14266e55839e1d61b67a60359c2c111841839225c0f940252506be02ba43fcc7c4be7cb01c64094fbd9a78cc331c6e7809e0be3a4b693adfeedd1b20ad36d321498b396fce7cf169b2fb10e54b
 Ctrl.hexxcghash = hexxcghash:d7303e57a2bf969f815c1b2fd08a879226c0e95c9897fb5586200c0f5e0a8a23
 Ctrl.hexsession_id = hexsession_id:20ace711e8190f5bbd2168bc93061c903899acd41697b76d0f6667d2bf345725
@@ -3100,7 +3101,7 @@ Ctrl.type = type:C
 Output = 5d02347e16760101a3689bf0087ed947
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100435266668e94e5f35d31f10f7b486bed8a88465cf30711e54f8c6550a917916fb7160c41880d364df5084446d7834e32917882c10eef49f8192fa6ff4c9498a12d87bbf710d4bba3e76a6681c7ac3470e6f5e80c55851dcca38a9ce48b015ab73b24e28e0553f3a1bbe1dfa9b67bb9cb9372ad0fb0aaf443c3a8927d00b9b2705f4d1b219c80f7caa637c986de79410c5924943128e64cf869491f19c1646cb403d8543d5aaaea7fbaaaa1a846b9851f4f708b14266e55839e1d61b67a60359c2c111841839225c0f940252506be02ba43fcc7c4be7cb01c64094fbd9a78cc331c6e7809e0be3a4b693adfeedd1b20ad36d321498b396fce7cf169b2fb10e54b
 Ctrl.hexxcghash = hexxcghash:d7303e57a2bf969f815c1b2fd08a879226c0e95c9897fb5586200c0f5e0a8a23
 Ctrl.hexsession_id = hexsession_id:20ace711e8190f5bbd2168bc93061c903899acd41697b76d0f6667d2bf345725
@@ -3108,7 +3109,7 @@ Ctrl.type = type:D
 Output = 2fb5e0eb5552f7e26ad9651bd22f1666
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100435266668e94e5f35d31f10f7b486bed8a88465cf30711e54f8c6550a917916fb7160c41880d364df5084446d7834e32917882c10eef49f8192fa6ff4c9498a12d87bbf710d4bba3e76a6681c7ac3470e6f5e80c55851dcca38a9ce48b015ab73b24e28e0553f3a1bbe1dfa9b67bb9cb9372ad0fb0aaf443c3a8927d00b9b2705f4d1b219c80f7caa637c986de79410c5924943128e64cf869491f19c1646cb403d8543d5aaaea7fbaaaa1a846b9851f4f708b14266e55839e1d61b67a60359c2c111841839225c0f940252506be02ba43fcc7c4be7cb01c64094fbd9a78cc331c6e7809e0be3a4b693adfeedd1b20ad36d321498b396fce7cf169b2fb10e54b
 Ctrl.hexxcghash = hexxcghash:d7303e57a2bf969f815c1b2fd08a879226c0e95c9897fb5586200c0f5e0a8a23
 Ctrl.hexsession_id = hexsession_id:20ace711e8190f5bbd2168bc93061c903899acd41697b76d0f6667d2bf345725
@@ -3116,7 +3117,7 @@ Ctrl.type = type:E
 Output = b7b7c4292a73e7d378284b12b318e0cd3ad714904b4ef9c83d44ee06ff49b1e1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100435266668e94e5f35d31f10f7b486bed8a88465cf30711e54f8c6550a917916fb7160c41880d364df5084446d7834e32917882c10eef49f8192fa6ff4c9498a12d87bbf710d4bba3e76a6681c7ac3470e6f5e80c55851dcca38a9ce48b015ab73b24e28e0553f3a1bbe1dfa9b67bb9cb9372ad0fb0aaf443c3a8927d00b9b2705f4d1b219c80f7caa637c986de79410c5924943128e64cf869491f19c1646cb403d8543d5aaaea7fbaaaa1a846b9851f4f708b14266e55839e1d61b67a60359c2c111841839225c0f940252506be02ba43fcc7c4be7cb01c64094fbd9a78cc331c6e7809e0be3a4b693adfeedd1b20ad36d321498b396fce7cf169b2fb10e54b
 Ctrl.hexxcghash = hexxcghash:d7303e57a2bf969f815c1b2fd08a879226c0e95c9897fb5586200c0f5e0a8a23
 Ctrl.hexsession_id = hexsession_id:20ace711e8190f5bbd2168bc93061c903899acd41697b76d0f6667d2bf345725
@@ -3124,7 +3125,7 @@ Ctrl.type = type:F
 Output = c9884e71b158f2255fb204733e888bc5b2ee38a5493de9d0ef6700949159ac6a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100745f5abd8fb685eaae10854a96900806cd7d17d2d255990328594a4fdbb9fa28088ccb8fbf92ef23492a595f92c49d5fa32ea5ef6d76000635fb58496c9db824aaa41b67c3c2e8bdd525f6c6a224562c670076f6efd21fe49222c2627596b775c56dff5d477cd4cc008ef566086a495cf4ba634af20a42fb13fa52597dc252edebdfa57592494fd9cd44d0f7e27d6a6ff370876c42733977db656d7372d553c2ffc824fb02375e55069d5cccb493ec77001fb4cd73cbec6976bd45ae2cc0812c078784d917c0a0a54d8df6c745a2710828939be0685d7fc1657eee9c4dbc71615fab0174e62fb7971fa20f6d6b2da1c22c0a35c781c9dbdf009cec3d89891afc
 Ctrl.hexxcghash = hexxcghash:35f601a7877ef637d6c40b4f2e1d85b888eceac9f37e686254f9d707b22bd764
 Ctrl.hexsession_id = hexsession_id:d04bce75141ed2a44942d98354ded46e861da28fc1175e5a22e8dddad4942f9a
@@ -3132,7 +3133,7 @@ Ctrl.type = type:A
 Output = 88af3bdb49bd8e9d24489efc95dea1c1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100745f5abd8fb685eaae10854a96900806cd7d17d2d255990328594a4fdbb9fa28088ccb8fbf92ef23492a595f92c49d5fa32ea5ef6d76000635fb58496c9db824aaa41b67c3c2e8bdd525f6c6a224562c670076f6efd21fe49222c2627596b775c56dff5d477cd4cc008ef566086a495cf4ba634af20a42fb13fa52597dc252edebdfa57592494fd9cd44d0f7e27d6a6ff370876c42733977db656d7372d553c2ffc824fb02375e55069d5cccb493ec77001fb4cd73cbec6976bd45ae2cc0812c078784d917c0a0a54d8df6c745a2710828939be0685d7fc1657eee9c4dbc71615fab0174e62fb7971fa20f6d6b2da1c22c0a35c781c9dbdf009cec3d89891afc
 Ctrl.hexxcghash = hexxcghash:35f601a7877ef637d6c40b4f2e1d85b888eceac9f37e686254f9d707b22bd764
 Ctrl.hexsession_id = hexsession_id:d04bce75141ed2a44942d98354ded46e861da28fc1175e5a22e8dddad4942f9a
@@ -3140,7 +3141,7 @@ Ctrl.type = type:B
 Output = 5cf41e1d43f797c16a30e070f2f37dd4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100745f5abd8fb685eaae10854a96900806cd7d17d2d255990328594a4fdbb9fa28088ccb8fbf92ef23492a595f92c49d5fa32ea5ef6d76000635fb58496c9db824aaa41b67c3c2e8bdd525f6c6a224562c670076f6efd21fe49222c2627596b775c56dff5d477cd4cc008ef566086a495cf4ba634af20a42fb13fa52597dc252edebdfa57592494fd9cd44d0f7e27d6a6ff370876c42733977db656d7372d553c2ffc824fb02375e55069d5cccb493ec77001fb4cd73cbec6976bd45ae2cc0812c078784d917c0a0a54d8df6c745a2710828939be0685d7fc1657eee9c4dbc71615fab0174e62fb7971fa20f6d6b2da1c22c0a35c781c9dbdf009cec3d89891afc
 Ctrl.hexxcghash = hexxcghash:35f601a7877ef637d6c40b4f2e1d85b888eceac9f37e686254f9d707b22bd764
 Ctrl.hexsession_id = hexsession_id:d04bce75141ed2a44942d98354ded46e861da28fc1175e5a22e8dddad4942f9a
@@ -3148,7 +3149,7 @@ Ctrl.type = type:C
 Output = 7cc48e0f8b4bdd63f76e41ba411d7f37
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100745f5abd8fb685eaae10854a96900806cd7d17d2d255990328594a4fdbb9fa28088ccb8fbf92ef23492a595f92c49d5fa32ea5ef6d76000635fb58496c9db824aaa41b67c3c2e8bdd525f6c6a224562c670076f6efd21fe49222c2627596b775c56dff5d477cd4cc008ef566086a495cf4ba634af20a42fb13fa52597dc252edebdfa57592494fd9cd44d0f7e27d6a6ff370876c42733977db656d7372d553c2ffc824fb02375e55069d5cccb493ec77001fb4cd73cbec6976bd45ae2cc0812c078784d917c0a0a54d8df6c745a2710828939be0685d7fc1657eee9c4dbc71615fab0174e62fb7971fa20f6d6b2da1c22c0a35c781c9dbdf009cec3d89891afc
 Ctrl.hexxcghash = hexxcghash:35f601a7877ef637d6c40b4f2e1d85b888eceac9f37e686254f9d707b22bd764
 Ctrl.hexsession_id = hexsession_id:d04bce75141ed2a44942d98354ded46e861da28fc1175e5a22e8dddad4942f9a
@@ -3156,7 +3157,7 @@ Ctrl.type = type:D
 Output = 37d942416267be06cd1ff9498dcf1e6e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100745f5abd8fb685eaae10854a96900806cd7d17d2d255990328594a4fdbb9fa28088ccb8fbf92ef23492a595f92c49d5fa32ea5ef6d76000635fb58496c9db824aaa41b67c3c2e8bdd525f6c6a224562c670076f6efd21fe49222c2627596b775c56dff5d477cd4cc008ef566086a495cf4ba634af20a42fb13fa52597dc252edebdfa57592494fd9cd44d0f7e27d6a6ff370876c42733977db656d7372d553c2ffc824fb02375e55069d5cccb493ec77001fb4cd73cbec6976bd45ae2cc0812c078784d917c0a0a54d8df6c745a2710828939be0685d7fc1657eee9c4dbc71615fab0174e62fb7971fa20f6d6b2da1c22c0a35c781c9dbdf009cec3d89891afc
 Ctrl.hexxcghash = hexxcghash:35f601a7877ef637d6c40b4f2e1d85b888eceac9f37e686254f9d707b22bd764
 Ctrl.hexsession_id = hexsession_id:d04bce75141ed2a44942d98354ded46e861da28fc1175e5a22e8dddad4942f9a
@@ -3164,7 +3165,7 @@ Ctrl.type = type:E
 Output = c3c8b48e228a3a671ae8c48aa4e4f1fe32c1ad4d5ae48c904836d13e7350f72e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:00000100745f5abd8fb685eaae10854a96900806cd7d17d2d255990328594a4fdbb9fa28088ccb8fbf92ef23492a595f92c49d5fa32ea5ef6d76000635fb58496c9db824aaa41b67c3c2e8bdd525f6c6a224562c670076f6efd21fe49222c2627596b775c56dff5d477cd4cc008ef566086a495cf4ba634af20a42fb13fa52597dc252edebdfa57592494fd9cd44d0f7e27d6a6ff370876c42733977db656d7372d553c2ffc824fb02375e55069d5cccb493ec77001fb4cd73cbec6976bd45ae2cc0812c078784d917c0a0a54d8df6c745a2710828939be0685d7fc1657eee9c4dbc71615fab0174e62fb7971fa20f6d6b2da1c22c0a35c781c9dbdf009cec3d89891afc
 Ctrl.hexxcghash = hexxcghash:35f601a7877ef637d6c40b4f2e1d85b888eceac9f37e686254f9d707b22bd764
 Ctrl.hexsession_id = hexsession_id:d04bce75141ed2a44942d98354ded46e861da28fc1175e5a22e8dddad4942f9a
@@ -3172,7 +3173,7 @@ Ctrl.type = type:F
 Output = 605f7d3b3f28a8967402ba67ff916a61b0a4e9b736665c5e911fb33f60dc16fe
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001010089b741b0b9a6704f56df9aafe5f4294828fdc67f4243e9aa9b1d83166ad892f2d970fdff65eba7fa5eddb954dd86bda5262e084752c69c6b93c729ad34e9728f7c838c49f0e87349ae35feef1610b83a345c64c5b190fb5857bf0aa8419efba35789c258f19e8713e2729c184eab9d9c33a32ab3731d77e207a91849625bb855e581ca0be5d9f961aab9d65b463e416ee3d636ece573ead0d088a2fe05d87dd5ed21031f4dbea831112d3bd0e1cc1087a8395430cde3cb54d22a5965dd825329bee8c62d4599fb67ff90260204c6e608e6246f768e29a60cb85f580d4751f9c017cbf4e6062a160c6ff1d0c9d303a2c862a4986e22f72da79b17b868cee189a2
 Ctrl.hexxcghash = hexxcghash:61e49599eb3b01e3d7bc65415ce7004e20bf77805a4ff09681f3856adc129943
 Ctrl.hexsession_id = hexsession_id:832400eb1c4031502f7249d0a4279a7cbe4d4d6979289d02837d98b9ca16ff46
@@ -3180,7 +3181,7 @@ Ctrl.type = type:A
 Output = 7b91adc6eb48a6f82a8990efd2537903
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001010089b741b0b9a6704f56df9aafe5f4294828fdc67f4243e9aa9b1d83166ad892f2d970fdff65eba7fa5eddb954dd86bda5262e084752c69c6b93c729ad34e9728f7c838c49f0e87349ae35feef1610b83a345c64c5b190fb5857bf0aa8419efba35789c258f19e8713e2729c184eab9d9c33a32ab3731d77e207a91849625bb855e581ca0be5d9f961aab9d65b463e416ee3d636ece573ead0d088a2fe05d87dd5ed21031f4dbea831112d3bd0e1cc1087a8395430cde3cb54d22a5965dd825329bee8c62d4599fb67ff90260204c6e608e6246f768e29a60cb85f580d4751f9c017cbf4e6062a160c6ff1d0c9d303a2c862a4986e22f72da79b17b868cee189a2
 Ctrl.hexxcghash = hexxcghash:61e49599eb3b01e3d7bc65415ce7004e20bf77805a4ff09681f3856adc129943
 Ctrl.hexsession_id = hexsession_id:832400eb1c4031502f7249d0a4279a7cbe4d4d6979289d02837d98b9ca16ff46
@@ -3188,7 +3189,7 @@ Ctrl.type = type:B
 Output = 814c8fb54a535b38d4c2301aa49ad702
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001010089b741b0b9a6704f56df9aafe5f4294828fdc67f4243e9aa9b1d83166ad892f2d970fdff65eba7fa5eddb954dd86bda5262e084752c69c6b93c729ad34e9728f7c838c49f0e87349ae35feef1610b83a345c64c5b190fb5857bf0aa8419efba35789c258f19e8713e2729c184eab9d9c33a32ab3731d77e207a91849625bb855e581ca0be5d9f961aab9d65b463e416ee3d636ece573ead0d088a2fe05d87dd5ed21031f4dbea831112d3bd0e1cc1087a8395430cde3cb54d22a5965dd825329bee8c62d4599fb67ff90260204c6e608e6246f768e29a60cb85f580d4751f9c017cbf4e6062a160c6ff1d0c9d303a2c862a4986e22f72da79b17b868cee189a2
 Ctrl.hexxcghash = hexxcghash:61e49599eb3b01e3d7bc65415ce7004e20bf77805a4ff09681f3856adc129943
 Ctrl.hexsession_id = hexsession_id:832400eb1c4031502f7249d0a4279a7cbe4d4d6979289d02837d98b9ca16ff46
@@ -3196,7 +3197,7 @@ Ctrl.type = type:C
 Output = 3ec64c8571c7c7f39a9f37c0e1053324
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001010089b741b0b9a6704f56df9aafe5f4294828fdc67f4243e9aa9b1d83166ad892f2d970fdff65eba7fa5eddb954dd86bda5262e084752c69c6b93c729ad34e9728f7c838c49f0e87349ae35feef1610b83a345c64c5b190fb5857bf0aa8419efba35789c258f19e8713e2729c184eab9d9c33a32ab3731d77e207a91849625bb855e581ca0be5d9f961aab9d65b463e416ee3d636ece573ead0d088a2fe05d87dd5ed21031f4dbea831112d3bd0e1cc1087a8395430cde3cb54d22a5965dd825329bee8c62d4599fb67ff90260204c6e608e6246f768e29a60cb85f580d4751f9c017cbf4e6062a160c6ff1d0c9d303a2c862a4986e22f72da79b17b868cee189a2
 Ctrl.hexxcghash = hexxcghash:61e49599eb3b01e3d7bc65415ce7004e20bf77805a4ff09681f3856adc129943
 Ctrl.hexsession_id = hexsession_id:832400eb1c4031502f7249d0a4279a7cbe4d4d6979289d02837d98b9ca16ff46
@@ -3204,7 +3205,7 @@ Ctrl.type = type:D
 Output = 846d40dc45123f2710e27bd3140070c8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001010089b741b0b9a6704f56df9aafe5f4294828fdc67f4243e9aa9b1d83166ad892f2d970fdff65eba7fa5eddb954dd86bda5262e084752c69c6b93c729ad34e9728f7c838c49f0e87349ae35feef1610b83a345c64c5b190fb5857bf0aa8419efba35789c258f19e8713e2729c184eab9d9c33a32ab3731d77e207a91849625bb855e581ca0be5d9f961aab9d65b463e416ee3d636ece573ead0d088a2fe05d87dd5ed21031f4dbea831112d3bd0e1cc1087a8395430cde3cb54d22a5965dd825329bee8c62d4599fb67ff90260204c6e608e6246f768e29a60cb85f580d4751f9c017cbf4e6062a160c6ff1d0c9d303a2c862a4986e22f72da79b17b868cee189a2
 Ctrl.hexxcghash = hexxcghash:61e49599eb3b01e3d7bc65415ce7004e20bf77805a4ff09681f3856adc129943
 Ctrl.hexsession_id = hexsession_id:832400eb1c4031502f7249d0a4279a7cbe4d4d6979289d02837d98b9ca16ff46
@@ -3212,7 +3213,7 @@ Ctrl.type = type:E
 Output = c2199b9bd701c2f4ee82a145adc28f3e8fac0af8dd43cb7f3da173681bcad2e0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001010089b741b0b9a6704f56df9aafe5f4294828fdc67f4243e9aa9b1d83166ad892f2d970fdff65eba7fa5eddb954dd86bda5262e084752c69c6b93c729ad34e9728f7c838c49f0e87349ae35feef1610b83a345c64c5b190fb5857bf0aa8419efba35789c258f19e8713e2729c184eab9d9c33a32ab3731d77e207a91849625bb855e581ca0be5d9f961aab9d65b463e416ee3d636ece573ead0d088a2fe05d87dd5ed21031f4dbea831112d3bd0e1cc1087a8395430cde3cb54d22a5965dd825329bee8c62d4599fb67ff90260204c6e608e6246f768e29a60cb85f580d4751f9c017cbf4e6062a160c6ff1d0c9d303a2c862a4986e22f72da79b17b868cee189a2
 Ctrl.hexxcghash = hexxcghash:61e49599eb3b01e3d7bc65415ce7004e20bf77805a4ff09681f3856adc129943
 Ctrl.hexsession_id = hexsession_id:832400eb1c4031502f7249d0a4279a7cbe4d4d6979289d02837d98b9ca16ff46
@@ -3220,7 +3221,7 @@ Ctrl.type = type:F
 Output = 49f5fb8862a4f01900f9f76d6146f181483428beadb000d4f5097adf59c5eb99
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010100f7217049f9cc4f3d59ea109a06ac3cfb79fc05dc349e1c54482072c467e503494d845004c278dabd9338d3bdb3c2f3c58cb264d65575d9946961345dcda5b9ce59cc8fdfc994acb74fe8f3b1fc143abceedc541ae74d69cd543fa7438ac5b5c84168d6e6f7fba2722c279b7cd0c1e07cdd59bb231f17174d33b7c1a6eb199cfa093476cdd31292f3bff20ae224459caaec461c76d741f0e9269ba96676a3ccebe986a3843a36747a0998bb3feaba41671db20368867a13875f76136b2418b6c807335a7133b4e4fbc0e908516ce97458abec2a32355fb061237bada4e07b950a2b1c8d41201f1c0a41c771d990e4741fef6e2eb5cd106c3b4b6000ad07b482ad
 Ctrl.hexxcghash = hexxcghash:be79b302374817c2fd052704dfba5e98b05a8346db9269e6401265a1c7970d98
 Ctrl.hexsession_id = hexsession_id:def8533bf220d0c632aa4f1b16168e51c0be904c6f299225b30bd7df7bbdc6f2
@@ -3228,7 +3229,7 @@ Ctrl.type = type:A
 Output = 50afb2f3b8a3bc466b3a68f04da0d56c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010100f7217049f9cc4f3d59ea109a06ac3cfb79fc05dc349e1c54482072c467e503494d845004c278dabd9338d3bdb3c2f3c58cb264d65575d9946961345dcda5b9ce59cc8fdfc994acb74fe8f3b1fc143abceedc541ae74d69cd543fa7438ac5b5c84168d6e6f7fba2722c279b7cd0c1e07cdd59bb231f17174d33b7c1a6eb199cfa093476cdd31292f3bff20ae224459caaec461c76d741f0e9269ba96676a3ccebe986a3843a36747a0998bb3feaba41671db20368867a13875f76136b2418b6c807335a7133b4e4fbc0e908516ce97458abec2a32355fb061237bada4e07b950a2b1c8d41201f1c0a41c771d990e4741fef6e2eb5cd106c3b4b6000ad07b482ad
 Ctrl.hexxcghash = hexxcghash:be79b302374817c2fd052704dfba5e98b05a8346db9269e6401265a1c7970d98
 Ctrl.hexsession_id = hexsession_id:def8533bf220d0c632aa4f1b16168e51c0be904c6f299225b30bd7df7bbdc6f2
@@ -3236,7 +3237,7 @@ Ctrl.type = type:B
 Output = b8672a8cc59ee1316fb9a2c0a82ffd73
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010100f7217049f9cc4f3d59ea109a06ac3cfb79fc05dc349e1c54482072c467e503494d845004c278dabd9338d3bdb3c2f3c58cb264d65575d9946961345dcda5b9ce59cc8fdfc994acb74fe8f3b1fc143abceedc541ae74d69cd543fa7438ac5b5c84168d6e6f7fba2722c279b7cd0c1e07cdd59bb231f17174d33b7c1a6eb199cfa093476cdd31292f3bff20ae224459caaec461c76d741f0e9269ba96676a3ccebe986a3843a36747a0998bb3feaba41671db20368867a13875f76136b2418b6c807335a7133b4e4fbc0e908516ce97458abec2a32355fb061237bada4e07b950a2b1c8d41201f1c0a41c771d990e4741fef6e2eb5cd106c3b4b6000ad07b482ad
 Ctrl.hexxcghash = hexxcghash:be79b302374817c2fd052704dfba5e98b05a8346db9269e6401265a1c7970d98
 Ctrl.hexsession_id = hexsession_id:def8533bf220d0c632aa4f1b16168e51c0be904c6f299225b30bd7df7bbdc6f2
@@ -3244,7 +3245,7 @@ Ctrl.type = type:C
 Output = d854cbdb8f7544b796f982e4973d4de9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010100f7217049f9cc4f3d59ea109a06ac3cfb79fc05dc349e1c54482072c467e503494d845004c278dabd9338d3bdb3c2f3c58cb264d65575d9946961345dcda5b9ce59cc8fdfc994acb74fe8f3b1fc143abceedc541ae74d69cd543fa7438ac5b5c84168d6e6f7fba2722c279b7cd0c1e07cdd59bb231f17174d33b7c1a6eb199cfa093476cdd31292f3bff20ae224459caaec461c76d741f0e9269ba96676a3ccebe986a3843a36747a0998bb3feaba41671db20368867a13875f76136b2418b6c807335a7133b4e4fbc0e908516ce97458abec2a32355fb061237bada4e07b950a2b1c8d41201f1c0a41c771d990e4741fef6e2eb5cd106c3b4b6000ad07b482ad
 Ctrl.hexxcghash = hexxcghash:be79b302374817c2fd052704dfba5e98b05a8346db9269e6401265a1c7970d98
 Ctrl.hexsession_id = hexsession_id:def8533bf220d0c632aa4f1b16168e51c0be904c6f299225b30bd7df7bbdc6f2
@@ -3252,7 +3253,7 @@ Ctrl.type = type:D
 Output = bd6bde82c451ee39069d0794f7000f38
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010100f7217049f9cc4f3d59ea109a06ac3cfb79fc05dc349e1c54482072c467e503494d845004c278dabd9338d3bdb3c2f3c58cb264d65575d9946961345dcda5b9ce59cc8fdfc994acb74fe8f3b1fc143abceedc541ae74d69cd543fa7438ac5b5c84168d6e6f7fba2722c279b7cd0c1e07cdd59bb231f17174d33b7c1a6eb199cfa093476cdd31292f3bff20ae224459caaec461c76d741f0e9269ba96676a3ccebe986a3843a36747a0998bb3feaba41671db20368867a13875f76136b2418b6c807335a7133b4e4fbc0e908516ce97458abec2a32355fb061237bada4e07b950a2b1c8d41201f1c0a41c771d990e4741fef6e2eb5cd106c3b4b6000ad07b482ad
 Ctrl.hexxcghash = hexxcghash:be79b302374817c2fd052704dfba5e98b05a8346db9269e6401265a1c7970d98
 Ctrl.hexsession_id = hexsession_id:def8533bf220d0c632aa4f1b16168e51c0be904c6f299225b30bd7df7bbdc6f2
@@ -3260,7 +3261,7 @@ Ctrl.type = type:E
 Output = 270794ec70fcd9d742aad66c54001b4c218ae8cca813453560a9aeaacc6909ec
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:0000010100f7217049f9cc4f3d59ea109a06ac3cfb79fc05dc349e1c54482072c467e503494d845004c278dabd9338d3bdb3c2f3c58cb264d65575d9946961345dcda5b9ce59cc8fdfc994acb74fe8f3b1fc143abceedc541ae74d69cd543fa7438ac5b5c84168d6e6f7fba2722c279b7cd0c1e07cdd59bb231f17174d33b7c1a6eb199cfa093476cdd31292f3bff20ae224459caaec461c76d741f0e9269ba96676a3ccebe986a3843a36747a0998bb3feaba41671db20368867a13875f76136b2418b6c807335a7133b4e4fbc0e908516ce97458abec2a32355fb061237bada4e07b950a2b1c8d41201f1c0a41c771d990e4741fef6e2eb5cd106c3b4b6000ad07b482ad
 Ctrl.hexxcghash = hexxcghash:be79b302374817c2fd052704dfba5e98b05a8346db9269e6401265a1c7970d98
 Ctrl.hexsession_id = hexsession_id:def8533bf220d0c632aa4f1b16168e51c0be904c6f299225b30bd7df7bbdc6f2
@@ -3268,7 +3269,7 @@ Ctrl.type = type:F
 Output = e967df7571a0eb82f59ddfead22c617beeefa25ce4afd80ac8320bc2635c70d0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001001b3a1cab1e87a29e229efcae0f569d855a61d6da6ea0ae5bed3491c7bdb5f70f6caf8dc305100160bbf6ecd726b11799da685ce4528ee689fe292043e318ad9f797bd5746399e007cf1f40d7918b85e4607f6e674da84709543dd0d50ad1d5c993770b4d0c045fdef89d5534c3d77edd8dc4536a10cc2b5d0bd14caa7e029ba8a81d5f5fb16524b56ddb9f35d96593955514b80d89b711ff717e11ad3d691424f6cefc5c613b04e5532d89f91383e4a6f45058604bb63876b1308dc7eb8f86cb5c032e6f1f061646e0bbf27b0c7eaa8216ba9381cb7734df24fe6691183c4823d3b645f3139a45b2b8ee3909bb431477f332ea3616b919724782fda8546a3235
 Ctrl.hexxcghash = hexxcghash:fe491f41cdbcaec6b8821eda916eb03bc1a0e934c14850696f79bd30c73a18e2
 Ctrl.hexsession_id = hexsession_id:df1c0910cf8b81ca157916b8ac0411b7363f62ce10ee23cbb69ddfe8c3f16be9
@@ -3276,7 +3277,7 @@ Ctrl.type = type:A
 Output = ebb3d10f461d8697a064461822f34507
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001001b3a1cab1e87a29e229efcae0f569d855a61d6da6ea0ae5bed3491c7bdb5f70f6caf8dc305100160bbf6ecd726b11799da685ce4528ee689fe292043e318ad9f797bd5746399e007cf1f40d7918b85e4607f6e674da84709543dd0d50ad1d5c993770b4d0c045fdef89d5534c3d77edd8dc4536a10cc2b5d0bd14caa7e029ba8a81d5f5fb16524b56ddb9f35d96593955514b80d89b711ff717e11ad3d691424f6cefc5c613b04e5532d89f91383e4a6f45058604bb63876b1308dc7eb8f86cb5c032e6f1f061646e0bbf27b0c7eaa8216ba9381cb7734df24fe6691183c4823d3b645f3139a45b2b8ee3909bb431477f332ea3616b919724782fda8546a3235
 Ctrl.hexxcghash = hexxcghash:fe491f41cdbcaec6b8821eda916eb03bc1a0e934c14850696f79bd30c73a18e2
 Ctrl.hexsession_id = hexsession_id:df1c0910cf8b81ca157916b8ac0411b7363f62ce10ee23cbb69ddfe8c3f16be9
@@ -3284,7 +3285,7 @@ Ctrl.type = type:B
 Output = bb95f9cbed695529fd7977281332100b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001001b3a1cab1e87a29e229efcae0f569d855a61d6da6ea0ae5bed3491c7bdb5f70f6caf8dc305100160bbf6ecd726b11799da685ce4528ee689fe292043e318ad9f797bd5746399e007cf1f40d7918b85e4607f6e674da84709543dd0d50ad1d5c993770b4d0c045fdef89d5534c3d77edd8dc4536a10cc2b5d0bd14caa7e029ba8a81d5f5fb16524b56ddb9f35d96593955514b80d89b711ff717e11ad3d691424f6cefc5c613b04e5532d89f91383e4a6f45058604bb63876b1308dc7eb8f86cb5c032e6f1f061646e0bbf27b0c7eaa8216ba9381cb7734df24fe6691183c4823d3b645f3139a45b2b8ee3909bb431477f332ea3616b919724782fda8546a3235
 Ctrl.hexxcghash = hexxcghash:fe491f41cdbcaec6b8821eda916eb03bc1a0e934c14850696f79bd30c73a18e2
 Ctrl.hexsession_id = hexsession_id:df1c0910cf8b81ca157916b8ac0411b7363f62ce10ee23cbb69ddfe8c3f16be9
@@ -3292,7 +3293,7 @@ Ctrl.type = type:C
 Output = da1318a6a34224cc86c9afa41991db4b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001001b3a1cab1e87a29e229efcae0f569d855a61d6da6ea0ae5bed3491c7bdb5f70f6caf8dc305100160bbf6ecd726b11799da685ce4528ee689fe292043e318ad9f797bd5746399e007cf1f40d7918b85e4607f6e674da84709543dd0d50ad1d5c993770b4d0c045fdef89d5534c3d77edd8dc4536a10cc2b5d0bd14caa7e029ba8a81d5f5fb16524b56ddb9f35d96593955514b80d89b711ff717e11ad3d691424f6cefc5c613b04e5532d89f91383e4a6f45058604bb63876b1308dc7eb8f86cb5c032e6f1f061646e0bbf27b0c7eaa8216ba9381cb7734df24fe6691183c4823d3b645f3139a45b2b8ee3909bb431477f332ea3616b919724782fda8546a3235
 Ctrl.hexxcghash = hexxcghash:fe491f41cdbcaec6b8821eda916eb03bc1a0e934c14850696f79bd30c73a18e2
 Ctrl.hexsession_id = hexsession_id:df1c0910cf8b81ca157916b8ac0411b7363f62ce10ee23cbb69ddfe8c3f16be9
@@ -3300,7 +3301,7 @@ Ctrl.type = type:D
 Output = 091f8fa87a01c5768de8d663ba8bf9d7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001001b3a1cab1e87a29e229efcae0f569d855a61d6da6ea0ae5bed3491c7bdb5f70f6caf8dc305100160bbf6ecd726b11799da685ce4528ee689fe292043e318ad9f797bd5746399e007cf1f40d7918b85e4607f6e674da84709543dd0d50ad1d5c993770b4d0c045fdef89d5534c3d77edd8dc4536a10cc2b5d0bd14caa7e029ba8a81d5f5fb16524b56ddb9f35d96593955514b80d89b711ff717e11ad3d691424f6cefc5c613b04e5532d89f91383e4a6f45058604bb63876b1308dc7eb8f86cb5c032e6f1f061646e0bbf27b0c7eaa8216ba9381cb7734df24fe6691183c4823d3b645f3139a45b2b8ee3909bb431477f332ea3616b919724782fda8546a3235
 Ctrl.hexxcghash = hexxcghash:fe491f41cdbcaec6b8821eda916eb03bc1a0e934c14850696f79bd30c73a18e2
 Ctrl.hexsession_id = hexsession_id:df1c0910cf8b81ca157916b8ac0411b7363f62ce10ee23cbb69ddfe8c3f16be9
@@ -3308,7 +3309,7 @@ Ctrl.type = type:E
 Output = cc09127a759000f3bd9724fbf5285cd680ee323ffc19cf2f495403f896587317
 
 KDF = SSHKDF
-Ctrl.md = md:SHA256
+Ctrl.digest = digest:SHA256
 Ctrl.hexkey = hexkey:000001001b3a1cab1e87a29e229efcae0f569d855a61d6da6ea0ae5bed3491c7bdb5f70f6caf8dc305100160bbf6ecd726b11799da685ce4528ee689fe292043e318ad9f797bd5746399e007cf1f40d7918b85e4607f6e674da84709543dd0d50ad1d5c993770b4d0c045fdef89d5534c3d77edd8dc4536a10cc2b5d0bd14caa7e029ba8a81d5f5fb16524b56ddb9f35d96593955514b80d89b711ff717e11ad3d691424f6cefc5c613b04e5532d89f91383e4a6f45058604bb63876b1308dc7eb8f86cb5c032e6f1f061646e0bbf27b0c7eaa8216ba9381cb7734df24fe6691183c4823d3b645f3139a45b2b8ee3909bb431477f332ea3616b919724782fda8546a3235
 Ctrl.hexxcghash = hexxcghash:fe491f41cdbcaec6b8821eda916eb03bc1a0e934c14850696f79bd30c73a18e2
 Ctrl.hexsession_id = hexsession_id:df1c0910cf8b81ca157916b8ac0411b7363f62ce10ee23cbb69ddfe8c3f16be9
@@ -3316,7 +3317,7 @@ Ctrl.type = type:F
 Output = a3ceddafc49f7c0131ce2965945c3892be6605b465877bc0637685612ede242b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100941456bd72267a90690ffc873528f4b76394431aceee1e24a7bed414568d9b97c84ce13d34a2b4a63ef735bac23af0b7fa634a9e56c2d775c741a61d63981332f9027d3f52c4a9a3adb83e96d39f7e6bb72514797da32f2f0edb59accfc58a49fc34b198e0285b31032ac9f06907def196f5748bd32ce22a5383a1bbdbd31f24
 Ctrl.hexxcghash = hexxcghash:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
 Ctrl.hexsession_id = hexsession_id:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
@@ -3324,7 +3325,7 @@ Ctrl.type = type:A
 Output = d31c16f67b17bc69
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100941456bd72267a90690ffc873528f4b76394431aceee1e24a7bed414568d9b97c84ce13d34a2b4a63ef735bac23af0b7fa634a9e56c2d775c741a61d63981332f9027d3f52c4a9a3adb83e96d39f7e6bb72514797da32f2f0edb59accfc58a49fc34b198e0285b31032ac9f06907def196f5748bd32ce22a5383a1bbdbd31f24
 Ctrl.hexxcghash = hexxcghash:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
 Ctrl.hexsession_id = hexsession_id:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
@@ -3332,7 +3333,7 @@ Ctrl.type = type:B
 Output = 675340f27269e7ae
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100941456bd72267a90690ffc873528f4b76394431aceee1e24a7bed414568d9b97c84ce13d34a2b4a63ef735bac23af0b7fa634a9e56c2d775c741a61d63981332f9027d3f52c4a9a3adb83e96d39f7e6bb72514797da32f2f0edb59accfc58a49fc34b198e0285b31032ac9f06907def196f5748bd32ce22a5383a1bbdbd31f24
 Ctrl.hexxcghash = hexxcghash:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
 Ctrl.hexsession_id = hexsession_id:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
@@ -3340,7 +3341,7 @@ Ctrl.type = type:C
 Output = 2ffed577a90d29872ea59f3782c3b406908d7394ff63c9d7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100941456bd72267a90690ffc873528f4b76394431aceee1e24a7bed414568d9b97c84ce13d34a2b4a63ef735bac23af0b7fa634a9e56c2d775c741a61d63981332f9027d3f52c4a9a3adb83e96d39f7e6bb72514797da32f2f0edb59accfc58a49fc34b198e0285b31032ac9f06907def196f5748bd32ce22a5383a1bbdbd31f24
 Ctrl.hexxcghash = hexxcghash:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
 Ctrl.hexsession_id = hexsession_id:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
@@ -3348,7 +3349,7 @@ Ctrl.type = type:D
 Output = fae751987c1fa8665e4387e410297db58ff69b260a8fe85f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100941456bd72267a90690ffc873528f4b76394431aceee1e24a7bed414568d9b97c84ce13d34a2b4a63ef735bac23af0b7fa634a9e56c2d775c741a61d63981332f9027d3f52c4a9a3adb83e96d39f7e6bb72514797da32f2f0edb59accfc58a49fc34b198e0285b31032ac9f06907def196f5748bd32ce22a5383a1bbdbd31f24
 Ctrl.hexxcghash = hexxcghash:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
 Ctrl.hexsession_id = hexsession_id:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
@@ -3356,7 +3357,7 @@ Ctrl.type = type:E
 Output = ff2db5975edf3824325b257455791869434c6af47fb0c8145253c2695abfd2b8c980565ad20e6b9313ba44ee488bafb0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100941456bd72267a90690ffc873528f4b76394431aceee1e24a7bed414568d9b97c84ce13d34a2b4a63ef735bac23af0b7fa634a9e56c2d775c741a61d63981332f9027d3f52c4a9a3adb83e96d39f7e6bb72514797da32f2f0edb59accfc58a49fc34b198e0285b31032ac9f06907def196f5748bd32ce22a5383a1bbdbd31f24
 Ctrl.hexxcghash = hexxcghash:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
 Ctrl.hexsession_id = hexsession_id:e0dee80ccc162884393930ad2073d92120c804254162446b7d048f85a1a4dd7b636a09b69252b80952a0581e9490ee5a
@@ -3364,7 +3365,7 @@ Ctrl.type = type:F
 Output = 85a9463cd653c7619d4dc85006406d6ed3364220419ca13810301be0f0389d932ddeaebb0e504a0849e2e73a7d087db2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000080319534aabf1100b1ef3ec089ba6e5b25946bdf67cbc92493c29d0e63765ee38dc27e15720393d6aa5741b2129b24ee6a71c079190588232f4facadd034dd6e456bf45aedf72a059eca591ceb2d7c50f8ae918528872f40eaf62faa511d6bfbed4b8613163c42b99eb30c20ecce1c36a78b93fb0046467a0bcb41dfa1e609b61b
 Ctrl.hexxcghash = hexxcghash:0f831ff3e907b3f0922722bd8073b2c263c77c7f552c0b0b12be68f19520b1ae2bbf62a9dba0f582d5f0197c0d534f6e
 Ctrl.hexsession_id = hexsession_id:dede417f4b45d58d54cbe59e7d80bab3150ccd99583aa87f7ecde731462d074edf49907278819043341d1fe20e136563
@@ -3372,7 +3373,7 @@ Ctrl.type = type:A
 Output = 93323451441b761f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000080319534aabf1100b1ef3ec089ba6e5b25946bdf67cbc92493c29d0e63765ee38dc27e15720393d6aa5741b2129b24ee6a71c079190588232f4facadd034dd6e456bf45aedf72a059eca591ceb2d7c50f8ae918528872f40eaf62faa511d6bfbed4b8613163c42b99eb30c20ecce1c36a78b93fb0046467a0bcb41dfa1e609b61b
 Ctrl.hexxcghash = hexxcghash:0f831ff3e907b3f0922722bd8073b2c263c77c7f552c0b0b12be68f19520b1ae2bbf62a9dba0f582d5f0197c0d534f6e
 Ctrl.hexsession_id = hexsession_id:dede417f4b45d58d54cbe59e7d80bab3150ccd99583aa87f7ecde731462d074edf49907278819043341d1fe20e136563
@@ -3380,7 +3381,7 @@ Ctrl.type = type:B
 Output = 3dbfdc2364807ecc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000080319534aabf1100b1ef3ec089ba6e5b25946bdf67cbc92493c29d0e63765ee38dc27e15720393d6aa5741b2129b24ee6a71c079190588232f4facadd034dd6e456bf45aedf72a059eca591ceb2d7c50f8ae918528872f40eaf62faa511d6bfbed4b8613163c42b99eb30c20ecce1c36a78b93fb0046467a0bcb41dfa1e609b61b
 Ctrl.hexxcghash = hexxcghash:0f831ff3e907b3f0922722bd8073b2c263c77c7f552c0b0b12be68f19520b1ae2bbf62a9dba0f582d5f0197c0d534f6e
 Ctrl.hexsession_id = hexsession_id:dede417f4b45d58d54cbe59e7d80bab3150ccd99583aa87f7ecde731462d074edf49907278819043341d1fe20e136563
@@ -3388,7 +3389,7 @@ Ctrl.type = type:C
 Output = c699e3488f825fb24c5e2adc699ec83a5d8fce339fa0e9b0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000080319534aabf1100b1ef3ec089ba6e5b25946bdf67cbc92493c29d0e63765ee38dc27e15720393d6aa5741b2129b24ee6a71c079190588232f4facadd034dd6e456bf45aedf72a059eca591ceb2d7c50f8ae918528872f40eaf62faa511d6bfbed4b8613163c42b99eb30c20ecce1c36a78b93fb0046467a0bcb41dfa1e609b61b
 Ctrl.hexxcghash = hexxcghash:0f831ff3e907b3f0922722bd8073b2c263c77c7f552c0b0b12be68f19520b1ae2bbf62a9dba0f582d5f0197c0d534f6e
 Ctrl.hexsession_id = hexsession_id:dede417f4b45d58d54cbe59e7d80bab3150ccd99583aa87f7ecde731462d074edf49907278819043341d1fe20e136563
@@ -3396,7 +3397,7 @@ Ctrl.type = type:D
 Output = a250b13da0716f2d4440cc4cac01a2d591002ebfaada9758
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000080319534aabf1100b1ef3ec089ba6e5b25946bdf67cbc92493c29d0e63765ee38dc27e15720393d6aa5741b2129b24ee6a71c079190588232f4facadd034dd6e456bf45aedf72a059eca591ceb2d7c50f8ae918528872f40eaf62faa511d6bfbed4b8613163c42b99eb30c20ecce1c36a78b93fb0046467a0bcb41dfa1e609b61b
 Ctrl.hexxcghash = hexxcghash:0f831ff3e907b3f0922722bd8073b2c263c77c7f552c0b0b12be68f19520b1ae2bbf62a9dba0f582d5f0197c0d534f6e
 Ctrl.hexsession_id = hexsession_id:dede417f4b45d58d54cbe59e7d80bab3150ccd99583aa87f7ecde731462d074edf49907278819043341d1fe20e136563
@@ -3404,7 +3405,7 @@ Ctrl.type = type:E
 Output = 76966a1b7d5f250eea3696077a373b9421e8294dd7cb0aedd172cf9c6879ef34c9deb9c208f11c5d4b6fd713b576894d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000080319534aabf1100b1ef3ec089ba6e5b25946bdf67cbc92493c29d0e63765ee38dc27e15720393d6aa5741b2129b24ee6a71c079190588232f4facadd034dd6e456bf45aedf72a059eca591ceb2d7c50f8ae918528872f40eaf62faa511d6bfbed4b8613163c42b99eb30c20ecce1c36a78b93fb0046467a0bcb41dfa1e609b61b
 Ctrl.hexxcghash = hexxcghash:0f831ff3e907b3f0922722bd8073b2c263c77c7f552c0b0b12be68f19520b1ae2bbf62a9dba0f582d5f0197c0d534f6e
 Ctrl.hexsession_id = hexsession_id:dede417f4b45d58d54cbe59e7d80bab3150ccd99583aa87f7ecde731462d074edf49907278819043341d1fe20e136563
@@ -3412,7 +3413,7 @@ Ctrl.type = type:F
 Output = 28a66e21fe7f8a070fe40ecf68a64f2a35a46b84ac38810902639906611053832179d5c07a8422993496059af67f585f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000803b4fd086d25a4bf0b5347a2e323d45525b12a3df508b9129ae7d51637b6fc76aba743d7ee254888ee6d49314ebd8b82e25d187e80770ff6365fbfe96029e23b92ccbb2bfb4cf27e175cd09154b0e68d75a84c490f936ee0366180f781049ddcfefcb4bf25409ba8a8a9a3296cf0619bc51363abfd58cea3d0480673d8ac8370a
 Ctrl.hexxcghash = hexxcghash:8fbe46474bf6ccdad0f706492c4b534cf5698b38afc4b21a6af4a00c3ccda689cf5382e5de34a48bd798f083570ad411
 Ctrl.hexsession_id = hexsession_id:a397aa78a58fcf619f1e8368018d6e40934d4befc96671a63aea4558d5e54c9f42bdca50f618ec84b2d19b539a1f10f1
@@ -3420,7 +3421,7 @@ Ctrl.type = type:A
 Output = b0db344b1e2e98d3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000803b4fd086d25a4bf0b5347a2e323d45525b12a3df508b9129ae7d51637b6fc76aba743d7ee254888ee6d49314ebd8b82e25d187e80770ff6365fbfe96029e23b92ccbb2bfb4cf27e175cd09154b0e68d75a84c490f936ee0366180f781049ddcfefcb4bf25409ba8a8a9a3296cf0619bc51363abfd58cea3d0480673d8ac8370a
 Ctrl.hexxcghash = hexxcghash:8fbe46474bf6ccdad0f706492c4b534cf5698b38afc4b21a6af4a00c3ccda689cf5382e5de34a48bd798f083570ad411
 Ctrl.hexsession_id = hexsession_id:a397aa78a58fcf619f1e8368018d6e40934d4befc96671a63aea4558d5e54c9f42bdca50f618ec84b2d19b539a1f10f1
@@ -3428,7 +3429,7 @@ Ctrl.type = type:B
 Output = 29fcd6a7d317f527
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000803b4fd086d25a4bf0b5347a2e323d45525b12a3df508b9129ae7d51637b6fc76aba743d7ee254888ee6d49314ebd8b82e25d187e80770ff6365fbfe96029e23b92ccbb2bfb4cf27e175cd09154b0e68d75a84c490f936ee0366180f781049ddcfefcb4bf25409ba8a8a9a3296cf0619bc51363abfd58cea3d0480673d8ac8370a
 Ctrl.hexxcghash = hexxcghash:8fbe46474bf6ccdad0f706492c4b534cf5698b38afc4b21a6af4a00c3ccda689cf5382e5de34a48bd798f083570ad411
 Ctrl.hexsession_id = hexsession_id:a397aa78a58fcf619f1e8368018d6e40934d4befc96671a63aea4558d5e54c9f42bdca50f618ec84b2d19b539a1f10f1
@@ -3436,7 +3437,7 @@ Ctrl.type = type:C
 Output = 156f9d4c58d7783959e785af3fefb133662009b93891bff7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000803b4fd086d25a4bf0b5347a2e323d45525b12a3df508b9129ae7d51637b6fc76aba743d7ee254888ee6d49314ebd8b82e25d187e80770ff6365fbfe96029e23b92ccbb2bfb4cf27e175cd09154b0e68d75a84c490f936ee0366180f781049ddcfefcb4bf25409ba8a8a9a3296cf0619bc51363abfd58cea3d0480673d8ac8370a
 Ctrl.hexxcghash = hexxcghash:8fbe46474bf6ccdad0f706492c4b534cf5698b38afc4b21a6af4a00c3ccda689cf5382e5de34a48bd798f083570ad411
 Ctrl.hexsession_id = hexsession_id:a397aa78a58fcf619f1e8368018d6e40934d4befc96671a63aea4558d5e54c9f42bdca50f618ec84b2d19b539a1f10f1
@@ -3444,7 +3445,7 @@ Ctrl.type = type:D
 Output = c4bc4471e2c7f04dbef9100977e222f4156a7118a122f6cd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000803b4fd086d25a4bf0b5347a2e323d45525b12a3df508b9129ae7d51637b6fc76aba743d7ee254888ee6d49314ebd8b82e25d187e80770ff6365fbfe96029e23b92ccbb2bfb4cf27e175cd09154b0e68d75a84c490f936ee0366180f781049ddcfefcb4bf25409ba8a8a9a3296cf0619bc51363abfd58cea3d0480673d8ac8370a
 Ctrl.hexxcghash = hexxcghash:8fbe46474bf6ccdad0f706492c4b534cf5698b38afc4b21a6af4a00c3ccda689cf5382e5de34a48bd798f083570ad411
 Ctrl.hexsession_id = hexsession_id:a397aa78a58fcf619f1e8368018d6e40934d4befc96671a63aea4558d5e54c9f42bdca50f618ec84b2d19b539a1f10f1
@@ -3452,7 +3453,7 @@ Ctrl.type = type:E
 Output = 5878fdbf693638430e31b287ad8cfab560d952d7a828167bd0454e0c8aa14274c7c0c1921a31575f77fd80144e6d2999
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000803b4fd086d25a4bf0b5347a2e323d45525b12a3df508b9129ae7d51637b6fc76aba743d7ee254888ee6d49314ebd8b82e25d187e80770ff6365fbfe96029e23b92ccbb2bfb4cf27e175cd09154b0e68d75a84c490f936ee0366180f781049ddcfefcb4bf25409ba8a8a9a3296cf0619bc51363abfd58cea3d0480673d8ac8370a
 Ctrl.hexxcghash = hexxcghash:8fbe46474bf6ccdad0f706492c4b534cf5698b38afc4b21a6af4a00c3ccda689cf5382e5de34a48bd798f083570ad411
 Ctrl.hexsession_id = hexsession_id:a397aa78a58fcf619f1e8368018d6e40934d4befc96671a63aea4558d5e54c9f42bdca50f618ec84b2d19b539a1f10f1
@@ -3460,7 +3461,7 @@ Ctrl.type = type:F
 Output = 1fdb34ae9d2f12363350dd5aeefe728066500a083668ac2d48af671d7651a67acdf9b7a0581b922e67278d53f0b2fb17
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801a3eab3e516f776ab0a282861a42fec52223859d5af2da778727bd0363ba5983b5d883cd75132c94351a7b5b23fba10aec35a78ab03ba183682b4d3e72c67bd1e6b83afc5178c97624f718243d9377694f085e15cef33040fca144e856c74ab0e70dbf4a7766aa916e5edf184ae7dbd3f19d2491e45828fe5969d61075695e39
 Ctrl.hexxcghash = hexxcghash:5e9be9089c8b952d8ffdb0cbdbe5bb6c1f336e6620292da1ab5eb92eef379655579e24cd6273bd4f552d46dfa87df917
 Ctrl.hexsession_id = hexsession_id:c54542e32ba1ae8c266781c6d14c8356d6f548cfdb8a303c4f1c947318610eed8ae3d6d4350ab4dddc7f9202a510d32e
@@ -3468,7 +3469,7 @@ Ctrl.type = type:A
 Output = c828150149eb433a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801a3eab3e516f776ab0a282861a42fec52223859d5af2da778727bd0363ba5983b5d883cd75132c94351a7b5b23fba10aec35a78ab03ba183682b4d3e72c67bd1e6b83afc5178c97624f718243d9377694f085e15cef33040fca144e856c74ab0e70dbf4a7766aa916e5edf184ae7dbd3f19d2491e45828fe5969d61075695e39
 Ctrl.hexxcghash = hexxcghash:5e9be9089c8b952d8ffdb0cbdbe5bb6c1f336e6620292da1ab5eb92eef379655579e24cd6273bd4f552d46dfa87df917
 Ctrl.hexsession_id = hexsession_id:c54542e32ba1ae8c266781c6d14c8356d6f548cfdb8a303c4f1c947318610eed8ae3d6d4350ab4dddc7f9202a510d32e
@@ -3476,7 +3477,7 @@ Ctrl.type = type:B
 Output = 45636e088875de58
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801a3eab3e516f776ab0a282861a42fec52223859d5af2da778727bd0363ba5983b5d883cd75132c94351a7b5b23fba10aec35a78ab03ba183682b4d3e72c67bd1e6b83afc5178c97624f718243d9377694f085e15cef33040fca144e856c74ab0e70dbf4a7766aa916e5edf184ae7dbd3f19d2491e45828fe5969d61075695e39
 Ctrl.hexxcghash = hexxcghash:5e9be9089c8b952d8ffdb0cbdbe5bb6c1f336e6620292da1ab5eb92eef379655579e24cd6273bd4f552d46dfa87df917
 Ctrl.hexsession_id = hexsession_id:c54542e32ba1ae8c266781c6d14c8356d6f548cfdb8a303c4f1c947318610eed8ae3d6d4350ab4dddc7f9202a510d32e
@@ -3484,7 +3485,7 @@ Ctrl.type = type:C
 Output = 75da9408e65f61dac9dafa496675214b0d84b0e66feb68fe
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801a3eab3e516f776ab0a282861a42fec52223859d5af2da778727bd0363ba5983b5d883cd75132c94351a7b5b23fba10aec35a78ab03ba183682b4d3e72c67bd1e6b83afc5178c97624f718243d9377694f085e15cef33040fca144e856c74ab0e70dbf4a7766aa916e5edf184ae7dbd3f19d2491e45828fe5969d61075695e39
 Ctrl.hexxcghash = hexxcghash:5e9be9089c8b952d8ffdb0cbdbe5bb6c1f336e6620292da1ab5eb92eef379655579e24cd6273bd4f552d46dfa87df917
 Ctrl.hexsession_id = hexsession_id:c54542e32ba1ae8c266781c6d14c8356d6f548cfdb8a303c4f1c947318610eed8ae3d6d4350ab4dddc7f9202a510d32e
@@ -3492,7 +3493,7 @@ Ctrl.type = type:D
 Output = cb7897fdeb2c235be5812d1959cb55907ff02a9cf6c76c17
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801a3eab3e516f776ab0a282861a42fec52223859d5af2da778727bd0363ba5983b5d883cd75132c94351a7b5b23fba10aec35a78ab03ba183682b4d3e72c67bd1e6b83afc5178c97624f718243d9377694f085e15cef33040fca144e856c74ab0e70dbf4a7766aa916e5edf184ae7dbd3f19d2491e45828fe5969d61075695e39
 Ctrl.hexxcghash = hexxcghash:5e9be9089c8b952d8ffdb0cbdbe5bb6c1f336e6620292da1ab5eb92eef379655579e24cd6273bd4f552d46dfa87df917
 Ctrl.hexsession_id = hexsession_id:c54542e32ba1ae8c266781c6d14c8356d6f548cfdb8a303c4f1c947318610eed8ae3d6d4350ab4dddc7f9202a510d32e
@@ -3500,7 +3501,7 @@ Ctrl.type = type:E
 Output = 13a8062561c28c1bc678a019b22da95aa462f82cfff6268876ffe2fddc86536fa4d19bdc15d90c1cff4d37e69f1fc021
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801a3eab3e516f776ab0a282861a42fec52223859d5af2da778727bd0363ba5983b5d883cd75132c94351a7b5b23fba10aec35a78ab03ba183682b4d3e72c67bd1e6b83afc5178c97624f718243d9377694f085e15cef33040fca144e856c74ab0e70dbf4a7766aa916e5edf184ae7dbd3f19d2491e45828fe5969d61075695e39
 Ctrl.hexxcghash = hexxcghash:5e9be9089c8b952d8ffdb0cbdbe5bb6c1f336e6620292da1ab5eb92eef379655579e24cd6273bd4f552d46dfa87df917
 Ctrl.hexsession_id = hexsession_id:c54542e32ba1ae8c266781c6d14c8356d6f548cfdb8a303c4f1c947318610eed8ae3d6d4350ab4dddc7f9202a510d32e
@@ -3508,7 +3509,7 @@ Ctrl.type = type:F
 Output = 69437ec44d764caeb89faebf7b8577b433677abcb0c58f166a5e5724a4eb293d335004d412c983d4c7aca4df1b8328fd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000810091473fb24a9fca3fd1639c029c0e6ae6390c83b3278336017068771569d0957bf7ff80a8f188b936f7e238502efc86e518ebafcc4ecdf1b44f01bb070b3cc88c1b23937dcd04c456987a3b75df3874ca54a10e7f4a3123a7fb47365a7552c9e3f7070ec19d1ebb9922dd10aa0280222db770a71ce9541b60b53d9e7783350100
 Ctrl.hexxcghash = hexxcghash:d0bbb1a81edca6ae7ac5c9e60bf447d198bf875b945fcba06b0074e640331b2205c2c055864c011913f6dad3e34ed44b
 Ctrl.hexsession_id = hexsession_id:58d7b77f0cc5480254c68e4e9cb06a1ea5389b39a3f9cba5c9ca03a091fb123aeb5934c519b60181d097b8cc9455b96a
@@ -3516,7 +3517,7 @@ Ctrl.type = type:A
 Output = b669e05aa9706468
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000810091473fb24a9fca3fd1639c029c0e6ae6390c83b3278336017068771569d0957bf7ff80a8f188b936f7e238502efc86e518ebafcc4ecdf1b44f01bb070b3cc88c1b23937dcd04c456987a3b75df3874ca54a10e7f4a3123a7fb47365a7552c9e3f7070ec19d1ebb9922dd10aa0280222db770a71ce9541b60b53d9e7783350100
 Ctrl.hexxcghash = hexxcghash:d0bbb1a81edca6ae7ac5c9e60bf447d198bf875b945fcba06b0074e640331b2205c2c055864c011913f6dad3e34ed44b
 Ctrl.hexsession_id = hexsession_id:58d7b77f0cc5480254c68e4e9cb06a1ea5389b39a3f9cba5c9ca03a091fb123aeb5934c519b60181d097b8cc9455b96a
@@ -3524,7 +3525,7 @@ Ctrl.type = type:B
 Output = 57f943111ca01b15
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000810091473fb24a9fca3fd1639c029c0e6ae6390c83b3278336017068771569d0957bf7ff80a8f188b936f7e238502efc86e518ebafcc4ecdf1b44f01bb070b3cc88c1b23937dcd04c456987a3b75df3874ca54a10e7f4a3123a7fb47365a7552c9e3f7070ec19d1ebb9922dd10aa0280222db770a71ce9541b60b53d9e7783350100
 Ctrl.hexxcghash = hexxcghash:d0bbb1a81edca6ae7ac5c9e60bf447d198bf875b945fcba06b0074e640331b2205c2c055864c011913f6dad3e34ed44b
 Ctrl.hexsession_id = hexsession_id:58d7b77f0cc5480254c68e4e9cb06a1ea5389b39a3f9cba5c9ca03a091fb123aeb5934c519b60181d097b8cc9455b96a
@@ -3532,7 +3533,7 @@ Ctrl.type = type:C
 Output = e9aa354b6b85f357d6f982fcc18a6ca797bd7a125e786f8a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000810091473fb24a9fca3fd1639c029c0e6ae6390c83b3278336017068771569d0957bf7ff80a8f188b936f7e238502efc86e518ebafcc4ecdf1b44f01bb070b3cc88c1b23937dcd04c456987a3b75df3874ca54a10e7f4a3123a7fb47365a7552c9e3f7070ec19d1ebb9922dd10aa0280222db770a71ce9541b60b53d9e7783350100
 Ctrl.hexxcghash = hexxcghash:d0bbb1a81edca6ae7ac5c9e60bf447d198bf875b945fcba06b0074e640331b2205c2c055864c011913f6dad3e34ed44b
 Ctrl.hexsession_id = hexsession_id:58d7b77f0cc5480254c68e4e9cb06a1ea5389b39a3f9cba5c9ca03a091fb123aeb5934c519b60181d097b8cc9455b96a
@@ -3540,7 +3541,7 @@ Ctrl.type = type:D
 Output = 199d2b244689bfc4f807f225a7130a069c8a181f5b20d32a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000810091473fb24a9fca3fd1639c029c0e6ae6390c83b3278336017068771569d0957bf7ff80a8f188b936f7e238502efc86e518ebafcc4ecdf1b44f01bb070b3cc88c1b23937dcd04c456987a3b75df3874ca54a10e7f4a3123a7fb47365a7552c9e3f7070ec19d1ebb9922dd10aa0280222db770a71ce9541b60b53d9e7783350100
 Ctrl.hexxcghash = hexxcghash:d0bbb1a81edca6ae7ac5c9e60bf447d198bf875b945fcba06b0074e640331b2205c2c055864c011913f6dad3e34ed44b
 Ctrl.hexsession_id = hexsession_id:58d7b77f0cc5480254c68e4e9cb06a1ea5389b39a3f9cba5c9ca03a091fb123aeb5934c519b60181d097b8cc9455b96a
@@ -3548,7 +3549,7 @@ Ctrl.type = type:E
 Output = 69b55cc82d0429979a3832a3be35483596ff1d26a0c1a62944695764f0eb85c3467528be225db2f516e79f23c0c7c23c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000810091473fb24a9fca3fd1639c029c0e6ae6390c83b3278336017068771569d0957bf7ff80a8f188b936f7e238502efc86e518ebafcc4ecdf1b44f01bb070b3cc88c1b23937dcd04c456987a3b75df3874ca54a10e7f4a3123a7fb47365a7552c9e3f7070ec19d1ebb9922dd10aa0280222db770a71ce9541b60b53d9e7783350100
 Ctrl.hexxcghash = hexxcghash:d0bbb1a81edca6ae7ac5c9e60bf447d198bf875b945fcba06b0074e640331b2205c2c055864c011913f6dad3e34ed44b
 Ctrl.hexsession_id = hexsession_id:58d7b77f0cc5480254c68e4e9cb06a1ea5389b39a3f9cba5c9ca03a091fb123aeb5934c519b60181d097b8cc9455b96a
@@ -3556,7 +3557,7 @@ Ctrl.type = type:F
 Output = 6e06df643269751dfc9c8decefe466e1ab2ab99466661aa6f0dfab223c3b9bebcaed4c19cbc4109dfacda81cc8f902eb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801b8e7d2292f95d97c99e9c93fcc681f2a446437d7595137f761eb9351f50cfb71988aad2d9611a5e3d32c58b1efef596b2b495c12355b6caa5c647237670c7cbeb7b7ef5d39b600b44ab1cecc7ff454981f70366f5dc95f790c9744e55b0b5cee770df10dc3f081b8774b4735c86917384ed7da0b597bd932e676b7ef6fe2cd3
 Ctrl.hexxcghash = hexxcghash:d1ecf201e213b656e7e002d26b263ead5ef6f265a2cfd05eb83985dbc1dd0620f729800a92f676e6c8219aadbea0a037
 Ctrl.hexsession_id = hexsession_id:fc6bb80f9116c6746603327d5338e853f37b06593402e31bf5a43abd5e6de8f26166bb572ce0c88360a7bbbe83d0377b
@@ -3564,7 +3565,7 @@ Ctrl.type = type:A
 Output = b2ada53484907db5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801b8e7d2292f95d97c99e9c93fcc681f2a446437d7595137f761eb9351f50cfb71988aad2d9611a5e3d32c58b1efef596b2b495c12355b6caa5c647237670c7cbeb7b7ef5d39b600b44ab1cecc7ff454981f70366f5dc95f790c9744e55b0b5cee770df10dc3f081b8774b4735c86917384ed7da0b597bd932e676b7ef6fe2cd3
 Ctrl.hexxcghash = hexxcghash:d1ecf201e213b656e7e002d26b263ead5ef6f265a2cfd05eb83985dbc1dd0620f729800a92f676e6c8219aadbea0a037
 Ctrl.hexsession_id = hexsession_id:fc6bb80f9116c6746603327d5338e853f37b06593402e31bf5a43abd5e6de8f26166bb572ce0c88360a7bbbe83d0377b
@@ -3572,7 +3573,7 @@ Ctrl.type = type:B
 Output = 89224486fcb33030
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801b8e7d2292f95d97c99e9c93fcc681f2a446437d7595137f761eb9351f50cfb71988aad2d9611a5e3d32c58b1efef596b2b495c12355b6caa5c647237670c7cbeb7b7ef5d39b600b44ab1cecc7ff454981f70366f5dc95f790c9744e55b0b5cee770df10dc3f081b8774b4735c86917384ed7da0b597bd932e676b7ef6fe2cd3
 Ctrl.hexxcghash = hexxcghash:d1ecf201e213b656e7e002d26b263ead5ef6f265a2cfd05eb83985dbc1dd0620f729800a92f676e6c8219aadbea0a037
 Ctrl.hexsession_id = hexsession_id:fc6bb80f9116c6746603327d5338e853f37b06593402e31bf5a43abd5e6de8f26166bb572ce0c88360a7bbbe83d0377b
@@ -3580,7 +3581,7 @@ Ctrl.type = type:C
 Output = 38ccc00303d5aaf748f3c11d986b99f9bf36049a6f7ea92f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801b8e7d2292f95d97c99e9c93fcc681f2a446437d7595137f761eb9351f50cfb71988aad2d9611a5e3d32c58b1efef596b2b495c12355b6caa5c647237670c7cbeb7b7ef5d39b600b44ab1cecc7ff454981f70366f5dc95f790c9744e55b0b5cee770df10dc3f081b8774b4735c86917384ed7da0b597bd932e676b7ef6fe2cd3
 Ctrl.hexxcghash = hexxcghash:d1ecf201e213b656e7e002d26b263ead5ef6f265a2cfd05eb83985dbc1dd0620f729800a92f676e6c8219aadbea0a037
 Ctrl.hexsession_id = hexsession_id:fc6bb80f9116c6746603327d5338e853f37b06593402e31bf5a43abd5e6de8f26166bb572ce0c88360a7bbbe83d0377b
@@ -3588,7 +3589,7 @@ Ctrl.type = type:D
 Output = f8a7a4b2e1d28c6a38e120a2cb876ed49f454ea2aabc3a99
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801b8e7d2292f95d97c99e9c93fcc681f2a446437d7595137f761eb9351f50cfb71988aad2d9611a5e3d32c58b1efef596b2b495c12355b6caa5c647237670c7cbeb7b7ef5d39b600b44ab1cecc7ff454981f70366f5dc95f790c9744e55b0b5cee770df10dc3f081b8774b4735c86917384ed7da0b597bd932e676b7ef6fe2cd3
 Ctrl.hexxcghash = hexxcghash:d1ecf201e213b656e7e002d26b263ead5ef6f265a2cfd05eb83985dbc1dd0620f729800a92f676e6c8219aadbea0a037
 Ctrl.hexsession_id = hexsession_id:fc6bb80f9116c6746603327d5338e853f37b06593402e31bf5a43abd5e6de8f26166bb572ce0c88360a7bbbe83d0377b
@@ -3596,7 +3597,7 @@ Ctrl.type = type:E
 Output = 9f42ab15d0b041019960ff6a5a12e209c427dc334434126399fb8850ec8feda957b74f1976b4c8a97906d7d64c5c2a83
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000000801b8e7d2292f95d97c99e9c93fcc681f2a446437d7595137f761eb9351f50cfb71988aad2d9611a5e3d32c58b1efef596b2b495c12355b6caa5c647237670c7cbeb7b7ef5d39b600b44ab1cecc7ff454981f70366f5dc95f790c9744e55b0b5cee770df10dc3f081b8774b4735c86917384ed7da0b597bd932e676b7ef6fe2cd3
 Ctrl.hexxcghash = hexxcghash:d1ecf201e213b656e7e002d26b263ead5ef6f265a2cfd05eb83985dbc1dd0620f729800a92f676e6c8219aadbea0a037
 Ctrl.hexsession_id = hexsession_id:fc6bb80f9116c6746603327d5338e853f37b06593402e31bf5a43abd5e6de8f26166bb572ce0c88360a7bbbe83d0377b
@@ -3604,7 +3605,7 @@ Ctrl.type = type:F
 Output = d383bedd3b80ddc470db9b819893e85dfab9e359e40bc77576e23ed8c5e73beecefb511ccdf1eb66416c271be5f90199
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000081008efe3279e8fc51acceea0ad5958364c2a36315d92ce4d68f6f8486b3160293e4eff79998474b954431a6981864a34445b4bd68e5b598dbaba4de5661ef0b09d5dae9b1633da886f1540d1df601c1acaa139de540d3d8d0b01602559a833aab87730de5c6875b78f5ec6d19145db46e2a77cbb9ec39b1bdbd5ca3be193dcfd622
 Ctrl.hexxcghash = hexxcghash:5f6f8bd8d664b1f31c615cf457a5c7eaa8733bba6557f15f300cfb364b0ea927bcfe406ea5fb7e03ac648fd18cd93372
 Ctrl.hexsession_id = hexsession_id:a89ecfd6636423e8d5ba8da3aa8367092b1a662df5693c55cbc5bfabb97320d90692e6c9305af47c25e6617200648752
@@ -3612,7 +3613,7 @@ Ctrl.type = type:A
 Output = bac9e6c9553bba95
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000081008efe3279e8fc51acceea0ad5958364c2a36315d92ce4d68f6f8486b3160293e4eff79998474b954431a6981864a34445b4bd68e5b598dbaba4de5661ef0b09d5dae9b1633da886f1540d1df601c1acaa139de540d3d8d0b01602559a833aab87730de5c6875b78f5ec6d19145db46e2a77cbb9ec39b1bdbd5ca3be193dcfd622
 Ctrl.hexxcghash = hexxcghash:5f6f8bd8d664b1f31c615cf457a5c7eaa8733bba6557f15f300cfb364b0ea927bcfe406ea5fb7e03ac648fd18cd93372
 Ctrl.hexsession_id = hexsession_id:a89ecfd6636423e8d5ba8da3aa8367092b1a662df5693c55cbc5bfabb97320d90692e6c9305af47c25e6617200648752
@@ -3620,7 +3621,7 @@ Ctrl.type = type:B
 Output = f29bdc017028a9ca
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000081008efe3279e8fc51acceea0ad5958364c2a36315d92ce4d68f6f8486b3160293e4eff79998474b954431a6981864a34445b4bd68e5b598dbaba4de5661ef0b09d5dae9b1633da886f1540d1df601c1acaa139de540d3d8d0b01602559a833aab87730de5c6875b78f5ec6d19145db46e2a77cbb9ec39b1bdbd5ca3be193dcfd622
 Ctrl.hexxcghash = hexxcghash:5f6f8bd8d664b1f31c615cf457a5c7eaa8733bba6557f15f300cfb364b0ea927bcfe406ea5fb7e03ac648fd18cd93372
 Ctrl.hexsession_id = hexsession_id:a89ecfd6636423e8d5ba8da3aa8367092b1a662df5693c55cbc5bfabb97320d90692e6c9305af47c25e6617200648752
@@ -3628,7 +3629,7 @@ Ctrl.type = type:C
 Output = 840f7e966d633f57bf6cfb3e6aa6bb1435bbea5822c9db0c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000081008efe3279e8fc51acceea0ad5958364c2a36315d92ce4d68f6f8486b3160293e4eff79998474b954431a6981864a34445b4bd68e5b598dbaba4de5661ef0b09d5dae9b1633da886f1540d1df601c1acaa139de540d3d8d0b01602559a833aab87730de5c6875b78f5ec6d19145db46e2a77cbb9ec39b1bdbd5ca3be193dcfd622
 Ctrl.hexxcghash = hexxcghash:5f6f8bd8d664b1f31c615cf457a5c7eaa8733bba6557f15f300cfb364b0ea927bcfe406ea5fb7e03ac648fd18cd93372
 Ctrl.hexsession_id = hexsession_id:a89ecfd6636423e8d5ba8da3aa8367092b1a662df5693c55cbc5bfabb97320d90692e6c9305af47c25e6617200648752
@@ -3636,7 +3637,7 @@ Ctrl.type = type:D
 Output = f78b485e49bf72584e45de78fbd75392e3e0b1ce2a57e7a3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000081008efe3279e8fc51acceea0ad5958364c2a36315d92ce4d68f6f8486b3160293e4eff79998474b954431a6981864a34445b4bd68e5b598dbaba4de5661ef0b09d5dae9b1633da886f1540d1df601c1acaa139de540d3d8d0b01602559a833aab87730de5c6875b78f5ec6d19145db46e2a77cbb9ec39b1bdbd5ca3be193dcfd622
 Ctrl.hexxcghash = hexxcghash:5f6f8bd8d664b1f31c615cf457a5c7eaa8733bba6557f15f300cfb364b0ea927bcfe406ea5fb7e03ac648fd18cd93372
 Ctrl.hexsession_id = hexsession_id:a89ecfd6636423e8d5ba8da3aa8367092b1a662df5693c55cbc5bfabb97320d90692e6c9305af47c25e6617200648752
@@ -3644,7 +3645,7 @@ Ctrl.type = type:E
 Output = 9dcadff513667aee5e2fda86c4a198db4252a9311635d3659db957570e448f3689444dd3e10d6097a07dba923db349ba
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000081008efe3279e8fc51acceea0ad5958364c2a36315d92ce4d68f6f8486b3160293e4eff79998474b954431a6981864a34445b4bd68e5b598dbaba4de5661ef0b09d5dae9b1633da886f1540d1df601c1acaa139de540d3d8d0b01602559a833aab87730de5c6875b78f5ec6d19145db46e2a77cbb9ec39b1bdbd5ca3be193dcfd622
 Ctrl.hexxcghash = hexxcghash:5f6f8bd8d664b1f31c615cf457a5c7eaa8733bba6557f15f300cfb364b0ea927bcfe406ea5fb7e03ac648fd18cd93372
 Ctrl.hexsession_id = hexsession_id:a89ecfd6636423e8d5ba8da3aa8367092b1a662df5693c55cbc5bfabb97320d90692e6c9305af47c25e6617200648752
@@ -3652,7 +3653,7 @@ Ctrl.type = type:F
 Output = 5e7915ea90a0d81e3c2ada00c85890b6defbb64f45ac4f0e75b22cf6187978e630f356207c97362862389a1ef99fb51a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100a89b3f9628a4f984336377edc37d3bed4aa748fa0b0a6bc80c366e8ffdf0ccbbe07229c5f02394b230759d5255e3a7d7f63a2395e2f07e2d31bf885abaea150e1f97808f26f8fe8c5113c12e4d137844160a433f8451faaf432bd7c0469dbe713304c8bed29c03cb7629cdffebc253d0a01362052f55576fdaf89702fa33cedd
 Ctrl.hexxcghash = hexxcghash:8467d0335e6e254eb02253f97cd14c0221f1b21431a4ffe1c20675039d0ac26fa70a0c4bad639834d88d01f6c1ea878e
 Ctrl.hexsession_id = hexsession_id:9a100a5b0ad81f1c603e05c5d24415f2aa7031c0d92f16de15cab350bb1a2cf3639c6906f4e220e057deb966813bbb35
@@ -3660,7 +3661,7 @@ Ctrl.type = type:A
 Output = 11811427eaa92d61
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100a89b3f9628a4f984336377edc37d3bed4aa748fa0b0a6bc80c366e8ffdf0ccbbe07229c5f02394b230759d5255e3a7d7f63a2395e2f07e2d31bf885abaea150e1f97808f26f8fe8c5113c12e4d137844160a433f8451faaf432bd7c0469dbe713304c8bed29c03cb7629cdffebc253d0a01362052f55576fdaf89702fa33cedd
 Ctrl.hexxcghash = hexxcghash:8467d0335e6e254eb02253f97cd14c0221f1b21431a4ffe1c20675039d0ac26fa70a0c4bad639834d88d01f6c1ea878e
 Ctrl.hexsession_id = hexsession_id:9a100a5b0ad81f1c603e05c5d24415f2aa7031c0d92f16de15cab350bb1a2cf3639c6906f4e220e057deb966813bbb35
@@ -3668,7 +3669,7 @@ Ctrl.type = type:B
 Output = c13f22e0bd66a551
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100a89b3f9628a4f984336377edc37d3bed4aa748fa0b0a6bc80c366e8ffdf0ccbbe07229c5f02394b230759d5255e3a7d7f63a2395e2f07e2d31bf885abaea150e1f97808f26f8fe8c5113c12e4d137844160a433f8451faaf432bd7c0469dbe713304c8bed29c03cb7629cdffebc253d0a01362052f55576fdaf89702fa33cedd
 Ctrl.hexxcghash = hexxcghash:8467d0335e6e254eb02253f97cd14c0221f1b21431a4ffe1c20675039d0ac26fa70a0c4bad639834d88d01f6c1ea878e
 Ctrl.hexsession_id = hexsession_id:9a100a5b0ad81f1c603e05c5d24415f2aa7031c0d92f16de15cab350bb1a2cf3639c6906f4e220e057deb966813bbb35
@@ -3676,7 +3677,7 @@ Ctrl.type = type:C
 Output = 2b9c9c8ecae95d75472495363ca2d46dc79babdb2e0fda40
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100a89b3f9628a4f984336377edc37d3bed4aa748fa0b0a6bc80c366e8ffdf0ccbbe07229c5f02394b230759d5255e3a7d7f63a2395e2f07e2d31bf885abaea150e1f97808f26f8fe8c5113c12e4d137844160a433f8451faaf432bd7c0469dbe713304c8bed29c03cb7629cdffebc253d0a01362052f55576fdaf89702fa33cedd
 Ctrl.hexxcghash = hexxcghash:8467d0335e6e254eb02253f97cd14c0221f1b21431a4ffe1c20675039d0ac26fa70a0c4bad639834d88d01f6c1ea878e
 Ctrl.hexsession_id = hexsession_id:9a100a5b0ad81f1c603e05c5d24415f2aa7031c0d92f16de15cab350bb1a2cf3639c6906f4e220e057deb966813bbb35
@@ -3684,7 +3685,7 @@ Ctrl.type = type:D
 Output = f466d9b9871c1482c699a5d9f8636a041adb60920c6af855
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100a89b3f9628a4f984336377edc37d3bed4aa748fa0b0a6bc80c366e8ffdf0ccbbe07229c5f02394b230759d5255e3a7d7f63a2395e2f07e2d31bf885abaea150e1f97808f26f8fe8c5113c12e4d137844160a433f8451faaf432bd7c0469dbe713304c8bed29c03cb7629cdffebc253d0a01362052f55576fdaf89702fa33cedd
 Ctrl.hexxcghash = hexxcghash:8467d0335e6e254eb02253f97cd14c0221f1b21431a4ffe1c20675039d0ac26fa70a0c4bad639834d88d01f6c1ea878e
 Ctrl.hexsession_id = hexsession_id:9a100a5b0ad81f1c603e05c5d24415f2aa7031c0d92f16de15cab350bb1a2cf3639c6906f4e220e057deb966813bbb35
@@ -3692,7 +3693,7 @@ Ctrl.type = type:E
 Output = 1ecda0252461bd08960c54ba7c570e80715780e5e99ca0f754a3d451409ed2df928daab91ed6b4044fcc68bd5f907c96
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100a89b3f9628a4f984336377edc37d3bed4aa748fa0b0a6bc80c366e8ffdf0ccbbe07229c5f02394b230759d5255e3a7d7f63a2395e2f07e2d31bf885abaea150e1f97808f26f8fe8c5113c12e4d137844160a433f8451faaf432bd7c0469dbe713304c8bed29c03cb7629cdffebc253d0a01362052f55576fdaf89702fa33cedd
 Ctrl.hexxcghash = hexxcghash:8467d0335e6e254eb02253f97cd14c0221f1b21431a4ffe1c20675039d0ac26fa70a0c4bad639834d88d01f6c1ea878e
 Ctrl.hexsession_id = hexsession_id:9a100a5b0ad81f1c603e05c5d24415f2aa7031c0d92f16de15cab350bb1a2cf3639c6906f4e220e057deb966813bbb35
@@ -3700,7 +3701,7 @@ Ctrl.type = type:F
 Output = 202e4e3dda18306c7fa518ea849cf3a4788dbc5305f71267ba69fe8920d3b18d9fc59853a4d03b18480269698e24c190
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100f6e899f2b7542fd95e88e06ff0a68e43df6f3d913f1295922bd01b98f7078b67311e002cafcb41a65262585a78b22ec97c81278f3f329d726f08fff23f4ce5b90abc694c92195fe7bc140579f54c6b89d81b836a8d3998446aab9055904ef1e0bb7553739d2351c8cfae0fbf50d8ced4bbd3975450569d0f9e441a3ed3aac776
 Ctrl.hexxcghash = hexxcghash:1853bb0d312eb00d1c700d25ddaed9680ecf28eeefe9323566dc91ef42a85b2e3049286621f43b928e2b821e5605bf60
 Ctrl.hexsession_id = hexsession_id:da7d22e3c7815b6a6089f381ddd957df3ed78e97902133d62d3ff6119d8c174b69cd26e627d6ccd98f847521aa0e3896
@@ -3708,7 +3709,7 @@ Ctrl.type = type:A
 Output = 86183fd862bf42af
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100f6e899f2b7542fd95e88e06ff0a68e43df6f3d913f1295922bd01b98f7078b67311e002cafcb41a65262585a78b22ec97c81278f3f329d726f08fff23f4ce5b90abc694c92195fe7bc140579f54c6b89d81b836a8d3998446aab9055904ef1e0bb7553739d2351c8cfae0fbf50d8ced4bbd3975450569d0f9e441a3ed3aac776
 Ctrl.hexxcghash = hexxcghash:1853bb0d312eb00d1c700d25ddaed9680ecf28eeefe9323566dc91ef42a85b2e3049286621f43b928e2b821e5605bf60
 Ctrl.hexsession_id = hexsession_id:da7d22e3c7815b6a6089f381ddd957df3ed78e97902133d62d3ff6119d8c174b69cd26e627d6ccd98f847521aa0e3896
@@ -3716,7 +3717,7 @@ Ctrl.type = type:B
 Output = 04e146b085c71253
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100f6e899f2b7542fd95e88e06ff0a68e43df6f3d913f1295922bd01b98f7078b67311e002cafcb41a65262585a78b22ec97c81278f3f329d726f08fff23f4ce5b90abc694c92195fe7bc140579f54c6b89d81b836a8d3998446aab9055904ef1e0bb7553739d2351c8cfae0fbf50d8ced4bbd3975450569d0f9e441a3ed3aac776
 Ctrl.hexxcghash = hexxcghash:1853bb0d312eb00d1c700d25ddaed9680ecf28eeefe9323566dc91ef42a85b2e3049286621f43b928e2b821e5605bf60
 Ctrl.hexsession_id = hexsession_id:da7d22e3c7815b6a6089f381ddd957df3ed78e97902133d62d3ff6119d8c174b69cd26e627d6ccd98f847521aa0e3896
@@ -3724,7 +3725,7 @@ Ctrl.type = type:C
 Output = c4364d4e0e38fe4c5fc2b2a3ad42e49a57106ffa962f4c5e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100f6e899f2b7542fd95e88e06ff0a68e43df6f3d913f1295922bd01b98f7078b67311e002cafcb41a65262585a78b22ec97c81278f3f329d726f08fff23f4ce5b90abc694c92195fe7bc140579f54c6b89d81b836a8d3998446aab9055904ef1e0bb7553739d2351c8cfae0fbf50d8ced4bbd3975450569d0f9e441a3ed3aac776
 Ctrl.hexxcghash = hexxcghash:1853bb0d312eb00d1c700d25ddaed9680ecf28eeefe9323566dc91ef42a85b2e3049286621f43b928e2b821e5605bf60
 Ctrl.hexsession_id = hexsession_id:da7d22e3c7815b6a6089f381ddd957df3ed78e97902133d62d3ff6119d8c174b69cd26e627d6ccd98f847521aa0e3896
@@ -3732,7 +3733,7 @@ Ctrl.type = type:D
 Output = b9d1549032bf336c8708f13d8f5d281d696b8bddc296e709
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100f6e899f2b7542fd95e88e06ff0a68e43df6f3d913f1295922bd01b98f7078b67311e002cafcb41a65262585a78b22ec97c81278f3f329d726f08fff23f4ce5b90abc694c92195fe7bc140579f54c6b89d81b836a8d3998446aab9055904ef1e0bb7553739d2351c8cfae0fbf50d8ced4bbd3975450569d0f9e441a3ed3aac776
 Ctrl.hexxcghash = hexxcghash:1853bb0d312eb00d1c700d25ddaed9680ecf28eeefe9323566dc91ef42a85b2e3049286621f43b928e2b821e5605bf60
 Ctrl.hexsession_id = hexsession_id:da7d22e3c7815b6a6089f381ddd957df3ed78e97902133d62d3ff6119d8c174b69cd26e627d6ccd98f847521aa0e3896
@@ -3740,7 +3741,7 @@ Ctrl.type = type:E
 Output = c7ee72c40b26fce673ff23edea3265dfeb7b7f6fd66362bbc91548fac1819a08682c65c7d69d5e54e1c48b05e7233adc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008100f6e899f2b7542fd95e88e06ff0a68e43df6f3d913f1295922bd01b98f7078b67311e002cafcb41a65262585a78b22ec97c81278f3f329d726f08fff23f4ce5b90abc694c92195fe7bc140579f54c6b89d81b836a8d3998446aab9055904ef1e0bb7553739d2351c8cfae0fbf50d8ced4bbd3975450569d0f9e441a3ed3aac776
 Ctrl.hexxcghash = hexxcghash:1853bb0d312eb00d1c700d25ddaed9680ecf28eeefe9323566dc91ef42a85b2e3049286621f43b928e2b821e5605bf60
 Ctrl.hexsession_id = hexsession_id:da7d22e3c7815b6a6089f381ddd957df3ed78e97902133d62d3ff6119d8c174b69cd26e627d6ccd98f847521aa0e3896
@@ -3748,7 +3749,7 @@ Ctrl.type = type:F
 Output = 8b52078a6d45dfaa051193da8f9c8a18bfd0c058e7be145d0c4b5b677eec54a01f9e2a20c997e9c0a1ede9576800cfe5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008008483322bb2efee6320ba1fe14f296e0b170f9a0c6f76a49d0b23abb74251da468b53fb86ddbbc55a5c4881686d1aaa9b309b65907d92352c83597126cf7e3d367f543c8887105403d9b2ba86cf2bbafd4a984dfe8ebb7b8155c51d6416c89b4efb91ef5953b0e54dbcdbe76443a80e5cd011d7d6c9bc69ec81a19749b95f6c0
 Ctrl.hexxcghash = hexxcghash:ed7b1464334bb8a04d128b791cd860c1546faaf860aff394872373f5ccac0835b47cfeb8c3d049b211cb7b570bcc1f83
 Ctrl.hexsession_id = hexsession_id:cac7b46b66372be67b4ce198311faed9ddc8f8b95f6c61d8c71a1788724ab6b8d159e2ba61f937e6d87bbb9cb24a9fe7
@@ -3756,7 +3757,7 @@ Ctrl.type = type:A
 Output = 54f4be4a33dfa102
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008008483322bb2efee6320ba1fe14f296e0b170f9a0c6f76a49d0b23abb74251da468b53fb86ddbbc55a5c4881686d1aaa9b309b65907d92352c83597126cf7e3d367f543c8887105403d9b2ba86cf2bbafd4a984dfe8ebb7b8155c51d6416c89b4efb91ef5953b0e54dbcdbe76443a80e5cd011d7d6c9bc69ec81a19749b95f6c0
 Ctrl.hexxcghash = hexxcghash:ed7b1464334bb8a04d128b791cd860c1546faaf860aff394872373f5ccac0835b47cfeb8c3d049b211cb7b570bcc1f83
 Ctrl.hexsession_id = hexsession_id:cac7b46b66372be67b4ce198311faed9ddc8f8b95f6c61d8c71a1788724ab6b8d159e2ba61f937e6d87bbb9cb24a9fe7
@@ -3764,7 +3765,7 @@ Ctrl.type = type:B
 Output = bbb084483803aab4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008008483322bb2efee6320ba1fe14f296e0b170f9a0c6f76a49d0b23abb74251da468b53fb86ddbbc55a5c4881686d1aaa9b309b65907d92352c83597126cf7e3d367f543c8887105403d9b2ba86cf2bbafd4a984dfe8ebb7b8155c51d6416c89b4efb91ef5953b0e54dbcdbe76443a80e5cd011d7d6c9bc69ec81a19749b95f6c0
 Ctrl.hexxcghash = hexxcghash:ed7b1464334bb8a04d128b791cd860c1546faaf860aff394872373f5ccac0835b47cfeb8c3d049b211cb7b570bcc1f83
 Ctrl.hexsession_id = hexsession_id:cac7b46b66372be67b4ce198311faed9ddc8f8b95f6c61d8c71a1788724ab6b8d159e2ba61f937e6d87bbb9cb24a9fe7
@@ -3772,7 +3773,7 @@ Ctrl.type = type:C
 Output = 466a038b3a5c0d72cf19cf33e5a551437933dad54bfed655
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008008483322bb2efee6320ba1fe14f296e0b170f9a0c6f76a49d0b23abb74251da468b53fb86ddbbc55a5c4881686d1aaa9b309b65907d92352c83597126cf7e3d367f543c8887105403d9b2ba86cf2bbafd4a984dfe8ebb7b8155c51d6416c89b4efb91ef5953b0e54dbcdbe76443a80e5cd011d7d6c9bc69ec81a19749b95f6c0
 Ctrl.hexxcghash = hexxcghash:ed7b1464334bb8a04d128b791cd860c1546faaf860aff394872373f5ccac0835b47cfeb8c3d049b211cb7b570bcc1f83
 Ctrl.hexsession_id = hexsession_id:cac7b46b66372be67b4ce198311faed9ddc8f8b95f6c61d8c71a1788724ab6b8d159e2ba61f937e6d87bbb9cb24a9fe7
@@ -3780,7 +3781,7 @@ Ctrl.type = type:D
 Output = 44e09698e473edc642256e99bfbfbeab1db3e254d64a3ab7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008008483322bb2efee6320ba1fe14f296e0b170f9a0c6f76a49d0b23abb74251da468b53fb86ddbbc55a5c4881686d1aaa9b309b65907d92352c83597126cf7e3d367f543c8887105403d9b2ba86cf2bbafd4a984dfe8ebb7b8155c51d6416c89b4efb91ef5953b0e54dbcdbe76443a80e5cd011d7d6c9bc69ec81a19749b95f6c0
 Ctrl.hexxcghash = hexxcghash:ed7b1464334bb8a04d128b791cd860c1546faaf860aff394872373f5ccac0835b47cfeb8c3d049b211cb7b570bcc1f83
 Ctrl.hexsession_id = hexsession_id:cac7b46b66372be67b4ce198311faed9ddc8f8b95f6c61d8c71a1788724ab6b8d159e2ba61f937e6d87bbb9cb24a9fe7
@@ -3788,7 +3789,7 @@ Ctrl.type = type:E
 Output = 8e35d767e738c4282ec1925ba5d59dad723b7220c10ae8b69c9eb3da124ac1bea8195f5ecc1c3b03953938cd1e0e190b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000008008483322bb2efee6320ba1fe14f296e0b170f9a0c6f76a49d0b23abb74251da468b53fb86ddbbc55a5c4881686d1aaa9b309b65907d92352c83597126cf7e3d367f543c8887105403d9b2ba86cf2bbafd4a984dfe8ebb7b8155c51d6416c89b4efb91ef5953b0e54dbcdbe76443a80e5cd011d7d6c9bc69ec81a19749b95f6c0
 Ctrl.hexxcghash = hexxcghash:ed7b1464334bb8a04d128b791cd860c1546faaf860aff394872373f5ccac0835b47cfeb8c3d049b211cb7b570bcc1f83
 Ctrl.hexsession_id = hexsession_id:cac7b46b66372be67b4ce198311faed9ddc8f8b95f6c61d8c71a1788724ab6b8d159e2ba61f937e6d87bbb9cb24a9fe7
@@ -3796,7 +3797,7 @@ Ctrl.type = type:F
 Output = 63e5c62c4e6f2700bfa5927ca2e730101c12a684808ddd6cf5f9da2bad3b49ba3d05d4f88a3a91f341ad2b63952e7db0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000101008174aa2fab9372c253f3b993d723b55a2484430fb338095852b7a5099f9d609ca6afa6bff9d64a55f7ef0963c684f0d17ec6045ce57ce3382870d55fcac0e1341fb47a7f76f0d5d53b67fd5e0658ecb88ae2e2e42aa4b83b8cfcce9faae941450ace059a7f223623d1c8a9924638de7eebad35be9c9f1bf38aea041114351d585a1988ba53cccc6949150f367fd790fc427916afa2cccd1d2f1aa8583b948dfe56cf488b38ec2d2570a0e0441c07ccec8b5b4db5f60250741b1aeb0bf49a85cc779ad7465f0c197735698842be2a39af8591ab91c84b704e67e50cbcdb75c2799aaeba0184341dd520f6db8477f13d5815d37f191ccb20545e4a1eaca316370a
 Ctrl.hexxcghash = hexxcghash:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
 Ctrl.hexsession_id = hexsession_id:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
@@ -3804,7 +3805,7 @@ Ctrl.type = type:A
 Output = e46fdb8c912658c34b7d509f6acc1111
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000101008174aa2fab9372c253f3b993d723b55a2484430fb338095852b7a5099f9d609ca6afa6bff9d64a55f7ef0963c684f0d17ec6045ce57ce3382870d55fcac0e1341fb47a7f76f0d5d53b67fd5e0658ecb88ae2e2e42aa4b83b8cfcce9faae941450ace059a7f223623d1c8a9924638de7eebad35be9c9f1bf38aea041114351d585a1988ba53cccc6949150f367fd790fc427916afa2cccd1d2f1aa8583b948dfe56cf488b38ec2d2570a0e0441c07ccec8b5b4db5f60250741b1aeb0bf49a85cc779ad7465f0c197735698842be2a39af8591ab91c84b704e67e50cbcdb75c2799aaeba0184341dd520f6db8477f13d5815d37f191ccb20545e4a1eaca316370a
 Ctrl.hexxcghash = hexxcghash:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
 Ctrl.hexsession_id = hexsession_id:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
@@ -3812,7 +3813,7 @@ Ctrl.type = type:B
 Output = 959c339aaff2e2ed46da46c5286ddf3b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000101008174aa2fab9372c253f3b993d723b55a2484430fb338095852b7a5099f9d609ca6afa6bff9d64a55f7ef0963c684f0d17ec6045ce57ce3382870d55fcac0e1341fb47a7f76f0d5d53b67fd5e0658ecb88ae2e2e42aa4b83b8cfcce9faae941450ace059a7f223623d1c8a9924638de7eebad35be9c9f1bf38aea041114351d585a1988ba53cccc6949150f367fd790fc427916afa2cccd1d2f1aa8583b948dfe56cf488b38ec2d2570a0e0441c07ccec8b5b4db5f60250741b1aeb0bf49a85cc779ad7465f0c197735698842be2a39af8591ab91c84b704e67e50cbcdb75c2799aaeba0184341dd520f6db8477f13d5815d37f191ccb20545e4a1eaca316370a
 Ctrl.hexxcghash = hexxcghash:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
 Ctrl.hexsession_id = hexsession_id:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
@@ -3820,7 +3821,7 @@ Ctrl.type = type:C
 Output = a1cb0f9c7349d6443494df14b4bd9aad
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000101008174aa2fab9372c253f3b993d723b55a2484430fb338095852b7a5099f9d609ca6afa6bff9d64a55f7ef0963c684f0d17ec6045ce57ce3382870d55fcac0e1341fb47a7f76f0d5d53b67fd5e0658ecb88ae2e2e42aa4b83b8cfcce9faae941450ace059a7f223623d1c8a9924638de7eebad35be9c9f1bf38aea041114351d585a1988ba53cccc6949150f367fd790fc427916afa2cccd1d2f1aa8583b948dfe56cf488b38ec2d2570a0e0441c07ccec8b5b4db5f60250741b1aeb0bf49a85cc779ad7465f0c197735698842be2a39af8591ab91c84b704e67e50cbcdb75c2799aaeba0184341dd520f6db8477f13d5815d37f191ccb20545e4a1eaca316370a
 Ctrl.hexxcghash = hexxcghash:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
 Ctrl.hexsession_id = hexsession_id:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
@@ -3828,7 +3829,7 @@ Ctrl.type = type:D
 Output = cdcd2c2ccbda238e184058b76757ed5d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000101008174aa2fab9372c253f3b993d723b55a2484430fb338095852b7a5099f9d609ca6afa6bff9d64a55f7ef0963c684f0d17ec6045ce57ce3382870d55fcac0e1341fb47a7f76f0d5d53b67fd5e0658ecb88ae2e2e42aa4b83b8cfcce9faae941450ace059a7f223623d1c8a9924638de7eebad35be9c9f1bf38aea041114351d585a1988ba53cccc6949150f367fd790fc427916afa2cccd1d2f1aa8583b948dfe56cf488b38ec2d2570a0e0441c07ccec8b5b4db5f60250741b1aeb0bf49a85cc779ad7465f0c197735698842be2a39af8591ab91c84b704e67e50cbcdb75c2799aaeba0184341dd520f6db8477f13d5815d37f191ccb20545e4a1eaca316370a
 Ctrl.hexxcghash = hexxcghash:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
 Ctrl.hexsession_id = hexsession_id:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
@@ -3836,7 +3837,7 @@ Ctrl.type = type:E
 Output = 026ae927b4a5b63a513c02faac55534dae5c219779f08e239f67df78c52be743aab628607e5a103127450ea51833eb84
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:00000101008174aa2fab9372c253f3b993d723b55a2484430fb338095852b7a5099f9d609ca6afa6bff9d64a55f7ef0963c684f0d17ec6045ce57ce3382870d55fcac0e1341fb47a7f76f0d5d53b67fd5e0658ecb88ae2e2e42aa4b83b8cfcce9faae941450ace059a7f223623d1c8a9924638de7eebad35be9c9f1bf38aea041114351d585a1988ba53cccc6949150f367fd790fc427916afa2cccd1d2f1aa8583b948dfe56cf488b38ec2d2570a0e0441c07ccec8b5b4db5f60250741b1aeb0bf49a85cc779ad7465f0c197735698842be2a39af8591ab91c84b704e67e50cbcdb75c2799aaeba0184341dd520f6db8477f13d5815d37f191ccb20545e4a1eaca316370a
 Ctrl.hexxcghash = hexxcghash:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
 Ctrl.hexsession_id = hexsession_id:09d74bd79b47ceb3ada0d8df640595ba861ccfa3cc0d6c640eaac21d2d5f3f9fe61fb2e585fb6cc90bde11967a563c4e
@@ -3844,7 +3845,7 @@ Ctrl.type = type:F
 Output = 759fd6bd386f4825e644521edfce4187a7104ea7380f2c6c5e283f205c7c025be46c5ee73bc54a956f268c2031026bf6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c10fff0a20858c36e41082abaa65b96c5424ab67563882a42237258e736b5cfbdb2867df55f8c40f81b34e8c4c55d39c4629dc2d833257dc68070a61d10417487ef0840b76169145402327ae81f35cbddae6c2a45d52f52f48a0c94acdb20db076393b5b1e3d1a7acee3f371bdaccfee696262eecd20238cc54322e6ca72e58708aeb19bf761054d9f7426e4ea0059bd252beee03dcad1a7d6d034b4d9d307218bb3d7bee3a57572ded304df1dd8f97ed9550ebb0f5c25ee3f8c6df3dfc2aac92f364ec91040d001c5cb1eee33c1d43112e5a289b46706c7f12a327620cd98fbce2e7fe7b7bd0e05ee0005182c35ded65ee1d86aefe816e5894e07536697a7db
 Ctrl.hexxcghash = hexxcghash:62b3155ba0c160f838a6949d0a99b144868a7b247c583a53f431129e39aebd40e2feb4dbac7527f993ccf1646d559134
 Ctrl.hexsession_id = hexsession_id:7e4674330fb6987b64ef7f30335d171676c705a6b9ed958adc6b6fd16949830d3f586eec44812d0518cc3ebd4292b422
@@ -3852,7 +3853,7 @@ Ctrl.type = type:A
 Output = a433ac21ceda36a9d98abec722b2a5e7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c10fff0a20858c36e41082abaa65b96c5424ab67563882a42237258e736b5cfbdb2867df55f8c40f81b34e8c4c55d39c4629dc2d833257dc68070a61d10417487ef0840b76169145402327ae81f35cbddae6c2a45d52f52f48a0c94acdb20db076393b5b1e3d1a7acee3f371bdaccfee696262eecd20238cc54322e6ca72e58708aeb19bf761054d9f7426e4ea0059bd252beee03dcad1a7d6d034b4d9d307218bb3d7bee3a57572ded304df1dd8f97ed9550ebb0f5c25ee3f8c6df3dfc2aac92f364ec91040d001c5cb1eee33c1d43112e5a289b46706c7f12a327620cd98fbce2e7fe7b7bd0e05ee0005182c35ded65ee1d86aefe816e5894e07536697a7db
 Ctrl.hexxcghash = hexxcghash:62b3155ba0c160f838a6949d0a99b144868a7b247c583a53f431129e39aebd40e2feb4dbac7527f993ccf1646d559134
 Ctrl.hexsession_id = hexsession_id:7e4674330fb6987b64ef7f30335d171676c705a6b9ed958adc6b6fd16949830d3f586eec44812d0518cc3ebd4292b422
@@ -3860,7 +3861,7 @@ Ctrl.type = type:B
 Output = ed580c2c7890d5f3da87870d71d96300
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c10fff0a20858c36e41082abaa65b96c5424ab67563882a42237258e736b5cfbdb2867df55f8c40f81b34e8c4c55d39c4629dc2d833257dc68070a61d10417487ef0840b76169145402327ae81f35cbddae6c2a45d52f52f48a0c94acdb20db076393b5b1e3d1a7acee3f371bdaccfee696262eecd20238cc54322e6ca72e58708aeb19bf761054d9f7426e4ea0059bd252beee03dcad1a7d6d034b4d9d307218bb3d7bee3a57572ded304df1dd8f97ed9550ebb0f5c25ee3f8c6df3dfc2aac92f364ec91040d001c5cb1eee33c1d43112e5a289b46706c7f12a327620cd98fbce2e7fe7b7bd0e05ee0005182c35ded65ee1d86aefe816e5894e07536697a7db
 Ctrl.hexxcghash = hexxcghash:62b3155ba0c160f838a6949d0a99b144868a7b247c583a53f431129e39aebd40e2feb4dbac7527f993ccf1646d559134
 Ctrl.hexsession_id = hexsession_id:7e4674330fb6987b64ef7f30335d171676c705a6b9ed958adc6b6fd16949830d3f586eec44812d0518cc3ebd4292b422
@@ -3868,7 +3869,7 @@ Ctrl.type = type:C
 Output = b310304108476a31154febce2bfcf44e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c10fff0a20858c36e41082abaa65b96c5424ab67563882a42237258e736b5cfbdb2867df55f8c40f81b34e8c4c55d39c4629dc2d833257dc68070a61d10417487ef0840b76169145402327ae81f35cbddae6c2a45d52f52f48a0c94acdb20db076393b5b1e3d1a7acee3f371bdaccfee696262eecd20238cc54322e6ca72e58708aeb19bf761054d9f7426e4ea0059bd252beee03dcad1a7d6d034b4d9d307218bb3d7bee3a57572ded304df1dd8f97ed9550ebb0f5c25ee3f8c6df3dfc2aac92f364ec91040d001c5cb1eee33c1d43112e5a289b46706c7f12a327620cd98fbce2e7fe7b7bd0e05ee0005182c35ded65ee1d86aefe816e5894e07536697a7db
 Ctrl.hexxcghash = hexxcghash:62b3155ba0c160f838a6949d0a99b144868a7b247c583a53f431129e39aebd40e2feb4dbac7527f993ccf1646d559134
 Ctrl.hexsession_id = hexsession_id:7e4674330fb6987b64ef7f30335d171676c705a6b9ed958adc6b6fd16949830d3f586eec44812d0518cc3ebd4292b422
@@ -3876,7 +3877,7 @@ Ctrl.type = type:D
 Output = 63d729b0e32d9d7efe7efdc6111489b7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c10fff0a20858c36e41082abaa65b96c5424ab67563882a42237258e736b5cfbdb2867df55f8c40f81b34e8c4c55d39c4629dc2d833257dc68070a61d10417487ef0840b76169145402327ae81f35cbddae6c2a45d52f52f48a0c94acdb20db076393b5b1e3d1a7acee3f371bdaccfee696262eecd20238cc54322e6ca72e58708aeb19bf761054d9f7426e4ea0059bd252beee03dcad1a7d6d034b4d9d307218bb3d7bee3a57572ded304df1dd8f97ed9550ebb0f5c25ee3f8c6df3dfc2aac92f364ec91040d001c5cb1eee33c1d43112e5a289b46706c7f12a327620cd98fbce2e7fe7b7bd0e05ee0005182c35ded65ee1d86aefe816e5894e07536697a7db
 Ctrl.hexxcghash = hexxcghash:62b3155ba0c160f838a6949d0a99b144868a7b247c583a53f431129e39aebd40e2feb4dbac7527f993ccf1646d559134
 Ctrl.hexsession_id = hexsession_id:7e4674330fb6987b64ef7f30335d171676c705a6b9ed958adc6b6fd16949830d3f586eec44812d0518cc3ebd4292b422
@@ -3884,7 +3885,7 @@ Ctrl.type = type:E
 Output = 7443a278e0c47e4004ba1c534dfa5c460670d2dd4459a6dc7251664da187f633208f6c06470f6aed6148820187f35a25
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c10fff0a20858c36e41082abaa65b96c5424ab67563882a42237258e736b5cfbdb2867df55f8c40f81b34e8c4c55d39c4629dc2d833257dc68070a61d10417487ef0840b76169145402327ae81f35cbddae6c2a45d52f52f48a0c94acdb20db076393b5b1e3d1a7acee3f371bdaccfee696262eecd20238cc54322e6ca72e58708aeb19bf761054d9f7426e4ea0059bd252beee03dcad1a7d6d034b4d9d307218bb3d7bee3a57572ded304df1dd8f97ed9550ebb0f5c25ee3f8c6df3dfc2aac92f364ec91040d001c5cb1eee33c1d43112e5a289b46706c7f12a327620cd98fbce2e7fe7b7bd0e05ee0005182c35ded65ee1d86aefe816e5894e07536697a7db
 Ctrl.hexxcghash = hexxcghash:62b3155ba0c160f838a6949d0a99b144868a7b247c583a53f431129e39aebd40e2feb4dbac7527f993ccf1646d559134
 Ctrl.hexsession_id = hexsession_id:7e4674330fb6987b64ef7f30335d171676c705a6b9ed958adc6b6fd16949830d3f586eec44812d0518cc3ebd4292b422
@@ -3892,7 +3893,7 @@ Ctrl.type = type:F
 Output = 37500b699935ab38b9185018d3676f221dcd6643ba4cf3dccf8ede7ba2f0513c27ad2324158ae98df4e7fb52ffb96526
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c9d019aa8ab57cdbd1600def08b92f4a90b8ddb1c3fd329475e28ad9388525d5a813756472458bed674332a649c56eecb6cbba726b9afcfd9ce1f490bf327de49978b34fb106ae1ab4ece2f241e0b67ddf03bf835aa2dcc5cde5aca913d2a5ed74d1ad0e945169f10772d830fa5c33c7f7d543e2d2ac09fa03ff1509b94977cc0dcb8a464104a3e8d9f99cbefac4361b92517f14eda2558d572ae7410a78962e596c542a20d3aeb49cf41b48b54b387dea7c24c72edfd656bcb64c605b741c7b03892020ca2ff34e0b13534228bd83c9c3ffbfa219602041ac4238904bd782da7e3c653f518891f7ac1e7b05b7e37baab18eb54e8de76dfa8c803a0df843a28e
 Ctrl.hexxcghash = hexxcghash:a970acc5597f7965dcc540dac7cefde594c0232180187a32364b42dbb8d0307f8c3f52678e303e2f315b2ba1cf62863a
 Ctrl.hexsession_id = hexsession_id:bad9943e089550d17b90f2a34409660c07a39be5d48a77d8e1ad25726c93096081831c24e876060cb96def95df9a7fcd
@@ -3900,7 +3901,7 @@ Ctrl.type = type:A
 Output = 8ad38b03467ef0cac638f93b156e1c05
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c9d019aa8ab57cdbd1600def08b92f4a90b8ddb1c3fd329475e28ad9388525d5a813756472458bed674332a649c56eecb6cbba726b9afcfd9ce1f490bf327de49978b34fb106ae1ab4ece2f241e0b67ddf03bf835aa2dcc5cde5aca913d2a5ed74d1ad0e945169f10772d830fa5c33c7f7d543e2d2ac09fa03ff1509b94977cc0dcb8a464104a3e8d9f99cbefac4361b92517f14eda2558d572ae7410a78962e596c542a20d3aeb49cf41b48b54b387dea7c24c72edfd656bcb64c605b741c7b03892020ca2ff34e0b13534228bd83c9c3ffbfa219602041ac4238904bd782da7e3c653f518891f7ac1e7b05b7e37baab18eb54e8de76dfa8c803a0df843a28e
 Ctrl.hexxcghash = hexxcghash:a970acc5597f7965dcc540dac7cefde594c0232180187a32364b42dbb8d0307f8c3f52678e303e2f315b2ba1cf62863a
 Ctrl.hexsession_id = hexsession_id:bad9943e089550d17b90f2a34409660c07a39be5d48a77d8e1ad25726c93096081831c24e876060cb96def95df9a7fcd
@@ -3908,7 +3909,7 @@ Ctrl.type = type:B
 Output = c9a867164cad7619621c2390039db88f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c9d019aa8ab57cdbd1600def08b92f4a90b8ddb1c3fd329475e28ad9388525d5a813756472458bed674332a649c56eecb6cbba726b9afcfd9ce1f490bf327de49978b34fb106ae1ab4ece2f241e0b67ddf03bf835aa2dcc5cde5aca913d2a5ed74d1ad0e945169f10772d830fa5c33c7f7d543e2d2ac09fa03ff1509b94977cc0dcb8a464104a3e8d9f99cbefac4361b92517f14eda2558d572ae7410a78962e596c542a20d3aeb49cf41b48b54b387dea7c24c72edfd656bcb64c605b741c7b03892020ca2ff34e0b13534228bd83c9c3ffbfa219602041ac4238904bd782da7e3c653f518891f7ac1e7b05b7e37baab18eb54e8de76dfa8c803a0df843a28e
 Ctrl.hexxcghash = hexxcghash:a970acc5597f7965dcc540dac7cefde594c0232180187a32364b42dbb8d0307f8c3f52678e303e2f315b2ba1cf62863a
 Ctrl.hexsession_id = hexsession_id:bad9943e089550d17b90f2a34409660c07a39be5d48a77d8e1ad25726c93096081831c24e876060cb96def95df9a7fcd
@@ -3916,7 +3917,7 @@ Ctrl.type = type:C
 Output = 28d6e6a69e686b3b2ca02c7595b6a565
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c9d019aa8ab57cdbd1600def08b92f4a90b8ddb1c3fd329475e28ad9388525d5a813756472458bed674332a649c56eecb6cbba726b9afcfd9ce1f490bf327de49978b34fb106ae1ab4ece2f241e0b67ddf03bf835aa2dcc5cde5aca913d2a5ed74d1ad0e945169f10772d830fa5c33c7f7d543e2d2ac09fa03ff1509b94977cc0dcb8a464104a3e8d9f99cbefac4361b92517f14eda2558d572ae7410a78962e596c542a20d3aeb49cf41b48b54b387dea7c24c72edfd656bcb64c605b741c7b03892020ca2ff34e0b13534228bd83c9c3ffbfa219602041ac4238904bd782da7e3c653f518891f7ac1e7b05b7e37baab18eb54e8de76dfa8c803a0df843a28e
 Ctrl.hexxcghash = hexxcghash:a970acc5597f7965dcc540dac7cefde594c0232180187a32364b42dbb8d0307f8c3f52678e303e2f315b2ba1cf62863a
 Ctrl.hexsession_id = hexsession_id:bad9943e089550d17b90f2a34409660c07a39be5d48a77d8e1ad25726c93096081831c24e876060cb96def95df9a7fcd
@@ -3924,7 +3925,7 @@ Ctrl.type = type:D
 Output = a3486f9014731b15530dba7498d4b2ff
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c9d019aa8ab57cdbd1600def08b92f4a90b8ddb1c3fd329475e28ad9388525d5a813756472458bed674332a649c56eecb6cbba726b9afcfd9ce1f490bf327de49978b34fb106ae1ab4ece2f241e0b67ddf03bf835aa2dcc5cde5aca913d2a5ed74d1ad0e945169f10772d830fa5c33c7f7d543e2d2ac09fa03ff1509b94977cc0dcb8a464104a3e8d9f99cbefac4361b92517f14eda2558d572ae7410a78962e596c542a20d3aeb49cf41b48b54b387dea7c24c72edfd656bcb64c605b741c7b03892020ca2ff34e0b13534228bd83c9c3ffbfa219602041ac4238904bd782da7e3c653f518891f7ac1e7b05b7e37baab18eb54e8de76dfa8c803a0df843a28e
 Ctrl.hexxcghash = hexxcghash:a970acc5597f7965dcc540dac7cefde594c0232180187a32364b42dbb8d0307f8c3f52678e303e2f315b2ba1cf62863a
 Ctrl.hexsession_id = hexsession_id:bad9943e089550d17b90f2a34409660c07a39be5d48a77d8e1ad25726c93096081831c24e876060cb96def95df9a7fcd
@@ -3932,7 +3933,7 @@ Ctrl.type = type:E
 Output = 9640b7d6c1351a44dcd430f9728083949adbd8f3c47f1c7358b41d99730f0eeef9f8634cc99207b8d998c8aeb0085e4c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c9d019aa8ab57cdbd1600def08b92f4a90b8ddb1c3fd329475e28ad9388525d5a813756472458bed674332a649c56eecb6cbba726b9afcfd9ce1f490bf327de49978b34fb106ae1ab4ece2f241e0b67ddf03bf835aa2dcc5cde5aca913d2a5ed74d1ad0e945169f10772d830fa5c33c7f7d543e2d2ac09fa03ff1509b94977cc0dcb8a464104a3e8d9f99cbefac4361b92517f14eda2558d572ae7410a78962e596c542a20d3aeb49cf41b48b54b387dea7c24c72edfd656bcb64c605b741c7b03892020ca2ff34e0b13534228bd83c9c3ffbfa219602041ac4238904bd782da7e3c653f518891f7ac1e7b05b7e37baab18eb54e8de76dfa8c803a0df843a28e
 Ctrl.hexxcghash = hexxcghash:a970acc5597f7965dcc540dac7cefde594c0232180187a32364b42dbb8d0307f8c3f52678e303e2f315b2ba1cf62863a
 Ctrl.hexsession_id = hexsession_id:bad9943e089550d17b90f2a34409660c07a39be5d48a77d8e1ad25726c93096081831c24e876060cb96def95df9a7fcd
@@ -3940,7 +3941,7 @@ Ctrl.type = type:F
 Output = cef923f7cbc47534d9a6da613eea02117b19800995f66df9e49291203ad15e5d29cc08df86200bf09ca091b37cc45432
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100ba6b819aa094b3b9a2e93d37eda5df776720cce40858790532b8ab0de613b8e20efcef330eaa9e4ab290fd670b8f8ab1e2fc217d575655a7c39740ce223675a4376bd039f24165d83268a3e3a5b6e05f1b077dc752c90781d0cd6877c91c1fc865586bf661f28cbded4266f1b9364ae7233e6003b47088cb50f81a631d4b1d200f8c38455ad2217eaf03b6e0a0861aeebe28ef0fcbac5526bd06ebcc44f67de9b908f0359076527f6ff7bb959b3adfc9ac82728d7627bf506ffb2f8742ae28ce3ca7402c25b1cd3dac6781776a35549480ff537c33f63796dd5de4c64e1ff5546689d8f398be911707e0b5d347b8456e89eb2262270ee1de85902b7deb60b02b
 Ctrl.hexxcghash = hexxcghash:e94db0c0969c8f09c1c0d63fcca9f316ae85a0c034f118958c714fa165ac71a86bbcc7a4c017c11b9558bda897455f99
 Ctrl.hexsession_id = hexsession_id:a01426386ce69a9a9f101394e831dc9d17a6dc901349f3c3f4269788f5c5e20316c233d7632005b1771e5bc2f5ddf4c2
@@ -3948,7 +3949,7 @@ Ctrl.type = type:A
 Output = 1e2fd838058e4569de0699e57eb9bb30
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100ba6b819aa094b3b9a2e93d37eda5df776720cce40858790532b8ab0de613b8e20efcef330eaa9e4ab290fd670b8f8ab1e2fc217d575655a7c39740ce223675a4376bd039f24165d83268a3e3a5b6e05f1b077dc752c90781d0cd6877c91c1fc865586bf661f28cbded4266f1b9364ae7233e6003b47088cb50f81a631d4b1d200f8c38455ad2217eaf03b6e0a0861aeebe28ef0fcbac5526bd06ebcc44f67de9b908f0359076527f6ff7bb959b3adfc9ac82728d7627bf506ffb2f8742ae28ce3ca7402c25b1cd3dac6781776a35549480ff537c33f63796dd5de4c64e1ff5546689d8f398be911707e0b5d347b8456e89eb2262270ee1de85902b7deb60b02b
 Ctrl.hexxcghash = hexxcghash:e94db0c0969c8f09c1c0d63fcca9f316ae85a0c034f118958c714fa165ac71a86bbcc7a4c017c11b9558bda897455f99
 Ctrl.hexsession_id = hexsession_id:a01426386ce69a9a9f101394e831dc9d17a6dc901349f3c3f4269788f5c5e20316c233d7632005b1771e5bc2f5ddf4c2
@@ -3956,7 +3957,7 @@ Ctrl.type = type:B
 Output = d338052b2288e99bfdd16b5df26e3d3c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100ba6b819aa094b3b9a2e93d37eda5df776720cce40858790532b8ab0de613b8e20efcef330eaa9e4ab290fd670b8f8ab1e2fc217d575655a7c39740ce223675a4376bd039f24165d83268a3e3a5b6e05f1b077dc752c90781d0cd6877c91c1fc865586bf661f28cbded4266f1b9364ae7233e6003b47088cb50f81a631d4b1d200f8c38455ad2217eaf03b6e0a0861aeebe28ef0fcbac5526bd06ebcc44f67de9b908f0359076527f6ff7bb959b3adfc9ac82728d7627bf506ffb2f8742ae28ce3ca7402c25b1cd3dac6781776a35549480ff537c33f63796dd5de4c64e1ff5546689d8f398be911707e0b5d347b8456e89eb2262270ee1de85902b7deb60b02b
 Ctrl.hexxcghash = hexxcghash:e94db0c0969c8f09c1c0d63fcca9f316ae85a0c034f118958c714fa165ac71a86bbcc7a4c017c11b9558bda897455f99
 Ctrl.hexsession_id = hexsession_id:a01426386ce69a9a9f101394e831dc9d17a6dc901349f3c3f4269788f5c5e20316c233d7632005b1771e5bc2f5ddf4c2
@@ -3964,7 +3965,7 @@ Ctrl.type = type:C
 Output = 020c58037db045fc2a20a9b12e34205d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100ba6b819aa094b3b9a2e93d37eda5df776720cce40858790532b8ab0de613b8e20efcef330eaa9e4ab290fd670b8f8ab1e2fc217d575655a7c39740ce223675a4376bd039f24165d83268a3e3a5b6e05f1b077dc752c90781d0cd6877c91c1fc865586bf661f28cbded4266f1b9364ae7233e6003b47088cb50f81a631d4b1d200f8c38455ad2217eaf03b6e0a0861aeebe28ef0fcbac5526bd06ebcc44f67de9b908f0359076527f6ff7bb959b3adfc9ac82728d7627bf506ffb2f8742ae28ce3ca7402c25b1cd3dac6781776a35549480ff537c33f63796dd5de4c64e1ff5546689d8f398be911707e0b5d347b8456e89eb2262270ee1de85902b7deb60b02b
 Ctrl.hexxcghash = hexxcghash:e94db0c0969c8f09c1c0d63fcca9f316ae85a0c034f118958c714fa165ac71a86bbcc7a4c017c11b9558bda897455f99
 Ctrl.hexsession_id = hexsession_id:a01426386ce69a9a9f101394e831dc9d17a6dc901349f3c3f4269788f5c5e20316c233d7632005b1771e5bc2f5ddf4c2
@@ -3972,7 +3973,7 @@ Ctrl.type = type:D
 Output = b1e7b4361aaea7f9656151723c21b9a2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100ba6b819aa094b3b9a2e93d37eda5df776720cce40858790532b8ab0de613b8e20efcef330eaa9e4ab290fd670b8f8ab1e2fc217d575655a7c39740ce223675a4376bd039f24165d83268a3e3a5b6e05f1b077dc752c90781d0cd6877c91c1fc865586bf661f28cbded4266f1b9364ae7233e6003b47088cb50f81a631d4b1d200f8c38455ad2217eaf03b6e0a0861aeebe28ef0fcbac5526bd06ebcc44f67de9b908f0359076527f6ff7bb959b3adfc9ac82728d7627bf506ffb2f8742ae28ce3ca7402c25b1cd3dac6781776a35549480ff537c33f63796dd5de4c64e1ff5546689d8f398be911707e0b5d347b8456e89eb2262270ee1de85902b7deb60b02b
 Ctrl.hexxcghash = hexxcghash:e94db0c0969c8f09c1c0d63fcca9f316ae85a0c034f118958c714fa165ac71a86bbcc7a4c017c11b9558bda897455f99
 Ctrl.hexsession_id = hexsession_id:a01426386ce69a9a9f101394e831dc9d17a6dc901349f3c3f4269788f5c5e20316c233d7632005b1771e5bc2f5ddf4c2
@@ -3980,7 +3981,7 @@ Ctrl.type = type:E
 Output = 67d80666ba420d07153530859fed5a3a2f4b6decd37575714d4826f41a96a1638b89399cdd752af7f6ffd3db0214f0c1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100ba6b819aa094b3b9a2e93d37eda5df776720cce40858790532b8ab0de613b8e20efcef330eaa9e4ab290fd670b8f8ab1e2fc217d575655a7c39740ce223675a4376bd039f24165d83268a3e3a5b6e05f1b077dc752c90781d0cd6877c91c1fc865586bf661f28cbded4266f1b9364ae7233e6003b47088cb50f81a631d4b1d200f8c38455ad2217eaf03b6e0a0861aeebe28ef0fcbac5526bd06ebcc44f67de9b908f0359076527f6ff7bb959b3adfc9ac82728d7627bf506ffb2f8742ae28ce3ca7402c25b1cd3dac6781776a35549480ff537c33f63796dd5de4c64e1ff5546689d8f398be911707e0b5d347b8456e89eb2262270ee1de85902b7deb60b02b
 Ctrl.hexxcghash = hexxcghash:e94db0c0969c8f09c1c0d63fcca9f316ae85a0c034f118958c714fa165ac71a86bbcc7a4c017c11b9558bda897455f99
 Ctrl.hexsession_id = hexsession_id:a01426386ce69a9a9f101394e831dc9d17a6dc901349f3c3f4269788f5c5e20316c233d7632005b1771e5bc2f5ddf4c2
@@ -3988,7 +3989,7 @@ Ctrl.type = type:F
 Output = c3fb2ab670e39885cbb98a4609d69a90afd37d383512ad222d63c9c6f1009e2a42065a232ab5b39f55247f8bf9e6ab2c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001b9f110b05461796db3a0b751638b552e62a062d7b891591ac75e237d47f5f12d97a5d19be0718c8a2fbdd9100249c2d9ca59bf491b10afef75f61c53ae92455e8cb016e230408c869ea1c5f5d62e853ae84727e3d1f1bb0a0faa9ff575eede461f502b90ca38e8effae09478efedd16090202bf03530d03d0a2aa70825fb28c606b7545bdde26d606c059215a9f947e60c4b5de9b35a3704f73a5c8bc8811387431b7e90f1ddc71cf0696497fd640cb9b1b8866bff5d85e879e0a7848722d34cc62844afcc6318fe73ea80e484c3e62feb0cde9269c07edc0679683bc5427a163a4b4ac463802293f7c968e4188e7966b559c2581582c67ecda0c9b3b8eac94
 Ctrl.hexxcghash = hexxcghash:8886115c2324dede13be6895605a439c6ec48ca46f3d82170b863dcf1acc26176769626df893ebb7ce8c9432058633d8
 Ctrl.hexsession_id = hexsession_id:331f7e0103de46d90dbd885dadaf67c589bc6b3caf25e45e329d864c85b7c9ae17b27cb92a81c9b4421f431014cb0e03
@@ -3996,7 +3997,7 @@ Ctrl.type = type:A
 Output = 6e9bb7681d56457fd93aea6d40860dd9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001b9f110b05461796db3a0b751638b552e62a062d7b891591ac75e237d47f5f12d97a5d19be0718c8a2fbdd9100249c2d9ca59bf491b10afef75f61c53ae92455e8cb016e230408c869ea1c5f5d62e853ae84727e3d1f1bb0a0faa9ff575eede461f502b90ca38e8effae09478efedd16090202bf03530d03d0a2aa70825fb28c606b7545bdde26d606c059215a9f947e60c4b5de9b35a3704f73a5c8bc8811387431b7e90f1ddc71cf0696497fd640cb9b1b8866bff5d85e879e0a7848722d34cc62844afcc6318fe73ea80e484c3e62feb0cde9269c07edc0679683bc5427a163a4b4ac463802293f7c968e4188e7966b559c2581582c67ecda0c9b3b8eac94
 Ctrl.hexxcghash = hexxcghash:8886115c2324dede13be6895605a439c6ec48ca46f3d82170b863dcf1acc26176769626df893ebb7ce8c9432058633d8
 Ctrl.hexsession_id = hexsession_id:331f7e0103de46d90dbd885dadaf67c589bc6b3caf25e45e329d864c85b7c9ae17b27cb92a81c9b4421f431014cb0e03
@@ -4004,7 +4005,7 @@ Ctrl.type = type:B
 Output = 5d19ce6c6b16c5f2179753a7abdff3e4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001b9f110b05461796db3a0b751638b552e62a062d7b891591ac75e237d47f5f12d97a5d19be0718c8a2fbdd9100249c2d9ca59bf491b10afef75f61c53ae92455e8cb016e230408c869ea1c5f5d62e853ae84727e3d1f1bb0a0faa9ff575eede461f502b90ca38e8effae09478efedd16090202bf03530d03d0a2aa70825fb28c606b7545bdde26d606c059215a9f947e60c4b5de9b35a3704f73a5c8bc8811387431b7e90f1ddc71cf0696497fd640cb9b1b8866bff5d85e879e0a7848722d34cc62844afcc6318fe73ea80e484c3e62feb0cde9269c07edc0679683bc5427a163a4b4ac463802293f7c968e4188e7966b559c2581582c67ecda0c9b3b8eac94
 Ctrl.hexxcghash = hexxcghash:8886115c2324dede13be6895605a439c6ec48ca46f3d82170b863dcf1acc26176769626df893ebb7ce8c9432058633d8
 Ctrl.hexsession_id = hexsession_id:331f7e0103de46d90dbd885dadaf67c589bc6b3caf25e45e329d864c85b7c9ae17b27cb92a81c9b4421f431014cb0e03
@@ -4012,7 +4013,7 @@ Ctrl.type = type:C
 Output = c550416e8ea0608a09051cfffe0494e7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001b9f110b05461796db3a0b751638b552e62a062d7b891591ac75e237d47f5f12d97a5d19be0718c8a2fbdd9100249c2d9ca59bf491b10afef75f61c53ae92455e8cb016e230408c869ea1c5f5d62e853ae84727e3d1f1bb0a0faa9ff575eede461f502b90ca38e8effae09478efedd16090202bf03530d03d0a2aa70825fb28c606b7545bdde26d606c059215a9f947e60c4b5de9b35a3704f73a5c8bc8811387431b7e90f1ddc71cf0696497fd640cb9b1b8866bff5d85e879e0a7848722d34cc62844afcc6318fe73ea80e484c3e62feb0cde9269c07edc0679683bc5427a163a4b4ac463802293f7c968e4188e7966b559c2581582c67ecda0c9b3b8eac94
 Ctrl.hexxcghash = hexxcghash:8886115c2324dede13be6895605a439c6ec48ca46f3d82170b863dcf1acc26176769626df893ebb7ce8c9432058633d8
 Ctrl.hexsession_id = hexsession_id:331f7e0103de46d90dbd885dadaf67c589bc6b3caf25e45e329d864c85b7c9ae17b27cb92a81c9b4421f431014cb0e03
@@ -4020,7 +4021,7 @@ Ctrl.type = type:D
 Output = 33c9f3f03de395cef067684cb5b95200
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001b9f110b05461796db3a0b751638b552e62a062d7b891591ac75e237d47f5f12d97a5d19be0718c8a2fbdd9100249c2d9ca59bf491b10afef75f61c53ae92455e8cb016e230408c869ea1c5f5d62e853ae84727e3d1f1bb0a0faa9ff575eede461f502b90ca38e8effae09478efedd16090202bf03530d03d0a2aa70825fb28c606b7545bdde26d606c059215a9f947e60c4b5de9b35a3704f73a5c8bc8811387431b7e90f1ddc71cf0696497fd640cb9b1b8866bff5d85e879e0a7848722d34cc62844afcc6318fe73ea80e484c3e62feb0cde9269c07edc0679683bc5427a163a4b4ac463802293f7c968e4188e7966b559c2581582c67ecda0c9b3b8eac94
 Ctrl.hexxcghash = hexxcghash:8886115c2324dede13be6895605a439c6ec48ca46f3d82170b863dcf1acc26176769626df893ebb7ce8c9432058633d8
 Ctrl.hexsession_id = hexsession_id:331f7e0103de46d90dbd885dadaf67c589bc6b3caf25e45e329d864c85b7c9ae17b27cb92a81c9b4421f431014cb0e03
@@ -4028,7 +4029,7 @@ Ctrl.type = type:E
 Output = 99071b0615bdec08d040e731828028fac9a16d367b86d2d1302b607cd39ac9678ae7f9f87eb619fe2ba75d54da3b07d1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001b9f110b05461796db3a0b751638b552e62a062d7b891591ac75e237d47f5f12d97a5d19be0718c8a2fbdd9100249c2d9ca59bf491b10afef75f61c53ae92455e8cb016e230408c869ea1c5f5d62e853ae84727e3d1f1bb0a0faa9ff575eede461f502b90ca38e8effae09478efedd16090202bf03530d03d0a2aa70825fb28c606b7545bdde26d606c059215a9f947e60c4b5de9b35a3704f73a5c8bc8811387431b7e90f1ddc71cf0696497fd640cb9b1b8866bff5d85e879e0a7848722d34cc62844afcc6318fe73ea80e484c3e62feb0cde9269c07edc0679683bc5427a163a4b4ac463802293f7c968e4188e7966b559c2581582c67ecda0c9b3b8eac94
 Ctrl.hexxcghash = hexxcghash:8886115c2324dede13be6895605a439c6ec48ca46f3d82170b863dcf1acc26176769626df893ebb7ce8c9432058633d8
 Ctrl.hexsession_id = hexsession_id:331f7e0103de46d90dbd885dadaf67c589bc6b3caf25e45e329d864c85b7c9ae17b27cb92a81c9b4421f431014cb0e03
@@ -4036,7 +4037,7 @@ Ctrl.type = type:F
 Output = a11fc539c46d9314645e1f7517e19794a6ba4bf7d7d5a6f71bcb4621bfdedeae3bbcaa62fb638d994d1f21d14f5777d7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004db530516876fb9937bc2da16117f9675c721da6b80cd49e6b6eb0df6fe4af90ae755378e77e28dbc376e000903b1365a7b3cddfaf19410b31ae44e3e6641c5d47002ac5b261b1c4f7f301c8d16a917135c23bf7f84f15a6143e7e3466c52e1e3c30026f15d5254da11ced1b817739768de9913aca2d808acaa31e933763eb438238b347a6bd07834d4f661690cdb2372b4205aa9ad80df40340c1d0b1db320df1d1b13fa2ff4b9ee4500c9d03f45e75fb15a97b833ab9827708e4bca8fea562d69fea573ca7b5905c71e51dc9f24a74bd0c596051066acdeb66eb39c76fab66b10bdc88e1b72bba8aafa342088cd4a739a18e61c75be6b5df0904dc5094f0df
 Ctrl.hexxcghash = hexxcghash:12ce3e6a5407943831d65608c9fd59c972689136289af06071c015f8a41c9d1536d0afdad084322f832415fbf199d044
 Ctrl.hexsession_id = hexsession_id:939c41734aa3db9d9dfac7a7db54c889da38d8bbe00326f559a3b0f92a96b5ac3a454d8355ccd0f31099021d0ee43063
@@ -4044,7 +4045,7 @@ Ctrl.type = type:A
 Output = 876692595fbf1239e03b1eb28890cedf
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004db530516876fb9937bc2da16117f9675c721da6b80cd49e6b6eb0df6fe4af90ae755378e77e28dbc376e000903b1365a7b3cddfaf19410b31ae44e3e6641c5d47002ac5b261b1c4f7f301c8d16a917135c23bf7f84f15a6143e7e3466c52e1e3c30026f15d5254da11ced1b817739768de9913aca2d808acaa31e933763eb438238b347a6bd07834d4f661690cdb2372b4205aa9ad80df40340c1d0b1db320df1d1b13fa2ff4b9ee4500c9d03f45e75fb15a97b833ab9827708e4bca8fea562d69fea573ca7b5905c71e51dc9f24a74bd0c596051066acdeb66eb39c76fab66b10bdc88e1b72bba8aafa342088cd4a739a18e61c75be6b5df0904dc5094f0df
 Ctrl.hexxcghash = hexxcghash:12ce3e6a5407943831d65608c9fd59c972689136289af06071c015f8a41c9d1536d0afdad084322f832415fbf199d044
 Ctrl.hexsession_id = hexsession_id:939c41734aa3db9d9dfac7a7db54c889da38d8bbe00326f559a3b0f92a96b5ac3a454d8355ccd0f31099021d0ee43063
@@ -4052,7 +4053,7 @@ Ctrl.type = type:B
 Output = 438afd7eae8454675ed5964122fcbb9e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004db530516876fb9937bc2da16117f9675c721da6b80cd49e6b6eb0df6fe4af90ae755378e77e28dbc376e000903b1365a7b3cddfaf19410b31ae44e3e6641c5d47002ac5b261b1c4f7f301c8d16a917135c23bf7f84f15a6143e7e3466c52e1e3c30026f15d5254da11ced1b817739768de9913aca2d808acaa31e933763eb438238b347a6bd07834d4f661690cdb2372b4205aa9ad80df40340c1d0b1db320df1d1b13fa2ff4b9ee4500c9d03f45e75fb15a97b833ab9827708e4bca8fea562d69fea573ca7b5905c71e51dc9f24a74bd0c596051066acdeb66eb39c76fab66b10bdc88e1b72bba8aafa342088cd4a739a18e61c75be6b5df0904dc5094f0df
 Ctrl.hexxcghash = hexxcghash:12ce3e6a5407943831d65608c9fd59c972689136289af06071c015f8a41c9d1536d0afdad084322f832415fbf199d044
 Ctrl.hexsession_id = hexsession_id:939c41734aa3db9d9dfac7a7db54c889da38d8bbe00326f559a3b0f92a96b5ac3a454d8355ccd0f31099021d0ee43063
@@ -4060,7 +4061,7 @@ Ctrl.type = type:C
 Output = b9cc0e2718c5853e0aebb43409fcaaef
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004db530516876fb9937bc2da16117f9675c721da6b80cd49e6b6eb0df6fe4af90ae755378e77e28dbc376e000903b1365a7b3cddfaf19410b31ae44e3e6641c5d47002ac5b261b1c4f7f301c8d16a917135c23bf7f84f15a6143e7e3466c52e1e3c30026f15d5254da11ced1b817739768de9913aca2d808acaa31e933763eb438238b347a6bd07834d4f661690cdb2372b4205aa9ad80df40340c1d0b1db320df1d1b13fa2ff4b9ee4500c9d03f45e75fb15a97b833ab9827708e4bca8fea562d69fea573ca7b5905c71e51dc9f24a74bd0c596051066acdeb66eb39c76fab66b10bdc88e1b72bba8aafa342088cd4a739a18e61c75be6b5df0904dc5094f0df
 Ctrl.hexxcghash = hexxcghash:12ce3e6a5407943831d65608c9fd59c972689136289af06071c015f8a41c9d1536d0afdad084322f832415fbf199d044
 Ctrl.hexsession_id = hexsession_id:939c41734aa3db9d9dfac7a7db54c889da38d8bbe00326f559a3b0f92a96b5ac3a454d8355ccd0f31099021d0ee43063
@@ -4068,7 +4069,7 @@ Ctrl.type = type:D
 Output = 8def9f93e633ac2d28a7c5b76567a4cb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004db530516876fb9937bc2da16117f9675c721da6b80cd49e6b6eb0df6fe4af90ae755378e77e28dbc376e000903b1365a7b3cddfaf19410b31ae44e3e6641c5d47002ac5b261b1c4f7f301c8d16a917135c23bf7f84f15a6143e7e3466c52e1e3c30026f15d5254da11ced1b817739768de9913aca2d808acaa31e933763eb438238b347a6bd07834d4f661690cdb2372b4205aa9ad80df40340c1d0b1db320df1d1b13fa2ff4b9ee4500c9d03f45e75fb15a97b833ab9827708e4bca8fea562d69fea573ca7b5905c71e51dc9f24a74bd0c596051066acdeb66eb39c76fab66b10bdc88e1b72bba8aafa342088cd4a739a18e61c75be6b5df0904dc5094f0df
 Ctrl.hexxcghash = hexxcghash:12ce3e6a5407943831d65608c9fd59c972689136289af06071c015f8a41c9d1536d0afdad084322f832415fbf199d044
 Ctrl.hexsession_id = hexsession_id:939c41734aa3db9d9dfac7a7db54c889da38d8bbe00326f559a3b0f92a96b5ac3a454d8355ccd0f31099021d0ee43063
@@ -4076,7 +4077,7 @@ Ctrl.type = type:E
 Output = 3d80ed20f0703857154bda8531b12b96cf73aedfc662df6faf277321be6e38c904bfbd5f9206607684ac331dfc92bbbb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004db530516876fb9937bc2da16117f9675c721da6b80cd49e6b6eb0df6fe4af90ae755378e77e28dbc376e000903b1365a7b3cddfaf19410b31ae44e3e6641c5d47002ac5b261b1c4f7f301c8d16a917135c23bf7f84f15a6143e7e3466c52e1e3c30026f15d5254da11ced1b817739768de9913aca2d808acaa31e933763eb438238b347a6bd07834d4f661690cdb2372b4205aa9ad80df40340c1d0b1db320df1d1b13fa2ff4b9ee4500c9d03f45e75fb15a97b833ab9827708e4bca8fea562d69fea573ca7b5905c71e51dc9f24a74bd0c596051066acdeb66eb39c76fab66b10bdc88e1b72bba8aafa342088cd4a739a18e61c75be6b5df0904dc5094f0df
 Ctrl.hexxcghash = hexxcghash:12ce3e6a5407943831d65608c9fd59c972689136289af06071c015f8a41c9d1536d0afdad084322f832415fbf199d044
 Ctrl.hexsession_id = hexsession_id:939c41734aa3db9d9dfac7a7db54c889da38d8bbe00326f559a3b0f92a96b5ac3a454d8355ccd0f31099021d0ee43063
@@ -4084,7 +4085,7 @@ Ctrl.type = type:F
 Output = 736e77ad5a8fac835795ab08522d834e34a4cbc48439db2845cb1d8636a4dcfd49a7ac5413713a8177c277eead96a0ff
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004d7ba3e909e1e2886e00db333430d7cebe5107e9701672a2a1bc0bb5461c620c56fc8a8aa95a577cf48ac2e5b35d948e468bbc6232527f6a4e3bf5ea0b2f68b161ee3aadeef596c683e511bec1ff70df312d988eddd557952720f82f69882107f67880e38efcca68429374d85831eea3ac133a6a89b68a9ec27c71a67c87addfddb7040a7416ead43e29612dcdc5b7e6a82ad5cd243e8a6dd2997c44ad76a2a20145f89d7e6b2a26c2c0f2ce7d60b1f45410f9ebb79b52dde560f8c7c99b7a11d645f6ad6f94727cd2ea9d48ceb27467ee60371e6919a3ae044c8941a65182c94e8efd7b5c7eb45935baea722628d89d89de995d82b620059fe1054927864a91
 Ctrl.hexxcghash = hexxcghash:f3cc38427adf01b9483d1f9e4e9acef554a8c7d0d8dc088d3865f05bc06a4ff11efbbdbca7ab0e0c0e2df55a93f0b4b9
 Ctrl.hexsession_id = hexsession_id:aae879d8c0c6762d28c30fdc707b169a2155f8b8a943ced399a56419be89cc9f66ba9282d85ac4e53e0d5ae27adcf393
@@ -4092,7 +4093,7 @@ Ctrl.type = type:A
 Output = c84a4fcd4ade28805b032174428a6f27
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004d7ba3e909e1e2886e00db333430d7cebe5107e9701672a2a1bc0bb5461c620c56fc8a8aa95a577cf48ac2e5b35d948e468bbc6232527f6a4e3bf5ea0b2f68b161ee3aadeef596c683e511bec1ff70df312d988eddd557952720f82f69882107f67880e38efcca68429374d85831eea3ac133a6a89b68a9ec27c71a67c87addfddb7040a7416ead43e29612dcdc5b7e6a82ad5cd243e8a6dd2997c44ad76a2a20145f89d7e6b2a26c2c0f2ce7d60b1f45410f9ebb79b52dde560f8c7c99b7a11d645f6ad6f94727cd2ea9d48ceb27467ee60371e6919a3ae044c8941a65182c94e8efd7b5c7eb45935baea722628d89d89de995d82b620059fe1054927864a91
 Ctrl.hexxcghash = hexxcghash:f3cc38427adf01b9483d1f9e4e9acef554a8c7d0d8dc088d3865f05bc06a4ff11efbbdbca7ab0e0c0e2df55a93f0b4b9
 Ctrl.hexsession_id = hexsession_id:aae879d8c0c6762d28c30fdc707b169a2155f8b8a943ced399a56419be89cc9f66ba9282d85ac4e53e0d5ae27adcf393
@@ -4100,7 +4101,7 @@ Ctrl.type = type:B
 Output = 27b0de69f3bc7d79d2f6b54101f3e10f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004d7ba3e909e1e2886e00db333430d7cebe5107e9701672a2a1bc0bb5461c620c56fc8a8aa95a577cf48ac2e5b35d948e468bbc6232527f6a4e3bf5ea0b2f68b161ee3aadeef596c683e511bec1ff70df312d988eddd557952720f82f69882107f67880e38efcca68429374d85831eea3ac133a6a89b68a9ec27c71a67c87addfddb7040a7416ead43e29612dcdc5b7e6a82ad5cd243e8a6dd2997c44ad76a2a20145f89d7e6b2a26c2c0f2ce7d60b1f45410f9ebb79b52dde560f8c7c99b7a11d645f6ad6f94727cd2ea9d48ceb27467ee60371e6919a3ae044c8941a65182c94e8efd7b5c7eb45935baea722628d89d89de995d82b620059fe1054927864a91
 Ctrl.hexxcghash = hexxcghash:f3cc38427adf01b9483d1f9e4e9acef554a8c7d0d8dc088d3865f05bc06a4ff11efbbdbca7ab0e0c0e2df55a93f0b4b9
 Ctrl.hexsession_id = hexsession_id:aae879d8c0c6762d28c30fdc707b169a2155f8b8a943ced399a56419be89cc9f66ba9282d85ac4e53e0d5ae27adcf393
@@ -4108,7 +4109,7 @@ Ctrl.type = type:C
 Output = 3200c39e6ed260f4f345cbd0c88cac1a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004d7ba3e909e1e2886e00db333430d7cebe5107e9701672a2a1bc0bb5461c620c56fc8a8aa95a577cf48ac2e5b35d948e468bbc6232527f6a4e3bf5ea0b2f68b161ee3aadeef596c683e511bec1ff70df312d988eddd557952720f82f69882107f67880e38efcca68429374d85831eea3ac133a6a89b68a9ec27c71a67c87addfddb7040a7416ead43e29612dcdc5b7e6a82ad5cd243e8a6dd2997c44ad76a2a20145f89d7e6b2a26c2c0f2ce7d60b1f45410f9ebb79b52dde560f8c7c99b7a11d645f6ad6f94727cd2ea9d48ceb27467ee60371e6919a3ae044c8941a65182c94e8efd7b5c7eb45935baea722628d89d89de995d82b620059fe1054927864a91
 Ctrl.hexxcghash = hexxcghash:f3cc38427adf01b9483d1f9e4e9acef554a8c7d0d8dc088d3865f05bc06a4ff11efbbdbca7ab0e0c0e2df55a93f0b4b9
 Ctrl.hexsession_id = hexsession_id:aae879d8c0c6762d28c30fdc707b169a2155f8b8a943ced399a56419be89cc9f66ba9282d85ac4e53e0d5ae27adcf393
@@ -4116,7 +4117,7 @@ Ctrl.type = type:D
 Output = 7b9e506a1baede9b80dff09253a9ab88
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004d7ba3e909e1e2886e00db333430d7cebe5107e9701672a2a1bc0bb5461c620c56fc8a8aa95a577cf48ac2e5b35d948e468bbc6232527f6a4e3bf5ea0b2f68b161ee3aadeef596c683e511bec1ff70df312d988eddd557952720f82f69882107f67880e38efcca68429374d85831eea3ac133a6a89b68a9ec27c71a67c87addfddb7040a7416ead43e29612dcdc5b7e6a82ad5cd243e8a6dd2997c44ad76a2a20145f89d7e6b2a26c2c0f2ce7d60b1f45410f9ebb79b52dde560f8c7c99b7a11d645f6ad6f94727cd2ea9d48ceb27467ee60371e6919a3ae044c8941a65182c94e8efd7b5c7eb45935baea722628d89d89de995d82b620059fe1054927864a91
 Ctrl.hexxcghash = hexxcghash:f3cc38427adf01b9483d1f9e4e9acef554a8c7d0d8dc088d3865f05bc06a4ff11efbbdbca7ab0e0c0e2df55a93f0b4b9
 Ctrl.hexsession_id = hexsession_id:aae879d8c0c6762d28c30fdc707b169a2155f8b8a943ced399a56419be89cc9f66ba9282d85ac4e53e0d5ae27adcf393
@@ -4124,7 +4125,7 @@ Ctrl.type = type:E
 Output = 3c860ae21a5dab865eb560ed9ddf51775d3b6603e4e06285cf5e9273115a77d8d5ddfb977fd21c0a70c35798a5ef596e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001004d7ba3e909e1e2886e00db333430d7cebe5107e9701672a2a1bc0bb5461c620c56fc8a8aa95a577cf48ac2e5b35d948e468bbc6232527f6a4e3bf5ea0b2f68b161ee3aadeef596c683e511bec1ff70df312d988eddd557952720f82f69882107f67880e38efcca68429374d85831eea3ac133a6a89b68a9ec27c71a67c87addfddb7040a7416ead43e29612dcdc5b7e6a82ad5cd243e8a6dd2997c44ad76a2a20145f89d7e6b2a26c2c0f2ce7d60b1f45410f9ebb79b52dde560f8c7c99b7a11d645f6ad6f94727cd2ea9d48ceb27467ee60371e6919a3ae044c8941a65182c94e8efd7b5c7eb45935baea722628d89d89de995d82b620059fe1054927864a91
 Ctrl.hexxcghash = hexxcghash:f3cc38427adf01b9483d1f9e4e9acef554a8c7d0d8dc088d3865f05bc06a4ff11efbbdbca7ab0e0c0e2df55a93f0b4b9
 Ctrl.hexsession_id = hexsession_id:aae879d8c0c6762d28c30fdc707b169a2155f8b8a943ced399a56419be89cc9f66ba9282d85ac4e53e0d5ae27adcf393
@@ -4132,7 +4133,7 @@ Ctrl.type = type:F
 Output = c53cfa0836ac21bb13c58ed15ddf593e8e01c7437587112ba013058d411d262d87a5e56c098b69146d9019803206ef91
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001cbe25a738580c94ae733a5d4e9e61860bf1a68dfac365edc5818814166cfaecf269d07293d656c8e99973934b5f14eb4bcd1ac3c388596221f65f66e1193463bd41fcff389e458ef7f1ef858439b600bca422cd29c84d2cbc684c7a85d8b44f6a43a5fc53bbaa4ad1a6b0f2b841278efb1fbdd2513e6603984027efb81c72d8c4cbadc8dec51089dcd43ed3109ddbc6db29534186a237c5d8c3a66dedbb51b09937b1c7d4cf6cac682ba2dd1c9cf901d66f1a995f945d5ad12bd7bfdd3fcc5b0852376b9834f0bee3f7a666f587bd2a3b562ccf129b6132c902738fd0dfea3ff9538961bf5f59ac1779dd4ed68986059881f5e08be5ecd1a59380392e81f0a6
 Ctrl.hexxcghash = hexxcghash:b32d4e6b47772e651b867558a03f488fc00c715c196c7abb1abf3ebc24a638edd058e77aeadd9aade5ce34f43e19f1fc
 Ctrl.hexsession_id = hexsession_id:5d2a819b135d8d985643ceab3461ede24ed192c60471676031b4b1f8ae71dec657547fdb3a43f75112855ffce72b60f4
@@ -4140,7 +4141,7 @@ Ctrl.type = type:A
 Output = e34b595f755ff42a33126d8efabe1ec0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001cbe25a738580c94ae733a5d4e9e61860bf1a68dfac365edc5818814166cfaecf269d07293d656c8e99973934b5f14eb4bcd1ac3c388596221f65f66e1193463bd41fcff389e458ef7f1ef858439b600bca422cd29c84d2cbc684c7a85d8b44f6a43a5fc53bbaa4ad1a6b0f2b841278efb1fbdd2513e6603984027efb81c72d8c4cbadc8dec51089dcd43ed3109ddbc6db29534186a237c5d8c3a66dedbb51b09937b1c7d4cf6cac682ba2dd1c9cf901d66f1a995f945d5ad12bd7bfdd3fcc5b0852376b9834f0bee3f7a666f587bd2a3b562ccf129b6132c902738fd0dfea3ff9538961bf5f59ac1779dd4ed68986059881f5e08be5ecd1a59380392e81f0a6
 Ctrl.hexxcghash = hexxcghash:b32d4e6b47772e651b867558a03f488fc00c715c196c7abb1abf3ebc24a638edd058e77aeadd9aade5ce34f43e19f1fc
 Ctrl.hexsession_id = hexsession_id:5d2a819b135d8d985643ceab3461ede24ed192c60471676031b4b1f8ae71dec657547fdb3a43f75112855ffce72b60f4
@@ -4148,7 +4149,7 @@ Ctrl.type = type:B
 Output = a873f52aa3b91a8dd019be8358c04de6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001cbe25a738580c94ae733a5d4e9e61860bf1a68dfac365edc5818814166cfaecf269d07293d656c8e99973934b5f14eb4bcd1ac3c388596221f65f66e1193463bd41fcff389e458ef7f1ef858439b600bca422cd29c84d2cbc684c7a85d8b44f6a43a5fc53bbaa4ad1a6b0f2b841278efb1fbdd2513e6603984027efb81c72d8c4cbadc8dec51089dcd43ed3109ddbc6db29534186a237c5d8c3a66dedbb51b09937b1c7d4cf6cac682ba2dd1c9cf901d66f1a995f945d5ad12bd7bfdd3fcc5b0852376b9834f0bee3f7a666f587bd2a3b562ccf129b6132c902738fd0dfea3ff9538961bf5f59ac1779dd4ed68986059881f5e08be5ecd1a59380392e81f0a6
 Ctrl.hexxcghash = hexxcghash:b32d4e6b47772e651b867558a03f488fc00c715c196c7abb1abf3ebc24a638edd058e77aeadd9aade5ce34f43e19f1fc
 Ctrl.hexsession_id = hexsession_id:5d2a819b135d8d985643ceab3461ede24ed192c60471676031b4b1f8ae71dec657547fdb3a43f75112855ffce72b60f4
@@ -4156,7 +4157,7 @@ Ctrl.type = type:C
 Output = fce5c490a769fbd4aa31b0f5c7aad86b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001cbe25a738580c94ae733a5d4e9e61860bf1a68dfac365edc5818814166cfaecf269d07293d656c8e99973934b5f14eb4bcd1ac3c388596221f65f66e1193463bd41fcff389e458ef7f1ef858439b600bca422cd29c84d2cbc684c7a85d8b44f6a43a5fc53bbaa4ad1a6b0f2b841278efb1fbdd2513e6603984027efb81c72d8c4cbadc8dec51089dcd43ed3109ddbc6db29534186a237c5d8c3a66dedbb51b09937b1c7d4cf6cac682ba2dd1c9cf901d66f1a995f945d5ad12bd7bfdd3fcc5b0852376b9834f0bee3f7a666f587bd2a3b562ccf129b6132c902738fd0dfea3ff9538961bf5f59ac1779dd4ed68986059881f5e08be5ecd1a59380392e81f0a6
 Ctrl.hexxcghash = hexxcghash:b32d4e6b47772e651b867558a03f488fc00c715c196c7abb1abf3ebc24a638edd058e77aeadd9aade5ce34f43e19f1fc
 Ctrl.hexsession_id = hexsession_id:5d2a819b135d8d985643ceab3461ede24ed192c60471676031b4b1f8ae71dec657547fdb3a43f75112855ffce72b60f4
@@ -4164,7 +4165,7 @@ Ctrl.type = type:D
 Output = d36a9b7d2c63675d2b250d5a97b0e628
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001cbe25a738580c94ae733a5d4e9e61860bf1a68dfac365edc5818814166cfaecf269d07293d656c8e99973934b5f14eb4bcd1ac3c388596221f65f66e1193463bd41fcff389e458ef7f1ef858439b600bca422cd29c84d2cbc684c7a85d8b44f6a43a5fc53bbaa4ad1a6b0f2b841278efb1fbdd2513e6603984027efb81c72d8c4cbadc8dec51089dcd43ed3109ddbc6db29534186a237c5d8c3a66dedbb51b09937b1c7d4cf6cac682ba2dd1c9cf901d66f1a995f945d5ad12bd7bfdd3fcc5b0852376b9834f0bee3f7a666f587bd2a3b562ccf129b6132c902738fd0dfea3ff9538961bf5f59ac1779dd4ed68986059881f5e08be5ecd1a59380392e81f0a6
 Ctrl.hexxcghash = hexxcghash:b32d4e6b47772e651b867558a03f488fc00c715c196c7abb1abf3ebc24a638edd058e77aeadd9aade5ce34f43e19f1fc
 Ctrl.hexsession_id = hexsession_id:5d2a819b135d8d985643ceab3461ede24ed192c60471676031b4b1f8ae71dec657547fdb3a43f75112855ffce72b60f4
@@ -4172,7 +4173,7 @@ Ctrl.type = type:E
 Output = 92c8f89f84575cebb9c37be3a488d0b0312a12d9253dbada7db1318f5a193d4f8f75a212a75c1123bca89d5de43cbf08
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:000001001cbe25a738580c94ae733a5d4e9e61860bf1a68dfac365edc5818814166cfaecf269d07293d656c8e99973934b5f14eb4bcd1ac3c388596221f65f66e1193463bd41fcff389e458ef7f1ef858439b600bca422cd29c84d2cbc684c7a85d8b44f6a43a5fc53bbaa4ad1a6b0f2b841278efb1fbdd2513e6603984027efb81c72d8c4cbadc8dec51089dcd43ed3109ddbc6db29534186a237c5d8c3a66dedbb51b09937b1c7d4cf6cac682ba2dd1c9cf901d66f1a995f945d5ad12bd7bfdd3fcc5b0852376b9834f0bee3f7a666f587bd2a3b562ccf129b6132c902738fd0dfea3ff9538961bf5f59ac1779dd4ed68986059881f5e08be5ecd1a59380392e81f0a6
 Ctrl.hexxcghash = hexxcghash:b32d4e6b47772e651b867558a03f488fc00c715c196c7abb1abf3ebc24a638edd058e77aeadd9aade5ce34f43e19f1fc
 Ctrl.hexsession_id = hexsession_id:5d2a819b135d8d985643ceab3461ede24ed192c60471676031b4b1f8ae71dec657547fdb3a43f75112855ffce72b60f4
@@ -4180,7 +4181,7 @@ Ctrl.type = type:F
 Output = 16dcf1bd1aa4d5d6edc2d2b23792872f53767d6b2589e4700469a9bbbbb659c1c8716393fe1ed717833f491cd32d874b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c7f8bcaf17cb17db3d5c2c9e8db37fa77685463d604e6b577ace9ada1b5a7fb54a299684a5405973352262ed66a7e47e4cf9ba7981f76a0aa6bf407be5fc48f70869b6913f7d9b2395f73eda2f08ad5469df982bd82242c19bba0dbcc28fa5869bab99b84015a313cebcc3e86ec3fd15513e329a236487e909a6b37134bc75b03dbda7f9196738ae5f04ac3cae6a3c93150271eeed62f8c019f433df888acec09e947dee6537c4fee5e0dc37d3b4ae4ff77309382148f0127cd01b882f128ee844046c9f3052ff7fff81876c261ad6cdad0a9ebfc769a4308f124d2422f03c1b171ac3404d4d690e9c1d94fc3de479bda663c207120a18f1947a68179d19ecaa
 Ctrl.hexxcghash = hexxcghash:ce996d2b1198f069c24193526be1dd0d08a95d0b0a144da5a1303e84de4eb864d49ca71fa5a59f51c10b9d4257787626
 Ctrl.hexsession_id = hexsession_id:ed906230bdcff56bd239a8c52f3cb1e4e16d1249284162ca85b320e543f62a82d7270131231cf49e1b0c0b1e87643719
@@ -4188,7 +4189,7 @@ Ctrl.type = type:A
 Output = bbdc47242c877cc70585a5d9f0b8067d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c7f8bcaf17cb17db3d5c2c9e8db37fa77685463d604e6b577ace9ada1b5a7fb54a299684a5405973352262ed66a7e47e4cf9ba7981f76a0aa6bf407be5fc48f70869b6913f7d9b2395f73eda2f08ad5469df982bd82242c19bba0dbcc28fa5869bab99b84015a313cebcc3e86ec3fd15513e329a236487e909a6b37134bc75b03dbda7f9196738ae5f04ac3cae6a3c93150271eeed62f8c019f433df888acec09e947dee6537c4fee5e0dc37d3b4ae4ff77309382148f0127cd01b882f128ee844046c9f3052ff7fff81876c261ad6cdad0a9ebfc769a4308f124d2422f03c1b171ac3404d4d690e9c1d94fc3de479bda663c207120a18f1947a68179d19ecaa
 Ctrl.hexxcghash = hexxcghash:ce996d2b1198f069c24193526be1dd0d08a95d0b0a144da5a1303e84de4eb864d49ca71fa5a59f51c10b9d4257787626
 Ctrl.hexsession_id = hexsession_id:ed906230bdcff56bd239a8c52f3cb1e4e16d1249284162ca85b320e543f62a82d7270131231cf49e1b0c0b1e87643719
@@ -4196,7 +4197,7 @@ Ctrl.type = type:B
 Output = 6dcc6458af049a81a6d3139c2725f67d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c7f8bcaf17cb17db3d5c2c9e8db37fa77685463d604e6b577ace9ada1b5a7fb54a299684a5405973352262ed66a7e47e4cf9ba7981f76a0aa6bf407be5fc48f70869b6913f7d9b2395f73eda2f08ad5469df982bd82242c19bba0dbcc28fa5869bab99b84015a313cebcc3e86ec3fd15513e329a236487e909a6b37134bc75b03dbda7f9196738ae5f04ac3cae6a3c93150271eeed62f8c019f433df888acec09e947dee6537c4fee5e0dc37d3b4ae4ff77309382148f0127cd01b882f128ee844046c9f3052ff7fff81876c261ad6cdad0a9ebfc769a4308f124d2422f03c1b171ac3404d4d690e9c1d94fc3de479bda663c207120a18f1947a68179d19ecaa
 Ctrl.hexxcghash = hexxcghash:ce996d2b1198f069c24193526be1dd0d08a95d0b0a144da5a1303e84de4eb864d49ca71fa5a59f51c10b9d4257787626
 Ctrl.hexsession_id = hexsession_id:ed906230bdcff56bd239a8c52f3cb1e4e16d1249284162ca85b320e543f62a82d7270131231cf49e1b0c0b1e87643719
@@ -4204,7 +4205,7 @@ Ctrl.type = type:C
 Output = f788d0b9ea5373031d44972fad39d8e6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c7f8bcaf17cb17db3d5c2c9e8db37fa77685463d604e6b577ace9ada1b5a7fb54a299684a5405973352262ed66a7e47e4cf9ba7981f76a0aa6bf407be5fc48f70869b6913f7d9b2395f73eda2f08ad5469df982bd82242c19bba0dbcc28fa5869bab99b84015a313cebcc3e86ec3fd15513e329a236487e909a6b37134bc75b03dbda7f9196738ae5f04ac3cae6a3c93150271eeed62f8c019f433df888acec09e947dee6537c4fee5e0dc37d3b4ae4ff77309382148f0127cd01b882f128ee844046c9f3052ff7fff81876c261ad6cdad0a9ebfc769a4308f124d2422f03c1b171ac3404d4d690e9c1d94fc3de479bda663c207120a18f1947a68179d19ecaa
 Ctrl.hexxcghash = hexxcghash:ce996d2b1198f069c24193526be1dd0d08a95d0b0a144da5a1303e84de4eb864d49ca71fa5a59f51c10b9d4257787626
 Ctrl.hexsession_id = hexsession_id:ed906230bdcff56bd239a8c52f3cb1e4e16d1249284162ca85b320e543f62a82d7270131231cf49e1b0c0b1e87643719
@@ -4212,7 +4213,7 @@ Ctrl.type = type:D
 Output = e939b1367ea35c67ea990988c3c0c474
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c7f8bcaf17cb17db3d5c2c9e8db37fa77685463d604e6b577ace9ada1b5a7fb54a299684a5405973352262ed66a7e47e4cf9ba7981f76a0aa6bf407be5fc48f70869b6913f7d9b2395f73eda2f08ad5469df982bd82242c19bba0dbcc28fa5869bab99b84015a313cebcc3e86ec3fd15513e329a236487e909a6b37134bc75b03dbda7f9196738ae5f04ac3cae6a3c93150271eeed62f8c019f433df888acec09e947dee6537c4fee5e0dc37d3b4ae4ff77309382148f0127cd01b882f128ee844046c9f3052ff7fff81876c261ad6cdad0a9ebfc769a4308f124d2422f03c1b171ac3404d4d690e9c1d94fc3de479bda663c207120a18f1947a68179d19ecaa
 Ctrl.hexxcghash = hexxcghash:ce996d2b1198f069c24193526be1dd0d08a95d0b0a144da5a1303e84de4eb864d49ca71fa5a59f51c10b9d4257787626
 Ctrl.hexsession_id = hexsession_id:ed906230bdcff56bd239a8c52f3cb1e4e16d1249284162ca85b320e543f62a82d7270131231cf49e1b0c0b1e87643719
@@ -4220,7 +4221,7 @@ Ctrl.type = type:E
 Output = 069629f693b4d291ea6f16355eb4c57eef7824217d22651af095aadac27a789314fee4e86efa9bc63085a8ebfc606548
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100c7f8bcaf17cb17db3d5c2c9e8db37fa77685463d604e6b577ace9ada1b5a7fb54a299684a5405973352262ed66a7e47e4cf9ba7981f76a0aa6bf407be5fc48f70869b6913f7d9b2395f73eda2f08ad5469df982bd82242c19bba0dbcc28fa5869bab99b84015a313cebcc3e86ec3fd15513e329a236487e909a6b37134bc75b03dbda7f9196738ae5f04ac3cae6a3c93150271eeed62f8c019f433df888acec09e947dee6537c4fee5e0dc37d3b4ae4ff77309382148f0127cd01b882f128ee844046c9f3052ff7fff81876c261ad6cdad0a9ebfc769a4308f124d2422f03c1b171ac3404d4d690e9c1d94fc3de479bda663c207120a18f1947a68179d19ecaa
 Ctrl.hexxcghash = hexxcghash:ce996d2b1198f069c24193526be1dd0d08a95d0b0a144da5a1303e84de4eb864d49ca71fa5a59f51c10b9d4257787626
 Ctrl.hexsession_id = hexsession_id:ed906230bdcff56bd239a8c52f3cb1e4e16d1249284162ca85b320e543f62a82d7270131231cf49e1b0c0b1e87643719
@@ -4228,7 +4229,7 @@ Ctrl.type = type:F
 Output = 731107905e3b9b36ba3dca504b35f1a51e75e2a3ee2595ade882c21410d439ec1ec31fbc62e64362a5fddc0f39e76da0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100b41b41585296e85cce723619b40609b21799fb244d72fd87afa3088073819b232de7d9ab45ceaab3014099475e9314cff74149b5e4558962f31d3d2a84f24500558af928ff785dc32627f5062ea2d5bf6ff085edf6d200daca91037abda71b5c9c1660cbf60cfc3ec1fe590c3d6300aa279e42383f98f4000031bf57a2bb612c7a212bc0ec5057817b0843e01c14a9b353c26699670873db05de7049ac44951094c8b231713dab09ca641d3cea65c5e3b01d41d93351635b08a767afadfd7865388ebbe29e8f47033d1fe530d7d45fa1c266705b26d67282872da9551256d88708e1ec69ce9b94db6c7f3e6b7ae06418b36537b7839454c539b2bdd758af9c19
 Ctrl.hexxcghash = hexxcghash:5b168cac1113de12bac95aac34501866abd610c6ce0d51520f83c865db8d0c688b27af11e08deb4a2673c160edd1da93
 Ctrl.hexsession_id = hexsession_id:32dc32821483ed98f696813e712d229b6ff5a9e0f7f8e582a26f0a5204fa7655040ddbc791e00e7a979dded9354ea2dc
@@ -4236,7 +4237,7 @@ Ctrl.type = type:A
 Output = 8e1af4ce3b9aa9f1e7493775f8846ac0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100b41b41585296e85cce723619b40609b21799fb244d72fd87afa3088073819b232de7d9ab45ceaab3014099475e9314cff74149b5e4558962f31d3d2a84f24500558af928ff785dc32627f5062ea2d5bf6ff085edf6d200daca91037abda71b5c9c1660cbf60cfc3ec1fe590c3d6300aa279e42383f98f4000031bf57a2bb612c7a212bc0ec5057817b0843e01c14a9b353c26699670873db05de7049ac44951094c8b231713dab09ca641d3cea65c5e3b01d41d93351635b08a767afadfd7865388ebbe29e8f47033d1fe530d7d45fa1c266705b26d67282872da9551256d88708e1ec69ce9b94db6c7f3e6b7ae06418b36537b7839454c539b2bdd758af9c19
 Ctrl.hexxcghash = hexxcghash:5b168cac1113de12bac95aac34501866abd610c6ce0d51520f83c865db8d0c688b27af11e08deb4a2673c160edd1da93
 Ctrl.hexsession_id = hexsession_id:32dc32821483ed98f696813e712d229b6ff5a9e0f7f8e582a26f0a5204fa7655040ddbc791e00e7a979dded9354ea2dc
@@ -4244,7 +4245,7 @@ Ctrl.type = type:B
 Output = 1796cee0aeb39eb1fbbaeaf15d600832
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100b41b41585296e85cce723619b40609b21799fb244d72fd87afa3088073819b232de7d9ab45ceaab3014099475e9314cff74149b5e4558962f31d3d2a84f24500558af928ff785dc32627f5062ea2d5bf6ff085edf6d200daca91037abda71b5c9c1660cbf60cfc3ec1fe590c3d6300aa279e42383f98f4000031bf57a2bb612c7a212bc0ec5057817b0843e01c14a9b353c26699670873db05de7049ac44951094c8b231713dab09ca641d3cea65c5e3b01d41d93351635b08a767afadfd7865388ebbe29e8f47033d1fe530d7d45fa1c266705b26d67282872da9551256d88708e1ec69ce9b94db6c7f3e6b7ae06418b36537b7839454c539b2bdd758af9c19
 Ctrl.hexxcghash = hexxcghash:5b168cac1113de12bac95aac34501866abd610c6ce0d51520f83c865db8d0c688b27af11e08deb4a2673c160edd1da93
 Ctrl.hexsession_id = hexsession_id:32dc32821483ed98f696813e712d229b6ff5a9e0f7f8e582a26f0a5204fa7655040ddbc791e00e7a979dded9354ea2dc
@@ -4252,7 +4253,7 @@ Ctrl.type = type:C
 Output = 7a7485045a2f8cc86f82c8486f8e9f59
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100b41b41585296e85cce723619b40609b21799fb244d72fd87afa3088073819b232de7d9ab45ceaab3014099475e9314cff74149b5e4558962f31d3d2a84f24500558af928ff785dc32627f5062ea2d5bf6ff085edf6d200daca91037abda71b5c9c1660cbf60cfc3ec1fe590c3d6300aa279e42383f98f4000031bf57a2bb612c7a212bc0ec5057817b0843e01c14a9b353c26699670873db05de7049ac44951094c8b231713dab09ca641d3cea65c5e3b01d41d93351635b08a767afadfd7865388ebbe29e8f47033d1fe530d7d45fa1c266705b26d67282872da9551256d88708e1ec69ce9b94db6c7f3e6b7ae06418b36537b7839454c539b2bdd758af9c19
 Ctrl.hexxcghash = hexxcghash:5b168cac1113de12bac95aac34501866abd610c6ce0d51520f83c865db8d0c688b27af11e08deb4a2673c160edd1da93
 Ctrl.hexsession_id = hexsession_id:32dc32821483ed98f696813e712d229b6ff5a9e0f7f8e582a26f0a5204fa7655040ddbc791e00e7a979dded9354ea2dc
@@ -4260,7 +4261,7 @@ Ctrl.type = type:D
 Output = 00a9d893e8c14aa3a316163d50d83378
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100b41b41585296e85cce723619b40609b21799fb244d72fd87afa3088073819b232de7d9ab45ceaab3014099475e9314cff74149b5e4558962f31d3d2a84f24500558af928ff785dc32627f5062ea2d5bf6ff085edf6d200daca91037abda71b5c9c1660cbf60cfc3ec1fe590c3d6300aa279e42383f98f4000031bf57a2bb612c7a212bc0ec5057817b0843e01c14a9b353c26699670873db05de7049ac44951094c8b231713dab09ca641d3cea65c5e3b01d41d93351635b08a767afadfd7865388ebbe29e8f47033d1fe530d7d45fa1c266705b26d67282872da9551256d88708e1ec69ce9b94db6c7f3e6b7ae06418b36537b7839454c539b2bdd758af9c19
 Ctrl.hexxcghash = hexxcghash:5b168cac1113de12bac95aac34501866abd610c6ce0d51520f83c865db8d0c688b27af11e08deb4a2673c160edd1da93
 Ctrl.hexsession_id = hexsession_id:32dc32821483ed98f696813e712d229b6ff5a9e0f7f8e582a26f0a5204fa7655040ddbc791e00e7a979dded9354ea2dc
@@ -4268,7 +4269,7 @@ Ctrl.type = type:E
 Output = 46133b1cbab3e04043a1b336db99575183d5be76f9d56556493a8d4a8da37a020ae379ff2d470a99ca7e9d2b1cf85cb4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA384
+Ctrl.digest = digest:SHA384
 Ctrl.hexkey = hexkey:0000010100b41b41585296e85cce723619b40609b21799fb244d72fd87afa3088073819b232de7d9ab45ceaab3014099475e9314cff74149b5e4558962f31d3d2a84f24500558af928ff785dc32627f5062ea2d5bf6ff085edf6d200daca91037abda71b5c9c1660cbf60cfc3ec1fe590c3d6300aa279e42383f98f4000031bf57a2bb612c7a212bc0ec5057817b0843e01c14a9b353c26699670873db05de7049ac44951094c8b231713dab09ca641d3cea65c5e3b01d41d93351635b08a767afadfd7865388ebbe29e8f47033d1fe530d7d45fa1c266705b26d67282872da9551256d88708e1ec69ce9b94db6c7f3e6b7ae06418b36537b7839454c539b2bdd758af9c19
 Ctrl.hexxcghash = hexxcghash:5b168cac1113de12bac95aac34501866abd610c6ce0d51520f83c865db8d0c688b27af11e08deb4a2673c160edd1da93
 Ctrl.hexsession_id = hexsession_id:32dc32821483ed98f696813e712d229b6ff5a9e0f7f8e582a26f0a5204fa7655040ddbc791e00e7a979dded9354ea2dc
@@ -4276,7 +4277,7 @@ Ctrl.type = type:F
 Output = 9221abcc3db5a557cca60408e65528e937cc3673b548c350924cd9e6387de526f5cb35a0bbe4020c47318b59d1a0527d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000080575308ca395798bb21ec5438c46a88ffa3f7f7671c06f924abf7c3cfb46c78c025596e4aba50c3271089184a447a571abb7f4a1b1c41f5d5ca8062940d4369778589fde81a71b2228f018c4c836cf389f854f86de71a68b1693fe8ffa1c59ce7e9f9223debada2566d2b0e5678a48bfb530e7bee42bd2ac7304a0a5ae339a2cd
 Ctrl.hexxcghash = hexxcghash:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
 Ctrl.hexsession_id = hexsession_id:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
@@ -4284,7 +4285,7 @@ Ctrl.type = type:A
 Output = 0e2693ade0524af8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000080575308ca395798bb21ec5438c46a88ffa3f7f7671c06f924abf7c3cfb46c78c025596e4aba50c3271089184a447a571abb7f4a1b1c41f5d5ca8062940d4369778589fde81a71b2228f018c4c836cf389f854f86de71a68b1693fe8ffa1c59ce7e9f9223debada2566d2b0e5678a48bfb530e7bee42bd2ac7304a0a5ae339a2cd
 Ctrl.hexxcghash = hexxcghash:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
 Ctrl.hexsession_id = hexsession_id:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
@@ -4292,7 +4293,7 @@ Ctrl.type = type:B
 Output = b13144de02295bb8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000080575308ca395798bb21ec5438c46a88ffa3f7f7671c06f924abf7c3cfb46c78c025596e4aba50c3271089184a447a571abb7f4a1b1c41f5d5ca8062940d4369778589fde81a71b2228f018c4c836cf389f854f86de71a68b1693fe8ffa1c59ce7e9f9223debada2566d2b0e5678a48bfb530e7bee42bd2ac7304a0a5ae339a2cd
 Ctrl.hexxcghash = hexxcghash:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
 Ctrl.hexsession_id = hexsession_id:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
@@ -4300,7 +4301,7 @@ Ctrl.type = type:C
 Output = 7e4a721fb7379ebb423306464d57db46afa3cca10a1d7feb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000080575308ca395798bb21ec5438c46a88ffa3f7f7671c06f924abf7c3cfb46c78c025596e4aba50c3271089184a447a571abb7f4a1b1c41f5d5ca8062940d4369778589fde81a71b2228f018c4c836cf389f854f86de71a68b1693fe8ffa1c59ce7e9f9223debada2566d2b0e5678a48bfb530e7bee42bd2ac7304a0a5ae339a2cd
 Ctrl.hexxcghash = hexxcghash:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
 Ctrl.hexsession_id = hexsession_id:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
@@ -4308,7 +4309,7 @@ Ctrl.type = type:D
 Output = bb84123b1fac400e0df4767d78d011427e1edd4d4c934b95
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000080575308ca395798bb21ec5438c46a88ffa3f7f7671c06f924abf7c3cfb46c78c025596e4aba50c3271089184a447a571abb7f4a1b1c41f5d5ca8062940d4369778589fde81a71b2228f018c4c836cf389f854f86de71a68b1693fe8ffa1c59ce7e9f9223debada2566d2b0e5678a48bfb530e7bee42bd2ac7304a0a5ae339a2cd
 Ctrl.hexxcghash = hexxcghash:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
 Ctrl.hexsession_id = hexsession_id:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
@@ -4316,7 +4317,7 @@ Ctrl.type = type:E
 Output = 00fb0a45c650dd9c95666b0c7fcea8c98f0562f61b862054ee400aec875dbbc2bdef4806c09217709a5050569312efe3af513e7aa733c72457abe1607ac01c13
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000080575308ca395798bb21ec5438c46a88ffa3f7f7671c06f924abf7c3cfb46c78c025596e4aba50c3271089184a447a571abb7f4a1b1c41f5d5ca8062940d4369778589fde81a71b2228f018c4c836cf389f854f86de71a68b1693fe8ffa1c59ce7e9f9223debada2566d2b0e5678a48bfb530e7bee42bd2ac7304a0a5ae339a2cd
 Ctrl.hexxcghash = hexxcghash:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
 Ctrl.hexsession_id = hexsession_id:a4125aa9898092ca50c3c1631c03dcbc9df95cebb409881e580108b6cc4704b76cc77b8795fd5940561e3224cc75848518992bd8d9b70fe0fc977a476063c8bf
@@ -4324,7 +4325,7 @@ Ctrl.type = type:F
 Output = 70a8005e711fb96dea5991cb68831b9e86005821b45ceaf958c13d5c87cbd2953d0877c267796edf8c7fb3d768bb26b74e542f40bf9ac9f6a9d217077e85f511
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000802b2e6f7545fa66e1078c67c5457dbf5ee03801edef4421d4f0e797b947b79e293ef724253ec4adb53977f027a2d577d7779e96be4e093b0c36be62778c5bd48dbb0bff1335470e10cdec4df88e8feb00d322426baf3035e9fda1aaf819be48dacc640d52eb8750cc6fd8031d0cba0ef0a11973d43138dd2d11d2eef1fc926327
 Ctrl.hexxcghash = hexxcghash:4dc005dc6ad5075cf6abbedb53a0407104659cd168b58d014fb2465d6f1d1140d5fef634f345c6c38ac2a8db3771e4b0c71c51faf85a297bbdf7ddf8228c3159
 Ctrl.hexsession_id = hexsession_id:a674aaced8345324221bbd8356ab8355fd3d3e410ae974c0da196f4cd58cc0236a85900626da696dab8be23aaa529458ac6ccf64058fd2fd140ca1a1a0c57988
@@ -4332,7 +4333,7 @@ Ctrl.type = type:A
 Output = c75c77791f7b67c2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000802b2e6f7545fa66e1078c67c5457dbf5ee03801edef4421d4f0e797b947b79e293ef724253ec4adb53977f027a2d577d7779e96be4e093b0c36be62778c5bd48dbb0bff1335470e10cdec4df88e8feb00d322426baf3035e9fda1aaf819be48dacc640d52eb8750cc6fd8031d0cba0ef0a11973d43138dd2d11d2eef1fc926327
 Ctrl.hexxcghash = hexxcghash:4dc005dc6ad5075cf6abbedb53a0407104659cd168b58d014fb2465d6f1d1140d5fef634f345c6c38ac2a8db3771e4b0c71c51faf85a297bbdf7ddf8228c3159
 Ctrl.hexsession_id = hexsession_id:a674aaced8345324221bbd8356ab8355fd3d3e410ae974c0da196f4cd58cc0236a85900626da696dab8be23aaa529458ac6ccf64058fd2fd140ca1a1a0c57988
@@ -4340,7 +4341,7 @@ Ctrl.type = type:B
 Output = dae1e8bfab1b4b7e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000802b2e6f7545fa66e1078c67c5457dbf5ee03801edef4421d4f0e797b947b79e293ef724253ec4adb53977f027a2d577d7779e96be4e093b0c36be62778c5bd48dbb0bff1335470e10cdec4df88e8feb00d322426baf3035e9fda1aaf819be48dacc640d52eb8750cc6fd8031d0cba0ef0a11973d43138dd2d11d2eef1fc926327
 Ctrl.hexxcghash = hexxcghash:4dc005dc6ad5075cf6abbedb53a0407104659cd168b58d014fb2465d6f1d1140d5fef634f345c6c38ac2a8db3771e4b0c71c51faf85a297bbdf7ddf8228c3159
 Ctrl.hexsession_id = hexsession_id:a674aaced8345324221bbd8356ab8355fd3d3e410ae974c0da196f4cd58cc0236a85900626da696dab8be23aaa529458ac6ccf64058fd2fd140ca1a1a0c57988
@@ -4348,7 +4349,7 @@ Ctrl.type = type:C
 Output = 0e79f5b685ebe77ae6d62c344a5dd0f53502523a28e2b408
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000802b2e6f7545fa66e1078c67c5457dbf5ee03801edef4421d4f0e797b947b79e293ef724253ec4adb53977f027a2d577d7779e96be4e093b0c36be62778c5bd48dbb0bff1335470e10cdec4df88e8feb00d322426baf3035e9fda1aaf819be48dacc640d52eb8750cc6fd8031d0cba0ef0a11973d43138dd2d11d2eef1fc926327
 Ctrl.hexxcghash = hexxcghash:4dc005dc6ad5075cf6abbedb53a0407104659cd168b58d014fb2465d6f1d1140d5fef634f345c6c38ac2a8db3771e4b0c71c51faf85a297bbdf7ddf8228c3159
 Ctrl.hexsession_id = hexsession_id:a674aaced8345324221bbd8356ab8355fd3d3e410ae974c0da196f4cd58cc0236a85900626da696dab8be23aaa529458ac6ccf64058fd2fd140ca1a1a0c57988
@@ -4356,7 +4357,7 @@ Ctrl.type = type:D
 Output = c5ec1aae5d26c2c5fe769576eb1b75c53d3dc67d452dca1c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000802b2e6f7545fa66e1078c67c5457dbf5ee03801edef4421d4f0e797b947b79e293ef724253ec4adb53977f027a2d577d7779e96be4e093b0c36be62778c5bd48dbb0bff1335470e10cdec4df88e8feb00d322426baf3035e9fda1aaf819be48dacc640d52eb8750cc6fd8031d0cba0ef0a11973d43138dd2d11d2eef1fc926327
 Ctrl.hexxcghash = hexxcghash:4dc005dc6ad5075cf6abbedb53a0407104659cd168b58d014fb2465d6f1d1140d5fef634f345c6c38ac2a8db3771e4b0c71c51faf85a297bbdf7ddf8228c3159
 Ctrl.hexsession_id = hexsession_id:a674aaced8345324221bbd8356ab8355fd3d3e410ae974c0da196f4cd58cc0236a85900626da696dab8be23aaa529458ac6ccf64058fd2fd140ca1a1a0c57988
@@ -4364,7 +4365,7 @@ Ctrl.type = type:E
 Output = 6bc4e5d6049c69a8ffbf93c7617b6a168bd0f14d71471d199b81729250117272ad102772761a8c0b5d5240e589e48a4f85ab8c3e1bd030327e7c87428ee44d13
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000802b2e6f7545fa66e1078c67c5457dbf5ee03801edef4421d4f0e797b947b79e293ef724253ec4adb53977f027a2d577d7779e96be4e093b0c36be62778c5bd48dbb0bff1335470e10cdec4df88e8feb00d322426baf3035e9fda1aaf819be48dacc640d52eb8750cc6fd8031d0cba0ef0a11973d43138dd2d11d2eef1fc926327
 Ctrl.hexxcghash = hexxcghash:4dc005dc6ad5075cf6abbedb53a0407104659cd168b58d014fb2465d6f1d1140d5fef634f345c6c38ac2a8db3771e4b0c71c51faf85a297bbdf7ddf8228c3159
 Ctrl.hexsession_id = hexsession_id:a674aaced8345324221bbd8356ab8355fd3d3e410ae974c0da196f4cd58cc0236a85900626da696dab8be23aaa529458ac6ccf64058fd2fd140ca1a1a0c57988
@@ -4372,7 +4373,7 @@ Ctrl.type = type:F
 Output = ce109babe86778542856e3934be12decd239120a4dcb948a0154c4cb7b8ac0a4a3cbd682698086123e6c0481ee351bd9fedfba58d37f7814ba9c2b584f6cfedf
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810085874b95394d5ca3096b0a7e6444e129544e4acd8dd7078c46dc74633df1737986e7dc6f58ac09c7d734fd68378f1ee6df60c48bde343e55ab2a5796ca3ec295f15a75500f476a8a6f1725fdade3339cd7da0a2528449652d7ea21a834e42961ede8477f63bac84ccdba933c276512d3670477d2696402175208526276712541
 Ctrl.hexxcghash = hexxcghash:8540955867f6580e9c1e7e3dfaef9c4f810dbf3364e54f66c471b51d11686598fabff6c3f78a7ac1c90710ab991aa00980f9d5948d462662f6c439fa7b80483f
 Ctrl.hexsession_id = hexsession_id:f2ebb7479c714402275075725c4712994f04485c048fad37d1505f1ce2cd6e32051782848afbea4399231fea5b8d39ec596e118dcc95ea35ffddd8c5611f5298
@@ -4380,7 +4381,7 @@ Ctrl.type = type:A
 Output = 6a71fc98f044591d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810085874b95394d5ca3096b0a7e6444e129544e4acd8dd7078c46dc74633df1737986e7dc6f58ac09c7d734fd68378f1ee6df60c48bde343e55ab2a5796ca3ec295f15a75500f476a8a6f1725fdade3339cd7da0a2528449652d7ea21a834e42961ede8477f63bac84ccdba933c276512d3670477d2696402175208526276712541
 Ctrl.hexxcghash = hexxcghash:8540955867f6580e9c1e7e3dfaef9c4f810dbf3364e54f66c471b51d11686598fabff6c3f78a7ac1c90710ab991aa00980f9d5948d462662f6c439fa7b80483f
 Ctrl.hexsession_id = hexsession_id:f2ebb7479c714402275075725c4712994f04485c048fad37d1505f1ce2cd6e32051782848afbea4399231fea5b8d39ec596e118dcc95ea35ffddd8c5611f5298
@@ -4388,7 +4389,7 @@ Ctrl.type = type:B
 Output = 9f1a35a5c79014c0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810085874b95394d5ca3096b0a7e6444e129544e4acd8dd7078c46dc74633df1737986e7dc6f58ac09c7d734fd68378f1ee6df60c48bde343e55ab2a5796ca3ec295f15a75500f476a8a6f1725fdade3339cd7da0a2528449652d7ea21a834e42961ede8477f63bac84ccdba933c276512d3670477d2696402175208526276712541
 Ctrl.hexxcghash = hexxcghash:8540955867f6580e9c1e7e3dfaef9c4f810dbf3364e54f66c471b51d11686598fabff6c3f78a7ac1c90710ab991aa00980f9d5948d462662f6c439fa7b80483f
 Ctrl.hexsession_id = hexsession_id:f2ebb7479c714402275075725c4712994f04485c048fad37d1505f1ce2cd6e32051782848afbea4399231fea5b8d39ec596e118dcc95ea35ffddd8c5611f5298
@@ -4396,7 +4397,7 @@ Ctrl.type = type:C
 Output = 377901cc72e4c06e30e27b03902f65c4a58b9d3f5cf43431
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810085874b95394d5ca3096b0a7e6444e129544e4acd8dd7078c46dc74633df1737986e7dc6f58ac09c7d734fd68378f1ee6df60c48bde343e55ab2a5796ca3ec295f15a75500f476a8a6f1725fdade3339cd7da0a2528449652d7ea21a834e42961ede8477f63bac84ccdba933c276512d3670477d2696402175208526276712541
 Ctrl.hexxcghash = hexxcghash:8540955867f6580e9c1e7e3dfaef9c4f810dbf3364e54f66c471b51d11686598fabff6c3f78a7ac1c90710ab991aa00980f9d5948d462662f6c439fa7b80483f
 Ctrl.hexsession_id = hexsession_id:f2ebb7479c714402275075725c4712994f04485c048fad37d1505f1ce2cd6e32051782848afbea4399231fea5b8d39ec596e118dcc95ea35ffddd8c5611f5298
@@ -4404,7 +4405,7 @@ Ctrl.type = type:D
 Output = 82a9db94ea5c15dff736c3074a34951e828c8dfa3fef8596
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810085874b95394d5ca3096b0a7e6444e129544e4acd8dd7078c46dc74633df1737986e7dc6f58ac09c7d734fd68378f1ee6df60c48bde343e55ab2a5796ca3ec295f15a75500f476a8a6f1725fdade3339cd7da0a2528449652d7ea21a834e42961ede8477f63bac84ccdba933c276512d3670477d2696402175208526276712541
 Ctrl.hexxcghash = hexxcghash:8540955867f6580e9c1e7e3dfaef9c4f810dbf3364e54f66c471b51d11686598fabff6c3f78a7ac1c90710ab991aa00980f9d5948d462662f6c439fa7b80483f
 Ctrl.hexsession_id = hexsession_id:f2ebb7479c714402275075725c4712994f04485c048fad37d1505f1ce2cd6e32051782848afbea4399231fea5b8d39ec596e118dcc95ea35ffddd8c5611f5298
@@ -4412,7 +4413,7 @@ Ctrl.type = type:E
 Output = b3ce0202c966df307a0729a4bb3fcd0ee55d4c521a144ecd285a470830f60685b2d751883d85ccd29fcc2481f3f442fdedd58d17528e8c4fb28473ee5e539706
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810085874b95394d5ca3096b0a7e6444e129544e4acd8dd7078c46dc74633df1737986e7dc6f58ac09c7d734fd68378f1ee6df60c48bde343e55ab2a5796ca3ec295f15a75500f476a8a6f1725fdade3339cd7da0a2528449652d7ea21a834e42961ede8477f63bac84ccdba933c276512d3670477d2696402175208526276712541
 Ctrl.hexxcghash = hexxcghash:8540955867f6580e9c1e7e3dfaef9c4f810dbf3364e54f66c471b51d11686598fabff6c3f78a7ac1c90710ab991aa00980f9d5948d462662f6c439fa7b80483f
 Ctrl.hexsession_id = hexsession_id:f2ebb7479c714402275075725c4712994f04485c048fad37d1505f1ce2cd6e32051782848afbea4399231fea5b8d39ec596e118dcc95ea35ffddd8c5611f5298
@@ -4420,7 +4421,7 @@ Ctrl.type = type:F
 Output = c1ab7227f919cbda46cd6ac2bd4bb2ee5bd586cc55c7c1cb067df4c9a23209f716ff5e97ed76ebbc0354d683c5369937ca8db4cecf9e6c40886a186d9c4e2366
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100e1436b5ef714092a6a0c8cc1593682a7ca4c05de423fb5f57c1d225943d8e4a5b526288a46a9a0fdb10b59c0beb8c1dc5b4d2bdf34eec2525df84bca2f8b769897183a45c7e61171ecea6e2be80d3becec8355ac3853bd8d077697af6e774133143265bdd538b4fb64786aaaa33e45138fd8697ff1c77b50f63dd8e9476a74c0
 Ctrl.hexxcghash = hexxcghash:367c80484d7e01e0915959e9fcb5124fa674489cf0ec4b0fee6a62dd77f677db901d9fb417cecf2a98f0b24bc24edbb1f34ab19f8d4d2976958f7d99ae2c78b3
 Ctrl.hexsession_id = hexsession_id:0a1bbfb890087ef260a88fafb92f16765444adc4dcb00efd4750d59f1d8f4b6662edd379d812ddc822cea79675731a5e5791f29ebd17f3f83e675e9e9f6af3e3
@@ -4428,7 +4429,7 @@ Ctrl.type = type:A
 Output = 3832bf21b907daa3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100e1436b5ef714092a6a0c8cc1593682a7ca4c05de423fb5f57c1d225943d8e4a5b526288a46a9a0fdb10b59c0beb8c1dc5b4d2bdf34eec2525df84bca2f8b769897183a45c7e61171ecea6e2be80d3becec8355ac3853bd8d077697af6e774133143265bdd538b4fb64786aaaa33e45138fd8697ff1c77b50f63dd8e9476a74c0
 Ctrl.hexxcghash = hexxcghash:367c80484d7e01e0915959e9fcb5124fa674489cf0ec4b0fee6a62dd77f677db901d9fb417cecf2a98f0b24bc24edbb1f34ab19f8d4d2976958f7d99ae2c78b3
 Ctrl.hexsession_id = hexsession_id:0a1bbfb890087ef260a88fafb92f16765444adc4dcb00efd4750d59f1d8f4b6662edd379d812ddc822cea79675731a5e5791f29ebd17f3f83e675e9e9f6af3e3
@@ -4436,7 +4437,7 @@ Ctrl.type = type:B
 Output = 4e04d7787ba7fa68
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100e1436b5ef714092a6a0c8cc1593682a7ca4c05de423fb5f57c1d225943d8e4a5b526288a46a9a0fdb10b59c0beb8c1dc5b4d2bdf34eec2525df84bca2f8b769897183a45c7e61171ecea6e2be80d3becec8355ac3853bd8d077697af6e774133143265bdd538b4fb64786aaaa33e45138fd8697ff1c77b50f63dd8e9476a74c0
 Ctrl.hexxcghash = hexxcghash:367c80484d7e01e0915959e9fcb5124fa674489cf0ec4b0fee6a62dd77f677db901d9fb417cecf2a98f0b24bc24edbb1f34ab19f8d4d2976958f7d99ae2c78b3
 Ctrl.hexsession_id = hexsession_id:0a1bbfb890087ef260a88fafb92f16765444adc4dcb00efd4750d59f1d8f4b6662edd379d812ddc822cea79675731a5e5791f29ebd17f3f83e675e9e9f6af3e3
@@ -4444,7 +4445,7 @@ Ctrl.type = type:C
 Output = d7be949edcfe4e4b877de1cc6a861fa721e137bf3dd1bb27
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100e1436b5ef714092a6a0c8cc1593682a7ca4c05de423fb5f57c1d225943d8e4a5b526288a46a9a0fdb10b59c0beb8c1dc5b4d2bdf34eec2525df84bca2f8b769897183a45c7e61171ecea6e2be80d3becec8355ac3853bd8d077697af6e774133143265bdd538b4fb64786aaaa33e45138fd8697ff1c77b50f63dd8e9476a74c0
 Ctrl.hexxcghash = hexxcghash:367c80484d7e01e0915959e9fcb5124fa674489cf0ec4b0fee6a62dd77f677db901d9fb417cecf2a98f0b24bc24edbb1f34ab19f8d4d2976958f7d99ae2c78b3
 Ctrl.hexsession_id = hexsession_id:0a1bbfb890087ef260a88fafb92f16765444adc4dcb00efd4750d59f1d8f4b6662edd379d812ddc822cea79675731a5e5791f29ebd17f3f83e675e9e9f6af3e3
@@ -4452,7 +4453,7 @@ Ctrl.type = type:D
 Output = 5361fc87e24ec3031d97f0099766ac9ff7b8f91ea87666de
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100e1436b5ef714092a6a0c8cc1593682a7ca4c05de423fb5f57c1d225943d8e4a5b526288a46a9a0fdb10b59c0beb8c1dc5b4d2bdf34eec2525df84bca2f8b769897183a45c7e61171ecea6e2be80d3becec8355ac3853bd8d077697af6e774133143265bdd538b4fb64786aaaa33e45138fd8697ff1c77b50f63dd8e9476a74c0
 Ctrl.hexxcghash = hexxcghash:367c80484d7e01e0915959e9fcb5124fa674489cf0ec4b0fee6a62dd77f677db901d9fb417cecf2a98f0b24bc24edbb1f34ab19f8d4d2976958f7d99ae2c78b3
 Ctrl.hexsession_id = hexsession_id:0a1bbfb890087ef260a88fafb92f16765444adc4dcb00efd4750d59f1d8f4b6662edd379d812ddc822cea79675731a5e5791f29ebd17f3f83e675e9e9f6af3e3
@@ -4460,7 +4461,7 @@ Ctrl.type = type:E
 Output = 40a6897606035ebb04907fa15e1545a8973b9b09423f3786be4bcb8db9e4561e0385bcf1e3c0cece5a788e9852ed1da56963f36bad78fede21405ce3ea92a3b8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100e1436b5ef714092a6a0c8cc1593682a7ca4c05de423fb5f57c1d225943d8e4a5b526288a46a9a0fdb10b59c0beb8c1dc5b4d2bdf34eec2525df84bca2f8b769897183a45c7e61171ecea6e2be80d3becec8355ac3853bd8d077697af6e774133143265bdd538b4fb64786aaaa33e45138fd8697ff1c77b50f63dd8e9476a74c0
 Ctrl.hexxcghash = hexxcghash:367c80484d7e01e0915959e9fcb5124fa674489cf0ec4b0fee6a62dd77f677db901d9fb417cecf2a98f0b24bc24edbb1f34ab19f8d4d2976958f7d99ae2c78b3
 Ctrl.hexsession_id = hexsession_id:0a1bbfb890087ef260a88fafb92f16765444adc4dcb00efd4750d59f1d8f4b6662edd379d812ddc822cea79675731a5e5791f29ebd17f3f83e675e9e9f6af3e3
@@ -4468,7 +4469,7 @@ Ctrl.type = type:F
 Output = 727f9bade9334f97486f479c88614ce96b8cbc803a544fbfaf5fcaf0499a1b8edeb59daa1a824ca9b165879c63d9f0b6464bcd3121fb1ad29b38864fbaac7741
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100f8cf4795508e2aba0d9c007ee0afb38a7d570e26d4ebe97d3b9cb46dfc05b9b18396054fa91f856758b036195a9b360ee48b65dcec1f2fcb901d5faa308125b30b804e53ac15b2f43c2a12fdbc987707af58c36ecdcd89376117f9655e14da7f1808baeaab020a47ac35166a4868dab970ce79de592c69164045fce4eb55872f
 Ctrl.hexxcghash = hexxcghash:40d59c8836500e523e6404ac03d9895b105c7feceaac52dc3c5e4113e256c0057fbc770b805f7a2f18bf0be13357eb99db906efc5fb772f96e5fe76088e2e6f2
 Ctrl.hexsession_id = hexsession_id:a619290ad553a2b0924f3ea6152883685e3f2cf6063487616f083fadae950451df5f6e8a144cd951b2d853c7ec2d1aece9c438a89850788edc6bd5e2a7a98a47
@@ -4476,7 +4477,7 @@ Ctrl.type = type:A
 Output = 3f077a02dc957eb1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100f8cf4795508e2aba0d9c007ee0afb38a7d570e26d4ebe97d3b9cb46dfc05b9b18396054fa91f856758b036195a9b360ee48b65dcec1f2fcb901d5faa308125b30b804e53ac15b2f43c2a12fdbc987707af58c36ecdcd89376117f9655e14da7f1808baeaab020a47ac35166a4868dab970ce79de592c69164045fce4eb55872f
 Ctrl.hexxcghash = hexxcghash:40d59c8836500e523e6404ac03d9895b105c7feceaac52dc3c5e4113e256c0057fbc770b805f7a2f18bf0be13357eb99db906efc5fb772f96e5fe76088e2e6f2
 Ctrl.hexsession_id = hexsession_id:a619290ad553a2b0924f3ea6152883685e3f2cf6063487616f083fadae950451df5f6e8a144cd951b2d853c7ec2d1aece9c438a89850788edc6bd5e2a7a98a47
@@ -4484,7 +4485,7 @@ Ctrl.type = type:B
 Output = 3cc158e348e64a0a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100f8cf4795508e2aba0d9c007ee0afb38a7d570e26d4ebe97d3b9cb46dfc05b9b18396054fa91f856758b036195a9b360ee48b65dcec1f2fcb901d5faa308125b30b804e53ac15b2f43c2a12fdbc987707af58c36ecdcd89376117f9655e14da7f1808baeaab020a47ac35166a4868dab970ce79de592c69164045fce4eb55872f
 Ctrl.hexxcghash = hexxcghash:40d59c8836500e523e6404ac03d9895b105c7feceaac52dc3c5e4113e256c0057fbc770b805f7a2f18bf0be13357eb99db906efc5fb772f96e5fe76088e2e6f2
 Ctrl.hexsession_id = hexsession_id:a619290ad553a2b0924f3ea6152883685e3f2cf6063487616f083fadae950451df5f6e8a144cd951b2d853c7ec2d1aece9c438a89850788edc6bd5e2a7a98a47
@@ -4492,7 +4493,7 @@ Ctrl.type = type:C
 Output = 8770fb6792c2fc16a60c9f45c8d40db684fe52de7c60b482
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100f8cf4795508e2aba0d9c007ee0afb38a7d570e26d4ebe97d3b9cb46dfc05b9b18396054fa91f856758b036195a9b360ee48b65dcec1f2fcb901d5faa308125b30b804e53ac15b2f43c2a12fdbc987707af58c36ecdcd89376117f9655e14da7f1808baeaab020a47ac35166a4868dab970ce79de592c69164045fce4eb55872f
 Ctrl.hexxcghash = hexxcghash:40d59c8836500e523e6404ac03d9895b105c7feceaac52dc3c5e4113e256c0057fbc770b805f7a2f18bf0be13357eb99db906efc5fb772f96e5fe76088e2e6f2
 Ctrl.hexsession_id = hexsession_id:a619290ad553a2b0924f3ea6152883685e3f2cf6063487616f083fadae950451df5f6e8a144cd951b2d853c7ec2d1aece9c438a89850788edc6bd5e2a7a98a47
@@ -4500,7 +4501,7 @@ Ctrl.type = type:D
 Output = d417a07f1070a2e628424fa990ef436f137725a7cde43f1b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100f8cf4795508e2aba0d9c007ee0afb38a7d570e26d4ebe97d3b9cb46dfc05b9b18396054fa91f856758b036195a9b360ee48b65dcec1f2fcb901d5faa308125b30b804e53ac15b2f43c2a12fdbc987707af58c36ecdcd89376117f9655e14da7f1808baeaab020a47ac35166a4868dab970ce79de592c69164045fce4eb55872f
 Ctrl.hexxcghash = hexxcghash:40d59c8836500e523e6404ac03d9895b105c7feceaac52dc3c5e4113e256c0057fbc770b805f7a2f18bf0be13357eb99db906efc5fb772f96e5fe76088e2e6f2
 Ctrl.hexsession_id = hexsession_id:a619290ad553a2b0924f3ea6152883685e3f2cf6063487616f083fadae950451df5f6e8a144cd951b2d853c7ec2d1aece9c438a89850788edc6bd5e2a7a98a47
@@ -4508,7 +4509,7 @@ Ctrl.type = type:E
 Output = 20b810e4f6a540724f269194e37969a10e340d45c557eabe72c41f08a9fad85ab44a9c362e7fc5eea9ed5dd9b84cc837d2aaa46ee71b355cb1dfefa8dc544d1e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100f8cf4795508e2aba0d9c007ee0afb38a7d570e26d4ebe97d3b9cb46dfc05b9b18396054fa91f856758b036195a9b360ee48b65dcec1f2fcb901d5faa308125b30b804e53ac15b2f43c2a12fdbc987707af58c36ecdcd89376117f9655e14da7f1808baeaab020a47ac35166a4868dab970ce79de592c69164045fce4eb55872f
 Ctrl.hexxcghash = hexxcghash:40d59c8836500e523e6404ac03d9895b105c7feceaac52dc3c5e4113e256c0057fbc770b805f7a2f18bf0be13357eb99db906efc5fb772f96e5fe76088e2e6f2
 Ctrl.hexsession_id = hexsession_id:a619290ad553a2b0924f3ea6152883685e3f2cf6063487616f083fadae950451df5f6e8a144cd951b2d853c7ec2d1aece9c438a89850788edc6bd5e2a7a98a47
@@ -4516,7 +4517,7 @@ Ctrl.type = type:F
 Output = acd292ab652b49c7c2a5a35b93c31a71eeef8a629cbc6b1c782994ebc7566f7b0ae536cc0ccfe881bfd8cbfaff391fe23568fa5692198f188deff0c6d0808160
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000803105020875f56db2960579efb7509964f256c2b81009e5be554bcc8ebe84c492f0cd0990e78ef4e8582a45457712be71d6f6c0b33315668984f0a41cf45fb9a459193c710919b752be3b80b2c8c7de3be570f76df6fe1cbb9dc81085fff2ad1bbfb307c6fb21f434cf7c0b96ee9eb6bc0f9677136a6db91f5d953f8b104b3497
 Ctrl.hexxcghash = hexxcghash:5f45d483ef27aeb00ec7baef96f4b4d1b254260bf60671dbd00e35a32fdcb7ae06215d59e742158782e0626bd5e2e8bada1fd7ec5056679f4a1412eaa2ef10e5
 Ctrl.hexsession_id = hexsession_id:8ddcd28d02f2cb50661cf2111953c697c0e578e43a77dfeb593b2bf05189bb429f306bcb0bcb41219d5428c1795c84665bb1f0db33e55f52edbff2b781c7eb79
@@ -4524,7 +4525,7 @@ Ctrl.type = type:A
 Output = 7cf213cec41701ff
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000803105020875f56db2960579efb7509964f256c2b81009e5be554bcc8ebe84c492f0cd0990e78ef4e8582a45457712be71d6f6c0b33315668984f0a41cf45fb9a459193c710919b752be3b80b2c8c7de3be570f76df6fe1cbb9dc81085fff2ad1bbfb307c6fb21f434cf7c0b96ee9eb6bc0f9677136a6db91f5d953f8b104b3497
 Ctrl.hexxcghash = hexxcghash:5f45d483ef27aeb00ec7baef96f4b4d1b254260bf60671dbd00e35a32fdcb7ae06215d59e742158782e0626bd5e2e8bada1fd7ec5056679f4a1412eaa2ef10e5
 Ctrl.hexsession_id = hexsession_id:8ddcd28d02f2cb50661cf2111953c697c0e578e43a77dfeb593b2bf05189bb429f306bcb0bcb41219d5428c1795c84665bb1f0db33e55f52edbff2b781c7eb79
@@ -4532,7 +4533,7 @@ Ctrl.type = type:B
 Output = 81a44f6f95fff954
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000803105020875f56db2960579efb7509964f256c2b81009e5be554bcc8ebe84c492f0cd0990e78ef4e8582a45457712be71d6f6c0b33315668984f0a41cf45fb9a459193c710919b752be3b80b2c8c7de3be570f76df6fe1cbb9dc81085fff2ad1bbfb307c6fb21f434cf7c0b96ee9eb6bc0f9677136a6db91f5d953f8b104b3497
 Ctrl.hexxcghash = hexxcghash:5f45d483ef27aeb00ec7baef96f4b4d1b254260bf60671dbd00e35a32fdcb7ae06215d59e742158782e0626bd5e2e8bada1fd7ec5056679f4a1412eaa2ef10e5
 Ctrl.hexsession_id = hexsession_id:8ddcd28d02f2cb50661cf2111953c697c0e578e43a77dfeb593b2bf05189bb429f306bcb0bcb41219d5428c1795c84665bb1f0db33e55f52edbff2b781c7eb79
@@ -4540,7 +4541,7 @@ Ctrl.type = type:C
 Output = e1610d85ea2c24b4af18076c2d7dc0c3f3b3bf1c8df232a4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000803105020875f56db2960579efb7509964f256c2b81009e5be554bcc8ebe84c492f0cd0990e78ef4e8582a45457712be71d6f6c0b33315668984f0a41cf45fb9a459193c710919b752be3b80b2c8c7de3be570f76df6fe1cbb9dc81085fff2ad1bbfb307c6fb21f434cf7c0b96ee9eb6bc0f9677136a6db91f5d953f8b104b3497
 Ctrl.hexxcghash = hexxcghash:5f45d483ef27aeb00ec7baef96f4b4d1b254260bf60671dbd00e35a32fdcb7ae06215d59e742158782e0626bd5e2e8bada1fd7ec5056679f4a1412eaa2ef10e5
 Ctrl.hexsession_id = hexsession_id:8ddcd28d02f2cb50661cf2111953c697c0e578e43a77dfeb593b2bf05189bb429f306bcb0bcb41219d5428c1795c84665bb1f0db33e55f52edbff2b781c7eb79
@@ -4548,7 +4549,7 @@ Ctrl.type = type:D
 Output = db146cbf4923693449b857fa927d112f3c8bd1bac73f618a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000803105020875f56db2960579efb7509964f256c2b81009e5be554bcc8ebe84c492f0cd0990e78ef4e8582a45457712be71d6f6c0b33315668984f0a41cf45fb9a459193c710919b752be3b80b2c8c7de3be570f76df6fe1cbb9dc81085fff2ad1bbfb307c6fb21f434cf7c0b96ee9eb6bc0f9677136a6db91f5d953f8b104b3497
 Ctrl.hexxcghash = hexxcghash:5f45d483ef27aeb00ec7baef96f4b4d1b254260bf60671dbd00e35a32fdcb7ae06215d59e742158782e0626bd5e2e8bada1fd7ec5056679f4a1412eaa2ef10e5
 Ctrl.hexsession_id = hexsession_id:8ddcd28d02f2cb50661cf2111953c697c0e578e43a77dfeb593b2bf05189bb429f306bcb0bcb41219d5428c1795c84665bb1f0db33e55f52edbff2b781c7eb79
@@ -4556,7 +4557,7 @@ Ctrl.type = type:E
 Output = fac257f4544a0aa77659642c33a421cf27b2216a57399ff8ff48baab37519ce9c27f93bf447a02b3c10d9f9c6201745ed6ae28a13ff85e949e0e8048bf31e0c8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000803105020875f56db2960579efb7509964f256c2b81009e5be554bcc8ebe84c492f0cd0990e78ef4e8582a45457712be71d6f6c0b33315668984f0a41cf45fb9a459193c710919b752be3b80b2c8c7de3be570f76df6fe1cbb9dc81085fff2ad1bbfb307c6fb21f434cf7c0b96ee9eb6bc0f9677136a6db91f5d953f8b104b3497
 Ctrl.hexxcghash = hexxcghash:5f45d483ef27aeb00ec7baef96f4b4d1b254260bf60671dbd00e35a32fdcb7ae06215d59e742158782e0626bd5e2e8bada1fd7ec5056679f4a1412eaa2ef10e5
 Ctrl.hexsession_id = hexsession_id:8ddcd28d02f2cb50661cf2111953c697c0e578e43a77dfeb593b2bf05189bb429f306bcb0bcb41219d5428c1795c84665bb1f0db33e55f52edbff2b781c7eb79
@@ -4564,7 +4565,7 @@ Ctrl.type = type:F
 Output = 8532a1014a5a2feba5730823b0fb1781a7782a73f95a97697aedf60997e6cdf5107387be820b74c0e43e8caf42e83bbc703c6cd9d37b0e720aeacc115ce4633e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008045cafef6acb29ea351ad025a32cb0fb88fe52f138ac3cd7718140c883cffbc10778c2e6c573bdbfaf32eceaa2fc1e106170dadcdf1cb0e1653f2361c76f5153262295b16371daf9ae2015dfb407f4920240eb10293c48971d2086723507d2eb7e1481f2b737df223628ee602a49bb7f1ac52068f5c1a24b445786e35042fc6c0
 Ctrl.hexxcghash = hexxcghash:b1ce6e766a7340f40cec52585087c60e456cc390d0ee294bbc460d50b93c2170344cca3dd2e3067ebefe3efbd002ec4ed7f0fc1a8771eaffbc1fd4d5800aec21
 Ctrl.hexsession_id = hexsession_id:85ae5c53a8286dfddf295dd0b31237bc8c54e9858647e222db29a4f60ffb74a175e5de22c132a1a06826c6e0122e63aa657fc670ca44943159560ce1c48b6906
@@ -4572,7 +4573,7 @@ Ctrl.type = type:A
 Output = c5dffc4eb99a1c36
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008045cafef6acb29ea351ad025a32cb0fb88fe52f138ac3cd7718140c883cffbc10778c2e6c573bdbfaf32eceaa2fc1e106170dadcdf1cb0e1653f2361c76f5153262295b16371daf9ae2015dfb407f4920240eb10293c48971d2086723507d2eb7e1481f2b737df223628ee602a49bb7f1ac52068f5c1a24b445786e35042fc6c0
 Ctrl.hexxcghash = hexxcghash:b1ce6e766a7340f40cec52585087c60e456cc390d0ee294bbc460d50b93c2170344cca3dd2e3067ebefe3efbd002ec4ed7f0fc1a8771eaffbc1fd4d5800aec21
 Ctrl.hexsession_id = hexsession_id:85ae5c53a8286dfddf295dd0b31237bc8c54e9858647e222db29a4f60ffb74a175e5de22c132a1a06826c6e0122e63aa657fc670ca44943159560ce1c48b6906
@@ -4580,7 +4581,7 @@ Ctrl.type = type:B
 Output = 13cb7467ddf8ea7d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008045cafef6acb29ea351ad025a32cb0fb88fe52f138ac3cd7718140c883cffbc10778c2e6c573bdbfaf32eceaa2fc1e106170dadcdf1cb0e1653f2361c76f5153262295b16371daf9ae2015dfb407f4920240eb10293c48971d2086723507d2eb7e1481f2b737df223628ee602a49bb7f1ac52068f5c1a24b445786e35042fc6c0
 Ctrl.hexxcghash = hexxcghash:b1ce6e766a7340f40cec52585087c60e456cc390d0ee294bbc460d50b93c2170344cca3dd2e3067ebefe3efbd002ec4ed7f0fc1a8771eaffbc1fd4d5800aec21
 Ctrl.hexsession_id = hexsession_id:85ae5c53a8286dfddf295dd0b31237bc8c54e9858647e222db29a4f60ffb74a175e5de22c132a1a06826c6e0122e63aa657fc670ca44943159560ce1c48b6906
@@ -4588,7 +4589,7 @@ Ctrl.type = type:C
 Output = 4d77a9a1a36500d9ea0389e3813a201fb9b30751d1fcf0b3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008045cafef6acb29ea351ad025a32cb0fb88fe52f138ac3cd7718140c883cffbc10778c2e6c573bdbfaf32eceaa2fc1e106170dadcdf1cb0e1653f2361c76f5153262295b16371daf9ae2015dfb407f4920240eb10293c48971d2086723507d2eb7e1481f2b737df223628ee602a49bb7f1ac52068f5c1a24b445786e35042fc6c0
 Ctrl.hexxcghash = hexxcghash:b1ce6e766a7340f40cec52585087c60e456cc390d0ee294bbc460d50b93c2170344cca3dd2e3067ebefe3efbd002ec4ed7f0fc1a8771eaffbc1fd4d5800aec21
 Ctrl.hexsession_id = hexsession_id:85ae5c53a8286dfddf295dd0b31237bc8c54e9858647e222db29a4f60ffb74a175e5de22c132a1a06826c6e0122e63aa657fc670ca44943159560ce1c48b6906
@@ -4596,7 +4597,7 @@ Ctrl.type = type:D
 Output = a0e4ec099492c752b98013d2176af6e601eeef3cdc2029a9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008045cafef6acb29ea351ad025a32cb0fb88fe52f138ac3cd7718140c883cffbc10778c2e6c573bdbfaf32eceaa2fc1e106170dadcdf1cb0e1653f2361c76f5153262295b16371daf9ae2015dfb407f4920240eb10293c48971d2086723507d2eb7e1481f2b737df223628ee602a49bb7f1ac52068f5c1a24b445786e35042fc6c0
 Ctrl.hexxcghash = hexxcghash:b1ce6e766a7340f40cec52585087c60e456cc390d0ee294bbc460d50b93c2170344cca3dd2e3067ebefe3efbd002ec4ed7f0fc1a8771eaffbc1fd4d5800aec21
 Ctrl.hexsession_id = hexsession_id:85ae5c53a8286dfddf295dd0b31237bc8c54e9858647e222db29a4f60ffb74a175e5de22c132a1a06826c6e0122e63aa657fc670ca44943159560ce1c48b6906
@@ -4604,7 +4605,7 @@ Ctrl.type = type:E
 Output = b4035effa78e6da307f4c096226150e5cab92794192bba492ff8576da3fdbbfdc87fbf79721de0e8f38647261dcad096fd536c4f724f09782a4b684902a4b979
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008045cafef6acb29ea351ad025a32cb0fb88fe52f138ac3cd7718140c883cffbc10778c2e6c573bdbfaf32eceaa2fc1e106170dadcdf1cb0e1653f2361c76f5153262295b16371daf9ae2015dfb407f4920240eb10293c48971d2086723507d2eb7e1481f2b737df223628ee602a49bb7f1ac52068f5c1a24b445786e35042fc6c0
 Ctrl.hexxcghash = hexxcghash:b1ce6e766a7340f40cec52585087c60e456cc390d0ee294bbc460d50b93c2170344cca3dd2e3067ebefe3efbd002ec4ed7f0fc1a8771eaffbc1fd4d5800aec21
 Ctrl.hexsession_id = hexsession_id:85ae5c53a8286dfddf295dd0b31237bc8c54e9858647e222db29a4f60ffb74a175e5de22c132a1a06826c6e0122e63aa657fc670ca44943159560ce1c48b6906
@@ -4612,7 +4613,7 @@ Ctrl.type = type:F
 Output = eae8776eddb75cd4d14d2db129172bab92f0c8d2c8a439d4b63824c23e7481af502a45d2ebee77f3a801d658b59f6cbbdb797f479787ae4d5839b7ddf49ff908
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000081008b735b1cc9a88529c0d0faea307f79142abc920248b3495e56b7987605b5a7a93354c638752ae7ce47b2869600dc2ab8f240c0ce4e35147e00f8e69fbe940d6236daf01b38f3e74d7bff07d01111569e213cd8475e77de026c81dac6e40242cfc2df5af9d37e520c2d7aee165de9cc314750e856d7514b0b80c568e2292c733f
 Ctrl.hexxcghash = hexxcghash:c226bd264f49cba006b4806afa4edaf42c2c48992ec66c78ce3a982cb5b1d923344107eb77884b0d996af71997611fdffba499da38d5206db0d0a17c438d4d8a
 Ctrl.hexsession_id = hexsession_id:ae0f9a407aae7a964a900b1f5b7060a2e7d4c9de4e422fec063829a9ea1fcb74a6ae83b9eb08f8663e171bdf036bf0c263b23f8eff3053d617484cc3efd99990
@@ -4620,7 +4621,7 @@ Ctrl.type = type:A
 Output = 31ef8e737ec154c0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000081008b735b1cc9a88529c0d0faea307f79142abc920248b3495e56b7987605b5a7a93354c638752ae7ce47b2869600dc2ab8f240c0ce4e35147e00f8e69fbe940d6236daf01b38f3e74d7bff07d01111569e213cd8475e77de026c81dac6e40242cfc2df5af9d37e520c2d7aee165de9cc314750e856d7514b0b80c568e2292c733f
 Ctrl.hexxcghash = hexxcghash:c226bd264f49cba006b4806afa4edaf42c2c48992ec66c78ce3a982cb5b1d923344107eb77884b0d996af71997611fdffba499da38d5206db0d0a17c438d4d8a
 Ctrl.hexsession_id = hexsession_id:ae0f9a407aae7a964a900b1f5b7060a2e7d4c9de4e422fec063829a9ea1fcb74a6ae83b9eb08f8663e171bdf036bf0c263b23f8eff3053d617484cc3efd99990
@@ -4628,7 +4629,7 @@ Ctrl.type = type:B
 Output = c0bb41f2c51a0503
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000081008b735b1cc9a88529c0d0faea307f79142abc920248b3495e56b7987605b5a7a93354c638752ae7ce47b2869600dc2ab8f240c0ce4e35147e00f8e69fbe940d6236daf01b38f3e74d7bff07d01111569e213cd8475e77de026c81dac6e40242cfc2df5af9d37e520c2d7aee165de9cc314750e856d7514b0b80c568e2292c733f
 Ctrl.hexxcghash = hexxcghash:c226bd264f49cba006b4806afa4edaf42c2c48992ec66c78ce3a982cb5b1d923344107eb77884b0d996af71997611fdffba499da38d5206db0d0a17c438d4d8a
 Ctrl.hexsession_id = hexsession_id:ae0f9a407aae7a964a900b1f5b7060a2e7d4c9de4e422fec063829a9ea1fcb74a6ae83b9eb08f8663e171bdf036bf0c263b23f8eff3053d617484cc3efd99990
@@ -4636,7 +4637,7 @@ Ctrl.type = type:C
 Output = 3f9058812f36f302dc5ada7de8f4271c435dfe4589f22a00
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000081008b735b1cc9a88529c0d0faea307f79142abc920248b3495e56b7987605b5a7a93354c638752ae7ce47b2869600dc2ab8f240c0ce4e35147e00f8e69fbe940d6236daf01b38f3e74d7bff07d01111569e213cd8475e77de026c81dac6e40242cfc2df5af9d37e520c2d7aee165de9cc314750e856d7514b0b80c568e2292c733f
 Ctrl.hexxcghash = hexxcghash:c226bd264f49cba006b4806afa4edaf42c2c48992ec66c78ce3a982cb5b1d923344107eb77884b0d996af71997611fdffba499da38d5206db0d0a17c438d4d8a
 Ctrl.hexsession_id = hexsession_id:ae0f9a407aae7a964a900b1f5b7060a2e7d4c9de4e422fec063829a9ea1fcb74a6ae83b9eb08f8663e171bdf036bf0c263b23f8eff3053d617484cc3efd99990
@@ -4644,7 +4645,7 @@ Ctrl.type = type:D
 Output = b342a447abcb67f6819a19b8b300946c89739fabd049a6e0
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000081008b735b1cc9a88529c0d0faea307f79142abc920248b3495e56b7987605b5a7a93354c638752ae7ce47b2869600dc2ab8f240c0ce4e35147e00f8e69fbe940d6236daf01b38f3e74d7bff07d01111569e213cd8475e77de026c81dac6e40242cfc2df5af9d37e520c2d7aee165de9cc314750e856d7514b0b80c568e2292c733f
 Ctrl.hexxcghash = hexxcghash:c226bd264f49cba006b4806afa4edaf42c2c48992ec66c78ce3a982cb5b1d923344107eb77884b0d996af71997611fdffba499da38d5206db0d0a17c438d4d8a
 Ctrl.hexsession_id = hexsession_id:ae0f9a407aae7a964a900b1f5b7060a2e7d4c9de4e422fec063829a9ea1fcb74a6ae83b9eb08f8663e171bdf036bf0c263b23f8eff3053d617484cc3efd99990
@@ -4652,7 +4653,7 @@ Ctrl.type = type:E
 Output = a5d70cb0a3e351be09b9600c9b97f2781236bf549209a1fbf3304af145af0941c6cd9923f1f30cec946e8dea96332d284e01a4d8bcc90721fe2e515504073cb8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000081008b735b1cc9a88529c0d0faea307f79142abc920248b3495e56b7987605b5a7a93354c638752ae7ce47b2869600dc2ab8f240c0ce4e35147e00f8e69fbe940d6236daf01b38f3e74d7bff07d01111569e213cd8475e77de026c81dac6e40242cfc2df5af9d37e520c2d7aee165de9cc314750e856d7514b0b80c568e2292c733f
 Ctrl.hexxcghash = hexxcghash:c226bd264f49cba006b4806afa4edaf42c2c48992ec66c78ce3a982cb5b1d923344107eb77884b0d996af71997611fdffba499da38d5206db0d0a17c438d4d8a
 Ctrl.hexsession_id = hexsession_id:ae0f9a407aae7a964a900b1f5b7060a2e7d4c9de4e422fec063829a9ea1fcb74a6ae83b9eb08f8663e171bdf036bf0c263b23f8eff3053d617484cc3efd99990
@@ -4660,7 +4661,7 @@ Ctrl.type = type:F
 Output = dbc3ea086a49e220306cbe57b942d9409cbd205dec20c7b79fd6998906d173bcb2bc2eb5b7eea4c1d84f3926836bd15e0565a17af735596050d6161d9682f2e7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100c41430e9dfce9301082a4d034e0e1ffe73133e4c97afbd325d6bbe1f3a4f5a9103f57a05f66b1ac63a5f1724b3315daf7171f334e77eff356366daf4e23e55751422734d4d22e6dcac783bba0edc1be8fcc4c7c0d5a69d047291e33167057c774e46362dfb6f8432b427cf21c01304b23e2b49b664fd50dc463c17efffa146a0
 Ctrl.hexxcghash = hexxcghash:04aeff766f08c065092fdd7be43531f83d73682601069477ee10407821a0f0e8bf614e775dfab6f889a8d5120c2e39d96e38de4cda6f673fb7cb343de1e17b9c
 Ctrl.hexsession_id = hexsession_id:15f5653a107aee694bd1680d423c8da2dab8c1ec8e23c5208100ce3d8d4821b52bbb1d14791476253db4b07ebb715ae095b8b49e1545be3c92a3adcf39970be5
@@ -4668,7 +4669,7 @@ Ctrl.type = type:A
 Output = 19d6bc79713a4622
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100c41430e9dfce9301082a4d034e0e1ffe73133e4c97afbd325d6bbe1f3a4f5a9103f57a05f66b1ac63a5f1724b3315daf7171f334e77eff356366daf4e23e55751422734d4d22e6dcac783bba0edc1be8fcc4c7c0d5a69d047291e33167057c774e46362dfb6f8432b427cf21c01304b23e2b49b664fd50dc463c17efffa146a0
 Ctrl.hexxcghash = hexxcghash:04aeff766f08c065092fdd7be43531f83d73682601069477ee10407821a0f0e8bf614e775dfab6f889a8d5120c2e39d96e38de4cda6f673fb7cb343de1e17b9c
 Ctrl.hexsession_id = hexsession_id:15f5653a107aee694bd1680d423c8da2dab8c1ec8e23c5208100ce3d8d4821b52bbb1d14791476253db4b07ebb715ae095b8b49e1545be3c92a3adcf39970be5
@@ -4676,7 +4677,7 @@ Ctrl.type = type:B
 Output = 7de9caf89d325dcd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100c41430e9dfce9301082a4d034e0e1ffe73133e4c97afbd325d6bbe1f3a4f5a9103f57a05f66b1ac63a5f1724b3315daf7171f334e77eff356366daf4e23e55751422734d4d22e6dcac783bba0edc1be8fcc4c7c0d5a69d047291e33167057c774e46362dfb6f8432b427cf21c01304b23e2b49b664fd50dc463c17efffa146a0
 Ctrl.hexxcghash = hexxcghash:04aeff766f08c065092fdd7be43531f83d73682601069477ee10407821a0f0e8bf614e775dfab6f889a8d5120c2e39d96e38de4cda6f673fb7cb343de1e17b9c
 Ctrl.hexsession_id = hexsession_id:15f5653a107aee694bd1680d423c8da2dab8c1ec8e23c5208100ce3d8d4821b52bbb1d14791476253db4b07ebb715ae095b8b49e1545be3c92a3adcf39970be5
@@ -4684,7 +4685,7 @@ Ctrl.type = type:C
 Output = 1d5391d658abb9ec1b8df32cbf1db9a302a1301984ab06d4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100c41430e9dfce9301082a4d034e0e1ffe73133e4c97afbd325d6bbe1f3a4f5a9103f57a05f66b1ac63a5f1724b3315daf7171f334e77eff356366daf4e23e55751422734d4d22e6dcac783bba0edc1be8fcc4c7c0d5a69d047291e33167057c774e46362dfb6f8432b427cf21c01304b23e2b49b664fd50dc463c17efffa146a0
 Ctrl.hexxcghash = hexxcghash:04aeff766f08c065092fdd7be43531f83d73682601069477ee10407821a0f0e8bf614e775dfab6f889a8d5120c2e39d96e38de4cda6f673fb7cb343de1e17b9c
 Ctrl.hexsession_id = hexsession_id:15f5653a107aee694bd1680d423c8da2dab8c1ec8e23c5208100ce3d8d4821b52bbb1d14791476253db4b07ebb715ae095b8b49e1545be3c92a3adcf39970be5
@@ -4692,7 +4693,7 @@ Ctrl.type = type:D
 Output = 5d37dab50814543d8d8674f4f491d73d21973f20844c96a7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100c41430e9dfce9301082a4d034e0e1ffe73133e4c97afbd325d6bbe1f3a4f5a9103f57a05f66b1ac63a5f1724b3315daf7171f334e77eff356366daf4e23e55751422734d4d22e6dcac783bba0edc1be8fcc4c7c0d5a69d047291e33167057c774e46362dfb6f8432b427cf21c01304b23e2b49b664fd50dc463c17efffa146a0
 Ctrl.hexxcghash = hexxcghash:04aeff766f08c065092fdd7be43531f83d73682601069477ee10407821a0f0e8bf614e775dfab6f889a8d5120c2e39d96e38de4cda6f673fb7cb343de1e17b9c
 Ctrl.hexsession_id = hexsession_id:15f5653a107aee694bd1680d423c8da2dab8c1ec8e23c5208100ce3d8d4821b52bbb1d14791476253db4b07ebb715ae095b8b49e1545be3c92a3adcf39970be5
@@ -4700,7 +4701,7 @@ Ctrl.type = type:E
 Output = 3e882ae390a64c34f509bc9845df581987ae2524b2ff92d9243580168f32fa68750f3f732c8c5544c98fc585582fe743efbf55dd6c487fb5f9ffac1a156fa31c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000008100c41430e9dfce9301082a4d034e0e1ffe73133e4c97afbd325d6bbe1f3a4f5a9103f57a05f66b1ac63a5f1724b3315daf7171f334e77eff356366daf4e23e55751422734d4d22e6dcac783bba0edc1be8fcc4c7c0d5a69d047291e33167057c774e46362dfb6f8432b427cf21c01304b23e2b49b664fd50dc463c17efffa146a0
 Ctrl.hexxcghash = hexxcghash:04aeff766f08c065092fdd7be43531f83d73682601069477ee10407821a0f0e8bf614e775dfab6f889a8d5120c2e39d96e38de4cda6f673fb7cb343de1e17b9c
 Ctrl.hexsession_id = hexsession_id:15f5653a107aee694bd1680d423c8da2dab8c1ec8e23c5208100ce3d8d4821b52bbb1d14791476253db4b07ebb715ae095b8b49e1545be3c92a3adcf39970be5
@@ -4708,7 +4709,7 @@ Ctrl.type = type:F
 Output = ce4bcf9cabe7ee7c0e216e64e5427ebd38cb41ba9e9a6d9ae441ca47d9278347a59afdf758ae7f7fd667ed3830bf9a33d7badfd40e2112580af514da9464a6d1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810088181aaaa6b17924ced0033b1e4a3d007a464d4d53871f4da4689d477437b42f873d4b7d5f5c52909b6cca8be7a01d1a7a806f745500bb00b4fd6e6f8d0e1c9ad08d934c7d680a57ac5a4ed77f73182065f9295d745e1d50b8da0626f3e9ccb6651aad3b0c5c2cecd90c521318778f570333c011f02d5e2a406eb8b3d6036537
 Ctrl.hexxcghash = hexxcghash:3c4ecb173c39cedecbcd19ba0fc38454176b81b6451911b4422907b1b670dcedaabebaaa261fbac23b3b5738264c5eee3dccfd9e050a1cef17ac997527dd7095
 Ctrl.hexsession_id = hexsession_id:3b05253d9e5ab2f7f4ba2998bea5ed7d05afdf02b7499ac2dd554833b886b73d92e929316a366147e9af50201dbb4e54c123418d1a623bc2dc52766211dbe614
@@ -4716,7 +4717,7 @@ Ctrl.type = type:A
 Output = 93fbb01815b63533
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810088181aaaa6b17924ced0033b1e4a3d007a464d4d53871f4da4689d477437b42f873d4b7d5f5c52909b6cca8be7a01d1a7a806f745500bb00b4fd6e6f8d0e1c9ad08d934c7d680a57ac5a4ed77f73182065f9295d745e1d50b8da0626f3e9ccb6651aad3b0c5c2cecd90c521318778f570333c011f02d5e2a406eb8b3d6036537
 Ctrl.hexxcghash = hexxcghash:3c4ecb173c39cedecbcd19ba0fc38454176b81b6451911b4422907b1b670dcedaabebaaa261fbac23b3b5738264c5eee3dccfd9e050a1cef17ac997527dd7095
 Ctrl.hexsession_id = hexsession_id:3b05253d9e5ab2f7f4ba2998bea5ed7d05afdf02b7499ac2dd554833b886b73d92e929316a366147e9af50201dbb4e54c123418d1a623bc2dc52766211dbe614
@@ -4724,7 +4725,7 @@ Ctrl.type = type:B
 Output = aea76dfe77a87471
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810088181aaaa6b17924ced0033b1e4a3d007a464d4d53871f4da4689d477437b42f873d4b7d5f5c52909b6cca8be7a01d1a7a806f745500bb00b4fd6e6f8d0e1c9ad08d934c7d680a57ac5a4ed77f73182065f9295d745e1d50b8da0626f3e9ccb6651aad3b0c5c2cecd90c521318778f570333c011f02d5e2a406eb8b3d6036537
 Ctrl.hexxcghash = hexxcghash:3c4ecb173c39cedecbcd19ba0fc38454176b81b6451911b4422907b1b670dcedaabebaaa261fbac23b3b5738264c5eee3dccfd9e050a1cef17ac997527dd7095
 Ctrl.hexsession_id = hexsession_id:3b05253d9e5ab2f7f4ba2998bea5ed7d05afdf02b7499ac2dd554833b886b73d92e929316a366147e9af50201dbb4e54c123418d1a623bc2dc52766211dbe614
@@ -4732,7 +4733,7 @@ Ctrl.type = type:C
 Output = 73a55e25a0a8ec0899c1074bf0845fefd84e42f741897a3f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810088181aaaa6b17924ced0033b1e4a3d007a464d4d53871f4da4689d477437b42f873d4b7d5f5c52909b6cca8be7a01d1a7a806f745500bb00b4fd6e6f8d0e1c9ad08d934c7d680a57ac5a4ed77f73182065f9295d745e1d50b8da0626f3e9ccb6651aad3b0c5c2cecd90c521318778f570333c011f02d5e2a406eb8b3d6036537
 Ctrl.hexxcghash = hexxcghash:3c4ecb173c39cedecbcd19ba0fc38454176b81b6451911b4422907b1b670dcedaabebaaa261fbac23b3b5738264c5eee3dccfd9e050a1cef17ac997527dd7095
 Ctrl.hexsession_id = hexsession_id:3b05253d9e5ab2f7f4ba2998bea5ed7d05afdf02b7499ac2dd554833b886b73d92e929316a366147e9af50201dbb4e54c123418d1a623bc2dc52766211dbe614
@@ -4740,7 +4741,7 @@ Ctrl.type = type:D
 Output = fead3a851502aa3c58734065eeaf3e63ed4c59c8f450bb1a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810088181aaaa6b17924ced0033b1e4a3d007a464d4d53871f4da4689d477437b42f873d4b7d5f5c52909b6cca8be7a01d1a7a806f745500bb00b4fd6e6f8d0e1c9ad08d934c7d680a57ac5a4ed77f73182065f9295d745e1d50b8da0626f3e9ccb6651aad3b0c5c2cecd90c521318778f570333c011f02d5e2a406eb8b3d6036537
 Ctrl.hexxcghash = hexxcghash:3c4ecb173c39cedecbcd19ba0fc38454176b81b6451911b4422907b1b670dcedaabebaaa261fbac23b3b5738264c5eee3dccfd9e050a1cef17ac997527dd7095
 Ctrl.hexsession_id = hexsession_id:3b05253d9e5ab2f7f4ba2998bea5ed7d05afdf02b7499ac2dd554833b886b73d92e929316a366147e9af50201dbb4e54c123418d1a623bc2dc52766211dbe614
@@ -4748,7 +4749,7 @@ Ctrl.type = type:E
 Output = 55bde99a692820ad809eb0a62311f8f3e9469ba2ee4d782d5432628ca52d829b9c5bffc41b58232363f97c5dab603268b1997fbe9b9b34ab2aca3da27467b0c8
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000000810088181aaaa6b17924ced0033b1e4a3d007a464d4d53871f4da4689d477437b42f873d4b7d5f5c52909b6cca8be7a01d1a7a806f745500bb00b4fd6e6f8d0e1c9ad08d934c7d680a57ac5a4ed77f73182065f9295d745e1d50b8da0626f3e9ccb6651aad3b0c5c2cecd90c521318778f570333c011f02d5e2a406eb8b3d6036537
 Ctrl.hexxcghash = hexxcghash:3c4ecb173c39cedecbcd19ba0fc38454176b81b6451911b4422907b1b670dcedaabebaaa261fbac23b3b5738264c5eee3dccfd9e050a1cef17ac997527dd7095
 Ctrl.hexsession_id = hexsession_id:3b05253d9e5ab2f7f4ba2998bea5ed7d05afdf02b7499ac2dd554833b886b73d92e929316a366147e9af50201dbb4e54c123418d1a623bc2dc52766211dbe614
@@ -4756,7 +4757,7 @@ Ctrl.type = type:F
 Output = 756f65746c861f0985f3dd7d2f08004897ccb22be2f1d3b4791ca0c51d5ee0da776dd03d7dfb7f4db6c6cd37899871e63d75f7f60dff8348c313e99409ad2db5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100e8d52da494d198252b87189223bffb0bc1b68335ae987df15bf7cf95bd74a951b5eaa87b1739f91efc97f28f5a7f0a206fdbcf33e39003e154b334009563abd62a4169462865ba931ca3f8f4d70611e8bcb46228ee74983d2ec79c690d86329c2daac8dbdafe4573f114313f29c7507bd4aa50d87bb83b1cebb628e37b2501ffc9b1200d8d360e1b46bf6fdecd486fae790352eb79aa3f37e4964963a84dbd80fb3b80491210565d9449599bc9306ee76a932a764070702cd09c87e1f26095b1b78042bcc37d5f097e3f7b2db6cb6f7b3e2a332021f756fe1784edd2a82802c1274b9944dff99fb1c181f41d6d2f4eac5aa33c619c48167dce1eb47ddafbe5eb
 Ctrl.hexxcghash = hexxcghash:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
 Ctrl.hexsession_id = hexsession_id:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
@@ -4764,7 +4765,7 @@ Ctrl.type = type:A
 Output = a626c34c0a74b56262110185a34cd810
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100e8d52da494d198252b87189223bffb0bc1b68335ae987df15bf7cf95bd74a951b5eaa87b1739f91efc97f28f5a7f0a206fdbcf33e39003e154b334009563abd62a4169462865ba931ca3f8f4d70611e8bcb46228ee74983d2ec79c690d86329c2daac8dbdafe4573f114313f29c7507bd4aa50d87bb83b1cebb628e37b2501ffc9b1200d8d360e1b46bf6fdecd486fae790352eb79aa3f37e4964963a84dbd80fb3b80491210565d9449599bc9306ee76a932a764070702cd09c87e1f26095b1b78042bcc37d5f097e3f7b2db6cb6f7b3e2a332021f756fe1784edd2a82802c1274b9944dff99fb1c181f41d6d2f4eac5aa33c619c48167dce1eb47ddafbe5eb
 Ctrl.hexxcghash = hexxcghash:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
 Ctrl.hexsession_id = hexsession_id:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
@@ -4772,7 +4773,7 @@ Ctrl.type = type:B
 Output = 223d6fc57263da9ad61dad9759454e0f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100e8d52da494d198252b87189223bffb0bc1b68335ae987df15bf7cf95bd74a951b5eaa87b1739f91efc97f28f5a7f0a206fdbcf33e39003e154b334009563abd62a4169462865ba931ca3f8f4d70611e8bcb46228ee74983d2ec79c690d86329c2daac8dbdafe4573f114313f29c7507bd4aa50d87bb83b1cebb628e37b2501ffc9b1200d8d360e1b46bf6fdecd486fae790352eb79aa3f37e4964963a84dbd80fb3b80491210565d9449599bc9306ee76a932a764070702cd09c87e1f26095b1b78042bcc37d5f097e3f7b2db6cb6f7b3e2a332021f756fe1784edd2a82802c1274b9944dff99fb1c181f41d6d2f4eac5aa33c619c48167dce1eb47ddafbe5eb
 Ctrl.hexxcghash = hexxcghash:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
 Ctrl.hexsession_id = hexsession_id:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
@@ -4780,7 +4781,7 @@ Ctrl.type = type:C
 Output = 7c803e07506969666f446400b2372eee
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100e8d52da494d198252b87189223bffb0bc1b68335ae987df15bf7cf95bd74a951b5eaa87b1739f91efc97f28f5a7f0a206fdbcf33e39003e154b334009563abd62a4169462865ba931ca3f8f4d70611e8bcb46228ee74983d2ec79c690d86329c2daac8dbdafe4573f114313f29c7507bd4aa50d87bb83b1cebb628e37b2501ffc9b1200d8d360e1b46bf6fdecd486fae790352eb79aa3f37e4964963a84dbd80fb3b80491210565d9449599bc9306ee76a932a764070702cd09c87e1f26095b1b78042bcc37d5f097e3f7b2db6cb6f7b3e2a332021f756fe1784edd2a82802c1274b9944dff99fb1c181f41d6d2f4eac5aa33c619c48167dce1eb47ddafbe5eb
 Ctrl.hexxcghash = hexxcghash:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
 Ctrl.hexsession_id = hexsession_id:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
@@ -4788,7 +4789,7 @@ Ctrl.type = type:D
 Output = 4ad705fbc9e89c03c15f9dbbf34981df
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100e8d52da494d198252b87189223bffb0bc1b68335ae987df15bf7cf95bd74a951b5eaa87b1739f91efc97f28f5a7f0a206fdbcf33e39003e154b334009563abd62a4169462865ba931ca3f8f4d70611e8bcb46228ee74983d2ec79c690d86329c2daac8dbdafe4573f114313f29c7507bd4aa50d87bb83b1cebb628e37b2501ffc9b1200d8d360e1b46bf6fdecd486fae790352eb79aa3f37e4964963a84dbd80fb3b80491210565d9449599bc9306ee76a932a764070702cd09c87e1f26095b1b78042bcc37d5f097e3f7b2db6cb6f7b3e2a332021f756fe1784edd2a82802c1274b9944dff99fb1c181f41d6d2f4eac5aa33c619c48167dce1eb47ddafbe5eb
 Ctrl.hexxcghash = hexxcghash:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
 Ctrl.hexsession_id = hexsession_id:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
@@ -4796,7 +4797,7 @@ Ctrl.type = type:E
 Output = 36cac32cab8b943cd9d2142559c467593bfaf30d0be71560245c8b38a5671901a858ccc637b0ef6966a2bbfb1a7f51f2cf6d52c4165ca000d52bd908405c305f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100e8d52da494d198252b87189223bffb0bc1b68335ae987df15bf7cf95bd74a951b5eaa87b1739f91efc97f28f5a7f0a206fdbcf33e39003e154b334009563abd62a4169462865ba931ca3f8f4d70611e8bcb46228ee74983d2ec79c690d86329c2daac8dbdafe4573f114313f29c7507bd4aa50d87bb83b1cebb628e37b2501ffc9b1200d8d360e1b46bf6fdecd486fae790352eb79aa3f37e4964963a84dbd80fb3b80491210565d9449599bc9306ee76a932a764070702cd09c87e1f26095b1b78042bcc37d5f097e3f7b2db6cb6f7b3e2a332021f756fe1784edd2a82802c1274b9944dff99fb1c181f41d6d2f4eac5aa33c619c48167dce1eb47ddafbe5eb
 Ctrl.hexxcghash = hexxcghash:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
 Ctrl.hexsession_id = hexsession_id:3e81bd3b4b609955df0deaab293876592122e2d7fdc719ecd503b572c5e98cfaaac1f7e085d4097c76515f5b70413944a464ce346ada6d85d7c39a8009d4b121
@@ -4804,7 +4805,7 @@ Ctrl.type = type:F
 Output = 67d42301ce629c0f2a34b9dfb24ec60c138b4edc71f7123bb0db9447b3c915ebd8c54d3b20af04e30b484be3a2d4136f5d5c46f9c56de189b91fec78ecd53e1c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010034a5d2784c99976fb3b615c5b1bfacc9a749330d22bcf5a7c404c10f886e2a3115660a399d7c721d5dd141f458b0d27e0e6709a8290f9ef6f61681a11d876eb7bd52b930f79fb9516f5d2137c5bfa95a893890d26d7712fc9ecc4dc82a5171341b41a9f2c4a8f0c14efe82ef2a4db60a8a0b8e43d3f92992f8dcc2d6bae3759aea86a4f14f809fe648021fc4aa79936bd687450e801916d7d267dfab66bd86f9424b3460fa75b16af37151918cb2f8ba8ac33df5b0ccf7fb21c3ea9fb0ed2917a4eb9d6ed345c42a5a67a66fca7b7e69c1ad5c45c51866692f058ad537c0f59c83a2788ef9b9610cc06aa155aa1115f23fa36d7734152a0da209244c32d37e3a
 Ctrl.hexxcghash = hexxcghash:ab6f9c04514ae3f6591039c9cc6a9919279282d7c95971b4c27957e31cced5ef5b1c59a4418402203ab50a46df7dc03bd67d42a62592708b0581617a42ea6d71
 Ctrl.hexsession_id = hexsession_id:4e226639facaccf9894367cb1008663e989eb31757b912bd1cb3bd51058c7adf56e9a54eef87b63299a5cc092c047991dc9a380e749c7c5657bb99424bcce6d6
@@ -4812,7 +4813,7 @@ Ctrl.type = type:A
 Output = 8ebbf0e9afd9f108498f1543104ba8e2
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010034a5d2784c99976fb3b615c5b1bfacc9a749330d22bcf5a7c404c10f886e2a3115660a399d7c721d5dd141f458b0d27e0e6709a8290f9ef6f61681a11d876eb7bd52b930f79fb9516f5d2137c5bfa95a893890d26d7712fc9ecc4dc82a5171341b41a9f2c4a8f0c14efe82ef2a4db60a8a0b8e43d3f92992f8dcc2d6bae3759aea86a4f14f809fe648021fc4aa79936bd687450e801916d7d267dfab66bd86f9424b3460fa75b16af37151918cb2f8ba8ac33df5b0ccf7fb21c3ea9fb0ed2917a4eb9d6ed345c42a5a67a66fca7b7e69c1ad5c45c51866692f058ad537c0f59c83a2788ef9b9610cc06aa155aa1115f23fa36d7734152a0da209244c32d37e3a
 Ctrl.hexxcghash = hexxcghash:ab6f9c04514ae3f6591039c9cc6a9919279282d7c95971b4c27957e31cced5ef5b1c59a4418402203ab50a46df7dc03bd67d42a62592708b0581617a42ea6d71
 Ctrl.hexsession_id = hexsession_id:4e226639facaccf9894367cb1008663e989eb31757b912bd1cb3bd51058c7adf56e9a54eef87b63299a5cc092c047991dc9a380e749c7c5657bb99424bcce6d6
@@ -4820,7 +4821,7 @@ Ctrl.type = type:B
 Output = 38bfe6bed75f77675fa36d76b63816a4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010034a5d2784c99976fb3b615c5b1bfacc9a749330d22bcf5a7c404c10f886e2a3115660a399d7c721d5dd141f458b0d27e0e6709a8290f9ef6f61681a11d876eb7bd52b930f79fb9516f5d2137c5bfa95a893890d26d7712fc9ecc4dc82a5171341b41a9f2c4a8f0c14efe82ef2a4db60a8a0b8e43d3f92992f8dcc2d6bae3759aea86a4f14f809fe648021fc4aa79936bd687450e801916d7d267dfab66bd86f9424b3460fa75b16af37151918cb2f8ba8ac33df5b0ccf7fb21c3ea9fb0ed2917a4eb9d6ed345c42a5a67a66fca7b7e69c1ad5c45c51866692f058ad537c0f59c83a2788ef9b9610cc06aa155aa1115f23fa36d7734152a0da209244c32d37e3a
 Ctrl.hexxcghash = hexxcghash:ab6f9c04514ae3f6591039c9cc6a9919279282d7c95971b4c27957e31cced5ef5b1c59a4418402203ab50a46df7dc03bd67d42a62592708b0581617a42ea6d71
 Ctrl.hexsession_id = hexsession_id:4e226639facaccf9894367cb1008663e989eb31757b912bd1cb3bd51058c7adf56e9a54eef87b63299a5cc092c047991dc9a380e749c7c5657bb99424bcce6d6
@@ -4828,7 +4829,7 @@ Ctrl.type = type:C
 Output = f759f0ad2d72980f6b12f0fb317222f3
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010034a5d2784c99976fb3b615c5b1bfacc9a749330d22bcf5a7c404c10f886e2a3115660a399d7c721d5dd141f458b0d27e0e6709a8290f9ef6f61681a11d876eb7bd52b930f79fb9516f5d2137c5bfa95a893890d26d7712fc9ecc4dc82a5171341b41a9f2c4a8f0c14efe82ef2a4db60a8a0b8e43d3f92992f8dcc2d6bae3759aea86a4f14f809fe648021fc4aa79936bd687450e801916d7d267dfab66bd86f9424b3460fa75b16af37151918cb2f8ba8ac33df5b0ccf7fb21c3ea9fb0ed2917a4eb9d6ed345c42a5a67a66fca7b7e69c1ad5c45c51866692f058ad537c0f59c83a2788ef9b9610cc06aa155aa1115f23fa36d7734152a0da209244c32d37e3a
 Ctrl.hexxcghash = hexxcghash:ab6f9c04514ae3f6591039c9cc6a9919279282d7c95971b4c27957e31cced5ef5b1c59a4418402203ab50a46df7dc03bd67d42a62592708b0581617a42ea6d71
 Ctrl.hexsession_id = hexsession_id:4e226639facaccf9894367cb1008663e989eb31757b912bd1cb3bd51058c7adf56e9a54eef87b63299a5cc092c047991dc9a380e749c7c5657bb99424bcce6d6
@@ -4836,7 +4837,7 @@ Ctrl.type = type:D
 Output = 39f294ec25afb520f5d7f1064b7078c9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010034a5d2784c99976fb3b615c5b1bfacc9a749330d22bcf5a7c404c10f886e2a3115660a399d7c721d5dd141f458b0d27e0e6709a8290f9ef6f61681a11d876eb7bd52b930f79fb9516f5d2137c5bfa95a893890d26d7712fc9ecc4dc82a5171341b41a9f2c4a8f0c14efe82ef2a4db60a8a0b8e43d3f92992f8dcc2d6bae3759aea86a4f14f809fe648021fc4aa79936bd687450e801916d7d267dfab66bd86f9424b3460fa75b16af37151918cb2f8ba8ac33df5b0ccf7fb21c3ea9fb0ed2917a4eb9d6ed345c42a5a67a66fca7b7e69c1ad5c45c51866692f058ad537c0f59c83a2788ef9b9610cc06aa155aa1115f23fa36d7734152a0da209244c32d37e3a
 Ctrl.hexxcghash = hexxcghash:ab6f9c04514ae3f6591039c9cc6a9919279282d7c95971b4c27957e31cced5ef5b1c59a4418402203ab50a46df7dc03bd67d42a62592708b0581617a42ea6d71
 Ctrl.hexsession_id = hexsession_id:4e226639facaccf9894367cb1008663e989eb31757b912bd1cb3bd51058c7adf56e9a54eef87b63299a5cc092c047991dc9a380e749c7c5657bb99424bcce6d6
@@ -4844,7 +4845,7 @@ Ctrl.type = type:E
 Output = ff2ad139997ff26e7f4393e49d57d5fc973ddb6225d8f4b5fe990e46b9943772f0d33aa98d01089ff0aeb5740bd388ada35dc44240180c99e522c817dedfc2cd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010034a5d2784c99976fb3b615c5b1bfacc9a749330d22bcf5a7c404c10f886e2a3115660a399d7c721d5dd141f458b0d27e0e6709a8290f9ef6f61681a11d876eb7bd52b930f79fb9516f5d2137c5bfa95a893890d26d7712fc9ecc4dc82a5171341b41a9f2c4a8f0c14efe82ef2a4db60a8a0b8e43d3f92992f8dcc2d6bae3759aea86a4f14f809fe648021fc4aa79936bd687450e801916d7d267dfab66bd86f9424b3460fa75b16af37151918cb2f8ba8ac33df5b0ccf7fb21c3ea9fb0ed2917a4eb9d6ed345c42a5a67a66fca7b7e69c1ad5c45c51866692f058ad537c0f59c83a2788ef9b9610cc06aa155aa1115f23fa36d7734152a0da209244c32d37e3a
 Ctrl.hexxcghash = hexxcghash:ab6f9c04514ae3f6591039c9cc6a9919279282d7c95971b4c27957e31cced5ef5b1c59a4418402203ab50a46df7dc03bd67d42a62592708b0581617a42ea6d71
 Ctrl.hexsession_id = hexsession_id:4e226639facaccf9894367cb1008663e989eb31757b912bd1cb3bd51058c7adf56e9a54eef87b63299a5cc092c047991dc9a380e749c7c5657bb99424bcce6d6
@@ -4852,7 +4853,7 @@ Ctrl.type = type:F
 Output = a670c9583c71f403207a192700d5e4fd7a007b60a4617b7f93708399a0cb771af08b9e5f4237e6975f055d6f0a4d91523fa0805013df6ae4a19f077646f1cd4b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000100192471d29d9fbc8b61570e4efa053a5f17b2efc0aa5415b3309f7dc3971c64d9f1093f6114941d4912f7bfb771db41d1f166d4bdaec8dde214aeb058e2227277393e3c0b12adc1b6a445870bc26e753e05e27b90b97d781e3e8493eb5e717c243213de4dcdd5a11d467b8d26759118692b10357c28b0efb0228cbe257b9ee0cb77bb7bc8b072edf418768c977e485635b4ab61078587128e9a8b3c6deca2a4e64cf9fd6eca880aebd1043deaf94447ea50b0c11b574259cdcafd208d9657c7177cf394de26dd8364b615786198c38e63c568e22b5263be41d6dd8843ad5254f61cf01b7162948652568c2b42833a95619fa5072adb0bfbf38e3eace7e1596066
 Ctrl.hexxcghash = hexxcghash:a0a53cb8bcc48ffe44fd9e50e0f7532d3e326f93d7ecb10135d4385dab550cd7be03a7374dfc2a92794be13e40c794811a9916c3d1c4e7ea31ed5269537c1c22
 Ctrl.hexsession_id = hexsession_id:9bcf3f3397ff464126cb2a99c04908721871354b842ffd3d873d49407db0382f98cc54d66665d950ec8277c374f19e9f0dd2e727f8759017c49b5b80baa87c63
@@ -4860,7 +4861,7 @@ Ctrl.type = type:A
 Output = f68353f802d39a43c728641e44087cc5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000100192471d29d9fbc8b61570e4efa053a5f17b2efc0aa5415b3309f7dc3971c64d9f1093f6114941d4912f7bfb771db41d1f166d4bdaec8dde214aeb058e2227277393e3c0b12adc1b6a445870bc26e753e05e27b90b97d781e3e8493eb5e717c243213de4dcdd5a11d467b8d26759118692b10357c28b0efb0228cbe257b9ee0cb77bb7bc8b072edf418768c977e485635b4ab61078587128e9a8b3c6deca2a4e64cf9fd6eca880aebd1043deaf94447ea50b0c11b574259cdcafd208d9657c7177cf394de26dd8364b615786198c38e63c568e22b5263be41d6dd8843ad5254f61cf01b7162948652568c2b42833a95619fa5072adb0bfbf38e3eace7e1596066
 Ctrl.hexxcghash = hexxcghash:a0a53cb8bcc48ffe44fd9e50e0f7532d3e326f93d7ecb10135d4385dab550cd7be03a7374dfc2a92794be13e40c794811a9916c3d1c4e7ea31ed5269537c1c22
 Ctrl.hexsession_id = hexsession_id:9bcf3f3397ff464126cb2a99c04908721871354b842ffd3d873d49407db0382f98cc54d66665d950ec8277c374f19e9f0dd2e727f8759017c49b5b80baa87c63
@@ -4868,7 +4869,7 @@ Ctrl.type = type:B
 Output = 23c2377f826f77519871941b62cb9fdd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000100192471d29d9fbc8b61570e4efa053a5f17b2efc0aa5415b3309f7dc3971c64d9f1093f6114941d4912f7bfb771db41d1f166d4bdaec8dde214aeb058e2227277393e3c0b12adc1b6a445870bc26e753e05e27b90b97d781e3e8493eb5e717c243213de4dcdd5a11d467b8d26759118692b10357c28b0efb0228cbe257b9ee0cb77bb7bc8b072edf418768c977e485635b4ab61078587128e9a8b3c6deca2a4e64cf9fd6eca880aebd1043deaf94447ea50b0c11b574259cdcafd208d9657c7177cf394de26dd8364b615786198c38e63c568e22b5263be41d6dd8843ad5254f61cf01b7162948652568c2b42833a95619fa5072adb0bfbf38e3eace7e1596066
 Ctrl.hexxcghash = hexxcghash:a0a53cb8bcc48ffe44fd9e50e0f7532d3e326f93d7ecb10135d4385dab550cd7be03a7374dfc2a92794be13e40c794811a9916c3d1c4e7ea31ed5269537c1c22
 Ctrl.hexsession_id = hexsession_id:9bcf3f3397ff464126cb2a99c04908721871354b842ffd3d873d49407db0382f98cc54d66665d950ec8277c374f19e9f0dd2e727f8759017c49b5b80baa87c63
@@ -4876,7 +4877,7 @@ Ctrl.type = type:C
 Output = c92b86a099e2605037d531746a6af7cb
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000100192471d29d9fbc8b61570e4efa053a5f17b2efc0aa5415b3309f7dc3971c64d9f1093f6114941d4912f7bfb771db41d1f166d4bdaec8dde214aeb058e2227277393e3c0b12adc1b6a445870bc26e753e05e27b90b97d781e3e8493eb5e717c243213de4dcdd5a11d467b8d26759118692b10357c28b0efb0228cbe257b9ee0cb77bb7bc8b072edf418768c977e485635b4ab61078587128e9a8b3c6deca2a4e64cf9fd6eca880aebd1043deaf94447ea50b0c11b574259cdcafd208d9657c7177cf394de26dd8364b615786198c38e63c568e22b5263be41d6dd8843ad5254f61cf01b7162948652568c2b42833a95619fa5072adb0bfbf38e3eace7e1596066
 Ctrl.hexxcghash = hexxcghash:a0a53cb8bcc48ffe44fd9e50e0f7532d3e326f93d7ecb10135d4385dab550cd7be03a7374dfc2a92794be13e40c794811a9916c3d1c4e7ea31ed5269537c1c22
 Ctrl.hexsession_id = hexsession_id:9bcf3f3397ff464126cb2a99c04908721871354b842ffd3d873d49407db0382f98cc54d66665d950ec8277c374f19e9f0dd2e727f8759017c49b5b80baa87c63
@@ -4884,7 +4885,7 @@ Ctrl.type = type:D
 Output = 1517de253a5b9f7d9c4c3f234b27392e
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000100192471d29d9fbc8b61570e4efa053a5f17b2efc0aa5415b3309f7dc3971c64d9f1093f6114941d4912f7bfb771db41d1f166d4bdaec8dde214aeb058e2227277393e3c0b12adc1b6a445870bc26e753e05e27b90b97d781e3e8493eb5e717c243213de4dcdd5a11d467b8d26759118692b10357c28b0efb0228cbe257b9ee0cb77bb7bc8b072edf418768c977e485635b4ab61078587128e9a8b3c6deca2a4e64cf9fd6eca880aebd1043deaf94447ea50b0c11b574259cdcafd208d9657c7177cf394de26dd8364b615786198c38e63c568e22b5263be41d6dd8843ad5254f61cf01b7162948652568c2b42833a95619fa5072adb0bfbf38e3eace7e1596066
 Ctrl.hexxcghash = hexxcghash:a0a53cb8bcc48ffe44fd9e50e0f7532d3e326f93d7ecb10135d4385dab550cd7be03a7374dfc2a92794be13e40c794811a9916c3d1c4e7ea31ed5269537c1c22
 Ctrl.hexsession_id = hexsession_id:9bcf3f3397ff464126cb2a99c04908721871354b842ffd3d873d49407db0382f98cc54d66665d950ec8277c374f19e9f0dd2e727f8759017c49b5b80baa87c63
@@ -4892,7 +4893,7 @@ Ctrl.type = type:E
 Output = be48a82cd246cf4d6ddb397a39f1ed62d98b5265e75190624a523033796d05046d63e0810b4b7a6efe9b834cb043871203638557063968910ad1cfa0abe62bb1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:00000100192471d29d9fbc8b61570e4efa053a5f17b2efc0aa5415b3309f7dc3971c64d9f1093f6114941d4912f7bfb771db41d1f166d4bdaec8dde214aeb058e2227277393e3c0b12adc1b6a445870bc26e753e05e27b90b97d781e3e8493eb5e717c243213de4dcdd5a11d467b8d26759118692b10357c28b0efb0228cbe257b9ee0cb77bb7bc8b072edf418768c977e485635b4ab61078587128e9a8b3c6deca2a4e64cf9fd6eca880aebd1043deaf94447ea50b0c11b574259cdcafd208d9657c7177cf394de26dd8364b615786198c38e63c568e22b5263be41d6dd8843ad5254f61cf01b7162948652568c2b42833a95619fa5072adb0bfbf38e3eace7e1596066
 Ctrl.hexxcghash = hexxcghash:a0a53cb8bcc48ffe44fd9e50e0f7532d3e326f93d7ecb10135d4385dab550cd7be03a7374dfc2a92794be13e40c794811a9916c3d1c4e7ea31ed5269537c1c22
 Ctrl.hexsession_id = hexsession_id:9bcf3f3397ff464126cb2a99c04908721871354b842ffd3d873d49407db0382f98cc54d66665d950ec8277c374f19e9f0dd2e727f8759017c49b5b80baa87c63
@@ -4900,7 +4901,7 @@ Ctrl.type = type:F
 Output = 0c9af3775d5dc49a1b9b85fa18420ce1ca10d5159f83f9e078c217289688639dbce5f85665f866d8f93b2c6823bc7b2655830d8bb51fba945ce6eac2b0e6ce8a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010015b3157b538e31a14797d981a6ef62814cd55fbea25ea88a16a5839484c7624d7befccc82d91e2ff2b6f402daba861b77c1016bab9e3d58bab985563f32d663407f9f3582856ee0aa3a56680c221ecddc48af6de71fd34626b716d9efe530df470c0b7b1e4131861bc4f12e44de7f1d1910047465c0eb95f7232d6e71d639d75ac58e6848e560210a5dc2e6996c1d96f9f688fb86558ba96422d1a69cf795ea67e66d534bef2160f4e9d4351c9c2faaad7c2ad2476ace5556c9b3c4c2d3bdac82bfb54d2e54eb6ed398b813c5928aa560b442c585a038571c4db98a44d8c8cdb02fa731b400adb859b591c1846900791d791927363d745042a38597ef883cbda
 Ctrl.hexxcghash = hexxcghash:651bdee255eef5fb47c7733df03d4346bc335cf1de2bfbd453f4ff18c775de475719a6ec4c5c55badadda4822e3fbf5ae3c0e6e9608a893fea68bfcc0af86d73
 Ctrl.hexsession_id = hexsession_id:ee603130d0bdec24952cd3392272dbd7a536c2e76c794cc2f678ca9dd789670453e6bcd330dbf4e93930ec0b3e506e4c629b3d156ab1171d247d0ba44217d292
@@ -4908,7 +4909,7 @@ Ctrl.type = type:A
 Output = 7b802a74d216a41f7708c597b9053223
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010015b3157b538e31a14797d981a6ef62814cd55fbea25ea88a16a5839484c7624d7befccc82d91e2ff2b6f402daba861b77c1016bab9e3d58bab985563f32d663407f9f3582856ee0aa3a56680c221ecddc48af6de71fd34626b716d9efe530df470c0b7b1e4131861bc4f12e44de7f1d1910047465c0eb95f7232d6e71d639d75ac58e6848e560210a5dc2e6996c1d96f9f688fb86558ba96422d1a69cf795ea67e66d534bef2160f4e9d4351c9c2faaad7c2ad2476ace5556c9b3c4c2d3bdac82bfb54d2e54eb6ed398b813c5928aa560b442c585a038571c4db98a44d8c8cdb02fa731b400adb859b591c1846900791d791927363d745042a38597ef883cbda
 Ctrl.hexxcghash = hexxcghash:651bdee255eef5fb47c7733df03d4346bc335cf1de2bfbd453f4ff18c775de475719a6ec4c5c55badadda4822e3fbf5ae3c0e6e9608a893fea68bfcc0af86d73
 Ctrl.hexsession_id = hexsession_id:ee603130d0bdec24952cd3392272dbd7a536c2e76c794cc2f678ca9dd789670453e6bcd330dbf4e93930ec0b3e506e4c629b3d156ab1171d247d0ba44217d292
@@ -4916,7 +4917,7 @@ Ctrl.type = type:B
 Output = 355223971bed70b804d191b64cde39e6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010015b3157b538e31a14797d981a6ef62814cd55fbea25ea88a16a5839484c7624d7befccc82d91e2ff2b6f402daba861b77c1016bab9e3d58bab985563f32d663407f9f3582856ee0aa3a56680c221ecddc48af6de71fd34626b716d9efe530df470c0b7b1e4131861bc4f12e44de7f1d1910047465c0eb95f7232d6e71d639d75ac58e6848e560210a5dc2e6996c1d96f9f688fb86558ba96422d1a69cf795ea67e66d534bef2160f4e9d4351c9c2faaad7c2ad2476ace5556c9b3c4c2d3bdac82bfb54d2e54eb6ed398b813c5928aa560b442c585a038571c4db98a44d8c8cdb02fa731b400adb859b591c1846900791d791927363d745042a38597ef883cbda
 Ctrl.hexxcghash = hexxcghash:651bdee255eef5fb47c7733df03d4346bc335cf1de2bfbd453f4ff18c775de475719a6ec4c5c55badadda4822e3fbf5ae3c0e6e9608a893fea68bfcc0af86d73
 Ctrl.hexsession_id = hexsession_id:ee603130d0bdec24952cd3392272dbd7a536c2e76c794cc2f678ca9dd789670453e6bcd330dbf4e93930ec0b3e506e4c629b3d156ab1171d247d0ba44217d292
@@ -4924,7 +4925,7 @@ Ctrl.type = type:C
 Output = 925f2b036ac2682e20f022377499c3e1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010015b3157b538e31a14797d981a6ef62814cd55fbea25ea88a16a5839484c7624d7befccc82d91e2ff2b6f402daba861b77c1016bab9e3d58bab985563f32d663407f9f3582856ee0aa3a56680c221ecddc48af6de71fd34626b716d9efe530df470c0b7b1e4131861bc4f12e44de7f1d1910047465c0eb95f7232d6e71d639d75ac58e6848e560210a5dc2e6996c1d96f9f688fb86558ba96422d1a69cf795ea67e66d534bef2160f4e9d4351c9c2faaad7c2ad2476ace5556c9b3c4c2d3bdac82bfb54d2e54eb6ed398b813c5928aa560b442c585a038571c4db98a44d8c8cdb02fa731b400adb859b591c1846900791d791927363d745042a38597ef883cbda
 Ctrl.hexxcghash = hexxcghash:651bdee255eef5fb47c7733df03d4346bc335cf1de2bfbd453f4ff18c775de475719a6ec4c5c55badadda4822e3fbf5ae3c0e6e9608a893fea68bfcc0af86d73
 Ctrl.hexsession_id = hexsession_id:ee603130d0bdec24952cd3392272dbd7a536c2e76c794cc2f678ca9dd789670453e6bcd330dbf4e93930ec0b3e506e4c629b3d156ab1171d247d0ba44217d292
@@ -4932,7 +4933,7 @@ Ctrl.type = type:D
 Output = 37ae2bbbb1603c07d5274fc8f57126dc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010015b3157b538e31a14797d981a6ef62814cd55fbea25ea88a16a5839484c7624d7befccc82d91e2ff2b6f402daba861b77c1016bab9e3d58bab985563f32d663407f9f3582856ee0aa3a56680c221ecddc48af6de71fd34626b716d9efe530df470c0b7b1e4131861bc4f12e44de7f1d1910047465c0eb95f7232d6e71d639d75ac58e6848e560210a5dc2e6996c1d96f9f688fb86558ba96422d1a69cf795ea67e66d534bef2160f4e9d4351c9c2faaad7c2ad2476ace5556c9b3c4c2d3bdac82bfb54d2e54eb6ed398b813c5928aa560b442c585a038571c4db98a44d8c8cdb02fa731b400adb859b591c1846900791d791927363d745042a38597ef883cbda
 Ctrl.hexxcghash = hexxcghash:651bdee255eef5fb47c7733df03d4346bc335cf1de2bfbd453f4ff18c775de475719a6ec4c5c55badadda4822e3fbf5ae3c0e6e9608a893fea68bfcc0af86d73
 Ctrl.hexsession_id = hexsession_id:ee603130d0bdec24952cd3392272dbd7a536c2e76c794cc2f678ca9dd789670453e6bcd330dbf4e93930ec0b3e506e4c629b3d156ab1171d247d0ba44217d292
@@ -4940,7 +4941,7 @@ Ctrl.type = type:E
 Output = 8b36c7e175797bf7bbb079ac5d06e6f7f62fc5a957e0fefab7df565eb72ae0586dbebad978975aaa35846de667b44b7174315b2b932f0be538fba76b92531019
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010015b3157b538e31a14797d981a6ef62814cd55fbea25ea88a16a5839484c7624d7befccc82d91e2ff2b6f402daba861b77c1016bab9e3d58bab985563f32d663407f9f3582856ee0aa3a56680c221ecddc48af6de71fd34626b716d9efe530df470c0b7b1e4131861bc4f12e44de7f1d1910047465c0eb95f7232d6e71d639d75ac58e6848e560210a5dc2e6996c1d96f9f688fb86558ba96422d1a69cf795ea67e66d534bef2160f4e9d4351c9c2faaad7c2ad2476ace5556c9b3c4c2d3bdac82bfb54d2e54eb6ed398b813c5928aa560b442c585a038571c4db98a44d8c8cdb02fa731b400adb859b591c1846900791d791927363d745042a38597ef883cbda
 Ctrl.hexxcghash = hexxcghash:651bdee255eef5fb47c7733df03d4346bc335cf1de2bfbd453f4ff18c775de475719a6ec4c5c55badadda4822e3fbf5ae3c0e6e9608a893fea68bfcc0af86d73
 Ctrl.hexsession_id = hexsession_id:ee603130d0bdec24952cd3392272dbd7a536c2e76c794cc2f678ca9dd789670453e6bcd330dbf4e93930ec0b3e506e4c629b3d156ab1171d247d0ba44217d292
@@ -4948,7 +4949,7 @@ Ctrl.type = type:F
 Output = 388ef310bce13188df3fd6285576041754a281548fcc6a212e0de564db661640320130e4df4a6ff31162edaa7ced5b7f05f3456f674ee8be0b03424142058795
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100b41c0bdf180d02ff459079925b32e54299128298da864be28b4c02532244b057219e3fa5fea09841351604ab713021622e6a6d0748f354fc3f29a9ac8bb64fdd984b725f00f56df3cf16d3bac786524a29105096f96f387422361bcc24774fd4d5b71bd6f757a8193fd691411b8e0aa14307e6ed1e97907925d93cee9ed266f387af66cd3da3e99d543e4baaf8a7fdb36c10869267767d80509717b5666e3fcdf8cca6486a1c18e3d3c15ba0c6773dcbe374d83de1c108a400998b25afa4d3b60917594a1120e449a57db1f3b2e048c3c64a408ed41bb32145364932f105788cd0b198522f0c59b1d774b1ac80cd76d18e06b53c3d599f625c72f38b15745478
 Ctrl.hexxcghash = hexxcghash:94ce7876dd7d98475ff8dd634b9b48e0e3416d1afd633637b49a49c525ee905ad8a17c12194746e210207c54628c453287a77515575a79ad40b270b5115030b8
 Ctrl.hexsession_id = hexsession_id:d2e7ea215f35381164a1382533f752eb21e6fa9f25d399b7914c0317998f2b7820f893557459f0773eca3dbafd8375021b955a8dfe7ad659dfe480e3107724f8
@@ -4956,7 +4957,7 @@ Ctrl.type = type:A
 Output = efeb5305eda69b0bd6999b4a27479667
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100b41c0bdf180d02ff459079925b32e54299128298da864be28b4c02532244b057219e3fa5fea09841351604ab713021622e6a6d0748f354fc3f29a9ac8bb64fdd984b725f00f56df3cf16d3bac786524a29105096f96f387422361bcc24774fd4d5b71bd6f757a8193fd691411b8e0aa14307e6ed1e97907925d93cee9ed266f387af66cd3da3e99d543e4baaf8a7fdb36c10869267767d80509717b5666e3fcdf8cca6486a1c18e3d3c15ba0c6773dcbe374d83de1c108a400998b25afa4d3b60917594a1120e449a57db1f3b2e048c3c64a408ed41bb32145364932f105788cd0b198522f0c59b1d774b1ac80cd76d18e06b53c3d599f625c72f38b15745478
 Ctrl.hexxcghash = hexxcghash:94ce7876dd7d98475ff8dd634b9b48e0e3416d1afd633637b49a49c525ee905ad8a17c12194746e210207c54628c453287a77515575a79ad40b270b5115030b8
 Ctrl.hexsession_id = hexsession_id:d2e7ea215f35381164a1382533f752eb21e6fa9f25d399b7914c0317998f2b7820f893557459f0773eca3dbafd8375021b955a8dfe7ad659dfe480e3107724f8
@@ -4964,7 +4965,7 @@ Ctrl.type = type:B
 Output = 806fca9189c02e7ec2a6459387b03506
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100b41c0bdf180d02ff459079925b32e54299128298da864be28b4c02532244b057219e3fa5fea09841351604ab713021622e6a6d0748f354fc3f29a9ac8bb64fdd984b725f00f56df3cf16d3bac786524a29105096f96f387422361bcc24774fd4d5b71bd6f757a8193fd691411b8e0aa14307e6ed1e97907925d93cee9ed266f387af66cd3da3e99d543e4baaf8a7fdb36c10869267767d80509717b5666e3fcdf8cca6486a1c18e3d3c15ba0c6773dcbe374d83de1c108a400998b25afa4d3b60917594a1120e449a57db1f3b2e048c3c64a408ed41bb32145364932f105788cd0b198522f0c59b1d774b1ac80cd76d18e06b53c3d599f625c72f38b15745478
 Ctrl.hexxcghash = hexxcghash:94ce7876dd7d98475ff8dd634b9b48e0e3416d1afd633637b49a49c525ee905ad8a17c12194746e210207c54628c453287a77515575a79ad40b270b5115030b8
 Ctrl.hexsession_id = hexsession_id:d2e7ea215f35381164a1382533f752eb21e6fa9f25d399b7914c0317998f2b7820f893557459f0773eca3dbafd8375021b955a8dfe7ad659dfe480e3107724f8
@@ -4972,7 +4973,7 @@ Ctrl.type = type:C
 Output = 9e542282d0db345a6ba20eba7c5de531
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100b41c0bdf180d02ff459079925b32e54299128298da864be28b4c02532244b057219e3fa5fea09841351604ab713021622e6a6d0748f354fc3f29a9ac8bb64fdd984b725f00f56df3cf16d3bac786524a29105096f96f387422361bcc24774fd4d5b71bd6f757a8193fd691411b8e0aa14307e6ed1e97907925d93cee9ed266f387af66cd3da3e99d543e4baaf8a7fdb36c10869267767d80509717b5666e3fcdf8cca6486a1c18e3d3c15ba0c6773dcbe374d83de1c108a400998b25afa4d3b60917594a1120e449a57db1f3b2e048c3c64a408ed41bb32145364932f105788cd0b198522f0c59b1d774b1ac80cd76d18e06b53c3d599f625c72f38b15745478
 Ctrl.hexxcghash = hexxcghash:94ce7876dd7d98475ff8dd634b9b48e0e3416d1afd633637b49a49c525ee905ad8a17c12194746e210207c54628c453287a77515575a79ad40b270b5115030b8
 Ctrl.hexsession_id = hexsession_id:d2e7ea215f35381164a1382533f752eb21e6fa9f25d399b7914c0317998f2b7820f893557459f0773eca3dbafd8375021b955a8dfe7ad659dfe480e3107724f8
@@ -4980,7 +4981,7 @@ Ctrl.type = type:D
 Output = 41e7962b57a67f75072f15a5ba405d15
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100b41c0bdf180d02ff459079925b32e54299128298da864be28b4c02532244b057219e3fa5fea09841351604ab713021622e6a6d0748f354fc3f29a9ac8bb64fdd984b725f00f56df3cf16d3bac786524a29105096f96f387422361bcc24774fd4d5b71bd6f757a8193fd691411b8e0aa14307e6ed1e97907925d93cee9ed266f387af66cd3da3e99d543e4baaf8a7fdb36c10869267767d80509717b5666e3fcdf8cca6486a1c18e3d3c15ba0c6773dcbe374d83de1c108a400998b25afa4d3b60917594a1120e449a57db1f3b2e048c3c64a408ed41bb32145364932f105788cd0b198522f0c59b1d774b1ac80cd76d18e06b53c3d599f625c72f38b15745478
 Ctrl.hexxcghash = hexxcghash:94ce7876dd7d98475ff8dd634b9b48e0e3416d1afd633637b49a49c525ee905ad8a17c12194746e210207c54628c453287a77515575a79ad40b270b5115030b8
 Ctrl.hexsession_id = hexsession_id:d2e7ea215f35381164a1382533f752eb21e6fa9f25d399b7914c0317998f2b7820f893557459f0773eca3dbafd8375021b955a8dfe7ad659dfe480e3107724f8
@@ -4988,7 +4989,7 @@ Ctrl.type = type:E
 Output = 7bf8f25fd155e41d1dc85cc814704dd8732275b3a53dc1b8c6b330c08f307b5c0da31606cb7eaa1b37b2721f4a1bf70a6885c30d17d7acd32fcc894768fe4106
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100b41c0bdf180d02ff459079925b32e54299128298da864be28b4c02532244b057219e3fa5fea09841351604ab713021622e6a6d0748f354fc3f29a9ac8bb64fdd984b725f00f56df3cf16d3bac786524a29105096f96f387422361bcc24774fd4d5b71bd6f757a8193fd691411b8e0aa14307e6ed1e97907925d93cee9ed266f387af66cd3da3e99d543e4baaf8a7fdb36c10869267767d80509717b5666e3fcdf8cca6486a1c18e3d3c15ba0c6773dcbe374d83de1c108a400998b25afa4d3b60917594a1120e449a57db1f3b2e048c3c64a408ed41bb32145364932f105788cd0b198522f0c59b1d774b1ac80cd76d18e06b53c3d599f625c72f38b15745478
 Ctrl.hexxcghash = hexxcghash:94ce7876dd7d98475ff8dd634b9b48e0e3416d1afd633637b49a49c525ee905ad8a17c12194746e210207c54628c453287a77515575a79ad40b270b5115030b8
 Ctrl.hexsession_id = hexsession_id:d2e7ea215f35381164a1382533f752eb21e6fa9f25d399b7914c0317998f2b7820f893557459f0773eca3dbafd8375021b955a8dfe7ad659dfe480e3107724f8
@@ -4996,7 +4997,7 @@ Ctrl.type = type:F
 Output = 66b8f8c1a38120c73cc55950455a69c426fda44b9c66c3becaf259dd57a620e5ed3a749a486d05eab52c289f489581cb655865d4388a81e79b06bd105e3ae858
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000001003ba71746e4622911dbcd76359dbd01a3958175cac500fac87146f4a2616782ac0328ea32046762f62080df8fe76ff112acbf4e4c7a36fa648ec60c50d4a0f7b27b67cdcd725ed2d51c3b5c438c45c8f46d953845a899e89378e981aa270bd6cc190a5ab53e9516f5c194f9b61ef782573b417702337b32776765e75d6efb371a3af98c1b0eaa90ee43a99e58d803bc645a65100371cda8316d51618e4ada4d9a46cd049673cbfcf6ce3ec66c964902eb9bd28514d1fce32ebf8ee2ae3c8e46f4bf18f153a6f1031cefc7e736d82105dbeb60db422b79f4c4f3f4838fee891341cc982e79917aefb82529d134648847de15cf3ba1d7b5000e74b78198d6a3efce
 Ctrl.hexxcghash = hexxcghash:327a1cfc89837c90fb7141ad3a7df293af5c9e2fd482fb77f6769db8e91417377fe0a0a30c072f8276e824975afdc0f73e1a1cbeda86d5c70c2799912602ee78
 Ctrl.hexsession_id = hexsession_id:46282b8a6dea1654de89199972c414ee512f33ab832e7284547cfc345af6eea9fbafb75f4646789755078a174c98c5aa1d740af1cf40844ae680cdd80466086b
@@ -5004,7 +5005,7 @@ Ctrl.type = type:A
 Output = 8f6ac18ff5300849be34602630bb4102
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000001003ba71746e4622911dbcd76359dbd01a3958175cac500fac87146f4a2616782ac0328ea32046762f62080df8fe76ff112acbf4e4c7a36fa648ec60c50d4a0f7b27b67cdcd725ed2d51c3b5c438c45c8f46d953845a899e89378e981aa270bd6cc190a5ab53e9516f5c194f9b61ef782573b417702337b32776765e75d6efb371a3af98c1b0eaa90ee43a99e58d803bc645a65100371cda8316d51618e4ada4d9a46cd049673cbfcf6ce3ec66c964902eb9bd28514d1fce32ebf8ee2ae3c8e46f4bf18f153a6f1031cefc7e736d82105dbeb60db422b79f4c4f3f4838fee891341cc982e79917aefb82529d134648847de15cf3ba1d7b5000e74b78198d6a3efce
 Ctrl.hexxcghash = hexxcghash:327a1cfc89837c90fb7141ad3a7df293af5c9e2fd482fb77f6769db8e91417377fe0a0a30c072f8276e824975afdc0f73e1a1cbeda86d5c70c2799912602ee78
 Ctrl.hexsession_id = hexsession_id:46282b8a6dea1654de89199972c414ee512f33ab832e7284547cfc345af6eea9fbafb75f4646789755078a174c98c5aa1d740af1cf40844ae680cdd80466086b
@@ -5012,7 +5013,7 @@ Ctrl.type = type:B
 Output = f2b45df2508656758529a1f4679839fd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000001003ba71746e4622911dbcd76359dbd01a3958175cac500fac87146f4a2616782ac0328ea32046762f62080df8fe76ff112acbf4e4c7a36fa648ec60c50d4a0f7b27b67cdcd725ed2d51c3b5c438c45c8f46d953845a899e89378e981aa270bd6cc190a5ab53e9516f5c194f9b61ef782573b417702337b32776765e75d6efb371a3af98c1b0eaa90ee43a99e58d803bc645a65100371cda8316d51618e4ada4d9a46cd049673cbfcf6ce3ec66c964902eb9bd28514d1fce32ebf8ee2ae3c8e46f4bf18f153a6f1031cefc7e736d82105dbeb60db422b79f4c4f3f4838fee891341cc982e79917aefb82529d134648847de15cf3ba1d7b5000e74b78198d6a3efce
 Ctrl.hexxcghash = hexxcghash:327a1cfc89837c90fb7141ad3a7df293af5c9e2fd482fb77f6769db8e91417377fe0a0a30c072f8276e824975afdc0f73e1a1cbeda86d5c70c2799912602ee78
 Ctrl.hexsession_id = hexsession_id:46282b8a6dea1654de89199972c414ee512f33ab832e7284547cfc345af6eea9fbafb75f4646789755078a174c98c5aa1d740af1cf40844ae680cdd80466086b
@@ -5020,7 +5021,7 @@ Ctrl.type = type:C
 Output = 3356d58f61bcca506058e0990c9821f5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000001003ba71746e4622911dbcd76359dbd01a3958175cac500fac87146f4a2616782ac0328ea32046762f62080df8fe76ff112acbf4e4c7a36fa648ec60c50d4a0f7b27b67cdcd725ed2d51c3b5c438c45c8f46d953845a899e89378e981aa270bd6cc190a5ab53e9516f5c194f9b61ef782573b417702337b32776765e75d6efb371a3af98c1b0eaa90ee43a99e58d803bc645a65100371cda8316d51618e4ada4d9a46cd049673cbfcf6ce3ec66c964902eb9bd28514d1fce32ebf8ee2ae3c8e46f4bf18f153a6f1031cefc7e736d82105dbeb60db422b79f4c4f3f4838fee891341cc982e79917aefb82529d134648847de15cf3ba1d7b5000e74b78198d6a3efce
 Ctrl.hexxcghash = hexxcghash:327a1cfc89837c90fb7141ad3a7df293af5c9e2fd482fb77f6769db8e91417377fe0a0a30c072f8276e824975afdc0f73e1a1cbeda86d5c70c2799912602ee78
 Ctrl.hexsession_id = hexsession_id:46282b8a6dea1654de89199972c414ee512f33ab832e7284547cfc345af6eea9fbafb75f4646789755078a174c98c5aa1d740af1cf40844ae680cdd80466086b
@@ -5028,7 +5029,7 @@ Ctrl.type = type:D
 Output = 78495438a5326cca5351a239545941c1
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000001003ba71746e4622911dbcd76359dbd01a3958175cac500fac87146f4a2616782ac0328ea32046762f62080df8fe76ff112acbf4e4c7a36fa648ec60c50d4a0f7b27b67cdcd725ed2d51c3b5c438c45c8f46d953845a899e89378e981aa270bd6cc190a5ab53e9516f5c194f9b61ef782573b417702337b32776765e75d6efb371a3af98c1b0eaa90ee43a99e58d803bc645a65100371cda8316d51618e4ada4d9a46cd049673cbfcf6ce3ec66c964902eb9bd28514d1fce32ebf8ee2ae3c8e46f4bf18f153a6f1031cefc7e736d82105dbeb60db422b79f4c4f3f4838fee891341cc982e79917aefb82529d134648847de15cf3ba1d7b5000e74b78198d6a3efce
 Ctrl.hexxcghash = hexxcghash:327a1cfc89837c90fb7141ad3a7df293af5c9e2fd482fb77f6769db8e91417377fe0a0a30c072f8276e824975afdc0f73e1a1cbeda86d5c70c2799912602ee78
 Ctrl.hexsession_id = hexsession_id:46282b8a6dea1654de89199972c414ee512f33ab832e7284547cfc345af6eea9fbafb75f4646789755078a174c98c5aa1d740af1cf40844ae680cdd80466086b
@@ -5036,7 +5037,7 @@ Ctrl.type = type:E
 Output = dcfc5d099f5040513f76b012ab62ee45d5d8271aec9cbbdd1e1f7e0806f363d21c2eca730f9489ee70fbc7490a1901587b1d418c0e4f429c8098cd793c6d285c
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:000001003ba71746e4622911dbcd76359dbd01a3958175cac500fac87146f4a2616782ac0328ea32046762f62080df8fe76ff112acbf4e4c7a36fa648ec60c50d4a0f7b27b67cdcd725ed2d51c3b5c438c45c8f46d953845a899e89378e981aa270bd6cc190a5ab53e9516f5c194f9b61ef782573b417702337b32776765e75d6efb371a3af98c1b0eaa90ee43a99e58d803bc645a65100371cda8316d51618e4ada4d9a46cd049673cbfcf6ce3ec66c964902eb9bd28514d1fce32ebf8ee2ae3c8e46f4bf18f153a6f1031cefc7e736d82105dbeb60db422b79f4c4f3f4838fee891341cc982e79917aefb82529d134648847de15cf3ba1d7b5000e74b78198d6a3efce
 Ctrl.hexxcghash = hexxcghash:327a1cfc89837c90fb7141ad3a7df293af5c9e2fd482fb77f6769db8e91417377fe0a0a30c072f8276e824975afdc0f73e1a1cbeda86d5c70c2799912602ee78
 Ctrl.hexsession_id = hexsession_id:46282b8a6dea1654de89199972c414ee512f33ab832e7284547cfc345af6eea9fbafb75f4646789755078a174c98c5aa1d740af1cf40844ae680cdd80466086b
@@ -5044,7 +5045,7 @@ Ctrl.type = type:F
 Output = a75817465c73517bd7884dcd230464583ae491ae5e39330873cd7a967188022cad63e712c7ec261abdb34c01bddd8989dfce8f5d8a8cdbdcc305429b3fd93c76
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100f3a28f9574691777f2a9e05a882295e5ae272a6af486e53a8574e0ce7633a5c6871a39e6ba3176a41ce3fe6c80aa8469df71401583987e34374586ec56268b37d42bc047cc898750379aa7ddc5549cc069fa10d29fca303e6063a2cb800322a84a63480d91606db0244d2dd456005bb4a4b33f91ddf33335ec4d4d519e430542e087d5b1e952b183a32b3f7b118c410c46dc44b7ad669e7d98b934e48830e61ddd2e6094e0d1fa39b9041b9ca9dc768af4da702f912b2e82738cf506479c68fa9a5f2a9153189cf83bd11a05a92428d7c7124094f684f7c848114dc272d8a308d7b65e47b1d3c2c70d5a63efbc191ff5f0359356f706ac703445778b2b43a8d6
 Ctrl.hexxcghash = hexxcghash:4f3aaea9ade34a07f46c11a4480461e2c523a740492b23b0bfa2a9e2e2c2ce542a09644154a4b3ab0e8b71ea950444a9954a156c0530a1436aa98951af7e1972
 Ctrl.hexsession_id = hexsession_id:c778cdc03ecc941ff7d37c41fe67dc84df375117abd62d099129f38d37375f3cde4e75a0160fb05edf392d1eac509d5a6796f635623794d81df9b4cf81021738
@@ -5052,7 +5053,7 @@ Ctrl.type = type:A
 Output = 4fa1b8c53d25f7c1adb4810c46b48ae7
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100f3a28f9574691777f2a9e05a882295e5ae272a6af486e53a8574e0ce7633a5c6871a39e6ba3176a41ce3fe6c80aa8469df71401583987e34374586ec56268b37d42bc047cc898750379aa7ddc5549cc069fa10d29fca303e6063a2cb800322a84a63480d91606db0244d2dd456005bb4a4b33f91ddf33335ec4d4d519e430542e087d5b1e952b183a32b3f7b118c410c46dc44b7ad669e7d98b934e48830e61ddd2e6094e0d1fa39b9041b9ca9dc768af4da702f912b2e82738cf506479c68fa9a5f2a9153189cf83bd11a05a92428d7c7124094f684f7c848114dc272d8a308d7b65e47b1d3c2c70d5a63efbc191ff5f0359356f706ac703445778b2b43a8d6
 Ctrl.hexxcghash = hexxcghash:4f3aaea9ade34a07f46c11a4480461e2c523a740492b23b0bfa2a9e2e2c2ce542a09644154a4b3ab0e8b71ea950444a9954a156c0530a1436aa98951af7e1972
 Ctrl.hexsession_id = hexsession_id:c778cdc03ecc941ff7d37c41fe67dc84df375117abd62d099129f38d37375f3cde4e75a0160fb05edf392d1eac509d5a6796f635623794d81df9b4cf81021738
@@ -5060,7 +5061,7 @@ Ctrl.type = type:B
 Output = 3c453d0f50b7f41826e74e5cce5b5996
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100f3a28f9574691777f2a9e05a882295e5ae272a6af486e53a8574e0ce7633a5c6871a39e6ba3176a41ce3fe6c80aa8469df71401583987e34374586ec56268b37d42bc047cc898750379aa7ddc5549cc069fa10d29fca303e6063a2cb800322a84a63480d91606db0244d2dd456005bb4a4b33f91ddf33335ec4d4d519e430542e087d5b1e952b183a32b3f7b118c410c46dc44b7ad669e7d98b934e48830e61ddd2e6094e0d1fa39b9041b9ca9dc768af4da702f912b2e82738cf506479c68fa9a5f2a9153189cf83bd11a05a92428d7c7124094f684f7c848114dc272d8a308d7b65e47b1d3c2c70d5a63efbc191ff5f0359356f706ac703445778b2b43a8d6
 Ctrl.hexxcghash = hexxcghash:4f3aaea9ade34a07f46c11a4480461e2c523a740492b23b0bfa2a9e2e2c2ce542a09644154a4b3ab0e8b71ea950444a9954a156c0530a1436aa98951af7e1972
 Ctrl.hexsession_id = hexsession_id:c778cdc03ecc941ff7d37c41fe67dc84df375117abd62d099129f38d37375f3cde4e75a0160fb05edf392d1eac509d5a6796f635623794d81df9b4cf81021738
@@ -5068,7 +5069,7 @@ Ctrl.type = type:C
 Output = 22f47a00a5de0f56b3e586357eeebe57
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100f3a28f9574691777f2a9e05a882295e5ae272a6af486e53a8574e0ce7633a5c6871a39e6ba3176a41ce3fe6c80aa8469df71401583987e34374586ec56268b37d42bc047cc898750379aa7ddc5549cc069fa10d29fca303e6063a2cb800322a84a63480d91606db0244d2dd456005bb4a4b33f91ddf33335ec4d4d519e430542e087d5b1e952b183a32b3f7b118c410c46dc44b7ad669e7d98b934e48830e61ddd2e6094e0d1fa39b9041b9ca9dc768af4da702f912b2e82738cf506479c68fa9a5f2a9153189cf83bd11a05a92428d7c7124094f684f7c848114dc272d8a308d7b65e47b1d3c2c70d5a63efbc191ff5f0359356f706ac703445778b2b43a8d6
 Ctrl.hexxcghash = hexxcghash:4f3aaea9ade34a07f46c11a4480461e2c523a740492b23b0bfa2a9e2e2c2ce542a09644154a4b3ab0e8b71ea950444a9954a156c0530a1436aa98951af7e1972
 Ctrl.hexsession_id = hexsession_id:c778cdc03ecc941ff7d37c41fe67dc84df375117abd62d099129f38d37375f3cde4e75a0160fb05edf392d1eac509d5a6796f635623794d81df9b4cf81021738
@@ -5076,7 +5077,7 @@ Ctrl.type = type:D
 Output = 8d32d1945e93c4982bd106567f8e481f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100f3a28f9574691777f2a9e05a882295e5ae272a6af486e53a8574e0ce7633a5c6871a39e6ba3176a41ce3fe6c80aa8469df71401583987e34374586ec56268b37d42bc047cc898750379aa7ddc5549cc069fa10d29fca303e6063a2cb800322a84a63480d91606db0244d2dd456005bb4a4b33f91ddf33335ec4d4d519e430542e087d5b1e952b183a32b3f7b118c410c46dc44b7ad669e7d98b934e48830e61ddd2e6094e0d1fa39b9041b9ca9dc768af4da702f912b2e82738cf506479c68fa9a5f2a9153189cf83bd11a05a92428d7c7124094f684f7c848114dc272d8a308d7b65e47b1d3c2c70d5a63efbc191ff5f0359356f706ac703445778b2b43a8d6
 Ctrl.hexxcghash = hexxcghash:4f3aaea9ade34a07f46c11a4480461e2c523a740492b23b0bfa2a9e2e2c2ce542a09644154a4b3ab0e8b71ea950444a9954a156c0530a1436aa98951af7e1972
 Ctrl.hexsession_id = hexsession_id:c778cdc03ecc941ff7d37c41fe67dc84df375117abd62d099129f38d37375f3cde4e75a0160fb05edf392d1eac509d5a6796f635623794d81df9b4cf81021738
@@ -5084,7 +5085,7 @@ Ctrl.type = type:E
 Output = 9eefe581b1514160f81c94193d374d8f85879136e9ae494c487119b1974aac3e143948f656c1c1e837ff1368ef0d997cd3ca9f46c71056269eb8a1da8daf5678
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100f3a28f9574691777f2a9e05a882295e5ae272a6af486e53a8574e0ce7633a5c6871a39e6ba3176a41ce3fe6c80aa8469df71401583987e34374586ec56268b37d42bc047cc898750379aa7ddc5549cc069fa10d29fca303e6063a2cb800322a84a63480d91606db0244d2dd456005bb4a4b33f91ddf33335ec4d4d519e430542e087d5b1e952b183a32b3f7b118c410c46dc44b7ad669e7d98b934e48830e61ddd2e6094e0d1fa39b9041b9ca9dc768af4da702f912b2e82738cf506479c68fa9a5f2a9153189cf83bd11a05a92428d7c7124094f684f7c848114dc272d8a308d7b65e47b1d3c2c70d5a63efbc191ff5f0359356f706ac703445778b2b43a8d6
 Ctrl.hexxcghash = hexxcghash:4f3aaea9ade34a07f46c11a4480461e2c523a740492b23b0bfa2a9e2e2c2ce542a09644154a4b3ab0e8b71ea950444a9954a156c0530a1436aa98951af7e1972
 Ctrl.hexsession_id = hexsession_id:c778cdc03ecc941ff7d37c41fe67dc84df375117abd62d099129f38d37375f3cde4e75a0160fb05edf392d1eac509d5a6796f635623794d81df9b4cf81021738
@@ -5092,7 +5093,7 @@ Ctrl.type = type:F
 Output = 8dd76f59e6692ff642894ee1bb147f3e1490cac944af29de6b2b5abcc4ab9eb41d236e9cd2f40cf83935097f307a246d7b35005dd302bacfe7e4fed37d2f46e9
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010012c99d1e0542b3b71e287b1ea15e54a3197f95cfbf7f6a209ada41fce3a6faad9bc4d569b690223e5d668019c11204716bb96a858c36c853bd41b28c1505ddce9df22b31dbdaa014b07ec53a79cfeb5b540902669c7a283f3647c1a9f685b5027bfb18e827818a76c23fa6ad20760f228a4239a4d558240130b5cc389d2be41b806cafd24d1d425c26a61508c974d62aae6f6830459c79e7a9ff5610291661bf03528fbafe47cf4c2e51f4856749ef543eb7cd8f72e84a4075fa7df9ad12565e5b3810c6d6292ff878ee8499611688989f0a04f4dc7275e01c0444a0321f0a0327fbe8a55689307b1bfd66d5d27ade78df5c1dfcef8868ebbe339d7efdae1973
 Ctrl.hexxcghash = hexxcghash:7317f576ce95d5bed93d08c65eb814d037ecd42f09b2d514fad58335e8e8bec807b9cf74b9044f449581c792ebb08843f2b80da87d91625e20f25de91b4d5d23
 Ctrl.hexsession_id = hexsession_id:7d153fda85bd3488962bdf03b8d0f26cf61f737173587ac6ee3d6f601a00f6474f5401370ef04720c620ea2b9668ab72cb6c40dc96057fc4537e7a6b0e79e9c5
@@ -5100,7 +5101,7 @@ Ctrl.type = type:A
 Output = f335b3ab270d7e686c5e023b3a2da75b
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010012c99d1e0542b3b71e287b1ea15e54a3197f95cfbf7f6a209ada41fce3a6faad9bc4d569b690223e5d668019c11204716bb96a858c36c853bd41b28c1505ddce9df22b31dbdaa014b07ec53a79cfeb5b540902669c7a283f3647c1a9f685b5027bfb18e827818a76c23fa6ad20760f228a4239a4d558240130b5cc389d2be41b806cafd24d1d425c26a61508c974d62aae6f6830459c79e7a9ff5610291661bf03528fbafe47cf4c2e51f4856749ef543eb7cd8f72e84a4075fa7df9ad12565e5b3810c6d6292ff878ee8499611688989f0a04f4dc7275e01c0444a0321f0a0327fbe8a55689307b1bfd66d5d27ade78df5c1dfcef8868ebbe339d7efdae1973
 Ctrl.hexxcghash = hexxcghash:7317f576ce95d5bed93d08c65eb814d037ecd42f09b2d514fad58335e8e8bec807b9cf74b9044f449581c792ebb08843f2b80da87d91625e20f25de91b4d5d23
 Ctrl.hexsession_id = hexsession_id:7d153fda85bd3488962bdf03b8d0f26cf61f737173587ac6ee3d6f601a00f6474f5401370ef04720c620ea2b9668ab72cb6c40dc96057fc4537e7a6b0e79e9c5
@@ -5108,7 +5109,7 @@ Ctrl.type = type:B
 Output = 857c9245c67bad84b7377c424c5e7e7a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010012c99d1e0542b3b71e287b1ea15e54a3197f95cfbf7f6a209ada41fce3a6faad9bc4d569b690223e5d668019c11204716bb96a858c36c853bd41b28c1505ddce9df22b31dbdaa014b07ec53a79cfeb5b540902669c7a283f3647c1a9f685b5027bfb18e827818a76c23fa6ad20760f228a4239a4d558240130b5cc389d2be41b806cafd24d1d425c26a61508c974d62aae6f6830459c79e7a9ff5610291661bf03528fbafe47cf4c2e51f4856749ef543eb7cd8f72e84a4075fa7df9ad12565e5b3810c6d6292ff878ee8499611688989f0a04f4dc7275e01c0444a0321f0a0327fbe8a55689307b1bfd66d5d27ade78df5c1dfcef8868ebbe339d7efdae1973
 Ctrl.hexxcghash = hexxcghash:7317f576ce95d5bed93d08c65eb814d037ecd42f09b2d514fad58335e8e8bec807b9cf74b9044f449581c792ebb08843f2b80da87d91625e20f25de91b4d5d23
 Ctrl.hexsession_id = hexsession_id:7d153fda85bd3488962bdf03b8d0f26cf61f737173587ac6ee3d6f601a00f6474f5401370ef04720c620ea2b9668ab72cb6c40dc96057fc4537e7a6b0e79e9c5
@@ -5116,7 +5117,7 @@ Ctrl.type = type:C
 Output = 1c44ef56440f5856bdfd951305fd81e4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010012c99d1e0542b3b71e287b1ea15e54a3197f95cfbf7f6a209ada41fce3a6faad9bc4d569b690223e5d668019c11204716bb96a858c36c853bd41b28c1505ddce9df22b31dbdaa014b07ec53a79cfeb5b540902669c7a283f3647c1a9f685b5027bfb18e827818a76c23fa6ad20760f228a4239a4d558240130b5cc389d2be41b806cafd24d1d425c26a61508c974d62aae6f6830459c79e7a9ff5610291661bf03528fbafe47cf4c2e51f4856749ef543eb7cd8f72e84a4075fa7df9ad12565e5b3810c6d6292ff878ee8499611688989f0a04f4dc7275e01c0444a0321f0a0327fbe8a55689307b1bfd66d5d27ade78df5c1dfcef8868ebbe339d7efdae1973
 Ctrl.hexxcghash = hexxcghash:7317f576ce95d5bed93d08c65eb814d037ecd42f09b2d514fad58335e8e8bec807b9cf74b9044f449581c792ebb08843f2b80da87d91625e20f25de91b4d5d23
 Ctrl.hexsession_id = hexsession_id:7d153fda85bd3488962bdf03b8d0f26cf61f737173587ac6ee3d6f601a00f6474f5401370ef04720c620ea2b9668ab72cb6c40dc96057fc4537e7a6b0e79e9c5
@@ -5124,7 +5125,7 @@ Ctrl.type = type:D
 Output = 8d3496ac631bb3588abbb13d4ae2dc2d
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010012c99d1e0542b3b71e287b1ea15e54a3197f95cfbf7f6a209ada41fce3a6faad9bc4d569b690223e5d668019c11204716bb96a858c36c853bd41b28c1505ddce9df22b31dbdaa014b07ec53a79cfeb5b540902669c7a283f3647c1a9f685b5027bfb18e827818a76c23fa6ad20760f228a4239a4d558240130b5cc389d2be41b806cafd24d1d425c26a61508c974d62aae6f6830459c79e7a9ff5610291661bf03528fbafe47cf4c2e51f4856749ef543eb7cd8f72e84a4075fa7df9ad12565e5b3810c6d6292ff878ee8499611688989f0a04f4dc7275e01c0444a0321f0a0327fbe8a55689307b1bfd66d5d27ade78df5c1dfcef8868ebbe339d7efdae1973
 Ctrl.hexxcghash = hexxcghash:7317f576ce95d5bed93d08c65eb814d037ecd42f09b2d514fad58335e8e8bec807b9cf74b9044f449581c792ebb08843f2b80da87d91625e20f25de91b4d5d23
 Ctrl.hexsession_id = hexsession_id:7d153fda85bd3488962bdf03b8d0f26cf61f737173587ac6ee3d6f601a00f6474f5401370ef04720c620ea2b9668ab72cb6c40dc96057fc4537e7a6b0e79e9c5
@@ -5132,7 +5133,7 @@ Ctrl.type = type:E
 Output = ac7899494cfcebbdaa8ee7c343a0a458228a0a5e59730c928e9c8775487e57c3a5f34fdb72c1b3b57cc35e0356e4b7c6a56368e74c68a017538a5b484886ec81
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010012c99d1e0542b3b71e287b1ea15e54a3197f95cfbf7f6a209ada41fce3a6faad9bc4d569b690223e5d668019c11204716bb96a858c36c853bd41b28c1505ddce9df22b31dbdaa014b07ec53a79cfeb5b540902669c7a283f3647c1a9f685b5027bfb18e827818a76c23fa6ad20760f228a4239a4d558240130b5cc389d2be41b806cafd24d1d425c26a61508c974d62aae6f6830459c79e7a9ff5610291661bf03528fbafe47cf4c2e51f4856749ef543eb7cd8f72e84a4075fa7df9ad12565e5b3810c6d6292ff878ee8499611688989f0a04f4dc7275e01c0444a0321f0a0327fbe8a55689307b1bfd66d5d27ade78df5c1dfcef8868ebbe339d7efdae1973
 Ctrl.hexxcghash = hexxcghash:7317f576ce95d5bed93d08c65eb814d037ecd42f09b2d514fad58335e8e8bec807b9cf74b9044f449581c792ebb08843f2b80da87d91625e20f25de91b4d5d23
 Ctrl.hexsession_id = hexsession_id:7d153fda85bd3488962bdf03b8d0f26cf61f737173587ac6ee3d6f601a00f6474f5401370ef04720c620ea2b9668ab72cb6c40dc96057fc4537e7a6b0e79e9c5
@@ -5140,7 +5141,7 @@ Ctrl.type = type:F
 Output = d32d849b488594d0b8efce91604296393b2240121f2ed51fb7c0bb5b371c33775d184ffaf3028306bc8040b21887f6885e5916ae158ef74a3ba09a1f30654f1a
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100c6c401e7a417025fce8ca5d5e654de6cac8eb1bf24fffa1eefaba828f425b5df93323ad62565d9e74c0b45619c3e97a8e006a9b28a42e96e13ea2f3807319ac587850731f64c86a3a9acd4aaa04e8a586833faeb902f95177d27e89ce25307365b22b7bf444c8e72ef2bb0fce86fe326a90b787948085fd101f04a7311ed6cf65d5073a6a29c7d99fe9fa0b915fac1d9bb6b95143ca8936e10e6e319201112ba52823dbaad935972842361394999e5a67356076e9f0b528d62325181f80d66e9b3288ba7482458c737806f474867036a234201253a91a6246c8c2876d210d2579951dd12cbc153dcec403156739be9c7d291e4904f079a5a71c01b9a84481800
 Ctrl.hexxcghash = hexxcghash:b060195095692352bde81e90c1b648ec46d57476892e79489d42cb8e0da2027ec41fd2e62da8e8e2a9e1ebcb8eecfaadef75e6714008ed6a2cbdef6c321bbaaa
 Ctrl.hexsession_id = hexsession_id:5c910a53cafca6f8c0d97c4748f67aecd9a54c8ba96bf33327565f6f68ae0a2e7a62733a9051364ff9f68bdb416176522a0e5a2f28fe27a3f5ec402b3d99da13
@@ -5148,7 +5149,7 @@ Ctrl.type = type:A
 Output = 5aa8ed531557a1dc934ed667029e062f
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100c6c401e7a417025fce8ca5d5e654de6cac8eb1bf24fffa1eefaba828f425b5df93323ad62565d9e74c0b45619c3e97a8e006a9b28a42e96e13ea2f3807319ac587850731f64c86a3a9acd4aaa04e8a586833faeb902f95177d27e89ce25307365b22b7bf444c8e72ef2bb0fce86fe326a90b787948085fd101f04a7311ed6cf65d5073a6a29c7d99fe9fa0b915fac1d9bb6b95143ca8936e10e6e319201112ba52823dbaad935972842361394999e5a67356076e9f0b528d62325181f80d66e9b3288ba7482458c737806f474867036a234201253a91a6246c8c2876d210d2579951dd12cbc153dcec403156739be9c7d291e4904f079a5a71c01b9a84481800
 Ctrl.hexxcghash = hexxcghash:b060195095692352bde81e90c1b648ec46d57476892e79489d42cb8e0da2027ec41fd2e62da8e8e2a9e1ebcb8eecfaadef75e6714008ed6a2cbdef6c321bbaaa
 Ctrl.hexsession_id = hexsession_id:5c910a53cafca6f8c0d97c4748f67aecd9a54c8ba96bf33327565f6f68ae0a2e7a62733a9051364ff9f68bdb416176522a0e5a2f28fe27a3f5ec402b3d99da13
@@ -5156,7 +5157,7 @@ Ctrl.type = type:B
 Output = 11a810c69785949d5a0ef6eeff960fb4
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100c6c401e7a417025fce8ca5d5e654de6cac8eb1bf24fffa1eefaba828f425b5df93323ad62565d9e74c0b45619c3e97a8e006a9b28a42e96e13ea2f3807319ac587850731f64c86a3a9acd4aaa04e8a586833faeb902f95177d27e89ce25307365b22b7bf444c8e72ef2bb0fce86fe326a90b787948085fd101f04a7311ed6cf65d5073a6a29c7d99fe9fa0b915fac1d9bb6b95143ca8936e10e6e319201112ba52823dbaad935972842361394999e5a67356076e9f0b528d62325181f80d66e9b3288ba7482458c737806f474867036a234201253a91a6246c8c2876d210d2579951dd12cbc153dcec403156739be9c7d291e4904f079a5a71c01b9a84481800
 Ctrl.hexxcghash = hexxcghash:b060195095692352bde81e90c1b648ec46d57476892e79489d42cb8e0da2027ec41fd2e62da8e8e2a9e1ebcb8eecfaadef75e6714008ed6a2cbdef6c321bbaaa
 Ctrl.hexsession_id = hexsession_id:5c910a53cafca6f8c0d97c4748f67aecd9a54c8ba96bf33327565f6f68ae0a2e7a62733a9051364ff9f68bdb416176522a0e5a2f28fe27a3f5ec402b3d99da13
@@ -5164,7 +5165,7 @@ Ctrl.type = type:C
 Output = 54e9402e4f85b08c271b2a9f15d56c75
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100c6c401e7a417025fce8ca5d5e654de6cac8eb1bf24fffa1eefaba828f425b5df93323ad62565d9e74c0b45619c3e97a8e006a9b28a42e96e13ea2f3807319ac587850731f64c86a3a9acd4aaa04e8a586833faeb902f95177d27e89ce25307365b22b7bf444c8e72ef2bb0fce86fe326a90b787948085fd101f04a7311ed6cf65d5073a6a29c7d99fe9fa0b915fac1d9bb6b95143ca8936e10e6e319201112ba52823dbaad935972842361394999e5a67356076e9f0b528d62325181f80d66e9b3288ba7482458c737806f474867036a234201253a91a6246c8c2876d210d2579951dd12cbc153dcec403156739be9c7d291e4904f079a5a71c01b9a84481800
 Ctrl.hexxcghash = hexxcghash:b060195095692352bde81e90c1b648ec46d57476892e79489d42cb8e0da2027ec41fd2e62da8e8e2a9e1ebcb8eecfaadef75e6714008ed6a2cbdef6c321bbaaa
 Ctrl.hexsession_id = hexsession_id:5c910a53cafca6f8c0d97c4748f67aecd9a54c8ba96bf33327565f6f68ae0a2e7a62733a9051364ff9f68bdb416176522a0e5a2f28fe27a3f5ec402b3d99da13
@@ -5172,7 +5173,7 @@ Ctrl.type = type:D
 Output = 838209e0ebe7626cf6482f25c7774bfd
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100c6c401e7a417025fce8ca5d5e654de6cac8eb1bf24fffa1eefaba828f425b5df93323ad62565d9e74c0b45619c3e97a8e006a9b28a42e96e13ea2f3807319ac587850731f64c86a3a9acd4aaa04e8a586833faeb902f95177d27e89ce25307365b22b7bf444c8e72ef2bb0fce86fe326a90b787948085fd101f04a7311ed6cf65d5073a6a29c7d99fe9fa0b915fac1d9bb6b95143ca8936e10e6e319201112ba52823dbaad935972842361394999e5a67356076e9f0b528d62325181f80d66e9b3288ba7482458c737806f474867036a234201253a91a6246c8c2876d210d2579951dd12cbc153dcec403156739be9c7d291e4904f079a5a71c01b9a84481800
 Ctrl.hexxcghash = hexxcghash:b060195095692352bde81e90c1b648ec46d57476892e79489d42cb8e0da2027ec41fd2e62da8e8e2a9e1ebcb8eecfaadef75e6714008ed6a2cbdef6c321bbaaa
 Ctrl.hexsession_id = hexsession_id:5c910a53cafca6f8c0d97c4748f67aecd9a54c8ba96bf33327565f6f68ae0a2e7a62733a9051364ff9f68bdb416176522a0e5a2f28fe27a3f5ec402b3d99da13
@@ -5180,7 +5181,7 @@ Ctrl.type = type:E
 Output = bc62048ddb762ac50336ae0e91a402cc78e73472fe180756a4686299967d2904318b8ad1b8dc622edd75e9ff0e74f7fcb8a1f8acb86e2567a5167084c648c7ef
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100c6c401e7a417025fce8ca5d5e654de6cac8eb1bf24fffa1eefaba828f425b5df93323ad62565d9e74c0b45619c3e97a8e006a9b28a42e96e13ea2f3807319ac587850731f64c86a3a9acd4aaa04e8a586833faeb902f95177d27e89ce25307365b22b7bf444c8e72ef2bb0fce86fe326a90b787948085fd101f04a7311ed6cf65d5073a6a29c7d99fe9fa0b915fac1d9bb6b95143ca8936e10e6e319201112ba52823dbaad935972842361394999e5a67356076e9f0b528d62325181f80d66e9b3288ba7482458c737806f474867036a234201253a91a6246c8c2876d210d2579951dd12cbc153dcec403156739be9c7d291e4904f079a5a71c01b9a84481800
 Ctrl.hexxcghash = hexxcghash:b060195095692352bde81e90c1b648ec46d57476892e79489d42cb8e0da2027ec41fd2e62da8e8e2a9e1ebcb8eecfaadef75e6714008ed6a2cbdef6c321bbaaa
 Ctrl.hexsession_id = hexsession_id:5c910a53cafca6f8c0d97c4748f67aecd9a54c8ba96bf33327565f6f68ae0a2e7a62733a9051364ff9f68bdb416176522a0e5a2f28fe27a3f5ec402b3d99da13
@@ -5188,7 +5189,7 @@ Ctrl.type = type:F
 Output = 4e9644a01a3fe6c3f4f5aceddb00e2584e277354aee6392a1a5aef05024d37fcf25ff46fdd8fe52e7d1dd9a96e77328aadf44b8fc92ac22a14f63d64ad0db621
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100a82ae4062baef678d20dd9cf1704cdc69e9e78eea5faa435e4dffec06976ff73bd1e2ebd206658a26fb85a0911e2034eede31e7df2d7b87aa9700cf301b6b38502ba4db2b9723505455a7da0c6e0cf374b063921179d1bc69508f660bbb26d05ab16a2325716dbd0a733809cac36660d9a73ff0f61e09f55d1ff0652474130be7fcd2d37ebd1203960d788a1307fae48ec4e1042ab85f037a01bfd17f15725ee929d6e6246bbda00fe7105461ee873b0190c2f44692845e464949f909df46309a8eb72037278f792c87249897a0564d290bec1e09b2c9d3ad3011710fc4dcfabfa435611794dc7d1507b657229a2aab65ce2e789305d5d24ed955e89d8eb4f7e
 Ctrl.hexxcghash = hexxcghash:a6ef8e3102b16ce51b2a2fe17e8dc711a964c195ca4d597aabecce595187344ccb2ea37dc4cac0a77a47e7ea1b9055b1c9948e6e09793a9121f120b3bd07c5f2
 Ctrl.hexsession_id = hexsession_id:cc85cf95e29a5991306b21c1738de9a6612b8cb09f12b1738a4873c29f971e8d204aeb98bb7a7502cdab952eaaa6ec1e3a9655db3e5217afbff63ad588fbbf85
@@ -5196,7 +5197,7 @@ Ctrl.type = type:A
 Output = 77cb432c67bf0ae658aa4e34376d01b5
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100a82ae4062baef678d20dd9cf1704cdc69e9e78eea5faa435e4dffec06976ff73bd1e2ebd206658a26fb85a0911e2034eede31e7df2d7b87aa9700cf301b6b38502ba4db2b9723505455a7da0c6e0cf374b063921179d1bc69508f660bbb26d05ab16a2325716dbd0a733809cac36660d9a73ff0f61e09f55d1ff0652474130be7fcd2d37ebd1203960d788a1307fae48ec4e1042ab85f037a01bfd17f15725ee929d6e6246bbda00fe7105461ee873b0190c2f44692845e464949f909df46309a8eb72037278f792c87249897a0564d290bec1e09b2c9d3ad3011710fc4dcfabfa435611794dc7d1507b657229a2aab65ce2e789305d5d24ed955e89d8eb4f7e
 Ctrl.hexxcghash = hexxcghash:a6ef8e3102b16ce51b2a2fe17e8dc711a964c195ca4d597aabecce595187344ccb2ea37dc4cac0a77a47e7ea1b9055b1c9948e6e09793a9121f120b3bd07c5f2
 Ctrl.hexsession_id = hexsession_id:cc85cf95e29a5991306b21c1738de9a6612b8cb09f12b1738a4873c29f971e8d204aeb98bb7a7502cdab952eaaa6ec1e3a9655db3e5217afbff63ad588fbbf85
@@ -5204,7 +5205,7 @@ Ctrl.type = type:B
 Output = f55c74d112746001d8908edd347d7e69
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100a82ae4062baef678d20dd9cf1704cdc69e9e78eea5faa435e4dffec06976ff73bd1e2ebd206658a26fb85a0911e2034eede31e7df2d7b87aa9700cf301b6b38502ba4db2b9723505455a7da0c6e0cf374b063921179d1bc69508f660bbb26d05ab16a2325716dbd0a733809cac36660d9a73ff0f61e09f55d1ff0652474130be7fcd2d37ebd1203960d788a1307fae48ec4e1042ab85f037a01bfd17f15725ee929d6e6246bbda00fe7105461ee873b0190c2f44692845e464949f909df46309a8eb72037278f792c87249897a0564d290bec1e09b2c9d3ad3011710fc4dcfabfa435611794dc7d1507b657229a2aab65ce2e789305d5d24ed955e89d8eb4f7e
 Ctrl.hexxcghash = hexxcghash:a6ef8e3102b16ce51b2a2fe17e8dc711a964c195ca4d597aabecce595187344ccb2ea37dc4cac0a77a47e7ea1b9055b1c9948e6e09793a9121f120b3bd07c5f2
 Ctrl.hexsession_id = hexsession_id:cc85cf95e29a5991306b21c1738de9a6612b8cb09f12b1738a4873c29f971e8d204aeb98bb7a7502cdab952eaaa6ec1e3a9655db3e5217afbff63ad588fbbf85
@@ -5212,7 +5213,7 @@ Ctrl.type = type:C
 Output = 34a48ab90890b385198ea6bf8c50c3f6
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100a82ae4062baef678d20dd9cf1704cdc69e9e78eea5faa435e4dffec06976ff73bd1e2ebd206658a26fb85a0911e2034eede31e7df2d7b87aa9700cf301b6b38502ba4db2b9723505455a7da0c6e0cf374b063921179d1bc69508f660bbb26d05ab16a2325716dbd0a733809cac36660d9a73ff0f61e09f55d1ff0652474130be7fcd2d37ebd1203960d788a1307fae48ec4e1042ab85f037a01bfd17f15725ee929d6e6246bbda00fe7105461ee873b0190c2f44692845e464949f909df46309a8eb72037278f792c87249897a0564d290bec1e09b2c9d3ad3011710fc4dcfabfa435611794dc7d1507b657229a2aab65ce2e789305d5d24ed955e89d8eb4f7e
 Ctrl.hexxcghash = hexxcghash:a6ef8e3102b16ce51b2a2fe17e8dc711a964c195ca4d597aabecce595187344ccb2ea37dc4cac0a77a47e7ea1b9055b1c9948e6e09793a9121f120b3bd07c5f2
 Ctrl.hexsession_id = hexsession_id:cc85cf95e29a5991306b21c1738de9a6612b8cb09f12b1738a4873c29f971e8d204aeb98bb7a7502cdab952eaaa6ec1e3a9655db3e5217afbff63ad588fbbf85
@@ -5220,7 +5221,7 @@ Ctrl.type = type:D
 Output = f2b6046d3439c50a9000a63909146abc
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100a82ae4062baef678d20dd9cf1704cdc69e9e78eea5faa435e4dffec06976ff73bd1e2ebd206658a26fb85a0911e2034eede31e7df2d7b87aa9700cf301b6b38502ba4db2b9723505455a7da0c6e0cf374b063921179d1bc69508f660bbb26d05ab16a2325716dbd0a733809cac36660d9a73ff0f61e09f55d1ff0652474130be7fcd2d37ebd1203960d788a1307fae48ec4e1042ab85f037a01bfd17f15725ee929d6e6246bbda00fe7105461ee873b0190c2f44692845e464949f909df46309a8eb72037278f792c87249897a0564d290bec1e09b2c9d3ad3011710fc4dcfabfa435611794dc7d1507b657229a2aab65ce2e789305d5d24ed955e89d8eb4f7e
 Ctrl.hexxcghash = hexxcghash:a6ef8e3102b16ce51b2a2fe17e8dc711a964c195ca4d597aabecce595187344ccb2ea37dc4cac0a77a47e7ea1b9055b1c9948e6e09793a9121f120b3bd07c5f2
 Ctrl.hexsession_id = hexsession_id:cc85cf95e29a5991306b21c1738de9a6612b8cb09f12b1738a4873c29f971e8d204aeb98bb7a7502cdab952eaaa6ec1e3a9655db3e5217afbff63ad588fbbf85
@@ -5228,7 +5229,7 @@ Ctrl.type = type:E
 Output = 70357486ca57c93418c6705b731b054bc41be03289c25a5ed29a937732807ae10a3604486c53d1f2431411808d87bfbaa6b25971fa2e4ec3719b5d2622aed2ff
 
 KDF = SSHKDF
-Ctrl.md = md:SHA512
+Ctrl.digest = digest:SHA512
 Ctrl.hexkey = hexkey:0000010100a82ae4062baef678d20dd9cf1704cdc69e9e78eea5faa435e4dffec06976ff73bd1e2ebd206658a26fb85a0911e2034eede31e7df2d7b87aa9700cf301b6b38502ba4db2b9723505455a7da0c6e0cf374b063921179d1bc69508f660bbb26d05ab16a2325716dbd0a733809cac36660d9a73ff0f61e09f55d1ff0652474130be7fcd2d37ebd1203960d788a1307fae48ec4e1042ab85f037a01bfd17f15725ee929d6e6246bbda00fe7105461ee873b0190c2f44692845e464949f909df46309a8eb72037278f792c87249897a0564d290bec1e09b2c9d3ad3011710fc4dcfabfa435611794dc7d1507b657229a2aab65ce2e789305d5d24ed955e89d8eb4f7e
 Ctrl.hexxcghash = hexxcghash:a6ef8e3102b16ce51b2a2fe17e8dc711a964c195ca4d597aabecce595187344ccb2ea37dc4cac0a77a47e7ea1b9055b1c9948e6e09793a9121f120b3bd07c5f2
 Ctrl.hexsession_id = hexsession_id:cc85cf95e29a5991306b21c1738de9a6612b8cb09f12b1738a4873c29f971e8d204aeb98bb7a7502cdab952eaaa6ec1e3a9655db3e5217afbff63ad588fbbf85
@@ -5238,7 +5239,7 @@ Output = 4e6428f7a87455bdef6026cdf68a2f6d93d6cda5145d6bca60ee4eb2d6248b399f6568c
 Title = SSHKDF test error conditions
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.type = type:A
@@ -5246,7 +5247,7 @@ Output = FF
 Result = KDF_DERIVE_ERROR
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.type = type:A
@@ -5254,7 +5255,7 @@ Output = FF
 Result = KDF_DERIVE_ERROR
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.type = type:A
@@ -5262,7 +5263,7 @@ Output = FF
 Result = KDF_DERIVE_ERROR
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -5270,7 +5271,7 @@ Output = FF
 Result = KDF_DERIVE_ERROR
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245
@@ -5279,7 +5280,7 @@ Output = FF
 Result = KDF_CTRL_ERROR
 
 KDF = SSHKDF
-Ctrl.md = md:SHA1
+Ctrl.digest = digest:SHA1
 Ctrl.hexkey = hexkey:0000008055bae931c07fd824bf10add1902b6fbc7c665347383498a686929ff5a25f8e40cb6645ea814fb1a5e0a11f852f86255641e5ed986e83a78bc8269480eac0b0dfd770cab92e7a28dd87ff452466d6ae867cead63b366b1c286e6c4811a9f14c27aea14c5171d49b78c06e3735d36e6a3be321dd5fc82308f34ee1cb17fba94a59
 Ctrl.hexxcghash = hexxcghash:a4ebd45934f56792b5112dcd75a1075fdc889245
 Ctrl.hexsession_id = hexsession_id:a4ebd45934f56792b5112dcd75a1075fdc889245


### PR DESCRIPTION
Conform to other modules which were changed at the last minute and this
discrepancy was not noticed.
Retain "md" as an alias so not to break 3rd party backports/tests scripts.

Depends on #8762 and #8774 

Need to change:
- [x] Merge #8762 
- [x] Merge #8774
- [x] 20-test_kdf.t after #8762 is merged
