### PR TITLE
Allow an output indentation of zero in apps.

### DIFF
--- a/apps/lib/app_params.c
+++ b/apps/lib/app_params.c
@@ -75,20 +75,20 @@ static int describe_param_type(char *buf, size_t bufsz, const OSSL_PARAM *param)
 int print_param_types(const char *thing, const OSSL_PARAM *pdefs, int indent)
 {
     if (pdefs == NULL) {
-        BIO_printf(bio_out, "%*sNo declared %s\n", indent, " ", thing);
+        BIO_printf(bio_out, "%*sNo declared %s\n", indent, "", thing);
     } else if (pdefs->key == NULL) {
         /*
          * An empty list?  This shouldn't happen, but let's just make sure to
          * say something if there's a badly written provider...
          */
-        BIO_printf(bio_out, "%*sEmpty list of %s (!!!)\n", indent, " ", thing);
+        BIO_printf(bio_out, "%*sEmpty list of %s (!!!)\n", indent, "", thing);
     } else {
-        BIO_printf(bio_out, "%*s%s:\n", indent, " ", thing);
+        BIO_printf(bio_out, "%*s%s:\n", indent, "", thing);
         for (; pdefs->key != NULL; pdefs++) {
             char buf[200];       /* This should be ample space */
 
             describe_param_type(buf, sizeof(buf), pdefs);
-            BIO_printf(bio_out, "%*s  %s\n", indent, " ", buf);
+            BIO_printf(bio_out, "%*s  %s\n", indent, "", buf);
         }
     }
     return 1;

--- a/apps/provider.c
+++ b/apps/provider.c
@@ -68,13 +68,13 @@ static void print_caps(META *meta, INFO *info)
         if (meta->first) {
             if (meta->total > 0)
                 BIO_printf(bio_out, "\n");
-            BIO_printf(bio_out, "%*s%ss:", meta->indent, " ", meta->label);
+            BIO_printf(bio_out, "%*s%ss:", meta->indent, "", meta->label);
         }
         BIO_printf(bio_out, " %s", info->name);
         break;
     case 3:
     default:
-        BIO_printf(bio_out, "%*s%s %s\n", meta->indent, " ", meta->label,
+        BIO_printf(bio_out, "%*s%s %s\n", meta->indent, "", meta->label,
                    info->name);
         print_param_types("retrievable algorithm parameters",
                           info->gettable_params, meta->subindent);


### PR DESCRIPTION
Previously, it would indent one space even if zero were specified.

