### PR TITLE
Don't complain if function name doesn't match

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -394,10 +394,6 @@ foreach my $file ( @source ) {
                 $fnew{$2}++;
             }
             $ftrans{$3} = $func unless exists $ftrans{$3};
-            if ( uc($func) ne $3 ) {
-                print STDERR "ERROR: mismatch $file:$linenr $func:$3\n";
-                $errors++;
-            }
             print STDERR "  Function $1 = $fcodes{$1}\n"
               if $debug;
         }


### PR DESCRIPTION
The "function" argument is now unused in the XXXerr defines, so mkerr
doesn't need to check if the value/name match.

Addresses https://github.com/openssl/openssl/pull/9058#issuecomment-512843706.
