### PR TITLE
Fix ASN1_TYPE_get/set with type=V_ASN1_BOOLEAN

### DIFF
--- a/crypto/asn1/a_type.c
+++ b/crypto/asn1/a_type.c
@@ -15,7 +15,9 @@
 
 int ASN1_TYPE_get(const ASN1_TYPE *a)
 {
-    if ((a->value.ptr != NULL) || (a->type == V_ASN1_NULL))
+    if (a->type == V_ASN1_BOOLEAN
+            || a->type == V_ASN1_NULL
+            || a->value.ptr != NULL)
         return a->type;
     else
         return 0;
@@ -23,7 +25,9 @@ int ASN1_TYPE_get(const ASN1_TYPE *a)
 
 void ASN1_TYPE_set(ASN1_TYPE *a, int type, void *value)
 {
-    if (a->value.ptr != NULL) {
+    if (a->type != V_ASN1_BOOLEAN
+            && a->type != V_ASN1_NULL
+            && a->value.ptr != NULL) {
         ASN1_TYPE **tmp_a = &a;
         asn1_primitive_free((ASN1_VALUE **)tmp_a, NULL, 0);
     }

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -314,7 +314,9 @@ void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,
     ttmp = X509_ATTRIBUTE_get0_type(attr, idx);
     if (!ttmp)
         return NULL;
-    if (atrtype != ASN1_TYPE_get(ttmp)) {
+    if (atrtype == V_ASN1_BOOLEAN
+            || atrtype == V_ASN1_NULL
+            || atrtype != ASN1_TYPE_get(ttmp)) {
         X509err(X509_F_X509_ATTRIBUTE_GET0_DATA, X509_R_WRONG_TYPE);
         return NULL;
     }


### PR DESCRIPTION
BOOLEAN does not have valid data in the value.ptr member,
thus don't use it here.

Fixes #9276

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
