### PR TITLE
BIO_s_connect: add an error state and use it [1.1.1]

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -54,6 +54,7 @@ void BIO_CONNECT_free(BIO_CONNECT *a);
 #define BIO_CONN_S_CONNECT               4
 #define BIO_CONN_S_OK                    5
 #define BIO_CONN_S_BLOCKED_CONNECT       6
+#define BIO_CONN_S_CONNECT_ERROR         7
 
 static const BIO_METHOD methods_connectp = {
     BIO_TYPE_CONNECT,
@@ -174,7 +175,8 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     ERR_add_error_data(4,
                                        "hostname=", c->param_hostname,
                                        " service=", c->param_service);
-                    BIOerr(BIO_F_CONN_STATE, BIO_R_CONNECT_ERROR);
+                    c->state = BIO_CONN_S_CONNECT_ERROR;
+                    break;
                 }
                 goto exit_loop;
             } else {
@@ -196,6 +198,11 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             } else
                 c->state = BIO_CONN_S_OK;
             break;
+
+        case BIO_CONN_S_CONNECT_ERROR:
+            BIOerr(BIO_F_CONN_STATE, BIO_R_CONNECT_ERROR);
+            ret = 0;
+            goto exit_loop;
 
         case BIO_CONN_S_OK:
             ret = 1;


### PR DESCRIPTION
If no connection could be made, addr_iter will eventually end up being
NULL, and if the user didn't check the returned error value, the
BIO_CONN_S_CONNECT code will be performed again and will crash.

So instead, we add a state BIO_CONN_S_CONNECT_ERROR that we enter into
when we run out of addresses to try.  That state will just simply say
"error" back, until the user does something better with the BIO, such
as free it or reset it.

-----

Backport of #7630