### PR TITLE
Configure: clang: add -Wno-unknown-warning-option [1.0.2]

### DIFF
--- a/Configure
+++ b/Configure
@@ -118,7 +118,7 @@ my $gcc_devteam_warn = "-Wall -pedantic -DPEDANTIC -Wno-long-long -Wsign-compare
 # -Wincompatible-pointer-types-discards-qualifiers, -Wcast-align,
 # -Wunreachable-code -Wunused-parameter -Wlanguage-extension-token
 # -Wextended-offsetof
-my $clang_disabled_warnings = "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-language-extension-token  -Wno-extended-offsetof";
+my $clang_disabled_warnings = "-Wno-unknown-warning-option -Wno-unused-parameter -Wno-missing-field-initializers -Wno-language-extension-token  -Wno-extended-offsetof";
 
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.
 # TODO(openssl-team): fix problems and investigate if (at least) the
@@ -128,7 +128,7 @@ my $clang_disabled_warnings = "-Wno-unused-parameter -Wno-missing-field-initiali
 # -Wincompatible-pointer-types-discards-qualifiers, -Wcast-align,
 # -Wunreachable-code -Wunused-parameter -Wlanguage-extension-token
 # -Wextended-offsetof
-my $clang_devteam_warn = "-Wno-unused-parameter -Wno-missing-field-initializers -Wno-language-extension-token -Wno-extended-offsetof -Qunused-arguments";
+my $clang_devteam_warn = "-Wno-unknown-warning-option -Wno-unused-parameter -Wno-missing-field-initializers -Wno-language-extension-token -Wno-extended-offsetof -Qunused-arguments";
 
 # Warn that "make depend" should be run?
 my $warn_make_depend = 0;


### PR DESCRIPTION
Pull request #9425 fixed the symptoms but not the cure: The clang error might not only affected the travis ci but also users which build OpenSSL with strict errors enabled using clang, after upgrading to a newer clang version. This pull request reverts 0bc650d58a58 and replaces it by the following:

    Configure: clang: add -Wno-unknown-warning-option
    
    Fixes travis build errors due to clang
    
        error: unknown warning option '-Wno-extended-offsetof'
    
    It seems like '-Wextended-offsetof' was removed from clang in version 6.0.0,
    (see [1], [2]). While gcc ignores unknown options of the type '-Wno-xxx',
    clang by default issues a warning [-Wunknown-warning-option] (see [3]), which
    together with '-Werror' causes the build to fail.
    
    This commit adds the '-Wno-unknown-warning-option' option to make clang
    behave more relaxed like gcc.
    
    [1] https://reviews.llvm.org/D40267
    [2] https://github.com/llvm/llvm-project/commit/52a3ca9e2909
    [3] https://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-warning-option

_(Note: the corresponding pull request for master/1.1.1 can be found at #9447)_