### PR TITLE
Configure: No error on use of deprecated functions

### DIFF
--- a/Configure
+++ b/Configure
@@ -145,7 +145,7 @@ my @gcc_devteam_warn = qw(
     -Werror
     -Wmissing-prototypes
     -Wstrict-prototypes
-    -Wno-error=deprecated-declarations
+    -Wno-deprecated-declarations
 );
 
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.

--- a/Configure
+++ b/Configure
@@ -145,6 +145,7 @@ my @gcc_devteam_warn = qw(
     -Werror
     -Wmissing-prototypes
     -Wstrict-prototypes
+    -Wno-error=deprecated-declarations
 );
 
 # These are used in addition to $gcc_devteam_warn when the compiler is clang.


### PR DESCRIPTION
So far, we have let usage of deprecated functions become errors with
--strict-warnings.  This turns out to be too hard as we're looking at
deprecating functionality that we are still going to have to support
until they are removed, which means that usage of deprecated functions
must still be able to compile.
