### PR TITLE
Implement ERR_raise() / ERR_raise_data()

### DIFF
--- a/crypto/err/build.info
+++ b/crypto/err/build.info
@@ -1,3 +1,3 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
-        err.c err_all.c err_prn.c
+        err_blocks.c err.c err_all.c err_prn.c

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -355,44 +355,6 @@ void err_free_strings_int(void)
 
 /********************************************************/
 
-void ERR_put_func_error(int lib, const char *func, int reason,
-                        const char *file, int line)
-{
-    ERR_put_error(lib, 0, reason, file, line);
-    ERR_add_error_data(2, "calling function ", func);
-}
-
-void ERR_put_error(int lib, int func, int reason, const char *file, int line)
-{
-    ERR_STATE *es;
-
-#ifdef _OSD_POSIX
-    /*
-     * In the BS2000-OSD POSIX subsystem, the compiler generates path names
-     * in the form "*POSIX(/etc/passwd)". This dirty hack strips them to
-     * something sensible. @@@ We shouldn't modify a const string, though.
-     */
-    if (strncmp(file, "*POSIX(", sizeof("*POSIX(") - 1) == 0) {
-        char *end;
-
-        /* Skip the "*POSIX(" prefix */
-        file += sizeof("*POSIX(") - 1;
-        end = &file[strlen(file) - 1];
-        if (*end == ')')
-            *end = '\0';
-        /* Optional: use the basename of the path only. */
-        if ((end = strrchr(file, '/')) != NULL)
-            file = &end[1];
-    }
-#endif
-    es = ERR_get_state();
-    if (es == NULL)
-        return;
-
-    err_get_slot(es);
-    err_clear(es, es->top, 0);
-}
-
 void ERR_clear_error(void)
 {
     int i;

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/err.h>
+#include "err_locl.h"
+
+void ERR_new(void)
+{
+    ERR_STATE *es;
+
+    es = ERR_get_state();
+    if (es == NULL)
+        return;
+
+    /* Allocate a slot */
+    err_allocate(es);
+    err_clear(es, es->top);
+}
+
+void ERR_set_debug(const char *file, int line, const char *func)
+{
+    ERR_STATE *es;
+
+    es = ERR_get_state();
+    if (es == NULL)
+        return;
+
+    err_set_debug(es, es->top, file, line, func);
+}
+
+void ERR_set_error(int lib, int reason, const char *fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    ERR_vset_error(lib, reason, fmt, args);
+    va_end(args);
+}
+
+void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
+{
+    ERR_STATE *es;
+    char *buf = NULL;
+    size_t buf_len = 0;
+    unsigned long flags = 0;
+
+    es = ERR_get_state();
+    if (es == NULL)
+        return;
+
+    if (fmt != NULL
+        && (buf = OPENSSL_malloc(ERR_MAX_DATA_SIZE)) != NULL) {
+        int printed_len = 0;
+        char *rbuf = NULL;
+
+        printed_len = BIO_vsnprintf(buf, ERR_MAX_DATA_SIZE, fmt, args);
+        if (printed_len > 0)
+            buf_len += printed_len;
+        buf[buf_len] = '\0';
+
+        /* Try to reduce the size */
+        rbuf = OPENSSL_realloc(buf, buf_len + 1);
+
+        /*
+         * According to documentation, realloc leaves the old buffer untouched
+         * if it fails.  We could deal with this in two ways, either free the
+         * buffer, or simply keep it.  We choose the former, because that's
+         * what ERR_add_error_vdata() does on the same kind of failure.
+         */
+        if (rbuf == NULL)
+            OPENSSL_free(buf);
+        buf = rbuf;
+
+        if (buf != NULL)
+            flags = ERR_TXT_MALLOCED | ERR_TXT_STRING;
+    }
+
+    err_clear_data(es, es->top);
+    err_set_error(es, es->top, lib, reason);
+    err_set_data(es, es->top, buf, flags);
+}

--- a/crypto/err/err_locl.h
+++ b/crypto/err/err_locl.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/err.h>
+#include <openssl/e_os2.h>
+
+static ossl_inline void err_get_slot(ERR_STATE *es)
+{
+    es->top = (es->top + 1) % ERR_NUM_ERRORS;
+    if (es->top == es->bottom)
+        es->bottom = (es->bottom + 1) % ERR_NUM_ERRORS;
+}
+
+static ossl_inline void err_clear_data(ERR_STATE *es, size_t i, int deall)
+{
+    if (es->err_data_flags[i] & ERR_TXT_MALLOCED) {
+        if (deall) {
+            OPENSSL_free(es->err_data[i]);
+            es->err_data[i] = NULL;
+            es->err_data_size[i] = 0;
+            es->err_data_flags[i] = 0;
+        } else if (es->err_data[i] != NULL) {
+            es->err_data[i][0] = '\0';
+        }
+    } else {
+        es->err_data[i] = NULL;
+        es->err_data_size[i] = 0;
+        es->err_data_flags[i] = 0;
+    }
+}
+
+static ossl_inline void err_set_error(ERR_STATE *es, size_t i,
+                                      int lib, int reason)
+{
+    es->err_buffer[i] = ERR_PACK(lib, 0, reason);
+}
+
+static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
+                                      const char *file, int line,
+                                      const char *fn)
+{
+    es->err_file[i] = file;
+    es->err_line[i] = line;
+    es->err_func[i] = fn;
+}
+
+static ossl_inline void err_set_data(ERR_STATE *es, size_t i,
+                                     void *data, size_t datasz, int flags)
+{
+    es->err_data[i] = data;
+    es->err_data_size[i] = datasz;
+    es->err_data_flags[i] = flags;
+}
+
+static ossl_inline void err_clear(ERR_STATE *es, size_t i, int deall)
+{
+    err_clear_data(es, i, (deall));
+    es->err_flags[i] = 0;
+    es->err_buffer[i] = 0;
+    es->err_file[i] = NULL;
+    es->err_line[i] = -1;
+}

--- a/doc/man3/ERR_new.pod
+++ b/doc/man3/ERR_new.pod
@@ -1,0 +1,78 @@
+=pod
+
+=head1 NAME
+
+ERR_new, ERR_set_debug, ERR_set_error, ERR_vset_error
+- Error recording building blocks
+
+=head1 SYNOPSIS
+
+ #include <openssl/err.h>
+
+ void ERR_new(void);
+ void ERR_set_debug(const char *file, int line, const char *func);
+ void ERR_set_error(int lib, int reason, const char *fmt, ...);
+ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
+
+=head1 DESCRIPTION
+
+The functions described here are generally not used directly, but
+rather through macros such as L<ERR_raise(3)>.
+They can still be useful for anyone that wants to make their own
+macros.
+
+ERR_new() allocates a new slot in the thread's error queue.
+
+ERR_set_debug() sets the debug information related to the current
+error in the thread's error queue.
+The values that can be given are the file name I<file>, line in the
+file I<line> and the name of the function I<func> where the error
+occured.
+The names must be constant, this function will only save away the
+pointers, not copy the strings.
+
+ERR_set_error() sets the error information, which are the library
+number I<lib> and the reason code I<reason>, and additional data as a
+format string I<fmt> and an arbitrary number of arguments.
+The additional data is processed with L<BIO_snprintf(3)> to form the
+additional data string, which is allocated and store in the error
+record.
+
+ERR_vset_error() works like ERR_set_error(), but takes a B<va_list>
+argument instead of a variable number of arguments.
+
+=head1 RETURN VALUES
+
+ERR_new, ERR_set_debug, ERR_set_error and ERR_vset_error
+do not return any values.
+
+=head1 NOTES
+
+The library number is unique to each unit that records errors.
+OpenSSL has a number of pre-allocated ones for its own uses, but
+others may allocate their own library number dynamically with
+L<ERR_get_next_error_library(3)>.
+
+Reason codes are unique within each library, and may have an
+associated set of strings as a short description of the reason.
+For dynamically allocated library numbers, reason strings are recorded
+with L<ERR_load_strings(3)>.
+
+Provider authors are supplied with core versions of these functions,
+see L<provider-base(7)>.
+
+=head1 SEE ALSO
+
+L<ERR_raise(3)>, L<ERR_get_next_error_library(3)>,
+L<ERR_load_strings(3)>, L<BIO_snprintf(3)>, L<provider-base(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -2,12 +2,16 @@
 
 =head1 NAME
 
+ERR_raise, ERR_raise_data,
 ERR_put_error, ERR_put_func_error,
 ERR_add_error_data, ERR_add_error_vdata - record an error
 
 =head1 SYNOPSIS
 
  #include <openssl/err.h>
+
+ void ERR_raise(int lib, int reason);
+ void ERR_raise_data(int lib, int reason, const char *fmt, ...);
 
  void ERR_put_error(int lib, int func, int reason, const char *file, int line);
  void ERR_put_func_error(int lib, const char *func, int reason,
@@ -17,6 +21,16 @@ ERR_add_error_data, ERR_add_error_vdata - record an error
  void ERR_add_error_vdata(int num, va_list arg);
 
 =head1 DESCRIPTION
+
+ERR_raise() adds a new error to the thread's error queue.  The
+error occured in the library B<lib> for the reason given by the
+B<reason> code.  Furthermore, the name of the file, the line, and name
+of the function where the error occured is saved with the error
+record.
+
+ERR_raise_data() does the same thing as ERR_raise(), but also lets the
+caller specify additional information as a format string B<fmt> and an
+arbitrary number of values, which are processed with L<BIO_snprintf(3)>.  
 
 ERR_put_error() adds an error code to the thread's error queue. It
 signals that the error of reason code B<reason> occurred in function
@@ -64,8 +78,12 @@ the ASN1err() macro.
 
 =head1 RETURN VALUES
 
-ERR_put_error() and ERR_add_error_data() return
-no values.
+ERR_raise(), ERR_put_error() and ERR_add_error_data()
+return no values.
+
+=head1 NOTES
+
+ERR_raise() is implemented as a macro.
 
 =head1 SEE ALSO
 
@@ -73,7 +91,7 @@ L<ERR_load_strings(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -3,8 +3,8 @@
 =head1 NAME
 
 ERR_raise, ERR_raise_data,
-ERR_put_error, ERR_put_func_error,
-ERR_add_error_data, ERR_add_error_vdata - record an error
+ERR_put_error, ERR_add_error_data, ERR_add_error_vdata
+- record an error
 
 =head1 SYNOPSIS
 
@@ -13,12 +13,12 @@ ERR_add_error_data, ERR_add_error_vdata - record an error
  void ERR_raise(int lib, int reason);
  void ERR_raise_data(int lib, int reason, const char *fmt, ...);
 
- void ERR_put_error(int lib, int func, int reason, const char *file, int line);
- void ERR_put_func_error(int lib, const char *func, int reason,
-                         const char *file, int line);
-
  void ERR_add_error_data(int num, ...);
  void ERR_add_error_vdata(int num, va_list arg);
+
+Deprecated since OpenSSL 3.0:
+
+ void ERR_put_error(int lib, int func, int reason, const char *file, int line);
 
 =head1 DESCRIPTION
 
@@ -37,10 +37,6 @@ signals that the error of reason code B<reason> occurred in function
 B<func> of library B<lib>, in line number B<line> of B<file>.
 This function is usually called by a macro.
 
-ERR_put_func_err() is similar except that the B<func> is a string naming
-a function external to OpenSSL, usually provided by the platform on which
-OpenSSL and the application is running.
-
 ERR_add_error_data() associates the concatenation of its B<num> string
 arguments with the error code added last.
 ERR_add_error_vdata() is similar except the argument is a B<va_list>.
@@ -51,6 +47,8 @@ error strings so that the application can a generate human-readable
 error messages for the error code.
 
 =head2 Reporting errors
+
+=for comment TODO(3.0) should this be internal documentation?
 
 Each sub-library has a specific macro XXXerr() that is used to report
 errors. Its first argument is a function code B<XXX_F_...>, the second
@@ -78,12 +76,12 @@ the ASN1err() macro.
 
 =head1 RETURN VALUES
 
-ERR_raise(), ERR_put_error() and ERR_add_error_data()
-return no values.
+ERR_raise(), ERR_put_error(), ERR_add_error_data() and
+ERR_add_error_vdata() return no values.
 
 =head1 NOTES
 
-ERR_raise() is implemented as a macro.
+ERR_raise() and ERR_put_error() are implemented as macros.
 
 =head1 SEE ALSO
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -20,11 +20,12 @@ provider-base
  int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
  int core_thread_start(const OSSL_PROVIDER *prov,
                        OSSL_thread_stop_handler_fn handfn);
- void core_put_error(const OSSL_PROVIDER *prov,
-                     uint32_t reason, const char *file, int line);
- void core_add_error_vdata(const OSSL_PROVIDER *prov,
-                           int num, va_list args);
  OPENSSL_CTX *core_get_library_context(const OSSL_PROVIDER *prov);
+ void core_new_error(const OSSL_PROVIDER *prov);
+ void core_set_error_debug(const OSSL_PROVIDER *prov,
+                           const char *file, int line, const char *func);
+ void core_vset_error(const OSSL_PROVIDER *prov,
+                      uint32_t reason, const char *fmt, va_list args);
 
  /*
   * Some OpenSSL functionality is directly offered to providers via
@@ -89,9 +90,10 @@ provider):
  core_get_param_types           OSSL_FUNC_CORE_GET_PARAM_TYPES
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
- core_put_error                 OSSL_FUNC_CORE_PUT_ERROR
- core_add_error_vdata           OSSL_FUNC_CORE_ADD_ERROR_VDATA
  core_get_library_context       OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT
+ core_new_error                 OSSL_FUNC_CORE_NEW_ERROR
+ core_set_error_debug           OSSL_FUNC_CORE_SET_ERROR_DEBUG
+ core_set_error                 OSSL_FUNC_CORE_SET_ERROR
  CRYPTO_malloc                  OSSL_FUNC_CRYPTO_MALLOC
  CRYPTO_zalloc                  OSSL_FUNC_CRYPTO_ZALLOC
  CRYPTO_memdup                  OSSL_FUNC_CRYPTO_MEMDUP
@@ -129,25 +131,47 @@ parameters.
 
 =for comment core_thread_start() TBA
 
-core_put_error() is used to report an error back to the core, with
-reference to the provider object I<prov>.
-The I<reason> is a number defined by the provider and used to index
-the reason strings table that's returned by
-provider_get_reason_strings().
-I<file> and I<line> may also be passed to indicate exactly where the
-error occured or was reported.
-This corresponds to the OpenSSL function L<ERR_put_error(3)>.
-
-core_add_error_vdata() is used to add additional text data to an
-error already reported with core_put_error().
-It takes I<num> strings in a B<va_list> and concatenates them.
-Provider authors will have to write the corresponding variadic
-argument function.
-
 core_get_library_context() retrieves the library context in which the
 B<OSSL_PROVIDER> object I<prov> is stored.
 This may sometimes be useful if the provider wishes to store a
 reference to its context in the same library context.
+
+core_new_error(), core_set_error_debug() and core_set_error() are
+building blocks for reporting an error back to the core, with
+reference to the provider object I<prov>.
+
+=over 4
+
+=item core_new_error()
+
+allocates a new thread specific error record.
+
+This corresponds to the OpenSSL function L<ERR_new(3)>.
+
+=item core_set_error_debug()
+
+sets debugging information in the current thread specific error
+record.
+The debugging information includes the name of the file I<file>, the
+line I<line> and the function name I<func> where the error occured.
+
+This corresponds to the OpenSSL function L<ERR_set_debug(3)>.
+
+=item core_set_error()
+
+sets the I<reason> for the error, along with any addition data.
+The I<reason> is a number defined by the provider and used to index
+the reason strings table that's returned by
+provider_get_reason_strings().
+The additional data is given as a format string I<fmt> and a set of
+arguments I<args>, which are treated in the same manner as with
+BIO_vsnprintf().
+I<file> and I<line> may also be passed to indicate exactly where the
+error occured or was reported.
+
+This corresponds to the OpenSSL function L<ERR_vset_error(3)>.
+
+=back
 
 CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_memdup(), CRYPTO_strdup(),
 CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),

--- a/engines/e_afalg_err.c
+++ b/engines/e_afalg_err.c
@@ -66,5 +66,6 @@ static void ERR_AFALG_error(int function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();
-    ERR_PUT_error(lib_code, function, reason, file, line);
+    ERR_raise(lib_code, reason);
+    ERR_set_debug(file, line, NULL);
 }

--- a/engines/e_capi_err.c
+++ b/engines/e_capi_err.c
@@ -89,5 +89,6 @@ static void ERR_CAPI_error(int function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();
-    ERR_PUT_error(lib_code, function, reason, file, line);
+    ERR_raise(lib_code, reason);
+    ERR_set_debug(file, line, NULL);
 }

--- a/engines/e_dasync_err.c
+++ b/engines/e_dasync_err.c
@@ -51,5 +51,6 @@ static void ERR_DASYNC_error(int function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();
-    ERR_PUT_error(lib_code, function, reason, file, line);
+    ERR_raise(lib_code, reason);
+    ERR_set_debug(file, line, NULL);
 }

--- a/engines/e_ossltest_err.c
+++ b/engines/e_ossltest_err.c
@@ -51,5 +51,6 @@ static void ERR_OSSLTEST_error(int function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();
-    ERR_PUT_error(lib_code, function, reason, file, line);
+    ERR_raise(lib_code, reason);
+    ERR_set_debug(file, line, NULL);
 }

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -66,17 +66,19 @@ OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
 # define OSSL_FUNC_CORE_THREAD_START           3
 OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_PROVIDER *prov,
                                            OSSL_thread_stop_handler_fn handfn))
-# define OSSL_FUNC_CORE_PUT_ERROR              4
-OSSL_CORE_MAKE_FUNC(void,core_put_error,
-                    (const OSSL_PROVIDER *prov,
-                     uint32_t reason, const char *file, int line))
-# define OSSL_FUNC_CORE_ADD_ERROR_VDATA        5
-OSSL_CORE_MAKE_FUNC(void,core_add_error_vdata,(const OSSL_PROVIDER *prov,
-                                               int num, va_list args))
-# define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    6
+# define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    4
 OSSL_CORE_MAKE_FUNC(OPENSSL_CTX *,core_get_library_context,
                     (const OSSL_PROVIDER *prov))
-
+# define OSSL_FUNC_CORE_NEW_ERROR              5
+OSSL_CORE_MAKE_FUNC(void,core_new_error,(const OSSL_PROVIDER *prov))
+# define OSSL_FUNC_CORE_SET_ERROR_DEBUG        6
+OSSL_CORE_MAKE_FUNC(void,core_set_error_debug,
+                    (const OSSL_PROVIDER *prov,
+                     const char *file, int line, const char *func))
+# define OSSL_FUNC_CORE_VSET_ERROR             7
+OSSL_CORE_MAKE_FUNC(void,core_vset_error,
+                    (const OSSL_PROVIDER *prov,
+                     uint32_t reason, const char *fmt, va_list args))
 
 /* Memory allocation, freeing, clearing. */
 #define OSSL_FUNC_CRYPTO_MALLOC               10

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -252,9 +252,14 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
      ERR_set_debug(OPENSSL_FILE,OPENSSL_LINE,OPENSSL_FUNC),     \
      ERR_set_error)
 
-void ERR_put_error(int lib, int func, int reason, const char *file, int line);
-void ERR_put_func_error(int lib, const char *func, int reason,
-                        const char *file, int line);
+#if !OPENSSL_API_3
+/* Backward compatibility */
+#define ERR_put_error(lib, func, reason, file, line)            \
+    (ERR_new(),                                                 \
+     ERR_set_debug((file), (line), NULL),                       \
+     ERR_set_error((lib), (reason), NULL))
+#endif
+
 void ERR_set_error_data(char *data, int flags);
 
 unsigned long ERR_get_error(void);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -236,6 +236,15 @@ typedef struct ERR_string_data_st {
 
 DEFINE_LHASH_OF(ERR_STRING_DATA);
 
+/* 12 lines and some on an 80 column terminal */
+#define ERR_MAX_DATA_SIZE       1024
+
+/* Building blocks */
+void ERR_new(void);
+void ERR_set_debug(const char *file, int line, const char *func);
+void ERR_set_error(int lib, int reason, const char *fmt, ...);
+void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
+
 void ERR_put_error(int lib, int func, int reason, const char *file, int line);
 void ERR_put_func_error(int lib, const char *func, int reason,
                         const char *file, int line);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -46,6 +46,7 @@ typedef struct err_state_st {
     int err_flags[ERR_NUM_ERRORS];
     unsigned long err_buffer[ERR_NUM_ERRORS];
     char *err_data[ERR_NUM_ERRORS];
+    size_t err_data_size[ERR_NUM_ERRORS];
     int err_data_flags[ERR_NUM_ERRORS];
     const char *err_file[ERR_NUM_ERRORS];
     int err_line[ERR_NUM_ERRORS];

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -108,49 +108,49 @@ typedef struct err_state_st {
 # define ERR_LIB_USER            128
 
 # if ! OPENSSL_API_3
-#  define SYSerr(f,r)  ERR_PUT_error(ERR_LIB_SYS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-#endif
-# define FUNCerr(f,r)  ERR_PUT_func_error(ERR_LIB_SYS,(f),(r),OPENSSL_FILE,OPENSSL_LINE)
-# define BNerr(f,r)   ERR_PUT_error(ERR_LIB_BN,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define RSAerr(f,r)  ERR_PUT_error(ERR_LIB_RSA,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define DHerr(f,r)   ERR_PUT_error(ERR_LIB_DH,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define EVPerr(f,r)  ERR_PUT_error(ERR_LIB_EVP,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define BUFerr(f,r)  ERR_PUT_error(ERR_LIB_BUF,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define OBJerr(f,r)  ERR_PUT_error(ERR_LIB_OBJ,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define PEMerr(f,r)  ERR_PUT_error(ERR_LIB_PEM,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define DSAerr(f,r)  ERR_PUT_error(ERR_LIB_DSA,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define X509err(f,r) ERR_PUT_error(ERR_LIB_X509,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ASN1err(f,r) ERR_PUT_error(ERR_LIB_ASN1,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define CONFerr(f,r) ERR_PUT_error(ERR_LIB_CONF,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define CRYPTOerr(f,r) ERR_PUT_error(ERR_LIB_CRYPTO,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ECerr(f,r)   ERR_PUT_error(ERR_LIB_EC,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define SSLerr(f,r)  ERR_PUT_error(ERR_LIB_SSL,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define BIOerr(f,r)  ERR_PUT_error(ERR_LIB_BIO,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define PKCS7err(f,r) ERR_PUT_error(ERR_LIB_PKCS7,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define X509V3err(f,r) ERR_PUT_error(ERR_LIB_X509V3,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define PKCS12err(f,r) ERR_PUT_error(ERR_LIB_PKCS12,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define RANDerr(f,r) ERR_PUT_error(ERR_LIB_RAND,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define DSOerr(f,r) ERR_PUT_error(ERR_LIB_DSO,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ENGINEerr(f,r) ERR_PUT_error(ERR_LIB_ENGINE,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define OCSPerr(f,r) ERR_PUT_error(ERR_LIB_OCSP,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define UIerr(f,r) ERR_PUT_error(ERR_LIB_UI,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define COMPerr(f,r) ERR_PUT_error(ERR_LIB_COMP,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ECDSAerr(f,r)  ERR_PUT_error(ERR_LIB_ECDSA,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ECDHerr(f,r)  ERR_PUT_error(ERR_LIB_ECDH,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define OSSL_STOREerr(f,r) ERR_PUT_error(ERR_LIB_OSSL_STORE,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define FIPSerr(f,r) ERR_PUT_error(ERR_LIB_FIPS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define CMSerr(f,r) ERR_PUT_error(ERR_LIB_CMS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define CRMFerr(f,r) ERR_PUT_error(ERR_LIB_CRMF,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define CMPerr(f,r) ERR_PUT_error(ERR_LIB_CMP,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define TSerr(f,r) ERR_PUT_error(ERR_LIB_TS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define HMACerr(f,r) ERR_PUT_error(ERR_LIB_HMAC,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define CTerr(f,r) ERR_PUT_error(ERR_LIB_CT,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ASYNCerr(f,r) ERR_PUT_error(ERR_LIB_ASYNC,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define KDFerr(f,r) ERR_PUT_error(ERR_LIB_KDF,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define SM2err(f,r) ERR_PUT_error(ERR_LIB_SM2,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define ESSerr(f,r) ERR_PUT_error(ERR_LIB_ESS,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define PROPerr(f,r) ERR_PUT_error(ERR_LIB_PROP,0,(r),OPENSSL_FILE,OPENSSL_LINE)
-# define PROVerr(f,r) ERR_PUT_error(ERR_LIB_PROV,0,(r),OPENSSL_FILE,OPENSSL_LINE)
+#  define SYSerr(f,r)  ERR_raise(ERR_LIB_SYS,(r))
+# endif
+# define FUNCerr(f,r)  ERR_raise_data(ERR_LIB_SYS,(r),"calling function %s",(f))
+# define BNerr(f,r)   ERR_raise(ERR_LIB_RSA,(r))
+# define RSAerr(f,r)  ERR_raise(ERR_LIB_RSA,(r))
+# define DHerr(f,r)   ERR_raise(ERR_LIB_DH,(r))
+# define EVPerr(f,r)  ERR_raise(ERR_LIB_EVP,(r))
+# define BUFerr(f,r)  ERR_raise(ERR_LIB_BUF,(r))
+# define OBJerr(f,r)  ERR_raise(ERR_LIB_OBJ,(r))
+# define PEMerr(f,r)  ERR_raise(ERR_LIB_PEM,(r))
+# define DSAerr(f,r)  ERR_raise(ERR_LIB_DSA,(r))
+# define X509err(f,r) ERR_raise(ERR_LIB_X509,(r))
+# define ASN1err(f,r) ERR_raise(ERR_LIB_ASN1,(r))
+# define CONFerr(f,r) ERR_raise(ERR_LIB_CONF,(r))
+# define CRYPTOerr(f,r) ERR_raise(ERR_LIB_CRYPTO,(r))
+# define ECerr(f,r)   ERR_raise(ERR_LIB_EC,(r))
+# define SSLerr(f,r)  ERR_raise(ERR_LIB_SSL,(r))
+# define BIOerr(f,r)  ERR_raise(ERR_LIB_BIO,(r))
+# define PKCS7err(f,r) ERR_raise(ERR_LIB_PKCS7,(r))
+# define X509V3err(f,r) ERR_raise(ERR_LIB_X509V3,(r))
+# define PKCS12err(f,r) ERR_raise(ERR_LIB_PKCS12,(r))
+# define RANDerr(f,r) ERR_raise(ERR_LIB_RAND,(r))
+# define DSOerr(f,r) ERR_raise(ERR_LIB_DSO,(r))
+# define ENGINEerr(f,r) ERR_raise(ERR_LIB_ENGINE,(r))
+# define OCSPerr(f,r) ERR_raise(ERR_LIB_OCSP,(r))
+# define UIerr(f,r) ERR_raise(ERR_LIB_UI,(r))
+# define COMPerr(f,r) ERR_raise(ERR_LIB_COMP,(r))
+# define ECDSAerr(f,r)  ERR_raise(ERR_LIB_ECDSA,(r))
+# define ECDHerr(f,r)  ERR_raise(ERR_LIB_ECDH,(r))
+# define OSSL_STOREerr(f,r) ERR_raise(ERR_LIB_OSSL_STORE,(r))
+# define FIPSerr(f,r) ERR_raise(ERR_LIB_FIPS,(r))
+# define CMSerr(f,r) ERR_raise(ERR_LIB_CMS,(r))
+# define CRMFerr(f,r) ERR_raise(ERR_LIB_CRMF,(r))
+# define CMPerr(f,r) ERR_raise(ERR_LIB_CMP,(r))
+# define TSerr(f,r) ERR_raise(ERR_LIB_TS,(r))
+# define HMACerr(f,r) ERR_raise(ERR_LIB_HMAC,(r))
+# define CTerr(f,r) ERR_raise(ERR_LIB_CT,(r))
+# define ASYNCerr(f,r) ERR_raise(ERR_LIB_ASYNC,(r))
+# define KDFerr(f,r) ERR_raise(ERR_LIB_KDF,(r))
+# define SM2err(f,r) ERR_raise(ERR_LIB_SM2,(r))
+# define ESSerr(f,r) ERR_raise(ERR_LIB_ESS,(r))
+# define PROPerr(f,r) ERR_raise(ERR_LIB_PROP,(r))
+# define PROVerr(f,r) ERR_raise(ERR_LIB_PROV,(r))
 
 # define ERR_PACK(l,f,r) ( \
         (((unsigned int)(l) & 0x0FF) << 24L) | \
@@ -244,6 +244,13 @@ void ERR_new(void);
 void ERR_set_debug(const char *file, int line, const char *func);
 void ERR_set_error(int lib, int reason, const char *fmt, ...);
 void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
+
+/* Main error raising functions */
+#define ERR_raise(lib, reason) ERR_raise_data((lib),(reason),NULL)
+#define ERR_raise_data                                          \
+    (ERR_new(),                                                 \
+     ERR_set_debug(OPENSSL_FILE,OPENSSL_LINE,OPENSSL_FUNC),     \
+     ERR_set_error)
 
 void ERR_put_error(int lib, int func, int reason, const char *file, int line);
 void ERR_put_func_error(int lib, const char *func, int reason,

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -50,6 +50,7 @@ typedef struct err_state_st {
     int err_data_flags[ERR_NUM_ERRORS];
     const char *err_file[ERR_NUM_ERRORS];
     int err_line[ERR_NUM_ERRORS];
+    const char *err_func[ERR_NUM_ERRORS];
     int top, bottom;
 } ERR_STATE;
 

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OPENSSL_MACROS_H
+# define OPENSSL_MACROS_H
+
+/*
+ * Sometimes OPENSSSL_NO_xxx ends up with an empty file and some compilers
+ * don't like that.  This will hopefully silence them.
+ */
+# define NON_EMPTY_TRANSLATION_UNIT static void *dummy = &dummy;
+
+/*
+ * Applications should use -DOPENSSL_API_COMPAT=<version> to suppress the
+ * declarations of functions deprecated in or before <version>.  If this is
+ * undefined, the value of the macro OPENSSL_API_MIN above is the default.
+ *
+ * For any version number up until version 1.1.x, <version> is expected to be
+ * the calculated version number 0xMNNFFPPSL.  For version numbers 3.0.0 and
+ * on, <version> is expected to be only the major version number (i.e. 3 for
+ * version 3.0.0).
+ */
+# ifndef DECLARE_DEPRECATED
+#  define DECLARE_DEPRECATED(f)   f;
+#  ifdef __GNUC__
+#   if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#    undef DECLARE_DEPRECATED
+#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#   endif
+#  endif
+# endif
+
+/*
+ * We convert the OPENSSL_API_COMPAT value to an API level.  The API level
+ * is the major version number for 3.0.0 and on.  For earlier versions, it
+ * uses this scheme, which is close enough for our purposes:
+ *
+ *      0.x.y   0       (0.9.8 was the last release in this series)
+ *      1.0.x   1       (1.0.2 was the last release in this series)
+ *      1.1.x   2       (1.1.1 was the last release in this series)
+ */
+
+/* In case someone defined both */
+# if defined(OPENSSL_API_COMPAT) && defined(OPENSSL_API_LEVEL)
+#  error "Disallowed to define both OPENSSL_API_COMPAT and OPENSSL_API_LEVEL"
+# endif
+
+# ifndef OPENSSL_API_COMPAT
+#  define OPENSSL_API_LEVEL OPENSSL_MIN_API
+# else
+#  if (OPENSSL_API_COMPAT < 0x1000L) /* Major version numbers up to 16777215 */
+#   define OPENSSL_API_LEVEL OPENSSL_API_COMPAT
+#  elif (OPENSSL_API_COMPAT & 0xF0000000L) == 0x00000000L
+#   define OPENSSL_API_LEVEL 0
+#  elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10000000L
+#   define OPENSSL_API_LEVEL 1
+#  elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10100000L
+#   define OPENSSL_API_LEVEL 2
+#  else
+    /* Major number 3 to 15 */
+#   define OPENSSL_API_LEVEL ((OPENSSL_API_COMPAT >> 28) & 0xF)
+#  endif
+# endif
+
+/*
+ * Do not deprecate things to be deprecated in version 4.0 before the
+ * OpenSSL version number matches.
+ */
+# if OPENSSL_VERSION_MAJOR < 4
+#  define DEPRECATEDIN_4(f)       f;
+#  define OPENSSL_API_4 0
+# elif OPENSSL_API_LEVEL < 4
+#  define DEPRECATEDIN_4(f)       DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_4 0
+# else
+#  define DEPRECATEDIN_4(f)
+#  define OPENSSL_API_4 1
+# endif
+
+# if OPENSSL_API_LEVEL < 3
+#  define DEPRECATEDIN_3(f)       DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_3 0
+# else
+#  define DEPRECATEDIN_3(f)
+#  define OPENSSL_API_3 1
+# endif
+
+# if OPENSSL_API_LEVEL < 2
+#  define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_1_1_0 0
+# else
+#  define DEPRECATEDIN_1_1_0(f)
+#  define OPENSSL_API_1_1_0 1
+# endif
+
+# if OPENSSL_API_LEVEL < 1
+#  define DEPRECATEDIN_1_0_0(f)   DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_1_0_0 0
+# else
+#  define DEPRECATEDIN_1_0_0(f)
+#  define OPENSSL_API_1_0_0 1
+# endif
+
+# if OPENSSL_API_LEVEL < 0
+#  define DEPRECATEDIN_0_9_8(f)   DECLARE_DEPRECATED(f)
+#  define OPENSSL_API_0_9_8 0
+# else
+#  define DEPRECATEDIN_0_9_8(f)
+#  define OPENSSL_API_0_9_8 1
+# endif
+
+# ifndef OPENSSL_FILE
+#  ifdef OPENSSL_NO_FILENAMES
+#   define OPENSSL_FILE ""
+#   define OPENSSL_LINE 0
+#  else
+#   define OPENSSL_FILE __FILE__
+#   define OPENSSL_LINE __LINE__
+#  endif
+# endif
+
+# ifndef OPENSSL_FUNC
+#  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#   define OPENSSL_FUNC __func__
+#  elif defined(__STDC__) && defined(PEDANTIC)
+#   define OPENSSL_FUNC "(PEDANTIC disallows function name)"
+#  elif defined(_MSC_VER) || (defined(__GNUC__) && __GNUC__ >= 2)
+#   define OPENSSL_FUNC __FUNCTION__
+#  elif defined(__FUNCSIG__)
+#   define OPENSSL_FUNC __FUNCSIG__
+#  else
+#   define OPENSSL_FUNC "(unknown function)"
+#  endif
+# endif
+
+#endif  /* OPENSSL_MACROS_H */

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -47,121 +47,6 @@ extern "C" {
     "";
 -}
 
-/*
- * Sometimes OPENSSSL_NO_xxx ends up with an empty file and some compilers
- * don't like that.  This will hopefully silence them.
- */
-# define NON_EMPTY_TRANSLATION_UNIT static void *dummy = &dummy;
-
-/*
- * Applications should use -DOPENSSL_API_COMPAT=<version> to suppress the
- * declarations of functions deprecated in or before <version>.  If this is
- * undefined, the value of the macro OPENSSL_API_MIN above is the default.
- *
- * For any version number up until version 1.1.x, <version> is expected to be
- * the calculated version number 0xMNNFFPPSL.  For version numbers 3.0.0 and
- * on, <version> is expected to be only the major version number (i.e. 3 for
- * version 3.0.0).
- */
-# ifndef DECLARE_DEPRECATED
-#  define DECLARE_DEPRECATED(f)   f;
-#  ifdef __GNUC__
-#   if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-#    undef DECLARE_DEPRECATED
-#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
-#   endif
-#  endif
-# endif
-
-/*
- * We convert the OPENSSL_API_COMPAT value to an API level.  The API level
- * is the major version number for 3.0.0 and on.  For earlier versions, it
- * uses this scheme, which is close enough for our purposes:
- *
- *      0.x.y   0       (0.9.8 was the last release in this series)
- *      1.0.x   1       (1.0.2 was the last release in this series)
- *      1.1.x   2       (1.1.1 was the last release in this series)
- */
-
-/* In case someone defined both */
-# if defined(OPENSSL_API_COMPAT) && defined(OPENSSL_API_LEVEL)
-#  error "Disallowed to define both OPENSSL_API_COMPAT and OPENSSL_API_LEVEL"
-# endif
-
-# ifndef OPENSSL_API_COMPAT
-#  define OPENSSL_API_LEVEL OPENSSL_MIN_API
-# else
-#  if (OPENSSL_API_COMPAT < 0x1000L) /* Major version numbers up to 16777215 */
-#   define OPENSSL_API_LEVEL OPENSSL_API_COMPAT
-#  elif (OPENSSL_API_COMPAT & 0xF0000000L) == 0x00000000L
-#   define OPENSSL_API_LEVEL 0
-#  elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10000000L
-#   define OPENSSL_API_LEVEL 1
-#  elif (OPENSSL_API_COMPAT & 0xFFF00000L) == 0x10100000L
-#   define OPENSSL_API_LEVEL 2
-#  else
-    /* Major number 3 to 15 */
-#   define OPENSSL_API_LEVEL ((OPENSSL_API_COMPAT >> 28) & 0xF)
-#  endif
-# endif
-
-/*
- * Do not deprecate things to be deprecated in version 4.0 before the
- * OpenSSL version number matches.
- */
-# if OPENSSL_VERSION_MAJOR < 4
-#  define DEPRECATEDIN_4(f)       f;
-#  define OPENSSL_API_4 0
-# elif OPENSSL_API_LEVEL < 4
-#  define DEPRECATEDIN_4(f)       DECLARE_DEPRECATED(f)
-#  define OPENSSL_API_4 0
-# else
-#  define DEPRECATEDIN_4(f)
-#  define OPENSSL_API_4 1
-# endif
-
-# if OPENSSL_API_LEVEL < 3
-#  define DEPRECATEDIN_3(f)       DECLARE_DEPRECATED(f)
-#  define OPENSSL_API_3 0
-# else
-#  define DEPRECATEDIN_3(f)
-#  define OPENSSL_API_3 1
-# endif
-
-# if OPENSSL_API_LEVEL < 2
-#  define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
-#  define OPENSSL_API_1_1_0 0
-# else
-#  define DEPRECATEDIN_1_1_0(f)
-#  define OPENSSL_API_1_1_0 1
-# endif
-
-# if OPENSSL_API_LEVEL < 1
-#  define DEPRECATEDIN_1_0_0(f)   DECLARE_DEPRECATED(f)
-#  define OPENSSL_API_1_0_0 0
-# else
-#  define DEPRECATEDIN_1_0_0(f)
-#  define OPENSSL_API_1_0_0 1
-# endif
-
-# if OPENSSL_API_LEVEL < 0
-#  define DEPRECATEDIN_0_9_8(f)   DECLARE_DEPRECATED(f)
-#  define OPENSSL_API_0_9_8 0
-# else
-#  define DEPRECATEDIN_0_9_8(f)
-#  define OPENSSL_API_0_9_8 1
-# endif
-
-# ifndef OPENSSL_FILE
-#  ifdef OPENSSL_NO_FILENAMES
-#   define OPENSSL_FILE ""
-#   define OPENSSL_LINE 0
-#  else
-#   define OPENSSL_FILE __FILE__
-#   define OPENSSL_LINE __LINE__
-#  endif
-# endif
-
 /* Generate 80386 code? */
 {- $config{processor} eq "386" ? "# define" : "# undef" -} I386_ONLY
 
@@ -177,6 +62,8 @@ extern "C" {
 # endif
 
 # define RC4_INT {- $config{rc4_int} -}
+
+#include <openssl/macros.h>
 
 # ifdef  __cplusplus
 }

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -118,7 +118,8 @@ void ossl_statem_set_renegotiate(SSL *s)
 void ossl_statem_fatal(SSL *s, int al, int func, int reason, const char *file,
                        int line)
 {
-    ERR_put_error(ERR_LIB_SSL, func, reason, file, line);
+    ERR_raise(ERR_LIB_SSL, reason);
+    ERR_set_debug(file, line, NULL); /* Override what ERR_raise set */
     /* We shouldn't call SSLfatal() twice. Once is enough */
     if (s->statem.in_init && s->statem.state == MSG_FLOW_ERROR)
       return;

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -47,12 +47,14 @@ static int vdata_appends(void)
 /* Test that setting a platform error sets the right values. */
 static int platform_error(void)
 {
-    const char *file = __FILE__, *f, *data;
-    const int line = __LINE__;
+    const char *file, *f, *data;
+    int line;
     int l;
     unsigned long e;
 
-    ERR_put_func_error(ERR_LIB_SYS, "exit", ERR_R_INTERNAL_ERROR, file, line);
+    file = __FILE__;
+    line = __LINE__ + 1; /* The error is generated on the next line */
+    FUNCerr("exit", ERR_R_INTERNAL_ERROR);
     if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
             || !TEST_int_eq(l, line)

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4700,3 +4700,7 @@ EVP_CIPHER_do_all_ex                    4805	3_0_0	EXIST::FUNCTION:
 EVP_MD_do_all_ex                        4806	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_provider                    4807	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_available                 4808	3_0_0	EXIST::FUNCTION:
+ERR_new                                 4809	3_0_0	EXIST::FUNCTION:
+ERR_set_debug                           4810	3_0_0	EXIST::FUNCTION:
+ERR_set_error                           4811	3_0_0	EXIST::FUNCTION:
+ERR_vset_error                          4812	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -998,7 +998,7 @@ OPENSSL_LH_get_down_load                1023	3_0_0	EXIST::FUNCTION:
 EVP_md4                                 1024	3_0_0	EXIST::FUNCTION:MD4
 X509_set_subject_name                   1025	3_0_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKey_nid_bio             1026	3_0_0	EXIST::FUNCTION:
-ERR_put_error                           1027	3_0_0	EXIST::FUNCTION:
+ERR_put_error                           1027	3_0_0	NOEXIST::FUNCTION:
 ERR_add_error_data                      1028	3_0_0	EXIST::FUNCTION:
 X509_ALGORS_it                          1029	3_0_0	EXIST::FUNCTION:
 MD5_Update                              1030	3_0_0	EXIST::FUNCTION:MD5
@@ -4690,7 +4690,7 @@ EVP_KEYMGMT_up_ref                      4795	3_0_0	EXIST::FUNCTION:
 EVP_KEYMGMT_free                        4796	3_0_0	EXIST::FUNCTION:
 EVP_KEYMGMT_provider                    4797	3_0_0	EXIST::FUNCTION:
 X509_PUBKEY_dup                         4798	3_0_0	EXIST::FUNCTION:
-ERR_put_func_error                      4799	3_0_0	EXIST::FUNCTION:
+ERR_put_func_error                      4799	3_0_0	NOEXIST::FUNCTION:
 EVP_MD_name                             4800	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_name                         4801	3_0_0	EXIST::FUNCTION:
 EVP_MD_provider                         4802	3_0_0	EXIST::FUNCTION:

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -650,7 +650,8 @@ ${st}void ERR_${lib}_error(int function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();
-    ERR_PUT_error(lib_code, function, reason, file, line);
+    ERR_raise(lib_code, reason);
+    ERR_set_debug(file, line, NULL);
 }
 EOF
 

--- a/util/private.num
+++ b/util/private.num
@@ -196,6 +196,8 @@ ERR_GET_REASON                          define
 ERR_PACK                                define
 ERR_free_strings                        define deprecated 1.1.0
 ERR_load_crypto_strings                 define deprecated 1.1.0
+ERR_raise                               define
+ERR_raise_data                          define
 EVP_DigestSignUpdate                    define
 EVP_DigestVerifyUpdate                  define
 EVP_KDF_name                            define

--- a/util/private.num
+++ b/util/private.num
@@ -195,6 +195,7 @@ ERR_GET_LIB                             define
 ERR_GET_REASON                          define
 ERR_PACK                                define
 ERR_free_strings                        define deprecated 1.1.0
+ERR_put_error                           define deprecated 3.0
 ERR_load_crypto_strings                 define deprecated 1.1.0
 ERR_raise                               define
 ERR_raise_data                          define


### PR DESCRIPTION
`ERR_raise()` and `ERR_raise_data` is new functionality to raise errors, with this intended signature:

``` C
void ERR_raise(int lib, int reason);
void ERR_raise_data(int lib, int reason, const char *fmt, ...);
```

The intention with this is to have functionality that makes it easier to report errors with additional text, instead of the sometimes cumbersome error handling with `ERR_set_error_data()`.

`ERR_raise()` and `ERR_raise_data` are implemented as macros which works with a few building blocks:

- `ERR_new()` which simply allocates a new error record in the error queue.
- `ERR_set_debug()` which sets debugging information in the current error record.  "debugging information" are `__FILE__`, `__LINE__` and `__func__` or variants thereof (in reality, we use `OPENSSL_FILE`, `OPENSSL_LINE` and `OPENSSL_FUNC`, which are defined appropriately for the toolchain that builds this)
- `ERR_set_error()` which sets the basic error information in the current error record; library number, reason code, and a format string followed by arguments that form the additional data.

All the `FOOerr` macros are reimplemented in terms of `ERR_raise()` / `ERR_raise_data`, including `FUNCerr`, which also means that `ERR_put_func_error()` lost its meaning.

-----

This functionality was briefly discussed in [this thread on openssl-project](https://mta.openssl.org/pipermail/openssl-project/2019-June/001426.html)