### PR TITLE
Fix EVP_CIPHER_CTX_rand_key using wrong key_len

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -945,9 +945,12 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 
 int EVP_CIPHER_CTX_rand_key(EVP_CIPHER_CTX *ctx, unsigned char *key)
 {
+    int key_len;
+
     if (ctx->cipher->flags & EVP_CIPH_RAND_KEY)
         return EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_RAND_KEY, 0, key);
-    if (RAND_priv_bytes(key, ctx->key_len) <= 0)
+    key_len = EVP_CIPHER_CTX_key_length(ctx);
+    if (key_len <= 0 || RAND_priv_bytes(key, key_len) <= 0)
         return 0;
     return 1;
 }


### PR DESCRIPTION
with EVP_aes_256_cbc key_len appers to be 0, but was previously 32.