### PR TITLE
Clarify the INSTALL instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -100,13 +100,7 @@
     $ nmake install
 
  Note that in order to perform the install step above you need to have
- appropriate permissions to write to the installation directory. For example,
- in many cases on Unix, you may need to instead run the command like this:
-
-    $ sudo make install
-
- On Windows you may need to run the command from an administrator command
- prompt.
+ appropriate permissions to write to the installation directory.
 
  If any of these steps fails, see section Installation in Detail below.
 
@@ -116,6 +110,12 @@
   OpenVMS: SYS$COMMON:[OPENSSL-'version'...], where 'version' is the
            OpenSSL version number with underscores instead of periods.
   Windows: C:\Program Files\OpenSSL or C:\Program Files (x86)\OpenSSL
+
+ The installation directory should be appropriately protected to ensure
+ untrusted users cannot make changes to OpenSSL binaries or files, or install
+ engines. If you already have a pre-installed version of OpenSSL as part of
+ your Operating System it is recommended that you do not overwrite the system
+ version and instead install to somewhere else.
 
  If you want to install it anywhere else, run config like this:
 
@@ -951,14 +951,7 @@
        $ nmake install                                  # Windows
 
      Note that in order to perform the install step above you need to have
-     appropriate permissions to write to the installation directory. For
-     example, in many cases on Unix, you may need to instead run the command
-     like this:
-
-       $ sudo make install
-
-     On Windows you may need to run the command from an administrator command
-     prompt.
+     appropriate permissions to write to the installation directory.
 
      The above commands will install all the software components in this
      directory tree under PREFIX (the directory given with --prefix or its
@@ -1016,6 +1009,12 @@
          private        Initially empty, this is the default location
                         for private key files.
          misc           Various scripts.
+
+     The installation directory should be appropriately protected to ensure
+     untrusted users cannot make changes to OpenSSL binaries or files, or
+     install engines. If you already have a pre-installed version of OpenSSL as
+     part of your Operating System it is recommended that you do not overwrite
+     the system version and instead install to somewhere else. 
 
      Package builders who want to configure the library for standard
      locations, but have the package installed somewhere else so that

--- a/INSTALL
+++ b/INSTALL
@@ -99,6 +99,15 @@
     $ nmake test
     $ nmake install
 
+ Note that in order to perform the install step above you need to have
+ appropriate permissions to write to the installation directory. For example,
+ in many cases on Unix, you may need to instead run the command like this:
+
+    $ sudo make install
+
+ On Windows you may need to run the command from an administrator command
+ prompt.
+
  If any of these steps fails, see section Installation in Detail below.
 
  This will build and install OpenSSL in the default location, which is:
@@ -941,8 +950,18 @@
        $ mms install                                    ! OpenVMS
        $ nmake install                                  # Windows
 
-     This will install all the software components in this directory
-     tree under PREFIX (the directory given with --prefix or its
+     Note that in order to perform the install step above you need to have
+     appropriate permissions to write to the installation directory. For
+     example, in many cases on Unix, you may need to instead run the command
+     like this:
+
+       $ sudo make install
+
+     On Windows you may need to run the command from an administrator command
+     prompt.
+
+     The above commands will install all the software components in this
+     directory tree under PREFIX (the directory given with --prefix or its
      default):
 
        Unix:


### PR DESCRIPTION
Ensure users understand that they need to have appropriate permissions
to write to the install location.

The following Stack Overflow post was pointed out to me which motivated this change:

https://stackoverflow.com/questions/41938564/problems-during-last-step-of-installing-openssl-on-mac-os-sierra

