### PR TITLE
Man1 pages for new sub-commands only known as 'openssl-subcommand'

### DIFF
--- a/doc/man1/info.pod
+++ b/doc/man1/info.pod
@@ -2,8 +2,7 @@
 
 =head1 NAME
 
-openssl-info,
-info - print OpenSSL built-in information
+openssl-info - print OpenSSL built-in information
 
 =head1 SYNOPSIS
 

--- a/doc/man1/kdf.pod
+++ b/doc/man1/kdf.pod
@@ -2,8 +2,7 @@
 
 =head1 NAME
 
-openssl-kdf,
-kdf - perform Key Derivation Function operations
+openssl-kdf - perform Key Derivation Function operations
 
 =head1 SYNOPSIS
 

--- a/doc/man1/mac.pod
+++ b/doc/man1/mac.pod
@@ -2,8 +2,7 @@
 
 =head1 NAME
 
-openssl-mac,
-mac - perform Message Authentication Code operations
+openssl-mac - perform Message Authentication Code operations
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
So as not to add clutter to the global command namespace, only use the
'openssl-subcommand' name form for new subcommands / man1 manpages.
The 'subcommand' form stays with older manpages for backward
compatibility.

Is is encouraged to use 'man openssl subcommand' to read these manual,
rather than 'man subcommand'.
