### PR TITLE
Fix test error if DSA & Scrypt are disabled

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1395,6 +1395,7 @@ static int test_EVP_CIPHER_fetch(int tst)
     return ret;
 }
 
+#ifndef OPENSSL_NO_DSA
 /* Test getting and setting parameters on an EVP_PKEY_CTX */
 static int test_EVP_PKEY_CTX_get_set_params(void)
 {
@@ -1505,6 +1506,7 @@ static int test_EVP_PKEY_CTX_get_set_params(void)
 
     return ret;
 }
+#endif
 
 int setup_tests(void)
 {
@@ -1542,6 +1544,8 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_EVP_MD_fetch, 5);
     ADD_ALL_TESTS(test_EVP_CIPHER_fetch, 5);
 #endif
+#ifndef OPENSSL_NO_DSA
     ADD_TEST(test_EVP_PKEY_CTX_get_set_params);
+#endif
     return 1;
 }

--- a/test/recipes/30-test_evp_data/evpkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf.txt
@@ -254,7 +254,7 @@ Output = 2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081
 
 Title = id-scrypt tests (from draft-josefsson-id-scrypt-kdf-03 and others)
 
-KDF = id-scrypt
+KDF = scrypt
 Ctrl.pass = pass:
 Ctrl.salt = salt:
 Ctrl.N = n:16
@@ -262,7 +262,7 @@ Ctrl.r = r:1
 Ctrl.p = p:1
 Output = 77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906
 
-KDF = id-scrypt
+KDF = scrypt
 Ctrl.pass = pass:password
 Ctrl.salt = salt:NaCl
 Ctrl.N = n:1024
@@ -270,7 +270,7 @@ Ctrl.r = r:8
 Ctrl.p = p:16
 Output = fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640
 
-KDF = id-scrypt
+KDF = scrypt
 Ctrl.hexpass = hexpass:70617373776f7264
 Ctrl.salt = salt:NaCl
 Ctrl.N = n:1024
@@ -278,7 +278,7 @@ Ctrl.r = r:8
 Ctrl.p = p:16
 Output = fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640
 
-KDF = id-scrypt
+KDF = scrypt
 Ctrl.pass = pass:password
 Ctrl.hexsalt = hexsalt:4e61436c
 Ctrl.N = n:1024
@@ -286,7 +286,7 @@ Ctrl.r = r:8
 Ctrl.p = p:16
 Output = fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640
 
-KDF = id-scrypt
+KDF = scrypt
 Ctrl.pass = pass:pleaseletmein
 Ctrl.salt = salt:SodiumChloride
 Ctrl.N = n:16384
@@ -295,7 +295,7 @@ Ctrl.p = p:1
 Output = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
 # Out of memory
-KDF = id-scrypt
+KDF = scrypt
 Ctrl.pass = pass:pleaseletmein
 Ctrl.salt = salt:SodiumChloride
 Ctrl.N = n:1048576


### PR DESCRIPTION
There are test cases errors of when compiling and testing if OpenSSL is
compiled with 'no-dsa' or 'no-scrypt'. This commit fixes the issue.

An alternative for fixing the 'scrypt' problem could be modifying the `evp_test.c` file to check the KDF name as `id-scrypt`, but it still seems the recipe text file which contains the test cases has a wrong name.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
