### PR TITLE
s390x assembly pack: add capability detection for new cpu

### DIFF
--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -26,6 +26,9 @@ void s390x_kmf(const unsigned char *in, size_t len, unsigned char *out,
                unsigned int fc, void *param);
 void s390x_kma(const unsigned char *aad, size_t alen, const unsigned char *in,
                size_t len, unsigned char *out, unsigned int fc, void *param);
+int s390x_pcc(unsigned int fc, void *param);
+int s390x_kdsa(unsigned int fc, void *param, const unsigned char *in,
+               size_t len);
 
 /*
  * The field elements of OPENSSL_s390xcap_P are the 64-bit words returned by
@@ -45,6 +48,8 @@ struct OPENSSL_s390xcap_st {
     unsigned long long kmf[2];
     unsigned long long prno[2];
     unsigned long long kma[2];
+    unsigned long long pcc[2];
+    unsigned long long kdsa[2];
 };
 
 extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
@@ -69,6 +74,8 @@ extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 # define S390X_KMF		0x90
 # define S390X_PRNO		0xa0
 # define S390X_KMA		0xb0
+# define S390X_PCC		0xc0
+# define S390X_KDSA		0xd0
 
 /* Facility Bit Numbers */
 # define S390X_MSA		17	/* message-security-assist */
@@ -80,6 +87,7 @@ extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 # define S390X_VXD		134	/* vector packed decimal */
 # define S390X_VXE		135	/* vector enhancements 1 */
 # define S390X_MSA8		146	/* message-security-assist-ext. 8 */
+# define S390X_MSA9		155	/* message-security-assist-ext. 9 */
 
 /* Function Codes */
 
@@ -111,10 +119,24 @@ extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 # define S390X_SHA_512_DRNG	3
 # define S390X_TRNG		114
 
+/* pcc */
+# define S390X_SCALAR_MULTIPLY_P256	64
+# define S390X_SCALAR_MULTIPLY_P384	65
+# define S390X_SCALAR_MULTIPLY_P521	66
+
+/* kdsa */
+# define S390X_ECDSA_VERIFY_P256	1
+# define S390X_ECDSA_VERIFY_P384	2
+# define S390X_ECDSA_VERIFY_P521	3
+# define S390X_ECDSA_SIGN_P256		9
+# define S390X_ECDSA_SIGN_P384		10
+# define S390X_ECDSA_SIGN_P521		11
+
 /* Register 0 Flags */
 # define S390X_DECRYPT		0x80
 # define S390X_KMA_LPC		0x100
 # define S390X_KMA_LAAD		0x200
 # define S390X_KMA_HS		0x400
+# define S390X_KDSA_D		0x80
 
 #endif

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -137,6 +137,10 @@ void OPENSSL_cpuid_setup(void)
         OPENSSL_s390xcap_P.prno[1] &= cap.prno[1];
         OPENSSL_s390xcap_P.kma[0] &= cap.kma[0];
         OPENSSL_s390xcap_P.kma[1] &= cap.kma[1];
+        OPENSSL_s390xcap_P.pcc[0] &= cap.pcc[0];
+        OPENSSL_s390xcap_P.pcc[1] &= cap.pcc[1];
+        OPENSSL_s390xcap_P.kdsa[0] &= cap.kdsa[0];
+        OPENSSL_s390xcap_P.kdsa[1] &= cap.kdsa[1];
     }
 }
 
@@ -163,6 +167,8 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         /*.kmf    = */{0ULL, 0ULL},
         /*.prno   = */{0ULL, 0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{0ULL, 0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -189,6 +195,8 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         /*.kmf    = */{0ULL, 0ULL},
         /*.prno   = */{0ULL, 0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{0ULL, 0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -220,6 +228,8 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         /*.kmf    = */{0ULL, 0ULL},
         /*.prno   = */{0ULL, 0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{0ULL, 0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -257,6 +267,8 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         /*.kmf    = */{0ULL, 0ULL},
         /*.prno   = */{0ULL, 0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{0ULL, 0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -313,6 +325,9 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
                        0ULL},
         /*.prno   = */{0ULL, 0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{S390X_CAPBIT(S390X_QUERY),
+                       0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -369,6 +384,9 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
                        0ULL},
         /*.prno   = */{0ULL, 0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{S390X_CAPBIT(S390X_QUERY),
+                       0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -429,6 +447,9 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
                        | S390X_CAPBIT(S390X_SHA_512_DRNG),
                        0ULL},
         /*.kma    = */{0ULL, 0ULL},
+        /*.pcc    = */{S390X_CAPBIT(S390X_QUERY),
+                       0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
     };
 
     /*-
@@ -508,6 +529,101 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
                        | S390X_CAPBIT(S390X_AES_192)
                        | S390X_CAPBIT(S390X_AES_256),
                        0ULL},
+        /*.pcc    = */{S390X_CAPBIT(S390X_QUERY),
+                       0ULL},
+        /*.kdsa   = */{0ULL, 0ULL},
+    };
+
+    /*-
+     * z15 (2019) - z/Architecture POP SA22-7832-12
+     * Implements MSA and MSA1-9.
+     */
+    static const struct OPENSSL_s390xcap_st z15 = {
+        /*.stfle  = */{S390X_CAPBIT(S390X_MSA)
+                       | S390X_CAPBIT(S390X_STCKF)
+                       | S390X_CAPBIT(S390X_MSA5),
+                       S390X_CAPBIT(S390X_MSA3)
+                       | S390X_CAPBIT(S390X_MSA4),
+                       S390X_CAPBIT(S390X_VX)
+                       | S390X_CAPBIT(S390X_VXD)
+                       | S390X_CAPBIT(S390X_VXE)
+                       | S390X_CAPBIT(S390X_MSA8),
+                       0ULL},
+        /*.kimd   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SHA_1)
+                       | S390X_CAPBIT(S390X_SHA_256)
+                       | S390X_CAPBIT(S390X_SHA_512)
+                       | S390X_CAPBIT(S390X_SHA3_224)
+                       | S390X_CAPBIT(S390X_SHA3_256)
+                       | S390X_CAPBIT(S390X_SHA3_384)
+                       | S390X_CAPBIT(S390X_SHA3_512)
+                       | S390X_CAPBIT(S390X_SHAKE_128)
+                       | S390X_CAPBIT(S390X_SHAKE_256),
+                       S390X_CAPBIT(S390X_GHASH)},
+        /*.klmd   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SHA_1)
+                       | S390X_CAPBIT(S390X_SHA_256)
+                       | S390X_CAPBIT(S390X_SHA_512)
+                       | S390X_CAPBIT(S390X_SHA3_224)
+                       | S390X_CAPBIT(S390X_SHA3_256)
+                       | S390X_CAPBIT(S390X_SHA3_384)
+                       | S390X_CAPBIT(S390X_SHA3_512)
+                       | S390X_CAPBIT(S390X_SHAKE_128)
+                       | S390X_CAPBIT(S390X_SHAKE_256),
+                       0ULL},
+        /*.km     = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256)
+                       | S390X_CAPBIT(S390X_XTS_AES_128)
+                       | S390X_CAPBIT(S390X_XTS_AES_256),
+                       0ULL},
+        /*.kmc    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmac   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmctr  = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmo    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.kmf    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.prno   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SHA_512_DRNG),
+                       S390X_CAPBIT(S390X_TRNG)},
+        /*.kma    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_AES_128)
+                       | S390X_CAPBIT(S390X_AES_192)
+                       | S390X_CAPBIT(S390X_AES_256),
+                       0ULL},
+        /*.pcc    = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P256)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P384)
+                       | S390X_CAPBIT(S390X_SCALAR_MULTIPLY_P521),
+                       0ULL},
+        /*.kdsa   = */{S390X_CAPBIT(S390X_QUERY)
+                       | S390X_CAPBIT(S390X_ECDSA_VERIFY_P256)
+                       | S390X_CAPBIT(S390X_ECDSA_VERIFY_P384)
+                       | S390X_CAPBIT(S390X_ECDSA_VERIFY_P521)
+                       | S390X_CAPBIT(S390X_ECDSA_SIGN_P256)
+                       | S390X_CAPBIT(S390X_ECDSA_SIGN_P384)
+                       | S390X_CAPBIT(S390X_ECDSA_SIGN_P521),
+                       0ULL},
     };
 
     char *tok_begin, *tok_end, *buff, tok[S390X_STFLE_MAX][LEN + 1];
@@ -551,6 +667,8 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         else if TOK_FUNC(kmf)
         else if TOK_FUNC(prno)
         else if TOK_FUNC(kma)
+        else if TOK_FUNC(pcc)
+        else if TOK_FUNC(kdsa)
 
         /* CPU model tokens */
         else if TOK_CPU(z900)
@@ -561,6 +679,7 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         else if TOK_CPU(zEC12)
         else if TOK_CPU(z13)
         else if TOK_CPU(z14)
+        else if TOK_CPU(z15)
 
         /* whitespace(ignored) or invalid tokens */
         else {

--- a/doc/man3/OPENSSL_s390xcap.pod
+++ b/doc/man3/OPENSSL_s390xcap.pod
@@ -34,14 +34,14 @@ There are three types of tokens:
 The name of a processor generation. A bit in the environment variable's
 mask is set to one if and only if the specified processor generation
 implements the corresponding instruction set extension. Possible values
-are z900, z990, z9, z10, z196, zEC12, z13 and z14.
+are z900, z990, z9, z10, z196, zEC12, z13, z14 and z15.
 
 =item <string>:<mask>:<mask>
 
 The name of an instruction followed by two 64-bit masks. The part of the
 environment variable's mask corresponding to the specified instruction is
 set to the specified 128-bit mask. Possible values are kimd, klmd, km, kmc,
-kmac, kmctr, kmo, kmf, prno and kma.
+kmac, kmctr, kmo, kmf, prno, kma, pcc and kdsa.
 
 =item stfle:<mask>:<mask>:<mask>
 
@@ -139,6 +139,21 @@ the numbering is continuous across 64-bit mask boundaries.
       # 20    1<<43    KMA-GCM-AES-256
       :
 
+ pcc  :
+      :
+      # 64    1<<63    PCC-Scalar-Multiply-P256
+      # 65    1<<62    PCC-Scalar-Multiply-P384
+      # 66    1<<61    PCC-Scalar-Multiply-P521
+
+ kdsa :
+      #  1    1<<62    KDSA-ECDSA-Verify-P256
+      #  2    1<<61    KDSA-ECDSA-Verify-P384
+      #  3    1<<60    KDSA-ECDSA-Verify-P521
+      #  9    1<<54    KDSA-ECDSA-Sign-P256
+      # 10    1<<53    KDSA-ECDSA-Sign-P384
+      # 11    1<<52    KDSA-ECDSA-Sign-P521
+      :
+
 =head1 RETURN VALUES
 
 Not available.
@@ -159,7 +174,7 @@ Disables the KM-XTS-AES and and the KIMD-SHAKE function codes:
 
 =head1 SEE ALSO
 
-[1] z/Architecture Principles of Operation, SA22-7832-11
+[1] z/Architecture Principles of Operation, SA22-7832-12
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
-detect message-security-assist extension 9
-detect available function codes for kdsa and pcc instructions
-add support for kdsa and pcc instructions
-update OPENSSL_s390xcap environment variable
-update corresponding man page

- [x] documentation is added or updated

