### PR TITLE
Add some missing NULL pointer return checks

### DIFF
--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -138,6 +138,10 @@ opthelp:
         BIO_write(out, dkm_bytes, dkm_len);
     } else {
         hexout = OPENSSL_buf2hexstr(dkm_bytes, dkm_len);
+        if (hexout == NULL) {
+            BIO_printf(bio_err, "Memory allocation failure\n");
+            goto err;
+        }
         BIO_printf(out, "%s\n\n", hexout);
     }
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -112,6 +112,8 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
 
         tid = CRYPTO_THREAD_get_current_id();
         hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
+        if (hex == NULL)
+            return 0;
         BIO_snprintf(buffer, sizeof(buffer), "TRACE[%s]:%s: ",
                      hex, OSSL_trace_get_category_name(category));
         OPENSSL_free(hex);

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -112,10 +112,9 @@ static size_t internal_trace_cb(const char *buf, size_t cnt,
 
         tid = CRYPTO_THREAD_get_current_id();
         hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
-        if (hex == NULL)
-            return 0;
         BIO_snprintf(buffer, sizeof(buffer), "TRACE[%s]:%s: ",
-                     hex, OSSL_trace_get_category_name(category));
+                     hex == NULL ? "<null>" : hex,
+                     OSSL_trace_get_category_name(category));
         OPENSSL_free(hex);
         BIO_ctrl(trace_data->bio, PREFIX_CTRL_SET_PREFIX,
                  strlen(buffer), buffer);

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -36,8 +36,8 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
             data = "";
         hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
         BIO_snprintf(buf, sizeof(buf), "%s:error:%s:%s:%s:%s:%d:%s\n",
-                     hex == NULL ? "" : hex, lib, func, reason, file, line,
-                     data);
+                     hex == NULL ? "<null>" : hex, lib, func, reason, file,
+                     line, data);
         OPENSSL_free(hex);
         if (cb(buf, strlen(buf), u) <= 0)
             break;              /* abort outputting the error report */

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -36,7 +36,8 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
             data = "";
         hex = OPENSSL_buf2hexstr((const unsigned char *)&tid, sizeof(tid));
         BIO_snprintf(buf, sizeof(buf), "%s:error:%s:%s:%s:%s:%d:%s\n",
-                     hex, lib, func, reason, file, line, data);
+                     hex == NULL ? "" : hex, lib, func, reason, file, line,
+                     data);
         OPENSSL_free(hex);
         if (cb(buf, strlen(buf), u) <= 0)
             break;              /* abort outputting the error report */

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -20,11 +20,14 @@ static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
 {
     EVP_KEYEXCH *exchange = OPENSSL_zalloc(sizeof(EVP_KEYEXCH));
 
-    if (exchange == NULL)
+    if (exchange == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
 
     exchange->lock = CRYPTO_THREAD_lock_new();
     if (exchange->lock == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(exchange);
         return NULL;
     }

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -20,6 +20,9 @@ static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
 {
     EVP_KEYEXCH *exchange = OPENSSL_zalloc(sizeof(EVP_KEYEXCH));
 
+    if (exchange == NULL)
+        return NULL;
+
     exchange->lock = CRYPTO_THREAD_lock_new();
     if (exchange->lock == NULL) {
         OPENSSL_free(exchange);

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -20,6 +20,9 @@ static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
 {
     EVP_SIGNATURE *signature = OPENSSL_zalloc(sizeof(EVP_SIGNATURE));
 
+    if (signature == NULL)
+        return NULL;
+
     signature->lock = CRYPTO_THREAD_lock_new();
     if (signature->lock == NULL) {
         OPENSSL_free(signature);
@@ -759,6 +762,9 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
 static EVP_ASYM_CIPHER *evp_asym_cipher_new(OSSL_PROVIDER *prov)
 {
     EVP_ASYM_CIPHER *cipher = OPENSSL_zalloc(sizeof(EVP_ASYM_CIPHER));
+
+    if (cipher == NULL)
+        return NULL;
 
     cipher->lock = CRYPTO_THREAD_lock_new();
     if (cipher->lock == NULL) {

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -20,11 +20,14 @@ static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
 {
     EVP_SIGNATURE *signature = OPENSSL_zalloc(sizeof(EVP_SIGNATURE));
 
-    if (signature == NULL)
+    if (signature == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
 
     signature->lock = CRYPTO_THREAD_lock_new();
     if (signature->lock == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(signature);
         return NULL;
     }
@@ -763,11 +766,14 @@ static EVP_ASYM_CIPHER *evp_asym_cipher_new(OSSL_PROVIDER *prov)
 {
     EVP_ASYM_CIPHER *cipher = OPENSSL_zalloc(sizeof(EVP_ASYM_CIPHER));
 
-    if (cipher == NULL)
+    if (cipher == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
 
     cipher->lock = CRYPTO_THREAD_lock_new();
     if (cipher->lock == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(cipher);
         return NULL;
     }

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -375,7 +375,7 @@ static void print_leak(const MEM *m, MEM_LEAK *l)
     hex = OPENSSL_buf2hexstr((const unsigned char *)&m->threadid,
                              sizeof(m->threadid));
     n = BIO_snprintf(bufp, len, "thread=%s, number=%d, address=%p\n",
-                     hex == NULL ? "" : hex, m->num, m->addr);
+                     hex == NULL ? "<null>" : hex, m->num, m->addr);
     OPENSSL_free(hex);
     if (n <= 0)
         return;

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -374,8 +374,8 @@ static void print_leak(const MEM *m, MEM_LEAK *l)
 
     hex = OPENSSL_buf2hexstr((const unsigned char *)&m->threadid,
                              sizeof(m->threadid));
-    n = BIO_snprintf(bufp, len, "thread=%s, number=%d, address=%p\n", hex,
-                     m->num, m->addr);
+    n = BIO_snprintf(bufp, len, "thread=%s, number=%d, address=%p\n",
+                     hex == NULL ? "" : hex, m->num, m->addr);
     OPENSSL_free(hex);
     if (n <= 0)
         return;

--- a/crypto/x509/v3_akey.c
+++ b/crypto/x509/v3_akey.c
@@ -42,8 +42,10 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     char *tmp;
     if (akeyid->keyid) {
         tmp = OPENSSL_buf2hexstr(akeyid->keyid->data, akeyid->keyid->length);
-        if (tmp == NULL)
+        if (tmp == NULL) {
+            ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
             return NULL;
+        }
         X509V3_add_value((akeyid->issuer || akeyid->serial) ? "keyid" : NULL,
                          tmp, &extlist);
         OPENSSL_free(tmp);
@@ -52,8 +54,10 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
         extlist = i2v_GENERAL_NAMES(NULL, akeyid->issuer, extlist);
     if (akeyid->serial) {
         tmp = OPENSSL_buf2hexstr(akeyid->serial->data, akeyid->serial->length);
-        if (tmp == NULL)
+        if (tmp == NULL) {
+            ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
             return NULL;
+        }
         X509V3_add_value("serial", tmp, &extlist);
         OPENSSL_free(tmp);
     }

--- a/crypto/x509/v3_akey.c
+++ b/crypto/x509/v3_akey.c
@@ -42,13 +42,18 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     char *tmp;
     if (akeyid->keyid) {
         tmp = OPENSSL_buf2hexstr(akeyid->keyid->data, akeyid->keyid->length);
-        X509V3_add_value((akeyid->issuer || akeyid->serial) ? "keyid" : NULL, tmp, &extlist);
+        if (tmp == NULL)
+            return NULL;
+        X509V3_add_value((akeyid->issuer || akeyid->serial) ? "keyid" : NULL,
+                         tmp, &extlist);
         OPENSSL_free(tmp);
     }
     if (akeyid->issuer)
         extlist = i2v_GENERAL_NAMES(NULL, akeyid->issuer, extlist);
     if (akeyid->serial) {
         tmp = OPENSSL_buf2hexstr(akeyid->serial->data, akeyid->serial->length);
+        if (tmp == NULL)
+            return NULL;
         X509V3_add_value("serial", tmp, &extlist);
         OPENSSL_free(tmp);
     }


### PR DESCRIPTION
Check the return value after OPENSSL_zalloc() for some EVP types.

We  should also check the return value from OPENSSL_buf2hextr() which may also be NULL.

Fixes #10525.