### PR TITLE
Remove L<> to non-existing page

### DIFF
--- a/doc/man3/DSA_meth_new.pod
+++ b/doc/man3/DSA_meth_new.pod
@@ -88,8 +88,7 @@ DSA_meth_set_keygen - Routines to build up DSA methods
 
 The B<DSA_METHOD> type is a structure used for the provision of custom DSA
 implementations. It provides a set of functions used by OpenSSL for the
-implementation of the various DSA capabilities. See the L<dsa> page for more
-information.
+implementation of the various DSA capabilities.
 
 DSA_meth_new() creates a new B<DSA_METHOD> structure. It should be given a
 unique B<name> and a set of B<flags>. The B<name> should be a NULL terminated

--- a/doc/man3/RSA_meth_new.pod
+++ b/doc/man3/RSA_meth_new.pod
@@ -125,8 +125,7 @@ RSA_meth_get_multi_prime_keygen, RSA_meth_set_multi_prime_keygen
 
 The B<RSA_METHOD> type is a structure used for the provision of custom
 RSA implementations. It provides a set of functions used by OpenSSL
-for the implementation of the various RSA capabilities. See the L<rsa>
-page for more information.
+for the implementation of the various RSA capabilities.
 
 RSA_meth_new() creates a new B<RSA_METHOD> structure. It should be
 given a unique B<name> and a set of B<flags>. The B<name> should be a


### PR DESCRIPTION
Remove references to pages that do not exist. At this point, frankly, they're never going to get written.  And 3.0 is moving away from "method" stuff to provider implementation of algorithms anyway.

This could be backported.
