### PR TITLE
Make EVP_MD_CTX_ctrl() work for legacy use cases.

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -90,7 +90,7 @@ Cleans up digest context B<ctx> and frees up the space allocated to it.
 
 =item EVP_MD_CTX_ctrl()
 
-This is a deprecated function. EVP_MD_CTX_set_params() and EVP_MD_CTX_get_params()
+This is a legacy method. EVP_MD_CTX_set_params() and EVP_MD_CTX_get_params()
 is the mechanism that should be used to set and get parameters that are used by
 providers.
 Performs digest-specific control actions on context B<ctx>. The control command

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -42,8 +42,7 @@ extern "C" {
 
 /* digest parameters */
 #define OSSL_DIGEST_PARAM_XOFLEN    "xoflen"
-#define OSSL_DIGEST_PARAM_CMD       "cmd"
-#define OSSL_DIGEST_PARAM_MSG       "msg"
+#define OSSL_DIGEST_PARAM_SSL3_MS   "ssl3-ms"
 #define OSSL_DIGEST_PARAM_PAD_TYPE  "pad_type"
 #define OSSL_DIGEST_PARAM_MICALG    "micalg"
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -542,7 +542,7 @@ void BIO_set_md(BIO *, const EVP_MD *md);
 
 int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[]);
 int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[]);
-DEPRECATEDIN_3(int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2))
+int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx);

--- a/providers/common/digests/sha2_prov.c
+++ b/providers/common/digests/sha2_prov.c
@@ -10,6 +10,7 @@
 #include <openssl/crypto.h>
 #include <openssl/core_numbers.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #include <openssl/params.h>
 #include <openssl/core_names.h>
 #include "internal/core_mkdigest.h"
@@ -21,20 +22,14 @@ static OSSL_OP_digest_set_params_fn sha1_set_params;
 /* Special set_params method for SSL3 */
 static int sha1_set_params(void *vctx, const OSSL_PARAM params[])
 {
-    int cmd = 0;
-    size_t msg_len = 0;
-    const void *msg = NULL;
     const OSSL_PARAM *p;
     SHA_CTX *ctx = (SHA_CTX *)vctx;
 
     if (ctx != NULL && params != NULL) {
-        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_CMD);
-        if (p != NULL && !OSSL_PARAM_get_int(p, &cmd))
-            return 0;
-        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_MSG);
-        if (p != NULL && !OSSL_PARAM_get_octet_ptr(p, &msg, &msg_len))
-            return 0;
-        return sha1_ctrl(ctx, cmd, msg_len, (void *)msg);
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SSL3_MS);
+        if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
+            return sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET, p->data_size,
+                             p->data);
     }
     return 0;
 }

--- a/providers/default/digests/md5_sha1_prov.c
+++ b/providers/default/digests/md5_sha1_prov.c
@@ -22,20 +22,14 @@ static OSSL_OP_digest_set_params_fn md5_sha1_set_params;
 /* Special set_params method for SSL3 */
 static int md5_sha1_set_params(void *vctx, const OSSL_PARAM params[])
 {
-    int cmd = 0;
-    size_t msg_len = 0;
-    const void *msg = NULL;
     const OSSL_PARAM *p;
     MD5_SHA1_CTX *ctx = (MD5_SHA1_CTX *)vctx;
 
     if (ctx != NULL && params != NULL) {
-        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_CMD);
-        if (p != NULL && !OSSL_PARAM_get_int(p, &cmd))
-            return 0;
-        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_MSG);
-        if (p != NULL && !OSSL_PARAM_get_octet_ptr(p, &msg, &msg_len))
-            return 0;
-        return md5_sha1_ctrl(ctx, cmd, msg_len, (void *)msg);
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SSL3_MS);
+        if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
+            return md5_sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET, p->data_size,
+                                 p->data);
     }
     return 0;
 }

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -415,14 +415,10 @@ void ssl3_digest_master_key_set_params(const SSL_SESSION *session,
                                        OSSL_PARAM params[])
 {
     int n = 0;
-    int cmd = EVP_CTRL_SSL3_MASTER_SECRET;
-
-    params[n++] = OSSL_PARAM_construct_int(OSSL_DIGEST_PARAM_CMD, &cmd,
-                                           NULL);
-    params[n++] = OSSL_PARAM_construct_octet_ptr(OSSL_DIGEST_PARAM_MSG,
-                                                (void **)&session->master_key,
-                                                 session->master_key_length,
-                                                 NULL);
+    params[n++] = OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_SSL3_MS,
+                                                    (void *)session->master_key,
+                                                    session->master_key_length,
+                                                    NULL);
     params[n++] = OSSL_PARAM_construct_end();
 }
 
@@ -468,6 +464,7 @@ size_t ssl3_final_finish_mac(SSL *s, const char *sender, size_t len,
         OSSL_PARAM digest_cmd_params[3];
 
         ssl3_digest_master_key_set_params(s->session, digest_cmd_params);
+
         if (EVP_DigestUpdate(ctx, sender, len) <= 0
             || EVP_MD_CTX_set_params(ctx, digest_cmd_params) <= 0
             || EVP_DigestFinal_ex(ctx, p, NULL) <= 0) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -285,11 +285,14 @@ int tls_construct_cert_verify(SSL *s, WPACKET *pkt)
         }
     }
     if (s->version == SSL3_VERSION) {
-        OSSL_PARAM digest_cmd_params[3];
-
-        ssl3_digest_master_key_set_params(s->session, digest_cmd_params);
         if (EVP_DigestSignUpdate(mctx, hdata, hdatalen) <= 0
-            || EVP_MD_CTX_set_params(mctx, digest_cmd_params) <= 0
+            /*
+             * TODO(3.0) Replace this when EVP_MD_CTX_ctrl() is deprecated
+             * with a call to ssl3_digest_master_key_set_params()
+             */
+            || EVP_MD_CTX_ctrl(mctx, EVP_CTRL_SSL3_MASTER_SECRET,
+                               (int)s->session->master_key_length,
+                               s->session->master_key) <= 0
             || EVP_DigestSignFinal(mctx, sig, &siglen) <= 0) {
 
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CERT_VERIFY,
@@ -474,11 +477,14 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
         }
     }
     if (s->version == SSL3_VERSION) {
-        OSSL_PARAM digest_cmd_params[3];
-
-        ssl3_digest_master_key_set_params(s->session, digest_cmd_params);
+        /*
+         * TODO(3.0) Replace this when EVP_MD_CTX_ctrl() is deprecated
+         * with a call to ssl3_digest_master_key_set_params()
+         */
         if (EVP_DigestVerifyUpdate(mctx, hdata, hdatalen) <= 0
-                || EVP_MD_CTX_set_params(mctx, digest_cmd_params) <= 0) {
+                || EVP_MD_CTX_ctrl(mctx, EVP_CTRL_SSL3_MASTER_SECRET,
+                                   (int)s->session->master_key_length,
+                                    s->session->master_key) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CERT_VERIFY,
                      ERR_R_EVP_LIB);
             goto err;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3562,7 +3562,7 @@ X509_NAME_get_index_by_NID              3515	3_0_0	EXIST::FUNCTION:
 ENGINE_get_first                        3516	3_0_0	EXIST::FUNCTION:ENGINE
 CERTIFICATEPOLICIES_it                  3517	3_0_0	EXIST:!EXPORT_VAR_AS_FUNCTION:VARIABLE:
 CERTIFICATEPOLICIES_it                  3517	3_0_0	EXIST:EXPORT_VAR_AS_FUNCTION:FUNCTION:
-EVP_MD_CTX_ctrl                         3518	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
+EVP_MD_CTX_ctrl                         3518	3_0_0	EXIST::FUNCTION:
 PKCS7_final                             3519	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_size                           3520	3_0_0	EXIST::FUNCTION:
 EVP_DecryptFinal_ex                     3521	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is still required by engines and digestsign/digestverify

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
