### PR TITLE
Fix typo in function TS_VERIFY_CTS_set_certs()

### DIFF
--- a/apps/ts.c
+++ b/apps/ts.c
@@ -921,7 +921,7 @@ static TS_VERIFY_CTX *create_verify_ctx(const char *data, const char *digest,
 
     /* Loading untrusted certificates. */
     if (untrusted
-        && TS_VERIFY_CTS_set_certs(ctx, TS_CONF_load_certs(untrusted)) == NULL)
+        && TS_VERIFY_CTX_set_certs(ctx, TS_CONF_load_certs(untrusted)) == NULL)
         goto err;
     ret = 1;
 

--- a/crypto/ts/ts_verify_ctx.c
+++ b/crypto/ts/ts_verify_ctx.c
@@ -60,7 +60,7 @@ X509_STORE *TS_VERIFY_CTX_set_store(TS_VERIFY_CTX *ctx, X509_STORE *s)
     return ctx->store;
 }
 
-STACK_OF(X509) *TS_VERIFY_CTS_set_certs(TS_VERIFY_CTX *ctx,
+STACK_OF(X509) *TS_VERIFY_CTX_set_certs(TS_VERIFY_CTX *ctx,
                                         STACK_OF(X509) *certs)
 {
     ctx->certs = certs;

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -421,7 +421,10 @@ BIO *TS_VERIFY_CTX_set_data(TS_VERIFY_CTX *ctx, BIO *b);
 unsigned char *TS_VERIFY_CTX_set_imprint(TS_VERIFY_CTX *ctx,
                                          unsigned char *hexstr, long len);
 X509_STORE *TS_VERIFY_CTX_set_store(TS_VERIFY_CTX *ctx, X509_STORE *s);
-STACK_OF(X509) *TS_VERIFY_CTS_set_certs(TS_VERIFY_CTX *ctx, STACK_OF(X509) *certs);
+# if !OPENSSL_API_3
+#  define TS_VERIFY_CTS_set_certs(ctx, cert) TS_VERIFY_CTX_set_certs(ctx,cert)
+# endif
+STACK_OF(X509) *TS_VERIFY_CTX_set_certs(TS_VERIFY_CTX *ctx, STACK_OF(X509) *certs);
 
 /*-
  * If ctx is NULL, it allocates and returns a new object, otherwise

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -916,7 +916,7 @@ TS_TST_INFO_ext_free                    938	3_0_0	EXIST::FUNCTION:TS
 i2d_X509_CRL_fp                         939	3_0_0	EXIST::FUNCTION:STDIO
 PKCS7_get0_signers                      940	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_ex_data              941	3_0_0	EXIST::FUNCTION:
-TS_VERIFY_CTS_set_certs                 942	3_0_0	EXIST::FUNCTION:TS
+TS_VERIFY_CTX_set_certs                 942	3_0_0	EXIST::FUNCTION:TS
 BN_MONT_CTX_copy                        943	3_0_0	EXIST::FUNCTION:
 OPENSSL_INIT_new                        945	3_0_0	EXIST::FUNCTION:
 TS_ACCURACY_dup                         946	3_0_0	EXIST::FUNCTION:TS

--- a/util/missingcrypto.txt
+++ b/util/missingcrypto.txt
@@ -1080,7 +1080,7 @@ TS_TST_INFO_set_serial
 TS_TST_INFO_set_time
 TS_TST_INFO_set_tsa
 TS_TST_INFO_set_version
-TS_VERIFY_CTS_set_certs
+TS_VERIFY_CTX_set_certs
 TS_VERIFY_CTX_add_flags
 TS_VERIFY_CTX_cleanup
 TS_VERIFY_CTX_free

--- a/util/missingmacro.txt
+++ b/util/missingmacro.txt
@@ -214,3 +214,4 @@ X509V3_set_ctx_test
 X509V3_set_ctx_nodb
 EXT_BITSTRING
 EXT_IA5STRING
+TS_VERIFY_CTS_set_certs


### PR DESCRIPTION
(I'm pretty sure, that) there's a typo in TS_VERIFY_CTS_set_certs()'s function name. It should be TS_VERIFY_CTX_set_certs().

I know that this change is an API break, but eventually it's necessary.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
