### PR TITLE
Fix init_get_thread_local()

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -114,15 +114,18 @@ init_get_thread_local(CRYPTO_THREAD_LOCAL *local, int alloc, int keep)
                 CRYPTO_THREAD_unlock(gtr->lock);
                 return NULL;
             }
-            CRYPTO_THREAD_unlock(gtr->lock);
 #endif
             if (!CRYPTO_THREAD_set_local(local, hands)) {
 #ifndef FIPS_MODE
                 sk_THREAD_EVENT_HANDLER_PTR_pop(gtr->skhands);
+                CRYPTO_THREAD_unlock(gtr->lock);
 #endif
                 OPENSSL_free(hands);
                 return NULL;
             }
+#ifndef FIPS_MODE
+            CRYPTO_THREAD_unlock(gtr->lock);
+#endif
         }
     } else if (!keep) {
         CRYPTO_THREAD_set_local(local, NULL);

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -117,6 +117,9 @@ init_get_thread_local(CRYPTO_THREAD_LOCAL *local, int alloc, int keep)
             CRYPTO_THREAD_unlock(gtr->lock);
 #endif
             if (!CRYPTO_THREAD_set_local(local, hands)) {
+#ifndef FIPS_MODE
+                sk_THREAD_EVENT_HANDLER_PTR_pop(gtr->skhands);
+#endif
                 OPENSSL_free(hands);
                 return NULL;
             }


### PR DESCRIPTION
When CRYPTO_THREAD_set_local() failed, we didn't pop the hands arrays
from the thread event handler pointer stack that we had just pushed,
but still free that same array.  That left the pointer in the stack
open for pointing at complete garbage.

Fixed by popping the stack in this case.
