### PR TITLE
crypto/modes/build.conf: Fix MODES asm mistakes

### DIFF
--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -25,7 +25,7 @@ IF[{- !$disabled{asm} -}]
   $MODESASM_armv4=ghash-armv4.S ghashv8-armx.S
   $MODESDEF_armv4=GHASH_ASM
   $MODESASM_aarch64=ghashv8-armx.S
-  $MODESDEF_aarch64=GHASH_ASM
+  $MODESDEF_aarch64=
 
   $MODESASM_parisc11=ghash-parisc.s
   $MODESDEF_parisc11=GHASH_ASM


### PR DESCRIPTION
The old rule in Configure was that if the asm source had a file name
with 'ghash-' as part of the name, GHASH_ASM should be defined.  Since
none of the aarch64 asm files has such a name, that macro shouldn't
have been defined.

Fixes #9173
