### PR TITLE
Fix long name of some Microsoft objects

### DIFF
--- a/crypto/objects/obj_dat.h
+++ b/crypto/objects/obj_dat.h
@@ -1737,8 +1737,8 @@ static const ASN1_OBJECT nid_objs[NUM_NID] = {
     {"ITU-T", "itu-t", NID_itu_t},
     {"JOINT-ISO-ITU-T", "joint-iso-itu-t", NID_joint_iso_itu_t},
     {"international-organizations", "International Organizations", NID_international_organizations, 1, &so[4439]},
-    {"msSmartcardLogin", "Microsoft Smartcardlogin", NID_ms_smartcard_login, 10, &so[4440]},
-    {"msUPN", "Microsoft Universal Principal Name", NID_ms_upn, 10, &so[4450]},
+    {"msSmartcardLogin", "Microsoft Smartcard Login", NID_ms_smartcard_login, 10, &so[4440]},
+    {"msUPN", "Microsoft User Principal Name", NID_ms_upn, 10, &so[4450]},
     {"AES-128-CFB1", "aes-128-cfb1", NID_aes_128_cfb1},
     {"AES-192-CFB1", "aes-192-cfb1", NID_aes_192_cfb1},
     {"AES-256-CFB1", "aes-256-cfb1", NID_aes_256_cfb1},
@@ -3619,9 +3619,9 @@ static const unsigned int ln_objs[NUM_LN] = {
      134,    /* "Microsoft Individual Code Signing" */
      856,    /* "Microsoft Local Key set" */
      137,    /* "Microsoft Server Gated Crypto" */
-     648,    /* "Microsoft Smartcardlogin" */
+     648,    /* "Microsoft Smartcard Login" */
      136,    /* "Microsoft Trust List Signing" */
-     649,    /* "Microsoft Universal Principal Name" */
+     649,    /* "Microsoft User Principal Name" */
      393,    /* "NULL" */
      404,    /* "NULL" */
       72,    /* "Netscape Base Url" */

--- a/crypto/objects/objects.txt
+++ b/crypto/objects/objects.txt
@@ -431,9 +431,9 @@ rsadsi 3 8		: RC5-CBC		: rc5-cbc
 !Cname ms-efs
 1 3 6 1 4 1 311 10 3 4	: msEFS			: Microsoft Encrypted File System
 !Cname ms-smartcard-login
-1 3 6 1 4 1 311 20 2 2	: msSmartcardLogin	: Microsoft Smartcardlogin
+1 3 6 1 4 1 311 20 2 2	: msSmartcardLogin	: Microsoft Smartcard Login
 !Cname ms-upn
-1 3 6 1 4 1 311 20 2 3	: msUPN			: Microsoft Universal Principal Name
+1 3 6 1 4 1 311 20 2 3	: msUPN			: Microsoft User Principal Name
 
 1 3 6 1 4 1 188 7 1 1 2	: IDEA-CBC		: idea-cbc
 			: IDEA-ECB		: idea-ecb

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -1300,12 +1300,12 @@
 #define OBJ_ms_efs              1L,3L,6L,1L,4L,1L,311L,10L,3L,4L
 
 #define SN_ms_smartcard_login           "msSmartcardLogin"
-#define LN_ms_smartcard_login           "Microsoft Smartcardlogin"
+#define LN_ms_smartcard_login           "Microsoft Smartcard Login"
 #define NID_ms_smartcard_login          648
 #define OBJ_ms_smartcard_login          1L,3L,6L,1L,4L,1L,311L,20L,2L,2L
 
 #define SN_ms_upn               "msUPN"
-#define LN_ms_upn               "Microsoft Universal Principal Name"
+#define LN_ms_upn               "Microsoft User Principal Name"
 #define NID_ms_upn              649
 #define OBJ_ms_upn              1L,3L,6L,1L,4L,1L,311L,20L,2L,3L
 


### PR DESCRIPTION
Some long names are mislabeled, especially UPN.
