### PR TITLE
Change ERR_add_error_[v]data to append

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -408,6 +408,25 @@ void ERR_put_error(int lib, int func, int reason, const char *file, int line)
 {
     ERR_STATE *es;
 
+#ifdef _OSD_POSIX
+    /*
+     * In the BS2000-OSD POSIX subsystem, the compiler generates path names
+     * in the form "*POSIX(/etc/passwd)". This dirty hack strips them to
+     * something sensible. @@@ We shouldn't modify a const string, though.
+     */
+    if (strncmp(file, "*POSIX(", sizeof("*POSIX(") - 1) == 0) {
+        char *end;
+
+        /* Skip the "*POSIX(" prefix */
+        file += sizeof("*POSIX(") - 1;
+        end = &file[strlen(file) - 1];
+        if (*end == ')')
+            *end = '\0';
+        /* Optional: use the basename of the path only. */
+        if ((end = strrchr(file, '/')) != NULL)
+            file = &end[1];
+    }
+#endif
     es = ERR_get_state();
     if (es == NULL)
         return;

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -23,7 +23,7 @@ This function is usually called by a macro.
 ERR_add_error_data() associates the concatenation of its B<num> string
 arguments with the error code added last.
 ERR_add_error_vdata() is similar except the argument is a B<va_list>.
-+Multiple calls to these functions append to the current top of the error queue.
+Multiple calls to these functions append to the current top of the error queue.
 
 L<ERR_load_strings(3)> can be used to register
 error strings so that the application can a generate human-readable

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -23,6 +23,7 @@ This function is usually called by a macro.
 ERR_add_error_data() associates the concatenation of its B<num> string
 arguments with the error code added last.
 ERR_add_error_vdata() is similar except the argument is a B<va_list>.
++Multiple calls to these functions append to the current top of the error queue.
 
 L<ERR_load_strings(3)> can be used to register
 error strings so that the application can a generate human-readable

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -326,11 +326,13 @@ void ERR_put_error(int lib, int func, int reason, const char *file, int line)
      * so we'll need to come up with something else for them.
      */
     c_put_error(lib, func, reason, file, line);
+    ERR_add_error_data(1, "(in the FIPS module)");
 }
 
 void ERR_add_error_data(int num, ...)
 {
     va_list args;
+
     va_start(args, num);
     ERR_add_error_vdata(num, args);
     va_end(args);

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -32,8 +32,21 @@ static int preserves_system_error(void)
 #endif
 }
 
+/* Test that calls to ERR_add_error_[v]data append */
+static int vdata_appends(void)
+{
+    const char *data;
+
+    CRYPTOerr(0, ERR_R_MALLOC_FAILURE);
+    ERR_add_error_data(1, "hello ");
+    ERR_add_error_data(1, "world");
+    ERR_get_error_line_data(NULL, NULL, &data, NULL);
+    return TEST_str_eq(data, "hello world");
+}
+
 int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
+    ADD_TEST(vdata_appends);
     return 1;
 }


### PR DESCRIPTION
The "add error data" functions now append to the current error.
Add a test for this, and update the documentation.
Cleanup some of the ERR_put functions.
In the FIPS module, always append "(in the FIPS module)" to any errors.

This replaces #8887.  Ping @levitte.