### PR TITLE
Remove warnings as Errors on win32 builds

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1352,7 +1352,6 @@ my %targets = (
     },
     "VC-WIN32" => {
         inherit_from     => [ "VC-noCE-common" ],
-        CFLAGS           => add("/WX"),
         AS               => sub { vc_win32_info()->{AS} },
         ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
         asoutflag        => sub { vc_win32_info()->{asoutflag} },


### PR DESCRIPTION
This matches the Win64 options.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
