### PR TITLE
Diverse ERR fixes

### DIFF
--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -25,12 +25,12 @@
 extern "C" {
 #endif
 
-# ifndef OPENSSL_NO_ERR
-#  define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,fn,ln)
-#  define ERR_PUT_func_error(l,f,r,fn,ln) ERR_put_func_error(l,f,r,fn,ln)
-# else
-#  define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,NULL,0)
-#  define ERR_PUT_func_error(l,f,r,fn,ln) ERR_put_func_error(l,f,r,NULL,0)
+# if !OPENSSL_API_3
+#  ifndef OPENSSL_NO_ERR
+#   define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,fn,ln)
+#  else
+#   define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,NULL,0)
+#  endif
 # endif
 
 # include <errno.h>
@@ -244,20 +244,30 @@ void ERR_set_debug(const char *file, int line, const char *func);
 void ERR_set_error(int lib, int reason, const char *fmt, ...);
 void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
 
+# ifndef OPENSSL_NO_ERR
+#  define ERR_DBG_FILE OPENSSL_FILE
+#  define ERR_DBG_LINE OPENSSL_LINE
+#  define ERR_DBG_FUNC OPENSSL_FUNC
+# else
+#  define ERR_DBG_FILE NULL
+#  define ERR_DBG_LINE 0
+#  define ERR_DBG_FUNC NULL
+# endif
+
 /* Main error raising functions */
-#define ERR_raise(lib, reason) ERR_raise_data((lib),(reason),NULL)
-#define ERR_raise_data                                          \
+# define ERR_raise(lib, reason) ERR_raise_data((lib),(reason),NULL)
+# define ERR_raise_data                                         \
     (ERR_new(),                                                 \
-     ERR_set_debug(OPENSSL_FILE,OPENSSL_LINE,OPENSSL_FUNC),     \
+     ERR_set_debug(ERR_DBG_FILE,ERR_DBG_LINE,ERR_DBG_FUNC),     \
      ERR_set_error)
 
-#if !OPENSSL_API_3
+# if !OPENSSL_API_3
 /* Backward compatibility */
-#define ERR_put_error(lib, func, reason, file, line)            \
+#  define ERR_put_error(lib, func, reason, file, line)          \
     (ERR_new(),                                                 \
      ERR_set_debug((file), (line), NULL),                       \
      ERR_set_error((lib), (reason), NULL))
-#endif
+# endif
 
 void ERR_set_error_data(char *data, int flags);
 


### PR DESCRIPTION
1.  There are still references to the removed ERR_put_func_error().
2.  ERR_put_error() is deprecated as off version 3.0, so should
    ERR_PUT_error().
3.  'no-err' didn't affect what was passed to ERR_set_debug().

Fixes #9522
