### PR TITLE
util/mkerr.pl: don't stop reading conserved symbols from the state file

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -210,12 +210,6 @@ if ( ! $reindex && $statefile ) {
             print "Skipping $_";
             $skippedstate++;
             next;
-        } elsif ( $hinc{$lib} eq 'NONE' ) {
-            # When the header is NONE but the err file is specified,
-            # it signifies that the err file should be conserved but
-            # remain untouched, and the same goes for the symbols in
-            # the state file.
-            next;
         }
         if ( $name =~ /^(?:OSSL_|OPENSSL_)?[A-Z0-9]{2,}_R_/ ) {
             die "$lib reason code $code collision at $name\n"


### PR DESCRIPTION
If we don't read them, they will not be conserved.

Fixes #10522
