### PR TITLE
crypto/core_fetch.c: before contructing a method, check if it already exists

### DIFF
--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -39,10 +39,11 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
      * to copy a property definition and paste that wherever a property
      * is being queried.
      */
-    if (data->mcm->get(data->libctx, NULL, data->operation_id,
-                       algo->algorithm_name, algo->property_definition,
-                       data->mcm_data) != NULL)
-        return;
+    if ((method = data->mcm->get(data->libctx, NULL, data->operation_id,
+                                 algo->algorithm_name,
+                                 algo->property_definition,
+                                 data->mcm_data)) != NULL)
+        goto end;
 
     if ((method = data->mcm->construct(algo->algorithm_name,
                                        algo->implementation, provider,
@@ -74,6 +75,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
                    algo->algorithm_name, algo->property_definition,
                    data->mcm_data);
 
+ end:
     /* refcnt-- because we're dropping the reference */
     data->mcm->destruct(method, data->mcm_data);
 }

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -38,12 +38,12 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
      * supposed to store the method in the global store.
      *
      * Note that while data->mcm->put() takes a property *definition*,
-     * while data->mcm->get() takes a property *query*, but we're using
-     * the property *definition* string as a property query here.
+     * data->mcm->get() takes a property *query*, but we're using the
+     * property *definition* string as a property query here.
      * This is possible because property definitions have a syntax that
      * can also be used for a property query with equality tests.  We do
      * this to look up already existing methods matching the implementation
-     * that we just for from the provider (via |algo|),
+     * that we just got from the provider (via |algo|).
      */
     if (global_store
         && (method = data->mcm->get(data->libctx, NULL, data->operation_id,

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -30,21 +30,31 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
 {
     struct construct_data_st *data = cbdata;
     void *method = NULL;
+    int global_store = data->force_store || !no_store;
 
     /*
      * Check to see if a method has already been constructed from this
-     * implementation.  Note that we use the property definition as a
-     * property query, which stresses that they MUST have compatible
-     * syntax, or else...  (in other words, it must always be possible
-     * to copy a property definition and paste that wherever a property
-     * is being queried.
+     * implementation.  It's pointless to do this check if we're not
+     * supposed to store the method in the global store.
+     *
+     * Note that while data->mcm->put() takes a property *definition*,
+     * while data->mcm->get() takes a property *query*, but we're using
+     * the property *definition* string as a property query here.
+     * This is possible because property definitions have a syntax that
+     * can also be used for a property query with equality tests.  We do
+     * this to look up already existing methods matching the implementation
+     * that we just for from the provider (via |algo|),
      */
-    if ((method = data->mcm->get(data->libctx, NULL, data->operation_id,
-                                 algo->algorithm_name,
-                                 algo->property_definition,
-                                 data->mcm_data)) != NULL)
+    if (global_store
+        && (method = data->mcm->get(data->libctx, NULL, data->operation_id,
+                                    algo->algorithm_name,
+                                    algo->property_definition,
+                                    data->mcm_data)) != NULL)
         goto end;
 
+    /*
+     * No pre-existing method in the global store, then we create it.
+     */
     if ((method = data->mcm->construct(algo->algorithm_name,
                                        algo->implementation, provider,
                                        data->mcm_data)) == NULL)
@@ -61,19 +71,16 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
      * of the passed method.
      */
 
-    if (data->force_store || !no_store) {
-        /*
-         * If we haven't been told not to store,
-         * add to the global store
-         */
-        data->mcm->put(data->libctx, NULL, method, data->operation_id,
-                       algo->algorithm_name,
-                       algo->property_definition, data->mcm_data);
+    if (global_store) {
+        /* If we haven't been told not to store, add to the global store */
+        (void)data->mcm->put(data->libctx, NULL, method, data->operation_id,
+                             algo->algorithm_name,
+                             algo->property_definition, data->mcm_data);
     }
 
-    data->mcm->put(data->libctx, data->store, method, data->operation_id,
-                   algo->algorithm_name, algo->property_definition,
-                   data->mcm_data);
+    (void)data->mcm->put(data->libctx, data->store, method, data->operation_id,
+                         algo->algorithm_name, algo->property_definition,
+                         data->mcm_data);
 
  end:
     /* refcnt-- because we're dropping the reference */

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -31,6 +31,19 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
     struct construct_data_st *data = cbdata;
     void *method = NULL;
 
+    /*
+     * Check to see if a method has already been constructed from this
+     * implementation.  Note that we use the property definition as a
+     * property query, which stresses that they MUST have compatible
+     * syntax, or else...  (in other words, it must always be possible
+     * to copy a property definition and paste that wherever a property
+     * is being queried.
+     */
+    if (data->mcm->get(data->libctx, NULL, data->operation_id,
+                       algo->algorithm_name, algo->property_definition,
+                       data->mcm_data) != NULL)
+        return;
+
     if ((method = data->mcm->construct(algo->algorithm_name,
                                        algo->implementation, provider,
                                        data->mcm_data)) == NULL)

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -132,10 +132,13 @@ static int put_method_in_store(OPENSSL_CTX *libctx, void *store,
         && (store = get_default_method_store(libctx)) == NULL)
         return 0;
 
-    if (methdata->refcnt_up_method(method)
-        && ossl_method_store_add(store, methid, propdef, method,
-                                 methdata->destruct_method))
-        return 1;
+    if (methdata->refcnt_up_method(method)) {
+        if (ossl_method_store_add(store, methid, propdef, method,
+                                  methdata->destruct_method))
+            return 1;
+        /* refcnt-- */
+        methdata->destruct_method(method);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Fixes #9561
