### PR TITLE
Configure: add missing dependency to fix parallel builds on Windows

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -82,6 +82,7 @@ SOURCE[../providers/fips]=$UTIL_COMMON
 DEFINE[../providers/fips]=$UTIL_DEFINE
 
 
+DEPEND[info.o]=buildinf.h
 DEPEND[cversion.o]=buildinf.h
 GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
 DEPEND[buildinf.h]=../configdata.pm


### PR DESCRIPTION
The issue was encountered when testing parallel builds of OpenSSL on Windows using `jom` instead of `nmake`. The builds persistently failed with the following error message because the generated file "buildinf.h" did not exist yet.

```make
crypto\info.c(15): fatal error C1083:
    cannot open include file: "buildinf.h": No such file or directory
```

Apparently this error does not occur on Linux because `make` parallelizes the builds differently such that `crypto\cversion.c`, which has an explicit dependency on `buildinf.h`, gets compiled first. Also, the
include dependency was added only recently in commit 096978f0990. _(=> no backport to 1.1.1 required)_
