### PR TITLE
Constify param builder string functions.

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -160,7 +160,7 @@ int ossl_param_bld_push_BN(OSSL_PARAM_BLD *bld, const char *key,
 }
 
 int ossl_param_bld_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
-                                    char *buf, size_t bsize)
+                                    const char *buf, size_t bsize)
 {
     OSSL_PARAM_BLD_DEF *pd;
 
@@ -198,7 +198,7 @@ int ossl_param_bld_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
 }
 
 int ossl_param_bld_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
-                                     void *buf, size_t bsize)
+                                     const void *buf, size_t bsize)
 {
     OSSL_PARAM_BLD_DEF *pd;
 

--- a/doc/internal/man3/ossl_param_bld_init.pod
+++ b/doc/internal/man3/ossl_param_bld_init.pod
@@ -36,11 +36,11 @@ ossl_param_bld_push_octet_ptr
                             const BIGNUM *bn);
 
  int ossl_param_bld_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
-                                     char *buf, size_t bsize);
+                                     const char *buf, size_t bsize);
  int ossl_param_bld_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
                                   char *buf, size_t bsize);
  int ossl_param_bld_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
-                                      void *buf, size_t bsize);
+                                      const void *buf, size_t bsize);
  int ossl_param_bld_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
                                    void *buf, size_t bsize);
 

--- a/include/internal/param_build.h
+++ b/include/internal/param_build.h
@@ -69,10 +69,10 @@ int ossl_param_bld_push_double(OSSL_PARAM_BLD *bld, const char *key,
 int ossl_param_bld_push_BN(OSSL_PARAM_BLD *bld, const char *key,
                            const BIGNUM *bn);
 int ossl_param_bld_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
-                                    char *buf, size_t bsize);
+                                    const char *buf, size_t bsize);
 int ossl_param_bld_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
                                  char *buf, size_t bsize);
 int ossl_param_bld_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
-                                     void *buf, size_t bsize);
+                                     const void *buf, size_t bsize);
 int ossl_param_bld_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
                                   void *buf, size_t bsize);


### PR DESCRIPTION
Making the string value argument to the builder string functions const avoids needing a cast when using a fixed value.

E.g. `ossl_param_bld_push_utf8_string(&bld, "digest", "sha256", 0)` becomes legal.  Without the third argument needs a cast to remove the const.

 This cannot be done so easily for the `OSSL_PARAM_construct_{utf8,octet}string` functions where a return buffer can be specified.

- [x] documentation is added or updated
- [ ] tests are added or updated