### PR TITLE
kdfs: make free calls check for NULL.

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -75,8 +75,10 @@ static void kdf_hkdf_free(void *vctx)
 {
     KDF_HKDF *ctx = (KDF_HKDF *)vctx;
 
-    kdf_hkdf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        kdf_hkdf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void kdf_hkdf_reset(void *vctx)

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -113,8 +113,10 @@ static void kbkdf_free(void *vctx)
 {
     KBKDF *ctx = (KBKDF *)vctx;
 
-    kbkdf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        kbkdf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void kbkdf_reset(void *vctx)

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -63,8 +63,10 @@ static void krb5kdf_free(void *vctx)
 {
     KRB5KDF_CTX *ctx = (KRB5KDF_CTX *)vctx;
 
-    krb5kdf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        krb5kdf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void krb5kdf_reset(void *vctx)

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -80,8 +80,10 @@ static void kdf_pbkdf2_free(void *vctx)
 {
     KDF_PBKDF2 *ctx = (KDF_PBKDF2 *)vctx;
 
-    kdf_pbkdf2_cleanup(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        kdf_pbkdf2_cleanup(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void kdf_pbkdf2_reset(void *vctx)

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -74,9 +74,11 @@ static void kdf_scrypt_free(void *vctx)
 {
     KDF_SCRYPT *ctx = (KDF_SCRYPT *)vctx;
 
-    EVP_MD_meth_free(ctx->sha256);
-    kdf_scrypt_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        EVP_MD_meth_free(ctx->sha256);
+        kdf_scrypt_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void kdf_scrypt_reset(void *vctx)

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -63,8 +63,10 @@ static void kdf_sshkdf_free(void *vctx)
 {
     KDF_SSHKDF *ctx = (KDF_SSHKDF *)vctx;
 
-    kdf_sshkdf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        kdf_sshkdf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void kdf_sshkdf_reset(void *vctx)

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -315,8 +315,10 @@ static void sskdf_free(void *vctx)
 {
     KDF_SSKDF *ctx = (KDF_SSKDF *)vctx;
 
-    sskdf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        sskdf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static int sskdf_set_buffer(unsigned char **out, size_t *out_len,

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -106,8 +106,10 @@ static void kdf_tls1_prf_free(void *vctx)
 {
     TLS1_PRF *ctx = (TLS1_PRF *)vctx;
 
-    kdf_tls1_prf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        kdf_tls1_prf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static void kdf_tls1_prf_reset(void *vctx)

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -266,8 +266,10 @@ static void x942kdf_free(void *vctx)
 {
     KDF_X942 *ctx = (KDF_X942 *)vctx;
 
-    x942kdf_reset(ctx);
-    OPENSSL_free(ctx);
+    if (ctx != NULL) {
+        x942kdf_reset(ctx);
+        OPENSSL_free(ctx);
+    }
 }
 
 static int x942kdf_set_buffer(unsigned char **out, size_t *out_len,


### PR DESCRIPTION
Endemic issue in the provider KDF free functions.

Fixes  #10494
