### PR TITLE
EVP: Make the KEYEXCH implementation leaner

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -102,8 +102,6 @@ struct evp_keyexch_st {
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
 
-    EVP_KEYMGMT *keymgmt;
-
     OSSL_OP_keyexch_newctx_fn *newctx;
     OSSL_OP_keyexch_init_fn *init;
     OSSL_OP_keyexch_set_peer_fn *set_peer;

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -180,12 +180,12 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
      * checking if exchange is already there.  Keymgmt is a different
      * matter, as it isn't tied to a specific EVP_PKEY op.
      */
-    exchange = EVP_KEYEXCH_fetch(NULL, ctx->algorithm, ctx->propquery);
+    exchange = EVP_KEYEXCH_fetch(ctx->libctx, ctx->algorithm, ctx->propquery);
     if (exchange != NULL && ctx->keymgmt == NULL) {
         int name_id = EVP_KEYEXCH_number(exchange);
 
         ctx->keymgmt =
-            evp_keymgmt_fetch_by_number(NULL, name_id, ctx->propquery);
+            evp_keymgmt_fetch_by_number(ctx->libctx, name_id, ctx->propquery);
     }
 
     if (ctx->keymgmt == NULL

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -482,6 +482,7 @@ void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx)
         ctx->pmeth->cleanup(ctx);
 
     evp_pkey_ctx_free_old_ops(ctx);
+    EVP_KEYMGMT_free(ctx->keymgmt);
 
     EVP_PKEY_free(ctx->pkey);
     EVP_PKEY_free(ctx->peerkey);

--- a/doc/man3/EVP_PKEY_derive.pod
+++ b/doc/man3/EVP_PKEY_derive.pod
@@ -2,43 +2,34 @@
 
 =head1 NAME
 
-EVP_PKEY_derive_init, EVP_PKEY_derive_init_ex, EVP_PKEY_derive_set_peer,
-EVP_PKEY_derive - derive public key algorithm shared secret
+EVP_PKEY_derive_init, EVP_PKEY_derive_set_peer, EVP_PKEY_derive
+- derive public key algorithm shared secret
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
- int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, EVP_KEYEXCH *exchange);
  int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer);
  int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
 
 =head1 DESCRIPTION
 
-The EVP_PKEY_derive_init_ex() function initializes a public key algorithm
-context for shared secret derivation using the key exchange algorithm
-B<exchange>.
-The key exchange algorithm B<exchange> should be fetched using a call to
-L<EVP_KEYEXCH_fetch(3)>.
-The EVP_PKEY object associated with B<ctx> must be compatible with that
-algorithm.
-B<exchange> may be NULL in which case the EVP_KEYEXCH algorithm is fetched
-implicitly based on the type of EVP_PKEY associated with B<ctx>.
-See L<provider(7)/Implicit fetch> for more information about implict fetches.
-
-The EVP_PKEY_derive_init() function is the same as EVP_PKEY_derive_init_ex()
-except that the EVP_KEYEXCH algorithm is always implicitly fetched.
+EVP_PKEY_derive_init() initializes a public key algorithm context I<ctx> for
+shared secret derivation using the algorithm given when the context was created
+using L<EVP_PKEY_CTX_new(3)> or variants thereof.  The algorithm is used to
+fetch a B<EVP_KEYEXCH> method implicitly, see L<provider(7)/Implicit fetch> for
+more information about implict fetches.
 
 The EVP_PKEY_derive_set_peer() function sets the peer key: this will normally
 be a public key.
 
-The EVP_PKEY_derive() derives a shared secret using B<ctx>.
-If B<key> is B<NULL> then the maximum size of the output buffer is written to
-the B<keylen> parameter. If B<key> is not B<NULL> then before the call the
-B<keylen> parameter should contain the length of the B<key> buffer, if the call
-is successful the shared secret is written to B<key> and the amount of data
-written to B<keylen>.
+The EVP_PKEY_derive() derives a shared secret using I<ctx>.
+If I<key> is NULL then the maximum size of the output buffer is written to the
+I<keylen> parameter. If I<key> is not NULL then before the call the I<keylen>
+parameter should contain the length of the I<key> buffer, if the call is
+successful the shared secret is written to I<key> and the amount of data
+written to I<keylen>.
 
 =head1 NOTES
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -29,6 +29,9 @@ struct evp_pkey_ctx_st {
     const char *algorithm;
     const char *propquery;
 
+    /* cached key manager */
+    EVP_KEYMGMT *keymgmt;
+
     union {
         struct {
             EVP_KEYEXCH *exchange;

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1550,7 +1550,6 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
                      unsigned char *out, size_t *outlen,
                      const unsigned char *in, size_t inlen);
 
-int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, EVP_KEYEXCH *exchange);
 int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer);
 int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4666,7 +4666,7 @@ BN_priv_rand_ex                         4782	3_0_0	EXIST::FUNCTION:
 BN_rand_range_ex                        4783	3_0_0	EXIST::FUNCTION:
 BN_priv_rand_range_ex                   4784	3_0_0	EXIST::FUNCTION:
 BN_generate_prime_ex2                   4785	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_derive_init_ex                 4786	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_derive_init_ex                 4786	3_0_0	NOEXIST::FUNCTION:
 EVP_KEYEXCH_free                        4787	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_up_ref                      4788	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_fetch                       4789	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Because the algorithm to use is decided already when creating an
EVP_PKEY_CTX regardless of how it was created, it turns out that it's
unnecessary to provide the KEYEXCH method explicitly, and rather
always have it be fetched implicitly.

This means fewer changes for applications that want to use new key
exchange algorithms / implementations.
