### PR TITLE
EVP_EncryptUpdate, EVP_EncryptFinal_ex: don't branch on uninitialized memory

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -587,11 +587,14 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                                inl + (blocksize == 1 ? 0 : blocksize), in,
                                (size_t)inl);
 
-    if (soutl > INT_MAX) {
-        EVPerr(EVP_F_EVP_ENCRYPTUPDATE, EVP_R_UPDATE_ERROR);
-        return 0;
+    if (ret) {
+        if (soutl > INT_MAX) {
+            EVPerr(EVP_F_EVP_ENCRYPTUPDATE, EVP_R_UPDATE_ERROR);
+            return 0;
+        }
+        *outl = soutl;
     }
-    *outl = soutl;
+
     return ret;
 
     /* TODO(3.0): Remove legacy code below */
@@ -633,11 +636,13 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
     ret = ctx->cipher->cfinal(ctx->provctx, out, &soutl,
                               blocksize == 1 ? 0 : blocksize);
 
-    if (soutl > INT_MAX) {
-        EVPerr(EVP_F_EVP_ENCRYPTFINAL_EX, EVP_R_FINAL_ERROR);
-        return 0;
+    if (ret) {
+        if (soutl > INT_MAX) {
+            EVPerr(EVP_F_EVP_ENCRYPTFINAL_EX, EVP_R_FINAL_ERROR);
+            return 0;
+        }
+        *outl = soutl;
     }
-    *outl = soutl;
 
     return ret;
 


### PR DESCRIPTION
If ctx->cipher->cupdate/ctx->cipher->cfinal failed, 'soutl' is left
uninitialized.

This patch incorporates the same logic as present in EVP_DecryptUpdate and
EVP_DecryptFinal_ex: only branch on 'soutl' if the preceding call succeeded.

Bug found by OSS-Fuzz.

Signed-off-by: Guido Vranken <guidovranken@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
