### PR TITLE
Support parsing of SM2 ID in hexadecimal

### DIFF
--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -341,6 +341,13 @@ This sets the ID string used in SM2 sign or verify operations. While verifying
 an SM2 signature, the ID string must be the same one used when signing the data.
 Otherwise the verification will fail.
 
+=item B<sm2_hex_id:hex_string>
+
+This sets the ID string used in SM2 sign or verify operations. While verifying
+an SM2 signature, the ID string must be the same one used when signing the data.
+Otherwise the verification will fail. The ID string provided with this option
+should be a valid hexadecimal value.
+
 =back
 
 =head1 EXAMPLES

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1444,7 +1444,6 @@ void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
 # define EVP_PKEY_CTX_set1_id(ctx, id, id_len) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
                                 EVP_PKEY_CTRL_SET1_ID, (int)id_len, (void*)(id))
-
 # define EVP_PKEY_CTX_get1_id(ctx, id) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
                                 EVP_PKEY_CTRL_GET1_ID, 0, (void*)(id))

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -59,10 +59,10 @@ subtest "generating certificate requests" => sub {
 };
 
 subtest "generating SM2 certificate requests" => sub {
-    plan tests => 2;
+    plan tests => 4;
 
     SKIP: {
-        skip "SM2 is not supported by this OpenSSL build", 2
+        skip "SM2 is not supported by this OpenSSL build", 4
         if disabled("sm2");
         ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
                     "-new", "-key", srctop_file("test", "certs", "sm2.key"),
@@ -73,6 +73,17 @@ subtest "generating SM2 certificate requests" => sub {
         ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
                     "-verify", "-in", "testreq.pem", "-noout",
                     "-sm2-id", "1234567812345678", "-sm3"])),
+           "Verifying signature on SM2 certificate request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-key", srctop_file("test", "certs", "sm2.key"),
+                    "-sigopt", "sm2_hex_id:DEADBEEF",
+                    "-out", "testreq.pem", "-sm3"])),
+           "Generating SM2 certificate request with hex id");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout",
+                    "-sm2-hex-id", "DEADBEEF", "-sm3"])),
            "Verifying signature on SM2 certificate request");
     }
 };


### PR DESCRIPTION
The current EVP_PEKY_ctrl for SM2 has no capability of parsing an ID input in hexadecimal.

The newly added ctrl string is called: sm2_hex_id

Test cases and documentation are updated.

Another alternative of implementation is to reuse the 'EVP_PKEY_CTRL_SET1_ID' macro and try to parse the id string 'intelligently' inside one 'switch-case' block...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
