### PR TITLE
Rename provider and core get_param_types functions

### DIFF
--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -47,9 +47,9 @@ int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name)
     return available;
 }
 
-const OSSL_PARAM *OSSL_PROVIDER_gettable_types(const OSSL_PROVIDER *prov)
+const OSSL_PARAM *OSSL_PROVIDER_gettable_params(const OSSL_PROVIDER *prov)
 {
-    return ossl_provider_gettable_types(prov);
+    return ossl_provider_gettable_params(prov);
 }
 
 int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -47,9 +47,9 @@ int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name)
     return available;
 }
 
-const OSSL_PARAM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov)
+const OSSL_PARAM *OSSL_PROVIDER_gettable_types(const OSSL_PROVIDER *prov)
 {
-    return ossl_provider_get_param_types(prov);
+    return ossl_provider_gettable_types(prov);
 }
 
 int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -62,7 +62,7 @@ struct ossl_provider_st {
 
     /* Provider side functions */
     OSSL_provider_teardown_fn *teardown;
-    OSSL_provider_get_param_types_fn *get_param_types;
+    OSSL_provider_gettable_types_fn *gettable_types;
     OSSL_provider_get_params_fn *get_params;
     OSSL_provider_query_operation_fn *query_operation;
 
@@ -464,9 +464,9 @@ static int provider_activate(OSSL_PROVIDER *prov)
             prov->teardown =
                 OSSL_get_provider_teardown(provider_dispatch);
             break;
-        case OSSL_FUNC_PROVIDER_GET_PARAM_TYPES:
-            prov->get_param_types =
-                OSSL_get_provider_get_param_types(provider_dispatch);
+        case OSSL_FUNC_PROVIDER_GETTABLE_TYPES:
+            prov->gettable_types =
+                OSSL_get_provider_gettable_types(provider_dispatch);
             break;
         case OSSL_FUNC_PROVIDER_GET_PARAMS:
             prov->get_params =
@@ -713,10 +713,10 @@ void ossl_provider_teardown(const OSSL_PROVIDER *prov)
         prov->teardown(prov->provctx);
 }
 
-const OSSL_PARAM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov)
+const OSSL_PARAM *ossl_provider_gettable_types(const OSSL_PROVIDER *prov)
 {
-    return prov->get_param_types == NULL
-        ? NULL : prov->get_param_types(prov->provctx);
+    return prov->gettable_types == NULL
+        ? NULL : prov->gettable_types(prov->provctx);
 }
 
 int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
@@ -756,7 +756,7 @@ static const OSSL_PARAM param_types[] = {
  * This ensures that the compiler will complain if they aren't defined
  * with the correct signature.
  */
-static OSSL_core_get_param_types_fn core_get_param_types;
+static OSSL_core_gettable_types_fn core_gettable_types;
 static OSSL_core_get_params_fn core_get_params;
 static OSSL_core_thread_start_fn core_thread_start;
 static OSSL_core_get_library_context_fn core_get_libctx;
@@ -766,7 +766,7 @@ static OSSL_core_set_error_debug_fn core_set_error_debug;
 static OSSL_core_vset_error_fn core_vset_error;
 #endif
 
-static const OSSL_PARAM *core_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *core_gettable_types(const OSSL_PROVIDER *prov)
 {
     return param_types;
 }
@@ -855,7 +855,7 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
  * functions.
  */
 static const OSSL_DISPATCH core_dispatch_[] = {
-    { OSSL_FUNC_CORE_GET_PARAM_TYPES, (void (*)(void))core_get_param_types },
+    { OSSL_FUNC_CORE_GETTABLE_TYPES, (void (*)(void))core_gettable_types },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
     { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
     { OSSL_FUNC_CORE_THREAD_START, (void (*)(void))core_thread_start },

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -464,7 +464,7 @@ static int provider_activate(OSSL_PROVIDER *prov)
             prov->teardown =
                 OSSL_get_provider_teardown(provider_dispatch);
             break;
-        case OSSL_FUNC_PROVIDER_GETTABLE_TYPES:
+        case OSSL_FUNC_PROVIDER_GETTABLE_PARAMS:
             prov->gettable_params =
                 OSSL_get_provider_gettable_params(provider_dispatch);
             break;
@@ -855,7 +855,7 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
  * functions.
  */
 static const OSSL_DISPATCH core_dispatch_[] = {
-    { OSSL_FUNC_CORE_GETTABLE_TYPES, (void (*)(void))core_gettable_params },
+    { OSSL_FUNC_CORE_GETTABLE_PARAMS, (void (*)(void))core_gettable_params },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
     { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
     { OSSL_FUNC_CORE_THREAD_START, (void (*)(void))core_thread_start },

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -62,7 +62,7 @@ struct ossl_provider_st {
 
     /* Provider side functions */
     OSSL_provider_teardown_fn *teardown;
-    OSSL_provider_gettable_types_fn *gettable_types;
+    OSSL_provider_gettable_params_fn *gettable_params;
     OSSL_provider_get_params_fn *get_params;
     OSSL_provider_query_operation_fn *query_operation;
 
@@ -465,8 +465,8 @@ static int provider_activate(OSSL_PROVIDER *prov)
                 OSSL_get_provider_teardown(provider_dispatch);
             break;
         case OSSL_FUNC_PROVIDER_GETTABLE_TYPES:
-            prov->gettable_types =
-                OSSL_get_provider_gettable_types(provider_dispatch);
+            prov->gettable_params =
+                OSSL_get_provider_gettable_params(provider_dispatch);
             break;
         case OSSL_FUNC_PROVIDER_GET_PARAMS:
             prov->get_params =
@@ -713,10 +713,10 @@ void ossl_provider_teardown(const OSSL_PROVIDER *prov)
         prov->teardown(prov->provctx);
 }
 
-const OSSL_PARAM *ossl_provider_gettable_types(const OSSL_PROVIDER *prov)
+const OSSL_PARAM *ossl_provider_gettable_params(const OSSL_PROVIDER *prov)
 {
-    return prov->gettable_types == NULL
-        ? NULL : prov->gettable_types(prov->provctx);
+    return prov->gettable_params == NULL
+        ? NULL : prov->gettable_params(prov->provctx);
 }
 
 int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
@@ -756,7 +756,7 @@ static const OSSL_PARAM param_types[] = {
  * This ensures that the compiler will complain if they aren't defined
  * with the correct signature.
  */
-static OSSL_core_gettable_types_fn core_gettable_types;
+static OSSL_core_gettable_params_fn core_gettable_params;
 static OSSL_core_get_params_fn core_get_params;
 static OSSL_core_thread_start_fn core_thread_start;
 static OSSL_core_get_library_context_fn core_get_libctx;
@@ -766,7 +766,7 @@ static OSSL_core_set_error_debug_fn core_set_error_debug;
 static OSSL_core_vset_error_fn core_vset_error;
 #endif
 
-static const OSSL_PARAM *core_gettable_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *core_gettable_params(const OSSL_PROVIDER *prov)
 {
     return param_types;
 }
@@ -855,7 +855,7 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
  * functions.
  */
 static const OSSL_DISPATCH core_dispatch_[] = {
-    { OSSL_FUNC_CORE_GETTABLE_TYPES, (void (*)(void))core_gettable_types },
+    { OSSL_FUNC_CORE_GETTABLE_TYPES, (void (*)(void))core_gettable_params },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
     { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
     { OSSL_FUNC_CORE_THREAD_START, (void (*)(void))core_thread_start },

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -11,7 +11,7 @@ ossl_provider_ctx,
 ossl_provider_forall_loaded,
 ossl_provider_name, ossl_provider_dso,
 ossl_provider_module_name, ossl_provider_module_path,
-ossl_provider_teardown, ossl_provider_get_param_types,
+ossl_provider_teardown, ossl_provider_gettable_types,
 ossl_provider_get_params, ossl_provider_query_operation
 - internal provider routines
 
@@ -55,7 +55,7 @@ ossl_provider_get_params, ossl_provider_query_operation
 
  /* Thin wrappers around calls to the provider */
  void ossl_provider_teardown(const OSSL_PROVIDER *prov);
- const OSSL_PARAM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov);
+ const OSSL_PARAM *ossl_provider_gettable_types(const OSSL_PROVIDER *prov);
  int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
  const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                      int operation_id,
@@ -188,7 +188,7 @@ for providers that come in the form of loadable modules.
 ossl_provider_teardown() calls the provider's I<teardown> function, if
 the provider has one.
 
-ossl_provider_get_param_types() calls the provider's I<get_param_types>
+ossl_provider_gettable_types() calls the provider's I<gettable_types>
 function, if the provider has one.
 It should return an array of I<OSSL_PARAM> to describe all the
 parameters that the provider has for the provider object.
@@ -254,7 +254,7 @@ is returned.
 
 ossl_provider_teardown() doesnt't return any value.
 
-ossl_provider_get_param_types() returns a pointer to a constant
+ossl_provider_gettable_types() returns a pointer to a constant
 I<OSSL_PARAM> array if this function is available in the provider,
 otherwise NULL.
 

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -11,7 +11,7 @@ ossl_provider_ctx,
 ossl_provider_forall_loaded,
 ossl_provider_name, ossl_provider_dso,
 ossl_provider_module_name, ossl_provider_module_path,
-ossl_provider_teardown, ossl_provider_gettable_types,
+ossl_provider_teardown, ossl_provider_gettable_params,
 ossl_provider_get_params, ossl_provider_query_operation
 - internal provider routines
 
@@ -55,7 +55,7 @@ ossl_provider_get_params, ossl_provider_query_operation
 
  /* Thin wrappers around calls to the provider */
  void ossl_provider_teardown(const OSSL_PROVIDER *prov);
- const OSSL_PARAM *ossl_provider_gettable_types(const OSSL_PROVIDER *prov);
+ const OSSL_PARAM *ossl_provider_gettable_params(const OSSL_PROVIDER *prov);
  int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
  const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                      int operation_id,
@@ -188,7 +188,7 @@ for providers that come in the form of loadable modules.
 ossl_provider_teardown() calls the provider's I<teardown> function, if
 the provider has one.
 
-ossl_provider_gettable_types() calls the provider's I<gettable_types>
+ossl_provider_gettable_params() calls the provider's I<gettable_params>
 function, if the provider has one.
 It should return an array of I<OSSL_PARAM> to describe all the
 parameters that the provider has for the provider object.
@@ -254,7 +254,7 @@ is returned.
 
 ossl_provider_teardown() doesnt't return any value.
 
-ossl_provider_gettable_types() returns a pointer to a constant
+ossl_provider_gettable_params() returns a pointer to a constant
 I<OSSL_PARAM> array if this function is available in the provider,
 otherwise NULL.
 

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -4,7 +4,7 @@
 
 OSSL_PROVIDER, OSSL_PROVIDER_load, OSSL_PROVIDER_unload,
 OSSL_PROVIDER_available,
-OSSL_PROVIDER_gettable_types, OSSL_PROVIDER_get_params,
+OSSL_PROVIDER_gettable_params, OSSL_PROVIDER_get_params,
 OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
 
 =head1 SYNOPSIS
@@ -17,7 +17,7 @@ OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name);
 
- const OSSL_PARAM *OSSL_PROVIDER_gettable_types(OSSL_PROVIDER *prov);
+ const OSSL_PARAM *OSSL_PROVIDER_gettable_params(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_get_params(OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
  int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *libctx, const char *name,
@@ -57,7 +57,7 @@ runs its teardown function.
 OSSL_PROVIDER_available() checks if a named provider is available
 for use.
 
-OSSL_PROVIDER_gettable_types() is used to get a provider parameter
+OSSL_PROVIDER_gettable_params() is used to get a provider parameter
 descriptor set as a constant B<OSSL_PARAM> array.
 See L<OSSL_PARAM(3)> for more information.
 
@@ -80,7 +80,7 @@ OSSL_PROVIDER_unload() returns 1 on success, or 0 on error.
 OSSL_PROVIDER_available() returns 1 if the named provider is available,
 otherwise 0.
 
-OSSL_PROVIDER_gettable_types() returns a pointer to an array
+OSSL_PROVIDER_gettable_params() returns a pointer to an array
 of constant B<OSSL_PARAM>, or NULL if none is provided.
 
 OSSL_PROVIDER_get_params() returns 1 on success, or 0 on error.

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -4,7 +4,7 @@
 
 OSSL_PROVIDER, OSSL_PROVIDER_load, OSSL_PROVIDER_unload,
 OSSL_PROVIDER_available,
-OSSL_PROVIDER_get_param_types, OSSL_PROVIDER_get_params,
+OSSL_PROVIDER_gettable_types, OSSL_PROVIDER_get_params,
 OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
 
 =head1 SYNOPSIS
@@ -17,7 +17,7 @@ OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name);
 
- const OSSL_PARAM *OSSL_PROVIDER_get_param_types(OSSL_PROVIDER *prov);
+ const OSSL_PARAM *OSSL_PROVIDER_gettable_types(OSSL_PROVIDER *prov);
  int OSSL_PROVIDER_get_params(OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
  int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *libctx, const char *name,
@@ -57,7 +57,7 @@ runs its teardown function.
 OSSL_PROVIDER_available() checks if a named provider is available
 for use.
 
-OSSL_PROVIDER_get_param_types() is used to get a provider parameter
+OSSL_PROVIDER_gettable_types() is used to get a provider parameter
 descriptor set as a constant B<OSSL_PARAM> array.
 See L<OSSL_PARAM(3)> for more information.
 
@@ -80,7 +80,7 @@ OSSL_PROVIDER_unload() returns 1 on success, or 0 on error.
 OSSL_PROVIDER_available() returns 1 if the named provider is available,
 otherwise 0.
 
-OSSL_PROVIDER_get_param_types() returns a pointer to an array
+OSSL_PROVIDER_gettable_types() returns a pointer to an array
 of constant B<OSSL_PARAM>, or NULL if none is provided.
 
 OSSL_PROVIDER_get_params() returns 1 on success, or 0 on error.

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -16,7 +16,7 @@ provider-base
   */
 
  /* Functions offered by libcrypto to the providers */
- const OSSL_ITEM *core_get_param_types(const OSSL_PROVIDER *prov);
+ const OSSL_ITEM *core_gettable_types(const OSSL_PROVIDER *prov);
  int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
  int core_thread_start(const OSSL_PROVIDER *prov,
                        OSSL_thread_stop_handler_fn handfn);
@@ -56,7 +56,7 @@ provider-base
 
  /* Functions offered by the provider to libcrypto */
  void provider_teardown(void *provctx);
- const OSSL_ITEM *provider_get_param_types(void *provctx);
+ const OSSL_ITEM *provider_gettable_types(void *provctx);
  int provider_get_params(void *provctx, OSSL_PARAM params[]);
  const OSSL_ALGORITHM *provider_query_operation(void *provctx,
                                                 int operation_id,
@@ -74,12 +74,12 @@ All these "functions" have a corresponding function type definition
 named B<OSSL_{name}_fn>, and a helper function to retrieve the
 function pointer from a B<OSSL_DISPATCH> element named
 B<OSSL_get_{name}>.
-For example, the "function" core_get_param_types() has these:
+For example, the "function" core_gettable_types() has these:
 
  typedef OSSL_ITEM *
-     (OSSL_core_get_param_types_fn)(const OSSL_PROVIDER *prov);
- static ossl_inline OSSL_NAME_core_get_param_types_fn
-     OSSL_get_core_get_param_types(const OSSL_DISPATCH *opf);
+     (OSSL_core_gettable_types_fn)(const OSSL_PROVIDER *prov);
+ static ossl_inline OSSL_NAME_core_gettable_types_fn
+     OSSL_get_core_gettable_types(const OSSL_DISPATCH *opf);
 
 B<OSSL_DISPATCH> arrays are indexed by numbers that are provided as
 macros in L<openssl-core_numbers.h(7)>, as follows:
@@ -87,7 +87,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 For I<in> (the B<OSSL_DISPATCH> array passed from F<libcrypto> to the
 provider):
 
- core_get_param_types           OSSL_FUNC_CORE_GET_PARAM_TYPES
+ core_gettable_types            OSSL_FUNC_CORE_GETTABLE_TYPES
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
  core_get_library_context       OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT
@@ -115,14 +115,14 @@ For I<*out> (the B<OSSL_DISPATCH> array passed from the provider to
 F<libcrypto>):
 
  provider_teardown              OSSL_FUNC_PROVIDER_TEARDOWN
- provider_get_param_types       OSSL_FUNC_PROVIDER_GET_PARAM_TYPES
+ provider_gettable_types        OSSL_FUNC_PROVIDER_GETTABLE_TYPES
  provider_get_params            OSSL_FUNC_PROVIDER_GET_PARAMS
  provider_query_operation       OSSL_FUNC_PROVIDER_QUERY_OPERATION
  provider_get_reason_strings    OSSL_FUNC_PROVIDER_GET_REASON_STRINGS
 
 =head2 Core functions
 
-core_get_param_types() returns a constant array of descriptor
+core_gettable_types() returns a constant array of descriptor
 B<OSSL_PARAM>, for parameters that core_get_params() can handle.
 
 core_get_params() retrieves I<prov> parameters from the core.
@@ -189,7 +189,7 @@ provider_teardown() is called when a provider is shut down and removed
 from the core's provider store.
 It must free the passed I<provctx>.
 
-provider_get_param_types() should return a constant array of
+provider_gettable_types() should return a constant array of
 descriptor B<OSSL_PARAM>, for parameters that provider_get_params()
 can handle.
 
@@ -208,7 +208,7 @@ use when reporting errors using core_put_error().
 
 None of these functions are mandatory, but a provider is fairly
 useless without at least provider_query_operation(), and
-provider_get_param_types() is fairly useless if not accompanied by
+provider_gettable_types() is fairly useless if not accompanied by
 provider_get_params().
 
 =head2 Core parameters

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -87,7 +87,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 For I<in> (the B<OSSL_DISPATCH> array passed from F<libcrypto> to the
 provider):
 
- core_gettable_params            OSSL_FUNC_CORE_GETTABLE_PARAMS
+ core_gettable_params           OSSL_FUNC_CORE_GETTABLE_PARAMS
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
  core_get_library_context       OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT
@@ -115,7 +115,7 @@ For I<*out> (the B<OSSL_DISPATCH> array passed from the provider to
 F<libcrypto>):
 
  provider_teardown              OSSL_FUNC_PROVIDER_TEARDOWN
- provider_gettable_params        OSSL_FUNC_PROVIDER_GETTABLE_PARAMS
+ provider_gettable_params       OSSL_FUNC_PROVIDER_GETTABLE_PARAMS
  provider_get_params            OSSL_FUNC_PROVIDER_GET_PARAMS
  provider_query_operation       OSSL_FUNC_PROVIDER_QUERY_OPERATION
  provider_get_reason_strings    OSSL_FUNC_PROVIDER_GET_REASON_STRINGS

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -16,7 +16,7 @@ provider-base
   */
 
  /* Functions offered by libcrypto to the providers */
- const OSSL_ITEM *core_gettable_types(const OSSL_PROVIDER *prov);
+ const OSSL_ITEM *core_gettable_params(const OSSL_PROVIDER *prov);
  int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
  int core_thread_start(const OSSL_PROVIDER *prov,
                        OSSL_thread_stop_handler_fn handfn);
@@ -56,7 +56,7 @@ provider-base
 
  /* Functions offered by the provider to libcrypto */
  void provider_teardown(void *provctx);
- const OSSL_ITEM *provider_gettable_types(void *provctx);
+ const OSSL_ITEM *provider_gettable_params(void *provctx);
  int provider_get_params(void *provctx, OSSL_PARAM params[]);
  const OSSL_ALGORITHM *provider_query_operation(void *provctx,
                                                 int operation_id,
@@ -74,12 +74,12 @@ All these "functions" have a corresponding function type definition
 named B<OSSL_{name}_fn>, and a helper function to retrieve the
 function pointer from a B<OSSL_DISPATCH> element named
 B<OSSL_get_{name}>.
-For example, the "function" core_gettable_types() has these:
+For example, the "function" core_gettable_params() has these:
 
  typedef OSSL_ITEM *
-     (OSSL_core_gettable_types_fn)(const OSSL_PROVIDER *prov);
- static ossl_inline OSSL_NAME_core_gettable_types_fn
-     OSSL_get_core_gettable_types(const OSSL_DISPATCH *opf);
+     (OSSL_core_gettable_params_fn)(const OSSL_PROVIDER *prov);
+ static ossl_inline OSSL_NAME_core_gettable_params_fn
+     OSSL_get_core_gettable_params(const OSSL_DISPATCH *opf);
 
 B<OSSL_DISPATCH> arrays are indexed by numbers that are provided as
 macros in L<openssl-core_numbers.h(7)>, as follows:
@@ -87,7 +87,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 For I<in> (the B<OSSL_DISPATCH> array passed from F<libcrypto> to the
 provider):
 
- core_gettable_types            OSSL_FUNC_CORE_GETTABLE_TYPES
+ core_gettable_params            OSSL_FUNC_CORE_GETTABLE_TYPES
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
  core_get_library_context       OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT
@@ -115,14 +115,14 @@ For I<*out> (the B<OSSL_DISPATCH> array passed from the provider to
 F<libcrypto>):
 
  provider_teardown              OSSL_FUNC_PROVIDER_TEARDOWN
- provider_gettable_types        OSSL_FUNC_PROVIDER_GETTABLE_TYPES
+ provider_gettable_params        OSSL_FUNC_PROVIDER_GETTABLE_TYPES
  provider_get_params            OSSL_FUNC_PROVIDER_GET_PARAMS
  provider_query_operation       OSSL_FUNC_PROVIDER_QUERY_OPERATION
  provider_get_reason_strings    OSSL_FUNC_PROVIDER_GET_REASON_STRINGS
 
 =head2 Core functions
 
-core_gettable_types() returns a constant array of descriptor
+core_gettable_params() returns a constant array of descriptor
 B<OSSL_PARAM>, for parameters that core_get_params() can handle.
 
 core_get_params() retrieves I<prov> parameters from the core.
@@ -189,7 +189,7 @@ provider_teardown() is called when a provider is shut down and removed
 from the core's provider store.
 It must free the passed I<provctx>.
 
-provider_gettable_types() should return a constant array of
+provider_gettable_params() should return a constant array of
 descriptor B<OSSL_PARAM>, for parameters that provider_get_params()
 can handle.
 
@@ -208,7 +208,7 @@ use when reporting errors using core_put_error().
 
 None of these functions are mandatory, but a provider is fairly
 useless without at least provider_query_operation(), and
-provider_gettable_types() is fairly useless if not accompanied by
+provider_gettable_params() is fairly useless if not accompanied by
 provider_get_params().
 
 =head2 Core parameters

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -87,7 +87,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 For I<in> (the B<OSSL_DISPATCH> array passed from F<libcrypto> to the
 provider):
 
- core_gettable_params            OSSL_FUNC_CORE_GETTABLE_TYPES
+ core_gettable_params            OSSL_FUNC_CORE_GETTABLE_PARAMS
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
  core_get_library_context       OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT
@@ -115,7 +115,7 @@ For I<*out> (the B<OSSL_DISPATCH> array passed from the provider to
 F<libcrypto>):
 
  provider_teardown              OSSL_FUNC_PROVIDER_TEARDOWN
- provider_gettable_params        OSSL_FUNC_PROVIDER_GETTABLE_TYPES
+ provider_gettable_params        OSSL_FUNC_PROVIDER_GETTABLE_PARAMS
  provider_get_params            OSSL_FUNC_PROVIDER_GET_PARAMS
  provider_query_operation       OSSL_FUNC_PROVIDER_QUERY_OPERATION
  provider_get_reason_strings    OSSL_FUNC_PROVIDER_GET_REASON_STRINGS

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -66,7 +66,7 @@ const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);
-const OSSL_PARAM *ossl_provider_gettable_types(const OSSL_PROVIDER *prov);
+const OSSL_PARAM *ossl_provider_gettable_params(const OSSL_PROVIDER *prov);
 int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -66,7 +66,7 @@ const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);
-const OSSL_PARAM *ossl_provider_get_param_types(const OSSL_PROVIDER *prov);
+const OSSL_PARAM *ossl_provider_gettable_types(const OSSL_PROVIDER *prov);
 int ossl_provider_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -17,9 +17,9 @@
 /* ossl_provider_available vs OSSL_PROVIDER_available */
 #  undef ossl_provider_available
 #  define ossl_provider_available                 ossl_int_prov_available
-/* ossl_provider_get_param_types vs OSSL_PROVIDER_get_param_types */
-#  undef ossl_provider_get_param_types
-#  define ossl_provider_get_param_types           ossl_int_prov_get_param_types
+/* ossl_provider_gettable_types vs OSSL_PROVIDER_gettable_types */
+#  undef ossl_provider_gettable_types
+#  define ossl_provider_gettable_types            ossl_int_prov_gettable_types
 /* ossl_provider_get_params vs OSSL_PROVIDER_get_params */
 #  undef ossl_provider_get_params
 #  define ossl_provider_get_params                ossl_int_prov_get_params

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -17,9 +17,9 @@
 /* ossl_provider_available vs OSSL_PROVIDER_available */
 #  undef ossl_provider_available
 #  define ossl_provider_available                 ossl_int_prov_available
-/* ossl_provider_gettable_types vs OSSL_PROVIDER_gettable_types */
-#  undef ossl_provider_gettable_types
-#  define ossl_provider_gettable_types            ossl_int_prov_gettable_types
+/* ossl_provider_gettable_params vs OSSL_PROVIDER_gettable_params */
+#  undef ossl_provider_gettable_params
+#  define ossl_provider_gettable_params            ossl_int_prov_gettable_params
 /* ossl_provider_get_params vs OSSL_PROVIDER_get_params */
 #  undef ossl_provider_get_params
 #  define ossl_provider_get_params                ossl_int_prov_get_params

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -57,9 +57,9 @@ extern "C" {
  * therefore NEVER be used as a function identity.
  */
 /* Functions provided by the Core to the provider, reserved numbers 1-1023 */
-# define OSSL_FUNC_CORE_GET_PARAM_TYPES        1
+# define OSSL_FUNC_CORE_GETTABLE_TYPES         1
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    core_get_param_types,(const OSSL_PROVIDER *prov))
+                    core_gettable_types,(const OSSL_PROVIDER *prov))
 # define OSSL_FUNC_CORE_GET_PARAMS             2
 OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
                                          OSSL_PARAM params[]))
@@ -121,9 +121,9 @@ OSSL_CORE_MAKE_FUNC(void,
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024
 OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))
-# define OSSL_FUNC_PROVIDER_GET_PARAM_TYPES  1025
+# define OSSL_FUNC_PROVIDER_GETTABLE_TYPES   1025
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    provider_get_param_types,(void *provctx))
+                    provider_gettable_types,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAMS       1026
 OSSL_CORE_MAKE_FUNC(int,provider_get_params,(void *provctx,
                                              OSSL_PARAM params[]))

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -57,7 +57,7 @@ extern "C" {
  * therefore NEVER be used as a function identity.
  */
 /* Functions provided by the Core to the provider, reserved numbers 1-1023 */
-# define OSSL_FUNC_CORE_GETTABLE_TYPES         1
+# define OSSL_FUNC_CORE_GETTABLE_PARAMS        1
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
                     core_gettable_params,(const OSSL_PROVIDER *prov))
 # define OSSL_FUNC_CORE_GET_PARAMS             2
@@ -121,7 +121,7 @@ OSSL_CORE_MAKE_FUNC(void,
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024
 OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))
-# define OSSL_FUNC_PROVIDER_GETTABLE_TYPES   1025
+# define OSSL_FUNC_PROVIDER_GETTABLE_PARAMS  1025
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
                     provider_gettable_params,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAMS       1026

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -59,7 +59,7 @@ extern "C" {
 /* Functions provided by the Core to the provider, reserved numbers 1-1023 */
 # define OSSL_FUNC_CORE_GETTABLE_TYPES         1
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    core_gettable_types,(const OSSL_PROVIDER *prov))
+                    core_gettable_params,(const OSSL_PROVIDER *prov))
 # define OSSL_FUNC_CORE_GET_PARAMS             2
 OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
                                          OSSL_PARAM params[]))
@@ -123,7 +123,7 @@ OSSL_CORE_MAKE_FUNC(void,
 OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GETTABLE_TYPES   1025
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    provider_gettable_types,(void *provctx))
+                    provider_gettable_params,(void *provctx))
 # define OSSL_FUNC_PROVIDER_GET_PARAMS       1026
 OSSL_CORE_MAKE_FUNC(int,provider_get_params,(void *provctx,
                                              OSSL_PARAM params[]))

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -21,7 +21,7 @@ OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_available(OPENSSL_CTX *, const char *name);
 
-const OSSL_PARAM *OSSL_PROVIDER_get_param_types(const OSSL_PROVIDER *prov);
+const OSSL_PARAM *OSSL_PROVIDER_gettable_types(const OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
 /* Add a built in providers */

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -21,7 +21,7 @@ OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_available(OPENSSL_CTX *, const char *name);
 
-const OSSL_PARAM *OSSL_PROVIDER_gettable_types(const OSSL_PROVIDER *prov);
+const OSSL_PARAM *OSSL_PROVIDER_gettable_params(const OSSL_PROVIDER *prov);
 int OSSL_PROVIDER_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
 
 /* Add a built in providers */

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -16,7 +16,7 @@
 #include "internal/provider_algs.h"
 
 /* Functions provided by the core */
-static OSSL_core_gettable_types_fn *c_gettable_types = NULL;
+static OSSL_core_gettable_params_fn *c_gettable_params = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
@@ -27,7 +27,7 @@ static const OSSL_PARAM deflt_param_types[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *deflt_gettable_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *deflt_gettable_params(const OSSL_PROVIDER *prov)
 {
     return deflt_param_types;
 }
@@ -156,7 +156,7 @@ static const OSSL_ALGORITHM *deflt_query(OSSL_PROVIDER *prov,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH deflt_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))deflt_gettable_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))deflt_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))deflt_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))deflt_query },
     { 0, NULL }
@@ -174,7 +174,7 @@ int ossl_default_provider_init(const OSSL_PROVIDER *provider,
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_TYPES:
-            c_gettable_types = OSSL_get_core_gettable_types(in);
+            c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -16,7 +16,7 @@
 #include "internal/provider_algs.h"
 
 /* Functions provided by the core */
-static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
+static OSSL_core_gettable_types_fn *c_gettable_types = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
@@ -27,7 +27,7 @@ static const OSSL_PARAM deflt_param_types[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *deflt_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *deflt_gettable_types(const OSSL_PROVIDER *prov)
 {
     return deflt_param_types;
 }
@@ -156,7 +156,7 @@ static const OSSL_ALGORITHM *deflt_query(OSSL_PROVIDER *prov,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH deflt_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_GET_PARAM_TYPES, (void (*)(void))deflt_get_param_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))deflt_gettable_types },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))deflt_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))deflt_query },
     { 0, NULL }
@@ -173,8 +173,8 @@ int ossl_default_provider_init(const OSSL_PROVIDER *provider,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GET_PARAM_TYPES:
-            c_get_param_types = OSSL_get_core_get_param_types(in);
+        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+            c_gettable_types = OSSL_get_core_gettable_types(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -156,7 +156,7 @@ static const OSSL_ALGORITHM *deflt_query(OSSL_PROVIDER *prov,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH deflt_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))deflt_gettable_params },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))deflt_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))deflt_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))deflt_query },
     { 0, NULL }
@@ -173,7 +173,7 @@ int ossl_default_provider_init(const OSSL_PROVIDER *provider,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
             c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -37,7 +37,7 @@ extern OSSL_core_thread_start_fn *c_thread_start;
  * us with the OPENSSL_CTX as a parameter.
  */
 /* Functions provided by the core */
-static OSSL_core_gettable_types_fn *c_gettable_types;
+static OSSL_core_gettable_params_fn *c_gettable_params;
 static OSSL_core_get_params_fn *c_get_params;
 OSSL_core_thread_start_fn *c_thread_start;
 static OSSL_core_new_error_fn *c_new_error;
@@ -164,7 +164,7 @@ static int dummy_evp_call(void *provctx)
     return ret;
 }
 
-static const OSSL_PARAM *fips_gettable_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *fips_gettable_params(const OSSL_PROVIDER *prov)
 {
     return fips_param_types;
 }
@@ -295,7 +295,7 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
      * use OPENSSL_CTX_free directly as our teardown function
      */
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OPENSSL_CTX_free },
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))fips_gettable_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))fips_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))fips_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fips_query },
     { 0, NULL }
@@ -319,7 +319,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_TYPES:
-            c_gettable_types = OSSL_get_core_gettable_types(in);
+            c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -295,7 +295,7 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
      * use OPENSSL_CTX_free directly as our teardown function
      */
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OPENSSL_CTX_free },
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))fips_gettable_params },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))fips_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))fips_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fips_query },
     { 0, NULL }
@@ -318,7 +318,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
             c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -37,7 +37,7 @@ extern OSSL_core_thread_start_fn *c_thread_start;
  * us with the OPENSSL_CTX as a parameter.
  */
 /* Functions provided by the core */
-static OSSL_core_get_param_types_fn *c_get_param_types;
+static OSSL_core_gettable_types_fn *c_gettable_types;
 static OSSL_core_get_params_fn *c_get_params;
 OSSL_core_thread_start_fn *c_thread_start;
 static OSSL_core_new_error_fn *c_new_error;
@@ -164,7 +164,7 @@ static int dummy_evp_call(void *provctx)
     return ret;
 }
 
-static const OSSL_PARAM *fips_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *fips_gettable_types(const OSSL_PROVIDER *prov)
 {
     return fips_param_types;
 }
@@ -295,7 +295,7 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
      * use OPENSSL_CTX_free directly as our teardown function
      */
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OPENSSL_CTX_free },
-    { OSSL_FUNC_PROVIDER_GET_PARAM_TYPES, (void (*)(void))fips_get_param_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))fips_gettable_types },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))fips_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fips_query },
     { 0, NULL }
@@ -318,8 +318,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GET_PARAM_TYPES:
-            c_get_param_types = OSSL_get_core_get_param_types(in);
+        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+            c_gettable_types = OSSL_get_core_gettable_types(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -87,7 +87,7 @@ static const OSSL_ALGORITHM *legacy_query(OSSL_PROVIDER *prov,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH legacy_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))legacy_gettable_params },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))legacy_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))legacy_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))legacy_query },
     { 0, NULL }
@@ -102,7 +102,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
             c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -16,7 +16,7 @@
 #include "internal/provider_algs.h"
 
 /* Functions provided by the core */
-static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
+static OSSL_core_gettable_types_fn *c_gettable_types = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
@@ -27,7 +27,7 @@ static const OSSL_ITEM legacy_param_types[] = {
     { 0, NULL }
 };
 
-static const OSSL_ITEM *legacy_get_param_types(const OSSL_PROVIDER *prov)
+static const OSSL_ITEM *legacy_gettable_types(const OSSL_PROVIDER *prov)
 {
     return legacy_param_types;
 }
@@ -87,7 +87,7 @@ static const OSSL_ALGORITHM *legacy_query(OSSL_PROVIDER *prov,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH legacy_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_GET_PARAM_TYPES, (void (*)(void))legacy_get_param_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))legacy_gettable_types },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))legacy_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))legacy_query },
     { 0, NULL }
@@ -102,8 +102,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GET_PARAM_TYPES:
-            c_get_param_types = OSSL_get_core_get_param_types(in);
+        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+            c_gettable_types = OSSL_get_core_gettable_types(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -16,7 +16,7 @@
 #include "internal/provider_algs.h"
 
 /* Functions provided by the core */
-static OSSL_core_gettable_types_fn *c_gettable_types = NULL;
+static OSSL_core_gettable_params_fn *c_gettable_params = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Parameters we provide to the core */
@@ -27,7 +27,7 @@ static const OSSL_ITEM legacy_param_types[] = {
     { 0, NULL }
 };
 
-static const OSSL_ITEM *legacy_gettable_types(const OSSL_PROVIDER *prov)
+static const OSSL_ITEM *legacy_gettable_params(const OSSL_PROVIDER *prov)
 {
     return legacy_param_types;
 }
@@ -87,7 +87,7 @@ static const OSSL_ALGORITHM *legacy_query(OSSL_PROVIDER *prov,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH legacy_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))legacy_gettable_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))legacy_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))legacy_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))legacy_query },
     { 0, NULL }
@@ -103,7 +103,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_TYPES:
-            c_gettable_types = OSSL_get_core_gettable_types(in);
+            c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -29,7 +29,7 @@
 #include <openssl/core.h>
 #include <openssl/core_numbers.h>
 
-static OSSL_core_get_param_types_fn *c_get_param_types = NULL;
+static OSSL_core_gettable_types_fn *c_gettable_types = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Tell the core what params we provide and what type they are */
@@ -39,10 +39,10 @@ static const OSSL_PARAM p_param_types[] = {
 };
 
 /* This is a trick to ensure we define the provider functions correctly */
-static OSSL_provider_get_param_types_fn p_get_param_types;
+static OSSL_provider_gettable_types_fn p_gettable_types;
 static OSSL_provider_get_params_fn p_get_params;
 
-static const OSSL_PARAM *p_get_param_types(void *_)
+static const OSSL_PARAM *p_gettable_types(void *_)
 {
     return p_param_types;
 }
@@ -101,7 +101,7 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
 }
 
 static const OSSL_DISPATCH p_test_table[] = {
-    { OSSL_FUNC_PROVIDER_GET_PARAM_TYPES, (void (*)(void))p_get_param_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))p_gettable_types },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p_get_params },
     { 0, NULL }
 };
@@ -113,8 +113,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 {
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GET_PARAM_TYPES:
-            c_get_param_types = OSSL_get_core_get_param_types(in);
+        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+            c_gettable_types = OSSL_get_core_gettable_types(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -29,7 +29,7 @@
 #include <openssl/core.h>
 #include <openssl/core_numbers.h>
 
-static OSSL_core_gettable_types_fn *c_gettable_types = NULL;
+static OSSL_core_gettable_params_fn *c_gettable_params = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;
 
 /* Tell the core what params we provide and what type they are */
@@ -39,10 +39,10 @@ static const OSSL_PARAM p_param_types[] = {
 };
 
 /* This is a trick to ensure we define the provider functions correctly */
-static OSSL_provider_gettable_types_fn p_gettable_types;
+static OSSL_provider_gettable_params_fn p_gettable_params;
 static OSSL_provider_get_params_fn p_get_params;
 
-static const OSSL_PARAM *p_gettable_types(void *_)
+static const OSSL_PARAM *p_gettable_params(void *_)
 {
     return p_param_types;
 }
@@ -101,7 +101,7 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
 }
 
 static const OSSL_DISPATCH p_test_table[] = {
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))p_gettable_types },
+    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))p_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p_get_params },
     { 0, NULL }
 };
@@ -114,7 +114,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_TYPES:
-            c_gettable_types = OSSL_get_core_gettable_types(in);
+            c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_get_core_get_params(in);

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -101,7 +101,7 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
 }
 
 static const OSSL_DISPATCH p_test_table[] = {
-    { OSSL_FUNC_PROVIDER_GETTABLE_TYPES, (void (*)(void))p_gettable_params },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))p_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p_get_params },
     { 0, NULL }
 };
@@ -113,7 +113,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 {
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_TYPES:
+        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
             c_gettable_params = OSSL_get_core_gettable_params(in);
             break;
         case OSSL_FUNC_CORE_GET_PARAMS:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4504,7 +4504,7 @@ OSSL_trace_end                          4613	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_load                      4614	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_unload                    4615	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_add_builtin               4616	3_0_0	EXIST::FUNCTION:
-OSSL_PROVIDER_gettable_params            4617	3_0_0	EXIST::FUNCTION:
+OSSL_PROVIDER_gettable_params           4617	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_get_params                4618	3_0_0	EXIST::FUNCTION:
 d2i_OSSL_CRMF_ENCRYPTEDVALUE            4619	3_0_0	EXIST::FUNCTION:CRMF
 i2d_OSSL_CRMF_ENCRYPTEDVALUE            4620	3_0_0	EXIST::FUNCTION:CRMF

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4504,7 +4504,7 @@ OSSL_trace_end                          4613	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_load                      4614	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_unload                    4615	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_add_builtin               4616	3_0_0	EXIST::FUNCTION:
-OSSL_PROVIDER_get_param_types           4617	3_0_0	EXIST::FUNCTION:
+OSSL_PROVIDER_gettable_types            4617	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_get_params                4618	3_0_0	EXIST::FUNCTION:
 d2i_OSSL_CRMF_ENCRYPTEDVALUE            4619	3_0_0	EXIST::FUNCTION:CRMF
 i2d_OSSL_CRMF_ENCRYPTEDVALUE            4620	3_0_0	EXIST::FUNCTION:CRMF

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4504,7 +4504,7 @@ OSSL_trace_end                          4613	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_load                      4614	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_unload                    4615	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_add_builtin               4616	3_0_0	EXIST::FUNCTION:
-OSSL_PROVIDER_gettable_types            4617	3_0_0	EXIST::FUNCTION:
+OSSL_PROVIDER_gettable_params            4617	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_get_params                4618	3_0_0	EXIST::FUNCTION:
 d2i_OSSL_CRMF_ENCRYPTEDVALUE            4619	3_0_0	EXIST::FUNCTION:CRMF
 i2d_OSSL_CRMF_ENCRYPTEDVALUE            4620	3_0_0	EXIST::FUNCTION:CRMF


### PR DESCRIPTION
It was argued that names like SOMETHING_set_param_types were confusing,
and a rename has been proposed to SOMETHING_settable_types, and by
consequence, SOMETHING_get_param_types is renamed
SOMETHING_gettable_types.

This changes implements this change for the dispatched provider and
core functions.
