### PR TITLE
Explicit test against NULL

### DIFF
--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -102,7 +102,7 @@ ASN1_ITEM_end(CBIGNUM)
 static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
     *pval = (ASN1_VALUE *)BN_new();
-    if (*pval)
+    if (*pval != NULL)
         return 1;
     else
         return 0;
@@ -110,7 +110,7 @@ static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
 
 static void bn_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
-    if (!*pval)
+    if (*pval == NULL)
         return;
     if (it->size & BN_SENSITIVE)
         BN_clear_free((BIGNUM *)*pval);
@@ -124,7 +124,7 @@ static int bn_i2c(ASN1_VALUE **pval, unsigned char *cont, int *putype,
 {
     BIGNUM *bn;
     int pad;
-    if (!*pval)
+    if (*pval == NULL)
         return -1;
     bn = (BIGNUM *)*pval;
     /* If MSB set in an octet we need a padding byte */


### PR DESCRIPTION
Same as #9881 but for 1.0.2 branch.

As per @richsalz recommendation in #9779 , change the style to explicitly test against NULL and unify notation in the file.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

