### PR TITLE
Fix an uninitialised read in conf_def.c

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -107,7 +107,7 @@ static CONF *def_create(CONF_METHOD *meth)
 {
     CONF *ret;
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = OPENSSL_malloc(sizeof(*ret));
     if (ret != NULL)
         if (meth->init(ret) == 0) {
             OPENSSL_free(ret);
@@ -121,6 +121,7 @@ static int def_init_default(CONF *conf)
     if (conf == NULL)
         return 0;
 
+    memset(conf, 0, sizeof(*conf));
     conf->meth = &default_method;
     conf->meth_data = (void *)CONF_type_default;
 
@@ -133,6 +134,7 @@ static int def_init_WIN32(CONF *conf)
     if (conf == NULL)
         return 0;
 
+    memset(conf, 0, sizeof(*conf));
     conf->meth = &WIN32_method;
     conf->meth_data = (void *)CONF_type_win32;
 

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -107,7 +107,7 @@ static CONF *def_create(CONF_METHOD *meth)
 {
     CONF *ret;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = OPENSSL_zalloc(sizeof(*ret));
     if (ret != NULL)
         if (meth->init(ret) == 0) {
             OPENSSL_free(ret);
@@ -123,7 +123,6 @@ static int def_init_default(CONF *conf)
 
     conf->meth = &default_method;
     conf->meth_data = (void *)CONF_type_default;
-    conf->data = NULL;
 
     return 1;
 }
@@ -136,7 +135,6 @@ static int def_init_WIN32(CONF *conf)
 
     conf->meth = &WIN32_method;
     conf->meth_data = (void *)CONF_type_win32;
-    conf->data = NULL;
 
     return 1;
 }


### PR DESCRIPTION
PR #8882 added a new field to the CONF structure. Unfortunately this
structure was created using OPENSSL_malloc() instead of OPENSSL_zalloc() and
therefore the new field was not created in an initialised state. Therefore
when we came to read it for the first time we got an uninitialised read.
