### PR TITLE
Fix the return value for SSL_get0_chain_certs()

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3552,6 +3552,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 
     case SSL_CTRL_GET_CHAIN_CERTS:
         *(STACK_OF(X509) **)parg = s->cert->key->chain;
+        ret = 1;
         break;
 
     case SSL_CTRL_SELECT_CURRENT_CERT:


### PR DESCRIPTION
This function was always returning 0. It should return 1 on success.

Fixes #9374