### PR TITLE
Fix 9bf682f which broke nistp224_method

### DIFF
--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -291,10 +291,10 @@ const EC_METHOD *EC_GFp_nistp224_method(void)
         ec_key_simple_generate_public_key,
         0, /* keycopy */
         0, /* keyfinish */
+        ecdh_simple_compute_key,
         ecdsa_simple_sign_setup,
         ecdsa_simple_sign_sig,
         ecdsa_simple_verify_sig,
-        ecdh_simple_compute_key,
         0, /* field_inverse_mod_ord */
         0, /* blind_coordinates */
         0, /* ladder_pre */


### PR DESCRIPTION
@richsalz noticed that PR https://github.com/openssl/openssl/pull/9348#issuecomment-521737125 introduced an error.

I assume it must have happened during one of the rebases. I only wonder why i neither see the warning with gcc (--strict-warnings enabled) nor the test suite failed (the p224 code is enabled per default, no?) ..
