### PR TITLE
Remove superfluous call to OPENSSL_cpuid_setup

### DIFF
--- a/crypto/engine/eng_all.c
+++ b/crypto/engine/eng_all.c
@@ -12,9 +12,6 @@
 
 void ENGINE_load_builtin_engines(void)
 {
-    /* Some ENGINEs need this */
-    OPENSSL_cpuid_setup();
-
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
 }
 


### PR DESCRIPTION
Fixes https://github.com/openssl/openssl/issues/9411
