### PR TITLE
Print thread IDs nicely.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -130,11 +130,8 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
 {
     int ret = 0;
     tracedata *trace_data = vdata;
-    union {
-        CRYPTO_THREAD_ID tid;
-        unsigned long ltid;
-    } tid;
-    char buffer[256];
+    char buffer[256], *hex;
+    CRYPTO_THREAD_ID tid;
 
     switch (cmd) {
     case OSSL_TRACE_CTRL_BEGIN:
@@ -142,11 +139,11 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
             return 0;
         trace_data->ingroup = 1;
 
-        tid.ltid = 0;
-        tid.tid = CRYPTO_THREAD_get_current_id();
-
-        BIO_snprintf(buffer, sizeof(buffer), "TRACE[%lx]:%s: ", tid.ltid,
-                     OSSL_trace_get_category_name(category));
+        tid = CRYPTO_THREAD_get_current_id();
+        hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
+        BIO_snprintf(buffer, sizeof(buffer), "TRACE[%s]:%s: ",
+                     hex, OSSL_trace_get_category_name(category));
+        OPENSSL_free(hex);
         BIO_ctrl(trace_data->bio, PREFIX_CTRL_SET_PREFIX,
                  strlen(buffer), buffer);
         break;

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -16,27 +16,19 @@
 void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
                          void *u)
 {
+    CRYPTO_THREAD_ID tid = CRYPTO_THREAD_get_current_id();
     unsigned long l;
     char buf[256];
-    char buf2[4096];
+    char buf2[4096], *hex;
     const char *file, *data;
     int line, flags;
-    /*
-     * We don't know what kind of thing CRYPTO_THREAD_ID is. Here is our best
-     * attempt to convert it into something we can print.
-     */
-    union {
-        CRYPTO_THREAD_ID tid;
-        unsigned long ltid;
-    } tid;
-
-    tid.ltid = 0;
-    tid.tid = CRYPTO_THREAD_get_current_id();
 
     while ((l = ERR_get_error_line_data(&file, &line, &data, &flags)) != 0) {
         ERR_error_string_n(l, buf, sizeof(buf));
-        BIO_snprintf(buf2, sizeof(buf2), "%lu:%s:%s:%d:%s\n", tid.ltid, buf,
-                     file, line, (flags & ERR_TXT_STRING) ? data : "");
+        hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
+        BIO_snprintf(buf2, sizeof(buf2), "%s:%s:%s:%d:%s\n", hex, buf, file,
+                     line, (flags & ERR_TXT_STRING) ? data : "");
+        OPENSSL_free(hex);
         if (cb(buf2, strlen(buf2), u) <= 0)
             break;              /* abort outputting the error report */
     }

--- a/test/testutil/init.c
+++ b/test/testutil/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -24,21 +24,18 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
 {
     int ret = 0;
     tracedata *trace_data = vdata;
-    union {
-        CRYPTO_THREAD_ID tid;
-        unsigned long ltid;
-    } tid;
-    char buffer[256];
+    char buffer[256], *hex;
+    CRYPTO_THREAD_ID tid;
 
     switch (cmd) {
     case OSSL_TRACE_CTRL_BEGIN:
         trace_data->ingroup = 1;
 
-        tid.ltid = 0;
-        tid.tid = CRYPTO_THREAD_get_current_id();
-
-        BIO_snprintf(buffer, sizeof(buffer), "TRACE[%lx]:%s: ", tid.ltid,
-                     OSSL_trace_get_category_name(category));
+        tid = CRYPTO_THREAD_get_current_id();
+        hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
+        BIO_snprintf(buffer, sizeof(buffer), "TRACE[%s]:%s: ",
+                     hex, OSSL_trace_get_category_name(category));
+        OPENSSL_free(hex);
         BIO_ctrl(trace_data->bio, PREFIX_CTRL_SET_PREFIX,
                  strlen(buffer), buffer);
         break;


### PR DESCRIPTION
Remove the union that effectively cast thread IDs to long integers before
display and instead print a hex dump of the entire object.

Refer #9191

- [x] tests are added or updated
