### PR TITLE
i2b_PVK(): Use Encrypt, not Decrypt

### DIFF
--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -844,9 +844,9 @@ static int i2b_PVK(unsigned char **out, EVP_PKEY *pk, int enclevel,
         if (!EVP_EncryptInit_ex(cctx, EVP_rc4(), NULL, keybuf, NULL))
             goto error;
         OPENSSL_cleanse(keybuf, 20);
-        if (!EVP_DecryptUpdate(cctx, p, &enctmplen, p, pklen - 8))
+        if (!EVP_EncryptUpdate(cctx, p, &enctmplen, p, pklen - 8))
             goto error;
-        if (!EVP_DecryptFinal_ex(cctx, p + enctmplen, &enctmplen))
+        if (!EVP_EncryptFinal_ex(cctx, p + enctmplen, &enctmplen))
             goto error;
     }
 


### PR DESCRIPTION
We used EVP_EncryptInit_ex() to initialise, but EVP_DecryptUpdate()
and EVP_DecryptFinal_ex() to actually perform encryption.  This worked
long ago, when the Encrypt and Decrypt variants were the same, but
doesn't now (actually haven't for a very long time).

This shows how seldom PVK is actually used.

Fixes #9338
