### PR TITLE
Include mac_meth and mac_lib in the FIPS provider

### DIFF
--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -1,6 +1,6 @@
 LIBS=../../libcrypto
 $COMMON=digest.c evp_enc.c evp_lib.c evp_fetch.c cmeth_lib.c evp_utils.c \
-        keymgmt_meth.c keymgmt_lib.c
+        mac_lib.c mac_meth.c keymgmt_meth.c keymgmt_lib.c
 SOURCE[../../libcrypto]=$COMMON\
         encode.c evp_key.c evp_cnf.c \
         e_des.c e_bf.c e_idea.c e_des3.c e_camellia.c\
@@ -16,7 +16,7 @@ SOURCE[../../libcrypto]=$COMMON\
         e_old.c pmeth_lib.c pmeth_fn.c pmeth_gn.c m_sigver.c \
         e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha256.c e_rc4_hmac_md5.c \
         e_chacha20_poly1305.c \
-        mac_lib.c mac_meth.c pkey_mac.c exchange.c
+        pkey_mac.c exchange.c
 SOURCE[../../providers/fips]=$COMMON
 
 INCLUDE[e_aes.o]=.. ../modes


### PR DESCRIPTION
Seems like these were missed somewhere along the MAC movements.