### PR TITLE
test/errtest.c: more conditions for checking __FILE__ and __LINE__

### DIFF
--- a/test/errtest.c
+++ b/test/errtest.c
@@ -44,13 +44,17 @@ static int vdata_appends(void)
     return TEST_str_eq(data, "hello world");
 }
 
-/* Test that setting a platform error sets the right values. */
-static int platform_error(void)
+static int raised_error(void)
 {
     const char *f, *data;
     int l;
     unsigned long e;
-#ifndef OPENSSL_NO_FILENAMES
+
+    /*
+     * When OPENSSL_NO_ERR or OPENSSL_NO_FILENAMES, no file name or line
+     * number is saved, so no point checking them.
+     */
+#if !defined(OPENSSL_NO_FILENAMES) && !defined(OPENSSL_NO_ERR)
     const char *file;
     int line;
 
@@ -61,7 +65,7 @@ static int platform_error(void)
                    "calling exit()");
     if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
-#ifndef OPENSSL_NO_FILENAMES
+#if !defined(OPENSSL_NO_FILENAMES) && !defined(OPENSSL_NO_ERR)
             || !TEST_int_eq(l, line)
             || !TEST_str_eq(f, file)
 #endif
@@ -74,6 +78,6 @@ int setup_tests(void)
 {
     ADD_TEST(preserves_system_error);
     ADD_TEST(vdata_appends);
-    ADD_TEST(platform_error);
+    ADD_TEST(raised_error);
     return 1;
 }


### PR DESCRIPTION
When at least one of `OPENSSL_NO_ERR` or `OPENSSL_NO_FILENAMES` is
defined, `__FILE__` and `__LINE__` are not saved with the error record.
This test only checked `OPENSSL_NO_FILENAMES`.  Now fixed.
