### PR TITLE
FIPS: Fix compiler errors in rsa_chk.c when building with `-DFIPS_MODE`

### DIFF
--- a/crypto/rsa/rsa_chk.c
+++ b/crypto/rsa/rsa_chk.c
@@ -25,11 +25,9 @@ int RSA_check_key(const RSA *key)
 int RSA_check_key_ex(const RSA *key, BN_GENCB *cb)
 {
 #ifdef FIPS_MODE
-    if (!(rsa_sp800_56b_check_public(key)
-            && rsa_sp800_56b_check_private(key)
-            && rsa_sp800_56b_check_keypair(key, NULL, -1, RSA_bits(key))
-        return 0;
-
+    return rsa_sp800_56b_check_public(key)
+               && rsa_sp800_56b_check_private(key)
+               && rsa_sp800_56b_check_keypair(key, NULL, -1, RSA_bits(key));
 #else
     BIGNUM *i, *j, *k, *l, *m;
     BN_CTX *ctx;


### PR DESCRIPTION
~~This commit contains two fixes:~~

**Fix compiler error in rsa_chk.c**


This file currently does not compile with `-DFIPS_MODE`.

```make
~/src/openssl$ CFLAGS=-DFIPS_MODE perl ./Configure debug-linux-x86_64 enable-crypto-mdebug shared --strict-warnings --prefix=/opt/openssl-dev
~/src/openssl$ make

...

crypto/rsa/rsa_chk.c: In function 'RSA_check_key_ex':
crypto/rsa/rsa_chk.c:30:73: error: expected ')' before 'return'
             && rsa_sp800_56b_check_keypair(key, NULL, -1, RSA_bits(key))
                                                                         ^
                                                                         )
         return 0;
         ~~~~~~                                                           
crypto/rsa/rsa_chk.c:28:10: note: to match this '('
     if (!(rsa_sp800_56b_check_public(key)
          ^
crypto/rsa/rsa_chk.c:31:18: error: expected ')' before '}' token
         return 0;
                  ^
                  )
crypto/rsa/rsa_chk.c:242:1:
 }
 ~                 
crypto/rsa/rsa_chk.c:28:8: note: to match this '('
     if (!(rsa_sp800_56b_check_public(key)
        ^
crypto/rsa/rsa_chk.c:242:1: error: expected expression before '}' token
 }
 ^
crypto/rsa/rsa_chk.c:242:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:10742: crypto/rsa/libcrypto-lib-rsa_chk.o] Error 1
make[1]: Leaving directory '/home/msp/openssl/openssl'
make: *** [Makefile:165: all] Error 2
```

_Note: To my surprise it seems like it is broken since  July 5, 2018 (commit 8240d5fa653). But maybe it's because I configured it in a non-standard fashion by adding the `-DFIPS_MODE` flag explicitly?_

_I did this in order to take a look at the CRNG test (#8790), because I was unsure whether the FIPS provider implementation is already in a usable state and how it is configured properly._


**~~Temporarily disable bignum tests in FIPS mode~~**


~~This is only a temporary workaround until the todo from 9efa0ae0b60 is fixed.~~

~~To make the change more easily revertible, I used a separate `#ifndef FIPS_DISABLE_BIGNUM_TESTS` instead of `#ifndef FIPS_MODE`.~~

