### PR TITLE
Add support for ELFv2 ABI on big endian ppc64

### DIFF
--- a/Configure
+++ b/Configure
@@ -1403,13 +1403,17 @@ if ($target{sys_id} ne "")
         push @{$config{openssl_sys_defines}}, "OPENSSL_SYS_$target{sys_id}";
         }
 
-unless ($disabled{asm}) {
-}
-
 my %predefined_C = compiler_predefined($config{CROSS_COMPILE}.$config{CC});
 my %predefined_CXX = $config{CXX}
     ? compiler_predefined($config{CROSS_COMPILE}.$config{CXX})
     : ();
+
+unless ($disabled{asm}) {
+    # big endian systems can use ELFv2 ABI
+    if ($target eq "linux-ppc64") {
+        $target{perlasm_scheme} = "linux64v2" if ($predefined_C{_CALL_ELF} == 2);
+    }
+}
 
 # Check for makedepend capabilities.
 if (!$disabled{makedepend}) {

--- a/crypto/perlasm/ppc-xlate.pl
+++ b/crypto/perlasm/ppc-xlate.pl
@@ -49,7 +49,7 @@ my $globl = sub {
 	/osx/		&& do { $name = "_$name";
 				last;
 			      };
-	/linux.*(32|64le)/
+	/linux.*(32|64(le|v2))/
 			&& do {	$ret .= ".globl	$name";
 				if (!$$type) {
 				    $ret .= "\n.type	$name,\@function";
@@ -80,7 +80,7 @@ my $globl = sub {
 };
 my $text = sub {
     my $ret = ($flavour =~ /aix/) ? ".csect\t.text[PR],7" : ".text";
-    $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64le/);
+    $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64(le|v2)/);
     $ret;
 };
 my $machine = sub {
@@ -186,7 +186,7 @@ my $vmr = sub {
 
 # Some ABIs specify vrsave, special-purpose register #256, as reserved
 # for system use.
-my $no_vrsave = ($flavour =~ /aix|linux64le/);
+my $no_vrsave = ($flavour =~ /aix|linux64(le|v2)/);
 my $mtspr = sub {
     my ($f,$idx,$ra) = @_;
     if ($idx == 256 && $no_vrsave) {
@@ -320,7 +320,7 @@ while($line=<>) {
 	if ($label) {
 	    my $xlated = ($GLOBALS{$label} or $label);
 	    print "$xlated:";
-	    if ($flavour =~ /linux.*64le/) {
+	    if ($flavour =~ /linux.*64(le|v2)/) {
 		if ($TYPES{$label} =~ /function/) {
 		    printf "\n.localentry	%s,0\n",$xlated;
 		}


### PR DESCRIPTION
While big endian ppc64 has traditionally used the ELFv1 ABI, it is possible to use the same ELFv2 ABI as on little endian on big endian too. Some distributions are doing this now, too - particularly any big endian distro using the `musl` libc uses ELFv2 unconditionally (e.g. Adélie Linux) and `glibc` can also use it (Void Linux provides both `glibc` and `musl` with ELFv2).

Previously, compiling OpenSSL with asm on those platforms has resulted in miscompilation and crashes. Fortunately, all that is really necessary is to modify `xlate` to do the same stuff on ELFv2 big endian as on little endian, while keeping the endianness checks in the actual crypto assembly code the same. Whether we're compiling OpenSSL for ELFv1 or ELFv2 can be decided based on the value of the `_CALL_ELF` macro in C.

All tests are passing. I also re-checked this on little endian just in case, where it also passes.

```
bash-5.0# file libcrypto.so.3
libcrypto.so.3: ELF 64-bit MSB shared object, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, BuildID[sha1]=d1107b36159ac7474646111e4f03b06bc2ebc526, with debug_info, not stripped
bash-5.0# readelf -h libcrypto.so.3|grep abiv
  Flags:                             0x2, abiv2
bash-5.0# uname -a
Linux bevoid 5.0.10_1 #1 SMP Tue Apr 30 10:05:02 UTC 2019 ppc64 GNU/Linux
```

```
bash-5.0# perl configdata.pm --dump|grep perlasm
    perlasm_scheme => "linux64v2",
```

```
../../test/recipes/01-test_abort.t .................... ok   
../../test/recipes/01-test_sanity.t ................... ok   
../../test/recipes/01-test_symbol_presence.t .......... ok   
../../test/recipes/01-test_test.t ..................... ok   
../../test/recipes/02-test_errstr.t ................... ok     
../../test/recipes/02-test_internal_context.t ......... ok   
../../test/recipes/02-test_internal_ctype.t ........... ok   
../../test/recipes/02-test_internal_provider.t ........ ok   
../../test/recipes/02-test_lhash.t .................... ok   
../../test/recipes/02-test_ordinals.t ................. ok   
../../test/recipes/02-test_sparse_array.t ............. ok   
../../test/recipes/02-test_stack.t .................... ok   
../../test/recipes/03-test_exdata.t ................... ok   
../../test/recipes/03-test_internal_asn1.t ............ ok   
../../test/recipes/03-test_internal_bn.t .............. ok   
../../test/recipes/03-test_internal_chacha.t .......... ok   
../../test/recipes/03-test_internal_curve448.t ........ ok   
../../test/recipes/03-test_internal_ec.t .............. ok   
../../test/recipes/03-test_internal_mdc2.t ............ ok   
../../test/recipes/03-test_internal_modes.t ........... ok   
../../test/recipes/03-test_internal_poly1305.t ........ ok   
../../test/recipes/03-test_internal_rsa_sp800_56b.t ... ok   
../../test/recipes/03-test_internal_siphash.t ......... ok   
../../test/recipes/03-test_internal_sm2.t ............. ok   
../../test/recipes/03-test_internal_sm4.t ............. ok   
../../test/recipes/03-test_internal_ssl_cert_table.t .. ok   
../../test/recipes/03-test_internal_x509.t ............ ok   
../../test/recipes/03-test_params_api.t ............... ok   
../../test/recipes/03-test_property.t ................. ok   
../../test/recipes/03-test_ui.t ....................... ok   
../../test/recipes/04-test_asn1_decode.t .............. ok   
../../test/recipes/04-test_asn1_encode.t .............. ok   
../../test/recipes/04-test_asn1_string_table.t ........ ok   
../../test/recipes/04-test_bio_callback.t ............. ok   
../../test/recipes/04-test_bioprint.t ................. ok   
../../test/recipes/04-test_err.t ...................... ok   
../../test/recipes/04-test_params.t ................... ok   
../../test/recipes/04-test_pem.t ...................... ok     
../../test/recipes/04-test_provider.t ................. ok   
../../test/recipes/05-test_bf.t ....................... ok   
../../test/recipes/05-test_cast.t ..................... ok   
../../test/recipes/05-test_des.t ...................... ok   
../../test/recipes/05-test_hmac.t ..................... ok   
../../test/recipes/05-test_idea.t ..................... ok   
../../test/recipes/05-test_md2.t ...................... skipped: md2 is not supported by this OpenSSL build
../../test/recipes/05-test_mdc2.t ..................... ok   
../../test/recipes/05-test_rand.t ..................... ok   
../../test/recipes/05-test_rc2.t ...................... ok   
../../test/recipes/05-test_rc4.t ...................... ok   
../../test/recipes/05-test_rc5.t ...................... skipped: rc5 is not supported by this OpenSSL build
../../test/recipes/06-test-rdrand.t ................... ok   
../../test/recipes/10-test_bn.t ....................... ok   
../../test/recipes/10-test_exp.t ...................... ok   
../../test/recipes/15-test_dh.t ....................... ok   
../../test/recipes/15-test_dsa.t ...................... ok   
../../test/recipes/15-test_ec.t ....................... ok   
../../test/recipes/15-test_ecdsa.t .................... ok   
../../test/recipes/15-test_ecparam.t .................. ok       
../../test/recipes/15-test_genrsa.t ................... ok   
../../test/recipes/15-test_mp_rsa.t ................... ok     
../../test/recipes/15-test_out_option.t ............... ok   
../../test/recipes/15-test_rsa.t ...................... ok   
../../test/recipes/15-test_rsapss.t ................... ok   
../../test/recipes/20-test_enc.t ...................... ok       
../../test/recipes/20-test_enc_more.t ................. ok       
../../test/recipes/20-test_kdf.t ...................... ok   
../../test/recipes/20-test_mac.t ...................... ok     
../../test/recipes/20-test_passwd.t ................... ok     
../../test/recipes/20-test_pkeyutl.t .................. ok   
../../test/recipes/25-test_crl.t ...................... ok   
../../test/recipes/25-test_d2i.t ...................... ok     
../../test/recipes/25-test_pkcs7.t .................... ok   
../../test/recipes/25-test_req.t ...................... ok   
../../test/recipes/25-test_sid.t ...................... ok   
../../test/recipes/25-test_verify.t ................... ok       
../../test/recipes/25-test_x509.t ..................... ok     
../../test/recipes/30-test_aesgcm.t ................... ok   
../../test/recipes/30-test_afalg.t .................... ok   
../../test/recipes/30-test_engine.t ................... ok   
../../test/recipes/30-test_evp.t ...................... ok     
../../test/recipes/30-test_evp_extra.t ................ ok   
../../test/recipes/30-test_evp_kdf.t .................. ok   
../../test/recipes/30-test_pbelu.t .................... ok   
../../test/recipes/30-test_pkey_meth.t ................ ok   
../../test/recipes/30-test_pkey_meth_kdf.t ............ ok   
../../test/recipes/40-test_rehash.t ................... ok   
../../test/recipes/60-test_x509_check_cert_pkey.t ..... ok   
../../test/recipes/60-test_x509_dup_cert.t ............ ok   
../../test/recipes/60-test_x509_store.t ............... ok   
../../test/recipes/60-test_x509_time.t ................ ok   
../../test/recipes/70-test_asyncio.t .................. ok   
../../test/recipes/70-test_bad_dtls.t ................. ok   
../../test/recipes/70-test_clienthello.t .............. ok   
../../test/recipes/70-test_comp.t ..................... ok   
../../test/recipes/70-test_key_share.t ................ ok    
../../test/recipes/70-test_packet.t ................... ok   
../../test/recipes/70-test_recordlen.t ................ ok   
../../test/recipes/70-test_renegotiation.t ............ ok   
../../test/recipes/70-test_servername.t ............... ok   
../../test/recipes/70-test_sslcbcpadding.t ............ ok   
../../test/recipes/70-test_sslcertstatus.t ............ ok   
../../test/recipes/70-test_sslextension.t ............. ok   
../../test/recipes/70-test_sslmessages.t .............. ok    
../../test/recipes/70-test_sslrecords.t ............... ok    
../../test/recipes/70-test_sslsessiontick.t ........... ok    
../../test/recipes/70-test_sslsigalgs.t ............... ok    
../../test/recipes/70-test_sslsignature.t ............. ok   
../../test/recipes/70-test_sslskewith0p.t ............. ok   
../../test/recipes/70-test_sslversions.t .............. ok   
../../test/recipes/70-test_sslvertol.t ................ ok   
../../test/recipes/70-test_tls13alerts.t .............. ok   
../../test/recipes/70-test_tls13cookie.t .............. ok   
../../test/recipes/70-test_tls13downgrade.t ........... ok   
../../test/recipes/70-test_tls13hrr.t ................. ok   
../../test/recipes/70-test_tls13kexmodes.t ............ ok    
../../test/recipes/70-test_tls13messages.t ............ ok    
../../test/recipes/70-test_tls13psk.t ................. ok   
../../test/recipes/70-test_tlsextms.t ................. ok    
../../test/recipes/70-test_verify_extra.t ............. ok   
../../test/recipes/70-test_wpacket.t .................. ok   
../../test/recipes/80-test_ca.t ....................... ok   
../../test/recipes/80-test_cipherbytes.t .............. ok   
../../test/recipes/80-test_cipherlist.t ............... ok   
../../test/recipes/80-test_ciphername.t ............... ok   
../../test/recipes/80-test_cms.t ...................... ok   
../../test/recipes/80-test_cmsapi.t ................... ok   
../../test/recipes/80-test_ct.t ....................... ok   
../../test/recipes/80-test_dane.t ..................... ok   
../../test/recipes/80-test_dtls.t ..................... ok   
../../test/recipes/80-test_dtls_mtu.t ................. ok   
../../test/recipes/80-test_dtlsv1listen.t ............. ok   
../../test/recipes/80-test_ocsp.t ..................... ok     
../../test/recipes/80-test_pkcs12.t ................... ok   
../../test/recipes/80-test_ssl_new.t .................. ok     
../../test/recipes/80-test_ssl_old.t .................. ok   
../../test/recipes/80-test_ssl_test_ctx.t ............. ok   
../../test/recipes/80-test_sslcorrupt.t ............... ok   
../../test/recipes/80-test_tsa.t ...................... ok     
../../test/recipes/80-test_x509aux.t .................. ok   
../../test/recipes/90-test_asn1_time.t ................ ok   
../../test/recipes/90-test_async.t .................... ok   
../../test/recipes/90-test_bio_enc.t .................. ok   
../../test/recipes/90-test_bio_memleak.t .............. ok   
../../test/recipes/90-test_constant_time.t ............ ok   
../../test/recipes/90-test_fatalerr.t ................. ok   
../../test/recipes/90-test_gmdiff.t ................... ok   
../../test/recipes/90-test_gost.t ..................... skipped: No test GOST engine found
../../test/recipes/90-test_ige.t ...................... ok   
../../test/recipes/90-test_includes.t ................. ok   
../../test/recipes/90-test_memleak.t .................. ok   
../../test/recipes/90-test_overhead.t ................. skipped: Only supported in no-shared builds
../../test/recipes/90-test_secmem.t ................... ok   
../../test/recipes/90-test_shlibload.t ................ ok     
../../test/recipes/90-test_srp.t ...................... ok   
../../test/recipes/90-test_sslapi.t ................... ok   
../../test/recipes/90-test_sslbuffers.t ............... ok   
../../test/recipes/90-test_store.t .................... ok       
../../test/recipes/90-test_sysdefault.t ............... ok   
../../test/recipes/90-test_threads.t .................. ok   
../../test/recipes/90-test_time_offset.t .............. ok   
../../test/recipes/90-test_tls13ccs.t ................. ok   
../../test/recipes/90-test_tls13encryption.t .......... ok   
../../test/recipes/90-test_tls13secrets.t ............. ok   
../../test/recipes/90-test_v3name.t ................... ok   
../../test/recipes/95-test_external_boringssl.t ....... skipped: No external tests in this configuration
../../test/recipes/95-test_external_krb5.t ............ skipped: No external tests in this configuration
../../test/recipes/95-test_external_pyca.t ............ skipped: No external tests in this configuration
../../test/recipes/99-test_ecstress.t ................. ok   
../../test/recipes/99-test_fuzz.t ..................... ok     
All tests successful.
Files=169, Tests=1636, 131 wallclock secs ( 2.15 usr  0.11 sys + 132.23 cusr  4.84 csys = 139.33 CPU)
Result: PASS
```

This fixes https://github.com/openssl/openssl/issues/8858.

@dot-asm @awilfox