### PR TITLE
Don't use '-z defs' if sanitizers are used

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -33,9 +33,9 @@ my %shared_info;
             %{$shared_info{'gnu-shared'}},
             shared_defflag    => '-Wl,--version-script=',
             dso_ldflags       =>
-                $disabled{asan} && $disabled{msan} && $disabled{ubsan}
-                ? '-z defs'
-                : '',
+                (grep /(?:^|\s)-fsanitize/, @{$config{CFLAGS}})
+                ? ''
+                : '-z defs',
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },


### PR DESCRIPTION
There are quite a number of sanitizers for clang that aren't
documented in the clang user documentation.  This makes it impossible
to be selective about what sanitizers to look at to determine if
'-z defs' should be used of not.

Under these circumstances, the sane thing to do is to just look for
any sanitizer specification and not use '-z defs' if there's one
present.

Fixes #8735
