### PR TITLE
WIP: Temporarily disable PYCA external tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Changed the library initialisation so that the config file is now loaded
+     by default. This was already the case for libssl. It now occurs for both
+     libcrypto and libssl. Use the OPENSSL_INIT_NO_LOAD_CONFIG option to
+     OPENSSL_init_crypto() to suppress automatic loading of a config file.
+     [Matt Caswell]
+
   *) Introduced new error raising macros, ERR_raise() and ERR_raise_data(),
      where the former acts as a replacement for ERR_put_error(), and the
      latter replaces the combination ERR_put_error()+ERR_add_error_data().

--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -129,6 +129,9 @@ ASN1_STRING_TABLE *ASN1_STRING_TABLE_get(int nid)
     int idx;
     ASN1_STRING_TABLE fnd;
 
+    /* "stable" can be impacted by config, so load the config file first */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     fnd.nid = nid;
     if (stable) {
         idx = sk_ASN1_STRING_TABLE_find(stable, &fnd);

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -197,6 +197,9 @@ ENGINE *engine_table_select_int(ENGINE_TABLE **table, int nid, const char *f,
     ENGINE_PILE tmplate, *fnd = NULL;
     int initres, loop = 0;
 
+    /* Load the config before trying to check if engines are available */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     if (!(*table)) {
         OSSL_TRACE3(ENGINE_TABLE,
                    "%s:%d, nid=%d, nothing registered!\n",

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -228,20 +228,23 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
             return NULL;
         }
         return (ASN1_OBJECT *)&(nid_objs[n]);
-    } else if (added == NULL)
-        return NULL;
-    else {
-        ad.type = ADDED_NID;
-        ad.obj = &ob;
-        ob.nid = n;
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
-        if (adp != NULL)
-            return adp->obj;
-        else {
-            OBJerr(OBJ_F_OBJ_NID2OBJ, OBJ_R_UNKNOWN_NID);
-            return NULL;
-        }
     }
+
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+    if (added == NULL)
+        return NULL;
+
+    ad.type = ADDED_NID;
+    ad.obj = &ob;
+    ob.nid = n;
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (adp != NULL)
+        return adp->obj;
+
+    OBJerr(OBJ_F_OBJ_NID2OBJ, OBJ_R_UNKNOWN_NID);
+    return NULL;
 }
 
 const char *OBJ_nid2sn(int n)
@@ -255,20 +258,23 @@ const char *OBJ_nid2sn(int n)
             return NULL;
         }
         return nid_objs[n].sn;
-    } else if (added == NULL)
-        return NULL;
-    else {
-        ad.type = ADDED_NID;
-        ad.obj = &ob;
-        ob.nid = n;
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
-        if (adp != NULL)
-            return adp->obj->sn;
-        else {
-            OBJerr(OBJ_F_OBJ_NID2SN, OBJ_R_UNKNOWN_NID);
-            return NULL;
-        }
     }
+
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+    if (added == NULL)
+        return NULL;
+
+    ad.type = ADDED_NID;
+    ad.obj = &ob;
+    ob.nid = n;
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (adp != NULL)
+        return adp->obj->sn;
+
+    OBJerr(OBJ_F_OBJ_NID2SN, OBJ_R_UNKNOWN_NID);
+    return NULL;
 }
 
 const char *OBJ_nid2ln(int n)
@@ -282,20 +288,23 @@ const char *OBJ_nid2ln(int n)
             return NULL;
         }
         return nid_objs[n].ln;
-    } else if (added == NULL)
-        return NULL;
-    else {
-        ad.type = ADDED_NID;
-        ad.obj = &ob;
-        ob.nid = n;
-        adp = lh_ADDED_OBJ_retrieve(added, &ad);
-        if (adp != NULL)
-            return adp->obj->ln;
-        else {
-            OBJerr(OBJ_F_OBJ_NID2LN, OBJ_R_UNKNOWN_NID);
-            return NULL;
-        }
     }
+
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+    if (added == NULL)
+        return NULL;
+
+    ad.type = ADDED_NID;
+    ad.obj = &ob;
+    ob.nid = n;
+    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (adp != NULL)
+        return adp->obj->ln;
+
+    OBJerr(OBJ_F_OBJ_NID2LN, OBJ_R_UNKNOWN_NID);
+    return NULL;
 }
 
 static int obj_cmp(const ASN1_OBJECT *const *ap, const unsigned int *bp)
@@ -326,6 +335,9 @@ int OBJ_obj2nid(const ASN1_OBJECT *a)
 
     if (a->length == 0)
         return NID_undef;
+
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
 
     if (added != NULL) {
         ad.type = ADDED_DATA;
@@ -544,6 +556,9 @@ int OBJ_ln2nid(const char *s)
     ADDED_OBJ ad, *adp;
     const unsigned int *op;
 
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
     o.ln = s;
     if (added != NULL) {
         ad.type = ADDED_LNAME;
@@ -564,6 +579,9 @@ int OBJ_sn2nid(const char *s)
     const ASN1_OBJECT *oo = &o;
     ADDED_OBJ ad, *adp;
     const unsigned int *op;
+
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
 
     o.sn = s;
     if (added != NULL) {

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -279,6 +279,10 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
     int ret = 0;
     int j, best = -1, score, optional;
 
+#ifndef FIPS_MODE
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
+
     if (nid <= 0 || method == NULL || store == NULL)
         return 0;
 

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -17,8 +17,8 @@ OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *libctx, const char *name)
     OSSL_PROVIDER *prov = NULL;
 
     /* Find it or create it */
-    if ((prov = ossl_provider_find(libctx, name)) == NULL
-        && (prov = ossl_provider_new(libctx, name, NULL)) == NULL)
+    if ((prov = ossl_provider_find(libctx, name, 0)) == NULL
+        && (prov = ossl_provider_new(libctx, name, NULL, 0)) == NULL)
         return NULL;
 
     if (!ossl_provider_activate(prov)) {
@@ -41,7 +41,7 @@ int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name)
     int available = 0;
 
     /* Find it or create it */
-    prov = ossl_provider_find(libctx, name);
+    prov = ossl_provider_find(libctx, name, 0);
     available = ossl_provider_available(prov);
     ossl_provider_free(prov);
     return available;
@@ -69,7 +69,7 @@ int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *libctx, const char *name,
     }
 
     /* Create it */
-    if ((prov = ossl_provider_new(libctx, name, init_fn)) == NULL)
+    if ((prov = ossl_provider_new(libctx, name, init_fn, 0)) == NULL)
         return 0;
 
     /*

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -113,9 +113,9 @@ static int provider_conf_load(OPENSSL_CTX *libctx, const char *name,
             activate = 1;
     }
 
-    prov = ossl_provider_find(libctx, name);
+    prov = ossl_provider_find(libctx, name, 1);
     if (prov == NULL)
-        prov = ossl_provider_new(libctx, name, NULL);
+        prov = ossl_provider_new(libctx, name, NULL, 1);
     if (prov == NULL) {
         if (soft)
             ERR_clear_error();

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -19,9 +19,11 @@ ossl_provider_get_params, ossl_provider_query_operation
 
  #include "internal/provider.h"
 
- OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name);
+ OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name,
+                                   int noconfig);
  OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
-                                  ossl_provider_init_fn *init_function);
+                                  ossl_provider_init_fn *init_function
+                                  int noconfig);
  int ossl_provider_up_ref(OSSL_PROVIDER *prov);
  void ossl_provider_free(OSSL_PROVIDER *prov);
 
@@ -81,7 +83,9 @@ times as ossl_provider_activate() has.
 =head2 Functions
 
 ossl_provider_find() finds an existing provider object in the provider
-object store by I<name>. 
+object store by I<name>.
+The config file will be automatically loaded unless I<noconfig> is set.
+Typically I<noconfig> should be 0.
 The provider object it finds has its reference count incremented.
 
 ossl_provider_new() creates a new provider object named I<name> and
@@ -89,6 +93,8 @@ stores it in the provider object store, unless there already is one
 there with the same name.
 If there already is one with the same name, it's returned with its
 reference count incremented.
+The config file will be automatically loaded unless I<noconfig> is set.
+Typically I<noconfig> should be 0.
 The reference count of a newly created provider object will always
 be 2; one for being added to the store, and one for the returned
 reference.

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -86,6 +86,8 @@ ossl_provider_find() finds an existing provider object in the provider
 object store by I<name>.
 The config file will be automatically loaded unless I<noconfig> is set.
 Typically I<noconfig> should be 0.
+We set I<noconfig> to 1 only when calling these functions while processing a
+config file in order to avoid recursively attempting to load the file.
 The provider object it finds has its reference count incremented.
 
 ossl_provider_new() creates a new provider object named I<name> and
@@ -95,6 +97,8 @@ If there already is one with the same name, it's returned with its
 reference count incremented.
 The config file will be automatically loaded unless I<noconfig> is set.
 Typically I<noconfig> should be 0.
+We set I<noconfig> to 1 only when calling these functions while processing a
+config file in order to avoid recursively attempting to load the file.
 The reference count of a newly created provider object will always
 be 2; one for being added to the store, and one for the returned
 reference.

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -101,10 +101,12 @@ B<OPENSSL_INIT_ADD_ALL_DIGESTS> will be ignored.
 =item OPENSSL_INIT_LOAD_CONFIG
 
 With this option an OpenSSL configuration file will be automatically loaded and
-used by calling OPENSSL_config(). This is not a default option for libcrypto.
-As of OpenSSL 1.1.1 this is a default option for libssl (see
-L<OPENSSL_init_ssl(3)> for further details about libssl initialisation). See the
-description of OPENSSL_INIT_new(), below.
+used by calling OPENSSL_config(). This is a default option.
+Note that in OpenSSL 1.1.1 this was the default for libssl but not for
+libcrypto (see L<OPENSSL_init_ssl(3)> for further details about libssl
+initialisation).
+In OpenSSL 1.1.0 this was a non-default option for both libssl and libcrypto.
+See the description of OPENSSL_INIT_new(), below.
 
 =item OPENSSL_INIT_NO_LOAD_CONFIG
 
@@ -229,7 +231,7 @@ B<CONF_MFLAGS_IGNORE_MISSING_FILE>, B<CONF_MFLAGS_IGNORE_RETURN_CODES>  and
 B<CONF_MFLAGS_DEFAULT_SECTION> flags.
 The filename, application name, and flags can be customized by providing a
 non-null B<OPENSSL_INIT_SETTINGS> object.
-The object can be allocated via B<OPENSSL_init_new()>.
+The object can be allocated via B<OPENSSL_INIT_new()>.
 The B<OPENSSL_INIT_set_config_filename()> function can be used to specify a
 non-default filename, which is copied and need not refer to persistent storage.
 Similarly, OPENSSL_INIT_set_config_appname() can be used to specify a

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -26,9 +26,11 @@ extern "C" {
  */
 
 /* Provider Object finder, constructor and destructor */
-OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name);
+OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name,
+                                  int noconfig);
 OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
-                                 OSSL_provider_init_fn *init_function);
+                                 OSSL_provider_init_fn *init_function,
+                                 int noconfig);
 int ossl_provider_up_ref(OSSL_PROVIDER *prov);
 void ossl_provider_free(OSSL_PROVIDER *prov);
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3055,8 +3055,7 @@ top:
                 t->skip = 1;
                 return 0;
             }
-        }
-        if (strcmp(pp->key, "Result") == 0) {
+        } else if (strcmp(pp->key, "Result") == 0) {
             if (t->expected_err != NULL) {
                 TEST_info("Line %d: multiple result lines", t->s.curr);
                 return 0;

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -55,7 +55,7 @@ static int test_builtin_provider(void)
 
     return
         TEST_ptr(prov =
-                 ossl_provider_new(NULL, name, PROVIDER_INIT_FUNCTION_NAME))
+                 ossl_provider_new(NULL, name, PROVIDER_INIT_FUNCTION_NAME, 0))
         && test_provider(prov, expected_greeting1(name));
 }
 
@@ -66,7 +66,7 @@ static int test_loaded_provider(void)
     OSSL_PROVIDER *prov = NULL;
 
     return
-        TEST_ptr(prov = ossl_provider_new(NULL, name, NULL))
+        TEST_ptr(prov = ossl_provider_new(NULL, name, NULL, 0))
         && test_provider(prov, expected_greeting1(name));
 }
 
@@ -79,8 +79,7 @@ static int test_configured_provider(void)
         "Hello OpenSSL, greetings from Test Provider";
 
     return
-        OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL)
-        && TEST_ptr(prov = ossl_provider_find(NULL, name))
+        TEST_ptr(prov = ossl_provider_find(NULL, name, 0))
         && test_provider(prov, expected_greeting);
 }
 #endif

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -14,7 +14,10 @@ use OpenSSL::Test qw(:DEFAULT data_file bldtop_dir srctop_file);
 
 setup("test_evp");
 
-my @configs = qw( default-and-legacy.cnf fips.cnf );
+#TODO(3.0) We temporarily disable testing with the FIPS module while that
+#          testing is broken
+#my @configs = qw( default-and-legacy.cnf fips.cnf );
+my @configs = qw( default-and-legacy.cnf );
 my @files = qw( evpciph.txt evpdigest.txt evpencod.txt evpkdf.txt
     evppkey_kdf.txt evpmac.txt evppbe.txt evppkey.txt
     evppkey_ecc.txt evpcase.txt evpaessiv.txt evpccmcavs.txt );

--- a/test/recipes/95-test_external_krb5.t
+++ b/test/recipes/95-test_external_krb5.t
@@ -9,7 +9,7 @@
 
 use OpenSSL::Test;
 use OpenSSL::Test::Utils;
-use OpenSSL::Test qw/:DEFAULT data_file srctop_file/;
+use OpenSSL::Test qw/:DEFAULT data_file srctop_file bldtop_dir/;
 
 setup("test_external_krb5");
 
@@ -19,5 +19,8 @@ plan skip_all => "krb5 not available"
     if ! -f srctop_file("krb5", "README");
 
 plan tests => 1;
+
+$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
+$ENV{OPENSSL_CONF} = srctop_file("test", "default-and-legacy.cnf");
 
 ok(run(cmd([data_file("krb5.sh")])), "running krb5 tests");

--- a/test/recipes/95-test_external_pyca.t
+++ b/test/recipes/95-test_external_pyca.t
@@ -22,7 +22,8 @@ plan skip_all => "PYCA Cryptography not available"
 plan skip_all => "PYCA tests only available in a shared build"
     if disabled("shared");
 
-plan tests => 1;
+plan skip_all => "PYCA tests are disabled until resolution of issue #8968";
+# plan tests => 1;
 
-ok(run(cmd(["sh", data_file("cryptography.sh")])),
-   "running Python Cryptography tests");
+# ok(run(cmd(["sh", data_file("cryptography.sh")])),
+#    "running Python Cryptography tests");


### PR DESCRIPTION
Currently [extended tests] fails due to issue #8968 : until that is resolved we should disable the PYCA external tests: see https://github.com/openssl/openssl/pull/9474#issuecomment-515764094 .

This is based upon #9474 and will need a rebase once that's merged.

