### PR TITLE
Suppress an error when doing SM2 sign/verify ops

### DIFF
--- a/crypto/sm2/sm2_pmeth.c
+++ b/crypto/sm2/sm2_pmeth.c
@@ -220,6 +220,10 @@ static int pkey_sm2_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         *(size_t *)p2 = smctx->id_len;
         return 1;
 
+    case EVP_PKEY_CTRL_DIGESTINIT:
+        /* nothing to be inited, this is to suppress the error... */
+        return 1;
+
     default:
         return -2;
     }


### PR DESCRIPTION
This was fixed in #8321 right after the 1.1.1 was released but never
back ported to 1.1.1. Now fix it.

Issue reported from lua-openssl project.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
