### PR TITLE
chacha_enc.c: fix for EBCDIC platforms

### DIFF
--- a/crypto/chacha/chacha_enc.c
+++ b/crypto/chacha/chacha_enc.c
@@ -12,7 +12,7 @@
 #include <string.h>
 
 #include "crypto/chacha.h"
-#include <ctype.h>
+#include "crypto/ctype.h"
 
 typedef unsigned int u32;
 typedef unsigned char u8;

--- a/crypto/chacha/chacha_enc.c
+++ b/crypto/chacha/chacha_enc.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "crypto/chacha.h"
+#include <ctype.h>
 
 typedef unsigned int u32;
 typedef unsigned char u8;
@@ -78,10 +79,18 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
     size_t todo, i;
 
     /* sigma constant "expand 32-byte k" in little-endian encoding */
-    input[0] = ((u32)'e') | ((u32)'x'<<8) | ((u32)'p'<<16) | ((u32)'a'<<24);
-    input[1] = ((u32)'n') | ((u32)'d'<<8) | ((u32)' '<<16) | ((u32)'3'<<24);
-    input[2] = ((u32)'2') | ((u32)'-'<<8) | ((u32)'b'<<16) | ((u32)'y'<<24);
-    input[3] = ((u32)'t') | ((u32)'e'<<8) | ((u32)' '<<16) | ((u32)'k'<<24);
+    input[0] = ((u32)ossl_toascii('e')) | ((u32)ossl_toascii('x') << 8)
+               | ((u32)ossl_toascii('p') << 16)
+               | ((u32)ossl_toascii('a') << 24);
+    input[1] = ((u32)ossl_toascii('n')) | ((u32)ossl_toascii('d') << 8)
+               | ((u32)ossl_toascii(' ') << 16)
+               | ((u32)ossl_toascii('3') << 24);
+    input[2] = ((u32)ossl_toascii('2')) | ((u32)ossl_toascii('-') << 8)
+               | ((u32)ossl_toascii('b') << 16)
+               | ((u32)ossl_toascii('y') << 24);
+    input[3] = ((u32)ossl_toascii('t')) | ((u32)ossl_toascii('e') << 8)
+               | ((u32)ossl_toascii(' ') << 16)
+               | ((u32)ossl_toascii('k') << 24);
 
     input[4] = key[0];
     input[5] = key[1];


### PR DESCRIPTION
Enforce the sigma constant "expand 32-byte k" to be always in ASCII to fix EBCDIC builds.

Signed-off-by: Joerg Schmidbauer <jschmidb@de.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
