### PR TITLE
Fix no-engine

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -321,7 +321,9 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
                                 size_t len, const EVP_CIPHER *cipher)
 {
 #ifndef OPENSSL_NO_CMAC
+# ifndef OPENSSL_NO_ENGINE
     const char *engine_name = e != NULL ? ENGINE_get_name(e) : NULL;
+# endif
     const char *cipher_name = EVP_CIPHER_name(cipher);
     const OSSL_PROVIDER *prov = EVP_CIPHER_provider(cipher);
     OPENSSL_CTX *libctx =
@@ -339,11 +341,14 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
         goto err;
     }
 
+# ifndef OPENSSL_NO_ENGINE
     if (engine_name != NULL)
         params[paramsn++] =
             OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
                                              (char *)engine_name,
                                              strlen(engine_name) + 1);
+# endif
+
     params[paramsn++] =
         OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
                                          (char *)cipher_name,

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -322,7 +322,7 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
 {
 #ifndef OPENSSL_NO_CMAC
 # ifndef OPENSSL_NO_ENGINE
-    const char *engine_name = e != NULL ? ENGINE_get_name(e) : NULL;
+    const char *engine_id = e != NULL ? ENGINE_get_id(e) : NULL;
 # endif
     const char *cipher_name = EVP_CIPHER_name(cipher);
     const OSSL_PROVIDER *prov = EVP_CIPHER_provider(cipher);
@@ -342,11 +342,11 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
     }
 
 # ifndef OPENSSL_NO_ENGINE
-    if (engine_name != NULL)
+    if (engine_id != NULL)
         params[paramsn++] =
             OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                             (char *)engine_name,
-                                             strlen(engine_name) + 1);
+                                             (char *)engine_id,
+                                             strlen(engine_id) + 1);
 # endif
 
     params[paramsn++] =

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -274,12 +274,14 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 OSSL_PARAM params[3];
                 size_t params_n = 0;
                 char *ciphname = (char *)OBJ_nid2sn(EVP_CIPHER_nid(p2));
+#ifndef OPENSSL_NO_ENGINE
                 char *engineid = (char *)ENGINE_get_id(ctx->engine);
 
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
                                                      engineid,
                                                      strlen(engineid) + 1);
+#endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
                                                      ciphname,
@@ -396,6 +398,7 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 size_t params_n = 0;
                 char *mdname =
                     (char *)OBJ_nid2sn(EVP_MD_nid(hctx->raw_data.md));
+#ifndef OPENSSL_NO_ENGINE
                 char *engineid = ctx->engine == NULL
                     ? NULL : (char *)ENGINE_get_id(ctx->engine);
 
@@ -406,6 +409,7 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                                                          engineid,
                                                          engineid_l);
                 }
+#endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
                                                      mdname,

--- a/providers/common/macs/cmac_prov.c
+++ b/providers/common/macs/cmac_prov.c
@@ -187,7 +187,8 @@ static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
             const char *algoname = p->data;
             const char *propquery = NULL;
 
-#ifndef FIPS_MODE /* Inside the FIPS module, we don't support engines */
+/* Inside the FIPS module, we don't support engines */
+#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
             ENGINE_finish(macctx->tmpengine);
             macctx->tmpengine = NULL;
 

--- a/providers/common/macs/gmac_prov.c
+++ b/providers/common/macs/gmac_prov.c
@@ -198,7 +198,8 @@ static int gmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
             const char *algoname = p->data;
             const char *propquery = NULL;
 
-#ifndef FIPS_MODE /* Inside the FIPS module, we don't support engines */
+/* Inside the FIPS module, we don't support engines */
+#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
             ENGINE_finish(macctx->engine);
             macctx->engine = NULL;
 

--- a/providers/common/macs/hmac_prov.c
+++ b/providers/common/macs/hmac_prov.c
@@ -198,7 +198,8 @@ static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
             const char *algoname = p->data;
             const char *propquery = NULL;
 
-#ifndef FIPS_MODE /* Inside the FIPS module, we don't support engines */
+/* Inside the FIPS module, we don't support engines */
+#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
             ENGINE_finish(macctx->tmpengine);
             macctx->tmpengine = NULL;
 


### PR DESCRIPTION
Make sure references to ENGINE functions are appropriately guarded.
