### PR TITLE
Make ERR_put_error and ERR_add_error_vdata available to providers

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -80,7 +80,6 @@ SOURCE[../providers/fips]=$UTIL_COMMON
 DEFINE[../providers/fips]=$UTIL_DEFINE
         
 
-
 DEPEND[cversion.o]=buildinf.h
 GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
 DEPEND[buildinf.h]=../configdata.pm

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -676,10 +676,12 @@ static int core_thread_start(const OSSL_PROVIDER *prov,
 static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_GET_PARAM_TYPES, (void (*)(void))core_get_param_types },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
-    { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
     { OSSL_FUNC_CORE_THREAD_START, (void (*)(void))core_thread_start },
-    { OSSL_FUNC_CORE_PUT_ERROR, (void (*)(void))ERR_put_error },
-    { OSSL_FUNC_CORE_ADD_ERROR_VDATA, (void (*)(void))ERR_add_error_vdata },
+    { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
+
+    { OSSL_FUNC_ERR_PUT_ERROR, (void (*)(void)) ERR_put_error },
+    { OSSL_FUNC_ERR_ADD_ERROR_VDATA, (void (*)(void))ERR_add_error_vdata },
+
     { 0, NULL }
 };
 static const OSSL_DISPATCH *core_dispatch = core_dispatch_;

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -23,6 +23,7 @@ This function is usually called by a macro.
 ERR_add_error_data() associates the concatenation of its B<num> string
 arguments with the error code added last.
 ERR_add_error_vdata() is similar except the argument is a B<va_list>.
+Multiple calls to these functions append to the current top of the error queue.
 
 L<ERR_load_strings(3)> can be used to register
 error strings so that the application can a generate human-readable

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -61,15 +61,15 @@ OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
 # define OSSL_FUNC_CORE_THREAD_START           3
 OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_PROVIDER *prov,
                                            OSSL_thread_stop_handler_fn handfn))
-# define OSSL_FUNC_CORE_PUT_ERROR              4
-OSSL_CORE_MAKE_FUNC(void,core_put_error,(int lib, int func, int reason,
-                                         const char *file, int line))
-# define OSSL_FUNC_CORE_ADD_ERROR_VDATA        5
-OSSL_CORE_MAKE_FUNC(void,core_add_error_vdata,(int num, va_list args))
-# define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    6
+# define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    4
 OSSL_CORE_MAKE_FUNC(OPENSSL_CTX *,core_get_library_context,
                     (const OSSL_PROVIDER *prov))
 
+# define OSSL_FUNC_ERR_PUT_ERROR               5
+OSSL_CORE_MAKE_FUNC(void, ERR_put_error,
+                (int lib, int func, int reason, const char *file, int line))
+# define OSSL_FUNC_ERR_ADD_ERROR_VDATA         6
+OSSL_CORE_MAKE_FUNC(int, ERR_add_error_vdata, (int num, va_list args))
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -31,12 +31,13 @@
  * the OPENSSL_CTX as a parameter.
  */
 /* Functions provided by the core */
-static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
-static OSSL_core_get_params_fn *c_get_params = NULL;
 extern OSSL_core_thread_start_fn *c_thread_start;
-OSSL_core_thread_start_fn *c_thread_start = NULL;
-static OSSL_core_put_error_fn *c_put_error = NULL;
-static OSSL_core_add_error_vdata_fn *c_add_error_vdata = NULL;
+
+OSSL_core_thread_start_fn *c_thread_start;
+static OSSL_core_get_param_types_fn *c_get_param_types;
+static OSSL_core_get_params_fn *c_get_params;
+static OSSL_ERR_put_error_fn *c_ERR_put_error;
+static OSSL_ERR_add_error_vdata_fn *c_ERR_add_error_vdata;
 
 typedef struct fips_global_st {
     const OSSL_PROVIDER *prov;
@@ -240,11 +241,11 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_THREAD_START:
             c_thread_start = OSSL_get_core_thread_start(in);
             break;
-        case OSSL_FUNC_CORE_PUT_ERROR:
-            c_put_error = OSSL_get_core_put_error(in);
+        case OSSL_FUNC_ERR_PUT_ERROR:
+            c_ERR_put_error = OSSL_get_ERR_put_error(in);
             break;
-        case OSSL_FUNC_CORE_ADD_ERROR_VDATA:
-            c_add_error_vdata = OSSL_get_core_add_error_vdata(in);
+        case OSSL_FUNC_ERR_ADD_ERROR_VDATA:
+            c_ERR_add_error_vdata = OSSL_get_ERR_add_error_vdata(in);
             break;
         /* Just ignore anything we don't understand */
         default:
@@ -319,26 +320,22 @@ int fips_intern_provider_init(const OSSL_PROVIDER *provider,
 
 void ERR_put_error(int lib, int func, int reason, const char *file, int line)
 {
-    /*
-     * TODO(3.0): This works for the FIPS module because we're going to be
-     * using lib/func/reason codes that libcrypto already knows about. This
-     * won't work for third party providers that have their own error mechanisms,
-     * so we'll need to come up with something else for them.
-     */
-    c_put_error(lib, func, reason, file, line);
+    c_ERR_put_error(lib, func, reason, file, line);
+    ERR_add_error_data(1, "(in the FIPS module)");
 }
 
 void ERR_add_error_data(int num, ...)
 {
     va_list args;
+
     va_start(args, num);
-    ERR_add_error_vdata(num, args);
+    c_ERR_add_error_vdata(num, args);
     va_end(args);
 }
 
 void ERR_add_error_vdata(int num, va_list args)
 {
-    c_add_error_vdata(num, args);
+    c_ERR_add_error_vdata(num, args);
 }
 
 const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx)

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -32,8 +32,21 @@ static int preserves_system_error(void)
 #endif
 }
 
+/* Test that calls to vdata append */
+static int vdata_appends(void)
+{
+    const char *data;
+
+    CRYPTOerr(0, ERR_R_MALLOC_FAILURE);
+    ERR_add_error_data(1, "hello ");
+    ERR_add_error_data(1, "world");
+    ERR_get_error_line_data(NULL, NULL, &data, NULL);
+    return TEST_str_eq(data, "hello world");
+}
+
 int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
+    ADD_TEST(vdata_appends);
     return 1;
 }


### PR DESCRIPTION
This makes the main error-reporting functions available to a provider. The other main change is that calling add_data or add_vdata *appends* to the current error data if possible, so that a module that re-uses openssl source files can add an error indication that it's inside a module.  This builds on #8886 and replaces parts of #8728.