### PR TITLE
Fix incorrect usage of a test case

### DIFF
--- a/test/x509_check_cert_pkey_test.c
+++ b/test/x509_check_cert_pkey_test.c
@@ -110,10 +110,11 @@ const OPTIONS *test_get_options(void)
 {
     enum { OPT_TEST_ENUM };
     static const OPTIONS test_options[] = {
-        OPT_TEST_OPTIONS_WITH_EXTRA_USAGE("certname key.pem type expected\n"),
-        { OPT_HELP_STR, 1, '-', "certname\tCertificate filename .pem/.req\n" },
-        { OPT_HELP_STR, 1, '-', "type\t\tvalue must be 'pem' or 'req'\n" },
-        { OPT_HELP_STR, 1, '-', "expected\tthe expected return value\n" },
+        OPT_TEST_OPTIONS_WITH_EXTRA_USAGE("cert key type expected\n"),
+        { OPT_HELP_STR, 1, '-', "cert\tcertificate or CSR filename in PEM\n" },
+        { OPT_HELP_STR, 1, '-', "key\tprivate key filename in PEM\n" },
+        { OPT_HELP_STR, 1, '-', "type\t\tvalue must be 'cert' or 'req'\n" },
+        { OPT_HELP_STR, 1, '-', "expected\tthe expected return value, either 'ok' or 'failed'\n" },
         { NULL }
     };
     return test_options;


### PR DESCRIPTION
`test/x509_check_cert_pkey_test.c` has incorrect usage description.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
