### PR TITLE
Support ciphersuites using a SHA2 384 digest in FreeBSD KTLS.

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -410,6 +410,9 @@ int tls1_change_cipher_state(SSL *s, int which)
         case SSL_SHA256:
             crypto_info.auth_algorithm = CRYPTO_SHA2_256_HMAC;
             break;
+        case SSL_SHA384:
+            crypto_info.auth_algorithm = CRYPTO_SHA2_384_HMAC;
+            break;
         default:
             goto skip_ktls;
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
