### PR TITLE
Fix a copy&paste error in the TLSv1.3 server side PSK documentation

### DIFF
--- a/doc/man3/SSL_CTX_use_psk_identity_hint.pod
+++ b/doc/man3/SSL_CTX_use_psk_identity_hint.pod
@@ -39,9 +39,9 @@ SSL_set_psk_find_session_callback
 
 =head1 DESCRIPTION
 
-A client application wishing to use TLSv1.3 PSKs should set a callback
-using either SSL_CTX_set_psk_use_session_callback() or
-SSL_set_psk_use_session_callback() as appropriate.
+A server application wishing to use TLSv1.3 PSKs should set a callback
+using either SSL_CTX_set_psk_find_session_callback() or
+SSL_set_psk_find_session_callback() as appropriate.
 
 The callback function is given a pointer to the SSL connection in B<ssl> and
 an identity in B<identity> of length B<identity_len>. The callback function


### PR DESCRIPTION
The introductory paragraph for the TLSv1.3 server side PSK documentation
is a copy & paste of the client side documentation which has not been
updated with the server side equivalent information.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
