### PR TITLE
Stdarg based OSSL_PARAM array building.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -907,7 +907,7 @@ static void param_process(va_list ap, const char *name,
 
     for (; name != NULL; name = va_arg(ap, const char *)) {
         type = va_arg(ap, int);
-#define T(type, type_name, param_type) \
+#define T(param_type, type, type_name) \
     case OSSL_PARAM_TYPE_ ## type_name: { \
             type val = va_arg(ap, type); \
             \
@@ -915,16 +915,16 @@ static void param_process(va_list ap, const char *name,
             break; \
         }
         switch (type) {
-        T(int, int, INTEGER);
-        T(unsigned int, uint, UNSIGNED_INTEGER);
-        T(long, long, INTEGER);
-        T(unsigned long, ulong, UNSIGNED_INTEGER);
-        T(int32_t, int32, INTEGER);
-        T(uint32_t, uint32, UNSIGNED_INTEGER);
-        T(int64_t, int64, INTEGER);
-        T(uint64_t, uint64, UNSIGNED_INTEGER);
-        T(size_t, size_t, UNSIGNED_INTEGER);
-        T(double, double, REAL);
+        T(INTEGER, int, int);
+        T(UNSIGNED_INTEGER, unsigned int, uint);
+        T(INTEGER, long, long);
+        T(UNSIGNED_INTEGER, unsigned long, ulong);
+        T(INTEGER, int32_t, int32);
+        T(UNSIGNED_INTEGER, uint32_t, uint32);
+        T(INTEGER, int64_t, int64);
+        T(UNSIGNED_INTEGER, uint64_t, uint64);
+        T(UNSIGNED_INTEGER, size_t, size_t);
+        T(REAL, double, double);
 #undef T
         case OSSL_PARAM_TYPE_BN: {
             size_t len = va_arg(ap, size_t);

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -285,7 +285,7 @@ could fill in the parameters like this:
 
 =head1 SEE ALSO
 
-L<openssl-core.h(7)>, L<OSSL_PARAM_get_int32_t(3)>
+L<openssl-core.h(7)>, L<OSSL_PARAM_get_int32_t(3)>, L<OSSL_PARAM_build(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_PARAM_build.pod
+++ b/doc/man3/OSSL_PARAM_build.pod
@@ -19,7 +19,7 @@ OSSL_PARAM_BUILD_octet_string,
 
  #include <openssl/params.h>
 
- #define OSSL_PARAM_BUILD_TYPE(key, address)
+ #define OSSL_PARAM_BUILD_TYPE(key, value)
  #define OSSL_PARAM_BUILD_utf8_string(key, address, size)
  #define OSSL_PARAM_BUILD_octet_string(key, address, size)
  #define OSSL_PARAM_BUILD_BN(key, address, size)
@@ -29,7 +29,7 @@ OSSL_PARAM_BUILD_octet_string,
 
 =head1 DESCRIPTION
 
-A collection of utility functions that simplify building arrays of
+This is a collection of utility functions that simplify building arrays of
 OSSL_PARAM structures.  The following B<TYPE> names are supported:
 
 =over 1
@@ -89,8 +89,8 @@ OSSL_PARAM_BUILD_utf8_string(), OSSL_PARAM_BUILD_octet_string(),
 OSSL_PARAM_BUILD_BN() are macros that provide support
 for defining UTF8 strings, OCTET strings and big numbers.
 A parameter with B<name> is defined, storage of length B<len> is allocated and
-the B<value> copied.
-If the B<value> is NULL, the allocated memory will be zeroed.
+the value at the specified B<address> is copied.
+If the B<address> is NULL, the allocated memory will be zeroed.
 If B<len> is zero, the length will be calculated for
 OSSL_PARAM_BUILD_utf8_string() and OSSL_PARAM_BUILD_BN().
 For OSSL_PARAM_BUILD_octet_string() the length must be specified.
@@ -98,7 +98,7 @@ For OSSL_PARAM_BUILD_octet_string() the length must be specified.
 OSSL_PARAM_build() allocates storage for and creates an array of OSSL_PARAM
 structures and their associated values.
 The parameter list must be terminated with a NULL.
-The order of the elements in the allocated OSSL_PARAM array are undefined.
+The order of the elements in the allocated OSSL_PARAM array is undefined.
 
 OSSL_PARAM_build_free() frees storage allocated for the B<params> array and
 the values the OSSL_PARAM structures reference.
@@ -177,7 +177,7 @@ L<openssl-core.h(7)>, L<OSSL_PARAM(3)>, L<OSSL_PARAM_build(3)>
 
 =head1 HISTORY
 
-These APIs were introduced in OpenSSL 3.0.0.
+This API was introduced in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_PARAM_build.pod
+++ b/doc/man3/OSSL_PARAM_build.pod
@@ -147,7 +147,7 @@ The other is an integer with the value 42.
 
     /*
      * Create the array containing the two parameter structures.
-     * It is automatically terminated with a third OSSL_PARAM_END structure.
+     * The function argument list is terminated using a NULL entry.
      */
     params = OSSL_PARAM_build(
         OSSL_PARAM_utf8_string("foo", NULL, 32),

--- a/doc/man3/OSSL_PARAM_build.pod
+++ b/doc/man3/OSSL_PARAM_build.pod
@@ -131,7 +131,7 @@ Individual OSSL_PARAM structures must be looked up by name.
 
 =back
 
-=head1 EXAMPLES
+=head1 EXAMPLE
 
 This example creates an array of OSSL_PARAM containing two structures.
 One is a UTF8 string of length 32 which is named I<foo>.

--- a/doc/man3/OSSL_PARAM_build.pod
+++ b/doc/man3/OSSL_PARAM_build.pod
@@ -1,0 +1,191 @@
+=pod
+
+=head1 NAME
+
+OSSL_PARAM_build, OSSL_PARAM_build_free,
+OSSL_PARAM_BUILD_BN, OSSL_PARAM_BUILD_double,
+OSSL_PARAM_BUILD_int, OSSL_PARAM_BUILD_int32,
+OSSL_PARAM_BUILD_int64, OSSL_PARAM_BUILD_long,
+OSSL_PARAM_BUILD_size_t, OSSL_PARAM_BUILD_uint,
+OSSL_PARAM_BUILD_uint32, OSSL_PARAM_BUILD_uint64,
+OSSL_PARAM_BUILD_ulong, OSSL_PARAM_BUILD_BN,
+OSSL_PARAM_BUILD_utf8_string,
+OSSL_PARAM_BUILD_octet_string,
+- OSSL_PARAM array helpers
+
+=head1 SYNOPSIS
+
+=for comment generic
+
+ #include <openssl/params.h>
+
+ #define OSSL_PARAM_BUILD_TYPE(key, address)
+ #define OSSL_PARAM_BUILD_utf8_string(key, address, size)
+ #define OSSL_PARAM_BUILD_octet_string(key, address, size)
+ #define OSSL_PARAM_BUILD_BN(key, address, size)
+
+ OSSL_PARAM *OSSL_PARAM_build(const char *name, ..., NULL);
+ void OSSL_PARAM_build_free(OSSL_PARAM *params);
+
+=head1 DESCRIPTION
+
+A collection of utility functions that simplify building arrays of
+OSSL_PARAM structures.  The following B<TYPE> names are supported:
+
+=over 1
+
+=item *
+
+double
+
+=item *
+
+int
+
+=item *
+
+int32 (int32_t)
+
+=item *
+
+int64 (int64_t)
+
+=item *
+
+long int (long)
+
+=item *
+
+size_t
+
+=item *
+
+uint32 (uint32_t)
+
+=item *
+
+uint64 (uint64_t)
+
+=item *
+
+unsigned int (uint)
+
+=item *
+
+unsigned long int (ulong)
+
+=back
+
+OSSL_PARAM_BUILD_TYPE() are a series of macros designed to assist calling the
+OSSL_PARAM_build() function.
+In each case a parameter record is defined with the specified B<name> and
+B<value>.
+Each of these macros expands into a series of arguments appropriate for passing
+to the OSSL_PARAM_build() function which reduces the chance of parameters
+mistakes.
+Casts are also inserted to again reduce typing mistakes.
+
+OSSL_PARAM_BUILD_utf8_string(), OSSL_PARAM_BUILD_octet_string(),
+OSSL_PARAM_BUILD_BN() are macros that provide support
+for defining UTF8 strings, OCTET strings and big numbers.
+A parameter with B<name> is defined, storage of length B<len> is allocated and
+the B<value> copied.
+If the B<value> is NULL, the allocated memory will be zeroed.
+If B<len> is zero, the length will be calculated for
+OSSL_PARAM_BUILD_utf8_string() and OSSL_PARAM_BUILD_BN().
+For OSSL_PARAM_BUILD_octet_string() the length must be specified.
+
+OSSL_PARAM_build() allocates storage for and creates an array of OSSL_PARAM
+structures and their associated values.
+The parameter list must be terminated with a NULL.
+The order of the elements in the allocated OSSL_PARAM array are undefined.
+
+OSSL_PARAM_build_free() frees storage allocated for the B<params> array and
+the values the OSSL_PARAM structures reference.
+Only B<params> pointers returned from OSSL_PARAM_build() should be freed using
+this function.
+
+=head1 RETURN VALUES
+
+OSSL_PARAM_build() returns a populated OSSL_PARAM array, or NULL on failure.
+
+=head1 NOTES
+
+Using these functions introduces additional overhead when compared to raw
+OSSL_PARAM operations.
+
+=over 1
+
+=item *
+
+Memory for the array of OSSL_PARAM structures and the values referenced is
+dynamically allocated.
+
+=item *
+
+An extra copy is introduced for each value passed.
+
+=item *
+
+Individual OSSL_PARAM structures must be looked up by name.
+
+=back
+
+=head1 EXAMPLES
+
+This example creates an array of OSSL_PARAM containing two structures.
+One is a UTF8 string of length 32 which is named I<foo>.
+The other is an integer with the value 42.
+
+    #include <openssl/params.h>
+
+    OSSL_PARAM *params;
+    int bar_int;
+    char foo_buffer[1024];
+    char *foo_pointer = foo_buffer;
+    OSSL_PARAM *p;
+
+    /*
+     * Create the array containing the two parameter structures.
+     * It is automatically terminated with a third OSSL_PARAM_END structure.
+     */
+    params = OSSL_PARAM_build(
+        OSSL_PARAM_utf8_string("foo", NULL, 32),
+        OSSL_PARAM_int("bar", 42),
+        NULL
+    );
+
+    /*
+     * Read the values of the elements in the array.
+     */
+    p = OSSL_PARAM_locate(params, "bar");
+    if (p != NULL)
+        OSSL_PARAM_get_int(p, &bar_int);
+
+    p = OSSL_PARAM_locate(params, "foo");
+    if (p != NULL)
+        OSSL_PARAM_get_utf8_string("foo", &foo_pointer, sizeof(foo_buffer));
+
+    /*
+     * Clean up allocated memory.
+     */
+    OSSL_PARAM_build_free(params);
+
+=head1 SEE ALSO
+
+L<openssl-core.h(7)>, L<OSSL_PARAM(3)>, L<OSSL_PARAM_build(3)>
+
+=head1 HISTORY
+
+These APIs were introduced in OpenSSL 3.0.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -308,7 +308,7 @@ could fill in the parameters like this:
 
 =head1 SEE ALSO
 
-L<openssl-core.h(7)>, L<OSSL_PARAM(3)>
+L<openssl-core.h(7)>, L<OSSL_PARAM(3)>, L<OSSL_PARAM_build(3)>
 
 =head1 HISTORY
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -167,12 +167,12 @@ void OSSL_PARAM_build_free(OSSL_PARAM *params);
     (name), OSSL_PARAM_TYPE_size_t, (size_t)(value)
 #define OSSL_PARAM_BUILD_double(name, value) \
     (name), OSSL_PARAM_TYPE_double, (double)(value)
-#define OSSL_PARAM_BUILD_BN(name, value, len) \
-    (name), OSSL_PARAM_TYPE_BN, (size_t)(len), (value)
-#define OSSL_PARAM_BUILD_utf8_string(name, value, len) \
-    (name), OSSL_PARAM_TYPE_utf8, (size_t)(len), (value)
-#define OSSL_PARAM_BUILD_octet_string(name, value, len) \
-    (name), OSSL_PARAM_TYPE_utf8, (size_t)(len), (value)
+#define OSSL_PARAM_BUILD_BN(name, address, len) \
+    (name), OSSL_PARAM_TYPE_BN, (size_t)(len), (address)
+#define OSSL_PARAM_BUILD_utf8_string(name, address, len) \
+    (name), OSSL_PARAM_TYPE_utf8, (size_t)(len), (address)
+#define OSSL_PARAM_BUILD_octet_string(name, address, len) \
+    (name), OSSL_PARAM_TYPE_utf8, (size_t)(len), (address)
 
 
 # ifdef  __cplusplus

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -130,6 +130,51 @@ int OSSL_PARAM_get_octet_ptr(const OSSL_PARAM *p, const void **val,
 int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                              size_t used_len);
 
+#define OSSL_PARAM_TYPE_int 1
+#define OSSL_PARAM_TYPE_uint 2
+#define OSSL_PARAM_TYPE_long 3
+#define OSSL_PARAM_TYPE_ulong 4
+#define OSSL_PARAM_TYPE_int32 5
+#define OSSL_PARAM_TYPE_uint32 6
+#define OSSL_PARAM_TYPE_int64 7
+#define OSSL_PARAM_TYPE_uint64 8
+#define OSSL_PARAM_TYPE_size_t 9
+#define OSSL_PARAM_TYPE_double 10
+#define OSSL_PARAM_TYPE_BN 11
+#define OSSL_PARAM_TYPE_utf8 12
+#define OSSL_PARAM_TYPE_octet 13
+
+OSSL_PARAM *OSSL_PARAM_build(const char *name, ...);
+void OSSL_PARAM_build_free(OSSL_PARAM *params);
+
+#define OSSL_PARAM_BUILD_int(name, value) \
+    (name), OSSL_PARAM_TYPE_int, (int)(value)
+#define OSSL_PARAM_BUILD_uint(name, value) \
+    (name), OSSL_PARAM_TYPE_uint, (unsigned int)(value)
+#define OSSL_PARAM_BUILD_long(name, value) \
+    (name), OSSL_PARAM_TYPE_long, (long int)(value)
+#define OSSL_PARAM_BUILD_ulong(name, value) \
+    (name), OSSL_PARAM_TYPE_ulong, (unsigned long int)(value)
+#define OSSL_PARAM_BUILD_int32(name, value) \
+    (name), OSSL_PARAM_TYPE_int32, (int32_t)(value)
+#define OSSL_PARAM_BUILD_uint32(name, value) \
+    (name), OSSL_PARAM_TYPE_uint32, (uint32_t)(value)
+#define OSSL_PARAM_BUILD_int64(name, value) \
+    (name), OSSL_PARAM_TYPE_int64, (int64_t)(value)
+#define OSSL_PARAM_BUILD_uint64(name, value) \
+    (name), OSSL_PARAM_TYPE_uint64, (uint64_t)(value)
+#define OSSL_PARAM_BUILD_size_t(name, value) \
+    (name), OSSL_PARAM_TYPE_size_t, (size_t)(value)
+#define OSSL_PARAM_BUILD_double(name, value) \
+    (name), OSSL_PARAM_TYPE_double, (double)(value)
+#define OSSL_PARAM_BUILD_BN(name, value, len) \
+    (name), OSSL_PARAM_TYPE_BN, (size_t)(len), (value)
+#define OSSL_PARAM_BUILD_utf8_string(name, value, len) \
+    (name), OSSL_PARAM_TYPE_utf8, (size_t)(len), (value)
+#define OSSL_PARAM_BUILD_octet_string(name, value, len) \
+    (name), OSSL_PARAM_TYPE_utf8, (size_t)(len), (value)
+
+
 # ifdef  __cplusplus
 }
 # endif

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -543,8 +543,36 @@ static int test_case(int i)
                                  test_cases[i].prov));
 }
 
+static int test_build(void) {
+    int i, res;
+    char buf[1024], *cp = buf;
+    OSSL_PARAM *p, *params =
+        OSSL_PARAM_build(
+            OSSL_PARAM_BUILD_int("p1", p1_init),
+            OSSL_PARAM_BUILD_BN("p3", NULL, sizeof(bignumbin)),
+            OSSL_PARAM_BUILD_utf8_string("p4", NULL, sizeof(app_p4)),
+            OSSL_PARAM_BUILD_utf8_string("p5", p5_init, 0),
+            OSSL_PARAM_BUILD_utf8_string("p6", p6_init, sizeof(app_p6_init)),
+            OSSL_PARAM_BUILD_octet_string("foo", &foo, sizeof(foo)),
+            NULL);
+
+    res = TEST_ptr(params)
+        && TEST_ptr(p = OSSL_PARAM_locate(params, "p1"))
+        && TEST_true(OSSL_PARAM_get_int(p, &i))
+        && TEST_int_eq(i, p1_init)
+        && TEST_ptr(p = OSSL_PARAM_locate(params, "p4"))
+        && TEST_true(OSSL_PARAM_get_utf8_string(p, &cp, sizeof(buf)))
+        && TEST_str_eq(buf, "")
+        && TEST_ptr(p = OSSL_PARAM_locate(params, "p5"))
+        && TEST_true(OSSL_PARAM_get_utf8_string(p, &cp, sizeof(buf)))
+        && TEST_str_eq(buf, p5_init);
+    OSSL_PARAM_build_free(params);
+    return res;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_case, OSSL_NELEM(test_cases));
+    ADD_TEST(test_build);
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4833,3 +4833,5 @@ BN_CTX_new_ex                           4777	3_0_0	EXIST::FUNCTION:
 BN_CTX_secure_new_ex                    4778	3_0_0	EXIST::FUNCTION:
 OPENSSL_thread_stop_ex                  4779	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_locate_const                 4780	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_build                        4781	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_build_free                   4782	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add a function that allows an array of OSSL_PARAMs to be allocated and populated in one call.

- [x] documentation is added or updated
- [x] tests are added or updated
