### PR TITLE
EVP: Make the SIGNATURE implementation leaner

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -120,8 +120,6 @@ struct evp_signature_st {
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
 
-    EVP_KEYMGMT *keymgmt;
-
     OSSL_OP_signature_newctx_fn *newctx;
     OSSL_OP_signature_sign_init_fn *sign_init;
     OSSL_OP_signature_sign_fn *sign;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -76,13 +76,14 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
      * checking if signature is already there.  Keymgmt is a different
      * matter, as it isn't tied to a specific EVP_PKEY op.
      */
-    signature =
-        EVP_SIGNATURE_fetch(NULL, locpctx->algorithm, locpctx->propquery);
+    signature = EVP_SIGNATURE_fetch(locpctx->libctx, locpctx->algorithm,
+                                    locpctx->propquery);
     if (signature != NULL && locpctx->keymgmt == NULL) {
         int name_id = EVP_SIGNATURE_number(signature);
 
         locpctx->keymgmt =
-            evp_keymgmt_fetch_by_number(NULL, name_id, locpctx->propquery);
+            evp_keymgmt_fetch_by_number(locpctx->libctx, name_id,
+                                        locpctx->propquery);
     }
 
     if (locpctx->keymgmt == NULL

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -129,11 +129,8 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
          * man pages), i.e. the ref count is not updated so the EVP_MD should
          * not be used beyound the lifetime of the EVP_MD_CTX.
          */
-        OSSL_PROVIDER *sigprov = EVP_SIGNATURE_provider(signature);
-
         ctx->reqdigest = ctx->fetched_digest =
-            EVP_MD_fetch(ossl_provider_library_context(sigprov),
-                         mdname, props);
+            EVP_MD_fetch(locpctx->libctx, mdname, props);
     }
 
     if (ver) {

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -334,12 +334,13 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
      * checking if signature is already there.  Keymgmt is a different
      * matter, as it isn't tied to a specific EVP_PKEY op.
      */
-    signature = EVP_SIGNATURE_fetch(NULL, ctx->algorithm, ctx->propquery);
+    signature = EVP_SIGNATURE_fetch(ctx->libctx, ctx->algorithm,
+                                    ctx->propquery);
     if (signature != NULL && ctx->keymgmt == NULL) {
         int name_id = EVP_SIGNATURE_number(signature);
 
-        ctx->keymgmt =
-            evp_keymgmt_fetch_by_number(NULL, name_id, ctx->propquery);
+        ctx->keymgmt = evp_keymgmt_fetch_by_number(ctx->libctx, name_id,
+                                                   ctx->propquery);
     }
 
     if (ctx->keymgmt == NULL

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -482,6 +482,7 @@ void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx)
         ctx->pmeth->cleanup(ctx);
 
     evp_pkey_ctx_free_old_ops(ctx);
+    EVP_KEYMGMT_free(ctx->keymgmt);
 
     EVP_PKEY_free(ctx->pkey);
     EVP_PKEY_free(ctx->peerkey);

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -11,7 +11,7 @@ EVP_DigestSignFinal, EVP_DigestSign - EVP signing functions
 
  int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                            const char *mdname, const char *props,
-                           EVP_PKEY *pkey, EVP_SIGNATURE *signature);
+                           EVP_PKEY *pkey);
  int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                         const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
  int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
@@ -26,41 +26,38 @@ EVP_DigestSignFinal, EVP_DigestSign - EVP signing functions
 The EVP signature routines are a high level interface to digital signatures.
 Input data is digested first before the signing takes place.
 
-EVP_DigestSignInit_ex() sets up signing context B<ctx> to use a digest with the
-name B<mdname> and private key B<pkey>. The signature algorithm B<signature>
-will be used for the actual signing which must be compatible with the private
-key. The name of the digest to be used is passed to the provider of the
-signature algorithm in use. How that provider interprets the digest name is
-provider specific. The provider may implement that digest directly itself or it
-may (optionally) choose to fetch it (which could result in a digest from a
-different provider being selected). If the provider supports fetching the digest
-then it may use the B<props> argument for the properties to be used during the
-fetch.
+EVP_DigestSignInit_ex() sets up signing context I<ctx> to use a digest with the
+name I<mdname> and private key I<pkey>. The name of the digest to be used is
+passed to the provider of the signature algorithm in use. How that provider
+interprets the digest name is provider specific. The provider may implement
+that digest directly itself or it may (optionally) choose to fetch it (which
+could result in a digest from a different provider being selected). If the
+provider supports fetching the digest then it may use the I<props> argument for
+the properties to be used during the fetch.
 
-The B<signature> parameter may be NULL in which case a suitable signature
-algorithm implementation will be implicitly fetched based on the type of key in
-use. See L<provider(7)> for further information about providers and fetching
-algorithms.
+The I<pkey> algorithm is used to fetch a B<EVP_SIGNATURE> method implicitly, to
+be used for the actual signing. See L<provider(7)/Implicit fetch> for
+more information about implict fetches.
 
 The OpenSSL default and legacy providers support fetching digests and can fetch
 those digests from any available provider. The OpenSSL fips provider also
 supports fetching digests but will only fetch digests that are themselves
 implemented inside the fips provider.
 
-B<ctx> must be created with EVP_MD_CTX_new() before calling this function. If
-B<pctx> is not NULL, the EVP_PKEY_CTX of the signing operation will be written
-to B<*pctx>: this can be used to set alternative signing options. Note that any
-existing value in B<*pctx> is overwritten. The EVP_PKEY_CTX value returned must
-not be freed directly by the application if B<ctx> is not assigned an
+I<ctx> must be created with EVP_MD_CTX_new() before calling this function. If
+I<pctx> is not NULL, the EVP_PKEY_CTX of the signing operation will be written
+to I<*pctx>: this can be used to set alternative signing options. Note that any
+existing value in I<*pctx> is overwritten. The EVP_PKEY_CTX value returned must
+not be freed directly by the application if I<ctx> is not assigned an
 EVP_PKEY_CTX value before being passed to EVP_DigestSignInit_ex() (which means
 the EVP_PKEY_CTX is created inside EVP_DigestSignInit_ex() and it will be freed
 automatically when the EVP_MD_CTX is freed).
 
-The digest B<mdname> may be NULL if the signing algorithm supports it. The
-B<props> argument can always be NULL.
+The digest I<mdname> may be NULL if the signing algorithm supports it. The
+I<props> argument can always be NULL.
 
 No B<EVP_PKEY_CTX> will be created by EVP_DigestSignInit_ex() if the passed
-B<ctx> has already been assigned one via L<EVP_MD_CTX_set_ctx(3)>. See also
+I<ctx> has already been assigned one via L<EVP_MD_CTX_set_ctx(3)>. See also
 L<SM2(7)>.
 
 Only EVP_PKEY types that support signing can be used with these functions. This
@@ -82,7 +79,7 @@ Supports SHA1, SHA224, SHA256, SHA384, SHA512 and SM3
 
 =item RSA with no padding
 
-Supports no digests (the digest B<type> must be NULL)
+Supports no digests (the digest I<type> must be NULL)
 
 =item RSA with X931 padding
 
@@ -95,7 +92,7 @@ SHA3-224, SHA3-256, SHA3-384, SHA3-512
 
 =item Ed25519 and Ed448
 
-Support no digests (the digest B<type> must be NULL)
+Support no digests (the digest I<type> must be NULL)
 
 =item HMAC
 
@@ -110,23 +107,23 @@ Will ignore any digest provided.
 If RSA-PSS is used and restrictions apply then the digest must match.
 
 EVP_DigestSignInit() works in the same way as EVP_DigestSignInit_ex() except
-that the B<mdname> parameter will be inferred from the supplied digest B<type>,
-and B<props> will be NULL. Where supplied the ENGINE B<e> will be used for the
-signing and digest algorithm implementations. B<e> may be NULL.
+that the I<mdname> parameter will be inferred from the supplied digest I<type>,
+and I<props> will be NULL. Where supplied the ENGINE I<e> will be used for the
+signing and digest algorithm implementations. I<e> may be NULL.
 
-EVP_DigestSignUpdate() hashes B<cnt> bytes of data at B<d> into the
-signature context B<ctx>. This function can be called several times on the
-same B<ctx> to include additional data.
+EVP_DigestSignUpdate() hashes I<cnt> bytes of data at I<d> into the
+signature context I<ctx>. This function can be called several times on the
+same I<ctx> to include additional data.
 
-EVP_DigestSignFinal() signs the data in B<ctx> and places the signature in B<sig>.
-If B<sig> is B<NULL> then the maximum size of the output buffer is written to
-the B<siglen> parameter. If B<sig> is not B<NULL> then before the call the
-B<siglen> parameter should contain the length of the B<sig> buffer. If the
-call is successful the signature is written to B<sig> and the amount of data
-written to B<siglen>.
+EVP_DigestSignFinal() signs the data in I<ctx> and places the signature in I<sig>.
+If I<sig> is NULL then the maximum size of the output buffer is written to
+the I<siglen> parameter. If I<sig> is not NULL then before the call the
+I<siglen> parameter should contain the length of the I<sig> buffer. If the
+call is successful the signature is written to I<sig> and the amount of data
+written to I<siglen>.
 
-EVP_DigestSign() signs B<tbslen> bytes of data at B<tbs> and places the
-signature in B<sig> and its length in B<siglen> in a similar way to
+EVP_DigestSign() signs I<tbslen> bytes of data at I<tbs> and places the
+signature in I<sig> and its length in I<siglen> in a similar way to
 EVP_DigestSignFinal().
 
 =head1 RETURN VALUES

--- a/doc/man3/EVP_PKEY_sign.pod
+++ b/doc/man3/EVP_PKEY_sign.pod
@@ -2,14 +2,13 @@
 
 =head1 NAME
 
-EVP_PKEY_sign_init_ex, EVP_PKEY_sign_init, EVP_PKEY_sign
+EVP_PKEY_sign_init, EVP_PKEY_sign
 - sign using a public key algorithm
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
- int EVP_PKEY_sign_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
  int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
                    unsigned char *sig, size_t *siglen,
@@ -17,26 +16,19 @@ EVP_PKEY_sign_init_ex, EVP_PKEY_sign_init, EVP_PKEY_sign
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_sign_init_ex() function initializes a public key algorithm
-context for performing signing using the signature algorithm B<signature>.
-The signature algorithm B<signature> should be fetched using a call to
-L<EVP_SIGNATURE_fetch(3)>.
-The EVP_PKEY object associated with B<ctx> must be compatible with that
-algorithm.
-B<signature> may be NULL in which case the EVP_SIGNATURE algorithm is fetched
-implicitly based on the type of EVP_PKEY associated with B<ctx>.
-See L<provider(7)/Implicit fetch> for more information about implict fetches.
-
-The EVP_PKEY_sign_init() function is the same as EVP_PKEY_sign_init_ex() except
-that the EVP_SIGNATURE algorithm is always implicitly fetched.
+EVP_PKEY_sign_init() initializes a public key algorithm context I<ctx> for
+signing using the algorithm given when the context was created
+using L<EVP_PKEY_CTX_new(3)> or variants thereof.  The algorithm is used to
+fetch a B<EVP_SIGNATURE> method implicitly, see L<provider(7)/Implicit fetch>
+for more information about implict fetches.
 
 The EVP_PKEY_sign() function performs a public key signing operation
-using B<ctx>. The data to be signed is specified using the B<tbs> and
-B<tbslen> parameters. If B<sig> is B<NULL> then the maximum size of the output
-buffer is written to the B<siglen> parameter. If B<sig> is not B<NULL> then
-before the call the B<siglen> parameter should contain the length of the
-B<sig> buffer, if the call is successful the signature is written to
-B<sig> and the amount of data written to B<siglen>.
+using I<ctx>. The data to be signed is specified using the I<tbs> and
+I<tbslen> parameters. If I<sig> is NULL then the maximum size of the output
+buffer is written to the I<siglen> parameter. If I<sig> is not NULL then
+before the call the I<siglen> parameter should contain the length of the
+I<sig> buffer, if the call is successful the signature is written to
+I<sig> and the amount of data written to I<siglen>.
 
 =head1 NOTES
 

--- a/doc/man3/EVP_PKEY_verify.pod
+++ b/doc/man3/EVP_PKEY_verify.pod
@@ -2,14 +2,13 @@
 
 =head1 NAME
 
-EVP_PKEY_verify_init_ex, EVP_PKEY_verify_init, EVP_PKEY_verify
+EVP_PKEY_verify_init, EVP_PKEY_verify
 - signature verification using a public key algorithm
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
- int EVP_PKEY_verify_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
  int EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
                      const unsigned char *sig, size_t siglen,
@@ -17,24 +16,16 @@ EVP_PKEY_verify_init_ex, EVP_PKEY_verify_init, EVP_PKEY_verify
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_verify_init_ex() function initializes a public key algorithm
-context for performing signature verification using the signature algorithm
-B<signature>.
-The signature algorithm B<signature> should be fetched using a call to
-L<EVP_SIGNATURE_fetch(3)>.
-The EVP_PKEY object associated with B<ctx> must be compatible with that
-algorithm.
-B<signature> may be NULL in which case the EVP_SIGNATURE algorithm is fetched
-implicitly based on the type of EVP_PKEY associated with B<ctx>.
-See L<provider(7)/Implicit fetch> for more information about implict fetches.
-
-The EVP_PKEY_verify_init() function is the same as EVP_PKEY_verify_init_ex()
-except that the EVP_SIGNATURE algorithm is always implicitly fetched.
+EVP_PKEY_verify_init() initializes a public key algorithm context I<ctx> for
+signing using the algorithm given when the context was created
+using L<EVP_PKEY_CTX_new(3)> or variants thereof.  The algorithm is used to
+fetch a B<EVP_SIGNATURE> method implicitly, see L<provider(7)/Implicit fetch>
+for more information about implict fetches.
 
 The EVP_PKEY_verify() function performs a public key verification operation
-using B<ctx>. The signature is specified using the B<sig> and
-B<siglen> parameters. The verified data (i.e. the data believed originally
-signed) is specified using the B<tbs> and B<tbslen> parameters.
+using I<ctx>. The signature is specified using the I<sig> and
+I<siglen> parameters. The verified data (i.e. the data believed originally
+signed) is specified using the I<tbs> and I<tbslen> parameters.
 
 =head1 NOTES
 

--- a/doc/man3/EVP_PKEY_verify_recover.pod
+++ b/doc/man3/EVP_PKEY_verify_recover.pod
@@ -2,15 +2,13 @@
 
 =head1 NAME
 
-EVP_PKEY_verify_recover_init_ex, EVP_PKEY_verify_recover_init,
-EVP_PKEY_verify_recover - recover signature using a public key algorithm
+EVP_PKEY_verify_recover_init, EVP_PKEY_verify_recover
+- recover signature using a public key algorithm
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
- int EVP_PKEY_verify_recover_init_ex(EVP_PKEY_CTX *ctx,
-                                     EVP_SIGNATURE *signature);
  int EVP_PKEY_verify_recover_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
                              unsigned char *rout, size_t *routlen,
@@ -18,28 +16,19 @@ EVP_PKEY_verify_recover - recover signature using a public key algorithm
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_verify_recover_init_ex() function initializes a public key
-algorithm context for performing signature signed data recovery using the
-signature algorithm B<signature>.
-The signature algorithm B<signature> should be fetched using a call to
-L<EVP_SIGNATURE_fetch(3)>.
-The EVP_PKEY object associated with B<ctx> must be compatible with that
-algorithm.
-B<signature> may be NULL in which case the EVP_SIGNATURE algorithm is fetched
-implicitly based on the type of EVP_PKEY associated with B<ctx>.
-See L<provider(7)/Implicit fetch> for more information about implict fetches.
-
-The EVP_PKEY_verify_recover_init() function is the same as
-EVP_PKEY_verify_recover_init_ex() except that the EVP_SIGNATURE algorithm is
-always implicitly fetched.
+EVP_PKEY_verify_recover_init() initializes a public key algorithm context
+I<ctx> for signing using the algorithm given when the context was created
+using L<EVP_PKEY_CTX_new(3)> or variants thereof.  The algorithm is used to
+fetch a B<EVP_SIGNATURE> method implicitly, see L<provider(7)/Implicit fetch>
+for more information about implict fetches.
 
 The EVP_PKEY_verify_recover() function recovers signed data
-using B<ctx>. The signature is specified using the B<sig> and
-B<siglen> parameters. If B<rout> is B<NULL> then the maximum size of the output
-buffer is written to the B<routlen> parameter. If B<rout> is not B<NULL> then
-before the call the B<routlen> parameter should contain the length of the
-B<rout> buffer, if the call is successful recovered data is written to
-B<rout> and the amount of data written to B<routlen>.
+using I<ctx>. The signature is specified using the I<sig> and
+I<siglen> parameters. If I<rout> is NULL then the maximum size of the output
+buffer is written to the I<routlen> parameter. If I<rout> is not NULL then
+before the call the I<routlen> parameter should contain the length of the
+I<rout> buffer, if the call is successful recovered data is written to
+I<rout> and the amount of data written to I<routlen>.
 
 =head1 NOTES
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -29,6 +29,9 @@ struct evp_pkey_ctx_st {
     const char *algorithm;
     const char *propquery;
 
+    /* cached key manager */
+    EVP_KEYMGMT *keymgmt;
+
     union {
         struct {
             EVP_KEYEXCH *exchange;

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -678,8 +678,8 @@ __owur int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
                             size_t tbslen);
 
 int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                          const char *mdname, const char *props, EVP_PKEY *pkey,
-                          EVP_SIGNATURE *signature);
+                          const char *mdname, const char *props,
+                          EVP_PKEY *pkey);
 /*__owur*/ int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                   const EVP_MD *type, ENGINE *e,
                                   EVP_PKEY *pkey);
@@ -689,7 +689,7 @@ __owur int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
 
 int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                             const char *mdname, const char *props,
-                            EVP_PKEY *pkey, EVP_SIGNATURE *signature);
+                            EVP_PKEY *pkey);
 __owur int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                 const EVP_MD *type, ENGINE *e,
                                 EVP_PKEY *pkey);
@@ -1526,17 +1526,14 @@ void EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
                                 void (*fn)(const char *name, void *data),
                                 void *data);
 
-int EVP_PKEY_sign_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
 int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
                   unsigned char *sig, size_t *siglen,
                   const unsigned char *tbs, size_t tbslen);
-int EVP_PKEY_verify_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
 int EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
                     const unsigned char *sig, size_t siglen,
                     const unsigned char *tbs, size_t tbslen);
-int EVP_PKEY_verify_recover_init_ex(EVP_PKEY_CTX *ctx, EVP_SIGNATURE *signature);
 int EVP_PKEY_verify_recover_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
                             unsigned char *rout, size_t *routlen,

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1237,10 +1237,8 @@ static int test_EVP_PKEY_CTX_get_set_params(void)
 
     /* Initialise a sign operation */
     ctx = EVP_PKEY_CTX_new(pkey, NULL);
-    dsaimpl = EVP_SIGNATURE_fetch(NULL, "DSA", NULL);
     if (!TEST_ptr(ctx)
-            || !TEST_ptr(dsaimpl)
-            || !TEST_int_gt(EVP_PKEY_sign_init_ex(ctx, dsaimpl), 0))
+            || !TEST_int_gt(EVP_PKEY_sign_init(ctx), 0))
         goto err;
 
     /*
@@ -1299,8 +1297,7 @@ static int test_EVP_PKEY_CTX_get_set_params(void)
      */
     mdctx = EVP_MD_CTX_new();
     if (!TEST_ptr(mdctx)
-            || !TEST_true(EVP_DigestSignInit_ex(mdctx, NULL, "SHA1", NULL,
-                                                pkey, dsaimpl)))
+        || !TEST_true(EVP_DigestSignInit_ex(mdctx, NULL, "SHA1", NULL, pkey)))
         goto err;
 
     /*

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4742,10 +4742,10 @@ EVP_SIGNATURE_free                      4858	3_0_0	EXIST::FUNCTION:
 EVP_SIGNATURE_up_ref                    4859	3_0_0	EXIST::FUNCTION:
 EVP_SIGNATURE_provider                  4860	3_0_0	EXIST::FUNCTION:
 EVP_SIGNATURE_fetch                     4861	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_sign_init_ex                   4862	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_sign_init_ex                   4862	3_0_0	NOEXIST::FUNCTION:
 EVP_PKEY_CTX_set_signature_md           4863	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_verify_init_ex                 4864	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_verify_recover_init_ex         4865	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_verify_init_ex                 4864	3_0_0	NOEXIST::FUNCTION:
+EVP_PKEY_verify_recover_init_ex         4865	3_0_0	NOEXIST::FUNCTION:
 EVP_PKEY_CTX_get_signature_md           4866	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get_params                 4867	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_gettable_params            4868	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Because the algorithm to use is decided already when creating an
EVP_PKEY_CTX regardless of how it was created, it turns out that it's
unnecessary to provide the SIGNATURE method explicitly, and rather
always have it be fetched implicitly.

This means fewer changes for applications that want to use new
signature algorithms / implementations.
