### PR TITLE
Configure: Add support for variables in build.info files

### DIFF
--- a/Configure
+++ b/Configure
@@ -1826,6 +1826,24 @@ if ($builder eq "unified") {
         my %depends = ();
         my %generate = ();
 
+        # Support for $variablename in build.info files.
+        # Embedded perl code is the ultimate master, still.  If its output
+        # contains a dollar sign, it had better be escaped, or it will be
+        # taken for a variable name prefix.
+        my %variables = ();
+        my $variable_re = qr/\$([[:alpha:]][[:alnum:]_]*)/;
+        my $expand_variables = sub {
+            my $value = '';
+            my $value_rest = shift;
+
+            while ($value_rest =~ /(?<!\\)${variable_re}/) {
+                $value .= $`;
+                $value .= $variables{$1};
+                $value_rest = $';
+            }
+            return $value . $value_rest;
+        };
+
         # We want to detect configdata.pm in the source tree, so we
         # don't use it if the build tree is different.
         my $src_configdata = cleanfile($srcdir, "configdata.pm", $blddir);
@@ -1881,10 +1899,16 @@ if ($builder eq "unified") {
             qr/^\s*ENDIF\s*$/
             => sub { die "ENDIF out of scope" if ! @skip;
                      pop @skip; },
+            qr/^\s*${variable_re}\s*=\s*(.*?)\s*$/
+            => sub {
+                if (!@skip || $skip[$#skip] > 0) {
+                    $variables{$1} = $2;
+                }
+            },
             qr/^\s*SUBDIRS\s*=\s*(.*)\s*$/
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
-                    foreach (tokenize($1)) {
+                    foreach (tokenize($expand_variables->($1))) {
                         push @build_dirs, [ @curd, splitdir($_, 1) ];
                     }
                 }
@@ -1893,7 +1917,7 @@ if ($builder eq "unified") {
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
                     my @a = tokenize($1, qr|\s*,\s*|);
-                    my @p = tokenize($2);
+                    my @p = tokenize($expand_variables->($2));
                     push @programs, @p;
                     foreach my $a (@a) {
                         my $ak = $a;
@@ -1912,7 +1936,7 @@ if ($builder eq "unified") {
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
                     my @a = tokenize($1, qr|\s*,\s*|);
-                    my @l = tokenize($2);
+                    my @l = tokenize($expand_variables->($2));
                     push @libraries, @l;
                     foreach my $a (@a) {
                         my $ak = $a;
@@ -1931,7 +1955,7 @@ if ($builder eq "unified") {
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
                     my @a = tokenize($1, qr|\s*,\s*|);
-                    my @m = tokenize($2);
+                    my @m = tokenize($expand_variables->($2));
                     push @modules, @m;
                     foreach my $a (@a) {
                         my $ak = $a;
@@ -1950,7 +1974,7 @@ if ($builder eq "unified") {
             => sub {
                 if (!@skip || $skip[$#skip] > 0) {
                     my @a = tokenize($1, qr|\s*,\s*|);
-                    my @s = tokenize($2);
+                    my @s = tokenize($expand_variables->($2));
                     push @scripts, @s;
                     foreach my $a (@a) {
                         my $ak = $a;
@@ -1967,22 +1991,23 @@ if ($builder eq "unified") {
             },
 
             qr/^\s*ORDINALS\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/,
-            => sub { push @{$ordinals{$1}}, tokenize($2)
+            => sub { push @{$ordinals{$1}}, tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SOURCE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$sources{$1}}, tokenize($2)
+            => sub { push @{$sources{$1}}, tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SHARED_SOURCE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$shared_sources{$1}}, tokenize($2)
+            => sub { push @{$shared_sources{$1}},
+                         tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*INCLUDE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$includes{$1}}, tokenize($2)
+            => sub { push @{$includes{$1}}, tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*DEFINE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$defines{$1}}, tokenize($2)
+            => sub { push @{$defines{$1}}, tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*DEPEND\[((?:\\.|[^\\\]])*)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$depends{$1}}, tokenize($2)
+            => sub { push @{$depends{$1}}, tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*GENERATE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
             => sub { push @{$generate{$1}}, $2

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -1,11 +1,9 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        aes_misc.c aes_ecb.c aes_cfb.c aes_ofb.c \
-        aes_ige.c aes_wrap.c {- $target{aes_asm_src} -}
 
-SOURCE[../../providers/fips]=\
-        aes_misc.c aes_ecb.c \
-        {- $target{aes_asm_src} -}
+$COMMON=aes_misc.c aes_ecb.c {- $target{aes_asm_src} -}
+SOURCE[../../libcrypto]=$COMMON \
+        aes_cfb.c aes_ofb.c aes_ige.c aes_wrap.c
+SOURCE[../../providers/fips]=$COMMON
 
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -1,15 +1,13 @@
 LIBS=../../libcrypto
 
-{- our @src = ( qw( bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_mul.c
-                    bn_mod.c bn_conv.c bn_rand.c bn_shift.c bn_word.c bn_blind.c
-                    bn_kron.c bn_sqrt.c bn_gcd.c bn_prime.c bn_sqr.c
-                    bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c
-                    bn_const.c bn_x931p.c bn_intern.c bn_dh.c
-                    bn_rsa_fips186_4.c ), $target{bn_asm_src} ); "" -}
-
-SOURCE[../../libcrypto]={- join(' ', @src) -} bn_print.c bn_err.c bn_depr.c bn_srp.c
-
-SOURCE[../../providers/fips]={- join(' ', @src) -}
+$COMMON=bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_mul.c \
+        bn_mod.c bn_conv.c bn_rand.c bn_shift.c bn_word.c bn_blind.c \
+        bn_kron.c bn_sqrt.c bn_gcd.c bn_prime.c bn_sqr.c \
+        bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c \
+        bn_const.c bn_x931p.c bn_intern.c bn_dh.c \
+        bn_rsa_fips186_4.c {- $target{bn_asm_src} -}
+SOURCE[../../libcrypto]=$COMMON bn_print.c bn_err.c bn_depr.c bn_srp.c
+SOURCE[../../providers/fips]=$COMMON
 
 
 INCLUDE[../../libcrypto]=../../crypto/include

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -9,26 +9,23 @@ SUBDIRS=objects buffer bio stack lhash rand evp asn1 pem x509 conf \
 
 LIBS=../libcrypto
 # The Core
-SOURCE[../libcrypto]=provider_core.c provider_predefined.c provider_conf.c \
-        core_fetch.c core_namemap.c
+$CORE_COMMON=provider_core.c provider_predefined.c core_fetch.c core_namemap.c
 
-SOURCE[../providers/fips]=provider_core.c provider_predefined.c \
-        core_fetch.c core_namemap.c
+SOURCE[../libcrypto]=$CORE_COMMON provider_conf.c
+SOURCE[../providers/fips]=$CORE_COMMON
 
 # Central utilities
-SOURCE[../libcrypto]=\
-        cryptlib.c mem.c mem_dbg.c cversion.c info.c ex_data.c cpt_err.c \
-        ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c ctype.c \
-        threads_pthread.c threads_win.c threads_none.c getenv.c \
-        o_init.c o_fips.c mem_sec.c init.c context.c sparse_array.c \
-        trace.c provider.c params.c bsearch.c \
-        {- $target{cpuid_asm_src} -} {- $target{uplink_aux_src} -}
-
-# FIPS module
-SOURCE[../providers/fips]=\
+$UTIL_COMMON=\
         cryptlib.c mem.c mem_sec.c params.c bsearch.c ex_data.c o_str.c \
         ctype.c threads_pthread.c threads_win.c threads_none.c context.c \
         sparse_array.c {- $target{cpuid_asm_src} -}
+
+SOURCE[../libcrypto]=$UTIL_COMMON \
+        mem_dbg.c cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \
+        o_fopen.c getenv.c o_init.c o_fips.c init.c trace.c provider.c \
+        {- $target{uplink_aux_src} -}
+SOURCE[../providers/fips]=$UTIL_COMMON
+        
 
 
 DEPEND[cversion.o]=buildinf.h

--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -1,6 +1,7 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        encode.c digest.c evp_enc.c evp_key.c evp_cnf.c \
+$COMMON=digest.c evp_enc.c evp_lib.c evp_fetch.c cmeth_lib.c
+SOURCE[../../libcrypto]=$COMMON\
+        encode.c evp_key.c evp_cnf.c \
         e_des.c e_bf.c e_idea.c e_des3.c e_camellia.c\
         e_rc4.c e_aes.c names.c e_seed.c e_aria.c e_sm4.c \
         e_xcbc_d.c e_rc2.c e_cast.c e_rc5.c \
@@ -8,21 +9,14 @@ SOURCE[../../libcrypto]=\
         m_md5_sha1.c m_mdc2.c m_ripemd.c m_sha3.c \
         p_open.c p_seal.c p_sign.c p_verify.c p_lib.c p_enc.c p_dec.c \
         bio_md.c bio_b64.c bio_enc.c evp_err.c e_null.c \
-        c_allc.c c_alld.c evp_lib.c bio_ok.c \
+        c_allc.c c_alld.c bio_ok.c \
         evp_pkey.c kdf_lib.c evp_pbe.c p5_crpt.c p5_crpt2.c pbe_scrypt.c \
         pkey_kdf.c c_allkdf.c \
         e_old.c pmeth_lib.c pmeth_fn.c pmeth_gn.c m_sigver.c \
         e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha256.c e_rc4_hmac_md5.c \
-        e_chacha20_poly1305.c cmeth_lib.c \
+        e_chacha20_poly1305.c \
         mac_lib.c c_allm.c pkey_mac.c
-
-# New design
-SOURCE[../../libcrypto]=\
-	evp_fetch.c
-
-# FIPS Module
-SOURCE[../../providers/fips]=\
-        digest.c evp_enc.c evp_lib.c evp_fetch.c cmeth_lib.c
+SOURCE[../../providers/fips]=$COMMON
 
 INCLUDE[e_aes.o]=.. ../modes
 INCLUDE[e_aes_cbc_hmac_sha1.o]=../modes

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -1,12 +1,9 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        cbc128.c ctr128.c cts128.c cfb128.c ofb128.c gcm128.c \
-        ccm128.c xts128.c wrap128.c ocb128.c siv128.c \
-        {- $target{modes_asm_src} -}
 
-SOURCE[../../providers/fips]=\
-        cbc128.c ctr128.c cfb128.c ofb128.c \
-        {- $target{modes_asm_src} -}
+$COMMON=cbc128.c ctr128.c cfb128.c ofb128.c {- $target{modes_asm_src} -}
+SOURCE[../../libcrypto]=$COMMON \
+        cts128.c gcm128.c ccm128.c xts128.c wrap128.c ocb128.c siv128.c
+SOURCE[../../providers/fips]=$COMMON
 
 INCLUDE[gcm128.o]=..
 

--- a/crypto/property/build.info
+++ b/crypto/property/build.info
@@ -1,5 +1,4 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=property_string.c property_parse.c property.c \
-                        property_err.c defn_cache.c
-SOURCE[../../providers/fips]=\
-    property_string.c property_parse.c property.c defn_cache.c
+$COMMON=property_string.c property_parse.c property.c defn_cache.c
+SOURCE[../../libcrypto]=$COMMON property_err.c
+SOURCE[../../providers/fips]=$COMMON

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -1,10 +1,9 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        sha1dgst.c sha1_one.c sha256.c sha512.c sha3.c \
-        {- $target{sha1_asm_src} -} {- $target{keccak1600_asm_src} -}
 
-SOURCE[../../providers/fips]= sha1dgst.c sha256.c sha512.c sha3.c \
-        {- $target{keccak1600_asm_src} -} {- $target{sha1_asm_src} -}
+$COMMON=sha1dgst.c sha256.c sha512.c sha3.c \
+        {- $target{sha1_asm_src} -} {- $target{keccak1600_asm_src} -}
+SOURCE[../../libcrypto]=$COMMON sha1_one.c
+SOURCE[../../providers/fips]= $COMMON
 
 GENERATE[sha1-586.s]=asm/sha1-586.pl \
         $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)


### PR DESCRIPTION
Variables have the syntax defined with this regular expression:

    \$([[:alpha:]_][[:alnum:]_]*)

They are always local to the build.info they are defined in, and are
defined like this:

    $VAR=text

Expansion is done very simply, any reference to the variable (with the
exact same variable syntax) is replaced with its defined value.
