### PR TITLE
Temporary workaround for ectest.c for [extended tests]

### DIFF
--- a/test/ectest.c
+++ b/test/ectest.c
@@ -1820,7 +1820,7 @@ static int parameter_test(void)
     unsigned char *buf = NULL;
     int r = 0, len;
 
-    if (!TEST_ptr(group = EC_GROUP_new_by_curve_name(NID_secp224r1))
+    if (!TEST_ptr(group = EC_GROUP_new_by_curve_name(NID_secp384r1))
         || !TEST_ptr(ecparameters = EC_GROUP_get_ecparameters(group, NULL))
         || !TEST_ptr(group2 = EC_GROUP_new_from_ecparameters(ecparameters))
         || !TEST_int_eq(EC_GROUP_cmp(group, group2, NULL), 0))


### PR DESCRIPTION
[extended tests]

This is a temporary workaround for issue #9251, which contains a full
discussion of the real problem.

As a temporary workaround, we test `EC_GROUP_new_from_ecparameters()`
against a curve that does not currently have alternative
implementations.

The proper fix is dependant on resolution of issue #8615