### PR TITLE
Fix SSL_set_ciphersuites to set even if no call to SSL_set_cipher_list

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1344,9 +1344,11 @@ static int update_cipher_list(STACK_OF(SSL_CIPHER) **cipher_list,
                               STACK_OF(SSL_CIPHER) **cipher_list_by_id,
                               STACK_OF(SSL_CIPHER) *tls13_ciphersuites)
 {
+    STACK_OF(SSL_CIPHER) *tmp_cipher_list;
     int i;
-    STACK_OF(SSL_CIPHER) *tmp_cipher_list = sk_SSL_CIPHER_dup(*cipher_list);
 
+    tmp_cipher_list = (*cipher_list == NULL) ? sk_SSL_CIPHER_new_null() :
+                                               sk_SSL_CIPHER_dup(*cipher_list);
     if (tmp_cipher_list == NULL)
         return 0;
 
@@ -1377,11 +1379,9 @@ int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
 {
     int ret = set_ciphersuites(&(ctx->tls13_ciphersuites), str);
 
-    if (ret && ctx->cipher_list != NULL) {
-        /* We already have a cipher_list, so we need to update it */
+    if (ret)
         return update_cipher_list(&ctx->cipher_list, &ctx->cipher_list_by_id,
                                   ctx->tls13_ciphersuites);
-    }
 
     return ret;
 }
@@ -1390,11 +1390,9 @@ int SSL_set_ciphersuites(SSL *s, const char *str)
 {
     int ret = set_ciphersuites(&(s->tls13_ciphersuites), str);
 
-    if (ret && s->cipher_list != NULL) {
-        /* We already have a cipher_list, so we need to update it */
+    if (ret)
         return update_cipher_list(&s->cipher_list, &s->cipher_list_by_id,
                                   s->tls13_ciphersuites);
-    }
 
     return ret;
 }


### PR DESCRIPTION
Currently only calling `SSL_set_ciphersuites` is not configuring TLS1.3 ciphersuite. Instead it requires additional call to `SSL_set_cipher_list` with null String or some valid TLS1.2 ciphersuite.

But this behaviour is not with the Context level API `SSL_CTX_set_ciphersuites`. 

https://www.mail-archive.com/openssl-users@openssl.org/msg86247.html

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
