### PR TITLE
drbg: ensure fork-safety [1.1.1]

### DIFF
--- a/crypto/include/internal/rand_int.h
+++ b/crypto/include/internal/rand_int.h
@@ -26,7 +26,6 @@ typedef struct rand_pool_st RAND_POOL;
 void rand_cleanup_int(void);
 void rand_drbg_cleanup_int(void);
 void drbg_delete_thread_state(void);
-void rand_fork(void);
 
 /* Hardware-based seeding functions. */
 size_t rand_acquire_entropy_from_tsc(RAND_POOL *pool);

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -847,6 +847,5 @@ void OPENSSL_fork_parent(void)
 
 void OPENSSL_fork_child(void)
 {
-    rand_fork();
 }
 #endif

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -197,7 +197,7 @@ static RAND_DRBG *rand_drbg_new(int secure,
     }
 
     drbg->secure = secure && CRYPTO_secure_allocated(drbg);
-    drbg->fork_count = rand_fork_count;
+    drbg->fork_id = openssl_get_fork_id();
     drbg->parent = parent;
 
     if (parent == NULL) {
@@ -578,6 +578,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
                        int prediction_resistance,
                        const unsigned char *adin, size_t adinlen)
 {
+    int fork_id;
     int reseed_required = 0;
 
     if (drbg->state != DRBG_READY) {
@@ -603,8 +604,10 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
         return 0;
     }
 
-    if (drbg->fork_count != rand_fork_count) {
-        drbg->fork_count = rand_fork_count;
+    fork_id = openssl_get_fork_id();
+
+    if (drbg->fork_id != fork_id) {
+        drbg->fork_id = fork_id;
         reseed_required = 1;
     }
 

--- a/crypto/rand/rand_lcl.h
+++ b/crypto/rand/rand_lcl.h
@@ -186,12 +186,12 @@ struct rand_drbg_st {
     int secure; /* 1: allocated on the secure heap, 0: otherwise */
     int type; /* the nid of the underlying algorithm */
     /*
-     * Stores the value of the rand_fork_count global as of when we last
-     * reseeded.  The DRBG reseeds automatically whenever drbg->fork_count !=
-     * rand_fork_count.  Used to provide fork-safety and reseed this DRBG in
-     * the child process.
+     * Stores the return value of openssl_get_fork_id() as of when we last
+     * reseeded.  The DRBG reseeds automatically whenever drbg->fork_id !=
+     * openssl_get_fork_id().  Used to provide fork-safety and reseed this
+     * DRBG in the child process.
      */
-    int fork_count;
+    int fork_id;
     unsigned short flags; /* various external flags */
 
     /*
@@ -282,19 +282,6 @@ struct rand_drbg_st {
 
 /* The global RAND method, and the global buffer and DRBG instance. */
 extern RAND_METHOD rand_meth;
-
-/*
- * A "generation count" of forks.  Incremented in the child process after a
- * fork.  Since rand_fork_count is increment-only, and only ever written to in
- * the child process of the fork, which is guaranteed to be single-threaded, no
- * locking is needed for normal (read) accesses; the rest of pthread fork
- * processing is assumed to introduce the necessary memory barriers.  Sibling
- * children of a given parent will produce duplicate values, but this is not
- * problematic because the reseeding process pulls input from the system CSPRNG
- * and/or other global sources, so the siblings will end up generating
- * different output streams.
- */
-extern int rand_fork_count;
 
 /* DRBG helpers */
 int rand_drbg_restart(RAND_DRBG *drbg,

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -26,8 +26,6 @@ static CRYPTO_RWLOCK *rand_meth_lock;
 static const RAND_METHOD *default_RAND_meth;
 static CRYPTO_ONCE rand_init = CRYPTO_ONCE_STATIC_INIT;
 
-int rand_fork_count;
-
 static CRYPTO_RWLOCK *rand_nonce_lock;
 static int rand_nonce_count;
 
@@ -301,11 +299,6 @@ size_t rand_drbg_get_additional_data(RAND_POOL *pool, unsigned char **pout)
 void rand_drbg_cleanup_additional_data(RAND_POOL *pool, unsigned char *out)
 {
     rand_pool_reattach(pool, out);
-}
-
-void rand_fork(void)
-{
-    rand_fork_count++;
 }
 
 DEFINE_RUN_ONCE_STATIC(do_rand_init)

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -161,7 +161,9 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
             size_t bytes = 0;
 
             /*
-             * Get random from parent, include our state as additional input.
+             * Get random data from parent. Include our address as additional input,
+             * in order to provide some additional distinction between different
+             * DRBG child instances.
              * Our lock is already held, but we need to lock our parent before
              * generating bits from it. (Note: taking the lock will be a no-op
              * if locking if drbg->parent->lock == NULL.)
@@ -170,7 +172,7 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
             if (RAND_DRBG_generate(drbg->parent,
                                    buffer, bytes_needed,
                                    prediction_resistance,
-                                   NULL, 0) != 0)
+                                   (unsigned char *)&drbg, sizeof(drbg)) != 0)
                 bytes = bytes_needed;
             drbg->reseed_next_counter
                 = tsan_load(&drbg->parent->reseed_prop_counter);

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -711,15 +711,18 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
 int rand_pool_add_additional_data(RAND_POOL *pool)
 {
     struct {
+        int fork_id;
         CRYPTO_THREAD_ID tid;
         uint64_t time;
     } data = { 0 };
 
     /*
      * Add some noise from the thread id and a high resolution timer.
+     * The fork_id adds some extra fork-safety.
      * The thread id adds a little randomness if the drbg is accessed
      * concurrently (which is the case for the <master> drbg).
      */
+    data.fork_id = openssl_get_fork_id();
     data.tid = CRYPTO_THREAD_get_current_id();
     data.time = get_timer_bits();
 

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -133,4 +133,8 @@ int openssl_init_fork_handlers(void)
     return 0;
 }
 
+int openssl_get_fork_id(void)
+{
+    return return 0;
+}
 #endif

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -12,6 +12,11 @@
 
 #if !defined(OPENSSL_THREADS) || defined(CRYPTO_TDEBUG)
 
+# if defined(OPENSSL_SYS_UNIX)
+#  include <sys/types.h>
+#  include <unistd.h>
+# endif
+
 CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
 {
     CRYPTO_RWLOCK *lock;
@@ -135,6 +140,10 @@ int openssl_init_fork_handlers(void)
 
 int openssl_get_fork_id(void)
 {
+# if defined(OPENSSL_SYS_UNIX)
+    return getpid();
+# else
     return return 0;
+# endif
 }
 #endif

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -12,6 +12,11 @@
 
 #if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG) && !defined(OPENSSL_SYS_WINDOWS)
 
+# if defined(OPENSSL_SYS_UNIX)
+#  include <sys/types.h>
+#  include <unistd.h>
+#endif
+
 # ifdef PTHREAD_RWLOCK_INITIALIZER
 #  define USE_RWLOCK
 # endif
@@ -192,5 +197,10 @@ int openssl_init_fork_handlers(void)
         return 1;
 # endif
     return 0;
+}
+
+int openssl_get_fork_id(void)
+{
+    return getpid();
 }
 #endif

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -164,4 +164,8 @@ int openssl_init_fork_handlers(void)
     return 0;
 }
 
+int openssl_get_fork_id(void)
+{
+    return getpid();
+}
 #endif

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -166,6 +166,6 @@ int openssl_init_fork_handlers(void)
 
 int openssl_get_fork_id(void)
 {
-    return getpid();
+    return 0;
 }
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -80,6 +80,7 @@ extern unsigned int OPENSSL_ia32cap_P[];
 void OPENSSL_showfatal(const char *fmta, ...);
 void crypto_cleanup_all_ex_data_int(void);
 int openssl_init_fork_handlers(void);
+int openssl_get_fork_id(void);
 
 char *ossl_safe_getenv(const char *name);
 


### PR DESCRIPTION
For a description, see commit messages (bottom-up):

commit 9d6b8ae5580f0b710bd90c660892904c8d2f6488 (HEAD -> pr-drbg-ensure-fork-safety-111)
Author: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Date:   Thu May 30 18:37:29 2019 +0200

    drbg: fix issue where DRBG_CTR fails if NO_DF is used (2nd attempt)
    
    Since commit 7c226dfc434d a chained DRBG does not add additional
    data anymore when reseeding from its parent. The reason is that
    the size of the additional data exceeded the allowed size when
    no derivation function was used.
    
    This commit provides an alternative fix: instead of adding the
    entire DRBG's complete state, we just add the DRBG's address
    in memory, thereby providing some distinction between the different
    DRBG instances.

commit 9ab3831b334bc6b05fcdda3bc3ef2a1ea3d45897
Author: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Date:   Thu May 30 18:52:39 2019 +0200

    drbg: add fork id to additional data on UNIX systems
    
    Provides a little extra fork-safety on UNIX systems, adding to the
    fact that all DRBGs reseed automatically when the fork_id changes.

commit 2a48fd9ea3f6c4d224a8ed3a5ec9d87585dc4195
Author: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Date:   Thu May 30 18:15:13 2019 +0200

    drbg: ensure fork-safety without using an atfork handler
    
    This commit replaces the fork count by a fork id, which coincides
    with the process id on UNIX operating systems and is zero on other
    operating systems. It is used to detect when an automatic reseed
    after a fork is necessary.

commit 973638ea4b82ae1d8f4ea5469a81add0568187c1
Author: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Date:   Mon May 27 21:03:09 2019 +0200

    drbgtest: test whether DRBG reseeds after forking

