### PR TITLE
Replumbing: offer a core upcall to get the provider object's library context

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -401,23 +401,7 @@ static int provider_activate(OSSL_PROVIDER *prov)
 #endif
     }
 
-    /*
-     * We call the initialise function for the provider.
-     *
-     * If FIPS_MODE is defined then we are inside the FIPS module and are about
-     * to recursively initialise ourselves. We need to do this so that we can
-     * get all the provider callback functions set up in order for us to be able
-     * to make EVP calls from within the FIPS module itself. Only algorithms
-     * from the FIPS module itself are available via the FIPS module EVP
-     * interface, i.e. we only ever have one provider available inside the FIPS
-     * module - the FIPS provider itself.
-     *
-     * For modules in general we cannot know what value will be used for the
-     * provctx - it is a "black box". But for the FIPS module we know that the
-     * provctx is really a library context. We default the provctx value to the
-     * same library context as was used for the EVP call that caused this call
-     * to "provider_activate".
-     */
+    /* Call the initialise function for the provider. */
     if (prov->init_function == NULL
         || !prov->init_function(prov, core_dispatch, &provider_dispatch,
                                 &prov->provctx)) {

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -47,6 +47,7 @@ struct ossl_provider_st {
     DSO *module;
     OSSL_provider_init_fn *init_function;
     STACK_OF(INFOPAIR) *parameters;
+    OPENSSL_CTX *libctx; /* The library context this instance is in */
     struct provider_store_st *store; /* The store this instance belongs to */
 
     /* Provider side functions */
@@ -229,6 +230,7 @@ OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
         ossl_provider_free(prov); /* -1 Reference that was to be returned */
         prov = NULL;
     } else {
+        prov->libctx = libctx;
         prov->store = store;
     }
     CRYPTO_THREAD_unlock(store->lock);
@@ -341,11 +343,9 @@ static const OSSL_DISPATCH *core_dispatch; /* Define further down */
 /*
  * Internal version that doesn't affect the store flags, and thereby avoid
  * locking.  Direct callers must remember to set the store flags when
- * appropriate. The libctx parameter is only necessary when FIPS_MODE is set
- * (i.e. we are being called from inside the FIPS module) - it is ignored for
- * other uses.
+ * appropriate.
  */
-static int provider_activate(OSSL_PROVIDER *prov, OPENSSL_CTX *libctx)
+static int provider_activate(OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *provider_dispatch = NULL;
 
@@ -417,9 +417,6 @@ static int provider_activate(OSSL_PROVIDER *prov, OPENSSL_CTX *libctx)
      * same library context as was used for the EVP call that caused this call
      * to "provider_activate".
      */
-#ifdef FIPS_MODE
-    prov->provctx = libctx;
-#endif
     if (prov->init_function == NULL
         || !prov->init_function(prov, core_dispatch, &provider_dispatch,
                                 &prov->provctx)) {
@@ -461,7 +458,7 @@ static int provider_activate(OSSL_PROVIDER *prov, OPENSSL_CTX *libctx)
 
 int ossl_provider_activate(OSSL_PROVIDER *prov)
 {
-    if (provider_activate(prov, NULL)) {
+    if (provider_activate(prov)) {
         CRYPTO_THREAD_write_lock(prov->store->lock);
         prov->store->use_fallbacks = 0;
         CRYPTO_THREAD_unlock(prov->store->lock);
@@ -538,7 +535,7 @@ int ossl_provider_forall_loaded(OPENSSL_CTX *ctx,
                  */
                 if (prov->flag_fallback) {
                     activated_fallback_count++;
-                    provider_activate(prov, ctx);
+                    provider_activate(prov);
                 }
             }
 
@@ -679,9 +676,16 @@ static int core_get_params(const OSSL_PROVIDER *prov, const OSSL_PARAM params[])
     return 1;
 }
 
+static OSSL_core_get_library_context_fn core_get_libctx; /* Check */
+static OPENSSL_CTX *core_get_libctx(const OSSL_PROVIDER *prov)
+{
+    return prov->libctx;
+}
+
 static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_GET_PARAM_TYPES, (void (*)(void))core_get_param_types },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
+    { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
     { OSSL_FUNC_CORE_PUT_ERROR, (void (*)(void))ERR_put_error },
     { OSSL_FUNC_CORE_ADD_ERROR_VDATA, (void (*)(void))ERR_add_error_vdata },
     { 0, NULL }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -121,6 +121,7 @@ static void *provider_store_new(OPENSSL_CTX *ctx)
             CRYPTOerr(CRYPTO_F_PROVIDER_STORE_NEW, ERR_R_INTERNAL_ERROR);
             return NULL;
         }
+        prov->libctx = ctx;
         prov->store = store;
         if(p->is_fallback)
             ossl_provider_set_fallback(prov);

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -63,6 +63,9 @@ OSSL_CORE_MAKE_FUNC(void,core_put_error,(int lib, int func, int reason,
                                          const char *file, int line))
 # define OSSL_FUNC_CORE_ADD_ERROR_VDATA        4
 OSSL_CORE_MAKE_FUNC(void,core_add_error_vdata,(int num, va_list args))
+# define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    5
+OSSL_CORE_MAKE_FUNC(OPENSSL_CTX *,core_get_library_context,
+                    (const OSSL_PROVIDER *prov))
 
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */

--- a/providers/common/include/internal/provider_ctx.h
+++ b/providers/common/include/internal/provider_ctx.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * To be used anywhere the library context needs to be passed, such as to
+ * fetching functions.
+ */
+#define PROV_LIBRARY_CONTEXT_OF(provctx)        (provctx)

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -229,13 +229,9 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 /*
  * The internal init function used when the FIPS module uses EVP to call
  * another algorithm also in the FIPS module. This is a recursive call that has
- * been made from within the FIPS module itself. Normally we are responsible for
- * providing our own provctx value, but in this recursive case it has been
- * pre-populated for us with the same library context that was used in the EVP
- * call that initiated this recursive call - so we don't need to do anything
- * further with that parameter. This only works because we *know* in the core
- * code that the FIPS module uses a library context for its provctx. This is
- * not generally true for all providers.
+ * been made from within the FIPS module itself. To make this work, we populate
+ * the provider context of this inner instance with the same library context
+ * that was used in the EVP call that initiated this recursive call.
  */
 OSSL_provider_init_fn fips_intern_provider_init;
 int fips_intern_provider_init(const OSSL_PROVIDER *provider,

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -239,6 +239,30 @@ int fips_intern_provider_init(const OSSL_PROVIDER *provider,
                               const OSSL_DISPATCH **out,
                               void **provctx)
 {
+    OSSL_core_get_library_context_fn *c_get_libctx = NULL;
+
+    for (; in->function_id != 0; in++) {
+        switch (in->function_id) {
+        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
+            c_get_libctx = OSSL_get_core_get_library_context(in);
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (c_get_libctx == NULL)
+        return 0;
+
+    *provctx = c_get_libctx(provider);
+
+    /*
+     * Safety measure...  we should get the library context that was
+     * created up in OSSL_provider_init().
+     */
+    if (*provctx == NULL)
+        return 0;
+
     *out = intern_dispatch_table;
     return 1;
 }

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -99,6 +99,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
                        const OSSL_DISPATCH **out,
                        void **provctx)
 {
+    OSSL_core_get_library_context_fn *c_get_libctx = NULL;
+
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GET_PARAM_TYPES:
@@ -107,12 +109,25 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);
             break;
+        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
+            c_get_libctx = OSSL_get_core_get_library_context(in);
+            break;
         /* Just ignore anything we don't understand */
         default:
             break;
         }
     }
 
+    if (c_get_libctx == NULL)
+        return 0;
+
     *out = legacy_dispatch_table;
+
+    /*
+     * We want to make sure that all calls from this provider that requires
+     * a library context use the same context as the one used to call our
+     * functions.  We do that by passing it along as the provider context.
+     */
+    *provctx = c_get_libctx(provider);
     return 1;
 }


### PR DESCRIPTION
The FIPS module currently has "magic" support to have the library
context become the provider context within the core code, for the FIPS
module's inner provider.

We replace that with a core upcall that returns the library context
associated with a provider object.  That way, the FIPS module can
handle the assignment of the inner provider context itself.  This
allows the FIPS module (and any other provider module that wishes to
use a similar mechanism) to define for itself what the provider
context is.  It's currently simply a pointer to a library context,
but may contain other stuff as well in the future.
