### PR TITLE
AES_ige_encrypt: ensure memcpy buffers dont overlap

### DIFF
--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -46,7 +46,7 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
     size_t n;
     size_t len = length;
 
-    if (length == 0)
+    if (length / AES_BLOCK_SIZE == 0)
         return;
 
     OPENSSL_assert(in && out && key && ivec);

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -46,7 +46,7 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
     size_t n;
     size_t len = length;
 
-    if (length / AES_BLOCK_SIZE == 0)
+    if (length == 0)
         return;
 
     OPENSSL_assert(in && out && key && ivec);
@@ -54,6 +54,8 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
     OPENSSL_assert((length % AES_BLOCK_SIZE) == 0);
 
     len = length / AES_BLOCK_SIZE;
+    if (!ossl_assert(len > 0))
+        return;
 
     if (AES_ENCRYPT == enc) {
         if (in != out &&


### PR DESCRIPTION
AES_ige_encrypt must not process inputs less than 16 bytes.
Those inputs would lead to overlapping buffers with memcpy
and sanitizers may error.
