### PR TITLE
make local functions in ecp_nistz256-sparcv9.S indeed local

### DIFF
--- a/crypto/ec/asm/ecp_nistz256-sparcv9.pl
+++ b/crypto/ec/asm/ecp_nistz256-sparcv9.pl
@@ -2301,7 +2301,6 @@ my ($Z1sqr, $Z2sqr) = ($Hsqr, $Rsqr);
 # !in1infty, !in2infty and result of check for zero.
 
 $code.=<<___;
-.globl	ecp_nistz256_point_add_vis3
 .align	32
 ecp_nistz256_point_add_vis3:
 	save	%sp,-STACK64_FRAME-32*18-32,%sp


### PR DESCRIPTION
Fixes a linking issue on Solaris 11.4 by making all local functions to adhere to common scheme.

I used the `solaris64-sparcv9-cc` build target and used Oracle Developer studio 12.5 + Solaris linker for building. e.g. `libcrypto.so` was built like this:
```
cc -KPIC -xarch=v9 -xstrconst -Xa -xO5 -xdepend -L. -G -dy -z text -Wl,-Bsymbolic -mt  -Wl,-h,libcrypto.so.3 \
        -o libcrypto.so.3 -Wl,-M,libcrypto.ld crypto/aes/libcrypto-shlib-aes-sparcv9.o  
... number of object files elided
                 -lsocket -lnsl -ldl -lpthread -lc 
```
i.e. it used the `-z text` option that uncovered the problematic `ecp_nistz256_point_add_vis3` function definition.