### PR TITLE
30-test_evp.t: make the tested configs depend on what's been built

### DIFF
--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -11,10 +11,17 @@ use strict;
 use warnings;
 
 use OpenSSL::Test qw(:DEFAULT data_file bldtop_dir srctop_file);
+use OpenSSL::Test::Utils;
 
 setup("test_evp");
 
-my @configs = qw( default-and-legacy.cnf fips.cnf );
+# Default config depends on if the legacy module is built or not
+my $defaultcnf = disabled('legacy') ? 'default.cnf' : 'default-and-legacy.cnf';
+
+my @configs = ( $defaultcnf );
+# Only add the FIPS config if the FIPS module has been built
+push @configs, 'fips.cnf' unless disabled('fips');
+
 my @files = qw( evpciph.txt evpdigest.txt );
 my @defltfiles = qw( evpencod.txt evpkdf.txt evppkey_kdf.txt evpmac.txt
     evppbe.txt evppkey.txt evppkey_ecc.txt evpcase.txt evpaessiv.txt
@@ -36,7 +43,7 @@ foreach (@configs) {
 #TODO(3.0): As more operations are converted to providers we can move more of
 #           these tests to the loop above
 
-$ENV{OPENSSL_CONF} = srctop_file("test", "default-and-legacy.cnf");
+$ENV{OPENSSL_CONF} = srctop_file("test", $defaultcnf);
 
 foreach my $f ( @defltfiles ) {
     ok(run(test(["evp_test", data_file("$f")])),


### PR DESCRIPTION
If the FIPS module hasn't been built, don't use test/fips.cnf, for example.

Fixes #9568
