### PR TITLE
Add support for io_pgetevents_time64 syscall

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -125,7 +125,23 @@ static ossl_inline int io_getevents(aio_context_t ctx, long min, long max,
                                struct io_event *events,
                                struct timespec *timeout)
 {
+#if defined(__NR_io_getevents)
     return syscall(__NR_io_getevents, ctx, min, max, events, timeout);
+#elif defined(__NR_io_pgetevents_time64)
+    /* Let's only support the 64 suffix syscalls for 64-bit time_t.
+     * This simplifies the code for us as we don't need to use a 64-bit
+     * version of timespec with a 32-bit time_t and handle converting
+     * between 64-bit and 32-bit times and check for overflows.
+     */
+    if (sizeof(timeout->tv_sec) == 8)
+        return syscall(__NR_io_pgetevents_time64, ctx, min, max, events, timeout, NULL);
+    else {
+        errno = ENOSYS;
+        return -1;
+    }
+#else
+# error "We require either the io_getevents syscall or __NR_io_pgetevents_time64."
+#endif
 }
 
 static void afalg_waitfd_cleanup(ASYNC_WAIT_CTX *ctx, const void *key,


### PR DESCRIPTION
32-bit architectures that are y2038 safe don't include syscalls that use
32-bit time_t. Instead these architectures have suffixed syscalls that
always use a 64-bit time_t. In the case of the io_getevents syscall the
syscall has been replaced with the io_pgetevents_time64 syscall instead.

This patch changes the io_getevents() function to use the correct
syscall based on the avaliable syscalls and the time_t size. We will
only use the new 64-bit time_t syscall if the architecture is using a
64-bit time_t. This is to avoid having to deal with 32/64-bit
conversions. In the future if a 32-bit time_t architecture wants to use
the 64-bit syscalls we can handle the conversion.

This fixes build failures on 32-bit RISC-V.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>