### PR TITLE
WIP: Convenience function for -XXXform flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,35 @@
 /include/openssl/opensslconf.h
 /include/openssl/opensslv.h
 
+# Auto generated doc files
+doc/man1/openssl-ca.pod
+doc/man1/openssl-cms.pod
+doc/man1/openssl-crl.pod
+doc/man1/openssl-dgst.pod
+doc/man1/openssl-dhparam.pod
+doc/man1/openssl-dsaparam.pod
+doc/man1/openssl-ecparam.pod
+doc/man1/openssl-enc.pod
+doc/man1/openssl-gendsa.pod
+doc/man1/openssl-genrsa.pod
+doc/man1/openssl-ocsp.pod
+doc/man1/openssl-passwd.pod
+doc/man1/openssl-pkcs12.pod
+doc/man1/openssl-pkcs8.pod
+doc/man1/openssl-pkeyutl.pod
+doc/man1/openssl-rand.pod
+doc/man1/openssl-req.pod
+doc/man1/openssl-rsautl.pod
+doc/man1/openssl-s_client.pod
+doc/man1/openssl-s_server.pod
+doc/man1/openssl-s_time.pod
+doc/man1/openssl-smime.pod
+doc/man1/openssl-speed.pod
+doc/man1/openssl-srp.pod
+doc/man1/openssl-ts.pod
+doc/man1/openssl-verify.pod
+doc/man1/openssl-x509.pod
+
 # error code files
 /crypto/err/openssl.txt.old
 /engines/e_afalg.txt.old

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,12 +177,12 @@ script:
           echo -e '\052\052 FAILED -- UPDATED FILES NOT COMMITED';
           travis_terminate 1;
       fi
-    - if test -n "$CHECKDOCS" && ! $make doc-nits; then
-          echo -e '\052\052 FAILED -- MAKE DOC-NITS';
-          travis_terminate 1;
-      fi
     - if test -n "$GENERATE" && ! $make build_all_generated; then
           echo -e '\052\052 FAILED -- MAKE BUILD_ALL_GENERATED';
+          travis_terminate 1;
+      fi
+    - if test -n "$CHECKDOCS" && ! $make doc-nits; then
+          echo -e '\052\052 FAILED -- MAKE DOC-NITS';
           travis_terminate 1;
       fi
     - if ! $make2; then

--- a/build.info
+++ b/build.info
@@ -1,6 +1,6 @@
 # Note that some of these directories are filtered in Configure.  Look for
 # %skipdir there for further explanations.
-SUBDIRS=crypto ssl apps test util tools fuzz engines providers
+SUBDIRS=crypto ssl apps test util tools fuzz engines providers doc/man1
 
 LIBS=libcrypto libssl
 INCLUDE[libcrypto]=. include
@@ -12,6 +12,7 @@ DEPEND[libssl]=libcrypto
 DEPEND[]=include/openssl/opensslconf.h include/openssl/opensslv.h \
          include/crypto/bn_conf.h include/crypto/dso_conf.h \
          doc/man7/openssl_user_macros.pod
+
 GENERATE[include/openssl/opensslconf.h]=include/openssl/opensslconf.h.in
 GENERATE[include/openssl/opensslv.h]=include/openssl/opensslv.h.in
 GENERATE[include/crypto/bn_conf.h]=include/crypto/bn_conf.h.in

--- a/doc/man1/build.info
+++ b/doc/man1/build.info
@@ -1,0 +1,84 @@
+
+DEPEND[]= \
+         openssl-ca.pod \
+         openssl-cms.pod \
+         openssl-crl.pod \
+         openssl-dgst.pod \
+         openssl-dhparam.pod \
+         openssl-dsaparam.pod \
+         openssl-ecparam.pod \
+         openssl-enc.pod \
+         openssl-gendsa.pod \
+         openssl-genrsa.pod \
+         openssl-ocsp.pod \
+         openssl-passwd.pod \
+         openssl-pkcs12.pod \
+         openssl-pkcs8.pod \
+         openssl-pkeyutl.pod \
+         openssl-rand.pod \
+         openssl-req.pod \
+         openssl-rsautl.pod \
+         openssl-s_client.pod \
+         openssl-s_server.pod \
+         openssl-s_time.pod \
+         openssl-smime.pod \
+         openssl-speed.pod \
+         openssl-srp.pod \
+         openssl-ts.pod \
+         openssl-verify.pod \
+         openssl-x509.pod
+
+DEPEND[openssl-ca.pod]=../perlvars.pm
+GENERATE[openssl-ca.pod]=openssl-ca.pod.in
+DEPEND[openssl-cms.pod]=../perlvars.pm
+GENERATE[openssl-cms.pod]=openssl-cms.pod.in
+DEPEND[openssl-crl.pod]=../perlvars.pm
+GENERATE[openssl-crl.pod]=openssl-crl.pod.in
+DEPEND[openssl-dgst.pod]=../perlvars.pm
+GENERATE[openssl-dgst.pod]=openssl-dgst.pod.in
+DEPEND[openssl-dhparam.pod]=../perlvars.pm
+GENERATE[openssl-dhparam.pod]=openssl-dhparam.pod.in
+DEPEND[openssl-dsaparam.pod]=../perlvars.pm
+GENERATE[openssl-dsaparam.pod]=openssl-dsaparam.pod.in
+DEPEND[openssl-ecparam.pod]=../perlvars.pm
+GENERATE[openssl-ecparam.pod]=openssl-ecparam.pod.in
+DEPEND[openssl-enc.pod]=../perlvars.pm
+GENERATE[openssl-enc.pod]=openssl-enc.pod.in
+DEPEND[openssl-gendsa.pod]=../perlvars.pm
+GENERATE[openssl-gendsa.pod]=openssl-gendsa.pod.in
+DEPEND[openssl-genrsa.pod]=../perlvars.pm
+GENERATE[openssl-genrsa.pod]=openssl-genrsa.pod.in
+DEPEND[openssl-ocsp.pod]=../perlvars.pm
+GENERATE[openssl-ocsp.pod]=openssl-ocsp.pod.in
+DEPEND[openssl-passwd.pod]=../perlvars.pm
+GENERATE[openssl-passwd.pod]=openssl-passwd.pod.in
+DEPEND[openssl-pkcs8.pod]=../perlvars.pm
+GENERATE[openssl-pkcs8.pod]=openssl-pkcs8.pod.in
+DEPEND[openssl-pkcs12.pod]=../perlvars.pm
+GENERATE[openssl-pkcs12.pod]=openssl-pkcs12.pod.in
+DEPEND[openssl-pkeyutl.pod]=../perlvars.pm
+GENERATE[openssl-pkeyutl.pod]=openssl-pkeyutl.pod.in
+DEPEND[openssl-rand.pod]=../perlvars.pm
+GENERATE[openssl-rand.pod]=openssl-rand.pod.in
+DEPEND[openssl-req.pod]=../perlvars.pm
+GENERATE[openssl-req.pod]=openssl-req.pod.in
+DEPEND[openssl-rsautl.pod]=../perlvars.pm
+GENERATE[openssl-rsautl.pod]=openssl-rsautl.pod.in
+DEPEND[openssl-s_client.pod]=../perlvars.pm
+GENERATE[openssl-s_client.pod]=openssl-s_client.pod.in
+DEPEND[openssl-s_server.pod]=../perlvars.pm
+GENERATE[openssl-s_server.pod]=openssl-s_server.pod.in
+DEPEND[openssl-s_time.pod]=../perlvars.pm
+GENERATE[openssl-s_time.pod]=openssl-s_time.pod.in
+DEPEND[openssl-smime.pod]=../perlvars.pm
+GENERATE[openssl-smime.pod]=openssl-smime.pod.in
+DEPEND[openssl-speed.pod]=../perlvars.pm
+GENERATE[openssl-speed.pod]=openssl-speed.pod.in
+DEPEND[openssl-srp.pod]=../perlvars.pm
+GENERATE[openssl-srp.pod]=openssl-srp.pod.in
+DEPEND[openssl-ts.pod]=../perlvars.pm
+GENERATE[openssl-ts.pod]=openssl-ts.pod.in
+DEPEND[openssl-verify.pod]=../perlvars.pm
+GENERATE[openssl-verify.pod]=openssl-verify.pod.in
+DEPEND[openssl-x509.pod]=../perlvars.pm
+GENERATE[openssl-x509.pod]=openssl-x509.pod.in

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-ca - sample minimal CA application
@@ -54,10 +59,9 @@ B<openssl> B<ca>
 [B<-create_serial>]
 [B<-rand_serial>]
 [B<-multivalue-rdn>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-sm2-id> I<string>]
 [B<-sm2-hex-id> I<hex-string>]
+{- $OpenSSL::safe::opt_r_synopsys -}
 
 =for openssl ifdef engine sm2-id sm2-hex-id
 
@@ -294,10 +298,6 @@ C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 If B<-multi-rdn> is not used then the UID value is C<123456+CN=John Doe>.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-sm2-id> I<string>
 
 Specify the ID string to use when verifying an SM2 certificate. The ID string is
@@ -307,6 +307,8 @@ required by the SM2 signature algorithm for signing and verification.
 
 Specify a binary ID string to use when signing or verifying using an SM2
 certificate. The argument for this option is string of hexadecimal digits.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-cms - CMS utility
@@ -38,10 +43,6 @@ B<openssl> B<cms>
 [B<-text>]
 [B<-noout>]
 [B<-print>]
-[B<-CAfile> I<file>]
-[B<-CApath> I<dir>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-attime> I<timestamp>]
 [B<-check_ss_sig>]
 [B<-crl_check>]
@@ -97,11 +98,11 @@ B<openssl> B<cms>
 [B<-inkey> I<file>]
 [B<-keyopt> I<name>:I<parameter>]
 [B<-passin> I<arg>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-to> I<addr>]
 [B<-from> I<addr>]
 [B<-subject> I<subj>]
+{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_trust_synopsis -}
 [I<cert.pem> ...]
 
 =for openssl ifdef des-wrap engine
@@ -286,10 +287,6 @@ structure is being checked.
 For the B<-cmsout> operation print out all fields of the CMS structure. This
 is mainly useful for testing purposes.
 
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
-
 =item B<-md> I<digest>
 
 Digest algorithm to use when signing or resigning. If not present then the
@@ -462,15 +459,6 @@ or to modify default parameters for ECDH.
 The private key password source. For more information about the format of B<arg>
 see L<openssl(1)/Pass Phrase Options>.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
-=item I<cert.pem> ...
-
-One or more certificates of message recipients: used when encrypting
-a message.
-
 =item B<-to>, B<-from>, B<-subject>
 
 The relevant mail headers. These are included outside the signed
@@ -488,6 +476,15 @@ B<-verify_ip>, B<-verify_name>, B<-x509_strict>
 
 Set various certificate chain validation options. See the
 L<openssl-verify(1)> manual page for details.
+
+{- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_r_item -}
+
+=item I<cert.pem> ...
+
+One or more certificates of message recipients: used when encrypting
+a message.
 
 =back
 

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-crl - CRL utility
@@ -20,10 +25,7 @@ B<openssl> B<crl>
 [B<-issuer>]
 [B<-lastupdate>]
 [B<-nextupdate>]
-[B<-CAfile> I<file>]
-[B<-CApath> I<dir>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
 
 =for openssl ifdef hash_old
 
@@ -94,9 +96,7 @@ Output the lastUpdate field.
 
 Output the nextUpdate field.
 
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
+{- $OpenSSL::safe::opt_trust_item -}
 
 =back
 

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-dgst - perform digest operations
@@ -25,10 +30,9 @@ B<openssl> B<dgst>|I<digest>
 [B<-sigopt> I<nm>:I<v>]
 [B<-hmac> I<key>]
 [B<-fips-fingerprint>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
 [B<-engine_impl>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<file> ...]
 
 =head1 DESCRIPTION
@@ -164,10 +168,6 @@ for example exactly 32 chars for gost-mac.
 The L<openssl-mac(1)> command should be preferred to using this command line
 option.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-fips-fingerprint>
 
 Compute HMAC using a specific key for certain OpenSSL-FIPS operations.
@@ -183,6 +183,8 @@ specified.
 
 When used with the B<-engine> option, it specifies to also use
 engine I<id> for digest operations.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =item I<file> ...
 

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-dhparam - DH parameter manipulation and generation
@@ -20,9 +25,8 @@ B<openssl dhparam>
 [B<-2>]
 [B<-3>]
 [B<-5>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<numbits>]
 
 =for openssl ifdef dsaparam engine
@@ -80,10 +84,6 @@ input file is ignored and parameters are generated instead. If not
 present but I<numbits> is present, parameters are generated with the
 default generator 2.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item I<numbits>
 
 This option specifies that a parameter set should be generated of size
@@ -112,6 +112,8 @@ Specifying an engine (by its unique I<id> string) will cause B<dhparam>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-dsaparam - DSA parameter manipulation and generation
@@ -15,11 +20,10 @@ B<openssl dsaparam>
 [B<-noout>]
 [B<-text>]
 [B<-C>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-genkey>]
 [B<-engine> I<id>]
 [B<-verbose>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<numbits>]
 
 =head1 DESCRIPTION
@@ -75,10 +79,6 @@ be loaded by calling the get_dsaXXX() function.
 This option will generate a DSA either using the specified or generated
 parameters.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-engine> I<id>
 
 Specifying an engine (by its unique I<id> string) will cause this command
@@ -89,6 +89,8 @@ for all available algorithms.
 =item B<-verbose>
 
 Print extra details about the operations being performed.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =item I<numbits>
 

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-ecparam - EC parameter manipulation and generation
@@ -22,10 +27,9 @@ B<openssl ecparam>
 [B<-conv_form> I<arg>]
 [B<-param_enc> I<arg>]
 [B<-no_seed>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-genkey>]
 [B<-engine> I<id>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine
 
@@ -122,16 +126,14 @@ is included in the ECParameters structure (see RFC 3279).
 
 This option will generate an EC private key using the specified parameters.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-engine> I<id>
 
 Specifying an engine (by its unique I<id> string) will cause B<ecparam>
 to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-enc - symmetric cipher routines
@@ -36,9 +41,8 @@ B<openssl> B<enc>|I<cipher>
 [B<-nopad>]
 [B<-debug>]
 [B<-none>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef z engine
 
@@ -190,9 +194,7 @@ or zlib-dynamic option.
 
 Use NULL cipher (no encryption or decryption of input).
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-gendsa - generate a DSA private key from a set of parameters
@@ -21,10 +26,9 @@ B<openssl> B<gendsa>
 [B<-des>]
 [B<-des3>]
 [B<-idea>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
 [B<-verbose>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<paramfile>]
 
 =for openssl ifdef engine
@@ -53,10 +57,6 @@ These options encrypt the private key with specified
 cipher before outputting it. A pass phrase is prompted for.
 If none of these options is specified no encryption is used.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-engine> I<id>
 
 Specifying an engine (by its unique I<id> string) will cause this command
@@ -73,6 +73,8 @@ Print extra details about the operations being performed.
 The DSA parameter file to use. The parameters in this file determine
 the size of the private key. DSA parameters can be generated and
 examined using the L<openssl-dsaparam(1)> command.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-genrsa - generate an RSA private key
@@ -23,11 +28,10 @@ B<openssl> B<genrsa>
 [B<-des3>]
 [B<-idea>]
 [B<-f4>|B<-3>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
 [B<-primes> I<num>]
 [B<-verbose>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [B<numbits>]
 
 =for openssl ifdef engine
@@ -65,10 +69,6 @@ for if it is not supplied via the B<-passout> argument.
 
 The public exponent to use, either 65537 or 3. The default is 65537.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-engine> I<id>
 
 Specifying an engine (by its unique I<id> string) will cause this command
@@ -86,6 +86,8 @@ RSA key, which is defined in RFC 8017.
 =item B<-verbose>
 
 Print extra details about the operations being performed.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =item B<numbits>
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-ocsp - Online Certificate Status Protocol utility
@@ -30,10 +35,6 @@ B<openssl> B<ocsp>
 [B<-multi> I<process-count>]
 [B<-header>]
 [B<-path>]
-[B<-CApath> I<dir>]
-[B<-CAfile> I<file>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-attime> I<timestamp>]
 [B<-check_ss_sig>]
 [B<-crl_check>]
@@ -89,6 +90,7 @@ B<openssl> B<ocsp>
 [B<-nrequest> I<n>]
 [B<-rcid> I<digest>]
 [B<-I<digest>>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
 
 =for openssl ifdef multi
 
@@ -207,10 +209,6 @@ each child is willing to wait for the client's OCSP response.
 This option is available on POSIX systems (that support the fork() and other
 required unix system-calls).
 
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
-
 =item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
 B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,
 B<-inhibit_map>, B<-no_alt_chains>, B<-no_check_time>, B<-partial_chain>, B<-policy>,
@@ -309,6 +307,8 @@ This option sets digest algorithm to use for certificate identification in the
 OCSP request. Any digest supported by the OpenSSL B<dgst> command can be used.
 The default is SHA-1. This option may be used multiple times to specify the
 digest used by subsequent certificate identifiers.
+
+{- $OpenSSL::safe::opt_trust_item -}
 
 =back
 

--- a/doc/man1/openssl-passwd.pod.in
+++ b/doc/man1/openssl-passwd.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-passwd - compute password hashes
@@ -20,8 +25,7 @@ B<openssl passwd>
 [B<-noverify>]
 [B<-quiet>]
 [B<-table>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 {I<password>}
 
 =for openssl ifdef crypt
@@ -93,9 +97,7 @@ Don't output warnings when passwords given at the command line are truncated.
 In the output list, prepend the cleartext password and a TAB character
 to each password hash.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-pkcs12 - PKCS#12 file utility
@@ -36,13 +41,9 @@ B<openssl> B<pkcs12>
 [B<-password> I<arg>]
 [B<-passin> I<arg>]
 [B<-passout> I<arg>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
-[B<-CAfile> I<file>]
-[B<-CApath> I<dir>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-CSP> I<name>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine
 
@@ -263,17 +264,13 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 Don't attempt to provide the MAC integrity.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
-
 =item B<-CSP> I<name>
 
 Write I<name> as a Microsoft CSP name.
+
+{- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-pkcs8 - PKCS#8 format private key conversion tool
@@ -17,8 +22,6 @@ B<openssl> B<pkcs8>
 [B<-passout> I<arg>]
 [B<-iter> I<count>]
 [B<-noiter>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-nocrypt>]
 [B<-traditional>]
 [B<-v2> I<alg>]
@@ -29,6 +32,7 @@ B<openssl> B<pkcs8>
 [B<-scrypt_N> I<N>]
 [B<-scrypt_r> I<r>]
 [B<-scrypt_p> I<p>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine scrypt scrypt_N scrypt_r scrypt_p
 
@@ -113,10 +117,6 @@ This option does not encrypt private keys at all and should only be used
 when absolutely necessary. Certain software such as some versions of Java
 code signing software used unencrypted private keys.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-v2> I<alg>
 
 This option sets the PKCS#5 v2.0 algorithm.
@@ -157,6 +157,8 @@ B<-scrypt_p> and B<-v2> options.
 =item B<-scrypt_N> I<N>, B<-scrypt_r> I<r>, B<-scrypt_p> I<p>
 
 Sets the scrypt I<N>, I<r> or I<p> parameters.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-pkeyutl - public key algorithm utility
@@ -33,10 +38,9 @@ B<openssl> B<pkeyutl>
 [B<-pkeyopt_passin> I<opt>[:I<passarg>]]
 [B<-hexdump>]
 [B<-asn1parse>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
 [B<-engine_impl>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine engine_impl
 
@@ -179,10 +183,6 @@ hex dump the output data.
 Parse the ASN.1 output data, this is useful when combined with the
 B<-verifyrecover> option when an ASN1 structure is signed.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-engine> I<id>
 
 Specifying an engine (by its unique I<id> string) will cause this command
@@ -194,6 +194,8 @@ for all available algorithms.
 
 When used with the B<-engine> option, it specifies to also use
 engine I<id> for crypto operations.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-rand - generate pseudo-random bytes
@@ -9,10 +14,9 @@ openssl-rand - generate pseudo-random bytes
 B<openssl rand>
 [B<-help>]
 [B<-out> I<file>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-base64>]
 [B<-hex>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 I<num>
 
 =for openssl ifdef engine
@@ -34,10 +38,6 @@ Print out a usage message.
 
 Write to I<file> instead of standard output.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-base64>
 
 Perform base64 encoding on the output.
@@ -45,6 +45,8 @@ Perform base64 encoding on the output.
 =item B<-hex>
 
 Show the output as a hex string.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-req - PKCS#10 certificate request and certificate generating utility
@@ -20,8 +25,6 @@ B<openssl> B<req>
 [B<-verify>]
 [B<-modulus>]
 [B<-new>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-newkey> I<arg>]
 [B<-nodes>]
 [B<-key> I<filename>]
@@ -50,6 +53,7 @@ B<openssl> B<req>
 [B<-engine> I<id>]
 [B<-sm2-id> I<string>]
 [B<-sm2-hex-id> I<hex-string>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine keygen_engine sm2-id sm2-hex-id
 
@@ -131,10 +135,6 @@ in the configuration file and any requested extensions.
 
 If the B<-key> option is not used it will generate a new RSA private
 key using information specified in the configuration file.
-
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
 
 =item B<-newkey> I<arg>
 
@@ -333,6 +333,8 @@ string is required by the SM2 signature algorithm for signing and verification.
 
 Specify a binary ID string to use when verifying an SM2 certificate request. The
 argument for this option is string of hexadecimal digits.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-rsautl.pod.in
+++ b/doc/man1/openssl-rsautl.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-rsautl - RSA utility
@@ -18,13 +23,12 @@ B<openssl> B<rsautl>
 [B<-verify>]
 [B<-encrypt>]
 [B<-decrypt>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-pkcs>]
 [B<-ssl>]
 [B<-raw>]
 [B<-hexdump>]
 [B<-asn1parse>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine
 
@@ -85,10 +89,6 @@ Encrypt the input data using an RSA public key.
 
 Decrypt the input data using an RSA private key.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-pkcs>, B<-oaep>, B<-ssl>, B<-raw>
 
 The padding to use: PKCS#1 v1.5 (the default), PKCS#1 OAEP,
@@ -104,6 +104,8 @@ Hex dump the output data.
 
 Parse the ASN.1 output data, this is useful when combined with the
 B<-verify> option.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-s_client - SSL/TLS client program
@@ -27,19 +32,9 @@ B<openssl> B<s_client>
 [B<-keyform> B<DER>|B<PEM>]
 [B<-cert_chain> I<filename>]
 [B<-build_chain>]
-[B<-xkey>]
-[B<-xcert>]
-[B<-xchain>]
-[B<-xchain_build>]
-[B<-xcertform> B<DER>|B<PEM>]
-[B<-xkeyform> B<DER>|B<PEM>]
 [B<-pass> I<arg>]
-[B<-CApath> I<directory>]
-[B<-CAfile> I<filename>]
 [B<-chainCApath> I<directory>]
 [B<-chainCAfile> I<filename>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-requestCAfile> I<filename>]
 [B<-dane_tlsa_domain> I<domain>]
 [B<-dane_tlsa_rrdata> I<rrdata>]
@@ -126,8 +121,6 @@ B<openssl> B<s_client>
 [B<-no_ticket>]
 [B<-sess_out> I<filename>]
 [B<-sess_in> I<filename>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-serverinfo> I<types>]
 [B<-status>]
 [B<-alpn> I<protocols>]
@@ -138,6 +131,9 @@ B<openssl> B<s_client>
 [B<-keylogfile> I<file>]
 [B<-early_data> I<file>]
 [B<-enable_pha>]
+{- $OpenSSL::safe::opt_x_synopsis -}
+{- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<host>:I<port>]
 
 =for openssl ifdef engine ssl_client_engine ct noct ctlogfile
@@ -176,7 +172,7 @@ select the host and port using the optional target positional argument instead.
 If neither this nor the target positional argument are specified then an attempt
 is made to connect to the local host on port 4433.
 
-=item B<-bind> I<host:port>]
+=item B<-bind> I<host:port>
 
 This specifies the host address and or port to bind as the source for the
 connection.  For Unix-domain sockets the port is ignored and the host is
@@ -218,14 +214,14 @@ Use IPv6 only.
 =item B<-servername> I<name>
 
 Set the TLS SNI (Server Name Indication) extension in the ClientHello message to
-the given value. 
-If B<-servername> is not provided, the TLS SNI extension will be populated with 
-the name given to B<-connect> if it follows a DNS name format. If B<-connect> is 
+the given value.
+If B<-servername> is not provided, the TLS SNI extension will be populated with
+the name given to B<-connect> if it follows a DNS name format. If B<-connect> is
 not provided either, the SNI is set to "localhost".
 This is the default since OpenSSL 1.1.1.
 
-Even though SNI should normally be a DNS name and not an IP address, if 
-B<-servername> is provided then that name will be sent, regardless of whether 
+Even though SNI should normally be a DNS name and not an IP address, if
+B<-servername> is provided then that name will be sent, regardless of whether
 it is a DNS name or not.
 
 This option cannot be used in conjunction with B<-noservername>.
@@ -271,24 +267,6 @@ B<-cert> option.
 Specify whether the application should build the certificate chain to be
 provided to the server.
 
-=item B<-xkey> I<infile>, B<-xcert> I<infile>, B<-xchain>
-
-Specify an extra certificate, private key and certificate chain. These behave
-in the same manner as the B<-cert>, B<-key> and B<-cert_chain> options.  When
-specified, the callback returning the first valid chain will be in use by the
-client.
-
-=item B<-xchain_build>
-
-Specify whether the application should build the certificate chain to be
-provided to the server for the extra certificates provided via B<-xkey> I<infile>,
-B<-xcert> I<infile>, B<-xchain> options.
-
-=item B<-xcertform> B<DER>|B<PEM>, B<-xkeyform> B<DER>|B<PEM>
-
-Extra certificate and private key format respectively.
-See L<openssl(1)/Format Options> for details.
-
 =item B<-pass> I<arg>
 
 the private key password source. For more information about the format of I<arg>
@@ -313,10 +291,6 @@ Option which determines how the subject or issuer names are displayed. The
 I<option> argument can be a single option or multiple options separated by
 commas.  Alternatively the B<-nameopt> switch may be used more than once to
 set multiple options. See the L<openssl-x509(1)> manual page for details.
-
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
 
 =item B<-chainCApath> I<directory>
 
@@ -667,10 +641,6 @@ to attempt to obtain a functional reference to the specified engine,
 thus initialising it if needed. The engine will then be set as the default
 for all available algorithms.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-serverinfo> I<types>
 
 A list of comma-separated TLS Extension Types (numbers between 0 and
@@ -734,6 +704,12 @@ Rather than providing B<-connect>, the target hostname and optional port may
 be provided as a single positional argument after all options. If neither this
 nor B<-connect> are provided, falls back to attempting to connect to
 I<localhost> on port I<4433>.
+
+{- $OpenSSL::safe::opt_x_item -}
+
+{- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -10,6 +10,11 @@
 openssl-s_server - SSL/TLS server program
 
 =head1 SYNOPSIS
+{- OpenSSL::safe::form('cert', 'certificate', 'pem', 'DER');
+OpenSSL::safe::form('key', 'private key', 'DER', 'PEM');
+OpenSSL::safe::form('dcert', 'additional certificate', 'pem', 'der');
+OpenSSL::safe::form('dkey', 'additional private key', 'PEM', 'DER');
+OpenSSL::safe::form('CRL', 'certificate revocation list', 'PEM', 'DER'); -}
 
 B<openssl> B<s_server>
 [B<-help>]
@@ -26,14 +31,10 @@ B<openssl> B<s_server>
 [B<-nameopt> I<val>]
 [B<-naccept> I<+int>]
 [B<-serverinfo> I<val>]
-[B<-certform> B<DER>|B<PEM>]
 [B<-key> I<infile>]
-[B<-keyform> B<DER>|B<PEM>]
 [B<-pass> I<val>]
 [B<-dcert> I<infile>]
-[B<-dcertform> B<DER>|B<PEM>]
 [B<-dkey> I<infile>]
-[B<-dkeyform> B<DER>|B<PEM>]
 [B<-dpass> I<val>]
 [B<-nbio_test>]
 [B<-crlf>]
@@ -179,6 +180,7 @@ B<openssl> B<s_server>
 {- $OpenSSL::safe::opt_x_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::form_synopsis -}
 
 =for openssl ifdef unix 4 6 unlink no_dhe nextprotoneg use_srtp engine
 
@@ -285,20 +287,10 @@ followed by "length" bytes of extension data).  If the client sends
 an empty TLS ClientHello extension matching the type, the corresponding
 ServerHello extension will be returned.
 
-=item B<-certform> B<DER>|B<PEM>, B<-CRLForm> B<DER>|B<PEM>
-
-The certificate and CRL format; the default is PEM.
-See L<openssl(1)/Format Options> for details.
-
 =item B<-key> I<infile>
 
 The private key to use. If not specified then the certificate file will
 be used.
-
-=item B<-keyform> B<DER>|B<PEM>
-
-The key format; the default is B<PEM>.
-See L<openssl(1)/Format Options> for details.
 
 =item B<-pass> I<val>
 
@@ -322,11 +314,6 @@ by using an appropriate certificate.
 A file containing trusted certificates to use when attempting to build the
 server certificate chain when a certificate specified via the B<-dcert> option
 is in use.
-
-=item B<-dcertform> B<DER>|B<PEM>, B<-dkeyform> B<DER>|B<PEM>
-
-The format of the certificate and private key; the default is B<PEM>
-see L<openssl(1)/Format Options>.
 
 =item B<-dpass> I<val>
 
@@ -718,6 +705,8 @@ by the client in binary mode.
 {- $OpenSSL::safe::opt_trust_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::form_items -}
 
 =back
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-s_server - SSL/TLS server program
@@ -36,10 +41,6 @@ B<openssl> B<s_server>
 [B<-msg>]
 [B<-msgfile> I<outfile>]
 [B<-state>]
-[B<-CAfile> I<infile>]
-[B<-CApath> I<dir>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-nocert>]
 [B<-quiet>]
 [B<-no_resume_ephemeral>]
@@ -52,8 +53,6 @@ B<openssl> B<s_server>
 [B<-tlsextdebug>]
 [B<-HTTP>]
 [B<-id_prefix> I<val>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-keymatexport> I<val>]
 [B<-keymatexportlen> I<+int>]
 [B<-CRL> I<infile>]
@@ -146,13 +145,6 @@ B<openssl> B<s_server>
 [B<-no_alt_chains>]
 [B<-no_check_time>]
 [B<-allow_proxy_certs>]
-[B<-xkey>]
-[B<-xcert>]
-[B<-xchain>]
-[B<-xchain_build>]
-[B<-CRLform> B<DER>|B<PEM>]
-[B<-xcertform> B<DER>|B<PEM>]
-[B<-xkeyform> B<DER>|B<PEM>]
 [B<-nbio>]
 [B<-psk_identity> I<val>]
 [B<-psk_hint> I<val>]
@@ -184,6 +176,9 @@ B<openssl> B<s_server>
 [B<-anti_replay>]
 [B<-no_anti_replay>]
 [B<-http_server_binmode>]
+{- $OpenSSL::safe::opt_x_synopsis -}
+{- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef unix 4 6 unlink no_dhe nextprotoneg use_srtp engine
 
@@ -300,7 +295,7 @@ See L<openssl(1)/Format Options> for details.
 The private key to use. If not specified then the certificate file will
 be used.
 
-=item B<-keyform> B<DER>|B<PEM>]
+=item B<-keyform> B<DER>|B<PEM>
 
 The key format; the default is B<PEM>.
 See L<openssl(1)/Format Options> for details.
@@ -339,25 +334,6 @@ The passphrase for the additional private key.
 For more information about the format of I<val>,
 see L<openssl(1)/Pass Phrase Options>.
 
-=item B<-xkey> I<infile>, B<-xcert> I<infile>, B<-xchain>
-
-Specify an extra certificate, private key and certificate chain. These behave
-in the same manner as the B<-cert>, B<-key> and B<-cert_chain> options.  When
-specified, the callback returning the first valid chain will be in use by
-the server.
-
-=item B<-xchain_build>
-
-Specify whether the application should build the certificate chain to be
-provided to the client for the extra certificates provided via B<-xkey> I<infile>,
-B<-xcert> I<infile>, B<-xchain> options.
-
-=item B<-xcertform> B<DER>|B<PEM>, B<-xkeyform> B<DER>|B<PEM>
-
-The format for the extra certificate and private key, respectively;
-the default format is B<PEM>.
-see L<openssl(1)/Pass Phrase Options>.
-
 =item B<-nbio_test>
 
 Tests non blocking I/O.
@@ -381,10 +357,6 @@ File to send output of B<-msg> or B<-trace> to, default standard output.
 =item B<-state>
 
 Prints the SSL session states.
-
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
 
 =item B<-chainCApath> I<dir>
 
@@ -440,10 +412,6 @@ Generate SSL/TLS session IDs prefixed by I<val>. This is mostly useful
 for testing any SSL/TLS code (eg. proxies) that wish to deal with multiple
 servers, when each of which might be generating a unique range of session
 IDs (eg. with a certain prefix).
-
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
 
 =item B<-verify_return_error>
 
@@ -744,6 +712,12 @@ data that was sent will be rejected.
 
 When acting as web-server (using option B<-WWW> or B<-HTTP>) open files requested
 by the client in binary mode.
+
+{- $OpenSSL::safe::opt_x_item -}
+
+{- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-s_time - SSL/TLS performance timing program
@@ -12,10 +17,6 @@ B<openssl> B<s_time>
 [B<-www> I<page>]
 [B<-cert> I<filename>]
 [B<-key> I<filename>]
-[B<-CApath> I<directory>]
-[B<-cafile> I<filename>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-reuse>]
 [B<-new>]
 [B<-verify> I<depth>]
@@ -29,6 +30,7 @@ B<openssl> B<s_time>
 [B<-bugs>]
 [B<-cipher> I<cipherlist>]
 [B<-ciphersuites> I<val>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
 
 =for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3
 
@@ -91,10 +93,6 @@ The directory to use for server certificate verification. This directory
 must be in "hash format", see L<openssl-verify(1)> for more information.
 These are also used when building the client certificate chain.
 
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
-
 =item B<-new>
 
 Performs the timing test using a new session ID for each connection.
@@ -144,6 +142,8 @@ Specifies how long (in seconds) this command should establish connections
 and optionally transfer payload data from a server. Server and client
 performance and the link speed determine how many connections it
 can establish.
+
+{- $OpenSSL::safe::opt_trust_item -}
 
 =back
 

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-smime - S/MIME utility
@@ -18,10 +23,6 @@ B<openssl> B<smime>
 [B<-crlfeol>]
 [B<-I<cipher>>]
 [B<-in> I<file>]
-[B<-CAfile> I<file>]
-[B<-CApath> I<dir>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-attime> I<timestamp>]
 [B<-check_ss_sig>]
 [B<-crl_check>]
@@ -66,9 +67,9 @@ B<openssl> B<smime>
 [B<-indef>]
 [B<-noindef>]
 [B<-stream>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-md> I<digest>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_r_synopsis -}
 I<cert.pem> ...
 
 =for openssl ifdef engine
@@ -179,10 +180,6 @@ message if encrypting or signing. If decrypting or verifying it strips
 off text headers: if the decrypted or verified message is not of MIME
 type text/plain then an error occurs.
 
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
-
 =item B<-md> I<digest>
 
 Digest algorithm to use when signing or resigning. If not present then the
@@ -283,10 +280,6 @@ specified, the argument is given to the engine as a key identifier.
 The private key password source. For more information about the format of I<arg>
 see L<openssl(1)/Pass Phrase Options>.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-to>, B<-from>, B<-subject>
 
 The relevant mail headers. These are included outside the signed
@@ -304,6 +297,10 @@ B<-verify_ip>, B<-verify_name>, B<-x509_strict>
 
 Set various options of certificate chain verification. See
 L<openssl-verify(1)> manual page for details.
+
+{- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =item I<cert.pem> ...
 

--- a/doc/man1/openssl-speed.pod.in
+++ b/doc/man1/openssl-speed.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-speed - test library performance
@@ -14,11 +19,10 @@ B<openssl speed>
 [B<-hmac> I<algo>]
 [B<-cmac> I<algo>]
 [B<-decrypt>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-primes> I<num>]
 [B<-seconds> I<num>]
 [B<-bytes> I<num>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<algorithm> ...]
 
 =for openssl ifdef cmac multi async_jobs engine
@@ -71,10 +75,6 @@ C<openssl speed -cmac aes128>.
 
 Time the decryption instead of encryption. Affects only the EVP testing.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-primes> I<num>
 
 Generate a I<num>-prime RSA key and use it to run the benchmarks. This option
@@ -87,6 +87,8 @@ Run benchmarks for I<num> seconds.
 =item B<-bytes> I<num>
 
 Run benchmarks on I<num>-byte buffers. Affects ciphers, digests and the CSPRNG.
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =item I<algorithm> ...
 

--- a/doc/man1/openssl-srp.pod.in
+++ b/doc/man1/openssl-srp.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-srp - maintain SRP password file
@@ -20,8 +25,7 @@ B<openssl srp>
 [B<-userinfo> I<text>]
 [B<-passin> I<arg>]
 [B<-passout> I<arg>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 [I<user> ...]
 
 =for openssl ifdef engine
@@ -71,9 +75,7 @@ The password source for the input and output file.
 For more information about the format of B<arg>
 see L<openssl(1)/Pass Phrase Options>.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =back
 

--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-ts - Time Stamping Authority tool (client/server)
@@ -8,8 +13,6 @@ openssl-ts - Time Stamping Authority tool (client/server)
 
 B<openssl> B<ts>
 B<-query>
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-config> I<configfile>]
 [B<-data> I<file_to_hash>]
 [B<-digest> I<digest_bytes>]
@@ -20,6 +23,7 @@ B<-query>
 [B<-in> I<request.tsq>]
 [B<-out> I<request.tsq>]
 [B<-text>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 B<openssl> B<ts>
 B<-reply>
@@ -134,10 +138,6 @@ request with the following options:
 
 =over 4
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-config> I<configfile>
 
 The configuration file to use.
@@ -199,6 +199,8 @@ is stdout. (Optional)
 
 If this option is specified the output is human-readable text format
 instead of DER. (Optional)
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-verify - Utility to verify certificates
@@ -8,10 +13,6 @@ openssl-verify - Utility to verify certificates
 
 B<openssl> B<verify>
 [B<-help>]
-[B<-CAfile> I<file>]
-[B<-CApath> I<directory>]
-[B<-no-CAfile>]
-[B<-no-CApath>]
 [B<-allow_proxy_certs>]
 [B<-attime> I<timestamp>]
 [B<-check_ss_sig>]
@@ -51,6 +52,7 @@ B<openssl> B<verify>
 [B<-show_chain>]
 [B<-sm2-id> I<string>]
 [B<-sm2-hex-id> I<hex-string>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
 [B<-->]
 [I<certificate> ...]
 
@@ -67,10 +69,6 @@ This command verifies certificate chains.
 =item B<-help>
 
 Print out a usage message.
-
-=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>
-
-See L<openssl(1)/Trusted Certificate Options> for more information.
 
 =item B<-allow_proxy_certs>
 
@@ -317,6 +315,8 @@ certificate. The argument for this option is string of hexadecimal digits.
 Indicates the last option. All arguments following this are assumed to be
 certificate files. This is useful if the first certificate filename begins
 with a B<-->.
+
+{- $OpenSSL::safe::opt_trust_item -}
 
 =item I<certificate> ...
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -1,5 +1,10 @@
 =pod
 
+=begin comment
+{- join("\n", @autowarntext) -}
+
+=end comment
+
 =head1 NAME
 
 openssl-x509 - Certificate display and signing utility
@@ -63,10 +68,9 @@ B<openssl> B<x509>
 [B<-extfile> I<filename>]
 [B<-extensions> I<section>]
 [B<-sigopt> I<nm>:I<v>]
-[B<-rand> I<files>]
-[B<-writerand> I<file>]
 [B<-engine> I<id>]
 [B<-preserve_dates>]
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =for openssl ifdef engine subject_hash_old issuer_hash_old
 
@@ -117,10 +121,6 @@ Any digest supported by the L<openssl-dgst(1)> command can be used.
 If not specified then SHA1 is used with B<-fingerprint> or
 the default digest for the signing algorithm is used, typically SHA256.
 
-=item B<-rand> I<files>, B<-writerand> I<file>
-
-See L<openssl(1)/Random State Options> for more information.
-
 =item B<-engine> I<id>
 
 Specifying an engine (by its unique I<id> string) will cause this command
@@ -133,6 +133,8 @@ for all available algorithms.
 When signing a certificate, preserve the "notBefore" and "notAfter" dates
 instead of adjusting them to current time and duration.
 Cannot be used with the B<-days> option.
+
+{- $OpenSSL::safe::opt_r_synopsis -}
 
 =back
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -613,7 +613,7 @@ The format of the input or output streams.
 
 Format of a private key input source.
 
-=item B<-CRLform> I<fornat>
+=item B<-CRLform> I<format>
 
 Format of a CRL input source.
 
@@ -729,6 +729,40 @@ with different filenames.
 
 Writes the seed data to the specified I<file> upon exit.
 This file can be used in a subsequent command invocation.
+
+=back
+
+=head2 Extended Verification Options
+
+Sometimes there may be more than one certificate chain leading to an
+end-entity certificate.
+This usually happens when a root or intermediate CA signs a certificate
+for another a CA in other organization.
+Another reason is when a CA might have intermediates that use two different
+signature formats, such as a SHA-1 and a SHA-256 digest.
+
+The following options can be used to provide data that will allow the
+OpenSSL command to generate an alternative chain.
+
+=over 4
+
+=item B<-xchain_build>
+
+Specify whether the application should build the certificate chain to be
+provided to the server for the extra certificates via the B<-xkey>,
+B<-xcert>, and B<-xchain> options.
+
+=item B<-xkey> I<infile>, B<-xcert> I<infile>, B<-xchain>
+
+Specify an extra certificate, private key and certificate chain. These behave
+in the same manner as the B<-cert>, B<-key> and B<-cert_chain> options.  When
+specified, the callback returning the first valid chain will be in use by the
+client.
+
+=item B<-xcertform> B<DER>|B<PEM>, B<-xkeyform> B<DER>|B<PEM>
+
+The input format for the extra certifcate and key, respectively.
+See L<openssl(1)/Format Options> for details.
 
 =back
 

--- a/doc/perlvars.pm
+++ b/doc/perlvars.pm
@@ -127,3 +127,33 @@ $OpenSSL::safe::opt_s_item = ""
 . "B<-record_padding> I<padding>, B<-debug_broken_protocol>, B<-no_middlebox>\n"
 . "\n"
 . "See L<SSL_CONF_cmd(3)/SUPPORTED COMMAND LINE COMMANDS> for details.";
+
+
+package OpenSSL::safe;
+$form_synopsis = "";
+$form_items = "";
+
+#    &form(OPTNAME, DESCRIPTION, LIST, OF, FORMATS);
+# For example
+#    &form('key', 'private key', 'PEM', 'DER', 'ENGINE')
+# The first format is the default
+sub form {
+    my $name = shift;
+    my $what = shift;
+    my $deflt = uc(@_[0]);
+    my $formats = join('|', map { my $U = uc($_); "B<$U>" } sort @_);
+
+    $form_synopsis .= "\n"
+        if $form_synopsis ne "";
+    $form_synopsis .= "[B<-${name}form> $formats]";
+    $form_items .= <<EOF;
+
+=item B<-${name}form> $formats
+
+The format of the $what; the default is B<$deflt>.
+See L<openssl(1)/Format Options> for details.
+EOF
+    "";
+
+}
+1;

--- a/doc/perlvars.pm
+++ b/doc/perlvars.pm
@@ -1,0 +1,129 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+
+# Set some Perl variables for use by util/dofile.pl when processing
+# POD files (mainly man1).
+
+# Verify options
+$OpenSSL::safe::opt_v_synopsis = ""
+. "[B<-attime> I<timestamp>]\n"
+. "[B<-check_ss_sig>]\n"
+. "[B<-crl_check>]\n"
+. "[B<-crl_check_all>]\n"
+. "[B<-explicit_policy>]\n"
+. "[B<-extended_crl>]\n"
+. "[B<-ignore_critical>]\n"
+. "[B<-inhibit_any>]\n"
+. "[B<-inhibit_map>]\n"
+. "[B<-partial_chain>]\n"
+. "[B<-policy> I<arg>]\n"
+. "[B<-policy_check>]\n"
+. "[B<-policy_print>]\n"
+. "[B<-purpose> I<purpose>]\n"
+. "[B<-suiteB_128>]\n"
+. "[B<-suiteB_128_only>]\n"
+. "[B<-suiteB_192>]\n"
+. "[B<-trusted_first>]\n"
+. "[B<-no_alt_chains>]\n"
+. "[B<-use_deltas>]\n"
+. "[B<-auth_level> I<num>]\n"
+. "[B<-verify_depth> I<num>]\n"
+. "[B<-verify_email> I<email>]\n"
+. "[B<-verify_hostname> I<hostname>]\n"
+. "[B<-verify_ip> I<ip>]\n"
+. "[B<-verify_name> I<name>]\n"
+. "[B<-x509_strict>]\n"
+. "[B<-certfile> I<file>]";
+$OpenSSL::safe::opt_v_item = ""
+. "=item B<-attime>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,\n"
+. "B<-explicit_policy>, B<-extended_crl>, B<-ignore_critical>, B<-inhibit_any>,\n"
+. "B<-inhibit_map>, B<-no_alt_chains>, B<-partial_chain>, B<-policy>,\n"
+. "B<-policy_check>, B<-policy_print>, B<-purpose>, B<-suiteB_128>,\n"
+. "B<-suiteB_128_only>, B<-suiteB_192>, B<-trusted_first>, B<-use_deltas>,\n"
+. "B<-auth_level>, B<-verify_depth>, B<-verify_email>, B<-verify_hostname>,\n"
+. "B<-verify_ip>, B<-verify_name>, B<-x509_strict>\n"
+. "\n"
+. "Set various options of certificate chain verification.\n"
+. "See L<openssl(1)/Verification Options> for details.";
+
+
+# Extended validation options.
+$OpenSSL::safe::opt_x_synopsis = ""
+. "[B<-xkey>] I<infile>\n"
+. "[B<-xcert> I<file>]\n"
+. "[B<-xchain>] I<file>\n"
+. "[B<-xchain_build>] I<file>\n"
+. "[B<-xcertform> B<DER>|B<PEM>]>\n"
+. "[B<-xkeyform> B<DER>|B<PEM>]>";
+$OpenSSL::safe::opt_x_item = ""
+. "=item B<xkey> I<infile>, B<-xcert> I<file>, B<-xchain> I<file>,\n"
+. "B<-xchain_build> I<file>, B<-xcertform> B<DER>|B<PEM>,\n"
+. "B<-xkeyform> B<DER>|B<PEM>>\n"
+. "\n"
+. "Set extended certificate verification options.\n"
+. "See L<openssl(1)/Extended Verification Options> for details.";
+
+
+# Random State Options
+$OpenSSL::safe::opt_r_synopsis = ""
+. "[B<-rand> I<files>]\n"
+. "[B<-writerand> I<file>]";
+$OpenSSL::safe::opt_r_item = ""
+. "=item B<-rand> I<files>, B<-writerand> I<file>\n"
+. "\n"
+. "See L<openssl(1)/Random State Options> for details.";
+
+# Trusted certs options
+$OpenSSL::safe::opt_trust_synopsis = ""
+. "[B<-CAfile> I<file>]\n"
+. "[B<-no-CAfile>]\n"
+. "[B<-CApath> I<dir>]\n"
+. "[B<-no-CApath>]";
+$OpenSSL::safe::opt_trust_item = ""
+. "=item B<-CAfile> I<file>, B<-no-CAfile>, B<-CApath> I<dir>, B<-no-CApath>\n"
+. "\n"
+. "See L<openssl(1)/Trusted Certificate Options> for details.";
+
+# SSL connection options.
+# TODO(3.0) Not currently used.  The refactoring needs to be done, and
+# the options will probably be re-ordered.
+$OpenSSL::safe::opt_s_synopsis = ""
+. "[B<-bugs>]\n"
+. "[B<-no_comp>]\n"
+. "[B<-no_ticket>]\n"
+. "[B<-serverpref>]\n"
+. "[B<-legacy_renegotiation>]\n"
+. "[B<-no_renegotiation>]\n"
+. "[B<-legacy_server_connect>]\n"
+. "[B<-no_resumption_on_reneg>]\n"
+. "[B<-no_legacy_server_connect>]\n"
+. "[B<-allow_no_dhe_kex>]\n"
+. "[B<-prioritize_chacha>]\n"
+. "[B<-strict>]\n"
+. "[B<-sigalgs> I<algs>]\n"
+. "[B<-client_sigalgs> I<algs>]\n"
+. "[B<-groups> I<groups>]\n"
+. "[B<-curves> I<curves>]\n"
+. "[B<-named_curve> I<curves>]\n"
+. "[B<-cipher> I<ciphers>]\n"
+. "[B<-ciphersuites> I<1.3ciphers>]\n"
+. "[B<-min_protocol> I<minprot>]\n"
+. "[B<-max_protocol> I<maxprot>]\n"
+. "[B<-record_padding> I<padding>]\n"
+. "[B<-debug_broken_protocol>]\n"
+. "[B<-no_middlebox>]";
+$OpenSSL::safe::opt_s_item = ""
+. "=item B<-bugs>, B<-no_comp>, B<-no_ticket>, B<-serverpref>,"
+. "B<-legacy_renegotiation>, B<-no_renegotiation>, B<-legacy_server_connect>,\n"
+. "B<-no_resumption_on_reneg>, B<-no_legacy_server_connect>,\n"
+. "B<-allow_no_dhe_kex>, B<-prioritize_chacha>, B<-strict>, B<-sigalgs>\n"
+. "I<algs>, B<-client_sigalgs> I<algs>, B<-groups> I<groups>, B<-curves>\n"
+. "I<curves>, B<-named_curve> I<curves>, B<-cipher> I<ciphers>, B<-ciphersuites>\n"
+. "I<1.3ciphers>, B<-min_protocol> I<minprot>, B<-max_protocol> I<maxprot>,\n"
+. "B<-record_padding> I<padding>, B<-debug_broken_protocol>, B<-no_middlebox>\n"
+. "\n"
+. "See L<SSL_CONF_cmd(3)/SUPPORTED COMMAND LINE COMMANDS> for details.";


### PR DESCRIPTION
I am not sure this is worth doing because it put all the "form" (e.g., -certform, -keyform) items in together, as opposed to being next to the thing (e.g., -cert -key).  But it does show to @levitte that I'm learning Perl whether I want to or not :)