### PR TITLE
Ignore function code collisions

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -220,8 +220,6 @@ if ( ! $reindex && $statefile ) {
             }
             $rcodes{$name} = $code;
         } elsif ( $name =~ /^(?:OSSL_|OPENSSL_)?[A-Z0-9]{2,}_F_/ ) {
-            die "$lib function code $code collision at $name\n"
-                if $fassigned{$lib} =~ /:$code:/;
             $fassigned{$lib} .= "$code:";
             $fmax{$lib} = $code if $code > $fmax{$lib};
             $fcodes{$name} = $code;


### PR DESCRIPTION
"make update" is broken.

Before this fix:
```
EC function code 300 collision at EC_F_OSSL_ECDSA_SIGN_SETUP
Makefile:582: recipe for target 'errors' failed
make: *** [errors] Error 1
```

Since function codes aren't used any more in master, just ignore errors.
