### PR TITLE
Enforce a strict output length check in CRYPTO_ccm128_tag

### DIFF
--- a/crypto/modes/ccm128.c
+++ b/crypto/modes/ccm128.c
@@ -425,7 +425,7 @@ size_t CRYPTO_ccm128_tag(CCM128_CONTEXT *ctx, unsigned char *tag, size_t len)
 
     M *= 2;
     M += 2;
-    if (len < M)
+    if (len != M)
         return 0;
     memcpy(tag, ctx->cmac.c, M);
     return M;


### PR DESCRIPTION
Return error if the output tag buffer size doesn't match
the tag size exactly. This prevents the caller from
using that portion of the tag buffer that remains
uninitialized after an otherwise succesfull call to
CRYPTO_ccm128_tag.

Bug found by OSS-Fuzz.

Fix suggested by Kurt Roeckx.

Signed-off-by: Guido Vranken <guidovranken@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
