### PR TITLE
Cleanup hardcoded cipher suite codepoints in s_server

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -182,9 +182,6 @@ static unsigned int psk_server_cb(SSL *ssl, const char *identity,
 }
 #endif
 
-#define TLS13_AES_128_GCM_SHA256_BYTES  ((const unsigned char *)"\x13\x01")
-#define TLS13_AES_256_GCM_SHA384_BYTES  ((const unsigned char *)"\x13\x02")
-
 static int psk_find_session_cb(SSL *ssl, const unsigned char *identity,
                                size_t identity_len, SSL_SESSION **sess)
 {


### PR DESCRIPTION
The hardcoded code points for TLSv1.3 cipher suites are used in the TLS
PSK server callback. However, they seem to have been refactored a while
ago to use tls13_aes128gcmsha256_id, so these defines are not necessary
within the s_server code anymore.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
