### PR TITLE
Use the OSSL_PARAM types throughout the documentation.

### DIFF
--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -198,7 +198,7 @@ The length must never exceed what can be given with a B<size_t>.
 
 Memory-hard password-based KDF algorithms, such as scrypt, use an amount of
 memory that depends on the load factors provided as input.
-For those KDF implementations that support it, this uint64_t parameter sets
+For those KDF implementations that support it, this B<uint64_t> parameter sets
 an upper limit on the amount of memory that may be consumed while performing
 a key derivation.
 If this memory usage limit is exceeded because the load factors are chosen

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -163,7 +163,7 @@ The parameters currently supported by the default provider are:
 
 =over 4
 
-=item "pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <uint>
+=item "pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <unsigned integer>
 
 Sets the DH padding mode.
 If B<OSSL_EXCHANGE_PARAM_PAD> is 1 then the  shared secret is padded with zeroes
@@ -171,15 +171,16 @@ up to the size of the DH prime B<p>.
 If B<OSSL_EXCHANGE_PARAM_PAD> is zero (the default) then no padding is
 performed.
 
-=item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <utf8 string>
+=item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
 Gets and sets the name of the digest algorithm used for the input to the
 signature functions.
 
-=item "digest-size" (B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE>) <size_t>
+=item "digest-size" (B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE>) <unsigned integer>
 
 Gets and sets the output size of the digest algorithm used for the input to the
 signature functions.
+The length of the "digest-size" parameter should not exceed that of a B<size_t>.
 The internal algorithm that supports this parameter is DSA.
 
 =back

--- a/doc/man7/EVP_KDF-HKDF.pod
+++ b/doc/man7/EVP_KDF-HKDF.pod
@@ -42,7 +42,7 @@ This parameter sets the info value.
 The length of the context info buffer cannot exceed 1024 bytes;
 this should be more than enough for any normal use of HKDF.
 
-=item B<OSSL_KDF_PARAM_MODE> ("mode") <UTF8 string> or <int>
+=item B<OSSL_KDF_PARAM_MODE> ("mode") <UTF8 string> or <integer>
 
 This parameter sets the mode for the HKDF operation.
 There are three modes that are currently defined:

--- a/doc/man7/EVP_KDF-PBKDF2.pod
+++ b/doc/man7/EVP_KDF-PBKDF2.pod
@@ -28,7 +28,7 @@ The supported parameters are:
 
 =item B<OSSL_KDF_PARAM_SALT> ("salt") <octet string>
 
-=item B<OSSL_KDF_PARAM_ITER> ("iter") <unsigned int>
+=item B<OSSL_KDF_PARAM_ITER> ("iter") <unsigned integer>
 
 This parameter has a default value of 2048.
 
@@ -38,7 +38,7 @@ This parameter has a default value of 2048.
 
 These parameters work as described in L<EVP_KDF(3)/PARAMETERS>.
 
-=item B<OSSL_KDF_PARAM_PKCS5> ("pkcs5") <int>
+=item B<OSSL_KDF_PARAM_PKCS5> ("pkcs5") <integer>
 
 This parameter can be used to enable or disable SP800-132 compliance checks.
 Setting the mode to 0 enables the compliance checks.

--- a/doc/man7/EVP_KDF-SCRYPT.pod
+++ b/doc/man7/EVP_KDF-SCRYPT.pod
@@ -49,15 +49,15 @@ The supported parameters are:
 
 These parameters work as described in L<EVP_KDF(3)/PARAMETERS>.
 
-=item B<OSSL_KDF_PARAM_SCRYPT_N> ("n") <int>
+=item B<OSSL_KDF_PARAM_SCRYPT_N> ("n") <unsigned integer>
 
-=item B<OSSL_KDF_PARAM_SCRYPT_R> ("r") <int>
+=item B<OSSL_KDF_PARAM_SCRYPT_R> ("r") <unsigned integer>
 
-=item B<OSSL_KDF_PARAM_SCRYPT_P> ("p") <int>
+=item B<OSSL_KDF_PARAM_SCRYPT_P> ("p") <unsigned integer>
 
 These parameters configure the scrypt work factors N, r and p.
-N is a parameter of type uint64_t.
-Both r and p are parameters of type uint32_t.
+N is a parameter of type B<uint64_t>.
+Both r and p are parameters of type B<uint32_t>.
 
 =back
 

--- a/doc/man7/EVP_KDF-SS.pod
+++ b/doc/man7/EVP_KDF-SS.pod
@@ -45,7 +45,7 @@ The supported parameters are:
 
 =item B<OSSL_KDF_PARAM_MAC> ("mac") <UTF8 string>
 
-=item B<OSSL_KDF_PARAM_MAC_SIZE> ("maclen") <size_t>
+=item B<OSSL_KDF_PARAM_MAC_SIZE> ("maclen") <unsigned integer>
 
 =item B<OSSL_KDF_PARAM_SALT> ("salt") <octet string>
 

--- a/doc/man7/EVP_KDF-SSHKDF.pod
+++ b/doc/man7/EVP_KDF-SSHKDF.pod
@@ -41,7 +41,7 @@ These parameters work as described in L<EVP_KDF(3)/PARAMETERS>.
 These parameters set the respective values for the KDF.
 If a value is already set, the contents are replaced.
 
-=item B<OSSL_KDF_PARAM_SSHKDF_TYPE> ("type") <int>
+=item B<OSSL_KDF_PARAM_SSHKDF_TYPE> ("type") <integer>
 
 This parameter sets the type for the SSHHKDF operation.
 There are six supported types:

--- a/doc/man7/EVP_MAC-BLAKE2.pod
+++ b/doc/man7/EVP_MAC-BLAKE2.pod
@@ -30,6 +30,7 @@ L<EVP_MAC(3)/PARAMETERS>.
 All these parameters can be set with EVP_MAC_CTX_set_params().
 Furthermore, the "size" parameter can be retrieved with
 EVP_MAC_CTX_get_params(), or with EVP_MAC_size().
+The length of the "size" parameter should not exceed that of a B<size_t>.
 
 =over 4
 
@@ -50,7 +51,7 @@ This is an optional value of at most 16 bytes for BLAKE2BMAC or 8 for
 BLAKE2SMAC.
 It is empty by default.
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <size_t>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 When set, this can be any number between between 1 and 32 for
 EVP_MAC_BLAKE2S or 64 for EVP_MAC_BLAKE2B.

--- a/doc/man7/EVP_MAC-CMAC.pod
+++ b/doc/man7/EVP_MAC-CMAC.pod
@@ -30,9 +30,9 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item B<OSSL_MAC_PARAM_KEY> ("key") <octet string>
 
-=item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <utf8 string>
+=item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>
+=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <UTF8 string>
 
 =back
 
@@ -41,11 +41,12 @@ EVP_MAC_CTX_get_params():
 
 =over 4
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned int>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 =back
 
 The "size" parameter can also be retrieved with with EVP_MAC_size().
+The length of the "size" parameter is equal to that of an B<unsigned int>.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_MAC-GMAC.pod
+++ b/doc/man7/EVP_MAC-GMAC.pod
@@ -32,9 +32,9 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item B<OSSL_MAC_PARAM_IV> ("iv") <octet string>
 
-=item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <utf8 string>
+=item B<OSSL_MAC_PARAM_CIPHER> ("cipher") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>
+=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <UTF8 string>
 
 =back
 
@@ -43,11 +43,12 @@ EVP_MAC_CTX_get_params():
 
 =over 4
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned int>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 =back
 
 The "size" parameter can also be retrieved with EVP_MAC_size().
+The length of the "size" parameter is equal to that of an B<unsigned int>.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -32,24 +32,25 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item B<OSSL_MAC_PARAM_FLAGS> ("flags") <octet string>
 
-=item B<OSSL_MAC_PARAM_DIGEST> ("digest") <utf8 string>
+=item B<OSSL_MAC_PARAM_DIGEST> ("digest") <UTF8 string>
 
-=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <utf8 string>
+=item B<OSSL_MAC_PARAM_PROPERTIES> ("properties") <UTF8 string>
 
 =back
 
 The "flags" parameter is passed directly to HMAC_CTX_set_flags().
 
-The following parameters can be retrieved with
+The following parameter can be retrieved with
 EVP_MAC_CTX_get_params():
 
 =over 4
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned int>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 =back
 
 The "size" parameter can also be retrieved with EVP_MAC_size().
+The length of the "size" parameter is equal to that of an B<unsigned int>.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_MAC-KMAC.pod
+++ b/doc/man7/EVP_MAC-KMAC.pod
@@ -30,6 +30,7 @@ L<EVP_MAC(3)/PARAMETERS>.
 All these parameters can be set with EVP_MAC_CTX_set_params().
 Furthermore, the "size" parameter can be retrieved with
 EVP_MAC_CTX_get_params(), or with EVP_MAC_size().
+The length of the "size" parameter should not exceed that of a B<size_t>.
 
 =over 4
 
@@ -37,7 +38,7 @@ EVP_MAC_CTX_get_params(), or with EVP_MAC_size().
 
 =item B<OSSL_MAC_PARAM_CUSTOM> ("custom") <octet string>
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <size_t>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 =item B<OSSL_MAC_PARAM_XOF>
 

--- a/doc/man7/EVP_MAC-Poly1305.pod
+++ b/doc/man7/EVP_MAC-Poly1305.pod
@@ -37,11 +37,12 @@ EVP_MAC_CTX_get_params():
 
 =over 4
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned int>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 =back
 
 The "size" parameter can also be retrieved with with EVP_MAC_size().
+The length of the "size" parameter should not exceed that of an B<unsigned int>.
 
 =head1 SEE ALSO
 

--- a/doc/man7/EVP_MAC-Siphash.pod
+++ b/doc/man7/EVP_MAC-Siphash.pod
@@ -28,12 +28,13 @@ L<EVP_MAC(3)/PARAMETERS>.
 All these parameters can be set with EVP_MAC_CTX_set_params().
 Furthermore, the "size" parameter can be retrieved with
 EVP_MAC_CTX_get_params(), or with EVP_MAC_size().
+The length of the "size" parameter should not exceed that of a B<size_t>.
 
 =over 4
 
 =item B<OSSL_MAC_PARAM_KEY> ("key") <octet string>
 
-=item B<OSSL_MAC_PARAM_SIZE> ("size") <size_t>
+=item B<OSSL_MAC_PARAM_SIZE> ("size") <unsigned integer>
 
 =back
 

--- a/doc/man7/provider-digest.pod
+++ b/doc/man7/provider-digest.pod
@@ -227,9 +227,10 @@ parameters are relevant to, or are understood by all digests:
 
 =over 4
 
-=item B<OSSL_DIGEST_PARAM_XOFLEN> (size_t)
+=item B<OSSL_DIGEST_PARAM_XOFLEN> (unsigned integer)
 
 Sets the digest length for extendable output functions.
+The length of the "xoflen" parameter should not exceed that of a B<size_t>.
 
 =item B<OSSL_DIGEST_PARAM_SSL3_MS> (octet string)
 
@@ -243,7 +244,7 @@ section 5.6.8.
 The next call after setting this parameter will be OP_digest_final().
 This is only relevant for implementations of SHA1 or MD5_SHA1.
 
-=item B<OSSL_DIGEST_PARAM_PAD_TYPE> (uint)
+=item B<OSSL_DIGEST_PARAM_PAD_TYPE> (unsigned integer)
 
 Sets the pad type to be used.
 The only built-in digest that uses this is MDC2.
@@ -251,7 +252,7 @@ Normally the final MDC2 block is padded with 0s.
 If the pad type is set to 2 then the final block is padded with 0x80 followed by
 0s.
 
-=item B<OSSL_DIGEST_PARAM_MICALG> (utf8 string)
+=item B<OSSL_DIGEST_PARAM_MICALG> (UTF8 string)
 
 Gets the digest Message Integrity Check algorithm string.
 This is used when creating S/MIME multipart/signed messages, as specified in

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -159,7 +159,7 @@ Sets the key in the associated MAC ctx.
 
 Sets the IV of the underlying cipher, when applicable.
 
-=item B<OSSL_MAC_PARAM_CUSTOM> (utf8 string)
+=item B<OSSL_MAC_PARAM_CUSTOM> (UTF8 string)
 
 Sets the custom string in the associated MAC ctx.
 
@@ -167,31 +167,31 @@ Sets the custom string in the associated MAC ctx.
 
 Sets the salt of the underlying cipher, when applicable.
 
-=item B<OSSL_MAC_PARAM_BLOCK_XOF> (int)
+=item B<OSSL_MAC_PARAM_BLOCK_XOF> (integer)
 
 Sets XOF mode in the associated MAC ctx.
 0 means no XOF mode, 1 means XOF mode.
 
-=item B<OSSL_MAC_PARAM_FLAGS> (int)
+=item B<OSSL_MAC_PARAM_FLAGS> (integer)
 
 Gets flags associated with the MAC.
 
 =for comment We need to investigate if this is the right approach
 
-=item B<OSSL_MAC_PARAM_CIPHER> (utf8 string)
+=item B<OSSL_MAC_PARAM_CIPHER> (UTF8 string)
 
-=item B<OSSL_MAC_PARAM_DIGEST> (utf8 string)
+=item B<OSSL_MAC_PARAM_DIGEST> (UTF8 string)
 
 Sets the name of the underlying cipher or digest to be used.
 It must name a suitable algorithm for the MAC that's being used.
 
-=item B<OSSL_MAC_PARAM_PROPERTIES> (utf8 string)
+=item B<OSSL_MAC_PARAM_PROPERTIES> (UTF8 string)
 
 Sets the properties to be queried when trying to fetch the underlying algorithm.
 This must be given together with the algorithm naming parameter to be
 considered valid.
 
-=item B<OSSL_MAC_PARAM_SIZE> (int)
+=item B<OSSL_MAC_PARAM_SIZE> (integer)
 
 Can be used to get the resulting MAC size.
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -194,15 +194,17 @@ algorithms:
 
 =over 4
 
-=item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <utf8 string>
+=item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
 Get or sets the name of the digest algorithm used for the input to the signature
 functions.
 
-=item "digest-size" (B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE>) <size_t>
+=item "digest-size" (B<OSSL_SIGNATURE_PARAM_DIGEST_SIZE>) <unsigned integer>
 
 Gets or sets the output size of the digest algorithm used for the input to the
 signature functions.
+The length of the "digest-size" parameter should not exceed that of a B<size_t>.
+
 
 =back
 


### PR DESCRIPTION
The descriptions mention specific types when relevant.

Also change _utf8 string_ to _UTF8 string_

- [x] documentation is added or updated
- [ ] tests are added or updated
