### PR TITLE
Fix OSSL_PARAM_set_BN() to fill the given buffer correctly.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -640,8 +640,11 @@ int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val)
     p->return_size = bytes;
     if (p->data == NULL)
         return 1;
-    return p->data_size >= bytes
-        && BN_bn2nativepad(val, p->data, bytes) >= 0;
+    if (p->data_size >= bytes) {
+        p->return_size = p->data_size;
+        return BN_bn2nativepad(val, p->data, p->data_size) >= 0;
+    }
+    return 0;
 }
 
 OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -100,10 +100,12 @@ accepted, otherwise it specifies the maximum size allowed.
 =item I<return_size>
 
 When an array of B<OSSL_PARAM> is used to request data, the
-I<responder> must set this field to indicate the actual size of the
-parameter data.
-In case the I<data_size> is too small for the data, the I<responder>
-must still set this field to indicate the minimum data size required.
+I<responder> must set this field to indicate size of the parameter
+data, including padding as the case may be.
+In case the I<data_size> is an unsuitable size for the data, the
+I<responder> must still set this field to indicate the minimum data
+size required.
+(further notes on this in L</NOTES> below).
 
 When the B<OSSL_PARAM> is used as a parameter descriptor,
 I<return_size> should be ignored.
@@ -238,8 +240,18 @@ B<OSSL_PARAM_OCTET_STRING>), but this is in no way mandatory.
 
 If a I<responder> finds that some data sizes are too small for the
 requested data, it must set I<return_size> for each such
-B<OSSL_PARAM> item to the required size, and eventually return an
-error.
+B<OSSL_PARAM> item to the minimum required size, and eventually return
+an error.
+
+=item *
+
+For the integer type parameters (B<OSSL_PARAM_UNSIGNED_INTEGER> and
+B<OSSL_PARAM_INTEGER>), a I<responder> may choose to return an error
+if the I<data_size> isn't a suitable size (even if I<data_size> is
+bigger than needed).  If the I<responder> finds the size suitable, it
+must fill all I<data_size> bytes and ensure correct padding for the
+native endianness, and set I<return_size> to the same value as
+I<data_size>.
 
 =back
 

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -548,7 +548,7 @@ static int test_param_construct(void)
     if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "bignum"))
         || !TEST_ptr(bn = BN_lebin2bn(bn_val, (int)sizeof(bn_val), NULL))
         || !TEST_true(OSSL_PARAM_set_BN(cp, bn))
-        || !TEST_size_t_eq(cp->return_size, sizeof(bn_val)))
+        || !TEST_size_t_eq(cp->data_size, cp->return_size))
         goto err;
     /* Match the return size to avoid trailing garbage bytes */
     cp->data_size = cp->return_size;


### PR DESCRIPTION
OSSL_PARAM_set_BN() filled the buffer from the left with as many bytes
as that the BIGNUM takes, regardless of buffer size or native
endianness.  This was due to BN_bn2nativepad() being given the size of
the BIGNUM rather than the size of the buffer (which meant it never
had to pad anything).

The fix is to given BN_bn2nativepad() the size of the buffer instead.
This aligns well with the corresponding _set_ functions for native
integer types work.

Alternative to #10318