### PR TITLE
VMS: Added new method to gather entropy on VMS, based on SYS$GET_ENTROPY

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Added new method to gather entropy on VMS, based on SYS$GET_ENTROPY.
+     The presence of this system service is determined at run-time.
+     [Richard Levitte]
+
   *) Added functionality to create an EVP_PKEY context based on data
      for methods from providers.  This takes an algorithm name and a
      property query string and simply stores them, with the intent

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
-  *) Added new method to gather entropy on VMS, based on SYS$GET_ENTROPY.
+  *) Added a new method to gather entropy on VMS, based on SYS$GET_ENTROPY.
      The presence of this system service is determined at run-time.
      [Richard Levitte]
 

--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -521,9 +521,9 @@ static int (*get_entropy_address)(void *buffer, size_t buffer_size) = NULL;
 static int init_get_entropy_address(void)
 {
     if (get_entropy_address_flag == 0)
-        get_entropy_addr = dlsym(dlopen(PUBLIC_VECTORS, 0), OLD_ROUTINE);
+        get_entropy_address = dlsym(dlopen(PUBLIC_VECTORS, 0), GET_ENTROPY);
     get_entropy_address_flag = 1;
-    return get_entropy_addr != NULL;
+    return get_entropy_address != NULL;
 }
 
 size_t get_entropy_method(RAND_POOL *pool)

--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -42,9 +42,9 @@
  * DATA COLLECTION METHOD
  * ======================
  *
- * This is a method to get *some* very low quality entropy.
+ * This is a method to get low quality entropy.
  * It works by collecting all kinds of statistical data that
- * VMS offers and using them as "entropy".
+ * VMS offers and using them as random seed.
  */
 
 /* We need to make sure we have the right size pointer in some cases */
@@ -506,12 +506,11 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
  * SYS$GET_ENTROPY METHOD
  * ======================
  *
- * This is a high entropy method based on a new systems service that is
+ * This is a high entropy method based on a new system service that is
  * based on getentropy() from FreeBSD 12.  It's only used if available,
  * and its availability is detected at run-time.
  *
- * We assume that this function gives 1 bit of entropy for each bit of
- * output.
+ * We assume that this function provides full entropy random output.
  */
 #define PUBLIC_VECTORS "SYS$LIBRARY:SYS$PUBLIC_VECTORS.EXE"
 #define GET_ENTROPY "SYS$GET_ENTROPY"
@@ -563,7 +562,7 @@ size_t get_entropy_method(RAND_POOL *pool)
 }
 
 /*
- * MAIN ENTTROPY AQUISITION FUNCTIONS
+ * MAIN ENTROPY ACQUISITION FUNCTIONS
  * ==================================
  *
  * These functions are called by the RAND / DRBG functions

--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -456,15 +456,9 @@ size_t data_collect_method(RAND_POOL *pool)
      * If we can't feed the requirements from the caller, we're in deep trouble.
      */
     if (!ossl_assert(total_length >= bytes_needed)) {
-        char neededstr[20];
-        char availablestr[20];
-
-        BIO_snprintf(neededstr, sizeof(neededstr), "%zu", bytes_needed);
-        BIO_snprintf(availablestr, sizeof(availablestr), "%zu", total_length);
-        RANDerr(RAND_F_RAND_POOL_ACQUIRE_ENTROPY,
-                RAND_R_RANDOM_POOL_UNDERFLOW);
-        ERR_add_error_data(4, "Needed: ", neededstr, ", Available: ",
-                           availablestr);
+        ERR_raise_data(ERR_LIB_RAND, RAND_R_RANDOM_POOL_UNDERFLOW,
+                       "Needed: %zu, Available: %zu",
+                       bytes_needed, total_length);
         return 0;
     }
 


### PR DESCRIPTION
This system services is based on FreeBSD 12's getentropy(), and is
therefore treated the same way as getentropy() with regards to amount
of entropy bits per data bit.
