### PR TITLE
Refactor the approach for recursive init calls

### DIFF
--- a/crypto/engine/eng_init.c
+++ b/crypto/engine/eng_init.c
@@ -81,7 +81,7 @@ int ENGINE_init(ENGINE *e)
         ENGINEerr(ENGINE_F_ENGINE_INIT, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
+    if (!engine_lock_init()) {
         ENGINEerr(ENGINE_F_ENGINE_INIT, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/engine/eng_int.h
+++ b/crypto/engine/eng_int.h
@@ -98,8 +98,7 @@ void engine_pkey_meths_free(ENGINE *e);
 void engine_pkey_asn1_meths_free(ENGINE *e);
 
 /* Once initialisation function */
-extern CRYPTO_ONCE engine_lock_init;
-DECLARE_RUN_ONCE(do_engine_lock_init)
+int engine_lock_init(void);
 
 /*
  * This is a structure for storing implementations of various crypto

--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -131,7 +131,7 @@ ENGINE *ENGINE_get_first(void)
 {
     ENGINE *ret;
 
-    if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
+    if (!engine_lock_init()) {
         ENGINEerr(ENGINE_F_ENGINE_GET_FIRST, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -150,7 +150,7 @@ ENGINE *ENGINE_get_last(void)
 {
     ENGINE *ret;
 
-    if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
+    if (!engine_lock_init()) {
         ENGINEerr(ENGINE_F_ENGINE_GET_LAST, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -282,7 +282,7 @@ ENGINE *ENGINE_by_id(const char *id)
         ENGINEerr(ENGINE_F_ENGINE_BY_ID, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
+    if (!engine_lock_init()) {
         ENGINEerr(ENGINE_F_ENGINE_BY_ID, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -191,7 +191,7 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_pkey_asn1_find_str(ENGINE **pe,
     fstr.str = str;
     fstr.len = len;
 
-    if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
+    if (!engine_lock_init()) {
         ENGINEerr(ENGINE_F_ENGINE_PKEY_ASN1_FIND_STR, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -674,7 +674,7 @@ ERR_STATE *ERR_get_state(void)
     ERR_STATE *state;
     int saveerrno = get_last_sys_error();
 
-    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
+    if (!OPENSSL_init_crypto(0, NULL))
         return NULL;
 
     if (!RUN_ONCE(&err_init, err_do_init))
@@ -728,7 +728,7 @@ int err_shelve_state(void **state)
      * call is needed, but some care is required to make sure that the re-entry
      * remains a NOOP.
      */
-    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
+    if (!OPENSSL_init_crypto(0, NULL))
         return 0;
 
     if (!RUN_ONCE(&err_init, err_do_init))

--- a/crypto/include/internal/cryptlib_int.h
+++ b/crypto/include/internal/cryptlib_int.h
@@ -25,7 +25,7 @@ void ossl_ctx_thread_stop(void *arg);
  * use".
  */
 # define OPENSSL_INIT_ZLIB                   0x00010000L
-# define OPENSSL_INIT_BASE_ONLY              0x00040000L
+# define OPENSSL_INIT_BASE                   0x00040000L
 
 int ossl_trace_init(void);
 void ossl_trace_cleanup(void);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -405,9 +405,6 @@ void OPENSSL_cleanup(void)
     }
     stop_handlers = NULL;
 
-    CRYPTO_THREAD_lock_free(init_lock);
-    init_lock = NULL;
-
     /*
      * We assume we are single-threaded for this function, i.e. no race
      * conditions for the various "*_inited" vars below.
@@ -477,6 +474,9 @@ void OPENSSL_cleanup(void)
     OSSL_TRACE(INIT, "OPENSSL_cleanup: ossl_trace_cleanup()\n");
     ossl_trace_cleanup();
 
+    CRYPTO_THREAD_lock_free(init_lock);
+    init_lock = NULL;
+
     base_inited = 0;
 }
 
@@ -498,8 +498,9 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
      * of this into OPENSSL_CTX.
      */
 
-    if (stopped && opts != 0) {
-        CRYPTOerr(CRYPTO_F_OPENSSL_INIT_CRYPTO, ERR_R_INIT_FAIL);
+    if (stopped) {
+        if (opts != 0)
+            CRYPTOerr(CRYPTO_F_OPENSSL_INIT_CRYPTO, ERR_R_INIT_FAIL);
         return 0;
     }
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -480,7 +480,11 @@ void OPENSSL_cleanup(void)
     base_inited = 0;
 }
 
-int last_opts = 0;
+/*
+ * We keep track of all the init options that have been attempted so far.
+ * See further comments inside OPENSSL_init_crypto().
+ */
+static int last_opts = 0;
 
 /*
  * If this function is called with a non NULL settings value then it must be

--- a/crypto/store/store_init.c
+++ b/crypto/store/store_init.c
@@ -14,13 +14,13 @@
 static CRYPTO_ONCE store_init = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(do_store_init)
 {
-    return OPENSSL_init_crypto(0, NULL)
-        && ossl_store_file_loader_init();
+    return ossl_store_file_loader_init();
 }
 
 int ossl_store_init_once(void)
 {
-    if (!RUN_ONCE(&store_init, do_store_init)) {
+    if (!OPENSSL_init_crypto(0, NULL)
+        || !RUN_ONCE(&store_init, do_store_init)) {
         OSSL_STOREerr(OSSL_STORE_F_OSSL_STORE_INIT_ONCE, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -392,7 +392,7 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 # define OPENSSL_INIT_ENGINE_AFALG           0x00008000L
 /* OPENSSL_INIT_ZLIB                         0x00010000L */
 # define OPENSSL_INIT_ATFORK                 0x00020000L
-/* OPENSSL_INIT_BASE_ONLY                    0x00040000L */
+/* OPENSSL_INIT_BASE                         0x00040000L */
 # define OPENSSL_INIT_NO_ATEXIT              0x00080000L
 /* OPENSSL_INIT flag range 0x03f00000 reserved for OPENSSL_init_ssl() */
 # define OPENSSL_INIT_NO_ADD_ALL_MACS        0x04000000L


### PR DESCRIPTION
At any point, we can expect OPENSSL_init_crypto() to be called
recursively.  This works, as long as no locking happens in code that's
executed again in the recursion.  We already had a similar situation
with the ERR code, and solved it with a rather ugly special case.

Here, we change the approach by keeping track of what initializations
have already been started, and simply never try to start them again.
We do so by masking away accumulated previous opts from the current
ones in the OPENSSL_init_crypto call.

There's a consequence, that any init opt can only be used once, even
if that particular initialization ends with aan error.
