### PR TITLE
BIO_lookup_ex: Always retry the lookup on failure with AI_NUMERICHOST…

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -676,7 +676,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 
     if (1) {
 #ifdef AI_PASSIVE
-        int gai_ret = 0;
+        int gai_ret = 0, old_ret = 0;
         struct addrinfo hints;
 
         memset(&hints, 0, sizeof(hints));
@@ -684,12 +684,12 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         hints.ai_family = family;
         hints.ai_socktype = socktype;
         hints.ai_protocol = protocol;
-#ifdef AI_ADDRCONFIG
-#ifdef AF_UNSPEC
+# ifdef AI_ADDRCONFIG
+#  ifdef AF_UNSPEC
         if (family == AF_UNSPEC)
-#endif
+#  endif
             hints.ai_flags |= AI_ADDRCONFIG;
-#endif
+# endif
 
         if (lookup_type == BIO_LOOKUP_SERVER)
             hints.ai_flags |= AI_PASSIVE;
@@ -706,6 +706,11 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             break;
 # endif
+# ifdef EAI_MEMORY
+        case EAI_MEMORY:
+            BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_MALLOC_FAILURE);
+            break;
+# endif
         case 0:
             ret = 1;             /* Success */
             break;
@@ -714,11 +719,12 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             if (hints.ai_flags & AI_ADDRCONFIG) {
                 hints.ai_flags &= ~AI_ADDRCONFIG;
                 hints.ai_flags |= AI_NUMERICHOST;
+                old_ret = gai_ret;
                 goto retry;
             }
 # endif
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
-            ERR_add_error_data(1, gai_strerror(gai_ret));
+            ERR_add_error_data(1, gai_strerror(old_ret ? old_ret : gai_ret));
             break;
         }
     } else {

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -709,20 +709,14 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         case 0:
             ret = 1;             /* Success */
             break;
-# if (defined(EAI_FAMILY) || defined(EAI_ADDRFAMILY)) && defined(AI_ADDRCONFIG)
-#  ifdef EAI_FAMILY
-        case EAI_FAMILY:
-#  endif
-#  ifdef EAI_ADDRFAMILY
-        case EAI_ADDRFAMILY:
-#  endif
+        default:
+# if defined(AI_ADDRCONFIG) && defined(AI_NUMERICHOST)
             if (hints.ai_flags & AI_ADDRCONFIG) {
                 hints.ai_flags &= ~AI_ADDRCONFIG;
+                hints.ai_flags |= AI_NUMERICHOST;
                 goto retry;
             }
 # endif
-            /* fall through */
-        default:
             BIOerr(BIO_F_BIO_LOOKUP_EX, ERR_R_SYS_LIB);
             ERR_add_error_data(1, gai_strerror(gai_ret));
             break;


### PR DESCRIPTION
… set

Do not try to discern the error return value on
getaddrinfo() failure but when retrying set the AI_NUMERICHOST
to avoid DNS lookups.

Fixes: #9053

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

