### PR TITLE
Add functions to see if a provider is available for use.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Introduced a new function, OSSL_PROVIDER_available(), which can be used
+     to check if a named provider is loaded and available.  When called, it
+     will also activate all fallback providers if such are still present.
+     [Richard Levitte]
+
   *) Enforce a minimum DH modulus size of 512 bits.
      [Bernd Edlinger]
 

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -35,6 +35,18 @@ int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
     return 1;
 }
 
+int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name)
+{
+    OSSL_PROVIDER *prov = NULL;
+    int available = 0;
+
+    /* Find it or create it */
+    prov = ossl_provider_find(libctx, name);
+    available = ossl_provider_available(prov);
+    ossl_provider_free(prov);
+    return available;
+}
+
 const OSSL_PARAM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_get_param_types(prov);

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -572,65 +572,75 @@ static int provider_forall_loaded(struct provider_store_st *store,
     return ret;
 }
 
+/*
+ * This function only does something once when store->use_fallbacks == 1,
+ * and then sets store->use_fallbacks = 0, so the second call and so on is
+ * effectively a no-op.
+ */
+static void provider_activate_fallbacks(struct provider_store_st *store)
+{
+    if (store->use_fallbacks) {
+        int num_provs = sk_OSSL_PROVIDER_num(store->providers);
+        int activated_fallback_count = 0;
+        int i;
+
+        for (i = 0; i < num_provs; i++) {
+            OSSL_PROVIDER *prov = sk_OSSL_PROVIDER_value(store->providers, i);
+
+            /*
+             * Note that we don't care if the activation succeeds or not.
+             * If it doesn't succeed, then any attempt to use any of the
+             * fallback providers will fail anyway.
+             */
+            if (prov->flag_fallback) {
+                activated_fallback_count++;
+                provider_activate(prov);
+            }
+        }
+
+        /*
+         * We assume that all fallbacks have been added to the store before
+         * any fallback is activated.
+         * TODO: We may have to reconsider this, IF we find ourselves adding
+         * fallbacks after any previous fallback has been activated.
+         */
+        if (activated_fallback_count > 0)
+            store->use_fallbacks = 0;
+    }
+}
+
 int ossl_provider_forall_loaded(OPENSSL_CTX *ctx,
                                 int (*cb)(OSSL_PROVIDER *provider,
                                           void *cbdata),
                                 void *cbdata)
 {
     int ret = 1;
-    int i;
     struct provider_store_st *store = get_provider_store(ctx);
 
     if (store != NULL) {
-        int found_activated = 0;
-
         CRYPTO_THREAD_read_lock(store->lock);
-        ret = provider_forall_loaded(store, &found_activated, cb, cbdata);
+
+        provider_activate_fallbacks(store);
 
         /*
-         * If there's nothing activated ever in this store, try to activate
-         * all fallbacks.
+         * Now, we sweep through all providers
          */
-        if (!found_activated && store->use_fallbacks) {
-            int num_provs = sk_OSSL_PROVIDER_num(store->providers);
-            int activated_fallback_count = 0;
+        ret = provider_forall_loaded(store, NULL, cb, cbdata);
 
-            for (i = 0; i < num_provs; i++) {
-                OSSL_PROVIDER *prov =
-                    sk_OSSL_PROVIDER_value(store->providers, i);
-
-                /*
-                 * Note that we don't care if the activation succeeds or
-                 * not.  If it doesn't succeed, then the next loop will
-                 * fail anyway.
-                 */
-                if (prov->flag_fallback) {
-                    activated_fallback_count++;
-                    provider_activate(prov);
-                }
-            }
-
-            if (activated_fallback_count > 0) {
-                /*
-                 * We assume that all fallbacks have been added to the store
-                 * before any fallback is activated.
-                 * TODO: We may have to reconsider this, IF we find ourselves
-                 * adding fallbacks after any previous fallback has been
-                 * activated.
-                 */
-                store->use_fallbacks = 0;
-
-                /*
-                 * Now that we've activated available fallbacks, try a
-                 * second sweep
-                 */
-                ret = provider_forall_loaded(store, NULL, cb, cbdata);
-            }
-        }
         CRYPTO_THREAD_unlock(store->lock);
     }
 
     return ret;
+}
+
+int ossl_provider_available(OSSL_PROVIDER *prov)
+{
+    if (prov != NULL) {
+        provider_activate_fallbacks(prov->store);
+
+        return prov->flag_initialized;
+    }
+    return 0;
 }
 
 /* Setters of Provider Object data */

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -636,7 +636,9 @@ int ossl_provider_forall_loaded(OPENSSL_CTX *ctx,
 int ossl_provider_available(OSSL_PROVIDER *prov)
 {
     if (prov != NULL) {
+        CRYPTO_THREAD_read_lock(prov->store->lock);
         provider_activate_fallbacks(prov->store);
+        CRYPTO_THREAD_unlock(prov->store->lock);
 
         return prov->flag_initialized;
     }

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -150,8 +150,9 @@ be located in that module, and called.
 
 =back
 
-ossl_provider_available() checks if given provider object I<prov> is
-"activated" or a fallback.
+ossl_provider_available() activates all fallbacks of no provider is
+activated yet, then checks if given provider object I<prov> is
+activated.
 
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -6,7 +6,7 @@ ossl_provider_find, ossl_provider_new, ossl_provider_up_ref,
 ossl_provider_free,
 ossl_provider_set_fallback, ossl_provider_set_module_path,
 ossl_provider_add_parameter,
-ossl_provider_activate,
+ossl_provider_activate, ossl_provider_available,
 ossl_provider_ctx,
 ossl_provider_forall_loaded,
 ossl_provider_name, ossl_provider_dso,
@@ -33,6 +33,8 @@ ossl_provider_get_params, ossl_provider_query_operation
 
  /* Load and initialize the Provider */
  int ossl_provider_activate(OSSL_PROVIDER *prov);
+ /* Check if provider is available */
+ int ossl_provider_available(OSSL_PROVIDER *prov);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -148,6 +150,9 @@ be located in that module, and called.
 
 =back
 
+ossl_provider_available() checks if given provider object I<prov> is
+"activated" or a fallback.
+
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be
 passed back to some of the provider functions.
@@ -227,6 +232,9 @@ ossl_provider_free() doesn't return any value.
 
 ossl_provider_set_module_path(), ossl_provider_set_fallback() and
 ossl_provider_activate() return 1 on success, or 0 on error.
+
+ossl_provider_available() return 1 if the provider is available,
+otherwise 0.
 
 ossl_provider_name(), ossl_provider_dso(),
 ossl_provider_module_name(), and ossl_provider_module_path() return a

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -3,6 +3,7 @@
 =head1 NAME
 
 OSSL_PROVIDER, OSSL_PROVIDER_load, OSSL_PROVIDER_unload,
+OSSL_PROVIDER_available,
 OSSL_PROVIDER_get_param_types, OSSL_PROVIDER_get_params,
 OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
 
@@ -12,13 +13,14 @@ OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
 
  typedef struct ossl_provider_st OSSL_PROVIDER;
 
- OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
+ OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *libctx, const char *name);
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
+ int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name);
 
  const OSSL_PARAM *OSSL_PROVIDER_get_param_types(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_get_params(OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
- int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *, const char *name,
+ int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *libctx, const char *name,
                                ossl_provider_init_fn *init_fn);
 
  const char *OSSL_PROVIDER_name(const OSSL_PROVIDER *prov);
@@ -31,6 +33,9 @@ provider is).
 A provider can be built in to the application or the OpenSSL
 libraries, or can be a loadable module.
 The functions described here handle both forms.
+
+Some of these functions operate within a library context, please see
+L<OPENSSL_CTX(3)> for further details.
 
 =head2 Functions
 
@@ -48,6 +53,9 @@ entry point, C<OSSL_provider_init>.
 OSSL_PROVIDER_unload() unloads the given provider.
 For a provider added with OSSL_PROVIDER_add_builtin(), this simply
 runs its teardown function.
+
+OSSL_PROVIDER_available() checks if a named provider is available
+for use.
 
 OSSL_PROVIDER_get_param_types() is used to get a provider parameter
 descriptor set as a constant B<OSSL_PARAM> array.
@@ -68,6 +76,9 @@ OSSL_PROVIDER_load() returns a pointer to a provider object on
 success, or B<NULL> on error.
 
 OSSL_PROVIDER_unload() returns 1 on success, or 0 on error.
+
+OSSL_PROVIDER_available() returns 1 if the named provider is available,
+otherwise 0.
 
 OSSL_PROVIDER_get_param_types() returns a pointer to an array
 of constant B<OSSL_PARAM>, or NULL if none is provided.
@@ -95,7 +106,7 @@ its build number.
 
 =head1 SEE ALSO
 
-L<openssl-core.h(7)>, L<provider(7)>
+L<openssl-core.h(7)>, L<OPENSSL_CTX(3)>, L<provider(7)>
 
 =head1 HISTORY
 

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -44,6 +44,8 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
  * Inactivation is done by freeing the Provider
  */
 int ossl_provider_activate(OSSL_PROVIDER *prov);
+/* Check if the provider is available */
+int ossl_provider_available(OSSL_PROVIDER *prov);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -14,6 +14,9 @@
 
 # if defined(OPENSSL_SYS_VMS)
 
+/* ossl_provider_available vs OSSL_PROVIDER_available */
+#  undef ossl_provider_available
+#  define ossl_provider_available                 ossl_int_prov_available
 /* ossl_provider_get_param_types vs OSSL_PROVIDER_get_param_types */
 #  undef ossl_provider_get_param_types
 #  define ossl_provider_get_param_types           ossl_int_prov_get_param_types

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -19,6 +19,7 @@ extern "C" {
 /* Load and unload a provider */
 OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
+int OSSL_PROVIDER_available(OPENSSL_CTX *, const char *name);
 
 const OSSL_PARAM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);

--- a/test/default-and-legacy.cnf
+++ b/test/default-and-legacy.cnf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1

--- a/test/default.cnf
+++ b/test/default.cnf
@@ -1,0 +1,10 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+
+[default_sect]
+activate = 1

--- a/test/fips.cnf
+++ b/test/fips.cnf
@@ -1,0 +1,10 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+fips = fips_sect
+
+[fips_sect]
+activate = 1

--- a/test/legacy.cnf
+++ b/test/legacy.cnf
@@ -1,0 +1,10 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+legacy = legacy_sect
+
+[legacy_sect]
+activate = 1

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -10,19 +10,24 @@
 use strict;
 use warnings;
 
-use OpenSSL::Test qw(:DEFAULT data_file bldtop_dir);
+use OpenSSL::Test qw(:DEFAULT data_file bldtop_dir srctop_file);
 
 setup("test_evp");
 
-my @files = ( "evpciph.txt", "evpdigest.txt", "evpencod.txt", "evpkdf.txt",
-    "evppkey_kdf.txt", "evpmac.txt", "evppbe.txt", "evppkey.txt",
-    "evppkey_ecc.txt", "evpcase.txt", "evpaessiv.txt", "evpccmcavs.txt" );
+my @configs = qw( default-and-legacy.cnf fips.cnf );
+my @files = qw( evpciph.txt evpdigest.txt evpencod.txt evpkdf.txt
+    evppkey_kdf.txt evpmac.txt evppbe.txt evppkey.txt
+    evppkey_ecc.txt evpcase.txt evpaessiv.txt evpccmcavs.txt );
 
-plan tests => scalar(@files);
+plan tests => scalar(@configs) * scalar(@files);
 
 $ENV{OPENSSL_MODULES} = bldtop_dir("providers");
 
-foreach my $f ( @files ) {
-    ok(run(test(["evp_test", data_file("$f")])),
-       "running evp_test $f");
+foreach (@configs) {
+    $ENV{OPENSSL_CONF} = srctop_file("test", $_);
+
+    foreach my $f ( @files ) {
+        ok(run(test(["evp_test", data_file("$f")])),
+           "running evp_test $f");
+    }
 }

--- a/test/recipes/30-test_evp_data/evpdigest.txt
+++ b/test/recipes/30-test_evp_data/evpdigest.txt
@@ -274,129 +274,129 @@ Output = 8215ef0796a20bcaaae116d3876c664a84983e441c3bd26ebaae4aa1f95129e5e54670f
 Title = MD4 tests
 
 Digest = MD4
+Availablein = legacy
 Input = ""
 Output = 31d6cfe0d16ae931b73c59d7e0c089c0
-Legacy = 1
 
 Digest = MD4
+Availablein = legacy
 Input = "a"
 Output = bde52cb31de33e46245e05fbdbd6fb24
-Legacy = 1
 
 Digest = MD4
+Availablein = legacy
 Input = "abc"
 Output = a448017aaf21d8525fc10ae87aa6729d
-Legacy = 1
 
 Digest = MD4
+Availablein = legacy
 Input = "message digest"
 Output = d9130a8164549fe818874806e1c7014b
-Legacy = 1
 
 Digest = MD4
+Availablein = legacy
 Input = "abcdefghijklmnopqrstuvwxyz"
 Output = d79e1c308aa5bbcdeea8ed63df412da9
-Legacy = 1
 
 Digest = MD4
+Availablein = legacy
 Input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 Output = 043f8582f241db351ce627e153e7f0e4
-Legacy = 1
 
 Digest = MD4
+Availablein = legacy
 Input = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
 Output = e33b4ddc9c38f2199c3e7b164fcc0536
-Legacy = 1
 
 Title = RIPEMD160 tests
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = ""
 Output = 9c1185a5c5e9fc54612808977ee8f548b2258d31
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "a"
 Output = 0bdc9d2d256b3ee9daae347be6f4dc835a467ffe
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "abc"
 Output = 8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "message digest"
 Output = 5d0689ef49d2fae572b881b123a85ffa21595f36
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "abcdefghijklmnopqrstuvwxyz"
 Output = f71c27109c692c1b56bbdceb5b9d2865b3708dbc
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
 Output = 12a053384a9c0c88e405a06c27dcf49ada62eb2b
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 Output = b0e20b6e3116640286ed3a87a5713079b21f5189
-Legacy = 1
 
 Digest = RIPEMD160
+Availablein = legacy
 Input = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
 Output = 9b752e45573d4b39f4dbd3323cab82bf63326bfb
-Legacy = 1
 
 Title = Whirlpool (from ISO/IEC 10118-3 test vector set)
 
 Digest = whirlpool
+Availablein = legacy
 Input = ""
 Output = 19FA61D75522A4669B44E39C1D2E1726C530232130D407F89AFEE0964997F7A73E83BE698B288FEBCF88E3E03C4F0757EA8964E59B63D93708B138CC42A66EB3
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "a"
 Output = 8ACA2602792AEC6F11A67206531FB7D7F0DFF59413145E6973C45001D0087B42D11BC645413AEFF63A42391A39145A591A92200D560195E53B478584FDAE231A
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "abc"
 Output = 4E2448A4C6F486BB16B6562C73B4020BF3043E3A731BCE721AE1B303D97E6D4C7181EEBDB6C57E277D0E34957114CBD6C797FC9D95D8B582D225292076D4EEF5
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "message digest"
 Output = 378C84A4126E2DC6E56DCC7458377AAC838D00032230F53CE1F5700C0FFB4D3B8421557659EF55C106B4B52AC5A4AAA692ED920052838F3362E86DBD37A8903E
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "abcdefghijklmnopqrstuvwxyz"
 Output = F1D754662636FFE92C82EBB9212A484A8D38631EAD4238F5442EE13B8054E41B08BF2A9251C30B6A0B8AAE86177AB4A6F68F673E7207865D5D9819A3DBA4EB3B
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 Output = DC37E008CF9EE69BF11F00ED9ABA26901DD7C28CDEC066CC6AF42E40F82F3A1E08EBA26629129D8FB7CB57211B9281A65517CC879D7B962142C65F5A7AF01467
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
 Output = 466EF18BABB0154D25B9D38A6414F5C08784372BCCB204D6549C4AFADB6014294D5BD8DF2A6C44E538CD047B2681A51A2C60481E88C5A20B2C2A80CF3A9A083B
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "abcdbcdecdefdefgefghfghighijhijk"
 Output = 2A987EA40F917061F5D6F0A0E4644F488A7A5A52DEEE656207C562F988E95C6916BDC8031BC5BE1B7B947639FE050B56939BAAA0ADFF9AE6745B7B181C3BE3FD
-Legacy = 1
 
 Digest = whirlpool
+Availablein = legacy
 Input = "aaaaaaaaaa"
 Count = 100000
 Output = 0C99005BEB57EFF50A7CF005560DDF5D29057FD86B20BFD62DECA0F1CCEA4AF51FC15490EDDC47AF32BB2B66C34FF9AD8C6008AD677F77126953B226E4ED8B01
-Legacy = 1
 
 Title = SHA3
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4699,3 +4699,4 @@ OSSL_PROVIDER_name                      4804	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_do_all_ex                    4805	3_0_0	EXIST::FUNCTION:
 EVP_MD_do_all_ex                        4806	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_provider                    4807	3_0_0	EXIST::FUNCTION:
+OSSL_PROVIDER_available                 4808	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Public function OSSL_PROVIDER_available() takes a library context and
a provider name, and returns 1 if it's available for use, i.e. if it's
possible to fetch implementations from it, otherwise 0.

Internal function ossl_provider_activated() returns 1 if the given
OSSL_PROVIDER is activated, otherwise 0.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
