### PR TITLE
mention what happens if OPENSSL_NO_RC2 is defined

### DIFF
--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -225,7 +225,8 @@ for this search. If the search fails it is considered a fatal error.
 
 Encrypt the certificate using triple DES, this may render the PKCS#12
 file unreadable by some "export grade" software. By default the private
-key is encrypted using triple DES and the certificate using 40 bit RC2.
+key is encrypted using triple DES and the certificate using 40 bit RC2
+unless RC2 is disabled in which case triple DES is used.
 
 =item B<-keypbe alg>, B<-certpbe alg>
 


### PR DESCRIPTION
The changes in cset 7e1b7485 modified the `pkcs12` command to use 3DES for certificate encryption if RC2 is disabled. This updates the man page to reflect the change.