### PR TITLE
fix ERR_add_error_vdata() for use with multiple args/calls

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -790,7 +790,7 @@ void ERR_add_error_vdata(int num, va_list args)
     }
     len = strlen(str);
 
-    for (len = 0; --num >= 0; ) {
+    while (--num >= 0) {
         arg = va_arg(args, char *);
         if (arg == NULL)
             arg = "<NULL>";


### PR DESCRIPTION
When preparing tests for our CMP contribution chunk 4 #9107 I came across a bug in 
`ERR_add_error_vdata()`: 
the stored error data is truncated after 20 chars of the second string arg.

It turns out there is an obvious mistake resetting the `len` variable - see the fix provided.