### PR TITLE
enhance trace API adding verbosity levels and automatic func+file+line output

### DIFF
--- a/Configure
+++ b/Configure
@@ -462,6 +462,7 @@ our %disabled = ( # "what"         => "comment"
                   "ssl-trace"           => "default",
                   "ssl3"                => "default",
                   "ssl3-method"         => "default",
+                  "trace"               => "default",
                   "ubsan"               => "default",
                   "unit-test"           => "default",
                   "weak-ssl-ciphers"    => "default",

--- a/Configure
+++ b/Configure
@@ -462,7 +462,6 @@ our %disabled = ( # "what"         => "comment"
                   "ssl-trace"           => "default",
                   "ssl3"                => "default",
                   "ssl3-method"         => "default",
-                  "trace"               => "default",
                   "ubsan"               => "default",
                   "unit-test"           => "default",
                   "weak-ssl-ciphers"    => "default",

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -159,7 +159,7 @@ int OSSL_trace_get_category_num(const char *name)
 /* We use one trace channel for each trace category */
 static struct {
     enum { SIMPLE_CHANNEL, CALLBACK_CHANNEL } type;
-    int verbosity;
+    int level;
     BIO *bio;
     char *prefix;
     char *suffix;
@@ -326,7 +326,7 @@ void ossl_trace_cleanup(void)
 #endif
 }
 
-const char *OSSL_trace_get_verbosity_name(int level)
+const char *OSSL_trace_get_level_name(int level)
 {
     switch (level) {
     case OSSL_TRACE_LEVEL_ALERT: return "ALERT";
@@ -339,27 +339,27 @@ const char *OSSL_trace_get_verbosity_name(int level)
     }
 }
 
-int OSSL_trace_get_verbosity(int category)
+int OSSL_trace_get_level(int category)
 {
 #ifndef OPENSSL_NO_TRACE
     if (category < 0 || category >= OSSL_TRACE_CATEGORY_NUM)
         return OSSL_TRACE_LEVEL_UNDEFINED;
-    if (trace_channels[category].verbosity == OSSL_TRACE_LEVEL_UNDEFINED)
+    if (trace_channels[category].level == OSSL_TRACE_LEVEL_UNDEFINED)
         return OSSL_TRACE_LEVEL_DEFAULT;
-    return trace_channels[category].verbosity;
+    return trace_channels[category].level;
 #else
     return OSSL_TRACE_LEVEL_UNDEFINED;
 #endif
 }
 
-int OSSL_trace_set_verbosity(int category, int level)
+int OSSL_trace_set_level(int category, int level)
 {
 #ifndef OPENSSL_NO_TRACE
     if (category < 0 || category >= OSSL_TRACE_CATEGORY_NUM)
         return 0;
     if (level <= OSSL_TRACE_LEVEL_UNDEFINED || OSSL_TRACE_LEVEL_TRACE < level)
         return 0;
-    trace_channels[category].verbosity = level;
+    trace_channels[category].level = level;
 #endif
     return 1;
 }
@@ -487,7 +487,7 @@ BIO *OSSL_trace_begin(int category, int level)
         return NULL;
 
     if (level != OSSL_TRACE_LEVEL_UNDEFINED
-            && level > OSSL_trace_get_verbosity(category))
+            && level > OSSL_trace_get_level(category))
         return NULL;
 
     channel = trace_channels[category].bio;

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -59,7 +59,7 @@ int OSSL_trace_get_category_num(const char *name);
 const char *OSSL_trace_get_category_name(int num);
 
 /*
- * TRACE LEVEL AND VERBOSITY
+ * TRACE LEVEL
  */
 
 # define OSSL_TRACE_LEVEL_UNDEFINED     0
@@ -72,9 +72,9 @@ const char *OSSL_trace_get_category_name(int num);
 # define OSSL_TRACE_LEVEL_DEFAULT       OSSL_TRACE_LEVEL_INFO
 /* could be OSSL_TRACE_LEVEL_DEBUG if defined DEBUG && !defined NDEBUG */
 
-const char *OSSL_trace_get_verbosity_name(int level);
-int OSSL_trace_get_verbosity(int category);
-int OSSL_trace_set_verbosity(int category, int level);
+const char *OSSL_trace_get_level_name(int level);
+int OSSL_trace_get_level(int category);
+int OSSL_trace_set_level(int category, int level);
 
 /*
  * TRACE CONSUMERS
@@ -301,7 +301,7 @@ void OSSL_trace_end(int category, BIO *channel);
         if (trc_out != NULL) { \
             BIO_printf(trc_out, "%s:%s:%d:%s:", OSSL_FUNC, OPENSSL_FILE, \
                        OPENSSL_LINE, \
-                       OSSL_trace_get_verbosity_name(OSSL_TRACE_LEVEL_##level)); \
+                       OSSL_trace_get_level_name(OSSL_TRACE_LEVEL_##level)); \
             BIO_printf args; \
         } \
     OSSL_TRACE_END(category) \

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -69,11 +69,8 @@ const char *OSSL_trace_get_category_name(int num);
 # define OSSL_TRACE_LEVEL_INFO          4
 # define OSSL_TRACE_LEVEL_DEBUG         5
 # define OSSL_TRACE_LEVEL_TRACE         6
-# if defined DEBUG && !defined NDEBUG
-#  define OSSL_TRACE_LEVEL_DEFAULT      OSSL_TRACE_LEVEL_DEBUG
-# else
-#  define OSSL_TRACE_LEVEL_DEFAULT      OSSL_TRACE_LEVEL_INFO
-# endif
+# define OSSL_TRACE_LEVEL_DEFAULT       OSSL_TRACE_LEVEL_INFO
+/* could be OSSL_TRACE_LEVEL_DEBUG if defined DEBUG && !defined NDEBUG */
 
 const char *OSSL_trace_get_verbosity_name(int level);
 int OSSL_trace_get_verbosity(int category);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4824,3 +4824,6 @@ OSSL_CMP_MSG_dup                        4768	3_0_0	EXIST::FUNCTION:CMP
 ERR_load_CMP_strings                    4769	3_0_0	EXIST::FUNCTION:CMP
 EVP_MD_CTX_set_params                   4770	3_0_0	EXIST::FUNCTION:
 EVP_MD_CTX_get_params                   4771	3_0_0	EXIST::FUNCTION:
+OSSL_trace_get_level_name               4772	3_0_0	EXIST::FUNCTION:
+OSSL_trace_get_level                    4773	3_0_0	EXIST::FUNCTION:
+OSSL_trace_set_level                    4774	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is a by-product of the CMP contribution. As discussed with @mattcaswell  for the preview of chunk 4: https://github.com/mpeylo/cmpossl/pull/178#discussion_r287743229 I've carved this out as an independent PR. It is going to be used first in #9107.

This adds 
* severity/verbosity levels per category: alert/error/warning/info/debug/trace
* automatic output of function name, file name, line number, and severity level to the trace API.

I have not yet updated the documentation files accordingly because I thought it would be more efficient to collect some feedback, decide on any further changes, and then implement them along with the due extensions of the respective `.pod` files.

The use of the severity level functions should be self-explanatory.
Log messages can be produced like this:
```
OSSL_TRACE(TLS, "message with default severity level"); /* as before, backward compatsible */
OSSL_TRACEV(TLS, INFO, (trc_out, "this is a TLS %s message\n", "info")); /* with explicit level etc. */
OSSL_CMP_info("this is a CMP info message"); /* using include/openssl/cmp_util.h */
```
The output, as far as enabled according to the level, looks like this:
```
my_function:test/my_file.c:103:INFO:this is a CMP info message
```
It turns out that the trace facility of OpenSSL is disabled globally by default and needs to be enabled explicitly via the enable-trace configuration option. This is not adequate when using the trace API for error and warning output.
What I propose instead is to enable its inclusion by default (as done in this PR in `Configiure`)
while taking, e.g., `OSSL_TRACE_LEVEL_INFO` as the default level of verbosity. In this way detailed (trace-level and debugging) output remains disabled while alert, error, warning, and info output is enabled.
When `DEBUG` is defined and `NDEBUG` is not defined, the default becomes `OSSL_TRACE_LEVEL_DEBUG`.
Using the new code in `trace.h` and `trace.c`, the level of verbosity can be adapted per category.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated

