### PR TITLE
Restrict usage of bio_dgram_sctp_data only to DGRAM SCTP methods

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -53,6 +53,8 @@ static int dgram_sctp_puts(BIO *h, const char *str);
 static long dgram_sctp_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int dgram_sctp_new(BIO *h);
 static int dgram_sctp_free(BIO *data);
+static int dgram_sctp_wait_for_dry(BIO *b);
+static int dgram_sctp_msg_waiting(BIO *b);
 #  ifdef SCTP_AUTHENTICATION_EVENT
 static void dgram_sctp_handle_auth_free_key_event(BIO *b, union sctp_notification
                                                   *snp);
@@ -124,7 +126,7 @@ typedef struct bio_dgram_sctp_data_st {
     struct bio_dgram_sctp_sndinfo sndinfo;
     struct bio_dgram_sctp_rcvinfo rcvinfo;
     struct bio_dgram_sctp_prinfo prinfo;
-    void (*handle_notifications) (BIO *bio, void *context, void *buf);
+    BIO_dgram_sctp_notification_handler_fn handle_notifications;
     void *notification_context;
     int in_handshake;
     int ccs_rcvd;
@@ -1562,6 +1564,10 @@ static long dgram_sctp_ctrl(BIO *b, int cmd, long num, void *ptr)
         else
             data->save_shutdown = 0;
         break;
+    case BIO_CTRL_DGRAM_SCTP_WAIT_FOR_DRY:
+        return dgram_sctp_wait_for_dry(b);
+    case BIO_CTRL_DGRAM_SCTP_MSG_WAITING:
+        return dgram_sctp_msg_waiting(b);
 
     default:
         /*
@@ -1574,11 +1580,8 @@ static long dgram_sctp_ctrl(BIO *b, int cmd, long num, void *ptr)
 }
 
 int BIO_dgram_sctp_notification_cb(BIO *b,
-                                   void (*handle_notifications) (BIO *bio,
-                                                                 void
-                                                                 *context,
-                                                                 void *buf),
-                                   void *context)
+                BIO_dgram_sctp_notification_handler_fn handle_notifications,
+                void *context)
 {
     bio_dgram_sctp_data *data = (bio_dgram_sctp_data *) b->ptr;
 
@@ -1605,6 +1608,11 @@ int BIO_dgram_sctp_notification_cb(BIO *b,
  *  1 when dry
  */
 int BIO_dgram_sctp_wait_for_dry(BIO *b)
+{
+    return (int)BIO_ctrl(b, BIO_CTRL_DGRAM_SCTP_WAIT_FOR_DRY, 0, NULL);
+}
+
+static int dgram_sctp_wait_for_dry(BIO *b)
 {
     int is_dry = 0;
     int sockflags = 0;
@@ -1763,6 +1771,11 @@ int BIO_dgram_sctp_wait_for_dry(BIO *b)
 }
 
 int BIO_dgram_sctp_msg_waiting(BIO *b)
+{
+    return (int)BIO_ctrl(b, BIO_CTRL_DGRAM_SCTP_MSG_WAITING, 0, NULL);
+}
+
+static int dgram_sctp_msg_waiting(BIO *b)
 {
     int n, sockflags;
     union sctp_notification snp;

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -151,6 +151,9 @@ extern "C" {
 # define BIO_CTRL_GET_KTLS_SEND                 73
 # define BIO_CTRL_GET_KTLS_RECV                 76
 
+# define BIO_CTRL_DGRAM_SCTP_WAIT_FOR_DRY       77
+# define BIO_CTRL_DGRAM_SCTP_MSG_WAITING        78
+
 # ifndef OPENSSL_NO_KTLS
 #  define BIO_get_ktls_send(b)         \
      (BIO_method_type(b) == BIO_TYPE_SOCKET \
@@ -282,6 +285,9 @@ DEFINE_STACK_OF(BIO)
 typedef int asn1_ps_func (BIO *b, unsigned char **pbuf, int *plen,
                           void *parg);
 
+typedef void (*BIO_dgram_sctp_notification_handler_fn) (BIO *b,
+                                                        void *context,
+                                                        void *buf);
 # ifndef OPENSSL_NO_SCTP
 /* SCTP parameter structs */
 struct bio_dgram_sctp_sndinfo {
@@ -632,10 +638,8 @@ const BIO_METHOD *BIO_s_datagram_sctp(void);
 BIO *BIO_new_dgram_sctp(int fd, int close_flag);
 int BIO_dgram_is_sctp(BIO *bio);
 int BIO_dgram_sctp_notification_cb(BIO *b,
-                                   void (*handle_notifications) (BIO *bio,
-                                                                 void *context,
-                                                                 void *buf),
-                                   void *context);
+                BIO_dgram_sctp_notification_handler_fn handle_notifications,
+                void *context);
 int BIO_dgram_sctp_wait_for_dry(BIO *b);
 int BIO_dgram_sctp_msg_waiting(BIO *b);
 #  endif


### PR DESCRIPTION
The `ptr` member of `BIO` should be dereferenced only on functions of `BIO_METHOD`. But in DGRAM SCTP it is accessed outside. That means members of `bio_dgram_sctp_data` are accessed other than `BIO_METHOD` functions like `BIO_dgram_sctp_notification_cb`, `BIO_dgram_sctp_wait_for_dry` and `BIO_dgram_sctp_msg_waiting`. I feel this should be avoided.

So added new control command to set the members (`handle_notifications` and `notification_context`) required to access outside `BIO_METHOD` functions. And also made `BIO_dgram_sctp_wait_for_dry()` and `BIO_dgram_sctp_msg_waiting()` as part of control function.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
