### PR TITLE
Fix up some undocumented commands issues

### DIFF
--- a/doc/man1/openssl-ca.pod
+++ b/doc/man1/openssl-ca.pod
@@ -59,6 +59,8 @@ B<openssl> B<ca>
 [B<-sm2-id string>]
 [B<-sm2-hex-id hex-string>]
 
+=for comment ifdef engine sm2-id sm2-hex-id
+
 =head1 DESCRIPTION
 
 The B<ca> command is a minimal CA application. It can be used

--- a/doc/man1/openssl-ciphers.pod
+++ b/doc/man1/openssl-ciphers.pod
@@ -24,6 +24,8 @@ B<openssl> B<ciphers>
 [B<-ciphersuites val>]
 [B<cipherlist>]
 
+=for comment ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 psk srp
+
 =head1 DESCRIPTION
 
 The B<ciphers> command converts textual OpenSSL cipher lists into ordered

--- a/doc/man1/openssl-cms.pod
+++ b/doc/man1/openssl-cms.pod
@@ -102,6 +102,8 @@ B<openssl> B<cms>
 [B<-subject subj>]
 [cert.pem]...
 
+=for comment ifdef des-wrap engine
+
 =head1 DESCRIPTION
 
 The B<cms> command handles S/MIME v3.1 mail. It can encrypt, decrypt, sign and

--- a/doc/man1/openssl-crl.pod
+++ b/doc/man1/openssl-crl.pod
@@ -22,6 +22,8 @@ B<openssl> B<crl>
 [B<-CAfile file>]
 [B<-CApath dir>]
 
+=for comment ifdef hash_old
+
 =head1 DESCRIPTION
 
 The B<crl> command processes CRL files in DER or PEM format.

--- a/doc/man1/openssl-dhparam.pod
+++ b/doc/man1/openssl-dhparam.pod
@@ -25,6 +25,8 @@ B<openssl dhparam>
 [B<-engine id>]
 [I<numbits>]
 
+=for comment ifdef dsaparam engine
+
 =head1 DESCRIPTION
 
 This command is used to manipulate DH parameter files.

--- a/doc/man1/openssl-dsa.pod
+++ b/doc/man1/openssl-dsa.pod
@@ -33,6 +33,8 @@ B<openssl> B<dsa>
 [B<-pubout>]
 [B<-engine id>]
 
+=for comment ifdef pvk-string pvk-weak pvk-none engine
+
 =head1 DESCRIPTION
 
 The B<dsa> command processes DSA keys. They can be converted between various

--- a/doc/man1/openssl-ec.pod
+++ b/doc/man1/openssl-ec.pod
@@ -28,6 +28,8 @@ B<openssl> B<ec>
 [B<-check>]
 [B<-engine id>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<ec> command processes EC keys. They can be converted between various

--- a/doc/man1/openssl-ecparam.pod
+++ b/doc/man1/openssl-ecparam.pod
@@ -27,6 +27,8 @@ B<openssl ecparam>
 [B<-genkey>]
 [B<-engine id>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 This command is used to manipulate or generate EC parameter files.

--- a/doc/man1/openssl-enc.pod
+++ b/doc/man1/openssl-enc.pod
@@ -38,6 +38,8 @@ B<openssl enc -I<cipher>>
 [B<-writerand file>]
 [B<-engine id>]
 
+=for comment ifdef z engine
+
 B<openssl> I<[cipher]> [B<...>]
 
 =head1 DESCRIPTION

--- a/doc/man1/openssl-gendsa.pod
+++ b/doc/man1/openssl-gendsa.pod
@@ -27,6 +27,8 @@ B<openssl> B<gendsa>
 [B<-verbose>]
 [B<paramfile>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<gendsa> command generates a DSA private key from a DSA parameter file

--- a/doc/man1/openssl-genpkey.pod
+++ b/doc/man1/openssl-genpkey.pod
@@ -19,6 +19,8 @@ B<openssl> B<genpkey>
 [B<-genparam>]
 [B<-text>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<genpkey> command generates a private key.

--- a/doc/man1/openssl-genrsa.pod
+++ b/doc/man1/openssl-genrsa.pod
@@ -31,6 +31,8 @@ B<openssl> B<genrsa>
 [B<-verbose>]
 [B<numbits>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<genrsa> command generates an RSA private key.

--- a/doc/man1/openssl-info.pod
+++ b/doc/man1/openssl-info.pod
@@ -12,7 +12,7 @@ B<openssl info>
 [B<-enginesdir>]
 [B<-modulesdir> ]
 [B<-dsoext>]
-[B<-dirfilesep>]
+[B<-dirnamesep>]
 [B<-listsep>]
 [B<-seeds>]
 [B<-cpusettings>]

--- a/doc/man1/openssl-ocsp.pod
+++ b/doc/man1/openssl-ocsp.pod
@@ -90,6 +90,8 @@ B<openssl> B<ocsp>
 [B<-rcid I<digest>>]
 [B<-I<digest>>]
 
+=for comment ifdef multi
+
 =head1 DESCRIPTION
 
 The Online Certificate Status Protocol (OCSP) enables applications to

--- a/doc/man1/openssl-passwd.pod
+++ b/doc/man1/openssl-passwd.pod
@@ -24,6 +24,8 @@ B<openssl passwd>
 [B<-writerand file>]
 {I<password>}
 
+=for comment ifdef crypt
+
 =head1 DESCRIPTION
 
 The B<passwd> command computes the hash of a password typed at

--- a/doc/man1/openssl-pkcs12.pod
+++ b/doc/man1/openssl-pkcs12.pod
@@ -44,6 +44,8 @@ B<openssl> B<pkcs12>
 [B<-no-CApath>]
 [B<-CSP name>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<pkcs12> command allows PKCS#12 files (sometimes referred to as

--- a/doc/man1/openssl-pkcs7.pod
+++ b/doc/man1/openssl-pkcs7.pod
@@ -17,6 +17,8 @@ B<openssl> B<pkcs7>
 [B<-noout>]
 [B<-engine id>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<pkcs7> command processes PKCS#7 files in DER or PEM format.

--- a/doc/man1/openssl-pkcs8.pod
+++ b/doc/man1/openssl-pkcs8.pod
@@ -30,6 +30,8 @@ B<openssl> B<pkcs8>
 [B<-scrypt_r r>]
 [B<-scrypt_p p>]
 
+=for comment ifdef engine scrypt scrypt_N scrypt_r scrypt_p
+
 =head1 DESCRIPTION
 
 The B<pkcs8> command processes private keys in PKCS#8 format. It can handle

--- a/doc/man1/openssl-pkey.pod
+++ b/doc/man1/openssl-pkey.pod
@@ -25,6 +25,8 @@ B<openssl> B<pkey>
 [B<-check>]
 [B<-pubcheck>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<pkey> command processes public or private keys. They can be converted

--- a/doc/man1/openssl-pkeyparam.pod
+++ b/doc/man1/openssl-pkeyparam.pod
@@ -15,6 +15,8 @@ B<openssl> B<pkeyparam>
 [B<-engine id>]
 [B<-check>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<pkeyparam> command processes public key algorithm parameters.

--- a/doc/man1/openssl-pkeyutl.pod
+++ b/doc/man1/openssl-pkeyutl.pod
@@ -38,6 +38,8 @@ B<openssl> B<pkeyutl>
 [B<-engine id>]
 [B<-engine_impl>]
 
+=for comment ifdef engine engine_impl
+
 =head1 DESCRIPTION
 
 The B<pkeyutl> command can be used to perform low level public key operations

--- a/doc/man1/openssl-provider.pod
+++ b/doc/man1/openssl-provider.pod
@@ -7,6 +7,7 @@ openssl-provider - load and query providers
 =head1 SYNOPSIS
 
 B<openssl provider>
+[B<-help>]
 [B<-v>]
 [B<-vv>]
 [B<-vvv>]
@@ -20,6 +21,10 @@ I<provider>'s.
 =head1 OPTIONS
 
 =over 4
+
+=item B<-help>
+
+Print out a usage message.
 
 =item B<-v> B<-vv> B<-vvv>
 

--- a/doc/man1/openssl-rand.pod
+++ b/doc/man1/openssl-rand.pod
@@ -15,6 +15,8 @@ B<openssl rand>
 [B<-hex>]
 I<num>
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<rand> command outputs I<num> pseudo-random bytes after seeding

--- a/doc/man1/openssl-req.pod
+++ b/doc/man1/openssl-req.pod
@@ -52,6 +52,8 @@ B<openssl> B<req>
 [B<-sm2-id string>]
 [B<-sm2-hex-id hex-string>]
 
+=for comment ifdef engine keygen_engine sm2-id sm2-hex-id
+
 =head1 DESCRIPTION
 
 The B<req> command primarily creates and processes certificate requests

--- a/doc/man1/openssl-rsa.pod
+++ b/doc/man1/openssl-rsa.pod
@@ -36,6 +36,8 @@ B<openssl> B<rsa>
 [B<-RSAPublicKey_out>]
 [B<-engine id>]
 
+=for comment ifdef pvk-strong pvk-weak pvk-none engine
+
 =head1 DESCRIPTION
 
 The B<rsa> command processes RSA keys. They can be converted between various

--- a/doc/man1/openssl-rsautl.pod
+++ b/doc/man1/openssl-rsautl.pod
@@ -26,6 +26,8 @@ B<openssl> B<rsautl>
 [B<-hexdump>]
 [B<-asn1parse>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<rsautl> command can be used to sign, verify, encrypt and decrypt

--- a/doc/man1/openssl-s_client.pod
+++ b/doc/man1/openssl-s_client.pod
@@ -139,6 +139,16 @@ B<openssl> B<s_client>
 [B<-enable_pha>]
 [B<target>]
 
+=for comment ifdef engine ssl_client_engine ct noct ctlogfile
+
+=for comment ifdef ssl3 unix 4 6 use_srtp status trace wdebug nextprotoneg
+
+=for comment ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 dtls mtu dtls1 dtls1_2
+
+=for comment ifdef sctp_label_bug sctp
+
+=for comment ifdef srpuser srppass srp_lateuser srp_moregroups srp_strength
+
 =head1 DESCRIPTION
 
 The B<s_client> command implements a generic SSL/TLS client which connects

--- a/doc/man1/openssl-s_server.pod
+++ b/doc/man1/openssl-s_server.pod
@@ -185,6 +185,16 @@ B<openssl> B<s_server>
 [B<-no_anti_replay>]
 [B<-http_server_binmode>]
 
+=for comment ifdef unix 4 6 unlink no_dhe nextprotoneg use_srtp engine
+
+=for comment ifdef status status_verbose status_timeout status_url status_file
+
+=for comment ifdef psk_hint srpvfile srpuserseed sctp sctp_label_bug
+
+=for comment ifdef sctp sctp_label_bug trace mtu timeout listen
+
+=for comment ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 dtls mtu dtls1 dtls1_2
+
 =head1 DESCRIPTION
 
 The B<s_server> command implements a generic SSL/TLS server which listens

--- a/doc/man1/openssl-s_time.pod
+++ b/doc/man1/openssl-s_time.pod
@@ -30,6 +30,8 @@ B<openssl> B<s_time>
 [B<-cipher cipherlist>]
 [B<-ciphersuites val>]
 
+=for comment ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3
+
 =head1 DESCRIPTION
 
 The B<s_time> command implements a generic SSL/TLS client which connects to a

--- a/doc/man1/openssl-smime.pod
+++ b/doc/man1/openssl-smime.pod
@@ -70,6 +70,8 @@ B<openssl> B<smime>
 [B<-md digest>]
 [cert.pem]...
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<smime> command handles S/MIME mail. It can encrypt, decrypt, sign and

--- a/doc/man1/openssl-speed.pod
+++ b/doc/man1/openssl-speed.pod
@@ -21,6 +21,8 @@ B<openssl speed>
 [B<-bytes num>]
 [B<algorithm...>]
 
+=for comment ifdef cmac multi async_jobs engine
+
 =head1 DESCRIPTION
 
 This command is used to test the performance of cryptographic algorithms.

--- a/doc/man1/openssl-spkac.pod
+++ b/doc/man1/openssl-spkac.pod
@@ -21,6 +21,8 @@ B<openssl> B<spkac>
 [B<-verify>]
 [B<-engine id>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<spkac> command processes Netscape signed public key and challenge

--- a/doc/man1/openssl-srp.pod
+++ b/doc/man1/openssl-srp.pod
@@ -22,6 +22,8 @@ B<openssl srp>
 [B<-passout arg>]
 [I<user...>]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<srp> command is used to maintain an SRP (secure remote password)

--- a/doc/man1/openssl-ts.pod
+++ b/doc/man1/openssl-ts.pod
@@ -82,6 +82,8 @@ I<verify options:>
 [-verify_name name]
 [-x509_strict]
 
+=for comment ifdef engine
+
 =head1 DESCRIPTION
 
 The B<ts> command is a basic Time Stamping Authority (TSA) client and server

--- a/doc/man1/openssl-verify.pod
+++ b/doc/man1/openssl-verify.pod
@@ -54,6 +54,8 @@ B<openssl> B<verify>
 [B<->]
 [certificates]
 
+=for comment ifdef engine sm2-id sm2-hex-id
+
 =head1 DESCRIPTION
 
 The B<verify> command verifies certificate chains.

--- a/doc/man1/openssl-x509.pod
+++ b/doc/man1/openssl-x509.pod
@@ -68,6 +68,8 @@ B<openssl> B<x509>
 [B<-engine id>]
 [B<-preserve_dates>]
 
+=for comment ifdef engine subject_hash_old issuer_hash_old
+
 =head1 DESCRIPTION
 
 The B<x509> command is a multi purpose certificate utility. It can be

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -524,6 +524,7 @@ sub publicize {
     }
 }
 
+# Cipher/digests to skip if not documented
 my %skips = (
     'aes128' => 1,
     'aes192' => 1,
@@ -537,8 +538,8 @@ my %skips = (
     'des' => 1,
     'des3' => 1,
     'idea' => 1,
-    '[cipher]' => 1,
-    '[digest]' => 1,
+    'cipher' => 1,
+    'digest' => 1,
 );
 
 sub checkflags {
@@ -546,6 +547,7 @@ sub checkflags {
     my $doc = shift;
     my %cmdopts;
     my %docopts;
+    my %localskips;
 
     # Get the list of options in the command.
     open CFH, "./apps/openssl list --options $cmd|"
@@ -563,7 +565,15 @@ sub checkflags {
     while ( <CFH> ) {
         chop;
         last if /DESCRIPTION/;
+        if ( /=for comment ifdef (.*)/ ) {
+            foreach my $f ( split / /, $1 ) {
+                $localskips{$f} = 1;
+            }
+            next;
+        }
         next unless /\[B<-([^ >]+)/;
+        my $opt = $1;
+        $opt = $1 if $opt =~ /I<(.*)/;
         $docopts{$1} = 1;
     }
     close CFH;
@@ -575,7 +585,7 @@ sub checkflags {
     }
     if ( scalar @undocced > 0 ) {
         foreach ( @undocced ) {
-            err("doc/man1/$cmd.pod: Missing -$_");
+            err("$doc: undocumented option -$_");
         }
     }
 
@@ -586,8 +596,8 @@ sub checkflags {
     }
     if ( scalar @unimpl > 0 ) {
         foreach ( @unimpl ) {
-            next if defined $skips{$_};
-            err("doc/man1/$cmd.pod: Not implemented -$_");
+            next if defined $skips{$_} || defined $localskips{$_};
+            err("$cmd documented but not implemented -$_");
         }
     }
 }


### PR DESCRIPTION
Make find-doc-nits understand that
        =for comment ifdef ssl3
in a POD page means that the "-ssl3" command might be ifdef'd out in the
local environment, and not to complain about it.

Added a handful of those lines to pages that complain for me.
Additional flags will probably have to be added.
