### PR TITLE
build_SYS_str_reasons: Fix a crash caused by overlong locales

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -238,7 +238,7 @@ static void build_SYS_str_reasons(void)
                  * VMS has an unusual quirk of adding spaces at the end of
                  * some (most? all?) messages. Lets trim them off.
                  */
-                if (cur > strerror_pool && ossl_isspace(cur[-1])) {
+                if (ossl_isspace(cur[-1])) {
                     while (cur > strerror_pool && ossl_isspace(cur[-1])) {
                         cur--;
                         cnt--;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -187,8 +187,8 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 }
 
 #ifndef OPENSSL_NO_ERR
-/* A measurement on Linux 2018-11-21 showed about 3.5kib */
-# define SPACE_SYS_STR_REASONS 4 * 1024
+/* 2019-05-21: Some locale on Linux (Russian, Ukrainian) require more than 6,5 kB */
+# define SPACE_SYS_STR_REASONS 8 * 1024
 # define NUM_SYS_STR_REASONS 127
 
 static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
@@ -228,8 +228,8 @@ static void build_SYS_str_reasons(void)
 
                 str->string = cur;
                 cnt += l;
-                if (cnt > sizeof(strerror_pool))
-                    cnt = sizeof(strerror_pool);
+                if (cnt >= sizeof(strerror_pool))
+                    cnt = sizeof(strerror_pool) - 1;
                 cur += l;
 
                 /*

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -228,7 +228,7 @@ static void build_SYS_str_reasons(void)
          */
         if (str->string == NULL && cnt < sizeof(strerror_pool)) {
             if (openssl_strerror_r(i, cur, sizeof(strerror_pool) - cnt)) {
-                size_t l = strlen(cur) + 1;
+                size_t l = strlen(cur);
 
                 str->string = cur;
                 cnt += l;
@@ -238,14 +238,12 @@ static void build_SYS_str_reasons(void)
                  * VMS has an unusual quirk of adding spaces at the end of
                  * some (most? all?) messages. Lets trim them off.
                  */
-                if (ossl_isspace(cur[-1])) {
-                    while (cur > strerror_pool && ossl_isspace(cur[-1])) {
-                        cur--;
-                        cnt--;
-                    }
-                    *cur++ = '\0';
-                    cnt++;
+                while (cur > strerror_pool && ossl_isspace(cur[-1])) {
+                    cur--;
+                    cnt--;
                 }
+                *cur++ = '\0';
+                cnt++;
             }
         }
         if (str->string == NULL)


### PR DESCRIPTION
Applications using OpenSSL crash in openSUSE upon initialization under Russian locales.
See https://bugzilla.opensuse.org/show_bug.cgi?id=1135550.

This happens due to several factors.

Apparently it gets exposed by commit e3b35d2b29e9446af83fcaa534e67e7b04a60d7a which we apply in openSUSE.

The crypto/err/err.c 4 kB SPACE_SYS_STR_REASONS isn't enough for some locales. The Russian locales consume 6856 bytes, Ukrainian even 7000.

build_SYS_str_reasons() contains an overflow check:
```
  if (cnt > sizeof(strerror_pool))
      cnt = sizeof(strerror_pool);
```
But it no longer works since commit 9f15e5b911ba6053e09578f190354568e01c07d7, where ```cnt``` is incremented once more after the condition.

The added ```cnt++;``` at the end of the VMS hack results in openssl_strerror_r() being called with a size parameter equal to -1, meaning SIZE_MAX. This leads to an unbounded OPENSSL_strlcpy() writing after the array.

```
(gdb) bt
#0  OPENSSL_strlcpy (dst=0x7ffff7840e81 <ex_data+1> "", src=0x7ffff71630e4 "\265-сокету", size=18446744073709551554) at crypto/o_str.c:86
#1  0x00007ffff76ccef0 in openssl_strerror_r (errnum=88, buf=0x7ffff7840e43 <prompt_string+35> "Операция для сокета применена к ", <incomplete sequence \320>, buflen=18446744073709551615) at crypto/o_str.c:244
#2  0x00007ffff768f84f in build_SYS_str_reasons () at crypto/err/err.c:223
223                 if (openssl_strerror_r(i, cur, sizeof(strerror_pool) - cnt)) {
(gdb) p sizeof(strerror_pool)
$10 = 4096
(gdb) p cnt 
$11 = 4097
```
Invalid memory is overwritten, making the program crash later.
