### PR TITLE
Finalize dynamic engines before OpenSSL tool execution's end

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -55,6 +55,7 @@ static int apps_startup(void)
 
     /* Set non-default library initialisation settings */
     if (!OPENSSL_init_ssl(OPENSSL_INIT_ENGINE_ALL_BUILTIN
+                          | OPENSSL_INIT_NO_ATEXIT
                           | OPENSSL_INIT_LOAD_CONFIG, NULL))
         return 0;
 
@@ -376,6 +377,7 @@ int main(int argc, char *argv[])
         ret = 1;
 #endif
     BIO_free(bio_err);
+    OPENSSL_cleanup();
     EXIT(ret);
 }
 


### PR DESCRIPTION
OpenSSL calls cleanup functions in atexit() fuction by default for
libraries which were freed by OS to this moment. This lead to double free
in some legal cases such as calling free() for memory which was allocated
in initialization routine with malloc().

Fixes: #9581
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
