### PR TITLE
Untangle / retangle opensslv.h, openssslconf.h and macros.h

### DIFF
--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/opensslconf.h>
+
 #ifndef OPENSSL_MACROS_H
 # define OPENSSL_MACROS_H
 
@@ -74,13 +76,12 @@
 # endif
 
 /*
- * Do not deprecate things to be deprecated in version 4.0 before the
- * OpenSSL version number matches.
+ * Define API level check macros up to what makes sense.  Since we
+ * do future deprecations, we define one API level beyond the current
+ * major version number.
  */
-# if OPENSSL_VERSION_MAJOR < 4
-#  define DEPRECATEDIN_4(f)       f;
-#  define OPENSSL_API_4 0
-# elif OPENSSL_API_LEVEL < 4
+
+# if OPENSSL_API_LEVEL < 4
 #  define DEPRECATEDIN_4(f)       DECLARE_DEPRECATED(f)
 #  define OPENSSL_API_4 0
 # else

--- a/include/openssl/opensslconf.h.in
+++ b/include/openssl/opensslconf.h.in
@@ -9,8 +9,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/opensslv.h>
-
 #ifndef HEADER_OPENSSLCONF_H
 # define HEADER_OPENSSLCONF_H
 

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -119,9 +119,9 @@ const char *OPENSSL_version_build_metadata(void);
     "OpenSSL " OPENSSL_FULL_VERSION_STR " " OPENSSL_RELEASE_DATE
 
 /*
- * SECTION 3: BACKWARD COMPATIBILITY
+ * SECTION 4: BACKWARD COMPATIBILITY
  */
-# include <openssl/opensslconf.h>
+# include <openssl/macros.h>
 
 # if !OPENSSL_API_4
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */


### PR DESCRIPTION
When openssl/macros.h is included without openssl/opensslv.h, it can't
define OPENSSL_API_4 properly (with sufficient warnings enabled, the
compiler will complain about OPENSSL_VERSION_MAJOR not being defined).
The quick fix could have been to include openssl/opensslv.h in
openssl/macros.h, but that would create a nasty include loop, since
openssl/opensslv.h includes openssl/opensslconf.h, which includes
openssl/macros.h, in an order that leads back to macro check errors.

The objective is to make these headers more independent:

- openssl/opensslconf.h should really be completely independent, as it
  only defines macros for configuration values.  However, it needs to
  include openssl/macros.h for backward compatibility reasons.  We do
  this at the very end, under inclusion guards.
- openssl/macros.h is changed to include openssl/opensslconf.h, so it
  gets necessary configuration values to build some macros.  This will
  not cause an endless inclusion loop, since opensslconf.h's inclusion
  of macros.h is under guard.
- openssl/opensslv.h is changed to include openssl/macros.h instead of
  openssl/opensslconf.h.

Only one last piece needs to be done to make openssl/macros.h
independent from openssl/opensslv.h.  We can realise that the
definition of OPENSSL_API_4 doesn't need to depend on the current
version number.  There's nothing in our configuration that  would have
OPENSSL_API_4 defined to 1, and if the user sets OPENSSL_API_COMPAT or
OPENSSL_API_LEVEL to a high enough value, we consider that a
deliberate and knowledgable action on their part.

Fixes #7874
Fixes #9601

-----

This is an alternative to #9623