### PR TITLE
Backout deprecation of EVP_MD_CTX_ctrl and fix enable-ssl3

### DIFF
--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -542,7 +542,8 @@ void BIO_set_md(BIO *, const EVP_MD *md);
 
 int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[]);
 int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[]);
-DEPRECATEDIN_3(int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2))
+/* TODO(3.0): Deprecate this function in favour of EVP_MD_CTX_set_params */
+int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx);

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2363,7 +2363,8 @@ __owur const SSL_CIPHER *ssl3_get_cipher(unsigned int u);
 int ssl3_renegotiate(SSL *ssl);
 int ssl3_renegotiate_check(SSL *ssl, int initok);
 void ssl3_digest_master_key_set_params(const SSL_SESSION *session,
-                                       OSSL_PARAM params[]);
+                                       OSSL_PARAM params[], int *cmd,
+                                       void **msg);
 __owur int ssl3_dispatch_alert(SSL *s);
 __owur size_t ssl3_final_finish_mac(SSL *s, const char *sender, size_t slen,
                                     unsigned char *p);


### PR DESCRIPTION
Commit d5e5e2f deprecated the use of EVP_MD_CTX_ctrl in favour of EVP_MD_CTX_set_params. However this latter function requires the use of a provider, but a provider cannot currently be used for DigestSign/ DigestVerify operations or if an ENGINE is involved. The code to do this will come later but isn't there yet.

Therefore the deprecation was a little premature. There are places in libssl (notably in the SSLv3 code) that need to use the old function, so we back out the deprecation until such time as we are able to put it back. The documentation that says the function is deprecated has not been removed since backing ths out is considered a temporary measure.

Additionally when setting up OSSL_PARAMS we must be careful not to refer to memory locations that go out of scope before we've finished using the OSSL_PARAMS object.

Both of these issues together were causing builds with SSLv3 enabled to fail.

Fixes #9096