### PR TITLE
Comma after eg ie

### DIFF
--- a/doc/internal/man3/evp_keymgmt_export_to_provider.pod
+++ b/doc/internal/man3/evp_keymgmt_export_to_provider.pod
@@ -22,7 +22,7 @@ It maintains a cache of provider key references in I<pk> to keep track
 of all such exports.
 
 If I<pk> has an assigned legacy key, a check is done to see if any of
-its key material has changed since last export, i.e. the legacy key's
+its key material has changed since last export, i.e., the legacy key's
 is_dirty() method returns 1.
 If it has, the cache of already exported keys is cleared, and a new
 export is made with the new key material.

--- a/doc/internal/man3/openssl_ctx_get_data.pod
+++ b/doc/internal/man3/openssl_ctx_get_data.pod
@@ -63,7 +63,7 @@ failure.
 =head2 Initialization
 
 For a type C<FOO> that should end up in the OpenSSL library context, a
-small bit of initialization is needed, i.e. to associate a constructor
+small bit of initialization is needed, i.e., to associate a constructor
 and a destructor to an index.
 
  typedef struct foo_st {

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -65,7 +65,7 @@ I<mcm> and the data in I<mcm_data> (which is passed by
 ossl_method_construct()).
 
 This function assumes that the sub-system method creator implements
-reference counting and acts accordingly (i.e. it will call the
+reference counting and acts accordingly (i.e., it will call the
 sub-system destruct() method to decrement the reference count when
 appropriate).
 

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -74,7 +74,7 @@ in the library context.
 
 Provider objects are reference counted.
 
-Provider objects are initially inactive, i.e. they are only recorded
+Provider objects are initially inactive, i.e., they are only recorded
 in the store, but are not used.
 They are activated with the first call to ossl_provider_activate(),
 and are inactivated when ossl_provider_free() has been called as many

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -193,7 +193,7 @@ The number of days to certify the certificate for.
 
 The message digest to use.
 Any digest supported by the OpenSSL B<dgst> command can be used. For signing
-algorithms that do not support a digest (i.e. Ed25519 and Ed448) any message
+algorithms that do not support a digest (i.e., Ed25519 and Ed448) any message
 digest that is set is ignored. This option also applies to CRLs.
 
 =item B<-policy arg>
@@ -474,7 +474,7 @@ least one of these must be present to generate a CRL.
 =item B<default_md>
 
 The same as the B<-md> option. Mandatory except where the signing algorithm does
-not require a digest (i.e. Ed25519 and Ed448).
+not require a digest (i.e., Ed25519 and Ed448).
 
 =item B<database>
 

--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -145,7 +145,7 @@ Names and values of these options are algorithm-specific.
 =item B<-key password>
 
 The password used to encrypt the private key. Since on some
-systems the command line arguments are visible (e.g. Unix with
+systems the command line arguments are visible (e.g., Unix with
 the 'ps' utility) this option should be used with caution.
 
 =item B<-selfsign>

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -258,17 +258,17 @@ Anonymous Elliptic Curve Diffie-Hellman cipher suites.
 
 =item B<aDSS>, B<DSS>
 
-Cipher suites using DSS authentication, i.e. the certificates carry DSS keys.
+Cipher suites using DSS authentication, i.e., the certificates carry DSS keys.
 
 =item B<aDH>
 
-Cipher suites effectively using DH authentication, i.e. the certificates carry
+Cipher suites effectively using DH authentication, i.e., the certificates carry
 DH keys.
 All these cipher suites have been removed in OpenSSL 1.1.0.
 
 =item B<aECDSA>, B<ECDSA>
 
-Cipher suites using ECDSA authentication, i.e. the certificates carry ECDSA
+Cipher suites using ECDSA authentication, i.e., the certificates carry ECDSA
 keys.
 
 =item B<TLSv1.2>, B<TLSv1.0>, B<SSLv3>

--- a/doc/man1/ciphers.pod
+++ b/doc/man1/ciphers.pod
@@ -405,7 +405,7 @@ permissible.
 The following lists give the SSL or TLS cipher suites names from the
 relevant specification and their OpenSSL equivalents. It should be noted,
 that several cipher suite names do not include the authentication used,
-e.g. DES-CBC3-SHA. In these cases, RSA authentication is used.
+e.g., DES-CBC3-SHA. In these cases, RSA authentication is used.
 
 =head2 SSL v3.0 cipher suites
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -589,7 +589,7 @@ An ESS signing-certificate-v2 attribute allows for the use of any digest algorit
 The digital signature value computed on the user data and, when present, on the signed attributes.
 
 Note that currently the B<-cades> option applies only to the B<-sign> operation and is ignored during
-the B<-verify> operation, i.e. the signing certification is not checked during the verification process.
+the B<-verify> operation, i.e., the signing certification is not checked during the verification process.
 This feature might be added in a future version.
 
 =back

--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -125,7 +125,7 @@ the preprocessor macro B<OPENSSL_EC_BIN_PT_COMP> at compile time.
 =item B<-param_enc arg>
 
 This specifies how the elliptic curve parameters are encoded.
-Possible value are: B<named_curve>, i.e. the ec parameters are
+Possible value are: B<named_curve>, i.e., the ec parameters are
 specified by an OID, or B<explicit> where the ec parameters are
 explicitly given (see RFC 3279 for the definition of the
 EC parameters structures). The default value is B<named_curve>.

--- a/doc/man1/ecparam.pod
+++ b/doc/man1/ecparam.pod
@@ -108,7 +108,7 @@ the preprocessor macro B<OPENSSL_EC_BIN_PT_COMP> at compile time.
 =item B<-param_enc arg>
 
 This specifies how the elliptic curve parameters are encoded.
-Possible value are: B<named_curve>, i.e. the ec parameters are
+Possible value are: B<named_curve>, i.e., the ec parameters are
 specified by an OID, or B<explicit> where the ec parameters are
 explicitly given (see RFC 3279 for the definition of the
 EC parameters structures). The default value is B<named_curve>.

--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -198,7 +198,7 @@ The digest to use during parameter generation. Must be one of B<sha1>, B<sha224>
 or B<sha256>. If set, then the number of bits in B<q> will match the output size
 of the specified digest and the B<dsa_paramgen_q_bits> parameter will be
 ignored. If not set, then a digest will be used that gives an output matching
-the number of bits in B<q>, i.e. B<sha1> if q length is 160, B<sha224> if it 224
+the number of bits in B<q>, i.e., B<sha1> if q length is 160, B<sha224> if it 224
 or B<sha256> if it is 256.
 
 =back

--- a/doc/man1/list.pod
+++ b/doc/man1/list.pod
@@ -108,7 +108,7 @@ of the installation.
 
 =item B<-objects>
 
-Display a list of built in objects, i.e. OIDs with names.  They're listed in the
+Display a list of built in objects, i.e., OIDs with names.  They're listed in the
 format described in L<config(5)/ASN1 Object Configuration Module>.
 
 =back

--- a/doc/man1/mac.pod
+++ b/doc/man1/mac.pod
@@ -79,7 +79,7 @@ To see the list of supported digests, use the command I<list -digest-commands>.
 Used by CMAC and GMAC to specify the cipher algorithm.
 For CMAC it must be one of AES-128-CBC, AES-192-CBC, AES-256-CBC or
 DES-EDE3-CBC.
-For GMAC it should be a GCM mode cipher e.g. AES-128-GCM.
+For GMAC it should be a GCM mode cipher e.g., AES-128-GCM.
 
 =item B<iv:string>
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -524,7 +524,7 @@ where security is not important.
 
 Obtain the password from the environment variable B<var>. Since
 the environment of other processes is visible on certain platforms
-(e.g. ps under certain Unix OSes) this option should be used with caution.
+(e.g., ps under certain Unix OSes) this option should be used with caution.
 
 =item B<file:pathname>
 

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -77,7 +77,7 @@ default.  They are all written in PEM format.
 
 =item B<-passin arg>
 
-The PKCS#12 file (i.e. input file) password source. For more information about
+The PKCS#12 file (i.e., input file) password source. For more information about
 the format of B<arg> see the B<PASS PHRASE ARGUMENTS> section in
 L<openssl(1)>.
 
@@ -205,7 +205,7 @@ displays them.
 
 =item B<-pass arg>, B<-passout arg>
 
-The PKCS#12 file (i.e. output file) password source. For more information about
+The PKCS#12 file (i.e., output file) password source. For more information about
 the format of B<arg> see the B<PASS PHRASE ARGUMENTS> section in
 L<openssl(1)>.
 

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -165,7 +165,7 @@ Sets the scrypt B<N>, B<r> or B<p> parameters.
 Various different formats are used by the pkcs8 utility. These are detailed
 below.
 
-If a key is being converted from PKCS#8 form (i.e. the B<-topk8> option is
+If a key is being converted from PKCS#8 form (i.e., the B<-topk8> option is
 not used) then the input file must be in PKCS#8 format. An encrypted
 key is expected unless B<-nocrypt> is included.
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -214,7 +214,7 @@ The value B<alg> should represent a digest name as used in the
 EVP_get_digestbyname() function for example B<sha1>. This value is not used to
 hash the input data. It is used (by some algorithms) for sanity-checking the
 lengths of data passed in to the B<pkeyutl> and for creating the structures that
-make up the signature (e.g. B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
+make up the signature (e.g., B<DigestInfo> in RSASSA PKCS#1 v1.5 signatures).
 
 This utility does not hash the input data (except where -rawin is used) but
 rather it will use the data directly as input to the signature algorithm.
@@ -349,11 +349,11 @@ Sign some data using a private key:
 
  openssl pkeyutl -sign -in file -inkey key.pem -out sig
 
-Recover the signed data (e.g. if an RSA key is used):
+Recover the signed data (e.g., if an RSA key is used):
 
  openssl pkeyutl -verifyrecover -in sig -inkey key.pem
 
-Verify the signature (e.g. a DSA key):
+Verify the signature (e.g., a DSA key):
 
  openssl pkeyutl -verify -in file -sigfile sig -inkey key.pem
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -159,7 +159,7 @@ This can be used with a subsequent B<-rand> flag.
 This option creates a new certificate request and a new private
 key. The argument takes one of several forms. B<rsa:nbits>, where
 B<nbits> is the number of bits, generates an RSA key B<nbits>
-in size. If B<nbits> is omitted, i.e. B<-newkey rsa> specified,
+in size. If B<nbits> is omitted, i.e., B<-newkey rsa> specified,
 the default key size, specified in the configuration file is used.
 
 All other algorithms support the B<-newkey alg:file> form, where file may be
@@ -357,7 +357,7 @@ certificate. The argument for this option is string of hexadecimal digits.
 
 The configuration options are specified in the B<req> section of
 the configuration file. As with all configuration files if no
-value is specified in the specific section (i.e. B<req>) then
+value is specified in the specific section (i.e., B<req>) then
 the initial unnamed or B<default> section is searched too.
 
 The options available are described in detail below.
@@ -416,7 +416,7 @@ option. For compatibility B<encrypt_rsa_key> is an equivalent option.
 
 This option specifies the digest algorithm to use. Any digest supported by the
 OpenSSL B<dgst> command can be used. This option can be overridden on the
-command line. Certain signing algorithms (i.e. Ed25519 and Ed448) will ignore
+command line. Certain signing algorithms (i.e., Ed25519 and Ed448) will ignore
 any digest that has been set.
 
 =item B<string_mask>

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -485,7 +485,7 @@ just consist of field names and values: for example,
  OU=My Organization
  emailAddress=someone@somewhere.org
 
-This allows external programs (e.g. GUI based) to generate a template file
+This allows external programs (e.g., GUI based) to generate a template file
 with all the field names and values and just pass it to B<req>. An example
 of this kind of configuration file is contained in the B<EXAMPLES> section.
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -546,7 +546,7 @@ L<SSL_CTX_set_split_send_fragment(3)> for further information.
 =item B<-max_pipelines int>
 
 The maximum number of encrypt/decrypt pipelines to be used. This will only have
-an effect if an engine has been loaded that supports pipelining (e.g. the dasync
+an effect if an engine has been loaded that supports pipelining (e.g., the dasync
 engine) and a suitable cipher suite has been negotiated. The default value is 1.
 See L<SSL_CTX_set_max_pipelines(3)> for further information.
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -520,7 +520,7 @@ L<SSL_CTX_set_split_send_fragment(3)> for further information.
 =item B<-max_pipelines +int>
 
 The maximum number of encrypt/decrypt pipelines to be used. This will only have
-an effect if an engine has been loaded that supports pipelining (e.g. the dasync
+an effect if an engine has been loaded that supports pipelining (e.g., the dasync
 engine) and a suitable cipher suite has been negotiated. The default value is 1.
 See L<SSL_CTX_set_max_pipelines(3)> for further information.
 

--- a/doc/man1/speed.pod
+++ b/doc/man1/speed.pod
@@ -54,7 +54,7 @@ of hardware engines.
 
 Use the specified cipher or message digest algorithm via the EVP interface.
 If B<algo> is an AEAD cipher, then you can pass <-aead> to benchmark a
-TLS-like sequence. And if B<algo> is a multi-buffer capable cipher, e.g.
+TLS-like sequence. And if B<algo> is a multi-buffer capable cipher, such as
 aes-128-cbc-hmac-sha1, then B<-mb> will time multi-buffer operation.
 
 =item B<-hmac digest>
@@ -63,7 +63,7 @@ Time the HMAC algorithm using the specified message digest.
 
 =item B<-cmac cipher>
 
-Time the CMAC algorithm using the specified cipher e.g. B<speed -cmac aes128>.
+Time the CMAC algorithm using the specified cipher e.g., B<speed -cmac aes128>.
 
 =item B<-decrypt>
 

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -162,7 +162,7 @@ parameter is specified. (Optional)
 
 It is possible to specify the message imprint explicitly without the data
 file. The imprint must be specified in a hexadecimal format, two characters
-per byte, the bytes optionally separated by colons (e.g. 1A:F6:01:... or
+per byte, the bytes optionally separated by colons (e.g., 1A:F6:01:... or
 1AF601...). The number of bytes must match the message digest algorithm
 in use. (Optional)
 
@@ -285,7 +285,7 @@ B<default_policy> config file option. (Optional)
 Specifies a previously created time stamp response or time stamp token
 (if B<-token_in> is also specified) in DER format that will be written
 to the output file. This option does not require a request, it is
-useful e.g. when you need to examine the content of a response or
+useful e.g., when you need to examine the content of a response or
 token or you want to extract the time stamp token from a response. If
 the input is a token and the output is a time stamp response a default
 'granted' status info is added to the token. (Optional)
@@ -438,7 +438,7 @@ generation a new file is created with serial number 1. (Mandatory)
 
 Specifies the OpenSSL engine that will be set as the default for
 all available algorithms. The default value is builtin, you can specify
-any other engines supported by OpenSSL (e.g. use chil for the NCipher HSM).
+any other engines supported by OpenSSL (e.g., use chil for the NCipher HSM).
 (Optional)
 
 =item B<signer_cert>
@@ -481,7 +481,7 @@ one algorithm must be specified. (Mandatory)
 =item B<accuracy>
 
 The accuracy of the time source of the TSA in seconds, milliseconds
-and microseconds. E.g. secs:1, millisecs:500, microsecs:100. If any of
+and microseconds; e.g., secs:1, millisecs:500, microsecs:100. If any of
 the components is missing zero is assumed for that field. (Optional)
 
 =item B<clock_precision_digits>
@@ -525,7 +525,7 @@ public key certificate identifier. Default is sha256. (Optional)
 =head1 EXAMPLES
 
 All the examples below presume that B<OPENSSL_CONF> is set to a proper
-configuration file, e.g. the example configuration file
+configuration file, e.g., the example configuration file
 openssl/apps/openssl.cnf will do.
 
 =head2 Time Stamp Request

--- a/doc/man3/ASN1_TIME_set.pod
+++ b/doc/man3/ASN1_TIME_set.pod
@@ -108,7 +108,7 @@ The B<tm_sec>, B<tm_min>, B<tm_hour>, B<tm_mday>, B<tm_wday>, B<tm_yday>,
 B<tm_mon> and B<tm_year> fields of B<tm> structure are set to proper values,
 whereas all other fields are set to 0. If B<tm> is NULL this function performs
 a format check on B<s> only. If B<s> is in Generalized format with fractional
-seconds, e.g. YYYYMMDDHHMMSS.SSSZ, the fractional seconds will be lost while
+seconds, e.g., YYYYMMDDHHMMSS.SSSZ, the fractional seconds will be lost while
 converting B<s> to B<tm> structure.
 
 ASN1_TIME_diff() sets B<*pday> and B<*psec> to the time difference between

--- a/doc/man3/ASN1_TIME_set.pod
+++ b/doc/man3/ASN1_TIME_set.pod
@@ -89,7 +89,7 @@ on B<str> only.
 The ASN1_TIME_normalize() function converts an ASN1_GENERALIZEDTIME or
 ASN1_UTCTIME into a time value that can be used in a certificate. It
 should be used after the ASN1_TIME_set_string() functions and before
-ASN1_TIME_print() functions to get consistent (i.e. GMT) results.
+ASN1_TIME_print() functions to get consistent (i.e., GMT) results.
 
 The ASN1_TIME_check(), ASN1_UTCTIME_check() and ASN1_GENERALIZEDTIME_check()
 functions check the syntax of the time structure B<s>.

--- a/doc/man3/ASYNC_WAIT_CTX_new.pod
+++ b/doc/man3/ASYNC_WAIT_CTX_new.pod
@@ -57,7 +57,7 @@ function prior to calling ASYNC_start_job() (see L<ASYNC_start_job(3)>). When
 the job is started it is associated with the ASYNC_WAIT_CTX for the duration of
 that job. An ASYNC_WAIT_CTX should only be used for one ASYNC_JOB at any one
 time, but can be reused after an ASYNC_JOB has finished for a subsequent
-ASYNC_JOB. When the session is complete (e.g. the SSL connection is closed),
+ASYNC_JOB. When the session is complete (e.g., the SSL connection is closed),
 application code cleans up with ASYNC_WAIT_CTX_free().
 
 ASYNC_WAIT_CTXs can have "wait" file descriptors associated with them. Calling
@@ -83,7 +83,7 @@ will be populated with the list of added and deleted fds respectively. Similarly
 to ASYNC_WAIT_CTX_get_all_fds() either of these can be NULL, but if they are not
 NULL then the caller is responsible for ensuring sufficient memory is allocated.
 
-Implementors of async aware code (e.g. engines) are encouraged to return a
+Implementors of async aware code (e.g., engines) are encouraged to return a
 stable fd for the lifetime of the ASYNC_WAIT_CTX in order to reduce the "churn"
 of regularly changing fds - although no guarantees of this are provided to
 applications.
@@ -94,7 +94,7 @@ that the job should be resumed). If no file descriptor is made available then an
 application will have to periodically "poll" the job by attempting to restart it
 to see if it is ready to continue.
 
-Async aware code (e.g. engines) can get the current ASYNC_WAIT_CTX from the job
+Async aware code (e.g., engines) can get the current ASYNC_WAIT_CTX from the job
 via L<ASYNC_get_wait_ctx(3)> and provide a file descriptor to use for waiting
 on by calling ASYNC_WAIT_CTX_set_wait_fd(). Typically this would be done by an
 engine immediately prior to calling ASYNC_pause_job() and not by end user code.

--- a/doc/man3/ASYNC_WAIT_CTX_new.pod
+++ b/doc/man3/ASYNC_WAIT_CTX_new.pod
@@ -49,7 +49,7 @@ ASYNC_STATUS_EAGAIN
 
 For an overview of how asynchronous operations are implemented in OpenSSL see
 L<ASYNC_start_job(3)>. An ASYNC_WAIT_CTX object represents an asynchronous
-"session", i.e. a related set of crypto operations. For example in SSL terms
+"session", i.e., a related set of crypto operations. For example in SSL terms
 this would have a one-to-one correspondence with an SSL connection.
 
 Application code must create an ASYNC_WAIT_CTX using the ASYNC_WAIT_CTX_new()

--- a/doc/man3/ASYNC_start_job.pod
+++ b/doc/man3/ASYNC_start_job.pod
@@ -97,7 +97,7 @@ At any one time there can be a maximum of one job actively running per thread
 a pointer to the currently executing ASYNC_JOB. If no job is currently executing
 then this will return NULL.
 
-If executing within the context of a job (i.e. having been called directly or
+If executing within the context of a job (i.e., having been called directly or
 indirectly by the function "func" passed as an argument to ASYNC_start_job())
 then ASYNC_pause_job() will immediately return control to the calling
 application with ASYNC_PAUSE returned from the ASYNC_start_job() call. A
@@ -231,7 +231,7 @@ The following example demonstrates how to use most of the core async APIs:
 
      /*
       * Normally some external event would cause this to happen at some
-      * later point - but we do it here for demo purposes, i.e.
+      * later point - but we do it here for demo purposes, i.e.,
       * immediately signalling that the job is ready to be woken up after
       * we return to main via ASYNC_pause_job().
       */

--- a/doc/man3/ASYNC_start_job.pod
+++ b/doc/man3/ASYNC_start_job.pod
@@ -67,7 +67,7 @@ ASYNC_start_job will return one of the following values:
 
 =item B<ASYNC_ERR>
 
-An error occurred trying to start the job. Check the OpenSSL error queue (e.g.
+An error occurred trying to start the job. Check the OpenSSL error queue (e.g.,
 see L<ERR_print_errors(3)>) for more details.
 
 =item B<ASYNC_NO_JOBS>
@@ -130,7 +130,7 @@ used even if it has been set. See ASYNC_WAIT_CTX_new() for more details.
 
 The ASYNC_block_pause() function will prevent the currently active job from
 pausing. The block will remain in place until a subsequent call to
-ASYNC_unblock_pause(). These functions can be nested, e.g. if you call
+ASYNC_unblock_pause(). These functions can be nested, e.g., if you call
 ASYNC_block_pause() twice then you must call ASYNC_unblock_pause() twice in
 order to re-enable pausing. If these functions are called while there is no
 currently active job then they have no effect. This functionality can be useful

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -292,8 +292,8 @@ A zero or negative value is returned if the connection could not be established.
 In OpenSSL before 1.0.0 the BIO_pop() call was handled incorrectly,
 the I/O BIO reference count was incorrectly incremented (instead of
 decremented) and dissociated with the SSL BIO even if the SSL BIO was not
-explicitly being popped (e.g. a pop higher up the chain). Applications which
-included workarounds for this bug (e.g. freeing BIOs more than once) should
+explicitly being popped (e.g., a pop higher up the chain). Applications which
+included workarounds for this bug (e.g., freeing BIOs more than once) should
 be modified to handle this fix or they may free up an already freed BIO.
 
 =head1 COPYRIGHT

--- a/doc/man3/BIO_get_data.pod
+++ b/doc/man3/BIO_get_data.pod
@@ -33,7 +33,7 @@ have occurred (for example through calling custom ctrls). The BIO_get_init()
 function returns the value of the "init" flag.
 
 The BIO_set_shutdown() and BIO_get_shutdown() functions set and get the state of
-this BIO's shutdown (i.e. BIO_CLOSE) flag. If set then the underlying resource
+this BIO's shutdown (i.e., BIO_CLOSE) flag. If set then the underlying resource
 is also closed when the BIO is freed.
 
 =head1 RETURN VALUES
@@ -43,7 +43,7 @@ associated with this BIO, or NULL if none has been set.
 
 BIO_get_init() returns the state of the BIO's init flag.
 
-BIO_get_shutdown() returns the stat of the BIO's shutdown (i.e. BIO_CLOSE) flag.
+BIO_get_shutdown() returns the stat of the BIO's shutdown (i.e., BIO_CLOSE) flag.
 
 =head1 SEE ALSO
 

--- a/doc/man3/BIO_meth_new.pod
+++ b/doc/man3/BIO_meth_new.pod
@@ -71,7 +71,7 @@ standard OpenSSL provided BIO types is provided in B<bio.h>. Some examples
 include B<BIO_TYPE_BUFFER> and B<BIO_TYPE_CIPHER>. Filter BIOs should have a
 type which have the "filter" bit set (B<BIO_TYPE_FILTER>). Source/sink BIOs
 should have the "source/sink" bit set (B<BIO_TYPE_SOURCE_SINK>). File descriptor
-based BIOs (e.g. socket, fd, connect, accept etc) should additionally have the
+based BIOs (e.g., socket, fd, connect, accept etc) should additionally have the
 "descriptor" bit set (B<BIO_TYPE_DESCRIPTOR>). See the L<BIO_find_type> page for
 more information.
 

--- a/doc/man3/BIO_new_CMS.pod
+++ b/doc/man3/BIO_new_CMS.pod
@@ -46,7 +46,7 @@ a BIO_f_buffer() buffering BIO will prevent this.
 
 =head1 BUGS
 
-There is currently no corresponding inverse BIO: i.e. one which can decode
+There is currently no corresponding inverse BIO: i.e., one which can decode
 a CMS structure on the fly.
 
 =head1 RETURN VALUES

--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -51,7 +51,7 @@ BN_bn2lebinpad() and BN_lebin2bn() are identical to BN_bn2binpad() and
 BN_bin2bn() except the buffer is in little-endian format.
 
 BN_bn2nativepad() and BN_native2bn() are identical to BN_bn2binpad() and
-BN_bin2bn() except the buffer is in native format, i.e. most significant
+BN_bin2bn() except the buffer is in native format, i.e., most significant
 byte first on big-endian platforms, and least significant byte first on
 little-endian platforms.
 

--- a/doc/man3/BN_copy.pod
+++ b/doc/man3/BN_copy.pod
@@ -38,7 +38,7 @@ should not have been used for other purposes or initialised in any way.
 
 =item *
 
-B<dest> must only be used in "read-only" operations, i.e. typically those
+B<dest> must only be used in "read-only" operations, i.e., typically those
 functions where the relevant parameter is declared "const".
 
 =item *

--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -95,7 +95,7 @@ If B<add> is not B<NULL>, the prime will fulfill the condition p % B<add>
 == B<rem> (p % B<add> == 1 if B<rem> == B<NULL>) in order to suit a given
 generator.
 
-If B<safe> is true, it will be a safe prime (i.e. a prime p so
+If B<safe> is true, it will be a safe prime (i.e., a prime p so
 that (p-1)/2 is also prime). If B<safe> is true, and B<rem> == B<NULL>
 the condition will be p % B<add> == 3.
 It is recommended that B<add> is a multiple of 4.

--- a/doc/man3/BN_mod_mul_montgomery.pod
+++ b/doc/man3/BN_mod_mul_montgomery.pod
@@ -48,7 +48,7 @@ the result in I<r>.
 
 BN_from_montgomery() performs the Montgomery reduction I<r> = I<a>*R^-1.
 
-BN_to_montgomery() computes Mont(I<a>,R^2), i.e. I<a>*R.
+BN_to_montgomery() computes Mont(I<a>,R^2), i.e., I<a>*R.
 Note that I<a> must be non-negative and smaller than the modulus.
 
 For all functions, I<ctx> is a previously allocated B<BN_CTX> used for

--- a/doc/man3/CTLOG_STORE_get0_log_by_id.pod
+++ b/doc/man3/CTLOG_STORE_get0_log_by_id.pod
@@ -18,7 +18,7 @@ Get a Certificate Transparency log from a CTLOG_STORE
 A Signed Certificate Timestamp (SCT) identifies the Certificate Transparency
 (CT) log that issued it using the log's LogID (see RFC 6962, Section 3.2).
 Therefore, it is useful to be able to look up more information about a log
-(e.g. its public key) using this LogID.
+(e.g., its public key) using this LogID.
 
 CTLOG_STORE_get0_log_by_id() provides a way to do this. It will find a CTLOG
 in a CTLOG_STORE that has a given LogID.

--- a/doc/man3/CTLOG_new.pod
+++ b/doc/man3/CTLOG_new.pod
@@ -40,7 +40,7 @@ created. Ownership of the string remains with the CTLOG.
 
 CTLOG_get0_log_id() sets *log_id to point to a string containing that log's
 LogID (see RFC 6962). It sets *log_id_len to the length of that LogID. For a
-v1 CT log, the LogID will be a SHA-256 hash (i.e. 32 bytes long). Ownership of
+v1 CT log, the LogID will be a SHA-256 hash (i.e., 32 bytes long). Ownership of
 the string remains with the CTLOG.
 
 CTLOG_get0_public_key() returns the public key of the CT log. Ownership of the

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -86,7 +86,7 @@ CT_POLICY_EVAL_CTX_set_time() to set the time SCTs should be compared with to de
 The SCT timestamp will be compared to this time to check whether the SCT was
 issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
 timestamp is in the future". By default, this will be set to 5 minutes in the
-future (e.g. (time() + 300) * 1000), to allow for clock drift.
+future (e.g., (time() + 300) * 1000), to allow for clock drift.
 
 The time should be in milliseconds since the Unix epoch.
 

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -101,7 +101,7 @@ CT_POLICY_EVAL_CTX_free() to delete it.
 
 The issuer certificate only needs to be provided if at least one of the SCTs
 was issued for a pre-certificate. This will be the case for SCTs embedded in a
-certificate (i.e. those in an X.509 extension), but may not be the case for SCTs
+certificate (i.e., those in an X.509 extension), but may not be the case for SCTs
 found in the TLS SCT extension or OCSP response.
 
 =head1 RETURN VALUES

--- a/doc/man3/DTLSv1_listen.pod
+++ b/doc/man3/DTLSv1_listen.pod
@@ -36,7 +36,7 @@ If DTLS is used over UDP (or any datagram based protocol that does not validate
 the source IP) then it is susceptible to this type of attack. TLSv1.3 is
 designed to operate over a stream-based transport protocol (such as TCP).
 If TCP is being used then there is no need to use SSL_stateless(). However some
-stream-based transport protocols (e.g. QUIC) may not validate the source
+stream-based transport protocols (e.g., QUIC) may not validate the source
 address. In this case a TLSv1.3 application would be susceptible to this attack.
 
 As a countermeasure to this issue TLSv1.3 and DTLS include a stateless cookie

--- a/doc/man3/EC_GFp_simple_method.pod
+++ b/doc/man3/EC_GFp_simple_method.pod
@@ -27,7 +27,7 @@ implementation method must be provided. The functions described here all return 
 B<EC_METHOD> structure that can be passed to EC_GROUP_NEW. It is important that the correct implementation
 type for the form of curve selected is used.
 
-For F2^m curves there is only one implementation choice, i.e. EC_GF2_simple_method.
+For F2^m curves there is only one implementation choice, i.e., EC_GF2_simple_method.
 
 For Fp curves the lowest common denominator implementation is the EC_GFp_simple_method implementation. All
 other implementations are based on this one. EC_GFp_mont_method builds on EC_GFp_simple_method but adds the

--- a/doc/man3/EC_GROUP_copy.pod
+++ b/doc/man3/EC_GROUP_copy.pod
@@ -148,7 +148,7 @@ the correct order.
 
 The function EC_GROUP_check_named_curve determines if the group's domain parameters match one of the built-in curves supported by the library.
 The curve name is returned as a B<NID> if it matches. If the group's domain parameters have been modified then no match will be found.
-If the curve name of the given group is B<NID_undef> (e.g. it has been created by using explicit parameters with no curve name),
+If the curve name of the given group is B<NID_undef> (e.g., it has been created by using explicit parameters with no curve name),
 then this method can be used to lookup the name of the curve that matches the group domain parameters. The built-in curves contain
 aliases, so that multiple NID's can map to the same domain parameters. For such curves it is unspecified which of the aliases will be
 returned if the curve name of the given group is NID_undef.

--- a/doc/man3/EC_KEY_get_enc_flags.pod
+++ b/doc/man3/EC_KEY_get_enc_flags.pod
@@ -19,10 +19,10 @@ i2d_ECPrivateKey() (such as whether it is stored in a compressed form or not) is
 described by the point_conversion_form. See L<EC_GROUP_copy(3)>
 for a description of point_conversion_form.
 
-When reading a private key encoded without an associated public key (e.g. if
+When reading a private key encoded without an associated public key (e.g., if
 EC_PKEY_NO_PUBKEY has been used - see below), then d2i_ECPrivateKey() generates
 the missing public key automatically. Private keys encoded without parameters
-(e.g. if EC_PKEY_NO_PARAMETERS has been used - see below) cannot be loaded using
+(e.g., if EC_PKEY_NO_PARAMETERS has been used - see below) cannot be loaded using
 d2i_ECPrivateKey().
 
 The functions EC_KEY_get_enc_flags() and EC_KEY_set_enc_flags() get and set the

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -147,7 +147,7 @@ See L</PARAMS> below for more information.
 EVP_MD_CTX_settable_params()
 
 Get a B<OSSL_PARAM> array that describes the retrievable and settable
-parameters, i.e. parameters that can be used with EVP_MD_get_params(),
+parameters, i.e., parameters that can be used with EVP_MD_get_params(),
 EVP_MD_CTX_get_params() and EVP_MD_CTX_set_params(), respectively.
 See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
 
@@ -181,7 +181,7 @@ data.
 =item EVP_DigestFinal_ex()
 
 Retrieves the digest value from B<ctx> and places it in B<md>. If the B<s>
-parameter is not NULL then the number of bytes of data written (i.e. the
+parameter is not NULL then the number of bytes of data written (i.e., the
 length of the digest) will be written to the integer at B<s>, at most
 B<EVP_MAX_MD_SIZE> bytes will be written.  After calling EVP_DigestFinal_ex()
 no additional calls to EVP_DigestUpdate() can be made, but
@@ -229,7 +229,7 @@ B<EVP_MD>.
 EVP_MD_CTX_size()
 
 Return the size of the message digest when passed an B<EVP_MD> or an
-B<EVP_MD_CTX> structure, i.e. the size of the hash.
+B<EVP_MD_CTX> structure, i.e., the size of the hash.
 
 =item EVP_MD_block_size(),
 EVP_MD_CTX_block_size()
@@ -283,7 +283,7 @@ longer linked this function is only retained for compatibility reasons.
 
 =item EVP_md_null()
 
-A "null" message digest that does nothing: i.e. the hash it returns is of zero
+A "null" message digest that does nothing: i.e., the hash it returns is of zero
 length.
 
 =item EVP_get_digestbyname(),

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -118,7 +118,7 @@ transparent to the algorithm used and much more flexible.
 EVP_DigestSign() is a one shot operation which signs a single block of data
 in one function. For algorithms that support streaming it is equivalent to
 calling EVP_DigestSignUpdate() and EVP_DigestSignFinal(). For algorithms which
-do not support streaming (e.g. PureEdDSA) it is the only way to sign data.
+do not support streaming (e.g., PureEdDSA) it is the only way to sign data.
 
 In previous versions of OpenSSL there was a link between message digest types
 and public key algorithms. This meant that "clone" digests such as EVP_dss1()

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -68,7 +68,7 @@ transparent to the algorithm used and much more flexible.
 EVP_DigestVerify() is a one shot operation which verifies a single block of
 data in one function. For algorithms that support streaming it is equivalent
 to calling EVP_DigestVerifyUpdate() and EVP_DigestVerifyFinal(). For
-algorithms which do not support streaming (e.g. PureEdDSA) it is the only way
+algorithms which do not support streaming (e.g., PureEdDSA) it is the only way
 to verify data.
 
 In previous versions of OpenSSL there was a link between message digest types

--- a/doc/man3/EVP_EncodeInit.pod
+++ b/doc/man3/EVP_EncodeInit.pod
@@ -45,7 +45,7 @@ space allocated to it.
 
 Encoding of binary data is performed in blocks of 48 input bytes (or less for
 the final block). For each 48 byte input block encoded 64 bytes of base 64 data
-is output plus an additional newline character (i.e. 65 bytes in total). The
+is output plus an additional newline character (i.e., 65 bytes in total). The
 final block (which may be less than 48 bytes) will output 4 bytes for every 3
 bytes of input. If the data length is not divisible by 3 then a full 4 bytes is
 still output for the final 1 or 2 bytes of input. Similarly a newline character
@@ -74,7 +74,7 @@ process any partial block of data remaining in the B<ctx> object. The output
 data will be stored in B<out> and the length of the data written will be stored
 in B<*outl>. It is the caller's responsibility to ensure that B<out> is
 sufficiently large to accommodate the output data which will never be more than
-65 bytes plus an additional NUL terminator (i.e. 66 bytes in total).
+65 bytes plus an additional NUL terminator (i.e., 66 bytes in total).
 
 EVP_ENCODE_CTX_copy() can be used to copy a context B<sctx> to a context
 B<dctx>. B<dctx> must be initialized before calling this function.
@@ -88,7 +88,7 @@ output data will be produced. If B<dlen> is not divisible by 3 then the block is
 encoded as a final block of data and the output is padded such that it is always
 divisible by 4. Additionally a NUL terminator character will be added. For
 example if 16 bytes of input data is provided then 24 bytes of encoded data is
-created plus 1 byte for a NUL terminator (i.e. 25 bytes in total). The length of
+created plus 1 byte for a NUL terminator (i.e., 25 bytes in total). The length of
 the data generated I<without> the NUL terminator is returned from the function.
 
 EVP_DecodeInit() initialises B<ctx> for the start of a new decoding operation.

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -264,7 +264,7 @@ B<params> from CIPHER context B<ctx>.
 
 EVP_CIPHER_gettable_params(), EVP_CIPHER_CTX_gettable_params(), and
 EVP_CIPHER_CTX_settable_params() get a constant B<OSSL_PARAM> array
-that decribes the retrievable and settable parameters, i.e. parameters
+that decribes the retrievable and settable parameters, i.e., parameters
 that can be used with EVP_CIPHER_get_params(), EVP_CIPHER_CTX_get_params()
 and EVP_CIPHER_CTX_set_params(), respectively.
 See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
@@ -432,7 +432,7 @@ The following I<ctrl>s are supported in GCM and OCB modes.
 Sets the IV length. This call can only be made before specifying an IV. If
 not called a default IV length is used.
 
-For GCM AES and OCB AES the default is 12 (i.e. 96 bits). For OCB mode the
+For GCM AES and OCB AES the default is 12 (i.e., 96 bits). For OCB mode the
 maximum is 15.
 
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, taglen, tag)
@@ -459,7 +459,7 @@ In OCB mode, calling this before encryption with C<tag> set to C<NULL> sets the
 tag length.  If this is not called prior to encryption, a default tag length is
 used.
 
-For OCB AES, the default tag length is 16 (i.e. 128 bits).  It is also the
+For OCB AES, the default tag length is 16 (i.e., 128 bits).  It is also the
 maximum tag length for OCB.
 
 =back
@@ -551,8 +551,8 @@ The following I<ctrl>s are supported for the ChaCha20-Poly1305 AEAD algorithm.
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, ivlen, NULL)
 
 Sets the nonce length. This call can only be made before specifying the nonce.
-If not called a default nonce length of 12 (i.e. 96 bits) is used. The maximum
-nonce length is 12 bytes (i.e. 96-bits). If a nonce of less than 12 bytes is set
+If not called a default nonce length of 12 (i.e., 96 bits) is used. The maximum
+nonce length is 12 bytes (i.e., 96-bits). If a nonce of less than 12 bytes is set
 then the nonce is automatically padded with leading 0 bytes to make it 12 bytes
 in length.
 
@@ -562,7 +562,7 @@ Writes C<taglen> bytes of the tag value to the buffer indicated by C<tag>.
 This call can only be made when encrypting data and B<after> all data has been
 processed (e.g., after an EVP_EncryptFinal() call).
 
-C<taglen> specified here must be 16 (B<POLY1305_BLOCK_SIZE>, i.e. 128-bits) or
+C<taglen> specified here must be 16 (B<POLY1305_BLOCK_SIZE>, i.e., 128-bits) or
 less.
 
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, taglen, tag)

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -439,7 +439,7 @@ maximum is 15.
 
 Writes C<taglen> bytes of the tag value to the buffer indicated by C<tag>.
 This call can only be made when encrypting data and B<after> all data has been
-processed (e.g. after an EVP_EncryptFinal() call).
+processed (e.g., after an EVP_EncryptFinal() call).
 
 For OCB, C<taglen> must either be 16 or the value previously set via
 B<EVP_CTRL_AEAD_SET_TAG>.
@@ -525,13 +525,13 @@ The following ctrls are supported in both SIV modes.
 
 Writes B<taglen> bytes of the tag value to the buffer indicated by B<tag>.
 This call can only be made when encrypting data and B<after> all data has been
-processed (e.g. after an EVP_EncryptFinal() call). For SIV mode the taglen must
+processed (e.g., after an EVP_EncryptFinal() call). For SIV mode the taglen must
 be 16.
 
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG, taglen, tag);
 
 Sets the expected tag to B<taglen> bytes from B<tag>. This call is only legal
-when decrypting data and must be made B<before> any data is processed (e.g.
+when decrypting data and must be made B<before> any data is processed (e.g.,
 before any EVP_DecryptUpdate() call). For SIV mode the taglen must be 16.
 
 =back
@@ -560,7 +560,7 @@ in length.
 
 Writes C<taglen> bytes of the tag value to the buffer indicated by C<tag>.
 This call can only be made when encrypting data and B<after> all data has been
-processed (e.g. after an EVP_EncryptFinal() call).
+processed (e.g., after an EVP_EncryptFinal() call).
 
 C<taglen> specified here must be 16 (B<POLY1305_BLOCK_SIZE>, i.e. 128-bits) or
 less.

--- a/doc/man3/EVP_KDF_CTX.pod
+++ b/doc/man3/EVP_KDF_CTX.pod
@@ -101,7 +101,7 @@ EVP_get_kdfbynid() fetches a KDF implementation from the object
 database by numeric identity.
 
 EVP_get_kdfbyobj() fetches a KDF implementation from the object
-database by ASN.1 OBJECT (i.e. an encoded OID).
+database by ASN.1 OBJECT (i.e., an encoded OID).
 
 =head1 CONTROLS
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -139,7 +139,7 @@ EVP_get_macbynid() fetches a MAC implementation from the object
 database by numeric identity.
 
 EVP_get_macbyobj() fetches a MAC implementation from the object
-database by ASN.1 OBJECT (i.e. an encoded OID).
+database by ASN.1 OBJECT (i.e., an encoded OID).
 
 =head1 CONTROLS
 

--- a/doc/man3/EVP_PKEY_ASN1_METHOD.pod
+++ b/doc/man3/EVP_PKEY_ASN1_METHOD.pod
@@ -384,7 +384,7 @@ The following B<flags> are supported:
 
 If B<ASN1_PKEY_SIGPARAM_NULL> is set, then the signature algorithm
 parameters are given the type B<V_ASN1_NULL> by default, otherwise
-they will be given the type B<V_ASN1_UNDEF> (i.e. the parameter is
+they will be given the type B<V_ASN1_UNDEF> (i.e., the parameter is
 omitted).
 See L<X509_ALGOR_set0(3)> for more information.
 

--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -13,7 +13,7 @@ EVP_PKEY_get_default_digest_nid - get default signature digest
 
 The EVP_PKEY_get_default_digest_nid() function sets B<pnid> to the default
 message digest NID for the public key signature operations associated with key
-B<pkey>. Note that some signature algorithms (i.e. Ed25519 and Ed448) do not use
+B<pkey>. Note that some signature algorithms (i.e., Ed25519 and Ed448) do not use
 a digest during signing. In this case B<pnid> will be set to NID_undef.
 
 =head1 NOTES

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -91,7 +91,7 @@ give any useful information at all during key or parameter generation. Others
 might not even call the callback.
 
 The operation performed by key or parameter generation depends on the algorithm
-used. In some cases (e.g. EC with a supplied named curve) the "generation"
+used. In some cases (e.g., EC with a supplied named curve) the "generation"
 option merely sets the appropriate fields in an EVP_PKEY structure.
 
 In OpenSSL an EVP_PKEY structure containing a private key also contains the

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -49,7 +49,7 @@ count is zero, frees it up. If B<key> is NULL, nothing is done.
 EVP_PKEY_new_raw_private_key() allocates a new B<EVP_PKEY>. If B<e> is non-NULL
 then the new B<EVP_PKEY> structure is associated with the engine B<e>. The
 B<type> argument indicates what kind of key this is. The value should be a NID
-for a public key algorithm that supports raw private keys, i.e. one of
+for a public key algorithm that supports raw private keys, i.e., one of
 B<EVP_PKEY_HMAC>, B<EVP_PKEY_POLY1305>, B<EVP_PKEY_SIPHASH>, B<EVP_PKEY_X25519>,
 B<EVP_PKEY_ED25519>, B<EVP_PKEY_X448> or B<EVP_PKEY_ED448>. B<key> points to the
 raw private key data for this B<EVP_PKEY> which should be of length B<keylen>.

--- a/doc/man3/EVP_PKEY_verify.pod
+++ b/doc/man3/EVP_PKEY_verify.pod
@@ -20,7 +20,7 @@ context using key B<pkey> for a signature verification operation.
 
 The EVP_PKEY_verify() function performs a public key verification operation
 using B<ctx>. The signature is specified using the B<sig> and
-B<siglen> parameters. The verified data (i.e. the data believed originally
+B<siglen> parameters. The verified data (i.e., the data believed originally
 signed) is specified using the B<tbs> and B<tbslen> parameters.
 
 =head1 NOTES

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -36,7 +36,7 @@ same B<ctx> to include additional data.
 EVP_SignFinal() signs the data in B<ctx> using the private key B<pkey> and
 places the signature in B<sig>. B<sig> must be at least EVP_PKEY_size(pkey)
 bytes in size. B<s> is an OUT parameter, and not used as an IN parameter.
-The number of bytes of data written (i.e. the length of the signature)
+The number of bytes of data written (i.e., the length of the signature)
 will be written to the integer at B<s>, at most EVP_PKEY_size(pkey) bytes
 will be written.
 

--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -49,7 +49,7 @@ L<openssl_user_macros(7)>:
 
 =head1 DESCRIPTION
 
-HMAC is a MAC (message authentication code), i.e. a keyed hash
+HMAC is a MAC (message authentication code), i.e., a keyed hash
 function used for message authentication, which is based on a hash
 function.
 

--- a/doc/man3/OCSP_REQUEST_new.pod
+++ b/doc/man3/OCSP_REQUEST_new.pod
@@ -93,7 +93,7 @@ B<issuer>:
  if (OCSP_REQUEST_add0_id(req, cid) == NULL)
     /* error */
 
- /* Do something with req, e.g. query responder */
+ /* Do something with req, e.g., query responder */
 
  OCSP_REQUEST_free(req);
 

--- a/doc/man3/OPENSSL_ia32cap.pod
+++ b/doc/man3/OPENSSL_ia32cap.pod
@@ -88,11 +88,11 @@ CPUID with EAX=7 and ECX=0 as input. Following bits are significant:
 
 =over 4
 
-=item bit #64+3 denoting availability of BMI1 instructions, e.g. ANDN;
+=item bit #64+3 denoting availability of BMI1 instructions, e.g., ANDN;
 
 =item bit #64+5 denoting availability of AVX2 instructions;
 
-=item bit #64+8 denoting availability of BMI2 instructions, e.g. MULX
+=item bit #64+8 denoting availability of BMI2 instructions, e.g., MULX
 and RORX;
 
 =item bit #64+16 denoting availability of AVX512F extension;

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -245,7 +245,7 @@ The object can be released with OPENSSL_INIT_free() when done.
 =head1 NOTES
 
 Resources local to a thread are deallocated automatically when the thread exits
-(e.g. in a pthreads environment, when pthread_exit() is called). On Windows
+(e.g., in a pthreads environment, when pthread_exit() is called). On Windows
 platforms this is done in response to a DLL_THREAD_DETACH message being sent to
 the libcrypto32.dll entry point. Some windows functions may cause threads to exit
 without sending this message (for example ExitProcess()). If the application

--- a/doc/man3/OPENSSL_instrument_bus.pod
+++ b/doc/man3/OPENSSL_instrument_bus.pod
@@ -27,7 +27,7 @@ OPENSSL_instrument_bus() performs B<num> probes and records the number of
 oscillator cycles every probe took.
 
 OPENSSL_instrument_bus2() on the other hand B<accumulates> consecutive
-probes with the same value, i.e. in a way it records duration of
+probes with the same value, i.e., in a way it records duration of
 periods when probe values appeared deterministic. The subroutine
 performs at most B<max> probes in attempt to fill the B<vector[num]>,
 with B<max> value of 0 meaning "as many as it takes."

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -109,7 +109,7 @@ C<return_size> should be ignored.
 B<NOTE:>
 
 The key names and associated types are defined by the entity that
-offers these parameters, i.e. names for parameters provided by the
+offers these parameters, i.e., names for parameters provided by the
 OpenSSL libraries are defined by the libraries, and names for
 parameters provided by providers are defined by those providers,
 except for the pointer form of strings (see data type descriptions
@@ -130,7 +130,7 @@ The C<data_type> field can be one of the following types:
 =item C<OSSL_PARAM_UNSIGNED_INTEGER>
 
 The parameter data is an integer (signed or unsigned) of arbitrary
-length, organized in native form, i.e. most significant byte first on
+length, organized in native form, i.e., most significant byte first on
 Big-Endian systems, and least significant byte first on Little-Endian
 systems.
 

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -263,7 +263,7 @@ expected type of the parameter.
 
 For OSSL_PARAM_get_utf8_ptr() and OSSL_PARAM_get_octet_ptr(), B<bsize>
 is not relevant if the purpose is to send the B<OSSL_PARAM> array to a
-I<responder>, i.e. to get parameter data back.
+I<responder>, i.e., to get parameter data back.
 In that case, B<bsize> can safely be given zero.
 See L<OSSL_PARAM(3)/DESCRIPTION> for further information on the
 possible purposes.

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -293,7 +293,7 @@ necessary to configure and build OpenSSL with the 'enable-trace' option.
 
 When the library is built with tracing disabled, the macro
 C<OPENSSL_NO_TRACE> is defined in C<openssl/opensslconf.h> and all
-functions described here are inoperational, i.e. will do nothing.
+functions described here are inoperational, i.e., will do nothing.
 
 =head1 HISTORY
 

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -287,7 +287,7 @@ routine has the following form:
  int cb(char *buf, int size, int rwflag, void *u);
 
 B<buf> is the buffer to write the passphrase to. B<size> is the maximum
-length of the passphrase (i.e. the size of buf). B<rwflag> is a flag
+length of the passphrase (i.e., the size of buf). B<rwflag> is a flag
 which is set to 0 when reading and 1 when writing. A typical routine
 will ask the user to verify the passphrase (for example by prompting
 for it twice) if B<rwflag> is 1. The B<u> parameter has the same

--- a/doc/man3/RAND_load_file.pod
+++ b/doc/man3/RAND_load_file.pod
@@ -25,7 +25,7 @@ been updated by RAND_write_file() between reads.
 Also, note that B<filename> should be adequately protected so that an
 attacker cannot replace or examine the contents.
 If B<filename> is not a regular file, then user is considered to be
-responsible for any side effects, e.g. non-anticipated blocking or
+responsible for any side effects, e.g., non-anticipated blocking or
 capture of controlling terminal.
 
 RAND_write_file() writes a number of random bytes (currently 128) to

--- a/doc/man3/SCT_new.pod
+++ b/doc/man3/SCT_new.pod
@@ -193,7 +193,7 @@ malloc fails.
 B<SCT_set_signature_nid> returns 1 if the specified NID is supported, 0 otherwise.
 
 B<SCT_set1_extensions> and B<SCT_set1_signature> return 1 if the supplied buffer
-is copied successfully, 0 otherwise (i.e. if malloc fails).
+is copied successfully, 0 otherwise (i.e., if malloc fails).
 
 B<SCT_set_source> returns 1 on success, 0 otherwise.
 

--- a/doc/man3/SSL_CIPHER_get_name.pod
+++ b/doc/man3/SSL_CIPHER_get_name.pod
@@ -61,11 +61,11 @@ SSL_CIPHER_get_version() returns string which indicates the SSL/TLS protocol
 version that first defined the cipher.  It returns "(NONE)" if B<cipher> is NULL.
 
 SSL_CIPHER_get_cipher_nid() returns the cipher NID corresponding to B<c>.
-If there is no cipher (e.g. for cipher suites with no encryption) then
+If there is no cipher (e.g., for cipher suites with no encryption) then
 B<NID_undef> is returned.
 
 SSL_CIPHER_get_digest_nid() returns the digest NID corresponding to the MAC
-used by B<c> during record encryption/decryption. If there is no digest (e.g.
+used by B<c> during record encryption/decryption. If there is no digest (e.g.,
 for AEAD cipher suites) then B<NID_undef> is returned.
 
 SSL_CIPHER_get_handshake_digest() returns an EVP_MD for the digest used during
@@ -91,7 +91,7 @@ TLS 1.3 cipher suites) B<NID_auth_any> is returned. Examples (not comprehensive)
  NID_auth_ecdsa
  NID_auth_psk
 
-SSL_CIPHER_is_aead() returns 1 if the cipher B<c> is AEAD (e.g. GCM or
+SSL_CIPHER_is_aead() returns 1 if the cipher B<c> is AEAD (e.g., GCM or
 ChaCha20/Poly1305), and 0 if it is not AEAD.
 
 SSL_CIPHER_find() returns a B<SSL_CIPHER> structure which has the cipher ID stored

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -23,7 +23,7 @@ SSL_CONF_cmd_value_type() returns the type of value that B<cmd> refers to.
 
 =head1 SUPPORTED COMMAND LINE COMMANDS
 
-Currently supported B<cmd> names for command lines (i.e. when the
+Currently supported B<cmd> names for command lines (i.e., when the
 flag B<SSL_CONF_CMDLINE> is set) are listed below. Note: all B<cmd> names
 are case sensitive. Unless otherwise stated commands can be used by
 both clients and servers and the B<value> parameter is not used. The default
@@ -242,7 +242,7 @@ required. Switching off anti-replay is equivalent to B<SSL_OP_NO_ANTI_REPLAY>.
 
 =head1 SUPPORTED CONFIGURATION FILE COMMANDS
 
-Currently supported B<cmd> names for configuration files (i.e. when the
+Currently supported B<cmd> names for configuration files (i.e., when the
 flag B<SSL_CONF_FLAG_FILE> is set) are listed below. All configuration file
 B<cmd> names are case insensitive so B<signaturealgorithms> is recognised
 as well as B<SignatureAlgorithms>. Unless otherwise stated the B<value> names

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -78,8 +78,8 @@ will also be used for the B<key_share> sent by a client in a TLSv1.3
 B<ClientHello>.
 
 The B<value> argument is a colon separated list of groups. The group can be
-either the B<NIST> name (e.g. B<P-256>), some other commonly used name where
-applicable (e.g. B<X25519>, B<ffdhe2048>) or an OpenSSL OID name
+either the B<NIST> name (e.g., B<P-256>), some other commonly used name where
+applicable (e.g., B<X25519>, B<ffdhe2048>) or an OpenSSL OID name
 (e.g B<prime256v1>). Group names are case sensitive. The list should be in
 order of preference with the most preferred group first.
 
@@ -98,7 +98,7 @@ servers
 
 The B<value> argument is a curve name or the special value B<auto> which
 picks an appropriate curve based on client and server preferences. The curve
-can be either the B<NIST> name (e.g. B<P-256>) or an OpenSSL OID name
+can be either the B<NIST> name (e.g., B<P-256>) or an OpenSSL OID name
 (e.g B<prime256v1>). Curve names are case sensitive.
 
 =item B<-cipher>
@@ -198,7 +198,7 @@ Equivalent to B<SSL_OP_CIPHER_SERVER_PREFERENCE>. Only used by servers.
 
 Prioritize ChaCha ciphers when the client has a ChaCha20 cipher at the top of
 its preference list. This usually indicates a client without AES hardware
-acceleration (e.g. mobile) is in use. Equivalent to B<SSL_OP_PRIORITIZE_CHACHA>.
+acceleration (e.g., mobile) is in use. Equivalent to B<SSL_OP_PRIORITIZE_CHACHA>.
 Only used by servers. Requires B<-serverpref>.
 
 =item B<-no_resumption_on_reneg>
@@ -359,8 +359,8 @@ will also be used for the B<key_share> sent by a client in a TLSv1.3
 B<ClientHello>.
 
 The B<value> argument is a colon separated list of groups. The group can be
-either the B<NIST> name (e.g. B<P-256>), some other commonly used name where
-applicable (e.g. B<X25519>, B<ffdhe2048>) or an OpenSSL OID name
+either the B<NIST> name (e.g., B<P-256>), some other commonly used name where
+applicable (e.g., B<X25519>, B<ffdhe2048>) or an OpenSSL OID name
 (e.g B<prime256v1>). Group names are case sensitive. The list should be in
 order of preference with the most preferred group first.
 
@@ -414,7 +414,7 @@ by them.
 The B<Protocol> command is fragile and deprecated; do not use it.
 Use B<MinProtocol> and B<MaxProtocol> instead.
 If you do use B<Protocol>, make sure that the resulting range of enabled
-protocols has no "holes", e.g. if TLS 1.0 and TLS 1.2 are both enabled, make
+protocols has no "holes", e.g., if TLS 1.0 and TLS 1.2 are both enabled, make
 sure to also leave TLS 1.1 enabled.
 
 =item B<Options>
@@ -557,7 +557,7 @@ The value is a directory name.
 
 =item B<SSL_CONF_TYPE_NONE>
 
-The value string is not used e.g. a command line option which doesn't take an
+The value string is not used e.g., a command line option which doesn't take an
 argument.
 
 =back

--- a/doc/man3/SSL_CTX_add1_chain_cert.pod
+++ b/doc/man3/SSL_CTX_add1_chain_cert.pod
@@ -65,7 +65,7 @@ if flag B<SSL_BUILD_CHAIN_FLAG_CLEAR_ERROR> is also set verification errors
 are cleared from the error queue.
 
 Each of these functions operates on the I<current> end entity
-(i.e. server or client) certificate. This is the last certificate loaded or
+(i.e., server or client) certificate. This is the last certificate loaded or
 selected on the corresponding B<ctx> structure.
 
 SSL_CTX_select_current_cert() selects B<x509> as the current end entity

--- a/doc/man3/SSL_CTX_load_verify_locations.pod
+++ b/doc/man3/SSL_CTX_load_verify_locations.pod
@@ -51,7 +51,7 @@ format. The file can contain several CA certificates identified by
  -----END CERTIFICATE-----
 
 sequences. Before, between, and after the certificates text is allowed
-which can be used e.g. for descriptions of the certificates.
+which can be used e.g., for descriptions of the certificates.
 
 The B<CAfile> is processed on execution of the SSL_CTX_load_verify_locations()
 function.
@@ -60,12 +60,12 @@ If B<CApath> is not NULL, it points to a directory containing CA certificates
 in PEM format. The files each contain one CA certificate. The files are
 looked up by the CA subject name hash value, which must hence be available.
 If more than one CA certificate with the same name hash value exist, the
-extension must be different (e.g. 9d66eef0.0, 9d66eef0.1 etc). The search
+extension must be different (e.g., 9d66eef0.0, 9d66eef0.1 etc). The search
 is performed in the ordering of the extension number, regardless of other
 properties of the certificates.
 Use the B<c_rehash> utility to create the necessary links.
 
-The certificates in B<CApath> are only looked up when required, e.g. when
+The certificates in B<CApath> are only looked up when required, e.g., when
 building the certificate chain or when actually performing the verification
 of a peer certificate.
 

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -156,7 +156,7 @@ If you want to limit the supported protocols for the version flexible
 methods you can use L<SSL_CTX_set_min_proto_version(3)>,
 L<SSL_set_min_proto_version(3)>, L<SSL_CTX_set_max_proto_version(3)> and
 L<SSL_set_max_proto_version(3)> functions.
-Using these functions it is possible to choose e.g. TLS_server_method()
+Using these functions it is possible to choose e.g., TLS_server_method()
 and be able to negotiate with all possible clients, but to only
 allow newer protocols like TLS 1.0, TLS 1.1, TLS 1.2 or TLS 1.3.
 

--- a/doc/man3/SSL_CTX_sessions.pod
+++ b/doc/man3/SSL_CTX_sessions.pod
@@ -19,7 +19,7 @@ internal session cache for B<ctx>.
 
 The sessions in the internal session cache are kept in an
 L<LHASH(3)> type database. It is possible to directly
-access this database e.g. for searching. In parallel, the sessions
+access this database e.g., for searching. In parallel, the sessions
 form a linked list which is maintained separately from the
 L<LHASH(3)> operations, so that the database must not be
 modified directly but by using the

--- a/doc/man3/SSL_CTX_set_cert_store.pod
+++ b/doc/man3/SSL_CTX_set_cert_store.pod
@@ -41,7 +41,7 @@ call.
 
 Currently no detailed documentation on how to use the X509_STORE
 object is available. Not all members of the X509_STORE are used when
-the verification takes place. So will e.g. the verify_callback() be
+the verification takes place. So will e.g., the verify_callback() be
 overridden with the verify_callback() set via the
 L<SSL_CTX_set_verify(3)> family of functions.
 This document must therefore be updated when documentation about the

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -88,7 +88,7 @@ A DSA cipher can only be chosen, when a DSA certificate is available.
 DSA ciphers always use DH key exchange and therefore need DH-parameters
 (see L<SSL_CTX_set_tmp_dh_callback(3)>).
 
-When these conditions are not met for any cipher in the list (e.g. a
+When these conditions are not met for any cipher in the list (e.g., a
 client only supports export RSA ciphers with an asymmetric key length
 of 512 bits and the server is not configured to use temporary RSA
 keys), the "no shared cipher" (SSL_R_NO_SHARED_CIPHER) error is generated

--- a/doc/man3/SSL_CTX_set_ct_validation_callback.pod
+++ b/doc/man3/SSL_CTX_set_ct_validation_callback.pod
@@ -77,7 +77,7 @@ Ownership of this context remains with the caller.
 If no callback is set, SCTs will not be requested and Certificate Transparency
 validation will not occur.
 
-No callback will be invoked when the peer presents no certificate, e.g. by
+No callback will be invoked when the peer presents no certificate, e.g., by
 employing an anonymous (aNULL) cipher suite.
 In that case the handshake continues as it would had no callback been
 requested.
@@ -115,7 +115,7 @@ extensions (B<TLSEXT_TYPE_signed_certificate_timestamp>).
 SSL_enable_ct(), SSL_CTX_enable_ct(), SSL_CTX_set_ct_validation_callback() and
 SSL_set_ct_validation_callback() return 1 if the B<callback> is successfully
 set.
-They return 0 if an error occurs, e.g. a custom client extension handler has
+They return 0 if an error occurs, e.g., a custom client extension handler has
 been setup to handle SCTs.
 
 SSL_disable_ct() and SSL_CTX_disable_ct() do not return a result.

--- a/doc/man3/SSL_CTX_set_generate_session_id.pod
+++ b/doc/man3/SSL_CTX_set_generate_session_id.pod
@@ -42,7 +42,7 @@ sensitive information.
 Without a callback being set, an OpenSSL server will generate a unique
 session id from pseudo random numbers of the maximum possible length.
 Using the callback function, the session id can be changed to contain
-additional information like e.g. a host id in order to improve load balancing
+additional information like e.g., a host id in order to improve load balancing
 or external caching techniques.
 
 The callback function receives a pointer to the memory location to put
@@ -62,7 +62,7 @@ of generating the same session id is extremely small (2^256 for SSLv3/TLSv1).
 In order to assure the uniqueness of the generated session id, the callback must call
 SSL_has_matching_session_id() and generate another id if a conflict occurs.
 If an id conflict is not resolved, the handshake will fail.
-If the application codes e.g. a unique host id, a unique process number, and
+If the application codes e.g., a unique host id, a unique process number, and
 a unique sequence number into the session id, uniqueness could easily be
 achieved without randomness added (it should however be taken care that
 no confidential information is leaked this way). If the application can not

--- a/doc/man3/SSL_CTX_set_max_cert_list.pod
+++ b/doc/man3/SSL_CTX_set_max_cert_list.pod
@@ -45,7 +45,7 @@ L<SSL_CTX_set_verify(3)>, and certificates
 without special extensions have a typical size of 1-2kB).
 
 For special applications it can be necessary to extend the maximum certificate
-chain size allowed to be sent by the peer, see e.g. the work on
+chain size allowed to be sent by the peer, see e.g., the work on
 "Internet X.509 Public Key Infrastructure Proxy Certificate Profile"
 and "TLS Delegation Protocol" at http://www.ietf.org/ and
 http://www.globus.org/ .

--- a/doc/man3/SSL_CTX_set_mode.pod
+++ b/doc/man3/SSL_CTX_set_mode.pod
@@ -38,7 +38,7 @@ The following mode changes are available:
 
 =item SSL_MODE_ENABLE_PARTIAL_WRITE
 
-Allow SSL_write_ex(..., n, &r) to return with 0 < r < n (i.e. report success
+Allow SSL_write_ex(..., n, &r) to return with 0 < r < n (i.e., report success
 when just a single record has been written). This works in a similar way for
 SSL_write(). When not set (the default), SSL_write_ex() or SSL_write() will only
 report success once the complete chunk was written. Once SSL_write_ex() or

--- a/doc/man3/SSL_CTX_set_num_tickets.pod
+++ b/doc/man3/SSL_CTX_set_num_tickets.pod
@@ -33,7 +33,7 @@ custom session ticket callbacks (see L<SSL_CTX_set_session_ticket_cb(3)>).
 Tickets are also issued on receipt of a post-handshake certificate from the
 client following a request by the server using
 L<SSL_verify_client_post_handshake(3)>. These new tickets will be associated
-with the updated client identity (i.e. including their certificate and
+with the updated client identity (i.e., including their certificate and
 verification status). The number of tickets issued will normally be the same as
 was used for the initial handshake. If the initial handshake was a full
 handshake then SSL_set_num_tickets() can be called again prior to calling

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -221,7 +221,7 @@ that there will be no forward secrecy for the resumed session.
 When SSL_OP_CIPHER_SERVER_PREFERENCE is set, temporarily reprioritize
 ChaCha20-Poly1305 ciphers to the top of the server cipher list if a
 ChaCha20-Poly1305 cipher is at the top of the client cipher list. This helps
-those clients (e.g. mobile) use ChaCha20-Poly1305 if that cipher is anywhere
+those clients (e.g., mobile) use ChaCha20-Poly1305 if that cipher is anywhere
 in the server cipher list; but still allows other clients to use AES and other
 ciphers. Requires B<SSL_OP_CIPHER_SERVER_PREFERENCE>.
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -323,7 +323,7 @@ servers will fail.
 
 The option B<SSL_OP_LEGACY_SERVER_CONNECT> is currently set by default even
 though it has security implications: otherwise it would be impossible to
-connect to unpatched servers (i.e. all of them initially) and this is clearly
+connect to unpatched servers (i.e., all of them initially) and this is clearly
 not acceptable. Renegotiation is permitted because this does not add any
 additional security issues: during an attack clients do not see any
 renegotiations anyway.

--- a/doc/man3/SSL_CTX_set_read_ahead.pod
+++ b/doc/man3/SSL_CTX_set_read_ahead.pod
@@ -48,7 +48,7 @@ B<SSL_MODE_AUTO_RETRY> is not turned off using SSL_CTX_clear_mode().
 That will prevent getting B<SSL_ERROR_WANT_READ> when there is still a complete
 record available that hasn't been processed.
 
-If the application wants to continue to use the underlying transport (e.g. TCP
+If the application wants to continue to use the underlying transport (e.g., TCP
 connection) after the SSL connection is finished using SSL_shutdown() reading
 ahead should be turned off.
 Otherwise the SSL structure might read data that it shouldn't.

--- a/doc/man3/SSL_CTX_set_session_id_context.pod
+++ b/doc/man3/SSL_CTX_set_session_id_context.pod
@@ -25,12 +25,12 @@ B<sid_ctx_len> within which a session can be reused for the B<ssl> object.
 
 Sessions are generated within a certain context. When exporting/importing
 sessions with B<i2d_SSL_SESSION>/B<d2i_SSL_SESSION> it would be possible,
-to re-import a session generated from another context (e.g. another
+to re-import a session generated from another context (e.g., another
 application), which might lead to malfunctions. Therefore each application
 must set its own session id context B<sid_ctx> which is used to distinguish
 the contexts and is stored in exported sessions. The B<sid_ctx> can be
 any kind of binary data with a given length, it is therefore possible
-to use e.g. the name of the application and/or the hostname and/or service
+to use e.g., the name of the application and/or the hostname and/or service
 name ...
 
 The session id context becomes part of the session. The session id context

--- a/doc/man3/SSL_CTX_set_split_send_fragment.pod
+++ b/doc/man3/SSL_CTX_set_split_send_fragment.pod
@@ -53,7 +53,7 @@ functions will only accept a value in the range 512 - SSL3_RT_MAX_PLAIN_LENGTH.
 SSL_CTX_set_max_pipelines() and SSL_set_max_pipelines() set the maximum number
 of pipelines that will be used at any one time. This value applies to both
 "read" pipelining and "write" pipelining. By default only one pipeline will be
-used (i.e. normal non-parallel operation). The number of pipelines set must be
+used (i.e., normal non-parallel operation). The number of pipelines set must be
 in the range 1 - SSL_MAX_PIPELINES (32). Setting this to a value > 1 will also
 automatically turn on "read_ahead" (see L<SSL_CTX_set_read_ahead(3)>). This is
 explained further below. OpenSSL will only every use more than one pipeline if

--- a/doc/man3/SSL_CTX_use_certificate.pod
+++ b/doc/man3/SSL_CTX_use_certificate.pod
@@ -130,7 +130,7 @@ RSA key found to B<ssl>.
 SSL_CTX_check_private_key() checks the consistency of a private key with
 the corresponding certificate loaded into B<ctx>. If more than one
 key/certificate pair (RSA/DSA) is installed, the last item installed will
-be checked. If e.g. the last item was a RSA certificate or key, the RSA
+be checked. If e.g., the last item was a RSA certificate or key, the RSA
 key/certificate pair will be checked. SSL_check_private_key() performs
 the same check for B<ssl>. If no key/certificate was explicitly added for
 this B<ssl>, the last item added into B<ctx> will be checked.

--- a/doc/man3/SSL_CTX_use_serverinfo.pod
+++ b/doc/man3/SSL_CTX_use_serverinfo.pod
@@ -59,7 +59,7 @@ SSL_SERVERINFOV2 data or "BEGIN SERVERINFO FOR " for SSL_SERVERINFOV1 data.
 
 If more than one certificate (RSA/DSA) is installed using
 SSL_CTX_use_certificate(), the serverinfo extension will be loaded into the
-last certificate installed.  If e.g. the last item was a RSA certificate, the
+last certificate installed.  If e.g., the last item was a RSA certificate, the
 loaded serverinfo extension data will be loaded for that certificate.  To
 use the serverinfo extension for multiple certificates,
 SSL_CTX_use_serverinfo() needs to be called multiple times, once B<after>

--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -43,17 +43,17 @@ as a session may be reused, several SSL objects may be using one SSL_SESSION
 object at the same time. It is therefore crucial to keep the reference
 count (usage information) correct and not delete a SSL_SESSION object
 that is still used, as this may lead to program failures due to
-dangling pointers. These failures may also appear delayed, e.g.
+dangling pointers. These failures may also appear delayed, e.g.,
 when an SSL_SESSION object was completely freed as the reference count
 incorrectly became 0, but it is still referenced in the internal
 session cache and the cache list is processed during a
 L<SSL_CTX_flush_sessions(3)> operation.
 
 SSL_SESSION_free() must only be called for SSL_SESSION objects, for
-which the reference count was explicitly incremented (e.g.
+which the reference count was explicitly incremented (e.g.,
 by calling SSL_get1_session(), see L<SSL_get_session(3)>)
 or when the SSL_SESSION object was generated outside a TLS handshake
-operation, e.g. by using L<d2i_SSL_SESSION(3)>.
+operation, e.g., by using L<d2i_SSL_SESSION(3)>.
 It must not be called on other SSL_SESSION objects, as this would cause
 incorrect reference counts and therefore program failures.
 

--- a/doc/man3/SSL_SESSION_get_protocol_version.pod
+++ b/doc/man3/SSL_SESSION_get_protocol_version.pod
@@ -26,7 +26,7 @@ up a session based PSK (see L<SSL_CTX_set_psk_use_session_callback(3)>).
 =head1 RETURN VALUES
 
 SSL_SESSION_get_protocol_version() returns a number indicating the protocol
-version used for the session; this number matches the constants I<e.g.>
+version used for the session; this number matches the constants
 B<TLS1_VERSION>, B<TLS1_2_VERSION> or B<TLS1_3_VERSION>.
 
 Note that the SSL_SESSION_get_protocol_version() function

--- a/doc/man3/SSL_alert_type_string.pod
+++ b/doc/man3/SSL_alert_type_string.pod
@@ -86,7 +86,7 @@ MAC. This message is always fatal.
 
 =item "DF"/"decompression failure"
 
-The decompression function received improper input (e.g. data
+The decompression function received improper input (e.g., data
 that would expand to excessive length). This message is always
 fatal.
 

--- a/doc/man3/SSL_check_chain.pod
+++ b/doc/man3/SSL_check_chain.pod
@@ -40,7 +40,7 @@ acceptable (e.g., it is a supported curve).
 B<CERT_PKEY_CA_PARAM>: the parameters of all CA certificates are acceptable.
 
 B<CERT_PKEY_EXPLICIT_SIGN>: the end entity certificate algorithm
-can be used explicitly for signing (i.e. it is mentioned in the signature
+can be used explicitly for signing (i.e., it is mentioned in the signature
 algorithms extension).
 
 B<CERT_PKEY_ISSUER_NAME>: the issuer name is acceptable. This is only

--- a/doc/man3/SSL_check_chain.pod
+++ b/doc/man3/SSL_check_chain.pod
@@ -35,7 +35,7 @@ B<CERT_PKEY_CA_SIGNATURE>: the signature algorithms of all CA certificates
 are acceptable.
 
 B<CERT_PKEY_EE_PARAM>: the parameters of the end entity certificate are
-acceptable (e.g. it is a supported curve).
+acceptable (e.g., it is a supported curve).
 
 B<CERT_PKEY_CA_PARAM>: the parameters of all CA certificates are acceptable.
 

--- a/doc/man3/SSL_clear.pod
+++ b/doc/man3/SSL_clear.pod
@@ -26,7 +26,7 @@ or at least L<SSL_set_shutdown(3)> was used to
 set the SSL_SENT_SHUTDOWN state.
 
 If a session was closed cleanly, the session object will be kept and all
-settings corresponding. This explicitly means, that e.g. the special method
+settings corresponding. This explicitly means, that e.g., the special method
 used during the session will be kept for the next handshake. So if the
 session was a TLSv1 session, a SSL client object will use a TLSv1 client
 method for the next handshake and a SSL server object will use a TLSv1

--- a/doc/man3/SSL_extension_supported.pod
+++ b/doc/man3/SSL_extension_supported.pod
@@ -104,7 +104,7 @@ The callback B<add_cb> is called to send custom extension data to be
 included in various TLS messages. The B<ext_type> parameter is set to the
 extension type which will be added and B<add_arg> to the value set when the
 extension handler was added. When using the new style callbacks the B<context>
-parameter will indicate which message is currently being constructed e.g. for
+parameter will indicate which message is currently being constructed e.g., for
 the ClientHello it will be set to B<SSL_EXT_CLIENT_HELLO>.
 
 If the application wishes to include the extension B<ext_type> it should

--- a/doc/man3/SSL_get_all_async_fds.pod
+++ b/doc/man3/SSL_get_all_async_fds.pod
@@ -30,7 +30,7 @@ call to select() or poll() to determine whether the current asynchronous
 operation has completed or not. A completed operation will result in data
 appearing as "read ready" on the file descriptor (no actual data should be read
 from the file descriptor). This function should only be called if the SSL object
-is currently waiting for asynchronous work to complete (i.e.
+is currently waiting for asynchronous work to complete (i.e.,
 SSL_ERROR_WANT_ASYNC has been received - see L<SSL_get_error(3)>). Typically the
 list will only contain one file descriptor. However if multiple asynchronous
 capable engines are in use then more than one is possible. The number of file

--- a/doc/man3/SSL_get_ciphers.pod
+++ b/doc/man3/SSL_get_ciphers.pod
@@ -69,7 +69,7 @@ the buffer that should be populated with the list of names and B<size> is the
 size of that buffer. A pointer to B<buf> is returned on success or NULL on
 error. If the supplied buffer is not large enough to contain the complete list
 of names then a truncated list of names will be returned. Note that just because
-a ciphersuite is available (i.e. it is configured in the cipher list) and shared
+a ciphersuite is available (i.e., it is configured in the cipher list) and shared
 by both the client and the server it does not mean that it is enabled (see the
 description of SSL_get1_supported_ciphers() above). This function will return
 available shared ciphersuites whether or not they are enabled. This is a server

--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -75,7 +75,7 @@ even when the call that set this error was an SSL_write() or SSL_write_ex().
 However if the call was an SSL_write() or SSL_write_ex(), it should be called
 again to continue sending the application data.
 
-For socket B<BIO>s (e.g. when SSL_set_fd() was used), select() or
+For socket B<BIO>s (e.g., when SSL_set_fd() was used), select() or
 poll() on the underlying socket can be used to find out when the
 TLS/SSL I/O function should be retried.
 

--- a/doc/man3/SSL_get_extms_support.pod
+++ b/doc/man3/SSL_get_extms_support.pod
@@ -21,7 +21,7 @@ This function is implemented as a macro.
 
 SSL_get_extms_support() returns 1 if the current session used extended
 master secret, 0 if it did not and -1 if a handshake is currently in
-progress i.e. it is not possible to determine if extended master secret
+progress i.e., it is not possible to determine if extended master secret
 was used.
 
 =head1 SEE ALSO

--- a/doc/man3/SSL_get_peer_signature_nid.pod
+++ b/doc/man3/SSL_get_peer_signature_nid.pod
@@ -33,9 +33,9 @@ information for the local end of the connection.
 =head1 RETURN VALUES
 
 These functions return 1 for success and 0 for failure. There are several
-possible reasons for failure: the cipher suite has no signature (e.g. it
+possible reasons for failure: the cipher suite has no signature (e.g., it
 uses RSA key exchange or is anonymous), the TLS version is below 1.2 or
-the functions were called too early, e.g. before the peer signed a message.
+the functions were called too early, e.g., before the peer signed a message.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_get_session.pod
+++ b/doc/man3/SSL_get_session.pod
@@ -49,7 +49,7 @@ enables applications to obtain information about all sessions sent by the
 server.
 
 A session will be automatically removed from the session cache and marked as
-non-resumable if the connection is not closed down cleanly, e.g. if a fatal
+non-resumable if the connection is not closed down cleanly, e.g., if a fatal
 error occurs on the connection or L<SSL_shutdown(3)> is not called prior to
 L<SSL_free(3)>.
 

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -28,7 +28,7 @@ existing B<SSL> structure.
 
 SSL_dup() duplicates an existing B<SSL> structure into a new allocated one
 or just increments the reference count if the connection is active. All
-settings are inherited from the original B<SSL> structure. Dynamic data (i.e.
+settings are inherited from the original B<SSL> structure. Dynamic data (i.e.,
 existing connection details) are not copied, the new B<SSL> is set into an
 initial accept (server) or connect (client) state.
 

--- a/doc/man3/SSL_pending.pod
+++ b/doc/man3/SSL_pending.pod
@@ -15,7 +15,7 @@ SSL object
 =head1 DESCRIPTION
 
 Data is received in whole blocks known as records from the peer. A whole record
-is processed (e.g. decrypted) in one go and is buffered by OpenSSL until it is
+is processed (e.g., decrypted) in one go and is buffered by OpenSSL until it is
 read by the application via a call to L<SSL_read_ex(3)> or L<SSL_read(3)>.
 
 SSL_pending() returns the number of bytes which have been processed, buffered
@@ -39,7 +39,7 @@ data because the unprocessed buffered data when processed yielded no application
 data (for example this can happen during renegotiation). It is also possible in
 this scenario for SSL_has_pending() to continue to return 1 even after an
 SSL_read_ex() or SSL_read() call because the buffered and unprocessed data is
-not yet processable (e.g. because OpenSSL has only received a partial record so
+not yet processable (e.g., because OpenSSL has only received a partial record so
 far).
 
 =head1 RETURN VALUES

--- a/doc/man3/SSL_read.pod
+++ b/doc/man3/SSL_read.pod
@@ -53,7 +53,7 @@ buffer, the read functions will trigger the processing of the next record.
 Only when the record has been received and processed completely will the read
 functions return reporting success. At most the contents of one record will
 be returned. As the size of an SSL/TLS record may exceed the maximum packet size
-of the underlying transport (e.g. TCP), it may be necessary to read several
+of the underlying transport (e.g., TCP), it may be necessary to read several
 packets from the transport layer before the record is complete and the read call
 can succeed.
 
@@ -99,8 +99,8 @@ SSL_read_ex() and SSL_peek_ex() will return 1 for success or 0 for failure.
 Success means that 1 or more application data bytes have been read from the SSL
 connection.
 Failure means that no bytes could be read from the SSL connection.
-Failures can be retryable (e.g. we are waiting for more bytes to
-be delivered by the network) or non-retryable (e.g. a fatal network error).
+Failures can be retryable (e.g., we are waiting for more bytes to
+be delivered by the network) or non-retryable (e.g., a fatal network error).
 In the event of a failure call L<SSL_get_error(3)> to find out the reason which
 indicates whether the call is retryable or not.
 

--- a/doc/man3/SSL_read_early_data.pod
+++ b/doc/man3/SSL_read_early_data.pod
@@ -161,7 +161,7 @@ Once the initial SSL_read_early_data() call has completed successfully (i.e. it
 has returned SSL_READ_EARLY_DATA_SUCCESS or SSL_READ_EARLY_DATA_FINISH) then the
 server may choose to write data immediately to the unauthenticated client using
 SSL_write_early_data(). If SSL_read_early_data() returned
-SSL_READ_EARLY_DATA_FINISH then in some situations (e.g. if the client only
+SSL_READ_EARLY_DATA_FINISH then in some situations (e.g., if the client only
 supports TLSv1.2) the handshake may have already been completed and calls
 to SSL_write_early_data() are not allowed. Call L<SSL_is_init_finished(3)> to
 determine whether the handshake has completed or not. If the handshake is still
@@ -316,7 +316,7 @@ cache. Applications should be designed with this in mind in order to minimise
 the possibility of replay attacks.
 
 The OpenSSL replay protection does not apply to external Pre Shared Keys (PSKs)
-(e.g. see SSL_CTX_set_psk_find_session_callback(3)). Therefore extreme caution
+(e.g., see SSL_CTX_set_psk_find_session_callback(3)). Therefore extreme caution
 should be applied when combining external PSKs with early data.
 
 Some applications may mitigate the replay risks in other ways. For those

--- a/doc/man3/SSL_read_early_data.pod
+++ b/doc/man3/SSL_read_early_data.pod
@@ -72,7 +72,7 @@ data. For specific details, consult the TLS 1.3 specification.
 When a server receives early data it may opt to immediately respond by sending
 application data back to the client. Data sent by the server at this stage is
 done before the full handshake has been completed. Specifically the client's
-authentication messages have not yet been received, i.e. the client is
+authentication messages have not yet been received, i.e., the client is
 unauthenticated at this point and care should be taken when using this
 capability.
 
@@ -98,7 +98,7 @@ page describes the differences between SSL_write_early_data() and
 L<SSL_write_ex(3)>.
 
 When called by a client, SSL_write_early_data() must be the first IO function
-called on a new connection, i.e. it must occur before any calls to
+called on a new connection, i.e., it must occur before any calls to
 L<SSL_write_ex(3)>, L<SSL_read_ex(3)>, L<SSL_connect(3)>, L<SSL_do_handshake(3)>
 or other similar functions. It may be called multiple times to stream data to
 the server, but the total number of bytes written must not exceed the value
@@ -127,7 +127,7 @@ A server uses the SSL_read_early_data() function to receive early data on a
 connection for which early data has been enabled using
 SSL_CTX_set_max_early_data() or SSL_set_max_early_data(). As for
 SSL_write_early_data(), this must be the first IO function
-called on a connection, i.e. it must occur before any calls to
+called on a connection, i.e., it must occur before any calls to
 L<SSL_write_ex(3)>, L<SSL_read_ex(3)>, L<SSL_accept(3)>, L<SSL_do_handshake(3)>,
 or other similar functions.
 
@@ -157,7 +157,7 @@ or if the early data was rejected.
 
 =back
 
-Once the initial SSL_read_early_data() call has completed successfully (i.e. it
+Once the initial SSL_read_early_data() call has completed successfully (i.e., it
 has returned SSL_READ_EARLY_DATA_SUCCESS or SSL_READ_EARLY_DATA_FINISH) then the
 server may choose to write data immediately to the unauthenticated client using
 SSL_write_early_data(). If SSL_read_early_data() returned

--- a/doc/man3/SSL_shutdown.pod
+++ b/doc/man3/SSL_shutdown.pod
@@ -23,7 +23,7 @@ a currently open session is considered closed and good and will be kept in the
 session cache for further reuse.
 
 Note that SSL_shutdown() must not be called if a previous fatal error has
-occurred on a connection i.e. if SSL_get_error() has returned SSL_ERROR_SYSCALL
+occurred on a connection i.e., if SSL_get_error() has returned SSL_ERROR_SYSCALL
 or SSL_ERROR_SSL.
 
 The shutdown procedure consists of two steps: sending of the close_notify

--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -87,8 +87,8 @@ if SSL_MODE_ENABLE_PARTIAL_WRITE is in use, at least 1 application data byte has
 been written to the SSL connection. Failure means that not all the requested
 bytes have been written yet (if SSL_MODE_ENABLE_PARTIAL_WRITE is not in use) or
 no bytes could be written to the SSL connection (if
-SSL_MODE_ENABLE_PARTIAL_WRITE is in use). Failures can be retryable (e.g. the
-network write buffer has temporarily filled up) or non-retryable (e.g. a fatal
+SSL_MODE_ENABLE_PARTIAL_WRITE is in use). Failures can be retryable (e.g., the
+network write buffer has temporarily filled up) or non-retryable (e.g., a fatal
 network error). In the event of a failure call L<SSL_get_error(3)> to find out
 the reason which indicates whether the call is retryable or not.
 

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -118,7 +118,7 @@ UI_add_input_string() and UI_add_verify_string() add a prompt to the UI,
 as well as flags and a result buffer and the desired minimum and maximum
 sizes of the result, not counting the final NUL character.  The given
 information is used to prompt for information, for example a password,
-and to verify a password (i.e. having the user enter it twice and check
+and to verify a password (i.e., having the user enter it twice and check
 that the same string was entered twice).  UI_add_verify_string() takes
 and extra argument that should be a pointer to the result buffer of the
 input string that it's supposed to verify, or verification will fail.

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -66,7 +66,7 @@ If B<XN_FLAG_DN_REV> is set the whole DN is printed in reversed order.
 
 The fields B<XN_FLAG_FN_SN>, B<XN_FLAG_FN_LN>, B<XN_FLAG_FN_OID>,
 B<XN_FLAG_FN_NONE> determine how a field name is displayed. It will
-use the short name (e.g. CN) the long name (e.g. commonName) always
+use the short name (e.g., CN) the long name (e.g., commonName) always
 use OID numerical form (normally OIDs are only used if the field name is not
 recognised) and no field name respectively.
 

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -59,7 +59,7 @@ is no longer valid.
 If B<ctx> is NULL nothing is done.
 
 X509_STORE_CTX_init() sets up B<ctx> for a subsequent verification operation.
-It must be called before each call to X509_verify_cert(), i.e. a B<ctx> is only
+It must be called before each call to X509_verify_cert(), i.e., a B<ctx> is only
 good for one call to X509_verify_cert(); if you want to verify a second
 certificate with the same B<ctx> then you must call X509_STORE_CTX_cleanup()
 and then X509_STORE_CTX_init() again before the second call to

--- a/doc/man3/X509_check_host.pod
+++ b/doc/man3/X509_check_host.pod
@@ -105,7 +105,7 @@ for "*" as wildcard pattern in labels that have a prefix or suffix,
 such as: "www*" or "*www"; this only applies to B<X509_check_host>.
 
 If set, B<X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS> allows a "*" that
-constitutes the complete label of a DNS name (e.g. "*.example.com")
+constitutes the complete label of a DNS name (e.g., "*.example.com")
 to match more than one label in B<name>; this flag only applies
 to B<X509_check_host>.
 

--- a/doc/man3/X509_check_private_key.pod
+++ b/doc/man3/X509_check_private_key.pod
@@ -33,8 +33,8 @@ obtained using L<ERR_get_error(3)>.
 =head1 BUGS
 
 The B<check_private_key> functions don't check if B<k> itself is indeed
-a private key or not. It merely compares the public materials (e.g. exponent
-and modulus of an RSA key) and/or key parameters (e.g. EC params of an EC key)
+a private key or not. It merely compares the public materials (e.g., exponent
+and modulus of an RSA key) and/or key parameters (e.g., EC params of an EC key)
 of a key pair. So if you pass a public key to these functions in B<k>, it will
 return success.
 

--- a/doc/man3/X509_get0_signature.pod
+++ b/doc/man3/X509_get0_signature.pod
@@ -85,7 +85,7 @@ X509_get0_signature(), X509_REQ_get0_signature() and
 X509_CRL_get0_signature() do not return values.
 
 X509_get_signature_info() returns 1 if the signature information
-returned is valid or 0 if the information is not available (e.g.
+returned is valid or 0 if the information is not available (e.g.,
 unknown algorithms or malformed parameters).
 
 =head1 SEE ALSO

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -54,7 +54,7 @@ to encrypt or decrypt private keys should use other functions such as
 d2i_PKCS8PrivateKey() instead.
 
 If the B<*a> is not NULL when calling d2i_PrivateKey() or d2i_AutoPrivateKey()
-(i.e. an existing structure is being reused) and the key format is PKCS#8
+(i.e., an existing structure is being reused) and the key format is PKCS#8
 then B<*a> will be freed and replaced on a successful call.
 
 To decode a key with type B<EVP_PKEY_EC>, d2i_PublicKey() requires B<*a> to be

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -97,7 +97,7 @@ The configuration section should consist of a set of name value pairs which
 contain specific module configuration information. The B<name> represents
 the name of the I<configuration module>. The meaning of the B<value> is
 module specific: it may, for example, represent a further configuration
-section containing configuration module specific information. E.g.:
+section containing configuration module specific information. For example:
 
  # This must be in the default section
  openssl_conf = openssl_init
@@ -365,7 +365,7 @@ the B<EXAMPLES> section for an example of how to do this.
 If the same variable exists in the same section then all but the last
 value will be silently ignored. In certain circumstances such as with
 DNs the same field may occur multiple times. This is usually worked
-around by ignoring any characters before an initial B<.> e.g.
+around by ignoring any characters before an initial B<.>, for example:
 
  1.OU="My first OU"
  2.OU="My Second OU"

--- a/doc/man7/RAND_DRBG.pod
+++ b/doc/man7/RAND_DRBG.pod
@@ -98,7 +98,7 @@ The <master> DRBG is intended to be accessed concurrently for reseeding
 by its child DRBG instances. The necessary locking is done internally.
 It is I<not> thread-safe to access the <master> DRBG directly via the
 RAND_DRBG interface.
-The <public> and <private> DRBG are thread-local, i.e. there is an
+The <public> and <private> DRBG are thread-local, i.e., there is an
 instance of each per thread. So they can safely be accessed without
 locking via the RAND_DRBG interface.
 

--- a/doc/man7/openssl_user_macros.pod.in
+++ b/doc/man7/openssl_user_macros.pod.in
@@ -65,11 +65,11 @@ these numbers are also available:
 
 =over 4
 
-=item Z<>0 (C<0x00908000L>, i.e. version 0.9.8)
+=item Z<>0 (C<0x00908000L>, i.e., version 0.9.8)
 
-=item Z<>1 (C<0x10000000L>, i.e. version 1.0.0)
+=item Z<>1 (C<0x10000000L>, i.e., version 1.0.0)
 
-=item Z<>2 (C<0x10100000L>, i.e. version 1.1.0)
+=item Z<>2 (C<0x10100000L>, i.e., version 1.1.0)
 
 =back
 

--- a/doc/man7/passphrase-encoding.pod
+++ b/doc/man7/passphrase-encoding.pod
@@ -92,9 +92,9 @@ This section assumes that you know what pass phrase was used for encryption,
 but that it may have been encoded in a different character encoding than the
 one used by your current input method.
 For example, the pass phrase may have been used at a time when your default
-encoding was ISO-8859-1 (i.e. "naïve" resulting in the byte sequence 0x6E 0x61
+encoding was ISO-8859-1 (i.e., "naïve" resulting in the byte sequence 0x6E 0x61
 0xEF 0x76 0x65), and you're now in an environment where your default encoding
-is UTF-8 (i.e. "naïve" resulting in the byte sequence 0x6E 0x61 0xC3 0xAF 0x76
+is UTF-8 (i.e., "naïve" resulting in the byte sequence 0x6E 0x61 0xC3 0xAF 0x76
 0x65).
 Whenever it's mentioned that you should use a certain character encoding, it
 should be understood that you either change the input method to use the
@@ -145,7 +145,7 @@ according to the specification.
 
 =item 3.
 
-Do a naïve (i.e. purely mathematical) ISO-8859-1 to UTF-8 conversion and try
+Do a naïve (.e., purely mathematical) ISO-8859-1 to UTF-8 conversion and try
 with the result.
 This differs from the previous attempt because ISO-8859-1 maps directly to
 U+0000 to U+00FF, which other non-UTF-8 character sets do not.

--- a/doc/man7/passphrase-encoding.pod
+++ b/doc/man7/passphrase-encoding.pod
@@ -145,7 +145,7 @@ according to the specification.
 
 =item 3.
 
-Do a naïve (.e., purely mathematical) ISO-8859-1 to UTF-8 conversion and try
+Do a naïve i.e., purely mathematical) ISO-8859-1 to UTF-8 conversion and try
 with the result.
 This differs from the previous attempt because ISO-8859-1 maps directly to
 U+0000 to U+00FF, which other non-UTF-8 character sets do not.

--- a/doc/man7/property.pod
+++ b/doc/man7/property.pod
@@ -117,7 +117,7 @@ Ordering of optional clauses is not significant.
 =head2 Shortcut
 
 In order to permit a more concise expression of boolean properties, there
-is one short cut: a property name alone (e.g. "default") is
+is one short cut: a property name alone (e.g., "default") is
 exactly equivalent to "default=yes" in both definitions and queries.
 
 =head2 Global and Local

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -220,7 +220,7 @@ core_get_params() understands the following known parameters:
 =item "openssl-version"
 
 This is a B<OSSL_PARAM_UTF8_PTR> type of parameter, pointing at the
-OpenSSL libraries' full version string, i.e. the string expanded from
+OpenSSL libraries' full version string, i.e., the string expanded from
 the macro B<OPENSSL_VERSION_STR>.
 
 =item "provider-name"

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -282,7 +282,7 @@ The length of the explicit part of the IV and the tag length will depend on the
 cipher in use and will be defined in the RFC for the relevant ciphersuite.
 In order to allow for "in place" decryption the plaintext output should be
 written to the same location in the output buffer that the ciphertext payload
-was read from, i.e. immediately after the explicit IV.
+was read from, i.e., immediately after the explicit IV.
 
 When encrypting a record the first bytes of the input buffer will be empty to
 allow space for the explicit IV, as will the final bytes where the tag will

--- a/doc/man7/ssl.pod
+++ b/doc/man7/ssl.pod
@@ -212,7 +212,7 @@ definitions in the header files.
 =item const char *B<SSL_CIPHER_get_version>(SSL_CIPHER *cipher);
 
 Returns a string like "C<SSLv3>" or "C<TLSv1.2>" which indicates the
-SSL/TLS protocol version to which I<cipher> belongs (i.e. where it was defined
+SSL/TLS protocol version to which I<cipher> belongs (i.e., where it was defined
 in the specification the first time).
 
 =back

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -215,6 +215,8 @@ sub check()
         if $contents =~ /OpenSSL version [019]/;
     print "$id e.g. without comma\n"
         if $contents =~ /[Ee]\.g\.[^,]/;
+    print "$id i.e. without comma\n"
+        if $contents =~ /[Ii]\.e\.[^,]/;
 
     if ( $contents !~ /=for comment multiple includes/ ) {
         # Look for multiple consecutive openssl #include lines

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -213,6 +213,8 @@ sub check()
         if $contents =~ /=over([^ ][^24])/;
     print "$id Possible version style issue\n"
         if $contents =~ /OpenSSL version [019]/;
+    print "$id e.g. without comma\n"
+        if $contents =~ /[Ee]\.g\.[^,]/;
 
     if ( $contents !~ /=for comment multiple includes/ ) {
         # Look for multiple consecutive openssl #include lines


### PR DESCRIPTION
Common style is to put a comma after "i.e." and "e.g."  (More than that, you're supposed to set them off by putting a comma or open paren before, as well, but I didn't do that.)

Also updated find-doc-nits to catch future occurrences of this.

My biggest take-away from this doing this PR:  OpenSSL uses those abbreviations way too much.

This should be backported IMO.
