### PR TITLE
Update control logic for BN_gcd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - os: linux
           dist: trusty
           compiler: clang
-          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES no-deprecated"
+          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES no-deprecated" BUILDONLY="yes"
         - os: linux
           dist: bionic
           compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - os: linux
           dist: trusty
           compiler: clang
-          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES no-deprecated" BUILDONLY="yes"
+          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES no-deprecated"
         - os: linux
           dist: bionic
           compiler: clang


### PR DESCRIPTION
PR https://github.com/openssl/openssl/pull/10122 introduced changes to the BN_gcd function and the control logic inside it accessed `g->d[0]` irrespective of `g->top`.

When BN_add is called, in case the result is zero, `BN_zero` is called.
The latter behaves differently depending on the API compatibility level flag: normally `g->d[0]` is cleared but in `no-deprecated` builds only `g->top` is set to zero.

This commit uses bitwise logic to ensure that `g` is treated as zero if `g->top` is zero, irrespective of `g->d[0]`.

### Side notes

- `BN_add` requires refactoring to be constant-time.
- After refactoring these changes can probably go away since we can expect `g->d` to be properly zeroed.
- The second commit in this PR should be dropped, it is only meant to run `make test` in `no-deprecated` builds.
- `20-test_enc_more` seems to be currently failing but does not seem to depend on #10122.

@romen co-authored this.

Partially fixes #10224 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->