### PR TITLE
Fix SSL_get_servername() to not return NULL

### DIFF
--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -72,20 +72,51 @@ In particular note that in TLSv1.3 the servername is negotiated in every
 handshake. In TLSv1.2 the servername is only negotiated on initial handshakes
 and not on resumption handshakes.
 
-On the client, if this is called before a server accepts or ignores the
-servername, then it will return the servername being requested if one has been
-set. If a servername has not been set then it returns the servername from the
-original session (if a resumption is being attempted). After the server has
-accepted or ignored the servername, if TLSv1.2 or below has been negotiated and
-a session was resumed, then it returns the servername from the original session
-if there was one. Otherwise the servername requested by the client in this
-handshake is returned.
+=over 4
 
-On the server, if this is called before the servername extension from the client
-is processed, then NULL will be returned. After processing of any servername
-extension from the client, if TLSv1.2 has been negotiated and a session was
-resumed, then the servername from the original session is returned. Otherwise
-the servername requested by the client in this handshake is returned.
+=item On the client, before the handshake
+
+If a servername has been set via a call to SSL_set_tlsext_host_name() then it
+will return that servername.
+
+If one has not been set, but a TLSv1.2 resumption is being attempted and the
+session from the original handshake had a servername accepted by the server then
+it will return that servername.
+
+Otherwise it returns NULL.
+
+=item On the client, during or after the handshake and a TLSv1.2 (or below)
+resumption occurred
+
+If the session from the orignal handshake had a servername accepted by the
+server then it will return that servername.
+
+Otherwise it returns the servername set via SSL_set_tlsext_host_name() (or NULL
+if it was not called).
+
+=item On the client, during or after the handshake and a TLSv1.2 (or below)
+resumption did not occur
+
+It will return the servername set via SSL_set_tlsext_host_name() (or NULL if it
+was not called).
+
+=item On the server, before the handshake
+
+The function will always return NULL before the handshake
+
+=item On the server, after the servername extension has been processed and a
+TLSv1.2 (or below) resumption occurred
+
+If a servername was accepted by the server in the original handshake then it
+will return that servername, or NULL otherwise.
+
+=item On the server, after the servername extension has been processed and a
+TLSv1.2 (or below) resumption did not occur
+
+The function will return the servername requested by the client in this
+handshake or NULL if none was requested.
+
+=back
 
 Note that the ClientHello callback occurs before a servername extension from the
 client is processed. The servername, certificate and alpn callbacks occur after

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -153,23 +153,18 @@ L<SSL_get0_alpn_selected(3)>, L<SSL_CTX_set_client_hello_cb(3)>
 =head1 HISTORY
 
 SSL_get_servername() historically provided some unexpected results in certain
-corner cases. This has been fixed from OpenSSL 1.1.1e. Prior to that version
-the following occurred:
+corner cases. This has been fixed from OpenSSL 1.1.1e.
 
-If the client requests a servername in an initial TLSv1.2 handshake, the
-server accepts it, and then the client successfully resumes but sets a different
-explict servername in the second handshake we would expect SSL_get_servername()
-called by the client to return the servername from the original handshake. This
-is because a TLSv1.2 resumption was successful and therefore the servername that
-has been agreed for the connection is the one from the original handshake.
-However historically it returned the servername from the second handshake.
+Prior to 1.1.1e, when the client requested a servername in an initial TLSv1.2
+handshake, the server accepted it, and then the client successfully resumed but
+set a different explict servername in the second handshake it returned the
+servername from the second handshake. This has now been changed to the
+servername from the original handshake.
 
-If the client sends a servername in the first handshake but the server does not
-accept it, and then a second handshake occurs where TLSv1.2 resumption is
-successful then we would expect SSL_get_servername() called by the server to
-return NULL. This is because there was no servername negotiated for the session.
-However historically it returned the servername from the original handshake even
-though the server did not accept it.
+Also prior to 1.1.1e, if the client sent a servername in the first handshake but
+the server did not accept it, and then a second handshake occured where TLSv1.2
+resumption was successful then it returned the servername from the original
+handshake. This has now been changed to NULL.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -11,7 +11,7 @@ SSL_set_tlsext_host_name - handle server name indication (SNI)
  #include <openssl/ssl.h>
 
  long SSL_CTX_set_tlsext_servername_callback(SSL_CTX *ctx,
-                                   int (*cb)(SSL *, int *, void *));
+                                   int (*cb)(SSL *s, int *al, void *arg));
  long SSL_CTX_set_tlsext_servername_arg(SSL_CTX *ctx, void *arg);
 
  const char *SSL_get_servername(const SSL *s, const int type);
@@ -21,18 +21,51 @@ SSL_set_tlsext_host_name - handle server name indication (SNI)
 
 =head1 DESCRIPTION
 
-The functionality provided by the servername callback is superseded by the
-ClientHello callback, which can be set using SSL_CTX_set_client_hello_cb().
-The servername callback is retained for historical compatibility.
+The functionality provided by the servername callback is mostly superseded by
+the ClientHello callback, which can be set using SSL_CTX_set_client_hello_cb().
+However, even where the ClientHello callback is used, the servername callback is
+still necessary in order to acknowledge the servername requested by the client.
 
 SSL_CTX_set_tlsext_servername_callback() sets the application callback B<cb>
 used by a server to perform any actions or configuration required based on
 the servername extension received in the incoming connection. When B<cb>
-is NULL, SNI is not used. The B<arg> value is a pointer which is passed to
-the application callback.
+is NULL, SNI is not used.
+
+The servername callback should return one of the following values:
+
+=over 4
+
+=item SSL_TLSEXT_ERR_OK
+
+This is used to indicate that the servername requested by the client has been
+accepted. Typically a server will call SSL_set_SSL_CTX() in the callback to set
+up a different configuration for the selected servername in this case.
+
+=item SSL_TLSEXT_ERR_ALERT_FATAL
+
+In this case the servername requested by the client is not accepted and the
+handshake will be aborted. The value of the alert to be used should be stored in
+the location pointed to by the B<al> parameter to the callback. By default this
+value is initialised to SSL_AD_UNRECOGNIZED_NAME.
+
+=item SSL_TLSEXT_ERR_ALERT_WARNING
+
+If this value is returned then the servername is not accepted by the server.
+However the handshake will continue and send a warning alert instead. The value
+of the alert should be stored in the location pointed to by the B<al> parameter
+as for SSL_TLSEXT_ERR_ALERT_FATAL above. Note that TLSv1.3 does not support
+warning alerts, so if TLSv1.3 has been negotiated then this return value is
+treated the same way as SSL_TLSEXT_ERR_NOACK.
+
+=item SSL_TLSEXT_ERR_NOACK
+
+This return value indicates that the servername is not accepted by the server.
+No alerts are sent and the server will not acknowledge the requested servername.
+
+=back
 
 SSL_CTX_set_tlsext_servername_arg() sets a context-specific argument to be
-passed into the callback for this B<SSL_CTX>.
+passed into the callback (via the B<arg> parameter) for this B<SSL_CTX>.
 
 The behaviour of SSL_get_servername() depends on a number of different factors.
 In particular note that in TLSv1.3 the servername is negotiated in every
@@ -55,8 +88,8 @@ resumed, then the servername from the original session is returned. Otherwise
 the servername requested by the client in this handshake is returned.
 
 Note that the ClientHello callback occurs before a servername extension from the
-client is processed. The servername and alpn callbacks occur after a
-servername extension from the client is processed.
+client is processed. The servername, certificate and alpn callbacks occur after
+a servername extension from the client is processed.
 
 SSL_get_servername_type() returns the servername type or -1 if no servername
 is present. Currently the only supported type (defined in RFC3546) is

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -34,8 +34,24 @@ the application callback.
 SSL_CTX_set_tlsext_servername_arg() sets a context-specific argument to be
 passed into the callback for this B<SSL_CTX>.
 
-SSL_get_servername() returns a servername extension value of the specified
-type if provided in the Client Hello or NULL.
+The behaviour of SSL_get_servername() depends on a number of different factors.
+In particular note that in TLSv1.3 the servername is negotiated in every
+handshake. In TLSv1.2 the servername is only negotiated on initial handshakes
+and not on resumption handshakes.
+
+On the client, if this is called before a handshake has started, then it will
+return the servername being requested if one has been set. If a servername has
+not been set then it returns the servername from the original session (if a
+resumption is being attempted). After or during the handshake, if TLSv1.2 or
+below has been negotiated and a session was resumed, then it returns the
+servername from the original session if there was one. Otherwise the servername
+requested by the client in this handshake is returned.
+
+On the server, if this is called before a handshake has started, then NULL will
+be returned. After or during the handshake, if TLSv1.2 has been negotiated and
+a session was resumed, then the servername from the original session is
+returned. Otherwise the servername requested by the client in this handshake is
+returned.
 
 SSL_get_servername_type() returns the servername type or -1 if no servername
 is present. Currently the only supported type (defined in RFC3546) is

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -39,19 +39,24 @@ In particular note that in TLSv1.3 the servername is negotiated in every
 handshake. In TLSv1.2 the servername is only negotiated on initial handshakes
 and not on resumption handshakes.
 
-On the client, if this is called before a handshake has started, then it will
-return the servername being requested if one has been set. If a servername has
-not been set then it returns the servername from the original session (if a
-resumption is being attempted). After or during the handshake, if TLSv1.2 or
-below has been negotiated and a session was resumed, then it returns the
-servername from the original session if there was one. Otherwise the servername
-requested by the client in this handshake is returned.
+On the client, if this is called before a server accepts or ignores the
+servername, then it will return the servername being requested if one has been
+set. If a servername has not been set then it returns the servername from the
+original session (if a resumption is being attempted). After the server has
+accepted or ignored the servername, if TLSv1.2 or below has been negotiated and
+a session was resumed, then it returns the servername from the original session
+if there was one. Otherwise the servername requested by the client in this
+handshake is returned.
 
-On the server, if this is called before a handshake has started, then NULL will
-be returned. After or during the handshake, if TLSv1.2 has been negotiated and
-a session was resumed, then the servername from the original session is
-returned. Otherwise the servername requested by the client in this handshake is
-returned.
+On the server, if this is called before the servername extension from the client
+is processed, then NULL will be returned. After processing of any servername
+extension from the client, if TLSv1.2 has been negotiated and a session was
+resumed, then the servername from the original session is returned. Otherwise
+the servername requested by the client in this handshake is returned.
+
+Note that the ClientHello callback occurs before a servername extension from the
+client is processed. The servername and alpn callbacks occur after a
+servername extension from the client is processed.
 
 SSL_get_servername_type() returns the servername type or -1 if no servername
 is present. Currently the only supported type (defined in RFC3546) is

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -91,14 +91,14 @@ resumption occurred
 If the session from the orignal handshake had a servername accepted by the
 server then it will return that servername.
 
-Otherwise it returns the servername set via SSL_set_tlsext_host_name() (or NULL
-if it was not called).
+Otherwise it returns the servername set via SSL_set_tlsext_host_name() or NULL
+if it was not called.
 
 =item On the client, during or after the handshake and a TLSv1.2 (or below)
 resumption did not occur
 
-It will return the servername set via SSL_set_tlsext_host_name() (or NULL if it
-was not called).
+It will return the servername set via SSL_set_tlsext_host_name() or NULL if it
+was not called.
 
 =item On the server, before the handshake
 
@@ -119,7 +119,7 @@ handshake or NULL if none was requested.
 =back
 
 Note that the ClientHello callback occurs before a servername extension from the
-client is processed. The servername, certificate and alpn callbacks occur after
+client is processed. The servername, certificate and ALPN callbacks occur after
 a servername extension from the client is processed.
 
 SSL_get_servername_type() returns the servername type or -1 if no servername
@@ -159,7 +159,7 @@ Prior to 1.1.1e, when the client requested a servername in an initial TLSv1.2
 handshake, the server accepted it, and then the client successfully resumed but
 set a different explict servername in the second handshake then when called by
 the client it returned the servername from the second handshake. This has now
-been changed to the servername requested in the original handshake.
+been changed to return the servername requested in the original handshake.
 
 Also prior to 1.1.1e, if the client sent a servername in the first handshake but
 the server did not accept it, and then a second handshake occured where TLSv1.2

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -157,14 +157,15 @@ corner cases. This has been fixed from OpenSSL 1.1.1e.
 
 Prior to 1.1.1e, when the client requested a servername in an initial TLSv1.2
 handshake, the server accepted it, and then the client successfully resumed but
-set a different explict servername in the second handshake it returned the
-servername from the second handshake. This has now been changed to the
-servername from the original handshake.
+set a different explict servername in the second handshake then when called by
+the client it returned the servername from the second handshake. This has now
+been changed to the servername requested in the original handshake.
 
 Also prior to 1.1.1e, if the client sent a servername in the first handshake but
 the server did not accept it, and then a second handshake occured where TLSv1.2
-resumption was successful then it returned the servername from the original
-handshake. This has now been changed to NULL.
+resumption was successful then when called by the server it returned the
+servername requested in the original handshake. This has now been changed to
+NULL.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -150,6 +150,27 @@ SSL_set_tlsext_host_name() returns 1 on success, 0 in case of error.
 L<ssl(7)>, L<SSL_CTX_set_alpn_select_cb(3)>,
 L<SSL_get0_alpn_selected(3)>, L<SSL_CTX_set_client_hello_cb(3)>
 
+=head1 HISTORY
+
+SSL_get_servername() historically provided some unexpected results in certain
+corner cases. This has been fixed from OpenSSL 1.1.1e. Prior to that version
+the following occurred:
+
+If the client requests a servername in an initial TLSv1.2 handshake, the
+server accepts it, and then the client successfully resumes but sets a different
+explict servername in the second handshake we would expect SSL_get_servername()
+called by the client to return the servername from the original handshake. This
+is because a TLSv1.2 resumption was successful and therefore the servername that
+has been agreed for the connection is the one from the original handshake.
+However historically it returned the servername from the second handshake.
+
+If the client sends a servername in the first handshake but the server does not
+accept it, and then a second handshake occurs where TLSv1.2 resumption is
+successful then we would expect SSL_get_servername() called by the server to
+return NULL. This is because there was no servername negotiated for the session.
+However historically it returned the servername from the original handshake even
+though the server did not accept it.
+
 =head1 COPYRIGHT
 
 Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/SSL_SESSION_get0_hostname.pod
+++ b/doc/man3/SSL_SESSION_get0_hostname.pod
@@ -24,7 +24,10 @@ SSL_SESSION_set1_alpn_selected
 =head1 DESCRIPTION
 
 SSL_SESSION_get0_hostname() retrieves the SNI value that was sent by the
-client when the session was created, or NULL if no value was sent.
+client when the session was created if it was accepted by the server and TLSv1.2
+or below was negotiated. Otherwise NULL is returned. Note that in TLSv1.3 the
+SNI hostname is negotiated with each handshake including resumption handshakes
+and is therefore never associated with the session.
 
 The value returned is a pointer to memory maintained within B<s> and
 should not be free'd.

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2753,7 +2753,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
     return buf;
 }
 
-/*
+/**
  * Return the requested servername (SNI) value. Note that the behaviour varies
  * depending on:
  * - whether this is called by the client or the server,
@@ -2761,7 +2761,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
  * - if a resumption or normal handshake is being attempted/has occurred
  * - whether we have negotiated TLSv1.2 (or below) or TLSv1.3
  * 
- * Note that only host_name types are defined (RFC 3546).
+ * Note that only the host_name type is defined (RFC 3546).
  */
 const char *SSL_get_servername(const SSL *s, const int type)
 {
@@ -2774,7 +2774,7 @@ const char *SSL_get_servername(const SSL *s, const int type)
         return NULL;
 
     if (server) {
-        /*
+        /**
          * Server side
          * In TLSv1.3 on the server SNI is not associated with the session
          * but in TLSv1.2 or below it is.
@@ -2793,7 +2793,7 @@ const char *SSL_get_servername(const SSL *s, const int type)
          if (s->hit && !SSL_IS_TLS13(s))
             return s->session->ext.hostname;
     } else {
-        /*
+        /**
          * Client side
          *
          * Before the handshake:

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1010,6 +1010,7 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
         /* TLSv1.3 doesn't have warning alerts so we suppress this */
         if (!SSL_IS_TLS13(s))
             ssl3_send_alert(s, SSL3_AL_WARNING, altmp);
+        s->servername_done = 0;
         return 1;
 
     case SSL_TLSEXT_ERR_NOACK:

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -948,7 +948,7 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
      * was successful.
      */
     if (s->server) {
-        /* TODO(OpenSSL1.2) revisit !sent case */
+        /* In TLSv1.3 SNI is never associated with the session */
         if (sent && ret == SSL_TLSEXT_ERR_OK && !s->hit) {
             /* Only store the hostname in the session if we accepted it. */
             OPENSSL_free(s->session->ext.hostname);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -948,7 +948,6 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
      * was successful.
      */
     if (s->server) {
-        /* In TLSv1.3 SNI is never associated with the session */
         if (sent && ret == SSL_TLSEXT_ERR_OK && !s->hit) {
             /* Only store the hostname in the session if we accepted it. */
             OPENSSL_free(s->session->ext.hostname);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -159,13 +159,12 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
         }
 
         s->servername_done = 1;
-    }
-    /*
-     * In TLSv1.2 and below we should check if the SNI is consistent between
-     * the initial handshake and the resumption. In TLSv1.3 SNI is not
-     * associated with the session.
-     */
-    if (s->hit && !SSL_IS_TLS13(s)) {
+    } else {
+        /*
+         * In TLSv1.2 and below we should check if the SNI is consistent between
+         * the initial handshake and the resumption. In TLSv1.3 SNI is not
+         * associated with the session.
+         */
         /*
          * TODO(openssl-team): if the SNI doesn't match, we MUST
          * fall back to a full handshake.

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -127,6 +127,10 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
         return 0;
     }
 
+    /*
+     * In TLSv1.2 and below the SNI is associated with the session. In TLSv1.3
+     * we always use the SNI value from the handshake.
+     */
     if (!s->hit || SSL_IS_TLS13(s)) {
         if (PACKET_remaining(&hostname) > TLSEXT_MAXLEN_host_name) {
             SSLfatal(s, SSL_AD_UNRECOGNIZED_NAME,
@@ -156,7 +160,12 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
 
         s->servername_done = 1;
     }
-    if (s->hit) {
+    /*
+     * In TLSv1.2 and below we should check if the SNI is consistent between
+     * the initial handshake and the resumption. In TLSv1.3 SNI is not
+     * associated with the session.
+     */
+    if (s->hit && !SSL_IS_TLS13(s)) {
         /*
          * TODO(openssl-team): if the SNI doesn't match, we MUST
          * fall back to a full handshake.
@@ -164,9 +173,6 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
         s->servername_done = (s->session->ext.hostname != NULL)
             && PACKET_equal(&hostname, s->session->ext.hostname,
                             strlen(s->session->ext.hostname));
-
-        if (!s->servername_done && s->session->ext.hostname != NULL)
-            s->ext.early_data_ok = 0;
     }
 
     return 1;
@@ -1333,8 +1339,14 @@ EXT_RETURN tls_construct_stoc_server_name(SSL *s, WPACKET *pkt,
                                           unsigned int context, X509 *x,
                                           size_t chainidx)
 {
-    if (s->hit || s->servername_done != 1
-            || s->ext.hostname == NULL)
+    if (s->servername_done != 1)
+        return EXT_RETURN_NOT_SENT;
+
+    /*
+     * Prior to TLSv1.3 we ignore any SNI in the current handshake if resuming.
+     * We just use the servername from the initial handshake.
+     */
+    if (s->hit && !SSL_IS_TLS13(s))
         return EXT_RETURN_NOT_SENT;
 
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_server_name)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3191,7 +3191,8 @@ static int hostname_cb(SSL *s, int *al, void *arg)
 {
     const char *hostname = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
 
-    if (hostname != NULL && strcmp(hostname, "goodhost") == 0)
+    if (hostname != NULL && (strcmp(hostname, "goodhost") == 0
+                             || strcmp(hostname, "altgoodhost") == 0))
         return  SSL_TLSEXT_ERR_OK;
 
     return SSL_TLSEXT_ERR_NOACK;
@@ -3289,16 +3290,16 @@ static int test_early_data_psk(int idx)
 
     case 3:
         /*
-         * Set inconsistent SNI (server detected). In this case the connection
-         * will succeed but reject early_data.
+         * Set inconsistent SNI (server side). In this case the connection
+         * will succeed and accept early_data. In TLSv1.3 on the server side SNI
+         * is associated with each handshake - not the session. Therefore it
+         * should not matter that we used a different server name last time.
          */
         SSL_SESSION_free(serverpsk);
         serverpsk = SSL_SESSION_dup(clientpsk);
         if (!TEST_ptr(serverpsk)
                 || !TEST_true(SSL_SESSION_set1_hostname(serverpsk, "badhost")))
             goto end;
-        edstatus = SSL_EARLY_DATA_REJECTED;
-        readearlyres = SSL_READ_EARLY_DATA_FINISH;
         /* Fall through */
     case 4:
         /* Set consistent SNI */
@@ -6918,6 +6919,146 @@ end:
 }
 #endif /* OPENSSL_NO_TLS1_2 */
 
+/*
+ * Test 0: Client sets servername and server acknowledges it (TLSv1.2)
+ * Test 1: Client sets servername and server does not acknowledge it (TLSv1.2)
+ * Test 2: Client sets inconsistent servername on resumption (TLSv1.2)
+ * Test 3: Client sets servername and server acknowledges it (TLSv1.3)
+ * Test 4: Client sets servername and server does not acknowledge it (TLSv1.3)
+ * Test 5: Client sets inconsistent servername on resumption (TLSv1.3)
+ */
+static int test_servername(int tst)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+    SSL_SESSION *sess = NULL;
+    const char *sexpectedhost, *cexpectedhost;
+
+#ifdef OPENSSL_NO_TLS1_2
+    if (tst <= 2)
+        return 1;
+#endif
+#ifdef OPENSSL_NO_TLS1_3
+    if (tst >= 3)
+        return 1;
+#endif
+
+    if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
+                                       TLS_client_method(),
+                                       TLS1_VERSION,
+                                       (tst <= 2) ? TLS1_2_VERSION
+                                                  : TLS1_3_VERSION,
+                                       &sctx, &cctx, cert, privkey))
+            || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                             NULL, NULL))
+            || !TEST_true(SSL_set_tlsext_host_name(clientssl, "goodhost")))
+        goto end;
+
+    if (tst != 1 && tst != 4) {
+        if (!TEST_true(SSL_CTX_set_tlsext_servername_callback(sctx,
+                                                              hostname_cb)))
+            goto end;
+    }
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_str_eq(SSL_get_servername(clientssl, TLSEXT_NAMETYPE_host_name),
+                     "goodhost")
+            || !TEST_str_eq(SSL_get_servername(serverssl,
+                                               TLSEXT_NAMETYPE_host_name),
+                            "goodhost"))
+        goto end;
+
+    /* Now repeat with a resumption handshake */
+
+    if (!TEST_int_eq(SSL_shutdown(clientssl), 0)
+            || !TEST_ptr_ne(sess = SSL_get1_session(clientssl), NULL)
+            || !TEST_true(SSL_SESSION_is_resumable(sess))
+            || !TEST_int_eq(SSL_shutdown(serverssl), 0))
+        goto end;
+
+    SSL_free(clientssl);
+    SSL_free(serverssl);
+    clientssl = serverssl = NULL;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
+                                      NULL)))
+        goto end;
+
+    if (!TEST_true(SSL_set_session(clientssl, sess)))
+        goto end;
+
+    sexpectedhost = cexpectedhost = "goodhost";
+    if (tst == 2 || tst == 5) {
+        /* Set an inconsistent hostname */
+        if (!TEST_true(SSL_set_tlsext_host_name(clientssl, "altgoodhost")))
+            goto end;
+        /*
+         * In TLSv1.2 we expect the hostname from the original handshake, in
+         * TLSv1.3 we expect the hostname from this handshake
+         */
+        if (tst == 5)
+            sexpectedhost = cexpectedhost = "altgoodhost";
+
+        if (!TEST_str_eq(SSL_get_servername(clientssl,
+                                            TLSEXT_NAMETYPE_host_name),
+                         "altgoodhost"))
+            goto end;
+    } else {
+        if (!TEST_true(SSL_set_tlsext_host_name(clientssl, "goodhost")))
+            goto end;
+        /*
+         * In a TLSv1.2 resumption where the hostname was not acknowledged
+         * we expect the hostname on the server to be empty. On the client we
+         * return what was requested in this case.
+         */
+        if (tst == 1 || tst == 2)
+            sexpectedhost = NULL;
+
+        if (!TEST_str_eq(SSL_get_servername(clientssl,
+                                            TLSEXT_NAMETYPE_host_name),
+                         "goodhost"))
+            goto end;
+    }
+
+    if (tst != 1 && tst != 4) {
+        if (!TEST_true(SSL_CTX_set_tlsext_servername_callback(sctx,
+                                                              hostname_cb)))
+            goto end;
+    }
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_session_reused(clientssl))
+            || !TEST_true(SSL_session_reused(serverssl))
+            || !TEST_str_eq(SSL_get_servername(clientssl,
+                                               TLSEXT_NAMETYPE_host_name),
+                            cexpectedhost)
+               /*
+                * In TLSv1.2 we return the hostname from the original session -
+                * if we didn't acknowledge it will be empty.
+                * In TLSv1.3 we return the hostname from this handshake.
+                */
+            || !TEST_str_eq(SSL_get_servername(serverssl,
+                                               TLSEXT_NAMETYPE_host_name),
+                            sexpectedhost))
+        goto end;
+
+    testresult = 1;
+
+ end:
+    SSL_SESSION_free(sess);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile\n")
 
 int setup_tests(void)
@@ -7068,6 +7209,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_TLS1_2
     ADD_ALL_TESTS(test_multiblock_write, OSSL_NELEM(multiblock_cipherlist_data));
 #endif
+    ADD_ALL_TESTS(test_servername, 6);
     return 1;
 }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -6929,7 +6929,7 @@ end:
  * Test 6: Client sets servername and server does not acknowledge it (TLSv1.3)
  * Test 7: Client sets inconsistent servername on resumption (TLSv1.3)
  * Test 8: Client does not set servername on initial handshake(TLSv1.3)
- * Test 9: Client does not set servername on resumption handshake (TLSv1.2)
+ * Test 9: Client does not set servername on resumption handshake (TLSv1.3)
  */
 static int test_servername(int tst)
 {
@@ -7056,11 +7056,6 @@ static int test_servername(int tst)
             || !TEST_str_eq(SSL_get_servername(clientssl,
                                                TLSEXT_NAMETYPE_host_name),
                             cexpectedhost)
-               /*
-                * In TLSv1.2 we return the hostname from the original session -
-                * if we didn't acknowledge it will be empty.
-                * In TLSv1.3 we return the hostname from this handshake.
-                */
             || !TEST_str_eq(SSL_get_servername(serverssl,
                                                TLSEXT_NAMETYPE_host_name),
                             sexpectedhost))


### PR DESCRIPTION
If a client sets a servername, but the server does not acknowledge it
then the servername is not stored in the session. Regardless of that,
SSL_get_servername() will always return the servername first requested
on the initial connection. However on a resumption connection it always
returns the servername from the session - which will be NULL if the
server did not acknowledge it. Therefore the behaviour is inconsistent
between initial and resumption handshakes.

We restored the historical behaviour for SSL_get_servername() on the
client.

Fixes #8822

WIP for now because it needs a test.