### PR TITLE
crypto/conf: openssl_config_int() returns unitialized value

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -42,7 +42,7 @@ void OPENSSL_config(const char *appname)
 
 int openssl_config_int(const OPENSSL_INIT_SETTINGS *settings)
 {
-    int ret;
+    int ret = 0;
     const char *filename;
     const char *appname;
     unsigned long flags;


### PR DESCRIPTION
openssl_config_int() returns the uninitialized variable `ret` when compiled with OPENSSL_SYS_UEFI.

Fixes #9026
