### PR TITLE
Fix S390X compile error due to missing defines

### DIFF
--- a/crypto/include/internal/aes_platform.h
+++ b/crypto/include/internal/aes_platform.h
@@ -315,14 +315,24 @@ void aes256_t4_xts_decrypt(const unsigned char *in, unsigned char *out,
 #  define S390X_aes_128_xts_CAPABLE     1       /* checked by callee */
 #  define S390X_aes_256_xts_CAPABLE     1
 
-#  define S390X_aes_128_ccm_CAPABLE (S390X_aes_128_CAPABLE &&           \
-                                    (OPENSSL_s390xcap_P.kmac[0] &       \
+# define S390X_aes_128_gcm_CAPABLE (S390X_aes_128_CAPABLE &&        \
+                                    (OPENSSL_s390xcap_P.kma[0] &    \
                                      S390X_CAPBIT(S390X_AES_128)))
-#  define S390X_aes_192_ccm_CAPABLE (S390X_aes_192_CAPABLE &&           \
-                                    (OPENSSL_s390xcap_P.kmac[0] &       \
+# define S390X_aes_192_gcm_CAPABLE (S390X_aes_192_CAPABLE &&        \
+                                    (OPENSSL_s390xcap_P.kma[0] &    \
                                      S390X_CAPBIT(S390X_AES_192)))
-#  define S390X_aes_256_ccm_CAPABLE (S390X_aes_256_CAPABLE &&           \
-                                    (OPENSSL_s390xcap_P.kmac[0] &       \
+# define S390X_aes_256_gcm_CAPABLE (S390X_aes_256_CAPABLE &&        \
+                                    (OPENSSL_s390xcap_P.kma[0] &    \
+                                     S390X_CAPBIT(S390X_AES_256)))
+
+#  define S390X_aes_128_ccm_CAPABLE (S390X_aes_128_CAPABLE &&       \
+                                    (OPENSSL_s390xcap_P.kmac[0] &   \
+                                     S390X_CAPBIT(S390X_AES_128)))
+#  define S390X_aes_192_ccm_CAPABLE (S390X_aes_192_CAPABLE &&       \
+                                    (OPENSSL_s390xcap_P.kmac[0] &   \
+                                     S390X_CAPBIT(S390X_AES_192)))
+#  define S390X_aes_256_ccm_CAPABLE (S390X_aes_256_CAPABLE &&       \
+                                    (OPENSSL_s390xcap_P.kmac[0] &   \
                                      S390X_CAPBIT(S390X_AES_256)))
 #  define S390X_CCM_AAD_FLAG    0x40
 


### PR DESCRIPTION
Add the missing S390X_aes_XXX_gcm_CAPABLE() macros into aes_platform.h.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
