### PR TITLE
s390x assembly pack: fix bn_mul_comba4

### DIFF
--- a/crypto/bn/asm/s390x.S
+++ b/crypto/bn/asm/s390x.S
@@ -511,7 +511,7 @@ bn_mul_comba4:
 	lghi	zero,0
 
 	mul_add_c(0,0,c1,c2,c3);
-	stg	c1,0*8(%r3)
+	stg	c1,0*8(%r2)
 	lghi	c1,0
 
 	mul_add_c(0,1,c2,c3,c1);


### PR DESCRIPTION
looks like it is never called though: Only place where its not #if 0 -ed is in bn_mul_recursive which is inside #ifdef BN_RECURSION which is never defined as far as i can tell.
