### PR TITLE
Fix missing bn_mul_mont symbol in solaris fips module

### DIFF
--- a/crypto/sparcv9cap.c
+++ b/crypto/sparcv9cap.c
@@ -24,11 +24,6 @@ __attribute__ ((visibility("hidden")))
 #endif
 unsigned int OPENSSL_sparcv9cap_P[2] = { SPARCV9_TICK_PRIVILEGED, 0 };
 
-/*
- * TODO(3.0): Temporarily disabled some assembler that hasn't been brought into
- * the FIPS module yet.
- */
-#ifndef FIPS_MODE
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, int num)
 {
@@ -91,7 +86,6 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
     }
     return bn_mul_mont_int(rp, ap, bp, np, n0, num);
 }
-#endif /* FIPS_MODE */
 
 unsigned long _sparcv9_rdtick(void);
 void _sparcv9_vis1_probe(void);


### PR DESCRIPTION
Any tests that loaded the fips module were failing.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
