### PR TITLE
install suffixed man pages into suffixed directories

### DIFF
--- a/util/process_docs.pl
+++ b/util/process_docs.pl
@@ -109,7 +109,7 @@ _____
 pod2html "--podroot=$sourcedir" --htmldir=$updir --podpath=man1:man3:man5:man7 "--infile=$podpath" "--title=$podname" --quiet
 _____
                 } -> {$options{type}};
-            my $output_dir = catdir($options{destdir}, "man$podinfo{section}");
+            my $output_dir = catdir($options{destdir}, "man$podinfo{section}" . (defined($options{suffix}) and $options{type} eq 'man' ? $options{suffix} : ""));
             my $output_file = $podname . $suffix;
             my $output_path = catfile($output_dir, $output_file);
 


### PR DESCRIPTION
I think it makes more sense to install man pages with suffixes into man directory with the same suffix (consistency).

before:
```
$ perl util/process_docs.pl --destdir=/usr/openssl/1.1/share/man --type=man --suffix=openssl --dry-run | head
/usr/openssl/1.1/share/man/man1/asn1parse.1openssl
/usr/openssl/1.1/share/man/man1/openssl-asn1parse.1openssl -> /usr/openssl/1.1/share/man/man1/asn1parse.1openssl
/usr/openssl/1.1/share/man/man1/CA.pl.1openssl
/usr/openssl/1.1/share/man/man1/ca.1openssl
/usr/openssl/1.1/share/man/man1/openssl-ca.1openssl -> /usr/openssl/1.1/share/man/man1/ca.1openssl
/usr/openssl/1.1/share/man/man1/ciphers.1openssl
/usr/openssl/1.1/share/man/man1/openssl-ciphers.1openssl -> /usr/openssl/1.1/share/man/man1/ciphers.1openssl
/usr/openssl/1.1/share/man/man1/cms.1openssl
/usr/openssl/1.1/share/man/man1/openssl-cms.1openssl -> /usr/openssl/1.1/share/man/man1/cms.1openssl
/usr/openssl/1.1/share/man/man1/crl.1openssl
```
after:
```
$ perl util/process_docs.pl --destdir=/usr/openssl/1.1/share/man --type=man --suffix=openssl --dry-run | head
/usr/openssl/1.1/share/man/man1openssl/asn1parse.1openssl
/usr/openssl/1.1/share/man/man1openssl/openssl-asn1parse.1openssl -> /usr/openssl/1.1/share/man/man1openssl/asn1parse.1openssl
/usr/openssl/1.1/share/man/man1openssl/CA.pl.1openssl
/usr/openssl/1.1/share/man/man1openssl/ca.1openssl
/usr/openssl/1.1/share/man/man1openssl/openssl-ca.1openssl -> /usr/openssl/1.1/share/man/man1openssl/ca.1openssl
/usr/openssl/1.1/share/man/man1openssl/ciphers.1openssl
/usr/openssl/1.1/share/man/man1openssl/openssl-ciphers.1openssl -> /usr/openssl/1.1/share/man/man1openssl/ciphers.1openssl
/usr/openssl/1.1/share/man/man1openssl/cms.1openssl
/usr/openssl/1.1/share/man/man1openssl/openssl-cms.1openssl -> /usr/openssl/1.1/share/man/man1openssl/cms.1openssl
/usr/openssl/1.1/share/man/man1openssl/crl.1openssl
```