### PR TITLE
Thread: Avoid a NULL dereference after failed initialisation.

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -380,6 +380,8 @@ static int init_thread_deregister(void *index, int all)
     int i;
 
     gtr = get_global_tevent_register();
+    if (gtr == NULL)
+        return 0;
     if (!all)
         CRYPTO_THREAD_write_lock(gtr->lock);
     for (i = 0; i < sk_THREAD_EVENT_HANDLER_PTR_num(gtr->skhands); i++) {


### PR DESCRIPTION
Uncertain if the failure should return success or failure but chose failure.
The return value from the function isn't checked and there isn't much recovery possible.

Fixes #10491
