### PR TITLE
Fix RCFLAGS-related build issues on Windows

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -630,7 +630,7 @@ EOF
          my $res = platform->res($args{obj});
          return <<"EOF";
 $res: $deps
-	\$(RC) \$(RCOUTFLAG)\$\@ $srcs
+	\$(RC) \$(RCFLAGS) \$(RCOUTFLAG)\$\@ $srcs
 EOF
      }
      my $obj = platform->obj($args{obj});

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -206,6 +206,7 @@ AS={- $config{AS} -}
 ASFLAGS={- join(' ', @{$config{ASFLAGS}}) -}
 
 RC={- $config{RC} -}
+RCFLAGS={- join(' ', @{$config{RCFLAGS}}) -}
 
 ECHO="$(PERL)" "$(SRCDIR)\util\echo.pl"
 

--- a/Configure
+++ b/Configure
@@ -594,7 +594,7 @@ my %user = (
     PERL        => env('PERL') || ($^O ne "VMS" ? $^X : "perl"),
     RANLIB      => env('RANLIB'),
     RC          => env('RC') || env('WINDRES'),
-    RCFLAGS     => [],
+    RCFLAGS     => [ env('RCFLAGS') || () ],
     RM          => undef,
    );
 # Info about what "make variables" may be prefixed with the cross compiler

--- a/Configure
+++ b/Configure
@@ -611,6 +611,7 @@ my %useradd = (
     CXXFLAGS    => [],
     LDFLAGS     => [],
     LDLIBS      => [],
+    RCFLAGS     => [],
    );
 
 my %user_synonyms = (


### PR DESCRIPTION
Note: this PR is analogous to #8804 but applies to branch master instead of OpenSSL_1_1_1-stable

This PR addresses several problems with the Configure script encountered on Windows 10 with the VC-WIN64A-masm configuration and Visual Studio 2017.

* Most seriously, the RCFLAGS were not actually passed to the resource compiler
* To ease future usage, RCFLAGS can now be user-defined and set in custom configurations, an environment variable and as a RCFLAGS=... option to Configure.