### PR TITLE
Constify OSSL_PROVIDER getter input parameters

### DIFF
--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -35,12 +35,13 @@ int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
     return 1;
 }
 
-const OSSL_ITEM *OSSL_PROVIDER_get_param_types(OSSL_PROVIDER *prov)
+const OSSL_ITEM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_get_param_types(prov);
 }
 
-int OSSL_PROVIDER_get_params(OSSL_PROVIDER *prov, const OSSL_PARAM params[])
+int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov,
+                             const OSSL_PARAM params[])
 {
     return ossl_provider_get_params(prov, params);
 }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -575,17 +575,17 @@ int ossl_provider_set_fallback(OSSL_PROVIDER *prov)
 }
 
 /* Getters of Provider Object data */
-const char *ossl_provider_name(OSSL_PROVIDER *prov)
+const char *ossl_provider_name(const OSSL_PROVIDER *prov)
 {
     return prov->name;
 }
 
-const DSO *ossl_provider_dso(OSSL_PROVIDER *prov)
+const DSO *ossl_provider_dso(const OSSL_PROVIDER *prov)
 {
     return prov->module;
 }
 
-const char *ossl_provider_module_name(OSSL_PROVIDER *prov)
+const char *ossl_provider_module_name(const OSSL_PROVIDER *prov)
 {
 #ifdef FIPS_MODE
     return NULL;
@@ -594,7 +594,7 @@ const char *ossl_provider_module_name(OSSL_PROVIDER *prov)
 #endif
 }
 
-const char *ossl_provider_module_path(OSSL_PROVIDER *prov)
+const char *ossl_provider_module_path(const OSSL_PROVIDER *prov)
 {
 #ifdef FIPS_MODE
     return NULL;

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -55,10 +55,10 @@ int ossl_provider_forall_loaded(OPENSSL_CTX *,
                                 void *cbdata);
 
 /* Getters for other library functions */
-const char *ossl_provider_name(OSSL_PROVIDER *prov);
-const DSO *ossl_provider_dso(OSSL_PROVIDER *prov);
-const char *ossl_provider_module_name(OSSL_PROVIDER *prov);
-const char *ossl_provider_module_path(OSSL_PROVIDER *prov);
+const char *ossl_provider_name(const OSSL_PROVIDER *prov);
+const DSO *ossl_provider_dso(const OSSL_PROVIDER *prov);
+const char *ossl_provider_module_name(const OSSL_PROVIDER *prov);
+const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -20,8 +20,9 @@ extern "C" {
 OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
 
-const OSSL_ITEM *OSSL_PROVIDER_get_param_types(OSSL_PROVIDER *prov);
-int OSSL_PROVIDER_get_params(OSSL_PROVIDER *prov, const OSSL_PARAM params[]);
+const OSSL_ITEM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov);
+int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov,
+                             const OSSL_PARAM params[]);
 
 /* Add a built in providers */
 int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *, const char *name,


### PR DESCRIPTION
Some OSSL_PROVIDER getters took a non-const OSSL_PROVIDER parameter.
There's no reason to do so.
