### PR TITLE
Replumbing: give the possibility for the provider to create a context

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -172,7 +172,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 
     ctx->digest = type;
     if (ctx->provctx == NULL) {
-        ctx->provctx = ctx->digest->newctx();
+        ctx->provctx = ctx->digest->newctx(ossl_provider_ctx(type->prov));
         if (ctx->provctx == NULL) {
             EVPerr(EVP_F_EVP_DIGESTINIT_EX, EVP_R_INITIALIZATION_ERROR);
             return 0;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -206,7 +206,7 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
 
     ctx->cipher = cipher;
     if (ctx->provctx == NULL) {
-        ctx->provctx = ctx->cipher->newctx();
+        ctx->provctx = ctx->cipher->newctx(ossl_provider_ctx(cipher->prov));
         if (ctx->provctx == NULL) {
             EVPerr(EVP_F_EVP_CIPHERINIT_EX, EVP_R_INITIALIZATION_ERROR);
             return 0;

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -5,7 +5,7 @@
 ossl_provider_find, ossl_provider_new, ossl_provider_upref,
 ossl_provider_free, ossl_provider_add_module_location,
 ossl_provider_set_fallback, ossl_provider_activate,
-ossl_provider_forall_loaded,
+ossl_provider_ctx, ossl_provider_forall_loaded,
 ossl_provider_name, ossl_provider_dso,
 ossl_provider_module_name, ossl_provider_module_path,
 ossl_provider_teardown, ossl_provider_get_param_types,
@@ -28,6 +28,9 @@ ossl_provider_get_params, ossl_provider_query_operation
 
  /* Load and initialize the Provider */
  int ossl_provider_activate(OSSL_PROVIDER *prov);
+
+ /* Return pointer to the provider's context */
+ void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
 
  /* Iterate over all loaded providers */
  int ossl_provider_forall_loaded(OPENSSL_CTX *,
@@ -120,6 +123,10 @@ will be located and loaded, then the symbol C<OSSL_provider_init> will
 be located in that module, and called.
 
 =back
+
+ossl_provider_ctx() returns a context created by the provider.
+Outside of the provider, it's completely opaque, but it needs to be
+passed back to some of the provider functions.
 
 ossl_provider_forall_loaded() iterates over all the currently
 "activated" providers, and calls C<cb> for each of them.

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -45,6 +45,9 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
  */
 int ossl_provider_activate(OSSL_PROVIDER *prov);
 
+/* Return pointer to the provider's context */
+void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
+
 /* Iterate over all loaded providers */
 int ossl_provider_forall_loaded(OPENSSL_CTX *,
                                 int (*cb)(OSSL_PROVIDER *provider,

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -157,10 +157,14 @@ struct ossl_param_st {
  * |in|         is the array of functions that the Core passes to the provider.
  * |out|        will be the array of base functions that the provider passes
  *              back to the Core.
+ * |provctx|    a provider side context object, optionally created if the
+ *              provider needs it.  This value is passed to other provider
+ *              functions, notably other context constructors.
  */
 typedef int (OSSL_provider_init_fn)(const OSSL_PROVIDER *provider,
                                     const OSSL_DISPATCH *in,
-                                    const OSSL_DISPATCH **out);
+                                    const OSSL_DISPATCH **out,
+                                    void **provctx);
 # ifdef __VMS
 #  pragma names save
 #  pragma names uppercase,truncated

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -60,17 +60,16 @@ OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024
-OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void))
+OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAM_TYPES  1025
 OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,
-                    provider_get_param_types,(const OSSL_PROVIDER *prov))
+                    provider_get_param_types,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAMS       1026
-OSSL_CORE_MAKE_FUNC(int,provider_get_params,(const OSSL_PROVIDER *prov,
+OSSL_CORE_MAKE_FUNC(int,provider_get_params,(void *provctx,
                                              const OSSL_PARAM params[]))
 # define OSSL_FUNC_PROVIDER_QUERY_OPERATION  1027
 OSSL_CORE_MAKE_FUNC(const OSSL_ALGORITHM *,provider_query_operation,
-                    (const OSSL_PROVIDER *, int operation_id,
-                     const int *no_store))
+                    (void *provctx, int operation_id, const int *no_store))
 
 /* Digests */
 
@@ -87,19 +86,20 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ALGORITHM *,provider_query_operation,
 # define OSSL_FUNC_DIGEST_BLOCK_SIZE        9
 
 
-OSSL_CORE_MAKE_FUNC(void *, OP_digest_newctx, (void))
-OSSL_CORE_MAKE_FUNC(int, OP_digest_init, (void *vctx))
+OSSL_CORE_MAKE_FUNC(void *, OP_digest_newctx, (void *provctx))
+OSSL_CORE_MAKE_FUNC(int, OP_digest_init, (void *dctx))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_update,
-                    (void *, const unsigned char *in, size_t inl))
+                    (void *dctx, const unsigned char *in, size_t inl))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_final,
-                    (void *, unsigned char *out, size_t *outl, size_t outsz))
+                    (void *dctx,
+                     unsigned char *out, size_t *outl, size_t outsz))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_digest,
-                    (const unsigned char *in, size_t inl, unsigned char *out,
-                     size_t *out_l, size_t outsz))
+                    (void *provctx, const unsigned char *in, size_t inl,
+                     unsigned char *out, size_t *out_l, size_t outsz))
 
-OSSL_CORE_MAKE_FUNC(void, OP_digest_cleanctx, (void *vctx))
-OSSL_CORE_MAKE_FUNC(void, OP_digest_freectx, (void *vctx))
-OSSL_CORE_MAKE_FUNC(void *, OP_digest_dupctx, (void *vctx))
+OSSL_CORE_MAKE_FUNC(void, OP_digest_cleanctx, (void *dctx))
+OSSL_CORE_MAKE_FUNC(void, OP_digest_freectx, (void *dctx))
+OSSL_CORE_MAKE_FUNC(void *, OP_digest_dupctx, (void *dctx))
 OSSL_CORE_MAKE_FUNC(size_t, OP_digest_size, (void))
 OSSL_CORE_MAKE_FUNC(size_t, OP_digest_block_size, (void))
 
@@ -123,35 +123,37 @@ OSSL_CORE_MAKE_FUNC(size_t, OP_digest_block_size, (void))
 # define OSSL_FUNC_CIPHER_CTX_GET_PARAMS            13
 # define OSSL_FUNC_CIPHER_CTX_SET_PARAMS            14
 
-OSSL_CORE_MAKE_FUNC(void *, OP_cipher_newctx, (void))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_encrypt_init, (void *vctx,
+OSSL_CORE_MAKE_FUNC(void *, OP_cipher_newctx, (void *provctx))
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_encrypt_init, (void *cctx,
                                                   const unsigned char *key,
                                                   size_t keylen,
                                                   const unsigned char *iv,
                                                   size_t ivlen))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_decrypt_init, (void *vctx,
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_decrypt_init, (void *cctx,
                                                   const unsigned char *key,
                                                   size_t keylen,
                                                   const unsigned char *iv,
                                                   size_t ivlen))
 OSSL_CORE_MAKE_FUNC(int, OP_cipher_update,
-                    (void *, unsigned char *out, size_t *outl, size_t outsize,
-                     const unsigned char *in, size_t inl))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_final,
-                    (void *, unsigned char *out, size_t *outl, size_t outsize))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_cipher,
-                    (void *,
+                    (void *cctx,
                      unsigned char *out, size_t *outl, size_t outsize,
                      const unsigned char *in, size_t inl))
-OSSL_CORE_MAKE_FUNC(void, OP_cipher_freectx, (void *vctx))
-OSSL_CORE_MAKE_FUNC(void *, OP_cipher_dupctx, (void *vctx))
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_final,
+                    (void *cctx,
+                     unsigned char *out, size_t *outl, size_t outsize))
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_cipher,
+                    (void *cctx,
+                     unsigned char *out, size_t *outl, size_t outsize,
+                     const unsigned char *in, size_t inl))
+OSSL_CORE_MAKE_FUNC(void, OP_cipher_freectx, (void *cctx))
+OSSL_CORE_MAKE_FUNC(void *, OP_cipher_dupctx, (void *cctx))
 OSSL_CORE_MAKE_FUNC(size_t, OP_cipher_key_length, (void))
 OSSL_CORE_MAKE_FUNC(size_t, OP_cipher_iv_length, (void))
 OSSL_CORE_MAKE_FUNC(size_t, OP_cipher_block_size, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_cipher_get_params, (const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_ctx_get_params, (void *vctx,
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_ctx_get_params, (void *cctx,
                                                     const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_ctx_set_params, (void *vctx,
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_ctx_set_params, (void *cctx,
                                                     const OSSL_PARAM params[]))
 
 

--- a/providers/common/ciphers/aes.c
+++ b/providers/common/ciphers/aes.c
@@ -270,7 +270,7 @@ static int aes_cipher(void *vctx,
 
 #define IMPLEMENT_new_ctx(lcmode, UCMODE, len) \
     static OSSL_OP_cipher_newctx_fn aes_##len##_##lcmode##_newctx; \
-    static void *aes_##len##_##lcmode##_newctx(void) \
+    static void *aes_##len##_##lcmode##_newctx(void *provctx) \
     { \
         PROV_AES_KEY *ctx = OPENSSL_zalloc(sizeof(*ctx)); \
     \

--- a/providers/common/digests/sha2.c
+++ b/providers/common/digests/sha2.c
@@ -40,7 +40,7 @@ static int sha256_final(void *ctx,
     return 0;
 }
 
-static void *sha256_newctx(void)
+static void *sha256_newctx(void *provctx)
 {
     SHA256_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -106,7 +106,8 @@ OSSL_provider_init_fn ossl_default_provider_init;
 
 int ossl_default_provider_init(const OSSL_PROVIDER *provider,
                                const OSSL_DISPATCH *in,
-                               const OSSL_DISPATCH **out)
+                               const OSSL_DISPATCH **out,
+                               void **provctx)
 {
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -78,7 +78,8 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
 
 int OSSL_provider_init(const OSSL_PROVIDER *provider,
                        const OSSL_DISPATCH *in,
-                       const OSSL_DISPATCH **out)
+                       const OSSL_DISPATCH **out,
+                       void **provctx)
 {
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -80,7 +80,8 @@ static const OSSL_DISPATCH legacy_dispatch_table[] = {
 
 int OSSL_provider_init(const OSSL_PROVIDER *provider,
                        const OSSL_DISPATCH *in,
-                       const OSSL_DISPATCH **out)
+                       const OSSL_DISPATCH **out,
+                       void **provctx)
 {
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {


### PR DESCRIPTION
OSSL_provider_init() gets another output parameter, holding a pointer
to a provider side context.  It's entirely up to the provider to
define the context and what it's being used for.  This pointer is
passed back to other provider functions, typically the provider global
get_params and set_params functions, and also the diverse algorithm
context creators, and of course, the teardown function.

With this, a provider can be instantiated more than once, or be
re-loaded as the case may be, while maintaining instance state.
