### PR TITLE
Engine: Add NULL check.

### DIFF
--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -147,7 +147,8 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_get_pkey_asn1_meth_str(ENGINE *e,
     nidcount = e->pkey_asn1_meths(e, NULL, &nids, 0);
     for (i = 0; i < nidcount; i++) {
         e->pkey_asn1_meths(e, &ameth, NULL, nids[i]);
-        if (((int)strlen(ameth->pem_str) == len)
+        if (ameth != NULL
+            && ((int)strlen(ameth->pem_str) == len)
             && strncasecmp(ameth->pem_str, str, len) == 0)
             return ameth;
     }


### PR DESCRIPTION
Add NULL check for return from pkey_asn1_meths.

Fixes #10405

