### PR TITLE
[RFC] Truncate digests for ECDSA signature

### DIFF
--- a/crypto/ec/ecdsa_sign.c
+++ b/crypto/ec/ecdsa_sign.c
@@ -20,6 +20,10 @@ ECDSA_SIG *ECDSA_do_sign_ex(const unsigned char *dgst, int dlen,
                             const BIGNUM *kinv, const BIGNUM *rp,
                             EC_KEY *eckey)
 {
+    int curvebits = EC_GROUP_order_bits(EC_KEY_get0_group(eckey));
+    if (curvebits && dlen > (curvebits + 7) / 8)
+        dlen = (curvebits + 7) / 8;
+
     if (eckey->meth->sign_sig != NULL)
         return eckey->meth->sign_sig(dgst, dlen, kinv, rp, eckey);
     ECerr(EC_F_ECDSA_DO_SIGN_EX, EC_R_OPERATION_NOT_SUPPORTED);


### PR DESCRIPTION
```
FIPS-186-4 §6.4 says "When the length of the output of the hash
function is greater than the bit length of n, then the leftmost
n bits of the hash function output block shall be used in any
calculation using the hash function output during the generation
or verification of a digital signature."

Do that.
```
-----
So.... this actually addresses the problem in #7348 a different way.

It turns out that the EC keys in the TPM *can* sign SHA512 digests, because the ECDSA spec says they're supposed to be truncated to the bit length of the curve. Hence https://github.com/tpm2-software/tpm2-tss-engine/pull/72 from @AndreasFuchsSIT which I have submitted to @jejb's other TPMv2 ENGINE as https://groups.io/g/openssl-tpm2-engine/topic/patch_truncate_hashes_for/32999767

But if it's correct for the engines to do that, why should they? Wouldn't it be better for OpenSSL itself to do it? And what compatibility issues are there here? 

*(Removed comments about ECDSA_do_verify() failing, after fixing the rounding for curves with a bit length that isn't a multiple of 8)*