### PR TITLE
test/p_test.c: silence -Wstringop-overflow

### DIFF
--- a/test/p_test.c
+++ b/test/p_test.c
@@ -92,7 +92,7 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
 
             p->return_size = buf_l = strlen(buf) + 1;
             if (p->data_size >= buf_l)
-                strncpy(p->data, buf, buf_l);
+                strcpy(p->data, buf);
             else
                 ok = 0;
         }


### PR DESCRIPTION
```
test/p_test.c: In function 'p_get_params':
test/p_test.c:95:17: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-overflow=]
                 strncpy(p->data, buf, buf_l);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/p_test.c:93:38: note: length computed here
             p->return_size = buf_l = strlen(buf) + 1;
```
I propose to just use strcpy instead since lengths are already checked above.