### PR TITLE
Use macros internally for algorithm names

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -327,7 +327,7 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
     OPENSSL_CTX *libctx =
         prov == NULL ? NULL : ossl_provider_library_context(prov);
     EVP_PKEY *ret = EVP_PKEY_new();
-    EVP_MAC *cmac = EVP_MAC_fetch(libctx, "CMAC", NULL);
+    EVP_MAC *cmac = EVP_MAC_fetch(libctx, OSSL_MAC_NAME_CMAC, NULL);
     EVP_MAC_CTX *cmctx = cmac != NULL ? EVP_MAC_CTX_new(cmac) : NULL;
     OSSL_PARAM params[4];
     size_t paramsn = 0;

--- a/crypto/kdf/sskdf.c
+++ b/crypto/kdf/sskdf.c
@@ -467,7 +467,7 @@ static int sskdf_derive(EVP_KDF_IMPL *impl, unsigned char *key, size_t keylen)
          * block size?
          */
         macname = EVP_MAC_name(impl->mac);
-        if (strcmp(macname, "HMAC") == 0) {
+        if (strcmp(macname, OSSL_MAC_NAME_HMAC) == 0) {
             /* H(x) = HMAC(x, salt, hash) */
             if (impl->md == NULL) {
                 KDFerr(KDF_F_SSKDF_DERIVE, KDF_R_MISSING_MESSAGE_DIGEST);
@@ -476,12 +476,12 @@ static int sskdf_derive(EVP_KDF_IMPL *impl, unsigned char *key, size_t keylen)
             default_salt_len = EVP_MD_block_size(impl->md);
             if (default_salt_len <= 0)
                 return 0;
-        } else if (strcmp(macname, "KMAC128") == 0
-                   || strcmp(macname, "KMAC256") == 0) {
+        } else if (strcmp(macname, OSSL_MAC_NAME_KMAC128) == 0
+                   || strcmp(macname, OSSL_MAC_NAME_KMAC256) == 0) {
             /* H(x) = KMACzzz(x, salt, custom) */
             custom = kmac_custom_str;
             custom_len = sizeof(kmac_custom_str);
-            if (strcmp(macname, "KMAC128") == 0)
+            if (strcmp(macname, OSSL_MAC_NAME_KMAC128) == 0)
                 default_salt_len = SSKDF_KMAC128_DEFAULT_SALT_SIZE;
             else
                 default_salt_len = SSKDF_KMAC256_DEFAULT_SALT_SIZE;

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -243,7 +243,7 @@ static int tls1_prf_P_hash(const EVP_MD *md,
     int mac_flags;
     const char *mdname = EVP_MD_name(md);
 
-    mac = EVP_MAC_fetch(NULL, "HMAC", NULL); /* Implicit fetch */
+    mac = EVP_MAC_fetch(NULL, OSSL_MAC_NAME_HMAC, NULL); /* Implicit fetch */
     ctx_init = EVP_MAC_CTX_new(mac);
     if (ctx_init == NULL)
         goto err;

--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -186,7 +186,8 @@ int CRYPTO_siv128_init(SIV128_CONTEXT *ctx, const unsigned char *key, int klen,
     if (key == NULL || cbc == NULL || ctr == NULL
             || (ctx->cipher_ctx = EVP_CIPHER_CTX_new()) == NULL
             /* TODO(3.0) library context */
-            || (ctx->mac = EVP_MAC_fetch(NULL, "CMAC", NULL)) == NULL
+            || (ctx->mac =
+                EVP_MAC_fetch(NULL, OSSL_MAC_NAME_CMAC, NULL)) == NULL
             || (ctx->mac_ctx_init = EVP_MAC_CTX_new(ctx->mac)) == NULL
             || !EVP_MAC_CTX_set_params(ctx->mac_ctx_init, params)
             || !EVP_EncryptInit_ex(ctx->cipher_ctx, ctr, NULL, key + klen, NULL)

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -64,6 +64,10 @@ extern "C" {
 #define OSSL_DIGEST_PARAM_SIZE      "size" /* OSSL_PARAM_INTEGER */
 #define OSSL_DIGEST_PARAM_FLAGS     "flags" /* OSSL_PARAM_UNSIGNED_INTEGER */
 
+/* Known DIGEST names (not a complete list) */
+#define OSSL_DIGEST_NAME_KECCAK_KMAC128 "KECCAK_KMAC128"
+#define OSSL_DIGEST_NAME_KECCAK_KMAC256 "KECCAK_KMAC256"
+
 /* MAC parameters */
 #define OSSL_MAC_PARAM_KEY          "key"       /* octet string */
 #define OSSL_MAC_PARAM_IV           "iv"        /* octet string */
@@ -83,6 +87,12 @@ extern "C" {
 #define OSSL_MAC_PARAM_SIZE         "size"      /* size_t */
 #define OSSL_MAC_PARAM_DIGESTSIZE   "digestsize" /* size_t */
 #define OSSL_MAC_PARAM_OUTLEN       "outlen"    /* size_t */
+
+/* Known MAC names (not a complete list) */
+#define OSSL_MAC_NAME_CMAC          "CMAC"
+#define OSSL_MAC_NAME_HMAC          "HMAC"
+#define OSSL_MAC_NAME_KMAC128       "KMAC128"
+#define OSSL_MAC_NAME_KMAC256       "KMAC256"
 
 /* PKEY parameters */
 /* Diffie-Hellman Parameters */

--- a/providers/common/macs/kmac_prov.c
+++ b/providers/common/macs/kmac_prov.c
@@ -203,12 +203,12 @@ static void *kmac_fetch_new(void *provctx, const char *mdname)
 
 static void *kmac128_new(void *provctx)
 {
-    return kmac_fetch_new(provctx, "KECCAK_KMAC128");
+    return kmac_fetch_new(provctx, OSSL_DIGEST_NAME_KECCAK_KMAC128);
 }
 
 static void *kmac256_new(void *provctx)
 {
-    return kmac_fetch_new(provctx, "KECCAK_KMAC256");
+    return kmac_fetch_new(provctx, OSSL_DIGEST_NAME_KECCAK_KMAC256);
 }
 
 static void *kmac_dup(void *vsrc)

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -15,6 +15,7 @@
 
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
+#include <openssl/core_names.h>
 #include "testutil.h"
 
 static int test_kdf_tls1_prf(void)
@@ -278,7 +279,8 @@ static int test_kdf_ss_hmac(void)
 
     ret =
         TEST_ptr(kctx = EVP_KDF_CTX_new_id(EVP_KDF_SS))
-        && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_MAC, "HMAC"), 0)
+        && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_MAC,
+                                    OSSL_MAC_NAME_HMAC), 0)
         && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_MD,  EVP_sha256()), 0)
         && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_KEY, z, sizeof(z)), 0)
         && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_SSKDF_INFO, other,
@@ -317,7 +319,8 @@ static int test_kdf_ss_kmac(void)
 
     ret =
         TEST_ptr(kctx = EVP_KDF_CTX_new_id(EVP_KDF_SS))
-        && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_MAC, "KMAC128"), 0)
+        && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_MAC,
+                                    OSSL_MAC_NAME_KMAC128), 0)
         && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_KEY, z,
                                     sizeof(z)), 0)
         && TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_SSKDF_INFO, other,


### PR DESCRIPTION
The macros are defined in include/openssl/core_names.h and follow the
naming standard OSSL_{OPNAME}_NAME_{ALGONAME}, where {OPNAME} is the
name of the operation (such as MAC) and {ALGONAME} is the name of the
algorithm.  Example: OSSL_MAC_NAME_HMAC
