### PR TITLE
Fix warning C4164 in MSVC. Fixes #9487

### DIFF
--- a/crypto/whrlpool/wp_block.c
+++ b/crypto/whrlpool/wp_block.c
@@ -87,6 +87,7 @@ typedef unsigned long long u64;
 #ifndef PEDANTIC
 # if defined(_MSC_VER)
 #  if defined(_WIN64)            /* applies to both IA-64 and AMD64 */
+#   include <stdlib.h>
 #   pragma intrinsic(_rotl64)
 #   define ROTATE(a,n) _rotl64((a),n)
 #  endif


### PR DESCRIPTION
Fix: crypto\whrlpool\wp_block.c(90) : warning C4164: '_rotl64' : intrinsic function not declared.
#9487 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
