### PR TITLE
Remove HP/MPE and Tru64 Unix support

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -607,58 +607,6 @@ my %targets = (
         multilib         => "/hpux64",
     },
 
-#### HP MPE/iX http://jazz.external.hp.com/src/openssl/
-    "MPE/iX-gcc" => {
-        inherit_from     => [ "BASE_unix" ],
-        CC               => "gcc",
-        CFLAGS           => "-O3",
-        cppflags         => "-D_POSIX_SOURCE -D_SOCKET_SOURCE",
-        includes         => [ "/SYSLOG/PUB" ],
-        lib_cppflags     => "-DBN_DIV2W",
-        sys_id           => "MPE",
-        lflags           => add("-L/SYSLOG/PUB"),
-        ex_libs          => add("-lsyslog -lsocket -lcurses"),
-        thread_scheme    => "(unknown)",
-        bn_ops           => "BN_LLONG",
-    },
-
-#### DEC Alpha Tru64 targets. Tru64 is marketing name for OSF/1 version 4
-#### and forward. In reality 'uname -s' still returns "OSF1". Originally
-#### there were even osf1-* configs targeting prior versions provided,
-#### but not anymore...
-    "tru64-alpha-gcc" => {
-        inherit_from     => [ "BASE_unix" ],
-        CC               => "gcc",
-        CFLAGS           => "-O3",
-        cflags           => add("-std=c9x", threads("-pthread")),
-        cppflags         => "-D_XOPEN_SOURCE=500 -D_OSF_SOURCE",
-        ex_libs          => add("-lrt", threads("-pthread")), # for mlock(2)
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        asm_arch         => 'alpha',
-        perlasm_scheme   => "void",
-        thread_scheme    => "pthreads",
-        dso_scheme       => "dlfcn",
-        shared_target    => "alpha-osf1-shared",
-        shared_extension => ".so",
-    },
-    "tru64-alpha-cc" => {
-        inherit_from     => [ "BASE_unix" ],
-        CC               => "cc",
-        CFLAGS           => "-tune host -fast",
-        cflags           => add("-std1 -readonly_strings",
-                                threads("-pthread")),
-        cppflags         => "-D_XOPEN_SOURCE=500 -D_OSF_SOURCE",
-        ex_libs          => add("-lrt", threads("-pthread")), # for mlock(2)
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        asm_arch         => 'alpha',
-        perlasm_scheme   => "void",
-        thread_scheme    => "pthreads",
-        dso_scheme       => "dlfcn",
-        shared_target    => "alpha-osf1-shared",
-        shared_ldflag    => "-msym",
-        shared_extension => ".so",
-    },
-
 ####
 #### Variety of LINUX:-)
 ####

--- a/config
+++ b/config
@@ -225,21 +225,6 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
 	echo "${MACHINE}-unknown-OpenUNIX${VERSION}"; exit 0
 	;;
 
-    OSF1:*:*:*alpha*)
-	OSFMAJOR=`echo ${RELEASE}| sed -e 's/^V\([0-9]*\)\..*$/\1/'`
-	case "$OSFMAJOR" in
-	    4|5)
-		echo "${MACHINE}-dec-tru64"; exit 0
-		;;
-	    1|2|3)
-		echo "${MACHINE}-dec-osf"; exit 0
-		;;
-	    *)
-		echo "${MACHINE}-dec-osf"; exit 0
-		;;
-	esac
-	;;
-
     Paragon*:*:*:*)
 	echo "i860-intel-osf1"; exit 0
 	;;

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -22,13 +22,9 @@
 #ifdef DSO_DLFCN
 
 # ifdef HAVE_DLFCN_H
-#  ifdef __osf__
-#   define __EXTENSIONS__
-#  endif
 #  include <dlfcn.h>
 #  define HAVE_DLINFO 1
 #  if defined(__SCO_VERSION__) || defined(_SCO_ELF) || \
-     (defined(__osf__) && !defined(RTLD_NEXT))     || \
      (defined(__OpenBSD__) && !defined(RTLD_SELF)) || \
         defined(__ANDROID__)
 #   undef HAVE_DLINFO

--- a/e_os.h
+++ b/e_os.h
@@ -320,7 +320,7 @@ struct servent *getservbyname(const char *name, const char *proto);
 # if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
      && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
           || defined(__sun) || defined(__hpux) || defined(__sgi)      \
-          || defined(__osf__) )
+        )
 #  define OPENSSL_SECURE_MEMORY  /* secure memory is implemented */
 # endif
 #endif

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -208,7 +208,7 @@ typedef UINT32 uint32_t;
 typedef INT64 int64_t;
 typedef UINT64 uint64_t;
 # elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
-     defined(__osf__) || defined(__sgi) || defined(__hpux) || \
+     defined(__sgi) || defined(__hpux) || \
      defined(OPENSSL_SYS_VMS) || defined (__OpenBSD__)
 #  include <inttypes.h>
 #  undef OPENSSL_NO_INTTYPES_H

--- a/test/ctype_internal_test.c
+++ b/test/ctype_internal_test.c
@@ -18,7 +18,7 @@
  * so far (C RTL version 8.4). Same applies to OSF. For the sake of these
  * tests, we therefore define our own.
  */
-#if (defined(__VMS) && __CRTL_VER <= 80400000) || defined(__osf__)
+#if (defined(__VMS) && __CRTL_VER <= 80400000)
 static int isblank(int c)
 {
     return c == ' ' || c == '\t';


### PR DESCRIPTION
According to Wikipedia,  Tru64 was last released in 2010 and MPE was last released in 1998