### PR TITLE
KBKDF Feedback mode + CMAC support

### DIFF
--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -199,7 +199,8 @@ int CMAC_Final(CMAC_CTX *ctx, unsigned char *out, size_t *poutlen)
         return 0;
     if ((bl = EVP_CIPHER_CTX_block_size(ctx->cctx)) < 0)
         return 0;
-    *poutlen = (size_t)bl;
+    if (poutlen != NULL)
+        *poutlen = (size_t)bl;
     if (!out)
         return 1;
     lb = ctx->nlast_block;

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2694,6 +2694,7 @@ PROV_R_INVALID_MAC:151:invalid mac
 PROV_R_INVALID_MODE:125:invalid mode
 PROV_R_INVALID_MODE_INT:126:invalid mode int
 PROV_R_INVALID_SALT_LENGTH:112:invalid salt length
+PROV_R_INVALID_SEED_LENGTH:154:invalid seed length
 PROV_R_INVALID_TAG:110:invalid tag
 PROV_R_INVALID_TAGLEN:118:invalid taglen
 PROV_R_MISSING_CEK_ALG:144:missing cek alg

--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -21,17 +21,17 @@ The supported parameters are:
 
 =over 4
 
-=item B<OSSL_KDF_PARAM_PROPERTIES> ("properties") <UTF8 string>
+=item "properties" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
 
-=item B<OSSL_KDF_PARAM_DIGEST> ("digest") <UTF8 string>
+=item "digest" (B<OSSL_KDF_PARAM_DIGEST>) <UTF8 string>
 
-=item B<OSSL_KDF_PARAM_DIGEST> ("mac") <UTF8 string>
+=item "mac" (B<OSSL_KDF_PARAM_MAC>) <UTF8 string>
 
-=item B<OSSL_KDF_PARAM_KEY> ("key") <octet string>
+=item "key" (B<OSSL_KDF_PARAM_KEY>) <octet string>
 
-=item B<OSSL_KDF_PARAM_SALT> ("salt") <octet string>
+=item "salt" (B<OSSL_KDF_PARAM_SALT>) <octet string>
 
-=item B<OSSL_KDF_PARAM_INFO> ("info") <octet string>
+=item "info (B<OSSL_KDF_PARAM_INFO>) <octet string>
 
 =back
 

--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -23,9 +23,13 @@ The supported parameters are:
 
 =item "properties" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
 
-=item "digest" (B<OSSL_KDF_PARAM_DIGEST>) <UTF8 string>
+=item "mode" (B<OSSL_KDF_PARAM_MODE>) <UTF8 string>
 
 =item "mac" (B<OSSL_KDF_PARAM_MAC>) <UTF8 string>
+
+=item "digest" (B<OSSL_KDF_PARAM_DIGEST>) <UTF8 string>
+
+=item "cipher" (B<OSSL_KDF_PARAM_DIGEST>) <UTF8 string>
 
 =item "key" (B<OSSL_KDF_PARAM_KEY>) <octet string>
 
@@ -33,11 +37,20 @@ The supported parameters are:
 
 =item "info (B<OSSL_KDF_PARAM_INFO>) <octet string>
 
+=item "seed" (B<OSSL_KDF_PARAM_SEED>) <octet string>
+
 =back
 
-The parameters key, salt, and info correspond to KI, Label, and Context
-(respectively) in SP800-108.  As in that document, salt and info are optional
-and may be omitted.  Currently, only HMAC is supported for mac.
+The mode parameter determines which flavor of KBKDF to use - currently the
+choices are "counter" and "feedback".  Counter is the default, and will be
+used if unspecified.  The seed parameter is unused in counter mode.
+
+The parameters key, salt, info, and seed correspond to KI, Label, Context, and
+IV (respectively) in SP800-108.  As in that document, salt, info, and seed are
+optional and may be omitted.
+
+Depending on whether mac is CMAC or HMAC, either digest or cipher is required
+(respectively) and the other is unused.
 
 =head1 NOTES
 
@@ -49,7 +62,7 @@ A context for KBKDF can be obtained by calling:
 The output length of an KBKDF is specified via the C<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.
 
-Note that currently OpenSSL only implements Counter mode with HMAC.  Other
+Note that currently OpenSSL only implements counter and feedback modes.  Other
 variants may be supported in the future.
 
 =head1 EXAMPLES
@@ -84,9 +97,41 @@ Label "label", and Context "context".
 
  EVP_KDF_CTX_free(kctx);
 
+This example derives 10 bytes using FEEDBACK-CMAC-AES256, with KI "secret",
+Label "label", and IV "sixteen bytes iv".
+
+ EVP_KDF *kdf;
+ EVP_KDF_CTX *kctx;
+ unsigned char out[10];
+ OSSL_PARAM params[8], *p = params;
+ unsigned char *iv = "sixteen bytes iv";
+
+ kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
+ kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_free(kdf);
+
+ *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER, "AES256", 0);
+ *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC, "CMAC", 0);
+ *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MODE, "FEEDBACK", 0);
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+                                          "secret", strlen("secret"));
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
+                                          "context", strlen("context"));
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                                          "label", strlen("label"));
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
+                                          iv, strlen(iv));
+ *p = OSSL_PARAM_construct_end();
+ if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
+     error("EVP_KDF_CTX_set_params");
+ else if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0)
+     error("EVP_KDF_derive");
+
+ EVP_KDF_CTX_free(kctx);
+
 =head1 CONFORMING TO
 
-NIST SP800-108, IETF RFC 8009.
+NIST SP800-108, IETF RFC 6803, IETF RFC 8009.
 
 =head1 SEE ALSO
 

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -113,6 +113,7 @@ extern "C" {
 #define OSSL_KDF_PARAM_SALT         "salt"      /* octet string */
 #define OSSL_KDF_PARAM_PASSWORD     "pass"      /* octet string */
 #define OSSL_KDF_PARAM_DIGEST       OSSL_ALG_PARAM_DIGEST     /* utf8 string */
+#define OSSL_KDF_PARAM_CIPHER       OSSL_ALG_PARAM_CIPHER     /* utf8 string */
 #define OSSL_KDF_PARAM_MAC          OSSL_ALG_PARAM_MAC        /* utf8 string */
 #define OSSL_KDF_PARAM_MAC_SIZE     "maclen"    /* size_t */
 #define OSSL_KDF_PARAM_PROPERTIES   OSSL_ALG_PARAM_PROPERTIES /* utf8 string */

--- a/providers/common/include/prov/providercommonerr.h
+++ b/providers/common/include/prov/providercommonerr.h
@@ -73,6 +73,7 @@ int ERR_load_PROV_strings(void);
 # define PROV_R_INVALID_MODE                              125
 # define PROV_R_INVALID_MODE_INT                          126
 # define PROV_R_INVALID_SALT_LENGTH                       112
+# define PROV_R_INVALID_SEED_LENGTH                       154
 # define PROV_R_INVALID_TAG                               110
 # define PROV_R_INVALID_TAGLEN                            118
 # define PROV_R_MISSING_CEK_ALG                           144

--- a/providers/common/provider_err.c
+++ b/providers/common/provider_err.c
@@ -49,6 +49,8 @@ static const ERR_STRING_DATA PROV_str_reasons[] = {
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_INVALID_MODE_INT), "invalid mode int"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_INVALID_SALT_LENGTH),
     "invalid salt length"},
+    {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_INVALID_SEED_LENGTH),
+    "invalid seed length"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_INVALID_TAG), "invalid tag"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_INVALID_TAGLEN), "invalid taglen"},
     {ERR_PACK(ERR_LIB_PROV, 0, PROV_R_MISSING_CEK_ALG), "missing cek alg"},

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -214,7 +214,7 @@ int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
         *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
                                                  (char *)mdname, 0);
     if (ciphername != NULL)
-        *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+        *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
                                                  (char *)ciphername, 0);
     if (properties != NULL)
         *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -297,6 +297,131 @@ static int test_kdf_x963(void)
     return ret;
 }
 
+/*
+ * KBKDF test vectors from RFC 6803 (Camellia Encryption for Kerberos 5)
+ * section 10.
+ */
+static int test_kdf_kbkdf_6803_128(void)
+{
+    int ret = 0, i, p;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM params[7];
+    static unsigned char input_key[] = {
+        0x57, 0xD0, 0x29, 0x72, 0x98, 0xFF, 0xD9, 0xD3,
+        0x5D, 0xE5, 0xA4, 0x7F, 0xB4, 0xBD, 0xE2, 0x4B,
+    };
+    static unsigned char constants[][5] = {
+        { 0x00, 0x00, 0x00, 0x02, 0x99 },
+        { 0x00, 0x00, 0x00, 0x02, 0xaa },
+        { 0x00, 0x00, 0x00, 0x02, 0x55 },
+    };
+    static unsigned char outputs[][16] = {
+        {0xD1, 0x55, 0x77, 0x5A, 0x20, 0x9D, 0x05, 0xF0,
+         0x2B, 0x38, 0xD4, 0x2A, 0x38, 0x9E, 0x5A, 0x56},
+        {0x64, 0xDF, 0x83, 0xF8, 0x5A, 0x53, 0x2F, 0x17,
+         0x57, 0x7D, 0x8C, 0x37, 0x03, 0x57, 0x96, 0xAB},
+        {0x3E, 0x4F, 0xBD, 0xF3, 0x0F, 0xB8, 0x25, 0x9C,
+         0x42, 0x5C, 0xB6, 0xC9, 0x6F, 0x1F, 0x46, 0x35}
+    };
+    static unsigned char iv[16] = { 0 };
+    unsigned char result[16] = { 0 };
+
+    for (i = 0; i < 3; i++) {
+        p = 0;
+        params[p++] = OSSL_PARAM_construct_utf8_string(
+            OSSL_KDF_PARAM_CIPHER, "CAMELLIA-128-CBC", 0);
+        params[p++] = OSSL_PARAM_construct_utf8_string(
+            OSSL_KDF_PARAM_MAC, "CMAC", 0);
+        params[p++] = OSSL_PARAM_construct_utf8_string(
+            OSSL_KDF_PARAM_MODE, "FEEDBACK", 0);
+        params[p++] = OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_KEY, input_key, sizeof(input_key));
+        params[p++] = OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_SALT, constants[i], sizeof(constants[i]));
+        params[p++] = OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_SEED, iv, sizeof(iv));
+        params[p] = OSSL_PARAM_construct_end();
+
+        kctx = get_kdfbyname("KBKDF");
+        ret = TEST_ptr(kctx)
+            && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+            && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
+            && TEST_mem_eq(result, sizeof(result), outputs[i],
+                           sizeof(outputs[i]));
+        EVP_KDF_CTX_free(kctx);
+        if (ret != 1)
+            return ret;
+    }
+
+    return ret;
+}
+
+static int test_kdf_kbkdf_6803_256(void)
+{
+    int ret = 0, i, p;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM params[7];
+    static unsigned char input_key[] = {
+        0xB9, 0xD6, 0x82, 0x8B, 0x20, 0x56, 0xB7, 0xBE,
+        0x65, 0x6D, 0x88, 0xA1, 0x23, 0xB1, 0xFA, 0xC6,
+        0x82, 0x14, 0xAC, 0x2B, 0x72, 0x7E, 0xCF, 0x5F,
+        0x69, 0xAF, 0xE0, 0xC4, 0xDF, 0x2A, 0x6D, 0x2C,
+    };
+    static unsigned char constants[][5] = {
+        { 0x00, 0x00, 0x00, 0x02, 0x99 },
+        { 0x00, 0x00, 0x00, 0x02, 0xaa },
+        { 0x00, 0x00, 0x00, 0x02, 0x55 },
+    };
+    static unsigned char outputs[][32] = {
+        {0xE4, 0x67, 0xF9, 0xA9, 0x55, 0x2B, 0xC7, 0xD3,
+         0x15, 0x5A, 0x62, 0x20, 0xAF, 0x9C, 0x19, 0x22,
+         0x0E, 0xEE, 0xD4, 0xFF, 0x78, 0xB0, 0xD1, 0xE6,
+         0xA1, 0x54, 0x49, 0x91, 0x46, 0x1A, 0x9E, 0x50,
+        },
+        {0x41, 0x2A, 0xEF, 0xC3, 0x62, 0xA7, 0x28, 0x5F,
+         0xC3, 0x96, 0x6C, 0x6A, 0x51, 0x81, 0xE7, 0x60,
+         0x5A, 0xE6, 0x75, 0x23, 0x5B, 0x6D, 0x54, 0x9F,
+         0xBF, 0xC9, 0xAB, 0x66, 0x30, 0xA4, 0xC6, 0x04,
+        },
+        {0xFA, 0x62, 0x4F, 0xA0, 0xE5, 0x23, 0x99, 0x3F,
+         0xA3, 0x88, 0xAE, 0xFD, 0xC6, 0x7E, 0x67, 0xEB,
+         0xCD, 0x8C, 0x08, 0xE8, 0xA0, 0x24, 0x6B, 0x1D,
+         0x73, 0xB0, 0xD1, 0xDD, 0x9F, 0xC5, 0x82, 0xB0,
+        },
+    };
+    static unsigned char iv[16] = { 0 };
+    unsigned char result[32] = { 0 };
+
+    for (i = 0; i < 3; i++) {
+        p = 0;
+        params[p++] = OSSL_PARAM_construct_utf8_string(
+            OSSL_KDF_PARAM_CIPHER, "CAMELLIA-256-CBC", 0);
+        params[p++] = OSSL_PARAM_construct_utf8_string(
+            OSSL_KDF_PARAM_MAC, "CMAC", 0);
+        params[p++] = OSSL_PARAM_construct_utf8_string(
+            OSSL_KDF_PARAM_MODE, "FEEDBACK", 0);
+        params[p++] = OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_KEY, input_key, sizeof(input_key));
+        params[p++] = OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_SALT, constants[i], sizeof(constants[i]));
+        params[p++] = OSSL_PARAM_construct_octet_string(
+            OSSL_KDF_PARAM_SEED, iv, sizeof(iv));
+        params[p] = OSSL_PARAM_construct_end();
+
+        kctx = get_kdfbyname("KBKDF");
+        ret = TEST_ptr(kctx)
+            && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+            && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
+            && TEST_mem_eq(result, sizeof(result), outputs[i],
+                           sizeof(outputs[i]));
+        EVP_KDF_CTX_free(kctx);
+        if (ret != 1)
+            return ret;
+    }
+
+    return ret;
+}
+
 /* Two test vectors from RFC 8009 (AES Encryption with HMAC-SHA2 for Kerberos
  * 5) appendix A. */
 static int test_kdf_kbkdf_8009_prf1(void)
@@ -609,6 +734,8 @@ static int test_kdf_x942_asn1(void)
 
 int setup_tests(void)
 {
+    ADD_TEST(test_kdf_kbkdf_6803_128);
+    ADD_TEST(test_kdf_kbkdf_6803_256);
     ADD_TEST(test_kdf_kbkdf_8009_prf1);
     ADD_TEST(test_kdf_kbkdf_8009_prf2);
     ADD_TEST(test_kdf_get_kdf);


### PR DESCRIPTION
This is the final remaining KDF that Kerberos needs for modern operation: SP800-108 section 5.2 (feedback mode) using CMAC, as specified in RFC 6803.  Test vectors from RFC 6803 are included.

The first commit is a bugfix without which I can't set the cipher for CMAC.  The second could be worked around, but is inconvenient.  The third commit is the actual change.  I've grouped them since the change as written depends on the bugfixes in the first two, but could break them out into dependent PRs if that would be preferred.

krb5 test build branch (uses counter-hmac and feedback-cmac) created at https://github.com/frozencemetery/krb5/tree/800-108test

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
