### PR TITLE
crypto/s390xcap.c: Add guards around the GETAUXVAL checks

### DIFF
--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -19,7 +19,9 @@
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 # if __GLIBC_PREREQ(2, 16)
 #  include <sys/auxv.h>
-#  define OSSL_IMPLEMENT_GETAUXVAL
+#  if defined(HWCAP_S390_STFLE) && defined(HWCAP_S390_VX)
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
 # endif
 #endif
 
@@ -82,9 +84,7 @@ void OPENSSL_cpuid_setup(void)
     /* set a bit that will not be tested later */
     OPENSSL_s390xcap_P.stfle[0] |= S390X_CAPBIT(0);
 
-#if defined(OSSL_IMPLEMENT_GETAUXVAL) \
-    && defined(HWCAP_S390_STFLE) \
-    && defined(HWCAP_S390_VX)
+#if defined(OSSL_IMPLEMENT_GETAUXVAL)
     {
         const unsigned long hwcap = getauxval(AT_HWCAP);
 

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -86,16 +86,20 @@ void OPENSSL_cpuid_setup(void)
     {
         const unsigned long hwcap = getauxval(AT_HWCAP);
 
+# ifdef HWCAP_S390_STFLE
         /* protection against missing store-facility-list-extended */
         if (hwcap & HWCAP_S390_STFLE)
             OPENSSL_s390x_facilities();
+# endif
 
+# ifdef HWCAP_S390_VX
         /* protection against disabled vector facility */
         if (!(hwcap & HWCAP_S390_VX)) {
             OPENSSL_s390xcap_P.stfle[2] &= ~(S390X_CAPBIT(S390X_VX)
                                              | S390X_CAPBIT(S390X_VXD)
                                              | S390X_CAPBIT(S390X_VXE));
         }
+# endif
     }
 #else
     {

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -82,24 +82,22 @@ void OPENSSL_cpuid_setup(void)
     /* set a bit that will not be tested later */
     OPENSSL_s390xcap_P.stfle[0] |= S390X_CAPBIT(0);
 
-#ifdef OSSL_IMPLEMENT_GETAUXVAL
+#if defined(OSSL_IMPLEMENT_GETAUXVAL) \
+    && defined(HWCAP_S390_STFLE) \
+    && defined(HWCAP_S390_VX)
     {
         const unsigned long hwcap = getauxval(AT_HWCAP);
 
-# ifdef HWCAP_S390_STFLE
         /* protection against missing store-facility-list-extended */
         if (hwcap & HWCAP_S390_STFLE)
             OPENSSL_s390x_facilities();
-# endif
 
-# ifdef HWCAP_S390_VX
         /* protection against disabled vector facility */
         if (!(hwcap & HWCAP_S390_VX)) {
             OPENSSL_s390xcap_P.stfle[2] &= ~(S390X_CAPBIT(S390X_VX)
                                              | S390X_CAPBIT(S390X_VXD)
                                              | S390X_CAPBIT(S390X_VXE));
         }
-# endif
     }
 #else
     {


### PR DESCRIPTION
HWCAP_S390_VX is missing on SUSE Linux Enterprise Server 12 SP1, so we
add a guard that checks the present of that macro.  While we're at it,
we do the same with HWCAP_S390_STFLE, for consistency.
