### PR TITLE
Fix SSL_CTX_set_session_id_context() docs

### DIFF
--- a/doc/man3/SSL_CTX_set_session_id_context.pod
+++ b/doc/man3/SSL_CTX_set_session_id_context.pod
@@ -42,7 +42,7 @@ OpenSSL clients will check the session id context returned by the server
 when reusing a session.
 
 The maximum length of the B<sid_ctx> is limited to
-B<SSL_MAX_SSL_SESSION_ID_LENGTH>.
+B<SSL_MAX_SID_CTX_LENGTH>.
 
 =head1 WARNINGS
 
@@ -67,7 +67,7 @@ return the following values:
 =item Z<>0
 
 The length B<sid_ctx_len> of the session id context B<sid_ctx> exceeded
-the maximum allowed length of B<SSL_MAX_SSL_SESSION_ID_LENGTH>. The error
+the maximum allowed length of B<SSL_MAX_SID_CTX_LENGTH>. The error
 is logged to the error stack.
 
 =item Z<>1

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -877,7 +877,7 @@ int SSL_up_ref(SSL *s)
 int SSL_CTX_set_session_id_context(SSL_CTX *ctx, const unsigned char *sid_ctx,
                                    unsigned int sid_ctx_len)
 {
-    if (sid_ctx_len > sizeof(ctx->sid_ctx)) {
+    if (sid_ctx_len > SSL_MAX_SID_CTX_LENGTH) {
         SSLerr(SSL_F_SSL_CTX_SET_SESSION_ID_CONTEXT,
                SSL_R_SSL_SESSION_ID_CONTEXT_TOO_LONG);
         return 0;


### PR DESCRIPTION
Also, use define rather than sizeof

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
