### PR TITLE
Configure: also break up the OPTIONS line

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -57,7 +57,9 @@
      '';
 -}
 PLATFORM={- $config{target} -}
-OPTIONS={- $config{options} -}
+OPTIONS={- join(" \\\n" . ' ' x 8,
+                fill_lines(" ", $COLUMNS - 8,
+                           split(' ', $config{options}))) -}
 CONFIGURE_ARGS=({- join(", ",quotify_l(@{$config{perlargv}})) -})
 SRCDIR={- $config{sourcedir} -}
 BLDDIR={- $config{builddir} -}


### PR DESCRIPTION
c00d9311 ("Configure: break long lines in build files", 2019-05-23)
introduced wrapping of long Makefile lines, but it forgot to wrap the
configuration options, which are generally also longer than one screen
line.

Signed-off-by: Beat Bolli <dev@drbeat.li>
