### PR TITLE
Fix undeclared identifier OPENSSL_ia32cap_P for e_rc4_hmac_md5.c.

### DIFF
--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <internal/cryptlib.h>
 #include <openssl/opensslconf.h>
 
 #include <stdio.h>


### PR DESCRIPTION
When compiling with VS2019, the following error occurs in e_rc4_hmac_md5.c:
1>e_rc4_hmac_md5.c
1>C:\openssl\crypto\evp\e_rc4_hmac_md5.c(90,31): error C2065: 'OPENSSL_ia32cap_P': undeclared identifier
1>C:\openssl\crypto\evp\e_rc4_hmac_md5.c(90,33): error C2109: subscript requires array or pointer type
