### PR TITLE
Configure: make 'enable-buildtest-c++' work (not be a regexp)

### DIFF
--- a/Configure
+++ b/Configure
@@ -332,7 +332,7 @@ my @disablables = (
     "autoload-config",
     "bf",
     "blake2",
-    "buildtest-c++",
+    "buildtest-c\\+\\+",
     "camellia",
     "capieng",
     "cast",


### PR DESCRIPTION
OpenSSL 1.1.1's Configure treats the strings in @disablables as regexps,
which means that the 'buildtest-c++' option needs a bit of escaping to
be interpreted as intended.
