### PR TITLE
Fix SSL_set_ciphersuites to set even if no call to SSL_set_cipher_list

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1380,24 +1380,25 @@ int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
 {
     int ret = set_ciphersuites(&(ctx->tls13_ciphersuites), str);
 
-    if (ret && ctx->cipher_list != NULL) {
-        /* We already have a cipher_list, so we need to update it */
+    if (ret && ctx->cipher_list != NULL)
         return update_cipher_list(&ctx->cipher_list, &ctx->cipher_list_by_id,
                                   ctx->tls13_ciphersuites);
-    }
 
     return ret;
 }
 
 int SSL_set_ciphersuites(SSL *s, const char *str)
 {
+    STACK_OF(SSL_CIPHER) *cipher_list;
     int ret = set_ciphersuites(&(s->tls13_ciphersuites), str);
 
-    if (ret && s->cipher_list != NULL) {
-        /* We already have a cipher_list, so we need to update it */
+    if (s->cipher_list == NULL) {
+        if ((cipher_list = SSL_get_ciphers(s)) != NULL)
+            s->cipher_list = sk_SSL_CIPHER_dup(cipher_list);
+    }
+    if (ret && s->cipher_list != NULL)
         return update_cipher_list(&s->cipher_list, &s->cipher_list_by_id,
                                   s->tls13_ciphersuites);
-    }
 
     return ret;
 }

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -89,6 +89,7 @@ static int test_client_hello(int currtest)
     case TEST_SET_SESSION_TICK_DATA_VER_NEG:
 #if !defined(OPENSSL_NO_TLS1_3) && defined(OPENSSL_NO_TLS1_2)
         /* TLSv1.3 is enabled and TLSv1.2 is disabled so can't do this test */
+        SSL_CTX_free(ctx);
         return 1;
 #else
         /* Testing for session tickets <= TLS1.2; not relevant for 1.3 */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3908,6 +3908,142 @@ static int test_key_exchange(int idx)
 }
 
 /*
+ * Test TLSv1.3 Cipher Suite
+ * Test 0 = Set TLS1.3 cipher on context
+ * Test 1 = Set TLS1.3 cipher on SSL
+ * Test 2 = Set TLS1.3 and TLS1.2 cipher on context
+ * Test 3 = Set TLS1.3 and TLS1.2 cipher on SSL
+ */
+static int test_tls13_ciphersuite(int idx)
+{
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    static const char *t13_ciphers[] = {
+        TLS1_3_RFC_AES_128_GCM_SHA256,
+        TLS1_3_RFC_AES_256_GCM_SHA384,
+        TLS1_3_RFC_AES_128_CCM_SHA256,
+# if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+        TLS1_3_RFC_CHACHA20_POLY1305_SHA256,
+        TLS1_3_RFC_AES_256_GCM_SHA384 ":" TLS1_3_RFC_CHACHA20_POLY1305_SHA256,
+# endif
+        TLS1_3_RFC_AES_128_CCM_8_SHA256 ":" TLS1_3_RFC_AES_128_CCM_SHA256
+    };
+    const char *t13_cipher = NULL;
+    const char *t12_cipher = NULL;
+    const char *negotiated_scipher;
+    const char *negotiated_ccipher;
+    int set_at_ctx = 0;
+    int set_at_ssl = 0;
+    int testresult = 0;
+    int max_ver;
+    size_t i;
+
+    switch (idx) {
+        case 0:
+            set_at_ctx = 1;
+            break;
+        case 1:
+            set_at_ssl = 1;
+            break;
+        case 2:
+            set_at_ctx = 1;
+            t12_cipher = TLS1_TXT_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
+            break;
+        case 3:
+            set_at_ssl = 1;
+            t12_cipher = TLS1_TXT_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
+            break;
+    }
+
+    for (max_ver = TLS1_2_VERSION; max_ver <= TLS1_3_VERSION; max_ver++) {
+# ifdef OPENSSL_NO_TLS1_2
+        if (max_ver == TLS1_2_VERSION)
+            continue;
+# endif
+        for (i = 0; i < OSSL_NELEM(t13_ciphers); i++) {
+            t13_cipher = t13_ciphers[i];
+            if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
+                                               TLS_client_method(),
+                                               TLS1_VERSION, max_ver,
+                                               &sctx, &cctx, cert, privkey)))
+                goto end;
+
+            if (set_at_ctx) {
+                if (!TEST_true(SSL_CTX_set_ciphersuites(sctx, t13_cipher))
+                    || !TEST_true(SSL_CTX_set_ciphersuites(cctx, t13_cipher)))
+                    goto end;
+                if (t12_cipher != NULL) {
+                    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, t12_cipher))
+                        || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                              t12_cipher)))
+                        goto end;
+                }
+            }
+
+            if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                              &clientssl, NULL, NULL)))
+                goto end;
+
+            if (set_at_ssl) {
+                if (!TEST_true(SSL_set_ciphersuites(serverssl, t13_cipher))
+                    || !TEST_true(SSL_set_ciphersuites(clientssl, t13_cipher)))
+                    goto end;
+                if (t12_cipher != NULL) {
+                    if (!TEST_true(SSL_set_cipher_list(serverssl, t12_cipher))
+                        || !TEST_true(SSL_set_cipher_list(clientssl,
+                                                          t12_cipher)))
+                        goto end;
+                }
+            }
+
+            if (!TEST_true(create_ssl_connection(serverssl, clientssl,
+                                                 SSL_ERROR_NONE)))
+                goto end;
+
+            negotiated_scipher = SSL_CIPHER_get_name(SSL_get_current_cipher(
+                                                                 serverssl));
+            negotiated_ccipher = SSL_CIPHER_get_name(SSL_get_current_cipher(
+                                                                 clientssl));
+            if (!TEST_str_eq(negotiated_scipher, negotiated_ccipher))
+                goto end;
+
+            /*
+             * TEST_strn_eq is used below because t13_cipher can contain
+             * multiple ciphersuites
+             */
+            if (max_ver == TLS1_3_VERSION
+                && !TEST_strn_eq(t13_cipher, negotiated_scipher,
+                                 strlen(negotiated_scipher)))
+                goto end;
+
+# ifndef OPENSSL_NO_TLS1_2
+            /* Below validation is not done when t12_cipher is NULL */
+            if (max_ver == TLS1_2_VERSION && t12_cipher != NULL
+                && !TEST_str_eq(t12_cipher, negotiated_scipher))
+                goto end;
+# endif
+
+            SSL_free(serverssl);
+            serverssl = NULL;
+            SSL_free(clientssl);
+            clientssl = NULL;
+            SSL_CTX_free(sctx);
+            sctx = NULL;
+            SSL_CTX_free(cctx);
+            cctx = NULL;
+        }
+    }
+
+    testresult = 1;
+ end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
+/*
  * Test TLSv1.3 PSKs
  * Test 0 = Test new style callbacks
  * Test 1 = Test both new and old style callbacks
@@ -6805,6 +6941,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_TLS1_3
     ADD_ALL_TESTS(test_set_ciphersuite, 10);
     ADD_TEST(test_ciphersuite_change);
+    ADD_ALL_TESTS(test_tls13_ciphersuite, 4);
 #ifdef OPENSSL_NO_PSK
     ADD_ALL_TESTS(test_tls13_psk, 1);
 #else

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3742,46 +3742,44 @@ static int test_ciphersuite_change(void)
 }
 
 /*
- * Test Key exchange
- * Test 0 = Test ECDHE Key exchange with TLSv1.3 client and server
- * Test 1 = Test ECDHE with TLSv1.2 client and server
- * Test 2 = Test FFDHE Key exchange with TLSv1.3 client and server
- * Test 3 = Test FFDHE with TLSv1.2 client and server
- * Test 4 = Test NID_X9_62_prime256v1 with TLSv1.3 client and server
- * Test 5 = Test NID_secp384r1 with TLSv1.3 client and server
- * Test 6 = Test NID_secp521r1 with TLSv1.3 client and server
- * Test 7 = Test NID_X25519 with TLSv1.3 client and server
- * Test 8 = Test NID_X448 with TLSv1.3 client and server
- * Test 9 = Test NID_ffdhe2048 with TLSv1.3 client and server
- * Test 10 = Test NID_ffdhe3072 with TLSv1.3 client and server
- * Test 11 = Test NID_ffdhe4096 with TLSv1.3 client and server
- * Test 12 = Test NID_ffdhe6144 with TLSv1.3 client and server
- * Test 13 = Test NID_ffdhe8192 with TLSv1.3 client and server
+ * Test TLSv1.3 Key exchange
+ * Test 0 = Test all ECDHE Key exchange with TLSv1.3 client and server
+ * Test 1 = Test NID_X9_62_prime256v1 with TLSv1.3 client and server
+ * Test 2 = Test NID_secp384r1 with TLSv1.3 client and server
+ * Test 3 = Test NID_secp521r1 with TLSv1.3 client and server
+ * Test 4 = Test NID_X25519 with TLSv1.3 client and server
+ * Test 5 = Test NID_X448 with TLSv1.3 client and server
+ * Test 6 = Test all FFDHE Key exchange with TLSv1.3 client and server
+ * Test 7 = Test NID_ffdhe2048 with TLSv1.3 client and server
+ * Test 8 = Test NID_ffdhe3072 with TLSv1.3 client and server
+ * Test 9 = Test NID_ffdhe4096 with TLSv1.3 client and server
+ * Test 10 = Test NID_ffdhe6144 with TLSv1.3 client and server
+ * Test 11 = Test NID_ffdhe8192 with TLSv1.3 client and server
+ * Test 12 = Test all ECDHE with TLSv1.2 client and server
+ * Test 13 = Test all FFDHE with TLSv1.2 client and server
  */
 static int test_key_exchange(int idx)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
     SSL *serverssl = NULL, *clientssl = NULL;
     int testresult = 0;
-#if !defined(OPENSSL_NO_EC)
-    int ecdhe_kexch_groups[] = {NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1,
-                                NID_X25519, NID_X448};
-#endif
-#ifndef OPENSSL_NO_DH
+# ifndef OPENSSL_NO_EC
+    int ecdhe_kexch_groups[] = {NID_X9_62_prime256v1, NID_secp384r1,
+                                NID_secp521r1, NID_X25519, NID_X448};
+# endif
+# ifndef OPENSSL_NO_DH
     int ffdhe_kexch_groups[] = {NID_ffdhe2048, NID_ffdhe3072, NID_ffdhe4096,
                                 NID_ffdhe6144, NID_ffdhe8192};
-#endif
+# endif
     int kexch_alg;
     int *kexch_groups = &kexch_alg;
     int kexch_groups_size = 1;
     int max_version = TLS1_3_VERSION;
-    int want_err = SSL_ERROR_NONE;
-    int expected_err_reason = 0;
 
     switch (idx) {
-#ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC
 # ifndef OPENSSL_NO_TLS1_2
-        case 1:
+        case 12:
             max_version = TLS1_2_VERSION;
 # endif
             /* Fall through */
@@ -3789,48 +3787,48 @@ static int test_key_exchange(int idx)
             kexch_groups = ecdhe_kexch_groups;
             kexch_groups_size = OSSL_NELEM(ecdhe_kexch_groups);
             break;
-        case 4:
+        case 1:
             kexch_alg = NID_X9_62_prime256v1;
             break;
-        case 5:
+        case 2:
             kexch_alg = NID_secp384r1;
             break;
-        case 6:
+        case 3:
             kexch_alg = NID_secp521r1;
             break;
-        case 7:
+        case 4:
             kexch_alg = NID_X25519;
             break;
-        case 8:
+        case 5:
             kexch_alg = NID_X448;
             break;
-#endif
-#ifndef OPENSSL_NO_DH
+# endif
+# ifndef OPENSSL_NO_DH
 # ifndef OPENSSL_NO_TLS1_2
-        case 3:
+        case 13:
             max_version = TLS1_2_VERSION;
 # endif
             /* Fall through */
-        case 2:
+        case 6:
             kexch_groups = ffdhe_kexch_groups;
             kexch_groups_size = OSSL_NELEM(ffdhe_kexch_groups);
             break;
-        case 9:
+        case 7:
             kexch_alg = NID_ffdhe2048;
             break;
-        case 10:
+        case 8:
             kexch_alg = NID_ffdhe3072;
             break;
-        case 11:
+        case 9:
             kexch_alg = NID_ffdhe4096;
             break;
-        case 12:
+        case 10:
             kexch_alg = NID_ffdhe6144;
             break;
-        case 13:
+        case 11:
             kexch_alg = NID_ffdhe8192;
             break;
-#endif
+# endif
         default:
             /* We're skipping this test */
             return 1;
@@ -3841,23 +3839,28 @@ static int test_key_exchange(int idx)
                                        &sctx, &cctx, cert, privkey)))
         goto end;
 
-    if (!TEST_true(SSL_CTX_set_ciphersuites(sctx, TLS1_3_RFC_AES_128_GCM_SHA256)))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(sctx,
+                   TLS1_3_RFC_AES_128_GCM_SHA256)))
         goto end;
 
-    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, TLS1_3_RFC_AES_128_GCM_SHA256)))
+    if (!TEST_true(SSL_CTX_set_ciphersuites(cctx,
+                   TLS1_3_RFC_AES_128_GCM_SHA256)))
         goto end;
 
-    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, TLS1_TXT_RSA_WITH_AES_128_SHA)))
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx,
+                   TLS1_TXT_RSA_WITH_AES_128_SHA)))
         goto end;
 
     /*
      * Must include an EC ciphersuite so that we send supported groups in
      * TLSv1.2
      */
+# ifndef OPENSSL_NO_TLS1_2
     if (!TEST_true(SSL_CTX_set_cipher_list(cctx,
                    TLS1_TXT_ECDHE_ECDSA_WITH_AES_128_CCM ":"
                    TLS1_TXT_RSA_WITH_AES_128_SHA)))
         goto end;
+# endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                              NULL, NULL)))
@@ -3867,29 +3870,16 @@ static int test_key_exchange(int idx)
         || !TEST_true(SSL_set1_groups(clientssl, kexch_groups, kexch_groups_size)))
         goto end;
 
-    if (!TEST_true(create_ssl_connection(serverssl, clientssl, want_err))) {
-        /* Fail only if no error is expected in handshake */
-        if (expected_err_reason == 0)
-            goto end;
-    }
-
-    /* Fail if expected error is not happening for failure testcases */
-    if (expected_err_reason != 0) {
-        unsigned long err_code = ERR_get_error();
-
-        ERR_print_errors_fp(stdout);
-        if (TEST_int_eq(ERR_GET_REASON(err_code), expected_err_reason))
-            testresult = 1;
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
         goto end;
-    }
 
     /*
-     * If Handshake succeeds the negotiated kexch alg should the first one in
-     * configured, except in the case of FFDHE groups which are TLSv1.3 only
-     * so we expect no shared group to exist.
+     * If Handshake succeeds the negotiated kexch alg should be the first one in
+     * configured, except in the case of FFDHE groups (idx 13), which are
+     * TLSv1.3 only so we expect no shared group to exist.
      */
     if (!TEST_int_eq(SSL_get_shared_group(serverssl, 0),
-                     idx == 3 ? 0 : kexch_groups[0]))
+                     idx == 13 ? 0 : kexch_groups[0]))
         goto end;
     if (max_version == TLS1_3_VERSION) {
         if (!TEST_int_eq(SSL_get_negotiated_group(serverssl), kexch_groups[0]))
@@ -6942,12 +6932,18 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_set_ciphersuite, 10);
     ADD_TEST(test_ciphersuite_change);
     ADD_ALL_TESTS(test_tls13_ciphersuite, 4);
-#ifdef OPENSSL_NO_PSK
+# ifdef OPENSSL_NO_PSK
     ADD_ALL_TESTS(test_tls13_psk, 1);
-#else
+# else
     ADD_ALL_TESTS(test_tls13_psk, 4);
-#endif  /* OPENSSL_NO_PSK */
+# endif  /* OPENSSL_NO_PSK */
+# ifndef OPENSSL_NO_TLS1_2
+    /* Test with both TLSv1.3 and 1.2 versions */
     ADD_ALL_TESTS(test_key_exchange, 14);
+# else
+    /* Test with only TLSv1.3 versions */
+    ADD_ALL_TESTS(test_key_exchange, 12);
+# endif
     ADD_ALL_TESTS(test_custom_exts, 5);
     ADD_TEST(test_stateless);
     ADD_TEST(test_pha_key_update);


### PR DESCRIPTION
Currently only calling `SSL_set_ciphersuites` is not configuring TLS1.3 ciphersuite. Instead it requires additional call to `SSL_set_cipher_list` with null String or some valid TLS1.2 ciphersuite.

But this behaviour is not with the Context level API `SSL_CTX_set_ciphersuites`.

https://www.mail-archive.com/openssl-users@openssl.org/msg86247.html

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
