### PR TITLE
Fix a -Warray-bounds gcc warning in OPENSSL_DIR_read

### DIFF
--- a/crypto/LPdir_unix.c
+++ b/crypto/LPdir_unix.c
@@ -131,9 +131,8 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
         return 0;
     }
 
-    strncpy((*ctx)->entry_name, direntry->d_name,
-            sizeof((*ctx)->entry_name) - 1);
-    (*ctx)->entry_name[sizeof((*ctx)->entry_name) - 1] = '\0';
+    OPENSSL_strlcpy((*ctx)->entry_name, direntry->d_name,
+                    sizeof((*ctx)->entry_name));
 #ifdef __VMS
     if ((*ctx)->expect_file_generations) {
         char *p = (*ctx)->entry_name + strlen((*ctx)->entry_name);


### PR DESCRIPTION
Actually since direntry->d_name is guaranteed to be zero-terminated,
it does not matter that entry_name is larger.