### PR TITLE
ppc assembly pack: always increment CTR IV as quadword

### DIFF
--- a/crypto/aes/asm/aesp8-ppc.pl
+++ b/crypto/aes/asm/aesp8-ppc.pl
@@ -1331,7 +1331,7 @@ Loop_ctr32_enc:
 	addi		$idx,$idx,16
 	bdnz		Loop_ctr32_enc
 
-	vadduwm		$ivec,$ivec,$one
+	vadduqm		$ivec,$ivec,$one
 	 vmr		$dat,$inptail
 	 lvx		$inptail,0,$inp
 	 addi		$inp,$inp,16


### PR DESCRIPTION
The kernel self-tests picked up an issue with CTR mode. The issue was detected with a test vector with an IV of FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD: after 3 increments it should wrap around to 0.

There are two paths that increment IVs: the bulk (8 at a time) path, and the individual path which is used when there are fewer than 8 AES blocks to process.

In the bulk path, the IV is incremented with vadduqm: "Vector Add Unsigned Quadword Modulo", which does 128-bit addition.

In the individual path, however, the IV is incremented with vadduwm: "Vector Add Unsigned Word Modulo", which instead does 4 32-bit additions. Thus the IV would instead become FFFFFFFFFFFFFFFFFFFFFFFF00000000, throwing off the result.

Use vadduqm.

This was probably a typo originally, what with q and w being adjacent.

CLA: trivial

---

I have tested this in the Linux kernel context where we have a copy of this file, but I haven't done any tests on the openssl userspace. I am happy to run some on hardware if you can tell me what commands to run.