### PR TITLE
OSSL_PARAM.pod: document the mechanism to figure out buffer sizes

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -211,6 +211,8 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
     p->return_size = 0;
     if (p->data_type == OSSL_PARAM_INTEGER) {
         p->return_size = sizeof(int32_t); /* Minimum expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(int32_t):
             *(int32_t *)p->data = val;
@@ -219,9 +221,13 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
             p->return_size = sizeof(int64_t);
             *(int64_t *)p->data = (int64_t)val;
             return 1;
+        case 0:
+            break;
         }
     } else if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER && val >= 0) {
         p->return_size = sizeof(uint32_t); /* Minimum expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(uint32_t):
             *(uint32_t *)p->data = (uint32_t)val;
@@ -233,6 +239,8 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
         }
     } else if (p->data_type == OSSL_PARAM_REAL) {
         p->return_size = sizeof(double);
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(double):
             *(double *)p->data = (double)val;
@@ -310,6 +318,8 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
 
     if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER) {
         p->return_size = sizeof(uint32_t); /* Minimum expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(uint32_t):
             *(uint32_t *)p->data = val;
@@ -321,6 +331,8 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
         }
     } else if (p->data_type == OSSL_PARAM_INTEGER) {
         p->return_size = sizeof(int32_t); /* Minimum expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(int32_t):
             if (val <= INT32_MAX) {
@@ -335,6 +347,8 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
         }
     } else if (p->data_type == OSSL_PARAM_REAL) {
         p->return_size = sizeof(double);
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(double):
             *(double *)p->data = (double)val;
@@ -403,6 +417,8 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
     p->return_size = 0;
     if (p->data_type == OSSL_PARAM_INTEGER) {
         p->return_size = sizeof(int64_t); /* Expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(int32_t):
             if (val >= INT32_MIN && val <= INT32_MAX) {
@@ -417,6 +433,8 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
         }
     } else if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER && val >= 0) {
         p->return_size = sizeof(uint64_t); /* Expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(uint32_t):
             if (val <= UINT32_MAX) {
@@ -431,6 +449,8 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
         }
     } else if (p->data_type == OSSL_PARAM_REAL) {
         p->return_size = sizeof(double);
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(double):
             u64 = val < 0 ? -val : val;
@@ -506,6 +526,8 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
 
     if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER) {
         p->return_size = sizeof(uint64_t); /* Expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(uint32_t):
             if (val <= UINT32_MAX) {
@@ -520,6 +542,8 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
         }
     } else if (p->data_type == OSSL_PARAM_INTEGER) {
         p->return_size = sizeof(int64_t); /* Expected size */
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(int32_t):
             if (val <= INT32_MAX) {
@@ -616,6 +640,8 @@ int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val)
 
     bytes = (size_t)BN_num_bytes(val);
     p->return_size = bytes;
+    if (p->data == NULL)
+        return 1;
     return p->data_size >= bytes
         && BN_bn2nativepad(val, p->data, bytes) >= 0;
 }
@@ -680,6 +706,8 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
 
     if (p->data_type == OSSL_PARAM_REAL) {
         p->return_size = sizeof(double);
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(double):
             *(double *)p->data = val;
@@ -688,6 +716,8 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
     } else if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER
                && val == (ossl_uintmax_t)val) {
         p->return_size = sizeof(double);
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(uint32_t):
             if (val >= 0 && val <= UINT32_MAX) {
@@ -705,6 +735,8 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
             break;            }
     } else if (p->data_type == OSSL_PARAM_INTEGER && val == (ossl_intmax_t)val) {
         p->return_size = sizeof(double);
+        if (p->data == NULL)
+            return 1;
         switch (p->data_size) {
         case sizeof(int32_t):
             if (val >= INT32_MIN && val <= INT32_MAX) {
@@ -775,6 +807,8 @@ static int set_string_internal(OSSL_PARAM *p, const void *val, size_t len,
                                unsigned int type)
 {
     p->return_size = len;
+    if (p->data == NULL)
+        return 1;
     if (p->data_type != type || p->data_size < len)
         return 0;
 
@@ -847,6 +881,8 @@ static int set_ptr_internal(OSSL_PARAM *p, const void *val,
     p->return_size = len;
     if (p->data_type != type)
         return 0;
+    if (p->data == NULL)
+        return 1;
     *(const void **)p->data = val;
     return 1;
 }

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -87,6 +87,11 @@ setting parameters) or shall (when requesting parameters) be stored,
 and I<data_size> is its size in bytes.
 The organization of the data depends on the parameter type and flag.
 
+When I<requesting parameters>, it's acceptable for I<data> to be NULL.
+This can be used by the I<requestor> to figure out dynamically exactly
+how much buffer space is needed to store the parameter data.
+In this case, I<data_size> is ignored.
+
 When the B<OSSL_PARAM> is used as a parameter descriptor, I<data>
 should be ignored.
 If I<data_size> is zero, it means that an arbitrary data size is

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -198,6 +198,8 @@ Type coercion takes place as discussed in the NOTES section.
 
 OSSL_PARAM_set_TYPE() stores a value B<val> of type B<TYPE> into the parameter
 B<p>.
+If the parameter's I<data> field is NULL, then only its I<return_size> field
+will be assigned the size the parameter's I<data> buffer should have.
 Type coercion takes place as discussed in the NOTES section.
 
 OSSL_PARAM_get_BN() retrieves a BIGNUM from the parameter pointed to by B<p>.
@@ -205,6 +207,8 @@ The BIGNUM referenced by B<val> is updated and is allocated if B<*val> is
 B<NULL>.
 
 OSSL_PARAM_set_BN() stores the BIGNUM B<val> into the parameter B<p>.
+If the parameter's I<data> field is NULL, then only its I<return_size> field
+will be assigned the size the parameter's I<data> buffer should have.
 
 OSSL_PARAM_get_utf8_string() retrieves a UTF8 string from the parameter
 pointed to by B<p>.
@@ -215,6 +219,8 @@ If memory is allocated by this function, it must be freed by the caller.
 
 OSSL_PARAM_set_utf8_string() sets a UTF8 string from the parameter pointed to
 by B<p> to the value referenced by B<val>.
+If the parameter's I<data> field is NULL, then only its I<return_size> field
+will be assigned the size the parameter's I<data> buffer should have.
 
 OSSL_PARAM_get_octet_string() retrieves an OCTET string from the parameter
 pointed to by B<p>.
@@ -225,6 +231,8 @@ If memory is allocated by this function, it must be freed by the caller.
 
 OSSL_PARAM_set_octet_string() sets an OCTET string from the parameter
 pointed to by B<p> to the value referenced by B<val>.
+If the parameter's I<data> field is NULL, then only its I<return_size> field
+will be assigned the size the parameter's I<data> buffer should have.
 
 OSSL_PARAM_get_utf8_ptr() retrieves the UTF8 string pointer from the parameter
 referenced by B<p> and stores it in B<*val>.
@@ -260,9 +268,9 @@ representable by the target type or parameter.
 Apart from that, the functions must be used appropriately for the
 expected type of the parameter.
 
-For OSSL_PARAM_get_utf8_ptr() and OSSL_PARAM_get_octet_ptr(), B<bsize>
-is not relevant if the purpose is to send the B<OSSL_PARAM> array to a
-I<responder>, i.e. to get parameter data back.
+For OSSL_PARAM_construct_utf8_ptr() and OSSL_PARAM_consstruct_octet_ptr(),
+B<bsize> is not relevant if the purpose is to send the B<OSSL_PARAM> array
+to a I<responder>, i.e. to get parameter data back.
 In that case, B<bsize> can safely be given zero.
 See L<OSSL_PARAM(3)/DESCRIPTION> for further information on the
 possible purposes.


### PR DESCRIPTION
When requesting parameters, it's acceptable to make a first pass with
the |data| field of some parameters being NULL.  That can be used to
help the requestor to figure out dynamically what buffer size is
needed.  For variable size parameters, there's no other way to find
out.
