### PR TITLE
test/enginetest.c: Make sure no config file is loaded

### DIFF
--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -121,10 +121,12 @@ static int test_engines(void)
     display_engine_list();
 
     /*
-     * At this point, only |new_h1| should remain in the list of engines,
-     * so this removal should empty the list of available engines.
-     * If not, some engine got loaded by other means that our additions
-     * above, and adding |new_h1| again below may fail...
+     * At this point, we should have an empty list, unless some hardware
+     * support engine got added.  However, since we don't allow the config
+     * file to be loaded and don't otherwise load any built in engines,
+     * that is unlikely.  Still, we check, if for nothing else, then to
+     * notify that something is a little off (and might mean that |new_h1|
+     * wasn't unloaded when it should have)
      */
     if ((ptr = ENGINE_get_first()) != NULL) {
         if (!ENGINE_remove(ptr))

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -121,10 +121,10 @@ static int test_engines(void)
     display_engine_list();
 
     /*
-     * This supposedly removes |new_h1|, but that only works if no extra
-     * engines have been loaded, such as the dynamic engine that gets
-     * loaded when dealing with a config file.
-     * See global_init() below for how we deal with the issue.
+     * At this point, only |new_h1| should remain in the list of engines,
+     * so this removal should empty the list of available engines.
+     * If not, some engine got loaded by other means that our additions
+     * above, and adding |new_h1| again below may fail...
      */
     if ((ptr = ENGINE_get_first()) != NULL) {
         if (!ENGINE_remove(ptr))

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -121,8 +121,10 @@ static int test_engines(void)
     display_engine_list();
 
     /*
-     * Depending on whether there's any hardware support compiled in, this
-     * remove may be destined to fail.
+     * This supposedly removes |new_h1|, but that only works if no extra
+     * engines have been loaded, such as the dynamic engine that gets
+     * loaded when dealing with a config file.
+     * See global_init() below for how we deal with the issue.
      */
     if ((ptr = ENGINE_get_first()) != NULL) {
         if (!ENGINE_remove(ptr))
@@ -346,6 +348,15 @@ static int test_redirect(void)
     return to_return;
 }
 #endif
+
+int global_init(void)
+{
+    /*
+     * If the config file gets loaded, the dynamic engine will be loaded,
+     * and that interferes with our test above.
+     */
+    return OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, NULL);
+}
 
 int setup_tests(void)
 {


### PR DESCRIPTION
If a config file gets loaded, the tests get disturbed.
