### PR TITLE
Make ERR_STATE opaque

### DIFF
--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -283,7 +283,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     FuzzerSetRand();
 

--- a/fuzz/asn1parse.c
+++ b/fuzz/asn1parse.c
@@ -25,7 +25,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 {
     bio_out = BIO_new_file("/dev/null", "w");
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     return 1;
 }

--- a/fuzz/bignum.c
+++ b/fuzz/bignum.c
@@ -22,7 +22,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
 
     return 1;
 }

--- a/fuzz/bndiv.c
+++ b/fuzz/bndiv.c
@@ -38,7 +38,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     ctx = BN_CTX_new();
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
 
     return 1;
 }

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -44,7 +44,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();

--- a/fuzz/cms.c
+++ b/fuzz/cms.c
@@ -20,7 +20,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     return 1;
 }

--- a/fuzz/conf.c
+++ b/fuzz/conf.c
@@ -19,7 +19,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     return 1;
 }
 

--- a/fuzz/crl.c
+++ b/fuzz/crl.c
@@ -16,7 +16,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     return 1;
 }

--- a/fuzz/ct.c
+++ b/fuzz/ct.c
@@ -21,7 +21,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     CRYPTO_free_ex_index(0, -1);
-    ERR_get_state();
+    ERR_clear_error();
     return 1;
 }
 

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -491,7 +491,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -19,7 +19,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     FuzzerSetRand();
     return 1;

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -36,19 +36,6 @@ extern "C" {
 # define ERR_TXT_MALLOCED        0x01
 # define ERR_TXT_STRING          0x02
 
-# define ERR_FLAG_MARK           0x01
-# define ERR_FLAG_CLEAR          0x02
-
-# define ERR_NUM_ERRORS  16
-typedef struct err_state_st {
-    int err_flags[ERR_NUM_ERRORS];
-    unsigned long err_buffer[ERR_NUM_ERRORS];
-    char *err_data[ERR_NUM_ERRORS];
-    int err_data_flags[ERR_NUM_ERRORS];
-    const char *err_file[ERR_NUM_ERRORS];
-    int err_line[ERR_NUM_ERRORS];
-    int top, bottom;
-} ERR_STATE;
 
 /* library */
 # define ERR_LIB_NONE            1
@@ -270,6 +257,8 @@ int ERR_load_ERR_strings(void);
 
 DEPRECATEDIN_1_1_0(void ERR_remove_thread_state(void *))
 DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
+
+typedef struct err_state_st ERR_STATE;
 ERR_STATE *ERR_get_state(void);
 
 int ERR_get_next_error_library(void);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -257,9 +257,8 @@ int ERR_load_ERR_strings(void);
 
 DEPRECATEDIN_1_1_0(void ERR_remove_thread_state(void *))
 DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
-
 typedef struct err_state_st ERR_STATE;
-ERR_STATE *ERR_get_state(void);
+DEPRECATEDIN_3(ERR_STATE *ERR_get_state(void))
 
 int ERR_get_next_error_library(void);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2214,7 +2214,7 @@ EVP_PKEY_missing_parameters             2261	3_0_0	EXIST::FUNCTION:
 X509_REQ_INFO_new                       2262	3_0_0	EXIST::FUNCTION:
 EVP_rc2_cfb64                           2263	3_0_0	EXIST::FUNCTION:RC2
 PKCS7_get_smimecap                      2264	3_0_0	EXIST::FUNCTION:
-ERR_get_state                           2265	3_0_0	EXIST::FUNCTION:
+ERR_get_state                           2265	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 d2i_DSAPrivateKey_bio                   2266	3_0_0	EXIST::FUNCTION:DSA
 X509_PURPOSE_get_trust                  2267	3_0_0	EXIST::FUNCTION:
 EC_GROUP_get_point_conversion_form      2268	3_0_0	EXIST::FUNCTION:EC


### PR DESCRIPTION
I don't know if the OMC wants to do this, but I expect it will be "safe"

This is part of a set of ERR-related changes I've been proposing (dare I say improvements?) but like the others is independent of each.
