### PR TITLE
Avoid zero-length memdup in tls_construct_ctos_early_data

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -817,7 +817,7 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
     s->psksession = psksess;
     if (psksess != NULL) {
         OPENSSL_free(s->psksession_id);
-        s->psksession_id = OPENSSL_memdup(id, idlen);
+        s->psksession_id = OPENSSL_memdup(id, idlen + 1);
         if (s->psksession_id == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_CTOS_EARLY_DATA, ERR_R_INTERNAL_ERROR);


### PR DESCRIPTION
The old-style PSK client callback is documented to deal in
NUL-terminated identifiers, and indeed we use strlen() to determine
the length of the identifier in question.  Since we are using a
memdup-family function rather than a strdup-family function, we must
accordingly increment the length being copied to account for the NUL
terminator.

Reported by M-Peter-Fth in github Issue #8894.

