### PR TITLE
Add a fallback definition for __NR_getrandom for x86 linux

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -258,6 +258,10 @@ static ssize_t sysctl_random(char *buf, size_t buflen)
 #   if defined(__linux) && !defined(__NR_getrandom)
 #    if defined(__arm__) && defined(__NR_SYSCALL_BASE)
 #     define __NR_getrandom    (__NR_SYSCALL_BASE+384)
+#    elif defined(__i386__)
+#     define __NR_getrandom    355
+#    elif defined(__x86_64__) && !defined(__ILP32__)
+#     define __NR_getrandom    318
 #    endif
 #   endif
 


### PR DESCRIPTION
I have tested both code points on:

`Linux version 4.20.0+ (ed@w-ed) (gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.4)) #1 SMP PREEMPT Fri Jan 4 20:43:45 CET 2019`

... where I happened to have installed the kernel, but forgot abut the header files.