### PR TITLE
Configure: accept --api=3 and --api=3.x options

### DIFF
--- a/Configure
+++ b/Configure
@@ -45,7 +45,7 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 #
 # --cross-compile-prefix Add specified prefix to binutils components.
 #
-# --api         One of 0.9.8, 1.0.0, 1.0.1, 1.0.2, 1.1.0, 1.1.1, or 3.0.0 / 3.
+# --api         One of 0.9, 1.0, 1.1, or 3.0.0 / 3.
 #               Do not compile support for interfaces deprecated as of the
 #               specified OpenSSL version.
 #
@@ -182,15 +182,12 @@ our $BSDthreads="-pthread -D_THREAD_SAFE -D_REENTRANT";
 #
 # API compatibility name to version number mapping.
 #
-my $maxapi = "3.0.0";           # API for "no-deprecated" builds
+my $maxapi = "3.0";           # API for "no-deprecated" builds
 my $apitable = {
-    "3.0.0" => 3,
-    "1.1.1" => 2,
-    "1.1.0" => 2,
-    "1.0.2" => 1,
-    "1.0.1" => 1,
-    "1.0.0" => 1,
-    "0.9.8" => 0,
+    "3.0" => 3,
+    "1.1" => 2,
+    "1.0" => 1,
+    "0.9" => 0,
 };
 
 our %table = ();
@@ -839,7 +836,14 @@ while (@argvcopy)
                         }
                 elsif (/^--api=(.*)$/)
                         {
-                        $config{api}=$1;
+                        my $api = $1;
+                        if (index($api, '.') == -1)
+                                {
+                                $api = $api . ".0";
+                                }
+                        $config{api}=$api;
+                        die "Unknown --api choice $1\n"
+                            unless $api =~ /^([0-9]*(.[0-9]+)?)$/;
                         }
                 elsif (/^--libdir=(.*)$/)
                         {

--- a/INSTALL
+++ b/INSTALL
@@ -141,11 +141,11 @@
  --openssldir depend in what configuration is used and what Windows
  implementation OpenSSL is built on.  More notes on this in NOTES.WIN):
 
-  --api=x.y.z
+  --api=x(.y)?
                    Don't build with support for deprecated APIs below the
-                   specified version number. For example "--api=1.1.0" will
+                   specified version number. For example "--api=1.1" will
                    remove support for all APIS that were deprecated in OpenSSL
-                   version 1.1.0 or below. This is a rather specialized option
+                   version 1.1 or below. This is a rather specialized option
                    for developers. If you just intend to remove all deprecated
                    APIs entirely (up to the current version), it is easier
                    to add the 'no-deprecated' option instead (see below).


### PR DESCRIPTION
Resolves: https://github.com/openssl/openssl/issues/10166

Restrict `--api` option to allow detail until minor versions (as there is only deprecation at minor boundaries, not patches). 
For example: `--api=3.0`.

Add support for expanding api version if missing trailing minor version number. 
For example: `--api=3`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
