### PR TITLE
s390x: fix x448, add x448 test vector, ctime for x25519 and x448

### DIFF
--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -907,10 +907,8 @@ static void s390x_x448_mod_p(unsigned char u[56])
         c >>= 8;
     }
 
-    if (u_red[0] & 0x80) {
-        u_red[0] &= 0x7f;
+    if (c)
         memcpy(u, u_red, sizeof(u_red));
-    }
 }
 
 static int s390x_x25519_mul(unsigned char u_dst[32],
@@ -966,7 +964,7 @@ static int s390x_x448_mul(unsigned char u_dst[56],
     memcpy(param.x448.d_src, d_src, 56);
 
     s390x_flip_endian64(param.x448.u_src, param.x448.u_src);
-    s390x_x448_mod_p(param.x448.u_src);
+    s390x_x448_mod_p(param.x448.u_src + 8);
 
     s390x_flip_endian64(param.x448.d_src, param.x448.d_src);
     param.x448.d_src[63] &= 252;

--- a/include/internal/constant_time.h
+++ b/include/internal/constant_time.h
@@ -353,6 +353,34 @@ static ossl_inline void constant_time_cond_swap_64(uint64_t mask, uint64_t *a,
 }
 
 /*
+ * mask must be 0xFF or 0x00.
+ * "constant time" is per len.
+ *
+ * if (mask) {
+ *     unsigned char tmp[len];
+ *
+ *     memcpy(tmp, a, len);
+ *     memcpy(a, b);
+ *     memcpy(b, tmp);
+ * }
+ */
+static ossl_inline void constant_time_cond_swap_buff(unsigned char mask,
+                                                     unsigned char *a,
+                                                     unsigned char *b,
+                                                     size_t len)
+{
+    size_t i;
+    unsigned char tmp;
+
+    for (i = 0; i < len; i++) {
+        tmp = a[i] ^ b[i];
+        tmp &= mask;
+        a[i] ^= tmp;
+        b[i] ^= tmp;
+    }
+}
+
+/*
  * table is a two dimensional array of bytes. Each row has rowsize elements.
  * Copies row number idx into out. rowsize and numrows are not considered
  * private.

--- a/test/recipes/30-test_evp_data/evppkey.txt
+++ b/test/recipes/30-test_evp_data/evppkey.txt
@@ -807,6 +807,8 @@ PublicKeyRaw=Bob-448-PUBLIC-Raw:X448:3eb7a829b0cd20f5bcfc0b599b6feccf6da4627107b
 
 PrivPubKeyPair = Bob-448-Raw:Bob-448-PUBLIC-Raw
 
+PublicKeyRaw=Bob-448-PUBLIC-Raw-NonCanonical:X448:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
 Derive=Alice-448
 PeerKey=Bob-448-PUBLIC
 SharedSecret=07fff4181ac6cc95ec1c16a94a0f74d12da232ce40a77552281d282bb60c0b56fd2464c335543936521c24403085d59a449a5037514a879d
@@ -822,6 +824,11 @@ SharedSecret=07fff4181ac6cc95ec1c16a94a0f74d12da232ce40a77552281d282bb60c0b56fd2
 Derive=Bob-448-Raw
 PeerKey=Alice-448-PUBLIC-Raw
 SharedSecret=07fff4181ac6cc95ec1c16a94a0f74d12da232ce40a77552281d282bb60c0b56fd2464c335543936521c24403085d59a449a5037514a879d
+
+# Self-generated non-canonical
+Derive=Alice-448-Raw
+PeerKey=Bob-448-PUBLIC-Raw-NonCanonical
+SharedSecret=66e2e682b1f8e68c809f1bb3e406bd826921d9c1a5bfbfcbab7ae72feecee63660eabd54934f3382061d17607f581a90bdac917a064959fb
 
 # Illegal sign/verify operations with X448 key
 


### PR DESCRIPTION
The s390x x448 implementation does not correctly reduce non-canonical values, ie u-coordinates greater than or equal to p = 2^448 - 2^224 - 1. The first commit fixes this.

The bug went unnoticed because there is no test vector for that case. x25519 has such a test vector obtained from wycheproof but wycheproof does not have a corresponding x448 test vector. So the second commit adds a self-generated test vector for that case.

While we are at it, the third commit makes the processing of those non-canonical values constant time for x25519 and x448.

- [x] tests are added or updated
