### PR TITLE
test/evp_test.c: distinguish parsing errors from processing errors

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -557,7 +557,7 @@ static int cipher_test_parse(EVP_TEST *t, const char *keyword,
                 if (cdat->aad[i] == NULL)
                     return parse_bin(value, &cdat->aad[i], &cdat->aad_len[i]);
             }
-            return 0;
+            return -1;
         }
         if (strcmp(keyword, "Tag") == 0)
             return parse_bin(value, &cdat->tag, &cdat->tag_len);
@@ -567,7 +567,7 @@ static int cipher_test_parse(EVP_TEST *t, const char *keyword,
             else if (strcmp(value, "FALSE") == 0)
                 cdat->tag_late = 0;
             else
-                return 0;
+                return -1;
             return 1;
         }
     }
@@ -578,7 +578,7 @@ static int cipher_test_parse(EVP_TEST *t, const char *keyword,
         else if (strcmp(value, "DECRYPT") == 0)
             cdat->enc = 0;
         else
-            return 0;
+            return -1;
         return 1;
     }
     return 0;
@@ -1016,7 +1016,7 @@ static int mac_test_parse(EVP_TEST *t,
     if (strcmp(keyword, "Algorithm") == 0) {
         mdata->alg = OPENSSL_strdup(value);
         if (!mdata->alg)
-            return 0;
+            return -1;
         return 1;
     }
     if (strcmp(keyword, "Input") == 0)
@@ -1533,9 +1533,9 @@ static int pderive_test_parse(EVP_TEST *t,
     if (strcmp(keyword, "PeerKey") == 0) {
         EVP_PKEY *peer;
         if (find_key(&peer, value, public_keys) == 0)
-            return 0;
+            return -1;
         if (EVP_PKEY_derive_set_peer(kdata->ctx, peer) <= 0)
-            return 0;
+            return -1;
         return 1;
     }
     if (strcmp(keyword, "SharedSecret") == 0)
@@ -2529,7 +2529,7 @@ static int digestsigver_test_parse(EVP_TEST *t,
     }
     if (strcmp(keyword, "Ctrl") == 0) {
         if (mdata->pctx == NULL)
-            return 0;
+            return -1;
         return pkey_test_ctrl(t, mdata->pctx, value);
     }
     return 0;


### PR DESCRIPTION
Parsing functions are at liberty to return:

1:  when parsing on processing of the parsed value succeeded
0:  when the parsed keyword is unknown
-1: when the parsed value processing failed

Some parsing functions didn't do this quite right, they returned 0
when they should have returned -1, causing a message like this:

    Line 123: unknown keyword PeerKey

When this message (which is displayed when the parsing function
returns -1) would have been more appropriate:

    Line 123: error processing keyword PeerKey = ffdhe2048-2-pub
