### PR TITLE
[ec_asn1.c] Avoid injecting seed when built-in matches

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -855,6 +855,20 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
          * serialized using explicit parameters by default.
          */
         EC_GROUP_set_asn1_flag(ret, OPENSSL_EC_EXPLICIT_CURVE);
+
+        /*
+         * If the input params do not contain the optional seed field we make
+         * sure it is not added to the returned group.
+         *
+         * The seed field is not really used inside libcrypto anyway, and
+         * adding it to parsed explicit parameter keys would alter their DER
+         * encoding output (because of the extra field) which could impact
+         * applications fingerprinting keys by their DER encoding.
+         */
+        if (params->curve->seed == NULL) {
+            if (EC_GROUP_set_seed(ret, NULL, 0) != 1)
+                goto err;
+        }
     }
 
     ok = 1;


### PR DESCRIPTION
An unintended consequence of https://github.com/openssl/openssl/pull/9808
is that when an explicit parameters curve is matched against one of the
well-known builtin curves we automatically inherit also the associated
seed parameter, even if the the input parameters excluded such
parameter.

This later affects the serialization of such parsed keys, causing their
input DER encoding and output DER encoding to differ due to the
additional optional field.

This does not cause problems internally but could affect external
applications, as reported in
https://github.com/openssl/openssl/pull/9811#issuecomment-536153288

This commit fixes the issue by conditionally clearing the seed field if
the original input parameters did not include it.

## Backport

This commit cherry-picks cleanly into `1.1.1` and `1.1.0`, and trvially in `1.0.2` (for which #10141 has been opened).

## Checklist

- [ ] ~~needs a `CHANGES` entry?~~
