### PR TITLE
Fix no-blake2

### DIFF
--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -17,7 +17,7 @@ SOURCE[../../libcrypto]=$COMMON\
         e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha256.c e_rc4_hmac_md5.c \
         e_chacha20_poly1305.c \
         pkey_mac.c exchange.c \
-        legacy_sha.c legacy_md5_sha1.c legacy_blake2.c
+        legacy_sha.c legacy_md5_sha1.c
 
 IF[{- !$disabled{md2} -}]
   SOURCE[../../libcrypto]=legacy_md2.c
@@ -31,6 +31,10 @@ ENDIF
 IF[{- !$disabled{mdc2} -}]
   SOURCE[../../libcrypto]=legacy_mdc2.c
 ENDIF
+IF[{- !$disabled{blake2} -}]
+  SOURCE[../../libcrypto]=legacy_blake2.c
+ENDIF
+
 
 SOURCE[../../providers/libfips.a]=$COMMON
 

--- a/crypto/evp/legacy_blake2.c
+++ b/crypto/evp/legacy_blake2.c
@@ -9,7 +9,9 @@
 
 #include <openssl/opensslconf.h>
 
-#ifndef OPENSSL_NO_BLAKE2
+#ifdef OPENSSL_NO_BLAKE2
+NON_EMPTY_TRANSLATION_UNIT
+#else
 
 # include <openssl/obj_mac.h>
 # include "crypto/evp.h"

--- a/crypto/evp/legacy_blake2.c
+++ b/crypto/evp/legacy_blake2.c
@@ -9,9 +9,7 @@
 
 #include <openssl/opensslconf.h>
 
-#ifdef OPENSSL_NO_BLAKE2
-NON_EMPTY_TRANSLATION_UNIT
-#else
+#ifndef OPENSSL_NO_BLAKE2
 
 # include <openssl/obj_mac.h>
 # include "crypto/evp.h"


### PR DESCRIPTION
If blake2 has been disabled then the legacy_blake2.c has no content,
which was causing a compilation failure. Therefore we add the macro
NON_EMPTY_TRANSLATION_UNIT.
