### PR TITLE
Do not print extensions in Certificate message for TLS1.2 and lower

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1242,8 +1242,9 @@ static int ssl_print_certificates(BIO *bio, const SSL *ssl, int server,
     while (clen > 0) {
         if (!ssl_print_certificate(bio, indent + 2, &msg, &clen))
             return 0;
-        if (!ssl_print_extensions(bio, indent + 2, server, SSL3_MT_CERTIFICATE,
-                                  &msg, &clen))
+        if (SSL_IS_TLS13(ssl)
+            && !ssl_print_extensions(bio, indent + 2, server,
+                                     SSL3_MT_CERTIFICATE, &msg, &clen))
             return 0;
 
     }


### PR DESCRIPTION
According to RFC8446 CertificateEntry in Certificate message contains
extensions that were not present in the Certificate message in RFC5246.