### PR TITLE
Correct the Extended Master Secret string for EBCDIC

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,13 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Correct the extended master secret constant on EBCDIC systems. Without this
+     fix TLS connections between an EBCDIC system and a non-EBCDIC system that
+     negotiate EMS will fail. Unfortunately this also means that TLS connections
+     between EBCDIC systems with this fix, and EBCDIC systems without this
+     fix will fail if they negotiate EMS.
+     [Matt Caswell]
+
   *) Changed the library initialisation so that the config file is now loaded
      by default. This was already the case for libssl. It now occurs for both
      libcrypto and libssl. Use the OPENSSL_INIT_NO_LOAD_CONFIG option to

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -1192,7 +1192,7 @@ __owur int SSL_check_chain(SSL *s, X509 *x, EVP_PKEY *pk, STACK_OF(X509) *chain)
 /*
  * extended master secret
  */
-#  define TLS_MD_EXTENDED_MASTER_SECRET_CONST    "\x65\x78\x74\x65\x63\x64\x65\x64\x20\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"
+#  define TLS_MD_EXTENDED_MASTER_SECRET_CONST    "\x65\x78\x74\x65\x6e\x64\x65\x64\x20\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"
 # endif
 
 /* TLS Session Ticket extension struct */


### PR DESCRIPTION
The macro TLS_MD_MASTER_SECRET_CONST is supposed to hold the ascii string
"extended master secret". On EBCDIC machines it actually contained the
value "extecded master secret"
