### PR TITLE
Implement deterministic ECDSA sign (RFC6979)

### DIFF
--- a/crypto/bn/bn_dsa.c
+++ b/crypto/bn/bn_dsa.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <openssl/opensslconf.h>
+#ifdef FIPS_MODE
+NON_EMPTY_TRANSLATION_UNIT
+#else
+# include <stdio.h>
+# include <string.h>
+# include <openssl/evp.h>
+# include <openssl/rand_drbg.h>
+# include "internal/cryptlib.h"
+# include "crypto/bn.h"
+# include "internal/thread_once.h"
+# include "../rand/rand_local.h"
+
+typedef struct rfc6979_seed_st {
+    const unsigned char *x;
+    const unsigned char *h;
+    size_t rlen;
+} RFC6979_SEED;
+
+static size_t rfc6979_get_entropy(RAND_DRBG *drbg, unsigned char **pout,
+                          int entropy, size_t min_len, size_t max_len,
+                          int prediction_resistance)
+{
+    RFC6979_SEED *rfc6979_seed = RAND_DRBG_get_callback_data(drbg);
+
+    *pout = (unsigned char *)rfc6979_seed->x;
+    return rfc6979_seed->rlen;
+}
+
+static size_t rfc6979_get_nonce(RAND_DRBG *drbg, unsigned char **pout,
+                        int entropy, size_t min_len, size_t max_len)
+{
+    RFC6979_SEED *rfc6979_seed = RAND_DRBG_get_callback_data(drbg);
+
+    *pout = (unsigned char *)rfc6979_seed->h;
+    return rfc6979_seed->rlen;
+}
+
+/*
+ * RFC 6979 2.3.2.  Bit String to Integer
+ */
+static int bits2int(BIGNUM *out, int qlen,
+    const unsigned char *message, size_t message_len)
+{
+    if (BN_bin2bn(message, (int)message_len, out) == NULL)
+        return 0;
+    if ((int)message_len * 8 > qlen)
+        return BN_rshift(out, out, (int)message_len * 8 - qlen);
+    return 1;
+}
+
+/*
+ * RFC 6979 2.3.3.  Integer to Octet String
+ */
+static int int2octets(unsigned char *out, const BIGNUM *num, int rlen)
+{
+    return BN_bn2binpad(num, out, rlen);
+}
+
+/*
+ * RFC 6979 2.3.4.  Bit String to Octet String
+ */
+static int bits2octets(unsigned char *out, const BIGNUM *range,
+    const unsigned char *message, size_t message_len, BN_CTX *ctx)
+{
+    int ret = 1;
+    BIGNUM *num = BN_new();
+
+    if (!bits2int(num, BN_num_bits(range), message, message_len)
+        || !BN_mod(num, num, range, ctx)
+        || !BN_bn2binpad(num, out, BN_num_bytes(range)))
+    {
+        ret = 0;
+    }
+
+    BN_free(num);
+    return ret;
+}
+
+int bn_generate_dsa_deterministic_nonce(BIGNUM *out, const BIGNUM *range,
+    const BIGNUM *priv, const unsigned char *message,
+    size_t message_len, int hash_type, BN_CTX *ctx)
+{
+    int ret = 0, rlen = 0, qlen = 0;
+    RAND_DRBG *drbg = NULL;
+    RFC6979_SEED rfc6979_seed = { NULL, NULL, 0 };
+    unsigned int drbg_flags = RAND_DRBG_FLAG_HMAC;
+    unsigned char *x = NULL, *h = NULL, *T = NULL;
+
+    if ((qlen = BN_num_bits(range)) == 0
+        || (rlen = BN_num_bytes(range)) == 0)
+        goto end;
+
+    if ((x = (unsigned char *)OPENSSL_malloc(rlen)) == NULL
+        || (h = (unsigned char *)OPENSSL_malloc(rlen)) == NULL
+        || (T = (unsigned char *)OPENSSL_malloc(rlen)) == NULL)
+        goto end;
+
+    if (!int2octets(x, priv, rlen)
+        || !bits2octets(h, range, message, message_len, ctx))
+        goto end;
+
+    rfc6979_seed.x = x;
+    rfc6979_seed.h = h;
+    rfc6979_seed.rlen = rlen;
+
+    if ((drbg = RAND_DRBG_new(hash_type, drbg_flags, NULL)) == NULL
+        || !RAND_DRBG_set_callbacks(drbg, rfc6979_get_entropy, NULL, rfc6979_get_nonce, NULL)
+        || !RAND_DRBG_set_callback_data(drbg, &rfc6979_seed))
+        goto end;
+
+    /* TODO(3.0): Rewrite the following two lines and include "../rand/rand_lcl.h" if drbg min_lengths can be set using methods */
+    drbg->min_entropylen = rlen;
+    drbg->min_noncelen = rlen;
+
+    if (!RAND_DRBG_instantiate(drbg, NULL, 0))
+        goto end;
+
+    while (1)
+    {
+        if (!RAND_DRBG_generate(drbg, T, rlen, 0, NULL, 0)
+            || !bits2int(out, qlen, T, rlen))
+            goto end;
+        if ((!BN_is_zero(out)) && (!BN_is_one(out)) && (BN_cmp(out, range) < 0))
+            break;
+    }
+    ret = 1;
+
+end:
+    RAND_DRBG_uninstantiate(drbg);
+    RAND_DRBG_free(drbg);
+    OPENSSL_clear_free(x, rlen);
+    OPENSSL_free(h);
+    OPENSSL_clear_free(T, rlen);
+    return ret;
+}
+#endif

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -107,7 +107,7 @@ ELSE
   $BNDH=
 ENDIF
 
-$COMMON=bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_mul.c \
+$COMMON=bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_dsa.c bn_mul.c \
         bn_mod.c bn_conv.c bn_rand.c bn_shift.c bn_word.c bn_blind.c \
         bn_kron.c bn_sqrt.c bn_gcd.c bn_prime.c bn_sqr.c \
         bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c \

--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -668,7 +668,8 @@ struct ECDSA_SIG_st {
     BIGNUM *r;
     BIGNUM *s;
 };
-
+int ossl_ecdsa_deterministic_sign(int type, const unsigned char *dgst, int dlen,
+                    unsigned char *sig, unsigned int *siglen, EC_KEY *eckey);
 int ossl_ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in, BIGNUM **kinvp,
                           BIGNUM **rp);
 int ossl_ecdsa_sign(int type, const unsigned char *dgst, int dlen,

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -202,6 +202,7 @@ BN_F_BN_DIV_RECP:130:BN_div_recp
 BN_F_BN_EXP:123:BN_exp
 BN_F_BN_EXPAND_INTERNAL:120:bn_expand_internal
 BN_F_BN_GENCB_NEW:143:BN_GENCB_new
+BN_F_BN_GENERATE_DSA_DETERMINISTIC_NONCE:152:bn_generate_dsa_deterministic_nonce
 BN_F_BN_GENERATE_DSA_NONCE:140:BN_generate_dsa_nonce
 BN_F_BN_GENERATE_PRIME_EX:141:BN_generate_prime_ex
 BN_F_BN_GENERATE_PRIME_EX2:152:BN_generate_prime_ex2

--- a/doc/man3/ECDSA_SIG_new.pod
+++ b/doc/man3/ECDSA_SIG_new.pod
@@ -81,9 +81,11 @@ size use L<EVP_PKEY_sign(3)> with a NULL B<sig> parameter.
 ECDSA_sign() computes a digital signature of the B<dgstlen> bytes hash value
 B<dgst> using the private EC key B<eckey>. The DER encoded signatures is
 stored in B<sig> and its length is returned in B<sig_len>. Note: B<sig> must
-point to ECDSA_size(eckey) bytes of memory. The parameter B<type> is currently
-ignored. ECDSA_sign() is wrapper function for ECDSA_sign_ex() with B<kinv>
-and B<rp> set to NULL.
+point to ECDSA_size(eckey) bytes of memory. If the parameter B<type> is of
+non-positive value, it will be ignored and the signature's K (nonce) will be
+produced randomly, which is the default action. If the parameter B<type> is
+of positive value, it will be considered as the HashType (hash nid) for RFC6979
+deterministic signature generation.
 
 ECDSA_do_sign() is similar to ECDSA_sign() except the signature is returned
 as a newly allocated B<ECDSA_SIG> structure (or NULL on error). ECDSA_do_sign()
@@ -111,7 +113,10 @@ ECDSA_sign_ex() computes a digital signature of the B<dgstlen> bytes hash value
 B<dgst> using the private EC key B<eckey> and the optional pre-computed values
 B<kinv> and B<rp>. The DER encoded signature is stored in B<sig> and its
 length is returned in B<sig_len>. Note: B<sig> must point to ECDSA_size(eckey)
-bytes of memory. The parameter B<type> is ignored.
+bytes of memory. If the parameter B<type> is of non-positive value, it will be
+ignored and the signature's K (nonce) will be produced randomly, which is the
+default action. If the parameter B<type> is of positive value, it will be considered
+as the HashType (hash nid) for RFC6979 deterministic signature generation.
 
 ECDSA_do_sign_ex() is similar to ECDSA_sign_ex() except the signature is
 returned as a newly allocated B<ECDSA_SIG> structure (or NULL on error).

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -67,6 +67,8 @@ EVP_PKEY_CTX_set_ecdh_kdf_outlen,
 EVP_PKEY_CTX_get_ecdh_kdf_outlen,
 EVP_PKEY_CTX_set0_ecdh_kdf_ukm,
 EVP_PKEY_CTX_get0_ecdh_kdf_ukm,
+EVP_PKEY_CTX_set_ecdsa_nonce_type,
+EVP_PKEY_CTX_get_ecdsa_nonce_type,
 EVP_PKEY_CTX_set1_id, EVP_PKEY_CTX_get1_id, EVP_PKEY_CTX_get1_id_len
 - algorithm specific control operations
 
@@ -169,6 +171,8 @@ EVP_PKEY_CTX_set1_id, EVP_PKEY_CTX_get1_id, EVP_PKEY_CTX_get1_id_len
  int EVP_PKEY_CTX_get_ecdh_kdf_outlen(EVP_PKEY_CTX *ctx, int *len);
  int EVP_PKEY_CTX_set0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int len);
  int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
+ int EVP_PKEY_CTX_set_ecdsa_nonce_type(EVP_PKEY_CTX *ctx, int nonce);
+ int EVP_PKEY_CTX_get_ecdsa_nonce_type(EVP_PKEY_CTX *ctx);
 
  int EVP_PKEY_CTX_set1_id(EVP_PKEY_CTX *ctx, void *id, size_t id_len);
  int EVP_PKEY_CTX_get1_id(EVP_PKEY_CTX *ctx, void *id);
@@ -597,6 +601,17 @@ so the caller should not free the original memory pointed to by I<ukm>.
 The EVP_PKEY_CTX_get0_ecdh_kdf_ukm() macro gets the user key material for I<ctx>.
 The return value is the user key material length. The resulting pointer is owned
 by the library and should not be freed by the caller.
+
+=head2 ECDSA K (nonce) type parameters
+
+The EVP_PKEY_CTX_set_ecdsa_nonce_type() macro sets the ECDSA K (nonce) type to
+B<nonce_type> for ECDSA signing. Possible values are B<EVP_PKEY_ECDSA_NONCE_RANDOM>
+and B<EVP_PKEY_ECDSA_NONCE_DETERMINISTIC> which uses the DSA nonce generation process
+specified in RFC6979.
+
+The EVP_PKEY_CTX_get_ecdsa_nonce_type() macro returns the ECDSA K (nonce) type
+for B<ctx> used for ECDSA signing. Possible values are B<EVP_PKEY_ECDSA_NONCE_RANDOM>
+and B<EVP_PKEY_ECDSA_NONCE_DETERMINISTIC>.
 
 =head2 Other parameters
 

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -110,6 +110,10 @@ int bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
                                   const BIGNUM *r1, const BIGNUM *r2, int nlen,
                                   const BIGNUM *e, BN_CTX *ctx, BN_GENCB *cb);
 
+int bn_generate_dsa_deterministic_nonce(BIGNUM *out, const BIGNUM *range,
+                                        const BIGNUM *priv, const unsigned char *message,
+                                        size_t message_len, int hash_type, BN_CTX *ctx);
+
 OPENSSL_CTX *bn_get_lib_ctx(BN_CTX *ctx);
 
 extern const BIGNUM bn_inv_sqrt_2;

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1492,6 +1492,16 @@ int EVP_PKEY_CTX_set0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm,
                                    int len);
 int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 
+# define EVP_PKEY_CTX_set_ecdsa_nonce_type(ctx, nonce) \
+        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
+                                EVP_PKEY_OP_SIGN, \
+                                EVP_PKEY_CTRL_EC_NONCE_TYPE, nonce, NULL)
+
+# define EVP_PKEY_CTX_get_ecdsa_nonce_type(ctx) \
+        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
+                                EVP_PKEY_OP_SIGN, \
+                                EVP_PKEY_CTRL_EC_NONCE_TYPE, -2, NULL)
+
 /* SM2 will skip the operation check so no need to pass operation here */
 #  define EVP_PKEY_CTX_set1_id(ctx, id, id_len) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
@@ -1518,6 +1528,7 @@ int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 #  define EVP_PKEY_CTRL_SET1_ID                       15
 #  define EVP_PKEY_CTRL_GET1_ID                       16
 #  define EVP_PKEY_CTRL_GET1_ID_LEN                   17
+#  define EVP_PKEY_CTRL_EC_NONCE_TYPE                 (EVP_PKEY_ALG_CTRL + 14)
 
 /* KDF types */
 #  define EVP_PKEY_ECDH_KDF_NONE                      1
@@ -1528,6 +1539,10 @@ int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
  *  This identifier is retained for backwards compatibility
  */
 #  define EVP_PKEY_ECDH_KDF_X9_62   EVP_PKEY_ECDH_KDF_X9_63
+
+/* ECDSA K (nonce) types */
+#  define EVP_PKEY_ECDSA_NONCE_RANDOM                 1
+#  define EVP_PKEY_ECDSA_NONCE_DETERMINISTIC          2
 
 #  ifdef  __cplusplus
 }

--- a/util/other.syms
+++ b/util/other.syms
@@ -250,6 +250,7 @@ EVP_PKEY_CTX_get_ecdh_cofactor_mode     define
 EVP_PKEY_CTX_get_ecdh_kdf_md            define
 EVP_PKEY_CTX_get_ecdh_kdf_outlen        define
 EVP_PKEY_CTX_get_ecdh_kdf_type          define
+EVP_PKEY_CTX_get_ecdsa_nonce_type       define
 EVP_PKEY_CTX_get_rsa_mgf1_md            define
 EVP_PKEY_CTX_get_rsa_oaep_md            define
 EVP_PKEY_CTX_get_rsa_padding            define
@@ -285,6 +286,7 @@ EVP_PKEY_CTX_set_ecdh_cofactor_mode     define
 EVP_PKEY_CTX_set_ecdh_kdf_md            define
 EVP_PKEY_CTX_set_ecdh_kdf_outlen        define
 EVP_PKEY_CTX_set_ecdh_kdf_type          define
+EVP_PKEY_CTX_set_ecdsa_nonce_type       define
 EVP_PKEY_CTX_set_hkdf_md                define
 EVP_PKEY_CTX_set_mac_key                define
 EVP_PKEY_CTX_set_rsa_keygen_bits        define


### PR DESCRIPTION
Implements RFC6979 deterministic ECDSA/DSA sign (in this commit, only ECDSA is available)

ECDSA deterministic sign is now available by specifying "ecdsa_nonce_type:deterministic" when signing.
for example:
```
openssl dgst -sha1  -sign private.key -sigopt ecdsa_nonce_type:deterministic < test.data > test.sha1
```
Maybe fixed https://github.com/openssl/openssl/issues/2078

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated 

I haven't thought of that there would be so many comments in this PR. 
I read through this thread and list the up-to-date TO-DOs here:
- [x] [Add Test Vectors](https://github.com/openssl/openssl/pull/9223#pullrequestreview-256825551)  (Finished [here](https://github.com/bbbrumley/openssl/commit/921c0371c055f5246c9b5072d3d06ac725e69be7) but not pushed in this PR)
- [ ] [Prevent the use of rand_local.h](https://github.com/openssl/openssl/pull/9223#discussion_r300494249)
- [ ] [Modify CHANGES](https://github.com/openssl/openssl/pull/9223#issuecomment-507662154)
- [x] [Move the code into EVP](https://github.com/openssl/openssl/pull/9223#discussion_r300506501)
- [ ] [Rename ctrls](https://github.com/openssl/openssl/pull/9223#issuecomment-508404139)
- [x] [Prevent the use of RUN_ONCE](https://github.com/openssl/openssl/pull/9223#discussion_r300306010) (Fixed in [5cf5342](https://github.com/openssl/openssl/pull/9223/commits/5cf5342c116d643bc810ded630d1848a40439bd7))