### PR TITLE
 Deprecate the AES_ige_*() functions (take 3)

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -17,6 +17,9 @@
 #define EdDSA_SECONDS   10
 #define SM2_SECONDS     10
 
+/* We need to use some deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -73,17 +73,16 @@ void AES_cfb8_encrypt(const unsigned char *in, unsigned char *out,
 void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
                         unsigned char *ivec, int *num);
-# ifndef OPENSSL_NO_DEPRECATED_3_0
+
 /* NB: the IV is _two_ blocks long */
-void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
-                     size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc);
+DEPRECATEDIN_3_0(void AES_ige_encrypt(const unsigned char *in,
+    unsigned char *out, size_t length, const AES_KEY *key, unsigned char *ivec,
+    const int enc))
 /* NB: the IV is _four_ blocks long */
-void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
-                        size_t length, const AES_KEY *key,
-                        const AES_KEY *key2, const unsigned char *ivec,
-                        const int enc);
-# endif
+DEPRECATEDIN_3_0(void AES_bi_ige_encrypt(
+    const unsigned char *in, unsigned char *out, size_t length,
+    const AES_KEY *key, const AES_KEY *key2, const unsigned char *ivec,
+    const int enc))
 
 int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out,

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -75,14 +75,16 @@ void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                         unsigned char *ivec, int *num);
 
 /* NB: the IV is _two_ blocks long */
-DEPRECATEDIN_3_0(void AES_ige_encrypt(const unsigned char *in,
-    unsigned char *out, size_t length, const AES_KEY *key, unsigned char *ivec,
-    const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_ige_encrypt(const unsigned char *in, unsigned char *out,
+                                 size_t length, const AES_KEY *key,
+                                 unsigned char *ivec, const int enc))
 /* NB: the IV is _four_ blocks long */
-DEPRECATEDIN_3_0(void AES_bi_ige_encrypt(
-    const unsigned char *in, unsigned char *out, size_t length,
-    const AES_KEY *key, const AES_KEY *key2, const unsigned char *ivec,
-    const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
+                                    size_t length, const AES_KEY *key,
+                                    const AES_KEY *key2,
+                                    const unsigned char *ivec, const int enc))
 
 int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out,

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -28,15 +28,17 @@
  */
 # ifndef DECLARE_DEPRECATED
 #  define DECLARE_DEPRECATED(f)   f;
-#  ifdef __GNUC__
-#   if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
-#    undef DECLARE_DEPRECATED
-#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
-#   endif
-#  elif defined(__SUNPRO_C)
-#   if (__SUNPRO_C >= 0x5130)
-#    undef DECLARE_DEPRECATED
-#    define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#  ifndef OPENSSL_SUPPRESS_DEPRECATED
+#   ifdef __GNUC__
+#    if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ > 0)
+#     undef DECLARE_DEPRECATED
+#     define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#    endif
+#   elif defined(__SUNPRO_C)
+#    if (__SUNPRO_C >= 0x5130)
+#     undef DECLARE_DEPRECATED
+#     define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
+#    endif
 #   endif
 #  endif
 # endif

--- a/test/igetest.c
+++ b/test/igetest.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* The AES_ige_* functions are deprecated, so we suppress warnings about them */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/crypto.h>
 #include <openssl/aes.h>
 #include <openssl/rand.h>


### PR DESCRIPTION
These functions were already partially deprecated. Now we do it fully.

This is an alternative approach to that shown in #10540, and also to the one in #10538 and #10367.