### PR TITLE
 Verify that an EVP_CIPHER_CTX_set_key_length() call has worked

### DIFF
--- a/providers/common/ciphers/gcm.c
+++ b/providers/common/ciphers/gcm.c
@@ -209,25 +209,6 @@ static int gcm_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         }
     }
 
-    /*
-     * TODO(3.0) Temporary solution to address fuzz test crash, which will be
-     * reworked once the discussion in PR #9510 is resolved. i.e- We need a
-     * general solution for handling missing parameters inside set_params and
-     * get_params methods.
-     */
-    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_KEYLEN);
-    if (p != NULL) {
-        int keylen;
-
-        if (!OSSL_PARAM_get_int(p, &keylen)) {
-            PROVerr(0, PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        /* The key length can not be modified for gcm mode */
-        if (keylen != (int)ctx->keylen)
-            return 0;
-    }
-
     return 1;
 }
 


### PR DESCRIPTION
Not all ciphers will implement the OSSL_CIPHER_PARAM_KEYLEN parameter for setting, so if we attempt to set it we should check that it worked afterwards.