### PR TITLE
Enable providers to do signatures, and implement DSA in the default provider

### DIFF
--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -706,11 +706,23 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
         si->pctx = pctx;
     }
 
+    /*
+     * TODO(3.0): This causes problems when providers are in use, so disabled
+     * for now. Can we get rid of this completely? AFAICT this ctrl has been
+     * present since CMS was first put in - but has never been used to do
+     * anything. All internal implementations just return 1 and ignore this ctrl
+     * and have always done so by the looks of things. To fix this we could
+     * convert this ctrl into a param, which would require us to send all the
+     * signer info data as a set of params...but that is non-trivial and since
+     * this isn't used by anything it may be better just to remove it.
+     */
+#if 0
     if (EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_SIGN,
                           EVP_PKEY_CTRL_CMS_SIGN, 0, si) <= 0) {
         CMSerr(CMS_F_CMS_SIGNERINFO_SIGN, CMS_R_CTRL_ERROR);
         goto err;
     }
+#endif
 
     alen = ASN1_item_i2d((ASN1_VALUE *)si->signedAttrs, &abuf,
                          ASN1_ITEM_rptr(CMS_Attributes_Sign));
@@ -727,11 +739,23 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
     if (EVP_DigestSignFinal(mctx, abuf, &siglen) <= 0)
         goto err;
 
+    /*
+     * TODO(3.0): This causes problems when providers are in use, so disabled
+     * for now. Can we get rid of this completely? AFAICT this ctrl has been
+     * present since CMS was first put in - but has never been used to do
+     * anything. All internal implementations just return 1 and ignore this ctrl
+     * and have always done so by the looks of things. To fix this we could
+     * convert this ctrl into a param, which would require us to send all the
+     * signer info data as a set of params...but that is non-trivial and since
+     * this isn't used by anything it may be better just to remove it.
+     */
+#if 0
     if (EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_SIGN,
                           EVP_PKEY_CTRL_CMS_SIGN, 1, si) <= 0) {
         CMSerr(CMS_F_CMS_SIGNERINFO_SIGN, CMS_R_CTRL_ERROR);
         goto err;
     }
+#endif
 
     EVP_MD_CTX_reset(mctx);
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -563,13 +563,13 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
         return NULL;
 
     ossl_param_bld_init(&tmpl);
-    if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_P, p)
-        || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_G, g)
+    if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_P, p)
+        || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g)
         || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PUB_KEY, pub_key))
         return NULL;
 
     if (q != NULL) {
-        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_Q, q))
+        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_Q, q))
             return NULL;
     }
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -559,13 +559,12 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     OSSL_PARAM *params;
     void *provkey = NULL;
 
-    if (p == NULL || g == NULL || pub_key == NULL)
+    if (p == NULL || g == NULL)
         return NULL;
 
     ossl_param_bld_init(&tmpl);
     if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_P, p)
-        || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g)
-        || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PUB_KEY, pub_key))
+        || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g))
         return NULL;
 
     if (q != NULL) {
@@ -573,10 +572,20 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
             return NULL;
     }
 
-    if (priv_key != NULL) {
-        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PRIV_KEY,
-                                    priv_key))
+    /*
+     * This may be used to pass domain parameters only without any key data -
+     * so "pub_key" is optional. We can never have a "priv_key" without a
+     * corresponding "pub_key" though.
+     */
+    if (pub_key != NULL) {
+        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PUB_KEY, pub_key))
             return NULL;
+
+        if (priv_key != NULL) {
+            if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PRIV_KEY,
+                                        priv_key))
+                return NULL;
+        }
     }
 
     params = ossl_param_bld_to_param(&tmpl);

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -281,6 +281,7 @@ int dsa_builtin_paramgen(DSA *ret, size_t bits, size_t qbits,
         ret->p = BN_dup(p);
         ret->q = BN_dup(q);
         ret->g = BN_dup(g);
+        ret->dirty_cnt++;
         if (ret->p == NULL || ret->q == NULL || ret->g == NULL) {
             ok = 0;
             goto err;
@@ -598,6 +599,7 @@ int dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
             ok = -1;
             goto err;
         }
+        ret->dirty_cnt++;
         if (counter_ret != NULL)
             *counter_ret = counter;
         if (h_ret != NULL)

--- a/crypto/dsa/dsa_key.c
+++ b/crypto/dsa/dsa_key.c
@@ -65,6 +65,7 @@ static int dsa_builtin_keygen(DSA *dsa)
 
     dsa->priv_key = priv_key;
     dsa->pub_key = pub_key;
+    dsa->dirty_cnt++;
     ok = 1;
 
  err:

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -273,6 +273,7 @@ int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
         BN_free(d->g);
         d->g = g;
     }
+    d->dirty_cnt++;
 
     return 1;
 }
@@ -303,6 +304,7 @@ int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
         BN_free(d->priv_key);
         d->priv_key = priv_key;
     }
+    d->dirty_cnt++;
 
     return 1;
 }

--- a/crypto/dsa/dsa_locl.h
+++ b/crypto/dsa/dsa_locl.h
@@ -31,6 +31,9 @@ struct dsa_st {
     /* functional reference if 'meth' is ENGINE-provided */
     ENGINE *engine;
     CRYPTO_RWLOCK *lock;
+
+    /* Provider data */
+    size_t dirty_cnt; /* If any key material changes, increment this */
 };
 
 struct DSA_SIG_st {

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -270,7 +270,9 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
      * TODO(3.0): Temporarily no support for EVP_DigestSign* inside FIPS module
      * or when using providers.
      */
-    if (ctx->pctx != NULL && ctx->pctx->signature == NULL) {
+    if (ctx->pctx != NULL
+            && (!EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx->pctx)
+                 || ctx->pctx->op.sig.signature == NULL)) {
         int r;
         r = EVP_PKEY_CTX_ctrl(ctx->pctx, -1, EVP_PKEY_OP_TYPE_SIG,
                               EVP_PKEY_CTRL_DIGESTINIT, 0, ctx);

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -266,8 +266,11 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
  skip_to_init:
 #endif
 #ifndef FIPS_MODE
-    /* TODO(3.0): Temporarily no support for EVP_DigestSign* in FIPS module */
-    if (ctx->pctx != NULL) {
+    /*
+     * TODO(3.0): Temporarily no support for EVP_DigestSign* inside FIPS module
+     * or when using providers.
+     */
+    if (ctx->pctx != NULL && ctx->pctx->signature == NULL) {
         int r;
         r = EVP_PKEY_CTX_ctrl(ctx->pctx, -1, EVP_PKEY_OP_TYPE_SIG,
                               EVP_PKEY_CTRL_DIGESTINIT, 0, ctx);

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -124,6 +124,10 @@ struct evp_signature_st {
     OSSL_OP_signature_newctx_fn *newctx;
     OSSL_OP_signature_sign_init_fn *sign_init;
     OSSL_OP_signature_sign_fn *sign;
+    OSSL_OP_signature_verify_init_fn *verify_init;
+    OSSL_OP_signature_verify_fn *verify;
+    OSSL_OP_signature_verify_recover_init_fn *verify_recover_init;
+    OSSL_OP_signature_verify_recover_fn *verify_recover;
     OSSL_OP_signature_freectx_fn *freectx;
     OSSL_OP_signature_dupctx_fn *dupctx;
     OSSL_OP_signature_set_params_fn *set_params;

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -232,3 +232,5 @@ OSSL_PARAM *evp_pkey_to_param(EVP_PKEY *pkey, size_t *sz);
             return 0;                                             \
         }                                                         \
     }
+
+void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx);

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -91,6 +91,11 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_exportkey_types_fn *exportkey_types;
 } /* EVP_KEYMGMT */ ;
 
+struct keymgmt_data_st {
+    OPENSSL_CTX *ctx;
+    const char *properties;
+};
+
 struct evp_keyexch_st {
     char *name;
     OSSL_PROVIDER *prov;
@@ -107,6 +112,22 @@ struct evp_keyexch_st {
     OSSL_OP_keyexch_dupctx_fn *dupctx;
     OSSL_OP_keyexch_set_params_fn *set_params;
 } /* EVP_KEYEXCH */;
+
+struct evp_signature_st {
+    char *name;
+    OSSL_PROVIDER *prov;
+    CRYPTO_REF_COUNT refcnt;
+    CRYPTO_RWLOCK *lock;
+
+    EVP_KEYMGMT *keymgmt;
+
+    OSSL_OP_signature_newctx_fn *newctx;
+    OSSL_OP_signature_sign_init_fn *sign_init;
+    OSSL_OP_signature_sign_fn *sign;
+    OSSL_OP_signature_freectx_fn *freectx;
+    OSSL_OP_signature_dupctx_fn *dupctx;
+    OSSL_OP_signature_set_params_fn *set_params;
+} /* EVP_SIGNATURE */;
 
 int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int passlen, ASN1_TYPE *param,

--- a/crypto/evp/evp_locl.h
+++ b/crypto/evp/evp_locl.h
@@ -110,7 +110,8 @@ struct evp_keyexch_st {
     OSSL_OP_keyexch_derive_fn *derive;
     OSSL_OP_keyexch_freectx_fn *freectx;
     OSSL_OP_keyexch_dupctx_fn *dupctx;
-    OSSL_OP_keyexch_set_params_fn *set_params;
+    OSSL_OP_keyexch_set_ctx_params_fn *set_ctx_params;
+    OSSL_OP_keyexch_settable_ctx_params_fn *settable_ctx_params;
 } /* EVP_KEYEXCH */;
 
 struct evp_signature_st {
@@ -130,7 +131,10 @@ struct evp_signature_st {
     OSSL_OP_signature_verify_recover_fn *verify_recover;
     OSSL_OP_signature_freectx_fn *freectx;
     OSSL_OP_signature_dupctx_fn *dupctx;
-    OSSL_OP_signature_set_params_fn *set_params;
+    OSSL_OP_signature_get_ctx_params_fn *get_ctx_params;
+    OSSL_OP_signature_gettable_ctx_params_fn *gettable_ctx_params;
+    OSSL_OP_signature_set_ctx_params_fn *set_ctx_params;
+    OSSL_OP_signature_settable_ctx_params_fn *settable_ctx_params;
 } /* EVP_SIGNATURE */;
 
 int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -32,11 +32,6 @@ static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
     return exchange;
 }
 
-struct keymgmt_data_st {
-    OPENSSL_CTX *ctx;
-    const char *properties;
-};
-
 static void *evp_keyexch_from_dispatch(const char *name,
                                        const OSSL_DISPATCH *fns,
                                        OSSL_PROVIDER *prov,

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -194,6 +194,8 @@ int EVP_PKEY_sign_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature)
          */
         if (ctx->pkey != NULL) {
             switch (ctx->pkey->type) {
+            case NID_dsa:
+                break;
             default:
                 goto legacy;
             }

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -13,18 +13,232 @@
 #include <openssl/evp.h>
 #include "internal/cryptlib.h"
 #include "internal/evp_int.h"
+#include "internal/provider.h"
 #include "evp_locl.h"
 
-int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx)
+static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
+{
+    EVP_SIGNATURE *signature = OPENSSL_zalloc(sizeof(EVP_SIGNATURE));
+
+    signature->lock = CRYPTO_THREAD_lock_new();
+    if (signature->lock == NULL) {
+        OPENSSL_free(signature);
+        return NULL;
+    }
+    signature->prov = prov;
+    ossl_provider_up_ref(prov);
+    signature->refcnt = 1;
+
+    return signature;
+}
+
+static void *evp_signature_from_dispatch(const char *name,
+                                         const OSSL_DISPATCH *fns,
+                                         OSSL_PROVIDER *prov,
+                                         void *vkeymgmt_data)
+{
+    /*
+     * Signature functions cannot work without a key, and key management
+     * from the same provider to manage its keys.  We therefore fetch
+     * a key management method using the same algorithm and properties
+     * and pass that down to evp_generic_fetch to be passed on to our
+     * evp_signature_from_dispatch, which will attach the key management
+     * method to the newly created key exchange method as long as the
+     * provider matches.
+     */
+    struct keymgmt_data_st *keymgmt_data = vkeymgmt_data;
+    EVP_KEYMGMT *keymgmt = EVP_KEYMGMT_fetch(keymgmt_data->ctx, name,
+                                             keymgmt_data->properties);
+    EVP_SIGNATURE *signature = NULL;
+    int fncnt = 0;
+
+    if (keymgmt == NULL || EVP_KEYMGMT_provider(keymgmt) != prov) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_KEYMGMT_AVAILABLE);
+        goto err;
+    }
+
+    if ((signature = evp_signature_new(prov)) == NULL
+        || (signature->name = OPENSSL_strdup(name)) == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
+        goto err;
+    }
+
+    signature->keymgmt = keymgmt;
+    keymgmt = NULL;              /* avoid double free on failure below */
+
+    for (; fns->function_id != 0; fns++) {
+        switch (fns->function_id) {
+        case OSSL_FUNC_SIGNATURE_NEWCTX:
+            if (signature->newctx != NULL)
+                break;
+            signature->newctx = OSSL_get_OP_signature_newctx(fns);
+            fncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_SIGN_INIT:
+            if (signature->sign_init != NULL)
+                break;
+            signature->sign_init = OSSL_get_OP_signature_sign_init(fns);
+            fncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_SIGN:
+            if (signature->sign != NULL)
+                break;
+            signature->sign = OSSL_get_OP_signature_sign(fns);
+            fncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_FREECTX:
+            if (signature->freectx != NULL)
+                break;
+            signature->freectx = OSSL_get_OP_signature_freectx(fns);
+            fncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_DUPCTX:
+            if (signature->dupctx != NULL)
+                break;
+            signature->dupctx = OSSL_get_OP_signature_dupctx(fns);
+            break;
+        case OSSL_FUNC_SIGNATURE_SET_PARAMS:
+            if (signature->set_params != NULL)
+                break;
+            signature->set_params = OSSL_get_OP_signature_set_params(fns);
+            break;
+        }
+    }
+    if (fncnt != 4) {
+        /*
+         * In order to be a consistent set of functions we must have at least
+         * a complete set of "signature" functions: sign_init, sign, newctx,
+         * and freectx. The dupctx function is optional.
+         */
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_PROVIDER_FUNCTIONS);
+        goto err;
+    }
+
+    return signature;
+ err:
+    EVP_SIGNATURE_free(signature);
+    EVP_KEYMGMT_free(keymgmt);
+    return NULL;
+}
+
+void EVP_SIGNATURE_free(EVP_SIGNATURE *signature)
+{
+    if (signature != NULL) {
+        int i;
+
+        CRYPTO_DOWN_REF(&signature->refcnt, &i, signature->lock);
+        if (i > 0)
+            return;
+        EVP_KEYMGMT_free(signature->keymgmt);
+        ossl_provider_free(signature->prov);
+        OPENSSL_free(signature->name);
+        CRYPTO_THREAD_lock_free(signature->lock);
+        OPENSSL_free(signature);
+    }
+}
+
+int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature)
+{
+    int ref = 0;
+
+    CRYPTO_UP_REF(&signature->refcnt, &ref, signature->lock);
+    return 1;
+}
+
+OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature)
+{
+    return signature->prov;
+}
+
+EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+                                   const char *properties)
+{
+    struct keymgmt_data_st keymgmt_data;
+
+    /*
+     * A signature operation cannot work without a key, so we need key
+     * management from the same provider to manage its keys.
+     */
+    keymgmt_data.ctx = ctx;
+    keymgmt_data.properties = properties;
+    return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
+                             evp_signature_from_dispatch, &keymgmt_data,
+                             (int (*)(void *))EVP_SIGNATURE_up_ref,
+                             (void (*)(void *))EVP_SIGNATURE_free);
+}
+
+int EVP_PKEY_sign_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature)
 {
     int ret;
-    if (!ctx || !ctx->pmeth || !ctx->pmeth->sign) {
-        EVPerr(EVP_F_EVP_PKEY_SIGN_INIT,
-               EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+    void *provkey = NULL;
+
+    if (ctx == NULL) {
+        EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return -2;
     }
+
     ctx->operation = EVP_PKEY_OP_SIGN;
-    if (!ctx->pmeth->sign_init)
+
+    if (ctx->engine != NULL)
+        goto legacy;
+
+    if (signature != NULL) {
+        if (!EVP_SIGNATURE_up_ref(signature))
+            goto err;
+    } else {
+        int nid = ctx->pkey != NULL ? ctx->pkey->type : ctx->pmeth->pkey_id;
+
+        /*
+         * TODO(3.0): Check for legacy handling. Remove this once all all
+         * algorithms are moved to providers.
+         */
+        if (ctx->pkey != NULL) {
+            switch (ctx->pkey->type) {
+            default:
+                goto legacy;
+            }
+            signature = EVP_SIGNATURE_fetch(NULL, OBJ_nid2sn(nid), NULL);
+        } else {
+            goto legacy;
+        }
+
+        if (signature == NULL) {
+            EVPerr(0, EVP_R_INITIALIZATION_ERROR);
+            goto err;
+        }
+    }
+
+    if (ctx->sigprovctx != NULL && ctx->signature != NULL)
+        ctx->signature->freectx(ctx->sigprovctx);
+    EVP_SIGNATURE_free(ctx->signature);
+    ctx->signature = signature;
+    if (ctx->pkey != NULL) {
+        provkey = evp_keymgmt_export_to_provider(ctx->pkey, signature->keymgmt);
+        if (provkey == NULL) {
+            EVPerr(0, EVP_R_INITIALIZATION_ERROR);
+            goto err;
+        }
+    }
+    ctx->sigprovctx = signature->newctx(ossl_provider_ctx(signature->prov));
+    if (ctx->sigprovctx == NULL) {
+        /* The provider key can stay in the cache */
+        EVPerr(0, EVP_R_INITIALIZATION_ERROR);
+        goto err;
+    }
+    ret = signature->sign_init(ctx->sigprovctx, provkey);
+
+    return ret ? 1 : 0;
+ err:
+    ctx->operation = EVP_PKEY_OP_UNDEFINED;
+    return 0;
+
+ legacy:
+    if (ctx->pmeth == NULL || ctx->pmeth->sign == NULL) {
+        EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -2;
+    }
+
+    if (ctx->pmeth->sign_init == NULL)
         return 1;
     ret = ctx->pmeth->sign_init(ctx);
     if (ret <= 0)
@@ -32,19 +246,41 @@ int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx)
     return ret;
 }
 
+int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx)
+{
+    return EVP_PKEY_sign_init_ex(ctx, NULL);
+}
+
 int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
                   unsigned char *sig, size_t *siglen,
                   const unsigned char *tbs, size_t tbslen)
 {
-    if (!ctx || !ctx->pmeth || !ctx->pmeth->sign) {
-        EVPerr(EVP_F_EVP_PKEY_SIGN,
-               EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+    int ret;
+
+    if (ctx == NULL) {
+        EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return -2;
     }
+
     if (ctx->operation != EVP_PKEY_OP_SIGN) {
-        EVPerr(EVP_F_EVP_PKEY_SIGN, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
         return -1;
     }
+
+    if (ctx->sigprovctx == NULL)
+        goto legacy;
+
+    ret = ctx->signature->sign(ctx->sigprovctx, sig, siglen, SIZE_MAX,
+                               tbs, tbslen);
+
+    return ret;
+ legacy:
+ 
+    if (ctx->pmeth == NULL || ctx->pmeth->sign == NULL) {
+        EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -2;
+    }
+
     M_check_autoarg(ctx, sig, siglen, EVP_F_EVP_PKEY_SIGN)
         return ctx->pmeth->sign(ctx, sig, siglen, tbs, tbslen);
 }

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -51,6 +51,7 @@ static void *evp_signature_from_dispatch(const char *name,
                                              keymgmt_data->properties);
     EVP_SIGNATURE *signature = NULL;
     int ctxfncnt = 0, signfncnt = 0, verifyfncnt = 0, verifyrecfncnt = 0;
+    int gparamfncnt = 0, sparamfncnt = 0;
 
     if (keymgmt == NULL || EVP_KEYMGMT_provider(keymgmt) != prov) {
         ERR_raise(ERR_LIB_EVP, EVP_R_NO_KEYMGMT_AVAILABLE);
@@ -123,21 +124,49 @@ static void *evp_signature_from_dispatch(const char *name,
                 break;
             signature->dupctx = OSSL_get_OP_signature_dupctx(fns);
             break;
-        case OSSL_FUNC_SIGNATURE_SET_PARAMS:
-            if (signature->set_params != NULL)
+        case OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS:
+            if (signature->get_ctx_params != NULL)
                 break;
-            signature->set_params = OSSL_get_OP_signature_set_params(fns);
+            signature->get_ctx_params
+                = OSSL_get_OP_signature_get_ctx_params(fns);
+            gparamfncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS:
+            if (signature->gettable_ctx_params != NULL)
+                break;
+            signature->gettable_ctx_params
+                = OSSL_get_OP_signature_gettable_ctx_params(fns);
+            gparamfncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS:
+            if (signature->set_ctx_params != NULL)
+                break;
+            signature->set_ctx_params
+                = OSSL_get_OP_signature_set_ctx_params(fns);
+            sparamfncnt++;
+            break;
+        case OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS:
+            if (signature->settable_ctx_params != NULL)
+                break;
+            signature->settable_ctx_params
+                = OSSL_get_OP_signature_settable_ctx_params(fns);
+            sparamfncnt++;
             break;
         }
     }
     if (ctxfncnt != 2
-        || (signfncnt != 2 && verifyfncnt != 2 && verifyrecfncnt != 2)) {
+        || (signfncnt != 2 && verifyfncnt != 2 && verifyrecfncnt != 2)
+        || (gparamfncnt != 0 && gparamfncnt != 2)
+        || (sparamfncnt != 0 && sparamfncnt != 2)) {
         /*
          * In order to be a consistent set of functions we must have at least
          * a set of context functions (newctx and freectx) as well as a pair of
          * "signature" functions: (sign_init, sign) or (verify_init verify) or
-         * (verify_recover_init, verify_recover). The dupctx and set_params
-         * functions are optional.
+         * (verify_recover_init, verify_recover). set_ctx_params and
+         * settable_ctx_params are optional, but if one of them is present then
+         * the other one must also be present. The same applies to
+         * get_ctx_params and gettable_ctx_params. The dupctx function is
+         * optional.
          */
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_PROVIDER_FUNCTIONS);
         goto err;

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -390,6 +390,11 @@ void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx)
 
     EVP_KEYEXCH_free(ctx->exchange);
 
+    if (ctx->sigprovctx != NULL && ctx->signature != NULL)
+        ctx->signature->freectx(ctx->sigprovctx);
+
+    EVP_SIGNATURE_free(ctx->signature);
+
     EVP_PKEY_free(ctx->pkey);
     EVP_PKEY_free(ctx->peerkey);
 #ifndef OPENSSL_NO_ENGINE
@@ -402,6 +407,8 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
 {
     if (ctx->exchprovctx != NULL && ctx->exchange != NULL)
         return ctx->exchange->set_params(ctx->exchprovctx, params);
+    if (ctx->sigprovctx != NULL && ctx->signature != NULL)
+        return ctx->signature->set_params(ctx->sigprovctx, params);
     return 0;
 }
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -308,7 +308,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
     rctx->operation = pctx->operation;
 
     if (EVP_PKEY_CTX_IS_DERIVE_OP(pctx)) {
-        if (rctx->op.kex.exchange != NULL) {
+        if (pctx->op.kex.exchange != NULL) {
             rctx->op.kex.exchange = pctx->op.kex.exchange;
             if (!EVP_KEYEXCH_up_ref(rctx->op.kex.exchange)) {
                 OPENSSL_free(rctx);
@@ -328,7 +328,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
             return rctx;
         }
     } else if (EVP_PKEY_CTX_IS_SIGNATURE_OP(pctx)) {
-        if (rctx->op.sig.signature != NULL) {
+        if (pctx->op.sig.signature != NULL) {
             rctx->op.sig.signature = pctx->op.sig.signature;
             if (!EVP_SIGNATURE_up_ref(rctx->op.sig.signature)) {
                 OPENSSL_free(rctx);

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -18,11 +18,20 @@
 #define EVP_MD_CTX_FLAG_KEEP_PKEY_CTX   0x0400
 
 struct evp_pkey_ctx_st {
-    EVP_KEYEXCH *exchange;
-    void *exchprovctx;
+    /* Actual operation */
+    int operation;
 
-    EVP_SIGNATURE *signature;
-    void *sigprovctx;
+    union {
+        struct {
+            EVP_KEYEXCH *exchange;
+            void *exchprovctx;
+        } kex;
+
+        struct {
+            EVP_SIGNATURE *signature;
+            void *sigprovctx;
+        } sig;
+    } op;
 
     /* Legacy fields below */
 
@@ -34,8 +43,6 @@ struct evp_pkey_ctx_st {
     EVP_PKEY *pkey;
     /* Peer key for key agreement, may be NULL */
     EVP_PKEY *peerkey;
-    /* Actual operation */
-    int operation;
     /* Algorithm specific data */
     void *data;
     /* Application specific data */
@@ -553,6 +560,15 @@ struct evp_pkey_st {
     size_t dirty_cnt_copy;
 } /* EVP_PKEY */ ;
 
+#define EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx) \
+    ((ctx)->operation == EVP_PKEY_OP_SIGN \
+     || (ctx)->operation == EVP_PKEY_OP_SIGNCTX \
+     || (ctx)->operation == EVP_PKEY_OP_VERIFY \
+     || (ctx)->operation == EVP_PKEY_OP_VERIFYCTX \
+     || (ctx)->operation == EVP_PKEY_OP_VERIFYRECOVER)
+
+#define EVP_PKEY_CTX_IS_DERIVE_OP(ctx) \
+    ((ctx)->operation == EVP_PKEY_OP_DERIVE)
 
 void openssl_add_all_ciphers_int(void);
 void openssl_add_all_digests_int(void);

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -21,6 +21,9 @@ struct evp_pkey_ctx_st {
     EVP_KEYEXCH *exchange;
     void *exchprovctx;
 
+    EVP_SIGNATURE *signature;
+    void *sigprovctx;
+
     /* Legacy fields below */
 
     /* Method associated with this operation */

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -834,11 +834,29 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
     if (EVP_DigestSignInit(mctx, &pctx, md, NULL, si->pkey) <= 0)
         goto err;
 
+    /*
+     * TODO(3.0): This causes problems when providers are in use, so disabled
+     * for now. Can we get rid of this completely? AFAICT this ctrl has never
+     * been used since it was first put in. All internal implementations just
+     * return 1 and ignore this ctrl and have always done so by the looks of
+     * things. To fix this we could convert this ctrl into a param, which would
+     * require us to send all the signer info data as a set of params...but that
+     * is non-trivial and since this isn't used by anything it may be better
+     * just to remove it. The original commit that added it had this
+     * justification in CHANGES:
+     *
+     * "During PKCS7 signing pass the PKCS7 SignerInfo structure to the
+     *  EVP_PKEY_METHOD before and after signing via the
+     *  EVP_PKEY_CTRL_PKCS7_SIGN ctrl. It can then customise the structure
+     *  before and/or after signing if necessary."
+     */
+#if 0
     if (EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_SIGN,
                           EVP_PKEY_CTRL_PKCS7_SIGN, 0, si) <= 0) {
         PKCS7err(PKCS7_F_PKCS7_SIGNER_INFO_SIGN, PKCS7_R_CTRL_ERROR);
         goto err;
     }
+#endif
 
     alen = ASN1_item_i2d((ASN1_VALUE *)si->auth_attr, &abuf,
                          ASN1_ITEM_rptr(PKCS7_ATTR_SIGN));
@@ -856,11 +874,29 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
     if (EVP_DigestSignFinal(mctx, abuf, &siglen) <= 0)
         goto err;
 
+    /*
+     * TODO(3.0): This causes problems when providers are in use, so disabled
+     * for now. Can we get rid of this completely? AFAICT this ctrl has never
+     * been used since it was first put in. All internal implementations just
+     * return 1 and ignore this ctrl and have always done so by the looks of
+     * things. To fix this we could convert this ctrl into a param, which would
+     * require us to send all the signer info data as a set of params...but that
+     * is non-trivial and since this isn't used by anything it may be better
+     * just to remove it. The original commit that added it had this
+     * justification in CHANGES:
+     *
+     * "During PKCS7 signing pass the PKCS7 SignerInfo structure to the
+     *  EVP_PKEY_METHOD before and after signing via the
+     *  EVP_PKEY_CTRL_PKCS7_SIGN ctrl. It can then customise the structure
+     *  before and/or after signing if necessary."
+     */
+#if 0
     if (EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_SIGN,
                           EVP_PKEY_CTRL_PKCS7_SIGN, 1, si) <= 0) {
         PKCS7err(PKCS7_F_PKCS7_SIGNER_INFO_SIGN, PKCS7_R_CTRL_ERROR);
         goto err;
     }
+#endif
 
     EVP_MD_CTX_free(mctx);
 

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -161,6 +161,17 @@ up to the size of the DH prime B<p>.
 If B<OSSL_EXCHANGE_PARAM_PAD> is zero (the default) then no padding is
 performed.
 
+=item OSSL_SIGNATURE_PARAM_DIGEST (UTF8 string type)
+
+Sets the name of the digest algorithm used for the input to the signature
+functions.
+
+=item OSSL_SIGNATURE_PARAM_DIGEST_SIZE (size_t type)
+
+Sets the output size of the digest algorithm used for the input to the signature
+functions.
+The internal algorithm that supports this parameter is DSA.
+
 =back
 
 The function EVP_PKEY_CTX_ctrl() sends a control operation to the context

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -163,7 +163,7 @@ The parameters currently supported by the default provider are:
 
 =over 4
 
-=item "exchange-pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <uint>
+=item "pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <uint>
 
 Sets the DH padding mode.
 If B<OSSL_EXCHANGE_PARAM_PAD> is 1 then the  shared secret is padded with zeroes

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -2,7 +2,10 @@
 
 =head1 NAME
 
+EVP_PKEY_CTX_get_params,
+EVP_PKEY_CTX_gettable_params,
 EVP_PKEY_CTX_set_params,
+EVP_PKEY_CTX_settable_params,
 EVP_PKEY_CTX_ctrl,
 EVP_PKEY_CTX_ctrl_str,
 EVP_PKEY_CTX_ctrl_uint64,
@@ -63,7 +66,10 @@ EVP_PKEY_CTX_set1_id, EVP_PKEY_CTX_get1_id, EVP_PKEY_CTX_get1_id_len
 
  #include <openssl/evp.h>
 
+ int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
+ const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
+ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(EVP_PKEY_CTX *ctx);
 
  int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
                        int cmd, int p1, void *p2);
@@ -144,16 +150,20 @@ EVP_PKEY_CTX_set1_id, EVP_PKEY_CTX_get1_id, EVP_PKEY_CTX_get1_id_len
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_CTX_set_params() function sends arbitrary parameters to the
-algorithm implementation.
+The EVP_PKEY_CTX_get_params() and EVP_PKEY_CTX_set_params() functions get and
+send arbitrary parameters from and to the algorithm implementation respectively.
 Not all parameters may be supported by all providers.
 See L<OSSL_PROVIDER(3)> for more information on providers.
 See L<OSSL_PARAM(3)> for more information on parameters.
+These functions must only be called after the EVP_PKEY_CTX has been initialised
+for use in an operation (for example by L<EVP_PKEY_sign_init_ex(3)>,
+L<EVP_PKEY_derive_init_ex(3)> or other similar functions).
+
 The parameters currently supported by the default provider are:
 
 =over 4
 
-=item OSSL_EXCHANGE_PARAM_PAD (uint type)
+=item "exchange-pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <uint>
 
 Sets the DH padding mode.
 If B<OSSL_EXCHANGE_PARAM_PAD> is 1 then the  shared secret is padded with zeroes
@@ -161,18 +171,28 @@ up to the size of the DH prime B<p>.
 If B<OSSL_EXCHANGE_PARAM_PAD> is zero (the default) then no padding is
 performed.
 
-=item OSSL_SIGNATURE_PARAM_DIGEST (UTF8 string type)
+=item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <utf8 string>
 
-Sets the name of the digest algorithm used for the input to the signature
-functions.
+Gets and sets the name of the digest algorithm used for the input to the
+signature functions.
 
-=item OSSL_SIGNATURE_PARAM_DIGEST_SIZE (size_t type)
+=item "digest-size" (B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE>) <size_t>
 
-Sets the output size of the digest algorithm used for the input to the signature
-functions.
+Gets and sets the output size of the digest algorithm used for the input to the
+signature functions.
 The internal algorithm that supports this parameter is DSA.
 
 =back
+
+EVP_PKEY_CTX_gettable_params() and EVP_PKEY_CTX_settable_params() gets a
+constant B<OSSL_PARAM> array that decribes the  gettable and
+settable parameters for the current algorithm implementation, i.e. parameters
+that can be used with EVP_PKEY_CTX_get_params() and EVP_PKEY_CTX_set_params()
+respectively.
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+These functions must only be called after the EVP_PKEY_CTX has been initialised
+for use in an operation (for example by L<EVP_PKEY_sign_init_ex(3)>,
+L<EVP_PKEY_derive_init_ex(3)> or other similar functions).
 
 The function EVP_PKEY_CTX_ctrl() sends a control operation to the context
 B<ctx>. The key type used must match B<keytype> if it is not -1. The parameter
@@ -199,13 +219,13 @@ B<pkeyutl>, B<genpkey> and B<req> commands.
 The function EVP_PKEY_CTX_md() sends a message digest control operation
 to the context B<ctx>. The message digest is specified by its name B<md>.
 
-All the remaining "functions" are implemented as macros.
-
-The EVP_PKEY_CTX_set_signature_md() macro sets the message digest type used
+The EVP_PKEY_CTX_set_signature_md() function sets the message digest type used
 in a signature. It can be used in the RSA, DSA and ECDSA algorithms.
 
-The EVP_PKEY_CTX_get_signature_md() macro gets the message digest type used in a
-signature. It can be used in the RSA, DSA and ECDSA algorithms.
+The EVP_PKEY_CTX_get_signature_md() function gets the message digest type used
+in a signature. It can be used in the RSA, DSA and ECDSA algorithms.
+
+All the remaining "functions" are implemented as macros.
 
 Key generation typically involves setting up parameters to be used and
 generating the private and public key data. Some algorithm implementations
@@ -471,9 +491,15 @@ allocate adequate memory space for the B<id> before calling EVP_PKEY_CTX_get1_id
 
 =head1 RETURN VALUES
 
-EVP_PKEY_CTX_ctrl() and its macros return a positive value for success and 0
-or a negative value for failure. In particular a return value of -2
-indicates the operation is not supported by the public key algorithm.
+EVP_PKEY_CTX_set_params() returns 1 for success or 0 otherwise.
+EVP_PKEY_CTX_settable_params() returns an OSSL_PARAM array on success or NULL on
+error.
+It may also return NULL if there are no settable parameters available.
+
+EVP_PKEY_CTX_set_signature_md(), EVP_PKEY_CTX_set_dh_pad(), EVP_PKEY_CTX_ctrl()
+and its macros return a positive value for success and 0 or a negative value for
+failure. In particular a return value of -2 indicates the operation is not
+supported by the public key algorithm.
 
 =head1 SEE ALSO
 
@@ -492,8 +518,9 @@ The
 EVP_PKEY_CTX_set1_id(), EVP_PKEY_CTX_get1_id() and EVP_PKEY_CTX_get1_id_len()
 macros were added in 1.1.1, other functions were added in OpenSSL 1.0.0.
 
-EVP_PKEY_CTX_set_dh_pad() was a macro in OpenSSL 1.1.1 and below.
-From OpenSSL 3.0 it is a function.
+EVP_PKEY_CTX_get_signature_md(), EVP_PKEY_CTX_set_signature_md() and
+EVP_PKEY_CTX_set_dh_pad() were macros in OpenSSL 1.1.1 and below. From OpenSSL
+3.0 they are functions.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_derive.pod
+++ b/doc/man3/EVP_PKEY_derive.pod
@@ -25,10 +25,10 @@ The EVP_PKEY object associated with B<ctx> must be compatible with that
 algorithm.
 B<exchange> may be NULL in which case the EVP_KEYEXCH algorithm is fetched
 implicitly based on the type of EVP_PKEY associated with B<ctx>.
-See L<EVP_KEYEXCH_fetch(3)> for more information about implict fetches.
+See L<provider(7)/Implicit fetch> for more information about implict fetches.
 
-The EVP_PKEY_derive_init() function is the same as EVP_PKEY_derive() except that
-the EVP_KEYEXCH algorithm is always implicitly fetched.
+The EVP_PKEY_derive_init() function is the same as EVP_PKEY_derive_init_ex()
+except that the EVP_KEYEXCH algorithm is always implicitly fetched.
 
 The EVP_PKEY_derive_set_peer() function sets the peer key: this will normally
 be a public key.

--- a/doc/man3/EVP_PKEY_sign.pod
+++ b/doc/man3/EVP_PKEY_sign.pod
@@ -2,12 +2,14 @@
 
 =head1 NAME
 
-EVP_PKEY_sign_init, EVP_PKEY_sign - sign using a public key algorithm
+EVP_PKEY_sign_init_ex, EVP_PKEY_sign_init, EVP_PKEY_sign
+- sign using a public key algorithm
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
+ int EVP_PKEY_sign_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
  int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
                    unsigned char *sig, size_t *siglen,
@@ -15,8 +17,18 @@ EVP_PKEY_sign_init, EVP_PKEY_sign - sign using a public key algorithm
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_sign_init() function initializes a public key algorithm
-context using key B<pkey> for a signing operation.
+The EVP_PKEY_sign_init_ex() function initializes a public key algorithm
+context for performing signing using the signature algorithm B<signature>.
+The signature algorithm B<signature> should be fetched using a call to
+L<EVP_SIGNATURE_fetch(3)>.
+The EVP_PKEY object associated with B<ctx> must be compatible with that
+algorithm.
+B<signature> may be NULL in which case the EVP_SIGNATURE algorithm is fetched
+implicitly based on the type of EVP_PKEY associated with B<ctx>.
+See L<provider(7)/Implicit fetch> for more information about implict fetches.
+
+The EVP_PKEY_sign_init() function is the same as EVP_PKEY_sign_init_ex() except
+that the EVP_SIGNATURE algorithm is always implicitly fetched.
 
 The EVP_PKEY_sign() function performs a public key signing operation
 using B<ctx>. The data to be signed is specified using the B<tbs> and
@@ -101,6 +113,7 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
+EVP_PKEY_sign_init_ex() was added in OpenSSL 3.0.
 These functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT

--- a/doc/man3/EVP_PKEY_verify.pod
+++ b/doc/man3/EVP_PKEY_verify.pod
@@ -2,12 +2,14 @@
 
 =head1 NAME
 
-EVP_PKEY_verify_init, EVP_PKEY_verify - signature verification using a public key algorithm
+EVP_PKEY_verify_init_ex, EVP_PKEY_verify_init, EVP_PKEY_verify
+- signature verification using a public key algorithm
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
+ int EVP_PKEY_verify_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
  int EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
                      const unsigned char *sig, size_t siglen,
@@ -15,8 +17,19 @@ EVP_PKEY_verify_init, EVP_PKEY_verify - signature verification using a public ke
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_verify_init() function initializes a public key algorithm
-context using key B<pkey> for a signature verification operation.
+The EVP_PKEY_verify_init_ex() function initializes a public key algorithm
+context for performing signature verification using the signature algorithm
+B<signature>.
+The signature algorithm B<signature> should be fetched using a call to
+L<EVP_SIGNATURE_fetch(3)>.
+The EVP_PKEY object associated with B<ctx> must be compatible with that
+algorithm.
+B<signature> may be NULL in which case the EVP_SIGNATURE algorithm is fetched
+implicitly based on the type of EVP_PKEY associated with B<ctx>.
+See L<provider(7)/Implicit fetch> for more information about implict fetches.
+
+The EVP_PKEY_verify_init() function is the same as EVP_PKEY_verify_init_ex()
+except that the EVP_SIGNATURE algorithm is always implicitly fetched.
 
 The EVP_PKEY_verify() function performs a public key verification operation
 using B<ctx>. The signature is specified using the B<sig> and
@@ -89,7 +102,8 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.0.0.
+EVP_PKEY_verify_init_ex() was added in OpenSSL 3.0.
+All other functions were added in OpenSSL 1.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_verify_recover.pod
+++ b/doc/man3/EVP_PKEY_verify_recover.pod
@@ -2,12 +2,15 @@
 
 =head1 NAME
 
-EVP_PKEY_verify_recover_init, EVP_PKEY_verify_recover - recover signature using a public key algorithm
+EVP_PKEY_verify_recover_init_ex, EVP_PKEY_verify_recover_init,
+EVP_PKEY_verify_recover - recover signature using a public key algorithm
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
+ int EVP_PKEY_verify_recover_init_ex(EVP_PKEY_CTX *ctx,
+                                     EVP_SIGNATURE *signature);
  int EVP_PKEY_verify_recover_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
                              unsigned char *rout, size_t *routlen,
@@ -15,8 +18,20 @@ EVP_PKEY_verify_recover_init, EVP_PKEY_verify_recover - recover signature using 
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_verify_recover_init() function initializes a public key algorithm
-context using key B<pkey> for a verify recover operation.
+The EVP_PKEY_verify_recover_init_ex() function initializes a public key
+algorithm context for performing signature signed data recovery using the
+signature algorithm B<signature>.
+The signature algorithm B<signature> should be fetched using a call to
+L<EVP_SIGNATURE_fetch(3)>.
+The EVP_PKEY object associated with B<ctx> must be compatible with that
+algorithm.
+B<signature> may be NULL in which case the EVP_SIGNATURE algorithm is fetched
+implicitly based on the type of EVP_PKEY associated with B<ctx>.
+See L<provider(7)/Implicit fetch> for more information about implict fetches.
+
+The EVP_PKEY_verify_recover_init() function is the same as
+EVP_PKEY_verify_recover_init_ex() except that the EVP_SIGNATURE algorithm is
+always implicitly fetched.
 
 The EVP_PKEY_verify_recover() function recovers signed data
 using B<ctx>. The signature is specified using the B<sig> and

--- a/doc/man3/EVP_SIGNATURE_free.pod
+++ b/doc/man3/EVP_SIGNATURE_free.pod
@@ -1,0 +1,64 @@
+=pod
+
+=head1 NAME
+
+EVP_SIGNATURE_fetch, EVP_SIGNATURE_free, EVP_SIGNATURE_up_ref,
+EVP_SIGNATURE_provider
+- Functions to manage EVP_SIGNATURE algorithm objects
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+                                    const char *properties);
+ void EVP_SIGNATURE_free(EVP_SIGNATURE *signature);
+ int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature);
+ OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature);
+
+=head1 DESCRIPTION
+
+EVP_SIGNATURE_fetch() fetches the implementation for the given
+B<algorithm> from any provider offering it, within the criteria given
+by the B<properties>.
+The algorithm will be one offering functions for performing signature related
+tasks such as signing and verifying.
+See L<provider(7)/Fetching algorithms> for further information.
+
+The returned value must eventually be freed with EVP_SIGNATURE_free().
+
+EVP_SIGNATURE_free() decrements the reference count for the B<EVP_SIGNATURE>
+structure. Typically this structure will have been obtained from an earlier call
+to EVP_SIGNATURE_fetch(). If the reference count drops to 0 then the
+structure is freed.
+
+EVP_SIGNATURE_up_ref() increments the reference count for an B<EVP_SIGNATURE>
+structure.
+
+EVP_SIGNATURE_provider() returns the provider that I<signature> was fetched from.
+
+=head1 RETURN VALUES
+
+EVP_SIGNATURE_fetch() returns a pointer to an B<EVP_SIGNATURE> for success
+or B<NULL> for failure.
+
+EVP_SIGNATURE_up_ref() returns 1 for success or 0 otherwise.
+
+=head1 SEE ALSO
+
+L<provider(7)/Fetching algorithms>, L<OSSL_PROVIDER(3)>
+
+=head1 HISTORY
+
+The functions described here were added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -29,8 +29,8 @@ provider-keyexch - The keyexch library E<lt>-E<gt> provider functions
                        size_t outlen);
 
  /* Key Exchange parameters */
- int OP_keyexch_set_params(void *ctx, const OSSL_PARAM params[]);
-
+ int OP_keyexch_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_keyexch_settable_ctx_params(void);
 
 =head1 DESCRIPTION
 
@@ -61,15 +61,16 @@ For example, the "function" OP_keyexch_newctx() has these:
 B<OSSL_DISPATCH> arrays are indexed by numbers that are provided as
 macros in L<openssl-core_numbers.h(7)>, as follows:
 
- OP_keyexch_newctx           OSSL_FUNC_KEYEXCH_NEWCTX
- OP_keyexch_freectx          OSSL_FUNC_KEYEXCH_FREECTX
- OP_keyexch_dupctx           OSSL_FUNC_KEYEXCH_DUPCTX
+ OP_keyexch_newctx                OSSL_FUNC_KEYEXCH_NEWCTX
+ OP_keyexch_freectx               OSSL_FUNC_KEYEXCH_FREECTX
+ OP_keyexch_dupctx                OSSL_FUNC_KEYEXCH_DUPCTX
 
- OP_keyexch_init             OSSL_FUNC_KEYEXCH_INIT
- OP_keyexch_set_peer         OSSL_FUNC_KEYEXCH_SET_PEER
- OP_keyexch_derive           OSSL_FUNC_KEYEXCH_DERIVE
+ OP_keyexch_init                  OSSL_FUNC_KEYEXCH_INIT
+ OP_keyexch_set_peer              OSSL_FUNC_KEYEXCH_SET_PEER
+ OP_keyexch_derive                OSSL_FUNC_KEYEXCH_DERIVE
 
- OP_keyexch_set_params       OSSL_FUNC_KEYEXCH_SET_PARAMS
+ OP_keyexch_set_ctx_params        OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS
+ OP_keyexch_settable_ctx_params   OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS
 
 A key exchange algorithm implementation may not implement all of these functions.
 In order to be a consistent set of functions a provider must implement
@@ -127,8 +128,8 @@ written to B<*secretlen>.
 See L<OSSL_PARAM(3)> for further details on the parameters structure used by
 the OP_keyexch_set_params() function.
 
-OP_keyexch_set_params() sets key exchange parameters associated with the given
-provider side key exchange context B<ctx> to B<params>.
+OP_keyexch_set_ctx_params() sets key exchange parameters associated with the
+given provider side key exchange context B<ctx> to B<params>.
 Any parameter settings are additional to any that were previously set.
 
 Parameters currently recognised by built-in key exchange algorithms are as
@@ -150,6 +151,11 @@ with 0s where necessary to make the shared secret the same size as the largest
 possible secret size.
 
 =back
+
+OP_keyexch_settable_ctx_params() gets a constant B<OSSL_PARAM> array that
+decribes the settable parameters, i.e. parameters that can be used with
+OP_signature_set_ctx_params().
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
 
 =head1 RETURN VALUES
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -39,8 +39,10 @@ provider-signature - The signature library E<lt>-E<gt> provider functions
                                  const unsigned char *sig, size_t siglen);
 
  /* Signature parameters */
- int OP_signature_set_params(void *ctx, const OSSL_PARAM params[]);
-
+ int OP_signature_get_ctx_params(void *ctx, OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_signature_gettable_ctx_params(void);
+ int OP_signature_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_signature_settable_ctx_params(void);
 
 =head1 DESCRIPTION
 
@@ -86,7 +88,10 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_signature_verify_recover_init    OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_INIT
  OP_signature_verify_recover         OSSL_FUNC_SIGNATURE_VERIFY_RECOVER
 
- OP_signature_set_params             OSSL_FUNC_SIGNATURE_SET_PARAMS
+ OP_signature_get_ctx_params         OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS
+ OP_signature_gettable_ctx_params    OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS
+ OP_signature_set_ctx_params         OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS
+ OP_signature_settable_ctx_params    OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS
 
 A signature algorithm implementation may not implement all of these functions.
 In order to be a consistent set of functions a provider must implement
@@ -174,10 +179,12 @@ the B<routlen> parameter.
 =head2 Signature Parameters
 
 See L<OSSL_PARAM(3)> for further details on the parameters structure used by
-the OP_signature_set_params() function.
+the OP_signature_get_ctx_params() and OP_signature_set_ctx_params() functions.
 
-OP_signature_set_params() sets signature parameters associated with the given
-provider side key exchange context B<ctx> to B<params>.
+OP_signature_get_ctx_params() gets signature parameters associated with the
+given provider side signature context B<ctx> and stored them in B<params>.
+OP_signature_set_ctx_params() sets the signature parameters associated with the
+given provider side signature context B<ctx> to B<params>.
 Any parameter settings are additional to any that were previously set.
 
 Parameters currently recognised by built-in signature algorithms are as
@@ -187,27 +194,30 @@ algorithms:
 
 =over 4
 
-=item B<OSSL_SIGNATURE_PARAM_DIGEST> (UTF8 string)
+=item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <utf8 string>
 
-Sets the name of the digest algorithm used for the input to the signature
+Get or sets the name of the digest algorithm used for the input to the signature
 functions.
 
-=item B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE> (size_t)
+=item "digest-size" (B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE>) <size_t>
 
-Sets the output size of the digest algorithm used for the input to the signature
-functions.
+Gets or sets the output size of the digest algorithm used for the input to the
+signature functions.
 
 =back
+
+OP_signature_gettable_ctx_params() and OP_signature_settable_ctx_params() get a
+constant B<OSSL_PARAM> array that decribes the gettable and settable parameters,
+i.e. parameters that can be used with OP_signature_get_ctx_params() and
+OP_signature_set_ctx_params() respectively.
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
 
 =head1 RETURN VALUES
 
 OP_signature_newctx() and OP_signature_dupctx() should return the newly created
 provider side signature, or NULL on failure.
 
-OP_signature_sign_init(), OP_signature_sign(), OP_signature_verify_init(),
-OP_signature_verify(), OP_signature_verify_recover_init(),
-OP_signature_verify_recover() and OP_signature_set_params() should return 1 for
-success or 0 on error.
+All other functions should return 1 for success or 0 on error.
 
 =head1 SEE ALSO
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -1,0 +1,229 @@
+=pod
+
+=head1 NAME
+
+provider-signature - The signature library E<lt>-E<gt> provider functions
+
+=head1 SYNOPSIS
+
+=for comment multiple includes
+
+ #include <openssl/core_numbers.h>
+ #include <openssl/core_names.h>
+
+ /*
+  * None of these are actual functions, but are displayed like this for
+  * the function signatures for functions that are offered as function
+  * pointers in OSSL_DISPATCH arrays.
+  */
+
+ /* Context management */
+ void *OP_signature_newctx(void *provctx);
+ void OP_signature_freectx(void *ctx);
+ void *OP_signature_dupctx(void *ctx);
+
+ /* Signing */
+ int OP_signature_sign_init(void *ctx, void *provkey);
+ int OP_signature_sign(void *ctx, unsigned char *sig, size_t *siglen,
+                       size_t sigsize, const unsigned char *tbs, size_t tbslen);
+
+ /* Verifying */
+ int OP_signature_verify_init(void *ctx, void *provkey);
+ int OP_signature_verify(void *ctx, const unsigned char *sig, size_t siglen,
+                         const unsigned char *tbs, size_t tbslen);
+
+ /* Verify Recover */
+ int OP_signature_verify_recover_init(void *ctx, void *provkey);
+ int OP_signature_verify_recover(void *ctx, unsigned char *rout,
+                                 size_t *routlen, size_t routsize,
+                                 const unsigned char *sig, size_t siglen);
+
+ /* Signature parameters */
+ int OP_signature_set_params(void *ctx, const OSSL_PARAM params[]);
+
+
+=head1 DESCRIPTION
+
+This documentation is primarily aimed at provider authors. See L<provider(7)>
+for further information.
+
+The signature (OSSL_OP_SIGNATURE) operation enables providers to implement
+signature algorithms and make them available to applications via the API
+functions L<EVP_PKEY_sign_init_ex(3)>, L<EVP_PKEY_sign(3)>,
+L<EVP_PKEY_verify_init_ex(3)>, L<EVP_PKEY_verify(3)>,
+L<EVP_PKEY_verify_recover_init_ex(3)> and L<EVP_PKEY_verify_recover(3)> (as well
+as other related functions).
+
+All "functions" mentioned here are passed as function pointers between
+F<libcrypto> and the provider in B<OSSL_DISPATCH> arrays via
+B<OSSL_ALGORITHM> arrays that are returned by the provider's
+provider_query_operation() function
+(see L<provider-base(7)/Provider Functions>).
+
+All these "functions" have a corresponding function type definition
+named B<OSSL_{name}_fn>, and a helper function to retrieve the
+function pointer from an B<OSSL_DISPATCH> element named
+B<OSSL_get_{name}>.
+For example, the "function" OP_signature_newctx() has these:
+
+ typedef void *(OSSL_OP_signature_newctx_fn)(void *provctx);
+ static ossl_inline OSSL_OP_signature_newctx_fn
+     OSSL_get_OP_signature_newctx(const OSSL_DISPATCH *opf);
+
+B<OSSL_DISPATCH> arrays are indexed by numbers that are provided as
+macros in L<openssl-core_numbers.h(7)>, as follows:
+
+ OP_signature_newctx                 OSSL_FUNC_SIGNATURE_NEWCTX
+ OP_signature_freectx                OSSL_FUNC_SIGNATURE_FREECTX
+ OP_signature_dupctx                 OSSL_FUNC_SIGNATURE_DUPCTX
+
+ OP_signature_sign_init              OSSL_FUNC_SIGNATURE_SIGN_INIT
+ OP_signature_sign                   OSSL_FUNC_SIGNATURE_SIGN
+
+ OP_signature_verify_init            OSSL_FUNC_SIGNATURE_VERIFY_INIT
+ OP_signature_verify                 OSSL_FUNC_SIGNATURE_VERIFY
+
+ OP_signature_verify_recover_init    OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_INIT
+ OP_signature_verify_recover         OSSL_FUNC_SIGNATURE_VERIFY_RECOVER
+
+ OP_signature_set_params             OSSL_FUNC_SIGNATURE_SET_PARAMS
+
+A signature algorithm implementation may not implement all of these functions.
+In order to be a consistent set of functions a provider must implement
+OP_signature_newctx and OP_signature_freectx.
+It must also implement both of OP_signature_sign_init and OP_signature_sign,
+or both of OP_signature_verify_init and OP_signature_verify, or both of
+OP_signature_verify_recover_init and OP_signature_verify_recover.
+All other functions are optional.
+
+A signature algorithm must also implement some mechanism for generating,
+loading or importing keys via the key management (OSSL_OP_KEYMGMT) operation.
+See L<provider-keymgmt(7)> for further details.
+
+=head2 Context Management Functions
+
+OP_signature_newctx() should create and return a pointer to a provider side
+structure for holding context information during a signature operation.
+A pointer to this context will be passed back in a number of the other signature
+operation function calls.
+The parameter B<provctx> is the provider context generated during provider
+initialisation (see L<provider(3)>).
+
+OP_signature_freectx() is passed a pointer to the provider side signature
+context in the B<ctx> parameter.
+This function should free any resources associated with that context.
+
+OP_signature_dupctx() should duplicate the provider side signature context in
+the B<ctx> parameter and return the duplicate copy.
+
+=head2 Signing Functions
+
+OP_signature_sign_init() initialises a context for signing given a provider side
+signature context in the B<ctx> parameter, and a pointer to a provider key object
+in the B<provkey> parameter.
+The key object should have been previously generated, loaded or imported into
+the provider using the key management (OSSL_OP_KEYMGMT) operation (see
+provider-keymgmt(7)>.
+
+OP_signature_sign() performs the actual signing itself.
+A previously initialised signature context is passed in the B<ctx>
+parameter.
+The data to be signed is pointed to be the B<tbs> parameter which is B<tbslen>
+bytes long.
+Unless B<sig> is NULL, the signature should be written to the location pointed
+to by the B<sig> parameter and it should not exceed B<sigsize> bytes in length.
+The length of the signature should be written to B<*siglen>.
+If B<sig> is NULL then the maximum length of the signature should be written to
+B<*siglen>.
+
+=head2 Verify Functions
+
+OP_signature_verify_init() initialises a context for verifying a signature given
+a provider side signature context in the B<ctx> parameter, and a pointer to a
+provider key object in the B<provkey> parameter.
+The key object should have been previously generated, loaded or imported into
+the provider using the key management (OSSL_OP_KEYMGMT) operation (see
+provider-keymgmt(7)>.
+
+OP_signature_verify() performs the actual verification itself.
+A previously initialised signature context is passed in the B<ctx> parameter.
+The data that the signature covers is pointed to be the B<tbs> parameter which
+is B<tbslen> bytes long.
+The signature is pointed to by the B<sig> parameter which is B<siglen> bytes
+long.
+
+=head2 Verify Recover Functions
+
+OP_signature_verify_recover_init() initialises a context for recovering the
+signed data given a provider side signature context in the B<ctx> parameter, and
+a pointer to a provider key object in the B<provkey> parameter.
+The key object should have been previously generated, loaded or imported into
+the provider using the key management (OSSL_OP_KEYMGMT) operation (see
+provider-keymgmt(7)>.
+
+OP_signature_verify_recover() performs the actual verify recover itself.
+A previously initialised signature context is passed in the B<ctx> parameter.
+The signature is pointed to by the B<sig> parameter which is B<siglen> bytes
+long.
+Unless B<rout> is NULL, the recovered data should be written to the location
+pointed to by B<rout> which should not exceed B<routsize> bytes in length.
+The length of the recovered data should be written to B<*routlen>.
+If B<rout> is B<NULL> then the maximum size of the output buffer is written to
+the B<routlen> parameter.
+
+=head2 Signature Parameters
+
+See L<OSSL_PARAM(3)> for further details on the parameters structure used by
+the OP_signature_set_params() function.
+
+OP_signature_set_params() sets signature parameters associated with the given
+provider side key exchange context B<ctx> to B<params>.
+Any parameter settings are additional to any that were previously set.
+
+Parameters currently recognised by built-in signature algorithms are as
+follows.
+Not all parameters are relevant to, or are understood by all signature
+algorithms:
+
+=over 4
+
+=item B<OSSL_SIGNATURE_PARAM_DIGEST> (UTF8 string)
+
+Sets the name of the digest algorithm used for the input to the signature
+functions.
+
+=item B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE> (size_t)
+
+Sets the output size of the digest algorithm used for the input to the signature
+functions.
+
+=back
+
+=head1 RETURN VALUES
+
+OP_signature_newctx() and OP_signature_dupctx() should return the newly created
+provider side signature, or NULL on failure.
+
+OP_signature_sign_init(), OP_signature_sign(), OP_signature_verify_init(),
+OP_signature_verify(), OP_signature_verify_recover_init(),
+OP_signature_verify_recover() and OP_signature_set_params() should return 1 for
+success or 0 on error.
+
+=head1 SEE ALSO
+
+L<provider(7)>
+
+=head1 HISTORY
+
+The provider SIGNATURE interface was introduced in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -94,21 +94,21 @@ extern "C" {
 
 /* PKEY parameters */
 /* Diffie-Hellman/DSA Parameters */
-#define OSSL_PKEY_PARAM_FFC_P        "ffc-p"
-#define OSSL_PKEY_PARAM_FFC_G        "ffc-g"
-#define OSSL_PKEY_PARAM_FFC_Q        "ffc-q"
+#define OSSL_PKEY_PARAM_FFC_P        "p"
+#define OSSL_PKEY_PARAM_FFC_G        "g"
+#define OSSL_PKEY_PARAM_FFC_Q        "q"
 
 /* Diffie-Hellman Keys */
-#define OSSL_PKEY_PARAM_DH_PUB_KEY   "dh-pub"
-#define OSSL_PKEY_PARAM_DH_PRIV_KEY  "dh-priv"
+#define OSSL_PKEY_PARAM_DH_PUB_KEY   "pub"
+#define OSSL_PKEY_PARAM_DH_PRIV_KEY  "priv"
 
 /* DSA Keys */
-#define OSSL_PKEY_PARAM_DSA_PUB_KEY  "dsa-pub"
-#define OSSL_PKEY_PARAM_DSA_PRIV_KEY "dsa-priv"
+#define OSSL_PKEY_PARAM_DSA_PUB_KEY  "pub"
+#define OSSL_PKEY_PARAM_DSA_PRIV_KEY "priv"
 
 /* Key Exchange parameters */
 
-#define OSSL_EXCHANGE_PARAM_PAD      "exchange-pad" /* uint */
+#define OSSL_EXCHANGE_PARAM_PAD      "pad" /* uint */
 
 /* Signature parameters */
 #define OSSL_SIGNATURE_PARAM_DIGEST         "digest"

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -93,17 +93,26 @@ extern "C" {
 #define OSSL_MAC_NAME_KMAC256       "KMAC256"
 
 /* PKEY parameters */
-/* Diffie-Hellman Parameters */
-#define OSSL_PKEY_PARAM_DH_P         "dh-p"
-#define OSSL_PKEY_PARAM_DH_G         "dh-g"
-#define OSSL_PKEY_PARAM_DH_Q         "dh-q"
+/* Diffie-Hellman/DSA Parameters */
+#define OSSL_PKEY_PARAM_FFC_P        "ffc-p"
+#define OSSL_PKEY_PARAM_FFC_G        "ffc-g"
+#define OSSL_PKEY_PARAM_FFC_Q        "ffc-q"
+
 /* Diffie-Hellman Keys */
 #define OSSL_PKEY_PARAM_DH_PUB_KEY   "dh-pub"
 #define OSSL_PKEY_PARAM_DH_PRIV_KEY  "dh-priv"
 
+/* DSA Keys */
+#define OSSL_PKEY_PARAM_DSA_PUB_KEY  "dsa-pub"
+#define OSSL_PKEY_PARAM_DSA_PRIV_KEY "dsa-priv"
+
 /* Key Exchange parameters */
 
 #define OSSL_EXCHANGE_PARAM_PAD      "exchange-pad" /* uint */
+
+/* Signature parameters */
+#define OSSL_SIGNATURE_PARAM_DIGEST         "digest"
+#define OSSL_SIGNATURE_PARAM_DIGEST_SIZE    "digest-size"
 
 # ifdef __cplusplus
 }

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -359,7 +359,8 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_exportkey_types, (void))
 # define OSSL_FUNC_KEYEXCH_SET_PEER                    4
 # define OSSL_FUNC_KEYEXCH_FREECTX                     5
 # define OSSL_FUNC_KEYEXCH_DUPCTX                      6
-# define OSSL_FUNC_KEYEXCH_SET_PARAMS                  7
+# define OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS              7
+# define OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS         8
 
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_init, (void *ctx, void *provkey))
@@ -368,8 +369,10 @@ OSSL_CORE_MAKE_FUNC(int, OP_keyexch_derive, (void *ctx,  unsigned char *secret,
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_peer, (void *ctx, void *provkey))
 OSSL_CORE_MAKE_FUNC(void, OP_keyexch_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_dupctx, (void *ctx))
-OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_params, (void *ctx,
-                                                 const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_ctx_params, (void *ctx,
+                                                     const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keyexch_settable_ctx_params,
+                    (void))
 
 /* Signature */
 
@@ -382,7 +385,10 @@ OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_params, (void *ctx,
 # define OSSL_FUNC_SIGNATURE_VERIFY_RECOVER          7
 # define OSSL_FUNC_SIGNATURE_FREECTX                 8
 # define OSSL_FUNC_SIGNATURE_DUPCTX                  9
-# define OSSL_FUNC_SIGNATURE_SET_PARAMS             10
+# define OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS         10
+# define OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS    11
+# define OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS         12
+# define OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS    13
 
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_sign_init, (void *ctx, void *provkey))
@@ -406,8 +412,14 @@ OSSL_CORE_MAKE_FUNC(int, OP_signature_verify_recover, (void *ctx,
                                                        size_t siglen))
 OSSL_CORE_MAKE_FUNC(void, OP_signature_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_dupctx, (void *ctx))
-OSSL_CORE_MAKE_FUNC(int, OP_signature_set_params, (void *ctx,
-                                                   const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_get_ctx_params,
+                    (void *ctx, OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_signature_gettable_ctx_params,
+                    (void))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_set_ctx_params,
+                    (void *ctx, const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_signature_settable_ctx_params,
+                    (void))
 
 # ifdef __cplusplus
 }

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -378,6 +378,7 @@ OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_params, (void *ctx,
 # define OSSL_FUNC_SIGNATURE_SIGN                    3
 # define OSSL_FUNC_SIGNATURE_FREECTX                 4
 # define OSSL_FUNC_SIGNATURE_DUPCTX                  5
+# define OSSL_FUNC_SIGNATURE_SET_PARAMS              6
 
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_sign_init, (void *ctx, void *provkey))
@@ -387,6 +388,8 @@ OSSL_CORE_MAKE_FUNC(int, OP_signature_sign, (void *ctx,  unsigned char *sig,
                                              size_t tbslen))
 OSSL_CORE_MAKE_FUNC(void, OP_signature_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_dupctx, (void *ctx))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_set_params, (void *ctx,
+                                                   const OSSL_PARAM params[]))
 
 # ifdef __cplusplus
 }

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -155,8 +155,9 @@ OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,provider_get_reason_strings,
 # define OSSL_OP_MAC                                 3
 # define OSSL_OP_KEYMGMT                            10
 # define OSSL_OP_KEYEXCH                            11
+# define OSSL_OP_SIGNATURE                          12
 /* Highest known operation number */
-# define OSSL_OP__HIGHEST                           11
+# define OSSL_OP__HIGHEST                           12
 
 /* Digests */
 
@@ -369,6 +370,23 @@ OSSL_CORE_MAKE_FUNC(void, OP_keyexch_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_params, (void *ctx,
                                                  const OSSL_PARAM params[]))
+
+/* Signature */
+
+# define OSSL_FUNC_SIGNATURE_NEWCTX                  1
+# define OSSL_FUNC_SIGNATURE_SIGN_INIT               2
+# define OSSL_FUNC_SIGNATURE_SIGN                    3
+# define OSSL_FUNC_SIGNATURE_FREECTX                 4
+# define OSSL_FUNC_SIGNATURE_DUPCTX                  5
+
+OSSL_CORE_MAKE_FUNC(void *, OP_signature_newctx, (void *provctx))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_sign_init, (void *ctx, void *provkey))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_sign, (void *ctx,  unsigned char *sig,
+                                             size_t *siglen, size_t sigsize,
+                                             const unsigned char *tbs,
+                                             size_t tbslen))
+OSSL_CORE_MAKE_FUNC(void, OP_signature_freectx, (void *ctx))
+OSSL_CORE_MAKE_FUNC(void *, OP_signature_dupctx, (void *ctx))
 
 # ifdef __cplusplus
 }

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -376,9 +376,13 @@ OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_params, (void *ctx,
 # define OSSL_FUNC_SIGNATURE_NEWCTX                  1
 # define OSSL_FUNC_SIGNATURE_SIGN_INIT               2
 # define OSSL_FUNC_SIGNATURE_SIGN                    3
-# define OSSL_FUNC_SIGNATURE_FREECTX                 4
-# define OSSL_FUNC_SIGNATURE_DUPCTX                  5
-# define OSSL_FUNC_SIGNATURE_SET_PARAMS              6
+# define OSSL_FUNC_SIGNATURE_VERIFY_INIT             4
+# define OSSL_FUNC_SIGNATURE_VERIFY                  5
+# define OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_INIT     6
+# define OSSL_FUNC_SIGNATURE_VERIFY_RECOVER          7
+# define OSSL_FUNC_SIGNATURE_FREECTX                 8
+# define OSSL_FUNC_SIGNATURE_DUPCTX                  9
+# define OSSL_FUNC_SIGNATURE_SET_PARAMS             10
 
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_sign_init, (void *ctx, void *provkey))
@@ -386,6 +390,20 @@ OSSL_CORE_MAKE_FUNC(int, OP_signature_sign, (void *ctx,  unsigned char *sig,
                                              size_t *siglen, size_t sigsize,
                                              const unsigned char *tbs,
                                              size_t tbslen))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_verify_init, (void *ctx, void *provkey))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_verify, (void *ctx,
+                                               const unsigned char *sig,
+                                               size_t siglen,
+                                               const unsigned char *tbs,
+                                               size_t tbslen))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_verify_recover_init, (void *ctx,
+                                                            void *provkey))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_verify_recover, (void *ctx,
+                                                       unsigned char *rout,
+                                                       size_t *routlen,
+                                                       size_t routsize,
+                                                       const unsigned char *sig,
+                                                       size_t siglen))
 OSSL_CORE_MAKE_FUNC(void, OP_signature_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_set_params, (void *ctx,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1337,6 +1337,7 @@ void EVP_PKEY_asn1_set_security_bits(EVP_PKEY_ASN1_METHOD *ameth,
                                      int (*pkey_security_bits) (const EVP_PKEY
                                                                 *pk));
 
+int EVP_PKEY_CTX_get_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD **md);
 int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 
 # define EVP_PKEY_OP_UNDEFINED           0
@@ -1363,10 +1364,6 @@ int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 
 # define EVP_PKEY_OP_TYPE_GEN \
                 (EVP_PKEY_OP_PARAMGEN | EVP_PKEY_OP_KEYGEN)
-
-# define  EVP_PKEY_CTX_get_signature_md(ctx, pmd)        \
-                EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_TYPE_SIG,  \
-                                        EVP_PKEY_CTRL_GET_MD, 0, (void *)(pmd))
 
 # define  EVP_PKEY_CTX_set_mac_key(ctx, key, len)        \
                 EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_KEYGEN,  \
@@ -1427,7 +1424,10 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
 EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *ctx);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
 
+int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
+const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
+const OSSL_PARAM *EVP_PKEY_CTX_settable_params(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
                       int cmd, int p1, void *p2);
 int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1470,6 +1470,13 @@ EVP_PKEY *EVP_PKEY_CTX_get0_peerkey(EVP_PKEY_CTX *ctx);
 void EVP_PKEY_CTX_set_app_data(EVP_PKEY_CTX *ctx, void *data);
 void *EVP_PKEY_CTX_get_app_data(EVP_PKEY_CTX *ctx);
 
+void EVP_SIGNATURE_free(EVP_SIGNATURE *signature);
+int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature);
+OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature);
+EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+                                   const char *properties);
+
+int EVP_PKEY_sign_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
 int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
                   unsigned char *sig, size_t *siglen,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1337,6 +1337,8 @@ void EVP_PKEY_asn1_set_security_bits(EVP_PKEY_ASN1_METHOD *ameth,
                                      int (*pkey_security_bits) (const EVP_PKEY
                                                                 *pk));
 
+int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+
 # define EVP_PKEY_OP_UNDEFINED           0
 # define EVP_PKEY_OP_PARAMGEN            (1<<1)
 # define EVP_PKEY_OP_KEYGEN              (1<<2)
@@ -1361,10 +1363,6 @@ void EVP_PKEY_asn1_set_security_bits(EVP_PKEY_ASN1_METHOD *ameth,
 
 # define EVP_PKEY_OP_TYPE_GEN \
                 (EVP_PKEY_OP_PARAMGEN | EVP_PKEY_OP_KEYGEN)
-
-# define  EVP_PKEY_CTX_set_signature_md(ctx, md) \
-                EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_TYPE_SIG,  \
-                                        EVP_PKEY_CTRL_MD, 0, (void *)(md))
 
 # define  EVP_PKEY_CTX_get_signature_md(ctx, pmd)        \
                 EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_TYPE_SIG,  \

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1479,10 +1479,12 @@ int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
                   unsigned char *sig, size_t *siglen,
                   const unsigned char *tbs, size_t tbslen);
+int EVP_PKEY_verify_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
 int EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
                     const unsigned char *sig, size_t siglen,
                     const unsigned char *tbs, size_t tbslen);
+int EVP_PKEY_verify_recover_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
 int EVP_PKEY_verify_recover_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
                             unsigned char *rout, size_t *routlen,

--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -108,6 +108,8 @@ typedef struct evp_kdf_ctx_st EVP_KDF_CTX;
 
 typedef struct evp_keyexch_st EVP_KEYEXCH;
 
+typedef struct evp_signature_st EVP_SIGNATURE;
+
 typedef struct evp_Encode_Ctx_st EVP_ENCODE_CTX;
 
 typedef struct hmac_ctx_st HMAC_CTX;

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,4 +1,4 @@
-SUBDIRS=digests ciphers macs exchange keymgmt
+SUBDIRS=digests ciphers macs exchange keymgmt signature
 
 SOURCE[../../libcrypto]=\
         provider_err.c provlib.c

--- a/providers/common/exchange/dh_exch.c
+++ b/providers/common/exchange/dh_exch.c
@@ -20,6 +20,8 @@ static OSSL_OP_keyexch_set_peer_fn dh_set_peer;
 static OSSL_OP_keyexch_derive_fn dh_derive;
 static OSSL_OP_keyexch_freectx_fn dh_freectx;
 static OSSL_OP_keyexch_dupctx_fn dh_dupctx;
+static OSSL_OP_keyexch_set_ctx_params_fn dh_set_ctx_params;
+static OSSL_OP_keyexch_settable_ctx_params_fn dh_settable_ctx_params;
 
 /*
  * What's passed as an actual key is defined by the KEYMGMT interface.
@@ -124,7 +126,7 @@ static void *dh_dupctx(void *vpdhctx)
     return dstctx;
 }
 
-static int dh_set_params(void *vpdhctx, const OSSL_PARAM params[])
+static int dh_set_ctx_params(void *vpdhctx, const OSSL_PARAM params[])
 {
     PROV_DH_CTX *pdhctx = (PROV_DH_CTX *)vpdhctx;
     const OSSL_PARAM *p;
@@ -140,6 +142,16 @@ static int dh_set_params(void *vpdhctx, const OSSL_PARAM params[])
     return 1;
 }
 
+static const OSSL_PARAM known_settable_ctx_params[] = {
+    OSSL_PARAM_int(OSSL_EXCHANGE_PARAM_PAD, NULL),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *dh_settable_ctx_params(void)
+{
+    return known_settable_ctx_params;
+}
+
 const OSSL_DISPATCH dh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))dh_newctx },
     { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))dh_init },
@@ -147,6 +159,8 @@ const OSSL_DISPATCH dh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))dh_set_peer },
     { OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))dh_freectx },
     { OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))dh_dupctx },
-    { OSSL_FUNC_KEYEXCH_SET_PARAMS, (void (*)(void))dh_set_params },
+    { OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS, (void (*)(void))dh_set_ctx_params },
+    { OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS,
+      (void (*)(void))dh_settable_ctx_params },
     { 0, NULL }
 };

--- a/providers/common/include/internal/provider_algs.h
+++ b/providers/common/include/internal/provider_algs.h
@@ -146,6 +146,10 @@ extern const OSSL_DISPATCH tdes_wrap_cbc_functions[];
 
 /* Key management */
 extern const OSSL_DISPATCH dh_keymgmt_functions[];
+extern const OSSL_DISPATCH dsa_keymgmt_functions[];
 
 /* Key Exchange */
 extern const OSSL_DISPATCH dh_keyexch_functions[];
+
+/* Signature */
+extern const OSSL_DISPATCH dsa_signature_functions[];

--- a/providers/common/keymgmt/dh_kmgmt.c
+++ b/providers/common/keymgmt/dh_kmgmt.c
@@ -24,8 +24,8 @@ static int params_to_key(DH *dh, const OSSL_PARAM params[])
     if (dh == NULL)
         return 0;
 
-    param_p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_P);
-    param_g = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_G);
+    param_p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_P);
+    param_g = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_G);
     param_priv_key =
         OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_PRIV_KEY);
     param_pub_key =

--- a/providers/common/keymgmt/dsa_kmgmt.c
+++ b/providers/common/keymgmt/dsa_kmgmt.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
+#include <openssl/bn.h>
+#include <openssl/dsa.h>
+#include <openssl/params.h>
+#include "internal/provider_algs.h"
+
+static OSSL_OP_keymgmt_importkey_fn dsa_importkey;
+
+static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *param_p, *param_q, *param_g, *param_priv_key;
+    const OSSL_PARAM *param_pub_key;
+    BIGNUM *p = NULL, *q = NULL, *g = NULL, *priv_key = NULL, *pub_key = NULL;
+
+    if (dsa == NULL)
+        return 0;
+
+    param_p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_P);
+    param_q = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_Q);
+    param_g = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_G);
+    param_priv_key =
+        OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DSA_PRIV_KEY);
+    param_pub_key =
+        OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DSA_PUB_KEY);
+
+    /*
+     * DSA documentation says that a public key must be present if a private key
+     * is.
+     */
+    if (param_priv_key != NULL && param_pub_key == NULL)
+        return 0;
+
+    if ((param_p != NULL && !OSSL_PARAM_get_BN(param_p, &p))
+        || (param_q != NULL && !OSSL_PARAM_get_BN(param_q, &q))
+        || (param_g != NULL && !OSSL_PARAM_get_BN(param_g, &g))
+        || (param_priv_key != NULL
+            && !OSSL_PARAM_get_BN(param_priv_key, &priv_key))
+        || (param_pub_key != NULL
+            && !OSSL_PARAM_get_BN(param_pub_key, &pub_key)))
+        goto err;
+
+    if (!DSA_set0_pqg(dsa, p, q, g))
+        goto err;
+    p = q = g = NULL;
+
+    if (pub_key != NULL && !DSA_set0_key(dsa, pub_key, priv_key))
+        goto err;
+    priv_key = pub_key = NULL;
+
+    return 1;
+
+ err:
+    BN_free(p);
+    BN_free(q);
+    BN_free(g);
+    BN_free(priv_key);
+    BN_free(pub_key);
+    return 0;
+}
+
+static void *dsa_importkey(void *provctx, const OSSL_PARAM params[])
+{
+    DSA *dsa;
+
+    if ((dsa = DSA_new()) == NULL
+        || !params_to_key(dsa, params)) {
+        DSA_free(dsa);
+        dsa = NULL;
+    }
+    return dsa;
+}
+
+const OSSL_DISPATCH dsa_keymgmt_functions[] = {
+    /*
+     * TODO(3.0) When implementing OSSL_FUNC_KEYMGMT_GENKEY, remember to also
+     * implement OSSL_FUNC_KEYMGMT_EXPORTKEY.
+     */
+    { OSSL_FUNC_KEYMGMT_IMPORTKEY, (void (*)(void))dsa_importkey },
+    { OSSL_FUNC_KEYMGMT_FREEKEY, (void (*)(void))DSA_free },
+    { 0, NULL }
+};

--- a/providers/common/signature/build.info
+++ b/providers/common/signature/build.info
@@ -1,5 +1,7 @@
 LIBS=../../../libcrypto
-IF[{- !$disabled{dh} -}]
+IF[{- !$disabled{dsa} -}]
   SOURCE[../../../libcrypto]=\
-          dh_kmgmt.c dsa_kmgmt.c
+          dsa.c
 ENDIF
+
+

--- a/providers/common/signature/dsa.c
+++ b/providers/common/signature/dsa.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>
+#include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
+#include <openssl/dsa.h>
+#include <openssl/params.h>
+#include "internal/provider_algs.h"
+
+static OSSL_OP_signature_newctx_fn dsa_newctx;
+static OSSL_OP_signature_sign_init_fn dsa_sign_init;
+static OSSL_OP_signature_sign_fn dsa_sign;
+static OSSL_OP_signature_freectx_fn dsa_freectx;
+static OSSL_OP_signature_dupctx_fn dsa_dupctx;
+static OSSL_OP_signature_set_params_fn dsa_set_params;
+
+/*
+ * What's passed as an actual key is defined by the KEYMGMT interface.
+ * We happen to know that our KEYMGMT simply passes DSA structures, so
+ * we use that here too.
+ */
+
+typedef struct {
+    DSA *dsa;
+    size_t mdsize;
+} PROV_DSA_CTX;
+
+static void *dsa_newctx(void *provctx)
+{
+    return OPENSSL_zalloc(sizeof(PROV_DSA_CTX));
+}
+
+static int dsa_sign_init(void *vpdsactx, void *vdsa)
+{
+    PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
+
+    if (pdsactx == NULL || vdsa == NULL || !DSA_up_ref(vdsa))
+        return 0;
+    DSA_free(pdsactx->dsa);
+    pdsactx->dsa = vdsa;
+    return 1;
+}
+
+static int dsa_sign(void *vpdsactx, unsigned char *sig, size_t *siglen,
+                    size_t sigsize, const unsigned char *tbs, size_t tbslen)
+{
+    PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
+    int ret;
+    unsigned int sltmp;
+    size_t dsasize = DSA_size(pdsactx->dsa);
+
+    if (sig == NULL) {
+        *siglen = dsasize;
+        return 1;
+    }
+
+    if (sigsize < (size_t)dsasize)
+        return 0;
+
+    if (pdsactx->mdsize != 0 && tbslen != pdsactx->mdsize)
+        return 0;
+
+    ret = DSA_sign(0, tbs, tbslen, sig, &sltmp, pdsactx-> dsa);
+
+    if (ret <= 0)
+        return 0;
+
+    *siglen = sltmp;
+    return 1;
+}
+
+static void dsa_freectx(void *vpdsactx)
+{
+    PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
+
+    DSA_free(pdsactx->dsa);
+
+    OPENSSL_free(pdsactx);
+}
+
+static void *dsa_dupctx(void *vpdsactx)
+{
+    PROV_DSA_CTX *srcctx = (PROV_DSA_CTX *)vpdsactx;
+    PROV_DSA_CTX *dstctx;
+
+    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    if (dstctx == NULL)
+        return NULL;
+
+    *dstctx = *srcctx;
+    if (dstctx->dsa != NULL && !DSA_up_ref(dstctx->dsa)) {
+        OPENSSL_free(dstctx);
+        return NULL;
+    }
+
+    return dstctx;
+}
+
+static int dsa_set_params(void *vpdsactx, const OSSL_PARAM params[])
+{
+    PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
+    const OSSL_PARAM *p;
+    size_t mdsize;
+
+    if (pdsactx == NULL || params == NULL)
+        return 0;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST_SIZE);
+    if (p == NULL || !OSSL_PARAM_get_size_t(p, &mdsize))
+        return 0;
+
+    pdsactx->mdsize = mdsize;
+
+    return 1;
+}
+
+const OSSL_DISPATCH dsa_signature_functions[] = {
+    { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))dsa_newctx },
+    { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))dsa_sign_init },
+    { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))dsa_sign },
+    { OSSL_FUNC_SIGNATURE_FREECTX, (void (*)(void))dsa_freectx },
+    { OSSL_FUNC_SIGNATURE_DUPCTX, (void (*)(void))dsa_dupctx },
+    { OSSL_FUNC_SIGNATURE_SET_PARAMS, (void (*)(void))dsa_set_params },
+    { 0, NULL }
+};

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -218,9 +218,20 @@ static const OSSL_ALGORITHM deflt_keyexch[] = {
     { NULL, NULL, NULL }
 };
 
+static const OSSL_ALGORITHM deflt_signature[] = {
+#ifndef OPENSSL_NO_DSA
+    { "DSA", "default=yes", dsa_signature_functions },
+#endif
+    { NULL, NULL, NULL }
+};
+
+
 static const OSSL_ALGORITHM deflt_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
     { "dhKeyAgreement", "default=yes", dh_keymgmt_functions },
+#endif
+#ifndef OPENSSL_NO_DSA
+    { "DSA", "default=yes", dsa_keymgmt_functions },
 #endif
     { NULL, NULL, NULL }
 };
@@ -241,6 +252,8 @@ static const OSSL_ALGORITHM *deflt_query(OSSL_PROVIDER *prov,
         return deflt_keymgmt;
     case OSSL_OP_KEYEXCH:
         return deflt_keyexch;
+    case OSSL_OP_SIGNATURE:
+        return deflt_signature;
     }
     return NULL;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -20,6 +20,7 @@
 #include <openssl/kdf.h>
 #include <openssl/provider.h>
 #include <openssl/core_names.h>
+#include <openssl/dsa.h>
 #include "testutil.h"
 #include "internal/nelem.h"
 #include "internal/evp_int.h"

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4739,3 +4739,4 @@ EVP_SIGNATURE_up_ref                    4848	3_0_0	EXIST::FUNCTION:
 EVP_SIGNATURE_provider                  4849	3_0_0	EXIST::FUNCTION:
 EVP_SIGNATURE_fetch                     4850	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_sign_init_ex                   4851	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_set_signature_md           4852	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4734,3 +4734,8 @@ EVP_MAC_provider                        4843	3_0_0	EXIST::FUNCTION:
 EVP_MAC_do_all_ex                       4844	3_0_0	EXIST::FUNCTION:
 EVP_MD_free                             4845	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_free                         4846	3_0_0	EXIST::FUNCTION:
+EVP_SIGNATURE_free                      4847	3_0_0	EXIST::FUNCTION:
+EVP_SIGNATURE_up_ref                    4848	3_0_0	EXIST::FUNCTION:
+EVP_SIGNATURE_provider                  4849	3_0_0	EXIST::FUNCTION:
+EVP_SIGNATURE_fetch                     4850	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_sign_init_ex                   4851	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4740,3 +4740,5 @@ EVP_SIGNATURE_provider                  4849	3_0_0	EXIST::FUNCTION:
 EVP_SIGNATURE_fetch                     4850	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_sign_init_ex                   4851	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_signature_md           4852	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_verify_init_ex                 4853	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_verify_recover_init_ex         4854	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4742,3 +4742,7 @@ EVP_PKEY_sign_init_ex                   4851	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_signature_md           4852	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_verify_init_ex                 4853	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_verify_recover_init_ex         4854	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_get_signature_md           4855	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_get_params                 4856	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_gettable_params            4857	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_settable_params            4858	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This makes EVP_PKEY_sign and EVP_PKEY_sign_init provider aware. It
also introduces the new type EVP_SIGNATURE to represent signature
algorithms. This also automatically makes the EVP_Sign* APIs provider
aware because they use EVP_Digest* (which is already provider aware)
and EVP_PKEY_sign(_init) under the covers.

I've not yet attempted to untangle the logic in EVP_DigestSign*. That will need to be a different PR.

Finally I've moved DSA handing into the default provider