### PR TITLE
Fix SCA vulnerability when using PVK and MSBLOB key formats

### DIFF
--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -274,6 +274,9 @@ static EVP_PKEY *b2i_dss(const unsigned char **in,
         if (!read_lebn(&p, 20, &priv_key))
             goto memerr;
 
+        /* Set constant time flag before public key calculation */
+        BN_set_flags(priv_key, BN_FLG_CONSTTIME);
+
         /* Calculate public key */
         pub_key = BN_new();
         if (pub_key == NULL)


### PR DESCRIPTION
This PR addresses a side-channel vulnerability present each time PVK and MSBLOB key formats are loaded into OpenSSL.

### Details

The `BN_FLG_CONSTTIME` is not set before computing the public key each time PVK and MSBLOB key formats are used, leading to the default variable-time modular exponentiation.
A malicious attacker can perform a data cache-timing attack to recover the multipliers used during
the exponentiation and from there, recover the private key.

This issue affects all versions of OpenSSL.

### Acknowledgement

This issue was discovered and reported by the NISEC group at Tampere University, Finland.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

