### PR TITLE
Fix Typos (1.1.1)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -346,7 +346,7 @@
         SSL_set_ciphersuites()
      [Matt Caswell]
 
-  *) Memory allocation failures consistenly add an error to the error
+  *) Memory allocation failures consistently add an error to the error
      stack.
      [Rich Salz]
 

--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -1,6 +1,6 @@
 #### iPhoneOS/iOS
 #
-# It takes recent enough XCode to use following two targets. It shouldn't
+# It takes recent enough Xcode to use following two targets. It shouldn't
 # be a problem by now, but if they don't work, original targets below
 # that depend on manual definition of environment variables should still
 # work...

--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -1,6 +1,6 @@
 # Windows OneCore targets.
 #
-# OneCore is new API stability "contract" that transends Desktop, IoT and
+# OneCore is new API stability "contract" that transcends Desktop, IoT and
 # Mobile[?] Windows editions. It's a set up "umbrella" libraries that
 # export subset of Win32 API that are common to all Windows 10 devices.
 #

--- a/Configurations/common0.tmpl
+++ b/Configurations/common0.tmpl
@@ -22,7 +22,7 @@
  our @generated =
      sort ( ( grep { defined $unified_info{generate}->{$_} }
               sort keys %generatables ),
-            # Scripts are assumed to be generated, so add thhem too
+            # Scripts are assumed to be generated, so add them too
             ( grep { defined $unified_info{sources}->{$_} }
               @{$unified_info{scripts}} ) );
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -838,7 +838,7 @@ static int alg_print(const X509_ALGOR *alg)
                 goto done;
             }
             BIO_printf(bio_err, ", Salt length: %d, Cost(N): %ld, "
-                       "Block size(r): %ld, Paralelizm(p): %ld",
+                       "Block size(r): %ld, Parallelism(p): %ld",
                        ASN1_STRING_length(kdf->salt),
                        ASN1_INTEGER_get(kdf->costParameter),
                        ASN1_INTEGER_get(kdf->blockSize),

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1790,7 +1790,7 @@ int speed_main(int argc, char **argv)
         }
 
         buflen = lengths[size_num - 1];
-        if (buflen < 36)    /* size of random vector in RSA bencmark */
+        if (buflen < 36)    /* size of random vector in RSA benchmark */
             buflen = 36;
         buflen += MAX_MISALIGNMENT + 1;
         loopargs[i].buf_malloc = app_malloc(buflen, "input buffer");

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -125,7 +125,7 @@ int storeutl_main(int argc, char *argv[])
                 }
                 /*
                  * If expected wasn't set at this point, it means the map
-                 * isn't syncronised with the possible options leading here.
+                 * isn't synchronised with the possible options leading here.
                  */
                 OPENSSL_assert(expected != 0);
             }

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -38,14 +38,14 @@
 # Implement AES_set_[en|de]crypt_key. Key schedule setup is avoided
 # for 128-bit keys, if hardware support is detected.
 
-# Januray 2009.
+# January 2009.
 #
 # Add support for hardware AES192/256 and reschedule instructions to
 # minimize/avoid Address Generation Interlock hazard and to favour
 # dual-issue z10 pipeline. This gave ~25% improvement on z10 and
 # almost 50% on z9. The gain is smaller on z10, because being dual-
 # issue z10 makes it impossible to eliminate the interlock condition:
-# critial path is not long enough. Yet it spends ~24 cycles per byte
+# critical path is not long enough. Yet it spends ~24 cycles per byte
 # processed with 128-bit key.
 #
 # Unlike previous version hardware support detection takes place only

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -67,7 +67,7 @@ static void determine_days(struct tm *tm)
     }
     c = y / 100;
     y %= 100;
-    /* Zeller's congruance */
+    /* Zeller's congruence */
     tm->tm_wday = (d + (13 * m) / 5 + y + y / 4 + c / 4 + 5 * c + 6) % 7;
 }
 

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -784,7 +784,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
      * reasons. When BIO_CTRL_DGRAM_SET_PEEK_MODE was first defined its value
      * was incorrectly clashing with BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE. The
      * value has been updated to a non-clashing value. However to preserve
-     * binary compatiblity we now respond to both the old value and the new one
+     * binary compatibility we now respond to both the old value and the new one
      */
     case BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE:
     case BIO_CTRL_DGRAM_SET_PEEK_MODE:

--- a/crypto/bn/asm/mips.pl
+++ b/crypto/bn/asm/mips.pl
@@ -801,7 +801,7 @@ $code.=<<___;
 #if 0
 /*
  * The bn_div_3_words entry point is re-used for constant-time interface.
- * Implementation is retained as hystorical reference.
+ * Implementation is retained as historical reference.
  */
 .align 5
 .globl	bn_div_3_words

--- a/crypto/bn/bn_div.c
+++ b/crypto/bn/bn_div.c
@@ -258,7 +258,7 @@ int BN_div(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num, const BIGNUM *divisor,
  *
  *     - availability of constant-time bn_div_3_words;
  *     - dividend is at least as "wide" as divisor, limb-wise, zero-padded
- *       if so requied, which shouldn't be a privacy problem, because
+ *       if so required, which shouldn't be a privacy problem, because
  *       divisor's length is considered public;
  */
 int bn_div_fixed_top(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num,

--- a/crypto/bn/bn_lcl.h
+++ b/crypto/bn/bn_lcl.h
@@ -295,7 +295,7 @@ struct bn_gencb_st {
                  (b) >  23 ? 3 : 1)
 
 /*
- * BN_mod_exp_mont_conttime is based on the assumption that the L1 data cache
+ * BN_mod_exp_mont_consttime is based on the assumption that the L1 data cache
  * line width of the target processor is at least the following value.
  */
 # define MOD_EXP_CTIME_MIN_CACHE_LINE_WIDTH      ( 64 )

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -248,7 +248,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
      * one bit longer than the modulus.
      *
      * There are some concerns about the efficacy of doing this.  More
-     * specificly refer to the discussion starting with:
+     * specifically refer to the discussion starting with:
      *     https://github.com/openssl/openssl/pull/7486#discussion_r228323705
      * The fix is to rework BN so these gymnastics aren't required.
      */

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -1301,7 +1301,7 @@ ecp_nistz256_ord_mul_montx:
 
 	################################# reduction
 	mulx	8*0+128(%r14), $t0, $t1
-	adcx	$t0, $acc3		# guranteed to be zero
+	adcx	$t0, $acc3		# guaranteed to be zero
 	adox	$t1, $acc4
 
 	mulx	8*1+128(%r14), $t0, $t1

--- a/crypto/ec/asm/x25519-ppc64.pl
+++ b/crypto/ec/asm/x25519-ppc64.pl
@@ -451,7 +451,7 @@ x25519_fe64_tobytes:
 	and	$t0,$t0,$t1
 	sldi	$a3,$a3,1
 	add	$t0,$t0,$t1		# compare to modulus in the same go
-	srdi	$a3,$a3,1		# most signifcant bit cleared
+	srdi	$a3,$a3,1		# most significant bit cleared
 
 	addc	$a0,$a0,$t0
 	addze	$a1,$a1
@@ -462,7 +462,7 @@ x25519_fe64_tobytes:
 	sradi	$t0,$a3,63		# most significant bit -> mask
 	sldi	$a3,$a3,1
 	andc	$t0,$t1,$t0
-	srdi	$a3,$a3,1		# most signifcant bit cleared
+	srdi	$a3,$a3,1		# most significant bit cleared
 
 	subi	$rp,$rp,1
 	subfc	$a0,$t0,$a0

--- a/crypto/ec/ec_lcl.h
+++ b/crypto/ec/ec_lcl.h
@@ -154,7 +154,7 @@ struct ec_method_st {
     int (*field_div) (const EC_GROUP *, BIGNUM *r, const BIGNUM *a,
                       const BIGNUM *b, BN_CTX *);
     /*-
-     * 'field_inv' computes the multipicative inverse of a in the field,
+     * 'field_inv' computes the multiplicative inverse of a in the field,
      * storing the result in r.
      *
      * If 'a' is zero (or equivalent), you'll get an EC_R_CANNOT_INVERT error.

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1269,7 +1269,7 @@ static void point_add(felem x3, felem y3, felem z3,
          * ffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb
          * 71e913863f7, in that case the penultimate intermediate is -9G and
          * the final digit is also -9G. Since this only happens for a single
-         * scalar, the timing leak is irrelevent. (Any attacker who wanted to
+         * scalar, the timing leak is irrelevant. (Any attacker who wanted to
          * check whether a secret scalar was that exact value, can already do
          * so.)
          */

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -532,7 +532,7 @@ static int ecd_item_sign25519(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
     X509_ALGOR_set0(alg1, OBJ_nid2obj(NID_ED25519), V_ASN1_UNDEF, NULL);
     if (alg2)
         X509_ALGOR_set0(alg2, OBJ_nid2obj(NID_ED25519), V_ASN1_UNDEF, NULL);
-    /* Algorithm idetifiers set: carry on as normal */
+    /* Algorithm identifiers set: carry on as normal */
     return 3;
 }
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -40,7 +40,7 @@ static int stopped = 0;
  * destructor for threads terminating before libcrypto is initialized or
  * after it's de-initialized. Access to the key doesn't have to be
  * serialized for the said threads, because they didn't use libcrypto
- * and it doesn't matter if they pick "impossible" or derefernce real
+ * and it doesn't matter if they pick "impossible" or dereference real
  * key value and pull NULL past initialization in the first thread that
  * intends to use libcrypto.
  */

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -19,14 +19,14 @@
 
 /*
  * A hashing implementation that appears to be based on the linear hashing
- * alogrithm:
+ * algorithm:
  * https://en.wikipedia.org/wiki/Linear_hashing
  *
  * Litwin, Witold (1980), "Linear hashing: A new tool for file and table
  * addressing", Proc. 6th Conference on Very Large Databases: 212-223
- * http://hackthology.com/pdfs/Litwin-1980-Linear_Hashing.pdf
+ * https://hackthology.com/pdfs/Litwin-1980-Linear_Hashing.pdf
  *
- * From the wikipedia article "Linear hashing is used in the BDB Berkeley
+ * From the Wikipedia article "Linear hashing is used in the BDB Berkeley
  * database system, which in turn is used by many software systems such as
  * OpenLDAP, using a C implementation derived from the CACM article and first
  * published on the Usenet in 1988 by Esmond Pitt."

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -318,7 +318,7 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
     /*
      * NIST SP800-90Ar1 section 9.1 says you can combine getting the entropy
      * and nonce in 1 call by increasing the entropy with 50% and increasing
-     * the minimum length to accomadate the length of the nonce.
+     * the minimum length to accommodate the length of the nonce.
      * We do this in case a nonce is require and get_nonce is NULL.
      */
     if (drbg->min_noncelen > 0 && drbg->get_nonce == NULL) {

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -363,7 +363,7 @@ void rand_cleanup_int(void)
 }
 
 /*
- * RAND_close_seed_files() ensures that any seed file decriptors are
+ * RAND_close_seed_files() ensures that any seed file descriptors are
  * closed after use.
  */
 void RAND_keep_random_devices_open(int keep)

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -250,7 +250,7 @@ static int rsa_builtin_keygen(RSA *rsa, int bits, int primes, BIGNUM *e_value,
              *
              * This strategy has the following goals:
              *
-             * 1. 1024-bit factors are effcient when using 3072 and 4096-bit key
+             * 1. 1024-bit factors are efficient when using 3072 and 4096-bit key
              * 2. stay the same logic with normal 2-prime key
              */
             bitse -= bitsr[i];

--- a/crypto/sha/asm/sha512-sparcv9.pl
+++ b/crypto/sha/asm/sha512-sparcv9.pl
@@ -27,7 +27,7 @@
 # over 2x than 32-bit code. X[16] resides on stack, but access to it
 # is scheduled for L2 latency and staged through 32 least significant
 # bits of %l0-%l7. The latter is done to achieve 32-/64-bit ABI
-# duality. Nevetheless it's ~40% faster than SHA256, which is pretty
+# duality. Nevertheless it's ~40% faster than SHA256, which is pretty
 # good [optimal coefficient is 50%].
 #
 # SHA512 on UltraSPARC T1.

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -313,12 +313,12 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
 
     /*
      * B1: verify whether r' in [1,n-1], verification failed if not
-     * B2: vefify whether s' in [1,n-1], verification failed if not
+     * B2: verify whether s' in [1,n-1], verification failed if not
      * B3: set M'~=ZA || M'
      * B4: calculate e'=Hv(M'~)
      * B5: calculate t = (r' + s') modn, verification failed if t=0
      * B6: calculate the point (x1', y1')=[s']G + [t]PA
-     * B7: calculate R=(e'+x1') modn, verfication pass if yes, otherwise failed
+     * B7: calculate R=(e'+x1') modn, verification pass if yes, otherwise failed
      */
 
     ECDSA_SIG_get0(sig, &r, &s);

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -172,7 +172,7 @@ typedef OSSL_STORE_INFO *(*file_try_decode_fn)(const char *pem_name,
 typedef int (*file_eof_fn)(void *handler_ctx);
 /*
  * The destroy_ctx function is used to destroy the handler_ctx that was
- * intiated by a repeatable try_decode fuction.  This is only used when
+ * initiated by a repeatable try_decode function.  This is only used when
  * the handler is marked repeatable.
  */
 typedef void (*file_destroy_ctx_fn)(void **handler_ctx);
@@ -470,7 +470,7 @@ static FILE_HANDLER PrivateKey_handler = {
 };
 
 /*
- * Public key decoder.  Only supports SubjectPublicKeyInfo formated keys.
+ * Public key decoder.  Only supports SubjectPublicKeyInfo formatted keys.
  */
 static OSSL_STORE_INFO *try_decode_PUBKEY(const char *pem_name,
                                           const char *pem_header,

--- a/demos/bio/descrip.mms
+++ b/demos/bio/descrip.mms
@@ -37,7 +37,7 @@ server-arg.exe : server-arg.obj
 server-cmod.exe : server-cmod.obj
 server-conf.exe : server-conf.obj
 
-# Stoopid MMS doesn't infer this automatically...
+# MMS doesn't infer this automatically...
 client-arg.obj : client-arg.c
 client-conf.obj : client-conf.c
 saccept.obj : saccept.c

--- a/demos/evp/aesgcm.c
+++ b/demos/evp/aesgcm.c
@@ -84,7 +84,7 @@ void aes_gcm_decrypt(void)
     EVP_CIPHER_CTX *ctx;
     int outlen, tmplen, rv;
     unsigned char outbuf[1024];
-    printf("AES GCM Derypt:\n");
+    printf("AES GCM Decrypt:\n");
     printf("Ciphertext:\n");
     BIO_dump_fp(stdout, gcm_ct, sizeof(gcm_ct));
     ctx = EVP_CIPHER_CTX_new();

--- a/doc/man3/ADMISSIONS.pod
+++ b/doc/man3/ADMISSIONS.pod
@@ -130,7 +130,7 @@ ADMISSION_SYNTAX_set0_contentsOfAdmissions()
 functions free any existing value and set the pointer to the specified value.
 
 The B<ADMISSION> type has an authority name, authority object, and a
-stack of B<PROFSSION_INFO> items.
+stack of B<PROFESSION_INFO> items.
 The ADMISSIONS_get0_admissionAuthority(), ADMISSIONS_get0_namingAuthority(),
 and ADMISSIONS_get0_professionInfos()
 functions return pointers to those values within the object.

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -109,7 +109,7 @@ Calling BIO_reset() on a read write memory BIO with BIO_FLAGS_NONCLEAR_RST
 flag set can have unexpected outcome when the reads and writes to the
 BIO are intertwined. As documented above the BIO will be reset to the
 state after the last completed write operation. The effects of reads
-preceeding that write operation cannot be undone.
+preceding that write operation cannot be undone.
 
 Calling BIO_get_mem_ptr() prior to a BIO_reset() call with
 BIO_FLAGS_NONCLEAR_RST set has the same effect as a write operation.

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -35,7 +35,7 @@ EVP_MD_CTX is freed).
 
 The digest B<type> may be NULL if the signing algorithm supports it.
 
-No B<EVP_PKEY_CTX> will be created by EVP_DigsetSignInit() if the passed B<ctx>
+No B<EVP_PKEY_CTX> will be created by EVP_DigestSignInit() if the passed B<ctx>
 has already been assigned one via L<EVP_MD_CTX_set_ctx(3)>. See also L<SM2(7)>.
 
 Only EVP_PKEY types that support signing can be used with these functions. This

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -32,7 +32,7 @@ being passed to EVP_DigestVerifyInit() (which means the EVP_PKEY_CTX is created
 inside EVP_DigestVerifyInit() and it will be freed automatically when the
 EVP_MD_CTX is freed).
 
-No B<EVP_PKEY_CTX> will be created by EVP_DigsetSignInit() if the passed B<ctx>
+No B<EVP_PKEY_CTX> will be created by EVP_DigestSignInit() if the passed B<ctx>
 has already been assigned one via L<EVP_MD_CTX_set_ctx(3)>. See also L<SM2(7)>.
 
 EVP_DigestVerifyUpdate() hashes B<cnt> bytes of data at B<d> into the

--- a/doc/man3/EVP_md5.pod
+++ b/doc/man3/EVP_md5.pod
@@ -29,7 +29,7 @@ The MD5 algorithm which produces a 128-bit output from a given input.
 
 =item EVP_md5_sha1()
 
-A hash algorithm of SSL v3 that combines MD5 with SHA-1 as decirbed in RFC
+A hash algorithm of SSL v3 that combines MD5 with SHA-1 as described in RFC
 6101.
 
 WARNING: this algorithm is not intended for non-SSL usage.

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -95,7 +95,7 @@ manner possible according to the scheme the loader implements, it also
 takes a B<UI_METHOD> and associated data, to be used any time
 something needs to be prompted for.
 Furthermore, this function is expected to initialize what needs to be
-initialized, to create a privata data store (B<OSSL_STORE_LOADER_CTX>, see
+initialized, to create a private data store (B<OSSL_STORE_LOADER_CTX>, see
 above), and to return it.
 If something goes wrong, this function is expected to return NULL.
 

--- a/doc/man3/OSSL_STORE_expect.pod
+++ b/doc/man3/OSSL_STORE_expect.pod
@@ -32,7 +32,7 @@ grained search of objects.
 
 OSSL_STORE_supports_search() checks if the loader of the given OSSL_STORE
 context supports the given search type.
-See L<OSSL_STORE_SEARCH/SUPPORED CRITERION TYPES> for information on the
+See L<OSSL_STORE_SEARCH/SUPPORTED CRITERION TYPES> for information on the
 supported search criterion types.
 
 OSSL_STORE_expect() and OSSL_STORE_find I<must> be called before the first

--- a/doc/man3/RAND_DRBG_set_callbacks.pod
+++ b/doc/man3/RAND_DRBG_set_callbacks.pod
@@ -114,7 +114,7 @@ In other words, prediction resistance is currently not supported yet by the DRBG
 The derivation function is disabled during initialization by calling the
 RAND_DRBG_set() function with the RAND_DRBG_FLAG_CTR_NO_DF flag.
 For more information on the derivation function and when it can be omitted,
-see [NIST SP 800-90A Rev. 1]. Roughly speeking it can be omitted if the random
+see [NIST SP 800-90A Rev. 1]. Roughly speaking it can be omitted if the random
 source has "full entropy", i.e., contains 8 bits of entropy per byte.
 
 Even if a nonce is required, the B<get_nonce>() and B<cleanup_nonce>()

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -31,7 +31,7 @@ B<ssl>.
 
 SSL_CTX_set_ciphersuites() is used to configure the available TLSv1.3
 ciphersuites for B<ctx>. This is a simple colon (":") separated list of TLSv1.3
-ciphersuite names in order of perference. Valid TLSv1.3 ciphersuite names are:
+ciphersuite names in order of preference. Valid TLSv1.3 ciphersuite names are:
 
 =over 4
 

--- a/doc/man3/SSL_SESSION_get0_hostname.pod
+++ b/doc/man3/SSL_SESSION_get0_hostname.pod
@@ -6,7 +6,7 @@ SSL_SESSION_get0_hostname,
 SSL_SESSION_set1_hostname,
 SSL_SESSION_get0_alpn_selected,
 SSL_SESSION_set1_alpn_selected
-- get and set SNI and ALPN data ssociated with a session
+- get and set SNI and ALPN data associated with a session
 
 =head1 SYNOPSIS
 

--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -72,7 +72,7 @@
  * function defined via DEFINE_ONCE_STATIC where both functions use the same
  * CRYPTO_ONCE object to synchronise. Where an alternative initialiser function
  * is used only one of the primary or the alternative initialiser function will
- * ever be called - and that function will be called exactly once. Definitition
+ * ever be called - and that function will be called exactly once. Definition
  * of an alternative initialiser function MUST occur AFTER the definition of the
  * primary initialiser function.
  *

--- a/include/internal/tsan_assist.h
+++ b/include/internal/tsan_assist.h
@@ -18,7 +18,7 @@
  * if (var == NOT_YET_INITIALIZED)
  *     var = function_returning_same_value();
  *
- * This does work provided that loads and stores are single-instuction
+ * This does work provided that loads and stores are single-instruction
  * operations (and integer ones are on *all* supported platforms), but
  * it upsets Thread Sanitizer. Suggested solution is
  *

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -24,8 +24,8 @@ struct testdata {
     int expected_type;      /* expected type after set/set_string_gmt */
     int check_result;       /* check result */
     time_t t;               /* expected time_t*/
-    int cmp_result;         /* compariston to baseline result */
-    int convert_result;     /* convertion result */
+    int cmp_result;         /* comparison to baseline result */
+    int convert_result;     /* conversion result */
 };
 
 static struct testdata tbl_testdata_pos[] = {

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -293,7 +293,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
      * Personalisation string tests
      */
 
-    /* Test detection of too large personlisation string */
+    /* Test detection of too large personalisation string */
     if (!init(drbg, td, &t)
             || RAND_DRBG_instantiate(drbg, td->pers, drbg->max_perslen + 1) > 0)
         goto err;

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -96,7 +96,7 @@ static int test_dtls_unprocessed(int testidx)
 
     /*
      * Create the connection. We use "create_bare_ssl_connection" here so that
-     * we can force the connection to not do "SSL_read" once partly conencted.
+     * we can force the connection to not do "SSL_read" once partly connected.
      * We don't want to accidentally read the dummy records we injected because
      * they will fail to decrypt.
      */

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -920,7 +920,7 @@ int create_ssl_connection(SSL *serverssl, SSL *clientssl, int want)
     /*
      * We attempt to read some data on the client side which we expect to fail.
      * This will ensure we have received the NewSessionTicket in TLSv1.3 where
-     * appropriate. We do this twice because there are 2 NewSesionTickets.
+     * appropriate. We do this twice because there are 2 NewSessionTickets.
      */
     for (i = 0; i < 2; i++) {
         if (SSL_read_ex(clientssl, &buf, sizeof(buf), &readbytes) > 0) {

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -27,7 +27,7 @@
 #define KEYLEN  16
 
 /*
- * Based on the test vectors availble in:
+ * Based on the test vectors available in:
  * https://tools.ietf.org/html/draft-ietf-tls-tls13-vectors-06
  */
 

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -164,13 +164,13 @@ C<indir> takes some additional options OPTS that affect the subdirectory:
 
 =item B<create =E<gt> 0|1>
 
-When set to 1 (or any value that perl preceives as true), the subdirectory
+When set to 1 (or any value that perl perceives as true), the subdirectory
 will be created if it doesn't already exist.  This happens before BLOCK
 is executed.
 
 =item B<cleanup =E<gt> 0|1>
 
-When set to 1 (or any value that perl preceives as true), the subdirectory
+When set to 1 (or any value that perl perceives as true), the subdirectory
 will be cleaned out and removed.  This happens both before and after BLOCK
 is executed.
 


### PR DESCRIPTION
Reapplying #9288 on branch 1.1.1, with minor differences due to some files not existing in one branch or another.

##### Checklist
- [x] documentation is added or updated
