### PR TITLE
Add TLS version options to s_time

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -47,7 +47,7 @@ typedef enum OPTION_choice {
     OPT_CONNECT, OPT_CIPHER, OPT_CIPHERSUITES, OPT_CERT, OPT_NAMEOPT, OPT_KEY,
     OPT_CAPATH, OPT_CAFILE, OPT_NOCAPATH, OPT_NOCAFILE, OPT_NEW, OPT_REUSE,
     OPT_BUGS, OPT_VERIFY, OPT_TIME, OPT_SSL3,
-    OPT_WWW
+    OPT_WWW, OPT_TLS1, OPT_TLS1_1, OPT_TLS1_2, OPT_TLS1_3
 } OPTION_CHOICE;
 
 const OPTIONS s_time_options[] = {
@@ -76,6 +76,18 @@ const OPTIONS s_time_options[] = {
 #ifndef OPENSSL_NO_SSL3
     {"ssl3", OPT_SSL3, '-', "Just use SSLv3"},
 #endif
+#ifndef OPENSSL_NO_TLS1
+    {"tls1", OPT_TLS1, '-', "Just use TLSv1.0"},
+#endif
+#ifndef OPENSSL_NO_TLS1_1
+    {"tls1_1", OPT_TLS1_1, '-', "Just use TLSv1.1"},
+#endif
+#ifndef OPENSSL_NO_TLS1_2
+    {"tls1_2", OPT_TLS1_2, '-', "Just use TLSv1.2"},
+#endif
+#ifndef OPENSSL_NO_TLS1_3
+    {"tls1_3", OPT_TLS1_3, '-', "Just use TLSv1.3"},
+#endif
     {NULL}
 };
 
@@ -101,7 +113,7 @@ int s_time_main(int argc, char **argv)
     int maxtime = SECONDS, nConn = 0, perform = 3, ret = 1, i, st_bugs = 0;
     long bytes_read = 0, finishtime = 0;
     OPTION_CHOICE o;
-    int max_version = 0, ver, buf_len;
+    int min_version = 0, max_version = 0, ver, buf_len;
     size_t buf_size;
 
     meth = TLS_client_method();
@@ -177,7 +189,24 @@ int s_time_main(int argc, char **argv)
             }
             break;
         case OPT_SSL3:
+            min_version = SSL3_VERSION;
             max_version = SSL3_VERSION;
+            break;
+        case OPT_TLS1:
+            min_version = TLS1_VERSION;
+            max_version = TLS1_VERSION;
+            break;
+        case OPT_TLS1_1:
+            min_version = TLS1_1_VERSION;
+            max_version = TLS1_1_VERSION;
+            break;
+        case OPT_TLS1_2:
+            min_version = TLS1_2_VERSION;
+            max_version = TLS1_2_VERSION;
+            break;
+        case OPT_TLS1_3:
+            min_version = TLS1_3_VERSION;
+            max_version = TLS1_3_VERSION;
             break;
         }
     }
@@ -193,6 +222,8 @@ int s_time_main(int argc, char **argv)
 
     SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
     SSL_CTX_set_quiet_shutdown(ctx, 1);
+    if (SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
+        goto end;
     if (SSL_CTX_set_max_proto_version(ctx, max_version) == 0)
         goto end;
 

--- a/doc/man1/openssl-s_time.pod
+++ b/doc/man1/openssl-s_time.pod
@@ -22,6 +22,10 @@ B<openssl> B<s_time>
 [B<-nameopt option>]
 [B<-time seconds>]
 [B<-ssl3>]
+[B<-tls1>]
+[B<-tls1_1>]
+[B<-tls1_2>]
+[B<-tls1_3>]
 [B<-bugs>]
 [B<-cipher cipherlist>]
 [B<-ciphersuites val>]
@@ -109,19 +113,13 @@ Performs the timing test using the same session ID; this can be used as a test
 that session caching is working. If neither B<-new> nor B<-reuse> are
 specified, they are both on by default and executed in sequence.
 
-=item B<-ssl3>
+=item B<-ssl3>, B<-tls1>, B<-tls1_1>, B<-tls1_2>, B<-tls1_3>
 
-This option disables the use of SSL version 3. By default
-the initial handshake uses a method which should be compatible with all
-servers and permit them to use SSL v3 or TLS as appropriate.
-
-The timing program is not as rich in options to turn protocols on and off as
-the L<s_client(1)> program and may not connect to all servers.
-Unfortunately there are a lot of ancient and broken servers in use which
-cannot handle this technique and will fail to connect. Some servers only
-work if TLS is turned off with the B<-ssl3> option.
-
-Note that this option may not be available, depending on how
+These options enable specific SSL or TLS protocol versions for the handshake
+initiated by B<s_time>.
+By default B<s_time> negotiates the highest mutually supported protocol
+version.
+Note that not all protocols and flags may be available, depending on how
 OpenSSL was built.
 
 =item B<-bugs>


### PR DESCRIPTION
Added TLS version options like (`-tls1`, `-tls1_1`, `-tls1_2`, `-tls1_3`) to `s_time`.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

