### PR TITLE
Fix S390X bad size_t that causes memory trash in legacy ciphers

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -318,7 +318,7 @@ int EVP_CIPHER_iv_length(const EVP_CIPHER *cipher)
 int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
 {
     int rv;
-    size_t len, v = EVP_CIPHER_iv_length(ctx->cipher);
+    size_t v = EVP_CIPHER_iv_length(ctx->cipher);
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &v);
@@ -329,9 +329,11 @@ int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
     /* TODO (3.0) Remove legacy support */
 legacy:
     if ((EVP_CIPHER_flags(ctx->cipher) & EVP_CIPH_CUSTOM_IV_LENGTH) != 0) {
+        int len = 0;
+
         rv = EVP_CIPHER_CTX_ctrl((EVP_CIPHER_CTX *)ctx, EVP_CTRL_GET_IVLEN,
                                  0, &len);
-        return (rv == 1) ? (int)len : -1;
+        return (rv == 1) ? len : -1;
     }
     return v;
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -317,8 +317,8 @@ int EVP_CIPHER_iv_length(const EVP_CIPHER *cipher)
 
 int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
 {
-    int rv;
-    size_t v = EVP_CIPHER_iv_length(ctx->cipher);
+    int rv, len = EVP_CIPHER_iv_length(ctx->cipher);
+    size_t v = len;
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &v);
@@ -329,13 +329,11 @@ int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
     /* TODO (3.0) Remove legacy support */
 legacy:
     if ((EVP_CIPHER_flags(ctx->cipher) & EVP_CIPH_CUSTOM_IV_LENGTH) != 0) {
-        int len = 0;
-
         rv = EVP_CIPHER_CTX_ctrl((EVP_CIPHER_CTX *)ctx, EVP_CTRL_GET_IVLEN,
                                  0, &len);
         return (rv == 1) ? len : -1;
     }
-    return v;
+    return len;
 }
 
 int EVP_CIPHER_CTX_tag_length(const EVP_CIPHER_CTX *ctx)


### PR DESCRIPTION
This caused a SEGV inside tls13_enc() when using chacha_poly.
The tls code assigns the iv_length to a size_t (even though it is an int).
This is actually really bad since it could be -1, which will then trash the iv buffer.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
