### PR TITLE
Update dependent functions to deal with "const" pointers.

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -174,7 +174,7 @@ int ossl_param_bld_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
     pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_UTF8_STRING, 0);
     if (pd == NULL)
         return 0;
-    pd->string = buf;
+    pd->string = (char *)buf;
     return 1;
 }
 
@@ -210,7 +210,7 @@ int ossl_param_bld_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
     pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_OCTET_STRING, 0);
     if (pd == NULL)
         return 0;
-    pd->string = buf;
+    pd->string = (void *)buf;
     return 1;
 }
 


### PR DESCRIPTION
The (updated) param builder helpers missed a couple of casts.  This adds them.

The recent PR's are a result of one of our (non-OpenSSL) guy's having difficulties with the new OSSL_PARAM MAC APIs.  They are error prone or worse :(  The param builders are an improvement but still tricky in places.

The older ctl calls seem to be more manageable.

