### PR TITLE
Fix CMP test error

### DIFF
--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -240,7 +240,8 @@ static int test_log_cb(const char *func, const char *file, int line,
 {
     test_log_cb_res =
 # ifndef PEDANTIC
-        strcmp(func, "execute_cmp_ctx_log_cb_test") == 0 &&
+        (strcmp(func, "execute_cmp_ctx_log_cb_test") == 0
+         || strcmp(func, "(unknown function)") == 0) &&
 # endif
         (strcmp(file, OPENSSL_FILE) == 0 || strcmp(file, "(no file)") == 0)
         && (line == test_log_line || line == 0)


### PR DESCRIPTION
Some platforms end up defining OPENSSL_FUNC as '(unknown function)'
So the CMP test need to take this into account.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
