### PR TITLE
Remove handling of outdated macro's

### DIFF
--- a/include/openssl/asn1.h
+++ b/include/openssl/asn1.h
@@ -276,7 +276,8 @@ typedef struct ASN1_VALUE_st ASN1_VALUE;
 # define TYPEDEF_I2D_OF(type) typedef int i2d_of_##type(const type *,unsigned char **)
 # define TYPEDEF_D2I2D_OF(type) TYPEDEF_D2I_OF(type); TYPEDEF_I2D_OF(type)
 
-TYPEDEF_D2I2D_OF(void);
+typedef void *d2i_of_void(void **, const unsigned char **, long);
+typedef int i2d_of_void(const void *, unsigned char **);
 
 /*-
  * The following macros and typedefs allow an ASN1_ITEM

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -321,7 +321,7 @@ while ( ( my $hdr, my $lib ) = each %libinc ) {
         s/[\n\s]*$//g;
 
         # Skip over recognized non-function declarations
-        next if /typedef\W/ or /DECLARE_STACK_OF/ or /TYPEDEF_.*_OF/;
+        next if /typedef\W/;
 
         # Remove STACK_OF(foo)
         s/STACK_OF\(\w+\)/void/;

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -372,34 +372,9 @@ EOF
     { regexp   => qr/DEFINE_STACK_OF_CONST<<<\((.*)\)>>>/,
       massager => sub { return ("SKM_DEFINE_STACK_OF($1,const $1,$1)"); },
     },
-    { regexp   => qr/PREDECLARE_STACK_OF<<<\((.*)\)>>>/,
-      massager => sub { return ("STACK_OF($1);"); }
-    },
-    { regexp   => qr/DECLARE_STACK_OF<<<\((.*)\)>>>/,
-      massager => sub { return ("STACK_OF($1);"); }
-    },
-    { regexp   => qr/DECLARE_SPECIAL_STACK_OF<<<\((.*?),\s*(.*?)\)>>>/,
-      massager => sub { return ("STACK_OF($1);"); }
-     },
 
     #####
     # ASN1 stuff
-
-    { regexp   => qr/TYPEDEF_D2I_OF<<<\((.*)\)>>>/,
-      massager => sub {
-          return ("typedef $1 *d2i_of_$1($1 **,const unsigned char **,long)");
-      },
-    },
-    { regexp   => qr/TYPEDEF_I2D_OF<<<\((.*)\)>>>/,
-      massager => sub {
-          return ("typedef $1 *i2d_of_$1($1 *,unsigned char **)");
-      },
-    },
-    { regexp   => qr/TYPEDEF_D2I2D_OF<<<\((.*)\)>>>/,
-      massager => sub {
-          return ("TYPEDEF_D2I_OF($1); TYPEDEF_I2D_OF($1)");
-      },
-    },
     { regexp   => qr/DECLARE_ASN1_ITEM<<<\((.*)\)>>>/,
       massager => sub {
           return (<<"EOF");


### PR DESCRIPTION
code cleanup.  could probably be backported.
