### PR TITLE
KEYMGMT: export/import domain parameters

### DIFF
--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -548,7 +548,8 @@ static size_t dh_pkey_dirty_cnt(const EVP_PKEY *pkey)
     return pkey->pkey.dh->dirty_cnt;
 }
 
-static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
+static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
+                               int *is_domainparams)
 {
     DH *dh = pk->pkey.dh;
     OSSL_PARAM_BLD tmpl;
@@ -556,7 +557,7 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     const BIGNUM *pub_key = DH_get0_pub_key(dh);
     const BIGNUM *priv_key = DH_get0_priv_key(dh);
     OSSL_PARAM *params;
-    void *provkey = NULL;
+    void *provdata = NULL;
 
     if (p == NULL || g == NULL)
         return NULL;
@@ -565,19 +566,16 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_P, p)
         || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g))
         return NULL;
-
     if (q != NULL) {
         if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_Q, q))
             return NULL;
     }
 
-    /*
-     * This may be used to pass domain parameters only without any key data -
-     * so "pub_key" is optional. We can never have a "priv_key" without a
-     * corresponding "pub_key" though.
-     */
-    if (pub_key != NULL) {
-        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PUB_KEY, pub_key))
+    *is_domainparams = (pub_key == NULL && priv_key == NULL);
+    if (!*is_domainparams) {
+        /* A key must at least have a public part. */
+        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PUB_KEY,
+                                    pub_key))
             return NULL;
 
         if (priv_key != NULL) {
@@ -590,10 +588,12 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     params = ossl_param_bld_to_param(&tmpl);
 
     /* We export, the provider imports */
-    provkey = evp_keymgmt_importkey(keymgmt, params);
+    provdata = *is_domainparams
+        ? evp_keymgmt_importdomparams(keymgmt, params)
+        : evp_keymgmt_importkey(keymgmt, params);
 
     ossl_param_bld_free(params);
-    return provkey;
+    return provdata;
 }
 
 const EVP_PKEY_ASN1_METHOD dh_asn1_meth = {

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -549,7 +549,7 @@ static size_t dh_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
-                               int *is_domainparams)
+                               int want_domainparams)
 {
     DH *dh = pk->pkey.dh;
     OSSL_PARAM_BLD tmpl;
@@ -571,8 +571,7 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
             return NULL;
     }
 
-    *is_domainparams = (pub_key == NULL && priv_key == NULL);
-    if (!*is_domainparams) {
+    if (!want_domainparams) {
         /* A key must at least have a public part. */
         if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DH_PUB_KEY,
                                     pub_key))
@@ -588,7 +587,7 @@ static void *dh_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
     params = ossl_param_bld_to_param(&tmpl);
 
     /* We export, the provider imports */
-    provdata = *is_domainparams
+    provdata = want_domainparams
         ? evp_keymgmt_importdomparams(keymgmt, params)
         : evp_keymgmt_importkey(keymgmt, params);
 

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -534,7 +534,7 @@ static size_t dsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
-                                int *is_domainparams)
+                                int want_domainparams)
 {
     DSA *dsa = pk->pkey.dsa;
     OSSL_PARAM_BLD tmpl;
@@ -553,8 +553,7 @@ static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
         || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g))
         return NULL;
 
-    *is_domainparams = (pub_key == NULL && priv_key == NULL);
-    if (!*is_domainparams) {
+    if (!want_domainparams) {
         /* A key must at least have a public part. */
         if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DSA_PUB_KEY,
                                     pub_key))
@@ -570,7 +569,7 @@ static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
     params = ossl_param_bld_to_param(&tmpl);
 
     /* We export, the provider imports */
-    provdata = *is_domainparams
+    provdata = want_domainparams
         ? evp_keymgmt_importdomparams(keymgmt, params)
         : evp_keymgmt_importkey(keymgmt, params);
 

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -533,7 +533,8 @@ static size_t dsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
     return pkey->pkey.dsa->dirty_cnt;
 }
 
-static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
+static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
+                                int *is_domainparams)
 {
     DSA *dsa = pk->pkey.dsa;
     OSSL_PARAM_BLD tmpl;
@@ -541,7 +542,7 @@ static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     const BIGNUM *q = DSA_get0_q(dsa), *pub_key = DSA_get0_pub_key(dsa);
     const BIGNUM *priv_key = DSA_get0_priv_key(dsa);
     OSSL_PARAM *params;
-    void *provkey = NULL;
+    void *provdata = NULL;
 
     if (p == NULL || q == NULL || g == NULL)
         return NULL;
@@ -552,12 +553,9 @@ static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
         || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g))
         return NULL;
 
-    /*
-     * This may be used to pass domain parameters only without any key data -
-     * so "pub_key" is optional. We can never have a "priv_key" without a
-     * corresponding "pub_key" though.
-     */
-    if (pub_key != NULL) {
+    *is_domainparams = (pub_key == NULL && priv_key == NULL);
+    if (!*is_domainparams) {
+        /* A key must at least have a public part. */
         if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_DSA_PUB_KEY,
                                     pub_key))
             return NULL;
@@ -572,10 +570,12 @@ static void *dsa_pkey_export_to(const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     params = ossl_param_bld_to_param(&tmpl);
 
     /* We export, the provider imports */
-    provkey = evp_keymgmt_importkey(keymgmt, params);
+    provdata = *is_domainparams
+        ? evp_keymgmt_importdomparams(keymgmt, params)
+        : evp_keymgmt_importkey(keymgmt, params);
 
     ossl_param_bld_free(params);
-    return provkey;
+    return provdata;
 }
 
 /* NB these are sorted in pkey_id order, lowest first */

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -224,7 +224,8 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, EVP_KEYEXCH *exchange)
 
     ctx->op.kex.exchange = exchange;
     if (ctx->pkey != NULL) {
-        provkey = evp_keymgmt_export_to_provider(ctx->pkey, exchange->keymgmt);
+        provkey =
+            evp_keymgmt_export_to_provider(ctx->pkey, exchange->keymgmt, 0);
         if (provkey == NULL) {
             EVPerr(EVP_F_EVP_PKEY_DERIVE_INIT_EX, EVP_R_INITIALIZATION_ERROR);
             goto err;
@@ -283,8 +284,8 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
         return -2;
     }
 
-    provkey = evp_keymgmt_export_to_provider(peer,
-                                             ctx->op.kex.exchange->keymgmt);
+    provkey =
+        evp_keymgmt_export_to_provider(peer, ctx->op.kex.exchange->keymgmt, 0);
     if (provkey == NULL) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE_SET_PEER, ERR_R_INTERNAL_ERROR);
         return 0;

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -52,6 +52,9 @@ static void *allocate_params_space(OSSL_PARAM *params)
     for (space = 0, p = params; p->key != NULL; p++)
         space += ((p->return_size + ALIGN_SIZE - 1) / ALIGN_SIZE) * ALIGN_SIZE;
 
+    if (space == 0)
+        return NULL;
+
     data = OPENSSL_zalloc(space);
 
     for (space = 0, p = params; p->key != NULL; p++) {
@@ -62,9 +65,11 @@ static void *allocate_params_space(OSSL_PARAM *params)
     return data;
 }
 
-void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
+void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
+                                     int want_domainparams)
 {
-    void *provkey = NULL;
+    int is_domainparams = -1;    /* Unknown so far */
+    void *provdata = NULL;
     size_t i, j;
 
     /*
@@ -90,8 +95,9 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     for (i = 0;
          i < OSSL_NELEM(pk->pkeys) && pk->pkeys[i].keymgmt != NULL;
          i++) {
-        if (keymgmt == pk->pkeys[i].keymgmt)
-            return pk->pkeys[i].provkey;
+        if (keymgmt == pk->pkeys[i].keymgmt
+            && want_domainparams == pk->pkeys[i].domainparams)
+            return pk->pkeys[i].provdata;
     }
 
     if (pk->pkey.ptr != NULL) {
@@ -101,11 +107,11 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
         if (pk->ameth->export_to == NULL)
             return NULL;
 
-        /* Otherwise, simply use it */
-        provkey = pk->ameth->export_to(pk, keymgmt);
+        /* Otherwise, simply use it.  The export_to will tell us what it is */
+        provdata = pk->ameth->export_to(pk, keymgmt, &is_domainparams);
 
         /* Synchronize the dirty count, but only if we exported successfully */
-        if (provkey != NULL)
+        if (provdata != NULL)
             pk->dirty_cnt_copy = pk->ameth->dirty_cnt(pk);
 
     } else {
@@ -116,10 +122,13 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
          * the new provider.
          */
 
+        void *(*importfn)(void *provctx, const OSSL_PARAM params[]) =
+            want_domainparams ? keymgmt->importdomparams : keymgmt->importkey;
+
         /*
          * If the given keymgmt doesn't have an import function, give up
          */
-        if (keymgmt->importkey == NULL)
+        if (importfn == NULL)
             return NULL;
 
         for (j = 0; j < i && pk->pkeys[j].keymgmt != NULL; j++) {
@@ -129,6 +138,14 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
                 void *data = NULL;
                 void *provctx =
                     ossl_provider_ctx(EVP_KEYMGMT_provider(keymgmt));
+                int (*exportfn)(void *provctx, OSSL_PARAM params[]) = NULL;
+
+                if (pk->pkeys[j].domainparams != want_domainparams)
+                    continue;
+
+                exportfn = want_domainparams
+                    ? pk->pkeys[j].keymgmt->exportdomparams
+                    : pk->pkeys[j].keymgmt->exportkey;
 
                 paramdefs = pk->pkeys[j].keymgmt->exportkey_types();
                 /*
@@ -138,29 +155,36 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
                  */
                 params = paramdefs_to_params(paramdefs);
                 /* Get 'return_size' filled */
-                pk->pkeys[j].keymgmt->exportkey(pk->pkeys[j].provkey, params);
+                exportfn(pk->pkeys[j].provdata, params);
 
                 /*
                  * Allocate space and assign 'data' to point into the
-                 * data block
+                 * data block.
+                 * If something goes wrong, go to the next cached key.
                  */
-                data = allocate_params_space(params);
+                if ((data = allocate_params_space(params)) == NULL)
+                    goto cont;
 
                 /*
                  * Call the exportkey function a second time, to get
-                 * the data filled
+                 * the data filled.
+                 * If something goes wrong, go to the next cached key.
                  */
-                pk->pkeys[j].keymgmt->exportkey(pk->pkeys[j].provkey, params);
+                if (!exportfn(pk->pkeys[j].provdata, params))
+                    goto cont;
 
                 /*
                  * We should have all the data at this point, so import
                  * into the new provider and hope to get a key back.
                  */
-                provkey = keymgmt->importkey(provctx, params);
+                provdata = importfn(provctx, params);
+                is_domainparams = want_domainparams;
+
+             cont:
                 OPENSSL_free(params);
                 OPENSSL_free(data);
 
-                if (provkey != NULL)
+                if (provdata != NULL)
                     break;
             }
         }
@@ -173,12 +197,25 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
      */
     j = ossl_assert(i < OSSL_NELEM(pk->pkeys));
 
-    if (provkey != NULL) {
+    if (provdata != NULL) {
         EVP_KEYMGMT_up_ref(keymgmt);
         pk->pkeys[i].keymgmt = keymgmt;
-        pk->pkeys[i].provkey = provkey;
+        pk->pkeys[i].provdata = provdata;
+        pk->pkeys[i].domainparams = is_domainparams;
     }
-    return provkey;
+
+    /*
+     * If we got something the caller didn't want, don't return it.
+     * This condition will only happen when what we did originated
+     * from a libcrypto / legacy key.  In that case, we know for a
+     * fact that a full key contains domain parameters, while the
+     * other way around isn't as certain.
+     */
+    if (want_domainparams || want_domainparams == is_domainparams)
+        return provdata;
+
+    /* The caller isn't getting what it wants */
+    return NULL;
 }
 
 void evp_keymgmt_clear_pkey_cache(EVP_PKEY *pk)
@@ -190,11 +227,14 @@ void evp_keymgmt_clear_pkey_cache(EVP_PKEY *pk)
              i < OSSL_NELEM(pk->pkeys) && pk->pkeys[i].keymgmt != NULL;
              i++) {
             EVP_KEYMGMT *keymgmt = pk->pkeys[i].keymgmt;
-            void *provkey = pk->pkeys[i].provkey;
+            void *provdata = pk->pkeys[i].provdata;
 
             pk->pkeys[i].keymgmt = NULL;
-            pk->pkeys[i].provkey = NULL;
-            keymgmt->freekey(provkey);
+            pk->pkeys[i].provdata = NULL;
+            if (pk->pkeys[i].domainparams)
+                keymgmt->freedomparams(provdata);
+            else
+                keymgmt->freekey(provdata);
             EVP_KEYMGMT_free(keymgmt);
         }
     }

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -94,7 +94,8 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         ERR_raise(ERR_LIB_EVP,  EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
-    provkey = evp_keymgmt_export_to_provider(locpctx->pkey, signature->keymgmt);
+    provkey =
+        evp_keymgmt_export_to_provider(locpctx->pkey, signature->keymgmt, 0);
     if (provkey == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -359,7 +359,8 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature,
 
     ctx->op.sig.signature = signature;
     if (ctx->pkey != NULL) {
-        provkey = evp_keymgmt_export_to_provider(ctx->pkey, signature->keymgmt);
+        provkey =
+            evp_keymgmt_export_to_provider(ctx->pkey, signature->keymgmt, 0);
         if (provkey == NULL) {
             EVPerr(0, EVP_R_INITIALIZATION_ERROR);
             goto err;

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -71,7 +71,7 @@ struct evp_pkey_asn1_method_st {
     /* Exports to providers */
     size_t (*dirty_cnt) (const EVP_PKEY *pk);
     void *(*export_to) (const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
-                        int *is_domainparams);
+                        int want_domainparams);
 } /* EVP_PKEY_ASN1_METHOD */ ;
 
 DEFINE_STACK_OF_CONST(EVP_PKEY_ASN1_METHOD)

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -70,7 +70,8 @@ struct evp_pkey_asn1_method_st {
      */
     /* Exports to providers */
     size_t (*dirty_cnt) (const EVP_PKEY *pk);
-    void *(*export_to) (const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt);
+    void *(*export_to) (const EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
+                        int *is_domainparams);
 } /* EVP_PKEY_ASN1_METHOD */ ;
 
 DEFINE_STACK_OF_CONST(EVP_PKEY_ASN1_METHOD)

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -534,13 +534,15 @@ struct evp_pkey_st {
     /*
      * To support transparent export/import between providers that
      * support the methods for it, and still not having to do the
-     * export/import every time a key is used, we maintain a cache
-     * of imported key, indexed by provider address.
-     * pkeys[0] is *always* the "original" key.
+     * export/import every time a key or domain params are used, we
+     * maintain a cache of imported key / domain params, indexed by
+     * provider address.  pkeys[0] is *always* the "original" data.
      */
     struct {
         EVP_KEYMGMT *keymgmt;
-        void *provkey;
+        void *provdata;
+        /* 0 = provdata is a key, 1 = provdata is domain params */
+        int domainparams;
     } pkeys[10];
     /*
      * If there is a legacy key assigned to this structure, we keep
@@ -565,7 +567,8 @@ void evp_cleanup_int(void);
 void evp_app_cleanup_int(void);
 
 /* KEYMGMT helper functions */
-void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt);
+void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
+                                     int domainparams);
 void evp_keymgmt_clear_pkey_cache(EVP_PKEY *pk);
 
 /* KEYMGMT provider interface functions */

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -15,7 +15,9 @@
 #include "prov/implementations.h"
 
 static OSSL_OP_keymgmt_importdomparams_fn dh_importdomparams;
+static OSSL_OP_keymgmt_exportdomparams_fn dh_exportdomparams;
 static OSSL_OP_keymgmt_importkey_fn dh_importkey;
+static OSSL_OP_keymgmt_exportkey_fn dh_exportkey;
 
 static int params_to_domparams(DH *dh, const OSSL_PARAM params[])
 {
@@ -42,6 +44,25 @@ static int params_to_domparams(DH *dh, const OSSL_PARAM params[])
     BN_free(p);
     BN_free(g);
     return 0;
+}
+
+static int domparams_to_params(DH *dh, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+    const BIGNUM *dh_p = NULL, *dh_g = NULL;
+
+    if (dh == NULL)
+        return 0;
+
+    DH_get0_pqg(dh, &dh_p, NULL, &dh_g);
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_P)) != NULL
+        && !OSSL_PARAM_set_BN(p, dh_p))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_G)) != NULL
+        && !OSSL_PARAM_set_BN(p, dh_g))
+        return 0;
+
+    return 1;
 }
 
 static int params_to_key(DH *dh, const OSSL_PARAM params[])
@@ -86,6 +107,29 @@ static int params_to_key(DH *dh, const OSSL_PARAM params[])
     return 0;
 }
 
+static int key_to_params(DH *dh, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+    const BIGNUM *priv_key = NULL, *pub_key = NULL;
+
+    if (dh == NULL)
+        return 0;
+    if (!domparams_to_params(dh, params))
+        return 0;
+
+    DH_get0_key(dh, &pub_key, &priv_key);
+    if ((p = OSSL_PARAM_locate(params,
+                                     OSSL_PKEY_PARAM_DH_PRIV_KEY)) != NULL
+        && !OSSL_PARAM_set_BN(p, priv_key))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params,
+                                     OSSL_PKEY_PARAM_DH_PUB_KEY)) != NULL
+        && !OSSL_PARAM_set_BN(p, pub_key))
+        return 0;
+
+    return 1;
+}
+
 static void *dh_importdomparams(void *provctx, const OSSL_PARAM params[])
 {
     DH *dh;
@@ -96,6 +140,13 @@ static void *dh_importdomparams(void *provctx, const OSSL_PARAM params[])
         dh = NULL;
     }
     return dh;
+}
+
+static int dh_exportdomparams(void *domparams, OSSL_PARAM params[])
+{
+    DH *dh = domparams;
+
+    return dh != NULL && !domparams_to_params(dh, params);
 }
 
 static void *dh_importkey(void *provctx, const OSSL_PARAM params[])
@@ -110,14 +161,23 @@ static void *dh_importkey(void *provctx, const OSSL_PARAM params[])
     return dh;
 }
 
+static int dh_exportkey(void *key, OSSL_PARAM params[])
+{
+    DH *dh = key;
+
+    return dh != NULL && !key_to_params(dh, params);
+}
+
 const OSSL_DISPATCH dh_keymgmt_functions[] = {
     /*
      * TODO(3.0) When implementing OSSL_FUNC_KEYMGMT_GENKEY, remember to also
      * implement OSSL_FUNC_KEYMGMT_EXPORTKEY.
      */
     { OSSL_FUNC_KEYMGMT_IMPORTDOMPARAMS, (void (*)(void))dh_importdomparams },
+    { OSSL_FUNC_KEYMGMT_EXPORTDOMPARAMS, (void (*)(void))dh_exportdomparams },
     { OSSL_FUNC_KEYMGMT_FREEDOMPARAMS, (void (*)(void))DH_free },
     { OSSL_FUNC_KEYMGMT_IMPORTKEY, (void (*)(void))dh_importkey },
+    { OSSL_FUNC_KEYMGMT_EXPORTKEY, (void (*)(void))dh_exportkey },
     { OSSL_FUNC_KEYMGMT_FREEKEY, (void (*)(void))DH_free },
     { 0, NULL }
 };

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -14,18 +14,47 @@
 #include <openssl/params.h>
 #include "prov/implementations.h"
 
+static OSSL_OP_keymgmt_importdomparams_fn dh_importdomparams;
 static OSSL_OP_keymgmt_importkey_fn dh_importkey;
 
-static int params_to_key(DH *dh, const OSSL_PARAM params[])
+static int params_to_domparams(DH *dh, const OSSL_PARAM params[])
 {
-    const OSSL_PARAM *param_p, *param_g, *param_priv_key, *param_pub_key;
-    BIGNUM *p = NULL, *g = NULL, *priv_key = NULL, *pub_key = NULL;
+    const OSSL_PARAM *param_p, *param_g;
+    BIGNUM *p = NULL, *g = NULL;
 
     if (dh == NULL)
         return 0;
 
     param_p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_P);
     param_g = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_G);
+
+    if ((param_p != NULL && !OSSL_PARAM_get_BN(param_p, &p))
+        || (param_g != NULL && !OSSL_PARAM_get_BN(param_g, &g)))
+        goto err;
+
+    if (!DH_set0_pqg(dh, p, NULL, g))
+        goto err;
+    p = g = NULL;
+
+    return 1;
+
+ err:
+    BN_free(p);
+    BN_free(g);
+    return 0;
+}
+
+static int params_to_key(DH *dh, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *param_priv_key, *param_pub_key;
+    BIGNUM *priv_key = NULL, *pub_key = NULL;
+
+    if (dh == NULL)
+        return 0;
+
+    if (!params_to_domparams(dh, params))
+        return 0;
+
     param_priv_key =
         OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_PRIV_KEY);
     param_pub_key =
@@ -40,16 +69,10 @@ static int params_to_key(DH *dh, const OSSL_PARAM params[])
     if (param_pub_key == NULL)
         return 0;
 
-    if ((param_p != NULL && !OSSL_PARAM_get_BN(param_p, &p))
-        || (param_g != NULL && !OSSL_PARAM_get_BN(param_g, &g))
-        || (param_priv_key != NULL
-            && !OSSL_PARAM_get_BN(param_priv_key, &priv_key))
+    if ((param_priv_key != NULL
+         && !OSSL_PARAM_get_BN(param_priv_key, &priv_key))
         || !OSSL_PARAM_get_BN(param_pub_key, &pub_key))
         goto err;
-
-    if (!DH_set0_pqg(dh, p, NULL, g))
-        goto err;
-    p = g = NULL;
 
     if (!DH_set0_key(dh, pub_key, priv_key))
         goto err;
@@ -58,11 +81,21 @@ static int params_to_key(DH *dh, const OSSL_PARAM params[])
     return 1;
 
  err:
-    BN_free(p);
-    BN_free(g);
     BN_free(priv_key);
     BN_free(pub_key);
     return 0;
+}
+
+static void *dh_importdomparams(void *provctx, const OSSL_PARAM params[])
+{
+    DH *dh;
+
+    if ((dh = DH_new()) == NULL
+        || !params_to_domparams(dh, params)) {
+        DH_free(dh);
+        dh = NULL;
+    }
+    return dh;
 }
 
 static void *dh_importkey(void *provctx, const OSSL_PARAM params[])
@@ -82,6 +115,8 @@ const OSSL_DISPATCH dh_keymgmt_functions[] = {
      * TODO(3.0) When implementing OSSL_FUNC_KEYMGMT_GENKEY, remember to also
      * implement OSSL_FUNC_KEYMGMT_EXPORTKEY.
      */
+    { OSSL_FUNC_KEYMGMT_IMPORTDOMPARAMS, (void (*)(void))dh_importdomparams },
+    { OSSL_FUNC_KEYMGMT_FREEDOMPARAMS, (void (*)(void))DH_free },
     { OSSL_FUNC_KEYMGMT_IMPORTKEY, (void (*)(void))dh_importkey },
     { OSSL_FUNC_KEYMGMT_FREEKEY, (void (*)(void))DH_free },
     { 0, NULL }

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -36,7 +36,6 @@ static int params_to_domparams(DH *dh, const OSSL_PARAM params[])
 
     if (!DH_set0_pqg(dh, p, NULL, g))
         goto err;
-    p = g = NULL;
 
     return 1;
 
@@ -97,7 +96,6 @@ static int params_to_key(DH *dh, const OSSL_PARAM params[])
 
     if (!DH_set0_key(dh, pub_key, priv_key))
         goto err;
-    priv_key = pub_key = NULL;
 
     return 1;
 

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -38,7 +38,6 @@ static int params_to_domparams(DSA *dsa, const OSSL_PARAM params[])
 
     if (!DSA_set0_pqg(dsa, p, q, g))
         goto err;
-    p = q = g = NULL;
 
     return 1;
 
@@ -102,7 +101,6 @@ static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
 
     if (pub_key != NULL && !DSA_set0_key(dsa, pub_key, priv_key))
         goto err;
-    priv_key = pub_key = NULL;
 
     return 1;
 

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -14,13 +14,13 @@
 #include <openssl/params.h>
 #include "prov/implementations.h"
 
+static OSSL_OP_keymgmt_importdomparams_fn dsa_importdomparams;
 static OSSL_OP_keymgmt_importkey_fn dsa_importkey;
 
-static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
+static int params_to_domparams(DSA *dsa, const OSSL_PARAM params[])
 {
-    const OSSL_PARAM *param_p, *param_q, *param_g, *param_priv_key;
-    const OSSL_PARAM *param_pub_key;
-    BIGNUM *p = NULL, *q = NULL, *g = NULL, *priv_key = NULL, *pub_key = NULL;
+    const OSSL_PARAM *param_p, *param_q, *param_g;
+    BIGNUM *p = NULL, *q = NULL, *g = NULL;
 
     if (dsa == NULL)
         return 0;
@@ -28,6 +28,36 @@ static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
     param_p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_P);
     param_q = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_Q);
     param_g = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_G);
+
+    if ((param_p != NULL && !OSSL_PARAM_get_BN(param_p, &p))
+        || (param_q != NULL && !OSSL_PARAM_get_BN(param_q, &q))
+        || (param_g != NULL && !OSSL_PARAM_get_BN(param_g, &g)))
+        goto err;
+
+    if (!DSA_set0_pqg(dsa, p, q, g))
+        goto err;
+    p = q = g = NULL;
+
+    return 1;
+
+ err:
+    BN_free(p);
+    BN_free(q);
+    BN_free(g);
+    return 0;
+}
+
+static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *param_priv_key, *param_pub_key;
+    BIGNUM *priv_key = NULL, *pub_key = NULL;
+
+    if (dsa == NULL)
+        return 0;
+
+    if (!params_to_domparams(dsa, params))
+        return 0;
+
     param_priv_key =
         OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DSA_PRIV_KEY);
     param_pub_key =
@@ -40,18 +70,11 @@ static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
     if (param_priv_key != NULL && param_pub_key == NULL)
         return 0;
 
-    if ((param_p != NULL && !OSSL_PARAM_get_BN(param_p, &p))
-        || (param_q != NULL && !OSSL_PARAM_get_BN(param_q, &q))
-        || (param_g != NULL && !OSSL_PARAM_get_BN(param_g, &g))
-        || (param_priv_key != NULL
-            && !OSSL_PARAM_get_BN(param_priv_key, &priv_key))
+    if ((param_priv_key != NULL
+         && !OSSL_PARAM_get_BN(param_priv_key, &priv_key))
         || (param_pub_key != NULL
             && !OSSL_PARAM_get_BN(param_pub_key, &pub_key)))
         goto err;
-
-    if (!DSA_set0_pqg(dsa, p, q, g))
-        goto err;
-    p = q = g = NULL;
 
     if (pub_key != NULL && !DSA_set0_key(dsa, pub_key, priv_key))
         goto err;
@@ -60,12 +83,21 @@ static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
     return 1;
 
  err:
-    BN_free(p);
-    BN_free(q);
-    BN_free(g);
     BN_free(priv_key);
     BN_free(pub_key);
     return 0;
+}
+
+static void *dsa_importdomparams(void *provctx, const OSSL_PARAM params[])
+{
+    DSA *dsa;
+
+    if ((dsa = DSA_new()) == NULL
+        || !params_to_domparams(dsa, params)) {
+        DSA_free(dsa);
+        dsa = NULL;
+    }
+    return dsa;
 }
 
 static void *dsa_importkey(void *provctx, const OSSL_PARAM params[])
@@ -85,6 +117,8 @@ const OSSL_DISPATCH dsa_keymgmt_functions[] = {
      * TODO(3.0) When implementing OSSL_FUNC_KEYMGMT_GENKEY, remember to also
      * implement OSSL_FUNC_KEYMGMT_EXPORTKEY.
      */
+    { OSSL_FUNC_KEYMGMT_IMPORTDOMPARAMS, (void (*)(void))dsa_importdomparams },
+    { OSSL_FUNC_KEYMGMT_FREEDOMPARAMS, (void (*)(void))DSA_free },
     { OSSL_FUNC_KEYMGMT_IMPORTKEY, (void (*)(void))dsa_importkey },
     { OSSL_FUNC_KEYMGMT_FREEKEY, (void (*)(void))DSA_free },
     { 0, NULL }

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -15,7 +15,9 @@
 #include "prov/implementations.h"
 
 static OSSL_OP_keymgmt_importdomparams_fn dsa_importdomparams;
+static OSSL_OP_keymgmt_exportdomparams_fn dsa_exportdomparams;
 static OSSL_OP_keymgmt_importkey_fn dsa_importkey;
+static OSSL_OP_keymgmt_exportkey_fn dsa_exportkey;
 
 static int params_to_domparams(DSA *dsa, const OSSL_PARAM params[])
 {
@@ -45,6 +47,28 @@ static int params_to_domparams(DSA *dsa, const OSSL_PARAM params[])
     BN_free(q);
     BN_free(g);
     return 0;
+}
+
+static int domparams_to_params(DSA *dsa, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+    const BIGNUM *dsa_p = NULL, *dsa_q = NULL, *dsa_g = NULL;
+
+    if (dsa == NULL)
+        return 0;
+
+    DSA_get0_pqg(dsa, &dsa_p, &dsa_q, &dsa_g);
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_P)) != NULL
+        && !OSSL_PARAM_set_BN(p, dsa_p))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_Q)) != NULL
+        && !OSSL_PARAM_set_BN(p, dsa_q))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_FFC_G)) != NULL
+        && !OSSL_PARAM_set_BN(p, dsa_g))
+        return 0;
+
+    return 1;
 }
 
 static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
@@ -88,6 +112,27 @@ static int params_to_key(DSA *dsa, const OSSL_PARAM params[])
     return 0;
 }
 
+static int key_to_params(DSA *dsa, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+    const BIGNUM *priv_key = NULL, *pub_key = NULL;
+
+    if (dsa == NULL)
+        return 0;
+    if (!domparams_to_params(dsa, params))
+        return 0;
+
+    DSA_get0_key(dsa, &pub_key, &priv_key);
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DSA_PRIV_KEY)) != NULL
+        && !OSSL_PARAM_set_BN(p, priv_key))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DSA_PUB_KEY)) != NULL
+        && !OSSL_PARAM_set_BN(p, pub_key))
+        return 0;
+
+    return 1;
+}
+
 static void *dsa_importdomparams(void *provctx, const OSSL_PARAM params[])
 {
     DSA *dsa;
@@ -98,6 +143,13 @@ static void *dsa_importdomparams(void *provctx, const OSSL_PARAM params[])
         dsa = NULL;
     }
     return dsa;
+}
+
+static int dsa_exportdomparams(void *domparams, OSSL_PARAM params[])
+{
+    DSA *dsa = domparams;
+
+    return dsa != NULL && !domparams_to_params(dsa, params);
 }
 
 static void *dsa_importkey(void *provctx, const OSSL_PARAM params[])
@@ -112,14 +164,23 @@ static void *dsa_importkey(void *provctx, const OSSL_PARAM params[])
     return dsa;
 }
 
+static int dsa_exportkey(void *key, OSSL_PARAM params[])
+{
+    DSA *dsa = key;
+
+    return dsa != NULL && !key_to_params(dsa, params);
+}
+
 const OSSL_DISPATCH dsa_keymgmt_functions[] = {
     /*
      * TODO(3.0) When implementing OSSL_FUNC_KEYMGMT_GENKEY, remember to also
      * implement OSSL_FUNC_KEYMGMT_EXPORTKEY.
      */
     { OSSL_FUNC_KEYMGMT_IMPORTDOMPARAMS, (void (*)(void))dsa_importdomparams },
+    { OSSL_FUNC_KEYMGMT_EXPORTDOMPARAMS, (void (*)(void))dsa_exportdomparams },
     { OSSL_FUNC_KEYMGMT_FREEDOMPARAMS, (void (*)(void))DSA_free },
     { OSSL_FUNC_KEYMGMT_IMPORTKEY, (void (*)(void))dsa_importkey },
+    { OSSL_FUNC_KEYMGMT_EXPORTKEY, (void (*)(void))dsa_exportkey },
     { OSSL_FUNC_KEYMGMT_FREEKEY, (void (*)(void))DSA_free },
     { 0, NULL }
 };

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1201,7 +1201,7 @@ static int test_EVP_PKEY_CTX_get_set_params(void)
     const OSSL_PARAM *params;
     OSSL_PARAM ourparams[2], *param = ourparams;
     DSA *dsa = NULL;
-    BIGNUM *p = NULL, *q = NULL, *g = NULL;
+    BIGNUM *p = NULL, *q = NULL, *g = NULL, *pub = NULL, *priv = NULL;
     EVP_PKEY *pkey = NULL;
     int ret = 0;
     const EVP_MD *md;
@@ -1209,21 +1209,24 @@ static int test_EVP_PKEY_CTX_get_set_params(void)
     char ssl3ms[48];
 
     /*
-     * Setup the parameters for our DSA object. For our purposes they don't have
-     * to actually be *valid* parameters. We just need to set something. We
-     * don't even need a pub_key/priv_key.
+     * Setup the parameters for our DSA object. For our purposes they don't
+     * have to actually be *valid* parameters. We just need to set something.
      */
     dsa = DSA_new();
     p = BN_new();
     q = BN_new();
     g = BN_new();
+    pub = BN_new();
+    priv = BN_new();
     if (!TEST_ptr(dsa)
             || !TEST_ptr(p)
             || !TEST_ptr(q)
             || !TEST_ptr(g)
-            || !DSA_set0_pqg(dsa, p, q, g))
+            || !TEST_ptr(pub)
+            || !DSA_set0_pqg(dsa, p, q, g)
+        || !DSA_set0_key(dsa, pub, priv))
         goto err;
-    p = q = g = NULL;
+    p = q = g = pub = priv = NULL;
 
     pkey = EVP_PKEY_new();
     if (!TEST_ptr(pkey)
@@ -1331,6 +1334,8 @@ static int test_EVP_PKEY_CTX_get_set_params(void)
     BN_free(p);
     BN_free(q);
     BN_free(g);
+    BN_free(pub);
+    BN_free(priv);
 
     return ret;
 }


### PR DESCRIPTION
Including DH and DSA functionality for import and export of domain parameters and keys

This is the foundation needed to manipulate domain parameters and keys with providers beyond what we currently do.  What we've done so far is allow libcrypto generated keys to be transported to providers to be able to use them for signature and key exchange operations.  However, with things like key generation, not to mention *any* domain parameter handling, we're soon going to find ourselves in a situation where the libcrypto generated keys are not relevant at all for some operations (such as domain parameter and key generation).

Tests will happen as soon as the diverse upcoming PKEY operations start using this functionality.  (next up is key generation)