### PR TITLE
Correct documented return value for BIO_get_mem_data()

### DIFF
--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -122,8 +122,11 @@ There should be an option to set the maximum size of a memory BIO.
 
 BIO_s_mem() and BIO_s_secmem() return a valid memory B<BIO_METHOD> structure.
 
-BIO_set_mem_eof_return(), BIO_get_mem_data(), BIO_set_mem_buf() and BIO_get_mem_ptr()
+BIO_set_mem_eof_return(), BIO_set_mem_buf() and BIO_get_mem_ptr()
 return 1 on success or a value which is less than or equal to 0 if an error occurred.
+
+BIO_get_mem_data() returns the total number of bytes available on success,
+0 if b is NULL, or a negative value in case of other errors.
 
 BIO_new_mem_buf() returns a valid B<BIO> structure on success or NULL on error.
 


### PR DESCRIPTION
CLA: trivial

Hi, I noticed that the return value for BIO_get_mem_data() was documented incorrectly. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

