### PR TITLE
Fix simple typo in cipher_chacha20_poly1305_hw.c

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -142,7 +142,7 @@ static int chacha20_poly1305_tls_cipher(PROV_CIPHER_CTX *bctx,
         ctx->len.text = plen;
 
         if (plen) {
-            if (ctx->base.enc)
+            if (bctx->enc)
                 ctr = xor128_encrypt_n_pad(out, in, ctr, plen);
             else
                 ctr = xor128_decrypt_n_pad(out, in, ctr, plen);

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -142,7 +142,7 @@ static int chacha20_poly1305_tls_cipher(PROV_CIPHER_CTX *bctx,
         ctx->len.text = plen;
 
         if (plen) {
-            if (ctx->enc)
+            if (ctx->base.enc)
                 ctr = xor128_encrypt_n_pad(out, in, ctr, plen);
             else
                 ctr = xor128_decrypt_n_pad(out, in, ctr, plen);


### PR DESCRIPTION
Compile error occurs at:
1>cipher_chacha20_poly1305_hw.c
1>C:\openssl\providers\implementations\ciphers\cipher_chacha20_poly1305_hw.c(145,22): error C2039: 'enc': is not a member of 'PROV_CHACHA20_POLY1305_CTX'
1>C:\openssl\providers\implementations\ciphers\cipher_chacha20_poly1305.h(18): message : see declaration of 'PROV_CHACHA20_POLY1305_CTX'
