### PR TITLE
Configure: for '-z defs', also check $config{cflags}

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -33,7 +33,8 @@ my %shared_info;
             %{$shared_info{'gnu-shared'}},
             shared_defflag    => '-Wl,--version-script=',
             dso_ldflags       =>
-                (grep /(?:^|\s)-fsanitize/, @{$config{CFLAGS}})
+                (grep /(?:^|\s)-fsanitize/,
+                 @{$config{CFLAGS}}, @{$config{cflags}})
                 ? ''
                 : '-z defs',
         };


### PR DESCRIPTION
When sanitize options are added as 'enable-msan' or similar, the
-fsanitize C flags is set in $config{cflags} rather than
$config{CFLAGS}, so we need to check both.
