### PR TITLE
Fix EVP_Cipher() for provided cipher implementations

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -25,6 +25,7 @@ EVP_DecryptInit,
 EVP_DecryptFinal,
 EVP_CipherInit,
 EVP_CipherFinal,
+EVP_Cipher,
 EVP_get_cipherbyname,
 EVP_get_cipherbynid,
 EVP_get_cipherbyobj,
@@ -106,6 +107,9 @@ EVP_CIPHER_do_all_ex
  int EVP_CipherInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                     const unsigned char *key, const unsigned char *iv, int enc);
  int EVP_CipherFinal(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+
+ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                const unsigned char *in, unsigned int inl);
 
  int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *x, int padding);
  int EVP_CIPHER_CTX_set_key_length(EVP_CIPHER_CTX *x, int keylen);
@@ -251,6 +255,16 @@ EVP_CipherFinal_ex(). In previous releases they also cleaned up
 the B<ctx>, but this is no longer done and EVP_CIPHER_CTX_clean()
 must be called to free any context resources.
 
+EVP_Cipher() encrypts or decrypts a maximum I<inl> amount of bytes from I<in>
+and leaving the result in I<out>.
+If the cipher has the flag B<EVP_CIPH_FLAG_CUSTOM_CIPHER> set, then all I<inl>
+are guaranteed to be consumed, otherwise it's undefined if more than a multiple
+of EVP_CIPHER_block_size() bytes are consumed (in other words, a remainder of
+C<inl % EVP_CIPHER_block_size()> may remain unconsumed).  The safest is to
+ensure that I<inl> always is a multiple of EVP_CIPHER_block_size().
+No buffering is guaranteed with this function.  If you want guaranteed
+buffering, consider using the Update and Final functions instead.
+
 EVP_get_cipherbyname(), EVP_get_cipherbynid() and EVP_get_cipherbyobj()
 return an EVP_CIPHER structure when passed a cipher name, a NID or an
 ASN1_OBJECT structure.
@@ -387,6 +401,11 @@ EVP_DecryptFinal_ex() returns 0 if the decrypt failed or 1 for success.
 
 EVP_CipherInit_ex() and EVP_CipherUpdate() return 1 for success and 0 for failure.
 EVP_CipherFinal_ex() returns 0 for a decryption failure or 1 for success.
+
+EVP_Cipher() returns the amount of encrypted / decrypted bytes, or -1
+on failure, if the flag B<EVP_CIPH_FLAG_CUSTOM_CIPHER> is set for the
+cipher.  EVP_Cipher() returns 1 on success or 0 on failure, if the flag
+B<EVP_CIPH_FLAG_CUSTOM_CIPHER> is not set for the cipher.
 
 EVP_CIPHER_CTX_reset() returns 1 for success and 0 for failure.
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -256,7 +256,7 @@ the B<ctx>, but this is no longer done and EVP_CIPHER_CTX_clean()
 must be called to free any context resources.
 
 EVP_Cipher() encrypts or decrypts a maximum I<inl> amount of bytes from
-I<in> and leaving the result in I<out>.
+I<in> and leaves the result in I<out>.
 If the cipher doesn't have the flag B<EVP_CIPH_FLAG_CUSTOM_CIPHER> set,
 then I<inl> must be a multiple of EVP_CIPHER_block_size().  If it isn't,
 the result is undefined.  If the cipher has that flag set, then I<inl>

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -262,7 +262,7 @@ then I<inl> must be a multiple of EVP_CIPHER_block_size().  If it isn't,
 the result is undefined.  If the cipher has that flag set, then I<inl>
 can be any size.
 This function is historic and shouldn't be used in an application, please
-consider using Update and Final functions instead.
+consider using EVP_CipherUpdate(), and EVP_CipherFinal_ex instead.
 
 EVP_get_cipherbyname(), EVP_get_cipherbynid() and EVP_get_cipherbyobj()
 return an EVP_CIPHER structure when passed a cipher name, a NID or an

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -262,7 +262,7 @@ then I<inl> must be a multiple of EVP_CIPHER_block_size().  If it isn't,
 the result is undefined.  If the cipher has that flag set, then I<inl>
 can be any size.
 This function is historic and shouldn't be used in an application, please
-consider using EVP_CipherUpdate(), and EVP_CipherFinal_ex instead.
+consider using EVP_CipherUpdate() and EVP_CipherFinal_ex instead.
 
 EVP_get_cipherbyname(), EVP_get_cipherbynid() and EVP_get_cipherbyobj()
 return an EVP_CIPHER structure when passed a cipher name, a NID or an

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -255,15 +255,14 @@ EVP_CipherFinal_ex(). In previous releases they also cleaned up
 the B<ctx>, but this is no longer done and EVP_CIPHER_CTX_clean()
 must be called to free any context resources.
 
-EVP_Cipher() encrypts or decrypts a maximum I<inl> amount of bytes from I<in>
-and leaving the result in I<out>.
-If the cipher has the flag B<EVP_CIPH_FLAG_CUSTOM_CIPHER> set, then all I<inl>
-are guaranteed to be consumed, otherwise it's undefined if more than a multiple
-of EVP_CIPHER_block_size() bytes are consumed (in other words, a remainder of
-C<inl % EVP_CIPHER_block_size()> may remain unconsumed).  The safest is to
-ensure that I<inl> always is a multiple of EVP_CIPHER_block_size().
-No buffering is guaranteed with this function.  If you want guaranteed
-buffering, consider using the Update and Final functions instead.
+EVP_Cipher() encrypts or decrypts a maximum I<inl> amount of bytes from
+I<in> and leaving the result in I<out>.
+If the cipher doesn't have the flag B<EVP_CIPH_FLAG_CUSTOM_CIPHER> set,
+then I<inl> must be a multiple of EVP_CIPHER_block_size().  If it isn't,
+the result is undefined.  If the cipher has that flag set, then I<inl>
+can be any size.
+This function is historic and shouldn't be used in an application, please
+consider using Update and Final functions instead.
 
 EVP_get_cipherbyname(), EVP_get_cipherbynid() and EVP_get_cipherbyobj()
 return an EVP_CIPHER structure when passed a cipher name, a NID or an

--- a/providers/common/ciphers/cipher_ccm.c
+++ b/providers/common/ciphers/cipher_ccm.c
@@ -278,11 +278,11 @@ int ccm_cipher(void *vctx,
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     if (ccm_cipher_internal(ctx, out, outl, in, inl) <= 0)
-        return -1;
+        return 0;
 
     *outl = inl;
     return 1;

--- a/providers/common/ciphers/cipher_gcm.c
+++ b/providers/common/ciphers/cipher_gcm.c
@@ -263,11 +263,11 @@ int gcm_cipher(void *vctx,
 
     if (outsize < inl) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     if (gcm_cipher_internal(ctx, out, outl, in, inl) <= 0)
-        return -1;
+        return 0;
 
     *outl = inl;
     return 1;

--- a/providers/common/include/prov/cipher_aead.h
+++ b/providers/common/include/prov/cipher_aead.h
@@ -12,7 +12,6 @@
 /* TODO(3.0) Figure out what flags are really needed */
 #define AEAD_FLAGS (EVP_CIPH_FLAG_AEAD_CIPHER           \
                     | EVP_CIPH_CUSTOM_IV                \
-                    | EVP_CIPH_FLAG_CUSTOM_CIPHER       \
                     | EVP_CIPH_ALWAYS_CALL_INIT         \
                     | EVP_CIPH_CTRL_INIT                \
                     | EVP_CIPH_CUSTOM_COPY)

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -16,9 +16,8 @@
 #define AES_WRAP_NOPAD_IVLEN 8
 
 /* TODO(3.0) Figure out what flags need to be passed */
-#define WRAP_FLAGS (EVP_CIPH_WRAP_MODE \
-                   | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER \
-                   | EVP_CIPH_ALWAYS_CALL_INIT)
+#define WRAP_FLAGS (EVP_CIPH_WRAP_MODE | EVP_CIPH_CUSTOM_IV \
+                    | EVP_CIPH_ALWAYS_CALL_INIT)
 
 typedef size_t (*aeswrap_fn)(void *key, const unsigned char *iv,
                              unsigned char *out, const unsigned char *in,

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -129,7 +129,7 @@ static int tdes_wrap_cipher(void *vctx,
     *outl = 0;
     if (outsize < inl) {
         PROVerr(0, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
-        return -1;
+        return 0;
     }
 
     ret = tdes_wrap_cipher_internal(ctx, out, in, inl);

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -15,9 +15,7 @@
 #include "prov/providercommonerr.h"
 
 /* TODO (3.0) Figure out what flags are requred */
-#define TDES_WRAP_FLAGS (EVP_CIPH_WRAP_MODE             \
-                         | EVP_CIPH_CUSTOM_IV           \
-                         | EVP_CIPH_FLAG_CUSTOM_CIPHER)
+#define TDES_WRAP_FLAGS (EVP_CIPH_WRAP_MODE | EVP_CIPH_CUSTOM_IV)
 
 
 static OSSL_OP_cipher_update_fn tdes_wrap_update;


### PR DESCRIPTION
EVP_Cipher() would return whatever ctx->cipher->ccipher() returned
with no regard for historical semantics.

We change this to first look if there is a ctx->cipher->ccipher(), and
in that case we treat the implementation as one with a custom cipher,
and "translate" it's return value like this: 0 => -1, 1 => outl, where
|outl| is the output length.

If there is no ctx->cipher->ccipher, we treat the implementation as
one without a custom cipher, call ctx->cipher->cupdate or
ctx->cipher->cfinal depending on input, and return whatever they
return (0 or 1).

Furthermore, we add a small hack in EVP_CIPHER_flags() to check if the
cipher is a provided one, and add EVP_CIPH_FLAG_CUSTOM_CIPHER to the
flags to be returned if there is a cipher->ccipher.  That way,
provided implementations never have to set that flag themselves, all
they need to do is to include a OSSL_FUNC_CIPHER_CIPHER function.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
