### PR TITLE
Update dgst.c to show a list of message digests [1.1.1]

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -50,7 +50,8 @@ typedef enum OPTION_choice {
 
 const OPTIONS enc_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
-    {"ciphers", OPT_LIST, '-', "List ciphers"},
+    {"list", OPT_LIST, '-', "List ciphers"},
+    {"ciphers", OPT_LIST, '-', "Alias for -list"},
     {"in", OPT_IN, '<', "Input file"},
     {"out", OPT_OUT, '>', "Output file"},
     {"pass", OPT_PASS, 's', "Passphrase source"},

--- a/doc/man1/dgst.pod
+++ b/doc/man1/dgst.pod
@@ -12,6 +12,7 @@ B<openssl dgst>
 [B<-help>]
 [B<-c>]
 [B<-d>]
+[B<-list>]
 [B<-hex>]
 [B<-binary>]
 [B<-r>]
@@ -66,6 +67,10 @@ B<hex> format output is used.
 =item B<-d>
 
 Print out BIO debugging information.
+
+=item B<-list>
+
+Prints out a list of supported message digests.
 
 =item B<-hex>
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -9,6 +9,7 @@ enc - symmetric cipher routines
 
 B<openssl enc -I<cipher>>
 [B<-help>]
+[B<-list>]
 [B<-ciphers>]
 [B<-in filename>]
 [B<-out filename>]
@@ -56,9 +57,13 @@ either by itself or in addition to the encryption or decryption.
 
 Print out a usage message.
 
-=item B<-ciphers>
+=item B<-list>
 
 List all supported ciphers.
+
+=item B<-ciphers>
+
+Alias of -list to display all supported ciphers.
 
 =item B<-in filename>
 
@@ -418,6 +423,8 @@ certain parameters. So if, for example, you want to use RC2 with a
 =head1 HISTORY
 
 The default digest was changed from MD5 to SHA256 in OpenSSL 1.1.0.
+
+The B<-list> option was added in OpenSSL 1.1.1e.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Fixes #9893

_(Backport of #9912 without the deprecation marker)_