### PR TITLE
Handle CTRL-C as non-redoable abort signal

### DIFF
--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -500,6 +500,7 @@ int UI_process(UI *ui)
     if (ui->meth->ui_flush != NULL)
         switch (ui->meth->ui_flush(ui)) {
         case -1:               /* Interrupt/Cancel/something... */
+            ui->flags &= ~UI_FLAG_REDOABLE;
             ok = -2;
             goto err;
         case 0:                /* Errors */
@@ -517,6 +518,7 @@ int UI_process(UI *ui)
                                              sk_UI_STRING_value(ui->strings,
                                                                 i))) {
             case -1:           /* Interrupt/Cancel/something... */
+                ui->flags &= ~UI_FLAG_REDOABLE;
                 ok = -2;
                 goto err;
             case 0:            /* Errors */


### PR DESCRIPTION
This is a bit annoying, if for instance "openssl genrsa -aes128"
tries to read a 4+ character size password, but CTRL-C does no longer
work after a RETURN key, since the flag UI_FLAG_REDOABLE is set by
UI_set_result_ex, together with the error "You must type in 4 to 1023 characters".
Thus remove the REDOABLE flag to allow CTRL-C to work.

[extended tests]
