### PR TITLE
Add documentation for X509_cmp and related APIs

### DIFF
--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -31,19 +31,19 @@ values of two B<X509> objects and the canonical (DER) encoding values.
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
 parameters B<a> and B<b>. The comparison is based on the B<memcmp> result of
 the canonical (DER) encoding values of the two objects. L<i2d_X509_NAME(3)>
-has a more detailed description on the DER encoding of B<X509_NAME> structure.
+has a more detailed description of the DER encoding of the B<X509_NAME> structure.
 
 The X509_issuer_and_serial_cmp() function compares the serial number and issuer
 values in the given B<X509> objects B<a> and B<b>.
 
 The X509_issuer_name_cmp(), X509_subject_name_cmp() and X509_CRL_cmp() functions
-are effectively wrappers of X509_NAME_cmp() function. These functions compare 
+are effectively wrappers of the X509_NAME_cmp() function. These functions compare
 issuer names and subject names of the X<509> objects, or issuers of B<X509_CRL>
 objects, respectively.
 
 The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
-X509_CRL_cmp() function, this function compares the the whole CRL content
-instead of just the issuer name.
+X509_CRL_cmp() function, this function compares the whole CRL content instead
+of just the issuer name.
 
 =head1 RETURN VALUES
 
@@ -56,8 +56,8 @@ X509_subject_name_cmp() and X509_CRL_cmp() may return B<-2> to indicate an error
 
 =head1 NOTES
 
-These functions in fact utilize the underlying B<memcmp> of C library to do the
-comparison job. Data to be compared varies from DER encoding data, SHA-1 hash
+These functions in fact utilize the underlying B<memcmp> of the C library to do
+the comparison job. Data to be compared varies from DER encoding data, hash
 value or B<ASN1_STRING>. The sign of the comparison can be used to order the
 objects but it does not have a special meaning in some cases.
 

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -1,0 +1,79 @@
+=pod
+
+=head1 NAME
+
+X509_cmp, X509_NAME_cmp,
+X509_issuer_and_serial_cmp, X509_issuer_name_cmp, X509_subject_name_cmp,
+X509_CRL_cmp, X509_CRL_match
+- compare X509 certificates and related values
+
+=head1 SYNOPSIS
+
+ #include <openssl/x509.h>
+
+ int X509_cmp(const X509 *a, const X509 *b);
+ int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b);
+ int X509_issuer_and_serial_cmp(const X509 *a, const X509 *b);
+ int X509_issuer_name_cmp(const X509 *a, const X509 *b);
+ int X509_subject_name_cmp(const X509 *a, const X509 *b);
+ int X509_CRL_cmp(const X509_CRL *a, const X509_CRL *b);
+ int X509_CRL_match(const X509_CRL *a, const X509_CRL *b);
+
+=head1 DESCRIPTION
+
+This set of functions are used to compare X509 objects, including X509
+certificates, X509 CRL objects and various values in an X509 certificate.
+
+The X509_cmp() function compares two B<X509> objects indicated by parameters
+B<a> and B<b>. The comparison is based on the B<memcmp> result of the SHA-1
+hash values of two B<X509> objects and the canonical (DER) encoding values.
+
+The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
+parameters B<a> and B<b>. The comparison is based on the B<memcmp> result of
+the canonical (DER) encoding values of the two objects. L<i2d_X509_NAME(3)>
+has a more detailed description on the DER encoding of B<X509_NAME> structure.
+
+The X509_issuer_and_serial_cmp() function compares the serial number and issuer
+values in the given B<X509> objects B<a> and B<b>.
+
+The X509_issuer_name_cmp(), X509_subject_name_cmp() and X509_CRL_cmp() functions
+are effectively wrappers of X509_NAME_cmp() function. These functions compare 
+issuer names and subject names of the X<509> objects, or issuers of B<X509_CRL>
+objects, respectively.
+
+The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
+X509_CRL_cmp() function, this function compares the SHA-1 hash values of the
+whole CRL content indicated by parameter B<a> and B<b>.
+
+=head1 RETURN VALUES
+
+Like common memory comparison functions, the B<X509> comparison functions return
+an integer less than, equal to, or greater than zero if object B<a> is found,
+respectively, to be less than, to match, or be greater than object B<b>.
+
+X509_NAME_cmp(), X509_issuer_and_serial_cmp(), X509_issuer_name_cmp(),
+X509_subject_name_cmp() and X509_CRL_cmp() may return B<-2> to indicate an error.
+
+=head1 NOTES
+
+These functions in fact utilize the underlying B<memcmp> of C library to do the
+comparison job. Data to be compared varies from DER encoding data, SHA-1 hash
+value or B<ASN1_STRING>.
+
+X509_NAME_cmp() and wrappers utilize B<-2> value to indicated errors in some
+circumstances, which could cause confusion for the applications.
+
+=head1 SEE ALSO
+
+L<i2d_X509_NAME(3)>, L<i2d_X509(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -25,8 +25,8 @@ This set of functions are used to compare X509 objects, including X509
 certificates, X509 CRL objects and various values in an X509 certificate.
 
 The X509_cmp() function compares two B<X509> objects indicated by parameters
-B<a> and B<b>. The comparison is based on the B<memcmp> result of the SHA-1
-hash values of two B<X509> objects and the canonical (DER) encoding values.
+B<a> and B<b>. The comparison is based on the B<memcmp> result of the hash
+values of two B<X509> objects and the canonical (DER) encoding values.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
 parameters B<a> and B<b>. The comparison is based on the B<memcmp> result of
@@ -42,8 +42,8 @@ issuer names and subject names of the X<509> objects, or issuers of B<X509_CRL>
 objects, respectively.
 
 The X509_CRL_match() function compares two B<X509_CRL> objects. Unlike the
-X509_CRL_cmp() function, this function compares the SHA-1 hash values of the
-whole CRL content indicated by parameter B<a> and B<b>.
+X509_CRL_cmp() function, this function compares the the whole CRL content
+instead of just the issuer name.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -48,8 +48,8 @@ whole CRL content indicated by parameter B<a> and B<b>.
 =head1 RETURN VALUES
 
 Like common memory comparison functions, the B<X509> comparison functions return
-an integer less than, equal to, or greater than zero if object B<a> is found,
-respectively, to be less than, to match, or be greater than object B<b>.
+an integer less than, equal to, or greater than zero if object B<a> is found to
+be less than, to match, or be greater than object B<b>, respectively.
 
 X509_NAME_cmp(), X509_issuer_and_serial_cmp(), X509_issuer_name_cmp(),
 X509_subject_name_cmp() and X509_CRL_cmp() may return B<-2> to indicate an error.
@@ -58,9 +58,10 @@ X509_subject_name_cmp() and X509_CRL_cmp() may return B<-2> to indicate an error
 
 These functions in fact utilize the underlying B<memcmp> of C library to do the
 comparison job. Data to be compared varies from DER encoding data, SHA-1 hash
-value or B<ASN1_STRING>.
+value or B<ASN1_STRING>. The sign of the comparison can be used to order the
+objects but it does not have a special meaning in some cases.
 
-X509_NAME_cmp() and wrappers utilize B<-2> value to indicated errors in some
+X509_NAME_cmp() and wrappers utilize B<-2> value to indicate errors in some
 circumstances, which could cause confusion for the applications.
 
 =head1 SEE ALSO

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -61,7 +61,7 @@ comparison job. Data to be compared varies from DER encoding data, SHA-1 hash
 value or B<ASN1_STRING>. The sign of the comparison can be used to order the
 objects but it does not have a special meaning in some cases.
 
-X509_NAME_cmp() and wrappers utilize B<-2> value to indicate errors in some
+X509_NAME_cmp() and wrappers utilize the value B<-2> to indicate errors in some
 circumstances, which could cause confusion for the applications.
 
 =head1 SEE ALSO


### PR DESCRIPTION
Fixes: #9088

Functions documented in this commit: X509_cmp, X509_NAME_cmp,
X509_issuer_and_serial_cmp, X509_issuer_name_cmp, X509_subject_name_cmp,
X509_CRL_cmp, X509_CRL_match

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
