### PR TITLE
Move a fall through comment

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -718,8 +718,8 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 hints.ai_flags &= ~AI_ADDRCONFIG;
                 goto retry;
             }
-            /* fall through */
 # endif
+            /* fall through */
         default:
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             ERR_add_error_data(1, gai_strerror(gai_ret));


### PR DESCRIPTION
When compiling with --strict-warnings using gcc 7.4.0 the compiler
complains that a case falls through, even though there is an explicit
comment stating this. Moving the comment outside of the conditional
compilation section resolves this.