### PR TITLE
Configure: Enable LTO by default on GCC 8 and later

### DIFF
--- a/Configure
+++ b/Configure
@@ -375,6 +375,7 @@ my @disablables = (
     "gost",
     "idea",
     "legacy",
+    "lto",
     "makedepend",
     "md2",
     "md4",
@@ -1645,6 +1646,17 @@ unless ($disabled{ktls}) {
         }
     } else {
         disable('not-linux', 'ktls');
+    }
+}
+
+unless ($disabled{lto}) {
+    $config{lto}="";
+	 if ($predefined_C{__GNUC__} >= 8 &&
+		 $predefined_CXX{__GNUC__} >= 8) {
+		 push @{$config{cflags}}, "-flto";
+		 push @{$config{cxxflags}}, "-flto";
+    } else {
+        disable('not-gcc-8+', 'lto');
     }
 }
 


### PR DESCRIPTION
By enabling Link Time Optimisation (LTO) the optimisation is performed
at linking stage and allows optimisation by considering all compilation
units.
Size differences:
```
   text    data     bss     dec     hex filename
 519701   49280     496  569477   8b085 build-O2/libssl.so
 507494   48808     512  556814   87f0e build-lto-O2/libssl.so
 537866   49280     496  587642   8f77a build-O3/libssl.so
 579656   48776     496  628928   998c0 build-lto-O3/libssl.so
2798766  224864   13640 3037270  2e5856 build-O2/libcrypto.so
2784762  223288   13480 3021530  2e1ada build-lto-O2/libcrypto.so
2983438  225056   13640 3222134  312a76 build-O3/libcrypto.so
3019274  223432   13448 3256154  31af5a build-lto-O3/libcrypto.so
```

The -O2 LTO version produces smaller binaries than the non-LTO version.
The -O3 LTO version produces larger binaries than the non-LTO version
because it inlines more often.
Performance wise it is hard to tell since the crypto code is all
assembly.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
