### PR TITLE
Fix no-dh

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4795,7 +4795,7 @@ EVP_PKEY *ssl_generate_param_group(uint16_t id)
         goto err;
     if (EVP_PKEY_paramgen_init(pctx) <= 0)
         goto err;
-# ifndef OPENSSl_NO_DH
+# ifndef OPENSSL_NO_DH
     if (ginf->flags & TLS_GROUP_FFDHE) {
         if (EVP_PKEY_CTX_set_dh_nid(pctx, ginf->nid) <= 0)
             goto err;
@@ -4844,8 +4844,10 @@ int ssl_derive(SSL *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gensecret)
         goto err;
     }
 
+#ifndef OPENSSL_NO_DH
     if (SSL_IS_TLS13(s) &&  EVP_PKEY_id(privkey) == EVP_PKEY_DH)
         EVP_PKEY_CTX_set_dh_pad(pctx, 1);
+#endif
 
     pms = OPENSSL_malloc(pmslen);
     if (pms == NULL) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3749,8 +3749,10 @@ static int test_tls13_key_exchange(int idx)
     int testresult = 0;
     int ecdhe_kexch_groups[] = {NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1,
                                 NID_X25519, NID_X448};
+#ifndef OPENSSL_NO_DH
     int ffdhe_kexch_groups[] = {NID_ffdhe2048, NID_ffdhe3072, NID_ffdhe4096,
                                 NID_ffdhe6144, NID_ffdhe8192};
+#endif
     int *kexch_groups = NULL;
     int kexch_groups_size = 0;
     int max_version = TLS1_3_VERSION;
@@ -3763,10 +3765,12 @@ static int test_tls13_key_exchange(int idx)
             kexch_groups = ecdhe_kexch_groups;
             kexch_groups_size = OSSL_NELEM(ecdhe_kexch_groups);
             break;
+#ifndef OPENSSL_NO_DH
         case 1:
             kexch_groups = ffdhe_kexch_groups;
             kexch_groups_size = OSSL_NELEM(ffdhe_kexch_groups);
             break;
+#endif
         case 2:
             kexch_groups = ecdhe_kexch_groups;
             kexch_groups_size = OSSL_NELEM(ecdhe_kexch_groups);
@@ -3775,6 +3779,7 @@ static int test_tls13_key_exchange(int idx)
             expected_err_reason = SSL_R_NO_SHARED_CIPHER;
             want_err = SSL_ERROR_SSL;
             break;
+#ifndef OPENSSL_NO_DH
         case 3:
             kexch_groups = ffdhe_kexch_groups;
             kexch_groups_size = OSSL_NELEM(ffdhe_kexch_groups);
@@ -3783,6 +3788,10 @@ static int test_tls13_key_exchange(int idx)
             expected_err_func = SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS;
             expected_err_reason = ERR_R_INTERNAL_ERROR;
             break;
+#endif
+        default:
+            /* We're skipping this test */
+            return 1;
     }
 
     if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(), TLS_client_method(),


### PR DESCRIPTION
The recent TLSv1.3 FFDHE support missed a few OPENSSL_NO_DH guards.
