### PR TITLE
Don't create an OPENSSL_CTX twice

### DIFF
--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -216,18 +216,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
                        void **provctx)
 {
     FIPS_GLOBAL *fgbl;
-    OPENSSL_CTX *ctx = OPENSSL_CTX_new();
-
-    if (ctx == NULL)
-        return 0;
-
-    fgbl = openssl_ctx_get_data(ctx, OPENSSL_CTX_FIPS_PROV_INDEX,
-                                &fips_prov_ossl_ctx_method);
-
-    if (fgbl == NULL)
-        goto err;
-
-    fgbl->prov = provider;
+    OPENSSL_CTX *ctx;
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
@@ -255,6 +244,14 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
     ctx = OPENSSL_CTX_new();
     if (ctx == NULL)
         return 0;
+
+    fgbl = openssl_ctx_get_data(ctx, OPENSSL_CTX_FIPS_PROV_INDEX,
+                                &fips_prov_ossl_ctx_method);
+
+    if (fgbl == NULL)
+        goto err;
+
+    fgbl->prov = provider;
 
     *out = fips_dispatch_table;
     *provctx = ctx;


### PR DESCRIPTION
The fips provider was creating the OPENSSL_CTX twice due to a previous
merge error.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
