### PR TITLE
Implement domparam and key generation

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -81,6 +81,14 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_set_params_fn *set_params;
     OSSL_OP_keymgmt_settable_params_fn *settable_params;
 
+    /* Generation, a complex constructor */
+    OSSL_OP_keymgmt_gen_init_fn *gen_init;
+    OSSL_OP_keymgmt_gen_set_template_fn *gen_set_template;
+    OSSL_OP_keymgmt_gen_set_params_fn *gen_set_params;
+    OSSL_OP_keymgmt_gen_settable_params_fn *gen_settable_params;
+    OSSL_OP_keymgmt_gen_fn *gen;
+    OSSL_OP_keymgmt_gen_cleanup_fn *gen_cleanup;
+
     /* Key object checking */
     OSSL_OP_keymgmt_query_operation_name_fn *query_operation_name;
     OSSL_OP_keymgmt_has_fn *has;

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -350,3 +350,23 @@ int evp_keymgmt_util_copy(EVP_PKEY *to, EVP_PKEY *from, int selection)
 
     return 1;
 }
+
+void *evp_keymgmt_util_gen(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
+                           void *genctx, OSSL_CALLBACK *cb, void *cbarg)
+{
+    void *keydata = evp_keymgmt_gen(keymgmt, genctx, cb, cbarg);
+
+    if (keydata != NULL) {
+        if (!EVP_KEYMGMT_up_ref(keymgmt)) {
+            evp_keymgmt_freedata(keymgmt, keydata);
+            return NULL;
+        }
+
+        evp_keymgmt_util_clear_operation_cache(target);
+        target->keymgmt = keymgmt;
+        target->keydata = keydata;
+        evp_keymgmt_util_cache_keyinfo(target);
+    }
+
+    return keydata;
+}

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1012,7 +1012,7 @@ int EVP_PKEY_up_ref(EVP_PKEY *pkey)
 }
 
 #ifndef FIPS_MODE
-static void evp_pkey_free_legacy(EVP_PKEY *x)
+void evp_pkey_free_legacy(EVP_PKEY *x)
 {
     if (x->ameth != NULL) {
         if (x->ameth->pkey_free != NULL)

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -951,6 +951,12 @@ static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
         name = OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL;
     else if (strcmp(name, "rsa_pss_saltlen") == 0)
         name = OSSL_SIGNATURE_PARAM_PSS_SALTLEN;
+    else if (strcmp(name, "rsa_keygen_bits") == 0)
+        name = OSSL_PKEY_PARAM_RSA_BITS;
+    else if (strcmp(name, "rsa_keygen_pubexp") == 0)
+        name = OSSL_PKEY_PARAM_RSA_E;
+    else if (strcmp(name, "rsa_keygen_primes") == 0)
+        name = OSSL_PKEY_PARAM_RSA_PRIMES;
 # ifndef OPENSSL_NO_DH
     else if (strcmp(name, "dh_pad") == 0)
         name = OSSL_EXCHANGE_PARAM_PAD;

--- a/doc/man3/EVP_PKEY_gen.pod
+++ b/doc/man3/EVP_PKEY_gen.pod
@@ -2,11 +2,12 @@
 
 =head1 NAME
 
-EVP_PKEY_keygen_init, EVP_PKEY_keygen, EVP_PKEY_paramgen_init,
-EVP_PKEY_paramgen, EVP_PKEY_CTX_set_cb, EVP_PKEY_CTX_get_cb,
+EVP_PKEY_keygen_init, EVP_PKEY_paramgen_init, EVP_PKEY_gen,
+EVP_PKEY_CTX_set_cb, EVP_PKEY_CTX_get_cb,
 EVP_PKEY_CTX_get_keygen_info, EVP_PKEY_CTX_set_app_data,
 EVP_PKEY_CTX_get_app_data,
-EVP_PKEY_gen_cb
+EVP_PKEY_gen_cb,
+EVP_PKEY_paramgen, EVP_PKEY_keygen
 - key and parameter generation and check functions
 
 =head1 SYNOPSIS
@@ -14,9 +15,10 @@ EVP_PKEY_gen_cb
  #include <openssl/evp.h>
 
  int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx);
- int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
  int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
+ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
  int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
+ int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 
  typedef int EVP_PKEY_gen_cb(EVP_PKEY_CTX *ctx);
 
@@ -30,24 +32,51 @@ EVP_PKEY_gen_cb
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_keygen_init() function initializes a public key algorithm
-context using key B<pkey> for a key generation operation.
+Generating keys is sometimes straight forward, just generate the key's
+numbers and be done with it.  However, there are certain key types that need
+key parameters, often called domain parameters but not necessarily limited
+to that, that also need to be generated.  In addition to this, the caller
+may want to set user provided generation parameters that further affect key
+parameter or key generation, such as the desired key size.
 
-The EVP_PKEY_keygen() function performs a key generation operation, the
-generated key is written to B<ppkey>.
+To flexibly allow all that's just been described, key parameter and key
+generation is divided into an initialization of a key algorithm context,
+functions to set user provided parameters, and finally the key parameter or
+key generation function itself.
 
-The functions EVP_PKEY_paramgen_init() and EVP_PKEY_paramgen() are similar
-except parameters are generated.
+The key algorithm context must be created using L<EVP_PKEY_CTX_new(3)> or
+variants thereof, see that manual for details.
+
+EVP_PKEY_keygen_init() initializes a public key algorithm context using key
+I<pkey> for a key generation operation.
+
+EVP_PKEY_paramgen_init() is similar to EVP_PKEY_keygen_init() except key
+parameters are generated.
+
+After initialization, generation parameters may be provided with
+L<EVP_PKEY_CTX_ctrl(3)> or L<EVP_PKEY_CTX_set_params(3)>, or any other
+function described in those manuals.
+
+EVP_PKEY_gen() performs the generation operation, the resulting key
+parameters or key are written to I<*ppkey>.  If I<*ppkey> is NULL when this
+function is called, it will be allocated, and should be freed by the caller
+when no longer useful, using L<EVP_PKEY_free(3)>.
+
+EVP_PKEY_paramgen() and EVP_PKEY_keygen() do exactly the same thing as
+EVP_PKEY_gen(), after checking that the corresponding EVP_PKEY_paramgen_init()
+or EVP_PKEY_keygen_init() was used to initialize I<ctx>.
+These are older functions that are kept for backward compatibility.
+It is safe to use EVP_PKEY_gen() instead.
 
 The function EVP_PKEY_set_cb() sets the key or parameter generation callback
-to B<cb>. The function EVP_PKEY_CTX_get_cb() returns the key or parameter
+to I<cb>. The function EVP_PKEY_CTX_get_cb() returns the key or parameter
 generation callback.
 
 The function EVP_PKEY_CTX_get_keygen_info() returns parameters associated
-with the generation operation. If B<idx> is -1 the total number of
+with the generation operation. If I<idx> is -1 the total number of
 parameters available is returned. Any non negative value returns the value of
 that parameter. EVP_PKEY_CTX_gen_keygen_info() with a non-negative value for
-B<idx> should only be called within the generation callback.
+I<idx> should only be called within the generation callback.
 
 If the callback returns 0 then the key generation operation is aborted and an
 error occurs. This might occur during a time consuming operation where
@@ -57,6 +86,13 @@ The functions EVP_PKEY_CTX_set_app_data() and EVP_PKEY_CTX_get_app_data() set
 and retrieve an opaque pointer. This can be used to set some application
 defined value which can be retrieved in the callback: for example a handle
 which is used to update a "progress dialog".
+
+=head1 RETURN VALUES
+
+EVP_PKEY_keygen_init(), EVP_PKEY_paramgen_init(), EVP_PKEY_keygen() and
+EVP_PKEY_paramgen() return 1 for success and 0 or a negative value for failure.
+In particular a return value of -2 indicates the operation is not supported by
+the public key algorithm.
 
 =head1 NOTES
 
@@ -81,13 +117,6 @@ In OpenSSL an EVP_PKEY structure containing a private key also contains the
 public key components and parameters (if any). An OpenSSL private key is
 equivalent to what some libraries call a "key pair". A private key can be used
 in functions which require the use of a public key or parameters.
-
-=head1 RETURN VALUES
-
-EVP_PKEY_keygen_init(), EVP_PKEY_paramgen_init(), EVP_PKEY_keygen() and
-EVP_PKEY_paramgen() return 1 for success and 0 or a negative value for failure.
-In particular a return value of -2 indicates the operation is not supported by
-the public key algorithm.
 
 =head1 EXAMPLES
 
@@ -168,11 +197,17 @@ L<EVP_PKEY_derive(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.0.0.
+EVP_PKEY_keygen_init(), int EVP_PKEY_paramgen_init(), EVP_PKEY_keygen(),
+EVP_PKEY_paramgen(), EVP_PKEY_gen_cb(), EVP_PKEY_CTX_set_cb(),
+EVP_PKEY_CTX_get_cb(), EVP_PKEY_CTX_get_keygen_info(),
+EVP_PKEY_CTX_set_app_data() and EVP_PKEY_CTX_get_app_data() were added in
+OpenSSL 1.0.0.
+
+EVP_PKEY_gen() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2006-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2006-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -18,6 +18,13 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  void *OP_keymgmt_new(void *provctx);
  void OP_keymgmt_free(void *keydata);
 
+ void *OP_keymgmt_gen_init(void *provctx, int selection);
+ int OP_keymgmt_gen_set_template(void *genctx, void *template);
+ int OP_keymgmt_gen_set_params(void *genctx, const OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_keymgmt_gen_settable_params(void *provctx);
+ void *OP_keymgmt_gen(void *genctx, OSSL_CALLBACK *cb, void *cbarg);
+ void OP_keymgmt_gen_cleanup(void *genctx);
+
  /* Key object information */
  int OP_keymgmt_get_params(void *keydata, OSSL_PARAM params[]);
  const OSSL_PARAM *OP_keymgmt_gettable_params(void);
@@ -79,6 +86,13 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 
  OP_keymgmt_new                  OSSL_FUNC_KEYMGMT_NEW
  OP_keymgmt_free                 OSSL_FUNC_KEYMGMT_FREE
+
+ OP_keymgmt_gen_init             OSSL_FUNC_KEYMGMT_GEN_INIT
+ OP_keymgmt_gen_set_template     OSSL_FUNC_KEYMGMT_GEN_SET_TEMPLATE
+ OP_keymgmt_gen_set_params       OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS
+ OP_keymgmt_gen_settable_params  OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS
+ OP_keymgmt_gen                  OSSL_FUNC_KEYMGMT_GEN
+ OP_keymgmt_gen_cleanup          OSSL_FUNC_KEYMGMT_GEN_CLEANUP
 
  OP_keymgmt_get_params           OSSL_FUNC_KEYMGMT_GET_PARAMS
  OP_keymgmt_gettable_params      OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS
@@ -193,12 +207,41 @@ key object, but that is not mandatory.
 
 OP_keymgmt_free() should free the passed I<keydata>.
 
-The constructor and destructor are mandatory, a KEYMGMT implementation
-without them will not be accepted.
+OP_keymgmt_gen_init(), OP_keymgmt_gen_set_template(),
+OP_keymgmt_gen_set_params(), OP_keymgmt_gen_settable_params(),
+OP_keymgmt_gen() and OP_keymgmt_gen_cleanup() work together as a more
+elaborate context based key object constructor.
 
-=for comment when new constructors appear, it's sufficient if only one
-of them is present.  The remark above will have to change to reflect
-that.
+OP_keymgmt_gen_init() should create the key object generation context
+and initialize it with I<selections>, which will determine what kind
+of contents the key object to be generated should get.
+
+OP_keymgmt_gen_set_template() should add I<template> to the context
+I<genctx>.  The I<template> is assumed to be a key object constructed
+with the same KEYMGMT, and from which content that the implementation
+chooses can be used as a template for the key object to be generated.
+Typically, the generation of a DSA or DH key would get the domain
+parameters from this I<template>.
+
+OP_keymgmt_gen_set_params() should set additional parameters from
+I<params> in the key object generation context I<genctx>.
+
+OP_keymgmt_gen_settable_params() should return a constant array of
+descriptor B<OSSL_PARAM>, for parameters that OP_keymgmt_gen_set_params() 
+can handle.
+
+OP_keymgmt_gen() should perform the key object generation itself, and
+return the result.  The callback I<cb> should be called at regular
+intervals with indications on how the key object generation
+progresses.
+
+OP_keymgmt_gen_cleanup() should clean up and free the key object
+generation context I<genctx>
+
+At least one of OP_keymgmt_new() and OP_keymgmt_gen() are mandatory,
+as well as OP_keymgmt_free().  Additionally, if OP_keymgmt_gen() is
+present, OP_keymgmt_gen_init() and OP_keymgmt_gen_cleanup() must be
+present as well.
 
 =head2 Key Object Information Functions
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -636,6 +636,16 @@ int evp_keymgmt_set_params(const EVP_KEYMGMT *keymgmt,
                            void *keydata, const OSSL_PARAM params[]);
 const OSSL_PARAM *evp_keymgmt_settable_params(const EVP_KEYMGMT *keymgmt);
 
+void *evp_keymgmt_gen_init(const EVP_KEYMGMT *keymgmt, int selection);
+int evp_keymgmt_gen_set_template(const EVP_KEYMGMT *keymgmt, void *genctx,
+                                 void *template);
+int evp_keymgmt_gen_set_params(const EVP_KEYMGMT *keymgmt, void *genctx,
+                               const OSSL_PARAM params[]);
+const OSSL_PARAM *
+evp_keymgmt_gen_settable_params(const EVP_KEYMGMT *keymgmt);
+void *evp_keymgmt_gen(const EVP_KEYMGMT *keymgmt, void *genctx,
+                      OSSL_CALLBACK *cb, void *cbarg);
+void evp_keymgmt_gen_cleanup(const EVP_KEYMGMT *keymgmt, void *genctx);
 
 int evp_keymgmt_has(const EVP_KEYMGMT *keymgmt, void *keyddata, int selection);
 int evp_keymgmt_validate(const EVP_KEYMGMT *keymgmt, void *keydata,

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -221,7 +221,7 @@ extern "C" {
 #define OSSL_PKEY_PARAM_RSA_EXPONENT    "rsa-exponent"
 #define OSSL_PKEY_PARAM_RSA_COEFFICIENT "rsa-coefficient"
 /* Key generation parameters */
-#define OSSL_PKEY_PARAM_RSA_BITS        "bits"
+#define OSSL_PKEY_PARAM_RSA_BITS        OSSL_PKEY_PARAM_BITS
 #define OSSL_PKEY_PARAM_RSA_PRIMES      "primes"
 
 /* Key Exchange parameters */

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -220,6 +220,9 @@ extern "C" {
 #define OSSL_PKEY_PARAM_RSA_FACTOR      "rsa-factor"
 #define OSSL_PKEY_PARAM_RSA_EXPONENT    "rsa-exponent"
 #define OSSL_PKEY_PARAM_RSA_COEFFICIENT "rsa-coefficient"
+/* Key generation parameters */
+#define OSSL_PKEY_PARAM_RSA_BITS        "bits"
+#define OSSL_PKEY_PARAM_RSA_PRIMES      "primes"
 
 /* Key Exchange parameters */
 
@@ -278,6 +281,10 @@ extern "C" {
 
 /* Passphrase callback parameters */
 #define OSSL_PASSPHRASE_PARAM_INFO              "info"
+
+/* Keygen callback parameters, from provider to libcrypto */
+#define OSSL_GEN_PARAM_POTENTIAL            "potential" /* integer */
+#define OSSL_GEN_PARAM_ITERATION            "iteration" /* integer */
 
 # ifdef __cplusplus
 }

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -380,10 +380,31 @@ OSSL_CORE_MAKE_FUNC(int, OP_kdf_set_ctx_params,
 # define OSSL_KEYMGMT_SELECT_ALL                \
     ( OSSL_KEYMGMT_SELECT_KEYPAIR | OSSL_KEYMGMT_SELECT_ALL_PARAMETERS )
 
-/* Basic key object creation, destruction */
+/* Basic key object creation */
 # define OSSL_FUNC_KEYMGMT_NEW                         1
-# define OSSL_FUNC_KEYMGMT_FREE                        9
 OSSL_CORE_MAKE_FUNC(void *, OP_keymgmt_new, (void *provctx))
+
+/* Generation, a more complex constructor */
+# define OSSL_FUNC_KEYMGMT_GEN_INIT                    3
+# define OSSL_FUNC_KEYMGMT_GEN_SET_TEMPLATE            4
+# define OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS              5
+# define OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS         6
+# define OSSL_FUNC_KEYMGMT_GEN                         7
+# define OSSL_FUNC_KEYMGMT_GEN_CLEANUP                 8
+OSSL_CORE_MAKE_FUNC(void *, OP_keymgmt_gen_init,
+                    (void *provctx, int selection))
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_gen_set_template,
+                    (void *genctx, void *templ))
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_gen_set_params,
+                    (void *genctx, const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
+                    OP_keymgmt_gen_settable_params, (void *provctx))
+OSSL_CORE_MAKE_FUNC(void *, OP_keymgmt_gen,
+                    (void *genctx, OSSL_CALLBACK *cb, void *cbarg))
+OSSL_CORE_MAKE_FUNC(void, OP_keymgmt_gen_cleanup, (void *genctx))
+
+/* Basic key object destruction */
+# define OSSL_FUNC_KEYMGMT_FREE                        9
 OSSL_CORE_MAKE_FUNC(void, OP_keymgmt_free, (void *keydata))
 
 /* Key object information, with discovery */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1596,6 +1596,7 @@ int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
+int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 int EVP_PKEY_check(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx);

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -111,6 +111,10 @@ int EVP_PKEY_CTX_get_rsa_padding(EVP_PKEY_CTX *ctx, int *pad_mode);
 int EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int saltlen);
 int EVP_PKEY_CTX_get_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int *saltlen);
 
+int EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int bits);
+int EVP_PKEY_CTX_set_rsa_keygen_pubexp(EVP_PKEY_CTX *ctx, BIGNUM *pubexp);
+int EVP_PKEY_CTX_set_rsa_keygen_primes(EVP_PKEY_CTX *ctx, int primes);
+
 /* Salt length matches digest */
 #  define RSA_PSS_SALTLEN_DIGEST -1
 /* Verify only: auto detect salt length */
@@ -123,18 +127,6 @@ int EVP_PKEY_CTX_get_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int *saltlen);
 #  define EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(ctx, len) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA_PSS, EVP_PKEY_OP_KEYGEN, \
                           EVP_PKEY_CTRL_RSA_PSS_SALTLEN, len, NULL)
-
-#  define EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, bits) \
-        RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_KEYGEN_BITS, bits, NULL)
-
-#  define EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, pubexp) \
-        RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP, 0, pubexp)
-
-#  define EVP_PKEY_CTX_set_rsa_keygen_primes(ctx, primes) \
-        RSA_pkey_ctx_ctrl(ctx, EVP_PKEY_OP_KEYGEN, \
-                          EVP_PKEY_CTRL_RSA_KEYGEN_PRIMES, primes, NULL)
 
 int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_CTX_set_rsa_mgf1_md_name(EVP_PKEY_CTX *ctx, const char *mdname,

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2504,8 +2504,8 @@ static int keygen_test_run(EVP_TEST *t)
 {
     KEYGEN_TEST_DATA *keygen = t->data;
     EVP_PKEY *pkey = NULL;
+    int rv = 1;
 
-    t->err = NULL;
     if (EVP_PKEY_keygen(keygen->genctx, &pkey) <= 0) {
         t->err = "KEYGEN_GENERATE_ERROR";
         goto err;
@@ -2514,6 +2514,7 @@ static int keygen_test_run(EVP_TEST *t)
     if (keygen->keyname != NULL) {
         KEY_LIST *key;
 
+        rv = 0;
         if (find_key(NULL, keygen->keyname, private_keys)) {
             TEST_info("Duplicate key %s", keygen->keyname);
             goto err;
@@ -2526,15 +2527,15 @@ static int keygen_test_run(EVP_TEST *t)
         key->key = pkey;
         key->next = private_keys;
         private_keys = key;
+        rv = 1;
     } else {
         EVP_PKEY_free(pkey);
     }
 
-    return 1;
+    t->err = NULL;
 
 err:
-    EVP_PKEY_free(pkey);
-    return 0;
+    return rv;
 }
 
 static const EVP_TEST_METHOD keygen_test_method = {

--- a/test/recipes/30-test_evp_data/evppkey.txt
+++ b/test/recipes/30-test_evp_data/evppkey.txt
@@ -18563,7 +18563,7 @@ KeyGen = rsaEncryption
 Availablein = default
 Ctrl = rsa_keygen_bits:128
 KeyName = tmprsa
-Result = PKEY_CTRL_INVALID
+Result = KEYGEN_GENERATE_ERROR
 Reason = key size too small
 
 # RSA-PSS with restrictions, should succeed.

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4981,3 +4981,6 @@ OSSL_CMP_SRV_CTX_set_accept_unprotected ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_set_accept_raverified  ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_set_grant_implicit_confirm ?	3_0_0	EXIST::FUNCTION:CMP
 EVP_PKEY_gen                            ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_set_rsa_keygen_bits        ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_keygen_pubexp      ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_CTX_set_rsa_keygen_primes      ?	3_0_0	EXIST::FUNCTION:RSA

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4980,3 +4980,4 @@ OSSL_CMP_SRV_CTX_set_send_unprotected_errors ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_set_accept_unprotected ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_set_accept_raverified  ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_set_grant_implicit_confirm ?	3_0_0	EXIST::FUNCTION:CMP
+EVP_PKEY_gen                            ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This turned out to be a fairly big ordeal.  To begin with, our libcrypto<->provider interface couldn't support the way things are done in the EVP_PKEY API in a sane manner, so this needed to be redesigned a bit.

Furthermore, domparam and key generation use an application callback to give the user some feedback when the key is created, and that support needs to be extended to providers.  However, it would be very unsafe to just pass some random function pointer directly to the provider methods, so with some inspiration from `BN_GENCB`, I created a new callback type that is used by libcrypto to pass the necessary data to the provider, which then ends up calling an upcall that knows exactly how to handle that structure.

Please read the individual commits for more information.

NOTE: apart from making a key that can be used immediately, this functionality is of little use because we have no way of extracting key data to create PEM files from.  That's a matter for another PR, and is also the reason why this PR is currently WIP / draft.