### PR TITLE
Add fips provider code for handling self test data

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -751,7 +751,7 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
  * never knows.
  */
 static const OSSL_PARAM param_types[] = {
-    OSSL_PARAM_DEFN("openssl-verstion", OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN("openssl-version", OSSL_PARAM_UTF8_PTR, NULL, 0),
     OSSL_PARAM_DEFN("provider-name", OSSL_PARAM_UTF8_PTR, NULL, 0),
     OSSL_PARAM_END
 };
@@ -780,11 +780,6 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
 {
     int i;
     OSSL_PARAM *p;
-
-#ifndef FIPS_MODE
-    /* Load config before we attempt to read any provider parameters */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-#endif
 
     if ((p = OSSL_PARAM_locate(params, "openssl-version")) != NULL)
         OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR);
@@ -868,6 +863,10 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_NEW_ERROR, (void (*)(void))core_new_error },
     { OSSL_FUNC_CORE_SET_ERROR_DEBUG, (void (*)(void))core_set_error_debug },
     { OSSL_FUNC_CORE_VSET_ERROR, (void (*)(void))core_vset_error },
+    { OSSL_FUNC_BIO_NEW_FILE, (void (*)(void))BIO_new_file },
+    { OSSL_FUNC_BIO_NEW_MEMBUF, (void (*)(void))BIO_new_mem_buf },
+    { OSSL_FUNC_BIO_READ, (void (*)(void))BIO_read },
+    { OSSL_FUNC_BIO_FREE, (void (*)(void))BIO_free },
 #endif
 
     { OSSL_FUNC_CRYPTO_MALLOC, (void (*)(void))CRYPTO_malloc },

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -787,6 +787,11 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     if ((p = OSSL_PARAM_locate(params, "provider-name")) != NULL)
         OSSL_PARAM_set_utf8_ptr(p, prov->name);
 
+#ifndef FIPS_MODE
+    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_MODULE_FILENAME)) != NULL)
+        OSSL_PARAM_set_utf8_ptr(p, ossl_provider_module_path(prov));
+#endif
+
     if (prov->parameters == NULL)
         return 1;
 
@@ -796,10 +801,6 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
         if ((p = OSSL_PARAM_locate(params, pair->name)) != NULL)
             OSSL_PARAM_set_utf8_ptr(p, pair->value);
     }
-#ifndef FIPS_MODE
-    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_MODULE_FILENAME)) != NULL)
-        OSSL_PARAM_set_utf8_ptr(p, ossl_provider_module_path(prov));
-#endif
     return 1;
 }
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -9,6 +9,7 @@
 
 #include <openssl/core.h>
 #include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
 #include <openssl/params.h>
 #include <openssl/opensslv.h>
 #include "internal/cryptlib_int.h"
@@ -795,7 +796,10 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
         if ((p = OSSL_PARAM_locate(params, pair->name)) != NULL)
             OSSL_PARAM_set_utf8_ptr(p, pair->value);
     }
-
+#ifndef FIPS_MODE
+    if ((p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_MODULE_FILENAME)) != NULL)
+        OSSL_PARAM_set_utf8_ptr(p, ossl_provider_module_path(prov));
+#endif
     return 1;
 }
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -504,7 +504,7 @@ file.
 
 =head1 SEE ALSO
 
-L<x509(1)>, L<req(1)>, L<ca(1)>
+L<x509(1)>, L<req(1)>, L<ca(1)>, L<fips_config(5)>
 
 =head1 COPYRIGHT
 

--- a/doc/man5/fips_config.pod
+++ b/doc/man5/fips_config.pod
@@ -1,0 +1,65 @@
+=pod
+
+=head1 NAME
+
+OPENSSL FIPS CONFIGURATION
+
+=head1 DESCRIPTION
+
+A separate configuration file containing data related to FIPS 'self tests' is
+written to during installation time.
+This data is used for 2 purposes when the fips module is loaded.
+
+ - Verify the module's checksum each time the fips module loads.
+ - Run the startup FIPS self test KATS (known answer tests). This only needs
+   to be run once during installation.
+
+The supported options are:
+
+=over 4
+
+=item B<module-checksum>
+
+The calculated MAC of the module file
+
+=item B<install-version>
+
+A version number for the fips install process. Should be 1.
+
+=item B<install-status>
+
+The install status indicator description that will be verified.
+If this field is not present the FIPS self tests will run when the fips module
+loads. This value should only be written to after the FIPS module has
+successfully passed its self tests during installation.
+
+=item B<install-checksum>
+
+The calculated MAC of the install status indicator. It is initially empty and
+is written to at the same time as the install_status.
+
+=back
+
+For example:
+
+ [fips_install]
+
+ install-version = 1
+ module-checksum = 41:D0:FA:C2:5D:41:75:CD:7D:C3:90:55:6F:A4:DC
+ install-checksum = FE:10:13:5A:D3:B4:C7:82:1B:1E:17:4C:AC:84:0C
+ install-status = INSTALL_SELF_TEST_KATS_RUN
+
+=head1 SEE ALSO
+
+L<config(5)>
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man5/fips_config.pod
+++ b/doc/man5/fips_config.pod
@@ -8,11 +8,16 @@ OPENSSL FIPS CONFIGURATION
 
 A separate configuration file containing data related to FIPS 'self tests' is
 written to during installation time.
-This data is used for 2 purposes when the fips module is loaded.
+This data is used for 2 purposes when the fips module is loaded:
 
- - Verify the module's checksum each time the fips module loads.
- - Run the startup FIPS self test KATS (known answer tests). This only needs
-   to be run once during installation.
+=over 4
+
+=item - Verify the module's checksum each time the fips module loads.
+
+=item - Run the startup FIPS self test KATS (known answer tests).
+This only needs to be run once during installation.
+
+=back
 
 The supported options are:
 
@@ -30,13 +35,14 @@ A version number for the fips install process. Should be 1.
 
 The install status indicator description that will be verified.
 If this field is not present the FIPS self tests will run when the fips module
-loads. This value should only be written to after the FIPS module has
+loads.
+This value should only be written to after the FIPS module has
 successfully passed its self tests during installation.
 
 =item B<install-checksum>
 
-The calculated MAC of the install status indicator. It is initially empty and
-is written to at the same time as the install_status.
+The calculated MAC of the install status indicator.
+It is initially empty and is written to at the same time as the install_status.
 
 =back
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -108,6 +108,10 @@ provider):
  CRYPTO_secure_free             OSSL_FUNC_CRYPTO_SECURE_FREE
  CRYPTO_secure_clear_free       OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE
  CRYPTO_secure_allocated        OSSL_FUNC_CRYPTO_SECURE_ALLOCATED
+ BIO_new_file                   OSSL_FUNC_BIO_NEW_FILE
+ BIO_new_mem_buf                OSSL_FUNC_BIO_NEW_MEMBUF
+ BIO_read                       OSSL_FUNC_BIO_READ
+ BIO_free                       OSSL_FUNC_BIO_FREE
  OPENSSL_cleanse                OSSL_FUNC_OPENSSL_CLEANSE
  OPENSSL_hexstr2buf             OSSL_FUNC_OPENSSL_HEXSTR2BUF
 
@@ -178,6 +182,7 @@ CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),
 CRYPTO_realloc(), CRYPTO_clear_realloc(), CRYPTO_secure_malloc(),
 CRYPTO_secure_zalloc(), CRYPTO_secure_free(),
 CRYPTO_secure_clear_free(), CRYPTO_secure_allocated(),
+BIO_new_file(), BIO_new_mem_buf(), BIO_read(), BIO_free(),
 OPENSSL_cleanse(), and OPENSSL_hexstr2buf() correspond exactly to the
 public functions with the same name.
 As a matter of fact, the pointers in the B<OSSL_DISPATCH> array are

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -34,6 +34,31 @@ extern "C" {
  */
 #define OSSL_PROV_PARAM_BUILDINFO   "buildinfo"
 
+/*
+ * The modules filename including the path (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+#define OSSL_PROV_PARAM_MODULE_FILENAME "module-filename"
+/*
+ * The calculated MAC of the module file (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+#define OSSL_PROV_PARAM_MODULE_MAC      "module-checksum"
+/*
+ * A version number for the fips install process (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+#define OSSL_PROV_PARAM_INSTALL_VERSION "install-version"
+/*
+ * The calculated MAC of the install status indicator (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+#define OSSL_PROV_PARAM_INSTALL_MAC     "install-checksum"
+/*
+ * The install status indicator (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+#define OSSL_PROV_PARAM_INSTALL_STATUS  "install-status"
 
 /* cipher parameters */
 #define OSSL_CIPHER_PARAM_PADDING   "padding"    /* int */

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -35,30 +35,10 @@ extern "C" {
 #define OSSL_PROV_PARAM_BUILDINFO   "buildinfo"
 
 /*
- * The module filename (Used for FIPS Self Testing)
- * Type: OSSL_PARAM_UTF8_STRING
+ * The module filename
+ * Type: OSSL_PARAM_OCTET_STRING
  */
 #define OSSL_PROV_PARAM_MODULE_FILENAME "module-filename"
-/*
- * The calculated MAC of the module file (Used for FIPS Self Testing)
- * Type: OSSL_PARAM_UTF8_STRING
- */
-#define OSSL_PROV_PARAM_MODULE_MAC      "module-checksum"
-/*
- * A version number for the fips install process (Used for FIPS Self Testing)
- * Type: OSSL_PARAM_UTF8_STRING
- */
-#define OSSL_PROV_PARAM_INSTALL_VERSION "install-version"
-/*
- * The calculated MAC of the install status indicator (Used for FIPS Self Testing)
- * Type: OSSL_PARAM_UTF8_STRING
- */
-#define OSSL_PROV_PARAM_INSTALL_MAC     "install-checksum"
-/*
- * The install status indicator (Used for FIPS Self Testing)
- * Type: OSSL_PARAM_UTF8_STRING
- */
-#define OSSL_PROV_PARAM_INSTALL_STATUS  "install-status"
 
 /* cipher parameters */
 #define OSSL_CIPHER_PARAM_PADDING   "padding"    /* int */

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -35,7 +35,7 @@ extern "C" {
 #define OSSL_PROV_PARAM_BUILDINFO   "buildinfo"
 
 /*
- * The modules filename including the path (Used for FIPS Self Testing)
+ * The module filename (Used for FIPS Self Testing)
  * Type: OSSL_PARAM_UTF8_STRING
  */
 #define OSSL_PROV_PARAM_MODULE_FILENAME "module-filename"

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -118,6 +118,18 @@ OSSL_CORE_MAKE_FUNC(int,
 OSSL_CORE_MAKE_FUNC(void,
         OPENSSL_cleanse, (void *ptr, size_t len))
 
+/* Bio functions provided by the core */
+#define OSSL_FUNC_BIO_NEW_FILE                22
+#define OSSL_FUNC_BIO_NEW_MEMBUF              23
+#define OSSL_FUNC_BIO_READ                    24
+#define OSSL_FUNC_BIO_FREE                    25
+
+OSSL_CORE_MAKE_FUNC(BIO *, BIO_new_file, (const char *filename, const char *mode))
+OSSL_CORE_MAKE_FUNC(BIO *, BIO_new_membuf, (const void *buf, int len))
+OSSL_CORE_MAKE_FUNC(int, BIO_read, (BIO *bio, void *data, size_t data_len,
+                                    size_t *bytes_read))
+OSSL_CORE_MAKE_FUNC(int, BIO_free, (BIO *bio))
+
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024
 OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))

--- a/include/openssl/fips.h
+++ b/include/openssl/fips.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_FIPS_H
+# define OSSL_FIPS_H
+
+# ifdef __cplusplus
+extern "C" {
+# endif
+
+/*
+ * Parameter names that the FIPS Provider defines
+ */
+
+/*
+ * The calculated MAC of the module file (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_MODULE_MAC      "module-checksum"
+/*
+ * A version number for the fips install process (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_INSTALL_VERSION "install-version"
+/*
+ * The calculated MAC of the install status indicator (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_INSTALL_MAC     "install-checksum"
+/*
+ * The install status indicator (Used for FIPS Self Testing)
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_INSTALL_STATUS  "install-status"
+
+# ifdef __cplusplus
+}
+# endif
+
+#endif /* OSSL_FIPS_H */

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OSSL_FIPS_H
-# define OSSL_FIPS_H
+#ifndef OSSL_FIPS_NAMES_H
+# define OSSL_FIPS_NAMES_H
 
 # ifdef __cplusplus
 extern "C" {
@@ -43,4 +43,4 @@ extern "C" {
 }
 # endif
 
-#endif /* OSSL_FIPS_H */
+#endif /* OSSL_FIPS_NAMES_H */

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -12,6 +12,7 @@
 #include <openssl/core.h>
 #include <openssl/core_numbers.h>
 #include <openssl/core_names.h>
+#include <openssl/fips.h>
 #include <openssl/params.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -92,23 +93,23 @@ static const OSSL_PARAM fips_param_types[] = {
 /*
  * Parameters to retrieve from the core provider - required for self testing.
  * NOTE: inside core_get_params() these will be loaded from config items
- * stored inside prov->parameters.
+ * stored inside prov->parameters (except for OSSL_PROV_PARAM_MODULE_FILENAME).
  */
 static OSSL_PARAM core_params[] =
 {
     OSSL_PARAM_utf8_ptr(OSSL_PROV_PARAM_MODULE_FILENAME,
                         selftest_params.module_filename,
                         sizeof(selftest_params.module_filename)),
-    OSSL_PARAM_utf8_ptr(OSSL_PROV_PARAM_MODULE_MAC,
+    OSSL_PARAM_utf8_ptr(OSSL_PROV_FIPS_PARAM_MODULE_MAC,
                         selftest_params.module_checksum_data,
                         sizeof(selftest_params.module_checksum_data)),
-    OSSL_PARAM_utf8_ptr(OSSL_PROV_PARAM_INSTALL_MAC,
+    OSSL_PARAM_utf8_ptr(OSSL_PROV_FIPS_PARAM_INSTALL_MAC,
                         selftest_params.indicator_checksum_data,
                         sizeof(selftest_params.indicator_checksum_data)),
-    OSSL_PARAM_utf8_ptr(OSSL_PROV_PARAM_INSTALL_STATUS,
+    OSSL_PARAM_utf8_ptr(OSSL_PROV_FIPS_PARAM_INSTALL_STATUS,
                         selftest_params.indicator_data,
                         sizeof(selftest_params.indicator_data)),
-    OSSL_PARAM_utf8_ptr(OSSL_PROV_PARAM_INSTALL_VERSION,
+    OSSL_PARAM_utf8_ptr(OSSL_PROV_FIPS_PARAM_INSTALL_VERSION,
                         selftest_params.indicator_version,
                         sizeof(selftest_params.indicator_version)),
     OSSL_PARAM_END
@@ -359,8 +360,6 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 {
     FIPS_GLOBAL *fgbl;
     OPENSSL_CTX *ctx;
-
-    memset(&selftest_params, 0, sizeof(selftest_params));
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -92,7 +92,7 @@ static const OSSL_PARAM fips_param_types[] = {
 /*
  * Parameters to retrieve from the core provider - required for self testing.
  * NOTE: inside core_get_params() these will be loaded from config items
- * styored inside prov->parameters
+ * stored inside prov->parameters.
  */
 static OSSL_PARAM core_params[] =
 {

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -12,7 +12,6 @@
 #include <openssl/core.h>
 #include <openssl/core_numbers.h>
 #include <openssl/core_names.h>
-#include <openssl/fips.h>
 #include <openssl/params.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -21,6 +20,7 @@
 #include <openssl/sha.h>
 #include <openssl/rand_drbg.h>
 #include <openssl/ec.h>
+#include <openssl/fips_names.h>
 
 #include "internal/cryptlib.h"
 #include "internal/property.h"

--- a/providers/fips/selftest.h
+++ b/providers/fips/selftest.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/params.h>
+#include <openssl/core_numbers.h>
+
+typedef struct self_test_post_params_st {
+    /* FIPS module integrity check parameters */
+    char *module_filename;                /* Module file to perform MAC on */
+    unsigned char *module_checksum_data;  /* Expected module MAC integrity */
+    size_t module_checksum_len;
+
+    /* Used for KAT install indicator integrity check */
+    char *indicator_version;                /* version - for future proofing */
+    char *indicator_data;                   /* data to perform MAC on */
+    unsigned char *indicator_checksum_data; /* Expected MAC integrity value */
+    size_t indicator_checksum_len;
+
+    /* BIO callbacks supplied to the FIPS provider */
+    OSSL_BIO_new_file_fn *bio_new_file_cb;
+    OSSL_BIO_new_membuf_fn *bio_new_buffer_cb;
+    OSSL_BIO_read_fn *bio_read_cb;
+    OSSL_BIO_free_fn *bio_free_cb;
+
+} SELF_TEST_POST_PARAMS;

--- a/providers/fips/selftest.h
+++ b/providers/fips/selftest.h
@@ -12,15 +12,13 @@
 
 typedef struct self_test_post_params_st {
     /* FIPS module integrity check parameters */
-    char *module_filename;                /* Module file to perform MAC on */
-    unsigned char *module_checksum_data;  /* Expected module MAC integrity */
-    size_t module_checksum_len;
+    const char *module_filename;            /* Module file to perform MAC on */
+    const char *module_checksum_data;       /* Expected module MAC integrity */
 
     /* Used for KAT install indicator integrity check */
-    char *indicator_version;                /* version - for future proofing */
-    char *indicator_data;                   /* data to perform MAC on */
-    unsigned char *indicator_checksum_data; /* Expected MAC integrity value */
-    size_t indicator_checksum_len;
+    const char *indicator_version;          /* version - for future proofing */
+    const char *indicator_data;             /* data to perform MAC on */
+    const char *indicator_checksum_data;    /* Expected MAC integrity value */
 
     /* BIO callbacks supplied to the FIPS provider */
     OSSL_BIO_new_file_fn *bio_new_file_cb;


### PR DESCRIPTION
More PR's related to self test will be derived from this PR.

Note: the code removed in core_get_params() was causing a freeze since the
fips module was being loaded from a config file, which then called core_get_params()
which then tried to init the config fle again...

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
