### PR TITLE
GCM cipher in provider now fails if passed bad keylength

### DIFF
--- a/providers/common/ciphers/gcm.c
+++ b/providers/common/ciphers/gcm.c
@@ -209,6 +209,12 @@ static int gcm_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         }
     }
 
+    /*
+     * TODO(3.0) Temporary solution to address fuzz test crash, which will be
+     * reworked once the discussion in PR #9510 is resolved. i.e- We need a
+     * general solution for handling missing parameters inside set_params and
+     * get_params methods.
+     */
     p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_KEYLEN);
     if (p != NULL) {
         int keylen;

--- a/providers/common/ciphers/gcm.c
+++ b/providers/common/ciphers/gcm.c
@@ -209,6 +209,19 @@ static int gcm_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         }
     }
 
+    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_KEYLEN);
+    if (p != NULL) {
+        int keylen;
+
+        if (!OSSL_PARAM_get_int(p, &keylen)) {
+            PROVerr(0, PROV_R_FAILED_TO_GET_PARAMETER);
+            return 0;
+        }
+        /* The key length can not be modified for gcm mode */
+        if (keylen != (int)ctx->keylen)
+            return 0;
+    }
+
     return 1;
 }
 

--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -100,6 +100,20 @@ static int kat_test(void)
            && do_decrypt(gcm_iv, ct, ctlen, tag, taglen);
 }
 
+static int badkeylen_test(void)
+{
+    int ret;
+    EVP_CIPHER_CTX *ctx = NULL;
+    const EVP_CIPHER *cipher;
+
+    ret = TEST_ptr(cipher = EVP_aes_192_gcm())
+          && TEST_ptr(ctx = EVP_CIPHER_CTX_new())
+          && TEST_true(EVP_EncryptInit_ex(ctx, cipher, NULL, NULL, NULL))
+          && TEST_false(EVP_CIPHER_CTX_set_key_length(ctx, 2));
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
 #ifdef FIPS_MODE
 static int ivgen_test(void)
 {
@@ -116,6 +130,7 @@ static int ivgen_test(void)
 int setup_tests(void)
 {
     ADD_TEST(kat_test);
+    ADD_TEST(badkeylen_test);
 #ifdef FIPS_MODE
     ADD_TEST(ivgen_test);
 #endif /* FIPS_MODE */


### PR DESCRIPTION
Fixes #9500

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
