### PR TITLE
Remove some duplicate words from the documentation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -239,7 +239,7 @@
                                source exists.
                    getrandom:  Use the L<getrandom(2)> or equivalent system
                                call.
-                   devrandom:  Use the the first device from the DEVRANDOM list
+                   devrandom:  Use the first device from the DEVRANDOM list
                                which can be opened to read random bytes. The
                                DEVRANDOM preprocessor constant expands to
                                "/dev/urandom","/dev/random","/dev/srandom" on

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -149,7 +149,7 @@ SSL servers.
 =head1 OPTIONS
 
 In addition to the options below the B<s_client> utility also supports the
-common and client only options documented in the
+common and client only options documented
 in the "Supported Command Line Commands" section of the L<SSL_CONF_cmd(3)>
 manual page.
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -194,7 +194,7 @@ for connections on a given port using SSL/TLS.
 =head1 OPTIONS
 
 In addition to the options below the B<s_server> utility also supports the
-common and server only options documented in the
+common and server only options documented
 in the "Supported Command Line Commands" section of the L<SSL_CONF_cmd(3)>
 manual page.
 


### PR DESCRIPTION
As the commit message says.