### PR TITLE
Add X509_V_FLAG_NO_CHECK_SUBJECT and change default to be safe

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,13 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Validation of SSL server certificates will no longer succeed by
+     default when no identity has been set with SSL_set1_host() (or
+     similar methods). Applications which manually verify the subject
+     of the server certificate can restore the original behaviour by
+     setting X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK.
+     [David Woodhouse]
+
   *) Added functionality to create an EVP_PKEY context based on data
      for methods from providers.  This takes an algorithm name and a
      property query string and simply stores them, with the intent

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -29,7 +29,7 @@
         OPT_V_SUITEB_128_ONLY, OPT_V_SUITEB_128, OPT_V_SUITEB_192, \
         OPT_V_PARTIAL_CHAIN, OPT_V_NO_ALT_CHAINS, OPT_V_NO_CHECK_TIME, \
         OPT_V_VERIFY_AUTH_LEVEL, OPT_V_ALLOW_PROXY_CERTS, \
-        OPT_V__LAST
+        OPT_V_ALLOW_NO_SUBJECT_CHECK, OPT_V__LAST
 
 # define OPT_V_OPTIONS \
         { "policy", OPT_V_POLICY, 's', "adds policy to the acceptable policy set"}, \
@@ -79,7 +79,8 @@
             "accept chains anchored by intermediate trust-store CAs"}, \
         { "no_alt_chains", OPT_V_NO_ALT_CHAINS, '-', "(deprecated)" }, \
         { "no_check_time", OPT_V_NO_CHECK_TIME, '-', "ignore certificate validity time" }, \
-        { "allow_proxy_certs", OPT_V_ALLOW_PROXY_CERTS, '-', "allow the use of proxy certificates" }
+        { "allow_proxy_certs", OPT_V_ALLOW_PROXY_CERTS, '-', "allow the use of proxy certificates" }, \
+        { "allow_no_subject_check", OPT_V_ALLOW_NO_SUBJECT_CHECK, '-', "do not require target identity to be provided" }
 
 # define OPT_V_CASES \
         OPT_V__FIRST: case OPT_V__LAST: break; \
@@ -112,7 +113,8 @@
         case OPT_V_PARTIAL_CHAIN: \
         case OPT_V_NO_ALT_CHAINS: \
         case OPT_V_NO_CHECK_TIME: \
-        case OPT_V_ALLOW_PROXY_CERTS
+        case OPT_V_ALLOW_PROXY_CERTS: \
+        case OPT_V_ALLOW_NO_SUBJECT_CHECK
 
 /*
  * Common "extended validation" options.

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -608,6 +608,9 @@ int opt_verify(int opt, X509_VERIFY_PARAM *vpm)
     case OPT_V_ALLOW_PROXY_CERTS:
         X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_ALLOW_PROXY_CERTS);
         break;
+    case OPT_V_ALLOW_NO_SUBJECT_CHECK:
+        X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK);
+        break;
     }
     return 1;
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -307,6 +307,17 @@ The B<X509_V_FLAG_NO_CHECK_TIME> flag suppresses checking the validity period
 of certificates and CRLs against the current time. If X509_VERIFY_PARAM_set_time()
 is used to specify a verification time, the check is not suppressed.
 
+The B<X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK> flag allows verification of a
+certificate for the B<X509_PURPOSE_SSL_SERVER> purpose to succeed even if
+the application has not provided a DNS hostname, IP or email address to
+be checked against the Subject of the certificate. Since OpenSSL 3.0.0,
+validation of SSL server certificates will fail unless either a matching
+identity has been provided or this flag is set.
+This flag has no effect if an identity has been set; it only affects the
+default behaviour when no identity has been provided for checking the
+subject of the peer certificate.
+
+
 =head1 INHERITANCE FLAGS
 
 These flags specify how parameters are "inherited" from one structure to

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -246,6 +246,8 @@ void X509_STORE_CTX_set_depth(X509_STORE_CTX *ctx, int depth);
 # define X509_V_FLAG_NO_ALT_CHAINS               0x100000
 /* Do not check certificate/CRL validity against current time */
 # define X509_V_FLAG_NO_CHECK_TIME               0x200000
+/* Do not require an identity for certificate subject matching */
+# define X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK      0x400000
 
 # define X509_VP_FLAG_DEFAULT                    0x1
 # define X509_VP_FLAG_OVERWRITE                  0x2

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -18,7 +18,7 @@ setup("test_verify");
 
 sub verify {
     my ($cert, $purpose, $trusted, $untrusted, @opts) = @_;
-    my @args = qw(openssl verify -auth_level 1 -purpose);
+    my @args = qw(openssl verify -auth_level 1 -allow_no_subject_check -purpose);
     my @path = qw(test certs);
     push(@args, "$purpose", @opts);
     for (@$trusted) { push(@args, "-trusted", srctop_file(@path, "$_.pem")) }

--- a/test/recipes/60-test_x509_store.t
+++ b/test/recipes/60-test_x509_store.t
@@ -27,7 +27,7 @@ plan skip_all => "test_rehash is not available on this platform"
 
 sub verify {
     my ($cert, $purpose, $trustedpath, $untrusted, @opts) = @_;
-    my @args = qw(openssl verify -auth_level 1 -purpose);
+    my @args = qw(openssl verify -auth_level 1 -allow_no_subject_check -purpose);
     my @path = qw(test certs);
     push(@args, "$purpose", @opts);
     push(@args, "-CApath", $trustedpath);

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -482,6 +482,14 @@ static int test_handshake(int idx)
         && !SSL_CTX_config(resume_client_ctx, "resume-client"))
         goto err;
 
+    {
+        X509_VERIFY_PARAM *param = SSL_CTX_get0_param(client_ctx);
+        X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK);
+    }
+    if (resume_client_ctx != NULL) {
+        X509_VERIFY_PARAM *param = SSL_CTX_get0_param(resume_client_ctx);
+        X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK);
+    }
     result = do_handshake(server_ctx, server2_ctx, client_ctx,
                           resume_server_ctx, resume_client_ctx, test_ctx);
 

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -1530,6 +1530,11 @@ int main(int argc, char *argv[])
     }
 
     {
+        X509_VERIFY_PARAM *param = SSL_CTX_get0_param(c_ctx);
+        X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_ALLOW_NO_SUBJECT_CHECK);
+    }
+
+    {
         int session_id_context = 0;
         if (!SSL_CTX_set_session_id_context(s_ctx, (void *)&session_id_context,
                                             sizeof(session_id_context)) ||


### PR DESCRIPTION
If no hostname/IP/email is added for verification, OpenSSL will currently
allow verification to succeed for *any* validly signed certificate,
regardless of its subject.

This behaviour isn't just a suboptimal default; in any real application
it is egregiously and insecurely wrong. If any application really wants
it, they should have to jump through hoops to *ask* for it.

Add X509_V_FLAG_NO_CHECK_SUBJECT to permit that behaviour, and change
the default to fail verification if no identity is set.

This would have prevented CVE-2019-14553
(https://bugzilla.tianocore.org/show_bug.cgi?id=960) and others. I got
this wrong in OpenConnect myself in the early days too, when I was
young and naïve and didn't *expect* that the crypto libraries were
all out to get me :)

This straw man commits breaks some tests; if we agree on the principle
then it should be simple enough to go through and fix them to either
set X509_V_FLAG_NO_CHECK_SUBJECT or provide the expected subject.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
