### PR TITLE
Clarify the description of the NULL argument in SSL_set1_host().

### DIFF
--- a/doc/man3/SSL_set1_host.pod
+++ b/doc/man3/SSL_set1_host.pod
@@ -20,7 +20,7 @@ These functions configure server hostname checks in the SSL client.
 
 SSL_set1_host() sets the expected DNS hostname to B<name> clearing
 any previously specified hostname.  If B<name> is NULL
-or the empty string, the list of hostnames is cleared, and name
+or the empty string, the list of hostnames is cleared and name
 checks are not performed on the peer certificate.  When a non-empty
 B<name> is specified, certificate verification automatically checks
 the peer hostname via L<X509_check_host(3)> with B<flags> as specified

--- a/doc/man3/SSL_set1_host.pod
+++ b/doc/man3/SSL_set1_host.pod
@@ -19,8 +19,8 @@ SSL server verification parameters
 These functions configure server hostname checks in the SSL client.
 
 SSL_set1_host() sets the expected DNS hostname to B<name> clearing
-any previously specified hostname.  If B<name> is NULL,
-or the empty string the list of hostnames is cleared, and name
+any previously specified hostname.  If B<name> is NULL
+or the empty string, the list of hostnames is cleared, and name
 checks are not performed on the peer certificate.  When a non-empty
 B<name> is specified, certificate verification automatically checks
 the peer hostname via L<X509_check_host(3)> with B<flags> as specified


### PR DESCRIPTION
Moving a command to make the sentence parse better.

- [x] documentation is added or updated
- [ ] tests are added or updated
