### PR TITLE
Structure alignment macro.

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -15,6 +15,7 @@
 #include <assert.h>
 #include <openssl/aes.h>
 #include "internal/evp_int.h"
+#include "internal/cryptlib.h"
 #include "modes_lcl.h"
 #include <openssl/rand.h>
 #include <openssl/cmac.h>
@@ -22,7 +23,7 @@
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ks;
     block128_f block;
@@ -34,7 +35,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ks;                       /* AES key schedule to use */
     int key_set;                /* Set if key initialised */
@@ -52,7 +53,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ks1, ks2;                 /* AES key schedules to use */
     XTS128_CONTEXT xts;
@@ -64,7 +65,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ks;                       /* AES key schedule to use */
     int key_set;                /* Set if key initialised */
@@ -80,11 +81,11 @@ typedef struct {
 #ifndef OPENSSL_NO_OCB
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ksenc;                    /* AES key schedule to use for encryption */
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ksdec;                    /* AES key schedule to use for decryption */
     int key_set;                /* Set if key initialised */
@@ -1008,7 +1009,7 @@ const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         /*-
          * KM-AES parameter block - begin
          * (see z/Architecture Principles of Operation >= SA22-7832-06)
@@ -1023,7 +1024,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         /*-
          * KMO-AES parameter block - begin
          * (see z/Architecture Principles of Operation >= SA22-7832-08)
@@ -1041,7 +1042,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         /*-
          * KMF-AES parameter block - begin
          * (see z/Architecture Principles of Operation >= SA22-7832-08)
@@ -1059,7 +1060,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         /*-
          * KMA-GCM-AES parameter block - begin
          * (see z/Architecture Principles of Operation >= SA22-7832-11)
@@ -1108,7 +1109,7 @@ typedef struct {
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         /*-
          * Padding is chosen so that ccm.kmac_param.k overlaps with key.k and
          * ccm.fc with key.k.rounds. Remember that on s390x, an AES_KEY's
@@ -3853,7 +3854,7 @@ BLOCK_CIPHER_custom(NID_aes, 128, 1, 12, ccm, CCM,
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ks;
     /* Indicates if IV has been set */

--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2017, Oracle and/or its affiliates.  All rights reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
@@ -27,7 +27,7 @@ typedef struct {
 /* ARIA GCM context */
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         ARIA_KEY ks;
     } ks;                       /* ARIA subkey to use */
     int key_set;                /* Set if key initialised */
@@ -43,7 +43,7 @@ typedef struct {
 /* ARIA CCM context */
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         ARIA_KEY ks;
     } ks;                       /* ARIA key schedule to use */
     int key_set;                /* Set if key initialised */

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2015-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -20,7 +20,7 @@
 
 typedef struct {
     union {
-        double align;   /* this ensures even sizeof(EVP_CHACHA_KEY)%8==0 */
+        OSSL_UNION_ALIGN;  /* this ensures even sizeof(EVP_CHACHA_KEY)%8==0 */
         unsigned int d[CHACHA_KEY_SIZE / 4];
     } key;
     unsigned int  counter[CHACHA_CTR_SIZE / 4];

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -18,7 +18,7 @@
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         DES_key_schedule ks;
     } ks;
     union {

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -19,7 +19,7 @@
 
 typedef struct {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         DES_key_schedule ks[3];
     } ks;
     union {

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -41,6 +41,16 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
                                          __FILE__, __LINE__)
 
 #endif
+
+/*
+ * Use this inside a union with the field that needs to be aligned to a
+ * reasonable boundary for the platform.  The most pessimistic alignment
+ * of the listed types will be used by the compiler.
+ */
+# define OSSL_UNION_ALIGN       \
+    double align;               \
+    ossl_uintmax_t align_int;   \
+    void *align_ptr
 
 typedef struct ex_callback_st EX_CALLBACK;
 

--- a/providers/common/ciphers/ciphers_locl.h
+++ b/providers/common/ciphers/ciphers_locl.h
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
  *
@@ -9,12 +10,13 @@
 
 #include <openssl/aes.h>
 #include <openssl/modes.h>
+#include "internal/cryptlib.h"
 
 typedef struct prov_aes_cipher_st PROV_AES_CIPHER;
 
 typedef struct prov_aes_key_st {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         AES_KEY ks;
     } ks;
     block128_f block;
@@ -29,7 +31,7 @@ typedef struct prov_aes_key_st {
 #if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
         struct {
             union {
-                double align;
+                OSSL_UNION_ALIGN;
                 /*-
                  * KM-AES parameter block - begin
                  * (see z/Architecture Principles of Operation >= SA22-7832-06)

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2012-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -136,7 +136,7 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
                            size_t mac_secret_length, char is_sslv3)
 {
     union {
-        double align;
+        OSSL_UNION_ALIGN;
         unsigned char c[sizeof(LARGEST_DIGEST_CTX)];
     } md_state;
     void (*md_final_raw) (void *ctx, unsigned char *md_out);


### PR DESCRIPTION
Introduce a macro that allows all structure alignment tricks to be rolled up
into a single place.

The assumption is that double, uintmax_t and void * are currently sufficient to get _good_ alignment.

Public because proivider.

Fixes #8791 
