### PR TITLE
EVP fetching: make operation_id part of the method identity

### DIFF
--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -59,12 +59,12 @@ static int ossl_method_construct_this(OSSL_PROVIDER *provider, void *cbdata)
              * If we haven't been told not to store,
              * add to the global store
              */
-            data->mcm->put(data->libctx, NULL, method,
+            data->mcm->put(data->libctx, NULL, method, data->operation_id,
                            thismap->algorithm_name,
                            thismap->property_definition, data->mcm_data);
         }
 
-        data->mcm->put(data->libctx, data->store, method,
+        data->mcm->put(data->libctx, data->store, method, data->operation_id,
                        thismap->algorithm_name, thismap->property_definition,
                        data->mcm_data);
 
@@ -83,7 +83,8 @@ void *ossl_method_construct(OPENSSL_CTX *libctx, int operation_id,
     void *method = NULL;
 
     if ((method =
-         mcm->get(libctx, NULL, name, propquery, mcm_data)) == NULL) {
+         mcm->get(libctx, NULL, operation_id, name, propquery, mcm_data))
+        == NULL) {
         struct construct_data_st cbdata;
 
         /*
@@ -101,7 +102,8 @@ void *ossl_method_construct(OPENSSL_CTX *libctx, int operation_id,
         ossl_provider_forall_loaded(libctx, ossl_method_construct_this,
                                     &cbdata);
 
-        method = mcm->get(libctx, cbdata.store, name, propquery, mcm_data);
+        method = mcm->get(libctx, cbdata.store, operation_id, name,
+                          propquery, mcm_data);
         mcm->dealloc_tmp_store(cbdata.store);
     }
 

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -99,10 +99,10 @@ static void *get_method_from_store(OPENSSL_CTX *libctx, void *store,
         return NULL;
 
     if ((namemap = ossl_namemap_stored(libctx)) == NULL
-        || (nameid = ossl_namemap_add(namemap, name)) == 0)
+        || (nameid = ossl_namemap_add(namemap, name)) == 0
+        || (methid = method_id(operation_id, nameid)) == 0)
         return NULL;
 
-    methid = method_id(operation_id, nameid);
     (void)ossl_method_store_fetch(store, methid, propquery, &method);
 
     if (method != NULL
@@ -123,14 +123,14 @@ static int put_method_in_store(OPENSSL_CTX *libctx, void *store,
     uint32_t methid;
 
     if ((namemap = ossl_namemap_stored(methdata->libctx)) == NULL
-        || (nameid = ossl_namemap_add(namemap, name)) == 0)
+        || (nameid = ossl_namemap_add(namemap, name)) == 0
+        || (methid = method_id(operation_id, nameid)) == 0)
         return 0;
 
     if (store == NULL
         && (store = get_default_method_store(libctx)) == NULL)
         return 0;
 
-    methid = method_id(operation_id, nameid);
     if (methdata->refcnt_up_method(method)
         && ossl_method_store_add(store, methid, propdef, method,
                                  methdata->destruct_method))

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -162,8 +162,8 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
 {
     OSSL_METHOD_STORE *store = get_default_method_store(libctx);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-    int nameid;
-    uint32_t methid;
+    int nameid = 0;
+    uint32_t methid = 0;
     void *method = NULL;
 
     if (store == NULL || namemap == NULL)

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -58,10 +58,10 @@ It's important to keep in mind that a method is identified by three things:
 =head2 Functions
 
 ossl_method_construct() creates a method by asking all available
-providers for a dispatch table given an C<operation_id>, an algorithm
-C<name> and a set of C<properties>, and then calling appropriate
+providers for a dispatch table given an I<operation_id>, an algorithm
+I<name> and a set of I<properties>, and then calling appropriate
 functions given by the sub-system specific method creator through
-C<mcm> and the data in C<mcm_data> (which is passed by
+I<mcm> and the data in I<mcm_data> (which is passed by
 ossl_method_construct()).
 
 This function assumes that the sub-system method creator implements
@@ -73,14 +73,14 @@ appropriate).
 
 A central part of constructing a sub-system specific method is to give
 ossl_method_construct a set of functions, all in the
-C<OSSL_METHOD_CONSTRUCT_METHOD> structure, which holds the following
+B<OSSL_METHOD_CONSTRUCT_METHOD> structure, which holds the following
 function pointers:
 
 =over 4
 
 =item alloc_tmp_store()
 
-Create a temporary method store in the scope of the library context C<ctx>.
+Create a temporary method store in the scope of the library context I<ctx>.
 This store is used to temporarily store methods for easier lookup, for
 when the provider doesn't want its dispatch table stored in a longer
 term cache.
@@ -93,41 +93,41 @@ Remove a temporary store.
 
 Look up an already existing method from a store by name.
 
-The store may be given with C<store>.
+The store may be given with I<store>.
 B<NULL> is a valid value and means that a sub-system default store
 must be used.
-This default store should be stored in the library context C<libctx>.
+This default store should be stored in the library context I<libctx>.
 
 The method to be looked up should be identified with the given
-C<operation_id>, C<name>, the provided property query C<propquery>
-and data from C<data> (which is the C<mcm_data> that was passed to
+I<operation_id>, I<name>, the provided property query I<propquery>
+and data from I<data> (which is the I<mcm_data> that was passed to
 ossl_construct_method()).
 
 This function is expected to increment the method's reference count.
 
 =item put()
 
-Places the C<method> created by the construct() function (see below)
+Places the I<method> created by the construct() function (see below)
 in a store.
 
-The store may be given with C<store>.
+The store may be given with I<store>.
 B<NULL> is a valid value and means that a sub-system default store
 must be used.
-This default store should be stored in the library context C<libctx>.
+This default store should be stored in the library context I<libctx>.
 
-The method should be associated with the given C<operation_id>,
-C<name> and property definition C<propdef> as well as any
-identification data given through C<data> (which is the C<mcm_data>
+The method should be associated with the given I<operation_id>,
+I<name> and property definition I<propdef> as well as any
+identification data given through I<data> (which is the I<mcm_data>
 that was passed to ossl_construct_method()).
 
-This function is expected to increment the C<method>'s reference count.
+This function is expected to increment the I<method>'s reference count.
 
 =item construct()
 
-Constructs a sub-system method for the given C<name> and the given
-dispatch table C<fns>.
+Constructs a sub-system method for the given I<name> and the given
+dispatch table I<fns>.
 
-The associated I<provider object> C<prov> is passed as well, to make
+The associated provider object I<prov> is passed as well, to make
 it possible for the sub-system constructor to keep a reference, which
 is recommended.
 If such a reference is kept, the I<provider object> reference counter
@@ -137,7 +137,7 @@ This function is expected to set the method's reference count to 1.
 
 =item desctruct()
 
-Decrement the C<method>'s reference count, and destruct it when
+Decrement the I<method>'s reference count, and destruct it when
 the reference count reaches zero.
 
 =back

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -15,11 +15,13 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
      /* Remove a store */
      void (*dealloc_tmp_store)(void *store);
      /* Get an already existing method from a store */
-     void *(*get)(OPENSSL_CTX *libctx, void *store, const char *name,
-                  const char *propquery, void *data);
+     void *(*get)(OPENSSL_CTX *libctx, void *store,
+                  int operation_id, const char *name, const char *propquery,
+                  void *data);
      /* Store a method in a store */
      int (*put)(OPENSSL_CTX *libctx, void *store, void *method,
-                const char *name, const char *propdef, void *data);
+                int operation_id, const char *name, const char *propdef,
+                void *data);
      /* Construct a new method */
      void *(*construct)(const char *name, const OSSL_DISPATCH *fns,
                         OSSL_PROVIDER *prov, void *data);
@@ -40,6 +42,18 @@ All libcrypto sub-systems that want to create their own methods based
 on provider dispatch tables need to do so in exactly the same way.
 ossl_method_construct() does this while leaving it to the sub-systems
 to define more precisely how the methods are created, stored, etc.
+
+It's important to keep in mind that a method is identified by three things:
+
+=over 4
+
+=item The operation identity
+
+=item The name of the algorithm
+
+=item The properties associated with the algorithm implementation
+
+=back
 
 =head2 Functions
 
@@ -84,10 +98,10 @@ B<NULL> is a valid value and means that a sub-system default store
 must be used.
 This default store should be stored in the library context C<libctx>.
 
-The method to be looked up should be identified with the given C<name> and
-data from C<data>
-(which is the C<mcm_data> that was passed to ossl_construct_method())
-and the provided property query C<propquery>.
+The method to be looked up should be identified with the given
+C<operation_id>, C<name>, the provided property query C<propquery>
+and data from C<data> (which is the C<mcm_data> that was passed to
+ossl_construct_method()).
 
 This function is expected to increment the method's reference count.
 
@@ -101,9 +115,10 @@ B<NULL> is a valid value and means that a sub-system default store
 must be used.
 This default store should be stored in the library context C<libctx>.
 
-The method should be associated with the given C<name> and property definition
-C<propdef> as well as any identification data given through C<data> (which is
-the C<mcm_data> that was passed to ossl_construct_method()).
+The method should be associated with the given C<operation_id>,
+C<name> and property definition C<propdef> as well as any
+identification data given through C<data> (which is the C<mcm_data>
+that was passed to ossl_construct_method()).
 
 This function is expected to increment the C<method>'s reference count.
 

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -32,11 +32,13 @@ typedef struct ossl_method_construct_method_st {
     /* Remove a store */
     void (*dealloc_tmp_store)(void *store);
     /* Get an already existing method from a store */
-    void *(*get)(OPENSSL_CTX *libctx, void *store, const char *name,
-                 const char *propquery, void *data);
+    void *(*get)(OPENSSL_CTX *libctx, void *store,
+                 int operation_id, const char *name, const char *propquery,
+                 void *data);
     /* Store a method in a store */
     int (*put)(OPENSSL_CTX *libctx, void *store, void *method,
-               const char *name, const char *propdef, void *data);
+               int operation_id, const char *name, const char *propdef,
+               void *data);
     /* Construct a new method */
     void *(*construct)(const char *name, const OSSL_DISPATCH *fns,
                        OSSL_PROVIDER *prov, void *data);


### PR DESCRIPTION
Because the operation identity wasn't integrated with the created
methods, the following code would give unexpected results:

    EVP_MD *md = EVP_MD_fetch(NULL, "MD5", NULL);
    EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "MD5", NULL);

    if (md != NULL)
        printf("MD5 is a digest\n");
    if (cipher != NULL)
        printf("MD5 is a cipher\n");

The message is that MD5 is both a digest and a cipher.

Partially fixes #9106
