### PR TITLE
Fix bug in entropy gathering.

### DIFF
--- a/crypto/rand/rand_crng_test.c
+++ b/crypto/rand/rand_crng_test.c
@@ -30,7 +30,7 @@ int rand_crngt_get_entropy_cb(unsigned char *buf)
     while ((n = rand_pool_acquire_entropy(crngt_pool)) != 0)
         if (n >= CRNGT_BUFSIZ) {
             p = rand_pool_detach(crngt_pool);
-            memcpy(crngt_prev, p, CRNGT_BUFSIZ);
+            memcpy(buf, p, CRNGT_BUFSIZ);
             rand_pool_reattach(crngt_pool, p);
             return 1;
         }


### PR DESCRIPTION
This only impacts FIPS mode or someone who has enabled the FIPS 140.2
4.9.2 Conditional Tests.  i.e. nobody currently.

Fix a significant issue in the entropy gathering for the continuous RNG
testing.  The impact is using an uninitialised buffer instead of the gathered
entropy.
