### PR TITLE
Fix ktls support

### DIFF
--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -156,10 +156,10 @@ extern "C" {
 
 # ifndef OPENSSL_NO_KTLS
 #  define BIO_get_ktls_send(b)         \
-     (BIO_method_type(b) == BIO_TYPE_SOCKET \
+     (BIO_find_type(b, BIO_TYPE_SOCKET) != NULL \
       && BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL))
 #  define BIO_get_ktls_recv(b)         \
-     (BIO_method_type(b) == BIO_TYPE_SOCKET \
+     (BIO_find_type(b, BIO_TYPE_SOCKET) != NULL \
       && BIO_ctrl(b, BIO_CTRL_GET_KTLS_RECV, 0, NULL))
 # else
 #  define BIO_get_ktls_send(b)  (0)


### PR DESCRIPTION
This commit fixes an issue in KTLS support introduced by PR8793.
PR8793 modified BIO_get_ktls_send and BIO_get_ktls_recv to verify the
BIO_method_type to be BIO_TYPE_SOCKET.
However, KTLS can be applied to BIO_TYPE_FD and to BIOs with filters.

This commit fixes this issue by introducing the bio_get_method_final function
which checks the type of the innermost BIO.

[extended tests]

Signed-off-by: Boris Pismenny <borisp@mellanox.com>