### PR TITLE
Use large enough buffer for signature in dgst.c

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -535,8 +535,9 @@ int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
     }
     if (key != NULL) {
         EVP_MD_CTX *ctx;
+        int pkey_len;
         BIO_get_md_ctx(bp, &ctx);
-        int pkey_len = EVP_PKEY_size(key);
+        pkey_len = EVP_PKEY_size(key);
         if (pkey_len > BUFSIZE) {
             len = pkey_len;
             sigbuf = app_malloc(len, "Signature buffer");

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -502,7 +502,7 @@ int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
           const char *sig_name, const char *md_name,
           const char *file)
 {
-    size_t len;
+    size_t len = BUFSIZE;
     int i, backslash = 0, ret = 1;
     unsigned char *sigbuf = NULL;
 
@@ -542,8 +542,6 @@ int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
             len = pkey_len;
             sigbuf = app_malloc(len, "Signature buffer");
             buf = sigbuf;
-        } else {
-            len = BUFSIZE;
         }
         if (!EVP_DigestSignFinal(ctx, buf, &len)) {
             BIO_printf(bio_err, "Error Signing Data\n");

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -590,8 +590,8 @@ int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
 
     ret = 0;
  end:
-    if (NULL != sigbuf) {
+    if (sigbuf != NULL)
         OPENSSL_clear_free(sigbuf, len);
-    }
+
     return ret;
 }

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -591,7 +591,7 @@ int do_fp(BIO *out, unsigned char *buf, BIO *bp, int sep, int binout,
 
     ret = 0;
  end:
-    if (sigbuf) {
+    if (NULL != sigbuf) {
         OPENSSL_clear_free(sigbuf, len);
     }
     return ret;


### PR DESCRIPTION
Fixes #9732

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


