### PR TITLE
The SHA256 is not a mandatory digest for DSA.

### DIFF
--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -505,7 +505,7 @@ static int dsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
         *(int *)arg2 = NID_sha256;
-        return 2;
+        return 1;
 
     default:
         return -2;


### PR DESCRIPTION
The #7408 implemented mandatory digest checking in TLS.
However this broke compatibility of DSS support with GnuTLS
which supports only SHA1 with DSS.

There is no reason why SHA256 would be a mandatory digest
for DSA as other digests in SHA family can be used as well.
