### PR TITLE
test/testutil/init.c, apps/openssl.c: add trace cleanup handle earlier

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -216,6 +216,13 @@ static void setup_trace(const char *str)
 {
     char *val;
 
+    /*
+     * We add this handler as early as possible to ensure it's executed
+     * as late as possible, i.e. after the TRACE code has done its cleanup
+     * (which happens last in OPENSSL_cleanup).
+     */
+    atexit(cleanup_trace);
+
     trace_data_stack = sk_tracedata_new_null();
     val = OPENSSL_strdup(str);
 
@@ -240,7 +247,6 @@ static void setup_trace(const char *str)
     }
 
     OPENSSL_free(val);
-    atexit(cleanup_trace);
 }
 #endif /* OPENSSL_NO_TRACE */
 

--- a/test/testutil/init.c
+++ b/test/testutil/init.c
@@ -102,6 +102,13 @@ static void setup_trace(const char *str)
 {
     char *val;
 
+    /*
+     * We add this handler as early as possible to ensure it's executed
+     * as late as possible, i.e. after the TRACE code has done its cleanup
+     * (which happens last in OPENSSL_cleanup).
+     */
+    atexit(cleanup_trace);
+
     trace_data_stack = sk_tracedata_new_null();
     val = OPENSSL_strdup(str);
 
@@ -126,7 +133,6 @@ static void setup_trace(const char *str)
     }
 
     OPENSSL_free(val);
-    atexit(cleanup_trace);
 }
 #endif /* OPENSSL_NO_TRACE */
 


### PR DESCRIPTION
It turned out that the internal trace cleanup handler was added too
late, so it would be executed before OPENSSL_cleanup().
This results in address errors, as the trace code that's executed in
OPENSSL_cleanup() itself tries to reach for data that's been freed at
that point.
