### PR TITLE
EVP p_lib: Add NULL check to EVP_PKEY_missing_parameters.

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -105,7 +105,7 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 
 int EVP_PKEY_missing_parameters(const EVP_PKEY *pkey)
 {
-    if (pkey->ameth && pkey->ameth->param_missing)
+    if (pkey != NULL && pkey->ameth && pkey->ameth->param_missing)
         return pkey->ameth->param_missing(pkey);
     return 0;
 }


### PR DESCRIPTION
Check for NULL and return error if so.
This can possibly be called from `apps/ca.c` with a NULL argument.

Fixes #10404
