### PR TITLE
Define AESNI_ASM if AESNI assembler is included, and use it

### DIFF
--- a/Configure
+++ b/Configure
@@ -1376,6 +1376,7 @@ unless ($disabled{asm}) {
     }
     if ($target{aes_asm_src}) {
         push @{$config{lib_defines}}, "AES_ASM" if ($target{aes_asm_src} =~ m/\baes-/);;
+        push @{$config{lib_defines}}, "AESNI_ASM" if ($target{aes_asm_src} =~ m/\baesni-/);;
         # aes-ctr.fake is not a real file, only indication that assembler
         # module implements AES_ctr32_encrypt...
         push @{$config{lib_defines}}, "AES_CTR_ASM" if ($target{aes_asm_src} =~ s/\s*aes-ctr\.fake//);

--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -33,7 +33,7 @@ typedef struct {
 
 #define NO_PAYLOAD_LENGTH       ((size_t)-1)
 
-#if     defined(AES_ASM) &&     ( \
+#if     defined(AESNI_ASM) &&     ( \
         defined(__x86_64)       || defined(__x86_64__)  || \
         defined(_M_AMD64)       || defined(_M_X64)      )
 

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -34,7 +34,7 @@ typedef struct {
 
 # define NO_PAYLOAD_LENGTH       ((size_t)-1)
 
-#if     defined(AES_ASM) &&     ( \
+#if     defined(AESNI_ASM) &&   ( \
         defined(__x86_64)       || defined(__x86_64__)  || \
         defined(_M_AMD64)       || defined(_M_X64)      )
 
@@ -947,4 +947,4 @@ const EVP_CIPHER *EVP_aes_256_cbc_hmac_sha256(void)
 {
     return NULL;
 }
-#endif
+#endif  /* AESNI_ASM */


### PR DESCRIPTION
Because we have cases where basic assembler support isn't present, but
AESNI asssembler support is, we need a separate macro that indicates
that, and use it.

-----

Alternative to #10074