### PR TITLE
WIP: AESNI based DRBG CTR

### DIFF
--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -12,6 +12,8 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include "crypto/modes.h"
+#include "crypto/ciphermode_platform.h"
 #include "internal/thread_once.h"
 #include "rand_local.h"
 
@@ -30,6 +32,32 @@ static void inc_128(RAND_DRBG_CTR *ctr)
         *p = c;
         if (c != 0) {
             /* If we didn't wrap around, we're done. */
+            break;
+        }
+    }
+}
+
+static size_t inc_8_by_value(unsigned char *p, size_t value)
+{
+    size_t result;
+
+    result = *p + value;
+    *p = result % 256;
+    return result / 256;
+}
+
+static void inc_128_by_value(RAND_DRBG_CTR *ctr, size_t value)
+{
+    int i;
+    unsigned char *p = &ctr->V[15];
+    unsigned int carry = 0, next_carry;
+
+    for (i = 0; i < 16; i++, p--) {
+        next_carry = inc_8_by_value(p, value & 0xFF);
+        if (carry != 0)
+            next_carry += inc_8_by_value(p, carry);
+        /* Break when both carry and value becomes zero */
+        if ((carry = next_carry) == 0 && (value = value >> 8) == 0) {
             break;
         }
     }
@@ -72,9 +100,12 @@ __owur static int ctr_BCC_block(RAND_DRBG_CTR *ctr, unsigned char *out,
     for (i = 0; i < 16; i++)
         out[i] ^= in[i];
 
-    if (!EVP_CipherUpdate(ctr->ctx_df, out, &outlen, out, AES_BLOCK_SIZE)
-        || outlen != AES_BLOCK_SIZE)
-        return 0;
+    if (ctr->block128 != NULL)
+        ctr->block128(out, out, &ctr->ks_df);
+    else
+        if (!EVP_CipherUpdate(ctr->ctx_df, out, &outlen, out, AES_BLOCK_SIZE)
+            || outlen != AES_BLOCK_SIZE)
+            return 0;
     return 1;
 }
 
@@ -218,6 +249,53 @@ __owur static int ctr_df(RAND_DRBG_CTR *ctr,
     return 1;
 }
 
+__owur static int ctr_aesni_df(RAND_DRBG_CTR *ctr,
+                         const unsigned char *in1, size_t in1len,
+                         const unsigned char *in2, size_t in2len,
+                         const unsigned char *in3, size_t in3len)
+{
+    static unsigned char c80 = 0x80;
+    size_t inlen;
+    unsigned char *p = ctr->bltmp;
+
+    if (!ctr_BCC_init(ctr))
+        return 0;
+    if (in1 == NULL)
+        in1len = 0;
+    if (in2 == NULL)
+        in2len = 0;
+    if (in3 == NULL)
+        in3len = 0;
+    inlen = in1len + in2len + in3len;
+    /* Initialise L||N in temporary block */
+    *p++ = (inlen >> 24) & 0xff;
+    *p++ = (inlen >> 16) & 0xff;
+    *p++ = (inlen >> 8) & 0xff;
+    *p++ = inlen & 0xff;
+
+    /* NB keylen is at most 32 bytes */
+    *p++ = 0;
+    *p++ = 0;
+    *p++ = 0;
+    *p = (unsigned char)((ctr->keylen + 16) & 0xff);
+    ctr->bltmp_pos = 8;
+    if (!ctr_BCC_update(ctr, in1, in1len)
+        || !ctr_BCC_update(ctr, in2, in2len)
+        || !ctr_BCC_update(ctr, in3, in3len)
+        || !ctr_BCC_update(ctr, &c80, 1)
+        || !ctr_BCC_final(ctr))
+        return 0;
+    /* Set up key K */
+    if (aesni_set_encrypt_key(ctr->KX, ctr->keylen * 8, &ctr->ks) < 0)
+        return 0;
+    /* X follows key K */
+    ctr->block128(ctr->KX + ctr->keylen, ctr->KX, &ctr->ks);
+    ctr->block128(ctr->KX, ctr->KX + 16, &ctr->ks);
+    if (ctr->keylen != 16)
+        ctr->block128(ctr->KX + 16, ctr->KX + 32, &ctr->ks);
+    return 1;
+}
+
 /*
  * NB the no-df Update in SP800-90A specifies a constant input length
  * of seedlen, however other uses of this algorithm pad the input with
@@ -274,6 +352,49 @@ __owur static int ctr_update(RAND_DRBG *drbg,
         return 0;
     return 1;
 }
+__owur static int ctr_aesni_update(RAND_DRBG *drbg,
+                             const unsigned char *in1, size_t in1len,
+                             const unsigned char *in2, size_t in2len,
+                             const unsigned char *nonce, size_t noncelen)
+{
+    RAND_DRBG_CTR *ctr = &drbg->data.ctr;
+
+    /* correct key is already set up. */
+    inc_128_by_value(ctr, 1);
+    ctr->block128(ctr->V, ctr->K, &ctr->ks);
+
+    /* If keylen longer than 128 bits need extra encrypt */
+    if (ctr->keylen != 16) {
+        inc_128_by_value(ctr, 1);
+        ctr->block128(ctr->V, ctr->K + 16, &ctr->ks);
+    }
+    inc_128_by_value(ctr, 1);
+    ctr->block128(ctr->V, ctr->V, &ctr->ks);
+
+    /* If 192 bit key part of V is on end of K */
+    if (ctr->keylen == 24) {
+        memcpy(ctr->V + 8, ctr->V, 8);
+        memcpy(ctr->V, ctr->K + 24, 8);
+    }
+
+    if ((drbg->flags & RAND_DRBG_FLAG_CTR_NO_DF) == 0) {
+        /* If no input reuse existing derived value */
+        if (in1 != NULL || nonce != NULL || in2 != NULL)
+            if (!ctr_aesni_df(ctr, in1, in1len, nonce, noncelen, in2, in2len))
+                return 0;
+        /* If this a reuse input in1len != 0 */
+        if (in1len)
+            ctr_XOR(ctr, ctr->KX, drbg->seedlen);
+    } else {
+        ctr_XOR(ctr, in1, in1len);
+        ctr_XOR(ctr, in2, in2len);
+    }
+
+    if (aesni_set_encrypt_key(ctr->K, ctr->keylen * 8, &ctr->ks) < 0)
+        return 0;
+
+    return 1;
+}
 
 __owur static int drbg_ctr_instantiate(RAND_DRBG *drbg,
                                        const unsigned char *entropy, size_t entropylen,
@@ -294,6 +415,25 @@ __owur static int drbg_ctr_instantiate(RAND_DRBG *drbg,
     return 1;
 }
 
+__owur static int drbg_ctr_aesni_instantiate(RAND_DRBG *drbg,
+                                       const unsigned char *entropy, size_t entropylen,
+                                       const unsigned char *nonce, size_t noncelen,
+                                       const unsigned char *pers, size_t perslen)
+{
+    RAND_DRBG_CTR *ctr = &drbg->data.ctr;
+
+    if (entropy == NULL)
+        return 0;
+
+    memset(ctr->K, 0, sizeof(ctr->K));
+    memset(ctr->V, 0, sizeof(ctr->V));
+    if (aesni_set_encrypt_key(ctr->K, ctr->keylen * 8, &ctr->ks) < 0)
+        return 0;
+    if (!ctr_aesni_update(drbg, entropy, entropylen, pers, perslen, nonce, noncelen))
+        return 0;
+    return 1;
+}
+
 __owur static int drbg_ctr_reseed(RAND_DRBG *drbg,
                                   const unsigned char *entropy, size_t entropylen,
                                   const unsigned char *adin, size_t adinlen)
@@ -301,6 +441,17 @@ __owur static int drbg_ctr_reseed(RAND_DRBG *drbg,
     if (entropy == NULL)
         return 0;
     if (!ctr_update(drbg, entropy, entropylen, adin, adinlen, NULL, 0))
+        return 0;
+    return 1;
+}
+
+__owur static int drbg_ctr_aesni_reseed(RAND_DRBG *drbg,
+                                  const unsigned char *entropy, size_t entropylen,
+                                  const unsigned char *adin, size_t adinlen)
+{
+    if (entropy == NULL)
+        return 0;
+    if (!ctr_aesni_update(drbg, entropy, entropylen, adin, adinlen, NULL, 0))
         return 0;
     return 1;
 }
@@ -350,11 +501,62 @@ __owur static int drbg_ctr_generate(RAND_DRBG *drbg,
     return 1;
 }
 
+__owur static int drbg_ctr_aesni_generate(RAND_DRBG *drbg,
+                                    unsigned char *out, size_t outlen,
+                                    const unsigned char *adin, size_t adinlen)
+{
+    RAND_DRBG_CTR *ctr = &drbg->data.ctr;
+    uint8_t tmp[AES_BLOCK_SIZE];
+    size_t blocks;
+
+    if (adin != NULL && adinlen != 0) {
+        if (!ctr_aesni_update(drbg, adin, adinlen, NULL, 0, NULL, 0))
+            return 0;
+        /* This means we reuse derived value */
+        if ((drbg->flags & RAND_DRBG_FLAG_CTR_NO_DF) == 0) {
+            adin = NULL;
+            adinlen = 1;
+        }
+    } else {
+        adinlen = 0;
+    }
+
+    while (outlen >= AES_BLOCK_SIZE) {
+        blocks = outlen / AES_BLOCK_SIZE;
+        if (sizeof(size_t) > sizeof(unsigned int) && blocks > (1U << 28))
+            blocks = (1U << 28);
+
+        /* TODO Current implementation passes Nonce as input data */
+        /* Need to check is it really needed */
+        ctr->ctr128(out, out, blocks, &ctr->ks, ctr->V);
+        inc_128_by_value(ctr, blocks);
+        blocks *= AES_BLOCK_SIZE;
+        out += blocks;
+        outlen -= blocks;
+    }
+
+    if (outlen != 0) {
+        inc_128_by_value(ctr, 1);
+        ctr->block128(ctr->V, tmp, &ctr->ks);
+        memcpy(out, tmp, outlen);
+    }
+
+    if (!ctr_aesni_update(drbg, adin, adinlen, NULL, 0, NULL, 0))
+        return 0;
+    return 1;
+}
+
 static int drbg_ctr_uninstantiate(RAND_DRBG *drbg)
 {
     EVP_CIPHER_CTX_free(drbg->data.ctr.ctx);
     EVP_CIPHER_CTX_free(drbg->data.ctr.ctx_df);
     EVP_CIPHER_free(drbg->data.ctr.cipher);
+    OPENSSL_cleanse(&drbg->data.ctr, sizeof(drbg->data.ctr));
+    return 1;
+}
+
+static int drbg_ctr_aesni_uninstantiate(RAND_DRBG *drbg)
+{
     OPENSSL_cleanse(&drbg->data.ctr, sizeof(drbg->data.ctr));
     return 1;
 }
@@ -422,6 +624,82 @@ int drbg_ctr_init(RAND_DRBG *drbg)
         if (!EVP_CipherInit_ex(ctr->ctx_df, ctr->cipher, NULL, df_key, NULL, 1))
             return 0;
 
+        drbg->min_entropylen = ctr->keylen;
+        drbg->max_entropylen = DRBG_MAX_LENGTH;
+        drbg->min_noncelen = drbg->min_entropylen / 2;
+        drbg->max_noncelen = DRBG_MAX_LENGTH;
+        drbg->max_perslen = DRBG_MAX_LENGTH;
+        drbg->max_adinlen = DRBG_MAX_LENGTH;
+    } else {
+#ifdef FIPS_MODE
+        RANDerr(RAND_F_DRBG_CTR_INIT,
+                RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS);
+        return 0;
+#else
+        drbg->min_entropylen = drbg->seedlen;
+        drbg->max_entropylen = drbg->seedlen;
+        /* Nonce not used */
+        drbg->min_noncelen = 0;
+        drbg->max_noncelen = 0;
+        drbg->max_perslen = drbg->seedlen;
+        drbg->max_adinlen = drbg->seedlen;
+#endif
+    }
+
+    drbg->max_request = 1 << 16;
+
+    return 1;
+}
+
+static RAND_DRBG_METHOD drbg_ctr_aesni_meth = {
+    drbg_ctr_aesni_instantiate,
+    drbg_ctr_aesni_reseed,
+    drbg_ctr_aesni_generate,
+    drbg_ctr_aesni_uninstantiate
+};
+
+int drbg_ctr_aesni_init(RAND_DRBG *drbg)
+{
+    RAND_DRBG_CTR *ctr = &drbg->data.ctr;
+    size_t keylen;
+
+    switch (drbg->type) {
+    default:
+        /* This can't happen, but silence the compiler warning. */
+        return 0;
+    case NID_aes_128_ctr:
+        keylen = 16;
+        break;
+    case NID_aes_192_ctr:
+        keylen = 24;
+        break;
+    case NID_aes_256_ctr:
+        keylen = 32;
+        break;
+    }
+    ctr->ctr128 = aesni_ctr32_encrypt_blocks;
+    ctr->block128 = (block128_f)aesni_encrypt;
+    ctr->type = drbg->type;
+
+    drbg->meth = &drbg_ctr_aesni_meth;
+
+    ctr->keylen = keylen;
+
+    drbg->strength = keylen * 8;
+    drbg->seedlen = keylen + 16;
+
+    if ((drbg->flags & RAND_DRBG_FLAG_CTR_NO_DF) == 0) {
+        /* df initialisation */
+        static const unsigned char df_key[32] = {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+            0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+            0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+        };
+
+        /* Set key schedule for df_key */
+        if (aesni_set_encrypt_key(df_key, ctr->keylen * 8, &ctr->ks_df) < 0)
+            return 0;
         drbg->min_entropylen = ctr->keylen;
         drbg->max_entropylen = DRBG_MAX_LENGTH;
         drbg->min_noncelen = drbg->min_entropylen / 2;

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -336,7 +336,9 @@ int RAND_DRBG_set(RAND_DRBG *drbg, int type, unsigned int flags)
         drbg->meth = NULL;
         return 1;
     } else if (is_ctr(type)) {
-        ret = drbg_ctr_init(drbg);
+        //ret = drbg_ctr_init(drbg);
+        /* TODO Need to check and call aesni */
+        ret = drbg_ctr_aesni_init(drbg);
     } else if (is_digest(type)) {
         if (flags & RAND_DRBG_FLAG_HMAC)
             ret = drbg_hmac_init(drbg);

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -16,6 +16,7 @@
 # include <openssl/hmac.h>
 # include <openssl/ec.h>
 # include <openssl/rand_drbg.h>
+# include <openssl/modes.h>
 # include "internal/tsan_assist.h"
 # include "crypto/rand.h"
 
@@ -175,9 +176,14 @@ typedef struct rand_drbg_hmac_st {
  * The state of a DRBG AES-CTR.
  */
 typedef struct rand_drbg_ctr_st {
+    int type;
     EVP_CIPHER_CTX *ctx;
     EVP_CIPHER_CTX *ctx_df;
     EVP_CIPHER *cipher;
+    ctr128_f ctr128;
+    block128_f block128;
+    AES_KEY ks;
+    AES_KEY ks_df;
     size_t keylen;
     unsigned char K[32];
     unsigned char V[16];
@@ -343,6 +349,7 @@ int rand_drbg_enable_locking(RAND_DRBG *drbg);
 
 /* initializes the DRBG implementation */
 int drbg_ctr_init(RAND_DRBG *drbg);
+int drbg_ctr_aesni_init(RAND_DRBG *drbg);
 int drbg_hash_init(RAND_DRBG *drbg);
 int drbg_hmac_init(RAND_DRBG *drbg);
 


### PR DESCRIPTION
Current DRBG CTR rand performs each block by block, changing that to use AESNI based multi block CTR operation gives better performance on rand generation.This inturn helps in improving some of the ECDSA curves (P224, P256) sign operation which invokes random nonce generation.

Improvement in performance measured using `speed` app are listed below

Operations | Base Perf | Perf with Changes
---------- | --------- | -----------------
 16 bytes rand gen | 2 MB/s | 17 MB/s
 64 bytes rand gen | 9 MB/s | 71 MB/s
 256 bytes rand gen | 28 MB/s | 271 MB/s
 1024 bytes rand gen | 52 MB/s | 888 MB/s
 P224 sign | 2346 op/s | 2441 op/s
 P224 verify | 2858 op/s | 2942 op/s
 P256 sign | 27487 op/s | 32717 op/s
 P256 verify | 10422 op/s | 10492 op/s
 P384 sign | 927 op/s | 938 op/s
 P384 verify | 1242 op/s | 1219 op/s
 P521 sign | 394 op/s | 394 op/s
 P521 verify | 553 op/s | 551 op/s

This performance is measured on a ubuntu 18.04 x86_64 PC.