### PR TITLE
Check the modulus bit length

### DIFF
--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -176,7 +176,8 @@ int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key)
 {
     int errflags = 0;
 
-    (void)DH_check(dh, &errflags);
+    if (!DH_check_pub_key(dh, pub_key, &errflags))
+        return 0;
 
     if ((errflags & DH_CHECK_PUBKEY_TOO_SMALL) != 0)
         DHerr(DH_F_DH_CHECK_PUB_KEY_EX, DH_R_CHECK_PUBKEY_TOO_SMALL);

--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -31,6 +31,10 @@ int DH_check_params_ex(const DH *dh)
         DHerr(DH_F_DH_CHECK_PARAMS_EX, DH_R_CHECK_P_NOT_PRIME);
     if ((errflags & DH_NOT_SUITABLE_GENERATOR) != 0)
         DHerr(DH_F_DH_CHECK_PARAMS_EX, DH_R_NOT_SUITABLE_GENERATOR);
+    if ((errflags & DH_MODULUS_TOO_SMALL) != 0)
+        DHerr(DH_F_DH_CHECK_PARAMS_EX, DH_R_MODULUS_TOO_SMALL);
+    if ((errflags & DH_MODULUS_TOO_LARGE) != 0)
+        DHerr(DH_F_DH_CHECK_PARAMS_EX, DH_R_MODULUS_TOO_LARGE);
 
     return errflags == 0;
 }
@@ -58,6 +62,10 @@ int DH_check_params(const DH *dh, int *ret)
         goto err;
     if (BN_cmp(dh->g, tmp) >= 0)
         *ret |= DH_NOT_SUITABLE_GENERATOR;
+    if (BN_num_bits(dh->p) < DH_MIN_MODULUS_BITS)
+        *ret |= DH_MODULUS_TOO_SMALL;
+    if (BN_num_bits(dh->p) > OPENSSL_DH_MAX_MODULUS_BITS)
+        *ret |= DH_MODULUS_TOO_LARGE;
 
     ok = 1;
  err:
@@ -91,6 +99,10 @@ int DH_check_ex(const DH *dh)
         DHerr(DH_F_DH_CHECK_EX, DH_R_CHECK_P_NOT_PRIME);
     if ((errflags & DH_CHECK_P_NOT_SAFE_PRIME) != 0)
         DHerr(DH_F_DH_CHECK_EX, DH_R_CHECK_P_NOT_SAFE_PRIME);
+    if ((errflags & DH_MODULUS_TOO_SMALL) != 0)
+        DHerr(DH_F_DH_CHECK_EX, DH_R_MODULUS_TOO_SMALL);
+    if ((errflags & DH_MODULUS_TOO_LARGE) != 0)
+        DHerr(DH_F_DH_CHECK_EX, DH_R_MODULUS_TOO_LARGE);
 
     return errflags == 0;
 }

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -235,11 +235,11 @@ void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
 int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
 {
     if (pub_key != NULL) {
-        BN_free(dh->pub_key);
+        BN_clear_free(dh->pub_key);
         dh->pub_key = pub_key;
     }
     if (priv_key != NULL) {
-        BN_free(dh->priv_key);
+        BN_clear_free(dh->priv_key);
         dh->priv_key = priv_key;
     }
 

--- a/doc/man3/DH_generate_parameters.pod
+++ b/doc/man3/DH_generate_parameters.pod
@@ -73,6 +73,14 @@ The generator B<g> is not suitable.
 Note that the lack of this bit doesn't guarantee that B<g> is
 suitable, unless B<p> is known to be a strong prime.
 
+=item DH_MODULUS_TOO_SMALL
+
+The modulus is too small.
+
+=item DH_MODULUS_TOO_LARGE
+
+The modulus is too large.
+
 =back
 
 DH_check() confirms that the Diffie-Hellman parameters B<dh> are valid. The
@@ -141,7 +149,7 @@ DH_generate_parameters_ex() instead.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -76,6 +76,8 @@ DECLARE_ASN1_ITEM(DHparams)
 # define DH_CHECK_Q_NOT_PRIME            0x10
 # define DH_CHECK_INVALID_Q_VALUE        0x20
 # define DH_CHECK_INVALID_J_VALUE        0x40
+# define DH_MODULUS_TOO_SMALL            0x80
+# define DH_MODULUS_TOO_LARGE            0x100
 
 /* DH_check_pub_key error codes */
 # define DH_CHECK_PUBKEY_TOO_SMALL       0x01

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -63,14 +63,19 @@ static int dh_test(void)
         || !TEST_true(DH_set0_pqg(dh, p, q, g)))
         goto err1;
 
+    /* check fails, because p is way too small */
     if (!DH_check(dh, &i))
         goto err2;
+    i ^= DH_MODULUS_TOO_SMALL;
     if (!TEST_false(i & DH_CHECK_P_NOT_PRIME)
             || !TEST_false(i & DH_CHECK_P_NOT_SAFE_PRIME)
-            || !TEST_false(i & DH_CHECK_INVALID_Q_VALUE)
-            || !TEST_false(i & DH_CHECK_Q_NOT_PRIME)
             || !TEST_false(i & DH_UNABLE_TO_CHECK_GENERATOR)
             || !TEST_false(i & DH_NOT_SUITABLE_GENERATOR)
+            || !TEST_false(i & DH_CHECK_Q_NOT_PRIME)
+            || !TEST_false(i & DH_CHECK_INVALID_Q_VALUE)
+            || !TEST_false(i & DH_CHECK_INVALID_J_VALUE)
+            || !TEST_false(i & DH_MODULUS_TOO_SMALL)
+            || !TEST_false(i & DH_MODULUS_TOO_LARGE)
             || !TEST_false(i))
         goto err2;
 
@@ -130,6 +135,11 @@ static int dh_test(void)
             || !TEST_false(i & DH_CHECK_P_NOT_SAFE_PRIME)
             || !TEST_false(i & DH_UNABLE_TO_CHECK_GENERATOR)
             || !TEST_false(i & DH_NOT_SUITABLE_GENERATOR)
+            || !TEST_false(i & DH_CHECK_Q_NOT_PRIME)
+            || !TEST_false(i & DH_CHECK_INVALID_Q_VALUE)
+            || !TEST_false(i & DH_CHECK_INVALID_J_VALUE)
+            || !TEST_false(i & DH_MODULUS_TOO_SMALL)
+            || !TEST_false(i & DH_MODULUS_TOO_LARGE)
             || !TEST_false(i))
         goto err3;
 


### PR DESCRIPTION
The check was missing in DH_check and DH_check_params.
DH_check_pub_key_ex was accidentally calling DH_check,
so results were undefined.

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
