### PR TITLE
fix unused goto label gcc warning (1.1.1d)

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -697,7 +697,9 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         /* Note that |res| SHOULD be a 'struct addrinfo **' thanks to
          * macro magic in bio_lcl.h
          */
+# if defined(AI_ADDRCONFIG) && defined(AI_NUMERICHOST)
       retry:
+# endif
         switch ((gai_ret = getaddrinfo(host, service, &hints, res))) {
 # ifdef EAI_SYSTEM
         case EAI_SYSTEM:


### PR DESCRIPTION
On systems with undefined AI_ADDRCONFIG and AI_NUMERICHOST:
```
x86_64-w64-mingw32-gcc  -I. -Icrypto/include -Iinclude -m64 -Wall -O3 -fno-ident -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_CPUID_OBJ -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DKECCAK1600_ASM -DRC4_ASM -DMD5_ASM -DVPAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DX25519_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"C:/Program Files/Common Files/SSL\"" -DENGINESDIR="\"C:/Windows/System32/OpenSSL/lib/engines-1_1\"" -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN -D_MT -DNDEBUG   -c -o crypto/bio/b_addr.o crypto/bio/b_addr.c
crypto/bio/b_addr.c: In function 'BIO_lookup_ex':
crypto/bio/b_addr.c:699:7: warning: label 'retry' defined but not used [-Wunused-label]
       retry:
       ^~~~~
```

Regression from: 3f91ede9aea70774d9b5d509bc76d484ebaff6aa

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
