### PR TITLE
EVP_{CIPHER,MD}_CTX_ctrl(): make sure to return 0 or 1

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -665,7 +665,7 @@ int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
         ret = EVP_MD_CTX_set_params(ctx, params);
     else
         ret = EVP_MD_CTX_get_params(ctx, params);
-    return ret;
+    goto conclude;
 
 
 /* TODO(3.0): Remove legacy code below */
@@ -676,6 +676,7 @@ int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
     }
 
     ret = ctx->digest->md_ctrl(ctx, cmd, p1, p2);
+ conclude:
     if (ret <= 0)
         return 0;
     return ret;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1148,7 +1148,7 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
         ret = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);
     else
         ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
-    return ret;
+    goto conclude;
 
 /* TODO(3.0): Remove legacy code below */
 legacy:
@@ -1158,6 +1158,8 @@ legacy:
     }
 
     ret = ctx->cipher->ctrl(ctx, type, arg, ptr);
+
+ conclude:
     if (ret == EVP_CTRL_RET_UNSUPPORTED) {
         EVPerr(EVP_F_EVP_CIPHER_CTX_CTRL,
                EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED);


### PR DESCRIPTION
Even thought the underlying calls might return something other than 0
or 1, `EVP_CIPHER_CTX_ctrl()` and `EVP_MD_CTX_ctrl()` were made to only
return those values regardless.  That behaviour was recently lost, so
we need to restore it.

Fixes #10106
