### PR TITLE
Directly return from final sha3/keccak_final if no bytes are requested 

### DIFF
--- a/crypto/sha/sha3.c
+++ b/crypto/sha/sha3.c
@@ -89,6 +89,9 @@ int sha3_final(unsigned char *md, KECCAK1600_CTX *ctx)
     size_t bsz = ctx->block_size;
     size_t num = ctx->bufsz;
 
+    if (ctx->md_size == 0)
+        return 1;
+
     /*
      * Pad the data with 10*1. Note that |num| can be |bsz - 1|
      * in which case both byte operations below are performed on

--- a/providers/common/digests/sha3_prov.c
+++ b/providers/common/digests/sha3_prov.c
@@ -89,10 +89,12 @@ static int keccak_update(void *vctx, const unsigned char *inp, size_t len)
 static int keccak_final(void *vctx, unsigned char *out, size_t *outl,
                         size_t outsz)
 {
-    int ret;
+    int ret = 1;
     KECCAK1600_CTX *ctx = vctx;
 
-    ret = ctx->meth.final(out, ctx);
+    if (outsz > 0)
+        ret = ctx->meth.final(out, ctx);
+
     *outl = ctx->md_size;
     return ret;
 }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -404,6 +404,28 @@ static int digest_test_run(EVP_TEST *t)
     }
 
     if (EVP_MD_flags(expected->digest) & EVP_MD_FLAG_XOF) {
+        EVP_MD_CTX *mctx_cpy;
+        char dont[] = "touch";
+
+        if (!TEST_ptr(mctx_cpy = EVP_MD_CTX_new())) {
+            goto err;
+        }
+        if (!EVP_MD_CTX_copy(mctx_cpy, mctx)) {
+            EVP_MD_CTX_free(mctx_cpy);
+            goto err;
+        }
+        if (!EVP_DigestFinalXOF(mctx_cpy, (unsigned char *)dont, 0)) {
+            EVP_MD_CTX_free(mctx_cpy);
+            t->err = "DIGESTFINALXOF_ERROR";
+            goto err;
+        }
+        if (!TEST_str_eq(dont, "touch")) {
+            EVP_MD_CTX_free(mctx_cpy);
+            t->err = "DIGESTFINALXOF_ERROR";
+            goto err;
+        }
+        EVP_MD_CTX_free(mctx_cpy);
+
         got_len = expected->output_len;
         if (!EVP_DigestFinalXOF(mctx, got, got_len)) {
             t->err = "DIGESTFINALXOF_ERROR";


### PR DESCRIPTION
Reference implementation in keccak1600.c does not touch output buffer
if output lenght is zero while some asm implementations do.

A regression test for this issue is added to evp_test.c

Fixes https://github.com/openssl/openssl/issues/9431

I need help to verify the fix for architectures i have no access.

Already verified for: s390.

- [ ] documentation is added or updated
- [x] tests are added or updated
