### PR TITLE
Fix default installation paths on mingw [1.1.0]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,13 @@
 
  Changes between 1.1.0k and 1.1.0l [xx XXX xxxx]
 
-  *)
+  *) Use Windows installation paths in the mingw builds
+
+     Mingw isn't a POSIX environment per se, which means that Windows
+     paths should be used for installation.
+     (CVE-2019-1552)
+     [Richard Levitte]
+
 
  Changes between 1.1.0j and 1.1.0k [28 May 2019]
 

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1444,6 +1444,7 @@ sub vms_info {
         shared_extension => ".dll",
         multilib         => "",
         apps_aux_src     => add("win32_init.c"),
+        build_scheme     => add("mingw", { separator => undef }),
     },
     "mingw64" => {
         # As for OPENSSL_USE_APPLINK. Applink makes it possible to use
@@ -1473,6 +1474,7 @@ sub vms_info {
         shared_extension => ".dll",
         multilib         => "64",
         apps_aux_src     => add("win32_init.c"),
+        build_scheme     => add("mingw64", { separator => undef }),
     },
 
 #### UEFI

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -13,6 +13,28 @@
      our $shlibextimport = $target{shared_import_extension} || "";
      our $dsoext = $target{dso_extension} || ".so";
 
+     # $mingw_installroot and $mingw_commonroot is relevant for mingw only.
+     my $mingw_installenv =
+         $target{build_scheme}->[2] eq "mingw"
+         ? "ProgramFiles(x86)" : "ProgramW6432";
+     my $mingw_commonenv =
+         $target{build_scheme}->[2] eq "mingw"
+         ? "CommonProgramFiles(x86)" : "CommonProgramW6432";
+     our $mingw_installroot =
+         defined($ENV{$mingw_installenv})
+         ? $mingw_installenv : 'ProgramFiles';
+     our $mingw_commonroot =
+         defined($ENV{$mingw_commonenv})
+         ? $mingw_commonenv : 'CommonProgramFiles';
+     my $mingw_installdflt =
+         defined($ENV{$mingw_installenv})
+          ? "C:/Program Files (x86)" : "C:/Program Files";
+     my $mingw_commondflt = "$mingw_installdflt/Common Files";
+
+     # expand variables early
+     $mingw_installroot = $ENV{$mingw_installroot} // $mingw_installdflt;
+     $mingw_commonroot = $ENV{$mingw_commonroot} // $mingw_commondflt;
+
      sub windowsdll { $config{target} =~ /^(?:Cygwin|mingw)/ }
 
      our $sover = $config{target} =~ /^mingw/
@@ -121,6 +143,7 @@ APPS_OPENSSL={- use File::Spec::Functions;
 # Normally it is left empty.
 DESTDIR=
 
+{- output_off() if $config{target} =~ /^mingw/; "" -}
 # Do not edit these manually. Use Configure with --prefix or --openssldir
 # to change this!  Short explanation in the top comment in Configure
 INSTALLTOP={- # $prefix is used in the OPENSSLDIR perl snippet
@@ -159,6 +182,79 @@ ENGINESDIR={- use File::Spec::Functions;
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications
 LIBRPATH=$(INSTALLTOP)/$(LIBDIR)
+{- output_on() if $config{target} =~ /^mingw/;
+   output_off() if $config{target} !~ /^mingw/;
+   "" -}
+# Do not edit these manually. Use Configure with --prefix or --openssldir
+# to change this!  Short explanation in the top comment in Configure
+INSTALLTOP_dev={- # $prefix is used in the OPENSSLDIR perl snippet
+                  #
+                  use File::Spec::Win32;
+                  my $prefix_default = "$mingw_installroot/OpenSSL";
+                  our $prefix =
+                      File::Spec::Win32->canonpath($config{prefix}
+                                                  || $prefix_default);
+                  our ($prefix_dev, $prefix_dir, $prefix_file) =
+                      File::Spec::Win32->splitpath($prefix, 1);
+                  $prefix =~ s|\\|/|g;
+                  $prefix_dir =~ s|\\|/|g;
+                  $prefix_dev -}
+INSTALLTOP_dir={- my $x = File::Spec::Win32->canonpath($prefix_dir);
+                  $x =~ s|\\|/|g;
+                  $x -}
+OPENSSLDIR_dev={- #
+                  # The logic here is that if no --openssldir was given,
+                  # OPENSSLDIR will get the value "$mingw_commonroot/SSL".
+                  # If --openssldir was given and the value is an absolute
+                  # path, OPENSSLDIR will get its value without change.
+                  # If the value from --openssldir is a relative path,
+                  # OPENSSLDIR will get $prefix with the --openssldir
+                  # value appended as a subdirectory.
+                  #
+                  use File::Spec::Win32;
+                  our $openssldir =
+                      $config{openssldir} ?
+                          (File::Spec::Win32->file_name_is_absolute($config{openssldir}) ?
+                               File::Spec::Win32->canonpath($config{openssldir})
+                               : File::Spec::Win32->catdir($prefix, $config{openssldir}))
+                          : File::Spec::Win32->canonpath("$mingw_commonroot/SSL");
+                  our ($openssldir_dev, $openssldir_dir, $openssldir_file) =
+                      File::Spec::Win32->splitpath($openssldir, 1);
+                  $openssldir =~ s|\\|/|g;
+                  $openssldir_dir =~ s|\\|/|g;
+                  $openssldir_dev -}
+OPENSSLDIR_dir={- my $x = File::Spec::Win32->canonpath($openssldir_dir);
+                  $x =~ s|\\|/|g;
+                  $x -}
+LIBDIR={- our $libdir = $config{libdir} || "lib";
+          $libdir -}
+ENGINESDIR_dev={- use File::Spec::Win32;
+                  our $enginesdir =
+                      File::Spec::Win32->catdir($prefix,$libdir,
+                                                "engines-$sover_dirname");
+                  our ($enginesdir_dev, $enginesdir_dir, $enginesdir_file) =
+                      File::Spec::Win32->splitpath($enginesdir, 1);
+                  $enginesdir =~ s|\\|/|g;
+                  $enginesdir_dir =~ s|\\|/|g;
+                  $enginesdir_dev -}
+ENGINESDIR_dir={- my $x = File::Spec::Win32->canonpath($enginesdir_dir);
+                  $x =~ s|\\|/|g;
+                  $x -}
+# In a Windows environment, $(DESTDIR) is harder to contatenate with other
+# directory variables, because both may contain devices.  What we do here is
+# to adapt INSTALLTOP, OPENSSLDIR and ENGINESDIR depending on if $(DESTDIR)
+# has a value or not, to ensure that concatenation will always work further
+# down.
+ifneq "$(DESTDIR)" ""
+INSTALLTOP=$(INSTALLTOP_dir)
+OPENSSLDIR=$(OPENSSLDIR_dir)
+ENGINESDIR=$(ENGINESDIR_dir)
+else
+INSTALLTOP=$(INSTALLTOP_dev)$(INSTALLTOP_dir)
+OPENSSLDIR=$(OPENSSLDIR_dev)$(OPENSSLDIR_dir)
+ENGINESDIR=$(ENGINESDIR_dev)$(ENGINESDIR_dir)
+endif
+{- output_on() if $config{target} !~ /^mingw/; "" -}
 
 MANDIR=$(INSTALLTOP)/share/man
 DOCDIR=$(INSTALLTOP)/share/doc/$(BASENAME)

--- a/NOTES.WIN
+++ b/NOTES.WIN
@@ -107,6 +107,21 @@
    and i686-w64-mingw32-.
 
 
+ Independently of the method chosen to build for mingw, the installation
+ paths are similar to those used when building with VC-* targets, except
+ that in case the fallbacks mentioned there aren't possible (typically
+ when cross compiling on Linux), the paths will be the following:
+
+ For mingw:
+
+     PREFIX:      C:/Program Files (x86)/OpenSSL
+     OPENSSLDIR   C:/Program Files (x86)/Common Files/SSL
+
+ For mingw64:
+
+     PREFIX:      C:/Program Files/OpenSSL
+     OPENSSLDIR   C:/Program Files/Common Files/SSL
+
  Linking your application
  ------------------------
 


### PR DESCRIPTION
*[This is a port of #9400 to 1.1.0]*

Mingw config targets assumed that resulting programs and libraries are
installed in a Unix-like environment and the default installation
prefix was therefore set to '/usr/local'.

However, mingw programs are installed in a Windows environment, and
the installation directories should therefore have Windows defaults,
i.e. the same kind of defaults as the VC config targets.

A difficulty is, however, that a "cross compiled" build can't figure
out the system defaults from environment the same way it's done when
building "natively", so we have to fall back to hard coded defaults in
that case.

Tests can still be performed when cross compiled on a non-Windows
platform, since all tests only depend on the source and build
directory, and otherwise relies on normal local paths.

CVE-2019-1552
