### PR TITLE
Remove BS2000/OSD

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1220,19 +1220,6 @@ my %targets = (
         RANLIB           => add("-X64"),
     },
 
-# SIEMENS BS2000/OSD: an EBCDIC-based mainframe
-    "BS2000-OSD" => {
-        inherit_from     => [ "BASE_unix" ],
-        CC               => "c89",
-        CFLAGS           => "-O",
-        cflags           => "-XLLML -XLLMK -XL",
-        cppflags         => "-DCHARSET_EBCDIC",
-        lib_cppflags     => "-DB_ENDIAN",
-        ex_libs          => add("-lsocket -lnsl"),
-        bn_ops           => "THIRTY_TWO_BIT RC4_CHAR",
-        thread_scheme    => "(unknown)",
-    },
-
 #### Visual C targets
 #
 # Win64 targets, WIN64I denotes IA-64/Itanium and WIN64A - AMD64

--- a/config
+++ b/config
@@ -732,7 +732,6 @@ case "$GUESSOS" in
 	options="$options no-threads no-shared no-asm no-dso"
 	EXE=".pm"
 	OUT="vos-$CC" ;;
-  BS2000-siemens-sysv4) OUT="BS2000-OSD" ;;
   *-hpux1*)
 	if [ $CC = "gcc" -a $GCC_BITS = "64" ]; then
 	    OUT="hpux64-parisc2-gcc"

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -376,25 +376,6 @@ void ERR_put_error(int lib, int func, int reason, const char *file, int line)
 {
     ERR_STATE *es;
 
-#ifdef _OSD_POSIX
-    /*
-     * In the BS2000-OSD POSIX subsystem, the compiler generates path names
-     * in the form "*POSIX(/etc/passwd)". This dirty hack strips them to
-     * something sensible. @@@ We shouldn't modify a const string, though.
-     */
-    if (strncmp(file, "*POSIX(", sizeof("*POSIX(") - 1) == 0) {
-        char *end;
-
-        /* Skip the "*POSIX(" prefix */
-        file += sizeof("*POSIX(") - 1;
-        end = &file[strlen(file) - 1];
-        if (*end == ')')
-            *end = '\0';
-        /* Optional: use the basename of the path only. */
-        if ((end = strrchr(file, '/')) != NULL)
-            file = &end[1];
-    }
-#endif
     es = ERR_get_state();
     if (es == NULL)
         return;


### PR DESCRIPTION
Nobody knows is the POSIX offering of BS2000 still does this.  Let users come and complain if so.  The code being removed modifies a const string.
