### PR TITLE
Suppress 'No server certificate CA names sent' message

### DIFF
--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -1508,7 +1508,8 @@ void print_ca_names(BIO *bio, SSL *s)
     int i;
 
     if (sk == NULL || sk_X509_NAME_num(sk) == 0) {
-        BIO_printf(bio, "---\nNo %s certificate CA names sent\n", cs);
+        if (!SSL_is_server(s))
+            BIO_printf(bio, "---\nNo %s certificate CA names sent\n", cs);
         return;
     }
 


### PR DESCRIPTION
Fixes #9080

Signed-off-by: Billy Brawner <billy@wbrawner.com>

