### PR TITLE
Fix multiple SCA vulnerabilities during RSA key validation

### DIFF
--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -133,16 +133,12 @@ static int bn_secure_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     int ret;
     BIGNUM *bn;
 
-    if (!*pval) {
-        if (!bn_secure_new(pval, it))
-            return 0;
-    }
+    if (!*pval && !bn_secure_new(pval, it))
+        return 0;
 
     ret = bn_c2i(pval, cont, len, utype, free_cont, it);
-    if (!ret) {
-        bn_free(pval, it);
+    if (!ret)
         return 0;
-    }
 
     /* Set constant-time flag for all secure BIGNUMS */
     bn = (BIGNUM *)*pval;

--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -133,9 +133,17 @@ static int bn_secure_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     int ret;
     BIGNUM *bn;
 
-    if (!*pval)
-        bn_secure_new(pval, it);
+    if (!*pval) {
+        if (!bn_secure_new(pval, it))
+            return 0;
+    }
+
     ret = bn_c2i(pval, cont, len, utype, free_cont, it);
+    if (!ret) {
+        bn_free(pval, it);
+        return 0;
+    }
+
     /* Set constant-time flag for all secure BIGNUMS */
     bn = (BIGNUM *)*pval;
     BN_set_flags(bn, BN_FLG_CONSTTIME);

--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -130,9 +130,16 @@ static int bn_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 static int bn_secure_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
                          int utype, char *free_cont, const ASN1_ITEM *it)
 {
+    int ret;
+    BIGNUM *bn;
+
     if (!*pval)
         bn_secure_new(pval, it);
-    return bn_c2i(pval, cont, len, utype, free_cont, it);
+    ret = bn_c2i(pval, cont, len, utype, free_cont, it);
+    /* Set constant-time flag for all secure BIGNUMS */
+    bn = (BIGNUM *)*pval;
+    BN_set_flags(bn, BN_FLG_CONSTTIME);
+    return ret;
 }
 
 static int bn_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -415,6 +415,9 @@ int RSA_set0_multi_prime_params(RSA *r, BIGNUM *primes[], BIGNUM *exps[],
             pinfo->r = primes[i];
             pinfo->d = exps[i];
             pinfo->t = coeffs[i];
+            BN_set_flags(pinfo->r, BN_FLG_CONSTTIME);
+            BN_set_flags(pinfo->d, BN_FLG_CONSTTIME);
+            BN_set_flags(pinfo->t, BN_FLG_CONSTTIME);
         } else {
             rsa_multip_info_free(pinfo);
             goto err;

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -409,9 +409,9 @@ int RSA_set0_multi_prime_params(RSA *r, BIGNUM *primes[], BIGNUM *exps[],
         if (pinfo == NULL)
             goto err;
         if (primes[i] != NULL && exps[i] != NULL && coeffs[i] != NULL) {
-            BN_free(pinfo->r);
-            BN_free(pinfo->d);
-            BN_free(pinfo->t);
+            BN_clear_free(pinfo->r);
+            BN_clear_free(pinfo->d);
+            BN_clear_free(pinfo->t);
             pinfo->r = primes[i];
             pinfo->d = exps[i];
             pinfo->t = coeffs[i];

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -325,6 +325,7 @@ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
     if (d != NULL) {
         BN_clear_free(r->d);
         r->d = d;
+        BN_set_flags(r->d, BN_FLG_CONSTTIME);
     }
 
     return 1;
@@ -342,10 +343,12 @@ int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
     if (p != NULL) {
         BN_clear_free(r->p);
         r->p = p;
+        BN_set_flags(r->p, BN_FLG_CONSTTIME);
     }
     if (q != NULL) {
         BN_clear_free(r->q);
         r->q = q;
+        BN_set_flags(r->q, BN_FLG_CONSTTIME);
     }
 
     return 1;
@@ -364,14 +367,17 @@ int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp)
     if (dmp1 != NULL) {
         BN_clear_free(r->dmp1);
         r->dmp1 = dmp1;
+        BN_set_flags(r->dmp1, BN_FLG_CONSTTIME);
     }
     if (dmq1 != NULL) {
         BN_clear_free(r->dmq1);
         r->dmq1 = dmq1;
+        BN_set_flags(r->dmq1, BN_FLG_CONSTTIME);
     }
     if (iqmp != NULL) {
         BN_clear_free(r->iqmp);
         r->iqmp = iqmp;
+        BN_set_flags(r->iqmp, BN_FLG_CONSTTIME);
     }
 
     return 1;


### PR DESCRIPTION
This commit addresses multiple side-channel vulnerabilities present during RSA key validation.
Private key parameters are re-computed using variable-time functions.

### Details

An attacker is able to bypass RSA SCA countermeasures via key validation.
Using this method, the code path followed calls several times functions handling
 secret inputs without setting the `BN_FLG_CONSTTIME` and leaking bits of
information on `p` and `q`.

It is possible to trigger this behavior with the following commands:

`openssl rsa -in rsa.key -check`
`openssl pkey -in rsa.key -check`

Check the [paper](http://arxiv.org/abs/1909.01785) more technical information.

This issue affects all OpenSSL versions.

### Acknowledgement

This issue was discovered and reported by the NISEC group at TAU Finland.

