### PR TITLE
Version application includes library version used.

### DIFF
--- a/apps/version.c
+++ b/apps/version.c
@@ -130,22 +130,22 @@ opthelp:
     if (platform)
         printf("%s\n", OpenSSL_version(OPENSSL_PLATFORM));
     if (options) {
-        printf("options:  ");
-        printf("%s ", BN_options());
+        printf("options: ");
+        printf(" %s", BN_options());
 #ifndef OPENSSL_NO_MD2
-        printf("%s ", MD2_options());
+        printf(" %s", MD2_options());
 #endif
 #ifndef OPENSSL_NO_RC4
-        printf("%s ", RC4_options());
+        printf(" %s", RC4_options());
 #endif
 #ifndef OPENSSL_NO_DES
-        printf("%s ", DES_options());
+        printf(" %s", DES_options());
 #endif
 #ifndef OPENSSL_NO_IDEA
-        printf("%s ", IDEA_options());
+        printf(" %s", IDEA_options());
 #endif
 #ifndef OPENSSL_NO_BF
-        printf("%s ", BF_options());
+        printf(" %s", BF_options());
 #endif
         printf("\n");
     }

--- a/apps/version.c
+++ b/apps/version.c
@@ -122,14 +122,9 @@ opthelp:
     if (!dirty)
         version = 1;
 
-    if (version) {
-        if (strcmp(OpenSSL_version(OPENSSL_FULL_VERSION_STRING),
-                   OPENSSL_FULL_VERSION_STR) == 0)
-            printf("%s\n", OpenSSL_version(OPENSSL_VERSION));
-        else
-            printf("%s (Library: %s)\n",
-                   OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
-    }
+    if (version)
+        printf("%s (Library: %s)\n",
+               OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
     if (date)
         printf("%s\n", OpenSSL_version(OPENSSL_BUILT_ON));
     if (platform)


### PR DESCRIPTION
The version application included the version of the library being used if it was different to the version of OpenSSL applications being run.  This change makes version always include both version strings.

The version output is now fixed format (rather than the older one of two possibilities).

This is an API breaking change, which was suggested at the OMC face to face earlier in the month.


Also reformatted the _-o_ option output to remove the training space from the line.
