### PR TITLE
Note that the mac command is preferable to the MAC command line options.

### DIFF
--- a/doc/man1/openssl-dgst.pod
+++ b/doc/man1/openssl-dgst.pod
@@ -123,6 +123,9 @@ The actual signature to verify.
 
 Create a hashed MAC using "key".
 
+The L<openssl-mac(1)> command should be preferred to using this command line
+option.
+
 =item B<-mac alg>
 
 Create MAC (keyed Message Authentication Code). The most popular MAC
@@ -130,6 +133,9 @@ algorithm is HMAC (hash-based MAC), but there are other MAC algorithms
 which are not based on hash, for instance B<gost-mac> algorithm,
 supported by B<ccgost> engine. MAC keys and other options should be set
 via B<-macopt> parameter.
+
+The L<openssl-mac(1)> command should be preferred to using this command line
+option.
 
 =item B<-macopt nm:v>
 
@@ -151,6 +157,9 @@ Key length must conform to any restrictions of the MAC algorithm
 for example exactly 32 chars for gost-mac.
 
 =back
+
+The L<openssl-mac(1)> command should be preferred to using this command line
+option.
 
 =item B<-rand file...>
 
@@ -228,6 +237,13 @@ being signed or verified.
 Hex signatures cannot be verified using B<openssl>.  Instead, use "xxd -r"
 or similar program to transform the hex signature into a binary signature
 prior to verification.
+
+The L<openssl-mac(1)> command is preferred over the B<-hmac>, B<-mac> and
+B<-macopt> command line options.
+
+=head1 SEE ALSO
+
+L<openssl-mac(1)>
 
 =head1 HISTORY
 


### PR DESCRIPTION

The dgst command allows MACs to be calculated, the mac command is the more
recent interface for doing the same and provides better access to a wider
range of MACs.


- [x] documentation is added or updated
