### PR TITLE
Fix aesni_xts compile error

### DIFF
--- a/providers/common/ciphers/cipher_aes_xts_hw.c
+++ b/providers/common/ciphers/cipher_aes_xts_hw.c
@@ -84,7 +84,7 @@ static int cipher_hw_aesni_xts_initkey(PROV_CIPHER_CTX *ctx,
     PROV_AES_XTS_CTX *xctx = (PROV_AES_XTS_CTX *)ctx;
 
     XTS_SET_KEY_FN(aesni_set_encrypt_key, aesni_set_decrypt_key,
-                   aesni_xts_encrypt, aesni_decrypt,
+                   aesni_encrypt, aesni_decrypt,
                    aesni_xts_encrypt, aesni_xts_decrypt);
     return 1;
 }


### PR DESCRIPTION
Block copy bug..

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
