### PR TITLE
Add defines for __NR_getrandom for all Linux architectures

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -261,12 +261,52 @@ static ssize_t sysctl_random(char *buf, size_t buflen)
 #  if defined(OPENSSL_RAND_SEED_GETRANDOM)
 
 #   if defined(__linux) && !defined(__NR_getrandom)
-#    if defined(__arm__) && defined(__NR_SYSCALL_BASE)
+#    if defined(__arm__)
 #     define __NR_getrandom    (__NR_SYSCALL_BASE+384)
 #    elif defined(__i386__)
 #     define __NR_getrandom    355
-#    elif defined(__x86_64__) && !defined(__ILP32__)
+#    elif defined(__x86_64__)
 #     define __NR_getrandom    318
+#    elif defined(__xtensa__)
+#     define __NR_getrandom    338
+#    elif defined(__s390__) || defined(__s390x__)
+#     define __NR_getrandom    349
+#    elif defined(__bfin__)
+#     define __NR_getrandom    389
+#    elif defined(__powerpc__)
+#     define __NR_getrandom    359
+#    elif defined(__mips__) || defined(__mips64)
+#     if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define __NR_getrandom   (__NR_Linux + 353)
+#     elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define __NR_getrandom   (__NR_Linux + 313)
+#     elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define __NR_getrandom   (__NR_Linux + 317)
+#     endif
+#    elif defined(__hppa__)
+#     define __NR_getrandom    (__NR_Linux + 339)
+#    elif defined(__sparc__)
+#     define __NR_getrandom    347
+#    elif defined(__ia64__)
+#     define __NR_getrandom    1339
+#    elif defined(__alpha__)
+#     define __NR_getrandom    511
+#    elif defined(__sh__)
+#     if defined(__ILP32__)
+#      define __NR_getrandom   373
+#     else
+#      define __NR_getrandom   384
+#     endif
+#    elif defined(__avr32__)
+#     define __NR_getrandom    317
+#    elif defined(__microblaze__)
+#     define __NR_getrandom    385
+#    elif defined(__m68k__)
+#     define __NR_getrandom    352
+#    elif defined(__cris__)
+#     define __NR_getrandom    356
+#    else /* generic, includes __aarch64__ */
+#     define __NR_getrandom    278
 #    endif
 #   endif
 

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -266,7 +266,11 @@ static ssize_t sysctl_random(char *buf, size_t buflen)
 #    elif defined(__i386__)
 #     define __NR_getrandom    355
 #    elif defined(__x86_64__)
-#     define __NR_getrandom    318
+#     if defined(__ILP32__)
+#      define __NR_getrandom   (__X32_SYSCALL_BIT + 318)
+#     else
+#      define __NR_getrandom   318
+#     endif
 #    elif defined(__xtensa__)
 #     define __NR_getrandom    338
 #    elif defined(__s390__) || defined(__s390x__)
@@ -292,7 +296,7 @@ static ssize_t sysctl_random(char *buf, size_t buflen)
 #    elif defined(__alpha__)
 #     define __NR_getrandom    511
 #    elif defined(__sh__)
-#     if defined(__ILP32__)
+#     if defined(__SH5__)
 #      define __NR_getrandom   373
 #     else
 #      define __NR_getrandom   384
@@ -305,7 +309,9 @@ static ssize_t sysctl_random(char *buf, size_t buflen)
 #     define __NR_getrandom    352
 #    elif defined(__cris__)
 #     define __NR_getrandom    356
-#    else /* generic, includes __aarch64__ */
+#    elif defined(__aarch64__)
+#     define __NR_getrandom    278
+#    else /* generic */
 #     define __NR_getrandom    278
 #    endif
 #   endif


### PR DESCRIPTION
Fixes: #10015

This hasn't been tested yet. I'm not sure about the proper conditions at the point, it's all just a guess.
