### PR TITLE
Remove potential usage of CRT object across DLL boundaries

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1382,7 +1382,6 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     CONF *dbattr_conf = NULL;
     char buf[BSIZE];
 #ifndef OPENSSL_NO_POSIX_IO
-    FILE *dbfp;
     struct stat dbst;
 #endif
 
@@ -1393,10 +1392,9 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     }
 
 #ifndef OPENSSL_NO_POSIX_IO
-    BIO_get_fp(in, &dbfp);
-    if (fstat(fileno(dbfp), &dbst) == -1) {
+    if (stat(dbfile, &dbst) == -1) {
         ERR_raise_data(ERR_LIB_SYS, errno,
-                       "calling fstat(%s)", dbfile);
+                       "calling stat(%s)", dbfile);
         ERR_print_errors(bio_err);
         goto err;
     }


### PR DESCRIPTION
If we compile shared libcrypto and openssl tool with static runtime
on windows, we'll be using libcrypto's CRT object in another instance
of CRT (the one in the tool). This commit fixes it.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
