### PR TITLE
Fix invalid TLS CertificateVerify max message length #10267

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -976,7 +976,7 @@ size_t ossl_statem_client_max_message_size(SSL *s)
         return s->max_cert_list;
 
     case TLS_ST_CR_CERT_VRFY:
-        return SSL3_RT_MAX_PLAIN_LENGTH;
+        return CERT_VERIFY_MAX_LENGTH;
 
     case TLS_ST_CR_CERT_STATUS:
         return SSL3_RT_MAX_PLAIN_LENGTH;

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -29,6 +29,15 @@
 /* Max should actually be 36 but we are generous */
 #define FINISHED_MAX_LENGTH             64
 
+/*
+ * Maximum size (excluding the Handshake header) of a CertificateVerify
+ * message, calculated as follows:
+ *
+ * 2 + # signature scheme
+ * 65535 # signature
+ */
+#define CERT_VERIFY_MAX_LENGTH   65537
+
 /* Dummy message type */
 #define SSL3_MT_DUMMY   -1
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1133,7 +1133,7 @@ size_t ossl_statem_server_max_message_size(SSL *s)
         return CLIENT_KEY_EXCH_MAX_LENGTH;
 
     case TLS_ST_SR_CERT_VRFY:
-        return SSL3_RT_MAX_PLAIN_LENGTH;
+        return CERT_VERIFY_MAX_LENGTH;
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
     case TLS_ST_SR_NEXT_PROTO:


### PR DESCRIPTION
Fixed CertificateVerify max message length, see issue #10267.