### PR TITLE
Configure: AIX needs a specific DSO extension function

### DIFF
--- a/Configurations/platform/AIX.pm
+++ b/Configurations/platform/AIX.pm
@@ -12,6 +12,7 @@ require platform::Unix;
 # Assume someone set @INC right before loading this module
 use configdata;
 
+sub dsoext              { '.so' }
 sub shlibextsimple      { '.a' }
 
 # In shared mode, the default static library names clashes with the final


### PR DESCRIPTION
DSO extensions are normally derived from platform->shlibextsimple() on
Unix.  This isn't the case for AIX, so it needs to define its own DSO
extension specifically.
