### PR TITLE
Restore MD5-SHA1 in legacy method database

### DIFF
--- a/crypto/evp/c_alld.c
+++ b/crypto/evp/c_alld.c
@@ -22,6 +22,7 @@ void openssl_add_all_digests_int(void)
 #ifndef OPENSSL_NO_MD5
     EVP_add_digest(EVP_md5());
     EVP_add_digest_alias(SN_md5, "ssl3-md5");
+    EVP_add_digest(EVP_md5_sha1());
 #endif
     EVP_add_digest(EVP_sha1());
     EVP_add_digest_alias(SN_sha1, "ssl3-sha1");


### PR DESCRIPTION
If we remove these, the functions EVP_get_digestbyname() and
EVP_get_cipherbyname() will stop working entirely, and it's too early
to criple them yet.
