### PR TITLE
Replumbing: make the oneshot proider cipher function like the others

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -232,8 +232,14 @@ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                const unsigned char *in, unsigned int inl)
 {
     if (ctx->cipher->prov != NULL) {
+        size_t outl = 0;         /* ignored */
+        int blocksize = EVP_CIPHER_CTX_block_size(ctx);
+
         if (ctx->cipher->ccipher != NULL)
-            return ctx->cipher->ccipher(ctx->provctx, out, in, (size_t)inl);
+            return
+                ctx->cipher->ccipher(ctx->provctx, out, &outl,
+                                     inl + (blocksize == 1 ? 0 : blocksize),
+                                     in, (size_t)inl);
         return 0;
     }
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -140,8 +140,9 @@ OSSL_CORE_MAKE_FUNC(int, OP_cipher_update,
 OSSL_CORE_MAKE_FUNC(int, OP_cipher_final,
                     (void *, unsigned char *out, size_t *outl, size_t outsize))
 OSSL_CORE_MAKE_FUNC(int, OP_cipher_cipher,
-                    (void *, unsigned char *out, const unsigned char *in,
-                     size_t inl))
+                    (void *,
+                     unsigned char *out, size_t *outl, size_t outsize,
+                     const unsigned char *in, size_t inl))
 OSSL_CORE_MAKE_FUNC(void, OP_cipher_freectx, (void *vctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_cipher_dupctx, (void *vctx))
 OSSL_CORE_MAKE_FUNC(size_t, OP_cipher_key_length, (void))

--- a/providers/common/ciphers/aes.c
+++ b/providers/common/ciphers/aes.c
@@ -235,16 +235,23 @@ static int aes_stream_final(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-static int aes_cipher(void *vctx, unsigned char *out, const unsigned char *in,
-                      size_t inl)
+static int aes_cipher(void *vctx,
+                      unsigned char *out, size_t *outl, size_t outsize,
+                      const unsigned char *in, size_t inl)
 {
     PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
+
+    if (outsize < inl) {
+        PROVerr(PROV_F_AES_CIPHER, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+        return 0;
+    }
 
     if (!ctx->ciph->cipher(ctx, out, in, inl)) {
         PROVerr(PROV_F_AES_CIPHER, PROV_R_CIPHER_OPERATION_FAILED);
         return 0;
     }
 
+    *outl = inl;
     return 1;
 }
 


### PR DESCRIPTION
The OP_cipher_final function takes a return output size and an output
buffer size argument.  The oneshot OP_cipher_cipher function should do
the same.
