### PR TITLE
Turn off HARNESS_VERBOSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,7 +195,7 @@ script:
           if [ -e krb5/src ]; then
               sudo apt-get -yq install bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python-cjson python-paste python-pyrad slapd tcl-dev tcsh;
           fi;
-          if ! HARNESS_VERBOSE=yes BORING_RUNNER_DIR=$top/boringssl/ssl/test/runner make test; then
+          if ! BORING_RUNNER_DIR=$top/boringssl/ssl/test/runner make test; then
               echo -e '\052\052 FAILED -- MAKE TEST';
               travis_terminate 1;
           fi;

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -11,7 +11,7 @@ use warnings;
 
 # Recognise VERBOSE and V which is common on other projects.
 BEGIN {
-    $ENV{HARNESS_VERBOSE} = "yes" if $ENV{VERBOSE} || $ENV{V};
+    $ENV{HARNESS_VERBOSE} = "1" if $ENV{VERBOSE} || $ENV{V};
 }
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
@@ -31,7 +31,7 @@ my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 $ENV{OPENSSL_CONF} = catdir($srctop, "apps", "openssl.cnf");
 
 my %tapargs =
-    ( verbosity => $ENV{VERBOSE} || $ENV{V} || $ENV{HARNESS_VERBOSE} ? 1 : 0,
+    ( verbosity => $ENV{HARNESS_VERBOSE} ? 1 : 0,
       lib       => [ $libdir ],
       switches  => '-w',
       merge     => 1


### PR DESCRIPTION
Experimenting with less HARNESS_VERBOSE verbosity in travis since we seem to get many "log too long, stopping build" errors these days.

