### PR TITLE
Update the d2i docs to reflect reality

### DIFF
--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -522,8 +522,8 @@ Represents the B<DigestInfo> structure defined in PKCS#1 and PKCS#7.
 
 d2i_TYPE(), d2i_TYPE_bio() and d2i_TYPE_fp() return a valid B<TYPE> structure
 or B<NULL> if an error occurs.  If the "reuse" capability has been used with
-a valid structure being passed in via B<a>, then the object is not freed in
-the event of error but may be in a potentially invalid or inconsistent state.
+a valid structure being passed in via B<a>, then the object is freed in
+the event of error and B<*a> is set to NULL.
 
 i2d_TYPE() returns the number of bytes successfully encoded or a negative
 value if an error occurs.
@@ -604,9 +604,13 @@ happen.
 =head1 BUGS
 
 In some versions of OpenSSL the "reuse" behaviour of d2i_TYPE() when
-B<*px> is valid is broken and some parts of the reused structure may
-persist if they are not present in the new one. As a result the use
-of this "reuse" behaviour is strongly discouraged.
+B<*a> is valid is broken and some parts of the reused structure may
+persist if they are not present in the new one. Additionally, in versions of
+OpenSSL prior to 1.1.0, when the "reuse" behaviour is used and an error occurs
+the behaviour is inconsistent. Some functions behaved as described here, while
+some did not free B<*a> on error and did not set B<*a> to NULL.
+
+As a result of the above issues the "reuse" behaviour is strongly discouraged.
 
 i2d_TYPE() will not return an error in many versions of OpenSSL,
 if mandatory fields are not initialized due to a programming error


### PR DESCRIPTION
The d2i docs state that if an error occurs then |*a| is not freed. This
is not correct. On error it is freed and set to NULL. We update the docs
to say this, and also discuss the fact that this behaviour was inconsistent
prior to OpenSSL 1.1.0.