### PR TITLE
Swap #if blocks around in uid.c so target platform gets checked before host

### DIFF
--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -10,20 +10,20 @@
 #include <openssl/crypto.h>
 #include <openssl/opensslconf.h>
 
-#if defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__)
+#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
+
+int OPENSSL_issetugid(void)
+{
+    return 0;
+}
+
+#elif defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__)
 
 # include OPENSSL_UNISTD
 
 int OPENSSL_issetugid(void)
 {
     return issetugid();
-}
-
-#elif defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
-
-int OPENSSL_issetugid(void)
-{
-    return 0;
 }
 
 #else


### PR DESCRIPTION
This avoids the case where a UEFI build on FreeBSD tries to call the system
issetugid function instead of returning 0 as it should do.

CLA: trivial