### PR TITLE
Revert the DEVRANDOM_WAIT feature [1.1.1]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,17 @@
 
  Changes between 1.1.1c and 1.1.1d [xx XXX xxxx]
 
-  *)
+  *) Revert the DEVRANDOM_WAIT feature for Linux systems
+
+     The DEVRANDOM_WAIT feature added a select() call to wait for the
+     /dev/random device to become readable before reading from the
+     /dev/urandom device.
+
+     It turned out that this change had negative side effects on the
+     performance which were not acceptable. After some discussion it
+     was decided to revert this feature and leave it up to the OS
+     resp. the platform maintainer to ensure a proper initialization
+     during early boot time.
 
  Changes between 1.1.1b and 1.1.1c [28 May 2019]
 
@@ -78,6 +88,16 @@
      Greef of Ronomon.
      (CVE-2019-1543)
      [Matt Caswell]
+
+  *) Add DEVRANDOM_WAIT feature for Linux systems
+
+     On older Linux systems where the getrandom() system call is not available,
+     OpenSSL normally uses the /dev/urandom device for seeding its CSPRNG.
+     Contrary to getrandom(), the /dev/urandom device will not block during
+     early boot when the kernel CSPRNG has not been initially seeded yet.
+
+     To mitigate this known weakness, use select() to wait for /dev/random to
+     become readable before reading from /dev/urandom.
 
   *) Ensure that SM2 only uses SM3 as digest algorithm
      [Paul Yang]

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -510,29 +510,6 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
     bytes_needed = rand_pool_bytes_needed(pool, 1 /*entropy_factor*/);
     {
         size_t i;
-#ifdef DEVRANDOM_WAIT
-        static int wait_done = 0;
-
-        /*
-         * On some implementations reading from /dev/urandom is possible
-         * before it is initialized. Therefore we wait for /dev/random
-         * to be readable to make sure /dev/urandom is initialized.
-         */
-        if (!wait_done && bytes_needed > 0) {
-             int f = open(DEVRANDOM_WAIT, O_RDONLY);
-
-             if (f >= 0) {
-                 fd_set fds;
-
-                 FD_ZERO(&fds);
-                 FD_SET(f, &fds);
-                 while (select(f+1, &fds, NULL, NULL, NULL) < 0
-                        && errno == EINTR);
-                 close(f);
-             }
-             wait_done = 1;
-        }
-#endif
 
         for (i = 0; bytes_needed > 0 && i < OSSL_NELEM(random_device_paths); i++) {
             ssize_t bytes = 0;

--- a/e_os.h
+++ b/e_os.h
@@ -28,9 +28,6 @@
  * default, we will try to read at least one of these files
  */
 #  define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
-#  ifdef __linux
-#   define DEVRANDOM_WAIT "/dev/random"
-#  endif
 # endif
 # if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
 /*


### PR DESCRIPTION
The first commit of this pull request is the (unmodified) cherry-pick of #9084, the second adds the CHANGES entries:

82c4bcbeb3 Revert the DEVRANDOM_WAIT feature (cherry picked from commit c19c5a6)
55df89e5f8 Add CHANGES entries for the DEVRANDOM_WAIT feature and its removal.