### PR TITLE
Fix trace init loop

### DIFF
--- a/crypto/include/internal/cryptlib_int.h
+++ b/crypto/include/internal/cryptlib_int.h
@@ -27,6 +27,5 @@ void ossl_ctx_thread_stop(void *arg);
 # define OPENSSL_INIT_ZLIB                   0x00010000L
 # define OPENSSL_INIT_BASE_ONLY              0x00040000L
 
-int ossl_trace_init(void);
 void ossl_trace_cleanup(void);
 void ossl_malloc_setup_failures(void);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -44,8 +44,7 @@ static CRYPTO_ONCE base = CRYPTO_ONCE_STATIC_INIT;
 static int base_inited = 0;
 DEFINE_RUN_ONCE_STATIC(ossl_init_base)
 {
-    if (ossl_trace_init() == 0)
-        return 0;
+    /* no need to init trace */
 
     OSSL_TRACE(INIT, "ossl_init_base: setting up stop handlers\n");
 #ifndef OPENSSL_NO_CRYPTO_MDEBUG


### PR DESCRIPTION
Adding automatic initialization of the CMP logging facility in PR #9107, which uses the trace API, it turned out that an endless init loop is entered when an init function that uses the trace API is added, using `RUN_ONCE`, to `OPENSSL_init_crypto()`.

I found that this is because `set_trace_data()` in trace.c dares to call `OPENSSL_init_crypto(0, NULL)` while it would be sufficient to make sure that the code in `ossl_trace_init()` is called once.
This PR does the respective fix, making sure that `ossl_trace_init()` is called once also in case  `OPENSSL_init_crypto()` is invoked beforehand.

When analyzing this issue I found in the doc of `OPENSSL_init_crypto()` that
> OPENSSL_init_crypto() MUST be called by application code prior to any other OpenSSL function calls.

which is not the case in `test/testutil/main.c`. 
At first I suspected that this might fix the above issue, but it does not. Still the test application should call the init function right away, which is achieved by the other commit in this PR.
