### PR TITLE
Add macros for the KDF algorithm names.

### DIFF
--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -39,7 +39,7 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
     if (oid_sn == NULL)
         return 0;
 
-    kdf = EVP_KDF_fetch(provctx, SN_x942kdf, NULL);
+    kdf = EVP_KDF_fetch(provctx, OSSL_KDF_NAME_X942KDF, NULL);
     if ((kctx = EVP_KDF_CTX_new(kdf)) == NULL)
         goto err;
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,

--- a/crypto/ec/ecdh_kdf.c
+++ b/crypto/ec/ecdh_kdf.c
@@ -24,7 +24,7 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
     EVP_KDF_CTX *kctx = NULL;
     OSSL_PARAM params[4], *p = params;
     const char *mdname = EVP_MD_name(md);
-    EVP_KDF *kdf = EVP_KDF_fetch(NULL, SN_x963kdf, NULL);
+    EVP_KDF *kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_X963KDF, NULL);
 
     if ((kctx = EVP_KDF_CTX_new(kdf)) != NULL) {
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -40,7 +40,7 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
     if (salt == NULL && saltlen == 0)
         salt = (unsigned char *)empty;
 
-    kdf = EVP_KDF_fetch(NULL, LN_id_pbkdf2, NULL);
+    kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_PBKDF2, NULL);
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL)

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -62,7 +62,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     if (maxmem == 0)
         maxmem = SCRYPT_MAX_MEM;
 
-    kdf = EVP_KDF_fetch(NULL, SN_id_scrypt, NULL);
+    kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_SCRYPT, NULL);
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL)

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -128,6 +128,16 @@ extern "C" {
 #define OSSL_KDF_PARAM_SSHKDF_TYPE  "type"      /* int */
 #define OSSL_KDF_PARAM_SIZE         "size"      /* size_t */
 
+/* Known KDF names */
+#define OSSL_KDF_NAME_HKDF          "HKDF"
+#define OSSL_KDF_NAME_PBKDF2        "PBKDF2"
+#define OSSL_KDF_NAME_SCRYPT        "id-scrypt"
+#define OSSL_KDF_NAME_SSHKDF        "SSHKDF"
+#define OSSL_KDF_NAME_SSKDF         "SSKDF"
+#define OSSL_KDF_NAME_TLS1_PRF      "TLS1-PRF"
+#define OSSL_KDF_NAME_X942KDF       "X942KDF"
+#define OSSL_KDF_NAME_X963KDF       "X963KDF"
+
 /* PKEY parameters */
 /* Diffie-Hellman/DSA Parameters */
 #define OSSL_PKEY_PARAM_FFC_P        "p"

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -212,17 +212,17 @@ static const OSSL_ALGORITHM deflt_macs[] = {
 };
 
 static const OSSL_ALGORITHM deflt_kdfs[] = {
-    { "HKDF", "default=yes", kdf_hkdf_functions },
-    { "SSKDF", "default=yes", kdf_sskdf_functions },
-    { "PBKDF2", "default=yes", kdf_pbkdf2_functions },
-    { "SSHKDF", "default=yes", kdf_sshkdf_functions },
-    { "X963KDF", "default=yes", kdf_x963_kdf_functions },
-    { "TLS1-PRF", "default=yes", kdf_tls1_prf_functions },
+    { OSSL_KDF_NAME_HKDF, "default=yes", kdf_hkdf_functions },
+    { OSSL_KDF_NAME_SSKDF, "default=yes", kdf_sskdf_functions },
+    { OSSL_KDF_NAME_PBKDF2, "default=yes", kdf_pbkdf2_functions },
+    { OSSL_KDF_NAME_SSHKDF, "default=yes", kdf_sshkdf_functions },
+    { OSSL_KDF_NAME_X963KDF, "default=yes", kdf_x963_kdf_functions },
+    { OSSL_KDF_NAME_TLS1_PRF, "default=yes", kdf_tls1_prf_functions },
 #ifndef OPENSSL_NO_CMS
-    { "X942KDF", "default=yes", kdf_x942_kdf_functions },
+    { OSSL_KDF_NAME_X942KDF, "default=yes", kdf_x942_kdf_functions },
 #endif
 #ifndef OPENSSL_NO_SCRYPT
-    { "id-scrypt", "default=yes", kdf_scrypt_functions },
+    { OSSL_KDF_NAME_SCRYPT, "default=yes", kdf_scrypt_functions },
 #endif
    { NULL, NULL, NULL }
 };

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -122,7 +122,7 @@ static int dummy_evp_call(void *provctx)
     OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
     EVP_MD *sha256 = EVP_MD_fetch(libctx, "SHA256", NULL);
-    EVP_KDF *kdf = EVP_KDF_fetch(libctx, "pbkdf2", NULL);
+    EVP_KDF *kdf = EVP_KDF_fetch(libctx, OSSL_KDF_NAME_PBKDF2, NULL);
     char msg[] = "Hello World!";
     const unsigned char exptd[] = {
         0x7f, 0x83, 0xb1, 0x65, 0x7f, 0xf1, 0xfc, 0x53, 0xb9, 0x2d, 0xc1, 0x81,

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -346,10 +346,10 @@ static const OSSL_ALGORITHM fips_macs[] = {
 };
 
 static const OSSL_ALGORITHM fips_kdfs[] = {
-    { "HKDF", "fips=yes", kdf_hkdf_functions },
-    { "SSKDF", "fips=yes", kdf_sskdf_functions },
-    { "PBKDF2", "fips=yes", kdf_pbkdf2_functions },
-    { "TLS1-PRF", "fips=yes", kdf_tls1_prf_functions },
+    { OSSL_KDF_NAME_HKDF, "fips=yes", kdf_hkdf_functions },
+    { OSSL_KDF_NAME_SSKDF, "fips=yes", kdf_sskdf_functions },
+    { OSSL_KDF_NAME_PBKDF2, "fips=yes", kdf_pbkdf2_functions },
+    { OSSL_KDF_NAME_TLS1_PRF, "fips=yes", kdf_tls1_prf_functions },
    { NULL, NULL, NULL }
 };
 

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -46,7 +46,7 @@ static int tls1_PRF(SSL *s,
             SSLerr(SSL_F_TLS1_PRF, ERR_R_INTERNAL_ERROR);
         return 0;
     }
-    kdf = EVP_KDF_fetch(NULL, SN_tls1_prf, NULL);
+    kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_TLS1_PRF, NULL);
     if (kdf == NULL)
         goto err;
     kctx = EVP_KDF_CTX_new(kdf);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -36,7 +36,7 @@ int tls13_hkdf_expand(SSL *s, const EVP_MD *md, const unsigned char *secret,
 #else
     static const unsigned char label_prefix[] = "tls13 ";
 #endif
-    EVP_KDF *kdf = EVP_KDF_fetch(NULL, SN_hkdf, NULL);
+    EVP_KDF *kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_HKDF, NULL);
     EVP_KDF_CTX *kctx;
     OSSL_PARAM params[5], *p = params;
     int mode = EVP_PKEY_HKDEF_MODE_EXPAND_ONLY;
@@ -194,7 +194,7 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
 #endif
     unsigned char preextractsec[EVP_MAX_MD_SIZE];
 
-    kdf = EVP_KDF_fetch(NULL, SN_hkdf, NULL);
+    kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_HKDF, NULL);
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL) {

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -49,7 +49,7 @@ static int test_kdf_tls1_prf(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_tls1_prf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -79,7 +79,7 @@ static int test_kdf_hkdf(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_hkdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -120,7 +120,7 @@ static int test_kdf_pbkdf2(void)
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &mode);
     *p = OSSL_PARAM_construct_end();
 
-    if (!TEST_ptr(kctx = get_kdfbyname(LN_id_pbkdf2))
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
         || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         || !TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))
@@ -190,7 +190,7 @@ static int test_kdf_scrypt(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_id_scrypt))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SCRYPT))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         /* failure test *//*
         && TEST_int_le(EVP_KDF_derive(kctx, out, sizeof(out)), 0)*/
@@ -234,7 +234,7 @@ static int test_kdf_ss_hash(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_sskdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSKDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -288,7 +288,7 @@ static int test_kdf_x963(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_x963kdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_X963KDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -331,7 +331,7 @@ static int test_kdf_ss_hmac(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_sskdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSKDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -377,7 +377,7 @@ static int test_kdf_ss_kmac(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_sskdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSKDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -435,7 +435,7 @@ static int test_kdf_sshkdf(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_sshkdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSHKDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
@@ -451,7 +451,7 @@ static int test_kdf_get_kdf(void)
     int ok = 1;
 
     if (!TEST_ptr(obj = OBJ_nid2obj(NID_id_pbkdf2))
-        || !TEST_ptr(kdf1 = EVP_KDF_fetch(NULL, LN_id_pbkdf2, NULL))
+        || !TEST_ptr(kdf1 = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_PBKDF2, NULL))
         || !TEST_ptr(kdf2 = EVP_KDF_fetch(NULL, OBJ_nid2sn(OBJ_obj2nid(obj)),
                                           NULL))
         || !TEST_ptr_eq(kdf1, kdf2))
@@ -509,7 +509,7 @@ static int test_kdf_x942_asn1(void)
     *p = OSSL_PARAM_construct_end();
 
     ret =
-        TEST_ptr(kctx = get_kdfbyname(SN_x942kdf))
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_X942KDF))
         && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));


### PR DESCRIPTION
This avoids the problems with PBKDF2 and SCRYPT not being of the same form
as the rest.

- [ ] documentation is added or updated
- [x] tests are added or updated
