### PR TITLE
Fix Compiler error/warning for windows icl build

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -73,7 +73,7 @@ static __inline__ int CRYPTO_DOWN_REF(int *val, int *ret, void *lock)
         __atomic_thread_fence(__ATOMIC_ACQUIRE);
     return 1;
 }
-#  elif defined (__ICL)
+#  elif defined(__ICL) && defined(_WIN32)
 #   define HAVE_ATOMICS 1
 typedef volatile int CRYPTO_REF_COUNT;
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -73,6 +73,21 @@ static __inline__ int CRYPTO_DOWN_REF(int *val, int *ret, void *lock)
         __atomic_thread_fence(__ATOMIC_ACQUIRE);
     return 1;
 }
+#  elif defined (__ICL)
+#   define HAVE_ATOMICS 1
+typedef volatile int CRYPTO_REF_COUNT;
+
+static __inline int CRYPTO_UP_REF(volatile int *val, int *ret, void *lock)
+{
+    *ret = _InterlockedExchangeAdd((void *)val, 1) + 1;
+    return 1;
+}
+
+static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret, void *lock)
+{
+    *ret = _InterlockedExchangeAdd((void *)val, -1) - 1;
+    return 1;
+}
 
 #  elif defined(_MSC_VER) && _MSC_VER>=1200
 


### PR DESCRIPTION
On x86 build the following warning/error is reported..

../include/internal/refcount.h(117): warning #2330: argument of type "volatile int *" is incompatible with parameter of type "void *" (dropping qualifiers)
      *ret = _InterlockedExchangeAdd(val, 1) + 1;
                                     ^
../include/internal/refcount.h(123): warning #2330: argument of type "volatile int *" is incompatible with parameter of type "void *" (dropping qualifiers)
      *ret = _InterlockedExchangeAdd(val, -1) - 1


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
