### PR TITLE
Fix examples in the section 7 KDF man pages.

### DIFF
--- a/doc/man7/EVP_KDF-HKDF.pod
+++ b/doc/man7/EVP_KDF-HKDF.pod
@@ -119,8 +119,8 @@ salt value "salt" and info value "label":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                           "salt", (size_t)4);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");

--- a/doc/man7/EVP_KDF-SCRYPT.pod
+++ b/doc/man7/EVP_KDF-SCRYPT.pod
@@ -93,8 +93,8 @@ This example derives a 64-byte long test vector using scrypt with the password
  *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_SCRYPT_R, (uint32_t)8);
  *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_SCRYPT_P, (uint32_t)16);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");

--- a/doc/man7/EVP_KDF-SS.pod
+++ b/doc/man7/EVP_KDF-SS.pod
@@ -92,8 +92,8 @@ and fixedinfo value "label":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "label", (size_t)5);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
@@ -124,8 +124,8 @@ fixedinfo value "label" and salt "salt":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                           "salt", (size_t)4);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
@@ -157,8 +157,8 @@ fixedinfo value "label", salt of "salt" and KMAC outlen of 20:
                                           "salt", (size_t)4);
  *p++ = OSSL_PARAM_construct_size_t(OSSL_KDF_PARAM_MAC_SIZE, (size_t)20);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");

--- a/doc/man7/EVP_KDF-SSHKDF.pod
+++ b/doc/man7/EVP_KDF-SSHKDF.pod
@@ -125,7 +125,7 @@ This example derives an 8 byte IV using SHA-256 with a 1K "key" and appropriate
  *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_SSHKDF_TYPE,
                                  EVP_KDF_SSHKDF_TYPE_INITIAL_IV_CLI_TO_SRV);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0)
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
      /* Error */
 
  if (EVP_KDF_derive(kctx, out, &outlen) <= 0)

--- a/doc/man7/EVP_KDF-TLS1_PRF.pod
+++ b/doc/man7/EVP_KDF-TLS1_PRF.pod
@@ -80,8 +80,8 @@ and seed value "seed":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
                                           "seed", (size_t)4);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");

--- a/doc/man7/EVP_KDF-X942.pod
+++ b/doc/man7/EVP_KDF-X942.pod
@@ -85,8 +85,8 @@ keying material:
                                          SN_id_smime_alg_CMS3DESwrap,
                                          strlen(SN_id_smime_alg_CMS3DESwrap));
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0)
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
+     error("EVP_KDF_CTX_set_params");
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0)
      error("EVP_KDF_derive");
 

--- a/doc/man7/EVP_KDF-X963.pod
+++ b/doc/man7/EVP_KDF-X963.pod
@@ -72,8 +72,8 @@ value "label":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "label", (size_t)5);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_set_params");
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
+     error("EVP_KDF_CTX_set_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");


### PR DESCRIPTION
All of the examples called `EVP_KDF_set_params()` when they should have been
calling `EVP_KDF_CTX_set_params()`.

- [x] documentation is added or updated
