### PR TITLE
Replace OSSL_ITEM with OSSL_PARAM as parameter descriptor

### DIFF
--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -35,7 +35,7 @@ int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
     return 1;
 }
 
-const OSSL_ITEM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov)
+const OSSL_PARAM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_get_param_types(prov);
 }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -680,7 +680,7 @@ void ossl_provider_teardown(const OSSL_PROVIDER *prov)
         prov->teardown(prov->provctx);
 }
 
-const OSSL_ITEM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov)
+const OSSL_PARAM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov)
 {
     return prov->get_param_types == NULL
         ? NULL : prov->get_param_types(prov->provctx);
@@ -712,13 +712,13 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
  * discovery.  We do not expect that many providers will use this, but one
  * never knows.
  */
-static const OSSL_ITEM param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, "openssl-version" },
-    { OSSL_PARAM_UTF8_PTR, "provider-name" },
-    { 0, NULL }
+static const OSSL_PARAM param_types[] = {
+    OSSL_PARAM_DEFN("openssl-verstion", OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN("provider-name", OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_END
 };
 
-static const OSSL_ITEM *core_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *core_get_param_types(const OSSL_PROVIDER *prov)
 {
     return param_types;
 }

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -51,7 +51,7 @@ ossl_provider_get_params, ossl_provider_query_operation
 
  /* Thin wrappers around calls to the provider */
  void ossl_provider_teardown(const OSSL_PROVIDER *prov);
- const OSSL_ITEM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov);
+ const OSSL_PARAM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov);
  int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
  const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                      int operation_id,
@@ -174,7 +174,7 @@ the provider has one.
 
 ossl_provider_get_param_types() calls the provider's I<get_param_types>
 function, if the provider has one.
-It should return an array of I<OSSL_ITEM> to describe all the
+It should return an array of I<OSSL_PARAM> to describe all the
 parameters that the provider has for the provider object.
 
 ossl_provider_get_params() calls the provider's parameter request
@@ -235,9 +235,9 @@ is returned.
 
 ossl_provider_teardown() doesnt't return any value.
 
-ossl_provider_get_param_types() returns a pointer to an I<OSSL_ITEM>
-array if this function is available in the provider, otherwise
-NULL.
+ossl_provider_get_param_types() returns a pointer to a constant
+I<OSSL_PARAM> array if this function is available in the provider,
+otherwise NULL.
 
 ossl_provider_get_params() returns 1 on success, or 0 on error.
 If this function isn't available in the provider, 0 is returned.

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -27,26 +27,36 @@ A typical usage example could be an application that wants to set some
 parameters for an object, or wants to find out some parameters of an
 object.
 
-Arrays of this type can be used for two purposes:
+Arrays of this type can be used for the following purposes:
 
 =over 4
 
-=item *
+=item * Setting parameters for some object
 
-Setting parameters for some object.
 The caller sets up the C<OSSL_PARAM> array and calls some function
 (the I<setter>) that has intimate knowledge about the object that can
 take the data from the C<OSSL_PARAM> array and assign them in a
 suitable form for the internal structure of the object.
 
-=item *
+=item * Request parameters of some object
 
-Request parameters of some object.
 The caller (the I<requestor>) sets up the C<OSSL_PARAM> array and
 calls some function (the I<responder>) that has intimate knowledge
 about the object, which can take the internal data of the object and
 copy (possibly convert) that to the memory prepared by the
 I<requestor> and pointed at with the C<OSSL_PARAM> C<data>.
+
+=item * Request parameter descriptors
+
+The caller gets an array of constant C<OSSL_PARAM>, which describe
+available parameters and some of their properties; name, data type and
+expected data size.
+For a detailed description of each field for this use, see the field
+descriptions below.
+
+The caller may then use the information from this descriptor array to
+build up its own C<OSSL_PARAM> array to pass down to a I<setter> or
+I<responder>.
 
 =back
 
@@ -78,6 +88,11 @@ setting parameters) or shall (when requesting parameters) be stored,
 and C<data_size> is its size in bytes.
 The organization of the data depends on the parameter type and flag.
 
+When the C<OSSL_PARAM> is used as a parameter descriptor, C<data>
+should be ignored.
+If C<data_size> may be zero, it means that an arbitrary data size is
+accepted, otherwise it specifies the maximum size allowed.
+
 =item C<return_size>
 
 When an array of C<OSSL_PARAM> is used to request data, the
@@ -85,6 +100,9 @@ I<responder> must set this field to indicate the actual size of the
 parameter data.
 In case the C<data_size> is too small for the data, the I<responder>
 must still set this field to indicate the minimum data size required.
+
+When the C<OSSL_PARAM> is used as a parameter descriptor,
+C<return_size> should be ignored.
 
 =back
 
@@ -218,6 +236,14 @@ If a I<responder> finds that some data sizes are too small for the
 requested data, it must set C<return_size> for each such
 C<OSSL_PARAM> item to the required size, and eventually return an
 error.
+
+=item *
+
+Functions returning a constant C<OSSL_PARAM> array as a parameter
+descriptor may set C<data> and C<return_size> for their own purposes.
+And example would be to have C<data> point at handler functions for
+each parameter, which would be used by a I<setter> or I<responder> of
+those same parameters.
 
 =back
 

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -237,14 +237,6 @@ requested data, it must set C<return_size> for each such
 C<OSSL_PARAM> item to the required size, and eventually return an
 error.
 
-=item *
-
-Functions returning a constant C<OSSL_PARAM> array as a parameter
-descriptor may set C<data> and C<return_size> for their own purposes.
-And example would be to have C<data> point at handler functions for
-each parameter, which would be used by a I<setter> or I<responder> of
-those same parameters.
-
 =back
 
 =begin comment RETURN VALUES doesn't make sense for a manual that only

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -15,7 +15,7 @@ OSSL_PROVIDER_add_builtin - provider routines
  OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
 
- const OSSL_ITEM *OSSL_PROVIDER_get_param_types(OSSL_PROVIDER *prov);
+ const OSSL_PARAM *OSSL_PROVIDER_get_param_types(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_get_params(OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
  int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *, const char *name,
@@ -48,11 +48,8 @@ For a provider added with OSSL_PROVIDER_add_builtin(), this simply
 runs its teardown function.
 
 OSSL_PROVIDER_get_param_types() is used to get a provider parameter
-descriptor set as an B<OSSL_ITEM> array.
-Each element is a tuple of an B<OSSL_PARAM> parameter type and a name
-in form of a C string.
-See L<openssl-core.h(7)> for more information on B<OSSL_ITEM> and
-parameter types.
+descriptor set as a constant B<OSSL_PARAM> array.
+See L<OSSL_PARAM(3)> for more information.
 
 OSSL_PROVIDER_get_params() is used to get provider parameter values.
 The caller must prepare the B<OSSL_PARAM> array before calling this
@@ -68,8 +65,8 @@ success, or B<NULL> on error.
 
 OSSL_PROVIDER_unload() returns 1 on success, or 0 on error.
 
-OSSL_PROVIDER_get_param_types() returns a pointer to a constant array
-of B<OSSL_ITEM>, or NULL if none is provided.
+OSSL_PROVIDER_get_param_types() returns a pointer to an array
+of constant B<OSSL_PARAM>, or NULL if none is provided.
 
 OSSL_PROVIDER_get_params() returns 1 on success, or 0 on error.
 

--- a/doc/man7/openssl-core.h.pod
+++ b/doc/man7/openssl-core.h.pod
@@ -69,8 +69,8 @@ It's normally passed in arrays, where the array is terminated with an
 element where all fields are zero (for non-pointers) or C<NULL> (for
 pointers).
 
-These arrays can be used both to set parameters for some object, and
-to request parameters.
+These arrays can be used to set parameters for some object, to request
+parameters, and to describe parameters.
 
 C<OSSL_PARAM> is further described in L<OSSL_PARAM(3)>
 

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -62,7 +62,7 @@ const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);
-const OSSL_ITEM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov);
+const OSSL_PARAM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov);
 int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -43,7 +43,7 @@ struct ossl_dispatch_st {
  * tables remain tables with function pointers only.
  *
  * This is used whenever we need to pass things like a table of error reason
- * codes <-> reason string maps, parameter name <-> parameter type maps, ...
+ * codes <-> reason string maps, ...
  *
  * Usage determines which field works as key if any, rather than field order.
  *

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -53,7 +53,7 @@ extern "C" {
  */
 /* Functions provided by the Core to the provider, reserved numbers 1-1023 */
 # define OSSL_FUNC_CORE_GET_PARAM_TYPES        1
-OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
                     core_get_param_types,(const OSSL_PROVIDER *prov))
 # define OSSL_FUNC_CORE_GET_PARAMS             2
 OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
@@ -77,7 +77,7 @@ OSSL_CORE_MAKE_FUNC(OPENSSL_CTX *,core_get_library_context,
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024
 OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAM_TYPES  1025
-OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
                     provider_get_param_types,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAMS       1026
 OSSL_CORE_MAKE_FUNC(int,provider_get_params,(void *provctx,

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -20,7 +20,7 @@ extern "C" {
 OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
 
-const OSSL_ITEM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov);
+const OSSL_PARAM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
 /* Add a built in providers */

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -20,14 +20,14 @@ static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
-static const OSSL_ITEM deflt_param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
-    { 0, NULL }
+static const OSSL_PARAM deflt_param_types[] = {
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_END
 };
 
-static const OSSL_ITEM *deflt_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *deflt_get_param_types(const OSSL_PROVIDER *prov)
 {
     return deflt_param_types;
 }

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -64,11 +64,11 @@ static const OPENSSL_CTX_METHOD fips_prov_ossl_ctx_method = {
 
 
 /* Parameters we provide to the core */
-static const OSSL_ITEM fips_param_types[] = {
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_VERSION },
-    { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_BUILDINFO },
-    { 0, NULL }
+static const OSSL_PARAM fips_param_types[] = {
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_END
 };
 
 /* TODO(3.0): To be removed */
@@ -133,7 +133,7 @@ static int dummy_evp_call(void *provctx)
     return ret;
 }
 
-static const OSSL_ITEM *fips_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *fips_get_param_types(const OSSL_PROVIDER *prov)
 {
     return fips_param_types;
 }

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -33,16 +33,16 @@ static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Tell the core what params we provide and what type they are */
-static const OSSL_ITEM p_param_types[] = {
-    { OSSL_PARAM_UTF8_STRING, "greeting" },
-    { 0, NULL }
+static const OSSL_PARAM p_param_types[] = {
+    { "greeting", OSSL_PARAM_UTF8_STRING, NULL, 0, 0 },
+    { NULL, 0, NULL, 0, 0 }
 };
 
 /* This is a trick to ensure we define the provider functions correctly */
 static OSSL_provider_get_param_types_fn p_get_param_types;
 static OSSL_provider_get_params_fn p_get_params;
 
-static const OSSL_ITEM *p_get_param_types(void *_)
+static const OSSL_PARAM *p_get_param_types(void *_)
 {
     return p_param_types;
 }


### PR DESCRIPTION
This has been coming for quite some time now, its use is already visible in #9303, and it's also visible in #8877.

This PR describes the use of `OSSL_PARAM` as a descriptor, and changes all instances of `_get_param_types` and `_set_param_types` to return an array of this type rather than of `OSSL_ITEM`