### PR TITLE
e_devcrypto:  e_devcrypto: Alleviate problems with forks

### DIFF
--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -197,9 +197,8 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         get_cipher_data(EVP_CIPHER_CTX_nid(ctx));
 
     /* cleanup a previous session */
-    if (cipher_ctx->sess.ses != 0 &&
-        clean_devcrypto_session(&cipher_ctx->sess) == 0)
-        return 0;
+    if (cipher_ctx->sess.ses != 0)
+        clean_devcrypto_session(&cipher_ctx->sess);
 
     cipher_ctx->sess.cipher = cipher_d->devcryptoid;
     cipher_ctx->sess.keylen = cipher_d->keylen;


### PR DESCRIPTION
This PR is an attempt to alleviate problems described in #8430.  It's far from fixing it, so I did not write that in the commit message.  The C program I wrote there will still fail with this applied, but I plan to close the issue if this is merged nonetheless, as that case is fictional, openssh is real.  One can always reopen or open another issue if something else is found to be broken.

I'm covering the most common cases I observed here:
 - Errors in ECB ciphers used in `drbg_ctr_init()` across forks.  I'm just ignoring an error closing a previous open session in `cipher_init`, so init does not fail because of it.  With ECB there is no partial state data to be copied, so this fixes it.
 - The HMAC digests done across forks that completely break openssh
The previous `cryptodev` engine worked by storing digest input data, and then running it though /dev/crypto only when `DigestFinal` was called.  This worked with forks, as all that needed to be duplicated was the temporary storage.

Then with the new engine, we feed data to cryptodev at every `DigestUpdate` call.  What I'm doing here is to keep a small data cache that is only going to be fed to cryptodev when its size is > 8k, and also deferring cryptodev initialization until we are actually sending data to it.  Since the common case observed is the HMAC inner key, by the time the process forks, the cryptodev session should not be open, and the only thing we're copying is the input cache data.  In order to avoid duplicating a large chunk of memory, if the new data arriving is larger than 256K, then the current cache data is sent to cryptodev, and then another call is made to send the new data.  Both of these parameters can be changed in `CFLAGS`.  

I've also added an `#ifndef` check to `DEVCRYPTO_DEFAULT_USE_SOFTDRIVERS`, so it could be changed in `CFLAGS` as well--I use that to allow testing in a x86_64 without hw-crypto, rather than using a slower openwrt router every time.

I have tested this with `make test` on x86_64, and with openssh-8.0 in a Linksys WRT3200ACM running openwrt master, confirming that it does not run with the current engine, it exits with
```
# /usr/sbin/sshd -ddd
debug2: load_server_config: filename /etc/ssh/sshd_config
debug2: load_server_config: done config len = 272
debug2: parse_server_config: config /etc/ssh/sshd_config len 272
debug3: /etc/ssh/sshd_config:13 setting Port 2200
debug3: /etc/ssh/sshd_config:19 setting HostKey /etc/ssh/ssh_host_ecdsa_key
debug3: /etc/ssh/sshd_config:20 setting HostKey /etc/ssh/ssh_host_ed25519_key
debug3: /etc/ssh/sshd_config:41 setting AuthorizedKeysFile .ssh/authorized_keys
debug3: /etc/ssh/sshd_config:109 setting Subsystem sftp /usr/lib/sftp-server
debug1: sshd version OpenSSH_8.0, OpenSSL 1.1.1c  28 May 2019
sshkey_fingerprint failed
```
After this change, sshd works as expected.  BTW, openwrt has had 1dea0bf applied for a while now, so it has been tested to some extent.  Digests problem was dealt by disabling them by default.  People will try to turn them on and get into trouble eventually.

Ping @levitte 