### PR TITLE
Reenable the stitched AES-CBC-HMAC-SHA implementations. [1.1.1]

### DIFF
--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -33,7 +33,7 @@ typedef struct {
 
 #define NO_PAYLOAD_LENGTH       ((size_t)-1)
 
-#if     defined(AES_ASM) &&     ( \
+#if     !defined(OPENSSL_NO_ASM) &&     ( \
         defined(__x86_64)       || defined(__x86_64__)  || \
         defined(_M_AMD64)       || defined(_M_X64)      )
 

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -34,7 +34,7 @@ typedef struct {
 
 # define NO_PAYLOAD_LENGTH       ((size_t)-1)
 
-#if     defined(AES_ASM) &&     ( \
+#if     !defined(OPENSSL_NO_ASM) &&     ( \
         defined(__x86_64)       || defined(__x86_64__)  || \
         defined(_M_AMD64)       || defined(_M_X64)      )
 


### PR DESCRIPTION
After PR#9675 was merged the AES-CBC-HMAC-SHA stitched implementations
were effectively disabled in build time, because AES_ASM is not set
anymore for x86 build targets.
