### PR TITLE
Replace FUNCerr with ERR_raise_data

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,10 +31,6 @@
      private key for those. This avoids leaking bit 0 of the private key.
      [Bernd Edlinger]
 
-  *) Added a new FUNCerr() macro that takes a function name.
-     The macro SYSerr() is deprecated.
-     [Rich Salz]
-
   *) Significantly reduce secure memory usage by the randomness pools.
      [Paul Dale]
 

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1396,7 +1396,7 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     BIO_get_fp(in, &dbfp);
     if (fstat(fileno(dbfp), &dbst) == -1) {
         ERR_raise_data(ERR_LIB_SYS, errno,
-                       "calling fstat(\"%s\")", dbfile);
+                       "calling fstat(%s)", dbfile);
         ERR_print_errors(bio_err);
         goto err;
     }

--- a/apps/apps.c
+++ b/apps/apps.c
@@ -1395,8 +1395,8 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
 #ifndef OPENSSL_NO_POSIX_IO
     BIO_get_fp(in, &dbfp);
     if (fstat(fileno(dbfp), &dbst) == -1) {
-        FUNCerr("fstat", errno);
-        ERR_add_error_data(1, dbfile);
+        ERR_raise_data(ERR_LIB_SYS, errno,
+                       "calling fstat(\"%s\")", dbfile);
         ERR_print_errors(bio_err);
         goto err;
     }

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -207,7 +207,8 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
                                flags)) != 0) {
 # ifdef EAI_SYSTEM
             if (ret == EAI_SYSTEM) {
-                FUNCerr("getnameinfo", get_last_socket_error());
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling %s()", "getnameinfo");
                 BIOerr(BIO_F_ADDR_STRINGS, ERR_R_SYS_LIB);
             } else
 # endif
@@ -700,7 +701,8 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         switch ((gai_ret = getaddrinfo(host, service, &hints, res))) {
 # ifdef EAI_SYSTEM
         case EAI_SYSTEM:
-            FUNCerr("getaddrinfo", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "getaddrinfo");
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             break;
 # endif
@@ -804,12 +806,15 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                  */
 # if defined(OPENSSL_SYS_VXWORKS)
                 /* h_errno doesn't exist on VxWorks */
-                FUNCerr("gethostbyname", 1000 );
+                ERR_raise_data(ERR_LIB_SYS, 1000,
+                               "calling %s()", "gethostbyname");
 # else
-                FUNCerr("gethostbyname", 1000 + h_errno);
+                ERR_raise_data(ERR_LIB_SYS, 1000 + h_errno,
+                               "calling %s()", "gethostbyname");
 # endif
 #else
-                FUNCerr("gethostbyname", get_last_socket_error());
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling %s()", "gethostbyname");
 #endif
                 ret = 0;
                 goto err;
@@ -855,7 +860,8 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 se = getservbyname(service, proto);
 
                 if (se == NULL) {
-                    FUNCerr("getservbyname", get_last_socket_error());
+                    ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                                   "calling %s()", "getservbyname");
                     goto err;
                 }
             } else {

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -208,7 +208,7 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
 # ifdef EAI_SYSTEM
             if (ret == EAI_SYSTEM) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                               "calling %s()", "getnameinfo");
+                               "calling getnameinfo()");
                 BIOerr(BIO_F_ADDR_STRINGS, ERR_R_SYS_LIB);
             } else
 # endif
@@ -702,7 +702,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 # ifdef EAI_SYSTEM
         case EAI_SYSTEM:
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "getaddrinfo");
+                           "calling getaddrinfo()");
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             break;
 # endif
@@ -807,14 +807,14 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 # if defined(OPENSSL_SYS_VXWORKS)
                 /* h_errno doesn't exist on VxWorks */
                 ERR_raise_data(ERR_LIB_SYS, 1000,
-                               "calling %s()", "gethostbyname");
+                               "calling gethostbyname()");
 # else
                 ERR_raise_data(ERR_LIB_SYS, 1000 + h_errno,
-                               "calling %s()", "gethostbyname");
+                               "calling gethostbyname()");
 # endif
 #else
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                               "calling %s()", "gethostbyname");
+                               "calling gethostbyname()");
 #endif
                 ret = 0;
                 goto err;
@@ -861,7 +861,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 
                 if (se == NULL) {
                     ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                                   "calling %s()", "getservbyname");
+                                   "calling getservbyname()");
                     goto err;
                 }
             } else {

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -130,7 +130,7 @@ int BIO_sock_init(void)
          */
         if (WSAStartup(0x0202, &wsa_state) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "wsastartup");
+                           "calling wsastartup()");
             BIOerr(BIO_F_BIO_SOCK_INIT, BIO_R_WSASTARTUP);
             return -1;
         }
@@ -191,7 +191,7 @@ int BIO_socket_ioctl(int fd, long type, void *arg)
 #  endif                        /* __DJGPP__ */
     if (i < 0)
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                       "calling %s()", "ioctlsocket");
+                       "calling ioctlsocket()");
     return i;
 }
 
@@ -243,7 +243,7 @@ int BIO_accept(int sock, char **ip_port)
             goto end;
         }
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                       "calling %s()", "accept");
+                       "calling accept()");
         BIOerr(BIO_F_BIO_ACCEPT, BIO_R_ACCEPT_ERROR);
         goto end;
     }
@@ -309,7 +309,7 @@ int BIO_socket_nbio(int s, int mode)
     l = fcntl(s, F_GETFL, 0);
     if (l == -1) {
         ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                       "calling %s()", "fcntl");
+                       "calling fcntl()");
         ret = -1;
     } else {
 #  if defined(O_NONBLOCK)
@@ -328,7 +328,7 @@ int BIO_socket_nbio(int s, int mode)
 
         if (ret < 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                           "calling %s()", "fcntl");
+                           "calling fcntl()");
         }
     }
 # else
@@ -352,7 +352,7 @@ int BIO_sock_info(int sock,
                               &addr_len);
             if (ret == -1) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                               "calling %s()", "getsockname");
+                               "calling getsockname()");
                 BIOerr(BIO_F_BIO_SOCK_INFO, BIO_R_GETSOCKNAME_ERROR);
                 return 0;
             }

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -129,7 +129,8 @@ int BIO_sock_init(void)
          * probed at run-time with DSO_global_lookup.
          */
         if (WSAStartup(0x0202, &wsa_state) != 0) {
-            FUNCerr("wsastartup", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "wsastartup");
             BIOerr(BIO_F_BIO_SOCK_INIT, BIO_R_WSASTARTUP);
             return -1;
         }
@@ -189,7 +190,8 @@ int BIO_socket_ioctl(int fd, long type, void *arg)
     i = ioctlsocket(fd, type, ARG);
 #  endif                        /* __DJGPP__ */
     if (i < 0)
-        FUNCerr("ioctlsocket", get_last_socket_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                       "calling %s()", "ioctlsocket");
     return i;
 }
 
@@ -240,7 +242,8 @@ int BIO_accept(int sock, char **ip_port)
             ret = -2;
             goto end;
         }
-        FUNCerr("accept", get_last_socket_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                       "calling %s()", "accept");
         BIOerr(BIO_F_BIO_ACCEPT, BIO_R_ACCEPT_ERROR);
         goto end;
     }
@@ -305,7 +308,8 @@ int BIO_socket_nbio(int s, int mode)
 
     l = fcntl(s, F_GETFL, 0);
     if (l == -1) {
-        FUNCerr("fcntl", get_last_sys_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                       "calling %s()", "fcntl");
         ret = -1;
     } else {
 #  if defined(O_NONBLOCK)
@@ -323,7 +327,8 @@ int BIO_socket_nbio(int s, int mode)
         ret = fcntl(s, F_SETFL, l);
 
         if (ret < 0) {
-            FUNCerr("fcntl", get_last_sys_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                           "calling %s()", "fcntl");
         }
     }
 # else
@@ -346,7 +351,8 @@ int BIO_sock_info(int sock,
             ret = getsockname(sock, BIO_ADDR_sockaddr_noconst(info->addr),
                               &addr_len);
             if (ret == -1) {
-                FUNCerr("getsockname", get_last_socket_error());
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling %s()", "getsockname");
                 BIOerr(BIO_F_BIO_SOCK_INFO, BIO_R_GETSOCKNAME_ERROR);
                 return 0;
             }

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -47,7 +47,7 @@ int BIO_socket(int domain, int socktype, int protocol, int options)
     sock = socket(domain, socktype, protocol);
     if (sock == -1) {
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                       "calling %s()", "socket");
+                       "calling socket()");
         BIOerr(BIO_F_BIO_SOCKET, BIO_R_UNABLE_TO_CREATE_SOCKET);
         return INVALID_SOCKET;
     }
@@ -91,7 +91,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "setsockopt");
+                           "calling setsockopt()");
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -101,7 +101,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "setsockopt");
+                           "calling setsockopt()");
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -111,7 +111,7 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
                 BIO_ADDR_sockaddr_size(addr)) == -1) {
         if (!BIO_sock_should_retry(-1)) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "connect");
+                           "calling connect()");
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_CONNECT_ERROR);
         }
         return 0;
@@ -155,7 +155,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                        (const void *)&on, sizeof(on)) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "setsockopt");
+                           "calling setsockopt()");
             BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_REUSEADDR);
             return 0;
         }
@@ -164,7 +164,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
 
     if (bind(sock, BIO_ADDR_sockaddr(addr), BIO_ADDR_sockaddr_size(addr)) != 0) {
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                       "calling %s()", "bind");
+                       "calling bind()");
         BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_BIND_SOCKET);
         return 0;
     }
@@ -224,7 +224,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
                    (void *)&socktype, &socktype_len) != 0
         || socktype_len != sizeof(socktype)) {
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                       "calling %s()", "getsockopt");
+                       "calling getsockopt()");
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_GETTING_SOCKTYPE);
         return 0;
     }
@@ -236,7 +236,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "setsockopt");
+                           "calling setsockopt()");
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -246,7 +246,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "setsockopt");
+                           "calling setsockopt()");
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -262,7 +262,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (const void *)&on, sizeof(on)) != 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "setsockopt");
+                           "calling setsockopt()");
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_LISTEN_V6_ONLY);
             return 0;
         }
@@ -274,7 +274,7 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
 
     if (socktype != SOCK_DGRAM && listen(sock, MAX_LISTEN) == -1) {
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                       "calling %s()", "listen");
+                       "calling listen()");
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_LISTEN_SOCKET);
         return 0;
     }
@@ -302,7 +302,7 @@ int BIO_accept_ex(int accept_sock, BIO_ADDR *addr_, int options)
     if (accepted_sock == -1) {
         if (!BIO_sock_should_retry(accepted_sock)) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                           "calling %s()", "accept");
+                           "calling accept()");
             BIOerr(BIO_F_BIO_ACCEPT_EX, BIO_R_ACCEPT_ERROR);
         }
         return INVALID_SOCKET;

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -46,7 +46,8 @@ int BIO_socket(int domain, int socktype, int protocol, int options)
 
     sock = socket(domain, socktype, protocol);
     if (sock == -1) {
-        FUNCerr("socket", get_last_socket_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                       "calling %s()", "socket");
         BIOerr(BIO_F_BIO_SOCKET, BIO_R_UNABLE_TO_CREATE_SOCKET);
         return INVALID_SOCKET;
     }
@@ -89,7 +90,8 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_KEEPALIVE) {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
-            FUNCerr("setsockopt", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "setsockopt");
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -98,7 +100,8 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_NODELAY) {
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
-            FUNCerr("setsockopt", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "setsockopt");
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -107,7 +110,8 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
     if (connect(sock, BIO_ADDR_sockaddr(addr),
                 BIO_ADDR_sockaddr_size(addr)) == -1) {
         if (!BIO_sock_should_retry(-1)) {
-            FUNCerr("connect", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "connect");
             BIOerr(BIO_F_BIO_CONNECT, BIO_R_CONNECT_ERROR);
         }
         return 0;
@@ -150,7 +154,8 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_REUSEADDR) {
         if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                        (const void *)&on, sizeof(on)) != 0) {
-            FUNCerr("setsockopt", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "setsockopt");
             BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_REUSEADDR);
             return 0;
         }
@@ -158,7 +163,8 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
 # endif
 
     if (bind(sock, BIO_ADDR_sockaddr(addr), BIO_ADDR_sockaddr_size(addr)) != 0) {
-        FUNCerr("bind", get_last_socket_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                       "calling %s()", "bind");
         BIOerr(BIO_F_BIO_BIND, BIO_R_UNABLE_TO_BIND_SOCKET);
         return 0;
     }
@@ -217,7 +223,8 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (getsockopt(sock, SOL_SOCKET, SO_TYPE,
                    (void *)&socktype, &socktype_len) != 0
         || socktype_len != sizeof(socktype)) {
-        FUNCerr("getsockopt", get_last_socket_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                       "calling %s()", "getsockopt");
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_GETTING_SOCKTYPE);
         return 0;
     }
@@ -228,7 +235,8 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_KEEPALIVE) {
         if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
                        (const void *)&on, sizeof(on)) != 0) {
-            FUNCerr("setsockopt", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "setsockopt");
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_KEEPALIVE);
             return 0;
         }
@@ -237,7 +245,8 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
     if (options & BIO_SOCK_NODELAY) {
         if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                        (const void *)&on, sizeof(on)) != 0) {
-            FUNCerr("setsockopt", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "setsockopt");
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_NODELAY);
             return 0;
         }
@@ -252,7 +261,8 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         on = options & BIO_SOCK_V6_ONLY ? 1 : 0;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
                        (const void *)&on, sizeof(on)) != 0) {
-            FUNCerr("setsockopt", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "setsockopt");
             BIOerr(BIO_F_BIO_LISTEN, BIO_R_LISTEN_V6_ONLY);
             return 0;
         }
@@ -263,7 +273,8 @@ int BIO_listen(int sock, const BIO_ADDR *addr, int options)
         return 0;
 
     if (socktype != SOCK_DGRAM && listen(sock, MAX_LISTEN) == -1) {
-        FUNCerr("listen", get_last_socket_error());
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                       "calling %s()", "listen");
         BIOerr(BIO_F_BIO_LISTEN, BIO_R_UNABLE_TO_LISTEN_SOCKET);
         return 0;
     }
@@ -290,7 +301,8 @@ int BIO_accept_ex(int accept_sock, BIO_ADDR *addr_, int options)
                            BIO_ADDR_sockaddr_noconst(addr), &len);
     if (accepted_sock == -1) {
         if (!BIO_sock_should_retry(accepted_sock)) {
-            FUNCerr("accept", get_last_socket_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling %s()", "accept");
             BIOerr(BIO_F_BIO_ACCEPT_EX, BIO_R_ACCEPT_ERROR);
         }
         return INVALID_SOCKET;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -227,7 +227,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                               "calling socket(\"%s\", \"%s\")",
+                               "calling socket(%s, %s)",
                                 c->param_addr, c->param_serv);
                 BIOerr(BIO_F_ACPT_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -227,7 +227,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                               "calling socket hostname=%s service=%s",
+                               "calling socket(\"%s\", \"%s\")",
                                 c->param_addr, c->param_serv);
                 BIOerr(BIO_F_ACPT_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -226,10 +226,9 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                              BIO_ADDRINFO_socktype(c->addr_iter),
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
-                FUNCerr("socket", get_last_socket_error());
-                ERR_add_error_data(4,
-                                   "hostname=", c->param_addr,
-                                   " service=", c->param_serv);
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling socket hostname=%s service=%s",
+                                c->param_addr, c->param_serv);
                 BIOerr(BIO_F_ACPT_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;
             }

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -138,10 +138,9 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                              BIO_ADDRINFO_socktype(c->addr_iter),
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
-                FUNCerr("socket", get_last_socket_error());
-                ERR_add_error_data(4,
-                                   "hostname=", c->param_hostname,
-                                   " service=", c->param_service);
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling socket hostname=%s service=%s",
+                               c->param_hostname, c->param_service);
                 BIOerr(BIO_F_CONN_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;
             }
@@ -170,10 +169,9 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     ERR_clear_error();
                     break;
                 } else {
-                    FUNCerr("connect", get_last_socket_error());
-                    ERR_add_error_data(4,
-                                       "hostname=", c->param_hostname,
-                                       " service=", c->param_service);
+                    ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                                   "calling connect hostname=%s service=%s",
+                                    c->param_hostname, c->param_service);
                     BIOerr(BIO_F_CONN_STATE, BIO_R_CONNECT_ERROR);
                 }
                 goto exit_loop;
@@ -186,10 +184,9 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             i = BIO_sock_error(b->num);
             if (i) {
                 BIO_clear_retry_flags(b);
-                FUNCerr("connect", i);
-                ERR_add_error_data(4,
-                                   "hostname=", c->param_hostname,
-                                   " service=", c->param_service);
+                ERR_raise_data(ERR_LIB_SYS, i,
+                               "calling connect(\"%s\", \"%s\")",
+                                c->param_hostname, c->param_service);
                 BIOerr(BIO_F_CONN_STATE, BIO_R_NBIO_CONNECT_ERROR);
                 ret = 0;
                 goto exit_loop;

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -139,7 +139,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
             if (ret == (int)INVALID_SOCKET) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                               "calling socket hostname=%s service=%s",
+                               "calling socket(%s, %s)",
                                c->param_hostname, c->param_service);
                 BIOerr(BIO_F_CONN_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;
@@ -170,7 +170,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     break;
                 } else {
                     ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
-                                   "calling connect hostname=%s service=%s",
+                                   "calling connect(%s, %s)",
                                     c->param_hostname, c->param_service);
                     BIOerr(BIO_F_CONN_STATE, BIO_R_CONNECT_ERROR);
                 }
@@ -185,7 +185,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             if (i) {
                 BIO_clear_retry_flags(b);
                 ERR_raise_data(ERR_LIB_SYS, i,
-                               "calling connect(\"%s\", \"%s\")",
+                               "calling connect(%s, %s)",
                                 c->param_hostname, c->param_service);
                 BIOerr(BIO_F_CONN_STATE, BIO_R_NBIO_CONNECT_ERROR);
                 ret = 0;

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -148,7 +148,7 @@ static int file_read(BIO *b, char *out, int outl)
             && (b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_ferror((FILE *)b->ptr) : ferror((FILE *)b->ptr))) {
             ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                           "calling %s()", "fread");
+                           "calling fread()");
             BIOerr(BIO_F_FILE_READ, ERR_R_SYS_LIB);
             ret = -1;
         }
@@ -317,7 +317,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
                 ? UP_fflush(b->ptr) : fflush((FILE *)b->ptr);
         if (st == EOF) {
             ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                           "calling %s()", "fflush");
+                           "calling fflush()");
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;
         }

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -66,8 +66,9 @@ BIO *BIO_new_file(const char *filename, const char *mode)
         fp_flags |= BIO_FP_TEXT;
 
     if (file == NULL) {
-        FUNCerr("fopen", get_last_sys_error());
-        ERR_add_error_data(5, "fopen('", filename, "','", mode, "')");
+        ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                       "calling fopen(\"%s\", \"%s\")",
+                       filename, mode);
         if (errno == ENOENT
 #ifdef ENXIO
             || errno == ENXIO
@@ -146,7 +147,8 @@ static int file_read(BIO *b, char *out, int outl)
         if (ret == 0
             && (b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_ferror((FILE *)b->ptr) : ferror((FILE *)b->ptr))) {
-            FUNCerr("fread", get_last_sys_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                           "calling %s()", "fread");
             BIOerr(BIO_F_FILE_READ, ERR_R_SYS_LIB);
             ret = -1;
         }
@@ -285,8 +287,9 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
 # endif
         fp = openssl_fopen(ptr, p);
         if (fp == NULL) {
-            FUNCerr("fopen", get_last_sys_error());
-            ERR_add_error_data(5, "fopen('", ptr, "','", p, "')");
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                           "calling fopen(\"%s\", \"%s\")",
+                           ptr, p);
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;
             break;
@@ -313,8 +316,8 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         st = b->flags & BIO_FLAGS_UPLINK_INTERNAL
                 ? UP_fflush(b->ptr) : fflush((FILE *)b->ptr);
         if (st == EOF) {
-            FUNCerr("fflush", get_last_sys_error());
-            ERR_add_error_data(1, "fflush()");
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                           "calling %s()", "fflush");
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;
         }

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -67,7 +67,7 @@ BIO *BIO_new_file(const char *filename, const char *mode)
 
     if (file == NULL) {
         ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                       "calling fopen(\"%s\", \"%s\")",
+                       "calling fopen(%s, %s)",
                        filename, mode);
         if (errno == ENOENT
 #ifdef ENXIO
@@ -288,7 +288,7 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         fp = openssl_fopen(ptr, p);
         if (fp == NULL) {
             ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                           "calling fopen(\"%s\", \"%s\")",
+                           "calling fopen(%s, %s)",
                            ptr, p);
             BIOerr(BIO_F_FILE_CTRL, ERR_R_SYS_LIB);
             ret = 0;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -674,7 +674,7 @@ static BIO *process_include(char *include, OPENSSL_DIR_CTX **dirctx,
 
     if (stat(include, &st) < 0) {
         ERR_raise_data(ERR_LIB_SYS, errno,
-                       "calling stat(\"%s\")",
+                       "calling stat(%s)",
                        include);
         /* missing include file is not fatal error */
         return NULL;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -673,8 +673,9 @@ static BIO *process_include(char *include, OPENSSL_DIR_CTX **dirctx,
     BIO *next;
 
     if (stat(include, &st) < 0) {
-        FUNCerr("stat", errno);
-        ERR_add_error_data(1, include);
+        ERR_raise_data(ERR_LIB_SYS, errno,
+                       "calling stat(\"%s\")",
+                       include);
         /* missing include file is not fatal error */
         return NULL;
     }

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -825,7 +825,7 @@ static OSSL_STORE_LOADER_CTX *file_open(const OSSL_STORE_LOADER *loader,
 
         if (stat(path_data[i].path, &st) < 0) {
             ERR_raise_data(ERR_LIB_SYS, errno,
-                           "calling stat(\"%s\")",
+                           "calling stat(%s)",
                            path_data[i].path);
         } else {
             path = path_data[i].path;

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -824,8 +824,9 @@ static OSSL_STORE_LOADER_CTX *file_open(const OSSL_STORE_LOADER *loader,
         }
 
         if (stat(path_data[i].path, &st) < 0) {
-            FUNCerr("stat", errno);
-            ERR_add_error_data(1, path_data[i].path);
+            ERR_raise_data(ERR_LIB_SYS, errno,
+                           "calling stat(\"%s\")",
+                           path_data[i].path);
         } else {
             path = path_data[i].path;
         }

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -72,7 +72,7 @@ void engine_load_devcrypto_int(void);
 
 static int clean_devcrypto_session(struct session_op *sess) {
     if (ioctl(cfd, CIOCFSESSION, &sess->ses) < 0) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
     memset(sess, 0, sizeof(struct session_op));
@@ -208,7 +208,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     cipher_ctx->mode = cipher_d->flags & EVP_CIPH_MODE;
     cipher_ctx->blocksize = cipher_d->blocksize;
     if (ioctl(cfd, CIOCGSESSION, &cipher_ctx->sess) < 0) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
 
@@ -260,7 +260,7 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 #endif
 
     if (ioctl(cfd, CIOCCRYPT, &cryp) < 0) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
 
@@ -704,7 +704,7 @@ static int digest_init(EVP_MD_CTX *ctx)
     memset(&digest_ctx->sess, 0, sizeof(digest_ctx->sess));
     digest_ctx->sess.mac = digest_d->devcryptoid;
     if (ioctl(cfd, CIOCGSESSION, &digest_ctx->sess) < 0) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
     return 1;
@@ -743,7 +743,7 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
         return 1;
     }
 
-    ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+    ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
     return 0;
 }
 
@@ -758,7 +758,7 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     if (EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
         memcpy(md, digest_ctx->digest_res, EVP_MD_CTX_size(ctx));
     } else if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
 
@@ -777,14 +777,14 @@ static int digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
         return 1;
 
     if (!digest_init(to)) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
 
     cphash.src_ses = digest_from->sess.ses;
     cphash.dst_ses = digest_to->sess.ses;
     if (ioctl(cfd, CIOCCPHASH, &cphash) < 0) {
-        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
         return 0;
     }
     return 1;

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -72,7 +72,7 @@ void engine_load_devcrypto_int(void);
 
 static int clean_devcrypto_session(struct session_op *sess) {
     if (ioctl(cfd, CIOCFSESSION, &sess->ses) < 0) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
     memset(sess, 0, sizeof(struct session_op));
@@ -208,7 +208,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     cipher_ctx->mode = cipher_d->flags & EVP_CIPH_MODE;
     cipher_ctx->blocksize = cipher_d->blocksize;
     if (ioctl(cfd, CIOCGSESSION, &cipher_ctx->sess) < 0) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
 
@@ -260,7 +260,7 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 #endif
 
     if (ioctl(cfd, CIOCCRYPT, &cryp) < 0) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
 
@@ -704,7 +704,7 @@ static int digest_init(EVP_MD_CTX *ctx)
     memset(&digest_ctx->sess, 0, sizeof(digest_ctx->sess));
     digest_ctx->sess.mac = digest_d->devcryptoid;
     if (ioctl(cfd, CIOCGSESSION, &digest_ctx->sess) < 0) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
     return 1;
@@ -743,7 +743,7 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
         return 1;
     }
 
-    FUNCerr("ioctl", errno);
+    ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
     return 0;
 }
 
@@ -758,7 +758,7 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
     if (EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_ONESHOT)) {
         memcpy(md, digest_ctx->digest_res, EVP_MD_CTX_size(ctx));
     } else if (digest_op(digest_ctx, NULL, 0, md, COP_FLAG_FINAL) < 0) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
 
@@ -777,14 +777,14 @@ static int digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
         return 1;
 
     if (!digest_init(to)) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
 
     cphash.src_ses = digest_from->sess.ses;
     cphash.dst_ses = digest_to->sess.ses;
     if (ioctl(cfd, CIOCCPHASH, &cphash) < 0) {
-        FUNCerr("ioctl", errno);
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling %s()", "ioctl");
         return 0;
     }
     return 1;

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -110,7 +110,6 @@ typedef struct err_state_st {
 # if ! OPENSSL_API_3
 #  define SYSerr(f,r)  ERR_raise(ERR_LIB_SYS,(r))
 # endif
-# define FUNCerr(f,r)  ERR_raise_data(ERR_LIB_SYS,(r),"calling function %s",(f))
 # define BNerr(f,r)   ERR_raise(ERR_LIB_RSA,(r))
 # define RSAerr(f,r)  ERR_raise(ERR_LIB_RSA,(r))
 # define DHerr(f,r)   ERR_raise(ERR_LIB_DH,(r))

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -767,7 +767,7 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
 
     if (errno) {
         ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                       "calling readdir(\"%s\")",
+                       "calling OPENSSL_dir_read(%s)",
                        dir);
         SSLerr(SSL_F_SSL_ADD_DIR_CERT_SUBJECTS_TO_STACK, ERR_R_SYS_LIB);
         goto err;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -766,8 +766,9 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     }
 
     if (errno) {
-        FUNCerr("readdir", get_last_sys_error());
-        ERR_add_error_data(3, "OPENSSL_DIR_read(&ctx, '", dir, "')");
+        ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                       "calling readdir(\"%s\")",
+                       dir);
         SSLerr(SSL_F_SSL_ADD_DIR_CERT_SUBJECTS_TO_STACK, ERR_R_SYS_LIB);
         goto err;
     }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2075,7 +2075,8 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
         else
 #endif
 #ifdef OPENSSL_NO_KTLS
-            FUNCerr("sendfile", get_last_sys_error());
+            ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
+                          "calling %s()", "sendfile");
 #else
             SSLerr(SSL_F_SSL_SENDFILE, SSL_R_UNINITIALIZED);
 #endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2076,7 +2076,7 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
 #endif
 #ifdef OPENSSL_NO_KTLS
             ERR_raise_data(ERR_LIB_SYS, get_last_sys_error(),
-                          "calling %s()", "sendfile");
+                          "calling sendfile()");
 #else
             SSLerr(SSL_F_SSL_SENDFILE, SSL_R_UNINITIALIZED);
 #endif

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -54,12 +54,13 @@ static int platform_error(void)
 
     file = __FILE__;
     line = __LINE__ + 1; /* The error is generated on the next line */
-    FUNCerr("exit", ERR_R_INTERNAL_ERROR);
+    ERR_raise_data(ERR_LIB_SYS, ERR_R_INTERNAL_ERROR,
+                   "calling %s()", "exit");
     if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
             || !TEST_int_eq(l, line)
             || !TEST_str_eq(f, file)
-            || !TEST_str_eq(data, "calling function exit"))
+            || !TEST_str_eq(data, "calling exit()"))
         return 0;
     return 1;
 }

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -55,7 +55,7 @@ static int platform_error(void)
     file = __FILE__;
     line = __LINE__ + 1; /* The error is generated on the next line */
     ERR_raise_data(ERR_LIB_SYS, ERR_R_INTERNAL_ERROR,
-                   "calling %s()", "exit");
+                   "calling exit()");
     if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
             || !TEST_int_eq(l, line)


### PR DESCRIPTION
Now that #9452 has been merged, let's replace all ```FUNCerr``` calls with ``ERR_raise_data```

No compatibility is needed since ```ERRfunc()``` was only in master.