### PR TITLE
Add CPU info to the speed command summary

### DIFF
--- a/apps/info.c
+++ b/apps/info.c
@@ -14,7 +14,7 @@
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_CONFIGDIR, OPT_ENGINESDIR, OPT_MODULESDIR, OPT_DSOEXT, OPT_DIRNAMESEP,
-    OPT_LISTSEP, OPT_SEEDS
+    OPT_LISTSEP, OPT_SEEDS, OPT_CPUSETTINGS
 } OPTION_CHOICE;
 
 const OPTIONS info_options[] = {
@@ -31,6 +31,7 @@ const OPTIONS info_options[] = {
     {"dirnamesep", OPT_DIRNAMESEP, '-', "Directory-filename separator"},
     {"listsep", OPT_LISTSEP, '-', "List separator character"},
     {"seeds", OPT_SEEDS, '-', "Seed sources"},
+    {"cpusettings", OPT_CPUSETTINGS, '-', "CPU settings info"},
     {NULL}
 };
 
@@ -77,6 +78,10 @@ opthelp:
             break;
         case OPT_SEEDS:
             type = OPENSSL_INFO_SEED_SOURCE;
+            dirty++;
+            break;
+        case OPT_CPUSETTINGS:
+            type = OPENSSL_INFO_CPU_SETTINGS;
             dirty++;
             break;
         }

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3363,6 +3363,7 @@ int speed_main(int argc, char **argv)
         printf("%s ", BF_options());
 #endif
         printf("\n%s\n", OpenSSL_version(OPENSSL_CFLAGS));
+        printf("%s\n", OpenSSL_version(OPENSSL_CPU_INFO));
     }
 
     if (pr_header) {

--- a/apps/version.c
+++ b/apps/version.c
@@ -33,7 +33,7 @@
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_B, OPT_D, OPT_E, OPT_M, OPT_F, OPT_O, OPT_P, OPT_V, OPT_A, OPT_R
+    OPT_B, OPT_D, OPT_E, OPT_M, OPT_F, OPT_O, OPT_P, OPT_V, OPT_A, OPT_R, OPT_C
 } OPTION_CHOICE;
 
 const OPTIONS version_options[] = {
@@ -48,6 +48,7 @@ const OPTIONS version_options[] = {
     {"p", OPT_P, '-', "Show target build platform"},
     {"r", OPT_R, '-', "Show random seeding options"},
     {"v", OPT_V, '-', "Show library version"},
+    {"c", OPT_C, '-', "Show CPU settings info"},
     {NULL}
 };
 
@@ -65,7 +66,7 @@ int version_main(int argc, char **argv)
 {
     int ret = 1, dirty = 0, seed = 0;
     int cflags = 0, version = 0, date = 0, options = 0, platform = 0, dir = 0;
-    int engdir = 0, moddir = 0;
+    int engdir = 0, moddir = 0, cpuinfo = 0;
     char *prog;
     OPTION_CHOICE o;
 
@@ -108,9 +109,12 @@ opthelp:
         case OPT_V:
             dirty = version = 1;
             break;
+        case OPT_C:
+            dirty = cpuinfo = 1;
+            break;
         case OPT_A:
             seed = options = cflags = version = date = platform
-                = dir = engdir = moddir
+                = dir = engdir = moddir = cpuinfo
                 = 1;
             break;
         }
@@ -157,8 +161,12 @@ opthelp:
         printf("%s\n", OpenSSL_version(OPENSSL_ENGINES_DIR));
     if (moddir)
         printf("%s\n", OpenSSL_version(OPENSSL_MODULES_DIR));
-    if (seed)
-        printf("Seeding source: %s\n", OPENSSL_info(OPENSSL_INFO_SEED_SOURCE));
+    if (seed) {
+        const char *src = OPENSSL_info(OPENSSL_INFO_SEED_SOURCE);
+        printf("Seeding source: %s\n", src ? src : "N/A");
+    }
+    if (cpuinfo)
+        printf("%s\n", OpenSSL_version(OPENSSL_CPU_INFO));
     ret = 0;
  end:
     return ret;

--- a/apps/version.c
+++ b/apps/version.c
@@ -52,16 +52,6 @@ const OPTIONS version_options[] = {
     {NULL}
 };
 
-#if defined(OPENSSL_RAND_SEED_DEVRANDOM) || defined(OPENSSL_RAND_SEED_EGD)
-static void printlist(const char *prefix, const char **dev)
-{
-    printf("%s (", prefix);
-    for ( ; *dev != NULL; dev++)
-        printf(" \"%s\"", *dev);
-    printf(" )");
-}
-#endif
-
 int version_main(int argc, char **argv)
 {
     int ret = 1, dirty = 0, seed = 0;

--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -43,6 +43,8 @@ const char *OPENSSL_version_build_metadata(void)
     return OPENSSL_VERSION_BUILD_METADATA_STR;
 }
 
+extern char ossl_cpu_info_str[];
+
 const char *OpenSSL_version(int t)
 {
     switch (t) {
@@ -76,6 +78,11 @@ const char *OpenSSL_version(int t)
 #else
         return "MODULESDIR: N/A";
 #endif
+    case OPENSSL_CPU_INFO:
+        if (OPENSSL_info(OPENSSL_INFO_CPU_SETTINGS) != NULL)
+            return ossl_cpu_info_str;
+        else
+            return "CPUINFO: N/A";
     }
     return "not available";
 }

--- a/doc/man1/openssl-info.pod
+++ b/doc/man1/openssl-info.pod
@@ -15,6 +15,7 @@ B<openssl info>
 [B<-dirfilesep>]
 [B<-listsep]>
 [B<-seeds]>
+[B<-cpusettings]>
 
 =head1 DESCRIPTION
 
@@ -66,6 +67,10 @@ style lists.
 =item B<-seeds>
 
 Outputs the randomness seed sources.
+
+=item B<-cpusettings>
+
+Outputs the OpenSSL CPU settings info.
 
 =back
 

--- a/doc/man1/openssl-version.pod
+++ b/doc/man1/openssl-version.pod
@@ -16,6 +16,9 @@ B<openssl version>
 [B<-p>]
 [B<-d>]
 [B<-e>]
+[B<-m>]
+[B<-r>]
+[B<-c>]
 
 =head1 DESCRIPTION
 
@@ -60,6 +63,18 @@ OPENSSLDIR setting.
 =item B<-e>
 
 ENGINESDIR settings.
+
+=item B<-m>
+
+MODULESDIR settings.
+
+=item B<-r>
+
+The random number generator source settings.
+
+=item B<-c>
+
+The OpenSSL CPU settings info.
 
 =back
 

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -125,6 +125,20 @@ if available or "OPENSSLDIR: N/A" otherwise.
 The "ENGINESDIR" setting of the library build in the form "ENGINESDIR: "...""
 if available or "ENGINESDIR: N/A" otherwise.
 
+=item OPENSSL_MODULES_DIR
+
+The "MODULESDIR" setting of the library build in the form "MODULESDIR: "...""
+if available or "MODULESDIR: N/A" otherwise.
+
+=item OPENSSL_CPU_INFO
+
+The current OpenSSL cpu settings.
+This is the current setting of the cpu capability flags. It is usually
+automatically configured but may be set via an environment variable.
+The value has the same syntax as the environment variable.
+For x86 the string looks like "CPUINFO: OPENSSL_ia32cap=0x123:0x456".
+Or "CPUINFO: N/A" if not available, e.g. no-asm build.
+
 =back
 
 For an unknown B<t>, the text "not available" is returned.
@@ -165,6 +179,14 @@ This is typically used in strings that are lists of items, such as the
 value of the environment variable C<$PATH> on Unix (where the
 separator is ":") or C<%PATH%> on Windows (where the separator is
 ";").
+
+=item OPENSSL_INFO_CPU_SETTINGS
+
+The current OpenSSL cpu settings.
+This is the current setting of the cpu capability flags. It is usually
+automatically configured but may be set via an environment variable.
+The value has the same syntax as the environment variable.
+For x86 the string looks like "OPENSSL_ia32cap=0x123:0x456".
 
 =back
 
@@ -224,7 +246,7 @@ with the exception of the L</BACKWARD COMPATIBILITY> ones.
 
 =head1 COPYRIGHT
 
-Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2018-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -169,6 +169,7 @@ const char *OpenSSL_version(int type);
 # define OPENSSL_VERSION_STRING         6
 # define OPENSSL_FULL_VERSION_STRING    7
 # define OPENSSL_MODULES_DIR            8
+# define OPENSSL_CPU_INFO               9
 
 const char *OPENSSL_info(int type);
 /*
@@ -182,6 +183,7 @@ const char *OPENSSL_info(int type);
 # define OPENSSL_INFO_DIR_FILENAME_SEPARATOR    1005
 # define OPENSSL_INFO_LIST_SEPARATOR            1006
 # define OPENSSL_INFO_SEED_SOURCE               1007
+# define OPENSSL_INFO_CPU_SETTINGS              1008
 
 int OPENSSL_issetugid(void);
 


### PR DESCRIPTION
I noticed the speed info depends heavily on the enabled CPU features.
I would like to see the effective OPENSSL_ia32cap value on each output
if this speed command.