### PR TITLE
Test: use keywords instead of magic numbers for 'rsa_pss_saltlen'

### DIFF
--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -20,14 +20,14 @@ plan tests => 5;
 
 #using test/testrsa.pem which happens to be a 512 bit RSA
 ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha1',
-            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:max',
             '-sigopt', 'rsa_mgf1_md:sha512', '-out', 'testrsapss.sig',
             srctop_file('test', 'testrsa.pem')])),
    "openssl dgst -sign");
 
 with({ exit_checker => sub { return shift == 1; } },
      sub { ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha512',
-                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:max',
                        '-sigopt', 'rsa_mgf1_md:sha512', srctop_file('test', 'testrsa.pem')])),
               "openssl dgst -sign, expect to fail gracefully");
            ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha512',
@@ -35,14 +35,14 @@ with({ exit_checker => sub { return shift == 1; } },
                        '-sigopt', 'rsa_mgf1_md:sha1', srctop_file('test', 'testrsa.pem')])),
               "openssl dgst -sign, expect to fail gracefully");
            ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), '-sha512',
-                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+                       '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:max',
                        '-sigopt', 'rsa_mgf1_md:sha512', '-signature', 'testrsapss.sig',
                        srctop_file('test', 'testrsa.pem')])),
               "openssl dgst -prverify, expect to fail gracefully");
          });
 
 ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'), '-sha1',
-            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-3',
+            '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:max',
             '-sigopt', 'rsa_mgf1_md:sha512', '-signature', 'testrsapss.sig',
             srctop_file('test', 'testrsa.pem')])),
    "openssl dgst -prverify");

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -324,10 +324,10 @@ my @smime_cms_param_tests = (
 	"-CAfile", catfile($smdir, "smroot.pem"), "-out", "smtst.txt" ]
     ],
 
-    [ "signed content test streaming PEM format, RSA keys, PSS signature, saltlen=-3",
+    [ "signed content test streaming PEM format, RSA keys, PSS signature, saltlen=max",
       [ "-sign", "-in", $smcont, "-outform", "PEM", "-nodetach",
 	"-signer", catfile($smdir, "smrsa1.pem"), "-keyopt", "rsa_padding_mode:pss",
-	"-keyopt", "rsa_pss_saltlen:-3", "-out", "test.cms" ],
+	"-keyopt", "rsa_pss_saltlen:max", "-out", "test.cms" ],
       [ "-verify", "-in", "test.cms", "-inform", "PEM",
 	"-CAfile", catfile($smdir, "smroot.pem"), "-out", "smtst.txt" ]
     ],


### PR DESCRIPTION
Since commit 137096a7ead it is possible to specify keywords instead
of negative magic numbers for the salt length. This commit replaces
the remaining occurrences of `rsa_pss_saltlen:-3` in the test recipes
by `rsa_pss_saltlen:max`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
