### PR TITLE
Add OSSL_RET_UNSUPPORTED

### DIFF
--- a/crypto/aes/aes_core.c
+++ b/crypto/aes/aes_core.c
@@ -640,7 +640,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
     if (!userKey || !key)
         return -1;
     if (bits != 128 && bits != 192 && bits != 256)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     rk = key->rd_key;
 
@@ -1218,7 +1218,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
     if (!userKey || !key)
         return -1;
     if (bits != 128 && bits != 192 && bits != 256)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     rk = key->rd_key;
 

--- a/crypto/aes/aes_x86core.c
+++ b/crypto/aes/aes_x86core.c
@@ -482,7 +482,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
     if (!userKey || !key)
         return -1;
     if (bits != 128 && bits != 192 && bits != 256)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     rk = key->rd_key;
 

--- a/crypto/aria/aria.c
+++ b/crypto/aria/aria.c
@@ -19,6 +19,7 @@
  */
 
 #include <openssl/e_os2.h>
+#include <openssl/crypto.h>
 #include "crypto/aria.h"
 
 #include <assert.h>
@@ -549,7 +550,7 @@ int aria_set_encrypt_key(const unsigned char *userKey, const int bits,
         return -1;
     }
     if (bits != 128 && bits != 192 && bits != 256) {
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     rk = key->rd_key;
@@ -1130,7 +1131,7 @@ int aria_set_encrypt_key(const unsigned char *userKey, const int bits,
     memcpy(w0.c, userKey, sizeof(w0));
     switch (bits) {
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     case 128:
         key->rounds = 12;
         ck1 = &c1;

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -513,6 +513,7 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
     return 0;
 }
 
+/* Because -1 is a valid return value, this function returns -2 as error */
 int ASN1_TIME_cmp_time_t(const ASN1_TIME *s, time_t t)
 {
     struct tm stm, ttm;
@@ -544,6 +545,7 @@ int ASN1_TIME_normalize(ASN1_TIME *t)
     return asn1_time_from_tm(t, &tm, V_ASN1_UNDEF) != NULL;
 }
 
+/* Because -1 is a valid return value, this function returns -2 as error */
 int ASN1_TIME_compare(const ASN1_TIME *a, const ASN1_TIME *b)
 {
     int day, sec;

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -69,6 +69,7 @@ ASN1_UTCTIME *ASN1_UTCTIME_adj(ASN1_UTCTIME *s, time_t t,
     return asn1_time_from_tm(s, ts, V_ASN1_UTCTIME);
 }
 
+/* Because -1 is a valid return value, this function returns -2 as error */
 int ASN1_UTCTIME_cmp_time_t(const ASN1_UTCTIME *s, time_t t)
 {
     struct tm stm, ttm;

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -171,7 +171,7 @@ static int asn1_write_micalg(BIO *out, STACK_OF(X509_ALGOR) *mdalgs)
                 OPENSSL_free(micstr);
                 continue;
             }
-            if (rv != -2)
+            if (rv != OSSL_RET_UNSUPPORTED)
                 goto err;
         }
         switch (md_nid) {

--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -239,7 +239,7 @@ int BIO_accept(int sock, char **ip_port)
     ret = BIO_accept_ex(sock, &res, 0);
     if (ret == (int)INVALID_SOCKET) {
         if (BIO_sock_should_retry(ret)) {
-            ret = -2;
+            ret = OSSL_RET_UNSUPPORTED;
             goto end;
         }
         ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -254,7 +254,7 @@ static int bio_read_intern(BIO *b, void *data, size_t dlen, size_t *readbytes)
 
     if ((b == NULL) || (b->method == NULL) || (b->method->bread == NULL)) {
         BIOerr(BIO_F_BIO_READ_INTERN, BIO_R_UNSUPPORTED_METHOD);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if ((b->callback != NULL || b->callback_ex != NULL) &&
@@ -327,7 +327,7 @@ static int bio_write_intern(BIO *b, const void *data, size_t dlen,
 
     if ((b->method == NULL) || (b->method->bwrite == NULL)) {
         BIOerr(BIO_F_BIO_WRITE_INTERN, BIO_R_UNSUPPORTED_METHOD);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if ((b->callback != NULL || b->callback_ex != NULL) &&
@@ -391,7 +391,7 @@ int BIO_puts(BIO *b, const char *buf)
 
     if ((b == NULL) || (b->method == NULL) || (b->method->bputs == NULL)) {
         BIOerr(BIO_F_BIO_PUTS, BIO_R_UNSUPPORTED_METHOD);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (b->callback != NULL || b->callback_ex != NULL) {
@@ -436,7 +436,7 @@ int BIO_gets(BIO *b, char *buf, int size)
 
     if ((b == NULL) || (b->method == NULL) || (b->method->bgets == NULL)) {
         BIOerr(BIO_F_BIO_GETS, BIO_R_UNSUPPORTED_METHOD);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (size < 0) {
@@ -516,7 +516,7 @@ long BIO_ctrl(BIO *b, int cmd, long larg, void *parg)
 
     if ((b->method == NULL) || (b->method->ctrl == NULL)) {
         BIOerr(BIO_F_BIO_CTRL, BIO_R_UNSUPPORTED_METHOD);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (b->callback != NULL || b->callback_ex != NULL) {
@@ -544,7 +544,7 @@ long BIO_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
     if ((b->method == NULL) || (b->method->callback_ctrl == NULL)
             || (cmd != BIO_CTRL_SET_CALLBACK)) {
         BIOerr(BIO_F_BIO_CALLBACK_CTRL, BIO_R_UNSUPPORTED_METHOD);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (b->callback != NULL || b->callback_ex != NULL) {

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -264,7 +264,7 @@ static int bio_read_intern(BIO *b, void *data, size_t dlen, size_t *readbytes)
 
     if (!b->init) {
         BIOerr(BIO_F_BIO_READ_INTERN, BIO_R_UNINITIALIZED);
-        return -2;
+        return -2;               /* shouldn't this be -1? */
     }
 
     ret = b->method->bread(b, data, dlen, readbytes);
@@ -337,7 +337,7 @@ static int bio_write_intern(BIO *b, const void *data, size_t dlen,
 
     if (!b->init) {
         BIOerr(BIO_F_BIO_WRITE_INTERN, BIO_R_UNINITIALIZED);
-        return -2;
+        return -2;               /* shouldn't this be -1? */
     }
 
     ret = b->method->bwrite(b, data, dlen, written);
@@ -402,7 +402,7 @@ int BIO_puts(BIO *b, const char *buf)
 
     if (!b->init) {
         BIOerr(BIO_F_BIO_PUTS, BIO_R_UNINITIALIZED);
-        return -2;
+        return -2;               /* shouldn't this be -1? */
     }
 
     ret = b->method->bputs(b, buf);
@@ -452,7 +452,7 @@ int BIO_gets(BIO *b, char *buf, int size)
 
     if (!b->init) {
         BIOerr(BIO_F_BIO_GETS, BIO_R_UNINITIALIZED);
-        return -2;
+        return -2;               /* shouldn't this be -1? */
     }
 
     ret = b->method->bgets(b, buf, size);

--- a/crypto/camellia/cmll_misc.c
+++ b/crypto/camellia/cmll_misc.c
@@ -9,6 +9,7 @@
 
 #include <openssl/opensslv.h>
 #include <openssl/camellia.h>
+#include <openssl/crypto.h>
 #include "cmll_local.h"
 
 int Camellia_set_key(const unsigned char *userKey, const int bits,
@@ -17,7 +18,7 @@ int Camellia_set_key(const unsigned char *userKey, const int bits,
     if (!userKey || !key)
         return -1;
     if (bits != 128 && bits != 192 && bits != 256)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     key->grand_rounds = Camellia_Ekeygen(bits, userKey, key->u.rd_key);
     return 0;
 }

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -67,7 +67,7 @@ int cms_env_asn1_ctrl(CMS_RecipientInfo *ri, int cmd)
     if (pkey->ameth == NULL || pkey->ameth->pkey_ctrl == NULL)
         return 1;
     i = pkey->ameth->pkey_ctrl(pkey, ASN1_PKEY_CTRL_CMS_ENVELOPE, cmd, ri);
-    if (i == -2) {
+    if (i == OSSL_RET_UNSUPPORTED) {
         CMSerr(CMS_F_CMS_ENV_ASN1_CTRL,
                CMS_R_NOT_SUPPORTED_FOR_THIS_KEY_TYPE);
         return 0;

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -267,6 +267,7 @@ int CMS_RecipientInfo_ktri_get0_signer_id(CMS_RecipientInfo *ri,
     return cms_SignerIdentifier_get0_signer_id(ktri->rid, keyid, issuer, sno);
 }
 
+/* -1 is a valid return value, so we use -2 for error here */
 int CMS_RecipientInfo_ktri_cert_cmp(CMS_RecipientInfo *ri, X509 *cert)
 {
     if (ri->type != CMS_RECIPINFO_TRANS) {
@@ -440,6 +441,7 @@ static int cms_RecipientInfo_ktri_decrypt(CMS_ContentInfo *cms,
 
 /* Key Encrypted Key (KEK) RecipientInfo routines */
 
+/* -1 is a valid return value, so we use -2 for error here */
 int CMS_RecipientInfo_kekri_id_cmp(CMS_RecipientInfo *ri,
                                    const unsigned char *id, size_t idlen)
 {

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -90,6 +90,7 @@ int CMS_RecipientInfo_kari_get0_orig_id(CMS_RecipientInfo *ri,
     return 1;
 }
 
+/* -1 is a valid return value, so we use -2 for error here */
 int CMS_RecipientInfo_kari_orig_id_cmp(CMS_RecipientInfo *ri, X509 *cert)
 {
     CMS_OriginatorIdentifierOrKey *oik;

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -230,7 +230,7 @@ static int cms_sd_asn1_ctrl(CMS_SignerInfo *si, int cmd)
     if (pkey->ameth == NULL || pkey->ameth->pkey_ctrl == NULL)
         return 1;
     i = pkey->ameth->pkey_ctrl(pkey, ASN1_PKEY_CTRL_CMS_SIGN, cmd, si);
-    if (i == -2) {
+    if (i == OSSL_RET_UNSUPPORTED) {
         CMSerr(CMS_F_CMS_SD_ASN1_CTRL, CMS_R_NOT_SUPPORTED_FOR_THIS_KEY_TYPE);
         return 0;
     }

--- a/crypto/des/set_key.c
+++ b/crypto/des/set_key.c
@@ -287,7 +287,7 @@ int DES_set_key_checked(const_DES_cblock *key, DES_key_schedule *schedule)
     if (!DES_check_key_parity(key))
         return -1;
     if (DES_is_weak_key(key))
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     DES_set_key_unchecked(key, schedule);
     return 0;
 }

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -498,7 +498,7 @@ static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
     case ASN1_PKEY_CTRL_GET1_TLS_ENCPT:
         return dh_key2buf(EVP_PKEY_get0_DH(pkey), arg2);
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 }
 
@@ -512,14 +512,14 @@ static int dhx_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
             return dh_cms_decrypt(arg2);
         else if (arg1 == 0)
             return dh_cms_encrypt(arg2);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     case ASN1_PKEY_CTRL_CMS_RI_TYPE:
         *(int *)arg2 = CMS_RECIPINFO_AGREE;
         return 1;
 #endif
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
 }

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -115,13 +115,13 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     switch (type) {
     case EVP_PKEY_CTRL_DH_PARAMGEN_PRIME_LEN:
         if (p1 < 256)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->prime_len = p1;
         return 1;
 
     case EVP_PKEY_CTRL_DH_PARAMGEN_SUBPRIME_LEN:
         if (dctx->use_dsa == 0)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->subprime_len = p1;
         return 1;
 
@@ -131,30 +131,30 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR:
         if (dctx->use_dsa)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->generator = p1;
         return 1;
 
     case EVP_PKEY_CTRL_DH_PARAMGEN_TYPE:
 #ifdef OPENSSL_NO_DSA
         if (p1 != 0)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
 #else
         if (p1 < 0 || p1 > 2)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
 #endif
         dctx->use_dsa = p1;
         return 1;
 
     case EVP_PKEY_CTRL_DH_RFC5114:
         if (p1 < 1 || p1 > 3 || dctx->param_nid != NID_undef)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->rfc5114_param = p1;
         return 1;
 
     case EVP_PKEY_CTRL_DH_NID:
         if (p1 <= 0 || dctx->rfc5114_param != 0)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->param_nid = p1;
         return 1;
 
@@ -163,14 +163,14 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     case EVP_PKEY_CTRL_DH_KDF_TYPE:
-        if (p1 == -2)
+        if (p1 == OSSL_RET_UNSUPPORTED)
             return dctx->kdf_type;
 #ifdef OPENSSL_NO_CMS
         if (p1 != EVP_PKEY_DH_KDF_NONE)
 #else
         if (p1 != EVP_PKEY_DH_KDF_NONE && p1 != EVP_PKEY_DH_KDF_X9_42)
 #endif
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->kdf_type = p1;
         return 1;
 
@@ -184,7 +184,7 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case EVP_PKEY_CTRL_DH_KDF_OUTLEN:
         if (p1 <= 0)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->kdf_outlen = (size_t)p1;
         return 1;
 
@@ -215,7 +215,7 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 }
@@ -233,7 +233,7 @@ static int pkey_dh_ctrl_str(EVP_PKEY_CTX *ctx,
         int len;
         len = atoi(value);
         if (len < 0 || len > 3)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->rfc5114_param = len;
         return 1;
     }
@@ -243,7 +243,7 @@ static int pkey_dh_ctrl_str(EVP_PKEY_CTX *ctx,
 
         if (nid == NID_undef) {
             DHerr(DH_F_PKEY_DH_CTRL_STR, DH_R_INVALID_PARAMETER_NAME);
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         }
         dctx->param_nid = nid;
         return 1;
@@ -268,7 +268,7 @@ static int pkey_dh_ctrl_str(EVP_PKEY_CTX *ctx,
         pad = atoi(value);
         return EVP_PKEY_CTX_set_dh_pad(ctx, pad);
     }
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 #ifndef OPENSSL_NO_DSA
@@ -346,7 +346,7 @@ static int pkey_dh_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
             break;
 
         default:
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         }
         EVP_PKEY_assign(pkey, EVP_PKEY_DHX, dh);
         return 1;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -522,7 +522,7 @@ static int dsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return 1;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -111,13 +111,13 @@ static int pkey_dsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     switch (type) {
     case EVP_PKEY_CTRL_DSA_PARAMGEN_BITS:
         if (p1 < 256)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->nbits = p1;
         return 1;
 
     case EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS:
         if (p1 != 160 && p1 != 224 && p1 && p1 != 256)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->qbits = p1;
         return 1;
 
@@ -161,9 +161,9 @@ static int pkey_dsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     case EVP_PKEY_CTRL_PEER_KEY:
         DSAerr(DSA_F_PKEY_DSA_CTRL,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 }
@@ -189,7 +189,7 @@ static int pkey_dsa_ctrl_str(EVP_PKEY_CTX *ctx,
         }
         return EVP_PKEY_CTX_set_dsa_paramgen_md(ctx, md);
     }
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static int pkey_dsa_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -166,6 +166,7 @@ static int eckey_pub_decode(EVP_PKEY *pkey, X509_PUBKEY *pubkey)
     return 0;
 }
 
+/* -1 is a valid return value, so we return -2 for error */
 static int eckey_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     int r;
@@ -316,6 +317,7 @@ static int ec_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
     return 0;
 }
 
+/* -1 is a valid return value, so we return -2 for error */
 static int ec_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     const EC_GROUP *group_a = EC_KEY_get0_group(a->pkey.ec),

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -496,7 +496,7 @@ static int ec_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
             return ecdh_cms_decrypt(arg2);
         else if (arg1 == 0)
             return ecdh_cms_encrypt(arg2);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     case ASN1_PKEY_CTRL_CMS_RI_TYPE:
         *(int *)arg2 = CMS_RECIPINFO_AGREE;
@@ -520,7 +520,7 @@ static int ec_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
                               POINT_CONVERSION_UNCOMPRESSED, arg2, NULL);
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 

--- a/crypto/ec/ec_pmeth.c
+++ b/crypto/ec/ec_pmeth.c
@@ -253,12 +253,12 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 return EC_KEY_get_flags(ec_key) & EC_FLAG_COFACTOR_ECDH ? 1 : 0;
             }
         } else if (p1 < -1 || p1 > 1)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->cofactor_mode = p1;
         if (p1 != -1) {
             EC_KEY *ec_key = ctx->pkey->pkey.ec;
             if (!ec_key->group)
-                return -2;
+                return OSSL_RET_UNSUPPORTED;
             /* If cofactor is 1 cofactor mode does nothing */
             if (BN_is_one(ec_key->group->cofactor))
                 return 1;
@@ -282,7 +282,7 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         if (p1 == -2)
             return dctx->kdf_type;
         if (p1 != EVP_PKEY_ECDH_KDF_NONE && p1 != EVP_PKEY_ECDH_KDF_X9_63)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->kdf_type = p1;
         return 1;
 
@@ -296,7 +296,7 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case EVP_PKEY_CTRL_EC_KDF_OUTLEN:
         if (p1 <= 0)
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         dctx->kdf_outlen = (size_t)p1;
         return 1;
 
@@ -347,7 +347,7 @@ static int pkey_ec_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 }
@@ -374,7 +374,7 @@ static int pkey_ec_ctrl_str(EVP_PKEY_CTX *ctx,
         else if (strcmp(value, "named_curve") == 0)
             param_enc = OPENSSL_EC_NAMED_CURVE;
         else
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
     } else if (strcmp(type, "ecdh_kdf_md") == 0) {
         const EVP_MD *md;
@@ -389,7 +389,7 @@ static int pkey_ec_ctrl_str(EVP_PKEY_CTX *ctx,
         return EVP_PKEY_CTX_set_ecdh_cofactor_mode(ctx, co_mode);
     }
 
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static int pkey_ec_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -163,6 +163,7 @@ static int ecx_pub_decode(EVP_PKEY *pkey, X509_PUBKEY *pubkey)
                       KEY_OP_PUBLIC);
 }
 
+/* -1 is a valid return value, so we return -2 for error */
 static int ecx_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     const ECX_KEY *akey = a->pkey.ecx;

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -337,7 +337,7 @@ static int ecx_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return 0;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 }
@@ -351,7 +351,7 @@ static int ecd_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return 2;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 }
@@ -716,7 +716,7 @@ static int pkey_ecx_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     /* Only need to handle peer key for derivation */
     if (type == EVP_PKEY_CTRL_PEER_KEY)
         return 1;
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static const EVP_PKEY_METHOD ecx25519_pkey_meth = {
@@ -827,7 +827,7 @@ static int pkey_ecd_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     case EVP_PKEY_CTRL_DIGESTINIT:
         return 1;
     }
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static const EVP_PKEY_METHOD ed25519_pkey_meth = {

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -566,7 +566,7 @@ static int ossl_hmac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         break;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
     return 1;
@@ -593,7 +593,7 @@ static int ossl_hmac_ctrl_str(EVP_PKEY_CTX *ctx,
         OPENSSL_free(key);
         return r;
     }
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static EVP_PKEY_METHOD *ossl_hmac_meth;

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -649,7 +649,7 @@ const OSSL_PARAM *EVP_MD_CTX_gettable_params(EVP_MD_CTX *ctx)
 /* TODO(3.0): Remove legacy code below - only used by engines & DigestSign */
 int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
 {
-    int ret = EVP_CTRL_RET_UNSUPPORTED;
+    int ret = OSSL_RET_UNSUPPORTED;
     int set_params = 1;
     size_t sz;
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -271,7 +271,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
         int r;
         r = EVP_PKEY_CTX_ctrl(ctx->pctx, -1, EVP_PKEY_OP_TYPE_SIG,
                               EVP_PKEY_CTRL_DIGESTINIT, 0, ctx);
-        if (r <= 0 && (r != -2))
+        if (r <= 0 && (r != OSSL_RET_UNSUPPORTED))
             return 0;
     }
 #endif

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1082,7 +1082,7 @@ int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad)
 
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 {
-    int ret = EVP_CTRL_RET_UNSUPPORTED;
+    int ret = OSSL_RET_UNSUPPORTED;
     int set_params = 1;
     size_t sz = arg;
     unsigned int i;
@@ -1198,7 +1198,7 @@ legacy:
     ret = ctx->cipher->ctrl(ctx, type, arg, ptr);
 
  end:
-    if (ret == EVP_CTRL_RET_UNSUPPORTED) {
+    if (ret == OSSL_RET_UNSUPPORTED) {
         EVPerr(EVP_F_EVP_CIPHER_CTX_CTRL,
                EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED);
         return 0;

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -54,7 +54,7 @@ int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
         case EVP_CIPH_CCM_MODE:
         case EVP_CIPH_XTS_MODE:
         case EVP_CIPH_OCB_MODE:
-            ret = -2;
+            ret = OSSL_RET_UNSUPPORTED;
             break;
 
         default:
@@ -90,11 +90,11 @@ int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
             OPENSSL_free(der);
         }
     } else {
-        ret = -2;
+        ret = OSSL_RET_UNSUPPORTED;
     }
 
  err:
-    if (ret == -2)
+    if (ret == OSSL_RET_UNSUPPORTED)
         EVPerr(EVP_F_EVP_CIPHER_PARAM_TO_ASN1, ASN1_R_UNSUPPORTED_CIPHER);
     else if (ret <= 0)
         EVPerr(EVP_F_EVP_CIPHER_PARAM_TO_ASN1, EVP_R_CIPHER_PARAMETER_ERROR);
@@ -136,7 +136,7 @@ int EVP_CIPHER_asn1_to_param(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
         case EVP_CIPH_CCM_MODE:
         case EVP_CIPH_XTS_MODE:
         case EVP_CIPH_OCB_MODE:
-            ret = -2;
+            ret = OSSL_RET_UNSUPPORTED;
             break;
 
         default:
@@ -157,10 +157,10 @@ int EVP_CIPHER_asn1_to_param(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
             OPENSSL_free(der);
         }
     } else {
-        ret = -2;
+        ret = OSSL_RET_UNSUPPORTED;
     }
 
-    if (ret == -2)
+    if (ret == OSSL_RET_UNSUPPORTED)
         EVPerr(EVP_F_EVP_CIPHER_ASN1_TO_PARAM, EVP_R_UNSUPPORTED_CIPHER);
     else if (ret <= 0)
         EVPerr(EVP_F_EVP_CIPHER_ASN1_TO_PARAM, EVP_R_CIPHER_PARAMETER_ERROR);

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -403,7 +403,7 @@ int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
 
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &v);
     rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
-    if (rv == EVP_CTRL_RET_UNSUPPORTED)
+    if (rv == OSSL_RET_UNSUPPORTED)
         goto legacy;
     return rv != 0 ? (int)v : -1;
     /* TODO (3.0) Remove legacy support */
@@ -486,7 +486,7 @@ int EVP_CIPHER_CTX_num(const EVP_CIPHER_CTX *ctx)
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_NUM, &v);
     ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
 
-    return ok != 0 ? (int)v : EVP_CTRL_RET_UNSUPPORTED;
+    return ok != 0 ? (int)v : -1;
 }
 
 int EVP_CIPHER_CTX_set_num(EVP_CIPHER_CTX *ctx, int num)
@@ -517,7 +517,7 @@ int EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx)
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &v);
     ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
 
-    return ok != 0 ? (int)v : EVP_CTRL_RET_UNSUPPORTED;
+    return ok != 0 ? (int)v : -1;
 }
 
 int EVP_CIPHER_nid(const EVP_CIPHER *cipher)

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -11,9 +11,6 @@
 
 #include <openssl/core_numbers.h>
 
-#define EVP_CTRL_RET_UNSUPPORTED -1
-
-
 struct evp_md_ctx_st {
     const EVP_MD *reqdigest;    /* The original requested digest */
     const EVP_MD *digest;

--- a/crypto/evp/evp_utils.c
+++ b/crypto/evp/evp_utils.c
@@ -18,7 +18,7 @@
 #include "evp_local.h"
 
 /*
- * EVP_CTRL_RET_UNSUPPORTED = -1 is the returned value from any ctrl function
+ * OSSL_RET_UNSUPPORTED = -2 is the returned value from any ctrl function
  * where the control command isn't supported, and an alternative code path
  * may be chosen.
  * Since these functions are used to implement ctrl functionality, we
@@ -28,7 +28,7 @@
     if (obj == NULL)                                                           \
         return 0;                                                              \
     if (obj->prov == NULL)                                                     \
-        return EVP_CTRL_RET_UNSUPPORTED;                                       \
+        return OSSL_RET_UNSUPPORTED;                                           \
     if (obj->func == NULL) {                                                   \
         errfunc();                                                             \
         return 0;                                                              \

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -161,7 +161,7 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     evp_pkey_ctx_free_old_ops(ctx);
@@ -223,7 +223,7 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
  legacy:
     if (ctx == NULL || ctx->pmeth == NULL || ctx->pmeth->derive == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->pmeth->derive_init == NULL)
@@ -242,7 +242,7 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
     if (ctx == NULL) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE_SET_PEER,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (!EVP_PKEY_CTX_IS_DERIVE_OP(ctx) || ctx->op.kex.exchprovctx == NULL)
@@ -251,7 +251,7 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
     if (ctx->op.kex.exchange->set_peer == NULL) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE_SET_PEER,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     provkey = evp_keymgmt_export_to_provider(peer, ctx->keymgmt, 0);
@@ -269,7 +269,7 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
         || ctx->pmeth->ctrl == NULL) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE_SET_PEER,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     if (ctx->operation != EVP_PKEY_OP_DERIVE
         && ctx->operation != EVP_PKEY_OP_ENCRYPT
@@ -331,7 +331,7 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *pkeylen)
     if (ctx == NULL) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (!EVP_PKEY_CTX_IS_DERIVE_OP(ctx)) {
@@ -350,7 +350,7 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *pkeylen)
     if (ctx ==  NULL || ctx->pmeth == NULL || ctx->pmeth->derive == NULL) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     M_check_autoarg(ctx, key, pkeylen, EVP_F_EVP_PKEY_DERIVE)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -119,6 +119,13 @@ int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
     return -2;
 }
 
+/*
+ * Return values:
+ *  1: match
+ *  0: key type match, but not key contents
+ * -1: key type mismatch
+ * -2: key type match, comparison otherwise unsupported
+ */
 int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     if (a->type != b->type)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -41,7 +41,7 @@ int EVP_PKEY_security_bits(const EVP_PKEY *pkey)
     if (pkey == NULL)
         return 0;
     if (pkey->ameth == NULL || pkey->ameth->pkey_security_bits == NULL)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     return pkey->ameth->pkey_security_bits(pkey);
 }
 
@@ -692,7 +692,7 @@ int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
 static int evp_pkey_asn1_ctrl(EVP_PKEY *pkey, int op, int arg1, void *arg2)
 {
     if (pkey->ameth == NULL || pkey->ameth->pkey_ctrl == NULL)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     return pkey->ameth->pkey_ctrl(pkey, op, arg1, arg2);
 }
 
@@ -706,7 +706,7 @@ int EVP_PKEY_supports_digest_nid(EVP_PKEY *pkey, int nid)
     int rv, default_nid;
 
     rv = evp_pkey_asn1_ctrl(pkey, ASN1_PKEY_CTRL_SUPPORTS_MD_NID, nid, NULL);
-    if (rv == -2) {
+    if (rv == OSSL_RET_UNSUPPORTED) {
         /*
          * If there is a mandatory default digest and this isn't it, then
          * the answer is 'no'.

--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -163,7 +163,7 @@ static int pkey_kdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         name = OSSL_KDF_PARAM_SCRYPT_MAXMEM;
         break;
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (collector != NULL) {

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -268,7 +268,8 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     case EVP_PKEY_CTRL_CIPHER:
         switch (hctx->type) {
         case MAC_TYPE_RAW:
-            return -2;       /* The raw types don't support ciphers */
+            /* The raw types don't support ciphers */
+            return OSSL_RET_UNSUPPORTED;
         case MAC_TYPE_MAC:
             {
                 OSSL_PARAM params[3];
@@ -352,7 +353,7 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
              * control is unsupported.
              */
             if (verify != size)
-                return -2;
+                return OSSL_RET_UNSUPPORTED;
         }
         break;
     case EVP_PKEY_CTRL_SET_MAC_KEY:
@@ -415,7 +416,8 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             }
             break;
         case MAC_TYPE_MAC:
-            return -2;       /* The mac types don't support ciphers */
+            /* The mac types don't support ciphers */
+            return OSSL_RET_UNSUPPORTED;
         default:
             /* This should be dead code */
             return 0;
@@ -423,7 +425,7 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         break;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
     return 1;

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -319,7 +319,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     evp_pkey_ctx_free_old_ops(ctx);
@@ -377,7 +377,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     case EVP_PKEY_OP_SIGN:
         if (signature->sign_init == NULL) {
             EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-            ret = -2;
+            ret = OSSL_RET_UNSUPPORTED;
             goto err;
         }
         ret = signature->sign_init(ctx->op.sig.sigprovctx, provkey);
@@ -385,7 +385,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     case EVP_PKEY_OP_VERIFY:
         if (signature->verify_init == NULL) {
             EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-            ret = -2;
+            ret = OSSL_RET_UNSUPPORTED;
             goto err;
         }
         ret = signature->verify_init(ctx->op.sig.sigprovctx, provkey);
@@ -393,7 +393,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     case EVP_PKEY_OP_VERIFYRECOVER:
         if (signature->verify_recover_init == NULL) {
             EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-            ret = -2;
+            ret = OSSL_RET_UNSUPPORTED;
             goto err;
         }
         ret = signature->verify_recover_init(ctx->op.sig.sigprovctx, provkey);
@@ -417,7 +417,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
             || (operation == EVP_PKEY_OP_VERIFYRECOVER
                 && ctx->pmeth->verify_recover == NULL)) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     switch (operation) {
@@ -462,7 +462,7 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->operation != EVP_PKEY_OP_SIGN) {
@@ -481,7 +481,7 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
  
     if (ctx->pmeth == NULL || ctx->pmeth->sign == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     M_check_autoarg(ctx, sig, siglen, EVP_F_EVP_PKEY_SIGN)
@@ -501,7 +501,7 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFY) {
@@ -519,7 +519,7 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
  legacy:
     if (ctx->pmeth == NULL || ctx->pmeth->verify == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     return ctx->pmeth->verify(ctx, sig, siglen, tbs, tbslen);
@@ -538,7 +538,7 @@ int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFYRECOVER) {
@@ -557,7 +557,7 @@ int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
  legacy:
     if (ctx->pmeth == NULL || ctx->pmeth->verify_recover == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     M_check_autoarg(ctx, rout, routlen, EVP_F_EVP_PKEY_VERIFY_RECOVER)
         return ctx->pmeth->verify_recover(ctx, rout, routlen, sig, siglen);
@@ -571,7 +571,7 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     evp_pkey_ctx_free_old_ops(ctx);
@@ -692,7 +692,7 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->operation != EVP_PKEY_OP_ENCRYPT) {
@@ -730,7 +730,7 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
 
     if (ctx == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->operation != EVP_PKEY_OP_DECRYPT) {

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -34,7 +34,7 @@ static int fromdata_init(EVP_PKEY_CTX *ctx, int operation)
  not_supported:
     ctx->operation = EVP_PKEY_OP_UNDEFINED;
     ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 int EVP_PKEY_param_fromdata_init(EVP_PKEY_CTX *ctx)
@@ -53,7 +53,7 @@ int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM params[])
 
     if (ctx == NULL || (ctx->operation & EVP_PKEY_OP_TYPE_FROMDATA) == 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ppkey == NULL)
@@ -106,7 +106,7 @@ int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx)
     if (!ctx || !ctx->pmeth || !ctx->pmeth->paramgen) {
         EVPerr(EVP_F_EVP_PKEY_PARAMGEN_INIT,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     ctx->operation = EVP_PKEY_OP_PARAMGEN;
     if (!ctx->pmeth->paramgen_init)
@@ -123,7 +123,7 @@ int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     if (!ctx || !ctx->pmeth || !ctx->pmeth->paramgen) {
         EVPerr(EVP_F_EVP_PKEY_PARAMGEN,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if (ctx->operation != EVP_PKEY_OP_PARAMGEN) {
@@ -156,7 +156,7 @@ int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx)
     if (!ctx || !ctx->pmeth || !ctx->pmeth->keygen) {
         EVPerr(EVP_F_EVP_PKEY_KEYGEN_INIT,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     ctx->operation = EVP_PKEY_OP_KEYGEN;
     if (!ctx->pmeth->keygen_init)
@@ -174,7 +174,7 @@ int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     if (!ctx || !ctx->pmeth || !ctx->pmeth->keygen) {
         EVPerr(EVP_F_EVP_PKEY_KEYGEN,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     if (ctx->operation != EVP_PKEY_OP_KEYGEN) {
         EVPerr(EVP_F_EVP_PKEY_KEYGEN, EVP_R_OPERATON_NOT_INITIALIZED);
@@ -270,7 +270,7 @@ int EVP_PKEY_check(EVP_PKEY_CTX *ctx)
     if (pkey->ameth == NULL || pkey->ameth->pkey_check == NULL) {
         EVPerr(EVP_F_EVP_PKEY_CHECK,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     return pkey->ameth->pkey_check(pkey);
@@ -293,7 +293,7 @@ int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx)
     if (pkey->ameth == NULL || pkey->ameth->pkey_public_check == NULL) {
         EVPerr(EVP_F_EVP_PKEY_PUBLIC_CHECK,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     return pkey->ameth->pkey_public_check(pkey);
@@ -316,7 +316,7 @@ int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx)
     if (pkey->ameth == NULL || pkey->ameth->pkey_param_check == NULL) {
         EVPerr(EVP_F_EVP_PKEY_PARAM_CHECK,
                EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     return pkey->ameth->pkey_param_check(pkey);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -601,7 +601,7 @@ int EVP_PKEY_CTX_set_dh_pad(EVP_PKEY_CTX *ctx, int pad)
     /* We use EVP_PKEY_CTX_ctrl return values */
     if (ctx == NULL || !EVP_PKEY_CTX_IS_DERIVE_OP(ctx)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     /* TODO(3.0): Remove this eventually when no more legacy */
@@ -626,7 +626,7 @@ int EVP_PKEY_CTX_get_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD **md)
     if (ctx == NULL || !EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
         /* Uses the same return values as EVP_PKEY_CTX_ctrl */
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     /* TODO(3.0): Remove this eventually when no more legacy */
@@ -660,7 +660,7 @@ int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
     if (ctx == NULL || !EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
         /* Uses the same return values as EVP_PKEY_CTX_ctrl */
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     /* TODO(3.0): Remove this eventually when no more legacy */
@@ -740,7 +740,7 @@ int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
 
     if (ctx == NULL) {
         EVPerr(EVP_F_EVP_PKEY_CTX_CTRL, EVP_R_COMMAND_NOT_SUPPORTED);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if ((EVP_PKEY_CTX_IS_DERIVE_OP(ctx) && ctx->op.kex.exchprovctx != NULL)
@@ -752,7 +752,7 @@ int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
 
     if (ctx->pmeth == NULL || ctx->pmeth->ctrl == NULL) {
         EVPerr(EVP_F_EVP_PKEY_CTX_CTRL, EVP_R_COMMAND_NOT_SUPPORTED);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     if ((keytype != -1) && (ctx->pmeth->pkey_id != keytype))
         return -1;
@@ -774,7 +774,7 @@ int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype,
  doit:
     ret = ctx->pmeth->ctrl(ctx, cmd, p1, p2);
 
-    if (ret == -2)
+    if (ret == OSSL_RET_UNSUPPORTED)
         EVPerr(EVP_F_EVP_PKEY_CTX_CTRL, EVP_R_COMMAND_NOT_SUPPORTED);
 
     return ret;
@@ -866,7 +866,7 @@ int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx,
 {
     if (ctx == NULL) {
         EVPerr(EVP_F_EVP_PKEY_CTX_CTRL_STR, EVP_R_COMMAND_NOT_SUPPORTED);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 
     if ((EVP_PKEY_CTX_IS_DERIVE_OP(ctx) && ctx->op.kex.exchprovctx != NULL)
@@ -878,7 +878,7 @@ int EVP_PKEY_CTX_ctrl_str(EVP_PKEY_CTX *ctx,
 
     if (!ctx || !ctx->pmeth || !ctx->pmeth->ctrl_str) {
         EVPerr(EVP_F_EVP_PKEY_CTX_CTRL_STR, EVP_R_COMMAND_NOT_SUPPORTED);
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
     if (strcmp(name, "digest") == 0)
         return EVP_PKEY_CTX_md(ctx, EVP_PKEY_OP_TYPE_SIG, EVP_PKEY_CTRL_MD,

--- a/crypto/hmac/hm_ameth.c
+++ b/crypto/hmac/hm_ameth.c
@@ -41,7 +41,7 @@ static int hmac_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return 1;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 }
 

--- a/crypto/md5/md5_sha1.c
+++ b/crypto/md5/md5_sha1.c
@@ -38,7 +38,7 @@ int md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms)
     unsigned char sha1tmp[SHA_DIGEST_LENGTH];
 
     if (cmd != EVP_CTRL_SSL3_MASTER_SECRET)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     if (mctx == NULL)
         return 0;

--- a/crypto/modes/ccm128.c
+++ b/crypto/modes/ccm128.c
@@ -157,7 +157,7 @@ int CRYPTO_ccm128_encrypt(CCM128_CONTEXT *ctx,
 
     ctx->blocks += ((len + 15) >> 3) | 1;
     if (ctx->blocks > (U64(1) << 61))
-        return -2;              /* too much data */
+        return OSSL_RET_UNSUPPORTED; /* too much data */
 
     while (len >= 16) {
 #if defined(STRICT_ALIGNMENT)
@@ -328,7 +328,7 @@ int CRYPTO_ccm128_encrypt_ccm64(CCM128_CONTEXT *ctx,
 
     ctx->blocks += ((len + 15) >> 3) | 1;
     if (ctx->blocks > (U64(1) << 61))
-        return -2;              /* too much data */
+        return OSSL_RET_UNSUPPORTED; /* too much data */
 
     if ((n = len / 16)) {
         (*stream) (inp, out, n, key, ctx->nonce.c, ctx->cmac.c);

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -334,7 +334,7 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
         ret = pkey->ameth->pkey_ctrl(pkey, ASN1_PKEY_CTRL_PKCS7_SIGN, 0, p7i);
         if (ret > 0)
             return 1;
-        if (ret != -2) {
+        if (ret != OSSL_RET_UNSUPPORTED) {
             PKCS7err(PKCS7_F_PKCS7_SIGNER_INFO_SET,
                      PKCS7_R_SIGNING_CTRL_FAILURE);
             return 0;
@@ -483,7 +483,7 @@ int PKCS7_RECIP_INFO_set(PKCS7_RECIP_INFO *p7i, X509 *x509)
     }
 
     ret = pkey->ameth->pkey_ctrl(pkey, ASN1_PKEY_CTRL_PKCS7_ENCRYPT, 0, p7i);
-    if (ret == -2) {
+    if (ret == OSSL_RET_UNSUPPORTED) {
         PKCS7err(PKCS7_F_PKCS7_RECIP_INFO_SET,
                  PKCS7_R_ENCRYPTION_NOT_SUPPORTED_FOR_THIS_KEY_TYPE);
         goto err;

--- a/crypto/poly1305/poly1305_ameth.c
+++ b/crypto/poly1305/poly1305_ameth.c
@@ -37,7 +37,7 @@ static void poly1305_key_free(EVP_PKEY *pkey)
 static int poly1305_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     /* nothing, (including ASN1_PKEY_CTRL_DEFAULT_MD_NID), is supported */
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static int poly1305_pkey_public_cmp(const EVP_PKEY *a, const EVP_PKEY *b)

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -474,7 +474,7 @@ static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     case ASN1_PKEY_CTRL_PKCS7_ENCRYPT:
         if (pkey_is_pss(pkey))
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         if (arg1 == 0)
             PKCS7_RECIP_INFO_get0_alg(arg2, &alg);
         break;
@@ -488,7 +488,7 @@ static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     case ASN1_PKEY_CTRL_CMS_ENVELOPE:
         if (pkey_is_pss(pkey))
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         if (arg1 == 0)
             return rsa_cms_encrypt(arg2);
         else if (arg1 == 1)
@@ -497,7 +497,7 @@ static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     case ASN1_PKEY_CTRL_CMS_RI_TYPE:
         if (pkey_is_pss(pkey))
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         *(int *)arg2 = CMS_RECIPINFO_TRANS;
         return 1;
 #endif
@@ -517,7 +517,7 @@ static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return 1;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     }
 

--- a/crypto/sha/sha1dgst.c
+++ b/crypto/sha/sha1dgst.c
@@ -25,7 +25,7 @@ int sha1_ctrl(SHA_CTX *sha1, int cmd, int mslen, void *ms)
     unsigned char sha1tmp[SHA_DIGEST_LENGTH];
 
     if (cmd != EVP_CTRL_SSL3_MASTER_SECRET)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
 
     if (sha1 == NULL)
         return 0;

--- a/crypto/siphash/siphash_ameth.c
+++ b/crypto/siphash/siphash_ameth.c
@@ -39,7 +39,7 @@ static void siphash_key_free(EVP_PKEY *pkey)
 static int siphash_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     /* nothing (including ASN1_PKEY_CTRL_DEFAULT_MD_NID), is supported */
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static int siphash_pkey_public_cmp(const EVP_PKEY *a, const EVP_PKEY *b)

--- a/crypto/sm2/sm2_pmeth.c
+++ b/crypto/sm2/sm2_pmeth.c
@@ -225,7 +225,7 @@ static int pkey_sm2_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         return 1;
 
     default:
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     }
 }
 
@@ -254,7 +254,7 @@ static int pkey_sm2_ctrl_str(EVP_PKEY_CTX *ctx,
         else if (strcmp(value, "named_curve") == 0)
             param_enc = OPENSSL_EC_NAMED_CURVE;
         else
-            return -2;
+            return OSSL_RET_UNSUPPORTED;
         return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
     } else if (strcmp(type, "sm2_id") == 0) {
         return pkey_sm2_ctrl(ctx, EVP_PKEY_CTRL_SET1_ID,
@@ -276,7 +276,7 @@ static int pkey_sm2_ctrl_str(EVP_PKEY_CTX *ctx,
         return ret;
     }
 
-    return -2;
+    return OSSL_RET_UNSUPPORTED;
 }
 
 static int pkey_sm2_digest_custom(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -96,7 +96,7 @@ static long trace_ctrl(BIO *channel, int cmd, long argl, void *argp)
     default:
         break;
     }
-    return -2;                   /* Unsupported */
+    return OSSL_RET_UNSUPPORTED; /* Unsupported */
 }
 
 static int trace_free(BIO *channel)

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -28,7 +28,7 @@ int X509at_get_attr_by_NID(const STACK_OF(X509_ATTRIBUTE) *x, int nid,
     const ASN1_OBJECT *obj = OBJ_nid2obj(nid);
 
     if (obj == NULL)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     return X509at_get_attr_by_OBJ(x, obj, lastpos);
 }
 

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -154,6 +154,7 @@ int X509_cmp(const X509 *a, const X509 *b)
     return rv;
 }
 
+/* -1 is a valid return value, so we return -2 for error */
 int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b)
 {
     int ret;

--- a/crypto/x509/x509_v3.c
+++ b/crypto/x509/x509_v3.c
@@ -31,7 +31,7 @@ int X509v3_get_ext_by_NID(const STACK_OF(X509_EXTENSION) *x, int nid,
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     return X509v3_get_ext_by_OBJ(x, obj, lastpos);
 }
 

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -59,7 +59,7 @@ int X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos)
 
     obj = OBJ_nid2obj(nid);
     if (obj == NULL)
-        return -2;
+        return OSSL_RET_UNSUPPORTED;
     return X509_NAME_get_index_by_OBJ(name, obj, lastpos);
 }
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -50,6 +50,8 @@
 extern "C" {
 #endif
 
+# define OSSL_RET_UNSUPPORTED   -2
+
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define SSLeay                  OpenSSL_version_num
 #  define SSLeay_version          OpenSSL_version

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -568,6 +568,7 @@ int SSL_CTX_add_client_CA(SSL_CTX *ctx, X509 *x)
     return add_ca_name(&ctx->client_ca_names, x);
 }
 
+/* -1 is a valid return value, so we return -2 for error */
 static int xname_cmp(const X509_NAME *a, const X509_NAME *b)
 {
     unsigned char *abuf = NULL, *bbuf = NULL;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1106,7 +1106,7 @@ static int mac_test_ctrl_pkey(EVP_TEST *t, EVP_PKEY_CTX *pctx,
     if (p != NULL)
         *p++ = '\0';
     rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
-    if (rv == -2)
+    if (rv == OSSL_RET_UNSUPPORTED)
         t->err = "PKEY_CTRL_INVALID";
     else if (rv <= 0)
         t->err = "PKEY_CTRL_ERROR";
@@ -1448,7 +1448,7 @@ static int pkey_test_ctrl(EVP_TEST *t, EVP_PKEY_CTX *pctx,
     if (p != NULL)
         *p++ = '\0';
     rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
-    if (rv == -2) {
+    if (rv == OSSL_RET_UNSUPPORTED) {
         t->err = "PKEY_CTRL_INVALID";
         rv = 1;
     } else if (p != NULL && rv <= 0) {


### PR DESCRIPTION
It's been complained numerous times that OpenSSL uses "magic values" with not much of an explanation, except manual pages mentioning it a little here and there.

-2 is such a value, which is used fairly consistently throughout the code, to signify that a function call with its combination of parameters is unsupported or unrecognised.  This allows a caller to use fallbacks, or otherwise treat this return value in special ways.

There are some API functions that return -2 for other reasons, and those are left alone.  Typically, this applies to comparison functions, where -1 is a valid return value, and -2 is therefore used to signify that an error of some kind has occurred.  This *could* be interpreted as unsupported, but it's unclear whether that is useful or not.

An oddity was discovered as part of this work; some BIO functions return -2 when the BIO itself hasn't been initialised.  That strikes me as odd, isn't that a "normal" error?

It also turns out that our previous `EVP_CTRL_RET_UNSUPPORTED` is incorrect, as there are backend ctrls that do return -2 to signify that the command number is unsupported.