### PR TITLE
Add option grouping to pkcs12 app

### DIFF
--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -277,6 +277,10 @@ typedef struct options_st {
      */
     int valtype;
     const char *helpstr;
+    /*
+     * Group options for better readability
+     */
+    int group;
 } OPTIONS;
 
 /*
@@ -338,6 +342,7 @@ int opt_num_rest(void);
 int opt_verify(int i, X509_VERIFY_PARAM *vpm);
 int opt_rand(int i);
 void opt_help(const OPTIONS * list);
+void opt_help_ex(const OPTIONS * list, const char** groups, int num_groups);
 int opt_format_error(const char *s, unsigned long flags);
 int opt_isdir(const char *name);
 int opt_printf_stderr(const char *fmt, ...);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -832,40 +832,16 @@ static const char *valtype2param(const OPTIONS *o)
     return "parm";
 }
 
-void opt_help(const OPTIONS *list)
+void opt_print(const OPTIONS *o, int width, const char** groups)
 {
-    const OPTIONS *o;
-    int i;
-    int standard_prolog;
-    int width = 5;
+    const char* help;
     char start[80 + 1];
     char *p;
-    const char *help;
 
-    /* Starts with its own help message? */
-    standard_prolog = list[0].name != OPT_HELP_STR;
-
-    /* Find the widest help. */
-    for (o = list; o->name; o++) {
-        if (o->name == OPT_MORE_STR)
-            continue;
-        i = 2 + (int)strlen(o->name);
-        if (o->valtype != '-')
-            i += 1 + strlen(valtype2param(o));
-        if (i < MAX_OPT_HELP_WIDTH && i > width)
-            width = i;
-        OPENSSL_assert(i < (int)sizeof(start));
-    }
-
-    if (standard_prolog)
-        opt_printf_stderr("Usage: %s [options]\nValid options are:\n", prog);
-
-    /* Now let's print. */
-    for (o = list; o->name; o++) {
         help = o->helpstr ? o->helpstr : "(No additional info)";
         if (o->name == OPT_HELP_STR) {
             opt_printf_stderr(help, prog);
-            continue;
+            return;
         }
 
         /* Pad out prefix */
@@ -876,7 +852,7 @@ void opt_help(const OPTIONS *list)
             /* Continuation of previous line; pad and print. */
             start[width] = '\0';
             opt_printf_stderr("%s  %s\n", start, help);
-            continue;
+            return;
         }
 
         /* Build up the "-flag [param]" part. */
@@ -899,7 +875,60 @@ void opt_help(const OPTIONS *list)
         }
         start[width] = '\0';
         opt_printf_stderr("%s  %s\n", start, help);
+}
+
+void opt_help_ex(const OPTIONS *list, const char** groups, int num_groups)
+{
+    const OPTIONS *o;
+    int i;
+    int grp;
+    int standard_prolog;
+    int width = 5;
+    char start[80 + 1];
+    char *p;
+    const char *help;
+
+    /* Starts with its own help message? */
+    standard_prolog = list[0].name != OPT_HELP_STR;
+
+    /* Find the widest help. */
+    for (o = list; o->name; o++) {
+        if (o->name == OPT_MORE_STR)
+            continue;
+        i = 2 + (int)strlen(o->name);
+        if (o->valtype != '-')
+            i += 1 + strlen(valtype2param(o));
+        if (groups != NULL)
+            i += 1 + strlen(groups[o->group]);
+        if (i < MAX_OPT_HELP_WIDTH && i > width)
+            width = i;
+        OPENSSL_assert(i < (int)sizeof(start));
     }
+
+    if (standard_prolog)
+        opt_printf_stderr("Usage: %s [options]\n", prog);
+        if (groups == NULL)
+            opt_printf_stderr("Valid options are:\n");
+
+    /* Now let's print. */
+    if (groups != NULL) {
+        for (grp = 0; grp < num_groups; grp++) {
+            opt_printf_stderr("%s options:\n", groups[grp]);
+            for (o = list; o->name; o++) {
+                if (o->group == grp)
+                    opt_print(o, width, groups);
+            }
+        }
+    } else {
+        for (o = list; o->name; o++) {
+            opt_print(o, width, groups);
+        }
+    }
+}
+
+void opt_help(const OPTIONS *list)
+{
+    return opt_help_ex(list, NULL, 0);
 }
 
 /* opt_isdir section */

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -60,58 +60,73 @@ typedef enum OPTION_choice {
     OPT_R_ENUM
 } OPTION_CHOICE;
 
+typedef enum OPTION_group {
+    OPT_GRP_GENERAL = 0,
+    OPT_GRP_PASSWORD,
+    OPT_GRP_ENCRYPT,
+    OPT_GRP_MAC,
+    OPT_GRP_CA,
+    OPT_GRP_ATTR,
+    OPT_GRP_INPUT,
+    OPT_GRP_OUTPUT,
+} OPTION_GROUP;
+
+const char* pkcs12_opt_groups[] = {
+    "General", "Password", "Encryption", "MAC", "CA Certificate", "Attribute", "Input", "Output"
+};
+
 const OPTIONS pkcs12_options[] = {
-    {"help", OPT_HELP, '-', "Display this summary"},
-    {"nokeys", OPT_NOKEYS, '-', "Don't output private keys"},
+    {"help", OPT_HELP, '-', "Display this summary", OPT_GRP_GENERAL},
+    {"nokeys", OPT_NOKEYS, '-', "Don't output private keys", OPT_GRP_OUTPUT},
     {"keyex", OPT_KEYEX, '-', "Set MS key exchange type"},
     {"keysig", OPT_KEYSIG, '-', "Set MS key signature type"},
-    {"nocerts", OPT_NOCERTS, '-', "Don't output certificates"},
-    {"clcerts", OPT_CLCERTS, '-', "Only output client certificates"},
-    {"cacerts", OPT_CACERTS, '-', "Only output CA certificates"},
-    {"noout", OPT_NOOUT, '-', "Don't output anything, just verify"},
-    {"info", OPT_INFO, '-', "Print info about PKCS#12 structure"},
+    {"nocerts", OPT_NOCERTS, '-', "Don't output certificates", OPT_GRP_OUTPUT},
+    {"clcerts", OPT_CLCERTS, '-', "Only output client certificates", OPT_GRP_OUTPUT},
+    {"cacerts", OPT_CACERTS, '-', "Only output CA certificates", OPT_GRP_OUTPUT},
+    {"noout", OPT_NOOUT, '-', "Don't output anything, just verify", OPT_GRP_OUTPUT},
+    {"info", OPT_INFO, '-', "Print info about PKCS#12 structure", OPT_GRP_OUTPUT},
     {"chain", OPT_CHAIN, '-', "Add certificate chain"},
-    {"twopass", OPT_TWOPASS, '-', "Separate MAC, encryption passwords"},
-    {"nomacver", OPT_NOMACVER, '-', "Don't verify MAC"},
+    {"twopass", OPT_TWOPASS, '-', "Separate MAC, encryption passwords", OPT_GRP_PASSWORD},
+    {"nomacver", OPT_NOMACVER, '-', "Don't verify MAC", OPT_GRP_MAC},
 # ifndef OPENSSL_NO_RC2
     {"descert", OPT_DESCERT, '-',
-     "Encrypt output with 3DES (default RC2-40)"},
+     "Encrypt output with 3DES (default RC2-40)", OPT_GRP_ENCRYPT},
     {"certpbe", OPT_CERTPBE, 's',
-     "Certificate PBE algorithm (default RC2-40)"},
+     "Certificate PBE algorithm (default RC2-40)", OPT_GRP_ENCRYPT},
 # else
-    {"descert", OPT_DESCERT, '-', "Encrypt output with 3DES (the default)"},
-    {"certpbe", OPT_CERTPBE, 's', "Certificate PBE algorithm (default 3DES)"},
+    {"descert", OPT_DESCERT, '-', "Encrypt output with 3DES (the default)", OPT_GRP_ENCRYPT},
+    {"certpbe", OPT_CERTPBE, 's', "Certificate PBE algorithm (default 3DES)", OPT_GRP_ENCRYPT},
 # endif
-    {"export", OPT_EXPORT, '-', "Output PKCS12 file"},
-    {"noiter", OPT_NOITER, '-', "Don't use encryption iteration"},
-    {"maciter", OPT_MACITER, '-', "Use MAC iteration"},
-    {"nomaciter", OPT_NOMACITER, '-', "Don't use MAC iteration"},
-    {"nomac", OPT_NOMAC, '-', "Don't generate MAC"},
+    {"export", OPT_EXPORT, '-', "Output PKCS12 file", OPT_GRP_OUTPUT},
+    {"noiter", OPT_NOITER, '-', "Don't use encryption iteration", OPT_GRP_ENCRYPT},
+    {"maciter", OPT_MACITER, '-', "Use MAC iteration", OPT_GRP_MAC},
+    {"nomaciter", OPT_NOMACITER, '-', "Don't use MAC iteration", OPT_GRP_MAC},
+    {"nomac", OPT_NOMAC, '-', "Don't generate MAC", OPT_GRP_MAC},
     {"LMK", OPT_LMK, '-',
-     "Add local machine keyset attribute to private key"},
-    {"nodes", OPT_NODES, '-', "Don't encrypt private keys"},
+     "Add local machine keyset attribute to private key", OPT_GRP_ATTR},
+    {"nodes", OPT_NODES, '-', "Don't encrypt private keys", OPT_GRP_ENCRYPT},
     {"macalg", OPT_MACALG, 's',
-     "Digest algorithm used in MAC (default SHA1)"},
-    {"keypbe", OPT_KEYPBE, 's', "Private key PBE algorithm (default 3DES)"},
+     "Digest algorithm used in MAC (default SHA1)", OPT_GRP_MAC},
+    {"keypbe", OPT_KEYPBE, 's', "Private key PBE algorithm (default 3DES)", OPT_GRP_ENCRYPT},
     OPT_R_OPTIONS,
-    {"inkey", OPT_INKEY, 's', "Private key if not infile"},
-    {"certfile", OPT_CERTFILE, '<', "Load certs from file"},
-    {"name", OPT_NAME, 's', "Use name as friendly name"},
-    {"CSP", OPT_CSP, 's', "Microsoft CSP name"},
+    {"inkey", OPT_INKEY, 's', "Private key if not infile", OPT_GRP_INPUT},
+    {"certfile", OPT_CERTFILE, '<', "Load certs from file", OPT_GRP_INPUT},
+    {"name", OPT_NAME, 's', "Use name as friendly name", OPT_GRP_ATTR},
+    {"CSP", OPT_CSP, 's', "Microsoft CSP name", OPT_GRP_ATTR},
     {"caname", OPT_CANAME, 's',
      "Use name as CA friendly name (can be repeated)"},
-    {"in", OPT_IN, '<', "Input filename"},
-    {"out", OPT_OUT, '>', "Output filename"},
-    {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
-    {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
-    {"password", OPT_PASSWORD, 's', "Set import/export password source"},
-    {"CApath", OPT_CAPATH, '/', "PEM-format directory of CA's"},
-    {"CAfile", OPT_CAFILE, '<', "PEM-format file of CA's"},
+    {"in", OPT_IN, '<', "Input filename", OPT_GRP_INPUT},
+    {"out", OPT_OUT, '>', "Output filename", OPT_GRP_OUTPUT},
+    {"passin", OPT_PASSIN, 's', "Input file pass phrase source", OPT_GRP_PASSWORD},
+    {"passout", OPT_PASSOUT, 's', "Output file pass phrase source", OPT_GRP_PASSWORD},
+    {"password", OPT_PASSWORD, 's', "Set import/export password source", OPT_GRP_PASSWORD},
+    {"CApath", OPT_CAPATH, '/', "PEM-format directory of CA's", OPT_GRP_CA},
+    {"CAfile", OPT_CAFILE, '<', "PEM-format file of CA's", OPT_GRP_CA},
     {"no-CAfile", OPT_NOCAFILE, '-',
-     "Do not load the default certificates file"},
+     "Do not load the default certificates file", OPT_GRP_CA},
     {"no-CApath", OPT_NOCAPATH, '-',
-     "Do not load certificates from the default certificates directory"},
-    {"", OPT_CIPHER, '-', "Any supported cipher"},
+     "Do not load certificates from the default certificates directory", OPT_GRP_CA},
+    {"", OPT_CIPHER, '-', "Any supported cipher", OPT_GRP_ENCRYPT},
 # ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
 # endif
@@ -154,7 +169,7 @@ int pkcs12_main(int argc, char **argv)
             BIO_printf(bio_err, "%s: Use -help for summary.\n", prog);
             goto end;
         case OPT_HELP:
-            opt_help(pkcs12_options);
+            opt_help_ex(pkcs12_options, pkcs12_opt_groups, sizeof(pkcs12_opt_groups)/sizeof(char*));
             ret = 0;
             goto end;
         case OPT_NOKEYS:


### PR DESCRIPTION
Added a way to group options which is backward compatible with existing apps. The new function is opt_help_ex() which accepts a set of option groups.

The output from 'openssl pkcs12 --help' would be:

```
Usage: pkcs12 [options]
General options:
 -help                       Display this summary
 -keyex                      Set MS key exchange type
 -keysig                     Set MS key signature type
 -chain                      Add certificate chain
 -rand val                   Load the file(s) into the random number generator
 -writerand outfile          Write random data to the specified file
 -caname val                 Use name as CA friendly name (can be repeated)
 -engine val                 Use engine, possibly a hardware device
Password options:
 -twopass                    Separate MAC, encryption passwords
 -passin val                 Input file pass phrase source
 -passout val                Output file pass phrase source
 -password val               Set import/export password source
Encryption options:
 -descert                    Encrypt output with 3DES (default RC2-40)
 -certpbe val                Certificate PBE algorithm (default RC2-40)
 -noiter                     Don't use encryption iteration
 -nodes                      Don't encrypt private keys
 -keypbe val                 Private key PBE algorithm (default 3DES)
 -*                          Any supported cipher
MAC options:
 -nomacver                   Don't verify MAC
 -maciter                    Use MAC iteration
 -nomaciter                  Don't use MAC iteration
 -nomac                      Don't generate MAC
 -macalg val                 Digest algorithm used in MAC (default SHA1)
CA Certificate options:
 -CApath dir                 PEM-format directory of CA's
 -CAfile infile              PEM-format file of CA's
 -no-CAfile                  Do not load the default certificates file
 -no-CApath                  Do not load certificates from the default certificates directory
Attribute options:
 -LMK                        Add local machine keyset attribute to private key
 -name val                   Use name as friendly name
 -CSP val                    Microsoft CSP name
Input options:
 -inkey val                  Private key if not infile
 -certfile infile            Load certs from file
 -in infile                  Input filename
Output options:
 -nokeys                     Don't output private keys
 -nocerts                    Don't output certificates
 -clcerts                    Only output client certificates
 -cacerts                    Only output CA certificates
 -noout                      Don't output anything, just verify
 -info                       Print info about PKCS#12 structure
 -export                     Output PKCS12 file
 -out outfile                Output filename
```
