### PR TITLE
Fix find/rm command in Unix clean recipe

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -460,8 +460,8 @@ libclean:
 clean: libclean
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(MODULES) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
-	-$(RM) `find . -name '*{- platform->depext() -}' \! -name '.*' -print`
-	-$(RM) `find . -name '*{- platform->objext() -}' \! -name '.*' -print`
+	-$(RM) `find . -name '*{- platform->depext() -}' \! -name '.*' \! -type d -print`
+	-$(RM) `find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -print`
 	$(RM) core
 	$(RM) tags TAGS doc-nits
 	$(RM) -r test/test-runs


### PR DESCRIPTION
The `./pyca-cryptography/.travis/downstream.d` subdirectory that causes the `rm` command to fail (albeit harmlessly, but with a warning from `make` nonetheless).

>rm -f \`find . -name '\*.d' \\! -name '.\*' -print\`
>rm: cannot remove './pyca-cryptography/.travis/downstream.d': Is a directory
>make: [Makefile:1910: clean] Error 1 (ignored)

Exclude directories from being matched by the `find` commands.

CLA: trivial