### PR TITLE
Fix enable-ec_nistp_64_gcc_128

### DIFF
--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1286,7 +1286,7 @@ int ec_GFp_nistp224_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
-        new_ctx = BN_CTX_new();
+        ctx = new_ctx = BN_CTX_new();
 #endif
     if (ctx == NULL)
         return 0;
@@ -1606,7 +1606,7 @@ int ec_GFp_nistp224_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
 
 #ifndef FIPS_MODE
     if (ctx == NULL)
-        new_ctx = BN_CTX_new();
+        ctx = new_ctx = BN_CTX_new();
 #endif
     if (ctx == NULL)
         return 0;

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1906,7 +1906,7 @@ int ec_GFp_nistp256_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
-        new_ctx = BN_CTX_new();
+        ctx = new_ctx = BN_CTX_new();
 #endif
     if (ctx == NULL)
         return 0;
@@ -2234,7 +2234,7 @@ int ec_GFp_nistp256_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
 
 #ifndef FIPS_MODE
     if (ctx == NULL)
-        new_ctx = BN_CTX_new();
+        ctx = new_ctx = BN_CTX_new();
 #endif
     if (ctx == NULL)
         return 0;

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1748,7 +1748,7 @@ int ec_GFp_nistp521_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
-        new_ctx = BN_CTX_new();
+        ctx = new_ctx = BN_CTX_new();
 #endif
     if (ctx == NULL)
         return 0;
@@ -2072,7 +2072,7 @@ int ec_GFp_nistp521_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
 
 #ifndef FIPS_MODE
     if (ctx == NULL)
-        new_ctx = BN_CTX_new();
+        ctx = new_ctx = BN_CTX_new();
 #endif
     if (ctx == NULL)
         return 0;


### PR DESCRIPTION
When creating a BN_CTX, make sure we store it in the right variable!