### PR TITLE
Fix the issue that aes-xxx-siv algorithms failed in OpenSSL speed test

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -49,9 +49,6 @@ static int siv_init(void *vctx, const unsigned char *key, size_t keylen,
 
     ctx->enc = enc;
 
-    if (iv != NULL)
-        return 0;
-
     if (key != NULL) {
         if (keylen != ctx->keylen) {
             ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);


### PR DESCRIPTION
Speed test, aes-siv related cases fail on both x86 and arm.
The return value of siv_init() causes this problem.
Verify it locally, the result is pass.

Fixes #10416

Change-Id: If1a18599f3d0f56f22a1ce4f8f114b8db0f68cca

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
