### PR TITLE
WIP: Add "legacy" among the fallbacks

### DIFF
--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -18,6 +18,11 @@ const struct predefined_providers_st predefined_providers[] = {
     { "fips", fips_intern_provider_init, 1 },
 #else
     { "default", ossl_default_provider_init, 1 },
+    /*
+     * TODO(4.0) Revisit this.  This is primarly to avoid surprise failures
+     * for OpenSSL 3.0 users.
+     */
+    { "legacy", NULL, 1 },
 #endif
     { NULL, NULL, 0 }
 };


### PR DESCRIPTION
That makes the use of 3.0 less surprising.

To be revisited in OpenSSL 4.0.
