### PR TITLE
enable DECLARE_DEPRECATED macro for Developer Studio compiler

### DIFF
--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -33,6 +33,11 @@
 #    undef DECLARE_DEPRECATED
 #    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
 #   endif
+#  elif defined(__SUNPRO_C)
+#   if (__SUNPRO_C >= 0x5130)
+#    undef DECLARE_DEPRECATED
+#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#   endif
 #  endif
 # endif
 


### PR DESCRIPTION
The `DECLARE_DEPRECATED` macro works only for GCC. This change adds support for Solaris/Developer Studio compiler.