### PR TITLE
Replace rsa macro functions with real functions

### DIFF
--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -19,6 +19,47 @@
 #include "crypto/rsa.h"
 #include "rsa_local.h"
 
+int EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(EVP_PKEY_CTX *ctx, int len)
+{
+    return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS, EVP_PKEY_OP_KEYGEN,
+                             EVP_PKEY_CTRL_RSA_PSS_SALTLEN, len, NULL);
+}
+
+int EVP_PKEY_CTX_get_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int *plen)
+{
+    return RSA_pkey_ctx_ctrl(ctx, (EVP_PKEY_OP_SIGN|EVP_PKEY_OP_VERIFY),
+                             EVP_PKEY_CTRL_GET_RSA_PSS_SALTLEN, 0, plen);
+}
+
+int EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
+{
+    return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS, EVP_PKEY_OP_KEYGEN,
+                             EVP_PKEY_CTRL_RSA_MGF1_MD, 0, (void *)(md));
+}
+
+int EVP_PKEY_CTX_set_rsa_pss_keygen_md(EVP_PKEY_CTX *ctx, const EVP_MD *md){
+    return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS, EVP_PKEY_OP_KEYGEN,
+                             EVP_PKEY_CTRL_MD, 0, (void *)(md));
+}
+
+int EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits)
+{
+    return RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN,
+                             EVP_PKEY_CTRL_RSA_KEYGEN_BITS, mbits, NULL);
+}
+
+int EVP_PKEY_CTX_set_rsa_keygen_pubexp(EVP_PKEY_CTX *ctx, BIGNUM *pubexp)
+{
+    return RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN,
+                             EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP, 0, pubexp);
+}
+
+int EVP_PKEY_CTX_set_rsa_keygen_primes(EVP_PKEY_CTX *ctx, int primes)
+{
+    return RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN,
+                             EVP_PKEY_CTRL_RSA_KEYGEN_PRIMES, primes, NULL);
+}
+
 RSA *RSA_new(void)
 {
     return RSA_new_method(NULL);

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -281,18 +281,18 @@ to be automatically determined based on the B<PSS> block structure. If this
 macro is not called maximum salt length is used when signing and auto detection
 when verifying is used by default.
 
-The EVP_PKEY_CTX_get_rsa_pss_saltlen() macro gets the RSA PSS salt length
+The EVP_PKEY_CTX_get_rsa_pss_saltlen() function gets the RSA PSS salt length
 for B<ctx>. The padding mode must have been set to B<RSA_PKCS1_PSS_PADDING>.
 
-The EVP_PKEY_CTX_set_rsa_keygen_bits() macro sets the RSA key length for
+The EVP_PKEY_CTX_set_rsa_keygen_bits() function sets the RSA key length for
 RSA key generation to B<bits>. If not specified 1024 bits is used.
 
-The EVP_PKEY_CTX_set_rsa_keygen_pubexp() macro sets the public exponent value
+The EVP_PKEY_CTX_set_rsa_keygen_pubexp() function sets the public exponent value
 for RSA key generation to B<pubexp>. Currently it should be an odd integer. The
 B<pubexp> pointer is used internally by this function so it should not be
 modified or freed after the call. If not specified 65537 is used.
 
-The EVP_PKEY_CTX_set_rsa_keygen_primes() macro sets the number of primes for
+The EVP_PKEY_CTX_set_rsa_keygen_primes() function sets the number of primes for
 RSA key generation to B<primes>. If not specified 2 is used.
 
 The EVP_PKEY_CTX_set_rsa_mgf1_md_name() function sets the MGF1 digest for RSA

--- a/doc/man3/EVP_PKEY_CTX_set_rsa_pss_keygen_md.pod
+++ b/doc/man3/EVP_PKEY_CTX_set_rsa_pss_keygen_md.pod
@@ -44,7 +44,7 @@ similar to the B<RSA> versions.
 =head2 Key Generation
 
 As with RSA key generation the EVP_PKEY_CTX_set_rsa_keygen_bits()
-and EVP_PKEY_CTX_set_rsa_keygen_pubexp() macros are supported for RSA-PSS:
+and EVP_PKEY_CTX_set_rsa_keygen_pubexp() functions are supported for RSA-PSS:
 they have exactly the same meaning as for the RSA algorithm.
 
 Optional parameter restrictions can be specified when generating a PSS key.

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -115,25 +115,6 @@ int EVP_PKEY_CTX_get_rsa_padding(EVP_PKEY_CTX *ctx, int *pad_mode);
 /* Old compatible max salt length for sign only */
 # define RSA_PSS_SALTLEN_MAX_SIGN    -2
 
-# define EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(ctx, len) \
-        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_PSS_SALTLEN, len, NULL)
-
-# define EVP_PKEY_CTX_get_rsa_pss_saltlen(ctx, plen) \
-        RSA_pkey_ctx_ctrl(ctx, (EVP_PKEY_OP_SIGN|EVP_PKEY_OP_VERIFY), \
-                          EVP_PKEY_CTRL_GET_RSA_PSS_SALTLEN, 0, plen)
-
-# define EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, bits) \
-        RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_KEYGEN_BITS, bits, NULL)
-
-# define EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, pubexp) \
-        RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP, 0, pubexp)
-
-# define EVP_PKEY_CTX_set_rsa_keygen_primes(ctx, primes) \
-        RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_KEYGEN_PRIMES, primes, NULL)
 
 int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_CTX_set_rsa_mgf1_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
@@ -142,10 +123,6 @@ int EVP_PKEY_CTX_get_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD **md);
 int EVP_PKEY_CTX_get_rsa_mgf1_md_name(EVP_PKEY_CTX *ctx, char *name,
                                       size_t namelen);
 
-
-# define  EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(ctx, md) \
-        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_MGF1_MD, 0, (void *)(md))
 
 int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_CTX_set_rsa_oaep_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
@@ -157,10 +134,14 @@ int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, void *label,
                                      int llen);
 int EVP_PKEY_CTX_get0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char **label);
 
-# define  EVP_PKEY_CTX_set_rsa_pss_keygen_md(ctx, md) \
-        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS,  \
-                          EVP_PKEY_OP_KEYGEN, EVP_PKEY_CTRL_MD,  \
-                          0, (void *)(md))
+
+int EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(EVP_PKEY_CTX *ctx, int saltlen);
+int EVP_PKEY_CTX_get_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int *len);
+int EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+int EVP_PKEY_CTX_set_rsa_pss_keygen_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+int EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits);
+int EVP_PKEY_CTX_set_rsa_keygen_pubexp(EVP_PKEY_CTX *ctx, BIGNUM *pubexp);
+int EVP_PKEY_CTX_set_rsa_keygen_primes(EVP_PKEY_CTX *ctx, int primes);
 
 
 # define EVP_PKEY_CTRL_RSA_PADDING       (EVP_PKEY_ALG_CTRL + 1)

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4878,3 +4878,10 @@ EVP_PKEY_meth_set_digestsign            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_digestverify          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_digestsign            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_digestverify          ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_get_rsa_pss_saltlen        ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_pss_keygen_md      ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_keygen_bits        ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_keygen_pubexp      ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_keygen_primes      ?	3_0_0	EXIST::FUNCTION:RSA


### PR DESCRIPTION
Use the function signature described in the man page.

With the macro version, there where at least two issues.

1)
User code would emit warnings when compiling with `-Wcast-qual` on
GCC, since `(void*)` would cast `const` away. This should be an
implementation detail.
The cast is necessary as `EVP_PKEY_CTX_ctrl` takes a `void*` and not a
`const void*`.

2)
The unconditional cast to `void*` of the last parameter permits to pass
any parameter type to the macros without triggering any warning, making
the functions easy to misuse and possibly triggering undefined behaviour.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated: this MR updates the code to what the documentation states
- [x] tests are added or updated: no new tests

Notice: The file `req.c` does not compile as it uses `EVP_PKEY_CTX_set_rsa_keygen_bits`, but apparently does not link to the rsa library.
I was not able to understand where I should update the makefile, any help?


This MR is related to "issue" https://github.com/openssl/openssl/issues/9644