### PR TITLE
Unify BN_rshift design

### DIFF
--- a/crypto/bn/bn_shift.c
+++ b/crypto/bn/bn_shift.c
@@ -152,57 +152,19 @@ int bn_lshift_fixed_top(BIGNUM *r, const BIGNUM *a, int n)
 
 int BN_rshift(BIGNUM *r, const BIGNUM *a, int n)
 {
-    int i, j, nw, lb, rb;
-    BN_ULONG *t, *f;
-    BN_ULONG l, tmp;
-
-    bn_check_top(r);
-    bn_check_top(a);
+    int ret = 0;
 
     if (n < 0) {
         BNerr(BN_F_BN_RSHIFT, BN_R_INVALID_SHIFT);
         return 0;
     }
 
-    nw = n / BN_BITS2;
-    rb = n % BN_BITS2;
-    lb = BN_BITS2 - rb;
-    if (nw >= a->top || a->top == 0) {
-        BN_zero(r);
-        return 1;
-    }
-    i = (BN_num_bits(a) - n + (BN_BITS2 - 1)) / BN_BITS2;
-    if (r != a) {
-        if (bn_wexpand(r, i) == NULL)
-            return 0;
-        r->neg = a->neg;
-    } else {
-        if (n == 0)
-            return 1;           /* or the copying loop will go berserk */
-    }
+    ret = bn_rshift_fixed_top(r, a, n);
 
-    f = &(a->d[nw]);
-    t = r->d;
-    j = a->top - nw;
-    r->top = i;
-
-    if (rb == 0) {
-        for (i = j; i != 0; i--)
-            *(t++) = *(f++);
-    } else {
-        l = *(f++);
-        for (i = j - 1; i != 0; i--) {
-            tmp = (l >> rb) & BN_MASK2;
-            l = *(f++);
-            *(t++) = (tmp | (l << lb)) & BN_MASK2;
-        }
-        if ((l = (l >> rb) & BN_MASK2))
-            *(t) = l;
-    }
-    if (!r->top)
-        r->neg = 0; /* don't allow negative zero */
+    bn_correct_top(r);
     bn_check_top(r);
-    return 1;
+
+    return ret;
 }
 
 /*


### PR DESCRIPTION
This PR aims at refactoring the `BN_rshift` by making it a wrapper around `bn_rshift_fixed_top`, in order to match the current design of `BN_lshift`, as suggested in the discussion at https://github.com/openssl/openssl/pull/10122#discussion_r332474277 .

As described in the code, by refactoring this function, `BN_rshift` provides a constant-time behavior for sufficiently[!] zero-padded inputs under the following assumptions: `|n < BN_BITS2|` or `|n / BN_BITS2|` being non-secret.

Notice that `BN_rshift` returns a canonical representation of the BIGNUM, if a `fixed_top` representation is required, the caller should call `bn_rshift_fixed_top` instead.

## Benchmarks
To validate the impact of this change, we ran `openssl speed` across different cryptosystems following different code paths. These are the results:

### Current `BN_rshift` (a397aca43598ef20c84e69f6d6e5d95652aa0325)
```
~/openssl$ ./util/shlib_wrap.sh ./apps/openssl speed dsa2048 rsa2048 ecdsap224 ecdsap256 ecdsap384 ecdsab283
Doing 2048 bits private rsa's for 10s: 16617 2048 bits private RSA's in 10.00s
Doing 2048 bits public rsa's for 10s: 562429 2048 bits public RSA's in 10.00s
Doing 2048 bits sign dsa's for 10s: 37590 2048 bits DSA signs in 9.99s
Doing 2048 bits verify dsa's for 10s: 44473 2048 bits DSA verify in 10.00s
Doing 224 bits sign ecdsa's for 10s: 174958 224 bits ECDSA signs in 9.94s
Doing 224 bits verify ecdsa's for 10s: 86694 224 bits ECDSA verify in 10.00s
Doing 256 bits sign ecdsa's for 10s: 336600 256 bits ECDSA signs in 9.89s
Doing 256 bits verify ecdsa's for 10s: 146099 256 bits ECDSA verify in 10.00s
Doing 384 bits sign ecdsa's for 10s: 9701 384 bits ECDSA signs in 9.99s
Doing 384 bits verify ecdsa's for 10s: 13086 384 bits ECDSA verify in 10.00s
Doing 283 bits sign ecdsa's for 10s: 17822 283 bits ECDSA signs in 9.98s
Doing 283 bits verify ecdsa's for 10s: 8963 283 bits ECDSA verify in 9.98s
version: 3.0.0-dev
built on: built on: Wed Oct 16 11:58:34 2019 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr)
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DDEBUG_UNUSED -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wswitch -Wsign-compare -Wshadow -Wformat -Wtype-limits -Wundef -Werror -Wmissing-prototypes -Wstrict-prototypes -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffaf3ffffebffff:0x29c6fbf
                  sign    verify    sign/s verify/s
rsa 2048 bits 0.000602s 0.000018s   1661.7  56242.9
                  sign    verify    sign/s verify/s
dsa 2048 bits 0.000266s 0.000225s   3762.8   4447.3
                              sign    verify    sign/s verify/s
 224 bits ecdsa (nistp224)   0.0001s   0.0001s  17601.4   8669.4
 256 bits ecdsa (nistp256)   0.0000s   0.0001s  34034.4  14609.9
 384 bits ecdsa (nistp384)   0.0010s   0.0008s    971.1   1308.6
 283 bits ecdsa (nistb283)   0.0006s   0.0011s   1785.8    898.1
```

### Refactored `BN_rshift` 
```
~/openssl$ ./util/shlib_wrap.sh ./apps/openssl speed dsa2048 rsa2048 ecdsap224 ecdsap256 ecdsap384 ecdsab283
Doing 2048 bits private rsa's for 10s: 16670 2048 bits private RSA's in 10.00s
Doing 2048 bits public rsa's for 10s: 565334 2048 bits public RSA's in 10.00s
Doing 2048 bits sign dsa's for 10s: 37642 2048 bits DSA signs in 9.99s
Doing 2048 bits verify dsa's for 10s: 44939 2048 bits DSA verify in 10.00s
Doing 224 bits sign ecdsa's for 10s: 174438 224 bits ECDSA signs in 9.97s
Doing 224 bits verify ecdsa's for 10s: 86997 224 bits ECDSA verify in 10.00s
Doing 256 bits sign ecdsa's for 10s: 334184 256 bits ECDSA signs in 9.90s
Doing 256 bits verify ecdsa's for 10s: 146641 256 bits ECDSA verify in 10.00s
Doing 384 bits sign ecdsa's for 10s: 9696 384 bits ECDSA signs in 10.00s
Doing 384 bits verify ecdsa's for 10s: 12905 384 bits ECDSA verify in 10.00s
Doing 283 bits sign ecdsa's for 10s: 17685 283 bits ECDSA signs in 9.98s
Doing 283 bits verify ecdsa's for 10s: 9074 283 bits ECDSA verify in 9.98s
version: 3.0.0-dev
built on: built on: Wed Oct 16 11:51:25 2019 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr)
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DDEBUG_UNUSED -DPEDANTIC -pedantic -Wno-long-long -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wswitch -Wsign-compare -Wshadow -Wformat -Wtype-limits -Wundef -Werror -Wmissing-prototypes -Wstrict-prototypes -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffaf3ffffebffff:0x29c6fbf
                  sign    verify    sign/s verify/s
rsa 2048 bits 0.000600s 0.000018s   1667.0  56533.4
                  sign    verify    sign/s verify/s
dsa 2048 bits 0.000265s 0.000223s   3768.0   4493.9
                              sign    verify    sign/s verify/s
 224 bits ecdsa (nistp224)   0.0001s   0.0001s  17496.3   8699.7
 256 bits ecdsa (nistp256)   0.0000s   0.0001s  33756.0  14664.1
 384 bits ecdsa (nistp384)   0.0010s   0.0008s    969.6   1290.5
 283 bits ecdsa (nistb283)   0.0006s   0.0011s   1772.0    909.2
```

Ping @romen, @bbbrumley, @mattcaswell and @paulidale since this is related to #10122 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

