### PR TITLE
DTLS memory optimization when used with SCTP as transport

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1039,14 +1039,25 @@ WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs, int stop)
     int cleanuphand = s->statem.cleanuphand;
 
     if (clearbufs) {
-        if (!SSL_IS_DTLS(s)) {
+        if (!SSL_IS_DTLS(s)
+#ifndef OPENSSL_NO_SCTP
+                /*
+                 * RFC6083: SCTP provides a reliable and in-sequence transport service for DTLS
+                 * messages that require it. Therefore, DTLS procedures for retransmissions
+                 * MUST NOT be used.
+                 * Hence the init_buf can be cleared when DTLS over SCTP as transport is used.
+                 */
+	        || BIO_dgram_is_sctp(SSL_get_wbio(s))
+#endif
+	        ) {
             /*
-             * We don't do this in DTLS because we may still need the init_buf
+             * We don't do this in DTLS over UDP because we may still need the init_buf
              * in case there are any unexpected retransmits
              */
             BUF_MEM_free(s->init_buf);
             s->init_buf = NULL;
         }
+
         if (!ssl_free_wbio_buffer(s)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_FINISH_HANDSHAKE,
                      ERR_R_INTERNAL_ERROR);


### PR DESCRIPTION
A DTLS connection memory can be optimized by freeing the `init_buf` after the handshake is completed when the transport is SCTP . This `init_buf` is required to handle the re-transmitted messages like 'FINISHED' from client. `init_buf` memory is around 22KB in case of DTLS.
DTLS over UDP can still get the re-transmitted message but there is no re-transmission in case of DTLS over SCTP.

RFC 6083:
  SCTP provides a reliable and in-sequence transport service for DTLS
   messages that require it.  As per section 4.4.  Therefore, DTLS
   procedures for re-transmissions MUST NOT be used.

Hence `init_buf` can be freed when DTLS over SCTP as transport is used.