### PR TITLE
Stop using EVP_MD_CTX_FLAG_NON_FIPS_ALLOW

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -13,6 +13,7 @@
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <openssl/core_names.h>
 #include "crypto/x509.h"
 
 int X509_issuer_and_serial_cmp(const X509 *a, const X509 *b)
@@ -205,23 +206,26 @@ unsigned long X509_NAME_hash(X509_NAME *x)
 
 unsigned long X509_NAME_hash_old(X509_NAME *x)
 {
+    EVP_MD *md5 = EVP_MD_fetch(NULL, OSSL_DIGEST_NAME_MD5, "-fips");
     EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
     unsigned long ret = 0;
     unsigned char md[16];
 
-    if (md_ctx == NULL)
-        return ret;
+    if (md5 == NULL || md_ctx == NULL)
+        goto end;
 
     /* Make sure X509_NAME structure contains valid cached encoding */
     i2d_X509_NAME(x, NULL);
-    EVP_MD_CTX_set_flags(md_ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-    if (EVP_DigestInit_ex(md_ctx, EVP_md5(), NULL)
+    if (EVP_DigestInit_ex(md_ctx, md5, NULL)
         && EVP_DigestUpdate(md_ctx, x->bytes->data, x->bytes->length)
         && EVP_DigestFinal_ex(md_ctx, md, NULL))
         ret = (((unsigned long)md[0]) | ((unsigned long)md[1] << 8L) |
                ((unsigned long)md[2] << 16L) | ((unsigned long)md[3] << 24L)
             ) & 0xffffffffL;
+
+ end:
     EVP_MD_CTX_free(md_ctx);
+    EVP_MD_free(md5);
 
     return ret;
 }

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -81,6 +81,7 @@ extern "C" {
 #define OSSL_DIGEST_PARAM_FLAGS      "flags"     /* ulong */
 
 /* Known DIGEST names (not a complete list) */
+#define OSSL_DIGEST_NAME_MD5 "MD5"
 #define OSSL_DIGEST_NAME_KECCAK_KMAC128 "KECCAK_KMAC128"
 #define OSSL_DIGEST_NAME_KECCAK_KMAC256 "KECCAK_KMAC256"
 

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -17,6 +17,7 @@
 
 static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
 {
+    EVP_MD *md5;
     EVP_MD_CTX *m5;
     EVP_MD_CTX *s1;
     unsigned char buf[16], smd[SHA_DIGEST_LENGTH];
@@ -28,14 +29,14 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
     c = os_toascii[c];          /* 'A' in ASCII */
 #endif
     k = 0;
+    md5 = EVP_MD_fetch(NULL, OSSL_DIGEST_NAME_MD5, "-fips");
     m5 = EVP_MD_CTX_new();
     s1 = EVP_MD_CTX_new();
-    if (m5 == NULL || s1 == NULL) {
+    if (md5 == NULL || m5 == NULL || s1 == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL3_GENERATE_KEY_BLOCK,
                  ERR_R_MALLOC_FAILURE);
         goto err;
     }
-    EVP_MD_CTX_set_flags(m5, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
     for (i = 0; (int)i < num; i += MD5_DIGEST_LENGTH) {
         k++;
         if (k > sizeof(buf)) {
@@ -55,7 +56,7 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
             || !EVP_DigestUpdate(s1, s->s3.server_random, SSL3_RANDOM_SIZE)
             || !EVP_DigestUpdate(s1, s->s3.client_random, SSL3_RANDOM_SIZE)
             || !EVP_DigestFinal_ex(s1, smd, NULL)
-            || !EVP_DigestInit_ex(m5, EVP_md5(), NULL)
+            || !EVP_DigestInit_ex(m5, md5, NULL)
             || !EVP_DigestUpdate(m5, s->session->master_key,
                                  s->session->master_key_length)
             || !EVP_DigestUpdate(m5, smd, SHA_DIGEST_LENGTH)) {
@@ -85,6 +86,7 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
  err:
     EVP_MD_CTX_free(m5);
     EVP_MD_CTX_free(s1);
+    EVP_MD_free(md5);
     return ret;
 }
 


### PR DESCRIPTION
This is a flag that has lost its relevance.  The new mechanism to do
the same thing is to fetch the needed digest explicitly with "-fips"
as property query, i.e. we remove any requirement for that property to
be set when fetching, even if the default property query string
requires its presence.
