### PR TITLE
apps/speed: various cleanups and improvements

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -248,21 +248,6 @@ static int opt_found(const char *name, unsigned int *result,
 #define opt_found(value, pairs, result)\
     opt_found(value, result, pairs, OSSL_NELEM(pairs))
 
-static int alg_found(const char *name, unsigned int *result,
-                     const char * const alg_names[], unsigned int nbelem)
-{
-    unsigned int idx;
-
-    for (idx = 0; idx < nbelem; ++idx)
-        if (strcmp(name, alg_names[idx]) == 0) {
-            *result = idx;
-            return 1;
-        }
-    return 0;
-}
-#define found(value, algo_name_list, result)\
-    alg_found(value, result, algo_name_list, OSSL_NELEM(algo_name_list))
-
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_ELAPSED, OPT_EVP, OPT_HMAC, OPT_DECRYPT, OPT_ENGINE, OPT_MULTI,
@@ -415,7 +400,7 @@ static double results[ALGOR_NUM][SIZE_NUM];
 
 #ifndef OPENSSL_NO_DSA
 enum { R_DSA_512, R_DSA_1024, R_DSA_2048, DSA_NUM };
-static const OPT_PAIR dsa_choices[] = {
+static const OPT_PAIR dsa_choices[DSA_NUM] = {
     {"dsa512", R_DSA_512},
     {"dsa1024", R_DSA_1024},
     {"dsa2048", R_DSA_2048}
@@ -2793,6 +2778,7 @@ int speed_main(int argc, char **argv)
 
     if (doit[D_EVP_HMAC] && evp_hmac_md != NULL) {
         const char *md_name = OBJ_nid2ln(EVP_MD_type(evp_hmac_md));
+
         evp_hmac_name = app_malloc(sizeof("HMAC()") + strlen(md_name),
                                    "HMAC name");
         sprintf(evp_hmac_name, "HMAC(%s)", md_name);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -139,69 +139,6 @@ static volatile int run = 0;
 static int mr = 0;
 static int usertime = 1;
 
-#ifndef OPENSSL_NO_MD2
-static int EVP_Digest_MD2_loop(void *args);
-#endif
-
-#ifndef OPENSSL_NO_MDC2
-static int EVP_Digest_MDC2_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_MD4
-static int EVP_Digest_MD4_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_MD5
-static int MD5_loop(void *args);
-static int HMAC_loop(void *args);
-#endif
-static int SHA1_loop(void *args);
-static int SHA256_loop(void *args);
-static int SHA512_loop(void *args);
-#ifndef OPENSSL_NO_WHIRLPOOL
-static int WHIRLPOOL_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_RMD160
-static int EVP_Digest_RMD160_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_RC4
-static int RC4_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_DES
-static int DES_ncbc_encrypt_loop(void *args);
-static int DES_ede3_cbc_encrypt_loop(void *args);
-#endif
-static int AES_cbc_128_encrypt_loop(void *args);
-static int AES_cbc_192_encrypt_loop(void *args);
-static int AES_cbc_256_encrypt_loop(void *args);
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-static int AES_ige_128_encrypt_loop(void *args);
-static int AES_ige_192_encrypt_loop(void *args);
-static int AES_ige_256_encrypt_loop(void *args);
-#endif
-static int CRYPTO_gcm128_aad_loop(void *args);
-static int RAND_bytes_loop(void *args);
-static int EVP_Update_loop(void *args);
-static int EVP_Update_loop_ccm(void *args);
-static int EVP_Update_loop_aead(void *args);
-static int EVP_Digest_loop(void *args);
-#ifndef OPENSSL_NO_RSA
-static int RSA_sign_loop(void *args);
-static int RSA_verify_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_DSA
-static int DSA_sign_loop(void *args);
-static int DSA_verify_loop(void *args);
-#endif
-#ifndef OPENSSL_NO_EC
-static int ECDSA_sign_loop(void *args);
-static int ECDSA_verify_loop(void *args);
-static int EdDSA_sign_loop(void *args);
-static int EdDSA_verify_loop(void *args);
-# ifndef OPENSSL_NO_SM2
-static int SM2_sign_loop(void *args);
-static int SM2_verify_loop(void *args);
-# endif
-#endif
-
 static double Time_F(int s);
 static void print_message(const char *s, long num, int length, int tm);
 static void pkey_print_message(const char *str, const char *str2,

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2396,6 +2396,8 @@ int speed_main(int argc, char **argv)
             count = run_benchmark(async_jobs, EVP_Digest_MDC2_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_MDC2, testnum, count, d);
+            if (count < 0)
+                break;
         }
     }
 #endif
@@ -2409,6 +2411,8 @@ int speed_main(int argc, char **argv)
             count = run_benchmark(async_jobs, EVP_Digest_MD4_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_MD4, testnum, count, d);
+            if (count < 0)
+                break;
         }
     }
 #endif
@@ -2503,6 +2507,8 @@ int speed_main(int argc, char **argv)
             count = run_benchmark(async_jobs, EVP_Digest_RMD160_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_RMD160, testnum, count, d);
+            if (count < 0)
+                break;
         }
     }
 #endif
@@ -3920,8 +3926,10 @@ static void pkey_print_message(const char *str, const char *str2, long num,
 static void print_result(int alg, int run_no, int count, double time_used)
 {
     if (count == -1) {
-        BIO_puts(bio_err, "EVP error!\n");
-        exit(1);
+        BIO_printf(bio_err, "%s error!\n", names[alg]);
+        ERR_print_errors(bio_err);
+        /* exit(1);  disable exit until default provider enabled */
+        return;
     }
     BIO_printf(bio_err,
                mr ? "+R:%d:%s:%f\n"


### PR DESCRIPTION
- replace bunchs of #define with enums.
- load crypto material only when its algorithm is enabled.
- improve error handling, avoid exit(1) when `default provider` is missing.
- factorize some internal structures definitions for tested curves.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
