### PR TITLE
Save frame pointer in sha1.

### DIFF
--- a/crypto/sha/asm/sha1-x86_64.pl
+++ b/crypto/sha/asm/sha1-x86_64.pl
@@ -480,12 +480,12 @@ my $Xi=4;
 my @X=map("%xmm$_",(4..7,0..3));
 my @Tx=map("%xmm$_",(8..10));
 my $Kx="%xmm11";
-my @V=($A,$B,$C,$D,$E)=("%eax","%ebx","%ecx","%edx","%ebp");	# size optimization
+my @V=($A,$B,$C,$D,$E)=("%eax","%ebx","%ecx","%edx","%r11d");	# size optimization
 my @T=("%esi","%edi");
 my $j=0;
 my $rx=0;
 my $K_XX_XX="%r14";
-my $fp="%r11";
+my $fp="%rbp";
 
 my $_rol=sub { &rol(@_) };
 my $_ror=sub { &ror(@_) };
@@ -507,12 +507,12 @@ $code.=<<___;
 sha1_block_data_order_ssse3:
 _ssse3_shortcut:
 .cfi_startproc
+	push	%rbp
+.cfi_adjust_cfa_offset -8
 	mov	%rsp,$fp	# frame pointer
 .cfi_def_cfa_register	$fp
 	push	%rbx
 .cfi_push	%rbx
-	push	%rbp
-.cfi_push	%rbp
 	push	%r12
 .cfi_push	%r12
 	push	%r13		# redundant, done to share Win64 SE handler
@@ -945,18 +945,18 @@ $code.=<<___ if ($win64);
 	movaps	-40-1*16($fp),%xmm11
 ___
 $code.=<<___;
-	mov	-40($fp),%r14
+	mov	-32($fp),%r14
 .cfi_restore	%r14
-	mov	-32($fp),%r13
+	mov	-24($fp),%r13
 .cfi_restore	%r13
-	mov	-24($fp),%r12
+	mov	-16($fp),%r12
 .cfi_restore	%r12
-	mov	-16($fp),%rbp
-.cfi_restore	%rbp
 	mov	-8($fp),%rbx
 .cfi_restore	%rbx
-	lea	($fp),%rsp
+	mov	$fp,%rsp
 .cfi_def_cfa_register	%rsp
+	pop     %rbp
+.cfi_adjust_cfa_offset 8
 .Lepilogue_ssse3:
 	ret
 .cfi_endproc
@@ -981,12 +981,12 @@ $code.=<<___;
 sha1_block_data_order_avx:
 _avx_shortcut:
 .cfi_startproc
+	push	%rbp
+.cfi_adjust_cfa_offset -8
 	mov	%rsp,$fp
 .cfi_def_cfa_register	$fp
 	push	%rbx
 .cfi_push	%rbx
-	push	%rbp
-.cfi_push	%rbp
 	push	%r12
 .cfi_push	%r12
 	push	%r13		# redundant, done to share Win64 SE handler
@@ -1321,18 +1321,18 @@ $code.=<<___ if ($win64);
 	movaps	-40-1*16($fp),%xmm11
 ___
 $code.=<<___;
-	mov	-40($fp),%r14
+	mov	-32($fp),%r14
 .cfi_restore	%r14
-	mov	-32($fp),%r13
+	mov	-24($fp),%r13
 .cfi_restore	%r13
-	mov	-24($fp),%r12
+	mov	-16($fp),%r12
 .cfi_restore	%r12
-	mov	-16($fp),%rbp
-.cfi_restore	%rbp
 	mov	-8($fp),%rbx
 .cfi_restore	%rbx
-	lea	($fp),%rsp
+	mov	$fp,%rsp
 .cfi_def_cfa_register	%rsp
+	pop	%rbp
+.cfi_adjust_cfa_offset 8
 .Lepilogue_avx:
 	ret
 .cfi_endproc
@@ -1347,7 +1347,7 @@ $Xi=4;					# reset variables
 $Kx="%ymm11";
 $j=0;
 
-my @ROTX=("%eax","%ebp","%ebx","%ecx","%edx","%esi");
+my @ROTX=("%eax","%r11d","%ebx","%ecx","%edx","%esi");
 my ($a5,$t0)=("%r12d","%edi");
 
 my ($A,$F,$B,$C,$D,$E)=@ROTX;
@@ -1360,12 +1360,12 @@ $code.=<<___;
 sha1_block_data_order_avx2:
 _avx2_shortcut:
 .cfi_startproc
+	push	%rbp
+.cfi_adjust_cfa_offset -8
 	mov	%rsp,$fp
 .cfi_def_cfa_register	$fp
 	push	%rbx
 .cfi_push	%rbx
-	push	%rbp
-.cfi_push	%rbp
 	push	%r12
 .cfi_push	%r12
 	push	%r13
@@ -1812,18 +1812,18 @@ $code.=<<___ if ($win64);
 	movaps	-40-1*16($fp),%xmm11
 ___
 $code.=<<___;
-	mov	-40($fp),%r14
+	mov	-32($fp),%r14
 .cfi_restore	%r14
-	mov	-32($fp),%r13
+	mov	-24($fp),%r13
 .cfi_restore	%r13
-	mov	-24($fp),%r12
+	mov	-16($fp),%r12
 .cfi_restore	%r12
-	mov	-16($fp),%rbp
-.cfi_restore	%rbp
 	mov	-8($fp),%rbx
 .cfi_restore	%rbx
-	lea	($fp),%rsp
+	mov	$fp,%rsp
 .cfi_def_cfa_register	%rsp
+	pop	%rbp
+.cfi_adjust_cfa_offset 8
 .Lepilogue_avx2:
 	ret
 .cfi_endproc


### PR DESCRIPTION
This allows perf to record accurate call stacks. We already save rbp,
and use register as a frame pointer, so simply use rbp as a frame pointer.
Tested by looking at perf report after perf record -g openssl speed sha1.