### PR TITLE
[Pending on #10390] CORE & PROV: make export of key data leaner through callback

### DIFF
--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -593,7 +593,7 @@ void *evp_keymgmt_gendomparams(const EVP_KEYMGMT *keymgmt,
 void evp_keymgmt_freedomparams(const EVP_KEYMGMT *keymgmt,
                                void *provdomparams);
 int evp_keymgmt_exportdomparams(const EVP_KEYMGMT *keymgmt,
-                                void *provdomparams, OSSL_PARAM params[]);
+                                void *provdomparams, OSSL_CALLBACK *param_cb);
 const OSSL_PARAM *
 evp_keymgmt_importdomparam_types(const EVP_KEYMGMT *keymgmt);
 const OSSL_PARAM *
@@ -607,7 +607,7 @@ void *evp_keymgmt_loadkey(const EVP_KEYMGMT *keymgmt,
                           void *id, size_t idlen);
 void evp_keymgmt_freekey(const EVP_KEYMGMT *keymgmt, void *provkey);
 int evp_keymgmt_exportkey(const EVP_KEYMGMT *keymgmt,
-                               void *provkey, OSSL_PARAM params[]);
+                          void *provkey, OSSL_CALLBACK *param_cb);
 const OSSL_PARAM *evp_keymgmt_importkey_types(const EVP_KEYMGMT *keymgmt);
 const OSSL_PARAM *evp_keymgmt_exportkey_types(const EVP_KEYMGMT *keymgmt);
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -346,7 +346,7 @@ OSSL_CORE_MAKE_FUNC(void, OP_keymgmt_freedomparams, (void *domparams))
 /* Key domain parameter export */
 # define OSSL_FUNC_KEYMGMT_EXPORTDOMPARAMS          4
 OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_exportdomparams,
-                    (void *domparams, OSSL_PARAM params[]))
+                    (void *domparams, OSSL_CALLBACK *param_callback))
 
 /* Key domain parameter discovery */
 # define OSSL_FUNC_KEYMGMT_IMPORTDOMPARAM_TYPES     5
@@ -373,7 +373,7 @@ OSSL_CORE_MAKE_FUNC(void, OP_keymgmt_freekey, (void *key))
 /* Key export */
 # define OSSL_FUNC_KEYMGMT_EXPORTKEY               14
 OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_exportkey,
-                    (void *key, OSSL_PARAM params[]))
+                    (void *key, OSSL_CALLBACK *param_callback))
 
 /* Key discovery */
 # define OSSL_FUNC_KEYMGMT_IMPORTKEY_TYPES         15


### PR DESCRIPTION
Exporting data from a provider owned domainparams or key is quite an
ordeal, with having to figure out what parameter keys an
implementation supports, call the export function a first time to find
out how large each parameter buffer must be, allocate the necessary
space for it, and call the export function again.

So how about letting the export function build up the key data params
and call back with that?  This change implements exactly such a
mechanism.
