### PR TITLE
Add confdump to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ doc/man1/openssl-x509.pod
 /test/versions
 /test/ossl_shim/ossl_shim
 /test/rsa_complex
+/test/confdump
 # Other generated files in test/
 /test/provider_internal_test.conf
 /test/fipsinstall.conf


### PR DESCRIPTION
We added a new executable to the test directory which didn't match the
existing gitignore rules, so we add it explicitly.