### PR TITLE
use native atomic increment function on Solaris

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -167,6 +167,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
         return 1;
     }
 # elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
+    /* This will work for all future Solaris versions. */
     if (ret != NULL) {
         *ret = atomic_add_int_nv((volatile unsigned int *)val, amount);
         return 1;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -166,7 +166,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
         *ret = __atomic_add_fetch(val, amount, __ATOMIC_ACQ_REL);
         return 1;
     }
-# elif defined(__sun)
+# elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
     if (ret != NULL) {
         *ret = atomic_add_int_nv((volatile unsigned int *)val, amount);
         return 1;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -10,6 +10,10 @@
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 
+# if defined(__sun)
+#include <atomic.h>
+# endif
+
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_SYS_WINDOWS)
 
 # ifdef PTHREAD_RWLOCK_INITIALIZER
@@ -160,6 +164,11 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 # if defined(__GNUC__) && defined(__ATOMIC_ACQ_REL)
     if (__atomic_is_lock_free(sizeof(*val), val)) {
         *ret = __atomic_add_fetch(val, amount, __ATOMIC_ACQ_REL);
+        return 1;
+    }
+# elif defined(__sun)
+    if (ret != NULL) {
+        *ret = atomic_add_int_nv((volatile unsigned int *)val, amount);
         return 1;
     }
 # endif

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -10,9 +10,9 @@
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 
-# if defined(__sun)
-#include <atomic.h>
-# endif
+#if defined(__sun)
+# include <atomic.h>
+#endif
 
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_SYS_WINDOWS)
 


### PR DESCRIPTION
`CRYPTO_atomic_add()` currently has atomics only for GCC builtins. This change adds the support for Solaris libc builtins. When run in a tight loop on SPARC T5 the following program is 3x faster than the original (using RW locks - verified with `truss -u libc:: ./a.out`):
```C
#include <stdio.h>
#include <assert.h>
#include <err.h>

#include <openssl/crypto.h>

int
main(int argc, char *argv[])
{
        int val;

        if (argc != 2)
                errx(1, "usage: %s <count>", argv[0]);

        CRYPTO_RWLOCK *lock = CRYPTO_THREAD_lock_new();
        assert(lock != NULL);

        for (size_t i = 0; i < atoi(argv[1]); i++) {
                assert(CRYPTO_atomic_add(&val, 13, &val, lock) == 1);
        }

        return (0);
}
```
Tested on Solaris 11 with OpenSSL built in 64-bit mode using the Oracle Developer Studio 12.5 compiler.