### PR TITLE
Fix init_get_thread_local()

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -137,11 +137,14 @@ static union {
 } destructor_key = { -1 };
 
 /*
- * The thread event handler is thread specific and is a linked
- * list of all handler functions that should be called for the
- * current thread. We also keep a global reference to that linked
- * list, so that we can deregister handlers if necessary before all
- * the threads are stopped.
+ * The thread event handler list is a thread specific linked list
+ * of callback functions which are invoked in list order by the
+ * current thread in case of certain events. (Currently, there is
+ * only one type of event, the 'thread stop' event.)
+ *
+ * We also keep a global reference to that linked list, so that we
+ * can deregister handlers if necessary before all the threads are
+ * stopped.
  */
 static int init_thread_push_handlers(THREAD_EVENT_HANDLER **hands)
 {


### PR DESCRIPTION
_This pull request is an alternative to pull request #9370._

```
    Fix init_get_thread_local()
   
    Previously, init_get_thread_local() pushed the thread event handler
    list onto the global register before calling CRYPTO_THREAD_set_local(),
    and when the latter failed, forgot to pop the list from the stack again.
    
    Instead of cleaning the stack on error, this commit avoids the situation
    entirely by postponing the push operation until all other operations
    succeeded. This reordering also significantly reduces the scope of the
    critical section.
    
    Another simplification of the code is achieved by moving the push operation
    onto the register (which is disabled in FIPS mode) into a separate function.
```


_@levitte I'm sorry, but I couldn't resist to add function prototypes at the beginning of the module. Not to tease you, but for three practical reasons:_

- It's easier to understand a module if the functions are ordered top-down. This implies that the auxiliary functions need to go after the functions where they are used.
- It makes more sense to group the auxiliary functions logically and not in (inverse) order of dependency. In my case, the natural place for the `init_thread_push_handlers()` function was next to (resp. in front of) `init_thread_remove_handlers()`.
- Last but not least: placing the `init_thread_push_handlers()` _before_ `init_get_thread_local()` would have trashed the diff.


