### PR TITLE
test/cipher_overhead_test.c: build unconditionally

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -445,12 +445,12 @@ IF[{- !$disabled{tests} -}]
     INCLUDE[shlibloadtest]=../include ../apps/include ../crypto/include
   ENDIF
 
-  IF[{- $disabled{shared} -}]
-    PROGRAMS{noinst}=cipher_overhead_test
-    SOURCE[cipher_overhead_test]=cipher_overhead_test.c
-    INCLUDE[cipher_overhead_test]=.. ../include ../apps/include
-    DEPEND[cipher_overhead_test]=../libcrypto ../libssl libtestutil.a
-  ENDIF
+  # cipher_overhead_test uses internal symbols, so it must be linked with
+  # the static libraries
+  PROGRAMS{noinst}=cipher_overhead_test
+  SOURCE[cipher_overhead_test]=cipher_overhead_test.c
+  INCLUDE[cipher_overhead_test]=.. ../include ../apps/include
+  DEPEND[cipher_overhead_test]=../libcrypto.a ../libssl.a libtestutil.a
 
   SOURCE[uitest]=uitest.c ../apps/lib/apps_ui.c
   INCLUDE[uitest]=.. ../include ../apps/include

--- a/test/recipes/90-test_overhead.t
+++ b/test/recipes/90-test_overhead.t
@@ -12,9 +12,6 @@ use OpenSSL::Test::Utils;
 
 setup("test_overhead");
 
-plan skip_all => "Only supported in no-shared builds"
-    if !disabled("shared");
-
 plan tests => 1;
 
 ok(run(test(["cipher_overhead_test"])), "running cipher_overhead_test");


### PR DESCRIPTION
Build it against static libraries always, since that's the only way it
can work as intended.
