### PR TITLE
Fix: EVP_Cipher() is supposed to return the output length, or -1 on e…

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -305,8 +305,10 @@ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             return
                 ctx->cipher->ccipher(ctx->provctx, out, &outl,
                                      inl + (blocksize == 1 ? 0 : blocksize),
-                                     in, (size_t)inl);
-        return 0;
+                                     in, (size_t)inl)
+                ? (int)outl
+                : -1;
+        return -1;
     }
 
     return ctx->cipher->do_cipher(ctx, out, in, inl);

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -25,6 +25,7 @@ EVP_DecryptInit,
 EVP_DecryptFinal,
 EVP_CipherInit,
 EVP_CipherFinal,
+EVP_Cipher,
 EVP_get_cipherbyname,
 EVP_get_cipherbynid,
 EVP_get_cipherbyobj,
@@ -106,6 +107,9 @@ EVP_CIPHER_do_all_ex
  int EVP_CipherInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                     const unsigned char *key, const unsigned char *iv, int enc);
  int EVP_CipherFinal(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+
+ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                const unsigned char *in, unsigned int inl)
 
  int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *x, int padding);
  int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *x, int keylen);
@@ -250,6 +254,12 @@ identical to EVP_EncryptFinal_ex(), EVP_DecryptFinal_ex() and
 EVP_CipherFinal_ex(). In previous releases they also cleaned up
 the B<ctx>, but this is no longer done and EVP_CIPHER_CTX_clean()
 must be called to free any context resources.
+
+EVP_Cipher() encrypts or decrypts as many EVP_CIPHER_block_size() block from
+I<in> that I<inl> allows and places the result in I<out>.  It returns the
+number of encrypted or decrypted bytes.  This function does not buffer anything
+like EVP_CipherUpdate does, and therefore gives a very direct access to the
+central block cipher of the cipher implementation.
 
 EVP_get_cipherbyname(), EVP_get_cipherbynid() and EVP_get_cipherbyobj()
 return an EVP_CIPHER structure when passed a cipher name, a NID or an

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -109,7 +109,7 @@ EVP_CIPHER_do_all_ex
  int EVP_CipherFinal(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
 
  int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
-                const unsigned char *in, unsigned int inl)
+                const unsigned char *in, unsigned int inl);
 
  int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *x, int padding);
  int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *x, int keylen);
@@ -255,11 +255,12 @@ EVP_CipherFinal_ex(). In previous releases they also cleaned up
 the B<ctx>, but this is no longer done and EVP_CIPHER_CTX_clean()
 must be called to free any context resources.
 
-EVP_Cipher() encrypts or decrypts as many EVP_CIPHER_block_size() block from
-I<in> that I<inl> allows and places the result in I<out>.  It returns the
-number of encrypted or decrypted bytes.  This function does not buffer anything
-like EVP_CipherUpdate does, and therefore gives a very direct access to the
-central block cipher of the cipher implementation.
+EVP_Cipher() encrypts or decrypts as many EVP_CIPHER_block_size() blocks
+from I<in> that I<inl> allows and places the result in I<out>.  The rest
+of I<in>, if there is any (C<inl % EVP_CIPHER_block_size(cipher) != 0>),
+will remain unused.  This function gives direct access to the low level
+cipher implementation.  If buffering is required EVP_CipherUpdate() should
+be used instead.
 
 EVP_get_cipherbyname(), EVP_get_cipherbynid() and EVP_get_cipherbyobj()
 return an EVP_CIPHER structure when passed a cipher name, a NID or an
@@ -397,6 +398,9 @@ EVP_DecryptFinal_ex() returns 0 if the decrypt failed or 1 for success.
 
 EVP_CipherInit_ex() and EVP_CipherUpdate() return 1 for success and 0 for failure.
 EVP_CipherFinal_ex() returns 0 for a decryption failure or 1 for success.
+
+EVP_Cipher() returns the amount of encrypted / decrypted bytes, or -1 on
+failure.
 
 EVP_CIPHER_CTX_reset() returns 1 for success and 0 for failure.
 

--- a/providers/common/ciphers/cipher_aes_hw_t4.inc
+++ b/providers/common/ciphers/cipher_aes_hw_t4.inc
@@ -15,7 +15,7 @@
 static int cipher_hw_aes_t4_initkey(PROV_CIPHER_CTX *dat,
                                     const unsigned char *key, size_t keylen)
 {
-    int ret, bits;
+    int ret = 0, bits;
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
     AES_KEY *ks = &adat->ks.ks;
 
@@ -24,7 +24,7 @@ static int cipher_hw_aes_t4_initkey(PROV_CIPHER_CTX *dat,
     bits = keylen * 8;
     if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)
         && !dat->enc) {
-        ret = 0;
+        ret = 1;
         aes_t4_set_decrypt_key(key, bits, ks);
         dat->block = (block128_f)aes_t4_decrypt;
         switch (bits) {
@@ -41,10 +41,10 @@ static int cipher_hw_aes_t4_initkey(PROV_CIPHER_CTX *dat,
                 (cbc128_f)aes256_t4_cbc_decrypt : NULL;
             break;
         default:
-            ret = -1;
+            ret = 0;
         }
     } else {
-        ret = 0;
+        ret = 1;
         aes_t4_set_encrypt_key(key, bits, ks);
         dat->block = (block128_f)aes_t4_encrypt;
         switch (bits) {
@@ -73,16 +73,14 @@ static int cipher_hw_aes_t4_initkey(PROV_CIPHER_CTX *dat,
                 dat->stream.cbc = NULL;
             break;
         default:
-            ret = -1;
+            ret = 0;
         }
     }
 
-    if (ret < 0) {
+    if (!ret)
         ERR_raise(ERR_LIB_PROV, PROV_R_AES_KEY_SETUP_FAILED);
-        return 0;
-    }
 
-    return 1;
+    return ret;
 }
 
 #define PROV_CIPHER_HW_declare(mode)                                           \

--- a/providers/common/ciphers/cipher_ccm.c
+++ b/providers/common/ciphers/cipher_ccm.c
@@ -278,11 +278,11 @@ int ccm_cipher(void *vctx,
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     if (ccm_cipher_internal(ctx, out, outl, in, inl) <= 0)
-        return -1;
+        return 0;
 
     *outl = inl;
     return 1;

--- a/providers/common/ciphers/cipher_gcm.c
+++ b/providers/common/ciphers/cipher_gcm.c
@@ -231,12 +231,12 @@ int gcm_stream_update(void *vctx, unsigned char *out, size_t *outl,
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     if (gcm_cipher_internal(ctx, out, outl, in, inl) <= 0) {
         ERR_raise(ERR_LIB_PROV, PROV_R_CIPHER_OPERATION_FAILED);
-        return -1;
+        return 0;
     }
     return 1;
 }
@@ -263,11 +263,11 @@ int gcm_cipher(void *vctx,
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     if (gcm_cipher_internal(ctx, out, outl, in, inl) <= 0)
-        return -1;
+        return 0;
 
     *outl = inl;
     return 1;

--- a/providers/common/ciphers/cipher_gcm_hw.c
+++ b/providers/common/ciphers/cipher_gcm_hw.c
@@ -61,7 +61,7 @@ int gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
                 size_t res = (16 - ctx->gcm.mres) % 16;
 
                 if (CRYPTO_gcm128_decrypt(&ctx->gcm, in, out, res))
-                    return -1;
+                    return 0;
 
                 bulk = aesni_gcm_decrypt(in + res, out + res, len - res,
                                          ctx->gcm.key,

--- a/providers/default/ciphers/cipher_camellia_hw_t4.inc
+++ b/providers/default/ciphers/cipher_camellia_hw_t4.inc
@@ -27,6 +27,7 @@ static int cipher_hw_camellia_t4_initkey(PROV_CIPHER_CTX *dat,
 
     if (dat->enc || (mode != EVP_CIPH_ECB_MODE && mode != EVP_CIPH_CBC_MODE)) {
         dat->block = (block128_f) cmll_t4_encrypt;
+        ret = 1;
         switch (bits) {
         case 128:
             if (mode == EVP_CIPH_CBC_MODE)
@@ -46,11 +47,12 @@ static int cipher_hw_camellia_t4_initkey(PROV_CIPHER_CTX *dat,
                 dat->stream.cbc = NULL;
             break;
         default:
-            ret = -1;
+            ret = 0;
             break;
         }
     } else {
         dat->block = (block128_f) cmll_t4_decrypt;
+        ret = 1;
         switch (bits) {
         case 128:
             dat->stream.cbc = mode == EVP_CIPH_CBC_MODE ?
@@ -62,15 +64,14 @@ static int cipher_hw_camellia_t4_initkey(PROV_CIPHER_CTX *dat,
                 (cbc128_f) cmll256_t4_cbc_decrypt : NULL;
             break;
         default:
-            ret = -1;
+            ret = 0;
             break;
         }
     }
-    if (ret < 0) {
+    if (!ret)
         ERR_raise(ERR_LIB_PROV, EVP_R_CAMELLIA_KEY_SETUP_FAILED);
-        return 0;
-    }
-    return 1;
+
+    return ret;
 }
 
 #define PROV_CIPHER_HW_declare(mode)                                           \

--- a/providers/default/ciphers/cipher_tdes_wrap.c
+++ b/providers/default/ciphers/cipher_tdes_wrap.c
@@ -131,7 +131,7 @@ static int tdes_wrap_cipher(void *vctx,
     *outl = 0;
     if (outsize < inl) {
         PROVerr(0, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     ret = tdes_wrap_cipher_internal(ctx, out, in, inl);


### PR DESCRIPTION
…rror

EVP_Cipher() is undocumented, but study of previous OpenSSL versions,
it's clear that it is supposed to return the length of the encrypted
or decrypted content, and that 0 is a permissible output length,
leaving -1 for errors.

The corresponding provider dispatched function has different
semantics, where it returns 0 on error and 1 on success, and sets the
output length to one of it's writable parameters.  We therefore need
to "translate" those returned values to EVP_Cipher() semantics.
