### PR TITLE
Prefer VPAES over BSAES if both are supported

### DIFF
--- a/providers/common/ciphers/cipher_aes_hw.c
+++ b/providers/common/ciphers/cipher_aes_hw.c
@@ -31,19 +31,20 @@ static int cipher_hw_aes_initkey(PROV_CIPHER_CTX *dat,
 # endif
         } else
 #endif
-#ifdef BSAES_CAPABLE
-        if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CBC_MODE) {
-            ret = AES_set_decrypt_key(key, keylen * 8, ks);
-            dat->block = (block128_f)AES_decrypt;
-            dat->stream.cbc = (cbc128_f)bsaes_cbc_encrypt;
-        } else
-#endif
 #ifdef VPAES_CAPABLE
         if (VPAES_CAPABLE) {
             ret = vpaes_set_decrypt_key(key, keylen * 8, ks);
             dat->block = (block128_f)vpaes_decrypt;
             dat->stream.cbc = (dat->mode == EVP_CIPH_CBC_MODE)
                               ?(cbc128_f)vpaes_cbc_encrypt : NULL;
+        } else
+#endif
+#ifdef BSAES_CAPABLE
+        /* not completely constant time */
+        if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CBC_MODE) {
+            ret = AES_set_decrypt_key(key, keylen * 8, ks);
+            dat->block = (block128_f)AES_decrypt;
+            dat->stream.cbc = (cbc128_f)bsaes_cbc_encrypt;
         } else
 #endif
         {
@@ -71,19 +72,20 @@ static int cipher_hw_aes_initkey(PROV_CIPHER_CTX *dat,
             (void)0;            /* terminate potentially open 'else' */
     } else
 #endif
-#ifdef BSAES_CAPABLE
-    if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CTR_MODE) {
-        ret = AES_set_encrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f)AES_encrypt;
-        dat->stream.ctr = (ctr128_f)bsaes_ctr32_encrypt_blocks;
-    } else
-#endif
 #ifdef VPAES_CAPABLE
     if (VPAES_CAPABLE) {
         ret = vpaes_set_encrypt_key(key, keylen * 8, ks);
         dat->block = (block128_f)vpaes_encrypt;
         dat->stream.cbc = (dat->mode == EVP_CIPH_CBC_MODE)
                           ? (cbc128_f)vpaes_cbc_encrypt : NULL;
+    } else
+#endif
+#ifdef BSAES_CAPABLE
+    /* not completely constant time */
+    if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CTR_MODE) {
+        ret = AES_set_encrypt_key(key, keylen * 8, ks);
+        dat->block = (block128_f)AES_encrypt;
+        dat->stream.ctr = (ctr128_f)bsaes_ctr32_encrypt_blocks;
     } else
 #endif
     {

--- a/providers/common/ciphers/cipher_gcm_hw.c
+++ b/providers/common/ciphers/cipher_gcm_hw.c
@@ -58,18 +58,19 @@ static int generic_aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
     } else
 # endif /* HWAES_CAPABLE */
 
-# ifdef BSAES_CAPABLE
-    if (BSAES_CAPABLE) {
-        SET_KEY_CTR_FN(ks, AES_set_encrypt_key, AES_encrypt,
-                       bsaes_ctr32_encrypt_blocks);
-    } else
-# endif /* BSAES_CAPABLE */
-
 # ifdef VPAES_CAPABLE
     if (VPAES_CAPABLE) {
         SET_KEY_CTR_FN(ks, vpaes_set_encrypt_key, vpaes_encrypt, NULL);
     } else
 # endif /* VPAES_CAPABLE */
+
+# ifdef BSAES_CAPABLE
+    /* not completely constant time */
+    if (BSAES_CAPABLE) {
+        SET_KEY_CTR_FN(ks, AES_set_encrypt_key, AES_encrypt,
+                       bsaes_ctr32_encrypt_blocks);
+    } else
+# endif /* BSAES_CAPABLE */
 
     {
 # ifdef AES_CTR_ASM


### PR DESCRIPTION
The performance is comparable but BSAES is not
completely constant time, there are table lookups
using secret key data in AES_set_encrypt/decrypt_key
and in the ctr mode short data uses the non-constant
time AES_encrypt function instead of bit-slicing.