### PR TITLE
An utility API to get negotiated Key exchange alg group NID

### DIFF
--- a/doc/man3/SSL_CTX_set1_curves.pod
+++ b/doc/man3/SSL_CTX_set1_curves.pod
@@ -4,8 +4,8 @@
 
 SSL_CTX_set1_groups, SSL_CTX_set1_groups_list, SSL_set1_groups,
 SSL_set1_groups_list, SSL_get1_groups, SSL_get_shared_group,
-SSL_CTX_set1_curves, SSL_CTX_set1_curves_list, SSL_set1_curves,
-SSL_set1_curves_list, SSL_get1_curves, SSL_get_shared_curve
+SSL_get_negotiated_group, SSL_CTX_set1_curves, SSL_CTX_set1_curves_list,
+SSL_set1_curves, SSL_set1_curves_list, SSL_get1_curves, SSL_get_shared_curve
 - EC supported curve functions
 
 =head1 SYNOPSIS
@@ -20,6 +20,7 @@ SSL_set1_curves_list, SSL_get1_curves, SSL_get_shared_curve
 
  int SSL_get1_groups(SSL *ssl, int *groups);
  int SSL_get_shared_group(SSL *s, int n);
+ int SSL_get_negotiated_group(SSL *s);
 
  int SSL_CTX_set1_curves(SSL_CTX *ctx, int *clist, int clistlen);
  int SSL_CTX_set1_curves_list(SSL_CTX *ctx, char *list);
@@ -68,6 +69,9 @@ most applications will only be interested in the first shared group
 so B<n> is normally set to zero. If the value B<n> is out of range,
 NID_undef is returned.
 
+SSL_get_negotiated_group() returns the negotiated group on a TLSv1.3 connection
+for key exchange. This can be called by either client or server.
+
 All these functions are implemented as macros.
 
 The curve functions are synonyms for the equivalently named group functions and
@@ -96,6 +100,10 @@ is -1.
 When called on a client B<ssl>, SSL_get_shared_group() has no meaning and
 returns -1.
 
+SSL_get_negotiated_group() returns the NID of the negotiated group on a
+TLSv1.3 connection for key exchange. Or it returns NID_undef if no negotiated
+group.
+
 =head1 SEE ALSO
 
 L<SSL_CTX_add_extra_chain_cert(3)>
@@ -103,7 +111,8 @@ L<SSL_CTX_add_extra_chain_cert(3)>
 =head1 HISTORY
 
 The curve functions were added in OpenSSL 1.0.2. The equivalent group
-functions were added in OpenSSL 1.1.1.
+functions were added in OpenSSL 1.1.1. The SSL_get_negotiated_group() function
+was added in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1316,6 +1316,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_GET_MAX_PROTO_VERSION          131
 # define SSL_CTRL_GET_SIGNATURE_NID              132
 # define SSL_CTRL_GET_TMP_KEY                    133
+# define SSL_CTRL_GET_NEGOTIATED_GROUP           134
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3
@@ -1415,6 +1416,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_ctrl(s,SSL_CTRL_SET_GROUPS_LIST,0,(char *)(str))
 # define SSL_get_shared_group(s, n) \
         SSL_ctrl(s,SSL_CTRL_GET_SHARED_GROUP,n,NULL)
+# define SSL_get_negotiated_group(s) \
+        SSL_ctrl(s,SSL_CTRL_GET_NEGOTIATED_GROUP,0,NULL)
 # define SSL_CTX_set1_sigalgs(ctx, slist, slistlen) \
         SSL_CTX_ctrl(ctx,SSL_CTRL_SET_SIGALGS,slistlen,(int *)(slist))
 # define SSL_CTX_set1_sigalgs_list(ctx, s) \

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3616,13 +3616,13 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         {
             uint16_t id = tls1_shared_group(s, larg);
 
-            if (larg != -1) {
-                const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(id);
-
-                return ginf == NULL ? 0 : ginf->nid;
-            }
+            if (larg != -1)
+                return tls1_group_id2nid(id);
             return id;
         }
+    case SSL_CTRL_GET_NEGOTIATED_GROUP:
+        ret = tls1_group_id2nid(s->s3.group_id);
+        break;
 #endif /* !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH) */
 
     case SSL_CTRL_SET_SIGALGS:

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -2531,6 +2531,7 @@ __owur int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL *s);
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t curve_id);
+__owur int tls1_group_id2nid(uint16_t group_id);
 __owur int tls1_check_group_id(SSL *s, uint16_t group_id, int check_own_curves);
 __owur uint16_t tls1_shared_group(SSL *s, int nmatch);
 __owur int tls1_set_groups(uint16_t **pext, size_t *pextlen,

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -226,6 +226,13 @@ const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t group_id)
 }
 
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
+int tls1_group_id2nid(uint16_t group_id)
+{
+    const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(group_id);
+
+    return ginf == NULL ? NID_undef : ginf->nid;
+}
+
 static uint16_t tls1_nid2group_id(int nid)
 {
     size_t i;

--- a/util/private.num
+++ b/util/private.num
@@ -445,6 +445,7 @@ SSL_get_secure_renegotiation_support    define
 SSL_get_server_tmp_key                  define
 SSL_get_shared_curve                    define
 SSL_get_shared_group                    define
+SSL_get_negotiated_group                define
 SSL_get_signature_nid                   define
 SSL_get_time                            define
 SSL_get_timeout                         define


### PR DESCRIPTION
Added a new utility API `SSL_get_negotiated_group()` to get the negotiated key exchange algorithm on a TLSv1.3 connection. Currently there is an another API `SSL_get_shared_group()` which is supported only for server and it returns nth shared group.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
