### PR TITLE
configdata.pm.in, util/dofile.pl: load 'platform' unconditionally

### DIFF
--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -124,8 +124,6 @@ unless (caller) {
         my $prepend = <<"_____";
 use File::Spec::Functions;
 use lib '{- sourcedir('util', 'perl') -}';
-_____
-        $prepend .= <<"_____" if defined $target{perl_platform};
 use lib '{- sourcedir('Configurations') -}';
 use lib '{- $config{builddir} -}';
 use platform;

--- a/util/dofile.pl
+++ b/util/dofile.pl
@@ -63,8 +63,6 @@ sub errorcallback {
 
 my $prepend = <<"_____";
 use File::Spec::Functions;
-_____
-$prepend .= <<"_____" if defined $target{perl_platform};
 use lib "$FindBin::Bin/../Configurations";
 use lib '$config{builddir}';
 use platform;


### PR DESCRIPTION
The 'platform' module handles defaults fine, there's no need to add
extra conditions on it being loaded.

Fixes #10513
