### PR TITLE
ERR fixups and additions (fixes #9756)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,19 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Added ERR functionality to give callers access to the stored function
+     names that have replaced the older function code based functions.
+
+     New functions are ERR_get_error_func(), ERR_peek_error_func(),
+     ERR_peek_last_error_func(), ERR_get_error_data(), ERR_peek_error_data(),
+     ERR_peek_last_error_data(), ERR_get_error_all(), ERR_peek_error_all()
+     and ERR_peek_last_error_all().
+
+     These functions have become deprecated: ERR_get_error_line_data(),
+     ERR_peek_error_line_data(), ERR_peek_last_error_line_data() and
+     ERR_func_error_string().
+     [Richard Levitte]
+
   *) Extended testing to be verbose for failing tests only.  The make variables
      VERBOSE_FAILURE or VF can be used to enable this:
 

--- a/crypto/asn1/asn1_err.c
+++ b/crypto/asn1/asn1_err.c
@@ -201,7 +201,7 @@ static const ERR_STRING_DATA ASN1_str_reasons[] = {
 int ERR_load_ASN1_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(ASN1_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(ASN1_str_reasons[0].error) == NULL)
         ERR_load_strings_const(ASN1_str_reasons);
 #endif
     return 1;

--- a/crypto/async/async_err.c
+++ b/crypto/async/async_err.c
@@ -29,7 +29,7 @@ static const ERR_STRING_DATA ASYNC_str_reasons[] = {
 int ERR_load_ASYNC_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(ASYNC_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(ASYNC_str_reasons[0].error) == NULL)
         ERR_load_strings_const(ASYNC_str_reasons);
 #endif
     return 1;

--- a/crypto/bio/bio_err.c
+++ b/crypto/bio/bio_err.c
@@ -76,7 +76,7 @@ static const ERR_STRING_DATA BIO_str_reasons[] = {
 int ERR_load_BIO_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(BIO_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(BIO_str_reasons[0].error) == NULL)
         ERR_load_strings_const(BIO_str_reasons);
 #endif
     return 1;

--- a/crypto/bn/bn_err.c
+++ b/crypto/bn/bn_err.c
@@ -47,7 +47,7 @@ static const ERR_STRING_DATA BN_str_reasons[] = {
 int ERR_load_BN_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(BN_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(BN_str_reasons[0].error) == NULL)
         ERR_load_strings_const(BN_str_reasons);
 #endif
     return 1;

--- a/crypto/buffer/buf_err.c
+++ b/crypto/buffer/buf_err.c
@@ -22,7 +22,7 @@ static const ERR_STRING_DATA BUF_str_reasons[] = {
 int ERR_load_BUF_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(BUF_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(BUF_str_reasons[0].error) == NULL)
         ERR_load_strings_const(BUF_str_reasons);
 #endif
     return 1;

--- a/crypto/cmp/cmp_err.c
+++ b/crypto/cmp/cmp_err.c
@@ -22,7 +22,7 @@ static const ERR_STRING_DATA CMP_str_reasons[] = {
 int ERR_load_CMP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(CMP_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(CMP_str_reasons[0].error) == NULL)
         ERR_load_strings_const(CMP_str_reasons);
 #endif
     return 1;

--- a/crypto/cms/cms_err.c
+++ b/crypto/cms/cms_err.c
@@ -146,7 +146,7 @@ static const ERR_STRING_DATA CMS_str_reasons[] = {
 int ERR_load_CMS_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(CMS_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(CMS_str_reasons[0].error) == NULL)
         ERR_load_strings_const(CMS_str_reasons);
 #endif
     return 1;

--- a/crypto/comp/comp_err.c
+++ b/crypto/comp/comp_err.c
@@ -28,7 +28,7 @@ static const ERR_STRING_DATA COMP_str_reasons[] = {
 int ERR_load_COMP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(COMP_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(COMP_str_reasons[0].error) == NULL)
         ERR_load_strings_const(COMP_str_reasons);
 #endif
     return 1;

--- a/crypto/conf/conf_err.c
+++ b/crypto/conf/conf_err.c
@@ -58,7 +58,7 @@ static const ERR_STRING_DATA CONF_str_reasons[] = {
 int ERR_load_CONF_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(CONF_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(CONF_str_reasons[0].error) == NULL)
         ERR_load_strings_const(CONF_str_reasons);
 #endif
     return 1;

--- a/crypto/cpt_err.c
+++ b/crypto/cpt_err.c
@@ -52,7 +52,7 @@ static const ERR_STRING_DATA CRYPTO_str_reasons[] = {
 int ERR_load_CRYPTO_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(CRYPTO_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(CRYPTO_str_reasons[0].error) == NULL)
         ERR_load_strings_const(CRYPTO_str_reasons);
 #endif
     return 1;

--- a/crypto/crmf/crmf_err.c
+++ b/crypto/crmf/crmf_err.c
@@ -54,7 +54,7 @@ static const ERR_STRING_DATA CRMF_str_reasons[] = {
 int ERR_load_CRMF_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(CRMF_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(CRMF_str_reasons[0].error) == NULL)
         ERR_load_strings_const(CRMF_str_reasons);
 #endif
     return 1;

--- a/crypto/ct/ct_err.c
+++ b/crypto/ct/ct_err.c
@@ -48,7 +48,7 @@ static const ERR_STRING_DATA CT_str_reasons[] = {
 int ERR_load_CT_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(CT_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(CT_str_reasons[0].error) == NULL)
         ERR_load_strings_const(CT_str_reasons);
 #endif
     return 1;

--- a/crypto/dh/dh_err.c
+++ b/crypto/dh/dh_err.c
@@ -60,7 +60,7 @@ static const ERR_STRING_DATA DH_str_reasons[] = {
 int ERR_load_DH_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(DH_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(DH_str_reasons[0].error) == NULL)
         ERR_load_strings_const(DH_str_reasons);
 #endif
     return 1;

--- a/crypto/dsa/dsa_err.c
+++ b/crypto/dsa/dsa_err.c
@@ -39,7 +39,7 @@ static const ERR_STRING_DATA DSA_str_reasons[] = {
 int ERR_load_DSA_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(DSA_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(DSA_str_reasons[0].error) == NULL)
         ERR_load_strings_const(DSA_str_reasons);
 #endif
     return 1;

--- a/crypto/dso/dso_err.c
+++ b/crypto/dso/dso_err.c
@@ -49,7 +49,7 @@ static const ERR_STRING_DATA DSO_str_reasons[] = {
 int ERR_load_DSO_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(DSO_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(DSO_str_reasons[0].error) == NULL)
         ERR_load_strings_const(DSO_str_reasons);
 #endif
     return 1;

--- a/crypto/ec/ec_err.c
+++ b/crypto/ec/ec_err.c
@@ -112,7 +112,7 @@ static const ERR_STRING_DATA EC_str_reasons[] = {
 int ERR_load_EC_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(EC_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(EC_str_reasons[0].error) == NULL)
         ERR_load_strings_const(EC_str_reasons);
 #endif
     return 1;

--- a/crypto/engine/eng_err.c
+++ b/crypto/engine/eng_err.c
@@ -81,7 +81,7 @@ static const ERR_STRING_DATA ENGINE_str_reasons[] = {
 int ERR_load_ENGINE_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(ENGINE_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(ENGINE_str_reasons[0].error) == NULL)
         ERR_load_strings_const(ENGINE_str_reasons);
 #endif
     return 1;

--- a/crypto/ess/ess_err.c
+++ b/crypto/ess/ess_err.c
@@ -28,7 +28,7 @@ static const ERR_STRING_DATA ESS_str_reasons[] = {
 int ERR_load_ESS_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(ESS_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(ESS_str_reasons[0].error) == NULL)
         ERR_load_strings_const(ESS_str_reasons);
 #endif
     return 1;

--- a/crypto/evp/evp_err.c
+++ b/crypto/evp/evp_err.c
@@ -161,7 +161,7 @@ static const ERR_STRING_DATA EVP_str_reasons[] = {
 int ERR_load_EVP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(EVP_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(EVP_str_reasons[0].error) == NULL)
         ERR_load_strings_const(EVP_str_reasons);
 #endif
     return 1;

--- a/crypto/objects/obj_err.c
+++ b/crypto/objects/obj_err.c
@@ -24,7 +24,7 @@ static const ERR_STRING_DATA OBJ_str_reasons[] = {
 int ERR_load_OBJ_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(OBJ_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(OBJ_str_reasons[0].error) == NULL)
         ERR_load_strings_const(OBJ_str_reasons);
 #endif
     return 1;

--- a/crypto/ocsp/ocsp_err.c
+++ b/crypto/ocsp/ocsp_err.c
@@ -65,7 +65,7 @@ static const ERR_STRING_DATA OCSP_str_reasons[] = {
 int ERR_load_OCSP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(OCSP_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(OCSP_str_reasons[0].error) == NULL)
         ERR_load_strings_const(OCSP_str_reasons);
 #endif
     return 1;

--- a/crypto/pem/pem_err.c
+++ b/crypto/pem/pem_err.c
@@ -60,7 +60,7 @@ static const ERR_STRING_DATA PEM_str_reasons[] = {
 int ERR_load_PEM_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(PEM_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(PEM_str_reasons[0].error) == NULL)
         ERR_load_strings_const(PEM_str_reasons);
 #endif
     return 1;

--- a/crypto/pkcs12/pk12err.c
+++ b/crypto/pkcs12/pk12err.c
@@ -56,7 +56,7 @@ static const ERR_STRING_DATA PKCS12_str_reasons[] = {
 int ERR_load_PKCS12_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(PKCS12_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(PKCS12_str_reasons[0].error) == NULL)
         ERR_load_strings_const(PKCS12_str_reasons);
 #endif
     return 1;

--- a/crypto/pkcs7/pkcs7err.c
+++ b/crypto/pkcs7/pkcs7err.c
@@ -90,7 +90,7 @@ static const ERR_STRING_DATA PKCS7_str_reasons[] = {
 int ERR_load_PKCS7_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(PKCS7_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(PKCS7_str_reasons[0].error) == NULL)
         ERR_load_strings_const(PKCS7_str_reasons);
 #endif
     return 1;

--- a/crypto/property/property_err.c
+++ b/crypto/property/property_err.c
@@ -39,7 +39,7 @@ static const ERR_STRING_DATA PROP_str_reasons[] = {
 int ERR_load_PROP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(PROP_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(PROP_str_reasons[0].error) == NULL)
         ERR_load_strings_const(PROP_str_reasons);
 #endif
     return 1;

--- a/crypto/rand/rand_err.c
+++ b/crypto/rand/rand_err.c
@@ -89,7 +89,7 @@ static const ERR_STRING_DATA RAND_str_reasons[] = {
 int ERR_load_RAND_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(RAND_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(RAND_str_reasons[0].error) == NULL)
         ERR_load_strings_const(RAND_str_reasons);
 #endif
     return 1;

--- a/crypto/rsa/rsa_err.c
+++ b/crypto/rsa/rsa_err.c
@@ -155,7 +155,7 @@ static const ERR_STRING_DATA RSA_str_reasons[] = {
 int ERR_load_RSA_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(RSA_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(RSA_str_reasons[0].error) == NULL)
         ERR_load_strings_const(RSA_str_reasons);
 #endif
     return 1;

--- a/crypto/sm2/sm2_err.c
+++ b/crypto/sm2/sm2_err.c
@@ -36,7 +36,7 @@ static const ERR_STRING_DATA SM2_str_reasons[] = {
 int ERR_load_SM2_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(SM2_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(SM2_str_reasons[0].error) == NULL)
         ERR_load_strings_const(SM2_str_reasons);
 #endif
     return 1;

--- a/crypto/store/store_err.c
+++ b/crypto/store/store_err.c
@@ -62,7 +62,7 @@ static const ERR_STRING_DATA OSSL_STORE_str_reasons[] = {
 int ERR_load_OSSL_STORE_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(OSSL_STORE_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(OSSL_STORE_str_reasons[0].error) == NULL)
         ERR_load_strings_const(OSSL_STORE_str_reasons);
 #endif
     return 1;

--- a/crypto/ts/ts_err.c
+++ b/crypto/ts/ts_err.c
@@ -78,7 +78,7 @@ static const ERR_STRING_DATA TS_str_reasons[] = {
 int ERR_load_TS_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(TS_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(TS_str_reasons[0].error) == NULL)
         ERR_load_strings_const(TS_str_reasons);
 #endif
     return 1;

--- a/crypto/ui/ui_err.c
+++ b/crypto/ui/ui_err.c
@@ -39,7 +39,7 @@ static const ERR_STRING_DATA UI_str_reasons[] = {
 int ERR_load_UI_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(UI_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(UI_str_reasons[0].error) == NULL)
         ERR_load_strings_const(UI_str_reasons);
 #endif
     return 1;

--- a/crypto/x509/v3err.c
+++ b/crypto/x509/v3err.c
@@ -134,7 +134,7 @@ static const ERR_STRING_DATA X509V3_str_reasons[] = {
 int ERR_load_X509V3_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(X509V3_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(X509V3_str_reasons[0].error) == NULL)
         ERR_load_strings_const(X509V3_str_reasons);
 #endif
     return 1;

--- a/crypto/x509/x509_err.c
+++ b/crypto/x509/x509_err.c
@@ -77,7 +77,7 @@ static const ERR_STRING_DATA X509_str_reasons[] = {
 int ERR_load_X509_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(X509_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(X509_str_reasons[0].error) == NULL)
         ERR_load_strings_const(X509_str_reasons);
 #endif
     return 1;

--- a/doc/man3/ERR_error_string.pod
+++ b/doc/man3/ERR_error_string.pod
@@ -14,8 +14,11 @@ error message
  void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 
  const char *ERR_lib_error_string(unsigned long e);
- const char *ERR_func_error_string(unsigned long e);
  const char *ERR_reason_error_string(unsigned long e);
+
+Deprecated in OpenSSL 3.0:
+
+ const char *ERR_func_error_string(unsigned long e);
 
 =head1 DESCRIPTION
 
@@ -33,13 +36,12 @@ For ERR_error_string_n(), I<buf> may not be B<NULL>.
 
 The string will have the following format:
 
- error:[error code]:[library name]:[function name]:[reason string]
+ error:[error code]:[library name]::[reason string]
 
-I<error code> is an 8 digit hexadecimal number, I<library name>,
-I<function name> and I<reason string> are ASCII text.
+I<error code> is an 8 digit hexadecimal number, I<library name> and
+I<reason string> are ASCII text.
 
-ERR_lib_error_string(), ERR_func_error_string() and
-ERR_reason_error_string() return the library name, function
+ERR_lib_error_string() and ERR_reason_error_string() return the library
 name and reason string respectively.
 
 If there is no text string registered for the given error code,
@@ -53,14 +55,19 @@ all error codes currently in the queue.
 ERR_error_string() returns a pointer to a static buffer containing the
 string if I<buf> B<== NULL>, I<buf> otherwise.
 
-ERR_lib_error_string(), ERR_func_error_string() and
-ERR_reason_error_string() return the strings, and B<NULL> if
-none is registered for the error code.
+ERR_lib_error_string() and ERR_reason_error_string() return the strings,
+and B<NULL> if none is registered for the error code.
+
+ERR_func_error_string() returns NULL.
 
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>,
 L<ERR_print_errors(3)>
+
+=head1 HISTORY
+
+ERR_func_error_string() became deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -4,8 +4,11 @@
 
 ERR_get_error, ERR_peek_error, ERR_peek_last_error,
 ERR_get_error_line, ERR_peek_error_line, ERR_peek_last_error_line,
-ERR_get_error_line_data, ERR_peek_error_line_data,
-ERR_peek_last_error_line_data - obtain error code and data
+ERR_get_error_func, ERR_peek_error_func, ERR_peek_last_error_func,
+ERR_get_error_data, ERR_peek_error_data, ERR_peek_last_error_data,
+ERR_get_error_all, ERR_peek_error_all, ERR_peek_last_error_all,
+ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
+- obtain error code and data
 
 =head1 SYNOPSIS
 
@@ -18,6 +21,26 @@ ERR_peek_last_error_line_data - obtain error code and data
  unsigned long ERR_get_error_line(const char **file, int *line);
  unsigned long ERR_peek_error_line(const char **file, int *line);
  unsigned long ERR_peek_last_error_line(const char **file, int *line);
+
+ unsigned long ERR_get_error_func(const char **func);
+ unsigned long ERR_peek_error_func(const char **func);
+ unsigned long ERR_peek_last_error_func(const char **func);
+
+ unsigned long ERR_get_error_data(const char **data, int *flags);
+ unsigned long ERR_peek_error_data(const char **data, int *flags);
+ unsigned long ERR_peek_last_error_data(const char **data, int *flags);
+
+ unsigned long ERR_get_error_all(const char **file, int *line,
+                                 const char *func,
+                                 const char **data, int *flags);
+ unsigned long ERR_peek_error_all(const char **file, int *line,
+                                  const char *func,
+                                  const char **data, int *flags);
+ unsigned long ERR_peek_last_error_all(const char **file, int *line,
+                                       const char *func,
+                                       const char **data, int *flags);
+
+Deprecated since OpenSSL 3.0:
 
  unsigned long ERR_get_error_line_data(const char **file, int *line,
                                        const char **data, int *flags);
@@ -44,15 +67,31 @@ L<ERR_error_string(3)> for human-readable error
 messages.
 
 ERR_get_error_line(), ERR_peek_error_line() and
-ERR_peek_last_error_line() are the same as the above, but they
+ERR_peek_last_error_line() are the same as ERR_get_error(),
+ERR_peek_error() and ERR_peek_last_error(), but they
 additionally store the file name and line number where
 the error occurred in *B<file> and *B<line>, unless these are B<NULL>.
 
+ERR_get_error_func(), ERR_peek_error_func() and
+ERR_peek_last_error_func() are the same as ERR_get_error(),
+ERR_peek_error() and ERR_peek_last_error(), but they
+additionally store the name of the function where the error in *B<func>,
+unless it is B<NULL>.
+
+ERR_get_error_data(), ERR_peek_error_data() and
+ERR_peek_last_error_data() are the same as ERR_get_error(),
+ERR_peek_error() and ERR_peek_last_error(), but they
+additionally store additional data and flags associated with the error
+code in *B<data> and *B<flags>, unless these are B<NULL>.
+*B<data> contains a string if *B<flags>&B<ERR_TXT_STRING> is true.
+
+ERR_get_error_all(), ERR_peek_error_all() and
+ERR_peek_last_error_all() are combinations of all of the above.
+
 ERR_get_error_line_data(), ERR_peek_error_line_data() and
-ERR_peek_last_error_line_data() store additional data and flags
-associated with the error code in *B<data>
-and *B<flags>, unless these are B<NULL>. *B<data> contains a string
-if *B<flags>&B<ERR_TXT_STRING> is true.
+ERR_peek_last_error_line_data() are older variants of ERR_get_error_all(),
+ERR_peek_error_all() and ERR_peek_last_error_all(), and should no longer
+be used.
 
 An application B<MUST NOT> free the *B<data> pointer (or any other pointers
 returned by these functions) with OPENSSL_free() as freeing is handled
@@ -66,6 +105,17 @@ The error code, or 0 if there is no error in the queue.
 
 L<ERR_error_string(3)>,
 L<ERR_GET_LIB(3)>
+
+=head1 HISTORY
+
+ERR_get_error_func(), ERR_peek_error_func(), ERR_peek_last_error_func(),
+ERR_get_error_data(), ERR_peek_error_data(), ERR_peek_last_error_data(),
+ERR_get_error_all(), ERR_peek_error_all() and ERR_peek_last_error_all()
+were added in OpenSSL 3.0.
+
+ERR_get_error_line_data(), ERR_peek_error_line_data() and
+ERR_peek_last_error_line_data() became deprecated in OpenSSL 3.0.
+
 
 =head1 COPYRIGHT
 

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -260,31 +260,64 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
 void ERR_set_error_data(char *data, int flags);
 
 unsigned long ERR_get_error(void);
+/*
+ * TODO(3.0) consider if the following three functions should be deprecated.
+ * They all drop the error record from the error queue, so regardless of which
+ * one is used, the rest of the information is lost, making them not so useful.
+ * The recommendation should be to use the peek functions to extract all the
+ * additional data.
+ */
 unsigned long ERR_get_error_line(const char **file, int *line);
-unsigned long ERR_get_error_line_data(const char **file, int *line,
-                                      const char **data, int *flags);
+unsigned long ERR_get_error_func(const char **func);
+unsigned long ERR_get_error_data(const char **data, int *flags);
+unsigned long ERR_get_error_all(const char **file, int *line,
+                                const char **func,
+                                const char **data, int *flags);
+DEPRECATEDIN_3(unsigned long ERR_get_error_line_data(const char **file,
+                                                     int *line,
+                                                     const char **data,
+                                                     int *flags))
 unsigned long ERR_peek_error(void);
 unsigned long ERR_peek_error_line(const char **file, int *line);
-unsigned long ERR_peek_error_line_data(const char **file, int *line,
-                                       const char **data, int *flags);
+unsigned long ERR_peek_error_func(const char **func);
+unsigned long ERR_peek_error_data(const char **data, int *flags);
+unsigned long ERR_peek_error_all(const char **file, int *line,
+                                 const char **func,
+                                 const char **data, int *flags);
+DEPRECATEDIN_3(unsigned long ERR_peek_error_line_data(const char **file,
+                                                      int *line,
+                                                      const char **data,
+                                                      int *flags))
 unsigned long ERR_peek_last_error(void);
 unsigned long ERR_peek_last_error_line(const char **file, int *line);
-unsigned long ERR_peek_last_error_line_data(const char **file, int *line,
-                                            const char **data, int *flags);
+unsigned long ERR_peek_last_error_func(const char **func);
+unsigned long ERR_peek_last_error_data(const char **data, int *flags);
+unsigned long ERR_peek_last_error_all(const char **file, int *line,
+                                      const char **func,
+                                      const char **data, int *flags);
+DEPRECATEDIN_3(unsigned long ERR_peek_last_error_line_data(const char **file,
+                                                           int *line,
+                                                           const char **data,
+                                                           int *flags))
+
 void ERR_clear_error(void);
+
 char *ERR_error_string(unsigned long e, char *buf);
 void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 const char *ERR_lib_error_string(unsigned long e);
-const char *ERR_func_error_string(unsigned long e);
+DEPRECATEDIN_3(const char *ERR_func_error_string(unsigned long e))
 const char *ERR_reason_error_string(unsigned long e);
+
 void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
                          void *u);
 # ifndef OPENSSL_NO_STDIO
 void ERR_print_errors_fp(FILE *fp);
 # endif
 void ERR_print_errors(BIO *bp);
+
 void ERR_add_error_data(int num, ...);
 void ERR_add_error_vdata(int num, va_list args);
+
 int ERR_load_strings(int lib, ERR_STRING_DATA *str);
 int ERR_load_strings_const(const ERR_STRING_DATA *str);
 int ERR_unload_strings(int lib, ERR_STRING_DATA *str);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 # if !OPENSSL_API_3
-#  ifndef OPENSSL_NO_ERR
+#  ifndef OPENSSL_NO_FILENAMES
 #   define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,fn,ln)
 #  else
 #   define ERR_PUT_error(l,f,r,fn,ln)      ERR_put_error(l,f,r,NULL,0)
@@ -242,28 +242,18 @@ void ERR_set_debug(const char *file, int line, const char *func);
 void ERR_set_error(int lib, int reason, const char *fmt, ...);
 void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
 
-# ifndef OPENSSL_NO_ERR
-#  define ERR_DBG_FILE OPENSSL_FILE
-#  define ERR_DBG_LINE OPENSSL_LINE
-#  define ERR_DBG_FUNC OPENSSL_FUNC
-# else
-#  define ERR_DBG_FILE NULL
-#  define ERR_DBG_LINE 0
-#  define ERR_DBG_FUNC NULL
-# endif
-
 /* Main error raising functions */
 # define ERR_raise(lib, reason) ERR_raise_data((lib),(reason),NULL)
 # define ERR_raise_data                                         \
     (ERR_new(),                                                 \
-     ERR_set_debug(ERR_DBG_FILE,ERR_DBG_LINE,ERR_DBG_FUNC),     \
+     ERR_set_debug(OPENSSL_FILE,OPENSSL_LINE,OPENSSL_FUNC),     \
      ERR_set_error)
 
 # if !OPENSSL_API_3
 /* Backward compatibility */
 #  define ERR_put_error(lib, func, reason, file, line)          \
     (ERR_new(),                                                 \
-     ERR_set_debug((file), (line), NULL),                       \
+     ERR_set_debug((file), (line), OPENSSL_FUNC),               \
      ERR_set_error((lib), (reason), NULL))
 # endif
 

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -134,8 +134,8 @@
 # ifndef OPENSSL_FUNC
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #   define OPENSSL_FUNC __func__
-#  elif defined(__STDC__) && defined(PEDANTIC)
-#   define OPENSSL_FUNC "(PEDANTIC disallows function name)"
+#  elif defined(__STRICT_ANSI__)
+#   define OPENSSL_FUNC "(unknown function)"
 #  elif defined(_MSC_VER) || (defined(__GNUC__) && __GNUC__ >= 2)
 #   define OPENSSL_FUNC __FUNCTION__
 #  elif defined(__FUNCSIG__)

--- a/include/openssl/rsaerr.h
+++ b/include/openssl/rsaerr.h
@@ -142,8 +142,8 @@ int ERR_load_RSA_strings(void);
 # define RSA_R_KEY_PRIME_NUM_INVALID                      165
 # define RSA_R_KEY_SIZE_TOO_SMALL                         120
 # define RSA_R_LAST_OCTET_INVALID                         134
-# define RSA_R_MISSING_PRIVATE_KEY                        179
 # define RSA_R_MGF1_DIGEST_NOT_ALLOWED                    152
+# define RSA_R_MISSING_PRIVATE_KEY                        179
 # define RSA_R_MODULUS_TOO_LARGE                          105
 # define RSA_R_MP_COEFFICIENT_NOT_INVERSE_OF_R            168
 # define RSA_R_MP_EXPONENT_NOT_CONGRUENT_TO_D             169

--- a/providers/common/provider_err.c
+++ b/providers/common/provider_err.c
@@ -91,7 +91,7 @@ static const ERR_STRING_DATA PROV_str_reasons[] = {
 int ERR_load_PROV_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(PROV_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(PROV_str_reasons[0].error) == NULL)
         ERR_load_strings_const(PROV_str_reasons);
 #endif
     return 1;

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -552,7 +552,7 @@ static const ERR_STRING_DATA SSL_str_reasons[] = {
 int ERR_load_SSL_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(SSL_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(SSL_str_reasons[0].error) == NULL)
         ERR_load_strings_const(SSL_str_reasons);
 #endif
     return 1;

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -40,7 +40,7 @@ static int vdata_appends(void)
     CRYPTOerr(0, ERR_R_MALLOC_FAILURE);
     ERR_add_error_data(1, "hello ");
     ERR_add_error_data(1, "world");
-    ERR_get_error_line_data(NULL, NULL, &data, NULL);
+    ERR_peek_error_data(&data, NULL);
     return TEST_str_eq(data, "hello world");
 }
 
@@ -63,7 +63,7 @@ static int raised_error(void)
 #endif
     ERR_raise_data(ERR_LIB_SYS, ERR_R_INTERNAL_ERROR,
                    "calling exit()");
-    if (!TEST_ulong_ne(e = ERR_get_error_line_data(&f, &l, &data, NULL), 0)
+    if (!TEST_ulong_ne(e = ERR_get_error_all(&f, &l, NULL, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)
 #if !defined(OPENSSL_NO_FILENAMES) && !defined(OPENSSL_NO_ERR)
             || !TEST_int_eq(l, line)

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2799,7 +2799,6 @@ static void clear_test(EVP_TEST *t)
 static int check_test_error(EVP_TEST *t)
 {
     unsigned long err;
-    const char *func;
     const char *reason;
 
     if (t->err == NULL && t->expected_err == NULL)
@@ -2842,9 +2841,8 @@ static int check_test_error(EVP_TEST *t)
         return 0;
     }
 
-    func = ERR_func_error_string(err);
     reason = ERR_reason_error_string(err);
-    if (func == NULL && reason == NULL) {
+    if (reason == NULL) {
         TEST_info("%s:%d: Expected error \"%s\", no strings available."
                   " Assuming ok.",
                   t->s.test_file, t->s.start, t->reason);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -515,7 +515,7 @@ DH_generate_parameters                  526	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_0
 BN_set_negative                         527	3_0_0	EXIST::FUNCTION:
 i2d_TS_RESP_bio                         528	3_0_0	EXIST::FUNCTION:TS
 ASYNC_WAIT_CTX_set_wait_fd              529	3_0_0	EXIST::FUNCTION:
-ERR_func_error_string                   530	3_0_0	EXIST::FUNCTION:
+ERR_func_error_string                   530	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 ASN1_STRING_data                        531	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0
 X509_CRL_add1_ext_i2d                   532	3_0_0	EXIST::FUNCTION:
 i2d_TS_TST_INFO                         533	3_0_0	EXIST::FUNCTION:TS
@@ -757,7 +757,7 @@ EVP_rc5_32_12_16_cfb64                  775	3_0_0	EXIST::FUNCTION:RC5
 PKCS7_dataVerify                        776	3_0_0	EXIST::FUNCTION:
 PKCS7_SIGNER_INFO_free                  777	3_0_0	EXIST::FUNCTION:
 PKCS7_add_attrib_smimecap               778	3_0_0	EXIST::FUNCTION:
-ERR_peek_last_error_line_data           779	3_0_0	EXIST::FUNCTION:
+ERR_peek_last_error_line_data           779	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 EVP_PKEY_meth_set_sign                  780	3_0_0	EXIST::FUNCTION:
 ASN1_i2d_bio                            781	3_0_0	EXIST::FUNCTION:
 DSA_verify                              782	3_0_0	EXIST::FUNCTION:DSA
@@ -969,7 +969,7 @@ DH_get_default_method                   993	3_0_0	EXIST::FUNCTION:DH
 PEM_proc_type                           994	3_0_0	EXIST::FUNCTION:
 BIO_printf                              995	3_0_0	EXIST::FUNCTION:
 a2i_IPADDRESS                           996	3_0_0	EXIST::FUNCTION:
-ERR_peek_error_line_data                997	3_0_0	EXIST::FUNCTION:
+ERR_peek_error_line_data                997	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 ERR_unload_strings                      998	3_0_0	EXIST::FUNCTION:
 SEED_cfb128_encrypt                     999	3_0_0	EXIST::FUNCTION:SEED
 ASN1_BIT_STRING_it                      1000	3_0_0	EXIST::FUNCTION:
@@ -1554,7 +1554,7 @@ SRP_VBASE_free                          1588	3_0_0	EXIST::FUNCTION:SRP
 PKCS7_add0_attrib_signing_time          1589	3_0_0	EXIST::FUNCTION:
 X509_STORE_set_flags                    1590	3_0_0	EXIST::FUNCTION:
 UI_get0_output_string                   1591	3_0_0	EXIST::FUNCTION:
-ERR_get_error_line_data                 1592	3_0_0	EXIST::FUNCTION:
+ERR_get_error_line_data                 1592	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 CTLOG_get0_name                         1593	3_0_0	EXIST::FUNCTION:CT
 ASN1_TBOOLEAN_it                        1594	3_0_0	EXIST::FUNCTION:
 RC2_set_key                             1595	3_0_0	EXIST::FUNCTION:RC2
@@ -4753,3 +4753,12 @@ EVP_PKEY_CTX_get_params                 4869	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_gettable_params            4870	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_settable_params            4871	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_tag_length               4872	3_0_0	EXIST::FUNCTION:
+ERR_get_error_func                      4873	3_0_0	EXIST::FUNCTION:
+ERR_get_error_data                      4874	3_0_0	EXIST::FUNCTION:
+ERR_get_error_all                       4875	3_0_0	EXIST::FUNCTION:
+ERR_peek_error_func                     4876	3_0_0	EXIST::FUNCTION:
+ERR_peek_error_data                     4877	3_0_0	EXIST::FUNCTION:
+ERR_peek_error_all                      4878	3_0_0	EXIST::FUNCTION:
+ERR_peek_last_error_func                4879	3_0_0	EXIST::FUNCTION:
+ERR_peek_last_error_data                4880	3_0_0	EXIST::FUNCTION:
+ERR_peek_last_error_all                 4881	3_0_0	EXIST::FUNCTION:

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -607,7 +607,7 @@ EOF
 int ERR_load_${lib}_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
-    if (ERR_func_error_string(${lib}_str_reasons[0].error) == NULL)
+    if (ERR_reason_error_string(${lib}_str_reasons[0].error) == NULL)
         ERR_load_strings_const(${lib}_str_reasons);
 #endif
     return 1;


### PR DESCRIPTION
## `util/mkerr.pl`: make it not depend on the function code

The output C code was made to use `ERR_func_error_string()` to see if a
string table was already loaded or not.  Since this function returns
NULL always, this check became useless.

Change it to use `ERR_reason_error_string()` instead, as there's no
reason to believe we will get rid of reason strings, ever.

To top it off, we rebuild all affected C sources.

## `include/openssl/macros.h`: Remove the `PEDANTIC` `OPENSSL_FUNC` definition

There was a section to define `OPENSSL_FUNC` that depended on `PEDANTIC`
being defined.  That is an internal build macro that should never
appear in a public header.  The solution was simple, just remove that
clause.  There's a constant string fallback at the end anyway.

## `include/openssl/err.h`: Depend on `OPENSSL_NO_FILENAMES`, not `OPENSSL_NO_ERR`

The configuration option `'no-err'` is documented to be used to avoid
loading error related string tables.  For some reason, it was also
used to define if `ERR_PUT_error()` would pass the source file name and
line information or not.

The configuration option `'no-filenames'` is documented to be used to
avoid passing the source file name and line anywhere.  So, the
definition of `ERR_PUT_error()` should depend on `OPENSSL_NO_FILENAMES`
rather than `OPENSSL_NO_ERR`.

Furthermore, the definition of `OPENSSL_FILE` and `OPENSSL_LINE` depends
on if `OPENSSL_NO_FILENAMES` is defined or not, so there was never any
need to do extra macro gymnastics in `include/openssl/err.h`, so we
simply remove it and use `OPENSSL_FILE` and `OPENSSL_LINE` directly.

Finally, the macro `OPENSSL_FUNC` is unaffected by all these
configuration options, so it should be used in all macros that call
`ERR_set_debug()`.

## Modernise the ERR functionality further (new functions and deprecations)

`ERR_func_error_string()` essentially returns NULL, and since all
function codes are now removed for all intents and purposes, this
function has fallen out of use and cannot be modified to suit the
data, since its only function is to interpret an error code.

To compensate for the loss of error code, we instead provide new
functions that extracts the function name strings from an error
record:

- `ERR_get_error_func()`
- `ERR_peek_error_func()`
- `ERR_peek_last_error_func()`

Similarly, the once all encompasing functions
`ERR_peek_last_error_line_data()`, `ERR_peek_error_line_data()` and
`ERR_get_error_line_data()` lack the capability of getting the function
name string, so we deprecate those and add these functions to replace
them:

- `ERR_get_error_all()`
- `ERR_peek_error_all()`
- `ERR_peek_last_error_all()`

Finally, we adjust a few lines of code that used the now deprecated
functions.

## Modernise `ERR_print_errors_cb()`

`ERR_print_errors_cb()` used functionality that isn't suitable any more,
as that functionality couldn't integrate the error record function
name strings.  We therefore refactor it a bit to use better adapted
methods.