### PR TITLE
Convert KDF lookups to sparse arrays

### DIFF
--- a/crypto/include/internal/sparse_array.h
+++ b/crypto/include/internal/sparse_array.h
@@ -19,7 +19,7 @@ extern "C" {
 
 # define SPARSE_ARRAY_OF(type) struct sparse_array_st_ ## type
 
-# define DEFINE_SPARSE_ARRAY_OF(type) \
+# define DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, ctype) \
     SPARSE_ARRAY_OF(type); \
     static ossl_unused ossl_inline SPARSE_ARRAY_OF(type) * \
         ossl_sa_##type##_new(void) \
@@ -53,17 +53,22 @@ extern "C" {
                                                 void *))leaf, \
                              arg); \
     } \
-    static ossl_unused ossl_inline type *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, \
+    static ossl_unused ossl_inline ctype *ossl_sa_##type##_get(const SPARSE_ARRAY_OF(type) *sa, \
                                                   ossl_uintmax_t n) \
     { \
         return (type *)OPENSSL_SA_get((OPENSSL_SA *)sa, n); \
     } \
     static ossl_unused ossl_inline int ossl_sa_##type##_set(SPARSE_ARRAY_OF(type) *sa, \
-                                                ossl_uintmax_t n, type *val) \
+                                                ossl_uintmax_t n, ctype *val) \
     { \
         return OPENSSL_SA_set((OPENSSL_SA *)sa, n, (void *)val); \
     } \
     SPARSE_ARRAY_OF(type)
+
+# define DEFINE_SPARSE_ARRAY_OF(type) \
+    DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, type)
+# define DEFINE_SPARSE_ARRAY_OF_CONST(type) \
+    DEFINE_SPARSE_ARRAY_OF_INTERNAL(type, const type)
 
 typedef struct sparse_array_st OPENSSL_SA;
 OPENSSL_SA *OPENSSL_SA_new(void);


### PR DESCRIPTION
Change the KDF internal lookup from a binary search to a sparse array implementation.

Not a significant change until applications are permitted to add their own KDF implementations, then the `bsearch` with auxiliary _user_ data structure that is present in other places can be avoided.
