### PR TITLE
replace perl based c_rehash with compatible bash alternative

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -1,231 +1,150 @@
-#!{- $config{HASHBANGPERL} -}
+#!/bin/bash -ue
 
-# {- join("\n# ", @autowarntext) -}
-# Copyright 1999-2018 The OpenSSL Project Authors. All Rights Reserved.
-#
-# Licensed under the Apache License 2.0 (the "License").  You may not use
-# this file except in compliance with the License.  You can obtain a copy
-# in the file LICENSE in the source distribution or at
-# https://www.openssl.org/source/license.html
+## interpret options, possibly print usage
+options=$(getopt -o "hvn" -l "old,help" -a -- "$@")
 
-# Perl c_rehash script, scan all files in a directory
-# and add symbolic links to their hash values.
+eval set -- "$options"
 
-my $dir = {- quotify1($config{openssldir}) -};
-my $prefix = {- quotify1($config{prefix}) -};
+ENABLE_LEGACY=0
+REMOVE_LINKS=0
+while true
+do
+	case "$1" in
+	"-h" | "--help")
+		echo "Usage: c_rehash [-old] [-h] [-help] [-v] [dirs...]"
+		echo "   -old use old-style digest"
+		echo "   -h or -help print this help text"
+		echo "   -v print files removed and linked"
 
-my $errorcount = 0;
-my $openssl = $ENV{OPENSSL} || "openssl";
-my $pwd;
-my $x509hash = "-subject_hash";
-my $crlhash = "-hash";
-my $verbose = 0;
-my $symlink_exists=eval {symlink("",""); 1};
-my $removelinks = 1;
+		exit 0
+	;;
 
-##  Parse flags.
-while ( $ARGV[0] =~ /^-/ ) {
-    my $flag = shift @ARGV;
-    last if ( $flag eq '--');
-    if ( $flag eq '-old') {
-	    $x509hash = "-subject_hash_old";
-	    $crlhash = "-hash_old";
-    } elsif ( $flag eq '-h' || $flag eq '-help' ) {
-	    help();
-    } elsif ( $flag eq '-n' ) {
-	    $removelinks = 0;
-    } elsif ( $flag eq '-v' ) {
-	    $verbose++;
-    }
-    else {
-	    print STDERR "Usage error; try -h.\n";
-	    exit 1;
-    }
+	"-v")
+		function cp { /usr/bin/cp -v "$@";}
+		function ln { /usr/bin/ln -v "$@";}
+		function rm { /usr/bin/rm -v "$@";}
+	;;
+
+	"--old")
+		ENABLE_LEGACY=1
+	;;
+
+	# undocumented
+	"-n")
+		REMOVE_LINKS=1
+	;;
+
+	"--")
+		shift
+		break
+	;;
+	esac
+	shift
+done
+
+## our internal variables, not influenced by options
+declare -A CREATED
+CAN_SYMLINK=$(command -v ln >/dev/null && echo 1 || echo 0)
+DEFAULT_DIR={- quotify1($config{openssldir}) -}
+[[ $OSTYPE == "cygwin" || $OSTYPE == "msys" || $OSTYPE == "win32" ]] && PATH_DELIM=';' || PATH_DELIM=':'
+
+
+## verify openssl is available
+PATH="{- $config{prefix} -}$PATH_DELIM$PATH"
+openssl version >/dev/null || {
+	echo "c_rehash: rehashing skipped ('openssl' program not available)" >&2
+
+	exit 1
 }
 
-sub help {
-	print "Usage: c_rehash [-old] [-h] [-help] [-v] [dirs...]\n";
-	print "   -old use old-style digest\n";
-	print "   -h or -help print this help text\n";
-	print "   -v print files removed and linked\n";
-	exit 0;
+
+## define functions
+# given a target directory, loop through all files (non-recursive) and attempt to link supported types
+function hashDir {
+	dir=$1
+
+	echo "c_rehash: scanning $dir"
+	cd "$dir"
+
+	if [[ ${REMOVE_LINKS} -eq 1 ]]; then
+		for f in [0-9a-f]*.[01]; do
+			[[ -L "$f" ]] && rm "$f"
+		done
+	fi
+
+	for f in *.pem *.crt *.cer *.crl; do
+		[[ -e "$f" ]] || continue
+
+		hdr=$(grep -- '-----BEGIN' "$f")
+		hdr=${hdr//-/}
+
+		certRegexp='^BEGIN (X509 |TRUSTED |)CERTIFICATE$'
+		if [[ $hdr =~ $certRegexp ]]; then
+			linkHash 0 "$f"
+		elif [[ $hdr == "BEGIN X509 CRL" ]]; then
+			linkHash 1 "$f"
+		else
+			echo "WARNING: $f does not contain a certificate or CRL: skipping" >&2
+			continue
+		fi
+	done
 }
 
-eval "require Cwd";
-if (defined(&Cwd::getcwd)) {
-	$pwd=Cwd::getcwd();
-} else {
-	$pwd=`pwd`;
-	chomp($pwd);
+# given a type and filepath, create a link/copy of file based on its hash
+function linkHash {
+	isCrl="$1"
+	f="$2"
+
+	[[ $isCrl -eq 1 ]] && cmd='crl' || cmd='x509'
+	[[ $isCrl -eq 1 ]] && opt='-hash' || opt='-subject_hash'
+	[[ $ENABLE_LEGACY -eq 1 ]] && opt=${opt}_old
+
+	  hash=$(openssl $cmd $opt -noout -in "$f")
+	fprint=$(openssl $cmd -fingerprint  -noout -in "$f")
+	fprint=${fprint##*=}
+	fprint=${fprint//:/}
+
+	suffix=0
+	[[ $isCrl -eq 1 ]] && extra="r" || extra=""
+
+	while [[ -n ${CREATED[$hash.$extra$suffix]} ]]; do
+		[[ ${CREATED[$hash.$extra$suffix]} -eq $fprint ]] && {
+			echo "WARNING: Skipping duplicate certificate $f" >&2
+			return
+		}
+
+		((suffix++))
+	done
+
+	if [[ $CAN_SYMLINK -eq 1 ]]; then
+		ln -s "$f" "$hash.$extra$suffix"
+	else
+		cp "$f" "$hash.$extra$suffix"
+	fi
+
+	CREATED[$hash.$extra$suffix]=$fprint
 }
 
-# DOS/Win32 or Unix delimiter?  Prefix our installdir, then search.
-my $path_delim = ($pwd =~ /^[a-z]\:/i) ? ';' : ':';
-$ENV{PATH} = "$prefix/bin" . ($ENV{PATH} ? $path_delim . $ENV{PATH} : "");
 
-if (! -x $openssl) {
-	my $found = 0;
-	foreach (split /$path_delim/, $ENV{PATH}) {
-		if (-x "$_/$openssl") {
-			$found = 1;
-			$openssl = "$_/$openssl";
-			last;
-		}	
+## determine target directories and loop through them
+
+if [[ $# -gt 0 ]]; then
+	dirList=("$@")
+elif [[ -n $SSL_CERT_DIR ]]; then
+	IFS=$PATH_DELIM read -r -a dirList <<< "$SSL_CERT_DIR"
+else
+	dirList=("$DEFAULT_DIR/certs")
+fi
+
+for d in "${dirList[@]}"
+do
+	[[ ! -w $d ]] && {
+		echo "Skipping $d, can't write" >&2
+		((errs++))
+		continue
 	}
-	if ($found == 0) {
-		print STDERR "c_rehash: rehashing skipped ('openssl' program not available)\n";
-		exit 0;
-	}
-}
 
-if (@ARGV) {
-	@dirlist = @ARGV;
-} elsif ($ENV{SSL_CERT_DIR}) {
-	@dirlist = split /$path_delim/, $ENV{SSL_CERT_DIR};
-} else {
-	$dirlist[0] = "$dir/certs";
-}
+	hashDir "$d"
+done
 
-if (-d $dirlist[0]) {
-	chdir $dirlist[0];
-	$openssl="$pwd/$openssl" if (!-x $openssl);
-	chdir $pwd;
-}
-
-foreach (@dirlist) {
-	if (-d $_ ) {
-            if ( -w $_) {
-		hash_dir($_);
-            } else {
-                print "Skipping $_, can't write\n";
-                $errorcount++;
-            }
-	}
-}
-exit($errorcount);
-
-sub hash_dir {
-	my %hashlist;
-	print "Doing $_[0]\n";
-	chdir $_[0];
-	opendir(DIR, ".");
-	my @flist = sort readdir(DIR);
-	closedir DIR;
-	if ( $removelinks ) {
-		# Delete any existing symbolic links
-		foreach (grep {/^[\da-f]+\.r{0,1}\d+$/} @flist) {
-			if (-l $_) {
-				print "unlink $_" if $verbose;
-				unlink $_ || warn "Can't unlink $_, $!\n";
-			}
-		}
-	}
-	FILE: foreach $fname (grep {/\.(pem)|(crt)|(cer)|(crl)$/} @flist) {
-		# Check to see if certificates and/or CRLs present.
-		my ($cert, $crl) = check_file($fname);
-		if (!$cert && !$crl) {
-			print STDERR "WARNING: $fname does not contain a certificate or CRL: skipping\n";
-			next;
-		}
-		link_hash_cert($fname) if ($cert);
-		link_hash_crl($fname) if ($crl);
-	}
-}
-
-sub check_file {
-	my ($is_cert, $is_crl) = (0,0);
-	my $fname = $_[0];
-	open IN, $fname;
-	while(<IN>) {
-		if (/^-----BEGIN (.*)-----/) {
-			my $hdr = $1;
-			if ($hdr =~ /^(X509 |TRUSTED |)CERTIFICATE$/) {
-				$is_cert = 1;
-				last if ($is_crl);
-			} elsif ($hdr eq "X509 CRL") {
-				$is_crl = 1;
-				last if ($is_cert);
-			}
-		}
-	}
-	close IN;
-	return ($is_cert, $is_crl);
-}
-
-
-# Link a certificate to its subject name hash value, each hash is of
-# the form <hash>.<n> where n is an integer. If the hash value already exists
-# then we need to up the value of n, unless its a duplicate in which
-# case we skip the link. We check for duplicates by comparing the
-# certificate fingerprints
-
-sub link_hash_cert {
-		my $fname = $_[0];
-		$fname =~ s/'/'\\''/g;
-		my ($hash, $fprint) = `"$openssl" x509 $x509hash -fingerprint -noout -in "$fname"`;
-		chomp $hash;
-		chomp $fprint;
-		$fprint =~ s/^.*=//;
-		$fprint =~ tr/://d;
-		my $suffix = 0;
-		# Search for an unused hash filename
-		while(exists $hashlist{"$hash.$suffix"}) {
-			# Hash matches: if fingerprint matches its a duplicate cert
-			if ($hashlist{"$hash.$suffix"} eq $fprint) {
-				print STDERR "WARNING: Skipping duplicate certificate $fname\n";
-				return;
-			}
-			$suffix++;
-		}
-		$hash .= ".$suffix";
-		if ($symlink_exists) {
-			print "link $fname -> $hash\n" if $verbose;
-			symlink $fname, $hash || warn "Can't symlink, $!";
-		} else {
-			print "copy $fname -> $hash\n" if $verbose;
-                        if (open($in, "<", $fname)) {
-                            if (open($out,">", $hash)) {
-                                print $out $_ while (<$in>);
-                                close $out;
-                            } else {
-                                warn "can't open $hash for write, $!";
-                            }
-                            close $in;
-                        } else {
-                            warn "can't open $fname for read, $!";
-                        }
-		}
-		$hashlist{$hash} = $fprint;
-}
-
-# Same as above except for a CRL. CRL links are of the form <hash>.r<n>
-
-sub link_hash_crl {
-		my $fname = $_[0];
-		$fname =~ s/'/'\\''/g;
-		my ($hash, $fprint) = `"$openssl" crl $crlhash -fingerprint -noout -in '$fname'`;
-		chomp $hash;
-		chomp $fprint;
-		$fprint =~ s/^.*=//;
-		$fprint =~ tr/://d;
-		my $suffix = 0;
-		# Search for an unused hash filename
-		while(exists $hashlist{"$hash.r$suffix"}) {
-			# Hash matches: if fingerprint matches its a duplicate cert
-			if ($hashlist{"$hash.r$suffix"} eq $fprint) {
-				print STDERR "WARNING: Skipping duplicate CRL $fname\n";
-				return;
-			}
-			$suffix++;
-		}
-		$hash .= ".r$suffix";
-		if ($symlink_exists) {
-			print "link $fname -> $hash\n" if $verbose;
-			symlink $fname, $hash || warn "Can't symlink, $!";
-		} else {
-			print "cp $fname -> $hash\n" if $verbose;
-			system ("cp", $fname, $hash);
-                        warn "Can't copy, $!" if ($? >> 8) != 0;
-		}
-		$hashlist{$hash} = $fprint;
-}
+exit $errs


### PR DESCRIPTION
when openssl is packaged in popular distributions, it depends on `perl`, only because `c_rehash` has a dependency on it.

While keeping perl required for building is fine - it shouldn't be a dependency once `openssl` has been installed by the user. This PR fixes that by rewriting c_rehash in `bash`