### PR TITLE
Fix small typo in doc for X509_STORE_CTX_new

### DIFF
--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -28,7 +28,7 @@ X509_STORE_CTX_verify_fn
  void X509_STORE_CTX_set0_trusted_stack(X509_STORE_CTX *ctx, STACK_OF(X509) *sk);
 
  void X509_STORE_CTX_set_cert(X509_STORE_CTX *ctx, X509 *x);
- STACK_OF(X509) *X509_STORE_CTX_get0_chain(X609_STORE_CTX *ctx);
+ STACK_OF(X509) *X509_STORE_CTX_get0_chain(X509_STORE_CTX *ctx);
  void X509_STORE_CTX_set0_verified_chain(X509_STORE_CTX *ctx, STACK_OF(X509) *chain);
  void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk);
 


### PR DESCRIPTION
The manpage for X509_STORE_CTX_new has a small typo. (X609 instead of X509)