### PR TITLE
Add new NIDs for GOST 28147-89 block cipher

### DIFF
--- a/crypto/objects/obj_mac.num
+++ b/crypto/objects/obj_mac.num
@@ -1192,3 +1192,6 @@ magma_cfb		1191
 magma_mac		1192
 hmacWithSHA512_224		1193
 hmacWithSHA512_256		1194
+gost89-cfb-12		1195
+gost89-cbc-12		1196
+gost89-ecb-12		1197

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -1253,10 +1253,13 @@ cryptopro 19		: gost2001	: GOST R 34.10-2001
 cryptopro 20		: gost94	: GOST R 34.10-94
 !Cname id-Gost28147-89
 cryptopro 21		: gost89 		: GOST 28147-89
+			: gost89-cfb-12
 			: gost89-cnt
 			: gost89-cnt-12
 			: gost89-cbc
+			: gost89-cbc-12
 			: gost89-ecb
+			: gost89-ecb-12
 			: gost89-ctr
 !Cname id-Gost28147-89-MAC
 cryptopro 22		: gost-mac	: GOST 28147-89 MAC

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -3974,6 +3974,9 @@
 #define NID_id_Gost28147_89             813
 #define OBJ_id_Gost28147_89             OBJ_cryptopro,21L
 
+#define SN_gost89_cfb_12                "gost89-cfb-12"
+#define NID_gost89_cfb_12               1195
+
 #define SN_gost89_cnt           "gost89-cnt"
 #define NID_gost89_cnt          814
 
@@ -3983,8 +3986,14 @@
 #define SN_gost89_cbc           "gost89-cbc"
 #define NID_gost89_cbc          1009
 
+#define SN_gost89_cbc_12                "gost89-cbc-12"
+#define NID_gost89_cbc_12               1196
+
 #define SN_gost89_ecb           "gost89-ecb"
 #define NID_gost89_ecb          1010
+
+#define SN_gost89_ecb_12                "gost89-ecb-12"
+#define NID_gost89_ecb_12               1197
 
 #define SN_gost89_ctr           "gost89-ctr"
 #define NID_gost89_ctr          1011


### PR DESCRIPTION
There is an asymmetry in NIDs definition for GOST 28147. NID pairs such
as NID_gost89_cnt and NID_gost89_cnt_12 are used for the same cipher mode
but with different default parameter set. There is a number of cipher modes
which don't have a pair so this commit fixes this.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
