### PR TITLE
bss_dgram.c: fix unaligned access

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -1125,7 +1125,7 @@ static int dgram_sctp_read(BIO *b, char *out, int outl)
                     data->handle_notifications(b, data->notification_context,
                                                (void *)out);
 
-                OPENSSL_cleanse(&snp, sizeof(snp));
+                memset(&snp, 0, sizeof(snp));
                 memset(out, 0, outl);
             } else {
                 ret += n;


### PR DESCRIPTION
char (alignment 1) casted to union sctp_notification (alignment > 1).

A suggestion for a fix for #9538. Please review.

