### PR TITLE
WIP: Unbend error initialization

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -57,7 +57,7 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
     OPENSSL_cpuid_setup();
 
     if (!ossl_init_thread())
-        return 0;
+        goto err;
 
     base_inited = 1;
     return 1;
@@ -496,37 +496,19 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         return 0;
     }
 
-    /*
-     * When the caller specifies OPENSSL_INIT_BASE_ONLY, that should be the
-     * *only* option specified.  With that option we return immediately after
-     * doing the requested limited initialization.  Note that
-     * err_shelve_state() called by us via ossl_init_load_crypto_nodelete()
-     * re-enters OPENSSL_init_crypto() with OPENSSL_INIT_BASE_ONLY, but with
-     * base already initialized this is a harmless NOOP.
-     *
-     * If we remain the only caller of err_shelve_state() the recursion should
-     * perhaps be removed, but if in doubt, it can be left in place.
-     */
     if (!RUN_ONCE(&base, ossl_init_base))
         return 0;
 
+    /*
+     * Many internals only need the basic init too function properly.
+     * Doing more risks creating nasty init loops.  One example would
+     * be if anything down the line causes the error sub-system to be
+     * called...
+     */
     if (opts & OPENSSL_INIT_BASE_ONLY)
         return 1;
 
-    /*
-     * Now we don't always set up exit handlers, the INIT_BASE_ONLY calls
-     * should not have the side-effect of setting up exit handlers, and
-     * therefore, this code block is below the INIT_BASE_ONLY-conditioned early
-     * return above.
-     */
-    if ((opts & OPENSSL_INIT_NO_ATEXIT) != 0) {
-        if (!RUN_ONCE_ALT(&register_atexit, ossl_init_no_register_atexit,
-                          ossl_init_register_atexit))
-            return 0;
-    } else if (!RUN_ONCE(&register_atexit, ossl_init_register_atexit)) {
-        return 0;
-    }
-
+    /* Anything below is optional, at user discretion */
     if (!RUN_ONCE(&load_crypto_nodelete, ossl_init_load_crypto_nodelete))
         return 0;
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -499,6 +499,14 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     if (!RUN_ONCE(&base, ossl_init_base))
         return 0;
 
+    if ((opts & OPENSSL_INIT_NO_ATEXIT) != 0) {
+        if (!RUN_ONCE_ALT(&register_atexit, ossl_init_no_register_atexit,
+                          ossl_init_register_atexit))
+            return 0;
+    } else if (!RUN_ONCE(&register_atexit, ossl_init_register_atexit)) {
+        return 0;
+    }
+
     /*
      * Many internals only need the basic init too function properly.
      * Doing more risks creating nasty init loops.  One example would

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -117,6 +117,9 @@ init_get_thread_local(CRYPTO_THREAD_LOCAL *local, int alloc, int keep)
             CRYPTO_THREAD_unlock(gtr->lock);
 #endif
             if (!CRYPTO_THREAD_set_local(local, hands)) {
+#ifndef FIPS_MODE
+                sk_THREAD_EVENT_HANDLER_PTR_pop(gtr->skhands);
+#endif
                 OPENSSL_free(hands);
                 return NULL;
             }


### PR DESCRIPTION
Error initialization did two things at the same time:

- Create a lock
- Load the standard strings.

Among others, the initialization is called when setting an error
status.

Because other parts of libcrypto that are also called when
initializing might need to set an error, it created a fragile
situation that could potentially interlock.

This situation is resolved by splitting the initialization in two
parts:

1.  Create the lock, which is now done as part of the base init.
    Any setting of error depends on this lock.
2.  Load the standard strings, which is done on demand as before.
    Setting an error does not depend on these strings existing,
    only the final extraction of error as printable strings is.

This simplifies the initialization situation, and takes away the need
for the internal init option OPENSSL_INIT_BASE_ONLY.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
