### PR TITLE
Fix a C++ comment in the refcount.h

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -105,7 +105,7 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret, void *lock)
 #    if _WIN32_WCE >= 0x600
       extern long __cdecl _InterlockedExchangeAdd(long volatile*, long);
 #    else
-      // under Windows CE we still have old-style Interlocked* functions
+      /* under Windows CE we still have old-style Interlocked* functions */
       extern long __cdecl InterlockedExchangeAdd(long volatile*, long);
 #     define _InterlockedExchangeAdd InterlockedExchangeAdd
 #    endif


### PR DESCRIPTION
Although in a false-conditional code section gcc-4.8.4 flagged this with
a C90 warning :-(

include/internal/refcount.h:108:7: error: C++ style comments are not allowed in ISO C90 [-Werror]
       // under Windows CE we still have old-style Interlocked* functions

