### PR TITLE
Dont pass zero length input to asm modules for ciphers

### DIFF
--- a/providers/common/ciphers/cipher_common.c
+++ b/providers/common/ciphers/cipher_common.c
@@ -180,6 +180,8 @@ int cipher_generic_block_update(void *vctx, unsigned char *out, size_t *outl,
             ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
             return 0;
         }
+    }
+    if (nextblocks > 0) {
         if (!ctx->hw->cipher(ctx, out, in, nextblocks)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_CIPHER_OPERATION_FAILED);
             return 0;


### PR DESCRIPTION
The asm modules may assume an input length > 0.

Fixes: #9262

Remember the same applied to keccak https://github.com/openssl/openssl/issues/9431, so in general we shouldnt pass zero length input to an asm module that does not explicitely claim to handle that case. This was handeled correctly before the re-plumbing, but seems to have been lost here and there.
