### PR TITLE
CORE & PROV: Add a generic callback structure and upcall

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -13,6 +13,7 @@
 #include <openssl/params.h>
 #include <openssl/opensslv.h>
 #include "crypto/cryptlib.h"
+#include "internal/core.h"
 #include "internal/nelem.h"
 #include "internal/thread_once.h"
 #include "internal/provider.h"
@@ -772,6 +773,7 @@ static OSSL_core_new_error_fn core_new_error;
 static OSSL_core_set_error_debug_fn core_set_error_debug;
 static OSSL_core_vset_error_fn core_vset_error;
 #endif
+static OSSL_core_generic_callback_fn core_generic_callback;
 
 static const OSSL_PARAM *core_gettable_params(const OSSL_PROVIDER *prov)
 {
@@ -856,6 +858,11 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
 }
 #endif
 
+static int core_generic_callback(OSSL_CALLBACK *cb, const OSSL_PARAM params[])
+{
+    return cb->callback(params, cb->arg);
+}
+
 /*
  * Functions provided by the core.  Blank line separates "families" of related
  * functions.
@@ -889,6 +896,8 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CRYPTO_SECURE_ALLOCATED,
         (void (*)(void))CRYPTO_secure_allocated },
     { OSSL_FUNC_OPENSSL_CLEANSE, (void (*)(void))OPENSSL_cleanse },
+
+    { OSSL_FUNC_CORE_GENERIC_CALLBACK, (void (*)(void))core_generic_callback },
 
     { 0, NULL }
 };

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -55,4 +55,10 @@ void ossl_algorithm_do_all(OPENSSL_CTX *libctx, int operation_id,
                                       int no_store, void *data),
                            void *data);
 
+/* Typedef in openssl/core.h */
+struct ossl_callback_st {
+    int (*callback)(const OSSL_PARAM params[], void *arg);
+    void *arg;
+};
+
 #endif

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -187,6 +187,18 @@ extern OSSL_provider_init_fn OSSL_provider_init;
 #  pragma names restore
 # endif
 
+/*-
+ * Generic callback
+ * ----------------
+ *
+ * The application may want to initiate an operation that takes a callback
+ * function, to be called by the provider.  This opaque type helps transfer
+ * the necessary data to the provider functions, and should simply be passed
+ * back to the upcall identified with OSSL_FUNC_CORE_GENERIC_CALLBACK.
+ */
+
+typedef struct ossl_callback_st OSSL_CALLBACK;
+
 # ifdef __cplusplus
 }
 # endif

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -132,6 +132,11 @@ OSSL_CORE_MAKE_FUNC(int, BIO_read_ex, (BIO *bio, void *data, size_t data_len,
                                        size_t *bytes_read))
 OSSL_CORE_MAKE_FUNC(int, BIO_free, (BIO *bio))
 
+/* Callbacks for providers */
+#define OSSL_FUNC_CORE_GENERIC_CALLBACK       100
+OSSL_CORE_MAKE_FUNC(int, core_generic_callback,
+                    (OSSL_CALLBACK *cb, const OSSL_PARAM []))
+
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN         1024
 OSSL_CORE_MAKE_FUNC(void,provider_teardown,(void *provctx))

--- a/providers/build.info
+++ b/providers/build.info
@@ -148,5 +148,5 @@ IF[{- !$disabled{legacy} -}]
   # Common things that are valid no matter what form the Legacy provider
   # takes.
   SOURCE[$LEGACYGOAL]=legacyprov.c
-  INCLUDE[$LEGACYGOAL]=../include implementations/include
+  INCLUDE[$LEGACYGOAL]=../include common/include implementations/include
 ENDIF

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=digests ciphers
 
-SOURCE[../libcommon.a]=provider_err.c
+SOURCE[../libcommon.a]=provider_err.c callback_prov.c
 $FIPSCOMMON=provider_util.c
 SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
 SOURCE[../libfips.a]=$FIPSCOMMON

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=digests ciphers
 
-SOURCE[../libcommon.a]=provider_err.c provlib.c
+SOURCE[../libcommon.a]=provider_err.c
 $FIPSCOMMON=provider_util.c
-SOURCE[../libnonfips.a]=$FIPSCOMMON
+SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
 SOURCE[../libfips.a]=$FIPSCOMMON

--- a/providers/common/callback_prov.c
+++ b/providers/common/callback_prov.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core.h>
+#include <openssl/core_numbers.h>
+#include "prov/callback.h"
+
+static OSSL_core_generic_callback_fn *c_generic_callback = NULL;
+
+int ossl_prov_callback_from_dispatch(const OSSL_DISPATCH *fns)
+{
+    for (; fns->function_id != 0; fns++) {
+        switch (fns->function_id) {
+        case OSSL_FUNC_CORE_GENERIC_CALLBACK:
+            c_generic_callback = OSSL_get_core_generic_callback(fns);
+            break;
+        }
+    }
+
+    return 1;
+}
+
+int ossl_prov_generic_callback(OSSL_CALLBACK *cb, const OSSL_PARAM *params)
+{
+    if (c_generic_callback == NULL)
+        return 0;
+    return c_generic_callback(cb, params);
+}

--- a/providers/common/include/prov/callback.h
+++ b/providers/common/include/prov/callback.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core.h>
+
+int ossl_prov_callback_from_dispatch(const OSSL_DISPATCH *fns);
+
+int ossl_prov_generic_callback(OSSL_CALLBACK *cb, const OSSL_PARAM *params);

--- a/providers/common/nid_to_name.c
+++ b/providers/common/nid_to_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -14,6 +14,7 @@
 #include <openssl/core_numbers.h>
 #include <openssl/core_names.h>
 #include <openssl/params.h>
+#include "prov/callback.h"
 #include "prov/implementations.h"
 
 /* Functions provided by the core */
@@ -415,6 +416,8 @@ int ossl_default_provider_init(const OSSL_PROVIDER *provider,
 {
     OSSL_core_get_library_context_fn *c_get_libctx = NULL;
 
+    if (!ossl_prov_callback_from_dispatch(in))
+        return 0;
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_PARAMS:

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -29,6 +29,7 @@
 #include "prov/implementations.h"
 #include "prov/provider_ctx.h"
 #include "prov/providercommon.h"
+#include "prov/callback.h"
 #include "selftest.h"
 
 extern OSSL_core_thread_start_fn *c_thread_start;
@@ -462,6 +463,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
     FIPS_GLOBAL *fgbl;
     OPENSSL_CTX *ctx;
 
+    if (!ossl_prov_callback_from_dispatch(in))
+        return 0;
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_PARAMS:

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -14,6 +14,7 @@
 #include <openssl/core_names.h>
 #include <openssl/params.h>
 #include "prov/implementations.h"
+#include "prov/callback.h"
 
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
@@ -105,6 +106,8 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
 {
     OSSL_core_get_library_context_fn *c_get_libctx = NULL;
 
+    if (!ossl_prov_callback_from_dispatch(in))
+        return 0;
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_PARAMS:


### PR DESCRIPTION
The idea is that libcrypto code will be able to build up the structure
it needs for any callback, pass that to the provider where the provider
will accept it, and the provider passes that back along with an
OSSL_PARAM array with data from the provider to the core_generic_callback
upcall, which knows how to handle the passed structure.

The structure is very simple, and includes a function pointer to a
libcrypto callback, as well as a pointer to some libcrypto data.  That
libcrypto callback needs to know what to do with that data to call the
application callback with the arguments it requires.

This method permits the provider to call application callbacks without
having any information of what signature they have, and caters to those
who may want to build a provider module into a secure environment where
all the calls simply can't be any random function call, but rather must
be in form of up- or downcalls in the libcrypto<->provider interface.

On the provider side, support is added, and is fairly minimal