### PR TITLE
SSL: Pass the master key by explicit parameters

### DIFF
--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -42,8 +42,7 @@ extern "C" {
 
 /* digest parameters */
 #define OSSL_DIGEST_PARAM_XOFLEN    "xoflen"
-#define OSSL_DIGEST_PARAM_CMD       "cmd"
-#define OSSL_DIGEST_PARAM_MSG       "msg"
+#define OSSL_DIGEST_PARAM_SSL3_MS   "ssl3-ms"
 #define OSSL_DIGEST_PARAM_PAD_TYPE  "pad_type"
 #define OSSL_DIGEST_PARAM_MICALG    "micalg"
 

--- a/providers/common/digests/sha2_prov.c
+++ b/providers/common/digests/sha2_prov.c
@@ -28,9 +28,9 @@ static int sha1_set_params(void *vctx, const OSSL_PARAM params[])
     if (ctx != NULL && params != NULL) {
         p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SSL3_MS);
         /*
-         * We don't use OSSL_PARAM_get_octet_ptr(), because it assumes it
-         * should copy the data.  However, we know that sha1_ctrl() will
-         * consume the data anyway, making an extra copy unnecessary.
+         * Since we know that sha1_ctrl() uses the data right away, we don't
+         * use OSSL_PARAM_get_octet_ptr(), since it assumes it should copy
+         * the data.  That extra copy isn't necessary here.
          */
         if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
             return sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,

--- a/providers/common/digests/sha2_prov.c
+++ b/providers/common/digests/sha2_prov.c
@@ -22,17 +22,19 @@ static OSSL_OP_digest_set_params_fn sha1_set_params;
 /* Special set_params method for SSL3 */
 static int sha1_set_params(void *vctx, const OSSL_PARAM params[])
 {
-    size_t msg_len = 0;
-    const void *msg = NULL;
     const OSSL_PARAM *p;
     SHA_CTX *ctx = (SHA_CTX *)vctx;
 
     if (ctx != NULL && params != NULL) {
         p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SSL3_MS);
-        if (p != NULL && !OSSL_PARAM_get_octet_ptr(p, &msg, &msg_len))
-            return 0;
-        return sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
-                         msg_len, (void *)msg);
+        /*
+         * We don't use OSSL_PARAM_get_octet_ptr(), because it assumes it
+         * should copy the data.  However, we know that sha1_ctrl() will
+         * consume the data anyway, making an extra copy unnecessary.
+         */
+        if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
+            return sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
+                             p->data_size, p->data);
     }
     return 0;
 }

--- a/providers/default/digests/md5_sha1_prov.c
+++ b/providers/default/digests/md5_sha1_prov.c
@@ -22,20 +22,17 @@ static OSSL_OP_digest_set_params_fn md5_sha1_set_params;
 /* Special set_params method for SSL3 */
 static int md5_sha1_set_params(void *vctx, const OSSL_PARAM params[])
 {
-    int cmd = 0;
     size_t msg_len = 0;
     const void *msg = NULL;
     const OSSL_PARAM *p;
     MD5_SHA1_CTX *ctx = (MD5_SHA1_CTX *)vctx;
 
     if (ctx != NULL && params != NULL) {
-        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_CMD);
-        if (p != NULL && !OSSL_PARAM_get_int(p, &cmd))
-            return 0;
-        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_MSG);
+        p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SSL3_MS);
         if (p != NULL && !OSSL_PARAM_get_octet_ptr(p, &msg, &msg_len))
             return 0;
-        return md5_sha1_ctrl(ctx, cmd, msg_len, (void *)msg);
+        return md5_sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
+                             msg_len, (void *)msg);
     }
     return 0;
 }

--- a/providers/default/digests/md5_sha1_prov.c
+++ b/providers/default/digests/md5_sha1_prov.c
@@ -28,9 +28,9 @@ static int md5_sha1_set_params(void *vctx, const OSSL_PARAM params[])
     if (ctx != NULL && params != NULL) {
         p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SSL3_MS);
         /*
-         * We don't use OSSL_PARAM_get_octet_ptr(), because it assumes it
-         * should copy the data.  However, we know that sha1_ctrl() will
-         * consume the data anyway, making an extra copy unnecessary.
+         * Since we know that md5_sha1_ctrl() uses the data right away, we
+         * don't use OSSL_PARAM_get_octet_ptr(), since it assumes it should
+         * copy the data.  That extra copy isn't necessary here.
          */
         if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
             return md5_sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -415,11 +415,8 @@ void ssl3_digest_master_key_set_params(const SSL_SESSION *session,
                                        OSSL_PARAM params[])
 {
     int n = 0;
-    int cmd = EVP_CTRL_SSL3_MASTER_SECRET;
 
-    params[n++] = OSSL_PARAM_construct_int(OSSL_DIGEST_PARAM_CMD, &cmd,
-                                           NULL);
-    params[n++] = OSSL_PARAM_construct_octet_ptr(OSSL_DIGEST_PARAM_MSG,
+    params[n++] = OSSL_PARAM_construct_octet_ptr(OSSL_DIGEST_PARAM_SSL3_MS,
                                                 (void **)&session->master_key,
                                                  session->master_key_length,
                                                  NULL);

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -416,10 +416,11 @@ void ssl3_digest_master_key_set_params(const SSL_SESSION *session,
 {
     int n = 0;
 
-    params[n++] = OSSL_PARAM_construct_octet_ptr(OSSL_DIGEST_PARAM_SSL3_MS,
-                                                (void **)&session->master_key,
-                                                 session->master_key_length,
-                                                 NULL);
+    params[n++] =
+        OSSL_PARAM_construct_octet_string(OSSL_DIGEST_PARAM_SSL3_MS,
+                                          (void *)session->master_key,
+                                          session->master_key_length,
+                                          NULL);
     params[n++] = OSSL_PARAM_construct_end();
 }
 


### PR DESCRIPTION
The parameter keys for passing the master key down to the algorithms
handling that was done in a way that mimics the legacy EVP_MD_CTX_ctrl()
function.  We now change that to use an explicit parameter key, and
let set_params() type functions translate that into legacy controls
where needed, under the hood.
