### PR TITLE
Bug fix :  print dummy password when object type is pkcs9 challengePassword

### DIFF
--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -17,6 +17,8 @@
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
 
+#define OSSL_DUMMY_STRING "******"
+
 #ifndef OPENSSL_NO_STDIO
 int X509_REQ_print_fp(FILE *fp, X509_REQ *x)
 {
@@ -147,9 +149,15 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
                 case V_ASN1_NUMERICSTRING:
                 case V_ASN1_UTF8STRING:
                 case V_ASN1_IA5STRING:
-                    if (BIO_write(bp, (char *)bs->data, bs->length)
-                            != bs->length)
-                        goto err;
+                    if (NID_pkcs9_challengePassword == (OBJ_obj2nid(X509_ATTRIBUTE_get0_object(a)))) {
+                        if (BIO_write(bp,OSSL_DUMMY_STRING,
+                            (int)strlen(OSSL_DUMMY_STRING)) != (int)strlen(OSSL_DUMMY_STRING))
+                            goto err;
+                    } else {
+                        if (BIO_write(bp, (char *)bs->data, bs->length)
+                                != bs->length)
+                            goto err;
+                    }
                     if (BIO_puts(bp, "\n") <= 0)
                         goto err;
                     break;


### PR DESCRIPTION
1) File : mem.c
  Change : Null check is added for str in function CRYPTO_free. Suggest to add NULL check for free 
   API functions. 

2) File : t_req.c
  Change : This is to avoid sensitive data (password) printing. when NID is of type 
  ChallengePassword, then we dont need to print anything. so added a Dummy string.

3) File : x509_lu.c , x509_vrf.h (Prototype of API)
  Change : added 3 new APIs
     a) X509_OBJECT_get0_data  --> API used to get data of ptr. this helps to get the info of any 
        member in union (unlike specific member). since there is not API to get the data.pkey this 
        generic API is added.
     b) X509_OBJECT_set0_data  --> API is added to set data of union data. this is also generic api to 
        set any memeber in the union. Since there is no set API for data.pey, this can be used. 
     c) X509_OBJECT_set0_type  --> API to set the type of union data. user can set his own type when 
        the union data is not X509_LU_X509 & X509_LU_CRL. 

- [ ] documentation is added or updated
- [ ] tests are added or updated
