### PR TITLE
Create a generic number ↔ name and let EVP use it

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -10,7 +10,7 @@ SUBDIRS=objects buffer bio stack lhash rand evp asn1 pem x509 x509v3 conf \
 LIBS=../libcrypto
 # The Core
 SOURCE[../libcrypto]=provider_core.c provider_predefined.c provider_conf.c \
-        core_fetch.c
+        core_fetch.c core_namemap.c
 
 # Central utilities
 SOURCE[../libcrypto]=\

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -56,14 +56,14 @@ static int ossl_method_construct_this(OSSL_PROVIDER *provider, void *cbdata)
              * If we haven't been told not to store,
              * add to the global store
              */
-            data->mcm->put(data->libctx, NULL,
-                           thismap->property_definition,
-                           method, data->mcm_data);
+            data->mcm->put(data->libctx, NULL, method,
+                           thismap->algorithm_name,
+                           thismap->property_definition, data->mcm_data);
         }
 
-        data->mcm->put(data->libctx, data->store,
-                       thismap->property_definition,
-                       method, data->mcm_data);
+        data->mcm->put(data->libctx, data->store, method,
+                       thismap->algorithm_name, thismap->property_definition,
+                       data->mcm_data);
 
         /* refcnt-- because we're dropping the reference */
         data->mcm->destruct(method, data->mcm_data);
@@ -79,7 +79,8 @@ void *ossl_method_construct(OPENSSL_CTX *libctx, int operation_id,
 {
     void *method = NULL;
 
-    if ((method = mcm->get(libctx, NULL, propquery, mcm_data)) == NULL) {
+    if ((method =
+         mcm->get(libctx, NULL, name, propquery, mcm_data)) == NULL) {
         struct construct_data_st cbdata;
 
         /*
@@ -97,7 +98,7 @@ void *ossl_method_construct(OPENSSL_CTX *libctx, int operation_id,
         ossl_provider_forall_loaded(libctx, ossl_method_construct_this,
                                     &cbdata);
 
-        method = mcm->get(libctx, cbdata.store, propquery, mcm_data);
+        method = mcm->get(libctx, cbdata.store, name, propquery, mcm_data);
         mcm->dealloc_tmp_store(cbdata.store);
     }
 

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -55,9 +55,8 @@ static void *stored_namemap_new(OPENSSL_CTX *libctx)
 {
     OSSL_NAMEMAP *namemap = ossl_namemap_new();
 
-    if (namemap != NULL) {
+    if (namemap != NULL)
         namemap->stored = 1;
-    }
 
     return namemap;
 }
@@ -66,7 +65,7 @@ static void stored_namemap_free(void *vnamemap)
 {
     OSSL_NAMEMAP *namemap = vnamemap;
 
-    /* Pretend it's stored, or ossl_namemap_free() will do nothing */
+    /* Pretend it isn't stored, or ossl_namemap_free() will do nothing */
     namemap->stored = 0;
     ossl_namemap_free(namemap);
 }
@@ -93,7 +92,6 @@ OSSL_NAMEMAP *ossl_namemap_new(void)
         && (namemap->numname = sk_NAMEMAP_ENTRY_new_null()) != NULL
         && (namemap->namenum =
             lh_NAMEMAP_ENTRY_new(namemap_hash, namemap_cmp)) != NULL) {
-        namemap->stored = 0;
         return namemap;
     }
 

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -119,17 +119,18 @@ void ossl_namemap_free(OSSL_NAMEMAP *namemap)
  * general reason why the same string wouldn't result in the same number
  * within a unit...
  *
- * This isn't currently possible because of FIPS module constraints, so
- * we currently disable the code that would allow it.
+ * This isn't currently possible in the FIPS module because if init and
+ * cleanup constraints, so we currently disable the code that would allow
+ * it when FIPS_MODE is defined.
  */
 
 const char *ossl_namemap_name(const OSSL_NAMEMAP *namemap, int number)
 {
     NAMEMAP_ENTRY *entry;
 
-#if 0                            /* TODO(3.0) */
+#ifndef FIPS_MODE
     if (namemap == NULL)
-        namemap = default_namemap();
+        namemap = ossl_namemap_stored(NULL);
 #endif
 
     if (namemap == NULL || number == 0)
@@ -148,7 +149,7 @@ int ossl_namemap_number(const OSSL_NAMEMAP *namemap, const char *name)
 {
     NAMEMAP_ENTRY *entry, template;
 
-#if 0                            /* TODO(3.0) */
+#ifndef FIPS_MODE
     if (namemap == NULL)
         namemap = default_namemap();
 #endif
@@ -172,7 +173,7 @@ int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name)
     NAMEMAP_ENTRY *entry;
     int number;
 
-#if 0                            /* TODO(3.0) */
+#ifndef FIPS_MODE
     if (namemap == NULL)
         namemap = default_namemap();
 #endif

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -145,8 +145,8 @@ int ossl_namemap_new(OPENSSL_CTX *libctx, const char *name)
     if (name == NULL || store == NULL)
         return 0;
 
-    if (ossl_namemap_number(libctx, name) != 0)
-        return 1;                /* Pretend success */
+    if ((number = ossl_namemap_number(libctx, name)) != 0)
+        return number;           /* Pretend success */
 
     if ((entry = OPENSSL_zalloc(sizeof(*entry) + strlen(name))) == NULL)
         goto err;

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/namemap.h"
+#include <openssl/lhash.h>
+#include <openssl/safestack.h>
+
+typedef struct {
+    int number;
+    const char *name;
+    char body[1];        /* Sized appropriately to contain the name */
+} NAMEMAP;
+
+DEFINE_LHASH_OF(NAMEMAP);
+DEFINE_STACK_OF(NAMEMAP)
+
+/* LHASH callbacks */
+
+static unsigned long namemap_hash(const NAMEMAP *n)
+{
+    return OPENSSL_LH_strhash(n->name);
+}
+
+static int namemap_cmp(const NAMEMAP *a, const NAMEMAP *b)
+{
+    return strcmp(a->name, b->name);
+}
+
+static void namemap_free(NAMEMAP *n)
+{
+    OPENSSL_free(n);
+}
+
+/* The store, which provides for bidirectional indexing */
+
+typedef struct {
+    LHASH_OF(NAMEMAP) *namenum;  /* Name->number mapping */
+    STACK_OF(NAMEMAP) *numname;  /* Number->name mapping */
+} NAMEMAP_STORE;
+
+/* OPENSSL_CTX_METHOD functions */
+
+static void namemap_store_free(void *vstore)
+{
+    NAMEMAP_STORE *store = vstore;
+
+    if (store != NULL)
+        return;
+
+     /* The elements will be freed by sk_NAMEMAP_pop_free() */
+    lh_NAMEMAP_free(store->namenum);
+
+    sk_NAMEMAP_pop_free(store->numname, namemap_free);
+
+    OPENSSL_free(store);
+}
+
+static void *namemap_store_new(OPENSSL_CTX *ctx)
+{
+    NAMEMAP_STORE *store;
+
+    if ((store = OPENSSL_zalloc(sizeof(*store))) != NULL
+        && (store->numname = sk_NAMEMAP_new_null()) != NULL
+        && (store->namenum = lh_NAMEMAP_new(namemap_hash,
+                                            namemap_cmp)) != NULL)
+        return store;
+
+    namemap_store_free(store);
+    return NULL;
+}
+
+static const OPENSSL_CTX_METHOD namemap_store_method = {
+    namemap_store_new,
+    namemap_store_free,
+};
+
+/* Store getter */
+
+static NAMEMAP_STORE *namemap_store(OPENSSL_CTX *libctx)
+{
+    return openssl_ctx_get_data(libctx, OPENSSL_CTX_NAMEMAP_INDEX,
+                                &namemap_store_method);
+}
+
+const char *ossl_namemap_name(OPENSSL_CTX *libctx, int number)
+{
+    NAMEMAP_STORE *store = namemap_store(libctx);
+    NAMEMAP *entry;
+
+    if (store == NULL || number == 0)
+        return NULL;
+
+    entry = sk_NAMEMAP_value(store->numname, number);
+
+    if (entry != NULL)
+        return entry->name;
+    return NULL;
+}
+
+int ossl_namemap_number(OPENSSL_CTX *libctx, const char *name)
+{
+    NAMEMAP_STORE *store = namemap_store(libctx);
+    NAMEMAP *entry, template;
+
+    if (store == NULL)
+        return 0;
+
+    template.name = name;
+    entry = lh_NAMEMAP_retrieve(store->namenum, &template);
+    if (entry == NULL)
+        return 0;
+
+    return entry->number;
+}
+
+int ossl_namemap_new(OPENSSL_CTX *libctx, const char *name)
+{
+    NAMEMAP_STORE *store = namemap_store(libctx);
+    NAMEMAP *entry;
+
+    if (name == NULL || store == NULL)
+        return 0;
+
+    if (ossl_namemap_number(libctx, name) != 0)
+        return 1;                /* Pretend success */
+
+    if ((entry = OPENSSL_zalloc(sizeof(*entry) + strlen(name))) == NULL)
+        goto err;
+
+    strcpy(entry->body, name);
+    entry->name = entry->body;
+    entry->number = sk_NAMEMAP_push(store->numname, entry);
+
+    if (entry->number == 0)
+        goto err;
+
+    (void)lh_NAMEMAP_insert(store->namenum, entry);
+    if (lh_NAMEMAP_error(store->namenum))
+        goto err;
+
+    return entry->number;
+
+ err:
+    if (entry != NULL) {
+        if (entry->number != 0)
+            (void)sk_NAMEMAP_pop(store->numname);
+        lh_NAMEMAP_delete(store->namenum, entry);
+    }
+    return 0;
+}

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -11,124 +11,157 @@
 #include <openssl/lhash.h>
 #include <openssl/safestack.h>
 
+/* The namemap entry */
 typedef struct {
     int number;
     const char *name;
     char body[1];        /* Sized appropriately to contain the name */
-} NAMEMAP;
+} NAMEMAP_ENTRY;
 
-DEFINE_LHASH_OF(NAMEMAP);
-DEFINE_STACK_OF(NAMEMAP)
+DEFINE_LHASH_OF(NAMEMAP_ENTRY);
+DEFINE_STACK_OF(NAMEMAP_ENTRY)
+
+/* The namemap, which provides for bidirectional indexing */
+
+struct ossl_namemap_st {
+    /* Flags */
+    unsigned int floating:1; /* If 0, it's stored in a library context */
+
+    CRYPTO_RWLOCK *lock;
+    LHASH_OF(NAMEMAP_ENTRY) *namenum;  /* Name->number mapping */
+    STACK_OF(NAMEMAP_ENTRY) *numname;  /* Number->name mapping */
+};
 
 /* LHASH callbacks */
 
-static unsigned long namemap_hash(const NAMEMAP *n)
+static unsigned long namemap_hash(const NAMEMAP_ENTRY *n)
 {
     return OPENSSL_LH_strhash(n->name);
 }
 
-static int namemap_cmp(const NAMEMAP *a, const NAMEMAP *b)
+static int namemap_cmp(const NAMEMAP_ENTRY *a, const NAMEMAP_ENTRY *b)
 {
     return strcmp(a->name, b->name);
 }
 
-static void namemap_free(NAMEMAP *n)
+static void namemap_free(NAMEMAP_ENTRY *n)
 {
     OPENSSL_free(n);
 }
 
-/* The store, which provides for bidirectional indexing */
+/* OPENSSL_CTX_METHOD functions for a namemap stored in a library context */
 
-typedef struct {
-    CRYPTO_RWLOCK *lock;
-    LHASH_OF(NAMEMAP) *namenum;  /* Name->number mapping */
-    STACK_OF(NAMEMAP) *numname;  /* Number->name mapping */
-} NAMEMAP_STORE;
-
-/* OPENSSL_CTX_METHOD functions */
-
-static void namemap_store_free(void *vstore)
+static void *stored_namemap_new(OPENSSL_CTX *libctx)
 {
-    NAMEMAP_STORE *store = vstore;
+    OSSL_NAMEMAP *namemap = ossl_namemap_new();
 
-    if (store != NULL)
-        return;
+    if (namemap != NULL) {
+        namemap->floating = 0;
+    }
 
-     /* The elements will be freed by sk_NAMEMAP_pop_free() */
-    lh_NAMEMAP_free(store->namenum);
-
-    sk_NAMEMAP_pop_free(store->numname, namemap_free);
-
-    CRYPTO_THREAD_lock_free(store->lock);
-    OPENSSL_free(store);
+    return namemap;
 }
 
-static void *namemap_store_new(OPENSSL_CTX *ctx)
+static void stored_namemap_free(void *vnamemap)
 {
-    NAMEMAP_STORE *store;
+    OSSL_NAMEMAP *namemap = vnamemap;
 
-    if ((store = OPENSSL_zalloc(sizeof(*store))) != NULL
-        && (store->lock = CRYPTO_THREAD_lock_new()) != NULL
-        && (store->numname = sk_NAMEMAP_new_null()) != NULL
-        && (store->namenum = lh_NAMEMAP_new(namemap_hash,
-                                            namemap_cmp)) != NULL)
-        return store;
-
-    namemap_store_free(store);
-    return NULL;
+    /* Pretend it's floating, or ossl_namemap_free() will do nothing */
+    namemap->floating = 1;
+    ossl_namemap_free(namemap);
 }
 
-static const OPENSSL_CTX_METHOD namemap_store_method = {
-    namemap_store_new,
-    namemap_store_free,
+static const OPENSSL_CTX_METHOD stored_namemap_method = {
+    stored_namemap_new,
+    stored_namemap_free,
 };
-
-/* Store getter */
-
-static NAMEMAP_STORE *namemap_store(OPENSSL_CTX *libctx)
-{
-    /*
-     * TODO(3.0): Figure out a way to always have this in the default
-     * library context no matter what.  There's no reason why the same
-     * string wouldn't result in the same number within a unit...
-     * However, this forces the default library context to always exist,
-     * and that's currently not always possible.
-     */
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_NAMEMAP_INDEX,
-                                &namemap_store_method);
-}
 
 /* API functions */
 
-const char *ossl_namemap_name(OPENSSL_CTX *libctx, int number)
+OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx)
 {
-    NAMEMAP_STORE *store = namemap_store(libctx);
-    NAMEMAP *entry;
+    return openssl_ctx_get_data(libctx, OPENSSL_CTX_NAMEMAP_INDEX,
+                                &stored_namemap_method);
+}
 
-    if (store == NULL || number == 0)
+OSSL_NAMEMAP *ossl_namemap_new(void)
+{
+    OSSL_NAMEMAP *namemap;
+
+    if ((namemap = OPENSSL_zalloc(sizeof(*namemap))) != NULL
+        && (namemap->lock = CRYPTO_THREAD_lock_new()) != NULL
+        && (namemap->numname = sk_NAMEMAP_ENTRY_new_null()) != NULL
+        && (namemap->namenum =
+            lh_NAMEMAP_ENTRY_new(namemap_hash, namemap_cmp)) != NULL) {
+        namemap->floating = 1;
+        return namemap;
+    }
+
+    ossl_namemap_free(namemap);
+    return NULL;
+}
+
+void ossl_namemap_free(OSSL_NAMEMAP *namemap)
+{
+    if (namemap == NULL || !namemap->floating)
+        return;
+
+     /* The elements will be freed by sk_NAMEMAP_ENTRY_pop_free() */
+    lh_NAMEMAP_ENTRY_free(namemap->namenum);
+
+    sk_NAMEMAP_ENTRY_pop_free(namemap->numname, namemap_free);
+
+    CRYPTO_THREAD_lock_free(namemap->lock);
+    OPENSSL_free(namemap);
+}
+
+/*
+ * TODO(3.0) Make NULL to signify the default namemap, found in the default
+ * library context.  The argument for wanting this is that there's no
+ * general reason why the same string wouldn't result in the same number
+ * within a unit...
+ *
+ * This isn't currently possible because of FIPS module constraints, so
+ * we currently disable the code that would allow it.
+ */
+
+const char *ossl_namemap_name(OSSL_NAMEMAP *namemap, int number)
+{
+    NAMEMAP_ENTRY *entry;
+
+#if 0                            /* TODO(3.0) */
+    if (namemap == NULL)
+        namemap = default_namemap();
+#endif
+
+    if (namemap == NULL || number == 0)
         return NULL;
 
-    CRYPTO_THREAD_read_lock(store->lock);
-    entry = sk_NAMEMAP_value(store->numname, number);
-    CRYPTO_THREAD_unlock(store->lock);
+    CRYPTO_THREAD_read_lock(namemap->lock);
+    entry = sk_NAMEMAP_ENTRY_value(namemap->numname, number);
+    CRYPTO_THREAD_unlock(namemap->lock);
 
     if (entry != NULL)
         return entry->name;
     return NULL;
 }
 
-int ossl_namemap_number(OPENSSL_CTX *libctx, const char *name)
+int ossl_namemap_number(OSSL_NAMEMAP *namemap, const char *name)
 {
-    NAMEMAP_STORE *store = namemap_store(libctx);
-    NAMEMAP *entry, template;
+    NAMEMAP_ENTRY *entry, template;
 
-    if (store == NULL)
+#if 0                            /* TODO(3.0) */
+    if (namemap == NULL)
+        namemap = default_namemap();
+#endif
+
+    if (namemap == NULL)
         return 0;
 
     template.name = name;
-    CRYPTO_THREAD_read_lock(store->lock);
-    entry = lh_NAMEMAP_retrieve(store->namenum, &template);
-    CRYPTO_THREAD_unlock(store->lock);
+    CRYPTO_THREAD_read_lock(namemap->lock);
+    entry = lh_NAMEMAP_ENTRY_retrieve(namemap->namenum, &template);
+    CRYPTO_THREAD_unlock(namemap->lock);
 
     if (entry == NULL)
         return 0;
@@ -136,16 +169,20 @@ int ossl_namemap_number(OPENSSL_CTX *libctx, const char *name)
     return entry->number;
 }
 
-int ossl_namemap_new(OPENSSL_CTX *libctx, const char *name)
+int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name)
 {
-    NAMEMAP_STORE *store = namemap_store(libctx);
-    NAMEMAP *entry;
-    int lherror;
+    NAMEMAP_ENTRY *entry;
+    int number;
 
-    if (name == NULL || store == NULL)
+#if 0                            /* TODO(3.0) */
+    if (namemap == NULL)
+        namemap = default_namemap();
+#endif
+
+    if (name == NULL || namemap == NULL)
         return 0;
 
-    if ((number = ossl_namemap_number(libctx, name)) != 0)
+    if ((number = ossl_namemap_number(namemap, name)) != 0)
         return number;           /* Pretend success */
 
     if ((entry = OPENSSL_zalloc(sizeof(*entry) + strlen(name))) == NULL)
@@ -154,27 +191,27 @@ int ossl_namemap_new(OPENSSL_CTX *libctx, const char *name)
     strcpy(entry->body, name);
     entry->name = entry->body;
 
-    CRYPTO_THREAD_write_lock(store->lock);
+    CRYPTO_THREAD_write_lock(namemap->lock);
 
-    entry->number = sk_NAMEMAP_push(store->numname, entry);
+    entry->number = sk_NAMEMAP_ENTRY_push(namemap->numname, entry);
 
     if (entry->number == 0)
         goto err;
 
-    (void)lh_NAMEMAP_insert(store->namenum, entry);
-    if (lh_NAMEMAP_error(store->namenum))
+    (void)lh_NAMEMAP_ENTRY_insert(namemap->namenum, entry);
+    if (lh_NAMEMAP_ENTRY_error(namemap->namenum))
         goto err;
 
-    CRYPTO_THREAD_unlock(store->lock);
+    CRYPTO_THREAD_unlock(namemap->lock);
 
     return entry->number;
 
  err:
     if (entry != NULL) {
-        if (entry->number != 0) {
-            (void)sk_NAMEMAP_pop(store->numname);
-        lh_NAMEMAP_delete(store->namenum, entry);
-        CRYPTO_THREAD_unlock(store->lock);
+        if (entry->number != 0)
+            (void)sk_NAMEMAP_ENTRY_pop(namemap->numname);
+        lh_NAMEMAP_ENTRY_delete(namemap->namenum, entry);
+        CRYPTO_THREAD_unlock(namemap->lock);
     }
     return 0;
 }

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -114,14 +114,9 @@ void ossl_namemap_free(OSSL_NAMEMAP *namemap)
 }
 
 /*
- * TODO(3.0) Make NULL to signify the default namemap, found in the default
- * library context.  The argument for wanting this is that there's no
- * general reason why the same string wouldn't result in the same number
- * within a unit...
- *
- * This isn't currently possible in the FIPS module because if init and
- * cleanup constraints, so we currently disable the code that would allow
- * it when FIPS_MODE is defined.
+ * TODO(3.0) It isn't currently possible to have a default namemap in the
+ * FIPS module because if init and cleanup constraints, so we currently
+ * disable the code that would allow it when FIPS_MODE is defined.
  */
 
 const char *ossl_namemap_name(const OSSL_NAMEMAP *namemap, int number)
@@ -151,7 +146,7 @@ int ossl_namemap_number(const OSSL_NAMEMAP *namemap, const char *name)
 
 #ifndef FIPS_MODE
     if (namemap == NULL)
-        namemap = default_namemap();
+        namemap = ossl_namemap_stored(NULL);
 #endif
 
     if (namemap == NULL)
@@ -175,7 +170,7 @@ int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name)
 
 #ifndef FIPS_MODE
     if (namemap == NULL)
-        namemap = default_namemap();
+        namemap = ossl_namemap_stored(NULL);
 #endif
 
     if (name == NULL || namemap == NULL)

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -75,17 +75,17 @@ static void *get_method_from_store(OPENSSL_CTX *libctx, void *store,
     struct method_data_st *methdata = data;
     void *method = NULL;
     OSSL_NAMEMAP *namemap;
-    int nid;
+    int id;
 
     if (store == NULL
         && (store = get_default_method_store(libctx)) == NULL)
         return NULL;
 
     if ((namemap = ossl_namemap_stored(libctx)) == NULL
-        || (nid = ossl_namemap_add(namemap, name)) == 0)
+        || (id = ossl_namemap_add(namemap, name)) == 0)
         return NULL;
 
-    (void)ossl_method_store_fetch(store, nid, propquery, &method);
+    (void)ossl_method_store_fetch(store, id, propquery, &method);
 
     if (method != NULL
         && !methdata->refcnt_up_method(method)) {
@@ -100,10 +100,10 @@ static int put_method_in_store(OPENSSL_CTX *libctx, void *store,
 {
     struct method_data_st *methdata = data;
     OSSL_NAMEMAP *namemap;
-    int nid;
+    int id;
 
     if ((namemap = ossl_namemap_stored(methdata->libctx)) == NULL
-        || (nid = ossl_namemap_add(namemap, name)) == 0)
+        || (id = ossl_namemap_add(namemap, name)) == 0)
         return 0;
 
     if (store == NULL
@@ -111,7 +111,7 @@ static int put_method_in_store(OPENSSL_CTX *libctx, void *store,
         return 0;
 
     if (methdata->refcnt_up_method(method)
-        && ossl_method_store_add(store, nid, propdef, method,
+        && ossl_method_store_add(store, id, propdef, method,
                                  methdata->destruct_method))
         return 1;
     return 0;
@@ -144,14 +144,14 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
 {
     OSSL_METHOD_STORE *store = get_default_method_store(libctx);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-    int nid;
+    int id;
     void *method = NULL;
 
     if (store == NULL || namemap == NULL)
         return NULL;
 
-    if ((nid = ossl_namemap_number(namemap, name)) == 0
-        || !ossl_method_store_cache_get(store, nid, properties, &method)) {
+    if ((id = ossl_namemap_number(namemap, name)) == 0
+        || !ossl_method_store_cache_get(store, id, properties, &method)) {
         OSSL_METHOD_CONSTRUCT_METHOD mcm = {
             alloc_tmp_method_store,
             dealloc_tmp_method_store,
@@ -172,7 +172,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
         method = ossl_method_construct(libctx, operation_id, name,
                                        properties, 0 /* !force_cache */,
                                        &mcm, &mcmdata);
-        ossl_method_store_cache_set(store, nid, properties, method);
+        ossl_method_store_cache_set(store, id, properties, method);
     } else {
         upref_method(method);
     }

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -91,8 +91,7 @@ int is_partially_overlapping(const void *ptr1, const void *ptr2, int len);
 
 void *evp_generic_fetch(OPENSSL_CTX *ctx, int operation_id,
                         const char *algorithm, const char *properties,
-                        void *(*new_method)(int nid, const OSSL_DISPATCH *fns,
+                        void *(*new_method)(const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
                         int (*upref_method)(void *),
-                        void (*free_method)(void *),
-                        int (*nid_method)(void *));
+                        void (*free_method)(void *));

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -11,11 +11,10 @@ evp_generic_fetch - generic algorithm fetcher and method creator for EVP
 
  void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
                          const char *name, const char *properties,
-                         void *(*new_method)(int nid, const OSSL_DISPATCH *fns,
+                         void *(*new_method)(const OSSL_DISPATCH *fns,
                                              OSSL_PROVIDER *prov),
                          int (*upref_method)(void *),
-                         void (*free_method)(void *),
-                         int (*nid_method)(void *));
+                         void (*free_method)(void *));
 
 =head1 DESCRIPTION
 
@@ -41,10 +40,6 @@ one.
 =item free_method()
 
 frees the given method.
-
-=item nid_method()
-
-returns the nid associated with the given method.
 
 =back
 
@@ -80,7 +75,6 @@ And here's the implementation of the FOO method fetcher:
     /* typedef struct evp_foo_st EVP_FOO */
     struct evp_foo_st {
         OSSL_PROVIDER *prov;
-        int nid;
 	CRYPTO_REF_COUNT refcnt;
         OSSL_OP_foo_newctx_fn *newctx;
         OSSL_OP_foo_init_fn *init;
@@ -93,7 +87,7 @@ And here's the implementation of the FOO method fetcher:
      * In this example, we have a public method creator and destructor.
      * It's not absolutely necessary, but is in the spirit of OpenSSL.
      */
-    EVP_FOO *EVP_FOO_meth_from_dispatch(int foo_type, const OSSL_DISPATCH *fns,
+    EVP_FOO *EVP_FOO_meth_from_dispatch(const OSSL_DISPATCH *fns,
                                         OSSL_PROVIDER *prov)
     {
         EVP_FOO *foo = NULL;
@@ -120,7 +114,6 @@ And here's the implementation of the FOO method fetcher:
                 break;
             }
         }
-        foo->nid = foo_type;
         foo->prov = prov;
         if (prov)
             ossl_provider_upref(prov);
@@ -138,10 +131,10 @@ And here's the implementation of the FOO method fetcher:
         }
     }
 
-    static void *foo_from_dispatch(int nid, const OSSL_DISPATCH *fns,
+    static void *foo_from_dispatch(const OSSL_DISPATCH *fns,
                                    OSSL_PROVIDER *prov)
     {
-        return EVP_FOO_meth_from_dispatch(nid, fns, prov);
+        return EVP_FOO_meth_from_dispatch(fns, prov);
     }
 
     static int foo_upref(void *vfoo)
@@ -162,8 +155,18 @@ And here's the implementation of the FOO method fetcher:
                            const char *name,
                            const char *properties)
     {
-        return evp_generic_fetch(ctx, OSSL_OP_FOO, name, properties,
-                                 foo_from_dispatch, foo_upref, foo_free);
+        EVP_FOO *foo =
+            evp_generic_fetch(ctx, OSSL_OP_FOO, name, properties,
+                              foo_from_dispatch, foo_upref, foo_free);
+
+        /*
+         * If this method exists in legacy form, with a constant NID for the
+         * given |name|, this is the spot to find that NID and set it in
+         * the newly constructed EVP_FOO instance.
+         */
+
+        return foo;
+
     }
 
 And finally, the library functions:

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -10,7 +10,7 @@ evp_generic_fetch - generic algorithm fetcher and method creator for EVP
  #include "evp_locl.h"
 
  void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
-                         const char *algorithm, const char *properties,
+                         const char *name, const char *properties,
                          void *(*new_method)(int nid, const OSSL_DISPATCH *fns,
                                              OSSL_PROVIDER *prov),
                          int (*upref_method)(void *),
@@ -20,7 +20,7 @@ evp_generic_fetch - generic algorithm fetcher and method creator for EVP
 =head1 DESCRIPTION
 
 evp_generic_fetch() calls ossl_method_construct() with the given
-C<libctx>, C<operation_id>, C<algorithm>, and C<properties> and uses
+C<libctx>, C<operation_id>, C<name>, and C<properties> and uses
 it to create an EVP method with the help of the functions
 C<new_method>, C<upref_method>, and C<free_method>.
 
@@ -159,10 +159,10 @@ And here's the implementation of the FOO method fetcher:
     }
 
     EVP_FOO *EVP_FOO_fetch(OPENSSL_CTX *ctx,
-                           const char *algorithm,
+                           const char *name,
                            const char *properties)
     {
-        return evp_generic_fetch(ctx, OSSL_OP_FOO, algorithm, properties,
+        return evp_generic_fetch(ctx, OSSL_OP_FOO, name, properties,
                                  foo_from_dispatch, foo_upref, foo_free);
     }
 

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -15,13 +15,13 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
      /* Remove a store */
      void (*dealloc_tmp_store)(void *store);
      /* Get an already existing method from a store */
-     void *(*get)(OPENSSL_CTX *libctx, void *store, const char *propquery,
-                  void *data);
+     void *(*get)(OPENSSL_CTX *libctx, void *store, const char *name,
+                  const char *propquery, void *data);
      /* Store a method in a store */
-     int (*put)(OPENSSL_CTX *libctx, void *store, const char *propdef,
-                void *method, void *data);
+     int (*put)(OPENSSL_CTX *libctx, void *store, void *method,
+                const char *name, const char *propdef, void *data);
      /* Construct a new method */
-     void *(*construct)(const char *algorithm_name, const OSSL_DISPATCH *fns,
+     void *(*construct)(const char *name, const OSSL_DISPATCH *fns,
                         OSSL_PROVIDER *prov, void *data);
      /* Destruct a method */
      void (*destruct)(void *method);
@@ -77,14 +77,15 @@ Remove a temporary store.
 
 =item get()
 
-Look up an already existing method from a store.
+Look up an already existing method from a store by name.
 
 The store may be given with C<store>.
 B<NULL> is a valid value and means that a sub-system default store
 must be used.
 This default store should be stored in the library context C<libctx>.
 
-The method to be looked up should be identified with data from C<data>
+The method to be looked up should be identified with the given C<name> and
+data from C<data>
 (which is the C<mcm_data> that was passed to ossl_construct_method())
 and the provided property query C<propquery>.
 
@@ -100,15 +101,15 @@ B<NULL> is a valid value and means that a sub-system default store
 must be used.
 This default store should be stored in the library context C<libctx>.
 
-The method should be associated with the given property definition
-C<propdef> and any identification data given through C<data> (which is
+The method should be associated with the given C<name> and property definition
+C<propdef> as well as any identification data given through C<data> (which is
 the C<mcm_data> that was passed to ossl_construct_method()).
 
 This function is expected to increment the C<method>'s reference count.
 
 =item construct()
 
-Constructs a sub-system method for the given C<algorithm_name> and the given
+Constructs a sub-system method for the given C<name> and the given
 dispatch table C<fns>.
 
 The associated I<provider object> C<prov> is passed as well, to make
@@ -133,7 +134,7 @@ B<NULL> on error.
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -4,7 +4,7 @@
 
 ossl_namemap_new, ossl_namemap_free, ossl_namemap_stored,
 ossl_namemap_add, ossl_namemap_name, ossl_namemap_number
-- internal number <-> name map
+- internal number E<lt>-E<gt> name map
 
 =head1 SYNOPSIS
 
@@ -21,9 +21,10 @@ ossl_namemap_add, ossl_namemap_name, ossl_namemap_number
 
 =head1 DESCRIPTION
 
-A B<OSSL_NAMEMAP> is a simple number <-> name map, which can be used
-to give arbitrary any name (any string) a unique dynamic identity that
-is valid throughout the lifetime of the associated library context.
+A B<OSSL_NAMEMAP> is a simple number E<lt>-E<gt> name map, which can
+be used to give arbitrary any name (any string) a unique dynamic
+identity that is valid throughout the lifetime of the associated
+library context.
 
 ossl_namemap_new() and ossl_namemap_free() construct and destruct a
 new B<OSSL_NAMEMAP>.

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -44,16 +44,6 @@ ossl_namemap_name() finds the name corresponding to the given number.
 ossl_namemap_number() finds the number corresponding to the given
 name.
 
-=begin comment
-
-TODO(3.0)
-It's possible that ossl_namemap_add(), ossl_namemap_name() and
-ossl_namemap_number() will change to accept NULL as a B<OSSL_NAMEMAP>
-to use one that is auto-created and associated with the default
-library context.
-
-=end comment
-
 =head1 RETURN VALUES
 
 ossl_namemap_new() and ossl_namemap_stored() return the pointer to a

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -1,0 +1,80 @@
+=pod
+
+=head1 NAME
+
+ossl_namemap_new, ossl_namemap_free, ossl_namemap_stored,
+ossl_namemap_add, ossl_namemap_name, ossl_namemap_number
+- internal number <-> name map
+
+=head1 SYNOPSIS
+
+ #include "internal/cryptlib.h"
+
+ OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx);
+
+ OSSL_NAMEMAP *ossl_namemap_new(void);
+ void ossl_namemap_free(OSSL_NAMEMAP *namemap);
+
+ int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name);
+ const char *ossl_namemap_name(OSSL_NAMEMAP *namemap, int number);
+ int ossl_namemap_number(OSSL_NAMEMAP *namemap, const char *name);
+
+=head1 DESCRIPTION
+
+A B<OSSL_NAMEMAP> is a simple number <-> name map, which can be used
+to give arbitrary any name (any string) a unique dynamic identity that
+is valid throughout the lifetime of the associated library context.
+
+ossl_namemap_new() and ossl_namemap_free() construct and destruct a
+new B<OSSL_NAMEMAP>.
+This is suitable to use when the B<OSSL_NAMEMAP> is embedded in other
+structures, or should be independent for any reason.
+
+ossl_namemap_stored() finds or a auto-creates the default namemap in
+the given library context.
+The returned B<OSSL_NAMEMAP> can't be destructed using
+ossl_namemap_free().
+
+ossl_namemap_add() adds a new name to the namemap if it's not already
+present.
+
+ossl_namemap_name() finds the name corresponding to the given number.
+
+ossl_namemap_number() finds the number corresponding to the given
+name.
+
+=head1 NOTES
+
+It's possible that ossl_namemap_add(), ossl_namemap_name() and
+ossl_namemap_number() will change to accept NULL as a B<OSSL_NAMEMAP>
+to use one that is auto-created and associated with the default
+library context.
+
+=head1 RETURN VALUES
+
+ossl_namemap_new() and ossl_namemap_stored() return the pointer to a
+B<OSSL_NAMEMAP>, or NULL on error.
+
+ossl_namemap_add() returns the number associated with the added
+string, or zero on error.
+
+ossl_namemap_name() returns a pointer to the name corresponding to the
+given number, or NULL if it's undefined in the given B<OSSL_NAMEMAP>.
+
+ossl_namemap_number() returns the number corresponding to the given
+name, or 0 if it's undefined in the given B<OSSL_NAMEMAP>.
+
+=head1 HISTORY
+
+The functions described here were all added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -16,23 +16,23 @@ ossl_namemap_add, ossl_namemap_name, ossl_namemap_number
  void ossl_namemap_free(OSSL_NAMEMAP *namemap);
 
  int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name);
- const char *ossl_namemap_name(OSSL_NAMEMAP *namemap, int number);
- int ossl_namemap_number(OSSL_NAMEMAP *namemap, const char *name);
+ const char *ossl_namemap_name(const OSSL_NAMEMAP *namemap, int number);
+ int ossl_namemap_number(const OSSL_NAMEMAP *namemap, const char *name);
 
 =head1 DESCRIPTION
 
 A B<OSSL_NAMEMAP> is a simple number E<lt>-E<gt> name map, which can
-be used to give arbitrary any name (any string) a unique dynamic
-identity that is valid throughout the lifetime of the associated
-library context.
+be used to give arbitrary any arbitrary name (any string) a unique
+dynamic identity that is valid throughout the lifetime of the
+associated library context.
 
 ossl_namemap_new() and ossl_namemap_free() construct and destruct a
 new B<OSSL_NAMEMAP>.
 This is suitable to use when the B<OSSL_NAMEMAP> is embedded in other
 structures, or should be independent for any reason.
 
-ossl_namemap_stored() finds or a auto-creates the default namemap in
-the given library context.
+ossl_namemap_stored() finds or auto-creates the default namemap in the
+given library context.
 The returned B<OSSL_NAMEMAP> can't be destructed using
 ossl_namemap_free().
 

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -46,6 +46,7 @@ name.
 
 =begin comment
 
+TODO(3.0)
 It's possible that ossl_namemap_add(), ossl_namemap_name() and
 ossl_namemap_number() will change to accept NULL as a B<OSSL_NAMEMAP>
 to use one that is auto-created and associated with the default

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -22,9 +22,9 @@ ossl_namemap_add, ossl_namemap_name, ossl_namemap_number
 =head1 DESCRIPTION
 
 A B<OSSL_NAMEMAP> is a simple number E<lt>-E<gt> name map, which can
-be used to give arbitrary any arbitrary name (any string) a unique
-dynamic identity that is valid throughout the lifetime of the
-associated library context.
+be used to give any arbitrary name (any string) a unique dynamic
+identity that is valid throughout the lifetime of the associated
+library context.
 
 ossl_namemap_new() and ossl_namemap_free() construct and destruct a
 new B<OSSL_NAMEMAP>.
@@ -44,12 +44,14 @@ ossl_namemap_name() finds the name corresponding to the given number.
 ossl_namemap_number() finds the number corresponding to the given
 name.
 
-=head1 NOTES
+=begin comment
 
 It's possible that ossl_namemap_add(), ossl_namemap_name() and
 ossl_namemap_number() will change to accept NULL as a B<OSSL_NAMEMAP>
 to use one that is auto-created and associated with the default
 library context.
+
+=end comment
 
 =head1 RETURN VALUES
 

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -32,13 +32,13 @@ typedef struct ossl_method_construct_method_st {
     /* Remove a store */
     void (*dealloc_tmp_store)(void *store);
     /* Get an already existing method from a store */
-    void *(*get)(OPENSSL_CTX *libctx, void *store, const char *propquery,
-                 void *data);
+    void *(*get)(OPENSSL_CTX *libctx, void *store, const char *name,
+                 const char *propquery, void *data);
     /* Store a method in a store */
-    int (*put)(OPENSSL_CTX *libctx, void *store, const char *propdef,
-               void *method, void *data);
+    int (*put)(OPENSSL_CTX *libctx, void *store, void *method,
+               const char *name, const char *propdef, void *data);
     /* Construct a new method */
-    void *(*construct)(const char *algorithm_name, const OSSL_DISPATCH *fns,
+    void *(*construct)(const char *name, const OSSL_DISPATCH *fns,
                        OSSL_PROVIDER *prov, void *data);
     /* Destruct a method */
     void (*destruct)(void *method, void *data);

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -145,7 +145,8 @@ typedef struct ossl_ex_data_global_st {
 # define OPENSSL_CTX_PROVIDER_STORE_INDEX           1
 # define OPENSSL_CTX_PROPERTY_DEFN_INDEX            2
 # define OPENSSL_CTX_PROPERTY_STRING_INDEX          3
-# define OPENSSL_CTX_MAX_INDEXES                    4
+# define OPENSSL_CTX_NAMEMAP_INDEX                  4
+# define OPENSSL_CTX_MAX_INDEXES                    5
 
 typedef struct openssl_ctx_method {
     void *(*new_func)(OPENSSL_CTX *ctx);

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/cryptlib.h"
+
+const char *ossl_namemap_name(OPENSSL_CTX *libctx, int number);
+int ossl_namemap_number(OPENSSL_CTX *libctx, const char *name);
+int ossl_namemap_new(OPENSSL_CTX *libctx, const char *name);

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -17,7 +17,5 @@ OSSL_NAMEMAP *ossl_namemap_new(void);
 void ossl_namemap_free(OSSL_NAMEMAP *namemap);
 
 int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name);
-const char *ossl_namemap_name(OSSL_NAMEMAP *namemap, int number);
-int ossl_namemap_number(OSSL_NAMEMAP *namemap, const char *name);
-
-
+const char *ossl_namemap_name(const OSSL_NAMEMAP *namemap, int number);
+int ossl_namemap_number(const OSSL_NAMEMAP *namemap, const char *name);

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -9,6 +9,15 @@
 
 #include "internal/cryptlib.h"
 
-const char *ossl_namemap_name(OPENSSL_CTX *libctx, int number);
-int ossl_namemap_number(OPENSSL_CTX *libctx, const char *name);
-int ossl_namemap_new(OPENSSL_CTX *libctx, const char *name);
+typedef struct ossl_namemap_st OSSL_NAMEMAP;
+
+OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx);
+
+OSSL_NAMEMAP *ossl_namemap_new(void);
+void ossl_namemap_free(OSSL_NAMEMAP *namemap);
+
+int ossl_namemap_add(OSSL_NAMEMAP *namemap, const char *name);
+const char *ossl_namemap_name(OSSL_NAMEMAP *namemap, int number);
+int ossl_namemap_number(OSSL_NAMEMAP *namemap, const char *name);
+
+

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -66,6 +66,7 @@ sub name_synopsis()
     $tmp =~ tr/\n/ /;
     print "$id trailing comma before - in NAME\n" if $tmp =~ /, *-/;
     $tmp =~ s/ -.*//g;
+    print "$id POD markup among the names in NAME\n" if $tmp =~ /[<>]/;
     $tmp =~ s/  */ /g;
     print "$id missing comma in NAME\n" if $tmp =~ /[^,] /;
 
@@ -198,8 +199,6 @@ sub check()
         if $contents =~ /=head\d\s\s+/;
     print "$id period in NAME section\n"
         if $contents =~ /=head1 NAME.*\.\n.*=head1 SYNOPSIS/ms;
-    print "$id POD markup in NAME section\n"
-        if $contents =~ /=head1 NAME.*[<>].*=head1 SYNOPSIS/ms;
     print "$id Duplicate $1 in L<>\n"
         if $contents =~ /L<([^>]*)\|([^>]*)>/ && $1 eq $2;
     print "$id Bad =over $1\n"


### PR DESCRIPTION
This creates a generic, per library context number ↔ name map, and has the EVP fetcher use it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

