### PR TITLE
 Allow TLSv1.3 in a no-ec build

### DIFF
--- a/Configure
+++ b/Configure
@@ -483,7 +483,8 @@ my @disable_cascades = (
     "zlib"              => [ "zlib-dynamic" ],
     "des"               => [ "mdc2" ],
     "ec"                => [ "ecdsa", "ecdh", "sm2" ],
-
+    sub { $disabled{"ec"} && $disabled{"dh"} }
+                        => [ "tls1_3" ],
     "dgram"             => [ "dtls", "sctp" ],
     "sock"              => [ "dgram" ],
     "dtls"              => [ @dtls ],

--- a/Configure
+++ b/Configure
@@ -482,7 +482,7 @@ my @disable_cascades = (
     "ssl3-method"       => [ "ssl3" ],
     "zlib"              => [ "zlib-dynamic" ],
     "des"               => [ "mdc2" ],
-    "ec"                => [ "ecdsa", "ecdh" ],
+    "ec"                => [ "ecdsa", "ecdh", "sm2" ],
 
     "dgram"             => [ "dtls", "sctp" ],
     "sock"              => [ "dgram" ],
@@ -526,7 +526,6 @@ my @disable_cascades = (
     "apps"              => [ "tests" ],
     "tests"             => [ "external-tests" ],
     "comp"              => [ "zlib" ],
-    "ec"                => [ "tls1_3", "sm2" ],
     "sm3"               => [ "sm2" ],
     sub { !$disabled{"unit-test"} } => [ "heartbeats" ],
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3578,6 +3578,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         }
         return ssl_cert_set_current(s->cert, larg);
 
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
     case SSL_CTRL_GET_GROUPS:
         {
             uint16_t *clist;
@@ -3622,6 +3623,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             }
             return id;
         }
+#endif /* !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH) */
 
     case SSL_CTRL_SET_SIGALGS:
         return tls1_set_sigalgs(s->cert, parg, larg, 0);
@@ -3898,6 +3900,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         break;
 #endif
 
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
     case SSL_CTRL_SET_GROUPS:
         return tls1_set_groups(&ctx->ext.supportedgroups,
                                &ctx->ext.supportedgroups_len,
@@ -3907,6 +3910,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         return tls1_set_groups_list(&ctx->ext.supportedgroups,
                                     &ctx->ext.supportedgroups_len,
                                     parg);
+#endif /* !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH) */
 
     case SSL_CTRL_SET_SIGALGS:
         return tls1_set_sigalgs(ctx->cert, parg, larg, 0);
@@ -4678,6 +4682,7 @@ EVP_PKEY *ssl_generate_pkey(EVP_PKEY *pm)
 }
 
 /* Generate a private key from a group ID */
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id)
 {
     const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(id);
@@ -4764,6 +4769,7 @@ EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id)
     EVP_PKEY_CTX_free(pctx);
     return pkey;
 }
+#endif
 
 /*
  * Generate parameters from a group ID

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3578,7 +3578,6 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         }
         return ssl_cert_set_current(s->cert, larg);
 
-#ifndef OPENSSL_NO_EC
     case SSL_CTRL_GET_GROUPS:
         {
             uint16_t *clist;
@@ -3623,7 +3622,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             }
             return id;
         }
-#endif
+
     case SSL_CTRL_SET_SIGALGS:
         return tls1_set_sigalgs(s->cert, parg, larg, 0);
 
@@ -3899,7 +3898,6 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         break;
 #endif
 
-#ifndef OPENSSL_NO_EC
     case SSL_CTRL_SET_GROUPS:
         return tls1_set_groups(&ctx->ext.supportedgroups,
                                &ctx->ext.supportedgroups_len,
@@ -3909,7 +3907,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         return tls1_set_groups_list(&ctx->ext.supportedgroups,
                                     &ctx->ext.supportedgroups_len,
                                     parg);
-#endif
+
     case SSL_CTRL_SET_SIGALGS:
         return tls1_set_sigalgs(ctx->cert, parg, larg, 0);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -780,6 +780,7 @@ SSL *SSL_new(SSL_CTX *ctx)
         s->ext.ecpointformats_len =
             ctx->ext.ecpointformats_len;
     }
+#endif
     if (ctx->ext.supportedgroups) {
         s->ext.supportedgroups =
             OPENSSL_memdup(ctx->ext.supportedgroups,
@@ -789,7 +790,7 @@ SSL *SSL_new(SSL_CTX *ctx)
             goto err;
         s->ext.supportedgroups_len = ctx->ext.supportedgroups_len;
     }
-#endif
+
 #ifndef OPENSSL_NO_NEXTPROTONEG
     s->ext.npn = NULL;
 #endif

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -959,9 +959,10 @@ struct ssl_ctx_st {
         /* EC extension values inherited by SSL structure */
         size_t ecpointformats_len;
         unsigned char *ecpointformats;
+# endif                         /* OPENSSL_NO_EC */
+
         size_t supportedgroups_len;
         uint16_t *supportedgroups;
-# endif                         /* OPENSSL_NO_EC */
 
         /*
          * ALPN information (we are in the process of transitioning from NPN to
@@ -2525,8 +2526,6 @@ __owur int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL *s);
 
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 
-#  ifndef OPENSSL_NO_EC
-
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t curve_id);
 __owur int tls1_check_group_id(SSL *s, uint16_t group_id, int check_own_curves);
 __owur uint16_t tls1_shared_group(SSL *s, int nmatch);
@@ -2534,15 +2533,16 @@ __owur int tls1_set_groups(uint16_t **pext, size_t *pextlen,
                            int *curves, size_t ncurves);
 __owur int tls1_set_groups_list(uint16_t **pext, size_t *pextlen,
                                 const char *str);
-void tls1_get_formatlist(SSL *s, const unsigned char **pformats,
-                         size_t *num_formats);
-__owur int tls1_check_ec_tmp_key(SSL *s, unsigned long id);
 __owur EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id);
 __owur int tls_valid_group(SSL *s, uint16_t group_id, int version);
 __owur EVP_PKEY *ssl_generate_param_group(uint16_t id);
+#  ifndef OPENSSL_NO_EC
+void tls1_get_formatlist(SSL *s, const unsigned char **pformats,
+                         size_t *num_formats);
+__owur int tls1_check_ec_tmp_key(SSL *s, unsigned long id);
 #  endif                        /* OPENSSL_NO_EC */
 
-__owur int tls_curve_allowed(SSL *s, uint16_t curve, int op);
+__owur int tls_group_allowed(SSL *s, uint16_t curve, int op);
 void tls1_get_supported_groups(SSL *s, const uint16_t **pgroups,
                                size_t *pgroupslen);
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1267,6 +1267,7 @@ static int final_sig_algs(SSL *s, unsigned int context, int sent)
 
 static int final_key_share(SSL *s, unsigned int context, int sent)
 {
+#if !defined(OPENSSL_NO_TLS1_3)
     if (!SSL_IS_TLS13(s))
         return 1;
 
@@ -1424,7 +1425,7 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
             return 0;
         }
     }
-
+#endif /* !defined(OPENSSL_NO_TLS1_3) */
     return 1;
 }
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -46,9 +46,7 @@ static int init_etm(SSL *s, unsigned int context);
 static int init_ems(SSL *s, unsigned int context);
 static int final_ems(SSL *s, unsigned int context, int sent);
 static int init_psk_kex_modes(SSL *s, unsigned int context);
-#ifndef OPENSSL_NO_EC
 static int final_key_share(SSL *s, unsigned int context, int sent);
-#endif
 #ifndef OPENSSL_NO_SRTP
 static int init_srtp(SSL *s, unsigned int context);
 #endif
@@ -162,6 +160,10 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_stoc_ec_pt_formats, tls_construct_ctos_ec_pt_formats,
         final_ec_pt_formats
     },
+#else
+    INVALID_EXTENSION,
+#endif
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
     {
         /*
          * "supported_groups" is spread across several specifications.
@@ -196,7 +198,6 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_ctos_supported_groups, NULL
     },
 #else
-    INVALID_EXTENSION,
     INVALID_EXTENSION,
 #endif
     {
@@ -322,7 +323,6 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         init_psk_kex_modes, tls_parse_ctos_psk_kex_modes, NULL, NULL,
         tls_construct_ctos_psk_kex_modes, NULL
     },
-#ifndef OPENSSL_NO_EC
     {
         /*
          * Must be in this list after supported_groups. We need that to have
@@ -336,7 +336,6 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_stoc_key_share, tls_construct_ctos_key_share,
         final_key_share
     },
-#endif
     {
         /* Must be after key_share */
         TLSEXT_TYPE_cookie,
@@ -1266,7 +1265,6 @@ static int final_sig_algs(SSL *s, unsigned int context, int sent)
     return 1;
 }
 
-#ifndef OPENSSL_NO_EC
 static int final_key_share(SSL *s, unsigned int context, int sent)
 {
     if (!SSL_IS_TLS13(s))
@@ -1429,7 +1427,6 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
 
     return 1;
 }
-#endif
 
 static int init_psk_kex_modes(SSL *s, unsigned int context)
 {

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -113,11 +113,13 @@ EXT_RETURN tls_construct_ctos_srp(SSL *s, WPACKET *pkt, unsigned int context,
 #endif
 
 #ifndef OPENSSL_NO_EC
-static int use_ecc(SSL *s)
+static int use_ecc(SSL *s, int max_version)
 {
     int i, end, ret = 0;
     unsigned long alg_k, alg_a;
     STACK_OF(SSL_CIPHER) *cipher_stack = NULL;
+    const uint16_t *pgroups = NULL;
+    size_t num_groups, j;
 
     /* See if we support any ECC ciphersuites */
     if (s->version == SSL3_VERSION)
@@ -137,9 +139,21 @@ static int use_ecc(SSL *s)
             break;
         }
     }
-
     sk_SSL_CIPHER_free(cipher_stack);
-    return ret;
+    if (!ret)
+        return 0;
+
+    /* Check we have at least one EC supported group */
+    tls1_get_supported_groups(s, &pgroups, &num_groups);
+    for (j = 0; j < num_groups; j++) {
+        uint16_t ctmp = pgroups[j];
+
+        if (tls_valid_group(s, ctmp, max_version)
+                && tls_group_allowed(s, ctmp, SSL_SECOP_CURVE_SUPPORTED))
+            return 1;
+    }
+
+    return 0;
 }
 
 EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
@@ -148,8 +162,15 @@ EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
 {
     const unsigned char *pformats;
     size_t num_formats;
-
-    if (!use_ecc(s))
+    int reason, min_version, max_version;
+    
+    reason = ssl_get_min_max_version(s, &min_version, &max_version, NULL);
+    if (reason != 0) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                 SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS, reason);
+        return EXT_RETURN_FAIL;
+    }
+    if (!use_ecc(s, max_version))
         return EXT_RETURN_NOT_SENT;
 
     /* Add TLS extension ECPointFormats to the ClientHello message */
@@ -167,7 +188,9 @@ EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
 
     return EXT_RETURN_SENT;
 }
+#endif
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
                                                unsigned int context, X509 *x,
                                                size_t chainidx)
@@ -176,15 +199,20 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
     size_t num_groups = 0, i;
     int min_version, max_version, reason;
 
-    if (!use_ecc(s))
-        return EXT_RETURN_NOT_SENT;
-
     reason = ssl_get_min_max_version(s, &min_version, &max_version, NULL);
     if (reason != 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS, reason);
         return EXT_RETURN_FAIL;
     }
+
+#if defined(OPENSSL_NO_EC)
+    if (max_version < TLS1_3_VERSION)
+        return EXT_RETURN_NOT_SENT;
+#else
+    if (!use_ecc(s, max_version) && max_version < TLS1_3_VERSION)
+        return EXT_RETURN_NOT_SENT;
+#endif
 
     /*
      * Add TLS extension supported_groups to the ClientHello message
@@ -206,7 +234,7 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
         uint16_t ctmp = pgroups[i];
 
         if (tls_valid_group(s, ctmp, max_version)
-                && tls_curve_allowed(s, ctmp, SSL_SECOP_CURVE_SUPPORTED)) {
+                && tls_group_allowed(s, ctmp, SSL_SECOP_CURVE_SUPPORTED)) {
             if (!WPACKET_put_bytes_u16(pkt, ctmp)) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                          SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS,
@@ -683,7 +711,7 @@ EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
     } else {
         for (i = 0; i < num_groups; i++) {
 
-            if (!tls_curve_allowed(s, pgroups[i], SSL_SECOP_CURVE_SUPPORTED))
+            if (!tls_group_allowed(s, pgroups[i], SSL_SECOP_CURVE_SUPPORTED))
                 continue;
 
             curve_id = pgroups[i];
@@ -1843,7 +1871,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                 break;
         }
         if (i >= num_groups
-                || !tls_curve_allowed(s, group_id, SSL_SECOP_CURVE_SUPPORTED)) {
+                || !tls_group_allowed(s, group_id, SSL_SECOP_CURVE_SUPPORTED)) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_F_TLS_PARSE_STOC_KEY_SHARE, SSL_R_BAD_KEY_SHARE);
             return 0;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -163,11 +163,11 @@ EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
     const unsigned char *pformats;
     size_t num_formats;
     int reason, min_version, max_version;
-    
+
     reason = ssl_get_min_max_version(s, &min_version, &max_version, NULL);
     if (reason != 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
-                 SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS, reason);
+                 SSL_F_TLS_CONSTRUCT_CTOS_EC_PT_FORMATS, reason);
         return EXT_RETURN_FAIL;
     }
     if (!use_ecc(s, max_version))

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -946,7 +946,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     return 1;
 }
 
-#ifndef OPENSSL_NO_EC
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
 int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
                                     X509 *x, size_t chainidx)
 {
@@ -1400,7 +1400,7 @@ EXT_RETURN tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt,
 }
 #endif
 
-#ifndef OPENSSL_NO_EC
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
 EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
                                                unsigned int context, X509 *x,
                                                size_t chainidx)
@@ -1425,7 +1425,7 @@ EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
         uint16_t group = groups[i];
 
         if (tls_valid_group(s, group, SSL_version(s))
-                && tls_curve_allowed(s, group, SSL_SECOP_CURVE_SUPPORTED)) {
+                && tls_group_allowed(s, group, SSL_SECOP_CURVE_SUPPORTED)) {
             if (first) {
                 /*
                  * Check if the client is already using our preferred group. If

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2137,7 +2137,6 @@ int ssl_set_client_hello_version(SSL *s)
  * used. Returns 1 if the group is in the list (and allowed if |checkallow| is
  * 1) or 0 otherwise.
  */
-#ifndef OPENSSL_NO_EC
 int check_in_list(SSL *s, uint16_t group_id, const uint16_t *groups,
                   size_t num_groups, int checkallow)
 {
@@ -2151,14 +2150,13 @@ int check_in_list(SSL *s, uint16_t group_id, const uint16_t *groups,
 
         if (group_id == group
                 && (!checkallow
-                    || tls_curve_allowed(s, group, SSL_SECOP_CURVE_CHECK))) {
+                    || tls_group_allowed(s, group, SSL_SECOP_CURVE_CHECK))) {
             return 1;
         }
     }
 
     return 0;
 }
-#endif
 
 /* Replace ClientHello1 in the transcript hash with a synthetic message */
 int create_synthetic_message_hash(SSL *s, const unsigned char *hashval,

--- a/ssl/statem/statem_locl.h
+++ b/ssl/statem/statem_locl.h
@@ -199,9 +199,9 @@ int tls_parse_ctos_early_data(SSL *s, PACKET *pkt, unsigned int context,
 #ifndef OPENSSL_NO_EC
 int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
                                  X509 *x, size_t chainidx);
+#endif
 int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
                                     X509 *x, size_t chainidxl);
-#endif
 int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx);
 int tls_parse_ctos_sig_algs_cert(SSL *s, PACKET *pkt, unsigned int context,
@@ -314,10 +314,11 @@ EXT_RETURN tls_construct_ctos_srp(SSL *s, WPACKET *pkt, unsigned int context, X5
 EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
                                             unsigned int context, X509 *x,
                                             size_t chainidx);
+#endif
 EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
                                                unsigned int context, X509 *x,
                                                size_t chainidx);
-#endif
+
 EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
                                          unsigned int context, X509 *x,
                                          size_t chainidx);

--- a/test/recipes/70-test_clienthello.t
+++ b/test/recipes/70-test_clienthello.t
@@ -15,6 +15,10 @@ setup("test_clienthello");
 plan skip_all => "No TLS/SSL protocols are supported by this OpenSSL build"
     if alldisabled(grep { $_ ne "ssl3" } available_protocols("tls"));
 
+#No EC with TLSv1.3 confuses the padding calculations in this test
+plan skip_all => "No EC with TLSv1.3 is not supported by this test"
+    if disabled("ec") && !disabled("tls1_3");
+
 plan tests => 1;
 
 ok(run(test(["clienthellotest", srctop_file("test", "session.pem")])),

--- a/test/recipes/70-test_key_share.t
+++ b/test/recipes/70-test_key_share.t
@@ -36,7 +36,9 @@ use constant {
 
 use constant {
     X25519 => 0x1d,
-    P_256 => 0x17
+    P_256 => 0x17,
+    FFDHE2048 => 0x0100,
+    FFDHE3072 => 0x0101
 };
 
 my $testtype;
@@ -74,7 +76,11 @@ my $proxy = TLSProxy::Proxy->new(
 $testtype = EMPTY_EXTENSION;
 $direction = CLIENT_TO_SERVER;
 $proxy->filter(\&modify_key_shares_filter);
-$proxy->serverflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->serverflags("-groups ffdhe3072");
+} else {
+    $proxy->serverflags("-groups P-256");
+}
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 22;
 ok(TLSProxy::Message->success(), "Success after HRR");
@@ -95,31 +101,52 @@ ok(TLSProxy::Message->fail(), "Missing key_shares extension");
 #        HelloRetryRequest
 $proxy->clear();
 $proxy->filter(undef);
-$proxy->serverflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->serverflags("-groups ffdhe3072");
+} else {
+    $proxy->serverflags("-groups P-256");
+}
 $proxy->start();
 ok(TLSProxy::Message->success(), "No initial acceptable key_shares");
 
 #Test 5: No acceptable key_shares and no shared groups should fail
 $proxy->clear();
 $proxy->filter(undef);
-$proxy->serverflags("-curves P-256");
-$proxy->clientflags("-curves P-384");
+if (disabled("ec")) {
+    $proxy->serverflags("-groups ffdhe2048");
+} else {
+    $proxy->serverflags("-groups P-256");
+}
+if (disabled("ec")) {
+    $proxy->clientflags("-groups ffdhe3072");
+} else {
+    $proxy->clientflags("-groups P-384");
+}
 $proxy->start();
 ok(TLSProxy::Message->fail(), "No acceptable key_shares");
 
 #Test 6: A non preferred but acceptable key_share should succeed
 $proxy->clear();
 $proxy->clientflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->clientflags("-groups ffdhe3072");
+} else {
+    $proxy->clientflags("-groups P-256");
+}
 $proxy->start();
 ok(TLSProxy::Message->success(), "Non preferred key_share");
 $proxy->filter(\&modify_key_shares_filter);
 
-#Test 7: An acceptable key_share after a list of non-acceptable ones should
-#succeed
-$proxy->clear();
-$testtype = ACCEPTABLE_AT_END;
-$proxy->start();
-ok(TLSProxy::Message->success(), "Acceptable key_share at end of list");
+SKIP: {
+    skip "No ec support in this OpenSSL build", 1 if disabled("ec");
+
+    #Test 7: An acceptable key_share after a list of non-acceptable ones should
+    #succeed
+    $proxy->clear();
+    $testtype = ACCEPTABLE_AT_END;
+    $proxy->start();
+    ok(TLSProxy::Message->success(), "Acceptable key_share at end of list");
+}
 
 #Test 8: An acceptable key_share but for a group not in supported_groups should
 #fail
@@ -156,22 +183,45 @@ ok(TLSProxy::Message->fail(), "key_share list trailing data");
 $proxy->clear();
 $direction = SERVER_TO_CLIENT;
 $testtype = LOOK_ONLY;
-$proxy->clientflags("-curves P-256:X25519");
+$selectedgroupid = 0;
+if (disabled("ec")) {
+    $proxy->clientflags("-groups ffdhe3072:ffdhe2048");
+} else {
+    $proxy->clientflags("-groups P-256:X25519");
+}
 $proxy->start();
-ok(TLSProxy::Message->success() && ($selectedgroupid == P_256),
-   "Multiple acceptable key_shares");
+if (disabled("ec")) {
+    ok(TLSProxy::Message->success() && ($selectedgroupid == FFDHE3072),
+       "Multiple acceptable key_shares");
+} else {
+    ok(TLSProxy::Message->success() && ($selectedgroupid == P_256),
+       "Multiple acceptable key_shares");
+}
 
 #Test 14: Multiple acceptable key_shares - we choose the first one (part 2)
 $proxy->clear();
-$proxy->clientflags("-curves X25519:P-256");
+if (disabled("ec")) {
+    $proxy->clientflags("-curves ffdhe2048:ffdhe3072");
+} else {
+    $proxy->clientflags("-curves X25519:P-256");
+}
 $proxy->start();
-ok(TLSProxy::Message->success() && ($selectedgroupid == X25519),
-   "Multiple acceptable key_shares (part 2)");
+if (disabled("ec")) {
+    ok(TLSProxy::Message->success() && ($selectedgroupid == FFDHE2048),
+       "Multiple acceptable key_shares (part 2)");
+} else {
+    ok(TLSProxy::Message->success() && ($selectedgroupid == X25519),
+       "Multiple acceptable key_shares (part 2)");
+}
 
 #Test 15: Server sends key_share that wasn't offered should fail
 $proxy->clear();
 $testtype = SELECT_X25519;
-$proxy->clientflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->clientflags("-groups ffdhe3072");
+} else {
+    $proxy->clientflags("-groups P-256");
+}
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Non offered key_share");
 
@@ -229,7 +279,11 @@ SKIP: {
 $proxy->clear();
 $direction = SERVER_TO_CLIENT;
 $testtype = NO_KEY_SHARES_IN_HRR;
-$proxy->serverflags("-curves X25519");
+if (disabled("ec")) {
+    $proxy->serverflags("-groups ffdhe2048");
+} else {
+    $proxy->serverflags("-groups X25519");
+}
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Server sends HRR with no key_shares");
 

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -217,7 +217,10 @@ SKIP: {
     $proxy->clientflags("-no_tls1_3 -noservername");
     $proxy->start();
     ok($fatal_alert, "Unsolicited server name extension");
-
+}
+SKIP: {
+    skip "TLS <= 1.2 disabled or EC disabled", 1
+        if $no_below_tls13 || disabled("ec");
     #Test 5: Inject a noncompliant supported_groups extension (<= TLSv1.2)
     $proxy->clear();
     $proxy->filter(\&inject_unsolicited_extension);

--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -46,17 +46,27 @@ my $testtype;
 #Test 1: Inserting a cookie into an HRR should see it echoed in the ClientHello
 $testtype = COOKIE_ONLY;
 $proxy->filter(\&cookie_filter);
-$proxy->serverflags("-curves X25519");
+$proxy->serverflags("-curves X25519") if !disabled("ec");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 2;
-ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
+SKIP: {
+    skip "EC disabled", 1, if disabled("ec");
+    ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
+}
+
+
 
 #Test 2: Same as test 1 but should also work where a new key_share is also
 #        required
 $testtype = COOKIE_AND_KEY_SHARE;
 $proxy->clear();
-$proxy->clientflags("-curves P-256:X25519");
-$proxy->serverflags("-curves X25519");
+if (disabled("ec")) {
+    $proxy->clientflags("-curves ffdhe3072:ffdhe2048");
+    $proxy->serverflags("-curves ffdhe2048");
+} else {
+    $proxy->clientflags("-curves P-256:X25519");
+    $proxy->serverflags("-curves X25519");
+}
 $proxy->start();
 ok(TLSProxy::Message->success() && $cookieseen == 1, "Cookie seen");
 

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -43,7 +43,11 @@ use constant {
 #Test 1: A client should fail if the server changes the ciphersuite between the
 #        HRR and the SH
 $proxy->filter(\&hrr_filter);
-$proxy->serverflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->serverflags("-curves ffdhe3072");
+} else {
+    $proxy->serverflags("-curves P-256");
+}
 my $testtype = CHANGE_HRR_CIPHERSUITE;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 2;
@@ -52,7 +56,11 @@ ok(TLSProxy::Message->fail(), "Server ciphersuite changes");
 #Test 2: It is an error if the client changes the offered ciphersuites so that
 #        we end up selecting a different ciphersuite between HRR and the SH
 $proxy->clear();
-$proxy->serverflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->serverflags("-curves ffdhe3072");
+} else {
+    $proxy->serverflags("-curves P-256");
+}
 $proxy->ciphersuitess("TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384");
 $testtype = CHANGE_CH1_CIPHERSUITE;
 $proxy->start();

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -28,6 +28,9 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3");
 
+plan skip_all => "$test_name needs EC enabled"
+    if disabled("ec");
+
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
 

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -28,6 +28,9 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3");
 
+plan skip_all => "$test_name needs EC enabled"
+    if disabled("ec");
+
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.conf");
 

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -66,7 +66,11 @@ ok(TLSProxy::Message->fail(), "PSK not last");
 #        ciphersuite. Should see PSK on second ClientHello
 $proxy->clear();
 $proxy->clientflags("-sess_in ".$session);
-$proxy->serverflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->serverflags("-curves ffdhe3072");
+} else {
+    $proxy->serverflags("-curves P-256");
+}
 $proxy->filter(undef);
 $proxy->start();
 #Check if the PSK is present in the second ClientHello
@@ -81,7 +85,11 @@ ok($pskseen, "PSK hash matches");
 $proxy->clear();
 $proxy->clientflags("-sess_in ".$session);
 $proxy->filter(\&modify_psk_filter);
-$proxy->serverflags("-curves P-256");
+if (disabled("ec")) {
+    $proxy->serverflags("-curves ffdhe3072");
+} else {
+    $proxy->serverflags("-curves P-256");
+}
 $proxy->ciphersuitesc("TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384");
 $proxy->ciphersuitess("TLS_AES_256_GCM_SHA384");
 #We force an early failure because TLS Proxy doesn't actually support

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -59,7 +59,7 @@ my %conf_dependent_tests = (
                            || !disabled("sctp"),
   "05-sni.conf" => disabled("tls1_1"),
   "07-dtls-protocol-version.conf" => !$is_default_dtls || !disabled("sctp"),
-  "10-resumption.conf" => !$is_default_tls,
+  "10-resumption.conf" => !$is_default_tls || $no_ec,
   "11-dtls_resumption.conf" => !$is_default_dtls || !disabled("sctp"),
   "16-dtls-certstatus.conf" => !$is_default_dtls || !disabled("sctp"),
   "17-renegotiate.conf" => disabled("tls1_2"),

--- a/test/recipes/90-test_gost.t
+++ b/test/recipes/90-test_gost.t
@@ -21,6 +21,10 @@ plan skip_all => "GOST support is disabled in this OpenSSL build"
 plan skip_all => "TLSv1.3 or TLSv1.2 are disabled in this OpenSSL build"
     if disabled("tls1_3") || disabled("tls1_2");
 
+plan skip_all => "EC is disabled in this OpenSSL build"
+    if disabled("ec");
+
+
 plan skip_all => "No test GOST engine found"
     if !$ENV{OPENSSL_GOST_ENGINE_SO};
 

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -252,7 +252,7 @@ sub generate_resumption_tests {
             "client" => {
             },
             "server" => {
-                "Curves" => "P-256"
+                "Curves" => disabled("ec") ? "ffdhe3072" : "P-256"
             },
             "resume_client" => {
             },

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -316,8 +316,10 @@ static int test_tls13ccs(int tst)
     if ((tst >= 3 && tst <= 5) || tst >= 9) {
         /* HRR handshake */
 #if defined(OPENSSL_NO_EC)
+# if !defined(OPENSSL_NO_DH)
         if (!TEST_true(SSL_CTX_set1_groups_list(sctx, "ffdhe3072")))
             goto err;
+# endif
 #else
         if (!TEST_true(SSL_CTX_set1_groups_list(sctx, "P-256")))
             goto err;

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -315,8 +315,13 @@ static int test_tls13ccs(int tst)
 
     if ((tst >= 3 && tst <= 5) || tst >= 9) {
         /* HRR handshake */
+#if defined(OPENSSL_NO_EC)
+        if (!TEST_true(SSL_CTX_set1_groups_list(sctx, "ffdhe3072")))
+            goto err;
+#else
         if (!TEST_true(SSL_CTX_set1_groups_list(sctx, "P-256")))
             goto err;
+#endif
     }
 
     s_to_c_fbio = BIO_new(bio_f_watchccs_filter());


### PR DESCRIPTION
Now that we have TLSv1.3 FFDHE support there is no reason why we should
not allow TLSv1.3 to be used in a no-ec build. This commit enables that
to happen.

It also fixes no-ec which was previously broken.