### PR TITLE
crypto/threads_none.c: fix syntax error in openssl_get_fork_id()

### DIFF
--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -143,7 +143,7 @@ int openssl_get_fork_id(void)
 # if defined(OPENSSL_SYS_UNIX)
     return getpid();
 # else
-    return return 0;
+    return 0;
 # endif
 }
 #endif

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -24,15 +24,15 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
         return NULL;
     }
 
-#if !defined(_WIN32_WCE)
+# if !defined(_WIN32_WCE)
     /* 0x400 is the spin count value suggested in the documentation */
     if (!InitializeCriticalSectionAndSpinCount(lock, 0x400)) {
         OPENSSL_free(lock);
         return NULL;
     }
-#else
+# else
     InitializeCriticalSection(lock);
-#endif
+# endif
 
     return lock;
 }


### PR DESCRIPTION
Fixes #9858

_(Marked as WIP until I completed  the check why this error went unnoticed.)_