### PR TITLE
Configure: clang: add -Wno-unknown-warning-option [1.1.0]

### DIFF
--- a/Configure
+++ b/Configure
@@ -142,6 +142,7 @@ my $gcc_devteam_warn = "-DDEBUG_UNUSED"
 #       -Wunused-macros -- no, too tricky for BN and _XOPEN_SOURCE etc
 #       -Wextended-offsetof -- no, needed in CMS ASN1 code
 my $clang_devteam_warn = ""
+        . " -Wno-unknown-warning-option"
         . " -Qunused-arguments"
         . " -Wno-language-extension-token"
         . " -Wno-extended-offsetof"


### PR DESCRIPTION
This corresponds to #9446 [1.0.2] resp. #9447 [master, 1.1.1]

Fixes travis build errors due to clang

    error: unknown warning option '-Wno-extended-offsetof'

It seems like '-Wextended-offsetof' was removed from clang in version 6.0.0,
(see [1], [2]). While gcc ignores unknown options of the type '-Wno-xxx',
clang by default issues a warning [-Wunknown-warning-option] (see [3]), which
together with '-Werror' causes the build to fail.

This commit adds the '-Wno-unknown-warning-option' option to make clang
behave more relaxed like gcc.

[1] https://reviews.llvm.org/D40267
[2] https://github.com/llvm/llvm-project/commit/52a3ca9e2909
[3] https://clang.llvm.org/docs/DiagnosticsReference.html#wunknown-warning-option

[extended tests]
