### PR TITLE
Support SM2 in apps/speed

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -15,6 +15,7 @@
 #define ECDSA_SECONDS   10
 #define ECDH_SECONDS    10
 #define EdDSA_SECONDS   10
+#define SM2_SECONDS     10
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -127,6 +128,7 @@ typedef struct openssl_speed_sec_st {
     int ecdsa;
     int ecdh;
     int eddsa;
+    int sm2;
 } openssl_speed_sec_t;
 
 static volatile int run = 0;
@@ -191,6 +193,10 @@ static int ECDSA_sign_loop(void *args);
 static int ECDSA_verify_loop(void *args);
 static int EdDSA_sign_loop(void *args);
 static int EdDSA_verify_loop(void *args);
+# ifndef OPENSSL_NO_SM2
+static int SM2_sign_loop(void *args);
+static int SM2_verify_loop(void *args);
+# endif
 #endif
 
 static double Time_F(int s);
@@ -604,6 +610,16 @@ static OPT_PAIR eddsa_choices[] = {
 # define EdDSA_NUM       OSSL_NELEM(eddsa_choices)
 
 static double eddsa_results[EdDSA_NUM][2];    /* 2 ops: sign then verify */
+
+# ifndef OPENSSL_NO_SM2
+#  define R_EC_SM2P256        0
+static OPT_PAIR sm2_choices[] = {
+    {"sm2p256", R_EC_SM2P256}
+};
+#  define SM2_NUM       OSSL_NELEM(sm2_choices)
+
+static double sm2_results[SM2_NUM][2];    /* 2 ops: sign then verify */
+# endif /* OPENSSL_NO_SM2 */
 #endif /* OPENSSL_NO_EC */
 
 #ifndef SIGALRM
@@ -634,6 +650,11 @@ typedef struct loopargs_st {
     EC_KEY *ecdsa[ECDSA_NUM];
     EVP_PKEY_CTX *ecdh_ctx[EC_NUM];
     EVP_MD_CTX *eddsa_ctx[EdDSA_NUM];
+# ifndef OPENSSL_NO_SM2
+    EVP_MD_CTX *sm2_ctx[SM2_NUM];
+    EVP_MD_CTX *sm2_vfy_ctx[SM2_NUM];
+    EVP_PKEY *sm2_pkey[SM2_NUM];
+# endif
     unsigned char *secret_a;
     unsigned char *secret_b;
     size_t outlen[EC_NUM];
@@ -1296,6 +1317,74 @@ static int EdDSA_verify_loop(void *args)
     }
     return count;
 }
+
+# ifndef OPENSSL_NO_SM2
+static long sm2_c[SM2_NUM][2];
+static int SM2_sign_loop(void *args)
+{
+    loopargs_t *tempargs = *(loopargs_t **) args;
+    unsigned char *buf = tempargs->buf;
+    EVP_MD_CTX **sm2ctx = tempargs->sm2_ctx;
+    unsigned char *sm2sig = tempargs->buf2;
+    size_t sm2sigsize = tempargs->sigsize;
+    const size_t max_size = tempargs->sigsize;
+    int ret, count;
+    EVP_PKEY **sm2_pkey = tempargs->sm2_pkey;
+
+    for (count = 0; COND(sm2_c[testnum][0]); count++) {
+        if (!EVP_DigestSignInit(sm2ctx[testnum], NULL, EVP_sm3(),
+                                NULL, sm2_pkey[testnum])) {
+            BIO_printf(bio_err, "SM2 init sign failure\n");
+            ERR_print_errors(bio_err);
+            count = -1;
+            break;
+        }
+        ret = EVP_DigestSign(sm2ctx[testnum], sm2sig, &sm2sigsize,
+                             buf, 20);
+        if (ret == 0) {
+            BIO_printf(bio_err, "SM2 sign failure\n");
+            ERR_print_errors(bio_err);
+            count = -1;
+            break;
+        }
+        /* update the latest returned size and always use the fixed buffer size */
+        tempargs->sigsize = sm2sigsize;
+        sm2sigsize = max_size;
+    }
+
+    return count;
+}
+
+static int SM2_verify_loop(void *args)
+{
+    loopargs_t *tempargs = *(loopargs_t **) args;
+    unsigned char *buf = tempargs->buf;
+    EVP_MD_CTX **sm2ctx = tempargs->sm2_vfy_ctx;
+    unsigned char *sm2sig = tempargs->buf2;
+    size_t sm2sigsize = tempargs->sigsize;
+    int ret, count;
+    EVP_PKEY **sm2_pkey = tempargs->sm2_pkey;
+
+    for (count = 0; COND(sm2_c[testnum][1]); count++) {
+        if (!EVP_DigestVerifyInit(sm2ctx[testnum], NULL, EVP_sm3(),
+                                  NULL, sm2_pkey[testnum])) {
+            BIO_printf(bio_err, "SM2 verify init failure\n");
+            ERR_print_errors(bio_err);
+            count = -1;
+            break;
+        }
+        ret = EVP_DigestVerify(sm2ctx[testnum], sm2sig, sm2sigsize,
+                               buf, 20);
+        if (ret != 1) {
+            BIO_printf(bio_err, "SM2 verify failure\n");
+            ERR_print_errors(bio_err);
+            count = -1;
+            break;
+        }
+    }
+    return count;
+}
+# endif                         /* OPENSSL_NO_SM2 */
 #endif                          /* OPENSSL_NO_EC */
 
 static int run_benchmark(int async_jobs,
@@ -1477,7 +1566,7 @@ int speed_main(int argc, char **argv)
 #endif
     openssl_speed_sec_t seconds = { SECONDS, RSA_SECONDS, DSA_SECONDS,
                                     ECDSA_SECONDS, ECDH_SECONDS,
-                                    EdDSA_SECONDS };
+                                    EdDSA_SECONDS, SM2_SECONDS };
 
     /* What follows are the buffers and key material. */
 #ifndef OPENSSL_NO_RC5
@@ -1609,11 +1698,23 @@ int speed_main(int argc, char **argv)
         {"Ed25519", NID_ED25519, 253, 64},
         {"Ed448", NID_ED448, 456, 114}
     };
+# ifndef OPENSSL_NO_SM2
+    static const struct {
+        const char *name;
+        unsigned int nid;
+        unsigned int bits;
+    } test_sm2_curves[] = {
+        /* SM2 */
+        {"CurveSM2", NID_sm2, 256}
+    };
+# endif
     int ecdsa_doit[ECDSA_NUM] = { 0 };
     int ecdh_doit[EC_NUM] = { 0 };
     int eddsa_doit[EdDSA_NUM] = { 0 };
+    int sm2_doit[SM2_NUM] = { 0 };
     OPENSSL_assert(OSSL_NELEM(test_curves) >= EC_NUM);
     OPENSSL_assert(OSSL_NELEM(test_ed_curves) >= EdDSA_NUM);
+    OPENSSL_assert(OSSL_NELEM(test_sm2_curves) >= SM2_NUM);
 #endif                          /* ndef OPENSSL_NO_EC */
 
     prog = opt_init(argc, argv, speed_options);
@@ -1726,7 +1827,8 @@ int speed_main(int argc, char **argv)
             break;
         case OPT_SECONDS:
             seconds.sym = seconds.rsa = seconds.dsa = seconds.ecdsa
-                        = seconds.ecdh = seconds.eddsa = atoi(opt_arg());
+                        = seconds.ecdh = seconds.eddsa
+                        = seconds.sm2 = atoi(opt_arg());
             break;
         case OPT_BYTES:
             lengths_single = atoi(opt_arg());
@@ -1819,6 +1921,17 @@ int speed_main(int argc, char **argv)
             eddsa_doit[i] = 2;
             continue;
         }
+# ifndef OPENSSL_NO_SM2
+        if (strcmp(*argv, "sm2") == 0) {
+            for (loop = 0; loop < OSSL_NELEM(sm2_doit); loop++)
+                sm2_doit[loop] = 1;
+            continue;
+        }
+        if (found(*argv, sm2_choices, &i)) {
+            sm2_doit[i] = 2;
+            continue;
+        }
+# endif
 #endif
         BIO_printf(bio_err, "%s: Unknown algorithm %s\n", prog, *argv);
         goto end;
@@ -1921,6 +2034,10 @@ int speed_main(int argc, char **argv)
             ecdh_doit[loop] = 1;
         for (loop = 0; loop < OSSL_NELEM(eddsa_doit); loop++)
             eddsa_doit[loop] = 1;
+# ifndef OPENSSL_NO_SM2
+        for (loop = 0; loop < OSSL_NELEM(sm2_doit); loop++)
+            sm2_doit[loop] = 1;
+# endif
 #endif
     }
     for (i = 0; i < ALGOR_NUM; i++)
@@ -2226,6 +2343,10 @@ int speed_main(int argc, char **argv)
 
     eddsa_c[R_EC_Ed25519][0] = count / 1800;
     eddsa_c[R_EC_Ed448][0] = count / 7200;
+
+#   ifndef OPENSSL_NO_SM2
+    sm2_c[R_EC_SM2P256][0] = count / 1800;
+#   endif
 #  endif
 
 # else
@@ -3337,6 +3458,178 @@ int speed_main(int argc, char **argv)
         }
     }
 
+# ifndef OPENSSL_NO_SM2
+    for (testnum = 0; testnum < SM2_NUM; testnum++) {
+        int st = 1;
+        EVP_PKEY *sm2_pkey = NULL;
+        EVP_PKEY_CTX *pctx = NULL;
+        EVP_PKEY_CTX *sm2_pctx = NULL;
+        EVP_PKEY_CTX *sm2_vfy_pctx = NULL;
+        size_t sm2_sigsize = 0;
+
+        if (!sm2_doit[testnum])
+            continue;           /* Ignore Curve */
+        /* Init signing and verification */
+        for (i = 0; i < loopargs_len; i++) {
+            loopargs[i].sm2_ctx[testnum] = EVP_MD_CTX_new();
+            if (loopargs[i].sm2_ctx[testnum] == NULL) {
+                st = 0;
+                break;
+            }
+            loopargs[i].sm2_vfy_ctx[testnum] = EVP_MD_CTX_new();
+            if (loopargs[i].sm2_vfy_ctx[testnum] == NULL) {
+                st = 0;
+                break;
+            }
+
+            /* SM2 keys are generated as normal EC keys with a special curve */
+            if ((pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) == NULL
+                || EVP_PKEY_keygen_init(pctx) <= 0
+                || EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx,
+                    test_sm2_curves[testnum].nid) <= 0
+                || EVP_PKEY_keygen(pctx, &sm2_pkey) <= 0) {
+                st = 0;
+                EVP_PKEY_CTX_free(pctx);
+                break;
+            }
+            /* free previous one and alloc a new one */
+            EVP_PKEY_CTX_free(pctx);
+
+#ifndef FIPS_MODE
+            loopargs[i].sigsize = sm2_sigsize
+                = ECDSA_size(EVP_PKEY_get0_EC_KEY(sm2_pkey));
+#endif
+            if (!EVP_PKEY_set_alias_type(sm2_pkey, EVP_PKEY_SM2)) {
+                st = 0;
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+
+            sm2_pctx = EVP_PKEY_CTX_new(sm2_pkey, NULL);
+            if (sm2_pctx == NULL) {
+                st = 0;
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+            sm2_vfy_pctx = EVP_PKEY_CTX_new(sm2_pkey, NULL);
+            if (sm2_vfy_pctx == NULL) {
+                st = 0;
+                EVP_PKEY_CTX_free(sm2_pctx);
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+            /*
+             * No need to allow user to set an explicit ID here, just use
+             * the one defined in the 'draft-yang-tls-tl13-sm-suites' I-D.
+             */
+            if (EVP_PKEY_CTX_set1_id(sm2_pctx, "TLSv1.3+GM+Cipher+Suite",
+                        sizeof("TLSv1.3+GM+Cipher+Suite") - 1) != 1) {
+                st = 0;
+                EVP_PKEY_CTX_free(sm2_pctx);
+                EVP_PKEY_CTX_free(sm2_vfy_pctx);
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+
+            if (EVP_PKEY_CTX_set1_id(sm2_vfy_pctx, "TLSv1.3+GM+Cipher+Suite",
+                        sizeof("TLSv1.3+GM+Cipher+Suite") - 1) != 1) {
+                st = 0;
+                EVP_PKEY_CTX_free(sm2_pctx);
+                EVP_PKEY_CTX_free(sm2_vfy_pctx);
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+
+            EVP_MD_CTX_set_pkey_ctx(loopargs[i].sm2_ctx[testnum], sm2_pctx);
+            EVP_MD_CTX_set_pkey_ctx(loopargs[i].sm2_vfy_ctx[testnum], sm2_vfy_pctx);
+
+            if (!EVP_DigestSignInit(loopargs[i].sm2_ctx[testnum], NULL,
+                                    EVP_sm3(), NULL, sm2_pkey)) {
+                st = 0;
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+            if (!EVP_DigestVerifyInit(loopargs[i].sm2_vfy_ctx[testnum], NULL,
+                                      EVP_sm3(), NULL, sm2_pkey)) {
+                st = 0;
+                EVP_PKEY_free(sm2_pkey);
+                break;
+            }
+            loopargs[i].sm2_pkey[testnum] = sm2_pkey;
+        }
+        if (st == 0) {
+            BIO_printf(bio_err, "SM2 failure.\n");
+            ERR_print_errors(bio_err);
+            rsa_count = 1;
+        } else {
+            for (i = 0; i < loopargs_len; i++) {
+                sm2_sigsize = loopargs[i].sigsize;
+                /* Perform SM2 signature test */
+                st = EVP_DigestSign(loopargs[i].sm2_ctx[testnum],
+                                    loopargs[i].buf2, &sm2_sigsize,
+                                    loopargs[i].buf, 20);
+                if (st == 0)
+                    break;
+            }
+            if (st == 0) {
+                BIO_printf(bio_err,
+                           "SM2 sign failure.  No SM2 sign will be done.\n");
+                ERR_print_errors(bio_err);
+                rsa_count = 1;
+            } else {
+                pkey_print_message("sign", test_sm2_curves[testnum].name,
+                                   sm2_c[testnum][0],
+                                   test_sm2_curves[testnum].bits, seconds.sm2);
+                Time_F(START);
+                count = run_benchmark(async_jobs, SM2_sign_loop, loopargs);
+                d = Time_F(STOP);
+
+                BIO_printf(bio_err,
+                           mr ? "+R8:%ld:%u:%s:%.2f\n" :
+                           "%ld %u bits %s signs in %.2fs \n",
+                           count, test_sm2_curves[testnum].bits,
+                           test_sm2_curves[testnum].name, d);
+                sm2_results[testnum][0] = (double)count / d;
+                rsa_count = count;
+            }
+
+            /* Perform SM2 verification test */
+            for (i = 0; i < loopargs_len; i++) {
+                st = EVP_DigestVerify(loopargs[i].sm2_vfy_ctx[testnum],
+                                      loopargs[i].buf2, loopargs[i].sigsize,
+                                      loopargs[i].buf, 20);
+                if (st != 1)
+                    break;
+            }
+            if (st != 1) {
+                BIO_printf(bio_err,
+                           "SM2 verify failure.  No SM2 verify will be done.\n");
+                ERR_print_errors(bio_err);
+                sm2_doit[testnum] = 0;
+            } else {
+                pkey_print_message("verify", test_sm2_curves[testnum].name,
+                                   sm2_c[testnum][1],
+                                   test_sm2_curves[testnum].bits, seconds.sm2);
+                Time_F(START);
+                count = run_benchmark(async_jobs, SM2_verify_loop, loopargs);
+                d = Time_F(STOP);
+                BIO_printf(bio_err,
+                           mr ? "+R9:%ld:%u:%s:%.2f\n"
+                           : "%ld %u bits %s verify in %.2fs\n",
+                           count, test_sm2_curves[testnum].bits,
+                           test_sm2_curves[testnum].name, d);
+                sm2_results[testnum][1] = (double)count / d;
+            }
+
+            if (rsa_count <= 1) {
+                /* if longer than 10s, don't do any more */
+                for (testnum++; testnum < SM2_NUM; testnum++)
+                    sm2_doit[testnum] = 0;
+            }
+        }
+    }
+# endif                         /* OPENSSL_NO_SM2 */
+
 #endif                          /* OPENSSL_NO_EC */
 #ifndef NO_FORK
  show_res:
@@ -3489,6 +3782,28 @@ int speed_main(int argc, char **argv)
                    1.0 / eddsa_results[k][0], 1.0 / eddsa_results[k][1],
                    eddsa_results[k][0], eddsa_results[k][1]);
     }
+
+# ifndef OPENSSL_NO_SM2
+    testnum = 1;
+    for (k = 0; k < OSSL_NELEM(sm2_doit); k++) {
+        if (!sm2_doit[k])
+            continue;
+        if (testnum && !mr) {
+            printf("%30ssign    verify    sign/s verify/s\n", " ");
+            testnum = 0;
+        }
+
+        if (mr)
+            printf("+F6:%u:%u:%s:%f:%f\n",
+                   k, test_sm2_curves[k].bits, test_sm2_curves[k].name,
+                   sm2_results[k][0], sm2_results[k][1]);
+        else
+            printf("%4u bits SM2 (%s) %8.4fs %8.4fs %8.1f %8.1f\n",
+                   test_sm2_curves[k].bits, test_sm2_curves[k].name,
+                   1.0 / sm2_results[k][0], 1.0 / sm2_results[k][1],
+                   sm2_results[k][0], sm2_results[k][1]);
+    }
+# endif
 #endif
 
     ret = 0;
@@ -3514,6 +3829,24 @@ int speed_main(int argc, char **argv)
             EVP_PKEY_CTX_free(loopargs[i].ecdh_ctx[k]);
         for (k = 0; k < EdDSA_NUM; k++)
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx[k]);
+# ifndef OPENSSL_NO_SM2
+        for (k = 0; k < SM2_NUM; k++) {
+            EVP_PKEY_CTX *pctx = NULL;
+
+            /* free signing ctx */
+            if (loopargs[i].sm2_ctx[k] != NULL
+                    && (pctx = EVP_MD_CTX_pkey_ctx(loopargs[i].sm2_ctx[k])) != NULL)
+                EVP_PKEY_CTX_free(pctx);
+            EVP_MD_CTX_free(loopargs[i].sm2_ctx[k]);
+            /* free verification ctx */
+            if (loopargs[i].sm2_vfy_ctx[k] == NULL
+                    || (pctx = EVP_MD_CTX_pkey_ctx(loopargs[i].sm2_vfy_ctx[k])) != NULL)
+                EVP_PKEY_CTX_free(pctx);
+            EVP_MD_CTX_free(loopargs[i].sm2_vfy_ctx[k]);
+            /* free pkey */
+            EVP_PKEY_free(loopargs[i].sm2_pkey[k]);
+        }
+# endif
         OPENSSL_free(loopargs[i].secret_a);
         OPENSSL_free(loopargs[i].secret_b);
 #endif
@@ -3739,6 +4072,22 @@ static int do_multi(int multi, int size_num)
                 d = atof(sstrsep(&p, sep));
                 eddsa_results[k][1] += d;
             }
+#  ifndef OPENSSL_NO_SM2
+            else if (strncmp(buf, "+F7:", 4) == 0) {
+                int k;
+                double d;
+
+                p = buf + 4;
+                k = atoi(sstrsep(&p, sep));
+                sstrsep(&p, sep);
+
+                d = atof(sstrsep(&p, sep));
+                sm2_results[k][0] += d;
+
+                d = atof(sstrsep(&p, sep));
+                sm2_results[k][1] += d;
+            }
+#  endif /* OPENSSL_NO_SM2 */
 # endif
 
             else if (strncmp(buf, "+H:", 3) == 0) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -612,9 +612,9 @@ static OPT_PAIR eddsa_choices[] = {
 static double eddsa_results[EdDSA_NUM][2];    /* 2 ops: sign then verify */
 
 # ifndef OPENSSL_NO_SM2
-#  define R_EC_SM2P256        0
+#  define R_EC_CURVESM2        0
 static OPT_PAIR sm2_choices[] = {
-    {"sm2p256", R_EC_SM2P256}
+    {"curveSM2", R_EC_CURVESM2}
 };
 #  define SM2_ID        "TLSv1.3+GM+Cipher+Suite"
 #  define SM2_ID_LEN    sizeof("TLSv1.3+GM+Cipher+Suite") - 1

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -616,6 +616,8 @@ static double eddsa_results[EdDSA_NUM][2];    /* 2 ops: sign then verify */
 static OPT_PAIR sm2_choices[] = {
     {"sm2p256", R_EC_SM2P256}
 };
+#  define SM2_ID        "TLSv1.3+GM+Cipher+Suite"
+#  define SM2_ID_LEN    sizeof("TLSv1.3+GM+Cipher+Suite") - 1
 #  define SM2_NUM       OSSL_NELEM(sm2_choices)
 
 static double sm2_results[SM2_NUM][2];    /* 2 ops: sign then verify */
@@ -3522,8 +3524,7 @@ int speed_main(int argc, char **argv)
              * No need to allow user to set an explicit ID here, just use
              * the one defined in the 'draft-yang-tls-tl13-sm-suites' I-D.
              */
-            if (EVP_PKEY_CTX_set1_id(sm2_pctx, "TLSv1.3+GM+Cipher+Suite",
-                        sizeof("TLSv1.3+GM+Cipher+Suite") - 1) != 1) {
+            if (EVP_PKEY_CTX_set1_id(sm2_pctx, SM2_ID, SM2_ID_LEN) != 1) {
                 st = 0;
                 EVP_PKEY_CTX_free(sm2_pctx);
                 EVP_PKEY_CTX_free(sm2_vfy_pctx);
@@ -3531,8 +3532,7 @@ int speed_main(int argc, char **argv)
                 break;
             }
 
-            if (EVP_PKEY_CTX_set1_id(sm2_vfy_pctx, "TLSv1.3+GM+Cipher+Suite",
-                        sizeof("TLSv1.3+GM+Cipher+Suite") - 1) != 1) {
+            if (EVP_PKEY_CTX_set1_id(sm2_vfy_pctx, SM2_ID, SM2_ID_LEN) != 1) {
                 st = 0;
                 EVP_PKEY_CTX_free(sm2_pctx);
                 EVP_PKEY_CTX_free(sm2_vfy_pctx);
@@ -3839,8 +3839,8 @@ int speed_main(int argc, char **argv)
                 EVP_PKEY_CTX_free(pctx);
             EVP_MD_CTX_free(loopargs[i].sm2_ctx[k]);
             /* free verification ctx */
-            if (loopargs[i].sm2_vfy_ctx[k] == NULL
-                    || (pctx = EVP_MD_CTX_pkey_ctx(loopargs[i].sm2_vfy_ctx[k])) != NULL)
+            if (loopargs[i].sm2_vfy_ctx[k] != NULL
+                    && (pctx = EVP_MD_CTX_pkey_ctx(loopargs[i].sm2_vfy_ctx[k])) != NULL)
                 EVP_PKEY_CTX_free(pctx);
             EVP_MD_CTX_free(loopargs[i].sm2_vfy_ctx[k]);
             /* free pkey */

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3497,10 +3497,9 @@ int speed_main(int argc, char **argv)
             /* free previous one and alloc a new one */
             EVP_PKEY_CTX_free(pctx);
 
-#ifndef FIPS_MODE
             loopargs[i].sigsize = sm2_sigsize
                 = ECDSA_size(EVP_PKEY_get0_EC_KEY(sm2_pkey));
-#endif
+
             if (!EVP_PKEY_set_alias_type(sm2_pkey, EVP_PKEY_SM2)) {
                 st = 0;
                 EVP_PKEY_free(sm2_pkey);

--- a/doc/man7/SM2.pod
+++ b/doc/man7/SM2.pod
@@ -41,6 +41,9 @@ done by calling:
 And normally there is no need to pass a B<pctx> parameter to EVP_DigestSignInit()
 or EVP_DigestVerifyInit() in such a scenario.
 
+SM2 can be tested within L<speed(1)> application since version 3.0.0. At current
+stage, the only valid algorithm name is B<sm2>.
+
 =head1 EXAMPLES
 
 This example demonstrates the calling sequence for using an B<EVP_PKEY> to verify


### PR DESCRIPTION
This one is almost the same as #7073 . During the review progress of #7073, ideas came up for refactoring the `speed` application after 1.1.1. But considering it's not done yet so this patch still follows the old-fashioned way of adding a new algorithm to benchmark.

SM2 is a little different with other EC based algorithm - it requires to set an ID in the `init` phase before any other actions to be taken. So when benchmark the sign/verify operations with speed, the init phase it also benchmarked..

Output of speed sm2 is something like:

```
$ bin/openssl speed sm2
Doing 256 bits sign CurveSM2's for 10s: 16302 256 bits CurveSM2 signs in 9.87s
Doing 256 bits verify CurveSM2's for 10s: 18461 256 bits CurveSM2 verify in 9.91s
version: 3.0.0-dev
built on: built on: Sun Sep 29 06:03:48 2019 UTC
options:bn(64,64) aes(partial)
compiler: cc -fPIC -arch x86_64 -fsanitize=address -fno-omit-frame-pointer -g -O3 -Wall -DDEBUG_UNUSED -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wswitch -Wsign-compare -Wshadow -Wformat -Wtype-limits -Wundef -Werror -Wmissing-prototypes -Wstrict-prototypes -Wno-unknown-warning-option -Wswitch-default -Wno-parentheses-equality -Wno-language-extension-token -Wno-extended-offsetof -Wconditional-uninitialized -Wincompatible-pointer-types-discards-qualifiers -Wmissing-variable-declarations -DL_ENDIAN -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffaf3bfffebffff:0x29c67af
                              sign    verify    sign/s verify/s
 256 bits SM2 (CurveSM2)   0.0006s   0.0005s   1651.7   1862.9
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
