### PR TITLE
Fix S390 compile errors in gcm due to renamed defines

### DIFF
--- a/providers/common/ciphers/gcm_s390x.c
+++ b/providers/common/ciphers/gcm_s390x.c
@@ -42,14 +42,14 @@ static int s390x_aes_gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv,
     actx->plat.s390x.areslen = 0;
     actx->plat.s390x.kreslen = 0;
 
-    if (ivlen == AES_GCM_IV_DEFAULT_SIZE) {
+    if (ivlen == GCM_IV_DEFAULT_SIZE) {
         memcpy(&kma->j0, iv, ivlen);
         kma->j0.w[3] = 1;
         kma->cv.w = 1;
     } else {
         unsigned long long ivbits = ivlen << 3;
         size_t len = S390X_gcm_ivpadlen(ivlen);
-        unsigned char iv_zero_pad[S390X_gcm_ivpadlen(AES_GCM_IV_MAX_SIZE)];
+        unsigned char iv_zero_pad[S390X_gcm_ivpadlen(GCM_IV_MAX_SIZE)];
         /*
          * The IV length needs to be zero padded to be a multiple of 16 bytes
          * followed by 8 bytes of zeros and 8 bytes for the IV length.
@@ -93,7 +93,7 @@ static int s390x_aes_gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
     OPENSSL_cleanse(out, actx->plat.s390x.mreslen);
 
     if (ctx->enc) {
-        ctx->taglen = AES_GCM_TAG_MAX_SIZE;
+        ctx->taglen = GCM_TAG_MAX_SIZE;
         memcpy(tag, kma->t.b, ctx->taglen);
         rc = 1;
     } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

Sigh - this happened when I merged aria into the aes gcm code.. Forgot to rename the variable in s390.