### PR TITLE
 Ensure EVP_get_digestbyname() and EVP_get_cipherbyname() know all aliases

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -593,7 +593,11 @@ int EVP_PKEY_CTX_get_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD **md)
     if (!EVP_PKEY_CTX_get_params(ctx, sig_md_params))
         return 0;
 
-    tmp = EVP_get_digestbyname(name);
+    /*
+     * TODO(3.0): We need to pass the library context here - but at the time
+     * of writing we don't seem to store that in the EVP_PKEY_CTX.
+     */
+    tmp = evp_get_digestbyname_ex(NULL, name);
     if (tmp == NULL)
         return 0;
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -593,11 +593,7 @@ int EVP_PKEY_CTX_get_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD **md)
     if (!EVP_PKEY_CTX_get_params(ctx, sig_md_params))
         return 0;
 
-    /*
-     * TODO(3.0): We need to pass the library context here - but at the time
-     * of writing we don't seem to store that in the EVP_PKEY_CTX.
-     */
-    tmp = evp_get_digestbyname_ex(NULL, name);
+    tmp = evp_get_digestbyname_ex(ctx->libctx, name);
     if (tmp == NULL)
         return 0;
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -619,3 +619,6 @@ void evp_encode_ctx_set_flags(EVP_ENCODE_CTX *ctx, unsigned int flags);
 #define EVP_ENCODE_CTX_NO_NEWLINES          1
 /* Use the SRP base64 alphabet instead of the standard one */
 #define EVP_ENCODE_CTX_USE_SRP_ALPHABET     2
+
+const EVP_CIPHER *evp_get_cipherbyname_ex(OPENSSL_CTX *libctx, const char *name);
+const EVP_MD *evp_get_digestbyname_ex(OPENSSL_CTX *libctx, const char *name);

--- a/test/namemap_internal_test.c
+++ b/test/namemap_internal_test.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/evp.h>
 #include "internal/namemap.h"
 #include "testutil.h"
 
@@ -55,9 +56,64 @@ static int test_namemap_stored(void)
         && test_namemap(nm);
 }
 
+/*
+ * Test that EVP_get_digestbyname() will use the namemap when it can't find
+ * entries in the legacy method database.
+ */
+static int test_digestbyname(void)
+{
+    int id;
+    OSSL_NAMEMAP *nm = ossl_namemap_stored(NULL);
+    const EVP_MD *sha256, *foo;
+
+    id = ossl_namemap_add(nm, 0, "SHA256");
+    if (!TEST_int_ne(id, 0))
+        return 0;
+    if (!TEST_int_eq(ossl_namemap_add(nm, id, "foo"), id))
+        return 0;
+
+    sha256 = EVP_get_digestbyname("SHA256");
+    if (!TEST_ptr(sha256))
+        return 0;
+    foo = EVP_get_digestbyname("foo");
+    if (!TEST_ptr_eq(sha256, foo))
+        return 0;
+
+    return 1;
+}
+
+/*
+ * Test that EVP_get_cipherbyname() will use the namemap when it can't find
+ * entries in the legacy method database.
+ */
+static int test_cipherbyname(void)
+{
+    int id;
+    OSSL_NAMEMAP *nm = ossl_namemap_stored(NULL);
+    const EVP_CIPHER *aes128, *bar;
+
+    id = ossl_namemap_add(nm, 0, "AES-128-CBC");
+    if (!TEST_int_ne(id, 0))
+        return 0;
+    if (!TEST_int_eq(ossl_namemap_add(nm, id, "bar"), id))
+        return 0;
+
+    aes128 = EVP_get_cipherbyname("AES-128-CBC");
+    if (!TEST_ptr(aes128))
+        return 0;
+    bar = EVP_get_cipherbyname("bar");
+    if (!TEST_ptr_eq(aes128, bar))
+        return 0;
+
+    return 1;
+}
+
+
 int setup_tests(void)
 {
     ADD_TEST(test_namemap_independent);
     ADD_TEST(test_namemap_stored);
+    ADD_TEST(test_digestbyname);
+    ADD_TEST(test_cipherbyname);
     return 1;
 }


### PR DESCRIPTION
Now that we have an EVP namemap containing all aliases that providers know about for any given algorithm, it is possible that an application attempts to look up a digest or a cipher via `EVP_get_digestbyname()` or `EVP_get_cipherbyname()` with an algorithm name that is unknown to the legacy method database. Therefore we extend those functions to additionally check the aliases in the namemap when searching for a method in the event that our initial lookup attempt fails.
