### PR TITLE
Missing else in cipher_hw_aes_ocb_generic_initkey

### DIFF
--- a/providers/default/ciphers/cipher_aes_ocb_hw.c
+++ b/providers/default/ciphers/cipher_aes_ocb_hw.c
@@ -37,7 +37,7 @@ static int cipher_hw_aes_ocb_generic_initkey(PROV_CIPHER_CTX *vctx,
         OCB_SET_KEY_FN(HWAES_set_encrypt_key, HWAES_set_decrypt_key,
                        HWAES_encrypt, HWAES_decrypt,
                        HWAES_ocb_encrypt, HWAES_ocb_decrypt);
-    }
+    } else
 # endif
 # ifdef VPAES_CAPABLE
     if (VPAES_CAPABLE) {


### PR DESCRIPTION
This came from commit 3837c202 "Add aes_ocb cipher to providers". It
causes the default non-hardware accelerated AES implementation to be
used even if HWAES_CAPABLE is set. Affects all platforms except X86 and
SPARC.

Patch by: Nick Gasson <Nick.Gasson@arm.com>

Change-Id: I26001a3a922ff23f6090fdcefefaecf68e92e2a6

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
