### PR TITLE
include/openssl/macros.h: Rework OPENSSL_FUNC for div C standards

### DIFF
--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -131,6 +131,22 @@
 #  endif
 # endif
 
+/*
+ * __func__ was standardized in C99, so for any compiler that claims
+ * to implement that language level or newer, we assume we can safely
+ * used that symbol.
+ *
+ * GNU C also provides __FUNCTION__ since version 2, which predates
+ * C99.  We can, however, only use this if __STDC_VERSION exists,
+ * as it's otherwise not allowed according to ISO C standards (C90).
+ * (compiling with GNU C's -pedantic tells us so)
+ *
+ * If none of the above applies, we check if the compiler is MSVC,
+ * and use __FUNCTION__ if that's the case.
+ *
+ * If all these possibilities are exhausted, we give up and use a
+ * static string.
+ */
 # ifndef OPENSSL_FUNC
 #  if defined(__STDC_VERSION__)
 #   if __STDC_VERSION__ >= 199901L
@@ -140,8 +156,6 @@
 #   endif
 #  elif defined(_MSC_VER)
 #    define OPENSSL_FUNC __FUNCTION__
-#  elif defined(__FUNCSIG__)
-#   define OPENSSL_FUNC __FUNCSIG__
 #  else
 #   define OPENSSL_FUNC "(unknown function)"
 #  endif

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -134,10 +134,10 @@
 /*
  * __func__ was standardized in C99, so for any compiler that claims
  * to implement that language level or newer, we assume we can safely
- * used that symbol.
+ * use that symbol.
  *
  * GNU C also provides __FUNCTION__ since version 2, which predates
- * C99.  We can, however, only use this if __STDC_VERSION exists,
+ * C99.  We can, however, only use this if __STDC_VERSION__ exists,
  * as it's otherwise not allowed according to ISO C standards (C90).
  * (compiling with GNU C's -pedantic tells us so)
  *

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -132,12 +132,14 @@
 # endif
 
 # ifndef OPENSSL_FUNC
-#  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#   define OPENSSL_FUNC __func__
-#  elif defined(__STRICT_ANSI__)
-#   define OPENSSL_FUNC "(unknown function)"
-#  elif defined(_MSC_VER) || (defined(__GNUC__) && __GNUC__ >= 2)
-#   define OPENSSL_FUNC __FUNCTION__
+#  if defined(__STDC_VERSION__)
+#   if __STDC_VERSION__ >= 199901L
+#    define OPENSSL_FUNC __func__
+#   elif defined(__GNUC__) && __GNUC__ >= 2
+#    define OPENSSL_FUNC __FUNCTION__
+#   endif
+#  elif defined(_MSC_VER)
+#    define OPENSSL_FUNC __FUNCTION__
 #  elif defined(__FUNCSIG__)
 #   define OPENSSL_FUNC __FUNCSIG__
 #  else


### PR DESCRIPTION
OPENSSL_FUNC was defined as an alias for __FUNCTION__ with new enough
GNU C, regardless of the language standard used.  We change this
slightly, so this won't happen unless __STDC_VERSION is defined.

Fixes #9911
