### PR TITLE
Fix multiple SCA vulnerabilities during RSA key validation.

### DIFF
--- a/crypto/rsa/rsa_chk.c
+++ b/crypto/rsa/rsa_chk.c
@@ -63,6 +63,13 @@ int RSA_check_key(const RSA *key)
         return 0;
     }
 
+    /* Set consant-time flag on all private parameters */
+    BN_set_flags(key->p, BN_FLG_CONSTTIME);
+    BN_set_flags(key->q, BN_FLG_CONSTTIME);
+    BN_set_flags(key->d, BN_FLG_CONSTTIME);
+    BN_set_flags(key->dmp1, BN_FLG_CONSTTIME);
+    BN_set_flags(key->dmq1, BN_FLG_CONSTTIME);
+    BN_set_flags(key->iqmp, BN_FLG_CONSTTIME);
     i = BN_new();
     j = BN_new();
     k = BN_new();

--- a/crypto/rsa/rsa_chk.c
+++ b/crypto/rsa/rsa_chk.c
@@ -63,13 +63,10 @@ int RSA_check_key(const RSA *key)
         return 0;
     }
 
-    /* Set consant-time flag on all private parameters */
+    /* Set consant-time flag on private parameters */
     BN_set_flags(key->p, BN_FLG_CONSTTIME);
     BN_set_flags(key->q, BN_FLG_CONSTTIME);
     BN_set_flags(key->d, BN_FLG_CONSTTIME);
-    BN_set_flags(key->dmp1, BN_FLG_CONSTTIME);
-    BN_set_flags(key->dmq1, BN_FLG_CONSTTIME);
-    BN_set_flags(key->iqmp, BN_FLG_CONSTTIME);
     i = BN_new();
     j = BN_new();
     k = BN_new();
@@ -148,6 +145,10 @@ int RSA_check_key(const RSA *key)
     }
 
     if (key->dmp1 != NULL && key->dmq1 != NULL && key->iqmp != NULL) {
+        /* Set consant-time flag on CRT parameters */
+        BN_set_flags(key->dmp1, BN_FLG_CONSTTIME);
+        BN_set_flags(key->dmq1, BN_FLG_CONSTTIME);
+        BN_set_flags(key->iqmp, BN_FLG_CONSTTIME);
         /* dmp1 = d mod (p-1)? */
         if (!BN_sub(i, key->p, BN_value_one())) {
             ret = -1;


### PR DESCRIPTION
Addresses #9779 for branch 1.0.2

## Original report

This commit addresses multiple side-channel vulnerabilities present during RSA key validation.
Private key parameters are re-computed using variable-time functions.

### Details
An attacker is able to bypass RSA SCA countermeasures via key validation.
Using this method, the code path followed calls several times functions handling
secret inputs without setting the `BN_FLG_CONSTTIME` and leaking bits of
information on p and q.

It is possible to trigger this behavior with the following commands:

`openssl rsa -in rsa.key -check`
`openssl pkey -in rsa.key -check`

Check the paper more technical information.

This issue affects all OpenSSL versions.

### Acknowledgement
This issue was discovered and reported by the NISEC group at TAU Finland.