### PR TITLE
Fixed eddsa sign and verify output

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -4064,6 +4064,7 @@ static int do_multi(int multi, int size_num)
                 p = buf + 4;
                 k = atoi(sstrsep(&p, sep));
                 sstrsep(&p, sep);
+                sstrsep(&p, sep);
 
                 d = atof(sstrsep(&p, sep));
                 eddsa_results[k][0] += d;


### PR DESCRIPTION
Speed  application showing 0 for Eddsa Sign and Verify with -multi option.
Added the following line in do_multi() 
+          sstrsep(&p, sep);
This moves pointer 'p' to sign numbers in buffer.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
