### PR TITLE
SSL: Document SSL_add_{file,dir,store}_cert_subjects_to_stack()

### DIFF
--- a/doc/man3/SSL_load_client_CA_file.pod
+++ b/doc/man3/SSL_load_client_CA_file.pod
@@ -2,7 +2,11 @@
 
 =head1 NAME
 
-SSL_load_client_CA_file - load certificate names from file
+SSL_load_client_CA_file,
+SSL_add_file_cert_subjects_to_stack,
+SSL_add_dir_cert_subjects_to_stack,
+SSL_add_store_cert_subjects_to_stack
+- load certificate names
 
 =head1 SYNOPSIS
 
@@ -10,10 +14,28 @@ SSL_load_client_CA_file - load certificate names from file
 
  STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file);
 
+ int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
+                                         const char *file)
+ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
+                                        const char *dir)
+ int SSL_add_store_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
+                                          const char *store)
+
 =head1 DESCRIPTION
 
-SSL_load_client_CA_file() reads certificates from B<file> and returns
+SSL_load_client_CA_file() reads certificates from I<file> and returns
 a STACK_OF(X509_NAME) with the subject names found.
+
+SSL_add_file_cert_subjects_to_stack() reads certificates from I<file>,
+and adds their subject name to the already existing I<stack>.
+
+SSL_add_dir_cert_subjects_to_stack() reads certificates from every
+file in the directory I<dir>, and adds their subject name to the
+already existing I<stack>.
+
+SSL_add_store_cert_subjects_to_stack() loads certificates from the
+I<store> URI, and adds their subject name to the already existing
+I<stack>.
 
 =head1 NOTES
 
@@ -57,11 +79,16 @@ Load names of CAs from file and use it as a client CA list:
 =head1 SEE ALSO
 
 L<ssl(7)>,
+L<ossl_store(7)>,
 L<SSL_CTX_set_client_CA_list(3)>
+
+=head1 HISTORY
+
+SSL_add_store_cert_subjects_to_stack() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -602,14 +602,6 @@ static unsigned long xname_hash(const X509_NAME *a)
     return X509_NAME_hash((X509_NAME *)a);
 }
 
-/**
- * Load CA certs from a file into a ::STACK. Note that it is somewhat misnamed;
- * it doesn't really have anything to do with clients (except that a common use
- * for a stack of CAs is to send it to the client). Actually, it doesn't have
- * much to do with CAs, either, since it will load any old cert.
- * \param file the file containing one or more certs.
- * \return a ::STACK containing the certs.
- */
 STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file)
 {
     BIO *in = BIO_new(BIO_s_file());
@@ -667,15 +659,6 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file)
     return ret;
 }
 
-/**
- * Add a file of certs to a stack.
- * \param stack the stack to add to.
- * \param file the file to add from. All certs in this file that are not
- * already in the stack will be added.
- * \return 1 for success, 0 for failure. Note that in the case of failure some
- * certs may have been added to \c stack.
- */
-
 int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
                                         const char *file)
 {
@@ -726,17 +709,6 @@ int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     return ret;
 }
 
-/**
- * Add a directory of certs to a stack.
- * \param stack the stack to append to.
- * \param dir the directory to append from. All files in this directory will be
- * examined as potential certs. Any that are acceptable to
- * SSL_add_dir_cert_subjects_to_stack() that are not already in the stack will be
- * included.
- * \return 1 for success, 0 for failure. Note that in the case of failure some
- * certs may have been added to \c stack.
- */
-
 int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
                                        const char *dir)
 {
@@ -783,15 +755,6 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     return ret;
 }
 
-/**
- * Add a container of certs to a stack.
- * \param stack the stack to add to.
- * \param file the file to add from. All certs in this file that are not
- * already in the stack will be added.
- * \return 1 for success, 0 for failure. Note that in the case of failure some
- * certs may have been added to \c stack.
- */
-
 static int add_uris_recursive(STACK_OF(X509_NAME) *stack,
                               const char *uri, int depth)
 {
@@ -815,8 +778,9 @@ static int add_uris_recursive(STACK_OF(X509_NAME) *stack,
              * This is an entry in the "directory" represented by the current
              * uri.  if |depth| allows, dive into it.
              */
-            if (depth == 0)
-                ok = add_uris_recursive(stack, uri, depth - 1);
+            if (depth > 0)
+                ok = add_uris_recursive(stack, OSSL_STORE_INFO_get0_NAME(info),
+                                        depth - 1);
         } else if (infotype == OSSL_STORE_INFO_CERT) {
             if ((x = OSSL_STORE_INFO_get0_CERT(info)) == NULL
                 || (xn = X509_get_subject_name(x)) == NULL

--- a/util/missingssl.txt
+++ b/util/missingssl.txt
@@ -17,9 +17,6 @@ SSL_CTX_set_purpose
 SSL_CTX_set_trust
 SSL_SRP_CTX_free
 SSL_SRP_CTX_init
-SSL_add_dir_cert_subjects_to_stack
-SSL_add_file_cert_subjects_to_stack
-SSL_add_store_cert_subjects_to_stack
 SSL_add_ssl_module
 SSL_certs_clear
 SSL_copy_session_id

--- a/util/missingssl111.txt
+++ b/util/missingssl111.txt
@@ -28,8 +28,6 @@ SSL_CTX_set_srp_verify_param_callback
 SSL_CTX_set_trust
 SSL_SRP_CTX_free
 SSL_SRP_CTX_init
-SSL_add_dir_cert_subjects_to_stack
-SSL_add_file_cert_subjects_to_stack
 SSL_add_ssl_module
 SSL_certs_clear
 SSL_copy_session_id


### PR DESCRIPTION
This also removes the incorrect documentation comments by those
functions, and fixes a bug in SSL_add_store_cert_subjects_to_stack().
