### PR TITLE
Avoid overflowing FDSET when using select(2).

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -390,7 +390,7 @@ static int wait_random_seeded(void)
             }
             /* Open /dev/random and wait for it to be readable */
             if ((fd = open(DEVRANDOM_WAIT, O_RDONLY)) != -1) {
-                if (DEVRANDM_WAIT_USE_SELECT) {
+                if (DEVRANDM_WAIT_USE_SELECT && fd < FD_SETSIZE) {
                     FD_ZERO(&fds);
                     FD_SET(fd, &fds);
                     while ((r = select(fd + 1, &fds, NULL, NULL, NULL)) < 0


### PR DESCRIPTION
There is a problem in the rand_unix.c code when the random seed fd is greater
than or equal to FD_SETSIZE and the FDSET overruns its limit and walks the
stack.
