### PR TITLE
EVP_{CIPHER,MD}_CTX_ctrl(): make extra sure to return 0 or 1

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -676,7 +676,7 @@ int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
                                                      p2, p1 ? p1 : 9999);
         break;
     default:
-        return EVP_CTRL_RET_UNSUPPORTED;
+        goto conclude;
     }
 
     if (set_params)

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1087,8 +1087,16 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                                               ptr, sz);
         break;
 
+    case EVP_CTRL_INIT:
+        /*
+         * TODO(3.0) EVP_CTRL_INIT is purely legacy, no provider counterpart
+         * As a matter of fact, this should be dead code, but some caller
+         * might still do a direct control call with this command, so...
+         * Legacy methods return 1 except for exceptional circumstances, so
+         * we do the same here to not be disruptive.
+         */
+        return 1;
     case EVP_CTRL_SET_PIPELINE_OUTPUT_BUFS: /* Used by DASYNC */
-    case EVP_CTRL_INIT: /* TODO(3.0) Purely legacy, no provider counterpart */
     default:
         goto end;
     case EVP_CTRL_GET_IV:

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1090,7 +1090,7 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     case EVP_CTRL_SET_PIPELINE_OUTPUT_BUFS: /* Used by DASYNC */
     case EVP_CTRL_INIT: /* TODO(3.0) Purely legacy, no provider counterpart */
     default:
-        return EVP_CTRL_RET_UNSUPPORTED;
+        goto conclude;
     case EVP_CTRL_GET_IV:
         set_params = 0;
         params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
@@ -1127,12 +1127,12 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                                               ptr, sz);
         ret = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);
         if (ret <= 0)
-            return ret;
+            goto conclude;
         params[0] =
             OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, &sz);
         ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
         if (ret <= 0)
-            return 0;
+            goto conclude;
         return sz;
 #ifndef OPENSSL_NO_RC2
     case EVP_CTRL_GET_RC2_KEY_BITS:

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1090,7 +1090,7 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
     case EVP_CTRL_SET_PIPELINE_OUTPUT_BUFS: /* Used by DASYNC */
     case EVP_CTRL_INIT: /* TODO(3.0) Purely legacy, no provider counterpart */
     default:
-        goto conclude;
+        goto end;
     case EVP_CTRL_GET_IV:
         set_params = 0;
         params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV,
@@ -1127,12 +1127,12 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
                                               ptr, sz);
         ret = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);
         if (ret <= 0)
-            goto conclude;
+            goto end;
         params[0] =
             OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, &sz);
         ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
         if (ret <= 0)
-            goto conclude;
+            goto end;
         return sz;
 #ifndef OPENSSL_NO_RC2
     case EVP_CTRL_GET_RC2_KEY_BITS:
@@ -1147,7 +1147,7 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
         ret = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);
     else
         ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
-    goto conclude;
+    goto end;
 
 /* TODO(3.0): Remove legacy code below */
 legacy:
@@ -1158,7 +1158,7 @@ legacy:
 
     ret = ctx->cipher->ctrl(ctx, type, arg, ptr);
 
- conclude:
+ end:
     if (ret == EVP_CTRL_RET_UNSUPPORTED) {
         EVPerr(EVP_F_EVP_CIPHER_CTX_CTRL,
                EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED);


### PR DESCRIPTION
The previous fix (#10108) was incomplete.

Fixes #10106
