### PR TITLE
Make SSL_set1_host and SSL_add1_host handle IP addresses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Allow SSL_set1_host() and SSL_add1_host() to take IP literal addresses
+   as well as actual hostnames.
+
+   *David Woodhouse*
+
  * The 'MinProtocol' and 'MaxProtocol' configuration commands now silently
    ignore TLS protocol version bounds when configuring DTLS-based contexts, and
    conversely, silently ignore DTLS protocol version bounds when configuring

--- a/demos/bio/sconnect.c
+++ b/demos/bio/sconnect.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 {
     const char *hostport = HOSTPORT;
     const char *CAfile = CAFILE;
-    char *hostname;
+    const char *hostname;
     char *cp;
     BIO *out = NULL;
     char buf[1024 * 10], *p;
@@ -42,10 +42,6 @@ int main(int argc, char *argv[])
         hostport = argv[1];
     if (argc > 2)
         CAfile = argv[2];
-
-    hostname = OPENSSL_strdup(hostport);
-    if ((cp = strchr(hostname, ':')) != NULL)
-        *cp = 0;
 
 #ifdef WATT32
     dbug_init();
@@ -62,9 +58,6 @@ int main(int argc, char *argv[])
     ssl = SSL_new(ssl_ctx);
     SSL_set_connect_state(ssl);
 
-    /* Enable peername verification */
-    if (SSL_set1_host(ssl, hostname) <= 0)
-        goto err;
 
     /* Use it inside an SSL BIO */
     ssl_bio = BIO_new(BIO_f_ssl());
@@ -73,6 +66,12 @@ int main(int argc, char *argv[])
     /* Lets use a connect BIO under the SSL BIO */
     out = BIO_new(BIO_s_connect());
     BIO_set_conn_hostname(out, hostport);
+
+    /* The BIO has parsed the host:port and even IPv6 literals in [] */
+    hostname = BIO_get_conn_hostname(out);
+    if (!hostname || SSL_set1_host(ssl, hostname) <= 0)
+        goto err;
+
     BIO_set_nbio(out, 1);
     out = BIO_push(ssl_bio, out);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -955,11 +955,21 @@ int SSL_set_trust(SSL *s, int trust)
 
 int SSL_set1_host(SSL *s, const char *hostname)
 {
+    /* If a hostname is provided and parses as an IP address,
+     * treat it as such. */
+    if (hostname && X509_VERIFY_PARAM_set1_ip_asc(s->param, hostname) == 1)
+        return 1;
+
     return X509_VERIFY_PARAM_set1_host(s->param, hostname, 0);
 }
 
 int SSL_add1_host(SSL *s, const char *hostname)
 {
+    /* If a hostname is provided and parses as an IP address,
+     * treat it as such. */
+    if (hostname && X509_VERIFY_PARAM_set1_ip_asc(s->param, hostname) == 1)
+        return 1;
+
     return X509_VERIFY_PARAM_add1_host(s->param, hostname, 0);
 }
 


### PR DESCRIPTION
We have SSL_set1_hostname() already. It would be reasonable for developers to assume that it can be used for IP literals. It can't. Add the functions that can.

Then use them to fix the sconnect demo, which was failing for IP literals.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
