### PR TITLE
Move gcm decryption tag check higher up in the callstack

### DIFF
--- a/providers/common/ciphers/cipher_gcm.c
+++ b/providers/common/ciphers/cipher_gcm.c
@@ -344,7 +344,9 @@ static int gcm_cipher_internal(PROV_GCM_CTX *ctx, unsigned char *out,
                 goto err;
         }
     } else {
-        /* Finished when in == NULL */
+        /* The tag must be set before actually decrypting data */
+        if (!ctx->enc && ctx->taglen == UNINITIALISED_SIZET)
+            goto err;
         if (!hw->cipherfinal(ctx, ctx->buf))
             goto err;
         ctx->iv_state = IV_STATE_FINISHED; /* Don't reuse the IV */

--- a/providers/common/ciphers/cipher_gcm_hw.c
+++ b/providers/common/ciphers/cipher_gcm_hw.c
@@ -90,8 +90,7 @@ int gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
         CRYPTO_gcm128_tag(&ctx->gcm, tag, GCM_TAG_MAX_SIZE);
         ctx->taglen = GCM_TAG_MAX_SIZE;
     } else {
-        if (ctx->taglen == UNINITIALISED_SIZET
-            || CRYPTO_gcm128_finish(&ctx->gcm, tag, ctx->taglen) != 0)
+        if (CRYPTO_gcm128_finish(&ctx->gcm, tag, ctx->taglen) != 0)
             return 0;
     }
     return 1;


### PR DESCRIPTION
Code was updated for s390 that accidently removed the check inside the final method.
Moving the check up before the final method is called is a better way of handling this.
The oneshot method also calls the final method but doesnt need to do this check.

This is a fix for the changes in #9937
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
