### PR TITLE
Param type documentation consistency updates.

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -339,12 +339,13 @@ EVP_MD_CTX_set_params() can be used with the following OSSL_PARAM keys:
 
 =over 4
 
-=item OSSL_PARAM_DIGEST_KEY_XOFLEN <size_t>
+=item OSSL_PARAM_DIGEST_KEY_XOFLEN <unsigned integer>
 
 Sets the digest length for extendable output functions.
-It is used by the SHAKE algorithm.
+It is used by the SHAKE algorithm and should not exceed what can be given
+using a B<size_t>.
 
-=item OSSL_PARAM_DIGEST_KEY_PAD_TYPE <int>
+=item OSSL_PARAM_DIGEST_KEY_PAD_TYPE <integer>
 
 Sets the pad type.
 It is used by the MDC2 algorithm.
@@ -355,7 +356,7 @@ EVP_MD_CTX_get_params() can be used with the following OSSL_PARAM keys:
 
 =over 4
 
-=item OSSL_PARAM_DIGEST_KEY_MICALG <utf8string>.
+=item OSSL_PARAM_DIGEST_KEY_MICALG <UTF8 string>.
 
 Gets the digest Message Integrity Check algorithm string. This is used when
 creating S/MIME multipart/signed messages, as specified in RFC 3851.

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -156,7 +156,7 @@ For those KDF implementations that support it, this parameter sets the salt.
 
 The default value, if any, is implementation dependent.
 
-=item B<OSSL_KDF_PARAM_ITER> ("iter") <unsigned int>
+=item B<OSSL_KDF_PARAM_ITER> ("iter") <unsigned integer>
 
 Some KDF implementations require an iteration count.
 For those KDF implementations that support it, this parameter sets the
@@ -170,7 +170,7 @@ The default value, if any, is implementation dependent.
 
 =item B<OSSL_KDF_PARAM_DIGEST> ("digest") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <utf8string>
+=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <UTF8 string>
 
 For KDF implementations that use an underlying computation MAC or
 digest, these parameters set what the algorithm should be, and the
@@ -189,15 +189,16 @@ Some KDF implementations require a key.
 For those KDF implementations that support it, this octet string parameter
 sets the key.
 
-=item B<OSSL_KDF_PARAM_MAC_SIZE> ("maclen") <size_t>
+=item B<OSSL_KDF_PARAM_MAC_SIZE> ("maclen") <unsigned integer>
 
 Used by implementations that use a MAC with a variable output size (KMAC).
 For those KDF implementations that support it, this parameter
 sets the MAC output size.
 
 The default value, if any, is implementation dependent.
+The length must never exceed what can be given with a B<size_t>.
 
-=item B<OSSL_KDF_PARAM_SCRYPT_MAXMEM> ("macmaxmem_byteslen") <size_t>
+=item B<OSSL_KDF_PARAM_SCRYPT_MAXMEM> ("macmaxmem_byteslen") <unsigned integer>
 
 Memory-hard password-based KDF algorithms, such as scrypt, use an amount of
 memory that depends on the load factors provided as input.
@@ -208,6 +209,7 @@ If this memory usage limit is exceeded because the load factors are chosen
 too high, the key derivation will fail.
 
 The default value is implementation dependent.
+The memory size must never exceed what can be given with a B<size_t>.
 
 =back
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -210,13 +210,13 @@ This option is used by KMAC.
 These will set the MAC flags to the given numbers.
 Some MACs do not support this option.
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <utf8 string>
+=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>
+=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_DIGEST> ("digest") <utf8 string>
+=item B<OSSL_MAC_PARAM_DIGEST> ("digest") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <utf8 string>
+=item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <UTF8 string>
 
 For MAC implementations that use an underlying computation cipher or
 digest, these parameters set what the algorithm should be, and the
@@ -234,7 +234,8 @@ or SHAKE256.
 
 For MAC implementations that support it, set the output size that
 EVP_MAC_final() should produce.
-The allowed sizes vary between MAC implementations.
+The allowed sizes vary between MAC implementations, but must never exceed
+what can be given with a B<size_t>.
 
 =back
 


### PR DESCRIPTION
Use the parameter types when describing generic params.

- [x] documentation is added or updated
- [ ] tests are added or updated
