### PR TITLE
Boot time RNG seeding.

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -37,6 +37,7 @@
 # include <fcntl.h>
 # include <unistd.h>
 # include <sys/time.h>
+# include <sys/file.h>
 
 static uint64_t get_time_stamp(void);
 static uint64_t get_timer_bits(void);


### PR DESCRIPTION
Add a mechanism that ensures that /dev/urandom is properly seeded before
drawing any material from it in a manner that prevent starvation or blocking
of processes after the initial seeding has been completed.

