### PR TITLE
KDF: clean away old EVP_KDF declarations

### DIFF
--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -169,15 +169,6 @@ struct evp_kdf_st {
     OSSL_OP_kdf_set_ctx_params_fn *set_ctx_params;
 };
 
-extern const EVP_KDF pbkdf2_kdf_meth;
-extern const EVP_KDF scrypt_kdf_meth;
-extern const EVP_KDF tls1_prf_kdf_meth;
-extern const EVP_KDF hkdf_kdf_meth;
-extern const EVP_KDF sshkdf_kdf_meth;
-extern const EVP_KDF ss_kdf_meth;
-extern const EVP_KDF x963_kdf_meth;
-extern const EVP_KDF x942_kdf_meth;
-
 struct evp_md_st {
     /* nid */
     int type;


### PR DESCRIPTION
They were left-overs from when we still had the legacy KDF implementation
