### PR TITLE
Fix a double free issue when signing SM2 cert

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1734,10 +1734,6 @@ static int do_sign_init(EVP_MD_CTX *ctx, EVP_PKEY *pkey,
 
     ret = 1;
  err:
-#ifndef OPENSSL_NO_SM2
-    if (!ret)
-        EVP_PKEY_CTX_free(pctx);
-#endif
     return ret;
 }
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -1744,7 +1744,7 @@ static int do_sign_init(EVP_MD_CTX *ctx, EVP_PKEY *pkey,
 int do_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md,
                  STACK_OF(OPENSSL_STRING) *sigopts)
 {
-    int rv, try_free = 0;
+    int rv;
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
 #ifndef OPENSSL_NO_SM2
     EVP_PKEY_CTX *pctx = NULL;
@@ -1753,18 +1753,17 @@ int do_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md,
     rv = do_sign_init(mctx, pkey, md, sigopts);
     if (rv > 0) {
         rv = X509_sign_ctx(x, mctx);
-        try_free = 1;
-    }
 #ifndef OPENSSL_NO_SM2
-    /*
-     * only in SM2 case we need to free the pctx explicitly
-     * if do_sign_init() fails, no need to double free pctx
-     */
-    if (try_free && ec_pkey_is_sm2(pkey)) {
-        pctx = EVP_MD_CTX_pkey_ctx(mctx);
-        EVP_PKEY_CTX_free(pctx);
-    }
+        /*
+         * only in SM2 case we need to free the pctx explicitly
+         * if do_sign_init() fails, pctx is already freed in it
+         */
+        if (ec_pkey_is_sm2(pkey)) {
+            pctx = EVP_MD_CTX_pkey_ctx(mctx);
+            EVP_PKEY_CTX_free(pctx);
+        }
 #endif
+    }
     EVP_MD_CTX_free(mctx);
     return rv > 0 ? 1 : 0;
 }
@@ -1772,7 +1771,7 @@ int do_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md,
 int do_X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md,
                      STACK_OF(OPENSSL_STRING) *sigopts)
 {
-    int rv, try_free = 0;
+    int rv;
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
 #ifndef OPENSSL_NO_SM2
     EVP_PKEY_CTX *pctx = NULL;
@@ -1781,18 +1780,17 @@ int do_X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md,
     rv = do_sign_init(mctx, pkey, md, sigopts);
     if (rv > 0) {
         rv = X509_REQ_sign_ctx(x, mctx);
-        try_free = 1;
-    }
 #ifndef OPENSSL_NO_SM2
-    /*
-     * only in SM2 case we need to free the pctx explicitly
-     * if do_sign_init() fails, no need to double free pctx
-     */
-    if (try_free && ec_pkey_is_sm2(pkey)) {
-        pctx = EVP_MD_CTX_pkey_ctx(mctx);
-        EVP_PKEY_CTX_free(pctx);
-    }
+        /*
+         * only in SM2 case we need to free the pctx explicitly
+         * if do_sign_init() fails, pctx is already freed in it
+         */
+        if (ec_pkey_is_sm2(pkey)) {
+            pctx = EVP_MD_CTX_pkey_ctx(mctx);
+            EVP_PKEY_CTX_free(pctx);
+        }
 #endif
+    }
     EVP_MD_CTX_free(mctx);
     return rv > 0 ? 1 : 0;
 }
@@ -1800,7 +1798,7 @@ int do_X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md,
 int do_X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md,
                      STACK_OF(OPENSSL_STRING) *sigopts)
 {
-    int rv, try_free = 0;
+    int rv;
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
 #ifndef OPENSSL_NO_SM2
     EVP_PKEY_CTX *pctx = NULL;
@@ -1809,18 +1807,17 @@ int do_X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md,
     rv = do_sign_init(mctx, pkey, md, sigopts);
     if (rv > 0) {
         rv = X509_CRL_sign_ctx(x, mctx);
-        try_free = 1;
-    }
 #ifndef OPENSSL_NO_SM2
-    /*
-     * only in SM2 case we need to free the pctx explicitly
-     * if do_sign_init() fails, no need to double free pctx
-     */
-    if (try_free && ec_pkey_is_sm2(pkey)) {
-        pctx = EVP_MD_CTX_pkey_ctx(mctx);
-        EVP_PKEY_CTX_free(pctx);
-    }
+        /*
+         * only in SM2 case we need to free the pctx explicitly
+         * if do_sign_init() fails, no need to double free pctx
+         */
+        if (ec_pkey_is_sm2(pkey)) {
+            pctx = EVP_MD_CTX_pkey_ctx(mctx);
+            EVP_PKEY_CTX_free(pctx);
+        }
 #endif
+    }
     EVP_MD_CTX_free(mctx);
     return rv > 0 ? 1 : 0;
 }

--- a/doc/man1/openssl-req.pod
+++ b/doc/man1/openssl-req.pod
@@ -347,8 +347,8 @@ string is required by the SM2 signature algorithm for signing and verification.
 
 =item B<-sm2-hex-id>
 
-Specify a binary ID string to use when verifying an SM2 certificate request.
-The argument for this option is string of hexadecimal digits.
+Specify a binary ID string to use when signing or verifying using an SM2
+certificate. The argument for this option is string of hexadecimal digits.
 
 =back
 

--- a/doc/man1/openssl-req.pod
+++ b/doc/man1/openssl-req.pod
@@ -342,13 +342,13 @@ for key generation operations.
 
 =item B<-sm2-id>
 
-Specify the ID string to use when verifying an SM2 certificate. The ID string is
-required by the SM2 signature algorithm for signing and verification.
+Specify the ID string to use when verifying an SM2 certificate request. The ID
+string is required by the SM2 signature algorithm for signing and verification.
 
 =item B<-sm2-hex-id>
 
-Specify a binary ID string to use when signing or verifying using an SM2
-certificate. The argument for this option is string of hexadecimal digits.
+Specify a binary ID string to use when verifying an SM2 certificate request.
+The argument for this option is string of hexadecimal digits.
 
 =back
 

--- a/doc/man1/openssl-req.pod
+++ b/doc/man1/openssl-req.pod
@@ -347,8 +347,8 @@ string is required by the SM2 signature algorithm for signing and verification.
 
 =item B<-sm2-hex-id>
 
-Specify a binary ID string to use when signing or verifying using an SM2
-certificate. The argument for this option is string of hexadecimal digits.
+Specify a binary ID string to use when verifying an SM2 certificate request. The
+argument for this option is string of hexadecimal digits.
 
 =back
 


### PR DESCRIPTION
If the SM2 ID value has not been passed correctly when signing an SM2 certificate/certificate request, a double free occurs. For instance:

``` 
 openssl req -x509 ... -sm2-id 1234567812345678
```

The '-sm2-id' should not be used in this scenario, while the '-sigopt' is the correct one to use. Documentation has also been updated to make the options more clear.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
