### PR TITLE
Clarify the key length in the example code.

### DIFF
--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -308,6 +308,10 @@ EVP_MAC_do_all_ex() returns nothing at all.
           params[params_n++] =
               OSSL_PARAM_construct_utf8_string("digest", digest,
                                                strlen(digest) + 1, NULL);
+      /*
+       * Note that in general, the key would be binary data and that
+       * the strlen(key) call would not be appropriate here.
+       */
       params[params_n++] =
           OSSL_PARAM_construct_octet_string("key", key, strlen(key), NULL);
       params[params_n] = OSSL_PARAM_construct_end();


### PR DESCRIPTION
The key length is calculated using `strlen(key)`.  Normally a key would be
binary data and `strlen(3)` would not be an appropriate way to determine its
length.

This commit adds a comment to indicate this and to try to avoid confusion on the readers' behalf.

- [x] documentation is added or updated
- [ ] tests are added or updated
