### PR TITLE
Add value_barriers in constant time select functions [1.0.2]

### DIFF
--- a/crypto/constant_time_locl.h
+++ b/crypto/constant_time_locl.h
@@ -185,11 +185,29 @@ static inline unsigned char constant_time_eq_int_8(int a, int b)
     return constant_time_eq_8((unsigned)(a), (unsigned)(b));
 }
 
+/*
+ * Returns the value unmodified, but avoids optimizations.
+ * The barriers prevent the compiler from narrowing down the
+ * possible value range of the mask and ~mask in the select
+ * statements, which avoids the recognition of the select
+ * and turning it into a conditional load or branch.
+ */
+static inline unsigned int value_barrier(unsigned int a)
+{
+#if !defined(OPENSSL_NO_ASM) && defined(__GNUC__)
+    unsigned int r;
+    __asm__("" : "=r"(r) : "0"(a));
+#else
+    volatile unsigned int r = a;
+#endif
+    return r;
+}
+
 static inline unsigned int constant_time_select(unsigned int mask,
                                                 unsigned int a,
                                                 unsigned int b)
 {
-    return (mask & a) | (~mask & b);
+    return (value_barrier(mask) & a) | (value_barrier(~mask) & b);
 }
 
 static inline unsigned char constant_time_select_8(unsigned char mask,


### PR DESCRIPTION
The barriers prevent the compiler from narrowing down the
possible value range of the mask and ~mask in the select
statements, which avoids the recognition of the select
and turning it into a conditional load or branch.

back-port of #9217 to 1.0.2