### PR TITLE
rand_lib.c: fix null pointer dereferences after RAND_get_rand_method() failure [1.1.1]

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1027,6 +1027,7 @@ RAND_F_RAND_POOL_ATTACH:124:rand_pool_attach
 RAND_F_RAND_POOL_BYTES_NEEDED:115:rand_pool_bytes_needed
 RAND_F_RAND_POOL_GROW:125:rand_pool_grow
 RAND_F_RAND_POOL_NEW:116:rand_pool_new
+RAND_F_RAND_PSEUDO_BYTES:126:RAND_pseudo_bytes
 RAND_F_RAND_WRITE_FILE:112:RAND_write_file
 RSA_F_CHECK_PADDING_MD:140:check_padding_md
 RSA_F_ENCODE_PKCS1:146:encode_pkcs1

--- a/crypto/rand/rand_err.c
+++ b/crypto/rand/rand_err.c
@@ -49,6 +49,7 @@ static const ERR_STRING_DATA RAND_str_functs[] = {
      "rand_pool_bytes_needed"},
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_GROW, 0), "rand_pool_grow"},
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_POOL_NEW, 0), "rand_pool_new"},
+    {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_PSEUDO_BYTES, 0), "RAND_pseudo_bytes"},
     {ERR_PACK(ERR_LIB_RAND, RAND_F_RAND_WRITE_FILE, 0), "RAND_write_file"},
     {0, NULL}
 };

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -386,6 +386,9 @@ int RAND_poll(void)
 
     const RAND_METHOD *meth = RAND_get_rand_method();
 
+    if (meth == NULL)
+        return 0;
+
     if (meth == RAND_OpenSSL()) {
         /* fill random pool and seed the master DRBG */
         RAND_DRBG *drbg = RAND_DRBG_get0_master();
@@ -896,7 +899,7 @@ void RAND_seed(const void *buf, int num)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();
 
-    if (meth->seed != NULL)
+    if (meth != NULL && meth->seed != NULL)
         meth->seed(buf, num);
 }
 
@@ -904,7 +907,7 @@ void RAND_add(const void *buf, int num, double randomness)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();
 
-    if (meth->add != NULL)
+    if (meth != NULL && meth->add != NULL)
         meth->add(buf, num, randomness);
 }
 
@@ -918,6 +921,9 @@ int RAND_priv_bytes(unsigned char *buf, int num)
     const RAND_METHOD *meth = RAND_get_rand_method();
     RAND_DRBG *drbg;
     int ret;
+
+    if (meth == NULL)
+        return 0;
 
     if (meth != RAND_OpenSSL())
         return RAND_bytes(buf, num);
@@ -934,7 +940,7 @@ int RAND_bytes(unsigned char *buf, int num)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();
 
-    if (meth->bytes != NULL)
+    if (meth != NULL && meth->bytes != NULL)
         return meth->bytes(buf, num);
     RANDerr(RAND_F_RAND_BYTES, RAND_R_FUNC_NOT_IMPLEMENTED);
     return -1;
@@ -945,7 +951,7 @@ int RAND_pseudo_bytes(unsigned char *buf, int num)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();
 
-    if (meth->pseudorand != NULL)
+    if (meth != NULL && meth->pseudorand != NULL)
         return meth->pseudorand(buf, num);
     return -1;
 }
@@ -955,7 +961,7 @@ int RAND_status(void)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();
 
-    if (meth->status != NULL)
+    if (meth != NULL && meth->status != NULL)
         return meth->status();
     return 0;
 }

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -948,6 +948,7 @@ int RAND_pseudo_bytes(unsigned char *buf, int num)
 
     if (meth != NULL && meth->pseudorand != NULL)
         return meth->pseudorand(buf, num);
+    RANDerr(RAND_F_RAND_PSEUDO_BYTES, RAND_R_FUNC_NOT_IMPLEMENTED);
     return -1;
 }
 #endif

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -920,20 +920,15 @@ int RAND_priv_bytes(unsigned char *buf, int num)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();
     RAND_DRBG *drbg;
-    int ret;
 
-    if (meth == NULL)
-        return 0;
-
-    if (meth != RAND_OpenSSL())
+    if (meth != NULL && meth != RAND_OpenSSL())
         return RAND_bytes(buf, num);
 
     drbg = RAND_DRBG_get0_private();
-    if (drbg == NULL)
-        return 0;
+    if (drbg != NULL)
+        return RAND_DRBG_bytes(drbg, buf, num);
 
-    ret = RAND_DRBG_bytes(drbg, buf, num);
-    return ret;
+    return 0;
 }
 
 int RAND_bytes(unsigned char *buf, int num)

--- a/include/openssl/randerr.h
+++ b/include/openssl/randerr.h
@@ -46,6 +46,7 @@ int ERR_load_RAND_strings(void);
 # define RAND_F_RAND_POOL_BYTES_NEEDED                    115
 # define RAND_F_RAND_POOL_GROW                            125
 # define RAND_F_RAND_POOL_NEW                             116
+# define RAND_F_RAND_PSEUDO_BYTES                         126
 # define RAND_F_RAND_WRITE_FILE                           112
 
 /*


### PR DESCRIPTION
Manual backpport of #10483.