### PR TITLE
Windows UWP builds: determine automatically if asm should be disabled

### DIFF
--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -19,7 +19,9 @@ sub UWP_info {
         my @SDKver_split = split(/\./, $SDKver);
         # SDK version older than 10.0.17763 don't support our ASM builds
         if ($SDKver_split[0] < 10
-            || $SDKver_split[1] == 0 && $SDKver_split[2] < 17763) {
+            || ($SDKver_split[1] == 10
+                && $SDKver_split[1] == 0
+                && $SDKver_split[2] < 17763)) {
             $UWP_info->{disable} = [ 'asm' ];
         } else {
             $UWP_info->{disable} = [ ];

--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -1,3 +1,4 @@
+## -*- mode: perl; -*-
 # Windows OneCore targets.
 #
 # OneCore is new API stability "contract" that transcends Desktop, IoT and
@@ -9,6 +10,23 @@
 # Error messages are provided via standard error only.
 # TODO: extend error handling to use ETW based eventing
 # (Or rework whole error messaging)
+
+my $UWP_info = {};
+sub UWP_info {
+    unless (%$UWP_info) {
+        my $SDKver = `powershell -Command  \"& {\$(Get-Item \\\"hklm:\\SOFTWARE\\WOW6432Node\\Microsoft\\Microsoft SDKs\\Windows\\\").GetValue(\\\"CurrentVersion\\\")}\"`;
+        $SDKver =~ s|\R$||;
+        my @SDKver_split = split(/\./, $SDKver);
+        # SDK version older than 10.0.17763 don't support our ASM builds
+        if ($SDKver_split[0] < 10
+            || $SDKver_split[1] == 0 && $SDKver_split[2] < 17763) {
+            $UWP_info->{disable} = [ 'asm' ];
+        } else {
+            $UWP_info->{disable} = [ ];
+        }
+    }
+    return $UWP_info;
+}
 
 my %targets = (
     "VC-WIN32-ONECORE" => {
@@ -80,7 +98,8 @@ my %targets = (
         defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
                                "_WIN32_WINNT=0x0A00"),
         dso_scheme      => "",
-        disable         => [ 'ui-console', 'stdio', 'async', 'uplink' ],
+        disable         => sub { [ 'ui-console', 'stdio', 'async', 'uplink',
+                                   @{ UWP_info()->{disable} } ] },
         ex_libs         => "WindowsApp.lib",
     },
      "VC-WIN64A-UWP" => {
@@ -89,7 +108,8 @@ my %targets = (
         defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
                                "_WIN32_WINNT=0x0A00"),
         dso_scheme      => "",
-        disable         => [ 'ui-console', 'stdio', 'async', 'uplink' ],
+        disable         => sub { [ 'ui-console', 'stdio', 'async', 'uplink',
+                                   @{ UWP_info()->{disable} } ] },
         ex_libs         => "WindowsApp.lib",
     },
     "VC-WIN32-ARM-UWP" => {
@@ -98,7 +118,8 @@ my %targets = (
         defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
                                "_WIN32_WINNT=0x0A00"),
         dso_scheme      => "",
-        disable         => [ 'ui-console', 'stdio', 'async', 'uplink' ],
+        disable         => sub { [ 'ui-console', 'stdio', 'async', 'uplink',
+                                   @{ UWP_info()->{disable} } ] },
         ex_libs         => "WindowsApp.lib",
     },
      "VC-WIN64-ARM-UWP" => {
@@ -107,7 +128,8 @@ my %targets = (
         defines         => add("WINAPI_FAMILY=WINAPI_FAMILY_APP",
                                "_WIN32_WINNT=0x0A00"),
         dso_scheme      => "",
-        disable         => [ 'ui-console', 'stdio', 'async', 'uplink' ],
+        disable         => sub { [ 'ui-console', 'stdio', 'async', 'uplink',
+                                   @{ UWP_info()->{disable} } ] },
         ex_libs         => "WindowsApp.lib",
     },
 );

--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -19,7 +19,7 @@ sub UWP_info {
         my @SDKver_split = split(/\./, $SDKver);
         # SDK version older than 10.0.17763 don't support our ASM builds
         if ($SDKver_split[0] < 10
-            || ($SDKver_split[1] == 10
+            || ($SDKver_split[0] == 10
                 && $SDKver_split[1] == 0
                 && $SDKver_split[2] < 17763)) {
             $UWP_info->{disable} = [ 'asm' ];


### PR DESCRIPTION
Earlier Windows SDK versions lack the necessary support for our ASM
builds, so we check for the SDK version that has the support.

Information on exactly what registry key to check was found here:

https://stackoverflow.com/questions/2665755/how-can-i-determine-the-version-of-the-windows-sdk-installed-on-my-computer

Ref: #9125
