### PR TITLE
In documentation, consistently refer to OpenSSL 3.0

### DIFF
--- a/doc/internal/man3/DEFINE_SPARSE_ARRAY_OF.pod
+++ b/doc/internal/man3/DEFINE_SPARSE_ARRAY_OF.pod
@@ -108,7 +108,7 @@ ossl_sa_TYPE_free_leaves() do not return values.
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/internal/man3/OSSL_METHOD_STORE.pod
+++ b/doc/internal/man3/OSSL_METHOD_STORE.pod
@@ -103,7 +103,7 @@ ossl_method_store_free() and ossl_method_store_cleanup() do not return values.
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/verify.pod
+++ b/doc/man1/verify.pod
@@ -779,7 +779,7 @@ The B<-show_chain> option was added in OpenSSL 1.1.0.
 The B<-issuer_checks> option is deprecated as of OpenSSL 1.1.0 and
 is silently ignored.
 
-The B<-sm2-id> and B<-sm2-hex-id> options were added in OpenSSL 3.0.0.
+The B<-sm2-id> and B<-sm2-hex-id> options were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/ASYNC_WAIT_CTX_new.pod
+++ b/doc/man3/ASYNC_WAIT_CTX_new.pod
@@ -195,7 +195,7 @@ were added in OpenSSL 1.1.0.
 
 ASYNC_WAIT_CTX_set_callback(), ASYNC_WAIT_CTX_get_callback(),
 ASYNC_WAIT_CTX_set_status(), and ASYNC_WAIT_CTX_get_status()
-were added in OpenSSL 3.0.0.
+were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -141,7 +141,7 @@ the case of BIO_seek() on a file BIO for a successful operation.
 =head1 HISTORY
 
 The BIO_get_ktls_send() and BIO_get_ktls_recv() functions were added in
-OpenSSL 3.0.0.
+OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -162,7 +162,7 @@ dup_func() should return 0 for failure and 1 for success.
 
 =head1 HISTORY
 
-CRYPTO_alloc_ex_data() was added in OpenSSL 3.0.0.
+CRYPTO_alloc_ex_data() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_KDF_CTX.pod
+++ b/doc/man3/EVP_KDF_CTX.pod
@@ -282,7 +282,7 @@ L<EVP_KDF_X942KDF(7)>
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -358,7 +358,7 @@ L<EVP_MAC_POLY1305(7)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 3.0.0.
+These functions were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_supports_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_supports_digest_nid.pod
@@ -39,7 +39,7 @@ L<EVP_PKEY_verify_recover(3)>,
 
 =head1 HISTORY
 
-The EVP_PKEY_supports_digest_nid() function was added in OpenSSL 3.0.0.
+The EVP_PKEY_supports_digest_nid() function was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OPENSSL_CTX.pod
+++ b/doc/man3/OPENSSL_CTX.pod
@@ -38,7 +38,7 @@ OPENSSL_CTX_free() doesn't return any value.
 =head1 HISTORY
 
 OPENSSL_CTX, OPENSSL_CTX_new() and OPENSSL_CTX_free()
-were added in OpenSSL 3.0.0.
+were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -312,7 +312,7 @@ L<openssl-core.h(7)>, L<OSSL_PARAM(3)>
 
 =head1 HISTORY
 
-These APIs were introduced in OpenSSL 3.0.0.
+These APIs were introduced in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -278,7 +278,7 @@ otherwise C<NULL>.
 
 =head1 HISTORY
 
-The OpenSSL Tracing API was added ino OpenSSL 3.0.0.
+The OpenSSL Tracing API was added ino OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_trace_get_category_num.pod
+++ b/doc/man3/OSSL_trace_get_category_num.pod
@@ -30,7 +30,7 @@ C<num> is a recognised category number, otherwise NULL.
 
 =head1 HISTORY
 
-The OpenSSL Tracing API was added ino OpenSSL 3.0.0.
+The OpenSSL Tracing API was added ino OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -297,7 +297,7 @@ functions described here are inoperational, i.e. will do nothing.
 
 OSSL_trace_set_channel(), OSSL_trace_set_prefix(),
 OSSL_trace_set_suffix(), and OSSL_trace_set_callback() were all added
-in OpenSSL 3.0.0.
+in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -219,7 +219,7 @@ L<crypto(7)>
 
 =head1 HISTORY
 
-The macros and functions described here were added in OpenSSL 3.0.0,
+The macros and functions described here were added in OpenSSL 3.0,
 with the exception of the L</BACKWARD COMPATIBILITY> ones.
 
 =head1 COPYRIGHT

--- a/doc/man3/RAND_DRBG_generate.pod
+++ b/doc/man3/RAND_DRBG_generate.pod
@@ -76,7 +76,7 @@ L<RAND_DRBG(7)>
 
 The RAND_DRBG functions were added in OpenSSL 1.1.1.
 
-Prediction resistance is supported from OpenSSL 3.0.0.
+Prediction resistance is supported from OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/RAND_DRBG_reseed.pod
+++ b/doc/man3/RAND_DRBG_reseed.pod
@@ -104,7 +104,7 @@ L<RAND_DRBG(7)>
 
 The RAND_DRBG functions were added in OpenSSL 1.1.1.
 
-Prediction resistance is supported from OpenSSL 3.0.0.
+Prediction resistance is supported from OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_VBASE_new.pod
+++ b/doc/man3/SRP_VBASE_new.pod
@@ -83,7 +83,7 @@ L<SSL_CTX_set_srp_password(3)>
 
 =head1 HISTORY
 
-The SRP_VBASE_add0_user() function was added in OpenSSL 3.0.0.
+The SRP_VBASE_add0_user() function was added in OpenSSL 3.0.
 
 All other functions were added in OpenSSL 1.0.1.
 

--- a/doc/man3/SRP_user_pwd_new.pod
+++ b/doc/man3/SRP_user_pwd_new.pod
@@ -56,7 +56,7 @@ L<SSL_CTX_set_srp_password(3)>
 
 =head1 HISTORY
 
-These functions were made public in OpenSSL 3.0.0.
+These functions were made public in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -96,7 +96,7 @@ and the handshake will fail.
 
 OSSL_default_cipher_list() and OSSL_default_ciphersuites() replace
 SSL_DEFAULT_CIPHER_LIST and TLS_DEFAULT_CIPHERSUITES, respectively. The
-cipher list defines are deprecated as of 3.0.0.
+cipher list defines are deprecated as of 3.0.
 
 =head1 RETURN VALUES
 
@@ -115,7 +115,7 @@ L<ciphers(1)>
 
 =head1 HISTORY
 
-OSSL_default_cipher_list() and OSSL_default_ciphersites() are new in 3.0.0.
+OSSL_default_cipher_list() and OSSL_default_ciphersites() are new in 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_mode.pod
+++ b/doc/man3/SSL_CTX_set_mode.pod
@@ -150,7 +150,7 @@ L<SSL_write(3)>, L<SSL_get_error(3)>
 =head1 HISTORY
 
 SSL_MODE_ASYNC was added in OpenSSL 1.1.0.
-SSL_MODE_NO_KTLS_TX was added in OpenSSL 3.0.0.
+SSL_MODE_NO_KTLS_TX was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -374,7 +374,7 @@ OpenSSL 0.9.8m.
 The B<SSL_OP_PRIORITIZE_CHACHA> and B<SSL_OP_NO_RENEGOTIATION> options
 were added in OpenSSL 1.1.1.
 
-The B<SSL_OP_NO_EXTENDED_MASTER_SECRET> option was added in OpenSSL 3.0.0.
+The B<SSL_OP_NO_EXTENDED_MASTER_SECRET> option was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_set_async_callback.pod
+++ b/doc/man3/SSL_set_async_callback.pod
@@ -82,7 +82,7 @@ SSL_get_async_status() return 1 on success or 0 on error.
 
 SSL_CTX_set_async_callback(), SSL_CTX_set_async_callback_arg(),
 SSL_set_async_callback(), SSL_set_async_callback_arg() and
-SSL_get_async_status() were first added to OpenSSL 3.0.0.
+SSL_get_async_status() were first added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -141,7 +141,7 @@ L<ssl(7)>, L<bio(7)>
 =head1 HISTORY
 
 The SSL_write_ex() function was added in OpenSSL 1.1.1.
-The SSL_sendfile() function was added in OpenSSL 3.0.0.
+The SSL_sendfile() function was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_KDF_PBKDF2.pod
+++ b/doc/man7/EVP_KDF_PBKDF2.pod
@@ -93,7 +93,7 @@ L<EVP_KDF_CTX(3)/CONTROLS>
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_KDF_SS.pod
+++ b/doc/man7/EVP_KDF_SS.pod
@@ -211,7 +211,7 @@ L<EVP_KDF_CTX(3)/CONTROLS>
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_KDF_X942.pod
+++ b/doc/man7/EVP_KDF_X942.pod
@@ -136,7 +136,7 @@ L<EVP_KDF_CTX(3)/CONTROLS>
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_KDF_X963.pod
+++ b/doc/man7/EVP_KDF_X963.pod
@@ -122,7 +122,7 @@ L<EVP_KDF_CTX(3)/CONTROLS>
 
 =head1 HISTORY
 
-This functionality was added to OpenSSL 3.0.0.
+This functionality was added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_MAC_BLAKE2.pod
+++ b/doc/man7/EVP_MAC_BLAKE2.pod
@@ -100,7 +100,7 @@ L<EVP_MAC_ctrl(3)>, L<EVP_MAC(3)/CONTROLS>
 
 =head1 HISTORY
 
-The macros and functions described here were added to OpenSSL 3.0.0.
+The macros and functions described here were added to OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/openssl_user_macros.pod.in
+++ b/doc/man7/openssl_user_macros.pod.in
@@ -60,7 +60,7 @@ However, it is recommended to start using the second form instead:
 =item C<m>
 
 This form is a simple number that represents the major version number
-and is supported for version 3.0.0 and up.  For extra convenience,
+and is supported for version 3.0 and up.  For extra convenience,
 these numbers are also available:
 
 =over 4


### PR DESCRIPTION
3.0.0 is a habit from pre-3.0 OpenSSL, which doesn't make sense with
the new version scheme.
