### PR TITLE
Add EVP functionality to create domain params and keys by user data

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,13 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Added functionality to create an EVP_PKEY from user data.  This
+     is effectively the same as creating a RSA, DH or DSA object and
+     then assign them to an EVP_PKEY, but directly using algorithm
+     agnostic EVP functions.  A benefit is that this should be future
+     proof for public key algorithms to come.
+     [Richard Levitte]
+
   *) Added the X509_LOOKUP_METHOD called X509_LOOKUP_store, to allow
      access to certificate and CRL stores via URIs and OSSL_STORE
      loaders.

--- a/CHANGES
+++ b/CHANGES
@@ -11,7 +11,7 @@
 
   *) Added functionality to create an EVP_PKEY from user data.  This
      is effectively the same as creating a RSA, DH or DSA object and
-     then assign them to an EVP_PKEY, but directly using algorithm
+     then assigning them to an EVP_PKEY, but directly using algorithm
      agnostic EVP functions.  A benefit is that this should be future
      proof for public key algorithms to come.
      [Richard Levitte]

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -254,6 +254,24 @@ void evp_keymgmt_clear_pkey_cache(EVP_PKEY *pk)
     }
 }
 
+void *evp_keymgmt_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
+                           const OSSL_PARAM params[], int domainparams)
+{
+    void *provctx = ossl_provider_ctx(EVP_KEYMGMT_provider(keymgmt));
+    void *provdata = domainparams
+        ? keymgmt->importdomparams(provctx, params)
+        : keymgmt->importkey(provctx, params);
+
+    evp_keymgmt_clear_pkey_cache(target);
+    if (provdata != NULL) {
+        EVP_KEYMGMT_up_ref(keymgmt);
+        target->pkeys[0].keymgmt = keymgmt;
+        target->pkeys[0].provdata = provdata;
+        target->pkeys[0].domainparams = domainparams;
+    }
+
+    return provdata;
+}
 
 /* internal functions */
 /* TODO(3.0) decide if these should be public or internal */

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -15,6 +15,90 @@
 #include "crypto/bn.h"
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
+#include "evp_local.h"
+
+static int fromdata_init(EVP_PKEY_CTX *ctx, int operation)
+{
+    if (ctx == NULL || ctx->algorithm == NULL)
+        goto not_supported;
+
+    evp_pkey_ctx_free_old_ops(ctx);
+    ctx->operation = operation;
+    if (ctx->keymgmt == NULL)
+        ctx->keymgmt = EVP_KEYMGMT_fetch(NULL, ctx->algorithm, ctx->propquery);
+    if (ctx->keymgmt == NULL)
+        goto not_supported;
+
+    return 1;
+
+ not_supported:
+    ctx->operation = EVP_PKEY_OP_UNDEFINED;
+    ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+    return -2;
+}
+
+int EVP_PKEY_param_fromdata_init(EVP_PKEY_CTX *ctx)
+{
+    return fromdata_init(ctx, EVP_PKEY_OP_PARAMFROMDATA);
+}
+
+int EVP_PKEY_key_fromdata_init(EVP_PKEY_CTX *ctx)
+{
+    return fromdata_init(ctx, EVP_PKEY_OP_KEYFROMDATA);
+}
+
+int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM params[])
+{
+    void *provdata = NULL;
+
+    if (ctx == NULL || (ctx->operation & EVP_PKEY_OP_TYPE_FROMDATA) == 0) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
+        return -2;
+    }
+
+    if (ppkey == NULL)
+        return -1;
+
+    if (*ppkey == NULL)
+        *ppkey = EVP_PKEY_new();
+
+    if (*ppkey == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
+        return -1;
+    }
+
+    provdata =
+        evp_keymgmt_fromdata(*ppkey, ctx->keymgmt, params,
+                             ctx->operation == EVP_PKEY_OP_PARAMFROMDATA);
+
+    if (provdata == NULL)
+        return 0;
+    /* provdata is cached in *ppkey, so we need not bother with it further */
+    return 1;
+}
+
+/*
+ * TODO(3.0) Re-evalutate the names, it's possible that we find these to be
+ * better:
+ *
+ * EVP_PKEY_param_settable()
+ * EVP_PKEY_param_gettable()
+ */
+const OSSL_PARAM *EVP_PKEY_param_fromdata_settable(EVP_PKEY_CTX *ctx)
+{
+    /* We call fromdata_init to get ctx->keymgmt populated */
+    if (fromdata_init(ctx, EVP_PKEY_OP_UNDEFINED))
+        return evp_keymgmt_importdomparam_types(ctx->keymgmt);
+    return NULL;
+}
+
+const OSSL_PARAM *EVP_PKEY_key_fromdata_settable(EVP_PKEY_CTX *ctx)
+{
+    /* We call fromdata_init to get ctx->keymgmt populated */
+    if (fromdata_init(ctx, EVP_PKEY_OP_UNDEFINED))
+        return evp_keymgmt_importdomparam_types(ctx->keymgmt);
+    return NULL;
+}
 
 int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx)
 {

--- a/doc/man3/EVP_PKEY_fromdata.pod
+++ b/doc/man3/EVP_PKEY_fromdata.pod
@@ -1,0 +1,69 @@
+=pod
+
+=head1 NAME
+
+EVP_PKEY_param_fromdata_init, EVP_PKEY_key_fromdata_init, EVP_PKEY_fromdata,
+EVP_PKEY_param_fromdata_settable, EVP_PKEY_key_fromdata_settable
+- functions to create domain parameters and keys from user data
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ int EVP_PKEY_param_fromdata_init(EVP_PKEY_CTX *ctx);
+ int EVP_PKEY_key_fromdata_init(EVP_PKEY_CTX *ctx);
+ int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM params[]);
+ const OSSL_PARAM *EVP_PKEY_param_fromdata_settable(EVP_PKEY_CTX *ctx);
+ const OSSL_PARAM *EVP_PKEY_key_fromdata_settable(EVP_PKEY_CTX *ctx);
+
+=head1 DESCRIPTION
+
+EVP_PKEY_param_fromdata_init() initializes a public key algorithm context
+for creating domain parameters from user data.
+
+EVP_PKEY_key_fromdata_init() initializes a public key algorithm context for
+creating a key from user data.
+
+EVP_PKEY_fromdata() creates domain parameters or a key, given data from
+I<params> and a context that's been initialized with
+EVP_PKEY_param_fromdata_init() or EVP_PKEY_key_fromdata_init().  The result is
+written to I<*ppkey>.
+
+EVP_PKEY_param_fromdata_settable() and EVP_PKEY_key_fromdata_settable()
+get a constant B<OSSL_PARAM> array that describes the settable parameters
+that can be used with EVP_PKEY_fromdata().
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+
+=head1 NOTES
+
+These functions only work with key management methods coming from a
+provider.
+
+=for comment We may choose to make this available for legacy methods too... 
+
+=head1 RETURN VALUES
+
+EVP_PKEY_key_fromdata_init(), EVP_PKEY_param_fromdata_init() and
+EVP_PKEY_fromdata() return 1 for success and 0 or a negative value for
+failure.  In particular a return value of -2 indicates the operation is
+not supported by the public key algorithm.
+
+=head1 SEE ALSO
+
+L<EVP_PKEY_CTX_new(3)>, L<provider(7)>
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut
+

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -581,6 +581,9 @@ void evp_app_cleanup_int(void);
 void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
                                      int domainparams);
 void evp_keymgmt_clear_pkey_cache(EVP_PKEY *pk);
+void *evp_keymgmt_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
+                           const OSSL_PARAM params[], int domainparams);
+
 
 /* KEYMGMT provider interface functions */
 void *evp_keymgmt_importdomparams(const EVP_KEYMGMT *keymgmt,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1375,14 +1375,16 @@ int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 # define EVP_PKEY_OP_UNDEFINED           0
 # define EVP_PKEY_OP_PARAMGEN            (1<<1)
 # define EVP_PKEY_OP_KEYGEN              (1<<2)
-# define EVP_PKEY_OP_SIGN                (1<<3)
-# define EVP_PKEY_OP_VERIFY              (1<<4)
-# define EVP_PKEY_OP_VERIFYRECOVER       (1<<5)
-# define EVP_PKEY_OP_SIGNCTX             (1<<6)
-# define EVP_PKEY_OP_VERIFYCTX           (1<<7)
-# define EVP_PKEY_OP_ENCRYPT             (1<<8)
-# define EVP_PKEY_OP_DECRYPT             (1<<9)
-# define EVP_PKEY_OP_DERIVE              (1<<10)
+# define EVP_PKEY_OP_PARAMFROMDATA       (1<<3)
+# define EVP_PKEY_OP_KEYFROMDATA         (1<<4)
+# define EVP_PKEY_OP_SIGN                (1<<5)
+# define EVP_PKEY_OP_VERIFY              (1<<6)
+# define EVP_PKEY_OP_VERIFYRECOVER       (1<<7)
+# define EVP_PKEY_OP_SIGNCTX             (1<<8)
+# define EVP_PKEY_OP_VERIFYCTX           (1<<9)
+# define EVP_PKEY_OP_ENCRYPT             (1<<10)
+# define EVP_PKEY_OP_DECRYPT             (1<<11)
+# define EVP_PKEY_OP_DERIVE              (1<<12)
 
 # define EVP_PKEY_OP_TYPE_SIG    \
         (EVP_PKEY_OP_SIGN | EVP_PKEY_OP_VERIFY | EVP_PKEY_OP_VERIFYRECOVER \
@@ -1395,7 +1397,10 @@ int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
         (EVP_PKEY_OP_TYPE_SIG | EVP_PKEY_OP_TYPE_CRYPT | EVP_PKEY_OP_DERIVE)
 
 # define EVP_PKEY_OP_TYPE_GEN \
-                (EVP_PKEY_OP_PARAMGEN | EVP_PKEY_OP_KEYGEN)
+        (EVP_PKEY_OP_PARAMGEN | EVP_PKEY_OP_KEYGEN)
+
+# define EVP_PKEY_OP_TYPE_FROMDATA \
+        (EVP_PKEY_OP_PARAMFROMDATA | EVP_PKEY_OP_KEYFROMDATA)
 
 # define  EVP_PKEY_CTX_set_mac_key(ctx, key, len)        \
                 EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_KEYGEN,  \
@@ -1553,6 +1558,11 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
 
 typedef int EVP_PKEY_gen_cb(EVP_PKEY_CTX *ctx);
 
+int EVP_PKEY_param_fromdata_init(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_key_fromdata_init(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM param[]);
+const OSSL_PARAM *EVP_PKEY_param_fromdata_settable(EVP_PKEY_CTX *ctx);
+const OSSL_PARAM *EVP_PKEY_key_fromdata_settable(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx);

--- a/test/build.info
+++ b/test/build.info
@@ -38,7 +38,8 @@ IF[{- !$disabled{tests} -}]
           destest mdc2test \
           dhtest enginetest casttest \
           bftest ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
-          evp_test evp_extra_test evp_fetch_prov_test igetest v3nametest v3ext \
+          evp_fromdata_test evp_test evp_extra_test evp_fetch_prov_test \
+          igetest v3nametest v3ext \
           crltest danetest bad_dtls_test lhash_test sparse_array_test \
           conf_include_test params_api_test params_conversion_test \
           constant_time_test verify_extra_test clienthellotest \
@@ -203,6 +204,10 @@ IF[{- !$disabled{tests} -}]
   IF[{- $disabled{fips} || !$target{dso_scheme} -}]
     DEFINE[evp_extra_test]=NO_FIPS_MODULE
   ENDIF
+
+  SOURCE[evp_fromdata_test]=evp_fromdata_test.c
+  INCLUDE[evp_fromdata_test]=../include ../apps/include
+  DEPEND[evp_fromdata_test]=../libcrypto libtestutil.a
 
   SOURCE[igetest]=igetest.c
   INCLUDE[igetest]=../include ../apps/include

--- a/test/evp_fromdata_test.c
+++ b/test/evp_fromdata_test.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+#include <openssl/params.h>
+#include <openssl/core_names.h>
+#include "internal/nelem.h"
+#include "crypto/evp.h"          /* For the internal API */
+#include "testutil.h"
+
+/* Array indexes used in test_fromdata_rsa */
+#define N       0
+#define E       1
+#define D       2
+#define P       3
+#define Q       4
+#define DP      5
+#define DQ      6
+#define QINV    7
+
+static int test_fromdata_rsa(void)
+{
+    int ret = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pk = NULL;
+    /*
+     * 32-bit RSA key, extracted from this command,
+     * executed with OpenSSL 1.0.2:
+     *
+     * openssl genrsa 32 | openssl rsa -text
+     */
+    static unsigned long key_numbers[] = {
+        0xbc747fc5,              /* N */
+        0x10001,                 /* E */
+        0x7b133399,              /* D */
+        0xe963,                  /* P */
+        0xceb7,                  /* Q */
+        0x8599,                  /* DP */
+        0xbd87,                  /* DQ */
+        0xcc3b,                  /* QINV */
+    };
+    OSSL_PARAM fromdata_params[] = {
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_N, &key_numbers[N]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_E, &key_numbers[E]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_D, &key_numbers[D]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_FACTOR, &key_numbers[P]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_FACTOR, &key_numbers[Q]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_EXPONENT, &key_numbers[DP]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_EXPONENT, &key_numbers[DQ]),
+        OSSL_PARAM_ulong(OSSL_PKEY_PARAM_RSA_COEFFICIENT, &key_numbers[QINV]),
+        OSSL_PARAM_END
+    };
+
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_provided("RSA", NULL)))
+        goto err;
+
+    if (!TEST_true(EVP_PKEY_key_fromdata_init(ctx))
+        || !TEST_true(EVP_PKEY_fromdata(ctx, &pk, fromdata_params)))
+        goto err;
+
+    /*
+     * TODO(3.0) We can't do much more at this point without using internals,
+     * because RSA functionality is still missing.  When the time comes, it
+     * would be nice to try and do something "useful" with this key, such
+     * as signing a small piece of data.
+     */
+    ret = 1;
+
+ err:
+    EVP_PKEY_free(pk);
+    EVP_PKEY_CTX_free(ctx);
+
+    return ret;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_fromdata_rsa);
+    return 1;
+}

--- a/test/evp_fromdata_test.c
+++ b/test/evp_fromdata_test.c
@@ -58,7 +58,7 @@ static int test_fromdata_rsa(void)
         OSSL_PARAM_END
     };
 
-    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_provided("RSA", NULL)))
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_provided(NULL, "RSA", NULL)))
         goto err;
 
     if (!TEST_true(EVP_PKEY_key_fromdata_init(ctx))

--- a/test/recipes/30-test_evp_fromdata.t
+++ b/test/recipes/30-test_evp_fromdata.t
@@ -1,0 +1,13 @@
+#! /usr/bin/env perl
+# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright (c) 2018, Oracle and/or its affiliates.  All rights reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_evp_fromdata", "evp_fromdata_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4857,3 +4857,8 @@ X509_LOOKUP_store                       ?	3_0_0	EXIST::FUNCTION:
 X509_STORE_load_file                    ?	3_0_0	EXIST::FUNCTION:
 X509_STORE_load_path                    ?	3_0_0	EXIST::FUNCTION:
 X509_STORE_load_store                   ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_param_fromdata_init            ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_key_fromdata_init              ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_fromdata                       ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_param_fromdata_settable        ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_key_fromdata_settable          ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is the EVP operation that corresponds to creating direct RSA, DH
and DSA keys and set their numbers, to then assign them to an EVP_PKEY,
but done entirely using an algorithm agnostic EVP interface.

- [x] Documentation
- [x] Test