### PR TITLE
Fix context locking

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -238,6 +238,7 @@ void *openssl_ctx_get_data(OPENSSL_CTX *ctx, int index,
 
     if (!openssl_ctx_init_index(ctx, index, meth)) {
         CRYPTO_THREAD_unlock(ctx->lock);
+        CRYPTO_THREAD_unlock(ctx->index_locks[index]);
         return NULL;
     }
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -607,6 +607,8 @@ static void *evp_md_from_dispatch(const char *name, const OSSL_DISPATCH *fns,
      * FIPS module note: since internal fetches will be entirely
      * provider based, we know that none of its code depends on legacy
      * NIDs or any functionality that use them.
+     *
+     * TODO(3.x) get rid of the need for legacy NIDs
      */
     md->type = OBJ_sn2nid(name);
 #endif

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -602,6 +602,15 @@ static void *evp_md_from_dispatch(const char *name, const OSSL_DISPATCH *fns,
         return NULL;
     }
 
+#ifndef FIPS_MODE
+    /*
+     * FIPS module note: since internal fetches will be entirely
+     * provider based, we know that none of its code depends on legacy
+     * NIDs or any functionality that use them.
+     */
+    md->type = OBJ_sn2nid(name);
+#endif
+
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
         case OSSL_FUNC_DIGEST_NEWCTX:
@@ -693,18 +702,6 @@ EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
         evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
                           evp_md_from_dispatch, evp_md_up_ref,
                           evp_md_free);
-
-#ifndef FIPS_MODE
-    /* TODO(3.x) get rid of the need for legacy NIDs */
-    if (md != NULL) {
-        /*
-         * FIPS module note: since internal fetches will be entirely
-         * provider based, we know that none of its code depends on legacy
-         * NIDs or any functionality that use them.
-         */
-        md->type = OBJ_sn2nid(algorithm);
-    }
-#endif
 
     return md;
 }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1150,6 +1150,8 @@ static void *evp_cipher_from_dispatch(const char *name,
      * FIPS module note: since internal fetches will be entirely
      * provider based, we know that none of its code depends on legacy
      * NIDs or any functionality that use them.
+     *
+     * TODO(3.x) get rid of the need for legacy NIDs
      */
     cipher->nid = OBJ_sn2nid(name);
 #endif

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -83,12 +83,6 @@ int ossl_property_unlock(OSSL_METHOD_STORE *p)
     return p != 0 ? CRYPTO_THREAD_unlock(p->lock) : 0;
 }
 
-static openssl_ctx_run_once_fn do_method_store_init;
-int do_method_store_init(OPENSSL_CTX *ctx)
-{
-    return ossl_property_parse_init(ctx);
-}
-
 static unsigned long query_hash(const QUERY *a)
 {
     return OPENSSL_LH_strhash(a->query);
@@ -130,11 +124,6 @@ static void alg_cleanup(ossl_uintmax_t idx, ALGORITHM *a)
 OSSL_METHOD_STORE *ossl_method_store_new(OPENSSL_CTX *ctx)
 {
     OSSL_METHOD_STORE *res;
-
-    if (!openssl_ctx_run_once(ctx,
-                              OPENSSL_CTX_METHOD_STORE_RUN_ONCE_INDEX,
-                              do_method_store_init))
-        return NULL;
 
     res = OPENSSL_zalloc(sizeof(*res));
     if (res != NULL) {

--- a/crypto/property/property_lcl.h
+++ b/crypto/property/property_lcl.h
@@ -21,7 +21,6 @@ OSSL_PROPERTY_IDX ossl_property_value(OPENSSL_CTX *ctx, const char *s,
                                       int create);
 
 /* Property list functions */
-int ossl_property_parse_init(OPENSSL_CTX *ctx);
 void ossl_property_free(OSSL_PROPERTY_LIST *p);
 int ossl_property_has_optional(const OSSL_PROPERTY_LIST *query);
 int ossl_property_match_count(const OSSL_PROPERTY_LIST *query,

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -15,6 +15,9 @@
 
 typedef struct ossl_method_store_st OSSL_METHOD_STORE;
 
+/* Initialisation */
+int ossl_property_parse_init(OPENSSL_CTX *ctx);
+
 /* Implementation store functions */
 OSSL_METHOD_STORE *ossl_method_store_new(OPENSSL_CTX *ctx);
 void ossl_method_store_free(OSSL_METHOD_STORE *store);


### PR DESCRIPTION
Some parts of OPENSSL_CTX intialisation can get quite complex (e.g. RAND).
This can lead to complex interactions where different parts of the library
try to initialise while other parts are still initialising. This can lead
to deadlocks because both parts want to obtain the init lock.

We separate out the init lock so that it is only used to manage the
dynamic list of indexes. Each part of the library gets its own
initialisation lock.

Fixes #9454

I also simplified properties initialisation because there were some thread santizer issues cropping up in this area too. Finally I fixed some data races in EVP_CIPHER_fetch and EVP_MD_fetch.

There are still some thread sanitizer issues coming from evp_test that I haven't looked at yet, but I believe they are unrelated issues to those addressed here.