### PR TITLE
Fix a gcc warning about possible null pointer

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -307,7 +307,7 @@ static int ccm_tls_cipher(PROV_CCM_CTX *ctx,
     size_t olen = 0;
 
     /* Encrypt/decrypt must be performed in place */
-    if (out != in || len < (EVP_CCM_TLS_EXPLICIT_IV_LEN + (size_t)ctx->m))
+    if (in == NULL || out != in || len < EVP_CCM_TLS_EXPLICIT_IV_LEN + ctx->m)
         goto err;
 
     /* If encrypting set explicit IV from sequence number (start of AAD) */


### PR DESCRIPTION
```
In function 'ccm_tls_cipher',
    inlined from 'ccm_cipher_internal' at providers/common/ciphers/cipher_ccm.c:359:16,
    inlined from 'ccm_stream_final' at providers/common/ciphers/cipher_ccm.c:265:9:
providers/common/ciphers/cipher_ccm.c:317:5: error: argument 2 null where non-null expected [-Werror=nonnull]
  317 |     memcpy(ctx->iv + EVP_CCM_TLS_FIXED_IV_LEN, in, EVP_CCM_TLS_EXPLICIT_IV_LEN);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from include/internal/cryptlib.h:14,
                 from providers/common/include/prov/ciphercommon.h:14,
                 from providers/common/ciphers/cipher_ccm.c:12:
providers/common/ciphers/cipher_ccm.c: In function 'ccm_stream_final':
/home/ed/gnu/arm-linux-gnueabihf-linux64/arm-linux-gnueabihf/sys-include/string.h:44:14: note: in a call to function 'memcpy' declared here
   44 | extern void *memcpy (void *__restrict __dest,
      |              ^~~~~~
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
