### PR TITLE
PEM: constify PEM_write_ routines

### DIFF
--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -43,7 +43,7 @@ int i2d_CMS_bio(BIO *bp, CMS_ContentInfo *cms)
     return ASN1_item_i2d_bio(ASN1_ITEM_rptr(CMS_ContentInfo), bp, cms);
 }
 
-IMPLEMENT_PEM_rw_const(CMS, CMS_ContentInfo, PEM_STRING_CMS, CMS_ContentInfo)
+IMPLEMENT_PEM_rw(CMS, CMS_ContentInfo, PEM_STRING_CMS, CMS_ContentInfo)
 
 BIO *BIO_new_CMS(BIO *out, CMS_ContentInfo *cms)
 {

--- a/crypto/pem/pem_all.c
+++ b/crypto/pem/pem_all.c
@@ -79,14 +79,9 @@ RSA *PEM_read_RSAPrivateKey(FILE *fp, RSA **rsa, pem_password_cb *cb, void *u)
 
 # endif
 
-IMPLEMENT_PEM_write_cb_const(RSAPrivateKey, RSA, PEM_STRING_RSA,
-                             RSAPrivateKey)
-
-
-IMPLEMENT_PEM_rw_const(RSAPublicKey, RSA, PEM_STRING_RSA_PUBLIC,
-                       RSAPublicKey) IMPLEMENT_PEM_rw(RSA_PUBKEY, RSA,
-                                                      PEM_STRING_PUBLIC,
-                                                      RSA_PUBKEY)
+IMPLEMENT_PEM_write_cb(RSAPrivateKey, RSA, PEM_STRING_RSA, RSAPrivateKey)
+IMPLEMENT_PEM_rw(RSAPublicKey, RSA, PEM_STRING_RSA_PUBLIC, RSAPublicKey)
+IMPLEMENT_PEM_rw(RSA_PUBKEY, RSA, PEM_STRING_PUBLIC, RSA_PUBKEY)
 #endif
 #ifndef OPENSSL_NO_DSA
 static DSA *pkey_get_dsa(EVP_PKEY *key, DSA **dsa)
@@ -113,9 +108,8 @@ DSA *PEM_read_bio_DSAPrivateKey(BIO *bp, DSA **dsa, pem_password_cb *cb,
     return pkey_get_dsa(pktmp, dsa); /* will free pktmp */
 }
 
-IMPLEMENT_PEM_write_cb_const(DSAPrivateKey, DSA, PEM_STRING_DSA,
-                             DSAPrivateKey)
-    IMPLEMENT_PEM_rw(DSA_PUBKEY, DSA, PEM_STRING_PUBLIC, DSA_PUBKEY)
+IMPLEMENT_PEM_write_cb(DSAPrivateKey, DSA, PEM_STRING_DSA, DSAPrivateKey)
+IMPLEMENT_PEM_rw(DSA_PUBKEY, DSA, PEM_STRING_PUBLIC, DSA_PUBKEY)
 # ifndef OPENSSL_NO_STDIO
 DSA *PEM_read_DSAPrivateKey(FILE *fp, DSA **dsa, pem_password_cb *cb, void *u)
 {
@@ -126,7 +120,7 @@ DSA *PEM_read_DSAPrivateKey(FILE *fp, DSA **dsa, pem_password_cb *cb, void *u)
 
 # endif
 
-IMPLEMENT_PEM_rw_const(DSAparams, DSA, PEM_STRING_DSAPARAMS, DSAparams)
+IMPLEMENT_PEM_rw(DSAparams, DSA, PEM_STRING_DSAPARAMS, DSAparams)
 #endif
 #ifndef OPENSSL_NO_EC
 static EC_KEY *pkey_get_eckey(EVP_PKEY *key, EC_KEY **eckey)
@@ -153,8 +147,8 @@ EC_KEY *PEM_read_bio_ECPrivateKey(BIO *bp, EC_KEY **key, pem_password_cb *cb,
     return pkey_get_eckey(pktmp, key); /* will free pktmp */
 }
 
-IMPLEMENT_PEM_rw_const(ECPKParameters, EC_GROUP, PEM_STRING_ECPARAMETERS,
-                       ECPKParameters)
+IMPLEMENT_PEM_rw(ECPKParameters, EC_GROUP, PEM_STRING_ECPARAMETERS,
+                 ECPKParameters)
 
 
 IMPLEMENT_PEM_write_cb(ECPrivateKey, EC_KEY, PEM_STRING_ECPRIVATEKEY,
@@ -175,7 +169,7 @@ EC_KEY *PEM_read_ECPrivateKey(FILE *fp, EC_KEY **eckey, pem_password_cb *cb,
 
 #ifndef OPENSSL_NO_DH
 
-IMPLEMENT_PEM_write_const(DHparams, DH, PEM_STRING_DHPARAMS, DHparams)
-    IMPLEMENT_PEM_write_const(DHxparams, DH, PEM_STRING_DHXPARAMS, DHxparams)
+IMPLEMENT_PEM_write(DHparams, DH, PEM_STRING_DHPARAMS, DHparams)
+IMPLEMENT_PEM_write(DHxparams, DH, PEM_STRING_DHXPARAMS, DHxparams)
 #endif
 IMPLEMENT_PEM_rw(PUBKEY, EVP_PKEY, PEM_STRING_PUBLIC, PUBKEY)

--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -244,15 +244,15 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read_bio(BIO *bp, STACK_OF(X509_INFO) *sk,
 }
 
 /* A TJH addition */
-int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
-                            unsigned char *kstr, int klen,
+int PEM_X509_INFO_write_bio(BIO *bp, const X509_INFO *xi, EVP_CIPHER *enc,
+                            const unsigned char *kstr, int klen,
                             pem_password_cb *cb, void *u)
 {
     int i, ret = 0;
     unsigned char *data = NULL;
     const char *objstr = NULL;
     char buf[PEM_BUFSIZE];
-    unsigned char *iv = NULL;
+    const unsigned char *iv = NULL;
 
     if (enc != NULL) {
         objstr = OBJ_nid2sn(EVP_CIPHER_nid(enc));
@@ -301,7 +301,7 @@ int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
             buf[0] = '\0';
             PEM_proc_type(buf, PEM_TYPE_ENCRYPTED);
             PEM_dek_info(buf, objstr, EVP_CIPHER_iv_length(enc),
-                         (char *)iv);
+                         (const char *)iv);
 
             /* use the normal code to write things out */
             i = PEM_write_bio(bp, PEM_STRING_RSA, buf, data, i);

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -80,7 +80,7 @@ void PEM_proc_type(char *buf, int type)
     BIO_snprintf(p, PEM_BUFSIZE - (size_t)(p - buf), "Proc-Type: 4,%s\n", str);
 }
 
-void PEM_dek_info(char *buf, const char *type, int len, char *str)
+void PEM_dek_info(char *buf, const char *type, int len, const char *str)
 {
     long i;
     char *p = buf + strlen(buf);
@@ -288,8 +288,9 @@ int PEM_bytes_read_bio_secmem(unsigned char **pdata, long *plen, char **pnm,
 
 #ifndef OPENSSL_NO_STDIO
 int PEM_ASN1_write(i2d_of_void *i2d, const char *name, FILE *fp,
-                   void *x, const EVP_CIPHER *enc, unsigned char *kstr,
-                   int klen, pem_password_cb *callback, void *u)
+                   const void *x, const EVP_CIPHER *enc,
+                   const unsigned char *kstr, int klen,
+                   pem_password_cb *callback, void *u)
 {
     BIO *b;
     int ret;
@@ -306,8 +307,9 @@ int PEM_ASN1_write(i2d_of_void *i2d, const char *name, FILE *fp,
 #endif
 
 int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp,
-                       void *x, const EVP_CIPHER *enc, unsigned char *kstr,
-                       int klen, pem_password_cb *callback, void *u)
+                       const void *x, const EVP_CIPHER *enc,
+                       const unsigned char *kstr, int klen,
+                       pem_password_cb *callback, void *u)
 {
     EVP_CIPHER_CTX *ctx = NULL;
     int dsize = 0, i = 0, j = 0, ret = 0;

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -18,12 +18,14 @@
 
 static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder,
                       int nid, const EVP_CIPHER *enc,
-                      char *kstr, int klen, pem_password_cb *cb, void *u);
+                      const char *kstr, int klen,
+                      pem_password_cb *cb, void *u);
 
 #ifndef OPENSSL_NO_STDIO
 static int do_pk8pkey_fp(FILE *bp, const EVP_PKEY *x, int isder,
                          int nid, const EVP_CIPHER *enc,
-                         char *kstr, int klen, pem_password_cb *cb, void *u);
+                         const char *kstr, int klen,
+                         pem_password_cb *cb, void *u);
 #endif
 /*
  * These functions write a private key in PKCS#8 format: it is a "drop in"
@@ -33,35 +35,35 @@ static int do_pk8pkey_fp(FILE *bp, const EVP_PKEY *x, int isder,
  */
 
 int PEM_write_bio_PKCS8PrivateKey_nid(BIO *bp, const EVP_PKEY *x, int nid,
-                                      char *kstr, int klen,
+                                      const char *kstr, int klen,
                                       pem_password_cb *cb, void *u)
 {
     return do_pk8pkey(bp, x, 0, nid, NULL, kstr, klen, cb, u);
 }
 
 int PEM_write_bio_PKCS8PrivateKey(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                                  char *kstr, int klen,
+                                  const char *kstr, int klen,
                                   pem_password_cb *cb, void *u)
 {
     return do_pk8pkey(bp, x, 0, -1, enc, kstr, klen, cb, u);
 }
 
 int i2d_PKCS8PrivateKey_bio(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                            char *kstr, int klen,
+                            const char *kstr, int klen,
                             pem_password_cb *cb, void *u)
 {
     return do_pk8pkey(bp, x, 1, -1, enc, kstr, klen, cb, u);
 }
 
 int i2d_PKCS8PrivateKey_nid_bio(BIO *bp, const EVP_PKEY *x, int nid,
-                                char *kstr, int klen,
+                                const char *kstr, int klen,
                                 pem_password_cb *cb, void *u)
 {
     return do_pk8pkey(bp, x, 1, nid, NULL, kstr, klen, cb, u);
 }
 
 static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
-                      const EVP_CIPHER *enc, char *kstr, int klen,
+                      const EVP_CIPHER *enc, const char *kstr, int klen,
                       pem_password_cb *cb, void *u)
 {
     X509_SIG *p8;
@@ -149,34 +151,35 @@ EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
 #ifndef OPENSSL_NO_STDIO
 
 int i2d_PKCS8PrivateKey_fp(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                           char *kstr, int klen, pem_password_cb *cb, void *u)
+                           const char *kstr, int klen,
+                           pem_password_cb *cb, void *u)
 {
     return do_pk8pkey_fp(fp, x, 1, -1, enc, kstr, klen, cb, u);
 }
 
 int i2d_PKCS8PrivateKey_nid_fp(FILE *fp, const EVP_PKEY *x, int nid,
-                               char *kstr, int klen,
+                               const char *kstr, int klen,
                                pem_password_cb *cb, void *u)
 {
     return do_pk8pkey_fp(fp, x, 1, nid, NULL, kstr, klen, cb, u);
 }
 
 int PEM_write_PKCS8PrivateKey_nid(FILE *fp, const EVP_PKEY *x, int nid,
-                                  char *kstr, int klen,
+                                  const char *kstr, int klen,
                                   pem_password_cb *cb, void *u)
 {
     return do_pk8pkey_fp(fp, x, 0, nid, NULL, kstr, klen, cb, u);
 }
 
 int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                              char *kstr, int klen, pem_password_cb *cb,
-                              void *u)
+                              const char *kstr, int klen,
+                              pem_password_cb *cb, void *u)
 {
     return do_pk8pkey_fp(fp, x, 0, -1, enc, kstr, klen, cb, u);
 }
 
 static int do_pk8pkey_fp(FILE *fp, const EVP_PKEY *x, int isder, int nid,
-                         const EVP_CIPHER *enc, char *kstr, int klen,
+                         const EVP_CIPHER *enc, const char *kstr, int klen,
                          pem_password_cb *cb, void *u)
 {
     BIO *bp;

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -64,19 +64,20 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
     return ret;
 }
 
-int PEM_write_bio_PrivateKey(BIO *bp, EVP_PKEY *x, const EVP_CIPHER *enc,
-                             unsigned char *kstr, int klen,
+int PEM_write_bio_PrivateKey(BIO *bp, const EVP_PKEY *x,
+                             const EVP_CIPHER *enc,
+                             const unsigned char *kstr, int klen,
                              pem_password_cb *cb, void *u)
 {
     if (x->ameth == NULL || x->ameth->priv_encode != NULL)
         return PEM_write_bio_PKCS8PrivateKey(bp, x, enc,
-                                             (char *)kstr, klen, cb, u);
+                                             (const char *)kstr, klen, cb, u);
     return PEM_write_bio_PrivateKey_traditional(bp, x, enc, kstr, klen, cb, u);
 }
 
-int PEM_write_bio_PrivateKey_traditional(BIO *bp, EVP_PKEY *x,
+int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
                                          const EVP_CIPHER *enc,
-                                         unsigned char *kstr, int klen,
+                                         const unsigned char *kstr, int klen,
                                          pem_password_cb *cb, void *u)
 {
     char pem_str[80];
@@ -111,7 +112,7 @@ EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x)
     return ret;
 }
 
-int PEM_write_bio_Parameters(BIO *bp, EVP_PKEY *x)
+int PEM_write_bio_Parameters(BIO *bp, const EVP_PKEY *x)
 {
     char pem_str[80];
     if (!x->ameth || !x->ameth->param_encode)
@@ -139,8 +140,8 @@ EVP_PKEY *PEM_read_PrivateKey(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
     return ret;
 }
 
-int PEM_write_PrivateKey(FILE *fp, EVP_PKEY *x, const EVP_CIPHER *enc,
-                         unsigned char *kstr, int klen,
+int PEM_write_PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
+                         const unsigned char *kstr, int klen,
                          pem_password_cb *cb, void *u)
 {
     BIO *b;

--- a/crypto/pem/pem_sign.c
+++ b/crypto/pem/pem_sign.c
@@ -19,7 +19,8 @@ int PEM_SignInit(EVP_MD_CTX *ctx, EVP_MD *type)
     return EVP_DigestInit_ex(ctx, type, NULL);
 }
 
-int PEM_SignUpdate(EVP_MD_CTX *ctx, unsigned char *data, unsigned int count)
+int PEM_SignUpdate(EVP_MD_CTX *ctx,
+                   const unsigned char *data, unsigned int count)
 {
     return EVP_DigestUpdate(ctx, data, count);
 }

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -424,7 +424,7 @@ static int check_bitlen_dsa(DSA *dsa, int ispub, unsigned int *magic);
 static void write_rsa(unsigned char **out, RSA *rsa, int ispub);
 static void write_dsa(unsigned char **out, DSA *dsa, int ispub);
 
-static int do_i2b(unsigned char **out, EVP_PKEY *pk, int ispub)
+static int do_i2b(unsigned char **out, const EVP_PKEY *pk, int ispub)
 {
     unsigned char *p;
     unsigned int bitlen, magic = 0, keyalg;
@@ -473,7 +473,7 @@ static int do_i2b(unsigned char **out, EVP_PKEY *pk, int ispub)
     return outlen;
 }
 
-static int do_i2b_bio(BIO *out, EVP_PKEY *pk, int ispub)
+static int do_i2b_bio(BIO *out, const EVP_PKEY *pk, int ispub)
 {
     unsigned char *tmp = NULL;
     int outlen, wrlen;
@@ -599,12 +599,12 @@ static void write_dsa(unsigned char **out, DSA *dsa, int ispub)
     return;
 }
 
-int i2b_PrivateKey_bio(BIO *out, EVP_PKEY *pk)
+int i2b_PrivateKey_bio(BIO *out, const EVP_PKEY *pk)
 {
     return do_i2b_bio(out, pk, 0);
 }
 
-int i2b_PublicKey_bio(BIO *out, EVP_PKEY *pk)
+int i2b_PublicKey_bio(BIO *out, const EVP_PKEY *pk)
 {
     return do_i2b_bio(out, pk, 1);
 }
@@ -780,7 +780,7 @@ EVP_PKEY *b2i_PVK_bio(BIO *in, pem_password_cb *cb, void *u)
     return ret;
 }
 
-static int i2b_PVK(unsigned char **out, EVP_PKEY *pk, int enclevel,
+static int i2b_PVK(unsigned char **out, const EVP_PKEY *pk, int enclevel,
                    pem_password_cb *cb, void *u)
 {
     int outlen = 24, pklen;
@@ -865,7 +865,7 @@ static int i2b_PVK(unsigned char **out, EVP_PKEY *pk, int enclevel,
     return -1;
 }
 
-int i2b_PVK_bio(BIO *out, EVP_PKEY *pk, int enclevel,
+int i2b_PVK_bio(BIO *out, const EVP_PKEY *pk, int enclevel,
                 pem_password_cb *cb, void *u)
 {
     unsigned char *tmp = NULL;

--- a/include/openssl/cms.h
+++ b/include/openssl/cms.h
@@ -91,7 +91,7 @@ int CMS_is_detached(CMS_ContentInfo *cms);
 int CMS_set_detached(CMS_ContentInfo *cms, int detached);
 
 # ifdef OPENSSL_PEM_H
-DECLARE_PEM_rw_const(CMS, CMS_ContentInfo)
+DECLARE_PEM_rw(CMS, CMS_ContentInfo)
 # endif
 int CMS_stream(unsigned char ***boundary, CMS_ContentInfo *cms);
 CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms);

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -70,94 +70,104 @@ extern "C" {
 
 #  define IMPLEMENT_PEM_read_fp(name, type, str, asn1) /**/
 #  define IMPLEMENT_PEM_write_fp(name, type, str, asn1) /**/
-#  define IMPLEMENT_PEM_write_fp_const(name, type, str, asn1) /**/
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define IMPLEMENT_PEM_write_fp_const(name, type, str, asn1) /**/
+#  endif
 #  define IMPLEMENT_PEM_write_cb_fp(name, type, str, asn1) /**/
-#  define IMPLEMENT_PEM_write_cb_fp_const(name, type, str, asn1) /**/
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define IMPLEMENT_PEM_write_cb_fp_const(name, type, str, asn1) /**/
+#  endif
 # else
 
-#  define IMPLEMENT_PEM_read_fp(name, type, str, asn1) \
-type *PEM_read_##name(FILE *fp, type **x, pem_password_cb *cb, void *u)\
-{ \
-return PEM_ASN1_read((d2i_of_void *)d2i_##asn1, str,fp,(void **)x,cb,u); \
-}
+#  define IMPLEMENT_PEM_read_fp(name, type, str, asn1)                  \
+    type *PEM_read_##name(FILE *fp, type **x, pem_password_cb *cb, void *u) \
+    {                                                                   \
+        return PEM_ASN1_read((d2i_of_void *)d2i_##asn1, str, fp,        \
+                             (void **)x, cb, u);                        \
+    }
 
-#  define IMPLEMENT_PEM_write_fp(name, type, str, asn1) \
-int PEM_write_##name(FILE *fp, type *x) \
-{ \
-return PEM_ASN1_write((i2d_of_void *)i2d_##asn1,str,fp,x,NULL,NULL,0,NULL,NULL); \
-}
+#  define IMPLEMENT_PEM_write_fp(name, type, str, asn1)                 \
+    int PEM_write_##name(FILE *fp, const type *x)                       \
+    {                                                                   \
+        return PEM_ASN1_write((i2d_of_void *)i2d_##asn1, str, fp,       \
+                              x, NULL, NULL, 0, NULL, NULL);            \
+    }
 
-#  define IMPLEMENT_PEM_write_fp_const(name, type, str, asn1) \
-int PEM_write_##name(FILE *fp, const type *x) \
-{ \
-return PEM_ASN1_write((i2d_of_void *)i2d_##asn1,str,fp,(void *)x,NULL,NULL,0,NULL,NULL); \
-}
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define IMPLEMENT_PEM_write_fp_const(name, type, str, asn1)  \
+    IMPLEMENT_PEM_write_fp(name, type, str, asn1)
+#  endif
 
-#  define IMPLEMENT_PEM_write_cb_fp(name, type, str, asn1) \
-int PEM_write_##name(FILE *fp, type *x, const EVP_CIPHER *enc, \
-             unsigned char *kstr, int klen, pem_password_cb *cb, \
-                  void *u) \
-        { \
-        return PEM_ASN1_write((i2d_of_void *)i2d_##asn1,str,fp,x,enc,kstr,klen,cb,u); \
-        }
+#  define IMPLEMENT_PEM_write_cb_fp(name, type, str, asn1)              \
+    int PEM_write_##name(FILE *fp, const type *x,                       \
+                         const EVP_CIPHER *enc,                         \
+                         const unsigned char *kstr, int klen,           \
+                         pem_password_cb *cb, void *u)                  \
+    {                                                                   \
+        return PEM_ASN1_write((i2d_of_void *)i2d_##asn1, str, fp,       \
+                              x, enc, kstr, klen, cb, u);               \
+    }
 
-#  define IMPLEMENT_PEM_write_cb_fp_const(name, type, str, asn1) \
-int PEM_write_##name(FILE *fp, type *x, const EVP_CIPHER *enc, \
-             unsigned char *kstr, int klen, pem_password_cb *cb, \
-                  void *u) \
-        { \
-        return PEM_ASN1_write((i2d_of_void *)i2d_##asn1,str,fp,x,enc,kstr,klen,cb,u); \
-        }
-
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define IMPLEMENT_PEM_write_cb_fp_const(name, type, str, asn1)       \
+    IMPLEMENT_PEM_write_cb_fp(name, type, str, asn1)
+#  endif
 # endif
 
-# define IMPLEMENT_PEM_read_bio(name, type, str, asn1) \
-type *PEM_read_bio_##name(BIO *bp, type **x, pem_password_cb *cb, void *u)\
-{ \
-return PEM_ASN1_read_bio((d2i_of_void *)d2i_##asn1, str,bp,(void **)x,cb,u); \
-}
+# define IMPLEMENT_PEM_read_bio(name, type, str, asn1)                  \
+    type *PEM_read_bio_##name(BIO *bp, type **x,                        \
+                              pem_password_cb *cb, void *u)             \
+    {                                                                   \
+        return PEM_ASN1_read_bio((d2i_of_void *)d2i_##asn1, str, bp,    \
+                                 (void **)x, cb, u);                    \
+    }
 
-# define IMPLEMENT_PEM_write_bio(name, type, str, asn1) \
-int PEM_write_bio_##name(BIO *bp, type *x) \
-{ \
-return PEM_ASN1_write_bio((i2d_of_void *)i2d_##asn1,str,bp,x,NULL,NULL,0,NULL,NULL); \
-}
+# define IMPLEMENT_PEM_write_bio(name, type, str, asn1)                 \
+    int PEM_write_bio_##name(BIO *bp, const type *x)                    \
+    {                                                                   \
+        return PEM_ASN1_write_bio((i2d_of_void *)i2d_##asn1, str, bp,   \
+                                  x, NULL,NULL,0,NULL,NULL);            \
+    }
 
-# define IMPLEMENT_PEM_write_bio_const(name, type, str, asn1) \
-int PEM_write_bio_##name(BIO *bp, const type *x) \
-{ \
-return PEM_ASN1_write_bio((i2d_of_void *)i2d_##asn1,str,bp,(void *)x,NULL,NULL,0,NULL,NULL); \
-}
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define IMPLEMENT_PEM_write_bio_const(name, type, str, asn1)   \
+    IMPLEMENT_PEM_write_bio(name, type, str, asn1)
+# endif
 
-# define IMPLEMENT_PEM_write_cb_bio(name, type, str, asn1) \
-int PEM_write_bio_##name(BIO *bp, type *x, const EVP_CIPHER *enc, \
-             unsigned char *kstr, int klen, pem_password_cb *cb, void *u) \
-        { \
-        return PEM_ASN1_write_bio((i2d_of_void *)i2d_##asn1,str,bp,x,enc,kstr,klen,cb,u); \
-        }
+# define IMPLEMENT_PEM_write_cb_bio(name, type, str, asn1)              \
+    int PEM_write_bio_##name(BIO *bp, const type *x,                    \
+                             const EVP_CIPHER *enc,                     \
+                             const unsigned char *kstr, int klen,       \
+                             pem_password_cb *cb, void *u)              \
+    {                                                                   \
+        return PEM_ASN1_write_bio((i2d_of_void *)i2d_##asn1, str, bp,   \
+                                  x, enc, kstr, klen, cb, u);           \
+    }
 
-# define IMPLEMENT_PEM_write_cb_bio_const(name, type, str, asn1) \
-int PEM_write_bio_##name(BIO *bp, type *x, const EVP_CIPHER *enc, \
-             unsigned char *kstr, int klen, pem_password_cb *cb, void *u) \
-        { \
-        return PEM_ASN1_write_bio((i2d_of_void *)i2d_##asn1,str,bp,(void *)x,enc,kstr,klen,cb,u); \
-        }
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define IMPLEMENT_PEM_write_cb_bio_const(name, type, str, asn1)  \
+    IMPLEMENT_PEM_write_cb_bio(name, type, str, asn1)
+# endif
 
 # define IMPLEMENT_PEM_write(name, type, str, asn1) \
         IMPLEMENT_PEM_write_bio(name, type, str, asn1) \
         IMPLEMENT_PEM_write_fp(name, type, str, asn1)
 
-# define IMPLEMENT_PEM_write_const(name, type, str, asn1) \
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define IMPLEMENT_PEM_write_const(name, type, str, asn1) \
         IMPLEMENT_PEM_write_bio_const(name, type, str, asn1) \
         IMPLEMENT_PEM_write_fp_const(name, type, str, asn1)
+# endif
 
 # define IMPLEMENT_PEM_write_cb(name, type, str, asn1) \
         IMPLEMENT_PEM_write_cb_bio(name, type, str, asn1) \
         IMPLEMENT_PEM_write_cb_fp(name, type, str, asn1)
 
-# define IMPLEMENT_PEM_write_cb_const(name, type, str, asn1) \
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define IMPLEMENT_PEM_write_cb_const(name, type, str, asn1) \
         IMPLEMENT_PEM_write_cb_bio_const(name, type, str, asn1) \
         IMPLEMENT_PEM_write_cb_fp_const(name, type, str, asn1)
+# endif
 
 # define IMPLEMENT_PEM_read(name, type, str, asn1) \
         IMPLEMENT_PEM_read_bio(name, type, str, asn1) \
@@ -167,9 +177,11 @@ int PEM_write_bio_##name(BIO *bp, type *x, const EVP_CIPHER *enc, \
         IMPLEMENT_PEM_read(name, type, str, asn1) \
         IMPLEMENT_PEM_write(name, type, str, asn1)
 
-# define IMPLEMENT_PEM_rw_const(name, type, str, asn1) \
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define IMPLEMENT_PEM_rw_const(name, type, str, asn1) \
         IMPLEMENT_PEM_read(name, type, str, asn1) \
         IMPLEMENT_PEM_write_const(name, type, str, asn1)
+# endif
 
 # define IMPLEMENT_PEM_rw_cb(name, type, str, asn1) \
         IMPLEMENT_PEM_read(name, type, str, asn1) \
@@ -181,44 +193,57 @@ int PEM_write_bio_##name(BIO *bp, type *x, const EVP_CIPHER *enc, \
 
 #  define DECLARE_PEM_read_fp(name, type) /**/
 #  define DECLARE_PEM_write_fp(name, type) /**/
-#  define DECLARE_PEM_write_fp_const(name, type) /**/
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define DECLARE_PEM_write_fp_const(name, type) /**/
+#  endif
 #  define DECLARE_PEM_write_cb_fp(name, type) /**/
 # else
 
-#  define DECLARE_PEM_read_fp(name, type) \
-        type *PEM_read_##name(FILE *fp, type **x, pem_password_cb *cb, void *u);
+#  define DECLARE_PEM_read_fp(name, type)                               \
+    type *PEM_read_##name(FILE *fp, type **x, pem_password_cb *cb, void *u);
 
-#  define DECLARE_PEM_write_fp(name, type) \
-        int PEM_write_##name(FILE *fp, type *x);
+#  define DECLARE_PEM_write_fp(name, type)              \
+    int PEM_write_##name(FILE *fp, const type *x);
 
-#  define DECLARE_PEM_write_fp_const(name, type) \
-        int PEM_write_##name(FILE *fp, const type *x);
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define DECLARE_PEM_write_fp_const(name, type)        \
+    DECLARE_PEM_write_fp(name, type)
+#  endif
 
-#  define DECLARE_PEM_write_cb_fp(name, type) \
-        int PEM_write_##name(FILE *fp, type *x, const EVP_CIPHER *enc, \
-             unsigned char *kstr, int klen, pem_password_cb *cb, void *u);
+#  define DECLARE_PEM_write_cb_fp(name, type)                   \
+    int PEM_write_##name(FILE *fp, const type *x,               \
+                         const EVP_CIPHER *enc,                 \
+                         const unsigned char *kstr, int klen,   \
+                         pem_password_cb *cb, void *u);
 
 # endif
 
-#  define DECLARE_PEM_read_bio(name, type) \
-        type *PEM_read_bio_##name(BIO *bp, type **x, pem_password_cb *cb, void *u);
+#  define DECLARE_PEM_read_bio(name, type)                      \
+    type *PEM_read_bio_##name(BIO *bp, type **x,                \
+                              pem_password_cb *cb, void *u);
 
-#  define DECLARE_PEM_write_bio(name, type) \
-        int PEM_write_bio_##name(BIO *bp, type *x);
+#  define DECLARE_PEM_write_bio(name, type)             \
+    int PEM_write_bio_##name(BIO *bp, const type *x);
 
-#  define DECLARE_PEM_write_bio_const(name, type) \
-        int PEM_write_bio_##name(BIO *bp, const type *x);
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define DECLARE_PEM_write_bio_const(name, type)       \
+    DECLARE_PEM_write_bio(name, type)
+#  endif
 
-#  define DECLARE_PEM_write_cb_bio(name, type) \
-        int PEM_write_bio_##name(BIO *bp, type *x, const EVP_CIPHER *enc, \
-             unsigned char *kstr, int klen, pem_password_cb *cb, void *u);
+#  define DECLARE_PEM_write_cb_bio(name, type)                          \
+    int PEM_write_bio_##name(BIO *bp, const type *x,                    \
+                             const EVP_CIPHER *enc,                     \
+                             const unsigned char *kstr, int klen,       \
+                             pem_password_cb *cb, void *u);
 
 # define DECLARE_PEM_write(name, type) \
         DECLARE_PEM_write_bio(name, type) \
         DECLARE_PEM_write_fp(name, type)
-# define DECLARE_PEM_write_const(name, type) \
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define DECLARE_PEM_write_const(name, type) \
         DECLARE_PEM_write_bio_const(name, type) \
         DECLARE_PEM_write_fp_const(name, type)
+# endif
 # define DECLARE_PEM_write_cb(name, type) \
         DECLARE_PEM_write_cb_bio(name, type) \
         DECLARE_PEM_write_cb_fp(name, type)
@@ -228,9 +253,11 @@ int PEM_write_bio_##name(BIO *bp, type *x, const EVP_CIPHER *enc, \
 # define DECLARE_PEM_rw(name, type) \
         DECLARE_PEM_read(name, type) \
         DECLARE_PEM_write(name, type)
-# define DECLARE_PEM_rw_const(name, type) \
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define DECLARE_PEM_rw_const(name, type) \
         DECLARE_PEM_read(name, type) \
         DECLARE_PEM_write_const(name, type)
+# endif
 # define DECLARE_PEM_rw_cb(name, type) \
         DECLARE_PEM_read(name, type) \
         DECLARE_PEM_write_cb(name, type)
@@ -257,14 +284,15 @@ int PEM_bytes_read_bio(unsigned char **pdata, long *plen, char **pnm,
                        void *u);
 void *PEM_ASN1_read_bio(d2i_of_void *d2i, const char *name, BIO *bp, void **x,
                         pem_password_cb *cb, void *u);
-int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp, void *x,
-                       const EVP_CIPHER *enc, unsigned char *kstr, int klen,
+int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp,
+                       const void *x, const EVP_CIPHER *enc,
+                       const unsigned char *kstr, int klen,
                        pem_password_cb *cb, void *u);
 
 STACK_OF(X509_INFO) *PEM_X509_INFO_read_bio(BIO *bp, STACK_OF(X509_INFO) *sk,
                                             pem_password_cb *cb, void *u);
-int PEM_X509_INFO_write_bio(BIO *bp, X509_INFO *xi, EVP_CIPHER *enc,
-                            unsigned char *kstr, int klen,
+int PEM_X509_INFO_write_bio(BIO *bp, const X509_INFO *xi, EVP_CIPHER *enc,
+                            const unsigned char *kstr, int klen,
                             pem_password_cb *cd, void *u);
 
 #ifndef OPENSSL_NO_STDIO
@@ -275,21 +303,22 @@ int PEM_write(FILE *fp, const char *name, const char *hdr,
 void *PEM_ASN1_read(d2i_of_void *d2i, const char *name, FILE *fp, void **x,
                     pem_password_cb *cb, void *u);
 int PEM_ASN1_write(i2d_of_void *i2d, const char *name, FILE *fp,
-                   void *x, const EVP_CIPHER *enc, unsigned char *kstr,
-                   int klen, pem_password_cb *callback, void *u);
+                   const void *x, const EVP_CIPHER *enc,
+                   const unsigned char *kstr, int klen,
+                   pem_password_cb *callback, void *u);
 STACK_OF(X509_INFO) *PEM_X509_INFO_read(FILE *fp, STACK_OF(X509_INFO) *sk,
                                         pem_password_cb *cb, void *u);
 #endif
 
 int PEM_SignInit(EVP_MD_CTX *ctx, EVP_MD *type);
-int PEM_SignUpdate(EVP_MD_CTX *ctx, unsigned char *d, unsigned int cnt);
+int PEM_SignUpdate(EVP_MD_CTX *ctx, const unsigned char *d, unsigned int cnt);
 int PEM_SignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
                   unsigned int *siglen, EVP_PKEY *pkey);
 
 /* The default pem_password_cb that's used internally */
 int PEM_def_callback(char *buf, int num, int rwflag, void *userdata);
 void PEM_proc_type(char *buf, int type);
-void PEM_dek_info(char *buf, const char *type, int len, char *str);
+void PEM_dek_info(char *buf, const char *type, int len, const char *str);
 
 # include <openssl/symhacks.h>
 
@@ -304,76 +333,78 @@ DECLARE_PEM_rw(PKCS8, X509_SIG)
 DECLARE_PEM_rw(PKCS8_PRIV_KEY_INFO, PKCS8_PRIV_KEY_INFO)
 # ifndef OPENSSL_NO_RSA
 DECLARE_PEM_rw_cb(RSAPrivateKey, RSA)
-DECLARE_PEM_rw_const(RSAPublicKey, RSA)
+DECLARE_PEM_rw(RSAPublicKey, RSA)
 DECLARE_PEM_rw(RSA_PUBKEY, RSA)
 # endif
 # ifndef OPENSSL_NO_DSA
 DECLARE_PEM_rw_cb(DSAPrivateKey, DSA)
 DECLARE_PEM_rw(DSA_PUBKEY, DSA)
-DECLARE_PEM_rw_const(DSAparams, DSA)
+DECLARE_PEM_rw(DSAparams, DSA)
 # endif
 # ifndef OPENSSL_NO_EC
-DECLARE_PEM_rw_const(ECPKParameters, EC_GROUP)
+DECLARE_PEM_rw(ECPKParameters, EC_GROUP)
 DECLARE_PEM_rw_cb(ECPrivateKey, EC_KEY)
 DECLARE_PEM_rw(EC_PUBKEY, EC_KEY)
 # endif
 # ifndef OPENSSL_NO_DH
-DECLARE_PEM_rw_const(DHparams, DH)
-DECLARE_PEM_write_const(DHxparams, DH)
+DECLARE_PEM_rw(DHparams, DH)
+DECLARE_PEM_write(DHxparams, DH)
 # endif
 DECLARE_PEM_rw_cb(PrivateKey, EVP_PKEY)
 DECLARE_PEM_rw(PUBKEY, EVP_PKEY)
 
-int PEM_write_bio_PrivateKey_traditional(BIO *bp, EVP_PKEY *x,
+int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
                                          const EVP_CIPHER *enc,
-                                         unsigned char *kstr, int klen,
+                                         const unsigned char *kstr, int klen,
                                          pem_password_cb *cb, void *u);
 
+/* Why do these take a signed char *kstr? */
 int PEM_write_bio_PKCS8PrivateKey_nid(BIO *bp, const EVP_PKEY *x, int nid,
-                                      char *kstr, int klen,
+                                      const char *kstr, int klen,
                                       pem_password_cb *cb, void *u);
 int PEM_write_bio_PKCS8PrivateKey(BIO *, const EVP_PKEY *, const EVP_CIPHER *,
-                                  char *, int, pem_password_cb *, void *);
+                                  const char *kstr, int klen,
+                                  pem_password_cb *cb, void *u);
 int i2d_PKCS8PrivateKey_bio(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                            char *kstr, int klen,
+                            const char *kstr, int klen,
                             pem_password_cb *cb, void *u);
 int i2d_PKCS8PrivateKey_nid_bio(BIO *bp, const EVP_PKEY *x, int nid,
-                                char *kstr, int klen,
+                                const char *kstr, int klen,
                                 pem_password_cb *cb, void *u);
 EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
                                   void *u);
 
 # ifndef OPENSSL_NO_STDIO
 int i2d_PKCS8PrivateKey_fp(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                           char *kstr, int klen,
+                           const char *kstr, int klen,
                            pem_password_cb *cb, void *u);
 int i2d_PKCS8PrivateKey_nid_fp(FILE *fp, const EVP_PKEY *x, int nid,
-                               char *kstr, int klen,
+                               const char *kstr, int klen,
                                pem_password_cb *cb, void *u);
 int PEM_write_PKCS8PrivateKey_nid(FILE *fp, const EVP_PKEY *x, int nid,
-                                  char *kstr, int klen,
+                                  const char *kstr, int klen,
                                   pem_password_cb *cb, void *u);
 
 EVP_PKEY *d2i_PKCS8PrivateKey_fp(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
                                  void *u);
 
 int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                              char *kstr, int klen, pem_password_cb *cd,
-                              void *u);
+                              const char *kstr, int klen,
+                              pem_password_cb *cd, void *u);
 # endif
 EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x);
-int PEM_write_bio_Parameters(BIO *bp, EVP_PKEY *x);
+int PEM_write_bio_Parameters(BIO *bp, const EVP_PKEY *x);
 
 # ifndef OPENSSL_NO_DSA
 EVP_PKEY *b2i_PrivateKey(const unsigned char **in, long length);
 EVP_PKEY *b2i_PublicKey(const unsigned char **in, long length);
 EVP_PKEY *b2i_PrivateKey_bio(BIO *in);
 EVP_PKEY *b2i_PublicKey_bio(BIO *in);
-int i2b_PrivateKey_bio(BIO *out, EVP_PKEY *pk);
-int i2b_PublicKey_bio(BIO *out, EVP_PKEY *pk);
+int i2b_PrivateKey_bio(BIO *out, const EVP_PKEY *pk);
+int i2b_PublicKey_bio(BIO *out, const EVP_PKEY *pk);
 #  ifndef OPENSSL_NO_RC4
 EVP_PKEY *b2i_PVK_bio(BIO *in, pem_password_cb *cb, void *u);
-int i2b_PVK_bio(BIO *out, EVP_PKEY *pk, int enclevel,
+int i2b_PVK_bio(BIO *out, const EVP_PKEY *pk, int enclevel,
                 pem_password_cb *cb, void *u);
 #  endif
 # endif


### PR DESCRIPTION
There's no reason why the object to be written, or the key string
given by the caller should be non-const.

This makes the `IMPLEMENT_PEM_..._const` and `DECLARE_PEM_..._const`
macros superfluous, so we keep them around but mark them deprecated.

In all places where `IMPLEMENT_PEM_..._const` and `DECLARE_PEM_..._const`
are used, they are replaced with the corresponding macros without
`_const`.
