### PR TITLE
Remove NextStep support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Removed NextStep support and the macro OPENSSL_UNISTD
+     [Rich Salz]
+
   *) RC5_32_set_key has been changed to return an int type, with 0 indicating
      an error and 1 indicating success. In previous versions of OpenSSL this
      was a void type. If a key was set longer than the maximum possible this

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1051,23 +1051,6 @@ my %targets = (
         shared_cflag     => "-fPIC",
     },
 
-    "nextstep" => {
-        inherit_from     => [ "BASE_unix" ],
-        CC               => "cc",
-        CFLAGS           => "-O -Wall",
-        unistd           => "<libc.h>",
-        bn_ops           => "BN_LLONG",
-        thread_scheme    => "(unknown)",
-    },
-    "nextstep3.3" => {
-        inherit_from     => [ "BASE_unix" ],
-        CC               => "cc",
-        CFLAGS           => "-O3 -Wall",
-        unistd           => "<libc.h>",
-        bn_ops           => "BN_LLONG",
-        thread_scheme    => "(unknown)",
-    },
-
 #### SCO/Caldera targets.
 #
 # Originally we had like unixware-*, unixware-*-pentium, unixware-*-p6, etc.

--- a/Configure
+++ b/Configure
@@ -3314,7 +3314,6 @@ sub print_table_entry
         "includes",
         "cc",
         "cflags",
-        "unistd",
         "ld",
         "lflags",
         "loutflag",

--- a/apps/opt.c
+++ b/apps/opt.c
@@ -15,7 +15,7 @@
 #include "internal/nelem.h"
 #include <string.h>
 #if !defined(OPENSSL_SYS_MSDOS)
-# include OPENSSL_UNISTD
+# include <unistd.h>
 #endif
 
 #include <stdlib.h>

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -24,7 +24,7 @@
 #include <openssl/err.h>
 #include <internal/sockets.h>
 #if !defined(OPENSSL_SYS_MSDOS)
-# include OPENSSL_UNISTD
+# include <unistd.h>
 #endif
 
 #define SSL_CONNECT_NAME        "localhost:4433"

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -29,7 +29,7 @@
 #include <openssl/objects.h>
 #include <openssl/async.h>
 #if !defined(OPENSSL_SYS_MSDOS)
-# include OPENSSL_UNISTD
+# include <unistd.h>
 #endif
 
 #if defined(_WIN32)

--- a/config
+++ b/config
@@ -349,17 +349,6 @@ if [ -d /usr/apollo ]; then
     exit 0
 fi
 
-# Now NeXT
-ISNEXT=`hostinfo 2>/dev/null`
-case "$ISNEXT" in
-    *'NeXT Mach 3.3'*)
-	echo "whatever-next-nextstep3.3"; exit 0
-	;;
-    *NeXT*)
-	echo "whatever-next-nextstep"; exit 0
-	;;
-esac
-
 # At this point we gone through all the one's
 # we know of: Punt
 

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -38,7 +38,7 @@ int RAND_egd_bytes(const char *path, int bytes)
 
 # else
 
-#  include OPENSSL_UNISTD
+#  include <unistd.h>
 #  include <stddef.h>
 #  include <sys/types.h>
 #  include <sys/socket.h>

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -34,11 +34,7 @@
 # include <errno.h>
 
 # if !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS)
-#  ifdef OPENSSL_UNISTD
-#   include OPENSSL_UNISTD
-#  else
-#   include <unistd.h>
-#  endif
+#  include <unistd.h>
 /*
  * If unistd.h defines _POSIX_VERSION, we conclude that we are on a POSIX
  * system and have sigaction and termios.

--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -19,7 +19,7 @@ int OPENSSL_issetugid(void)
 
 #elif defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__)
 
-# include OPENSSL_UNISTD
+# include <unistd.h>
 
 int OPENSSL_issetugid(void)
 {
@@ -28,7 +28,7 @@ int OPENSSL_issetugid(void)
 
 #else
 
-# include OPENSSL_UNISTD
+# include <unistd.h>
 # include <sys/types.h>
 
 # if defined(__GLIBC__) && defined(__GLIBC_PREREQ)

--- a/e_os.h
+++ b/e_os.h
@@ -257,11 +257,7 @@ extern FILE *_imp___iob;
 
 #  else
      /* !defined VMS */
-#   ifdef OPENSSL_UNISTD
-#    include OPENSSL_UNISTD
-#   else
-#    include <unistd.h>
-#   endif
+#   include <unistd.h>
 #   include <sys/types.h>
 #   ifdef OPENSSL_SYS_WIN32_CYGWIN
 #    include <io.h>

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -136,15 +136,6 @@ extern "C" {
  * That's it for OS-specific stuff
  *****************************************************************************/
 
-/* Specials for I/O an exit */
-# ifdef OPENSSL_SYS_MSDOS
-#  define OPENSSL_UNISTD_IO <io.h>
-#  define OPENSSL_DECLARE_EXIT extern void exit(int);
-# else
-#  define OPENSSL_UNISTD_IO OPENSSL_UNISTD
-#  define OPENSSL_DECLARE_EXIT  /* declared in unistd.h */
-# endif
-
 /*-
  * OPENSSL_EXTERN is normally used to declare a symbol with possible extra
  * attributes to handle its presence in a shared library.

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -165,9 +165,6 @@ extern "C" {
 /* Generate 80386 code? */
 {- $config{processor} eq "386" ? "# define" : "# undef" -} I386_ONLY
 
-# undef OPENSSL_UNISTD
-# define OPENSSL_UNISTD {- $target{unistd} -}
-
 {- $config{export_var_as_fn} ? "# define" : "# undef" -} OPENSSL_EXPORT_VAR_AS_FUNCTION
 
 /*

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -71,7 +71,7 @@
 #ifdef OPENSSL_SYS_WINDOWS
 # include <winsock.h>
 #else
-# include OPENSSL_UNISTD
+# include <unistd.h>
 #endif
 
 static SSL_CTX *s_ctx = NULL;


### PR DESCRIPTION
Because of that we can remove OPENSSL_UNISTD.

According to Wikipedia, the last release was in 1995 (the last preview release was in 1997) -- more than 20 years ago.  Time to remove it.

See #6232.