### PR TITLE
Remove user visible traces of the "engine" OSSL_PARAM.

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -344,8 +344,7 @@ EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
 # ifndef OPENSSL_NO_ENGINE
     if (engine_id != NULL)
         params[paramsn++] =
-            OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                             (char *)engine_id, 0);
+            OSSL_PARAM_construct_utf8_string("engine", (char *)engine_id, 0);
 # endif
 
     params[paramsn++] =

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -278,8 +278,7 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 char *engineid = (char *)ENGINE_get_id(ctx->engine);
 
                 params[params_n++] =
-                    OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                                     engineid, 0);
+                    OSSL_PARAM_construct_utf8_string("engine", engineid, 0);
 #endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
@@ -400,11 +399,9 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 char *engineid = ctx->engine == NULL
                     ? NULL : (char *)ENGINE_get_id(ctx->engine);
 
-                if (engineid != NULL) {
+                if (engineid != NULL)
                     params[params_n++] =
-                        OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
-                                                         engineid, 0);
-                }
+                        OSSL_PARAM_construct_utf8_string("engine", engineid, 0);
 #endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -170,14 +170,10 @@ The default value, if any, is implementation dependent.
 
 =item B<OSSL_KDF_PARAM_DIGEST> ("digest") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <UTF8 string>
-
 For KDF implementations that use an underlying computation MAC or
-digest, these parameters set what the algorithm should be, and the
-engine that implements the algorithm or the properties to fetch it
-by if needed.
+digest, these parameters set what the algorithm should be.
 
-The value is always the name of the intended engine, algorithm,
+The value is always the name of the intended algorithm,
 or the properties.
 
 Note that not all algorithms may support all possible underlying

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -215,8 +215,6 @@ This option is used by KMAC.
 These will set the MAC flags to the given numbers.
 Some MACs do not support this option.
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <UTF8 string>
-
 =item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <UTF8 string>
 
 =item B<OSSL_MAC_PARAM_DIGEST> ("digest") <UTF8 string>
@@ -224,11 +222,9 @@ Some MACs do not support this option.
 =item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <UTF8 string>
 
 For MAC implementations that use an underlying computation cipher or
-digest, these parameters set what the algorithm should be, and the
-engine that implements the algorithm or the properties to fetch it
-by if needed.
+digest, these parameters set what the algorithm should be.
 
-The value is always the name of the intended engine, algorithm,
+The value is always the name of the intended algorithm,
 or the properties.
 
 Note that not all algorithms may support all digests.

--- a/doc/man7/EVP_MAC-CMAC.pod
+++ b/doc/man7/EVP_MAC-CMAC.pod
@@ -30,8 +30,6 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item B<OSSL_MAC_PARAM_KEY> ("key") <octet string>
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <utf8 string>
-
 =item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <utf8 string>
 
 =item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>

--- a/doc/man7/EVP_MAC-GMAC.pod
+++ b/doc/man7/EVP_MAC-GMAC.pod
@@ -32,8 +32,6 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item B<OSSL_MAC_PARAM_IV> ("iv") <octet string>
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <utf8 string>
-
 =item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <utf8 string>
 
 =item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -32,8 +32,6 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item B<OSSL_MAC_PARAM_FLAGS> ("flags") <octet string>
 
-=item B<OSSL_MAC_PARAM_ENGINE> ("engine") <utf8 string>
-
 =item B<OSSL_MAC_PARAM_DIGEST> ("digest") <utf8 string>
 
 =item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -185,21 +185,11 @@ Gets flags associated with the MAC.
 Sets the name of the underlying cipher or digest to be used.
 It must name a suitable algorithm for the MAC that's being used.
 
-=item B<OSSL_MAC_PARAM_ENGINE> (utf8 string)
-
-Sets the name of an engine that implements the underlying algorithm.
-This must be given together with the algorithm naming parameter to be
-considered valid.
-
 =item B<OSSL_MAC_PARAM_PROPERTIES> (utf8 string)
 
 Sets the properties to be queried when trying to fetch the underlying algorithm.
 This must be given together with the algorithm naming parameter to be
 considered valid.
-
-Note that both this and B<OSSL_MAC_PARAM_ENGINE> can be given at the same time.
-If the underlying algorithm ends up being fetched from a provider, offered by
-and engine, or a built in legacy function depends on what is available.
 
 =item B<OSSL_MAC_PARAM_SIZE> (int)
 

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -48,7 +48,6 @@ extern "C" {
 #define OSSL_ALG_PARAM_DIGEST       "digest"    /* utf8_string */
 #define OSSL_ALG_PARAM_CIPHER       "cipher"    /* utf8_string */
 #define OSSL_ALG_PARAM_MAC          "mac"       /* utf8_string */
-#define OSSL_ALG_PARAM_ENGINE       "engine"    /* utf8_string */
 #define OSSL_ALG_PARAM_PROPERTIES   "properties"/* utf8_string */
 
 /* cipher parameters */
@@ -94,7 +93,6 @@ extern "C" {
  */
 #define OSSL_MAC_PARAM_CIPHER       OSSL_ALG_PARAM_CIPHER     /* utf8 string */
 #define OSSL_MAC_PARAM_DIGEST       OSSL_ALG_PARAM_DIGEST     /* utf8 string */
-#define OSSL_MAC_PARAM_ENGINE       OSSL_ALG_PARAM_ENGINE     /* utf8 string */
 #define OSSL_MAC_PARAM_PROPERTIES   OSSL_ALG_PARAM_PROPERTIES /* utf8 string */
 #define OSSL_MAC_PARAM_SIZE         "size"       /* size_t */
 
@@ -112,7 +110,6 @@ extern "C" {
 #define OSSL_KDF_PARAM_DIGEST       OSSL_ALG_PARAM_DIGEST     /* utf8 string */
 #define OSSL_KDF_PARAM_MAC          OSSL_ALG_PARAM_MAC        /* utf8 string */
 #define OSSL_KDF_PARAM_MAC_SIZE     "maclen"    /* size_t */
-#define OSSL_KDF_PARAM_ENGINE       OSSL_ALG_PARAM_ENGINE     /* utf8 string */
 #define OSSL_KDF_PARAM_PROPERTIES   OSSL_ALG_PARAM_PROPERTIES /* utf8 string */
 #define OSSL_KDF_PARAM_ITER         "iter"      /* unsigned int */
 #define OSSL_KDF_PARAM_MODE         "mode"      /* utf8 string or int */

--- a/providers/common/macs/cmac_prov.c
+++ b/providers/common/macs/cmac_prov.c
@@ -136,7 +136,6 @@ static int cmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 
 static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_CIPHER, NULL, 0),
-    OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_ENGINE, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_PROPERTIES, NULL, 0),
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END

--- a/providers/common/macs/gmac_prov.c
+++ b/providers/common/macs/gmac_prov.c
@@ -153,7 +153,6 @@ static int gmac_get_params(OSSL_PARAM params[])
 
 static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_CIPHER, NULL, 0),
-    OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_ENGINE, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_PROPERTIES, NULL, 0),
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_IV, NULL, 0),

--- a/providers/common/macs/hmac_prov.c
+++ b/providers/common/macs/hmac_prov.c
@@ -150,7 +150,6 @@ static int hmac_get_ctx_params(void *vmacctx, OSSL_PARAM params[])
 
 static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_DIGEST, NULL, 0),
-    OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_ENGINE, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_MAC_PARAM_PROPERTIES, NULL, 0),
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_int(OSSL_MAC_PARAM_FLAGS, NULL),

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -46,7 +46,7 @@ static int load_common(const OSSL_PARAM params[], const char **propquery,
     /* TODO legacy stuff, to be removed */
     /* Inside the FIPS module, we don't support legacy ciphers */
 #if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
-    p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_ENGINE);
+    p = OSSL_PARAM_locate_const(params, "engine");
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
@@ -221,10 +221,10 @@ int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
                                                  (char *)properties, 0);
 
 #if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
-    if ((p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_ENGINE)) != NULL) {
+    if ((p = OSSL_PARAM_locate_const(params, "engine")) != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_ENGINE,
+        *mp++ = OSSL_PARAM_construct_utf8_string("engine",
                                                  p->data, p->data_size);
     }
 #endif


### PR DESCRIPTION
The OSSL_PARAM "engine" is present only to allow backwards compatibility for engines until they are wrapped in to a engine-provider.  Because this means the parameter will be relatively short lived, it is better if it was never exposed publicly.

- [x] documentation is added or updated
- [ ] tests are added or updated
