### PR TITLE
apps/ocsp.c: sock_timeout -> socket_timeout

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -115,7 +115,7 @@ static int acfd = (int) INVALID_SOCKET;
 static int index_changed(CA_DB *);
 static void spawn_loop(void);
 static int print_syslog(const char *str, size_t len, void *levPtr);
-static void sock_timeout(int signum);
+static void socket_timeout(int signum);
 # endif
 
 # ifndef OPENSSL_NO_SOCK
@@ -622,7 +622,7 @@ int ocsp_main(int argc, char **argv)
     if (multi && acbio != NULL)
         spawn_loop();
     if (acbio != NULL && req_timeout > 0)
-        signal(SIGALRM, sock_timeout);
+        signal(SIGALRM, socket_timeout);
 #endif
 
     if (acbio != NULL)
@@ -1389,7 +1389,7 @@ static int urldecode(char *p)
 # endif
 
 # ifdef OCSP_DAEMON
-static void sock_timeout(int signum)
+static void socket_timeout(int signum)
 {
     if (acfd != (int)INVALID_SOCKET)
         (void)shutdown(acfd, SHUT_RD);


### PR DESCRIPTION
It appears that 'sock_timeout' is defined at least with DJGPP, so we
rename our symbol and hope the new name isn't taken.
