### PR TITLE
Make EVP_PKEY_CTX initialization more precise

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -132,8 +132,24 @@ static EVP_PKEY_CTX *int_ctx_new(EVP_PKEY *pkey, ENGINE *e,
             return 0;
         id = pkey->type;
     }
-    name = OBJ_nid2sn(id);
+
+    /*
+     * Here, we extract what information we can for the purpose of
+     * supporting usage with implementations from providers, to make
+     * for a smooth transition from legacy stuff to provider based stuff.
+     *
+     * If an engine is given, this is entirely legacy, and we should not
+     * pretend anything else, so we only set the name when no engine is
+     * given.  If both are already given, someone made a mistake, and
+     * since that can only happen internally, it's safe to make an
+     * assertion.
+     */
+    if (!ossl_assert(e == NULL || name == NULL))
+        return NULL;
+    if (e == NULL)
+        name = OBJ_nid2sn(id);
     propquery = NULL;
+
 #ifndef OPENSSL_NO_ENGINE
     if (e == NULL && pkey != NULL)
         e = pkey->pmeth_engine != NULL ? pkey->pmeth_engine : pkey->engine;

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -12,7 +12,8 @@ EVP_PKEY_CTX_dup, EVP_PKEY_CTX_free
 
  EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
  EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
- EVP_PKEY_CTX *EVP_PKEY_CTX_new_provided(const char *name,
+ EVP_PKEY_CTX *EVP_PKEY_CTX_new_provided(OPENSSL_CTX *libctx,
+                                         const char *name,
                                          const char *propquery);
  EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *ctx);
  void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
@@ -25,11 +26,11 @@ the algorithm specified in I<pkey> and ENGINE I<e>.
 The EVP_PKEY_CTX_new_id() function allocates public key algorithm context
 using the algorithm specified by I<id> and ENGINE I<e>.
 
-The EVP_PKEY_CTX_new_provided() function allocates a public key
-algorithm context using the algorithm specified by I<name> and the
-property query I<propquery>.  The strings aren't duplicated, so they
-must remain unchanged for the lifetime of the returned B<EVP_PKEY_CTX>
-or of any of its duplicates.
+The EVP_PKEY_CTX_new_provided() function allocates a public key algorithm
+context using the library context I<libctx> (see L<OPENSSL_CTX(3)>), the
+algorithm specified by I<name> and the property query I<propquery>.  None
+of the arguments are duplicated, so they  must remain unchanged for the
+lifetime of the returned B<EVP_PKEY_CTX> or of any of its duplicates.
 
 EVP_PKEY_CTX_new_id() and EVP_PKEY_CTX_new_provided() are normally
 used when no B<EVP_PKEY> structure is associated with the operations,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -21,7 +21,11 @@ struct evp_pkey_ctx_st {
     /* Actual operation */
     int operation;
 
-    /* Algorithm name and properties associated with this context */
+    /*
+     * Library context, Algorithm name and properties associated
+     * with this context
+     */
+    OPENSSL_CTX *libctx;
     const char *algorithm;
     const char *propquery;
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1461,7 +1461,8 @@ void EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
-EVP_PKEY_CTX *EVP_PKEY_CTX_new_provided(const char *name,
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_provided(OPENSSL_CTX *libctx,
+                                        const char *name,
                                         const char *propquery);
 EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *ctx);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);


### PR DESCRIPTION
There is a vagueness around how the provider data (algorithm name and
property query string) is initialized in the presence of an engine.
This change modifies this slightly so that the algorithm name for use
with providers is never set if the initilization was given an engine.

This makes it easier for other functions to simply check ctx->algorithm
to see if the context is meant to be used for strictly legacy stuff or
not.

Additionally, we change `EVP_PKEY_CTX_new_provided()` to take a library
context alongside the algorithm name and property query string.