### PR TITLE
Fix error handling in X509_chain_up_ref

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -490,6 +490,8 @@ STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *chain)
     STACK_OF(X509) *ret;
     int i;
     ret = sk_X509_dup(chain);
+    if (ret == NULL)
+        return NULL;
     for (i = 0; i < sk_X509_num(ret); i++) {
         X509 *x = sk_X509_value(ret, i);
         CRYPTO_add(&x->references, 1, CRYPTO_LOCK_X509);


### PR DESCRIPTION
For 1.0.2 branch, fixes possible crash.