### PR TITLE
Windows: Add missing quotes in build file

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -539,7 +539,7 @@ reconfigure reconf:
               $args{generator}->[1] || platform->dsoname($args{product});
           return <<"EOF";
 $target: $args{generator}->[0] $deps $mkdef
-	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name --OS windows > $target
+	"\$(PERL)" $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name --OS windows > $target
 EOF
       } elsif (!platform->isasm($args{src})) {
           my $target = $args{src};


### PR DESCRIPTION
All invokations of $(PERL) need to be quoted, in case it contains
spaces.  That was forgotten in one spot.

Fixes #9060
