### PR TITLE
Fix platform specific issues with provider ciphers

### DIFF
--- a/crypto/include/internal/ciphermode_platform.h
+++ b/crypto/include/internal/ciphermode_platform.h
@@ -194,6 +194,7 @@ extern unsigned int OPENSSL_sparcv9cap_P[];
 
 #  ifndef OPENSSL_NO_CAMELLIA
 #   define SPARC_CMLL_CAPABLE      (OPENSSL_sparcv9cap_P[1] & CFR_CAMELLIA)
+#   include "openssl/camellia.h"
 
 void cmll_t4_set_key(const unsigned char *key, int bits, CAMELLIA_KEY *ks);
 void cmll_t4_encrypt(const unsigned char *in, unsigned char *out,

--- a/providers/common/ciphers/cipher_aes_hw_s390x.inc
+++ b/providers/common/ciphers/cipher_aes_hw_s390x.inc
@@ -21,6 +21,13 @@
 #define s390x_aes_cfb1_cipher_hw cipher_hw_generic_cfb1
 #define s390x_aes_ctr_cipher_hw  cipher_hw_generic_ctr
 
+#define S390X_aes_128_ofb128_CAPABLE S390X_aes_128_ofb_CAPABLE
+#define S390X_aes_192_ofb128_CAPABLE S390X_aes_192_ofb_CAPABLE
+#define S390X_aes_256_ofb128_CAPABLE S390X_aes_256_ofb_CAPABLE
+#define S390X_aes_128_cfb128_CAPABLE S390X_aes_128_cfb_CAPABLE
+#define S390X_aes_192_cfb128_CAPABLE S390X_aes_192_cfb_CAPABLE
+#define S390X_aes_256_cfb128_CAPABLE S390X_aes_256_cfb_CAPABLE
+
 static int s390x_aes_ecb_initkey(PROV_CIPHER_CTX *dat,
                                  const unsigned char *key, size_t keylen)
 {
@@ -43,8 +50,8 @@ static int s390x_aes_ecb_cipher_hw(PROV_CIPHER_CTX *dat, unsigned char *out,
     return 1;
 }
 
-static int s390x_aes_ofb_initkey(PROV_CIPHER_CTX *dat,
-                                 const unsigned char *key, size_t keylen)
+static int s390x_aes_ofb128_initkey(PROV_CIPHER_CTX *dat,
+                                    const unsigned char *key, size_t keylen)
 {
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
 
@@ -55,8 +62,8 @@ static int s390x_aes_ofb_initkey(PROV_CIPHER_CTX *dat,
     return 1;
 }
 
-static int s390x_aes_ofb_cipher_hw(PROV_CIPHER_CTX *dat, unsigned char *out,
-                                   const unsigned char *in, size_t len)
+static int s390x_aes_ofb128_cipher_hw(PROV_CIPHER_CTX *dat, unsigned char *out,
+                                      const unsigned char *in, size_t len)
 {
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
     int n = adat->plat.s390x.res;
@@ -96,8 +103,8 @@ static int s390x_aes_ofb_cipher_hw(PROV_CIPHER_CTX *dat, unsigned char *out,
     return 1;
 }
 
-static int s390x_aes_cfb_initkey(PROV_CIPHER_CTX *dat,
-                                 const unsigned char *key, size_t keylen)
+static int s390x_aes_cfb128_initkey(PROV_CIPHER_CTX *dat,
+                                    const unsigned char *key, size_t keylen)
 {
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
 
@@ -112,8 +119,8 @@ static int s390x_aes_cfb_initkey(PROV_CIPHER_CTX *dat,
     return 1;
 }
 
-static int s390x_aes_cfb_cipher_hw(PROV_CIPHER_CTX *dat, unsigned char *out,
-                                   const unsigned char *in, size_t len)
+static int s390x_aes_cfb128_cipher_hw(PROV_CIPHER_CTX *dat, unsigned char *out,
+                                      const unsigned char *in, size_t len)
 {
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
     int n = adat->plat.s390x.res;


### PR DESCRIPTION
s390_aes naming issues with ofb128 and cfb128
Solaris missing include for camellia.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
