### PR TITLE
Deprecate the public definition of ERR_STATE

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Deprecated the public definition of ERR_STATE as well as the function
+     ERR_get_state().  This is done in preparation of making ERR_STATE an
+     opaque type.
+     [Richard Levitte]
+
   *) Added ERR functionality to give callers access to the stored function
      names that have replaced the older function code based functions.
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -365,7 +365,7 @@ void ERR_clear_error(void)
     int i;
     ERR_STATE *es;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return;
 
@@ -488,7 +488,7 @@ static unsigned long get_error_values(int inc, int top, const char **file,
     ERR_STATE *es;
     unsigned long ret;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return 0;
 
@@ -685,7 +685,7 @@ DEFINE_RUN_ONCE_STATIC(err_do_init)
     return CRYPTO_THREAD_init_local(&err_thread_local, NULL);
 }
 
-ERR_STATE *ERR_get_state(void)
+ERR_STATE *err_get_state_int(void)
 {
     ERR_STATE *state;
     int saveerrno = get_last_sys_error();
@@ -723,6 +723,14 @@ ERR_STATE *ERR_get_state(void)
     set_sys_error(saveerrno);
     return state;
 }
+
+#if !OPENSSL_API_3
+ERR_STATE *ERR_get_state(void)
+{
+    return err_get_state_int();
+}
+#endif
+
 
 /*
  * err_shelve_state returns the current thread local error state
@@ -786,7 +794,7 @@ static int err_set_error_data_int(char *data, size_t size, int flags,
 {
     ERR_STATE *es;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return 0;
 
@@ -831,7 +839,7 @@ void ERR_add_error_vdata(int num, va_list args)
     ERR_STATE *es;
 
     /* Get the current error data; if an allocated string get it. */
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return;
     i = es->top;
@@ -886,7 +894,7 @@ int ERR_set_mark(void)
 {
     ERR_STATE *es;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return 0;
 
@@ -900,7 +908,7 @@ int ERR_pop_to_mark(void)
 {
     ERR_STATE *es;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return 0;
 
@@ -921,7 +929,7 @@ int ERR_clear_last_mark(void)
     ERR_STATE *es;
     int top;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return 0;
 
@@ -942,7 +950,7 @@ void err_clear_last_constant_time(int clear)
     ERR_STATE *es;
     int top;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return;
 

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* TODO: When ERR_STATE becomes opaque, this musts be removed */
+#define OSSL_FORCE_ERR_STATE
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -23,6 +26,9 @@
 #include "internal/constant_time_locl.h"
 #include "e_os.h"
 #include "err_locl.h"
+
+/* Forward declaration in case it's not published because of configuration */
+ERR_STATE *ERR_get_state(void);
 
 static int err_load_strings(const ERR_STRING_DATA *str);
 

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* TODO: When ERR_STATE becomes opaque, this musts be removed */
+#define OSSL_FORCE_ERR_STATE
+
 #include <string.h>
 #include <openssl/err.h>
 #include "err_locl.h"

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -18,7 +18,7 @@ void ERR_new(void)
 {
     ERR_STATE *es;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return;
 
@@ -31,7 +31,7 @@ void ERR_set_debug(const char *file, int line, const char *func)
 {
     ERR_STATE *es;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return;
 
@@ -55,7 +55,7 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
     unsigned long flags = 0;
     size_t i;
 
-    es = ERR_get_state();
+    es = err_get_state_int();
     if (es == NULL)
         return;
     i = es->top;

--- a/crypto/err/err_locl.h
+++ b/crypto/err/err_locl.h
@@ -66,3 +66,5 @@ static ossl_inline void err_clear(ERR_STATE *es, size_t i, int deall)
     es->err_file[i] = NULL;
     es->err_line[i] = -1;
 }
+
+ERR_STATE *err_get_state_int(void);

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* TODO: When ERR_STATE becomes opaque, this musts be removed */
+#define OSSL_FORCE_ERR_STATE
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/crypto.h>

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -283,7 +283,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     FuzzerSetRand();
 

--- a/fuzz/asn1parse.c
+++ b/fuzz/asn1parse.c
@@ -25,7 +25,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 {
     bio_out = BIO_new_file("/dev/null", "w");
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     return 1;
 }

--- a/fuzz/bignum.c
+++ b/fuzz/bignum.c
@@ -22,7 +22,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
 
     return 1;
 }

--- a/fuzz/bndiv.c
+++ b/fuzz/bndiv.c
@@ -38,7 +38,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     ctx = BN_CTX_new();
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
 
     return 1;
 }

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -44,7 +44,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();

--- a/fuzz/cms.c
+++ b/fuzz/cms.c
@@ -20,7 +20,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     return 1;
 }

--- a/fuzz/conf.c
+++ b/fuzz/conf.c
@@ -19,7 +19,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     return 1;
 }
 

--- a/fuzz/crl.c
+++ b/fuzz/crl.c
@@ -16,7 +16,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     return 1;
 }

--- a/fuzz/ct.c
+++ b/fuzz/ct.c
@@ -21,7 +21,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     CRYPTO_free_ex_index(0, -1);
-    ERR_get_state();
+    ERR_clear_error();
     return 1;
 }
 

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -491,7 +491,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
     FuzzerSetRand();

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -19,7 +19,7 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
-    ERR_get_state();
+    ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     FuzzerSetRand();
     return 1;

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -333,7 +333,7 @@ int ERR_load_ERR_strings(void);
 
 DEPRECATEDIN_1_1_0(void ERR_remove_thread_state(void *))
 DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
-ERR_STATE *ERR_get_state(void);
+DEPRECATEDIN_3(ERR_STATE *ERR_get_state(void))
 
 int ERR_get_next_error_library(void);
 

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -38,11 +38,12 @@ extern "C" {
 # define ERR_TXT_MALLOCED        0x01
 # define ERR_TXT_STRING          0x02
 
-# define ERR_FLAG_MARK           0x01
-# define ERR_FLAG_CLEAR          0x02
+# if !OPENSSL_API_3 || defined(OSSL_FORCE_ERR_STATE)
+#  define ERR_FLAG_MARK           0x01
+#  define ERR_FLAG_CLEAR          0x02
 
-# define ERR_NUM_ERRORS  16
-typedef struct err_state_st {
+#  define ERR_NUM_ERRORS  16
+struct err_state_st {
     int err_flags[ERR_NUM_ERRORS];
     unsigned long err_buffer[ERR_NUM_ERRORS];
     char *err_data[ERR_NUM_ERRORS];
@@ -52,7 +53,8 @@ typedef struct err_state_st {
     int err_line[ERR_NUM_ERRORS];
     const char *err_func[ERR_NUM_ERRORS];
     int top, bottom;
-} ERR_STATE;
+};
+# endif
 
 /* library */
 # define ERR_LIB_NONE            1

--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -88,6 +88,8 @@ typedef struct bn_gencb_st BN_GENCB;
 
 typedef struct buf_mem_st BUF_MEM;
 
+typedef struct err_state_st ERR_STATE;
+
 typedef struct evp_cipher_st EVP_CIPHER;
 typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
 typedef struct evp_md_st EVP_MD;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2213,7 +2213,7 @@ EVP_PKEY_missing_parameters             2261	3_0_0	EXIST::FUNCTION:
 X509_REQ_INFO_new                       2262	3_0_0	EXIST::FUNCTION:
 EVP_rc2_cfb64                           2263	3_0_0	EXIST::FUNCTION:RC2
 PKCS7_get_smimecap                      2264	3_0_0	EXIST::FUNCTION:
-ERR_get_state                           2265	3_0_0	EXIST::FUNCTION:
+ERR_get_state                           2265	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 d2i_DSAPrivateKey_bio                   2266	3_0_0	EXIST::FUNCTION:DSA
 X509_PURPOSE_get_trust                  2267	3_0_0	EXIST::FUNCTION:
 EC_GROUP_get_point_conversion_form      2268	3_0_0	EXIST::FUNCTION:EC


### PR DESCRIPTION
The intention is to make it opaque later on.
