### PR TITLE
BIO_f_zlib(): add pending / wpending controls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ env:
 
 matrix:
     include:
+        - os: linux
+          sudo: false
+          compiler: clang
+          env: CONFIG_OPTS="--strict-warnings zlib"
         - os: linux-ppc64le
           sudo: false
           compiler: clang

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -564,6 +564,13 @@ static long bio_zlib_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = BIO_flush(next);
         break;
 
+    case BIO_CTRL_PENDING:
+        ret = ctx->zin.avail_in != 0;
+        break;
+    case BIO_CTRL_WPENDING:
+        ret = ctx->ocount != 0;
+        break;
+
     case BIO_C_SET_BUFF_SIZE:
         ibs = -1;
         obs = -1;


### PR DESCRIPTION
This filter was lacking support to check if there's any more pending
data, which may result in the last zlib block being lost.

Fixes #9866
