### PR TITLE
Only cache a method if we actually created one

### DIFF
--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -207,7 +207,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
         mcmdata.destruct_method = free_method;
         if ((method = ossl_method_construct(libctx, operation_id, name,
                                             properties, 0 /* !force_cache */,
-                                            &mcm, &mcmdata)) == NULL) {
+                                            &mcm, &mcmdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that
              * there is a correct nameid and methodid, since those have


### PR DESCRIPTION
We were attempting to cache a method after we failed to create it
which leads to an assertion failure.

Fixes #9264

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
