### PR TITLE
Configure: add -fkeep-inline-functions to --strict-warnings

### DIFF
--- a/Configure
+++ b/Configure
@@ -131,7 +131,8 @@ my %gcc_devteam_warn = ();
                      -Wformat
                      -Wtype-limits
                      -Wundef
-                     -Werror );
+                     -Werror
+                     -fkeep-inline-functions );
     %gcc_devteam_warn = (
         CFLAGS          => [ @common, qw( -Wmissing-prototypes
                                           -Wstrict-prototypes ) ],


### PR DESCRIPTION
The reason for doing this is that there are compilers (such as SUNPRO
CC) that do this by default, and this has consequences when header
files like safestack.h and lhash.h are included (possibly via other
header files) but the resulting program isn't linked with libcrypto.

Incidently, we have a test program that gets safestack.h included and
doesn't link with libcrypto (it shouldn't need to, since all it does
is to verify that it builds without macro clash), and is thereby the
perfect test victim.

Related to #8102

-----

NOTES:

- I fully expect this PR to fail.  That is a success, there will be a follow up PR that fixes the problem.
- I'm making this PR for 1.1.1, and will do the same with the follow up PR, because that's the branch that this has been reported for.  Of course, this and the follow up PR will be up-ported to master.