### PR TITLE
Fix --strict-warnings build

### DIFF
--- a/test/test_test.c
+++ b/test/test_test.c
@@ -491,7 +491,7 @@ static int test_single_eval(void)
            && TEST_ptr_eq(p, buf + 1)
            && TEST_ptr_null(p = NULL)
            /* strings */
-           && TEST_str_eq(p = "123456" + 1, "23456")
+           && TEST_str_eq(p = &("123456"[1]), "23456")
            && TEST_str_eq("3456", ++p)
            && TEST_str_ne(p++, "456")
            /* memory */


### PR DESCRIPTION
Appease -Wstring-plus-int.

```
clang  -Iinclude -Iapps/include  -pthread -m64 -Wall -O3 -DDEBUG_UNUSED -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wswitch -Wsign-compare -Wshadow -Wformat -Wtype-limits -Wundef -Werror -Wmissing-prototypes -Wstrict-prototypes -Wswitch-default -Wno-parentheses-equality -Wno-language-extension-token -Wno-extended-offsetof -Wconditional-uninitialized -Wincompatible-pointer-types-discards-qualifiers -Wno-unknown-warning-option -Wmissing-variable-declarations -DNDEBUG  -MMD -MF test/test_test-bin-test_test.d.tmp -MT test/test_test-bin-test_test.o -c -o test/test_test-bin-test_test.o test/test_test.c
test/test_test.c:494:40: error: adding 'int' to a string does not append to the string [-Werror,-Wstring-plus-int]
           && TEST_str_eq(p = "123456" + 1, "23456")
                              ~~~~~~~~~^~~
test/testutil.h:433:71: note: expanded from macro 'TEST_str_eq'
# define TEST_str_eq(a, b)    test_str_eq(__FILE__, __LINE__, #a, #b, a, b)
                                                                      ^
test/test_test.c:494:40: note: use array indexing to silence this warning
           && TEST_str_eq(p = "123456" + 1, "23456")
                                       ^
                              &        [
test/testutil.h:433:71: note: expanded from macro 'TEST_str_eq'
# define TEST_str_eq(a, b)    test_str_eq(__FILE__, __LINE__, #a, #b, a, b)
                                                                      ^
1 error generated.
``

- [x] tests are added or updated
