### PR TITLE
Fix <intypes.h> missing issues (Windows failure  in test) + (Apps opt.c failure).

### DIFF
--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -317,7 +317,8 @@ int opt_int(const char *arg, int *result);
 int opt_ulong(const char *arg, unsigned long *result);
 int opt_long(const char *arg, long *result);
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
-    defined(INTMAX_MAX) && defined(UINTMAX_MAX)
+    defined(INTMAX_MAX) && defined(UINTMAX_MAX) && \
+    !defined(OPENSSL_NO_INTTYPES_H)
 int opt_imax(const char *arg, intmax_t *result);
 int opt_umax(const char *arg, uintmax_t *result);
 #else

--- a/apps/opt.c
+++ b/apps/opt.c
@@ -377,7 +377,8 @@ int opt_long(const char *value, long *result)
 }
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
-    defined(INTMAX_MAX) && defined(UINTMAX_MAX)
+    defined(INTMAX_MAX) && defined(UINTMAX_MAX) && \
+    !defined(OPENSSL_NO_INTTYPES_H)
 
 /* Parse an intmax_t, put it into *result; return 0 on failure, else 1. */
 int opt_imax(const char *value, intmax_t *result)

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -228,6 +228,8 @@ extern "C" {
 # endif
 
 /* Standard integer types */
+# define OPENSSL_NO_INTTYPES_H
+# define OPENSSL_NO_STDINT_H
 # if defined(OPENSSL_SYS_UEFI)
 typedef INT8 int8_t;
 typedef UINT8 uint8_t;
@@ -241,6 +243,9 @@ typedef UINT64 uint64_t;
      defined(__osf__) || defined(__sgi) || defined(__hpux) || \
      defined(OPENSSL_SYS_VMS) || defined (__OpenBSD__)
 #  include <inttypes.h>
+#  undef OPENSSL_NO_INTTYPES_H
+/* Because the specs say that inttypes.h includes stdint.h if present */
+#  undef OPENSSL_NO_STDINT_H
 # elif defined(_MSC_VER) && _MSC_VER<=1500
 /*
  * minimally required typdefs for systems not supporting inttypes.h or
@@ -256,6 +261,7 @@ typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
 # else
 #  include <stdint.h>
+#  undef OPENSSL_NO_STDINT_H
 # endif
 
 /* ossl_inline: portable inline definition usable in public headers */

--- a/test/params_conversion_test.c
+++ b/test/params_conversion_test.c
@@ -9,13 +9,15 @@
  */
 
 #include <string.h>
-#include <inttypes.h>
 #include <openssl/params.h>
 #include "testutil.h"
 
-#ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
-#endif
+/* On machines that dont support <inttypes.h> just disable the tests */
+#if !defined(OPENSSL_NO_INTTYPES_H)
+
+# ifdef OPENSSL_SYS_WINDOWS
+#  define strcasecmp _stricmp
+# endif
 
 typedef struct {
     const OSSL_PARAM *param;
@@ -320,6 +322,8 @@ end:
     return res;
 }
 
+#endif /* OPENSSL_NO_INTTYPES_H */
+
 OPT_TEST_DECLARE_USAGE("file...\n")
 
 int setup_tests(void)
@@ -329,6 +333,9 @@ int setup_tests(void)
     if (n == 0)
         return 0;
 
+#if !defined(OPENSSL_NO_INTTYPES_H)
     ADD_ALL_TESTS(run_param_file_tests, n);
+#endif /* OPENSSL_NO_INTTYPES_H */
+
     return 1;
 }


### PR DESCRIPTION
including <inttypes.h> causes windows build failure, There seems to be no real dependancy on this file so it has been removed

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
