### PR TITLE
Avoid using EC_GROUP_clear_free() internally

### DIFF
--- a/crypto/ec/ec_cvt.c
+++ b/crypto/ec/ec_cvt.c
@@ -53,7 +53,7 @@ EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
         return NULL;
 
     if (!EC_GROUP_set_curve(ret, p, a, b, ctx)) {
-        EC_GROUP_clear_free(ret);
+        EC_GROUP_free(ret);
         return NULL;
     }
 
@@ -74,7 +74,7 @@ EC_GROUP *EC_GROUP_new_curve_GF2m(const BIGNUM *p, const BIGNUM *a,
         return NULL;
 
     if (!EC_GROUP_set_curve(ret, p, a, b, ctx)) {
-        EC_GROUP_clear_free(ret);
+        EC_GROUP_free(ret);
         return NULL;
     }
 

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -116,6 +116,7 @@ void EC_GROUP_free(EC_GROUP *group)
     OPENSSL_free(group);
 }
 
+#if !OPENSSL_API_3
 void EC_GROUP_clear_free(EC_GROUP *group)
 {
     if (!group)
@@ -134,6 +135,7 @@ void EC_GROUP_clear_free(EC_GROUP *group)
     OPENSSL_clear_free(group->seed, group->seed_len);
     OPENSSL_clear_free(group, sizeof(*group));
 }
+#endif
 
 int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
 {

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -32,7 +32,6 @@ objects
  EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
  EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params)
  void EC_GROUP_free(EC_GROUP *group);
- void EC_GROUP_clear_free(EC_GROUP *group);
 
  EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
                                   const BIGNUM *b, BN_CTX *ctx);
@@ -58,6 +57,12 @@ objects
  ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group, ECPKPARAMETERS *params)
 
  size_t EC_get_builtin_curves(EC_builtin_curve *r, size_t nitems);
+
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
+ void EC_GROUP_clear_free(EC_GROUP *group);
 
 =head1 DESCRIPTION
 
@@ -129,7 +134,10 @@ that the default library context is always used.
 EC_GROUP_free frees the memory associated with the EC_GROUP.
 If B<group> is NULL nothing is done.
 
-EC_GROUP_clear_free destroys any sensitive data held within the EC_GROUP and then frees its memory.
+EC_GROUP_clear_free is deprecated: it was meant to destroy any sensitive data
+held within the EC_GROUP and then free its memory, but since all the data stored
+in the EC_GROUP is public anyway, this function is unnecessary.
+Its use can be safely replaced with EC_GROUP_free.
 If B<group> is NULL nothing is done.
 
 =head1 RETURN VALUES
@@ -149,7 +157,17 @@ L<OPENSSL_CTX(3)>
 
 =head1 HISTORY
 
+=over 2
+
+=item *
+
 EC_GROUP_new_ex and EC_GROUP_new_by_curve_name_ex were added in OpenSSL 3.0.
+
+=item *
+
+EC_GROUP_clear_free() was deprecated in OpenSSL 3.0; use EC_GROUP_free() instead.
+
+=back
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -80,7 +80,7 @@ y^2 + xy = x^3 + ax^2 + b (where b != 0)
 Operations in a binary field are performed relative to an B<irreducible polynomial>. All such curves with OpenSSL
 use a trinomial or a pentanomial for this parameter.
 
-A new curve can be constructed by calling EC_GROUP_new_ex, using the implementation provided by B<meth> (see
+A new curve can be constructed by calling EC_GROUP_new_ex(), using the implementation provided by B<meth> (see
 L<EC_GFp_simple_method(3)>) and associated with the library context B<ctx>
 (see L<OPENSSL_CTX(3)>).
 The B<ctx> parameter may be NULL in which case the default library context is used.
@@ -89,7 +89,7 @@ EC_GROUP_new_from_ecparameters() will create a group from the
 specified B<params> and
 EC_GROUP_new_from_ecpkparameters() will create a group from the specific PK B<params>.
 
-EC_GROUP_new is the same as EC_GROUP_new_ex() except that the library context
+EC_GROUP_new() is the same as EC_GROUP_new_ex() except that the library context
 used is always the default library context.
 
 EC_GROUP_set_curve() sets the curve parameters B<p>, B<a> and B<b>. For a curve over Fp B<b>
@@ -105,8 +105,8 @@ backwards compatibility only and should not be used.
 EC_GROUP_get_curve_GFp() and EC_GROUP_get_curve_GF2m() are synonyms for EC_GROUP_get_curve(). They are defined for
 backwards compatibility only and should not be used.
 
-The functions EC_GROUP_new_curve_GFp and EC_GROUP_new_curve_GF2m are shortcuts for calling EC_GROUP_new and then the
-EC_GROUP_set_curve function. An appropriate default implementation method will be used.
+The functions EC_GROUP_new_curve_GFp() and EC_GROUP_new_curve_GF2m() are shortcuts for calling EC_GROUP_new() and then the
+EC_GROUP_set_curve() function. An appropriate default implementation method will be used.
 
 Whilst the library can be used to create any curve using the functions described above, there are also a number of
 predefined curves that are available. In order to obtain a list of all of the predefined curves, call the function
@@ -124,29 +124,29 @@ The EC_builtin_curve structure is defined as follows:
 
 Each EC_builtin_curve item has a unique integer id (B<nid>), and a human readable comment string describing the curve.
 
-In order to construct a built-in curve use the function EC_GROUP_new_by_curve_name_ex and provide the B<nid> of the curve to
+In order to construct a built-in curve use the function EC_GROUP_new_by_curve_name_ex() and provide the B<nid> of the curve to
 be constructed and the associated library context to be used in B<ctx> (see L<OPENSSL_CTX(3)>).
 The B<ctx> value may be NULL in which case the default library context is used.
 
-EC_GROUP_new_by_curve_name is the same as EC_GROUP_new_by_curve_name_ex except
+EC_GROUP_new_by_curve_name() is the same as EC_GROUP_new_by_curve_name_ex() except
 that the default library context is always used.
 
-EC_GROUP_free frees the memory associated with the EC_GROUP.
+EC_GROUP_free() frees the memory associated with the EC_GROUP.
 If B<group> is NULL nothing is done.
 
-EC_GROUP_clear_free is deprecated: it was meant to destroy any sensitive data
+EC_GROUP_clear_free() is deprecated: it was meant to destroy any sensitive data
 held within the EC_GROUP and then free its memory, but since all the data stored
 in the EC_GROUP is public anyway, this function is unnecessary.
-Its use can be safely replaced with EC_GROUP_free.
+Its use can be safely replaced with EC_GROUP_free().
 If B<group> is NULL nothing is done.
 
 =head1 RETURN VALUES
 
 All EC_GROUP_new* functions return a pointer to the newly constructed group, or NULL on error.
 
-EC_get_builtin_curves returns the number of built-in curves that are available.
+EC_get_builtin_curves() returns the number of built-in curves that are available.
 
-EC_GROUP_set_curve_GFp, EC_GROUP_get_curve_GFp, EC_GROUP_set_curve_GF2m, EC_GROUP_get_curve_GF2m return 1 on success or 0 on error.
+EC_GROUP_set_curve_GFp(), EC_GROUP_get_curve_GFp(), EC_GROUP_set_curve_GF2m(), EC_GROUP_get_curve_GF2m() return 1 on success or 0 on error.
 
 =head1 SEE ALSO
 
@@ -161,7 +161,7 @@ L<OPENSSL_CTX(3)>
 
 =item *
 
-EC_GROUP_new_ex and EC_GROUP_new_by_curve_name_ex were added in OpenSSL 3.0.
+EC_GROUP_new_ex() and EC_GROUP_new_by_curve_name_ex() were added in OpenSSL 3.0.
 
 =item *
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -66,55 +66,68 @@ L<openssl_user_macros(7)>:
 
 =head1 DESCRIPTION
 
-Within the library there are two forms of elliptic curve that are of interest. The first form is those defined over the
-prime field Fp. The elements of Fp are the integers 0 to p-1, where p is a prime number. This gives us a revised
+Within the library there are two forms of elliptic curve that are of interest.
+The first form is those defined over the prime field Fp. The elements of Fp are
+the integers 0 to p-1, where p is a prime number. This gives us a revised
 elliptic curve equation as follows:
 
 y^2 mod p = x^3 +ax + b mod p
 
-The second form is those defined over a binary field F2^m where the elements of the field are integers of length at
-most m bits. For this form the elliptic curve equation is modified to:
+The second form is those defined over a binary field F2^m where the elements of
+the field are integers of length at most m bits. For this form the elliptic
+curve equation is modified to:
 
 y^2 + xy = x^3 + ax^2 + b (where b != 0)
 
-Operations in a binary field are performed relative to an B<irreducible polynomial>. All such curves with OpenSSL
-use a trinomial or a pentanomial for this parameter.
+Operations in a binary field are performed relative to an
+B<irreducible polynomial>. All such curves with OpenSSL use a trinomial or a
+pentanomial for this parameter.
 
-A new curve can be constructed by calling EC_GROUP_new_ex(), using the implementation provided by B<meth> (see
-L<EC_GFp_simple_method(3)>) and associated with the library context B<ctx>
-(see L<OPENSSL_CTX(3)>).
-The B<ctx> parameter may be NULL in which case the default library context is used.
+A new curve can be constructed by calling EC_GROUP_new_ex(), using the
+implementation provided by B<meth> (see L<EC_GFp_simple_method(3)>) and
+associated with the library context B<ctx> (see L<OPENSSL_CTX(3)>).
+The B<ctx> parameter may be NULL in which case the default library context is
+used.
 It is then necessary to call EC_GROUP_set_curve() to set the curve parameters.
 EC_GROUP_new_from_ecparameters() will create a group from the
 specified B<params> and
-EC_GROUP_new_from_ecpkparameters() will create a group from the specific PK B<params>.
+EC_GROUP_new_from_ecpkparameters() will create a group from the specific PK
+B<params>.
 
 EC_GROUP_new() is the same as EC_GROUP_new_ex() except that the library context
 used is always the default library context.
 
-EC_GROUP_set_curve() sets the curve parameters B<p>, B<a> and B<b>. For a curve over Fp B<b>
-is the prime for the field. For a curve over F2^m B<p> represents the irreducible polynomial - each bit
-represents a term in the polynomial. Therefore there will either be three or five bits set dependent on whether
-the polynomial is a trinomial or a pentanomial.
+EC_GROUP_set_curve() sets the curve parameters B<p>, B<a> and B<b>. For a curve
+over Fp B<b> is the prime for the field. For a curve over F2^m B<p> represents
+the irreducible polynomial - each bit represents a term in the polynomial.
+Therefore there will either be three or five bits set dependent on whether the
+polynomial is a trinomial or a pentanomial.
 
 EC_group_get_curve() obtains the previously set curve parameters.
 
-EC_GROUP_set_curve_GFp() and EC_GROUP_set_curve_GF2m() are synonyms for EC_GROUP_set_curve(). They are defined for
-backwards compatibility only and should not be used.
+EC_GROUP_set_curve_GFp() and EC_GROUP_set_curve_GF2m() are synonyms for
+EC_GROUP_set_curve(). They are defined for backwards compatibility only and
+should not be used.
 
-EC_GROUP_get_curve_GFp() and EC_GROUP_get_curve_GF2m() are synonyms for EC_GROUP_get_curve(). They are defined for
-backwards compatibility only and should not be used.
+EC_GROUP_get_curve_GFp() and EC_GROUP_get_curve_GF2m() are synonyms for
+EC_GROUP_get_curve(). They are defined for backwards compatibility only and
+should not be used.
 
-The functions EC_GROUP_new_curve_GFp() and EC_GROUP_new_curve_GF2m() are shortcuts for calling EC_GROUP_new() and then the
-EC_GROUP_set_curve() function. An appropriate default implementation method will be used.
+The functions EC_GROUP_new_curve_GFp() and EC_GROUP_new_curve_GF2m() are
+shortcuts for calling EC_GROUP_new() and then the EC_GROUP_set_curve() function.
+An appropriate default implementation method will be used.
 
-Whilst the library can be used to create any curve using the functions described above, there are also a number of
-predefined curves that are available. In order to obtain a list of all of the predefined curves, call the function
-EC_get_builtin_curves(). The parameter B<r> should be an array of EC_builtin_curve structures of size B<nitems>. The function
-will populate the B<r> array with information about the built-in curves. If B<nitems> is less than the total number of
-curves available, then the first B<nitems> curves will be returned. Otherwise the total number of curves will be
-provided. The return value is the total number of curves available (whether that number has been populated in B<r> or
-not). Passing a NULL B<r>, or setting B<nitems> to 0 will do nothing other than return the total number of curves available.
+Whilst the library can be used to create any curve using the functions described
+above, there are also a number of predefined curves that are available. In order
+to obtain a list of all of the predefined curves, call the function
+EC_get_builtin_curves(). The parameter B<r> should be an array of
+EC_builtin_curve structures of size B<nitems>. The function will populate the
+B<r> array with information about the built-in curves. If B<nitems> is less than
+the total number of curves available, then the first B<nitems> curves will be
+returned. Otherwise the total number of curves will be provided. The return
+value is the total number of curves available (whether that number has been
+populated in B<r> or not). Passing a NULL B<r>, or setting B<nitems> to 0 will
+do nothing other than return the total number of curves available.
 The EC_builtin_curve structure is defined as follows:
 
  typedef struct {
@@ -122,14 +135,17 @@ The EC_builtin_curve structure is defined as follows:
         const char *comment;
         } EC_builtin_curve;
 
-Each EC_builtin_curve item has a unique integer id (B<nid>), and a human readable comment string describing the curve.
+Each EC_builtin_curve item has a unique integer id (B<nid>), and a human
+readable comment string describing the curve.
 
-In order to construct a built-in curve use the function EC_GROUP_new_by_curve_name_ex() and provide the B<nid> of the curve to
-be constructed and the associated library context to be used in B<ctx> (see L<OPENSSL_CTX(3)>).
-The B<ctx> value may be NULL in which case the default library context is used.
+In order to construct a built-in curve use the function
+EC_GROUP_new_by_curve_name_ex() and provide the B<nid> of the curve to be
+constructed and the associated library context to be used in B<ctx> (see
+L<OPENSSL_CTX(3)>).  The B<ctx> value may be NULL in which case the default
+library context is used.
 
-EC_GROUP_new_by_curve_name() is the same as EC_GROUP_new_by_curve_name_ex() except
-that the default library context is always used.
+EC_GROUP_new_by_curve_name() is the same as EC_GROUP_new_by_curve_name_ex()
+except that the default library context is always used.
 
 EC_GROUP_free() frees the memory associated with the EC_GROUP.
 If B<group> is NULL nothing is done.
@@ -142,11 +158,14 @@ If B<group> is NULL nothing is done.
 
 =head1 RETURN VALUES
 
-All EC_GROUP_new* functions return a pointer to the newly constructed group, or NULL on error.
+All EC_GROUP_new* functions return a pointer to the newly constructed group, or
+NULL on error.
 
-EC_get_builtin_curves() returns the number of built-in curves that are available.
+EC_get_builtin_curves() returns the number of built-in curves that are
+available.
 
-EC_GROUP_set_curve_GFp(), EC_GROUP_get_curve_GFp(), EC_GROUP_set_curve_GF2m(), EC_GROUP_get_curve_GF2m() return 1 on success or 0 on error.
+EC_GROUP_set_curve_GFp(), EC_GROUP_get_curve_GFp(), EC_GROUP_set_curve_GF2m(),
+EC_GROUP_get_curve_GF2m() return 1 on success or 0 on error.
 
 =head1 SEE ALSO
 
@@ -165,7 +184,8 @@ EC_GROUP_new_ex() and EC_GROUP_new_by_curve_name_ex() were added in OpenSSL 3.0.
 
 =item *
 
-EC_GROUP_clear_free() was deprecated in OpenSSL 3.0; use EC_GROUP_free() instead.
+EC_GROUP_clear_free() was deprecated in OpenSSL 3.0; use EC_GROUP_free()
+instead.
 
 =back
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -98,10 +98,12 @@ EC_GROUP_new() is the same as EC_GROUP_new_ex() except that the library context
 used is always the default library context.
 
 EC_GROUP_set_curve() sets the curve parameters B<p>, B<a> and B<b>. For a curve
-over Fp B<b> is the prime for the field. For a curve over F2^m B<p> represents
+over Fp B<p> is the prime for the field. For a curve over F2^m B<p> represents
 the irreducible polynomial - each bit represents a term in the polynomial.
 Therefore there will either be three or five bits set dependent on whether the
 polynomial is a trinomial or a pentanomial.
+In either case, B<a> and B<b> represents the coefficients a and b from the
+relevant equation introduced above.
 
 EC_group_get_curve() obtains the previously set curve parameters.
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -131,7 +131,7 @@ void EC_GROUP_free(EC_GROUP *group);
 /** Clears and frees a EC_GROUP object
  *  \param  group  EC_GROUP object to be cleared and freed.
  */
-void EC_GROUP_clear_free(EC_GROUP *group);
+DEPRECATEDIN_3(void EC_GROUP_clear_free(EC_GROUP *group))
 
 /** Copies EC_GROUP objects. Note: both EC_GROUPs must use the same EC_METHOD.
  *  \param  dst  destination EC_GROUP object

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2577,7 +2577,7 @@ PKCS7_ENVELOPE_it                       2632	3_0_0	EXIST::FUNCTION:
 ASIdentifierChoice_it                   2633	3_0_0	EXIST::FUNCTION:RFC3779
 CMS_RecipientEncryptedKey_cert_cmp      2634	3_0_0	EXIST::FUNCTION:CMS
 EVP_PKEY_CTX_get_app_data               2635	3_0_0	EXIST::FUNCTION:
-EC_GROUP_clear_free                     2636	3_0_0	EXIST::FUNCTION:EC
+EC_GROUP_clear_free                     2636	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3,EC
 BN_get_rfc2409_prime_1024               2637	3_0_0	EXIST::FUNCTION:
 CRYPTO_set_mem_functions                2638	3_0_0	EXIST::FUNCTION:
 i2d_ASN1_VISIBLESTRING                  2639	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
There is nothing confidential in `EC_GROUP` so really having a
`EC_GROUP_clear_free` function at all doe snot make much sense anymore.

See https://github.com/openssl/openssl/issues/9822

WIP to address the documentation and the proper path for deprecation.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is updated
- [x] mark as deprecated in the API
