### PR TITLE
Prevent the use of RUN_ONCE inside the FIPS module

### DIFF
--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -10,6 +10,13 @@
 #include <openssl/crypto.h>
 
 /*
+ * Initialisation of global data should never happen via "RUN_ONCE" inside the
+ * FIPS module. Global data should instead always be associated with a specific
+ * OPENSSL_CTX object. In this way data will get cleaned up correctly when the
+ * module gets unloaded.
+ */
+#ifndef FIPS_MODE
+/*
  * DEFINE_RUN_ONCE: Define an initialiser function that should be run exactly
  * once. It takes no arguments and returns and int result (1 for success or
  * 0 for failure). Typical usage might be:
@@ -23,7 +30,7 @@
  *     return 0;
  * }
  */
-#define DEFINE_RUN_ONCE(init)                   \
+# define DEFINE_RUN_ONCE(init)                   \
     static int init(void);                     \
     int init##_ossl_ret_ = 0;                   \
     void init##_ossl_(void)                     \
@@ -36,7 +43,7 @@
  * DECLARE_RUN_ONCE: Declare an initialiser function that should be run exactly
  * once that has been defined in another file via DEFINE_RUN_ONCE().
  */
-#define DECLARE_RUN_ONCE(init)                  \
+# define DECLARE_RUN_ONCE(init)                  \
     extern int init##_ossl_ret_;                \
     void init##_ossl_(void);
 
@@ -55,7 +62,7 @@
  *     return 0;
  * }
  */
-#define DEFINE_RUN_ONCE_STATIC(init)            \
+# define DEFINE_RUN_ONCE_STATIC(init)            \
     static int init(void);                     \
     static int init##_ossl_ret_ = 0;            \
     static void init##_ossl_(void)              \
@@ -96,7 +103,7 @@
  *     return 0;
  * }
  */
-#define DEFINE_RUN_ONCE_STATIC_ALT(initalt, init) \
+# define DEFINE_RUN_ONCE_STATIC_ALT(initalt, init) \
     static int initalt(void);                     \
     static void initalt##_ossl_(void)             \
     {                                             \
@@ -115,7 +122,7 @@
  *
  * (*) by convention, since the init function must return 1 on success.
  */
-#define RUN_ONCE(once, init)                                            \
+# define RUN_ONCE(once, init)                                            \
     (CRYPTO_THREAD_run_once(once, init##_ossl_) ? init##_ossl_ret_ : 0)
 
 /*
@@ -133,5 +140,7 @@
  *
  * (*) by convention, since the init function must return 1 on success.
  */
-#define RUN_ONCE_ALT(once, initalt, init)                               \
+# define RUN_ONCE_ALT(once, initalt, init)                               \
     (CRYPTO_THREAD_run_once(once, initalt##_ossl_) ? init##_ossl_ret_ : 0)
+
+#endif /* FIPS_MODE */


### PR DESCRIPTION
FIPS module code *always* runs within the scope of an associated
OPENSSL_CTX. When the module is loaded the OPENSSL_CTX gets created, and
when the module is unloaded the OPENSSL_CX gets freed. A module may be
loaded multiple times within the scope of different OPENSSL_CTX objects.
"Global" data should always be stored within the OPENSSL_CTX. In this
way it will always get cleaned up properly when the module is unloaded.

All current code within the FIPS module works this way. To avoid
"accidents" we disabled the RUN_ONCE code inside the FIPS module.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
