### PR TITLE
Revert "ppc assembly pack: always increment CTR IV as quadword"

### DIFF
--- a/crypto/aes/asm/aesp8-ppc.pl
+++ b/crypto/aes/asm/aesp8-ppc.pl
@@ -1331,7 +1331,7 @@ Loop_ctr32_enc:
 	addi		$idx,$idx,16
 	bdnz		Loop_ctr32_enc
 
-	vadduqm		$ivec,$ivec,$one
+	vadduwm		$ivec,$ivec,$one
 	 vmr		$dat,$inptail
 	 lvx		$inptail,0,$inp
 	 addi		$inp,$inp,16


### PR DESCRIPTION
The 32 bit counter behaviour is necessary and was intentional.

This reverts commit e9f148c9356b18995298f37bafbf1836a3fce078.

Refer #8942 for discussion.
