### PR TITLE
Make allocation/free/clean available to providers

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -66,13 +66,14 @@ SOURCE[../providers/fips]=$CORE_COMMON
 
 # Central utilities
 $UTIL_COMMON=\
-        cryptlib.c mem.c mem_sec.c params.c bsearch.c ex_data.c o_str.c \
+        cryptlib.c params.c bsearch.c ex_data.c o_str.c \
         ctype.c threads_pthread.c threads_win.c threads_none.c initthread.c \
         context.c sparse_array.c $CPUIDASM
 $UTIL_DEFINE=$CPUIDDEF
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
-        mem_dbg.c cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \
+        mem.c mem_sec.c mem_str.c mem_dbg.c \
+        cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \
         o_fopen.c getenv.c o_init.c o_fips.c init.c trace.c provider.c \
         $UPLINKSRC
 DEFINE[../libcrypto]=$UTIL_DEFINE $UPLINKDEF

--- a/crypto/mem_str.c
+++ b/crypto/mem_str.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2003-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "e_os.h"
+#include <limits.h>
+#include <openssl/crypto.h>
+#include "internal/cryptlib.h"
+
+char *CRYPTO_strdup(const char *str, const char* file, int line)
+{
+    char *ret;
+
+    if (str == NULL)
+        return NULL;
+    ret = CRYPTO_malloc(strlen(str) + 1, file, line);
+    if (ret != NULL)
+        strcpy(ret, str);
+    return ret;
+}
+
+char *CRYPTO_strndup(const char *str, size_t s, const char* file, int line)
+{
+    size_t maxlen;
+    char *ret;
+
+    if (str == NULL)
+        return NULL;
+
+    maxlen = OPENSSL_strnlen(str, s);
+
+    ret = CRYPTO_malloc(maxlen + 1, file, line);
+    if (ret) {
+        memcpy(ret, str, maxlen);
+        ret[maxlen] = '\0';
+    }
+    return ret;
+}
+
+void *CRYPTO_memdup(const void *data, size_t siz, const char* file, int line)
+{
+    void *ret;
+
+    if (data == NULL || siz >= INT_MAX)
+        return NULL;
+
+    ret = CRYPTO_malloc(siz, file, line);
+    if (ret == NULL) {
+        CRYPTOerr(CRYPTO_F_CRYPTO_MEMDUP, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+    return memcpy(ret, data, siz);
+}
+
+/*
+ * Give a string of hex digits convert to a buffer
+ */
+unsigned char *OPENSSL_hexstr2buf(const char *str, long *len)
+{
+    unsigned char *hexbuf, *q;
+    unsigned char ch, cl;
+    int chi, cli;
+    const unsigned char *p;
+    size_t s;
+
+    s = strlen(str);
+    if ((hexbuf = OPENSSL_malloc(s >> 1)) == NULL) {
+        CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+    for (p = (const unsigned char *)str, q = hexbuf; *p; ) {
+        ch = *p++;
+        if (ch == ':')
+            continue;
+        cl = *p++;
+        if (!cl) {
+            CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF,
+                      CRYPTO_R_ODD_NUMBER_OF_DIGITS);
+            OPENSSL_free(hexbuf);
+            return NULL;
+        }
+        cli = OPENSSL_hexchar2int(cl);
+        chi = OPENSSL_hexchar2int(ch);
+        if (cli < 0 || chi < 0) {
+            OPENSSL_free(hexbuf);
+            CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF, CRYPTO_R_ILLEGAL_HEX_DIGIT);
+            return NULL;
+        }
+        *q++ = (unsigned char)((chi << 4) | cli);
+    }
+
+    if (len)
+        *len = q - hexbuf;
+    return hexbuf;
+}
+
+/*
+ * Given a buffer of length 'len' return a OPENSSL_malloc'ed string with its
+ * hex representation @@@ (Contents of buffer are always kept in ASCII, also
+ * on EBCDIC machines)
+ */
+char *OPENSSL_buf2hexstr(const unsigned char *buffer, long len)
+{
+    static const char hexdig[] = "0123456789ABCDEF";
+    char *tmp, *q;
+    const unsigned char *p;
+    int i;
+
+    if (len == 0)
+        return OPENSSL_zalloc(1);
+
+    if ((tmp = OPENSSL_malloc(len * 3)) == NULL) {
+        CRYPTOerr(CRYPTO_F_OPENSSL_BUF2HEXSTR, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+    q = tmp;
+    for (i = 0, p = buffer; i < len; i++, p++) {
+        *q++ = hexdig[(*p >> 4) & 0xf];
+        *q++ = hexdig[*p & 0xf];
+        *q++ = ':';
+    }
+    q[-1] = 0;
+#ifdef CHARSET_EBCDIC
+    ebcdic2ascii(tmp, tmp, q - tmp - 1);
+#endif
+
+    return tmp;
+}

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -12,51 +12,6 @@
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 
-char *CRYPTO_strdup(const char *str, const char* file, int line)
-{
-    char *ret;
-
-    if (str == NULL)
-        return NULL;
-    ret = CRYPTO_malloc(strlen(str) + 1, file, line);
-    if (ret != NULL)
-        strcpy(ret, str);
-    return ret;
-}
-
-char *CRYPTO_strndup(const char *str, size_t s, const char* file, int line)
-{
-    size_t maxlen;
-    char *ret;
-
-    if (str == NULL)
-        return NULL;
-
-    maxlen = OPENSSL_strnlen(str, s);
-
-    ret = CRYPTO_malloc(maxlen + 1, file, line);
-    if (ret) {
-        memcpy(ret, str, maxlen);
-        ret[maxlen] = '\0';
-    }
-    return ret;
-}
-
-void *CRYPTO_memdup(const void *data, size_t siz, const char* file, int line)
-{
-    void *ret;
-
-    if (data == NULL || siz >= INT_MAX)
-        return NULL;
-
-    ret = CRYPTO_malloc(siz, file, line);
-    if (ret == NULL) {
-        CRYPTOerr(CRYPTO_F_CRYPTO_MEMDUP, ERR_R_MALLOC_FAILURE);
-        return NULL;
-    }
-    return memcpy(ret, data, siz);
-}
-
 size_t OPENSSL_strnlen(const char *str, size_t maxlen)
 {
     const char *p;
@@ -127,83 +82,6 @@ int OPENSSL_hexchar2int(unsigned char c)
           return 0x0F;
     }
     return -1;
-}
-
-/*
- * Give a string of hex digits convert to a buffer
- */
-unsigned char *OPENSSL_hexstr2buf(const char *str, long *len)
-{
-    unsigned char *hexbuf, *q;
-    unsigned char ch, cl;
-    int chi, cli;
-    const unsigned char *p;
-    size_t s;
-
-    s = strlen(str);
-    if ((hexbuf = OPENSSL_malloc(s >> 1)) == NULL) {
-        CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF, ERR_R_MALLOC_FAILURE);
-        return NULL;
-    }
-    for (p = (const unsigned char *)str, q = hexbuf; *p; ) {
-        ch = *p++;
-        if (ch == ':')
-            continue;
-        cl = *p++;
-        if (!cl) {
-            CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF,
-                      CRYPTO_R_ODD_NUMBER_OF_DIGITS);
-            OPENSSL_free(hexbuf);
-            return NULL;
-        }
-        cli = OPENSSL_hexchar2int(cl);
-        chi = OPENSSL_hexchar2int(ch);
-        if (cli < 0 || chi < 0) {
-            OPENSSL_free(hexbuf);
-            CRYPTOerr(CRYPTO_F_OPENSSL_HEXSTR2BUF, CRYPTO_R_ILLEGAL_HEX_DIGIT);
-            return NULL;
-        }
-        *q++ = (unsigned char)((chi << 4) | cli);
-    }
-
-    if (len)
-        *len = q - hexbuf;
-    return hexbuf;
-}
-
-/*
- * Given a buffer of length 'len' return a OPENSSL_malloc'ed string with its
- * hex representation @@@ (Contents of buffer are always kept in ASCII, also
- * on EBCDIC machines)
- */
-char *OPENSSL_buf2hexstr(const unsigned char *buffer, long len)
-{
-    static const char hexdig[] = "0123456789ABCDEF";
-    char *tmp, *q;
-    const unsigned char *p;
-    int i;
-
-    if (len == 0)
-    {
-        return OPENSSL_zalloc(1);
-    }
-
-    if ((tmp = OPENSSL_malloc(len * 3)) == NULL) {
-        CRYPTOerr(CRYPTO_F_OPENSSL_BUF2HEXSTR, ERR_R_MALLOC_FAILURE);
-        return NULL;
-    }
-    q = tmp;
-    for (i = 0, p = buffer; i < len; i++, p++) {
-        *q++ = hexdig[(*p >> 4) & 0xf];
-        *q++ = hexdig[*p & 0xf];
-        *q++ = ':';
-    }
-    q[-1] = 0;
-#ifdef CHARSET_EBCDIC
-    ebcdic2ascii(tmp, tmp, q - tmp - 1);
-#endif
-
-    return tmp;
 }
 
 int openssl_strerror_r(int errnum, char *buf, size_t buflen)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -796,6 +796,10 @@ static void core_add_error_vdata(const OSSL_PROVIDER *prov,
 }
 #endif
 
+/*
+ * Functions provided by the core.  Blank line separates "families" of related
+ * functions.
+ */
 static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_GET_PARAM_TYPES, (void (*)(void))core_get_param_types },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
@@ -805,6 +809,24 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_PUT_ERROR, (void (*)(void))core_put_error },
     { OSSL_FUNC_CORE_ADD_ERROR_VDATA, (void (*)(void))core_add_error_vdata },
 #endif
+
+    { OSSL_FUNC_CRYPTO_MALLOC, (void (*)(void))CRYPTO_malloc },
+    { OSSL_FUNC_CRYPTO_ZALLOC, (void (*)(void))CRYPTO_zalloc },
+    { OSSL_FUNC_CRYPTO_MEMDUP, (void (*)(void))CRYPTO_memdup },
+    { OSSL_FUNC_CRYPTO_STRDUP, (void (*)(void))CRYPTO_strdup },
+    { OSSL_FUNC_CRYPTO_STRNDUP, (void (*)(void))CRYPTO_strndup },
+    { OSSL_FUNC_CRYPTO_FREE, (void (*)(void))CRYPTO_free },
+    { OSSL_FUNC_CRYPTO_CLEAR_FREE, (void (*)(void))CRYPTO_clear_free },
+    { OSSL_FUNC_CRYPTO_REALLOC, (void (*)(void))CRYPTO_realloc },
+    { OSSL_FUNC_CRYPTO_CLEAR_REALLOC, (void (*)(void))CRYPTO_clear_realloc },
+    { OSSL_FUNC_CRYPTO_SECURE_MALLOC, (void (*)(void))CRYPTO_secure_malloc },
+    { OSSL_FUNC_CRYPTO_SECURE_ZALLOC, (void (*)(void))CRYPTO_secure_zalloc },
+    { OSSL_FUNC_CRYPTO_SECURE_FREE, (void (*)(void))CRYPTO_secure_free },
+    { OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE,
+        (void (*)(void))CRYPTO_secure_clear_free },
+    { OSSL_FUNC_OPENSSL_CLEANSE, (void (*)(void))OPENSSL_cleanse },
+    { OSSL_FUNC_OPENSSL_HEXSTR2BUF, (void (*)(void))OPENSSL_hexstr2buf },
+
     { 0, NULL }
 };
 static const OSSL_DISPATCH *core_dispatch = core_dispatch_;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -824,6 +824,8 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CRYPTO_SECURE_FREE, (void (*)(void))CRYPTO_secure_free },
     { OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE,
         (void (*)(void))CRYPTO_secure_clear_free },
+    { OSSL_FUNC_CRYPTO_SECURE_ALLOCATED,
+        (void (*)(void))CRYPTO_secure_allocated },
     { OSSL_FUNC_OPENSSL_CLEANSE, (void (*)(void))OPENSSL_cleanse },
     { OSSL_FUNC_OPENSSL_HEXSTR2BUF, (void (*)(void))OPENSSL_hexstr2buf },
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -35,7 +35,12 @@ extern "C" {
  * - a function pointer extractor function with the name OSSL_'foo'
  */
 
-/* Helper macro to create the function signature typedef and the extractor */
+/*
+ * Helper macro to create the function signature typedef and the extractor
+ * |type| is the return-type of the function, |name| is the name of the
+ * function to fetch, and |args| is a parenthesized list of parameters
+ * for the function (that is, it is |name|'s function signature).
+ */
 #define OSSL_CORE_MAKE_FUNC(type,name,args)                             \
     typedef type (OSSL_##name##_fn)args;                                \
     static ossl_inline \
@@ -72,6 +77,53 @@ OSSL_CORE_MAKE_FUNC(void,core_add_error_vdata,(const OSSL_PROVIDER *prov,
 OSSL_CORE_MAKE_FUNC(OPENSSL_CTX *,core_get_library_context,
                     (const OSSL_PROVIDER *prov))
 
+
+/* Memory allocation, freeing, clearing. */
+#define OSSL_FUNC_CRYPTO_MALLOC               10
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_malloc, (size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_ZALLOC               11
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_zalloc, (size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_MEMDUP               12
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_memdup, (const void *str, size_t siz, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_STRDUP               13
+OSSL_CORE_MAKE_FUNC(char *,
+        CRYPTO_strdup, (const char *str, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_STRNDUP              14
+OSSL_CORE_MAKE_FUNC(char *,
+        CRYPTO_strndup, (const char *str, size_t s, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_FREE                 15
+OSSL_CORE_MAKE_FUNC(void,
+        CRYPTO_free, (void *ptr, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_CLEAR_FREE           16
+OSSL_CORE_MAKE_FUNC(void,
+        CRYPTO_clear_free, (void *ptr, size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_REALLOC              17
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_realloc, (void *addr, size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_CLEAR_REALLOC        18
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_clear_realloc, (void *addr, size_t old_num, size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_SECURE_MALLOC        19
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_secure_malloc, (size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_SECURE_ZALLOC        20
+OSSL_CORE_MAKE_FUNC(void *,
+        CRYPTO_secure_zalloc, (size_t num, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_SECURE_FREE          21
+OSSL_CORE_MAKE_FUNC(void,
+        CRYPTO_secure_free, (void *ptr, const char *file, int line))
+#define OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE    22
+OSSL_CORE_MAKE_FUNC(void,
+        CRYPTO_secure_clear_free, (void *ptr, size_t num, const char *file, int line))
+#define OSSL_FUNC_OPENSSL_CLEANSE             23
+OSSL_CORE_MAKE_FUNC(void,
+        OPENSSL_cleanse, (void *ptr, size_t len))
+# define OSSL_FUNC_OPENSSL_HEXSTR2BUF         24
+OSSL_CORE_MAKE_FUNC(unsigned char *,
+        OPENSSL_hexstr2buf, (const char *str, long *len))
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -118,10 +118,13 @@ OSSL_CORE_MAKE_FUNC(void,
 #define OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE    22
 OSSL_CORE_MAKE_FUNC(void,
         CRYPTO_secure_clear_free, (void *ptr, size_t num, const char *file, int line))
-#define OSSL_FUNC_OPENSSL_CLEANSE             23
+#define OSSL_FUNC_CRYPTO_SECURE_ALLOCATED     23
+OSSL_CORE_MAKE_FUNC(int,
+        CRYPTO_secure_allocated, (const void *ptr))
+#define OSSL_FUNC_OPENSSL_CLEANSE             24
 OSSL_CORE_MAKE_FUNC(void,
         OPENSSL_cleanse, (void *ptr, size_t len))
-# define OSSL_FUNC_OPENSSL_HEXSTR2BUF         24
+# define OSSL_FUNC_OPENSSL_HEXSTR2BUF         25
 OSSL_CORE_MAKE_FUNC(unsigned char *,
         OPENSSL_hexstr2buf, (const char *str, long *len))
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -54,6 +54,7 @@ static OSSL_CRYPTO_secure_malloc_fn *c_CRYPTO_secure_malloc;
 static OSSL_CRYPTO_secure_zalloc_fn *c_CRYPTO_secure_zalloc;
 static OSSL_CRYPTO_secure_free_fn *c_CRYPTO_secure_free;
 static OSSL_CRYPTO_secure_clear_free_fn *c_CRYPTO_secure_clear_free;
+static OSSL_CRYPTO_secure_allocated_fn *c_CRYPTO_secure_allocated;
 static OSSL_OPENSSL_hexstr2buf_fn *c_OPENSSL_hexstr2buf;
 
 typedef struct fips_global_st {
@@ -353,6 +354,9 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE:
             c_CRYPTO_secure_clear_free = OSSL_get_CRYPTO_secure_clear_free(in);
             break;
+        case OSSL_FUNC_CRYPTO_SECURE_ALLOCATED:
+            c_CRYPTO_secure_allocated = OSSL_get_CRYPTO_secure_allocated(in);
+            break;
         case OSSL_FUNC_OPENSSL_HEXSTR2BUF:
             c_OPENSSL_hexstr2buf = OSSL_get_OPENSSL_hexstr2buf(in);
             break;
@@ -533,4 +537,9 @@ void CRYPTO_secure_clear_free(void *ptr, size_t num, const char *file, int line)
 unsigned char *OPENSSL_hexstr2buf(const char *str, long *len)
 {
     return c_OPENSSL_hexstr2buf(str, len);
+}
+
+int CRYPTO_secure_allocated(const void *ptr)
+{
+    return c_CRYPTO_secure_allocated(ptr);
 }

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -27,19 +27,34 @@
 #include "internal/provider_ctx.h"
 #include "internal/providercommon.h"
 
+extern OSSL_core_thread_start_fn *c_thread_start;
+
 /*
  * TODO(3.0): Should these be stored in the provider side provctx? Could they
  * ever be different from one init to the next? Unfortunately we can't do this
- * at the moment because c_put_error/c_add_error_vdata do not provide us with
- * the OPENSSL_CTX as a parameter.
+ * at the moment because c_put_error/c_add_error_vdata do not provide
+ * us with the OPENSSL_CTX as a parameter.
  */
 /* Functions provided by the core */
-static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
-static OSSL_core_get_params_fn *c_get_params = NULL;
-extern OSSL_core_thread_start_fn *c_thread_start;
-OSSL_core_thread_start_fn *c_thread_start = NULL;
-static OSSL_core_put_error_fn *c_put_error = NULL;
-static OSSL_core_add_error_vdata_fn *c_add_error_vdata = NULL;
+static OSSL_core_get_param_types_fn *c_get_param_types;
+static OSSL_core_get_params_fn *c_get_params;
+OSSL_core_thread_start_fn *c_thread_start;
+static OSSL_core_put_error_fn *c_put_error;
+static OSSL_core_add_error_vdata_fn *c_add_error_vdata;
+static OSSL_CRYPTO_malloc_fn *c_CRYPTO_malloc;
+static OSSL_CRYPTO_zalloc_fn *c_CRYPTO_zalloc;
+static OSSL_CRYPTO_memdup_fn *c_CRYPTO_memdup;
+static OSSL_CRYPTO_strdup_fn *c_CRYPTO_strdup;
+static OSSL_CRYPTO_strndup_fn *c_CRYPTO_strndup;
+static OSSL_CRYPTO_free_fn *c_CRYPTO_free;
+static OSSL_CRYPTO_clear_free_fn *c_CRYPTO_clear_free;
+static OSSL_CRYPTO_realloc_fn *c_CRYPTO_realloc;
+static OSSL_CRYPTO_clear_realloc_fn *c_CRYPTO_clear_realloc;
+static OSSL_CRYPTO_secure_malloc_fn *c_CRYPTO_secure_malloc;
+static OSSL_CRYPTO_secure_zalloc_fn *c_CRYPTO_secure_zalloc;
+static OSSL_CRYPTO_secure_free_fn *c_CRYPTO_secure_free;
+static OSSL_CRYPTO_secure_clear_free_fn *c_CRYPTO_secure_clear_free;
+static OSSL_OPENSSL_hexstr2buf_fn *c_OPENSSL_hexstr2buf;
 
 typedef struct fips_global_st {
     const OSSL_PROVIDER *prov;
@@ -299,24 +314,63 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_ADD_ERROR_VDATA:
             c_add_error_vdata = OSSL_get_core_add_error_vdata(in);
             break;
-        /* Just ignore anything we don't understand */
+        case OSSL_FUNC_CRYPTO_MALLOC:
+            c_CRYPTO_malloc = OSSL_get_CRYPTO_malloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_ZALLOC:
+            c_CRYPTO_zalloc = OSSL_get_CRYPTO_zalloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_MEMDUP:
+            c_CRYPTO_memdup = OSSL_get_CRYPTO_memdup(in);
+            break;
+        case OSSL_FUNC_CRYPTO_STRDUP:
+            c_CRYPTO_strdup = OSSL_get_CRYPTO_strdup(in);
+            break;
+        case OSSL_FUNC_CRYPTO_STRNDUP:
+            c_CRYPTO_strndup = OSSL_get_CRYPTO_strndup(in);
+            break;
+        case OSSL_FUNC_CRYPTO_FREE:
+            c_CRYPTO_free = OSSL_get_CRYPTO_free(in);
+            break;
+        case OSSL_FUNC_CRYPTO_CLEAR_FREE:
+            c_CRYPTO_clear_free = OSSL_get_CRYPTO_clear_free(in);
+            break;
+        case OSSL_FUNC_CRYPTO_REALLOC:
+            c_CRYPTO_realloc = OSSL_get_CRYPTO_realloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_CLEAR_REALLOC:
+            c_CRYPTO_clear_realloc = OSSL_get_CRYPTO_clear_realloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_SECURE_MALLOC:
+            c_CRYPTO_secure_malloc = OSSL_get_CRYPTO_secure_malloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_SECURE_ZALLOC:
+            c_CRYPTO_secure_zalloc = OSSL_get_CRYPTO_secure_zalloc(in);
+            break;
+        case OSSL_FUNC_CRYPTO_SECURE_FREE:
+            c_CRYPTO_secure_free = OSSL_get_CRYPTO_secure_free(in);
+            break;
+        case OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE:
+            c_CRYPTO_secure_clear_free = OSSL_get_CRYPTO_secure_clear_free(in);
+            break;
+        case OSSL_FUNC_OPENSSL_HEXSTR2BUF:
+            c_OPENSSL_hexstr2buf = OSSL_get_OPENSSL_hexstr2buf(in);
+            break;
         default:
+            /* Just ignore anything we don't understand */
             break;
         }
     }
 
-    ctx = OPENSSL_CTX_new();
-    if (ctx == NULL)
+    /*  Create a context. */
+    if ((ctx = OPENSSL_CTX_new()) == NULL)
         return 0;
-
-    fgbl = openssl_ctx_get_data(ctx, OPENSSL_CTX_FIPS_PROV_INDEX,
-                                &fips_prov_ossl_ctx_method);
-
-    if (fgbl == NULL)
-        goto err;
-
+    if ((fgbl = openssl_ctx_get_data(ctx, OPENSSL_CTX_FIPS_PROV_INDEX,
+                                     &fips_prov_ossl_ctx_method)) == NULL) {
+        OPENSSL_CTX_free(ctx);
+        return 0;
+    }
     fgbl->prov = provider;
-
     *out = fips_dispatch_table;
     *provctx = ctx;
 
@@ -331,10 +385,6 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
     }
 
     return 1;
-
- err:
-    OPENSSL_CTX_free(ctx);
-    return 0;
 }
 
 /*
@@ -412,4 +462,75 @@ const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx)
         return NULL;
 
     return fgbl->prov;
+}
+
+void *CRYPTO_malloc(size_t num, const char *file, int line)
+{
+    return c_CRYPTO_malloc(num, file, line);
+}
+
+void *CRYPTO_zalloc(size_t num, const char *file, int line)
+{
+    return c_CRYPTO_zalloc(num, file, line);
+}
+
+void *CRYPTO_memdup(const void *str, size_t siz, const char *file, int line)
+{
+    return c_CRYPTO_memdup(str, siz, file, line);
+}
+
+char *CRYPTO_strdup(const char *str, const char *file, int line)
+{
+    return c_CRYPTO_strdup(str, file, line);
+}
+
+char *CRYPTO_strndup(const char *str, size_t s, const char *file, int line)
+{
+    return c_CRYPTO_strndup(str, s, file, line);
+}
+
+void CRYPTO_free(void *ptr, const char *file, int line)
+{
+    c_CRYPTO_free(ptr, file, line);
+}
+
+void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line)
+{
+    c_CRYPTO_clear_free(ptr, num, file, line);
+}
+
+void *CRYPTO_realloc(void *addr, size_t num, const char *file, int line)
+{
+    return c_CRYPTO_realloc(addr, num, file, line);
+}
+
+void *CRYPTO_clear_realloc(void *addr, size_t old_num, size_t num,
+                           const char *file, int line)
+{
+    return c_CRYPTO_clear_realloc(addr, old_num, num, file, line);
+}
+
+void *CRYPTO_secure_malloc(size_t num, const char *file, int line)
+{
+    return c_CRYPTO_secure_malloc(num, file, line);
+}
+
+void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
+{
+    return c_CRYPTO_secure_zalloc(num, file, line);
+}
+
+void CRYPTO_secure_free(void *ptr, const char *file, int line)
+{
+    c_CRYPTO_secure_free(ptr, file, line);
+}
+
+void CRYPTO_secure_clear_free(void *ptr, size_t num, const char *file, int line)
+{
+    c_CRYPTO_secure_clear_free(ptr, num, file, line);
+}
+
+unsigned char *OPENSSL_hexstr2buf(const char *str, long *len)
+{
+    return c_OPENSSL_hexstr2buf(str, len);
 }


### PR DESCRIPTION
As a side-note, editing crypto/build.info for the FIPS provider, as opposed to providers/fips/build.info, is kind of confusing.

This DOES NOT WORK if an application calls ```CRYPTO_set_mem_functions```  I will do so in a separate PR once this is merged.
