### PR TITLE
Rename ctx_{get,set}_params to {get,set}_ctx_params

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1150,8 +1150,8 @@ PROV_F_AESNI_INIT_KEY:101:aesni_init_key
 PROV_F_AES_BLOCK_FINAL:102:aes_block_final
 PROV_F_AES_BLOCK_UPDATE:103:aes_block_update
 PROV_F_AES_CIPHER:104:aes_cipher
-PROV_F_AES_CTX_GET_PARAMS:105:aes_ctx_get_params
-PROV_F_AES_CTX_SET_PARAMS:106:aes_ctx_set_params
+PROV_F_AES_GET_CTX_PARAMS:105:aes_get_ctx_params
+PROV_F_AES_SET_CTX_PARAMS:106:aes_set_ctx_params
 PROV_F_AES_DINIT:107:aes_dinit
 PROV_F_AES_DUPCTX:108:aes_dupctx
 PROV_F_AES_EINIT:109:aes_einit

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -540,8 +540,8 @@ const OSSL_PARAM *EVP_MD_gettable_params(const EVP_MD *digest)
 
 int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[])
 {
-    if (ctx->digest != NULL && ctx->digest->ctx_set_params != NULL)
-        return ctx->digest->ctx_set_params(ctx->provctx, params);
+    if (ctx->digest != NULL && ctx->digest->set_ctx_params != NULL)
+        return ctx->digest->set_ctx_params(ctx->provctx, params);
     return 0;
 }
 
@@ -555,7 +555,7 @@ const OSSL_PARAM *EVP_MD_CTX_settable_params(const EVP_MD *digest)
 int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, OSSL_PARAM params[])
 {
     if (ctx->digest != NULL && ctx->digest->get_params != NULL)
-        return ctx->digest->ctx_get_params(ctx->provctx, params);
+        return ctx->digest->get_ctx_params(ctx->provctx, params);
     return 0;
 }
 
@@ -675,13 +675,13 @@ static void *evp_md_from_dispatch(const char *name, const OSSL_DISPATCH *fns,
             if (md->get_params == NULL)
                 md->get_params = OSSL_get_OP_digest_get_params(fns);
             break;
-        case OSSL_FUNC_DIGEST_CTX_SET_PARAMS:
-            if (md->ctx_set_params == NULL)
-                md->ctx_set_params = OSSL_get_OP_digest_ctx_set_params(fns);
+        case OSSL_FUNC_DIGEST_SET_CTX_PARAMS:
+            if (md->set_ctx_params == NULL)
+                md->set_ctx_params = OSSL_get_OP_digest_set_ctx_params(fns);
             break;
-        case OSSL_FUNC_DIGEST_CTX_GET_PARAMS:
-            if (md->ctx_get_params == NULL)
-                md->ctx_get_params = OSSL_get_OP_digest_ctx_get_params(fns);
+        case OSSL_FUNC_DIGEST_GET_CTX_PARAMS:
+            if (md->get_ctx_params == NULL)
+                md->get_ctx_params = OSSL_get_OP_digest_get_ctx_params(fns);
             break;
         case OSSL_FUNC_DIGEST_GETTABLE_PARAMS:
             if (md->gettable_params == NULL)

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1060,15 +1060,15 @@ int EVP_CIPHER_get_params(EVP_CIPHER *cipher, OSSL_PARAM params[])
 
 int EVP_CIPHER_CTX_set_params(EVP_CIPHER_CTX *ctx, const OSSL_PARAM params[])
 {
-    if (ctx->cipher != NULL && ctx->cipher->ctx_set_params != NULL)
-        return ctx->cipher->ctx_set_params(ctx->provctx, params);
+    if (ctx->cipher != NULL && ctx->cipher->set_ctx_params != NULL)
+        return ctx->cipher->set_ctx_params(ctx->provctx, params);
     return 0;
 }
 
 int EVP_CIPHER_CTX_get_params(EVP_CIPHER_CTX *ctx, OSSL_PARAM params[])
 {
-    if (ctx->cipher != NULL && ctx->cipher->ctx_get_params != NULL)
-        return ctx->cipher->ctx_get_params(ctx->provctx, params);
+    if (ctx->cipher != NULL && ctx->cipher->get_ctx_params != NULL)
+        return ctx->cipher->get_ctx_params(ctx->provctx, params);
     return 0;
 }
 
@@ -1244,15 +1244,15 @@ static void *evp_cipher_from_dispatch(const char *name,
                 break;
             cipher->get_params = OSSL_get_OP_cipher_get_params(fns);
             break;
-        case OSSL_FUNC_CIPHER_CTX_GET_PARAMS:
-            if (cipher->ctx_get_params != NULL)
+        case OSSL_FUNC_CIPHER_GET_CTX_PARAMS:
+            if (cipher->get_ctx_params != NULL)
                 break;
-            cipher->ctx_get_params = OSSL_get_OP_cipher_ctx_get_params(fns);
+            cipher->get_ctx_params = OSSL_get_OP_cipher_get_ctx_params(fns);
             break;
-        case OSSL_FUNC_CIPHER_CTX_SET_PARAMS:
-            if (cipher->ctx_set_params != NULL)
+        case OSSL_FUNC_CIPHER_SET_CTX_PARAMS:
+            if (cipher->set_ctx_params != NULL)
                 break;
-            cipher->ctx_set_params = OSSL_get_OP_cipher_ctx_set_params(fns);
+            cipher->set_ctx_params = OSSL_get_OP_cipher_set_ctx_params(fns);
             break;
         case OSSL_FUNC_CIPHER_GETTABLE_PARAMS:
             if (cipher->gettable_params != NULL)

--- a/crypto/evp/evp_utils.c
+++ b/crypto/evp/evp_utils.c
@@ -70,10 +70,10 @@ static void seterr(void)
 
 PARAM_FUNCTIONS(EVP_CIPHER,
                 evp_do_ciph_getparams, get_params,
-                evp_do_ciph_ctx_getparams, ctx_get_params,
-                evp_do_ciph_ctx_setparams, ctx_set_params)
+                evp_do_ciph_ctx_getparams, get_ctx_params,
+                evp_do_ciph_ctx_setparams, set_ctx_params)
 
 PARAM_FUNCTIONS(EVP_MD,
                 evp_do_md_getparams, get_params,
-                evp_do_md_ctx_getparams, ctx_get_params,
-                evp_do_md_ctx_setparams, ctx_set_params)
+                evp_do_md_ctx_getparams, get_ctx_params,
+                evp_do_md_ctx_setparams, set_ctx_params)

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -90,8 +90,8 @@ size_t EVP_MAC_size(EVP_MAC_CTX *ctx)
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
         params[0] = OSSL_PARAM_construct_size_t(OSSL_MAC_PARAM_OUTLEN, &sz);
-        if (ctx->meth->ctx_get_params != NULL) {
-            if (ctx->meth->ctx_get_params(ctx->data, params))
+        if (ctx->meth->get_ctx_params != NULL) {
+            if (ctx->meth->get_ctx_params(ctx->data, params))
                 return sz;
         } else if (ctx->meth->get_params != NULL) {
             if (ctx->meth->get_params(params))
@@ -146,14 +146,14 @@ int EVP_MAC_get_params(EVP_MAC *mac, OSSL_PARAM params[])
 
 int EVP_MAC_CTX_get_params(EVP_MAC_CTX *ctx, OSSL_PARAM params[])
 {
-    if (ctx->meth->ctx_get_params != NULL)
-        return ctx->meth->ctx_get_params(ctx->data, params);
+    if (ctx->meth->get_ctx_params != NULL)
+        return ctx->meth->get_ctx_params(ctx->data, params);
     return 1;
 }
 
 int EVP_MAC_CTX_set_params(EVP_MAC_CTX *ctx, const OSSL_PARAM params[])
 {
-    if (ctx->meth->ctx_set_params != NULL)
-        return ctx->meth->ctx_set_params(ctx->data, params);
+    if (ctx->meth->set_ctx_params != NULL)
+        return ctx->meth->set_ctx_params(ctx->data, params);
     return 1;
 }

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -120,15 +120,15 @@ static void *evp_mac_from_dispatch(const char *name, const OSSL_DISPATCH *fns,
                 break;
             mac->get_params = OSSL_get_OP_mac_get_params(fns);
             break;
-        case OSSL_FUNC_MAC_CTX_GET_PARAMS:
-            if (mac->ctx_get_params != NULL)
+        case OSSL_FUNC_MAC_GET_CTX_PARAMS:
+            if (mac->get_ctx_params != NULL)
                 break;
-            mac->ctx_get_params = OSSL_get_OP_mac_ctx_get_params(fns);
+            mac->get_ctx_params = OSSL_get_OP_mac_get_ctx_params(fns);
             break;
-        case OSSL_FUNC_MAC_CTX_SET_PARAMS:
-            if (mac->ctx_set_params != NULL)
+        case OSSL_FUNC_MAC_SET_CTX_PARAMS:
+            if (mac->set_ctx_params != NULL)
                 break;
-            mac->ctx_set_params = OSSL_get_OP_mac_ctx_set_params(fns);
+            mac->set_ctx_params = OSSL_get_OP_mac_set_ctx_params(fns);
             break;
         }
     }

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -138,8 +138,8 @@ struct evp_mac_st {
     OSSL_OP_mac_gettable_ctx_params_fn *gettable_ctx_params;
     OSSL_OP_mac_settable_ctx_params_fn *settable_ctx_params;
     OSSL_OP_mac_get_params_fn *get_params;
-    OSSL_OP_mac_ctx_get_params_fn *ctx_get_params;
-    OSSL_OP_mac_ctx_set_params_fn *ctx_set_params;
+    OSSL_OP_mac_get_ctx_params_fn *get_ctx_params;
+    OSSL_OP_mac_set_ctx_params_fn *set_ctx_params;
 };
 
 /* Internal keccak algorithms used for KMAC */
@@ -211,8 +211,8 @@ struct evp_md_st {
     OSSL_OP_digest_freectx_fn *freectx;
     OSSL_OP_digest_dupctx_fn *dupctx;
     OSSL_OP_digest_get_params_fn *get_params;
-    OSSL_OP_digest_ctx_set_params_fn *ctx_set_params;
-    OSSL_OP_digest_ctx_get_params_fn *ctx_get_params;
+    OSSL_OP_digest_set_ctx_params_fn *set_ctx_params;
+    OSSL_OP_digest_get_ctx_params_fn *get_ctx_params;
     OSSL_OP_digest_gettable_params_fn *gettable_params;
     OSSL_OP_digest_settable_ctx_params_fn *settable_ctx_params;
     OSSL_OP_digest_gettable_ctx_params_fn *gettable_ctx_params;
@@ -265,8 +265,8 @@ struct evp_cipher_st {
     OSSL_OP_cipher_freectx_fn *freectx;
     OSSL_OP_cipher_dupctx_fn *dupctx;
     OSSL_OP_cipher_get_params_fn *get_params;
-    OSSL_OP_cipher_ctx_get_params_fn *ctx_get_params;
-    OSSL_OP_cipher_ctx_set_params_fn *ctx_set_params;
+    OSSL_OP_cipher_get_ctx_params_fn *get_ctx_params;
+    OSSL_OP_cipher_set_ctx_params_fn *set_ctx_params;
     OSSL_OP_cipher_gettable_params_fn *gettable_params;
     OSSL_OP_cipher_gettable_ctx_params_fn *gettable_ctx_params;
     OSSL_OP_cipher_settable_ctx_params_fn *settable_ctx_params;

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -47,8 +47,8 @@ provider-cipher - The cipher library E<lt>-E<gt> provider functions
  int OP_cipher_get_params(OSSL_PARAM params[]);
 
  /* Cipher operation parameters */
- int OP_cipher_ctx_get_params(void *cctx, OSSL_PARAM params[]);
- int OP_cipher_ctx_set_params(void *cctx, const OSSL_PARAM params[]);
+ int OP_cipher_get_ctx_params(void *cctx, OSSL_PARAM params[]);
+ int OP_cipher_set_ctx_params(void *cctx, const OSSL_PARAM params[]);
 
 =head1 DESCRIPTION
 
@@ -90,8 +90,8 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_cipher_cipher               OSSL_FUNC_CIPHER_CIPHER
 
  OP_cipher_get_params           OSSL_FUNC_CIPHER_GET_PARAMS
- OP_cipher_ctx_get_params       OSSL_FUNC_CIPHER_CTX_GET_PARAMS
- OP_cipher_ctx_set_params       OSSL_FUNC_CIPHER_CTX_SET_PARAMS
+ OP_cipher_get_ctx_params       OSSL_FUNC_CIPHER_GET_CTX_PARAMS
+ OP_cipher_set_ctx_params       OSSL_FUNC_CIPHER_SET_CTX_PARAMS
 
  OP_cipher_gettable_params      OSSL_FUNC_CIPHER_GETTABLE_PARAMS
  OP_cipher_gettable_ctx_params  OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS
@@ -179,17 +179,17 @@ these functions.
 OP_cipher_get_params() gets details of the algorithm implementation
 and stores them in B<params>.
 
-OP_cipher_ctx_set_params() sets cipher operation parameters for the
+OP_cipher_set_ctx_params() sets cipher operation parameters for the
 provider side cipher context B<cctx> to B<params>.
 Any parameter settings are additional to any that were previously set.
 
-OP_cipher_ctx_get_params() gets cipher operation details details from
+OP_cipher_get_ctx_params() gets cipher operation details details from
 the given provider side cipher context B<cctx> and stores them in B<params>.
 
 OP_cipher_gettable_params(), OP_cipher_gettable_ctx_params(), and
 OP_cipher_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
 as descriptors of the parameters that OP_cipher_get_params(),
-OP_cipher_ctx_get_params(), and OP_cipher_ctx_set_params() can handle,
+OP_cipher_get_ctx_params(), and OP_cipher_set_ctx_params() can handle,
 respectively.
 
 Parameters currently recognised by built-in ciphers are as follows. Not all
@@ -311,7 +311,7 @@ provider side cipher context, or NULL on failure.
 
 OP_cipher_encrypt_init(), OP_cipher_decrypt_init(), OP_cipher_update(),
 OP_cipher_final(), OP_cipher_cipher(), OP_cipher_get_params(),
-OP_cipher_ctx_get_params() and OP_cipher_ctx_set_params() should return 1 for
+OP_cipher_get_ctx_params() and OP_cipher_set_ctx_params() should return 1 for
 success or 0 on error.
 
 =head1 SEE ALSO

--- a/doc/man7/provider-digest.pod
+++ b/doc/man7/provider-digest.pod
@@ -41,8 +41,8 @@ provider-digest - The digest library E<lt>-E<gt> provider functions
  int OP_digest_get_params(OSSL_PARAM params[]);
 
  /* Digest operation parameters */
- int OP_digest_ctx_set_params(void *dctx, const OSSL_PARAM params[]);
- int OP_digest_ctx_get_params(void *dctx, OSSL_PARAM params[]);
+ int OP_digest_set_ctx_params(void *dctx, const OSSL_PARAM params[]);
+ int OP_digest_get_ctx_params(void *dctx, OSSL_PARAM params[]);
 
 =head1 DESCRIPTION
 
@@ -82,8 +82,8 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_digest_digest               OSSL_FUNC_DIGEST_DIGEST
 
  OP_digest_get_params           OSSL_FUNC_DIGEST_GET_PARAMS
- OP_digest_ctx_get_params       OSSL_FUNC_DIGEST_CTX_GET_PARAMS
- OP_digest_ctx_set_params       OSSL_FUNC_DIGEST_CTX_SET_PARAMS
+ OP_digest_get_ctx_params       OSSL_FUNC_DIGEST_GET_CTX_PARAMS
+ OP_digest_set_ctx_params       OSSL_FUNC_DIGEST_SET_CTX_PARAMS
 
  OP_digest_gettable_params      OSSL_FUNC_DIGEST_GETTABLE_PARAMS
  OP_digest_gettable_ctx_params  OSSL_FUNC_DIGEST_GETTABLE_CTX_PARAMS
@@ -146,17 +146,17 @@ these functions.
 OP_digest_get_params() gets details of the algorithm implementation
 and stores them in B<params>.
 
-OP_digest_ctx_set_params() sets digest operation parameters for the
+OP_digest_set_ctx_params() sets digest operation parameters for the
 provider side digest context B<dctx> to B<params>.
 Any parameter settings are additional to any that were previously set.
 
-OP_digest_ctx_get_params() gets digest operation details details from
+OP_digest_get_ctx_params() gets digest operation details details from
 the given provider side digest context B<dctx> and stores them in B<params>.
 
 OP_digest_gettable_params(), OP_digest_gettable_ctx_params(), and
 OP_digest_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
 as descriptors of the parameters that OP_digest_get_params(),
-OP_digest_ctx_get_params(), and OP_digest_ctx_set_params() can handle,
+OP_digest_get_ctx_params(), and OP_digest_set_ctx_params() can handle,
 respectively.
 
 Parameters currently recognised by built-in digests with this function
@@ -213,12 +213,12 @@ Currently unused.
 
 =head2 Digest Context Parameters
 
-OP_digest_ctx_set_params() sets digest parameters associated with the
+OP_digest_set_ctx_params() sets digest parameters associated with the
 given provider side digest context B<dctx> to B<params>.
 Any parameter settings are additional to any that were previously set.
 See L<OSSL_PARAM(3)> for further details on the parameters structure.
 
-OP_digest_ctx_get_params() gets details of currently set parameters
+OP_digest_get_ctx_params() gets details of currently set parameters
 values associated with the give provider side digest context B<dctx>
 and stores them in B<params>.
 See L<OSSL_PARAM(3)> for further details on the parameters structure.

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -29,13 +29,13 @@ provider-mac - The mac library E<lt>-E<gt> provider functions
 
  /* MAC parameter descriptors */
  const OSSL_PARAM *OP_mac_get_params(void);
- const OSSL_PARAM *OP_mac_ctx_get_params(void);
- const OSSL_PARAM *OP_mac_ctx_set_params(void);
+ const OSSL_PARAM *OP_mac_get_ctx_params(void);
+ const OSSL_PARAM *OP_mac_set_ctx_params(void);
 
  /* MAC parameters */
  int OP_mac_get_params(OSSL_PARAM params[]);
- int OP_mac_ctx_get_params(void *mctx, OSSL_PARAM params[]);
- int OP_mac_ctx_set_params(void *mctx, const OSSL_PARAM params[]);
+ int OP_mac_get_ctx_params(void *mctx, OSSL_PARAM params[]);
+ int OP_mac_set_ctx_params(void *mctx, const OSSL_PARAM params[]);
 
 =head1 DESCRIPTION
 
@@ -74,8 +74,8 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_mac_final                OSSL_FUNC_MAC_FINAL
 
  OP_mac_get_params           OSSL_FUNC_MAC_GET_PARAMS
- OP_mac_ctx_get_params       OSSL_FUNC_MAC_CTX_GET_PARAMS
- OP_mac_ctx_set_params       OSSL_FUNC_MAC_CTX_SET_PARAMS
+ OP_mac_get_ctx_params       OSSL_FUNC_MAC_GET_CTX_PARAMS
+ OP_mac_set_ctx_params       OSSL_FUNC_MAC_SET_CTX_PARAMS
 
  OP_mac_gettable_params      OSSL_FUNC_MAC_GETTABLE_PARAMS
  OP_mac_gettable_ctx_params  OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS
@@ -132,18 +132,18 @@ these functions.
 OP_mac_get_params() gets details of parameter values associated with the
 provider algorithm and stores them in I<params>.
 
-OP_mac_ctx_set_params() sets mac parameters associated with the given
+OP_mac_set_ctx_params() sets mac parameters associated with the given
 provider side mac context I<mctx> to I<params>.
 Any parameter settings are additional to any that were previously set.
 
-OP_mac_ctx_get_params() gets details of currently set parameter values
+OP_mac_get_ctx_params() gets details of currently set parameter values
 associated with the given provider side mac context I<mctx> and stores them
 in I<params>.
 
 OP_mac_gettable_params(), OP_mac_gettable_ctx_params(), and
 OP_mac_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
 as descriptors of the parameters that OP_mac_get_params(),
-OP_mac_ctx_get_params(), and OP_mac_ctx_set_params() can handle,
+OP_mac_get_ctx_params(), and OP_mac_set_ctx_params() can handle,
 respectively.
 
 Parameters currently recognised by built-in macs are as follows. Not all
@@ -228,7 +228,7 @@ OP_mac_newctx() and OP_mac_dupctx() should return the newly created
 provider side mac context, or NULL on failure.
 
 OP_mac_init(), OP_mac_update(), OP_mac_final(), OP_mac_get_params(),
-OP_mac_ctx_get_params() and OP_mac_ctx_set_params() should return 1 for
+OP_mac_get_ctx_params() and OP_mac_set_ctx_params() should return 1 for
 success or 0 on error.
 
 OP_mac_gettable_params(), OP_mac_gettable_ctx_params() and

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -146,8 +146,8 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,provider_get_reason_strings,
 # define OSSL_FUNC_DIGEST_FREECTX                    6
 # define OSSL_FUNC_DIGEST_DUPCTX                     7
 # define OSSL_FUNC_DIGEST_GET_PARAMS                 8
-# define OSSL_FUNC_DIGEST_CTX_SET_PARAMS             9
-# define OSSL_FUNC_DIGEST_CTX_GET_PARAMS            10
+# define OSSL_FUNC_DIGEST_SET_CTX_PARAMS             9
+# define OSSL_FUNC_DIGEST_GET_CTX_PARAMS            10
 # define OSSL_FUNC_DIGEST_GETTABLE_PARAMS           11
 # define OSSL_FUNC_DIGEST_SETTABLE_CTX_PARAMS       12
 # define OSSL_FUNC_DIGEST_GETTABLE_CTX_PARAMS       13
@@ -167,9 +167,9 @@ OSSL_CORE_MAKE_FUNC(void, OP_digest_freectx, (void *dctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_digest_dupctx, (void *dctx))
 
 OSSL_CORE_MAKE_FUNC(int, OP_digest_get_params, (OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_digest_ctx_set_params,
+OSSL_CORE_MAKE_FUNC(int, OP_digest_set_ctx_params,
                     (void *vctx, const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_digest_ctx_get_params,
+OSSL_CORE_MAKE_FUNC(int, OP_digest_get_ctx_params,
                     (void *vctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_digest_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_digest_settable_ctx_params, (void))
@@ -188,8 +188,8 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_digest_gettable_ctx_params, (void))
 # define OSSL_FUNC_CIPHER_FREECTX                    7
 # define OSSL_FUNC_CIPHER_DUPCTX                     8
 # define OSSL_FUNC_CIPHER_GET_PARAMS                 9
-# define OSSL_FUNC_CIPHER_CTX_GET_PARAMS            10
-# define OSSL_FUNC_CIPHER_CTX_SET_PARAMS            11
+# define OSSL_FUNC_CIPHER_GET_CTX_PARAMS            10
+# define OSSL_FUNC_CIPHER_SET_CTX_PARAMS            11
 # define OSSL_FUNC_CIPHER_GETTABLE_PARAMS           12
 # define OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS       13
 # define OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS       14
@@ -219,9 +219,9 @@ OSSL_CORE_MAKE_FUNC(int, OP_cipher_cipher,
 OSSL_CORE_MAKE_FUNC(void, OP_cipher_freectx, (void *cctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_cipher_dupctx, (void *cctx))
 OSSL_CORE_MAKE_FUNC(int, OP_cipher_get_params, (OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_ctx_get_params, (void *cctx,
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_get_ctx_params, (void *cctx,
                                                     OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_cipher_ctx_set_params, (void *cctx,
+OSSL_CORE_MAKE_FUNC(int, OP_cipher_set_ctx_params, (void *cctx,
                                                     const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_params,
                     (void))
@@ -244,8 +244,8 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_cipher_gettable_ctx_params,
 # define OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS           8
 # define OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS           9
 # define OSSL_FUNC_MAC_GET_PARAMS                   10
-# define OSSL_FUNC_MAC_CTX_GET_PARAMS               11
-# define OSSL_FUNC_MAC_CTX_SET_PARAMS               12
+# define OSSL_FUNC_MAC_GET_CTX_PARAMS               11
+# define OSSL_FUNC_MAC_SET_CTX_PARAMS               12
 
 OSSL_CORE_MAKE_FUNC(void *, OP_mac_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_mac_dupctx, (void *src))
@@ -261,9 +261,9 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_mac_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_mac_gettable_ctx_params, (void))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_mac_settable_ctx_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_mac_get_params, (OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_mac_ctx_get_params,
+OSSL_CORE_MAKE_FUNC(int, OP_mac_get_ctx_params,
                     (void *mctx, OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(int, OP_mac_ctx_set_params,
+OSSL_CORE_MAKE_FUNC(int, OP_mac_set_ctx_params,
                     (void *mctx, const OSSL_PARAM params[]))
 
 /*-

--- a/providers/common/ciphers/aes.c
+++ b/providers/common/ciphers/aes.c
@@ -28,8 +28,8 @@ static OSSL_OP_cipher_final_fn aes_stream_final;
 static OSSL_OP_cipher_cipher_fn aes_cipher;
 static OSSL_OP_cipher_freectx_fn aes_freectx;
 static OSSL_OP_cipher_dupctx_fn aes_dupctx;
-static OSSL_OP_cipher_ctx_get_params_fn aes_ctx_get_params;
-static OSSL_OP_cipher_ctx_set_params_fn aes_ctx_set_params;
+static OSSL_OP_cipher_get_ctx_params_fn aes_get_ctx_params;
+static OSSL_OP_cipher_set_ctx_params_fn aes_set_ctx_params;
 
 static int PROV_AES_KEY_generic_init(PROV_AES_KEY *ctx,
                                       const unsigned char *iv,
@@ -360,7 +360,7 @@ static void *aes_dupctx(void *ctx)
     return ret;
 }
 
-static int aes_ctx_get_params(void *vctx, OSSL_PARAM params[])
+static int aes_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
     OSSL_PARAM *p;
@@ -372,26 +372,26 @@ static int aes_ctx_get_params(void *vctx, OSSL_PARAM params[])
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_PADDING);
     if (p != NULL && !OSSL_PARAM_set_int(p, ctx->pad)) {
-        PROVerr(PROV_F_AES_CTX_GET_PARAMS, PROV_R_FAILED_TO_SET_PARAMETER);
+        PROVerr(PROV_F_AES_GET_CTX_PARAMS, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
     if (p != NULL
         && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, AES_BLOCK_SIZE)
         && !OSSL_PARAM_set_octet_string(p, &ctx->iv, AES_BLOCK_SIZE)) {
-        PROVerr(PROV_F_AES_CTX_GET_PARAMS,
+        PROVerr(PROV_F_AES_GET_CTX_PARAMS,
                 PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_NUM);
     if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->num)) {
-        PROVerr(PROV_F_AES_CTX_GET_PARAMS,
+        PROVerr(PROV_F_AES_GET_CTX_PARAMS,
                 PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
     if (p != NULL && !OSSL_PARAM_set_int(p, ctx->keylen)) {
-        PROVerr(PROV_F_AES_CTX_GET_PARAMS,
+        PROVerr(PROV_F_AES_GET_CTX_PARAMS,
                 PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
@@ -399,7 +399,7 @@ static int aes_ctx_get_params(void *vctx, OSSL_PARAM params[])
     return 1;
 }
 
-static int aes_ctx_set_params(void *vctx, const OSSL_PARAM params[])
+static int aes_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_AES_KEY *ctx = (PROV_AES_KEY *)vctx;
     const OSSL_PARAM *p;
@@ -409,7 +409,7 @@ static int aes_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         int pad;
 
         if (!OSSL_PARAM_get_int(p, &pad)) {
-            PROVerr(PROV_F_AES_CTX_SET_PARAMS,
+            PROVerr(PROV_F_AES_SET_CTX_PARAMS,
                     PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
@@ -420,7 +420,7 @@ static int aes_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         int num;
 
         if (!OSSL_PARAM_get_int(p, &num)) {
-            PROVerr(PROV_F_AES_CTX_SET_PARAMS,
+            PROVerr(PROV_F_AES_SET_CTX_PARAMS,
                     PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
@@ -431,7 +431,7 @@ static int aes_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         int keylen;
 
         if (!OSSL_PARAM_get_int(p, &keylen)) {
-            PROVerr(PROV_F_AES_CTX_SET_PARAMS,
+            PROVerr(PROV_F_AES_SET_CTX_PARAMS,
                     PROV_R_FAILED_TO_GET_PARAMETER);
             return 0;
         }
@@ -451,8 +451,8 @@ static int aes_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))aes_freectx }, \
         { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))aes_dupctx }, \
         { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void))aes_##kbits##_##mode##_get_params }, \
-        { OSSL_FUNC_CIPHER_CTX_GET_PARAMS, (void (*)(void))aes_ctx_get_params }, \
-        { OSSL_FUNC_CIPHER_CTX_SET_PARAMS, (void (*)(void))aes_ctx_set_params }, \
+        { OSSL_FUNC_CIPHER_GET_CTX_PARAMS, (void (*)(void))aes_get_ctx_params }, \
+        { OSSL_FUNC_CIPHER_SET_CTX_PARAMS, (void (*)(void))aes_set_ctx_params }, \
         { 0, NULL } \
     };
 
@@ -467,8 +467,8 @@ static int aes_ctx_set_params(void *vctx, const OSSL_PARAM params[])
         { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))aes_freectx }, \
         { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))aes_dupctx }, \
         { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void))aes_##kbits##_##mode##_get_params }, \
-        { OSSL_FUNC_CIPHER_CTX_GET_PARAMS, (void (*)(void))aes_ctx_get_params }, \
-        { OSSL_FUNC_CIPHER_CTX_SET_PARAMS, (void (*)(void))aes_ctx_set_params }, \
+        { OSSL_FUNC_CIPHER_GET_CTX_PARAMS, (void (*)(void))aes_get_ctx_params }, \
+        { OSSL_FUNC_CIPHER_SET_CTX_PARAMS, (void (*)(void))aes_set_ctx_params }, \
         { 0, NULL } \
     };
 

--- a/providers/common/ciphers/gcm.c
+++ b/providers/common/ciphers/gcm.c
@@ -25,8 +25,8 @@
 
 static OSSL_OP_cipher_encrypt_init_fn gcm_einit;
 static OSSL_OP_cipher_decrypt_init_fn gcm_dinit;
-static OSSL_OP_cipher_ctx_get_params_fn gcm_ctx_get_params;
-static OSSL_OP_cipher_ctx_set_params_fn gcm_ctx_set_params;
+static OSSL_OP_cipher_get_ctx_params_fn gcm_get_ctx_params;
+static OSSL_OP_cipher_set_ctx_params_fn gcm_set_ctx_params;
 static OSSL_OP_cipher_cipher_fn gcm_cipher;
 static OSSL_OP_cipher_update_fn gcm_stream_update;
 static OSSL_OP_cipher_final_fn gcm_stream_final;
@@ -98,7 +98,7 @@ static int gcm_dinit(void *vctx, const unsigned char *key, size_t keylen,
     return gcm_init(vctx, key, keylen, iv, ivlen, 0);
 }
 
-static int gcm_ctx_get_params(void *vctx, OSSL_PARAM params[])
+static int gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     OSSL_PARAM *p;
@@ -149,7 +149,7 @@ static int gcm_ctx_get_params(void *vctx, OSSL_PARAM params[])
     return 1;
 }
 
-static int gcm_ctx_set_params(void *vctx, const OSSL_PARAM params[])
+static int gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     const OSSL_PARAM *p;
@@ -535,10 +535,10 @@ err:
         { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_gcm_freectx },      \
         { OSSL_FUNC_CIPHER_GET_PARAMS,                                         \
             (void (*)(void)) alg##_##kbits##_##lcmode##_get_params },          \
-        { OSSL_FUNC_CIPHER_CTX_GET_PARAMS,                                     \
-            (void (*)(void))gcm_ctx_get_params },                              \
-        { OSSL_FUNC_CIPHER_CTX_SET_PARAMS,                                     \
-            (void (*)(void))gcm_ctx_set_params },                              \
+        { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,                                     \
+            (void (*)(void))gcm_get_ctx_params },                              \
+        { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,                                     \
+            (void (*)(void))gcm_set_ctx_params },                              \
         { 0, NULL }                                                            \
     }
 

--- a/providers/common/digests/sha2_prov.c
+++ b/providers/common/digests/sha2_prov.c
@@ -18,7 +18,7 @@
 #include "internal/provider_algs.h"
 #include "internal/sha.h"
 
-static OSSL_OP_digest_ctx_set_params_fn sha1_set_params;
+static OSSL_OP_digest_set_ctx_params_fn sha1_set_params;
 static OSSL_OP_digest_settable_ctx_params_fn sha1_settable_params;
 
 static const OSSL_PARAM known_sha1_ctx_params[] = {

--- a/providers/common/digests/sha3_prov.c
+++ b/providers/common/digests/sha3_prov.c
@@ -26,7 +26,7 @@ static OSSL_OP_digest_update_fn keccak_update;
 static OSSL_OP_digest_final_fn keccak_final;
 static OSSL_OP_digest_freectx_fn keccak_freectx;
 static OSSL_OP_digest_dupctx_fn keccak_dupctx;
-static OSSL_OP_digest_ctx_set_params_fn shake_ctx_set_params;
+static OSSL_OP_digest_set_ctx_params_fn shake_set_ctx_params;
 static OSSL_OP_digest_settable_ctx_params_fn shake_settable_ctx_params;
 static sha3_absorb_fn generic_sha3_absorb;
 static sha3_final_fn generic_sha3_final;
@@ -244,7 +244,7 @@ const OSSL_DISPATCH name##_functions[] = {                              \
     { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))name##_get_params }, \
     { OSSL_FUNC_DIGEST_GETTABLE_PARAMS,                                 \
       (void (*)(void))name##_gettable_params },                         \
-    { OSSL_FUNC_DIGEST_CTX_SET_PARAMS, (void (*)(void))stparams },      \
+    { OSSL_FUNC_DIGEST_SET_CTX_PARAMS, (void (*)(void))stparams },      \
     { OSSL_FUNC_DIGEST_SETTABLE_CTX_PARAMS,                             \
       (void (*)(void))stparamtypes },                                   \
 OSSL_FUNC_DIGEST_CONSTRUCT_END
@@ -275,7 +275,7 @@ static const OSSL_PARAM *shake_settable_ctx_params(void)
     return known_shake_settable_ctx_params;
 }
 
-static int shake_ctx_set_params(void *vctx, const OSSL_PARAM params[])
+static int shake_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)vctx;
@@ -300,13 +300,13 @@ static int shake_ctx_set_params(void *vctx, const OSSL_PARAM params[])
     OSSL_FUNC_SHA3_DIGEST(shake_##bitlen, bitlen, \
                           SHA3_BLOCKSIZE(bitlen), SHA3_MDSIZE(bitlen), \
                           EVP_MD_FLAG_XOF, \
-                          shake_settable_ctx_params, shake_ctx_set_params)
+                          shake_settable_ctx_params, shake_set_ctx_params)
 #define KMAC(bitlen) \
     KMAC_newctx(keccak_kmac_##bitlen, bitlen, '\x04') \
     OSSL_FUNC_SHA3_DIGEST(keccak_kmac_##bitlen, bitlen, \
                           SHA3_BLOCKSIZE(bitlen), KMAC_MDSIZE(bitlen), \
                           EVP_MD_FLAG_XOF, \
-                          shake_settable_ctx_params, shake_ctx_set_params)
+                          shake_settable_ctx_params, shake_set_ctx_params)
 
 SHA3(224)
 SHA3(256)

--- a/providers/common/include/internal/core_mkdigest.h
+++ b/providers/common/include/internal/core_mkdigest.h
@@ -120,7 +120,7 @@ OSSL_FUNC_DIGEST_CONSTRUCT_START(name, CTX, blksize, dgstsize, flags,   \
                                  init, upd, fin)                        \
     { OSSL_FUNC_DIGEST_SETTABLE_CTX_PARAMS,                             \
       (void (*)(void))setparamtypes },                                  \
-    { OSSL_FUNC_DIGEST_CTX_SET_PARAMS, (void (*)(void))setparams },     \
+    { OSSL_FUNC_DIGEST_SET_CTX_PARAMS, (void (*)(void))setparams },     \
 OSSL_FUNC_DIGEST_CONSTRUCT_END
 
 # ifdef __cplusplus

--- a/providers/common/include/internal/providercommonerr.h
+++ b/providers/common/include/internal/providercommonerr.h
@@ -28,8 +28,8 @@ int ERR_load_PROV_strings(void);
 #  define PROV_F_AES_BLOCK_FINAL                           0
 #  define PROV_F_AES_BLOCK_UPDATE                          0
 #  define PROV_F_AES_CIPHER                                0
-#  define PROV_F_AES_CTX_GET_PARAMS                        0
-#  define PROV_F_AES_CTX_SET_PARAMS                        0
+#  define PROV_F_AES_GET_CTX_PARAMS                        0
+#  define PROV_F_AES_SET_CTX_PARAMS                        0
 #  define PROV_F_AES_DINIT                                 0
 #  define PROV_F_AES_DUPCTX                                0
 #  define PROV_F_AES_EINIT                                 0

--- a/providers/common/macs/cmac_prov.c
+++ b/providers/common/macs/cmac_prov.c
@@ -29,9 +29,9 @@ static OSSL_OP_mac_newctx_fn cmac_new;
 static OSSL_OP_mac_dupctx_fn cmac_dup;
 static OSSL_OP_mac_freectx_fn cmac_free;
 static OSSL_OP_mac_gettable_ctx_params_fn cmac_gettable_ctx_params;
-static OSSL_OP_mac_ctx_get_params_fn cmac_ctx_get_params;
+static OSSL_OP_mac_get_ctx_params_fn cmac_get_ctx_params;
 static OSSL_OP_mac_settable_ctx_params_fn cmac_settable_ctx_params;
-static OSSL_OP_mac_ctx_set_params_fn cmac_ctx_set_params;
+static OSSL_OP_mac_set_ctx_params_fn cmac_set_ctx_params;
 static OSSL_OP_mac_init_fn cmac_init;
 static OSSL_OP_mac_update_fn cmac_update;
 static OSSL_OP_mac_final_fn cmac_final;
@@ -149,7 +149,7 @@ static const OSSL_PARAM *cmac_gettable_ctx_params(void)
     return known_gettable_ctx_params;
 }
 
-static int cmac_ctx_get_params(void *vmacctx, OSSL_PARAM params[])
+static int cmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -177,7 +177,7 @@ static const OSSL_PARAM *cmac_settable_ctx_params(void)
 /*
  * ALL parameters should be set before init().
  */
-static int cmac_ctx_set_params(void *vmacctx, const OSSL_PARAM params[])
+static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct cmac_data_st *macctx = vmacctx;
     const OSSL_PARAM *p;
@@ -255,10 +255,10 @@ const OSSL_DISPATCH cmac_functions[] = {
     { OSSL_FUNC_MAC_FINAL, (void (*)(void))cmac_final },
     { OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS,
       (void (*)(void))cmac_gettable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_GET_PARAMS, (void (*)(void))cmac_ctx_get_params },
+    { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))cmac_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))cmac_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))cmac_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))cmac_set_ctx_params },
     { 0, NULL }
 };
 

--- a/providers/common/macs/gmac_prov.c
+++ b/providers/common/macs/gmac_prov.c
@@ -30,7 +30,7 @@ static OSSL_OP_mac_freectx_fn gmac_free;
 static OSSL_OP_mac_gettable_params_fn gmac_gettable_params;
 static OSSL_OP_mac_get_params_fn gmac_get_params;
 static OSSL_OP_mac_settable_ctx_params_fn gmac_settable_ctx_params;
-static OSSL_OP_mac_ctx_set_params_fn gmac_ctx_set_params;
+static OSSL_OP_mac_set_ctx_params_fn gmac_set_ctx_params;
 static OSSL_OP_mac_init_fn gmac_init;
 static OSSL_OP_mac_update_fn gmac_update;
 static OSSL_OP_mac_final_fn gmac_final;
@@ -188,7 +188,7 @@ static const OSSL_PARAM *gmac_settable_ctx_params(void)
 /*
  * ALL parameters should be set before init().
  */
-static int gmac_ctx_set_params(void *vmacctx, const OSSL_PARAM params[])
+static int gmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct gmac_data_st *macctx = vmacctx;
     EVP_CIPHER_CTX *ctx = macctx->ctx;
@@ -286,6 +286,6 @@ const OSSL_DISPATCH gmac_functions[] = {
     { OSSL_FUNC_MAC_GET_PARAMS, (void (*)(void))gmac_get_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))gmac_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))gmac_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))gmac_set_ctx_params },
     { 0, NULL }
 };

--- a/providers/common/macs/hmac_prov.c
+++ b/providers/common/macs/hmac_prov.c
@@ -26,9 +26,9 @@ static OSSL_OP_mac_newctx_fn hmac_new;
 static OSSL_OP_mac_dupctx_fn hmac_dup;
 static OSSL_OP_mac_freectx_fn hmac_free;
 static OSSL_OP_mac_gettable_ctx_params_fn hmac_gettable_ctx_params;
-static OSSL_OP_mac_ctx_get_params_fn hmac_ctx_get_params;
+static OSSL_OP_mac_get_ctx_params_fn hmac_get_ctx_params;
 static OSSL_OP_mac_settable_ctx_params_fn hmac_settable_ctx_params;
-static OSSL_OP_mac_ctx_set_params_fn hmac_ctx_set_params;
+static OSSL_OP_mac_set_ctx_params_fn hmac_set_ctx_params;
 static OSSL_OP_mac_init_fn hmac_init;
 static OSSL_OP_mac_update_fn hmac_update;
 static OSSL_OP_mac_final_fn hmac_final;
@@ -160,7 +160,7 @@ static const OSSL_PARAM *hmac_gettable_ctx_params(void)
     return known_gettable_ctx_params;
 }
 
-static int hmac_ctx_get_params(void *vmacctx, OSSL_PARAM params[])
+static int hmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -189,7 +189,7 @@ static const OSSL_PARAM *hmac_settable_ctx_params(void)
 /*
  * ALL parameters should be set before init().
  */
-static int hmac_ctx_set_params(void *vmacctx, const OSSL_PARAM params[])
+static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct hmac_data_st *macctx = vmacctx;
     const OSSL_PARAM *p;
@@ -276,9 +276,9 @@ const OSSL_DISPATCH hmac_functions[] = {
     { OSSL_FUNC_MAC_FINAL, (void (*)(void))hmac_final },
     { OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS,
       (void (*)(void))hmac_gettable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_GET_PARAMS, (void (*)(void))hmac_ctx_get_params },
+    { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))hmac_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))hmac_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))hmac_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))hmac_set_ctx_params },
     { 0, NULL }
 };

--- a/providers/common/macs/kmac_prov.c
+++ b/providers/common/macs/kmac_prov.c
@@ -68,9 +68,9 @@ static OSSL_OP_mac_newctx_fn kmac256_new;
 static OSSL_OP_mac_dupctx_fn kmac_dup;
 static OSSL_OP_mac_freectx_fn kmac_free;
 static OSSL_OP_mac_gettable_ctx_params_fn kmac_gettable_ctx_params;
-static OSSL_OP_mac_ctx_get_params_fn kmac_ctx_get_params;
+static OSSL_OP_mac_get_ctx_params_fn kmac_get_ctx_params;
 static OSSL_OP_mac_settable_ctx_params_fn kmac_settable_ctx_params;
-static OSSL_OP_mac_ctx_set_params_fn kmac_ctx_set_params;
+static OSSL_OP_mac_set_ctx_params_fn kmac_set_ctx_params;
 static OSSL_OP_mac_size_fn kmac_size;
 static OSSL_OP_mac_init_fn kmac_init;
 static OSSL_OP_mac_update_fn kmac_update;
@@ -266,7 +266,7 @@ static int kmac_init(void *vmacctx)
             OSSL_PARAM_octet_string(OSSL_MAC_PARAM_CUSTOM, "", 0),
             OSSL_PARAM_END
         };
-        (void)kmac_ctx_set_params(kctx, params);
+        (void)kmac_set_ctx_params(kctx, params);
     }
 
     return bytepad(out, &out_len, kmac_string, sizeof(kmac_string),
@@ -321,7 +321,7 @@ static const OSSL_PARAM *kmac_gettable_ctx_params(void)
     return known_gettable_ctx_params;
 }
 
-static int kmac_ctx_get_params(void *vmacctx, OSSL_PARAM params[])
+static int kmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -355,7 +355,7 @@ static const OSSL_PARAM *kmac_settable_ctx_params(void)
  *
  * All other params should be set before init().
  */
-static int kmac_ctx_set_params(void *vmacctx, const OSSL_PARAM *params)
+static int kmac_set_ctx_params(void *vmacctx, const OSSL_PARAM *params)
 {
     struct kmac_data_st *kctx = vmacctx;
     const OSSL_PARAM *p;
@@ -534,10 +534,10 @@ const OSSL_DISPATCH kmac128_functions[] = {
     { OSSL_FUNC_MAC_FINAL, (void (*)(void))kmac_final },
     { OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS,
       (void (*)(void))kmac_gettable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_GET_PARAMS, (void (*)(void))kmac_ctx_get_params },
+    { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))kmac_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))kmac_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))kmac_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))kmac_set_ctx_params },
     { 0, NULL }
 };
 
@@ -550,9 +550,9 @@ const OSSL_DISPATCH kmac256_functions[] = {
     { OSSL_FUNC_MAC_FINAL, (void (*)(void))kmac_final },
     { OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS,
       (void (*)(void))kmac_gettable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_GET_PARAMS, (void (*)(void))kmac_ctx_get_params },
+    { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))kmac_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))kmac_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))kmac_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))kmac_set_ctx_params },
     { 0, NULL }
 };

--- a/providers/default/digests/md5_sha1_prov.c
+++ b/providers/default/digests/md5_sha1_prov.c
@@ -17,7 +17,7 @@
 #include "internal/md5_sha1.h"
 #include "internal/provider_algs.h"
 
-static OSSL_OP_digest_ctx_set_params_fn md5_sha1_ctx_set_params;
+static OSSL_OP_digest_set_ctx_params_fn md5_sha1_set_ctx_params;
 static OSSL_OP_digest_settable_ctx_params_fn md5_sha1_settable_ctx_params;
 
 static const OSSL_PARAM known_md5_sha1_settable_ctx_params[] = {
@@ -31,7 +31,7 @@ static const OSSL_PARAM *md5_sha1_settable_ctx_params(void)
 }
 
 /* Special set_params method for SSL3 */
-static int md5_sha1_ctx_set_params(void *vctx, const OSSL_PARAM params[])
+static int md5_sha1_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     MD5_SHA1_CTX *ctx = (MD5_SHA1_CTX *)vctx;
@@ -49,4 +49,4 @@ OSSL_FUNC_DIGEST_CONSTRUCT_PARAMS(md5_sha1, MD5_SHA1_CTX,
                                   MD5_SHA1_CBLOCK, MD5_SHA1_DIGEST_LENGTH, 0,
                                   md5_sha1_init, md5_sha1_update, md5_sha1_final,
                                   md5_sha1_settable_ctx_params,
-                                  md5_sha1_ctx_set_params)
+                                  md5_sha1_set_ctx_params)

--- a/providers/default/macs/blake2_mac_impl.c
+++ b/providers/default/macs/blake2_mac_impl.c
@@ -28,9 +28,9 @@ static OSSL_OP_mac_newctx_fn blake2_mac_new;
 static OSSL_OP_mac_dupctx_fn blake2_mac_dup;
 static OSSL_OP_mac_freectx_fn blake2_mac_free;
 static OSSL_OP_mac_gettable_ctx_params_fn blake2_gettable_ctx_params;
-static OSSL_OP_mac_ctx_get_params_fn blake2_ctx_get_params;
+static OSSL_OP_mac_get_ctx_params_fn blake2_get_ctx_params;
 static OSSL_OP_mac_settable_ctx_params_fn blake2_mac_settable_ctx_params;
-static OSSL_OP_mac_ctx_set_params_fn blake2_mac_ctx_set_params;
+static OSSL_OP_mac_set_ctx_params_fn blake2_mac_set_ctx_params;
 static OSSL_OP_mac_init_fn blake2_mac_init;
 static OSSL_OP_mac_update_fn blake2_mac_update;
 static OSSL_OP_mac_final_fn blake2_mac_final;
@@ -117,7 +117,7 @@ static const OSSL_PARAM *blake2_gettable_ctx_params(void)
     return known_gettable_ctx_params;
 }
 
-static int blake2_ctx_get_params(void *vmacctx, OSSL_PARAM params[])
+static int blake2_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -144,7 +144,7 @@ static const OSSL_PARAM *blake2_mac_settable_ctx_params()
 /*
  * ALL parameters should be set before init().
  */
-static int blake2_mac_ctx_set_params(void *vmacctx, const OSSL_PARAM params[])
+static int blake2_mac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct blake2_mac_data_st *macctx = vmacctx;
     const OSSL_PARAM *p;
@@ -220,10 +220,10 @@ const OSSL_DISPATCH BLAKE2_FUNCTIONS[] = {
     { OSSL_FUNC_MAC_FINAL, (void (*)(void))blake2_mac_final },
     { OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS,
       (void (*)(void))blake2_gettable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_GET_PARAMS, (void (*)(void))blake2_ctx_get_params },
+    { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))blake2_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))blake2_mac_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))blake2_mac_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))blake2_mac_set_ctx_params },
     { 0, NULL }
 };
 

--- a/providers/default/macs/poly1305_prov.c
+++ b/providers/default/macs/poly1305_prov.c
@@ -38,7 +38,7 @@ static OSSL_OP_mac_freectx_fn poly1305_free;
 static OSSL_OP_mac_gettable_params_fn poly1305_gettable_params;
 static OSSL_OP_mac_get_params_fn poly1305_get_params;
 static OSSL_OP_mac_settable_ctx_params_fn poly1305_settable_ctx_params;
-static OSSL_OP_mac_ctx_set_params_fn poly1305_ctx_set_params;
+static OSSL_OP_mac_set_ctx_params_fn poly1305_set_ctx_params;
 static OSSL_OP_mac_init_fn poly1305_init;
 static OSSL_OP_mac_update_fn poly1305_update;
 static OSSL_OP_mac_final_fn poly1305_final;
@@ -135,7 +135,7 @@ static const OSSL_PARAM *poly1305_settable_ctx_params(void)
     return known_settable_ctx_params;
 }
 
-static int poly1305_ctx_set_params(void *vmacctx, const OSSL_PARAM *params)
+static int poly1305_set_ctx_params(void *vmacctx, const OSSL_PARAM *params)
 {
     struct poly1305_data_st *ctx = vmacctx;
     const OSSL_PARAM *p = NULL;
@@ -162,7 +162,7 @@ const OSSL_DISPATCH poly1305_functions[] = {
     { OSSL_FUNC_MAC_GET_PARAMS, (void (*)(void))poly1305_get_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))poly1305_settable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))poly1305_ctx_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))poly1305_set_ctx_params },
     { 0, NULL }
 };
 

--- a/providers/default/macs/siphash_prov.c
+++ b/providers/default/macs/siphash_prov.c
@@ -37,9 +37,9 @@ static OSSL_OP_mac_newctx_fn siphash_new;
 static OSSL_OP_mac_dupctx_fn siphash_dup;
 static OSSL_OP_mac_freectx_fn siphash_free;
 static OSSL_OP_mac_gettable_ctx_params_fn siphash_gettable_ctx_params;
-static OSSL_OP_mac_ctx_get_params_fn siphash_ctx_get_params;
+static OSSL_OP_mac_get_ctx_params_fn siphash_get_ctx_params;
 static OSSL_OP_mac_settable_ctx_params_fn siphash_settable_params;
-static OSSL_OP_mac_ctx_set_params_fn siphash_set_params;
+static OSSL_OP_mac_set_ctx_params_fn siphash_set_params;
 static OSSL_OP_mac_size_fn siphash_size;
 static OSSL_OP_mac_init_fn siphash_init;
 static OSSL_OP_mac_update_fn siphash_update;
@@ -121,7 +121,7 @@ static const OSSL_PARAM *siphash_gettable_ctx_params(void)
     return known_gettable_ctx_params;
 }
 
-static int siphash_ctx_get_params(void *vmacctx, OSSL_PARAM params[])
+static int siphash_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -178,10 +178,10 @@ const OSSL_DISPATCH siphash_functions[] = {
     { OSSL_FUNC_MAC_FINAL, (void (*)(void))siphash_final },
     { OSSL_FUNC_MAC_GETTABLE_CTX_PARAMS,
       (void (*)(void))siphash_gettable_ctx_params },
-    { OSSL_FUNC_MAC_CTX_GET_PARAMS, (void (*)(void))siphash_ctx_get_params },
+    { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))siphash_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))siphash_settable_params },
-    { OSSL_FUNC_MAC_CTX_SET_PARAMS, (void (*)(void))siphash_set_params },
+    { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))siphash_set_params },
     { 0, NULL }
 };
 

--- a/providers/legacy/digests/mdc2_prov.c
+++ b/providers/legacy/digests/mdc2_prov.c
@@ -15,7 +15,7 @@
 #include "internal/core_mkdigest.h"
 #include "internal/provider_algs.h"
 
-static OSSL_OP_digest_ctx_set_params_fn mdc2_ctx_set_params;
+static OSSL_OP_digest_set_ctx_params_fn mdc2_set_ctx_params;
 static OSSL_OP_digest_settable_ctx_params_fn mdc2_settable_ctx_params;
 
 static const OSSL_PARAM known_mdc2_settable_ctx_params[] = {
@@ -28,7 +28,7 @@ static const OSSL_PARAM *mdc2_settable_ctx_params(void)
     return known_mdc2_settable_ctx_params;
 }
 
-static int mdc2_ctx_set_params(void *vctx, const OSSL_PARAM params[])
+static int mdc2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     MDC2_CTX *ctx = (MDC2_CTX *)vctx;
@@ -45,4 +45,4 @@ static int mdc2_ctx_set_params(void *vctx, const OSSL_PARAM params[])
 OSSL_FUNC_DIGEST_CONSTRUCT_PARAMS(mdc2, MDC2_CTX,
                                   MDC2_BLOCK, MDC2_DIGEST_LENGTH, 0,
                                   MDC2_Init, MDC2_Update, MDC2_Final,
-                                  mdc2_settable_ctx_params, mdc2_ctx_set_params)
+                                  mdc2_settable_ctx_params, mdc2_set_ctx_params)


### PR DESCRIPTION
Recently, we added dispatched functions to get parameter descriptions,
and those for operation context parameters ended up being called
something_gettable_ctx_params and something_settable_ctx_params.

The corresponding dispatched functions to actually perform parameter
transfers were previously called something_ctx_get_params and
something_ctx_set_params, which doesn't quite match, so we rename them
to something_get_ctx_params and something_set_ctx_params.

An argument in favor of this name change is English, where you'd
rather say something like "set the context parameters".

This only change the libcrypto <-> provider interface.
