### PR TITLE
Fix exit issue in travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ matrix:
 before_script:
     - env
     - if [ "$TRAVIS_PULL_REQUEST" != "false" -a -n "$EXTENDED_TEST" ]; then
-          (git log -1 $TRAVIS_COMMIT_RANGE | grep '\[extended tests\]' > /dev/null) || exit 0;
+          (git log -1 $TRAVIS_COMMIT_RANGE | grep '\[extended tests\]' > /dev/null) || travis_terminate 0;
       fi
     - if [ -n "$DESTDIR" ]; then
           sh .travis-create-release.sh $TRAVIS_OS_NAME;


### PR DESCRIPTION
Ungraceful 'exit' probably causes unexpeced error on background activity.
So replace 'exit' with recommended 'travis_terminate'. Also see
https://travis-ci.community/t/exit-0-cannot-exit-successfully-on-arm/5731/4