### PR TITLE
WIP: Use upcalls for malloc/exdata

### DIFF
--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -57,7 +57,7 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,
 # define OSSL_FUNC_CORE_GET_PARAMS             2
 OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
                                          const OSSL_PARAM params[]))
-# define OSSL_FUNC_PROVIDER_EXDATA_NEW         3
+# define OSSL_FUNC_CORE_EXDATA_NEW             3
 # ifdef HEADER_CRYPTO_H
 OSSL_CORE_MAKE_FUNC(int, core_get_exdata_index,
         (int class_index, long argl, void *argp,

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -57,6 +57,13 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,
 # define OSSL_FUNC_CORE_GET_PARAMS             2
 OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
                                          const OSSL_PARAM params[]))
+# define OSSL_FUNC_PROVIDER_EXDATA_NEW         3
+# ifdef HEADER_CRYPTO_H
+OSSL_CORE_MAKE_FUNC(int, core_get_exdata_index,
+        (int class_index, long argl, void *argp,
+         CRYPTO_EX_new *new_func, CRYPTO_EX_dup *dup_func,
+         CRYPTO_EX_free *free_func))
+# endif
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -188,6 +188,7 @@ typedef int CRYPTO_EX_dup (CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
 __owur int CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
                             CRYPTO_EX_new *new_func, CRYPTO_EX_dup *dup_func,
                             CRYPTO_EX_free *free_func);
+
 /* No longer use an index. */
 int CRYPTO_free_ex_index(int class_index, int idx);
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -117,7 +117,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);
             break;
-        case OSSL_FUNC_PROVIDER_EXDATA_NEW:
+        case OSSL_FUNC_CORE_EXDATA_NEW:
             c_get_exdata_index = OSSL_get_core_get_exdata_index(in);
             break;
         /* Just ignore anything we don't understand */


### PR DESCRIPTION
An upcall is when a provider calls up (back) to the core for some
functionality.  This commit adds the ex_data and malloc.

---

This shows how we can add whatever the FIPS module needs by calling back to the core for various services. It avoids having to include ex_data, crypto_malloc, secure_malloc, etc., in the provider, which means that complex initialization interactions between modules and the core aren't necessary and things like adding ex_data into a module aren't needed either.

IT's a WIP because I didn't make the FIPS module actually link, and I didn't add the dozen function typedef's in a public place.  Thoughts on where to do the latter?