### PR TITLE
[bp-111] Add more tests for apps/req

### DIFF
--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 9;
+plan tests => 12;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -45,6 +45,62 @@ ok(!run(app([@addext_args, "-addext", $val, "-addext", $val])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val2])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val3])));
 ok(!run(app([@addext_args, "-addext", $val2, "-addext", $val3])));
+
+subtest "generating certificate requests with RSA" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "RSA is not supported by this OpenSSL build", 2
+            if disabled("rsa");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-new", "-out", "testreq.pem", "-utf8",
+            "-key", srctop_file("test", "testrsa.pem")])),
+           "Generating request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-verify", "-in", "testreq.pem", "-noout"])),
+           "Verifying signature on request");
+        }
+};
+
+subtest "generating certificate requests with DSA" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "This test is failing and disabled", 2
+            if 1;
+#       skip "DSA is not supported by this OpenSSL build", 2
+#           if disabled("dsa");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-new", "-out", "testreq.pem", "-utf8",
+            "-key", srctop_file("test", "testdsa.pem")])),
+           "Generating request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-verify", "-in", "testreq.pem", "-noout"])),
+           "Verifying signature on request");
+        }
+};
+
+subtest "generating certificate requests with DSA" => sub {
+    plan tests => 2;
+
+    SKIP: {
+        skip "ECDSA is not supported by this OpenSSL build", 2
+            if disabled("ec");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-new", "-out", "testreq.pem", "-utf8",
+            "-key", srctop_file("test", "testec-p256.pem")])),
+           "Generating request");
+
+        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
+            "-verify", "-in", "testreq.pem", "-noout"])),
+           "Verifying signature on request");
+        }
+};
 
 subtest "generating certificate requests" => sub {
     plan tests => 2;

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -82,7 +82,7 @@ subtest "generating certificate requests with DSA" => sub {
         }
 };
 
-subtest "generating certificate requests with DSA" => sub {
+subtest "generating certificate requests with ECDSA" => sub {
     plan tests => 2;
 
     SKIP: {

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -53,15 +53,17 @@ subtest "generating certificate requests with RSA" => sub {
         skip "RSA is not supported by this OpenSSL build", 2
             if disabled("rsa");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-new", "-out", "testreq.pem", "-utf8",
-            "-key", srctop_file("test", "testrsa.pem")])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq.pem", "-utf8",
+                    "-key", srctop_file("test", "testrsa.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-verify", "-in", "testreq.pem", "-noout"])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout"])),
            "Verifying signature on request");
-        }
+    }
 };
 
 subtest "generating certificate requests with DSA" => sub {
@@ -71,15 +73,17 @@ subtest "generating certificate requests with DSA" => sub {
         skip "DSA is not supported by this OpenSSL build", 2
             if disabled("dsa");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-new", "-out", "testreq.pem", "-utf8",
-            "-key", srctop_file("test", "testdsa.pem")])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq.pem", "-utf8",
+                    "-key", srctop_file("test", "testdsa.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-verify", "-in", "testreq.pem", "-noout"])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout"])),
            "Verifying signature on request");
-        }
+    }
 };
 
 subtest "generating certificate requests with ECDSA" => sub {
@@ -89,35 +93,37 @@ subtest "generating certificate requests with ECDSA" => sub {
         skip "ECDSA is not supported by this OpenSSL build", 2
             if disabled("ec");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-new", "-out", "testreq.pem", "-utf8",
-            "-key", srctop_file("test", "testec-p256.pem")])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-new", "-out", "testreq.pem", "-utf8",
+                    "-key", srctop_file("test", "testec-p256.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-            "-verify", "-in", "testreq.pem", "-noout"])),
+        ok(run(app(["openssl", "req",
+                    "-config", srctop_file("test", "test.cnf"),
+                    "-verify", "-in", "testreq.pem", "-noout"])),
            "Verifying signature on request");
-        }
+    }
 };
 
 subtest "generating certificate requests" => sub {
     plan tests => 2;
 
     ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-		@req_new, "-out", "testreq.pem"])),
+                @req_new, "-out", "testreq.pem"])),
        "Generating request");
 
     ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
-		"-verify", "-in", "testreq.pem", "-noout"])),
+                "-verify", "-in", "testreq.pem", "-noout"])),
        "Verifying signature on request");
 };
 
 my @openssl_args = ("req", "-config", srctop_file("apps", "openssl.cnf"));
 
 run_conversion('req conversions',
-	       "testreq.pem");
+               "testreq.pem");
 run_conversion('req conversions -- testreq2',
-	       srctop_file("test", "testreq2.pem"));
+               srctop_file("test", "testreq2.pem"));
 
 unlink "testkey.pem", "testreq.pem";
 
@@ -126,20 +132,20 @@ sub run_conversion {
     my $reqfile = shift;
 
     subtest $title => sub {
-	run(app(["openssl", @openssl_args,
-		 "-in", $reqfile, "-inform", "p",
-		 "-noout", "-text"],
-		stderr => "req-check.err", stdout => undef));
-	open DATA, "req-check.err";
+    run(app(["openssl", @openssl_args,
+             "-in", $reqfile, "-inform", "p",
+             "-noout", "-text"],
+            stderr => "req-check.err", stdout => undef));
+    open DATA, "req-check.err";
       SKIP: {
-	  plan skip_all => "skipping req conversion test for $reqfile"
-	      if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
+      plan skip_all => "skipping req conversion test for $reqfile"
+          if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
 
-	  tconversion("req", $reqfile, @openssl_args);
-	}
-	close DATA;
-	unlink "req-check.err";
+      tconversion("req", $reqfile, @openssl_args);
+    }
+    close DATA;
+    unlink "req-check.err";
 
-	done_testing();
+    done_testing();
     };
 }

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -132,20 +132,20 @@ sub run_conversion {
     my $reqfile = shift;
 
     subtest $title => sub {
-    run(app(["openssl", @openssl_args,
-             "-in", $reqfile, "-inform", "p",
-             "-noout", "-text"],
-            stderr => "req-check.err", stdout => undef));
-    open DATA, "req-check.err";
-      SKIP: {
-      plan skip_all => "skipping req conversion test for $reqfile"
-          if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
+        run(app(["openssl", @openssl_args,
+                 "-in", $reqfile, "-inform", "p",
+                 "-noout", "-text"],
+                stderr => "req-check.err", stdout => undef));
+        open DATA, "req-check.err";
+        SKIP: {
+            plan skip_all => "skipping req conversion test for $reqfile"
+                if grep /Unknown Public Key/, map { s/\R//; } <DATA>;
 
-      tconversion("req", $reqfile, @openssl_args);
-    }
-    close DATA;
-    unlink "req-check.err";
+            tconversion("req", $reqfile, @openssl_args);
+        }
+        close DATA;
+        unlink "req-check.err";
 
-    done_testing();
+        done_testing();
     };
 }

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -68,10 +68,8 @@ subtest "generating certificate requests with DSA" => sub {
     plan tests => 2;
 
     SKIP: {
-        skip "This test is failing and disabled", 2
-            if 1;
-#       skip "DSA is not supported by this OpenSSL build", 2
-#           if disabled("dsa");
+        skip "DSA is not supported by this OpenSSL build", 2
+            if disabled("dsa");
 
         ok(run(app(["openssl", "req", "-config", srctop_file("test", "test.cnf"),
             "-new", "-out", "testreq.pem", "-utf8",


### PR DESCRIPTION
This is a backport for 1.1.1 of #10312 

This only adds extra testing for `apps/req`: although the chances of breaking something related to this in 1.1.1 are way lower than in the development of 3.0, the original issue that triggered #10312 highlighted that while we have improved unit-testing of single API functions, we sometime lack testing of common usage patterns triggered by our own apps or by external users.

This slightly improves the situation as `req` is an extensive user of the X509 and EVP_DigestSign APIs.

That's why I beleive this is a good candidate for backporting to 1.1.1.

It's happening as a separate PR because the amount of changes (mostly due to formatting) that were manually needed to cherry-pick the original commits went over my personal comfort zone for "trivial changes".

## Editorial

I'd like to make this dependent on the successful merge of #10312 into `master`, so that while squashing the commits of this PR I can properly include in the commit message a reference to the commit originating the cherry-pick.

##### Checklist

- [x] tests are added or updated
