### PR TITLE
Remove select(2) usage in entropy initialization as it creates stack …

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -41,12 +41,12 @@
 #    define DEVRANDOM_SAFE_KERNEL        4, 8
 #   endif
 /*
- * Some operating systems do not permit select(2) on their random devices,
+ * Some operating systems do not permit poll(2) on their random devices,
  * defining this to zero will force the used of read(2) to extract one byte
  * from /dev/random.
  */
-#   ifndef DEVRANDM_WAIT_USE_SELECT
-#    define DEVRANDM_WAIT_USE_SELECT     1
+#   ifndef DEVRANDM_WAIT_USE_POLL
+#    define DEVRANDM_WAIT_USE_POLL     1
 #   endif
 /*
  * Define the shared memory identifier used to indicate if the operating


### PR DESCRIPTION
…corruption when having more than 1024 opened file descriptors.

Hi,

One of my colleague has investigate a segmentation we were getting "randomly" in one of our process while initiating the first SSL connection, that is new in OpenSSL 1.1.1c and which was not there with OpenSSL 1.1.1b. We were getting obvious stack corruption in stack often different, but which always had the same bottom frames, like:

```
#0  0x00000000004c97ab in rand_drbg_get_entropy (drbg=0x1, pout=0x7fff31ebd088, entropy=<optimized out>, min_len=<optimized out>, max_len=<optimized out>,
    prediction_resistance=<optimized out>) at crypto/rand/rand_lib.c:203
#1  0x00000000004c78c9 in RAND_DRBG_instantiate (drbg=drbg@entry=0x248d280, pers=pers@entry=0x611e40 <ossl_pers_string> "OpenSSL NIST SP 800-90A DRBG", perslen=perslen@entry=28)
    at crypto/rand/drbg_lib.c:338
#2  0x00000000004c8940 in drbg_setup (parent=0x0) at crypto/rand/drbg_lib.c:892
#3  do_rand_drbg_init () at crypto/rand/drbg_lib.c:921
#4  do_rand_drbg_init_ossl_ () at crypto/rand/drbg_lib.c:906
#5  0x00007f8bf616dff7 in __pthread_once_slow () from /opt/1A/toolchain/x86_64-2.6.32-v4.0.66/lib/libpthread.so.0
#6  0x00000000004fa8ba in CRYPTO_THREAD_run_once (once=once@entry=0x6c80f8 <rand_drbg_init>, init=init@entry=0x4c88a0 <do_rand_drbg_init_ossl_ at crypto/rand/drbg_lib.c:912>)
    at crypto/threads_pthread.c:113
#7  0x00000000004c8cfa in RAND_DRBG_get0_public () at crypto/rand/drbg_lib.c:1113
#8  0x00000000004c8de1 in drbg_bytes (out=0x248c5f0 "", count=16) at crypto/rand/drbg_lib.c:963
#9  0x000000000041a25f in SSL_CTX_new (meth=0x6b66e0 <TLS_method_data.23328>) at ssl/ssl_lib.c:2996
#10 0x0000000000404193 in main ()
```

The different values of drbg and/or pout in the upper stack would seems strange, and different from lower frames. It looked like stack corruption.

After investigation, he found the guilty code to be the usage of "select(2)" while sometimes our process has more than 1024 opened file descriptor while starting the first SSL connection.

We could reproduce the problem with OpenSSL 1.1.1c using this program:

```
#include <openssl/ssl.h>
#include <fcntl.h>
#include <assert.h>
#include <errno.h>
                                                                                                 
// Replace glibc's getentropy, if defined, so that we bypass glibc's getentropy
// and openssl direct syscall to getrandom, and we move on to the "select" syscall.
int getentropy(void* buffer, size_t size)
{                         
    errno = ENOSYS;
    return -1;
}

int main(int argc, const char** argv)         
{
    assert(argc == 2);
    int max_fd = atoi(argv[1]);
     
    for (int i = 1; i <= max_fd; ++i)
    {                                
        assert(open("/dev/null", O_WRONLY) != -1);
    }
                         
    SSL_CTX_new(SSLv23_method());
}
```

Compiled with:
`gcc -fno-lto -pthread reproduce-select-stack-corruption.c -o reproduce-select-stack-corruption -Wl,-Bstatic -lssl -lcrypto -lz -Wl,-Bdynamic -ldl`

And then make it segfault by trying the right "number of file descriptor" to generate a visible corruption:

```
rgeissler@ncerndobedev6097:~/wk/ospack/openssl (release/18.0.0 *% u+1)> ls core.*
zsh: no matches found: core.*
rgeissler@ncerndobedev6097:~/wk/ospack/openssl (release/18.0.0 *% u+1)> (set -xe; for i in {1020..2000}; do ./reproduce-select-stack-corruption $i; done)
...snap...
+/usr/bin/zsh:422> i=1212
+/usr/bin/zsh:422> ./reproduce-select-stack-corruption 1212
+/usr/bin/zsh:422> i=1213
+/usr/bin/zsh:422> ./reproduce-select-stack-corruption 1213
rgeissler@ncerndobedev6097:~/wk/ospack/openssl (release/18.0.0 *% u+1)> ls core.*
core.59984
```

(stack trace of the segfault is the one provided on top).

Indeed select is documented not to work with file descriptor numbers being bigger than 1024, in which case "poll(2)" should be used. We validated that this diff applied to OpenSSL 1.1.1c works:

```
commit 34739769f4caea4a1a0c222df3718de7550d9302 (HEAD -> remove-select-usage_1.1.1c)
Author: Romain Geissler <romain.geissler@amadeus.com>
Date:   Fri Aug 23 15:14:15 2019 +0000

    Remove select(2) usage in entropy initialization as it creates stack corruption when having more than 1024 opened file descriptors.

diff --git a/crypto/rand/rand_unix.c b/crypto/rand/rand_unix.c
index 4710dbb2d1..1be5ed39ac 100644
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -20,6 +20,9 @@
 #include "internal/dso.h"
 #if defined(__linux)
 # include <asm/unistd.h>
+# if defined(DEVRANDOM_WAIT)
+#   include "poll.h"
+# endif
 #endif
 #if defined(__FreeBSD__)    
 # include <sys/types.h>
@@ -522,12 +525,13 @@ size_t rand_pool_acquire_entropy(RAND_POOL *pool)
              int f = open(DEVRANDOM_WAIT, O_RDONLY);
              
              if (f >= 0) {
-                 fd_set fds;
+                 struct pollfd pset;
+
+                 pset.fd = f;
+                 pset.events = POLLIN;
+                 pset.revents = 0;

-                 FD_ZERO(&fds);
-                 FD_SET(f, &fds);
-                 while (select(f+1, &fds, NULL, NULL, NULL) < 0
-                        && errno == EINTR);
+                 while (poll(&pset, 1, -1) < 0 && errno == EINTR);
                  close(f);
              }   
              wait_done = 1;
```

Note: code has changed in the master branch and in the 1.1.1 branch since 1.1.1c. I have only tested the above code on 1.1.1c, not the latest git code, but the diff is very similar.

Is it ok for merging ? If yes, is it also ok for a backport in branch 1.1.1 ? An attacker could make a remote process crash by increasing the number of opened file descriptor (ie by 1024 opening non-SSL connections) before opening the first SSL connection and thus create a deny of service.

Cheers,
Romain