### PR TITLE
Digest stored entropy for CRNG test.

### DIFF
--- a/crypto/rand/rand_crng_test.c
+++ b/crypto/rand/rand_crng_test.c
@@ -27,15 +27,16 @@ int (*crngt_get_entropy)(unsigned char *, unsigned char *, unsigned int *)
 int rand_crngt_get_entropy_cb(unsigned char *buf, unsigned char *md,
                               unsigned int *md_size)
 {
-    int r;
+    int r, i;
     size_t n;
     unsigned char *p;
 
-    while ((n = rand_pool_acquire_entropy(crngt_pool)) != 0)
+    for (i = 0; i < 5 && (n = rand_pool_acquire_entropy(crngt_pool)) != 0; i++)
         if (n >= CRNGT_BUFSIZ) {
             p = rand_pool_detach(crngt_pool);
-            memcpy(buf, p, CRNGT_BUFSIZ);
             r = EVP_Digest(p, CRNGT_BUFSIZ, md, md_size, EVP_sha256(), NULL);
+            if (r != 0)
+                memcpy(buf, p, CRNGT_BUFSIZ);
             rand_pool_reattach(crngt_pool, p);
             return r;
         }

--- a/crypto/rand/rand_crng_test.c
+++ b/crypto/rand/rand_crng_test.c
@@ -27,19 +27,19 @@ int (*crngt_get_entropy)(unsigned char *, unsigned char *, unsigned int *)
 int rand_crngt_get_entropy_cb(unsigned char *buf, unsigned char *md,
                               unsigned int *md_size)
 {
-    int r, i;
+    int r;
     size_t n;
     unsigned char *p;
 
-    for (i = 0; i < 5 && (n = rand_pool_acquire_entropy(crngt_pool)) != 0; i++)
-        if (n >= CRNGT_BUFSIZ) {
-            p = rand_pool_detach(crngt_pool);
-            r = EVP_Digest(p, CRNGT_BUFSIZ, md, md_size, EVP_sha256(), NULL);
-            if (r != 0)
-                memcpy(buf, p, CRNGT_BUFSIZ);
-            rand_pool_reattach(crngt_pool, p);
-            return r;
-        }
+    n = rand_pool_acquire_entropy(crngt_pool);
+    if (n >= CRNGT_BUFSIZ) {
+        p = rand_pool_detach(crngt_pool);
+        r = EVP_Digest(p, CRNGT_BUFSIZ, md, md_size, EVP_sha256(), NULL);
+        if (r != 0)
+            memcpy(buf, p, CRNGT_BUFSIZ);
+        rand_pool_reattach(crngt_pool, p);
+        return r;
+    }
     return 0;
 }
 

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -334,8 +334,10 @@ int drbg_hmac_init(RAND_DRBG *drbg);
  * Entropy call back for the FIPS 140-2 section 4.9.2 Conditional Tests.
  * These need to be exposed for the unit tests.
  */
-int rand_crngt_get_entropy_cb(unsigned char *buf);
-extern int (*crngt_get_entropy)(unsigned char *);
+int rand_crngt_get_entropy_cb(unsigned char *buf, unsigned char *md,
+                              unsigned int *md_size);
+extern int (*crngt_get_entropy)(unsigned char *buf, unsigned char *md,
+                                unsigned int *md_size);
 int rand_crngt_init(void);
 void rand_crngt_cleanup(void);
 

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -1249,7 +1249,8 @@ static const size_t crngt_num_cases = 6;
 
 static size_t crngt_case, crngt_idx;
 
-static int crngt_entropy_cb(unsigned char *buf)
+static int crngt_entropy_cb(unsigned char *buf, unsigned char *md,
+                            unsigned int *md_size)
 {
     size_t i, z;
 
@@ -1261,7 +1262,7 @@ static int crngt_entropy_cb(unsigned char *buf)
         z--;
     for (i = 0; i < CRNGT_BUFSIZ; i++)
         buf[i] = (unsigned char)(i + 'A' + z);
-    return 1;
+    return EVP_Digest(buf, CRNGT_BUFSIZ, md, md_size, EVP_sha256(), NULL);
 }
 
 static int test_crngt(int n)


### PR DESCRIPTION
Digest stored entropy for CRNG test.

Via the FIPS lab, NIST confirmed:

> The CMVP had a chance to discuss this inquiry and we agree that hashing the NDRNG block does meet the spirit and letter of AS09.42.

> However, the CMVP did have a few questions: what hash algorithm would be used in this application? Is it approved? Is it CAVs tested?

SHA256 is being used here and it will be both approved and CAVs tested.

This means that no raw entropy needs to be kept between RNG seedings, preventing
a potential attack vector aganst the randomness source and the DRBG chains.

It also means the block of secure memory allocated for this purpose is no longer
required.


Based over #8789.

- [x] tests are added or updated
