### PR TITLE
Fix reversed meaning of error codes

### DIFF
--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -101,8 +101,8 @@ the operation was successful.
 
 =item B<X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT: unable to get issuer certificate>
 
-the issuer certificate could not be found: this occurs if the issuer certificate
-of an untrusted certificate cannot be found.
+the issuer certificate of a locally looked up certificate could not be found.
+This normally means the list of trusted certificates is not complete.
 
 =item B<X509_V_ERR_UNABLE_TO_GET_CRL: unable to get certificate CRL>
 
@@ -180,8 +180,8 @@ the root could not be found locally.
 
 =item B<X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY: unable to get local issuer certificate>
 
-the issuer certificate of a locally looked up certificate could not be found.
-This normally means the list of trusted certificates is not complete.
+the issuer certificate could not be found: this occurs if the issuer certificate
+of an untrusted certificate cannot be found.
 
 =item B<X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE: unable to verify the first certificate>
 


### PR DESCRIPTION
The meaning of the X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY and X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT error codes were still reversed in the X509_STORE_CTX_get_error function documentation.
This used to be the problem also in the verify application documentation, but was fixed on 2010-02-23 in 7d3d178.

Although the change may be trivial, I'll send the ICLA as I expect to be doing multiple such smaller documentation-related pull requests in the near future.

@richsalz: This is a bit from newer research on the usability of X509-capable libraries here at [CRoCS, Masaryk University](https://crocs.fi.muni.cz/), you reviewed my previous suggestion in #4548.