### PR TITLE
Fix memory deallocation code in `kssl_build_principal_2`

### DIFF
--- a/ssl/kssl.c
+++ b/ssl/kssl.c
@@ -2234,10 +2234,10 @@ krb5_error_code kssl_build_principal_2(
     return 0;
 
  err:
-    if (new_p && new_p[0].data)
-        free(new_p[0].data);
-    if (new_p && new_p[1].data)
-        free(new_p[1].data);
+    if (p_data && p_data[0].data)
+        free(p_data[0].data);
+    if (p_data && p_data[1].data)
+        free(p_data[1].data);
     if (new_p)
         free(new_p);
     if (new_r)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### 
The error handling code in `kssl_build_principal_2` wrongly use `free(new_p[1].data)`, while `new_p` is not a pointer to array, when allocation fail.(when `calloc` return `NULL`);
I think it is intended to free `p_data[0].data` and `p_data[1].data`.
This patch just fix it.