### PR TITLE
ossl_provider_upref to ossl_provider_up_ref

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -660,7 +660,7 @@ static void *evp_md_from_dispatch(const OSSL_DISPATCH *fns,
     }
     md->prov = prov;
     if (prov != NULL)
-        ossl_provider_upref(prov);
+        ossl_provider_up_ref(prov);
 
     return md;
 }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1174,7 +1174,7 @@ static void *evp_cipher_from_dispatch(const OSSL_DISPATCH *fns,
     }
     cipher->prov = prov;
     if (prov != NULL)
-        ossl_provider_upref(prov);
+        ossl_provider_up_ref(prov);
 
     return cipher;
 }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -157,7 +157,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
                         const char *name, const char *properties,
                         void *(*new_method)(const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
-                        int (*upref_method)(void *),
+                        int (*up_ref_method)(void *),
                         void (*free_method)(void *))
 {
     OSSL_METHOD_STORE *store = get_default_method_store(libctx);
@@ -203,7 +203,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
         mcmdata.name = name;
         mcmdata.method_from_dispatch = new_method;
         mcmdata.destruct_method = free_method;
-        mcmdata.refcnt_up_method = upref_method;
+        mcmdata.refcnt_up_method = up_ref_method;
         mcmdata.destruct_method = free_method;
         if ((method = ossl_method_construct(libctx, operation_id, name,
                                             properties, 0 /* !force_cache */,
@@ -219,7 +219,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
             ossl_method_store_cache_set(store, methid, properties, method);
         }
     } else {
-        upref_method(method);
+        up_ref_method(method);
     }
 
     return method;

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -93,5 +93,5 @@ void *evp_generic_fetch(OPENSSL_CTX *ctx, int operation_id,
                         const char *algorithm, const char *properties,
                         void *(*new_method)(const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
-                        int (*upref_method)(void *),
+                        int (*up_ref_method)(void *),
                         void (*free_method)(void *));

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -159,7 +159,7 @@ OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name)
         CRYPTO_THREAD_write_lock(store->lock);
         if ((i = sk_OSSL_PROVIDER_find(store->providers, &tmpl)) == -1
             || (prov = sk_OSSL_PROVIDER_value(store->providers, i)) == NULL
-            || !ossl_provider_upref(prov))
+            || !ossl_provider_up_ref(prov))
             prov = NULL;
         CRYPTO_THREAD_unlock(store->lock);
     }
@@ -181,7 +181,7 @@ static OSSL_PROVIDER *provider_new(const char *name,
 #ifndef HAVE_ATOMICS
         || (prov->refcnt_lock = CRYPTO_THREAD_lock_new()) == NULL
 #endif
-        || !ossl_provider_upref(prov) /* +1 One reference to be returned */
+        || !ossl_provider_up_ref(prov) /* +1 One reference to be returned */
         || (prov->name = OPENSSL_strdup(name)) == NULL) {
         ossl_provider_free(prov);
         CRYPTOerr(CRYPTO_F_PROVIDER_NEW, ERR_R_MALLOC_FAILURE);
@@ -192,7 +192,7 @@ static OSSL_PROVIDER *provider_new(const char *name,
     return prov;
 }
 
-int ossl_provider_upref(OSSL_PROVIDER *prov)
+int ossl_provider_up_ref(OSSL_PROVIDER *prov)
 {
     int ref = 0;
 
@@ -223,7 +223,7 @@ OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
         return NULL;
 
     CRYPTO_THREAD_write_lock(store->lock);
-    if (!ossl_provider_upref(prov)) { /* +1 One reference for the store */
+    if (!ossl_provider_up_ref(prov)) { /* +1 One reference for the store */
         ossl_provider_free(prov); /* -1 Reference that was to be returned */
         prov = NULL;
     } else if (sk_OSSL_PROVIDER_push(store->providers, prov) == 0) {

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -13,7 +13,7 @@ evp_generic_fetch - generic algorithm fetcher and method creator for EVP
                          const char *name, const char *properties,
                          void *(*new_method)(const OSSL_DISPATCH *fns,
                                              OSSL_PROVIDER *prov),
-                         int (*upref_method)(void *),
+                         int (*up_ref_method)(void *),
                          void (*free_method)(void *));
 
 =head1 DESCRIPTION
@@ -21,7 +21,7 @@ evp_generic_fetch - generic algorithm fetcher and method creator for EVP
 evp_generic_fetch() calls ossl_method_construct() with the given
 C<libctx>, C<operation_id>, C<name>, and C<properties> and uses
 it to create an EVP method with the help of the functions
-C<new_method>, C<upref_method>, and C<free_method>.
+C<new_method>, C<up_ref_method>, and C<free_method>.
 
 The three functions are supposed to:
 
@@ -32,7 +32,7 @@ The three functions are supposed to:
 creates an internal method from function pointers found in the
 dispatch table C<fns>.
 
-=item upref_method()
+=item up_ref_method()
 
 increments the reference counter for the given method, if there is
 one.
@@ -116,7 +116,7 @@ And here's the implementation of the FOO method fetcher:
         }
         foo->prov = prov;
         if (prov)
-            ossl_provider_upref(prov);
+            ossl_provider_up_ref(prov);
 
         return foo;
     }
@@ -137,7 +137,7 @@ And here's the implementation of the FOO method fetcher:
         return EVP_FOO_meth_from_dispatch(fns, prov);
     }
 
-    static int foo_upref(void *vfoo)
+    static int foo_up_ref(void *vfoo)
     {
         EVP_FOO *foo = vfoo;
         int ref = 0;
@@ -157,7 +157,7 @@ And here's the implementation of the FOO method fetcher:
     {
         EVP_FOO *foo =
             evp_generic_fetch(ctx, OSSL_OP_FOO, name, properties,
-                              foo_from_dispatch, foo_upref, foo_free);
+                              foo_from_dispatch, foo_up_ref, foo_free);
 
         /*
          * If this method exists in legacy form, with a constant NID for the

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -131,7 +131,7 @@ The associated provider object I<prov> is passed as well, to make
 it possible for the sub-system constructor to keep a reference, which
 is recommended.
 If such a reference is kept, the I<provider object> reference counter
-must be incremented, using ossl_provider_upref().
+must be incremented, using ossl_provider_up_ref().
 
 This function is expected to set the method's reference count to 1.
 

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-ossl_provider_find, ossl_provider_new, ossl_provider_upref,
+ossl_provider_find, ossl_provider_new, ossl_provider_up_ref,
 ossl_provider_free,
 ossl_provider_set_fallback, ossl_provider_set_module_path,
 ossl_provider_add_parameter,
@@ -22,7 +22,7 @@ ossl_provider_get_params, ossl_provider_query_operation
  OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name);
  OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
                                   ossl_provider_init_fn *init_function);
- int ossl_provider_upref(OSSL_PROVIDER *prov);
+ int ossl_provider_up_ref(OSSL_PROVIDER *prov);
  void ossl_provider_free(OSSL_PROVIDER *prov);
 
  /* Setters */
@@ -99,7 +99,7 @@ function.
 For further description of the initialisation function, see the
 description of ossl_provider_activate() below.
 
-ossl_provider_upref() increments the provider object I<prov>'s
+ossl_provider_up_ref() increments the provider object I<prov>'s
 reference count.
 
 ossl_provider_free() decrements the provider object I<prov>'s
@@ -220,7 +220,7 @@ of the built in macro B<MODULESDIR>.
 ossl_provider_find() and ossl_provider_new() return a pointer to a
 provider object (I<OSSL_PROVIDER>) on success, or NULL on error.
 
-ossl_provider_upref() returns the value of the reference count after
+ossl_provider_up_ref() returns the value of the reference count after
 it has been incremented.
 
 ossl_provider_free() doesn't return any value.

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -29,7 +29,7 @@ extern "C" {
 OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name);
 OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
                                  OSSL_provider_init_fn *init_function);
-int ossl_provider_upref(OSSL_PROVIDER *prov);
+int ossl_provider_up_ref(OSSL_PROVIDER *prov);
 void ossl_provider_free(OSSL_PROVIDER *prov);
 
 /* Setters */


### PR DESCRIPTION
Common pattern is that the routines to increment the reference count
are called something_up_ref, not something_upref.  Adapt
ossl_provider_upref() accordingly.
