### PR TITLE
Building: Add modules with DEPENDs to GENERATEd files

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -775,10 +775,14 @@ EOF
 	      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                    "util", "dofile.pl")),
                                    rel2abs($config{builddir}));
+              my @modules = ( 'configdata.pm',
+                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+              my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
+              @modules = map { '"-M'.basename($_, '.pm').'"' } @modules;
+              my $modules = join(' ', '', sort keys %moduleincs, @modules);
               return <<"EOF";
 $target : $args{generator}->[0] $deps
-	\$(PERL) "-I\$(BLDDIR)" "-Mconfigdata" $dofile \\
-	    "-o$target{build_file}" $generator > \$\@
+	\$(PERL)$modules $dofile "-o$target{build_file}" $generator > \$\@
 EOF
 	  } else {
               return <<"EOF";

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -966,10 +966,14 @@ EOF
               my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                    "util", "dofile.pl")),
                                    rel2abs($config{builddir}));
+              my @modules = ( 'configdata.pm',
+                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+              my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
+              @modules = map { "-M".basename($_, '.pm') } @modules;
+              my $modules = join(' ', '', sort keys %moduleincs, @modules);
               return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	\$(PERL) "-I\$(BLDDIR)" -Mconfigdata "$dofile" \\
-	    "-o$target{build_file}" $generator > \$@
+$args{src}: $args{generator}->[0] $deps \$(BLDDIR)/configdata.pm
+	\$(PERL)$modules "$dofile" "-o$target{build_file}" $generator > \$@
 EOF
 	  } else {
               return <<"EOF";

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -558,10 +558,14 @@ EOF
               my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                    "util", "dofile.pl")),
                                    rel2abs($config{builddir}));
+              my @modules = ( 'configdata.pm',
+                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+              my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
+              @modules = map { "-M".basename($_, '.pm') } @modules;
+              my $modules = join(' ', '', sort keys %moduleincs, @modules);
               return <<"EOF";
 $target: "$args{generator}->[0]" $deps
-	"\$(PERL)" "-I\$(BLDDIR)" -Mconfigdata "$dofile" \\
-	    "-o$target{build_file}" $generator > \$@
+	"\$(PERL)"$modules "$dofile" "-o$target{build_file}" $generator > \$@
 EOF
 	  } else {
               return <<"EOF";

--- a/build.info
+++ b/build.info
@@ -11,13 +11,9 @@ DEPEND[libssl]=libcrypto
 # unconditionally before anything else.
 DEPEND[]=include/openssl/opensslconf.h include/crypto/bn_conf.h \
          include/crypto/dso_conf.h doc/man7/openssl_user_macros.pod
-DEPEND[include/openssl/opensslconf.h]=configdata.pm
 GENERATE[include/openssl/opensslconf.h]=include/openssl/opensslconf.h.in
-DEPEND[include/crypto/bn_conf.h]=configdata.pm
 GENERATE[include/crypto/bn_conf.h]=include/crypto/bn_conf.h.in
-DEPEND[include/crypto/dso_conf.h]=configdata.pm
 GENERATE[include/crypto/dso_conf.h]=include/crypto/dso_conf.h.in
-DEPEND[doc/man7/openssl_user_macros.pod]=configdata.pm
 GENERATE[doc/man7/openssl_user_macros.pod]=doc/man7/openssl_user_macros.pod.in
 
 IF[{- defined $target{shared_defflag} -}]

--- a/doc/internal/man7/build.info.pod
+++ b/doc/internal/man7/build.info.pod
@@ -441,7 +441,9 @@ file as last argument.
 
 For I<generator>s where this is applicable, any B<INCLUDE> statement
 for the same I<item> will be given to the I<generator> as its
-inclusion directories.
+inclusion directories.  Likewise, any B<DEPEND> statement for the same
+I<item> will be given to the I<generator> as an extra file or module
+to load, where this is applicable.
 
 The build file generators must be able to recognise the I<generator>.
 Currently, they at least recognise files ending in C<.pl>, and will


### PR DESCRIPTION
For files GENERATEd from templates (.in files), any perl module (.pm
file) that the file depends on will automatically be used.

This means that these two lines:

    GENERATE[foo]=foo.in
    DEPEND[foo]=whatever.pm

will emit this command in a Makefile (or corresponding):

    foo: foo.in whatever.pm configdata.pm
    $(PERL) -I. -Ipathto -Mwhatever -Mconfigdata $(SRCDIR)/util/dofile.pl \\
        foo.in > foo

Note that configdata.pm is automatically added, since util/dofile.pl
itself depends on it.
