### PR TITLE
WIP: Allocate param array entries dynamically.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -9,8 +9,10 @@
  */
 
 #include <string.h>
+#include <stdarg.h>
 #include <openssl/params.h>
 #include "internal/thread_once.h"
+#include "internal/cryptlib.h"
 
 OSSL_PARAM *OSSL_PARAM_locate(OSSL_PARAM *p, const char *key)
 {
@@ -39,6 +41,23 @@ static OSSL_PARAM ossl_param_construct(const char *key, unsigned int data_type,
     return res;
 }
 
+static OSSL_PARAM ossl_param_allocate(const char *key, unsigned int data_type,
+                                      void *data, size_t data_size,
+                                      size_t *return_size)
+{
+    void *p = OPENSSL_malloc(data_size);
+
+    if (p != NULL) {
+        if (data == NULL)
+            memset(p, 0, data_size);
+        else
+            memcpy(p, data, data_size);
+    } else {
+        data_type = 0;
+    }   
+    return ossl_param_construct(key, data_type, p, data_size);
+}
+
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val)
 {
     switch (sizeof(int)) {
@@ -64,6 +83,12 @@ int OSSL_PARAM_set_int(OSSL_PARAM *p, int val)
 OSSL_PARAM OSSL_PARAM_construct_int(const char *key, int *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_INTEGER, buf, sizeof(int));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_int(const char *key, int value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_INTEGER, &value, sizeof(int),
+                               NULL);
 }
 
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val)
@@ -94,6 +119,12 @@ OSSL_PARAM OSSL_PARAM_construct_uint(const char *key, unsigned int *buf)
                                 sizeof(unsigned int));
 }
 
+OSSL_PARAM OSSL_PARAM_allocate_uint(const char *key, unsigned int value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_UNSIGNED_INTEGER, &value,
+                               sizeof(unsigned int), NULL);
+}
+
 int OSSL_PARAM_get_long(const OSSL_PARAM *p, long int *val)
 {
     switch (sizeof(long int)) {
@@ -119,6 +150,12 @@ int OSSL_PARAM_set_long(OSSL_PARAM *p, long int val)
 OSSL_PARAM OSSL_PARAM_construct_long(const char *key, long int *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_INTEGER, buf, sizeof(long int));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_long(const char *key, long int value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_INTEGER, &value,
+                               sizeof(long int), NULL);
 }
 
 int OSSL_PARAM_get_ulong(const OSSL_PARAM *p, unsigned long int *val)
@@ -147,6 +184,12 @@ OSSL_PARAM OSSL_PARAM_construct_ulong(const char *key, unsigned long int *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_UNSIGNED_INTEGER, buf,
                                 sizeof(unsigned long int));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_ulong(const char *key, unsigned long int value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_UNSIGNED_INTEGER, &value,
+                               sizeof(unsigned long int), NULL);
 }
 
 int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
@@ -245,6 +288,12 @@ OSSL_PARAM OSSL_PARAM_construct_int32(const char *key, int32_t *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_INTEGER, buf,
                                 sizeof(int32_t));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_int32(const char *key, int32_t value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_INTEGER, &value, sizeof(int32_t),
+                               NULL);
 }
 
 int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
@@ -349,6 +398,12 @@ OSSL_PARAM OSSL_PARAM_construct_uint32(const char *key, uint32_t *buf)
                                 sizeof(uint32_t));
 }
 
+OSSL_PARAM OSSL_PARAM_allocate_uint32(const char *key, uint32_t value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_UNSIGNED_INTEGER, &value,
+                               sizeof(uint32_t), NULL);
+}
+
 int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 {
     uint64_t u64;
@@ -446,6 +501,12 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
 OSSL_PARAM OSSL_PARAM_construct_int64(const char *key, int64_t *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_INTEGER, buf, sizeof(int64_t));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_int64(const char *key, int64_t value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_INTEGER, &value, sizeof(int64_t),
+                               NULL);
 }
 
 int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
@@ -554,6 +615,12 @@ OSSL_PARAM OSSL_PARAM_construct_uint64(const char *key, uint64_t *buf)
                                 sizeof(uint64_t));
 }
 
+OSSL_PARAM OSSL_PARAM_allocate_uint64(const char *key, uint64_t value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_UNSIGNED_INTEGER, &value,
+                               sizeof(uint64_t), NULL);
+}
+
 int OSSL_PARAM_get_size_t(const OSSL_PARAM *p, size_t *val)
 {
     switch (sizeof(size_t)) {
@@ -580,6 +647,12 @@ OSSL_PARAM OSSL_PARAM_construct_size_t(const char *key, size_t *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_UNSIGNED_INTEGER, buf,
                                 sizeof(size_t));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_size_t(const char *key, size_t value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_UNSIGNED_INTEGER, &value,
+                               sizeof(size_t), NULL);
 }
 
 #ifndef FIPS_MODE
@@ -735,6 +808,12 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
 OSSL_PARAM OSSL_PARAM_construct_double(const char *key, double *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_REAL, buf, sizeof(double));
+}
+
+OSSL_PARAM OSSL_PARAM_allocate_double(const char *key, double value)
+{
+    return ossl_param_allocate(key, OSSL_PARAM_REAL, &value, sizeof(double),
+                               NULL);
 }
 
 static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
@@ -894,4 +973,13 @@ OSSL_PARAM OSSL_PARAM_construct_end(void)
     OSSL_PARAM end = OSSL_PARAM_END;
 
     return end;
+}
+
+int OSSL_PARAM_allocate_failed(const OSSL_PARAM *p)
+{
+    if (p != NULL)
+        while (p->key != NULL)
+            if (!p++->data_type)
+                return 1;
+    return 0;
 }

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <openssl/params.h>
+#include <openssl/crypto.h>
 #include "internal/thread_once.h"
 #include "internal/cryptlib.h"
 
@@ -727,16 +728,12 @@ OSSL_PARAM OSSL_PARAM_allocate_BN(const char *key, BIGNUM *bn, size_t bsize)
     if (bn != NULL) {
         if (bsize == 0)
             bsize = (size_t)BN_num_bytes(bn);
-
-        if (BN_get_flags(bn, BN_FLG_SECURE)) {
+        if (BN_get_flags(bn, BN_FLG_SECURE) == BN_FLG_SECURE) {
             secure = 1;
             flag |= OWNER_FLAG_secure;
         }
     }
-    if (secure)
-        p = OPENSSL_secure_malloc(bsize);
-    else
-        p = OPENSSL_malloc(bsize);
+    p = secure ? OPENSSL_secure_malloc(bsize) : OPENSSL_malloc(bsize);
     if (p != NULL) {
         if (bn == NULL)
             memset(p, 0, bsize);

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -11,7 +11,8 @@ OSSL_PARAM - a structure to pass or request object parameters
  typedef struct ossl_param_st OSSL_PARAM;
  struct ossl_param_st {
      const char *key;             /* the name of the parameter */
-     unsigned char data_type;     /* declare what kind of content is in data */
+     unsigned short data_type;    /* declare what kind of content is in data */
+     unsigned short owner_data;   /* owner's unspecified use */
      void *data;                  /* value being passed in or out */
      size_t data_size;            /* data size */
      size_t return_size;          /* returned size */
@@ -68,6 +69,12 @@ names as an array of OSSL_ITEM, for discovery purposes.
 The C<data_type> is a value that describes the type and organization of
 the data.
 See L</Supported types> below for a description of the types.
+
+=item C<owner_data>
+
+The C<owner_data> is an opaque value set by the creator of the OSSL_PARAM.
+The use of this value is undefined and reservde for the owner.
+It should not be used a receiver of parameters.
 
 =item C<data>
 

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -74,7 +74,8 @@ struct ossl_algorithm_st {
  */
 struct ossl_param_st {
     const char *key;             /* the name of the parameter */
-    unsigned int data_type;      /* declare what kind of content is in buffer */
+    unsigned short data_type;    /* declare what kind of content is in buffer */
+    unsigned short owner_data;   /* owner's unspecified use */
     void *data;                  /* value being passed in or out */
     size_t data_size;            /* data size */
     size_t return_size;          /* returned content size */

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -89,6 +89,20 @@ OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
                                           size_t bsize);
 OSSL_PARAM OSSL_PARAM_construct_end(void);
 
+/* Run time construction including storage allocation */
+OSSL_PARAM OSSL_PARAM_allocate_int(const char *key, int value);
+OSSL_PARAM OSSL_PARAM_allocate_uint(const char *key, unsigned int value);
+OSSL_PARAM OSSL_PARAM_allocate_long(const char *key, long int value);
+OSSL_PARAM OSSL_PARAM_allocate_ulong(const char *key, unsigned long int value);
+OSSL_PARAM OSSL_PARAM_allocate_int32(const char *key, int32_t value);
+OSSL_PARAM OSSL_PARAM_allocate_uint32(const char *key, uint32_t value);
+OSSL_PARAM OSSL_PARAM_allocate_int64(const char *key, int64_t value);
+OSSL_PARAM OSSL_PARAM_allocate_uint64(const char *key, uint64_t value);
+OSSL_PARAM OSSL_PARAM_allocate_size_t(const char *key, size_t value);
+OSSL_PARAM OSSL_PARAM_allocate_double(const char *key, double value);
+
+int OSSL_PARAM_allocate_failed(const OSSL_PARAM *p);
+
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val);
 int OSSL_PARAM_get_long(const OSSL_PARAM *p, long int *val);
@@ -129,6 +143,7 @@ int OSSL_PARAM_get_octet_ptr(const OSSL_PARAM *p, const void **val,
                              size_t *used_len);
 int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                              size_t used_len);
+
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -19,10 +19,10 @@ extern "C" {
 # endif
 
 # define OSSL_PARAM_END \
-    { NULL, 0, NULL, 0, 0 }
+    { NULL, 0, 0, NULL, 0, 0 }
 
 # define OSSL_PARAM_DEFN(key, type, addr, sz)    \
-    { (key), (type), (addr), (sz), 0 }
+    { (key), (type), 0, (addr), (sz), 0 }
 
 /* Basic parameter types without return sizes */
 # define OSSL_PARAM_int(key, addr) \
@@ -100,8 +100,18 @@ OSSL_PARAM OSSL_PARAM_allocate_int64(const char *key, int64_t value);
 OSSL_PARAM OSSL_PARAM_allocate_uint64(const char *key, uint64_t value);
 OSSL_PARAM OSSL_PARAM_allocate_size_t(const char *key, size_t value);
 OSSL_PARAM OSSL_PARAM_allocate_double(const char *key, double value);
+OSSL_PARAM OSSL_PARAM_allocate_BN(const char *key, BIGNUM *bn, size_t bsize);
+OSSL_PARAM OSSL_PARAM_allocate_utf8_string(const char *key, char *buf,
+                                           size_t bsize);
+OSSL_PARAM OSSL_PARAM_allocate_utf8_ptr(const char *key, char *buf,
+                                        size_t bsize);
+OSSL_PARAM OSSL_PARAM_allocate_octet_string(const char *key, void *buf,
+                                            size_t bsize);
+OSSL_PARAM OSSL_PARAM_allocate_octet_ptr(const char *key, void *buf,
+                                         size_t bsize);
 
 int OSSL_PARAM_allocate_failed(const OSSL_PARAM *p);
+void OSSL_PARAM_free(OSSL_PARAM *p);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val);

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -60,16 +60,16 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
             static char *greeting;
             static OSSL_PARAM counter_request[] = {
                 /* Known libcrypto provided parameters */
-                { "openssl-version", OSSL_PARAM_UTF8_PTR,
+                { "openssl-version", OSSL_PARAM_UTF8_PTR, 0,
                   &opensslv, sizeof(&opensslv), 0 },
-                { "provider-name", OSSL_PARAM_UTF8_PTR,
+                { "provider-name", OSSL_PARAM_UTF8_PTR, 0,
                   &provname, sizeof(&provname), 0},
 
                 /* This might be present, if there's such a configuration */
-                { "greeting", OSSL_PARAM_UTF8_PTR,
+                { "greeting", OSSL_PARAM_UTF8_PTR, 0,
                   &greeting, sizeof(&greeting), 0 },
 
-                { NULL, 0, NULL, 0, 0 }
+                { NULL, 0, 0, NULL, 0, 0 }
             };
             char buf[256];
             size_t buf_l;

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -349,14 +349,14 @@ static int init_app_variables(void)
 
 /* An array of OSSL_PARAM, specific in the most raw manner possible */
 static OSSL_PARAM static_raw_params[] = {
-    { "p1", OSSL_PARAM_INTEGER, &app_p1, sizeof(app_p1), 0 },
-    { "p3", OSSL_PARAM_UNSIGNED_INTEGER, &bignumbin, sizeof(bignumbin), 0 },
-    { "p4", OSSL_PARAM_UTF8_STRING, &app_p4, sizeof(app_p4), 0 },
-    { "p5", OSSL_PARAM_UTF8_STRING, &app_p5, sizeof(app_p5), 0 },
+    { "p1", OSSL_PARAM_INTEGER, 0, &app_p1, sizeof(app_p1), 0 },
+    { "p3", OSSL_PARAM_UNSIGNED_INTEGER, 0, &bignumbin, sizeof(bignumbin), 0 },
+    { "p4", OSSL_PARAM_UTF8_STRING, 0, &app_p4, sizeof(app_p4), 0 },
+    { "p5", OSSL_PARAM_UTF8_STRING, 0, &app_p5, sizeof(app_p5), 0 },
     /* sizeof(app_p6_init), because we know that's what we're using */
-    { "p6", OSSL_PARAM_UTF8_PTR, &app_p6, sizeof(app_p6_init), 0 },
-    { "foo", OSSL_PARAM_OCTET_STRING, &foo, sizeof(foo), 0 },
-    { NULL, 0, NULL, 0, 0 }
+    { "p6", OSSL_PARAM_UTF8_PTR, 0, &app_p6, sizeof(app_p6_init), 0 },
+    { "foo", OSSL_PARAM_OCTET_STRING, 0, &foo, sizeof(foo), 0 },
+    { NULL, 0, 0, NULL, 0, 0 }
 };
 
 /* The same array of OSSL_PARAM, specified with the macros from params.h */

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <openssl/crypto.h>
+#include <openssl/params.h>
 #include "internal/provider.h"
 #include "testutil.h"
 
@@ -16,8 +17,8 @@ extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
 
 static char buf[256];
 static OSSL_PARAM greeting_request[] = {
-    { "greeting", OSSL_PARAM_UTF8_STRING, buf, sizeof(buf), 0 },
-    { NULL, 0, NULL, 0, 0 }
+    OSSL_PARAM_utf8_string("greeting", buf, sizeof(buf)),
+    OSSL_PARAM_END
 };
 
 static int test_provider(OSSL_PROVIDER *prov, const char *expected_greeting)

--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -9,14 +9,15 @@
 
 #include <stddef.h>
 #include <openssl/provider.h>
+#include <openssl/params.h>
 #include "testutil.h"
 
 extern OSSL_provider_init_fn PROVIDER_INIT_FUNCTION_NAME;
 
 static char buf[256];
 static OSSL_PARAM greeting_request[] = {
-    { "greeting", OSSL_PARAM_UTF8_STRING, buf, sizeof(buf) },
-    { NULL, 0, NULL, 0, 0 }
+    OSSL_PARAM_utf8_string("greeting", buf, sizeof(buf)),
+    OSSL_PARAM_END
 };
 
 static int test_provider(const char *name)


### PR DESCRIPTION
This provides an alternative for the `OSSL_PARAM_construct_ `series of functions which allocate storage for the values rather than relying on local on stack storage.  The new `OSSL_PARAM_allocate_` and the existing `OSSL_PARAM_construct_` calls can be freely intermingled.

- [ ] documentation is added or updated
- [ ] tests are added or updated
