### PR TITLE
crypto/ppccap.c: Fix FIPS build on PPC

### DIFF
--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -65,11 +65,6 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
     return bn_mul_mont_int(rp, ap, bp, np, n0, num);
 }
 #endif
-/*
- * TODO(3.0): Temporarily disabled some assembler that hasn't been brought into
- * the FIPS module yet.
- */
-#ifndef FIPS_MODE
 void sha256_block_p8(void *ctx, const void *inp, size_t len);
 void sha256_block_ppc(void *ctx, const void *inp, size_t len);
 void sha256_block_data_order(void *ctx, const void *inp, size_t len);
@@ -88,6 +83,11 @@ void sha512_block_data_order(void *ctx, const void *inp, size_t len)
         sha512_block_ppc(ctx, inp, len);
 }
 
+/*
+ * TODO(3.0): Temporarily disabled some assembler that hasn't been brought into
+ * the FIPS module yet.
+ */
+#ifndef FIPS_MODE
 # ifndef OPENSSL_NO_CHACHA
 void ChaCha20_ctr32_int(unsigned char *out, const unsigned char *inp,
                         size_t len, const unsigned int key[8],


### PR DESCRIPTION
Some code was temporarly disabled in the FIPS module because SHA other
SHA1 hadn't been ported.  Now that they have, we must enable this code
again.
