### PR TITLE
ERR: re-use the err_data field when possible

### DIFF
--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -37,7 +37,6 @@ extern "C" {
 
 # define ERR_TXT_MALLOCED        0x01
 # define ERR_TXT_STRING          0x02
-# define ERR_TXT_IGNORE          0x04
 
 # define ERR_FLAG_MARK           0x01
 # define ERR_FLAG_CLEAR          0x02

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -37,6 +37,7 @@ extern "C" {
 
 # define ERR_TXT_MALLOCED        0x01
 # define ERR_TXT_STRING          0x02
+# define ERR_TXT_IGNORE          0x04
 
 # define ERR_FLAG_MARK           0x01
 # define ERR_FLAG_CLEAR          0x02
@@ -46,6 +47,7 @@ typedef struct err_state_st {
     int err_flags[ERR_NUM_ERRORS];
     unsigned long err_buffer[ERR_NUM_ERRORS];
     char *err_data[ERR_NUM_ERRORS];
+    size_t err_data_size[ERR_NUM_ERRORS];
     int err_data_flags[ERR_NUM_ERRORS];
     const char *err_file[ERR_NUM_ERRORS];
     int err_line[ERR_NUM_ERRORS];


### PR DESCRIPTION
To deallocate the err_data field and then allocating it again might be
a waste of processing, but may also be a source of errors when memory
is scarce.  While we normally tolerate that, the ERR sub-system is an
exception and we need to pay closer attention to how we handle memory.

This adds a new err_data flag, ERR_TXT_IGNORE, which means that even
if there is err_data memory allocated, its contents should be ignored.
Deallocation of the err_data field is much more selective, aand should
only happen when ERR_free_state() is called.

Fixes #9458
