### PR TITLE
Deprecate the AES_ige_*() functions

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -17,6 +17,9 @@
 #define EdDSA_SECONDS   10
 #define SM2_SECONDS     10
 
+/* We need to use some deprecated APIs */
+#define OPENSSL_INTERNAL_USE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -73,17 +73,16 @@ void AES_cfb8_encrypt(const unsigned char *in, unsigned char *out,
 void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
                         unsigned char *ivec, int *num);
-# ifndef OPENSSL_NO_DEPRECATED_3_0
+
 /* NB: the IV is _two_ blocks long */
-void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
-                     size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc);
+DEPRECATEDIN_3_0_EXTERN(void AES_ige_encrypt(const unsigned char *in,
+    unsigned char *out, size_t length, const AES_KEY *key, unsigned char *ivec,
+    const int enc))
 /* NB: the IV is _four_ blocks long */
-void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
-                        size_t length, const AES_KEY *key,
-                        const AES_KEY *key2, const unsigned char *ivec,
-                        const int enc);
-# endif
+DEPRECATEDIN_3_0_EXTERN(void AES_bi_ige_encrypt(
+    const unsigned char *in, unsigned char *out, size_t length,
+    const AES_KEY *key, const AES_KEY *key2, const unsigned char *ivec,
+    const int enc))
 
 int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out,

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -203,6 +203,16 @@
 # endif
 
 /*
+ * Some deprecated functions are still needed for use internally within OpenSSL.
+ * Applications should *not* define the OPENSSL_INTERNAL_USE macro.
+ */
+# ifdef OPENSSL_INTERNAL_USE
+#  define DEPRECATEDIN_3_0_EXTERN(f)       f;
+# else
+#  define DEPRECATEDIN_3_0_EXTERN(f)       DEPRECATEDIN_3_0(f)
+# endif
+
+/*
  * Make our own variants of __FILE__ and __LINE__, depending on configuration
  */
 

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* The AES_ige_* functions are deprecated, so we suppress warnings about them */
+#define OPENSSL_INTERNAL_USE
+
 #include <openssl/crypto.h>
 #include <openssl/aes.h>
 #include <openssl/rand.h>

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -264,7 +264,7 @@ my @opensslchandlers = (
     # We trick the parser by pretending that the declaration is wrapped in a
     # check if the DEPRECATEDIN macro is defined or not.  Callers of parse()
     # will have to decide what to do with it.
-    { regexp   => qr/(DEPRECATEDIN_\d+_\d+(?:_\d+)?)<<<\((.*)\)>>>/,
+    { regexp   => qr/(DEPRECATEDIN_\d+_\d+(?:_\d+)?)(?:_EXTERN)?<<<\((.*)\)>>>/,
       massager => sub { return (<<"EOF");
 #ifndef $1
 $2;


### PR DESCRIPTION
These functions were already partially deprecated. Now we do it fully.

This is an alternative approach to that shown in #10538 and #10367.