### PR TITLE
Add missing docs for some PKCS12 functions

### DIFF
--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -16,16 +16,16 @@ PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen - Retrieve attributes from a PKCS
 =head1 DESCRIPTION
 
 PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag.
-B<bag> is the B<PKCS12_SAFEBAG> retrieve the attributes from.
+B<bag> is the B<PKCS12_SAFEBAG> to retrieve the attributes from.
 
 PKCS12_get_attr_gen() retrieves an attribute by NID from a stack of B<X509_ATTRIBUTE>s.
-B<attr_nid> is the NID for the attribute to retrieve.
+B<attr_nid> is the NID of the attribute to retrieve.
 
 =head1 RETURN VALUES
 
 PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag, which could be empty.
 
-PKCS12_get_attr_gen() returns an ASN1_TYPE object containing the attribute, or NULL if the attribute was not present or an error occurred.
+PKCS12_get_attr_gen() returns an ASN1_TYPE object containing the attribute, or NULL if the attribute was either not present or an error occurred.
 PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute is still owned by the B<PKCS12_SAFEBAG> in which it resides.
 
 =head1 SEE ALSO

--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-PKCS12_SAFEBAG_get0_attrs,PKCS12_get_attr_gen - Retrieve attributes from a PKCS#12 safeBag
+PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen - Retrieve attributes from a PKCS#12 safeBag
 
 =head1 SYNOPSIS
 
@@ -30,11 +30,13 @@ PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute 
 
 =head1 SEE ALSO
 
-L<PKCS12_add_friendlyname_asc(3)>,
+L<PKCS12_get_friendlyname(3)>,
+L<PKCS12_get_localkeyid(3)>,
+L<PKCS12_add_friendlyname_asc(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -1,0 +1,44 @@
+=pod
+
+=head1 NAME
+
+PKCS12_SAFEBAG_get0_attrs,PKCS12_get_attr_gen - Retrieve attributes from a PKCS#12 safeBag
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs12.h>
+
+ const STACK_OF(X509_ATTRIBUTE) *PKCS12_SAFEBAG_get0_attrs(const PKCS12_SAFEBAG *bag);
+
+ ASN1_TYPE *PKCS12_get_attr_gen(const STACK_OF(X509_ATTRIBUTE) *attrs,
+                                int attr_nid)
+
+=head1 DESCRIPTION
+
+PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag.
+B<bag> is the B<PKCS12_SAFEBAG> retrieve the attributes from.
+
+PKCS12_get_attr_gen() retrieves an attribute by NID from a stack of B<X509_ATTRIBUTE>s.
+B<attr_nid> is the NID for the attribute to retrieve.
+
+=head1 RETURN VALUES
+
+PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag, which could be empty.
+
+PKCS12_get_attr_gen() returns an ASN1_TYPE object containing the attribute, or NULL if the attribute was not present or an error occurred.
+PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute is still owned by the B<PKCS12_SAFEBAG> in which it resides.
+
+=head1 SEE ALSO
+
+L<PKCS12_add_friendlyname_asc(3)>,
+
+=head1 COPYRIGHT
+
+Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -15,18 +15,22 @@ PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen - Retrieve attributes from a PKCS
 
 =head1 DESCRIPTION
 
-PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag.
-I<bag> is the B<PKCS12_SAFEBAG> to retrieve the attributes from.
+PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a 
+PKCS#12 safeBag. I<bag> is the B<PKCS12_SAFEBAG> to retrieve the attributes from.
 
-PKCS12_get_attr_gen() retrieves an attribute by NID from a stack of B<X509_ATTRIBUTE>s.
-I<attr_nid> is the NID of the attribute to retrieve.
+PKCS12_get_attr_gen() retrieves an attribute by NID from a stack of
+B<X509_ATTRIBUTE>s. I<attr_nid> is the NID of the attribute to retrieve.
 
 =head1 RETURN VALUES
 
-PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag, which could be empty.
+PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a 
+PKCS#12 safeBag, which could be empty.
 
-PKCS12_get_attr_gen() returns an B<ASN1_TYPE> object containing the attribute, or NULL if the attribute was either not present or an error occurred.
-PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute is still owned by the B<PKCS12_SAFEBAG> in which it resides.
+PKCS12_get_attr_gen() returns an B<ASN1_TYPE> object containing the attribute, 
+or NULL if the attribute was either not present or an error occurred.
+
+PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute
+is still owned by the B<PKCS12_SAFEBAG> in which it resides.
 
 =head1 SEE ALSO
 

--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -16,16 +16,16 @@ PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen - Retrieve attributes from a PKCS
 =head1 DESCRIPTION
 
 PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag.
-B<bag> is the B<PKCS12_SAFEBAG> to retrieve the attributes from.
+I<bag> is the B<PKCS12_SAFEBAG> to retrieve the attributes from.
 
 PKCS12_get_attr_gen() retrieves an attribute by NID from a stack of B<X509_ATTRIBUTE>s.
-B<attr_nid> is the NID of the attribute to retrieve.
+I<attr_nid> is the NID of the attribute to retrieve.
 
 =head1 RETURN VALUES
 
 PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a PKCS#12 safeBag, which could be empty.
 
-PKCS12_get_attr_gen() returns an ASN1_TYPE object containing the attribute, or NULL if the attribute was either not present or an error occurred.
+PKCS12_get_attr_gen() returns an B<ASN1_TYPE> object containing the attribute, or NULL if the attribute was either not present or an error occurred.
 PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute is still owned by the B<PKCS12_SAFEBAG> in which it resides.
 
 =head1 SEE ALSO

--- a/doc/man3/PKCS12_add_CSPName_asc.pod
+++ b/doc/man3/PKCS12_add_CSPName_asc.pod
@@ -22,11 +22,11 @@ Returns 1 for success or 0 for failure.
 
 =head1 SEE ALSO
 
-L<PKCS12_add_friendlyname_asc(3)>,
+L<PKCS12_add_friendlyname_asc(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/PKCS12_add_CSPName_asc.pod
+++ b/doc/man3/PKCS12_add_CSPName_asc.pod
@@ -14,7 +14,7 @@ PKCS12_add_CSPName_asc - Add a Microsoft CSP Name attribute to a PKCS#12 safeBag
 
 PKCS12_add_CSPName_asc() adds an ASCII string representation of the Microsoft CSP Name attribute to a PKCS#12 safeBag.
 
-B<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
+I<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/PKCS12_add_CSPName_asc.pod
+++ b/doc/man3/PKCS12_add_CSPName_asc.pod
@@ -1,0 +1,36 @@
+=pod
+
+=head1 NAME
+
+PKCS12_add_CSPName_asc - Add a Microsoft CSP Name attribute to a PKCS#12 safeBag
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs12.h>
+
+ int PKCS12_add_CSPName_asc(PKCS12_SAFEBAG *bag, const char *name, int namelen);
+
+=head1 DESCRIPTION
+
+PKCS12_add_CSPName_asc() adds an ASCII string representation of the Microsoft CSP Name attribute to a PKCS#12 safeBag.
+
+B<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
+
+=head1 RETURN VALUES
+
+Returns 1 for success or 0 for failure.
+
+=head1 SEE ALSO
+
+L<PKCS12_add_friendlyname_asc(3)>,
+
+=head1 COPYRIGHT
+
+Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/PKCS12_add_friendlyname_asc.pod
+++ b/doc/man3/PKCS12_add_friendlyname_asc.pod
@@ -2,26 +2,33 @@
 
 =head1 NAME
 
-PKCS12_add_friendlyname_asc, PKCS12_add_friendlyname_utf8, PKCS12_add_friendlyname_uni - Functions to add the friendlyname attribute to a PKCS#12 safeBag
+PKCS12_add_friendlyname_asc, PKCS12_add_friendlyname_utf8,
+PKCS12_add_friendlyname_uni - Functions to add the friendlyname attribute to a
+PKCS#12 safeBag
 
 =head1 SYNOPSIS
 
  #include <openssl/pkcs12.h>
 
  int PKCS12_add_friendlyname_asc(PKCS12_SAFEBAG *bag, const char *name,
-                                int namelen);
+                                 int namelen);
 
  int PKCS12_add_friendlyname_utf8(PKCS12_SAFEBAG *bag, const char *name,
-                                int namelen);
+                                 int namelen);
 
  int PKCS12_add_friendlyname_uni(PKCS12_SAFEBAG *bag,
-                                const unsigned char *name, int namelen);
+                                 const unsigned char *name, int namelen);
 
 =head1 DESCRIPTION
 
-PKCS12_add_friendlyname_asc() adds an ASCII string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
-PKCS12_add_friendlyname_utf8() adds a UTF-8 string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
-PKCS12_add_friendlyname_uni() adds a Unicode string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
+PKCS12_add_friendlyname_asc() adds an ASCII string representation of the PKCS#9
+friendlyName attribute to a PKCS#12 safeBag.
+
+PKCS12_add_friendlyname_utf8() adds a UTF-8 string representation of the PKCS#9
+friendlyName attribute to a PKCS#12 safeBag.
+
+PKCS12_add_friendlyname_uni() adds a Unicode string representation of the PKCS#9
+friendlyName attribute to a PKCS#12 safeBag.
 
 I<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
 

--- a/doc/man3/PKCS12_add_friendlyname_asc.pod
+++ b/doc/man3/PKCS12_add_friendlyname_asc.pod
@@ -23,7 +23,7 @@ PKCS12_add_friendlyname_asc() adds an ASCII string representation of the PKCS#9 
 PKCS12_add_friendlyname_utf8() adds a UTF-8 string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
 PKCS12_add_friendlyname_uni() adds a Unicode string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
 
-B<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
+I<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/PKCS12_add_friendlyname_asc.pod
+++ b/doc/man3/PKCS12_add_friendlyname_asc.pod
@@ -1,0 +1,45 @@
+=pod
+
+=head1 NAME
+
+PKCS12_add_friendlyname_asc,PKCS12_add_friendlyname_utf8,PKCS12_add_friendlyname_uni - Functions to add the friendlyname attribute to a PKCS#12 safeBag
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs12.h>
+
+ int PKCS12_add_friendlyname_asc(PKCS12_SAFEBAG *bag, const char *name,
+                                int namelen);
+
+ int PKCS12_add_friendlyname_utf8(PKCS12_SAFEBAG *bag, const char *name,
+                                int namelen);
+
+ int PKCS12_add_friendlyname_uni(PKCS12_SAFEBAG *bag,
+                                const unsigned char *name, int namelen);
+
+=head1 DESCRIPTION
+
+PKCS12_add_friendlyname_asc() adds an ASCII string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
+PKCS12_add_friendlyname_utf8() adds a UTF-8 string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
+PKCS12_add_friendlyname_uni() adds a Unicode string representation of the PKCS#9 friendlyName attribute to a PKCS#12 safeBag.
+
+B<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
+
+=head1 RETURN VALUES
+
+Returns 1 for success or 0 for failure.
+
+=head1 SEE ALSO
+
+L<PKCS12_get_friendlyname(3)>,
+
+=head1 COPYRIGHT
+
+Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/PKCS12_add_friendlyname_asc.pod
+++ b/doc/man3/PKCS12_add_friendlyname_asc.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-PKCS12_add_friendlyname_asc,PKCS12_add_friendlyname_utf8,PKCS12_add_friendlyname_uni - Functions to add the friendlyname attribute to a PKCS#12 safeBag
+PKCS12_add_friendlyname_asc, PKCS12_add_friendlyname_utf8, PKCS12_add_friendlyname_uni - Functions to add the friendlyname attribute to a PKCS#12 safeBag
 
 =head1 SYNOPSIS
 
@@ -31,11 +31,11 @@ Returns 1 for success or 0 for failure.
 
 =head1 SEE ALSO
 
-L<PKCS12_get_friendlyname(3)>,
+L<PKCS12_get_friendlyname(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/PKCS12_add_localkeyid.pod
+++ b/doc/man3/PKCS12_add_localkeyid.pod
@@ -9,11 +9,12 @@ PKCS12_add_localkeyid - Add the localKeyId attribute to a PKCS#12 safeBag
  #include <openssl/pkcs12.h>
 
  int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const char *name,
-                                int namelen);
+                           int namelen);
 
 =head1 DESCRIPTION
 
-PKCS12_add_localkeyid() adds an octet string representation of the PKCS#9 localKeyId attribute to a PKCS#12 safeBag.
+PKCS12_add_localkeyid() adds an octet string representation of the PKCS#9
+localKeyId attribute to a PKCS#12 safeBag.
 
 I<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
 

--- a/doc/man3/PKCS12_add_localkeyid.pod
+++ b/doc/man3/PKCS12_add_localkeyid.pod
@@ -15,7 +15,7 @@ PKCS12_add_localkeyid - Add the localKeyId attribute to a PKCS#12 safeBag
 
 PKCS12_add_localkeyid() adds an octet string representation of the PKCS#9 localKeyId attribute to a PKCS#12 safeBag.
 
-B<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
+I<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/PKCS12_add_localkeyid.pod
+++ b/doc/man3/PKCS12_add_localkeyid.pod
@@ -1,0 +1,37 @@
+=pod
+
+=head1 NAME
+
+PKCS12_add_localkeyid - Add the localKeyId attribute to a PKCS#12 safeBag
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs12.h>
+
+ int PKCS12_add_localkeyid(PKCS12_SAFEBAG *bag, const char *name,
+                                int namelen);
+
+=head1 DESCRIPTION
+
+PKCS12_add_localkeyid() adds an octet string representation of the PKCS#9 localKeyId attribute to a PKCS#12 safeBag.
+
+B<bag> is the B<PKCS12_SAFEBAG> to add the attribute to.
+
+=head1 RETURN VALUES
+
+Returns 1 for success or 0 for failure.
+
+=head1 SEE ALSO
+
+L<PKCS12_add_friendlyname_asc(3)>,
+
+=head1 COPYRIGHT
+
+Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/PKCS12_add_localkeyid.pod
+++ b/doc/man3/PKCS12_add_localkeyid.pod
@@ -23,11 +23,11 @@ Returns 1 for success or 0 for failure.
 
 =head1 SEE ALSO
 
-L<PKCS12_add_friendlyname_asc(3)>,
+L<PKCS12_add_friendlyname_asc(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/PKCS12_get_friendlyname.pod
+++ b/doc/man3/PKCS12_get_friendlyname.pod
@@ -12,7 +12,8 @@ PKCS12_get_friendlyname - Retrieve the friendlyname attribute from a PKCS#12 saf
 
 =head1 DESCRIPTION
 
-PKCS12_get_friendlyname() retrieves a UTF-8 string representation of the PKCS#9 friendlyName attribute for a PKCS#12 safeBag item.
+PKCS12_get_friendlyname() retrieves a UTF-8 string representation of the PKCS#9
+friendlyName attribute for a PKCS#12 safeBag item.
 
 I<bag> is the B<PKCS12_SAFEBAG> to retrieve the attribute from.
 

--- a/doc/man3/PKCS12_get_friendlyname.pod
+++ b/doc/man3/PKCS12_get_friendlyname.pod
@@ -14,7 +14,7 @@ PKCS12_get_friendlyname - Retrieve the friendlyname attribute from a PKCS#12 saf
 
 PKCS12_get_friendlyname() retrieves a UTF-8 string representation of the PKCS#9 friendlyName attribute for a PKCS#12 safeBag item.
 
-B<bag> is the B<PKCS12_SAFEBAG> retrieve the attribute from.
+B<bag> is the B<PKCS12_SAFEBAG> to retrieve the attribute from.
 
 =head1 RETURN VALUES
 
@@ -24,11 +24,11 @@ The returned string is allocated by OpenSSL and should be freed by the user.
 
 =head1 SEE ALSO
 
-L<PKCS12_add_friendlyname_asc(3)>,
+L<PKCS12_add_friendlyname_asc(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/PKCS12_get_friendlyname.pod
+++ b/doc/man3/PKCS12_get_friendlyname.pod
@@ -1,0 +1,38 @@
+=pod
+
+=head1 NAME
+
+PKCS12_get_friendlyname - Retrieve the friendlyname attribute from a PKCS#12 safeBag
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs12.h>
+
+ char *PKCS12_get_friendlyname(PKCS12_SAFEBAG *bag);
+
+=head1 DESCRIPTION
+
+PKCS12_get_friendlyname() retrieves a UTF-8 string representation of the PKCS#9 friendlyName attribute for a PKCS#12 safeBag item.
+
+B<bag> is the B<PKCS12_SAFEBAG> retrieve the attribute from.
+
+=head1 RETURN VALUES
+
+A UTF-8 string, or NULL if the attribute was not present or an error occurred.
+
+The returned string is allocated by OpenSSL and should be freed by the user.
+
+=head1 SEE ALSO
+
+L<PKCS12_add_friendlyname_asc(3)>,
+
+=head1 COPYRIGHT
+
+Copyright 2002-2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/PKCS12_get_friendlyname.pod
+++ b/doc/man3/PKCS12_get_friendlyname.pod
@@ -14,7 +14,7 @@ PKCS12_get_friendlyname - Retrieve the friendlyname attribute from a PKCS#12 saf
 
 PKCS12_get_friendlyname() retrieves a UTF-8 string representation of the PKCS#9 friendlyName attribute for a PKCS#12 safeBag item.
 
-B<bag> is the B<PKCS12_SAFEBAG> to retrieve the attribute from.
+I<bag> is the B<PKCS12_SAFEBAG> to retrieve the attribute from.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/PKCS12_get_friendlyname.pod
+++ b/doc/man3/PKCS12_get_friendlyname.pod
@@ -18,7 +18,7 @@ B<bag> is the B<PKCS12_SAFEBAG> to retrieve the attribute from.
 
 =head1 RETURN VALUES
 
-A UTF-8 string, or NULL if the attribute was not present or an error occurred.
+A UTF-8 string, or NULL if the attribute was either not present or an error occurred.
 
 The returned string is allocated by OpenSSL and should be freed by the user.
 


### PR DESCRIPTION
Some functions listed in include/openssl/pkcs12.h are missing documentation.

- [X] documentation is added or updated
