### PR TITLE
Disable running test/shlibloadtest with -dso_ref on Cygwin

### DIFF
--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -42,7 +42,11 @@ sub run_shlibloadtest {
 run_shlibloadtest(1, "-crypto_first");
 run_shlibloadtest(1, "-ssl_first");
 run_shlibloadtest(1, "-just_crypto");
-run_shlibloadtest(1, "-dso_ref");
+ SKIP: {
+     skip "Skipping -dso_ref, not supported on this platform", 2
+         if config('target') =~ m|^Cygwin|;
+     run_shlibloadtest(1, "-dso_ref");
+}
 run_shlibloadtest(0, "-no_atexit");
 
 sub check_atexit {

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -28,31 +28,20 @@ plan tests => 10;
 my $libcrypto = platform->sharedlib('libcrypto');
 my $libssl = platform->sharedlib('libssl');
 
-(my $fh, my $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -crypto_first $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-ssl_first", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -ssl_first $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-just_crypto", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -just_crypto $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-dso_ref", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -dso_ref $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-no_atexit", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -no_atexit $filename");
-ok(!check_atexit($fh));
-unlink $filename;
+sub run_shlibloadtest {
+    (my $fh, my $filename) = tempfile();
+    ok(run(test(["shlibloadtest", @_, $libcrypto, $libssl, $filename])),
+       join(' ', ("running shlibloadtest", @_,"$filename")));
+    ok(check_atexit($fh));
+    unlink $filename;
+}
+
+# Each run_shlibloadtest runs two tests
+run_shlibloadtest("-crypto_first");
+run_shlibloadtest("-ssl_first");
+run_shlibloadtest("-just_crypto");
+run_shlibloadtest("-dso_ref");
+run_shlibloadtest("-no_atexit");
 
 sub check_atexit {
     my $fh = shift;

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -29,19 +29,21 @@ my $libcrypto = platform->sharedlib('libcrypto');
 my $libssl = platform->sharedlib('libssl');
 
 sub run_shlibloadtest {
+    my $atexit = shift;
     (my $fh, my $filename) = tempfile();
     ok(run(test(["shlibloadtest", @_, $libcrypto, $libssl, $filename])),
        join(' ', ("running shlibloadtest", @_,"$filename")));
-    ok(check_atexit($fh));
+    cmp_ok(check_atexit($fh), '==', $atexit,
+           "checking that 'atexit()' ".($atexit ? "was" : "wasn't")." run");
     unlink $filename;
 }
 
 # Each run_shlibloadtest runs two tests
-run_shlibloadtest("-crypto_first");
-run_shlibloadtest("-ssl_first");
-run_shlibloadtest("-just_crypto");
-run_shlibloadtest("-dso_ref");
-run_shlibloadtest("-no_atexit");
+run_shlibloadtest(1, "-crypto_first");
+run_shlibloadtest(1, "-ssl_first");
+run_shlibloadtest(1, "-just_crypto");
+run_shlibloadtest(1, "-dso_ref");
+run_shlibloadtest(0, "-no_atexit");
 
 sub check_atexit {
     my $fh = shift;


### PR DESCRIPTION
That platform currently lacks the needed support.

Fixes #9330 

-----

While I'm at it, I refactored test/recipes/90-test_shlibload.t for better readability and maintainability.