### PR TITLE
ECDSA: don't clear free memory after verify.

### DIFF
--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -344,7 +344,7 @@ int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
         goto err;
     ret = ECDSA_do_verify(dgst, dgst_len, s, eckey);
  err:
-    OPENSSL_clear_free(der, derlen);
+    OPENSSL_free(der);
     ECDSA_SIG_free(s);
     return ret;
 }


### PR DESCRIPTION
Verifications are public, there is no need to clear the used storage before
freeing it.

Fixes #10406
