### PR TITLE
Cleanup cipher code

### DIFF
--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -314,6 +314,10 @@ OP_cipher_final(), OP_cipher_cipher(), OP_cipher_get_params(),
 OP_cipher_get_ctx_params() and OP_cipher_set_ctx_params() should return 1 for
 success or 0 on error.
 
+OP_cipher_gettable_params(), OP_cipher_gettable_ctx_params() and
+OP_cipher_settable_ctx_params() should return a constant B<OSSL_PARAM>
+array, or NULL if none is offered.
+
 =head1 SEE ALSO
 
 L<provider(7)>

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -98,7 +98,8 @@ OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_realloc, (void *addr, size_t num, const char *file, int line))
 #define OSSL_FUNC_CRYPTO_CLEAR_REALLOC        15
 OSSL_CORE_MAKE_FUNC(void *,
-        CRYPTO_clear_realloc, (void *addr, size_t old_num, size_t num, const char *file, int line))
+        CRYPTO_clear_realloc, (void *addr, size_t old_num, size_t num,
+                               const char *file, int line))
 #define OSSL_FUNC_CRYPTO_SECURE_MALLOC        16
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_secure_malloc, (size_t num, const char *file, int line))
@@ -110,7 +111,8 @@ OSSL_CORE_MAKE_FUNC(void,
         CRYPTO_secure_free, (void *ptr, const char *file, int line))
 #define OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE    19
 OSSL_CORE_MAKE_FUNC(void,
-        CRYPTO_secure_clear_free, (void *ptr, size_t num, const char *file, int line))
+        CRYPTO_secure_clear_free, (void *ptr, size_t num, const char *file,
+                                   int line))
 #define OSSL_FUNC_CRYPTO_SECURE_ALLOCATED     20
 OSSL_CORE_MAKE_FUNC(int,
         CRYPTO_secure_allocated, (const void *ptr))
@@ -141,9 +143,8 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,provider_get_reason_strings,
 # define OSSL_OP_MAC                                 3
 # define OSSL_OP_KEYMGMT                            10
 # define OSSL_OP_KEYEXCH                            11
-
 /* Highest known operation number */
-# define OSSL_OP__HIGHEST                            3
+# define OSSL_OP__HIGHEST                           11
 
 /* Digests */
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -134,9 +134,18 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ALGORITHM *,provider_query_operation,
 OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,provider_get_reason_strings,
                     (void *provctx))
 
-/* Digests */
+/* Operations */
 
 # define OSSL_OP_DIGEST                              1
+# define OSSL_OP_CIPHER                              2   /* Symmetric Ciphers */
+# define OSSL_OP_MAC                                 3
+# define OSSL_OP_KEYMGMT                            10
+# define OSSL_OP_KEYEXCH                            11
+
+/* Highest known operation number */
+# define OSSL_OP__HIGHEST                            3
+
+/* Digests */
 
 # define OSSL_FUNC_DIGEST_NEWCTX                     1
 # define OSSL_FUNC_DIGEST_INIT                       2
@@ -176,8 +185,6 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_digest_settable_ctx_params, (void))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_digest_gettable_ctx_params, (void))
 
 /* Symmetric Ciphers */
-
-# define OSSL_OP_CIPHER                              2
 
 # define OSSL_FUNC_CIPHER_NEWCTX                     1
 # define OSSL_FUNC_CIPHER_ENCRYPT_INIT               2
@@ -223,16 +230,11 @@ OSSL_CORE_MAKE_FUNC(int, OP_cipher_get_ctx_params, (void *cctx,
                                                     OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, OP_cipher_set_ctx_params, (void *cctx,
                                                     const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_params,
-                    (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_settable_ctx_params,
-                    (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_ctx_params,
-                    (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_params,     (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_settable_ctx_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_ctx_params, (void))
 
 /* MACs */
-
-# define OSSL_OP_MAC                                 3
 
 # define OSSL_FUNC_MAC_NEWCTX                        1
 # define OSSL_FUNC_MAC_DUPCTX                        2
@@ -240,12 +242,12 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_ctx_params,
 # define OSSL_FUNC_MAC_INIT                          4
 # define OSSL_FUNC_MAC_UPDATE                        5
 # define OSSL_FUNC_MAC_FINAL                         6
-# define OSSL_FUNC_MAC_GETTABLE_PARAMS               7
-# define OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS           8
-# define OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS           9
-# define OSSL_FUNC_MAC_GET_PARAMS                   10
-# define OSSL_FUNC_MAC_GET_CTX_PARAMS               11
-# define OSSL_FUNC_MAC_SET_CTX_PARAMS               12
+# define OSSL_FUNC_MAC_GET_PARAMS                    7
+# define OSSL_FUNC_MAC_GET_CTX_PARAMS                8
+# define OSSL_FUNC_MAC_SET_CTX_PARAMS                9
+# define OSSL_FUNC_MAC_GETTABLE_PARAMS              10
+# define OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS          11
+# define OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS          12
 
 OSSL_CORE_MAKE_FUNC(void *, OP_mac_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_mac_dupctx, (void *src))
@@ -286,8 +288,6 @@ OSSL_CORE_MAKE_FUNC(int, OP_mac_set_ctx_params,
  * - by loading an internal key, given a binary blob that forms an identity.
  *   THE CALLER MUST ENSURE THAT A CORRECT IDENTITY IS USED.
  */
-
-# define OSSL_OP_KEYMGMT                           10
 
 /* Key domain parameter creation and destruction */
 # define OSSL_FUNC_KEYMGMT_IMPORTDOMPARAMS          1
@@ -339,8 +339,6 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_exportkey_types, (void))
 
 /* Key Exchange */
 
-# define OSSL_OP_KEYEXCH                              11
-
 # define OSSL_FUNC_KEYEXCH_NEWCTX                      1
 # define OSSL_FUNC_KEYEXCH_INIT                        2
 # define OSSL_FUNC_KEYEXCH_DERIVE                      3
@@ -358,9 +356,6 @@ OSSL_CORE_MAKE_FUNC(void, OP_keyexch_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_params, (void *ctx,
                                                  const OSSL_PARAM params[]))
-
-/* Highest known operation number */
-# define OSSL_OP__HIGHEST                            3
 
 # ifdef __cplusplus
 }

--- a/providers/common/ciphers/aes.c
+++ b/providers/common/ciphers/aes.c
@@ -54,7 +54,7 @@ static int aes_einit(void *vctx, const unsigned char *key, size_t keylen,
     PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
 
     if (!PROV_AES_KEY_generic_init(ctx, iv, ivlen, 1)) {
-        /* ERR_raise( already called */
+        /* ERR_raise already called */
         return 0;
     }
     if (key != NULL) {
@@ -74,7 +74,7 @@ static int aes_dinit(void *vctx, const unsigned char *key, size_t keylen,
     PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
 
     if (!PROV_AES_KEY_generic_init(ctx, iv, ivlen, 0)) {
-        /* ERR_raise( already called */
+        /* ERR_raise already called */
         return 0;
     }
     if (key != NULL) {
@@ -136,7 +136,7 @@ static int aes_block_update(void *vctx, unsigned char *out, size_t *outl,
         inl -= nextblocks;
     }
     if (!trailingdata(ctx->buf, &ctx->bufsz, AES_BLOCK_SIZE, &in, &inl)) {
-        /* ERR_raise( already called */
+        /* ERR_raise already called */
         return 0;
     }
 
@@ -189,7 +189,7 @@ static int aes_block_final(void *vctx, unsigned char *out, size_t *outl,
     }
 
     if (ctx->pad && !unpadblock(ctx->buf, &ctx->bufsz, AES_BLOCK_SIZE)) {
-        /* ERR_raise( already called */
+        /* ERR_raise already called */
         return 0;
     }
 

--- a/providers/common/ciphers/aes.c
+++ b/providers/common/ciphers/aes.c
@@ -261,35 +261,97 @@ static void *aes_new_ctx(void *provctx, size_t mode, size_t kbits,
     return ctx;
 }
 
-int aes_get_params(OSSL_PARAM params[], int md, unsigned long flags,
-                   int kbits, int blkbits, int ivbits)
+static void aes_freectx(void *vctx)
 {
+    PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
+
+    OPENSSL_clear_free(ctx,  sizeof(*ctx));
+}
+
+static void *aes_dupctx(void *ctx)
+{
+    PROV_AES_KEY *in = (PROV_AES_KEY *)ctx;
+    PROV_AES_KEY *ret = OPENSSL_malloc(sizeof(*ret));
+
+    if (ret == NULL) {
+        PROVerr(PROV_F_AES_DUPCTX, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+    *ret = *in;
+
+    return ret;
+}
+
+static int aes_get_ctx_params(void *vctx, OSSL_PARAM params[])
+{
+    PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
     OSSL_PARAM *p;
 
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
-    if (p != NULL) {
-        if (!OSSL_PARAM_set_int(p, md))
-            return 0;
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
+    if (p != NULL && !OSSL_PARAM_set_int(p, AES_BLOCK_SIZE)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
     }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_FLAGS);
-    if (p != NULL) {
-        if (!OSSL_PARAM_set_ulong(p, flags))
-            return 0;
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_PADDING);
+    if (p != NULL && !OSSL_PARAM_set_int(p, ctx->pad)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
+    if (p != NULL
+        && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, AES_BLOCK_SIZE)
+        && !OSSL_PARAM_set_octet_string(p, &ctx->iv, AES_BLOCK_SIZE)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_NUM);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->num)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
-    if (p != NULL) {
-        if (!OSSL_PARAM_set_int(p, kbits / 8))
-            return 0;
+    if (p != NULL && !OSSL_PARAM_set_int(p, ctx->keylen)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
     }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_BLOCK_SIZE);
+
+    return 1;
+}
+
+static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_PADDING);
     if (p != NULL) {
-        if (!OSSL_PARAM_set_int(p, blkbits / 8))
+        int pad;
+
+        if (!OSSL_PARAM_get_int(p, &pad)) {
+            PROVerr(0, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
+        }
+        ctx->pad = pad ? 1 : 0;
     }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
+    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_NUM);
     if (p != NULL) {
-        if (!OSSL_PARAM_set_int(p, ivbits / 8))
+        int num;
+
+        if (!OSSL_PARAM_get_int(p, &num)) {
+            PROVerr(0, PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
+        }
+        ctx->num = num;
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_KEYLEN);
+    if (p != NULL) {
+        int keylen;
+
+        if (!OSSL_PARAM_get_int(p, &keylen)) {
+            PROVerr(0, PROV_R_FAILED_TO_GET_PARAMETER);
+            return 0;
+        }
+        ctx->keylen = keylen;
     }
     return 1;
 }
@@ -298,8 +360,8 @@ int aes_get_params(OSSL_PARAM params[], int md, unsigned long flags,
     static OSSL_OP_cipher_get_params_fn aes_##kbits##_##lcmode##_get_params;   \
     static int aes_##kbits##_##lcmode##_get_params(OSSL_PARAM params[])        \
     {                                                                          \
-        return aes_get_params(params, EVP_CIPH_##UCMODE##_MODE, flags, kbits,  \
-                              blkbits, ivbits);                                \
+        return cipher_default_get_params(params, EVP_CIPH_##UCMODE##_MODE,     \
+                                         flags, kbits, blkbits, ivbits);       \
     }                                                                          \
     static OSSL_OP_cipher_newctx_fn aes_##kbits##_##lcmode##_newctx;           \
     static void *aes_##kbits##_##lcmode##_newctx(void *provctx)                \
@@ -339,166 +401,59 @@ IMPLEMENT_cipher(ctr, CTR, 0, 256, 8, 128)
 IMPLEMENT_cipher(ctr, CTR, 0, 192, 8, 128)
 IMPLEMENT_cipher(ctr, CTR, 0, 128, 8, 128)
 
-static void aes_freectx(void *vctx)
-{
-    PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
 
-    OPENSSL_clear_free(ctx,  sizeof(*ctx));
-}
-
-static void *aes_dupctx(void *ctx)
-{
-    PROV_AES_KEY *in = (PROV_AES_KEY *)ctx;
-    PROV_AES_KEY *ret = OPENSSL_malloc(sizeof(*ret));
-
-    if (ret == NULL) {
-        PROVerr(PROV_F_AES_DUPCTX, ERR_R_MALLOC_FAILURE);
-        return NULL;
-    }
-    *ret = *in;
-
-    return ret;
-}
-
-static int aes_get_ctx_params(void *vctx, OSSL_PARAM params[])
-{
-    PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
-    if (p != NULL) {
-        if (!OSSL_PARAM_set_int(p, AES_BLOCK_SIZE))
-            return 0;
-    }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_PADDING);
-    if (p != NULL && !OSSL_PARAM_set_int(p, ctx->pad)) {
-        PROVerr(PROV_F_AES_GET_CTX_PARAMS, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
-    }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
-    if (p != NULL
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, AES_BLOCK_SIZE)
-        && !OSSL_PARAM_set_octet_string(p, &ctx->iv, AES_BLOCK_SIZE)) {
-        PROVerr(PROV_F_AES_GET_CTX_PARAMS,
-                PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
-    }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_NUM);
-    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->num)) {
-        PROVerr(PROV_F_AES_GET_CTX_PARAMS,
-                PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
-    }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
-    if (p != NULL && !OSSL_PARAM_set_int(p, ctx->keylen)) {
-        PROVerr(PROV_F_AES_GET_CTX_PARAMS,
-                PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
-    }
-
-    return 1;
-}
-
-static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
-{
-    PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
-    const OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_PADDING);
-    if (p != NULL) {
-        int pad;
-
-        if (!OSSL_PARAM_get_int(p, &pad)) {
-            PROVerr(PROV_F_AES_SET_CTX_PARAMS,
-                    PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        ctx->pad = pad ? 1 : 0;
-    }
-    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_NUM);
-    if (p != NULL) {
-        int num;
-
-        if (!OSSL_PARAM_get_int(p, &num)) {
-            PROVerr(PROV_F_AES_SET_CTX_PARAMS,
-                    PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        ctx->num = num;
-    }
-    p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_KEYLEN);
-    if (p != NULL) {
-        int keylen;
-
-        if (!OSSL_PARAM_get_int(p, &keylen)) {
-            PROVerr(PROV_F_AES_SET_CTX_PARAMS,
-                    PROV_R_FAILED_TO_GET_PARAMETER);
-            return 0;
-        }
-        ctx->keylen = keylen;
-    }
-    return 1;
-}
-
-#define IMPLEMENT_block_funcs(mode, kbits) \
-    const OSSL_DISPATCH aes##kbits##mode##_functions[] = { \
-        { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))aes_##kbits##_##mode##_newctx }, \
-        { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))aes_einit }, \
-        { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))aes_dinit }, \
-        { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))aes_block_update }, \
-        { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))aes_block_final }, \
-        { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))aes_cipher }, \
-        { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))aes_freectx }, \
-        { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))aes_dupctx }, \
-        { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void))aes_##kbits##_##mode##_get_params }, \
-        { OSSL_FUNC_CIPHER_GET_CTX_PARAMS, (void (*)(void))aes_get_ctx_params }, \
-        { OSSL_FUNC_CIPHER_SET_CTX_PARAMS, (void (*)(void))aes_set_ctx_params }, \
-        { 0, NULL } \
-    };
-
-#define IMPLEMENT_stream_funcs(mode, kbits) \
-    const OSSL_DISPATCH aes##kbits##mode##_functions[] = { \
-        { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))aes_##kbits##_##mode##_newctx }, \
-        { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))aes_einit }, \
-        { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))aes_dinit }, \
-        { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))aes_stream_update }, \
-        { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))aes_stream_final }, \
-        { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))aes_cipher }, \
-        { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))aes_freectx }, \
-        { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))aes_dupctx }, \
-        { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void))aes_##kbits##_##mode##_get_params }, \
-        { OSSL_FUNC_CIPHER_GET_CTX_PARAMS, (void (*)(void))aes_get_ctx_params }, \
-        { OSSL_FUNC_CIPHER_SET_CTX_PARAMS, (void (*)(void))aes_set_ctx_params }, \
-        { 0, NULL } \
-    };
+#define IMPLEMENT_funcs(mode, kbits, type)                                     \
+const OSSL_DISPATCH aes##kbits##mode##_functions[] = {                         \
+    { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))aes_##kbits##_##mode##_newctx },\
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))aes_einit },              \
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))aes_dinit },              \
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))aes_##type##_update },          \
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))aes_##type##_final },            \
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))aes_cipher },                   \
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))aes_freectx },                 \
+    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))aes_dupctx },                   \
+    { OSSL_FUNC_CIPHER_GET_PARAMS,                                             \
+      (void (*)(void))aes_##kbits##_##mode##_get_params },                     \
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,                                         \
+      (void (*)(void))aes_get_ctx_params },                                    \
+    { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,                                         \
+      (void (*)(void))aes_set_ctx_params },                                    \
+    { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,                                        \
+      (void (*)(void))cipher_default_gettable_params },                        \
+    { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,                                    \
+      (void (*)(void))cipher_default_gettable_ctx_params },                    \
+    { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
+      (void (*)(void))cipher_default_settable_ctx_params },                    \
+    { 0, NULL }                                                                \
+};
 
 /* ECB */
-IMPLEMENT_block_funcs(ecb, 256)
-IMPLEMENT_block_funcs(ecb, 192)
-IMPLEMENT_block_funcs(ecb, 128)
+IMPLEMENT_funcs(ecb, 256, block)
+IMPLEMENT_funcs(ecb, 192, block)
+IMPLEMENT_funcs(ecb, 128, block)
 
 /* CBC */
-IMPLEMENT_block_funcs(cbc, 256)
-IMPLEMENT_block_funcs(cbc, 192)
-IMPLEMENT_block_funcs(cbc, 128)
+IMPLEMENT_funcs(cbc, 256, block)
+IMPLEMENT_funcs(cbc, 192, block)
+IMPLEMENT_funcs(cbc, 128, block)
 
 /* OFB */
-IMPLEMENT_stream_funcs(ofb, 256)
-IMPLEMENT_stream_funcs(ofb, 192)
-IMPLEMENT_stream_funcs(ofb, 128)
+IMPLEMENT_funcs(ofb, 256, stream)
+IMPLEMENT_funcs(ofb, 192, stream)
+IMPLEMENT_funcs(ofb, 128, stream)
 
 /* CFB */
-IMPLEMENT_stream_funcs(cfb, 256)
-IMPLEMENT_stream_funcs(cfb, 192)
-IMPLEMENT_stream_funcs(cfb, 128)
-IMPLEMENT_stream_funcs(cfb1, 256)
-IMPLEMENT_stream_funcs(cfb1, 192)
-IMPLEMENT_stream_funcs(cfb1, 128)
-IMPLEMENT_stream_funcs(cfb8, 256)
-IMPLEMENT_stream_funcs(cfb8, 192)
-IMPLEMENT_stream_funcs(cfb8, 128)
+IMPLEMENT_funcs(cfb, 256, stream)
+IMPLEMENT_funcs(cfb, 192, stream)
+IMPLEMENT_funcs(cfb, 128, stream)
+IMPLEMENT_funcs(cfb1, 256, stream)
+IMPLEMENT_funcs(cfb1, 192, stream)
+IMPLEMENT_funcs(cfb1, 128, stream)
+IMPLEMENT_funcs(cfb8, 256, stream)
+IMPLEMENT_funcs(cfb8, 192, stream)
+IMPLEMENT_funcs(cfb8, 128, stream)
 
 /* CTR */
-IMPLEMENT_stream_funcs(ctr, 256)
-IMPLEMENT_stream_funcs(ctr, 192)
-IMPLEMENT_stream_funcs(ctr, 128)
+IMPLEMENT_funcs(ctr, 256, stream)
+IMPLEMENT_funcs(ctr, 192, stream)
+IMPLEMENT_funcs(ctr, 128, stream)

--- a/providers/common/ciphers/aes_basic.c
+++ b/providers/common/ciphers/aes_basic.c
@@ -48,7 +48,7 @@ static int aesni_init_key(PROV_AES_KEY *dat, const unsigned char *key,
     }
 
     if (ret < 0) {
-        PROVerr(PROV_F_AESNI_INIT_KEY, PROV_R_AES_KEY_SETUP_FAILED);
+        ERR_raise(ERR_LIB_PROV, PROV_R_AES_KEY_SETUP_FAILED);
         return 0;
     }
 
@@ -169,7 +169,7 @@ static int aes_t4_init_key(PROV_AES_KEY *dat, const unsigned char *key,
     }
 
     if (ret < 0) {
-        PROVerr(PROV_F_AES_T4_INIT_KEY, PROV_R_AES_KEY_SETUP_FAILED);
+        ERR_raise(ERR_LIB_PROV, PROV_R_AES_KEY_SETUP_FAILED);
         return 0;
     }
 
@@ -509,7 +509,7 @@ static int aes_init_key(PROV_AES_KEY *dat, const unsigned char *key,
     }
 
     if (ret < 0) {
-        PROVerr(PROV_F_AES_INIT_KEY, PROV_R_AES_KEY_SETUP_FAILED);
+        ERR_raise(ERR_LIB_PROV, PROV_R_AES_KEY_SETUP_FAILED);
         return 0;
     }
 

--- a/providers/common/ciphers/block.c
+++ b/providers/common/ciphers/block.c
@@ -67,7 +67,7 @@ int trailingdata(unsigned char *buf, size_t *buflen, size_t blocksize,
         return 1;
 
     if (*buflen + *inlen > blocksize) {
-        PROVerr(PROV_F_TRAILINGDATA, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
@@ -94,7 +94,7 @@ int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
     size_t len = *buflen;
 
     if(len != blocksize) {
-        PROVerr(PROV_F_UNPADBLOCK, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
@@ -104,12 +104,12 @@ int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
      */
     pad = buf[blocksize - 1];
     if (pad == 0 || pad > blocksize) {
-        PROVerr(PROV_F_UNPADBLOCK, PROV_R_BAD_DECRYPT);
+        ERR_raise(ERR_LIB_PROV, PROV_R_BAD_DECRYPT);
         return 0;
     }
     for (i = 0; i < pad; i++) {
         if (buf[--len] != pad) {
-            PROVerr(PROV_F_UNPADBLOCK, PROV_R_BAD_DECRYPT);
+            ERR_raise(ERR_LIB_PROV, PROV_R_BAD_DECRYPT);
             return 0;
         }
     }

--- a/providers/common/ciphers/build.info
+++ b/providers/common/ciphers/build.info
@@ -1,5 +1,5 @@
 LIBS=../../../libcrypto
-$COMMON=block.c aes.c aes_basic.c gcm.c gcm_hw.c
+$COMMON=block.c aes.c aes_basic.c gcm.c gcm_hw.c ciphers_common.c
 
 SOURCE[../../../libcrypto]=$COMMON
 INCLUDE[../../../libcrypto]=. ../../../crypto

--- a/providers/common/ciphers/ciphers_common.c
+++ b/providers/common/ciphers/ciphers_common.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include "ciphers_locl.h"
+#include "internal/provider_algs.h"
+#include "internal/providercommonerr.h"
+
+/*-
+ * Default cipher functions for OSSL_PARAM gettables and settables
+ */
+static const OSSL_PARAM cipher_known_gettable_params[] = {
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_MODE, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_IVLEN, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_BLOCK_SIZE, NULL),
+    OSSL_PARAM_END
+};
+const OSSL_PARAM *cipher_default_gettable_params(void)
+{
+    return cipher_known_gettable_params;
+}
+
+int cipher_default_get_params(OSSL_PARAM params[], int md, unsigned long flags,
+                              int kbits, int blkbits, int ivbits)
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
+    if (p != NULL && !OSSL_PARAM_set_int(p, md)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_FLAGS);
+    if (p != NULL && !OSSL_PARAM_set_ulong(p, flags)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
+    if (p != NULL && !OSSL_PARAM_set_int(p, kbits / 8)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_BLOCK_SIZE);
+    if (p != NULL && !OSSL_PARAM_set_int(p, blkbits / 8)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
+    if (p != NULL && !OSSL_PARAM_set_int(p, ivbits / 8)) {
+        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    return 1;
+}
+
+static const OSSL_PARAM cipher_known_gettable_ctx_params[] = {
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_IVLEN, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_PADDING, NULL),
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_NUM, NULL),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_IV, NULL, 0),
+    OSSL_PARAM_END
+};
+const OSSL_PARAM *cipher_default_gettable_ctx_params(void)
+{
+    return cipher_known_gettable_ctx_params;
+}
+
+static const OSSL_PARAM cipher_known_settable_ctx_params[] = {
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_PADDING, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_NUM, NULL),
+    OSSL_PARAM_END
+};
+const OSSL_PARAM *cipher_default_settable_ctx_params(void)
+{
+    return cipher_known_settable_ctx_params;
+}
+
+/*-
+ * AEAD cipher functions for OSSL_PARAM gettables and settables
+ */
+static const OSSL_PARAM cipher_aead_known_gettable_ctx_params[] = {
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_IVLEN, NULL),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_IV, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, NULL),
+    OSSL_PARAM_END
+};
+const OSSL_PARAM *cipher_aead_gettable_ctx_params(void)
+{
+    return cipher_aead_known_gettable_ctx_params;
+}
+
+static const OSSL_PARAM cipher_aead_known_settable_ctx_params[] = {
+    OSSL_PARAM_int(OSSL_CIPHER_PARAM_KEYLEN, NULL),
+    OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_AEAD_IVLEN, NULL),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD, NULL, 0),
+    OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_IV_FIXED, NULL, 0),
+    OSSL_PARAM_END
+};
+const OSSL_PARAM *cipher_aead_settable_ctx_params(void)
+{
+    return cipher_aead_known_settable_ctx_params;
+}

--- a/providers/common/ciphers/ciphers_common.c
+++ b/providers/common/ciphers/ciphers_common.c
@@ -35,27 +35,27 @@ int cipher_default_get_params(OSSL_PARAM params[], int md, unsigned long flags,
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_MODE);
     if (p != NULL && !OSSL_PARAM_set_int(p, md)) {
-        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_FLAGS);
     if (p != NULL && !OSSL_PARAM_set_ulong(p, flags)) {
-        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
     if (p != NULL && !OSSL_PARAM_set_int(p, kbits / 8)) {
-        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_BLOCK_SIZE);
     if (p != NULL && !OSSL_PARAM_set_int(p, blkbits / 8)) {
-        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
     if (p != NULL && !OSSL_PARAM_set_int(p, ivbits / 8)) {
-        PROVerr(0, PROV_R_FAILED_TO_SET_PARAMETER);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     return 1;

--- a/providers/common/ciphers/ciphers_locl.h
+++ b/providers/common/ciphers/ciphers_locl.h
@@ -10,6 +10,7 @@
 #include <openssl/opensslconf.h>
 #include <openssl/aes.h>
 #include <openssl/params.h>
+#include <openssl/core_numbers.h>
 #include "internal/cryptlib.h"
 #include "internal/modes_int.h"
 
@@ -144,5 +145,13 @@ int trailingdata(unsigned char *buf, size_t *buflen, size_t blocksize,
                  const unsigned char **in, size_t *inlen);
 void padblock(unsigned char *buf, size_t *buflen, size_t blocksize);
 int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize);
-int aes_get_params(OSSL_PARAM params[], int md, unsigned long flags,
-                   int kbits, int blkbits, int ivbits);
+
+OSSL_OP_cipher_gettable_params_fn     cipher_default_gettable_params;
+OSSL_OP_cipher_gettable_ctx_params_fn cipher_default_gettable_ctx_params;
+OSSL_OP_cipher_settable_ctx_params_fn cipher_default_settable_ctx_params;
+OSSL_OP_cipher_gettable_ctx_params_fn cipher_aead_gettable_ctx_params;
+OSSL_OP_cipher_settable_ctx_params_fn cipher_aead_settable_ctx_params;
+
+int cipher_default_get_params(OSSL_PARAM params[], int md, unsigned long flags,
+                              int kbits, int blkbits, int ivbits);
+

--- a/providers/common/ciphers/gcm.c
+++ b/providers/common/ciphers/gcm.c
@@ -517,8 +517,8 @@ err:
     static OSSL_OP_cipher_get_params_fn alg##_##kbits##_##lcmode##_get_params; \
     static int alg##_##kbits##_##lcmode##_get_params(OSSL_PARAM params[])      \
     {                                                                          \
-        return aes_get_params(params, EVP_CIPH_##UCMODE##_MODE, flags,         \
-                               kbits, blkbits, ivbits);                        \
+        return cipher_default_get_params(params, EVP_CIPH_##UCMODE##_MODE,     \
+                                         flags, kbits, blkbits, ivbits);       \
     }                                                                          \
     static OSSL_OP_cipher_newctx_fn alg##kbits##gcm_newctx;                    \
     static void *alg##kbits##gcm_newctx(void *provctx)                         \
@@ -539,6 +539,12 @@ err:
             (void (*)(void))gcm_get_ctx_params },                              \
         { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,                                     \
             (void (*)(void))gcm_set_ctx_params },                              \
+        { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,                                    \
+                (void (*)(void))cipher_default_gettable_params },              \
+        { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,                                \
+                (void (*)(void))cipher_aead_gettable_ctx_params },             \
+        { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                \
+                (void (*)(void))cipher_aead_settable_ctx_params },             \
         { 0, NULL }                                                            \
     }
 


### PR DESCRIPTION

Add test to evp_test_extra for ciphers (that is similiar to the digest_fetch) that also calls these new methods.
Move some of the aes and gcm methods that can be shared with other ciphers into ciphers_common.c

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
