### PR TITLE
Make basic AES ciphers available from within the FIPS providers

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -287,7 +287,17 @@ DSO_ASFLAGS={- join(' ', $target{dso_asflags} || (),
                          @{$config{module_asflags}},
                          '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
 DSO_CPPFLAGS={- join(' ', $target{dso_cppflags} || (),
-                          $target{module_cppflags} || (),
+                          $target{module_cppflag} || (),
+                          (map { '-D'.quotify1($_) }
+                               @{$target{dso_defines}},
+                               @{$target{module_defines}},
+                               @{$config{dso_defines}},
+                               @{$config{module_defines}}),
+                          (map { '-I'.quotify1($_) }
+                               @{$target{dso_includes}},
+                               @{$target{module_includes}},
+                               @{$config{dso_includes}},
+                               @{$config{module_includes}}),
                           @{$config{dso_cppflags}},
                           @{$config{module_cppflags}},
                           '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}

--- a/Configure
+++ b/Configure
@@ -1400,7 +1400,10 @@ if ($target{sys_id} ne "")
 
 unless ($disabled{asm}) {
     $target{cpuid_asm_src}=$table{DEFAULTS}->{cpuid_asm_src} if ($config{processor} eq "386");
-    push @{$config{lib_defines}}, "OPENSSL_CPUID_OBJ" if ($target{cpuid_asm_src} ne "mem_clr.c");
+    if ($target{cpuid_asm_src} ne "mem_clr.c") {
+        push @{$config{lib_defines}}, "OPENSSL_CPUID_OBJ";
+        push @{$config{dso_defines}}, "OPENSSL_CPUID_OBJ";
+    }
 
     $target{bn_asm_src} =~ s/\w+-gf2m.c// if (defined($disabled{ec2m}));
 
@@ -1432,15 +1435,30 @@ unless ($disabled{asm}) {
         push @{$config{lib_defines}}, "RMD160_ASM";
     }
     if ($target{aes_asm_src}) {
-        push @{$config{lib_defines}}, "AES_ASM" if ($target{aes_asm_src} =~ m/\baes-/);;
+        if ($target{aes_asm_src} =~ m/\baes-/) {
+            push @{$config{lib_defines}}, "AES_ASM";
+            push @{$config{dso_defines}}, "AES_ASM";
+        }
         # aes-ctr.fake is not a real file, only indication that assembler
         # module implements AES_ctr32_encrypt...
-        push @{$config{lib_defines}}, "AES_CTR_ASM" if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//);
+        if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//) {
+            push @{$config{lib_defines}}, "AES_CTR_ASM";
+            push @{$config{dso_defines}}, "AES_CTR_ASM";
+        }
         # aes-xts.fake indicates presence of AES_xts_[en|de]crypt...
-        push @{$config{lib_defines}}, "AES_XTS_ASM" if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//);
+        if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//) {
+            push @{$config{lib_defines}}, "AES_XTS_ASM";
+            push @{$config{dso_defines}}, "AES_XTS_ASM";
+        }
         $target{aes_asm_src} =~ s/\s*(vpaes|aesni)-x86\.s//g if ($disabled{sse2});
-        push @{$config{lib_defines}}, "VPAES_ASM" if ($target{aes_asm_src} =~ m/vpaes/);
-        push @{$config{lib_defines}}, "BSAES_ASM" if ($target{aes_asm_src} =~ m/bsaes/);
+        if ($target{aes_asm_src} =~ m/vpaes/) {
+            push @{$config{lib_defines}}, "VPAES_ASM";
+            push @{$config{dso_defines}}, "VPAES_ASM";
+        }
+        if ($target{aes_asm_src} =~ m/bsaes/) {
+            push @{$config{lib_defines}}, "BSAES_ASM";
+            push @{$config{dso_defines}}, "BSAES_ASM";
+        }
     }
     if ($target{wp_asm_src} =~ /mmx/) {
         if ($config{processor} eq "386") {

--- a/Configure
+++ b/Configure
@@ -1402,7 +1402,7 @@ unless ($disabled{asm}) {
     $target{cpuid_asm_src}=$table{DEFAULTS}->{cpuid_asm_src} if ($config{processor} eq "386");
     if ($target{cpuid_asm_src} ne "mem_clr.c") {
         push @{$config{lib_defines}}, "OPENSSL_CPUID_OBJ";
-        push @{$config{dso_defines}}, "OPENSSL_CPUID_OBJ";
+        push @{$config{module_defines}}, "OPENSSL_CPUID_OBJ";
     }
 
     $target{bn_asm_src} =~ s/\w+-gf2m.c// if (defined($disabled{ec2m}));
@@ -1437,27 +1437,27 @@ unless ($disabled{asm}) {
     if ($target{aes_asm_src}) {
         if ($target{aes_asm_src} =~ m/\baes-/) {
             push @{$config{lib_defines}}, "AES_ASM";
-            push @{$config{dso_defines}}, "AES_ASM";
+            push @{$config{module_defines}}, "AES_ASM";
         }
         # aes-ctr.fake is not a real file, only indication that assembler
         # module implements AES_ctr32_encrypt...
         if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//) {
             push @{$config{lib_defines}}, "AES_CTR_ASM";
-            push @{$config{dso_defines}}, "AES_CTR_ASM";
+            push @{$config{module_defines}}, "AES_CTR_ASM";
         }
         # aes-xts.fake indicates presence of AES_xts_[en|de]crypt...
         if ($target{aes_asm_src} =~ s/\s*aes-xts\.fake//) {
             push @{$config{lib_defines}}, "AES_XTS_ASM";
-            push @{$config{dso_defines}}, "AES_XTS_ASM";
+            push @{$config{module_defines}}, "AES_XTS_ASM";
         }
         $target{aes_asm_src} =~ s/\s*(vpaes|aesni)-x86\.s//g if ($disabled{sse2});
         if ($target{aes_asm_src} =~ m/vpaes/) {
             push @{$config{lib_defines}}, "VPAES_ASM";
-            push @{$config{dso_defines}}, "VPAES_ASM";
+            push @{$config{module_defines}}, "VPAES_ASM";
         }
         if ($target{aes_asm_src} =~ m/bsaes/) {
             push @{$config{lib_defines}}, "BSAES_ASM";
-            push @{$config{dso_defines}}, "BSAES_ASM";
+            push @{$config{module_defines}}, "BSAES_ASM";
         }
     }
     if ($target{wp_asm_src} =~ /mmx/) {

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -3,6 +3,10 @@ SOURCE[../../libcrypto]=\
         aes_misc.c aes_ecb.c aes_cfb.c aes_ofb.c \
         aes_ige.c aes_wrap.c {- $target{aes_asm_src} -}
 
+SOURCE[../../providers/fips]=\
+        aes_misc.c aes_ecb.c aes_cfb.c aes_ofb.c \
+        {- $target{aes_asm_src} -}
+
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 
 GENERATE[aes-586.s]=asm/aes-586.pl \

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -4,7 +4,7 @@ SOURCE[../../libcrypto]=\
         aes_ige.c aes_wrap.c {- $target{aes_asm_src} -}
 
 SOURCE[../../providers/fips]=\
-        aes_misc.c aes_ecb.c aes_cfb.c aes_ofb.c \
+        aes_misc.c aes_ecb.c \
         {- $target{aes_asm_src} -}
 
 GENERATE[aes-ia64.s]=asm/aes-ia64.S

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -26,9 +26,9 @@ SOURCE[../libcrypto]=\
 
 # FIPS module
 SOURCE[../providers/fips]=\
-        cryptlib.c mem.c mem_clr.c params.c bsearch.c ex_data.c o_str.c \
+        cryptlib.c mem.c params.c bsearch.c ex_data.c o_str.c \
         ctype.c threads_pthread.c threads_win.c threads_none.c context.c \
-        sparse_array.c
+        sparse_array.c {- $target{cpuid_asm_src} -}
 
 
 DEPEND[cversion.o]=buildinf.h

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -4,6 +4,10 @@ SOURCE[../../libcrypto]=\
         ccm128.c xts128.c wrap128.c ocb128.c siv128.c \
         {- $target{modes_asm_src} -}
 
+SOURCE[../../providers/fips]=\
+        cbc128.c ctr128.c cfb128.c ofb128.c \
+        {- $target{modes_asm_src} -}
+
 INCLUDE[gcm128.o]=..
 
 GENERATE[ghash-ia64.s]=asm/ghash-ia64.pl $(LIB_CFLAGS) $(LIB_CPPFLAGS)

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -38,7 +38,12 @@ unsigned int OPENSSL_ppccap_P = 0;
 
 static sigset_t all_masked;
 
-#ifdef OPENSSL_BN_ASM_MONT
+/*
+ * TODO(3.0): Temporarily disabled some assembler that hasn't been brought into
+ * the FIPS module yet.
+ */
+#ifndef FIPS_MODE
+# ifdef OPENSSL_BN_ASM_MONT
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, int num)
 {
@@ -63,7 +68,7 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
 
     return bn_mul_mont_int(rp, ap, bp, np, n0, num);
 }
-#endif
+# endif
 
 void sha256_block_p8(void *ctx, const void *inp, size_t len);
 void sha256_block_ppc(void *ctx, const void *inp, size_t len);
@@ -83,7 +88,7 @@ void sha512_block_data_order(void *ctx, const void *inp, size_t len)
         sha512_block_ppc(ctx, inp, len);
 }
 
-#ifndef OPENSSL_NO_CHACHA
+# ifndef OPENSSL_NO_CHACHA
 void ChaCha20_ctr32_int(unsigned char *out, const unsigned char *inp,
                         size_t len, const unsigned int key[8],
                         const unsigned int counter[4]);
@@ -103,9 +108,9 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
             ? ChaCha20_ctr32_vmx(out, inp, len, key, counter)
             : ChaCha20_ctr32_int(out, inp, len, key, counter);
 }
-#endif
+# endif
 
-#ifndef OPENSSL_NO_POLY1305
+# ifndef OPENSSL_NO_POLY1305
 void poly1305_init_int(void *ctx, const unsigned char key[16]);
 void poly1305_blocks(void *ctx, const unsigned char *inp, size_t len,
                          unsigned int padbit);
@@ -139,9 +144,9 @@ int poly1305_init(void *ctx, const unsigned char key[16], void *func[2])
     }
     return 1;
 }
-#endif
+# endif
 
-#ifdef ECP_NISTZ256_ASM
+# ifdef ECP_NISTZ256_ASM
 void ecp_nistz256_mul_mont(unsigned long res[4], const unsigned long a[4],
                            const unsigned long b[4]);
 
@@ -163,7 +168,8 @@ void ecp_nistz256_from_mont(unsigned long res[4], const unsigned long in[4])
 
     ecp_nistz256_mul_mont(res, in, one);
 }
-#endif
+# endif
+#endif /* FIPS_MODE */
 
 static sigjmp_buf ill_jmp;
 static void ill_handler(int sig)

--- a/crypto/sparcv9cap.c
+++ b/crypto/sparcv9cap.c
@@ -24,6 +24,11 @@ __attribute__ ((visibility("hidden")))
 #endif
 unsigned int OPENSSL_sparcv9cap_P[2] = { SPARCV9_TICK_PRIVILEGED, 0 };
 
+/*
+ * TODO(3.0): Temporarily disabled some assembler that hasn't been brought into
+ * the FIPS module yet.
+ */
+#ifndef FIPS_MODE
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, int num)
 {
@@ -86,6 +91,7 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
     }
     return bn_mul_mont_int(rp, ap, bp, np, n0, num);
 }
+#endif /* FIPS_MODE */
 
 unsigned long _sparcv9_rdtick(void);
 void _sparcv9_vis1_probe(void);

--- a/providers/common/ciphers/build.info
+++ b/providers/common/ciphers/build.info
@@ -5,3 +5,4 @@ INCLUDE[../../../libcrypto]=. ../../../crypto
 
 SOURCE[../../fips]=\
         block.c aes.c aes_basic.c
+INCLUDE[../../fips]=. ../../../crypto

--- a/providers/common/ciphers/build.info
+++ b/providers/common/ciphers/build.info
@@ -2,3 +2,6 @@ LIBS=../../../libcrypto
 SOURCE[../../../libcrypto]=\
         block.c aes.c aes_basic.c
 INCLUDE[../../../libcrypto]=. ../../../crypto
+
+SOURCE[../../fips]=\
+        block.c aes.c aes_basic.c

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -20,6 +20,7 @@
 #include "internal/cryptlib.h"
 #include "internal/property.h"
 #include "internal/evp_int.h"
+#include "internal/provider_algs.h"
 
 /* Functions provided by the core */
 static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
@@ -92,10 +93,21 @@ static int fips_get_params(const OSSL_PROVIDER *prov,
     return 1;
 }
 
-extern const OSSL_DISPATCH sha256_functions[];
-
 static const OSSL_ALGORITHM fips_digests[] = {
     { "SHA256", "fips=yes", sha256_functions },
+    { NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM fips_ciphers[] = {
+    { "AES-256-ECB", "fips=yes", aes256ecb_functions },
+    { "AES-192-ECB", "fips=yes", aes192ecb_functions },
+    { "AES-128-ECB", "fips=yes", aes128ecb_functions },
+    { "AES-256-CBC", "fips=yes", aes256cbc_functions },
+    { "AES-192-CBC", "fips=yes", aes192cbc_functions },
+    { "AES-128-CBC", "fips=yes", aes128cbc_functions },
+    { "AES-256-CTR", "fips=yes", aes256ctr_functions },
+    { "AES-192-CTR", "fips=yes", aes192ctr_functions },
+    { "AES-128-CTR", "fips=yes", aes128ctr_functions },
     { NULL, NULL, NULL }
 };
 
@@ -107,6 +119,8 @@ static const OSSL_ALGORITHM *fips_query(OSSL_PROVIDER *prov,
     switch (operation_id) {
     case OSSL_OP_DIGEST:
         return fips_digests;
+    case OSSL_OP_CIPHER:
+        return fips_ciphers;
     }
     return NULL;
 }


### PR DESCRIPTION
These ciphers were already provider aware, and were available from the
default provider. We move them into the FIPS provider too.

(Needed in order to move the RAND code into the FIPS provider - see #9035)