### PR TITLE
(1.1.1-stable backport) Fix RCFLAGS-related build issues on Windows

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -187,6 +187,7 @@ AS={- $config{AS} -}
 ASFLAGS={- join(' ', @{$config{ASFLAGS}}) -}
 
 RC={- $config{RC} -}
+RCFLAGS={- join(' ', @{$config{RCFLAGS}}) -}
 
 ECHO="$(PERL)" "$(SRCDIR)\util\echo.pl"
 

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -586,7 +586,7 @@ EOF
      if ($srcs[0] =~ /\.rc$/) {
          return <<"EOF";
 $args{obj}: $deps
-	\$(RC) \$(RCOUTFLAG)\$\@ $srcs
+	\$(RC) \$(RCFLAGS) \$(RCOUTFLAG)\$\@ $srcs
 EOF
      }
      (my $obj = $args{obj}) =~ s|\.o$||;

--- a/Configure
+++ b/Configure
@@ -562,7 +562,7 @@ my %user = (
     PERL        => env('PERL') || ($^O ne "VMS" ? $^X : "perl"),
     RANLIB      => env('RANLIB'),
     RC          => env('RC') || env('WINDRES'),
-    RCFLAGS     => [],
+    RCFLAGS     => [ env('RCFLAGS') || () ],
     RM          => undef,
    );
 # Info about what "make variables" may be prefixed with the cross compiler

--- a/Configure
+++ b/Configure
@@ -579,6 +579,7 @@ my %useradd = (
     CXXFLAGS    => [],
     LDFLAGS     => [],
     LDLIBS      => [],
+    RCFLAGS     => [],
    );
 
 my %user_synonyms = (


### PR DESCRIPTION
Note: this PR is analogous to #8803 but applies to branch OpenSSL_1_1_1-stable instead of master

This PR addresses several problems with the Configure script encountered on Windows 10 with the VC-WIN64A-masm configuration and Visual Studio 2017.

* Most seriously, the RCFLAGS were not actually passed to the resource compiler
* To ease future usage, RCFLAGS can now be user-defined and set in custom configurations, an environment variable and as a RCFLAGS=... option to Configure.

CLA: trivial