### PR TITLE
Fix missing Assembler defines

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -61,9 +61,15 @@ ENDIF
 
 $COMMON=aes_misc.c aes_ecb.c $AESASM
 SOURCE[../../libcrypto]=$COMMON aes_cfb.c aes_ofb.c aes_ige.c aes_wrap.c
-DEFINE[../../libcrypto]=$AESDEF
 SOURCE[../../providers/libfips.a]=$COMMON
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../../libcrypto]=$AESDEF
 DEFINE[../../providers/libfips.a]=$AESDEF
+DEFINE[../../providers/libimplementations.a]=$AESDEF
+# fipsprov.c needs access to AESNI.
+DEFINE[../../providers/fips]=$AESDEF
 
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -108,9 +108,12 @@ $COMMON=bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_mul.c \
         bn_const.c bn_x931p.c bn_intern.c bn_dh.c \
         bn_rsa_fips186_4.c $BNASM
 SOURCE[../../libcrypto]=$COMMON bn_print.c bn_err.c bn_depr.c bn_srp.c
-DEFINE[../../libcrypto]=$BNDEF
 SOURCE[../../providers/libfips.a]=$COMMON
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../../libcrypto]=$BNDEF
 DEFINE[../../providers/libfips.a]=$BNDEF
+DEFINE[../../providers/libimplementations.a]=$BNDEF
 
 INCLUDE[../../libcrypto]=../../crypto/include
 

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -77,10 +77,14 @@ SOURCE[../libcrypto]=$UTIL_COMMON \
         cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \
         o_fopen.c getenv.c o_init.c o_fips.c init.c trace.c provider.c \
         $UPLINKSRC
-DEFINE[../libcrypto]=$UTIL_DEFINE $UPLINKDEF
 SOURCE[../providers/libfips.a]=$UTIL_COMMON
-DEFINE[../providers/libfips.a]=$UTIL_DEFINE
 
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../libcrypto]=$UTIL_DEFINE $UPLINKDEF
+DEFINE[../providers/libfips.a]=$UTIL_DEFINE
+DEFINE[../providers/fips]=$UTIL_DEFINE
+DEFINE[../providers/libimplementations.a]=$UTIL_DEFINE
 
 DEPEND[info.o]=buildinf.h
 DEPEND[cversion.o]=buildinf.h

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -56,9 +56,13 @@ $COMMON=ec_lib.c ecp_smpl.c ecp_mont.c ecp_nist.c ec_cvt.c ec_mult.c \
         $ECASM
 SOURCE[../../libcrypto]=$COMMON ec_ameth.c ec_pmeth.c ecx_meth.c ec_err.c \
                         ecdh_kdf.c eck_prn.c
-DEFINE[../../libcrypto]=$ECDEF
 SOURCE[../../providers/libfips.a]=$COMMON
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../../libcrypto]=$ECDEF
 DEFINE[../../providers/libfips.a]=$ECDEF
+DEFINE[../../providers/libimplementations.a]=$ECDEF
 
 GENERATE[ecp_nistz256-x86.s]=asm/ecp_nistz256-x86.pl
 

--- a/crypto/md5/build.info
+++ b/crypto/md5/build.info
@@ -15,7 +15,11 @@ IF[{- !$disabled{asm} -}]
 ENDIF
 
 SOURCE[../../libcrypto]=md5_dgst.c md5_one.c md5_sha1.c $MD5ASM
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$MD5DEF
+DEFINE[../../providers/libimplementations.a]=$MD5DEF
 
 GENERATE[md5-586.s]=asm/md5-586.pl
 

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -52,10 +52,14 @@ $COMMON=cbc128.c ctr128.c cfb128.c ofb128.c gcm128.c ccm128.c xts128.c \
         wrap128.c $MODESASM
 SOURCE[../../libcrypto]=$COMMON \
         cts128.c ocb128.c siv128.c
-
-DEFINE[../../libcrypto]=$MODESDEF
 SOURCE[../../providers/libfips.a]=$COMMON
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../../libcrypto]=$MODESDEF
 DEFINE[../../providers/libfips.a]=$MODESDEF
+DEFINE[../../providers/libimplementations.a]=$MODESDEF
+
 
 INCLUDE[gcm128.o]=..
 

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -30,7 +30,11 @@ IF[{- !$disabled{asm} -}]
 ENDIF
 
 SOURCE[../../libcrypto]=poly1305_ameth.c poly1305.c $POLY1305ASM
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$POLY1305DEF
+DEFINE[../providers/libimplementations.a]=$POLY1305DEF
 
 GENERATE[poly1305-sparcv9.S]=asm/poly1305-sparcv9.pl
 INCLUDE[poly1305-sparcv9.o]=..

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -13,7 +13,11 @@ IF[{- !$disabled{asm} -}]
 ENDIF
 
 SOURCE[../../libcrypto]=rmd_dgst.c rmd_one.c $RMD160ASM
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules
 DEFINE[../../libcrypto]=$RMD160DEF
+DEFINE[../providers/libimplementations.a]=$RMD160DEF
 
 GENERATE[rmd-586.s]=asm/rmd-586.pl
 DEPEND[rmd-586.s]=../perlasm/x86asm.pl

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -75,9 +75,13 @@ ENDIF
 
 $COMMON=sha1dgst.c sha256.c sha512.c sha3.c $SHA1ASM $KECCAK1600ASM
 SOURCE[../../libcrypto]=$COMMON sha1_one.c
-DEFINE[../../libcrypto]=$SHA1DEF $KECCAK1600DEF
 SOURCE[../../providers/libfips.a]= $COMMON
-DEFINE[../../providers/libfips.a]= $SHA1DEF $KECCAK1600DEF
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../../libcrypto]=$SHA1DEF $KECCAK1600DEF
+DEFINE[../../providers/libfips.a]=$SHA1DEF $KECCAK1600DEF
+DEFINE[../../providers/libimplementations.a]=$SHA1DEF $KECCAK1600DEF
 
 GENERATE[sha1-586.s]=asm/sha1-586.pl
 DEPEND[sha1-586.s]=../perlasm/x86asm.pl

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -18,7 +18,11 @@ IF[{- !$disabled{asm} -}]
 ENDIF
 
 SOURCE[../../libcrypto]=wp_dgst.c $WPASM
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$WPDEF
+DEFINE[../../providers/libimplementations.a]=$WPDEF
 
 GENERATE[wp-mmx.s]=asm/wp-mmx.pl
 DEPEND[wp-mmx.s]=../perlasm/x86asm.pl


### PR DESCRIPTION
AES_ASM define was missing from libimplementations.a which disabled AESNI
aarch64 changes were made by xkqian.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
