### PR TITLE
s390x assembly pack: enable clang build

### DIFF
--- a/crypto/bn/asm/s390x-mont.pl
+++ b/crypto/bn/asm/s390x-mont.pl
@@ -147,7 +147,7 @@ $code.=<<___;
 	lghi	$NHI,0
 	alcgr	$NHI,$nhi
 
-	la	$j,8(%r0)	# j=1
+	la	$j,8		# j=1
 	lr	$count,$num
 
 .align	16
@@ -199,7 +199,7 @@ $code.=<<___;
 	lghi	$NHI,0
 	alcgr	$NHI,$nhi
 
-	la	$j,8(%r0)	# j=1
+	la	$j,8		# j=1
 	lr	$count,$num
 
 .align	16
@@ -243,7 +243,7 @@ $code.=<<___;
 	la	$ap,$stdframe($sp)
 	ahi	$num,1		# restore $num, incidentally clears "borrow"
 
-	la	$j,0(%r0)
+	la	$j,0
 	lr	$count,$num
 .Lsub:	lg	$alo,0($j,$ap)
 	lg	$nlo,0($j,$np)
@@ -257,7 +257,7 @@ $code.=<<___;
 	lghi	$NHI,-1
 	xgr	$NHI,$AHI
 
-	la	$j,0(%r0)
+	la	$j,0
 	lgr	$count,$num
 .Lcopy:	lg	$ahi,$stdframe($j,$sp)	# conditional copy
 	lg	$alo,0($j,$rp)

--- a/crypto/perlasm/s390x.pm
+++ b/crypto/perlasm/s390x.pm
@@ -130,7 +130,7 @@ sub AUTOLOAD {
 	confess(err("PARSE")) if (grep(!defined($_),@_));
 	my $token;
 	for ($AUTOLOAD) {
-		$token=".$1" if (/^.*::([A-Z_]+)$/);	# uppercase: directive
+		$token=lc(".$1") if (/^.*::([A-Z_]+)$/);# uppercase: directive
 		$token="\t$1" if (/^.*::([a-z]+)$/);	# lowercase: mnemonic
 		confess(err("PARSE")) if (!defined($token));
 	}

--- a/crypto/rc4/asm/rc4-s390x.pl
+++ b/crypto/rc4/asm/rc4-s390x.pl
@@ -186,7 +186,7 @@ $code.=<<___;
 RC4_set_key:
 	stm${g}	%r6,%r8,6*$SIZE_T($sp)
 	lhi	$cnt,256
-	la	$idx,0(%r0)
+	la	$idx,0
 	sth	$idx,0($key)
 .align	4
 .L1stloop:
@@ -196,8 +196,8 @@ RC4_set_key:
 
 	lghi	$ikey,-256
 	lr	$cnt,$len
-	la	$iinp,0(%r0)
-	la	$idx,0(%r0)
+	la	$iinp,0
+	la	$idx,0
 .align	16
 .L2ndloop:
 	llgc	$acc,2+256($ikey,$key)
@@ -214,7 +214,7 @@ RC4_set_key:
 	jz	.Ldone
 	brct	$cnt,.L2ndloop
 	lr	$cnt,$len
-	la	$iinp,0(%r0)
+	la	$iinp,0
 	j	.L2ndloop
 .Ldone:
 	lm${g}	%r6,%r8,6*$SIZE_T($sp)

--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -504,14 +504,14 @@ $code.=<<___;
 .type	s390x_flip_endian32,\@function
 .align	16
 s390x_flip_endian32:
-	lrvg	%r0,0(%r0,$src)
-	lrvg	%r1,8(%r0,$src)
-	lrvg	%r4,16(%r0,$src)
-	lrvg	%r5,24(%r0,$src)
-	stg	%r0,24(%r0,$dst)
-	stg	%r1,16(%r0,$dst)
-	stg	%r4,8(%r0,$dst)
-	stg	%r5,0(%r0,$dst)
+	lrvg	%r0,0($src)
+	lrvg	%r1,8($src)
+	lrvg	%r4,16($src)
+	lrvg	%r5,24($src)
+	stg	%r0,24($dst)
+	stg	%r1,16($dst)
+	stg	%r4,8($dst)
+	stg	%r5,0($dst)
 	br	$ra
 .size	s390x_flip_endian32,.-s390x_flip_endian32
 ___
@@ -528,22 +528,22 @@ $code.=<<___;
 s390x_flip_endian64:
 	stmg	%r6,%r9,6*$SIZE_T($sp)
 
-	lrvg	%r0,0(%r0,$src)
-	lrvg	%r1,8(%r0,$src)
-	lrvg	%r4,16(%r0,$src)
-	lrvg	%r5,24(%r0,$src)
-	lrvg	%r6,32(%r0,$src)
-	lrvg	%r7,40(%r0,$src)
-	lrvg	%r8,48(%r0,$src)
-	lrvg	%r9,56(%r0,$src)
-	stg	%r0,56(%r0,$dst)
-	stg	%r1,48(%r0,$dst)
-	stg	%r4,40(%r0,$dst)
-	stg	%r5,32(%r0,$dst)
-	stg	%r6,24(%r0,$dst)
-	stg	%r7,16(%r0,$dst)
-	stg	%r8,8(%r0,$dst)
-	stg	%r9,0(%r0,$dst)
+	lrvg	%r0,0($src)
+	lrvg	%r1,8($src)
+	lrvg	%r4,16($src)
+	lrvg	%r5,24($src)
+	lrvg	%r6,32($src)
+	lrvg	%r7,40($src)
+	lrvg	%r8,48($src)
+	lrvg	%r9,56($src)
+	stg	%r0,56($dst)
+	stg	%r1,48($dst)
+	stg	%r4,40($dst)
+	stg	%r5,32($dst)
+	stg	%r6,24($dst)
+	stg	%r7,16($dst)
+	stg	%r8,8($dst)
+	stg	%r9,0($dst)
 
 	lmg	%r6,%r9,6*$SIZE_T($sp)
 	br	$ra


### PR DESCRIPTION
clang imposes some restrictions on the assembler code that
gcc does not.
