### PR TITLE
cryptodev: digest_update: don't fail if len==0 [1.0.2]

### DIFF
--- a/crypto/engine/eng_cryptodev.c
+++ b/crypto/engine/eng_cryptodev.c
@@ -799,19 +799,20 @@ static int cryptodev_digest_update(EVP_MD_CTX *ctx, const void *data,
     struct dev_crypto_state *state = ctx->md_data;
     struct session_op *sess = &state->d_sess;
 
-    if (!data || state->d_fd < 0) {
+    if ((count && !data) || state->d_fd < 0) {
         printf("cryptodev_digest_update: illegal inputs \n");
-        return (0);
-    }
-
-    if (!count) {
         return (0);
     }
 
     if (!(ctx->flags & EVP_MD_CTX_FLAG_ONESHOT)) {
         /* if application doesn't support one buffer */
-        char *mac_data =
-            OPENSSL_realloc(state->mac_data, state->mac_len + count);
+        char *mac_data;
+
+        if (!count) {
+            return (1);
+        }
+
+        mac_data = OPENSSL_realloc(state->mac_data, state->mac_len + count);
 
         if (mac_data == NULL) {
             printf("cryptodev_digest_update: realloc failed\n");


### PR DESCRIPTION
~~Make this check before checking if the data pointer is NULL, and return
1 (success), instead of 0 (failure).~~
_**Edit**: First attempt was failing to get a digest when `EVP_MD_CTX_FLAG_ONESHOT` was set._

Don't fail if len==0, or if data is NULL, but len==0.

This keeps consistency with the default engine behavior, and
avoids an 'illegal inputs' error when performing RSA operations using
PKCS#1 OAEP padding.

To reproduce the issue:
- You need the cryptodev module installed (there should be a `/dev/crypto`)
- Compile 1.0.2 with `-DHAVE_CRYPTODEV -DUSE_CRYPTODEV_DIGESTS`
- Run:
```
$ echo 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' > /tmp/test.txt
$ ./apps/openssl genrsa -out /tmp/hostkey.pem
Generating RSA private key, 2048 bit long modulus
...........+++++
......+++++
e is 65537 (0x10001)
$ ./apps/openssl rsa -in /tmp/hostkey.pem -pubout > /tmp/key.pub
writing RSA key
$ ./apps/openssl rsautl -encrypt -pubin -inkey /tmp/key.pub -in /tmp/test.txt -out /tmp/cipher.txt -oaep
cryptodev_digest_update: illegal inputs
RSA operation error
$ hexdump -C /tmp/cipher.txt
$ sudo rmmod cryptodev
$ ./apps/openssl rsautl -encrypt -pubin -inkey /tmp/key.pub -in /tmp/test.txt -out /tmp/cipher.txt -oaep
$ hexdump -C /tmp/cipher.txt
00000000  7a a3 9e 89 ea c8 a9 e0  53 2e cd a7 70 42 96 56  |z.......S...pB.V|
00000010  d0 c6 5c 88 16 50 bf 0f  5e b4 35 9c 29 ef 0b 84  |..\..P..^.5.)...|
00000020  7f f1 b4 ca 47 08 89 58  05 3d 49 24 81 fe 12 0f  |....G..X.=I$....|
00000030  a6 66 02 e2 8d 10 bb 59  1b bc 34 2f a7 85 6c 56  |.f.....Y..4/..lV|
00000040  52 b3 2d 57 0d 85 8b 77  81 8e c8 fc 9a ab 2d 1c  |R.-W...w......-.|
00000050  b1 6d 86 c2 f2 7a df d9  54 54 d3 48 c7 25 6a 9a  |.m...z..TT.H.%j.|
00000060  4e 42 b0 4f 86 02 4f dd  75 05 55 f2 69 d7 da a2  |NB.O..O.u.U.i...|
00000070  44 23 6c 0c 1a 68 d3 88  0d 5b 40 3e 17 df c9 43  |D#l..h...[@>...C|
00000080  98 6a e8 13 79 26 18 80  d3 0c a9 a3 e2 01 ec 40  |.j..y&.........@|
00000090  39 9d 47 1d a8 cd a6 79  0c a9 e2 22 46 ff 5e 18  |9.G....y..."F.^.|
000000a0  31 06 97 69 ed 8d d7 35  c7 9b aa 7b b2 c8 51 1e  |1..i...5...{..Q.|
000000b0  4b 6c 91 11 c9 ee a4 0c  30 1c 0e f7 4e ee 45 1b  |Kl......0...N.E.|
000000c0  d2 24 ab 47 0e 23 fd 5e  0f 55 1a 40 97 59 f3 57  |.$.G.#.^.U.@.Y.W|
000000d0  c6 d7 7d 07 35 98 ea 40  77 29 53 e4 86 32 ff 59  |..}.5..@w)S..2.Y|
000000e0  2f 0a a1 14 ae 0a 71 25  54 51 ae 88 cf d0 14 02  |/.....q%TQ......|
000000f0  57 da 3a 4c 11 92 b6 ba  84 6f 66 f0 a8 70 e7 75  |W.:L.....of..p.u|
00000100
```
The following is the "relevant" `gdb` output:
```gdb
$ gdb --args ./apps/openssl rsautl -encrypt -pubin -inkey /tmp/key.pub -in /tmp/test.txt -out /tmp/cipher.txt -oaep
GNU gdb (Gentoo 8.3 vanilla) 8.3
(gdb) br crypto/engine/eng_cryptodev.c:803
Breakpoint 1 at 0x1756e9: file eng_cryptodev.c, line 803.
(gdb) run
Breakpoint 1, cryptodev_digest_update (ctx=0x7fffffffd630, data=0x0, count=0) at eng_cryptodev.c:803
803             printf("cryptodev_digest_update: illegal inputs \n");
(gdb) bt
#0  cryptodev_digest_update (ctx=0x7fffffffd630, data=0x0, count=0) at eng_cryptodev.c:803
#1  0x00005555556dc096 in EVP_DigestUpdate (ctx=0x7fffffffd630, data=0x0, count=0) at digest.c:259
#2  0x00005555556dc496 in EVP_Digest (data=0x0, count=0, md=0x5555558d0be5 "U", size=0x0, type=0x5555558acb60 <sha1_md>, impl=0x0)
    at digest.c:360
#3  0x00005555556b9a21 in RSA_padding_add_PKCS1_OAEP_mgf1 (to=0x5555558d0bd0 "", tlen=256,
    from=0x555555927ef0 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\nU", flen=53, param=0x0, plen=0,
    md=0x5555558acb60 <sha1_md>, mgf1md=0x5555558acb60 <sha1_md>) at rsa_oaep.c:72
#4  0x00005555556b98a3 in RSA_padding_add_PKCS1_OAEP (to=0x5555558d0bd0 "", tlen=256,
    from=0x555555927ef0 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\nU", flen=53, param=0x0, plen=0) at rsa_oaep.c:35
#5  0x00005555556b4197 in RSA_eay_public_encrypt (flen=53,
    from=0x555555927ef0 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\nU", to=0x5555559259e0 "\320\v\215UUU",
    rsa=0x55555594ecd0, padding=4) at rsa_eay.c:201
#6  0x00005555556bb46c in RSA_public_encrypt (flen=53,
    from=0x555555927ef0 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\nU", to=0x5555559259e0 "\320\v\215UUU",
    rsa=0x55555594ecd0, padding=4) at rsa_crpt.c:85
#7  0x00005555555b0e38 in rsautl_main (argc=0, argv=0x7fffffffdf80) at rsautl.c:300
#8  0x000055555559624b in do_cmd (prog=0x5555559488a0, argc=10, argv=0x7fffffffdf30) at openssl.c:477
#9  0x0000555555595e37 in main (Argc=10, Argv=0x7fffffffdf30) at openssl.c:371
(gdb) list
798         struct crypt_op cryp;
799         struct dev_crypto_state *state = ctx->md_data;
800         struct session_op *sess = &state->d_sess;
801
802         if (!data || state->d_fd < 0) {
803             printf("cryptodev_digest_update: illegal inputs \n");
804             return (0);
805         }
806
807         if (!count) {
(gdb) p state
$1 = (struct dev_crypto_state *) 0x55555594d200
(gdb) p *state
$2 = {d_sess = {cipher = 0, mac = 14, keylen = 0, key = 0x0, mackeylen = 20, mackey = 0x55555594d234 "", ses = 1292958119},
  d_fd = 3, dummy_mac_key = '\000' <repeats 63 times>, digest_res = '\000' <repeats 63 times>, mac_data = 0x0, mac_len = 0}
(gdb)
```
The [code that handles MD update by default](https://github.com/openssl/openssl/blob/7a7afc559ebc0ad88390cc62bfc34c221d595831/crypto/md32_common.h#L309) checks for len==0 and returns success before anything else.  

~~Alternatively, we could check for `state->d_fd < 0` and bail out first here, but my reasoning for not doing so right away is that an update call with empty data does not alter the current state, and that does not depend on anything else, then why should we consider that an error?  The error will inevitably happen when final or a non-empty update is called, but if the operation is somehow aborted before that, then there's no error to report, and that should be OK.~~
*__Edit__ This does not apply anymore, because if we bail out early, we won't get a result when `EVP_MD_CTX_FLAG_ONESHOT` is set.*

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>