### PR TITLE
Rename providers/common/provlib.c to nid_to_name.c

### DIFF
--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=digests ciphers
 
-SOURCE[../libcommon.a]=provider_err.c provlib.c
+SOURCE[../libcommon.a]=provider_err.c
 $FIPSCOMMON=provider_util.c
-SOURCE[../libnonfips.a]=$FIPSCOMMON
+SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
 SOURCE[../libfips.a]=$FIPSCOMMON

--- a/providers/common/nid_to_name.c
+++ b/providers/common/nid_to_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
It contains only one function, which should only get added to non-FIPS
providers.
