### PR TITLE
Rename X509_STORE ptr stored in opaque struct X509_STORE_CTX

### DIFF
--- a/crypto/include/internal/x509_int.h
+++ b/crypto/include/internal/x509_int.h
@@ -197,7 +197,7 @@ struct x509_st {
  * kept and passed around.
  */
 struct x509_store_ctx_st {      /* X509_STORE_CTX */
-    X509_STORE *ctx;
+    X509_STORE *store;
     /* The following are set by the caller */
     /* The cert to check */
     X509 *cert;

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -289,7 +289,7 @@ X509_OBJECT *X509_STORE_CTX_get_obj_by_subject(X509_STORE_CTX *vs,
 int X509_STORE_CTX_get_by_subject(X509_STORE_CTX *vs, X509_LOOKUP_TYPE type,
                                   X509_NAME *name, X509_OBJECT *ret)
 {
-    X509_STORE *store = vs->ctx;
+    X509_STORE *store = vs->store;
     X509_LOOKUP *lu;
     X509_OBJECT stmp, *tmp;
     int i, j;
@@ -533,7 +533,7 @@ STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *ctx, X509_NAME *nm)
     STACK_OF(X509) *sk = NULL;
     X509 *x;
     X509_OBJECT *obj;
-    X509_STORE *store = ctx->ctx;
+    X509_STORE *store = ctx->store;
 
     if (store == NULL)
         return NULL;
@@ -586,7 +586,7 @@ STACK_OF(X509_CRL) *X509_STORE_CTX_get1_crls(X509_STORE_CTX *ctx, X509_NAME *nm)
     STACK_OF(X509_CRL) *sk = sk_X509_CRL_new_null();
     X509_CRL *x;
     X509_OBJECT *obj, *xobj = X509_OBJECT_new();
-    X509_STORE *store = ctx->ctx;
+    X509_STORE *store = ctx->store;
 
     /* Always do lookup to possibly add new CRLs to cache */
     if (sk == NULL
@@ -665,7 +665,7 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x)
 {
     X509_NAME *xn;
     X509_OBJECT *obj = X509_OBJECT_new(), *pobj = NULL;
-    X509_STORE *store = ctx->ctx;
+    X509_STORE *store = ctx->store;
     int i, ok, idx, ret;
 
     if (obj == NULL)
@@ -900,5 +900,5 @@ void *X509_STORE_get_ex_data(X509_STORE *ctx, int idx)
 
 X509_STORE *X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx)
 {
-    return ctx->ctx;
+    return ctx->store;
 }

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1276,7 +1276,7 @@ static int check_crl_path(X509_STORE_CTX *ctx, X509 *x)
     /* Don't allow recursive CRL path validation */
     if (ctx->parent)
         return 0;
-    if (!X509_STORE_CTX_init(&crl_ctx, ctx->ctx, x, ctx->untrusted))
+    if (!X509_STORE_CTX_init(&crl_ctx, ctx->store, x, ctx->untrusted))
         return -1;
 
     crl_ctx.crls = ctx->crls;
@@ -2201,7 +2201,7 @@ int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
 {
     int ret = 1;
 
-    ctx->ctx = store;
+    ctx->store = store;
     ctx->cert = x509;
     ctx->untrusted = chain;
     ctx->crls = NULL;


### PR DESCRIPTION
Change name from 'ctx' to 'store' to remove ctx->ctx from code.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
