### PR TITLE
[1.1.0] Fix no-ec2m in ec_curve.c

### DIFF
--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3200,11 +3200,11 @@ int ec_point_get_affine_coordinates(const EC_GROUP *group,
 
 #ifndef OPENSSL_NO_EC2M
     if (field_nid == NID_X9_62_characteristic_two_field) {
-        return EC_POINT_get_affine_coordinates_GFp(group, point, x, y, ctx);
+        return EC_POINT_get_affine_coordinates_GF2m(group, point, x, y, ctx);
     } else
 #endif /* !def(OPENSSL_NO_EC2M) */
     if (field_nid == NID_X9_62_prime_field) {
-        return EC_POINT_get_affine_coordinates_GF2m(group, point, x, y, ctx);
+        return EC_POINT_get_affine_coordinates_GFp(group, point, x, y, ctx);
     } else {
         /* this should never happen */
         return 0;


### PR DESCRIPTION
I made a mistake in d4a5dac9f9242c580fb9d0a4389440eccd3494a7 (#9810) and
inverted the `GF2m` and `GFp` calls in `ec_point_get_affine_coordinates`, this
fixes it.

[I caught this later while backporting to `1.0.2`](https://github.com/openssl/openssl/pull/9811#pullrequestreview-285600690), but failed at detecting the same mistake in `1.1.0`.

Fixes #9872 

Thanks @Whissi for reporting this.