### PR TITLE
ARIA documentation titled itself AES

### DIFF
--- a/doc/man3/EVP_aria.pod
+++ b/doc/man3/EVP_aria.pod
@@ -32,7 +32,7 @@ EVP_aria_256_ccm,
 EVP_aria_128_gcm,
 EVP_aria_192_gcm,
 EVP_aria_256_gcm,
-- EVP AES cipher
+- EVP ARIA cipher
 
 =head1 SYNOPSIS
 
@@ -106,7 +106,7 @@ L<EVP_CIPHER_meth_new(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
Changes the documentation so the header is ARIA not AES.

- [x] documentation is added or updated

