### PR TITLE
Fix sha512_block_data_order_avx2 backtrace info

### DIFF
--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -2268,20 +2268,19 @@ $code.=<<___;
 .cfi_cfa_expression	$Tbl+`16*$SZ+3*8`,deref,+8
 
 .Ldone_avx2:
-	lea	($Tbl),%rsp
-	mov	$_rsp,%rsi
+	mov	`16*$SZ+3*8`($Tbl),%rsi
 .cfi_def_cfa	%rsi,8
 	vzeroupper
 ___
 $code.=<<___ if ($win64);
-	movaps	16*$SZ+32(%rsp),%xmm6
-	movaps	16*$SZ+48(%rsp),%xmm7
-	movaps	16*$SZ+64(%rsp),%xmm8
-	movaps	16*$SZ+80(%rsp),%xmm9
+	movaps	16*$SZ+32($Tbl),%xmm6
+	movaps	16*$SZ+48($Tbl),%xmm7
+	movaps	16*$SZ+64($Tbl),%xmm8
+	movaps	16*$SZ+80($Tbl),%xmm9
 ___
 $code.=<<___ if ($win64 && $SZ>4);
-	movaps	16*$SZ+96(%rsp),%xmm10
-	movaps	16*$SZ+112(%rsp),%xmm11
+	movaps	16*$SZ+96($Tbl),%xmm10
+	movaps	16*$SZ+112($Tbl),%xmm11
 ___
 $code.=<<___;
 	mov	-48(%rsi),%r15

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -2238,6 +2238,7 @@ $code.=<<___;
 	lea	`2*$SZ*($rounds-8)`(%rsp),%rsp
 # restore frame pointer to original location at $_rsp
 .cfi_cfa_expression	$_rsp,deref,+8
+
 	add	$SZ*0($ctx),$A
 	add	$SZ*1($ctx),$B
 	add	$SZ*2($ctx),$C

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -1996,7 +1996,7 @@ ___
 $code.=<<___ if (!$win64);
 # temporarily use %rdi as frame pointer
 	mov	$_rsp,%rdi
-.cfi_def_cfa_register	%rdi
+.cfi_def_cfa	%rdi,8
 ___
 $code.=<<___;
 	lea	-$PUSH8(%rsp),%rsp
@@ -2269,8 +2269,6 @@ $code.=<<___;
 
 .Ldone_avx2:
 	lea	($Tbl),%rsp
-# restore frame pointer to original location at $_rsp
-.cfi_cfa_expression	$_rsp,deref,+8
 	mov	$_rsp,%rsi
 .cfi_def_cfa	%rsi,8
 	vzeroupper

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -1930,6 +1930,7 @@ ${func}_avx2:
 	mov	$inp,$_inp		# save inp, 2nd arh
 	mov	%rdx,$_end		# save end pointer, "3rd" arg
 	mov	%rax,$_rsp		# save copy of %rsp
+.cfi_cfa_expression	$_rsp,deref,+8
 ___
 $code.=<<___ if (!$win64);
 # the frame info is at $_rsp, but the stack is moving...

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -2114,7 +2114,7 @@ ___
 $code.=<<___ if (!$win64);
 # temporarily use %rdi as frame pointer
 	mov	$_rsp,%rdi
-.cfi_def_cfa_register	%rdi
+.cfi_def_cfa	%rdi,8
 ___
 $code.=<<___;
 	lea	-$PUSH8(%rsp),%rsp

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -1930,6 +1930,8 @@ ${func}_avx2:
 	mov	$inp,$_inp		# save inp, 2nd arh
 	mov	%rdx,$_end		# save end pointer, "3rd" arg
 	mov	%rax,$_rsp		# save copy of %rsp
+___
+$code.=<<___ if (!$win64);
 # the frame info is at $_rsp, but the stack is moving...
 # so a second frame pointer is saved at -8(%rsp)
 # that is in the red zone
@@ -1997,11 +1999,15 @@ $code.=<<___;
 	xor	$a1,$a1
 	vmovdqa	$t1,0x20(%rsp)
 	lea	-$PUSH8(%rsp),%rsp
+___
+$code.=<<___ if (!$win64);
 .cfi_cfa_expression	%rsp+`$PUSH8-8`,deref,+8
 # copy secondary frame pointer to new location again at -8(%rsp)
 	mov	$PUSH8-8(%rsp),%rdi
 	mov	%rdi,-8(%rsp)
 .cfi_cfa_expression	%rsp-8,deref,+8
+___
+$code.=<<___;
 	mov	$B,$a3
 	vmovdqa	$t2,0x00(%rsp)
 	xor	$C,$a3			# magic
@@ -2022,8 +2028,8 @@ my @insns = (&$body,&$body,&$body,&$body);	# 96 instructions
 my $base = "+2*$PUSH8(%rsp)";
 
 	if (($j%2)==0) {
-$code.=<<___;
-	lea	-$PUSH8(%rsp),%rsp
+	&lea	("%rsp","-$PUSH8(%rsp)");
+$code.=<<___ if (!$win64);
 .cfi_cfa_expression	%rsp+`$PUSH8-8`,deref,+8
 # copy secondary frame pointer to new location again at -8(%rsp)
 	pushq	$PUSH8-8(%rsp)
@@ -2104,11 +2110,15 @@ $code.=<<___;
 	vpaddq	0x40($Tbl),@X[6],$t2
 	vmovdqa	$t3,0x60(%rsp)
 	lea	-$PUSH8(%rsp),%rsp
+___
+$code.=<<___ if (!$win64);
 .cfi_cfa_expression	%rsp+`$PUSH8-8`,deref,+8
 # copy secondary frame pointer to new location again at -8(%rsp)
 	mov	$PUSH8-8(%rsp),%rdi
 	mov	%rdi,-8(%rsp)
 .cfi_cfa_expression	%rsp-8,deref,+8
+___
+$code.=<<___;
 	vpaddq	0x60($Tbl),@X[7],$t3
 	vmovdqa	$t0,0x00(%rsp)
 	xor	$a1,$a1
@@ -2133,8 +2143,8 @@ my @insns = (&$body,&$body);			# 48 instructions
 my $base = "+2*$PUSH8(%rsp)";
 
 	if (($j%4)==0) {
-$code.=<<___;
-	lea	-$PUSH8(%rsp),%rsp
+	&lea	("%rsp","-$PUSH8(%rsp)");
+$code.=<<___ if (!$win64);
 .cfi_cfa_expression	%rsp+`$PUSH8-8`,deref,+8
 # copy secondary frame pointer to new location again at -8(%rsp)
 	pushq	$PUSH8-8(%rsp)
@@ -2218,6 +2228,8 @@ $code.=<<___;
 	add	$a1,$A
 	#mov	`2*$SZ*$rounds+8`(%rsp),$inp	# $_inp
 	lea	`2*$SZ*($rounds-8)`(%rsp),%rsp
+___
+$code.=<<___ if (!$win64);
 # restore frame pointer to original location at $_rsp
 .cfi_cfa_expression	$_rsp,deref,+8
 # copy secondary frame pointer to new location again at -8(%rsp)
@@ -2225,7 +2237,8 @@ $code.=<<___;
 .cfi_cfa_expression	%rsp,deref,+8
 	lea	8(%rsp),%rsp
 .cfi_cfa_expression	%rsp-8,deref,+8
-
+___
+$code.=<<___;
 	add	$SZ*0($ctx),$A
 	add	$SZ*1($ctx),$B
 	add	$SZ*2($ctx),$C


### PR DESCRIPTION
Add a frame pointer that is always reachable at rsp-8, the red zone.
Well, red zone it is not guaranteed to be preserved on windows but
for purpose of restoring the return frame we have the original copy.
When no free register is available I use a pushq / lea sequence.
When a free scratch register is available I use two mov insns.
I don't know if two mov are more expensive or not. 