### PR TITLE
Rework EVP_MD support, enhance existing functions

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -466,15 +466,18 @@ const OSSL_PROVIDER *EVP_MD_provider(const EVP_MD *md)
 
 int EVP_MD_block_size(const EVP_MD *md)
 {
+    int ok, v = md->block_size;
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+
     if (md == NULL) {
         EVPerr(EVP_F_EVP_MD_BLOCK_SIZE, EVP_R_MESSAGE_DIGEST_IS_NULL);
         return -1;
     }
 
-    if (md->prov != NULL && md->dblock_size != NULL)
-        return (int)md->dblock_size();
+    params[0] = OSSL_PARAM_construct_int(OSSL_DIGEST_PARAM_BLOCK_SIZE, &v);
+    ok = evp_do_md_getparams(md, params);
 
-    return md->block_size;
+    return ok != 0 ? v : -1;
 }
 
 int EVP_MD_type(const EVP_MD *md)
@@ -489,20 +492,30 @@ int EVP_MD_pkey_type(const EVP_MD *md)
 
 int EVP_MD_size(const EVP_MD *md)
 {
-    if (!md) {
+    int ok, v = md->md_size;
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+
+    if (md == NULL) {
         EVPerr(EVP_F_EVP_MD_SIZE, EVP_R_MESSAGE_DIGEST_IS_NULL);
         return -1;
     }
 
-    if (md->prov != NULL && md->size != NULL)
-        return (int)md->size();
+    params[0] = OSSL_PARAM_construct_int(OSSL_DIGEST_PARAM_SIZE, &v);
+    ok = evp_do_md_getparams(md, params);
 
-    return md->md_size;
+    return ok != 0 ? v : -1;
 }
 
 unsigned long EVP_MD_flags(const EVP_MD *md)
 {
-    return md->flags;
+    int ok;
+    unsigned long v = md->flags;
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+
+    params[0] = OSSL_PARAM_construct_ulong(OSSL_CIPHER_PARAM_FLAGS, &v);
+    ok = evp_do_md_getparams(md, params);
+
+    return ok != 0 ? v : 0;
 }
 
 EVP_MD *EVP_MD_meth_new(int md_type, int pkey_type)

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -170,6 +170,11 @@ int evp_do_ciph_ctx_getparams(const EVP_CIPHER *ciph, void *provctx,
                               OSSL_PARAM params[]);
 int evp_do_ciph_ctx_setparams(const EVP_CIPHER *ciph, void *provctx,
                               OSSL_PARAM params[]);
+int evp_do_md_getparams(const EVP_MD *md, OSSL_PARAM params[]);
+int evp_do_md_ctx_getparams(const EVP_MD *md, void *provctx,
+                            OSSL_PARAM params[]);
+int evp_do_md_ctx_setparams(const EVP_MD *md, void *provctx,
+                            OSSL_PARAM params[]);
 
 OSSL_PARAM *evp_pkey_to_param(EVP_PKEY *pkey, size_t *sz);
 

--- a/crypto/evp/evp_utils.c
+++ b/crypto/evp/evp_utils.c
@@ -73,9 +73,7 @@ PARAM_FUNCTIONS(EVP_CIPHER,
                 evp_do_ciph_ctx_getparams, ctx_get_params,
                 evp_do_ciph_ctx_setparams, ctx_set_params)
 
-#if 0
 PARAM_FUNCTIONS(EVP_MD,
                 evp_do_md_getparams, get_params,
                 evp_do_md_ctx_getparams, ctx_get_params,
                 evp_do_md_ctx_setparams, ctx_set_params)
-#endif

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -39,7 +39,7 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
      * The HMAC construction is not allowed to be used with the
      * extendable-output functions (XOF) shake128 and shake256.
      */
-    if ((EVP_MD_meth_get_flags(md) & EVP_MD_FLAG_XOF) != 0)
+    if ((EVP_MD_flags(md) & EVP_MD_FLAG_XOF) != 0)
         return 0;
 
     if (key != NULL) {

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -212,10 +212,9 @@ struct evp_md_st {
     OSSL_OP_digest_digest_fn *digest;
     OSSL_OP_digest_freectx_fn *freectx;
     OSSL_OP_digest_dupctx_fn *dupctx;
-    OSSL_OP_digest_size_fn *size;
-    OSSL_OP_digest_block_size_fn *dblock_size;
-    OSSL_OP_digest_set_params_fn *set_params;
     OSSL_OP_digest_get_params_fn *get_params;
+    OSSL_OP_digest_ctx_set_params_fn *ctx_set_params;
+    OSSL_OP_digest_ctx_get_params_fn *ctx_get_params;
 
 } /* EVP_MD */ ;
 

--- a/doc/man7/provider-digest.pod
+++ b/doc/man7/provider-digest.pod
@@ -31,10 +31,11 @@ provider-digest - The digest library E<lt>-E<gt> provider functions
                       unsigned char *out, size_t *outl, size_t outsz);
 
  /* Digest parameters */
- size_t OP_digest_size(void);
- size_t OP_digest_block_size(void);
- int OP_digest_set_params(void *dctx, const OSSL_PARAM params[]);
- int OP_digest_get_params(void *dctx, OSSL_PARAM params[]);
+ int OP_digest_get_params(OSSL_PARAM params[]);
+
+ /* Digest context parameters */
+ int OP_digest_ctx_set_params(void *dctx, const OSSL_PARAM params[]);
+ int OP_digest_ctx_get_params(void *dctx, OSSL_PARAM params[]);
 
 =head1 DESCRIPTION
 
@@ -129,18 +130,72 @@ exceed B<outsz> bytes.
 
 =head2 Digest Parameters
 
-OP_digest_size() should return the size of the digest.
+OP_digest_get_params() gets details of the algorithm implementation
+and stores them in B<params>.
+See L<OSSL_PARAM(3)> for further details on the parameters structure.
 
-OP_digest_block_size() should return the size of the block size of the
-underlying digest algorithm.
+Parameters currently recognised by built-in digests with this function
+are as follows. Not all parametes are relevant to, or are understood
+by all digests:
 
-OP_digest_set_params() set digest parameters associated with the given provider
-side digest context B<dctx> to B<params>.
+=over 4
+
+=item B<OSSL_DIGEST_PARAM_BLOCK_SIZE> (int)
+
+The digest block size.
+
+=item B<OSSL_DIGEST_PARAM_SIZE> (int)
+
+The digest output size.
+
+=item B<OSSL_DIGEST_PARAM_FLAGS> (unsigned long)
+
+Diverse flags that describe exceptional behaviour for the digest:
+
+=over 4
+
+=item B<EVP_MD_FLAG_ONESHOT>
+
+This digest method can only handle one block of input.
+
+=item B<EVP_MD_FLAG_XOF>
+
+This digest method is an extensible-output function (XOF) and supports
+setting the B<OSSL_DIGEST_PARAM_XOFLEN> parameter.
+
+=item B<EVP_MD_FLAG_DIGALGID_NULL>
+
+When setting up a DigestAlgorithmIdentifier, this flag will have the
+parameter set to NULL by default.  Use this for PKCS#1.  I<Note: if
+combined with EVP_MD_FLAG_DIGALGID_ABSENT, the latter will override.>
+
+=item B<EVP_MD_FLAG_DIGALGID_ABSENT>
+
+When setting up a DigestAlgorithmIdentifier, this flag will have the
+parameter be left absent by default.  I<Note: if combined with
+EVP_MD_FLAG_DIGALGID_NULL, the latter will be overridden.>
+
+=item B<EVP_MD_FLAG_DIGALGID_CUSTOM>
+
+Custom DigestAlgorithmIdentifier handling via ctrl, with
+B<EVP_MD_FLAG_DIGALGID_ABSENT> as default.  I<Note: if combined with
+EVP_MD_FLAG_DIGALGID_NULL, the latter will be overridden.>
+Currently unused.
+
+=back
+
+=back
+
+=head2 Digest Context Parameters
+
+OP_digest_ctx_set_params() sets digest parameters associated with the
+given provider side digest context B<dctx> to B<params>.
 Any parameter settings are additional to any that were previously set.
 See L<OSSL_PARAM(3)> for further details on the parameters structure.
 
-OP_digest_get_params() gets details of currently set parameters values associated
-with the give provider side digest context B<dctx> and stores them in B<params>.
+OP_digest_ctx_get_params() gets details of currently set parameters
+values associated with the give provider side digest context B<dctx>
+and stores them in B<params>.
 See L<OSSL_PARAM(3)> for further details on the parameters structure.
 
 Parameters currently recognised by built-in digests are as follows. Not all

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -55,6 +55,9 @@ extern "C" {
 #define OSSL_DIGEST_PARAM_SSL3_MS   "ssl3-ms"
 #define OSSL_DIGEST_PARAM_PAD_TYPE  "pad_type"
 #define OSSL_DIGEST_PARAM_MICALG    "micalg"
+#define OSSL_DIGEST_PARAM_BLOCK_SIZE "blocksize" /* OSSL_PARAM_INTEGER */
+#define OSSL_DIGEST_PARAM_SIZE      "size" /* OSSL_PARAM_INTEGER */
+#define OSSL_DIGEST_PARAM_FLAGS     "flags" /* OSSL_PARAM_UNSIGNED_INTEGER */
 
 /* PKEY parameters */
 /* Diffie-Hellman Parameters */

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -136,19 +136,18 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,provider_get_reason_strings,
 
 /* Digests */
 
-# define OSSL_OP_DIGEST                     1
+# define OSSL_OP_DIGEST                              1
 
-# define OSSL_FUNC_DIGEST_NEWCTX            1
-# define OSSL_FUNC_DIGEST_INIT              2
-# define OSSL_FUNC_DIGEST_UPDATE            3
-# define OSSL_FUNC_DIGEST_FINAL             4
-# define OSSL_FUNC_DIGEST_DIGEST            5
-# define OSSL_FUNC_DIGEST_FREECTX           6
-# define OSSL_FUNC_DIGEST_DUPCTX            7
-# define OSSL_FUNC_DIGEST_SIZE              8
-# define OSSL_FUNC_DIGEST_BLOCK_SIZE        9
-# define OSSL_FUNC_DIGEST_SET_PARAMS        10
-# define OSSL_FUNC_DIGEST_GET_PARAMS        11
+# define OSSL_FUNC_DIGEST_NEWCTX                     1
+# define OSSL_FUNC_DIGEST_INIT                       2
+# define OSSL_FUNC_DIGEST_UPDATE                     3
+# define OSSL_FUNC_DIGEST_FINAL                      4
+# define OSSL_FUNC_DIGEST_DIGEST                     5
+# define OSSL_FUNC_DIGEST_FREECTX                    6
+# define OSSL_FUNC_DIGEST_DUPCTX                     7
+# define OSSL_FUNC_DIGEST_GET_PARAMS                 8
+# define OSSL_FUNC_DIGEST_CTX_SET_PARAMS             9
+# define OSSL_FUNC_DIGEST_CTX_GET_PARAMS            10
 
 OSSL_CORE_MAKE_FUNC(void *, OP_digest_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_digest_init, (void *dctx))
@@ -164,12 +163,11 @@ OSSL_CORE_MAKE_FUNC(int, OP_digest_digest,
 OSSL_CORE_MAKE_FUNC(void, OP_digest_freectx, (void *dctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_digest_dupctx, (void *dctx))
 
-OSSL_CORE_MAKE_FUNC(size_t, OP_digest_size, (void))
-OSSL_CORE_MAKE_FUNC(size_t, OP_digest_block_size, (void))
-OSSL_CORE_MAKE_FUNC(int, OP_digest_set_params,
-                    (void *dctx, const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_digest_get_params,
-                    (void *dctx, OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_digest_get_params, (OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_digest_ctx_set_params,
+                    (void *vctx, const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_digest_ctx_get_params,
+                    (void *vctx, OSSL_PARAM params[]))
 
 /* Symmetric Ciphers */
 

--- a/providers/common/digests/sha2_prov.c
+++ b/providers/common/digests/sha2_prov.c
@@ -9,6 +9,7 @@
 
 #include <openssl/crypto.h>
 #include <openssl/core_numbers.h>
+#include <openssl/evp.h>
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/params.h>
@@ -17,7 +18,7 @@
 #include "internal/provider_algs.h"
 #include "internal/sha.h"
 
-static OSSL_OP_digest_set_params_fn sha1_set_params;
+static OSSL_OP_digest_ctx_set_params_fn sha1_set_params;
 
 /* Special set_params method for SSL3 */
 static int sha1_set_params(void *vctx, const OSSL_PARAM params[])
@@ -36,30 +37,37 @@ static int sha1_set_params(void *vctx, const OSSL_PARAM params[])
 
 OSSL_FUNC_DIGEST_CONSTRUCT_PARAMS(sha1, SHA_CTX,
                            SHA_CBLOCK, SHA_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA1_Init, SHA1_Update, SHA1_Final,
                            sha1_set_params)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sha224, SHA256_CTX,
                            SHA256_CBLOCK, SHA224_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA224_Init, SHA224_Update, SHA224_Final)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sha256, SHA256_CTX,
                            SHA256_CBLOCK, SHA256_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA256_Init, SHA256_Update, SHA256_Final)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sha384, SHA512_CTX,
                            SHA512_CBLOCK, SHA384_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA384_Init, SHA384_Update, SHA384_Final)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sha512, SHA512_CTX,
                            SHA512_CBLOCK, SHA512_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA512_Init, SHA512_Update, SHA512_Final)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sha512_224, SHA512_CTX,
                            SHA512_CBLOCK, SHA224_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            sha512_224_init, SHA512_Update, SHA512_Final)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sha512_256, SHA512_CTX,
                            SHA512_CBLOCK, SHA256_DIGEST_LENGTH,
+                           EVP_MD_FLAG_DIGALGID_ABSENT,
                            sha512_256_init, SHA512_Update, SHA512_Final)
 

--- a/providers/default/digests/blake2_prov.c
+++ b/providers/default/digests/blake2_prov.c
@@ -32,9 +32,9 @@ int blake2b512_init(void *ctx)
 }
 
 OSSL_FUNC_DIGEST_CONSTRUCT(blake2s256, BLAKE2S_CTX,
-                           BLAKE2S_BLOCKBYTES, BLAKE2S_DIGEST_LENGTH,
+                           BLAKE2S_BLOCKBYTES, BLAKE2S_DIGEST_LENGTH, 0,
                            blake2s256_init, blake2s_update, blake2s_final)
 
 OSSL_FUNC_DIGEST_CONSTRUCT(blake2b512, BLAKE2B_CTX,
-                           BLAKE2B_BLOCKBYTES, BLAKE2B_DIGEST_LENGTH,
+                           BLAKE2B_BLOCKBYTES, BLAKE2B_DIGEST_LENGTH, 0,
                            blake2b512_init, blake2b_update, blake2b_final)

--- a/providers/default/digests/md5_prov.c
+++ b/providers/default/digests/md5_prov.c
@@ -13,5 +13,5 @@
 #include "internal/provider_algs.h"
 
 OSSL_FUNC_DIGEST_CONSTRUCT(md5, MD5_CTX,
-                           MD5_CBLOCK, MD5_DIGEST_LENGTH,
+                           MD5_CBLOCK, MD5_DIGEST_LENGTH, 0,
                            MD5_Init, MD5_Update, MD5_Final)

--- a/providers/default/digests/md5_sha1_prov.c
+++ b/providers/default/digests/md5_sha1_prov.c
@@ -17,7 +17,7 @@
 #include "internal/md5_sha1.h"
 #include "internal/provider_algs.h"
 
-static OSSL_OP_digest_set_params_fn md5_sha1_set_params;
+static OSSL_OP_digest_ctx_set_params_fn md5_sha1_set_params;
 
 /* Special set_params method for SSL3 */
 static int md5_sha1_set_params(void *vctx, const OSSL_PARAM params[])
@@ -35,6 +35,6 @@ static int md5_sha1_set_params(void *vctx, const OSSL_PARAM params[])
 }
 
 OSSL_FUNC_DIGEST_CONSTRUCT_PARAMS(md5_sha1, MD5_SHA1_CTX,
-                                  MD5_SHA1_CBLOCK, MD5_SHA1_DIGEST_LENGTH,
+                                  MD5_SHA1_CBLOCK, MD5_SHA1_DIGEST_LENGTH, 0,
                                   md5_sha1_init, md5_sha1_update, md5_sha1_final,
                                   md5_sha1_set_params)

--- a/providers/default/digests/null_prov.c
+++ b/providers/default/digests/null_prov.c
@@ -8,6 +8,8 @@
  */
 
 #include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
 #include <openssl/whrlpool.h>
 #include "internal/provider_algs.h"
 
@@ -19,18 +21,7 @@ static OSSL_OP_digest_final_fn nullmd_final;
 static OSSL_OP_digest_newctx_fn nullmd_newctx;
 static OSSL_OP_digest_freectx_fn nullmd_freectx;
 static OSSL_OP_digest_dupctx_fn nullmd_dupctx;
-static OSSL_OP_digest_size_fn nullmd_size;
-static OSSL_OP_digest_block_size_fn nullmd_block_size;
-
-static size_t nullmd_block_size(void)
-{
-    return 0;
-}
-
-static size_t nullmd_size(void)
-{
-    return 0;
-}
+static OSSL_OP_digest_get_params_fn nullmd_get_params;
 
 static int nullmd_init(void *vctx)
 {
@@ -62,6 +53,22 @@ static void *nullmd_dupctx(void *ctx)
     return &nullmd_dummy;
 }
 
+static int nullmd_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p = NULL;
+
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_int(p, 0))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_int(p, 0))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_FLAGS);
+    if (p != NULL && !OSSL_PARAM_set_ulong(p, 0))
+        return 0;
+    return 1;
+}
+
 const OSSL_DISPATCH nullmd_functions[] = {
     { OSSL_FUNC_DIGEST_NEWCTX, (void (*)(void))nullmd_newctx },
     { OSSL_FUNC_DIGEST_INIT, (void (*)(void))nullmd_init },
@@ -69,7 +76,6 @@ const OSSL_DISPATCH nullmd_functions[] = {
     { OSSL_FUNC_DIGEST_FINAL, (void (*)(void))nullmd_final },
     { OSSL_FUNC_DIGEST_FREECTX, (void (*)(void))nullmd_freectx },
     { OSSL_FUNC_DIGEST_DUPCTX, (void (*)(void))nullmd_dupctx },
-    { OSSL_FUNC_DIGEST_SIZE, (void (*)(void))nullmd_size },
-    { OSSL_FUNC_DIGEST_BLOCK_SIZE, (void (*)(void))nullmd_block_size },
+    { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))nullmd_get_params },
     { 0, NULL }
 };

--- a/providers/default/digests/sm3_prov.c
+++ b/providers/default/digests/sm3_prov.c
@@ -13,5 +13,5 @@
 #include "internal/provider_algs.h"
 
 OSSL_FUNC_DIGEST_CONSTRUCT(sm3, SM3_CTX,
-                           SM3_CBLOCK, SM3_DIGEST_LENGTH,
+                           SM3_CBLOCK, SM3_DIGEST_LENGTH, 0,
                            sm3_init, sm3_update, sm3_final)

--- a/providers/legacy/digests/md2_prov.c
+++ b/providers/legacy/digests/md2_prov.c
@@ -14,5 +14,5 @@
 #include "internal/provider_algs.h"
 
 OSSL_FUNC_DIGEST_CONSTRUCT(md2, MD2_CTX,
-                           MD2_BLOCK, MD2_DIGEST_LENGTH,
+                           MD2_BLOCK, MD2_DIGEST_LENGTH, 0,
                            MD2_Init, MD2_Update, MD2_Final)

--- a/providers/legacy/digests/md4_prov.c
+++ b/providers/legacy/digests/md4_prov.c
@@ -14,5 +14,5 @@
 #include "internal/provider_algs.h"
 
 OSSL_FUNC_DIGEST_CONSTRUCT(md4, MD4_CTX,
-                           MD4_CBLOCK, MD4_DIGEST_LENGTH,
+                           MD4_CBLOCK, MD4_DIGEST_LENGTH, 0,
                            MD4_Init, MD4_Update, MD4_Final)

--- a/providers/legacy/digests/mdc2_prov.c
+++ b/providers/legacy/digests/mdc2_prov.c
@@ -15,7 +15,7 @@
 #include "internal/core_mkdigest.h"
 #include "internal/provider_algs.h"
 
-static OSSL_OP_digest_set_params_fn mdc2_set_params;
+static OSSL_OP_digest_ctx_set_params_fn mdc2_set_params;
 
 static int mdc2_set_params(void *vctx, const OSSL_PARAM params[])
 {
@@ -32,6 +32,6 @@ static int mdc2_set_params(void *vctx, const OSSL_PARAM params[])
 }
 
 OSSL_FUNC_DIGEST_CONSTRUCT_PARAMS(mdc2, MDC2_CTX,
-                                  MDC2_BLOCK, MDC2_DIGEST_LENGTH,
+                                  MDC2_BLOCK, MDC2_DIGEST_LENGTH, 0,
                                   MDC2_Init, MDC2_Update, MDC2_Final,
                                   mdc2_set_params)

--- a/providers/legacy/digests/ripemd_prov.c
+++ b/providers/legacy/digests/ripemd_prov.c
@@ -14,5 +14,5 @@
 #include "internal/provider_algs.h"
 
 OSSL_FUNC_DIGEST_CONSTRUCT(ripemd160, RIPEMD160_CTX,
-                           RIPEMD160_CBLOCK, RIPEMD160_DIGEST_LENGTH,
+                           RIPEMD160_CBLOCK, RIPEMD160_DIGEST_LENGTH, 0,
                            RIPEMD160_Init, RIPEMD160_Update, RIPEMD160_Final)

--- a/providers/legacy/digests/wp_prov.c
+++ b/providers/legacy/digests/wp_prov.c
@@ -14,5 +14,5 @@
 #include "internal/provider_algs.h"
 
 OSSL_FUNC_DIGEST_CONSTRUCT(wp, WHIRLPOOL_CTX,
-                           WHIRLPOOL_BBLOCK / 8, WHIRLPOOL_DIGEST_LENGTH,
+                           WHIRLPOOL_BBLOCK / 8, WHIRLPOOL_DIGEST_LENGTH, 0,
                            WHIRLPOOL_Init, WHIRLPOOL_Update, WHIRLPOOL_Final)


### PR DESCRIPTION
This adds missing support for providers in diverse EVP_MD and EVP_MD_CTX functions, and does a bit of cleanup as well.

This is similar to #9328, but for EVP_MD
