### PR TITLE
travis.yml: add arch s390x target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ matrix:
           arch: arm64
           compiler: gcc
           env: CONFIG_OPTS="--strict-warnings"
+        - os: linux
+          arch: s390x
+          compiler: gcc
+          env: CONFIG_OPTS="--strict-warnings"
         - os: linux-ppc64le
           sudo: false
           compiler: clang


### PR DESCRIPTION
s390x support comes to Travis CI! 
https://community.ibm.com/community/user/ibmz-and-linuxone/blogs/elizabeth-k-joseph1/2019/11/12/s390x-support-comes-to-travis-ci

Corresponding travis doc:
https://docs.travis-ci.com/user/multi-cpu-architectures

