### PR TITLE
doc: EVP_DigestInit clears all flags

### DIFF
--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -226,7 +226,7 @@ few bytes.
 =item EVP_DigestInit()
 
 Behaves in the same way as EVP_DigestInit_ex() except it always uses the
-default digest implementation.
+default digest implementation and calls EVP_MD_CTX_reset().
 
 =item EVP_DigestFinal()
 


### PR DESCRIPTION
Mention that EVP_DigestInit() also clears all flags.

Fixes: #10031
Signed-off-by: Christian Heimes <christian@python.org>

##### Checklist
- [X] documentation is added or updated
