### PR TITLE
Fix infinite recursion and avoid query cache depending on RAND.

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -429,8 +429,8 @@ static void ossl_method_cache_flush_some(OSSL_METHOD_STORE *store)
     state.nelem = 0;
     if ((state.seed = OPENSSL_rdtsc()) == 0)
         state.seed = 1;
-    ossl_sa_ALGORITHM_doall_arg(store->algs, &impl_cache_flush_one_alg, &state);
     store->need_flush = 0;
+    ossl_sa_ALGORITHM_doall_arg(store->algs, &impl_cache_flush_one_alg, &state);
     store->nelem = state.nelem;
 }
 


### PR DESCRIPTION
This is causing problem in the situation when the query cache
being flushed triggers the initialisation of the RAND subsystem.

The alternative is to use a fast and small xorshift random number generator.
The stochastic flushing doesn't require good random numbers, just enough
variety to avoid causing problems.

Fixes #9455

- [ ] documentation is added or updated
- [ ] tests are added or updated
