### PR TITLE
OSSL_PARAM_construct_utf8_string computes the string length.

### DIFF
--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -208,7 +208,7 @@ int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,
 
     macparams[0] =
         OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                         (char *)mdname, strlen(mdname) + 1);
+                                         (char *)mdname, 0);
     macparams[1] =
         OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, basekey, bklen);
     if ((mac = EVP_MAC_fetch(NULL, "HMAC", NULL)) == NULL

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -345,14 +345,12 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
     if (engine_id != NULL)
         params[paramsn++] =
             OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                             (char *)engine_id,
-                                             strlen(engine_id) + 1);
+                                             (char *)engine_id, 0);
 # endif
 
     params[paramsn++] =
         OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
-                                         (char *)cipher_name,
-                                         strlen(cipher_name) + 1);
+                                         (char *)cipher_name, 0);
     params[paramsn++] =
         OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
                                           (char *)priv, len);

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -279,13 +279,11 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                                     engineid,
-                                                     strlen(engineid) + 1);
+                                                     engineid, 0);
 #endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
-                                                     ciphname,
-                                                     strlen(ciphname) + 1);
+                                                     ciphname, 0);
                 params[params_n] = OSSL_PARAM_construct_end();
 
                 if (!EVP_MAC_CTX_set_params(hctx->ctx, params)
@@ -403,17 +401,14 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                     ? NULL : (char *)ENGINE_get_id(ctx->engine);
 
                 if (engineid != NULL) {
-                    size_t engineid_l = strlen(engineid) + 1;
                     params[params_n++] =
                         OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                                         engineid,
-                                                         engineid_l);
+                                                         engineid, 0);
                 }
 #endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                                     mdname,
-                                                     strlen(mdname) + 1);
+                                                     mdname, 0);
                 params[params_n++] =
                     OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
                                                       key->data, key->length);

--- a/crypto/kdf/sskdf.c
+++ b/crypto/kdf/sskdf.c
@@ -223,8 +223,7 @@ static int SSKDF_mac_kdm(EVP_MAC *kdf_mac, const EVP_MD *hmac_md,
         const char *mdname = EVP_MD_name(hmac_md);
         params[params_n++] =
             OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                             (char *)mdname,
-                                             strlen(mdname) + 1);
+                                             (char *)mdname, 0);
     }
     params[params_n++] =
         OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (void *)salt,

--- a/crypto/kdf/tls1_prf.c
+++ b/crypto/kdf/tls1_prf.c
@@ -252,8 +252,7 @@ static int tls1_prf_P_hash(const EVP_MD *md,
     mac_flags = EVP_MD_CTX_FLAG_NON_FIPS_ALLOW;
     params[0] = OSSL_PARAM_construct_int(OSSL_MAC_PARAM_FLAGS, &mac_flags);
     params[1] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                                 (char *)mdname,
-                                                 strlen(mdname) + 1);
+                                                 (char *)mdname, 0);
     params[2] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
                                                   (void *)sec, sec_len);
     params[3] = OSSL_PARAM_construct_end();

--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -173,8 +173,7 @@ int CRYPTO_siv128_init(SIV128_CONTEXT *ctx, const unsigned char *key, int klen,
     const char *cbc_name = EVP_CIPHER_name(cbc);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
-                                                 (char *)cbc_name,
-                                                 strlen(cbc_name) + 1);
+                                                 (char *)cbc_name, 0);
     params[1] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
                                                   (void *)key, klen);
     params[2] = OSSL_PARAM_construct_end();

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -808,6 +808,8 @@ int OSSL_PARAM_set_octet_string(OSSL_PARAM *p, const void *val,
 OSSL_PARAM OSSL_PARAM_construct_utf8_string(const char *key, char *buf,
                                             size_t bsize)
 {
+    if (buf != NULL && bsize == 0)
+        bsize = strlen(buf) + 1;
     return ossl_param_construct(key, OSSL_PARAM_UTF8_STRING, buf, bsize);
 }
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -305,12 +305,10 @@ EVP_MAC_do_all_ex() returns nothing at all.
 
       if (cipher != NULL)
           params[params_n++] =
-              OSSL_PARAM_construct_utf8_string("cipher", cipher,
-                                               strlen(cipher) + 1, NULL);
+              OSSL_PARAM_construct_utf8_string("cipher", cipher, 0, NULL);
       if (digest != NULL)
           params[params_n++] =
-              OSSL_PARAM_construct_utf8_string("digest", digest,
-                                               strlen(digest) + 1, NULL);
+              OSSL_PARAM_construct_utf8_string("digest", digest, 0, NULL);
       params[params_n++] =
           OSSL_PARAM_construct_octet_string("key", key, strlen(key), NULL);
       params[params_n] = OSSL_PARAM_construct_end();

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -166,23 +166,22 @@ size B<rsize> is created.
 
 OSSL_PARAM_construct_utf8_string() is a function that constructs a UTF8
 string OSSL_PARAM structure.
-A parameter with name B<key>, storage B<buf>, size B<bsize> and return
-size B<rsize> is created.
+A parameter with name B<key>, storage B<buf> and size B<bsize> is created.
+If B<bsize> is zero, the string length is determined using strlen(3).
 
 OSSL_PARAM_construct_octet_string() is a function that constructs an OCTET
 string OSSL_PARAM structure.
-A parameter with name B<key>, storage B<buf>, size B<bsize> and return
-size B<rsize> is created.
+A parameter with name B<key>, storage B<buf> and size B<bsize> is created.
 
 OSSL_PARAM_construct_utf8_ptr() is a function that constructes a UTF string
 pointer OSSL_PARAM structure.
-A parameter with name B<key>, storage pointer B<*buf>, size B<bsize> and
-return size B<rsize> is created.
+A parameter with name B<key>, storage pointer B<*buf> and size B<bsize>
+is created.
 
 OSSL_PARAM_construct_octet_ptr() is a function that constructes an OCTET string
 pointer OSSL_PARAM structure.
-A parameter with name B<key>, storage pointer B<*buf>, size B<bsize> and
-return size B<rsize> is created.
+A parameter with name B<key>, storage pointer B<*buf> and size B<bsize>
+is created.
 
 OSSL_PARAM_construct_end() is a function that constructs the terminating
 OSSL_PARAM structure.

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1173,14 +1173,12 @@ static int mac_test_run_mac(EVP_TEST *t)
                                     OSSL_MAC_PARAM_CIPHER) != NULL) {
             params[params_n++] =
                 OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
-                                                 expected->alg,
-                                                 strlen(expected->alg) + 1);
+                                                 expected->alg, 0);
         } else if (OSSL_PARAM_locate_const(defined_params,
                                            OSSL_MAC_PARAM_DIGEST) != NULL) {
             params[params_n++] =
                 OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
-                                                 expected->alg,
-                                                 strlen(expected->alg) + 1);
+                                                 expected->alg, 0);
         } else {
             t->err = "MAC_BAD_PARAMS";
             goto err;


### PR DESCRIPTION
If the passed string length is zero, the function computes the string length
from the passed string.


- [x] documentation is added or updated
- [x] tests are added or updated
