### PR TITLE
Add ERR_add_platform()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,10 @@
   *) Support SM2 signing and verification schemes with X509 certificate.
      [Paul Yang]
 
+  *) The macro SYSerr() was changed to take a function name, not
+     a numeric value; the SYS_F_xxx defines were removed.
+     [Rich Salz]
+
   *) Use SHA256 as the default digest for TS query in the ts app.
      [Tomas Mraz]
 

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Added a new FUNCerr() macro that takes a function name.
+     The macro SYSerr() is deprecated.
+     [Rich Salz]
+
   *) {CRYPTO,OPENSSL}_mem_debug_{push,pop} are now no-ops and have been
      deprecated.
      [Rich Salz]
@@ -44,10 +48,6 @@
 
   *) Support SM2 signing and verification schemes with X509 certificate.
      [Paul Yang]
-
-  *) The macro SYSerr() was changed to take a function name, not
-     a numeric value; the SYS_F_xxx defines were removed.
-     [Rich Salz]
 
   *) Use SHA256 as the default digest for TS query in the ts app.
      [Tomas Mraz]

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1388,7 +1388,7 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
 #ifndef OPENSSL_NO_POSIX_IO
     BIO_get_fp(in, &dbfp);
     if (fstat(fileno(dbfp), &dbst) == -1) {
-        SYSerr("fstat", errno);
+        FUNCerr("fstat", errno);
         ERR_add_error_data(1, dbfile);
         ERR_print_errors(bio_err);
         goto err;

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1388,8 +1388,8 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
 #ifndef OPENSSL_NO_POSIX_IO
     BIO_get_fp(in, &dbfp);
     if (fstat(fileno(dbfp), &dbst) == -1) {
-        SYSerr(SYS_F_FSTAT, errno);
-        ERR_add_error_data(3, "fstat('", dbfile, "')");
+        SYSerr("fstat", errno);
+        ERR_add_error_data(1, dbfile);
         ERR_print_errors(bio_err);
         goto err;
     }

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -207,7 +207,7 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
                                flags)) != 0) {
 # ifdef EAI_SYSTEM
             if (ret == EAI_SYSTEM) {
-                SYSerr("getnameinfo", get_last_socket_error());
+                FUNCerr("getnameinfo", get_last_socket_error());
                 BIOerr(BIO_F_ADDR_STRINGS, ERR_R_SYS_LIB);
             } else
 # endif
@@ -700,7 +700,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         switch ((gai_ret = getaddrinfo(host, service, &hints, res))) {
 # ifdef EAI_SYSTEM
         case EAI_SYSTEM:
-            SYSerr("getaddrinfo", get_last_socket_error());
+            FUNCerr("getaddrinfo", get_last_socket_error());
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             break;
 # endif
@@ -804,12 +804,12 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                  */
 # if defined(OPENSSL_SYS_VXWORKS)
                 /* h_errno doesn't exist on VxWorks */
-                SYSerr("gethostbyname", 1000 );
+                FUNCerr("gethostbyname", 1000 );
 # else
-                SYSerr("gethostbyname", 1000 + h_errno);
+                FUNCerr("gethostbyname", 1000 + h_errno);
 # endif
 #else
-                SYSerr("gethostbyname", get_last_socket_error());
+                FUNCerr("gethostbyname", get_last_socket_error());
 #endif
                 ret = 0;
                 goto err;
@@ -855,7 +855,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 se = getservbyname(service, proto);
 
                 if (se == NULL) {
-                    SYSerr("getservbyname", get_last_socket_error());
+                    FUNCerr("getservbyname", get_last_socket_error());
                     goto err;
                 }
             } else {

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -207,7 +207,7 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
                                flags)) != 0) {
 # ifdef EAI_SYSTEM
             if (ret == EAI_SYSTEM) {
-                SYSerr(SYS_F_GETNAMEINFO, get_last_socket_error());
+                SYSerr("getnameinfo", get_last_socket_error());
                 BIOerr(BIO_F_ADDR_STRINGS, ERR_R_SYS_LIB);
             } else
 # endif
@@ -700,7 +700,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         switch ((gai_ret = getaddrinfo(host, service, &hints, res))) {
 # ifdef EAI_SYSTEM
         case EAI_SYSTEM:
-            SYSerr(SYS_F_GETADDRINFO, get_last_socket_error());
+            SYSerr("getaddrinfo", get_last_socket_error());
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             break;
 # endif
@@ -804,12 +804,12 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                  */
 # if defined(OPENSSL_SYS_VXWORKS)
                 /* h_errno doesn't exist on VxWorks */
-                SYSerr(SYS_F_GETHOSTBYNAME, 1000 );
+                SYSerr("gethostbyname", 1000 );
 # else
-                SYSerr(SYS_F_GETHOSTBYNAME, 1000 + h_errno);
+                SYSerr("gethostbyname", 1000 + h_errno);
 # endif
 #else
-                SYSerr(SYS_F_GETHOSTBYNAME, WSAGetLastError());
+                SYSerr("gethostbyname", get_last_socket_error());
 #endif
                 ret = 0;
                 goto err;
@@ -855,11 +855,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 se = getservbyname(service, proto);
 
                 if (se == NULL) {
-#ifndef OPENSSL_SYS_WINDOWS
-                    SYSerr(SYS_F_GETSERVBYNAME, errno);
-#else
-                    SYSerr(SYS_F_GETSERVBYNAME, WSAGetLastError());
-#endif
+                    SYSerr("getservbyname", get_last_socket_error());
                     goto err;
                 }
             } else {

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -129,7 +129,7 @@ int BIO_sock_init(void)
          * probed at run-time with DSO_global_lookup.
          */
         if (WSAStartup(0x0202, &wsa_state) != 0) {
-            SYSerr("wsastartup", get_last_socket_error());
+            FUNCerr("wsastartup", get_last_socket_error());
             BIOerr(BIO_F_BIO_SOCK_INIT, BIO_R_WSASTARTUP);
             return -1;
         }
@@ -189,7 +189,7 @@ int BIO_socket_ioctl(int fd, long type, void *arg)
     i = ioctlsocket(fd, type, ARG);
 #  endif                        /* __DJGPP__ */
     if (i < 0)
-        SYSerr("ioctlsocket", get_last_socket_error());
+        FUNCerr("ioctlsocket", get_last_socket_error());
     return i;
 }
 
@@ -240,7 +240,7 @@ int BIO_accept(int sock, char **ip_port)
             ret = -2;
             goto end;
         }
-        SYSerr("accept", get_last_socket_error());
+        FUNCerr("accept", get_last_socket_error());
         BIOerr(BIO_F_BIO_ACCEPT, BIO_R_ACCEPT_ERROR);
         goto end;
     }
@@ -305,7 +305,7 @@ int BIO_socket_nbio(int s, int mode)
 
     l = fcntl(s, F_GETFL, 0);
     if (l == -1) {
-        SYSerr("fcntl", get_last_sys_error());
+        FUNCerr("fcntl", get_last_sys_error());
         ret = -1;
     } else {
 #  if defined(O_NONBLOCK)
@@ -323,7 +323,7 @@ int BIO_socket_nbio(int s, int mode)
         ret = fcntl(s, F_SETFL, l);
 
         if (ret < 0) {
-            SYSerr("fcntl", get_last_sys_error());
+            FUNCerr("fcntl", get_last_sys_error());
         }
     }
 # else
@@ -346,7 +346,7 @@ int BIO_sock_info(int sock,
             ret = getsockname(sock, BIO_ADDR_sockaddr_noconst(info->addr),
                               &addr_len);
             if (ret == -1) {
-                SYSerr("getsockname", get_last_socket_error());
+                FUNCerr("getsockname", get_last_socket_error());
                 BIOerr(BIO_F_BIO_SOCK_INFO, BIO_R_GETSOCKNAME_ERROR);
                 return 0;
             }

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -120,8 +120,6 @@ int BIO_sock_init(void)
     static struct WSAData wsa_state;
 
     if (!wsa_init_done) {
-        int err;
-
         wsa_init_done = 1;
         memset(&wsa_state, 0, sizeof(wsa_state));
         /*
@@ -131,8 +129,7 @@ int BIO_sock_init(void)
          * probed at run-time with DSO_global_lookup.
          */
         if (WSAStartup(0x0202, &wsa_state) != 0) {
-            err = WSAGetLastError();
-            SYSerr(SYS_F_WSASTARTUP, err);
+            SYSerr("wsastartup", get_last_socket_error());
             BIOerr(BIO_F_BIO_SOCK_INIT, BIO_R_WSASTARTUP);
             return -1;
         }
@@ -192,7 +189,7 @@ int BIO_socket_ioctl(int fd, long type, void *arg)
     i = ioctlsocket(fd, type, ARG);
 #  endif                        /* __DJGPP__ */
     if (i < 0)
-        SYSerr(SYS_F_IOCTLSOCKET, get_last_socket_error());
+        SYSerr("ioctlsocket", get_last_socket_error());
     return i;
 }
 
@@ -243,7 +240,7 @@ int BIO_accept(int sock, char **ip_port)
             ret = -2;
             goto end;
         }
-        SYSerr(SYS_F_ACCEPT, get_last_socket_error());
+        SYSerr("accept", get_last_socket_error());
         BIOerr(BIO_F_BIO_ACCEPT, BIO_R_ACCEPT_ERROR);
         goto end;
     }
@@ -308,7 +305,7 @@ int BIO_socket_nbio(int s, int mode)
 
     l = fcntl(s, F_GETFL, 0);
     if (l == -1) {
-        SYSerr(SYS_F_FCNTL, get_last_sys_error());
+        SYSerr("fcntl", get_last_sys_error());
         ret = -1;
     } else {
 #  if defined(O_NONBLOCK)
@@ -326,7 +323,7 @@ int BIO_socket_nbio(int s, int mode)
         ret = fcntl(s, F_SETFL, l);
 
         if (ret < 0) {
-            SYSerr(SYS_F_FCNTL, get_last_sys_error());
+            SYSerr("fcntl", get_last_sys_error());
         }
     }
 # else
@@ -349,7 +346,7 @@ int BIO_sock_info(int sock,
             ret = getsockname(sock, BIO_ADDR_sockaddr_noconst(info->addr),
                               &addr_len);
             if (ret == -1) {
-                SYSerr(SYS_F_GETSOCKNAME, get_last_socket_error());
+                SYSerr("getsockname", get_last_socket_error());
                 BIOerr(BIO_F_BIO_SOCK_INFO, BIO_R_GETSOCKNAME_ERROR);
                 return 0;
             }

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -46,7 +46,7 @@ int BIO_socket(int domain, int socktype, int protocol, int options)
 
     sock = socket(domain, socktype, protocol);
     if (sock == -1) {
-        SYSerr("socket", get_last_socket_error());
+        FUNCerr("socket", get_last_socket_error());
         BIOerr(BIO_F_BIO_SOCKET, BIO_R_UNABLE_TO_CREATE_SOCKET);
         return INVALID_SOCKET;
     }
@@ -89,7 +89,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_KEEPALIVE) {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr("setsockopt", get_last_socket_error());
+            FUNCerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -98,7 +98,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_NODELAY) {
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr("setsockopt", get_last_socket_error());
+            FUNCerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -107,7 +107,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (connect(sock, BIO_ADDR_sockaddr(addr),
                 BIO_ADDR_sockaddr_size(addr)) == -1) {
         if (!BIO_sock_should_retry(-1)) {
-            SYSerr("connect", get_last_socket_error());
+            FUNCerr("connect", get_last_socket_error());
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_CONNECT_ERROR);
         }
         return 0;
@@ -150,7 +150,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_REUSEADDR) {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr("setsockopt", get_last_socket_error());
+            FUNCerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_REUSEADDR);
             return 0;
         }
@@ -158,7 +158,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
 # endif
 
     if (bind(sock, BIO_ADDR_sockaddr(addr), BIO_ADDR_sockaddr_size(addr)) != 0) {
-        SYSerr("bind", get_last_socket_error());
+        FUNCerr("bind", get_last_socket_error());
         BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_BIND_SOCKET);
         return 0;
     }
@@ -217,7 +217,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (getsockopt(sock, SOL_SOCKET, SO_TYPE,
                    (void *)&socktype, &socktype_len) != 0
         || socktype_len != sizeof(socktype)) {
-        SYSerr("getsockopt", get_last_socket_error());
+        FUNCerr("getsockopt", get_last_socket_error());
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_GETTING_SOCKTYPE);
         return 0;
     }
@@ -228,7 +228,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_KEEPALIVE) {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr("setsockopt", get_last_socket_error());
+            FUNCerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -237,7 +237,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_NODELAY) {
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr("setsockopt", get_last_socket_error());
+            FUNCerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -252,7 +252,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         on = options & BIO_SOCK_V6_ONLY ? 1 : 0;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr("setsockopt", get_last_socket_error());
+            FUNCerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_LISTEN_V6_ONLY);
             return 0;
         }
@@ -263,7 +263,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         return 0;
 
     if (socktype != SOCK_DGRAM && listen(sock, MAX_LISTEN) == -1) {
-        SYSerr("listen", get_last_socket_error());
+        FUNCerr("listen", get_last_socket_error());
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_LISTEN_SOCKET);
         return 0;
     }
@@ -290,7 +290,7 @@ int BIO_accept_ex(int accept_sock, BIO_ADDR *addr_, int options)
                            BIO_ADDR_sockaddr_noconst(addr), &len);
     if (accepted_sock == -1) {
         if (!BIO_sock_should_retry(accepted_sock)) {
-            SYSerr("accept", get_last_socket_error());
+            FUNCerr("accept", get_last_socket_error());
             BIOerr(BIO_F_BIO_ACCEPT_EX, BIO_R_ACCEPT_ERROR);
         }
         return INVALID_SOCKET;

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -46,7 +46,7 @@ int BIO_socket(int domain, int socktype, int protocol, int options)
 
     sock = socket(domain, socktype, protocol);
     if (sock == -1) {
-        SYSerr(SYS_F_SOCKET, get_last_socket_error());
+        SYSerr("socket", get_last_socket_error());
         BIOerr(BIO_F_BIO_SOCKET, BIO_R_UNABLE_TO_CREATE_SOCKET);
         return INVALID_SOCKET;
     }
@@ -89,7 +89,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_KEEPALIVE) {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
+            SYSerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -98,7 +98,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_NODELAY) {
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
+            SYSerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -107,7 +107,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (connect(sock, BIO_ADDR_sockaddr(addr),
                 BIO_ADDR_sockaddr_size(addr)) == -1) {
         if (!BIO_sock_should_retry(-1)) {
-            SYSerr(SYS_F_CONNECT, get_last_socket_error());
+            SYSerr("connect", get_last_socket_error());
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_CONNECT_ERROR);
         }
         return 0;
@@ -150,7 +150,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_REUSEADDR) {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
+            SYSerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_REUSEADDR);
             return 0;
         }
@@ -158,7 +158,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
 # endif
 
     if (bind(sock, BIO_ADDR_sockaddr(addr), BIO_ADDR_sockaddr_size(addr)) != 0) {
-        SYSerr(SYS_F_BIND, get_last_socket_error());
+        SYSerr("bind", get_last_socket_error());
         BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_BIND_SOCKET);
         return 0;
     }
@@ -217,7 +217,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (getsockopt(sock, SOL_SOCKET, SO_TYPE,
                    (void *)&socktype, &socktype_len) != 0
         || socktype_len != sizeof(socktype)) {
-        SYSerr(SYS_F_GETSOCKOPT, get_last_socket_error());
+        SYSerr("getsockopt", get_last_socket_error());
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_GETTING_SOCKTYPE);
         return 0;
     }
@@ -228,7 +228,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_KEEPALIVE) {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
+            SYSerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -237,7 +237,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_NODELAY) {
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
+            SYSerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -252,7 +252,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         on = options & BIO_SOCK_V6_ONLY ? 1 : 0;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (const void *)&on, sizeof(on)) != 0) {
-            SYSerr(SYS_F_SETSOCKOPT, get_last_socket_error());
+            SYSerr("setsockopt", get_last_socket_error());
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_LISTEN_V6_ONLY);
             return 0;
         }
@@ -263,7 +263,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         return 0;
 
     if (socktype != SOCK_DGRAM && listen(sock, MAX_LISTEN) == -1) {
-        SYSerr(SYS_F_LISTEN, get_last_socket_error());
+        SYSerr("listen", get_last_socket_error());
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_LISTEN_SOCKET);
         return 0;
     }
@@ -290,7 +290,7 @@ int BIO_accept_ex(int accept_sock, BIO_ADDR *addr_, int options)
                            BIO_ADDR_sockaddr_noconst(addr), &len);
     if (accepted_sock == -1) {
         if (!BIO_sock_should_retry(accepted_sock)) {
-            SYSerr(SYS_F_ACCEPT, get_last_socket_error());
+            SYSerr("accept", get_last_socket_error());
             BIOerr(BIO_F_BIO_ACCEPT_EX, BIO_R_ACCEPT_ERROR);
         }
         return INVALID_SOCKET;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -226,7 +226,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                              BIO_ADDRINFO_socktype(c->addr_iter),
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
-                SYSerr(SYS_F_SOCKET, get_last_socket_error());
+                SYSerr("socket", get_last_socket_error());
                 ERR_add_error_data(4,
                                    "hostname=", c->param_addr,
                                    " service=", c->param_serv);

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -226,7 +226,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                              BIO_ADDRINFO_socktype(c->addr_iter),
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
-                SYSerr("socket", get_last_socket_error());
+                FUNCerr("socket", get_last_socket_error());
                 ERR_add_error_data(4,
                                    "hostname=", c->param_addr,
                                    " service=", c->param_serv);

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -138,7 +138,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                              BIO_ADDRINFO_socktype(c->addr_iter),
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
-                SYSerr("socket", get_last_socket_error());
+                FUNCerr("socket", get_last_socket_error());
                 ERR_add_error_data(4,
                                    "hostname=", c->param_hostname,
                                    " service=", c->param_service);
@@ -170,7 +170,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     ERR_clear_error();
                     break;
                 } else {
-                    SYSerr("connect", get_last_socket_error());
+                    FUNCerr("connect", get_last_socket_error());
                     ERR_add_error_data(4,
                                        "hostname=", c->param_hostname,
                                        " service=", c->param_service);
@@ -186,7 +186,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             i = BIO_sock_error(b->num);
             if (i) {
                 BIO_clear_retry_flags(b);
-                SYSerr("connect", i);
+                FUNCerr("connect", i);
                 ERR_add_error_data(4,
                                    "hostname=", c->param_hostname,
                                    " service=", c->param_service);

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -138,7 +138,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                              BIO_ADDRINFO_socktype(c->addr_iter),
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
-                SYSerr(SYS_F_SOCKET, get_last_socket_error());
+                SYSerr("socket", get_last_socket_error());
                 ERR_add_error_data(4,
                                    "hostname=", c->param_hostname,
                                    " service=", c->param_service);
@@ -170,7 +170,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     ERR_clear_error();
                     break;
                 } else {
-                    SYSerr(SYS_F_CONNECT, get_last_socket_error());
+                    SYSerr("connect", get_last_socket_error());
                     ERR_add_error_data(4,
                                        "hostname=", c->param_hostname,
                                        " service=", c->param_service);
@@ -186,7 +186,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             i = BIO_sock_error(b->num);
             if (i) {
                 BIO_clear_retry_flags(b);
-                SYSerr(SYS_F_CONNECT, i);
+                SYSerr("connect", i);
                 ERR_add_error_data(4,
                                    "hostname=", c->param_hostname,
                                    " service=", c->param_service);

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -69,7 +69,7 @@ BIO *BIO_new_file(const char *filename, const char *mode)
         fp_flags |= BIO_FP_TEXT;
 
     if (file == NULL) {
-        SYSerr(SYS_F_FOPEN, get_last_sys_error());
+        SYSerr("fopen", get_last_sys_error());
         ERR_add_error_data(5, "fopen('", filename, "','", mode, "')");
         if (errno == ENOENT
 # ifdef ENXIO
@@ -149,7 +149,7 @@ static int file_read(BIO *b, char *out, int outl)
         if (ret == 0
             && (b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_ferror((FILE *)b->ptr) : ferror((FILE *)b->ptr))) {
-            SYSerr(SYS_F_FREAD, get_last_sys_error());
+            SYSerr("fread", get_last_sys_error());
             BIOerr(BIO_F_FILE_READ, ERR_R_SYS_LIB);
             ret = -1;
         }
@@ -288,7 +288,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
 #  endif
         fp = openssl_fopen(ptr, p);
         if (fp == NULL) {
-            SYSerr(SYS_F_FOPEN, get_last_sys_error());
+            SYSerr("fopen", get_last_sys_error());
             ERR_add_error_data(5, "fopen('", ptr, "','", p, "')");
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;
@@ -316,7 +316,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         st = b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_fflush(b->ptr) : fflush((FILE *)b->ptr);
         if (st == EOF) {
-            SYSerr(SYS_F_FFLUSH, get_last_sys_error());
+            SYSerr("fflush", get_last_sys_error());
             ERR_add_error_data(1, "fflush()");
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -69,7 +69,7 @@ BIO *BIO_new_file(const char *filename, const char *mode)
         fp_flags |= BIO_FP_TEXT;
 
     if (file == NULL) {
-        SYSerr("fopen", get_last_sys_error());
+        FUNCerr("fopen", get_last_sys_error());
         ERR_add_error_data(5, "fopen('", filename, "','", mode, "')");
         if (errno == ENOENT
 # ifdef ENXIO
@@ -149,7 +149,7 @@ static int file_read(BIO *b, char *out, int outl)
         if (ret == 0
             && (b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_ferror((FILE *)b->ptr) : ferror((FILE *)b->ptr))) {
-            SYSerr("fread", get_last_sys_error());
+            FUNCerr("fread", get_last_sys_error());
             BIOerr(BIO_F_FILE_READ, ERR_R_SYS_LIB);
             ret = -1;
         }
@@ -288,7 +288,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
 #  endif
         fp = openssl_fopen(ptr, p);
         if (fp == NULL) {
-            SYSerr("fopen", get_last_sys_error());
+            FUNCerr("fopen", get_last_sys_error());
             ERR_add_error_data(5, "fopen('", ptr, "','", p, "')");
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;
@@ -316,7 +316,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         st = b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_fflush(b->ptr) : fflush((FILE *)b->ptr);
         if (st == EOF) {
-            SYSerr("fflush", get_last_sys_error());
+            FUNCerr("fflush", get_last_sys_error());
             ERR_add_error_data(1, "fflush()");
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -673,7 +673,7 @@ static BIO *process_include(char *include, OPENSSL_DIR_CTX **dirctx,
     BIO *next;
 
     if (stat(include, &st) < 0) {
-        SYSerr("stat", errno);
+        FUNCerr("stat", errno);
         ERR_add_error_data(1, include);
         /* missing include file is not fatal error */
         return NULL;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -673,7 +673,7 @@ static BIO *process_include(char *include, OPENSSL_DIR_CTX **dirctx,
     BIO *next;
 
     if (stat(include, &st) < 0) {
-        SYSerr(SYS_F_STAT, errno);
+        SYSerr("stat", errno);
         ERR_add_error_data(1, include);
         /* missing include file is not fatal error */
         return NULL;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -372,6 +372,13 @@ void err_free_strings_int(void)
 
 /********************************************************/
 
+void ERR_put_func_error(int lib, const char *func, int reason,
+                        const char *file, int line)
+{
+    ERR_put_error(lib, 0, reason, file, line);
+    ERR_add_error_data(2, "calling function ", func);
+}
+
 void ERR_put_error(int lib, int func, int reason, const char *file, int line)
 {
     ERR_STATE *es;

--- a/crypto/err/openssl.ec
+++ b/crypto/err/openssl.ec
@@ -3,6 +3,7 @@
 # The INPUT HEADER is scanned for declarations
 # LIBNAME       INPUT HEADER                    ERROR-TABLE FILE
 L ERR           NONE                            NONE
+L FUNC          NONE                            NONE
 L BN            include/openssl/bn.h            crypto/bn/bn_err.c
 L RSA           include/openssl/rsa.h           crypto/rsa/rsa_err.c
 L DH            include/openssl/dh.h            crypto/dh/dh_err.c

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -824,7 +824,7 @@ static OSSL_STORE_LOADER_CTX *file_open(const OSSL_STORE_LOADER *loader,
         }
 
         if (stat(path_data[i].path, &st) < 0) {
-            SYSerr("stat", errno);
+            FUNCerr("stat", errno);
             ERR_add_error_data(1, path_data[i].path);
         } else {
             path = path_data[i].path;

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -824,7 +824,7 @@ static OSSL_STORE_LOADER_CTX *file_open(const OSSL_STORE_LOADER *loader,
         }
 
         if (stat(path_data[i].path, &st) < 0) {
-            SYSerr(SYS_F_STAT, errno);
+            SYSerr("stat", errno);
             ERR_add_error_data(1, path_data[i].path);
         } else {
             path = path_data[i].path;

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -2,13 +2,16 @@
 
 =head1 NAME
 
-ERR_put_error, ERR_add_error_data, ERR_add_error_vdata - record an error
+ERR_put_error, ERR_put_func_error,
+ERR_add_error_data, ERR_add_error_vdata - record an error
 
 =head1 SYNOPSIS
 
  #include <openssl/err.h>
 
  void ERR_put_error(int lib, int func, int reason, const char *file, int line);
+ void ERR_put_func_error(int lib, const char *func, int reason,
+                         const char *file, int line);
 
  void ERR_add_error_data(int num, ...);
  void ERR_add_error_vdata(int num, va_list arg);
@@ -19,6 +22,10 @@ ERR_put_error() adds an error code to the thread's error queue. It
 signals that the error of reason code B<reason> occurred in function
 B<func> of library B<lib>, in line number B<line> of B<file>.
 This function is usually called by a macro.
+
+ERR_put_func_err() is similar except that the B<func> is a string naming
+a function external to OpenSSL, usually provided by the platform on which
+OpenSSL and the application is running.
 
 ERR_add_error_data() associates the concatenation of its B<num> string
 arguments with the error code added last.

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -72,7 +72,7 @@ void engine_load_devcrypto_int(void);
 
 static int clean_devcrypto_session(struct session_op *sess) {
     if (ioctl(cfd, CIOCFSESSION, &sess->ses) < 0) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
     memset(sess, 0, sizeof(struct session_op));
@@ -208,7 +208,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     cipher_ctx->mode = cipher_d->flags & EVP_CIPH_MODE;
     cipher_ctx->blocksize = cipher_d->blocksize;
     if (ioctl(cfd, CIOCGSESSION, &cipher_ctx->sess) < 0) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
 
@@ -260,7 +260,7 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 #endif
 
     if (ioctl(cfd, CIOCCRYPT, &cryp) < 0) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
 
@@ -704,7 +704,7 @@ static int digest_init(EVP_MD_CTX *ctx)
     memset(&digest_ctx->sess, 0, sizeof(digest_ctx->sess));
     digest_ctx->sess.mac = digest_d->devcryptoid;
     if (ioctl(cfd, CIOCGSESSION, &digest_ctx->sess) < 0) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
     return 1;
@@ -743,7 +743,7 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
         return 1;
     }
 
-    SYSerr("ioctl", errno);
+    FUNCerr("ioctl", errno);
     return 0;
 }
 
@@ -758,7 +758,7 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     if (EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
         memcpy(md, digest_ctx->digest_res, EVP_MD_CTX_size(ctx));
     } else if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
 
@@ -777,14 +777,14 @@ static int digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
         return 1;
 
     if (!digest_init(to)) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
 
     cphash.src_ses = digest_from->sess.ses;
     cphash.dst_ses = digest_to->sess.ses;
     if (ioctl(cfd, CIOCCPHASH, &cphash) < 0) {
-        SYSerr("ioctl", errno);
+        FUNCerr("ioctl", errno);
         return 0;
     }
     return 1;

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -72,7 +72,7 @@ void engine_load_devcrypto_int(void);
 
 static int clean_devcrypto_session(struct session_op *sess) {
     if (ioctl(cfd, CIOCFSESSION, &sess->ses) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
     memset(sess, 0, sizeof(struct session_op));
@@ -208,7 +208,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     cipher_ctx->mode = cipher_d->flags & EVP_CIPH_MODE;
     cipher_ctx->blocksize = cipher_d->blocksize;
     if (ioctl(cfd, CIOCGSESSION, &cipher_ctx->sess) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
 
@@ -260,7 +260,7 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 #endif
 
     if (ioctl(cfd, CIOCCRYPT, &cryp) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
 
@@ -704,7 +704,7 @@ static int digest_init(EVP_MD_CTX *ctx)
     memset(&digest_ctx->sess, 0, sizeof(digest_ctx->sess));
     digest_ctx->sess.mac = digest_d->devcryptoid;
     if (ioctl(cfd, CIOCGSESSION, &digest_ctx->sess) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
     return 1;
@@ -743,7 +743,7 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
         return 1;
     }
 
-    SYSerr(SYS_F_IOCTL, errno);
+    SYSerr("ioctl", errno);
     return 0;
 }
 
@@ -758,7 +758,7 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     if (EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
         memcpy(md, digest_ctx->digest_res, EVP_MD_CTX_size(ctx));
     } else if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
 
@@ -777,14 +777,14 @@ static int digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
         return 1;
 
     if (!digest_init(to)) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
 
     cphash.src_ses = digest_from->sess.ses;
     cphash.dst_ses = digest_to->sess.ses;
     if (ioctl(cfd, CIOCCPHASH, &cphash) < 0) {
-        SYSerr(SYS_F_IOCTL, errno);
+        SYSerr("ioctl", errno);
         return 0;
     }
     return 1;

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -105,7 +105,10 @@ typedef struct err_state_st {
 
 # define ERR_LIB_USER            128
 
-# define SYSerr(f,r)  ERR_PUT_func_error(ERR_LIB_SYS,(f),(r),OPENSSL_FILE,OPENSSL_LINE)
+# if ! OPENSSL_API_3
+#  define SYSerr(f,r)  ERR_PUT_error(ERR_LIB_SYS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
+#endif
+# define FUNCerr(f,r)  ERR_PUT_func_error(ERR_LIB_SYS,(f),(r),OPENSSL_FILE,OPENSSL_LINE)
 # define BNerr(f,r)   ERR_PUT_error(ERR_LIB_BN,0,(r),OPENSSL_FILE,OPENSSL_LINE)
 # define RSAerr(f,r)  ERR_PUT_error(ERR_LIB_RSA,0,(r),OPENSSL_FILE,OPENSSL_LINE)
 # define DHerr(f,r)   ERR_PUT_error(ERR_LIB_DH,0,(r),OPENSSL_FILE,OPENSSL_LINE)

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -26,9 +26,11 @@ extern "C" {
 #endif
 
 # ifndef OPENSSL_NO_ERR
-#  define ERR_PUT_error(a,b,c,d,e)        ERR_put_error(a,b,c,d,e)
+#  define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,fn,ln)
+#  define ERR_PUT_func_error(l,f,r,fn,ln) ERR_put_func_error(l,f,r,fn,ln)
 # else
-#  define ERR_PUT_error(a,b,c,d,e)        ERR_put_error(a,b,c,NULL,0)
+#  define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,NULL,0)
+#  define ERR_PUT_func_error(l,f,r,fn,ln) ERR_put_func_error(l,f,r,NULL,0)
 # endif
 
 # include <errno.h>
@@ -103,7 +105,7 @@ typedef struct err_state_st {
 
 # define ERR_LIB_USER            128
 
-# define SYSerr(f,r)  ERR_PUT_error(ERR_LIB_SYS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
+# define SYSerr(f,r)  ERR_PUT_func_error(ERR_LIB_SYS,(f),(r),OPENSSL_FILE,OPENSSL_LINE)
 # define BNerr(f,r)   ERR_PUT_error(ERR_LIB_BN,0,(r),OPENSSL_FILE,OPENSSL_LINE)
 # define RSAerr(f,r)  ERR_PUT_error(ERR_LIB_RSA,0,(r),OPENSSL_FILE,OPENSSL_LINE)
 # define DHerr(f,r)   ERR_PUT_error(ERR_LIB_DH,0,(r),OPENSSL_FILE,OPENSSL_LINE)
@@ -154,33 +156,6 @@ typedef struct err_state_st {
 # define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)
 # define ERR_FATAL_ERROR(l)      (int)( (l)         & ERR_R_FATAL)
 
-/* OS functions */
-# define SYS_F_FOPEN             1
-# define SYS_F_CONNECT           2
-# define SYS_F_GETSERVBYNAME     3
-# define SYS_F_SOCKET            4
-# define SYS_F_IOCTLSOCKET       5
-# define SYS_F_BIND              6
-# define SYS_F_LISTEN            7
-# define SYS_F_ACCEPT            8
-# define SYS_F_WSASTARTUP        9/* Winsock stuff */
-# define SYS_F_OPENDIR           10
-# define SYS_F_FREAD             11
-# define SYS_F_GETADDRINFO       12
-# define SYS_F_GETNAMEINFO       13
-# define SYS_F_SETSOCKOPT        14
-# define SYS_F_GETSOCKOPT        15
-# define SYS_F_GETSOCKNAME       16
-# define SYS_F_GETHOSTBYNAME     17
-# define SYS_F_FFLUSH            18
-# define SYS_F_OPEN              19
-# define SYS_F_CLOSE             20
-# define SYS_F_IOCTL             21
-# define SYS_F_STAT              22
-# define SYS_F_FCNTL             23
-# define SYS_F_FSTAT             24
-# define SYS_F_SENDFILE          25
-
 /* reasons */
 # define ERR_R_SYS_LIB   ERR_LIB_SYS/* 2 */
 # define ERR_R_BN_LIB    ERR_LIB_BN/* 3 */
@@ -229,6 +204,8 @@ typedef struct ERR_string_data_st {
 DEFINE_LHASH_OF(ERR_STRING_DATA);
 
 void ERR_put_error(int lib, int func, int reason, const char *file, int line);
+void ERR_put_func_error(int lib, const char *func, int reason,
+                        const char *file, int line);
 void ERR_set_error_data(char *data, int flags);
 
 unsigned long ERR_get_error(void);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -159,6 +159,34 @@ typedef struct err_state_st {
 # define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)
 # define ERR_FATAL_ERROR(l)      (int)( (l)         & ERR_R_FATAL)
 
+# if !OPENSSL_API_3
+#  define SYS_F_FOPEN             0
+#  define SYS_F_CONNECT           0
+#  define SYS_F_GETSERVBYNAME     0
+#  define SYS_F_SOCKET            0
+#  define SYS_F_IOCTLSOCKET       0
+#  define SYS_F_BIND              0
+#  define SYS_F_LISTEN            0
+#  define SYS_F_ACCEPT            0
+#  define SYS_F_WSASTARTUP        0
+#  define SYS_F_OPENDIR           0
+#  define SYS_F_FREAD             0
+#  define SYS_F_GETADDRINFO       0
+#  define SYS_F_GETNAMEINFO       0
+#  define SYS_F_SETSOCKOPT        0
+#  define SYS_F_GETSOCKOPT        0
+#  define SYS_F_GETSOCKNAME       0
+#  define SYS_F_GETHOSTBYNAME     0
+#  define SYS_F_FFLUSH            0
+#  define SYS_F_OPEN              0
+#  define SYS_F_CLOSE             0
+#  define SYS_F_IOCTL             0
+#  define SYS_F_STAT              0
+#  define SYS_F_FCNTL             0
+#  define SYS_F_FSTAT             0
+#  define SYS_F_SENDFILE          0
+# endif
+
 /* reasons */
 # define ERR_R_SYS_LIB   ERR_LIB_SYS/* 2 */
 # define ERR_R_BN_LIB    ERR_LIB_BN/* 3 */

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -766,7 +766,7 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     }
 
     if (errno) {
-        SYSerr(SYS_F_OPENDIR, get_last_sys_error());
+        SYSerr("readdir", get_last_sys_error());
         ERR_add_error_data(3, "OPENSSL_DIR_read(&ctx, '", dir, "')");
         SSLerr(SSL_F_SSL_ADD_DIR_CERT_SUBJECTS_TO_STACK, ERR_R_SYS_LIB);
         goto err;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -766,7 +766,7 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     }
 
     if (errno) {
-        SYSerr("readdir", get_last_sys_error());
+        FUNCerr("readdir", get_last_sys_error());
         ERR_add_error_data(3, "OPENSSL_DIR_read(&ctx, '", dir, "')");
         SSLerr(SSL_F_SSL_ADD_DIR_CERT_SUBJECTS_TO_STACK, ERR_R_SYS_LIB);
         goto err;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2075,7 +2075,7 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
         else
 #endif
 #ifdef OPENSSL_NO_KTLS
-            SYSerr(SYS_F_SENDFILE, get_last_sys_error());
+            SYSerr("sendfile", get_last_sys_error());
 #else
             SSLerr(SSL_F_SSL_SENDFILE, SSL_R_UNINITIALIZED);
 #endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2075,7 +2075,7 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
         else
 #endif
 #ifdef OPENSSL_NO_KTLS
-            SYSerr("sendfile", get_last_sys_error());
+            FUNCerr("sendfile", get_last_sys_error());
 #else
             SSLerr(SSL_F_SSL_SENDFILE, SSL_R_UNINITIALIZED);
 #endif

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -44,9 +44,28 @@ static int vdata_appends(void)
     return TEST_str_eq(data, "hello world");
 }
 
+/* Test that setting a platform error sets the right values. */
+static int platform_error(void)
+{
+    const char *file = __FILE__, *f, *data;
+    const int line = __LINE__;
+    int l;
+    unsigned long e;
+
+    ERR_put_func_error(ERR_LIB_SYS, "exit", ERR_R_INTERNAL_ERROR, file, line);
+    if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
+            || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
+            || !TEST_int_eq(l, line)
+            || !TEST_str_eq(f, file)
+            || !TEST_str_eq(data, "calling function exit"))
+        return 0;
+    return 1;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
     ADD_TEST(vdata_appends);
+    ADD_TEST(platform_error);
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4685,3 +4685,4 @@ EVP_KEYEXCH_up_ref                      4790	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_fetch                       4791	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_dh_pad                 4792	3_0_0	EXIST::FUNCTION:DH
 EVP_PKEY_CTX_set_params                 4793	3_0_0	EXIST::FUNCTION:
+ERR_put_func_error                      4794	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is related to https://github.com/openssl/openssl/pull/9058#issuecomment-497899398 and also a bit to #8887. If the OMC decides to remove the function name from error codes, as that comment thread points out, it is still useful to report what function failed if it's something on the platform; e.g., "gethostbyname" failed, or what have you.  This PR enables that.  It adds a new function, ```ERR_add_platform``` which takes a string name for the platform-provided function that failed, and reports that as "extra data" in the error stack.  All the ```SYS_F_xxx``` values are gone.