### PR TITLE
[KDF] Add KBKDF implementation for counter-mode HMAC

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2684,6 +2684,7 @@ PROV_R_INVALID_IV_LENGTH:109:invalid iv length
 PROV_R_INVALID_KEYLEN:117:invalid keylen
 PROV_R_INVALID_KEY_LEN:124:invalid key len
 PROV_R_INVALID_KEY_LENGTH:105:invalid key length
+PROV_R_INVALID_MAC:151:invalid mac
 PROV_R_INVALID_MODE:125:invalid mode
 PROV_R_INVALID_MODE_INT:126:invalid mode int
 PROV_R_INVALID_SALT_LENGTH:112:invalid salt length
@@ -2691,6 +2692,7 @@ PROV_R_INVALID_TAG:110:invalid tag
 PROV_R_INVALID_TAGLEN:118:invalid taglen
 PROV_R_MISSING_CEK_ALG:144:missing cek alg
 PROV_R_MISSING_KEY:128:missing key
+PROV_R_MISSING_MAC:150:missing mac
 PROV_R_MISSING_MESSAGE_DIGEST:129:missing message digest
 PROV_R_MISSING_PASS:130:missing pass
 PROV_R_MISSING_SALT:131:missing salt

--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -1,0 +1,115 @@
+=pod
+
+=head1 NAME
+
+EVP_KDF-KB - The Key-Based EVP_KDF implementation
+
+=head1 DESCRIPTION
+
+The EVP_KDF-KB algorithm implements the Key-Based key derivation function
+(KBKDF).  KBKDF derives a key from repeated application of a keyed MAC to an
+input secret (and other optional values).
+
+=head2 Identity
+
+"KBKDF" is the name for this implementation; it can be used with the
+EVP_KDF_fetch() function.
+
+=head2 Supported parameters
+
+The supported parameters are:
+
+=over 4
+
+=item B<OSSL_KDF_PARAM_PROPERTIES> ("properties") <UTF8 string>
+
+=item B<OSSL_KDF_PARAM_DIGEST> ("digest") <UTF8 string>
+
+=item B<OSSL_KDF_PARAM_DIGEST> ("mac") <UTF8 string>
+
+=item B<OSSL_KDF_PARAM_KEY> ("key") <octet string>
+
+=item B<OSSL_KDF_PARAM_SALT> ("salt") <octet string>
+
+=item B<OSSL_KDF_PARAM_INFO> ("info") <octet string>
+
+=back
+
+The parameters key, salt, and info correspond to KI, Label, and Context
+(respectively) in SP800-108.  As in that document, salt and info are optional
+and may be omitted.  Currently, only HMAC is supported for mac.
+
+=head1 NOTES
+
+A context for KBKDF can be obtained by calling:
+
+ EVP_KDF *kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
+ EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+
+The output length of an KBKDF is specified via the C<keylen>
+parameter to the L<EVP_KDF_derive(3)> function.
+
+Note that currently OpenSSL only implements Counter mode with HMAC.  Other
+variants may be supported in the future.
+
+=head1 EXAMPLES
+
+This example derives 10 bytes using COUNTER-HMAC-SHA256, with KI "secret",
+Label "label", and Context "context".
+
+ EVP_KDF *kdf;
+ EVP_KDF_CTX *kctx;
+ unsigned char out[10];
+ OSSL_PARAM params[6], *p = params;
+
+ kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
+ kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_free(kdf);
+
+ *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+                                         "SHA256", 0);
+ *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC,
+                                         "HMAC", 0);
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+                                          "secret", strlen("secret"))
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
+                                          "context", strlen("context"));
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                                          "label", strlen("label"));
+ *p = OSSL_PARAM_construct_end();
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
+     error("EVP_KDF_CTX_set_params");
+ else if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0)
+     error("EVP_KDF_derive");
+
+ EVP_KDF_CTX_free(kctx);
+
+=head1 CONFORMING TO
+
+NIST SP800-108, IETF RFC 8009.
+
+=head1 SEE ALSO
+
+L<EVP_KDF(3)>,
+L<EVP_KDF_CTX_new_id(3)>,
+L<EVP_KDF_CTX_free(3)>,
+L<EVP_KDF_ctrl(3)>,
+L<EVP_KDF_size(3)>,
+L<EVP_KDF_derive(3)>,
+L<EVP_KDF(3)/PARAMETERS>
+
+=head1 HISTORY
+
+This functionality was added to OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -136,6 +136,7 @@ extern "C" {
 #define OSSL_KDF_NAME_TLS1_PRF      "TLS1-PRF"
 #define OSSL_KDF_NAME_X942KDF       "X942KDF"
 #define OSSL_KDF_NAME_X963KDF       "X963KDF"
+#define OSSL_KDF_NAME_KBKDF         "KBKDF"
 
 /* PKEY parameters */
 /* Diffie-Hellman/DSA Parameters */

--- a/providers/common/include/internal/provider_algs.h
+++ b/providers/common/include/internal/provider_algs.h
@@ -212,6 +212,7 @@ extern const OSSL_DISPATCH kdf_hkdf_functions[];
 extern const OSSL_DISPATCH kdf_sshkdf_functions[];
 extern const OSSL_DISPATCH kdf_sskdf_functions[];
 extern const OSSL_DISPATCH kdf_x963_kdf_functions[];
+extern const OSSL_DISPATCH kdf_kbkdf_functions[];
 #ifndef OPENSSL_NO_CMS
 extern const OSSL_DISPATCH kdf_x942_kdf_functions[];
 #endif

--- a/providers/common/include/internal/providercommonerr.h
+++ b/providers/common/include/internal/providercommonerr.h
@@ -69,6 +69,7 @@ int ERR_load_PROV_strings(void);
 # define PROV_R_INVALID_KEYLEN                            117
 # define PROV_R_INVALID_KEY_LEN                           124
 # define PROV_R_INVALID_KEY_LENGTH                        105
+# define PROV_R_INVALID_MAC                               151
 # define PROV_R_INVALID_MODE                              125
 # define PROV_R_INVALID_MODE_INT                          126
 # define PROV_R_INVALID_SALT_LENGTH                       112
@@ -76,6 +77,7 @@ int ERR_load_PROV_strings(void);
 # define PROV_R_INVALID_TAGLEN                            118
 # define PROV_R_MISSING_CEK_ALG                           144
 # define PROV_R_MISSING_KEY                               128
+# define PROV_R_MISSING_MAC                               150
 # define PROV_R_MISSING_MESSAGE_DIGEST                    129
 # define PROV_R_MISSING_PASS                              130
 # define PROV_R_MISSING_SALT                              131

--- a/providers/common/kdfs/build.info
+++ b/providers/common/kdfs/build.info
@@ -1,4 +1,4 @@
-$COMMON=tls1_prf.c hkdf.c pbkdf2.c sskdf.c
+$COMMON=tls1_prf.c hkdf.c kbkdf.c pbkdf2.c sskdf.c
 
 LIBS=../../../libcrypto
 SOURCE[../../../libcrypto]=$COMMON

--- a/providers/common/kdfs/kbkdf.c
+++ b/providers/common/kdfs/kbkdf.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This implements https://csrc.nist.gov/publications/detail/sp/800-108/final
+ * section 5.1 ("counter mode") in HMAC only.  That document does not name the
+ * KDFs it defines; the name is derived from
+ * https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Key-Derivation
+ *
+ * Note that sections 5.2 ("feedback mode") and 5.3 ("double-pipeline mode")
+ * are not implemented, though it would be possible to do so in the future.
+ * CMAC mode is also not implemented; some plumbing would be required.
+ *
+ * These versions all assume the counter is used.  It would be relatively
+ * straightforward to expose a configuration handle should the need arise.
+ *
+ * Variable names attempt to match those of SP800-108.
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/kdf.h>
+#include <openssl/params.h>
+
+#include "internal/cryptlib.h"
+#include "internal/evp_int.h"
+#include "internal/numbers.h"
+#include "internal/provider_algs.h"
+#include "internal/provider_ctx.h"
+#include "internal/provider_util.h"
+#include "internal/providercommonerr.h"
+
+#include "e_os.h"
+
+#define MIN(a, b) ((a) < (b)) ? (a) : (b)
+
+/* Our context structure. */
+typedef struct {
+    void *provctx;
+    EVP_MAC_CTX *ctx_init;
+
+    /* Names are lowercased versions of those found in SP800-108. */
+    unsigned char *ki;
+    size_t ki_len;
+    unsigned char *label;
+    size_t label_len;
+    unsigned char *context;
+    size_t context_len;
+} KBKDF;
+
+/* Definitions needed for typechecking. */
+static OSSL_OP_kdf_newctx_fn kbkdf_new;
+static OSSL_OP_kdf_freectx_fn kbkdf_free;
+static OSSL_OP_kdf_reset_fn kbkdf_reset;
+static OSSL_OP_kdf_derive_fn kbkdf_derive;
+static OSSL_OP_kdf_settable_ctx_params_fn kbkdf_settable_ctx_params;
+static OSSL_OP_kdf_set_ctx_params_fn kbkdf_set_ctx_params;
+
+/* Not all platforms have htobe32(). */
+static uint32_t be32(uint32_t host)
+{
+    uint32_t big = 0;
+    const union {
+        long one;
+        char little;
+    } is_endian = { 1 };
+
+    if (!is_endian.little)
+        return host;
+
+    big |= (host & 0xff000000) >> 24;
+    big |= (host & 0x00ff0000) >> 8;
+    big |= (host & 0x0000ff00) << 8;
+    big |= (host & 0x000000ff) << 24;
+    return big;
+}
+
+static void *kbkdf_new(void *provctx)
+{
+    KBKDF *ctx;
+
+    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+
+    ctx->provctx = provctx;
+    return ctx;
+}
+
+static void kbkdf_free(void *vctx)
+{
+    KBKDF *ctx = (KBKDF *)vctx;
+
+    kbkdf_reset(ctx);
+    OPENSSL_free(ctx);
+}
+
+static void kbkdf_reset(void *vctx)
+{
+    KBKDF *ctx = (KBKDF *)vctx;
+
+    EVP_MAC_CTX_free(ctx->ctx_init);
+    OPENSSL_clear_free(ctx->context, ctx->context_len);
+    OPENSSL_clear_free(ctx->label, ctx->label_len);
+    OPENSSL_clear_free(ctx->ki, ctx->ki_len);
+    memset(ctx, 0, sizeof(*ctx));
+}
+
+/* SP800-108 section 5.1. */
+static int kbkdf_derive_counter(EVP_MAC_CTX *ctx_init,
+                                unsigned char *label, size_t label_len,
+                                unsigned char *context, size_t context_len,
+                                unsigned char *k_i, size_t h, uint32_t l,
+                                unsigned char *ko, size_t ko_len)
+{
+    int ret = 0;
+    EVP_MAC_CTX *ctx = NULL;
+    size_t written = 0, to_write;
+    const unsigned char zero = 0;
+    uint32_t counter, i;
+
+    for (counter = 1; written < ko_len; counter++) {
+        i = be32(counter);
+
+        ctx = EVP_MAC_CTX_dup(ctx_init);
+        if (ctx == NULL)
+            goto done;
+
+        if (!EVP_MAC_update(ctx, (unsigned char *)&i, 4)
+            || !EVP_MAC_update(ctx, label, label_len)
+            || !EVP_MAC_update(ctx, &zero, 1)
+            || !EVP_MAC_update(ctx, context, context_len)
+            || !EVP_MAC_update(ctx, (unsigned char *)&l, 4)
+            || !EVP_MAC_final(ctx, k_i, NULL, h))
+            goto done;
+
+        to_write = ko_len - written;
+        memcpy(ko + written, k_i, MIN(to_write, h));
+        written += h;
+
+        EVP_MAC_CTX_free(ctx);
+        ctx = NULL;
+    }
+
+    ret = 1;
+done:
+    EVP_MAC_CTX_free(ctx);
+    return ret;
+}
+
+static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen)
+{
+    KBKDF *ctx = (KBKDF *)vctx;
+    int ret = 0;
+    unsigned char *k_i = NULL;
+    uint32_t l = be32(keylen * 8);
+    size_t h = 0;
+
+    /* Label and Context are permitted to be empty. Check everything else. */
+    if (ctx->ctx_init == NULL) {
+        if (ctx->ki_len == 0 || ctx->ki == NULL) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+            return 0;
+        }
+        /* Could either be missing MAC or missing message digest -
+         * arbitrarily, I pick this one. */
+        ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_MAC);
+        return 0;
+    }
+
+    h = EVP_MAC_size(ctx->ctx_init);
+    if (h == 0)
+        goto done;
+
+    k_i = OPENSSL_zalloc(h);
+    if (k_i == NULL)
+        goto done;
+
+    ret = kbkdf_derive_counter(
+        ctx->ctx_init, ctx->label, ctx->label_len, ctx->context,
+        ctx->context_len, k_i, h, l, key, keylen);
+done:
+    if (ret != 1)
+        OPENSSL_cleanse(key, keylen);
+    OPENSSL_clear_free(k_i, h);
+    return ret;
+}
+
+static int kbkdf_set_buffer(unsigned char **out, size_t *out_len,
+                            const OSSL_PARAM *p)
+{
+    if (p->data == NULL || p->data_size == 0)
+        return 1;
+
+    OPENSSL_clear_free(*out, *out_len);
+    *out = NULL;
+    return OSSL_PARAM_get_octet_string(p, (void **)out, 0, out_len);
+}
+
+static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    KBKDF *ctx = (KBKDF *)vctx;
+    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    const OSSL_PARAM *p;
+    OSSL_PARAM mparams[2];
+
+    if (!ossl_prov_macctx_load_from_params(&ctx->ctx_init, params, NULL,
+                                           NULL, NULL, libctx))
+        return 0;
+    else if (ctx->ctx_init != NULL
+        && !EVP_MAC_is_a(EVP_MAC_CTX_mac(ctx->ctx_init),
+                         OSSL_MAC_NAME_HMAC)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_MAC);
+        return 0;
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_KEY);
+    if (p != NULL && !kbkdf_set_buffer(&ctx->ki, &ctx->ki_len, p))
+        return 0;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_SALT);
+    if (p != NULL && !kbkdf_set_buffer(&ctx->label, &ctx->label_len, p))
+        return 0;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_INFO);
+    if (p != NULL && !kbkdf_set_buffer(&ctx->context, &ctx->context_len, p))
+        return 0;
+
+    /* Set up digest context, if we can. */
+    if (ctx->ctx_init != NULL && ctx->ki_len != 0) {
+        mparams[0] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
+                                                       ctx->ki, ctx->ki_len);
+        mparams[1] = OSSL_PARAM_construct_end();
+
+        if (!EVP_MAC_CTX_set_params(ctx->ctx_init, mparams)
+            || !EVP_MAC_init(ctx->ctx_init))
+            return 0;
+    }
+
+    return 1;
+}
+
+static const OSSL_PARAM *kbkdf_settable_ctx_params(void)
+{
+    static const OSSL_PARAM known_settable_ctx_params[] = {
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SALT, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_KDF_PARAM_KEY, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MAC, NULL, 0),
+
+        OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return known_settable_ctx_params;
+}
+
+static int kbkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_KDF_PARAM_SIZE);
+    if (p == NULL)
+        return -2;
+
+    /* KBKDF can produce results as large as you like. */
+    return OSSL_PARAM_set_size_t(p, SIZE_MAX);
+}
+
+static const OSSL_PARAM *kbkdf_gettable_ctx_params(void)
+{
+    static const OSSL_PARAM known_gettable_ctx_params[] =
+        { OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL), OSSL_PARAM_END };
+    return known_gettable_ctx_params;
+}
+
+const OSSL_DISPATCH kdf_kbkdf_functions[] = {
+    { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kbkdf_new },
+    { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kbkdf_free },
+    { OSSL_FUNC_KDF_RESET, (void(*)(void))kbkdf_reset },
+    { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kbkdf_derive },
+    { OSSL_FUNC_KDF_SETTABLE_CTX_PARAMS,
+      (void(*)(void))kbkdf_settable_ctx_params },
+    { OSSL_FUNC_KDF_SET_CTX_PARAMS, (void(*)(void))kbkdf_set_ctx_params },
+    { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
+      (void(*)(void))kbkdf_gettable_ctx_params },
+    { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kbkdf_get_ctx_params },
+    { 0, NULL },
+};

--- a/providers/default/defltprov.c
+++ b/providers/default/defltprov.c
@@ -272,6 +272,7 @@ static const OSSL_ALGORITHM deflt_kdfs[] = {
     { OSSL_KDF_NAME_SSHKDF, "default=yes", kdf_sshkdf_functions },
     { OSSL_KDF_NAME_X963KDF, "default=yes", kdf_x963_kdf_functions },
     { OSSL_KDF_NAME_TLS1_PRF, "default=yes", kdf_tls1_prf_functions },
+    { OSSL_KDF_NAME_KBKDF, "default=yes", kdf_kbkdf_functions },
 #ifndef OPENSSL_NO_CMS
     { OSSL_KDF_NAME_X942KDF, "default=yes", kdf_x942_kdf_functions },
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -378,6 +378,7 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { OSSL_KDF_NAME_SSKDF, "fips=yes", kdf_sskdf_functions },
     { OSSL_KDF_NAME_PBKDF2, "fips=yes", kdf_pbkdf2_functions },
     { OSSL_KDF_NAME_TLS1_PRF, "fips=yes", kdf_tls1_prf_functions },
+    { OSSL_KDF_NAME_KBKDF, "fips=yes", kdf_kbkdf_functions },
    { NULL, NULL, NULL }
 };
 

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -297,6 +297,94 @@ static int test_kdf_x963(void)
     return ret;
 }
 
+/* Two test vectors from RFC 8009 (AES Encryption with HMAC-SHA2 for Kerberos
+ * 5) appendix A. */
+static int test_kdf_kbkdf_8009_prf1(void)
+{
+    int ret, i = 0;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM params[6];
+    char *label = "prf", *digest = "sha256", *prf_input = "test",
+        *mac = "HMAC";
+    static unsigned char input_key[] = {
+        0x37, 0x05, 0xD9, 0x60, 0x80, 0xC1, 0x77, 0x28,
+        0xA0, 0xE8, 0x00, 0xEA, 0xB6, 0xE0, 0xD2, 0x3C,
+    };
+    static unsigned char output[] = {
+        0x9D, 0x18, 0x86, 0x16, 0xF6, 0x38, 0x52, 0xFE,
+        0x86, 0x91, 0x5B, 0xB8, 0x40, 0xB4, 0xA8, 0x86,
+        0xFF, 0x3E, 0x6B, 0xB0, 0xF8, 0x19, 0xB4, 0x9B,
+        0x89, 0x33, 0x93, 0xD3, 0x93, 0x85, 0x42, 0x95,
+    };
+    unsigned char result[sizeof(output)] = { 0 };
+
+    params[i++] = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_DIGEST, digest, strlen(digest) + 1);
+    params[i++] = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_MAC, mac, strlen(mac) + 1);
+    params[i++] = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_KEY, input_key, sizeof(input_key));
+    params[i++] = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_SALT, label, strlen(label));
+    params[i++] = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_INFO, prf_input, strlen(prf_input));
+    params[i] = OSSL_PARAM_construct_end();
+
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
+        && TEST_mem_eq(result, sizeof(result), output, sizeof(output));
+
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
+
+static int test_kdf_kbkdf_8009_prf2(void)
+{
+    int ret, i = 0;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM params[6];
+    char *label = "prf", *digest = "sha384", *prf_input = "test",
+        *mac = "HMAC";
+    static unsigned char input_key[] = {
+        0x6D, 0x40, 0x4D, 0x37, 0xFA, 0xF7, 0x9F, 0x9D,
+        0xF0, 0xD3, 0x35, 0x68, 0xD3, 0x20, 0x66, 0x98,
+        0x00, 0xEB, 0x48, 0x36, 0x47, 0x2E, 0xA8, 0xA0,
+        0x26, 0xD1, 0x6B, 0x71, 0x82, 0x46, 0x0C, 0x52,
+    };
+    static unsigned char output[] = {
+        0x98, 0x01, 0xF6, 0x9A, 0x36, 0x8C, 0x2B, 0xF6,
+        0x75, 0xE5, 0x95, 0x21, 0xE1, 0x77, 0xD9, 0xA0,
+        0x7F, 0x67, 0xEF, 0xE1, 0xCF, 0xDE, 0x8D, 0x3C,
+        0x8D, 0x6F, 0x6A, 0x02, 0x56, 0xE3, 0xB1, 0x7D,
+        0xB3, 0xC1, 0xB6, 0x2A, 0xD1, 0xB8, 0x55, 0x33,
+        0x60, 0xD1, 0x73, 0x67, 0xEB, 0x15, 0x14, 0xD2,
+    };
+    unsigned char result[sizeof(output)] = { 0 };
+
+    params[i++] = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_DIGEST, digest, strlen(digest) + 1);
+    params[i++] = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_MAC, mac, strlen(mac) + 1);
+    params[i++] = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_KEY, input_key, sizeof(input_key));
+    params[i++] = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_SALT, label, strlen(label));
+    params[i++] = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_INFO, prf_input, strlen(prf_input));
+    params[i] = OSSL_PARAM_construct_end();
+
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
+        && TEST_mem_eq(result, sizeof(result), output, sizeof(output));
+
+    EVP_KDF_CTX_free(kctx);
+    return ret;
+}
+
 static int test_kdf_ss_hmac(void)
 {
     int ret;
@@ -521,6 +609,8 @@ static int test_kdf_x942_asn1(void)
 
 int setup_tests(void)
 {
+    ADD_TEST(test_kdf_kbkdf_8009_prf1);
+    ADD_TEST(test_kdf_kbkdf_8009_prf2);
     ADD_TEST(test_kdf_get_kdf);
     ADD_TEST(test_kdf_tls1_prf);
     ADD_TEST(test_kdf_hkdf);


### PR DESCRIPTION
Implement SP800-108 section 5.1 with HMAC intended for use in Kerberos.
Add test vectors from RFC 8009.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

### Notes

Hi!  First of krb5 with tested using this KDF can be found at https://github.com/krb5/krb5/compare/master...frozencemetery:800-108test .  I've also included test vectors.

I'm not really happy with the name of this thing: SP800-108 doesn't really name it, but NIST gives it the name KBKDF in https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Key-Derivation

Kerberos aficionados will note that there are other KDFs we use which are not present in OpenSSL.  Should it be acceptable to the project, I will add them as time allows.  However, in the interest of getting some feedback, I'm proposing what I have for now.

This implementation is not derived in any way from krb5's (beyond sharing of test vectors from RFC, of course), of which I am not the author.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
