### PR TITLE
A few fixes in the EVP_KDF-KB and EVP_KDF-KRB5KDF manpages

### DIFF
--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -86,9 +86,9 @@ Label "label", and Context "context".
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                           "secret", strlen("secret"))
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
-                                          "context", strlen("context"));
- *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "label", strlen("label"));
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                                          "context", strlen("context"));
  *p = OSSL_PARAM_construct_end();
  if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
      error("EVP_KDF_CTX_set_params");
@@ -116,9 +116,9 @@ Label "label", and IV "sixteen bytes iv".
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                           "secret", strlen("secret"));
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
-                                          "context", strlen("context"));
- *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "label", strlen("label"));
+ *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                                          "context", strlen("context"));
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
                                           iv, strlen(iv));
  *p = OSSL_PARAM_construct_end();

--- a/doc/man7/EVP_KDF-KRB5KDF.pod
+++ b/doc/man7/EVP_KDF-KRB5KDF.pod
@@ -24,7 +24,7 @@ The supported parameters are:
 
 =over 4
 
-=item "properies" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
+=item "properties" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
 
 =item "cipher" (B<OSSL_KDF_PARAM_CIPHER>) <UTF8 string>
 
@@ -84,9 +84,10 @@ This example derives a key using the AES-128-CBC cipher:
  if (EVP_KDF_set_params(kctx, params) <= 0)
      /* Error */
 
- if (EVP_KDF_derive(kctx, out, &outlen) <= 0)
+ if (EVP_KDF_derive(kctx, out, outlen) <= 0)
      /* Error */
 
+ EVP_KDF_CTX_free(kctx);
 
 =head1 CONFORMING TO
 


### PR DESCRIPTION
The context and label is info and salt respectively - fix
the example in KB manpage for that.

There are some typos and bug in EVP_KDF_derive call in the
KRB5KDF example.

##### Checklist
- [x] documentation is added or updated
