### PR TITLE
 tools/ossl-version.pl, util/mktar.sh: New version extraction script, use it

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -190,7 +190,8 @@
      return "" if $cache{$script};
      $OUT .= in2script(script => $script,
                        attrs => $unified_info{attributes}->{$script},
-                       sources => $unified_info{sources}->{$script});
+                       sources => $unified_info{sources}->{$script})
+         if defined $unified_info{sources}->{$script};
      $cache{$script} = 1;
  }
 

--- a/Configure
+++ b/Configure
@@ -2178,6 +2178,16 @@ EOF
 
     # Massage the result
 
+    # Scripts may not need any building, but we couldn't know that before.
+    # So we look through them now to see if they have any sources, and if
+    # not, we assume they exist in the source directory instead.
+    $unified_info{scripts} = {
+        map {
+            ( defined $unified_info{sources}->{$_}
+              ? $_ : cleanfile($srcdir, $_, $blddir) ) => 1;
+        } keys %{$unified_info{scripts}}
+    };
+
     # If we depend on a header file or a perl module, add an inclusion of
     # its directory to allow smoothe inclusion
     foreach my $dest (keys %{$unified_info{depends}}) {

--- a/tools/build.info
+++ b/tools/build.info
@@ -5,3 +5,5 @@ IF[{- !$disabled{apps} -}]
   SCRIPTS={- $c_rehash_name -}
   SOURCE[{- $c_rehash_name -}]=c_rehash.in
 ENDIF
+
+SCRIPTS=ossl-version.pl

--- a/tools/ossl-version.pl
+++ b/tools/ossl-version.pl
@@ -1,0 +1,87 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Spec::Functions;
+use FindBin;
+
+my $openssldir = $ARGV[0] || "$FindBin::Bin/..";
+my $versionheader = catfile($openssldir, 'include/openssl/opensslv.h');
+
+my @version1macros = qw(
+    OPENSSL_VERSION_TEXT
+    SHLIB_VERSION_NUMBER
+);
+my @currentmacros = qw(
+    OPENSSL_VERSION_MAJOR
+    OPENSSL_VERSION_MINOR
+    OPENSSL_VERSION_PATCH
+    OPENSSL_VERSION_PRE_RELEASE
+    OPENSSL_VERSION_BUILD_METADATA
+    OPENSSL_SHLIB_VERSION
+    );
+my @result = qw(
+    OPENSSL_VERSION_STR
+    OPENSSL_FULL_VERSION_STR
+    OPENSSL_VERSION_COMPAT
+);
+
+my $versionheadertxt = eval {
+    local $/ = undef;
+    open my $fh, $versionheader or die "Trying to open $versionheader: $!\n";
+    my $x = <$fh>;
+    close $fh;
+    $x
+};
+
+die $@ if $@;                   # Pass on the eval exec error, if there was any
+
+my $macroregex =
+    '^#\s*define\s+('
+    . join('|', @version1macros, @currentmacros)
+    . ')\s+(?|(\d+)|"([^"]*)")';
+my %macrovals =
+    map { $_ =~ m|$macroregex| ? ( $1 => $2 ) : () }
+    split m|\R|, $versionheadertxt;
+
+if (defined $macrovals{OPENSSL_VERSION_MAJOR}) {
+    # OpenSSL 3.0 and on
+    $macrovals{OPENSSL_VERSION_STR} =
+        join('.',
+             $macrovals{OPENSSL_VERSION_MAJOR},
+             $macrovals{OPENSSL_VERSION_MINOR},
+             $macrovals{OPENSSL_VERSION_PATCH});
+    $macrovals{OPENSSL_FULL_VERSION_STR} =
+        join('',
+             $macrovals{OPENSSL_VERSION_STR},
+             $macrovals{OPENSSL_VERSION_PRE_RELEASE} // '',
+             $macrovals{OPENSSL_VERSION_BUILD_METADATA} // '');
+    $macrovals{OPENSSL_VERSION_COMPAT} = $macrovals{OPENSSL_VERSION_MAJOR};
+} else {
+    # OpenSSL before 3.0
+    $macrovals{OPENSSL_FULL_VERSION_STR} =
+        [ split m|\s+|, $macrovals{OPENSSL_VERSION_TEXT} ] -> [1];
+    $macrovals{OPENSSL_VERSION_STR} =
+        [ split m|-|, $macrovals{OPENSSL_FULL_VERSION_STR} ] -> [0];
+    ( $macrovals{OPENSSL_VERSION_COMPAT} =
+      $macrovals{OPENSSL_VERSION_STR} ) =~ s|(\d+\.\d+).*|$1|;
+}
+
+foreach (@result) {
+    my $cmd = $^O eq 'MSWin32' ? "set " : "";
+    if ($^O eq "VMS") {
+        # For the benefit of VMS scripts, this can set CLI variables or define
+        # logical names, all depending on the definition of PERL_ENV_TABLES.
+        # For more info, see the perlvms manual page:
+        # https://perldoc.perl.org/perlvms.html
+        $ENV{$_}=$macrovals{$_};
+    }
+    print $cmd, $_, '=', $macrovals{$_}, "\n";
+}

--- a/util/mktar.sh
+++ b/util/mktar.sh
@@ -8,10 +8,10 @@
 
 HERE=`dirname $0`
 
-version=`grep 'OPENSSL_VERSION_TEXT  *"OpenSSL' $HERE/../include/openssl/opensslv.h | sed -e 's|.*"OpenSSL ||' -e 's| .*||'`
 basename=openssl
+eval `"$HERE/../tools/ossl-version.pl"`
 
-NAME="$basename-$version"
+NAME="$basename-$OPENSSL_FULL_VERSION_STR"
 
 while [ $# -gt 0 ]; do
     case "$1" in


### PR DESCRIPTION
util/mktar.sh was still adapted to pre-3.0 OpenSSL version data.

tools/ossl-version.pl is a new script that extracts OpenSSL version
data from any version of opensslv.h and outputs a set of shell
variable definitions reflecting the version data:

    OPENSSL_VERSION_STR         just the numbers
    OPENSSL_FULL_VERSION_STR    numbers plus possible pre-release tag
    OPENSSL_VERSION_COMPAT      the numbers this release is upward
                                compatible with

We adapt util/mktar.sh to use tools/ossl-version.pl to figure out the
version part of the tarball name.

We also install tools/ossl-version.pl for the benefit of scripts that
want to use it as well.  The usage differs depending on the operating
system family.  For Unix shell and MSWindows command lines, it outputs
appropriate variable setting lines, to be used as the user sees fit.
For VMS, it additionally defines environment variables with the same
name, which may end up as CLI symbols or logical names, depending on
the definition of the logical name PERL_ENV_TABLES.

Thanks to Roumen Petrov for notifying us