### PR TITLE
DOC: fix documentation of som EVP_MD_CTX functions

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -38,8 +38,8 @@ EVP_MD_do_all_ex
  void EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void* p2);
  int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, OSSL_PARAM params[]);
  int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *EVP_MD_CTX_settable_params(const EVP_MD_CTX *digest);
- const OSSL_PARAM *EVP_MD_CTX_gettable_params(const EVP_MD_CTX *digest);
+ const OSSL_PARAM *EVP_MD_CTX_settable_params(const EVP_MD *digest);
+ const OSSL_PARAM *EVP_MD_CTX_gettable_params(const EVP_MD *digest);
  void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
  void EVP_MD_CTX_clear_flags(EVP_MD_CTX *ctx, int flags);
  int EVP_MD_CTX_test_flags(const EVP_MD_CTX *ctx, int flags);

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -38,8 +38,8 @@ EVP_MD_do_all_ex
  void EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void* p2);
  int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, OSSL_PARAM params[]);
  int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *EVP_MD_CTX_settable_params(const EVP_MD *digest);
- const OSSL_PARAM *EVP_MD_CTX_gettable_params(const EVP_MD *digest);
+ const OSSL_PARAM *EVP_MD_CTX_settable_params(const EVP_MD_CTX *digest);
+ const OSSL_PARAM *EVP_MD_CTX_gettable_params(const EVP_MD_CTX *digest);
  void EVP_MD_CTX_set_flags(EVP_MD_CTX *ctx, int flags);
  void EVP_MD_CTX_clear_flags(EVP_MD_CTX *ctx, int flags);
  int EVP_MD_CTX_test_flags(const EVP_MD_CTX *ctx, int flags);
@@ -68,9 +68,9 @@ EVP_MD_do_all_ex
 
  const EVP_MD *EVP_MD_CTX_md(const EVP_MD_CTX *ctx);
  const char *EVP_MD_CTX_name(const EVP_MD_CTX *ctx);
- int EVP_MD_CTX_size(const EVP_MD *ctx);
- int EVP_MD_CTX_block_size(const EVP_MD *ctx);
- int EVP_MD_CTX_type(const EVP_MD *ctx);
+ int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);
+ int EVP_MD_CTX_block_size(const EVP_MD_CTX *ctx);
+ int EVP_MD_CTX_type(const EVP_MD_CTX *ctx);
  void *EVP_MD_CTX_md_data(const EVP_MD_CTX *ctx);
  int (*EVP_MD_CTX_update_fn(EVP_MD_CTX *ctx))(EVP_MD_CTX *ctx,
                                               const void *data, size_t count);


### PR DESCRIPTION
They were documented to take an EVP_MD pointer, when they really take
an EVP_MD_CTX pointer.

Fixes #9993
