### PR TITLE
RC4 is not a block cipher

### DIFF
--- a/providers/default/ciphers/cipher_rc4.c
+++ b/providers/default/ciphers/cipher_rc4.c
@@ -82,6 +82,6 @@ const OSSL_DISPATCH alg##kbits##_functions[] = {                               \
 };
 
 /* rc440_functions */
-IMPLEMENT_cipher(rc4, RC4, EVP_CIPH_VARIABLE_LENGTH, 40, 64, 0, stream)
+IMPLEMENT_cipher(rc4, RC4, EVP_CIPH_VARIABLE_LENGTH, 40, 8, 0, stream)
 /* rc4128_functions */
-IMPLEMENT_cipher(rc4, RC4, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 0, stream)
+IMPLEMENT_cipher(rc4, RC4, EVP_CIPH_VARIABLE_LENGTH, 128, 8, 0, stream)


### PR DESCRIPTION
RC4 is a stream cipher therefore EVP_CIPHER_CTX_block_size() should
return 1.

This fixes a test failure in ssl_test_old when enable-weak-ssl-ciphers
has been configured.
