### PR TITLE
Allow EVP_PKEY_get0_RSA for RSA-PSS keys

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -493,7 +493,7 @@ int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key)
 
 RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey)
 {
-    if (pkey->type != EVP_PKEY_RSA) {
+    if (pkey->type != EVP_PKEY_RSA && pkey->type != EVP_PKEY_RSA_PSS) {
         EVPerr(EVP_F_EVP_PKEY_GET0_RSA, EVP_R_EXPECTING_AN_RSA_KEY);
         return NULL;
     }


### PR DESCRIPTION
RSA-PSS keys use the same internal structure as RSA keys but do not allow accessing it through `EVP_PKEY_get0_RSA`. This commit changes that behavior.

I am not sure how to test this (or whether a test is even necessary), the function is never called directly from existing tests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
