### PR TITLE
providers/common/digests/sha3_prov.c: Fix s390x

### DIFF
--- a/providers/common/digests/sha3_prov.c
+++ b/providers/common/digests/sha3_prov.c
@@ -184,7 +184,7 @@ static void *name##_newctx(void *provctx) \
     if (ctx == NULL) \
         return NULL; \
     sha3_init(ctx, pad, bitlen); \
-    SHA3_SET_MD(name, typ) \
+    SHA3_SET_MD(uname, typ) \
     return ctx; \
 }
 


### PR DESCRIPTION
'name' was used instead of 'uname' in one spot, causing unresolved
symbols.
