### PR TITLE
Change SSL parameter SSL_session_reused const

### DIFF
--- a/doc/man3/SSL_session_reused.pod
+++ b/doc/man3/SSL_session_reused.pod
@@ -8,7 +8,7 @@ SSL_session_reused - query whether a reused session was negotiated during handsh
 
  #include <openssl/ssl.h>
 
- int SSL_session_reused(SSL *ssl);
+ int SSL_session_reused(const SSL *ssl);
 
 =head1 DESCRIPTION
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2152,7 +2152,7 @@ size_t SSL_CTX_get_num_tickets(const SSL_CTX *ctx);
 #  define SSL_cache_hit(s) SSL_session_reused(s)
 # endif
 
-__owur int SSL_session_reused(SSL *s);
+__owur int SSL_session_reused(const SSL *s);
 __owur int SSL_is_server(const SSL *s);
 
 __owur __owur SSL_CONF_CTX *SSL_CONF_CTX_new(void);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4606,7 +4606,7 @@ int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
     return ret;
 }
 
-int SSL_session_reused(SSL *s)
+int SSL_session_reused(const SSL *s)
 {
     return s->hit;
 }


### PR DESCRIPTION
This function only returns a status and does not modify the parameter.
Since similar function are already taking const parameters, also
change this function to have a const parameter.

Fixes #8934

CLA: trivial
Signed-off-by: Arne Schwabe <arne@rfc2549.org>

##### Checklist
- [x] documentation is added or updated

I am not 100% sure if this change requires also updating CHANGES and adding the change to the history of the function. If it does I will update the PR to include also those changes.