### PR TITLE
[master-forward][crypto/ec] for ECC parameters with NULL or zero cofactor, compute it

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Compute ECC cofactors if not provided during EC_GROUP construction. Before
+     this change, EC_GROUP_set_generator would accept order and/or cofactor as
+     NULL. After this change, only the cofactor parameter can be NULL. It also
+     does some minimal sanity checks on the passed order.
+     [Billy Bob Brumley]
+
   *) Early start up entropy quality from the DEVRANDOM seed source has been
      improved for older Linux systems.  The RAND subsystem will wait for
      /dev/random to be producing output before seeding from /dev/urandom.

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@
      this change, EC_GROUP_set_generator would accept order and/or cofactor as
      NULL. After this change, only the cofactor parameter can be NULL. It also
      does some minimal sanity checks on the passed order.
+     (CVE-2019-1547)
      [Billy Bob Brumley]
 
   *) Early start up entropy quality from the DEVRANDOM seed source has been

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -1914,19 +1914,19 @@ static int cardinality_test(int n)
         /* negative test for invalid cofactor */
         || !TEST_true(BN_set_word(g2_cf, 0))
         || !TEST_true(BN_sub(g2_cf, g2_cf, BN_value_one()))
-        || TEST_true(EC_GROUP_set_generator(g2, g2_gen, g1_order, g2_cf))
+        || !TEST_false(EC_GROUP_set_generator(g2, g2_gen, g1_order, g2_cf))
         /* negative test for NULL order */
-        || TEST_true(EC_GROUP_set_generator(g2, g2_gen, NULL, NULL))
+        || !TEST_false(EC_GROUP_set_generator(g2, g2_gen, NULL, NULL))
         /* negative test for zero order */
         || !TEST_true(BN_set_word(g1_order, 0))
-        || TEST_true(EC_GROUP_set_generator(g2, g2_gen, g1_order, NULL))
+        || !TEST_false(EC_GROUP_set_generator(g2, g2_gen, g1_order, NULL))
         /* negative test for negative order */
         || !TEST_true(BN_set_word(g2_cf, 0))
         || !TEST_true(BN_sub(g2_cf, g2_cf, BN_value_one()))
-        || TEST_true(EC_GROUP_set_generator(g2, g2_gen, g1_order, NULL))
+        || !TEST_false(EC_GROUP_set_generator(g2, g2_gen, g1_order, NULL))
         /* negative test for too large order */
         || !TEST_true(BN_lshift(g1_order, g1_p, 2))
-        || TEST_true(EC_GROUP_set_generator(g2, g2_gen, g1_order, NULL)))
+        || !TEST_false(EC_GROUP_set_generator(g2, g2_gen, g1_order, NULL)))
         goto err;
     ret = 1;
  err:


### PR DESCRIPTION
This PR forward ports the changes in the test logic of #9727 fixed while backporting to `1.1.1` in #9781 

It also recovers the new `CHANGES` entry from #9781

@bbbrumley is the original author of both commits, I am just opening the PR for the forward port.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
