### PR TITLE
Don't follow legacy path if ctx->pctx is set

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -148,7 +148,6 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 #if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
             || tmpimpl != NULL
 #endif
-            || ctx->pctx != NULL
             || (ctx->flags & EVP_MD_CTX_FLAG_NO_INIT) != 0) {
         if (ctx->digest == ctx->fetched_digest)
             ctx->digest = NULL;

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -140,8 +140,8 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 #endif
 
     /*
-     * If there are engines involved or if we're being used as part of
-     * EVP_DigestSignInit then we should use legacy handling for now.
+     * If there are engines involved or EVP_MD_CTX_FLAG_NO_INIT is set then we
+     * should use legacy handling for now.
      */
     if (ctx->engine != NULL
             || impl != NULL


### PR DESCRIPTION
EVP_DigestInit_ex forced following of the legacy path if ctx->pctx is
set (meaning we've actually been called via EVP_DigestSignInit_ex).

There is some code in the legacy path that calls the
EVP_PKEY_CTRL_DIGESTINIT ctrl on the pctx. Not going down the legacy path
if ctx->pctx is set means that ctrl message will neve get sent. However,
it turns out that all algs that understand that ctrl also set the
EVP_MD_CTX_FLAG_NO_INIT flag which forces legacy anyway. Therefore the
ctx->pctx check is not required and can be removed.
