### PR TITLE
Fix strict-warnings build

### DIFF
--- a/providers/common/ciphers/cipher_aes_gcm_hw_s390x.inc
+++ b/providers/common/ciphers/cipher_aes_gcm_hw_s390x.inc
@@ -97,10 +97,7 @@ static int s390x_aes_gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
         memcpy(tag, kma->t.b, ctx->taglen);
         rc = 1;
     } else {
-        if (ctx->taglen < 0)
-            rc = 0;
-        else
-            rc = (CRYPTO_memcmp(tag, kma->t.b, ctx->taglen) == 0);
+        rc = (CRYPTO_memcmp(tag, kma->t.b, ctx->taglen) == 0);
     }
     return rc;
 }


### PR DESCRIPTION
..which was broken for s390 due to 1c3ace68.