### PR TITLE
crypto/aes/build.info: Fix AES assembler specs

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -3,15 +3,14 @@ LIBS=../../libcrypto
 $AESASM=aes_core.c aes_cbc.c
 IF[{- !$disabled{asm} -}]
   $AESASM_x86=aes-586.s
+  $AESDEF_x86=AES_ASM
   $AESASM_x86_sse2=vpaes-x86.s aesni-x86.s
-  $AESDEF_x86_sse2=AES_ASM VPAES_ASM
+  $AESDEF_x86_sse2=VPAES_ASM
 
   $AESASM_x86_64=\
-        aes-x86_64.s bsaes-x86_64.s \
+        aes-x86_64.s vpaes-x86_64.s bsaes-x86_64.s aesni-x86_64.s \
         aesni-sha1-x86_64.s aesni-sha256-x86_64.s aesni-mb-x86_64.s
-  $AESDEF_x86_64=AES_ASM BSAES_ASM
-  $AESASM_x86_64_sse2=vpaes-x86_64.s aesni-x86_64.s
-  $AESDEF_x86_64_sse2=VPAES_ASM
+  $AESDEF_x86_64=AES_ASM VPAES_ASM BSAES_ASM
 
   $AESASM_ia64=aes_core.c aes_cbc.c aes-ia64.s
   $AESDEF_ia64=AES_ASM


### PR DESCRIPTION
Two mistakes were made:

1. AES_ASM for x86 was misplaced
2. sse2 isn't applicable for x86_64 code
