### PR TITLE
Configurations/unit-Makefile.tmpl: Don't clean away dotted files

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -391,13 +391,13 @@ libclean:
 clean: libclean
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(MODULES) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
-	-$(RM) `find . -name .git -prune -o -name '*{- platform->depext() -}' -print`
-	-$(RM) `find . -name .git -prune -o -name '*{- platform->objext() -}' -print`
+	-$(RM) `find . -name '*{- platform->depext() -}' \! -name '.*' -print`
+	-$(RM) `find . -name '*{- platform->objext() -}' \! -name '.*' -print`
 	$(RM) core
 	$(RM) tags TAGS doc-nits
 	$(RM) -r test/test-runs
 	$(RM) openssl.pc libcrypto.pc libssl.pc
-	-$(RM) `find . -name .git -prune -o -type l -print`
+	-$(RM) `find . -type l \! -name '.*' -print`
 	$(RM) $(TARFILE)
 
 distclean: clean


### PR DESCRIPTION
A local 'make clean' did some sweeping removals of files execpt for
the .git directory.  This is a little too sweeping, as other dotted
files might be cleaned away if they happen to match the pattern that's
searched for.

An example is a symlink .dir-locals.el that would keep disappearing if
you build in the source tree and do a make clean...

So we change this to leave all dotted files alone.  Our builds do not
produce such files anyway, so this is a harmless (or rather, less
harmful) change.
