### PR TITLE
Fix Issue OSS-Fuzz: Branch on uninitialized memory (in ccm code).

### DIFF
--- a/providers/common/ciphers/cipher_ccm.c
+++ b/providers/common/ciphers/cipher_ccm.c
@@ -349,7 +349,7 @@ static int ccm_cipher_internal(PROV_CCM_CTX *ctx, unsigned char *out,
 
     /* EVP_*Final() doesn't return any data */
     if (in == NULL && out != NULL)
-        return 1;
+        goto finish;
 
     if (!ctx->iv_set)
         goto err;
@@ -388,6 +388,7 @@ static int ccm_cipher_internal(PROV_CCM_CTX *ctx, unsigned char *out,
         }
     }
     olen = len;
+finish:
     rv = 1;
 err:
     *padlen = olen;


### PR DESCRIPTION
This would also happen for aes-ccm. There was one branch path where it just returned 1
without setting *padlen, It now branches so that the value is set to 0.

Fixes #9691

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
