### PR TITLE
Add more tests for `apps/req`

### DIFF
--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -82,7 +82,7 @@ subtest "generating certificate requests with DSA" => sub {
         }
 };
 
-subtest "generating certificate requests with DSA" => sub {
+subtest "generating certificate requests with ECDSA" => sub {
     plan tests => 2;
 
     SKIP: {

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -53,15 +53,17 @@ subtest "generating certificate requests with RSA" => sub {
         skip "RSA is not supported by this OpenSSL build", 2
             if disabled("rsa");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-new", "-out", "testreq.pem", "-utf8",
-            "-key", srctop_file("test", "testrsa.pem")])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq.pem", "-utf8",
+                    "-key", srctop_file("test", "testrsa.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-verify", "-in", "testreq.pem", "-noout"])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout"])),
            "Verifying signature on request");
-        }
+    }
 };
 
 subtest "generating certificate requests with DSA" => sub {
@@ -71,15 +73,17 @@ subtest "generating certificate requests with DSA" => sub {
         skip "DSA is not supported by this OpenSSL build", 2
             if disabled("dsa");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-new", "-out", "testreq.pem", "-utf8",
-            "-key", srctop_file("test", "testdsa.pem")])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq.pem", "-utf8",
+                    "-key", srctop_file("test", "testdsa.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-verify", "-in", "testreq.pem", "-noout"])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout"])),
            "Verifying signature on request");
-        }
+    }
 };
 
 subtest "generating certificate requests with ECDSA" => sub {
@@ -89,26 +93,28 @@ subtest "generating certificate requests with ECDSA" => sub {
         skip "ECDSA is not supported by this OpenSSL build", 2
             if disabled("ec");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-new", "-out", "testreq.pem", "-utf8",
-            "-key", srctop_file("test", "testec-p256.pem")])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq.pem", "-utf8",
+                    "-key", srctop_file("test", "testec-p256.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-verify", "-in", "testreq.pem", "-noout"])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout"])),
            "Verifying signature on request");
-        }
+    }
 };
 
 subtest "generating certificate requests" => sub {
     plan tests => 2;
 
     ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-		@req_new, "-out", "testreq.pem"])),
+                @req_new, "-out", "testreq.pem"])),
        "Generating request");
 
     ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-		"-verify", "-in", "testreq.pem", "-noout"])),
+                "-verify", "-in", "testreq.pem", "-noout"])),
        "Verifying signature on request");
 };
 
@@ -118,24 +124,28 @@ subtest "generating SM2 certificate requests" => sub {
     SKIP: {
         skip "SM2 is not supported by this OpenSSL build", 4
         if disabled("sm2");
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
                     "-new", "-key", srctop_file("test", "certs", "sm2.key"),
                     "-sigopt", "sm2_id:1234567812345678",
                     "-out", "testreq.pem", "-sm3"])),
            "Generating SM2 certificate request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
                     "-verify", "-in", "testreq.pem", "-noout",
                     "-sm2-id", "1234567812345678", "-sm3"])),
            "Verifying signature on SM2 certificate request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
                     "-new", "-key", srctop_file("test", "certs", "sm2.key"),
                     "-sigopt", "sm2_hex_id:DEADBEEF",
                     "-out", "testreq.pem", "-sm3"])),
            "Generating SM2 certificate request with hex id");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
                     "-verify", "-in", "testreq.pem", "-noout",
                     "-sm2-hex-id", "DEADBEEF", "-sm3"])),
            "Verifying signature on SM2 certificate request");
@@ -145,9 +155,9 @@ subtest "generating SM2 certificate requests" => sub {
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));
 
 run_conversion('req conversions',
-	       "testreq.pem");
+               "testreq.pem");
 run_conversion('req conversions -- testreq2',
-	       srctop_file("test", "testreq2.pem"));
+               srctop_file("test", "testreq2.pem"));
 
 unlink "testkey.pem", "testreq.pem";
 
@@ -156,20 +166,20 @@ sub run_conversion {
     my $reqfile = shift;
 
     subtest $title => sub {
-	run(app(["openssl", @openssl_args,
-		 "-in", $reqfile, "-inform", "p",
-		 "-noout", "-text"],
-		stderr => "req-check.err", stdout => undef));
-	open DATA, "req-check.err";
+    run(app(["openssl", @openssl_args,
+             "-in", $reqfile, "-inform", "p",
+             "-noout", "-text"],
+            stderr => "req-check.err", stdout => undef));
+    open DATA, "req-check.err";
       SKIP: {
-	  plan skip_all => "skipping req conversion test for $reqfile"
-	      if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
+      plan skip_all => "skipping req conversion test for $reqfile"
+          if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
 
-	  tconversion("req", $reqfile, @openssl_args);
-	}
-	close DATA;
-	unlink "req-check.err";
+      tconversion("req", $reqfile, @openssl_args);
+    }
+    close DATA;
+    unlink "req-check.err";
 
-	done_testing();
+    done_testing();
     };
 }

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 10;
+plan tests => 13;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -45,6 +45,62 @@ ok(!run(app([@addext_args, "-addext", $val, "-addext", $val])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val2])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val3])));
 ok(!run(app([@addext_args, "-addext", $val2, "-addext", $val3])));
+
+subtest "generating certificate requests with RSA" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "RSA is not supported by this OpenSSL build", 2
+            if disabled("rsa");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-new", "-out", "testreq.pem", "-utf8",
+            "-key", srctop_file("test", "testrsa.pem")])),
+           "Generating request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-verify", "-in", "testreq.pem", "-noout"])),
+           "Verifying signature on request");
+        }
+};
+
+subtest "generating certificate requests with DSA" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "This test is failing and disabled", 2
+            if 1;
+#       skip "DSA is not supported by this OpenSSL build", 2
+#           if disabled("dsa");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-new", "-out", "testreq.pem", "-utf8",
+            "-key", srctop_file("test", "testdsa.pem")])),
+           "Generating request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-verify", "-in", "testreq.pem", "-noout"])),
+           "Verifying signature on request");
+        }
+};
+
+subtest "generating certificate requests with DSA" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "ECDSA is not supported by this OpenSSL build", 2
+            if disabled("ec");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-new", "-out", "testreq.pem", "-utf8",
+            "-key", srctop_file("test", "testec-p256.pem")])),
+           "Generating request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-verify", "-in", "testreq.pem", "-noout"])),
+           "Verifying signature on request");
+        }
+};
 
 subtest "generating certificate requests" => sub {
     plan tests => 2;

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -166,20 +166,20 @@ sub run_conversion {
     my $reqfile = shift;
 
     subtest $title => sub {
-    run(app(["openssl", @openssl_args,
-             "-in", $reqfile, "-inform", "p",
-             "-noout", "-text"],
-            stderr => "req-check.err", stdout => undef));
-    open DATA, "req-check.err";
-      SKIP: {
-      plan skip_all => "skipping req conversion test for $reqfile"
-          if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
+        run(app(["openssl", @openssl_args,
+                 "-in", $reqfile, "-inform", "p",
+                 "-noout", "-text"],
+                stderr => "req-check.err", stdout => undef));
+        open DATA, "req-check.err";
+        SKIP: {
+            plan skip_all => "skipping req conversion test for $reqfile"
+                if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
 
-      tconversion("req", $reqfile, @openssl_args);
-    }
-    close DATA;
-    unlink "req-check.err";
+            tconversion("req", $reqfile, @openssl_args);
+        }
+        close DATA;
+        unlink "req-check.err";
 
-    done_testing();
+        done_testing();
     };
 }

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -68,10 +68,8 @@ subtest "generating certificate requests with DSA" => sub {
     plan tests => 2;
 
     SKIP: {
-        skip "This test is failing and disabled", 2
-            if 1;
-#       skip "DSA is not supported by this OpenSSL build", 2
-#           if disabled("dsa");
+        skip "DSA is not supported by this OpenSSL build", 2
+            if disabled("dsa");
 
         ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
             "-new", "-out", "testreq.pem", "-utf8",


### PR DESCRIPTION
https://github.com/openssl/openssl/issues/10224#issuecomment-546593113
highlighted that existing testing infrastructure is not covering common
usage patterns of the `req` app.

This commit explicitly adds request generations thorugh the CLI using
RSA, DSA and ECDSA (P-256) keys.



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
