### PR TITLE
Avoid passing NULL to memcpy

### DIFF
--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -82,17 +82,13 @@ static int collect(BUF_MEM **collector, void *data, size_t datalen)
         return 0;
     }
 
-    i = (*collector)->length; /* BUF_MEM_grow() changes it! */
-    /*
-     * The i + datalen check is to distinguish between BUF_MEM_grow()
-     * signaling an error and BUF_MEM_grow() simply returning the (zero)
-     * length.
-     */
-    if (!BUF_MEM_grow(*collector, i + datalen)
-        && i + datalen != 0)
-        return 0;
-    if (data != NULL)
+    if (data != NULL && datalen > 0) {
+        i = (*collector)->length; /* BUF_MEM_grow() changes it! */
+
+        if (!BUF_MEM_grow(*collector, i + datalen))
+            return 0;
         memcpy((*collector)->data + i, data, datalen);
+    }
     return 1;
 }
 


### PR DESCRIPTION
It is undefined behaviour to send NULL as either the src, or dest params
in memcpy.

In pkey_kdf.c we had a check to ensure that the src address is non-NULL.
However in some situations it is possible that the dest address could also
be NULL. Specifically in the case where the datalen is 0 and we are using
a newly allocated BUF_MEM.

We add a check of datalen to avoid the undefined behaviour.
