### PR TITLE
Don't include the DEVRANDOM being seeded logic on Android.

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -28,7 +28,7 @@
  * default, we will try to read at least one of these files
  */
 #  define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
-#  ifdef __linux
+#  if defined(__linux) && !defined(__ANDROID__)
 #   ifndef DEVRANDOM_WAIT
 #    define DEVRANDOM_WAIT   "/dev/random"
 #   endif


### PR DESCRIPTION
Android lacks exposure of the `shm*` functions that the check uses and should prefer the GETRANDOM source.

Fixes #9708
