### PR TITLE
Fix getaddrinfo() call with AI_ADDRCONFIG for inconsistent systems.

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -7,6 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * We need to do this early, because stdio.h includes the header files that
+ * handle _GNU_SOURCE and other similar macros.  Defining it later is simply
+ * too late, because those headers are protected from re- inclusion.
+ */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE            /* make sure EAI_ADDRFAMILY is declared */
+#endif
+
 #include <assert.h>
 #include <string.h>
 
@@ -709,7 +718,8 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         case 0:
             ret = 1;             /* Success */
             break;
-# if (defined(EAI_FAMILY) || defined(EAI_ADDRFAMILY)) && defined(AI_ADDRCONFIG)
+# ifdef AI_ADDRCONFIG
+	case EAI_NONAME:
 #  ifdef EAI_FAMILY
         case EAI_FAMILY:
 #  endif


### PR DESCRIPTION
Such a query fails if on a system the loopback device has an inet6 address configured, while other devices have no inet6 addresses. The previous commit 3f91ede9ae addressed the issue already but not completely.
On Linux systems the call returns -9 (EAI_ADDRFAMILY), but the definition is a GNU extension and needs therefore _GNU_SOURCE defined.
On AIX systems the call returns 8 (EAI_NONAME), but this case was not yet handled.

Fixes #9053 
