### PR TITLE
Configure: Make --strict-warnings meaningful with MSVC cl

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1352,7 +1352,6 @@ my %targets = (
     },
     "VC-WIN32" => {
         inherit_from     => [ "VC-noCE-common" ],
-        CFLAGS           => add("/WX"),
         AS               => sub { vc_win32_info()->{AS} },
         ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
         asoutflag        => sub { vc_win32_info()->{asoutflag} },

--- a/Configure
+++ b/Configure
@@ -164,6 +164,10 @@ my @clang_devteam_warn = qw(
     -Wmissing-variable-declarations
 );
 
+my @cl_devteam_warn = qw(
+    /WX
+);
+
 # This adds backtrace information to the memory leak info.  Is only used
 # when crypto-mdebug-backtrace is enabled.
 my $memleak_devteam_backtrace = "-rdynamic";
@@ -1519,11 +1523,20 @@ if ($strict_warnings)
         my $wopt;
         my $gccver = $predefined_C{__GNUC__} // -1;
 
-        warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike"
-            unless $gccver >= 4;
-        push @strict_warnings_collection, @gcc_devteam_warn;
-        push @strict_warnings_collection, @clang_devteam_warn
-            if (defined($predefined_C{__clang__}));
+        if ($gccver >= 4)
+                {
+                push @strict_warnings_collection, @gcc_devteam_warn;
+                push @strict_warnings_collection, @clang_devteam_warn
+                    if (defined($predefined_C{__clang__}));
+                }
+        elsif ($config{target} =~ /^VC-/)
+                {
+                push @strict_warnings_collection, @cl_devteam_warn;
+                }
+        else
+                {
+                warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike, or MSVC"
+                }
         }
 
 if (grep { $_ eq '-static' } @{$config{LDFLAGS}}) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,10 @@ before_build:
     - ps: >-
         If ($env:Platform -Match "x86") {
             $env:VCVARS_PLATFORM="x86"
-            $env:TARGET="VC-WIN32 no-asm"
+            $env:TARGET="VC-WIN32 no-asm --strict-warnings"
         } Else {
             $env:VCVARS_PLATFORM="amd64"
-            $env:TARGET="VC-WIN64A-masm --strict-warnings"
+            $env:TARGET="VC-WIN64A-masm"
         }
     - ps: >-
         If ($env:Configuration -Match "shared") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ before_build:
             $env:TARGET="VC-WIN32 no-asm"
         } Else {
             $env:VCVARS_PLATFORM="amd64"
-            $env:TARGET="VC-WIN64A-masm"
+            $env:TARGET="VC-WIN64A-masm --strict-warnings"
         }
     - ps: >-
         If ($env:Configuration -Match "shared") {


### PR DESCRIPTION
We also add this to our x86 builds on appveyor
