### PR TITLE
WIP: Testing: make it possible to test with the fips provider only

### DIFF
--- a/test/fips.cnf
+++ b/test/fips.cnf
@@ -1,0 +1,10 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+fips = fips_sect
+
+[fips_sect]
+activate = 1

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -28,7 +28,7 @@ my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 
-$ENV{OPENSSL_CONF} = ($ENV{TEST_FIPS} // 0)
+$ENV{OPENSSL_CONF} = ($ENV{FIPS_MODE} // 0)
     ? catdir($srctop, "test", "fips.cnf")
     : catdir($srctop, "apps", "openssl.cnf");
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -28,7 +28,11 @@ my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 
-$ENV{OPENSSL_CONF} = catdir($srctop, "apps", "openssl.cnf");
+$ENV{OPENSSL_CONF} = ($ENV{TEST_FIPS} // 0)
+    ? catdir($srctop, "test", "fips.cnf")
+    : catdir($srctop, "apps", "openssl.cnf");
+
+print STDERR "Default configuration file: $ENV{OPENSSL_CONF}\n";
 
 my %tapargs =
     ( verbosity => $ENV{VERBOSE} || $ENV{V} || $ENV{HARNESS_VERBOSE} ? 1 : 0,


### PR DESCRIPTION
This is done by using the environment variale TEST_FIPS, which can be
set through make like this:

    make test TEST_FIPS=1

We also add a special configuration file to load the FIPS provider
only.
