### PR TITLE
Fix ossl_param_bld_push_{utf8,octet}_string() / param_bld_convert()

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -260,7 +260,7 @@ static OSSL_PARAM *param_bld_convert(OSSL_PARAM_BLD *bld, OSSL_PARAM *param,
         } else if (pd->type == OSSL_PARAM_OCTET_PTR
                    || pd->type == OSSL_PARAM_UTF8_PTR) {
             /* PTR */
-            *(void **)p = pd->string;
+            *(const void **)p = pd->string;
         } else if (pd->type == OSSL_PARAM_OCTET_STRING
                    || pd->type == OSSL_PARAM_UTF8_STRING) {
             if (pd->string != NULL)

--- a/include/internal/param_build.h
+++ b/include/internal/param_build.h
@@ -20,7 +20,7 @@ typedef struct {
     size_t size;
     size_t alloc_blocks;
     const BIGNUM *bn;
-    void *string;
+    const void *string;
     union {
         /*
          * These fields are never directly addressed, but their sizes are


### PR DESCRIPTION
ossl_param_bld_push_{utf8,octet}_string() saved the constant string
pointer to a non-constant structure field, so we change that field to
a pointer to a constant.  We also modify param_bld_convert() to
pretend the resulting pointer for PTR types points to a constant as
well.

Completes #9649
