### PR TITLE
Add wordlist from man7.org

### DIFF
--- a/doc/HOWTO/proxy_certificates.txt
+++ b/doc/HOWTO/proxy_certificates.txt
@@ -108,7 +108,7 @@ recognised:
         superfluous, and was removed.
 
   file  indicates that the text of the policy should really be taken from a
-        file.  The string is then really a file name.  This is useful for
+        file.  The string is then really a filename.  This is useful for
         policies that are large (more than a few lines, e.g. XML documents).
 
 The 'policy' setting can be split up in multiple lines like this:

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -39,7 +39,7 @@ I<new_method>, I<up_ref_method>, and I<free_method>.
 
 evp_generic_fetch_by_number() does the same thing as evp_generic_fetch(), 
 but takes a I<name_id> instead of a number.
-I<name_id> must always be non-zero; as a matter of fact, it being zero
+I<name_id> must always be nonzero; as a matter of fact, it being zero
 is considered a programming error.
 This is meant to be used when one method needs to fetch an associated
 other method, and is typically called from inside the given function

--- a/doc/internal/man3/ossl_cmp_asn1_octet_string_set1.pod
+++ b/doc/internal/man3/ossl_cmp_asn1_octet_string_set1.pod
@@ -37,7 +37,7 @@ by L<OSSL_CMP_log(3)> etc.
 according to the pattern OSSL_CMP_LOG_START#level ": %s\n", filling in
 the variable pointed to by I<level> with the severity level or -1,
 the variable pointed to by I<func> with the function name string or NULL,
-the variable pointed to by I<file> with the file name string or NULL, and
+the variable pointed to by I<file> with the filename string or NULL, and
 the variable pointed to by I<line> with the line number or -1.
 Any string returned via I<*func> and I<*file> must be freeed by the caller.
 

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -43,7 +43,7 @@ ossl_namemap_add() adds a new name to the namemap if it's not already
 present.
 If the given I<number> is zero, a new number will be allocated to
 identify this I<name>.
-If the given I<number> is non-zero, the I<name> is added to the set of
+If the given I<number> is nonzero, the I<name> is added to the set of
 names already associated with that number.
 
 ossl_namemap_name2num() finds the number corresponding to the given

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -184,7 +184,7 @@ ossl_provider_new().
 ossl_provider_dso() returns a reference to the module, for providers
 that come in the form of loadable modules.
 
-ossl_provider_module_name() returns the file name of the module, for
+ossl_provider_module_name() returns the filename of the module, for
 providers that come in the form of loadable modules.
 
 ossl_provider_module_path() returns the full path of the module file,

--- a/doc/man1/CA.pl.pod
+++ b/doc/man1/CA.pl.pod
@@ -164,7 +164,7 @@ Create the CA directories and files:
 
  CA.pl -newca
 
-enter cacert.pem when prompted for the CA file name.
+enter cacert.pem when prompted for the CA filename.
 
 Create a DSA certificate request and private key (a different set of parameters
 can optionally be created first):

--- a/doc/man1/openssl-info.pod
+++ b/doc/man1/openssl-info.pod
@@ -54,7 +54,7 @@ Outputs the DSO extension OpenSSL uses.
 =item B<-dirnamesep>
 
 Outputs the separator character between a directory specification and
-a file name.
+a filename.
 Note that on some operating systems, this is not the same as the
 separator between directory elements.
 

--- a/doc/man1/openssl-ocsp.pod
+++ b/doc/man1/openssl-ocsp.pod
@@ -178,7 +178,7 @@ Specify the responder URL. Both HTTP and HTTPS (SSL/TLS) URLs can be specified.
 =item B<-host> I<hostname:port>, B<-path> I<pathname>
 
 If the B<host> option is present then the OCSP request is sent to the host
-B<hostname> on port B<port>. B<path> specifies the HTTP path name to use
+B<hostname> on port B<port>. B<path> specifies the HTTP pathname to use
 or "/" by default.  This is equivalent to specifying B<-url> with scheme
 http:// and the given hostname, port, and pathname.
 

--- a/doc/man1/openssl-ts.pod
+++ b/doc/man1/openssl-ts.pod
@@ -102,23 +102,23 @@ the hash to the TSA.
 =item 2.
 
 The TSA attaches the current date and time to the received hash value,
-signs them and sends the time stamp token back to the client. By
+signs them and sends the timestamp token back to the client. By
 creating this token the TSA certifies the existence of the original
 data file at the time of response generation.
 
 =item 3.
 
-The TSA client receives the time stamp token and verifies the
+The TSA client receives the timestamp token and verifies the
 signature on it. It also checks if the token contains the same hash
 value that it had sent to the TSA.
 
 =back
 
 There is one DER encoded protocol data unit defined for transporting a time
-stamp request to the TSA and one for sending the time stamp response
+stamp request to the TSA and one for sending the timestamp response
 back to the client. The B<ts> command has three main functions:
-creating a time stamp request based on a data file,
-creating a time stamp response based on a request, verifying if a
+creating a timestamp request based on a data file,
+creating a timestamp response based on a request, verifying if a
 response corresponds to a particular request or a data file.
 
 There is no support for sending the requests/responses automatically
@@ -127,9 +127,9 @@ requests either by ftp or e-mail.
 
 =head1 OPTIONS
 
-=head2 Time Stamp Request generation
+=head2 Timestamp Request generation
 
-The B<-query> switch can be used for creating and printing a time stamp
+The B<-query> switch can be used for creating and printing a timestamp
 request with the following options:
 
 =over 4
@@ -155,7 +155,7 @@ see L<openssl(1)/COMMAND SUMMARY>.
 
 =item B<-data> I<file_to_hash>
 
-The data file for which the time stamp request needs to be
+The data file for which the timestamp request needs to be
 created. stdin is the default if neither the B<-data> nor the B<-digest>
 parameter is specified. (Optional)
 
@@ -176,7 +176,7 @@ The default is SHA-256. (Optional)
 =item B<-tspolicy> I<object_id>
 
 The policy that the client expects the TSA to use for creating the
-time stamp token. Either the dotted OID notation or OID names defined
+timestamp token. Either the dotted OID notation or OID names defined
 in the config file can be used. If no policy is requested the TSA will
 use its own default policy. (Optional)
 
@@ -194,7 +194,7 @@ response. (Optional)
 
 =item B<-in> I<request.tsq>
 
-This option specifies a previously created time stamp request in DER
+This option specifies a previously created timestamp request in DER
 format that will be printed into the output file. Useful when you need
 to examine the content of a request in human-readable
 format. (Optional)
@@ -211,15 +211,15 @@ instead of DER. (Optional)
 
 =back
 
-=head2 Time Stamp Response generation
+=head2 Timestamp Response generation
 
-A time stamp response (TimeStampResp) consists of a response status
-and the time stamp token itself (ContentInfo), if the token generation was
-successful. The B<-reply> command is for creating a time stamp
-response or time stamp token based on a request and printing the
+A timestamp response (TimeStampResp) consists of a response status
+and the timestamp token itself (ContentInfo), if the token generation was
+successful. The B<-reply> command is for creating a timestamp
+response or timestamp token based on a request and printing the
 response/token in human-readable format. If B<-token_out> is not
-specified the output is always a time stamp response (TimeStampResp),
-otherwise it is a time stamp token (ContentInfo).
+specified the output is always a timestamp response (TimeStampResp),
+otherwise it is a timestamp token (ContentInfo).
 
 =over 4
 
@@ -238,7 +238,7 @@ used, see L</CONFIGURATION FILE OPTIONS> for details. (Optional)
 
 =item B<-queryfile> I<request.tsq>
 
-The name of the file containing a DER encoded time stamp request. (Optional)
+The name of the file containing a DER encoded timestamp request. (Optional)
 
 =item B<-passin> I<password_src>
 
@@ -283,19 +283,19 @@ B<default_policy> config file option. (Optional)
 
 =item B<-in> I<response.tsr>
 
-Specifies a previously created time stamp response or time stamp token
+Specifies a previously created timestamp response or timestamp token
 (if B<-token_in> is also specified) in DER format that will be written
 to the output file. This option does not require a request, it is
 useful e.g. when you need to examine the content of a response or
-token or you want to extract the time stamp token from a response. If
-the input is a token and the output is a time stamp response a default
+token or you want to extract the timestamp token from a response. If
+the input is a token and the output is a timestamp response a default
 'granted' status info is added to the token. (Optional)
 
 =item B<-token_in>
 
 This flag can be used together with the B<-in> option and indicates
-that the input is a DER encoded time stamp token (ContentInfo) instead
-of a time stamp response (TimeStampResp). (Optional)
+that the input is a DER encoded timestamp token (ContentInfo) instead
+of a timestamp response (TimeStampResp). (Optional)
 
 =item B<-out> I<response.tsr>
 
@@ -305,7 +305,7 @@ stdout. (Optional)
 
 =item B<-token_out>
 
-The output is a time stamp token (ContentInfo) instead of time stamp
+The output is a timestamp token (ContentInfo) instead of timestamp
 response (TimeStampResp). (Optional)
 
 =item B<-text>
@@ -318,14 +318,14 @@ instead of DER. (Optional)
 Specifying an engine (by its unique B<id> string) will cause B<ts>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
-for all available algorithms. Default is builtin. (Optional)
+for all available algorithms. Default is built-in. (Optional)
 
 =back
 
-=head2 Time Stamp Response verification
+=head2 Timestamp Response verification
 
-The B<-verify> command is for verifying if a time stamp response or time
-stamp token is valid and matches a particular time stamp request or
+The B<-verify> command is for verifying if a timestamp response or time
+stamp token is valid and matches a particular timestamp request or
 data file. The B<-verify> command does not use the configuration file.
 
 =over 4
@@ -346,18 +346,18 @@ specified with this one. (Optional)
 
 =item B<-queryfile> I<request.tsq>
 
-The original time stamp request in DER format. The B<-data> and B<-digest>
+The original timestamp request in DER format. The B<-data> and B<-digest>
 options must not be specified with this one. (Optional)
 
 =item B<-in> I<response.tsr>
 
-The time stamp response that needs to be verified in DER format. (Mandatory)
+The timestamp response that needs to be verified in DER format. (Mandatory)
 
 =item B<-token_in>
 
 This flag can be used together with the B<-in> option and indicates
-that the input is a DER encoded time stamp token (ContentInfo) instead
-of a time stamp response (TimeStampResp). (Optional)
+that the input is a DER encoded timestamp token (ContentInfo) instead
+of a timestamp response (TimeStampResp). (Optional)
 
 =item B<-CApath> I<trusted_cert_path>
 
@@ -431,14 +431,14 @@ See L<ca(1)> for description. (Optional)
 =item B<serial>
 
 The name of the file containing the hexadecimal serial number of the
-last time stamp response created. This number is incremented by 1 for
+last timestamp response created. This number is incremented by 1 for
 each response. If the file does not exist at the time of response
 generation a new file is created with serial number 1. (Mandatory)
 
 =item B<crypto_device>
 
 Specifies the OpenSSL engine that will be set as the default for
-all available algorithms. The default value is builtin, you can specify
+all available algorithms. The default value is built-in, you can specify
 any other engines supported by OpenSSL (e.g. use chil for the NCipher HSM).
 (Optional)
 
@@ -488,7 +488,7 @@ the components is missing zero is assumed for that field. (Optional)
 =item B<clock_precision_digits>
 
 Specifies the maximum number of digits, which represent the fraction of
-seconds, that  need to be included in the time field. The trailing zeroes
+seconds, that  need to be included in the time field. The trailing zeros
 must be removed from the time, so there might actually be fewer digits,
 or no fraction of seconds at all. Supported only on UNIX platforms.
 The maximum value is 6, default is 0.
@@ -529,16 +529,16 @@ All the examples below presume that B<OPENSSL_CONF> is set to a proper
 configuration file, e.g. the example configuration file
 openssl/apps/openssl.cnf will do.
 
-=head2 Time Stamp Request
+=head2 Timestamp Request
 
-To create a time stamp request for design1.txt with SHA-256 digest,
+To create a timestamp request for design1.txt with SHA-256 digest,
 without nonce and policy, and without requirement for a certificate
 in the response:
 
   openssl ts -query -data design1.txt -no_nonce \
         -out design1.tsq
 
-To create a similar time stamp request with specifying the message imprint
+To create a similar timestamp request with specifying the message imprint
 explicitly:
 
   openssl ts -query -digest b7e5d3f93198b38379852f2c04e78d73abdd0f4b \
@@ -548,7 +548,7 @@ To print the content of the previous request in human readable format:
 
   openssl ts -query -in design1.tsq -text
 
-To create a time stamp request which includes the SHA-512 digest
+To create a timestamp request which includes the SHA-512 digest
 of design2.txt, requests the signer certificate and nonce, and
 specifies a policy id (assuming the tsa_policy1 name is defined in the
 OID section of the config file):
@@ -556,7 +556,7 @@ OID section of the config file):
   openssl ts -query -data design2.txt -sha512 \
         -tspolicy tsa_policy1 -cert -out design2.tsq
 
-=head2 Time Stamp Response
+=head2 Timestamp Response
 
 Before generating a response a signing certificate must be created for
 the TSA that contains the B<timeStamping> critical extended key usage extension
@@ -570,7 +570,7 @@ below assume that cacert.pem contains the certificate of the CA,
 tsacert.pem is the signing certificate issued by cacert.pem and
 tsakey.pem is the private key of the TSA.
 
-To create a time stamp response for a request:
+To create a timestamp response for a request:
 
   openssl ts -reply -queryfile design1.tsq -inkey tsakey.pem \
         -signer tsacert.pem -out design1.tsr
@@ -579,44 +579,44 @@ If you want to use the settings in the config file you could just write:
 
   openssl ts -reply -queryfile design1.tsq -out design1.tsr
 
-To print a time stamp reply to stdout in human readable format:
+To print a timestamp reply to stdout in human readable format:
 
   openssl ts -reply -in design1.tsr -text
 
-To create a time stamp token instead of time stamp response:
+To create a timestamp token instead of timestamp response:
 
   openssl ts -reply -queryfile design1.tsq -out design1_token.der -token_out
 
-To print a time stamp token to stdout in human readable format:
+To print a timestamp token to stdout in human readable format:
 
   openssl ts -reply -in design1_token.der -token_in -text -token_out
 
-To extract the time stamp token from a response:
+To extract the timestamp token from a response:
 
   openssl ts -reply -in design1.tsr -out design1_token.der -token_out
 
-To add 'granted' status info to a time stamp token thereby creating a
+To add 'granted' status info to a timestamp token thereby creating a
 valid response:
 
   openssl ts -reply -in design1_token.der -token_in -out design1.tsr
 
-=head2 Time Stamp Verification
+=head2 Timestamp Verification
 
-To verify a time stamp reply against a request:
+To verify a timestamp reply against a request:
 
   openssl ts -verify -queryfile design1.tsq -in design1.tsr \
         -CAfile cacert.pem -untrusted tsacert.pem
 
-To verify a time stamp reply that includes the certificate chain:
+To verify a timestamp reply that includes the certificate chain:
 
   openssl ts -verify -queryfile design2.tsq -in design2.tsr \
         -CAfile cacert.pem
 
-To verify a time stamp token against the original data file:
+To verify a timestamp token against the original data file:
   openssl ts -verify -data design2.txt -in design2.tsr \
         -CAfile cacert.pem
 
-To verify a time stamp token against a message imprint:
+To verify a timestamp token against a message imprint:
   openssl ts -verify -digest b7e5d3f93198b38379852f2c04e78d73abdd0f4b \
          -in design2.tsr -CAfile cacert.pem
 
@@ -630,7 +630,7 @@ You could also look at the 'test' directory for more examples.
 
 =item *
 
-No support for time stamps over SMTP, though it is quite easy
+No support for timestamps over SMTP, though it is quite easy
 to implement an automatic e-mail based TSA with L<procmail(1)>
 and L<perl(1)>. HTTP server support is provided in the form of
 a separate apache module. HTTP client support is provided by
@@ -640,7 +640,7 @@ L<tsget(1)>. Pure TCP/IP protocol is not supported.
 
 The file containing the last serial number of the TSA is not
 locked when being read or written. This is a problem if more than one
-instance of L<openssl(1)> is trying to create a time stamp
+instance of L<openssl(1)> is trying to create a timestamp
 response at the same time. This is not an issue when using the apache
 server module, it does proper locking.
 

--- a/doc/man1/openssl-tsget.pod
+++ b/doc/man1/openssl-tsget.pod
@@ -23,15 +23,15 @@ B<-h> server_url
 
 =head1 DESCRIPTION
 
-The B<tsget> command can be used for sending a time stamp request, as
-specified in B<RFC 3161>, to a time stamp server over HTTP or HTTPS and storing
-the time stamp response in a file. This tool cannot be used for creating the
+The B<tsget> command can be used for sending a timestamp request, as
+specified in B<RFC 3161>, to a timestamp server over HTTP or HTTPS and storing
+the timestamp response in a file. This tool cannot be used for creating the
 requests and verifying responses, you can use the OpenSSL B<ts(1)> command to
 do that. B<tsget> can send several requests to the server without closing
 the TCP connection if more than one requests are specified on the command
 line.
 
-The tool sends the following HTTP request for each time stamp request:
+The tool sends the following HTTP request for each timestamp request:
 
         POST url HTTP/1.1
         User-Agent: OpenTSA tsget.pl/<version>
@@ -52,7 +52,7 @@ written to a file without any interpretation.
 
 =item B<-h> server_url
 
-The URL of the HTTP/HTTPS server listening for time stamp requests.
+The URL of the HTTP/HTTPS server listening for timestamp requests.
 
 =item B<-e> extension
 
@@ -63,8 +63,8 @@ the input files. Default extension is '.tsr'. (Optional)
 =item B<-o> output
 
 This option can be specified only when just one request is sent to the
-server. The time stamp response will be written to the given output file. '-'
-means standard output. In case of multiple time stamp requests or the absence
+server. The timestamp response will be written to the given output file. '-'
+means standard output. In case of multiple timestamp requests or the absence
 of this argument the names of the output files will be derived from the names
 of the input files and the default or specified extension argument. (Optional)
 
@@ -123,7 +123,7 @@ The name of an EGD socket to get random data from. (Optional)
 
 =item B<request...>
 
-List of files containing B<RFC 3161> DER-encoded time stamp requests. If no
+List of files containing B<RFC 3161> DER-encoded timestamp requests. If no
 requests are specified only one request will be sent to the server and it will be
 read from the standard input. (Optional)
 
@@ -138,35 +138,35 @@ arguments.
 =head1 EXAMPLES
 
 The examples below presume that B<file1.tsq> and B<file2.tsq> contain valid
-time stamp requests, tsa.opentsa.org listens at port 8080 for HTTP requests
+timestamp requests, tsa.opentsa.org listens at port 8080 for HTTP requests
 and at port 8443 for HTTPS requests, the TSA service is available at the /tsa
 absolute path.
 
-Get a time stamp response for file1.tsq over HTTP, output is written to
+Get a timestamp response for file1.tsq over HTTP, output is written to
 file1.tsr:
 
   tsget -h http://tsa.opentsa.org:8080/tsa file1.tsq
 
-Get a time stamp response for file1.tsq and file2.tsq over HTTP showing
+Get a timestamp response for file1.tsq and file2.tsq over HTTP showing
 progress, output is written to file1.reply and file2.reply respectively:
 
   tsget -h http://tsa.opentsa.org:8080/tsa -v -e .reply \
         file1.tsq file2.tsq
 
-Create a time stamp request, write it to file3.tsq, send it to the server and
+Create a timestamp request, write it to file3.tsq, send it to the server and
 write the response to file3.tsr:
 
   openssl ts -query -data file3.txt -cert | tee file3.tsq \
         | tsget -h http://tsa.opentsa.org:8080/tsa \
         -o file3.tsr
 
-Get a time stamp response for file1.tsq over HTTPS without client
+Get a timestamp response for file1.tsq over HTTPS without client
 authentication:
 
   tsget -h https://tsa.opentsa.org:8443/tsa \
         -C cacerts.pem file1.tsq
 
-Get a time stamp response for file1.tsq over HTTPS with certificate-based
+Get a timestamp response for file1.tsq over HTTPS with certificate-based
 client authentication (it will ask for the passphrase if client_key.pem is
 protected):
 

--- a/doc/man1/openssl-x509.pod
+++ b/doc/man1/openssl-x509.pod
@@ -259,7 +259,7 @@ Prints out the start and expiry dates of a certificate.
 =item B<-checkend> I<arg>
 
 Checks if the certificate expires within the next B<arg> seconds and exits
-non-zero if yes it will expire or zero if not.
+nonzero if yes it will expire or zero if not.
 
 =item B<-fingerprint>
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -32,7 +32,7 @@ It can be used for
  o  Encryption and Decryption with Ciphers
  o  SSL/TLS Client and Server Tests
  o  Handling of S/MIME signed or encrypted mail
- o  Time Stamp requests, generation and verification
+ o  Timestamp requests, generation and verification
 
 =head1 COMMAND SUMMARY
 

--- a/doc/man3/ASN1_TIME_set.pod
+++ b/doc/man3/ASN1_TIME_set.pod
@@ -117,7 +117,7 @@ one or both (depending on the time difference) of I<*pday> and I<*psec>
 will be positive. If I<to> represents a time earlier than I<from> then
 one or both of I<*pday> and I<*psec> will be negative. If I<to> and I<from>
 represent the same time then I<*pday> and I<*psec> will both be zero.
-If both I<*pday> and I<*psec> are non-zero they will always have the same
+If both I<*pday> and I<*psec> are nonzero they will always have the same
 sign. The value of I<*psec> will always be less than the number of seconds
 in a day. If I<from> or I<to> is NULL the current time is used.
 
@@ -169,7 +169,7 @@ either format.
 =head1 BUGS
 
 ASN1_TIME_print(), ASN1_UTCTIME_print() and ASN1_GENERALIZEDTIME_print()
-do not print out the time zone: it either prints out "GMT" or nothing. But all
+do not print out the timezone: it either prints out "GMT" or nothing. But all
 certificates complying with RFC5280 et al use GMT anyway.
 
 Use the ASN1_TIME_normalize() function to normalize the time value before

--- a/doc/man3/ASN1_TYPE_get.pod
+++ b/doc/man3/ASN1_TYPE_get.pod
@@ -33,7 +33,7 @@ up after the call.
 ASN1_TYPE_set1() sets the value of I<a> to I<type> a copy of I<value>.
 
 ASN1_TYPE_cmp() compares ASN.1 types I<a> and I<b> and returns 0 if
-they are identical and non-zero otherwise.
+they are identical and nonzero otherwise.
 
 ASN1_TYPE_unpack_sequence() attempts to parse the SEQUENCE present in
 I<t> using the ASN.1 structure I<it>. If successful it returns a pointer
@@ -63,11 +63,11 @@ length octets).
 
 ASN1_TYPE_cmp() may not return zero if two types are equivalent but have
 different encodings. For example the single content octet of the boolean TRUE
-value under BER can have any non-zero encoding but ASN1_TYPE_cmp() will
+value under BER can have any nonzero encoding but ASN1_TYPE_cmp() will
 only return zero if the values are the same.
 
 If either or both of the parameters passed to ASN1_TYPE_cmp() is NULL the
-return value is non-zero. Technically if both parameters are NULL the two
+return value is nonzero. Technically if both parameters are NULL the two
 types could be absent OPTIONAL fields and so should match, however passing
 NULL values could also indicate a programming error (for example an
 unparseable type which returns NULL) for types which do B<not> match. So
@@ -81,7 +81,7 @@ ASN1_TYPE_set() does not return a value.
 
 ASN1_TYPE_set1() returns 1 for success and 0 for failure.
 
-ASN1_TYPE_cmp() returns 0 if the types are identical and non-zero otherwise.
+ASN1_TYPE_cmp() returns 0 if the types are identical and nonzero otherwise.
 
 ASN1_TYPE_unpack_sequence() returns a pointer to an ASN.1 structure or
 NULL on failure.

--- a/doc/man3/BIO_get_data.pod
+++ b/doc/man3/BIO_get_data.pod
@@ -25,7 +25,7 @@ the BIO. This data can subsequently be retrieved via a call to BIO_get_data().
 This can be used by custom BIOs for storing implementation specific information.
 
 The BIO_set_init() function sets the value of the BIO's "init" flag to indicate
-whether initialisation has been completed for this BIO or not. A non-zero value
+whether initialisation has been completed for this BIO or not. A nonzero value
 indicates that initialisation is complete, whilst zero indicates that it is not.
 Often initialisation will complete during initial construction of the BIO. For
 some BIOs however, initialisation may not complete until after additional steps

--- a/doc/man3/BIO_parse_hostserv.pod
+++ b/doc/man3/BIO_parse_hostserv.pod
@@ -19,10 +19,10 @@ BIO_parse_hostserv
 =head1 DESCRIPTION
 
 BIO_parse_hostserv() will parse the information given in B<hostserv>,
-create strings with the host name and service name and give those
+create strings with the hostname and service name and give those
 back via B<host> and B<service>.  Those will need to be freed after
 they are used.  B<hostserv_prio> helps determine if B<hostserv> shall
-be interpreted primarily as a host name or a service name in ambiguous
+be interpreted primarily as a hostname or a service name in ambiguous
 cases.
 
 The syntax the BIO_parse_hostserv() recognises is:

--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -106,7 +106,7 @@ If blocking I/O is set then a non positive return value from any
 I/O call is caused by an error condition, although a zero return
 will normally mean that the connection was closed.
 
-If the port name is supplied as part of the host name then this will
+If the port name is supplied as part of the hostname then this will
 override any value set with BIO_set_conn_port(). This may be undesirable
 if the application does not wish to allow connection to arbitrary
 ports. This can be avoided by checking for the presence of the ':'

--- a/doc/man3/BIO_s_file.pod
+++ b/doc/man3/BIO_s_file.pod
@@ -78,7 +78,7 @@ in stdio behaviour will be mirrored by the corresponding BIO.
 
 On Windows BIO_new_files reserves for the filename argument to be
 UTF-8 encoded. In other words if you have to make it work in multi-
-lingual environment, encode file names in UTF-8.
+lingual environment, encode filenames in UTF-8.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/BN_bn2bin.pod
+++ b/doc/man3/BN_bn2bin.pod
@@ -40,7 +40,7 @@ memory.
 
 BN_bn2binpad() also converts the absolute value of B<a> into big-endian form
 and stores it at B<to>. B<tolen> indicates the length of the output buffer
-B<to>. The result is padded with zeroes if necessary. If B<tolen> is less than
+B<to>. The result is padded with zeros if necessary. If B<tolen> is less than
 BN_num_bytes(B<a>) an error is returned.
 
 BN_bin2bn() converts the positive integer in big-endian form of length

--- a/doc/man3/CONF_modules_free.pod
+++ b/doc/man3/CONF_modules_free.pod
@@ -30,7 +30,7 @@ to free up any configuration that module may have performed.
 
 CONF_modules_unload() finishes and unloads configuration modules. If
 B<all> is set to B<0> only modules loaded from DSOs will be unloads. If
-B<all> is B<1> all modules, including builtin modules will be unloaded.
+B<all> is B<1> all modules, including built-in modules will be unloaded.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/CRYPTO_memcmp.pod
+++ b/doc/man3/CRYPTO_memcmp.pod
@@ -19,13 +19,13 @@ contents of the memory regions pointed to by B<a> and B<b>.
 
 =head1 RETURN VALUES
 
-CRYPTO_memcmp() returns 0 if the memory regions are equal and non-zero
+CRYPTO_memcmp() returns 0 if the memory regions are equal and nonzero
 otherwise.
 
 =head1 NOTES
 
 Unlike memcmp(2), this function cannot be used to order the two memory regions
-as the return value when they differ is undefined, other than being non-zero.
+as the return value when they differ is undefined, other than being nonzero.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -88,7 +88,7 @@ issued in the future. RFC6962 states that "TLS clients MUST reject SCTs whose
 timestamp is in the future". By default, this will be set to 5 minutes in the
 future (e.g. (time() + 300) * 1000), to allow for clock drift.
 
-The time should be in milliseconds since the Unix epoch.
+The time should be in milliseconds since the Unix Epoch.
 
 =back
 

--- a/doc/man3/DES_random_key.pod
+++ b/doc/man3/DES_random_key.pod
@@ -134,7 +134,7 @@ DES_ecb_encrypt() is the basic DES encryption routine that encrypts or
 decrypts a single 8-byte I<DES_cblock> in I<electronic code book>
 (ECB) mode.  It always transforms the input data, pointed to by
 I<input>, into the output data, pointed to by the I<output> argument.
-If the I<encrypt> argument is non-zero (DES_ENCRYPT), the I<input>
+If the I<encrypt> argument is nonzero (DES_ENCRYPT), the I<input>
 (cleartext) is encrypted in to the I<output> (ciphertext) using the
 key_schedule specified by the I<schedule> argument, previously set via
 I<DES_set_key>. If I<encrypt> is zero (DES_DECRYPT), the I<input> (now
@@ -153,7 +153,7 @@ The macro DES_ecb2_encrypt() is provided to perform two-key Triple-DES
 encryption by using I<ks1> for the final encryption.
 
 DES_ncbc_encrypt() encrypts/decrypts using the I<cipher-block-chaining>
-(CBC) mode of DES.  If the I<encrypt> argument is non-zero, the
+(CBC) mode of DES.  If the I<encrypt> argument is nonzero, the
 routine cipher-block-chain encrypts the cleartext data pointed to by
 the I<input> argument into the ciphertext pointed to by the I<output>
 argument, using the key schedule provided by the I<schedule> argument,

--- a/doc/man3/DH_get0_pqg.pod
+++ b/doc/man3/DH_get0_pqg.pod
@@ -81,7 +81,7 @@ DH_get0_engine() returns a handle to the ENGINE that has been set for this DH
 object, or NULL if no such ENGINE has been set.
 
 The DH_get_length() and DH_set_length() functions get and set the optional
-length parameter associated with this DH object. If the length is non-zero then
+length parameter associated with this DH object. If the length is nonzero then
 it is used, otherwise it is ignored. The B<length> parameter indicates the
 length of the secret exponent (private key) in bits.
 

--- a/doc/man3/DH_set_method.pod
+++ b/doc/man3/DH_set_method.pod
@@ -64,7 +64,7 @@ B<DH_METHOD>s.
 
 DH_set_default_method() returns no value.
 
-DH_set_method() returns non-zero if the provided B<meth> was successfully set as
+DH_set_method() returns nonzero if the provided B<meth> was successfully set as
 the method for B<dh> (including unloading the ENGINE handle if the previous
 method was supplied by an ENGINE).
 

--- a/doc/man3/DSA_set_method.pod
+++ b/doc/man3/DSA_set_method.pod
@@ -64,7 +64,7 @@ B<DSA_METHOD>s.
 
 DSA_set_default_method() returns no value.
 
-DSA_set_method() returns non-zero if the provided B<meth> was successfully set as
+DSA_set_method() returns nonzero if the provided B<meth> was successfully set as
 the method for B<dsa> (including unloading the ENGINE handle if the previous
 method was supplied by an ENGINE).
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -105,8 +105,8 @@ EC_GROUP_set_curve function. An appropriate default implementation method will b
 
 Whilst the library can be used to create any curve using the functions described above, there are also a number of
 predefined curves that are available. In order to obtain a list of all of the predefined curves, call the function
-EC_get_builtin_curves. The parameter B<r> should be an array of EC_builtin_curve structures of size B<nitems>. The function
-will populate the B<r> array with information about the builtin curves. If B<nitems> is less than the total number of
+EC_get_builtin_curves(). The parameter B<r> should be an array of EC_builtin_curve structures of size B<nitems>. The function
+will populate the B<r> array with information about the built-in curves. If B<nitems> is less than the total number of
 curves available, then the first B<nitems> curves will be returned. Otherwise the total number of curves will be
 provided. The return value is the total number of curves available (whether that number has been populated in B<r> or
 not). Passing a NULL B<r>, or setting B<nitems> to 0 will do nothing other than return the total number of curves available.
@@ -119,7 +119,7 @@ The EC_builtin_curve structure is defined as follows:
 
 Each EC_builtin_curve item has a unique integer id (B<nid>), and a human readable comment string describing the curve.
 
-In order to construct a builtin curve use the function EC_GROUP_new_by_curve_name_ex and provide the B<nid> of the curve to
+In order to construct a built-in curve use the function EC_GROUP_new_by_curve_name_ex and provide the B<nid> of the curve to
 be constructed and the associated library context to be used in B<ctx> (see L<OPENSSL_CTX(3)>).
 The B<ctx> value may be NULL in which case the default library context is used.
 
@@ -136,7 +136,7 @@ If B<group> is NULL nothing is done.
 
 All EC_GROUP_new* functions return a pointer to the newly constructed group, or NULL on error.
 
-EC_get_builtin_curves returns the number of builtin curves that are available.
+EC_get_builtin_curves returns the number of built-in curves that are available.
 
 EC_GROUP_set_curve_GFp, EC_GROUP_get_curve_GFp, EC_GROUP_set_curve_GF2m, EC_GROUP_get_curve_GF2m return 1 on success or 0 on error.
 

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -254,7 +254,7 @@ To obtain a functional reference from an existing structural reference,
 call the ENGINE_init() function. This returns zero if the ENGINE was not
 already operational and couldn't be successfully initialised (eg. lack of
 system drivers, no special hardware attached, etc), otherwise it will
-return non-zero to indicate that the ENGINE is now operational and will
+return nonzero to indicate that the ENGINE is now operational and will
 have allocated a new B<functional> reference to the ENGINE. All functional
 references are released by calling ENGINE_finish() (which removes the
 implicit structural reference as well).
@@ -333,7 +333,7 @@ acceleration hardware attached to the machine or some such thing. There are
 probably numerous other ways in which applications may prefer to handle
 things, so we will simply illustrate the consequences as they apply to a
 couple of simple cases and leave developers to consider these and the
-source code to openssl's builtin utilities as guides.
+source code to openssl's built-in utilities as guides.
 
 If no ENGINE API functions are called within an application, then OpenSSL
 will not allocate any internal resources.  Prior to OpenSSL 1.1.0, however,
@@ -346,7 +346,7 @@ Here we'll assume an application has been configured by its user or admin
 to want to use the "ACME" ENGINE if it is available in the version of
 OpenSSL the application was compiled with. If it is available, it should be
 used by default for all RSA, DSA, and symmetric cipher operations, otherwise
-OpenSSL should use its builtin software as per usual. The following code
+OpenSSL should use its built-in software as per usual. The following code
 illustrates how to approach this;
 
  ENGINE *e;
@@ -374,7 +374,7 @@ illustrates how to approach this;
  /* Release the structural reference from ENGINE_by_id() */
  ENGINE_free(e);
 
-I<Automatically using builtin ENGINE implementations>
+I<Automatically using built-in ENGINE implementations>
 
 Here we'll assume we want to load and register all ENGINE implementations
 bundled with OpenSSL, such that for any cryptographic algorithm required by
@@ -422,7 +422,7 @@ calling ENGINE_init(). The other class of commands consist of settings or
 operations that tweak certain behaviour or cause certain operations to take
 place, and these commands may work either before or after ENGINE_init(), or
 in some cases both. ENGINE implementations should provide indications of
-this in the descriptions attached to builtin control commands and/or in
+this in the descriptions attached to built-in control commands and/or in
 external product documentation.
 
 I<Issuing control commands to an ENGINE>
@@ -477,7 +477,7 @@ boolean success or failure.
  }
 
 Note that ENGINE_ctrl_cmd_string() accepts a boolean argument that can
-relax the semantics of the function - if set non-zero it will only return
+relax the semantics of the function - if set nonzero it will only return
 failure if the ENGINE supported the given command name but failed while
 executing it, if the ENGINE doesn't support the command name it will simply
 return success without doing anything. In this case we assume the user is

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -68,9 +68,9 @@ and L<ERR_error_string(3)> for human-readable error messages.
 ERR_get_error_line(), ERR_peek_error_line() and
 ERR_peek_last_error_line() are the same as ERR_get_error(),
 ERR_peek_error() and ERR_peek_last_error(), but on success they
-additionally store the file name and line number where
+additionally store the filename and line number where
 the error occurred in *B<file> and *B<line>, as far as they are not B<NULL>.
-An unset file name is indicated as B<"">, i.e., an empty string.
+An unset filename is indicated as B<"">, i.e., an empty string.
 An unset line number is indicated as B<0>.
 
 A pointer returned this way by these functions and the ones below

--- a/doc/man3/ERR_load_strings.pod
+++ b/doc/man3/ERR_load_strings.pod
@@ -34,7 +34,7 @@ ERR_PACK() is a macro.
 The last entry in the array is {0,0}.
 
 ERR_get_next_error_library() can be used to assign library numbers
-to user libraries at runtime.
+to user libraries at run time.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/ERR_new.pod
+++ b/doc/man3/ERR_new.pod
@@ -25,7 +25,7 @@ ERR_new() allocates a new slot in the thread's error queue.
 
 ERR_set_debug() sets the debug information related to the current
 error in the thread's error queue.
-The values that can be given are the file name I<file>, line in the
+The values that can be given are the filename I<file>, line in the
 file I<line> and the name of the function I<func> where the error
 occured.
 The names must be constant, this function will only save away the

--- a/doc/man3/ERR_print_errors.pod
+++ b/doc/man3/ERR_print_errors.pod
@@ -29,7 +29,7 @@ B<u> as the callback parameters.
 
 The error strings will have the following format:
 
- [pid]:error:[error code]:[library name]:[function name]:[reason string]:[file name]:[line]:[optional text message]
+ [pid]:error:[error code]:[library name]:[function name]:[reason string]:[filename]:[line]:[optional text message]
 
 I<error code> is an 8 digit hexadecimal number. I<library name>,
 I<function name> and I<reason string> are ASCII text, as is I<optional

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -59,14 +59,14 @@ descriptions. For example, the function ssl3_read_bytes() reports a
 
  SSLerr(SSL_F_SSL3_READ_BYTES, SSL_R_SSL_HANDSHAKE_FAILURE);
 
-Function and reason codes should consist of upper case characters,
+Function and reason codes should consist of uppercase characters,
 numbers and underscores only. The error file generation script translates
 function codes into function names by looking in the header files
 for an appropriate function name, if none is found it just uses
 the capitalized form such as "SSL3_READ_BYTES" in the above example.
 
 The trailing section of a reason code (after the "_R_") is translated
-into lower case and underscores changed to spaces.
+into lowercase and underscores changed to spaces.
 
 Although a library will normally report errors using its own specific
 XXXerr macro, another library's macro can be used. This is normally

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -166,7 +166,7 @@ The parameters currently supported by the default provider are:
 =item "pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <unsigned integer>
 
 Sets the DH padding mode.
-If B<OSSL_EXCHANGE_PARAM_PAD> is 1 then the  shared secret is padded with zeroes
+If B<OSSL_EXCHANGE_PARAM_PAD> is 1 then the  shared secret is padded with zeros
 up to the size of the DH prime B<p>.
 If B<OSSL_EXCHANGE_PARAM_PAD> is zero (the default) then no padding is
 performed.
@@ -345,7 +345,7 @@ parameter generation. Use 0 for PKCS#3 DH and 1 for X9.42 DH.
 The default is 0.
 
 The EVP_PKEY_CTX_set_dh_pad() function sets the DH padding mode.
-If B<pad> is 1 the shared secret is padded with zeroes up to the size of the DH
+If B<pad> is 1 the shared secret is padded with zeros up to the size of the DH
 prime B<p>.
 If B<pad> is zero (the default) then no padding is performed.
 

--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -69,7 +69,7 @@ EVP_shake256().
 
 HMAC_CTX_new() creates a new HMAC_CTX in heap memory.
 
-HMAC_CTX_reset() zeroes an existing B<HMAC_CTX> and associated
+HMAC_CTX_reset() clears an existing B<HMAC_CTX> and associated
 resources, making it suitable for new computations as if it was newly
 created with HMAC_CTX_new().
 

--- a/doc/man3/OCSP_cert_to_id.pod
+++ b/doc/man3/OCSP_cert_to_id.pod
@@ -52,7 +52,7 @@ corresponding parameter can be set to B<NULL>.
 OCSP_cert_to_id() and OCSP_cert_id_new() return either a pointer to a valid
 B<OCSP_CERTID> structure or B<NULL> if an error occurred.
 
-OCSP_id_cmp() and OCSP_id_issuer_cmp() returns zero for a match and non-zero
+OCSP_id_cmp() and OCSP_id_issuer_cmp() returns zero for a match and nonzero
 otherwise.
 
 OCSP_CERTID_free() does not return a value.

--- a/doc/man3/OCSP_request_add1_nonce.pod
+++ b/doc/man3/OCSP_request_add1_nonce.pod
@@ -57,7 +57,7 @@ performance reasons. As a result they do not support nonces.
 
 The return values of OCSP_check_nonce() can be checked to cover each case.  A
 positive return value effectively indicates success: nonces are both present
-and match, both absent or present in the response only. A non-zero return
+and match, both absent or present in the response only. A nonzero return
 additionally covers the case where the nonce is present in the request only:
 this will happen if the responder doesn't support nonces. A zero return value
 indicates present and mismatched nonces: this should be treated as an error

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -112,7 +112,7 @@ no freeing of the results is necessary.
 
 OCSP_check_validity() checks the validity of B<thisupd> and B<nextupd> values
 which will be typically obtained from OCSP_resp_find_status() or
-OCSP_single_get0_status(). If B<sec> is non-zero it indicates how many seconds
+OCSP_single_get0_status(). If B<sec> is nonzero it indicates how many seconds
 leeway should be allowed in the check. If B<maxsec> is positive it indicates
 the maximum age of B<thisupd> in seconds.
 
@@ -167,7 +167,7 @@ can then take appropriate action based on the status of the certificate.
 
 An OCSP response for a certificate contains B<thisUpdate> and B<nextUpdate>
 fields. Normally the current time should be between these two values. To
-account for clock skew the B<maxsec> field can be set to non-zero in
+account for clock skew the B<maxsec> field can be set to nonzero in
 OCSP_check_validity(). Some responders do not set the B<nextUpdate> field, this
 would otherwise mean an ancient response would be considered valid: the
 B<maxsec> parameter to OCSP_check_validity() can be used to limit the permitted

--- a/doc/man3/OPENSSL_LH_COMPFUNC.pod
+++ b/doc/man3/OPENSSL_LH_COMPFUNC.pod
@@ -52,7 +52,7 @@ an unsigned long hash value for its key field.  The hash value is
 normally truncated to a power of 2, so make sure that your hash
 function returns well mixed low order bits.  The I<compare> callback
 takes two arguments (pointers to two hash table entries), and returns
-0 if their keys are equal, non-zero otherwise.
+0 if their keys are equal, nonzero otherwise.
 
 If your hash table
 will contain items of some particular type and the I<hash> and

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -315,7 +315,7 @@ in the given OSSL_CMP_CTX structure.
 OSSL_CMP_CTX_set_serverPort() sets the port of the CMP server to connect to.
 Port defaults to OSSL_CMP_DEFAULT_PORT = 80 if not set explicitly.
 
-OSSL_CMP_CTX_set1_proxyName() sets the host name of the HTTP proxy to be used
+OSSL_CMP_CTX_set1_proxyName() sets the hostname of the HTTP proxy to be used
 for connecting to the CA server.
 
 OSSL_CMP_CTX_set_proxyPort() sets the port of the HTTP proxy.

--- a/doc/man3/OSSL_CMP_log_open.pod
+++ b/doc/man3/OSSL_CMP_log_open.pod
@@ -78,7 +78,7 @@ with the following type:
 
 The parameters may provide
 a component identifier (which may be a library name or function name) or NULL,
-a file path name or NULL,
+a file pathname or NULL,
 a line number or 0 indicating the source code location,
 a severity level, and
 a message string describing the nature of the event, terminated by '\n'.

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -168,7 +168,7 @@ The configured dynamically loadable module extension.
 
 =item OPENSSL_INFO_DIR_FILENAME_SEPARATOR
 
-The separator between a directory specification and a file name.
+The separator between a directory specification and a filename.
 Note that on some operating systems, this is not the same as the
 separator between directory elements.
 

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -67,7 +67,7 @@ usage by the random seed sources. Some seed sources maintain open file
 descriptors by default, which allows such sources to operate in a
 chroot(2) jail without the associated device nodes being available. When
 the B<keep> argument is zero, this call disables the retention of file
-descriptors. Conversely, a non-zero argument enables the retention of
+descriptors. Conversely, a nonzero argument enables the retention of
 file descriptors. This function is usually called during initialization
 and it takes effect immediately.
 

--- a/doc/man3/RAND_load_file.pod
+++ b/doc/man3/RAND_load_file.pod
@@ -37,7 +37,7 @@ file. B<buf> points to a buffer of size B<num> in which to store the
 filename.
 
 On all systems, if the environment variable B<RANDFILE> is set, its
-value will be used as the seed file name.
+value will be used as the seed filename.
 Otherwise, the file is called C<.rnd>, found in platform dependent locations:
 
 =over 4
@@ -57,7 +57,7 @@ Otherwise, the file is called C<.rnd>, found in platform dependent locations:
 =back
 
 If C<$HOME> (on non-Windows and non-VMS system) is not set either, or
-B<num> is too small for the path name, an error occurs.
+B<num> is too small for the pathname, an error occurs.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/RSA_set_method.pod
+++ b/doc/man3/RSA_set_method.pod
@@ -129,7 +129,7 @@ the default method is used.
                        const unsigned char *m, unsigned int m_length,
                        const unsigned char *sigbuf, unsigned int siglen,
                        const RSA *rsa);
-     /* keygen. If NULL builtin RSA key generation will be used */
+     /* keygen. If NULL built-in RSA key generation will be used */
      int (*rsa_keygen)(RSA *rsa, int bits, BIGNUM *e, BN_GENCB *cb);
 
  } RSA_METHOD;

--- a/doc/man3/SCT_new.pod
+++ b/doc/man3/SCT_new.pod
@@ -108,7 +108,8 @@ See RFC 6962, Section 3.2 for the definition of LogID.
 
 =item *
 
-SCT_set_timestamp() to set the time the SCT was issued (epoch time in milliseconds).
+SCT_set_timestamp() to set the time the SCT was issued (time in milliseconds
+since the Unix Epoch).
 
 =item *
 
@@ -149,7 +150,7 @@ B<CT_LOG_ENTRY_TYPE_PRECERT> for a pre-certificate.
 
 =item *
 
-The time that the SCT was issued (epoch time in milliseconds).
+The time that the SCT was issued (time in milliseconds since the Unix Epoch).
 
 =item *
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -549,7 +549,7 @@ The value is a string without any specific structure.
 
 =item B<SSL_CONF_TYPE_FILE>
 
-The value is a file name.
+The value is a filename.
 
 =item B<SSL_CONF_TYPE_DIR>
 

--- a/doc/man3/SSL_CTX_dane_enable.pod
+++ b/doc/man3/SSL_CTX_dane_enable.pod
@@ -136,7 +136,7 @@ SSL_CTX_dane_set_flags() and SSL_dane_set_flags() can be used to enable
 optional DANE verification features.
 SSL_CTX_dane_clear_flags() and SSL_dane_clear_flags() can be used to disable
 the same features.
-The B<flags> argument is a bitmask of the features to enable or disable.
+The B<flags> argument is a bit-mask of the features to enable or disable.
 The B<flags> set for an B<SSL_CTX> context are copied to each B<SSL> handle
 associated with that context at the time the handle is created.
 Subsequent changes in the context's B<flags> have no effect on the B<flags> set

--- a/doc/man3/SSL_CTX_set_client_hello_cb.pod
+++ b/doc/man3/SSL_CTX_set_client_hello_cb.pod
@@ -26,7 +26,7 @@ SSL_CTX_set_client_hello_cb, SSL_client_hello_cb_fn, SSL_client_hello_isv2, SSL_
 SSL_CTX_set_client_hello_cb() sets the callback function, which is automatically
 called during the early stages of ClientHello processing on the server.
 The argument supplied when setting the callback is passed back to the
-callback at runtime.  A callback that returns failure (0) will cause the
+callback at run time.  A callback that returns failure (0) will cause the
 connection to terminate, and callbacks returning failure should indicate
 what alert value is to be sent in the B<al> parameter.  A callback may
 also return a negative value to suspend the handshake, and the handshake

--- a/doc/man3/SSL_CTX_set_info_callback.pod
+++ b/doc/man3/SSL_CTX_set_info_callback.pod
@@ -50,7 +50,7 @@ the callback function was called. If B<ret> is 0, an error condition occurred.
 If an alert is handled, SSL_CB_ALERT is set and B<ret> specifies the alert
 information.
 
-B<where> is a bitmask made up of the following bits:
+B<where> is a bit-mask made up of the following bits:
 
 =over 4
 

--- a/doc/man3/SSL_CTX_set_mode.pod
+++ b/doc/man3/SSL_CTX_set_mode.pod
@@ -18,13 +18,13 @@ SSL_CTX_set_mode, SSL_CTX_clear_mode, SSL_set_mode, SSL_clear_mode, SSL_CTX_get_
 
 =head1 DESCRIPTION
 
-SSL_CTX_set_mode() adds the mode set via bitmask in B<mode> to B<ctx>.
+SSL_CTX_set_mode() adds the mode set via bit-mask in B<mode> to B<ctx>.
 Options already set before are not cleared.
-SSL_CTX_clear_mode() removes the mode set via bitmask in B<mode> from B<ctx>.
+SSL_CTX_clear_mode() removes the mode set via bit-mask in B<mode> from B<ctx>.
 
-SSL_set_mode() adds the mode set via bitmask in B<mode> to B<ssl>.
+SSL_set_mode() adds the mode set via bit-mask in B<mode> to B<ssl>.
 Options already set before are not cleared.
-SSL_clear_mode() removes the mode set via bitmask in B<mode> from B<ssl>.
+SSL_clear_mode() removes the mode set via bit-mask in B<mode> from B<ssl>.
 
 SSL_CTX_get_mode() returns the mode set for B<ctx>.
 
@@ -137,10 +137,10 @@ default since 1.1.1.
 
 =head1 RETURN VALUES
 
-SSL_CTX_set_mode() and SSL_set_mode() return the new mode bitmask
+SSL_CTX_set_mode() and SSL_set_mode() return the new mode bit-mask
 after adding B<mode>.
 
-SSL_CTX_get_mode() and SSL_get_mode() return the current bitmask.
+SSL_CTX_get_mode() and SSL_get_mode() return the current bit-mask.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -23,16 +23,16 @@ SSL_get_secure_renegotiation_support - manipulate SSL options
 
 =head1 DESCRIPTION
 
-SSL_CTX_set_options() adds the options set via bitmask in B<options> to B<ctx>.
+SSL_CTX_set_options() adds the options set via bit-mask in B<options> to B<ctx>.
 Options already set before are not cleared!
 
-SSL_set_options() adds the options set via bitmask in B<options> to B<ssl>.
+SSL_set_options() adds the options set via bit-mask in B<options> to B<ssl>.
 Options already set before are not cleared!
 
-SSL_CTX_clear_options() clears the options set via bitmask in B<options>
+SSL_CTX_clear_options() clears the options set via bit-mask in B<options>
 to B<ctx>.
 
-SSL_clear_options() clears the options set via bitmask in B<options> to B<ssl>.
+SSL_clear_options() clears the options set via bit-mask in B<options> to B<ssl>.
 
 SSL_CTX_get_options() returns the options set for B<ctx>.
 
@@ -45,7 +45,7 @@ Note, this is implemented via a macro.
 =head1 NOTES
 
 The behaviour of the SSL library can be changed by setting several options.
-The options are coded as bitmasks and can be combined by a bitwise B<or>
+The options are coded as bit-masks and can be combined by a bitwise B<or>
 operation (|).
 
 SSL_CTX_set_options() and SSL_set_options() affect the (external)
@@ -348,13 +348,13 @@ and renegotiation between OpenSSL and unpatched clients or servers.
 
 =head1 RETURN VALUES
 
-SSL_CTX_set_options() and SSL_set_options() return the new options bitmask
+SSL_CTX_set_options() and SSL_set_options() return the new options bit-mask
 after adding B<options>.
 
-SSL_CTX_clear_options() and SSL_clear_options() return the new options bitmask
+SSL_CTX_clear_options() and SSL_clear_options() return the new options bit-mask
 after clearing B<options>.
 
-SSL_CTX_get_options() and SSL_get_options() return the current bitmask.
+SSL_CTX_get_options() and SSL_get_options() return the current bit-mask.
 
 SSL_get_secure_renegotiation_support() returns 1 is the peer supports
 secure renegotiation and 0 if it does not.

--- a/doc/man3/SSL_read_early_data.pod
+++ b/doc/man3/SSL_read_early_data.pod
@@ -202,7 +202,7 @@ early data settings for the SSL_CTX and SSL objects respectively. Generally a
 server application will either use both of SSL_read_early_data() and
 SSL_CTX_set_max_early_data() (or SSL_set_max_early_data()), or neither of them,
 since there is no practical benefit from using only one of them. If the maximum
-early data setting for a server is non-zero then replay protection is
+early data setting for a server is nonzero then replay protection is
 automatically enabled (see L</REPLAY PROTECTION> below).
 
 If the server rejects the early data sent by a client then it will skip over
@@ -285,7 +285,7 @@ retry with a lower maximum protocol version.
 When early data is in use the TLS protocol provides no security guarantees that
 the same early data was not replayed across multiple connections. As a
 mitigation for this issue OpenSSL automatically enables replay protection if the
-server is configured with a non-zero max early data value. With replay
+server is configured with a nonzero max early data value. With replay
 protection enabled sessions are forced to be single use only. If a client
 attempts to reuse a session ticket more than once, then the second and
 subsequent attempts will fall back to a full handshake (and any early data that

--- a/doc/man3/SSL_set1_host.pod
+++ b/doc/man3/SSL_set1_host.pod
@@ -19,7 +19,7 @@ SSL server verification parameters
 These functions configure server hostname checks in the SSL client.
 
 SSL_set1_host() sets the expected DNS hostname to B<name> clearing
-any previously specified host name or names.  If B<name> is NULL,
+any previously specified hostname.  If B<name> is NULL,
 or the empty string the list of hostnames is cleared, and name
 checks are not performed on the peer certificate.  When a non-empty
 B<name> is specified, certificate verification automatically checks

--- a/doc/man3/SSL_set_shutdown.pod
+++ b/doc/man3/SSL_set_shutdown.pod
@@ -20,7 +20,7 @@ SSL_get_shutdown() returns the shutdown mode of B<ssl>.
 
 =head1 NOTES
 
-The shutdown state of an ssl connection is a bitmask of:
+The shutdown state of an ssl connection is a bit-mask of:
 
 =over 4
 

--- a/doc/man3/UI_UTIL_read_pw.pod
+++ b/doc/man3/UI_UTIL_read_pw.pod
@@ -21,7 +21,7 @@ UI_UTIL_read_pw_string() asks for a passphrase, using B<prompt> as a
 prompt, and stores it in B<buf>.
 The maximum allowed size is given with B<length>, including the
 terminating NUL byte.
-If B<verify> is non-zero, the password will be verified as well.
+If B<verify> is nonzero, the password will be verified as well.
 
 UI_UTIL_read_pw() does the same as UI_UTIL_read_pw_string(), the
 difference is that you can give it an external buffer B<buff> for the

--- a/doc/man3/UI_new.pod
+++ b/doc/man3/UI_new.pod
@@ -132,7 +132,7 @@ the possible answers (given through the I<action_desc> argument).
 
 UI_add_info_string() and UI_add_error_string() add strings that are shown at
 the same time as the prompt for extra information or to show an error string.
-The difference between the two is only conceptual.  With the builtin method,
+The difference between the two is only conceptual.  With the built-in method,
 there's no technical difference between them.  Other methods may make a
 difference between them, however.
 
@@ -152,13 +152,13 @@ UI_construct_prompt() is a helper function that can be used to create
 a prompt from two pieces of information: an description and a name.
 The default constructor (if there is none provided by the method used)
 creates a string "Enter I<description> for I<name>:".  With the
-description "pass phrase" and the file name "foo.key", that becomes
+description "pass phrase" and the filename "foo.key", that becomes
 "Enter pass phrase for foo.key:".  Other methods may create whatever
 string and may include encodings that will be processed by the other
 method functions.
 
 UI_add_user_data() adds a user data pointer for the method to use at any
-time.  The builtin UI method doesn't care about this info.  Note that several
+time.  The built-in UI method doesn't care about this info.  Note that several
 calls to this function doesn't add data, it replaces the previous blob
 with the one given as argument.
 

--- a/doc/man3/X509_ALGOR_dup.pod
+++ b/doc/man3/X509_ALGOR_dup.pod
@@ -34,7 +34,7 @@ X509_ALGOR_set_md() sets the B<AlgorithmIdentifier> B<alg> to appropriate
 values for the message digest B<md>.
 
 X509_ALGOR_cmp() compares B<a> and B<b> and returns 0 if they have identical
-encodings and non-zero otherwise.
+encodings and nonzero otherwise.
 
 =head1 RETURN VALUES
 
@@ -46,7 +46,7 @@ X509_ALGOR_set0() returns 1 on success or 0 on error.
 X509_ALGOR_get0() and X509_ALGOR_set_md() return no values.
 
 X509_ALGOR_cmp() returns 0 if the two parameters have identical encodings and
-non-zero otherwise.
+nonzero otherwise.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_LOOKUP_hash_dir.pod
+++ b/doc/man3/X509_LOOKUP_hash_dir.pod
@@ -80,7 +80,7 @@ upon each lookup, so that newer CRLs are as soon as they appear in
 the directory.
 
 The directory should contain one certificate or CRL per file in PEM format,
-with a file name of the form I<hash>.I<N> for a certificate, or
+with a filename of the form I<hash>.I<N> for a certificate, or
 I<hash>.B<r>I<N> for a CRL.
 The I<hash> is the value returned by the L<X509_NAME_hash(3)> function applied
 to the subject name for certificates or issuer name for CRLs.

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -129,7 +129,7 @@ interoperable, though it will, for example, reject MD5 signatures or RSA keys
 shorter than 1024 bits.
 
 X509_VERIFY_PARAM_set1_host() sets the expected DNS hostname to
-B<name> clearing any previously specified host name or names.  If
+B<name> clearing any previously specified hostname.  If
 B<name> is NULL, or empty the list of hostnames is cleared, and
 name checks are not performed on the peer certificate.  If B<name>
 is NUL-terminated, B<namelen> may be zero, otherwise B<namelen>

--- a/doc/man3/X509_check_ca.pod
+++ b/doc/man3/X509_check_ca.pod
@@ -24,7 +24,7 @@ B<keyUsage> extension with bit B<keyCertSign> set, but without
 B<basicConstraints>, and 5 if it has outdated Netscape Certificate Type
 extension telling that it is CA certificate.
 
-Actually, any non-zero value means that this certificate could have been
+Actually, any nonzero value means that this certificate could have been
 used to sign other certificates.
 
 =head1 SEE ALSO

--- a/doc/man3/X509_check_host.pod
+++ b/doc/man3/X509_check_host.pod
@@ -19,7 +19,7 @@ X509_check_host, X509_check_email, X509_check_ip, X509_check_ip_asc - X.509 cert
 =head1 DESCRIPTION
 
 The certificate matching functions are used to check whether a
-certificate matches a given host name, email address, or IP address.
+certificate matches a given hostname, email address, or IP address.
 The validity of the certificate and its trust level has to be checked by
 other means.
 
@@ -130,7 +130,7 @@ NULs.
 =head1 NOTES
 
 Applications are encouraged to use X509_VERIFY_PARAM_set1_host()
-rather than explicitly calling L<X509_check_host(3)>. Host name
+rather than explicitly calling L<X509_check_host(3)>. Hostname
 checks may be out of scope with the DANE-EE(3) certificate usage,
 and the internal checks will be suppressed as appropriate when
 DANE support is enabled.

--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -71,7 +71,7 @@ the extension is found its index is returned otherwise B<-1> is returned.
 
 X509v3_get_ext_by_critical() is similar to X509v3_get_ext_by_NID() except it
 looks for an extension of criticality B<crit>. A zero value for B<crit>
-looks for a non-critical extension a non-zero value looks for a critical
+looks for a non-critical extension a nonzero value looks for a critical
 extension.
 
 X509v3_delete_ext() deletes the extension with index B<loc> from B<x>. The

--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -463,7 +463,7 @@ The actual TYPE structure passed to B<i2d_I<TYPE>>() must be a valid
 populated B<I<TYPE>> structure -- it B<cannot> simply be fed with an
 empty structure such as that returned by TYPE_new().
 
-The encoded data is in binary form and may contain embedded zeroes.
+The encoded data is in binary form and may contain embedded zeros.
 Therefore any FILE pointers or BIOs should be opened in binary mode.
 Functions such as strlen() will B<not> return the correct length
 of the encoded structure.

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -263,7 +263,7 @@ The command B<identity> is used to give the provider name. For example:
  identity = myfoo
 
 The parameter B<module> loads and adds a provider module from the
-given module path.  That path may be a simple file name, a relative
+given module path.  That path may be a simple filename, a relative
 path or an absolute path.
 
 The parameter B<activate> determines whether to activate the

--- a/doc/man7/ossl_store.pod
+++ b/doc/man7/ossl_store.pod
@@ -15,7 +15,7 @@ ossl_store - Store retrieval functions
 =head2 General
 
 A STORE is a layer of functionality to retrieve a number of supported
-objects from a repository of any kind, addressable as a file name or
+objects from a repository of any kind, addressable as a filename or
 as a URI.
 
 The functionality supports the pattern "open a channel to the

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -84,7 +84,7 @@ the initialization function.
 I<operation_id> is an operation identity (see L</Operations> below).
 
 I<no_store> is a flag back to the OpenSSL libraries which, when
-non-zero, signifies that the OpenSSL libraries will not store a
+nonzero, signifies that the OpenSSL libraries will not store a
 reference to the returned data in their internal store of
 implementations.
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -349,6 +349,59 @@ sub functionname_check {
     # with a variable part (typically marked up as B<foo_I<TYPE>_bar>
 }
 
+# This is from http://man7.org/linux/man-pages/man7/man-pages.7.html
+my %preferred_words = (
+    'bitmask'       => 'bit mask',
+    'builtin'       => 'built-in',
+   #'epoch'         => 'Epoch', # handled specially, below
+    'file name'     => 'filename',
+    'file system'   => 'filesystem',
+    'host name'     => 'hostname',
+    'i-node'        => 'inode',
+    'lower case'    => 'lowercase',
+    'lower-case'    => 'lowercase',
+    'non-zero'      => 'nonzero',
+    'path name'     => 'pathname',
+    'pseudo-terminal' => 'pseudoterminal',
+    'reserved port' => 'privileged port',
+    'system port'   => 'privileged port',
+    'realtime'      => 'real-time',
+    'real time'     => 'real-time',
+    'runtime'       => 'run time',
+    'saved group ID'=> 'saved set-group-ID',
+    'saved set-GID' => 'saved set-group-ID',
+    'saved user ID' => 'saved set-user-ID',
+    'saved set-UID' => 'saved set-user-ID',
+    'set-GID'       => 'set-group-ID',
+    'setgid'        => 'set-group-ID',
+    'set-UID'       => 'set-user-ID',
+    'setuid'        => 'set-user-ID',
+    'super user'    => 'superuser',
+    'super-user'    => 'superuser',
+    'super block'   => 'superblock',
+    'super-block'   => 'superblock',
+    'time stamp'    => 'timestamp',
+    'time zone'     => 'timezone',
+    'upper case'    => 'uppercase',
+    'upper-case'    => 'uppercase',
+    'useable'       => 'usable',
+    'userspace'     => 'user space',
+    'user name'     => 'username',
+    'zeroes'        => 'zeros'
+);
+
+sub wording {
+    my $id = shift;
+    my $contents = shift;
+
+    foreach my $k ( keys %preferred_words ) {
+        err($id, "found '$k' should use '$preferred_words{$k}'")
+            if $contents =~ /\b\Q$k\E\b/i;
+    }
+    err($id, "found 'epoch' should use 'Epoch'")
+        if $contents =~ /\bepoch\b/;
+}
+
 sub check {
     my $filename = shift;
     my $dirname = basename(dirname($filename));
@@ -379,6 +432,8 @@ sub check {
             option_check($id, $filename, $contents)
         }
     }
+
+    wording($id, $contents);
 
     err($id, "doesn't start with =pod")
         if $contents !~ /^=pod/;

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -395,6 +395,9 @@ sub wording {
     my $contents = shift;
 
     foreach my $k ( keys %preferred_words ) {
+        # Sigh, trademark
+        next if $k eq 'file system'
+            and $contents =~ /Microsoft Encrypted File System/;
         err($id, "found '$k' should use '$preferred_words{$k}'")
             if $contents =~ /\b\Q$k\E\b/i;
     }


### PR DESCRIPTION
Following the style of man7.org, update find-doc-nits to find 'terms to avoid' and suggest their
official replacements.

Do we want to do this?  There are about 70 errors found.
