### PR TITLE
Fixed 32bit issue for kdf_opts

### DIFF
--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -397,13 +397,11 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 /* OPENSSL_INIT flag range 0x03f00000 reserved for OPENSSL_init_ssl() */
 # define OPENSSL_INIT_NO_ADD_ALL_MACS        0x04000000L
 # define OPENSSL_INIT_ADD_ALL_MACS           0x08000000L
-/* FREE: 0x10000000L */
-/* FREE: 0x20000000L */
+# define OPENSSL_INIT_NO_ADD_ALL_KDFS        0x10000000L
+# define OPENSSL_INIT_ADD_ALL_KDFS           0x20000000L
 /* FREE: 0x40000000L */
 /* FREE: 0x80000000L */
 /* Max OPENSSL_INIT flag value is 0x80000000 */
-# define OPENSSL_INIT_NO_ADD_ALL_KDFS        0x100000000L
-# define OPENSSL_INIT_ADD_ALL_KDFS           0x200000000L
 
 /* openssl and dasync not counted as builtin */
 # define OPENSSL_INIT_ENGINE_ALL_BUILTIN \


### PR DESCRIPTION
Oops - not quite sure why I didnt read the comment.
/* Max OPENSSL_INIT flag value is 0x80000000 */
Especially when I added the new values right underneath it.

The KDF tests are all failing on a 32 bit build without this change. 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
