### PR TITLE
Configure: accept Windows style compiler options

### DIFF
--- a/Configure
+++ b/Configure
@@ -80,8 +80,8 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 #               separated by spaces, then the URL-style notation %20 can be
 #               used for the space character in order to avoid having to quote
 #               the option. For example, -opt%20arg gets expanded to -opt arg.
-#               In fact, any character can be encoded as %xx using its
-#               hexadecimal ASCII value.
+#               In fact, any ASCII character can be encoded as %xx using its
+#               hexadecimal encoding.
 # -static       while -static is also a pass-through compiler option (and
 #               as such is limited to environments where it's actually
 #               meaningful), it triggers a number configuration options,

--- a/Configure
+++ b/Configure
@@ -829,7 +829,7 @@ while (@argvcopy)
                 {
                 die "FIPS mode not supported\n";
                 }
-        elsif (/^[-+]/)
+        elsif (m|^[-+/]|)
                 {
                 if (/^--prefix=(.*)$/)
                         {
@@ -890,7 +890,7 @@ while (@argvcopy)
                         {
                         push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
                         }
-                elsif (/^-L(.*)$/ or /^-Wl,/)
+                elsif (m|^[-/]L(.*)$| or /^-Wl,/)
                         {
                         push @{$useradd{LDFLAGS}}, $_;
                         }
@@ -906,11 +906,11 @@ while (@argvcopy)
                         {
                         push @{$useradd{LDFLAGS}}, $_;
                         }
-                elsif (/^-D(.*)$/)
+                elsif (m|^[-/]D(.*)$|)
                         {
                         push @{$useradd{CPPDEFINES}}, $1;
                         }
-                elsif (/^-I(.*)$/)
+                elsif (m|^[-/]I(.*)$|)
                         {
                         push @{$useradd{CPPINCLUDES}}, $1;
                         }

--- a/Configure
+++ b/Configure
@@ -890,7 +890,7 @@ while (@argvcopy)
                         {
                         push @{$useradd{LDLIBS}}, $_, shift(@argvcopy);
                         }
-                elsif (m|^[-/]L(.*)$| or /^-Wl,/)
+                elsif (/^-L(.*)$/ or /^-Wl,/)
                         {
                         push @{$useradd{LDFLAGS}}, $_;
                         }

--- a/Configure
+++ b/Configure
@@ -73,7 +73,15 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # no-sse2       disables IA-32 SSE2 code in assembly modules, the above
 #               mentioned '386' option implies this one
 # no-<cipher>   build without specified algorithm (rsa, idea, rc5, ...)
-# -<xxx> +<xxx> compiler options are passed through
+# -<xxx> +<xxx> All options which are unknown to the 'Configure' script are
+# /<xxx>        passed through to the compiler. Unix-style options beginning
+#               with a '-' or '+' are recognized, as well as Windows-style
+#               options beginning with a '/'. If the option contains arguments
+#               separated by spaces, then the URL-style notation %20 can be
+#               used for the space character in order to avoid having to quote
+#               the option. For example, -opt%20arg gets expanded to -opt arg.
+#               In fact, any character can be encoded as %xx using its
+#               hexadecimal ASCII value.
 # -static       while -static is also a pass-through compiler option (and
 #               as such is limited to environments where it's actually
 #               meaningful), it triggers a number configuration options,
@@ -912,10 +920,22 @@ while (@argvcopy)
                         }
                 else    # common if (/^[-+]/), just pass down...
                         {
+                        # Treat %xx as an ASCII code (e.g. replace %20 by a space character).
+                        # This provides a simple way to pass options with arguments separated
+                        # by spaces without quoting (e.g. -opt%20arg translates to -opt arg).
                         $_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
                         push @{$useradd{CFLAGS}}, $_;
                         push @{$useradd{CXXFLAGS}}, $_;
                         }
+                }
+        elsif (m|^/|)
+                {
+                # Treat %xx as an ASCII code (e.g. replace %20 by a space character).
+                # This provides a simple way to pass options with arguments separated
+                # by spaces without quoting (e.g. /opt%20arg translates to /opt arg).
+                $_ =~ s/%([0-9a-f]{1,2})/chr(hex($1))/gei;
+                push @{$useradd{CFLAGS}}, $_;
+                push @{$useradd{CXXFLAGS}}, $_;
                 }
         else
                 {

--- a/INSTALL
+++ b/INSTALL
@@ -652,8 +652,8 @@
                    then the URL-style notation %20 can be used for the space
                    character in order to avoid having to quote the option.
                    For example, -opt%20arg gets expanded to -opt arg.
-                   In fact, any character can be encoded as %xx using its
-                   hexadecimal ASCII value.
+                   In fact, any ASCII character can be encoded as %xx using its
+                   hexadecimal encoding.
 
                    Take note of the VAR=value documentation below and how
                    these flags interact with those variables.

--- a/INSTALL
+++ b/INSTALL
@@ -641,10 +641,19 @@
                    Take note of the VAR=value documentation below and how
                    these flags interact with those variables.
 
-  -xxx, +xxx
+  -xxx, +xxx, /xxx
                    Additional options that are not otherwise recognised are
-                   passed through as they are to the compiler as well.  Again,
-                   consult your compiler documentation.
+                   passed through as they are to the compiler as well.
+                   Unix-style options beginning with a '-' or '+' and
+                   Windows-style options beginning with a '/' are recognized.
+                   Again, consult your compiler documentation.
+
+                   If the option contains arguments separated by spaces,
+                   then the URL-style notation %20 can be used for the space
+                   character in order to avoid having to quote the option.
+                   For example, -opt%20arg gets expanded to -opt arg.
+                   In fact, any character can be encoded as %xx using its
+                   hexadecimal ASCII value.
 
                    Take note of the VAR=value documentation below and how
                    these flags interact with those variables.


### PR DESCRIPTION
Currently the Configure command only supports passing UNIX style options (`-opt`) to the compiler. Passing Windows style options (`/opt`) yields an error. Fortunately, the compiler accepts both
types of options, nevertheless this commit fixes that discrimination of Windows users.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
