### PR TITLE
Fix no-filenames

### DIFF
--- a/test/errtest.c
+++ b/test/errtest.c
@@ -47,19 +47,24 @@ static int vdata_appends(void)
 /* Test that setting a platform error sets the right values. */
 static int platform_error(void)
 {
-    const char *file, *f, *data;
-    int line;
+    const char *f, *data;
     int l;
     unsigned long e;
+#ifndef OPENSSL_NO_FILENAMES
+    const char *file;
+    int line;
 
     file = __FILE__;
-    line = __LINE__ + 1; /* The error is generated on the next line */
+    line = __LINE__ + 2; /* The error is generated on the ERR_raise_data line */
+#endif
     ERR_raise_data(ERR_LIB_SYS, ERR_R_INTERNAL_ERROR,
                    "calling exit()");
     if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
+#ifndef OPENSSL_NO_FILENAMES
             || !TEST_int_eq(l, line)
             || !TEST_str_eq(f, file)
+#endif
             || !TEST_str_eq(data, "calling exit()"))
         return 0;
     return 1;


### PR DESCRIPTION
If built with no-filenames then we shouldn't test this functionality in the test suite.