### PR TITLE
Document issue with default installation paths on diverse Windows targets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,12 @@
 
  Changes between 1.0.2s and 1.0.2t [xx XXX xxxx]
 
-  *)
+  *) Document issue with installation paths in diverse Windows builds
+
+     '/usr/local/ssl' is an unsafe prefix for location to install OpenSSL
+     binaries and run-time config file.
+     (CVE-2019-1552)
+     [Richard Levitte]
 
  Changes between 1.0.2r and 1.0.2s [28 May 2019]
 

--- a/INSTALL.DJGPP
+++ b/INSTALL.DJGPP
@@ -33,8 +33,18 @@
  running in a DOS box under Windows. If so, just close the BASH
  shell, go back to Windows, and restart BASH. Then run "make" again.
 
- RUN-TIME CAVEAT LECTOR
- --------------
+ CAVEAT LECTOR
+ -------------
+
+ ### Default install and config paths
+
+ ./Configure defaults to '/usr/local/ssl' as installation top.  This is
+ suitable for Unix, but not for Windows, where this usually is a world
+ writable directory and therefore accessible for change by untrusted users.
+ It is therefore recommended to set your own --prefix or --openssldir
+ (see the example above)
+
+ ### Entropy
 
  Quoting FAQ:
 

--- a/INSTALL.DJGPP
+++ b/INSTALL.DJGPP
@@ -41,8 +41,8 @@
  ./Configure defaults to '/usr/local/ssl' as installation top.  This is
  suitable for Unix, but not for Windows, where this usually is a world
  writable directory and therefore accessible for change by untrusted users.
- It is therefore recommended to set your own --prefix or --openssldir
- (see the example above)
+ It is therefore recommended to set your own --prefix or --openssldir to
+ some location that is not world writeable (see the example above)
 
  ### Entropy
 

--- a/INSTALL.W32
+++ b/INSTALL.W32
@@ -42,8 +42,8 @@
  ./Configure defaults to '/usr/local/ssl' as installation top.  This is
  suitable for Unix, but not for Windows, where this usually is a world
  writable directory and therefore accessible for change by untrusted users.
- It is therefore recommended to set your own --prefix or --openssldir
- (see the examples below)
+ It is therefore recommended to set your own --prefix or --openssldir to
+ some location that is not world writeable (see the example above)
 
  Visual C++
  ----------

--- a/INSTALL.W32
+++ b/INSTALL.W32
@@ -34,6 +34,17 @@
  get it all to work. See the trouble shooting section later on for if (when?)
  it goes wrong.
 
+ CAVEAT LECTOR
+ -------------
+
+ ### Default install and config paths
+
+ ./Configure defaults to '/usr/local/ssl' as installation top.  This is
+ suitable for Unix, but not for Windows, where this usually is a world
+ writable directory and therefore accessible for change by untrusted users.
+ It is therefore recommended to set your own --prefix or --openssldir
+ (see the examples below)
+
  Visual C++
  ----------
 
@@ -104,7 +115,7 @@
  ---------------------
 
  * Configure for building with Borland Builder:
-   > perl Configure BC-32
+   > perl Configure BC-32 --prefix=c:\some\openssl\dir
 
  * Create the appropriate makefile
    > ms\do_nasm
@@ -196,7 +207,7 @@
 
  * Compile OpenSSL:
 
-   $ ./config
+   $ ./config --prefix=c:/some/openssl/dir
    [...]
    $ make
    [...]
@@ -206,7 +217,11 @@
    and openssl.exe application in apps directory.
 
    It is also possible to cross-compile it on Linux by configuring
-   with './Configure --cross-compile-prefix=i386-mingw32- mingw ...'.
+   like this:
+
+   $ ./Configure --cross-compile-prefix=i386-mingw32- \
+     --prefix=c:/some/openssl/dir mingw ...
+
    'make test' is naturally not applicable then.
 
    libcrypto.a and libssl.a are the static libraries. To use the DLLs,
@@ -239,6 +254,9 @@
 	$ copy /b out32dll\ssleay32.dll c:\openssl\bin
 	$ copy /b out32dll\libeay32.dll c:\openssl\bin
 	$ copy /b out32dll\openssl.exe  c:\openssl\bin
+
+      ("c:\openssl" should be whatever you specified to --prefix when
+      configuring the build)
 
       Of course, you can choose another device than c:.  C: is used here
       because that's usually the first (and often only) harddisk device.

--- a/INSTALL.W64
+++ b/INSTALL.W64
@@ -35,8 +35,8 @@
  ./Configure defaults to '/usr/local/ssl' as installation top.  This is
  suitable for Unix, but not for Windows, where this usually is a world
  writable directory and therefore accessible for change by untrusted users.
- It is therefore recommended to set your own --prefix or --openssldir
- (see the examples below)
+ It is therefore recommended to set your own --prefix or --openssldir to
+ some location that is not world writeable (see the example above)
 
  Compiling procedure
  -------------------

--- a/INSTALL.W64
+++ b/INSTALL.W64
@@ -30,6 +30,14 @@
    Neither of these is actually big deal and hardly encountered
    in real-life applications.
 
+ ### Default install and config paths
+
+ ./Configure defaults to '/usr/local/ssl' as installation top.  This is
+ suitable for Unix, but not for Windows, where this usually is a world
+ writable directory and therefore accessible for change by untrusted users.
+ It is therefore recommended to set your own --prefix or --openssldir
+ (see the examples below)
+
  Compiling procedure
  -------------------
 
@@ -43,7 +51,7 @@
 
  To build for Win64/x64:
 
- > perl Configure VC-WIN64A
+ > perl Configure VC-WIN64A --prefix=c:\some\openssl\dir
  > ms\do_win64a
  > nmake -f ms\ntdll.mak
  > cd out32dll
@@ -51,7 +59,7 @@
 
  To build for Win64/IA64:
 
- > perl Configure VC-WIN64I
+ > perl Configure VC-WIN64I --prefix=c:\some\openssl\dir
  > ms\do_win64i
  > nmake -f ms\ntdll.mak
  > cd out32dll

--- a/INSTALL.WCE
+++ b/INSTALL.WCE
@@ -43,8 +43,8 @@
  ./Configure defaults to '/usr/local/ssl' as installation top.  This is
  suitable for Unix, but not for Windows, where this usually is a world
  writable directory and therefore accessible for change by untrusted users.
- It is therefore recommended to set your own --prefix or --openssldir
- (see the examples below)
+ It is therefore recommended to set your own --prefix or --openssldir to
+ some location that is not world writeable (see the example above)
 
  Building
  --------

--- a/INSTALL.WCE
+++ b/INSTALL.WCE
@@ -35,6 +35,17 @@
  redirects IO to active sync link, while PortSDK - to NT-like console
  driver on the handheld itself.
 
+ CAVEAT LECTOR
+ -------------
+
+ ### Default install and config paths
+
+ ./Configure defaults to '/usr/local/ssl' as installation top.  This is
+ suitable for Unix, but not for Windows, where this usually is a world
+ writable directory and therefore accessible for change by untrusted users.
+ It is therefore recommended to set your own --prefix or --openssldir
+ (see the examples below)
+
  Building
  --------
 
@@ -61,7 +72,7 @@
 
  Next you should run Configure:
 
- > perl Configure VC-CE
+ > perl Configure VC-CE --prefix=c:\some\openssl\dir
 
  Next you need to build the Makefiles:
 


### PR DESCRIPTION
For all config targets (except VMS, because it has a completely different
set of scripts), '/usr/local/ssl' is the default prefix for installation
of programs and libraries, as well as the path for OpenSSL run-time
configuration.

For programs built to run in a Windows environment, this default is
unsafe, and the user should set a different prefix.  This has been hinted
at in some documentation but not all, and the danger of leaving the
default as is hasn't been documented at all.

This change documents the issue as a caveat lector, and all configuration
examples now include an example --prefix.

CVE-2019-1552

-----

While #9400 changes the actual defaults for 1.1.x, doing so for 1.0.2 is much less feasible, especially since the builds for the different platforms aren't unified as in 1.1.0.  We therefore turn to documentation.