### PR TITLE
make default values stored by ERR_get_error_all() and friends more co…

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -533,36 +533,22 @@ static unsigned long get_error_values(ERR_GET_ACTION g,
         es->err_buffer[i] = 0;
     }
 
-    if (file != NULL && line != NULL) {
-        if (es->err_file[i] == NULL) {
-            *file = "NA";
-            *line = 0;
-        } else {
-            *file = es->err_file[i];
-            *line = es->err_line[i];
-        }
-    }
-
-    if (func != NULL) {
+    if (file != NULL)
+        *file = es->err_file[i];
+    if (line != NULL)
+        *line = es->err_line[i];
+    if (func != NULL)
         *func = es->err_func[i];
-        if (*func == NULL)
-            *func = "N/A";
-    }
-
+    if (flags != NULL)
+        *flags = es->err_data_flags[i];
     if (data == NULL) {
         if (g == EV_POP) {
             err_clear_data(es, i, 0);
         }
     } else {
-        if (es->err_data[i] == NULL) {
-            *data = "";
-            if (flags != NULL)
-                *flags = 0;
-        } else {
-            *data = es->err_data[i];
-            if (flags != NULL)
-                *flags = es->err_data_flags[i];
-        }
+        *data = es->err_data[i];
+         if (*data == NULL && flags != NULL)
+             *flags = 0;
     }
     return ret;
 }

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -533,12 +533,18 @@ static unsigned long get_error_values(ERR_GET_ACTION g,
         es->err_buffer[i] = 0;
     }
 
-    if (file != NULL)
+    if (file != NULL) {
         *file = es->err_file[i];
+        if (*file == NULL)
+            *file = "";
+    }
     if (line != NULL)
         *line = es->err_line[i];
-    if (func != NULL)
+    if (func != NULL) {
         *func = es->err_func[i];
+        if (*func == NULL)
+            *func = "";
+    }
     if (flags != NULL)
         *flags = es->err_data_flags[i];
     if (data == NULL) {
@@ -547,8 +553,11 @@ static unsigned long get_error_values(ERR_GET_ACTION g,
         }
     } else {
         *data = es->err_data[i];
-         if (*data == NULL && flags != NULL)
-             *flags = 0;
+        if (*data == NULL) {
+            *data = "";
+            if (flags != NULL)
+                *flags = 0;
+        }
     }
     return ret;
 }

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -74,6 +74,9 @@ the error occurred in *B<file> and *B<line>, as far as they are not B<NULL>.
 An unset file name is indicated as B<NULL>.
 An unset line number is indicated as B<0>.
 
+A non-B<NULL> pointer returned this way by these functions and the ones below
+is valid until the respective entry is removed from the error queue.
+
 ERR_get_error_func(), ERR_peek_error_func() and
 ERR_peek_last_error_func() are the same as ERR_get_error(),
 ERR_peek_error() and ERR_peek_last_error(), but on success they

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -61,10 +61,9 @@ error queue without modifying it.
 ERR_peek_last_error() returns the latest error code from the thread's
 error queue without modifying it.
 
-See L<ERR_GET_LIB(3)> for obtaining information about
-location and reason of the error, and
-L<ERR_error_string(3)> for human-readable error
-messages.
+See L<ERR_GET_LIB(3)> for obtaining further specific information
+such as the reason of the error,
+and L<ERR_error_string(3)> for human-readable error messages.
 
 ERR_get_error_line(), ERR_peek_error_line() and
 ERR_peek_last_error_line() are the same as ERR_get_error(),

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -68,21 +68,26 @@ messages.
 
 ERR_get_error_line(), ERR_peek_error_line() and
 ERR_peek_last_error_line() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but they
+ERR_peek_error() and ERR_peek_last_error(), but on success they
 additionally store the file name and line number where
-the error occurred in *B<file> and *B<line>, unless these are B<NULL>.
+the error occurred in *B<file> and *B<line>, as far as they are not B<NULL>.
+An unset file name is indicated as B<NULL>.
+An unset line number is indicated as B<0>.
 
 ERR_get_error_func(), ERR_peek_error_func() and
 ERR_peek_last_error_func() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but they
-additionally store the name of the function where the error in *B<func>,
-unless it is B<NULL>.
+ERR_peek_error() and ERR_peek_last_error(), but on success they
+additionally store the name of the function where the error occurred
+in *B<func>, unless it is B<NULL>.
+An unset function name is indicated as B<NULL>.
 
 ERR_get_error_data(), ERR_peek_error_data() and
 ERR_peek_last_error_data() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but they
+ERR_peek_error() and ERR_peek_last_error(), but on success they
 additionally store additional data and flags associated with the error
-code in *B<data> and *B<flags>, unless these are B<NULL>.
+code in *B<data> and *B<flags>, as far as they are not B<NULL>.
+Unset data is indicated as B<NULL>.
+In this case the value given for the flag is irrelevant (and equals B<0>).
 *B<data> contains a string if *B<flags>&B<ERR_TXT_STRING> is true.
 
 ERR_get_error_all(), ERR_peek_error_all() and

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -70,10 +70,10 @@ ERR_peek_last_error_line() are the same as ERR_get_error(),
 ERR_peek_error() and ERR_peek_last_error(), but on success they
 additionally store the file name and line number where
 the error occurred in *B<file> and *B<line>, as far as they are not B<NULL>.
-An unset file name is indicated as B<NULL>.
+An unset file name is indicated as B<"">, i.e., an empty string.
 An unset line number is indicated as B<0>.
 
-A non-B<NULL> pointer returned this way by these functions and the ones below
+A pointer returned this way by these functions and the ones below
 is valid until the respective entry is removed from the error queue.
 
 ERR_get_error_func(), ERR_peek_error_func() and
@@ -81,14 +81,14 @@ ERR_peek_last_error_func() are the same as ERR_get_error(),
 ERR_peek_error() and ERR_peek_last_error(), but on success they
 additionally store the name of the function where the error occurred
 in *B<func>, unless it is B<NULL>.
-An unset function name is indicated as B<NULL>.
+An unset function name is indicated as B<"">.
 
 ERR_get_error_data(), ERR_peek_error_data() and
 ERR_peek_last_error_data() are the same as ERR_get_error(),
 ERR_peek_error() and ERR_peek_last_error(), but on success they
 additionally store additional data and flags associated with the error
 code in *B<data> and *B<flags>, as far as they are not B<NULL>.
-Unset data is indicated as B<NULL>.
+Unset data is indicated as B<"">.
 In this case the value given for the flag is irrelevant (and equals B<0>).
 *B<data> contains a string if *B<flags>&B<ERR_TXT_STRING> is true.
 


### PR DESCRIPTION
When chasing a regression in an error reporting test of our CMP contribution 
I came again across the issue that the documentation of `ERR_get_error_all()` and friends
does not state that they touch storage locations for which pointers are given only on success and 
does not state which values are stored in case no respective data (e.g., line number or function name) is available. Therefore it remains unclear if callers should initialize the respective locations beforehand and how they should detect the absence of a an actual value.

Moreover, the default pointer values provided by these functions in case the requested information is unset so far are rather inconsistent: `""` vs. `"NA"` vs. `"N/A"`.

This PR clarifies these things in the documentation and suggests a consistent default for pointer values: `NULL`. I chose `NULL` rather than `""` because the latter could be more easily confused with a legitimate value. If for compatibility with existing usage a proper pointer is needed (though I did not notice any such need at least in the existing test suite), I'd say `""` is better than `"NA"` or any other non-empty string because such a non-empty string could collide with a real value (e.g., function name).   


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
