### PR TITLE
Do not use hostname from resumed TLS session when none is provided

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2772,7 +2772,7 @@ const char *SSL_get_servername(const SSL *s, const int type)
      * call the relevant callbacks for such resumption flows, and callbacks
      * might error out if there is not a SNI value available.
      */
-    if (s->hit)
+    if (s->hit && s->session->ext.hostname != NULL)
         return s->session->ext.hostname;
     return s->ext.hostname;
 }


### PR DESCRIPTION
I’m not sure how to write a test for this or even if this is the/a correct approach. See the linked Node.js issue (nodejs/node#28985) for the investigation that we’ve done so far.

---

In `SSL_get_servername()`, fall back to returning the hostname
set earlier via `SSL_set_tlsext_host_name()` when the resumed
session data does not include a host name field.

Refs: https://github.com/openssl/openssl/issues/8822
Fixes: https://github.com/nodejs/node/issues/28985

CLA: Trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated
