### PR TITLE
Access data after obtaining the lock not before.

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -49,8 +49,8 @@ static EX_CALLBACKS *get_and_lock(OPENSSL_CTX *ctx, int class_index)
          return NULL;
     }
 
-    ip = &global->ex_data[class_index];
     CRYPTO_THREAD_write_lock(global->ex_data_lock);
+    ip = &global->ex_data[class_index];
     return ip;
 }
 


### PR DESCRIPTION
It isn't completely clear that this constitutes a race condition, but it will
always be conservative to access the locked data after getting the lock.
