### PR TITLE
Make the RAND code available from within the FIPS module

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -36,7 +36,7 @@ static EX_CALLBACKS *get_and_lock(OPENSSL_CTX *ctx, int class_index)
     }
 
     global = openssl_ctx_get_ex_data_global(ctx);
-    if (global->ex_data_lock == NULL) {
+    if (global == NULL || global->ex_data_lock == NULL) {
         /*
          * This can happen in normal operation when using CRYPTO_mem_leaks().
          * The CRYPTO_mem_leaks() function calls OPENSSL_cleanup() which cleans

--- a/crypto/hmac/build.info
+++ b/crypto/hmac/build.info
@@ -1,6 +1,6 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        hmac.c hm_ameth.c hm_meth.c
 
-SOURCE[../../providers/fips]=\
-        hmac.c hm_meth.c
+$COMMON=hmac.c hm_meth.c
+
+SOURCE[../../libcrypto]=$COMMON hm_ameth.c
+SOURCE[../../providers/fips]=$COMMON

--- a/crypto/hmac/build.info
+++ b/crypto/hmac/build.info
@@ -1,3 +1,6 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         hmac.c hm_ameth.c hm_meth.c
+
+SOURCE[../../providers/fips]=\
+        hmac.c hm_meth.c

--- a/crypto/hmac/hm_meth.c
+++ b/crypto/hmac/hm_meth.c
@@ -153,7 +153,14 @@ static int hmac_ctrl_str(EVP_MAC_IMPL *hctx, const char *type,
     if (!value)
         return 0;
 #ifndef FIPS_MODE
-    /* Not supported in FIPS mode due to the implict fetch of the md */
+    /*
+     * We don't have EVP_get_digestbyname() in FIPS_MODE. That function returns
+     * an EVP_MD without an associated provider implementation (i.e. it is
+     * using "implict fetch"). We could replace it with an "explicit" fetch
+     * using EVP_MD_fetch(), but we'd then be required to free the returned
+     * EVP_MD somewhere. Probably the complexity isn't worth it as we are
+     * unlikely to need this ctrl in FIPS_MODE anyway.
+     */
     if (strcmp(type, "digest") == 0) {
         const EVP_MD *d = EVP_get_digestbyname(value);
 

--- a/crypto/hmac/hm_meth.c
+++ b/crypto/hmac/hm_meth.c
@@ -156,7 +156,7 @@ static int hmac_ctrl_str(EVP_MAC_IMPL *hctx, const char *type,
     /*
      * We don't have EVP_get_digestbyname() in FIPS_MODE. That function returns
      * an EVP_MD without an associated provider implementation (i.e. it is
-     * using "implict fetch"). We could replace it with an "explicit" fetch
+     * using "implicit fetch"). We could replace it with an "explicit" fetch
      * using EVP_MD_fetch(), but we'd then be required to free the returned
      * EVP_MD somewhere. Probably the complexity isn't worth it as we are
      * unlikely to need this ctrl in FIPS_MODE anyway.

--- a/crypto/hmac/hm_meth.c
+++ b/crypto/hmac/hm_meth.c
@@ -152,6 +152,8 @@ static int hmac_ctrl_str(EVP_MAC_IMPL *hctx, const char *type,
 {
     if (!value)
         return 0;
+#ifndef FIPS_MODE
+    /* Not supported in FIPS mode due to the implict fetch of the md */
     if (strcmp(type, "digest") == 0) {
         const EVP_MD *d = EVP_get_digestbyname(value);
 
@@ -159,6 +161,7 @@ static int hmac_ctrl_str(EVP_MAC_IMPL *hctx, const char *type,
             return 0;
         return hmac_ctrl_int(hctx, EVP_MAC_CTRL_SET_MD, d);
     }
+#endif
     if (strcmp(type, "key") == 0)
         return EVP_str2ctrl(hmac_ctrl_str_cb, hctx, EVP_MAC_CTRL_SET_KEY,
                             value);

--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -1,10 +1,7 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        randfile.c rand_lib.c rand_err.c rand_crng_test.c rand_egd.c \
-        rand_win.c rand_unix.c rand_vms.c drbg_lib.c drbg_ctr.c rand_vxworks.c \
-        drbg_hash.c drbg_hmac.c
 
-# FIPS Module
-SOURCE[../../providers/fips]=\
-        rand_lib.c rand_crng_test.c rand_win.c rand_unix.c  rand_vms.c \
+$COMMON=rand_lib.c rand_crng_test.c rand_win.c rand_unix.c  rand_vms.c \
         drbg_lib.c drbg_ctr.c rand_vxworks.c drbg_hash.c drbg_hmac.c
+
+SOURCE[../../libcrypto]=$COMMON randfile.c rand_err.c rand_egd.c
+SOURCE[../../providers/fips]=$COMMON

--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -3,3 +3,8 @@ SOURCE[../../libcrypto]=\
         randfile.c rand_lib.c rand_err.c rand_crng_test.c rand_egd.c \
         rand_win.c rand_unix.c rand_vms.c drbg_lib.c drbg_ctr.c rand_vxworks.c \
         drbg_hash.c drbg_hmac.c
+
+# FIPS Module
+SOURCE[../../providers/fips]=\
+        rand_lib.c rand_crng_test.c rand_win.c rand_unix.c  rand_vms.c \
+        drbg_lib.c drbg_ctr.c rand_vxworks.c drbg_hash.c drbg_hmac.c

--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -354,6 +354,7 @@ static int drbg_ctr_uninstantiate(RAND_DRBG *drbg)
 {
     EVP_CIPHER_CTX_free(drbg->data.ctr.ctx);
     EVP_CIPHER_CTX_free(drbg->data.ctr.ctx_df);
+    EVP_CIPHER_meth_free(drbg->data.ctr.cipher);
     OPENSSL_cleanse(&drbg->data.ctr, sizeof(drbg->data.ctr));
     return 1;
 }
@@ -369,6 +370,7 @@ int drbg_ctr_init(RAND_DRBG *drbg)
 {
     RAND_DRBG_CTR *ctr = &drbg->data.ctr;
     size_t keylen;
+    EVP_CIPHER *cipher = NULL;
 
     switch (drbg->type) {
     default:
@@ -376,17 +378,22 @@ int drbg_ctr_init(RAND_DRBG *drbg)
         return 0;
     case NID_aes_128_ctr:
         keylen = 16;
-        ctr->cipher = EVP_aes_128_ecb();
+        cipher = EVP_CIPHER_fetch(drbg->libctx, "AES-128-ECB", "");
         break;
     case NID_aes_192_ctr:
         keylen = 24;
-        ctr->cipher = EVP_aes_192_ecb();
+        cipher = EVP_CIPHER_fetch(drbg->libctx, "AES-192-ECB", "");
         break;
     case NID_aes_256_ctr:
         keylen = 32;
-        ctr->cipher = EVP_aes_256_ecb();
+        cipher = EVP_CIPHER_fetch(drbg->libctx, "AES-256-ECB", "");
         break;
     }
+    if (cipher == NULL)
+        return 0;
+
+    EVP_CIPHER_meth_free(ctr->cipher);
+    ctr->cipher = cipher;
 
     drbg->meth = &drbg_ctr_meth;
 

--- a/crypto/rand/drbg_hash.c
+++ b/crypto/rand/drbg_hash.c
@@ -289,6 +289,7 @@ static int drbg_hash_generate(RAND_DRBG *drbg,
 
 static int drbg_hash_uninstantiate(RAND_DRBG *drbg)
 {
+    EVP_MD_meth_free(drbg->data.hash.md);
     EVP_MD_CTX_free(drbg->data.hash.ctx);
     OPENSSL_cleanse(&drbg->data.hash, sizeof(drbg->data.hash));
     return 1;
@@ -303,22 +304,38 @@ static RAND_DRBG_METHOD drbg_hash_meth = {
 
 int drbg_hash_init(RAND_DRBG *drbg)
 {
-    const EVP_MD *md;
+    EVP_MD *md;
     RAND_DRBG_HASH *hash = &drbg->data.hash;
 
+#ifndef FIPS_MODE
     /* Any approved digest is allowed */
-    md = EVP_get_digestbynid(drbg->type);
+    md = EVP_MD_meth_dup(EVP_get_digestbynid(drbg->type));
+#else
+    /* TODO(3.0): Fill this out with the complete list of allowed digests */
+    switch (drbg->type) {
+    default:
+        return 0;
+    case NID_sha256:
+        md = EVP_MD_fetch(drbg->libctx, "SHA256", "");
+        break;
+    }
+#endif
     if (md == NULL)
         return 0;
 
+
     drbg->meth = &drbg_hash_meth;
-    hash->md = md;
 
     if (hash->ctx == NULL) {
         hash->ctx = EVP_MD_CTX_new();
-        if (hash->ctx == NULL)
+        if (hash->ctx == NULL) {
+            EVP_MD_meth_free(md);
             return 0;
+        }
     }
+
+    EVP_MD_meth_free(hash->md);
+    hash->md = md;
 
     /* These are taken from SP 800-90 10.1 Table 2 */
     hash->blocklen = EVP_MD_size(md);

--- a/crypto/rand/drbg_hmac.c
+++ b/crypto/rand/drbg_hmac.c
@@ -13,6 +13,7 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include "internal/thread_once.h"
+#include "internal/providercommon.h"
 #include "rand_lcl.h"
 
 /*
@@ -201,19 +202,35 @@ int drbg_hmac_init(RAND_DRBG *drbg)
     EVP_MD *md = NULL;
     RAND_DRBG_HMAC *hmac = &drbg->data.hmac;
 
-#ifndef FIPS_MODE
-    /* Any approved digest is allowed - assume we pass digest (not NID_hmac*) */
-    md = EVP_MD_meth_dup(EVP_get_digestbynid(drbg->type));
-#else
-    /* TODO(3.0): Fill this out with the complete list of allowed digests */
+    /*
+     * Confirm digest is allowed. Outside FIPS_MODE we allow all non-legacy
+     * digests. Inside FIPS_MODE we only allow approved digests. Also no XOF
+     * digests (such as SHAKE).
+     */
     switch (drbg->type) {
     default:
         return 0;
+
+    case NID_sha1:
+    case NID_sha224:
     case NID_sha256:
-        md = EVP_MD_fetch(drbg->libctx, "SHA256", "");
+    case NID_sha384:
+    case NID_sha512:
+    case NID_sha512_224:
+    case NID_sha512_256:
+    case NID_sha3_224:
+    case NID_sha3_256:
+    case NID_sha3_384:
+    case NID_sha3_512:
+#ifndef FIPS_MODE
+    case NID_blake2b512:
+    case NID_blake2s256:
+    case NID_sm3:
+#endif
         break;
     }
-#endif
+
+    md = EVP_MD_fetch(drbg->libctx, ossl_prov_util_nid_to_name(drbg->type), "");
     if (md == NULL)
         return 0;
 

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -1339,7 +1339,8 @@ RAND_DRBG *OPENSSL_CTX_get0_public_drbg(OPENSSL_CTX *ctx)
 
     drbg = CRYPTO_THREAD_get_local(&dgbl->public_drbg);
     if (drbg == NULL) {
-        if (!ossl_init_thread_start(NULL, NULL, drbg_delete_thread_state))
+        ctx = openssl_ctx_get_concrete(ctx);
+        if (!ossl_init_thread_start(NULL, ctx, drbg_delete_thread_state))
             return NULL;
         drbg = drbg_setup(ctx, dgbl->master_drbg, RAND_DRBG_TYPE_PUBLIC);
         CRYPTO_THREAD_set_local(&dgbl->public_drbg, drbg);
@@ -1366,7 +1367,8 @@ RAND_DRBG *OPENSSL_CTX_get0_private_drbg(OPENSSL_CTX *ctx)
 
     drbg = CRYPTO_THREAD_get_local(&dgbl->private_drbg);
     if (drbg == NULL) {
-        if (!ossl_init_thread_start(NULL, NULL, drbg_delete_thread_state))
+        ctx = openssl_ctx_get_concrete(ctx);
+        if (!ossl_init_thread_start(NULL, ctx, drbg_delete_thread_state))
             return NULL;
         drbg = drbg_setup(ctx, dgbl->master_drbg, RAND_DRBG_TYPE_PRIVATE);
         CRYPTO_THREAD_set_local(&dgbl->private_drbg, drbg);

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -17,6 +17,7 @@
 # include <openssl/ec.h>
 # include <openssl/rand_drbg.h>
 # include "internal/tsan_assist.h"
+# include "internal/rand_int.h"
 
 # include "internal/numbers.h"
 
@@ -129,7 +130,7 @@ typedef struct rand_drbg_method_st {
 #define HASH_PRNG_MAX_SEEDLEN    (888/8)
 
 typedef struct rand_drbg_hash_st {
-    const EVP_MD *md;
+    EVP_MD *md;
     EVP_MD_CTX *ctx;
     size_t blocklen;
     unsigned char V[HASH_PRNG_MAX_SEEDLEN];
@@ -139,7 +140,7 @@ typedef struct rand_drbg_hash_st {
 } RAND_DRBG_HASH;
 
 typedef struct rand_drbg_hmac_st {
-    const EVP_MD *md;
+    EVP_MD *md;
     HMAC_CTX *ctx;
     size_t blocklen;
     unsigned char K[EVP_MAX_MD_SIZE];
@@ -152,7 +153,7 @@ typedef struct rand_drbg_hmac_st {
 typedef struct rand_drbg_ctr_st {
     EVP_CIPHER_CTX *ctx;
     EVP_CIPHER_CTX *ctx_df;
-    const EVP_CIPHER *cipher;
+    EVP_CIPHER *cipher;
     size_t keylen;
     unsigned char K[32];
     unsigned char V[16];
@@ -336,10 +337,11 @@ int drbg_hmac_init(RAND_DRBG *drbg);
  * Entropy call back for the FIPS 140-2 section 4.9.2 Conditional Tests.
  * These need to be exposed for the unit tests.
  */
-int rand_crngt_get_entropy_cb(OPENSSL_CTX *ctx, unsigned char *buf,
-                              unsigned char *md, unsigned int *md_size);
-extern int (*crngt_get_entropy)(OPENSSL_CTX *ctx, unsigned char *buf,
-                                unsigned char *md,
+int rand_crngt_get_entropy_cb(OPENSSL_CTX *ctx, RAND_POOL *pool,
+                              unsigned char *buf, unsigned char *md,
+                              unsigned int *md_size);
+extern int (*crngt_get_entropy)(OPENSSL_CTX *ctx, RAND_POOL *pool,
+                                unsigned char *buf, unsigned char *md,
                                 unsigned int *md_size);
 
 #endif

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -285,7 +285,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
 
     if (getentropy != NULL)
         return getentropy(buf, buflen) == 0 ? (ssize_t)buflen : -1;
-#  else
+#  elif !defined(FIPS_MODE)
     union {
         void *p;
         int (*f)(void *buffer, size_t length);

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -162,7 +162,7 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     return rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-# if !OPENSSL_API_1_1_0 || defined(FIPS_MODE)
+# if !OPENSSL_API_1_1_0 && !defined(FIPS_MODE)
 int RAND_event(UINT iMsg, WPARAM wParam, LPARAM lParam)
 {
     RAND_poll();

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -162,7 +162,7 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     return rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-# if !OPENSSL_API_1_1_0
+# if !OPENSSL_API_1_1_0 || defined(FIPS_MODE)
 int RAND_event(UINT iMsg, WPARAM wParam, LPARAM lParam)
 {
     RAND_poll();

--- a/doc/internal/man3/ossl_prov_util_nid_to_name.pod
+++ b/doc/internal/man3/ossl_prov_util_nid_to_name.pod
@@ -1,0 +1,35 @@
+=pod
+
+=head1 NAME
+
+ossl_prov_util_nid_to_name
+- provider utility functions
+
+=head1 SYNOPSIS
+
+ #include "internal/providercommon.h"
+
+ const char *ossl_prov_util_nid_to_name(int nid);
+
+=head1 DESCRIPTION
+
+The ossl_prov_util_nid_to_name() returns the name of an algorithm given a NID
+in the B<nid> parameter. For the default and legacy providers it is equivalent
+to calling OBJ_nid2sn(). The FIPS provider does not have the object database
+code available to it (because that code relies on the ASN.1 code), so this
+function is a static lookup of all known FIPS algorithm NIDs.
+
+=head1 RETURN VALUES
+
+Returns a pointer to the algorithm name, or NULL on error.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,4 +1,4 @@
 SUBDIRS=digests ciphers
 
 SOURCE[../../libcrypto]=\
-        provider_err.c
+        provider_err.c provlib.c

--- a/providers/common/include/internal/providercommon.h
+++ b/providers/common/include/internal/providercommon.h
@@ -7,4 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/provider.h>
+
 const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx);
+
+const char *ossl_prov_util_nid_to_name(int nid);

--- a/providers/common/provlib.c
+++ b/providers/common/provlib.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/objects.h>
+#include "internal/providercommon.h"
+
+/*
+ * The FIPS provider has its own version of this in fipsprov.c because it does
+ * not have OBJ_nid2sn();
+ */
+const char *ossl_prov_util_nid_to_name(int nid)
+{
+   return OBJ_nid2sn(nid); 
+}
+

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -15,8 +15,11 @@
 #include <openssl/params.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+
 /* TODO(3.0): Needed for dummy_evp_call(). To be removed */
 #include <openssl/sha.h>
+#include <openssl/rand_drbg.h>
+
 #include "internal/cryptlib.h"
 #include "internal/property.h"
 #include "internal/evp_int.h"
@@ -85,8 +88,10 @@ static int dummy_evp_call(void *provctx)
     int ret = 0;
     BN_CTX *bnctx = NULL;
     BIGNUM *a = NULL, *b = NULL;
+    unsigned char randbuf[128];
+    RAND_DRBG *drbg = OPENSSL_CTX_get0_public_drbg(libctx);
 
-    if (ctx == NULL || sha256 == NULL)
+    if (ctx == NULL || sha256 == NULL || drbg == NULL)
         goto err;
 
     if (!EVP_DigestInit_ex(ctx, sha256, NULL))
@@ -112,6 +117,9 @@ static int dummy_evp_call(void *provctx)
         || BN_cmp(a, b) != 0)
         goto err;
     
+    if (RAND_DRBG_bytes(drbg, randbuf, sizeof(randbuf)) <= 0)
+        goto err;
+
     ret = 1;
  err:
     BN_CTX_end(bnctx);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -153,6 +153,60 @@ static int fips_get_params(const OSSL_PROVIDER *prov,
     return 1;
 }
 
+/* FIPS specific version of the function of the same name in provlib.c */
+const char *ossl_prov_util_nid_to_name(int nid)
+{
+    /* We don't have OBJ_nid2n() in FIPS_MODE so we have an explicit list */
+
+    switch (nid) {
+    /* Digests */
+    case NID_sha1:
+        return "SHA224";
+    case NID_sha224:
+        return "SHA224";
+    case NID_sha256:
+        return "SHA256";
+    case NID_sha384:
+        return "SHA384";
+    case NID_sha512:
+        return "SHA512";
+    case NID_sha512_224:
+        return "SHA512-224";
+    case NID_sha512_256:
+        return "SHA512-256";
+    case NID_sha3_224:
+        return "SHA3-224";
+    case NID_sha3_256:
+        return "SHA3-256";
+    case NID_sha3_384:
+        return "SHA3-384";
+    case NID_sha3_512:
+        return "SHA3-512";
+
+    /* Ciphers */
+    case NID_aes_256_ecb:
+        return "AES-256-ECB";
+    case NID_aes_192_ecb:
+        return "AES-192-ECB";
+    case NID_aes_128_ecb:
+        return "AES-128-ECB";
+    case NID_aes_256_cbc:
+        return "AES-256-CBC";
+    case NID_aes_192_cbc:
+        return "AES-192-CBC";
+    case NID_aes_128_cbc:
+        return "AES-128-CBC";
+    case NID_aes_256_ctr:
+        return "AES-256-CTR";
+    case NID_aes_192_ctr:
+        return "AES-192-CTR";
+    case NID_aes_128_ctr:
+        return "AES-128-CTR";
+    }
+
+    return NULL;
+}
+
 static const OSSL_ALGORITHM fips_digests[] = {
     { "SHA1", "fips=yes", sha1_functions },
     { "SHA224", "fips=yes", sha224_functions },

--- a/test/build.info
+++ b/test/build.info
@@ -371,13 +371,13 @@ IF[{- !$disabled{tests} -}]
   DEPEND[recordlentest]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[drbgtest]=drbgtest.c
-  INCLUDE[drbgtest]=../include ../apps/include
+  INCLUDE[drbgtest]=../include ../apps/include ../crypto/include
   DEPEND[drbgtest]=../libcrypto.a libtestutil.a
 
   SOURCE[drbg_cavs_test]=drbg_cavs_test.c drbg_cavs_data_ctr.c \
                          drbg_cavs_data_hash.c drbg_cavs_data_hmac.c
 
-  INCLUDE[drbg_cavs_test]=../include ../apps/include . ..
+  INCLUDE[drbg_cavs_test]=../include ../apps/include . .. ../crypto/include
   DEPEND[drbg_cavs_test]=../libcrypto libtestutil.a
 
   SOURCE[x509_dup_cert_test]=x509_dup_cert_test.c

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -1264,8 +1264,8 @@ static const size_t crngt_num_cases = 6;
 
 static size_t crngt_case, crngt_idx;
 
-static int crngt_entropy_cb(OPENSSL_CTX *ctx, unsigned char *buf,
-                            unsigned char *md,
+static int crngt_entropy_cb(OPENSSL_CTX *ctx, RAND_POOL *pool,
+                            unsigned char *buf, unsigned char *md,
                             unsigned int *md_size)
 {
     size_t i, z;


### PR DESCRIPTION
This enables calls to RAND_*() functions from within the FIPS module. This is required in order to bring in support for BIGNUM, and the various asymmetric algorithms.

I've added a dummy call into the FIPS module just to demonstrate that it works. This will be removed in due course when we no longer need it.

