### PR TITLE
Add extra error text in the property parser

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -87,13 +87,12 @@ static int parse_name(OPENSSL_CTX *ctx, const char *t[], int create,
     int err = 0;
     size_t i = 0;
     const char *s = *t;
-    const char *start = *t;
     int user_name = 0;
 
     for (;;) {
         if (!ossl_isalpha(*s)) {
             PROPerr(PROP_F_PARSE_NAME, PROP_R_NOT_AN_IDENTIFIER);
-            ERR_add_error_data(2, "HERE-->", start);
+            ERR_add_error_data(2, "HERE-->", *t);
             return 0;
         }
         do {
@@ -112,20 +111,19 @@ static int parse_name(OPENSSL_CTX *ctx, const char *t[], int create,
         s++;
     }
     name[i] = '\0';
-    *t = skip_space(s);
-    if (!err) {
-        *idx = ossl_property_name(ctx, name, user_name && create);
-        return 1;
+    if (err) {
+        PROPerr(PROP_F_PARSE_NAME, PROP_R_NAME_TOO_LONG);
+        ERR_add_error_data(2, "HERE-->", *t);
+        return 0;
     }
-    PROPerr(PROP_F_PARSE_NAME, PROP_R_NAME_TOO_LONG);
-    ERR_add_error_data(2, "HERE-->", start);
-    return 0;
+    *t = skip_space(s);
+    *idx = ossl_property_name(ctx, name, user_name && create);
+    return 1;
 }
 
 static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
-    const char *start = *t;
     int64_t v = 0;
 
     if (!ossl_isdigit(*s))
@@ -135,7 +133,7 @@ static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
     } while (ossl_isdigit(*s));
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_NUMBER, PROP_R_NOT_A_DECIMAL_DIGIT);
-        ERR_add_error_data(2, "HERE-->", start);
+        ERR_add_error_data(2, "HERE-->", *t);
         return 0;
     }
     *t = skip_space(s);
@@ -147,7 +145,6 @@ static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
 static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
-    const char *start = *t;
     int64_t v = 0;
 
     if (!ossl_isxdigit(*s))
@@ -161,7 +158,7 @@ static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
     } while (ossl_isxdigit(*++s));
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_HEX, PROP_R_NOT_AN_HEXADECIMAL_DIGIT);
-        ERR_add_error_data(2, "HERE-->", start);
+        ERR_add_error_data(2, "HERE-->", *t);
         return 0;
     }
     *t = skip_space(s);
@@ -173,7 +170,6 @@ static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
 static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
-    const char *start = *t;
     int64_t v = 0;
 
     if (*s == '9' || *s == '8' || !ossl_isdigit(*s))
@@ -183,7 +179,7 @@ static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
     } while (ossl_isdigit(*++s) && *s != '9' && *s != '8');
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_OCT, PROP_R_NOT_AN_OCTAL_DIGIT);
-        ERR_add_error_data(2, "HERE-->", start);
+        ERR_add_error_data(2, "HERE-->", *t);
         return 0;
     }
     *t = skip_space(s);
@@ -197,7 +193,6 @@ static int parse_string(OPENSSL_CTX *ctx, const char *t[], char delim,
 {
     char v[1000];
     const char *s = *t;
-    const char *start = *t;
     size_t i = 0;
     int err = 0;
 
@@ -214,13 +209,13 @@ static int parse_string(OPENSSL_CTX *ctx, const char *t[], char delim,
         PROPerr(PROP_F_PARSE_STRING,
                 PROP_R_NO_MATCHING_STRING_DELIMETER);
         buf[0] = delim;
-        ERR_add_error_data(3, "HERE-->", buf, start);
+        ERR_add_error_data(3, "HERE-->", buf, *t);
         return 0;
     }
     v[i] = '\0';
     if (err) {
         PROPerr(PROP_F_PARSE_STRING, PROP_R_STRING_TOO_LONG);
-        ERR_add_error_data(2, "HERE-->", start);
+        ERR_add_error_data(2, "HERE-->", *t);
     } else {
         res->v.str_val = ossl_property_value(ctx, v, create);
     }
@@ -234,7 +229,6 @@ static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
 {
     char v[1000];
     const char *s = *t;
-    const char *start = *t;
     size_t i = 0;
     int err = 0;
 
@@ -255,7 +249,7 @@ static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
     v[i] = 0;
     if (err) {
         PROPerr(PROP_F_PARSE_UNQUOTED, PROP_R_STRING_TOO_LONG);
-        ERR_add_error_data(2, "HERE-->", start);
+        ERR_add_error_data(2, "HERE-->", *t);
     } else {
         res->v.str_val = ossl_property_value(ctx, v, create);
     }

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -87,11 +87,13 @@ static int parse_name(OPENSSL_CTX *ctx, const char *t[], int create,
     int err = 0;
     size_t i = 0;
     const char *s = *t;
+    const char *start = *t;
     int user_name = 0;
 
     for (;;) {
         if (!ossl_isalpha(*s)) {
             PROPerr(PROP_F_PARSE_NAME, PROP_R_NOT_AN_IDENTIFIER);
+            ERR_add_error_data(2, "HERE-->", start);
             return 0;
         }
         do {
@@ -116,12 +118,14 @@ static int parse_name(OPENSSL_CTX *ctx, const char *t[], int create,
         return 1;
     }
     PROPerr(PROP_F_PARSE_NAME, PROP_R_NAME_TOO_LONG);
+    ERR_add_error_data(2, "HERE-->", start);
     return 0;
 }
 
 static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
+    const char *start = *t;
     int64_t v = 0;
 
     if (!ossl_isdigit(*s))
@@ -131,6 +135,7 @@ static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
     } while (ossl_isdigit(*s));
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_NUMBER, PROP_R_NOT_A_DECIMAL_DIGIT);
+        ERR_add_error_data(2, "HERE-->", start);
         return 0;
     }
     *t = skip_space(s);
@@ -142,6 +147,7 @@ static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
 static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
+    const char *start = *t;
     int64_t v = 0;
 
     if (!ossl_isxdigit(*s))
@@ -155,6 +161,7 @@ static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
     } while (ossl_isxdigit(*++s));
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_HEX, PROP_R_NOT_AN_HEXADECIMAL_DIGIT);
+        ERR_add_error_data(2, "HERE-->", start);
         return 0;
     }
     *t = skip_space(s);
@@ -166,6 +173,7 @@ static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
 static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
+    const char *start = *t;
     int64_t v = 0;
 
     if (*s == '9' || *s == '8' || !ossl_isdigit(*s))
@@ -175,6 +183,7 @@ static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
     } while (ossl_isdigit(*++s) && *s != '9' && *s != '8');
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_OCT, PROP_R_NOT_AN_OCTAL_DIGIT);
+        ERR_add_error_data(2, "HERE-->", start);
         return 0;
     }
     *t = skip_space(s);
@@ -188,6 +197,7 @@ static int parse_string(OPENSSL_CTX *ctx, const char *t[], char delim,
 {
     char v[1000];
     const char *s = *t;
+    const char *start = *t;
     size_t i = 0;
     int err = 0;
 
@@ -199,16 +209,22 @@ static int parse_string(OPENSSL_CTX *ctx, const char *t[], char delim,
         s++;
     }
     if (*s == '\0') {
+        char buf[2] = { 0, 0 };
+
         PROPerr(PROP_F_PARSE_STRING,
                 PROP_R_NO_MATCHING_STRING_DELIMETER);
+        buf[0] = delim;
+        ERR_add_error_data(3, "HERE-->", buf, start);
         return 0;
     }
     v[i] = '\0';
-    *t = skip_space(s + 1);
-    if (err)
+    if (err) {
         PROPerr(PROP_F_PARSE_STRING, PROP_R_STRING_TOO_LONG);
-    else
+        ERR_add_error_data(2, "HERE-->", start);
+    } else {
         res->v.str_val = ossl_property_value(ctx, v, create);
+    }
+    *t = skip_space(s + 1);
     res->type = PROPERTY_TYPE_STRING;
     return !err;
 }
@@ -218,6 +234,7 @@ static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
 {
     char v[1000];
     const char *s = *t;
+    const char *start = *t;
     size_t i = 0;
     int err = 0;
 
@@ -232,14 +249,17 @@ static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
     }
     if (!ossl_isspace(*s) && *s != '\0' && *s != ',') {
         PROPerr(PROP_F_PARSE_UNQUOTED, PROP_R_NOT_AN_ASCII_CHARACTER);
+        ERR_add_error_data(2, "HERE-->", s);
         return 0;
     }
     v[i] = 0;
-    *t = skip_space(s);
-    if (err)
+    if (err) {
         PROPerr(PROP_F_PARSE_UNQUOTED, PROP_R_STRING_TOO_LONG);
-    else
+        ERR_add_error_data(2, "HERE-->", start);
+    } else {
         res->v.str_val = ossl_property_value(ctx, v, create);
+    }
+    *t = skip_space(s);
     res->type = PROPERTY_TYPE_STRING;
     return !err;
 }
@@ -333,6 +353,8 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OPENSSL_CTX *ctx, const char *defn)
     s = skip_space(s);
     done = *s == '\0';
     while (!done) {
+        const char *start = s;
+
         prop = OPENSSL_malloc(sizeof(*prop));
         if (prop == NULL)
             goto err;
@@ -343,11 +365,13 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OPENSSL_CTX *ctx, const char *defn)
         prop->oper = PROPERTY_OPER_EQ;
         if (prop->name_idx == 0) {
             PROPerr(PROP_F_OSSL_PARSE_PROPERTY, PROP_R_PARSE_FAILED);
+            ERR_add_error_data(2, "Unknown name HERE-->", start);
             goto err;
         }
         if (match_ch(&s, '=')) {
             if (!parse_value(ctx, &s, prop, 1)) {
                 PROPerr(PROP_F_OSSL_PARSE_PROPERTY, PROP_R_NO_VALUE);
+                ERR_add_error_data(2, "HERE-->", start);
                 goto err;
             }
         } else {
@@ -363,6 +387,7 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OPENSSL_CTX *ctx, const char *defn)
     }
     if (*s != '\0') {
         PROPerr(PROP_F_OSSL_PARSE_PROPERTY, PROP_R_TRAILING_CHARACTERS);
+        ERR_add_error_data(2, "HERE-->", s);
         goto err;
     }
     res = stack_to_property_list(sk);
@@ -424,6 +449,7 @@ skip_value:
     }
     if (*s != '\0') {
         PROPerr(PROP_F_OSSL_PARSE_QUERY, PROP_R_TRAILING_CHARACTERS);
+        ERR_add_error_data(2, "HERE-->", s);
         goto err;
     }
     res = stack_to_property_list(sk);


### PR DESCRIPTION
With properties being specified in all kinds of places, including hard
coded in providers, it's not always easy to figure out exactly what
string was incorrect when the parser would just say something like
'parse failed' with no more details.

Adding extra data to the error, showing exactly what string is
incorrect, helps a bit.  At the very least, this gives anyone
interested something to grep for.
