### PR TITLE
crypto/evp/evp_key.c: #define BUFSIZ if <stdio.h> doesn't #define it

### DIFF
--- a/crypto/evp/evp_key.c
+++ b/crypto/evp/evp_key.c
@@ -14,6 +14,10 @@
 #include <openssl/evp.h>
 #include <openssl/ui.h>
 
+#ifndef BUFSIZ
+# define BUFSIZ 256
+#endif
+
 /* should be init to zeros. */
 static char prompt_string[80];
 


### PR DESCRIPTION
Fixes #8904

Commit 48feaceb53fa ("Remove the possibility to disable the UI module
entirely", 2017-07-03) made the BUFSIZ references in "evp_key.c"
unconditional, by deleting the preprocessing directive "#ifndef
OPENSSL_NO_UI". This breaks the build when compiling OpenSSL for edk2
(OPENSSL_SYS_UEFI), because edk2's <stdio.h> doesn't #define BUFSIZ.

Provide a fallback definition, like we do in "crypto/ui/ui_util.c" (from
commit 984d6c605216, "Fix no-stdio build", 2015-09-29).

Signed-off-by: Laszlo Ersek <lersek@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
