### PR TITLE
Drop MinGW "-x64" dll suffix

### DIFF
--- a/Configurations/platform/mingw.pm
+++ b/Configurations/platform/mingw.pm
@@ -29,9 +29,7 @@ sub shlib_version_as_filename {
 sub sharedname {
     return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
                                     "-",
-                                    $_[0]->shlib_version_as_filename(),
-                                    ($config{target} eq "mingw64"
-                                         ? "-x64" : ""));
+                                    $_[0]->shlib_version_as_filename());
 }
 
 # With Mingw and other DLL producers, there isn't really any "simpler"


### PR DESCRIPTION
Such a dll suffix is unusual, if the goal is just fix the name conflict the more canonical way of doing things is using different build dirs.
Aside from fixing this weirdness, this would allow to use the same filename as the msvc dlls (c dlls are compatible) so we could swap them.
Also the use of this suffix is not consistent since engine plugins (capi.dll, padlock.dll) are not affected by this naming scheme.

cc @levitte

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
