### PR TITLE
Update dgst.c to show a list of message digests

### DIFF
--- a/Configure
+++ b/Configure
@@ -1213,7 +1213,7 @@ $config{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
 # The actual processing of these entries is done in the build.info lookup
 # loop further down.
 #
-# The key is a Unix formated path in the source tree, the value is an index
+# The key is a Unix formatted path in the source tree, the value is an index
 # into %disabled_info, so any existing path gets added to a corresponding
 # 'skipped' entry in there with the list of skipped directories.
 my %skipdir = ();

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -19,6 +19,7 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 #include <openssl/hmac.h>
+#include <ctype.h>
 
 #undef BUFSIZE
 #define BUFSIZE 1024*8
@@ -27,9 +28,15 @@ int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
           EVP_PKEY *key, unsigned char *sigin, int siglen,
           const char *sig_name, const char *md_name,
           const char *file);
+static void show_digests(const OBJ_NAME *name, void *bio_);
+
+struct doall_dgst_digests {
+    BIO *bio;
+    int n;
+};
 
 typedef enum OPTION_choice {
-    OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
+    OPT_ERR = -1, OPT_EOF = 0, OPT_HELP, OPT_LIST,
     OPT_C, OPT_R, OPT_OUT, OPT_SIGN, OPT_PASSIN, OPT_VERIFY,
     OPT_PRVERIFY, OPT_SIGNATURE, OPT_KEYFORM, OPT_ENGINE, OPT_ENGINE_IMPL,
     OPT_HEX, OPT_BINARY, OPT_DEBUG, OPT_FIPS_FINGERPRINT,
@@ -43,6 +50,7 @@ const OPTIONS dgst_options[] = {
     {OPT_HELP_STR, 1, '-',
         "  file... files to digest (default is stdin)\n"},
     {"help", OPT_HELP, '-', "Display this summary"},
+    {"list", OPT_LIST, '-', "List digests"},
     {"c", OPT_C, '-', "Print the digest with separating colons"},
     {"r", OPT_R, '-', "Print the digest in coreutils format"},
     {"out", OPT_OUT, '>', "Output to filename rather than stdout"},
@@ -92,6 +100,7 @@ int dgst_main(int argc, char **argv)
     int i, ret = 1, out_bin = -1, want_pub = 0, do_verify = 0;
     unsigned char *buf = NULL, *sigbuf = NULL;
     int engine_impl = 0;
+    struct doall_dgst_digests dec;
 
     prog = opt_progname(argv[0]);
     buf = app_malloc(BUFSIZE, "I/O buffer");
@@ -107,6 +116,15 @@ int dgst_main(int argc, char **argv)
             goto end;
         case OPT_HELP:
             opt_help(dgst_options);
+            ret = 0;
+            goto end;
+        case OPT_LIST:
+            BIO_printf(bio_out, "Supported digests:\n");
+            dec.bio = bio_out;
+            dec.n = 0;
+            OBJ_NAME_do_all_sorted(OBJ_NAME_TYPE_MD_METH,
+                                   show_digests, &dec);
+            BIO_printf(bio_out, "\n");
             ret = 0;
             goto end;
         case OPT_C:
@@ -412,6 +430,32 @@ int dgst_main(int argc, char **argv)
     BIO_free(bmd);
     release_engine(e);
     return ret;
+}
+
+static void show_digests(const OBJ_NAME *name, void *arg)
+{
+    struct doall_dgst_digests *dec = (struct doall_dgst_digests *)arg;
+    const EVP_MD *md = NULL;
+
+    /* Filter out signed digests (a.k.a signature algorithms) */
+    if (strstr(name->name, "rsa") != NULL || strstr(name->name, "RSA") != NULL)
+        return;
+
+    if (!islower((unsigned char)*name->name))
+        return;
+
+    /* Filter out message digests that we cannot use */
+    md = EVP_get_digestbyname(name->name);
+    if (md == NULL)
+        return;
+
+    BIO_printf(dec->bio, "-%-25s", name->name);
+    if (++dec->n == 3) {
+        BIO_printf(dec->bio, "\n");
+        dec->n = 0;
+    } else {
+        BIO_printf(dec->bio, " ");
+    }
 }
 
 /*

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -51,7 +51,9 @@ typedef enum OPTION_choice {
 const OPTIONS enc_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
     {"list", OPT_LIST, '-', "List ciphers"},
+#if !OPENSSL_API_3
     {"ciphers", OPT_LIST, '-', "Alias for -list"},
+#endif
     {"in", OPT_IN, '<', "Input file"},
     {"out", OPT_OUT, '>', "Output file"},
     {"pass", OPT_PASS, 's', "Passphrase source"},

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -50,7 +50,8 @@ typedef enum OPTION_choice {
 
 const OPTIONS enc_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
-    {"ciphers", OPT_LIST, '-', "List ciphers"},
+    {"list", OPT_LIST, '-', "List ciphers"},
+    {"ciphers", OPT_LIST, '-', "Alias for -list"},
     {"in", OPT_IN, '<', "Input file"},
     {"out", OPT_OUT, '>', "Output file"},
     {"pass", OPT_PASS, 's', "Passphrase source"},

--- a/doc/man1/openssl-dgst.pod
+++ b/doc/man1/openssl-dgst.pod
@@ -11,6 +11,7 @@ B<openssl dgst>
 [B<-help>]
 [B<-c>]
 [B<-d>]
+[B<-list>]
 [B<-hex>]
 [B<-binary>]
 [B<-r>]
@@ -65,6 +66,10 @@ B<hex> format output is used.
 =item B<-d>
 
 Print out BIO debugging information.
+
+=item B<-list>
+
+Prints out a list of supported message digests.
 
 =item B<-hex>
 

--- a/doc/man1/openssl-enc.pod
+++ b/doc/man1/openssl-enc.pod
@@ -428,6 +428,8 @@ The default digest was changed from MD5 to SHA256 in OpenSSL 1.1.0.
 
 The B<-list> option was added in OpenSSL 1.1.1e.
 
+The B<-ciphers> option was deprecated in OpenSSL 3.0.
+
 =head1 COPYRIGHT
 
 Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man1/openssl-enc.pod
+++ b/doc/man1/openssl-enc.pod
@@ -9,6 +9,7 @@ openssl-enc - symmetric cipher routines
 B<openssl>
 [B<-I<cipher>>]
 [B<-help>]
+[B<-list>]
 [B<-ciphers>]
 [B<-in> I<filename>]
 [B<-out> I<filename>]
@@ -58,9 +59,13 @@ either by itself or in addition to the encryption or decryption.
 
 Print out a usage message.
 
-=item B<-ciphers>
+=item B<-list>
 
 List all supported ciphers.
+
+=item B<-ciphers>
+
+Alias of -list to display all supported ciphers.
 
 =item B<-in> I<filename>
 
@@ -420,6 +425,8 @@ certain parameters. So if, for example, you want to use RC2 with a
 =head1 HISTORY
 
 The default digest was changed from MD5 to SHA256 in OpenSSL 1.1.0.
+
+The B<-list> option was added in OpenSSL 1.1.1e.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Work in progress PR for review on adding the `-list` option to dgst.c to match enc.c.
This PR follows the implementation steps provided in issue-9893:

> For openssl dgst, the option can be implemented analogously. Here is an outline of what's to be done:
> - Copy the relevant code from apps/enc.c to apps/dgst.c replacing OBJ_NAME_TYPE_CIPHER_METH with OBJ_NAME_TYPE_MD_METH.
> - Copy show_ciphers() to show_digests() and adjust it accordingly.
> - Add a -list option for enc and dgst, but keep the -ciphers option.
> - Update the documentation

Fixes #9893

