### PR TITLE
Adapt EVP_CIPHER_{param_to_asn1,asn1_to_param} for use with provider.

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -26,7 +26,7 @@ int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
 
     /*
      * For legacy implementations, we detect custom AlgorithmIdentifier
-     * parameter handling by checking if there the function pointer
+     * parameter handling by checking if the function pointer
      * cipher->set_asn1_parameters is set.  We know that this pointer
      * is NULL for provided implementations.
      *

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -504,6 +504,13 @@ int EVP_CIPHER_CTX_nid(const EVP_CIPHER_CTX *ctx)
 
 int EVP_CIPHER_is_a(const EVP_CIPHER *cipher, const char *name)
 {
+#ifndef FIPS_MODE
+    if (cipher->prov == NULL) {
+        int nid = EVP_CIPHER_nid(cipher);
+
+        return nid == OBJ_sn2nid(name) || nid == OBJ_ln2nid(name);
+    }
+#endif
     return evp_is_a(cipher->prov, cipher->name_id, name);
 }
 

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -324,13 +324,9 @@ odd parity).
 =item "alg_id_param" (B<OSSL_CIPHER_PARAM_ALG_ID>) (octet string)
 
 Used to pass the DER encoded AlgorithmIdentifier parameter to or from
-the cipher implementation.  Functions like L<EVP_CIPHER_param_to_asn1(3)>,
-L<EVP_CIPHER_asn1_to_param(3)>, L<EVP_CIPHER_get_asn1_iv(3)> and
-L<EVP_CIPHER_set_asn1_iv(3)> use this parameter for any implementation
-that has the flag B<EVP_CIPH_FLAG_CUSTOM_ASN1>.  If that flag isn't
-present, these functions will assume the AlgorithmIdentifier parameter
-is an OCTET STRING containing the desired initial IV, extract that IV
-and pass it on to the implementation.
+the cipher implementation.  Functions like L<EVP_CIPHER_param_to_asn1(3)>
+and L<EVP_CIPHER_asn1_to_param(3)> use this parameter for any implementation
+that has the flag B<EVP_CIPH_FLAG_CUSTOM_ASN1> set.
 
 =back
 

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -321,6 +321,17 @@ Gets a implementation specific randomly generated key for the associated
 cipher ctx. This is currently only supported by 3DES (which sets the key to
 odd parity).
 
+=item "alg_id_param" (B<OSSL_CIPHER_PARAM_ALG_ID>) (octet string)
+
+Used to pass the DER encoded AlgorithmIdentifier parameter to or from
+the cipher implementation.  Functions like L<EVP_CIPHER_param_to_asn1(3)>,
+L<EVP_CIPHER_asn1_to_param(3)>, L<EVP_CIPHER_get_asn1_iv(3)> and
+L<EVP_CIPHER_set_asn1_iv(3)> use this parameter for any implementation
+that has the flag B<EVP_CIPH_FLAG_CUSTOM_ASN1>.  If that flag isn't
+present, these functions will assume the AlgorithmIdentifier parameter
+is an OCTET STRING containing the desired initial IV, extract that IV
+and pass it on to the implementation.
+
 =back
 
 =head1 RETURN VALUES

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -66,6 +66,8 @@ extern "C" {
 #define OSSL_CIPHER_PARAM_AEAD_IVLEN         OSSL_CIPHER_PARAM_IVLEN
 #define OSSL_CIPHER_PARAM_AEAD_TAGLEN        "taglen"     /* size_t */
 #define OSSL_CIPHER_PARAM_RANDOM_KEY         "randkey"    /* octet_string */
+/* For passing the AlgorithmIdentifier parameter in DER form */
+#define OSSL_CIPHER_PARAM_ALG_ID             "alg_id_param" /* octet_string */
 
 /* digest parameters */
 #define OSSL_DIGEST_PARAM_XOFLEN     "xoflen"    /* size_t */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -270,7 +270,8 @@ int (*EVP_CIPHER_meth_get_ctrl(const EVP_CIPHER *cipher))(EVP_CIPHER_CTX *,
 /* Don't use standard iv length function */
 # define         EVP_CIPH_CUSTOM_IV_LENGTH       0x800
 /* Legacy and no longer relevant: Allow use default ASN1 get/set iv */
-# define         EVP_CIPH_FLAG_DEFAULT_ASN1      0x1000
+# define         EVP_CIPH_FLAG_DEFAULT_ASN1      0
+/* Free:                                         0x1000 */
 /* Buffer length in bits not bytes: CFB1 mode only */
 # define         EVP_CIPH_FLAG_LENGTH_BITS       0x2000
 /* Note if suitable for use in FIPS mode */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -269,7 +269,7 @@ int (*EVP_CIPHER_meth_get_ctrl(const EVP_CIPHER *cipher))(EVP_CIPHER_CTX *,
 # define         EVP_CIPH_CUSTOM_COPY            0x400
 /* Don't use standard iv length function */
 # define         EVP_CIPH_CUSTOM_IV_LENGTH       0x800
-/* Allow use default ASN1 get/set iv */
+/* Legacy and no longer relevant: Allow use default ASN1 get/set iv */
 # define         EVP_CIPH_FLAG_DEFAULT_ASN1      0x1000
 /* Buffer length in bits not bytes: CFB1 mode only */
 # define         EVP_CIPH_FLAG_LENGTH_BITS       0x2000
@@ -285,6 +285,8 @@ int (*EVP_CIPHER_meth_get_ctrl(const EVP_CIPHER *cipher))(EVP_CIPHER_CTX *,
 # define         EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK 0x400000
 /* Cipher can handle pipeline operations */
 # define         EVP_CIPH_FLAG_PIPELINE          0X800000
+/* For provider implementations that handle  ASN1 get/set param themselves */
+# define         EVP_CIPH_FLAG_CUSTOM_ASN1       0x1000000
 
 /*
  * Cipher context flag to indicate we can handle wrap mode: if allowed in

--- a/providers/common/ciphers/cipher_aes_wrp.c
+++ b/providers/common/ciphers/cipher_aes_wrp.c
@@ -18,7 +18,7 @@
 /* TODO(3.0) Figure out what flags need to be passed */
 #define WRAP_FLAGS (EVP_CIPH_WRAP_MODE \
                    | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER \
-                   | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_FLAG_DEFAULT_ASN1)
+                   | EVP_CIPH_ALWAYS_CALL_INIT)
 
 typedef size_t (*aeswrap_fn)(void *key, const unsigned char *iv,
                              unsigned char *out, const unsigned char *in,

--- a/providers/common/ciphers/cipher_aes_xts.c
+++ b/providers/common/ciphers/cipher_aes_xts.c
@@ -12,8 +12,9 @@
 #include "internal/providercommonerr.h"
 
 /* TODO (3.0) Figure out what flags need to be set */
-#define AES_XTS_FLAGS (EVP_CIPH_FLAG_DEFAULT_ASN1 | EVP_CIPH_CUSTOM_IV         \
-                       | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT        \
+#define AES_XTS_FLAGS (EVP_CIPH_CUSTOM_IV          \
+                       | EVP_CIPH_ALWAYS_CALL_INIT \
+                       | EVP_CIPH_CTRL_INIT        \
                        | EVP_CIPH_CUSTOM_COPY)
 
 #define AES_XTS_IV_BITS 128

--- a/providers/common/include/internal/ciphers/cipher_aead.h
+++ b/providers/common/include/internal/ciphers/cipher_aead.h
@@ -10,10 +10,12 @@
 #define UNINITIALISED_SIZET ((size_t)-1)
 
 /* TODO(3.0) Figure out what flags are really needed */
-#define AEAD_FLAGS (EVP_CIPH_FLAG_AEAD_CIPHER | EVP_CIPH_FLAG_DEFAULT_ASN1     \
-                       | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER      \
-                       | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_CTRL_INIT        \
-                       | EVP_CIPH_CUSTOM_COPY)
+#define AEAD_FLAGS (EVP_CIPH_FLAG_AEAD_CIPHER           \
+                    | EVP_CIPH_CUSTOM_IV                \
+                    | EVP_CIPH_FLAG_CUSTOM_CIPHER       \
+                    | EVP_CIPH_ALWAYS_CALL_INIT         \
+                    | EVP_CIPH_CTRL_INIT                \
+                    | EVP_CIPH_CUSTOM_COPY)
 
 #define IMPLEMENT_aead_cipher(alg, lc, UCMODE, flags, kbits, blkbits, ivbits)  \
 static OSSL_OP_cipher_get_params_fn alg##_##kbits##_##lc##_get_params;         \

--- a/providers/common/include/internal/ciphers/cipher_tdes.h
+++ b/providers/common/include/internal/ciphers/cipher_tdes.h
@@ -14,7 +14,7 @@
 #define TDES_IVLEN 8
 
 /* TODO(3.0) Figure out what flags need to be here */
-#define TDES_FLAGS (EVP_CIPH_RAND_KEY | EVP_CIPH_FLAG_DEFAULT_ASN1)
+#define TDES_FLAGS (EVP_CIPH_RAND_KEY)
 
 typedef struct prov_tdes_ctx_st {
     PROV_CIPHER_CTX base;      /* Must be first */

--- a/providers/default/ciphers/cipher_blowfish.c
+++ b/providers/default/ciphers/cipher_blowfish.c
@@ -12,6 +12,8 @@
 #include "cipher_blowfish.h"
 #include "internal/provider_algs.h"
 
+#define BF_FLAGS (EVP_CIPH_VARIABLE_LENGTH)
+
 static OSSL_OP_cipher_freectx_fn blowfish_freectx;
 static OSSL_OP_cipher_dupctx_fn blowfish_dupctx;
 
@@ -37,10 +39,10 @@ static void *blowfish_dupctx(void *ctx)
 }
 
 /* bf_ecb_functions */
-IMPLEMENT_generic_cipher(blowfish, BLOWFISH, ecb, ECB, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 0, block)
+IMPLEMENT_generic_cipher(blowfish, BLOWFISH, ecb, ECB, BF_FLAGS, 128, 64, 0, block)
 /* bf_cbc_functions */
-IMPLEMENT_generic_cipher(blowfish, BLOWFISH, cbc, CBC, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 64, block)
+IMPLEMENT_generic_cipher(blowfish, BLOWFISH, cbc, CBC, BF_FLAGS, 128, 64, 64, block)
 /* bf_ofb_functions */
-IMPLEMENT_generic_cipher(blowfish, BLOWFISH, ofb64, OFB, EVP_CIPH_VARIABLE_LENGTH, 64, 8, 64, stream)
+IMPLEMENT_generic_cipher(blowfish, BLOWFISH, ofb64, OFB, BF_FLAGS, 64, 8, 64, stream)
 /* bf_cfb_functions */
-IMPLEMENT_generic_cipher(blowfish, BLOWFISH, cfb64,  CFB, EVP_CIPH_VARIABLE_LENGTH, 64, 8, 64, stream)
+IMPLEMENT_generic_cipher(blowfish, BLOWFISH, cfb64,  CFB, BF_FLAGS, 64, 8, 64, stream)

--- a/providers/default/ciphers/cipher_cast5.c
+++ b/providers/default/ciphers/cipher_cast5.c
@@ -12,6 +12,8 @@
 #include "cipher_cast.h"
 #include "internal/provider_algs.h"
 
+#define CAST5_FLAGS (EVP_CIPH_VARIABLE_LENGTH)
+
 static OSSL_OP_cipher_freectx_fn cast5_freectx;
 static OSSL_OP_cipher_dupctx_fn cast5_dupctx;
 
@@ -37,10 +39,10 @@ static void *cast5_dupctx(void *ctx)
 }
 
 /* cast5128ecb_functions */
-IMPLEMENT_generic_cipher(cast5, CAST, ecb, ECB, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 0, block)
+IMPLEMENT_generic_cipher(cast5, CAST, ecb, ECB, CAST5_FLAGS, 128, 64, 0, block)
 /* cast5128cbc_functions */
-IMPLEMENT_generic_cipher(cast5, CAST, cbc, CBC, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 64, block)
+IMPLEMENT_generic_cipher(cast5, CAST, cbc, CBC, CAST5_FLAGS, 128, 64, 64, block)
 /* cast564ofb64_functions */
-IMPLEMENT_generic_cipher(cast5, CAST, ofb64, OFB, EVP_CIPH_VARIABLE_LENGTH, 64, 8, 64, stream)
+IMPLEMENT_generic_cipher(cast5, CAST, ofb64, OFB, CAST5_FLAGS, 64, 8, 64, stream)
 /* cast564cfb64_functions */
-IMPLEMENT_generic_cipher(cast5, CAST, cfb64,  CFB, EVP_CIPH_VARIABLE_LENGTH, 64, 8, 64, stream)
+IMPLEMENT_generic_cipher(cast5, CAST, cfb64,  CFB, CAST5_FLAGS, 64, 8, 64, stream)

--- a/providers/default/ciphers/cipher_seed.c
+++ b/providers/default/ciphers/cipher_seed.c
@@ -12,9 +12,6 @@
 #include "cipher_seed.h"
 #include "internal/provider_algs.h"
 
-/* TODO (3.0) Figure out what flags are required */
-#define SEED_FLAGS EVP_CIPH_FLAG_DEFAULT_ASN1
-
 static OSSL_OP_cipher_freectx_fn seed_freectx;
 static OSSL_OP_cipher_dupctx_fn seed_dupctx;
 
@@ -40,10 +37,10 @@ static void *seed_dupctx(void *ctx)
 }
 
 /* seed128ecb_functions */
-IMPLEMENT_generic_cipher(seed, SEED, ecb, ECB, SEED_FLAGS, 128, 128, 0, block)
+IMPLEMENT_generic_cipher(seed, SEED, ecb, ECB, 0, 128, 128, 0, block)
 /* seed128cbc_functions */
-IMPLEMENT_generic_cipher(seed, SEED, cbc, CBC, SEED_FLAGS, 128, 128, 128, block)
+IMPLEMENT_generic_cipher(seed, SEED, cbc, CBC, 0, 128, 128, 128, block)
 /* seed128ofb128_functions */
-IMPLEMENT_generic_cipher(seed, SEED, ofb128, OFB, SEED_FLAGS, 128, 8, 128, stream)
+IMPLEMENT_generic_cipher(seed, SEED, ofb128, OFB, 0, 128, 8, 128, stream)
 /* seed128cfb128_functions */
-IMPLEMENT_generic_cipher(seed, SEED, cfb128,  CFB, SEED_FLAGS, 128, 8, 128, stream)
+IMPLEMENT_generic_cipher(seed, SEED, cfb128,  CFB, 0, 128, 8, 128, stream)

--- a/providers/default/ciphers/cipher_sm4.c
+++ b/providers/default/ciphers/cipher_sm4.c
@@ -12,9 +12,6 @@
 #include "cipher_sm4.h"
 #include "internal/provider_algs.h"
 
-/* TODO (3.0) Figure out what flags to pass */
-#define SM4_FLAGS EVP_CIPH_FLAG_DEFAULT_ASN1
-
 static OSSL_OP_cipher_freectx_fn sm4_freectx;
 static OSSL_OP_cipher_dupctx_fn sm4_dupctx;
 
@@ -40,12 +37,12 @@ static void *sm4_dupctx(void *ctx)
 }
 
 /* sm4128ecb_functions */
-IMPLEMENT_generic_cipher(sm4, SM4, ecb, ECB, SM4_FLAGS, 128, 128, 0, block)
+IMPLEMENT_generic_cipher(sm4, SM4, ecb, ECB, 0, 128, 128, 0, block)
 /* sm4128cbc_functions */
-IMPLEMENT_generic_cipher(sm4, SM4, cbc, CBC, SM4_FLAGS, 128, 128, 128, block)
+IMPLEMENT_generic_cipher(sm4, SM4, cbc, CBC, 0, 128, 128, 128, block)
 /* sm4128ctr_functions */
-IMPLEMENT_generic_cipher(sm4, SM4, ctr, CTR, SM4_FLAGS, 128, 8, 128, stream)
+IMPLEMENT_generic_cipher(sm4, SM4, ctr, CTR, 0, 128, 8, 128, stream)
 /* sm4128ofb128_functions */
-IMPLEMENT_generic_cipher(sm4, SM4, ofb128, OFB, SM4_FLAGS, 128, 8, 128, stream)
+IMPLEMENT_generic_cipher(sm4, SM4, ofb128, OFB, 0, 128, 8, 128, stream)
 /* sm4128cfb128_functions */
-IMPLEMENT_generic_cipher(sm4, SM4, cfb128,  CFB, SM4_FLAGS, 128, 8, 128, stream)
+IMPLEMENT_generic_cipher(sm4, SM4, cfb128,  CFB, 0, 128, 8, 128, stream)

--- a/providers/default/ciphers/cipher_tdes_wrap.c
+++ b/providers/default/ciphers/cipher_tdes_wrap.c
@@ -15,9 +15,9 @@
 #include "internal/providercommonerr.h"
 
 /* TODO (3.0) Figure out what flags are requred */
-#define TDES_WRAP_FLAGS (EVP_CIPH_WRAP_MODE | EVP_CIPH_CUSTOM_IV               \
-                        | EVP_CIPH_FLAG_CUSTOM_CIPHER                          \
-                        | EVP_CIPH_FLAG_DEFAULT_ASN1)
+#define TDES_WRAP_FLAGS (EVP_CIPH_WRAP_MODE             \
+                         | EVP_CIPH_CUSTOM_IV           \
+                         | EVP_CIPH_FLAG_CUSTOM_CIPHER)
 
 
 static OSSL_OP_cipher_update_fn tdes_wrap_update;


### PR DESCRIPTION
So far, these two funtions have depended on legacy EVP_CIPHER
implementations to be able to do their work.  This change adapts them
to work with provided implementations as well, in one of two possible
ways:

1.  If the implementation's `set_asn1_parameters` or `get_asn1_parameters`
    function pointers are non-NULL, this is a legacy implementation,
    and that function is called.
2.  Otherwise, if the cipher doesn't have `EVP_CIPH_FLAG_CUSTOM_ASN1`
    set, the default AlgorithmIdentifier parameter code in libcrypto
    is executed.
3.  Otherwise, if the cipher is a provided implementation, the ASN1
    type structure is converted to a DER blob which is then passed to
    the implementation as a parameter (param_to_asn1) or the DER blob
    is retrieved from the implementation as a parameter and converted
    locally to a ASN1_TYPE (asn1_to_param).

With this, the old flag `EVP_CIPH_FLAG_DEFAULT_ASN1` has become
irrelevant and is simply ignored.