### PR TITLE
Fix no-dh

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -729,12 +729,13 @@ int EVP_hex2ctrl(int (*cb)(void *ctx, int cmd, void *buf, size_t buflen),
 }
 
 #ifndef FIPS_MODE
+# ifndef OPENSSL_NO_DH
 /*
  * TODO(3.0): Temporarily unavailable in FIPS mode. This will need to be added
  * in later.
  */
 
-#define MAX_PARAMS 10
+#  define MAX_PARAMS 10
 typedef struct {
     /* Number of the current param */
     size_t curr;
@@ -845,12 +846,15 @@ static OSSL_PARAM *evp_pkey_dh_to_param(EVP_PKEY *pkey, size_t *sz)
 
     return param_template_to_param(&tmpl, sz);
 }
+# endif /* OPENSSL_NO_DH */
 
 OSSL_PARAM *evp_pkey_to_param(EVP_PKEY *pkey, size_t *sz)
 {
     switch (pkey->type) {
+# ifndef OPENSSL_NO_DH
     case EVP_PKEY_DH:
         return evp_pkey_dh_to_param(pkey, sz);
+# endif
     default:
         return NULL;
     }

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -393,6 +393,7 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
     return 0;
 }
 
+#ifndef OPENSSL_NO_DH
 int EVP_PKEY_CTX_set_dh_pad(EVP_PKEY_CTX *ctx, int pad)
 {
     OSSL_PARAM dh_pad_params[2];
@@ -407,13 +408,16 @@ int EVP_PKEY_CTX_set_dh_pad(EVP_PKEY_CTX *ctx, int pad)
 
     return EVP_PKEY_CTX_set_params(ctx, dh_pad_params);
 }
+#endif
 
 static int legacy_ctrl_to_param(EVP_PKEY_CTX *ctx, int keytype, int optype,
                                 int cmd, int p1, void *p2)
 {
     switch (cmd) {
+#ifndef OPENSSL_NO_DH
     case EVP_PKEY_CTRL_DH_PAD:
         return EVP_PKEY_CTX_set_dh_pad(ctx, p1);
+#endif
     }
     return 0;
 }
@@ -470,12 +474,14 @@ int EVP_PKEY_CTX_ctrl_uint64(EVP_PKEY_CTX *ctx, int keytype, int optype,
 static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
                                     const char *value)
 {
+#ifndef OPENSSL_NO_DH
     if (strcmp(name, "dh_pad") == 0) {
         int pad;
 
         pad = atoi(value);
         return EVP_PKEY_CTX_set_dh_pad(ctx, pad);
     }
+#endif
     return 0;
 }
 

--- a/providers/common/exchange/build.info
+++ b/providers/common/exchange/build.info
@@ -1,5 +1,7 @@
 LIBS=../../../libcrypto
-SOURCE[../../../libcrypto]=\
-        dh.c
+IF[{- !$disabled{dh} -}]
+  SOURCE[../../../libcrypto]=\
+          dh.c
+ENDIF
 
 

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -115,7 +115,9 @@ static const OSSL_ALGORITHM deflt_ciphers[] = {
 };
 
 static const OSSL_ALGORITHM deflt_keyexch[] = {
+#ifndef OPENSSL_NO_DH
     { "dhKeyAgreement", "default=yes", dh_functions },
+#endif
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
The recent move of the DH code into the default provider broke no-dh. This
adds back in various missing guards.
