### PR TITLE
Remove deadlock that was caused by calling pthread_rwlock_wrlock() 

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -108,7 +108,7 @@ static int dummy_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
 
 int crypto_free_ex_index_ex(OPENSSL_CTX *ctx, int class_index, int idx)
 {
-    EX_CALLBACKS *ip = get_and_lock(ctx, class_index);
+    EX_CALLBACKS *ip;
     EX_CALLBACK *a;
     int toret = 0;
     OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ctx);


### PR DESCRIPTION
I have try to build current master with musl instead of glibc and I have found that fuzz test will get stucked. Issue seems to be deadlock caused by calling pthread_rwlock_wrlock() on same thread. I guess glibc is not following POSIX so strictly, because by description this may cause this behaviour "The calling thread may deadlock if at the time the call is made it holds the read-write lock (whether a read or write lock)."

CLA: trivial

Signed-off-by: Matus Kysel <mkysel@tachyum.com>
