### PR TITLE
Make rand_pool buffers more dynamic in their sizing.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,9 @@
      The macro SYSerr() is deprecated.
      [Rich Salz]
 
+  *) Significantly reduce secure memory usage by the randomness pools.
+     [Paul Dale]
+
   *) {CRYPTO,OPENSSL}_mem_debug_{push,pop} are now no-ops and have been
      deprecated.
      [Rich Salz]

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1177,6 +1177,7 @@ RAND_F_RAND_POOL_ADD_BEGIN:113:rand_pool_add_begin
 RAND_F_RAND_POOL_ADD_END:114:rand_pool_add_end
 RAND_F_RAND_POOL_ATTACH:124:rand_pool_attach
 RAND_F_RAND_POOL_BYTES_NEEDED:115:rand_pool_bytes_needed
+RAND_F_RAND_POOL_GROW:127:
 RAND_F_RAND_POOL_NEW:116:rand_pool_new
 RAND_F_RAND_WRITE_FILE:112:RAND_write_file
 RSA_F_CHECK_PADDING_MD:140:check_padding_md

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -82,6 +82,24 @@
  *                                1.5 * (RAND_DRBG_STRENGTH / 8))
  */
 
+/*
+ * Initial allocation minimum.
+ *
+ * There is a distinction between the secure and normal allocation minimums.
+ * Ideally, the secure allocation size should be a power of two.  The normal
+ * allocation size doesn't have any such restriction.
+ *
+ * The secure value is based on 128 bits of secure material, which is 16 bytes.
+ * Typically, the DRBGs will set a minimum larger than this so optimal
+ * allocation ought to take place (for full quality seed material).
+ *
+ * The normal value has been chosed by noticing that the rand_drbg_get_nonce
+ * function is usually the largest of the built in allocation (twenty four
+ * bytes and then appending another sixteen bytes).  This means the buffer ends
+ * with 40 bytes.  The value of forty eight is comfortably above this which
+ * allows some slack in the platform specific values used.
+ */
+# define RAND_POOL_MIN_ALLOCATION(secure) ((secure) ? 16 : 48)
 
 /* DRBG status values */
 typedef enum drbg_status_e {
@@ -184,6 +202,7 @@ struct rand_pool_st {
 
     size_t min_len; /* minimum number of random bytes requested */
     size_t max_len; /* maximum number of random bytes (allocated buffer size) */
+    size_t alloc_len; /* current number of bytes allocated */
     size_t entropy; /* current entropy count in bits */
     size_t entropy_requested; /* requested entropy count in bits */
 };

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -368,6 +368,7 @@ RAND_POOL *rand_pool_new(int entropy_requested, int secure,
                          size_t min_len, size_t max_len)
 {
     RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
+    size_t min_alloc_size = RAND_POOL_MIN_ALLOCATION(secure);
 
     if (pool == NULL) {
         RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
@@ -377,11 +378,14 @@ RAND_POOL *rand_pool_new(int entropy_requested, int secure,
     pool->min_len = min_len;
     pool->max_len = (max_len > RAND_POOL_MAX_LENGTH) ?
         RAND_POOL_MAX_LENGTH : max_len;
+    pool->alloc_len = min_len < min_alloc_size ? min_alloc_size : min_len;
+    if (pool->alloc_len > pool->max_len)
+        pool->alloc_len = pool->max_len;
 
     if (secure)
-        pool->buffer = OPENSSL_secure_zalloc(pool->max_len);
+        pool->buffer = OPENSSL_secure_zalloc(pool->alloc_len);
     else
-        pool->buffer = OPENSSL_zalloc(pool->max_len);
+        pool->buffer = OPENSSL_zalloc(pool->alloc_len);
 
     if (pool->buffer == NULL) {
         RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
@@ -424,7 +428,7 @@ RAND_POOL *rand_pool_attach(const unsigned char *buffer, size_t len,
 
     pool->attached = 1;
 
-    pool->min_len = pool->max_len = pool->len;
+    pool->min_len = pool->max_len = pool->alloc_len = pool->len;
     pool->entropy = entropy;
 
     return pool;
@@ -446,9 +450,9 @@ void rand_pool_free(RAND_POOL *pool)
      */
     if (!pool->attached) {
         if (pool->secure)
-            OPENSSL_secure_clear_free(pool->buffer, pool->max_len);
+            OPENSSL_secure_clear_free(pool->buffer, pool->alloc_len);
         else
-            OPENSSL_clear_free(pool->buffer, pool->max_len);
+            OPENSSL_clear_free(pool->buffer, pool->alloc_len);
     }
 
     OPENSSL_free(pool);
@@ -581,6 +585,29 @@ size_t rand_pool_bytes_remaining(RAND_POOL *pool)
     return pool->max_len - pool->len;
 }
 
+static int rand_pool_grow(RAND_POOL *pool, size_t len)
+{
+    if (len > pool->alloc_len - pool->len) {
+        unsigned char *p;
+        const size_t limit = pool->max_len / 2;
+        size_t newlen = pool->alloc_len;
+
+        do
+            newlen = newlen < limit ? newlen * 2 : pool->max_len;
+        while (len > newlen - pool->len);
+        p = OPENSSL_secure_malloc(newlen);
+        if (p == NULL) {
+            RANDerr(RAND_F_RAND_POOL_GROW, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+        memcpy(p, pool->buffer, pool->len);
+        OPENSSL_secure_clear_free(pool->buffer, pool->alloc_len);
+        pool->buffer = p;
+        pool->alloc_len = newlen;
+    }
+    return 1;
+}
+
 /*
  * Add random bytes to the random pool.
  *
@@ -604,6 +631,8 @@ int rand_pool_add(RAND_POOL *pool,
     }
 
     if (len > 0) {
+        if (!rand_pool_grow(pool, len))
+            return 0;
         memcpy(pool->buffer + pool->len, buffer, len);
         pool->len += len;
         pool->entropy += entropy;
@@ -639,6 +668,8 @@ unsigned char *rand_pool_add_begin(RAND_POOL *pool, size_t len)
         return NULL;
     }
 
+    if (!rand_pool_grow(pool, len))
+        return NULL;
     return pool->buffer + pool->len;
 }
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -596,21 +596,19 @@ static int rand_pool_grow(RAND_POOL *pool, size_t len)
             newlen = newlen < limit ? newlen * 2 : pool->max_len;
         while (len > newlen - pool->len);
 
-        if (pool->secure) {
-            p = OPENSSL_secure_malloc(newlen);
-            if (p == NULL) {
-                RANDerr(RAND_F_RAND_POOL_GROW, ERR_R_MALLOC_FAILURE);
-                return 0;
-            }
-            memcpy(p, pool->buffer, pool->len);
-            OPENSSL_secure_clear_free(pool->buffer, pool->alloc_len);
-        } else {
-            p = OPENSSL_realloc(pool->buffer, newlen);
-            if (p == NULL) {
-                RANDerr(RAND_F_RAND_POOL_GROW, ERR_R_MALLOC_FAILURE);
-                return 0;
-            }
+        if (pool->secure)
+            p = OPENSSL_secure_zalloc(newlen);
+        else
+            p = OPENSSL_zalloc(newlen);
+        if (p == NULL) {
+            RANDerr(RAND_F_RAND_POOL_GROW, ERR_R_MALLOC_FAILURE);
+            return 0;
         }
+        memcpy(p, pool->buffer, pool->len);
+        if (pool->secure)
+            OPENSSL_secure_clear_free(pool->buffer, pool->alloc_len);
+        else
+            OPENSSL_clear_free(pool->buffer, pool->alloc_len);
         pool->buffer = p;
         pool->alloc_len = newlen;
     }

--- a/include/openssl/randerr.h
+++ b/include/openssl/randerr.h
@@ -49,6 +49,7 @@ int ERR_load_RAND_strings(void);
 #  define RAND_F_RAND_POOL_ADD_END                         0
 #  define RAND_F_RAND_POOL_ATTACH                          0
 #  define RAND_F_RAND_POOL_BYTES_NEEDED                    0
+#  define RAND_F_RAND_POOL_GROW                            0
 #  define RAND_F_RAND_POOL_NEW                             0
 #  define RAND_F_RAND_WRITE_FILE                           0
 # endif


### PR DESCRIPTION
Allocate `rand_pool` buffers starting with the minimum size and increasing the buffer size on demand.  This is in contrast to the existing behaviour where the maximum size is always allocated (capped to 12288 bytes).  Typically only a small number of bytes are used.

See also #9423 

- [ ] documentation is added or updated
- [ ] tests are added or updated
