### PR TITLE
Document EVP_CIPHER_fetch and EVP_CIPHER_up_ref

### DIFF
--- a/crypto/evp/cmeth_lib.c
+++ b/crypto/evp/cmeth_lib.c
@@ -60,7 +60,7 @@ void EVP_CIPHER_meth_free(EVP_CIPHER *cipher)
     }
 }
 
-int EVP_CIPHER_upref(EVP_CIPHER *cipher)
+int EVP_CIPHER_up_ref(EVP_CIPHER *cipher)
 {
     int ref = 0;
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -422,7 +422,7 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
     out->provctx = NULL;
 
     if (in->fetched_digest != NULL)
-        EVP_MD_upref(in->fetched_digest);
+        EVP_MD_up_ref(in->fetched_digest);
 
     out->provctx = in->digest->dupctx(in->provctx);
     if (out->provctx == NULL) {
@@ -665,9 +665,9 @@ static void *evp_md_from_dispatch(const OSSL_DISPATCH *fns,
     return md;
 }
 
-static int evp_md_upref(void *md)
+static int evp_md_up_ref(void *md)
 {
-    return EVP_MD_upref(md);
+    return EVP_MD_up_ref(md);
 }
 
 static void evp_md_free(void *md)
@@ -680,7 +680,7 @@ EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
 {
     EVP_MD *md =
         evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
-                          evp_md_from_dispatch, evp_md_upref,
+                          evp_md_from_dispatch, evp_md_up_ref,
                           evp_md_free);
 
 #ifndef FIPS_MODE

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1016,7 +1016,7 @@ int EVP_CIPHER_CTX_copy(EVP_CIPHER_CTX *out, const EVP_CIPHER_CTX *in)
     *out = *in;
     out->provctx = NULL;
 
-    if (in->fetched_cipher != NULL && !EVP_CIPHER_upref(in->fetched_cipher)) {
+    if (in->fetched_cipher != NULL && !EVP_CIPHER_up_ref(in->fetched_cipher)) {
         out->fetched_cipher = NULL;
         return 0;
     }
@@ -1179,9 +1179,9 @@ static void *evp_cipher_from_dispatch(const OSSL_DISPATCH *fns,
     return cipher;
 }
 
-static int evp_cipher_upref(void *cipher)
+static int evp_cipher_up_ref(void *cipher)
 {
-    return EVP_CIPHER_upref(cipher);
+    return EVP_CIPHER_up_ref(cipher);
 }
 
 static void evp_cipher_free(void *cipher)
@@ -1194,7 +1194,7 @@ EVP_CIPHER *EVP_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
 {
     EVP_CIPHER *cipher =
         evp_generic_fetch(ctx, OSSL_OP_CIPHER, algorithm, properties,
-                          evp_cipher_from_dispatch, evp_cipher_upref,
+                          evp_cipher_from_dispatch, evp_cipher_up_ref,
                           evp_cipher_free);
 
 #ifndef FIPS_MODE

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -469,7 +469,7 @@ EVP_MD *EVP_MD_meth_dup(const EVP_MD *md)
     return to;
 }
 
-int EVP_MD_upref(EVP_MD *md)
+int EVP_MD_up_ref(EVP_MD *md)
 {
     int ref = 0;
 

--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -10,7 +10,8 @@ EVP_CIPHER_meth_set_set_asn1_params, EVP_CIPHER_meth_set_get_asn1_params,
 EVP_CIPHER_meth_set_ctrl, EVP_CIPHER_meth_get_init,
 EVP_CIPHER_meth_get_do_cipher, EVP_CIPHER_meth_get_cleanup,
 EVP_CIPHER_meth_get_set_asn1_params, EVP_CIPHER_meth_get_get_asn1_params,
-EVP_CIPHER_meth_get_ctrl - Routines to build up EVP_CIPHER methods
+EVP_CIPHER_meth_get_ctrl, EVP_CIPHER_up_ref
+- Routines to build up EVP_CIPHER methods
 
 =head1 SYNOPSIS
 
@@ -61,6 +62,8 @@ EVP_CIPHER_meth_get_ctrl - Routines to build up EVP_CIPHER methods
  int (*EVP_CIPHER_meth_get_ctrl(const EVP_CIPHER *cipher))(EVP_CIPHER_CTX *,
                                                            int type, int arg,
                                                            void *ptr);
+
+ int EVP_CIPHER_up_ref(EVP_CIPHER *cipher);
 
 =head1 DESCRIPTION
 
@@ -223,6 +226,8 @@ EVP_CIPHER_meth_get_get_asn1_params() and EVP_CIPHER_meth_get_ctrl()
 are all used to retrieve the method data given with the
 EVP_CIPHER_meth_set_*() functions above.
 
+EVP_CIPHER_up_ref() increments the reference count for an EVP_CIPHER structure.
+
 =head1 RETURN VALUES
 
 EVP_CIPHER_meth_new() and EVP_CIPHER_meth_dup() return a pointer to a
@@ -230,6 +235,8 @@ newly created B<EVP_CIPHER>, or NULL on failure.
 All EVP_CIPHER_meth_set_*() functions return 1.
 All EVP_CIPHER_meth_get_*() functions return pointers to their
 respective B<cipher> function.
+
+EVP_CIPHER_up_ref() returns 1 for success or 0 otherwise.
 
 =head1 SEE ALSO
 

--- a/doc/man3/EVP_MD_fetch.pod
+++ b/doc/man3/EVP_MD_fetch.pod
@@ -17,16 +17,33 @@ EVP_MD_fetch, EVP_CIPHER_fetch
 =head1 DESCRIPTION
 
 Cryptographic algorithms are represented by different OpenSSL objects depending
-on what type of algorithm it is.
+on what type of algorithm it is. The following cryptographic algorithm types are
+supported.
 
-The B<EVP_MD> object is used for representing a digest algorithm.
+=over 4
 
-B<EVP_CIPHER> objects are used to represent symmetric cipher algorithms.
+=item B<EVP_MD>
+
+Represents a digest algorithm.
+
+=item B<EVP_CIPHER>
+
+Represents a symmetric cipher algorithm.
+
+=item B<EVP_MAC>
+
+Represents a Message Authentication Code algorithm.
+
+=item B<EVP_KDF>
+
+Represents a Key Derivation Function algorithm.
+
+=back
 
 The algorithm objects may or may not have an associated algorithm
 implementation.
-Algorithms are implemented by providers and any one algorithm could have an
-implementation available from more than one provider.
+Cryptographic algorithms are implemented by providers.
+Any algorithm may be supported by zero or more providers.
 In order to use an algorithm an implementation must first be obtained.
 This can happen in one of three ways, i.e. implicit fetch, explicit fetch or
 user defined.
@@ -41,15 +58,15 @@ no associated implementation.
 When used in a function like L<EVP_DigestInit_ex(3)> or L<EVP_CipherInit_ex(3)>
 the actual implementation to be used will be fetched implicitly using default
 search criteria.
-Typically, (unless the default search criteria have been changed and/or
-different providers have been loaded), this will return an implementation of the
-appropriate algorithm from the default provider.
+Typically, this will return an implementation of the appropriate algorithm from
+the default provider unless the default search criteria have been changed and/or
+different providers have been loaded.
 
 =item Explicit Fetch
 
 With explicit fetch an application uses one of the "fetch" functions to obtain
 an algorithm object with an associated implementation.
-An implementation with the given name and satisfying the search criteria
+An implementation with the given name that satisfies the search criteria
 specified in the B<properties> parameter combined with the default search
 criteria will be looked for within the available providers and returned.
 See L<EVP_set_default_properties(3)> for information on default search criteria
@@ -63,8 +80,8 @@ See L<EVP_MD_meth_new(3)> and L<EVP_CIPHER_meth_new(3)> for details.
 
 =back
 
-Having obtained an algorithm implementation as an algorithm object it can be
-used to perform cryptographic operations.
+Having obtained an algorithm implementation as an algorithm object it can then
+be used to perform cryptographic operations.
 For example to calculate the digest of input data with an B<EVP_MD> algorithm
 object you can use functions such as L<EVP_DigestInit_ex(3)>,
 L<EVP_DigestUpdate(3)> and L<EVP_DigestFinal_ex(3)>.
@@ -79,7 +96,7 @@ The B<algorithm> parameter gives the name of the algorithm to be looked up.
 Different algorithms can be made available by loading different providers.
 
 The built-in default provider digest algorithm implementation names are: SHA1,
-SHA224, SHA256, SHA384, SHA512, SHA512-224, SHA512-256,SHA3-224, SHA3-256,
+SHA224, SHA256, SHA384, SHA512, SHA512-224, SHA512-256, SHA3-224, SHA3-256,
 SHA3-384, SHA3-512, SHAKE128, SHAKE256, SM3, BLAKE2b512, BLAKE2s256 and
 MD5-SHA1.
 
@@ -87,7 +104,8 @@ The built-in default provider cipher algorithm implementation names are:
 AES-256-ECB, AES-192-ECB, AES-128-ECB, AES-256-CBC, AES-192-CBC, AES-128-CBC,
 AES-256-OFB, AES-192-OFB, AES-128-OFB, AES-256-CFB, AES-192-CFB, AES-128-CFB,
 AES-256-CFB1, AES-192-CFB1, AES-128-CFB1, AES-256-CFB8, AES-192-CFB8,
-AES-128-CFB8, AES-256-CTR, AES-192-CTR and AES-128-CTR.
+AES-128-CFB8, AES-256-CTR, AES-192-CTR, AES-128-CTR, id-aes256-GCM,
+id-aes192-GCM and id-aes128-GCM.
 
 Additional algorithm implementations may be obtained by loading the "legacy"
 provider.
@@ -140,10 +158,14 @@ an EVP_MD object, or NULL on error.
 Fetch any available implementation of SHA256 in the default context:
 
  EVP_MD *md = EVP_MD_fetch(NULL, "SHA256", NULL);
+ ...
+ EVP_MD_meth_free(md);
 
 Fetch any available implementation of AES-128-CBC in the default context:
 
  EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-128-CBC", NULL);
+ ...
+ EVP_CIPHER_meth_free(cipher);
 
 Fetch an implementation of SHA256 from the default provider in the default
 context:

--- a/doc/man3/EVP_MD_fetch.pod
+++ b/doc/man3/EVP_MD_fetch.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-EVP_MD_fetch
+EVP_MD_fetch, EVP_CIPHER_fetch
 - Functions to explicitly fetch algorithm implementations
 
 =head1 SYNOPSIS
@@ -11,60 +11,88 @@ EVP_MD_fetch
 
  EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                       const char *properties);
+ EVP_CIPHER *EVP_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+                              const char *properties);
 
 =head1 DESCRIPTION
 
-The B<EVP_MD> object is used for representing a digest method implementation.
+Cryptographic algorithms are represented by different OpenSSL objects depending
+on what type of algorithm it is.
 
-Having obtained a digest implementation as an B<EVP_MD> type it can be used to
-calculate the digest of input data using functions such as
-L<EVP_DigestInit_ex(3)>, L<EVP_DigestUpdate(3)> and L<EVP_DigestFinal_ex(3)>.
+The B<EVP_MD> object is used for representing a digest algorithm.
 
-Digest implementations may be obtained in one of three ways, i.e. implicit
-fetch, explicit fetch or user defined.
+B<EVP_CIPHER> objects are used to represent symmetric cipher algorithms.
+
+The algorithm objects may or may not have an associated algorithm
+implementation.
+Algorithms are implemented by providers and any one algorithm could have an
+implementation available from more than one provider.
+In order to use an algorithm an implementation must first be obtained.
+This can happen in one of three ways, i.e. implicit fetch, explicit fetch or
+user defined.
 
 =over 4
 
 =item Implicit Fetch
 
 With implicit fetch an application can use functions such as L<EVP_sha256(3)>,
-L<EVP_sha512(3)> or L<EVP_blake2b512(3)> to obtain an B<EVP_MD> object. When
-used in a function like L<EVP_DigestInit_ex(3)> the actual implementation to
-be used will be fetched implicitly using default search criteria. Typically,
-(unless the default search criteria have been changed and/or different providers
-have been loaded), this will return an implementation of the appropriate
-algorithm from the default provider.
+L<EVP_blake2b512(3)> or L<EVP_aes_128_cbc(3)> to obtain an algorithm object with
+no associated implementation.
+When used in a function like L<EVP_DigestInit_ex(3)> or L<EVP_CipherInit_ex(3)>
+the actual implementation to be used will be fetched implicitly using default
+search criteria.
+Typically, (unless the default search criteria have been changed and/or
+different providers have been loaded), this will return an implementation of the
+appropriate algorithm from the default provider.
 
 =item Explicit Fetch
 
-With explicit fetch an application uses the EVP_MD_fetch() function to obtain
-an algorithm implementation. An implementation with the given name and
-satisfying the search criteria specified in the B<properties> parameter
-combined with the default search criteria will be looked for within the
-available providers and returned.
+With explicit fetch an application uses one of the "fetch" functions to obtain
+an algorithm object with an associated implementation.
+An implementation with the given name and satisfying the search criteria
+specified in the B<properties> parameter combined with the default search
+criteria will be looked for within the available providers and returned.
 See L<EVP_set_default_properties(3)> for information on default search criteria
 and L<OSSL_PROVIDER(3)> for information about providers.
 
 =item User defined
 
-Using the user defined approach an application constructs its own EVP_MD object.
-See L<EVP_MD_meth_new(3)> for details.
+Using the user defined approach an application constructs its own algorithm
+object.
+See L<EVP_MD_meth_new(3)> and L<EVP_CIPHER_meth_new(3)> for details.
 
 =back
 
-The EVP_MD_fetch() function will look for an algorithm within the providers that
-have been loaded into the B<OPENSSL_CTX> given in the B<ctx> parameter. This
-parameter may be NULL in which case the default B<OPENSSL_CTX> will be used. See
-L<OPENSSL_CTX_new(3)> and L<OSSL_PROVIDER_load(3)> for further details.
+Having obtained an algorithm implementation as an algorithm object it can be
+used to perform cryptographic operations.
+For example to calculate the digest of input data with an B<EVP_MD> algorithm
+object you can use functions such as L<EVP_DigestInit_ex(3)>,
+L<EVP_DigestUpdate(3)> and L<EVP_DigestFinal_ex(3)>.
+
+The fetch functions will look for an algorithm within the providers that
+have been loaded into the B<OPENSSL_CTX> given in the B<ctx> parameter.
+This parameter may be NULL in which case the default B<OPENSSL_CTX> will be
+used.
+See L<OPENSSL_CTX_new(3)> and L<OSSL_PROVIDER_load(3)> for further details.
 
 The B<algorithm> parameter gives the name of the algorithm to be looked up.
-Different algorithms can be made available by loading different providers. The
-built-in default provider algorithm implementation names are: SHA1, SHA224,
-SHA256, SHA384, SHA512, SHA512-224, SHA512-256,SHA3-224, SHA3-256, SHA3-384,
-SHA3-512, SHAKE128, SHAKE256, SM3, BLAKE2b512, BLAKE2s256 and MD5-SHA1.
+Different algorithms can be made available by loading different providers.
+
+The built-in default provider digest algorithm implementation names are: SHA1,
+SHA224, SHA256, SHA384, SHA512, SHA512-224, SHA512-256,SHA3-224, SHA3-256,
+SHA3-384, SHA3-512, SHAKE128, SHAKE256, SM3, BLAKE2b512, BLAKE2s256 and
+MD5-SHA1.
+
+The built-in default provider cipher algorithm implementation names are:
+AES-256-ECB, AES-192-ECB, AES-128-ECB, AES-256-CBC, AES-192-CBC, AES-128-CBC,
+AES-256-OFB, AES-192-OFB, AES-128-OFB, AES-256-CFB, AES-192-CFB, AES-128-CFB,
+AES-256-CFB1, AES-192-CFB1, AES-128-CFB1, AES-256-CFB8, AES-192-CFB8,
+AES-128-CFB8, AES-256-CTR, AES-192-CTR and AES-128-CTR.
 
 Additional algorithm implementations may be obtained by loading the "legacy"
-provider. The names of these algorithms are: RIPEMD160, MD2, MD4, MD5, MDC2 and
+provider.
+
+The legacy provider digest algorithms are: RIPEMD160, MD2, MD4, MD5, MDC2 and
 whirlpool.
 
 The B<properties> parameter specifies the search criteria that will be used to
@@ -82,8 +110,13 @@ NULL in which case any implementation from the available providers with the
 given algorithm name will be returned.
 
 The return value from a call to EVP_MD_fetch() must be freed by the caller using
-L<EVP_MD_meth_free(3)>. Note that EVP_MD objects are reference counted. See
-L<EVP_MD_upref(3)>.
+L<EVP_MD_meth_free(3)>.
+Note that EVP_MD objects are reference counted. See L<EVP_MD_up_ref(3)>.
+
+The return value from a call to EVP_CIPHER_fetch() must be freed by the caller
+using L<EVP_CIPHER_meth_free(3)>.
+Note that EVP_CIPHER objects are reference counted.
+See L<EVP_CIPHER_up_ref(3)>.
 
 =head1 NOTES
 
@@ -107,6 +140,10 @@ an EVP_MD object, or NULL on error.
 Fetch any available implementation of SHA256 in the default context:
 
  EVP_MD *md = EVP_MD_fetch(NULL, "SHA256", NULL);
+
+Fetch any available implementation of AES-128-CBC in the default context:
+
+ EVP_CIPHER *cipher = EVP_CIPHER_fetch(NULL, "AES-128-CBC", NULL);
 
 Fetch an implementation of SHA256 from the default provider in the default
 context:
@@ -157,9 +194,10 @@ other providers:
 
 =head1 SEE ALSO
 
-L<EVP_DigestInit(3)>, L<EVP_MD_meth_new(3)>, L<EVP_MD_meth_free(3)>,
-L<EVP_MD_upref(3)>, L<OSSL_PROVIDER_load(3)>, L<OPENSSL_CTX(3)>,
-L<EVP_set_default_properties(3)>
+L<EVP_DigestInit_ex(3)>, L<EVP_EncryptInit_ex(3)>, L<EVP_MD_meth_new(3)>,
+L<EVP_MD_meth_free(3)>, L<EVP_CIPHER_meth_new(3)>, L<EVP_CIPHER_meth_free(3)>,
+L<EVP_MD_up_ref(3)>, L<EVP_CIPHER_up_ref(3)>, L<OSSL_PROVIDER_load(3)>,
+L<OPENSSL_CTX(3)>, L<EVP_set_default_properties(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/EVP_MD_meth_new.pod
+++ b/doc/man3/EVP_MD_meth_new.pod
@@ -11,7 +11,7 @@ EVP_MD_meth_set_ctrl, EVP_MD_meth_get_input_blocksize,
 EVP_MD_meth_get_result_size, EVP_MD_meth_get_app_datasize,
 EVP_MD_meth_get_flags, EVP_MD_meth_get_init, EVP_MD_meth_get_update,
 EVP_MD_meth_get_final, EVP_MD_meth_get_copy, EVP_MD_meth_get_cleanup,
-EVP_MD_meth_get_ctrl, EVP_MD_upref
+EVP_MD_meth_get_ctrl, EVP_MD_up_ref
 - Routines to build up EVP_MD methods
 
 =head1 SYNOPSIS
@@ -54,7 +54,7 @@ EVP_MD_meth_get_ctrl, EVP_MD_upref
  int (*EVP_MD_meth_get_ctrl(const EVP_MD *md))(EVP_MD_CTX *ctx, int cmd,
                                                int p1, void *p2);
 
- int EVP_MD_upref(EVP_MD *md);
+ int EVP_MD_up_ref(EVP_MD *md);
 
 =head1 DESCRIPTION
 
@@ -162,7 +162,7 @@ EVP_MD_meth_get_cleanup() and EVP_MD_meth_get_ctrl() are all used
 to retrieve the method data given with the EVP_MD_meth_set_*()
 functions above.
 
-EVP_MD_upref() increments the reference count for an EVP_MD structure.
+EVP_MD_up_ref() increments the reference count for an EVP_MD structure.
 
 =head1 RETURN VALUES
 
@@ -175,7 +175,7 @@ indicated sizes or flags.
 All other EVP_CIPHER_meth_get_*() functions return pointers to their
 respective B<md> function.
 
-EVP_MD_upref() returns 1 for success or 0 otherwise.
+EVP_MD_up_ref() returns 1 for success or 0 otherwise.
 
 =head1 SEE ALSO
 
@@ -184,7 +184,7 @@ L<EVP_DigestInit(3)>, L<EVP_SignInit(3)>, L<EVP_VerifyInit(3)>
 =head1 HISTORY
 
 The B<EVP_MD> structure was openly available in OpenSSL before version
-1.1.  EVP_MD_upref() was added in OpenSSL 3.0. All other functions described
+1.1.  EVP_MD_up_ref() was added in OpenSSL 3.0. All other functions described
 here were added in OpenSSL 1.1.
 
 =head1 COPYRIGHT

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -80,7 +80,7 @@ int EVP_set_default_properties(OPENSSL_CTX *libctx, const char *propq);
 # ifndef EVP_MD
 EVP_MD *EVP_MD_meth_new(int md_type, int pkey_type);
 EVP_MD *EVP_MD_meth_dup(const EVP_MD *md);
-int EVP_MD_upref(EVP_MD *md);
+int EVP_MD_up_ref(EVP_MD *md);
 void EVP_MD_meth_free(EVP_MD *md);
 
 int EVP_MD_meth_set_input_blocksize(EVP_MD *md, int blocksize);
@@ -191,7 +191,7 @@ int (*EVP_MD_meth_get_ctrl(const EVP_MD *md))(EVP_MD_CTX *ctx, int cmd,
 EVP_CIPHER *EVP_CIPHER_meth_new(int cipher_type, int block_size, int key_len);
 EVP_CIPHER *EVP_CIPHER_meth_dup(const EVP_CIPHER *cipher);
 void EVP_CIPHER_meth_free(EVP_CIPHER *cipher);
-int EVP_CIPHER_upref(EVP_CIPHER *cipher);
+int EVP_CIPHER_up_ref(EVP_CIPHER *cipher);
 
 int EVP_CIPHER_meth_set_iv_length(EVP_CIPHER *cipher, int iv_len);
 int EVP_CIPHER_meth_set_flags(EVP_CIPHER *cipher, unsigned long flags);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1150,8 +1150,8 @@ static int test_EVP_MD_fetch(int tst)
             || !TEST_int_eq(EVP_MD_block_size(md), SHA256_CBLOCK))
         goto err;
 
-    /* Also test EVP_MD_upref() while we're doing this */
-    if (!TEST_true(EVP_MD_upref(md)))
+    /* Also test EVP_MD_up_ref() while we're doing this */
+    if (!TEST_true(EVP_MD_up_ref(md)))
         goto err;
     /* Ref count should now be 2. Release both */
     EVP_MD_meth_free(md);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4783,12 +4783,12 @@ OSSL_PARAM_set_octet_ptr                4730	3_0_0	EXIST::FUNCTION:
 X509_set0_sm2_id                        4731	3_0_0	EXIST::FUNCTION:SM2
 X509_get0_sm2_id                        4732	3_0_0	EXIST::FUNCTION:SM2
 EVP_PKEY_get0_engine                    4733	3_0_0	EXIST::FUNCTION:ENGINE
-EVP_MD_upref                            4734	3_0_0	EXIST::FUNCTION:
+EVP_MD_up_ref                           4734	3_0_0	EXIST::FUNCTION:
 EVP_MD_fetch                            4735	3_0_0	EXIST::FUNCTION:
 EVP_set_default_properties              4736	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_construct_end                4737	3_0_0	EXIST::FUNCTION:
 EC_GROUP_check_named_curve              4738	3_0_0	EXIST::FUNCTION:EC
-EVP_CIPHER_upref                        4739	3_0_0	EXIST::FUNCTION:
+EVP_CIPHER_up_ref                       4739	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_fetch                        4740	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_mode                         4741	3_0_0	EXIST::FUNCTION:
 OPENSSL_info                            4742	3_0_0	EXIST::FUNCTION:

--- a/util/missingcrypto.txt
+++ b/util/missingcrypto.txt
@@ -496,7 +496,6 @@ EVP_CIPHER_CTX_set_num
 EVP_CIPHER_CTX_test_flags
 EVP_CIPHER_do_all
 EVP_CIPHER_do_all_sorted
-EVP_CIPHER_fetch
 EVP_CIPHER_get_asn1_iv
 EVP_CIPHER_impl_ctx_size
 EVP_CIPHER_set_asn1_iv

--- a/util/missingcrypto.txt
+++ b/util/missingcrypto.txt
@@ -499,7 +499,7 @@ EVP_CIPHER_do_all_sorted
 EVP_CIPHER_get_asn1_iv
 EVP_CIPHER_impl_ctx_size
 EVP_CIPHER_set_asn1_iv
-EVP_CIPHER_upref
+EVP_CIPHER_up_ref
 EVP_Cipher
 EVP_MAC_do_all
 EVP_MAC_do_all_sorted

--- a/util/missingcrypto.txt
+++ b/util/missingcrypto.txt
@@ -499,7 +499,6 @@ EVP_CIPHER_do_all_sorted
 EVP_CIPHER_get_asn1_iv
 EVP_CIPHER_impl_ctx_size
 EVP_CIPHER_set_asn1_iv
-EVP_CIPHER_up_ref
 EVP_Cipher
 EVP_MAC_do_all
 EVP_MAC_do_all_sorted


### PR DESCRIPTION
Added documentation for the two recently added functions EVP_CIPHER_fetch and EVP_CIPHER_up_ref.

I also took the opportunity to rename EVP_MD_upref and EVP_CIPHER_upref to EVP_MD_up_ref and EVP_CIPHER_up_ref. These were the only two examples of upref functions spelled that way. Since they are new and not yet in any stable release we can rename them.

This address two of the functions noted as missing from #9095.