### PR TITLE
Add the NIST CAVS test vectors for CCM

### DIFF
--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -16,7 +16,7 @@ setup("test_evp");
 
 my @files = ( "evpciph.txt", "evpdigest.txt", "evpencod.txt", "evpkdf.txt",
     "evppkey_kdf.txt", "evpmac.txt", "evppbe.txt", "evppkey.txt",
-    "evppkey_ecc.txt", "evpcase.txt", "evpaessiv.txt" );
+    "evppkey_ecc.txt", "evpcase.txt", "evpaessiv.txt", "evpccmcavs.txt" );
 
 plan tests => scalar(@files);
 

--- a/test/recipes/30-test_evp_data/evpccmcavs.txt
+++ b/test/recipes/30-test_evp_data/evpccmcavs.txt
@@ -1,0 +1,23927 @@
+#
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# Tests from NIST CCM Test Vectors (SP800-38C)
+
+Title = NIST CCM 128 Decryption-Verfication Process Tests
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 5a8aa485c316e9
+AAD =
+Tag = 02209f55
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 3796cf51b87266
+AAD =
+Tag = 9a04c241
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 89ca5a64050f9f
+AAD =
+Tag = f5f915df
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = ec9d8edff25645
+AAD =
+Tag = 7a3c3499
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 05e16f0f42a6f4
+AAD =
+Tag = f09c2986
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 2e504b694f8df5
+AAD =
+Tag = 4ae97e71
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 06d102a9328863
+AAD =
+Tag = ecb38c8b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = c288b810fb5334
+AAD =
+Tag = 9c4dc530
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 08a166d9eb6610
+AAD =
+Tag = 67299ef6
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 4a5810b121c91b
+AAD =
+Tag = b0538d02
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 44077341139bf9
+AAD =
+Tag = 88200ea8
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = a9df4f37847e1f
+AAD =
+Tag = 19867aa5
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 11df57fcd131e9
+AAD =
+Tag = 3b392a52
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 890fff56d10dc0
+AAD =
+Tag = 1c5e47e0
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4ae701103c63deca5b5a3939d7d05992
+IV = 9dc18698731b27
+AAD =
+Tag = 97a56b8b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 5a8aa485c316e9
+AAD =
+Tag = 75d582db43ce9b13ab4b6f7f14341330
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 3796cf51b87266
+AAD =
+Tag = 3a65e03af37b81d05acc7ec1bc39deb0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 89ca5a64050f9f
+AAD =
+Tag = efc5721e0b9e4c3c90deab0e1d5c11bd
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = ec9d8edff25645
+AAD =
+Tag = 91b4b779823f4f0e3979ced93b99736c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 05e16f0f42a6f4
+AAD =
+Tag = e2e87ca82523ccfeb416b42af9d9aadc
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 2e504b694f8df5
+AAD =
+Tag = 7b85fd105cc960df86ad86846d178274
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 06d102a9328863
+AAD =
+Tag = ffa140be27b25f307a6efd9697d66c9b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = c288b810fb5334
+AAD =
+Tag = ed356542e0a804a724bfaa422e98a970
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 08a166d9eb6610
+AAD =
+Tag = e31dd8dc920fe7900e1b1817fe845c7d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 4a5810b121c91b
+AAD =
+Tag = ae5a0777f03bbf541f305d00acff0396
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 44077341139bf9
+AAD =
+Tag = 957dca58616c1cbe99f94fd8f7c257d9
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = a9df4f37847e1f
+AAD =
+Tag = 0e150af422f6da238bb476810b2d5bc2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 11df57fcd131e9
+AAD =
+Tag = 8e1150756ff3a733a1274470f072b74c
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 890fff56d10dc0
+AAD =
+Tag = a1f70df3fa9cfeb95f869b3fe08466e0
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 9dc18698731b27
+AAD =
+Tag = fdf3f6c177aa1d71fe3474a5a2eb6bb1
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = 90156f3f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = a16a2e741f1cd9717285b6d882
+AAD =
+Tag = 88909016
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 368f3b8180fd4b851b7b272cb1
+AAD =
+Tag = de547d03
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 7bb2bc00c0cafce65b5299ae64
+AAD =
+Tag = ea4bad52
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 935c1ef3d4032ff090f91141f3
+AAD =
+Tag = 1bc82b3d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 2640b14f10b116411d1b5c1ad1
+AAD =
+Tag = 92e72250
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = b229c173a13b2d83af91ec45b0
+AAD =
+Tag = e81f0647
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 37ca0dc2d6efd9efde69f14f03
+AAD =
+Tag = 7cb906ec
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 6b6238aed86d677ba2b3e2622c
+AAD =
+Tag = d60f815b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = d6cb2ac67bb13b8f6d31fad64a
+AAD =
+Tag = d3d4f3b0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 32a7cd361ef00e65f5778fdfd4
+AAD =
+Tag = a9df97ad
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = d0a1508fdefcf5be30a459b813
+AAD =
+Tag = 36a37a59
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = 5381a61b449dc6a42aa4c79b95
+AAD =
+Tag = dba02a36
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = c55430f2da0687ea40313884ab
+AAD =
+Tag = 25dcb3c5
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3
+IV = ec76d1850acc0979a1f11906fb
+AAD =
+Tag = 1d2832d0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = fb04dc5a44c6bb000f2440f5154364b4
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = a16a2e741f1cd9717285b6d882
+AAD =
+Tag = 5447075bf42a59b91f08064738b015ab
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 368f3b8180fd4b851b7b272cb1
+AAD =
+Tag = fdc992847f0815fac67aa935b35208ed
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 7bb2bc00c0cafce65b5299ae64
+AAD =
+Tag = 2cabd690a45e59854b7587b26dd77f8e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 935c1ef3d4032ff090f91141f3
+AAD =
+Tag = 3dacc71169f6da77ec91ff1d2f649ed1
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 2640b14f10b116411d1b5c1ad1
+AAD =
+Tag = 97a2eb170ef03fa12124f1315e3b694f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = b229c173a13b2d83af91ec45b0
+AAD =
+Tag = 94d85a83169d8dc76f58baf4d63ecfee
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 37ca0dc2d6efd9efde69f14f03
+AAD =
+Tag = d3903c6289ca3684b8ce1174c23153a4
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 6b6238aed86d677ba2b3e2622c
+AAD =
+Tag = 5cbac5c418374a68bd7085454c4b0c13
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = d6cb2ac67bb13b8f6d31fad64a
+AAD =
+Tag = 26317f6b8b0130097441ed04b8009aef
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 32a7cd361ef00e65f5778fdfd4
+AAD =
+Tag = b82ab6f3bbf59b6caafc54f05570f74e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = d0a1508fdefcf5be30a459b813
+AAD =
+Tag = 1ae34207e74c8c78890ae17e320e84bd
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 5381a61b449dc6a42aa4c79b95
+AAD =
+Tag = 5c5fa254c0be503b02caffade6b85259
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = c55430f2da0687ea40313884ab
+AAD =
+Tag = 9340266730ea36207bb734819d3553e9
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = ec76d1850acc0979a1f11906fb
+AAD =
+Tag = ec17cccf33bd9a0d4ce7aa20690c1333
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 5a8aa485c316e9
+AAD =
+Tag = 03e1fa6b
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = a90e8ea44085ced791b2fdb7fd44b5cf0bd7d27718029bb7
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 31f8fa25827d48
+AAD =
+Tag = 23e5d81c
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 50aafe0578c115c4a8e126ff7b3ccb64dce8ccaa8ceda69f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 5340ed7752c9ff
+AAD =
+Tag = 869a97f0
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 512ed208bf10d57406537e94d20a5b6e2e9ab0683dfdc685
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 9cbce402511b89
+AAD =
+Tag = 838e7f95
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = af72db9cd9d6f46607d6f9542ca69988dd15255c5c91171c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 123a0beace4e39
+AAD =
+Tag = 09b89801
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 47d71409a03c330be9451b3f92c9d21c584391ad1010e9d6
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 8ea1594a58fe4a
+AAD =
+Tag = eaf5f825
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = e562c7af0384ea16431ca20934a293a058d722cbfc3186c8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 5a7743e59e82da
+AAD =
+Tag = 5ec1aa6a
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 004d9d89c401aa79919c2805fcd5de69316e191df56426c0
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = f477f754d7ee76
+AAD =
+Tag = f3586c6f
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = d623673d7f6d57c208bde112ca858561f3af5cc2bf5de926
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 040a257dede70e
+AAD =
+Tag = 5fa40618
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = fd4733d158b5630f4f6c03ab26b11bff0cbe0d5d3df99a73
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = dd51b8e91683d1
+AAD =
+Tag = 5bf4f930
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = d352cb996c3075ff367a8dcacbbae46a12fbef08aa96ec83
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = ab3cb86cca6fb2
+AAD =
+Tag = 66f0496e
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 31730fac20e21eca0aef591faa9fa90b3c058e32af1ce48a
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = f67b98efd39b55
+AAD =
+Tag = b753181c
+Plaintext = f2e944e1ae47ad5873bf391f1b0cc07f6151eb4c50bb45b2
+Ciphertext = dd175905a7ea3aef9fce068e6cb78e9cc60519755a178c77
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = e60e2c002d1c99
+AAD =
+Tag = 0876f2da
+Plaintext = 70f48dc1d76e5028da07e29852801375a9edb2214a5ea4c0
+Ciphertext = 8ad6b76f54392ee0f2834f09142545bcde9bf03d04d64aa1
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 098e053fa08043
+AAD =
+Tag = d4f7fc07
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = 808eb3e04c39abde64674f0f7716dde11699cff8dd367c4c
+
+Cipher = aes-128-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd
+IV = 4bf48328725514
+AAD =
+Tag = 973a2712
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = e074d13aad43f7b2364d47db0a02326641ca3b2ad61a1c49
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 5a8aa485c316e9
+AAD =
+Tag = 2d9a3fbc210595b7b8b1b41523111a8e
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 24ab9eeb0e5508cae80074f1070ee188a637171860881f1f
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 31f8fa25827d48
+AAD =
+Tag = 63af747cc88a001fa94e060290f209c4
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 7ebfda6fa5da1dbffd82dc29b875798fbcef8ba0084fbd24
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 5340ed7752c9ff
+AAD =
+Tag = cf3b8e6c8aeb5eeb0a5efb3700be45a2
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = cbf133643851f91ddc7a1e19a0c21990459f2b7728da58f5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 9cbce402511b89
+AAD =
+Tag = f7bd61a0158accbca28913e39fe80906
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 0de7567a945c0af4a2291a651de411e8d0438508f2d4da80
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 123a0beace4e39
+AAD =
+Tag = 8feeda2e8f249dd93a8358def7639875
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = d43035cdb5a1868aa430e8b41a1dc57a639087238e38bd62
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 8ea1594a58fe4a
+AAD =
+Tag = bf19f89da977e56f308373c616299ad4
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 389547260b354a6cbc909de057d367677049e80613877f6f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 5a7743e59e82da
+AAD =
+Tag = 21366b9da457ede2a673351475b53d41
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = a95aa33483ed3711470025394616bf98fe624fbca8aa6fbc
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = f477f754d7ee76
+AAD =
+Tag = d889a7cae55efd71b369cd6d43ef363b
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 3d53b6ab8925f429ae14a0065cd203d4f9deddd402a79ac6
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 040a257dede70e
+AAD =
+Tag = 4be7f19463dd330a4b9f3cbb30b88fa5
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = d5e6e82cb5f8034a89e58adf8298476253f18981bcb3b036
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = dd51b8e91683d1
+AAD =
+Tag = c2df063f7fdbae27f0736a37fd065fb4
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 02f69107d62ff77145c7d57684c70ba671d55f1c63bb2ad8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = ab3cb86cca6fb2
+AAD =
+Tag = 9b45d54cc24cff1b1d8aa1df32fbd81a
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 64ec2f321111da9c5389e8255bfe69876d4f548f94cacd52
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = f67b98efd39b55
+AAD =
+Tag = 0217a4f1f4fb302257b0de7c9da2e750
+Plaintext = f2e944e1ae47ad5873bf391f1b0cc07f6151eb4c50bb45b2
+Ciphertext = 37d63c2bbf44d2eb155ecc1a844841d5c33f1a6d44341933
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = e60e2c002d1c99
+AAD =
+Tag = 36a305d520a1a24930a70a311aa3695d
+Plaintext = 70f48dc1d76e5028da07e29852801375a9edb2214a5ea4c0
+Ciphertext = 33e0dce4410e51bed5323ea49490207084ac91732bae4292
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 098e053fa08043
+AAD =
+Tag = 81e3d64ed546b6b70ee088a693f55fbb
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = 1d732c334319bd775e7cf93dbdc4204bbdb58192be082804
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 4bf48328725514
+AAD =
+Tag = 737719dd84ccfb397a4f61b70c85262a
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = c92fc2f0d24593f67d9c09d326158a8138237c4096093f0d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = a3e138b9
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 4a550134f94455979ec4bf89ad2bd80d25a77ae94e456134
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 49004912fdd7269279b1f06a89
+AAD =
+Tag = 091a5ae9
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 118ec53dd1bfbe52d5b9fe5dfebecf2ee674ec983eada654
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = efeb82c8c68d6600b24dd6d8ee
+AAD =
+Tag = 78b6bcc4
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 6b0fea26e4dfe902b5e876c7ba92afbad8aa52d3c1d00ae5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 7b93d368dc551640b00ba3cbb5
+AAD =
+Tag = ac542b09
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 640c740e2b8af851712a05948ecee055b25b145ccb82ca58
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 24b7a65391f88bea38fcd54a9a
+AAD =
+Tag = 6413020a
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 05f20b2ae70fcb0ea79aa1845c15b899a799ca60f51e6c29
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 6aa3f731522fce7e366ba59945
+AAD =
+Tag = 142d5636
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 9fa576a8a5c72468afa372338cbbc33fef81ad5a873eb38a
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = a11cf5bed0041ee3cb1fef4b43
+AAD =
+Tag = f3757b6a
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 8d26582c74b2b4d960ee9e417c6395daafaebb3aff45d477
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 273cc5013785baeb5abc79c8bd
+AAD =
+Tag = a7001a16
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = cb62a13e38e17cc6635e409c922956ece38f593189a51b99
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = d2d4482ea8e98c1cf309671895
+AAD =
+Tag = 050e9225
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = f3e29b792423c7fbe743a3b2f890a2bff29519f3636a6232
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = a8849b44adb48d271979656930
+AAD =
+Tag = 850ec9f0
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 136e60d6714d906d1f4c02b7bdbb5f3ccdd2165306912dec
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = a632ba0d00511122abcd6227ff
+AAD =
+Tag = 4eb95533
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 49b6d0b6eeff74af0de70072d9ccdc68a0ee36a5ddbf098b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = c47af80cd26d047630c1fdf0d1
+AAD =
+Tag = 0f8fb949
+Plaintext = d8306c9c4ea6c69c6e2ad0fc0e49b1e0126b01078d6419ff
+Ciphertext = a2a59041c3f78f6e10c3045118e8a475945e24c85b02abc4
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 70e132023acae1f88c7a237b68
+AAD =
+Tag = 69d8ab41
+Plaintext = d0b2bef5ed1a87d9c73d4a459cb05c11799c4f51ad640b1e
+Ciphertext = 19b4ad222795326cb031cfdb07b652dbf64ca5db5ff5d6d5
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = 8010d3a2a14f72f5585defc940
+AAD =
+Tag = f00fe764
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = 76b66b908657f4df8a329c34ccdde50ae7fc71c4a718b712
+
+Cipher = aes-128-ccm
+Key = 197afb02ffbd8f699dacae87094d5243
+IV = a98c2f0e0a7b68942853905191
+AAD =
+Tag = 79f9eb72
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = 20df4662ce6c8c4ce49b14fa791e41ff8598ec93d8a825e8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = 6a9a970b9beb2ac1bd4fd62168f8378a
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 4bfe4e35784f0a65b545477e5e2f4bae0e1e6fa717eaf2cb
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 49004912fdd7269279b1f06a89
+AAD =
+Tag = a65666144994bad0c8195bcb4ade1337
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 0c56a503aa2c12e87450d45a7b714db980fd348f327c0065
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = efeb82c8c68d6600b24dd6d8ee
+AAD =
+Tag = a85f868739404b64a7cbdd61b577c388
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 5f69d6c21f771eb98dc724f891f530b1c045f49a054de103
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 7b93d368dc551640b00ba3cbb5
+AAD =
+Tag = b2b164f3c255b699cbf75330d96c3c13
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = d335ba572520c336f711edf27ea738ba5e6b0d772ea443b8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 24b7a65391f88bea38fcd54a9a
+AAD =
+Tag = 2658e077687315eaf11458bdf6e3c36a
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 9fa846ef8d198c538f84f856bab8f7f9c3bed90b53acb6a3
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 6aa3f731522fce7e366ba59945
+AAD =
+Tag = 63db3756abba1feef626a956794d7e56
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = b7095030acdc5fbb8fea2c24717c1c236231f9737bcc78f4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = a11cf5bed0041ee3cb1fef4b43
+AAD =
+Tag = 7d6fee1de626bc7c93f2caa27a3ecaa0
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = d6911d5831163c8ebad0916af1833051b885aae822f9f665
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 273cc5013785baeb5abc79c8bd
+AAD =
+Tag = 89e2d235192f33ba0f357492112d98f4
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 6b10a098c96c2bbf9aeb5c9adcf91e4812838dff319f8be9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = d2d4482ea8e98c1cf309671895
+AAD =
+Tag = 800b81e834ea5dd2bdc2c688d9505359
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = aecd11cbac04e1f79b0fd24052c8cedf393dce9df350d24f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = a8849b44adb48d271979656930
+AAD =
+Tag = 430889cd5c97343cc0dedfbd62e6b6eb
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = d3a7a25f71b1988482dc852ed713d55abdcc4bb1129ddcae
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = a632ba0d00511122abcd6227ff
+AAD =
+Tag = 15acded53c41010554e1c1fe937a7605
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 368e1574a433d78d0276ce4a1cacfba834a216693536c00b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = c47af80cd26d047630c1fdf0d1
+AAD =
+Tag = c9390fbdb9ec416267096ccbf2c148e5
+Plaintext = d8306c9c4ea6c69c6e2ad0fc0e49b1e0126b01078d6419ff
+Ciphertext = 99e40b3c67aca95dd4462c20cbd6b2741e7033fc4f41a975
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 70e132023acae1f88c7a237b68
+AAD =
+Tag = 55c18ae38b7ee7f00f96cfca4fe9a2ef
+Plaintext = d0b2bef5ed1a87d9c73d4a459cb05c11799c4f51ad640b1e
+Ciphertext = de079418c25ba67e5fda009998e3fce61bfdc3b7787cf066
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 8010d3a2a14f72f5585defc940
+AAD =
+Tag = b35357a35ff9e58e18d6d80df9fc335d
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = fbab64d8dd8b6e33c7cc6124cd65f004d7247277fe98d5d3
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = a98c2f0e0a7b68942853905191
+AAD =
+Tag = 9aba89639f4033be9ba9f3c101acc1bd
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = 372b9af0655df2d0c830b4949a2d2faa8db251ee922a3bff
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 782e4318
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = a265480ca88d5f
+AAD = a2248a882ecbf850daf91933a389e78e81623d233dfd47bf8321361a38f138fe
+Tag = a04f270a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 87ec7423f1ebfc
+AAD = 2bed1ec06c1ca149d9ffbaf048c474ea2de000eb7950f18d6c25acf6ab3f19b5
+Tag = 97dfd257
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = b8b04f90616082
+AAD = 4898731e143fcc677c7cf1a8f2b3c4039fb5e57028e33b05e097d1763cbfe4d8
+Tag = 6c202a1c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 8c687b4318813a
+AAD = fcad52a88544325bb31eb5de4a41dbff6a96f69d0993b969a01792ee23953acf
+Tag = 1be535a0
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 29b810eed8fc92
+AAD = 40d1d320eb63a25d7a2b3141563a552114275ddda56beb62cc0c0273d5795faa
+Tag = 4fb6617d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 62452462c53934
+AAD = 1eb8863ea100babc1713654afcf54f21f8bff754223ad70269ace9d034f26a96
+Tag = c056bd3e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 4cceba0e7aee97
+AAD = f33e184c967165eb62542999afaca4e3e319840e439b5bb509544fb4b6901445
+Tag = 87048576
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = b5151b0601c683
+AAD = 73d27303ec91f28c79b278882034d11eb6a5266746f37edbb77f8409a8738b8c
+Tag = ea8c0407
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = 4e5d6d7ac9e71e
+AAD = a01b6e152fe232b6c10b5d89900961c445f4c46833df242c826678b68c869811
+Tag = 41c12dc5
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = dc88e989951a3f
+AAD = fdcacfaff46585406cc45a2da364e67e132a91c98900a8f9d7bfb14ec951fca5
+Tag = de84cf5c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = a1aeda4b4cb8dd
+AAD = db3022ef4cd68ae22b501599448ffe2dda15cfd2e259315c6f6d03036edea963
+Tag = e617e006
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = f248e5225e3d9a
+AAD = fdc64ef76a3bfd0a15d0bc8e8bacaf64346796a3e35afcf2ac1ab136f63f7b6e
+Tag = b7909395
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = e68228f5c65b73
+AAD = 614efdf89ce2a9fcbd38bdc0b4cece54dfd7532880e0b4ce6eb3a4010b7cb1e7
+Tag = 8a05d2ea
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 90929a4b0ac65b350ad1591611fe4829
+IV = ea167cfd1101d9
+AAD = 28130f938c45a1a92b02dbeadbd8df816b6d934e87cca2dfdbfdc49c7cd84041
+Tag = 8643ba47
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 41b476013f45e4a781f253a6f3b1e530
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = a265480ca88d5f
+AAD = a2248a882ecbf850daf91933a389e78e81623d233dfd47bf8321361a38f138fe
+Tag = f9f018fcd125822616083fffebc4c8e6
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 87ec7423f1ebfc
+AAD = 2bed1ec06c1ca149d9ffbaf048c474ea2de000eb7950f18d6c25acf6ab3f19b5
+Tag = 534cc67c44c877c9c908071ee1082f4c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = b8b04f90616082
+AAD = 4898731e143fcc677c7cf1a8f2b3c4039fb5e57028e33b05e097d1763cbfe4d8
+Tag = 201c0ef2ddaa51b645911b5c37d76e95
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 8c687b4318813a
+AAD = fcad52a88544325bb31eb5de4a41dbff6a96f69d0993b969a01792ee23953acf
+Tag = ec774d9000763bba3a5ac307418827b2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 29b810eed8fc92
+AAD = 40d1d320eb63a25d7a2b3141563a552114275ddda56beb62cc0c0273d5795faa
+Tag = 75798c3fe5202f0e33c9183c837aeaf5
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 62452462c53934
+AAD = 1eb8863ea100babc1713654afcf54f21f8bff754223ad70269ace9d034f26a96
+Tag = 32601de5960c11c925444b5c47d42289
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 4cceba0e7aee97
+AAD = f33e184c967165eb62542999afaca4e3e319840e439b5bb509544fb4b6901445
+Tag = 4c1cd6a774c8e6f4e261db1f73b0aa20
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = b5151b0601c683
+AAD = 73d27303ec91f28c79b278882034d11eb6a5266746f37edbb77f8409a8738b8c
+Tag = 8bd9c00ff23310216bbd24981c1e2cf7
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 4e5d6d7ac9e71e
+AAD = a01b6e152fe232b6c10b5d89900961c445f4c46833df242c826678b68c869811
+Tag = 174efd089409f9932b8e631965e762a6
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = dc88e989951a3f
+AAD = fdcacfaff46585406cc45a2da364e67e132a91c98900a8f9d7bfb14ec951fca5
+Tag = 8de80f620bd41eee6a58925dc8404bfa
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = a1aeda4b4cb8dd
+AAD = db3022ef4cd68ae22b501599448ffe2dda15cfd2e259315c6f6d03036edea963
+Tag = 0b9d79e8e33ec45532af5515a99f05df
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = f248e5225e3d9a
+AAD = fdc64ef76a3bfd0a15d0bc8e8bacaf64346796a3e35afcf2ac1ab136f63f7b6e
+Tag = 1583e1e5a86001bbcec62292ccfd4d48
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = e68228f5c65b73
+AAD = 614efdf89ce2a9fcbd38bdc0b4cece54dfd7532880e0b4ce6eb3a4010b7cb1e7
+Tag = b72caac6362e68e445f69f605f21e0a2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = ea167cfd1101d9
+AAD = 28130f938c45a1a92b02dbeadbd8df816b6d934e87cca2dfdbfdc49c7cd84041
+Tag = 352769a19ac75b8a116be031b33d6449
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = 9f69f24f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 8739b4bea1a099fe547499cbc6
+AAD = f6107696edb332b2ea059d8860fee26be42e5e12e1a4f79a8d0eafce1b2278a7
+Tag = e17afaa4
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 0f98fdbde2b04387f27b3401dd
+AAD = 02010329660fa716556193eb4870ee84bd934296a5c52d92bba859cc13caaddc
+Tag = 07155b7e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 4eed58f381e500902ba5c56864
+AAD = 96056d9ebd7c553c22cc2d9d816b61123750d96c1b08c4b661079424bf3c4946
+Tag = d538cf2f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 1e7e51f0fa9a33ed618c26f5e3
+AAD = da9b8ffb0f3c2aee2e386cc9f035ec1eb3e629bd1544c11dc21be4fd8ac9074a
+Tag = c283466f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = f012f94f5988c79aa179d7fdfc
+AAD = 612b2ef2683109d99452f95099417641d0c2be3f8ab4cbb2a44e83355ba9303c
+Tag = aa8d8098
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 715acf92cfb69ad56036c49e70
+AAD = 960667b85be07304634124b9324be12a1c11451f1fa9db82c683265b4cf8e5ff
+Tag = a44b69b0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 141be3601e38185a9fa1596d2e
+AAD = 606452c62290b43559a588bb03356f846cecb0ccaf0bdaf67a18abd811d4315a
+Tag = f395733f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = fcdda3c5f0e80843b03d8788da
+AAD = 03f22247a55461a293d253c77483859fdac1b87c2480e208a3df767cfbfde512
+Tag = 1e9e9237
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = ca660ed3b917c0aca140dcd3fb
+AAD = 254a86f5b20d344ad86fd5523d08f1864737be57731440c29aa6b42574572f51
+Tag = e9d2a722
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 642ae3466661ce1f51783deece
+AAD = 4432a1cec5976cc13b8fb78341d426c2248f091b597123d263ffafc7f82da5a5
+Tag = a90fc438
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 7864c717ec93db38b10679be47
+AAD = 679aad1ad1e57029e3362b325572fc71cac53184b0f1546867e665a4a59466c4
+Tag = 48f3a1ec
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = c3bf9dfe9d6c26f543188fb457
+AAD = e301f69ad3a7e08a3d02462f0aa584449eb0449b0e3c50aa8dfaa4472816c8b0
+Tag = 24763def
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = 1527657d2fd98f7deca55cc649
+AAD = f4c723433b7cafe3cda9bb4940a21a89a8382d13018b622ccd1ffb9ffd3211af
+Tag = 63394bee
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b
+IV = b8432d3d5525a0dadbbaa6b6b8
+AAD = 86ee6e37b4a2d9a0b52ec95643b4e8297e237721e15ce8bf7593a98644f83eba
+Tag = d79b1686
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = 1859ac36a40a6b28b34266253627797a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 8739b4bea1a099fe547499cbc6
+AAD = f6107696edb332b2ea059d8860fee26be42e5e12e1a4f79a8d0eafce1b2278a7
+Tag = edf8b46eb69ac0044116019dec183072
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 0f98fdbde2b04387f27b3401dd
+AAD = 02010329660fa716556193eb4870ee84bd934296a5c52d92bba859cc13caaddc
+Tag = 66622ac26c7227a0329739612012737c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 4eed58f381e500902ba5c56864
+AAD = 96056d9ebd7c553c22cc2d9d816b61123750d96c1b08c4b661079424bf3c4946
+Tag = e4c9e86493ee78b1cbf6e55e94731b63
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 1e7e51f0fa9a33ed618c26f5e3
+AAD = da9b8ffb0f3c2aee2e386cc9f035ec1eb3e629bd1544c11dc21be4fd8ac9074a
+Tag = 8b5bfe6b5b5552007300bae71172612f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = f012f94f5988c79aa179d7fdfc
+AAD = 612b2ef2683109d99452f95099417641d0c2be3f8ab4cbb2a44e83355ba9303c
+Tag = 1848be3cb7665ac68874c617a75d8bd2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 715acf92cfb69ad56036c49e70
+AAD = 960667b85be07304634124b9324be12a1c11451f1fa9db82c683265b4cf8e5ff
+Tag = 65a23b7b5ee78af9c7d0113447f78ab9
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 141be3601e38185a9fa1596d2e
+AAD = 606452c62290b43559a588bb03356f846cecb0ccaf0bdaf67a18abd811d4315a
+Tag = 90a420b6d2252392e161dcf4fb953d7e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = fcdda3c5f0e80843b03d8788da
+AAD = 03f22247a55461a293d253c77483859fdac1b87c2480e208a3df767cfbfde512
+Tag = 004cbe11292887e246de7704a4a1a05f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = ca660ed3b917c0aca140dcd3fb
+AAD = 254a86f5b20d344ad86fd5523d08f1864737be57731440c29aa6b42574572f51
+Tag = ad7af41e39ea0c0cd072263e826f3cf0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 642ae3466661ce1f51783deece
+AAD = 4432a1cec5976cc13b8fb78341d426c2248f091b597123d263ffafc7f82da5a5
+Tag = 16b1a4fadbadc906a949592d6ef319a3
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 7864c717ec93db38b10679be47
+AAD = 679aad1ad1e57029e3362b325572fc71cac53184b0f1546867e665a4a59466c4
+Tag = e9cfb1069380434f221db4229a083a76
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = c3bf9dfe9d6c26f543188fb457
+AAD = e301f69ad3a7e08a3d02462f0aa584449eb0449b0e3c50aa8dfaa4472816c8b0
+Tag = 380cb57fd531bb1dcf22350518bbf8af
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 1527657d2fd98f7deca55cc649
+AAD = f4c723433b7cafe3cda9bb4940a21a89a8382d13018b622ccd1ffb9ffd3211af
+Tag = fbf2becc35b5024078bfcfc1f831b669
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = b8432d3d5525a0dadbbaa6b6b8
+AAD = 86ee6e37b4a2d9a0b52ec95643b4e8297e237721e15ce8bf7593a98644f83eba
+Tag = 080203eb842b3f98a730abbbf98f493e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 38f125fa
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 6be31860ca271ef448de8f8d8b39346daf4b81d7e92d65b3
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = fdd2d6f503c915
+AAD = 5b92394f21ddc3ad49d9b0881b829a5935cb3a4d23e292a62fb66b5e7ab7020e
+Tag = 28a66b69
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 4cc57a9927a6bc401441870d3193bf89ebd163f5c01501c7
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 27d73d58100054
+AAD = f6468542923be79b4b06dfe70920d57d1da73a9c16f9c9a12d810d7de0d12467
+Tag = ee2de18c
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 1f16c6d370fff40c011a243356076b67e905d4672ae2f38f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = dd16e0ce1250e3
+AAD = bc65cfd65e9863c8b7457d58afa6bdb48a84170d8aa97ba5b397b52ad17a9242
+Tag = 24537a81
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 46edb001d58a01dce1bcf064cfc9a04accc82c42b33ba165
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = ccee19d037cf4a
+AAD = c026696e6425e6c33f45b4145febf1137e7ac26383c9f5aa4cd4e5e8abb19e07
+Tag = 9405edb1
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 9b61335f96fc5b31274cc1fb275f29c1105d68c67b70654f
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 6c8ba94f09cbe6
+AAD = 774ad1a88f8bb063951486d4aec5bf82d5fc535bd0b952f86200c123c37fa496
+Tag = 548effe3
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 97b5eb2d55847f5d5d9f8c762dace481d8efb19ccfd72265
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 1f670302fcdcc8
+AAD = 1a9ff9698cfc96b581d7115c822e4363d7355ec5daed2eae5bf89ee944ac7d9c
+Tag = 03459b29
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = f5cc8198dce8e890587b62572b07413a915bfb55628c901c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 5d05f658c729a2
+AAD = dd9564c1431ed490b17ef69f6115805e54ef156ef4e10e58f7d57a7e86626352
+Tag = 963b04f3
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 50c0b1f6c5e4c86a0c938ecbc762eeaf99b9fe04c2820a43
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 22a77db9fcbc95
+AAD = 86bf1739c10f63df734ee3e60ac40ff5636c49f68ca4c16ece289609eb413e7a
+Tag = 1330f633
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 1fdbe91189da01c5098cf1538addd85b1cfef0abd0797c14
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 491e32b0bbfa4c
+AAD = 75bef075c79d6cfd7fc73aefd67b2d215be0648937477ba606b1fe1be591239e
+Tag = 10c1f6d7
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 462e7cdf9a6a553bca37d4d93bed4986b715d0349238613e
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = bc4b7d3a380be0
+AAD = 353dbb41e2d525a9f4fcd858d0f0aa1b1e86ac0f936d5c09c6b61c343f94e3fc
+Tag = d37e5543
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 7d142f26aa6c9d55850c5c9f58ab36a66670d47c515bf93c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = a840e98df72ae9
+AAD = 22c6607732ef1bdc7fcf6197e037cdadd7ee17c008552dd9f04b8564d34fb17c
+Tag = cc5e0c4a
+Plaintext = a2f53385618b41301f4e3ea4c597f411103dac2b37abf5da
+Ciphertext = f7122cbcec93d53fc7e3fc629ea15d28363cad1c83a23bb3
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 39d93c3cf31a6f
+AAD = 937dfac5cded938438f4e97aabd9beb50dba40f824198260a89729479cfe6869
+Tag = fc12a512
+Plaintext = c1bdef96dc868446be48491b160504546f2a40dd581f9582
+Ciphertext = e1cad7f946b20c373323218c8a89e56edf3030662e50d459
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = 0bbc177019321e
+AAD = f6e02678820f5ccbede6cbded02d6dd58d486166d7b18ee975a688af421fb795
+Tag = c2eaf895
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = d4741814466a23e26107d773f103a4c83db9d772dbd5fdc1
+
+Cipher = aes-128-ccm
+Key = f9fdca4ac64fe7f014de0f43039c7571
+IV = ad048eb2ad7526
+AAD = 0d2739cfdac782b61f484fa1a423c478c414397ec420327963d79112b2d70a7e
+Tag = f92fa2f7
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = ed35ff66bc7f6d8ec7acf896f994d79f5792cf6d22d6691f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 2cf3a20b7fd7c49e6e79bef475c2906f
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = b351ab96b2e45515254558d5212673ee6c776d42dbca3b51
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = fdd2d6f503c915
+AAD = 5b92394f21ddc3ad49d9b0881b829a5935cb3a4d23e292a62fb66b5e7ab7020e
+Tag = 81d18ca149d6766bfaccec88f194eb5b
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = df1a5285caa41b4bb47f6e5ceceba4e82721828d68427a30
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 27d73d58100054
+AAD = f6468542923be79b4b06dfe70920d57d1da73a9c16f9c9a12d810d7de0d12467
+Tag = 5eb4f0875dda5ccd9b94026ba49fb34e
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 04a29fc109dfc626e8297e0f586d0bfaf31260017d95f62d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = dd16e0ce1250e3
+AAD = bc65cfd65e9863c8b7457d58afa6bdb48a84170d8aa97ba5b397b52ad17a9242
+Tag = 920843994def41aed3103995d3392eed
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 77e4cd5d319353ecb6b89e2de14bcfee4fbf738b61df14f3
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = ccee19d037cf4a
+AAD = c026696e6425e6c33f45b4145febf1137e7ac26383c9f5aa4cd4e5e8abb19e07
+Tag = d57603d5c45606c68be5535c671d5432
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = e676f5dfde8ad810d9e729d142670eef77f2878369a28797
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 6c8ba94f09cbe6
+AAD = 774ad1a88f8bb063951486d4aec5bf82d5fc535bd0b952f86200c123c37fa496
+Tag = a0bfd54fb786208e1e49c6d0e645d9fb
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 60c51e5c3fe4197454d64fa14017639bcfd1423b9d74e506
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 1f670302fcdcc8
+AAD = 1a9ff9698cfc96b581d7115c822e4363d7355ec5daed2eae5bf89ee944ac7d9c
+Tag = af8a9b7a5c50b0be4596290a4d405e79
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 64d1160365062eca1027cc7036862b027bdda3a9abdf794d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 5d05f658c729a2
+AAD = dd9564c1431ed490b17ef69f6115805e54ef156ef4e10e58f7d57a7e86626352
+Tag = 2ce9c776932ecf7fddd849be58096b88
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 968ca115583c645710d2b47fb196cf55f6ef33f2b01400e2
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 22a77db9fcbc95
+AAD = 86bf1739c10f63df734ee3e60ac40ff5636c49f68ca4c16ece289609eb413e7a
+Tag = 915d0020da92f483a5a7914cba14b1e7
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 4985821b16ff6d4d3416573e2fba4d53186d912f0b023a99
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 491e32b0bbfa4c
+AAD = 75bef075c79d6cfd7fc73aefd67b2d215be0648937477ba606b1fe1be591239e
+Tag = 71420e036ea48dddd671be622d372c5b
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = c7345b031ef85bde766226a7603adaa7dcb07a7b2a8be1b5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = bc4b7d3a380be0
+AAD = 353dbb41e2d525a9f4fcd858d0f0aa1b1e86ac0f936d5c09c6b61c343f94e3fc
+Tag = b619a331f8d67d70c3f3a59b3fab53a5
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 11460b9acccc13001be236814da6b73f2c8e0467574f151b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = a840e98df72ae9
+AAD = 22c6607732ef1bdc7fcf6197e037cdadd7ee17c008552dd9f04b8564d34fb17c
+Tag = b944bb46306a9b1e783f3e54c92d5f5e
+Plaintext = a2f53385618b41301f4e3ea4c597f411103dac2b37abf5da
+Ciphertext = 1bcff940a2d9d48e93bbfd13aed5947237485983e6ae04b8
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 39d93c3cf31a6f
+AAD = 937dfac5cded938438f4e97aabd9beb50dba40f824198260a89729479cfe6869
+Tag = 48608963f3037763843b70c35d7011f8
+Plaintext = c1bdef96dc868446be48491b160504546f2a40dd581f9582
+Ciphertext = 3b6c1570c85f297079be14cd66d335251c7b52e131a636f1
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 0bbc177019321e
+AAD = f6e02678820f5ccbede6cbded02d6dd58d486166d7b18ee975a688af421fb795
+Tag = 4ba2d0944c68cc36d4125b3ef9071d69
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = b540cd8cbe733e0ca2ba2112ea785596d2c1d707f4160851
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = ad048eb2ad7526
+AAD = 0d2739cfdac782b61f484fa1a423c478c414397ec420327963d79112b2d70a7e
+Tag = 51387922af7182b7d46a33c703e6e7a8
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = 3c9c1481f1428acf202b510dca67e5e6b2abc5dd71a954da
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = c25e5329
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 934f893824e880f743d196b22d1f340a52608155087bd28a
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 0812757ad0cc4d17c4cfe7a642
+AAD = ec6c44a7e94e51a3ca6dee229098391575ec7213c85267fbf7492fdbeee61b10
+Tag = 59b3b3ee
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = f43ba9d834ad85dfab3f1c0c27c3441fe4e411a38a261a65
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = eff510acc1b85f35029cf7dc00
+AAD = 0923b927b8295c5dfaf67da55e5014293bc8c708fda50af06c1e8aef31cccc86
+Tag = 0bf6688e
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = c686eac859a7bae3cce97d0b6527a0a7c8c2b24ece35f437
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 3d13d09057190366c63c8750e9
+AAD = 77e27aa9a7bf30e130c862a3296a1cd7a10195ed1d940f2c97bfff47c6f06e32
+Tag = 80ed869c
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 2b28355ecf7246ddb08d65c464dcaa90af85f434ff952672
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = e3c03ef7e1d31961ee0b97bd99
+AAD = 8a3676dd640821b58fb0f0329855fd5882c376ea166b958b7aaad223054e5784
+Tag = cd399507
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = ecde42091baa1f5c17b79746e21c3de5c78984570748021c
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 5d165ddd4e599387af5967cae6
+AAD = e374f875ce829b62c98fbd67bcf128b5647f25fff9a643300eb95559b889baed
+Tag = 3da37b66
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 5c338435ed4f148342604c9aed63e907c100453d719fda2a
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = fcec171162a27a96066181fab2
+AAD = cf431cc3671ec468ea86f6cc09842fcf3a84b3ef0fa1c7b20b232145b4469d62
+Tag = 7e75dded
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 30eac1042015eb82729673edd9939bf9995b2575da4d6c4c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 2fa8120398d1a946f391367cf6
+AAD = 92558a239c8e13230754f23aec67b153db29fdfc7daf641778185dd2931d89da
+Tag = 722b9c87
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = ebd3ce55b40e4bbd8172033948c6c78049161ee8f949eb50
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 88e0ae338bbca9d4299b294354
+AAD = 5db5c388dbadc9f175a5cd5a1472a458d25acd7fb9c951c0cd45edf64da473bb
+Tag = 48c042e5
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 20f79b36ca83baac97600fd8a6dad22c2cd0f9b7e7705760
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 4862e36296d6afc9399a95bbb4
+AAD = 36d82ebd0e0f5fe3b12946d041ae5aee16e6d17025406dd776f499bbd8e8b4c8
+Tag = 885ba975
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 77b76f249f936fb19bd47fe28ad4dbb7725dec365a1cb23a
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 2f360a4715074e942244ab7f9b
+AAD = f0087b0086a081c1071481f033a8be8e940c36763084329bb8461b9102238f4f
+Tag = aa799e79
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = cf6763a23c2eab730845d1eb79bbba9f54ee899fe3d70570
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 93e08854560edb096e5d654086
+AAD = bdc60dff08bfd5d44320b75c61e456fd4333c9c3d0294d4a48d936dfd5922ce2
+Tag = 6c0b0104
+Plaintext = 569e4aec88dd51ca519c0a00c922ee33d3559b98a32d7906
+Ciphertext = 1f8086a43c1b2dea557952db88e0dbbdb96aafdb345eddae
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = e3f37b68ff508cfe295441d9e3
+AAD = b2b6c5782e4f128467c589d2a6cf55ef12877adb771bbb6245c5bba9dcfd6208
+Tag = 47a28dd8
+Plaintext = 02b5511204bd55f7c37973e26f6df5883c0a530f07c7f8c2
+Ciphertext = c0c5f92285b114e0a0777e1bc22b810e7cc4f68c28cd5ce0
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = ea98ec44f5a86715014783172e
+AAD = e4692b9f06b666c7451b146c8aeb07a6e30c629d28065c3dde5940325b14b810
+Tag = b7543552
+Plaintext = 4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10
+Ciphertext = 56327f4db9c18f72bbefc3f316d31f9795dd77f493385ab7
+
+Cipher = aes-128-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728c
+IV = 5a16a8902bd70fa06cfe184c57
+AAD = 399d6b0652836457ec4f701f0dc0e5aed73d16585d61cb1bb5b7ee824fc287c8
+Tag = ee39867e
+Plaintext = 4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10
+Ciphertext = 37d5b17995fac8c94302ec9ba20a36d97678e85199b677f8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = c0a458bfcafa3b2609afe0f825cbf503
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 50038b5fdd364ee747b70d00bd36840ece4ea19998123375
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 0812757ad0cc4d17c4cfe7a642
+AAD = ec6c44a7e94e51a3ca6dee229098391575ec7213c85267fbf7492fdbeee61b10
+Tag = 390042ba8bb5f6798dab01c5afad7306
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 78ed8ff6b5a1255d0fbd0a719a9c27b059ff5f83d0c4962c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = eff510acc1b85f35029cf7dc00
+AAD = 0923b927b8295c5dfaf67da55e5014293bc8c708fda50af06c1e8aef31cccc86
+Tag = a3463394cf3c25bef8af8f244d0c0b00
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 4b91d8e616d3f60452fd3a576bd7c265b7f549523ed4a5d7
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 3d13d09057190366c63c8750e9
+AAD = 77e27aa9a7bf30e130c862a3296a1cd7a10195ed1d940f2c97bfff47c6f06e32
+Tag = 88caf8ae59d9d1131626da0dddf8722d
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = ab8cf8891ab62924c0c6f49dd253cfa0c3d6260d0ee4d9ba
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = e3c03ef7e1d31961ee0b97bd99
+AAD = 8a3676dd640821b58fb0f0329855fd5882c376ea166b958b7aaad223054e5784
+Tag = d1292373a76970eda77a8194f6276262
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = c6b7680f321132a8bd00e8e92f785d0b828b100af6392a04
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 5d165ddd4e599387af5967cae6
+AAD = e374f875ce829b62c98fbd67bcf128b5647f25fff9a643300eb95559b889baed
+Tag = a97af19d0b7bf7c7ce398cb0b44d73af
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = aea98867d3d707c43a963c1d7fdcfc953cbd707803b2b5f0
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = fcec171162a27a96066181fab2
+AAD = cf431cc3671ec468ea86f6cc09842fcf3a84b3ef0fa1c7b20b232145b4469d62
+Tag = 343065b4bdd973ee072dbf5160d310f3
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = c55e17ba7886eb58126d50bde8c5c211cc1aafd71a3d9e5b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 2fa8120398d1a946f391367cf6
+AAD = 92558a239c8e13230754f23aec67b153db29fdfc7daf641778185dd2931d89da
+Tag = 233ec600bca1d31f704807494fb0f18d
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 791a62d5fb39ff9735ad94507e1afe2647714d5cc56b6ff4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 88e0ae338bbca9d4299b294354
+AAD = 5db5c388dbadc9f175a5cd5a1472a458d25acd7fb9c951c0cd45edf64da473bb
+Tag = 7ec183db0e2a33ebb147d0e2363fbb01
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = f98a081998e29500f15ebd8978a95423aed4e8e78e0279d1
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 4862e36296d6afc9399a95bbb4
+AAD = 36d82ebd0e0f5fe3b12946d041ae5aee16e6d17025406dd776f499bbd8e8b4c8
+Tag = 7e67ea2577ade5836c26a89760e0959b
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 7779814dc295a23b4100ca94bec0ad4ce2f6be6fb75a0c21
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 2f360a4715074e942244ab7f9b
+AAD = f0087b0086a081c1071481f033a8be8e940c36763084329bb8461b9102238f4f
+Tag = 4978a7865df8369635269411b3aaeb32
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 55640eed12c7595a36ab423da8d8241905b6ff1e906db962
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = 93e08854560edb096e5d654086
+AAD = bdc60dff08bfd5d44320b75c61e456fd4333c9c3d0294d4a48d936dfd5922ce2
+Tag = 4f9d302e4f1d2a2aedf2768d7b29163f
+Plaintext = 569e4aec88dd51ca519c0a00c922ee33d3559b98a32d7906
+Ciphertext = 7fcdce0ba567b9a708d54fdb16125de71dce952f4741684f
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = e3f37b68ff508cfe295441d9e3
+AAD = b2b6c5782e4f128467c589d2a6cf55ef12877adb771bbb6245c5bba9dcfd6208
+Tag = a50036af67fadab163e9daa8bd8e9030
+Plaintext = 02b5511204bd55f7c37973e26f6df5883c0a530f07c7f8c2
+Ciphertext = d42111ba22987eac1ead5cc6cb8548bcda190d118dcd5461
+
+Cipher = aes-128-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0e
+IV = ea98ec44f5a86715014783172e
+AAD = e4692b9f06b666c7451b146c8aeb07a6e30c629d28065c3dde5940325b14b810
+Tag = 2f1322ac69b848b001476323aed84c47
+Plaintext = 4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10
+Ciphertext = 1bf0ba0ebb20d8edba59f29a9371750c9c714078f73c335d
+
+
+Title = NIST CCM 192 Decryption-Verfication Process Tests
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 5a8aa485c316e9
+AAD =
+Tag = 9d4b7f3b
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 3796cf51b87266
+AAD =
+Tag = 80745de9
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 89ca5a64050f9f
+AAD =
+Tag = 2f6fa823
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = ec9d8edff25645
+AAD =
+Tag = 3cc132c6
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 05e16f0f42a6f4
+AAD =
+Tag = c79d5557
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 2e504b694f8df5
+AAD =
+Tag = 41e0eea0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 06d102a9328863
+AAD =
+Tag = 1f129266
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = c288b810fb5334
+AAD =
+Tag = 41b0e4e2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 08a166d9eb6610
+AAD =
+Tag = 5082e06a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 4a5810b121c91b
+AAD =
+Tag = 70587cce
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 44077341139bf9
+AAD =
+Tag = 6aaa0acd
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = a9df4f37847e1f
+AAD =
+Tag = 22976e42
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 11df57fcd131e9
+AAD =
+Tag = f440ea1d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 890fff56d10dc0
+AAD =
+Tag = 88903fb9
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = c98ad7f38b2c7e970c9b965ec87a08208384718f78206c6c
+IV = 9dc18698731b27
+AAD =
+Tag = 3ff345c3
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 5a8aa485c316e9
+AAD =
+Tag = 17223038fa99d53681ca1beabe78d1b4
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 3796cf51b87266
+AAD =
+Tag = d0e1eeef4d2a264536bb1c2c1bde7c35
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 89ca5a64050f9f
+AAD =
+Tag = 81d587f8673fd514c23172af7fb7523d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = ec9d8edff25645
+AAD =
+Tag = 500142447e535207899ab1499994daea
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 05e16f0f42a6f4
+AAD =
+Tag = fdfdbb38bf161785114f9ee2018e892f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 2e504b694f8df5
+AAD =
+Tag = 38fe9622eaa2a50152cf57e393dd3063
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 06d102a9328863
+AAD =
+Tag = 73af4b87c167572e1400a0ee28209aff
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = c288b810fb5334
+AAD =
+Tag = ace2248b9f23efa813449c82217e4a4a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 08a166d9eb6610
+AAD =
+Tag = a9bb0e469829d9cf09ad765c5b0b58bf
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 4a5810b121c91b
+AAD =
+Tag = a5977f0826926ec0d32541b2bd4e2b1e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 44077341139bf9
+AAD =
+Tag = 6938fb5afec1a84e4abb062e1a943c20
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = a9df4f37847e1f
+AAD =
+Tag = 7e3bbe0eb13988a93972f2fbcd35659e
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 11df57fcd131e9
+AAD =
+Tag = 48d7a15cf4f5808eb45d1ad817470554
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 890fff56d10dc0
+AAD =
+Tag = 97185ce68af1e6ab718c8c4b83ec04cd
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 9dc18698731b27
+AAD =
+Tag = a81bc8f5a18293ffe19505a3687ce3f3
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = fe69ed84
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = a16a2e741f1cd9717285b6d882
+AAD =
+Tag = db7ffc82
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 368f3b8180fd4b851b7b272cb1
+AAD =
+Tag = 7a677329
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 7bb2bc00c0cafce65b5299ae64
+AAD =
+Tag = d903d8f7
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 935c1ef3d4032ff090f91141f3
+AAD =
+Tag = 215e0bf2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 2640b14f10b116411d1b5c1ad1
+AAD =
+Tag = 0d38100f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = b229c173a13b2d83af91ec45b0
+AAD =
+Tag = 9f8ab5f7
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 37ca0dc2d6efd9efde69f14f03
+AAD =
+Tag = 7d811d50
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 6b6238aed86d677ba2b3e2622c
+AAD =
+Tag = c2e18439
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = d6cb2ac67bb13b8f6d31fad64a
+AAD =
+Tag = d8b5817b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 32a7cd361ef00e65f5778fdfd4
+AAD =
+Tag = 28cd70ff
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = d0a1508fdefcf5be30a459b813
+AAD =
+Tag = 790b2624
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = 5381a61b449dc6a42aa4c79b95
+AAD =
+Tag = 9e46632d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = c55430f2da0687ea40313884ab
+AAD =
+Tag = 39b82901
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 4bb3c4a4f893ad8c9bdc833c325d62b3d3ad1bccf9282a65
+IV = ec76d1850acc0979a1f11906fb
+AAD =
+Tag = 4c0cf71f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = 0c66a8e547ed4f8c2c9a9a1eb5d455b9
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = a16a2e741f1cd9717285b6d882
+AAD =
+Tag = 38757b3a61a4dc97ca3ab88bf1240695
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 368f3b8180fd4b851b7b272cb1
+AAD =
+Tag = 11875da4445d92391d0fab5f3625497b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 7bb2bc00c0cafce65b5299ae64
+AAD =
+Tag = 64477bcd4316e5c5789e1a678fdef943
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 935c1ef3d4032ff090f91141f3
+AAD =
+Tag = 87da5dbc04e39fc468f43675d4e7df33
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 2640b14f10b116411d1b5c1ad1
+AAD =
+Tag = bf0d53ee529d8cafc5ad7a8f2d85e7a2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = b229c173a13b2d83af91ec45b0
+AAD =
+Tag = 676370637ad78c705d43fce066dc909f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 37ca0dc2d6efd9efde69f14f03
+AAD =
+Tag = 289936db0f9f148a3c9e2d28f7d7de51
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 6b6238aed86d677ba2b3e2622c
+AAD =
+Tag = 58a283641627669d5514f2af559b6c14
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = d6cb2ac67bb13b8f6d31fad64a
+AAD =
+Tag = a6b058540ed905d6e3499a13ea1f3d83
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 32a7cd361ef00e65f5778fdfd4
+AAD =
+Tag = 7a19b3377384f09915d0e1ae93a9f16c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = d0a1508fdefcf5be30a459b813
+AAD =
+Tag = a0d047a1f9940d325e474da54aa13897
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 5381a61b449dc6a42aa4c79b95
+AAD =
+Tag = 8a4768a2093694b6bcb7083c0bb6331c
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = c55430f2da0687ea40313884ab
+AAD =
+Tag = a7cafd6f68dc1f15a3603da654ce27bc
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = ec76d1850acc0979a1f11906fb
+AAD =
+Tag = c49845f2ea3c9981ad7e9b942f615b8d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 5a8aa485c316e9
+AAD =
+Tag = ddc93a54
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 411986d04d6463100bff03f7d0bde7ea2c3488784378138c
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 31f8fa25827d48
+AAD =
+Tag = b6889036
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 32b649ab56162e55d4148a1292d6a225a988eb1308298273
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 5340ed7752c9ff
+AAD =
+Tag = 9b4de35f
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = a963c3568ab413b174cd95cc1e3ca61ee181292bebdb2817
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 9cbce402511b89
+AAD =
+Tag = 6df9ffc5
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 0396e6c8db43e5fac205f4c576fd577368adcb688cf3d7e7
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 123a0beace4e39
+AAD =
+Tag = b28c8e38
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = b41bfba94edcafc41b4c144269b9126a6d47b19e83b15772
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 8ea1594a58fe4a
+AAD =
+Tag = 7336a30a
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 01e3bb938e16d0284d1d0fee049d80fb97356ae4d84127cf
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 5a7743e59e82da
+AAD =
+Tag = 0c40cc72
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = abd7551c5e84e9bef5fbfad3e24d13f02864410eae9177ad
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = f477f754d7ee76
+AAD =
+Tag = fc9fd290
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 3b5ae49e0974f41826152432b46f1a85ab4995afefbbccdd
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 040a257dede70e
+AAD =
+Tag = e485910b
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 21fb4324de4ba1e2762b3041ce26e43a3d191458a046d489
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = dd51b8e91683d1
+AAD =
+Tag = 8695053f
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 99ca8f542fd06481e23719214c9892442f393d72899deea0
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = ab3cb86cca6fb2
+AAD =
+Tag = 050d2054
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 5fcc05342cdc27f66b324ae7387205bfb4ab6302bfe0af09
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = f67b98efd39b55
+AAD =
+Tag = 6def28ab
+Plaintext = f2e944e1ae47ad5873bf391f1b0cc07f6151eb4c50bb45b2
+Ciphertext = 0a7fe63046daf8a979935b897088c64acc1b47a5a9b86fdd
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = e60e2c002d1c99
+AAD =
+Tag = 68941fce
+Plaintext = 70f48dc1d76e5028da07e29852801375a9edb2214a5ea4c0
+Ciphertext = daf7d7dfa512ceb1d7d3435634d9a70b3ef6c6dc38f409e0
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 098e053fa08043
+AAD =
+Tag = 51a1ec4a
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = cdb417dff6502208775f21e35cdb8e3e1199308d1a942290
+
+Cipher = aes-192-ccm
+Key = 19ebfde2d5468ba0a3031bde629b11fd4094afcb205393fa
+IV = 4bf48328725514
+AAD =
+Tag = 98eaddaf
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = e75441093c8ccba6eac5913dc246ce96de4784a010514982
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 5a8aa485c316e9
+AAD =
+Tag = c5a5ebecf7ac8607fe412189e83d9d20
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = cba4b4aeb85f0492fd8d905c4a6d8233139833373ef188a8
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 31f8fa25827d48
+AAD =
+Tag = e699f15f14d34dcaf9ba8ed4b877c97d
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = ca62713728b5c9d652504b0ae8fd4fee5d297ee6a8d19cb6
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 5340ed7752c9ff
+AAD =
+Tag = f3b8899459788c58794f177cfd838f35
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = 93012c0a5f6f1025b8c4a5d897d3eea0b1c77be8000c9e59
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 9cbce402511b89
+AAD =
+Tag = 3ad22e8fa4d2f9725ce4f212a8844855
+Plaintext = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22
+Ciphertext = b8eb95f72f643c2c51ad74775cc203d215c86626e903eb01
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 123a0beace4e39
+AAD =
+Tag = b5eab45d7d096577643815e6d467312d
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 71f17cf21c44267c676657db9e55bee33273787474e77b17
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 8ea1594a58fe4a
+AAD =
+Tag = 8b1a5ecca7354af824fea617b9b69031
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = d6737f642260c4ee3b19cb78cc2ef1767213416b82c71e91
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 5a7743e59e82da
+AAD =
+Tag = c54c98f8007ed55a21759f5452559538
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = cbe60d633399daa6ee66418be6d16e292ea47a93c291fce2
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = f477f754d7ee76
+AAD =
+Tag = a555aa972e1c2e3f439f85663ae25889
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 2a78a7beb8df4bf5d35ff0b2853bc51ce127163d2f56e00e
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 040a257dede70e
+AAD =
+Tag = 9aeb326578fa615e86969348d9bbfb7f
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = ee78ddbea9c3aede9f88af0e82464d9d1afe81de16aa18c4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = dd51b8e91683d1
+AAD =
+Tag = 2efbff1da769af3b72099cbda3cbf091
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = cdf7cb74d978e7ea738e288ed79edfccf10b553c09d1856e
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = ab3cb86cca6fb2
+AAD =
+Tag = 3291a566e6641a965ffdabe097050dc5
+Plaintext = 9d033e3b66efed1467868f382417c80594877a28bc97f406
+Ciphertext = 90b990a1ea254592f2c226c969b332fc7bfe5f808729c2d8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = f67b98efd39b55
+AAD =
+Tag = 84b47504dced5b70c302cc93502cc37e
+Plaintext = f2e944e1ae47ad5873bf391f1b0cc07f6151eb4c50bb45b2
+Ciphertext = 44a6aa954c3508b3c9264c20c272e80c0e95d50ddec28490
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = e60e2c002d1c99
+AAD =
+Tag = 37109739a3676f03adfd740dbaa4940d
+Plaintext = 70f48dc1d76e5028da07e29852801375a9edb2214a5ea4c0
+Ciphertext = 9d4ff7a44cdb9b14f586efc3d6be02d069b425c06bec4eed
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 098e053fa08043
+AAD =
+Tag = c4bfacbb2f246b570efd93d98e99be49
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = 23da95e102c7921a51b19b5733ea5776ab6c287f6057c00e
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 4bf48328725514
+AAD =
+Tag = 6496912db41761a1d2aecfda04fb2cfa
+Plaintext = bd81680e3dc0b35431c92598dcaa26ef09ca0da5e77193de
+Ciphertext = 53d00d5839d0a1e695916151f9450b7311982917edcbd7c6
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = 34fad277
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 042653c674ef2a90f7fb11d30848e530ae59478f1051633a
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 49004912fdd7269279b1f06a89
+AAD =
+Tag = a35df775
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 1902d9769a7ba3d3268e1257395c8c2e5f98eef295dcbfa5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = efeb82c8c68d6600b24dd6d8ee
+AAD =
+Tag = 1faaf310
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = ebacb8e78c0ad9d3ed99f1821b0b0085beac351f88a79ef7
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 7b93d368dc551640b00ba3cbb5
+AAD =
+Tag = 4d5e6103
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = efc1d5b6f0a48e4ce3e821d743d34206b28c69485c410fa9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 24b7a65391f88bea38fcd54a9a
+AAD =
+Tag = 69ac966a
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 3c1836e5d0f0473dab7bfd7a95ba69575f7f841970ac6c67
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 6aa3f731522fce7e366ba59945
+AAD =
+Tag = c47e9a8e
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 2c583e54d75a02948c7f6dcd12cba32a65e8d605fba7ec10
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = a11cf5bed0041ee3cb1fef4b43
+AAD =
+Tag = 1f3f537f
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = a8632dee22f34315b05c40135c6dd471c63b09438da834dc
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 273cc5013785baeb5abc79c8bd
+AAD =
+Tag = 26421940
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 0f03ea1b2561951d79062e19a85d98293c8c2846936c724c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = d2d4482ea8e98c1cf309671895
+AAD =
+Tag = a3a22ac7
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = f9764405e54d827ac433fd624506b92e123463a5b01f21ff
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = a8849b44adb48d271979656930
+AAD =
+Tag = 89429246
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = a326e0cf3f97adff3249944880ddfb8d616cd18a086e0462
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = a632ba0d00511122abcd6227ff
+AAD =
+Tag = 4c9649b7
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = f188bc1a72e81b34d75b402e4f8ef3d638d2f56a409eab06
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = c47af80cd26d047630c1fdf0d1
+AAD =
+Tag = e2e93f29
+Plaintext = d8306c9c4ea6c69c6e2ad0fc0e49b1e0126b01078d6419ff
+Ciphertext = 341df3a273e85cf387ab823bdf9c34a1ae2c86940cb4bfcd
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 70e132023acae1f88c7a237b68
+AAD =
+Tag = 35c7081d
+Plaintext = d0b2bef5ed1a87d9c73d4a459cb05c11799c4f51ad640b1e
+Ciphertext = a0e7997fd67ea66b6274d719b84da92433fdf7d512b160da
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = 8010d3a2a14f72f5585defc940
+AAD =
+Tag = f83a9ad7
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = dd8fd11e1c0746e7273fdd2e7dfa1ee4fc8ad835ca3141c0
+
+Cipher = aes-192-ccm
+Key = 197afb02ffbd8f699dacae87094d524324576b99844f75e1
+IV = a98c2f0e0a7b68942853905191
+AAD =
+Tag = 7ff1eb5d
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = 39b0d3603f1289b5885ac244953275d28491952e7e57d93c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 5a8aa485c316e9403aff859fbb
+AAD =
+Tag = a7ade30a07d185692ab0ebdf4c78cf7a
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = a5b7d8cca2069908d1ed88e6a9fe2c9bede3131dad54671e
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 49004912fdd7269279b1f06a89
+AAD =
+Tag = f042c86363cc05afb98c66e16be8a445
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 9a98617fb97a0dfe466be692272dcdaec1c5443a3b51312e
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = efeb82c8c68d6600b24dd6d8ee
+AAD =
+Tag = 41a8f6ac697430627826bd76b19da027
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = d3068ae815c3605d7670058abb9384f4c15b75150eb79100
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 7b93d368dc551640b00ba3cbb5
+AAD =
+Tag = 980581017fefef92c2b50ae20b93c81c
+Plaintext = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697
+Ciphertext = 388a289bb85533b667b141a78d0c79acdeb9fbf72886d5ab
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 24b7a65391f88bea38fcd54a9a
+AAD =
+Tag = 327f5f91763c0a0bec43264c27cd237f
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 71f68480a8801d4966c84807c5ff6139d83ba0a5b902bee3
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 6aa3f731522fce7e366ba59945
+AAD =
+Tag = 52c4b7fd911ca77950ff2d035e47b7ec
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 8627bf1e3edafc69f1328c393dd8e7bd1c182d021e6d3a36
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = a11cf5bed0041ee3cb1fef4b43
+AAD =
+Tag = 4ffcb29bde8b9a81945d671b0f619045
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = b10ea86a384432a45f50b3c2e482595b46c81c61ca39bc0f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 273cc5013785baeb5abc79c8bd
+AAD =
+Tag = 578cc14aa558e18d5f777ab6e16dcfee
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 3ace8b7e03a0c1fa9e97f46975ab0a4924446e791540e225
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = d2d4482ea8e98c1cf309671895
+AAD =
+Tag = 75433c4ae28757c8544c86f1f74ea6a5
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 8190abe4c21e320e10825e269190bb10a354691958e24362
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = a8849b44adb48d271979656930
+AAD =
+Tag = d7752ebe9c5dbf00ee8ad60ac34dd7d0
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 1d7e308c34cdca7b7b222f4ebc92afd8055bff542c0b76d3
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = a632ba0d00511122abcd6227ff
+AAD =
+Tag = 0a4432b35d3b884e4169c28d287499ff
+Plaintext = 43419715cef9a48dc7280bc035082a6581afd1d82bee9d1a
+Ciphertext = 9c2609f7af5b634a16e58f2e9cc7a9ef7812a12d20984700
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = c47af80cd26d047630c1fdf0d1
+AAD =
+Tag = 9256ace490c2f0afb93ba32be58fd1de
+Plaintext = d8306c9c4ea6c69c6e2ad0fc0e49b1e0126b01078d6419ff
+Ciphertext = 5b0b5e6690d648e1b92c12cfddb431d6d3dfe689d01db819
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 70e132023acae1f88c7a237b68
+AAD =
+Tag = efd8535dd6b7fa701c9ca8c8b635c30b
+Plaintext = d0b2bef5ed1a87d9c73d4a459cb05c11799c4f51ad640b1e
+Ciphertext = 8722fca71fdf750ec5d62fc6d7ba079aef19210da764067a
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 8010d3a2a14f72f5585defc940
+AAD =
+Tag = 1b5d2cd4d5b6d2ef48413245a6b27b67
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = 91ac457f5e53492301e72d9d495277ed17edb30e8c7a48d2
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = a98c2f0e0a7b68942853905191
+AAD =
+Tag = fdc83ea4863c3e84a5456f7f853a1ea6
+Plaintext = 4faba05569bf7ac656780c16995e9122e565fe9984be8a68
+Ciphertext = d2fe5293b7d53ed46ddf02a5618039adbae22845ce72e434
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 1d089a5f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = a265480ca88d5f
+AAD = a2248a882ecbf850daf91933a389e78e81623d233dfd47bf8321361a38f138fe
+Tag = 2f46022a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 87ec7423f1ebfc
+AAD = 2bed1ec06c1ca149d9ffbaf048c474ea2de000eb7950f18d6c25acf6ab3f19b5
+Tag = 67dc4693
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = b8b04f90616082
+AAD = 4898731e143fcc677c7cf1a8f2b3c4039fb5e57028e33b05e097d1763cbfe4d8
+Tag = 7027a849
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 8c687b4318813a
+AAD = fcad52a88544325bb31eb5de4a41dbff6a96f69d0993b969a01792ee23953acf
+Tag = 5c6a4de2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 29b810eed8fc92
+AAD = 40d1d320eb63a25d7a2b3141563a552114275ddda56beb62cc0c0273d5795faa
+Tag = 1d855f5d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 62452462c53934
+AAD = 1eb8863ea100babc1713654afcf54f21f8bff754223ad70269ace9d034f26a96
+Tag = 1b318980
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 4cceba0e7aee97
+AAD = f33e184c967165eb62542999afaca4e3e319840e439b5bb509544fb4b6901445
+Tag = cf871f91
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = b5151b0601c683
+AAD = 73d27303ec91f28c79b278882034d11eb6a5266746f37edbb77f8409a8738b8c
+Tag = 4f0e04bc
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = 4e5d6d7ac9e71e
+AAD = a01b6e152fe232b6c10b5d89900961c445f4c46833df242c826678b68c869811
+Tag = fc9013df
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = dc88e989951a3f
+AAD = fdcacfaff46585406cc45a2da364e67e132a91c98900a8f9d7bfb14ec951fca5
+Tag = 5134def3
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = a1aeda4b4cb8dd
+AAD = db3022ef4cd68ae22b501599448ffe2dda15cfd2e259315c6f6d03036edea963
+Tag = 5814103a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = f248e5225e3d9a
+AAD = fdc64ef76a3bfd0a15d0bc8e8bacaf64346796a3e35afcf2ac1ab136f63f7b6e
+Tag = 74c75c4a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = e68228f5c65b73
+AAD = 614efdf89ce2a9fcbd38bdc0b4cece54dfd7532880e0b4ce6eb3a4010b7cb1e7
+Tag = 9884898b
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 90929a4b0ac65b350ad1591611fe48297e03956f6083e451
+IV = ea167cfd1101d9
+AAD = 28130f938c45a1a92b02dbeadbd8df816b6d934e87cca2dfdbfdc49c7cd84041
+Tag = 0b1cbfb1
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 5280a2137fee3deefcfe9b63a1199fb3
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = a265480ca88d5f
+AAD = a2248a882ecbf850daf91933a389e78e81623d233dfd47bf8321361a38f138fe
+Tag = d40a7318c5f2d82f838c0beeefe0d598
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 87ec7423f1ebfc
+AAD = 2bed1ec06c1ca149d9ffbaf048c474ea2de000eb7950f18d6c25acf6ab3f19b5
+Tag = 7551978bc9592bf9e294b4984c5862bb
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = b8b04f90616082
+AAD = 4898731e143fcc677c7cf1a8f2b3c4039fb5e57028e33b05e097d1763cbfe4d8
+Tag = 859cf444f89225b32a55a1645bd24979
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 8c687b4318813a
+AAD = fcad52a88544325bb31eb5de4a41dbff6a96f69d0993b969a01792ee23953acf
+Tag = 29e967a0245607c36cf3eaf00fdae566
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 29b810eed8fc92
+AAD = 40d1d320eb63a25d7a2b3141563a552114275ddda56beb62cc0c0273d5795faa
+Tag = 9daa0e1c4df5f2bf507b1a57a1135b86
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 62452462c53934
+AAD = 1eb8863ea100babc1713654afcf54f21f8bff754223ad70269ace9d034f26a96
+Tag = 18caec79720a5d67d7457e9b7c7a153c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 4cceba0e7aee97
+AAD = f33e184c967165eb62542999afaca4e3e319840e439b5bb509544fb4b6901445
+Tag = 5f2c455546c56f514a0f69f05345c2c4
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = b5151b0601c683
+AAD = 73d27303ec91f28c79b278882034d11eb6a5266746f37edbb77f8409a8738b8c
+Tag = b7e4846ff30b7c3673a962a2701c0387
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 4e5d6d7ac9e71e
+AAD = a01b6e152fe232b6c10b5d89900961c445f4c46833df242c826678b68c869811
+Tag = 7b5fa0d42a616ab05ac2c58c904ce92f
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = dc88e989951a3f
+AAD = fdcacfaff46585406cc45a2da364e67e132a91c98900a8f9d7bfb14ec951fca5
+Tag = c8c67f558b5844b149dd47824c8cb9d8
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = a1aeda4b4cb8dd
+AAD = db3022ef4cd68ae22b501599448ffe2dda15cfd2e259315c6f6d03036edea963
+Tag = 70a09aaf22ac316124a169f6b0a83ffe
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = f248e5225e3d9a
+AAD = fdc64ef76a3bfd0a15d0bc8e8bacaf64346796a3e35afcf2ac1ab136f63f7b6e
+Tag = 5bc85ed5521a91b9eb42b437950f0e06
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = e68228f5c65b73
+AAD = 614efdf89ce2a9fcbd38bdc0b4cece54dfd7532880e0b4ce6eb3a4010b7cb1e7
+Tag = 989ec0e7b192ea010dd61d3fb64e8de0
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = ea167cfd1101d9
+AAD = 28130f938c45a1a92b02dbeadbd8df816b6d934e87cca2dfdbfdc49c7cd84041
+Tag = 15c2dbe7fa307654d8ca7c0f8d6d2f14
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = 5e0eaebd
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 8739b4bea1a099fe547499cbc6
+AAD = f6107696edb332b2ea059d8860fee26be42e5e12e1a4f79a8d0eafce1b2278a7
+Tag = 71b7fc33
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 0f98fdbde2b04387f27b3401dd
+AAD = 02010329660fa716556193eb4870ee84bd934296a5c52d92bba859cc13caaddc
+Tag = 93227bd4
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 4eed58f381e500902ba5c56864
+AAD = 96056d9ebd7c553c22cc2d9d816b61123750d96c1b08c4b661079424bf3c4946
+Tag = ced654e2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 1e7e51f0fa9a33ed618c26f5e3
+AAD = da9b8ffb0f3c2aee2e386cc9f035ec1eb3e629bd1544c11dc21be4fd8ac9074a
+Tag = bf7a8e0c
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = f012f94f5988c79aa179d7fdfc
+AAD = 612b2ef2683109d99452f95099417641d0c2be3f8ab4cbb2a44e83355ba9303c
+Tag = 840caa3e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 715acf92cfb69ad56036c49e70
+AAD = 960667b85be07304634124b9324be12a1c11451f1fa9db82c683265b4cf8e5ff
+Tag = 1e22fc41
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 141be3601e38185a9fa1596d2e
+AAD = 606452c62290b43559a588bb03356f846cecb0ccaf0bdaf67a18abd811d4315a
+Tag = 968ccbbf
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = fcdda3c5f0e80843b03d8788da
+AAD = 03f22247a55461a293d253c77483859fdac1b87c2480e208a3df767cfbfde512
+Tag = 0a31cc96
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = ca660ed3b917c0aca140dcd3fb
+AAD = 254a86f5b20d344ad86fd5523d08f1864737be57731440c29aa6b42574572f51
+Tag = a456c3da
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 642ae3466661ce1f51783deece
+AAD = 4432a1cec5976cc13b8fb78341d426c2248f091b597123d263ffafc7f82da5a5
+Tag = 29746eea
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 7864c717ec93db38b10679be47
+AAD = 679aad1ad1e57029e3362b325572fc71cac53184b0f1546867e665a4a59466c4
+Tag = df7f63ca
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = c3bf9dfe9d6c26f543188fb457
+AAD = e301f69ad3a7e08a3d02462f0aa584449eb0449b0e3c50aa8dfaa4472816c8b0
+Tag = bf0b1445
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = 1527657d2fd98f7deca55cc649
+AAD = f4c723433b7cafe3cda9bb4940a21a89a8382d13018b622ccd1ffb9ffd3211af
+Tag = ae8533f5
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 6a798d7c5e1a72b43e20ad5c7b08567b12ab744b61c070e2
+IV = b8432d3d5525a0dadbbaa6b6b8
+AAD = 86ee6e37b4a2d9a0b52ec95643b4e8297e237721e15ce8bf7593a98644f83eba
+Tag = 9426cf89
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = d07ccf9fdc3d33aa94cda3d230da707c
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 8739b4bea1a099fe547499cbc6
+AAD = f6107696edb332b2ea059d8860fee26be42e5e12e1a4f79a8d0eafce1b2278a7
+Tag = 65fe32b649dc328c9f531584897e85b3
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 0f98fdbde2b04387f27b3401dd
+AAD = 02010329660fa716556193eb4870ee84bd934296a5c52d92bba859cc13caaddc
+Tag = ec31fb6b41c2dae87cf395fc1fe3a080
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 4eed58f381e500902ba5c56864
+AAD = 96056d9ebd7c553c22cc2d9d816b61123750d96c1b08c4b661079424bf3c4946
+Tag = 33c2f2312dd5bfcadbb05f8d0a33fd4a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 1e7e51f0fa9a33ed618c26f5e3
+AAD = da9b8ffb0f3c2aee2e386cc9f035ec1eb3e629bd1544c11dc21be4fd8ac9074a
+Tag = a9e81afd1030d195c679e2c837aeb736
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = f012f94f5988c79aa179d7fdfc
+AAD = 612b2ef2683109d99452f95099417641d0c2be3f8ab4cbb2a44e83355ba9303c
+Tag = 1db000f0e7d3a03718293fc118678427
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 715acf92cfb69ad56036c49e70
+AAD = 960667b85be07304634124b9324be12a1c11451f1fa9db82c683265b4cf8e5ff
+Tag = ea37900f049db8fc5cbf46edb5fcac2c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 141be3601e38185a9fa1596d2e
+AAD = 606452c62290b43559a588bb03356f846cecb0ccaf0bdaf67a18abd811d4315a
+Tag = d1097ebd7ad0a41f61ba32a44dc15305
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = fcdda3c5f0e80843b03d8788da
+AAD = 03f22247a55461a293d253c77483859fdac1b87c2480e208a3df767cfbfde512
+Tag = 0979729272d8b42f2e3dc0eb181a1217
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = ca660ed3b917c0aca140dcd3fb
+AAD = 254a86f5b20d344ad86fd5523d08f1864737be57731440c29aa6b42574572f51
+Tag = 4457200916a20116b096225606f1a9e2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 642ae3466661ce1f51783deece
+AAD = 4432a1cec5976cc13b8fb78341d426c2248f091b597123d263ffafc7f82da5a5
+Tag = cc6b51f39a3dcfb54abbb89f4df21114
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 7864c717ec93db38b10679be47
+AAD = 679aad1ad1e57029e3362b325572fc71cac53184b0f1546867e665a4a59466c4
+Tag = aac09cef9697927331251f028d24c31f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = c3bf9dfe9d6c26f543188fb457
+AAD = e301f69ad3a7e08a3d02462f0aa584449eb0449b0e3c50aa8dfaa4472816c8b0
+Tag = 56c00070eae0db329894a045d866bbaf
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 1527657d2fd98f7deca55cc649
+AAD = f4c723433b7cafe3cda9bb4940a21a89a8382d13018b622ccd1ffb9ffd3211af
+Tag = 090016bb96aeaabbf66fd34fc97591a4
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = b8432d3d5525a0dadbbaa6b6b8
+AAD = 86ee6e37b4a2d9a0b52ec95643b4e8297e237721e15ce8bf7593a98644f83eba
+Tag = 264407dfe796bf7f6eb1f26c1f8504ef
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 75dea8d1
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 9f6ca4af9b159148c889a6584d1183ea26e2614874b05045
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = fdd2d6f503c915
+AAD = 5b92394f21ddc3ad49d9b0881b829a5935cb3a4d23e292a62fb66b5e7ab7020e
+Tag = d7965825
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 84d8212e9cfc2121252baa3b065b1edcf50497b9594db1eb
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 27d73d58100054
+AAD = f6468542923be79b4b06dfe70920d57d1da73a9c16f9c9a12d810d7de0d12467
+Tag = f7f796fe
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 5f60a8f867a33b2077ecc69863b295c3c6aeae7d7cade7f8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = dd16e0ce1250e3
+AAD = bc65cfd65e9863c8b7457d58afa6bdb48a84170d8aa97ba5b397b52ad17a9242
+Tag = b8f1f2ae
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 1353b3fa1bb1d57ffb139017885c02e26c90231a24b5a615
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = ccee19d037cf4a
+AAD = c026696e6425e6c33f45b4145febf1137e7ac26383c9f5aa4cd4e5e8abb19e07
+Tag = 8b4b53f6
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = c3116d9040e1ed4f7c9464d270fb302bd3f1561c25c5b95b
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 6c8ba94f09cbe6
+AAD = 774ad1a88f8bb063951486d4aec5bf82d5fc535bd0b952f86200c123c37fa496
+Tag = f6bf3800
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 0ca17e8f89bea67db48a8f132ef6c6df7a292914d401299a
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 1f670302fcdcc8
+AAD = 1a9ff9698cfc96b581d7115c822e4363d7355ec5daed2eae5bf89ee944ac7d9c
+Tag = 13244cf6
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 0ce543569e8187f3cec70399ff922e4903cb1d12f990f056
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 5d05f658c729a2
+AAD = dd9564c1431ed490b17ef69f6115805e54ef156ef4e10e58f7d57a7e86626352
+Tag = a5876de8
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 3acdbc163a350f312791b152a41e57627b1cc8bf3e41c8ae
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 22a77db9fcbc95
+AAD = 86bf1739c10f63df734ee3e60ac40ff5636c49f68ca4c16ece289609eb413e7a
+Tag = 1970ed17
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 604518e436edf7a0561d5e284f3915839a6d28cb06ef792a
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 491e32b0bbfa4c
+AAD = 75bef075c79d6cfd7fc73aefd67b2d215be0648937477ba606b1fe1be591239e
+Tag = f68d8da4
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = fc79b520d67da891e63654d7927db6c8012c96985a0059d5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = bc4b7d3a380be0
+AAD = 353dbb41e2d525a9f4fcd858d0f0aa1b1e86ac0f936d5c09c6b61c343f94e3fc
+Tag = 90ee4c14
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = d86bb51a98770098d0feb39170bd979199a8f741041df137
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = a840e98df72ae9
+AAD = 22c6607732ef1bdc7fcf6197e037cdadd7ee17c008552dd9f04b8564d34fb17c
+Tag = 29c87855
+Plaintext = a2f53385618b41301f4e3ea4c597f411103dac2b37abf5da
+Ciphertext = 51b6b928bdd1cc0bd0a0aed2cda302472d618ffaa60e1790
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 39d93c3cf31a6f
+AAD = 937dfac5cded938438f4e97aabd9beb50dba40f824198260a89729479cfe6869
+Tag = 4de8ed8d
+Plaintext = c1bdef96dc868446be48491b160504546f2a40dd581f9582
+Ciphertext = d0abab9b8e9d6c11bb9c15bea8a486704bed32c57297055b
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = 0bbc177019321e
+AAD = f6e02678820f5ccbede6cbded02d6dd58d486166d7b18ee975a688af421fb795
+Tag = 31d69947
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = 92fd519a966c0fbdd7087ff5a1bd946cd663502db3783835
+
+Cipher = aes-192-ccm
+Key = f9fdca4ac64fe7f014de0f43039c757194d544ce5d15eed4
+IV = ad048eb2ad7526
+AAD = 0d2739cfdac782b61f484fa1a423c478c414397ec420327963d79112b2d70a7e
+Tag = 30768d4d
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = 7f239b1916830161f3b52b7ab13542a5a0a97a17f30ca5fa
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 5a8aa485c316e9
+AAD = 3796cf51b8726652a4204733b8fbb047cf00fb91a9837e22ec22b1a268f88e2c
+Tag = 4d1d980d6fe0fb44b421992662b97975
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 6aab64c4787599d8f213446beadb16e08dba60e97f56dbd1
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = fdd2d6f503c915
+AAD = 5b92394f21ddc3ad49d9b0881b829a5935cb3a4d23e292a62fb66b5e7ab7020e
+Tag = 3c51d36c826f01384100886198a7f6a3
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 4980b2ee49b1aaf393175f5ab9bae95ec7904557dfa20660
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 27d73d58100054
+AAD = f6468542923be79b4b06dfe70920d57d1da73a9c16f9c9a12d810d7de0d12467
+Tag = 758a111aae4f735b7dd4d9802f2a8406
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 86a02bdd6ae733eee26f8eab898b336105978b5bbd6df781
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = dd16e0ce1250e3
+AAD = bc65cfd65e9863c8b7457d58afa6bdb48a84170d8aa97ba5b397b52ad17a9242
+Tag = 8cef14ebc2951069739d5d657d82addb
+Plaintext = a265480ca88d5f536db0dc6abc40faf0d05be7a966977768
+Ciphertext = 59cfab8956813c48e09332a2bb8a30dbcdf5afb2529532ab
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = ccee19d037cf4a
+AAD = c026696e6425e6c33f45b4145febf1137e7ac26383c9f5aa4cd4e5e8abb19e07
+Tag = 170a2b9c309de6c2326115a76efbdf98
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 67d989ea935b9ce190e3a7f3b645305e1e308a7fe617f80f
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 6c8ba94f09cbe6
+AAD = 774ad1a88f8bb063951486d4aec5bf82d5fc535bd0b952f86200c123c37fa496
+Tag = 4bcd14af0205af716f2b864f0c397f65
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 2522a5e4d157193ef2c264cfe877db8ac75b3cc5aab08a81
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 1f670302fcdcc8
+AAD = 1a9ff9698cfc96b581d7115c822e4363d7355ec5daed2eae5bf89ee944ac7d9c
+Tag = 762d5d8adafe75a191310a2618930c48
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 4536422bbad220079ee09e700e103efdaac832d016a20813
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 5d05f658c729a2
+AAD = dd9564c1431ed490b17ef69f6115805e54ef156ef4e10e58f7d57a7e86626352
+Tag = 206f80080dfa3e66e6371c0cde6cd205
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = d6711a78adf54f4effe647d531c4618cf32e3037eb700580
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 22a77db9fcbc95
+AAD = 86bf1739c10f63df734ee3e60ac40ff5636c49f68ca4c16ece289609eb413e7a
+Tag = b1b5b2b35c8a8125efccd1f4102f3e82
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = e44034a397778e1c6babab27f5a50fa4aac0e83d6b3eb25d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 491e32b0bbfa4c
+AAD = 75bef075c79d6cfd7fc73aefd67b2d215be0648937477ba606b1fe1be591239e
+Tag = ca36f53b01943f03cb8b69b5af53e505
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = b8e31c5910623e405f2ebf65821963e5b8814043612395fe
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = bc4b7d3a380be0
+AAD = 353dbb41e2d525a9f4fcd858d0f0aa1b1e86ac0f936d5c09c6b61c343f94e3fc
+Tag = c3bfc6851049d32105fd16bd45b29f29
+Plaintext = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005
+Ciphertext = 4000faf8558f2f4e01e45e90796cd236e5211d1704270f31
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = a840e98df72ae9
+AAD = 22c6607732ef1bdc7fcf6197e037cdadd7ee17c008552dd9f04b8564d34fb17c
+Tag = 847b022733ca5a5e3c4d472332484b7f
+Plaintext = a2f53385618b41301f4e3ea4c597f411103dac2b37abf5da
+Ciphertext = 53bb608f6236798839af35888cb0fa4797b599271084cc13
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 39d93c3cf31a6f
+AAD = 937dfac5cded938438f4e97aabd9beb50dba40f824198260a89729479cfe6869
+Tag = 1c79edbf38c50e0f240a2d70f65aa79f
+Plaintext = c1bdef96dc868446be48491b160504546f2a40dd581f9582
+Ciphertext = be54551d1d2f1b3eb60ffe3b165524ff90ca09fb252bf21c
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 0bbc177019321e
+AAD = f6e02678820f5ccbede6cbded02d6dd58d486166d7b18ee975a688af421fb795
+Tag = a82cd3ebaf6c2d3e21749bdf570ad28d
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = f07c1072d8f8e077dfbb3ad86dd92d32b41f29e647dcd7e3
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = ad048eb2ad7526
+AAD = 0d2739cfdac782b61f484fa1a423c478c414397ec420327963d79112b2d70a7e
+Tag = ef93a8759845326683a0d9c22151f486
+Plaintext = 72a70954d22ad722fc32756afce67b344b2f3c55fe1d9eed
+Ciphertext = 7f7cf7f4d0645934cb0a5e67b4227a909aa55dba09b2c39c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = c25e9fce
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 16e543d0e20615ff0df15acd9927ddfe40668a54bb854ccc
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 0812757ad0cc4d17c4cfe7a642
+AAD = ec6c44a7e94e51a3ca6dee229098391575ec7213c85267fbf7492fdbeee61b10
+Tag = 8ecedb3e
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = df35b109caf690656ae278bbd8f8bba687a2ce11b105dae9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = eff510acc1b85f35029cf7dc00
+AAD = 0923b927b8295c5dfaf67da55e5014293bc8c708fda50af06c1e8aef31cccc86
+Tag = 728da544
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 7075da2291e2cb527eb926ed08d8020c5f8f0f2d4a6a4745
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 3d13d09057190366c63c8750e9
+AAD = 77e27aa9a7bf30e130c862a3296a1cd7a10195ed1d940f2c97bfff47c6f06e32
+Tag = 02a9b9bc
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 18a77a66457b53286b1aea0845304cac8e66a02d5c642e4c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = e3c03ef7e1d31961ee0b97bd99
+AAD = 8a3676dd640821b58fb0f0329855fd5882c376ea166b958b7aaad223054e5784
+Tag = ccf8ecf0
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 24e1d3820101412d8f4d57118cab8f7e489d5cac78802dd5
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 5d165ddd4e599387af5967cae6
+AAD = e374f875ce829b62c98fbd67bcf128b5647f25fff9a643300eb95559b889baed
+Tag = 661181d5
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = b5929bc9648e24a553c5cd953ecb9d67ee508d2d4ac7b46e
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = fcec171162a27a96066181fab2
+AAD = cf431cc3671ec468ea86f6cc09842fcf3a84b3ef0fa1c7b20b232145b4469d62
+Tag = 7d74517d
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 54aa018dc7fdf8a54809e1393d18031bab4aa5ca35c20190
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 2fa8120398d1a946f391367cf6
+AAD = 92558a239c8e13230754f23aec67b153db29fdfc7daf641778185dd2931d89da
+Tag = 4a8edd83
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 69bcc300a459862b3cd284c15dd4af53dc7e95f3067bb825
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 88e0ae338bbca9d4299b294354
+AAD = 5db5c388dbadc9f175a5cd5a1472a458d25acd7fb9c951c0cd45edf64da473bb
+Tag = 70ad39a6
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 5c2d2df0d8aade3e5ae0f8d8b4b4d7c565817a31b2865dc2
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 4862e36296d6afc9399a95bbb4
+AAD = 36d82ebd0e0f5fe3b12946d041ae5aee16e6d17025406dd776f499bbd8e8b4c8
+Tag = ae423997
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = df1b3f98b6b0060191e7eb817f5908ddc0bc6f83860349e8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 2f360a4715074e942244ab7f9b
+AAD = f0087b0086a081c1071481f033a8be8e940c36763084329bb8461b9102238f4f
+Tag = 3309108e
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 16e59dd38395c7be7f580371edabb1e9bf21270de270aa28
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 93e08854560edb096e5d654086
+AAD = bdc60dff08bfd5d44320b75c61e456fd4333c9c3d0294d4a48d936dfd5922ce2
+Tag = bcc87096
+Plaintext = 569e4aec88dd51ca519c0a00c922ee33d3559b98a32d7906
+Ciphertext = 0ef8981dd37c055a3c3e14786fc662b2a11065964911d35e
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = e3f37b68ff508cfe295441d9e3
+AAD = b2b6c5782e4f128467c589d2a6cf55ef12877adb771bbb6245c5bba9dcfd6208
+Tag = e981e935
+Plaintext = 02b5511204bd55f7c37973e26f6df5883c0a530f07c7f8c2
+Ciphertext = fc1870cfc440f74f73f40e682cf4713d027c297b9426c3ef
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = ea98ec44f5a86715014783172e
+AAD = e4692b9f06b666c7451b146c8aeb07a6e30c629d28065c3dde5940325b14b810
+Tag = 3b98de4f
+Plaintext = 4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10
+Ciphertext = 9fc2c462dff1ba9756772d73de5c4e822b5ea0bc88845a32
+
+Cipher = aes-192-ccm
+Key = a7aa635ea51b0bb20a092bd5573e728ccd4b3e8cdd2ab33d
+IV = 5a16a8902bd70fa06cfe184c57
+AAD = 399d6b0652836457ec4f701f0dc0e5aed73d16585d61cb1bb5b7ee824fc287c8
+Tag = af3b74e1
+Plaintext = 4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10
+Ciphertext = 05fc586d5c780b8e06f618b5bb85f591665a54390eba4e14
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 5a8aa485c316e9403aff859fbb
+AAD = a16a2e741f1cd9717285b6d882c1fc53655e9773761ad697a7ee6410184c7982
+Tag = 8464a6f7fa2b76744e8e8d95691cecb8
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = c5b0b2ef17498c5570eb335df4588032958ba3d69bf6f317
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 0812757ad0cc4d17c4cfe7a642
+AAD = ec6c44a7e94e51a3ca6dee229098391575ec7213c85267fbf7492fdbeee61b10
+Tag = 06bd6dc2e6bcc3436cffb969ae900388
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = d1f0518929f4ae2f0543de2a7dfe4bb0110bb3057e524a1c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = eff510acc1b85f35029cf7dc00
+AAD = 0923b927b8295c5dfaf67da55e5014293bc8c708fda50af06c1e8aef31cccc86
+Tag = bb56d90669c726d866fe2206b8828727
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 1aa7dfa3a9818142c4971cbf4f64d4cbdbd354c6958ef474
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 3d13d09057190366c63c8750e9
+AAD = 77e27aa9a7bf30e130c862a3296a1cd7a10195ed1d940f2c97bfff47c6f06e32
+Tag = 9953fec4e091b3573214e1ecac1ac00c
+Plaintext = 8739b4bea1a099fe547499cbc6d1b13d849b8084c9b6acc5
+Ciphertext = 90352a5ec92d4fa52a96ae28251a57933728b2a3670e2ecd
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = e3c03ef7e1d31961ee0b97bd99
+AAD = 8a3676dd640821b58fb0f0329855fd5882c376ea166b958b7aaad223054e5784
+Tag = 783618374f6d03df28ee57a1a5aa38d8
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = eaa995946ed91d6a08ade14b260ac752cbd1081d5a7cad90
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 5d165ddd4e599387af5967cae6
+AAD = e374f875ce829b62c98fbd67bcf128b5647f25fff9a643300eb95559b889baed
+Tag = 47bb3f30d6e674d10a496806c1c8933e
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 0e320c4ece6ef0305a431a07a5a34d463ec4a37fc513c4b9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = fcec171162a27a96066181fab2
+AAD = cf431cc3671ec468ea86f6cc09842fcf3a84b3ef0fa1c7b20b232145b4469d62
+Tag = 7dd7ee3f75cfb47fa72433644f9cf62e
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 10685888091597c50acc54b2fb65150b83a7115351d6f8bd
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 2fa8120398d1a946f391367cf6
+AAD = 92558a239c8e13230754f23aec67b153db29fdfc7daf641778185dd2931d89da
+Tag = 43314076072a0ebd253fe1ab4883ebea
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = e456abf9ee83e0a68fbdb09c4a7afaba0efb0aa6d74a17c4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 88e0ae338bbca9d4299b294354
+AAD = 5db5c388dbadc9f175a5cd5a1472a458d25acd7fb9c951c0cd45edf64da473bb
+Tag = 16a72444f0949868f0e71907acbb29f4
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 5adadfd296edaf4bea92c8245983dc31b11335f682fb222c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 4862e36296d6afc9399a95bbb4
+AAD = 36d82ebd0e0f5fe3b12946d041ae5aee16e6d17025406dd776f499bbd8e8b4c8
+Tag = ab2025208191d73041c038cf2562bb8c
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = c2bb4d5a830646b3f8bf84044851c3b676c4ec02e43dcbf1
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 2f360a4715074e942244ab7f9b
+AAD = f0087b0086a081c1071481f033a8be8e940c36763084329bb8461b9102238f4f
+Tag = b7e6d183efa1f51b7ff31eaa52ed59ba
+Plaintext = 92973ce707733a73118c8ce6b5e3fc77a17f448310c0197f
+Ciphertext = 9589b8abcb47e54e6e8fad3e64fec7ed4f70ac435bb3e548
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 93e08854560edb096e5d654086
+AAD = bdc60dff08bfd5d44320b75c61e456fd4333c9c3d0294d4a48d936dfd5922ce2
+Tag = d990b642039f24755790332b3cc47c49
+Plaintext = 569e4aec88dd51ca519c0a00c922ee33d3559b98a32d7906
+Ciphertext = af63f27e2a9e70f106477493dc141d16a1d059dd7a8a7810
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = e3f37b68ff508cfe295441d9e3
+AAD = b2b6c5782e4f128467c589d2a6cf55ef12877adb771bbb6245c5bba9dcfd6208
+Tag = 6d3968fdceaae5138c411a29d0d333ee
+Plaintext = 02b5511204bd55f7c37973e26f6df5883c0a530f07c7f8c2
+Ciphertext = 1d2ae88c878684a0b404986252b3a7583e1a5a51163ddc60
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = ea98ec44f5a86715014783172e
+AAD = e4692b9f06b666c7451b146c8aeb07a6e30c629d28065c3dde5940325b14b810
+Tag = dbf8e9464909bdf337e48093c082a10b
+Plaintext = 4da40b80579c1d9a5309f7efecb7c059a2f914511ca5fc10
+Ciphertext = 30c154c616946eccc2e241d336ad33720953e449a0e6b0f0
+
+
+Title = NIST CCM 256 Decryption-Verfication Process Tests
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = a544218dadd3c1
+AAD =
+Tag = 469c90bb
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = d3d5424e20fbec
+AAD =
+Tag = 46a908ed
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = e776620a3bd961
+AAD =
+Tag = fdd35c4d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = 6c7a3be9f9ad55
+AAD =
+Tag = 869ce60e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = dbb3923156cfd6
+AAD =
+Tag = 1302d515
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = b390f67eaef8f5
+AAD =
+Tag = 156416ee
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = a259c114eaac89
+AAD =
+Tag = 4fe06e92
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = 7fc8804fef18ef
+AAD =
+Tag = 611091aa
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = fbaf4cbc49fa0f
+AAD =
+Tag = 696e9371
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = 2ed0c8761dbf04
+AAD =
+Tag = a0e0a2cb
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = 346bb04ea0db86
+AAD =
+Tag = 43cc0375
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = e1be89af98ffd7
+AAD =
+Tag = e5417f6b
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = a6a0d57aaaf012
+AAD =
+Tag = fff8a068
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = 1aa758eb2f9a28
+AAD =
+Tag = f8fa8e71
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = eda32f751456e33195f1f499cf2dc7c97ea127b6d488f211ccc5126fbb24afa6
+IV = 2911167fc98fc3
+AAD =
+Tag = 0bfa2d9d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = a544218dadd3c1
+AAD =
+Tag = 8207eb14d33855a52acceed17dbcbf6e
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = d3d5424e20fbec
+AAD =
+Tag = 60f8e127cb4d30db6df0622158cd931d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = e776620a3bd961
+AAD =
+Tag = 4239f29871651e9a26b8b06ffc5b3748
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 6c7a3be9f9ad55
+AAD =
+Tag = 5d35364c621fe8959dfe70ab44700fbe
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = dbb3923156cfd6
+AAD =
+Tag = e4dc5e03aacea691262ee69cee8ffbbe
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = b390f67eaef8f5
+AAD =
+Tag = c8eb7643b4ed3c796c3873e8c6624e0d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = a259c114eaac89
+AAD =
+Tag = f79c53fd5e69835b7e70496ea999718b
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 7fc8804fef18ef
+AAD =
+Tag = 687e00723a419fa81c0923b8b8e245ae
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = fbaf4cbc49fa0f
+AAD =
+Tag = 499ab350309ad6091ec4aaf6bf0cbd00
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 2ed0c8761dbf04
+AAD =
+Tag = c27b9f14787dc5375f59d0c561a23446
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 346bb04ea0db86
+AAD =
+Tag = 655c737722c78ac96582a883d407b2bb
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = e1be89af98ffd7
+AAD =
+Tag = 10d3f6fe08280d45e67e58fe41a7f036
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = a6a0d57aaaf012
+AAD =
+Tag = b4e425e43edb92c606f7cb2de8a06932
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 1aa758eb2f9a28
+AAD =
+Tag = 2590df2453cb94c304ba0a2bff3f3c71
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 2911167fc98fc3
+AAD =
+Tag = 1f344e30dfa95b2319e274caa5780e60
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = a544218dadd3c10583db49cf39
+AAD =
+Tag = 8a19a133
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 3c0e2815d37d844f7ac240ba9d
+AAD =
+Tag = 2e317f1b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 75549e7e5657e5fe19872fcee0
+AAD =
+Tag = 979bdcfe
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = d071ff72735820d73485870e83
+AAD =
+Tag = 8ef89acf
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 79ac204a26b9fee1132370c20f
+AAD =
+Tag = 154024b2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = a64bbc3d6d377dab513f7d9ce8
+AAD =
+Tag = 8dbcc439
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 0545fd9ecbc73ccdbbbd4244fd
+AAD =
+Tag = 5c349fb2
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 182fb47a12becf0bfe65df1287
+AAD =
+Tag = 79df3e02
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = f342059a6f9dc14226b40debc4
+AAD =
+Tag = fbc2c500
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 6cbfe6bb4c9b171b93d28e9f8f
+AAD =
+Tag = 2fac1bca
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 82877df921c6ade43064ad963e
+AAD =
+Tag = 99948f6e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = 0a37f2e7c66490e97285f1b09e
+AAD =
+Tag = c59bf14c
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = d7b9c346ce2f8bad9623122e10
+AAD =
+Tag = b764c393
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD =
+Tag = 5b96f41d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = e1b8a927a95efe94656677b692662000278b441c79e879dd5c0ddc758bdc9ee8
+IV = b6ce7d00731184b24428df046b
+AAD =
+Tag = f7e12df1
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = a544218dadd3c10583db49cf39
+AAD =
+Tag = 97e1a8dd4259ccd2e431e057b0397fcf
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 3c0e2815d37d844f7ac240ba9d
+AAD =
+Tag = 5a9596c511ea6a8671adefc4f2157d8b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 75549e7e5657e5fe19872fcee0
+AAD =
+Tag = 66f5c53efbc74fa02dedc303fd95133a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = d071ff72735820d73485870e83
+AAD =
+Tag = 2dfd3c852f68eace45acf433a6aa9c05
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 79ac204a26b9fee1132370c20f
+AAD =
+Tag = 5c8c9a5b97be8c7bc01ca8d693b809f9
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = a64bbc3d6d377dab513f7d9ce8
+AAD =
+Tag = ec093121bdcd589285f2262be8db5c4e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 0545fd9ecbc73ccdbbbd4244fd
+AAD =
+Tag = 84201662b213c7a1ff0c1b3c25e4ec45
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 182fb47a12becf0bfe65df1287
+AAD =
+Tag = bbe746d6d31e8e9745faed4095ab8d5d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = f342059a6f9dc14226b40debc4
+AAD =
+Tag = 646c1258dc4aa6fc380818e70e5f4328
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 6cbfe6bb4c9b171b93d28e9f8f
+AAD =
+Tag = 15fa37ca7f2883a4642c1ed41b8f6293
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 82877df921c6ade43064ad963e
+AAD =
+Tag = c6acf5e5ded4efb2c314370ebb9e9cde
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 0a37f2e7c66490e97285f1b09e
+AAD =
+Tag = 586e728193ce6db9a926b03b2d77dd6e
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = d7b9c346ce2f8bad9623122e10
+AAD =
+Tag = 642a187e71feff5989e28184aded0199
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD =
+Tag = 64864d21b6ee3fca13f07fc0486e232d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = b6ce7d00731184b24428df046b
+AAD =
+Tag = 58c63ce68f132d30d177c5834344cc5d
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = a544218dadd3c1
+AAD =
+Tag = 22aa8d59
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = 64a1341679972dc5869fcf69b19d5c5ea50aa0b5e985f5b7
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = bfcda8b5a2d0d2
+AAD =
+Tag = 77d00a75
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = c5b7f802bffc498c1626e3774f1d9f94045dfd8e1a10a202
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 6bae7f35c56b27
+AAD =
+Tag = 28588021
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = bf432e246b7fa4aff8b3ada738432b51f6872ed92284db9d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = c5e4214b1bf209
+AAD =
+Tag = 37921120
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = 0d5760ad0e156e401120a1ebd1b139248784c88e10e34254
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 9d773a31fe2ec7
+AAD =
+Tag = dce2d25e
+Plaintext = 839d8cfa2c921c3cceb7d1f46bd2eaad706e53f64523d8c0
+Ciphertext = 5acfbe5e488976d8b9b77e69a736e8c919053f9415551209
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = f42cb0cce9efb6
+AAD =
+Tag = 1ef530d0
+Plaintext = 839d8cfa2c921c3cceb7d1f46bd2eaad706e53f64523d8c0
+Ciphertext = be8be6046ac58411a00c131dd4a72d565f98d87a2c89124b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 24b7a65391f88b
+AAD =
+Tag = 750125f3
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = f00628e10e8e0115b4a4532a1212a23aade4090832c1972d
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = d2a7eb45780df3
+AAD =
+Tag = 08aaaf93
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 9078151f674d5f7b56e2451b0316156f776459f17d277e01
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 046cbfd26093d8
+AAD =
+Tag = bd95e677
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 921cbecce3b06f3d655a5a0a4d212320d4f147575079fd23
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 51b13b0b04d077
+AAD =
+Tag = 7e2ebb1d
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 8cab1ff22d474e9863c153e84680e2a66981f03605136047
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = ce2e9967bf9eb7
+AAD =
+Tag = 662f8684
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 15f476b5aefe072548a54f59506d9c3b9ce29025340214be
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = b672c91376f533
+AAD =
+Tag = d5642830
+Plaintext = 4f7a561e61b7861719e4445057ac9b74a9be953b772b09ec
+Ciphertext = 758aa03dc72c362c43b5f85bfaa3db4a74860887a8c29e47
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 62f6f1872462d8
+AAD =
+Tag = 01472fe1
+Plaintext = 4f7a561e61b7861719e4445057ac9b74a9be953b772b09ec
+Ciphertext = ec645769b22161567e6a7e23aa06575bc767a34aa54d3cba
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = a6d01fb88ca547
+AAD =
+Tag = 7aa999d7
+Plaintext = a36155de477364236591e453008114075b4872120ef17264
+Ciphertext = 615cbeabbe163ba8bc9c073df9ad40833fcf3f424644ccc3
+
+Cipher = aes-256-ccm
+Key = af063639e66c284083c5cf72b70d8bc277f5978e80d9322d99f2fdc718cda569
+IV = 46ad6ebbd8644a
+AAD =
+Tag = d27b7cf2
+Plaintext = a36155de477364236591e453008114075b4872120ef17264
+Ciphertext = 0ed6cc6451de57ca672d56dee45d4548a810d5c49dfe442d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = a544218dadd3c1
+AAD =
+Tag = 374f3bb6db8377ebfc79674858c4f305
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = bc51c3925a960e7732533e4ef3a4f69ee6826de952bcb0fd
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = bfcda8b5a2d0d2
+AAD =
+Tag = 3275f2a4907d51b734fe7238cebbd48f
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = afa1fa8e8a70e26b02161150556d604101fdf423f332c336
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 6bae7f35c56b27
+AAD =
+Tag = e672f1f22cbe4a5305f19aaa6967237b
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = 72bc8ef21a847047091b673ccf231d35ecf6f4049741703b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = c5e4214b1bf209
+AAD =
+Tag = 400b152113c3976be63dcd9e7a84ddac
+Plaintext = d3d5424e20fbec43ae495353ed830271515ab104f8860c98
+Ciphertext = b719f6555fc4e5424273f5903d5672af460413110278707f
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 9d773a31fe2ec7
+AAD =
+Tag = f2870ce198af11f4fb698a67af6c89ad
+Plaintext = 839d8cfa2c921c3cceb7d1f46bd2eaad706e53f64523d8c0
+Ciphertext = 4539bb13382b034ddb16a3329148f9243a4eee998fe444af
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = f42cb0cce9efb6
+AAD =
+Tag = cc98b3f5758972bf08ea9e88dc6e54ed
+Plaintext = 839d8cfa2c921c3cceb7d1f46bd2eaad706e53f64523d8c0
+Ciphertext = 47cbb909cb12fa0a4b0f1aefd54c52d1edd1533290f76b8c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 24b7a65391f88b
+AAD =
+Tag = 432704eff9b6830476db3d30d4c103e4
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 6d0f928352a17d63aca1899cbd305e1f831f1638d27c1e24
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = d2a7eb45780df3
+AAD =
+Tag = 71256981db86f1e768170a104ebfb81d
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = e0e686d917f78b3b0058fed7b084976244789073a6305ff5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 046cbfd26093d8
+AAD =
+Tag = 5efbbae6a346863a93d52e0321cef8b2
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 960c573f5d6934a4cac49d06998f827b3d665cf02c998fe5
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 51b13b0b04d077
+AAD =
+Tag = ac2fdc3cc683f6120e405f446a10e0f3
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = 7cf8f4806848e34aa7d3bd7e2cb9f5d9ff21395ff6d34826
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = ce2e9967bf9eb7
+AAD =
+Tag = d254f7765b6155054a5efde28dd38750
+Plaintext = 3bed52236182c19418867d468dbf47c8aac46c02445f99bb
+Ciphertext = e4f6445ca36e7ee3323f11f6a5ca8ded0c85871e092aa687
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = b672c91376f533
+AAD =
+Tag = 9dc42d22a5436bc12eff5505edb25e19
+Plaintext = 4f7a561e61b7861719e4445057ac9b74a9be953b772b09ec
+Ciphertext = f23ac1426cb1130c9a0913b347d8efafb6ed125913aa678a
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 62f6f1872462d8
+AAD =
+Tag = 2db05feb368ab772d977fd97b35262fa
+Plaintext = 4f7a561e61b7861719e4445057ac9b74a9be953b772b09ec
+Ciphertext = ac9f131389181b1023f1ee47633aa433fc5d93a87d9ece96
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = a6d01fb88ca547
+AAD =
+Tag = 789d2043179fdd8fdcbd52313b7b15cb
+Plaintext = a36155de477364236591e453008114075b4872120ef17264
+Ciphertext = 773b8eea2e9830297ac11d3c1f6ea4008c96040e83d76d55
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 46ad6ebbd8644a
+AAD =
+Tag = 079a2bac0ab4bc249bbdb330181cdd16
+Plaintext = a36155de477364236591e453008114075b4872120ef17264
+Ciphertext = d3fae92043c419fe8ac0d7491ca8041ad089559d895103cf
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = a544218dadd3c10583db49cf39
+AAD =
+Tag = 3d14fb3f
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = 63e00d30e4b08fd2a1cc8d70fab327b2368e77a93be4f412
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 894dcaa61008eb8fb052c60d41
+AAD =
+Tag = 8d0c0099
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = bb5425b3869b76856ec58e39886fb6f6f2ac13fe44cb132d
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 8feba0d720aa4a5e35abc99e82
+AAD =
+Tag = efd4365c
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = 2ca3be419d5be5ed682f8954d2c20efd9e6d360814735dae
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = ed04c9ca8702aec8d0a58e09a0
+AAD =
+Tag = a4ccbef1
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = 3d34bda62db39d6118d6fd5cd38f1a3820ca69ce584b94a2
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 1501a243bf60b2cb40d5aa20ca
+AAD =
+Tag = f1a72afc
+Plaintext = f5730a05fec31a11662e2e14e362ccc75c7c30cdfccbf994
+Ciphertext = 377b2f1e7bd9e3d1077038e084f61950761361095f7eeebb
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = c6edaf35f0cb433500a8c3a613
+AAD =
+Tag = be4f5f9a
+Plaintext = f5730a05fec31a11662e2e14e362ccc75c7c30cdfccbf994
+Ciphertext = 9cef6c889ff51666df9dd1dd2215c15f4b2078a29373c106
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = d65e0e53f765f9d5e6795c0c5e
+AAD =
+Tag = 9d0ef4f7
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 6cab3060bf3b33b163b933c2ed0ba51406810b54d0edcf5c
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 2b0163418a341588db0f5786d8
+AAD =
+Tag = c08a9e85
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = f9543a659e9a8b7d75dd859df923817452735f5051726422
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = f16bba081bddda83546eabc9a5
+AAD =
+Tag = 75dd819a
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 0d20bf6a9d02da72091d94cdb38743bfea2473d3ab62dcad
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = ace99268a32b9c1b5ccd8b0d84
+AAD =
+Tag = 86e205f9
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 8bca01e6ebd7ebcdfe52b88e314670ffeb35882fc05394b3
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 24570517bbb0df1b3fbd32f57a
+AAD =
+Tag = f73a8bf0
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 7061c84e2e1d9d58013543ff82666055a1f055c1296c42c8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = a6b2371acf8321864c08ddb4d8
+AAD =
+Tag = 94f223f0
+Plaintext = 1a43ca628026219c5a430c54021a5a3152ae517167399635
+Ciphertext = c5aa500d1f7c09a590e9d15d6860c4433684e04dd6bc5c8f
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = f8e2d4e043f5fe7a72b6117811
+AAD =
+Tag = 17af8b14
+Plaintext = 1a43ca628026219c5a430c54021a5a3152ae517167399635
+Ciphertext = e3efa7971e27ba1245ee9491ebdbb28ad9b24b325da57604
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = c2b60f14c894ec6178fe79919f
+AAD =
+Tag = b4d35d44
+Plaintext = 3e707d98f19972a63d913e6ea7533af2f41ff98aee2b2a36
+Ciphertext = 852cca903d7fdf899807bd14642057534c8a0ccacb8c7b8f
+
+Cipher = aes-256-ccm
+Key = f7079dfa3b5c7b056347d7e437bcded683abd6e2c9e069d333284082cbb5d453
+IV = 4de4c909ac0cc5fc608baf45ac
+AAD =
+Tag = 0bc044b1
+Plaintext = 3e707d98f19972a63d913e6ea7533af2f41ff98aee2b2a36
+Ciphertext = e04fd4f5b60833021ed57c98de300bb68d0d892b2bf68e08
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = a544218dadd3c10583db49cf39
+AAD =
+Tag = 3a578d179902f912f9ea1afbce1120b3
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = f0050ad16392021a3f40207bed3521fb1e9f808f49830c42
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 894dcaa61008eb8fb052c60d41
+AAD =
+Tag = 9084607b83bd06e6442eac8dacf583cc
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = c408190d0fbf5034f83b24a8ed9657331a7ce141de4fae76
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 8feba0d720aa4a5e35abc99e82
+AAD =
+Tag = 9002a46cfb734290924a15e9c3d99924
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = 52b3d31d02d1b92b38cbae8c510204dde6bf9588e994296c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = ed04c9ca8702aec8d0a58e09a0
+AAD =
+Tag = b238e316c3f9adccce95e8c8b9c7e8d2
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = f80190470212ce1e64bf4c64ca0133d90469abf87a8233c2
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 1501a243bf60b2cb40d5aa20ca
+AAD =
+Tag = 8aaa3f0133234c0cd91609982adc034b
+Plaintext = f5730a05fec31a11662e2e14e362ccc75c7c30cdfccbf994
+Ciphertext = 254b847d4175bbb44a82b4e805514fa444c224710933f3ec
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = c6edaf35f0cb433500a8c3a613
+AAD =
+Tag = 33255731cd88345860da913bc696fdc1
+Plaintext = f5730a05fec31a11662e2e14e362ccc75c7c30cdfccbf994
+Ciphertext = 7a5c7bc02aa69efc5a159d653f3993399f69e20752c3b006
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = d65e0e53f765f9d5e6795c0c5e
+AAD =
+Tag = fafb76adf12f36740347e3edae62bca4
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = c3618c991b15de641d291419ff6957e8b9ae5046dd8c6f08
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 2b0163418a341588db0f5786d8
+AAD =
+Tag = 066f55f23d4e55bcbbbf2312ea2d8071
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 240927bfd671a92aef0311395ad55ae42233ecee53873da4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = f16bba081bddda83546eabc9a5
+AAD =
+Tag = 004753689cc84810b8414f1464c0c5b9
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 4731a7e690c77cd47582ce54a1cec23d94c856b93a9fc767
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = ace99268a32b9c1b5ccd8b0d84
+AAD =
+Tag = 504da83478ede24026ec91fb12769e4b
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = f0ea12eaff20c3a50674aa1546aaae3bd5c9249108535b21
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 24570517bbb0df1b3fbd32f57a
+AAD =
+Tag = c9fcf9b9fd5e99767a7b1679b57ea961
+Plaintext = 20e394c7cc90bdfa6186fc1ba6fff158dfc690e24ba4c9fb
+Ciphertext = 5b164d9752ad6c497a7ab2d0bf8be68fea084ea5839b07b7
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = a6b2371acf8321864c08ddb4d8
+AAD =
+Tag = acb5a51d10a58d6584fbe73f1063c31b
+Plaintext = 1a43ca628026219c5a430c54021a5a3152ae517167399635
+Ciphertext = bd37326da18e5ac79a1a9512f724bb539530868576b79c67
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = f8e2d4e043f5fe7a72b6117811
+AAD =
+Tag = ce54cd7623a80a176f29a01b3abb642e
+Plaintext = 1a43ca628026219c5a430c54021a5a3152ae517167399635
+Ciphertext = 0455b4dd1069281e10531c0dc180ced9a5ef5d3fe0007470
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = c2b60f14c894ec6178fe79919f
+AAD =
+Tag = 95c66d3f411b478853886afd177d88c3
+Plaintext = 3e707d98f19972a63d913e6ea7533af2f41ff98aee2b2a36
+Ciphertext = ecd337640022635ce1ed273756d02b7feeb2515614c1fadc
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 4de4c909ac0cc5fc608baf45ac
+AAD =
+Tag = 830b2b6317716b3975e2b101aebdd920
+Plaintext = 3e707d98f19972a63d913e6ea7533af2f41ff98aee2b2a36
+Ciphertext = e25d7c9fb388596b13a13b885d5b24e31579a3494ad256da
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = a544218dadd3c1
+AAD = d3d5424e20fbec43ae495353ed830271515ab104f8860c988d15b6d36c038eab
+Tag = 92d00fbe
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 78c46e3249ca28
+AAD = 232e957c65ffa11988e830d4617d500f1c4a35c1221f396c41ab214f074ca2dc
+Tag = 9143e5c4
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = c18d9e7971e2ae
+AAD = 0d40324aa758dbbb5391b5e6edb8a2310c94a4ae51d4fba8a7458d7cc8488baa
+Tag = 54337466
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 162d061351d82d
+AAD = 106d1fb32d948b0d8884f178ad2332a599445fae0f6f71f9ebe53a60b2df9b8e
+Tag = bf0bf84c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 3fcb328bc96404
+AAD = 10b2ffed4f95af0f98ed4f77c677b5786ad01b31c095bbc6e1c99cf13977abba
+Tag = 11250056
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = b3fd1eb1422277
+AAD = fa5398cf4cddbe4b45e9f5d7491cd9eefc5e494255961ba3f4b40d22b5f5fe76
+Tag = 13de5339
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = c42ac63de6f12a
+AAD = 7ff8d06c5abcc50d3820de34b03089e6c5b202bcbaabca892825553d4d30020a
+Tag = 4eed80fd
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = d4a7a672237e17
+AAD = d1cdad7fe886d07625a4334be6de4df0645d2a8b4008a8d35f04e6bcf87bfa56
+Tag = 4bc2e450
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = b23255372455c6
+AAD = d2e2c3607c40e0a807b86c6ebbc502ab42bdb7f85ab26299cd963bbba3a3a8fa
+Tag = b30e6bbd
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 92272d40475fbb
+AAD = 2f3af695ee33a9ebe6a48ed1b00e337261857110bb104191a54fd13bd960d8bc
+Tag = f7c11fe2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = c4a756f6024a9d
+AAD = 2317b324b6420ada9ea7bf52b71c5faf2485528da5f56b42c517be6355cdb28b
+Tag = 76673751
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 3a1701b185d33a
+AAD = e5d54df8ed9f89b98c5ebb1bc5d5279c2e182784ff4cd9c869ae152e29d7a2b2
+Tag = 9a5382c3
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = e4db2e80dc3f63
+AAD = 7616bdf5737d01f936072b6576fa76556dfa072f7e2d7de16b9dc96ac8de409c
+Tag = 9e632f56
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = 4f490ce07e0150
+AAD = 3e12d09632c644c540077c6f90726d4167423a679322b2000a3f19cfcea02b33
+Tag = e1842c46
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 1b0e8df63c57f05d9ac457575ea764524b8610ae5164e6215f426f5a7ae6ede4
+IV = b4aaf9ad1bde60
+AAD = 8c96c891456ddec29fe04299506723db2079a6667f96db5d198bf085acf2a4ef
+Tag = 9f644671
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = a544218dadd3c1
+AAD = d3d5424e20fbec43ae495353ed830271515ab104f8860c988d15b6d36c038eab
+Tag = 93af11a08379eb37a16aa2837f09d69d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 78c46e3249ca28
+AAD = 232e957c65ffa11988e830d4617d500f1c4a35c1221f396c41ab214f074ca2dc
+Tag = d19b0c14ec686a7961ca7c386d125a65
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = c18d9e7971e2ae
+AAD = 0d40324aa758dbbb5391b5e6edb8a2310c94a4ae51d4fba8a7458d7cc8488baa
+Tag = 02ea916d60e2ceec6d9dc9b1185569b3
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 162d061351d82d
+AAD = 106d1fb32d948b0d8884f178ad2332a599445fae0f6f71f9ebe53a60b2df9b8e
+Tag = fabd2d0c422b47d363ea9936ff4a311b
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 3fcb328bc96404
+AAD = 10b2ffed4f95af0f98ed4f77c677b5786ad01b31c095bbc6e1c99cf13977abba
+Tag = b3884b69d117146cfa5529901753ddc0
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = b3fd1eb1422277
+AAD = fa5398cf4cddbe4b45e9f5d7491cd9eefc5e494255961ba3f4b40d22b5f5fe76
+Tag = 7162026b6306e74fe32ece8433801bc2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = c42ac63de6f12a
+AAD = 7ff8d06c5abcc50d3820de34b03089e6c5b202bcbaabca892825553d4d30020a
+Tag = b53d93cbfd3d5cf3720cef5080bc7224
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = d4a7a672237e17
+AAD = d1cdad7fe886d07625a4334be6de4df0645d2a8b4008a8d35f04e6bcf87bfa56
+Tag = c8bbecf69ecf8d10f0863bb4b7cbed51
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = b23255372455c6
+AAD = d2e2c3607c40e0a807b86c6ebbc502ab42bdb7f85ab26299cd963bbba3a3a8fa
+Tag = 6037145cc23a175760ae4b573907c80c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 92272d40475fbb
+AAD = 2f3af695ee33a9ebe6a48ed1b00e337261857110bb104191a54fd13bd960d8bc
+Tag = df7ea77425d631f652ffe096a8157f71
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = c4a756f6024a9d
+AAD = 2317b324b6420ada9ea7bf52b71c5faf2485528da5f56b42c517be6355cdb28b
+Tag = 7182b25ef5b113c13fa8f6769e74f1e2
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 3a1701b185d33a
+AAD = e5d54df8ed9f89b98c5ebb1bc5d5279c2e182784ff4cd9c869ae152e29d7a2b2
+Tag = 0a5d1bc02c5fe096a8b9d94d1267c49a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = e4db2e80dc3f63
+AAD = 7616bdf5737d01f936072b6576fa76556dfa072f7e2d7de16b9dc96ac8de409c
+Tag = 9eb6d9757ec7c56cc8c79461e0017486
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 4f490ce07e0150
+AAD = 3e12d09632c644c540077c6f90726d4167423a679322b2000a3f19cfcea02b33
+Tag = 1eda43bf07f2bf003107f3a0ba3a4c18
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = b4aaf9ad1bde60
+AAD = 8c96c891456ddec29fe04299506723db2079a6667f96db5d198bf085acf2a4ef
+Tag = 5287cc160c5dd3a0f9c1986aac2a621c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = a544218dadd3c10583db49cf39
+AAD = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e09a1005e024f6907
+Tag = 866d4227
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = e8de970f6ee8e80ede933581b5
+AAD = 89f8b068d34f56bc49d839d8e47b347e6dae737b903b278632447e6c0485d26a
+Tag = 94cb1127
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 6de75d3c05e83755083399a5f7
+AAD = 504b08cf34cbe17acf631ef219ae01437ebb6a980ab2f00121bb3073701b6511
+Tag = 82c2b67a
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 58d43b9f1581c590daab1a5c56
+AAD = 749f149ef306c70a5d006d9777adbbf7c0de453898c2978ef7c281535ea9b24c
+Tag = 8c8283f9
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = dfdcbdff329f7af70731d8e276
+AAD = 2ae56ddde2876d70b3b34eda8c2b1d096c836d5225d53ec460b724b6e16aa5a3
+Tag = c4ac0952
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 199ec321d1d24d5408076912d6
+AAD = a77526f3614cd974498a76d8b3cb7bacc623fdc9c85503289c462df888b199ed
+Tag = c59aa931
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 60f2490ba0c658848859fcbea8
+AAD = 3ad743283064929bf4fe4e0807f710f5e6a273e22614c728c3280a27b6c614a0
+Tag = 27c3953d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 6f29ca274190400720bba27651
+AAD = c0850aaf141bd3f1b24f4d882590f58682b41f874748f29f8925b4914f444842
+Tag = cb1ac8eb
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = f1dfb6fdb31cb423226f181c09
+AAD = ac6b08900fc1c9463e7dfdb60eee444c4989d7b200e675f3220ba1e14eed0ab4
+Tag = 4dcc55cc
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 0d45226c98eaa9bb445a3aa4f9
+AAD = b9cb3e1a5bcccb0b0599414c9822275b66fa0f913d51bdb0a2228cbb5aad0e0a
+Tag = 727d8f5e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 39cdbb24bd273a3fe96f42ca9d
+AAD = ddfe6c22f4cdc3128050072005f5bd4ecdef1d836e891683f1ba921d33fafba7
+Tag = 5aa56a54
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = db113f38f0504615c5c9347c3d
+AAD = 3b71bc84e48c6dadf6ead14621d22468a3d4c9c103ac96970269730bcfce239b
+Tag = c38fbdff
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = d16a20ef5f6587f1ee3cb7850b
+AAD = b1133e1cd369617a9f937e9a1eb86a0979ee30b5b7b0b6ff838d9e11301d6b72
+Tag = 6be30c42
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = d35f531f714694b5e49303a980
+AAD = 55b791ee495299916ff3c2327b4990952bebd0a2da9acfc553c6c996e354a4b5
+Tag = d34e90bb
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = a4bc10b1a62c96d459fbaf3a5aa3face7313bb9e1253e696f96a7a8e36801088
+IV = 220624db34a022b758473994a2
+AAD = 5b3b2ae87b0d6759f38a858423227f8687f35478a8f565409b741eadcac4d8c4
+Tag = 4a5d14bc
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = a544218dadd3c10583db49cf39
+AAD = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e09a1005e024f6907
+Tag = 867b0d87cf6e0f718200a97b4f6d5ad5
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = e8de970f6ee8e80ede933581b5
+AAD = 89f8b068d34f56bc49d839d8e47b347e6dae737b903b278632447e6c0485d26a
+Tag = 677a040d46ee3f2b7838273bdad14f16
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 6de75d3c05e83755083399a5f7
+AAD = 504b08cf34cbe17acf631ef219ae01437ebb6a980ab2f00121bb3073701b6511
+Tag = f650d46ade2cbabbc68ead6df1ea0c37
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 58d43b9f1581c590daab1a5c56
+AAD = 749f149ef306c70a5d006d9777adbbf7c0de453898c2978ef7c281535ea9b24c
+Tag = 11b8fe8c139ee38f77fd8fa552cbff67
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = dfdcbdff329f7af70731d8e276
+AAD = 2ae56ddde2876d70b3b34eda8c2b1d096c836d5225d53ec460b724b6e16aa5a3
+Tag = ad879c64425e6c1ec4841bbb0f99aa8b
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 199ec321d1d24d5408076912d6
+AAD = a77526f3614cd974498a76d8b3cb7bacc623fdc9c85503289c462df888b199ed
+Tag = 3c64f8731930ae000162c10654531066
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 60f2490ba0c658848859fcbea8
+AAD = 3ad743283064929bf4fe4e0807f710f5e6a273e22614c728c3280a27b6c614a0
+Tag = e2751f153fc76c0dec5e0cf2d30c1a28
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 6f29ca274190400720bba27651
+AAD = c0850aaf141bd3f1b24f4d882590f58682b41f874748f29f8925b4914f444842
+Tag = 76127bf891141e73854752ed10c02bd0
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = f1dfb6fdb31cb423226f181c09
+AAD = ac6b08900fc1c9463e7dfdb60eee444c4989d7b200e675f3220ba1e14eed0ab4
+Tag = 4bd833f9da0496e5f6a08a05d02df385
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 0d45226c98eaa9bb445a3aa4f9
+AAD = b9cb3e1a5bcccb0b0599414c9822275b66fa0f913d51bdb0a2228cbb5aad0e0a
+Tag = 05f166328a67a8c58b10a7348f3df612
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 39cdbb24bd273a3fe96f42ca9d
+AAD = ddfe6c22f4cdc3128050072005f5bd4ecdef1d836e891683f1ba921d33fafba7
+Tag = 42499bcd949a5163855a9794f11f917e
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = db113f38f0504615c5c9347c3d
+AAD = 3b71bc84e48c6dadf6ead14621d22468a3d4c9c103ac96970269730bcfce239b
+Tag = fc85464a81fe372c12c9e4f0f3bf9c37
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = d16a20ef5f6587f1ee3cb7850b
+AAD = b1133e1cd369617a9f937e9a1eb86a0979ee30b5b7b0b6ff838d9e11301d6b72
+Tag = 8c7501f423647dee77668858c5e350bb
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = d35f531f714694b5e49303a980
+AAD = 55b791ee495299916ff3c2327b4990952bebd0a2da9acfc553c6c996e354a4b5
+Tag = b1c09b093788da19e33c5a6e82ed9627
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 220624db34a022b758473994a2
+AAD = 5b3b2ae87b0d6759f38a858423227f8687f35478a8f565409b741eadcac4d8c4
+Tag = d2231ee1455b0bc337c4f8173fb8647c
+Plaintext =
+Ciphertext =
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = a544218dadd3c1
+AAD = d3d5424e20fbec43ae495353ed830271515ab104f8860c988d15b6d36c038eab
+Tag = 3ebc7720
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = c2fe12658139f5d0dd22cadf2e901695b579302a72fc5608
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 6ba004fd176791
+AAD = 5a053b2a1bb87e85d56527bfcdcd3ecafb991bb10e4c862bb0751c700a29f54b
+Tag = c44db2c9
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = 94748ba81229e53c38583a8564b23ebbafc6f6efdf4c2a81
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 45c5c284836414
+AAD = 8f01a61eb17366d4e70942ab69b4f4bcf8ff6a97f5972ee5780a264c9dcf7d93
+Tag = 83a09067
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = 1d670ccf3e9ba59186c48da2e5bd0ab21973eee2ea2985bf
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = c69f7679c80546
+AAD = 5d6c04a5b422b46065a79a889e30ac8d1b53b65d230d4c88190903a24e1fe1ea
+Tag = 392ae25d
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = 2c8c80ff10fac1bf6c9c83533c1514ee032c0983730b0657
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 57b940550a383b
+AAD = 33c2c3a57bf8393b126982c96d87daeacd5eadad1519073ad8c84cb9b760296f
+Tag = 3b91ff03
+Plaintext = 6fb5ce32a851676753ba3523edc5ca82af1843ffc08f1ef0
+Ciphertext = e1b4ec4279bb62902c12521e6b874171695c5da46c647cc0
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 11edd12ea5873d
+AAD = e32e5384038379e2b7382ba337b6f7a72a1569e110ee89c4dd6aa6f7e69f5250
+Tag = 64b837fb
+Plaintext = 6fb5ce32a851676753ba3523edc5ca82af1843ffc08f1ef0
+Ciphertext = b5dda89fe879d6a665b99285b6d937fd5877ebef4de049fb
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = f32222e9eec4bd
+AAD = 684595e36eda1db5f586941c9f34c9f8d477970d5ccc14632d1f0cec8190ae68
+Tag = 2a4e56a7
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = 224db21beb8cd0069007660e783c3f85706b014128368aab
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = e0a0a7f262cb51
+AAD = 1d93b2856ad2bf3700440f9a281bd8947ba209e9ffd18e69921ed0678c957c6c
+Tag = e960a769
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = ba1ce3a799e1173178b6788723005566f9269d5828c85d28
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 40316e7b38bdad
+AAD = 6e49acd9c26944740c778e74b1dbaa8d640c7e18e949a1661f8a77543db69e1f
+Tag = ed14a5a5
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = 79d59e4bb251988c019c4eaaee2a2513f9cb0521334018fd
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 33008ef5baf263
+AAD = a726f31d9a22bfc0e7e4c3111b0d304e106ab04ed318f8bfe6ec9cb3a811285b
+Tag = d7d6c61d
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = af4350795f24087aa05070d6d5f55ebb12d7ad3141066866
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = b48a16fb9a065d
+AAD = be05e9c934c1dcba45223d47c6646a2d13c3b93265e354ae4970484b5101d809
+Tag = d0605b84
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = 22d2da531be1f0d1da4bc21f984d29bf56bed2e92da6bf42
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 14c9bd561c47c1
+AAD = 141ae365f8e65ab9196c4e8cd4e62189b304d67de38f2117e84ec0ec8f260ebd
+Tag = 8f9d6814
+Plaintext = c22524a1ea444be3412b0d773d4ea2ff0af4c1ad2383cba8
+Ciphertext = 61b46c9024eed3989064a52df90349c18e14e4b552779d3f
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 5fb871eac2e52a
+AAD = ff23906e9067da8999842318f2a867759ca2d171395c2ff31fa5a4e2ab349c45
+Tag = d930f5ce
+Plaintext = c22524a1ea444be3412b0d773d4ea2ff0af4c1ad2383cba8
+Ciphertext = 539799c2b22a33dd648fc4497d12f9455beaf932f1eaaff4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 1ccec9923aa6e8
+AAD = 88a6d037009a1c1756f72bb4589d6d940bd514ed55386baefacc6ac3ca6f8795
+Tag = 0d83fa19
+Plaintext = 518a7fb11c463bf23798982118f3cfe4d7ddde9184f37d4f
+Ciphertext = 52f8205534447d722be2b9377f7395938cc88af081a11ccb
+
+Cipher = aes-256-ccm
+Key = 8c5cf3457ff22228c39c051c4e05ed4093657eb303f859a9d4b0f8be0127d88a
+IV = 68a5351e4422c8
+AAD = 303c767468f48ac9f6e331bbad535b06aa00ab593327320799e17eff63afd3fe
+Tag = f243e273
+Plaintext = 518a7fb11c463bf23798982118f3cfe4d7ddde9184f37d4f
+Ciphertext = d11c892ae155098f5e4b5fe60c7afd74fb2dbcc4db956556
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = a544218dadd3c1
+AAD = d3d5424e20fbec43ae495353ed830271515ab104f8860c988d15b6d36c038eab
+Tag = 1ac68bd42f5ec7fa7e068cc0ecd79c2a
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = 3341168eb8c48468c414347fb08f71d2086f7c2d1bd581ce
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 6ba004fd176791
+AAD = 5a053b2a1bb87e85d56527bfcdcd3ecafb991bb10e4c862bb0751c700a29f54b
+Tag = 47c3338a2400809e739b63ba8227d2f9
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = d543acda712b898cbb27b8f598b2e4438ce587a836e27851
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 45c5c284836414
+AAD = 8f01a61eb17366d4e70942ab69b4f4bcf8ff6a97f5972ee5780a264c9dcf7d93
+Tag = 46288ce9dd1c7088c752e35947fdca98
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = 39a8af5c976b995ea8049e55b68bc65503592ab009156386
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = c69f7679c80546
+AAD = 5d6c04a5b422b46065a79a889e30ac8d1b53b65d230d4c88190903a24e1fe1ea
+Tag = 7fd89caef9388fbb82361b8d53d9edc6
+Plaintext = 78c46e3249ca28e1ef0531d80fd37c124d9aecb7be6668e3
+Ciphertext = 950fbf6445f6ffb68178f52f5079d0c6081a48ae1f267a0b
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 57b940550a383b
+AAD = 33c2c3a57bf8393b126982c96d87daeacd5eadad1519073ad8c84cb9b760296f
+Tag = 4d8b30df941f3536ffb42083ef0e1c30
+Plaintext = 6fb5ce32a851676753ba3523edc5ca82af1843ffc08f1ef0
+Ciphertext = fbfed2c94f50ca10466da9903ef85833ad48ca00556e66d1
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 11edd12ea5873d
+AAD = e32e5384038379e2b7382ba337b6f7a72a1569e110ee89c4dd6aa6f7e69f5250
+Tag = 04cf3426e8f975125a7eed00e5f33b6c
+Plaintext = 6fb5ce32a851676753ba3523edc5ca82af1843ffc08f1ef0
+Ciphertext = 2ebfeb7a843618b37025352df3538526517ed320adfb486c
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = f32222e9eec4bd
+AAD = 684595e36eda1db5f586941c9f34c9f8d477970d5ccc14632d1f0cec8190ae68
+Tag = f78e9e5e9faa058112af57f4ac78db2c
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = dae13e6967c8b1ee0dd2d5ba1dd1de69f22c95da39528f9e
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = e0a0a7f262cb51
+AAD = 1d93b2856ad2bf3700440f9a281bd8947ba209e9ffd18e69921ed0678c957c6c
+Tag = 0c63959ce534a0f87fb42a9b000dec84
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = e683040a0bcf04c1748e7746400d6ef0f7cd8e77a2951779
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 40316e7b38bdad
+AAD = 6e49acd9c26944740c778e74b1dbaa8d640c7e18e949a1661f8a77543db69e1f
+Tag = 7d1a2111dc21aec79ef73193b306d31f
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = 829e50e8c09e727a58287e6eb7d38edeb8ab39db279c0639
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 33008ef5baf263
+AAD = a726f31d9a22bfc0e7e4c3111b0d304e106ab04ed318f8bfe6ec9cb3a811285b
+Tag = 7c516d2d1a8318893923f398ca249401
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = 873c91e76dca0062ae66325aefb84ece3e98928f8dbc5fee
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = b48a16fb9a065d
+AAD = be05e9c934c1dcba45223d47c6646a2d13c3b93265e354ae4970484b5101d809
+Tag = 8055e777bb57eb49497cd2e233ee06fd
+Plaintext = 2c29d4e2bb9294e90cb04ec697e663a1f7385a39f90c8ccf
+Ciphertext = 343f6c86f2b852ac388a096faec4472107a924aba56d0cb8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 14c9bd561c47c1
+AAD = 141ae365f8e65ab9196c4e8cd4e62189b304d67de38f2117e84ec0ec8f260ebd
+Tag = a1586bf922412e73ce338e372615c3bc
+Plaintext = c22524a1ea444be3412b0d773d4ea2ff0af4c1ad2383cba8
+Ciphertext = a654238fb8b05e293dba07f9d68d75a7f0fbf40fe20edaeb
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 5fb871eac2e52a
+AAD = ff23906e9067da8999842318f2a867759ca2d171395c2ff31fa5a4e2ab349c45
+Tag = 03538d108df6ecd6f39acfe076ba5fb8
+Plaintext = c22524a1ea444be3412b0d773d4ea2ff0af4c1ad2383cba8
+Ciphertext = 4846816923ed9f0254bdd0be01028f75061d3594ad3a45bd
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 1ccec9923aa6e8
+AAD = 88a6d037009a1c1756f72bb4589d6d940bd514ed55386baefacc6ac3ca6f8795
+Tag = 3e3f51ee37fdcc5d81dd85d9e9d4f44e
+Plaintext = 518a7fb11c463bf23798982118f3cfe4d7ddde9184f37d4f
+Ciphertext = 765067ef768908d91ee4c3923943e0c7be70e2e06db99a4b
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 68a5351e4422c8
+AAD = 303c767468f48ac9f6e331bbad535b06aa00ab593327320799e17eff63afd3fe
+Tag = d8a906488f79ad5d2234d72458dcfcd4
+Plaintext = 518a7fb11c463bf23798982118f3cfe4d7ddde9184f37d4f
+Ciphertext = e58ea6c1522e5a3e93a85edd05ae80d6cf5c4dd6d604a8f8
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = a544218dadd3c10583db49cf39
+AAD = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e09a1005e024f6907
+Tag = ef891339
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = c0ea400b599561e7905b99262b4565d5c3dc49fad84d7c69
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 8fa501c5dd9ac9b868144c9fa5
+AAD = 5bb40e3bb72b4509324a7edc852f72535f1f6283156e63f6959ffaf39dcde800
+Tag = 3d488623
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = 60871e03ea0eb968536c99f926ea24ef43d41272ad9fb7f6
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 9bc0d1502a47e46350fe8667ca
+AAD = 07203674260208d5bd4d39506836f7e76ffc58e938799f21aff7bb4dea4410d2
+Tag = 527e5ed0
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = 81d7859dcbe51dcc94fe2591cd3b0540003d49a8c4dccbf4
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 611cb4c66e88f6acf96fea1919
+AAD = 327ee3657e49d4d988362fabae303ccea6638e5cb45993d9d56269bc3d3af32b
+Tag = 4d20d5fa
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = bef380ad725b65fb5fceeabf09c665bc35089f434ec83149
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 0dd613c0fe28e913c0edbb8404
+AAD = 2ad306575b577c2f61da7212ab63e3db3941f1f751f2356c7443531a90b9d141
+Tag = d2898c3b
+Plaintext = 9522fb1f1aa58493cba682d788186d902cfc93e80fd6b998
+Ciphertext = fabe11c9629e598228f5209f3dbcc641fe4b1a22cadb0821
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 68806dfe720d0a9a84697de5f2
+AAD = c6b0e4dfd723d7637510f887b7852f60ecdf72e0d33396560fed6534d5b7f015
+Tag = 41e92090
+Plaintext = 9522fb1f1aa58493cba682d788186d902cfc93e80fd6b998
+Ciphertext = b7eb87f84951640de731d4093f1a4ed5f831138a27465d39
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 3e0fe3427eeda80f02dda4fed5
+AAD = ae0d1c9c834d60ff0ecfb3c0d78c72ddb789e58adfc166c81d5fc6395b31ec33
+Tag = d18fc889
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = d88f8fcd772125212ce09c2a6e5b5693dd35073f992004f0
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 7c0c76d9f9316ff6c98758b464
+AAD = 31a0338c3839931fa1dd5131cb796c4c6cfde9fb336d8a80ac35dec463be7a94
+Tag = 0f39ecea
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = d2d7d52b11304fc1d15b8c20e296ba7c63d99f4ce86cc8ae
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 07c728135bdfede0e0c8036b17
+AAD = 25a152850b4b80b19d8f0b504b2a8a241824b3a1fca8d85c8713b2c0c84b5e02
+Tag = 94b1d516
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = ae1d9f82efb464d5dc2018cffa309634c09b34d1122c4bd9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 710c96d7a6f09de83f0507f28a
+AAD = 2d64acfdbfc582cd9a933790eb1b739fb02e53f511255e49f421bb7acc98a130
+Tag = d394d047
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = 477c985d92ad1b69d22315235a29e3d3a5991487cbdc8d11
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 977bbcdeb6a7d9dcf8664bc2d8
+AAD = 135786125258a49475338ac1961d2718433b9e84cf64f63ca52913e8dd12e505
+Tag = bd3d22eb
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = d1c085c75d808dc6db493b8a0b4d884e0700d2844a1b4b46
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 60122cbd219e5cf17415e8bc09
+AAD = 895a45ddbe0c80793eccbf820de13a233b6aa7045cfd5313388e7184c392b216
+Tag = 1c0d067c
+Plaintext = 794e734966e6d0001699aec3f8ab8f194de7653d3091b1b9
+Ciphertext = 76bdd9a7b34bf14ae121a87fdfa144f71b848744af6a2f0b
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 83a07f2e685959cb50a1bd2bce
+AAD = 02afe300ec0cf0acb59108b2f70e069300294e34f40bb032cb59907599664408
+Tag = 74192744
+Plaintext = 794e734966e6d0001699aec3f8ab8f194de7653d3091b1b9
+Ciphertext = 413e2e8df9d65b4e5d3b63a738258aaee643f364be9a01b9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 3542fbe0f59a6d5f3abf619b7d
+AAD = dd4531f158a2fa3bc8a339f770595048f4a42bc1b03f2e824efc6ba4985119d8
+Tag = 79018ad5
+Plaintext = c5b3d71312ea14f2f8fae5bd1a453192b6604a45db75c5ed
+Ciphertext = 617d8036e2039d516709062379e0550cbd71ebb90fea967c
+
+Cipher = aes-256-ccm
+Key = 705334e30f53dd2f92d190d2c1437c8772f940c55aa35e562214ed45bd458ffe
+IV = 48f2d4c0b17072e0a9c300d90b
+AAD = c56175e2cfe0d37454d989afcc36686fb34c015439601567506a4d0003182be7
+Tag = 5c916f91
+Plaintext = c5b3d71312ea14f2f8fae5bd1a453192b6604a45db75c5ed
+Ciphertext = 40e609c739e409750a6c41d9c6ea64ce36f70711b4ca3e36
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = a544218dadd3c10583db49cf39
+AAD = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e09a1005e024f6907
+Tag = 367f30f2eaad8c063ca50795acd90203
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = 8d34cdca37ce77be68f65baf3382e31efa693e63f914a781
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 8fa501c5dd9ac9b868144c9fa5
+AAD = 5bb40e3bb72b4509324a7edc852f72535f1f6283156e63f6959ffaf39dcde800
+Tag = 4b41096dfdbe9cc1ab610f8f3e038d16
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = 516c0095cc3d85fd55e48da17c592e0c7014b9daafb82bdc
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 9bc0d1502a47e46350fe8667ca
+AAD = 07203674260208d5bd4d39506836f7e76ffc58e938799f21aff7bb4dea4410d2
+Tag = d81ec96df41b8fa8262ed2db880b5e85
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = 0293eae9f8d8bd7ad45357f733fc7b5d990d894783e18501
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 611cb4c66e88f6acf96fea1919
+AAD = 327ee3657e49d4d988362fabae303ccea6638e5cb45993d9d56269bc3d3af32b
+Tag = 6ee80f60f72db2cbf25b2f8c6af8749c
+Plaintext = e8de970f6ee8e80ede933581b5bcf4d837e2b72baa8b00c3
+Ciphertext = 256bad8295e67d8d450f5ecc8276920ec23b1156c57be7c9
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 0dd613c0fe28e913c0edbb8404
+AAD = 2ad306575b577c2f61da7212ab63e3db3941f1f751f2356c7443531a90b9d141
+Tag = 945ee6db24aea5f5098952f1203339ce
+Plaintext = 9522fb1f1aa58493cba682d788186d902cfc93e80fd6b998
+Ciphertext = 6df09613ea986c2d91a57a45a0942cbf20e0dfca12fbda8c
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 68806dfe720d0a9a84697de5f2
+AAD = c6b0e4dfd723d7637510f887b7852f60ecdf72e0d33396560fed6534d5b7f015
+Tag = 2cc4c90ac3f798957cb09a05868a8ad5
+Plaintext = 9522fb1f1aa58493cba682d788186d902cfc93e80fd6b998
+Ciphertext = c5b64577d3c34e50f7da5072db5bda1d1d2c6db1a4f1183e
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 3e0fe3427eeda80f02dda4fed5
+AAD = ae0d1c9c834d60ff0ecfb3c0d78c72ddb789e58adfc166c81d5fc6395b31ec33
+Tag = 6b1556631d3b52bf24154afec1448ef6
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = 2bfe51f1f43b982d47f76ea8206ddbf585d6f30cec0d4ef1
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 7c0c76d9f9316ff6c98758b464
+AAD = 31a0338c3839931fa1dd5131cb796c4c6cfde9fb336d8a80ac35dec463be7a94
+Tag = 14f42ec81e3af71c9a5de7e0ac16ca69
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = 1622ae109073f44a4596722d9943fea774dfc2a1f939fc09
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 07c728135bdfede0e0c8036b17
+AAD = 25a152850b4b80b19d8f0b504b2a8a241824b3a1fca8d85c8713b2c0c84b5e02
+Tag = 43d67d90850c4c76a43df1f95170b29b
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = 4c0b361a766d366d983c41e793d75635e17f6eab2eadcf97
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 710c96d7a6f09de83f0507f28a
+AAD = 2d64acfdbfc582cd9a933790eb1b739fb02e53f511255e49f421bb7acc98a130
+Tag = 7bd5d5c8c098299394333b34fae9a110
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = 5b02347f30213df7f1506d7dca41b838c92aea0f190c5dba
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 977bbcdeb6a7d9dcf8664bc2d8
+AAD = 135786125258a49475338ac1961d2718433b9e84cf64f63ca52913e8dd12e505
+Tag = e26149d4a9711be81b4f69aa9fabd7f6
+Plaintext = 38333ce78110bf53a2c2abc7db99e133ad218ca43ff7a7bc
+Ciphertext = c77283ca15484d82469ce7249d1fb8e5f4c3bc8245fb4d97
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 60122cbd219e5cf17415e8bc09
+AAD = 895a45ddbe0c80793eccbf820de13a233b6aa7045cfd5313388e7184c392b216
+Tag = e47d00f2eebb544e6ba7559ac2f34edb
+Plaintext = 794e734966e6d0001699aec3f8ab8f194de7653d3091b1b9
+Ciphertext = bf0d219bb50fcc1d51f654bb0fd8b44efa25aef39e2f11af
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 83a07f2e685959cb50a1bd2bce
+AAD = 02afe300ec0cf0acb59108b2f70e069300294e34f40bb032cb59907599664408
+Tag = 6fa3fddc87690a359fe55f8fa12ba749
+Plaintext = 794e734966e6d0001699aec3f8ab8f194de7653d3091b1b9
+Ciphertext = 1609f8de59da4f50ce034977d132d4f9881a9b85ffa5bb88
+Operation = DECRYPT
+Result = CIPHERUPDATE_ERROR
+
+Cipher = aes-256-ccm
+Key = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+IV = 3542fbe0f59a6d5f3abf619b7d
+AAD = dd4531f158a2fa3bc8a339f770595048f4a42bc1b03f2e824efc6ba4985119d8
+Tag = 567a6b4426f1667136bed4a5e32a2bc1
+Plaintext = c5b3d71312ea14f2f8fae5bd1a453192b6604a45db75c5ed
+Ciphertext = 39c2e8f6edfe663b90963b98eb79e2d4f7f28a5053ae8881
+
+
+Title = NIST CCM 128 Variable Associated Data Tests
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = 1123301219c70599b7c373ad4b3ad67b
+Plaintext = 7c86135ed9c2a515aaae0e9a208133897269220f30870006
+Ciphertext = 1faeb0ee2ca2cd52f0aa3966578344f24e69b742c4ab37ab
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = b77a140819f39ef045103e785e1df8c2
+Plaintext = 48df73208cdc63d716752df7794807b1b2a80794a2433455
+Ciphertext = 2bf7d09079bc0b904c711a0b0e4a70ca8ea892d9566f03f8
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = 4b01098842a618390619b86e00850b2e
+Plaintext = b99de8168e8c13ea4aef66bdb93133dff5d57e9837ff6ccb
+Ciphertext = dab54ba67bec7bad10eb5141ce3344a4c9d5ebd5c3d35b66
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = 8bd518724ab84fb814fe7b5570769f7f
+Plaintext = 09fc21ac4a1f43de29621cacf3ad84e055c6b220721af7ce
+Ciphertext = 6ad4821cbf7f2b9973662b5084aff39b69c6276d8636c063
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = 7229cbcecef221570cee8345b38cd6ec
+Plaintext = cb43320d7488dfd6eed9efd88f440ea3f6f77a0df09d0727
+Ciphertext = a86b91bd81e8b791b4ddd824f84679d8caf7ef4004b1308a
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = fee47fec27d7764e5e2819c850088bac
+Plaintext = a350ed58c04473e113b9088b1fb9dad92807f6b63b0d690c
+Ciphertext = c0784ee835241ba649bd3f7768bbada2140763fbcf215ea1
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = 54d610bc1ab4bc9a8a28c7306f7c539e
+Plaintext = 0709e691faf41383fab5d1848a8eee77101d1c99e526a264
+Ciphertext = 642145210f947bc4a0b1e678fd8c990c2c1d89d4110a95c9
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = 2e31657ecc51f5ec8590482fc053230d
+Plaintext = e7b913c2f0630562eb1c16b3b1ed84090c011a15c09e5471
+Ciphertext = 8491b07205036d25b118214fc6eff37230018f5834b263dc
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = d500827f2081b00397102f90fc9ccd88
+Plaintext = 6b909697074900d41ce8c7d559b229af11fb3cec334784d4
+Ciphertext = 08b83527f229689346ecf0292eb05ed42dfba9a1c76bb379
+
+Cipher = aes-128-ccm
+Key = d24a3d3dde8c84830280cb87abad0bb3
+IV = f1100035bb24a8d26004e0e24b
+AAD =
+Tag = e2e7997803029476598c0e8d4fc63857
+Plaintext = 495ff03335bcb39a317b9ea3f8bb6306fa771f3c55adebce
+Ciphertext = 2a775383c0dcdbdd6b7fa95f8fb9147dc6778a71a181dc63
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = dd
+Tag = d16b6282283e16602331bcca9d51ce76
+Plaintext = 1b156d7e2bf7c9a25ad91cff7b0b02161cb78ff9162286b0
+Ciphertext = e8b80af4960d5417c15726406e345c5c46831192b03432ee
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = c5
+Tag = 08ebeed45f67ef8733737c9c6f82daad
+Plaintext = 032fee9dbffccc751e6a1ee6d07bb218b3a7ec6bf5740ead
+Ciphertext = f0828917020651c085e42459c544ec52e99372005362baf3
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = 68
+Tag = f9b477e3a23bfdfdb619c7bc531fbcce
+Plaintext = 9c4cd65b92070bc382fd18146611defb4204acddfdf6b276
+Ciphertext = 6fe1b1d12ffd9676197322ab732e80b1183032b65be00628
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = be
+Tag = aa82130f5a86c0cd0433585e5c208cf7
+Plaintext = 2ff93ef2fc5fe2c297ace05f3f7585aed75ef90ade3acf89
+Ciphertext = dc54597841a57f770c22dae02a4adbe48d6a6761782c7bd7
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = 7a
+Tag = 9d60012a2f25463e036ceecea57b3c97
+Plaintext = 62766e9acd41285eeed9b4007340dbb611699624274ad117
+Ciphertext = 91db091070bbb5eb75578ebf667f85fc4b5d084f815c6549
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = 13
+Tag = e337897c90eb260729a729aed1c8a244
+Plaintext = ea689c268a04912d0527b16d9d9406df38302fb11cb64a99
+Ciphertext = 19c5fbac37fe0c989ea98bd288ab58956204b1dabaa0fec7
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = e5
+Tag = 73dc2911c75b37cd995481d42b04524a
+Plaintext = f31e35953beb211efcce487ba8c0cd1a8446343d5851b9fd
+Ciphertext = 00b3521f8611bcab674072c4bdff9350de72aa56fe470da3
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = e3
+Tag = 84f76ecf3dc5f3307ce982f185321248
+Plaintext = c4ac3c645387584c2a95b1f16b8317730592924dd831a388
+Ciphertext = 37015beeee7dc5f9b11b8b4e7ebc49395fa60c267e2717d6
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = d5
+Tag = 2c38d0fe4e4eba054c1420c39a3dcc61
+Plaintext = 81af394c2ea3a85e1ea954596e3772f01635d007794c0b19
+Ciphertext = 72025ec6935935eb85276ee67b082cba4c014e6cdf5abf47
+
+Cipher = aes-128-ccm
+Key = 08b0da255d2083808a1b4d367090bacc
+IV = 777828b13679a9e2ca89568233
+AAD = ed
+Tag = 7cfa6c9945f5aee3c799eee37b0605db
+Plaintext = e013a2edd5b86bab8df5c9940d0a0c864478c1ad42668304
+Ciphertext = 13bec5676842f61e167bf32b183552cc1e4c5fc6e470375a
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = c93c
+Tag = 3ca01d874439b4e1f79a26d8c6dc433a
+Plaintext = e7b819a853ffe79baaa72097ff0d04f02640ae62bcfd3da5
+Ciphertext = 1d8f42f9730424fa27240bd6277f4882604f440324b11b00
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = 4cf9
+Tag = b40653cd23afc7cc7a31fa13ba8f4e49
+Plaintext = dc6cf325ed6d968efba9f57e48a58f4578cc3540fe121ba2
+Ciphertext = 265ba874cd9655ef762ade3f90d7c3373ec3df21665e3d07
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = b469
+Tag = c8c10aaf90b1116be216f912c82ca96a
+Plaintext = 22ab6a0daf953165dda864cceeeb782e275c0b072aedd284
+Ciphertext = d89c315c8f6ef204502b4f8d3699345c6153e166b2a1f421
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = cf6b
+Tag = 2f568ef41324189fb3644edcd76dc19c
+Plaintext = a35f62a431fee63468dc02fdf7bef78d3a5937de56151939
+Ciphertext = 596839f511052555e55f29bc2fccbbff7c56ddbfce593f9c
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = af7c
+Tag = 2548c244a875d3681d715db3da19962f
+Plaintext = 548840cb0400824af809fb68447500b77e977128200d3b81
+Ciphertext = aebf1b9a24fb412b758ad0299c074cc538989b49b8411d24
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = 61dc
+Tag = b599bc8927ad8d43067807f4b858f854
+Plaintext = 440b6095c77495e73fff54c785b7ceb5eb358731c213ffcd
+Ciphertext = be3c3bc4e78f5686b27c7f865dc582c7ad3a6d505a5fd968
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = b97e
+Tag = 7454774ee78f76e555cf743df340381e
+Plaintext = 50c59ca54eb64575b82b13c6dac96488af369e9f5f86cdf2
+Ciphertext = aaf2c7f46e4d861435a8388702bb28fae93974fec7caeb57
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = 57ab
+Tag = e0a22a5ee031978271c7dd2a0d4e7018
+Plaintext = 21b8eb1f0bda26ca36167ce7bc2e796818bf11fc8c192885
+Ciphertext = db8fb04e2b21e5abbb9557a6645c351a5eb0fb9d14550e20
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = 5f9c
+Tag = 9a242ebae5c6da57ee38e5c227c46b32
+Plaintext = b4d84fb1e81e18c89391a7a59fc05fedaf160e0d0d027a7c
+Ciphertext = 4eef14e0c8e5dba91e128ce447b2139fe919e46c954e5cd9
+
+Cipher = aes-128-ccm
+Key = 1538cc03b60880bf3e7d388e29f27739
+IV = 9e734de325026b5d7128193973
+AAD = e0c4
+Tag = a5f8a92f4201c4658289307167cee810
+Plaintext = 54dc5a0e1b67577cda4e7dbd48b769c120c1d13dd567cfad
+Ciphertext = aeeb015f3b9c941d57cd56fc90c525b366ce3b5c4d2be908
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = f5827e
+Tag = 78e2a23411147a6187da6818506232ee
+Plaintext = 9759e6f21f5a588010f57e6d6eae178d8b20ab59cda66f42
+Ciphertext = f634bf00f1f9f1f93f41049d7f3797b05e805f0b14850f4e
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = e9699b
+Tag = f10835db9897b7528e3204fe3a81424f
+Plaintext = 1555bc87d6c688fd221a2c75cd1e4dd1c1693207ac421d24
+Ciphertext = 7438e575386521840dae5685dc87cdec14c9c65575617d28
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 972896
+Tag = 3efa05ba4a73ec2234461d459f54acd2
+Plaintext = b72b2a080d92f3f3bb7d96222982de82a28c9eebaddba247
+Ciphertext = d64673fae3315a8a94c9ecd2381b5ebf772c6ab974f8c24b
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 3053f3
+Tag = b557537c6525e827750917a1ed49602f
+Plaintext = b5417ed6933ffe2b57ea601d77e97eb12fa1fb8fdc06c86f
+Ciphertext = d42c27247d9c5752785e1aed6670fe8cfa010fdd0525a863
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 24db75
+Tag = dfd06b037e9094f120eb3d8649d48918
+Plaintext = 4e7f42666035a00e62783283c54b027603917685d27326bc
+Ciphertext = 2f121b948e9609774dcc4873d4d2824bd63182d70b5046b0
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = ff27a4
+Tag = bfa8cfabbd79b3e3210482e6f3822fee
+Plaintext = 7bf180699c294421ad9565cacc27227a4b3a7cf9637290c6
+Ciphertext = 1a9cd99b728aed5882211f3addbea2479e9a88abba51f0ca
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 77ec24
+Tag = 3b9575e347051e98d0c8646ad46318e6
+Plaintext = 3d47071c13f994cb42fb2887e5c6e53a542be7ddad9779e0
+Ciphertext = 5c2a5eeefd5a3db26d4f5277f45f6507818b138f74b419ec
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 6d7748
+Tag = 78e7af65eb0388ae7a52f58f6ba32109
+Plaintext = 317d5da0a2ec12c3b96c83dd61cc955242a9c1c640e2b92f
+Ciphertext = 501004524c4fbbba96d8f92d7055156f9709359499c1d923
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 029674
+Tag = 8019fa97ff70d4d21c0bd83caa434b3a
+Plaintext = c9bb21306ee1b4a6c4fa5443af2e181716993cbb374e177c
+Ciphertext = a8d678c280421ddfeb4e2eb3beb7982ac339c8e9ee6d7770
+
+Cipher = aes-128-ccm
+Key = f149e41d848f59276cfddd743bafa9a9
+IV = 14b756d66fc51134e203d1c6f9
+AAD = 60dfe8
+Tag = 1814ed48a21d97ea02e86d7e6e8834cb
+Plaintext = 44eb7edd6bee501ad97873aa7ecbf7ed8b613760d7c95e15
+Ciphertext = 2586272f854df963f6cc095a6f5277d05ec1c3320eea3e19
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = a95bdff6
+Tag = 9b6443a35f329b2068916fb6ab8227eb
+Plaintext = 035c516776c706a7dd5f181fa6aa891b04dd423042ea0667
+Ciphertext = b92f7ec2ebecebdbd2977b3874e61bf496a382153b2529fc
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = d2672cbb
+Tag = 19e2aa492ce9ddfb6de0ab7a447f5351
+Plaintext = 3ba306bcec94615c347f990b62841a16df7b321f113f1714
+Ciphertext = 81d0291971bf8c203bb7fa2cb0c888f94d05f23a68f0388f
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = 737f4d00
+Tag = 2bf683b1209f104e82ba39f7c62cd666
+Plaintext = 68313a29ace3efe521c3ca1e5bac8e98d6b4434c80a7dc74
+Ciphertext = d242158c31c802992e0ba93989e01c7744ca8369f968f3ef
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = 3610b1ae
+Tag = 4fc7d5cac043f182edbe5c2658f73092
+Plaintext = 963bfe556138317bebe3936b18a2c1dd100dc73be6fde556
+Ciphertext = 2c48d1f0fc13dc07e42bf04ccaee53328273071e9f32cacd
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = f1aa7f72
+Tag = b8234f3fbaca3dc2c497418219151b05
+Plaintext = 52d5c53ee4f23cb050a95db54112b44033c34ac31de96be8
+Ciphertext = e8a6ea9b79d9d1cc5f613e92935e26afa1bd8ae664264473
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = 6b1013aa
+Tag = 8fa5f9539e0500f139016e4a4337d86b
+Plaintext = a302aebc0f8fd61badc8371991beacf5933de46effacb8ce
+Ciphertext = 1971811992a43b67a200543e43f23e1a0143244b86639755
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = 33028129
+Tag = fa2379fde155e64b5b84e336056445c3
+Plaintext = f7d653c23254875625b20e1ef60ae92847046d84bb4ce857
+Ciphertext = 4da57c67af7f6a2a2a7a6d3924467bc7d57aada1c283c7cc
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = 2cab4a09
+Tag = 58208335cb81e4fb10923fca4ddb9ff9
+Plaintext = 872a3f7230e626abff519e5aeecc93897249405daeaffc98
+Ciphertext = 3d5910d7adcdcbd7f099fd7d3c800166e0378078d760d303
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = 73142ba7
+Tag = 2d6ecfb49ac8983415503efef1e21950
+Plaintext = 766f94e7d9b1ce74bbaf2c99d215350f060122767fc1953f
+Ciphertext = cc1cbb42449a2308b4674fbe0059a7e0947fe253060ebaa4
+
+Cipher = aes-128-ccm
+Key = 9a57a22c7f26feff8ca6cceff214e4c2
+IV = 88f30fd2b04fb8ddbce8fc26e6
+AAD = bc9f967e
+Tag = 1978a62d15430fc20b87940292b49641
+Plaintext = 5f089ed9267363bc23c6c7b8f73208a36f61fa8ea8084ff7
+Ciphertext = e57bb17cbb588ec02c0ea49f257e9a4cfd1f3aabd1c7606c
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 5f476348dd
+Tag = 4e5a32fbe7961b832b722bc07a18595b
+Plaintext = c69f7c5a50f3e72123371bbfd6bdf532b99ef78500508dfe
+Ciphertext = 20c43ad83610880249f1632dd418ec9a5ed333b50e996d1a
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 07db8aada5
+Tag = 401a2222443696021b5faa520129b563
+Plaintext = 9cf8b638f2b295b85cf782fabab11153dc091b4afcd761a9
+Ciphertext = 7aa3f0ba9451fa9b3631fa68b81408fb3b44df7af21e814d
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 31ef6561ff
+Tag = f842681d2e90da5718234ed893197662
+Plaintext = 62b8263dc015ef873cd16272e4da89799b910f2b04204420
+Ciphertext = 84e360bfa6f680a456171ae0e67f90d17cdccb1b0ae9a4c4
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = e97dfcbafb
+Tag = 33a08eb30ee154f71279682ab02eff27
+Plaintext = 810bed3a2bc0f9d75389155b7a39d9d014c08646814f9718
+Ciphertext = 6750abb84d2396f4394f6dc9789cc078f38d42768f8677fc
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 4981c51fcc
+Tag = 8d3071c79f0cf86fe4148cb5e8ace0ce
+Plaintext = 063d23fc3ec344c1ba3486802e01e55617455d5cfbfb5279
+Ciphertext = e066657e58202be2d0f2fe122ca4fcfef008996cf532b29d
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = c8437dba76
+Tag = 842700619dc1599603f3f3f6cfdf5e0b
+Plaintext = 41db5b245ea0fab985b93e7fc0a00cd3cca5bdbb642b7ebf
+Ciphertext = a7801da63843959aef7f46edc205157b2be8798b6ae29e5b
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 6f65a24344
+Tag = 39a0cd8d8bbf211b907f34411f868c79
+Plaintext = b0e36734b2ba871d59df0b029c7f32af68e003a689ac4911
+Ciphertext = 56b821b6d459e83e331973909eda2b078fadc7968765a9f5
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = cd62d6d203
+Tag = c4a90e5fc11266bab77eea1d24fbdbb9
+Plaintext = 747e53e627eabde0cd77d78d1bd720bea518f8a2f76e57a2
+Ciphertext = 922515644109d2c3a7b1af1f1972391642553c92f9a7b746
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 9663b3c8e6
+Tag = b3c1246f7dd6462ce757db82db45f36e
+Plaintext = c70c92ec4c518802662fa4c41a6a33a22599f79f8f7264b3
+Ciphertext = 2157d46e2ab2e7210ce9dc5618cf2a0ac2d433af81bb8457
+
+Cipher = aes-128-ccm
+Key = 54caf96ef6d448734700aadab50faf7a
+IV = a3803e752ae849c910d8da36af
+AAD = 35c4720d3c
+Tag = d472c06a5f4c04f97d06ec401d3e7fd9
+Plaintext = a26835605b66fc08abdbb5dc77e39783d60b8e8f2314e95f
+Ciphertext = 443373e23d85932bc11dcd4e75468e2b31464abf2ddd09bb
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = da853a27aee2
+Tag = 2e3ca4ec3c776ab58843f617d605fd72
+Plaintext = 15b369889699b6de1fa3ee73e5fe19814e46f129074c965b
+Ciphertext = f39755d160a64611368a8eccf6fcbc45ef7f1f56240eb19a
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = d4ed4584678e
+Tag = 327804c44c8f17a4446a3d5ba85f9c7f
+Plaintext = a18c0460b56a5bcd5bf6842cec6ed44d90b2bfa968a6a7e7
+Ciphertext = 47a838394355ab0272dfe493ff6c7189318b51d64be48026
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = 590a27721a36
+Tag = bcd00e9cb726d75e4283820ee81d933a
+Plaintext = 41cee0ecaf9c65cef740440af37954ef49a585779d2abbca
+Ciphertext = a7eadcb559a39501de6924b5e07bf12be89c6b08be689c0b
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = 58830fb0b1f3
+Tag = d5d71a1f0f1b6518c35f0632a30931fd
+Plaintext = dce983e4e3734a9bd8848dba0d744d07bbeba602f4006025
+Ciphertext = 3acdbfbd154cba54f1aded051e76e8c31ad2487dd74247e4
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = eedd0d767a25
+Tag = 3ad112899e9ba442660eb5dfe33b2f96
+Plaintext = 4653b3e879ab18b65c5c3706a5139698262cb830a22d943b
+Ciphertext = a0778fb18f94e879757557b9b611335c8715564f816fb3fa
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = 618bcf2e3e79
+Tag = 54fba446028919342b2fe86ee67efcc7
+Plaintext = 8586383281925363ac15fb19c26d64c639c75920c792dc2c
+Ciphertext = 63a2046b77ada3ac853c9ba6d16fc10298feb75fe4d0fbed
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = 549c9b84c7f7
+Tag = 9fc23013142f62881ccfa3037067e1ef
+Plaintext = 95c25ae4445cd8c4d267df82687484667e309992fcf1e737
+Ciphertext = 73e666bdb263280bfb4ebf3d7b7621a2df0977eddfb3c0f6
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = 92d7fa6a8135
+Tag = 8263568d56fae8bf35b2f2cdecbffe0a
+Plaintext = e58034bbb0e6f5e724e32ee56896dadae25c2a3efb8c6f2f
+Ciphertext = 03a408e246d905280dca4e5a7b947f1e4365c441d8ce48ee
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = f43e126c0f83
+Tag = de2c2fbfdddc7dd6672714af174c5121
+Plaintext = d98f0dddfe9cb3cae1336970d5efb55316a65e2c51e316f4
+Ciphertext = 3fab318408a34305c81a09cfc6ed1097b79fb05372a13135
+
+Cipher = aes-128-ccm
+Key = cc0c084d7de011e2f031616a302e7a31
+IV = f0b4522847f6f8336fe534a4e7
+AAD = f02074812dde
+Tag = 3704560ff23ce0000fba8812c45940ad
+Plaintext = 548747b1669c6383b793054d93957f9e99d605761c6c23b5
+Ciphertext = b2a37be890a3934c9eba65f28097da5a38efeb093f2e0474
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 922340ec94861f
+Tag = fd541b988a801cb5751c7faaf5b0c164
+Plaintext = 1edef80c57d17f969f8bde10ab38a1a8811a124de72c526e
+Ciphertext = de14558cc686e1836f1f121ea1b941a9ebd4f0fb916dc870
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 4eb379f21b1531
+Tag = c068bd1b1c309dfbd52d9a24be07c630
+Plaintext = ddd5282a207c1dcb03c1c3bbc9eb12a7bd28534118db2735
+Ciphertext = 1d1f85aab12b83def3550fb5c36af2a6d7e6b1f76e9abd2b
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 7fa89e9d6e3fec
+Tag = 2d114d6ab082738d05d60acca8e8ccfb
+Plaintext = c5b7c462eb166f48bb59c8102ee7b3dc67a28e5de7570c51
+Ciphertext = 057d69e27a41f15d4bcd041e246653dd0d6c6ceb9116964f
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = fda8665f87c618
+Tag = 1cc84bd77fe00e1a13433f2c10e3b799
+Plaintext = af793815e147e3180f5146aa6a582e343dc479f26b4226b2
+Ciphertext = 6fb3959570107d0dffc58aa460d9ce35570a9b441d03bcac
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 46bde207491ebd
+Tag = 990c81f1bae32c953bf02ddbde047632
+Plaintext = 47c76a0bbd5b1616b278089d41a050c509c7a1c280574bf7
+Ciphertext = 870dc78b2c0c880342ecc4934b21b0c463094374f616d1e9
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = a799f5f895fd7a
+Tag = 1af19f1f080dd1dd2da799059755e49f
+Plaintext = d554806ffc3900a0952a3c094c745808950697a6e5d62c1d
+Ciphertext = 159e2def6d6e9eb565bef00746f5b809ffc875109397b603
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 20225831a9ee06
+Tag = 23d3b9a0060834ac4860dae0eac570ef
+Plaintext = ba45e1859efae362a44a0116a14e488ba369da6c76c3913b
+Ciphertext = 7a8f4c050fad7d7754decd18abcfa88ac9a738da00820b25
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 785360916464eb
+Tag = ff96e7cf841a66c50bbb6fb2bac7ef51
+Plaintext = 57bc338946ff78cf76adf5021e2e44e34e687fb68ad703f3
+Ciphertext = 97769e09d7a8e6da8639390c14afa4e224a69d00fc9699ed
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 57b946369226db
+Tag = 86e1c33a45f9d52755c374650635bef6
+Plaintext = 9ac5be9929c4fe5a9992749a38dc69874866db3d4747da97
+Ciphertext = 5a0f1319b893604f6906b894325d898622a8398b31064089
+
+Cipher = aes-128-ccm
+Key = d7572ed0e37261efa02f8c83e695efdc
+IV = f4f96d7b4384a3930b3d830f82
+AAD = 73e4da8973c1e3
+Tag = d78592c2d89c15edc5bb7486aa93f896
+Plaintext = 5a05410aa3a71f5f1a253b8576eba269c06a4c30591144cc
+Ciphertext = 9acfec8a32f0814aeab1f78b7c6a4268aaa4ae862f50ded2
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = 2d5438b728b950d9
+Tag = eecfff971fdfaa856310b014aa59c978
+Plaintext = 9aa9c8358117564371366beeec923051ef433252197aaad5
+Ciphertext = 9ff942baa60f440c17a78e9581216b9a947a67f04d54911f
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = 6e430b497a16e7f5
+Tag = 6a4d7b4b4df6c831ee32116ee4dad98c
+Plaintext = 5758a500978c71a9b90f6e5beae9d96ef05a41486b10ea2e
+Ciphertext = 52082f8fb09463e6df9e8b20875a82a58b6314ea3f3ed1e4
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = e12f98507d6514c3
+Tag = 3243fc75cd1624e152f451678edcac87
+Plaintext = 49efe18c76a8355127d914a3a830c1c6ff2a163d728526e1
+Ciphertext = 4cbf6b0351b0271e4148f1d8c5839a0d8413439f26ab1d2b
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = eecf8d641ee0bee9
+Tag = dd6d8ca57da1880e1baff43736b3da34
+Plaintext = 49ae2309fbe6ce4e9421516b8f79ae64b1316cb849eaf638
+Ciphertext = 4cfea986dcfedc01f2b0b410e2caf5afca08391a1dc4cdf2
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = 9066367c784de0a4
+Tag = f05439a661001513a96b896de46b7081
+Plaintext = b1bda5fa4242aa6aad0f5a5b1d31d86b8d4a97588b3e315d
+Ciphertext = b4ed2f75655ab825cb9ebf20708283a0f673c2fadf100a97
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = edf848b2510f7803
+Tag = cf20709b2dc2ff9946094190b5ea09d1
+Plaintext = eaa8608f6763d968576a7e89056b9828a1686c8441b06377
+Ciphertext = eff8ea00407bcb2731fb9bf268d8c3e3da513926159e58bd
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = 0f49cae81c8628d2
+Tag = a5bb6b4f87b9b198665203e4fdf9e7f7
+Plaintext = f32029cf51609f0df9832ad1b283ea94a5356f70112c1328
+Ciphertext = f670a34076788d429f12cfaadf30b15fde0c3ad2450228e2
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = b0c47e9cce46a276
+Tag = 29f416f89f1a34bbbf2ce40d943c6d8b
+Plaintext = 7a550ef9254a8da6e4fee290a76ea838ffb61d3533d4d31f
+Ciphertext = 7f05847602529fe9826f07ebcaddf3f3848f489767fae8d5
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = a6fe7c9ce2d49f85
+Tag = 7eb95550b91b955d5c2d72d5c189b704
+Plaintext = e67c486dd7ba9a9061844b9354f55890321ae626efaa28cc
+Ciphertext = e32cc2e2f0a288df0715aee83946035b4923b384bb841306
+
+Cipher = aes-128-ccm
+Key = 98a42d7a0c5917deaf3b4de3f0cbe0a1
+IV = 03d33ab0c2df7bfce88b5ee4c4
+AAD = eb1d11cc4876f58f
+Tag = 0e8e8a5a7e0ea6860bab4a4320f03ae5
+Plaintext = 35f2c810091e930a52e4a3f28c9c8184967f1554c2675eb5
+Ciphertext = 30a2429f2e06814534754689e12fda4fed4640f69649657f
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = abe4f1d3812bfe3ccf
+Tag = fd49840440f866d1a22b0854996111d8
+Plaintext = 13b4a874888db0e5d8fd814b5e7e04f7fdfbc1601ccc02bc
+Ciphertext = 032835a3dbf688d09cf2a32a92b101959d33ff47500f92f4
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = 2e21f466814d3d6340
+Tag = de2f5c335df537fbbc6ae59cd562732f
+Plaintext = 08b5c773364cded74d7b308984313c17ff90eed496a27a2b
+Ciphertext = 18295aa46537e6e2097412e848fe39759f58d0f3da61ea63
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = dba22aabcea0e694fc
+Tag = cc5ed6e4a907ff4742ab6c835a427f92
+Plaintext = bbac1790abb7aafe272ec472c897e6363e335b3c4126c762
+Ciphertext = ab308a47f8cc92cb6321e6130458e3545efb651b0de5572a
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = 97e9d16bd757395ec1
+Tag = 1714b5a3df454f3bc35869da75adc882
+Plaintext = 7249612dc09809bbca9dd311e720f7da2cb54ce33e3eb9c3
+Ciphertext = 62d5fcfa93e3318e8e92f1702beff2b84c7d72c472fd298b
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = 866cf710470cac74d3
+Tag = aa33dffe2596832f98a9c8413bd898b9
+Plaintext = 060ae0ab9857324a3b2ac79f3b6e6f90f5de884ce9c7b930
+Ciphertext = 16967d7ccb2c0a7f7f25e5fef7a16af29516b66ba5042978
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = 2dd7a7f832b29ccce2
+Tag = dd5049f7c53d6a7fe5d7f959689ee960
+Plaintext = f77a9fd5363836deefd34e1bea0882484a7ab746b4495d59
+Ciphertext = e7e6020265430eebabdc6c7a26c7872a2ab28961f88acd11
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = 502349a60e897356b5
+Tag = ed9c3a0d0de8788471c5f6c2f9638b7c
+Plaintext = 96118dbfe53434d8aed88769a535eb0c8b5849dca1c81c34
+Ciphertext = 868d1068b64f0cedead7a50869faee6eeb9077fbed0b8c7c
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = debed45c9acf129268
+Tag = d49b4b9bead1b7de2021cff280d6f93b
+Plaintext = df5a47d3eb5c0b6cabb6711a45400602d205b82ecae9e849
+Ciphertext = cfc6da04b8273359efb9537b898f0360b2cd8609862a7801
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = 2726702dd62a6e5344
+Tag = 69df31aba209d87ee22bd6a1dcadb168
+Plaintext = 5a7649cb001fbb6f653cbca17756c5c1a078c2e240d92085
+Ciphertext = 4aead41c5364835a21339ec0bb99c0a3c0b0fcc50c1ab0cd
+
+Cipher = aes-128-ccm
+Key = 2a68e3fe746f593c1b97cb637079c3e5
+IV = cd62d0f27b7f4864dc7c343acd
+AAD = e8006cfb0536696ac7
+Tag = 7cc5b60c881fe834a789d28447d8fb54
+Plaintext = 95186d41f927cdbef42157f21d966e88061b6558b5ec932f
+Ciphertext = 8584f096aa5cf58bb02e7593d1596bea66d35b7ff92f0367
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 8d65880eddb9fd96d276
+Tag = 27ecdcb257d0d30491e5bf1aa8f90958
+Plaintext = cc0915194218d4536e467433cd6d79ff1d9eb9ff160ab684
+Ciphertext = bd56edc015692c6ab9bec493a9893863598414a3d11a6a0f
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 8a65cde13149d9d54a5b
+Tag = b10f9fc201e4128696dcd899dd2e24ea
+Plaintext = 28257133b1d8b0b2be4faecd6e819ac783707a5c5f50c302
+Ciphertext = 597a89eae6a9488b69b71e6d0a65db5bc76ad70098401f89
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = e999ec3e1bfb25b5877c
+Tag = c522e5ba5adbc6a639cbd06f103ebc9e
+Plaintext = 96ab0cfc204bafc4f5851d6c682d631d0c5ad03ac925a943
+Ciphertext = e7f4f425773a57fd227dadcc0cc9228148407d660e3575c8
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = a8554441e073d6065dce
+Tag = e1a4e0f7ebc3cff3915d27971cce7e91
+Plaintext = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+Ciphertext = 21cda08aff3bcbc6eed9e44483d3ae5dc9d564d38a42e922
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 838f0be8d04d28d77549
+Tag = c215c88d80bffc881aff10ba40f11976
+Plaintext = d0700658d5f4010ff21091f3d119c99645e339198029c3a9
+Ciphertext = a12ffe818285f93625e82153b5fd880a01f9944547391f22
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 20f014d928d5b25fbaf4
+Tag = 2cc9391bc06aa6ca9d486a4e2a218c54
+Plaintext = 4bdf28748a0c281dd49c7294ae8e55fe7a52d45ff6384db3
+Ciphertext = 3a80d0addd7dd0240364c234ca6a14623e48790331289138
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 56c026b8a71974ff7ecd
+Tag = 778b05c6c582a0bb7d1d9dcf6a46b9f6
+Plaintext = f75db057f0276fff85014f54ecdec8f90b96a2a982db14cb
+Ciphertext = 8602488ea75697c652f9fff4883a89654f8c0ff545cbc840
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 75c3b9e52648a4f9aca9
+Tag = f47d9ebbd3cff14623b10cecc94b53d6
+Plaintext = c15c554169dbb9b08494afaa44819a10dc9ddad54199ab54
+Ciphertext = b003ad983eaa4189536c1f0a2065db8c98877789868977df
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = 1c76c3014a14b7fa1ca8
+Tag = d2b74b84dc170c00dce85b56e346a976
+Plaintext = 19eef6f798fc68086aad1cda6d7976cdcfe6b8af74598032
+Ciphertext = 68b10e2ecf8d9031bd55ac7a099d37518bfc15f3b3495cb9
+
+Cipher = aes-128-ccm
+Key = 46b067cf9b1a28cf187002e90b14e130
+IV = bad8c03292bf01cfd8d34f860c
+AAD = a4eb60d4eb7ead1bd0e6
+Tag = d92e19fd8b5c1fcbff36adaa5e47ae84
+Plaintext = e06e5dba5ac35cfd07949e5cc12ad70507d4a86a952ecca3
+Ciphertext = 9131a5630db2a4c4d06c2efca5ce969943ce0536523e1028
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = 537038b5357e358a930bd6
+Tag = 8790c1648f461a31c84e62ea8592a074
+Plaintext = 4d64461c55eb16bf7b9120f22be349598f2f394da8460dc6
+Ciphertext = e9fc5004c2359724e1e4411ae6f834ef6bea046d549753c8
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = 7e3d7b3eada988668f3784
+Tag = acb1d1c9231d2c22ecfeed622792dfd0
+Plaintext = eab7d5dbd91d4cbbac8d79fadd70b5dcb3baadac5cb713a3
+Ciphertext = 4e2fc3c34ec3cd2036f81812106bc86a577f908ca0664dad
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = 78b107b29c4878ff18f749
+Tag = fffe60299768f048e7098033cde046b0
+Plaintext = 3c6ae2e2578875a1f5611582528e058aece2ddc33a4dde3d
+Ciphertext = 98f2f4fac056f43a6f14746a9f95783c0827e0e3c69c8033
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = d293908bb516c5f3a411b9
+Tag = 4ee6ebc0d90a0de05b428495c93e1801
+Plaintext = d7a46e726ed43f1580eb52141a93390982cc809dc833e3f0
+Ciphertext = 733c786af90abe8e1a9e33fcd78844bf6609bdbd34e2bdfe
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = 33ef208faad4d2948c9e67
+Tag = 7e7e64cc0fcd6a92c79ceb6ce2abd8ee
+Plaintext = b1fe5d9d34157193fc0608cd8ecb872e17720f5f6814a466
+Ciphertext = 15664b85a3cbf0086673692543d0fa98f3b7327f94c5fa68
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = b7f7ed9ccac3c2b4fbfee0
+Tag = b02b53bc779e0976b634b0d1b88fc0a9
+Plaintext = de6bb539fb7a9c87414f62a7cf25a4cfca176509e991af41
+Ciphertext = 7af3a3216ca41d1cdb3a034f023ed9792ed258291540f14f
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = a6e287383927f76e4927af
+Tag = 3c37fa936243b393f07fcccb0fc13e41
+Plaintext = 8719d20c20c8959068b8adcd65e6f6bc7b3693828f0735a0
+Ciphertext = 2381c414b716140bf2cdcc25a8fd8b0a9ff3aea273d66bae
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = 70828be6dd93954f4e7b6b
+Tag = 0d7534a489e6d242966ebea4455f8f79
+Plaintext = 30b39426831f61c8ba5f2ef5b71f0c4b2f916e3b5a578110
+Ciphertext = 942b823e14c1e053202a4f1d7a0471fdcb54531ba686df1e
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = 506015fc2831df293f4da0
+Tag = ccbf64f04e95b180d09e843847d22104
+Plaintext = 818d5d810f678629f078723f5c6c3657271077533bfb7c29
+Ciphertext = 25154b9998b907b26a0d13d791774be1c3d54a73c72a2227
+
+Cipher = aes-128-ccm
+Key = e94dac9c90984790a7c0c867536615ff
+IV = c19f06f91e645d4199365f18c0
+AAD = e9394b0245b379e68e3dea
+Tag = 27b546ef8cd717073832584fb25a0645
+Plaintext = f0613205a7a0822849df9e8a3cf6caf281f3adfa966c5507
+Ciphertext = 54f9241d307e03b3d3aaff62f1edb744653690da6abd0b09
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 040b25771239cc2a39446e3c
+Tag = 54e5d050a405f755047d09cb0f49546a
+Plaintext = 011fc50329bfd63a85ebd4f7693363602f1a4147371270b7
+Ciphertext = 4432d7eb42980734d34f19c50cf8abf71ac1b19ed75a7278
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 50a1d37fa2f3462bd304631b
+Tag = 2abee8547ee3f24cfa677468ecc1d121
+Plaintext = c90e40540d372ab1eb00ea5d5b8de5bf7c94ce4e376d6949
+Ciphertext = 8c2352bc6610fbbfbda4276f3e462d28494f3e97d7256b86
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = ac3bb872a41df35e415d2b0c
+Tag = 61cef865ce4080e7c7abfc43f62c03a3
+Plaintext = 9e7be78c0ab9e6a4c6c257e77c63681bea35d951f168b0c5
+Ciphertext = db56f564619e37aa90669ad519a8a08cdfee29881120b20a
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = e3106ae6456153dd922640a1
+Tag = e1d19c321a1e0852adba939b447220ab
+Plaintext = 00df0c5a5d3eceb2bd293066529799544f846672a9a1d31b
+Ciphertext = 45f21eb236191fbceb8dfd54375c51c37a5f96ab49e9d1d4
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 297b4498bf5427e6341aa927
+Tag = 79ea5fb65018abdcde1a39f6859ecb56
+Plaintext = 14967a0476dbaea03b07fa8d40d344eabaf479be2443243a
+Ciphertext = 51bb68ec1dfc7fae6da337bf25188c7d8f2f8967c40b26f5
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 5de60dc0e3b5bda0b33a9520
+Tag = c2629ff871ee15745fd8c1ddbdae4c29
+Plaintext = 2da3716d76d10b6766a1f9cbf9f420316fd5f396e7b9a2ba
+Ciphertext = 688e63851df6da69300534f99c3fe8a65a0e034f07f1a075
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 1c9b8541943ad50b4243c179
+Tag = 04e198ad16ad1106d3ba6172f4a13a8f
+Plaintext = 8c1b3ba18d1f5cff74a457aadd6b3e7d093d06ad2622e6a0
+Ciphertext = c9362949e6388df122009a98b8a0f6ea3ce6f674c66ae46f
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 51e926d2542ac8faef61465a
+Tag = 75981131e3934ec6d41e00d502729799
+Plaintext = 88936e97db070c0ec2aa58d1c6f5b34df3d32ddf7db34a8b
+Ciphertext = cdbe7c7fb020dd00940e95e3a33e7bdac608dd069dfb4844
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = ebefbac97b363e6f32526aac
+Tag = e2c005b5bebe07ff578b1b4bc51971cd
+Plaintext = c20742e4b410c5b661da373a905fb0ed55b20e0e879eff5c
+Ciphertext = 872a500cdf3714b8377efa08f594787a6069fed767d6fd93
+
+Cipher = aes-128-ccm
+Key = f6bb5d59b0fa9de0828b115303bf94aa
+IV = 05358f33e1fc6a53ab5a5c98ce
+AAD = 1ef059ac7d648e9e32d9b1f2
+Tag = 21a25f15b5b4229a872a9199972c85b3
+Plaintext = 65c55ca21a89a8325365bf2be861d700559de2eabb41b37f
+Ciphertext = 20e84e4a71ae793c05c172198daa1f97604612335b09b1b0
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = e3afd091d2b588465872a6300f
+Tag = 42d522cc9dc19c47a4fa0b1528069cf8
+Plaintext = 8e5fa1a6662a8378cda15697e926841594f2f394fa5a34ab
+Ciphertext = ca0d95e3ff186ad6b88d45fc4079e6b7b4a615e7e8dd5f47
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = ce3186bb737753b59ee76b748c
+Tag = 59b26510b8f25610799e011d7c850ecd
+Plaintext = 311ebc5ff2f625944562ea699b2690df3e6e64a17c62bd3a
+Ciphertext = 754c881a6bc4cc3a304ef9023279f27d1e3a82d26ee5d6d6
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = bfd636989dfbcb0edc9f014cc8
+Tag = 52942aa0d39649f3d9ed535bebc2b603
+Plaintext = c96cee5ba7b799f16254a17b1870cdb85fe0ef3f42110c13
+Ciphertext = 8d3eda1e3e85705f1778b210b12faf1a7fb4094c509667ff
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = 4812b092aa59d57451bfd812c3
+Tag = c1e61efb9c1d84ddac2d24f43531f569
+Plaintext = 13b1b4404dc5735655139414fcbd02c5327ae9fb148bd324
+Ciphertext = 57e38005d4f79af8203f877f55e26067122e0f88060cb8c8
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = f6ef9ac4f4c9ce1e4309c64fa8
+Tag = 13350de0ef34df12fb945b0ae0a0d9bd
+Plaintext = 6c5b59319e2710f5d63407f85b424d1860425ef8ce0cfe53
+Ciphertext = 28096d740715f95ba3181493f21d2fba4016b88bdc8b95bf
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = 9bf12168bb3d79ebd25262f2b4
+Tag = a0734563638598d8c4bf1fcd94009925
+Plaintext = 968e1d78008da78611e82985c4028e86770858cfe61c3723
+Ciphertext = d2dc293d99bf4e2864c43aee6d5dec24575cbebcf49b5ccf
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = 7d870d7e52d3053c65eefad477
+Tag = a1f5fc53b08aca82bccfba6fbcb27e69
+Plaintext = 6a1306d911434cc7400d2f9a95e36aedceddca2b3d583f51
+Ciphertext = 2e41329c8871a56935213cf13cbc084fee892c582fdf54bd
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = e95099f04371e445e5eaa1d80e
+Tag = 7d1a922953facbd630d7fea6b63594ec
+Plaintext = b9197eb50c8168d16b8a12bd261d553ffcc521d979b26fee
+Ciphertext = fd4b4af095b3817f1ea601d68f42379ddc91c7aa6b350402
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = 3e80eb03db6545204ef4241ad6
+Tag = 83fa000d10078256b71249d9d1f1846c
+Plaintext = 95f59e36eac8eb3b51709d635b07fa2da0976ea20e25807f
+Ciphertext = d1a7aa7373fa0295245c8e08f258988f80c388d11ca2eb93
+
+Cipher = aes-128-ccm
+Key = d1da2e961e78063af8de41865b226873
+IV = 03739f5474857006340cce554d
+AAD = 9748798c0f3cc766795c8ce0e4
+Tag = 2773c2f55b752477c489facee812c614
+Plaintext = a48db9add9ecdeb49e51d3ab7bb2075202ed2aa50c0195b1
+Ciphertext = e0df8de840de371aeb7dc0c0d2ed65f022b9ccd61e86fe5d
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = d24651ef0561282d3e20e834960c
+Tag = d9236d5c5c9319092078411b72c51ba8
+Plaintext = 798e31cce0a83702a95171fb1162a17b9ce00ec3592ce262
+Ciphertext = f3c3e52f1a1ff528a8d3783ee4e75f114e3e6416334815d2
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = c527d309ab29ee91c5fc53117e71
+Tag = d8ad2a48cb734e3f93e602c15c7c775e
+Plaintext = d79cd4c8891ec4ce2c51136712d23b32266b2b73768aeb1e
+Ciphertext = 5dd1002b73a906e42dd31aa2e757c558f4b541a61cee1cae
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = a93dfc3944514ddfc5acdd89fab7
+Tag = f34b297f3f106a9cdae255f7634fbd0f
+Plaintext = d7fa81c949f1f2af29dbd56529b307e3b348e996d0936455
+Ciphertext = 5db7552ab34630852859dca0dc36f98961968343baf793e5
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = e502abe21c7b22120693a08ef3e6
+Tag = 4f5d9c3dbfe3e2fe03a002e55039ebe6
+Plaintext = 6330caaeddf0473d564d175b9408c6f12e6d3cd4ee2c423f
+Ciphertext = e97d1e4d2747851757cf1e9e618d389bfcb356018448b58f
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = a49b34dfad43333fb2ffd701a2d6
+Tag = 6f7bb0749c99d75740f2d193fef36c60
+Plaintext = 45671482c390e65f75de15ca91b93596e9bf3d6fc9178bcb
+Ciphertext = cf2ac06139272475745c1c0f643ccbfc3b6157baa3737c7b
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = 9e4d8aa3dbdc4d4b4b8d72734f52
+Tag = ceec82fc674da9efa6926e8641729ed8
+Plaintext = c8f34bea8bdc403a48d8ed9268429141cd03c29558050ef4
+Ciphertext = 42be9f09716b8210495ae4579dc76f2b1fdda8403261f944
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = 052327ad59cc791259817fd0ed96
+Tag = 2ff19e93f60c8f3a511300fddc38ee59
+Plaintext = d8d1c57b16c23894b66023c29f8648ce4a6074647e1f5f69
+Ciphertext = 529c1198ec75fabeb7e22a076a03b6a498be1eb1147ba8d9
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = 14bc3c44c001ccb261a2a0526523
+Tag = 7fa00fb244eda0d77cf6c05c8fd590af
+Plaintext = 71c14a7031033db15bfe23b75fed9daf8886dd11392a0b78
+Ciphertext = fb8c9e93cbb4ff9b5a7c2a72aa6863c55a58b7c4534efcc8
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = 3477384c396a9e9efb3e169722cb
+Tag = bae19612657c87d3bb73cfb8cee7c8a8
+Plaintext = afa795f836763a1210bb36fef167864f73ba3b6abc593537
+Ciphertext = 25ea411bccc1f83811393f3b04e27825a16451bfd63dc287
+
+Cipher = aes-128-ccm
+Key = 1eee667267ef10b03624cf9c341e3f75
+IV = 0630a3eae27e505c61c56e6560
+AAD = 0c3b9a6924ad506038cb2d6590c9
+Tag = 3d9713d2e916c23ac3039de34c295fc4
+Plaintext = ca4a186f116a179579e3d327aec3f5be358bc7094f853bc3
+Ciphertext = 4007cc8cebddd5bf7861dae25b460bd4e755addc25e1cc73
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = 477937301c83ba02d50760b603e0ea
+Tag = df9a0e986ab2890736423bb3772cec3e
+Plaintext = 553714e17a208a2eceb847a4a2d95088388b1ac8d8ca43e0
+Ciphertext = 1c80213268bad5402c4dc9b5d836ab7499810d0d8a974716
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = c91eb5a07ff19c044023e5cf339203
+Tag = 39f907a92cb01215e3cda84ae13af48b
+Plaintext = c94d0b9e728413c58202cb3f6b82dba7aa9e3ca0a72c40c7
+Ciphertext = 80fa3e4d601e4cab60f7452e116d205b0b942b65f5714431
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = 38c71a8e9b279c605c7f0418a0afc1
+Tag = 3dbd8dbf7485106cdf9ea0e7088a5650
+Plaintext = b4e8c4fd5ad98a1be8b5a11677c57ca1c1694e3528092aa9
+Ciphertext = fd5ff12e4843d5750a402f070d2a875d606359f07a542e5f
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = f2c76ef617fa2bfc8a4d6bcbb15fe8
+Tag = 853fde6f4dca88ff11bbce20ed9e5012
+Plaintext = 578ce26cdb5ba2e8798e23588e5cd04ef782820b80e49a42
+Ciphertext = 1e3bd7bfc9c1fd869b7bad49f4b32bb2568895ced2b99eb4
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = 36004342dd74e7966692a848b2c11e
+Tag = d94e979108fcecbd32f6bdf72f0ccb4d
+Plaintext = 78733c635d4d4e8b0729732f1e174dfcec4e020a7ac3870d
+Ciphertext = 31c409b04fd711e5e5dcfd3e64f8b6004d4415cf289e83fb
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = db92bc3fe5d4141aeb39baea6f114c
+Tag = 229c8f9d4e39fc16cbdb44236ef125c7
+Plaintext = c7aafe7760945e45703c1e19f1032dfd56ddc216c3b03826
+Ciphertext = 8e1dcba4720e012b92c990088becd601f7d7d5d391ed3cd0
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = 34ec2d5b6f0d950509b47a0637d74c
+Tag = 1c9ab7cb0a779c3fa78c9ee12603802b
+Plaintext = 2345e36a63be0b78df95e60907c78da0e48e61e70685a1f3
+Ciphertext = 6af2d6b9712454163d6068187d28765c4584762254d8a505
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = 6ab658d177c2dd87c9b8787cd70182
+Tag = 648c6307ec5ea304045a7cdc93f36b9d
+Plaintext = b0725f735543eb0c0ec88ae69b140f5787d28ef4a2e36d57
+Ciphertext = f9c56aa047d9b462ec3d04f7e1fbf4ab26d89931f0be69a1
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = 483f135c61250fa610b4d14b99ecf0
+Tag = 364ff3b1ad915347b1c7f062b10d3da4
+Plaintext = 315a947bf5291278d446d332ee5ca0def7655d5c957a8fb4
+Ciphertext = 78eda1a8e7b34d1636b35d2394b35b22566f4a99c7278b42
+
+Cipher = aes-128-ccm
+Key = dbbd26f5d9e970e4e384b2273961be5a
+IV = 0b1eabe504ef4822542e397fec
+AAD = bb022aed60819ef84ae83ce27db9d0
+Tag = 7569808dab58d42181543b2e2d05992c
+Plaintext = f78d00755bcb45e6822121fe7cb03c8e627c9f548ccd7e7c
+Ciphertext = be3a35a649511a8860d4afef065fc772c3768891de907a8a
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = a209941fab710fda38d11c68b13d930f
+Tag = 2341ea8c0785569973f90ee9ee645acc
+Plaintext = e59782a9aea45f467b90e51a0fdf166baba05663def2d8b6
+Ciphertext = e357b1ccdaca6f3506dc45279c2e4c59f5307a5fd6a99cd7
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 2e2f6f9755a492ee54df77b2ecab9808
+Tag = 703eb81224cdb1fd2e1cfb2fbfe1e402
+Plaintext = 042a072f6ebf11f79fcb4f5a64f7946dc837d9d2355785ea
+Ciphertext = 02ea344a1ad12184e287ef67f706ce5f96a7f5ee3d0cc18b
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 99e98c9983c85d1f49ae43ebad67a652
+Tag = 64c4aea7f17f18f068897557c93ffaaa
+Plaintext = 5db6bda27910e7b8b61ac476c6532570b71b3932bd6a698c
+Ciphertext = 5b768ec70d7ed7cbcb56644b55a27f42e98b150eb5312ded
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 37a837d73fa15793f6f823fb99c2ea74
+Tag = 6f3b2e70e6e2dc7acc74a823a7f49722
+Plaintext = 8cac261a461c3ddd2642b8e4e5c3389e491fcb2ff8356412
+Ciphertext = 8a6c157f32720dae5b0e18d9763262ac178fe713f06e2073
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 11119a4e779cfb64c736d425e4ff554d
+Tag = 0dc3b57096f0df1d4eb5328c416921bc
+Plaintext = 3429f9b088b501d7944c462694d0799568282e7ce07d3e61
+Ciphertext = 32e9cad5fcdb31a4e900e61b072123a736b80240e8267a00
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 962d7d4305f23d1692747b504960c0a4
+Tag = f62ed804e9f2ac0f7001d0f35ea9f3c1
+Plaintext = a46ae4c71d4c9eb72fabfa76b8074aa02e07653eca10eef5
+Ciphertext = a2aad7a26922aec452e75a4b2bf6109270974902c24baa94
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = bbb1fdfefcf3657ba6cd93ff341a04e1
+Tag = 907dcd7ac1e0bb248d46c3036c39fb02
+Plaintext = 92f5e3083f57c77ac9553a2024a66489698bd2261f05d415
+Ciphertext = 9435d06d4b39f709b4199a1db7573ebb371bfe1a175e9074
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 74be126f7c596642dafa8fe3da904e69
+Tag = 87cbb80fd21127feca7e76fd6947d5b7
+Plaintext = 41ecc3aae5cfebfad7921a47a0684601ffe73816380f8716
+Ciphertext = 472cf0cf91a1db89aadeba7a33991c33a177142a3054c377
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = d72cc521c90a468522af8966c24799f3
+Tag = cdb5d1243b6e73b8e380d8ca041647db
+Plaintext = 8850bdda4bd0271e333db344a47b837183eb48269c3dc0b6
+Ciphertext = 8e908ebf3fbe176d4e711379378ad943dd7b641a946684d7
+
+Cipher = aes-128-ccm
+Key = 10a7720f2e18f739c26924925af6b670
+IV = 8c4e7813ab9bce9dafee01c628
+AAD = 28f427fba8d0bb0380bbe5072ccfa519
+Tag = 4a0ae8604b103f882f17db893ed5c576
+Plaintext = fdd3ca2f193f93f5a349b50357d26748b767cde6ab5cbfe7
+Ciphertext = fb13f94a6d51a386de05153ec4233d7ae9f7e1daa307fb86
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = 5cbba9ea778e01af00afb2a934f28c7211
+Tag = ab30780a2c4f12af8f35350d65284c59
+Plaintext = d91b12e8655dd92b1332fc1d71c391c96a17111562d90ba3
+Ciphertext = d302e5b2d5d90433186b804cd7717e2db2f22cdc34fb2942
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = 1583138aa307401dddc40804ac0f414d33
+Tag = 46577901b7f6feb88b8e2b8562f9cb5f
+Plaintext = eeafb08d4a4819f5682a01d44371e34cc5729079e74e73a6
+Ciphertext = e4b647d7faccc4ed63737d85e5c30ca81d97adb0b16c5147
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = 23931c258c84086500c6a3b6eda457e6b5
+Tag = 8735a59390ba7a892741694f3a89b0bf
+Plaintext = b8737d5bbfc976c2d8d9786148dea664dd83cee98df537b5
+Ciphertext = b26a8a010f4dabdad3800430ee6c49800566f320dbd71554
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = e12f98507d6514c3b551d240595346bc9e
+Tag = f4f81ed18cc1820375a7bec2318cde1e
+Plaintext = eb021b63c61c0b194bd44870608d7ef0b932b6104412d7a9
+Ciphertext = e11bec397698d601408d3421c63f911461d78bd91230f548
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = e14b87d49d231c0199eec627fd7f1b5332
+Tag = 187b430caa60d98dc3e2aeefe6249b44
+Plaintext = 93b42584c4956078359d77e80aef52281b9228a1f66aa36b
+Ciphertext = 99add2de7411bd603ec40bb9ac5dbdccc3771568a048818a
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = ca095aec96a8b093e62b10f0950ce35ce7
+Tag = 0a77372b727408e1bf5a70790b9eba3a
+Plaintext = 6a788d8238c7b313b8eba27b210a71c36819d719115b9b76
+Ciphertext = 60617ad888436e0bb3b2de2a87b89e27b0fcead04779b997
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = d1cac02b34ad33c0e77a5bda2c3baf5e5d
+Tag = dc1f5cb4d4fa2204e82eedcb3784443d
+Plaintext = 3bc1ee54d0094603dfc68eee118e547d031fb36e464e776d
+Ciphertext = 31d8190e608d9b1bd49ff2bfb73cbb99dbfa8ea7106c558c
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = 065c06b49a49898e20bb679e35edbb1f76
+Tag = 2413f9496592a75a1d6e42ee3a258607
+Plaintext = 8a12adb8b746216baa8a418725e608e4377f13816a036a10
+Ciphertext = 800b5ae207c2fc73a1d33dd68354e700ef9a2e483c2148f1
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = 98a42d7a0c5917deaf3b4de3f0cbe0a191
+Tag = b571a3150887df1ac5f813676b2eb24f
+Plaintext = 30a226c07401d0ae24c73d682e3a6e7e377ec1613bafba17
+Ciphertext = 3abbd19ac4850db62f9e41398888819aef9bfca86d8d98f6
+
+Cipher = aes-128-ccm
+Key = 6bffab1f4f4c1ff66b4a669b515b2f8d
+IV = ddb34d5e0140fb96d690e1a2b7
+AAD = e245a7528931841b52a5f59d861d98d7b7
+Tag = 31aa5e4657c92e31c69ab18d447d3578
+Plaintext = 3d17bcdf30445ebd8a9b6aa2fe11d443c1161bb1ee69ced0
+Ciphertext = 370e4b8580c083a581c216f358a33ba719f32678b84bec31
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = e04006b68c83a5dd4ceac3cde238e48895ae
+Tag = 0d6d676d11fce907b5c93fa1ed7bff2b
+Plaintext = 6a493c5ef3769ccc4101dbb2eb36e1e5bbc577a057ce0731
+Ciphertext = c7584c0203c2535c5702c6ae93b7cbfb066f4a055c627a18
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 5da64e368f45153ea5b7ddca966b6c5b699a
+Tag = 2cd45f211b1a1364c91ad07959bf0ee5
+Plaintext = 15e0c672c6764f3699d9d3e7120f8ce5daab166f08fdd074
+Ciphertext = b8f1b62e36c280a68fdacefb6a8ea6fb67012bca0351ad5d
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 1b315d024bb5d1e03d7510e61f37d8adb10a
+Tag = 18f021a98b2edfb0b7500363099c2a1a
+Plaintext = de907d58cd8f5a72acaa1d329b937dfbbfed65a4e45eb029
+Ciphertext = 73810d043d3b95e2baa9002ee31257e502475801eff2cd00
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 8691ba4f9232ca86f919fe72ddb39c91d707
+Tag = 2ac9aeb018c48f3902276ac759710b6d
+Plaintext = c7fa314d27be79f9d3e2d1e188c1785b0c970f91b8ed4290
+Ciphertext = 6aeb4111d70ab669c5e1ccfdf0405245b13d3234b3413fb9
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = ff0baf1cbb5884a9290ea7b5ee49915efb4b
+Tag = 7dac49f606dadb9f7034e0a1860d519b
+Plaintext = 33b05b20f3c849fac091a5028cbfa0bc9a1c32514136fee3
+Ciphertext = 9ea12b7c037c866ad692b81ef43e8aa227b60ff44a9a83ca
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 2d118cda20700bc2748ea1753fbca6f74933
+Tag = 623ccbab19c1442806e21c5a820945da
+Plaintext = f43832e420e2eccd5d80502bea2ba1804e17d4433318fc86
+Ciphertext = 592942b8d056235d4b834d3792aa8b9ef3bde9e638b481af
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 0c7a5fd2010c999a8a0efa81f89ff5bfefe0
+Tag = dbcd18947ac1800856c9c92eb0388c70
+Plaintext = ceb203c842a962183f22e602644fc66e4290b3d5be445fb4
+Ciphertext = 63a37394b21dad882921fb1e1cceec70ff3a8e70b5e8229d
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 73fdddb9e0a64f5671fd70c4ea8443507789
+Tag = 39c29ea73b0c5aa130d8b14f7b9926a9
+Plaintext = d6015b6bd5f5eabb2a649129f8f727c06a3ad59499f21caf
+Ciphertext = 7b102b372541252b3c678c3580760dded790e831925e6186
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 82c4484e3a6e18b6bbfd78b69b00c40b30c5
+Tag = f0a0f148ae138c2ea02538c8fd7ac76c
+Plaintext = c288b810fb533441bd549d02c0b28d5b834293683eaacda2
+Ciphertext = 6f99c84c0be7fbd1ab57801eb833a7453ee8aecd3506b08b
+
+Cipher = aes-128-ccm
+Key = ae6136df9ab43631ef143515dacedbe7
+IV = c5c445792208a50c8e93d64aa3
+AAD = 267d8385b14721eded743cffd69e4d595f7e
+Tag = 85eb537e7583f04e040a0ddc41106213
+Plaintext = 667cc47d13c34923be2441300066a6c150b24d66c947ca7b
+Ciphertext = cb6db421e37786b3a8275c2c78e78cdfed1870c3c2ebb752
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = 4a3634e5028df97fbe00eb016e8ea4f1918faa
+Tag = 52570e769629dcc2e568737ba53a1195
+Plaintext = eede01b08f9a303cdf14c99d7a45732972c6eff2a1db06eb
+Ciphertext = 90c850790b0b380f5aeb2488fdf43c9d5ef1759861e86f6e
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = 041b93e3fc059fa44aa755e88df277b9b6e499
+Tag = f1d82ec19a2e3ec43bbdb34e10999d90
+Plaintext = e61ca7310172eec16745a73e34516f65844eecd0dbc5566a
+Ciphertext = 980af6f885e3e6f2e2ba4a2bb3e020d1a87976ba1bf63fef
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = d1be393376cb5d23cf8139da0fd92f3d520ae9
+Tag = f2abb0ce4de9eeb5e8af9cdf3391d3cc
+Plaintext = ea887edee68ad5fa6bae928aa480dda898037f820700ec52
+Ciphertext = 949e2f17621bddc9ee517f9f2331921cb434e5e8c73385d7
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = f3e551b34d2db1286a9f41085e4dda95ec3f75
+Tag = 239c73b01ba49a8498b5ff4833851069
+Plaintext = 71fe1ba5d299495d2a56039c64032ec6263d437f55e3f5be
+Ciphertext = 0fe84a6c5608416eafa9ee89e3b261720a0ad91595d09c3b
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = a69ddc66e63a3415f21009d53adcf26bc1a9a5
+Tag = 2248dacd3903c26a2dc5ae649566ad67
+Plaintext = bd04d854216740a6ceb9827cbddd83761d19feb2a21d78ef
+Ciphertext = c312899da5f648954b466f693a6cccc2312e64d8622e116a
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = 5735d6f5882d8f27155eb4cc285a65138ad64a
+Tag = d4156cf7d97b2e744351b6960a807cf8
+Plaintext = 33b44873a7a1e5b0fdbb7e7347623e4fa1ccd937feb26fda
+Ciphertext = 4da219ba2330ed8378449366c0d371fb8dfb435d3e81065f
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = 5d94ed976ab2063512690ae704c3b115519742
+Tag = 5a50086b6711ac72533c3c5717f6892c
+Plaintext = d3909d577a4e89642227cc6fc146b61bc18392175e342898
+Ciphertext = ad86cc9efedf8157a7d8217a46f7f9afedb4087d9e07411d
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = db20b384620ab8691aed2fed14a745188d94c0
+Tag = 54fb74ecb9a5163b01b9dbf97ff2f999
+Plaintext = ba0716355fffb8ef947d2a15eb58375a1ff1084c56699029
+Ciphertext = c41147fcdb6eb0dc1182c7006ce978ee33c69226965af9ac
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = 94897cdd04e0c8480b2ef7b5201dda37558ba9
+Tag = d2a81702f665ff5c54f586defd268c94
+Plaintext = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9cc
+Ciphertext = 215d1e5e323b409e36cc81509d1d78cbf27d452d494cb049
+
+Cipher = aes-128-ccm
+Key = f1908328edf2996ebfc9655472ca5ad0
+IV = 4c693364546930b6c5250e2699
+AAD = 95c44e1e5ad256b3ce1cc1d87137a1e09f1fd4
+Tag = fa641889723e163825ab65727e8a5343
+Plaintext = 598e91d39c414496fd5e69f2cf80826b4e7d59ba28e0a0d8
+Ciphertext = 2798c01a18d04ca578a184e74831cddf624ac3d0e8d3c95d
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 09db3efac9473f713da630ae92c2c8604c61c51e
+Tag = d89756e5d78753ef22c012ae34b39a20
+Plaintext = 6ad541695a37c32d73ff6d5f870abd5b0f362a8968c4fce0
+Ciphertext = e65fcc975865c1499b088b58ba163283085d8ca68dc3b235
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = b6d07035aed9c141c713cc3bce60f7ba8ac2545f
+Tag = fc78ebae9c143a7283b0641e1f83f5a0
+Plaintext = 9cce4c82fe9d38ef64ac8abdf0619f201a25ce6903675627
+Ciphertext = 1044c17cfccf3a8b8c5b6cbacd7d10f81d4e6846e66018f2
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 80a5ab693378af29cd5a33555cb3579f9ae540aa
+Tag = 5a7e44348d2b3085348f787128a4e96a
+Plaintext = 7295a7aed3e987baef19ad68c33ba5a5dcbff27875ff5236
+Ciphertext = fe1f2a50d1bb85de07ee4b6ffe272a7ddbd4545790f81ce3
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 220817144a15a0a654fc1beaabce60270aa72df8
+Tag = 24dfc096cd8a09d2d81f6146fb54082a
+Plaintext = eb21fe20fc4f92452b261eac0d7b70016f7469afdff7a3f5
+Ciphertext = 67ab73defe1d9021c3d1f8ab3067ffd9681fcf803af0ed20
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 5a2423c2ff2d642c80ac1ca27dd779321f3e9c01
+Tag = 5da82204f4dd8f535cb2fec2f133d882
+Plaintext = 23bf80f51dfd83f63986910e69d54a315c2bfb43f432b7de
+Ciphertext = af350d0b1faf8192d171770954c9c5e95b405d6c1135f90b
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = f2c76ef617fa2bfc8a4d6bcbb15fe88436fdc216
+Tag = 108630135498ba409f4b6c8caee8a85b
+Plaintext = fc3a50cc8a68778327923ea697f5388da4c814381e29c5e4
+Ciphertext = 70b0dd32883a75e7cf65d8a1aae9b755a3a3b217fb2e8b31
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = b40c8c1d2cee490653105ca2443356cdb63e4fd0
+Tag = f89c515837d129ba41f9c24b0229ddcf
+Plaintext = 465e41c69928d08c33e063ea119595a04d0de6bffd17bba5
+Ciphertext = cad4cc389b7ad2e8db1785ed2c891a784a6640901810f570
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 6ebfa1e8f80b3cdb1bedf2e3c7e74f30f55c38e1
+Tag = a352fa6b9c4e40733ddcd3fcdaf9ae63
+Plaintext = 3f98ee3922f8f1086e3135ae66c5465426b13c8794954880
+Ciphertext = b31263c720aaf36c86c6d3a95bd9c98c21da9aa871920655
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 6d0159861031c1a5f01aab35927fe2ab28154d19
+Tag = 2c1aa13f062c0f1f5008e27ff2191942
+Plaintext = 5b43067a5ab3a9f9e633fdc084c44ffa7f11edd12ea5873d
+Ciphertext = d7c98b8458e1ab9d0ec41bc7b9d8c022787a4bfecba2c9e8
+
+Cipher = aes-128-ccm
+Key = 61cb8eb792e95d099a1455fb789d8d16
+IV = 1f37b3e59137f2a60dc09d16ac
+AAD = 15e5ade017b30ab41878a2747e93aa91c61c2908
+Tag = e149dd02bc7face0c4dfe4e501c2ac2a
+Plaintext = e40b7e9e46e339e64891526e730b3bf6562fa37acefce307
+Ciphertext = 6881f36044b13b82a066b4694e17b42e514405552bfbadd2
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 161d92c7df1ebb0924719e066e08b95eb4914a5eda
+Tag = 62d2b338a7b34ebd9d85c244c952d681
+Plaintext = a9eec383f63892521e4616fcbadc5485942ffaf4669c43a7
+Ciphertext = 949be340720c4fdc4adc05cb777dd81a2549628d33fba07e
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 6b1d94bc0c6e45fc905c509ea667853e4b2c5a8848
+Tag = 8a4defafeb3d61dad8c007b68d8fb9b3
+Plaintext = 7b44a093162bfc8b4d65f1031d890a6b08a3705b142c0c26
+Ciphertext = 46318050921f210519ffe234d02886f4b9c5e822414befff
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 868dd3e241f60f097a7a2fe571307ee5eb961218ca
+Tag = 57cbab553b511d68a4f41db211d0a2fc
+Plaintext = 28c4d6de3e2ce51b849b135d9cfd3084f0e3155447cad9d5
+Ciphertext = 15b1f61dba183895d001006a515cbc1b41858d2d12ad3a0c
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 3776f37fbf8803bdfd246ffaff2e59658a6c3f0ebb
+Tag = 0290fd7dbf0afa3e597274e3c9fe170b
+Plaintext = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+Ciphertext = 2ba665a3ee05875c14f0a8fc8e6c0034582e8802f3b699ab
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = d0f2769eba9b8e618f00eed6b34c261c59322a253b
+Tag = 9c7dec3960e6aba3174d793b4e08f449
+Plaintext = fcbbcdd9599a86e7c8ccb9347065789a9728ca1220fa51ca
+Ciphertext = c1ceed1addae5b699c56aa03bdc4f405264e526b759db213
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 2be180892faed0bb75887668d187807666d3c66c68
+Tag = 7057b9e2d844e86ee5c3ecfb3270804e
+Plaintext = 8d145b1f792cc31a2e5b86216609bb018e7aea3012ff70a5
+Ciphertext = b0617bdcfd181e947ac19516aba8379e3f1c72494798937c
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 52859849a5b7c1d432c3bfb35271cd8141db2ec774
+Tag = 1150fa899152eef7a30ae0f20986818e
+Plaintext = 741db990b43ef34993c33d1c4953b67b128b9299dfe86d74
+Ciphertext = 49689953300a2ec7c7592e2b84f23ae4a3ed0ae08a8f8ead
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = aa192759625f4e42d1d1fa73dc0f62199142155615
+Tag = ba7ff9203608089558698ec29472dda7
+Plaintext = 51dca5c0f8e5d49596f32d3eb87437bcae866640310ce1e3
+Ciphertext = 6ca985037cd1091bc2693e0975d5bb231fe0fe39646b023a
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = 6de564226884188ec7bea3894535a875cff2a42fdb
+Tag = 85bd0a5074ef852575baf5f12c22663e
+Plaintext = dfaa7aa8b28626210d5c24e2ddfe516189be05aabe26f3b2
+Ciphertext = e2df5a6b36b2fbaf59c637d5105fddfe38d89dd3eb41106b
+
+Cipher = aes-128-ccm
+Key = be1ed49e2cb0caf6b6a0940c58453b93
+IV = b78ad129457681fa7346435b97
+AAD = f245f2ee23755df863dee55d7ef0c3c09a0b6f0b0c
+Tag = 9eb617436bae012331daf020fce24e47
+Plaintext = eedf00aab5edefdd6549d37ed44358e11c588c24f141dc57
+Ciphertext = d3aa206931d9325331d3c04919e2d47ead3e145da4263f8e
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 1ab5cc3d7b01dc74e6cf838bb565fea3187d33d552a2
+Tag = 7ef14622a9b621d1721b944c60f7fd67
+Plaintext = 8d164f598ea141082b1069776fccd87baf6a2563cbdbc9d1
+Ciphertext = 0d30ab07153b5153637969e6bd3539448c541e42b3d432fd
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 1f1ac4674b272bc7a4ee9f4eae33e969b16fa90a69ba
+Tag = dfa4ec2c92671c64ee07946527be67f0
+Plaintext = 14e99a2ef0de650adbd785c692342cdb765e6d20d5fca09a
+Ciphertext = 94cf7e706b44755193be855740cdcde455605601adf35bb6
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 43ee77f12ea42e82a02275a68aa95cbd1bb440442bcf
+Tag = 173572fbf3d9495760aae4347397b110
+Plaintext = 383242c709fe5f2ce782bf8c83b645d171f2bd238abc655d
+Ciphertext = b814a69992644f77afebbf1d514fa4ee52cc8602f2b39e71
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = ae2ff288199be25bf640811541394ad7e1dd0dc0d24d
+Tag = 4d2327956e030b9df753e063b5b71201
+Plaintext = 9c16a5b638c35c97c5c981c1b8dbcba11aec30e72e45a936
+Ciphertext = 1c3041e8a3594ccc8da081506a222a9e39d20bc6564a521a
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 4ccfb4281852b5ca7e787723d689384a68ff9437db31
+Tag = e4dac0c9130f5641afd035dd884b6271
+Plaintext = ec9d8edff25645520801b6e8d14a2fc3b193db70d5e5e878
+Ciphertext = 6cbb6a8169cc55094068b67903b3cefc92ade051adea1354
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = d3a2fffc798fd9cc2f409471faf18caa2ff3dcf4e652
+Tag = 48807dd50a9cf41651083c49c7493ceb
+Plaintext = 0db33eda4188a9165147e24e40f79fee1985eb68d5162728
+Ciphertext = 8d95da84da12b94d192ee2df920e7ed13abbd049ad19dc04
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 7b5121aa4d1e314f209ffe3e92cd26ee4f74d91e27f2
+Tag = 8ea0da53046733f522ded40a09c6d7a6
+Plaintext = e0d3ea4308376423c4322503f56e427a64e2e6d8b4f5e668
+Ciphertext = 60f50e1d93ad74788c5b25922797a34547dcddf9ccfa1d44
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 6e12c112720ef346bbbe7d1c19483721b1c52c438dad
+Tag = 345cb5a968f39654b994686699d532c2
+Plaintext = 491f2bca585d6b5fdf38d18890e4d1bc923fe26930b3d2f1
+Ciphertext = c939cf94c3c77b049751d119421d3083b101d94848bc29dd
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 20433402a2d869c95ac4a070c7a3da838c928a385f89
+Tag = cce85eb55339b886b7121b306fccc0b2
+Plaintext = f45908d691ddaf89c0bc129ffada94c3ceda5f47d63ef76a
+Ciphertext = 747fec880a47bfd288d5120e282375fcede46466ae310c46
+
+Cipher = aes-128-ccm
+Key = 34ab6fd7f54a2e0276fcb7cf1e203aba
+IV = 6091afb62c1a8eed4da5624dd7
+AAD = 42f944c21cc221beaacb288115ac628346b8a1d94bd5
+Tag = a37ca5ce12aa6f0659467642deb8bfcd
+Plaintext = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b
+Ciphertext = 63261824c00c9038caaa5a64603b09dd40bc4e3a210ef667
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 105258d2f25f62675aee975cfdb668aff833f05b61eb2a
+Tag = c7fa9ee2e7cdc1b755258f2212a8a8f4
+Plaintext = 49db80f22bc267a70e5636dfbc8a21c83d9691fe4b9c3051
+Ciphertext = d2fcc8b7809b5fc07e44083e437d8180157f1782a9ce9f65
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 0f5938540651fa4ca03867e67518eb2b73f60dd8750fa0
+Tag = bfdb9bfcd3b969fb2e41221eb92b0147
+Plaintext = 26618e21099a79d6c517335389551323065ad89c8848ea12
+Ciphertext = bd46c664a2c341b1b5050db276a2b36b2eb35ee06a1a4526
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = d6b228960fcbcf07c7bede616139db62b3808718a5b511
+Tag = f8beea22cba93203c912209c78c03aa1
+Plaintext = 4de1d6d57144896ddea1c30f49afecd27bdf4840ed9928b5
+Ciphertext = d6c69e90da1db10aaeb3fdeeb6584c9a5336ce3c0fcb8781
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 75f8f071e229355e286882917ce5dd4f1db591fee51b6c
+Tag = 69a2e3ea4a40f7c491912c1a0778ebde
+Plaintext = 785359b1dc754a1e1b6d8731bd2d917ce3e91507401310e8
+Ciphertext = e37411f4772c72796b7fb9d042da3134cb00937ba241bfdc
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 4afb62aa8648ac7474dd16fcc376f8909c69e1ce36e6d1
+Tag = a75c7ba2a769c27903e99b72639b0841
+Plaintext = ab627aac1496d011ed2edcb2fc6b2afbcc394654f56124f6
+Ciphertext = 304532e9bfcfe8769d3ce253039c8ab3e4d0c02817338bc2
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 736fdf94db820a2efe89e7fc9dcfe7c23d5754ac2bcc7c
+Tag = f84f4ca4a69fde75d7207e50494819b6
+Plaintext = 40722cffb37f1455c2618408e777ed0f4b1bd039952730cc
+Ciphertext = db5564ba18262c32b273bae918804d4763f2564577759ff8
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 8a9a0367137c28db4c4e78d9cd9a68cde0d1b4583532ae
+Tag = a0c34a24d3ee0946034c71fba4dbb333
+Plaintext = dcaabf7a061502618541c09ea59dbbbd52b2692fd0064747
+Ciphertext = 478df73fad4c3a06f553fe7f5a6a1bf57a5bef533254e873
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 34dbbff560ef04ea731b8979aef2ae50972f4db3efe14a
+Tag = 0f5e24a435a39a716c39f43dabdc4281
+Plaintext = dd641a893b16e0e173ea2eda20638bb01849ac11e64e8ddb
+Ciphertext = 464352cc904fd88603f8103bdf942bf830a02a6d041c22ef
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = f3d1fcd912252431db9d8ccfc3e203d5b34d537468b4c6
+Tag = f623d59f66764d859a772bb50ec91fc3
+Plaintext = 9aa3e8ad92777dfeb121a646ce2e918d1e12b30754bc0947
+Ciphertext = 0184a0e8392e4599c13398a731d931c536fb357bb6eea673
+
+Cipher = aes-128-ccm
+Key = ea96f90fbae12a857f5c97e0cba57943
+IV = 21cc46d9ced1539b0ad946e600
+AAD = 513b4cdc551c203ed5f1e659813584862023911590b672
+Tag = 3b6549eb16fba96318afb3df51f4675f
+Plaintext = c8f44ae4b02fffdbce0df773c24075f877945fc7a86be460
+Ciphertext = 53d302a11b76c7bcbe1fc9923db7d5b05f7dd9bb4a394b54
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = d3c0ed74e5f25e4c1e479e1a51182bb018698ec267269149
+Tag = eee82c19ecba34280604b58d92dacd3f
+Plaintext = 7dd7396db6613eb80909a3b8c0029b624912aabedda0659b
+Ciphertext = 5b00cf8a66baa7fe22502ed6f4861af71fa64b550d643f95
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = 62f4fe53e99a9b0c51e9561d910d7e2ffe19a5176c9dec06
+Tag = ab4999e9689d52b8afeb87923efa3b48
+Plaintext = 897f0dfd90213f64a9277a0eda4f134f303fa89f56ca54fb
+Ciphertext = afa8fb1a40faa622827ef760eecb92da668b4974860e0ef5
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = 191c4dfa653c20292657f7694c6b6a4a410c49a879abd217
+Tag = cdc71e556c34fd4e1b5ebc50d38da8b3
+Plaintext = 2b7cf9e6e2d6abcd7775f8a6eb6294e822041c4c45f09c3c
+Ciphertext = 0dab0f01320d328b5c2c75c8dfe6157d74b0fda79534c632
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = ba34741f8edb51470eb20f891869aabeab562d92571ac943
+Tag = 46223d381090661c2ee2370d29a572a9
+Plaintext = dccb9a4625512496b372a2b8b768f75741d8c2e30e57d638
+Ciphertext = fa1c6ca1f58abdd0982b2fd683ec76c2176c2308de938c36
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = 8b922aca6125722ec490b134a45864397f4e2c281d6e2089
+Tag = f78af50466646b7c7e652f787afe5357
+Plaintext = e0e452c990665465160b02cad6367ca89723613488d8efbf
+Ciphertext = c633a42e40bdcd233d528fa4e2b2fd3dc19780df581cb5b1
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = afb9fd78e3f8eaf4e8c91da62b2da534508e54f7dfa214fc
+Tag = cc9d9a1270f78648a6b66cb8c0f2471b
+Plaintext = b536fdb8839f87080ae65ec35da347e792622ffe18a61d46
+Ciphertext = 93e10b5f53441e4e21bfd3ad6927c672c4d6ce15c8624748
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = ecf942ccee7396cb3ee177eadd4d96a4af1d90afdce97376
+Tag = b17d3d6f1fc4f530841b749d9f3a0a7a
+Plaintext = c81233826e5125e1f31fe275184ccba8f1a743e58e146e4d
+Ciphertext = eec5c565be8abca7d8466f1b2cc84a3da713a20e5ed03443
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = 16fea92ffcaad563792aa924bffe7ef690edc90ea4e29cc0
+Tag = 5852ed48cf88d9ab2326aa46b6541b60
+Plaintext = 24ab253b5b06552665c3c810254c0ed15e68a783180d7eee
+Ciphertext = 027cd3dc8bddcc604e9a457e11c88f4408dc4668c8c924e0
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = 76f110eecd369d79e21fb208058359d3a2f37581d1f7f691
+Tag = c62dff6bcade5ac2edb8ec9797ce433e
+Plaintext = 7f596bc7a815d103ed9f6dc428b60e72aeadcb9382ccde4a
+Ciphertext = 598e9d2078ce4845c6c6e0aa1c328fe7f8192a7852088444
+
+Cipher = aes-128-ccm
+Key = 35b403a15212097085d6e2b77ec3d4f2
+IV = daa423bf9256c3fcc347a293aa
+AAD = 8834c776a3237f060ae0ab9857324a3b2ac79f3b6e6f90f5
+Tag = b936ac4764575f85352c24ab23209d42
+Plaintext = 11cbfb3d348c7abef99f562607e289de34a2bb379a5dfe50
+Ciphertext = 371c0ddae457e3f8d2c6db483366084b62165adc4a99a45e
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 0c0b4a45df5c3919c1e1669c5af5d398d9545e44307d95c481
+Tag = a1138cff7b624f9908b5b4d7e90a824a
+Plaintext = 0b3d947de8632dc8ff752f619ba7c84716fac7a23e101641
+Ciphertext = 7db9f3f7dc26fc2adf58d4525d26d5601e977de5a7c33911
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = aa27a28a36b5a2cee57ffeca0233feb4bdd4eacb2cae28e98f
+Tag = e23f92b598f7a248a894e6b8f5691bee
+Plaintext = e6dedce2c278c44e5678d13e7d5b5d3501d61bb0bb6b5558
+Ciphertext = 905abb68f63d15ac76552a0dbbda401209bba1f722b87a08
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 66220aa9b40a1772caba7749a544bff938e804dbc6e556498f
+Tag = e94043c0d80fd651469232fe9d47a81f
+Plaintext = a276b0922fbd5094bf89b9329d07341e039d6204397b81c0
+Ciphertext = d4f2d7181bf881769fa442015b8629390bf0d843a0a8ae90
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 3d765d20e03a4cebfda50316c4b7d8b6c55078d5b3e9cbc567
+Tag = 25088b522fc0731097e729448236b317
+Plaintext = b99afbc2dbb377350cc58d4bfe8e954cef25d7b27b82fad4
+Ciphertext = cf1e9c48eff6a6d72ce87678380f886be7486df5e251d584
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = e91b6265879153e1692b00a112b4205111c8eb1a7b7f2c6898
+Tag = 2208cf07574cc4f3f83ed6301b904404
+Plaintext = 56114cc783b80ca2dd2881387b6d92a59a237dfc8e976d8b
+Ciphertext = 20952b4db7fddd40fd057a0bbdec8f82924ec7bb174442db
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 340b16f352817babb4fb70e9e6e18784b3e67bdd449872158c
+Tag = 14b0a900068e55cd24c92bbb78c521ad
+Plaintext = eb21fe20fc4f92452b261eac0d7b70016f7469afdff7a3f5
+Ciphertext = 9da599aac80a43a70b0be59fcbfa6d266719d3e846248ca5
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 5a2423c2ff2d642c80ac1ca27dd779321f3e9c01445be684dc
+Tag = 3f8ba66d74321c80c057f010078d2f28
+Plaintext = b15083a73607c9d7e197a8cc884ad3be98ac343f6493df67
+Ciphertext = c7d4e42d02421835c1ba53ff4ecbce9990c18e78fd40f037
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 5fe8bb27a59a5f4e370adbba96484c2365fc0d8c6e58d7d3e6
+Tag = 0a189319e4f06d53c1405d37b06cc8eb
+Plaintext = 07542d18e8f2d3e199fca0f90cabb78b169525fdce81666a
+Ciphertext = 71d04a92dcb70203b9d15bcaca2aaaac1ef89fba5752493a
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = 23e5422e8d7560a9e65642b5e723a47536c16791f3a0cf918d
+Tag = dd72f48ae03670249d74f8460b63b1ae
+Plaintext = cd574ed56bdfd1408f7831e0b24b4345ee979ac906a7aa22
+Ciphertext = bbd3295f5f9a00a2af55cad374ca5e62e6fa208e9f748572
+
+Cipher = aes-128-ccm
+Key = 7a459aadb48f1a528edae71fcf698b84
+IV = fa4616b715ea898772b0e89dd4
+AAD = fcc9422ba5023a9997baa9c4ee6cb196ffe96e08eb9c2b8a75
+Tag = 1717c00c93d36a77141b723d573c8c65
+Plaintext = 8c9abe94beed4c9bd46adb1d04fbfe7016dd50d324525abb
+Ciphertext = fa1ed91e8aa89d79f447202ec27ae3571eb0ea94bd8175eb
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 5fb96b045f494808c02014f06074bd45b8a8ad12b4cb448ec162
+Tag = b4a6843ec16078038c10afedc41f5362
+Plaintext = e92cd0cb97afe4fb00c4f12e9b9abe1d08db98f49a27f461
+Ciphertext = 82b666694232e86e82295beae66ae67d56aceb5d6b1484ce
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 87db0d9d69bc0cf69cabeb92570e482bbc8ff3e1ba72f12f3225
+Tag = a7c6566d0b8ff97f946d7c7773a845f2
+Plaintext = a6dbad96ad23ff61479df39b99f0673a09f2a7eaebbd34b9
+Ciphertext = cd411b3478bef3f4c570595fe4003f5a5785d4431a8e4416
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = a061a09024f1e03b223695d4703ee202e90e07156b95859a22e3
+Tag = e1d66a4728b67b42602e23c8500b0115
+Plaintext = b1dd81cc3b2b0efe540a3194d6fe304cd2de53db7929ebe1
+Ciphertext = da47376eeeb6026bd6e79b50ab0e682c8ca92072881a9b4e
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 0dd513c5d8d62b723ab8b0a3aaa477e843d9149dc8a2f878e585
+Tag = 03c51e8c59ed13b3e5d9b489d4ea2ccf
+Plaintext = fb30c2e98f3d7e4ed7431da285711d3d287884db13a474e7
+Ciphertext = 90aa744b5aa072db55aeb766f881455d760ff772e2970448
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 3ff59c40bd796048e586eccc23a82e4d09fc5e779f38eb4afbed
+Tag = f1ec270b43fc5a9811b56ccf033789c6
+Plaintext = 886f9f91a6566ceb99c39462ab675a3ae3be98f68787626f
+Ciphertext = e3f5293373cb607e1b2e3ea6d697025abdc9eb5f76b412c0
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 0df7ef91f7124da867e992bcbc6fb38232ff6d5205f38768da72
+Tag = bb4ed25940d58cba64271fe1d2e8013d
+Plaintext = ed370d1c2d6dc03e4fae4deb9343a7d4339562cffd427587
+Ciphertext = 86adbbbef8f0ccabcd43e72feeb3ffb46de211660c710528
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 6777de159c34d005b94f67c33ae4a35ebab09d9cb9c56b4c9c81
+Tag = 392636a5e373c1354ea9b969abb4932a
+Plaintext = 2f77c2eb07db14bd713c5af10c0760ea3a6ca5ff8d046d36
+Ciphertext = 44ed7449d2461828f3d1f03571f7388a641bd6567c371d99
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 75559898f4ba03c55afc25ea91aa61a93c2f8270a5fa51b6f6dc
+Tag = 59a7e8bc0570f19159f91fc14ac6532a
+Plaintext = 360fb89429dc9b48358097d930c8561b2bd18dc0a470d1d6
+Ciphertext = 5d950e36fc4197ddb76d3d1d4d380e7b75a6fe695543a179
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 5e03fc430473c5de96d68907fa506f9da353ae48a965445e1f24
+Tag = 07e559568c27a30b5676f98cc66f57d6
+Plaintext = f2d8d67b9f291c3edc264893922622b2693f3e7231137eba
+Ciphertext = 994260d94ab410ab5ecbe257efd67ad237484ddbc0200e15
+
+Cipher = aes-128-ccm
+Key = ca748225057f735f712ecc64791367f0
+IV = 1341a6998eb1f50d4b710a13ac
+AAD = 7eee4869e77f6db12c91d1f647cad2340d33a3defaeb362d311d
+Tag = 4910615920f6f3c3421a9c2bec1bec7e
+Plaintext = 7fd6fb81c36e44b150af10e04683b1ec9b5dda87c71ff939
+Ciphertext = 144c4d2316f34824d242ba243b73e98cc52aa92e362c8996
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = c76846da496ed87b9c0f65c6266c9a822224acde9775efb186a4a5
+Tag = 25d05e5a2e76a90f6fe489fd74cab2a3
+Plaintext = d7aa4efa5d75195a400018bd38f7d8cd53fdffe88df1837f
+Ciphertext = 150d9a8b78d9c04239d66207a1f95021bbb1b7c70d7c3548
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = 4efbd225553b541c3f53cabe8a1ac03845b0e846c8616b3ea2cc7d
+Tag = be6af49ce97d5e0e77c7fd5d9cc6d932
+Plaintext = 5f94a2e48d348a1d56c55a659306e319c3d2ad78b9fe43a7
+Ciphertext = 9d337695a89853052f1320df0a086bf52b9ee5573973f590
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = 7631cf7822a545daefa16a5ec43c877d475a82d5aa2d51cec7fbb4
+Tag = 924b268cab915f999aea3e1cc3a88ccd
+Plaintext = a44b010fc1c659eac9241a58b11a73d7ce33156ddfc54c3c
+Ciphertext = 66ecd57ee46a80f2b0f260e22814fb3b267f5d425f48fa0b
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = e4da34663edc44370bfd8aa8315945471a893a1cc069628a071ee0
+Tag = c368f5af8e311e67209e02dfa2613377
+Plaintext = 28d157f5741f1be057d5219711414c0638b47d165a905a6a
+Ciphertext = ea76838451b3c2f82e035b2d884fc4ead0f83539da1dec5d
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = 077509eae1dc367540f87832c5780f6c5b29e180bc6c1fee38e826
+Tag = ad175fcad35d29396380b79a28784cff
+Plaintext = ba7432a8e34bfaa91b35c8dfd822d86850be39e63150257f
+Ciphertext = 78d3e6d9c6e723b162e3b265412c5084b8f271c9b1dd9348
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = a513d750ca1e8bf6cb7b8cea5204e064c15c2dc40d742b31cf5459
+Tag = 93b4b3e33d325359c9c651290ce73bed
+Plaintext = 3f5830b0ce8849a660af7d58a60c19a9824a3033bb5fed43
+Ciphertext = fdffe4c1eb2490be197907e23f0291456a06781c3bd25b74
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = e439db829c1291df49fc42c2fa1a92118c2665f11e13f28dc6f11a
+Tag = 71f88ca5857c6d801e726a01c621a0c3
+Plaintext = e69b2a243340df5dc70b2cb05be12e5992ee36f7d9f4ca84
+Ciphertext = 243cfe5516ec0645bedd560ac2efa6b57aa27ed859797cb3
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = a12c690568114fd7a677f49d74e84fc1a6b7f7d2a08693266c0a91
+Tag = 0592d360fc6a46aa18c4ce5d74fa4532
+Plaintext = 9de35b840a69a84701ffae1b1d2bf13c34b42a57d14c524d
+Ciphertext = 5f448ff52fc5715f7829d4a1842579d0dcf8627851c1e47a
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = 1813bf176a1127f4d508d7663ae750f9c4bcb84a6e26811ac60d46
+Tag = 8b772cef893495cf0a94e8ebf06e920b
+Plaintext = 9e2fa20bf76768a5a1467d90a048bb503a2c33bbbaa71653
+Ciphertext = 5c88767ad2cbb1bdd890072a394633bcd2607b943a2aa064
+
+Cipher = aes-128-ccm
+Key = fdf2b2c7fcb3789b4e90abe607dca2af
+IV = a69ddc66e63a3415f21009d53a
+AAD = cc6e9cc2699d3ba0e624e715599480d6b7dbc6eeea0d12a9236444
+Tag = b1851d571a1ef8aed565b784dcaaac4e
+Plaintext = 6681b1cbeceea57a828324831407280b00f4917ed52a10df
+Ciphertext = a42665bac9427c62fb555e398d09a0e7e8b8d95155a7a6e8
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 9610949f6d23d5b1f3989b2f4e524fab4f297a5bec8ddad4f16cb616
+Tag = 2dd579cb0d201d22c86bbc7fbe47bd0d
+Plaintext = 109317556c21c969eda65a94176d7a11462c9ae18a865b6d
+Ciphertext = 4e6b967b1571c6d7b9e118b112b7ac949a4a175650316a24
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 96118dbfe53434d8aed88769a535eb0c8b5849dca1c81c34626ac9b9
+Tag = f0dd7aef4a609f3587652173446ebd82
+Plaintext = 3e6c914a196e175079315b1c92b2b8a844deb472e249e3d3
+Ciphertext = 60941064603e18ee2d76193997686e2d98b839c538fed29a
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 21fc96f73975298207f818909088295d6d6861677130ca258c2174f6
+Tag = 63e4405d45caf4836467edbf35089d87
+Plaintext = e0014147d5771b4380dc0192d45f36f7d60776d1ba47374d
+Ciphertext = bef9c069ac2714fdd49b43b7d185e0720a61fb6660f00604
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 72a5151abcb55933ff7c9314f3235eba2a400121454144c2670e8359
+Tag = 7441c813e90fac775eddb7290df059d9
+Plaintext = 0f1c6dffeda98f7a159f9cc61820bfb29910d8eaa41b751a
+Ciphertext = 51e4ecd194f980c441d8dee31dfa69374576555d7eac4453
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = dbbf192914b1ad73666e9f5e9c22c08ca398f7524af62b1046a863bd
+Tag = 34d9316f1f1c3142c1c9b26e5c220a32
+Plaintext = c1ddd14e380cc91324cf2a381df1da1ccffd90ae436a373a
+Ciphertext = 9f255060415cc6ad7088681d182b0c99139b1d1999dd0673
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 28e4b88fbf04e9897057ff5bfde7eb04fa480256817a50fa281030b4
+Tag = c0b188e33bfab29b237d6c6920ce3418
+Plaintext = d4dae9c4cae92afb80f9a5c99383ff16e23a2ec942eed4d2
+Ciphertext = 8a2268eab3b92545d4bee7ec965929933e5ca37e9859e59b
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = d9ebc1cbfab9034317132a72e0f11c341331146a59e7a2f26bf4f3d7
+Tag = fdde04d21b876468bd9184101b5f32d0
+Plaintext = 8a188d40a6e6fbb06a9f06304349a7a808b092cc2fc10b9e
+Ciphertext = d4e00c6edfb6f40e3ed844154693712dd4d61f7bf5763ad7
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 34ad69f192ae4dcab771aeeacf01bbd32609bcbbea8ff9df31ded719
+Tag = 068c65e9d0e5f1b81c86393900e64c19
+Plaintext = 590c1aac30ab166b1caff748452fc146765c372e226ffc26
+Ciphertext = 07f49b8249fb19d548e8b56d40f517c3aa3aba99f8d8cd6f
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = f5e50ce1f99ed5e9f2baa54b96ae7039234b1131e734ec190695d28d
+Tag = 06ab3b72c56c8df4a12dba89a2f21276
+Plaintext = 16d0522b2e691e42bd80ce95e00c8a7a1fc738169e904bdb
+Ciphertext = 4828d305573911fce9c78cb0e5d65cffc3a1b5a144277a92
+
+Cipher = aes-128-ccm
+Key = 7d870d7e52d3053c65eefad47764cfeb
+IV = 37d888f4aa452d7bf217f5a529
+AAD = 9b1e7e52ea1a12444d884866e11dcf367b70b816460936fdaebba36d
+Tag = 0170ca7b16d23537eeb3034105334699
+Plaintext = 0bddf342121b82f906368b0d7b04df1c682ecd4c2b2b43df
+Ciphertext = 5525726c6b4b8d475271c9287ede0999b44840fbf19c7296
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = 9ce65598cd1f86afc9aaaf172809570cc306333c25523f863c6d0e0154
+Tag = cb3b5151f327e65447e52c7525562c91
+Plaintext = 78d1e96af8cebdcc7e7e2a4ddcfa34f6cf9a24fb85672ad7
+Ciphertext = 9adb9a95a9379ad795d8d3ffd4e37a045160d6d727f974a6
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = e7c78ef4c4b959ee00cb1a09d71221a43892ef8ad705edd27ed85d03a3
+Tag = 34e5b08e27d8f5eeef0f064ff620652a
+Plaintext = bc59f18c8473941abc681a92741ab5ee13679829f542b8f4
+Ciphertext = 5e538273d58ab30157cee3207c03fb1c8d9d6a0557dce685
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = f1bce6f2a4bdd3a07ebf5f8d47f931d27e7e63389d70e1059f701216be
+Tag = 44c0a96baae318f4714f0206812516b5
+Plaintext = 5575d950312c14c89ac609dfb0b2fd1af732bb6aae5e8651
+Ciphertext = b77faaaf60d533d37160f06db8abb3e869c849460cc0d820
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = 3da3bb091016e54477dae88af1c84c1a51b59c1bb49a05deb6f32064e6
+Tag = 4e7bdce2dc6aae24178aab6984f31028
+Plaintext = df5947d8c6094ccc25816639ec42214b28731bfd7b8312dc
+Ciphertext = 3d53342797f06bd7ce279f8be45b6fb9b689e9d1d91d4cad
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = c4cd183071c37a8157c6930a7d4d530cf4b7eb021682327810bd48209e
+Tag = f18ece8260bd56ecdee768022d0dd8d1
+Plaintext = 2fbb6dc235761875411ef59ae06110df8f15f66b721b0fd6
+Ciphertext = cdb11e3d648f3f6eaab80c28e8785e2d11ef0447d08551a7
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = 0e0fece7b6b659b642668e8ba3dca330523e70279155f485f3f6f8041e
+Tag = 6f0fb3b7440b84ddc3cc53819c2e93be
+Plaintext = cd149d17dba7ec50000b8c5390d114697fafb61025301f4e
+Ciphertext = 2f1eeee88a5ecb4bebad75e198c85a9be155443c87ae413f
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = a35c6f70f637a9a5e6f215c694fdf65b6fd85f794ed3eaa1bc19abe592
+Tag = 29ca778c51f9320f121dd803ece8d5da
+Plaintext = 030390adb572f2bd2a6a4454fd68236cd1d465574328aa00
+Ciphertext = e109e352e48bd5a6c1ccbde6f5716d9e4f2e977be1b6f471
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = c2992096828325820e2d7acaa17ac789b6830ec3128dd7f904398afbec
+Tag = 9c223a5ad65120bfca4a5992e5ebc6fc
+Plaintext = f2d9cf953c8d3a051d9b3eae4307a3cb4fffaa2435b49586
+Ciphertext = 10d3bc6a6d741d1ef63dc71c4b1eed39d1055808972acbf7
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = c023763a285ea934bc5bc7ddfc2aefe2b3f9eafe7b87c61383dcc07990
+Tag = 5c3bc4f618ffb3a159f4e2d0622cea6e
+Plaintext = 4b92e8d2ffaa4af8f3e0ac037a900bd18e195f490a3d71e1
+Ciphertext = a9989b2dae536de3184655b17289452310e3ad65a8a32f90
+
+Cipher = aes-128-ccm
+Key = 8fcac40527c0e7ca8eaff265ca12c053
+IV = ae9f012fd9af60a400e20b1690
+AAD = 0a39ec0163c7aeb1b4fbe7cb4fa5b0592fade70f430e23730a23ed4160
+Tag = 6f099dce6e18435fba4d26c1e93bda0c
+Plaintext = 7c0e6a0d35f8ac854c7245ebc73693731bbbc3e6fab64446
+Ciphertext = 9e0419f264018b9ea7d4bc59cf2fdd81854131ca58281a37
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = 20c5ab290e6d97f53c74121951f39ba865b3acc465fa3f0fb8a591622277
+Tag = 1816df1e0e82bb7bc8105930ad6a2232
+Plaintext = 79d8841ab83279724ce35e1a8abd4e158168dcf388ab4c3d
+Ciphertext = d00d29396ffa9e691290d746527777bf96a851f306d4da0b
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = 0e205a4dc5d5ead0d9ff7f182dc140fc49511c01b0fdbc7e6d6cb5fdf027
+Tag = df823c8ccd466807f2bd1c4032f0cfeb
+Plaintext = 88b2572fbe7cf2b46df04db476ffedb41778ae2eb3c3aae4
+Ciphertext = 2167fa0c69b415af3383c4e8ae35d41e00b8232e3dbc3cd2
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = 48043560d60381e83c11d4bc9d997d3ee2add6b0524b779c62dfaa73ce0a
+Tag = 31f5be8c9965345c760c72cc1b7908d1
+Plaintext = d44bf28b010e076b45db1b053af03db718b60748da51db1f
+Ciphertext = 7d9e5fa8d6c6e0701ba89259e23a041d0f768a48542e4d29
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = f0729a8a2fd073699ab87b521cbe0420b43529556a505f5f87874d1a053c
+Tag = 381d94a828a95872ebdfda8a4c6a196b
+Plaintext = eab8cffb512eabe267cd64353552513defe97c2d10f35503
+Ciphertext = 436d62d886e64cf939beed69ed986897f829f12d9e8cc335
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = fc2cd69bb61223f713e33a5071d09bf2783640c307c22d836dd94952dd37
+Tag = 63931808533f4f70d7a78242ced110eb
+Plaintext = 001056926546c261fbbdf92b94498e038c2bcfd0b6345497
+Ciphertext = a9c5fbb1b28e257aa5ce70774c83b7a99beb42d0384bc2a1
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = 8f653c5c003c807d16d17f833eebb97c9c2f0e5aae3780a52ce53a6c33f7
+Tag = f34553198f8e40fde6473f9cf04f1de6
+Plaintext = 29ffaef9415fd300127ffd26ef324083a9d90e0f60e2ab4f
+Ciphertext = 802a03da9697341b4c0c747a37f87929be19830fee9d3d79
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = 8d05e7d3077151c6d9378cb08e049e4d7c28a908f7f7c079c46ff92cd01b
+Tag = 0fac20e8d45d2b0771d140b5e4a47c87
+Plaintext = 9874dc5ca1b541f7b21c7b3860fa6b0c3ab1b712ab0fca98
+Ciphertext = 31a1717f767da6ecec6ff264b83052a62d713a1225705cae
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = d4feb3ea76ac2945651f557406f3f38a2d7e9232ed55ff4eaf1201dd8255
+Tag = d3cacfe4281e52d79e60eeb38319bc3a
+Plaintext = 1e01c7128c821fb9c971a27fc7c6f9bb902fa735de583b8a
+Ciphertext = b7d46a315b4af8a297022b231f0cc01187ef2a355027adbc
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = 7cbb4ae995a3367a256cafd11cd6c6cab5bf3252fa97f27a8a1434ca9a27
+Tag = 8f0d7646a799b14288bb2f354b5d8847
+Plaintext = 51cd306fac7d20e3c7043eae3a6dfec046c5c24a666a0723
+Ciphertext = f8189d4c7bb5c7f89977b7f2e2a7c76a51054f4ae8159115
+
+Cipher = aes-128-ccm
+Key = ddf9f150cc3f1c15e8e773663c5b061c
+IV = 98c5036b7d54da9a1177105600
+AAD = bd40b06a4beded2be3d176266b10772c7fa2949f0a9b20d613af90c2daf5
+Tag = fd7f95e1d331e700aa9ef83f09b689fd
+Plaintext = fc5b26befc633a3e8ace011aa7a42bd0258a9f3dc14fc1c8
+Ciphertext = 558e8b9d2babdd25d4bd88467f6e127a324a123d4f3057fe
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = f8b08aa83bed09ca342249b2cf9e2b45a89dcfb8711a120395e455921af481
+Tag = 11297930fd44c63675b7cca70671ef4d
+Plaintext = 54390715b6e7c7bd51a234db059a51ba030cf22ee00b7277
+Ciphertext = cb629994c3418a662a8cde1b5f4d99aa7df66e24c53dc6df
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = 0351c969dd38eeaa4b9b0000e346eeb1a2cd462033c59d9e6e3331822045cd
+Tag = 7e77f5566ca2fd9293835bceb461dbaa
+Plaintext = 65b5e856a8cf35dffd42c5ba105cba4c434aa1c2a0390352
+Ciphertext = faee76d7dd697804866c2f7a4a8b725c3db03dc8850fb7fa
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = 5db8b6bc16740680f78fba917733a6899cdba5e4c10a8058963d1265681eaa
+Tag = ec2cf9f5d35521c1c000685e49d2ed42
+Plaintext = 9a7685e3daac43ccf22cad0df900ba8acddc5d420846118d
+Ciphertext = 052d1b62af0a0e17890247cda3d7729ab326c1482d70a525
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = e7d6024611210da0cfb90a9955195aa0a0539280a3a7c792a1540930daae2d
+Tag = 66f33dfb44ae413283b238616c6b99fb
+Plaintext = c18d9e7971e2ae5fc128777086338fbe194443324e2d2cd1
+Ciphertext = 5ed600f80444e384ba069db0dce447ae67bedf386b1b9879
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = 77a878c9c76f3e6a4ddd330d1d8828949d08e0fedffe0d8e2e557b29e7c78c
+Tag = 31df6fc6b4cf0b6332936ed7cfe9455e
+Plaintext = fcf8982f7342f1b953658453cd5ea413700eff00f1ee7d6f
+Ciphertext = 63a306ae06e4bc62284b6e9397896c030ef4630ad4d8c9c7
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = aa540554ee80dbffa475f702d862d6b60e0a4090792420a26d02926517723e
+Tag = 7c8162a815f2809601ad02595e2e0ff4
+Plaintext = 0d5690d2a7083ad6daf22b308314b8f5363aca77ca72835e
+Ciphertext = 920d0e53d2ae770da1dcc1f0d9c370e548c0567def4437f6
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = fae86f95dd06fb7fbae63a646615555aec8153dc328bdf79da5d4cc9677ed6
+Tag = 7fcaa11bdeab86f60f9cd0a2b45cee1a
+Plaintext = f6e313cc35e8f8812b10a44f8ad00b6893f8084d942effe0
+Ciphertext = 69b88d4d404eb55a503e4e8fd007c378ed029447b1184b48
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = fd525302d2fb246a47cf4e3a27808bda89d8488cf450f1a1c7df6eedd810ee
+Tag = 0a86a810881bd969744ad80f579400f1
+Plaintext = 91e961ea2eb750577c5137c609602dbfcc4c07955ba429ec
+Ciphertext = 0eb2ff6b5b111d8c077fdd0653b7e5afb2b69b9f7e929d44
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = 767b1bdf9793a512d3a84e99ef77b43011a3bcb8de4cd375dfe47a79293e01
+Tag = 250ca00d3231819ecdf501ad39c864f3
+Plaintext = 98438c4411bead6f30c89ead762a12bf39391d3652b78b7a
+Ciphertext = 071812c56418e0b44be6746d2cfddaaf47c3813c77813fd2
+
+Cipher = aes-128-ccm
+Key = b1dc81d116d94f5eced526b37c004b95
+IV = 97c8f69fb91b17299461fd8d63
+AAD = aac7014f606df6feec415a75e29015891007f07518c955875fbf5619262ff2
+Tag = 1224d1d0294d46981d7dc39114a693d2
+Plaintext = 540cb00c0eface3d1b2d632d80a642f53c78ff672a1ff6ff
+Ciphertext = cb572e8d7b5c83e6600389edda718ae54282636d0f294257
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = eca622a37570df619e10ebb18bebadb2f2b49c4d2b2ff715873bb672e30fc0ff
+Tag = 7c4b4fa597666b86dd1353e400f28864
+Plaintext = a34dfa24847c365291ce1b54bcf8d9a75d861e5133cc3a74
+Ciphertext = 7a60fa7ee8859e283cce378fb6b95522ab8b70efcdb0265f
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = 55a62968c222a8501d1ae56a9a815667f8a9554607b7c56e6753f8fa92a4d054
+Tag = 423862a715dda2f63a4197f894515803
+Plaintext = 764dbefb42644d18d23e5e4568685d14dbacfa418d36c4ef
+Ciphertext = af60bea12e9de5627f3e729e6229d1912da194ff734ad8c4
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = f8436e35b7a1c810ac6aabe8e2d48a3678d19e1e96337dada514ee5fc075fce4
+Tag = c200f190bd700f6108f9959f6d12f0f0
+Plaintext = cecef24b62676a5623bedae8087b9b05d7e22b41a14dd2d5
+Ciphertext = 17e3f2110e9ec22c8ebef633023a178021ef45ff5f31cefe
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = 548e2152f3a15b8fb81dc01062d99f7b4fc8f074e5cbdc1030c97f8ccc02ec3f
+Tag = 3a66ebc4e0777a6fc140a51e04a10f86
+Plaintext = 53c164a4990c6e0637267ff2556c1542712fc584f6ff7458
+Ciphertext = 8aec64fef5f5c67c9a2653295f2d99c78722ab3a08836873
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = d100f1d08ef1e3eda4aef22cd970c2b785c4ff9b523c401b4064324aecf7f2d9
+Tag = b810cdc08db0a9966dffeb43ba26446e
+Plaintext = 15681d2121ac56a63b9d0a38b9c4eccf84fdb746d32c14b4
+Ciphertext = cc451d7b4d55fedc969d26e3b385604a72f0d9f82d50089f
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = eece934a807c9f21487cd810f15fd55d7bb4421882333ff2c43b0353de7fc5a6
+Tag = cfc5b397578f8d02a0b936ffac29b99a
+Plaintext = 412a8ef924ca156de860f147575e5731825f0a3759688928
+Ciphertext = 98078ea34833bd174560dd9c5d1fdbb474526489a7149503
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = 86311ff444d9be90459b6ee3652e1705ed0b5cdac3d27293ddea3378fb686ee5
+Tag = 2c3fcd6d618c260d51724126f257534a
+Plaintext = 54ba8a020d0876fa369dc32e8627f565ba3dda862ea0bcfe
+Ciphertext = 8d978a5861f1de809b9deff58c6679e04c30b438d0dca0d5
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = ab6efbc44a8906d5c067eaed71af467e130aaf170827a58beb03c55069674125
+Tag = bf8b2821920640b992b00cd1c9618025
+Plaintext = 7a15506fd1dae444d77b2a3ae7b57a8d5b4f10e25a9f78e2
+Ciphertext = a3385035bd234c3e7a7b06e1edf4f608ad427e5ca4e364c9
+
+Cipher = aes-128-ccm
+Key = 5a33980e71e7d67fd6cf171454dc96e5
+IV = 33ae68ebb8010c6b3da6b9cb29
+AAD = ddb640923d083725587aced81ae1d7409983d1f1e3ccc8dcf94376dc1bbcae8b
+Tag = 4cd52d41a968284af8907ccbb4588cc0
+Plaintext = b18a61a89cd698f32e059b7a2a9f62a46be2c248790a9915
+Ciphertext = 68a761f2f02f30898305b7a120deee219defacf68776853e
+
+
+Title = NIST CCM 192 Variable Associated Data Tests
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = b090155d34a76c8324e5550c3ef426ed
+Plaintext = 39f08a2af1d8da6212550639b91fb2573e39a8eb5d801de8
+Ciphertext = 6342b8700edec97a960eb16e7cb1eb4412fb4e263ddd2206
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 167ee33e75d05023a7d63c770cfef2ea
+Plaintext = 296fbda0017351491c2187273fbde2c3a427170e430a703c
+Ciphertext = 73dd8ffafe754251987a3070fa13bbd088e5f1c323574fd2
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 70647420f79c0d91cbbd69b806fe96a5
+Plaintext = eb61c284fe009921039ef6a9ce50e702823e44b35357923f
+Ciphertext = b1d3f0de01068a3987c541fe0bfebe11aefca27e330aadd1
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 8a3ef2324754539ac774872282534386
+Plaintext = ffeccc6460d23fdcc387c697e75dbb959b78013a8282eaa4
+Ciphertext = a55efe3e9fd42cc447dc71c022f3e286b7bae7f7e2dfd54a
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = e292cd0e32535a848e327bc53cdae94c
+Plaintext = 90958d7f458d98c48cbb464c74bf495a49846dd468c514e9
+Ciphertext = ca27bf25ba8b8bdc08e0f11bb111104965468b1908982b07
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = bb21701af36936be5f62d02b84df87c3
+Plaintext = a4fad5205d38206e25097075687ca86032b95b3fe7e82a07
+Ciphertext = fe48e77aa23e3376a152c722add2f1731e7bbdf287b515e9
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 7da7f975367be24341e4af51b8bb156a
+Plaintext = b37114c65372b052cbeecf83d05a5da44f7b5bbff7d986b5
+Ciphertext = e9c3269cac74a34a4fb578d415f404b763b9bd729784b95b
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 360c6d50a96f316eda0b216cbb6380ef
+Plaintext = 9c0f0426f171ff18b2a4392f61fb4ee4a44c476fe03dc930
+Ciphertext = c6bd367c0e77ec0036ff8e78a45517f7888ea1a28060f6de
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 34cd1bd98e8137b578a174e39efe09b8
+Plaintext = 7b6e0a480a40585545b0e940e8d97c9ec987bd3c0e9c16a8
+Ciphertext = 21dc3812f5464b4dc1eb5e172d77258de5455bf16ec12946
+
+Cipher = aes-192-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886
+IV = 15b369889699b6de1fa3ee73e5
+AAD =
+Tag = 909a895a3b08b63d7a2a1e75d25e7861
+Plaintext = 34dac6dbc28be62332a6935efc122e37b26ee100eb4033f8
+Ciphertext = 6e68f4813d8df53bb6fd240939bc77249eac07cd8b1d0c16
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 67
+Tag = 7ff74e3b05b7d7c13284573bd3e7e481
+Plaintext = 100fa71462277d76ca81f2cfdb3d39d3894b0ca28074a0f0
+Ciphertext = 36e2415b4f888a6072f260d7e786d803be16f8b9cbee112d
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 17
+Tag = 3ee7ce845f85dfc770d96dee9ca54ccd
+Plaintext = 0217eb6778691f8dfe2d0e5241f05fcbcf97b9171f4de3f0
+Ciphertext = 24fa0d2855c6e89b465e9c4a7d4bbe1bf8ca4d0c54d7522d
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = dc
+Tag = dc14ddd8ae0aa5d810040a8d1d4da1e9
+Plaintext = a78b7bc6c1a7250c5fc236f2a8343725a9a7bd3ca81b53e4
+Ciphertext = 81669d89ec08d21ae7b1a4ea948fd6f59efa4927e381e239
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 0c
+Tag = 6b40dec7e647720f1f5e8474bf570c2f
+Plaintext = 390c808d998582793bb10ee60568eb8d975c51d68b4e4da9
+Ciphertext = 1fe166c2b42a756f83c29cfe39d30a5da001a5cdc0d4fc74
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 3e
+Tag = c10c4aac45d90119cce490cc8681a49f
+Plaintext = bcd9747fb54184b61b2e9e049caa75e22006e250f3722c0e
+Ciphertext = 9a34923098ee73a0a35d0c1ca0119432175b164bb8e89dd3
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 7e
+Tag = f9a95091d2cab7d3d9fa3e10d3e67ac9
+Plaintext = d0342e3cd2c1142b642da7297ee3b9978cec405e6810f12f
+Ciphertext = f6d9c873ff6ee33ddc5e353142585847bbb1b445238a40f2
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = e3
+Tag = 180f7818c373e89f7ff3003f53260060
+Plaintext = 7fab91d1aa072947d22f0dc322355a022fe7f0747f4a184b
+Ciphertext = 5946779e87a8de516a5c9fdb1e8ebbd218ba046f34d0a996
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 3e
+Tag = 1905f581585e59e3c8c038b5bf966559
+Plaintext = e487143dc4d98dcc6a2dfe6ee0f85d565d1f46bb0fafe62a
+Ciphertext = c26af272e9767adad25e6c76dc43bc866a42b2a0443557f7
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = 3b
+Tag = ea56569c34f8d9eea23e85fec18cfc51
+Plaintext = 976b489244ed6789a34251500057d1d4a3229367a42b9066
+Ciphertext = b186aedd6942909f1b31c3483cec3004947f677cefb121bb
+
+Cipher = aes-192-ccm
+Key = 9748798c0f3cc766795c8ce0e4c979c1930dfe7faefea84a
+IV = cdf4ba655acfe8e2134fa0542f
+AAD = a5
+Tag = 212da23548f2ca4e9a8a07962be6422c
+Plaintext = 71efa75961dfd60ad533082a8cfe111214eb02573adc4591
+Ciphertext = 570241164c70211c6d409a32b045f0c223b6f64c7146f44c
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = 1c8b
+Tag = 0ecdbc200be353112faf20e2be711908
+Plaintext = 262f4ac988812500cb437f52f0c182148e85a0bec67a2736
+Ciphertext = e6d43f822ad168aa9c2e29c07f4592d7bbeb0203f418f302
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = 9db5
+Tag = 015e5cd97b7dd3d981321ae0b2d99e1a
+Plaintext = d5982c462ad40458660cd7b120ce07fce9afe812caedcebd
+Ciphertext = 1563590d888449f231618123af4a173fdcc14aaff88f1a89
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = 69cf
+Tag = bf3e75863c7acd2699caba3cc301f4b2
+Plaintext = 1a95f06b821879df3fd3ac52fc99a7c1d3e9775263b7d036
+Ciphertext = da6e85202048347568befac0731db702e687d5ef51d50402
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = 6c6e
+Tag = 5d6a8f7a9f52a8038aa9dc1bdc9ed876
+Plaintext = 373c157e59b934a1afb57d4c5dd9ca7fb736b206a6210bef
+Ciphertext = f7c76035fbe9790bf8d82bded25ddabc825810bb9443dfdb
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = dafa
+Tag = 8a15603f10cbfdb041f8b2b12cc8f037
+Plaintext = 26e10a2ed8cc883a6552aee162c5542ff8bb8e758a1975f8
+Ciphertext = e61a7f657a9cc590323ff873ed4144eccdd52cc8b87ba1cc
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = c8b1
+Tag = 1278bf62ba6a4819513d49fdcdb45480
+Plaintext = dd235b05c15479dfe0326ba206ac784eca50038bbeb35d32
+Ciphertext = 1dd82e4e63043475b75f3d308928688dff3ea1368cd18906
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = af48
+Tag = 8b4d00309b50f9ea72f8105c94475b52
+Plaintext = a0818342a5cae4a90ef281d3d1289d83f273f418a545fcbf
+Ciphertext = 607af609079aa903599fd7415eac8d40c71d56a59727288b
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = b1cd
+Tag = 220ba58e97936612c4183ba86705b2f9
+Plaintext = 33c0d06b6583bb4d15b4a07364c4be70ac6e72795c3dae0f
+Ciphertext = f33ba520c7d3f6e742d9f6e1eb40aeb39900d0c46e5f7a3b
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = 649a
+Tag = 87d602dc85bb260fb3df1221e2fbd10c
+Plaintext = 3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863bde9
+Ciphertext = fb5a67c9744faec46fa7e127d646ed5f8be555566a0169dd
+
+Cipher = aes-192-ccm
+Key = 393dcac5a28d77297946d7ab471ae03bd303ba3499e2ce26
+IV = fe7329f343f6e726a90b11ae37
+AAD = 593c
+Tag = eb3835b7eecad6dac9785ad1d370ede4
+Plaintext = a97faefcae36732fcfe47736c2334ea7d411bf7638b0c019
+Ciphertext = 6984dbb70c663e85988921a44db75e64e17f1dcb0ad2142d
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = a4490e
+Tag = 91c88a3cb4fbafcb8a4a157d587d7e39
+Plaintext = 6372824bf416cd072a7ad0ae5f9f596c6127520c1b688ab4
+Ciphertext = b14a07bdc119d87611342c4c6935c5786ff1f9ae2eb49e61
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = 5cad2e
+Tag = 235c34d1390bba5b008c3fb29c2df958
+Plaintext = 295f4f3417a77fcf0bbda17b0fd629ad57a6086573c87eb1
+Ciphertext = fb67cac222a86abe30f35d99397cb5b95970a3c746146a64
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = ebdf4c
+Tag = 5a733bba0a6992d0664dc77d2b5d194c
+Plaintext = 86f354a505de941d34cd98e3af3706d56a938ab9a2797182
+Ciphertext = 54cbd15330d1816c0f836401999d9ac16445211b97a56557
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = 7c0d70
+Tag = 0902a31b15eed99c2dc4ed1bf11cad96
+Plaintext = 88c3bfb546abe2f6bfc92a7c56c627e24ab92a8a87a6b43c
+Ciphertext = 5afb3a4373a4f7878487d69e606cbbf6446f8128b27aa0e9
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = 8fa501
+Tag = 2f25595ae00103d4eb20288158132e7d
+Plaintext = 75d4216bad77943bfe82be216157843b0da0fd16eeee8471
+Ciphertext = a7eca49d9878814ac5cc42c357fd182f037656b4db3290a4
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = b7aca7
+Tag = 60e67693b509ea4795b7da32c5c5d17f
+Plaintext = bf1401e8dcf6f681ed6dd74c7e23b7e54b384608b0e5ec52
+Ciphertext = 6d2c841ee9f9e3f0d6232bae48892bf145eeedaa8539f887
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = 1f283f
+Tag = 80ef8ea380a1a0a38b2c20288e637a9f
+Plaintext = 7e623e7ef7d0a678b5d22a8402d89220f4f1bf759e3084dd
+Ciphertext = ac5abb88c2dfb3098e9cd66634720e34fa2714d7abec9008
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = e93f31
+Tag = d553aafe8536385d34c412c14d3a1563
+Plaintext = 14f80e7a6298d85d31fb80376a394a8f88b0ae47f00450c7
+Ciphertext = c6c08b8c5797cd2c0ab57cd55c93d69b866605e5c5d84412
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = 27e9a5
+Tag = f594d366c8fc826ce58309e9053c27f7
+Plaintext = 3330df12249639961f562a74b34f60b0a8bc7c783f6572fd
+Ciphertext = e1085ae411992ce72418d69685e5fca4a66ad7da0ab96628
+
+Cipher = aes-192-ccm
+Key = a74abc4347e4be0acb0a73bb8f7d25c35bae13b77f80233a
+IV = 6a850e94940da8781159ba97ef
+AAD = 72d566
+Tag = cdd6ac6c42cd3d11e0344a9c1001e253
+Plaintext = 1a1860ac8c11c5d262f8141738cae8ff91ca05906dc98bb4
+Ciphertext = c820e55ab91ed0a359b6e8f50e6074eb9f1cae3258159f61
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = 8ffc0e3d
+Tag = 99b2e1e803550dcdde55fd66ecb45edd
+Plaintext = e8c1a89228d8212f75c136bab7923a89f9fea18e781cb836
+Ciphertext = 66b5d782323925e1bd0a8413a9a5a881356453d5df2cbeb1
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = 2b4f9cfc
+Tag = 9e8fbc507244ba234a0581dc69962a66
+Plaintext = a12c6324e022affd61b7e0d8cccbeb23e2e6c65355c1d586
+Ciphertext = 2f581c34fac3ab33a97c5271d2fc792b2e7c3408f2f1d301
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = b4de3039
+Tag = 28a2857099af20a4ae08e687bdb02c75
+Plaintext = 7cccb26f1dd227bc77458b99fd9e00f8e801adaece7bfcd1
+Ciphertext = f2b8cd7f07332372bf8e3930e3a992f0249b5ff5694bfa56
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = bc59f18c
+Tag = e33a6416e387d9e571a1954471ec9cc7
+Plaintext = 692b53c1355475c71ceff0b0952a8b3541b2938270247d44
+Ciphertext = e75f2cd12fb57109d42442198b1d193d8d2861d9d7147bc3
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = 4fd9fd39
+Tag = 180f9735f994c8335e593f30b331a920
+Plaintext = 7e3e755e25bbe78d4a7770f9356ab9f4ff1bbfdba46383f5
+Ciphertext = f04a0a4e3f5ae34382bcc2502b5d2bfc33814d8003538572
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = 296cd04c
+Tag = 91990fa537d2657d01f66872ba9af22f
+Plaintext = 997b712cd9295dc43cc19b40679f218c27af3e8c638d2e5d
+Ciphertext = 170f0e3cc3c8590af40a29e979a8b384eb35ccd7c4bd28da
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = 88037d3e
+Tag = 4915cb93e84028c7aedce1a2dadbb6bb
+Plaintext = 577981ccb6c893dfe6405075fcb41507de7f9bfda860791f
+Ciphertext = d90dfedcac2997112e8be2dce283870f12e569a60f507f98
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = fc4bb852
+Tag = 25baa6385af8d7b807a2d2ab19aa4999
+Plaintext = 37ba9f57ec230675ce060ba3d388095adf15907aa0b0673d
+Ciphertext = b9cee047f6c202bb06cdb90acdbf9b52138f6221078061ba
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = f40ec14f
+Tag = 6adcdb44870e1105b7318d8bad0af957
+Plaintext = 401e0cdc132a9e4a9b5ceeed3c181f67e5203ea69508deff
+Ciphertext = ce6a73cc09cb9a8453975c44222f8d6f29baccfd3238d878
+
+Cipher = aes-192-ccm
+Key = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb0
+IV = ba356d392c3f700f4f2706a4ca
+AAD = 90e2c63b
+Tag = 8b079fb71d45bd985bffd343c3362653
+Plaintext = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+Ciphertext = 8c40a5f5a79be2a2af34beb3212d8b12c1e13ceff68c2dfa
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = a468f08d07
+Tag = fe4d3a3bb25f89f692884be230c6035c
+Plaintext = d3bef460223c81e4579c9d1d463ac5e0881685de1420a411
+Ciphertext = abb85db49a9b1c8724ecbc734cc8373bd20083cfa4007b1c
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 4497649a54
+Tag = d05ae56511a230627e02d066c52a919e
+Plaintext = 81ad3f386bedcbf656ff535c63580d1f87e3c72326461ee1
+Ciphertext = f9ab96ecd34a5695258f723269aaffc4ddf5c1329666c1ec
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = c30ddd994e
+Tag = 8ef92fc17dca026f1ac1eaf78a05017c
+Plaintext = 84b88264afec06b370dfcebf5e1d3e2c1f005faf248b3215
+Ciphertext = fcbe2bb0174b9bd003afefd154efccf7451659be94abed18
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 9573270f7e
+Tag = 38eddff1e60e2d9ae74a936364b8df21
+Plaintext = 9e4c8aa9b58a8eabc5586892f5541000b43f17d9a051a040
+Ciphertext = e64a237d0d2d13c8b62849fcffa6e2dbee2911c810717f4d
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 40336790fc
+Tag = aa3d464ad89cae59b474d019a5a7605c
+Plaintext = 260f67122dfbe03365bc9e35e9d4ac4b2eb150eddb30857d
+Ciphertext = 5e09cec6955c7d5016ccbf5be3265e9074a756fc6b105a70
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 0b310c8529
+Tag = beab0c520e64939c6950c0fa406eafb1
+Plaintext = 1d55e7352bd895c4ef77389a7225c664f72b38c8de778d57
+Ciphertext = 65534ee1937f08a79c0719f478d734bfad3d3ed96e57525a
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 5756b2c681
+Tag = d22d339c382343bf39c239fd64c2a64f
+Plaintext = fbd315e1f5bd0f0e60ee6684c88f3543452c62ea0701d11d
+Ciphertext = 83d5bc354d1a926d139e47eac27dc7981f3a64fbb7210e10
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 3b919e3665
+Tag = fcd6b562a1b6aa10be92a81f99ed540c
+Plaintext = d68d6556c5a5b1f5a123389b3ce966d5837cb8fcf5accfff
+Ciphertext = ae8bcc827d022c96d25319f5361b940ed96abeed458c10f2
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = 58749b643f
+Tag = 4b853022237d94d253b375bf2150e699
+Plaintext = 062cb6962fa5b3a6239b95f3a51b478a1f32b081dc538a80
+Ciphertext = 7e2a1f4297022ec550ebb49dafe9b5514524b6906c73558d
+
+Cipher = aes-192-ccm
+Key = 16d345606a315ad2406abbcb43cd8cabe948107ba6d17a72
+IV = d4ef3e9e04f1b7f20ffc5a022e
+AAD = a5d50c008b
+Tag = e7aee0d403b2cf6f8b993eebd6b93615
+Plaintext = 08c62ff9bd7bcf189f530d5065f8764532d2692f69858483
+Ciphertext = 70c0862d05dc527bec232c3e6f0a849e68c46f3ed9a55b8e
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = 28130f938c45
+Tag = eadc9601adf9fbdf4e3e94b395b0a332
+Plaintext = 6f3938932b5c1280311e892280d8a822a828a0be7fdb1bcd
+Ciphertext = df48662fe134e75a85abc2cece2c3b6236c88a70fa792e9b
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = f600024a7bf9
+Tag = 0692a40a6aba8d7c5addae21de90fea9
+Plaintext = 0af7345e71f4e8886503395ade0b0296a5856e086638b06a
+Ciphertext = ba866ae2bb9c1d52d1b672b690ff91d63b6544c6e39a853c
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = 4eef510d1f48
+Tag = 22f64becb581070411957e632e19bb8f
+Plaintext = 37f57772f056f45a5ce9f46d27be1858980c8935b9c839b7
+Ciphertext = 878429ce3a3e0180e85cbf81694a8b1806eca3fb3c6a0ce1
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = 4c9c76b6fad5
+Tag = 08c59f83aa97d069b6d83d9387051f43
+Plaintext = 8bb10c82bcabb7fb2b169252ab443b01df217cf908b8c241
+Ciphertext = 3bc0523e76c342219fa3d9bee5b0a84141c156378d1af717
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = 5572ecfc7e53
+Tag = f04686ee1d7b985d903f1de6cf78f8f4
+Plaintext = d1ccb4654a22b1afe32f3d3035fdccd87e9cbed83c679007
+Ciphertext = 61bdead9804a4475579a76dc7b095f98e07c9416b9c5a551
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = bffdf9d20d74
+Tag = f8118f1b9f39b51965ae9ef1bdb40111
+Plaintext = f990a8f6ba14065d48665db36eb470c49f38e2b6376a9bde
+Ciphertext = 49e1f64a707cf387fcd3165f2040e38401d8c878b2c8ae88
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = 3f27e678c580
+Tag = a3236d02f33f49759f281315e449bfef
+Plaintext = f8c7d89639ab742a8bcfffe776e868d671e1fbdd55807a8a
+Ciphertext = 48b6862af3c381f03f7ab40b381cfb96ef01d113d0224fdc
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = 1294cb9db5f5
+Tag = e74770a07c242c3854ceb242dadc1976
+Plaintext = 8601cfd7d935e8a8487b9c39d55ca27096255f2eb9e009e3
+Ciphertext = 3670916b135d1d72fcced7d59ba8313008c575e03c423cb5
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = cec271332b75
+Tag = d6c65f19175cfa49898655ccdddb864a
+Plaintext = 77c85b8022f58337b364142a2474fe5cfddb31cfca48af46
+Ciphertext = c7b9053ce89d76ed07d15fc66a806d1c633b1b014fea9a10
+
+Cipher = aes-192-ccm
+Key = 1c476cfd7dd300d961fd3f24a6fe0e80742b00851676ca63
+IV = e300fc7a5b96806382c35af5b2
+AAD = da06bd140502
+Tag = 458822e49e69031431b3eea872a72eb7
+Plaintext = b0f2db802475fa70af02057373844f637a3244cda4b4f93d
+Ciphertext = 0083853cee1d0faa1bb74e9f3d70dc23e4d26e032116cc6b
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = 076887d2abe900
+Tag = 18d1531a066de60a95d2924a6910e990
+Plaintext = 83c24f3a77b83b4ef45277ba90225f3ba1722312f52b1a07
+Ciphertext = 19d880f1d959a68f162de243d4a45747ace704613359b272
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = 7535bcc6fbd1a0
+Tag = 6dbf58406020e6df7b312b6825127f9a
+Plaintext = 24f85ef683cc521387f484bc0b2ad9172f61884c09a9718c
+Ciphertext = bee2913d2d2dcfd2658b11454facd16b22f4af3fcfdbd9f9
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = f4f96d7b4384a3
+Tag = 64dd755177efc87f8b1daf1fd88e51a6
+Plaintext = 212bedfa06b5e1a2c3a2f31f6f791dd9df8ef26077821c0a
+Ciphertext = bb312231a8547c6321dd66e62bff15a5d21bd513b1f0b47f
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = 3b7e3d9c1a7fa2
+Tag = 0be31cab31f1a20805d5c07dc516d707
+Plaintext = 8b9036914bb0f440c8dbcfde9b9547be5e5ef1f56492c75e
+Ciphertext = 118af95ae55169812aa45a27df134fc253cbd686a2e06f2b
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = a8c35fae8912d6
+Tag = 399df9a45ad153c0dfb3fec3b9d6f7c5
+Plaintext = 50f3f3a91bf6fd9573d5ef54b9bb5805205b2f9865d81fd7
+Ciphertext = cae93c62b517605491aa7aadfd3d50792dce08eba3aab7a2
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = db636541f2429d
+Tag = e20b7da94eac8c7ef8478671165e0d82
+Plaintext = 6fbda8d435555e735443f1e6bc09e96065092efd89edd64a
+Ciphertext = f5a7671f9bb4c3b2b63c641ff88fe11c689c098e4f9f7e3f
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = a8de55170c6dc0
+Tag = 4979c35bdbf9538666b6fa57f0f915d8
+Plaintext = 640ef4c246a2c6e16ddc49072a5aeef70319149ffba071ef
+Ciphertext = fe143b09e8435b208fa3dcfe6edce68b0e8c33ec3dd2d99a
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = f8d64ce2aa66e6
+Tag = 752824a691da2e99374ae6c031d74ffb
+Plaintext = a14e3910766f31594a28ad2c3678c31d0c3aee88484ca6d6
+Ciphertext = 3b54f6dbd88eac98a85738d572fecb6101afc9fb8e3e0ea3
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = b3c340afdc53a8
+Tag = 04159a68706faa2e8c3376b4dbeb423a
+Plaintext = 1b8e0a09e6364020b4cac704dc19bfa79455295604cf9c9a
+Ciphertext = 8194c5c248d7dde156b552fd989fb7db99c00e25c2bd34ef
+
+Cipher = aes-192-ccm
+Key = 79d1e38a70df1cf239be168833dcd0570bc8f37b3aa26c37
+IV = 8229d6d7e9e21fdc789bff5dcf
+AAD = 73824034001519
+Tag = e5adc7564721ead2af75cb98e61148b4
+Plaintext = 52c84a0735eea6c5c230644075ebfc5db0c3128056e7a8f4
+Ciphertext = c8d285cc9b0f3b04204ff1b9316df421bd5635f390950081
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = f427c47e10c45bb3
+Tag = 721961de5c768f4d19bd3034f44f08d2
+Plaintext = 54bc7e3c227df4e83252a5848fea12dfdb2d14b9e67c1629
+Ciphertext = 91e7baff2b42af63e26c87ce6991af22422c1f82906858b1
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = ca25504f3f5559aa
+Tag = 42968c638ecb8a2b358e8eaefd931efb
+Plaintext = ff4493fea916f49fbb3cae2838bc84e293531092cc0904ab
+Ciphertext = 3a1f573da029af146b028c62dec7391f0a521ba9ba1d4a33
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = 8215753d9efc5132
+Tag = f8ac11752fe51e354f3f8a68815539aa
+Plaintext = af16ab8558269a93d8e8c9e38f12a8768947d8b69be0e259
+Ciphertext = 6a4d6f465119c11808d6eba96969158b1046d38dedf4acc1
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = 9e7cdbc6202e6492
+Tag = 489de8e241dcab16bdcbf1a1ff4d8d10
+Plaintext = 744a167ae31a8ca20df82290766429de9ef0b7dfe199a78d
+Ciphertext = b111d2b9ea25d729ddc600da901f942307f1bce4978de915
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = b8d511d0ab86a07f
+Tag = 3fab212a1b6dc7b953e2bc211be194ae
+Plaintext = eeb39de1fe21b5aba654da45fe1481decb22365fa4cbe49d
+Ciphertext = 2be85922f71eee20766af80f186f3c2352233d64d2dfaa05
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = c74a5d4265f9f3d5
+Tag = 73918ab70fe048d6c5b63a01725eddfb
+Plaintext = e95c20e80153bae3fde3c3d82b6b33b35fc1959fa31a5d11
+Ciphertext = 2c07e42b086ce1682ddde192cd108e4ec6c09ea4d50e1389
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = fd849d3ada03181a
+Tag = 87089bc20867f474c1127aa1320f0000
+Plaintext = 6d00606c72cea3deaea5b51ae09e61924355e167058ef42c
+Ciphertext = a85ba4af7bf1f8557e9b975006e5dc6fda54ea5c739abab4
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = 56825a68681f498c
+Tag = 34a23b0b6ac4d297dd7832a5e2102272
+Plaintext = c47705d897a6c7e7aed710b96e2d8532c23b82090e21b114
+Ciphertext = 012cc11b9e999c6c7ee932f3885638cf5b3a89327835ff8c
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = 72e4da839913a26e
+Tag = dd665766c7af21ff890bd40178f1c660
+Plaintext = c822a1ee581cf85b0482c821473385bd3f28528e5e5760d9
+Ciphertext = 0d79652d5123a3d0d4bcea6ba1483840a62959b528432e41
+
+Cipher = aes-192-ccm
+Key = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+IV = 3820db475c7cb04a0f74d8e449
+AAD = 138457571ee8dafd
+Tag = 6a6a58bb772c79481dc26861ffbd68c6
+Plaintext = 3ffb82a83308da66e95ac63ae92931b09ffe0e42afbb4979
+Ciphertext = faa0466b3a3781ed3964e4700f528c4d06ff0579d9af07e1
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = 28d157f09a71da80dd
+Tag = 02ada34addf0aa2f4744ed2e07995491
+Plaintext = 0662e63c88e963d3e0cf2c4653515ae4474a2c78ab0394c0
+Ciphertext = 01dcd4dd3b8c1369518136ce45e8bb9df565b0ad231a887b
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = c17d311362c41d442b
+Tag = 38a27466b8741bffce44ef04b23af321
+Plaintext = d6df8b60c697093987b3d89a3667b36504b6ddddf12b0900
+Ciphertext = d161b98175f2798336fdc21220de521cb6994108793215bb
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = 006669ef1a11b65b1d
+Tag = 7d11372fb0dab1c99b159e5fe9f91118
+Plaintext = 49ad29ef5e82b08752ac5a50dd982e4bcb700005454ade6c
+Ciphertext = 4e131b0eede7c03de3e240d8cb21cf32795f9cd0cd53c2d7
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = 8eafce9ba466fd53eb
+Tag = 09e4898a4046f6ec9f40e412915007e4
+Plaintext = 385f9fb139dbf88561b7a500b0c7b835fe57e2698c6d9f76
+Ciphertext = 3fe1ad508abe883fd0f9bf88a67e594c4c787ebc047483cd
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = 796e55fbe7bed46d02
+Tag = 5d40a9902481bfac7ff33d08fb4b3d31
+Plaintext = 4ebb149b01cbacba32d11168ca61928ea149dcf2ee2c1001
+Ciphertext = 4905267ab2aedc00839f0be0dcd873f71366402766350cba
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = 8f958d796be0566512
+Tag = d972d09a17172161eb68a30b593b1bd6
+Plaintext = 0d974e5621caa1d86eaaee689ccbca57843373fcf20db407
+Ciphertext = 0a297cb792afd162dfe4f4e08a722b2e361cef297a14a8bc
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = cc879ff2d583a7288c
+Tag = 119cc26a80c152c253fbc36cb886e0fc
+Plaintext = f8e0dac6a691dfb231411b5c5f70a0daff83cc637b0c7bb3
+Ciphertext = ff5ee82715f4af08800f01d449c941a34dac50b6f3156708
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = 4765d696d19dec58bc
+Tag = 9de06cc5c3bc4ad75076c774576843fb
+Plaintext = 096a36396ccfa260f28fb0919157a5076b53506c51a2a4ef
+Ciphertext = 0ed404d8dfaad2da43c1aa1987ee447ed97cccb9d9bbb854
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = a004f283afc3309c31
+Tag = 135493b44f79a5774df6b2943b0bec67
+Plaintext = 5b943269be41e2758a4ea6a3cc621b711a8ba6002783aa72
+Ciphertext = 5c2a00880d2492cf3b00bc2bdadbfa08a8a43ad5af9ab6c9
+
+Cipher = aes-192-ccm
+Key = 39c03a0c8634047b1635348f284d3dc1e752ab40548eb337
+IV = 9e2ea8eb7f56087ee506925648
+AAD = cdd5d8aefe49a315ad
+Tag = 7a5da4a29a9012d78b6de6f1b3e8c9ed
+Plaintext = 5f27867109e74862ce0dbc9ba73c420b93067bdede17ae51
+Ciphertext = 5899b490ba8238d87f43a613b185a3722129e70b560eb2ea
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = 2352648299b0413cb2ce
+Tag = 0c96e8ab8774baa421f39c64a386c418
+Plaintext = 048c9ba4597c3bb595bfd5048e5e9a1296f30e5c0118b177
+Ciphertext = 25247a258e4ac0a988d8def60cc174a9d4578cd5346fb515
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = ce003c836a6f5f066053
+Tag = d453036cdc6bad0c5e770a6249a52e74
+Plaintext = 02ea8e7e488c863584f828df13dfeb68433294d11d9ca9d7
+Ciphertext = 23426fff9fba7d29999f232d914005d30196165828ebadb5
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = d11be73a104ccc6346d5
+Tag = 4627ad75bbfe17f3f5ddfd3dbc1045f3
+Plaintext = 6d5573c9279897d7d1602d8a95c04bb5ca3fad2dbe89a024
+Ciphertext = 4cfd9248f0ae6ccbcc072678175fa50e889b2fa48bfea446
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = 6a7b80b6738ff0a23ad5
+Tag = af8943f74706cc3394a170fd49f7011a
+Plaintext = 97a813e75d95d25c2edb1c705c4ffe4d7c08c756761fbc0b
+Ciphertext = b600f2668aa3294033bc1782ded010f63eac45df4368b869
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = a391acdb3a06dae4a671
+Tag = f22597f63074ca3533bb5e107860481f
+Plaintext = a78981ac244307451e4d3fd7f654b70cc4e6518aa47a3c18
+Ciphertext = 8621602df375fc59032a342574cb59b78642d303910d387a
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = 0b9f28f2d3215785f569
+Tag = 905b5609f593c6ea9281f66cd2e646dd
+Plaintext = 5d649d79ff0e304e164a383c74f13d7ffab145d00cb0ec2c
+Ciphertext = 7ccc7cf82838cb520b2d33cef66ed3c4b815c75939c7e84e
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = 7928b1091cbfb2eef0fe
+Tag = 428195355618ea0cf87260ad20b6d7b9
+Plaintext = 83a273687dced7b94d569f81d75508595cde668f06406183
+Ciphertext = a20a92e9aaf82ca55031947355cae6e21e7ae406333765e1
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = 3b74afb81f54a93c79d5
+Tag = 55019659f41a5f0430695b4ada9d8b8d
+Plaintext = b4dc3c059cf7b47dd0bb7f165a63fc80b5c6b5f3ca7eeb73
+Ciphertext = 9574dd844bc14f61cddc74e4d8fc123bf762377aff09ef11
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = a46ae4c71d4c9eb72fab
+Tag = 1514b252f33dc870c42260e48c4fa9fd
+Plaintext = 7e919581c5105d98717d0613e1ca869c6516506ea482d5c2
+Ciphertext = 5f3974001226a6846c1a0de16355682727b2d2e791f5d1a0
+
+Cipher = aes-192-ccm
+Key = e2a92ffbb0b5eb68cb82687f12449fae5167d375131b0b10
+IV = 441ad5e1382e083a95224f395d
+AAD = a1ace61711f0a09ac17d
+Tag = c263c667d7ed58907452c092905d0b31
+Plaintext = 3a4558b55214f21cbd2ae2eda5a2321cfc2f102e059b744a
+Ciphertext = 1bedb93485220900a04de91f273ddca7be8b92a730ec7028
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = 521583c25eb4a3b2e46120
+Tag = ed2c87135861b43a99f258b6938f66e3
+Plaintext = 9f580cc6c62a05ce125c6bec109a48ca527ee26a64b14b68
+Ciphertext = ff0ff95bcb0bccd5e4aadd77ac6770f5013654eb3c6386fd
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = 31adb39e947f8883fa4b69
+Tag = 32b87476d66a1bd405f484ef9ac8ab7e
+Plaintext = f16bba081bddda83546eabc9a55c81a439720dd8562ce964
+Ciphertext = 913c4f9516fc1398a2981d5219a1b99b6a3abb590efe24f1
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = f05f39eb0a3d6460076aa8
+Tag = a120b455b366cb104fd8b6dc2c80471e
+Plaintext = 6baf784f63cf45a1836fa8f3609fff7870ce8cbd1e91268c
+Ciphertext = 0bf88dd26eee8cba75991e68dc62c74723863a3c4643eb19
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = 74c7a633ff73ff507009c5
+Tag = 0c8ca09f4bf06b1c27e75abf15112e49
+Plaintext = d8176a6de1c15a14c8b8b58725c179dc84c9308268d718d5
+Ciphertext = b8409ff0ece0930f3e4e031c993c41e3d78186033005d540
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = ab322a88cf44b9ca774415
+Tag = b3159274a7de3550baf759f7fae53dbc
+Plaintext = 3706e4d8ff748574f382e5f9b0a3b6258f1f360fd87001b0
+Ciphertext = 57511145f2554c6f057453620c5e8e1adc57808e80a2cc25
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = d6fe6e17221d4e06ed3ab9
+Tag = 16fba8d193e133e6f78daa39681cb262
+Plaintext = e02217394772deffe218c405e40f2a3a56ca01d55d6d3330
+Ciphertext = 8075e2a44a5317e414ee729e58f212050582b75405bffea5
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = 2739d2cdfcbe7d5cd7d28c
+Tag = 65f92db3b3d1c2de04c69c5d06b0e001
+Plaintext = bb713f74a884bd1a994adba87561d637853c6181290ef5e8
+Ciphertext = db26cae9a5a574016fbc6d33c99cee08d674d70071dc387d
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = 5841571299cd064a6262b7
+Tag = 6e4d20ab5ffad6f71155f6839dfdbb25
+Plaintext = 9641dedd50d80ac0abf7591436065fa2e23e4687abbb86e4
+Ciphertext = f6162b405df9c3db5d01ef8f8afb679db176f006f3694b71
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = dc5d7fd97bb3243ba585fa
+Tag = 0ebc3af2de52b8bee3d130fa973f716b
+Plaintext = aefda8501193edacb8abb94fff875529a537a462c4b9b69c
+Ciphertext = ceaa5dcd1cb224b74e5d0fd4437a6d16f67f12e39c6b7b09
+
+Cipher = aes-192-ccm
+Key = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+IV = 8e7d8a44244daa7df2b340993e
+AAD = 8789e0b3e0dc13d9725b37
+Tag = b5cd5a004a0ef28e30383bdaed8f93c7
+Plaintext = 65e53f549b62aca03f21ab2a494b93805e02cfecf4f12aa4
+Ciphertext = 05b2cac9964365bbc9d71db1f5b6abbf0d4a796dac23e731
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = f1e0af185180d2eb63e50e37
+Tag = 4484d93cb422cb564acc63d3d18e169c
+Plaintext = 6333bde218b784ccd8370492f7c8c722f8ef143af66d71d7
+Ciphertext = b9401a4927b34dc15e9193db00212f85f0c319781ec90e3b
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = ea74231e49e667ca1c21d46d
+Tag = c4c151d9927e6a9f19d47ff7d79ca6f6
+Plaintext = 3c0e2815d37d844f7ac240ba9d6e3a0b2a86f706e885959e
+Ciphertext = e67d8fbeec794d42fc64d7f36a87d2ac22aafa440021ea72
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = 7f5871a8300471dc325f8289
+Tag = 959eee29be1415ab03444de0fa42707d
+Plaintext = c642c9722d84d708682350dc70bdaa9a1181a415a9e72b93
+Ciphertext = 1c316ed912801e05ee85c7958754423d19ada9574143547f
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = ee7e6075ba52846de5d62549
+Tag = ce97c1c8aea70de04580d7b37f8c014d
+Plaintext = 2286a1eddd80737a724ca941217e9f0232870b6c2f20d29c
+Ciphertext = f8f50646e284ba77f4ea3e08d69777a53aab062ec784ad70
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = a30f2fd445820cdf80014554
+Tag = 23b536f993381e525a14599dd5c02e80
+Plaintext = 92577d5db20391110309d490f52acecdfc18382f368bbe42
+Ciphertext = 4824daf68d07581c85af43d902c3266af434356dde2fc1ae
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = 0cfec933831644b468724e80
+Tag = d6ea722fdd82ede2c7b8832dde3cbe80
+Plaintext = 6803dc3f7c06568ca78ee5aa2e9b1b354a4f1e067ff6a25b
+Ciphertext = b2707b9443029f81212872e3d972f392426313449752ddb7
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = 6bd14e3bf91dc7fd6be07647
+Tag = 5c2994b2b469ad977564d83db1ebfe38
+Plaintext = 5580672e52aacb9d714a34c31c33fc221e13e8f90849adba
+Ciphertext = 8ff3c0856dae0290f7eca38aebda1485163fe5bbe0edd256
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = 6c6ad35e97d023217018162f
+Tag = ac31ebf9e255eecf3c69ddf198760556
+Plaintext = 1bd1bcc6766d251144376d91ff93ef83033d0e0ee546266f
+Ciphertext = c1a21b6d4969ec1cc291fad8087a07240b11034c0de25983
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = 52c35db85cc34b6efed180ee
+Tag = 3424079e3de87fa59c3d10fd62380a90
+Plaintext = 28f71a2fe498f89203a5d23e8f8fa64b124aea6459fe721d
+Ciphertext = f284bd84db9c319f8503457778664eec1a66e726b15a0df1
+
+Cipher = aes-192-ccm
+Key = 44cba20b7204ed85327c9c71c6fea00b47ce7bdde9dea490
+IV = f3329154d8908f4e4a5b079992
+AAD = a96e4776270683ee7d0c9b6e
+Tag = 2258e1f3fc3eb7e976c86c8a21bd6569
+Plaintext = 5be078ead1926074afca81f9a97dc93dcb954c955e4343e4
+Ciphertext = 8193df41ee96a979296c16b05e94219ac3b941d7b6e73c08
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = ead4c45ff9db54f9902a6de181
+Tag = 9503d811701642143013f28ce384d912
+Plaintext = 3726c1aaf85ee8099a7ebd3268700e07d4b3f292c65bba34
+Ciphertext = fd80e88f07dad09eed5569a4f9bb65c42ef426dda4045011
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = e63b89e95df8338ecdcc885c3b
+Tag = c6d3f9c7b9f25e09ce164a11370b8b05
+Plaintext = 37f86aa62b1e31e9ded3e1a38a7e1a8a638d619ac109694f
+Ciphertext = fd5e4383d49a097ea9f835351bb5714999cab5d5a356836a
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = a2161536e263459e0b0a29a225
+Tag = e02b848b006c28803303fd97bdc35476
+Plaintext = 1749f5977197359a5d318d5fea38aba95b3603f1d7011e66
+Ciphertext = ddefdcb28e130d0d2a1a59c97bf3c06aa171d7beb55ef443
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = 8ac95a6ae0bce0fb07f85368ab
+Tag = 431de2bc45b2b726bfda92939a11f68b
+Plaintext = 0842bfb8b38283257c2ea58b29c8350775f1dbf15f73c905
+Ciphertext = c2e4969d4c06bbb20b05711db8035ec48fb60fbe3d2c2320
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = 44cc9b2510680c4d73f1938c77
+Tag = 786add8c2619f0782ca12312a1d64266
+Plaintext = 68d09fce5e89e4ef6d453b8ee326090cedb97b75b886c7b3
+Ciphertext = a276b6eba10ddc781a6eef1872ed62cf17feaf3adad92d96
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = d8a662ab8449bd037da0346a24
+Tag = b6bd4a09f9b4aa2864d39ff1a03e0ff7
+Plaintext = 45245de4ac6a6196a0b15b77c622a21bb50627379ddb4256
+Ciphertext = 8f8274c153ee5901d79a8fe157e9c9d84f41f378ff84a873
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = 8ed39da1d9179e77156eb909f3
+Tag = 19b6935778ffbc0953974de0a9d87a31
+Plaintext = e928e37dbe8389a53c650edc86f83cd3589a53dc8e45adfd
+Ciphertext = 238eca584107b1324b4eda4a17335710a2dd8793ec1a47d8
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = 423515f7bd592d6a7a2408661a
+Tag = 00a3da0d3ce34a272b51582a998f461e
+Plaintext = 4c3bdc6186297896097b3297ba90bcde78dc8a9efe3bd8b1
+Ciphertext = 869df54479ad40017e50e6012b5bd71d829b5ed19c643294
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = 5a6bc2cd6890a473d478a582b4
+Tag = 4ef28c338f497a40f550f2945734ad1a
+Plaintext = 1c5ebaeb7b926a39b8aaf65a4c484b113d6f2caafadc33ea
+Ciphertext = d6f893ce841652aecf8122ccdd8320d2c728f8e59883d9cf
+
+Cipher = aes-192-ccm
+Key = b5f43f3ae38a6165f0f990abe9ee50cd9ad7e847a0a51731
+IV = 13501aebda19a9bf1b5ffaa42a
+AAD = 7bdc26b5b4df58af539d91eb2e
+Tag = e07f1998e57ba9b611568632dc5cb9fe
+Plaintext = be5c9fee6babf569c66e6a0d0f3c4dc314f40c0aeca493f7
+Ciphertext = 74fab6cb942fcdfeb145be9b9ef72600eeb3d8458efb79d2
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 5cc924222692979a8e28ab1e0018
+Tag = f58649400ac9e825b038d67f0c2a6f1c
+Plaintext = d3b36c6289ad6ae7c5d885fe83d62a76270689ce05fa3b48
+Ciphertext = bc4fcef401c2e1d1c335734ff23ea52c3474d2e6f31648a7
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 21fb9cdd9b110bbbc6832275dfa7
+Tag = 3fa5ad4142e0b4650fa5cc8f7ef70d62
+Plaintext = a7742dd9c3e8bbad08157fbd01ebfb94e1639117c4b4eb5d
+Ciphertext = c8888f4f4b87309b0ef8890c700374cef211ca3f325898b2
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 9919ddb6ee6c330646cd15953d39
+Tag = fec551d11b8647432cc4320173939600
+Plaintext = 297b4498bf5427e6341aa9275c1f62e3b0c9b150a195ae72
+Ciphertext = 4687e60e373bacd032f75f962df7edb9a3bbea785779dd9d
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = f94cfd1f8c7902a57784c10b9a5a
+Tag = a79a075ec2cacee1482b8328b697a3b2
+Plaintext = 2218868033e17220655f0196dab6193c58293ca105d467d9
+Ciphertext = 4de42416bb8ef91663b2f727ab5e96664b5b6789f3381436
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 63f3fe58c348dc6bcbb44c3c370f
+Tag = 39cbe17b4edd64a3dcd2b8ae3352c04a
+Plaintext = 4a9bc26fb10000a57b9e73a8a3d30f66ef9de8782201ffa8
+Ciphertext = 256760f9396f8b937d738519d23b803cfcefb350d4ed8c47
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = dec0ce763833305aa9c9efdc2c65
+Tag = f54665c476d0741164685b0d81caca31
+Plaintext = 1b61b3ff3e4847a17f55f7565826b0e2ccc1368f4de32022
+Ciphertext = 749d1169b627cc9779b801e729ce3fb8dfb36da7bb0f53cd
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 592ef6784ee839a049e0d96257fa
+Tag = 500d93b11fecc8b4560320878ba53550
+Plaintext = 32e5998b37987a38800f5bfe3132979ca1447314570aaef7
+Ciphertext = 5d193b1dbff7f10e86e2ad4f40da18c6b236283ca1e6dd18
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 4a47a82b999a2a739959f153a091
+Tag = 3c2a41443578adaf31483bbb6b9f10b0
+Plaintext = 84acfb6cf10b301558e5acbf41bbbe0b145dc66dc600f4df
+Ciphertext = eb5059fa7964bb235e085a0e30533151072f9d4530ec8730
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 4ceba98cc0ff5de1a7d580cf23d2
+Tag = 2232a856c07999e99a4701988b486ef2
+Plaintext = d7c73d77a286df38aad116843620911c92e11486be5fcb0c
+Ciphertext = b83b9fe12ae9540eac3ce03547c81e4681934fae48b3b8e3
+
+Cipher = aes-192-ccm
+Key = 13f179aa2a23bc90a85660306394940e9bb226ce3885ec01
+IV = aaa52c63ca1f74a203d08c2078
+AAD = 15e3b3c5794fececd703ac58ccb2
+Tag = b3a6d50a92f3183c0c5090edc3c7f822
+Plaintext = 140882c5d3534bb0861e7ba9423e67439a02ee6f0b0b00f3
+Ciphertext = 7bf420535b3cc08680f38d1833d6e8198970b547fde7731c
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = 39ba54a410a58a5d11615a2163cc3b
+Tag = 26a51fe5b9b598a17eb3da10f936813b
+Plaintext = 67d9728a88f1fac3af43ed6d634ba902896bd226858697d9
+Ciphertext = 360f0fc714994e3b59448b50cdd61d511b4f09e0e5fb5ac8
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = 38b0cca09d69320105d24ee3f96684
+Tag = ba673a94f4280e84724f4a2510165e9a
+Plaintext = a8365ba9fcfff060b28895f7a2d786c5991a8f7758962caa
+Ciphertext = f9e026e460974498448ff3ca0c4a32960b3e54b138ebe1bb
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = 76718dfb9c68acdd82592d96def39a
+Tag = 18865ab37be6f015316e0d177b6c2e91
+Plaintext = 497be597dd695cb159d8a64f44049c3b549ac927837b1b90
+Ciphertext = 18ad98da4101e849afdfc072ea992868c6be12e1e306d681
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = dd719ba1710916a546233c1494a7a7
+Tag = 3d903f67ad0d72fb8ffea2035216b769
+Plaintext = ca452c21383ebc3fb584f0d59a227374854983f243a3f460
+Ciphertext = 9b93516ca45608c7438396e834bfc727176d583423de3971
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = d893fa2bd7c70e21a5934dc2e99037
+Tag = 0b885e3e054f519d0355db1bd589bb35
+Plaintext = 3dd118ed65453d3d7844d8de78d7a43587ac5e9305b11464
+Ciphertext = 6c0765a0f92d89c58e43bee3d64a10661588855565ccd975
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = 97c60265a3a6993b97ac1b375a79b8
+Tag = 4a950e4bed4137e38787839e39924821
+Plaintext = a7375ba32251af0138bd9fd8fcd56a7c43ab2ca9a7fc0117
+Ciphertext = f6e126eebe391bf9cebaf9e55248de2fd18ff76fc781cc06
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = acfdf302ed116ac4755069d1704423
+Tag = ca94dd97fd2a5d50eb7dd6234b40c525
+Plaintext = d39d188f28521e4fb0a0c5e48e6d6efe4383c95b2535ea8d
+Ciphertext = 824b65c2b43aaab746a7a3d920f0daadd1a7129d4548279c
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = d449f97164aae9a3046624e98810bc
+Tag = 96f11450d5d2ba55ffb4a6cf7eab847a
+Plaintext = 758102470e221e30d87d2807b5f8b793a7a56c83eecf32a4
+Ciphertext = 24577f0a924aaac82e7a4e3a1b6503c03581b7458eb2ffb5
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = 3e6c914a196e175079315b1c92b2b8
+Tag = 64894e9218ecacd143fb62df69a13d33
+Plaintext = 1db875c4b4f9dd4926dfb5604d6c4d21aba7d905aed9d1b0
+Ciphertext = 4c6e0889289169b1d0d8d35de3f1f972398302c3cea41ca1
+
+Cipher = aes-192-ccm
+Key = c1dfc48273d406a3a7b9176f80b2dc4e9a7f68134bab66d2
+IV = 1ac53ba965cdaeeef7326a37e4
+AAD = e2b7b00d0cfbdfcc24f1819ae1869f
+Tag = 85a7c19bc9c2f8e36ed95015ebb679ae
+Plaintext = d7a75bc621addccbbe162b86d536d69c887c278384af54e7
+Ciphertext = 8671268bbdc5683348114dbb7bab62cf1a58fc45e4d299f6
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = 1c1c082eeb5b8548283d50cc2ace1c35
+Tag = 867601fe79a122a7817819655183283e
+Plaintext = 61fdd10938557080191d13dd6c3002dd445d9af988029199
+Ciphertext = 23c05927502a4ee6e61e4e10552d49b020643eab476eeacc
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = cae884fa25adedd883ef4e7c855def19
+Tag = 160bb976ab072aec8fcea8eab3dc5aff
+Plaintext = 8c7ae2c3c503e9072d6e04e44c2ea78fd24994503567a136
+Ciphertext = ce476aedad7cd761d26d59297533ece2b6703002fa0bda63
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = a350ed58c04473e113b9088b1fb9dad9
+Tag = 291b2c13a3f5e49ce35b9047ee1e8627
+Plaintext = 863f9a26182f131c594972398b52b3a01a9d314fd9390bf4
+Ciphertext = c402120870502d7aa64a2ff4b24ff8cd7ea4951d165570a1
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = cb7090f7a465782f680fd44cbc558107
+Tag = fdd9fd1d469a9042b80e6458d25292b4
+Plaintext = bd94c9ad6253c25dc417f87b6e52e03621ccf4b3bff5b402
+Ciphertext = ffa941830a2cfc3b3b14a5b6574fab5b45f550e17099cf57
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = 914cf55a3fc739b5f87ac7518cc4171b
+Tag = a8b8e82175ff30c69ea71d2cfb814ada
+Plaintext = c313bd213dc29c00691e25ce028884192e21a820003aece4
+Ciphertext = 812e350f55bda266961d78033b95cf744a180c72cf5697b1
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = adc8b69d84ef7ae62f9ca9f371d3488e
+Tag = 76fa36db27b2f84d1b8ab55e2fc89ab8
+Plaintext = 85e4e053b976e06a64dfa8523130cdd802d3e7c3d6d797c2
+Ciphertext = c7d9687dd109de0c9bdcf59f082d86b566ea439119bbec97
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = 29ed477994dd231d3a71157eb56d219d
+Tag = 0e32058ea939036805a735198934a072
+Plaintext = c77aae5fd09dc9bceee7428e0734d4b0556528396a58f909
+Ciphertext = 85472671b8e2f7da11e41f433e299fdd315c8c6ba534825c
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = 494c8f931029a4919e2dcbc16512a8bf
+Tag = 37098c81475f8a1d8f3b0e63d499d387
+Plaintext = 1f47273103f265f963e498878361c06c01a5ffcfb630a161
+Ciphertext = 5d7aaf1f6b8d5b9f9ce7c54aba7c8b01659c5b9d795cda34
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = 53200bc5d1f1fb0eeff02d2bc42f7d54
+Tag = 9d7317973878957e8fc1fa57a025a3e9
+Plaintext = a38231af405dc7b70c8dbc8cb84e6be8a0dc2e95fddc2ce8
+Ciphertext = e1bfb9812822f9d1f38ee14181532085c4e58ac732b057bd
+
+Cipher = aes-192-ccm
+Key = d8a662ab8449bd037da0346a24565683a3bbbbd1800e3c1c
+IV = 166fb8d0e110124c09013e0568
+AAD = 61e0e28bf344a9a1b04b15156e06498e
+Tag = b0aa1befae96e71b9d221673844b1cb7
+Plaintext = a0d3a94ba6bb3bedf38220d1cba7e91273ad19f9a1c436c0
+Ciphertext = e2ee2165cec4058b0c817d1cf2baa27f1794bdab6ea84d95
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 03c2d22a3bb08bbb96b2811ce4b1110a83
+Tag = 2f9340b0d48a17ae1cc71d7515e61ee9
+Plaintext = 1bd3b5db392402790be16e8d0a715453928f17f3384c13a7
+Ciphertext = ad736402626df0f9393fe4491eb812725ad39d6facf20b5b
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = f390387610741d560325b5d2010d8cd4a0
+Tag = 717bae4c040561bcfcf80fd842ae8dd8
+Plaintext = c93aaa04279e451b6880ed7b7fdb3ca9e80ab76180434937
+Ciphertext = 7f9a7bdd7cd7b79b5a5e67bf6b127a8820563dfd14fd51cb
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 891d7988a56415a7b433f463b1e80eaa62
+Tag = bc9fb15d874feccb6b5f581fa470734f
+Plaintext = 2611612ccb5ffefaa73195509bb52c641472bca0dfd09d49
+Ciphertext = 90b1b0f590160c7a95ef1f948f7c6a45dc2e363c4b6e85b5
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 831c0fed5e600dd82d7d55669262a9a17d
+Tag = a72589ee50d23f925f7998ab3ccac37f
+Plaintext = 08136e946e306cde0544ddc2f3f4a529c89c7b77a5e635c1
+Ciphertext = beb3bf4d35799e5e379a5706e73de30800c0f1eb31582d3d
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 32ca9d412d4ef0e89928496e96c9de7f2e
+Tag = 55c0b608f331dca47c65f5c879f2d532
+Plaintext = 695aaac402942de7d899cc3f741c7fb2b2d8247a7676cf29
+Ciphertext = dffa7b1d59dddf67ea4746fb60d539937a84aee6e2c8d7d5
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 0746b2e6149c7f55854e9ca3e6861bf0e9
+Tag = b039bd916e923e2fc1f7c60eb59916fd
+Plaintext = 8f958d796be0566512f0512dcebd2e12f3160b05b72ae955
+Ciphertext = 39355ca030a9a4e5202edbe9da7468333b4a81992394f1a9
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 0e4cbd1c574d656112bf6e70a8f23347f0
+Tag = ac07f2c0847069fe5be26e623033f532
+Plaintext = 367ecd1b71dfb96a84e2369f28705dfaebf0c73ed35d5364
+Ciphertext = 80de1cc22a964beab63cbc5b3cb91bdb23ac4da247e34b98
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 1a05ff12412bf728497536534c234901ce
+Tag = f4e66a2b210e5a03bb10ff2926ed8a48
+Plaintext = a9ccee975feb10f635d548a8502f7c8b6adbd2be74117257
+Ciphertext = 1f6c3f4e04a2e276070bc26c44e63aaaa2875822e0af6aab
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = 3bd063a51c71fab5aeb47e7f8f958d796b
+Tag = ec90169d0c5c11fff8f255fedb13a99a
+Plaintext = 7df6220599d6235eb450989b6f0cd6c96db62b0d13afc4f4
+Ciphertext = cb56f3dcc29fd1de868e125f7bc590e8a5eaa1918711dc08
+
+Cipher = aes-192-ccm
+Key = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5
+IV = 924322a3ef0c64412f460a91b2
+AAD = f0d334e0a27c3d00d56b15c2ee426e6347
+Tag = 170141cf3f207c4f0fc1b0238477cfad
+Plaintext = 6f65a24344c32debaf9f8c3fa426fe0b139e8ad1c8b1fbbb
+Ciphertext = d9c5739a1f8adf6b9d4106fbb0efb82adbc2004d5c0fe347
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = 68d199e8fced02b7aeba31aa94068a25d27a
+Tag = 7e30b2bcc3f1ea9ec2b8f28bf0af4ecf
+Plaintext = d7a954dae563b93385c02c82e0143b6c17ce3067d8b54120
+Ciphertext = c6cfaa1f54d041089bd81f89197e57a53b2880cefc3f9d87
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = fc4bbe329a86089ebe2a2f3320dad55a9bda
+Tag = 3a6e6844102d6bb86986c030765d3393
+Plaintext = a206a1eb70a9d24bb5e72f314e7d91de074f59055653bdd2
+Ciphertext = b3605f2ec11a2a70abff1c3ab717fd172ba9e9ac72d96175
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = d8741e540330692d83cc806a8ac1c4742be6
+Tag = 3f92a80b1d82f8c1dc32bfe64adca12a
+Plaintext = 56ef76dbec6b8b46f5b7b4e311c0baaa6fcf54c69c0b9c3b
+Ciphertext = 4789881e5dd8737debaf87e8e8aad6634329e46fb881409c
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = c8b1992dfba55b4ab86b480546c861655e1a
+Tag = 2fb48ad162b0c0678674d79d26a6b5ef
+Plaintext = 2729636112f2abe2c76ea5e52a3f80b0f882f0f3b6f7c806
+Ciphertext = 364f9da4a34153d9d97696eed355ec79d464405a927d14a1
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = 347e12eec56e95aafcc7d25bf10fc756b4e4
+Tag = 81c7cd81c974d985bf24b7fe9542141a
+Plaintext = dd433eb7422c7c4dccee57a1679633ced3b5f08df763d457
+Ciphertext = cc25c072f39f8476d2f664aa9efc5f07ff534024d3e908f0
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = 45b35a04d6e2645e9a5aef206ed4e36199c9
+Tag = a7f6a5c04e59896074e1594706ab27e9
+Plaintext = 70523bc397417e09d791a4976960e02636ca7144a5681cf7
+Ciphertext = 6134c50626f28632c989979c900a8cef1a2cc1ed81e2c050
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = 378b48531fe34f55125b2f14f59715dd6ef0
+Tag = a9d16c3ab79276cff345444511940a9d
+Plaintext = 514cb462dd4b117f26cac22062fcbeb353650c71649a7b3d
+Ciphertext = 402a4aa76cf8e94438d2f12b9b96d27a7f83bcd84010a79a
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = 73ed686d6fecdc031cd97653137f269d6537
+Tag = f92bf8aa6facbe6f9607ea02b54a1bf0
+Plaintext = 7f0c2b261db3f3de0ce3a733f4b8c446c374567d96d00379
+Ciphertext = 6e6ad5e3ac000be512fb94380dd2a88fef92e6d4b25adfde
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = 5b0441107e5560be94f030a41cedbdb116d9
+Tag = e4936ee93b5c7a302913292df33c1700
+Plaintext = ebb3e2ad7803508ba46e81e220b1cff33ea8381504110e9f
+Ciphertext = fad51c68c9b0a8b0ba76b2e9d9dba33a124e88bc209bd238
+
+Cipher = aes-192-ccm
+Key = e67f3ba11282d61fe36e38cab7b559c2fd9cbe8bf7eb5863
+IV = a727ed373886dd872859b92ccd
+AAD = feedcc5f8524fe7d49bcd178415b9f4c450a
+Tag = 93426b6193afe765a76b3dec00266e69
+Plaintext = 3216dce3b8b1ce0e79e40fffcac728ab191aaaf319d971d3
+Ciphertext = 237022260902363567fc3cf433ad446235fc1a5a3d53ad74
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 36e15baafa0002efbb4bb26503b7e3b79f6c68
+Tag = b60a77b9d38740356b544b1c0f259086
+Plaintext = 344dc8b6bd66a1fbbe330a95af5dd2a8783dc264d6a9267d
+Ciphertext = 43b3b96aa5a54378f3bb573ffda3e154aa7f425fc3008175
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 712b788f0276e2b5a58be80f9114a12ab2a268
+Tag = 5f750bb4cd42db3038e2c1622b72cea8
+Plaintext = 6d0546d4e95d1cfcb37a8f88a62064f5d95791311511535b
+Ciphertext = 1afb3708f19efe7ffef2d222f4de57090b15110a00b8f453
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 07f77f114d7264a122a7e9db4fc8d091334a03
+Tag = 61e77b59ef7eeeae35bb53bb9543b64a
+Plaintext = 05024ce13b9057dd2c509db7dbcbd5585e4e64a1e2e380ff
+Ciphertext = 72fc3d3d2353b55e61d8c01d8935e6a48c0ce49af74a27f7
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 899b036138cee77cd28382ba27984d858a6351
+Tag = 44a60fdb473098a11b2176d37b2c4643
+Plaintext = 77b8e735b13b10e45e411ab94c6fe1a9eb89f0a7af40ff1a
+Ciphertext = 004696e9a9f8f26713c947131e91d25539cb709cbae95812
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 4b000440a8484a5201cd54aec058919769772e
+Tag = 58d4afc30a7f672ea34e05ec1843d848
+Plaintext = 6b21800ae599a15254bb33f0bb080788fb6e9fa054bfd8b2
+Ciphertext = 1cdff1d6fd5a43d119336e5ae9f63474292c1f9b41167fba
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 73a222e681ed1ca47d92a6dd90625d895fbf29
+Tag = 4ef270e0f3b5e3ca0b8440af65c76e85
+Plaintext = bfa9d9af6e1f32b6626a1cd89b1c32513b5b50a18ddab028
+Ciphertext = c857a87376dcd0352fe24172c9e201ade919d09a98731720
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 7109a3a36b286059bc1a1abb2767c92f884e3f
+Tag = ffb66991b38a0345fbbff5f2362f87de
+Plaintext = c68b1bc0050e19780ab53efbea175634f70a7245d966966e
+Ciphertext = b1756a1c1dcdfbfb473d6351b8e965c82548f27ecccf3166
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = cd15973753b94b77bb4b778de8b3b0cabbde85
+Tag = d033a087c44c2e44adbeb333aa9ded10
+Plaintext = 4256f1c9b64390fe2120df9fd38e497c2903c2ca5679ab75
+Ciphertext = 35a88015ae80727d6ca8823581707a80fb4142f143d00c7d
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = 6e5e0793855f7145e13a5872f563e5ec61cfd2
+Tag = ff9c8713422fe38d5bbf2dedccbffe10
+Plaintext = bb0036b34b0c20094d335a8c74f6b3dea42eeccf4145192e
+Ciphertext = ccfe476f53cfc28a00bb072626088022766c6cf454ecbe26
+
+Cipher = aes-192-ccm
+Key = e0a29a2c7840cf9b41de49780b9ee92d646a4bfc5b9da74a
+IV = fc9fd876b1edded09f70b18824
+AAD = f844684f5404e7d8eedfa20394b40b4f5d910a
+Tag = e75de56eabcf8e02c1a27705adef2732
+Plaintext = 86afa9cdd743916563ebfd3adbdd56e015ea3a4ebc61cfe2
+Ciphertext = f151d811cf8073e62e63a0908923651cc7a8ba75a9c868ea
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 093ed26ada5628cfb8cfc1391526b3bcc4af97d9
+Tag = 6ca0e07e04674f21a46df2659a5905fb
+Plaintext = 37ab2a0b7b69942278e21032fc83eba6cdc34f5285a8b711
+Ciphertext = a3a60b422eb070b499cf6da0a404b13a05cedda549c6b93e
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 7df13c9d2247aa40af7bbe2da98bd366d8b47b43
+Tag = 836597806f5da1d176c745d95c4fa46a
+Plaintext = 93925579b6367ff592ecbd59495fdeccb50f31ea4fa390bc
+Ciphertext = 079f7430e3ef9b6373c1c0cb11d884507d02a31d83cd9e93
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 7f369bbc99b6f08049eeb43566269a174829d4dd
+Tag = f826dda99111691993027628c70ff6ae
+Plaintext = 8363aef9c7c34e1f8149de46c97d5ac79d38c6ed31ab1d12
+Ciphertext = 176e8fb0921aaa896064a3d491fa005b5535541afdc5133d
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 04aa8442179f62babad0c006e36af0c21105f27a
+Tag = d074b018143a7ea1b5369b7f80eae20d
+Plaintext = 17281acb525b13653000ab45d86e70106c10a93c99b18f76
+Ciphertext = 83253b820782f7f3d12dd6d780e92a8ca41d3bcb55df8159
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 997e646014f19a53beab8877ca6022bef23016f1
+Tag = 5db17d3f75214c3cf39858617cfee57a
+Plaintext = 5d48a71557608736eded309027a80349a18e9ce5dee2bc6a
+Ciphertext = c945865c02b963a00cc04d027f2f59d569830e12128cb245
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 60ffcb23d6b88e485b920af81d1083f6291d06ac
+Tag = 9550998376e61e11a5a69e9f8fe1c329
+Plaintext = 6c9d11cfb64d96bfab61c04a25d9e19294fb7330fb4847c8
+Ciphertext = f8903086e39472294a4cbdd87d5ebb0e5cf6e1c7372649e7
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = d574632658bf456dfbb11c2653602ed0f4dae777
+Tag = a1b0d05a7ebc657c3235479893bf7e5d
+Plaintext = 7d41688c86d5e3bc53966810f2299fdd732e3471fb0a88f9
+Ciphertext = e94c49c5d30c072ab2bb1582aaaec541bb23a686376486d6
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = d896ed60128f4bb0277d3af94c5138cf91697aa9
+Tag = 80c98c8959c158ce209aebcbd554f250
+Plaintext = 8c7ae2c3c503e9072d6e04e44c2ea78fd24994503567a136
+Ciphertext = 1877c38a90da0d91cc43797614a9fd131a4406a7f909af19
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = a350ed58c04473e113b9088b1fb9dad92807f6b6
+Tag = 573175f9105cd16ee384465ebb232200
+Plaintext = 49bc9d3bcf3c22daa8cf55c1b59d4bffddc2412d60518e98
+Ciphertext = ddb1bc729ae5c64c49e22853ed1a116315cfd3daac3f80b7
+
+Cipher = aes-192-ccm
+Key = 26d0a3a8509d97f81379d21981fe1a02c579121ab7356ca0
+IV = 8015c0f07a7acd4b1cbdd21b54
+AAD = 1db5887001204194e8b5dcee92c8af8fa5f7321f
+Tag = 2b67e993384f2e7229d1838efd040d99
+Plaintext = 25f3788e0d3dd8f5821faa4e45a9d6b3995fd881f927135c
+Ciphertext = b1fe59c758e43c636332d7dc1d2e8c2f51524a7635491d73
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = 796e55fbe7bed46d025599c258964a99574c523f6a
+Tag = 003c0c3b7369e79339433e1754c0937f
+Plaintext = e8610756528f75607b83926597ef515f4b32a8386437e6d4
+Ciphertext = e0a3d5f43e688ce104f4ae1a4fcd85500aa6b8fdbcd1b8d3
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = 5170836711fcb1a350b087907d8a17c7637aa1595b
+Tag = 120a7f18d021833b167bf330c4858239
+Plaintext = c61b0c1845fa9b2e0013b3fa9a8cb4f4fbbc6846f63ed180
+Ciphertext = ced9deba291d62af7f648f8542ae60fbba2878832ed88f87
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = 2a68e3fe746f593c1b97cb637079c3e5ee352c107a
+Tag = ca9698d9a88e892c364e57dd35c2f17a
+Plaintext = 10c654c78a9e3c0628f004b061e28c39a3c23e7250f53615
+Ciphertext = 18048665e679c587578738cfb9c05836e2562eb788136812
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = bf38ca0e89b8f5ccd29387f7f193ab5a967caa715b
+Tag = f3839d6f7e20a2e343f4c4da9eb9be13
+Plaintext = fa3a959fdff853c39f76da626094a1ea6dbc78bd2f091a79
+Ciphertext = f2f8473db31faa42e001e61db8b675e52c286878f7ef447e
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = bee00f2f75a4415ce993d2d14a6d8e01d1d59a48f6
+Tag = 6630bfb7a2a2441e020efdf36274b72f
+Plaintext = 76d12e3c4c5d990bf563c60aa4999e52998d887f97477f6d
+Ciphertext = 7e13fc9e20ba608a8a14fa757cbb4a5dd81998ba4fa1216a
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = d5b614e4e8f72a5d8b1ec2b375da5dac64c2cc30b1
+Tag = 866bcee343ec5aae61f9effa19b99d3b
+Plaintext = 693fae7af84aa397f0b2baaed9b3c7953f75e7424c49b634
+Ciphertext = 61fd7cd894ad5a168fc586d10191139a7ee1f78794afe833
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = 33f11aa36d8ab0fc53486839a576b31ee915dbd769
+Tag = 0331b60eb252f744a06b4a95aa9f4e7c
+Plaintext = 56ce9a09f38127b14dbbdcaa59f363c92a3b9843ad20e2b7
+Ciphertext = 5e0c48ab9f66de3032cce0d581d1b7c66baf888675c6bcb0
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = f40bce1a6817b29b9e8b56f214fcca7dfde17e7ee6
+Tag = 4153778a644cb2469cef3ad125e257bc
+Plaintext = 5cd8986e974d09ede34ba68fd81d6109a64092e7fbbaf87d
+Ciphertext = 541a4accfbaaf06c9c3c9af0003fb506e7d48222235ca67a
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = 53c457d8d4d4ab95ba116c28b82c16743cb09de9fe
+Tag = 7013e1c34dbc5efc7bcd4f8e52797644
+Plaintext = 9c3c610f204d98702dd91ea28e0cc14830b26bb5e2ee0349
+Ciphertext = 94feb3ad4caa61f152ae22dd562e154771267b703a085d4e
+
+Cipher = aes-192-ccm
+Key = aac60835c309d837aacc635931af95702a4784c214283ebb
+IV = 0e20602d4dc38baa1ebf94ded5
+AAD = c7acf1b17609dc336df1006ffac6497777cdfd497c
+Tag = 66aed667c761b7dea44822e30cff671f
+Plaintext = 90c5dd9db0316dac89db18f70491bdf0a06a6a7f72b77d9a
+Ciphertext = 98070f3fdcd6942df6ac2488dcb369ffe1fe7abaaa51239d
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 61dafc237cb52f83ab773ba8a885462b6f77d4924611
+Tag = 1bb089af0245792c16e6320cf5ffa19e
+Plaintext = 576b069ae2713f53d2924c1fd68f786cb2eec68892f9e1be
+Ciphertext = ce06b3d09b02921f290544032a081a776661294004886728
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 87e49b8164e7052becfa0c966991637b38df833fc5f7
+Tag = 3cec29bd5df92363d6bb75456f5cd32b
+Plaintext = d7eb0d7dd737805cd3b8dbf451aeea2fa1f6a96eb58cb428
+Ciphertext = 4e86b837ae442d10282fd3e8ad298834757946a623fd32be
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = d302a518d7c625756d3e4c8cc2b1d973a19107c945fc
+Tag = 01ca82cddb78a2fe3904d1d8bf6fe5b2
+Plaintext = 77d8c9e6321314524afd05b7ad599c29f4eedda9e9f0763f
+Ciphertext = eeb57cac4b60b91eb16a0dab51defe32206132617f81f0a9
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 6566bb616a94bb03df5c26b722bcd38d516285c5f6c1
+Tag = d095ad121f0f76f07b715cad996def52
+Plaintext = abbf28b3ae164051648293d0b94e11f5af8468450005c7c0
+Ciphertext = 32d29df9d765ed1d9f159bcc45c973ee7b0b878d96744156
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 141be3601e38185a9fa1596d2ee406415c9673af32f5
+Tag = 8529ec8f477462dc2409482c3479756d
+Plaintext = b67d50110f844b36a00d352123012a1123c7c3cba959dc48
+Ciphertext = 2f10e55b76f7e67a5b9a3d3ddf86480af7482c033f285ade
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = a2969243b0955402ab45a430fef2ef9e0c025006732b
+Tag = b14fe8dbb3c361ea61d7b44e689a1c48
+Plaintext = 2a63f7b09b43fee65738e8115bd8419b3ef3e8f86eca707f
+Ciphertext = b30e42fae23053aaacafe00da75f2380ea7c0730f8bbf6e9
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 87faef55c54250c30232ccaf5efa1ff41b6243b2a5bc
+Tag = 54f0659fae291f943f2f3b33688602cb
+Plaintext = 59dad755af92c29522da4348ab9b3037fe87004f5fa1394a
+Ciphertext = c0b7621fd6e16fd9d94d4b54571c522c2a08ef87c9d0bfdc
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 5d895fb949344e603ce5de029842b20d2bb614ecbbb8
+Tag = 3af4e3a7a20390a8da264299712a34e3
+Plaintext = 64d8bd3c646f76dc6ce89defd40777fe17316729e22ba90f
+Ciphertext = fdb508761d1cdb90977f95f3288015e5c3be88e1745a2f99
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 74cc8da150b0bacdefa8943900b4ea047611d96be70a
+Tag = a7f79d2b5a9bde5bd453bc8a03e971d8
+Plaintext = 0c3c9a634a000f00be003846eac7482e303a5bef3a70fe75
+Ciphertext = 95512f293373a24c4597305a16402a35e4b5b427ac0178e3
+
+Cipher = aes-192-ccm
+Key = 671544bf2988056f7f9ccd526861391a27233793a23f811f
+IV = 0a259148a1d081e0df381ecd0c
+AAD = 65f6adbaaa803dbad5ba9cb6d231314d55147cc61399
+Tag = ffccebfb8c833833db40e98a1950fb70
+Plaintext = 712c788928c8a1562bc1f3f0eb1286e15c3405f6a6fa0443
+Ciphertext = e841cdc351bb0c1ad056fbec1795e4fa88bbea3e308b82d5
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = f5629ca0eea589f6cf963d875a7d2efb656983f2dd2231
+Tag = f7ec84dd992fdf98514f845dac8f656e
+Plaintext = 44dd098b1f869d670a8a841900c4bef023a1946a0c278354
+Ciphertext = 6b38ca85450e05e7b9362ed7e6e291a130ff233b5a561cde
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = d43d7753530a7280b76221906dca85d396b6cf05125018
+Tag = 3613ed15d527d9dc58ab6893e723db58
+Plaintext = cea19562328bd1fea889f575db6a28a14b7d06fb9f9c98bb
+Ciphertext = e144566c6803497e1b355fbb3d4c07f05823b1aac9ed0731
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = 75650ce366757618af20205b69af7e5d4e82c398c00101
+Tag = ef8728d1bf3a2d93db3266bafadb7c26
+Plaintext = f0641f595b791edd860977fcf699688587a354e053e9c7fe
+Ciphertext = df81dc5701f1865d35b5dd3210bf47d494fde3b105985874
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = c00f1b8066677c63e898fddfb8a1b482b536963da0628d
+Tag = a5bce94d7564d297fe87730f1a36acf4
+Plaintext = c7486a084f8475e6f5138e8d6e9f42a1de90f05aa88a362d
+Ciphertext = e8ada906150ced6646af244388b96df0cdce470bfefba9a7
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = 5a89ab6b26b2ca78f98a8f8409fe8008b97ba9ef185d41
+Tag = cd971b07fc14c512b8df6dd964b129d0
+Plaintext = 091ef698e16dc43a11d3ea005d5a5cdb7f1bdb5665a6c81e
+Ciphertext = 26fb3596bbe55cbaa26f40cebb7c738a6c456c0733d75794
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = 5d24d80f22afe713c4076c200c1bab36917907fde7b6d3
+Tag = a192b781dc94448d4a0f6a439a716339
+Plaintext = 62f204394b367c4410746001e02dfd171858396568fdd43b
+Ciphertext = 4d17c73711bee4c4a3c8cacf060bd2460b068e343e8c4bb1
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = 4a47a82b999a2a739959f153a091a65c4d7387646da66b
+Tag = cade9533b272e0a3edeba68362b057b4
+Plaintext = ac1cd5ba4997af91dbd74aee7730f9ee92cf8a360ca96a8a
+Ciphertext = 83f916b4131f3711686be0209116d6bf81913d675ad8f500
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = d9fc295082e8f48569eb073ac1b9566246728fc62ccaab
+Tag = 5d68df8ff28345be4d83541a72071059
+Plaintext = d0a249a97b5f1486721a50d4c4ab3f5d674a0e29925d5bf2
+Ciphertext = ff478aa721d78c06c1a6fa1a228d100c7414b978c42cc478
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = 720a9dc3e33ac080775a06f67f4a6591c37d0e101944a0
+Tag = caa7ec8892be6a18458c663665495035
+Plaintext = 77fb98f24172f5d5edadbf466ee910855a71d46090b789ee
+Ciphertext = 581e5bfc1bfa6d555e11158888cf3fd4492f6331c6c61664
+
+Cipher = aes-192-ccm
+Key = 90e2c63b6e5394b1aeec03f95a9d13a01a7d4e9d58610786
+IV = dada5465eb9b7229807a39e557
+AAD = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903
+Tag = 862fda880e45e891a3a50da7e14344c8
+Plaintext = 77fb98f24172f5d5edadbf466ee910855a71d46090b789ee
+Ciphertext = 581e5bfc1bfa6d555e11158888cf3fd4492f6331c6c61664
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = ad6622279832502839a82348486d42e9b38626e8f06317c4
+Tag = 5623d15b24184481eadc63bb8c878fc4
+Plaintext = d7c837971b973f5f651102bf8d032e7dcd10e306739a0d6c
+Ciphertext = 4709600418f2839841e6d126359f6982bdb53acc7ff20963
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = ad4833aa53218949cfd724814a43889a74a2114bbef4cf37
+Tag = 614c3e546273f0aeef207bd3f4d32fca
+Plaintext = 7d672bccd0fb01ce79320ed61779146aa432038daa13cb41
+Ciphertext = eda67c5fd39ebd095dc5dd4fafe55395d497da47a67bcf4e
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 54a723826086c7175e8fdc854b62d780de6ac1f90b57dd3a
+Tag = 13c6395ce9aee2e22ac0606beb140185
+Plaintext = 0e1b73df74982f535a5fb08bc13d22515ee10969efe033bb
+Ciphertext = 9eda244c77fd93947ea8631279a165ae2e44d0a3e38837b4
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = bec02d7df4cc3deefdd7e7d3ea82d381c870ad46bc06d64f
+Tag = 61e4f02150bedd86dfa49f52b214239d
+Plaintext = 9a55aff269b180118ff0ea99e851c7474d19d23e641f16a9
+Ciphertext = 0a94f8616ad43cd6ab07390050cd80b83dbc0bf4687712a6
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 1b8090d712e0ec95a01bc3aeb6f5230c67c355e0ed68043a
+Tag = f0e82b9f04bfc0cc0ba432b5135450c2
+Plaintext = ff19294e8faed8353dbcab0b146e2ef928dd2680833424bd
+Ciphertext = 6fd87edd8ccb64f2194b7892acf269065878ff4a8f5c20b2
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 5ed0b9f25d07b26717cdcb2507bef9d681ecd9389831ac15
+Tag = 2e64c82b60880c5c7506321a1060a481
+Plaintext = db1eba6ac4a79aa1d97838d263c7c4ffa7d354770e762805
+Ciphertext = 4bdfedf9c7c22666fd8feb4bdb5b8300d7768dbd021e2c0a
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 55f16fefaf2168aebc61b5e01d9e1f7bfe215eaaef118974
+Tag = 7152f64dc993b36ad9d5d12bb52b1ad5
+Plaintext = 012d45168505ca9fde5aed123875639a207d473b993dc7b8
+Ciphertext = 91ec128586607658faad3e8b80e9246550d89ef19555c3b7
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 9893bf14fd3a86c418a35c5667e642d5998507e396596c50
+Tag = 3e5c69256b6326ebb7ee6e677d396765
+Plaintext = b205f26d6c8a8d6085ab28d595703cae046f96d82093082b
+Ciphertext = 22c4a5fe6fef31a7a15cfb4c2dec7b5174ca4f122cfb0c24
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 244b840085bda9576c8424bb05a925a6b09cad2d0528ab8d
+Tag = 2083dac565c7a63908f0022e2867bb68
+Plaintext = 549ba26a299391538b56ce4bd71dbbfd96995836f8915ca5
+Ciphertext = c45af5f92af62d94afa11dd26f81fc02e63c81fcf4f958aa
+
+Cipher = aes-192-ccm
+Key = 13cdaaa4f5721c6d7e709cc048063cfb8b9d92e6425903e6
+IV = f97b532259babac5322e9d9a79
+AAD = 9e8d492c304cf6ad59102bca0e0b23620338c15fc9ecd1e9
+Tag = 68242fe32958ea32e670ae1b3543974f
+Plaintext = 9e9dbd78a1066800ae33253be6104015158a0187e4f38116
+Ciphertext = 0e5ceaeba263d4c78ac4f6a25e8c07ea652fd84de89b8519
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 69a9dd9ac8be489c3a3f7f070bdaca10699171f66ab3da9351
+Tag = 46c7246bd3130803bf8d703ef5bdf15c
+Plaintext = ba1785a149cb8b69a4e011c11a3ff06f6d7218f525ac81b5
+Ciphertext = 89ab2efefa8406336d9e2245199fbc9454f0ef650b9ed0f4
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 0c39a72f0f38d2713c164b0f870646fc65b9838a322ecfddd0
+Tag = 096a6a4422e582c5d02973952ac80e5f
+Plaintext = 263dc4fb5cd8798ce0f183a816e51fafba167533dde1bf96
+Ciphertext = 15816fa4ef97f4d6298fb02c15455354839482a3f3d3eed7
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 911d9f5c4c34c2f4b69be1e253d43fe729e2ab2622130394b1
+Tag = 5965f6df4332fe7a2cdc4d1b80e28a34
+Plaintext = 7b5da2c283116713f3d80c7907114270964541e03ab80d50
+Ciphertext = 48e1099d305eea493aa63ffd04b10e8bafc7b670148a5c11
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 8a961df9c23f6d5ecdafa94c61164a22f460a1bf7415258d39
+Tag = 18bed174081b2170ffc6ab53b54c9ddb
+Plaintext = 541a2b3ee25022c92fdc6783a6cbde90680ad3dc41868e5f
+Ciphertext = 67a68061511faf93e6a25407a56b926b5188244c6fb4df1e
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = cac7a248a4d4e96a9733627e247234995d6aa57e491498118a
+Tag = bac3d3a2b9ef6d4c8715f9a5c6fe8245
+Plaintext = ebb2e893da9f32c363f98bc76fd14eda59e7cc620070f6d3
+Ciphertext = d80e43cc69d0bf99aa87b8436c71022160653bf22e42a792
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 41eacf70d05a6d0cdbdd38f197a52987def8fde37f332eebd9
+Tag = 7f9610c82fe9a7c78e8f1980e886b446
+Plaintext = 199cca0d0e1c70ec405d6816cbddc69f8ada624f2c168891
+Ciphertext = 2a206152bd53fdb689235b92c87d8a64b35895df0224d9d0
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 78b6ed20ed85337c969618bd41917cd85c37e7c35c3a12e25f
+Tag = aab366637ec41d0bf557f578be424a8b
+Plaintext = ca481f557306f9ce386edd0cfde375a550cb5b574be524f7
+Ciphertext = f9f4b40ac0497494f110ee88fe43395e6949acc765d775b6
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 87faef55c54250c30232ccaf5efa1ff41b6243b2a5bc93e7cf
+Tag = e57a5b3ae26469d229425f887ad5a2a1
+Plaintext = 6f1b4ff66d3aec7b0c0d9e202acc52722e15bca0983291e0
+Ciphertext = 5ca7e4a9de756121c573ada4296c1e8917974b30b600c0a1
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 7f19ac3e53a629a2df1cb56d68fde0c80a46be40a996830e2a
+Tag = 6ce4fe492062f74bff4c3c0e9ea849a4
+Plaintext = 7533c88ce55c2243b64b6c5bd01aed4dd6ac8bb9fd333e06
+Ciphertext = 468f63d35613af197f355fdfd3baa1b6ef2e7c29d3016f47
+
+Cipher = aes-192-ccm
+Key = 90851933d4d3257137984cdb9cba2ca737322dac4dbd64bc
+IV = be02df3a840322df8d448c600c
+AAD = 0516a69bfd8785ad001367b51e5410b75c11b761be08b9eea5
+Tag = ad47ffc17b871f530f62b9f9aec98509
+Plaintext = 19ea09a9bfd10db2a74e398859d8f4831fa5749767773acf
+Ciphertext = 2a56a2f60c9e80e86e300a0c5a78b8782627830749456b8e
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 09fc21ac4a1f43de29621cacf3ad84e055c6b220721af7ce33bb
+Tag = 101a34c777e918e16186fda05a386572
+Plaintext = b4da43ebfe9396b68f4689fba8837c68d0064841c6ddd4a7
+Ciphertext = d40725397229021a18f3481e3a85f70445557bb2a85e4ae8
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 10f0c45d06a138a964fb11b2d450620a2977bcd2952afe371cad
+Tag = c1e79234882846d916dabae40b1bd055
+Plaintext = 7b628930d44e22907277db057395601b82b65479fbd59613
+Ciphertext = 1bbfefe258f4b63ce5c21ae0e193eb7717e5678a9556085c
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 64dbb170a037b36beed28a2637c87830e2b23f8eea6cd9a7331c
+Tag = e35499e3c09dc384eb41344ee8be3769
+Plaintext = 9db30b669fc5d25f05e0dc708d597da6ddce2dacc85ae99c
+Ciphertext = fd6e6db4137f46f392551d951f5ff6ca489d1e5fa6d977d3
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = c47de6608546a02c6eebd6628c9123f6936c0154d3df52a367e5
+Tag = d605189608ce40b237dde7bed6fde487
+Plaintext = 62036cbed3666d85624d3dc9c1f437454b9ab5c03ce0de92
+Ciphertext = 02de0a6c5fdcf929f5f8fc2c53f2bc29dec98633526340dd
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = bab7e36098d59d3a31d7784d549aebfc6938bbd0612c85c0edb7
+Tag = c31f69c847440be20bd08cfef330002f
+Plaintext = 5c9bc739f6b6fe4214f3c6aad307d1f208892d79de010e37
+Ciphertext = 3c46a1eb7a0c6aee8346074f41015a9e9dda1e8ab0829078
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 8a9716135fa38c250e249f6712f7cb3ad9210d7278b53d599df9
+Tag = ca83622b127fa50fc9637998c0ddd44d
+Plaintext = 0df109298083d3896214b84ff6edb11e9cfdbd88f5702839
+Ciphertext = 6d2c6ffb0c394725f5a179aa64eb3a7209ae8e7b9bf3b676
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 2d52447d1244d2ebc28650e7b05654bad35b3a68eedc7f851530
+Tag = 81e738b9e4b0dc7b7a39eb7d03adc64a
+Plaintext = 518f651f6d82f670b63767ad8476ed8fc24df12a45110611
+Ciphertext = 315203cde13862dc2182a648167066e3571ec2d92b92985e
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 3cba0fd2bb16ae1d997cbe659a2dd101885c97f2322b0172b5d6
+Tag = d298c05b1d2e597f44f8621ecd11ed16
+Plaintext = e91a694bea2d351928b6098660d49f382c087f6777de159c
+Ciphertext = 89c70f996697a1b5bf03c863f2d21454b95b4c94195d8bd3
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = c7f93152016bba584dadc6002ec493a46305726068886d2340da
+Tag = 5fd5221fceecbf0dc7211a1aec06793a
+Plaintext = 2d14792ed349a878b2b879e7fa5f438a50e36947ce827e73
+Ciphertext = 4dc91ffc5ff33cd4250db8026859c8e6c5b05ab4a001e03c
+
+Cipher = aes-192-ccm
+Key = 5c5d02c93faa74a848e5046fc52f236049e28cd8096dcac6
+IV = 54cbf2889437673b8875a0f567
+AAD = 799cac048eaccded37ca6a70dd89595e1ee04606212da5572679
+Tag = 5c25f00b862b49fcfe8447949f39787c
+Plaintext = 315b8d95938d304015bbc94ea03c21f6dc25c90f991ba680
+Ciphertext = 5186eb471f37a4ec820e08ab323aaa9a4976fafcf79838cf
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = c37fdf7449fd7e943595d75e977089c623be0a3926e63fdbbfdf4a
+Tag = a461f44dac1112ae3f9c65671a931d3e
+Plaintext = 0f960a89a7e806f8709047cb7a2e7c4211ad724692c88a05
+Ciphertext = 3907880d25f910eab12dd14e704d1b33ea7c453634d54da2
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = 85f647d940a6d1acb6b7851912f807063515631eaabaa019dcfb99
+Tag = ed15db6e142ee07b59eb5b0ad3a59194
+Plaintext = ab40a4baa39b0e568bf2193fecbc36b84c76bb50523b2912
+Ciphertext = 9dd1263e218a18444a4f8fbae6df51c9b7a78c20f426eeb5
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = 79ae14843b2e7ccf0fd85218184f7844fbb35e934476841b056b3a
+Tag = 203f11f66b74366caeca8dbded2bf17a
+Plaintext = b74c06d9077c568762796d5be14f3563e7205a6e9bc65bcb
+Ciphertext = 81dd845d856d4095a3c4fbdeeb2c52121cf16d1e3ddb9c6c
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = 542d86fd7ff591f97e6926a090553538bc3b8a6bcd45f2e29c7d9f
+Tag = ed925fb9a4cf6b6bf17f72ab044653d1
+Plaintext = f2179beb5635a6d8a8340acea0ffcf4428e5de1306a8c12b
+Ciphertext = c486196fd424b0ca69899c4baa9ca835d334e963a0b5068c
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = 4392c3043287dd096b43b4a37ea7f5dc1d298b0623ccbf4fd650a4
+Tag = d1f677deca1bfda83c1b9223aaaedbfc
+Plaintext = d1a9e4593bc3d02c407e84a1736e587c1819c72195a07d57
+Ciphertext = e73866ddb9d2c63e81c31224790d3f0de3c8f05133bdbaf0
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = 966954582e78e99ba68d6ffaf794b55a82325834ec4f373b2bd227
+Tag = 12937871932a7ca3e1e27a90a7f73694
+Plaintext = 15b94910853a8f23dfb8b31c0262b8461f777075cc0937e9
+Ciphertext = 2328cb94072b99311e0525990801df37e4a647056a14f04e
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = b7aca715dcc402565cb711b001f21e8e95ec54c4afab2e2dcc8a2f
+Tag = a0464ff4ddeccbd523a5ed3b32337f7c
+Plaintext = fd1681cc306518bf77766f55226afac3eb21e31ed897075c
+Ciphertext = cb870348b2740eadb6cbf9d028099db210f0d46e7e8ac0fb
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = 290a36f7daeeeafca4431446b396dbec0bea0a1f6f081418811656
+Tag = 2f68ed5e44a71c5ba8bade07b7bf5495
+Plaintext = 0804fa48fc76f98bb021e3501bef8875b64a3b508adf8594
+Ciphertext = 3e9578cc7e67ef99719c75d5118cef044d9b0c202cc24233
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = f0739a855422310a21ed863376bce9d75dc7c687b9b535cb7a05cc
+Tag = 3b5dc1fbe32743e257b7c1c9d624adc8
+Plaintext = 4f5c6d80a3955f12f4d2594e02a045c42fabb11d90817fff
+Ciphertext = 79cdef0421844900356fcfcb08c322b5d47a866d369cb858
+
+Cipher = aes-192-ccm
+Key = 0234dae5bd7ae66c67ff0c1a3f1a191a0d7bceb451bc2b7d
+IV = 16d345606a315ad2406abbcb43
+AAD = ffac0edb0b62977bb5040e4128a48deaf711f5e6a84d8f677341f3
+Tag = e53b654de1976294897cae0476ac6248
+Plaintext = 5c29c458212d010a0d9c5a547aba1138eb4ce94742fef01e
+Ciphertext = 6ab846dca33c1718cc21ccd170d97649109dde37e4e337b9
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = 511c6924fa96db716f6b053b7a48aebdc1504145a56cd02d6be2590d
+Tag = 82c560fede4741e2fd3b54b3a48f3e38
+Plaintext = 0c0663dd69ccbffbbd0c8c2e9473d0354451ae7a20fa3695
+Ciphertext = 19f2745df5007619c79c84d174e4521b942776478a0601d9
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = d9ccd93317441e9d6ccc358f31e7e2ccef8c921b23d742993eff9d53
+Tag = ee82d927a2aa678e792acdeb615409f8
+Plaintext = 34a882834172924d39d2df5d637d9d273a99a9222971701c
+Ciphertext = 215c9503ddbe5baf4342d7a283ea1f09eaef711f838d4750
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = c268d65f7a7b30d3d198b2045fc8d1db7adda56604fa567d8855d1a5
+Tag = 7a48226389d24ed3ec3da2da1a9bdf7c
+Plaintext = 5b7450b73d68de079e92bba56c7860f11126b8fdedd3334d
+Ciphertext = 4e804737a1a417e5e402b35a8cefe2dfc15060c0472f0401
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = 4c2b6815156f0643b4573825e28b9f2a668a4976e3342884f48bc310
+Tag = 16fe6bd83993ccbdd50e1ca061f4845f
+Plaintext = 140c6933248f052e05bd4a36aec185ee86730108cc2989b6
+Ciphertext = 01f87eb3b843cccc7f2d42c94e5607c05605d93566d5befa
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = f11c873354b3c0cff2c8f8010e9e364582b9c05c62efdefbdcc2e1c0
+Tag = 577c5893cb3896400012e48f5b190b73
+Plaintext = 2a083de317380d94dd991349a7b8761c7c98013b1b0227e0
+Ciphertext = 3ffc2a638bf4c476a7091bb6472ff432aceed906b1fe10ac
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = d0a056754098d7f7ef2f639d61ea3d2b9cc936c48a1b2c5a9e96d169
+Tag = 80c80101fdfe6dc4cfce080bf921582e
+Plaintext = 02769283d5a06c363c2cc66c09b1ac954134e3ec7df773f2
+Ciphertext = 17828503496ca5d446bcce93e9262ebb91423bd1d70b44be
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = 56de0e55653b9a04a3ded71c31f8807c3c8dd96bc82892e4acccef30
+Tag = 122dfc20e3088dcd33b6706a0c1fdfa8
+Plaintext = 4890404bc5b24822b4cf7a2fe28abc52fbefb919ae0629ec
+Ciphertext = 5d6457cb597e81c0ce5f72d0021d3e7c2b99612404fa1ea0
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = 794a86f5b20d344ad86fd5523d08f1864737be57731440c29aa6b425
+Tag = 28f0a78ce798448529afe26eec875aa6
+Plaintext = 161f8501f59338f72026815c77cad6d8d581859192cd5644
+Ciphertext = 03eb9281695ff1155ab689a3975d54f605f75dac38316108
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = b1eafc03ea2fa3e9e3842a09a225e83055de8a1f412badd6fc9ead12
+Tag = a48856a266c0d404474316f418f8f4e4
+Plaintext = b3f38aedbf08dd7ead9d402c5aaa1ec9279c7e4bfd4a2967
+Ciphertext = a6079d6d23c4149cd70d48d3ba3d9ce7f7eaa67657b61e2b
+
+Cipher = aes-192-ccm
+Key = 6351a67fd6daabd2fd49ee944dd41dd37301f958dd17fcc3
+IV = b8d517b033754058128d13d11a
+AAD = 8fec99f1be0e69267620c0b934bf984d60c1437f74c6ac19610fe188
+Tag = 6412292d8015285efaa6f1154580eb57
+Plaintext = 5c09e2a6a055fe9c21e06e5519cf56b8e2e7fb44094e79f9
+Ciphertext = 49fdf5263c99377e5b7066aaf958d49632912379a3b24eb5
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = c95a86d52088a8b0107cc5b437a8938b2c9e74e46e2e03bb9bceecdbe3
+Tag = 811020480e834f6fe55900a162a4e61a
+Plaintext = 5bbe9c1fb2563e3e82999fe097b28da4dc6ff2e020f3b4f3
+Ciphertext = 6d5401db42b5c48b79203b6ad82806d7460ac4c82ad0809b
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193dfa755a5943
+Tag = ba9827513c7f1de970d316b6f81c109d
+Plaintext = 8a85a9b32a323c6af156a3fa2f1448b6387cc3660aa8a0f4
+Ciphertext = bc6f3477dad1c6df0aef0770608ec3c5a219f54e008b949c
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = c834096e059ea73ddc90b0c982f9a3a31bfc6b1b81a03f9d41c9c741e7
+Tag = c9d79dd3255a8323f8229ac1c6d76ae4
+Plaintext = 1e02c13104937fe084b18eba1ea8951dcc5e75b692937dea
+Ciphertext = 28e85cf5f47085557f082a3051321e6e563b439e98b04982
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = 9249022bdead3d86ef5bd03acf053132d08663ba1f2426e19c126b22e9
+Tag = 425dc81f93257ae8399fc2d48b4a7685
+Plaintext = 3225570fb15ae13a13c71e364ae9a9fef03d1c9a7fa5dfa0
+Ciphertext = 04cfcacb41b91b8fe87ebabc0573228d6a582ab27586ebc8
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = 3c3a92c4ece49fb9f84243d7c1bc91f595fce118305a758c83985c34b4
+Tag = b595003c58e69600c2a3b9ec45c0e15a
+Plaintext = fa0a458174537ddba25708b8d0c22d5517d57b122517b0c9
+Ciphertext = cce0d84584b0876e59eeac329f58a6268db04d3a2f3484a1
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = b49b845ccf76acf508f9db8543c73375d530d91f3b0e4ed70decfd2c2d
+Tag = 0da009261c43c6640303696655e2981f
+Plaintext = b7fbdaeaa3ee1d0bbf5ec47898b069ec4ba6a140a3e83996
+Ciphertext = 8111472e530de7be44e760f2d72ae29fd1c39768a9cb0dfe
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = 3aabdf589eeb1709bb3d60b08bc71eaa3ffeba4e2903a5dbd8339aae85
+Tag = dfdcdbd4ad711c493d3176f032a02af0
+Plaintext = 9aea86b9fbd9bd4504ee2e25054942b33d3cdbd84215db7e
+Ciphertext = ac001b7d0b3a47f0ff578aaf4ad3c9c0a759edf04836ef16
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = 6a79879cd62bd1dbf9609897d2ebf2dc4dda43cc15fcb241aaa0deb4b3
+Tag = fd59b45c05873c670f5f8bb47732d59f
+Plaintext = 3a861638ccd6591e51e2a525be59447e4a28bab32e36a5f3
+Ciphertext = 0c6c8bfc3c35a3abaa5b01aff1c3cf0dd04d8c9b2415919b
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = c5b6ca474eb251817ae4d2f47c0632c381e222aae3b6f585a0dcae120a
+Tag = 1572a24bc00b40a6b4b172b3648142e7
+Plaintext = c7da4e9ba6e5758be726e6e227d7bddb0332228f7e3ecb6b
+Ciphertext = f130d35f56068f3e1c9f4268684d36a8995714a7741dff03
+
+Cipher = aes-192-ccm
+Key = 9a5a9560baed3b8e0e90b92655d4e5f33889e5d7253d9f6c
+IV = c0049382cdd8646756d4e6bff5
+AAD = 64a96d191f1d5f95f5fed6259e33e7206adc07b0279e16cb453a9c6438
+Tag = 828bc33396179ac39ce0027a1d62e0fe
+Plaintext = 2b9347d3e195152dce22afdb92acd179eb484872285704c3
+Ciphertext = 1d79da171176ef98359b0b51dd365a0a712d7e5a227430ab
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = a08763ca936abdeece06467bef8c3c47c3a473636a039d4db540c867d3e3
+Tag = 95aa6b99d3f894d3790c2aa2dae1ba2c
+Plaintext = 1fada8f4c7daea0d1c370184c169485b80a278708ed41451
+Ciphertext = 680dd22f16a1290bde42c9792dfa997aed24d5bd2265b6e0
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = 19508a6c83b992c660a1a28597e07c729ea2ed39401aadbf9d7586b5720d
+Tag = 2d9d77109f4597e9c4c8cf7023dc5f3b
+Plaintext = e9f1f2cf0b8d563e2d20f39f9f464a808b136dba364a6446
+Ciphertext = 9e518814daf69538ef553b6273d59ba1e695c0779afbc6f7
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = e5929c3b5d68a4c9fcf1168ea35bf8c0bf3043cb1ed54ff301578b3b7266
+Tag = b2544ecc3c7d5accd22ac075e7b44d5a
+Plaintext = 07a74c3b874849ecbf013713b80a84337c90b690cea0b837
+Ciphertext = 700736e056338aea7d74ffee5499551211161b5d62111a86
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = caa5cc5d0d87680eafc29429bac55c9e33167d485789c7c124b5c57a1ba8
+Tag = f1a8a1db25de0fab7cabb11a18497584
+Plaintext = 4255f2cf90f0d15e9bead4be799165c57f7225980713d609
+Ciphertext = 35f58814418b1258599f1c439502b4e412f48855aba274b8
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = f61cf7ae23a66777bd3fabc3d542feed2b00c6d4f46a772fda11b5214551
+Tag = 5a9718ed0257a50e38de86154054fc3a
+Plaintext = 70b1e2e4cf260b108f5a52d0d8234838ffd6ffe7b4acd78d
+Ciphertext = 0711983f1e5dc8164d2f9a2d34b099199250522a181d753c
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = 85f647d940a6d1acb6b7851912f807063515631eaabaa019dcfb993e86f4
+Tag = 550d1acca34c28ba8a3b890bb0542b23
+Plaintext = af4be10b3a59ea99dadc75fbe5651f6f7630852bb556aa39
+Ciphertext = d8eb9bd0eb22299f18a9bd0609f6ce4e1bb628e619e70888
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = 296cd04c4d9ab493def7aeb6841a45309e777028868efe45166235c56b2d
+Tag = a268dc1596a7855639c63fa76ad8479b
+Plaintext = 72d5663727592f1bfc9c65be83f4d3508126fecc4e34ae72
+Ciphertext = 05751cecf622ec1d3ee9ad436f670271eca05301e2850cc3
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = f380ca0a26a94adcf2c1ce26d226d3bf520268c72412e58a71acd9a66d00
+Tag = e3416c75fc28924a21cc123e62a7894c
+Plaintext = 3e2ccce03c10ce1527ef8e002adb265edba5779fbd4fcaf6
+Ciphertext = 498cb63bed6b0d13e59a46fdc648f77fb623da5211fe6847
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = 8825532a31680cb3b5bdb027802d2d8718755e135367e0c8c88e21288311
+Tag = ff1a47f23d08485951aab18b393584ef
+Plaintext = a18dfe7f2d7bbaf316366f67445170afcbe18e2a1de1e947
+Ciphertext = d62d84a4fc0079f5d443a79aa8c2a18ea66723e7b1504bf6
+
+Cipher = aes-192-ccm
+Key = 3e61094c80df0053e86d43fccf4e1d3ee2cdb862d3237b0a
+IV = 63f00b2488809fdc49ca5f05d5
+AAD = f768375589b687fb17c56673af4263626da69eb991007d94d4f5a163fd05
+Tag = 7d024456bcb69a4f77008773a3f48805
+Plaintext = 17ca72a440c944fefd6c08ecc3a8ecb54d96b9cad9d2aa4c
+Ciphertext = 606a087f91b287f83f19c0112f3b3d9420101407756308fd
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = c5f1a26351e53e6509c8bbbed03c42c23ad81c65fccec7ffa1cb494c7f1fc4
+Tag = a260b5ea3b047020b73b5bafa17e5084
+Plaintext = 0b6de49b530703affc94010c2b793ddc6de0c44d48037ff2
+Ciphertext = 56b02fea595cc24e798691ae905be3d466ca68ca744005db
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 89899be18b4c389afa769b11ecd22e9fad8f38fd614ea5f8eb7a066c0ed8d8
+Tag = 5e4bd97b9dc83134867c00c2acea0aaf
+Plaintext = 2f1821aa57e5278ffd33c17d46615b77363149dbc9847041
+Ciphertext = 72c5eadb5dbee66e782151dffd43857f3d1be55cf5c70a68
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = d43b841f174335f1347834590b0984a2cb35f7a00a0ee993157d2d4f848748
+Tag = 55202ba34bb9918fe915776de65947c0
+Plaintext = c7da4e95cb38342c6d5bf0c381d5a192adc3bfc1cda3a1d7
+Ciphertext = 9a0785e4c163f5cde84960613af77f9aa6e91346f1e0dbfe
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = c1093518efd80245e3c42371f220b21f2034e6738fe02ef43e828190f01aef
+Tag = 2fdf807b5a6880f2d4c36d558b40eb90
+Plaintext = 414a70aba5a219dbd41cdc46b84812b28cc4f7399218004d
+Ciphertext = 1c97bbdaaff9d83a510e4ce4036accba87ee5bbeae5b7a64
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 90f627d5b939625bc76fe1bd4643b39edc11d3dc7f4bfe16e61bc26c3d49d8
+Tag = 5a9307ca4239380a45bb7f87e41c4cf7
+Plaintext = 58b260d3f645a35bad7a3842440bc03608248bd46e725e60
+Ciphertext = 056faba2fc1e62ba2868a8e0ff291e3e030e275352312449
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 2f360a4715074e942244ab7f9b6db127b0442df9af2efa2e78db1a94312905
+Tag = f3aeadff9dd60468aef2a8e2c56dda7d
+Plaintext = 5505caa97218957e90247fde60275bdafce4b16bcb36c263
+Ciphertext = 08d801d87843549f1536ef7cdb0585d2f7ce1decf775b84a
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 7db564811f14bc5c2098d5635655c3671fbd8288ea14944af925eaec653408
+Tag = 8335f2e31a0468b830c5009cd02dbd5f
+Plaintext = b93e40f556a786e39126b8834a6ecacd2dc9f0f528bab135
+Ciphertext = e4e38b845cfc470214342821f14c14c526e35c7214f9cb1c
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 36be91854d3d02a5d62503bb9047ef4354280510f7576c4272fd757240b621
+Tag = 5d772a599e91504e022b9dbfb124b71a
+Plaintext = 543a070fdb3a855dd7d83fbc5f983671ad9e905f307148e4
+Ciphertext = 09e7cc7ed16144bc52caaf1ee4bae879a6b43cd80c3232cd
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 6aa6ea668df60b0db85592d0a819c9df9e1099916272aafb8813ccc2f2dd96
+Tag = 9846cd12430f7adc910d1f0c51d80636
+Plaintext = 86ef67572cb339c6706eb5909b96848aba5246a196972a1e
+Ciphertext = db32ac2626e8f827f57c253220b45a82b178ea26aad45037
+
+Cipher = aes-192-ccm
+Key = b5664dd6ed435df006052f6ded74bb7ce9482ca9229886f7
+IV = 7a1649896f3e030c18f0205599
+AAD = 3a64414c3588d7c26871d7d054ac6c8420d4917e3baad4a343685916265321
+Tag = d9ee65ac3a8fae1b00a4f1dfe2577293
+Plaintext = cecef24b62676a5623bedae8087b9b05d7e22b41a14dd2d5
+Ciphertext = 9313393a683cabb7a6ac4a4ab359450ddcc887c69d0ea8fc
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = d70aef3532bdc5293a3ebb11589ac1f801c9f93ea0d656e1d04068facf9f768b
+Tag = 966e91a19617bb748f3495aa433585bb
+Plaintext = 718f061e8b972a3adcf465d66c5b28e8661f080127f6722f
+Ciphertext = bad3b0e6772e9c4c9c631c095e259d99692292932efb72b8
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = 1ee0eb409398bc252175cb460ef9a2da4c9beab2ef6d8206e4fcce74df785246
+Tag = c8f70aa565a12ca3545e68110968040f
+Plaintext = 72e6cebdaf88205c4e74428664bc0d7eb4687a272217b7ca
+Ciphertext = b9ba78455331962a0ee33b5956c2b80fbb55e0b52b1ab75d
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = 3820db475c7cb04a0f74d8e449f026ec951fa59667738698b0ed5c8cb09a8c96
+Tag = daf38076c810e14a7843444a02f010e0
+Plaintext = d959dd38a458039e2400d21d27b9a2faee8fe23683330cb5
+Ciphertext = 12056bc058e1b5e86497abc215c7178be1b278a48a3e0c22
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = f555216840a1f40b411d44128e567617e2694caf16216ea74c604a8d6ec01e72
+Tag = 594aebf9b8318877bdec2900a22df858
+Plaintext = 337f12e8ebc0544b82fcdd3c4a0dab0e5e75c9f433a27d66
+Ciphertext = f823a4101779e23dc26ba4e378731e7f514853663aaf7df1
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = 2311a6fe1feeda3a1f16310d635496c0dd662024f0b0f1de79325e030cb850e5
+Tag = 1d9872d1c10a6594b5c349b84f710d64
+Plaintext = 463c65fa7becae5605af80d1feca59075ee88c0abfc72cb4
+Ciphertext = 8d60d302875518204538f90eccb4ec7651d51698b6ca2c23
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = b2c633e3181ae5fe7828707ed5b70e0460088a84465eadeecdbcfa0e9ff19bb1
+Tag = a9db7c4bcaf6087e158c1a5d4eb1c2cc
+Plaintext = 23c1732959c4bf85bc707e45cc964b6227acd3a8fc73e675
+Ciphertext = e89dc5d1a57d09f3fce7079afee8fe132891493af57ee6e2
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = 791f23252094b9b99fafe7fac1d8ff3ba09305c476041e75afb245ac438b4069
+Tag = 5e1c87d9e1c1f3b7d30fdc2f0ccac783
+Plaintext = 02f60f967e7fbcf957313619882407ea8a03fc943062296c
+Ciphertext = c9aab96e82c60a8f17a64fc6ba5ab29b853e6606396f29fb
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = 22197f9ad14591e7a6d5f8b18c969a553de9a85309757fa5d319cc505c24f438
+Tag = 1514b449a741e07f9287f7e9090fa54b
+Plaintext = 6c1aa088d1a6086d0e72636744a6840c80ab8223409c61b7
+Ciphertext = a74616702d1fbe1b4ee51ab876d8317d8f9618b149916120
+
+Cipher = aes-192-ccm
+Key = 50925853a84a33ff392154e4e737efc18dcfc98f4d5235a9
+IV = 809343e986f6ff47f54d4cac22
+AAD = 0bb18f7280a30767cd769cb5ffd3edd1c18914b92d1b2192e27ac88f57135616
+Tag = 2c889b610157e16e9f31558c669298a7
+Plaintext = 57275bc3b4d63b9b01b0b0760235c9785d45761cace23f1e
+Ciphertext = 9c7bed3b486f8ded4127c9a9304b7c095278ec8ea5ef3f89
+
+
+Title = NIST CCM 256 Variable Associated Data Tests
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 935753e601b79db4ae730b6ae3500731
+Plaintext = 30d56ff2a25b83fee791110fcaea48e41db7c7f098a81000
+Ciphertext = 55f068c0bbba8b598013dd1841fd740fda2902322148ab5e
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 003abc6a4b020625adc8b6cd7bafbd42
+Plaintext = e44b4307234281209bd41f89dbe2cc3fbf68e14df2f7fce4
+Ciphertext = 816e44353aa38987fc56d39e50f5f0d478f6248f4b1747ba
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = e7cfa7a208a8b3e6b6377236045df17d
+Plaintext = 8db7a73856bcb4007346bb3e00096f69e75e97c0bb960f3b
+Ciphertext = e892a00a4f5dbca714c477298b1e538220c052020276b465
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 81b39a0c55822e32042b4f8981021090
+Plaintext = 48f3ceda4fd390a7eb38f7f5bcd14310af6b5a557e676d44
+Ciphertext = 2dd6c9e8563298008cba3be237c67ffb68f59f97c787d61a
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 091117e2ad77db510d902038743b5a98
+Plaintext = 7cdb2c9b167b3ae811289acf7dc1814bbe241f553447699f
+Ciphertext = 19fe2ba90f9a324f76aa56d8f6d6bda079bada978da7d2c1
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = ac7379b8e51592b98e4874f4592278a8
+Plaintext = 41eacf70d05a6d0cdbdd38f197a52987def8fde37f332eeb
+Ciphertext = 24cfc842c9bb65abbc5ff4e61cb2156c19663821c6d395b5
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = d08c1c902c4c2f078452dd6943b85028
+Plaintext = bde9e3eb9f0c57302c9185b1cb912ef76d88f2f9c3b51e9a
+Ciphertext = d8cce4d986ed5f974b1349a64086121caa16373b7a55a5c4
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 32fefb87445f1ca42811899acc0cdf68
+Plaintext = 6f9ccc033c6bfbdfad4719ad033c927e2175727a9a021dc6
+Ciphertext = 0ab9cb31258af378cac5d5ba882bae95e6ebb7b823e2a698
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 81d605a1019c8e9778b8928b4636053e
+Plaintext = cc67bc3b7afd625b2610226d3b30e111e6aa47a3254f711a
+Ciphertext = a942bb09631c6afc4192ee7ab027ddfa213482619cafca44
+
+Cipher = aes-256-ccm
+Key = 26511fb51fcfa75cb4b44da75a6e5a0eb8d9c8f3b906f886df3ba3e6da3a1389
+IV = 72a60f345a1978fb40f28a2fa4
+AAD =
+Tag = 96a82e8411e5b04426dc608298c6408d
+Plaintext = a10c81725f49ab9075fbf4d96be030a2d881d8501b115d61
+Ciphertext = c429864046a8a337127938cee0f70c491f1f1d92a2f1e63f
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = 9e
+Tag = a462ff2dd8ba44a381e1f6edab12b5a9
+Plaintext = 1b5cc6b1651dec4bbbf5130343852e971c7ff1774100d9be
+Ciphertext = 789bce069a725a96c484e64a9e54dcb7a7c268c85df47815
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = 4e
+Tag = 6b0789c5866b7e3312ad992e228d6d20
+Plaintext = e7ab98901c0cb1d7d76e125d8ac8e86edf6f469fa937bc10
+Ciphertext = 846c9027e363070aa81fe71457191a4e64d2df20b5c31dbb
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = cc
+Tag = 39b1b1a480fdd268c1c75b131cde798b
+Plaintext = 53bc7e3648d0b389b887b065e9e8f79685beb2eb36e2eb95
+Ciphertext = 307b7681b7bf0554c7f6452c343905b63e032b542a164a3e
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = 45
+Tag = 32060fea35c3e9528fd18994fae9fce8
+Plaintext = 6d7262476da95db63b322c5193ea05030923c3cbf0f8e8b1
+Ciphertext = 0eb56af092c6eb6b4443d9184e3bf723b29e5a74ec0c491a
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = 2c
+Tag = b4e0a604ab30a764e8c98a9cafbca8d4
+Plaintext = 8246bf7b81b287411777df7ecb53a1795e54b150ff3dd584
+Ciphertext = e181b7cc7edd319c68062a3716825359e5e928efe3c9742f
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = a9
+Tag = 7ca72f1acf6dfd078b6f4eb82fa01e9b
+Plaintext = 2596ca8772bc69b50bcbf33088c6efbab614b691ed836f92
+Ciphertext = 4651c2308dd3df6874ba067955171d9a0da92f2ef177ce39
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = 85
+Tag = 2a85c9252ee62612dc29cffa7289b2ca
+Plaintext = 703065d701f4fcadee20d64300b3082c0c76490eb2dc4ba7
+Ciphertext = 13f76d60fe9b4a709151230add62fa0cb7cbd0b1ae28ea0c
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = dc
+Tag = 9fbdac729413152c089d3939e30b8602
+Plaintext = a1aeda4b4cb8dd2943675181561bac48ba07e8de5b327837
+Ciphertext = c269d2fcb3d76bf43c16a4c88bca5e6801ba716147c6d99c
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = ce
+Tag = f86266c273f8184e901b50c04845b8ab
+Plaintext = aa17341f4cead054d41c171dd34c459f7052da225c6c365d
+Ciphertext = c9d03ca8b3856689ab6de2540e9db7bfcbef439d409897f6
+
+Cipher = aes-256-ccm
+Key = a4490ed6ab51dbfccd6f3702a857575dad44da3a27eaf31178abc97da60d1e4b
+IV = 26ceaf6e3b28190a17c4f0c378
+AAD = a6
+Tag = ddd02d5c9ae2bbac47a7a076edb1d207
+Plaintext = 448cdd9cbbf863eb666fda36b825f3798827da3c1349611f
+Ciphertext = 274bd52b4497d536191e2f7f65f40159339a43830fbdc0b4
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = c0c3
+Tag = 06ec97f23bd6ea97834f92f7263c3195
+Plaintext = f4d7978fad36223623ccb5bb18a7373cba8a6e3b1c921259
+Ciphertext = bea778540a90033b2c0d087e3cc447711ea25f7eea968555
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = 34b9
+Tag = f3230df0b52b5cb7ac907dcadcb662ca
+Plaintext = f6c043c70136585d012ae0df6f42b25584e374649d0116c5
+Ciphertext = bcb0ac1ca69079500eeb5d1a4b21c21820cb45216b0581c9
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = d4ab
+Tag = a99c3165ce83102891ef3885088ed6eb
+Plaintext = dec0c896b04490816409da1783478ef2510231d0a28c5b39
+Ciphertext = 94b0274d17e2b18c6bc867d2a724febff52a00955488cc35
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = 2a3a
+Tag = c9d8078607994ae5dff0de6526fb53d1
+Plaintext = cbfd94fc31785d30214271dab2264134805fee6e52aa0b5c
+Ciphertext = 818d7b2796de7c3d2e83cc1f964531792477df2ba4ae9c50
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = 4eb1
+Tag = 7e84da7d2564533e7ad55390ec3a6ff9
+Plaintext = 134d2d9726400d09dd3521326f96fbef993ddc0c40887700
+Ciphertext = 593dc24c81e62c04d2f49cf74bf58ba23d15ed49b68ce00c
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = 0a79
+Tag = 520849295a56191367a696999ffef8e9
+Plaintext = 1ccdcf789d42caba80d7893feaf26d3853fbcaf7d964df0b
+Ciphertext = 56bd20a33ae4ebb78f1634face911d75f7d3fbb22f604807
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = 865f
+Tag = bc4aceed1a10309b6402b9e9420b33a3
+Plaintext = 4042dbe148db3e6dc542b25d57a5787af535d38e8c34c71b
+Ciphertext = 0a32343aef7d1f60ca830f9873c60837511de2cb7a305017
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = f4ae
+Tag = 76c180d2e299ccf0b8781ba6de8a72ce
+Plaintext = 85b6894fec36294aa934cdc3523fd95c90ad56cbd18545dd
+Ciphertext = cfc666944b900847a6f57006765ca9113485678e2781d2d1
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = 10bf
+Tag = 98d91c68d94873a5d6557611a5402a0a
+Plaintext = 0f27f4fc8538a676a763b3e5db845a1bfb20d5fab340dee3
+Ciphertext = 45571b27229e877ba8a20e20ffe72a565f08e4bf454449ef
+
+Cipher = aes-256-ccm
+Key = df594db94ef8eca56a417afe946085eaed444c7cc648d07d58132e6cb5bc2bc3
+IV = c1ad812bf2bbb2cdaee4636ee7
+AAD = b92e
+Tag = 5321cedf1122354636e130acbd69718b
+Plaintext = 1b5ec0cb03810a12fc6a0a1ff565afb001405d2a45a1f18a
+Ciphertext = 512e2f10a4272b1ff3abb7dad106dffda5686c6fb3a56686
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = 4dc2f4
+Tag = f59626ad5cdac2e4d4cb07b538a1fd8f
+Plaintext = edba7d6312144e90ec9eaace7576045a46e553dcb8ee5a98
+Ciphertext = 44b9ea727c847336fd739ad11f4b906b292edb810462f06e
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = 2f3bf0
+Tag = ed0d53402253453e494ad350994ca77a
+Plaintext = 52a9626f5279c11e17e96f5dc5e1c1f58c1e913020d8499b
+Ciphertext = fbaaf57e3ce9fcb806045f42afdc55c4e3d5196d9c54e36d
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = 95d2cf
+Tag = 96dbc3bff865a1d94b164df23d708e8e
+Plaintext = 87b6447d97a74d0b315031078aa06fffc7b9f246bfa5f147
+Ciphertext = 2eb5d36cf93770ad20bd0118e09dfbcea8727a1b03295bb1
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = 0caba9
+Tag = 791b4469fe50d45f8efb81217cd68580
+Plaintext = 1852848046706f2e274ba381a2bee1422df4f61d93219af7
+Ciphertext = b151139128e0528836a6939ec8837573423f7e402fad3001
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = f8d459
+Tag = 587106da25012f92f01cc2db8d11ac29
+Plaintext = 99aac82fa66a15e4f76b76cf4590150999d5cf8468df7f42
+Ciphertext = 30a95f3ec8fa2842e68646d02fad8138f61e47d9d453d5b4
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = e883dd
+Tag = 64148536847290e4fdda7966fe6d5e3b
+Plaintext = 4e2f0f91990b855a00d27fbb2e8db7184cd82909de361b52
+Ciphertext = e72c9880f79bb8fc113f4fa444b023292313a15462bab1a4
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = e45da4
+Tag = cc4cb33472825363940e2b26424b7802
+Plaintext = e558be3fd246170b294d18ffa708842242681890baf8bed9
+Ciphertext = 4c5b292ebcd62aad38a028e0cd3510132da390cd0674142f
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = 3b6fc8
+Tag = a99dd8dbe89b3ecf663eda1b0f92be7f
+Plaintext = f8b284c2d851289275973fcd807fac5d8e5e3b6a75ba2ace
+Ciphertext = 51b113d3b6c11534647a0fd2ea42386ce195b337c9368038
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = 043d68
+Tag = dc4894c8fa0a1e1aa760acf9360042f5
+Plaintext = 8edf1eb90f0ad33be8a7c6446899e06addc10b3badc4ea25
+Ciphertext = 27dc89a8619aee9df94af65b02a4745bb20a8366114840d3
+
+Cipher = aes-256-ccm
+Key = d98193ab2a465e3fcd85651aaeca18b8e91489b73b7c7e93b518c4b5b81fc6ac
+IV = 2247dc7e2674e9e0a63fe70613
+AAD = e89257
+Tag = cdad1590fd8bf2d7ea919e60d0316566
+Plaintext = 8fe9a6bd82462c97f436d382d1ff971c95406b1a6c847d81
+Ciphertext = 26ea31acecd61131e5dbe39dbbc2032dfa8be347d008d777
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = 270981af
+Tag = c76fc350e585277e373e9119bf9595cb
+Plaintext = 0b92adbb251dc29a67f0bb97f8e7160862b6c4e843d07fd9
+Ciphertext = 274e2faea3271ea6fa0494c1951f115b5491a893056c3ee4
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = 633f3efa
+Tag = 0fa7e55dc54e80488a05ee7f1fc96e9d
+Plaintext = 1f88dfd4f5c52c22b1db47f9f4fb6e2f8bcd78d593061369
+Ciphertext = 33545dc173fff01e2c2f68af9903697cbdea14aed5ba5254
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = aad86fb5
+Tag = 18151c17d9e3f97244000a3b2d3c2f95
+Plaintext = b2b4cb5e90ebf4bd265093b7f5efd4d62dc60e29737aa496
+Ciphertext = 9e68494b16d12881bba4bce19817d3851be1625235c6e5ab
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = ed42941a
+Tag = 62d521c4b5c7a6f2c5ac65f2fd15b066
+Plaintext = f312b47d05f8eb5a29943b41347cb1983c75cb7a458a3868
+Ciphertext = dfce366883c23766b46014175984b6cb0a52a70103367955
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = e5b085d8
+Tag = e491a31218f688744098851672a09a64
+Plaintext = e9fb86938ea7f04cc230296859e7c96fcc352f968c9473e4
+Ciphertext = c5270486089d2c705fc4063e341fce3cfa1243edca2832d9
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = 3776f37f
+Tag = 0ece28347d7ebf8291d7eb66b7651b4e
+Plaintext = 8af6b7540f997954812e38dbd99ccfaedd5c69963c353a4e
+Ciphertext = a62a354189a3a5681cda178db464c8fdeb7b05ed7a897b73
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = 4eb08c9e
+Tag = cbd25fb40480d15c039878b5d2f25afb
+Plaintext = b90cfd9dd58e320d98510483b1d939bdb5f3b81666ecee59
+Ciphertext = 95d07f8853b4ee3105a52bd5dc213eee83d4d46d2050af64
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = c7f93152
+Tag = fbfd98c8567b78d4b9c3a49a4641908e
+Plaintext = 02caabc6ed0641681e7148c10cf3159fe35e44013252071e
+Ciphertext = 2e1629d36b3c9d5483856797610b12ccd579287a74ee4623
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = 57957630
+Tag = 655c1abcb3ed1a175f12721a407c5d00
+Plaintext = 2f29882fdf1418d04f0b9d44272995a56973c4369c687a99
+Ciphertext = 03f50a3a592ec4ecd2ffb2124ad192f65f54a84ddad43ba4
+
+Cipher = aes-256-ccm
+Key = 45c8afd7373cb0f6b092af3a633d9fd97c4ca378e19d75f9b74d089429726c29
+IV = fdb1fa230ae0b172ff98fc7496
+AAD = 19da955d
+Tag = 90621a5e5683df421a0dc52341485d1b
+Plaintext = 4e427130be9e94639320529ec135715e65da1117b5ba3c76
+Ciphertext = 629ef32538a4485f0ed47dc8accd760d53fd7d6cf3067d4b
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 3ba11282d6
+Tag = fe0667bcc5806b225224b04ade8b21c1
+Plaintext = d822f84b023f12ea9e3ce16b904278e4aaab5e11c2c23f3f
+Ciphertext = 9f91fd2f6472e33b02b1eabb9d6655729d44c44dad6b3883
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 3f3a4718ea
+Tag = a6750fffa5a487540ce65770cd836e99
+Plaintext = af87b347b59e37a424004a00907dcbcf6a554e6782a9be12
+Ciphertext = e834b623d3d3c675b88d41d09d59e6595dbad43bed00b9ae
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = ff79ca8965
+Tag = e7cfafe32bd71ea9813607c5df446c9d
+Plaintext = 82b7cd168b6a82cb2d837f41ceda0c27adc5f5b28030454b
+Ciphertext = c504c872ed27731ab10e7491c3fe21b19a2a6feeef9942f7
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 0021be18ed
+Tag = 76716fe674c33ad3b9d3e54cc86bfccf
+Plaintext = 1c1a0f144df76781e7c85ab178ed9b1ce8c6dc3f15c59149
+Ciphertext = 5ba90a702bba96507b45516175c9b68adf2946637a6c96f5
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 9ae7996547
+Tag = ab55dbee34f1bab555bbb196095fb5fd
+Plaintext = d9bb71ad90152d5c1af358c8501fa89ebd4b17bf4ff43841
+Ciphertext = 9e0874c9f658dc8d867e53185d3b85088aa48de3205d3ffd
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = fa292d1958
+Tag = 76a4e9e759d5bb79c187a157099e3d12
+Plaintext = fc7d028a1aa05c74b7ffe333ba6f676913b0f9f1ffa050b8
+Ciphertext = bbce07ee7cedada52b72e8e3b74b4aff245f63ad90095704
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 88800df7b6
+Tag = 9f0f3699c9743ad6c9f09dc00ea10487
+Plaintext = c9ea772e61742a6706da3ab3e81df14b31506ae58b063ece
+Ciphertext = 8e59724a0739dbb69a573163e539dcdd06bff0b9e4af3972
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 715041afd4
+Tag = 560d78cba6d9f50e9c2677a710f92155
+Plaintext = 70d2b8d64121ceccf1961444e8d33b7b7f998aeb58d3d270
+Ciphertext = 3761bdb2276c3f1d6d1b1f94e5f716ed487610b7377ad5cc
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = 14682301a9
+Tag = 95ffb6e29172a283d47e4478e2e1f7c4
+Plaintext = 1013946815001a2c08acca4196e0d6668ffbb3883cf111e7
+Ciphertext = 57a0910c734debfd9421c1919bc4fbf0b81429d45358165b
+
+Cipher = aes-256-ccm
+Key = a2e6bf39efd1ceddc92b4333ed92d65efeea6c031ca345adb93a7770a8039bcd
+IV = 693cbb46bc8366086ec7cd7776
+AAD = e44c3c21c1
+Tag = ccf233caf0bad9f68f71d78ee58512ec
+Plaintext = f40dc834067bd163e0004d0ec5dd4b96e2a1ea31ea431c98
+Ciphertext = b3becd50603620b27c8d46dec8f96600d54e706d85ea1b24
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 4759557e9bab
+Tag = a88179e0d32f4928eff13b4ce2873338
+Plaintext = e758796d7db73bccb1697c42df691ac57974b40ca9186a43
+Ciphertext = 93ad58bd5f4f77ac4f92b0ae16c62489e4074c7f152e2ed8
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 2ea07d393a0a
+Tag = b7d812c4d69f1f53ee9158382e56625b
+Plaintext = ce60ddbe40b70bd55a9147036ad079dec1558ef4c2c625b3
+Ciphertext = ba95fc6e624f47b5a46a8befa37f47925c2676877ef06128
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = aa6667faedc1
+Tag = 26fdbed62b228db008a1b14bd7942e12
+Plaintext = 89eb3056770a6157f06921bc153834447c4b6d862d10d185
+Ciphertext = fd1e118655f22d370e92ed50dc970a08e13895f59126951e
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 9e2127d92311
+Tag = 124e1eb78de01b8af83b684baf3e43ad
+Plaintext = 132f3e19e12f462a7463226b716c41a05a59c76f0e1a2f72
+Ciphertext = 67da1fc9c3d70a4a8a98ee87b8c37fecc72a3f1cb22c6be9
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 2f191bc9cff6
+Tag = cb0f79736d1a810d06a776094f9fb67f
+Plaintext = b8611cbb9a3667b9458ca57eb636eb1dc580e7dbb5701692
+Ciphertext = cc943d6bb8ce2bd9bb7769927f99d55158f31fa809465209
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = ad739d5f4736
+Tag = bfba2348f629471c232c9ff7e5f6f85a
+Plaintext = 112f89ccbdadc2433008d3ede2290f9ce81e5c736abf42a8
+Ciphertext = 65daa81c9f558e23cef31f012b8631d0756da400d6890633
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 01acc909b7d3
+Tag = c0f694d03ffed043787343827ea2603f
+Plaintext = d47f2ff745de39a9055ad002de6334971fde480bef268b33
+Ciphertext = a08a0e27672675c9fba11cee17cc0adb82adb0785310cfa8
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = ce003c836a6f
+Tag = 279b553998a6fee0a86e177a448573a4
+Plaintext = 13be365884b8a91a284ca24f70011e48794b51be275153b9
+Ciphertext = 674b1788a640e57ad6b76ea3b9ae2004e438a9cd9b671722
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 6a759a4efd00
+Tag = 4eeb434cca3ea719827417e94d6ed564
+Plaintext = d5c87c649579da3f632ba95cb0a07c924095e4bdd4e0376e
+Ciphertext = a13d5db4b781965f9dd065b0790f42dedde61cce68d673f5
+
+Cipher = aes-256-ccm
+Key = c5a850167a5bfdf56636ce9e56e2952855504e35cc4f5d24ee5e168853be82d8
+IV = c45b165477e8bfa9ca3a1cd3ca
+AAD = 02b84a26c773
+Tag = a74b5e4e2edb91fbbe722bfaf1500db4
+Plaintext = b7bc1580c68fd5d06c1bf75c31dad7a3e26d636d7eee20b9
+Ciphertext = c3493450e47799b092e03bb0f875e9ef7f1e9b1ec2d86422
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 0b1fabdf2a4107
+Tag = 6d5a6e4b1fbee15d35939c721004502e
+Plaintext = bc9ca92a9c9919e39095d3e53fb148694620ae61227e0069
+Ciphertext = 45811b0c8f754bf03950e520cd4afc81c2e3eb8a11f4fd38
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 2fc7f5c0ce052f
+Tag = 24a68f98716190fb55f743a8bf62a085
+Plaintext = f25a4ca20bbf4969bed6b93c1c77e3d7415f60fe3784216b
+Ciphertext = 0b47fe8418531b7a17138ff9ee8c573fc59c2515040edc3a
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 8a74412da3034b
+Tag = 23afef7b4955d7d1e8f1abef9933bf9f
+Plaintext = 3237bf953989d17c65a0fafd2bb1e32c237f98f55389e8f8
+Ciphertext = cb2a0db32a65836fcc65cc38d94a57c4a7bcdd1e600315a9
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 7139f3c1d6cc36
+Tag = 8e824c62632dff5cbc103d3060fbd174
+Plaintext = 55d86dc0423cfc2616ef996a3316e776707f8d25c985884a
+Ciphertext = acc5dfe651d0ae35bf2aafafc1ed539ef4bcc8cefa0f751b
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = af7a380f079aa1
+Tag = 80202d518ca871c9544f4a8c55fd8d20
+Plaintext = ac48398adb10292314973946f261ec39397442ca09b98dd8
+Ciphertext = 55558bacc8fc7b30bd520f83009a58d1bdb707213a337089
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = e602abe8f72964
+Tag = 4b33ea6e4344033f74f513d1e41b82ae
+Plaintext = 2fb78654e4395df8c37f260d74def234a3a4e3d2b1fe8614
+Ciphertext = d6aa3472f7d50feb6aba10c8862546dc2767a63982747b45
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 82741c5fd6e1df
+Tag = 73ccf18c7ea7dce79d0be1204c593234
+Plaintext = d488bdda400932de56a9f105f0e74ee79c2ed869faaadc31
+Ciphertext = 2d950ffc53e560cdff6cc7c0021cfa0f18ed9d82c9202160
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 78f0cc22535402
+Tag = b81b8af57b85093778690266e20e2fbb
+Plaintext = b22aba8d3e9f4b4bf006e26062de15daf94597731a600912
+Ciphertext = 4b3708ab2d73195859c3d4a59025a1327d86d29829eaf443
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = 18e468139dd16f
+Tag = 9b94a857e7a0423ef6c9cbebde1f9c40
+Plaintext = bd864f7b8efd6ed2b068f425482d449bf53a203ea88e1ca1
+Ciphertext = 449bfd5d9d113cc119adc2e0bad6f07371f965d59b04e1f0
+
+Cipher = aes-256-ccm
+Key = ae8f93c3efe38e2af07e256961dd33028faa0716e5320a7ab319a10d2f4c5548
+IV = 6333bde218b784ccd8370492f7
+AAD = a6dab47c0fbfe1
+Tag = 64718820065a739fbd3ba560a416895c
+Plaintext = 47d9d18b6addc5f88986f0457b666faae59aba4fa3a02abb
+Ciphertext = bec463ad793197eb2043c680899ddb426159ffa4902ad7ea
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = a6601111cd92c943
+Tag = f2a9047e37cc0be1fab0006af8db8dc4
+Plaintext = 49fd5cbe4aff89dc3b8718f9ce545d612cbbebb289ecbf42
+Ciphertext = 3cfc6211e359ae322802fc9566f377b0dfe17d1dfe0878eb
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 96f0b7cd7439721d
+Tag = 106a430b04938e97f2e4cda81108ad3e
+Plaintext = 94a95e945f660d1571b4d7d22709b000b45ff98b2129a4ae
+Ciphertext = e1a8603bf6c02afb623133be8fae9ad147056f2456cd6307
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 2ee135dc2ddd9501
+Tag = b2ab219c6c4952d52505cd9f904b0e04
+Plaintext = aeed3aea01755c912213c8c276a2b75dad24f888a611efa3
+Ciphertext = dbec0445a8d37b7f31962caede059d8c5e7e6e27d1f5280a
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 10c361934fd6ff77
+Tag = fc1f7b2fe314faea28ab0dae349feb9c
+Plaintext = be1fcebea4c22a1d71e08047b028d7f4ccab0a6b8085d344
+Ciphertext = cb1ef0110d640df36265642b188ffd253ff19cc4f76114ed
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 3f6c8a69917f7776
+Tag = 08e529d64e786a29661cccddc0366f3b
+Plaintext = 87680ac26fe1511e0f1f745aa4c2a5b9f6c0117dcf08feaa
+Ciphertext = f269346dc64776f01c9a90360c658f68059a87d2b8ec3903
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 0f7a1426ff3b5ee1
+Tag = 97c6510b85dfd097f3eac276aff00ba2
+Plaintext = 9e004b072a27b085e59ca201c157c7d3c906a2c3b455c56e
+Ciphertext = eb0175a88381976bf619466d69f0ed023a5c346cc3b102c7
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = faa5bed84dcf168e
+Tag = 8e522b6f13f99ecb553b6de845940907
+Plaintext = a1bf47b15cd66e43daff420edf014a14b11994b97ada4030
+Ciphertext = d4be791ef57049adc97aa66277a660c5424302160d3e8799
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 2851dae3cb3fcb1c
+Tag = 7a9ca39566189ee96c86462bfea78af5
+Plaintext = 2d15734871adc63ff32d7002ab40c4a235a4d5fad223953f
+Ciphertext = 58144de7d80be1d1e0a8946e03e7ee73c6fe4355a5c75296
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 35a29c1bcbe2182f
+Tag = a613b5fbbe73a2df6c630a00ff4b1b92
+Plaintext = 5a84c4fdd47510fb7aebc0f79d7b625ccd0a96575740b8e6
+Ciphertext = 2f85fa527dd33715696e249b35dc488d3e5000f820a47f4f
+
+Cipher = aes-256-ccm
+Key = 548c2d1eb7d91e003633d4d9ff199e4a8447180edd89ac7867d25a1db288b5ce
+IV = 23b205bd6ff8ed0bab0c98999c
+AAD = 45820ae66c3e8e77
+Tag = d19feb067e9f6225376da21b4899d296
+Plaintext = 2052a94e1392dc1db0e89be19ea8f7379ee4cb607a914c89
+Ciphertext = 555397e1ba34fbf3a36d7f8d360fdde66dbe5dcf0d758b20
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 82b8c736037ce2f2e8
+Tag = 0de1a3f7fc5d06cc30f06075f5504ed7
+Plaintext = 7c0889854658d3408c5d8043aad2f4ae4a89449a36f8a3b8
+Ciphertext = 1044250f58857c69f72b5d3454d43949e5c02b3822970b28
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 8f2777ec4930f7e349
+Tag = 835840df6fa96f5c972ac09d94148cbc
+Plaintext = bd845561f099500a6ff3fd09964dc3820f7ab48ba4ed04d5
+Ciphertext = d1c8f9ebee44ff231485207e684b0e65a033db29b082ac45
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 5cab3b846870709569
+Tag = 2f83ef84b299cfdb61d2b5039d536c3f
+Plaintext = a6e09404fe60badfc63dc228057485e6f563ba82acdabd7c
+Ciphertext = caac388ee0bd15f6bd4b1f5ffb7248015a2ad520b8b515ec
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 0938f2e2ebb64f8af8
+Tag = db04e655cbe22b9ea508d2a03757b97c
+Plaintext = 33404d7e0e620c1030b91020e33619c5f53d8b210fa86489
+Ciphertext = 5f0ce1f410bfa3394bcfcd571d30d4225a74e4831bc7cc19
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 82f78ca0e0da2b2d3a
+Tag = 4bd88dc6985f819004c2b634c5303ed8
+Plaintext = 617868ae91f705c6b583b5fd7e1e4086a1bb9f087a50bf50
+Ciphertext = 0d34c4248f2aaaefcef5688a80188d610ef2f0aa6e3f17c0
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 401191aa3fd34abe87
+Tag = 4ff3572e4ebf78473760d8cb4b0366b4
+Plaintext = 949cdd7c2973d7519e7bca98b2c5947e6d8e91c90e632319
+Ciphertext = f8d071f637ae7878e50d17ef4cc35999c2c7fe6b1a0c8b89
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 4df4377596d8987671
+Tag = de95ec3eee17753e60fb3c0661bdd098
+Plaintext = f6720a0bd8705c70e0f923338965e810b3ea939bad652327
+Ciphertext = 9a3ea681c6adf3599b8ffe44776325f71ca3fc39b90a8bb7
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 6593194b9970545c5a
+Tag = b8590ff04f967e51fbd1be84f01b4dcb
+Plaintext = de9b0556661e726f3e6e34515ff7196420fe61b4f38419f2
+Ciphertext = b2d7a9dc78c3dd464518e926a1f1d4838fb70e16e7ebb162
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = ab2d432058b540ac72
+Tag = 71d67b75b2da855a12ffb24ddd64a048
+Plaintext = 6cad7f3b9f196839bbc5a7f755c09aa8e17c83d9cb8b3954
+Ciphertext = 00e1d3b181c4c710c0b37a80abc6574f4e35ec7bdfe491c4
+
+Cipher = aes-256-ccm
+Key = aab793e377a12484dbdd74c9b3a85c74c286e1cc498663fbd7c718b5633bb91a
+IV = 10022cddb323e88b3c08f95a0f
+AAD = 5dc631eeeacb5a0b0b
+Tag = 1fc798dd16c1fadef607a9297cbfbfef
+Plaintext = 70a55aec1144357377612fd0bbc2c817f33465a656219957
+Ciphertext = 1ce9f6660f999a5a0c17f2a745c405f05c7d0a04424e31c7
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = 215e2a6c24325340fdec
+Tag = 3d70e6dffb31a376a1eb7f94526dca48
+Plaintext = 3216dce3b8b1ce0e79e40fffcac728ab191aaaf319d971d3
+Ciphertext = c5b3b50ed8a7b7b96b02ba9464b6a2ff80e90548605699a6
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = e0a29a2c7840cf9b41de
+Tag = cbf516608fe20e06bbff931e84683545
+Plaintext = 7e5e5710a693ebfa36335cf7965574740880acdddd13fb1a
+Ciphertext = 89fb3efdc685924d24d5e99c3824fe2091730366a49c136f
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = b8026fbada6339d84802
+Tag = d70eb14f3fa0229906b9e0360be3d3f9
+Plaintext = 08c342a50aa23362622934dfab55d9b22c22c249ad08138c
+Ciphertext = ff662b486ab44ad570cf81b4052453e6b5d16df2d487fbf9
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = 65f4b3a00c1c1ef39445
+Tag = 4184771199a427861bf17cd8401e794e
+Plaintext = e085aba85882c75d5e41559167731496cf17d3907894352a
+Ciphertext = 1720c2453894beea4ca7e0fac9029ec256e47c2b011bdd5f
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = 96118dbfe53434d8aed8
+Tag = 4e20b2db52fde68f88bfb886fdcb2c47
+Plaintext = 710f890be2b8da77c1eff429ede9cc931d50f059748cbcb6
+Ciphertext = 86aae0e682aea3c0d3094142439846c784a35fe20d0354c3
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = cdf4b485d2e04709cf8f
+Tag = 82ee3df38ddea8e269eb47e39900345e
+Plaintext = cda96efee4e188ab3048bc1904ac2c36ab018f2ab7602682
+Ciphertext = 3a0c071384f7f11c22ae0972aadda66232f22091ceefcef7
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = 50e57e57cf8e49e3a4e6
+Tag = 44aaac4ed86f687cfc031f22827725f1
+Plaintext = 3dc596d52e520779a50bcba3049388b340dbf6d0f2eb94cf
+Ciphertext = ca60ff384e447eceb7ed7ec8aae202e7d928596b8b647cba
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = 48c670f11ff7f74e7003
+Tag = d75255006ac037d6a4d048f1fc338012
+Plaintext = a33105c0dccf8e3b687212a870af9f710462756705fe09b3
+Ciphertext = 54946c2dbcd9f78c7a94a7c3dede15259d91dadc7c71e1c6
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = 465e3be6113a2fb2ee20
+Tag = 6c1da33a80bc8157cece1acf9400b2bb
+Plaintext = 573ac2436158eb7dd9be981e3cfbe75d3a188ea9cf2b1ee2
+Ciphertext = a09fabae014e92cacb582d75928a6d09a3eb2112b6a4f697
+
+Cipher = aes-256-ccm
+Key = 06ac39896073a44283611a66ccab067e2dd2faa8da82ff9a45bb29e54d2e6e77
+IV = 6c7942c9819cf69b817bfcdb0a
+AAD = ee4e10574faeae85e9b6
+Tag = 65c1cb98da4a1a920ca1ed9a7b6ec514
+Plaintext = ca35bdb54e73eac5a5200a296b3aba5f37c87349746102d4
+Ciphertext = 3d90d4582e659372b7c6bf42c54b300bae3bdcf20deeeaa1
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = f706a3e09df95d3e21d2e0
+Tag = d6c05eaf406a5ebd578e19edd5227380
+Plaintext = 6cdbd63f6d591f59776f828533b28e2453a214d1d0dd8a39
+Ciphertext = 8c8b4ae854a5d5c265b25e3b54bded9444cc454b3e0e6a24
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = e46b25b9a41a858e87900a
+Tag = 5088446e42591c0ede68e82334d97cfa
+Plaintext = 100132c315bfc9c4fb93023f5d3500d7208a68acb4d2c630
+Ciphertext = f051ae142c43035fe94ede813a3a636737e439365a01262d
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = 28d34b29afe6586fd9bf0e
+Tag = 3eaaef2823f5ac3f313f560bd774d10e
+Plaintext = d5460c1db0d24dedc63c4c78ce6d1f0b2d46f3b01934525c
+Ciphertext = 351690ca892e8776d4e190c6a9627cbb3a28a22af7e7b241
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = 2852d4fd68a3e9e47d44a7
+Tag = 62d30d99bb7dadec34e2891c156a1f5d
+Plaintext = d2d73b62e3b1c9ab75f3544ff8616741e0adbae84b8cf9d0
+Ciphertext = 3287a7b5da4d0330672e88f19f6e04f1f7c3eb72a55f19cd
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = ec1c17b2ab13d7c8ac874f
+Tag = 41c9a05ebf9ed27792bbced83b5dc582
+Plaintext = 74796d78d6ad03634ed80800af530212baa7e5093651cedf
+Ciphertext = 9429f1afef51c9f85c05d4bec85c61a2adc9b493d8822ec2
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = 4f1ab5ddb1c199e9a5daab
+Tag = 1ffc24020e86b1314724104e6b57b3ce
+Plaintext = fb432488b5d08d576a90f085181ad883407a6ce9ea29950a
+Ciphertext = 1b13b85f8c2c47cc784d2c3b7f15bb3357143d7304fa7517
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = 864e0e728aea856fae6c6d
+Tag = 539bbb0af8ecf77b4508533247b3501a
+Plaintext = 2b82d96ed1778412378abe4e09c633acf3359b9709ae3dcb
+Ciphertext = cbd245b9e88b4e89255762f06ec9501ce45bca0de77dddd6
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = 21ee21a5ed0d75d0380a28
+Tag = f8981ec6ce7c4687b178f2103fa8c8be
+Plaintext = 85143071241bb65261fe7afcc102416e59b9e46ee0c90073
+Ciphertext = 6544aca61de77cc97323a642a60d22de4ed7b5f40e1ae06e
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = 2b63f7b676f13f45d103dd
+Tag = 65d9d899c6b71c0ab3049ea1dbfaf6a9
+Plaintext = 185577b48237acbdaa3590b8057fe374f875ce829b62c98f
+Ciphertext = f805eb63bbcb6626b8e84c06627080c4ef1b9f1875b12992
+
+Cipher = aes-256-ccm
+Key = 50412c6444bcf9829506ab019e98234af1541061557412740bc120b456052763
+IV = 85684f94c3702c5d870310166d
+AAD = a33e86d813c2c4ff3bab20
+Tag = b246474c4e79822f5fd55f2fb0067a40
+Plaintext = f051beb936e60fd4f3bca31964f1ad3e6fa16dd27b65a6db
+Ciphertext = 1001226e0f1ac54fe1617fa703fece8e78cf3c4895b646c6
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = e4296d1c8cf4ffc4b2635135
+Tag = de3ed995d1b70561c8e28a7b1a7e3dc8
+Plaintext = c825952293e434ea866db558aaf486ef09a92bf366988f71
+Ciphertext = b8b3b15fdf6a4a0b5abc313afc769e4e8413bd887552583e
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = d18bfcc1584eeb8695388ebe
+Tag = 561575f6743c5759494be59afa0c3e11
+Plaintext = a1e0248355bfd1d881fb1a4798cda2f6f6ad513c69c5f9b4
+Ciphertext = d17600fe1931af395d2a9e25ce4fba577b17c7477a0f2efb
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = 14682301a99bf680805d1ffe
+Tag = 34f689367228cbaf3cd76fb407109cf6
+Plaintext = ded135fcbf62219bfba2cba40c2d2cbe4815ddaac1342231
+Ciphertext = ae471181f3ec5f7a27734fc65aaf341fc5af4bd1d2fef57e
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = 8853aa2dfea9c4d370678bb6
+Tag = 2cacb7fc3856abcf759feb8dc0998ab1
+Plaintext = 12d3900c6c01968b8344762e0e883e5e219f42b052dc6215
+Ciphertext = 6245b471208fe86a5f95f24c580a26ffac25d4cb4116b55a
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = c5d3b9c593c3185fe4b6d1bc
+Tag = 42a740cd3262424a2c3d77849ead6149
+Plaintext = 8c3c1193fe1a1ebad7e01a1eed1a32c08a0091b1c948e184
+Ciphertext = fcaa35eeb294605b0b319e7cbb982a6107ba07cada8236cb
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = dfb9e8149b51f89b1ec00a8e
+Tag = 47d4dbe0f9415d40843070e1e93059eb
+Plaintext = 8219618b7728ac89237705ecf84012cc7c80293c4cf171d8
+Ciphertext = f28f45f63ba6d268ffa6818eaec20a6df13abf475f3ba697
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = 08a4590d262e4dbcb7e23ffc
+Tag = 1215b3dccba4ca5de64be7fab8a7a22c
+Plaintext = b344b7dc239617fa51b9ea10a349e940c3163779f5284c9c
+Ciphertext = c3d293a16f18691b8d686e72f5cbf1e14eaca102e6e29bd3
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = 74aab7b5b96238710637c6e5
+Tag = 34e09945ee44c95c7923d8b9249ade7b
+Plaintext = 740d4b25ca7221d0826057701a6bfd66c50a82f010a57be8
+Ciphertext = 049b6f5886fc5f315eb1d3124ce9e5c748b0148b036faca7
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = 420aac47a3f212fffca40549
+Tag = 0a568dd779526a0058d522af1dafde30
+Plaintext = 5d9000489186abdf4f0a2794f0222fcaa156fe6309c10f79
+Ciphertext = 2d062435dd08d53e93dba3f6a6a0376b2cec68181a0bd836
+
+Cipher = aes-256-ccm
+Key = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0cb00b1abade1b5ce0ed
+IV = d80210b9f9776ea36dc0e0a787
+AAD = 6e80dd7f1badf3a1c9ab25c7
+Tag = 279442c88d612ed1a39ae0005f88155d
+Plaintext = ac2c44263363810bec3a309aa618b303e05099dfdbeb5c16
+Ciphertext = dcba605b7fedffea30ebb4f8f09aaba26dea0fa4c8218b59
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = 569c56b27268d3db54e728aac0
+Tag = 8aaaac20d4c9276f2851cbba2b04d185
+Plaintext = 10d4cff95ef490923c9e0906880729d4d05412e7675cce76
+Ciphertext = be3ce3e9dc72499839a98ae52abb17415e8547687e8a3c7b
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = d75635b6450e43285fba966835
+Tag = c121ff83891335dd1214ea6fc25f6a68
+Plaintext = c9db03e2efbab713b0b640421018d3971ffe2abd70fe8fa1
+Ciphertext = 67332ff26d3c6e19b581c3a1b2a4ed02912f7f3269287dac
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = 70750acea6a05f8b7b425d262b
+Tag = 549e71ec517cd65150f42b3cb53f936e
+Plaintext = add631ce5846ce71434aad4998f8e429aed430e7d38bdbb2
+Ciphertext = 033e1ddedac0177b467d2eaa3a44dabc20056568ca5d29bf
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = 2a567c7ec7edaa5a438ae3bb35
+Tag = 0e432ec394ddbb65205dc40a5a8e90a4
+Plaintext = a514d170422feb1d87bb7725a9e77cc6fc8afb45c2af6d90
+Ciphertext = 0bfcfd60c0a93217828cf4c60b5b4253725baecadb799f9d
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = 0f8795385b805246a0a2573afc
+Tag = 926b0d977107a3918717f79b63f36b0a
+Plaintext = 79d8841ab83279724ce35e1a8abd4e158168dcf388ab4c3d
+Ciphertext = d730a80a3ab4a07849d4ddf9280170800fb9897c917dbe30
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = 111d224c102b136159fbeb44a7
+Tag = c2cd61599bb93db3dd3dabc12aa90932
+Plaintext = 2edd498e54b23aab6f4fd7b3f22c4c787e3a4f1fb06c9ec7
+Ciphertext = 8035659ed634e3a16a785450509072edf0eb1a90a9ba6cca
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = df0821c9ea6ab329c626d11b4b
+Tag = bd027ecd00cc6dc5ffd5d746d92281e9
+Plaintext = 6e3e25db29da2c787bb37755ee770e2402fb8208da23389d
+Ciphertext = c0d609cbab5cf5727e84f4b64ccb30b18c2ad787c3f5ca90
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = aacaf4839c35338d6e2b47ac45
+Tag = 3c01354a450eda2588be7578530e38c0
+Plaintext = d4ed4584678e982ace8664e77d0e55be356be558cead3755
+Ciphertext = 7a056994e5084120cbb1e704dfb26b2bbbbab0d7d77bc558
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = dc6eed3f8bd1b5563c1eeb9afa
+Tag = 8d7a1d546e25ba026cd46556eb2c4b7e
+Plaintext = 4ebf00eadaf70711f630f5badf0214d8518a200afb0e5765
+Ciphertext = e0572cfa5871de1bf30776597dbe2a4ddf5b7585e2d8a568
+
+Cipher = aes-256-ccm
+Key = a4cc7e1c90f8684e6a5f95e6898ab4e3c194cb46e196d8228062b9f3fa744930
+IV = cdc2712e51c7f333d6bad78eee
+AAD = fbfe7e910f242a78dd6e69a2ec
+Tag = 0e951aee790239e7067ef37f497b4bf4
+Plaintext = 2729636112f2abe2c76ea5e52a3f80b0f882f0f3b6f7c806
+Ciphertext = 89c14f71907472e8c25926068883be257653a57caf213a0b
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = 511c6924fa96db716f6b053b7a48
+Tag = e949b93003dfe63c95c1d49edfb4de3f
+Plaintext = ca88dddfc876a12f45f19562bc9ca250f43267ab251a7f34
+Ciphertext = eeedcfa8f5b5b48c1d7e277526eecb7294213b9f5785167a
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = 10c26d5939618189a9503623f55f
+Tag = 85c32a90d77fed97eb0ac164ed616e1c
+Plaintext = de0c0d17c3950e7f8985b56d60623cbd010cd765da4df5ab
+Ciphertext = fa691f60fe561bdcd10a077afa10559f611f8b51a8d29ce5
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = bc09c59d20e55a9e184d70af2c7c
+Tag = 180fdf5f63045f326057cf74fd4cee6b
+Plaintext = 2f35102d78a32fcde1cfb563ea8d310ecb83c146ab8de362
+Ciphertext = 0b50025a45603a6eb940077470ff582cab909d72d9128a2c
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = b75887f13d6e8c4b35b27b965693
+Tag = 34959a180fc2cf2ba99af21cc1bc8e5c
+Plaintext = a3fcce3420effdd6edb37271735a0d30c10c65233aee173f
+Ciphertext = 8799dc431d2ce875b53cc066e9286412a11f391748717e71
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = 603401a9b8ecde4d5c86b6107363
+Tag = 2ca2e5195dbd44f0a119538c95788510
+Plaintext = 4ac918727e41b8c536484e3781c403e260c278712853508d
+Ciphertext = 6eac0a054382ad666ec7fc201bb66ac000d124455acc39c3
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = 7206b06f306124ca3a302e84c5a6
+Tag = 74a4e1198878a76291594b9826d4b563
+Plaintext = 97d770cbb2c42a552e450cc4e35e5668b2ff89cec735cc91
+Ciphertext = b3b262bc8f073ff676cabed3792c3f4ad2ecd5fab5aaa5df
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = b15efed90a5d1d62f545ac22af6e
+Tag = ff5f993dcfbd048274da7439c0f9ef5a
+Plaintext = 86bb2ae50e36c72936240a74502172625cbca210cf285077
+Ciphertext = a2de389233f5d28a6eabb863ca531b403caffe24bdb73939
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = c9eb714ed9858a8dc11a26ee3f00
+Tag = 0e87710559a375ece6ef2953b6aa2542
+Plaintext = 0dc79993047fd6e7260aac4d847fdb4d16483f28b13b5f17
+Ciphertext = 29a28be439bcc3447e851e5a1e0db26f765b631cc3a43659
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = 07ca22271e95cb48a872046822b7
+Tag = 998035c81716e2d1ed4b4d56ff18af5d
+Plaintext = f950e96d65a55efb3be3a55daffb421afad1d5625e3440a1
+Ciphertext = dd35fb1a58664b58636c174a35892b389ac289562cab29ef
+
+Cipher = aes-256-ccm
+Key = 347e12eec56e95aafcc7d25bf10fc756b4e42bc2e43da7f97df24331f27f1f5c
+IV = b8d517b033754058128d13d11a
+AAD = b65f6773516124317cfb4b1fcdf5
+Tag = 1ae73a9b6896d8fc1b8c0d772d632983
+Plaintext = e160e28e601a49d16db18f25410756b330b036c42e615fd6
+Ciphertext = c505f0f95dd95c72353e3d32db753f9150a36af05cfe3698
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = 22b4f8f1aac02a9b2ef785d0ff6f93
+Tag = 8a8f8d14d2bdac84c3737cfbd75b7c0b
+Plaintext = 533fee7d2c7740db55770e48cb1b541d990ea3f8f08ed1a6
+Ciphertext = fc867b319e0e4ab45ec518a1b5dcec4f29982173f3abfd4d
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = d0a43de391d492746ecf322acd6e5b
+Tag = fce59f5e6e3cee284b4cc747ff5ee13f
+Plaintext = cced20b59a6b2c3c45ea6c87802440c9c47b1015e83d86c3
+Ciphertext = 6354b5f9281226534e587a6efee3f89b74ed929eeb18aa28
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = 3a789c06f87f05933c34a1cf9834a8
+Tag = ddaef56d8255125f7c316c6c59ce779f
+Plaintext = 90939a4530181ad6900664f66bfc2ce0289432a0afe9babe
+Ciphertext = 3f2a0f09826110b99bb4721f153b94b29802b02baccc9655
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = 785260973f112c56d9f891160c4c11
+Tag = 55810cbcdf48f05d0a7808673c82d08d
+Plaintext = 86cd926b9565b76a88fde73c31e9ac908ffd1e6ca30b59ce
+Ciphertext = 29740727271cbd05834ff1d54f2e14c23f6b9ce7a02e7525
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = bf6a144591c0ea7b10274fbd3345a1
+Tag = 49e41e5d34a698ae1d96f16bc68da944
+Plaintext = 6ecd1c1acc6290672f9cf639ed0cebcb21ed0c56f35a5ce3
+Ciphertext = c17489567e1b9a08242ee0d093cb5399917b8eddf07f7008
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = 7d9488b500d89a27f367f34a448a87
+Tag = 1bc54e546d1a6fcf6187169feb1ea533
+Plaintext = b01e3f4fb5ee7501e8c2f4ccefb542ae20d7fd61a2c41c8b
+Ciphertext = 1fa7aa0307977f6ee370e2259172fafc90417feaa1e13060
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = 060fc718e994edc7bac9962ca7f28d
+Tag = f2eb6c0ab42acf42985c721bfd576e71
+Plaintext = 22ab6a0daf953165dda864cceeeb782e275c0b072aedd284
+Ciphertext = 8d12ff411dec3b0ad61a7225902cc07c97ca898c29c8fe6f
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = cb6f96dd06015967279ade310a7401
+Tag = ac502b8e65cc1329b6895afdd354f5db
+Plaintext = f96ed20b23c784015ff58f5f040798ca75e3b98045deca8e
+Ciphertext = 56d7474791be8e6e544799b67ac02098c5753b0b46fbe665
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = 9aa6d501455019b4ef4c7fb789d22f
+Tag = 87e5f8a8148f21adf721477c36bd99ca
+Plaintext = 648a84813ca97aef4ab7e143ee29acb946388660f18eb671
+Ciphertext = cb3311cd8ed070804105f7aa90ee14ebf6ae04ebf2ab9a9a
+
+Cipher = aes-256-ccm
+Key = 520902aa27c16dee112812b2e685aa203aeb8b8633bd1bfc99728a482d96c1fe
+IV = ddf50502f414c1bf24888f1328
+AAD = ebd1d12bbd14176a0d4080aa1edb89
+Tag = da9ea0427522dbeaa509a11755434760
+Plaintext = 32d71e59634126ac6c6156a80a0dfa0175b29e9f40a31696
+Ciphertext = 9d6e8b15d1382cc367d3404174ca4253c5241c1443863a7d
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = 0ae8c012ff39753510df3ee80707e4e2
+Tag = 0ec2c6fb687753bca4580adc6aa2f296
+Plaintext = ddc3c1aa73fb6de92bb4db138e26f3c2e0543ab4f5924871
+Ciphertext = daa8256d4753fdf9cfef876295badaba89b45cc497f54d22
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = d5b22e7697ba70e00c7ef32709563f01
+Tag = 8f30b9c8e380c98bb939a4e8a85af758
+Plaintext = 34270576724083e9989764d08a0d5c1b4738f34927a1e436
+Ciphertext = 334ce1b146e813f97ccc38a1919175632ed8953945c6e165
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = 6b4edef415763aabcef01863e8197aec
+Tag = 53e80d8ccc687fd303f4cdef44b6e8b9
+Plaintext = 904fe88e7a8e76447a64b488ef84184d0f1ab1b67f0c5a7d
+Ciphertext = 97240c494e26e6549e3fe8f9f418313566fad7c61d6b5f2e
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = 4c099809061024c010a77e9621fc2bcf
+Tag = 0c635dac5b70338dac3f33ce16a99145
+Plaintext = 51fe7bac8f3255f17f64fb9322210fb7d8da8e762498b233
+Ciphertext = 56959f6bbb9ac5e19b3fa7e239bd26cfb13ae80646ffb760
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = 9d329439588164d5a96675a85c07a039
+Tag = f996e8163affb1494bb3c12eeadf16b6
+Plaintext = eab6dbc13bb92df36b1882df2b8f34c3cefa41f95717fbd7
+Ciphertext = eddd3f060f11bde38f43deae30131dbba71a27893570fe84
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = b768fc3daf29ff9e8bd575072d986e99
+Tag = 98b4206a9622d5631751a497dfb1f662
+Plaintext = c44c9c287d3eac7c30570d9c4adf2e4857c598f7c54cd126
+Ciphertext = c32778ef49963c6cd40c51ed514307303e25fe87a72bd475
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = 3efc7cc2d16bf82d2bcfbc559a09b2c9
+Tag = 7dd300167d267ad700dea37fb475ecdd
+Plaintext = c11b9c9d7607f387359c0038d3e8ec4d527562ce63c3384c
+Ciphertext = c670785a42af6397d1c75c49c874c5353b9504be01a43d1f
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = 0ff89eff92a530b66684cd75a39481e7
+Tag = 303e9c9bd0d8e4aac42894ca03d6ab06
+Plaintext = cc17904b166f28df82f57889f391159a4a308e752d714ee5
+Ciphertext = cb7c748c22c7b8cf66ae24f8e80d3ce223d0e8054f164bb6
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = fbd11bc75759f0461e796f6917aeb42b
+Tag = 0953f46e0e9cf1369e9eb018a4df3c09
+Plaintext = 6f97e595ea2f40612ea84a2097b974d235055fe1dae59403
+Ciphertext = 68fc0152de87d071caf316518c255daa5ce53991b8829150
+
+Cipher = aes-256-ccm
+Key = 57da1c2704219ed59abfdf04743a9a93c87a63d471818de0f1564b2db6421562
+IV = 4b60a47b7e90f622fa0bf803e1
+AAD = b79940952f42537484aa2907c72dffa9
+Tag = 8a1702dfa0cd9c290c5ff9c35cc83705
+Plaintext = a48cbf933b88c0ec5ddcdd8fcad186391c2cbef308607de5
+Ciphertext = a3e75b540f2050fcb98781fed14daf4175ccd8836a0778b6
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = 5824689453bc406bf891b85e4576e38fe8
+Tag = 10ca926f1a430c08c12e23db3d913e93
+Plaintext = 967daf12f16f166b7b5038f83a1cf0b980f5abf4c7746f2a
+Ciphertext = 7cfe2a7a54306eb8d8a63d3d1ae86794f9a2c22198b2cb4f
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = cd15973753b94b77bb4b778de8b3b0cabb
+Tag = 5d5b674fd15410cc235dba6d8c8d82a8
+Plaintext = c4a756f6024a9dceabf6e264fffff9c719217fb418141ac5
+Ciphertext = 2e24d39ea715e51d0800e7a1df0b6eea6076166147d2bea0
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = ed8540f7ce451c522c1ff5d2d1030d7b3f
+Tag = 88750b5f36c86e7eda9015e960a7471a
+Plaintext = e0d5de7d1eace211c0e70859ff315ff485d1200c6dd13f93
+Ciphertext = 0a565b15bbf39ac263110d9cdfc5c8d9fc8649d932179bf6
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = cbbecf92551a15f5cf00a5be4a50b0eb17
+Tag = d5fa842209dbbc04c87965f78500fec1
+Plaintext = 05a4a4ba28fe8876f9bcfa5ec60651fd3fd4732f22049bd5
+Ciphertext = ef2721d28da1f0a55a4aff9be6f2c6d046831afa7dc23fb0
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = 873ba7f8b71517ec50297b21cf94cdb7a5
+Tag = 7d147edbe114bfdb3f3b9b37d5719ef5
+Plaintext = 9cdebaeee8690b68751070691f49593668a6de12d3a948b3
+Ciphertext = 765d3f864d3673bbd6e675ac3fbdce1b11f1b7c78c6fecd6
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = ac087420feb1e1e8c2546c2a8b8a5af0d0
+Tag = 57b4c2bbc377937d15b3b89543e29d0e
+Plaintext = 5672e61cf664d73918dc1ca84df1fce82db0e305a61d57b9
+Ciphertext = bcf16374533bafeabb2a196d6d056bc554e78ad0f9dbf3dc
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = a12c690568114fd7a677f49d74e84fc1a6
+Tag = 2e6ca774074b47b59adabeaf8835582d
+Plaintext = 0f5452e6b51540cf219998590995cd7f8785fa40b4f217fc
+Ciphertext = e5d7d78e104a381c826f9d9c29615a52fed29395eb34b399
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = 7a78ddfe5afb2dc90ee4a600c2fc014b0f
+Tag = bd320f48a7221537e3cbed5ac4154a56
+Plaintext = 9ad338cbfd1b52e6ae4178f05e00062274f8b0b25eae72f7
+Ciphertext = 7050bda358442a350db77d357ef4910f0dafd9670168d692
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = 6053e466ed1f647a3cd88c4d2052ec00cb
+Tag = 40574e201f9a26932a87c8d822505814
+Plaintext = d17b8d556e83190c84d4a812957c64ffa7f336298f4e2c72
+Ciphertext = 3bf8083dcbdc61df2722add7b588f3d2dea45ffcd0888817
+
+Cipher = aes-256-ccm
+Key = 9267ebc99ccf648b146cba3c251187e24a9947d806ceb0ced6894211641a1e0d
+IV = 9b7298950280e8762ecdc9bbe4
+AAD = f7673e3beb526834d6507058fe62e34987
+Tag = 837dfa3fdef2f012b6609de2ac5dd9d6
+Plaintext = 2eaef86b0f602364f86510eabc58bc9ad1e6f0a6f6df0b83
+Ciphertext = c42d7d03aa3f5bb75b93152f9cac2bb7a8b19973a919afe6
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 72674aca7eba2fc0eeafbd143c2c4d8aa6c8
+Tag = 57e9a9203da74387a9468f8af5e27547
+Plaintext = 33ae68ebb8010c6b3da6b9cb29fe9f8bd09b59ec39f4ce4b
+Ciphertext = b22afdf4f12c43ec23e01ac1215a3f5286059211207e9570
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = f7da3f100b80e2ade812f1700aab6b72f746
+Tag = a3985f12a49eac424a35c94645917e91
+Plaintext = dbb29817b86cb80e0d008742cedfbf52b236f15ee8cad50e
+Ciphertext = 5a360d08f141f78913462448c67b1f8be4a83aa3f1408e35
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 4b05eaadf98505d0806c233b2cdcaf4254e8
+Tag = 4ab089a8724b87a1167180963d44ec65
+Plaintext = 145aa8cfd544a2f46bae1aa83cbdb3d21c3d1350078a3af4
+Ciphertext = 95de3dd09c69ed7375e8b9a23419130b4aa3d8ad1e0061cf
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 05a3aaa08b9a6aaeb84704431425d0e45a14
+Tag = 0a7d1520141892e140448292185c41c7
+Plaintext = 6b32e8906dc89194a69410b79cd041b62eb01afb28a3e10a
+Ciphertext = eab67d8f24e5de13b8d2b3bd9474e16f782ed1063129ba31
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 74db01edc26a2d2044cb8eaad8b907b78863
+Tag = 72d3eee219d94bd788f62df4add5ec40
+Plaintext = 545ed03588fd85a8bbfeee66d2082ae6f8e2f3c9dbd8725f
+Ciphertext = d5da452ac1d0ca2fa5b84d6cdaac8a3fae7c3834c2522964
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 5f2c6ddf5a2403e04dac8b2813c060b67e76
+Tag = c600496f4f8b1b7da118ee36d8cd57f8
+Plaintext = 66dd5fd8611c551973a3d0c078ec2b4d39ad163d9168de3c
+Ciphertext = e759cac728311a9e6de573ca70488b946f33ddc088e28507
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = a650a2a5e3c6f7c95614570aaefd0cdd9a42
+Tag = 4710004d06ce7a7efbd19da4e3ce3cf7
+Plaintext = 6f364b3f778376cbf3f4b0b0c5350a8fa278f9d8c25faad6
+Ciphertext = eeb2de203eae394cedb213bacd91aa56f4e63225dbd5f1ed
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 477c2484cf5c56b813313927be8387b1024f
+Tag = 304099641c4ec3dc2c54fdf4f48dbef2
+Plaintext = 3de4798d8ad84c460b92abc10b7f5e7c9fae46a1dd353687
+Ciphertext = bc60ec92c3f503c115d408cb03dbfea5c9308d5cc4bf6dbc
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = 564e1df74aa2d7ee33b66cfeda810774e16c
+Tag = 905c1b05e8945685f8688faea777eb43
+Plaintext = 7769b45fea11f530fb9a67f1b5b1964a34cfa32bbb03f4b1
+Ciphertext = f6ed2140a33cbab7e5dcc4fbbd153693625168d6a289af8a
+
+Cipher = aes-256-ccm
+Key = 7a855e1690ee638de01db43b37401dcd569c1ae03dc73dd0a917d0cadb5abc29
+IV = 8f160a873a1166c8b32bccbba7
+AAD = d5e66502529b0045883d935e05acd242baa8
+Tag = ea5a3b6a8bafde4006b993cfb3b13557
+Plaintext = 0c0a502b42f81b51806c7080a8155280f493f2922cdc7df8
+Ciphertext = 8d8ec5340bd554d69e2ad38aa0b1f259a20d396f355626c3
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = 41e9d65632f74f449a6842d5e6c4a86ef83791
+Tag = 42be2e2ba05c54b619850db5c9d684fe
+Plaintext = c7360282c85484a5a33ab1c68dd70873ab4e74ffd4a62cd5
+Ciphertext = 2e961b3a2fa1609a4e6fd04bff6ac5e306ae2638706f997b
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = 555304659bde926cb2553b8a4605251fcddd92
+Tag = bbdee2605bc69601b1e83d1e7a0b400d
+Plaintext = 1332314d1cf783b9f64e0fa2d42d43d225da9fd5165b5f0a
+Ciphertext = fa9228f5fb0267861b1b6e2fa6908e42883acd12b292eaa4
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = 69ea953dbb910ec589372d797c7379d3f3b9e9
+Tag = 304611baf530932da7954f714514d228
+Plaintext = f264da8606ea429e0e25da3f2efafe28beaff05b42097369
+Ciphertext = 1bc4c33ee11fa6a1e370bbb25c4733b8134fa29ce6c0c6c7
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = d7186a67061319b44eedc0677ebf5d932d5bce
+Tag = 6d1d44e26404b7324767f0b3f7486f8b
+Plaintext = c9ee6482144dc61c43041324a2c18ede370011cb4882b0c5
+Ciphertext = 204e7d3af3b82223ae5172a9d07c434e9ae0430cec4b056b
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = 38f37d5e2da017f1953ff3701be0b38809ba80
+Tag = 5453724d2db19f606c85d00e49b0bb38
+Plaintext = 40524a4d32a711e7d5a59809878c318f42b6e2375b77b8a7
+Ciphertext = a9f253f5d552f5d838f0f984f531fc1fef56b0f0ffbe0d09
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = b3b2d249cd3517555fa692bbe9116f069e7405
+Tag = 6db1e4112fcd650e8c0f0f6fbf2d07e1
+Plaintext = 961c15bd7dc34cd5409c9e8869988676ec6845ecb0ee85fd
+Ciphertext = 7fbc0c059a36a8eaadc9ff051b254be64188172b14273053
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = f5b5bcc38efaff01f69bd3a106dcfca3cc6414
+Tag = 1cedb29e68322e47ff9997f859257d98
+Plaintext = 879568ab9ebdea768a5459ced1d3181d822536c3d1ba38c3
+Ciphertext = 6e35711379480e4967013843a36ed58d2fc5640475738d6d
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = a2098e3e23826e01f31107a208202f710eff00
+Tag = 1c12bf2a3571ed672592b27e986e9058
+Plaintext = 47cb57599686716c75d7ecef5541d20fb908e6d98c39925a
+Ciphertext = ae6b4ee17173955398828d6227fc1f9f14e8b41e28f027f4
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = 20a3d53e77201599540344c4e746c3ae3a5f84
+Tag = f12b2be8f5966d96602111c28f87b104
+Plaintext = 4a8667b5ee09d3d4a6dca9a95f4ad406f1da94b846dcc6b8
+Ciphertext = a3267e0d09fc37eb4b89c8242df719965c3ac67fe2157316
+
+Cipher = aes-256-ccm
+Key = 0ebdc6ddb4c502725dd6ee8da95d56a0d1044b4694d6ba8475a4434f23a8474f
+IV = fb717a8c82114477253acc14f6
+AAD = 92c592ead4b3f193cc36687593d4f0f412a5d5
+Tag = 776df0a0cf048892e65bd8ad77cb2255
+Plaintext = 1dc9e32ac4176f64bd78a6edd651ebeea3ba85dfcd8298a8
+Ciphertext = f469fa9223e28b5b502dc760a4ec267e0e5ad718694b2d06
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 2b411bea57b51d10a4d2fb17ef0f204aa53cf112
+Tag = e6f3ba30143acbc3a1c1c6ec74333107
+Plaintext = 4a17522da707b4b2587a0ae367a2cd2831bb593a18ef442a
+Ciphertext = 1bf122798bd8ee8e73391d589bd046a294d1615794e69cb9
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 0248359f8071143c3cc1d61882a3547a0b3d2175
+Tag = 36cb510c13a039f4df8cc26a942f9911
+Plaintext = 4a6a7151465c2abd7e7fa1fd13019ad098b6ebcd190e96f7
+Ciphertext = 1b8c01056a837081553cb646ef73115a3ddcd3a095074e64
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = cca77bc4cf6c0abd3393dac3fbe90fbc8a1154f7
+Tag = 7fe0dedc2899dff81a251cff16bf5897
+Plaintext = a94f5ede43929d48d2c5a58c3262d9127d2ac3cb2fbd5768
+Ciphertext = f8a92e8a6f4dc774f986b237ce105298d840fba6a3b48ffb
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 9c082a84646c070bb11b7d6b92b62f06ee5b5b71
+Tag = 86c43ac23800de60a1fd2caef0f03261
+Plaintext = 7303bd41cf47289a3111366d08e8e21548baf293052029eb
+Ciphertext = 22e5cd15e39872a61a5221d6f49a699fedd0cafe8929f178
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 1c3ede1982a807a410ae1e21947bf430f8db7027
+Tag = 26f7907e235c09d3322c4092d2e88f88
+Plaintext = fa9743a67978c20316cb91801d7789e350079aae3aadbd43
+Ciphertext = ab7133f255a7983f3d88863be1050269f56da2c3b6a465d0
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = deb05a30a026ff66ce71e98afa62f0255aef84f5
+Tag = 6bb44a28c145d49f49f2821d4044e4b6
+Plaintext = 99599b4042dcdb685350cdecfdf24992fd5b165670025d0c
+Ciphertext = c8bfeb146e0381547813da570180c21858312e3bfc0b859f
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 93dd9b00a3353e5331338dcfcb7ca7e0bb873a4e
+Tag = 0f7d20aa3d792d6a3ebc5ee0df2fd89c
+Plaintext = 451101250ec6f26652249d59dc974b7361d571a8101cdfd3
+Ciphertext = 14f771712219a85a79678ae220e5c0f9c4bf49c59c150740
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 0855263860043207543c8c34648d53ec51c4f47e
+Tag = 7ca4733f0208668b0a7879305e861d71
+Plaintext = b2db87b7787531968d603098cb20ca7c438b4af72623fea9
+Ciphertext = e33df7e354aa6baaa6232723375241f6e6e1729aaa2a263a
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = ee2d3a66deb3ebca867a902bb9202226ed516ded
+Tag = d76b482ff20429da8f60f0f863e1af50
+Plaintext = ca18ce38086223e63b4f0b616d110010f9e45eac42f2ba46
+Ciphertext = 9bfebe6c24bd79da100c1cda91638b9a5c8e66c1cefb62d5
+
+Cipher = aes-256-ccm
+Key = 2ff64bbec197a63315c2f328dcb4837d0cdc21a5d6f89ff1d97cb51195330cd8
+IV = a235f8ee3de9896b71910ac02c
+AAD = 8e531aaea849addab6a83497cbc504f489505952
+Tag = aab66e1ac2346ef97850a4985c64b737
+Plaintext = 5717ed5da5b8aa806a18bfe979502bab6632c9428d3a7725
+Ciphertext = 06f19d098967f0bc415ba8528522a021c358f12f0133afb6
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = 2d838eb51a4bc69a001a18adf2084a680f02a3c5fc
+Tag = ef9af5679edbcbb7db20ab6af30698db
+Plaintext = d3416a81b4246eb0bf8119a72a886bbc0ac9449c69f71d2f
+Ciphertext = e001a8fae390dc5d672cdd18f86a1f728158ec83a002050d
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = d83ee7ce22fd1a2882d8d552346e4d7b3efdd67da4
+Tag = d435a5a38f84387f63b13407f65ec86c
+Plaintext = 22b6f10b482448626f6c7bebb14f1497896d071738133b4d
+Ciphertext = 11f633701f90fa8fb7c1bf5463ad605902fcaf08f1e6236f
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = 2d5537b24d0b0f7a45703c1e131656ec9edc12cdf7
+Tag = 2ede8a705f8c988f55459542bd631b1c
+Plaintext = d60edc830be8207ffd9e9f646d3b4343b10b3d56acb89d44
+Ciphertext = e54e1ef85c5c929225335bdbbfd9378d3a9a9549654d8566
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = 1a750eb326923412d94ccb35f5acd0f87415268178
+Tag = 986de774a612230ce6c71449d26732ce
+Plaintext = 716d3132f449a9def383978102ae50ed3ccae0cb346ba1df
+Ciphertext = 422df349a3fd1b332b2e533ed04c2423b75b48d4fd9eb9fd
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = b10fc523bc4562d44edfe5956f93c15c4ab38bba3c
+Tag = e710431005264fa7d3fc04bac50fc1ec
+Plaintext = 063c2ae2a15f26f979bf90657d20643e3184f1a9f75a3aad
+Ciphertext = 357ce899f6eb9414a11254daafc210f0ba1559b63eaf228f
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = fe4f60ce9634e7dbc5e56204c4bf8aa9be577027ec
+Tag = 5c13bea6ad0cad724e6cd02c89517ffc
+Plaintext = bdc513e56a5bb70c02abc041af04d6e45e735d10cc88357f
+Ciphertext = 8e85d19e3def05e1da0604fe7de6a22ad5e2f50f057d2d5d
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = 48f3ceda4fd390a7eb38f7f5bcd14310af6b5a557e
+Tag = d2a5531655aae01e249f213e0e04af0d
+Plaintext = 7dc5d8cd90ce2faf76bbd0d52e5ae11b310fc2b0051c4377
+Ciphertext = 4e851ab6c77a9d42ae16146afcb895d5ba9e6aafcce95b55
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = 199ec321d1d24d5408076912d6bb2b6f192d6b347f
+Tag = 2a127ef341345f9641b26e91265e1482
+Plaintext = 66c2696edec26ba3d07bd3f485a0d6ce8a1b0a85b20083e7
+Ciphertext = 5582ab158976d94e08d6174b5742a200018aa29a7bf59bc5
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = 8b013f5782d5d1af8dbd451a4202866095dac975fc
+Tag = a005ca13c4bf715c3b7b2782f799b23a
+Plaintext = f4da8ac3e8fe5ec6a5b6a2f27b68396e850b46a024d441f0
+Ciphertext = c79a48b8bf4aec2b7d1b664da98a4da00e9aeebfed2159d2
+
+Cipher = aes-256-ccm
+Key = 24e9f08a9a007f9976919e10dc432002e2e078a339677f00105c72ed35633a3f
+IV = 15977424eeec0ec7f647e6c798
+AAD = e320df32b71cc530e8493b12b9afbeabc255c5eb44
+Tag = 04642aff9cb9288d49f0e567dd837e05
+Plaintext = 244891cb4af66cc8e99a3784a2e82475e51bd5c7fde67cf5
+Ciphertext = 170853b01d42de253137f33b700a50bb6e8a7dd8341364d7
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = a2f6337f86dd00d1a58448851e95d8c9bace4a5c8710
+Tag = abc1f9d0132394149c9062b74b82f04b
+Plaintext = 2f59d94d4ab8eeb84c2a6fefb7fb0a3ac059c1e1a65ae34a
+Ciphertext = 7ca0b1dbe34b0391e524b868b0af08b3e096917664d6aa2c
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = abf26b05558252c8e38c52b1ace087bbd1eb3d561239
+Tag = 6d7df57c6a792f6f6b24cb5f87e92123
+Plaintext = c25381853f73a3dc4195fdcbc45dfa1a40eb8324749adb2e
+Ciphertext = 91aae91396804ef5e89b2a4cc309f8936024d3b3b6169248
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = a13ade56b47803897666e42ef2ef88be0e779ac86c28
+Tag = 4ac19b0b74cd9d5e100598b96c9f1f2e
+Plaintext = 8dc5226a2a13088c87f4bf94262e0c0413f06b35d2fda79b
+Ciphertext = de3c4afc83e0e5a52efa6813217a0e8d333f3ba21071eefd
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = 3c5b68b65edf62755b7e064bd26c843816bf6c1cd481
+Tag = a77a27eabfc79f192c0ac491280af8d0
+Plaintext = ee4b23039cd512cfab8c7a2d0f2c78d66764520bc88759e1
+Ciphertext = bdb24b953526ffe60282adaa08787a5f47ab029c0a0b1087
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = 0213fe13c49083d7c00335e1864dc139c9e7123162d1
+Tag = 39935f91c1e29fc1e4c5c5427ca9da79
+Plaintext = 30b48d4021838090fbd5251069ff8c631452daee5ef899db
+Ciphertext = 634de5d688706db952dbf2976eab8eea349d8a799c74d0bd
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = a32291746b151be8134e183798aa82bef210343feaf6
+Tag = aeaec90ada2a1ffef64c3873af645a40
+Plaintext = 2286a1eddd80737a724ca941217e9f0232870b6c2f20d29c
+Ciphertext = 717fc97b74739e53db427ec6262a9d8b12485bfbedac9bfa
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = a30f2fd445820cdf800145540602c877da0e4c311272
+Tag = 7932952831d0ba25c77c18fe154d8ed8
+Plaintext = fe703ca0901e4a706ce1393c7d8ce18a03eb2caadbfa7b8e
+Ciphertext = ad89543639eda759c5efeebb7ad8e30323247c3d197632e8
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = ed438e393e0e37629cb25044ae89de9fd0d42d60c1a3
+Tag = 234fd0241d00f3890a23ccd0bf16dcbf
+Plaintext = 7043c67726870bb5816da925925bc2722478311c8a606cca
+Ciphertext = 23baaee18f74e69c28637ea2950fc0fb04b7618b48ec25ac
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = 1013946815001a2c08acca4196e0d6668ffbb3883cf1
+Tag = af43498b0c3f70c119f82d5812db940f
+Plaintext = 695e9712dbbf883e9bf8af9188bd01fc631968928258168d
+Ciphertext = 3aa7ff84724c651732f678168fe9037543d6380540d45feb
+
+Cipher = aes-256-ccm
+Key = 0ec1b22b8df05dc92135d2dfbefed8ea81458f5ea1b801e8a218faf6cbdf1a79
+IV = 97ebcb8575bb58260208d5c227
+AAD = 44cc9b2510680c4d73f1938c77de21242c8ee790ed7f
+Tag = db66dbb03a4c943ac089ed11eb214bbb
+Plaintext = 67ba90d22c6bb5f649bc0c505c5ed23a299882559a3bf520
+Ciphertext = 3443f844859858dfe0b2dbd75b0ad0b30957d2c258b7bc46
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 7cc9c51b69f98a06391ab32742fb6365e15106c811fe8a
+Tag = 9163fa7a867f04cab6f52dc250070f31
+Plaintext = 065ef9eeafbe077c1c7049f43eb0d8999708e8609f214d5c
+Ciphertext = 990065322a438e136860f7b019807e9feff52a642bf3d44a
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 7bb1bc069a783d45d51d8ecd0a53ab7a386fa1f5ef12a1
+Tag = fd33dd9155619fb040dcd6038c7b7367
+Plaintext = 69b2b056f2265e707d3e31e68bff6a060544c8a737b2a9b9
+Ciphertext = f6ec2c8a77dbd71f092e8fa2accfcc007db90aa3836030af
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 0dd220919d0eeee3b7cec36c47e376b778583b38bf61c8
+Tag = 4fcba5a886b1f33cf1cf44618d28f01f
+Plaintext = b98d79aaa4c04171398c7f1189497acaa7546ef068bc7a3f
+Ciphertext = 26d3e576213dc81e4d9cc155ae79dcccdfa9acf4dc6ee329
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 1c1915fab09348b9a5536495c70d1a040305708c112479
+Tag = eafe2c670eac203d5e90b9d520e7a618
+Plaintext = eeaeb773ade5fb2d27b50bb892916333e0b123c6e3ae5bdb
+Ciphertext = 71f02baf2818724253a5b5fcb5a1c535984ce1c2577cc2cd
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 614b0ac4611b6c6d3b4ed089510dcd2215567bc3789f85
+Tag = f0388746438e83b731b5588fef53f1f3
+Plaintext = f2198e1f91fde2672a1ef60403c0d175f366b6780ee9f1c2
+Ciphertext = 6d4712c314006b085e0e484024f077738b9b747cba3b68d4
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 866fea4483d4e903566844e31c24283571832dfae32c74
+Tag = fca81f8b36d16698a600fd701f2c6424
+Plaintext = ba37617342b4eefd4bdce8fad30c4751b206d47814973b3a
+Ciphertext = 2569fdafc74967923fcc56bef43ce157cafb167ca045a22c
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 9d7546f7e8b949c539d21a357f81d0151e278d0bf2c5a5
+Tag = 4c15a6d292c7ed2f31cf9512435ec7d2
+Plaintext = 69adcae8a1e9a3f2fe9e62591f7b4c5b19d3b50e769521f6
+Ciphertext = f6f3563424142a9d8a8edc1d384bea5d612e770ac247b8e0
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 42b692048c8b3cce1b5e83f4f33232a7d7d0bc20695e7e
+Tag = a2ad73179d0314b5fe52dd7217518cb8
+Plaintext = e0753d4248643642c7a96404de8d76c9d80527b659ec6d31
+Ciphertext = 7f2ba19ecd99bf2db3b9da40f9bdd0cfa0f8e5b2ed3ef427
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = f1dfb6fdb31cb423226f181c0988a52ee4015aef4536f4
+Tag = 9ccc5ba1caf933b80bfc6f281109688f
+Plaintext = 79ba959c7221b293e2115f538d9394c64284c756563c04b0
+Ciphertext = e6e40940f7dc3bfc9601e117aaa332c03a790552e2ee9da6
+
+Cipher = aes-256-ccm
+Key = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+IV = 451101250ec6f26652249d59dc
+AAD = 8eafce9ba466fd53eb87f499d7c76bd486db0e90a3d281
+Tag = 73271ec36d92fff34609169f579c8f1d
+Plaintext = e1590206717a708cad9cca7d23a3b8ee5f7fb7786aa3be47
+Ciphertext = 7e079edaf487f9e3d98c743904931ee82782757cde712751
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = cd0522ebe1fed82465277d1c10ae9316a98b4469be63b180
+Tag = b25764e40ac6a171e7e6bab4fdee4288
+Plaintext = c99c3e79125b6fd95e737326a842424eb6c6ecea4c0475c4
+Ciphertext = 76df4be4ec8373864399acda11294b220b9f7c3a7d2b3660
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = ce5bf070678cb07e963263b1562ff79311144addb6e4de4f
+Tag = fca49758d17f2073066b82667eae6ce3
+Plaintext = eede01b08f9a303cdf14c99d7a45732972c6eff2a1db06eb
+Ciphertext = 519d742d71422c63c2fe1661c32e7a45cf9f7f2290f4454f
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = 07175be2475cc735c9a3c1140895277378debf8fb1c87c24
+Tag = 7c1d64d7e9de47a6ad7878283da9d870
+Plaintext = 6d5579aaaf8737b01620424f3ddeaf538f10dfad094e5ec4
+Ciphertext = d2160c37515f2bef0bca9db384b5a63f32494f7d38611d60
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = c821a8d4bab9d993c20dd206955304a55968e6db5ab6480d
+Tag = adc2bb471862d25cfe25e66fedb8e28c
+Plaintext = d0628b2027f06c246497977d05f211b2c2e302d5b82700b5
+Ciphertext = 6f21febdd928707b797d4881bc9918de7fba920589084311
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = 68439bc9d176feeeb4119d00ed5449dfefb72b5a582bfd97
+Tag = 319a493abc947945f1312395ea98d937
+Plaintext = 6cc9749f48c61050e421afa3a10ad3dd3aa02cc3f8586915
+Ciphertext = d38a0102b61e0c0ff9cb705f1861dab187f9bc13c9772ab1
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = adb262c924942e4e1964e9d97c6a8c159fbf9bfedc5ff296
+Tag = 21d0602d29447ba6b24a67509eaee1e8
+Plaintext = 92d50736466e64e6225962e76bd90da824f716a3301a1a90
+Ciphertext = 2d9672abb8b678b93fb3bd1bd2b204c499ae867301355934
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = fc7b08707d3c3dac7689ec18088ee6502ef08d3ffbff38ed
+Tag = e52a2eeacb1f023e849161b6306b6cfa
+Plaintext = 87c7ac031fd63e4c83280dce6b68a92dfafb6ea19388fa9f
+Ciphertext = 3884d99ee10e22139ec2d232d203a04147a2fe71a2a7b93b
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = fd43dfb66041b117f2ac54c94f7b6e2677860864d9494175
+Tag = 0d8c5b1e96b21460e0b5414639abeb0b
+Plaintext = 6b53c46266b2f4284d8fe7f0549c98977344d67e178e9a8e
+Ciphertext = d410b1ff986ae8775065380cedf791fbce1d46ae26a1d92a
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = ef1ad3eb0bde7d4728389da2255d1f8a66ecb72e6f2f1ac4
+Tag = 1c97260d20797d374c595cbc2ff080bc
+Plaintext = 8e7d8a44244daa7df2b340993e32dac50e05d7b2e103be98
+Ciphertext = 313effd9da95b622ef599f658759d3a9b35c4762d02cfd3c
+
+Cipher = aes-256-ccm
+Key = ef4c1d2314e671f666cc6667660f1438a293208c7cc29b412d81277f0a635c91
+IV = 50b23b052922366c25dd40e348
+AAD = 9895b24d12b004b215583eac70a95f4fba7442164f35c57b
+Tag = 6cd287afcbdbc5531f11246080b22677
+Plaintext = cec07df916ffb7a453d0eb588b7462096f22874bd5abf814
+Ciphertext = 71830864e827abfb4e3a34a4321f6b65d27b179be484bbb0
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = f5b2c88f5232c37273b1e66aa31cfa7201e33c21d60054d025
+Tag = c1411af83237c0f9eb0bfe8ed914da66
+Plaintext = 617d54fc6a23601c79e3984f93bfc2d151fde420863206b3
+Ciphertext = 57b3414db48982c6567265e1e0173bf38fdfaffe4461fbeb
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = 8fabe14dcb3aa2fd28281147c326e98ad699ca7997f03a105d
+Tag = 7ed6e23720b60ffe54bbb9f7ff371008
+Plaintext = 337290d0b4ce1e87afc3cf01d6c98f8c17a4603120dcfcd1
+Ciphertext = 05bc85616a64fc5d805232afa56176aec9862befe28f0189
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = cf193eb3d755cb8e06c5be2334b5c8b7a22b6524d46d547ba3
+Tag = b6aa6b284e7720acbd027a50317f816a
+Plaintext = 01ef7ac6470aa02ccd8c1712827e52699d05751b78e4c5a6
+Ciphertext = 37216f7799a042f6e21deabcf1d6ab4b43273ec5bab738fe
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = b4cadb5f9cb66415c3a3b71421b926f147566a174160a0bcc0
+Tag = 7058e9c0164ca079668097fde19e5302
+Plaintext = 64fb9322210fb7d8da8e762498b233b0eb172c91231c50cb
+Ciphertext = 52358693ffa55502f51f8b8aeb1aca923535674fe14fad93
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = 48400d76ff882d6d5129c8674acc71f445356c9db9c91f8256
+Tag = f988611d5ce0f65b217bb4787bf59bbc
+Plaintext = 291aa463c4babc76b4a6faf2e27e9401586b1ac83e4b06a4
+Ciphertext = 1fd4b1d21a105eac9b37075c91d66d2386495116fc18fbfc
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = 749d369d837002ad33feb8aa22c3f68705eb4872e1b8f85a7f
+Tag = d6251a5fd375a48583a6d0f8eb75cbb4
+Plaintext = 141cdd7f964a78815be144a785c6a2a298c54230e73039e2
+Ciphertext = 22d2c8ce48e09a5b7470b909f66e5b8046e709ee2563c4ba
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = 80214108b16d030feff6e056c9a07a00a1d5e3ebb07abd3f4a
+Tag = af1dab0f105414293cb130bea285fd6a
+Plaintext = fa2441cb7f9d072b8a3f1a496b2be6728a38b94a4f44c9be
+Ciphertext = ccea547aa137e5f1a5aee7e718831f50541af2948d1734e6
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = 8b9fabe29718a8f297c9bf6f199c80bbc71f94eb3034a11ecb
+Tag = 1cc3f7640a42460be877fb7059a3ed61
+Plaintext = c8ce88ab40b62229223d46cc44f21bb39cfef27aa9fdccad
+Ciphertext = fe009d1a9e1cc0f30dacbb62375ae29142dcb9a46bae31f5
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = 8812f28a0cd5fdaa226fdd44ed857241007377057be3bea577
+Tag = bbe0ddd2e7f4aa2024b3fec9281b6cac
+Plaintext = cf59f75ca4d6d216cf8862b44b5192c382c140f862def117
+Ciphertext = f997e2ed7a7c30cce0199f1a38f96be15ce30b26a08d0c4f
+
+Cipher = aes-256-ccm
+Key = 8544808e8fbf8c3a5e1d4ca751d4b603af9fe119eabc6923205815e0e748b7e7
+IV = b44a58724596b4d8dea827c1a0
+AAD = c8f05e96d703a4850bae1421ae9ff3aec7531baf9b899dfd75
+Tag = e5df1e5e96bb84f730fcb253d468278f
+Plaintext = 4eed58f381e500902ba5c56864f6249d191e14d1b1fad3dd
+Ciphertext = 78234d425f4fe24a043438c6175eddbfc73c5f0f73a92e85
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = ef88f4393d6c1e7b7be55a12144209ee051bb779e440432721ef
+Tag = 8a20a1abe7c842ebc08c8c81a2743c81
+Plaintext = b3b0de10b7c0996662f1b064e04e528b7d85ca1166985d33
+Ciphertext = d63e6082c95c6c5ff2bc0771321a4f883ef61cff7b99e0ea
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = a4c891c9dd1fcc982c35bc74cfe71651bae424602519672b466d
+Tag = 845e2d6de83ab729dd200a21088a1ec3
+Plaintext = 4f0b40913f07269550b7b06ab9027a4d9331f8ef98a45dca
+Ciphertext = 2a85fe03419bd3acc0fa077f6b56674ed0422e0185a5e013
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = 4db5730cb9794f3b1facc9d6738115d02ba9f27ba02330fbb856
+Tag = 10ed272c732247a696a608ef67510f9c
+Plaintext = 841e032773d58bc72a3237bc9b24c61b9efdd850fc2ea605
+Ciphertext = e190bdb50d497efeba7f80a94970db18dd8e0ebee12f1bdc
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = 471a900ee49f2cfa1d3eb37c951d810c349364d4cc3b5b64fc47
+Tag = 15f0df52e392c37ec15f7458469dae84
+Plaintext = b4db42e523e65557157b93dc0281601f7997e6731543a914
+Ciphertext = d155fc775d7aa06e853624c9d0d57d1c3ae4309d084214cd
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = 7b40b3443d00a0348a060db109e8882157612c43084ac5c3e9c5
+Tag = 421433dafea2b5484ba87b5050e1fb49
+Plaintext = 73e0ed35c0e847188e607cde46586eb9e237fbdc5d59163c
+Ciphertext = 166e53a7be74b2211e2dcbcb940c73baa1442d324058abe5
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = d563f5c048a1b45265182b99ca7b9004fdc73a9cb07806dd44fc
+Tag = df91749fe3cd52a9431d9a847a8c2a9a
+Plaintext = 4f7669caaedee961dbba6bde9d09fee1a20eee55baaf98f5
+Ciphertext = 2af8d758d0421c584bf7dccb4f5de3e2e17d38bba7ae252c
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = d301a61eb17366d4e70942ab69b4f4bcf8ff6a97f5972ee5780a
+Tag = 7563d37846f5185bb44d71be1ea6a73c
+Plaintext = 154454fb74e9565c56775a8e4654f75a38b954dd28c4e939
+Ciphertext = 70caea690a75a365c63aed9b9400ea597bca823335c554e0
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = f74b48d168f77fbd3429728c0b168ecbd854264eaef70b74fffb
+Tag = 55e93bc2d3f05d7016747690fb920e12
+Plaintext = 716b371857e68a17b20ea06651cdcfd4560a741830ca8a13
+Ciphertext = 14e5898a297a7f2e224317738399d2d71579a2f62dcb37ca
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = 3a257ce3592a8f88162f0bb4ecd5db3bb79b54ab17b0bbc61506
+Tag = 1c46822f839f09c41b7aa6dc06035c93
+Plaintext = cfdb7363985aa01af6f8e8237dbfb7871eb39303b4135269
+Ciphertext = aa55cdf1e6c6552366b55f36afebaa845dc045eda912efb0
+
+Cipher = aes-256-ccm
+Key = e19eaddd9f1574447e7e6525f7fd67e3b42807e44fbb60e75d8c3e98abc18361
+IV = a8c459ce0223358826fb1ec0f0
+AAD = 21916ebeca9e66b77cf55d1cac80a4c85d8b6b014f268ffa73ca
+Tag = 4f8e77600c5bbc6d028fa25ba61a1719
+Plaintext = b4b67ac551d1966caa20d951351387f384c2e5d81a76a92c
+Ciphertext = d138c4572f4d63553a6d6e44e7479af0c7b13336077714f5
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = 70cfcb828d483216b46c3cd22e2f9ee879e9e3059b566179b6e16c
+Tag = 1f8332f4236437737438e7aa1b5100c7
+Plaintext = 0d16cc69caa9f19b88b05e151b3d26accd018ca4a5786a80
+Ciphertext = f1c4bedb8d6f91676881daa37656a7e6402f472735b04a0f
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = e7e5779282db80f424dc050b2c1e7754b2a5d3a8beae77beb74e34
+Tag = 8be2f6f356c2eb401468be15104e7763
+Plaintext = 148de640f3c11591a6f8c5c48632c5fb79d3b7e1cef9159c
+Ciphertext = e85f94f2b407756d46c94172eb5944b1f4fd7c625e313513
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = d17e8189a94a559b07be9549f73d653172740e8e978f5b0a38ad43
+Tag = 9646f2b6c2455603f1a6f20ea5a4611a
+Plaintext = 00a23b25bca7c206edd051814d81083db1cd00048ce8ead5
+Ciphertext = fc704997fb61a2fa0de1d53720ea89773ce3cb871c20ca5a
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = fda37ff136895de7ebeaf81e701e5751245201baed2e13d7e1b591
+Tag = 303fa5d8321241b1c9e18a5909d6e428
+Plaintext = a89409b0977f60a029dc4c1560ba6dbe7c65b068633acf74
+Ciphertext = 54467b02d0b9005cc9edc8a30dd1ecf4f14b7bebf3f2effb
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = 9c179fd0d6277a5e073e77dd6abb4cba00ad9c9932e6c002b951c7
+Tag = 9e8cb01db1da077502814db1610662ce
+Plaintext = e16c69861efc206e85aab1255e69d6d33c52cf058dec9d0b
+Ciphertext = 1dbe1b34593a4092659b359333025799b17c04861d24bd84
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = cf5703228e615428d3d3805e428e754961d205c5aa0297ecdea71d
+Tag = 40a02a49857d7b280330b8105efac854
+Plaintext = 62036cbed3666d85624d3dc9c1f437454b9ab5c03ce0de92
+Ciphertext = 9ed11e0c94a00d79827cb97fac9fb60fc6b47e43ac28fe1d
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = bab7e36098d59d3a31d7784d549aebfc6938bbd0612c85c0edb796
+Tag = 5ecfa9dd03e2db70aa212ee7dcb573fd
+Plaintext = 790ac86c5e9d8ce8cbec1dfb7e4fc4dca3d0b1039adfe585
+Ciphertext = 85d8bade195bec142bdd994d132445962efe7a800a17c50a
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = 96f0b7cd7439721d4c9cc4f69585f8c90a95bed8fea22150efffba
+Tag = e17a7a0cd162945a3616892e101e3e93
+Plaintext = 3cfacd61ea3398de20ca6bdb00e81af482320614bdfb8642
+Ciphertext = c028bfd3adf5f822c0fbef6d6d839bbe0f1ccd972d33a6cd
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = ee71e53d0b4eef82575c2bd38d7bd21b41fabe58c6f571954fe159
+Tag = 15fadc2d79841d230cd55c04379f22b4
+Plaintext = d75c153e34ae1c6d1fcf5b1052190d8882041e1f9c5490e2
+Ciphertext = 2b8e678c73687c91fffedfa63f728cc20f2ad59c0c9cb06d
+
+Cipher = aes-256-ccm
+Key = 9498f02e50487cfbda1ce6459e241233bd4c4cb10281dcb51915dbc7fb6545c0
+IV = e3bd4bc3a60cddd26c20aa8636
+AAD = 18a4aa894861c7720ddb43809c3d2ed2af2f1bfe8f9fd4f872c14c
+Tag = b229b9bae4634eea6b723f432e19ae55
+Plaintext = 0e728056c7c64214be8f1f1727408d8cca8c42e2ac7bf67e
+Ciphertext = f2a0f2e4800022e85ebe9ba14a2b0cc647a289613cb3d6f1
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = ecbd7091732e49c0f4bda2e63235ea43bbf8c8730f955f9c049dd1ec
+Tag = 475acd27900478f09fec1f479ab3a7c8
+Plaintext = 89198d3acc39b950f0d411119c478c60b2422ffe7e26e00b
+Ciphertext = 7717b8e4447afcea1eeebf3e39ffdab2f52828e7931ef27e
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = 9a04820205234795ecd540b6a0b2fbd0b19f18106c42f374a2b98425
+Tag = f7b7ed6e8ede6ef5a73b484bf13b3424
+Plaintext = c0f61950f98110db4226e269cf197c7e2794c5b87ad68cf9
+Ciphertext = 3ef82c8e71c25561ac1c4c466aa12aac60fec2a197ee9e8c
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = 0e4dbd167da0240298f4795102ef18ff9a8772c6fd73b3374cdfa30a
+Tag = e47d08ea0788f7ca0ecd846689c8027a
+Plaintext = 7960dbc9136880e2eea7956c3271adfe2aba7dca53da917d
+Ciphertext = 876eee179b2bc558009d3b4397c9fb2c6dd07ad3bee28308
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = 2de4291068a5d290b599a73c6a8ecff4f9fd6c9cc48f14c233e18581
+Tag = d081f66b1c7b70718dc50367c3da6792
+Plaintext = 0c5d7055bbfbd2bc213cfbbafa763b71b1fde6f4de96fa59
+Ciphertext = f253458b33b89706cf0655955fce6da3f697e1ed33aee82c
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = dedeb714f555575fcedbd9de8171484090e6466dd4fba3c6b7c42eae
+Tag = ce672883438da186741e6c542b3f805d
+Plaintext = b5654edcc8f09e4f80d0258c9376d7c53fb68f78d333b18b
+Ciphertext = 4b6b7b0240b3dbf56eea8ba336ce811778dc88613e0ba3fe
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = 03d340904ace1cd52d4b72a96d96afd77aee68ac3936415005ed0d56
+Tag = cf58d4a5552bc8ed1b1dda46703a256e
+Plaintext = d796f3409a7eeb896c3d4ebef46e9c6e553aab28b1cc4a90
+Ciphertext = 2998c69e123dae338207e09151d6cabc1250ac315cf458e5
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = c67f9aa8cf1be3b4377c30c175d33ab2af390982c6a015d99209acdd
+Tag = f95cf2b57e06de4d01bbb6c0e39f37e1
+Plaintext = e4dd279a79a381c68de777df941a4779e50a1381c8aa9122
+Ciphertext = 1ad31244f1e0c47c63ddd9f031a211aba260149825928357
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = fef1b2ccd661b9fac85ba005addebdf8317ab104920549d3a490a21a
+Tag = 7589cd12984286af98908db88920323c
+Plaintext = bbf0c267d952aeb6f810601b9cf1962a92dcaba7273e6902
+Ciphertext = 45fef7b95111eb0c162ace343949c0f8d5b6acbeca067b77
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = 693fae7af84aa397f0b2baaed9b3c7953f75e7424c49b6349c2fc20f
+Tag = ee8fc441da990dd92c0caeac9d956699
+Plaintext = e8b13a263e0c4fb5645e500e88ab8074ab7d92e5a8dac6aa
+Ciphertext = 16bf0ff8b64f0a0f8a64fe212d13d6a6ec1795fc45e2d4df
+
+Cipher = aes-256-ccm
+Key = 3ac7d5bc4698c021e49a685cd71057e09821633957d1d59c3c30cbc3f2d1dbf8
+IV = 54c8ff5459702aac058bb3be04
+AAD = 85e5df4ddec99f0bea14b3338b2eb190ab6584f5253c6c2ee3064637
+Tag = d502f5434bea8c3c13ad5422ff90e218
+Plaintext = 067de2869333ed22c7b63ed7eeba1301bbac69b0d430adb5
+Ciphertext = f873d7581b70a898298c90f84b0245d3fcc66ea93908bfc0
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = a516ca8405e5c8854e667921b5c5e1968bdd052915b55ac9984b7eefb3
+Tag = 12e57c576b315f48c11877178389aaa0
+Plaintext = 8b9130b0c3c15366831bbb19f377e3209a8dbf7619cd09bd
+Ciphertext = 4646b2acdeb11174171da23999cd54e297daa32bbc13d305
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = db3121ea71294983b185207a9d8de3e484a66c0431bf07c962eb82977c
+Tag = 66775e693f93af6575dccc7903538065
+Plaintext = 7f369bbc99b6f08049eeb43566269a174829d4dddb05cb9b
+Ciphertext = b2e119a084c6b292dde8ad150c9c2dd5457ec8807edb1123
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = 1651cf38fd9b2da65ebb4922b97dcb861128eeefa060d6c1c94b25eb4e
+Tag = b70d8de40c2068de96a274d3b5086b5a
+Plaintext = fd0900b5fa72e2fba43d611bad25de40a3507a5cc5d186c7
+Ciphertext = 30de82a9e702a0e9303b783bc79f6982ae076601600f5c7f
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = af87b347b59e37a424004a00907dcbcf6a554e6782a9be12cb3047625e
+Tag = e7da096d2fb28f20f64a000fe93e96e2
+Plaintext = 36318d80c02a1da41ef1652d9a752e155526b5f597fba226
+Ciphertext = fbe60f9cdd5a5fb68af77c0df0cf99d75871a9a83225789e
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = 0680d5bacefa2ab14aa12b0e517a1432862d4215dc72dc4d5ac6b96c1c
+Tag = b88748a2de31261534cdb2237565bf8a
+Plaintext = 7a29aa2994d11215ab3ef3382b3db6ed581164a235c4b1d1
+Ciphertext = b7fe283589a150073f38ea184187012f554678ff901a6b69
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = 9af701f0a9de52309267289bd170fb97c03c131c0a169d736137ff3d74
+Tag = 0c003eb65ceedc98ae4e38ef341ee47d
+Plaintext = 3542fbe0f59a6d5f3abf619b7d58b199f7caff0205093f8b
+Ciphertext = f89579fce8ea2f4daeb978bb17e2065bfa9de35fa0d7e533
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = dab7845fb7ead205569475753c7e26540c09d3a74312f2de25181511f8
+Tag = 5c2fb596d8ff6a863604cd224fa3be42
+Plaintext = 83c15520d9541c86b3dd809ede42de22bbb2b75ff18a023b
+Ciphertext = 4e16d73cc4245e9427db99beb4f869e0b6e5ab025454d883
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = a844d6dbd05545ecc736994dc9fc2260c5ab63ed6ffdc40b915f8744a1
+Tag = 2ac782e2cd8ecb06172eef2cb9b0e331
+Plaintext = 793a188fa3efa32f41d6e4c5b42353b95024117d546c79ca
+Ciphertext = b4ed9a93be9fe13dd5d0fde5de99e47b5d730d20f1b2a372
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = f9112503884615c0e8a1d8414724b0d19298988f393a27c436b2b6734c
+Tag = f814492b42571033f4dffc0282ea2f51
+Plaintext = 6b237444fb0e1f4150701546c4cb24021c5edad30d9b31dd
+Ciphertext = a6f4f658e67e5d53c4760c66ae7193c01109c68ea845eb65
+
+Cipher = aes-256-ccm
+Key = 948882c3667caa81c9b900996e3d591e6fcb3d08333eeb29911e9c6338710c17
+IV = 43b0aca2f0a9030f90559fa6d3
+AAD = d633a5a3defdde6a68f959ef39a91c6ea6e13ef1a7859d2c2c94d3a5b4
+Tag = 75999099df2de6e436bd99f0341423f4
+Plaintext = 6342312e8a72f71f2e5afe04cfcde4d60a41556111752103
+Ciphertext = ae95b3329702b50dba5ce724a57753140716493cb4abfbbb
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = ebf0b3e3199a5c3773c761c725c7600add5f9d8321c9f8e5e5fd1c7a5d2f
+Tag = f8562eadcdcbcdbad1299bea1523f5d2
+Plaintext = 094b538110495e938b08cf748a6bcf3e0c80ff9c66570237
+Ciphertext = 4d8b53016fc8bc9677184c0fa15bbd3d671b9366d82ecb67
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = a865b88d512e485ab3f2844c29e6dde0cf1151efa9ad3b3021d06fffb74b
+Tag = 59ff77cf0962455b3539dbf91f3077cc
+Plaintext = 23edddd8732cdbf03af08162f0e4a24c9222bdbb4549c663
+Ciphertext = 672ddd580cad39f5c6e00219dbd4d04ff9b9d141fb300f33
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 16918dbc785d94a8f1720c5ad234dde860219874c9fb076a5c290903f85b
+Tag = 6dbed76d94c90595b49d50c84c3efc76
+Plaintext = 1798286c37c1504fc0d7402681f6f70711ef506dcc3e29d0
+Ciphertext = 535828ec4840b24a3cc7c35daac685047a743c977247e080
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = a2969243b0955402ab45a430fef2ef9e0c025006732bf8e592e3d3884918
+Tag = 48fbe60c146056e5cb01268403e4b9f5
+Plaintext = 0d02778f90a164a4f9ada9dc7fd24eeb941069621418ef32
+Ciphertext = 49c2770fef2086a105bd2aa754e23ce8ff8b0598aa612662
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 2de5222a0609f058f60e9e581b6e4f0ddebed84fc8302c8e985d17b89241
+Tag = acff35df1ec942b43eef5aef980cb038
+Plaintext = b0c3858231e284af6d231f043b95772f5e7b16a34ffcd2ec
+Ciphertext = f40385024e6366aa91339c7f10a5052c35e07a59f1851bbc
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 3fc7453df038a92829dc103d44b63ad097d7cd7f9ae7996547012090c7c4
+Tag = 91a93f5fc28e5f4f351cfb888da763dc
+Plaintext = 319f396cc02834f8e69d65f77496d0eb31ce1a7b7e324820
+Ciphertext = 755f39ecbfa9d6fd1a8de68c5fa6a2e85a557681c04b8170
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 18f1e92bd3c4a597ed970911d03a78ff9a6790147c9bb0ca5f23b70cce7a
+Tag = 2c6a90ef2e9a969ec0576fae1d126a85
+Plaintext = 25550c03f8fa02b3781330f96e0fdc58681b0c0bc5e83fe9
+Ciphertext = 61950c83877be0b68403b382453fae5b038060f17b91f6b9
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 09ecb2406054716418ff3600c3c5cacb0845a377a2d80542abc36ec81bb1
+Tag = 59fd6aeb047200907911621e8756b45f
+Plaintext = 210ff7975e08388b9a46eb732230e3a3856a497549b5eb49
+Ciphertext = 65cff7172189da8e66566808090091a0eef1258ff7cc2219
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 62d515bb0525b565a6a3613ae20343c8da7424c8368e8cad6a862b7d37a5
+Tag = c4db6d5fd910c83fd77aefba3f7665d8
+Plaintext = 5d867265965bb2aafebb0691de9e157a24066d06fe3cbd7c
+Ciphertext = 194672e5e9da50af02ab85eaf5ae67794f9d01fc4045742c
+
+Cipher = aes-256-ccm
+Key = 3bf52cc5ee86b9a0190f390a5c0366a560b557000dbe5115fd9ee11630a62769
+IV = f9fbd02f28ecc929d369182752
+AAD = 00617ca141e55b045a188e4934caf6db63d4577f634db92c22010e1cbf1e
+Tag = df5f21f32cbe5d272004f1c104cbcae9
+Plaintext = 396b27afd16a1081f37bbc1f742b549f5f68df799b93083f
+Ciphertext = 7dab272faeebf2840f6b3f645f1b269c34f3b38325eac16f
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 860f4a09ad8b3d345c2aa18ffb803f0bc3b734a4d047a1437701a5e3d95288
+Tag = e678a392d228b210dc5c991905dacf3f
+Plaintext = bc8b3bc48c7a88c9fafde258b6ccaa9d4f0d018703d63871
+Ciphertext = 95f083ad6bbaee6ab540fe023858f8baf25e333fd3e89c00
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 8a84b57915bdbe7bf5a1c1a426512b3c178d883251cc46c95a8bbc8ed9e56b
+Tag = 10fbdd3b305522dae6b652322d89d9ac
+Plaintext = 9499ea48edab9bc21b91dd614f04934ca20db8630622f481
+Ciphertext = bde252210a6bfd61542cc13bc190c16b1f5e8adbd61c50f0
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = ed8540f7ce451c522c1ff5d2d1030d7b3fbd1219a21aaa84044c4f23c08f5d
+Tag = 8b6b08548e794eaf85ad9f5de80b1c00
+Plaintext = 73843a4e9e7937fed24bb1fae15822213b1aa86c07f1b5d1
+Ciphertext = 5aff822779b9515d9df6ada06fcc700686499ad4d7cf11a0
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 61bb196b212feab645f05a8aa1986f6210a384c15bc749245d840b3565fb36
+Tag = cc73643a7ee9291e15137d7046a92f3f
+Plaintext = a8e24266e5981b2ed14213a29f961cbbf7f02f63a33c987e
+Ciphertext = 8199fa0f02587d8d9eff0ff811024e9c4aa31ddb73023c0f
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = a49c2df94ba65107f375ce1c53b72406143f6bcd270945de5b7811682fe361
+Tag = 204438662ea82f423a69c6e4e3c0623a
+Plaintext = 3e3c402caeca41687d12897102e04312edf7b8c7d8567a22
+Ciphertext = 1747f845490a27cb32af952b8c74113550a48a7f0868de53
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 7c48480e9bc87ba299e03899698b2259eef150ee0f2efff40a5583b80ab484
+Tag = 6ea00b9cd881e3f4b1e838dfa31f6560
+Plaintext = cfa9292b9052ac6bb863205d3c0dc2d9e20d2ba6a680d2ed
+Ciphertext = e6d291427792cac8f7de3c07b29990fe5f5e191e76be769c
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 5cf9744090366d828b477dc890eab8ebebd44f6aeaa5b101291bf67d12867e
+Tag = c59b3b87d722a58cd1de58f3963d12b3
+Plaintext = e0fe4e139ab0deb4fdf2145b719f35c50b869e6cb20608b5
+Ciphertext = c985f67a7d70b817b24f0801ff0b67e2b6d5acd46238acc4
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 761d74be5fae170a1bdfa16081b44c1e49972e15ce0818df1390bf7204f619
+Tag = 158759886124f1f0ce8147c94f4e7114
+Plaintext = 665fdcdf55a1231e9912562eaa5a5011d69f6948e29e3f8f
+Ciphertext = 4f2464b6b26145bdd6af4a7424ce02366bcc5bf032a09bfe
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 9815353b69d0b4effa52cefff13703fa71a6296f9cca0f02568661be4b64cb
+Tag = 6310a79c9932456dbc00515b264f3168
+Plaintext = 7b2d52a5186d912cf6b83ace7740ceda3f5f443530c5a49f
+Ciphertext = 5256eaccffadf78fb9052694f9d49cfd820c768de0fb00ee
+
+Cipher = aes-256-ccm
+Key = e45bb1730d0d539aab3805350ac986540de9f0f6c239ee70395c291397b70309
+IV = d5c7824af715bb7822b6b340fe
+AAD = 69dd1a050c8d79dafbbe3403af4dc1f070b9b2b980888aa796e6cff68d9060
+Tag = da7e97f9984a7db3b93aefb4316d9acb
+Plaintext = 3cea5ff50167c5641066852fd00061df35b1f66bedb894b7
+Ciphertext = 1591e79ce6a7a3c75fdb99755e9433f888e2c4d33d8630c6
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = d37e35d7cdccd9824a1ae4c787819735e4af798a3beb49d4705336d6496853ad
+Tag = d6b14027324b657a56263df148665393
+Plaintext = 771a7baa9cf83aa253349f6475d5e74dba4525307b022ba7
+Ciphertext = eebac2475004970071dfa2cfb855c4e78b1add8dcbccfc0b
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = ab22bc22bf2628b0e0ab245c3db2fc5128d13a011c2cc9b9fea05a79a3410704
+Tag = a8c810b6944815fd2e434193520b1d5b
+Plaintext = dad95a4b4d3754613f0542caa62cfe4e375dfbdd369ec32e
+Ciphertext = 4379e3a681cbf9c31dee7f616bacdde40602036086501482
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = c48c5aacf701137fc40fd0d3649641aaa5be427ceee702cf7ddf6408f458a581
+Tag = 8aa447b79284c588bef50b423de97908
+Plaintext = 3f28df9263e473be648fabad163aa4142b633388b16d8392
+Ciphertext = a688667faf18de1c46649606dbba87be1a3ccb3501a3543e
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = 477c2484cf5c56b813313927be8387b1024f995e98fc87f1029091c01424bdc2
+Tag = d4f4a413eb3ac2c474134995d4db9a16
+Plaintext = f83107b50a1f192ed45cc43fa80e6b519bfd859173ea9ee9
+Ciphertext = 6191be58c6e3b48cf6b7f994658e48fbaaa27d2cc3244945
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = 143bc037f1d0bd4ec16825c58cb3796bf8989200d27bda9beabbbc49247f59f7
+Tag = 56a3fb2e06734b28fbd57942a609d914
+Plaintext = dfeb324ba459ec4a5c54d2534e98002412e67db19cfc66bb
+Ciphertext = 464b8ba668a541e87ebfeff88318238e23b9850c2c32b117
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = ffc416f1dae4e43c1a01339a604c44d6a0f25ab9ca3978c6aacb6d270d510ee6
+Tag = db94280d3c4a1cd8cb00705f60ae36f2
+Plaintext = 0765949e6f22c422ebd47dc1ed73f1b849d7a058a1656fc2
+Ciphertext = 9ec52d73a3de6980c93f406a20f3d212788858e511abb86e
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = 6090b596b4082ec6926576137f6561cf13916860ad1cfc43650d1b5142a12041
+Tag = 12caca26cc3bbb289da3be0616b3445f
+Plaintext = 6db320cbe76bc5b8cee9ef89aca11765571c6c501993195a
+Ciphertext = f41399262b97681aec02d222612134cf664394eda95dcef6
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = 178ba75adb7c5bea6769270bb3b4f6ce208d4a786913d3ced7bb4090b5f65544
+Tag = 6cc8c665289d907628eb0e299c2d411e
+Plaintext = 0875020959ed969cfb38636d1d5aabce9658b00171a7614e
+Ciphertext = 91d5bbe495113b3ed9d35ec6d0da8864a70748bcc169b6e2
+
+Cipher = aes-256-ccm
+Key = 2e6e34070caf1b8820ed39edfa83459abe1c15a1827f1c39f7ac316c4c27910f
+IV = c49ccef869bb86d21932cb443b
+AAD = 90f0474dca998916075b1b1428df14d90be05491bb8d5d88e32e65ec890ba9d3
+Tag = f7e481607a2a0529f9cda1d5903325b7
+Plaintext = 4f89ca6ad371f86a6e073ec12fb1b928bb10d6639233b918
+Ciphertext = d62973871f8d55c84cec036ae2319a828a4f2ede22fd6eb4
+
+
+Title = NIST CCM 128 Variable Nonce Tests
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = 37667f334dce90
+AAD = 0b3e8d9785c74c8f41ea257d4d87495ffbbb335542b12e0d62bb177ec7a164d9
+Tag = 84d71be8565c21a455db45816da8158c
+Plaintext = 4f065a23eeca6b18d118e1de4d7e5ca1a7c0e556d786d407
+Ciphertext = 768fccdf4898bca099e33c3d40565497dec22dd6e33dcf43
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = f7a5098b2a4d92
+AAD = bc498326755503ff25d02805eb3517221b54eb4fd79af0fcdf9312b2a9ad95f7
+Tag = 697b41c9a69acaf8386140ee6e36f406
+Plaintext = 3e2144e2a381b718962a77e167778bf579957a8fae29612c
+Ciphertext = 98ce91033fabaa8fe853d347be6cbe5de102fdccf042e7be
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = 732d2dd64b4a25
+AAD = 495b03df82e317e4f351c5323d17c673f4c77856983179d7c7cb75c2b0573c72
+Tag = 2d442ff663242fa269c4a742a220edc5
+Plaintext = 4bb0d170bdcc70fd18f19605cf9c6181082c4367f1e6fbce
+Ciphertext = 9bd9304259962448fa8487bc15d950303621213afd88f1e3
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = fefd3ac595428f
+AAD = 91ffb6be8e129cef9189f7e0fec8e937afcfc6083b6a79a778a724bb3e8d0794
+Tag = 564a2f1cb7d77e0223287740d5ff9003
+Plaintext = 9e8c4f1292e8d7e5179b34ae5d2ba2491d7754acc54bb91d
+Ciphertext = a5d012b3062cc93b831860d76539169c88854b85550c67fc
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = e14d81ee3b873a
+AAD = ecdc5249ceb48e8d5a4483043921c00c1acb1843fae00155a28f3a127150b1c4
+Tag = d217fb611daeb66fa2d8e1bd43cb2131
+Plaintext = f99e23288e6b5ae85c14610994d90d5fcbcab62b4ed1333e
+Ciphertext = cc4ee711d0202deb58664e00cf0cf70b737f48ddadcefd6c
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = 2cbeaba94dbbd1
+AAD = d129674c6c91c1c89f4408139afe187026b8114893d0f172f16469b183fee97e
+Tag = a45116736e95d823e579d73dc31dc487
+Plaintext = 1b42cb685bd462fbd40e0273a81c767aa81cb43f17d3c0c9
+Ciphertext = 1a1b1c7130aa63098dea17ffbb2216d1d276cb10145b0762
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = 8a961df9c23f6d
+AAD = 07185502bf6d275c84e3ac4f5f77c3d4b30d8e106603be84410c11849a3c18ea
+Tag = 837ed517dbd7e6fe34ea42b01c69d370
+Plaintext = 434e182d04ecda519a6119fbaa4c45e8c9803a9a3eb51dae
+Ciphertext = 3f603939c6226d8208b2b0e675b82557609ceaeeee4032c7
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = d3604d390faab3
+AAD = c95e7329d36145664da69d25f24b301d334e1bca2baa74b2d5c325ed7d04fae4
+Tag = ef2e0b322f51abb366a1e8e37f4fe4ee
+Plaintext = ee104be898a225eb1da99163bbf768d8ae6d5850af6f8767
+Ciphertext = 3e6a7683d9d804f791f77d2b69996102ba82477ec4557747
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = db5004a1cdae8e
+AAD = 1370fc9d5bf1ad2d071be5a28b235402a85270f536b5601c221519a3b329c71a
+Tag = 2e4ef944778281ed186b4a8099b47fff
+Plaintext = 59bee7d18fd4ba573f3e4f61076f5b9f6a3487e47d98c729
+Ciphertext = 6db54d6f5c3f3efa6da67aea1234d46e8b679a5c257c66d8
+
+Cipher = aes-128-ccm
+Key = c0425ed20cd28fda67a2bcc0ab342a49
+IV = 783477f981ef05
+AAD = 04bbf2a826bdf3d55069b1936c4f8e8e08189f54066a035c950c7347604b1b65
+Tag = bc5c098625c51ac7fdd15da2cc9ef4b6
+Plaintext = 6150f132b25727ebbaed9f16bd91ebce00c68e5b39bc0ef9
+Ciphertext = 36f78cef22cacaf9f3d4464821737f7fbacd79be517b4727
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = 21fd9011d6d9484a
+AAD = 66ff35c4f86ad7755b149e14e299034763023e7384f4af8c35277d2c7e1a7de2
+Tag = 4034d9fdb43c3f48932aa72177b23bf6
+Plaintext = 78a292662b8e05abc2d44fbefd0840795e7493028015d9f2
+Ciphertext = 5a0be834c57b59d47a4590d8d19a1206d3c06e937a9b57f7
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = 97f940d7c1230bd8
+AAD = 78337ddfe38be7897372b0f805603a9a9e55598452285764641c3bb7aeb54a3c
+Tag = a20a3995cf25c5a7b9477d8916adff73
+Plaintext = 772aeff60eb3adf5a9589ad54dda0401cc9765589609dbd3
+Ciphertext = ef5c408dc6d0b501925a47def54d8deb9880a07a3e6380bc
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = acfdf302ed116ac4
+AAD = fe9d9989bffae3c9e6161eb0aa9d54ee8f5051f0dcabb5a750c5478c11798ce1
+Tag = 7d0e2fe322f203c08f44d7f9bd7258c3
+Plaintext = 99ffe16de323a9b65fe60305a2d062cae490ccca6d9fe9da
+Ciphertext = 1bbc2c7877d845591660636cb6ccf4edcd4c156996a26a70
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = c8d36e13b7459c47
+AAD = 3f3c3a4c26dba18f385274ac5ac3df73282686488d91bc8190b7f61071b07f62
+Tag = 05fdd72307c3355b19ea66d4a16ef17d
+Plaintext = 316ee95430329f706348886b8ac7779e3056809e25da0a03
+Ciphertext = fd2db9611a26a3e90f4861467df60edcc595f442332b0899
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = 5822755a3e47c27d
+AAD = 1d72d6b371e85ca359483761704f80b3360f4d6610e6d5e490b0d509f73c3233
+Tag = 59124db19ab1373a5376f46ec7095ef4
+Plaintext = af4ae8f19cf6cbd199677fe033859f56906f1979b1b5926d
+Ciphertext = d5ed6f8d5c42f4f3ea527094173b278724a2ba787e416ad7
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = 6c1c94c2e71b865b
+AAD = 298cac1e4684182786f386ef3de79c11e30b2dab7579b8ca18d0312200860403
+Tag = eaa52d69ab9790edc384b9a5d8c91dbf
+Plaintext = 6e4d992d7541e02a4aa167e56c7e47206abc25fea6c5125d
+Ciphertext = 560cd43a502a6e8b1af478a3b640a68937d1a83057110d38
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = ce7ec65cfeda31da
+AAD = 13c1298cbf7fe6a9ab378f86d3c2207944cc2a232f9383513ceb3b202086d365
+Tag = b1f45de395e021c6fb1b2991c91bd643
+Plaintext = 196c80d02b663bdd89fdaa31e329b5a8f7c596236ee8dd80
+Ciphertext = 00174dd83a7f8edc71afbe5da095160336be9184f693db3d
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = ddb739acda6c56ec
+AAD = 7f89bbe513b9a7ebe9be3f6eb88782080593c83e8cbe47fbe15bdc3e5782090f
+Tag = 713d941b845d96a5bf65e9f80ae7f923
+Plaintext = e95e142217c838d1f998a52e342e4f2d80b1cfd35cf6b73d
+Ciphertext = 819d73dadaf095652cf39729b2e2cad7fc7783887a5acc15
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = d9bb71ad90152d5c
+AAD = 20bfcba120cdbeb07c5f4d70338ffce493822d78a03c9e80b5b934e16e39f70e
+Tag = 5e99761cb1ac77d772b9cce9345d9a75
+Plaintext = f1fe98b50ea2f9f088f6f93910757cf744d5aabf3081966d
+Ciphertext = 36decda8ade6ab104a201c6d370412b907a559738eef5966
+
+Cipher = aes-128-ccm
+Key = 0b6256bd328a4cda2510d527c0f73ed4
+IV = 2c9ec9f1f1358c50
+AAD = 96f0b1edec4ad14407dcaf30ed68942b46c48d58b2dd63af60fccd5bdd48e560
+Tag = 85ce60506ac3bd97327904ad2e072a6a
+Plaintext = d74badb8ad7f2c2bcdf67e497151d35a4fc2a3c4c871868a
+Ciphertext = 0e9066270da6e03cb4307c43adc71b4b596213a63fc80320
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = b7776aa998f4d1189b
+AAD = 9f9ac464de508b98e789243fdb32db458538f8a291ed93ddf8aeaacfbfc371aa
+Tag = 3e259aecf12ba08f2a2e966a3341d6d4
+Plaintext = 56d0942490e546798f30d3c60ad4e3e110fc04f5b1c1fa83
+Ciphertext = 96f124c74fd737819008ddef440320f4a3733d0062c83c89
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 278cf1f09b13f467fe
+AAD = af9627922758a9f7792345716782e8837ca78e8f9db16e3fe12a7124a3d4e99d
+Tag = 11751638ed36c1fd3c7268b71633c1cf
+Plaintext = aa9b9e80cef47b6db3816b1d665f233e696337e21bb8333a
+Ciphertext = 5eba7e3b3ecab78121b0d56acb9dbfc6756c1255b42f145d
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 4ae701103c63deca5b
+AAD = 5872a1507c833c581ac2750b2b54add4b92be14e45d72db7679f8fa2b4d1eeeb
+Tag = d3635aa1d8167087600b01643b0a5ce5
+Plaintext = e832b053854fbd40c0d8b6d6b8fd5de2da0c173f5fe594ef
+Ciphertext = 3b2b964c3a90d51c0ace186db79818b4d0f7b81236d36017
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = cfb5b12928e1c36849
+AAD = febe755bb8e4475d8d12f5e96269abd0d4e40d73cb966e2c523343e9a6d2d71a
+Tag = ee6f8c4b252e10b42fbaf8c7af1e9f3e
+Plaintext = f46d6970dcc37d32d93ff062e68034c1906ee487fd28eefa
+Ciphertext = 0d5332a42fc583f4f81744b899cdf2a64cad1e78d577112f
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 68d5863cafc69e6ceb
+AAD = 048ba28abb191ded5449dfe9dc7d19f9b132a2a9fd779aab7da44d2887485954
+Tag = 3a8639f21f8548fae45dc76de57bcee0
+Plaintext = dd4438d7ba3edc73872e42dbbf78cf300fe4bf0eac9e16b6
+Ciphertext = 874d3ef7f916db2c2799b6892ef4bfbeb4729ecbf26ac498
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = ea09fbe5da0fa4fe91
+AAD = 63ee18eb720b21ee4c157dafcb8c7bcc6817f54d5c1b8dd7058c37228a03f8ad
+Tag = 1d3853a52971b0ab46cc0a3eded435c1
+Plaintext = c1811d613bf0789beeef693611ef733cd173da703b66ab3c
+Ciphertext = cbe5c799952b28fadf414607a6cf8194e9f41194abace454
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 0021be18ed76b3a34c
+AAD = bb5eded483f0ae1106fd08c5e2b91cf06d3a7a73518ad4c479fb05e631ba5399
+Tag = a2a8e3cfb827c7e6edabb34f7bbafd01
+Plaintext = 2d5531d1c51c6ea100b028596bf9f24dd90be14eab58f07b
+Ciphertext = 7af0449f7359b7f3e5f6c1e7bc264c7724037f4f16077fd0
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 449b51ee0760179e35
+AAD = e99bdf783070a3a48431704e90277ca65a9704c12eeae2e2d70b62f816115267
+Tag = 4aa8feae6a500919a336dbba1d9fb7e9
+Plaintext = c4896d58442877c986e4f862a9f3a3179f0e9b96316a90d8
+Ciphertext = af7531c073df01077fd5c8ea9a5530c2fe1688d529e5c2f2
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 232114642e0c6b55b5
+AAD = da288d2014616f16a2abf5923dea49aded1748592adbcd97415c33ebfa57150d
+Tag = 0b25cea7ed6e4fe9069a2ce49875230d
+Plaintext = 11fd3f94b5a5ce94f2740a27a0771aeeac77f3155d2bc12c
+Ciphertext = f0c174a7927da0bb88e92917af8ae1df4ffc3527004e9e2d
+
+Cipher = aes-128-ccm
+Key = afdccc84f257cb768b7ad735edbd1990
+IV = 660cb6d654afcbdab4
+AAD = bd96c3c225099fc58cc1f97779304606b11efe9712fba13abf74fc1d7d44a900
+Tag = 6218635754d5563f2cd48bdbb267e5ca
+Plaintext = 793c0bc3deb6e0bec4c1d1fc17e455eb1aa5e9e25cada861
+Ciphertext = fa4b14a381ee41fec7b7279e58f0d06a3beec26d645f8133
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = c4fb7519a19f13d9d1fc
+AAD = 092e64fef08b5655a86cdb8de63ffaa7772e8730844e9016141af8bad2216246
+Tag = 5603ab284a73a38cc916f8b653c92ab4
+Plaintext = 5ea35c082e2b190e9d98e6b2daad8672f587b4f2968072fc
+Ciphertext = cda5fe3d15d00150b99120c7f206b88a4c2c4a39ca914342
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = 45927852550961f1ae9e
+AAD = 53ae030474795ffda4d9ac0fc3c45afb592ddd761f7b5335c13a6747e21075a7
+Tag = 35bb811491d142cf1b26350f8451bd14
+Plaintext = 6c5f468077536b4c9a94ea4a6fe3cf621083a210daee45b6
+Ciphertext = 694847b6429cbc3902d9cb7049625aef1e97b569e1e31690
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = d8c54463dfcf02d0e327
+AAD = ff95c0ed0da32d1b5f57570b815a50592ecdc9c1c4e727e0f6dfd93fc10ce88d
+Tag = 9c68e8e641b0120f7dd66e8f0cfa4205
+Plaintext = 7321a6de8d694ea05623206f5df438c5c2cdd6b1eccab4d8
+Ciphertext = 9cf8ef119aa5cf3d6305d50b2b520a0b10bcd240e2727674
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = f690f3a996928275050b
+AAD = 41c05fda535770699ed22cef253753b658437f833afe65c9c393581d835f0fea
+Tag = da44a62f97c0fead3f65b28928bfbcc3
+Plaintext = 56520a4bfd7b73a471e0446f9524a407e81c2681b7329e35
+Ciphertext = 14aa15f9f64c4c64f6e88094e012ecb24193249f044c033d
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = 26eb9ef25be62148fa61
+AAD = 8f45608a07521de86ed5a84a851e629b579b51d7bf4cc7202a773e0f9e9d8748
+Tag = f0d5444466bcc631bef8e58fe5818af7
+Plaintext = c68094c26c7f017b79f126dc26b3bbcb95f97535ca412da5
+Ciphertext = 7ba8a0c2fe2b230768d1c1874085ddff8926931961bc4558
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = fad21bc27dabafe7a4ae
+AAD = dc5d7fd97bb3243ba585fa0d71a07191667af418e30a6b76bedd05b32c673403
+Tag = 0b5419293a67eb008aef0f9f675201df
+Plaintext = c247fa8d8091cd3f299cdacba7fb7af93549e9e3160f9cf8
+Ciphertext = 3097d2ec0f8bf00b22504ab03a75e740d3e59c269c3ee3f0
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = c911348848fe67406dea
+AAD = 50d50a0b5ed4d6904ec3045263af0255a6494b7a7e2e95ea806c4bb788423dc1
+Tag = dec5a554f4bbecbf6943ffdab8d8a26a
+Plaintext = d846c170ae0111348362901503b26d58f5efc17b6d296aba
+Ciphertext = 5d72562f7dfb47bf34b90ee4ea11ff9f726c915b07f4d843
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = bb921b46a16d20ae4046
+AAD = 7d17f8f60ad1e61a168b5b0e7fbbc90cee79b612b6d6c0d7ff6ede042341e8a1
+Tag = e5b1162b7489a59a50c0f0f3618e6c2e
+Plaintext = 71bb6ae84262646c9be95e0f4289ffeab7555ec6746c6ae9
+Ciphertext = bac123320888b553666249756e6d63b3498760791cbe9e34
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = 61a8b8cbfc9bdbadb2a3
+AAD = 51cf2a8949e13eaa087a34c9ec4d7fd92b862efd6a0b1fef8b016fa2c6933426
+Tag = ed5505f1f0ff77723771338585c456b7
+Plaintext = 362f9a46aab59fb6213c83d791b2129b34367ac2de2048fb
+Ciphertext = b8a57e8714d8789f4ef2af29e0efec21b1ef67fdabc7cdf0
+
+Cipher = aes-128-ccm
+Key = 6ccb68d3838d4ddf660b9cd904cad40f
+IV = 6bc4cd23c32a913998a7
+AAD = 92fbc970b5e64198ce2a138de92767edff8d82f12f8832444b346d159657356b
+Tag = 714025f485c7f40256049f16f859b859
+Plaintext = fa442383da234cf8f0c5fb667218bc3bea0c091b3a8e6b77
+Ciphertext = cdfe3e83aba43a9804c5a1832e0e47a9a153359cc32db907
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 74e689eb5af9441dd690a6
+AAD = 42f6518ee0fbe42f28e13b4bb2eb60517b37c9744394d9143393a879c3e107c7
+Tag = 16f322ce85d7c54e71ac560fd4da9651
+Plaintext = ba15916733550d7aa82b2f6b117cd3f54c83ddc16cd0288a
+Ciphertext = dcc151443288f35d39ed8fae6f0ce1d1eb656f4f7fd65c0b
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = eb118fb41284bfcb1bc338
+AAD = b5a6067fbac46578cfc8d3fe04108588c9de077eb009249374f205553bba9d02
+Tag = 4a0177883346dc896eb39e8a32bc1393
+Plaintext = 863da00c7accf45418d47c1eda72338734dcc49cd599f328
+Ciphertext = d64de7a56146b971e21bf5784d67bab32dd837cfb81591da
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = caba2716d07e95de83855e
+AAD = 0e0ff2c73ea5fa8f8726a3514cf906ce1610a1a6dc19b22682f9e4619f762d82
+Tag = 775ea25fb272981de8b8aa0a637498fb
+Plaintext = 2af6d5636ab65db2058b2ba16df257369fc4e8aef8b9481c
+Ciphertext = 3c9e006c7d8eff5f448b0cc9c27c964713241aa7fed3665d
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 314c136999e41d137bd7ba
+AAD = 366c659bc45d0a88acd54ef7eeaa3e140e1cafb1b01474a065a9d460c5e83bfd
+Tag = f2aaa211dec623947a50b1252bc5aad3
+Plaintext = 217b19ea6a431a1f66bd9d02b718e8507a08ab8e6f603e3f
+Ciphertext = 33d7b672b23e8b03a39ff3fd1e7b0f2be67163e3e3bae072
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 6fe51f5013f53d4e4fd907
+AAD = ff182f2e179d790e827cbfd0bd8b9297ecae57ffcef9e25ef114474a22e4ec5b
+Tag = 75ed171bb0fbaa6f431c5411cf9b536d
+Plaintext = c6bf582b49dd4ab6cb33f3f88e8a4d14fe32b308ee3b4682
+Ciphertext = 26cd5dc5eac2acda283ca03354260ad57af79e20c5e92f57
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 24bc8dc1e2354667b79ba4
+AAD = d0d48d01fc79685c6bee04d45e40d06cdf1f4607542b1ece556fc2d1bb2b03f1
+Tag = f391749ea3acd624c01e4583ab1506b7
+Plaintext = 90f52ebb1bd5439386faeaa194623285f750672a7baae64b
+Ciphertext = a7f43f56c50705a1a101044b954414fdfbe32b518e934d38
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 89ce46b3de3afaf2518d41
+AAD = 5767202c913584d653f37d926a0c5ac1c67db3efd1dc58fbff998778a6856254
+Tag = 94e43a6b1cf73cb2d6a1dd8331549520
+Plaintext = b2ab379a0dd15baf91415eee3a4e56e7eca54d4c1c3094f8
+Ciphertext = 9f530e455a54b86835eacd8801b34c884a3b2ac819ba38f8
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = d3208eb695e84c7a925037
+AAD = 91d8fa65a6885f162a795afe2898f391990a8b3a87c11f94734dcbddf5f58da8
+Tag = b27fb6425fcc3537ce471425a5b17dcf
+Plaintext = f15e39f0e4eaa5bf81359d8e30186522f1a1a415436668cf
+Ciphertext = 7f1d9fcd9e5cce3a81e3495bfecec817fd7180d8bbfe0aba
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 067de2869333ed22c7b63e
+AAD = c31e441fd551b3fdfbe23ceec5ec1f838f31a5300f6055ad2a936a9d0c1c856e
+Tag = dfb879c21b46f3307ef22f1da579303f
+Plaintext = 1536d9c9a09302d142c85638202f5bbf0c287f68115d51d8
+Ciphertext = b1a5c7a7fd23228dc7ea26885802daa0719f6a23681e1d65
+
+Cipher = aes-128-ccm
+Key = e6ab9e70a4fb51b01c2e262233e64c0d
+IV = 15f61b4526d19bceae1093
+AAD = b97b122af73e928e617e98684f845be4cb80566345739b7a884c6a3eec5102bf
+Tag = 900504a73c8817ff2b55618b2602bf38
+Plaintext = 37c81988c07a5b01e2b40ff9f9ada5f50ca764efb717ff9e
+Ciphertext = 0d93a5c77482d573b7f1b8c5e283f2571efc9f54216a4c01
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 0ec3ac452b547b9062aac8fa
+AAD = 2f1821aa57e5278ffd33c17d46615b77363149dbc98470413f6543a6b749f2ca
+Tag = 4829e2a7752fa3a14890972884b511d8
+Plaintext = b6f345204526439daf84998f380dcfb4b4167c959c04ff65
+Ciphertext = 9575e16f35da3c88a19c26a7b762044f4d7bbbafeff05d75
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 472711261a9262bef077c0b7
+AAD = 17c87889a2652636bcf712d111c86b9d68d64d18d531928030a5ec97c59931a4
+Tag = 715a641834bbb75bb6572ca5a45c3183
+Plaintext = 9d63df773b3799e361c5328d44bbb12f4154747ecf7cc667
+Ciphertext = 53323b82d7a754d82cebf0d4bc930ef06d11e162c5c027c4
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 6a7b80b6738ff0a23ad58fb2
+AAD = 26c12e5cdfe225a5be56d7a8aaf9fd4eb327d2f29c2ebc7396022f884f33ce54
+Tag = 86a0e926daf21d17b359253d0d5d5d00
+Plaintext = ba1978d58492c7f827cafef87d00f1a137f3f05a2dedb14d
+Ciphertext = aa1d9eacabdcdd0f54681653ac44042a3dd47e338d15604e
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = d8e133e7ff8e0a0ec6c4096e
+AAD = ef9e432c15d8c93a4b5c0666608e61c824cd466d7940d642acd3dc33057c0395
+Tag = 9f9cdf6ab825f6e026f5be2ad895033e
+Plaintext = 2836de99c0f641cd55e89f5af76638947b8227377ef88bfb
+Ciphertext = 5edb056d85dafeaaf74bdf4caa47339d6a75bf1ee998565e
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 2fa8120398d1a946f391367c
+AAD = 377cd407ad28dc02bd3835a31d92f8295c9dbe597f56662ceda112c588dc73a5
+Tag = d3021f6ad620648b8196ab1693710398
+Plaintext = 7a37255b682766a0bfecf78e5162528885a339174c2a4932
+Ciphertext = 701f5f506fc7e9ea4a27a4db5cb890f7be3b4f6bcb20f97e
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 8d638ef43f56dece910139e9
+AAD = 87ea7b095388de70ac0ed23e86f502400910028a8ab5e3bbb91d05821c0d2d61
+Tag = 2d236162688096d80b8733d2afbcd244
+Plaintext = 7370d9b453936955b9c9d336f4b283237986232de007bf41
+Ciphertext = be2f03f6ce1731418a5f53b6f6e467b73992a0c8102d8ffc
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = f479ea8812b6b2f6ac78fe9d
+AAD = 20c2b8f5d3a65a66ba8a25e2ee339a779a32d45f5db91077efae6cf308feef50
+Tag = 61bb9415b32d6a58f5f7647ed41de685
+Plaintext = 59ff9f7581a781808d36fed378080963f35c00ea5a6e3932
+Ciphertext = d127c956349c16e2186f55b72254c677f03c61f1c4ada9e6
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 423515f7bd592d6a7a240866
+AAD = 19eef6f798fc68086aad1cda6d7976cdcfe6b8af74598032972c939db300d8c1
+Tag = 30ba95c4058501234a1b97543c998e9d
+Plaintext = 3c379f90b11c622a765756a15efc8fc3ca7b08b3281945f5
+Ciphertext = 15792e01fc17f5294c3405484291082c00a8f46dd9af8ca2
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = c3f3da69e13c5733039744b1
+AAD = eedf00aab5edefdd6549d37ed44358e11c588c24f141dc5731303fe0bd56b11e
+Tag = afca1b08b6dd589a17a32d49b6f7135b
+Plaintext = 9db6fe9adb8c0fee87cac9a7f01a7ed8a84f0512d09b1834
+Ciphertext = 9b6b829ca1dc4e90d4402188632ea3377cbec2ba60f0f072
+
+Cipher = aes-128-ccm
+Key = 005e8f4d8e0cbf4e1ceeb5d87a275848
+IV = 0a57d59f21ead5b6d80cd2ce
+AAD = de5f2d413c98c6ea2a5640a7b1c424aebe75cbc78b06710b5bff8bec6afb5a76
+Tag = f344f2f1b2218d9b4283fe640a6d315b
+Plaintext = 0b5f6389f7c20f4ba326e8f05d373ca27b7ebe59e6d729f0
+Ciphertext = 0b704e14bc7d2977d89e0b2e7ed7fe3c9e0f2ea80d2d6165
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 0245484bcd987787fe97fda6c8ffb6e7058d7b8f7064f27514afaac4048767fd
+Tag = 2eb66bb8213a515aa61e5f0945cd57f4
+Plaintext = 959403e0771c21a416bd03f3898390e90d0a0899f69f9552
+Ciphertext = cabf8aa613d5357aa3e70173d43f1f202b628a61d18e8b57
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = 2a27257bfaadf23a87df082c57
+AAD = 0001dc666c9daf3560daeaf514270db0b5075d295068e6caf231c1de0e1a9300
+Tag = 4cd9d735f51430275387c565cf1a69bc
+Plaintext = 6cbbfa6d736fbcc4cf73ab4d7be537420e0e574ee1f2d1b5
+Ciphertext = 72d525e6bb312bf2c20b91f41108779789c25720797ebffa
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = b94ac8ed14895c80a91fda8367
+AAD = e1eaf35fb266f243a3fa407cd41815ae6432ad79877bfa59d8f196cbf19bfbb2
+Tag = c89fb5f507f5aeefaa9365f0b18dcb3c
+Plaintext = e6ec561496ce18d96b26d594a47ffad02d68ef25d2d2edb9
+Ciphertext = c63500445239bbdf71a8dfe3f8c01061d659cfeb038b825d
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = bbae10aa491ac9c668a3ba8d7a
+AAD = 981fc31e64fbad244ba1ef0303ba1e4beef5bacca74f60ffdb9142a25a1ad5a3
+Tag = 83d0a61d453d596fbc5c2e315d9780bf
+Plaintext = b9bec3e2adc83620772048d6cbfb6f78e4fad74d754ffbbb
+Ciphertext = 9c629c375f014e162895cfc25a972c29839f97407e7c7cca
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = e0b10e78e9fb41ee970143e9e3
+AAD = 399b71ecb41f4590abda79045cdf6495f27daaa559c1b34f513b5c4ac105ec10
+Tag = 8e8f8e13b7896b244d0c9aa52ed31a95
+Plaintext = 4b81804d777a59b6a107cf3c99c9d1a35bd8e4ed36596789
+Ciphertext = 867799b30558697d6efb4afcfe458cfad8da21139a0b4312
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = 17b61109f5e37754e4e92a28d7
+AAD = 0bc2fdd890c19882640f8d4188b88b9db99cc1934cc3e98a5df08589287968a6
+Tag = c40eb85585cc3b7520a940a4e993327d
+Plaintext = 347c1eb4aff917bc0012f005e74caadc93f4f18f2b614ece
+Ciphertext = ee19f3120991b67b2389e6f36543d99590f2e6d785c9c8ec
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = db3ca9e80ab761804349379961
+AAD = ce01369d08d37dcda2c899c9fc0d11ccf94a0051b2816a1d6c3ad07fc8dd02d7
+Tag = 401358c7b44aea27617b429583103a1a
+Plaintext = f0e1af1276d2918be91a191814660bfe735463d3983de1ed
+Ciphertext = 0f1b1228729b181772d7cf55ad257fbcb19cd46f7b31a885
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = 1f57959cecbd377374477e33b3
+AAD = de1c7c83ac61e1f99ae99b198f4af5d24f8de60ea98fe637f3a801fab38b2a4b
+Tag = e93525fe8048c3b2147a149f12eaecd3
+Plaintext = 42a42b84df098ceb43519c4cb86c14c2fafca39346159e13
+Ciphertext = 12425453de653d0fe8103013fde1ebf4a8fe18f76f0c9d60
+
+Cipher = aes-128-ccm
+Key = ac87fef3b76e725d66d905625a387e82
+IV = c9db03e2efbab713b0b6404210
+AAD = a2969243b0955402ab45a430fef2ef9e0c025006732bf8e592e3d3884918696a
+Tag = 64ddee42614aa737231207636c114575
+Plaintext = d633a5a3defdde6a68f959ef39a91c6ea6e13ef1a7859d2c
+Ciphertext = 5cdc183c32b4c1878eb83e8473a17c55c88e2ad6b944ab1f
+
+
+Title = NIST CCM 192 Variable Nonce Tests
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 764043c49460b7
+AAD = 6e80dd7f1badf3a1c9ab25c75f10bde78c23fa0eb8f9aaa53adefbf4cbf78fe4
+Tag = 2dd6ef1c45d4ccb723dc074414db506d
+Plaintext = c8d275f919e17d7fe69c2a1f58939dfe4d403791b5df1310
+Ciphertext = 8a0f3d8229e48e7487fd95a28ad392c80b3681d4fbc7bbfd
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 026a0b8b17be95
+AAD = 44caa8ecfaf38e5e773cb0366e1b04aa0b9fac5c34a362310f471960c4a1e1c9
+Tag = fedf191496d88cbe17c6271b65096e66
+Plaintext = 0e52a384cedcdf7f179348de6e7336aa86f8855fbd903cfa
+Ciphertext = 3417044bad5fddd9455579123dda4fd342c273a57ff6333d
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = ea09fbe5da0fa4
+AAD = 1d9799f2bb0f7ab57fe3de27949ff64066131c81bfee172b308f9bb0b3171067
+Tag = d47e30b635d10d1663477d61d7ffb55d
+Plaintext = 469ff9698cfc96b581d7115c822e4363d7355ec5daed2eae
+Ciphertext = 1dae7cc16f1b469290902cfad47b959784b4d6f48a79e690
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 8d27bcbf9ebfd3
+AAD = a7070b85b7add9193c9dcd2e6c03f6e7ecc52ffe9e099866baf7472f20c03aab
+Tag = 2eca8766bdf0db6bb2dcc793e1749c21
+Plaintext = 225651d072dc9d93762dd79691ac2b6ddba00ec1252d69eb
+Ciphertext = 5da819adefbf794612eb458519debcd524c283763eb3d725
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 13f560187b6077
+AAD = c4ab4244db75f8256e55c5b613a07b11c963c3cc24f66128aad4ba8b7ca99331
+Tag = feab6761c55431bb5668e1f5b7505e89
+Plaintext = a38231af405dc7b70c8dbc8cb84e6be8a0dc2e95fddc2ce8
+Ciphertext = 3aedcf8347aa23fd3325ce08b6b00462536baed69968a753
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 61e0e28bf344a9
+AAD = 5f998952de70449ad46428f2ff8a01c5af43c0107a1bcc6930f19d4112598666
+Tag = 64b2302ace4f66216ca8b4d776197692
+Plaintext = db21b37e875d7709a02239ce6ea529cf37255d5b617c153d
+Ciphertext = b8f5fed39c723d7643d6dcf2efd3bbd1ba0da1ec901305fd
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = f6be4aad63d33a
+AAD = 18339be863fb8a887d04ae9ff3b4a7db095075cd5d113a9ec87b41fe85ea405e
+Tag = effb985b9c2dd9ec954bd25d9c464c67
+Plaintext = e53101e6eabcda32c13d7b1dd1d88e7c2ca3ddc2064f64c6
+Ciphertext = b758858ab60e1630a0883d4d330119a593729a3015c42525
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 2c1c59aa0d8eff
+AAD = d44af86b89fda8448a9b2fcae20ea156dd8738c8251699c02b785811c830bf72
+Tag = 72adafffbacb297d67f6b5c02b982e04
+Plaintext = 1fd7188a43dee7b059420e8634d71d2c0658f6d0d308dc73
+Ciphertext = d046f845a67800a5a58f461e5a8641e8fc9b4c53b32e61d1
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 48e4598edd191e
+AAD = 61588bdc980ea2310e87dec4c651e9a55c27e3858b6505cbf3bf85e51931badc
+Tag = 500ff4cfe66ade1832babc019778acc3
+Plaintext = c25868f390af5e59c035cb5830e018c62c5b96bd35b764f1
+Ciphertext = 0ece161bd77b7f969b3b20c818769a98c178d84524544664
+
+Cipher = aes-192-ccm
+Key = ceb009aea4454451feadf0e6b36f45555dd04723baa448e8
+IV = 6d576ce3c5fcb5
+AAD = 92c598cb5ca2926c11f67c3b3cf25493d77606fa60d7290430e0e975091644a6
+Tag = 391031b3a22b2adeb9791ee35765c8cc
+Plaintext = bcd97479db934357a163a9e5f5a85999ca987f8243d8017b
+Ciphertext = bee185e11b3d42bac846b9d92c70a078aebfa630ab763840
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = ad749d596d88a4b4
+AAD = c67219909828adef64422286008e1e306867a1c0b3da95444507a68b45c953e4
+Tag = 5a1969276aa2b0cdb37ccaf2845dbf6e
+Plaintext = bd92d6744cde446fc8621625658fc4bc00dcb97f06195ad7
+Ciphertext = 076cffd0ca978fe2bad411ced45a090abafb22a99896f6a7
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = b1dc81d116d94f5e
+AAD = aa4b71906b6642f10f66c2391ec157c7cde97eb322db10045af4c5248807f691
+Tag = a67e36d7cc8d54cfec0762514475127b
+Plaintext = 9aa6dbe1cd3eb98d330c937d31ef93bee8938b6c5cfd38de
+Ciphertext = 720f6876ac91665f20147483f0655fdbe21963a01e36f1da
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = e758738df5c89af3
+AAD = 5715fa238f432c926e62dd93708d0e3145428e0ed45e1efa8148d2c4ab6cba50
+Tag = ef50d85bc3ade6a773d956b2660ac367
+Plaintext = ce80b99039a16e69018d1e3c239dd1bf06e94a78b0b1df37
+Ciphertext = acdf7ba3edca1563727ed85cabf085c2f0c8f27556c3c064
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = d586c4c67d535476
+AAD = 1e8dc63c6c54a540b6b02067ba7c719221cf289fa3897299722c9a2bd6eed05b
+Tag = 81e024aaf0a62b353f9bed36681288d2
+Plaintext = 2f88305117f9a5d807d54b7e95ecfeb7327e52d9acac352f
+Ciphertext = e42b86e619be1a38973c934babeb4688243a9012c85d643d
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = 77e83758f68d272b
+AAD = 25c80edef3d5bd8b049fa731215b80ca2ee9ee6fb051326e8c6d0b9e11e3d7ef
+Tag = 05fe32f796f0b4a75a459fce6c7d740c
+Plaintext = 92e47b82b728d639777d5d5843de2a5c364956cb4b21cabd
+Ciphertext = 1b9177f5b76403cb8c690b39c3dd22b55da35cebccb9b64e
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = 311dc245549206cd
+AAD = 87767f13bb4904d0df0d64eb22c9ddb65e81b5739baad86ad5e2c239ffde9f6c
+Tag = b75f9e4239e43bbf93066897e60f6fbe
+Plaintext = 8691c0301a216a5f3ed9123886d100309bd85630d6b845f5
+Ciphertext = f39fe3620a03b37a4bf457909e0770447b498ad2a2f0f9d7
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = 2a17b70f10e120c0
+AAD = 981fc31e64fbad244ba1ef0303ba1e4beef5bacca74f60ffdb9142a25a1ad5a3
+Tag = a0c069a2439a2d8843302c6a9999e658
+Plaintext = b9bec3e2adc83620772048d6cbfb6f78e4fad74d754ffbbb
+Ciphertext = 92187955ee1ae702ef01a385537119b2bd4545402e8b2384
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = e0b10e78e9fb41ee
+AAD = 9d072b8a3f1a496b2be6728a38b94a4f44c9be40c8793b69afd81d01696a6b4a
+Tag = 5005b06d15f63f2f015cfe447828da09
+Plaintext = cea28e7cd0eff0c5eafeec908d4aa8ba303e72ada33db087
+Ciphertext = c605e48f2e66e8e0a92471e466981ae5e31db3e4ad80b09f
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = 02d72dde23f9772c
+AAD = 2dc44c39940e2d9c94d2dbe40bbf5cca5efb4d4b250a31aa24f208b87e9c2453
+Tag = 3ed92ebb789c314a89c83542b15ed694
+Plaintext = 809343e986f6ff47f54d4cac22ed39babd12271d4c7edb58
+Ciphertext = 0bb59581f22f6b15de76c0066645495a5c19e44381c34926
+
+Cipher = aes-192-ccm
+Key = 1dd56442fa09a42890b1b4274b950770ea8beea2e048193d
+IV = 28c4d6de3e2ce51b
+AAD = 913a8eda924589d3206ce0a951fef93668c6c0c454824b217997bff6b3026d54
+Tag = ada8e796f2ce7f9449f42de504873868
+Plaintext = a19f65ffdafd6ad5ee43570f7e168f94a8b4a7b7402ac80b
+Ciphertext = f0c91a29f1222b906550ef5c7c0944c5c4236cb6c31122cf
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = cd84acbe9abb6a990a
+AAD = 447b6f36acdad2d1cfd6e9a92f4055ad90142e61f4a19927caea9dbe634d3208
+Tag = c5e36222d17c6fb0631c3f560a3ce4a4
+Plaintext = 597b3614ff9cd567afd1aad4e5f52cc3fa4ca32b9b213c55
+Ciphertext = 2d7fb83e6621eed9073e0386d032c6941bef37b2cf36a4c6
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = 1fc7a43ed124745d04
+AAD = c892b095173076a40e24522297be27fd3a765c8d417f24c71a9f03b3fe3d8e20
+Tag = 7a2a13c22df4a156e6d6063235452c85
+Plaintext = 415cd8312dd20a1c26f4b90d98104cdfbe06739466fc0aa5
+Ciphertext = 7bebd6f55f15ae57ab73f92f7be6ff37ddd99740e988f01a
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = 19ff5e7c1f2c594abc
+AAD = effcea4e4dbc57410426b39fcf51c9daecd9d310888590d77827973a29c4ebff
+Tag = 7579b2c4a6bcf0356f48cf8959cfa54a
+Plaintext = 97fd2c259a4e672e9555a9a5b98f4c0ec8c4c49c7ade26a4
+Ciphertext = a460674c2f358762e97dfc958d90973e1e419dbc6a832e98
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = 64d9bd368ac2357cf2
+AAD = 62c5a16f946b4312517f67c80afe2614c822e3a01b87dc81538c00bbf3fc0108
+Tag = 92be2b06a0ecd2d00877abded7d9634c
+Plaintext = b6ada12f7a28211e9d2c07cbb3d39fa77aadc077b34c46f9
+Ciphertext = 8fb5e0954388b9b58519482962487e9b0768f0cee08afe9a
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = b4aaf2cd93efc0ce93
+AAD = 79d8841ab83279724ce35e1a8abd4e158168dcf388ab4c3d1ae70413e4e43d14
+Tag = f8d301ceace678f9bf91fc361dff5812
+Plaintext = dd42449da4c95e858b796085b6b5b3b5eef484dbf3c2bc8b
+Ciphertext = 893f86e29972928c1f3c3e25c73947c8d677814bca7fff2c
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = 132f3e19e12f462a74
+AAD = 176cc5a280f6171d00e247edacc81f05c1b9faa87fc831163ac9d76aae59a6c3
+Tag = 42ca4f4ccf986eb6a6b85b99db2fcd93
+Plaintext = 8ea05a5033ab8b009664fa2800c24e217488ce6888cad147
+Ciphertext = 4771d210ea678dbfab96e320e9c44b68f47cb05b01826ccf
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = de709ba64cb75704c0
+AAD = 0cf8e9ab95766b6fa85e88d86e4f349a17c0d90509939e343eede988e7462255
+Tag = 393162252ae91ca46fb8e8338cbeb75d
+Plaintext = 51dd9fda9549f25dd868245a6a54b8d59346d2f336adf9af
+Ciphertext = fccc3e44afa6bd2fbcfc5c834db63dc9d152c04c0dc0b43d
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = b11b4c1b7a26387265
+AAD = 14ed867cc909c0619f366918a7d5ae25279fb137e1dee7fd98ddbe3bd19d841d
+Tag = 1f498ea6ec8251a6d149c7ca38b25fe4
+Plaintext = e35ea4a16e274fcab457fd4dc7886c3d81fc668c19e0f374
+Ciphertext = dcca8aa2eab8ac3f5db9cd9560ae0758d7df40d7d868d1f7
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = 20d03227a7fcaef1ce
+AAD = c5c15245e641687d0ca9e913406acd2de3f21fbaf2dc5e4e8963222da61d02a6
+Tag = 8ce3ab864545ea81943ef0ea9489d223
+Plaintext = 6775e5faffd0b13e78da70a789042245d5ef31eab5245380
+Ciphertext = 4bb8ed2207f36f40f62d3a2c90f8e3bd8f589059b6903711
+
+Cipher = aes-192-ccm
+Key = 8cc622645065c72d0d2aca75802cf1bbbd81096721627c08
+IV = 267f76b9ec0f5e7c6f
+AAD = 2b421be47d07dcb12a0706f7490d05024fce8f433079e18ec78f4c8678f5f155
+Tag = 655e14c7bc8be97ea47388cb7b18bcf0
+Plaintext = 9330bb23428ab45f573923e977db74882282cbe1371da68e
+Ciphertext = c6ae24f82ac5cf9c18a2d98e610027eb2566a1ccfcf99945
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = d7a46e726ed43f1580eb
+AAD = baa86f14271b2be7dbb37ddc7c95ce4857e57aa94624d594d7bd6ceeaada8d5f
+Tag = 39365dce86859cd82395d11bfc8cf188
+Plaintext = 2a794b84fc9e4a7e6d70a82b5141fd132177a86b4e8fc13a
+Ciphertext = 2d7f76464417613bb61d3657481346b74fc9d6abc6a3babd
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = d0afcbc1b2524a4a4553
+AAD = 7c267223047af946b06f6a45ffde4a5ec49c28b81ca22da4a36bf523e89e9da8
+Tag = 8355b915ca2633fd557ca7ed41e00926
+Plaintext = bfc5ce1316ccdbcd8ac62484e7656c87947ff98cbba8e1e9
+Ciphertext = 4772c121367d0e8d3edade883342395f3ea065fe7dd7be8c
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = 6eecffd227e8d5349523
+AAD = df7736560b1a13aa8e536500ea6cdb9a6757309aadf25a6a9189055a309c3f8b
+Tag = e7d017514d498f1f3c07d650afde8293
+Plaintext = 19eef017100dc82f26ed0815c55c122e0b1587302894c391
+Ciphertext = e2864c6e12ac089daaa1e94af4b2ed04060d7ef65d2f72f0
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = a67c0675753f725a8fd4
+AAD = 7dd546397a9a0129861fb6815d419a307f90d259d55f3503961754126cd1b776
+Tag = 7499a8544bc2a8fe95f55fefc7316f8d
+Plaintext = 80f1f1ea46c92d28f2d60eab39ce056a4aefe63fa688538e
+Ciphertext = 882c687c03eaaad9d7f591649e736f0c1c78f95e40d40cd7
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = eb83928f0d5f7aa3a74f
+AAD = 060cd3e4aecdb03837dfa9f544318c0a16cdc37fa2a3135be7888ac67e7eb26b
+Tag = 623f3a13fc13db958cbac49f7421d6af
+Plaintext = 81e9174e9472777b6b184707108c01d6ea6b5d108ec3c6c8
+Ciphertext = 243cfa0a0a36a4c20333968910e6f52acc04c6f74e704180
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = 5757abe01f7a1183fdcf
+AAD = 744629263041f0eccfce4a1ebcc18c4c984010f9241d35966263a8b2f72ee26b
+Tag = 9c447a3132fbe5213133650000d50b06
+Plaintext = 991049f26b529af8b0bee0cc83989cf817d248254182f332
+Ciphertext = b20469b5f33f0996e8de869ad10ce09924a0bdd7b67a89a0
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = d9adfc5b44ad7aa94b05
+AAD = aa6a5448c6ec87be75eca35725ad2e902dbccf840d25b2bdf7e62e4a8fa4a511
+Tag = 5ae554cb440eadd875657fd5cecc214a
+Plaintext = 14682301a99bf680805d1ffe62e1506d48cee8c51ef1d255
+Ciphertext = 9b44efa185b0c10325bb4c3c0815e6a6e46eea366b9a416b
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = dc3ca30782c9c0a7fe89
+AAD = e788c98ae85b11b3ae884eed6f3b8f5bcf5ab1b7b20ad3f44f760b2287cc5793
+Tag = f8312986315522081f0989838ef0429b
+Plaintext = f9cb86f24536931a1b095b426a07e4621c000cf09b472bf8
+Ciphertext = 463f9124d1cc387a0f8b971d1e2da448f0efffc3956ebb2a
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = 9523f53f92b6e4ba86e5
+AAD = c3b123ccc916d26a2e6a8b5e30041ad69a944217e9b402b7acc0170c31e8c2e4
+Tag = 768e94f062e86129cc9210dfcd3e6128
+Plaintext = b9bdcac80f64175836ab51bb1a1bee5ffe3a6b9b71afe3ef
+Ciphertext = c356b5a78cebd123808fb740754dc47a8ec7c9448bfacf39
+
+Cipher = aes-192-ccm
+Key = ab72eef2aba30205c986e2052d6e2c67881d24ae5fceaa8f
+IV = 16bdf18c09d60f3a2a32
+AAD = eedd0796f23612749e9fd282c864f3118d0683409d3bef1fda352e1422273c7e
+Tag = 978757883f07802b25e9a5b15c43b451
+Plaintext = cc96133e473d197be1bafdfc1a21d58e57d0d89b2ba1c3ff
+Ciphertext = f9d78e9e3a41b3bcbfe756385a3715776eb84bb7d8d15432
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = df990c42a268950677c433
+AAD = a6ab5d78427f297a4b7e21f1091ff3a5b20caa3fe1cbcb09459d9df596a6c8e1
+Tag = fd6a7255e4801963bb30a63de3fc5b82
+Plaintext = 6db41aeb5f7c24df8929dbc30483b3c7934b3bd1cdce5bb9
+Ciphertext = 8c9328258bf71970d33e23a3ff81cc1c9cbe196a1294264b
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = b7ea72641bbe2dca6d85e7
+AAD = 4e0f2ddf183281ec131693bdcea3fc9743733c07a486a42d5737735b3f6e3fdf
+Tag = 262de30da6ef505fe640c53d765f672c
+Plaintext = 726844e41b1e4d883024b32fee0dcea38c889cb328885b7c
+Ciphertext = 9a133e4582c2ebc445862a9c6f2f4e39223c84081e322c8f
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 446fee1e75e79c0dfc9ddc
+AAD = 42b598eaee271e06d9e98dd94152b28ef10f506d65bd660b2fb8b1be9a2d7254
+Tag = 96ecb1e46beb16000d585e1d9559ee22
+Plaintext = 0cdcf348ecc9c3588001802c2106fb64be9c301adcc66e73
+Ciphertext = 0c2657b0482b6ca92e1b1c8fdf75eae3b0cd3af205e9bca3
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 2e6e34070caf1b8820ed39
+AAD = 8bd1ef3a1831fcc8919d736fb23111ca3ef4cccaf20264fab8eb3b071e56667f
+Tag = 5198cbe3e34c884c3f56a732974aa1d6
+Plaintext = ca0860cc1e96506c2beb25b53d2947fbab634f0372afc8ba
+Ciphertext = 19e4774030e43e6853ab5bf176ba9c4b59f29f285977e3c1
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 428542ecfb94a745980aa6
+AAD = 8efe01716b9018084e2ea7616f85b7333d945c0c970f8cdd400130b98db67cda
+Tag = e7cec415030997e1ac5db974b617b5a7
+Plaintext = bc6b59120ba2845b0e41f65a55e2ef1c45a81485c926c14c
+Ciphertext = cb48b0af6fad251d409d14ce0fbfae9cd9c40bf4a0c1e2b7
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = eff703e6d72ddd23ff52d9
+AAD = d7fc74035e66709d2590b7bb3276245dd43824c9896fbd801ec1d07018b39b6b
+Tag = 3e59bfecf263bfdb24686627fd95e120
+Plaintext = 1a5432e8085511ddac1be91be3e2945f85f0cdcc3a1c9f8d
+Ciphertext = c0a00cbaec65b7ca525fb26e80ee0cd18c7ef47c39c70483
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 6a652ce21334a40a259dcf
+AAD = 5d24d80f22afe713c4076c200c1bab36917907fde7b6d34e141066f543526db6
+Tag = 0652b67d559a84b4a915ca6a420fd300
+Plaintext = eb8f1988cb405041bf48d138ad41da7ef364d4ac59a9e324
+Ciphertext = d4f23166c09a15466c7e0e2b30627ee5a84f22d7e6135b4a
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 9382e12d447c0ca23cc9c3
+AAD = 239129eb760f8a770410c160e4e13a6b9497077c3e463b65397393fcd3cb5c70
+Tag = 50f5a52f82211542b4e2661cf870c80c
+Plaintext = b40e80564263c7f450c53ef84df67247d72e8a04dbb284bc
+Ciphertext = 6de2ba26caa80874814816154784912c55e3d6da83488e72
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 2c3a4148cbb02504a2483f
+AAD = 33c3bdbf185b580353de79e51e675b03b31e195f19ba1f063d44def0441dc528
+Tag = 7de16aaa41d06bc071657dacf14da754
+Plaintext = 60a31736d99c3dcf25b349f6110e1c152b93506e85a01e67
+Ciphertext = 4d5e705d08f3ed1ca6f1caa74b46e4b1eee18a0783686f20
+
+Cipher = aes-192-ccm
+Key = af84c6f302c59aeee6d5728ed5da2e3c64a5a781c52c4d1b
+IV = 691cdf6fe9ecc2154d0101
+AAD = dc096596644c4e09c44078b86e5e0887c45094042eb0d74a6a13aa2524463076
+Tag = f07f23e65475a20fd96e45c6c695cd83
+Plaintext = 77e6441ee017a93dd876ff2c7980540c77ee15edb0f23933
+Ciphertext = 24cecc81c8ac7ca9906372dc5263f2220b4dd162f1e08283
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = 1af29e721c98e81fb6286370
+AAD = 64f8a0eee5487a4958a489ed35f1327e2096542c1bdb2134fb942ca91804c274
+Tag = 0af2a663da51bac626c9f4128ba5ec0b
+Plaintext = 062eafb0cd09d26e65108c0f56fcc7a305f31c34e0f3a24c
+Ciphertext = 721344e2fd05d2ee50713531052d75e4071103ab0436f65f
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = ca650ed993c4010c1b0bd1f2
+AAD = 4efbd225553b541c3f53cabe8a1ac03845b0e846c8616b3ea2cc7d50d344340c
+Tag = ef7662525021c5777c2d74ea239a4c44
+Plaintext = fc375d984fa13af4a5a7516f3434365cd9473cd316e8964c
+Ciphertext = 5b300c718d5a64f537f6cbb4d212d0f903b547ab4b21af56
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = 318adeb8d8df47878ca59117
+AAD = feccf08d8c3a9be9a2c0f93f888e486b0076e2e9e2fd068c04b2db735cbeb23a
+Tag = 8925c37cc35c1c8530b0be4817814a8e
+Plaintext = 610a52216f47a544ec562117e0741e5f8b2e02bc9bc9122e
+Ciphertext = 83f14f6ba09a6e6b50f0d94d7d79376561f891f9a6162d0f
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = b4cadb5f9cb66415c3a3b714
+AAD = c4384069e09a3d4de2c94e7e6055d8a00394e268398d6ea32914097aec37a1f4
+Tag = 75ecb546efb8872a3f8b0281b3901752
+Plaintext = 22bade59214fa4b933cb5e3dc5f096e239af4c2f44f582b0
+Ciphertext = 2296e3f8a2245224d274f1b90ed1287cbeeb464c70a89ee4
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = 72e6cebdaf88205c4e744286
+AAD = feaf010f462ad40a38eefb788b648e1cc292cd4bb08ebeff3c39182862296042
+Tag = 51cffa571570618e2ada3376bd9f3e5f
+Plaintext = 30655a6b5a5965db992e7248d24141055e988d726abb8e72
+Ciphertext = 69b27f2bbaa61c4f24e1c25e0779147fef79ec1582486b46
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = d8030fb31eca2c43f3f5eb88
+AAD = 66704365ddd0145febeb33f68b228a3f09e1e5a4b68149e6e06d886301841295
+Tag = 2beeeea7a638c717e63764b3a5118a0c
+Plaintext = 9d014a02507a6f266bd1ace21b55ab8b73983ff503bb9adb
+Ciphertext = 233a883650538ab8c0da30b90527f880fcad5b16bd435e76
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = 58038cc35ad3dcd75195e125
+AAD = 3da7a757e942409a3b39ccdc0669ce6401f7e133c07c4c42e366d70a8e9bdd49
+Tag = 33a87fa29e5fbfa9bc0430b0cac00b7e
+Plaintext = eccfd817fa5e3a0146967fae13fc2471ee3944cee37969f4
+Ciphertext = 415a36872a04f5b4b5372f63394ab9fb353e0eb9b4304501
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = acd82ae31bfcabd90af5af45
+AAD = ce22126f01bde16249c47102b4da68ad3edebcd4a16c24a16ea7ccdd5d364d10
+Tag = b336cbbeb64fbebf2e7076a98ecf5bbe
+Plaintext = 9d2126d34963d3ba12cd841bd321036cb82cfb78f2a6535f
+Ciphertext = 88a5b889e6fd74fc15336e23374b430988416c7e6b6e7248
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = d24457d567fd0a65fdabf219
+AAD = 0091d39f3478d2c59bf874b96db9ce0f7e8b85a9b805e07dc96b219819d51663
+Tag = 0ea909047af4998c660afbaf346ed65b
+Plaintext = 6da3ac85505e93c4f391ea367a9e15fa9b388ef7ae2693c1
+Ciphertext = 7039a8a49cfa6402b4ba3b840e69200c13ac4a3eb1c709a3
+
+Cipher = aes-192-ccm
+Key = d49b255aed8be1c02eb6d8ae2bac6dcd7901f1f61df3bbf5
+IV = 50c59ca54eb64575b82b13c6
+AAD = 5e4e42cbf172853c351d597c7d6d38b1a9cbb7ac92c00863a80ac4a2d9f0e7fd
+Tag = b193dd767f17783f0b51ac0fb7323301
+Plaintext = 25b2ba0a937b71f3ee68e7172cf2c4524b662efcd08ce2b3
+Ciphertext = e95fc44287ce39c5ad6b91c88582563fa68a9e304094deb8
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 3af625df8be9d7685a842f260e
+AAD = 308443033ecd4a814475672b814b7c6d813d0ec2a0caeecbcaba18a2840cdb6c
+Tag = f8c99ccf2d82788cf613a61d60dae458
+Plaintext = 8b9db1c8f9b4892a5654c85467bcffa2e15e28392c938952
+Ciphertext = 6bc6890fee299c712fb8d9df9c141f24ee1572b8f15112c2
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 24eaeaa437649e61b706942b8d
+AAD = fff75462f96157d9554bddb6aac156fefd88fd4a90a8536dfc28cc577f19c83a
+Tag = d0a421bbbc002eb9ac9ad01f625f824b
+Plaintext = 49ff4ff85f7407ca383cfa4fd7177adb4dab26e642c8186d
+Ciphertext = 3647fae50c588d792442f43a20125e77ab5db3c469391d24
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 7325932d6694aaf61a8204c172
+AAD = be20ceb8ca14e9bef7158b280a26bcac763da79cd0eba9b1833ea808c5e7a66a
+Tag = ee32a7ffd4e7bc303d3482fbac431828
+Plaintext = 2861494eb40b9d964d339797c1b6aac63c6674187768957c
+Ciphertext = 286dc74001e2a6000a23db164f4b2912de4afcf1df8c3aa5
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 61c9949df5853e42599e5ee0c7
+AAD = 243d09ceb16755cb58d62065df84890b840ad9b7eec1132c6427cd7c3d843fcc
+Tag = 5eb30cbec49cbb51c41cd5032b7fd759
+Plaintext = 943a49073db6ae94a88844ed895f8fd99ed25c3f42a2f78c
+Ciphertext = d3c56bd265a2cb0811dd218f248800ceade4f02b5403b963
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 07b6c18dd3b0fd9e8ff026a436
+AAD = e85f141c3d1af7727fcdb00f8e2c34e42a436d04ac5b8ca9f321a178a2056806
+Tag = acb5cf2631987d3d963349b035324aac
+Plaintext = a18b0a4618063c0519818d113b8e5435aaf153f664058f1b
+Ciphertext = 69f933a2a5e774e8d013cbf78c6ab0b73e6ca323d0c52691
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 0c075df70630dec2fe81834945
+AAD = f3f5c5ffbfe8247bc0c33c793652f749fe91b6dd141cf0db56e71cef8a2fd266
+Tag = 4e239d33283d18415b54c2aad4bde354
+Plaintext = ddc4bac4115e8cb06d29d22e400674dbc615a667f933603d
+Ciphertext = 26bdd25c9f204fc7520d26c161464c28fb35e395b295b3db
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 0c2d20375057fcd4241d290f6a
+AAD = 70ff1b9ff8ec08fdb18b0e7dbe01127ed0cfe0b0a449ca2ace4992b7b6248b71
+Tag = 62d7e0320dc930df3640a786d7ea9ae4
+Plaintext = dacbdf1979e000d52b573e74800761b30acc26681f372acd
+Ciphertext = 6a642c389433a3464fc64783ae6a14a9a45f0998b56a5b91
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = ea0801cb3dab853750a922dd25
+AAD = d83360d0896e022bf014bd33710ab212ddedda6d95a54996f33db304e5f12f01
+Tag = 0d06b4a545609a2128a95d4d73471559
+Plaintext = 46cc5653bbd8300dfb0df6d0af3fb7c7639a830bdc9f68c7
+Ciphertext = f1b0728920351d9edfdbe7df360b21f6cc5b628dcf43a3f1
+
+Cipher = aes-192-ccm
+Key = 36ad1e3fb630d1b1fbccfd685f44edd8984427b78deae7a9
+IV = 97e6de379c90fccf3fa8f27013
+AAD = 539f8eb802bfecaa4fb5b19debbf3d4847db9c4e0473a308ab3f3c859e68fecf
+Tag = f3512baf72cd79ba9301194be204bcc0
+Plaintext = 8b013f52a828905013f250fb9c006a173f6c66a64b5ba317
+Ciphertext = 556a439bc979dac1cfea8c5b64aa78547f52a62896c19893
+
+
+Title = NIST CCM 256 Variable Nonce Tests
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = aaa23f101647d8
+AAD = a355d4c611812e5f9258d7188b3df8851477094ffc2af2cf0c8670db903fbbe0
+Tag = 3bdb67062a13ef4e986f5bb3d0bb4307
+Plaintext = 644eb34b9a126e437b5e015eea141ca1a88020f2d5d6cc2c
+Ciphertext = 27ed90668174ebf8241a3c74b35e1246b6617e4123578f15
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = 195c0b84baacc8
+AAD = c7d9557b2ed415652ce6faa8cff5217ac803530ec902890b31eaaf3eeb0aa98b
+Tag = 82c00b5b463654adbf82888099a7d258
+Plaintext = fe012718481b2c4e1d7f9a7685e3daac43ccf22cad0df900
+Ciphertext = 893af0f130f1317de9f217234274b0c04fcc202cea9a0df8
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = 363e0e921c6f11
+AAD = 805678936d4e94746ab4818dc5f50c41e32cf32e7a8aafb300fb91af6406108c
+Tag = 80adf2762a1617adfd4d8356bb48aa8a
+Plaintext = 7e7e33e1a07d4e8fde2f33304f21cb564d146860ccfeb49f
+Ciphertext = 645cdd11a1c232815ce1e07ca3ea83f372eba46cedafddd9
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = e323cc866af462
+AAD = 163c747f3ba4ffd68af87f2475f48f2714659a2ec43b9ed115e02fe0e3c8be99
+Tag = fb9c02753c57fec7e1a5fa8f3860501b
+Plaintext = 2bfc76f3b108ba3118b07433c4d3d5f41564d22547c12822
+Ciphertext = 0db04c6b068e73e3c4d71059bdeee3d27622f99dfd07d868
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = 03ae777078b95d
+AAD = f1dacf9062dff9a6a3d0498f9d058782f891475684196bf2d8e7e905393acff7
+Tag = d104990e598eabd88cc8342ac16424b5
+Plaintext = 38c4275a5f605fd1d99517e13deebf0c9794ef586070fa9a
+Ciphertext = df8f524872b5f06f3f219ba76524990b466409894930d7e0
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = 1c6c351d4fe9be
+AAD = 14285e97cc3cae452e1a52e2fa0bbe24df96abf2faf6b9779acc59764612eadd
+Tag = e004894b1861db5d2d8ae98ed8926c1e
+Plaintext = 9e2220f3c17532e1ce0d6f562b049fcef35bcaf9a7e196be
+Ciphertext = c274b28228a6b13b670c325080f88d188d40d78d385481ea
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = a121dc27479397
+AAD = 359421e9f78cc4a31f4f019977d7fd29780524e20288798c50002a682a6368b9
+Tag = ed2ac2cb63e1b9d7dc598634198fe4fc
+Plaintext = d42b16b32e77637724144eaddb21ca8d7db4e7f73acbf707
+Ciphertext = 56e3e3e59e978161355e7d8573dc0657db400ca0b083dae8
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = b1f0e26b60bf1d
+AAD = 2ab4239fffd13762fb5391f5a4760d12d96ea12666a793b4d651e9f4891c22c1
+Tag = 95b8a23ee377d5c2850f4ed95a385253
+Plaintext = 9a2851083ad4e7b915bb0526bb4054e4c0b4adf8626edc90
+Ciphertext = 5b2e0215523ff37f0df46e84f996fc9fc779986c766fa515
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = 50412c6444bcf9
+AAD = 09cdcaa87ddf8bbe6db8411d14bb9064e4a121286cc8a6e97fce1844935f436b
+Tag = 514ef5cbf9991a919fb4974d55506ce1
+Plaintext = b28a5bc814e7f71ae94586b58281ff05a71191c92e45db74
+Ciphertext = 05cbc32a6ca797684636dedd16ce65a1eed69bcab1b1bdbd
+
+Cipher = aes-256-ccm
+Key = 553521a765ab0c3fd203654e9916330e189bdf951feee9b44b10da208fee7acf
+IV = 225557b0faca3d
+AAD = 21611da060fa90cf7fd68b721caf303307a56e56453326495b628c7dc93cd175
+Tag = e8a3f7b848054cb235e1b58d6a12c5cb
+Plaintext = e831b739e8eb9f787f63c0bb071ddcc9f44cab8d5b447d23
+Ciphertext = a97e0879407eb3b7f93118ca73f17eb34e9f4baf43b07be2
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 790134a8db83f2da
+AAD = a7a86a4407b7ecebc89434baa65ef173e88bd2dad9899b717ca578867c2d916f
+Tag = bc00b1d8b2bc393a8d09e87af7811f55
+Plaintext = 59eb45bbbeb054b0b97334d53580ce03f699ac2a7e490143
+Ciphertext = db4961070f528ccd1a5a0681ee4d0ce3515fb890bccedc2d
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = fb2441d1594a488a
+AAD = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+Tag = ee21c5738d1f7fddf3030d004a702704
+Plaintext = 451101250ec6f26652249d59dc974b7361d571a8101cdfd3
+Ciphertext = 1bca7b0d35a68c0ffc568ffc8221cca738b67b95e3ab26ef
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 0855263860043207
+AAD = c7fc24863c33f7e8cf97b337918495d52d864ac570c99cbb09d151758d6b504e
+Tag = b223454c57c714d96681cd4d55615afd
+Plaintext = 61fcd7ef9bf151b9d8a81dc1ba4f82c45e9c2e4784627acd
+Ciphertext = 9b939b6b188e1d0fe016f366fb01eb79a99ef7b1b57c6f7a
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 415cd251a5e36943
+AAD = 1a393c7e85fb286709f4eb50f09640e1d65ec1135cb4443820136b3cec69772a
+Tag = 9af96d3ce4ea94213b60cb69d92050e6
+Plaintext = 66ae08d494dc9df9b7f8f53199fa37d0c88885458b168c57
+Ciphertext = 1731e260ae31b8068ad1099313b167d9e6cbe49f471da61a
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = d95bd65242bb2265
+AAD = d0e20e1358be5cc1c45c1cf02c82d0a6d0824cfcb65774cf95f047b9f2cc1d3f
+Tag = 627a352d056712e0d44404c61712e2ab
+Plaintext = 312c3791c64d79205a11eebfc14b2d7a6b00391793c9559b
+Ciphertext = c3fbe558ff9ea83ed86b7d66503ee38eee94e4a41fd53f0f
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 3f0bf0141dd3ace0
+AAD = 9dd4ed18209dd6cdf19cc76fee443827e7331aaf020960c15d7bbed0f6a3b1f7
+Tag = 32645a322fa9bc8aace600f942a84db4
+Plaintext = 08354480047eee3beeb5ab165da17d23f2f1a4ad98720611
+Ciphertext = 2db9d2c54134d37ebefcecb9e2076034b975677fde58ef60
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 3fd8b3a3ff563a42
+AAD = e58327efebad3276a7cd1b1ccb56db0caddd02a303cd9fc7ea5c607a2ebefaae
+Tag = 3957a2a5b6164218fc83e12c42d5c532
+Plaintext = d1abd89351384e1a3c3366f77c3175f6390801554d7cd783
+Ciphertext = be284dcb357ae99ada7cc891730320ebb32ca627eb8c8062
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 14db1ffc1c87117f
+AAD = 6c2b091433833a0ed915354dcb70d982095b614dc51a95a22cec417184d8e786
+Tag = 2cf16ce68a93f8839245baebb2278300
+Plaintext = 0594307491f157821e63f50c94034f9284f095d5b897153c
+Ciphertext = a114c84a10071e359bba2b2ba4ea67f893e27e6ea880aa4b
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 40b0f74ff27a3fc8
+AAD = 3b9e1f4e9b57a6dfb5e0ca7ef601fc6af30a1f8650228e51e0dc61180d0bec6b
+Tag = b8d191130e864bcfcd1dec94a1aaeaef
+Plaintext = fc8b7dbceef6b0ffcbade789e09303044042cd671607e819
+Ciphertext = d00ef56074a8213740af8b8f974f778db560ac365d6ce916
+
+Cipher = aes-256-ccm
+Key = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+IV = 96cbe9cd19351359
+AAD = cf498fd042f9a07503e490cec4873d4df91162cfde60bd2cbb2b710c6681a9fd
+Tag = 54e6ec9f6ae1e0976ecf04dbee6463c2
+Plaintext = 315e81c9ce556dcf97a5b68503fd2228a7a6a174a15cd618
+Ciphertext = 7383c2de08bce3f0b7e504dc03d062f44396bcedd2180fd9
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = caa3d928d2bf2b7f2c
+AAD = 304678b3ffd3200e33a8912bcb556b3cfec53ca17f70ecba00d359f9f51d3e3b
+Tag = 5a9140ff50dc4da375c7d2de80de097f
+Plaintext = e61bad17640ecff926d0b0238271ee4c9f8e801dd7243e9e
+Ciphertext = 7bb1137c14cb4d324a4a8f1115c619ebf74927f0bed60a8d
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = cf09ca67659a583bb1
+AAD = 5507c4c3107cb446d19975f91207dbf3e2a51d1dcfd7da2f082159dbc3f41547
+Tag = 971f02b7122d1e4f78de9c3376520f5a
+Plaintext = 1887bb0c02500093a30a44b99e137483704b06615d308c6b
+Ciphertext = 834d3b2e5f0915c2348c706b4d2ff2717983ab4490edcc63
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = 97f940d7c1230bd8d2
+AAD = 56be2c9e09b555373d58f6fe2a0ca9b4ddba899addddf12b0fda860ad791773a
+Tag = d30ece13481609809b218de04c4e5ed0
+Plaintext = 5ac67c9bec9b95c54e187a4a6812f5d701c4ac8f847c005b
+Ciphertext = 9f372ba1c87a115847cd708aaf5b8a143b6981ffc2c61cef
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = 147c7ebb6c92245054
+AAD = f95d64a513a9f3e6c95c9ed27b22fafd7dd10da52636029523142149116aff53
+Tag = 0c0986ecd7dab44e5e97db37392a485a
+Plaintext = 08f199a8d7e3ea821dd3106e8947cd2e9d485342b25a6471
+Ciphertext = c438aa6d187643d030dfe4d6b5b578f84838f4dc5c396d70
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = b9bad794d49cdac9b3
+AAD = de9ff2a43f49cdc502cd17a373989bafd13fa6ccff6660557ce05b6295186d47
+Tag = 38dd977042c4d97da84e4effa650799a
+Plaintext = 40d1cd4063750184356a1d7cae1cf1824f552c5d59a62dc1
+Ciphertext = 9952b25f4f4f375440cd958456184fe61610381ba92ca48f
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = bbe054fbef86db3ce7
+AAD = dcec76181e3b872a5a6e79f070354e38866c7f67fc428fbca29ae6d929b1dd7f
+Tag = bf22c81a5d824b4916660be6f9b513e6
+Plaintext = 5f29808ba74b672a0f82b3b7581dc32478c6e790e2b8c61c
+Ciphertext = 4d176f48b09b772dde8adbdaef720aba128a8d38a902847e
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = 6a35e1a4307f6efc6d
+AAD = af28120505a84a75b0f6b18cc9d8c75c661bf143be29c11d8ede78b9bb98c98a
+Tag = 588ace6fc303600abc8e5825cbaedc7c
+Plaintext = 5e2f601395ec406fcf96785f768162e849f867dca77667ab
+Ciphertext = 4e305e26d34711c6aa775f490939cc6560d3cb6905f5b0f5
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = f6c237fb3cfe95ec84
+AAD = 038f8ed89444784417a9c23bf11e9b436174e6c10959e00faa1704ce2f7f2c7e
+Tag = 015a1f78abc287bd2a63381ead07c558
+Plaintext = dfd9cacbf7d73d688447ebab13d2e13f3613652379b386f6
+Ciphertext = fb16c17a6b22a8658f446203ad46a48b34808083b271cabb
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = 50d024a3e7455d7249
+AAD = 8513365786b7988b208984e11022c15573f978bbdc29e8a7a4745c8a81885a1d
+Tag = 721f714120162514555b60560afa4256
+Plaintext = 400317786b7df63373ffe541efcee6318cfc95bb673aad3e
+Ciphertext = d33b3141fea3a9ebdeb80d1da32dae42680be78471fb3023
+
+Cipher = aes-256-ccm
+Key = 58ae7965a508e8dd2eda69b5d888a28a1cb3783bad55d59d5b0da87137b72e93
+IV = 02769283d5a06c363c
+AAD = 292c0be3713c6c588cb4e29a1c43b3e6353e33556194e568e800e4e44e8281e0
+Tag = 51f5e62b3b923a937e6c307af202fab3
+Plaintext = 12ba8eddff1c2a03ddd25bb924ff065a93fd712b2c4f61eb
+Ciphertext = b15b1789c323a68568f86f35483bd7e204beff8f318ae143
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = c527d309ab29ee91c5fc
+AAD = 8f9a73e7bc1c11e2919020ba3a404cbddf861e9e78477218e3be2cd4337b278d
+Tag = ffc040ef3977e0035ce6ea6d157c18d3
+Plaintext = d4291c99901345afe29f58912a414a7498f37b44362bdf3c
+Ciphertext = 392784a9e0b14bcd37639ec5409d6ead3e75f855e5a92c33
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = eebc31a5813b4fb93b63
+AAD = 9c87ad77953bf8a811e001ddb946eefafbfaa598150e85f0701853fa307d77d6
+Tag = ade65aa17e4dfb0aafe18cf71a72b180
+Plaintext = ebcfd71120b0f9a2cccb898e6dfa082998cbe10032de3e61
+Ciphertext = e38eaad1e2df77e85e7129a8ce0f82cfc32b0aef79ab651b
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = 231b33dc406c9210f59a
+AAD = 38be46d271bf868c198052391f8a2147c663700d9bb25a0caaa36974f18dacea
+Tag = b7f3b898a2356909784598f8a8916f5a
+Plaintext = 9032f910347daf661092b5c1f15b5ffed1369b194d9e12f0
+Ciphertext = 868b85288828501cf1d06610fec25e8b8a4b437e2e4f5563
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = f2a88c3ebc74e62f24c7
+AAD = 5f495c5da035cabeb77e8aef10e91a05bd5aa414d1a37fa1099af959b26e5403
+Tag = 2788860aae5534cf84979e30c3327d37
+Plaintext = cfe8ee9b475e36058471e2984ae66f6ba1b3cb477b15155e
+Ciphertext = 22c16333ac651cd9c183e78aba3e9312fb3b77dd6f919950
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = 9cbaf1c83ba60b1e90ea
+AAD = 7ef136bd9a5809676abbaa68016d6fc713e34ac4b768a8246b1198c959f43085
+Tag = 599ca6ec1c61a14c37b5902389e47aee
+Plaintext = c3bcb0aaea93893f05eeb6439c8619dec17670a6439e2921
+Ciphertext = ebd9fb86563aa8f10062624441336f982c161ce5717d990a
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = e25322845d87d8a76753
+AAD = 2a89b9f0e56a1cf87dd38ed78028b6286ef8b7141dd2b3c65c5a8e1ed79bf4aa
+Tag = a0604deb3fd9cea2d89987833ff5c2f1
+Plaintext = ae622ff9381854f831892c318bae5c003e74b15199bc12c0
+Ciphertext = 144c920f0fe278f353d0b053563d907c7589e4f1479d7a93
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = f4d7978fad36223623cc
+AAD = 8671de7e994967f2521d263925e745af9273682d9c08ced07d4a98fc985f68a0
+Tag = bc866ab47bea7a4d0070e52b492fb8f6
+Plaintext = ef9b4ff8da108cabc972192ffecd5f96594c6d0871ffa6aa
+Ciphertext = ae4948b3bc1e50beb9f5d005871fc0d3dbde295de1c9ec3c
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = 6597ffb9eaad0fd9d830
+AAD = d2967ddf69ef62a9e23c9118dfaa55df92b4116322f1c9275131e3875dc92faa
+Tag = efcb3dacac25bed0304f227fd5b77b8f
+Plaintext = 5015c894b2437ff15c46bca9236830ff4bb057cd5764f027
+Ciphertext = 0b1dcb3cb0b4c32f398f3c43eccfe8f4242f33c99a2a2283
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = 80e376b87272d99cde28
+AAD = c9cc8f967dff45c05b9345d03813b6e30dace99556f7df75b7120bb6e5f55827
+Tag = cd2f7494b1fb0a0c6a2184e5c4787fea
+Plaintext = 615f657e24129a3e0f119988959608821219ce8354c4be26
+Ciphertext = d3e8b8f7ff8faa666ffe2509187fa7befc7412fd4e3bdb06
+
+Cipher = aes-256-ccm
+Key = aecc5e18088bf9fd7b17f089bdd5607b69903b04b726361f8a81e221b1c91891
+IV = 344cce96455541d403f3
+AAD = 748cce18fb40126ce125dbe341fbbc59d2aacc170ed5ef0293b15713c9184a07
+Tag = d93b6f8c8a1bf72be75976e4ebe6dd1f
+Plaintext = 828b6a4cd49f499a6e8e8508f9ab35255d8e9fed33ba4d91
+Ciphertext = b67e582a74d7f022a16ada2de7ec18caafdefa6b104baf4e
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = 0bcf78103ec52d6df28887
+AAD = 049c10f0cb37ae08eae2d0766563b7c5a8454f841c2061a4f71a0a2158ae6ce5
+Tag = 7a483163dd8f228d1f20cd4f86cf38fd
+Plaintext = b99bf4dc781795fc4d3a8467b06e1665d4e543657f23129f
+Ciphertext = 0d3891fa0caac1f7ebe41b480920ffd34d4155064c24f3b1
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = ab6374c6b2faefd92fa3d3
+AAD = f19c044023e5cf339203738ee70e76527519763664c06ae00e002a5ba94c32c6
+Tag = 1f1ad61758d828b70d4881b7d6ae8cd0
+Plaintext = a2e5c51f516db01688b64c173bb25645182a005018022ee1
+Ciphertext = f70c598df3c64d3527ebb7fc8408b7de2cfaa1da7984ec36
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = cfb89e7ddcba601e875110
+AAD = 052714010da516c896ac5842a839ae845324643cddb080e6206148432d0d0407
+Tag = 316dd62075fc761e2bc80edc5c564bdf
+Plaintext = 037f206cab78a6ca0745dc8fc137e22e14f3d7183917ef83
+Ciphertext = ccd675862502a2e2520a33250150b8b7b220e84db854888c
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = 967cb6f8530bf8a43adb42
+AAD = cf391a84d03e2e22aec1965cec821f99e7bf21a7c3580dffa531464b22d83225
+Tag = fc8b5aca6d606222d6af7cfea0d1f4e1
+Plaintext = caa3d928d2bf2b7f2cd8a7f357055b6d6895a5e34f47972a
+Ciphertext = 4f4f509debe6e52eae4af8b1740dde0a5338f78711a3b4eb
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = f5b7b5dd2b5e1ec93710c9
+AAD = e7a6b228a67d37b9d29a38efc547e50b4a6d95d599b45ee189ece21101ac6b5b
+Tag = b2ff27a98029b23484e00c2a5d291887
+Plaintext = 4a74ff35418723f2cecec1012484b52114067b2b2393e7f4
+Ciphertext = 25b140922a9d4f2ce153a4ff86596a49d7de6a6184e931e8
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = 713de00faff892977d99d0
+AAD = 14ea93488d4284d21d4c7ce14414adf45c1ed9d2d99db866d0e59accb6234dac
+Tag = 3d2ae816edf857c810b6fdc7f2c71f1d
+Plaintext = 3820db475c7cb04a0f74d8e449f026ec951fa59667738698
+Ciphertext = e4d92ab8d1ffb0976670d891cc8338da12f86d5d79b33410
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = ba87934808de09b2ae829b
+AAD = 30e2ea2a505f19e8760a0a84961000c7a0b7fe3460a9d3f5a38f54149be2e9ee
+Tag = 93fc57997b977948d55bdb026db5bc48
+Plaintext = 0e52a384cedcdf7f179348de6e7336aa86f8855fbd903cfa
+Ciphertext = 6df893eed2be958e5f542f8cb4adb392b34786cb4ce821ec
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = ea09fbe5da0fa4fe911e18
+AAD = 237dc8512b29bccdeb8ee39cf83b9b6dd203823d175c44d5f605b194e7ec136e
+Tag = ff704a2bcfb8becd0226f76d68fbb08b
+Plaintext = 41cee0ecaf9c65cef740440af37954ef49a585779d2abbca
+Ciphertext = 2f204ebcf549ee2a800d870e6341b9a89a41ab4ae91b6902
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = 5b80d7affc4ab4a4b68bdd
+AAD = 3a38dd7da30f5c312fb1e978d87b7a39792fd9ea3e9ab1565874e99df587327c
+Tag = 8df9400df42baee6b9a0d75b45840104
+Plaintext = 5ff92f6d3ca791421363e10cc84b4e8e21e0ebe5d8c55d6c
+Ciphertext = 05472db7875d59f8bed45606f355a516de93740aa2baeba1
+
+Cipher = aes-256-ccm
+Key = 97bc7482a87ba005475dfa3448f59d4b3f9c4c969d08b39b1b21ef965c0f5125
+IV = 514bba483fe7f2b7e555cc
+AAD = ac8beb419099cdb42a39e9b46fd900cc52eec4b43a96ed18b37b899b63fb931c
+Tag = 847729a70d7b4cff5281aece37006015
+Plaintext = b0b11dfca9b3936d1b4a423c5acd3d012b399a487c19c994
+Ciphertext = fa20629d514c4ce7bf727629bca5aa1c0c7e7851fc1bfc5c
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 2f1d0717a822e20c7cd28f0a
+AAD = d50741d34c8564d92f396b97be782923ff3c855ea9757bde419f632c83997630
+Tag = 08aca7dec636170f481dcb9fefb85c05
+Plaintext = 98626ffc6c44f13c964e7fcb7d16e988990d6d063d012d33
+Ciphertext = 50e22db70ac2bab6d6af7059c90d00fbf0fb52eee5eb650e
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 819ecbe71f851743871163cc
+AAD = 48e06c3b2940819e58eb24122a2988c997697347a6e34c21267d76049febdcf8
+Tag = 32d42f9954f9d35d989a09e4292949fc
+Plaintext = 8d164f598ea141082b1069776fccd87baf6a2563cbdbc9d1
+Ciphertext = 70fd9d3c7d9e8af610edb3d329f371cf3052d820e79775a9
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 22168c66967d545823ea0b7a
+AAD = 7f596bc7a815d103ed9f6dc428b60e72aeadcb9382ccde4ac9f3b61e7e8047fd
+Tag = 7522efcd96cd4de4cf41e9b67c708f9f
+Plaintext = b28a5bc814e7f71ae94586b58281ff05a71191c92e45db74
+Ciphertext = 30254fe7c249c0125c56c90bad3983c7f852df91fa4e828b
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 225557b0faca3d6cbaedec5c
+AAD = c7aafe7d3b419fa4ea06143897054846ac4b25e4744b62ba8a809cc19253a94b
+Tag = ac57f6ae1080efab4ed93f8b4ce1d355
+Plaintext = 0e71863c2962244c7d1a28fc755f0c73e5cbd630a8dbdeb3
+Ciphertext = 2369b56f21336aba9ac3e9ba428e0d648842a7971182d5ff
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 78912be1a35e156a70fb72f7
+AAD = 12ba8eddff1c2a03ddd25bb924ff065a93fd712b2c4f61eb80d77fab2c4900e0
+Tag = ed3ccaeb7a814f69d3ec1fbf2ee9792d
+Plaintext = 113efd182f683596862ccd5eba2e2d4ffa709d9b85c6f1d5
+Ciphertext = 835a22eb8d718c0ee1531a2d1bb95f58215c997c612908ee
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 91ad90b58d2044abacf957e1
+AAD = 4fc795b9126c23dd7fd514c2e5a8ca583e88a783b28cbb2a5df09f8b520ba0d1
+Tag = c257d67143722a976c9d7f44b09a767d
+Plaintext = ed55f6b9eb8fe74474c037ede94ffd84ada846ede4ecff74
+Ciphertext = ecb595276fd5d412a7cc3f5cfe960f47a0d0e2df0b08a11a
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 4bbe4ca29122c4892ca09b5b
+AAD = 367ecd1b71dfb96a84e2369f28705dfaebf0c73ed35d5364449b2391230be846
+Tag = 6843a685bde3175695796f6e64f35901
+Plaintext = 8dd497bb777bbc3e56e3af25a43545007bb00f2b9e9f815c
+Ciphertext = 563d61fc0a5b82804a580a7d752a8e61d3342fb39372b39b
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = 218e7b8a8fd62927f90b70e5
+AAD = 01815f599d6ba0d1c09f6f673bb6cca4c2a7a74f4e985be4c0f37842c7bbc5a4
+Tag = d027e3466e8220144cb0552f9b2800e6
+Plaintext = 80f3e4245c3eab16ef8bf001429122e46bde21735f63adba
+Ciphertext = aaceb16589b9de253c99d0d32409a631db71e8df8a7644bf
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = eecc9f106a0721334cc7f5ba
+AAD = bf38d0ee11a796a517539bbc9ab00ff85a4ddbf0a612d46e2bc635180ad34c50
+Tag = 4c9027fc41bb8c848025fcf9d092a873
+Plaintext = 36cefa10af1a3446a2c8d4a1171144b9ddd8e33a7cd5a02d
+Ciphertext = 9bf3b2df93cf5b587ecc96f45fc75e6eb066cb286cb06f28
+
+Cipher = aes-256-ccm
+Key = d6ff67379a2ead2ca87aa4f29536258f9fb9fc2e91b0ed18e7b9f5df332dd1dc
+IV = e41af8ca408c4c12e37561a4
+AAD = e0b20892875f60b5d8763a04958487fa5b7cf8d67a456e430475b337245d671c
+Tag = 7e6e0e5dc0a03826e51bd94269d7a41d
+Plaintext = 32a4da08bdd51336ed5798c7177b853a534bc98f2e6f7d4e
+Ciphertext = 95ffdc68f721cf2294d0d88002e3814167306fd906dbebdb
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = 46eb390b175e75da6193d7edb6
+AAD = 282f05f734f249c0535ee396282218b7c4913c39b59ad2a03ffaf5b0e9b0f780
+Tag = 5460e9b7856d60a5ad9803c0762f8176
+Plaintext = 205f2a664a8512e18321a91c13ec13b9e6b633228c57cc1e
+Ciphertext = 58f1584f761983bef4d0060746b5d5ee610ecfda31101a7f
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = 8a56588fe5e125237b6cdc30f9
+AAD = b3aee5fbf409bcfe9b46ae68d570edbbed32c12d13926ffb5ddc60ff0bdb7f85
+Tag = 276664f6567f2f978bd4be4d80cd07be
+Plaintext = eca81bbd12d3fd28df85e2cc3dcc2ecbd87408002fd00fe1
+Ciphertext = 9aad62a5443550d11f9efdab2de0eba74d47ae4f7d16adf4
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = d908b04840caca2280e5293ade
+AAD = 314a202f836f9f257e22d8c11757832ae5131d357a72df88f3eff0ffcee0da4e
+Tag = 6e5a9df1b1d6284ef657cde6f74734bb
+Plaintext = ad1109ea5c79bb55d22e9713eb2df42767cb29a2eba3ad2c
+Ciphertext = 61fdcebb158cd03151697ae7871c0a998802997e0672e588
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = 080f82469505118842e5fa70df5323de175a37609904ee5e76288f94ca84b3c5
+Tag = 8cc80aa08572b90e9598d0a73712b720
+Plaintext = 1a95f06b821879df3fd3ac52fc99a7c1d3e9775263b7d036
+Ciphertext = 704f60f9cc3ef7bc00b4f7a271ca70a89f4d5605387b3e2f
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = 6c6ebacce80dde9fefb7e5bb47
+AAD = 93f0fca0c8c84d5cc48160b25e246226d489225c0f8275e52856da592c715aa6
+Tag = 86b2c952055899184f0d95ffe3959f89
+Plaintext = 46820aec46ebd0d61706129584058a1498514928a87fe620
+Ciphertext = 00f6cccf45f046da1e6266afe61eed61c60c28515b2e1ab3
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = b94bc20d8c9abca7645fc6bebf
+AAD = e1c083c93663f5a066ef337a61aa3fddde7c301a42463137c375cc2dcdd76954
+Tag = e37a53d77b9e38605febdd7b2b666f98
+Plaintext = f1fca581d3dbbc61060c0c02adb47bc57954d25a283f66d6
+Ciphertext = 90c65d23e0e1786cebb95f9b1306d001b2e503842cdedb75
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = a4974791d417d7e9eea0f4ae8d
+AAD = 33602f308f3a0f7e1c75fc1e4321d545ffa278234958dbadd37f59a0f85349c3
+Tag = 63ceb824708a20724c99c83f1caacd70
+Plaintext = 41712c058d2d56b43b2c79278e790858a289320746c15a60
+Ciphertext = aab5656a1ef060c9b1ef7e2f3cc0bda40ff0679004011825
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = 6003b771afe4e99e1ef1ed4a31
+AAD = f60d8362b2ebf523681bb051fd3ee13919ad86acd963c703c4178a5f01a84236
+Tag = a84e7af3116a18f7ce44ae93f420270b
+Plaintext = b766022311c5e1d74a607fec7cb8ee805b8397a6c5f374c1
+Ciphertext = f73b2a6dbf8f798d4bfb489a6578c9c79152e42aa3b81b64
+
+Cipher = aes-256-ccm
+Key = 4a75ff2f66dae2935403cce27e829ad8be98185c73f8bc61d3ce950a83007e11
+IV = 27861168ac731a223dc35c03e8
+AAD = b7ba1c66282cb6092ba601407ff9578afdadf7ba7a4d08edef06dbbfd87171bf
+Tag = 4009312bdae46958d844eca502bcb005
+Plaintext = 0822e3e6ba982091d532cd5271fbde25305d1f6e71880f81
+Ciphertext = 5ab3e5296cd1f08704c82f6b42939702515b7733853d723d
+
+
+Title = NIST CCM 128 Variable Plaintext Tests
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = e1de6c6119d7db471136285d10b47a450221b16978569190ef6a22b055295603
+Tag = 0ead29ef205fbb86d11abe5ed704b880
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = 98d477b7ef0e4ded679b0bc8d880f09823ad80e9732fde59c3a87da6a1fcf70b
+Tag = 5b85d144bb51d4927074d3536a2db83a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = 28f32de10b6c9d3c3f46efec7aee24006208a54c4d1c2bba4b8cdce166cab7d9
+Tag = 01045de4a09486eea5efa33ecc6cd299
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = af397a8b8dd73ab702ce8e53aa9f0189995c6c9e920dcb75795149550b499deb
+Tag = dfd75400b59c3ad387bc86dfbbfb52ac
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = 3fa956bfaa27e249bf0a1276468d808259f3b8e2687851d780885d44cc2f04bd
+Tag = 2b11d2549b4e2f0a81c07ee90af4d081
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = babbd1b44cae3af06e0150bf0e3d898f6fe862b71ea9f6b727accfc18848fc79
+Tag = 10f76ab445f4ec158ccc1f7c6fee3ede
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = 7fba0bfda3b03c736c121cf9a257db55060b621be5168619ec4182f13ef6a408
+Tag = 59e02d6a6aa3fb2692b04e65a0e735da
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = 057354a29808f4ed77671ed3dc36f8b03f5cd952caac5cb80dc3b319f3333e29
+Tag = 367a2ade4087964dcb0ca2984d44657e
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = ec08b618602d091e9304715cb552b357c16fd1d7f7f023a28d84a98ba21ca0ab
+Tag = 47cb92cd40bc89328d4dd44fbd727032
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 2ebf60f0969013a54a3dedb19d20f6c8
+IV = 1de8c5e21f9db33123ff870add
+AAD = 45622834ea658b09b17f32777d18b34b387ef957bd344468f68e7178417a7c24
+Tag = f5185afb8359b5ef995483c0bc4192c3
+Plaintext =
+Ciphertext =
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 9c9b0f11e020c6512a63dfa1a5ec8df8bd8e2ad83cf87b80b38635621c5dc0d7
+Tag = 201784bdab19e255787fecd02000c49d
+Plaintext = 0e
+Ciphertext = 4c
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 73616a428f1a567b2e9af86b1fc8aec6d597b1b55f2aa2219b3b662fa6bd3407
+Tag = f14519f06b63fac3d5b2d9bbfa0cb758
+Plaintext = 30
+Ciphertext = 72
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 6d62f4e15e8bcc9ba4993bc50a046737121016f0d15020b90068250551167b1c
+Tag = 76b581a28ca0a0ba5178eba7fe028da6
+Plaintext = 34
+Ciphertext = 76
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 8f0b8289a1834ecc2167b59ce3c9d3b58465c4cfaad50c728d04360cb7e5bc41
+Tag = d99b805c0a4785ff2913cab3e50f6205
+Plaintext = ec
+Ciphertext = ae
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 477b2a6932f838f0d1bc420c0ca306981d8e2dab945b6f259e15fe888667220a
+Tag = b50e41cd7af84a8fdb6aee144e904616
+Plaintext = ec
+Ciphertext = ae
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = d6518d409b1f05708d0b44f18fb5721f20f3220f8d2f2718650aa9932e4579e0
+Tag = 12639c863974f077fe8236c943b464c4
+Plaintext = d1
+Ciphertext = 93
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 865e7cde73b558e9bfd05356923f8a697970811fc484acad2d5b3528baf1f986
+Tag = d7265cde50bc7a3989458437baf06db5
+Plaintext = 24
+Ciphertext = 66
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = f0c3c67a935eace53ed32435655dd0974fafe283622e8294a15d70977398eae2
+Tag = 063144b25d2268063815d1b42ebbac34
+Plaintext = c5
+Ciphertext = 87
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 341e71b2ef26e9db03882e06d06cde2c0617326cd157d5984d22f6f3407a9c39
+Tag = 7da45c10d0d6498716bcf3f13ca7e26c
+Plaintext = 34
+Ciphertext = 76
+
+Cipher = aes-128-ccm
+Key = 6ae7a8e907b8720f4b0d5507c1d0dc41
+IV = 7f18ad442e536a0159e7aa8c0f
+AAD = 31fce6735ba9a3385df11c153179b8e4141a3c6b8ad6eceaa211f3f17bfd0474
+Tag = cb0a6f562974cfb3fb7c8d5cafd50f2b
+Plaintext = 7d
+Ciphertext = 3f
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = 90446190e1ff5e48e8a09d692b217de3ad0ab4a670e7f1b437f9c07a902cad60
+Tag = db77c1f8bbac2903a2ec7bc0f9c5654d
+Plaintext = 4360
+Ciphertext = e38f
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = 6bc3d30925c67371573271f1a4273ad76e91e07dfab65f7bce0b241b5e4cd00e
+Tag = 55210d62e1393e4fda647c2b2e59a47d
+Plaintext = 17c6
+Ciphertext = b729
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = d1bb4cdfc3f2c16d92576068543692aa4b5a427d688387af0f1583e91a0e8b3c
+Tag = d54fd88a47b9f6e39cb4606af86d13e8
+Plaintext = 6575
+Ciphertext = c59a
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = ae6136df9ab43631ef143515dacedbe759b3459e951bfaf4712a21c86352f1c0
+Tag = 6de841af64b55bb7ebe3fd30ba493c7d
+Plaintext = b1dd
+Ciphertext = 1132
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = ffead34ac26e21158212d07c367c3a7cb6b795887ee2d3d8ae25c60556ea88d3
+Tag = 3a206339de534271f6469edfa5ed07d3
+Plaintext = cd16
+Ciphertext = 6df9
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = e768e7d867820d46c1cc62ee0e51d4dac6f5c4b5785b5ccfbf05236871bdce2a
+Tag = a8f65144f2ec5809e2ccb38c8760f7bc
+Plaintext = 12f5
+Ciphertext = b21a
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = 402e802885e4119df17fe85f141c3d1af7727fcdb00f8e2c34e42a436d04ac5b
+Tag = 9af825957abe7d89e175b6e8c0b84b5f
+Plaintext = 39c0
+Ciphertext = 992f
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = 8a3a622b3d347c0c5210d484adf77fa33205ba02224ddceea71d89c9ad8429ae
+Tag = 25d6a12e91e84e355934547f6b5dceb8
+Plaintext = 912f
+Ciphertext = 31c0
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = 636114e5e5f83cec94e1df21d6babb9f6a14a532fcbfc3bcf649fbd79ac1abbb
+Tag = 6db959a21e9e4ebf25ca4f98501b560d
+Plaintext = cb6d
+Ciphertext = 6b82
+
+Cipher = aes-128-ccm
+Key = 3d746ae6cac5cefd01f021c0bbf4bc3c
+IV = 597b3614ff9cd567afd1aad4e5
+AAD = 04e84f9156998c2eca9e96079a6001f2947dc49a081b3d75e47d75f71ed4a606
+Tag = 2006ff22ff231a6646ae561923818a21
+Plaintext = 5bd2
+Ciphertext = fb3d
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 00d57896da2435a4271afb9c98f61a650e63a4955357c47d073c5165dd4ea318
+Tag = 57bfc5f385b179be7333eb3f57df546b
+Plaintext = 3a6734
+Ciphertext = 384be6
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 50f6e6dd57bd3a24f6bfdc8b1c7b5a36ebdd07fd6d194e6e82da47151d9c88fb
+Tag = b8ca97bda492546d82dccdebef441f8b
+Plaintext = 4ffad3
+Ciphertext = 4dd601
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 70e132023acae1f88c7a237b68f5bdce56bcfc92be9f403d95d3bcc93b4477a9
+Tag = fa0f3e397d9a580aa39c7028e1a508c9
+Plaintext = 8a594b
+Ciphertext = 887599
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 08d2b011f36e05dc728c1a8bda3d92c779a3d2f27c4b041810bd6222c852b14d
+Tag = 593460d335e2f7a6d40b8fe305b0f690
+Plaintext = 1f89df
+Ciphertext = 1da50d
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = b207eb870aeeab27c6201ef04650bdc7ea30028a243420f7d198f1c9c9a43023
+Tag = a2d49e1a113767ea4219107819d88b65
+Plaintext = 72e9c1
+Ciphertext = 70c513
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 74294088721fc9e7aabd5f1c66b5369b1e2d2cdb3e73abaa28ecd1c37d4ecea2
+Tag = dab1c819778be8453db163c882063af8
+Plaintext = 016083
+Ciphertext = 034c51
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = abbd347999a1c26368cdb17ab08bf57a8e942d1248296e952f5f42f2cabbf0e6
+Tag = 537eb435df8d0e48c3f7e0bd1877c866
+Plaintext = 25f665
+Ciphertext = 27dab7
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 231b33dc406c9210f59a5df1cfd595c803474db34b9b1848f0bcbe7b28df33c2
+Tag = da549fc63d55b5910bbbf64435b95220
+Plaintext = 158606
+Ciphertext = 17aad4
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 69b851e63a78baef90637978e3dfe8c47be4b21e85bb89bf67051cf251004376
+Tag = d5ee29fb2af47f8040fad585921057f5
+Plaintext = b07452
+Ciphertext = b25880
+
+Cipher = aes-128-ccm
+Key = 3e4fa1c6f8b00f1296956735ee86e310
+IV = c6a170936568651020edfe15df
+AAD = 9b1f786c887d310b8efd3e8192fe504f603024c94aaa4ec9123736a40bf1605d
+Tag = bc3ee43e10205f83143e0d3794a6734c
+Plaintext = 65187c
+Ciphertext = 6734ae
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = fba1d18a74a3bb38671ab2842ffaa434cd572a0b45320e4145930b3008d8d350
+Tag = 35c4dd96e83d5ab4c3c31c523453c317
+Plaintext = 4cabeb02
+Ciphertext = 32501f42
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = 78b3faecb2bdf6ed14ac2b86ded07aa791b60f5d54f9e24a965a8453f5131898
+Tag = 7907d6a03e66403a7d9330d30d934a8d
+Plaintext = 5ff73653
+Ciphertext = 210cc213
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = db1239528eb464dd063e2a97ee83a87d6002ebb4fbafa77036f72c14f3fe959b
+Tag = 44f4bc78fbb969935076134437df82b4
+Plaintext = 062fa9ca
+Ciphertext = 78d45d8a
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = 0071f1edb3a0ce57af3c88bb0ccf138f752697a77e55695838fb39de04c78dfb
+Tag = 59692911fea2e0034d06c3b2e89af3d1
+Plaintext = cad710b4
+Ciphertext = b42ce4f4
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = 7381471a62b1fa6f5061c4c37e9721f07099d007ffaf8639aa2ae3f82da5a559
+Tag = 68484e22381923bfcaed16e0cb85b0f8
+Plaintext = 7ac716b4
+Ciphertext = 043ce2f4
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = 19bea6d92d5892216e8e4a30dda802387800bb046a6717817fc46c7edafe17b0
+Tag = d081de39c247df309c4b56c31c03690d
+Plaintext = 362da02c
+Ciphertext = 48d6546c
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = 8503c8eb9cebc6110f259e35e03a0740267768130ce6f61b1c7d1d25be942274
+Tag = c6c6bd7b3a9d7c4dfa2738847ea3cb33
+Plaintext = de52b209
+Ciphertext = a0a94649
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = d2445db6efecaa3f426b06de8d496ceed54a1d0171384cc762e21b31e265c6d5
+Tag = 2ca874d18d0b790856837555f4d4699a
+Plaintext = 8fe8b383
+Ciphertext = f11347c3
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = 8cda7d1e135cf5fde1ec9473c4b42c1bbb445c27fd87b5f73df61ceb2d0b6f75
+Tag = 932c2f8d78e322aaffc90846025190f1
+Plaintext = d8d6b2c9
+Ciphertext = a62d4689
+
+Cipher = aes-128-ccm
+Key = 7ccbb8557f6e08f436d0957d4bbe7fdf
+IV = bb8e2ef2ed9484f9021cda7073
+AAD = b506a6ba900c1147c806775324b36eb376aa01d4c3eef6f5a4c25393ecbf2025
+Tag = c346a4084918081b4bbe53b50d896788
+Plaintext = 6a029e53
+Ciphertext = 14f96a13
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 11bc87f1c2d2076ba47c5cb530dd6c2a224f7a0f7f554e23d7d29077c7787680
+Tag = 2066751af249d521c6eaebdff40b2642
+Plaintext = f5499a7082
+Ciphertext = e378b77624
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = d54219ef4fb851bebd1c546011ae3922b8337e19c28d4d58428efd66f80edcf0
+Tag = e7258df363e0e9af67a543c86db3c994
+Plaintext = 513c46fcce
+Ciphertext = 470d6bfa68
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = a92e88edd297da8c7089e21822b3e6cffd6837c78b975c8413fd6cca1b99bcb0
+Tag = 72b7573e5b27a1d0e15cdb7b06c8857f
+Plaintext = 9d62e557c3
+Ciphertext = 8b53c85165
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 77d9c306aa257379053cf1f2043c388a301dac2a9e2bb89eb8bab6eb3f150fe3
+Tag = de691a412ad54bbdb6ceac45ed45902b
+Plaintext = 7a05db235f
+Ciphertext = 6c34f625f9
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 081568ae0b948aa647b9d4dda5d42641ad5de72aa9874d8d0717d872007720a8
+Tag = 8a1bb8ba3d6763dcb1bdd3400e3459f7
+Plaintext = 30a22ca0fc
+Ciphertext = 269301a65a
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 695ba4dea0f84baf190ec25a25fc00cb9898902d7a17e6f5ff2df323b974f7c4
+Tag = 403897d496cabcd5bd9de3282199a8ed
+Plaintext = 35e25aa51f
+Ciphertext = 23d377a3b9
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 1f3ba0336a634efdd11f8168c0fe25039f9403bfa70b3898f4dbe577dbd52957
+Tag = 70a81f7cb0ab7ab2b495f51d66abeee5
+Plaintext = 8bde704c74
+Ciphertext = 9def5d4ad2
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 097b9ebff3ff93a143678d59721fdf359e95cbc82585ae47727a773317925d38
+Tag = ce68e9b01a4462a2221bd2f3cadf64c0
+Plaintext = 428542ecfb
+Ciphertext = 54b46fea5d
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 76d0341dd44c39e43a23dbcf4cb602f15d5fb9fee20c3d0d262d539c3fd1dfd5
+Tag = f2545964ef3978cad3387d61104bab84
+Plaintext = bd6866ded0
+Ciphertext = ab594bd876
+
+Cipher = aes-128-ccm
+Key = 3725c7905bfaca415908c617b78f8dee
+IV = c98ec4473e051a4d4ac56fd082
+AAD = 7e7c40ad64b511005b4546f9ec61ca24829390fbc4bd8507225bc348ae0807d7
+Tag = 002c41938a935d51905b2a708a2c5194
+Plaintext = 5822755a3e
+Ciphertext = 4e13585c98
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = bb4e706e73d21df66f64173859d47e247527cd9832e20dccff8548ed5f554108
+Tag = 8427f36b1f6c633e4542f32b50ca8edb
+Plaintext = e479990bf082
+Ciphertext = 89c924623887
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = 9db2182c8a4f5471082bfa1a8496602cbcdef2790f7e8f71f791303bd48dcb05
+Tag = d76fe54da69af5edf8309c7f013bb07e
+Plaintext = 017a7fd1aecb
+Ciphertext = 6ccac2b866ce
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = bf483f59fb73681f27b68168c998c90ea8ceea997654c6fab2bd737dcdc884f9
+Tag = 662f53d17f7cb6673415bb2324ca0666
+Plaintext = 512fc5e4973a
+Ciphertext = 3c9f788d5f3f
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = b91e641d8210e1ef705fec2beb9f58a391c7d1a38935cd1d13f2c00363388ff5
+Tag = 40c86156b1065b64af1e4d6c89b32603
+Plaintext = 06212e989616
+Ciphertext = 6b9193f15e13
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = 5cebf908e232d797fcce8453c4c3000868d4172622a4ee0d6a1bdd876a0b7c96
+Tag = c07ef5349903b928e39e99e2e32625de
+Plaintext = c45629069ebc
+Ciphertext = a9e6946f56b9
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = ab92cbc97f3aa6f9ea4dae5d8c3d9e91231f43ffff548da7b668e61c183ac2cf
+Tag = 5e40654ea16e83cc6faeaad668c416f3
+Plaintext = b949ced37725
+Ciphertext = d4f973babf20
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = 2c3d2f9c7e89c2b9e07317c4db6e9f00f5faadfad531c5bea79d164ac24d4543
+Tag = 3102a502dbba0c280e1d5fc627fe3a9e
+Plaintext = 517ff7b383b7
+Ciphertext = 3ccf4ada4bb2
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = d798e77ab0f3697768f23014fd31b9e8762ae65b6aa8a4bbc17ecb8cbe78461f
+Tag = 6745fd4c954396e696697731e1f9a262
+Plaintext = b40d863ca4ff
+Ciphertext = d9bd3b556cfa
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = 45b44e3dec57e24d960fd1767797ffdbbab81e38bab37e6974df262c3d932327
+Tag = bdf2b2dd47077c98234eae5d47c3b594
+Plaintext = 56e00289a003
+Ciphertext = 3b50bfe06806
+
+Cipher = aes-128-ccm
+Key = 80bead98a05d1bb173cd4fca463b8fa3
+IV = 8a14a6d255aa4032ebff37a3d7
+AAD = 645d27970ccce096d082fccfc1183955bad2611af0dd7c58c9d54430f28bd992
+Tag = ea66649ad7e204a344d3234125aa324b
+Plaintext = aa22bb1de579
+Ciphertext = c79206742d7c
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 6d5573c9279897d7d1602d8a95c04bb5ca3fad2dbe89a024b3651eb227e73bb5
+Tag = a852a7c4358dfa9f5467357638acac90
+Plaintext = 2a5775986551c8
+Ciphertext = 4f259f2a718fae
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = ff0ab5021ef466e2e898b0993d691145168be558682c74914c172f2b5e863754
+Tag = 8767c76e707d48a2144e090812e0192d
+Plaintext = 8db3c1ca0580f9
+Ciphertext = e8c12b78115e9f
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 2ee03cc28f79773af139c4ea55ec4daa48bb2885b8adcd5f066eceda5c4ec27b
+Tag = 5486df740083c959fb62ef7e2e221602
+Plaintext = 3c69e2e83236b6
+Ciphertext = 591b085a26e8d0
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = f041504d4c1b3d5be358bd6d350af42921205d29ab22b44ffe221358adef5bb4
+Tag = bdc4d2b86b2528f75db4a7f5423f4395
+Plaintext = 777828ab5ccb68
+Ciphertext = 120ac21948150e
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 81ea116832d69542ac8d3d22c16c82eecf2ccac39264dd933c4f9c13c8d0f1d4
+Tag = a7b06d1b710baa15daef19069ecf46f0
+Plaintext = af556fef3584e3
+Ciphertext = ca27855d215a85
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 8a0a120ed290a62456f002da1c250a0ddb1ebd57185a733d8fb562aad482679d
+Tag = 3811129add52e1406d50cbff4aa82802
+Plaintext = 98f26635351f14
+Ciphertext = fd808c8721c172
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 12b5a76faedf6f855e328c2cb87be8aea78c5e926b32d828e167b46205c86de5
+Tag = 1563d3da8a6cabb7515f642e42fb4b2e
+Plaintext = bd22c1ec05dc26
+Ciphertext = d8502b5e110240
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 8dc32f35ef4bcbfd040ad25dc36d0bd2486f93d0cabb7704cd1582dc99f65449
+Tag = 17609a21f703253e5e56beef4ac71759
+Plaintext = 2a87c0d64806fe
+Ciphertext = 4ff52a645cd898
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 83ced632359a11eb0c4c99baad84df5cac15bc5453b6593d9ffb4c5e8c84037f
+Tag = 236c72f98da859b54be7c598d85c37eb
+Plaintext = f05f39eb0a3d64
+Ciphertext = 952dd3591ee302
+
+Cipher = aes-128-ccm
+Key = dc8ec91184ba18eae31ac2d3b252673f
+IV = 0da4c988f521f5648259f2bec2
+AAD = 771a818a24e7da7b98f4b4291ef34bec7e1656b0c6c6e9474a989a04ea7de385
+Tag = 64c8cd38cbcc46e7f09bf3e1c6590c71
+Plaintext = 59dad755af92c2
+Ciphertext = 3ca83de7bb4ca4
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = 85853f120981f33cf1d50fde6b8bc865fe988a9f12579acdb336f9f992b08b89
+Tag = 2563309efc19368cdee8266538ca89d3
+Plaintext = 6d972a673fbe1ca1
+Ciphertext = 2f12a7e7acecae5d
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = a4ec5aee89e2cce2115b6c1f42570bc5062887cad08192a682d0b4508fcd936a
+Tag = 28096a5fec5e5359c369833eac3b7efb
+Plaintext = 68b1b6367a15fe49
+Ciphertext = 2a343bb6e9474cb5
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = f5499a7082bf1e6e2923211271f5f7f6d7c7b26db7963071705a58ddc4dca0dd
+Tag = 754a65863efb60c98dbb536e2b5a69d8
+Plaintext = 707023615563a40e
+Ciphertext = 32f5aee1c63116f2
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = 765f267befe6fcfaaa4b46eda32e7bfab87f12ceb07fa3b37be74965bb664a21
+Tag = 0b6e9b7f3b3541ffee66a1f668f67d28
+Plaintext = b56454bc50df3e28
+Ciphertext = f7e1d93cc38d8cd4
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = 9ce65598cd1f86afc9aaaf172809570cc306333c25523f863c6d0e0154c55e40
+Tag = 7018c9db8baf6be349d93d4eef7d7c9d
+Plaintext = 962f765da3565bde
+Ciphertext = d4aafbdd3004e922
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = d0125e30c36232a8c07cee9abc53453b276849a7c04ade80ad586ed8cbcede51
+Tag = 501b28887f05fd66f050525943d101f8
+Plaintext = 4f18bcc8ee0bbb80
+Ciphertext = 0d9d31487d59097c
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = 90dfd9e7bb7bf8fb70c22a879ffa760d14cda7b79ce4968f69b8a7f2b7a59642
+Tag = da53dde2e1aef96b3658a7635ee54188
+Plaintext = ca293c9e1780b401
+Ciphertext = 88acb11e84d206fd
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = 58f518710e6b282482a7f1950fa353b13bdda10c9aaea6d5f0d7ea0a965d31e8
+Tag = b62a5ec234f1efd1b52c8fad1cf09890
+Plaintext = b9df9fb4a6b299b4
+Ciphertext = fb5a123435e02b48
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = df052e95aea3769a433ce4e4e800b8418649bbe8c6297eb07545e6802de7e807
+Tag = bc051ede6f37cf67543a7252d7d9b203
+Plaintext = fb2441d1594a488a
+Ciphertext = b9a1cc51ca18fa76
+
+Cipher = aes-128-ccm
+Key = 19f97ef5318b8005fc7133fa31dd1236
+IV = 01ce9814c6329dbee1d02b1321
+AAD = 0875020959ed969cfb38636d1d5aabce9658b00171a7614ea9e5395331c7659c
+Tag = 5be4be6bc6b18104fac167b6e3fc15f7
+Plaintext = 451101250ec6f266
+Ciphertext = 07948ca59d94409a
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = edf64f98b3ab593cbcf68ab37a8c9472e49cb849d4a744deae925a5a43faf262
+Tag = f8ee4a233dfb7753f6bfe321b3e26959
+Plaintext = 7caae2640e734539d3
+Ciphertext = 0dae8b3ccf0b439f6f
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = 29ac8fd6a20a5df4ec79660c44d373da42de7d7c5fc35982b6c29b480723b484
+Tag = 63b1477d9506a51ae23abbac179d8b02
+Plaintext = e574b3a37af3bf2251
+Ciphertext = 9470dafbbb8bb984ed
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = 9ae5a04baa9d02c8854e609899c6240851cbc83f81f752bc04c71affa4eed385
+Tag = db0986198bce2e486581c041029a81d9
+Plaintext = 2e3cf0af8c96c7b227
+Ciphertext = 5f3899f74deec1149b
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = cc8e789462879e348d20be4e1161d7b7fc6f8371d8f8cb2d25d13f0e07de47b0
+Tag = 0cbb2df2079a6eb964c3469f4f326122
+Plaintext = 16f22817c5b79f9fa6
+Ciphertext = 67f6414f04cf99391a
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = c63061f2800228269015693336f78bb535ae8b88869e4ccf4ead2f3b0ea4e48a
+Tag = a40ca7622acf7266b7c24cf0c3202e4c
+Plaintext = 64fe8076d4e8538e18
+Ciphertext = 15fae92e15905528a4
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = 71c14a7031033db15bfe23b75fed9daf8886dd11392a0b787660e7b1a581af11
+Tag = 7de20e98586cd5d684bf015a7abbe82c
+Plaintext = 4814aaac48bdf43c92
+Ciphertext = 3910c3f489c5f29a2e
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = 8f4947f8588ed866ed7477d7f1a28046430c6470806a50e3c9e80958c61f1b42
+Tag = 8d503f5d87818f7c0e173b857cef4288
+Plaintext = 392a692b57a8a97f60
+Ciphertext = 482e007396d0afd9dc
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = 9d44f6df58c2b43db67e3daa95b176c81daff32e996d670e86405e15eae72e93
+Tag = c85e2283d9e80700268a6459d1451d00
+Plaintext = cba1e00e345b0cb7eb
+Ciphertext = baa58956f5230a1157
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = b6ada12f7a28211e9d2c07cbb3d39fa77aadc077b34c46f93006c1ca2ff66f87
+Tag = 1056aea3d3e4f7a5219170aaa52465e1
+Plaintext = 22f5b6752582919dc1
+Ciphertext = 53f1df2de4fa973b7d
+
+Cipher = aes-128-ccm
+Key = c17944bfaeeb808eed66ae7242ab545f
+IV = 910b3db64df3728ca98219e01b
+AAD = d6411fd5b25433f67ca75e4560ceb809d3721266beec358dde126b2f6a514137
+Tag = fbfcf8200a8a3f8d995f50284a7280c8
+Plaintext = 6e1b55d6f5288c5451
+Ciphertext = 1f1f3c8e34508af2ed
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = 4f9938d5bc3dcbe47f6b256d5e99723d0891e50c6175aba41b011e4686113c49
+Tag = 4cf0d8c24189affd35060cb7ca3dd136
+Plaintext = e10cc36bc1c5d3c646ab
+Ciphertext = 7f797367de50be6dc04e
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = e013a2edd5b86bab8df5c9940d0a0c864478c1ad42668304a643141855adac10
+Tag = 4148ef85caab151488c1a6b3df540d21
+Plaintext = 15841284c959febe63f9
+Ciphertext = 8bf1a288d6cc9315e51c
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = 147d77d509f642189594df17574a0ce62b52a838feb62310e11533995ba4c851
+Tag = daaa1e7c22b3efa8362abb3d31ee8884
+Plaintext = a8b4e5829069c335d1d8
+Ciphertext = 36c1558e8ffcae9e573d
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = 0bb09658e23fe8a08c01a6994ef36cb8dcc9a806297a09c67efe3558ca56bb5d
+Tag = 317b141383ad38dd78569d5f846f2520
+Plaintext = 1bb2da0f1ae7e044deb0
+Ciphertext = 85c76a0305728def5855
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = 34eb2e6149bad764837f6f25ddd96865e5b05d5cbf233c4f6cc2aa654dfea3b7
+Tag = 4e6432971aecf6bf7cf5244d21f7f173
+Plaintext = 63af538196add9b3fad2
+Ciphertext = fddae38d8938b4187c37
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = b69f26fda6d1cd92897e03758cae020c4e1beb019ce5ad987f872940780a9468
+Tag = e4d0ffc0f0add38a80c7ffe6b4701e54
+Plaintext = 6ef2df5a1688ae795537
+Ciphertext = f0876f56091dc3d2d3d2
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = a7375ba32251af0138bd9fd8fcd56a7c43ab2ca9a7fc0117d25f6d4ef9c2fcbc
+Tag = 47fdd0b2f29f39094ba5a7375e278349
+Plaintext = 3f46c83021069ac488a1
+Ciphertext = a133783c3e93f76f0e44
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = f9b91f7298b4e43843fc739a2f41c57c3f2cf36378fe4c34b574a43f9cedee7b
+Tag = 57500f913ee3f46801e1bba9d4db7ecf
+Plaintext = 86c10a6dfdd6a06ef638
+Ciphertext = 18b4ba61e243cdc570dd
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = 9d35876d9449a1642b5062dfbfc7a26a7ac080b7198f4aeff2c79e463565cfd2
+Tag = 56a6b87519b4807a2114ced587f72189
+Plaintext = 196c80d02b663bdd89fd
+Ciphertext = 871930dc34f356760f18
+
+Cipher = aes-128-ccm
+Key = 0fb9df6f638847f5de371f003dd938f4
+IV = c9ddf61c052f3502ad6b229819
+AAD = f2d5e927eb507f889efc6f21d783851f638f978c74960cc347f89f2703476114
+Tag = 2101012808adefe9b8166e04685bd537
+Plaintext = bd27ae3ade0781a33d5f
+Ciphertext = 23521e36c192ec08bbba
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = 7d9681cac38e778fba11f4464f69ed9ebfea31b7ffcaf2925b3381c65d975974
+Tag = a625c43233476bbb959acd9edebe2883
+Plaintext = 31be1b241cae79c54c2446
+Ciphertext = 9dd8a4244fbdb30b624578
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = 1b0012c468009bd2851653013782c7b71ef43c393afd4dc0aec4d6d0c3fa11c5
+Tag = d477ca066ec2befa854a1faef018ea8b
+Plaintext = 8802831e22092b30110cf7
+Ciphertext = 24643c1e711ae1fe3f6dc9
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = 48b216375c00ca7e9c4048834b37944d2543e24fa091fb3c7290e11c53a6b6a0
+Tag = eb6be9a78dfbd9e16181679b782969ad
+Plaintext = 3b3f782d637319d7fd161d
+Ciphertext = 9759c72d3060d319d37723
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = f3e06a45fcf1f6abeb00727bf2c9bcea00ce621d38f7b7eba17c27e51f04c793
+Tag = 3d9574d95b821a5170e9b61d8e6b2ff3
+Plaintext = e98f5e5a20d02c80372d6d
+Ciphertext = 45e9e15a73c3e64e194c53
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = b36e27729f9a139d8ec4f61215b7bf1149cbb4d93a5c14bebd7cfb7c6fe585cb
+Tag = aa193d257907be1330abaa56bc4f431a
+Plaintext = ceeed4fde3406ec40f7ac6
+Ciphertext = 62886bfdb053a40a211bf8
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = 8886ed7fa414d74aef704a9751b197cbab02c41c6aedcaf65cda019dc2d2d815
+Tag = 1d92029a6428748664b5c815f15ca1b7
+Plaintext = b38f03449883773135c0cd
+Ciphertext = 1fe9bc44cb90bdff1ba1f3
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = 816d81af167d2294497d9b06a39fdf75e37cbacf4d10c3a444068c891b361bba
+Tag = 386e4ad7c72ce0081a85d4cfd34254c7
+Plaintext = 8efb141db7b77c521003cf
+Ciphertext = 229dab1de4a4b69c3e62f1
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = f427c47e10c45bb3c7e75e9e604503b3560427691470358efdef48ddaf3794d2
+Tag = 98eeb05bc376a1042735569d5b63f8fa
+Plaintext = 6dc38e37d1379732df4dd5
+Ciphertext = c1a5313782245dfcf12ceb
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = f3df712b5e8dd8e4aa8b7c5f41e93bd11b0df66a3456a01f3d0094ad91482cdb
+Tag = 065b03ebeb68a9153cb4ed152ce0d64c
+Plaintext = e0e358aff203369dd5960c
+Ciphertext = 4c85e7afa110fc53fbf732
+
+Cipher = aes-128-ccm
+Key = 006ff7d3153caf906ec7929f5aef9276
+IV = 57db1541a185bd9cdc34d62025
+AAD = 264f2c7b095a296eb8ff6b5151ab3d9497ea8dc0002a9e5b09c2fd0ccd32b6ff
+Tag = fcd16c8360a408e2787f930ed275bf3f
+Plaintext = 57b940550a383b40f3c308
+Ciphertext = fbdfff55592bf18edda236
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 26e011143a686a7224ddb8c5b1e5d31713fa22c386785e2c34f498ae56d07ed5
+Tag = cb56a9c1a1c3bb16fbb9fbaedacdb12b
+Plaintext = a82200ef3a08c390dec5cbf9
+Ciphertext = adf4fc6f9be113066c09248f
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 97a720ae4720546e31263a1a538ce1d35c198c23bd4362e0023a67536328ab9a
+Tag = 002120b619a391fbd23402e5edd4949e
+Plaintext = 7fc58d1bb450b396b9161f53
+Ciphertext = 7a13719b15b963000bdaf025
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = aff6c8cefda055c67262e9c68825d1ad2a7488e5b09640a111fabf6254d96cc0
+Tag = 48b6e9a8de0099a28cebbf5c2bad42ff
+Plaintext = e9ea182d7f895f312b9738db
+Ciphertext = ec3ce4adde608fa7995bd7ad
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 35a3963b43f47855ef3df12af5de3626e0c5c8d9cd2a534c737cd695609b05a9
+Tag = df80fd62e751757bb0a32a987980afe6
+Plaintext = cfbc8bcbb5e5bb744bb1f340
+Ciphertext = ca6a774b140c6be2f97d1c36
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 46a2e6bd3fd5336abf02eace3cd1e1f6dde505ab976a9fa596edd6fbde7175de
+Tag = 3b211350c70adf9bab5c01081bdc6a99
+Plaintext = a334f8f41897cbcaeb5cffdf
+Ciphertext = a6e20474b97e1b5c599010a9
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = d110651c00ac5540f9d1ed9eb175e06b97163fc36d43f048565e5d0c30a069b1
+Tag = d7f65690d9a2fb6759d658c9bdfdfc37
+Plaintext = 3f781267290e8e73c6355e75
+Ciphertext = 3aaeeee788e75ee574f9b103
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 978644dc4e36f1d98a2a63e19bbf8af11785d09fce58a95c00cc6bf6cecf6161
+Tag = 0d5df472f49e7f713cd1373293810906
+Plaintext = 3dc39dbb91efe8b16396d488
+Ciphertext = 3815613b30063827d15a3bfe
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 5ae7528c5e965880b1533cbd78c1e81a8187379327a2fc3f76ff45829049e183
+Tag = 4bfca9ef00b0f2bbb03c1a3f7a0862e7
+Plaintext = 6caa8c0764512baa39dabac0
+Ciphertext = 697c7087c5b8fb3c8b1655b6
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = afe754828be6e3731d3eee54b021b4fa182247bd958e9074fb0094a11030f5e8
+Tag = a03be1d1d262b03c0ab425d533fe4ec1
+Plaintext = b19bc92e2305883580dd7742
+Ciphertext = b44d35ae82ec58a332119834
+
+Cipher = aes-128-ccm
+Key = 026331e98aba9e8c23a9e8a91d0b0c97
+IV = bccfe69bba168b81cbdf7d018a
+AAD = 0650859c635654ca4d815963c0a99f9d2f47456ad37f739c425e924d4360bd7e
+Tag = da61ca8461925996880e2874393232d6
+Plaintext = dab87e79544df1cc98096b91
+Ciphertext = df6e82f9f5a4215a2ac584e7
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 0eff7d7bcceb873c3203a8df74f4e91b04bd607ec11202f96cfeb99f5bcdb7aa
+Tag = a6f73242f2f227350c0277e4e72cdaa6
+Plaintext = 4b10788c1a03bca656f04f1f98
+Ciphertext = 89f15b1cb665a8851da03b874c
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = a533b3279db530eaed425842b0d3528f5c5e4c16acfa0f49de43d6491f0060a9
+Tag = 94271cc06f81d510075728cfeb89222c
+Plaintext = de6ea86d3641d916c4394fdd31
+Ciphertext = 1c8f8bfd9a27cd358f693b45e5
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 8e6c1cde142e18635c1b4f0cb54d3cf817f22ad7c25bf6a022501682f6a7da1c
+Tag = ab1aefed75400a41447b2bd8f0605542
+Plaintext = 6f3b32adc8c0314872947f3d31
+Ciphertext = adda113d64a6256b39c40ba5e5
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 248a4389da2d51b87907dc11c46253515503ba80de5d06c9b505cb89906614a6
+Tag = 46b3a6463876f1a43a287748f339e913
+Plaintext = 0cc992a8c736b44fedb4ad498f
+Ciphertext = ce28b1386b50a06ca6e4d9d15b
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 2e2c8244a2cbf53816b59e413207fb75f9c5ce1af06e67d182d3250ea3283bcb
+Tag = f625786bdc58af24b17c1ba34fa87baa
+Plaintext = 98104fd3f3413ad1f57ef4912c
+Ciphertext = 5af16c435f272ef2be2e8009f8
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 4ada86d88d5f49dfcde13fc30ba9a1af58d5254b47fb1885a20fad915c87952e
+Tag = d4a918290cf97208232c76908514b07a
+Plaintext = 3b4fec79d52d8b2a533917b75f
+Ciphertext = f9aecfe9794b9f091869632f8b
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 9e3b23232e5a9e69747f8bcb148cd6d282fd9b7ecd6d97e8bb5cdc261b2fc86f
+Tag = 01d6306bb91c315bb4a23fe23d496d09
+Plaintext = f10c19c76ae7ed55e1651155df
+Ciphertext = 33ed3a57c681f976aa3565cd0b
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = ccea2c815ea4efadc3007f511d633e98f9fa38b0e0fb572b282ed6a610adf7a9
+Tag = 620d9d3004587c5d510e2a857fc857ea
+Plaintext = fa34af376868d9a49aa200f59a
+Ciphertext = 38d58ca7c40ecd87d1f2746d4e
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = f7277fb296e2c0d2c9ceb7013ea8b59fe37e26b3b42a0b8cd01aaaa8d35283d4
+Tag = 82d2438a5138977bde5f514e2335c28c
+Plaintext = abe2fd996bb6804ed3286c057d
+Ciphertext = 6903de09c7d0946d9878189da9
+
+Cipher = aes-128-ccm
+Key = d32088d50df9aba14d9022c870a0cb85
+IV = e16c69861efc206e85aab1255e
+AAD = 14dd1810df3eeee78ed3836c77edf510d91ea28f119bf57111e580d70da94b74
+Tag = 78100a05448fa6e74bd3ed16c3bd364e
+Plaintext = 395ea6979b77dabd2042aee4ff
+Ciphertext = fbbf85073711ce9e6b12da7c2b
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 2c5d114eff62c527cc2e03c33c595a80fe609bfc0fe13ce3380efe05d85cceac
+Tag = e8eeb5d5b493661259a9d91ea31a5f7e
+Plaintext = 484300aa3a506afcd313b49ead8d
+Ciphertext = 928ca58b0d373dc50c52afac787c
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = d9ebc1cbfab9034317132a72e0f11c341331146a59e7a2f26bf4f3d778da52c4
+Tag = 552193439abfedda67d765d030cef30b
+Plaintext = 8b318f75ed79a7978adc17c4d2d4
+Ciphertext = 51fe2a54da1ef0ae559d0cf60725
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 9aea86b9fbd9bd4504ee2e25054942b33d3cdbd84215db7ea337e548cb706780
+Tag = 15013c2bc9338868fad0d2fac11df019
+Plaintext = 0256b0d154c768c85070da6ea8c7
+Ciphertext = d89915f063a03ff18f31c15c7d36
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 08afe10bbfbd65b948a6561bbeaf3ab46a8e3d0a861f1cfc46584156197f30a3
+Tag = 6c3c4cb8c50891d6523245e4c619aa99
+Plaintext = 89ed296a3ac03fbfb71422b92117
+Ciphertext = 53228c4b0da768866855398bf4e6
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 7d653792bb8683e07c7d2c800db6f7f08343c85af2377115df4fc86ff7d8fcaa
+Tag = 792d2cb93e45811a4c897ae9d907c9cf
+Plaintext = 414b6acb1db479028f5cc8800f2b
+Ciphertext = 9b84cfea2ad32e3b501dd3b2dada
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 4d73c1484f9429eb15742f29ab05cbab6552abf40e127b93427d649d195ed25a
+Tag = 1983a87812eaa7b66c5a0e54a01cb882
+Plaintext = 163f67b3766c3c650ce26c5bd8b5
+Ciphertext = ccf0c292410b6b5cd3a377690d44
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 2fba7a881f019a8745691343d79ef3656e25bb37b93fb5ab7311889f92010a5f
+Tag = b0afabd23b33765a63753cad66b0e6db
+Plaintext = 9c5b4aa703c27d16d82013853e16
+Ciphertext = 4694ef8634a52a2f076108b7ebe7
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = a640343fd4a866aec07b667d25176e11a32fb4d8bfc08fde2c46dc9b492fa010
+Tag = 39b8d0f97540373a7b9061aa3b2f7044
+Plaintext = 99eb86b3202c7ce68a2339065f47
+Ciphertext = 43242392174b2bdf556222348ab6
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = 9efd58d3ef5f74f663b2b5ca5e96c5a2fe85ca5eac1495d7f1751c7d8b412b3e
+Tag = 312c803e29f7be7c5eb236401037a320
+Plaintext = 3f5c1d038161e65c9ed955c961af
+Ciphertext = e593b822b606b16541984efbb45e
+
+Cipher = aes-128-ccm
+Key = 7301c907b9d2aaac355c5416ff25c59b
+IV = 7304b65b6dab466273862c88b9
+AAD = a7d7ba684c0903323f7efc83dc32815195df325394162fb5a18f201047be7999
+Tag = fd929c717d75388387dc25bfcf90b707
+Plaintext = be8dea2b4e602a787ecd28f2f7f0
+Ciphertext = 64424f0a79077d41a18c33c02201
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = c6de3be97f11d0e2ab85c9353b783f25b37366a78a2012cecf5b7a87138b3c86
+Tag = 5e902f296dcce870263ae50cda4fadae
+Plaintext = 61bd1385be92097e866550a55278f0
+Ciphertext = 7c9fa8d99b38f825315ece6a2613f5
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = 7c8cf9c650511f33af82e807e60336ec086bd2d9400a5f35652b8c3fcf968ead
+Tag = cae8a9e4b606f5fbeac2b829b42a150a
+Plaintext = 7e5e51301fa44a21f2734731ee3710
+Ciphertext = 637cea6c3a0ebb7a4548d9fe9a5c15
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = 5f8b1400920891e8057639618183c9c847821c1aae79f2a90d75f114db21e975
+Tag = f5419c6085e5434f056162cf80f6729d
+Plaintext = 9cea3b061e5c402d48497ea4948d75
+Ciphertext = 81c8805a3bf6b176ff72e06be0e670
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = 238d3c9d9de32f2040b1dd0dd040b921e456c3653263f4020cffdc552b948a46
+Tag = 7fedcc743389a9d48e6b871dc0dd63b2
+Plaintext = 20660408d6890aed84aa65dfe23032
+Ciphertext = 3d44bf54f323fbb63391fb10965b37
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = 3b5d61ca21953fdd22280747dd4ae908a511750127875da84dfe7d0063a318c9
+Tag = 8137e0a856d3d911af9f420b68d8110d
+Plaintext = 9ab83c81f2d2c896c6596660c3974d
+Ciphertext = 879a87ddd77839cd7162f8afb7fc48
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = 78c1751e86144a78285a30dc04f51742bd47e3d36b607bab48d91cddabfff4b7
+Tag = 5644448fa8445b6cd185bdf9b3718033
+Plaintext = c1ec469aa9c73b677af225a9f5f6f8
+Ciphertext = dccefdc68c6dca3ccdc9bb66819dfd
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = add33e9a1d7e91e2c160c1123537e3f7e3535881cb4aac1a80ecbe367379212c
+Tag = bd38e4dc44f768cef0c51344e3a7f7b8
+Plaintext = 9df1d6b6debffdd316aeb27143508e
+Ciphertext = 80d36deafb150c88a1952cbe373b8b
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = df7736560b1a13aa8e536500ea6cdb9a6757309aadf25a6a9189055a309c3f8b
+Tag = 2e7f2ec918099898b843a34c385f2a57
+Plaintext = 19eef017100dc82f26ed0815c55c12
+Ciphertext = 04cc4b4b35a7397491d696dab13717
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = b40c8d22069b8a65cddb51c1ea3571160cacb19fd371552436b19c7122b28d08
+Tag = 94c2709685b0827cc42f3a25b579db28
+Plaintext = 2af5db43f2a5fe8b494b40661510bb
+Ciphertext = 37d7601fd70f0fd0fe70dea9617bbe
+
+Cipher = aes-128-ccm
+Key = 38be46d271bf868c198052391f8a2147
+IV = 6758f67db9bfea5f0e0972e08b
+AAD = 9de5559ea8ccc70f4375a436ce0b72551a75960ad5ed6a1949ee8f6c47548558
+Tag = 63bf4b40ce7e672587816fdcda16efbe
+Plaintext = 5de41a8ca8ed8011304fa9e9f36498
+Ciphertext = 40c6a1d08d47714a87743726870f9d
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 3fec0e5cc24d67139437cbc8112414fc8daccd1a94b49a4c76e2d39303547317
+Tag = eef08e3fb15f4227e0d989a4d587a8cf
+Plaintext = be322f58efa7f8c68a635e0b9cce77f2
+Ciphertext = 8e4425ae573974f0f0693a188b525812
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = b6fecd1edeb55a9a4148b1aefb716a1e162779a5ab2a682e4adce4479c527bd2
+Tag = df7f186e8d3d7c21c549c41ebcc7f505
+Plaintext = 0e6118d0409751d36cb642504678535e
+Ciphertext = 3e171226f809dde516bc264351e47cbe
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 5c3933c30bf9d4841eff4000aaa1cb4d39cdf8ef1240e2aabbf9da95bdee5270
+Tag = 810a68be1814f53c09aca4066527fef8
+Plaintext = 5c8a5fb36f860d00c21ae9e3f24097c4
+Ciphertext = 6cfc5545d7188136b8108df0e5dcb824
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 7ca7ef30d3ac08aa51a9e5d3d84e8b6bb7fdde921e72b98ad6a93ebf2efc6b04
+Tag = cc30245a6e64625c4f6531d7497fb144
+Plaintext = ebd1cb4b35257790c9806be476bd25a3
+Ciphertext = dba7c1bd8dbbfba6b38a0ff761210a43
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 90f1416768fca7dd48d01230dabf95f2f1a0c044bf2d755448aaf72316c8448c
+Tag = 10d85725dacc274034669acf7f34fed7
+Plaintext = 842b7e5f22d921b2b8ab3131684b7eff
+Ciphertext = b45d74a99a47ad84c2a155227fd7511f
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = adc5c36849283d57acb2bcbc0e12465cb7c1830cb4e314b9ce6e25acbd8d460c
+Tag = f731b465eb59c4989e42020d86102a59
+Plaintext = f0c2cc5a1b4c4cbe839338fa0d7a3435
+Ciphertext = c0b4c6aca3d2c088f9995ce91ae61bd5
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 80a7a483d1dbcdf00ed02a700e93d8b87fa6ac5c7368d1e81bd1b32cd1621cd7
+Tag = 84bcd2775448447ed801b3b0ff071c19
+Plaintext = 2c1a5f906f2ae0373cc25e3519df2ba4
+Ciphertext = 1c6c5566d7b46c0146c83a260e430444
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 13c02992992d2708250184a579c43bc29a3a8cf1e02dade4496cbd8b1214f97d
+Tag = 01d1919f1451ad16f115cde863f15303
+Plaintext = 1da5190517546f1ad852f64263e1f679
+Ciphertext = 2dd313f3afcae32ca2589251747dd999
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = f6f18dfe093e4c0c3fbfa8a5b1f4a703c08addc2ab959741611a594b93d08bf7
+Tag = ccae4f6ec07bf73d6f086cf09e2e14ed
+Plaintext = 13ccb08a580efea53dfba6a59626bbe2
+Ciphertext = 23baba7ce090729347f1c2b681ba9402
+
+Cipher = aes-128-ccm
+Key = 70010ed90e6186ecad41f0d3c7c42ff8
+IV = a5f4f4986e98472965f5abcc4b
+AAD = 63708e12dfa14f192ec5ee5856dc3cf2403817d9628c31899b4613f65e1e61c2
+Tag = 2bad8bf67d32a855c3940ac908397a5f
+Plaintext = e0b5fbc6c2269d445a60273bf844892b
+Ciphertext = d0c3f1307ab81172206a4328efd8a6cb
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = 46603500af9e4e7a2f9545411a58b21a6efd21f2b5f315d02d964c09270145b3
+Tag = 70f0edb415993588b2535e2e0e4fd086
+Plaintext = 001343e6191f5f1738e7d19d4eec2b9592
+Ciphertext = 2162e27bfbf1d00f2404754a254665fd92
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = 278afebc604bb7d87bed3574a2c5053de17eb8ca7e18ddc7892f2c54b38104a8
+Tag = 778e3c4a11f3f9dc42554d45796379ef
+Plaintext = ba47d5bfb36f6150a100e36caa116405c4
+Ciphertext = 9b3674225181ee48bde347bbc1bb2a6dc4
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = 3239b2ce4efe4f6a6255dc53347400a6446ed3280c65422386fab471ef09eed6
+Tag = ab5540cc01d867f641c9b196fa159291
+Plaintext = 96eccb7f9b0e16c6883de0a381e4767f5a
+Ciphertext = b79d6ae279e099de94de4474ea4e38175a
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = e2a5488d5f7930ea4ce399f2a6c0810265f7c0dc52fe824d19a0fa0d9ffd55e6
+Tag = 6366fbe302e142dcf6aa16337d98550f
+Plaintext = d68f5990da1a2fe39ed81af145ab834fa4
+Ciphertext = f7fef80d38f4a0fb823bbe262e01cd27a4
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = 0071f1edb3a0ce57af3c88bb0ccf138f752697a77e55695838fb39de04c78dfb
+Tag = f88c07797267bf5a49b3d0f601a225ce
+Plaintext = cdd4d8b3d8f6e4742793b456cefc9e686d
+Ciphertext = eca5792e3a186b6c3b701081a556d0006d
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = f5d6989587e463969d97aadabea9538511f8d109cc2d3cecf09ba7cc346aaea0
+Tag = 5c9fbf69d81cef238ac513562d4a0dd5
+Plaintext = e7d7fc60ae852b68102e01b506f9dab986
+Ciphertext = c6a65dfd4c6ba4700ccda5626d5394d186
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = e0b5fbc6c2269d445a60273bf844892b26fed03b82869edacd6dd7a63fd69e8d
+Tag = e2c748c8c9e3190de095de8eb0650203
+Plaintext = be9f51abfbe2da5a56db0f9a31b67c9f83
+Ciphertext = 9feef036190c55424a38ab4d5a1c32f783
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = e6bd0010c98e60b9af7cf905c58e0653bc425e2ccc809bd4f9cd7b1f95c18786
+Tag = 05cf563c5b4ba4ebd5bf107f2ad3555b
+Plaintext = 81b9c73029cea1936ef8755c80ba8d4093
+Ciphertext = a0c866adcb202e8b721bd18beb10c32893
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = b1688cbc058816974694cd26c0f28ba9418e9912867fc8c5f4e7bd9c891a8d2e
+Tag = 60dbbd8f46343c8442b03a472da4e23f
+Plaintext = 618dc26853ee339689467ffbc2a77be69e
+Ciphertext = 40fc63f5b100bc8e95a5db2ca90d358e9e
+
+Cipher = aes-128-ccm
+Key = 79eae5baddc5887bdf3031fd1d65085b
+IV = 9da59614535d1fad35f2ece00f
+AAD = 469e004fee9878ed40621b41d04ec34af175f213d64d16e2f77d0bb2b6efe2e3
+Tag = 43352e46995e8c1aee43dbdb26b46c30
+Plaintext = 4f18bcc8ee0bbb80de30a9e08629323116
+Ciphertext = 6e691d550ce53498c2d30d37ed837c5916
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 733f8e7670de3446016916510dfe722ce671570121d91331a64feb3d03f210e6
+Tag = b4cc36852fd64a423fb8e872252b248e
+Plaintext = 617868ae91f705c6b583b5fd7e1e4086a1bb
+Ciphertext = b2dc1e548b3d3f225a34082f4391980a0788
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = b6ec659856866959ef6fd4e71ba930f0e3e5fd49d7465fd65f6813ab4ca1a770
+Tag = 95a66eb5b902bb23a1a8584249409fda
+Plaintext = b8b342c49c28bffc2a1c457db0b537ad46bb
+Ciphertext = 6b17343e86e28518c5abf8af8d3aef21e088
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 89eb3636fff80230352a3582be5698e3401c9e0579d48f2680c6e5e24d99f74b
+Tag = 7fa792fb7246218f7d56d5fa4a5476bd
+Plaintext = 37d694ba94d0af8df662134f20d142903839
+Ciphertext = e472e2408e1a956919d5ae9d1d5e9a1c9e0a
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 03434f3709e19a1e37edfcaabc215116763b71ab1c5e053dbdb599f86959f25d
+Tag = a83dc3f0012ae6da32a15fd1684835ef
+Plaintext = 90e4c0550cb7b279ef61f9140b7d94b8003d
+Ciphertext = 4340b6af167d889d00d644c636f24c34a60e
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 0e2ddb65fcc72094ac388d53a1055c7e902285c4c3c33c13bb6fbb4f1956414a
+Tag = f09d38d3dba01995e36bd685c8ea3371
+Plaintext = 69b851e63a78baef90637978e3dfe8c47be4
+Ciphertext = ba1c271c20b2800b7fd4c4aade503048ddd7
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = a42b2538ee2fb5f6a85d4d00524b01ad3331f61c404069243f35f28e2c2d0a82
+Tag = c89becf8d2bb935cb17f44b950df3ef5
+Plaintext = b7dbf8382115199dd2a2d87938c6ae6c4241
+Ciphertext = 647f8ec23bdf23793d1565ab054976e0e472
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 09bc5c426dc1faa4d71f50908bd6f297ec8e754d4d20def005585b4bc1fa31da
+Tag = 96e28badf0202097e80561451796194d
+Plaintext = d53698d719c51bf9eae346269c6a1da07162
+Ciphertext = 0692ee2d030f211d0554fbf4a1e5c52cd751
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 2ac87e59c2c86532cf165af3e8ff4871d730f5e742cccca38bbcdffff4472c93
+Tag = 710d4d7f66660891ac655d6eca4a3f3e
+Plaintext = cfdb7363985aa01af6f8e8237dbfb7871eb3
+Ciphertext = 1c7f059982909afe194f55f140306f0bb880
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = 05d2fbc3d0ec81f52f31cb0c4bf960c2076867f6d9f0174ed9176e20177b2693
+Tag = f90ab18925fea6964490f364a975a473
+Plaintext = 56fdf10dc0c1dfd10965b83938e557459c61
+Ciphertext = 855987f7da0be535e6d205eb056a8fc93a52
+
+Cipher = aes-128-ccm
+Key = c14eda0f958465246fe6ab541e5dfd75
+IV = 32b63ca7e269223f80a56baaaa
+AAD = c2c3902cfe8622254b3787cc13e79c5a3c388c2357c29f1c1ab5539a10bfae5c
+Tag = 68a00e5e7a39b371024927d3ac98fe43
+Plaintext = e7c9812eda2ed7dcfc80fc5fe0d43e1e5982
+Ciphertext = 346df7d4c0e4ed381337418ddd5be692ffb1
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = 3a069a2bfda44abbb0a82a97e5e9047258c803da2c66190d77149e0f010b3af9
+Tag = a6d7568c738e3a7fdf142d8f2d1562c0
+Plaintext = 2f3bf0b566440912a1e47a0c07f1cfd39cb440
+Ciphertext = bd6265dcba9e14c59e515e395dc60bd053345f
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = 7709132415c94960025cc39c950ead208703a9d5a71e224fd022dc0a1817d0f4
+Tag = f22337efa5cb7db7240e7518b67ffbb1
+Plaintext = 7c880d787726c4ddeb2304b5d161b4a257298e
+Ciphertext = eed19811abfcd90ad49620808b5670a198a991
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = aad77595f87a27f2c7995fc7149317f4cbebcece8336db2068380070784a4283
+Tag = 40bac6094528f02eeda093312fcf716f
+Plaintext = 08c43bbfa706512aa39e2bfa5c365aca11e22e
+Ciphertext = 9a9daed67bdc4cfd9c2b0fcf06019ec9de6231
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = bdb1b82ba864893c2ee8f7426c7b9a8460b00a50f164fc8f2ff2ae9cddab8657
+Tag = 0c041d86dd483c1d6da366e91bd826dd
+Plaintext = a531c0ed8840b2fcf08d76eca71036153b6e11
+Ciphertext = 37685584549aaf2bcf3852d9fd27f216f4ee0e
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = 38b3b9f45041ceb743fc2655b409213fa081427e41c833a2321a09fbd566c80c
+Tag = fde45ca2a83dec2f930bb652a6fcdc5f
+Plaintext = 177946b4dc3b0b825a505f097a0a203eb21c00
+Ciphertext = 8520d3dd00e1165565e57b3c203de43d7d9c1f
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = ec9d8edff25645520801b6e8d14a2fc3b193db70d5e5e878742de83154a578da
+Tag = 8b89aa22cd7d0170a975565cd3a33dc1
+Plaintext = a2634ef20a2a418b2c3be64f0b5f79d7ea9b7b
+Ciphertext = 303adb9bd6f05c5c138ec27a5168bdd4251b64
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = 8f6c1de4efdc5ac2d6e5452b5b4f58416d618da672f521332fd297ede8350134
+Tag = d960b33c3df5cd38a82980dc0950ada4
+Plaintext = 40e52edaad5acf2d4eedfb3f9ac2908112e9b1
+Ciphertext = d2bcbbb37180d2fa7158df0ac0f55482dd69ae
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = b0f1dc85fe223bcf29cdfa9319866bacd0a0a79c554e24d1f10889279e31c0af
+Tag = 38fa273c4102b5ca050b23044ac2064f
+Plaintext = bf97780f498c23adcf1c49f60873780a235969
+Ciphertext = 2dceed6695563e7af0a96dc35244bc09ecd976
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = 7d02a323aa769a8201549bf48a520d940bf6f69ed6106f1ce68856c22a594216
+Tag = c15438af1bafac3eac61e1c24ed00ab7
+Plaintext = 58bfe1eb2d38d91f80b3467db94fdcb84ff5f3
+Ciphertext = cae67482f1e2c4c8bf066248e37818bb8075ec
+
+Cipher = aes-128-ccm
+Key = c5e7147f56ba4530b8799ababeb82772
+IV = bdd38e173fb20b981659c597d6
+AAD = d4b90ef8abad08c552c8c3b080b8c37df314d514049d45e27ec4527cb06cdf85
+Tag = 4422d9e2f4f84fde49e9701296294d5a
+Plaintext = a206a1eb70a9d24bb5e72f314e7d91de074f59
+Ciphertext = 305f3482ac73cf9c8a520b04144a55ddc8cf46
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = e98a77f2a941b36232589486b05f4278275588665a06d98aec98915cc5607e06
+Tag = 9d5ca3d8ec5065630d2de0717cdeb7d5
+Plaintext = 4802422c9b3b4459ba26e7863ad87b0c172cfe4b
+Ciphertext = daea2234ea433533bf0716abe1aa3844b6d3c51e
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 5970a836de1f1e91d94d7eef79742cbbd46a759c413715eb0224fd6a27145333
+Tag = 0ff0648ddb07f42f815b38bfc95688b1
+Plaintext = 796a69ad0e9379173ef6b66f44f5c84fa70a0e28
+Ciphertext = eb8209b57feb087d3bd747429f878b0706f5357d
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = e3f08834c4894f6fa66a55a280c0e677a79e97c1ef9488b21384e74e57b1b51f
+Tag = 3ddd9a6977ea8e7adf5c5234346e560f
+Plaintext = 98e1f8cf250183b13ad418024dc40c1a6a7ee8ac
+Ciphertext = 0a0998d75479f2db3ff5e92f96b64f52cb81d3f9
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 18349be2894d49290339b97f4db28c92b3e112ffac77100abbf9c093935b1a46
+Tag = bdee05328a7ea8cc6c2e42bf3faeeda0
+Plaintext = 4a856d9b50a5b40d6566b38eae6a53ed0c192805
+Ciphertext = d86d0d8321ddc567604742a3751810a5ade61350
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 7355e34ad13880de17a1d66b02672ea5c9f51774019f64ecbe36747ffcd9b671
+Tag = afb1435cf929db35ec5986aabaf4a7d1
+Plaintext = ad048eb2ad75266b43b59d9d1f073c44e4cbf25e
+Ciphertext = 3feceeaadc0d570146946cb0c4757f0c4534c90b
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 4be21ba2eb26234ddcbb6aac6b4c3be7ef644af64edf51b7c29ffc3ddd80036b
+Tag = 736be6563cf9f5bce97486b7cc6f1c18
+Plaintext = 5b527ac6cc6d1b4c3c56f8315bc96dae91632df9
+Ciphertext = c9ba1adebd156a263977091c80bb2ee6309c16ac
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 266e0e3365e06d3b1e864c6e5897145df7bdde90eb744013a7b36632d4cf6580
+Tag = 2e90335fcea56b969b4fce65442768dd
+Plaintext = cee059cb0fe91a39faccc2914340baeab4b644ce
+Ciphertext = 5c0839d37e916b53ffed33bc9832f9a215497f9b
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 55a723883a340877d85ad1a5f264f2c834d824c7bbf207cdd8500c9d11ef9225
+Tag = acd6afdb3578ebc75e8a408d32758931
+Plaintext = 85321fef6a2b7d31cbd079c4bf2bfbbc979df90b
+Ciphertext = 17da7ff71b530c5bcef188e96459b8f43662c25e
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = 773864475a1a60a778468a66cbe13dfe3458094e62abb593f50c8495e3a8b81e
+Tag = a19fb73fc0488d9f29a09c1b47e3e066
+Plaintext = e227b8d44320bd3ce9d3f7d688f3de887947b1e9
+Ciphertext = 70cfd8cc3258cc56ecf206fb53819dc0d8b88abc
+
+Cipher = aes-128-ccm
+Key = 78c46e3249ca28e1ef0531d80fd37c12
+IV = 5de41a86ce3f3fb1b685b3ca4d
+AAD = f64f3b00c9117aed3c486aa4c8d574b44d679be4069e1078bb7100af38cdb190
+Tag = ce2c5ef8cdce76b358739e2a1b173fb3
+Plaintext = 206e9eb2bc3f8534d844a38debf1306df808744a
+Ciphertext = b286feaacd47f45edd6552a03083732559f74f1f
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = 545aeac737c0ca2a3d5e1fd966840c3a0d71e0301abbe99c7af18d24cc7e9633
+Tag = 2f2da4dd4d817c9fa2d44bc02163a0a9
+Plaintext = d516bbff452e7706c91c7ace3e9baa76d65ff7050f
+Ciphertext = b85242fdc06344f2bd9a97b408902ebcd22aece3d4
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = f032db01da60ca078d35c3fb5d05d6750fce1c01911a0422e827e8976946e4dc
+Tag = 180f41bccbcd47c8b7890754c032269b
+Plaintext = 590d1aa655fed50ca2e402299f2da6fe20eed56071
+Ciphertext = 3449e3a4d0b3e6f8d662ef53a9262234249bce86aa
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = 71ecb4252518997b53491cf42a3e0fe1496a2af2329a16f9fcd9c4f249900341
+Tag = 1d6ba58cc2eb474401851bf9502c3413
+Plaintext = ecd86cdb7d78d310dca5b477cd9da2612f5a05ab39
+Ciphertext = 819c95d9f835e0e4a823590dfb9626ab2b2f1e4de2
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = ec7abed9bda4a52fdf1bf278b6bdd6b0a27d4688deb9ff5ca9c8c865a4d2f730
+Tag = 9b94d4b7a2044696c72322e850537b6d
+Plaintext = 0024b14c283df032cf80c22ad8d2c96289ee229092
+Ciphertext = 6d60484ead70c3c6bb062f50eed94da88d9b397649
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = c2c77d7ad7b27d7c0f976a1e28881ea4ec7ad03b63a4e67f47280a40b8f58086
+Tag = 9d8da8e718570caf8bed7909fbff3ec6
+Plaintext = bc6965d8f62d066d118c14044c1fd2a224b9d95110
+Ciphertext = d12d9cda73603599650af97e7a14566820ccc2b7cb
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = 28929286bd1391468ac75f5c03689f74780ddd7585fc16f9a9bf7b00357a72e5
+Tag = e671012690c61fe3c9abd50a78eb4736
+Plaintext = da4a630cabaff0728a1cc3e6a79721a7176b708f1d
+Ciphertext = b70e9a0e2ee2c386fe9a2e9c919ca56d131e6b69c6
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = ed360d22081b019dc979420a3a45c21c8903c59daedd9f1b4ef2bfdedff0ec1d
+Tag = e657e2250427130acef7032454cde7b6
+Plaintext = a95058f8e1f6bc0f143a9ca7e4425a2a63eb2f7e33
+Ciphertext = c414a1fa64bb8ffb60bc71ddd249dee0679e3498e8
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = 2b4022d0b951fe48635d04fb3e2fa032c07c855fdd73f45670953bb9ddc77cb4
+Tag = aac6ff0a264b8199550d93c1f06063da
+Plaintext = fcbbc7f9d1ace60e830ca56ec84814fbd2579993d4
+Ciphertext = 91ff3efb54e1d5faf78a4814fe439031d62282750f
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = 48e553a87a7d3c1bd68af39f96aca67583da86e06701d5e4c4ed404dc66d70f3
+Tag = 7e68bf636e81c332f72063dc0d6fc2b6
+Plaintext = b95d298d391c6b893c6cad66f9780534516e71455e
+Ciphertext = d419d08fbc51587d48ea401ccf7381fe551b6aa385
+
+Cipher = aes-128-ccm
+Key = 8883002bf13b3a94b2467225970df938
+IV = 818a702d5c8ee973b34e9acda1
+AAD = e8e2835e47144365a2f218d4c95d7522e824fb43b66d4727ee570f8303dd6dd3
+Tag = df3af9e9c4e04bad261dc17cf00a00dd
+Plaintext = bc79d444dff9d9e722effab07b068cb7723ae8fae0
+Ciphertext = d13d2d465ab4ea13566917ca4d0d087d764ff31c3b
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 50422c5e6a0fb8231b3bb6e2f89607019be6ad92a4dae8e0fe3f9e486476004b
+Tag = d828101682de32923788c70262b84814
+Plaintext = 33bfd0713f30fcac8f7f95920ac6d9b803ddd5480dd8
+Ciphertext = b168747dea3ae0fbede4402af9a3dc3185d6d162f859
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = bb0036b34b0c20094d335a8c74f6b3dea42eeccf4145192eada64ae00c726b2e
+Tag = bafc4ae4d31907def6f648b081174e2a
+Plaintext = 5576d94b577ed26820fb13c00ab0e2d1a1c3589bfdc4
+Ciphertext = d7a17d478274ce3f4260c678f9d5e75827c85cb10845
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 5140324aa758dbbb5391b5e6edb8a2310c94a4ae51d4fba8a7458d7cc8488baa
+Tag = 314e378e9ed6e725a14c07632b02bdbd
+Plaintext = 13303e14068205cbfa992d4ccb6a265804ea64a15d7f
+Ciphertext = 91e79a18d388199c9802f8f4380f23d182e1608ba8fe
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 74da07d324060e590356988f27d9879fa3a3ade0fe71e2a0e49054211cfa1fe1
+Tag = 5bc2f2f9331536f7f70be09c41bda0ad
+Plaintext = 567e6d14b446add630d53ea86a537c0938537c4604a8
+Ciphertext = d4a9c918614cb181524eeb1099367980be58786cf129
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 0e403cff47adee3ec5bb6b178dabfc7d53b60a04eaad33a2fedd9db705358a4c
+Tag = 6b59cc9c3c008bc5876ef86327859cbe
+Plaintext = 9f3d165d44cf1c5770346d211d4ff34ca2ecd6b28549
+Ciphertext = 1deab25191c5000012afb899ee2af6c524e7d29870c8
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 211e6ce3d0c3abdef069e6e4fa35015797bd8a9d64bc9b75f20b028b12cca04a
+Tag = 135e6d59a5385a78658d60d254f99962
+Plaintext = d726e599db6a6d40629bc4bda5e3fa2e5aeda229cea4
+Ciphertext = 55f141950e607117000011055686ffa7dce6a6033b25
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 3c5c67b083322115e1b3112c2b6968efc050094e23e646dce982eac9d6e67d10
+Tag = e234e83d9a0570dbf2b2fa59ce3cdbd9
+Plaintext = 42646cfb8a99e48a35cee3f5f9b3e6175695973f6de0
+Ciphertext = c0b3c8f75f93f8dd5755364d0ad6e39ed09e93159861
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = 37a931f1dd05755b376d1a164aa36b8de802e39f8108a0453c1114754665fe46
+Tag = 2084e352b1b157267228576dd056c1a3
+Plaintext = e814c7b5c72d973a9bc7ccd463f107325ffa3321783b
+Ciphertext = 6ac363b912278b6df95c196c909402bbd9f1370b8dba
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = f1ddc2c49da7363526ba36c600c589b4c3121fbb8c5b9a8aa0de0e7453b30568
+Tag = bf88ad35ee338e489e55bb49732447cf
+Plaintext = 4f7a5618870945b89f194e31b1aa802c5350326dc691
+Ciphertext = cdadf214520359effd829b8942cf85a5d55b36473310
+
+Cipher = aes-128-ccm
+Key = 5cea00ee44cfb9cfbb598d3812e380ef
+IV = 948788a9c8188cb988430a7ebd
+AAD = d14b3d3803df432488b5d66704abef6a500d397e855bc2c2574df746a515cf70
+Tag = 7ab67f9397a81371ef6ebc775cb7007b
+Plaintext = f555216840a1f40b411d44128e567617e2694caf1621
+Ciphertext = 7782856495abe85c238691aa7d33739e64624885e3a0
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 2bd112231f903fa0dff085db48a2e2a96ec0199249b005d5ab4c2eab753f9ad0
+Tag = af57647efda119c59862cd5dd3904efc
+Plaintext = eede01b08f9a303cdf14c99d7a45732972c6eff2a1db06
+Ciphertext = feb114b7bd3b43497b62454a675a632c3546d2802462c6
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 864e0e728aea856fae6c6daa6357d1542cef7177f441ba21a563f6c4f6fdc1dd
+Tag = 2af4027ca5824b41c7bb238d3e8eeebf
+Plaintext = 8a56588fe5e125237b6cdc30f940b8d88b2863ec501a0c
+Ciphertext = 9a394d88d7405656df1a50e7e45fa8ddcca85e9ed5a3cc
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = dac7f3cba0b5a47f67f85b226b66df695a8ae2501355e36aad105375bb95f732
+Tag = f7fbd7044ce1d7b266bdf545247a3c2b
+Plaintext = 66e34540d7accf377877aa2d3e6d2db0cfafc608a1eb3d
+Ciphertext = 768c5047e50dbc42dc0126fa23723db5882ffb7a2452fd
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 07f48cdc12aa27119fbdfda4ec07ce6068c92ba7ba9c930905aadd156b1dd56e
+Tag = afabc559b552cf7c7730c7dca25bc3ed
+Plaintext = a9ebd04fba7155c39b5c29c5571b5354c9ae228f5e5b13
+Ciphertext = b984c54888d026b63f2aa5124a0443518e2e1ffddbe2d3
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 2d24e79abd157af2c21b60932947fd9f9d6478f09ec56fffd341ea04a17b8e5f
+Tag = 488ca99e0f85ac388f981ce25560b8f9
+Plaintext = f179353aef342f0f691caf1fcb811e3f6504e14d6d9381
+Ciphertext = e116203ddd955c7acd6a23c8d69e0e3a2284dc3fe82a41
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = fea280f710379e4665b5ed3d1620729a7bc164899dc83e6aee3612d538fa20db
+Tag = 9156faae3d8860bed216e8d497a75962
+Plaintext = 6c19a18eab544acc883c5886eaa89f54d61ae5f1f1368c
+Ciphertext = 7c76b48999f539b92c4ad451f7b78f51919ad883748f4c
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 18f2e3457127c35f2e0cff2d821af8178028fcc7803bc795c49f4a435b37abeb
+Tag = 88cd7791c544d1098b2de49d04b1e0c1
+Plaintext = d0df1bdf1df6203241722fb9c9c1cf7405017497ae1545
+Ciphertext = c0b00ed82f575347e504a36ed4dedf71428149e52bac85
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 35221f0efcb109cb93c38a62c58b5ab8b236437e171e8507cf417a569af1767c
+Tag = c523fd8a2524717f63dac75c22268fa6
+Plaintext = 479526b33c42c240b9a4549ca70cbfb691f16ae3be8888
+Ciphertext = 57fa33b40ee3b1351dd2d84bba13afb3d67157913b3148
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 95f2ab02af01aeacce86b02cf846f9fbd516963d06e350e8b7f6df2778765a01
+Tag = 92904f05dc2397596543df73de5aa708
+Plaintext = aa6761148b254a2ff202b620c2ec2c5e623bf61f05e483
+Ciphertext = ba087413b984395a56743af7dff33c5b25bbcb6d805d43
+
+Cipher = aes-128-ccm
+Key = cb83f77751e72711401cbbf4f61aa0ed
+IV = c0b461b2e15b8b116ef9281704
+AAD = 3746a36154e42dd600049d506f5ce4d034864263b1a65cecd24c8e25fb9c82e1
+Tag = c3cbfecfa3f75fb111ef0011222b7948
+Plaintext = 2f298f106703b8a994cbb20acf47f9442e44f6b5e82c38
+Ciphertext = 3f469a1755a2cbdc30bd3eddd258e94169c4cbc76d95f8
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = 6a59aacadd416e465264c15e1a1e9bfa084687492710f9bda832e2571e468224
+Tag = 2ec067887114bc370281de6f00836ce4
+Plaintext = b506a6ba900c1147c806775324b36eb376aa01d4c3eef6f5
+Ciphertext = 14b14fe5b317411392861638ec383ae40ba95fefe34255dc
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = e82fc3ffd276218a82aede65fe5abf4fd35c7059a26923f8dbb97a59c903a7f4
+Tag = 0d2d30268e9f1ce0e7c762993297d828
+Plaintext = eab8cef576816a82ed036f158e5036f5987b195e60582a6f
+Ciphertext = 4b0f27aa559a3ad6b7830e7e46db62a2e578476540f48946
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = 776aae7f62225556b6da522c0c9432ac70fe72ac6f3f361071ef3deb4a6715e8
+Tag = 0939e56f0b7200d1b1409f3f8e8179cc
+Plaintext = 566ef9ce1d397be2547c385639507a9e7d6f9eed9a3b1055
+Ciphertext = f7d910913e222bb60efc593df1db2ec9006cc0d6ba97b37c
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = d9aef0955922f89747ba4a8ddcdb8c1c7579aefd3c2eb8ad0589c66576a8504c
+Tag = 138e3b817023993608be06fe92efca8b
+Plaintext = 8c28b6d93b23f1ea031d5020aa92f6608c3d3df0ee24a895
+Ciphertext = 2d9f5f861838a1be599d314b6219a237f13e63cbce880bbc
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = 13c222a65ce30570ecac85a185a2a0922a8c96d633339a1ca067ce57ae426e1d
+Tag = f3ca13b4ab7fd0d4badf158972570c06
+Plaintext = f0c1cd60f5fa8d1efd5e2e1ab37c4f7e6aef76d15e8d6ac8
+Ciphertext = 5176243fd6e1dd4aa7de4f717bf71b2917ec28ea7e21c9e1
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = ce40fb0cbfdf07676ed55b040ae6be5db8f0a0f28816ae8ea71da3cbd71661d8
+Tag = 0a79fa4e8b27a31ff360a1b6c05ff844
+Plaintext = 570d5f79aa8db14b1ac99ee567cc105ae9e238e482b52628
+Ciphertext = f6bab6268996e11f4049ff8eaf47440d94e166dfa2198501
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = 446b01d09cbc41b6393ef81ca65ab7e099018187d5f9d22f5074dfc491e72077
+Tag = 5d34ef0ca0b47d6a2ec7442cbb739504
+Plaintext = 7c267223047af946b06f6a45ffde4a5ec49c28b81ca22da4
+Ciphertext = dd919b7c2761a912eaef0b2e37551e09b99f76833c0e8e8d
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = 01ec87920b42639d4ba22adb1fbe5138d2849db670a2960fd94a399c1532ed75
+Tag = 8f607d154393e35fd1efc1ae8cb244e4
+Plaintext = cbf112e4fb85276c4e09649f3de225b2398e86ac3fe48bc7
+Ciphertext = 6a46fbbbd89e7738148905f4f56971e5448dd8971f4828ee
+
+Cipher = aes-128-ccm
+Key = 43c1142877d9f450e12d7b6db47a85ba
+IV = 76becd9d27ca8a026215f32712
+AAD = 5032b818d202872f3fe2b08fc7940696df02cf393a6d6247f5c6f5f2125cb08b
+Tag = 617d9cebea38591a00c9fba4ef9c8e71
+Plaintext = 4324a89788e8ddae5d560cf937df701743cbbc3bf980558c
+Ciphertext = e29341c8abf38dfa07d66d92ff5424403ec8e200d92cf6a5
+
+
+Title = NIST CCM 192 Variable Plaintext Tests
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = 58f70bab24e0a6137e5cd3eb18656f2b5ccddc3f538a0000c65190e4a3668e71
+Tag = 3bf9d93af6ffac9ac84cd3202d4e0cc8
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = 760d065275e345900a7bbab451cc9309fb161e6cfec526538b98800e4102e14d
+Tag = b0078a769ab68db44e723993da382abc
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = ffedc67efd355ea404fcbcb3993d3bae81386ded86230270771deb747163bf44
+Tag = 31fbff2d715a2eb9af54e8320a8e42e1
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = 55153ff5e4d208d2e647794f382c788e0e36f293e63e7290ba9ff2657ae0f167
+Tag = 945839d62c9d1b899f6dcd0ca9517e68
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = f8813985f59bf284bd3882e899ca9b67fb496f3eb78d7ebe6ffbad084f639915
+Tag = 903f90d23321a6882d6c4c1955b14847
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = 7b95cd827ab93507f1819ae76627d6e2a31d29890c092e5c300f0e2f9e4ef4d2
+Tag = 652ec5ab43088eb568186d0d9887b30f
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = bd144c9bb974729aaa1188ceefdf85e1d9fddc0b0c8afe8828ba204aa9293feb
+Tag = e6c1455d1117eec49338c96f51007309
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = 92b911cdc3137a6f7f32651b788eb82975660aea52b2c03b4759755a6da4a0f8
+Tag = 1cf3c32fb229dac209523eaa517bb59a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = a8200dbbfe4086015cdbdec2fc8e4934d0d663527430c424627ed44065ade091
+Tag = ee10bfeb1cf9b3cd5a0faebd4d8f3fe1
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 086e2967cde99e90faaea8a94e168bf0e066c503a849a9f3
+IV = 929542cd690f1babcf1696cb03
+AAD = 3b7f37b6b8e3c1390a99d59c47f7c102cf659d361a132ef8b4e70b9585bafebb
+Tag = c51ed994253adb9bb5b9a8c34a27f225
+Plaintext =
+Ciphertext =
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 27cabc40da0e1eda0ea5f8abbb7c179e30776250a7b30d711b0e106c5ee9d84a
+Tag = 96f58c3f38c44d1a345f3e2da6679f20
+Plaintext = 1c
+Ciphertext = 1a
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = dc2e28d5ae726c1beadb1e7e92ae7d14f5546320deb81a910bf170cbe0210eaa
+Tag = 0579aee7c17482691f3f832d867ffea7
+Plaintext = e9
+Ciphertext = ef
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = c579f912ac1b45d5aa8cf20f78f0a1ace32abd3dc7fd0b3f3a7182a008795c7f
+Tag = 3452d8ece38ffa1d4107d6a053acd8c8
+Plaintext = 97
+Ciphertext = 91
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 69ea953dbb910ec589372d797c7379d3f3b9e9fd48894c9b55e6e8eb360a6211
+Tag = 0d760b9fe29530738157db0ba2d253f0
+Plaintext = f4
+Ciphertext = f2
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 622835dea57b2c70cca8f7548d6210714070b55b36adde7a4c547269c07aba9c
+Tag = 6fc21f24dee7b52f51d69eea30819f4a
+Plaintext = 9f
+Ciphertext = 99
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 67ebda0a3573a9a58751d4169e10c7e8663febb3a8cf769d81bc872113f0720f
+Tag = 94c5b8db0064426a77dc536814c56147
+Plaintext = 43
+Ciphertext = 45
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 255412e380e9a28cbcd345be172c40f72dec3e8a10adfd8a9ab147e9022524e1
+Tag = 6d36c0b0d699a22da3116dfb8f453181
+Plaintext = c1
+Ciphertext = c7
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = c7c8e7151eb6844a954d091b460f83add0f0a634aa5ac213b774f2451aa497fb
+Tag = 0c3a1690acc3f0eb09c9cfd3396c7fa9
+Plaintext = 31
+Ciphertext = 37
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 63f00b2488809fdc49ca5f05d54e98468906308115f7e702da05ddfd970b5537
+Tag = ad45070fe4c61270c13cc52247fee411
+Plaintext = a7
+Ciphertext = a1
+
+Cipher = aes-192-ccm
+Key = 992d38768b11a236945bd4b327c3728fac24c091238b6553
+IV = b248a90b84b0122a5ad8e12760
+AAD = 8e2c5e55c0bf70014e9897b6f6940e4e738b1e84e8269b6382f0b1fe59b0e162
+Tag = b2a2a8b283ff7eeff5c2670f77b8809d
+Plaintext = 40
+Ciphertext = 46
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 40affd355416200191ba64edec8d7d27ead235a7b2e01a12662273deb36379b8
+Tag = ef3d6ef9f981557506ecc8797bbaaaa7
+Plaintext = 0c6c
+Ciphertext = c996
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = c5e12e17e02bcc12b3a4c14cf837250e2886db3ee1c717d28bd11e8a3b764ddf
+Tag = 4405257a837c5343b59d5689d6de5269
+Plaintext = 23df
+Ciphertext = e625
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 213b5b6015d472bd593be5acf85ebba6d6a09f3a962be302ba83c6d70c61f241
+Tag = e93e67d37d2367bb1f27f71b54b29317
+Plaintext = 0dc2
+Ciphertext = c838
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = fc1b6e152fe232b6c10b5d89900961c445f4c46833df242c826678b68c869811
+Tag = ca3744a4ab375af9060621a9dc4f4c32
+Plaintext = dc88
+Ciphertext = 1972
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 5b2eb1a6fa585d61d1fb3da68f5b93829c8e2d5e4fe03782617553d7a130ecf1
+Tag = 172626e930d24052bc056d8609c4175f
+Plaintext = 8179
+Ciphertext = 4483
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = e2b3c3bf33cf847660929e48cce51d9d9289945169651aaecb1e939756e93105
+Tag = 852310207be8d3417de800b372700da2
+Plaintext = 01fd
+Ciphertext = c407
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 6051f12cd8aae68b4023aaf7178fd086aa582b8d8821e36637abc97025f5e858
+Tag = 28553bc037954dbf4ce5db99792c2c7a
+Plaintext = ca18
+Ciphertext = 0fe2
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 2d3555faf285caaddfe95c010c2a7f233e09c2fc0cd30d644035269280527ad7
+Tag = 904725668634d6345bd8f90a3831b452
+Plaintext = a855
+Ciphertext = 6daf
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 4fca820dc545bf93bdffed33a04b67eb45384e696f092c2197e5d79cecd09913
+Tag = df6098cb3135c3045a54ffce88efaceb
+Plaintext = 5555
+Ciphertext = 90af
+
+Cipher = aes-192-ccm
+Key = 5012db40ff6ae23c1e1ce43768c5936c4400b0e79ae77f30
+IV = b67e500b35d60ad7264240027c
+AAD = 1789ae403e183d2225f431f001d475b53bccdec66572bb027340ae592839ba8b
+Tag = 8568e8c08ff5ee5ea0a608589c2fc029
+Plaintext = 11dd
+Ciphertext = d427
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 31a0338c3839931fa1dd5131cb796c4c6cfde9fb336d8a80ac35dec463be7a94
+Tag = 98d9a2147776dca9c1a42382bce323b2
+Plaintext = bcb898
+Ciphertext = 68f082
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 4863dd810ee70ef0f5da81f60c5ce550abb96454619032322e34657af25207de
+Tag = a9a77755b324f3a557217752ade14ed7
+Plaintext = d1da2e
+Ciphertext = 059234
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 173594fc26b167f044aeaf9bfe920cab99a27eb2b01827d61f7553cb2018b5fe
+Tag = a4441a79a90e228a28069fe109d5d876
+Plaintext = 394f31
+Ciphertext = ed072b
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 71cdd16eca9255aeedc23bd623513918ea97da21485074415fe75bcc42f454c0
+Tag = 65f272f44c5210b5bcc571e819580910
+Plaintext = 868bda
+Ciphertext = 52c3c0
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = e84418d332d16d2298e69e7ff3c37bc7b6e030cc822e73b3f4a0029bc2ea4d80
+Tag = 59c5f7f73a1b5f419c9f63ca401894a8
+Plaintext = 52d6bf
+Ciphertext = 869ea5
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 42d962109bea1d50be0f3d83b4c2a6033d53b3d7112591866b1ae52dc84cb5d0
+Tag = 220b828cf5365137fb3f1df67cc8d2a1
+Plaintext = 6f8d58
+Ciphertext = bbc542
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 943b4327b5c70dba63c82f27e0412b3ada012bc0f7dd39ebb13db2f864daf80e
+Tag = 422b0f41075ac79a0afa2d1047cbbfb5
+Plaintext = fda286
+Ciphertext = 29ea9c
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 6076b94caabfa476ab7e6482e4fda9b29f2e2b2883efe44d668c7c74628505bb
+Tag = ae68cd6d6815ecbfd01293d160d4d38a
+Plaintext = 8651fb
+Ciphertext = 5219e1
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 3e4bb5781f84b4bbd23583e3dae561c6ff4af8eff35e2a4f35b50d2f360d3469
+Tag = fbaa81cfdbcaee476860cd5102f556e4
+Plaintext = c3e179
+Ciphertext = 17a963
+
+Cipher = aes-192-ccm
+Key = fa15cc7f0de294d7341b1fd79326c8be78e67822343c1992
+IV = e5257aed2bda0495aa44591db4
+AAD = 364008acbad330d0b8d574641a97b0682c49279cfdc80ff309b7514514d18a44
+Tag = 7ad1520564b68824a3a939371c21a336
+Plaintext = 4a97d5
+Ciphertext = 9edfcf
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 1225b036e6044df52314016760e92750de0936120395de750a2c54a7fa0cea82
+Tag = 9344e2de064f269d065a2a6108605916
+Plaintext = b46b343e
+Ciphertext = c2c39d6f
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = aaa6257d6783936a4445833c2ac3bea8cb7334f22ade9c035d515bbc91d6a78a
+Tag = 693d90b8297b90bc41c231d08b0204fb
+Plaintext = cb216301
+Ciphertext = bd89ca50
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 1c1915fab09348b9a5536495c70d1a040305708c1124797e564b63e008e7b8ab
+Tag = 9d0146fe373437c529fb2eeb169e4bd7
+Plaintext = 697a8696
+Ciphertext = 1fd22fc7
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 864d0f786497c7ce283762ca0959ec9c825ed445a5dbe5b4b2e5772fe88ce7f5
+Tag = e389c549bfc4ede936d7896e544b23ad
+Plaintext = 6bee3db9
+Ciphertext = 1d4694e8
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = d5388b0b548c58886dcd335dff2b1ed23ce3eebbb708fb5bbd831c83e959d3fa
+Tag = 95177a9fe6d9329a585c8737c92a4d29
+Plaintext = 85d95855
+Ciphertext = f371f104
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 83cddd189736f224cad6a29efba45e43c75450a14f1541713b7fb926ffc768c6
+Tag = 3914431a10b1f94a2b99b9e442f3dca4
+Plaintext = e8b23340
+Ciphertext = 9e1a9a11
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 8fccbd1fc5240691cf24e8807bf3416c1b2d87fc86dbf3955fa2e52b9a3a8457
+Tag = 383d8dc98b22010dd93cd0cbb396d9e3
+Plaintext = 595c4d7c
+Ciphertext = 2ff4e42d
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 513d45f6f37f3f051667dc743215059e06e4fdc8945789b16d50556a2e839368
+Tag = 40c513bfc92d1a7db5ed7cab2d8212b0
+Plaintext = 314e0c7d
+Ciphertext = 47e6a52c
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 70828be102e554f0d4b07641fa3254bc8db06eefaf5b85a7c97e01c217fc8f3f
+Tag = ea98f4ac6b3eabd483f1e6ab92f3b83c
+Plaintext = 35753e32
+Ciphertext = 43dd9763
+
+Cipher = aes-192-ccm
+Key = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf
+IV = 2ef29d62b40d8643848797cde8
+AAD = 343d5a4ad39acf81adcf24e9807618932abcb3bc076734f179174c77c8cb89e9
+Tag = f99fb67b1e2aba2d232db2445e6aec2a
+Plaintext = a531c0ed
+Ciphertext = d39969bc
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = e04e81e860daf9696098c723085d8023c240ebe7a643131e35359ab04bd650fe
+Tag = 43ddf77b33d8cf2963ba76fd4e19f3c5
+Plaintext = 8ceaeb89fd
+Ciphertext = ec9d5ed362
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = 6217cd581d4b3b2f7bcf1b8dad9ad6430e2e3a0063cad52260e0a1cd6fc9e73a
+Tag = 6b73fe9e638e205b27f78ed1bb9b0ed0
+Plaintext = 7e51d6f870
+Ciphertext = 1e2663a2ef
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = 8aa7847e496f5e9f1f87851442de844f27a21c1b48f82fe525f0dd5a88b8ec38
+Tag = 5936115e23158aff1916edec241fad56
+Plaintext = e0023b674d
+Ciphertext = 80758e3dd2
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = 3612abc865a4d8d7b86a84109388584df6526525adb1006ec6c8d00048d725bc
+Tag = f15aae4b70dbee244be1daa74475d7e2
+Plaintext = e2b5b6f36e
+Ciphertext = 82c203a9f1
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = 849a99c6f1cae0ad4bcde4bd0811e87ca5ed7b913de1a8285a206e980b4b7043
+Tag = bbff424487848385f8501ab5a77f327c
+Plaintext = 9a17e4a22a
+Ciphertext = fa6051f8b5
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = 9066367c784de0a4d1116bbe95ce55ded85edddb6273c2049ee24e0fb3429352
+Tag = 72d8d5da6f593a8d9956731b42645aa9
+Plaintext = d4e765fc78
+Ciphertext = b490d0a6e7
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = e7aa9f767fa8920f96f91c41d9e86755faaedaeda596a444b65f99b7a9e23e85
+Tag = e3eca12b835dcfd08166ac8831585626
+Plaintext = 1074349e10
+Ciphertext = 700381c48f
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = bc0db1ebf910b6f4dcad5401401d6bc2272e23130947dc236ca664d5b5ed6d66
+Tag = 2bcce66018e9e552d2c8a229301361df
+Plaintext = a46dd7fb58
+Ciphertext = c41a62a1c7
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = fcbeba2d0d73239d05f691a52b08152c9dd871f8dc76c2c18b8a638a74460d31
+Tag = 3e41a50a28ea3be14baadf12964a37c4
+Plaintext = 2e0ca09221
+Ciphertext = 4e7b15c8be
+
+Cipher = aes-192-ccm
+Key = 30419145ae966591b408c29e5fd14d9112542909be5363f7
+IV = 27e6b2a482bbc6f13702005708
+AAD = dcdefce64ae4339f46c0759a4a10b29d59daaaf1e5dbf75cf11b4e4f73c5025f
+Tag = bee2ab25bfafa76dc3e54832b2f76864
+Plaintext = 2e108ce0fa
+Ciphertext = 4e6739ba65
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 691dd98f61fd213b0840ec5a6f06ef9a1420be0d59bde5e43546347a2a865a94
+Tag = c15536e21d961c675070ec4cff9037bc
+Plaintext = 24d6880aed7e
+Ciphertext = 270120f9634e
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = d1fd047cdb18463766841abb1fcd25257f1458b595bfcf24066ff9385232fa97
+Tag = 9b303af0b098f902dc24e66fe56adc6e
+Plaintext = 2298028d0213
+Ciphertext = 214faa7e8c23
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 65a480d120a0459dab69e8f23094801e10092666cc56f9fb2549662982bda6d0
+Tag = 1b657925a9740d6828bd85cd12205764
+Plaintext = f248e5225e3d
+Ciphertext = f19f4dd1d00d
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = b738a53fbc9689dd49f68f97f5a99665258cd52e74dc653b594cffec045508aa
+Tag = 395a1c49129ef6cce0ad5f6ef378aa1c
+Plaintext = 611dade00cec
+Ciphertext = 62ca051382dc
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 7006f54184f0ff0ab215ca408d46325b86c1cbae6da7838435b1826ff81f55dd
+Tag = 5e68468d1b2b516be3d688567d84ab80
+Plaintext = 5871a8300471
+Ciphertext = 5ba600c38a41
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 9e6e6675d4c6b1e0f3894aac071f4c99a364708edea12f319cbc27b40fabc0f1
+Tag = 0ba1af163049d16817021665d183bc9e
+Plaintext = 3ca8a7520e94
+Ciphertext = 3f7f0fa180a4
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 10ceef716f54b74d7c8a435d6aa38a10ff23939ca29e2de7b6c3e0a8269a23c9
+Tag = 670f35869da9821b6ff1fab3e6062ad4
+Plaintext = 9c2a0070fbba
+Ciphertext = 9ffda883758a
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 3ee0865f29be50160273b4a94ec078932b9cd10a858e31838d5b607867e1ce69
+Tag = 08f395250fd79087c858b83755411114
+Plaintext = 436179c74fd2
+Ciphertext = 40b6d134c1e2
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = ec2b8bfe1ccd491b02aa4a9178fd6f099556963e39e2ca5fe6ecb6b5d2a46085
+Tag = afcbd9af2d584a0f638d066f2496d9be
+Plaintext = ecfa41c614c5
+Ciphertext = ef2de9359af5
+
+Cipher = aes-192-ccm
+Key = 748ad503388a34041a7bdae6361d57894357c333bacf02ca
+IV = 518b79d194579b19f2d8845b70
+AAD = 5b6f6369643d83b1db33d75257d7dea761e574e6e1f1ecead64e5e354a2f4235
+Tag = 17861882b8930296fd51d969a1e9489e
+Plaintext = b48c10105dbc
+Ciphertext = b75bb8e3d38c
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 1cf83928b6a9e525fe578c5c0f40c322be71b3092239bff954dd6883738d6d71
+Tag = f4b6cab1383adb420c4724aa7bdfefb7
+Plaintext = 2a755e362373ef
+Ciphertext = f06238b0450fd1
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = bb5450f66273f63b2f79dce177381ce846584ce4f7a0ad5a0171a56e149370bb
+Tag = a1f99175d3dff5a73f0053a95c36fd8d
+Plaintext = fab43224bf8989
+Ciphertext = 20a354a2d9f5b7
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 3e5e1037bd2922eb20c34200c470b76e537baf7e7f1d8dd2f7a184a593c66554
+Tag = 34b4ad0e41117940abf530093dac648e
+Plaintext = e3aed6715aa429
+Ciphertext = 39b9b0f73cd817
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 3cc88a096a1a440827f5b7da675389e50b5cce35fa2cc36674d6bfc5a3a966b2
+Tag = 663a8324014550430c7eaeffbd8568f7
+Plaintext = e78db0f83997cb
+Ciphertext = 3d9ad67e5febf5
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 2cca33a10b9da7ba99a6b552d1405f2df3fdfd15358d8fdab5e15296b38f9135
+Tag = 34ab635c4eb5b38b86e71da8af3840ae
+Plaintext = 726557906845b1
+Ciphertext = a87231160e398f
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 2fe5dd58b17914187e29029c53cfe5b015ca74cab750d8f95e05f818c3cdf947
+Tag = bd9961766e03eaa7e8888227c98d1f42
+Plaintext = 043a759b578be4
+Ciphertext = de2d131d31f7da
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 8b8e3d7c88fa16d70130cee290b7e2eecf0ce711118cd9265093b11467e63554
+Tag = 637842d96d13c4aab97e296458745a9d
+Plaintext = f31f2fb4b3fd80
+Ciphertext = 29084932d581be
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 6341370e126097f9721a13c977eb4875cf1286e15c3adfa4e7597e0e13d93b6a
+Tag = a51ac46611366c666cab6bfd3d1baaa5
+Plaintext = 7e3c8224104669
+Ciphertext = a42be4a2763a57
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 227926b62f7cdd90e4d3b0cb5457e71fb087d329671f0fa891ec06eb8edeb58a
+Tag = 8c7d7e5aec14845f844ad38544a2f11d
+Plaintext = 26a0528ae6f9c1
+Ciphertext = fcb7340c8085ff
+
+Cipher = aes-192-ccm
+Key = b930cca30a3fd230c237c8f3cc6792d0c4084dff5c18d775
+IV = 7574802fd82fe96c05431acd40
+AAD = 05b50c40b02e79b74b94d726a7ce8b2b7216ef8af6e7a42d041d2a692a58ad83
+Tag = f1605ab8a2332012b759ccd2eedbed24
+Plaintext = 61dcf53d1a184e
+Ciphertext = bbcb93bb7c6470
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = 5c7ce4819b30b975ae6ce58dcc1bfa29a8b6dda8f4b76c7e23516487745e829c
+Tag = 07482362ab3f157c42d0e9c6c5cffcf0
+Plaintext = 4d54d8b06b204445
+Ciphertext = 2baf90c490b11f96
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = 90257ed88679197b8219bc4c2434a71a4e3664d5859c4ffb9a075654898ffedf
+Tag = 5389509b5b6f2df1faf7e8c39203970f
+Plaintext = b2a35df881cd63a2
+Ciphertext = d458158c7a5c3871
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = dff8ad83525d8235eacdccc91abeb80795e6b5f463fd28af35c46199f646ceb8
+Tag = 95328747ca544e987df28883d0377b35
+Plaintext = e98f5e5a20d02c80
+Ciphertext = 8f74162edb417753
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = cde159c5343cd9d98001cd719d3e9ea25e47e1ff13fc87055d4a53b741f59285
+Tag = a4ba841883a0d7aeda398c043161966f
+Plaintext = 90c3e48313cd4fe4
+Ciphertext = f638acf7e85c1437
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = fa88cf5a08be4fb0c1a7960f45726c303eb559861fa60d17aa8dfe8bb5795382
+Tag = 09195efe66c5faf413e0f68df8cb647d
+Plaintext = 8ad6d5a28ec075e6
+Ciphertext = ec2d9dd675512e35
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = fe9e93a9370b43efa1560aeb017ff04fca7f207191e6f707c1c35b2e90c44eb2
+Tag = b51af067ad69ad96009e50ead3d03f02
+Plaintext = eb83928f0d5f7aa3
+Ciphertext = 8d78dafbf6ce2170
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = 35792c854fdf1c8cf7f3f8ed2b8ec4f31fe17bf8d4ba49caec03f954bd8bb17a
+Tag = 6b1cb03ee76587f84364825f7c1fcbe9
+Plaintext = 4cd74ed2fd083011
+Ciphertext = 2a2c06a606996bc2
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = c084108f9c0a74cbf70f614dceae592546865006930db0401828a0eecff98671
+Tag = 8fa70c5e195f1f955d64892f532b7683
+Plaintext = 52365f94579e0646
+Ciphertext = 34cd17e0ac0f5d95
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = e8045949de61c5c18a63e628330a4d1d12782379a8f9187755409d1825f453c5
+Tag = 2ddf297bdad58083645a052815d29a83
+Plaintext = 8fb85c857a3e38e7
+Ciphertext = e94314f181af6334
+
+Cipher = aes-192-ccm
+Key = 314c136999e41d137bd7ba17201a9fa406025868334e39b3
+IV = 65f7a0f4c0f5bba9d26f7e0ddb
+AAD = 53cfdfd66d63c2924bd583487b90b1dd9ec199f90d660cb9c3a763a4776abfe1
+Tag = 1ad3b2be41dbc39df4c0145dcbae3e76
+Plaintext = 43d2828e86f7856b
+Ciphertext = 2529cafa7d66deb8
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = d68d5f763db6111c5d6324d694cb0236beab877daae8115ecb75d60530777b58
+Tag = 467fd8e139eb9ee8fcdca45ed87dc1c8
+Plaintext = 13511ae5ff6c6860a1
+Ciphertext = b3859b757802ebd048
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = f6e219b29884dab9ea9bad34d9ef8a50ae389c9a908de7154a1f2e894f27141f
+Tag = 89d0ee8323ea2ee7a68aaaa9c49b98df
+Plaintext = 7e7e33e1a07d4e8fde
+Ciphertext = deaab2712713cd3f37
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = bcca002d69d9d1044c40ae741ea33ce6b8463f5a28d0514e044fdae2fe7d3c3b
+Tag = 37c9fe3d9feb0485e6d7c04423b77a53
+Plaintext = cc88980c73e6c5f0cd
+Ciphertext = 6c5c199cf488464024
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = 39cac8f0825ffdb0668455933ad1581263a23b9e5f1305340528f0320d4b1269
+Tag = b87e90a71ffe6c30bee1771078a701ab
+Plaintext = 34cb528f50d073cfdc
+Ciphertext = 941fd31fd7bef07f35
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = 510a02a44d142c8e975d1d933f828fd7e47d28b88223f1698cf009dc3b079be6
+Tag = 9e9c5be0657649448c38692e8d703d30
+Plaintext = cbce3df86438a61065
+Ciphertext = 6b1abc68e35625a08c
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = 40e0418cd52f74d78a8e18ed86210e3661a86d8574aedcee540340d8996d9852
+Tag = 13e5f2bfd33101597cfae7cf334a8528
+Plaintext = 80a2b835f8b0729a4b
+Ciphertext = 207639a57fdef12aa2
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = 1f2938b3bde19e1af91299c08638061dc3c1ea3284c259d415e996477cb37b0e
+Tag = 516a7310fbd4ceb90d8db9a86cb6311b
+Plaintext = dd04794e65ce34127a
+Ciphertext = 7dd0f8dee2a0b7a293
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = cbae5b46e35fa2a279dcaa4c724b923805d4707412a84252b64228c91cedd019
+Tag = ef6165af65f3522dfbfed0293db39ecd
+Plaintext = 00c4101052f54462d5
+Ciphertext = a0109180d59bc7d23c
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = d0f27c7f42892f3ad4c0029c5b698abb1d035ba5869a665b1de8861db6c055e8
+Tag = 0726434c1349e3e874a2d6bf598d05fc
+Plaintext = d0865445d3b26b6f49
+Ciphertext = 7052d5d554dce8dfa0
+
+Cipher = aes-192-ccm
+Key = a19f6be062ec0aaf33046bd52734f3336c85d8368bef86ab
+IV = 7f2d07f8169c5672b4df7f6cac
+AAD = ab0f5a829a9319a74d5d5179aa0a410a0fcf52f344a7a896aeb1f7a6c5d398ea
+Tag = ab491e60fc97b3cb5248291e4866dcab
+Plaintext = 7c7c8580b944ed3fd3
+Ciphertext = dca804103e2a6e8f3a
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 9ad52c041390d0d4aaf65a4667c3239c95e7eae6178acc23fb4e70a852d483c6
+Tag = 6aba025abc01416a7ca9f096ab2529cb
+Plaintext = f777aba1fa70f94e6de9
+Ciphertext = 9d8bff6d2dcde77104ac
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = b49c7e7b47870c1cc339c7c09aaacfd6115fa8a0f04990367eea10cfacb9d23c
+Tag = 4acb200e85a0d4753a8ba226aca72f98
+Plaintext = 349feebfbe58f93ea3c3
+Ciphertext = 5e63ba7369e5e701ca86
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = e61ca7310172eec16745a73e34516f65844eecd0dbc5566ac5213626b9096ef1
+Tag = 7869784e3321183d8c044657a020e9b9
+Plaintext = 678a40b4c2c7df0e4c9d
+Ciphertext = 0d761478157ac13125d8
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 690f5e5d8da6cdb0f492e80449e152ffe88fea9742564d8383c79cef739a7f74
+Tag = 70634d00b1facf0e9e9979ca257a71e2
+Plaintext = 2b81e0533313664bf615
+Ciphertext = 417db49fe4ae78749f50
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 78e34b0a1d61ccd411cbfd306ea2ef3ce89c0b085deb4cfbaec2ab72ce16daa9
+Tag = 994630ed92e2973b22773f229b45bdad
+Plaintext = 1ac63aa38a206d8e7d68
+Ciphertext = 703a6e6f5d9d73b1142d
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 51bacfcf87ea11da34b76acba8c444792ec3db3c8ee6e600d69679975a682a54
+Tag = 04571b015bb6b4651f1eb9f6fb3a7b74
+Plaintext = 027a7fd7897808ec7a56
+Ciphertext = 68862b1b5ec516d31313
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 5159357a133e4743f903d05bd641da369a3675337760fcd2424a99221ba70b78
+Tag = bb0e11ac4608081fd0702a137da0aea3
+Plaintext = 1086953d352e94a51a6d
+Ciphertext = 7a7ac1f1e2938a9a7328
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = f567820865340314d46a17f520ff315efb6b33bdeda590ca9c4fad604c2d8e8d
+Tag = 52c9ec1317ce30dffeb4c9bf3fd0bbdd
+Plaintext = b8b148aafec4a035e9a7
+Ciphertext = d24d1c662979be0a80e2
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 0cfec933831644b468724e808bb3d25fe8f15850ce513fc341da46089c845208
+Tag = 691e32be3cdd9721a13aabad26dba58c
+Plaintext = 884242a87779d3921f8e
+Ciphertext = e2be1664a0c4cdad76cb
+
+Cipher = aes-192-ccm
+Key = de1c8263345081d2dfa9afdf37675971135e178df554a4d8
+IV = a301bb82f91a582db01355c388
+AAD = 8edc2b85d44297ac66bdd90d05d8df38124033d6a583bb8dda18a2246ba096e8
+Tag = 333a381be77800654aac335bf9220ac9
+Plaintext = 25c32770a299020d8500
+Ciphertext = 4f3f73bc75241c32ec45
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 9ec08c7ed6b70823d819e9ab019e9929249f966fdb2069311a0ddc680ac468f5
+Tag = 0cddce66df9b4802f737bea4bd8f5378
+Plaintext = 33709d9c7906e2f82dd9e2
+Ciphertext = 9114d36b79b1918b2720f4
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = ba13974d95f2eeb367b63850609c53dc66c2710f682f10bef0142d48f851b430
+Tag = 12c94615be2bd81bd598f3022f5775a4
+Plaintext = 84172985e7d194ba28a87c
+Ciphertext = 26736772e766e7c922516a
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 5f16180bfac9b7483774cb0e1d57a43e9bf3cf03bf6fe758293aadcbbef25b80
+Tag = 2758e936750e335702542bc598e211c4
+Plaintext = 9a34d32070c71d7de8f512
+Ciphertext = 38509dd770706e0ee20c04
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 4352057bdd1735a85dc0fc4dbeedc73279c27eb24a97641236f03f11cdafb8c0
+Tag = 0762bb2a7d04ba2ad251d595d0619dc4
+Plaintext = 2054a268b1f6fae4f15d91
+Ciphertext = 8230ec9fb1418997fba487
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = ddf118ae403b2509e75eb7a26d17e73e527acbacfbe49a56fa3210169030144b
+Tag = 27d85594da3fd35bd8498d7e389ee7cd
+Plaintext = f71afe9a60f08a0ef694aa
+Ciphertext = 557eb06d6047f97dfc6dbc
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 973904409e8154132439926f0dc45c0d81bbbd5793f7f81e20eb818bfa374d58
+Tag = 055936db383a8ad10b152046d721d3f7
+Plaintext = cdf5b47ff73306aa55c496
+Ciphertext = 6f91fa88f78475d95f3d80
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 06bca7ef6f91355d19f90bf25590a44a24e5a782f92bc693c031e6de1e948008
+Tag = d57e228369e24fe955fd8924526af6e5
+Plaintext = 9ebf93643854ea5c97a4f3
+Ciphertext = 3cdbdd9338e3992f9d5de5
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 8321f65baf9dc856ac1c24f3fee5c74d697eb0b50470d59d8f4a14b506e86c53
+Tag = 6c23abfb3b4eb39deb8da2064390dfa8
+Plaintext = 685116faa5cc527ac8bfa1
+Ciphertext = ca35580da57b2109c246b7
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = a4e7738038a5116592bb9d92d6d4ed191ab774310f6409e4e45fe907674c006f
+Tag = b4272c0639e8e6a1d356fb4fea86762c
+Plaintext = 9e8c4f1292e8d7e5179b34
+Ciphertext = 3ce801e5925fa4961d6222
+
+Cipher = aes-192-ccm
+Key = 248d36bd15f58e47fcf1c948272355821f8492e6e69f3661
+IV = 9e8d492c304cf6ad59102bca0e
+AAD = 0df202431ee7f251a38aaf6aa8cd313782bd293af9114005adfe9faab253b572
+Tag = 0633a0f9cdc9490231ec2dd69f6e35db
+Plaintext = 3ecc2ba566c723462eb0ea
+Ciphertext = 9ca86552667050352449fc
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = 8c18486d52571f70f2ba6a747aaa3d4b3ebc2e481ee1b70907dddb94bdfa0ca6
+Tag = ff4b0f2b2a5067283210aba8630d0306
+Plaintext = 10554c062d269ff6dcd98493
+Ciphertext = 7f8b0cad79b545e5addf0b04
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = 4e0b4771c7f6c66f9577c430611fdeec5702296ee3691b6bb8c6a81217edabe4
+Tag = 5b16dbdf0b9be3c8c82ac652992d630d
+Plaintext = 1c9e7875cf02129ac52daeb0
+Ciphertext = 734038de9b91c889b42b2127
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = 4a687e1d0a95ed2efb95b4c6b040999fcd35136811cd665f934d10224b6064c2
+Tag = e629274d654ef5a4480e24f6bef3bc8c
+Plaintext = 34575694dde459d195b7357a
+Ciphertext = 5b89163f897783c2e4b1baed
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = b5330a8447d74a7987fb718cfae246b5c7e057991064eeaf823641a12bfce9f5
+Tag = 42ab5407a08b648ce24e9955e28fe47e
+Plaintext = ab20c8e8aab1aac1e4f64206
+Ciphertext = c4fe8843fe2270d295f0cd91
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = 4f19bbc3135d7a216465b4c1df2616e8bfc3cc64af0bf52bdc42543f4d2448d4
+Tag = 151e94d311c7cd2c1b9048575076ceac
+Plaintext = e556ca05bcd1991d2c9836a9
+Ciphertext = 8a888aaee842430e5d9eb93e
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = b6ffc7387b19786282bda7caad52eb37fbe7e557afcb80faaf57767e2a0f178a
+Tag = 61b71330d72506050368186a5619f180
+Plaintext = e5b665600a2aa413e117c538
+Ciphertext = 8a6825cb5eb97e0090114aaf
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = 6a493c5ef3769ccc4101dbb2eb36e1e5bbc577a057ce0731203ba3f25b52497b
+Tag = ea21e36f99e5aab6ffa85994d13d5bb0
+Plaintext = 870864a611aa0475d120bc40
+Ciphertext = e8d6240d4539de66a02633d7
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = 8215753d9efc51325f182199e39f9082cc3fe524400f2a7434c68df7eb2b06d4
+Tag = 7cc93a50dea11c5e0b19f14b9c8f16bd
+Plaintext = 71afe8d00c6f2ea8c8b050d4
+Ciphertext = 1e71a87b58fcf4bbb9b6df43
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = eb8f198da6ee92a03913c6575343f6c749d2377a09430eb751b13c041e6edbea
+Tag = 99cbfd1beafa2d2942f6812b8dfc88e6
+Plaintext = 7021f18b8f398a5999fcdcd1
+Ciphertext = 1fffb120dbaa504ae8fa5346
+
+Cipher = aes-192-ccm
+Key = 77a67fb504b961028633321111aac2c30eb6d71a8cf72056
+IV = acadc0330194906f8c75ac287f
+AAD = de2ee30359e390db72f682c2ca0f14b72b60ff9bccd8c6fbd19a512b12add794
+Tag = 337405235dce6161441caa25cc6007c6
+Plaintext = affca856eb412f0b3276ae6e
+Ciphertext = c022e8fdbfd2f518437021f9
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = cdd9bf1b4f865e922c678ec4947ea0cb02e78bd5c1538f33aeb818ad3f47e519
+Tag = 37f16761dd6aedbfc789ad96edf1490d
+Plaintext = 4021ff104ff1dbd91e46db249f
+Ciphertext = 7953d3cd66d093785d123f65ba
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = 342de5fe61e05c2e58ac2978a871fbdf186a7294ec5f85c4631c21b584231211
+Tag = 8f8e855ae975a1fc64bcce3e7492e9d6
+Plaintext = 95050ca1d494bdb561d4840f8a
+Ciphertext = ac77207cfdb5f5142280604eaf
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = 7871482948d8d09d0a7491d915543082cb5fc7d6c1e82ee2218279f54c15c154
+Tag = 017a6515156691b3161b747576078da4
+Plaintext = c45823203b20821a48502f9c67
+Ciphertext = fd2a0ffd1201cabb0b04cbdd42
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = 65781d018f27ca0c72a9fa9ab4648ed369646dd3ce45d7ad3a54f6b051f1b6e9
+Tag = 25cec7d2566a07cd78181ae94577befe
+Plaintext = e901661b7d47c9918244ee1077
+Ciphertext = d0734ac654668130c1100a5152
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = 05556b04dae5cde8525633d1862aa200c54af534e302d2cbd34ddc2b78532a60
+Tag = 133f51dac00f973fd42e0948fab70ea9
+Plaintext = 5556f799d6a6cffb343f28c1a9
+Ciphertext = 6c24db44ff87875a776bcc808c
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = 151304e3e4f3c2d4d3227e035d849e0d3841ba00cf6cab1cf2e3e4d6cc760623
+Tag = fe78bdeaa8d408ffe8fe64811aa87742
+Plaintext = 56bf26be81c7b55ef898e23981
+Ciphertext = 6fcd0a63a8e6fdffbbcc0678a4
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = f870cc1fe67d6169279f905b0fe5fd9a0436c36498e4b7c6f584f00f7efe8784
+Tag = 97228d155dda2bc814ff33ebeb9a7ffd
+Plaintext = 36b304a72dbf4acfffa1d7d624
+Ciphertext = 0fc1287a049e026ebcf5339701
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = 5692c9d452ea1c067e62fdc554ddd2b18c8433d59067f971316797fd9853ae6a
+Tag = e7ba03e144e34a4ab34791a372a2b8ab
+Plaintext = fb529eb5ae79a0830474ffbc98
+Ciphertext = c220b2688758e82247201bfdbd
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = dcf7fe16b7ca9e27ec3291103398eaa2e77c7b770b67f8858c215af4c523822d
+Tag = 03c2eb5ef0657306d12b753a0694efcc
+Plaintext = 6218c778955d9a56360f06c704
+Ciphertext = 5b6aeba5bc7cd2f7755be28621
+
+Cipher = aes-192-ccm
+Key = 0d423519e4110c06063061323f8c7c95387776b6ee4e4b6e
+IV = 39abe53826d9b8e300fe747533
+AAD = b0f1e2668611dca86e8d0f58c2a4cf4a9472d81ba013e271800b75841fe5ffde
+Tag = 7cc6119151393461ecf65bfe06e0163b
+Plaintext = bf6b143fb713a81c965c5a9d8d
+Ciphertext = 861938e29e32e0bdd508bedca8
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = baa482c64eefd09118549a8968f44cfea7a436913a428e30aa4ab44802a4ba35
+Tag = 8242ac1a1979c5a9e7bc67d7698c7efa
+Plaintext = d64f9426febce6a84c954dd5ded5
+Ciphertext = f7580f17266d68237747bf57c7ed
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 2ad8ecc5ac9437ace079419f17e6018625b10490120fbe2f12b41e64b73b653c
+Tag = 18abced491c063d8bfd0e7341febddc3
+Plaintext = fcd9b67717bcadeceddea336c671
+Ciphertext = ddce2d46cf6d2367d60c51b4df49
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 7585ee95e74d7a869bdc0b59ca9939dd57e7b09afab179079d467bfe0668416c
+Tag = 659ecbb3dbfbcdb0f913abedf8afab05
+Plaintext = 18232d7c792fb80e6ca1c8f2c3cc
+Ciphertext = 3934b64da1fe368557733a70daf4
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 41be6ca6188f34da1ce83fb8c27652848dc2a71e32bd3631fb9b33ae69e5d879
+Tag = a220d5ec0b5397d6b4e323b5dc7d1b63
+Plaintext = 764dbefb42644d18d23e5e456868
+Ciphertext = 575a25ca9ab5c393e9ecacc77150
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 197cee3b15320d57996191dd13106fbd4546a5cc3d2bcf0c886af52ea3d9a855
+Tag = 3a5f713f5d0793b732c6e114805cc9b3
+Plaintext = 8003586af34bdd0acae4f5547394
+Ciphertext = a114c35b2b9a5381f13607d66aac
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = ee0b647a47656a6e9e09c2d64f734a2cc3fd45b7ee52fea51c24af59ee22a006
+Tag = ed90e8650bc16f590789dcc625b9e63d
+Plaintext = da143266516a4145cde92c93f961
+Ciphertext = fb03a95789bbcfcef63bde11e059
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 9f5bfffa01f1425d95465723735b49fc1dffbad06cf37a00ca4b59efa21739c1
+Tag = bda183dda1aef021d92210e27cdd7c5e
+Plaintext = 3842b033f3ca31a6f8e5a638b39e
+Ciphertext = 19552b022b1bbf2dc33754baaaa6
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 64e92ba2748d07f602808f7c5ded15cb0e43140400d37107e59a01e7d45b4c9c
+Tag = 5e4087fb314f893937e95383e66745c0
+Plaintext = cedf60b17185fc71b957cb759260
+Ciphertext = efc8fb80a95472fa828539f78b58
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = 6ebcaeb4bd44ff4c990305ac64264dfe2ada5f7cd4b294eb9f492865cd28905c
+Tag = 0a71ce5813c578532b742d704fa92276
+Plaintext = 035f449bb28f43365f4a0556096a
+Ciphertext = 2248dfaa6a5ecdbd6498f7d41052
+
+Cipher = aes-192-ccm
+Key = a60cf7ceb62bf3118532bc61daa25ce946991047f951b536
+IV = 7499494faa44a7576f9ed5580d
+AAD = db617207dccd1f6baea5f2242d5e577adb8d69af3bb1707a7a53a8b75452455c
+Tag = b7fc45d15d6939668065d2282fc589c7
+Plaintext = 9a2a45424f4965a71270e77cc403
+Ciphertext = bb3dde739798eb2c29a215fedd3b
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 6d14bb2635c5d0ae83687f1824279cf141173527e1b32d1baf8a27f7fe34a542
+Tag = cb3993ca35acf354cb2b4254ff672e7f
+Plaintext = 25a53fd3e476dc0860eeeea25fcb0c
+Ciphertext = 4a1cfd0023557a184b929965b0a445
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 9f8a56fecf32fa7d50f033b2524c3d798e254bc87245cce57e38edd6ee5d5f1a
+Tag = a25b5eb103bac224cad66ec0f100875c
+Plaintext = 797dca47597947c057789433309b67
+Ciphertext = 16c408949e5ae1d07c04e3f4dff42e
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 86f15b8b677b7655f358a2c7fd5785bc84d31e079ed859b6af88e198debd36fc
+Tag = b598cc6ec2295c586e7ae270a01846d1
+Plaintext = e61f9a663d3a2b50ea2f9475971270
+Ciphertext = 89a658b5fa198d40c153e3b2787d39
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 4de6bd43c28143ea5d40919cb5330a7e674f5bd8aeb7b178343a2851281c8668
+Tag = 97ff732093f7d0a96b30d8cdfd1bd583
+Plaintext = df990c42a268950677c433555319b3
+Ciphertext = b020ce91654b33165cb84492bc76fa
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = a5c3a480dea1b2a1e3a0ce416148b04f60104217c9d24a5b267b4aa6aa07a4dd
+Tag = ad98e32a9156e125ff021ef6951b0c40
+Plaintext = a7e72fb4bec3768594a2f6f5b4379e
+Ciphertext = c85eed6779e0d095bfde81325b58d7
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 51b041f1666c59045d333fe63d43457107e1adad34fcbf965e0d191f3e414776
+Tag = 390f10df08a84c21031626861b201fbd
+Plaintext = d3d1550047cf90eceaea7000d8e280
+Ciphertext = bc6897d380ec36fcc19607c7378dc9
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 22f8a3c9d85b2d53ffd92078d3c94373f855ecd01a8ac521d1abd0f2c7cba9ff
+Tag = dd5d840bb8c4348a9a548482e6b93043
+Plaintext = 756412c4ee6416f2f4e0342011cde2
+Ciphertext = 1addd0172947b0e2df9c43e7fea2ab
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = da08b14e1b770b81faaf1e59851df1cba8838cd63bef141340ee378e65fdcbd4
+Tag = 3f0d49927cd6103e3705ba201e8f73c6
+Plaintext = 666e4a4b3f6cf598aa763cdada4109
+Ciphertext = 09d78898f84f5388810a4b1d352e40
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 2db3ded385ef9c82fd39ea5782d9befe66e8a070066269b2aa7c4bbfac3711c3
+Tag = 2d97f7c2b3b42bf570cce79bf30ccc50
+Plaintext = eb9013a74352b0677a88bd73052477
+Ciphertext = 8429d1748471167751f4cab4ea4b3e
+
+Cipher = aes-192-ccm
+Key = 82d4bc9aac298b09112073277205e1bf42176d1e6339b76c
+IV = 70325ef19e581b743095cd5eb1
+AAD = 194c9e1eaa8e376f9c41bf33823efa28ee60a9213438665b7002cf0fcad7e644
+Tag = d3c2a4fc45d014a0c54edab2930a5bdc
+Plaintext = e3126400e3c571a4d39b37bc938a22
+Ciphertext = 8caba6d324e6d7b4f8e7407b7ce56b
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 77743b5d83a00d2c8d5f7e10781531b496e09f3bc9295d7ae9799e64668ef8c5
+Tag = 40bce58fd4cd6548df90a0337c842004
+Plaintext = 5051a0b0b6766cd6ea29a672769d40fe
+Ciphertext = 0ce5ac8d6b256fb7580bf6acc76426af
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = e883dd42e9ddf7bc64f460ba019c28597587d06e57c3b7242f84d5e7d124ab81
+Tag = 8707b1a4d9ce3def33703e19eaab6dda
+Plaintext = b31dfa833b0cda20eaa84d2ecd18f49a
+Ciphertext = efa9f6bee65fd941588a1df07ce192cb
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 409401eb49cd96b1aad2525c5124c509766ff86f88b2011c67a1d501d3485e31
+Tag = fd9041ddce37d88e79fba28e385b2327
+Plaintext = 24bc8dc1e2354667b79ba4d7061448ff
+Ciphertext = 780881fc3f66450605b9f409b7ed2eae
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 83bf5c063bf1febf71688a832d615e09d6f14badedeaeb6ffbfe343fc7274e78
+Tag = 91d971893543868bd8c69078fc2bdb24
+Plaintext = d41d95a1d2326e12cba636910ddfca53
+Ciphertext = 88a9999c0f616d737984664fbc26ac02
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 8cdd70524e24318c64d681aa27752d4c86c5348c05c9e48f06ed41594785a6e6
+Tag = 866b23e4c991f4007e56a1ee9265c6cf
+Plaintext = e8a4b80e081919f1912542d3136764f2
+Ciphertext = b410b433d54a1a902307120da29e02a3
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 615985f63571c0f94ffcd4df77326abd41e84f388f061d97573a181da7ee5695
+Tag = 2abbea637996b954027efa9464ced6b9
+Plaintext = 7fca7388058d6d1438b6eee0292131cb
+Ciphertext = 237e7fb5d8de6e758a94be3e98d8579a
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 17aa90f2bff0419011b01dee62be31354431cbc89f22332704b096143d4743f4
+Tag = 57bc8d48d82ebefc76f17323c518ecc2
+Plaintext = aa540554ee80dbffa475f702d862d6b6
+Ciphertext = f6e0096933d3d89e1657a7dc699bb0e7
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 85288b2be612e42335c144fb058a7dcd567c382fbcee3962bd5be4cc7a7000a8
+Tag = 65470c81e487a26cdc26830f2b51bd1c
+Plaintext = 6d745581831edba437e70ea89cad217d
+Ciphertext = 31c059bc5e4dd8c585c55e762d54472c
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 288f9f52824b54b608dd7226a0a89d43ae8c05107dbae761e1c756911a003b74
+Tag = a3043722be9448c3ef144f2288066f75
+Plaintext = 811a61869c7a6b2aa9ac0fcc523ef784
+Ciphertext = ddae6dbb4129684b1b8e5f12e3c791d5
+
+Cipher = aes-192-ccm
+Key = 6873f1c6c30975aff6f08470264321130a6e5984ade324e9
+IV = 7c4d2f7cec04361f187f0726d5
+AAD = 51dbaba180d4746edbb3420461919b5b735797bf7dd19f84d80475f5efc2748d
+Tag = 49aba95e04e11cf18ddf73773d395c1a
+Plaintext = 378a4e39817f308ed1e639f943b694c4
+Ciphertext = 6b3e42045c2c33ef63c46927f24ff295
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 30457e99616f0247f1339b101974ea231904d0ef7bd0d5ee9b57c6c16761a282
+Tag = dc5e53e68c51ee55b276eb3f85d2cf63
+Plaintext = f6dd2c64bf597e63263ccae1c54e0805fe
+Ciphertext = ce3031c3a70600e9340b2ddfe56aa72cff
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 42370f115bbd4b31bb99fe82cca273b3c93072f96b2e09bdc6718d926d48db69
+Tag = c6328a7476db2c10ec7bca3f6bd3df42
+Plaintext = f45fee3e086c28a7c590ec0cc05b972664
+Ciphertext = ccb2f3991033562dd7a70b32e07f380f65
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = e2d692c5678124998a7862b8e87276b0a19e293a609103c99583b36305bcb2b0
+Tag = 8080f0d51d3b8841683eff361984f7e4
+Plaintext = 4ad69a8ab433ed8909825c71f6081f64a7
+Ciphertext = 723b872dac6c93031bb5bb4fd62cb04da6
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = b5b38791160959dd2836ec1ad25286c1ba410d7212347a95b5738a3d725bb651
+Tag = c1428ef5d40bc9e363817f219af2ed56
+Plaintext = 3d47071c13f994cb42fb2887e5c6e53a54
+Ciphertext = 05aa1abb0ba6ea4150cccfb9c5e24a1355
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 02691171795a77d1e3bdad513b6fab5b50d1def81bcc1df15012de3433a6aa78
+Tag = fdfb37dfd1236198035c8461b304152b
+Plaintext = e8a4b80e081919f1912542d3136764f264
+Ciphertext = d049a5a91046677b8312a5ed3343cbdb65
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 7371d8ae79e628f53ffede174eb068db2318c05e2f6d94ad2233a59369b16db0
+Tag = cefde0e84a3ce0cb702ceb73ca1dd9a5
+Plaintext = 549aa84bb182312dd016e3107f3b1f9c5b
+Ciphertext = 6c77b5eca9dd4fa7c221042e5f1fb0b55a
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = bb1e1f51082e470f7245458ec902098e1e41d0ed28efa31be71d21ce86527ff7
+Tag = f8441d46dc5456a587b765e1a820c11c
+Plaintext = 31a12ca6d69db2e6e252474d7d59ed6552
+Ciphertext = 094c3101cec2cc6cf065a0735d7d424c53
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 7584f57b49e95bbf5a67153e18b9b8c4722644e8f611613c39cbe8c679aba5b4
+Tag = d0daddcfcc92349ef059149c54a25cd0
+Plaintext = 5bb121e70452a954f420a56aca8cd5c059
+Ciphertext = 635c3c401c0dd7dee6174254eaa87ae958
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 505687182c06e6f4effe7fe03c1f436199a9015380ff21d0b2aa9453cfa10b1d
+Tag = 48c1242b89490c6ee69dedc1e91286ee
+Plaintext = 5b80d1cf745b14cb71cbc8dfe0bc7c7358
+Ciphertext = 636dcc686c046a4163fc2fe1c098d35a59
+
+Cipher = aes-192-ccm
+Key = 3cf8da27d5be1af024158985f725fd7a6242cbe0041f2c17
+IV = 07f77f114d7264a122a7e9db4f
+AAD = 7ebb051741145a3bad87131553375c6debcbcecee9b79ee451bd1429cbb33fc1
+Tag = a2ddd54e509bca0a45dcf2fd514e1496
+Plaintext = 79ac204a26b9fee1132370c20f8c5bcada
+Ciphertext = 41413ded3ee6806b011497fc2fa8f4e3db
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = ea9405d6a46cac9783a7b48ac2e25cc9a3a519c4658b2a8770a37240d41587fb
+Tag = 0ca478f40a6fbde01f584d938a1c91bf
+Plaintext = 56d18d3e2e496440d0a5c9e1bcb464faf5bc
+Ciphertext = 01baba2e0d5b49d600d03a7ed84ee878926c
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = 72340d595f3dbd23b46513f8f2b73b6249328c705e7968084bcb647fe734a967
+Tag = e4646492b6f4cb169383c075756073b6
+Plaintext = 7a76eac44486afdb112fc4aab939e4d1eedb
+Ciphertext = 2d1dddd46794824dc15a3735ddc36853890b
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = d5c87c649579da3f632ba95cb0a07c924095e4bdd4e0376e06bb90e07460172e
+Tag = f584289f560cbf76606942fe1a92dd63
+Plaintext = 48348c5ec996f7a97ef0ba2cd6885572fe64
+Ciphertext = 1f5fbb4eea84da3fae8549b3b272d9f099b4
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = ffa6277395d31d5db13034d362228a87610e441c98ca3038e252a9db12bdbcef
+Tag = 5964f5f5532d7cddd7207f0e9a6aace9
+Plaintext = d5c58f10e1a03d8a2501d1eaf5fcdfff3ae5
+Ciphertext = 82aeb800c2b2101cf57422759106537d5d35
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = daf83d02a9bd992ea58c23e7ad18d41796314bae20e864e729f40ccc215454fc
+Tag = 90ae047e35aecfc38ffdc07e7d8f5705
+Plaintext = da2a863ab1c58ddde320ecadeecac9c5d2d8
+Ciphertext = 8d41b12a92d7a04b33551f328a304547b508
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = 21ddad5f550044dc5cb123ade17eeef549c4e0173b216bcc602c1e736764cca8
+Tag = b2bdf539ceaa35015712dd15265ca476
+Plaintext = 4573969afa831c244817230406fe51183091
+Ciphertext = 1218a18ad99131b29862d09b6204dd9a5741
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = 9228265ae5c3daf1485ff8011738da508bf2a73731396c5d9aa56fc554e0c00b
+Tag = 241412124ae20b84c13b0c3671d305c9
+Plaintext = edf5557e15473b747a819398c9ac1459ffdb
+Ciphertext = ba9e626e365516e2aaf46007ad5698db980b
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = c0a2ff0de21b3ba961e06015ccd71374856a65a4c57cf8cde0a1643aca8ed868
+Tag = ee9803747bf9fa63412bfc4e10aea89e
+Plaintext = e139263478900df806a0f3446bd6600c1aeb
+Ciphertext = b65211245b82206ed6d500db0f2cec8e7d3b
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = b54378f031a31cf3985f573829c9ffca14616742e0a7e03b0a2d7f05eff0219e
+Tag = 5afdf430b57845dcf622d4f25cdeb2a3
+Plaintext = 660eaff0f113eaa2f5f7ad4b62bb849a3a25
+Ciphertext = 316598e0d201c73425825ed4064108185df5
+
+Cipher = aes-192-ccm
+Key = b46a3a24c66eb846ca6413c001153dc6998970c12e7acd5a
+IV = b79c33c96a0a90030694163e2a
+AAD = e67f35c18a9336469eae23040f98f52338ca8d0cab269ac32fe6bc7605d3ea56
+Tag = 7ed4c04c4b4dd585891ecfddeab8cc87
+Plaintext = 0f89897271f5d0349d57399005ea60c0cadc
+Ciphertext = 58e2be6252e7fda24d22ca0f6110ec42ad0c
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = b89166f97deb9cc7fdeb63639eeafb145895b307749ec1a293b27115f3aa8232
+Tag = 87ebe35e883cbd53b82f2a4624c03894
+Plaintext = 890d05420d57e3b3d8dbef117fe60c3fa6a095
+Ciphertext = f842ff6662684de8785af275fa2d82d587de06
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 4392c3043287dd096b43b4a37ea7f5dc1d298b0623ccbf4fd650a49569a5b27b
+Tag = 07d4824f0a98db2d87365a42ca3b80e1
+Plaintext = 6b425cdcdf8304e7fbb70b2973d55e6940025b
+Ciphertext = 1a0da6f8b0bcaabc5b36164df61ed083617cc8
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 9b4fc98fcdcf485205e7054bc9d1e02d0d8584420537e20d3821de2fd6824787
+Tag = 404e631735c544edeeb4c0105c55bf0b
+Plaintext = c8bf145fcffbafd6cd1a4c5b6cedfe008aacb2
+Ciphertext = b9f0ee7ba0c4018d6d9b513fe92670eaabd221
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 45622e1472542be2f63f463d253617eafd4f2ad609f9020884905dd5c22fba53
+Tag = c16a4cf37e8e96eed1217d21133e83d1
+Plaintext = 12b5a76faedf6f855e328c2cb87be8aea78c5e
+Ciphertext = 63fa5d4bc1e0c1defeb391483db0664486f2cd
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 958689aea3c6cd19020eff9d635ef44ee0793424df38fdf13a238b969d429777
+Tag = 9facf81a636351f6e67d6ec12636ae0b
+Plaintext = f0927c3cb0a876d7877466507da8bfa0bd9a16
+Ciphertext = 81dd8618df97d88c27f57b34f863314a9ce485
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = c22911efc36fa739048af0c951ef2449bb3605c52f65120c4d71fe5976026032
+Tag = 7ce73a7e2db69d30441f89a03fd0e84e
+Plaintext = d2c5d4e2362f19c99de66da7bd9c495c03d9a1
+Ciphertext = a38a2ec65910b7923d6770c33857c7b622a732
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 799da61e2c10ebb4783f618b8f69da7704a1b2b925cebc228af57d7ceebb9825
+Tag = 8d787a9d06b8533ca96fb1db8aecc8e5
+Plaintext = 1c9d7f5b329ef4d384b8b7955a20f8a3fc15cd
+Ciphertext = 6dd2857f5da15a882439aaf1dfeb7649dd6b5e
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 14a8e18afe0b9fe18ddfd754219a7e18ed36f419f8262d91678e10daffb31c81
+Tag = 8ff5f819d552c08054b5ac02063e102a
+Plaintext = 3a64414c3588d7c26871d7d054ac6c8420d491
+Ciphertext = 4b2bbb685ab77999c8f0cab4d167e26e01aa02
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 7294a8b4ad97c81969e4a2876a3dc0ee322d554726997dc9ed98c5601985ee5b
+Tag = 1cde5af8fada67c47cbb5787a6b2d9c9
+Plaintext = 545dd71bea9967e07a89f84a2027aacd132187
+Ciphertext = 25122d3f85a6c9bbda08e52ea5ec2427325f14
+
+Cipher = aes-192-ccm
+Key = 7b71045ccef735bd0c5bea3cf3b7e16e58d9c62061a204e0
+IV = 2b9ecfd179242c295fe6c6fa55
+AAD = 99294b22d73805805630fb416d20d4fca67419ab660ff45cd19a3729e81b9f69
+Tag = 7412640b179bd3e8a417dc38462c16e8
+Plaintext = ec1b17b885c018272652453f47fa6e9ed972b9
+Ciphertext = 9d54ed9ceaffb67c86d3585bc231e074f80c2a
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = f799818d91be7bab555a2e39f1f45810a94d07179f94fe1151d95ab963c47611
+Tag = 743f71e15490ca41d245768988719ede
+Plaintext = f383bd3e6270876b74abbb5d35e7d4f11d83412c
+Ciphertext = 377b5df263c5c74f63603692cbb61ea37b6d686c
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 69adcae8a1e9a3f2fe9e62591f7b4c5b19d3b50e769521f67e7ea8d7b58d9fc8
+Tag = a9bc8cfaf2a1734a792076618c4b9690
+Plaintext = 615d724ae94a5daf8d27ad5132d507504898f61e
+Ciphertext = a5a59286e8ff1d8b9aec209ecc84cd022e76df5e
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 4586f73a1f162b2cdb65f6e798a60b5f48938d40b4612d84c1f39244f14efdce
+Tag = c5122df904b052e4d5580fdeddf5297c
+Plaintext = 6e923e1f404002aa5cf8f8aaf1b9772da425e21c
+Ciphertext = aa6aded341f5428e4b3375650fe8bd7fc2cbcb5c
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 9f7ae892e5662803408d4d062265846441a43c1fa202da59f640ae722a692671
+Tag = e0ba1bb1af18e15ade3316c21d6b41fb
+Plaintext = 68115771505daa18bb3ce90054bfb7d077e1f37c
+Ciphertext = ace9b7bd51e8ea3cacf764cfaaee7d82110fda3c
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 1f0769a7ae82bd985661e031c4a892c15d3ef37bdcfb45243d02f40fdb51d34b
+Tag = dc71e342fbc44289ef7e53e28edf3839
+Plaintext = 681fd2a324b3fea4cfebed567ae4546ba373c8f1
+Ciphertext = ace7326f2506be80d820609984b59e39c59de1b1
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = bf957ef5ab2805e58ea752da5793f7f23d98fce1b2b67738929e5de8a15f9801
+Tag = ced1fb4a2a3e349aa590aabbfc3d13bc
+Plaintext = a7b9d2d069941e8b943706a02d2847ea713bb103
+Ciphertext = 6341321c68215eaf83fc8b6fd3798db817d59843
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 833264c1bebb597043b4158087cb651960915d9023189c9509c0d2aed84e7fe4
+Tag = 5079f6c2739e2b789b6e3d3c60389374
+Plaintext = 9b946e8198ce69d2173e970f4e0c103a47ee4160
+Ciphertext = 5f6c8e4d997b29f600f51ac0b05dda6821006820
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 94c8414cbbec52e2d73bb8f02ef687c91432495c0c744666317d02e6d46706d2
+Tag = 2a02f287db7217148317d897f65f6a0c
+Plaintext = 81ac4618f3db6bcf9bbf67220b7671be4bb4f8a2
+Ciphertext = 4554a6d4f26e2beb8c74eaedf527bbec2d5ad1e2
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = fced1131dab3dabdc1a16d3409fa09a90ffe02f0e2c814a63f77f771c08c3389
+Tag = 362df9f8b41b1dd4821f8f14e9e633d7
+Plaintext = 90851933d4d3257137984cdb9cba2ca737322dac
+Ciphertext = 547df9ffd56665552053c11462ebe6f551dc04ec
+
+Cipher = aes-192-ccm
+Key = dc7c67715f2709e150cceff020aaacf88a1e7568191acbcf
+IV = da56ea046990c70fa216e5e6c4
+AAD = 495dfcf91f4735ab35c6bc4deef8468bd988e4099cd291a32b4707f93e13d82b
+Tag = f61ffb51e56497ca9f39c6665fcbdfa8
+Plaintext = c14ce6d57f0fe7367331c9fe159ae1fb8f1ccb2c
+Ciphertext = 05b406197ebaa71264fa4431ebcb2ba9e9f2e26c
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = dbe3e82e49624d968f5463ceb8af189fb3ad8b3b4122142b110d848a286dae71
+Tag = 6f68a03a11cf00d58f062a7b36465d13
+Plaintext = 81ad3f386bedcbf656ff535c63580d1f87e3c72326
+Ciphertext = 9f6028153e06d14d30b862a99a35413413c04a49dc
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = d9acfd611e5bbb08c5d05d56791b8aebabf8d69734ec89153c91a1f65b2e1adb
+Tag = ca1fb470b666523a19f83481f16481ed
+Plaintext = 35f6bb3f6a388f3a5a039b0a495b676d0b928aeb19
+Ciphertext = 2b3bac123fd395813c44aaffb0362b469fb10781e3
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = 6003b771afe4e99e1ef1ed4a31b10540d95f4ac49885f0c8e5cdcb63d213127e
+Tag = 53cb05bfcd64da2b45c2e9a89a380b49
+Plaintext = 6aa7e3802b5a29d4f9ca88eb59f94af783d1054466
+Ciphertext = 746af4ad7eb1336f9f8db91ea09406dc17f2882e9c
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = c371644275a6290821e7d308714bec2bf62d36c30f7fa77a0d60b28894f1c82a
+Tag = 48f70fbc680cf7092b3dd90b943fc6e5
+Plaintext = 13332b67ba5ba18137c306bd860dc3eb0a9a0b871a
+Ciphertext = 0dfe3c4aefb0bb3a518437487f608fc09eb986ede0
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = 8eceb15300ec4220510ed5b7deb3429de6ae5f618e1c222c28990a9ab4b4bac8
+Tag = e386f33c0b8da8d0c5934e617dd618e5
+Plaintext = 05981dc26a1db2d8e2c3d85ea9a4d1dc3432d9edc4
+Ciphertext = 1b550aef3ff6a8638484e9ab50c99df7a01154873e
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = 96d1cf3690c48c77a155ce13e67bbd62e6f03d88c893c1f7c30a6435d5ab36e0
+Tag = 3d2db1360fb1121893f4d197731bce4f
+Plaintext = 60249343a8cd4d33c6edc583ea7e5c221ef3064787
+Ciphertext = 7ee9846efd265788a0aaf476131310098ad08b2d7d
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = 379bbc9f919dc2a8687f2a86cc9c3291804240a9b566c58519956848102e6155
+Tag = 335ce1bfafc0948f2523e75f2aad86f9
+Plaintext = 79003a8d3d20d412f468f11712cec4d37cee847440
+Ciphertext = 67cd2da068cbcea9922fc0e2eba388f8e8cd091eba
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = 9bff9c9a8f94cd77e7016748da31f86d1b9c68465cbf954511c93a4776981524
+Tag = 7dc265e281307f0f4c38cddc556ac725
+Plaintext = 7d078a8b200514a00628756250d410f7a0f8a769e6
+Ciphertext = 63ca9da675ee0e1b606f4497a9b95cdc34db2a031c
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = 25125a4668c31dc2e8a68b6c4c95ad7cf9322852e371b415a357d09acb01b587
+Tag = 61c78a2f85a447c3e62b6197d65b9065
+Plaintext = d9b0eaaff786165f882f41a98dbc0c355b3a1aaf40
+Ciphertext = c77dfd82a26d0ce4ee68705c74d1401ecf1997c5ba
+
+Cipher = aes-192-ccm
+Key = f41e369a1599627e76983e9a4fc2e963dab4960b09ebe390
+IV = 68ef8285b90f28bcd3cb1bacea
+AAD = ad34d8f0902a5b79fb145b8206bb4d3b77e0bd8ae2d0964815389eacb33b4007
+Tag = 0312d067c08a9b4400e1df8bb7ed671a
+Plaintext = 17b517ef577f588da374340d2522cc9ea642c8d8ae
+Ciphertext = 097800c202944236c53305f8dc4f80b5326145b254
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = 2870bd9a26c510e9a256920899bbc77a4eb9b53f927045a943d5ed6b13638cf3
+Tag = 2fe9afafc2fccd98ccf63b0fdec30eac
+Plaintext = 53911a67b65738f87fc7c20d6db8044bde1af95838d1
+Ciphertext = 70cf37d4b6f7e707376b1574ce17c040b5143da47abb
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = 611032a95ee87f89ad6be7c0fed8bd245c5f81076087b3bda4cde5587b8d14b6
+Tag = 102dfd8c231d6a355f079c213ce6858e
+Plaintext = 46917e38b8a542296d290d065b0aa7c8aaa38950c386
+Ciphertext = 65cf538bb8059dd62585da7ff8a563c3c1ad4dac81ec
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = 2e7ea26d1cceaca3b7862a7a8469e366b52ec27ca127e3317222ee651d8da4a0
+Tag = 6df11febe34dd568da12c374674b9ac4
+Plaintext = b527828c89f674dc6f024f8cdd80c694bb3ebd57b2d9
+Ciphertext = 9679af3f8956ab2327ae98f57e2f029fd03079abf0b3
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = 0bf4413010daec585de34142224d1cad3072f9720f91ac664ad152820e838741
+Tag = b2916540d9439b832aa44236a7e187ac
+Plaintext = 78230f73f9c0150f630eca4cd679818551d449db82e6
+Ciphertext = 5b7d22c0f960caf02ba21d3575d6458e3ada8d27c08c
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = 2e7cae3306582eb5bad148247aa6c6ec943f8748e84b8a069ca9488b11844716
+Tag = 0d0768a18dead55700901408aa3f901a
+Plaintext = 847bb12e0e56fa07a086eeda5907ae148148fa4107d2
+Ciphertext = a7259c9d0ef625f8e82a39a3faa86a1fea463ebd45b8
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = 63036dc4ad13aee5dc1832e867f7538da108188fec7b08262af440d07579c451
+Tag = 5f2073605d2a441805b6ff89d8beb68c
+Plaintext = ec59e208c4bb429a371f1b3ffdf07fce5dea8a05f0ce
+Ciphertext = cf07cfbbc41b9d657fb3cc465e5fbbc536e44ef9b2a4
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = f9ec5ce4b63156d57e451eb67ab6d7a59cc397f43f6d26dc07d1036f0fb4a8cf
+Tag = dcabef6907811c6b7df4e74c7a63d83b
+Plaintext = fb12d94bd21b5748b23132a03065c78dae65a0bd2cfb
+Ciphertext = d84cf4f8d2bb88b7fa9de5d993ca0386c56b64416e91
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = e13a204e16f42bbf4716e95f1cb7e125ffac66a87f591c8ef2c7b8485ff707fd
+Tag = 26aa8aa37e858cd990f5593d9ef35f2a
+Plaintext = 239fa31d4a65de0318bfc5b60a06d706c129dcf255ac
+Ciphertext = 00c18eae4ac501fc501312cfa9a9130daa27180e17c6
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = c4591c3ad984a1e189c526b719212f8248289eeb277827272b8205d78191eb2d
+Tag = d81e424d6b4528901ae46fb35f8b3106
+Plaintext = 57caadbb1a56cc5b8a5cf9584552e17e7af9542ba13e
+Ciphertext = 749480081af613a4c2f02e21e6fd257511f790d7e354
+
+Cipher = aes-192-ccm
+Key = 3289e59e3a7b29bf4a309afc253030bba4b9bdd64f0722f9
+IV = 30259ce106e9bd7a8bacbaf212
+AAD = cf4795bc7f43c30d3c3a8fd1b8a9d77d69bf59eb8b59d0f464315f40cb52335d
+Tag = f25a4bfda35e1390f3f16f638dcd4047
+Plaintext = a68c74e05f0a44d4a0372c0e5915b83d8e6729efacbb
+Ciphertext = 85d259535faa9b2be89bfb77faba7c36e569ed13eed1
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = e9699b20b0574fce8b5cbc4ef792eb96e2c1cce36b1b1f06ea2a95fe300633cc
+Tag = a39c3b429a1f922fac0b59e29a122e43
+Plaintext = 8d98c580fb366f330dbfda20f91d99a0878b47efd14c6d
+Ciphertext = 579cdf9da62a2df471e03450516adb4ce99ae0f70b1776
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = bd94c9ad6253c25dc417f87b6e52e03621ccf4b3bff5b402677aeb51e216335f
+Tag = 67bf538e40f9366adf8758968f06ce8a
+Plaintext = 7391ba60fabe2c632bbaca16af9a235b2c7dae61691c0b
+Ciphertext = a995a07da7a26ea457e5246607ed61b7426c0979b34710
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = 4f263cda4a50b0e5379ec2fb546b326a07943527c1d175c029455a917753883b
+Tag = 64a1199251b54f419720a30de83161de
+Plaintext = 7e1e93a6ca35a2c0e4f08fdb2e7ee22b9f486f0ab919e2
+Ciphertext = a41a89bb9729e00798af61ab8609a0c7f159c8126342f9
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = 4d43702be4f0530319555d7f1a3356160f6cae48051f12e22a153d7e405c1149
+Tag = b417e4cceb8dcf45ef33cc0007755bbc
+Plaintext = f94ff053c7413f34f96eae41fd1ac101151069af5a9428
+Ciphertext = 234bea4e9a5d7df385314031556d83ed7b01ceb780cf33
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = f4d7978fad36223623ccb5bb18a7373cba8a6e3b1c921259e319266042db8887
+Tag = d35aed57f49dcfecf248cf9d246ac024
+Plaintext = ba0716355fffb8ef947d2a15eb58375a1ff1084c566990
+Ciphertext = 60030c2802e3fa28e822c465432f75b671e0af548c328b
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = 12e4fe727b1f27a619dd67bb976ddc2b18b2ef8b7184290d9553494a500d933e
+Tag = 97cda0e04d2ff65c2e06a8276bdf6f97
+Plaintext = 872940780a94680a791c937994ceafd2c8b7a22b5f4927
+Ciphertext = 5d2d5a6557882acd05437d093cb9ed3ea6a6053385123c
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = 2c16724296ff85e079627be3053ea95adf35722c21886baba343bd6c79b5cb57
+Tag = 3494dd2ee0a0fe5bfc9f69234c8142ed
+Plaintext = d71864877f2578db092daba2d6a1f9f4698a9c356c7830
+Ciphertext = 0d1c7e9a22393a1c757245d27ed6bb18079b3b2db6232b
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = cefc4f2fb796c2502329ca3d8f8af3200dd9edb8f164e15acec90536a15b6fdc
+Tag = 9008ead8e923997508eebf5e776198dc
+Plaintext = cda681aa3109ebf5f21ee3a849098ea3a551e844fae4b4
+Ciphertext = 17a29bb76c15a9328e410dd8e17ecc4fcb404f5c20bfaf
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = 94fc7eb8febb832097ba6eecd2697da91b5a8a1f2248f67a7659e0ac55a09a0d
+Tag = f136cc6ea1b0fdb554e0803053875b89
+Plaintext = d4f8d262870b5000a40b8fcce88f55c65c4d12e729975e
+Ciphertext = 0efcc87fda1712c7d85461bc40f8172a325cb5fff3cc45
+
+Cipher = aes-192-ccm
+Key = 40f1aff2e44d05f12126097a0f07ac0359ba1a609356a4e6
+IV = 0df3fc6396f851785fca9aa5ff
+AAD = 459085184094e302b2e921cc04270b676e75bbcf0e4b53ed387df2bd0e75e0ac
+Tag = 5da8ceccae093888daaf92c95817fc3d
+Plaintext = 732f211061c0a32c6ad124c58418d560ef5eab2602314c
+Ciphertext = a92b3b0d3cdce1eb168ecab52c6f978c814f0c3ed86a57
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 3bdfd7f18d2b6d0804d779f0679aaa2d7d32978c2df8015ae4b758d337be81dd
+Tag = b7e17f235bd660e7e17b2c65320e9fd4
+Plaintext = 4eaf9384cad976f65f98042d561d760b5a787330dc658f6c
+Ciphertext = 635530cab14e3d0a135bb6eebb5829412676e6dd4995f99c
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 9de45b7e30bb67e88735b8fb7729d6f3de46c78921b228bad8f17cc9c709c387
+Tag = 9f40890c7d650afccda40fb2a4cd603b
+Plaintext = 59bee7d18fd4ba573f3e4f61076f5b9f6a3487e47d98c729
+Ciphertext = 7444449ff443f1ab73fdfda2ea2a04d5163a1209e868b1d9
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 783477f981ef0551b5e7a714b640bbb38316c53756c96e30c898cdee3b72e6f4
+Tag = 50236cf1a12a9e3542a4051788f9775a
+Plaintext = 4e7f3c86d846ff351db81dbe1d2e9ed73ec0450587ae681b
+Ciphertext = 63859fc8a3d1b4c9517baf7df06bc19d42ced0e8125e1eeb
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 2851d40243512a43f70f9c25e9b18c122a1433f05c61e65017e197e88b129e43
+Tag = b1bbad9861192df356c6678b2f561ea3
+Plaintext = 2db7cb2739c839383b64c2c93c7d5c906d984756c3dedaa9
+Ciphertext = 004d6869425f72c477a7700ad13803da1196d2bb562eac59
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 1cfa2d62cc1f6313fb0c6eb21803e09cdf61ee3ddb15192529560e5d8096cafb
+Tag = 1da4211d4c28d2d91568117fc99fd911
+Plaintext = 2f2b82497c78369890809460d80a16be4f3330e8a0089165
+Ciphertext = 02d1210707ef7d64dc4326a3354f49f4333da50535f8e795
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 5a14b556156191b2704936f64df0bf1dd2bd8d587418f4f85472338fcf86aa52
+Tag = da99be0e054bb881a25a74b547d3ed5e
+Plaintext = 7cfefca725da1b6bb5d9545e3e50f5a624a8160bdb0e7d4e
+Ciphertext = 51045fe95e4d5097f91ae69dd315aaec58a683e64efe0bbe
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 148de640f3c11591a6f8c5c48632c5fb79d3b7e1cef9159c680d71fd1f9801fa
+Tag = 4c1fedb47fa30ff2ead6bf382431b2de
+Plaintext = 5205165c4e9612974dc92f60d1e328d68aa9466e27dbd499
+Ciphertext = 7fffb5123501596b010a9da33ca6779cf6a7d383b22ba269
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = f852e38703097cc37c589b7860dbc333e091411462d5576dc9909a8cf6ac99d4
+Tag = 338762a4e4299615c67130a28b56a383
+Plaintext = f968f2833427abbc9fe1cab7e7a3f905a3b23a35802029ff
+Ciphertext = d49251cd4fb0e040d32278740ae6a64fdfbcafd815d05f0f
+
+Cipher = aes-192-ccm
+Key = 91f9d636a071c3aad1743137e0644a73de9e47bd76acd919
+IV = 1bf491ac320d660eb2dd45c6c3
+AAD = 43df03a0e23c7ad0d13485150ca224c0b3f39d4e5f2d718db6308e003d3dc683
+Tag = 9dbdf61387294812f483aad76d48d899
+Plaintext = 67da6ca42655188af0b8e389152b2a1b6e2c3ed88926afa5
+Ciphertext = 4a20cfea5dc25376bc7b514af86e75511222ab351cd6d955
+
+
+Title = NIST CCM 256 Variable Plaintext Tests
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = b4f8326944a45d95f91887c2a6ac36b60eea5edef84c1c358146a666b6878335
+Tag = ca482c674b599046cc7d7ee0d00eec1e
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 36c17fd901169e5b144fdb2c4bea8cd65ad8acf7b4d3dd39acf2ad83da7b1971
+Tag = 67747defe5da5fecc00b9bf3b249f434
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 9a37c654ab8e5a0c6bdfff9793457197d206ed207d768cbc8318cfb39f077b89
+Tag = c57ef5d0faf49149c311707493a4cfd4
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 5ab80169184541393a6975f442ee583cd432d71a6d1568fa51159df7c5b8f959
+Tag = bc2fb5571a7563bb90689a229d2f63a7
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = c78a22a667aafab0c94047e03837d51b11490693d5c57ea27b901ff80b6a38f9
+Tag = 428888c6420c56806f465b415a66e65a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = e11e30cbf63623816379f578788b0c8e6b59ee3c9c50aa6e1dcd749172d48fed
+Tag = 9f1b7520025e1075731adc946b80121d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 05716168829276ff7ab23b7dd373db361e6d9e1f11d0028d374a0d3fe62be19f
+Tag = bd36b053b6a90f19e3b6622cba93105d
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 3e915389639435629fcc01e1b7022d3574e2848e9151261ad801d03387425dd7
+Tag = 458595a3413b965b189de46703760aa0
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 2f496be73a9a5d9db5927e622e166c6ec946150687b21c51c8ca7e680f9775ac
+Tag = 8b259b84a6ee5669e175affca8ba3b1a
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = c6c14c655e52c8a4c7e8d54e974d698e1f21ee3ba717a0adfa6136d02668c476
+IV = 291e91b19de518cd7806de44f6
+AAD = 0a8725bd8c8eab9ed52ca47835837b9f00a6c8d834ab17105b01eb4eb30402e7
+Tag = c5f35fdf2b63e77a18d154f0ddcfedbf
+Plaintext =
+Ciphertext =
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = 080f82469505118842e5fa70df5323de175a37609904ee5e76288f94ca84b3c5
+Tag = f24e87a11a95374d4c190945bf08ef2f
+Plaintext = 1a
+Ciphertext = a5
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = f6cfb81373f1cbb0574dda514747d0099635b48cb809c6f1fa30cbb671baa505
+Tag = d43c5f39be92778fdce3c832d2d3a019
+Plaintext = 40
+Ciphertext = ff
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = 5a88b14bada16b513d4aa349b11ce4a77d4cda6f6322ff4939ad77d8ecb63748
+Tag = 753b7b661f1aad57c24c889b1c4fe513
+Plaintext = 41
+Ciphertext = fe
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = a92b95b997cf9efded9ff5e1bff2e49d32e65f6283552ded4b05485b011f853f
+Tag = 1c5ac66e89bf2769ef5f38a3f1738b24
+Plaintext = 06
+Ciphertext = b9
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = a206a1eb70a9d24bb5e72f314e7d91de074f59055653bdd24aab5f2bbe112436
+Tag = 3fe64379cea1a8ae3627418dd3e489a2
+Plaintext = c8
+Ciphertext = 77
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = d3029f384fd7859c287e38c61a9475d5ddbfd64af93746b1dc86b8842a8c194c
+Tag = abc529442ff93005551b7689bcb748f7
+Plaintext = e2
+Ciphertext = 5d
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = 51ca3d3b70b5e354451a5177d7acfd8e7b44eae55e29d88b5e8eb8fc1e5c62fc
+Tag = ee68e416617ac974b3d1af7320cd51f6
+Plaintext = 1a
+Ciphertext = a5
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = 8c6c6791f1ac957b18bf008e260a0af4a5b7bfdb1e0008d6eaaa227f45cf4f62
+Tag = 43883d93d7066991e0fac453400b4fbf
+Plaintext = dd
+Ciphertext = 62
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = b0a1af969a95025385b251afd1e89f353426ed6e5d71019cd73366aa31d5b464
+Tag = b940d416f3435812f9d1b18f441b7721
+Plaintext = 4c
+Ciphertext = f3
+
+Cipher = aes-256-ccm
+Key = cc49d4a397887cb57bc92c8a8c26a7aac205c653ef4011c1f48390ad35f5df14
+IV = 6df8c5c28d1728975a0b766cd7
+AAD = 7e72b2ca698a18cb0bf625f5daddb0d40643009db938340a9e4fe164a052fee1
+Tag = 1d27e9a32feea28a6a7e7da2d27e1cc4
+Plaintext = 88
+Ciphertext = 37
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = b5c6e8313b9c68e6bb84bffd65fa4108d243f580eab99bb80563ed1050c8266b
+Tag = c3152e43d9efea26e16c1d1793e2a8c4
+Plaintext = be80
+Ciphertext = ecac
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 38e5032c5949c2668191ef1af5bb17eddc28abdb4e5bb41eaffec2523b2525d6
+Tag = d06bf4b50ccce0b2acfd16ce90a8854d
+Plaintext = 82c9
+Ciphertext = d0e5
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 0b50f5173249fb7118f80d25874d6745d88e4ce265fa0dd141ad67ae26c31122
+Tag = 8d784f486c1dc4a2bafd5b02ca1e1c05
+Plaintext = 8239
+Ciphertext = d015
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 0296743a3125b103a2b2a78a109e825ea10834bd684215ab2e85cc4172e37348
+Tag = a3377002a48f9fe306d157358e6df37d
+Plaintext = 16c1
+Ciphertext = 44ed
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = a94e64becb803e211785ba51db7f3db042fbf44a7a821509156a6828b0f207e9
+Tag = f6c09bf1dcb1c82bd98c6e2c13a8d7a5
+Plaintext = 2801
+Ciphertext = 7a2d
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 105358cc17b12107e023a23d57b44c66a2c58d8db05100311575e1ea152fc350
+Tag = 2ea363c0d8864363056467570959ba03
+Plaintext = 65e7
+Ciphertext = 37cb
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 669f9a63cf638a202dca1965c4116273249813ce0b39703887d89bdf5b3b12d6
+Tag = 6519377e6d0252b5f80cdf3d0253eccf
+Plaintext = 819d
+Ciphertext = d3b1
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = e288590a3eba28ac6847a50b0294ab6bd0a548716ff5102c44a5b656b2d9ddd6
+Tag = 9a4dee6ca2cde473f08f76f779856c3c
+Plaintext = 761e
+Ciphertext = 2432
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 5b222aae3c7786c3b9021ba672f9136190ec931cf055f84c85706127f74c6d5b
+Tag = 9e65c0f01e644e74092253b470cd5511
+Plaintext = 56de
+Ciphertext = 04f2
+
+Cipher = aes-256-ccm
+Key = 36b0175379e7ae19c277fe656a2252a82796309be0f0d4e1c07fdde88aca4510
+IV = 021bd8b551947be4c18cf1a455
+AAD = 2082f96c7e36b204ad076d8b2f796cccf5cbc80b8384b53a504e07706b07f596
+Tag = 809fa107f379957b52ac29fe0bc8a1e2
+Plaintext = b275
+Ciphertext = e059
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 887486fff7922768186363ef17eb78e5cf2fab8f47a4eb327de8b16d63b02acb
+Tag = 3f65d6be431e79700378049ac06f2599
+Plaintext = db457c
+Ciphertext = 54473c
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 0683c20e82d3c66787cb047f0b1eb1c58cdde9fb99ee4e4494bbf27eb62777d1
+Tag = 3b186edc15c22ba24e470eb5a072da9f
+Plaintext = 62a6c5
+Ciphertext = eda485
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 413074619b598f8bed34cab51ddf59941861ba0169ebe7570a5ed01d790c08e5
+Tag = 52a1fb5a58bd51931230c1a7dfb1a8c1
+Plaintext = cc67bc
+Ciphertext = 4365fc
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 2d65a5175c29a095dc082dab9cfcf4b895efbfa715c57614589d4db159543ce9
+Tag = 7d3810f59176cb108c7e969da51d4d79
+Plaintext = 33800b
+Ciphertext = bc824b
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 6a831b6059456be98e6fce608d8c71cb8efb04a96b45c2dfbdaeabf5420a1482
+Tag = 46ffea832595c9c86e6517215541ddbd
+Plaintext = b2c826
+Ciphertext = 3dca66
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 3a04a01160402bf36f33337c340883597207972728c5014213980cd7744e9e41
+Tag = e89a6725f0fc35622d89d2f3e34be90a
+Plaintext = d7e620
+Ciphertext = 58e460
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 64d8bd3c646f76dc6ce89defd40777fe17316729e22ba90f6a2443ee03f6390b
+Tag = b1bd7ad5d81686aeb44caa6025d488bd
+Plaintext = 795af4
+Ciphertext = f658b4
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 7bef8d35616108922aab78936967204980b8a4945b31602f5ef2feec9b144841
+Tag = 0553c801f37c2b6f82861a3cd68a75e3
+Plaintext = 66efcd
+Ciphertext = e9ed8d
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 92f7dc22dcbbe6420aca303bd586e5a24f4c3ed923a6ebe01ec1b66eee216341
+Tag = e3eeb8ea6c08b466baf246b3667feb3f
+Plaintext = 78b00d
+Ciphertext = f7b24d
+
+Cipher = aes-256-ccm
+Key = ddb739acda6c56ec9aefc4f4cbc258587f443da4e76ddfa85dbe0813a8784944
+IV = 0bddf342121b82f906368b0d7b
+AAD = 71bf573cf63b0022d8143780fc2d9c7dbd0505ac31e9dce0ad68c2428b0878a0
+Tag = 1db811640c533794bfec6eeb977233ec
+Plaintext = 9dd5e1
+Ciphertext = 12d7a1
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = fffb40b0d18cb23018aac109bf62d849adca42629d8a9ad1299b83fe274f9a63
+Tag = ab21dfdcfe95bd83592fb6b4168d9a23
+Plaintext = 87294078
+Ciphertext = 2bc22735
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = 75c3b3059e59032067e9cd94d872e66f168e503bcf46bc78d82a4d4a15a29f6e
+Tag = b5de3331078aa13bd3742b59df4f661a
+Plaintext = 0f28ee1c
+Ciphertext = a3c38951
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = 8fb9569f18a256aff71601d8412d22863e5a6e6f639214d180b095fa3b18d60e
+Tag = e52afe7326a12a9aaf22255a38d4bd0d
+Plaintext = d41c9c87
+Ciphertext = 78f7fbca
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = 8b62d9adf6819c46c870df8a1486f0a329672f7d137bb7d8659f419c361a466c
+Tag = 7543692a72f0d599de48b5e5f5a9413f
+Plaintext = 046bc0d8
+Ciphertext = a880a795
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = fd98f8f39dfa46ea5926e0ffacbabbe8c34205aade08aa0df82e1d4eaaf95515
+Tag = 30fc357f5482b9004d466bf858586acb
+Plaintext = 39bd4db8
+Ciphertext = 95562af5
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = 09bf4f77a9883733590a3cc7ee97f3c9b70f4db255620e88cd5080badc73684c
+Tag = a9e8db046fdd548b52d40375c1e9a448
+Plaintext = b43cdd3a
+Ciphertext = 18d7ba77
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = 40326d765e0f6cf4b4deccb128bebf65a7b3c3e5bcf1d58f6158e1e9153b7e85
+Tag = 4efbdd4ad8d3e863172d9372fca07c20
+Plaintext = e0052e9b
+Ciphertext = 4cee49d6
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = aa5ae6dcdc21b5446489bdabf5c6747bdf3bbfdb3de2c03170efefe5ccb06d69
+Tag = 95bd661b32bc18025808f8b4035acad6
+Plaintext = 696825f6
+Ciphertext = c58342bb
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = d3d34f140a856e55b29471fde4c0e5f7306b76d03faab26db79c10f95ffb3122
+Tag = ac05b072264e31a4b2801a6d790512d7
+Plaintext = 7eb07739
+Ciphertext = d25b1074
+
+Cipher = aes-256-ccm
+Key = 62b82637e567ad27c3066d533ed76e314522ac5c53851a8c958ce6c64b82ffd0
+IV = 5bc2896d8b81999546f88232ab
+AAD = 648a84813ca97aef4ab7e143ee29acb946388660f18eb671194646e0b0136432
+Tag = c00514d260e1d211de361c254369e93a
+Plaintext = 9cad70b1
+Ciphertext = 304617fc
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 574931ae4b24bdf7e9217eca6ce2a07287999e529f6e106e3721c42dacf00f5d
+Tag = 9c66e1a43103d9a18f5fba5fab83f994
+Plaintext = 3e8c6d1b12
+Ciphertext = 45f3795fcf
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 99cd9d15630a55e166114f04093bd1bb6dbb94ecaad126fe5c408dee5f012d9f
+Tag = 6f3cd579294f706213ed0f0bf32f00c5
+Plaintext = 76fc98ec66
+Ciphertext = 0d838ca8bb
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 1516fdf7a7a99f3c9acc7fff686203dec794c3e52272985449ddf5a268a47bc3
+Tag = 7d38e026f706c9273dbcb6dc982751d0
+Plaintext = 6564c247cc
+Ciphertext = 1e1bd60311
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 0c9c35be98591bf6737fc8d5624dcdba1a3523c6029013363b9153f0de77725b
+Tag = c3e46166767c6ad2aeffb347168b1b55
+Plaintext = c11b9c9d76
+Ciphertext = ba6488d9ab
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = e74afe3ba960e6409dba78ecb9457e2a4ce2e09792b1d2e3858f4c79f7ddba62
+Tag = 33a7dca78bcbf4d75d651ee5fadff31b
+Plaintext = 45a4e0d7dd
+Ciphertext = 3edbf49300
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 96cbe9cd193513599c81f5a520fabaff51ee8cbdb81063c8311b1a57a0b8c8fd
+Tag = 11585167c83105ee16828a574c84ac86
+Plaintext = e5861b2327
+Ciphertext = 9ef90f67fa
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 2e7ea84da4bc4d7cfb463e3f2c8647057afff3fbececa1d20024dac29e41e2cf
+Tag = ffaba456f78e431f4baa5665f14e1845
+Plaintext = f5b5bcc38e
+Ciphertext = 8ecaa88753
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = be125386f5be9532e36786d2e4011f1149abd227b9841150d1c00f7d0efbca4a
+Tag = 34714731f9503993df357954ecb19cd3
+Plaintext = b6cc89c75d
+Ciphertext = cdb39d8380
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 3fa8628594b2645bc35530203dca640838037daeaf9cf8acaa0fb76abf27a733
+Tag = 6c1b008b7572752f04362b2bfdc296bb
+Plaintext = 3802f2aa9e
+Ciphertext = 437de6ee43
+
+Cipher = aes-256-ccm
+Key = bc29a16e19cfbe32bf4948e8e4484159bc819b7eec504e4441a1a98ca210e576
+IV = 4f18bcc8ee0bbb80de30a9e086
+AAD = 642ae3466661ce1f51783deece86c38e986b8c0adea9e410e976f8a2fe0fe10f
+Tag = a3f7c3c29dc312c1f51a675400500e32
+Plaintext = e082b8741c
+Ciphertext = 9bfdac30c1
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = a66c980f6621e03ff93b55d5a148615c4ad36d6cbdd0b22b173b4b1479fb8ff7
+Tag = b14e0e659a6305b4aeffae82f8a66c94
+Plaintext = 1b62ad19dcac
+Ciphertext = 4ad1fcf57c12
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = c13f65bd491cb172a0f7bbc4a056c579484b62695e90383358d605307d5be0a5
+Tag = 79fa7932d365e2da9b05c00a7318384a
+Plaintext = 3ef0faaa9b79
+Ciphertext = 6f43ab463bc7
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = 59dcca8fc50740831f8f259eb55d4db11f763a83187d93758d78d166f4d73cd5
+Tag = 813229912137b7a4945dc07cea24a974
+Plaintext = 1a98ddbf35f1
+Ciphertext = 4b2b8c53954f
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = 578509ca4f57aadb78056794bf18b0714090970db786e2e838105e672165761c
+Tag = 6e045f19f737a24c8addf832ed3f7a42
+Plaintext = f46a7b1c28ea
+Ciphertext = a5d92af08854
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = 696c0c6427273cf06be79f2206c43af9cbda0b884efaf04deba0c4bf0a25cb26
+Tag = daae8a7dcd3b0fbb59438f88743ec6e8
+Plaintext = e98f5e5a20d0
+Ciphertext = b83c0fb6806e
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = 95a66b60249ed086eecaeb9bc449afcee9de212619e87516ca947351b25120df
+Tag = d9cb636ca6543c4e35964f47341f2814
+Plaintext = 06319c0480e2
+Ciphertext = 5782cde8205c
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = 2b411bea57b51d10a4d2fb17ef0f204aa53cf112e1130c21d411cdf16a84176d
+Tag = ec82eadf4eb1f055da1a92a82052ab8b
+Plaintext = f4c723433b7c
+Ciphertext = a57472af9bc2
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = ff3bff3a26fc5a91252d795f7e1b06f352314eb676bff50dc9fbe881c446941e
+Tag = 01b10a7ae24a4ca2bfb07ea2a3b31a97
+Plaintext = 02f809b01ce3
+Ciphertext = 534b585cbc5d
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = f6be4aad63d33a96c0b5e9c4be62323c9e2308b29961fff980ba0dbda0549274
+Tag = 231323a4b88af5d7d0b07c0e73ddce1d
+Plaintext = 2b6004823a29
+Ciphertext = 7ad3556e9a97
+
+Cipher = aes-256-ccm
+Key = 5f4b4f97b6aa48adb3336c451aac377fde4adf47897fd9ccdf139f33be76b18c
+IV = 7a76eac44486afdb112fc4aab9
+AAD = c3706a28d7420b41e072dcecc06b6b13116cca110bde8faea8e51f5107352d71
+Tag = db30eb33d2ede33abbe22f37704fe68b
+Plaintext = 236c60cba4fa
+Ciphertext = 72df31270444
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = e97175c23c5b47da8ce67811c6d60a7499b3b7e1347ad860519285b67201fe38
+Tag = 2fa325bafc176a07c31e6cc0a852d288
+Plaintext = d48daa2919348d
+Ciphertext = eb32ab153a8e09
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = ba45e1859efae362a44a0116a14e488ba369da6c76c3913b6df8e69e5e1111fa
+Tag = a24840f4f40a7963becde3a85968b29c
+Plaintext = f95b716bfe3475
+Ciphertext = c6e47057dd8ef1
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = efcaa6f6cda3036b0b52ff9f36bc38ca74049c32c6b7cdfb8a46ca4144bacd64
+Tag = 8f2a4a5c276727e0a210fc2efb5aeabe
+Plaintext = 4862e3677083f0
+Ciphertext = 77dde25b533974
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = 360bcb407603fe92f856bf677625b9882521e6dae8f35fdfc3dc737f9398f609
+Tag = 051734fc31232ab2ab63474020ab4dc9
+Plaintext = 7f1ca0728f6d65
+Ciphertext = 40a3a14eacd7e1
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = f12ee9d37946cfd88516cbe4a046f08c9bbba76a3973ff1e2cb14493405bd384
+Tag = c715244f307609ffa253e4e3659b0ece
+Plaintext = 67478ef73290fa
+Ciphertext = 58f88fcb112a7e
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = 5833dde0c577b2be4eb4b3d01d7b0042fa8441ad7043ea462bbbbd56a59790ea
+Tag = f11047da612d2987fa2e50ada5ae7f9d
+Plaintext = 36bb9e511276c5
+Ciphertext = 09049f6d31cc41
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = 1e103c63d8ead36b985f921044cd32b8f9f04a2ba9fa154a09e676ffaa093970
+Tag = 382f7648718127ebae7eb7443ebd2c2c
+Plaintext = d68d6556c5a5b1
+Ciphertext = e932646ae61f35
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = a1cfb61d45a140bdea6329ba0fe80429ff9aa4624a1d31bc752f7c97f1d390a0
+Tag = cc40a5e7fffb1fb9a5dd9d6ba91bede1
+Plaintext = 0568cca4ff79dc
+Ciphertext = 3ad7cd98dcc358
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = 116b5b015e44ceef0061b2d2e73fa0b386d5c1e187782beebdfc6efb5a1c6935
+Tag = 468d2b70c311732f11ed72b57d83e500
+Plaintext = bd93d08eea4263
+Ciphertext = 822cd1b2c9f8e7
+
+Cipher = aes-256-ccm
+Key = f7aaeff3a1dc0cc5ecf220c67ad9f6dda060b4f1be3cc609cb4f18b2342a88a2
+IV = d0d6871b9adc8623ac63faf00f
+AAD = 3d55882e6f3f89309b6940a3b408e573458eedd10fc3d0e1f3170eb313367475
+Tag = b41a70f548e359add30c0e5746fbeb2b
+Plaintext = 4fb62753024e92
+Ciphertext = 7009266f21f416
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = 579a637e37a0974cd2fc3b735d9ed088e8e488ffe210f043e0f9d2079a015ad6
+Tag = e2ba537355ae8ab25cc9ed3511ff5053
+Plaintext = e5653e512d8b0b70
+Ciphertext = 75d31f8d47bee5c4
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = 1583138aa307401dddc40804ac0f414d338fc3ffb2946f09aaaa7079426fc1ee
+Tag = 781a9e359804831f31a1efb1ae1cb71d
+Plaintext = 2c4ba9ce52e01645
+Ciphertext = bcfd881238d5f8f1
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = 78d3dda40e433bba7a330ca3e5bd5170f0895f2e3e438402344ced79fcb0c719
+Tag = 2dcc77c4e1fe2bafd477598977835f0c
+Plaintext = 5eb2d054a0e58c62
+Ciphertext = ce04f188cad062d6
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = dfc762466fa84c27326e0ee4320aa71103d1e9c8a5cf7d9fab5f27d79df94bd6
+Tag = 08946723baf0dbf613359b6e040f9bd5
+Plaintext = bbbf7830d04ab907
+Ciphertext = 2b0959ecba7f57b3
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = 7e8ea82d1137c1e233522da12626e90a5f66a988e70664cb014c12790d2ab520
+Tag = 003bd62ca51f74088bbbd33e54ac9dd4
+Plaintext = 10c654c78a9e3c06
+Ciphertext = 8070751be0abd2b2
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = 873da112557935b3929f713d80744ed08b4b276b86331dbc386fba361726d565
+Tag = 67e65e7f2cdedf6ef8cc0ee7a6dcfb02
+Plaintext = 668d32e322e1da3e
+Ciphertext = f63b133f48d4348a
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = cfba97919f703d864efc11eac5f260a5d920d780c52899e5d76f8fe66936ff82
+Tag = 0532f8c6639e5d6c7b755fcf516724e3
+Plaintext = e39f6225e8eab6cc
+Ciphertext = 732943f982df5878
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = 01abcfee196f9d74fcaa7b69ae24a275485c25af93cc2306d56e41e1eb7f5702
+Tag = 7fd7a33828413ebc252dd9d015773524
+Plaintext = 6021a00f6d0610a4
+Ciphertext = f09781d30733fe10
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = ce1c31e7121c071d89afab5a9676c9e96cac3d89dcae83136bbb6f5ca8f81e5d
+Tag = d3d51368799325ad1c8233fa071bade0
+Plaintext = bbaf0ac4e77ee78d
+Ciphertext = 2b192b188d4b0939
+
+Cipher = aes-256-ccm
+Key = 493e14623cd250058a7fc66a3fee0c24b6e363b966c2314aff53b276b6c2ea7b
+IV = fe2d8ae8da94a6df563f89ce00
+AAD = bb210ca5bc07e3c5b06f1d0084a5a72125f177d3e56c151221115ae020177739
+Tag = 5d1ea568637f773174a7f920a51b1fe1
+Plaintext = 98a2336549a23a76
+Ciphertext = 081412b92397d4c2
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 69adcae8a1e9a3f2fe9e62591f7b4c5b19d3b50e769521f67e7ea8d7b58d9fc8
+Tag = 896e7127f17d13f98013b420219eb877
+Plaintext = 615d724ae94a5daf8d
+Ciphertext = f019ae51063239287d
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 162d0033c9ea8d8334d485b29eef727302135a07a934eea5fee6041e9f1f47c1
+Tag = 7cc2cd61da9358b4045fef32f8192cbf
+Plaintext = 0d9168eeab3b27ba69
+Ciphertext = 9cd5b4f54443433d99
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 3f4ab57efa32f51a4c00790280e77c0e55b85bbda4f854e242368e9a289b5a81
+Tag = d280f0ffdd560fb8915978e3bd6205bb
+Plaintext = 6287dcffdd5fb97885
+Ciphertext = f3c300e43227ddff75
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 945d18134c148f164b39fd7c4aef0335045553f6ea690a3b1726418d86f0de00
+Tag = 7dbf90420a1ff2e24bd6303b80cfc199
+Plaintext = 6e5e01b3fd71d16b9c
+Ciphertext = ff1adda81209b5ec6c
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 23af12893431b07c2922ab623aed901c0eaaeb9a24efc55273e96aea4dab7038
+Tag = d741f4329ae7cc77d42bf7e5f2ec5ab6
+Plaintext = b51521e689b5247362
+Ciphertext = 2451fdfd66cd40f492
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = b15a118b3132c20c31e6c9d09acdee0e15fcc59d6f18306442682512d22eb10f
+Tag = c9ffdcc2f36edac14613b1d85baf25a9
+Plaintext = 7f973617e710fb76fe
+Ciphertext = eed3ea0c08689ff10e
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = dcfbeb6490f5fa7eaf917462473a6cec98bebf8f17493fe9b994119a6d5a5457
+Tag = 5a61a28bb10265b26043d7a8dd357713
+Plaintext = 7e909b6727ac3fd02f
+Ciphertext = efd4477cc8d45b57df
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 77e9317294f046f315a0d79e3423f29f7d9ebcd36d6eaa2a3fb2f4500309478c
+Tag = d321c371ae1fd01bdf3b6c75a597da6e
+Plaintext = a5075638932b5632f8
+Ciphertext = 34438a237c5332b508
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 3aa8f204eb127b547e13873ed0238018394e13686c8734e49e3e629deb352c77
+Tag = 9393d1635bc40ac62405a39155406c47
+Plaintext = c10f15a0de78db8aa3
+Ciphertext = 504bc9bb3100bf0d53
+
+Cipher = aes-256-ccm
+Key = b23255372455c69244a0210e6a9e13b155a5ec9d6d0900e54a8f4d9f7a255e3a
+IV = 274846196d78f0af2df5860231
+AAD = 7f67e6f97c6c258f014d721a4edaaa0ddb3f9f09993276ab7b714ea9356c231d
+Tag = ff89641e1bd5ad6cc827441b17c45ecf
+Plaintext = 8294f830cfca42cfbe
+Ciphertext = 13d0242b20b226484e
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 9ae5a04baa9d02c8854e609899c6240851cbc83f81f752bc04c71affa4eed385
+Tag = 76f2730d771d56099a0c8d2703d7a24e
+Plaintext = 2e3cf0af8c96c7b22719
+Ciphertext = e317df43ab46eb31be7e
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = da77c6d5627a2aa34911bd1f7cc5f8aa68a2c6546adc96a186b9af8e5baac4cf
+Tag = bcc7a8260ef361dc39fdb776d041f0d4
+Plaintext = e081c43a07450ce0dfa2
+Ciphertext = 2daaebd62095206346c5
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 134d2d9726400d09dd3521326f96fbef993ddc0c4088770057b0f8d70356456f
+Tag = 19f0cbb0899f221aac9762f2650f8058
+Plaintext = c381d2ae5e72fc82324a
+Ciphertext = 0eaafd4279a2d001ab2d
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 0d065dfde1de1f21784c7869eb566c977f807cfbd53578f4616995b51d7dc045
+Tag = 3dc92a9bd26b9653e5917359c331fcff
+Plaintext = 737f4d00c54ddca80eec
+Ciphertext = be5462ece29df02b978b
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 95c54d187f2415535451cbb9cb35869749b171f7043216ce6886dd77baeecf60
+Tag = 91dda72c27d272561e00f7041845d998
+Plaintext = 4e9e251ebbbbe5dbc8ff
+Ciphertext = 83b50af29c6bc9585198
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 0f98039e6a9fe360373b48c7850ce113a0ff7b2ae5ce773dd4c67ca967cd691b
+Tag = 928ac628758ad58fc1b5a768d4722848
+Plaintext = 0db72b281ab4046d15a6
+Ciphertext = c09c04c43d6428ee8cc1
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = ad840bc55654762e5eba0e4a9e7998992d990a06d70da1b1ca922ef193dab19a
+Tag = d11dad4dc8b265a53cf0bdd85c5f15f4
+Plaintext = 4f7b4f38ff1ba4df5a59
+Ciphertext = 825060d4d8cb885cc33e
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 911e9876ea98e1bcf710d8fd05b5bf000ea317d926b41b6015998ee1462ab615
+Tag = 8eb659a5a7084be48d099467da4395df
+Plaintext = 58ce55379ef24b72d6d6
+Ciphertext = 95e57adbb92267f14fb1
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 3f68a4fb4043bcf9b6d277c97e11365d949c705bd6679c6f0aaf52e62330ad79
+Tag = 3b2b2583fd117cec47b1c84d3863159e
+Plaintext = a219028a953ce1544835
+Ciphertext = 6f322d66b2eccdd7d152
+
+Cipher = aes-256-ccm
+Key = dbf06366f766e2811ecd5d4384d6d08336adc37e0824d620cf0d9e7fd1e7afa9
+IV = b3503ed4e277ed9769b20c10c0
+AAD = 02f32242cba6204319075ea8ce806a57845355ae73e6b875955df510096ebff9
+Tag = 5456eb2b6a2d35c649a84051f843153c
+Plaintext = 83b0ee9a52252c456105
+Ciphertext = 4e9bc17675f500c6f862
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = 9bcc5848e928ba0068f7a867e79e83a6f93593354a8bfcfc306aeeb9821c1da1
+Tag = 6512a0481255b729a10f9edb5f07c60c
+Plaintext = 8015c0f07a7acd4b1cbdd2
+Ciphertext = 8e9f80c726980b3d42e43a
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = c2e75952ab49216f305e3776865791ce877cef8c0229ca97561787093fddf1d8
+Tag = 8c514444f00ffdb80a4bb7e9eb651946
+Plaintext = c97b62a719720b44b7779c
+Ciphertext = c7f122904590cd32e92e74
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = c76a3ff4e6d1f742dd845be2d74c1a9b08e418909b15077deb20373ef55caf91
+Tag = db609dfc1929ac1ba5753fc83bf945b7
+Plaintext = cb7c17ef62464ecc8008f6
+Ciphertext = c5f657d83ea488bade511e
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = bdb69f99f9a144b9ad88c6cfd8ffb8304c201de9b2818552ce6379e6042c1951
+Tag = 53b74283296d0fca83b262915289163c
+Plaintext = 893a690cc5221de597d0e8
+Ciphertext = 87b0293b99c0db93c98900
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = 01815f599d6ba0d1c09f6f673bb6cca4c2a7a74f4e985be4c0f37842c7bbc5a4
+Tag = 88a34955893059d66549795b3ac2105c
+Plaintext = 80f3e4245c3eab16ef8bf0
+Ciphertext = 8e79a41300dc6d60b1d218
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = a9db62e9ab53c4a805c43838ce36b587d29b75b43fb34c17a22d3981120f3bc5
+Tag = 377c4e2f20aaa872a9a0b1d1d7f56df0
+Plaintext = 641c6914920a79943dca39
+Ciphertext = 6a962923cee8bfe26393d1
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = f0c2cc5a1b4c4cbe839338fa0d7a343514801302aef2403530605cf4f44d2811
+Tag = 5545aa0c1dd11551891ae553d3a91908
+Plaintext = 2286a1eddd80737a724ca9
+Ciphertext = 2c0ce1da8162b50c2c1541
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = 9842922499ad4d487488b3731f48765efe0b4eb59e7b491ba5f6636f09ed564d
+Tag = d9e07ec5806360843676ef27d811b246
+Plaintext = d8c63e7d7d332198249c0c
+Ciphertext = d64c7e4a21d1e7ee7ac5e4
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = 399b71ecb41f4590abda79045cdf6495f27daaa559c1b34f513b5c4ac105ec10
+Tag = 483b8727c5753ede25e1fab0d86963be
+Plaintext = 4b81804d777a59b6a107cf
+Ciphertext = 450bc07a2b989fc0ff5e27
+
+Cipher = aes-256-ccm
+Key = 4dd555bd3a5253a90b68b5d4d46bd050340ee07ddad3a72048c657b5d76bb207
+IV = bdb1b82ba864893c2ee8f7426c
+AAD = 2c186c5c3463a4a8bad771feb71e2973c4f6dede2529827707bf4fa40672660f
+Tag = 4b5c3c1dc577ee8fcf6ef3ebc0783430
+Plaintext = dfc762466fa84c27326e0e
+Ciphertext = d14d2271334a8a516c37e6
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = ea26ea68facdac3c75ba0cdf7b1ad703c9474af83b3fbfc58e548d776b2529b9
+Tag = 56bc555899345e0404b2938edf33168e
+Plaintext = a203aeb635e195bc33fd42fa
+Ciphertext = 62666297a809c982b50722bd
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = 0b32069fc7e676f229f1037d3026c93eef199913e426efd786b524ce1dbde543
+Tag = 9b15447c904b671824c2ca24c4fc7ad4
+Plaintext = aac414fbad945a49ae178103
+Ciphertext = 6aa1d8da307c067728ede144
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = 7a8658302e5181552292aa56e8209de63b5d86934167549b0d936202681757e1
+Tag = ea13850e99ef9300c65f5abc9419d13a
+Plaintext = 7ee0ce371329192618e3cda0
+Ciphertext = be8502168ec145189e19ade7
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = 4f05600950664d5190a2ebc29c9edb89c20079a4d3e6bc3b27d75e34e2fa3d02
+Tag = 486c93c31bbedc9e5ffa2f4154bceea9
+Plaintext = b0a1af969a95025385b251af
+Ciphertext = 70c463b7077d5e6d034831e8
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = 4530e4dc6a4c3733b8ab7e77e384223cc1a8c179fb66818c08aca47e5c705d89
+Tag = f18b556e7da59fd2549dc57a17bf64f8
+Plaintext = 9f6c6d60110fd3782bdf49b0
+Ciphertext = 5f09a1418ce78f46ad2529f7
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = f179353aef342f0f691caf1fcb811e3f6504e14d6d9381c5439b098ff978b01b
+Tag = 30aad3a838680cbd313004685a5510c5
+Plaintext = 90958d7f458d98c48cbb464c
+Ciphertext = 50f0415ed865c4fa0a41260b
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = f6df267e5cbc9d2a67b1c0fd762f891ee3b7c435884cb87d8228091b34aeddae
+Tag = 1d57b89ed0c91251aed37a6ca68a50c7
+Plaintext = 9f7ae892e5662803408d4d06
+Ciphertext = 5f1f24b3788e743dc6772d41
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = 4372e152b1afd99c7f87c8a51dbc3a5c14c49d04ea1c482a45dfbcda54972912
+Tag = d79a3b0feea16ff5fbca16211ea6fdd9
+Plaintext = 817074e351455f23cb67883d
+Ciphertext = 4115b8c2ccad031d4d9de87a
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = 82b6cd1c6618c42ba74e746075dc28700333578131ca6fde6971d2f0c6e31e6a
+Tag = 49f22737c4b2f9fa0a7e3dd4b067fbaa
+Plaintext = 1b7da3835e074fdf62f1eb3c
+Ciphertext = db186fa2c3ef13e1e40b8b7b
+
+Cipher = aes-256-ccm
+Key = d3ad8cda9a0d91a205c4c05665728bb255d50a83403c9ab9243fcbbe95ae7906
+IV = 0b5f69697eb1af24e8e6fcb605
+AAD = a5422e53975e43168726677930f6d3e13281bdbd13c67c168340ed67e45d15b0
+Tag = ef43a48dbea8c1547455ad0197af88a2
+Plaintext = 57473e7a105c806867379194
+Ciphertext = 9722f25b8db4dc56e1cdf1d3
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 9b1d85384cb6f47c0b13514a303d4e1d95af4c6442691f314a401135f07829ec
+Tag = 4c6520dac0f073856d9b9010b7857736
+Plaintext = 8714eb9ecf8bdb13e919de40f9
+Ciphertext = ba6063824d314aa3cbab14b8c5
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = fa17c693d0997140fbc521d39e042d8e08388106874207ca81c85f45c035d6e6
+Tag = 20a423dd30796b6016baff106aaef206
+Plaintext = a0837676e091213890dc6e0a34
+Ciphertext = 9df7fe6a622bb088b26ea4f208
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 27663597b389b78e96c785ca2f5510c8963a5561d2b0b24c4dcdf8e58562c12c
+Tag = 6032bc79c4aef1f74da25e92b0aa7f8a
+Plaintext = b8a2ce7e051b8d094ec43f2a7f
+Ciphertext = 85d6466287a11cb96c76f5d243
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = d8f1a83371487d611ce704e0a6731f97a933c43569690022fce33cb5aecdc0a7
+Tag = 658123d2e5bb324c7ead8897f8e32b0a
+Plaintext = 9e4103ab1dfb77ae3494507332
+Ciphertext = a3358bb79f41e61e16269a8b0e
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 05c57aab99f94b315cf8bdd2d6b54440c097fe33c62a96b98b1568cdee4ce62c
+Tag = 270758ab09f93fa3ba7d7a2aa8eac789
+Plaintext = fb3e3d1b6394d2daebf121f8ac
+Ciphertext = c64ab507e12e436ac943eb0090
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 1c1b0933c508c6a8a20846ebd0d0377e24f4abc0c900d3a92bc409ba14ef1434
+Tag = 2293813f1bcb96564f772e9308e42b2d
+Plaintext = 549ba26a299391538b56ce4bd7
+Ciphertext = 69ef2a76ab2900e3a9e404b3eb
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 9f5cf9149f556124d6bb4e3e243cca1502c02682709392cc2ec7eb262fd4d479
+Tag = 81877380d5cf097c2fb5177750f8b53a
+Plaintext = 287f31e69880823df7798c7970
+Ciphertext = 150bb9fa1a3a138dd5cb46814c
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 1a49aaea6fc6fae01a57d2fc207ef9f623dfd0bc2cf736c4a70aaaa0af5dafd3
+Tag = cf42c75787edc62a180568c6ef56545d
+Plaintext = 040d18b128ae4a1935f9509266
+Ciphertext = 397990adaa14dba9174b9a6a5a
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = f29a0b2c602ff2cacb587292db301182e6c76c5110b97ca8b706198f0e1dbc26
+Tag = 56d47a0631f2038103e3904b556ba7a5
+Plaintext = 92441cbe8d70820870bb01ad63
+Ciphertext = af3094a20fca13b85209cb555f
+
+Cipher = aes-256-ccm
+Key = e300fc7a5b96806382c35af5b2c2e8e26382751b59010d4b1cfc90a4a9cb06df
+IV = 55b59eb434dd1ba3723ee0dc72
+AAD = 01fcf5fef50e36175b0510874ea50a4d2005ad5e40e5889b61417700d827251e
+Tag = 5be15b7ae24edccd0b0934e3af513ed3
+Plaintext = f11d814df217de96333dee1cbf
+Ciphertext = cc69095170ad4f26118f24e483
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 0245484bcd987787fe97fda6c8ffb6e7058d7b8f7064f27514afaac4048767fd
+Tag = 6385a52c68914e9d1f63fd297ee6e7ed
+Plaintext = 959403e0771c21a416bd03f38983
+Ciphertext = 37a346bc4909965c549783825182
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 52f6a10a022e5ee57eda3fcf53dcf0d922e9a3785b39fad9498327744f2852e4
+Tag = 364b603de6afbc2d96d00510894ccbe7
+Plaintext = 23fe445efa5bcb318cc85e2ad1ac
+Ciphertext = 81c90102c44e7cc9cee2de5b09ad
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = d236e3841b9556b32dbd02886724d053a9b8488c5ad1b466b06482a62b79ebb6
+Tag = 1a4321c2ddbc35ce4864457d611219e9
+Plaintext = 762fdc3e0c30c7ecf2ec8808bb79
+Ciphertext = d418996232257014b0c608796378
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 0d2739cfdac782b61f484fa1a423c478c414397ec420327963d79112b2d70a7e
+Tag = 296e55efebb17fe145cdca9b31ea7bcc
+Plaintext = b6813d5fe8afa68d646c197337a2
+Ciphertext = 14b67803d6ba117526469902efa3
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 7f291aa463c4babc76b4a6faf2e27e9401586b1ac83e4b06a4090e94b3ef5fd4
+Tag = 59270a0510e7cc1b599705853af2144d
+Plaintext = 4ce8b6578537215224eb9398c011
+Ciphertext = eedff30bbb2296aa66c113e91810
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 06bca7ef6f91355d19f90bf25590a44a24e5a782f92bc693c031e6de1e948008
+Tag = b55847573bf21e946ce9bdc5f569e3ff
+Plaintext = 9ebf93643854ea5c97a4f38f50bd
+Ciphertext = 3c88d63806415da4d58e73fe88bc
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 5a44ff94f817c7c028a8f3db35a4d01364d2598432469f09ded86e5127d42d35
+Tag = b8a61c5687ea02f0276824b8316b76f1
+Plaintext = da989cc7d375ed5fac4d7f938d74
+Ciphertext = 78afd99bed605aa7ee67ffe25575
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 2a755e362373ef27a911c4d93ca07bc97135645442ad7ad6a8ef98146c71e9d7
+Tag = a07ee02791011129fcacffcfb1bf4145
+Plaintext = 6fbab5a0f98e21e4d15904af5948
+Ciphertext = cd8df0fcc79b961c937384de8149
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = f7988873f45a5de314e5381d3f14d8f8c48c9b649bf3e745ed5dc882d507da58
+Tag = d34204b1ce23f5f58a8eb7cf1fa8cfa7
+Plaintext = b610349e8b370a7c195598573637
+Ciphertext = 142771c2b522bd845b7f1826ee36
+
+Cipher = aes-256-ccm
+Key = 3ae5be5904bae62609ac525e2d1cad90133447573d7b608975a6a2b16cb2efc0
+IV = 61bf06b9fa5a450d094f3ddcb5
+AAD = 95d2c8502e28ab3ee2cac52e975c3e7bccb1a93acc33d9c32786f66d6268d198
+Tag = 9c618bb88bbcefb008a5ea6bed4ff949
+Plaintext = 1d969fd81dab5ced3e6ee70be3bf
+Ciphertext = bfa1da8423beeb157c44677a3bbe
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = 5e60b02b26e2d5f752eb55ea5f50bb354a6f01b800cea5c815ff0030b8c7d475
+Tag = d6852dc829469368491149d6bb140071
+Plaintext = 54be71705e453177b53c92bbf2ab13
+Ciphertext = 788db949697b8cd9abbc74ed9aa40c
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = 210c04632341fbfc185bfe3cbf6fe272bbe971104173bcb11419b35ab3aaf200
+Tag = 56940dc5a7e44bf10234806d00a012b5
+Plaintext = 22197f9ad14591e7a6d5f8b18c969a
+Ciphertext = 0e2ab7a3e67b2c49b8551ee7e49985
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = d3a205dd017e79a67400a937a20ef049f4c40d73311731f03ab857a3f93bd458
+Tag = 0898f7dbde25b0b70d335df71a06987b
+Plaintext = 096b2f530933c1273304a6ad423726
+Ciphertext = 2558e76a3e0d7c892d8440fb2a3839
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = 0c9b3ba4faf5fc2f310ad1bab06c4ca13474b714feeffb6ad615c1b850bbd6a3
+Tag = 2fd10d1f21b6b963c05aeda8eb09e272
+Plaintext = d44fdfd9da3a63c1083afe574e91bf
+Ciphertext = f87c17e0ed04de6f16ba1801269ea0
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = d9bb71ad90152d5c1af358c8501fa89ebd4b17bf4ff43841528cccb79fd791b3
+Tag = 4491d23d90ff55abca17e9d943b98c7f
+Plaintext = 8d836acc13ed83c2b2c706415c9679
+Ciphertext = a1b0a2f524d33e6cac47e017349966
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = 69dc21eb6f295b12ba493ee8fe6c40d78af946067ce772db316a3cbf00d3c521
+Tag = 9616886c6b2adc97db5a673846b6662c
+Plaintext = 2a68e3fe746f593c1b97cb637079c3
+Ciphertext = 065b2bc74351e49205172d351876dc
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = 095eb52135dc6d9c1f56a2571c1389852482e7aa3edc245a3904a0449db24a70
+Tag = 2441dcae1760db90379bd354fa99164e
+Plaintext = 39799b001ed2c334c269acb0f2328c
+Ciphertext = 154a533929ec7e9adce94ae69a3d93
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = efd7270e0396392fde8b0ddaab00544cbbd504f4d97d4e90d749d1946de90dcb
+Tag = c7c7deb28bdcf84886ef843216b94449
+Plaintext = 42143a2b9e1d0b354df3264d08f7b6
+Ciphertext = 6e27f212a923b69b5373c01b60f8a9
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = 8bc181ce2e66294e803a8dc3834958b5f173bc2123c0726e31f3fca25b622ed6
+Tag = 35061ae3cd892ba63c44b809d6d29421
+Plaintext = a3dcf26327059a4245b79a38bb8db6
+Ciphertext = 8fef3a5a103b27ec5b377c6ed382a9
+
+Cipher = aes-256-ccm
+Key = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+IV = a5c1b146c82c34b2e6ebeceb58
+AAD = c39ec70c2c71633ae0dccc41477ac32e47638c885cf59f34ebd4a096d32f91f9
+Tag = 3c9ae69a4c59ff8e251c2fe022d065a9
+Plaintext = 3d54883449ecca8f153436c25a0a01
+Ciphertext = 1167400d7ed277210bb4d09432051e
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = 718d13e47522ac4cdf3f828063980b6d452fcdcd6e1a1904bf87f548a5fd5a05
+Tag = 6f9d28fcb64234e1cd793c4144f1da50
+Plaintext = d15f98f2c6d670f55c78a06648332bc9
+Ciphertext = cc17bf8794c843457d899391898ed22a
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = a371ca29b92ed676bab5dfc4d78631bb6d9bb23a29f822907084a1f0fe17721f
+Tag = 8b55bbe42d8c97504b97c34a5f16e6a6
+Plaintext = 60d55a8d5ab591a51e87fdf6aaa2ad25
+Ciphertext = 7d9d7df808aba2153f76ce016b1f54c6
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = 01ec87920b42639d4ba22adb1fbe5138d2849db670a2960fd94a399c1532ed75
+Tag = 017d8706acd676ae99e93d5312a4113c
+Plaintext = cbf112e4fb85276c4e09649f3de225b2
+Ciphertext = d6b93591a99b14dc6ff85768fc5fdc51
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = eebd2bbf1e9f6d817cd8062a6a9680e7f10464eefeb50b07cb46b14b9b3fcb2c
+Tag = 5982f0fe5d951a8c62c87894657301e4
+Plaintext = 865b89aa38ee1b5a3ce56620307e8937
+Ciphertext = 9b13aedf6af028ea1d1455d7f1c370d4
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = 72863362612f146699f6b2f6ec3688f2ca6cb1505af7a309c91c1933e34d516a
+Tag = 5addfddbb59f4985947fb3a9ab56333e
+Plaintext = a8efc37d1b8b51f2a47b21dd14da383d
+Ciphertext = b5a7e40849956242858a122ad567c1de
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = 9c9efc6593f96207678db813608f2b8bc33ed1bef974ed77ed7b6e74b621b819
+Tag = b651053516673402a57538db1a9ce7e9
+Plaintext = d9b0eaaff786165f882f41a98dbc0c35
+Ciphertext = c4f8cddaa59825efa9de725e4c01f5d6
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = dc482a051b58d8a3904d3af37c37b51983f634a504451bbba6f77d71337f8e78
+Tag = 86d772b1a1991b7be6589bbccad36171
+Plaintext = df49d972b6ebbbb18ee975ac635d847e
+Ciphertext = c201fe07e4f58801af18465ba2e07d9d
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = 51ef065a43caa23faf750b02a41ad6ba701aeb8058f6d8738d6f6b005bec7f60
+Tag = 569387a1a6bcc826e94012670820576e
+Plaintext = 78318aa5cd16699b77bdcea2fc9d1d20
+Ciphertext = 6579add09f085a2b564cfd553d20e4c3
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = 88e2a74d2920c89c6a101f5f06d0624a6d5eabd9bdb51395ee3983934c55c73d
+Tag = e9c788b4aae9b2c6caf0c44aa9bd2ed0
+Plaintext = 8e20d65d02dd9a64379f75b6d8328f2d
+Ciphertext = 9368f12850c3a9d4166e4641198f76ce
+
+Cipher = aes-256-ccm
+Key = ee8ce187169779d13e443d6428e38b38b55dfb90f0228a8a4e62f8f535806e62
+IV = 121642c4218b391c98e6269c8a
+AAD = ada3ed7db2dabbfbc441ef68a5656e628d6d5bd6c1574369688497179a77601a
+Tag = f1df0f01944641a1b04d753e6ab8d3cc
+Plaintext = 97e8d8513af41b97801de98cc4269096
+Ciphertext = 8aa0ff2468ea2827a1ecda7b059b6975
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 217d130408a738e6a833931e69f8696960c817407301560bbe5fbd92361488b4
+Tag = f628ee49a8c2005c7d07d354bf80994d
+Plaintext = b0053d1f490809794250d856062d0aaa92
+Ciphertext = a6341ee3d60eb34a8a8bc2806d50dd57a3
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 4ae414bc888a42141d3060c71c2dbbffd425b6a952806982271a8e756b3c9e24
+Tag = 3c1c5755a5a240c33b2b890a486aac8b
+Plaintext = 51eb190c6a9f46e8ec1628b090795470c0
+Ciphertext = 47da3af0f599fcdb24cd3266fb04838df1
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 7b7f78ae1a5ee96fdc49dacd71be1a6ac09a6a162d44dea0172886eca5674e46
+Tag = 4cfca1c19abf447d7bc0898d61885144
+Plaintext = 25144e807e389bb0e45b6dc25558caf61a
+Ciphertext = 33256d7ce13e21832c8077143e251d0b2b
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 03f31c6143b77f6ad44749e2256306b8bf82242f2821fad4075b09b388ba81ca
+Tag = 229cc7a390867a245dcb7c434f1db347
+Plaintext = dbe1ee14abfe2ecf4edf6db206cf9886ce
+Ciphertext = cdd0cde834f894fc860477646db24f7bff
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 030390adb572f2bd2a6a4454fd68236cd1d465574328aa001d553375cc63f8a2
+Tag = 5361b539f9fe0fb7842907c2326aef63
+Plaintext = db6df31f12bf552f81deff5fa2a373fc22
+Ciphertext = cd5cd0e38db9ef1c4905e589c9dea40113
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 7294ae94358669f2ada4b64c125b248df7fe86c6715e3b6a7b9bb2bd99392c8a
+Tag = 8ed10943929e7d7bf798b2ae8371aae5
+Plaintext = ff2a97b49fcc6a50d4549c979d53ccc51f
+Ciphertext = e91bb44800cad0631c8f8641f62e1b382e
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 4d1513478fc1fb0a18eb6d2a9324fefbd975ecd1b409025de826bc397462acc1
+Tag = f92b9e49ab83f113f8949dc9e4a36e0d
+Plaintext = 73ddfa0185200a890b7690a7e3986d8818
+Ciphertext = 65ecd9fd1a26b0bac3ad8a7188e5ba7529
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = b26a7ff61bfe94864249af7cc9b4a723627dd4463f5a22f0ca6063769522eab7
+Tag = d0e53223adff22a08e3dddf66fff23e3
+Plaintext = 5c7604f9ac8fdf30ee5820e5aeb75b65d7
+Ciphertext = 4a4727053389650326833a33c5ca8c98e6
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 960f9a85cfbfb6eab223a4139c72ce926a680ea8e8ecc3088cf123de659ad310
+Tag = 33f49a42521a7a2367f91bfcc2180b7c
+Plaintext = d44fdfd9da3a63c1083afe574e91bf01c9
+Ciphertext = c27efc25453cd9f2c0e1e48125ec68fcf8
+
+Cipher = aes-256-ccm
+Key = 7da6ef35ad594a09cb74daf27e50a6b30d6b4160cf0de41ee32bbf2a208b911d
+IV = 98a32d7fe606583e2906420297
+AAD = 3718467effb5d5dc009aaefce84d8cb4fe8f80eb608f4c678f5d0de02ea11e59
+Tag = c08bd395c6807223311070659f550934
+Plaintext = bb515dc227abb9acad8fefaa14771bb77b
+Ciphertext = ad607e3eb8ad039f6554f57c7f0acc4a4a
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = 67874c808600a27fcab34d6f69cc5c730831ad4589075dd82479823cb9b41dc3
+Tag = 52f2210b7a798ad5c778ee7cfd7fe6e0
+Plaintext = 6a26677836d65bd0d35a027d278b2534e7df
+Ciphertext = d1c1f3c60603359c7d6a707f05ecb2296f8e
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = e0c27cddf919d3092d9a34766c89a5ae6dcf39fe954d1e6f1a70ddf96805def4
+Tag = 0923bb5a347af13df12f234fca5f03ef
+Plaintext = 4021ff104ff1dbd91e46db249fd82198b0a1
+Ciphertext = fbc66bae7f24b595b076a926bdbfb68538f0
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = 7ae9eca03f616ab39ebb3be26b848842b4aa584e5c8e5695065ad5af34951175
+Tag = d03ed7bffac83e890caceb6903d9cab5
+Plaintext = 6a681f164efce199a787bccff223b8ae1a98
+Ciphertext = d18f8ba87e298fd509b7cecdd0442fb392c9
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = b47c9bc4eb01c74f5db2e6a293bef80db18c58cf06feef7ee0f8a7a9a51c22bb
+Tag = 4dd8f30870025b2bd1e2a2511574d3e7
+Plaintext = 7861dac338ba3f8274dca04c8c6f92b6d44c
+Ciphertext = c3864e7d086f51cedaecd24eae0805ab5c1d
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = f6afd661f218c7426b92ee53e65d14898cd0c78a7e594fcc6ac0e3fb5cab1c9c
+Tag = 6046d17f337f3cb49884d94995edbdc9
+Plaintext = a3f0473c620d2739d5ba4f7156f88d0fb669
+Ciphertext = 1817d38252d849757b8a3d73749f1a123e38
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = d3802911e341577046cfc61d9043b4af059fb4bef3c6a2ff46ccdcb05670af37
+Tag = 5fdc77b43bca254d6459263cdfed8fbb
+Plaintext = 07c535d9456a6ff1e41321150d16dae3f7a3
+Ciphertext = bc22a16775bf01bd4a2353172f714dfe7ff2
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = db60720db67a60ca286fe744d46173c231fbcc7deb4c9b0d87d52a2247e06b74
+Tag = dd1a1d36c8164c55d55dbf0ff1e9517a
+Plaintext = 5ee220720a896249efdab2ce418318bb5ebf
+Ciphertext = e505b4cc3a5c0c0541eac0cc63e48fa6d6ee
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = 57f70ba5493265b30491decc726354e2065e7971a2efd56db9cf0f79b1d76859
+Tag = b476e2ca48fd52bec0539b00744a8a07
+Plaintext = 98e4eb0361c8bf40bcbe0539b0850e4c35ff
+Ciphertext = 23037fbd511dd10c128e773b92e29951bdae
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = 4a29b9ad548964942f87f28ba267ec0d0e8f72c73b3823ee57693dd63c2605c1
+Tag = fad68c62b81d62f2d490ae74f5bb1465
+Plaintext = 7f0745bea62479c0080ecec52e37c1e32d72
+Ciphertext = c4e0d10096f1178ca63ebcc70c5056fea523
+
+Cipher = aes-256-ccm
+Key = 0786706f680c27b792d054faa63f499a8e6b5ddb90502946235bf74c022d772c
+IV = f61ef1c8c10a863efeb4a1de86
+AAD = acbd2e9911b3218a230d9db5086d91dccac3fc93fc64b0f4a15d56954906b2b7
+Tag = 13b15d8000266c61ba5aec898eb35b52
+Plaintext = e99ed2ac6c38e033061b5d85f3e77dd72518
+Ciphertext = 527946125ced8e7fa82b2f87d180eacaad49
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = 89ad6ae1e550975eaa916a62615e6b6a66366a17a7e06380a95ea5cdcc1d3302
+Tag = e3243faec177de4a2e4a293952073e43
+Plaintext = c1a994dc198f5676ea85801cd27cc8f47267ec
+Ciphertext = 7c9b138177590edaafec4728c4663e77458ffb
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = dfddb719d00398bf48a6cefd27736389e654a93b8595cd5ac446af1996e0f161
+Tag = 8422f736fc435687634d42254b22fd99
+Plaintext = 791e232bfb42fb18197adc1967da1a83f70168
+Ciphertext = c42ca4769594a3b45c131b2d71c0ec00c0e97f
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = 58ef310997dcaf067dd217274921504da6dbf0428a2b48a65fe8a02c616ac306
+Tag = 38a96e68ef7dbaef1b460cc0980eacd4
+Plaintext = 3d4127942459bb8682e662dfc862467582fa68
+Ciphertext = 8073a0c94a8fe32ac78fa5ebde78b0f6b5127f
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = 511e5d5e100b595f6b20e791830bca37e23f7b785e482a58405bffe7a632a5b8
+Tag = 5c5c702a82d468929227502e4e35796f
+Plaintext = 0e71863c2962244c7d1a28fc755f0c73e5cbd6
+Ciphertext = b343016147b47ce03873efc86345faf0d223c1
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = e48dfaa53b6807ea6f01d8dca67960b9f321f7851f324459a9bf61fe0be73abb
+Tag = 89188c0940182dd99a902d158c5b0810
+Plaintext = e0f1cd013e6aea4fa484fc3fa35d348b1a2399
+Ciphertext = 5dc34a5c50bcb2e3e1ed3b0bb547c2082dcb8e
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = c12c0423fe36e4c88775dd00b4af267b85b7dd2a37a742a3156923c8917c97a3
+Tag = 15849acbb7af1892790300bb84fb0558
+Plaintext = b1cc1946b4fc1dbd033254cdf536f61e9f9cd7
+Ciphertext = 0cfe9e1bda2a4511465b93f9e32c009da874c0
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = 4255f8af18df7237e0abe98421aec9634443561752d893aaffe76380e829ef32
+Tag = e75aaf3077ac6dfb5454851ec3910de6
+Plaintext = 87284658928208e3bddca83e3ceb13708d88d4
+Ciphertext = 3a1ac105fc54504ff8b56f0a2af1e5f3ba60c3
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = ab83567833d2f3461b5fbecc0e366694bb5ea00933b2b3e792ec3aefe20325df
+Tag = e70f42e3e1f2b5bb58433bd11f5dea1f
+Plaintext = bdb79f931ef3035a33bdd1b032fd9de8f6b2ba
+Ciphertext = 008518ce70255bf676d4168424e76b6bc15aad
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = bd1446ba3185d1c16551730947c22142142caa8cc1c540e89ab734ec297401bc
+Tag = 564f6248cefe5fc7cfb547c90a558925
+Plaintext = 1f9c3a8eb8bc59f3869e10f73883aa8f8990cb
+Ciphertext = a2aebdd3d66a015fc3f7d7c32e995c0cbe78dc
+
+Cipher = aes-256-ccm
+Key = bac55f9847d93325bf5071c220c0a3dfeb38f214292d47b4acb7b0a597fe056f
+IV = 05b50c458adbba16c55fcc454d
+AAD = b87577755d2d9489194f6f7cfabf267dc3433a9c91954e81beb72c5e06870922
+Tag = b52249d812f7f235afa0732e984e91b2
+Plaintext = 5f28809181f9a889894da8d6fe1fde6cce354a
+Ciphertext = e21a07ccef2ff025cc246fe2e80528eff9dd5d
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = 7aebdfd955d6e8a19a701d387447a4bdd59a9382156ab0c0dcd37b89419d6eff
+Tag = 04e2dfeeeac9c3255f6227704848d5b2
+Plaintext = 7b125c3b9612a8b554913d0384f4795c90cd387c
+Ciphertext = 6cc611d816b18c6847b348e46a4119465104254a
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = d119f300fbd74e754a200ea2c3f9fabc1466d02078c84245db693eef3f5672a6
+Tag = 38d48329997c5981d678b5e24a6f01b0
+Plaintext = 8b013f5782d5d1af8dbd451a4202866095dac975
+Ciphertext = 9cd572b40276f5729e9f30fdacb7e67a5413d443
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = d6204303b86acf62d5ab860ca70161288ede56e3cf017c08dca56fd2d6f8f6fe
+Tag = a77e3ab68e0a73519591a33ed098b758
+Plaintext = b2b1d82a5523b72ea366a680922ed3a4624536c4
+Ciphertext = a56595c9d58093f3b044d3677c9bb3bea38c2bf2
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = 8557e22eb4529b43f16b1f8ae47c714ac8a2c827c1408a47704778b4c5b52601
+Tag = cff6c24251c2fb7b8604dfa10c60ef4a
+Plaintext = f8c4eb4285d3d7744da52775bb44ca436a3154f7
+Ciphertext = ef10a6a10570f3a95e87529255f1aa59abf849c1
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = 8c1a4187efbb3d38332f608f2c8bbe64247d9afa2281ced56c586ecb4ab7a85e
+Tag = 6c3c39f915d081d34559179869b32d81
+Plaintext = 6e7fe35fa39c937a0e6b3a8c072e218650f42b8d
+Ciphertext = 79abaebc233fb7a71d494f6be99b419c913d36bb
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = a41bb1f256228302cd0548ae2148ff42774d18c2d6d3e38b36bc4938da13bac3
+Tag = 9389a6a6a74c6eb0e1f87562469f2082
+Plaintext = 917b467d841850fc6e648f1bc298a7f9f1ee38ca
+Ciphertext = 86af0b9e04bb74217d46fafc2c2dc7e3302725fc
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = b0b024e20c4f75a6dad54c21a9edbce846792e957878b1c8ed2d916c757e2b3c
+Tag = 3bed3a2f5dfdbfcc0d7ac26c88d1962c
+Plaintext = 2b4314fe1a6bfa786b7cfc13fbee861b348efbf6
+Ciphertext = 3c97591d9ac8dea5785e89f4155be601f547e6c0
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = 42153925c46fc9d5d328312d62f59bb99fdc4ac479a3386d5f88fefd4b32f577
+Tag = 35ea1d99be344fa1467ee91c73bbca67
+Plaintext = e19fa7f83c79920cbff45c41a9dee8fc99e97396
+Ciphertext = f64bea1bbcdab6d1acd629a6476b88e658206ea0
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = 37ab2a0b7b69942278e21032fc83eba6cdc34f5285a8b711a08da6acd42299fe
+Tag = 7936ec10a81b36768b606e9a38b2f4c5
+Plaintext = 53e0475cf492b3d39dad600f5c58eb0bd0021554
+Ciphertext = 44340abf7431970e8e8f15e8b2ed8b1111cb0862
+
+Cipher = aes-256-ccm
+Key = 8beedeb85d42c2a7fa6f7237b05acb197dd8e1672471ac878064fe5319eab876
+IV = 8479bdfad28ebe781e9c01a3f6
+AAD = 4a17522da707b4b2587a0ae367a2cd2831bb593a18ef442a7977eda6de045878
+Tag = 11575ae03ea8a57bbe4a67c060367b74
+Plaintext = c119a383d9a3d4bff4270a1d22076b346db5f61c
+Ciphertext = d6cdee605900f062e7057ffaccb20b2eac7ceb2a
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = 2a243246bfe5b5ab05f51bf5f401af52d5bbaa2549cf57a18e197597fe15dd8c
+Tag = 2abeeaef1187f815ca481ed8ddd3dd37
+Plaintext = 73b09d18554471309141aa33b687f9248b50fe3154
+Ciphertext = b7e8264ca70fd2a4fb76f20a8ad5da3c37f5893fb1
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = 0595306eb7441622a49800edee0134492d82320707fceba902af2e0c95fe634a
+Tag = ccc2b55011dbe92ce7619e0ad48b4ccf
+Plaintext = b64d00f3a4df754fa4ee6376922fb67ccce0c6209f
+Ciphertext = 7215bba75694d6dbced93b4fae7d95647045b12e7a
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = bd439dbefec589e120fb4f9825b315bf86523b85c61791cd4da4c8d474ba2714
+Tag = 1e8b1f4d70d8f4c7df4f22847d36b394
+Plaintext = 2b11d1ac74ffe701ec733d32085b1054132726e622
+Ciphertext = ef496af886b444958644650b3409334caf8251e8c7
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = cfebe1cf82267394065bcecfada6709c6c35a3ac835644f560d4c9a8c1848364
+Tag = a85e76a9d07b7b361ca56d53c34cda50
+Plaintext = a88f22424643a523aa3d7d88f4364f1290f49dd0a2
+Ciphertext = 6cd79916b40806b7c00a25b1c8646c0a2c51eade47
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = 7a37255b682766a0bfecf78e5162528885a339174c2a49325739d2bd8877e64f
+Tag = fddb010e7508ad03ad287068ecee6020
+Plaintext = c81427bc84c6a3cfefd4c4cb210fe82212977e1947
+Ciphertext = 0c4c9ce8768d005b85e39cf21d5dcb3aae320917a2
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = 619f2ae80070e278615466a3fd6c9acb7b510c5679bed7038889c77e78d8bd32
+Tag = ddea785e6c470c52c4fdf432fd78b66e
+Plaintext = 28c4d6de3e2ce51b849b135d9cfd3084f0e3155447
+Ciphertext = ec9c6d8acc67468feeac4b64a0af139c4c46625aa2
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = b2571e56f66a857daffbdc99370ceddd4a7bed3867d600cc797000a3b7b57a9d
+Tag = 91232cfbd7ffff252498b35274fb2995
+Plaintext = 4c88151cafef75832bacef43a06e862349d56b67ee
+Ciphertext = 88d0ae485da4d617419bb77a9c3ca53bf5701c690b
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = db409636e3e3bcd606a91aeb7592009896f9ad2c4cc6b7f578e6ad59c0f8fa22
+Tag = 72b2c50e5e391ad104f9ee33b94f2872
+Plaintext = 572855e22ce89bc2bcf09cb15a1765d99973449d61
+Ciphertext = 9370eeb6dea33856d6c7c488664546c125d6339384
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = 62c89a835721207a182968c516dc8be45774ec846e8dcab9ab8611888f2a76a8
+Tag = 2d69c5d6db1b130102af3dae0690673b
+Plaintext = 89ce46b3de3afaf2518d419b1a2ac24cabca269a96
+Ciphertext = 4d96fde72c7159663bba19a22678e154176f519473
+
+Cipher = aes-256-ccm
+Key = c3a0c126cad581012151c25cf85a44472c23f83b6095b6004f4f32cd60ec2db2
+IV = 94ab51ce75db8b046d6ab92830
+AAD = 33f30ddd83002eea50fd4a8fae39d0980a04160a22ac88b755ac050f1d1f8639
+Tag = 489903365970c2673c9fd457e1077aad
+Plaintext = edf1682a626e9fbf3d57bb260e0876c6f92ba5b114
+Ciphertext = 29a9d37e90253c2b5760e31f325a55de458ed2bff1
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = f5353fb6bfc8f09d556158132d6cbb97d9045eacdc71f782bcef62d258b1950a
+Tag = 6eef83da9f6384b1a2bda10790dadb3f
+Plaintext = 3cbb08f133270e4454bcaaa0f20f6d63c38b6572e766
+Ciphertext = 3966930a2ae8fdd8f40e7007f3fde0bd6eb48a46e6d2
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = e3a1555ffe5f34bb43c4a2dae9019b19f1e44a45fb577d495d2a57097612448d
+Tag = 587bdd120a7d08cd3841cb117af444fb
+Plaintext = 946e86795c332031e2d1ee09d3d4a101fb6800d00911
+Ciphertext = 91b31d8245fcd3ad426334aed2262cdf5657efe408a5
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = 9c5d43c1a1269cde199509a1eff67cc83a1759b71c9e7a6ee99f76b98c6e23a6
+Tag = 45b32f81dcf03e2bcc2aaf62ad366e97
+Plaintext = b76ce2ab0065ba1c0a754494991c8c452cb416f18ab1
+Ciphertext = b2b1795019aa4980aac79e3398ee019b818bf9c58b05
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = b07452a7900a289b91b2771dfdd5108852536659aa259def7b41e38f80bd03ab
+Tag = fea17d78533bc9e022dbfb460afdf499
+Plaintext = a3e0d8d0784155bfc45769c52711d4fa68e8bc390c20
+Ciphertext = a63d432b618ea62364e5b36226e35924c5d7530d0d94
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = 6b30f55c3101540523a92380390f3f84632f42962061b2724cde78ac39809397
+Tag = 56defc6dcaeec80b1c639350ab6f1fde
+Plaintext = 6e6a88abbb52a709b47365ad6aa8016fa9a03a9bd834
+Ciphertext = 6bb71350a29d549514c1bf0a6b5a8cb1049fd5afd980
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = 9fc62d14f8b7a6026509275cff80312ff1ade2b5d9c274cb72a506a571439fc1
+Tag = 9d37b7251fb8c0ef2b37c36d51219d0f
+Plaintext = eba1810d537041821121aeff8e0914ac26a550072c8c
+Ciphertext = ee7c1af64abfb21eb19374588ffb99728b9abf332d38
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = 6b9389cc42113d639fd2b40cbc732ae0dc7c14513b88b36b45a6ea5a06fe4d2b
+Tag = d279d9da4437c8a2a252436508134c56
+Plaintext = dfc6692cd2442e5ff1f918c8812a27f81d107d16a12f
+Ciphertext = da1bf2d7cb8bddc3514bc26f80d8aa26b02f9222a09b
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = db72d98d63fc10acff7dceec0e2691a80ecee50a0e957ad166c77952a50318bd
+Tag = 63943543bc1c5f5991ecc5964a288f79
+Plaintext = 9ad338cbfd1b52e6ae4178f05e00062274f8b0b25eae
+Ciphertext = 9f0ea330e4d4a17a0ef3a2575ff28bfcd9c75f865f1a
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = e98b710c47a4d12a73cd8aa2613fc2910c16f4195ea7f15650132493521d19be
+Tag = 0a49ee2b7ceddcbd28abb24b77d5edee
+Plaintext = 9f5a05db89e0e336da066ce81b79ad9be1d0ec4fb7b8
+Ciphertext = 9a879e20902f10aa7ab4b64f1a8b20454cef037bb60c
+
+Cipher = aes-256-ccm
+Key = 9cdebaeee8690b68751070691f49593668a6de12d3a948b38ddbd3f75218b2d4
+IV = af1a97d43151f5ea9c48ad36a3
+AAD = 527817316fc48b105f8ab178dd2db1fefa09c50461aa9d8bdf3c03482343bbf9
+Tag = b099a68cfa3572d974e03232e09f37fb
+Plaintext = 58f31e5770070a5d4031fb795dc2d298561d3559960d
+Ciphertext = 5d2e85ac69c8f9c1e08321de5c305f46fb22da6d97b9
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 0cda000ed754456a844c9ed61843deea9dadf5e723ea1448057712996d660f8c
+Tag = 6950608d7bcb39dcf03a2cab01587f61
+Plaintext = 79ac1a6a9eca5e07ce635bfd666ef72b16f3f2e140d56c
+Ciphertext = 1abcc9b1649deaa0bfa7dcd23508282d9c50ca7fee7248
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 3fb6ddb76809b8e6d703347664ef00a365955124c603900d5c8d4ff476138252
+Tag = 1c4fb40e5c8bc37152a173d4bbb18c3e
+Plaintext = 76d12e3c4c5d990bf563c60aa4999e52998d887f97477f
+Ciphertext = 15c1fde7b60a2dac84a74125f7ff4154132eb0e139e05b
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = d9fc295082e8f48569eb073ac1b9566246728fc62ccaab4a5667c472c98b2626
+Tag = 019c359008adae3070b5a543ead0effb
+Plaintext = a027c28fbe22111fd4c8a226cfe8531c16d7790d561eca
+Ciphertext = c33711544475a5b8a50c25099c8e8c1a9c744193f8b9ee
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 7a459aadb48f1a528edae71fcf698b84ed64dc0e18cc23f27ab47eeabeaf833f
+Tag = bd099ab134756b90746762a92a4a9f7f
+Plaintext = fa597e37c26c38694abdcf450f9edc529160fa0d651979
+Ciphertext = 9949adec383b8cce3b79486a5cf803541bc3c293cbbe5d
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 484207909dec4c35929ebe82fcacf20d2af6d850bd69364ebac9557adeadfbd4
+Tag = fa4f6adfec85d055310107ba89198afa
+Plaintext = 9e4c8aa9b58a8eabc5586892f5541000b43f17d9a051a0
+Ciphertext = fd5c59724fdd3a0cb49cefbda632cf063e9c2f470ef684
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 88b5448372548e6aab1b262630a28a471d285514703f1bdb10c695850e18fe6d
+Tag = 915d23eb2e952afcc89fbddb567d9d75
+Plaintext = 7d9582cf9e3bb9ee34dce965f56b08e716589486b0641c
+Ciphertext = 1e855114646c0d4945186e4aa60dd7e19cfbac181ec338
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 0e71863c2962244c7d1a28fc755f0c73e5cbd630a8dbdeb38842d7795d830d2e
+Tag = aad6c31828314e24198f005955ca8f5e
+Plaintext = 5a387e7cc22491fc556fe6a0c060b4911d01f0c11f801e
+Ciphertext = 3928ada73873255b24ab618f93066b9797a2c85fb1273a
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 2aa7a28da38c42fda2e578d9d6340cd8e80b9b32047c3db296d0640d517b0872
+Tag = e531ebbadccfe47182b41904bbfebcfe
+Plaintext = 87946e910059cbaf48df63b220f397049c65ca10cd1920
+Ciphertext = e484bd4afa0e7f08391be49d7395480216c6f28e63be04
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = 3382051c268891da04e6ca73adcead4029f6a1593be4acfe3968e7351a6a2fb5
+Tag = 7c582414154236c09ee704cf4a5de411
+Plaintext = c62f67d208f1c8ffd5d57df9de15ef54f97fbc07d1630a
+Ciphertext = a53fb409f2a67c58a411fad68d73305273dc84997fc42e
+
+Cipher = aes-256-ccm
+Key = d34264a12c35cdd67ac105e2826b071e46f8131d1e325f8e0ae80a6447375135
+IV = 3891e308b9f44c5b5a8b59004a
+AAD = c352828b1920e53bbb60f2ea6a5f15639659e6f3243405c26f6e48628d5519a9
+Tag = 57c9990029c89d1b37988745fa5737a3
+Plaintext = 697e73eaaf562d31bdbf7ce9e78c7426fe1c87e421def9
+Ciphertext = 0a6ea03155019996cc7bfbc6b4eaab2074bfbf7a8f79dd
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = 5f8b1400920891e8057639618183c9c847821c1aae79f2a90d75f114db21e975
+Tag = 0f73bfb28ad42aa8f75f549a93594dd4
+Plaintext = 9cea3b061e5c402d48497ea4948d75b8af7746d4e570c848
+Ciphertext = f28ec535c2d834963c85814ec4173c0b8983dff8dc4a2d4e
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = 1ae8108f216defea65d9426da8f8746a3ae408e563d62203063d49bf7e0d6bdf
+Tag = 4de907a59c5e4d3f21e1348d7cdf92b6
+Plaintext = 2b223932fb2fd8433e4b1af9e8234a824569a141f6c96a69
+Ciphertext = 4546c70127abacf84a87e513b8b90331639d386dcff38f6f
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = 460f08114b1015fe8b7a9b5dd1b9e6a3d28367c4bd15f29b13c02a8cb9a53968
+Tag = ff4239544e2f354d6c6837cd9c23b884
+Plaintext = 4d57cbe4a7e780d4ed17267d5ebc91750c2f0209e0444bd2
+Ciphertext = 233335d77b63f46f99dbd9970e26d8c62adb9b25d97eaed4
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = 860f4428259d9c5b17698cc95363db6cfee603258582e3a3e8feb886599d4ac4
+Tag = 3f6c6f7cc494201069344e2d6d41bd9b
+Plaintext = fda8665f87c618646a89c7abdca275fd10c31453ad4b9c99
+Ciphertext = 93cc986c5b426cdf1e4538418c383c4e36378d7f9471799f
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = 1b43c482f83780c21583f88e5afcf6938edd20f21b74d895161b60c27a6a42f0
+Tag = 3787a15352cfceb028202c8730beaa7a
+Plaintext = 98104fd3f3413ad1f57ef4912cb50097dca379a58c47b0d2
+Ciphertext = f674b1e02fc54e6a81b20b7b7c2f4924fa57e089b57d55d4
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = b082ccd964617c27a5607b7324faad237ee53acfc18c35502dbf7c1937a9dfcb
+Tag = f3a0ca3da647eb31893e867956097983
+Plaintext = b46b343e64d2d70e0bd909dbb3f6bedf7e4adc74321be526
+Ciphertext = da0fca0db856a3b57f15f631e36cf76c58be45580b210020
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = b8539ba93ef17254ec1d8d62e8f4eae4d41ee1e75345bf90c9cbb26c63bce501
+Tag = e663fbbebbc251b9f1760afa49e89e71
+Plaintext = 8e12620bb575e6b167b085255b2b5631ff28e04cbef8826d
+Ciphertext = e0769c3869f1920a137c7acf0bb11f82d9dc796087c2676b
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = b6b09463b5ef5ead1f17f4021693a0d8452e98dcbb8e7590f9fde6394970a6f8
+Tag = da90cd87e9d9ca5d85430a150e682752
+Plaintext = 792aaa23b923d1b53173fe19853b9aa402a301d48529873e
+Ciphertext = 174e541065a7a50e45bf01f3d5a1d317245798f8bc136238
+
+Cipher = aes-256-ccm
+Key = 4ad98dbef0fb2a188b6c49a859c920967214b998435a00b93d931b5acecaf976
+IV = 00d772b07788536b688ff2b84a
+AAD = 390f6de14d5e1f2f78dbe757c00b89209d0cf8bc48cbbea035779f93de357905
+Tag = fc0cc4601afb61efa7059cfe49ec9dde
+Plaintext = ddc5b4e48970ebd72869be6998e9103c014475e8ae6ea29c
+Ciphertext = b3a14ad755f49f6c5ca54183c873598f27b0ecc49754479a
+
+
+Title = NIST CCM 128 Variable Tag Tests
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 2084f3861c9ad0ccee7c63a7e05aece5db8b34bd8724cc06b4ca99a7f9c4914f
+Tag = a8c74677
+Plaintext = a2b381c7d1545c408fe29817a21dc435a154c87256346b05
+Ciphertext = cc69ed76985e0ed4c8365a72775e5a19bfccc71aeb116c85
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 79db716e6b0b1627890d378c4560eba7871883d94527be3454dc3c257ea93556
+Tag = 676e2df1
+Plaintext = 47f4cdd574264f48716d02d616cf27c759fdf787cdcd43b1
+Ciphertext = 292ea1643d2c1ddc36b9c0b3c38cb9eb4765f8ef70e84431
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 0d02778f90a164a4f9ada9dc7fd24eeb941069621418ef32c3f9ca6bf6fb2c4a
+Tag = eb1321a1
+Plaintext = 5eadeaec29561244ede706b6eb30a1c371d74450a105c3f9
+Ciphertext = 3077865d605c40d0aa33c4d33e733fef6f4f4b381c20c479
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 02e5a1306f612bdec098458cff3e691d93f050ba11ba627355dc7029d2cea5ab
+Tag = dd8cb4ca
+Plaintext = aac9fb69fed114c62db65090947096a2f5c85c271c6a6d53
+Ciphertext = c41397d8b7db46526a6292f54133088eeb50534fa14f6ad3
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 25144e807e389bb0e45b6dc25558caf61a2263869c4d0e4079d07674d7091110
+Tag = b659a844
+Plaintext = fb6e8d38ce38a8c1e710f3a33c682e6dabf055fb33fe75f8
+Ciphertext = 95b4e1898732fa55a0c431c6e92bb041b5685a938edb7278
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = be303c1ed9327ad88dae7cb5930b5a786d4f5477ef9370a9fdb56501964cb8fa
+Tag = e9e5e005
+Plaintext = 87d81389a6062e8ed501ea964c2fe35b2d3de9fd676c04f7
+Ciphertext = e9027f38ef0c7c1a92d528f3996c7d7733a5e695da490377
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 46dfb8f3e06c3f168e5ac9b341e7710d7b9c6a19b32389eafb58036de0a27756
+Tag = c9fc48e0
+Plaintext = e1bd9095fa9bb811e4054643feea3eac13fb57b43a0502a0
+Ciphertext = 8f67fc24b391ea85a3d184262ba9a0800d6358dc87200520
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 19eb03c35c352b79e8c32fa40bb9759b0565e04a6c18519ace346e2e9987a250
+Tag = ac73022c
+Plaintext = 92f7dc22dcbbe6420aca303bd586e5a24f4c3ed923a6ebe0
+Ciphertext = fc2db09395b1b4d64d1ef25e00c57b8e51d431b19e83ec60
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = efa6ddd6fb8e4480a0f64414694e5f9e7f2e9b97cbe9cd145b65173d072ab001
+Tag = 5dc8d581
+Plaintext = cecdf831c4044c8fe149e4cd579a1aecf222bf8e9dadba09
+Ciphertext = a01794808d0e1e1ba69d26a882d984c0ecbab0e62088bd89
+
+Cipher = aes-128-ccm
+Key = 43b1a6bc8d0d22d6d1ca95c18593cca5
+IV = 9882578e750b9682c6ca7f8f86
+AAD = 1b156d7e2bf7c9a25ad91cff7b0b02161cb78ff9162286b0622fccda2e251c97
+Tag = b941b65b
+Plaintext = 7cfb0973ea13dedc33ef6728db90f47559273ea6d3cd4db6
+Ciphertext = 122165c2a3198c48743ba54d0ed36a5947bf31ce6ee84a36
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = cd149d17dba7ec50000b8c5390d114697fafb61025301f4e3eaa9f4535718a08
+Tag = 32bc2ffa8600
+Plaintext = 8db6ae1eb959963931d1c5224f29ef50019d2b0db7f5f76f
+Ciphertext = df952dce0f843374d33da94c969eff07b7bc2418ca9ee01e
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = 463c65fa7becae5605af80d1feca59075ee88c0abfc72cb463312b3c772ec308
+Tag = 8b847d3a0c98
+Plaintext = bde3fc83287ddd1227bdab4305102c94d885412eb332bf6b
+Ciphertext = efc07f539ea0785fc551c72ddca73cc36ea44e3bce59a81a
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = ab153b0a8933f2eb0d721621c86de0cfe100d13e09654824b09d54277912c79d
+Tag = fb4f9d559a8e
+Plaintext = 82176e573c6070faa08d18b5957f119bb1ff51d744b04240
+Ciphertext = d034ed878abdd5b7426174db4cc801cc07de5ec239db5531
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = b22aba8d3e9f4b4bf006e26062de15daf94597731a6009129bfd12957877b1ce
+Tag = 1e09ff3d6a6c
+Plaintext = bcfc4485eaf225d945146374b737cdf5301c7738ea9f142a
+Ciphertext = eedfc7555c2f8094a7f80f1a6e80dda2863d782d97f4035b
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = eb80a43c5986deee6925d7c6d53cbdcbe11194843ea133f72d3590d8e8363efa
+Tag = b60ba1175f1b
+Plaintext = aa182e3ec4fb2f7a905c03582b2ee100ab81a9a311a778bc
+Ciphertext = f83badee72268a3772b06f36f299f1571da0a6b66ccc6fcd
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = 3ee186594f110fb788a8bf8aa8be5d4ad52d6e3bd5f406f080d9df0d7553a851
+Tag = 4a75860f3dd6
+Plaintext = 8ad6db8216af16bfda3261a220d078cc98c8ad134e4a80ca
+Ciphertext = d8f55852a072b3f238de0dccf967689b2ee9a206332197bb
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = d36fc18b5b12662ff5f6ea55af7c7a82d25d386220e399a85a590b1505c0dcd5
+Tag = 00cf106d70a4
+Plaintext = a65d24bd1ab92d8d294d654423412860e113c976f12ed76b
+Ciphertext = f47ea76dac6488c0cba1092afaf638375732c6638c45c01a
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = f0028503e7cd54474c56dc8b2416fe41f416eed73c63ddd141bdd51a0f8fe49c
+Tag = c0193a87ddfb
+Plaintext = 6e9dc61dd9cf19a6eebc10c9b51c13970636de2c9ea33592
+Ciphertext = 3cbe45cd6f12bceb0c507ca76cab03c0b017d139e3c822e3
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = 9a58a226a578bda012dbd7d04b11c879179aaaa36c6145418586cb103360c6c2
+Tag = 444d9b63ffab
+Plaintext = b526896c11e514b5b4c26351859e2a33800fefd6fd9e6d1a
+Ciphertext = e7050abca738b1f8562e0f3f5c293a64362ee0c380f57a6b
+
+Cipher = aes-128-ccm
+Key = 44e89189b815b4649c4e9b38c4275a5a
+IV = 374c83e94384061ac01963f88d
+AAD = c015fb08540755a8a8adc387d60553478667158964202eb2d25e28efd94c8c76
+Tag = c339ba21fcf7
+Plaintext = 88907b639f3fd07f40bf6b9b6334b11b2852557975721bf3
+Ciphertext = dab3f8b329e27532a25307f5ba83a14c9e735a6c08190c82
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 34396dfcfa6f742aea7040976bd596497a7a6fa4fb85ee8e4ca394d02095b7bf
+Tag = f6d1d897d6051618
+Plaintext = 1cccd55825316a94c5979e049310d1d717cdfb7624289dac
+Ciphertext = 1a58094f0e8c6035a5584bfa8d1009c5f78fd2ca487ff222
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 25865c1b89f1973bfa680d8458df35a56993a7e81e407e061794004068e481ab
+Tag = ceca422687f41550
+Plaintext = 36004342dd74e7966692a848b2c11e1fc311eac9d9cef616
+Ciphertext = 30949f55f6c9ed37065d7db6acc1c60d2353c375b5999998
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = e6209480da9e49172ba58a9048f2f1b0349030e8e7a79dcdf295eecd613f401a
+Tag = d2b981fc741f2591
+Plaintext = e81f4fb360bcae372d8be3f32655a29bc10a2f31876173cc
+Ciphertext = ee8b93a44b01a4964d44360d38557a892148068deb361c42
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 112c969882e685b4ae1ee6b67f680e6a1d9d840e627d12118f991c1a3d71314c
+Tag = a1fd47cd41fcf013
+Plaintext = 27d6443e729d35d7a0690fcb7fe0b20892875f60b5d8763a
+Ciphertext = 2142982959203f76c0a6da3561e06a1a72c576dcd98f19b4
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 73ef62870c50faca5d4e6c6ec45fa7b54bf79ed229fcf1fc8c79c9c09596039b
+Tag = 43eb86ffa6958d71
+Plaintext = 6c17ad5496dfccde8b877630e1e582dab52aaabe385a321f
+Ciphertext = 6a837143bd62c67feb48a3ceffe55ac855688302540d5d91
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = b537f0f2981405f6069b401966656461b3516a32d181777121a60cea537e7cef
+Tag = 1dfc38975c948d29
+Plaintext = dc4a1e39561f14321238272adff8b74a4e770c0a0c864a52
+Ciphertext = dadec22e7da21e9372f7f2d4c1f86f58ae3525b660d125dc
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 96bd747ccdcd5fa6cd920514a2f38203e82ee9c7ec6e88080e9f6e2a6a812b0d
+Tag = 20a48ee3845d9e7a
+Plaintext = c51958d7d7d39906b14d4ebb574db881355ec3e6b41838dd
+Ciphertext = c38d84c0fc6e93a7d1829b45494d6093d51cea5ad84f5753
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 690d6a2377314fc2f7dd06ae401e3585c79faf648a7af358ae4ef615669222eb
+Tag = 884188f946c9a317
+Plaintext = 9eaf24f84e8818e286410de321d65ffbf25d1a14073c60da
+Ciphertext = 983bf8ef65351243e68ed81d3fd687e9121f33a86b6b0f54
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 748dc83299a43033239ad2fef2dc3d72b76a38ca127607cef72de94a56d5e5c0
+Tag = 0ae2dd33327f8459
+Plaintext = 71c8eb0079559a306e236c49b7ce1b6cfe26c7888733eb7e
+Ciphertext = 775c371752e890910eecb9b7a9cec37e1e64ee34eb6484f0
+
+Cipher = aes-128-ccm
+Key = 368f35a1f80eaaacd6bb136609389727
+IV = 842a8445847502ea77363a16b6
+AAD = 35a49535684637f67573fb0b4fdc1bdd8a57650a1d8f29b866fa552a6e0cdf91
+Tag = c50821a48b93d0ca
+Plaintext = f09569906381138cc49e3fc2384c5d33c34abd3d617c487b
+Ciphertext = f601b587483c192da451ea3c264c8521230894810d2b27f5
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = c71620d0477c8137b77ec5c72ced4df3a1e987fd9af6b5b10853f0526d876cd5
+Tag = 6d86e69c07f053d1a607
+Plaintext = 84cdd7380f47524b86168ed95386faa402831f22045183d0
+Ciphertext = a7fbf9dd1b099ed3acf6bcbd0b6f7cae57bee99f9d084f82
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 7b40b3443d00a0348a060db109e8882157612c43084ac5c3e9c5350c88bc165d
+Tag = 94af9359a96acfb31a4a
+Plaintext = 7ebb051741145a3bad87131553375c6debcbcecee9b79ee4
+Ciphertext = 5d8d2bf2555a96a3876721710bdeda67bef6387370ee52b6
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 5cab3b84687070956916c11cab0ceea61adb6ea1f909be63d73df96fbfa3a9f4
+Tag = 36d3920d1012bf093a5c
+Plaintext = 35a29c1bcbe2182f34fe05f09dfb9ac4a496f95819ef11ec
+Ciphertext = 1694b2fedfacd4b71e1e3794c5121ccef1ab0fe580b6ddbe
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 6d440b44a069a6967f8750c3b4f8118798fe32d2eaa696ccc7f24e16d6366753
+Tag = c23025c1776811647f99
+Plaintext = a0e21d971876ae4048a61b43a3ac07c685005a20bccbe6ec
+Ciphertext = 83d433720c3862d862462927fb4581ccd03dac9d25922abe
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 06904325b8c6fc2b5a0412ba8062cd48d3af51beacb5ced9e2bdf8d0e056b738
+Tag = 6efeeaed29e65f1a8908
+Plaintext = 8d333ed7d4b208e794e1673f6df692caee4e3a00fc49115e
+Ciphertext = ae051032c0fcc47fbe01555b351f14c0bb73ccbd6510dd0c
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = e5049e1c32f0a000024882e4fca9b77adb6c87fdbad96d0c8e97bdb8f46789dc
+Tag = 70d42f84a5411dfa43f9
+Plaintext = 4189351b5caea375a0299e81c621bf434b6b97da68ad44be
+Ciphertext = 62bf1bfe48e06fed8ac9ace59ec839491e566167f1f488ec
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 6f0be1905d1b5b607574ad93a1e7b4a536020fc6798acae862253916a0562707
+Tag = add2256112d1f7d04934
+Plaintext = 5a063a24410b3d265c9a32a027cb2382a52bb8e35db15b98
+Ciphertext = 793014c15545f1be767a00c47f22a588f0164e5ec4e897ca
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = a90f9f55ef22f5e6c542ed3573a9ab67d9c3b6775587fc2be70817479347ce00
+Tag = e187f5f37e8a5029ca4e
+Plaintext = 0b72cb09a444be2d7b34cf9997fc5b885851d7e6092008b4
+Ciphertext = 2844e5ecb00a72b551d4fdfdcf15dd820d6c215b9079c4e6
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 4dd64fd7d8b571704cddabef854c51691ace4c30de74bfecad42eaed65284ebf
+Tag = fbbb92009435f9ab6691
+Plaintext = ce2d996c9a4cf85edb888822773e03179feeb9e4b0928d6a
+Ciphertext = ed1bb7898e0234c6f168ba462fd7851dcad34f5929cb4138
+
+Cipher = aes-128-ccm
+Key = 996a09a652fa6c82eae8be7886d7e75e
+IV = a8b3eb68f205a46d8f632c3367
+AAD = 75f4031d2e5098a9ea3eaa20c2423fbc1705ea18289efb96e311f3fefc153b67
+Tag = 3cae38db7cc9d577b0ed
+Plaintext = aa182e3ec4fb2f7a905c03582b2ee100ab81a9a311a778bc
+Ciphertext = 892e00dbd0b5e3e2babc313c73c7670afebc5f1e88feb4ee
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = 2c16724296ff85e079627be3053ea95adf35722c21886baba343bd6c79b5cb57
+Tag = d6965f5aa6e31302a9cc2b36
+Plaintext = d71864877f2578db092daba2d6a1f9f4698a9c356c7830a1
+Ciphertext = b4dd74e7a0cc51aea45dfb401a41d5822c96901a83247ea0
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = 78230f73f9c0150f630eca4cd679818551d449db82e665d8dc25fc53ebc11293
+Tag = 6356e2548a22e7cbee3b89d4
+Plaintext = 048ba28abb191ded5449dfe9dc7d19f9b132a2a9fd779aab
+Ciphertext = 674eb2ea64f03498f9398f0b109d358ff42eae86122bd4aa
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = c09191a7d2fca98fca486f8843f275a78d57b8c9a6d330d5652ba641f928c6d8
+Tag = 35516f170a2aada38d1d94eb
+Plaintext = adf51386b3cc133ea9d18e679fe4bbf10ea780b7bed57d6a
+Ciphertext = ce3003e66c253a4b04a1de85530497874bbb8c985189336b
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = ea46cc1a7ba5afaa6176f8dedc049283d2ac38fa74ef37ea1fc575328033b222
+Tag = ea2d3237788a02ff15258351
+Plaintext = f660a28551416b2f8e21466ba99daee280a91740d98219cf
+Ciphertext = 95a5b2e58ea8425a23511689657d8294c5b51b6f36de57ce
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = 3093b74eb088bdd59999629d59509920938f4feabbd29df8e0b44364c8b55244
+Tag = 65fb6719509987930d350890
+Plaintext = b9a96f0e4c6dea8861e888bdd693b300017718da958aaa00
+Ciphertext = da6c7f6e9384c3fdcc98d85f1a739f76446b14f57ad6e401
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = 5580672e52aacb9d714a34c31c33fc221e13e8f90849adbad3f6b3bec8571838
+Tag = 8ecdf173444c334cfda5b22b
+Plaintext = cc4acdbd34ec9b7cbc3e23a53e0627c2a7c63206f3e0298d
+Ciphertext = af8fddddeb05b209114e7347f2e60bb4e2da3e291cbc678c
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = c7acf1b17609dc336df1006ffac6497777cdfd497c8c91525377c130accce0bc
+Tag = 2221c860022d92b0f961c3e6
+Plaintext = ed75d28be4794ad81bbc0f26a11c5466f23c0270d2d7b8f8
+Ciphertext = 8eb0c2eb3b9063adb6cc5fc46dfc7810b7200e5f3d8bf6f9
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = ac1adca686e1d129142c49f26b52941d037d8052b8a27d5215b7ffcfd2202481
+Tag = 1c73d6a695afc704228ed7a1
+Plaintext = b8234b8bd34d9c6ceffebbb85722764e7d37e43c495256e0
+Ciphertext = dbe65beb0ca4b519428eeb5a9bc25a38382be813a60e18e1
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = 472bf7946bce1d3c6f168f4475e5bb3a67d5df2fa01e64bce8bb6e43a6c8b177
+Tag = bf1e81950e44c63183a679d7
+Plaintext = 790134a8db83f2da35dde832c3ae45ec62aff0274495d6e7
+Ciphertext = 1ac424c8046adbaf98adb8d00f4e699a27b3fc08abc998e6
+
+Cipher = aes-128-ccm
+Key = 3ee186594f110fb788a8bf8aa8be5d4a
+IV = 44f705d52acf27b7f17196aa9b
+AAD = 1340ac7ff04dd7450afc13f8fa52df6d526c744a2dc2f76b0aadf284da270508
+Tag = c2c3a1876e49a47a9b44b737
+Plaintext = 21ea2f778cf37aa02fea30e855c20a77909548da4ee7eb61
+Ciphertext = 422f3f17531a53d5829a600a99222601d58944f5a1bba560
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 76cf3522aff97a44b4edd0eef3b81e3ab3cd1ccc93a767a133afd508315f05ed
+Tag = ddb36e37da1ee8a88a77d7f12cc6
+Plaintext = ea384b081f60bb450808e0c20dc2914ae14a320612c3e1e8
+Ciphertext = 79070f33114a980dfd48215051e224dfd01471ac293242af
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 41aa11ec55980609482575b97eee172590ff545d5798fd4246313da3fdbbcda6
+Tag = a850b0116f3269b5e44e57de7166
+Plaintext = 811d54bad842a8b92b96fc03b4fff8b5f1939fd3a49876dc
+Ciphertext = 12221081d6688bf1ded63d91e8df4d20c0cddc799f69d59b
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = dedfb02e93b975270f50cffa3351c85975a7b21fd89bbb921c40c1e5310e6702
+Tag = 0f053627bd0c90714820c4fbe5ec
+Plaintext = 8bbf87b490020b863fc596a8d169d79c0cb3506e1f1f5aa2
+Ciphertext = 1880c38f9e2828ceca85573a8d4962093ded13c424eef9e5
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = a727ed3d13331ee6a224ae4b73f0ccb04b997fcf88533a1f57e9b055275de92b
+Tag = f865a77d66f1232cd7e36af3d1be
+Plaintext = 7294ae94358669f2ada4b64c125b248df7fe86c6715e3b6a
+Ciphertext = e1abeaaf3bac4aba58e477de4e7b9118c6a0c56c4aaf982d
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 6704dc39a259152d2dc3f08b8799ffecf4e1bc38ce5b77c71cc293c6664ef2dd
+Tag = e1fba154f6b166549d0d6bb9b573
+Plaintext = 48033c46389f6221fb9cdda1ecb8fc25fdec6afe4eaa5fd0
+Ciphertext = db3c787d36b541690edc1c33b09849b0ccb22954755bfc97
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 6cba004dfb5e5d9e1433bf1223039ae1d2df89cd2db68f550327a22c8f946ae9
+Tag = c485e9e28ae33959f8acbb640fbf
+Plaintext = 01acc909b7d3bb3b3e1f72845f05238d2e1d9162976d3bd2
+Ciphertext = 92938d32b9f99873cb5fb316032596181f43d2c8ac9c9895
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = dd5799710523aa1da0b1209fab1e6f2ed177444ed3880d462deebbd5f774c621
+Tag = 8ef976fa9bda9544ed94ef266ed2
+Plaintext = 3706def87786e49baec2d13407865286cb4e05908cac430f
+Ciphertext = a4399ac379acc7d35b8210a65ba6e713fa10463ab75de048
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 5d7505ff863d218f6822150455b977ad2df3c02be094f6832ee68872b1ae7a01
+Tag = 0caadf1dbd07515e3bfb6992e2cd
+Plaintext = f38d4b225d9b80a0c5fadc61476aef419ad3d18937d8661f
+Ciphertext = 60b20f1953b1a3e830ba1df31b4a5ad4ab8d92230c29c558
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 796b62c7abf797de7f6bad8bf5d549688ccb7ada62fff9469c14b08208b07a8a
+Tag = 733ad369e4a067b7976c9d6d0456
+Plaintext = 993bb3a85f67f6c1a809d8094ee80e2ad9b694063af2fdb3
+Ciphertext = 0a04f793514dd5895d49199b12c8bbbfe8e8d7ac01035ef4
+
+Cipher = aes-128-ccm
+Key = 7b2d52a5186d912cf6b83ace7740ceda
+IV = f47be3a2b019d1beededf5b80c
+AAD = 84fd27557aeb283282366083e3586f3a59691ccd0d43ec81c4e5f4e85715eba8
+Tag = 39860d66891f32ce0a09788f5899
+Plaintext = 1286506be19fb865a288b09dda8af4323567cd9a66e08643
+Ciphertext = 81b91450efb59b2d57c8710f86aa41a704398e305d112504
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = 40a27c1d1e23ea3dbe8056b2774861a4a201cce49f19997d19206d8c8a343951
+Tag = d80e8bf80f4a46cab06d4313f0db9be9
+Plaintext = 4535d12b4377928a7c0a61c9f825a48671ea05910748c8ef
+Ciphertext = 26c56961c035a7e452cce61bc6ee220d77b3f94d18fd10b6
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = ac8dde7ba60e4ba226eecb0a789b1c4673ddffe8f371464389f52f767004f0a6
+Tag = 96363d27b9e11fee55111b273399f5ff
+Plaintext = 7c0889854658d3408c5d8043aad2f4ae4a89449a36f8a3b8
+Ciphertext = 1ff831cfc51ae62ea29b0791941972254cd0b846294d7be1
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = 8f2777ec4930f7e349c3bd4830120cebdd896db9d8a33d34f101672024bd737f
+Tag = f741e15ad9b2f5ab864ad94d3f9de562
+Plaintext = c641cf589020b94026ae5ac0bfdc29822cc13862a54614c7
+Ciphertext = a5b1771213628c2e0868dd128117af092a98c4bebaf3cc9e
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = a87426f83bf91bd3c3556bf859cd97f51c92609879f02dbca9c7ae637a3fbf05
+Tag = 652a083ea1b43b7da026692c7aa796d7
+Plaintext = d204994c128d6204ef2939c22572daa56c12df2e4d3e33e9
+Ciphertext = b1f4210691cf576ac1efbe101bb95c2e6a4b23f2528bebb0
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = 7ff9ca86f820e4d57995d450611009ffaa726e6fbe4ce1558ca1e775daed9ec2
+Tag = 057e0faa2711cfa1e3da5499f9a1ee0b
+Plaintext = aff9bb0238689255f54cd5fdebe6d3dff5f5604ab8d77038
+Ciphertext = cc090348bb2aa73bdb8a522fd52d5554f3ac9c96a762a861
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = faa6b7f8c6e076b5e5b981119b7ec2e0b9c73da4064f9704e303d5792f59674b
+Tag = 90b39704d8913391ebd3424117b93b68
+Plaintext = 95d2cf30b6174b17278ad9f44079a2199082dab917f89763
+Ciphertext = f622777a35557e79094c5e267eb2249296db2665084d4f3a
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = b553e65640c1ad0d2ff748c5b2af9d970c74131cff4fa73384a33dfec056332e
+Tag = d0a6cb58733be0a3b608afdf78eaa70c
+Plaintext = aaa53244520e157c4890a0e62100a12daa84f9be710242d7
+Ciphertext = c9558a0ed14c2012665627341fcb27a6acdd05626eb79a8e
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = a9be73668b94bc6a212744522a0adff03d49fd495daadaf6cd32f4ca25ebc2b5
+Tag = af20ce64e6a821e39ca96aded43f0875
+Plaintext = 1066b96c3c44301073717520ea5c07adbac7759b88d52154
+Ciphertext = 73960126bf06057e5db7f2f2d4978126bc9e89479760f90d
+
+Cipher = aes-128-ccm
+Key = 4189351b5caea375a0299e81c621bf43
+IV = 48c0906930561e0ab0ef4cd972
+AAD = 8b516c47e6630b2c31d8eefd8ba152d7315582a3f4d3f0e0eb2984a365b434db
+Tag = cf4699d23f5fc6742bffebbd16858f6e
+Plaintext = b5969813d0f892febe64ed52d429cc737b5df8d5e0c63207
+Ciphertext = d666205953baa79090a26a80eae24af87d040409ff73ea5e
+
+
+Title = NIST CCM 192 Variable Tag Tests
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = 7dc8c52144a7cb65b3e5a846e8fd7eae37bf6996c299b56e49144ebf43a1770f
+Tag = 1f2c5bad
+Plaintext = ee7e6075ba52846de5d6254959a18affc4faf59c8ef63489
+Ciphertext = 137d9da59baf5cbfd46620c5f298fc766de10ac68e774edf
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = edb8834974b02fc9ab29b4b3c49683426124e729b44e43cde4ab9bb1b30b5531
+Tag = 24285996
+Plaintext = d05410f42d4759f8cab3884785cf8f60ecbf902e525b92e8
+Ciphertext = 2d57ed240cba812afb038dcb2ef6f9e945a46f7452dae8be
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = 8baf194e81e47a6ca82ca51b488339d014a0a494007793aa5201ac72fc3f808d
+Tag = 6c510570
+Plaintext = db3022ef4cd68ae22b501599448ffe2dda15cfd2e259315c
+Ciphertext = 2633df3f6d2b52301ae01015efb688a4730e3088e2d84b0a
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = c0b55acc7fbfa9d9af6e1f32b6626a1cd89b1c32513b5b50a18ddab028470953
+Tag = b418cfd2
+Plaintext = 7f0745bea62479c0080ecec52e37c1e32d72a6b3864da44a
+Ciphertext = 8204b86e87d9a11239becb49850eb76a846959e986ccde1c
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = 9dc672e64c468242ddeec318c71f9b8cbaa14639eba3c861acfc26463fb7d5d7
+Tag = 3e5b5794
+Plaintext = 263dbe1bd5e9d9b29b316fe36ec8bb10f64543b4921c01f6
+Ciphertext = db3e43cbf4140160aa816a6fc5f1cd995f5ebcee929d7ba0
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = 1798286c37c1504fc0d7402681f6f70711ef506dcc3e29d0183dc578ed976f92
+Tag = f63b4847
+Plaintext = 22dbba2b1a39074ddac736767ebdedc37e4208b233e03b34
+Ciphertext = dfd847fb3bc4df9feb7733fad5849b4ad759f7e833614162
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = ed2898d0bcb34eebf98b5279bc3e8a20214321a7e23bc55b2b7613b1a9b94f2c
+Tag = 7ab29a40
+Plaintext = f0f1235ee88d04de3f3d1489ec6b28b285a6a4fbb344911a
+Ciphertext = 0df2de8ec970dc0c0e8d110547525e3b2cbd5ba1b3c5eb4c
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = 50c4a285d6a4e64efceb288b82e7c8277307cf1eaa4b8b9294f97a1c38926a60
+Tag = 68f40ff6
+Plaintext = 0e50aa6a3079c0b8d61e51c3bd93b592a03719acb9f0252e
+Ciphertext = f35357ba1184186ae7ae544f16aac31b092ce6f6b9715f78
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = b48a16fb9a065d3aeb2bdf1860e4b0f1348c8f13cd00b1729ff8c19e4e9724f3
+Tag = ceeff92c
+Plaintext = 82f39f5207afcfd677a7544579f2b888a1eabdee4e835924
+Ciphertext = 7ff0628226521704461751c9d2cbce0108f142b44e022372
+
+Cipher = aes-192-ccm
+Key = 11fd45743d946e6d37341fec49947e8c70482494a8f07fcc
+IV = c6aeebcb146cfafaae66f78aab
+AAD = d92b80544f29aba52496e2c9a0aa4adeb89820be321cfd2f0a53585a15d04c7f
+Tag = 619c1124
+Plaintext = bc3b08eec6506d1497572f901f0e5f3e9854b40b0f992d08
+Ciphertext = 4138f53ee7adb5c6a6e72a1cb43729b7314f4b510f18575e
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 599b12ebd3347a5ad098772c44c49eed954ec27c3ba6206d899ddaabca23a762
+Tag = 8ba1360406f9
+Plaintext = 473b6600559aefb67f7976f0a5cc744fb456efd86f615648
+Ciphertext = 26d2be30e171439d54a0fec291c6024d1de09d61b44f5325
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 3a8423feb661db30542dc3cfb596280429397f80755a4bc8d4d941d03b61aacc
+Tag = b5e5938e8c75
+Plaintext = 7edfce3dedd65a8592aec2bfc7a751e2360f3137941fc960
+Ciphertext = 1f36160d593df6aeb9774a8df3ad27e09fb9438e4f31cc0d
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 0dc79993047fd6e7260aac4d847fdb4d16483f28b13b5f17330744d401d2875b
+Tag = 94f534b76f0b
+Plaintext = a9fb3ebba43c273cacbf0f7187030c69172f31382e9e059b
+Ciphertext = c812e68b10d78b1787668743b3097a6bbe994381f5b000f6
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 6546d9a90e0e763679d5469a1bcffcc4f18f35f50c7714d14c7329b76ce7984e
+Tag = 3c6c025faa1b
+Plaintext = a7573e5b7dd7f4ce9e4480f603c14145a27f7c7a9246a3cf
+Ciphertext = c6bee66bc93c58e5b59d08c437cb37470bc90ec34968a6a2
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 7f398ff0d47e2c0fccd8a16cc9e79b4813abac42e346fa33ba033956f798d6ac
+Tag = ae0f88d836be
+Plaintext = 84370557e0bbf74fd0a4533185adfe202d9fa9d622bba72f
+Ciphertext = e5dedd6754505b64fb7ddb03b1a788228429db6ff995a242
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = d0f46fb37d516cc957aaefd3be2a8bede885330a8edb96f3e5e0ab8cd03a8c59
+Tag = 66d09f64b4c2
+Plaintext = 029575400bd3f2621c7d9ca9b6a09ea6f776968b19dc3f3e
+Ciphertext = 637cad70bf385e4937a4149b82aae8a45ec0e432c2f23a53
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 4abaa4260c864572e12553c5aabfe62e4e7038490d4ba160119fc5d646780cc6
+Tag = 677fd479c852
+Plaintext = 448be3821d94452425fae41a06457260a2666e890fa94954
+Ciphertext = 25623bb2a97fe90f0e236c28324f04620bd01c30d4874c39
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 686e0578eadd19583291a01e11a29fc95a2c156da100dd85429ad58ba65440c6
+Tag = bbc332573774
+Plaintext = aebfe3e15a876412ec9df714f1afa898e69004c1ef25732b
+Ciphertext = cf563bd1ee6cc839c7447f26c5a5de9a4f267678340b7646
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = e3d29f970667286a81586aa02bb490c72d8bb3a308eafec5da0d105fddd1a157
+Tag = 33171a8ccec1
+Plaintext = 08b2ce5f7296016e86d02f8c7952d746703ee4f0429b8df3
+Ciphertext = 695b166fc67dad45ad09a7be4d58a144d988964999b5889e
+
+Cipher = aes-192-ccm
+Key = 146a163bbf10746e7c1201546ba46de769be23f9d7cc2c80
+IV = f5827e51707d8d64bb522985bb
+AAD = 9e2ea8eb7f56087ee506925648661eeefffd643a056cd4f4fc5cc23172b5c637
+Tag = bc8299cc9f95
+Plaintext = e73d7d23736db17cca816ab2440062a8051177d47feb514e
+Ciphertext = 86d4a513c7861d57e158e280700a14aaaca7056da4c55423
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 4d6546167b3ed55f01c62bd384e02e1039c0d67ef7abe33291fecb136272f73b
+Tag = 778a299f1224f10c
+Plaintext = 0ff89eff92a530b66684cd75a39481e7e069a7d05e89b692
+Ciphertext = 6ef66a52c866bd5df20ec5096de92167ad83cab0e095ad0c
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 95722ef5e0cf9f482e4c359f1fd6b9efe2b6e0630413c40285b8958c31188ca4
+Tag = a5c2c6b097a04d50
+Plaintext = b1ea02e3721e44c327443fcf4b424cce19afbb9e8cf06b76
+Ciphertext = d0e4f64e28ddc928b3ce37b3853fec4e5445d6fe32ec70e8
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = f7b76a2a4fe0a1b07a6b193b4600aec02360eb35853d88fe8a4f31a8dda48ad9
+Tag = f62e74c2312f9243
+Plaintext = c1f9c7b2e0ba712b4d2b32e4693b145228213999703767fc
+Ciphertext = a0f7331fba79fcc0d9a13a98a746b4d265cb54f9ce2b7c62
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 406f39cb77b8d8c63f7797d184b6ebde819af7d48de5003538c022fe96b841ce
+Tag = f1cb228ffd2ff8e6
+Plaintext = ebf3a717546199c6f6b14efe8888613ca7e075e8290b277c
+Ciphertext = 8afd53ba0ea2142d623b468246f5c1bcea0a188897173ce2
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 3dd3110703a95b05b9b9cff92ab7244e6c6dcb4509522c305d5d33e03f1b0b60
+Tag = 1f38e2d280a8f3ff
+Plaintext = a0e317b790870e6703e6077dfb8ea327c12e29a17107284c
+Ciphertext = c1ede31aca44838c976c0f0135f303a78cc444c1cf1b33d2
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 044ae4064156b6ebc0921cb2c3c607976339f824d4dc6902eac66910dce086b2
+Tag = afbcf46b4e75bb11
+Plaintext = 8a16990690717dc16eea24da39878a2ee7c1579976e5b173
+Ciphertext = eb186dabcab2f02afa602ca6f7fa2aaeaa2b3af9c8f9aaed
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 5479cc7f92460ff7a3e500f76d70e3036c44300005058b5517e3f64ad41b46b3
+Tag = fac11c84d08e918e
+Plaintext = 1e7e51f0fa9a33ed618c26f5e37754df0f7de7778882c26c
+Ciphertext = 7f70a55da059be06f5062e892d0af45f42978a17369ed9f2
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = f950e96d65a55efb3be3a55daffb421afad1d5625e3440a16414085469effe1c
+Tag = b50cb871173d9bb8
+Plaintext = 3ef1f4c438dce131990ba536d7a6166022ae7de4a436f87c
+Ciphertext = 5fff0069621f6cda0d81ad4a19dbb6e06f4410841a2ae3e2
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = 52742be3969830ba9c2bce26c98c2fb44ac881ec55c85627b2c94ba17b0de8cf
+Tag = 4ce29627efbc3523
+Plaintext = 3c7b4a68dfb766e24739f14932563fb81f24591f0e31e895
+Ciphertext = 5d75bec58574eb09d3b3f935fc2b9f3852ce347fb02df30b
+
+Cipher = aes-192-ccm
+Key = bdf277af2226f03ec1a0ba7a8532ade6aea9b3d519fe2d38
+IV = cc3c596be884e7caed503315c0
+AAD = e16e5dc034719e5d815f937b672cf34d5d420a3945c8f73645241779d2bec150
+Tag = 095168ed90827db2
+Plaintext = 03038acd2d8351e4e5aa308e554abfcd0d0334d8f864ec60
+Ciphertext = 620d7e607740dc0f712038f29b371f4d40e959b84678f7fe
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = 1bc05440ee3e34d0f25e90ca1ecbb555d0fb92b311621d171be6f2b719923d23
+Tag = 2ff0bb90a8879812683f
+Plaintext = f5522e3405d9b77cbf3257db2b9675e618e8744a0ee03f0f
+Ciphertext = b9103942dbbb93e15086751c9bb0a3d33112b55f95b7d4f3
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = 25c32770a299020d8500d8a4b5d7621e4379dbd6ef34a9aceefd4055ea6144f5
+Tag = 6982d0796e1bd1cc9879
+Plaintext = c8bf145fcffbafd6cd1a4c5b6cedfe008aacb2528ef51c80
+Ciphertext = 84fd032911998b4b22ae6e9cdccb2835a356734715a2f77c
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = cba0e0140f094e17652ea6f64c26f69dd9429bfefb41aaf104c38f3f6501f4f9
+Tag = fe08edf50e05d4d85faf
+Plaintext = f8813985f59bf284bd3882e899ca9b67fb496f3eb78d7ebe
+Ciphertext = b4c32ef32bf9d619528ca02f29ec4d52d2b3ae2b2cda9542
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = a846d0f56eb963b308ab8f697adca378ab6ccf9f739edcd7f5db197b2ffa99ac
+Tag = 800ae2523c5f161ed96f
+Plaintext = 72862d82d940748d54369e3143192453069b80d10f32e569
+Ciphertext = 3ec43af407225010bb82bcf6f33ff2662f6141c494650e95
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = 1dc5f6d6103ed2ae7f4ecd7b1bae4d5b9c0adef9100527b1737e1cf57f1175ef
+Tag = 34a29547607846bc9834
+Plaintext = 46f2199305ff4e1f21a89d96d3902c54939f52278ba7aa0e
+Ciphertext = 0ab00ee5db9d6a82ce1cbf5163b6fa61ba65933210f041f2
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = 8c28bcb9c31191c347dd64e552af5aff500e6e6f39e866351dd7065501a2837d
+Tag = 95f73957e86152df56bd
+Plaintext = 18c38c41a4e70c3f7362249ea329059b0e026bce7ae976b0
+Ciphertext = 54819b377a8528a29cd60659130fd3ae27f8aadbe1be9d4c
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = 1081afd5bf9f1a87169973ebdca85c2b69598154673d7ca9d6e2f63d52030fc1
+Tag = b2b028cd785f4f964069
+Plaintext = c89e388dd6124c41251e7422b420a71e4618f5cf9f0a63fc
+Ciphertext = 84dc2ffb087068dccaaa56e50406712b6fe234da045d8800
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = 079bc543c966734fa70814139ba8051271ee1c4f701579013c427f8efb141db7
+Tag = fd3ef357e5e69f504c95
+Plaintext = 68449bc3f6c8bd8f3a46a8e147522d979948c88ca791d204
+Ciphertext = 24068cb528aa9912d5f28a26f774fba2b0b209993cc639f8
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = e7094697b78d20174ec3c97a48abcf67c2ba6790b4db5fda82b454becd2a25ef
+Tag = e092ed15d1a074306a9e
+Plaintext = 330088153204c3d5de7744047b60887c8c044e4eeaae4bab
+Ciphertext = 7f429f63ec66e74831c366c3cb465e49a5fe8f5b71f9a057
+
+Cipher = aes-192-ccm
+Key = 62f8eba1c2c5f66215493a6fa6ae007aae5be92f7880336a
+IV = 15769753f503aa324f4b0e8ee0
+AAD = f8d64ce2aa66e67de0f2fa584dec858983333b0570882ab628419bcee541395a
+Tag = afaad39e9183b2970027
+Plaintext = 893c5c45db989bd39485caa05ed700bb17c526b426edf4ba
+Ciphertext = c57e4b3305fabf4e7b31e867eef1d68e3e3fe7a1bdba1f46
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 29bdf65b29394d363d5243d4249bad087520f8d733a763daa1356be458d487e5
+Tag = 733013b8ebe5e92b1917640c
+Plaintext = d0e4024d6e33daafc011fe463545ed20f172872f6f33cefa
+Ciphertext = 479f3d408bfa00d1cd1c8bf11a167ce7ae4bcdb011f04e38
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 314f069dd4ac5aa3fdc2a74e83daa1d5d18330cd3b90684a9260bb48f5626d49
+Tag = 425a1bad4381dc84fee903e3
+Plaintext = 9ebd994a9af0cb94552ffd749fdd97f75a1ebd0ad3de3a9a
+Ciphertext = 09c6a6477f3911ea582288c3b08e06300527f795ad1dba58
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 3aa7f30ac5bfbcb3f8de7c5e76269c608fbc76361d215e78abc0e308ddc3528f
+Tag = efcb43c6aaec88b51d0a378b
+Plaintext = 590a27721a36987d1ffa15f23c6ca5cc556dfcfa6993a2fb
+Ciphertext = ce71187fffff420312f76045133f340b0a54b66517502239
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 5630345f662df248886f771b2b77cc0cbdc8fe4cc4a6cde52b1ea4e5d946cebe
+Tag = b9a60374d9304316e2fc50d9
+Plaintext = 65f4b3a00c1c1ef39445a69b2150b034705410140ff9dad0
+Ciphertext = f28f8cade9d5c48d9948d32c0e0321f32f6d5a8b713a5a12
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 38ee97f0dc635c7416a024e3af5c95dd1d496db8a5a5c3bcc20b9093ca906dfb
+Tag = 07611163d6b0f1734292ed8c
+Plaintext = 0edea2afaeaf650704d2c6c6622aad82169807c983c17309
+Ciphertext = 99a59da24b66bf7909dfb3714d793c4549a14d56fd02f3cb
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = ea3b3f3c5b28f7d48af2ccf97083937baccb0a6b1a041080a73b15b9640ccf44
+Tag = edefbcbb51d9d607b7b2e8f8
+Plaintext = b80175a03dff1b10078ded64ed759e5453e3bc0657c68590
+Ciphertext = 2f7a4aadd836c16e0a8098d3c2260f930cdaf69929050552
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 287f31e69880823df7798c7970c0e42e600bf567ad78f5d559d0182d570c03cb
+Tag = f2b6d4dc8afae25ff400d73d
+Plaintext = 531c1e721e185f58b2c654b9098ce0c1338bab4149c7bef7
+Ciphertext = c467217ffbd18526bfcb210e26df71066cb2e1de37043e35
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 1d4579c9410cc34ade1352ed433e0d4faaaa28200e359bcb4140d35939b3a792
+Tag = 19cd80c1ce0f9ed40f1e9dec
+Plaintext = cead1c5af16ca89bc0821775f8cba8c25620a03dfd27d6f1
+Ciphertext = 59d6235714a572e5cd8f62c2d79839050919eaa283e45633
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = 3fec0e5cc24d67139437cbc8112414fc8daccd1a94b49a4c76e2d39303547317
+Tag = e53d5aeccfb4a6837b79a625
+Plaintext = be322f58efa7f8c68a635e0b9cce77f28e3f8faaa76fcad4
+Ciphertext = 294910550a6e22b8876e2bbcb39de635d106c535d9ac4a16
+
+Cipher = aes-192-ccm
+Key = 5a5667197f46b8027980d0a3166c0a419713d4df0629a860
+IV = 6236b01079d180fce156fbaab4
+AAD = ec6857533675b5ed8d4315b0d5f59c826f3ccb2d0bd6f604bd54f7c9542123ce
+Tag = 385e080bf29ae097c328789a
+Plaintext = c222374d366baf2d0301340582aa056c04441ac766065ab1
+Ciphertext = 55590840d3a275530e0c41b2adf994ab5b7d505818c5da73
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = 9ef2d0d556d05cf9d1ee9dab9b322a389c75cd4e9dee2c0d08eea961efce8690
+Tag = 3abcdb0563978785bf7fd71c6c1f
+Plaintext = 78168e5cc3cddf4b90d5bc11613465030903e0196f1fe443
+Ciphertext = e2324a6d5643dfc8aea8c08cbbc245494a3dcbcb800c797c
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = 6f99d9ce00a4be502a5d2c76a07b914d56f49a1592c1ee2e46e11b3c9da0d083
+Tag = cb0e8ec0879db8ffa59125eac239
+Plaintext = 3c3992cac792e019720d38f768beac3deb6a43e7e1f59f20
+Ciphertext = a61d56fb521ce09a4c70446ab2488c77a85468350ee6021f
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = deae66f68bb18178d1bc0734f19fd3ab390049c2ca083a159f5c078fcb4f0a38
+Tag = 664a2d992f7cf821e19bb7d4dff8
+Plaintext = 8eaae72e532943d66ce8250c6b434d299b6afbf8e2b4f8b1
+Ciphertext = 148e231fc6a7435552955991b1b56d63d854d02a0da7658e
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = e2d592cb412e65f9044257d78e7491f9f80c8b08102c2d5da20535cef74ad8c8
+Tag = 46a4a816b709a55db450ac249c5c
+Plaintext = 1b8096b79ace8c6ee5dbd8735f1287aa2c94865f382dc2da
+Ciphertext = 81a452860f408ceddba6a4ee85e4a7e06faaad8dd73e5fe5
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = 78a292662b8e05abc2d44fbefd0840795e7493028015d9f2aae7b3b7a4634437
+Tag = fbebbdb2e35ebf682f7fe30996bc
+Plaintext = 014f15219463ac22820ba6a1fa04d7f686003ef24004da67
+Ciphertext = 9b6bd11001edaca1bc76da3c20f2f7bcc53e1520af174758
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = de6ea86d3641d916c4394fdd31e6a50194993d6ef1d3dfd9fffca20b2f58107d
+Tag = eee137bb5b1e7385aa1bd5d69831
+Plaintext = cc8c855a4c122046916bdcf8089eba3ddb80483e201c7102
+Ciphertext = 56a8416bd99c20c5af16a065d2689a7798be63eccf0fec3d
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = 87b937b1d36e8a9ab33a1d3eed617030923acaabc7e620dfcb3c388936030fc6
+Tag = 9b13b729c70e1fa89c43a05a544b
+Plaintext = 3fb7d1f17e7e36d5d4b816cc6db11d1d85848c577fdfe938
+Ciphertext = a59315c0ebf03656eac56a51b7473d57c6baa78590cc7407
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = 116f4855121d6aa53e8b8b43a2e23d468c8568c744f49de5f7f1a60cf4e16278
+Tag = 2d900340d90dc4f09a7171d331d6
+Plaintext = 268fe424d6db30f680c10fe2684707a0778069958e9a3bf7
+Ciphertext = bcab201543553075bebc737fb2b127ea34be42476189a6c8
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = e13e0c9cef1f86160a75ccb131586370b0edabbf8b3b63f21f3a6fee072dd926
+Tag = e4ad0d90322ed2813a3343029e93
+Plaintext = 9d64de7161895884e7fa3d6e9eb996e7ebe511b01fe19cd4
+Ciphertext = 07401a40f4075807d98741f3444fb6ada8db3a62f0f201eb
+
+Cipher = aes-192-ccm
+Key = d2d4482ea8e98c1cf309671895a16610152ce283434bca38
+IV = 6ee177d48f59bd37045ec03731
+AAD = d4cd69b26ea43596278b8caec441fedcf0d729d4e0c27ed1332f48871c96e958
+Tag = 0065601bb59972c35b580852e684
+Plaintext = e4abe343f98a2df09413c3defb85b56a6d34dba305dcce46
+Ciphertext = 7e8f27726c042d73aa6ebf43217395202e0af071eacf5379
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = 2529a834668187213f5342a1f3deea0dc2765478c7d71c9c21b9eb1351a5f6cb
+Tag = 380ea23dcffc9574f672bca92e306411
+Plaintext = 2cea0f7304860a4f40a28c8b890db60f3891b9982478495e
+Ciphertext = 5bb7aa6ab9c02a5712d62343fbe61f774e598d6b87545612
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = a4dbf26802b2dba1bf828f57618fd197d3e60b6efc9d884f965ce3b43e1dc008
+Tag = b93605b46a8a6a9c7e02cb8feac67af4
+Plaintext = 2baf3d378942bd44f67fb787def50aaf446bf15c56243484
+Ciphertext = 5cf2982e34049d5ca40b184fac1ea3d732a3c5aff5082bc8
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = cbd1302c9fffe29fe882838236f64fe9d9ba35db5499e90f0faa35f34c7490f2
+Tag = 82e411c052c0a025ab15767b0242ebf7
+Plaintext = a0639aa4e7a8bda4e9e096d17c1c47d3786010fabe9c72d2
+Ciphertext = d73e3fbd5aee9dbcbb9439190ef7eeab0ea824091db06d9e
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = b6112eb8299b28445aca8f72e7170a1cd8bbfee4d2145fbe8d49c6af8831c4d4
+Tag = ab58a892f7142414d3f7cf10925a403a
+Plaintext = e2d78ce5df9284c045b84df33f551211ddccf7bb14cd4529
+Ciphertext = 958a29fc62d4a4d817cce23b4dbebb69ab04c348b7e15a65
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = c70a9fb811894b73e445b78db7a931705a181f3a8730341cbb50eaff43572c6e
+Tag = b5b3ce6bae6ecb060289508d6e9212fe
+Plaintext = c3f1e735a6741aa481ad577a98dbac1f03cc80ea0dae1b94
+Ciphertext = b4ac422c1b323abcd3d9f8b2ea3005677504b419ae8204d8
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = c7cbda495a7dc1d91837f652a9d084df9b717e99b29bf1ab7f6c17b3341ecd6c
+Tag = a16229a91a2298ffe104f9c032720abb
+Plaintext = db8cd5d76e459afce765e07da98f4ac58231224238c293c7
+Ciphertext = acd170ced303bae4b5114fb5db64e3bdf4f916b19bee8c8b
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = 4bd3a656796cb1fa87976f3a93471e33dd1209ce33d7a28aaca4d17c99d78c94
+Tag = b9cacc4fdb44402971a0eee7f1ad90d7
+Plaintext = fd66aebc94f2513b1b9218396b08c63a869b9c4dd0752a91
+Ciphertext = 8a3b0ba529b4712349e6b7f119e36f42f053a8be735935dd
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = 448cdd9cbbf863eb666fda36b825f3798827da3c1349611f45605ab734b24498
+Tag = 13306e7f0a61d4b3da372db669321143
+Plaintext = 5831e9a6af0234d051ffd17a14b8e3c8da95067ab767901b
+Ciphertext = 2f6c4cbf124414c8038b7eb266534ab0ac5d3289144b8f57
+
+Cipher = aes-192-ccm
+Key = a7177fd129674c6c91c1c89f4408139afe187026b8114893
+IV = 31bb28f0e1e63c36ca3959dd18
+AAD = f8f04f12174b5205866515ce3775bd8e11d50d8b96142be0c347a773379fb928
+Tag = 09726d3a3d04005dc13629658624d05b
+Plaintext = 248a4969621cf291bec7f0d76d80b7f019d4eb002a22c46a
+Ciphertext = 53d7ec70df5ad289ecb35f1f1f6b1e886f1cdff3890edb26
+
+
+Title = NIST CCM 256 Variable Tag Tests
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 3c5f5404370abdcb1edde99de60d0682c600b034e063b7d3237723da70ab7552
+Tag = 3cb9afed
+Plaintext = 239029f150bccbd67edbb67f8ae456b4ea066a4beee065f9
+Ciphertext = 9c8d5dd227fd9f81237601830afee4f0115636c8e5d5fd74
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = ab91d1aa072947d22f0dc322355a022fe7f0747f4a184b48446bd27999ef01fe
+Tag = 169d7775
+Plaintext = 25a43fd8bf241d67dab9e3c106cd27b71fd45a87b9254a53
+Ciphertext = 9ab94bfbc86549308714543d86d795f3e4840604b210d2de
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 4c3bdc6186297896097b3297ba90bcde78dc8a9efe3bd8b10a85eed1bf63a30c
+Tag = b9c2e299
+Plaintext = e63d8303fa5c51550e417e77ec1ec647c9e2a853cab00fee
+Ciphertext = 5920f7208d1d050253ecc98b6c04740332b2f4d0c1859763
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 8587324c1ff6712aed8af134744de5df1f88c5d2cb33f4f888af9fd39eb8e813
+Tag = 02f73205
+Plaintext = f27548ec1608d3b8a5bdcbccb7e09cf4b5c29d3661b13a61
+Ciphertext = 4d683ccf614987eff8107c3037fa2eb04e92c1b56a84a2ec
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 58820fb68ba1cd73b05a6698b4394ba1b13e8e296480f5afe1154d9b8536007c
+Tag = 4e1dd81b
+Plaintext = ecbd7091732e49c0f4bda2e63235ea43bbf8c8730f955f9c
+Ciphertext = 53a004b2046f1d97a910151ab22f580740a894f004a0c711
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = f3034031933e7807d47140cf5c7794e42a228a522a83883b0765b57a411bad85
+Tag = 46525bc4
+Plaintext = 3002c6fb49497c7d1d06e1bd4edd57a9e54bbbb74e948c79
+Ciphertext = 8f1fb2d83e08282a40ab5641cec7e5ed1e1be73445a114f4
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 05981dc26a1db2d8e2c3d85ea9a4d1dc3432d9edc4795ca03ca4661d2fc35b8c
+Tag = 651844a3
+Plaintext = 214acfb2613b266f2929d43c7666f3a23e61423061cdbec3
+Ciphertext = 9e57bb91167a7238748463c0f67c41e6c5311eb36af8264e
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 968a302a27624c304e894633af600c3cc7c614b7da3af0bf2d3f239c7605338a
+Tag = 49fd550d
+Plaintext = 9c575d592a9622c014c1303329757a65a414a9ed0c1b1b3f
+Ciphertext = 234a297a5dd77697496c87cfa96fc8215f44f56e072e83b2
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 9011231ec382ecaaae57f34de1ac6bbb50741014a978160ce59c60491e64f30d
+Tag = 4137defa
+Plaintext = 426a4c83793abdcff5e2a99e161785dc27c6168a329ee465
+Ciphertext = fd7738a00e7be998a84f1e62960d3798dc964a0939ab7ce8
+
+Cipher = aes-256-ccm
+Key = 9074b1ae4ca3342fe5bf6f14bcf2f27904f0b15179d95a654f61e699692e6f71
+IV = 2e1e0132468500d4bd47862563
+AAD = 96f0b1edec4ad14407dcaf30ed68942b46c48d58b2dd63af60fccd5bdd48e560
+Tag = 56a4953f
+Plaintext = e04006b68c83a5dd4ceac3cde238e48895ae17728fdc7bbe
+Ciphertext = 5f5d7295fbc2f18a11477431622256cc6efe4bf184e9e333
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = 4e0d3aa502bd03fe1761b167c4e0df1d228301d3ebaa4a0281becd813266e255
+Tag = 265867a29eb3
+Plaintext = f0b065da6ecb9ddcab855152d3b4155037adfa758ba96070
+Ciphertext = d6a0f377f7c1b14dcdba729cae5271b027e71cc7850173ec
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = aeef2d1e3d3c9920a4fdb5f9d963b88e78a5d0edae531e3b55e702ed609d9a3c
+Tag = 66e89a72dc0e
+Plaintext = f2a8855e34854656df0776e80255ad1d125841c727201509
+Ciphertext = d4b813f3ad8f6ac7b93855267fb3c9fd0212a77529880695
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = 3051ffb19862370bc46ca94a8eb906a660d539b18e965583e95acc149190e3e9
+Tag = dff4f6257e06
+Plaintext = 20955a0ca3c9c10d4055406ec12226130ecdaf195b08d65e
+Ciphertext = 0685cca13ac3ed9c266a63a0bcc442f31e8749ab55a0c5c2
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = aafa45a107d909756b4a1956d5228b50316fc5852afdeecf401fa2a71aabea46
+Tag = ef0017c9acc1
+Plaintext = 246b60d17ea70deb1380fbf4bd767d88f53069b0f4136511
+Ciphertext = 027bf67ce7ad217a75bfd83ac0901968e57a8f02fabb768d
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = ccdeab6a28b1b9e9f0c67116a91f2215b229d0edcd35d696db2bcf54e77db743
+Tag = c73969437912
+Plaintext = 5b735697c5577ee0e352cf6a1495c490d6f7e97c3898f0ee
+Ciphertext = 7d63c03a5c5d5271856deca46973a070c6bd0fce3630e372
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = 33a1e7d4820ed6a76a6dab90b4ba830888caf12a262e4eb6d75a505b2207de36
+Tag = d7cb3721fcdd
+Plaintext = 1170416faf81896c7f00815f53c2be5f7246d4794895b4b1
+Ciphertext = 3760d7c2368ba5fd193fa2912e24dabf620c32cb463da72d
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = 3df3edd9fc93be9960b5a632e2847b30b10187c8f83de5b45fcb2e3ed475569a
+Tag = 82183448e643
+Plaintext = 556765ffe5c46015cbd8194e32abc41e8f711773e2bcac90
+Ciphertext = 7377f3527cce4c84ade73a804f4da0fe9f3bf1c1ec14bf0c
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = 4cb8663a1a934b6b27cbc1ed3040fbb99fbb6812f8ca35ff73cc13feeb483af7
+Tag = 6069901b5e3a
+Plaintext = 3070e269f3e87cd82af3896895a5dd6fbfa9898279e0f73b
+Ciphertext = 166074c46ae250494cccaaa6e843b98fafe36f307748e4a7
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = 876df130c01d0b9b8ebe43e71046c365e13124169026876d50d7e155f0299676
+Tag = 6d65c2b005d4
+Plaintext = dd18d40728c561e24e6e54834348dde5683f067baf8df469
+Ciphertext = fb0842aab1cf4d732851774d3eaeb9057875e0c9a125e7f5
+
+Cipher = aes-256-ccm
+Key = 8596a69890b0e47d43aeeca54b52029331da06fae63aa3249faaca94e2605feb
+IV = 20442e1c3f3c88919c39978b78
+AAD = da08b14e1b770b81faaf1e59851df1cba8838cd63bef141340ee378e65fdcbd4
+Tag = 75b37e9fb9e9
+Plaintext = 7064a2491f716f4a2969815e4a281a54690ced9f794b264e
+Ciphertext = 567434e4867b43db4f56a29037ce7eb479460b2d77e335d2
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 7022eaa52c9da821da72d2edd98f6b91dfe474999b75b34699aeb38465f70c1c
+Tag = 8cf050f48c505151
+Plaintext = 28ef408d57930086011b167ac04b866e5b58fe6690a0b9c3
+Ciphertext = 356367c6cee4453658418d9517f7c6faddcd7c65aef46013
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = a61b6c1f0293a7c35520abf158a995e5ae59b43ec5f38ff6fd6529970c9f83ac
+Tag = 6bca352f92f383e1
+Plaintext = 1c5ad37d2a55afbc390b27cde0c42d6651fe191239bfaa27
+Ciphertext = 01d6f436b322ea0c6051bc2237786df2d76b9b1107eb73f7
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 0f1c6dffeda98f7a159f9cc61820bfb29910d8eaa41b751a41f9fe5648f02fba
+Tag = 14fd7c84052208d9
+Plaintext = 6efe6652d46a84166d30befe2fbee0795e9475b401eedd60
+Ciphertext = 737241194d1dc1a6346a2511f802a0edd801f7b73fba04b0
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 151110a9ce7e44e5d76d9cad53c1819317527fcd169051f01c6a3efcc06ea999
+Tag = c3ebc7214b9eef31
+Plaintext = 55b791ee495299916ff3c2327b4990952bebd0a2da9acfc5
+Ciphertext = 483bb6a5d025dc2136a959ddacf5d001ad7e52a1e4ce1615
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 0ba1210696d735eebc13b609d0ec33bc740805105dd82f065b82892b931f1e6d
+Tag = eff08182f8a00f13
+Plaintext = 794a86f5b20d344ad86fd5523d08f1864737be57731440c2
+Ciphertext = 64c6a1be2b7a71fa81354ebdeab4b112c1a23c544d409912
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 5a3b71b0fdecce8bd759d3d72321b5c3e882c82627c14e0b59cc8c6d191f243f
+Tag = 6894be1f8fa14538
+Plaintext = efa6ddd6fb8e4480a0f64414694e5f9e7f2e9b97cbe9cd14
+Ciphertext = f22afa9d62f90130f9acdffbbef21f0af9bb1994f5bd14c4
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 5d344c5b94695a66192b6692e420c8eaa3cb482502be837b2a0a91b787fbe48e
+Tag = f4393bca514c3336
+Plaintext = 561dd3bf419ae33ff521a43898cf12c6a5c6163eec22abc1
+Ciphertext = 4b91f4f4d8eda68fac7b3fd74f7352522353943dd2767211
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 08344486df2b2f9a6880a03503a3986c485f067c480c31a51607553b875f91fa
+Tag = b708ffd04c8c2da0
+Plaintext = 6d3596f25401f2e3b099613236f1d88a2f3d8edc1f04bc0c
+Ciphertext = 70b9b1b9cd76b753e9c3fadde14d981ea9a80cdf215065dc
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = 9d0824a4dc7e67326c5b68a6ea99cb68298a2af2cc1952351454b038f6270603
+Tag = 1511d7d684d58762
+Plaintext = c563a43e4cc0f93d955432f68287e63400a7fdcae738ba84
+Ciphertext = d8ef8375d5b7bc8dcc0ea919553ba6a086327fc9d96c6354
+
+Cipher = aes-256-ccm
+Key = bae73483de27b581a7c13f178a6d7bda168c1b4a1cb9180512a13e3ab914eb61
+IV = daf54faef6e4fc7867624b76f2
+AAD = c4384069e09a3d4de2c94e7e6055d8a00394e268398d6ea32914097aec37a1f4
+Tag = ef0919c5f5daf093
+Plaintext = 18c5865b414b2a06b4d71ab9550985b4f3c3d7817e8a8d7c
+Ciphertext = 0549a110d83c6fb6ed8d815682b5c5207556558240de54ac
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = ba762bbda601d711e2dfc9dbe3003d39df1043ca845612b8e9dc9ff5c5d06ec4
+Tag = 01a4d765bc1c95c90a95
+Plaintext = 6aa6ea668df60b0db85592d0a819c9df9e1099916272aafb
+Ciphertext = 97027de5effd82c58f8dbfb909d7696fbe2d549162629120
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 77a685958ca801dbcbf346d6bac72662d3870899d7bcdef6665d57bacd4e558f
+Tag = 288aecb4c38c2391c21d
+Plaintext = c2992096828325820e2d7acaa17ac789b6830ec3128dd7f9
+Ciphertext = 3f3db715e088ac4a39f557a300b4673996bec3c3129dec22
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 3a54d3e14bbd0549570ef12425c4b36fd25382d56b68e217bc711ab1625fe9bb
+Tag = db4bd2cb1f1222e0d64f
+Plaintext = e5151262cafdd2f4dea187372dacb9e5975065572446f2a5
+Ciphertext = 18b185e1a8f65b3ce979aa5e8c621955b76da8572456c97e
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 5c7604f9ac8fdf30ee5820e5aeb75b65d7855e5d2ff9ccf021640707bf1f53e8
+Tag = 9283c1a61e9113462325
+Plaintext = 1fe786f52daab92a6aa5f43263bed74153d90579a34bceff
+Ciphertext = e24311764fa130e25d7dd95bc27077f173e4c879a35bf524
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 42b8863ea100babc1713654afcf54f21f8bff754223ad70269ace9d034f26a96
+Tag = bd3ffe1b1051ec3206db
+Plaintext = 56c3130c5af210b5bcf7c58b968fc75fc92b9c339efb7aee
+Ciphertext = ab67848f38f9997d8b2fe8e2374167efe91651339eeb4135
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = c5a369a8291f4278e797ff11ea5e777d69df3b9c0c32d46150ed4b3e2c3defdd
+Tag = 10d5d255f193b29eb961
+Plaintext = daa716f3cd1e008b46318ec90d976c3fbf88c3ff73cf0052
+Ciphertext = 27038170af15894371e9a3a0ac59cc8f9fb50eff73df3b89
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 63bdceb36a032d3e0e81b4e98ad9861e2c708cef4e870c5b88a87ecc24449be3
+Tag = 4e524729fb06212508e6
+Plaintext = 42477d7d44881dabccfce52efb8a2cc917b182a23b71fb49
+Ciphertext = bfe3eafe26839463fb24c8475a448c79378c4fa23b61c092
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = b7f8e7b66726e07c3c73d74135f068bb8025c9da9ba70affb9ed9a69675f0eef
+Tag = 222af86d91fb6a2b09d3
+Plaintext = 07f48cdc12aa27119fbdfda4ec07ce6068c92ba7ba9c9309
+Ciphertext = fa501b5f70a1aed9a865d0cd4dc96ed048f4e6a7ba8ca8d2
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 09891ed14f4488069cd6a5744061e06f8ff8d1bc87b10448b3fbfc1a4e327787
+Tag = 4cddcb65a76c40698017
+Plaintext = e2e7002b769fb5b4201053457158147d99b0d5147f3acac2
+Ciphertext = 1f4397a814943c7c17c87e2cd096b4cdb98d18147f2af119
+
+Cipher = aes-256-ccm
+Key = d5b321b0ac2fedce0933d57d12195c7b9941f4caa95529125ed21c41fac43374
+IV = b35fb2262edfa14938a0fba03e
+AAD = 8f9786940943752c536548497f9dae2bd8d677b8bbcb0121a9c9f3c399b62e4b
+Tag = ddb42d504b6fc47d6575
+Plaintext = 86be1d1949fe03b8b80ef7abb3e27394273d7b76d7697f0e
+Ciphertext = 7b1a8a9a2bf58a708fd6dac2122cd3240700b676d77944d5
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = 404f5df97ece7431987bc098cce994fc3c063b519ffa47b0365226a0015ef695
+Tag = 2927a053c9244d3217a7ad05
+Plaintext = 7ebef26bf4ecf6f0ebb2eb860edbf900f27b75b4a6340fdb
+Ciphertext = 353022db9c568bd7183a13c40b1ba30fcc768c54264aa2cd
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = e9ed05813262fbe769c1104d8ba5c836dbd229a22a681de3565d17ac1129f96b
+Tag = 1c000c9d88f047ca198c4e65
+Plaintext = fdf5a5fb377bb52ad07a971c6a9da3e1a68d279be9ac4ed7
+Ciphertext = b67b754b5fc1c80d23f26f5e6f5df9ee9880de7b69d2e3c1
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = f246f1e948c81c98ea13f03dd8eea878449d0c3d5b5fe87c633bbe0106fcb899
+Tag = 5c09878f1a963b795b29f4dd
+Plaintext = e5e6b57e74ce7afbde3697e2a69d61ca615aa3dfd32fe31f
+Ciphertext = ae6865ce1c7407dc2dbe6fa0a35d3bc55f575a3f53514e09
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = e4683285695348ff04a61d51d90b868dfe4cf6ea246544727adeaeface571d57
+Tag = 807d196d2628df1c384816f7
+Plaintext = ef2c3a6bb8602d290045854a5f223e6f43bfd0bb9278fa88
+Ciphertext = a4a2eadbd0da500ef3cd7d085ae264607db2295b1206579e
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = 42695369dbd69f07b46db282653704c34106aad82efdcc99b452598b5353f904
+Tag = 961c666279394e1e28cf1b02
+Plaintext = beda29c7fe15c73ee5bef96485eb8c9e3cd3ea7ee633ef45
+Ciphertext = f554f97796afba1916360126802bd69102de139e664d4253
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = 58c3ce3906633475441229cfcdf05e02ff3738ae8d1b255974f431b3309ed41e
+Tag = 64efe624dd6c6f8b8cdc76e3
+Plaintext = 419c96ba8142b27e3377716358c97a8a636d7fe8403165e1
+Ciphertext = 0a12460ae9f8cf59c0ff89215d0920855d608608c04fc8f7
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = a9c06d8029f8da31629c3a6ddceb6009220a69fc614af1c231ae8702b3a85d6e
+Tag = 0ef4b71970b9f80087533cf7
+Plaintext = 69bb441a7640f77e124d66af45a0e9f646658a838dfcb957
+Ciphertext = 223594aa1efa8a59e1c59eed4060b3f9786873630d821441
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = a92e88edd297da8c7089e21822b3e6cffd6837c78b975c8413fd6cca1b99bcb0
+Tag = 6e27dfbf1ff7f08d1b213848
+Plaintext = a45b755658d38bdea57d1faae21d75428a17f2c74a33d2d5
+Ciphertext = efd5a5e63069f6f956f5e7e8e7dd2f4db41a0b27ca4d7fc3
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = 421533453c8129fc8e681c68b9d7371adb0a19442ede7accd185129fcb7db648
+Tag = a48d1a0b815139fa28652d94
+Plaintext = 2c3e28b61cede08121e80ee08c4f1f19dabb19add9d2dc8a
+Ciphertext = 67b0f80674579da6d260f6a2898f4516e4b6e04d59ac719c
+
+Cipher = aes-256-ccm
+Key = 7f4af6765cad1d511db07e33aaafd57646ec279db629048aa6770af24849aa0d
+IV = dde2a362ce81b2b6913abc3095
+AAD = 55351bc7ddbc6b668d435088f1f9cf6f53caae16d4292b14bc0deec20f393ba0
+Tag = 1301c87a2a94df147c8cce4c
+Plaintext = 81fa7fd41ba267bcbdf024cef1543b041cadd96b62a7cf1f
+Ciphertext = ca74af6473181a9b4e78dc8cf494610b22a0208be2d96209
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = f1e0af185180d2eb63e50e37ba692647cac2c6a149d70c81dbd34685ed78feaa
+Tag = 5f82c828413643b8794494cb5236
+Plaintext = 138ee53b1914d3322c2dd0a4e02faab2236555131d5eea08
+Ciphertext = 5b2f3026f30fdd50accc40ddd093b7997f23d7c6d3c8bc42
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = 45c5c284836414407268d7c8a89a0146759cfc92242004027d58d0828fad74e7
+Tag = 6db5c92de5fb3aafba9537795e17
+Plaintext = fe3df84ee9b237f9edd77a5b8af96bc3e184579ac9c6e246
+Ciphertext = b69c2d5303a9399b6d36ea22ba4576e8bdc2d54f0750b40c
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = a41ea42692eac0914fef35e58409007342cef027de141223ffb46da7f58df034
+Tag = 1af6cf931ac943fd3affa6ad6fd1
+Plaintext = e0f5c02f9f84e57fada3f3575f1b1a748f360e0ea781b7b8
+Ciphertext = a8541532759feb1d2d42632e6fa7075fd3708cdb6917e1f2
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = 17dae00f2a9417780ecfef98f290a5ca9b17c873a9149cd81c18bd33164a0405
+Tag = 38a3f09c56ae653be49b355fb938
+Plaintext = 3a77a2ec5a1be6cbfbbfaab3e65427cb38d6798b132ff5c7
+Ciphertext = 72d677f1b000e8a97b5e3acad6e83ae06490fb5eddb9a38d
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = 33b44873a7a1e5b0fdbb7e7347623e4fa1ccd937feb26fda2749b42f00744e50
+Tag = 974deec7ce2e1f296890bee795cb
+Plaintext = d0628b26019dad84de628d9dabf42cfb195165a369c22b49
+Ciphertext = 98c35e3beb86a3e65e831de49b4831d04517e776a7547d03
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = f4fc5acff75d404849675b813cf7adcaeb8f3d56cb9a54a083f8ec07feb666bb
+Tag = 98a3bc56f900bee7e8271c6dab22
+Plaintext = 10b5ec41036e4bc5d61728e8811b520b7080c2177c122cbd
+Ciphertext = 5814395ce97545a756f6b891b1a74f202cc640c2b2847af7
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = ba051d1bc19b9a27520834fa3977b6413a319c9a52c8785e3e9594bd4265d911
+Tag = e6623d80c677633a9e4f999bb885
+Plaintext = 648a84813ca97aef4ab7e143ee29acb946388660f18eb671
+Ciphertext = 2c2b519cd6b2748dca56713ade95b1921a7e04b53f18e03b
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = f5c629299d18901c8c34c42e8fc29a70c377c160fdea4a6068a36867707575f7
+Tag = c65b88ff4fdd9b8187f7d71ba04b
+Plaintext = 3ead49ed0b41de79c829098d034b666bce052d79bf1f56db
+Ciphertext = 760c9cf0e15ad01b48c899f433f77b409243afac71890091
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = da486fd2953a72838e67e1909ed4042df67c355b648a45bcd2cc1ba610659e76
+Tag = 727c3404564ed41528973d389c7c
+Plaintext = 4543457c8fdf463c4bf8515a762cdc83d9aaa887d3eaa2af
+Ciphertext = 0de2906165c4485ecb19c1234690c1a885ec2a521d7cf4e5
+
+Cipher = aes-256-ccm
+Key = 5c8b59d3e7986c277d5ad51e4a2233251076809ebf59463f47cd10b4aa951f8c
+IV = 21ff892b743d661189e205c7f3
+AAD = a0b1d3600f6eba910a11537d61fa12184959f1c3ae386570cbbc9106f7a7ba07
+Tag = 46ecb536703a7a97928f80fcc7cf
+Plaintext = 22071ef5d204417f99bc2faf53ecc4c6cf795e77805633ee
+Ciphertext = 6aa6cbe8381f4f1d195dbfd66350d9ed933fdca24ec065a4
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = fab62b3e5deda7a9c1128663cc81c44b74ab1bfe70bc1c9dec7c7fd08173b80a
+Tag = 63ddd56464aed6d0613159d1aa181dcb
+Plaintext = a8be794613835c4366e75817d228438f011a2ec8a86f9797
+Ciphertext = cc3efe04d84a4ec5cb6a6c28dc2c2d386a359d9550dbdec9
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = b3ff11e57eeab41bc597622c770c9eea333e178d5bd5689c6a30011187a965b8
+Tag = 7c1273765bc5bfdeca429cc8ebd8aca2
+Plaintext = 7590769380dc91832da023798dfdd447b9f7adaa09d7e2d0
+Ciphertext = 1110f1d14b158305802d174683f9baf0d2d81ef7f163ab8e
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = 2a953a081c5d52bc500c9c12f56cd2aab5c920d73098335baa5d947100cb3411
+Tag = 886229c09b986bee3a8a3025c150d3a3
+Plaintext = 30e4de5e8c275677f8f4f7bbf9d101f96b38d79968ea028c
+Ciphertext = 5464591c47ee44f15579c384f7d56f4e001764c4905e4bd2
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = 99cc9d1b3db79640dfdc4423af3ded03c329f7ba5b6b509269c10e59519053b8
+Tag = 80cd04041918c4071ea5ac263f36c544
+Plaintext = 852698f6ab4aa794b3d657c4a2ca7b9c8bfb5fc9b4ad0aca
+Ciphertext = e1a61fb46083b5121e5b63fbacce152be0d4ec944c194394
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = b76aef71eaf03c2d0dc0623e90596fcb0bc4dbbed1d5bb24c8af37d778863e5b
+Tag = f001d6002eafaec49c472acdfaedf1de
+Plaintext = cd337fcf362d301d66916c7097bdeb31df8206e00f7ac106
+Ciphertext = a9b3f88dfde4229bcb1c584f99b98586b4adb5bdf7ce8858
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = 42a718d892e229a1807b74bd730fb15500ac4a790392100aef362cd7628d5806
+Tag = 75d86cde91b6610496c3bb5276238741
+Plaintext = 0041a0cf48fcf870b21db6107cfd9ef91e409afc7562ffa7
+Ciphertext = 64c1278d8335eaf61f90822f72f9f04e756f29a18dd6b6f9
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = e788c98ae85b11b3ae884eed6f3b8f5bcf5ab1b7b20ad3f44f760b2287cc5793
+Tag = db7d9f10e75d1b213beae0e0230dd82b
+Plaintext = fcc74ef1908dbcab9b05c76ee5a9941cdef933d433c0d25f
+Ciphertext = 9847c9b35b44ae2d3688f351ebadfaabb5d68089cb749b01
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = d330fc1ca406dd9528e9281aa1a3cdf013b698c14a4e55371e7539c9f6867dd4
+Tag = c63ba64291e73e6349ed089a53564291
+Plaintext = 611dade00cec14743be4e035cafe7507df5fb94b278875b1
+Ciphertext = 059d2aa2c72506f29669d40ac4fa1bb0b4700a16df3c3cef
+
+Cipher = aes-256-ccm
+Key = 60823b64e0b2da3a7eb772bd5941c534e6ff94ea96b564e2b38f82c78bb54522
+IV = 48526f1bffc97dd65e42906983
+AAD = 06bbadd5d22d1796d88415d7a4b024313f243bd0f58aafc75bb554a691d7e54f
+Tag = ac4d7bd964a2f9e2303df688dd0513da
+Plaintext = b67b5dd7f90ecd48a45853cb193e0d9702d78898f07e831d
+Ciphertext = d2fbda9532c7dfce09d567f4173a632069f83bc508caca43

--- a/util/cavs-to-evptest.pl
+++ b/util/cavs-to-evptest.pl
@@ -1,0 +1,121 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+#Convert CCM CAVS test vectors to a format suitable for evp_test
+
+use strict;
+use warnings;
+
+my $alg;
+my $mode;
+my $keylen;
+my $key = "";
+my $iv = "";
+my $aad = "";
+my $ct = "";
+my $pt = "";
+my $tag = "";
+my $aadlen = 0;
+my $ptlen = 0;
+my $taglen = 0;
+my $res = "";
+my $intest = 0;
+my $fixediv = 0;
+
+while (<STDIN>)
+{
+    chomp;
+
+    # Pull out the cipher mode from the comment at the beginning of the file
+    if(/^#\s*"([^-]+)-\w+" information/) {
+        $mode = lc($1);
+    # Pull out the key length from the comment at the beginning of the file
+    } elsif(/^#\s*(\w+) Keylen: (\d+)/) {
+        $alg = lc($1);
+        $keylen = $2;
+    # Some parameters common to many tests appear as a list in square brackets
+    # so parse these
+    } elsif(/\[(.*)\]/) {
+        my @pairs = split(/, /, $1);
+        foreach my $pair (@pairs) {
+            $pair =~ /(\w+)\s*=\s*(\d+)/;
+            # AAD Length
+            if ($1 eq "Alen") {
+                $aadlen = $2;
+            # Plaintext length
+            } elsif ($1 eq "Plen") {
+                $ptlen = $2;
+            # Tag length
+            } elsif ($1 eq "Tlen") {
+                $taglen = $2;
+            }
+        }
+    # Key/Value pair
+    } elsif (/^\s*(\w+)\s*=\s*(\S.*)\r/) {
+        if ($1 eq "Key") {
+            $key = $2;
+        } elsif ($1 eq "Nonce") {
+            $iv = $2;
+            if ($intest == 0) {
+                $fixediv = 1;
+            } else {
+                $fixediv = 0;
+            }
+        } elsif ($1 eq "Adata") {
+            $aad = $2;
+        } elsif ($1 eq "CT") {
+            $ct = substr($2, 0, length($2) - ($taglen * 2));
+            $tag = substr($2, $taglen * -2);
+        } elsif ($1 eq "Payload") {
+            $pt = $2;
+        } elsif ($1 eq "Result") {
+            if ($2 =~ /Fail/) {
+                $res = "CIPHERUPDATE_ERROR";
+            }
+        } elsif ($1 eq "Count") {
+            $intest = 1;
+        } elsif ($1 eq "Plen") {
+            $ptlen = $2;
+        } elsif ($1 eq "Tlen") {
+            $taglen = $2;
+        } elsif ($1 eq "Alen") {
+            $aadlen = $2;
+        }
+    # Something else - probably just a blank line
+    } elsif ($intest) {
+        print "Cipher = $alg-$keylen-$mode\n";
+        print "Key = $key\n";
+        print "IV = $iv\n";
+        print "AAD =";
+        if ($aadlen > 0) {
+            print " $aad";
+        }
+        print "\nTag =";
+        if ($taglen > 0) {
+            print " $tag";
+        }
+        print "\nPlaintext =";
+        if ($ptlen > 0) {
+            print " $pt";
+        }
+        print "\nCiphertext = $ct\n";
+        if ($res ne "") {
+            print "Operation = DECRYPT\n";
+            print "Result = $res\n";
+        }
+        print "\n";
+        $res = "";
+        if ($fixediv == 0) {
+            $iv = "";
+        }
+        $aad = "";
+        $tag = "";
+        $pt = "";
+        $intest = 0;
+    }
+}


### PR DESCRIPTION
This imports all of the NIST CAVS test vectors for CCM (SP800-38C) and
coverts them for use within evp_test. This commit also adds a script to
convert the .rsp CAVS files into the evp_test format. This script may work
for other CAVS test vectors but this is untested.