### PR TITLE
Configure: Make --strict-warnings meaningful with MSVC cl [1.1.1]

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1313,7 +1313,6 @@ my %targets = (
     "VC-WIN32" => {
         inherit_from     => [ "VC-noCE-common", asm("x86_asm"),
                               sub { $disabled{shared} ? () : "uplink_common" } ],
-        CFLAGS           => add("/WX"),
         AS               => sub { vc_win32_info()->{AS} },
         ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
         asoutflag        => sub { vc_win32_info()->{asoutflag} },

--- a/Configure
+++ b/Configure
@@ -160,6 +160,10 @@ my @clang_devteam_warn = qw(
     -Wmissing-variable-declarations
 );
 
+my @cl_devteam_warn = qw(
+    /WX
+);
+
 # This adds backtrace information to the memory leak info.  Is only used
 # when crypto-mdebug-backtrace is enabled.
 my $memleak_devteam_backtrace = "-rdynamic";
@@ -1523,11 +1527,20 @@ if ($strict_warnings)
         my $wopt;
         my $gccver = $predefined_C{__GNUC__} // -1;
 
-        warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike"
-            unless $gccver >= 4;
-        push @strict_warnings_collection, @gcc_devteam_warn;
-        push @strict_warnings_collection, @clang_devteam_warn
-            if (defined($predefined_C{__clang__}));
+        if ($gccver >= 4)
+                {
+                push @strict_warnings_collection, @gcc_devteam_warn;
+                push @strict_warnings_collection, @clang_devteam_warn
+                    if (defined($predefined_C{__clang__}));
+                }
+        elsif ($config{target} =~ /^VC-/)
+                {
+                push @strict_warnings_collection, @cl_devteam_warn;
+                }
+        else
+                {
+                warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike, or MSVC"
+                }
         }
 
 if (grep { $_ eq '-static' } @{$config{LDFLAGS}}) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ before_build:
     - ps: >-
         If ($env:Platform -Match "x86") {
             $env:VCVARS_PLATFORM="x86"
-            $env:TARGET="VC-WIN32 no-asm"
+            $env:TARGET="VC-WIN32 no-asm --strict-warnings"
         } Else {
             $env:VCVARS_PLATFORM="amd64"
             $env:TARGET="VC-WIN64A-masm"


### PR DESCRIPTION
We also add this to our x86_64 builds on appveyor

(cherry picked from commit b4a7b4ec4acc712b1f22a83966ac986b510f25d8)
