### PR TITLE
Fix some KTLS issues

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -90,6 +90,10 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
 #     define TCP_ULP 31
 #    endif
 
+#    ifndef TLS_RX
+#     define TLS_RX                  2
+#    endif
+
 /*
  * When successful, this socket option doesn't change the behaviour of the
  * TCP socket, except changing the TCP setsockopt handler to enable the

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -152,13 +152,20 @@ extern "C" {
  * # define BIO_CTRL_CLEAR_KTLS_CTRL_MSG           75
  */
 
-#  define BIO_CTRL_GET_KTLS_SEND                 73
-#  define BIO_CTRL_GET_KTLS_RECV                 76
+# define BIO_CTRL_GET_KTLS_SEND                 73
+# define BIO_CTRL_GET_KTLS_RECV                 76
 
+# ifndef OPENSSL_NO_KTLS
 #  define BIO_get_ktls_send(b)         \
-     BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL)
+     (BIO_method_type(b) == BIO_TYPE_SOCKET \
+      && BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL))
 #  define BIO_get_ktls_recv(b)         \
-     BIO_ctrl(b, BIO_CTRL_GET_KTLS_RECV, 0, NULL)
+     (BIO_method_type(b) == BIO_TYPE_SOCKET \
+      && BIO_ctrl(b, BIO_CTRL_GET_KTLS_RECV, 0, NULL))
+# else
+#  define BIO_get_ktls_send(b)  (0)
+#  define BIO_get_ktls_recv(b)  (0)
+# endif
 
 /* modifiers */
 # define BIO_FP_READ             0x02

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -211,9 +211,9 @@ int ssl3_get_record(SSL *s)
                                SSL3_BUFFER_get_len(rbuf), 0,
                                num_recs == 0 ? 1 : 0, &n);
             if (rret <= 0) {
+#ifndef OPENSSL_NO_KTLS
                 if (!BIO_get_ktls_recv(s->rbio))
                     return rret;     /* error or non-blocking */
-#ifndef OPENSSL_NO_KTLS
                 switch (errno) {
                 case EBADMSG:
                     SSLfatal(s, SSL_AD_BAD_RECORD_MAC,
@@ -233,8 +233,8 @@ int ssl3_get_record(SSL *s)
                 default:
                     break;
                 }
-                return rret;
 #endif
+                return rret;
             }
             RECORD_LAYER_set_rstate(&s->rlayer, SSL_ST_READ_BODY);
 


### PR DESCRIPTION
This PR fixes a number of KTLS related issues:

- If the kernel headers are sufficiently recent to have KTLS transmit support, but not recent enough to have KTLS receive support then a compilation error would be the result.
- If we were using a different type of BIO than a socket BIO then BIO_get_ktls_send() and BIO_get_ktls_recv() could return the wrong result.
- The above occurred even if KTLS was disabled at compile time - so we should additionally ensure that those macros do nothing if KTLS is disabled.
- Finally we make the logic in ssl3_get_record() a little more robust when KTLS has been disabled.

This should fix the boringssl test failure. I am running this with extended tests to confirm. I expect the pyca and krb5 tests to continue to fail (I haven't looked at those issues yet).

[extended tests]