### PR TITLE
Configure: clang: move -Wno-unknown-warning-option to the front

### DIFF
--- a/Configure
+++ b/Configure
@@ -144,13 +144,13 @@ my @gcc_devteam_warn = qw(
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
 my @clang_devteam_warn = qw(
+    -Wno-unknown-warning-option
     -Wswitch-default
     -Wno-parentheses-equality
     -Wno-language-extension-token
     -Wno-extended-offsetof
     -Wconditional-uninitialized
     -Wincompatible-pointer-types-discards-qualifiers
-    -Wno-unknown-warning-option
     -Wmissing-variable-declarations
 );
 


### PR DESCRIPTION
Avoids ~~travis~~ clang  warnings resp. errors of the following type:
_(edit: will be fixed in commit message)_

    error: unknown warning option '-Wno-extended-offsetof'

It seems like '-Wextended-offsetof' was removed from clang in version 6.0.0,
(see [1], [2]). While gcc ignores unknown options of the type '-Wno-xxx',
clang by default issues a warning [-Wunknown-warning-option] (see [3]), which
together with '-Werror' causes the build to fail.

This commit adds the '-Wno-unknown-warning-option' option to make clang
behave more relaxed like gcc.

[1] https://reviews.llvm.org/D40267
[2] https://github.com/llvm/llvm-project/commit/52a3ca9e2909
[3] https://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-warning-option
