### PR TITLE
Cleanup include/openssl/opensslv.h.in

### DIFF
--- a/crypto/cversion.c
+++ b/crypto/cversion.c
@@ -33,12 +33,12 @@ unsigned int OPENSSL_version_patch(void)
 
 const char *OPENSSL_version_pre_release(void)
 {
-    return OPENSSL_VERSION_PRE_RELEASE_STR;
+    return OPENSSL_VERSION_PRE_RELEASE;
 }
 
 const char *OPENSSL_version_build_metadata(void)
 {
-    return OPENSSL_VERSION_BUILD_METADATA_STR;
+    return OPENSSL_VERSION_BUILD_METADATA;
 }
 
 extern char ossl_cpu_info_str[];

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -4,7 +4,6 @@
 
 OPENSSL_VERSION_MAJOR, OPENSSL_VERSION_MINOR, OPENSSL_VERSION_PATCH,
 OPENSSL_VERSION_PRE_RELEASE, OPENSSL_VERSION_BUILD_METADATA,
-OPENSSL_VERSION_PRE_RELEASE_STR, OPENSSL_VERSION_BUILD_METADATA_STR,
 OPENSSL_VERSION_TEXT,
 OPENSSL_version_major, OPENSSL_version_minor, OPENSSL_version_patch,
 OPENSSL_version_pre_release, OPENSSL_version_build_metadata, OpenSSL_version,
@@ -20,10 +19,8 @@ OPENSSL_VERSION_NUMBER, OpenSSL_version_num, OPENSSL_info
  #define OPENSSL_VERSION_PATCH  z
 
  /* The definitions here are typical release values */
- #undef OPENSSL_VERSION_PRE_RELEASE
- #undef OPENSSL_VERSION_BUILD_METADATA
- #define OPENSSL_VERSION_PRE_RELEASE_STR ""
- #define OPENSSL_VERSION_BUILD_METADATA_STR ""
+ #define OPENSSL_VERSION_PRE_RELEASE ""
+ #define OPENSSL_VERSION_BUILD_METADATA ""
 
  #define OPENSSL_VERSION_TEXT "OpenSSL x.y.z xx XXX xxxx"
 
@@ -55,15 +52,14 @@ The three macros B<OPENSSL_VERSION_MAJOR>, B<OPENSSL_VERSION_MINOR> and
 B<OPENSSL_VERSION_PATCH> represent the three parts of a version
 identifier, B<I<MAJOR>.I<MINOR>.I<PATCH>>.
 
-The macro B<OPENSSL_VERSION_PRE_RELEASE> is an added bit of text that,
-when defined, indicates that this is a pre-release version, such as
-C<"-dev"> for an ongoing development snapshot or C<"-alpha3"> for an
-alpha release.
+The macro B<OPENSSL_VERSION_PRE_RELEASE> is an added bit of text that
+indicates that this is a pre-release version, such as C<"-dev"> for an
+ongoing development snapshot or C<"-alpha3"> for an alpha release.
 The value must be a string.
 
 The macro B<OPENSSL_VERSION_BUILD_METADATA> is extra information, reserved
-for other parties, such as C<"+fips">, or C<"+vendor.1">.
-The OpenSSL project will not touch this macro.
+for other parties, such as C<"+fips">, or C<"+vendor.1">).
+The OpenSSL project will not touch this macro (will leave it an empty string).
 The value must be a string.
 
 B<OPENSSL_VERSION_STR> is a convenience macro to get the short version

--- a/include/openssl/opensslv.h.in
+++ b/include/openssl/opensslv.h.in
@@ -51,7 +51,7 @@ extern "C" {
 /*
  * Note: The OpenSSL Project will never define OPENSSL_VERSION_BUILD_METADATA
  * to be anything but the empty string.  Its use is entirely reserved for
- * others vendors
+ * others
  */
 
 /*

--- a/include/openssl/opensslv.h.in
+++ b/include/openssl/opensslv.h.in
@@ -36,54 +36,23 @@ extern "C" {
 # define OPENSSL_VERSION_PATCH  {- $config{patch} -}
 
 /*
- * Additional version information, defined only when used.
+ * Additional version information
  *
  * These are also part of the new version scheme, but aren't part
  * of the version number itself.
  */
 
 /* Could be: #define OPENSSL_VERSION_PRE_RELEASE "-alpha.1" */
-{- $config{prerelease}
-    ? << "_____"
-# define OPENSSL_VERSION_PRE_RELEASE "$config{prerelease}"
-_____
-    : << "_____"
-# undef OPENSSL_VERSION_PRE_RELEASE
-_____
--}
+# define OPENSSL_VERSION_PRE_RELEASE "{- $config{prerelease} -}"
 /* Could be: #define OPENSSL_VERSION_BUILD_METADATA "+fips" */
 /* Could be: #define OPENSSL_VERSION_BUILD_METADATA "+vendor.1" */
-{- $build_metadata
-    ? << "_____"
 # define OPENSSL_VERSION_BUILD_METADATA "{- $config{build_metadata} -}"
-_____
-    : << "_____"
-# undef OPENSSL_VERSION_BUILD_METADATA
-_____
--}
 
 /*
- * Note: OPENSSL_VERSION_BUILD_METADATA will never be defined by
- * the OpenSSL Project, it's entirely reserved for others vendors
+ * Note: The OpenSSL Project will never define OPENSSL_VERSION_BUILD_METADATA
+ * to be anything but the empty string.  Its use is entirely reserved for
+ * others vendors
  */
-
-/*
- * Absolute string versions of OPENSSL_VERSION_PRE_RELEASE and
- * OPENSSL_VERSION_BUILD_METADATA.  As opposed to those, which
- * may be undefined, these are guaranteed to have strings as
- * values.
- */
-
-# ifdef OPENSSL_VERSION_PRE_RELEASE
-#  define OPENSSL_VERSION_PRE_RELEASE_STR OPENSSL_VERSION_PRE_RELEASE
-# else
-#  define OPENSSL_VERSION_PRE_RELEASE_STR ""
-# endif
-# ifdef OPENSSL_VERSION_BUILD_METADATA
-#  define OPENSSL_VERSION_BUILD_METADATA_STR OPENSSL_VERSION_BUILD_METADATA
-# else
-#  define OPENSSL_VERSION_BUILD_METADATA_STR ""
-# endif
 
 /*
  * Shared library version
@@ -95,7 +64,7 @@ _____
 # define OPENSSL_SHLIB_VERSION {- $config{shlib_version} -}
 
 /*
- * SECTION 2: USEFUL MACROS AND FUNCTIONS
+ * SECTION 2: USEFUL MACROS
  */
 
 /* For checking general API compatibility when preprocessing */
@@ -118,11 +87,13 @@ _____
  * These strings are defined separately to allow them to be parsable.
  */
 # define OPENSSL_RELEASE_DATE "{- $config{release_date} -}"
-# define OPENSSL_VERSION_TEXT "OpenSSL {- "$config{full_version} $config{release_date}" -}"
 
 /*
  * SECTION 4: BACKWARD COMPATIBILITY
  */
+
+# define OPENSSL_VERSION_TEXT "OpenSSL {- "$config{full_version} $config{release_date}" -}"
+
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
 # ifdef OPENSSL_VERSION_PRE_RELEASE
 #  define _OPENSSL_VERSION_PRE_RELEASE 0x0


### PR DESCRIPTION
Now that we generate include/openssl/opensslv.h, there's no point
keeping some macross around, we can just set a simpler set to their
respective value and be done with it.
