### PR TITLE
Extra level of indirection for string _PTR param types removed.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -824,69 +824,70 @@ OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
     return ossl_param_construct(key, OSSL_PARAM_OCTET_STRING, buf, bsize);
 }
 
-static int get_ptr_internal(const OSSL_PARAM *p, const void **val,
-                            size_t *used_len, unsigned int type)
+static int get_const_internal(const OSSL_PARAM *p, const void **val,
+                              size_t *used_len, unsigned int type)
 {
     if (val == NULL || p == NULL || p->data_type != type)
         return 0;
     if (used_len != NULL)
         *used_len = p->data_size;
-    *val = *(const void **)p->data;
+    *val = p->data;
     return 1;
 }
 
-int OSSL_PARAM_get_utf8_ptr(const OSSL_PARAM *p, const char **val)
+int OSSL_PARAM_get_utf8_const(const OSSL_PARAM *p, const char **val)
 {
-    return get_ptr_internal(p, (const void **)val, NULL, OSSL_PARAM_UTF8_PTR);
+    return get_const_internal(p, (const void **)val, NULL,
+                              OSSL_PARAM_UTF8_CONST);
 }
 
-int OSSL_PARAM_get_octet_ptr(const OSSL_PARAM *p, const void **val,
-                             size_t *used_len)
+int OSSL_PARAM_get_octet_const(const OSSL_PARAM *p, const void **val,
+                               size_t *used_len)
 {
-    return get_ptr_internal(p, val, used_len, OSSL_PARAM_OCTET_PTR);
+    return get_const_internal(p, val, used_len, OSSL_PARAM_OCTET_CONST);
 }
 
-static int set_ptr_internal(OSSL_PARAM *p, const void *val,
-                            unsigned int type, size_t len)
+static int set_const_internal(OSSL_PARAM *p, const void *val,
+                              unsigned int type, size_t len)
 {
     p->return_size = len;
     if (p->data_type != type)
         return 0;
-    *(const void **)p->data = val;
+    p->data = (void *)val;
     return 1;
 }
 
-int OSSL_PARAM_set_utf8_ptr(OSSL_PARAM *p, const char *val)
+int OSSL_PARAM_set_utf8_const(OSSL_PARAM *p, const char *val)
 {
     if (p == NULL)
         return 0;
     p->return_size = 0;
     if (val == NULL)
         return 0;
-    return set_ptr_internal(p, val, OSSL_PARAM_UTF8_PTR, strlen(val) + 1);
+    return set_const_internal(p, val, OSSL_PARAM_UTF8_CONST, strlen(val) + 1);
 }
 
-int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
-                             size_t used_len)
+int OSSL_PARAM_set_octet_const(OSSL_PARAM *p, const void *val,
+                               size_t used_len)
 {
     if (p == NULL)
         return 0;
     p->return_size = 0;
     if (val == NULL)
         return 0;
-    return set_ptr_internal(p, val, OSSL_PARAM_OCTET_PTR, used_len);
+    return set_const_internal(p, val, OSSL_PARAM_OCTET_CONST, used_len);
 }
 
-OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
-                                         size_t bsize)
+OSSL_PARAM OSSL_PARAM_construct_utf8_const(const char *key, char *buf,
+                                           size_t bsize)
 {
-    return ossl_param_construct(key, OSSL_PARAM_UTF8_PTR, buf, bsize);
+    return ossl_param_construct(key, OSSL_PARAM_UTF8_CONST, buf, bsize);
 }
 
-OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
-                                          size_t bsize)
+OSSL_PARAM OSSL_PARAM_construct_octet_const(const char *key, void *buf,
+                                            size_t bsize)
 {
-    return ossl_param_construct(key, OSSL_PARAM_OCTET_PTR, buf, bsize);
+    return ossl_param_construct(key, OSSL_PARAM_OCTET_CONST, buf, bsize);
 }
 
 OSSL_PARAM OSSL_PARAM_construct_end(void)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -630,8 +630,8 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
  * never knows.
  */
 static const OSSL_ITEM param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, "openssl-version" },
-    { OSSL_PARAM_UTF8_PTR, "provider-name" },
+    { OSSL_PARAM_UTF8_CONST, "openssl-version" },
+    { OSSL_PARAM_UTF8_CONST, "provider-name" },
     { 0, NULL }
 };
 
@@ -646,9 +646,9 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate(params, "openssl-version")) != NULL)
-        OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR);
+        OSSL_PARAM_set_utf8_const(p, OPENSSL_VERSION_STR);
     if ((p = OSSL_PARAM_locate(params, "provider-name")) != NULL)
-        OSSL_PARAM_set_utf8_ptr(p, prov->name);
+        OSSL_PARAM_set_utf8_const(p, prov->name);
 
     if (prov->parameters == NULL)
         return 1;
@@ -657,7 +657,7 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
         INFOPAIR *pair = sk_INFOPAIR_value(prov->parameters, i);
 
         if ((p = OSSL_PARAM_locate(params, pair->name)) != NULL)
-            OSSL_PARAM_set_utf8_ptr(p, pair->value);
+            OSSL_PARAM_set_utf8_const(p, pair->value);
     }
 
     return 1;

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -128,7 +128,7 @@ The parameter data is a printable string.
 
 The parameter data is an arbitrary string of bytes.
 
-=item C<OSSL_PARAM_UTF8_PTR>
+=item C<OSSL_PARAM_UTF8_CONST>
 
 The parameter data is a pointer to a printable string.
 
@@ -150,7 +150,7 @@ used for data that remains constant and in a constant location for a
 long enough duration (such as the life-time of the entity that
 offers these parameters).
 
-=item C<OSSL_PARAM_OCTET_PTR>
+=item C<OSSL_PARAM_OCTET_CONST>
 
 The parameter data is a pointer to an arbitrary string of bytes.
 
@@ -242,11 +242,10 @@ This example is for setting parameters on some object:
 
     #include <openssl/core.h>
 
-    const char *foo = "some string";
-    size_t foo_l = strlen(foo) + 1;
+    const char foo[] = "some string";
     const char bar[] = "some other string";
     OSSL_PARAM set[] = {
-        { "foo", OSSL_PARAM_UTF8_STRING_PTR, &foo, foo_l, 0 },
+        { "foo", OSSL_PARAM_UTF8_STRING_CONST, foo, sizeof(foo), 0 },
         { "bar", OSSL_PARAM_UTF8_STRING, &bar, sizeof(bar), 0 },
         { NULL, 0, NULL, 0, NULL }
     };
@@ -260,7 +259,7 @@ This example is for requesting parameters on some object:
     char bar[1024];
     size_t bar_l;
     OSSL_PARAM request[] = {
-        { "foo", OSSL_PARAM_UTF8_STRING_PTR, &foo, 0 /*irrelevant*/, 0 },
+        { "foo", OSSL_PARAM_UTF8_STRING_CONST, NULL, 0 /*irrelevant*/, 0 },
         { "bar", OSSL_PARAM_UTF8_STRING, &bar, sizeof(bar), 0 },
         { NULL, 0, NULL, 0, NULL }
     };
@@ -274,7 +273,7 @@ could fill in the parameters like this:
 
     for (i = 0; params[i].key != NULL; i++) {
         if (strcmp(params[i].key, "foo") == 0) {
-            *(char **)params[i].data = "foo value";
+            params[i].data = "foo value";
             params[i].return_size = 10; /* size of "foo value" */
         } else if (strcmp(params[i].key, "bar") == 0) {
             memcpy(params[i].data, "bar value", 10);

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -130,20 +130,12 @@ The parameter data is an arbitrary string of bytes.
 
 =item C<OSSL_PARAM_UTF8_CONST>
 
-The parameter data is a pointer to a printable string.
+The parameter is a pointer to a printable string.
 
 The difference between this and C<OSSL_PARAM_UTF8_STRING> is that C<data>
-doesn't point directly at the data, but to a pointer that points to the data.
-
-This is used to indicate that constant data is or will be passed,
-and there is therefore no need to copy the data that is passed, just
+is expected to remain unmodified.
+There is therefore no need to copy the data that is passed, just
 the pointer to it.
-
-C<data_size> must be set to the size of the data, not the size of the
-pointer to the data.
-If this is used in a parameter request,
-C<data_size> is not relevant.  However, the I<responder> will set
-C<return_size> to the size of the data.
 
 Note that the use of this type is B<fragile> and can only be safely
 used for data that remains constant and in a constant location for a
@@ -154,24 +146,16 @@ offers these parameters).
 
 The parameter data is a pointer to an arbitrary string of bytes.
 
-The difference between this and C<OSSL_PARAM_OCTET_STRING> is that
-C<data> doesn't point directly at the data, but to a pointer that
-points to the data.
-
-This is used to indicate that constant data is or will be passed, and
-there is therefore no need to copy the data that is passed, just the
-pointer to it.
-
-C<data_size> must be set to the size of the data, not the size of the
-pointer to the data.
-If this is used in a parameter request,
-C<data_size> is not relevant.  However, the I<responder> will set
-C<return_size> to the size of the data.
+The difference between this and C<OSSL_PARAM_OCTET_STRING> is that C<data>
+is expected to remain unmodified.
+There is therefore no need to copy the data that is passed, just
+the pointer to it.
 
 Note that the use of this type is B<fragile> and can only be safely
 used for data that remains constant and in a constant location for a
 long enough duration (such as the life-time of the entity that
 offers these parameters).
+
 
 =back
 

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -5,15 +5,15 @@
 OSSL_PARAM_double, OSSL_PARAM_int, OSSL_PARAM_int32, OSSL_PARAM_int64,
 OSSL_PARAM_long, OSSL_PARAM_size_t, OSSL_PARAM_uint, OSSL_PARAM_uint32,
 OSSL_PARAM_uint64, OSSL_PARAM_ulong, OSSL_PARAM_BN, OSSL_PARAM_utf8_string,
-OSSL_PARAM_octet_string, OSSL_PARAM_utf8_ptr, OSSL_PARAM_octet_ptr,
+OSSL_PARAM_octet_string, OSSL_PARAM_utf8_const, OSSL_PARAM_octet_const,
 OSSL_PARAM_END, OSSL_PARAM_construct_BN, OSSL_PARAM_construct_double,
 OSSL_PARAM_construct_int, OSSL_PARAM_construct_int32,
 OSSL_PARAM_construct_int64, OSSL_PARAM_construct_long,
 OSSL_PARAM_construct_size_t, OSSL_PARAM_construct_uint,
 OSSL_PARAM_construct_uint32, OSSL_PARAM_construct_uint64,
 OSSL_PARAM_construct_ulong, OSSL_PARAM_END, OSSL_PARAM_construct_BN,
-OSSL_PARAM_construct_utf8_string, OSSL_PARAM_construct_utf8_ptr,
-OSSL_PARAM_construct_octet_string, OSSL_PARAM_construct_octet_ptr,
+OSSL_PARAM_construct_utf8_string, OSSL_PARAM_construct_utf8_const,
+OSSL_PARAM_construct_octet_string, OSSL_PARAM_construct_octet_const,
 OSSL_PARAM_construct_end, OSSL_PARAM_locate, OSSL_PARAM_locate_const,
 OSSL_PARAM_get_double, OSSL_PARAM_get_int, OSSL_PARAM_get_int32,
 OSSL_PARAM_get_int64, OSSL_PARAM_get_long, OSSL_PARAM_get_size_t,
@@ -24,8 +24,8 @@ OSSL_PARAM_set_size_t, OSSL_PARAM_set_uint, OSSL_PARAM_set_uint32,
 OSSL_PARAM_set_uint64, OSSL_PARAM_set_ulong, OSSL_PARAM_get_BN,
 OSSL_PARAM_set_BN, OSSL_PARAM_get_utf8_string, OSSL_PARAM_set_utf8_string,
 OSSL_PARAM_get_octet_string, OSSL_PARAM_set_octet_string,
-OSSL_PARAM_get_utf8_ptr, OSSL_PARAM_set_utf8_ptr, OSSL_PARAM_get_octet_ptr,
-OSSL_PARAM_set_octet_ptr
+OSSL_PARAM_get_utf8_const, OSSL_PARAM_set_utf8_const,
+OSSL_PARAM_get_octet_const, OSSL_PARAM_set_octet_const
 - OSSL_PARAM helpers
 
 =head1 SYNOPSIS
@@ -37,8 +37,8 @@ OSSL_PARAM_set_octet_ptr
  #define OSSL_PARAM_TYPE(key, address)
  #define OSSL_PARAM_utf8_string(key, address, size)
  #define OSSL_PARAM_octet_string(key, address, size)
- #define OSSL_PARAM_utf8_ptr(key, address, size)
- #define OSSL_PARAM_octet_ptr(key, address, size)
+ #define OSSL_PARAM_utf8_const(key, address, size)
+ #define OSSL_PARAM_octet_const(key, address, size)
  #define OSSL_PARAM_BN(key, address, size)
  #define OSSL_PARAM_END
 
@@ -49,9 +49,9 @@ OSSL_PARAM_set_octet_ptr
                                              size_t bsize);
  OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
                                               size_t bsize);
- OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
-                                          size_t bsize);
- OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
+ OSSL_PARAM OSSL_PARAM_construct_utf8_const(const char *key, char *buf,
+                                            size_t bsize);
+ OSSL_PARAM OSSL_PARAM_construct_octet_const(const char *key, void *buf,
                                            size_t bsize);
  OSSL_PARAM OSSL_PARAM_construct_end(void);
 
@@ -73,12 +73,12 @@ OSSL_PARAM_set_octet_ptr
                                  size_t max_len, size_t *used_len);
  int OSSL_PARAM_set_octet_string(OSSL_PARAM *p, const void *val, size_t len);
 
- int OSSL_PARAM_get_utf8_ptr(const OSSL_PARAM *p, char **val);
- int OSSL_PARAM_set_utf8_ptr(OSSL_PARAM *p, char *val);
+ int OSSL_PARAM_get_utf8_const(const OSSL_PARAM *p, char **val);
+ int OSSL_PARAM_set_utf8_const(OSSL_PARAM *p, char *val);
 
- int OSSL_PARAM_get_octet_ptr(const OSSL_PARAM *p, void **val,
-                              size_t *used_len);
- int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, void *val, size_t used_len);
+ int OSSL_PARAM_get_octet_const(const OSSL_PARAM *p, void **val,
+                               size_t *used_len);
+ int OSSL_PARAM_set_octet_const(OSSL_PARAM *p, void *val, size_t used_len);
 
 =head1 DESCRIPTION
 
@@ -134,8 +134,8 @@ array of OSSL_PARAM structures.
 Each of these macros defines a parameter of the specified B<TYPE> with the
 provided B<key> and parameter variable B<address>.
 
-OSSL_PARAM_utf8_string(), OSSL_PARAM_octet_string(), OSSL_PARAM_utf8_ptr(),
-OSSL_PARAM_octet_ptr(), OSSL_PARAM_BN() are macros that provide support
+OSSL_PARAM_utf8_string(), OSSL_PARAM_octet_string(), OSSL_PARAM_utf8_const(),
+OSSL_PARAM_octet_const(), OSSL_PARAM_BN() are macros that provide support
 for defining UTF8 strings, OCTET strings and big numbers.
 A parameter with name B<key> is defined.
 The storage for this parameter is at B<address> and is of B<size> bytes.
@@ -163,14 +163,14 @@ string OSSL_PARAM structure.
 A parameter with name B<key>, storage B<buf>, size B<bsize> and return
 size B<rsize> is created.
 
-OSSL_PARAM_construct_utf8_ptr() is a function that constructes a UTF string
+OSSL_PARAM_construct_utf8_const() is a function that constructes a UTF string
 pointer OSSL_PARAM structure.
-A parameter with name B<key>, storage pointer B<*buf>, size B<bsize> and
+A parameter with name B<key>, storage pointer B<buf>, size B<bsize> and
 return size B<rsize> is created.
 
-OSSL_PARAM_construct_octet_ptr() is a function that constructes an OCTET string
-pointer OSSL_PARAM structure.
-A parameter with name B<key>, storage pointer B<*buf>, size B<bsize> and
+OSSL_PARAM_construct_octet_const() is a function that constructes an OCTET
+string pointer OSSL_PARAM structure.
+A parameter with name B<key>, storage pointer B<buf>, size B<bsize> and
 return size B<rsize> is created.
 
 OSSL_PARAM_construct_end() is a function that constructs the terminating
@@ -216,17 +216,17 @@ If memory is allocated by this function, it must be freed by the caller.
 OSSL_PARAM_set_octet_string() sets an OCTET string from the parameter
 pointed to by B<p> to the value referenced by B<val>.
 
-OSSL_PARAM_get_utf8_ptr() retrieves the UTF8 string pointer from the parameter
+OSSL_PARAM_get_utf8_const() retrieves the UTF8 string pointer from the parameter
 referenced by B<p> and stores it in B<*val>.
 
-OSSL_PARAM_set_utf8_ptr() sets the UTF8 string pointer in the parameter
+OSSL_PARAM_set_utf8_const() sets the UTF8 string pointer in the parameter
 referenced by B<p> to the values B<val>.
 
-OSSL_PARAM_get_octet_ptr() retrieves the OCTET string pointer from the parameter
-referenced by B<p> and stores it in B<*val>.
+OSSL_PARAM_get_octet_const() retrieves the OCTET string pointer from the
+parameter referenced by B<p> and stores it in B<*val>.
 The length of the OCTET string is stored in B<*used_len>.
 
-OSSL_PARAM_set_octet_ptr() sets the OCTET string pointer in the parameter
+OSSL_PARAM_set_octet_const() sets the OCTET string pointer in the parameter
 referenced by B<p> to the values B<val>.
 The length of the OCTET string is provided by B<used_len>.
 
@@ -234,7 +234,7 @@ The length of the OCTET string is provided by B<used_len>.
 
 OSSL_PARAM_construct_TYPE(), OSSL_PARAM_construct_BN(),
 OSSL_PARAM_construct_utf8_string(), OSSL_PARAM_construct_octet_string(),
-OSSL_PARAM_construct_utf8_ptr() and OSSL_PARAM_construct_octet_ptr()
+OSSL_PARAM_construct_utf8_const() and OSSL_PARAM_construct_octet_const()
 return a populated OSSL_PARAM structure.
 
 OSSL_PARAM_locate() and OSSL_PARAM_locate_const() return a pointer to
@@ -250,7 +250,7 @@ representable by the target type or parameter.
 Apart from that, the functions must be used appropriately for the
 expected type of the parameter.
 
-For OSSL_PARAM_get_utf8_ptr() and OSSL_PARAM_get_octet_ptr(), B<bsize>
+For OSSL_PARAM_get_utf8_const() and OSSL_PARAM_get_octet_const(), B<bsize>
 is not relevant if the purpose is to send the B<OSSL_PARAM> array to a
 I<responder>, i.e. to get parameter data back.
 In that case, B<bsize> can safely be given zero.
@@ -273,7 +273,7 @@ This example is for setting parameters on some object:
     size_t foo_l = strlen(foo) + 1;
     const char bar[] = "some other string";
     const OSSL_PARAM set[] = {
-        OSSL_PARAM_utf8_ptr("foo", foo, foo_l),
+        OSSL_PARAM_utf8_const("foo", foo, foo_l),
         OSSL_PARAM_utf8_string("bar", bar, sizeof(bar)),
         OSSL_PARAM_END
     };
@@ -287,7 +287,7 @@ available parameters:
     const char *foo = NULL;
     char bar[1024];
     OSSL_PARAM request[] = {
-        OSSL_PARAM_utf8_ptr("foo", foo, 0),
+        OSSL_PARAM_utf8_const("foo", foo, 0),
         OSSL_PARAM_utf8_string("bar", bar, sizeof(bar)),
         OSSL_PARAM_END
     };
@@ -300,11 +300,11 @@ could fill in the parameters like this:
     OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate(params, "foo")) == NULL)
-        OSSL_PARAM_set_utf8_ptr(p, "foo value");
+        OSSL_PARAM_set_utf8_const(p, "foo value");
     if ((p = OSSL_PARAM_locate(params, "bar")) == NULL)
-        OSSL_PARAM_set_utf8_ptr(p, "bar value");
+        OSSL_PARAM_set_utf8_const(p, "bar value");
     if ((p = OSSL_PARAM_locate(params, "cookie")) == NULL)
-        OSSL_PARAM_set_utf8_ptr(p, "cookie value");
+        OSSL_PARAM_set_utf8_const(p, "cookie value");
 
 =head1 SEE ALSO
 

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -112,7 +112,7 @@ struct ossl_param_st {
  */
 # define OSSL_PARAM_OCTET_STRING         5
 /*-
- * OSSL_PARAM_UTF8_PTR
+ * OSSL_PARAM_UTF8_CONST
  * is a pointer to a printable string.  Is expteced to be printed as it is.
  *
  * The difference between this and OSSL_PARAM_UTF8_STRING is that only pointers
@@ -120,14 +120,14 @@ struct ossl_param_st {
  *
  * This is more relevant for parameter requests, where the responding
  * function doesn't need to copy the data to the provided buffer, but
- * sets the provided buffer to point at the actual data instead.
+ * sets the data pointer to point at the actual data instead.
  *
  * WARNING!  Using these is FRAGILE, as it assumes that the actual
  * data and its location are constant.
  */
-# define OSSL_PARAM_UTF8_PTR             6
+# define OSSL_PARAM_UTF8_CONST           6
 /*-
- * OSSL_PARAM_OCTET_PTR
+ * OSSL_PARAM_OCTET_CONST
  * is a pointer to a string of bytes with no further specification.  It is
  * expected to be printed as a hexdump.
  *
@@ -136,12 +136,12 @@ struct ossl_param_st {
  *
  * This is more relevant for parameter requests, where the responding
  * function doesn't need to copy the data to the provided buffer, but
- * sets the provided buffer to point at the actual data instead.
+ * sets the data pointer to point at the actual data instead.
  *
  * WARNING!  Using these is FRAGILE, as it assumes that the actual
  * data and its location are constant.
  */
-# define OSSL_PARAM_OCTET_PTR            7
+# define OSSL_PARAM_OCTET_CONST          7
 
 /*
  * Typedef for the thread stop handling callback. Used both internally and by

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -57,10 +57,10 @@ extern "C" {
 # define OSSL_PARAM_octet_string(key, addr, sz) \
     OSSL_PARAM_DEFN((key), OSSL_PARAM_OCTET_STRING, (addr), sz)
 
-# define OSSL_PARAM_utf8_ptr(key, addr, sz) \
-    OSSL_PARAM_DEFN((key), OSSL_PARAM_UTF8_PTR, &(addr), sz)
-# define OSSL_PARAM_octet_ptr(key, addr, sz) \
-    OSSL_PARAM_DEFN((key), OSSL_PARAM_OCTET_PTR, &(addr), sz)
+# define OSSL_PARAM_utf8_const(key) \
+    OSSL_PARAM_DEFN((key), OSSL_PARAM_UTF8_CONST, NULL, 0)
+# define OSSL_PARAM_octet_const(key) \
+    OSSL_PARAM_DEFN((key), OSSL_PARAM_OCTET_CONST, NULL, 0)
 
 /* Search an OSSL_PARAM array for a matching name */
 OSSL_PARAM *OSSL_PARAM_locate(OSSL_PARAM *p, const char *key);
@@ -81,12 +81,12 @@ OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
 OSSL_PARAM OSSL_PARAM_construct_double(const char *key, double *buf);
 OSSL_PARAM OSSL_PARAM_construct_utf8_string(const char *key, char *buf,
                                             size_t bsize);
-OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
-                                         size_t bsize);
+OSSL_PARAM OSSL_PARAM_construct_utf8_const(const char *key, char *buf,
+                                           size_t bsize);
 OSSL_PARAM OSSL_PARAM_construct_octet_string(const char *key, void *buf,
                                              size_t bsize);
-OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
-                                          size_t bsize);
+OSSL_PARAM OSSL_PARAM_construct_octet_const(const char *key, void *buf,
+                                            size_t bsize);
 OSSL_PARAM OSSL_PARAM_construct_end(void);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
@@ -122,13 +122,13 @@ int OSSL_PARAM_get_octet_string(const OSSL_PARAM *p, void **val, size_t max_len,
                                 size_t *used_len);
 int OSSL_PARAM_set_octet_string(OSSL_PARAM *p, const void *val, size_t len);
 
-int OSSL_PARAM_get_utf8_ptr(const OSSL_PARAM *p, const char **val);
-int OSSL_PARAM_set_utf8_ptr(OSSL_PARAM *p, const char *val);
+int OSSL_PARAM_get_utf8_const(const OSSL_PARAM *p, const char **val);
+int OSSL_PARAM_set_utf8_const(OSSL_PARAM *p, const char *val);
 
-int OSSL_PARAM_get_octet_ptr(const OSSL_PARAM *p, const void **val,
-                             size_t *used_len);
-int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
-                             size_t used_len);
+int OSSL_PARAM_get_octet_const(const OSSL_PARAM *p, const void **val,
+                               size_t *used_len);
+int OSSL_PARAM_set_octet_const(OSSL_PARAM *p, const void *val,
+                               size_t used_len);
 
 # ifdef  __cplusplus
 }

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -21,9 +21,9 @@ static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
 static const OSSL_ITEM deflt_param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_NAME },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_VERSION },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_BUILDINFO },
     { 0, NULL }
 };
 
@@ -37,13 +37,13 @@ static int deflt_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL Default Provider"))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, "OpenSSL Default Provider"))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, OPENSSL_VERSION_STR))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, OPENSSL_FULL_VERSION_STR))
         return 0;
 
     return 1;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -65,9 +65,9 @@ static const OPENSSL_CTX_METHOD fips_prov_ossl_ctx_method = {
 
 /* Parameters we provide to the core */
 static const OSSL_ITEM fips_param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_NAME },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_VERSION },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_BUILDINFO },
     { 0, NULL }
 };
 
@@ -140,13 +140,13 @@ static int fips_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL FIPS Provider"))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, "OpenSSL FIPS Provider"))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, OPENSSL_VERSION_STR))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, OPENSSL_FULL_VERSION_STR))
         return 0;
 
     return 1;

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -21,9 +21,9 @@ static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
 static const OSSL_ITEM legacy_param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_NAME },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_VERSION },
+    { OSSL_PARAM_UTF8_CONST, OSSL_PROV_PARAM_BUILDINFO },
     { 0, NULL }
 };
 
@@ -37,13 +37,13 @@ static int legacy_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL Legacy Provider"))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, "OpenSSL Legacy Provider"))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, OPENSSL_VERSION_STR))
         return 0;
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+    if (p != NULL && !OSSL_PARAM_set_utf8_const(p, OPENSSL_FULL_VERSION_STR))
         return 0;
 
     return 1;

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -55,33 +55,26 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
 
     for (; ok && p->key != NULL; p++) {
         if (strcmp(p->key, "greeting") == 0) {
-            static char *opensslv;
-            static char *provname;
-            static char *greeting;
             static OSSL_PARAM counter_request[] = {
                 /* Known libcrypto provided parameters */
-                { "openssl-version", OSSL_PARAM_UTF8_PTR,
-                  &opensslv, sizeof(&opensslv), 0 },
-                { "provider-name", OSSL_PARAM_UTF8_PTR,
-                  &provname, sizeof(&provname), 0},
+                { "openssl-version", OSSL_PARAM_UTF8_CONST, NULL, 0, 0 },
+                { "provider-name", OSSL_PARAM_UTF8_CONST, NULL, 0, 0},
 
                 /* This might be present, if there's such a configuration */
-                { "greeting", OSSL_PARAM_UTF8_PTR,
-                  &greeting, sizeof(&greeting), 0 },
-
+                { "greeting", OSSL_PARAM_UTF8_CONST, NULL, 0, 0 },
                 { NULL, 0, NULL, 0, 0 }
             };
             char buf[256];
             size_t buf_l;
 
-            opensslv = provname = greeting = NULL;
-
             if (c_get_params(prov, counter_request)) {
+                const char *greeting = counter_request[2].data;
+
                 if (greeting) {
                     strcpy(buf, greeting);
                 } else {
-                    const char *versionp = *(void **)counter_request[0].data;
-                    const char *namep = *(void **)counter_request[1].data;
+                    const char *versionp = counter_request[0].data;
+                    const char *namep = counter_request[1].data;
 
                     sprintf(buf, "Hello OpenSSL %.20s, greetings from %s!",
                             versionp, namep);

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -453,8 +453,8 @@ static int test_param_construct(void)
     params[n++] = OSSL_PARAM_construct_BN("bignum", ubuf, sizeof(ubuf));
     params[n++] = OSSL_PARAM_construct_utf8_string("utf8str", buf, sizeof(buf));
     params[n++] = OSSL_PARAM_construct_octet_string("octstr", buf, sizeof(buf));
-    params[n++] = OSSL_PARAM_construct_utf8_ptr("utf8ptr", &bufp, 0);
-    params[n++] = OSSL_PARAM_construct_octet_ptr("octptr", &vp, 0);
+    params[n++] = OSSL_PARAM_construct_utf8_const("utf8const", NULL, 0);
+    params[n++] = OSSL_PARAM_construct_octet_const("octconst", NULL, 0);
     params[n] = OSSL_PARAM_construct_end();
 
     /* Search failure */
@@ -505,12 +505,12 @@ static int test_param_construct(void)
         goto err;
     /* UTF8 pointer */
     bufp = buf;
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "utf8ptr"))
-        || !TEST_true(OSSL_PARAM_set_utf8_ptr(cp, "tuvwxyz"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "utf8const"))
+        || !TEST_true(OSSL_PARAM_set_utf8_const(cp, "tuvwxyz"))
         || !TEST_size_t_eq(cp->return_size, sizeof("tuvwxyz"))
-        || !TEST_str_eq(bufp, "tuvwxyz")
-        || !TEST_true(OSSL_PARAM_get_utf8_ptr(cp, (const char **)&bufp2))
-        || !TEST_ptr_eq(bufp2, bufp))
+        || !TEST_str_eq(cp->data, "tuvwxyz")
+        || !TEST_true(OSSL_PARAM_get_utf8_const(cp, (const char **)&bufp2))
+        || !TEST_str_eq(bufp2, "tuvwxyz"))
         goto err;
     /* OCTET string */
     if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "octstr"))
@@ -533,16 +533,16 @@ static int test_param_construct(void)
         goto err;
     /* OCTET pointer */
     vp = &l;
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "octptr"))
-        || !TEST_true(OSSL_PARAM_set_octet_ptr(cp, &ul, sizeof(ul)))
-        || !TEST_size_t_eq(cp->return_size, sizeof(ul))
-        || !TEST_ptr_eq(vp, &ul))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "octconst"))
+        || !TEST_true(OSSL_PARAM_set_octet_const(cp, bn_val, sizeof(bn_val)))
+        || !TEST_size_t_eq(cp->return_size, sizeof(bn_val))
+        || !TEST_ptr_eq(cp->data, bn_val))
         goto err;
     /* Match the return size to avoid trailing garbage bytes */
     cp->data_size = cp->return_size;
-    if (!TEST_true(OSSL_PARAM_get_octet_ptr(cp, (const void **)&vp2, &k))
-        || !TEST_size_t_eq(k, sizeof(ul))
-        || !TEST_ptr_eq(vp2, vp))
+    if (!TEST_true(OSSL_PARAM_get_octet_const(cp, (const void **)&vp2, &k))
+        || !TEST_size_t_eq(k, sizeof(bn_val))
+        || !TEST_ptr_eq(vp2, bn_val))
         goto err;
     /* BIGNUM */
     if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "bignum"))

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -301,6 +301,7 @@ static BIGNUM *app_p3 = NULL;         /* "p3" */
 static unsigned char bignumbin[4096]; /* "p3" */
 static char app_p4[256];              /* "p4" */
 static char app_p5[256];              /* "p5" */
+static char app_p6[256];              /* "p6" */
 static unsigned char foo[1];          /* "foo" */
 
 #define app_p1_init 17           /* A random number */
@@ -331,6 +332,7 @@ static int init_app_variables(void)
         return 0;
     strcpy(app_p4, app_p4_init);
     strcpy(app_p5, app_p5_init);
+    strcpy(app_p6, app_p6_init);
     foo[0] = app_foo_init;
 
     return 1;
@@ -346,7 +348,7 @@ static OSSL_PARAM static_raw_params[] = {
     { "p3", OSSL_PARAM_UNSIGNED_INTEGER, &bignumbin, sizeof(bignumbin), 0 },
     { "p4", OSSL_PARAM_UTF8_STRING, &app_p4, sizeof(app_p4), 0 },
     { "p5", OSSL_PARAM_UTF8_STRING, &app_p5, sizeof(app_p5), 0 },
-    { "p6", OSSL_PARAM_UTF8_CONST, app_p6_init, sizeof(app_p6_init), 0 },
+    { "p6", OSSL_PARAM_UTF8_CONST, app_p6, sizeof(app_p6), 0 },
     { "foo", OSSL_PARAM_OCTET_STRING, &foo, sizeof(foo), 0 },
     { NULL, 0, NULL, 0, 0 }
 };
@@ -357,8 +359,7 @@ static OSSL_PARAM static_api_params[] = {
     OSSL_PARAM_BN("p3", &bignumbin, sizeof(bignumbin)),
     OSSL_PARAM_DEFN("p4", OSSL_PARAM_UTF8_STRING, &app_p4, sizeof(app_p4)),
     OSSL_PARAM_DEFN("p5", OSSL_PARAM_UTF8_STRING, &app_p5, sizeof(app_p5)),
-    OSSL_PARAM_DEFN("p6", OSSL_PARAM_UTF8_CONST, app_p6_init,
-                    sizeof(app_p6_init)),
+    OSSL_PARAM_DEFN("p6", OSSL_PARAM_UTF8_CONST, &app_p6, sizeof(app_p6)),
     OSSL_PARAM_DEFN("foo", OSSL_PARAM_OCTET_STRING, &foo, sizeof(foo)),
     OSSL_PARAM_END
 };
@@ -378,8 +379,8 @@ static OSSL_PARAM *construct_api_params(void)
                                                    sizeof(app_p4));
     params[n++] = OSSL_PARAM_construct_utf8_string("p5", app_p5,
                                                    sizeof(app_p5));
-    params[n++] = OSSL_PARAM_construct_utf8_const("p6", app_p6_init,
-                                                  sizeof(app_p6_init));
+    params[n++] = OSSL_PARAM_construct_utf8_const("p6", app_p6,
+                                                  sizeof(app_p6));
     params[n++] = OSSL_PARAM_construct_octet_string("foo", &foo, sizeof(foo));
     params[n++] = OSSL_PARAM_construct_end();
 
@@ -458,7 +459,7 @@ static int test_case_variant(OSSL_PARAM *params, const struct provider_dispatch_
         || !TEST_str_eq(app_p5, p5_init)        /* "provider" value */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "p6"))
         || !TEST_size_t_eq(p->return_size, sizeof(p6_init)) /* "provider" value */
-        || !TEST_str_eq(p->data, p6_init)        /* "provider" value */
+        || !TEST_str_eq(app_p6, p6_init)        /* "provider" value */
         || !TEST_char_eq(foo[0], app_foo_init)  /* Should remain untouched */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "foo"))
         || !TEST_int_eq(p->return_size, 0))
@@ -479,8 +480,7 @@ static int test_case_variant(OSSL_PARAM *params, const struct provider_dispatch_
             || !TEST_BN_eq(sneakpeek->p3, app_p3)       /* app value set */
             || !TEST_str_eq(sneakpeek->p4, app_p4)      /* app value set */
             || !TEST_str_eq(sneakpeek->p5, app_p5)      /* app value set */
-            || !TEST_ptr(p = OSSL_PARAM_locate(params, "p6"))
-            || !TEST_str_eq(sneakpeek->p6, p->data))     /* app value set */
+            || !TEST_str_eq(sneakpeek->p6, app_p6))     /* app value set */
             errcnt++;
         printf("sneak %s\n", sneakpeek->p6);
     }
@@ -496,9 +496,6 @@ static int test_case_variant(OSSL_PARAM *params, const struct provider_dispatch_
         errcnt++;
         goto fin;
     }
-    if (!TEST_true(p = OSSL_PARAM_locate(params, "p6")))
-        goto fin;
-    sneakpeek->p6 = app_p6_init;
 
     if (!TEST_true(prov->get_params(obj, params))
         || !TEST_int_eq(app_p1, app_p1_init)    /* app value */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4745,9 +4745,9 @@ OSSL_PARAM_construct_size_t             4694	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_construct_BN                 4695	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_construct_double             4696	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_construct_utf8_string        4697	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_construct_utf8_ptr           4698	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_construct_utf8_const         4698	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_construct_octet_string       4699	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_construct_octet_ptr          4700	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_construct_octet_const        4700	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_get_int                      4701	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_get_uint                     4702	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_get_long                     4703	3_0_0	EXIST::FUNCTION:
@@ -4774,10 +4774,10 @@ OSSL_PARAM_get_utf8_string              4723	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_set_utf8_string              4724	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_get_octet_string             4725	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_set_octet_string             4726	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_get_utf8_ptr                 4727	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_set_utf8_ptr                 4728	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_get_octet_ptr                4729	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_set_octet_ptr                4730	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_get_utf8_const               4727	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_set_utf8_const               4728	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_get_octet_const              4729	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_set_octet_const              4730	3_0_0	EXIST::FUNCTION:
 X509_set0_sm2_id                        4731	3_0_0	EXIST::FUNCTION:SM2
 X509_get0_sm2_id                        4732	3_0_0	EXIST::FUNCTION:SM2
 EVP_PKEY_get0_engine                    4733	3_0_0	EXIST::FUNCTION:ENGINE


### PR DESCRIPTION
The two _PTR string types have had the indirection removed.  The pointer to
their data lives inside the OSSL_PARAM structure without needing an intermediate
pointer.


- [x] documentation is added or updated
- [x] tests are added or updated
