### PR TITLE
Deprecate _CONF_ API, make conf_method_st opaque

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,10 @@
      The macro SYSerr() is deprecated.
      [Rich Salz]
 
+  *) The old _CONF_xxx API has been removed and the CONF_METHOD type has
+     been made opaque.
+     [Rich Salz]
+
   *) {CRYPTO,OPENSSL}_mem_debug_{push,pop} are now no-ops and have been
      deprecated.
      [Rich Salz]

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -15,8 +15,8 @@
 #include "internal/o_dir.h"
 #include <openssl/lhash.h>
 #include <openssl/conf.h>
-#include <openssl/conf_api.h>
 #include "conf_def.h"
+#include "conf_lcl.h"
 #include <openssl/buffer.h>
 #include <openssl/err.h>
 #ifndef OPENSSL_NO_POSIX_IO
@@ -149,7 +149,7 @@ static int def_destroy_data(CONF *conf)
 {
     if (conf == NULL)
         return 0;
-    _CONF_free_data(conf);
+    conf_free_data(conf);
     return 1;
 }
 
@@ -209,12 +209,12 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
         goto err;
     }
 
-    if (_CONF_new_data(conf) == 0) {
+    if (conf_new_data(conf) == 0) {
         CONFerr(CONF_F_DEF_LOAD_BIO, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
-    sv = _CONF_new_section(conf, section);
+    sv = conf_new_section(conf, section);
     if (sv == NULL) {
         CONFerr(CONF_F_DEF_LOAD_BIO, CONF_R_UNABLE_TO_CREATE_NEW_SECTION);
         goto err;
@@ -327,8 +327,8 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
             *end = '\0';
             if (!str_copy(conf, NULL, &section, start))
                 goto err;
-            if ((sv = _CONF_get_section(conf, section)) == NULL)
-                sv = _CONF_new_section(conf, section);
+            if ((sv = conf_get_section(conf, section)) == NULL)
+                sv = conf_new_section(conf, section);
             if (sv == NULL) {
                 CONFerr(CONF_F_DEF_LOAD_BIO,
                         CONF_R_UNABLE_TO_CREATE_NEW_SECTION);
@@ -410,9 +410,9 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 goto err;
 
             if (strcmp(psection, section) != 0) {
-                if ((tv = _CONF_get_section(conf, psection))
+                if ((tv = conf_get_section(conf, psection))
                     == NULL)
-                    tv = _CONF_new_section(conf, psection);
+                    tv = conf_new_section(conf, psection);
                 if (tv == NULL) {
                     CONFerr(CONF_F_DEF_LOAD_BIO,
                             CONF_R_UNABLE_TO_CREATE_NEW_SECTION);
@@ -420,7 +420,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 }
             } else
                 tv = sv;
-            if (_CONF_add_string(conf, tv, v) == 0) {
+            if (conf_add_string(conf, tv, v) == 0) {
                 CONFerr(CONF_F_DEF_LOAD_BIO, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
@@ -614,7 +614,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
              * r and rr are the chars replaced by the '\0'
              * rp and rrp is where 'r' and 'rr' came from.
              */
-            p = _CONF_get_string(conf, cp, np);
+            p = conf_get_string(conf, cp, np);
             if (rrp != NULL)
                 *rrp = rr;
             *rp = r;

--- a/crypto/conf/conf_lcl.h
+++ b/crypto/conf/conf_lcl.h
@@ -21,12 +21,15 @@ struct conf_method_st {
     int (*load) (CONF *conf, const char *name, long *eline);
 };
 
-void conf_add_ssl_module(void);
-void conf_free_data(CONF *conf);
+/* Functions implementing the internal CONF/NCONF functionality. */
 int conf_new_data(CONF *conf);
+void conf_free_data(CONF *conf);
 CONF_VALUE *conf_new_section(CONF *conf, const char *section);
 CONF_VALUE *conf_get_section(const CONF *conf, const char *section);
 STACK_OF(CONF_VALUE) *conf_get_section_values(const CONF *conf,
                                               const char *section);
 int conf_add_string(CONF *conf, CONF_VALUE *section, CONF_VALUE *value);
 char *conf_get_string(const CONF *conf, const char *section, const char *name);
+
+/* Functions to load modules. */
+void conf_add_ssl_module(void);

--- a/crypto/conf/conf_lcl.h
+++ b/crypto/conf/conf_lcl.h
@@ -7,5 +7,26 @@
  * https://www.openssl.org/source/license.html
  */
 
-void conf_add_ssl_module(void);
 
+struct conf_method_st {
+    const char *name;
+    CONF *(*create) (CONF_METHOD *meth);
+    int (*init) (CONF *conf);
+    int (*destroy) (CONF *conf);
+    int (*destroy_data) (CONF *conf);
+    int (*load_bio) (CONF *conf, BIO *bp, long *eline);
+    int (*dump) (const CONF *conf, BIO *bp);
+    int (*is_number) (const CONF *conf, char c);
+    int (*to_int) (const CONF *conf, char c);
+    int (*load) (CONF *conf, const char *name, long *eline);
+};
+
+void conf_add_ssl_module(void);
+void conf_free_data(CONF *conf);
+int conf_new_data(CONF *conf);
+CONF_VALUE *conf_new_section(CONF *conf, const char *section);
+CONF_VALUE *conf_get_section(const CONF *conf, const char *section);
+STACK_OF(CONF_VALUE) *conf_get_section_values(const CONF *conf,
+                                              const char *section);
+int conf_add_string(CONF *conf, CONF_VALUE *section, CONF_VALUE *value);
+char *conf_get_string(const CONF *conf, const char *section, const char *name);

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -11,11 +11,11 @@
 #include <stdio.h>
 #include <string.h>
 #include "internal/conf.h"
+#include "conf_lcl.h"
 #include "internal/ctype.h"
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/conf.h>
-#include <openssl/conf_api.h>
 #include <openssl/lhash.h>
 
 static CONF_METHOD *default_CONF_method = NULL;
@@ -251,12 +251,12 @@ STACK_OF(CONF_VALUE) *NCONF_get_section(const CONF *conf, const char *section)
         return NULL;
     }
 
-    return _CONF_get_section_values(conf, section);
+    return conf_get_section_values(conf, section);
 }
 
 char *NCONF_get_string(const CONF *conf, const char *group, const char *name)
 {
-    char *s = _CONF_get_string(conf, group, name);
+    char *s = conf_get_string(conf, group, name);
 
     /*
      * Since we may get a value from an environment variable even if conf is

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct conf_value_st {
     char *section;
     char *name;
     char *value;
@@ -29,29 +29,6 @@ typedef struct {
 
 DEFINE_STACK_OF(CONF_VALUE)
 DEFINE_LHASH_OF(CONF_VALUE);
-
-struct conf_st;
-struct conf_method_st;
-typedef struct conf_method_st CONF_METHOD;
-
-struct conf_method_st {
-    const char *name;
-    CONF *(*create) (CONF_METHOD *meth);
-    int (*init) (CONF *conf);
-    int (*destroy) (CONF *conf);
-    int (*destroy_data) (CONF *conf);
-    int (*load_bio) (CONF *conf, BIO *bp, long *eline);
-    int (*dump) (const CONF *conf, BIO *bp);
-    int (*is_number) (const CONF *conf, char c);
-    int (*to_int) (const CONF *conf, char c);
-    int (*load) (CONF *conf, const char *name, long *eline);
-};
-
-/* Module definitions */
-
-typedef struct conf_imodule_st CONF_IMODULE;
-typedef struct conf_module_st CONF_MODULE;
-
 DEFINE_STACK_OF(CONF_MODULE)
 DEFINE_STACK_OF(CONF_IMODULE)
 

--- a/include/openssl/conf_api.h
+++ b/include/openssl/conf_api.h
@@ -10,31 +10,6 @@
 #ifndef  HEADER_CONF_API_H
 # define HEADER_CONF_API_H
 
-# include <openssl/lhash.h>
 # include <openssl/conf.h>
 
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
-/* Up until OpenSSL 0.9.5a, this was new_section */
-CONF_VALUE *_CONF_new_section(CONF *conf, const char *section);
-/* Up until OpenSSL 0.9.5a, this was get_section */
-CONF_VALUE *_CONF_get_section(const CONF *conf, const char *section);
-/* Up until OpenSSL 0.9.5a, this was CONF_get_section */
-STACK_OF(CONF_VALUE) *_CONF_get_section_values(const CONF *conf,
-                                               const char *section);
-
-int _CONF_add_string(CONF *conf, CONF_VALUE *section, CONF_VALUE *value);
-char *_CONF_get_string(const CONF *conf, const char *section,
-                       const char *name);
-long _CONF_get_number(const CONF *conf, const char *section,
-                      const char *name);
-
-int _CONF_new_data(CONF *conf);
-void _CONF_free_data(CONF *conf);
-
-#ifdef  __cplusplus
-}
-#endif
 #endif

--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -88,6 +88,11 @@ typedef struct bn_gencb_st BN_GENCB;
 
 typedef struct buf_mem_st BUF_MEM;
 
+typedef struct conf_st CONF;
+typedef struct conf_method_st CONF_METHOD;
+typedef struct conf_imodule_st CONF_IMODULE;
+typedef struct conf_module_st CONF_MODULE;
+
 typedef struct evp_cipher_st EVP_CIPHER;
 typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
 typedef struct evp_md_st EVP_MD;
@@ -148,7 +153,6 @@ typedef struct x509_sig_info_st X509_SIG_INFO;
 typedef struct pkcs8_priv_key_info_st PKCS8_PRIV_KEY_INFO;
 
 typedef struct v3_ext_ctx X509V3_CTX;
-typedef struct conf_st CONF;
 typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
 
 typedef struct ui_st UI;


### PR DESCRIPTION
Rewrite _CONF_xxx API in terms of new internal conf_xxx functions,
which are basically the old ones renamed.
