### PR TITLE
openssl cms: add error message if operation option is missing

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -640,6 +640,7 @@ int cms_main(int argc, char **argv)
             goto opthelp;
         }
     } else if (!operation) {
+        BIO_printf(bio_err, "No operation option (-encrypt|-decrypt|-sign|-verify|...) specified.\n");
         goto opthelp;
     }
 


### PR DESCRIPTION
If the `openssl cms` command is called without specifying an operation, it replies with the following laconic error message:

```
cms: Use -help for summary.
```
This commit adds a helpful error message:

```
No operation option (-encrypt|-decrypt|-sign|-verify|...) specified.
```