### PR TITLE
 When building of modules is disabled, build the legacy provider into libcrypto

### DIFF
--- a/Configure
+++ b/Configure
@@ -518,7 +518,7 @@ my @disable_cascades = (
     # or modules.
     "pic"               => [ "shared", "module" ],
 
-    "module"            => [ "fips", "legacy" ],
+    "module"            => [ "fips" ],
 
     "engine"            => [ grep /eng$/, @disablables ],
     "hw"                => [ "padlockeng" ],

--- a/Configure
+++ b/Configure
@@ -1742,10 +1742,18 @@ if ($builder eq "unified") {
             my $value = '';
             my $value_rest = shift;
 
+            if ($ENV{CONFIGURE_DEBUG_VARIABLE_EXPAND}) {
+                print STDERR
+                    "DEBUG[\$expand_variables] Parsed '$value_rest' into:\n"
+            }
             while ($value_rest =~ /(?<!\\)${variable_re}/) {
                 $value .= $`;
                 $value .= $variables{$1};
                 $value_rest = $';
+            }
+            if ($ENV{CONFIGURE_DEBUG_VARIABLE_EXPAND}) {
+                print STDERR
+                    "DEBUG[\$expand_variables] ... '$value$value_rest'\n";
             }
             return $value . $value_rest;
         };
@@ -1899,26 +1907,31 @@ if ($builder eq "unified") {
             },
 
             qr/^\s*ORDINALS\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/,
-            => sub { push @{$ordinals{$1}}, tokenize($expand_variables->($2))
+            => sub { push @{$ordinals{$expand_variables->($1)}},
+                         tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SOURCE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$sources{$1}}, tokenize($expand_variables->($2))
+            => sub { push @{$sources{$expand_variables->($1)}},
+                         tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*SHARED_SOURCE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$shared_sources{$1}},
+            => sub { push @{$shared_sources{$expand_variables->($1)}},
                          tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*INCLUDE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$includes{$1}}, tokenize($expand_variables->($2))
+            => sub { push @{$includes{$expand_variables->($1)}},
+                         tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
-            qr/^\s*DEFINE\[((?:\\.|[^\\\]])*)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$defines{$1}}, tokenize($expand_variables->($2))
+            qr/^\s*DEFINE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
+            => sub { push @{$defines{$expand_variables->($1)}},
+                         tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*DEPEND\[((?:\\.|[^\\\]])*)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$depends{$1}}, tokenize($expand_variables->($2))
+            => sub { push @{$depends{$expand_variables->($1)}},
+                         tokenize($expand_variables->($2))
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*GENERATE\[((?:\\.|[^\\\]])+)\]\s*=\s*(.*)\s*$/
-            => sub { push @{$generate{$1}}, $2
+            => sub { push @{$generate{$expand_variables->($1)}}, $2
                          if !@skip || $skip[$#skip] > 0 },
             qr/^\s*(?:#.*)?$/ => sub { },
             "OTHERWISE" => sub { die "Something wrong with this line:\n$_\nat $sourced/$f" },

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -12,12 +12,17 @@
 
 OSSL_provider_init_fn ossl_default_provider_init;
 OSSL_provider_init_fn fips_intern_provider_init;
-
+#ifdef STATIC_LEGACY
+OSSL_provider_init_fn ossl_legacy_provider_init;
+#endif
 const struct predefined_providers_st predefined_providers[] = {
 #ifdef FIPS_MODE
     { "fips", fips_intern_provider_init, 1 },
 #else
     { "default", ossl_default_provider_init, 1 },
+# ifdef STATIC_LEGACY
+    { "legacy", ossl_legacy_provider_init, 0 },
+# endif
 #endif
     { NULL, NULL, 0 }
 };

--- a/providers/build.info
+++ b/providers/build.info
@@ -15,11 +15,16 @@ ENDIF
 
 IF[{- !$disabled{legacy} -}]
   SUBDIRS=legacy
-  MODULES=legacy
-  IF[{- defined $target{shared_defflag} -}]
-    SOURCE[legacy]=legacy.ld
-    GENERATE[legacy.ld]=../util/providers.num
+  IF[{- $disabled{module} -}]
+    LIBS=../libcrypto
+    DEFINE[../libcrypto]=STATIC_LEGACY
+  ELSE
+    MODULES=legacy
+    IF[{- defined $target{shared_defflag} -}]
+      SOURCE[legacy]=legacy.ld
+      GENERATE[legacy.ld]=../util/providers.num
+    ENDIF
+    DEPEND[legacy]=../libcrypto
+    INCLUDE[legacy]=.. ../include ../crypto/include common/include
   ENDIF
-  INCLUDE[legacy]=.. ../include ../crypto/include common/include
-  DEPEND[legacy]=../libcrypto
 ENDIF

--- a/providers/legacy/build.info
+++ b/providers/legacy/build.info
@@ -1,4 +1,8 @@
 SUBDIRS=digests
+IF[{- $disabled{module} -}]
+  $GOAL=../../libcrypto
+ELSE
+  $GOAL=../legacy
+ENDIF
 
-SOURCE[../legacy]=\
-        legacyprov.c
+SOURCE[$GOAL]=legacyprov.c

--- a/providers/legacy/digests/build.info
+++ b/providers/legacy/digests/build.info
@@ -1,24 +1,30 @@
+IF[{- $disabled{module} -}]
+  $GOAL=../../../libcrypto
+ELSE
+  $GOAL=../../legacy
+ENDIF
+
 IF[{- !$disabled{md2} -}]
-  SOURCE[../../legacy]=\
+  SOURCE[$GOAL]=\
           md2_prov.c
 ENDIF
 
 IF[{- !$disabled{md4} -}]
-  SOURCE[../../legacy]=\
+  SOURCE[$GOAL]=\
           md4_prov.c
 ENDIF
 
 IF[{- !$disabled{mdc2} -}]
-  SOURCE[../../legacy]=\
+  SOURCE[$GOAL]=\
           mdc2_prov.c
 ENDIF
 
 IF[{- !$disabled{whirlpool} -}]
-  SOURCE[../../legacy]=\
+  SOURCE[$GOAL]=\
           wp_prov.c
 ENDIF
 
 IF[{- !$disabled{rmd160} -}]
-  SOURCE[../../legacy]=\
+  SOURCE[$GOAL]=\
           ripemd_prov.c
 ENDIF

--- a/providers/legacy/legacyprov.c
+++ b/providers/legacy/legacyprov.c
@@ -15,6 +15,11 @@
 #include <openssl/params.h>
 #include "internal/provider_algs.h"
 
+#ifdef STATIC_LEGACY
+OSSL_provider_init_fn ossl_legacy_provider_init;
+# define OSSL_provider_init ossl_legacy_provider_init
+#endif
+
 /* Functions provided by the core */
 static OSSL_core_gettable_params_fn *c_gettable_params = NULL;
 static OSSL_core_get_params_fn *c_get_params = NULL;


### PR DESCRIPTION
This makes the legacy provider available regardless of building conditions.

This includes a modification to the use of variables in build.info files, to make them usable in indexes.  That makes it possible to assign different goals for translation units depending on need.

Related to #9568, where a solution like this was briefly discussed.