### PR TITLE
Removes use of definition I_CAN_LIVE_WITH_LNK4049 in e_os.h

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -156,21 +156,6 @@ FILE *__iob_func();
 #     define stdin  (&__iob_func()[0])
 #     define stdout (&__iob_func()[1])
 #     define stderr (&__iob_func()[2])
-#    elif _MSC_VER<1300 && defined(I_CAN_LIVE_WITH_LNK4049)
-#     undef stdin
-#     undef stdout
-#     undef stderr
-         /*
-          * pre-1300 has __p__iob(), but it's available only in msvcrt.lib,
-          * or in other words with /MD. Declaring implicit import, i.e. with
-          * _imp_ prefix, works correctly with all compiler options, but
-          * without /MD results in LINK warning LNK4049: 'locally defined
-          * symbol "__iob" imported'.
-          */
-extern FILE *_imp___iob;
-#     define stdin  (&_imp___iob[0])
-#     define stdout (&_imp___iob[1])
-#     define stderr (&_imp___iob[2])
 #    endif
 #   endif
 #  endif


### PR DESCRIPTION
Fixes #9332

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
