### PR TITLE
Update fuzz README.md

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -60,9 +60,9 @@ AFL
 Configure for fuzzing:
 
     $ sudo apt-get install afl-clang
-    $ CC=afl-clang-fast ./config enable-fuzz-afl no-shared -DPEDANTIC \
-        enable-tls1_3 enable-weak-ssl-ciphers enable-rc5 enable-md2 \
-        enable-ssl3 enable-ssl3-method enable-nextprotoneg \
+    $ CC=afl-clang-fast ./config enable-fuzz-afl no-shared no-module \
+        -DPEDANTIC enable-tls1_3 enable-weak-ssl-ciphers enable-rc5 \
+        enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg \
         enable-ec_nistp_64_gcc_128 -fno-sanitize=alignment \
         --debug
     $ make


### PR DESCRIPTION
Building with enable-fuzz-afl has always required no-shared. We now also
need no-module for a successful build. Therefore update the README
accordingly.