### PR TITLE
Fix --strict-warnings build

### DIFF
--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -49,8 +49,8 @@ static void tree_print(BIO *channel,
         curr++;
 
     BIO_printf(channel, "Level print after %s\n", str);
-    BIO_printf(channel, "Printing Up to Level %zd\n",
-               curr - tree->levels);
+    BIO_printf(channel, "Printing Up to Level %ld\n",
+               (long)(curr - tree->levels));
     for (plev = tree->levels; plev != curr; plev++) {
         int i;
 


### PR DESCRIPTION
The %zd format corresponds to ssize_t which is used for
function to either return a valid size or a negative value
to indicate an error. Since size_t is in [-1,SSIZE_MAX] it
is not a portable way to represent a pointer diff. For
the %td format which corresponds to ptrdiff_t is C11,
we chose to cast to long instead as it is already done
in other places.

