### PR TITLE
PROV: check for memory allocation failure in digest _dupctx.

### DIFF
--- a/providers/common/include/prov/digestcommon.h
+++ b/providers/common/include/prov/digestcommon.h
@@ -49,7 +49,8 @@ static void *name##_dupctx(void *ctx)                                          \
 {                                                                              \
     CTX *in = (CTX *)ctx;                                                      \
     CTX *ret = OPENSSL_malloc(sizeof(*ret));                                   \
-    *ret = *in;                                                                \
+    if (ret != NULL)                                                           \
+        *ret = *in;                                                            \
     return ret;                                                                \
 }                                                                              \
 static OSSL_OP_digest_final_fn name##_internal_final;                          \

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -241,7 +241,8 @@ static void *keccak_dupctx(void *ctx)
     KECCAK1600_CTX *in = (KECCAK1600_CTX *)ctx;
     KECCAK1600_CTX *ret = OPENSSL_malloc(sizeof(*ret));
 
-    *ret = *in;
+    if (ret != NULL)
+        *ret = *in;
     return ret;
 }
 


### PR DESCRIPTION
Fixes #10481

