### PR TITLE
Fix bugs in "info" commands flags

### DIFF
--- a/apps/info.c
+++ b/apps/info.c
@@ -20,12 +20,8 @@ typedef enum OPTION_choice {
 const OPTIONS info_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
     {"configdir", OPT_CONFIGDIR, '-', "Default configuration file directory"},
-    {"c", OPT_CONFIGDIR, '-', "Default configuration file directory"},
     {"enginesdir", OPT_ENGINESDIR, '-', "Default engine module directory"},
-    {"e", OPT_ENGINESDIR, '-', "Default engine module directory"},
-    {"modulesdir", OPT_ENGINESDIR, '-',
-     "Default module directory (other than engine modules)"},
-    {"m", OPT_ENGINESDIR, '-',
+    {"modulesdir", OPT_MODULESDIR, '-',
      "Default module directory (other than engine modules)"},
     {"dsoext", OPT_DSOEXT, '-', "Configured extension for modules"},
     {"dirnamesep", OPT_DIRNAMESEP, '-', "Directory-filename separator"},

--- a/doc/man1/openssl-info.pod
+++ b/doc/man1/openssl-info.pod
@@ -8,14 +8,14 @@ openssl-info - print OpenSSL built-in information
 
 B<openssl info>
 [B<-help>]
-[B<-configdir> | B<-c>]
-[B<-enginesdir> | B<-e>]
-[B<-modulesdir> | B<-m>]
+[B<-configdir>]
+[B<-enginesdir>]
+[B<-modulesdir> ]
 [B<-dsoext>]
 [B<-dirfilesep>]
-[B<-listsep]>
-[B<-seeds]>
-[B<-cpusettings]>
+[B<-listsep>]
+[B<-seeds>]
+[B<-cpusettings>]
 
 =head1 DESCRIPTION
 
@@ -34,15 +34,15 @@ command.
 
 Print out a usage message.
 
-=item B<-configdir>, B<-c>
+=item B<-configdir>
 
 Outputs the default directory for OpenSSL configuration files.
 
-=item B<-enginesdir>, B<-e>
+=item B<-enginesdir>
 
 Outputs the default directory for OpenSSL engine modules.
 
-=item B<-modulesdir>, B<-m>
+=item B<-modulesdir>
 
 Outputs the default directory for OpenSSL dynamically loadable modules
 other than engine modules.


### PR DESCRIPTION
Remove -c/-e/-m aliases, OpenSSL commands don't do that.
Fix typo's in the documentation.
Fix -module flag to print the right thing.
