### PR TITLE
Disallow overwriting md_size if already set

### DIFF
--- a/crypto/evp/cmeth_lib.c
+++ b/crypto/evp/cmeth_lib.c
@@ -54,18 +54,27 @@ void EVP_CIPHER_meth_free(EVP_CIPHER *cipher)
 
 int EVP_CIPHER_meth_set_iv_length(EVP_CIPHER *cipher, int iv_len)
 {
+    if (cipher->iv_len != 0)
+        return 0;
+
     cipher->iv_len = iv_len;
     return 1;
 }
 
 int EVP_CIPHER_meth_set_flags(EVP_CIPHER *cipher, unsigned long flags)
 {
+    if (cipher->flags != 0)
+        return 0;
+
     cipher->flags = flags;
     return 1;
 }
 
 int EVP_CIPHER_meth_set_impl_ctx_size(EVP_CIPHER *cipher, int ctx_size)
 {
+    if (cipher->ctx_size != 0)
+        return 0;
+
     cipher->ctx_size = ctx_size;
     return 1;
 }
@@ -76,6 +85,9 @@ int EVP_CIPHER_meth_set_init(EVP_CIPHER *cipher,
                                           const unsigned char *iv,
                                           int enc))
 {
+    if (cipher->init != NULL)
+        return 0;
+
     cipher->init = init;
     return 1;
 }
@@ -86,6 +98,9 @@ int EVP_CIPHER_meth_set_do_cipher(EVP_CIPHER *cipher,
                                                     const unsigned char *in,
                                                     size_t inl))
 {
+    if (cipher->do_cipher != NULL)
+        return 0;
+
     cipher->do_cipher = do_cipher;
     return 1;
 }
@@ -93,6 +108,9 @@ int EVP_CIPHER_meth_set_do_cipher(EVP_CIPHER *cipher,
 int EVP_CIPHER_meth_set_cleanup(EVP_CIPHER *cipher,
                                 int (*cleanup) (EVP_CIPHER_CTX *))
 {
+    if (cipher->cleanup != NULL)
+        return 0;
+
     cipher->cleanup = cleanup;
     return 1;
 }
@@ -101,6 +119,9 @@ int EVP_CIPHER_meth_set_set_asn1_params(EVP_CIPHER *cipher,
                                         int (*set_asn1_parameters) (EVP_CIPHER_CTX *,
                                                                     ASN1_TYPE *))
 {
+    if (cipher->set_asn1_parameters != NULL)
+        return 0;
+
     cipher->set_asn1_parameters = set_asn1_parameters;
     return 1;
 }
@@ -109,6 +130,9 @@ int EVP_CIPHER_meth_set_get_asn1_params(EVP_CIPHER *cipher,
                                         int (*get_asn1_parameters) (EVP_CIPHER_CTX *,
                                                                     ASN1_TYPE *))
 {
+    if (cipher->get_asn1_parameters != NULL)
+        return 0;
+
     cipher->get_asn1_parameters = get_asn1_parameters;
     return 1;
 }
@@ -117,6 +141,9 @@ int EVP_CIPHER_meth_set_ctrl(EVP_CIPHER *cipher,
                              int (*ctrl) (EVP_CIPHER_CTX *, int type,
                                           int arg, void *ptr))
 {
+    if (cipher->ctrl != NULL)
+        return 0;
+
     cipher->ctrl = ctrl;
     return 1;
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -564,6 +564,9 @@ void EVP_MD_meth_free(EVP_MD *md)
 }
 int EVP_MD_meth_set_input_blocksize(EVP_MD *md, int blocksize)
 {
+    if (md->block_size != 0)
+        return 0;
+
     md->block_size = blocksize;
     return 1;
 }
@@ -577,16 +580,25 @@ int EVP_MD_meth_set_result_size(EVP_MD *md, int resultsize)
 }
 int EVP_MD_meth_set_app_datasize(EVP_MD *md, int datasize)
 {
+    if (md->ctx_size != 0)
+        return 0;
+
     md->ctx_size = datasize;
     return 1;
 }
 int EVP_MD_meth_set_flags(EVP_MD *md, unsigned long flags)
 {
+    if (md->flags != 0)
+        return 0;
+
     md->flags = flags;
     return 1;
 }
 int EVP_MD_meth_set_init(EVP_MD *md, int (*init)(EVP_MD_CTX *ctx))
 {
+    if (md->init != NULL)
+        return 0;
+
     md->init = init;
     return 1;
 }
@@ -594,29 +606,44 @@ int EVP_MD_meth_set_update(EVP_MD *md, int (*update)(EVP_MD_CTX *ctx,
                                                      const void *data,
                                                      size_t count))
 {
+    if (md->update != NULL)
+        return 0;
+
     md->update = update;
     return 1;
 }
 int EVP_MD_meth_set_final(EVP_MD *md, int (*final)(EVP_MD_CTX *ctx,
                                                    unsigned char *md))
 {
+    if (md->final != NULL)
+        return 0;
+
     md->final = final;
     return 1;
 }
 int EVP_MD_meth_set_copy(EVP_MD *md, int (*copy)(EVP_MD_CTX *to,
                                                  const EVP_MD_CTX *from))
 {
+    if (md->copy != NULL)
+        return 0;
+
     md->copy = copy;
     return 1;
 }
 int EVP_MD_meth_set_cleanup(EVP_MD *md, int (*cleanup)(EVP_MD_CTX *ctx))
 {
+    if (md->cleanup != NULL)
+        return 0;
+
     md->cleanup = cleanup;
     return 1;
 }
 int EVP_MD_meth_set_ctrl(EVP_MD *md, int (*ctrl)(EVP_MD_CTX *ctx, int cmd,
                                                  int p1, void *p2))
 {
+    if (md->md_ctrl != NULL)
+        return 0;
+
     md->md_ctrl = ctrl;
     return 1;
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -569,6 +569,9 @@ int EVP_MD_meth_set_input_blocksize(EVP_MD *md, int blocksize)
 }
 int EVP_MD_meth_set_result_size(EVP_MD *md, int resultsize)
 {
+    if (md->md_size != 0)
+        return 0;
+
     md->md_size = resultsize;
     return 1;
 }


### PR DESCRIPTION
If EVP_MD is already initialized, changing the digest size can cause many problems. Let's forbid it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
