### PR TITLE
Backport the RSA_get0_pss_params() function from master

### DIFF
--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -451,6 +451,11 @@ const BIGNUM *RSA_get0_iqmp(const RSA *r)
     return r->iqmp;
 }
 
+const RSA_PSS_PARAMS *RSA_get0_pss_params(const RSA *r)
+{
+    return r->pss;
+}
+
 void RSA_clear_flags(RSA *r, int flags)
 {
     r->flags &= ~flags;

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -5,7 +5,7 @@
 RSA_set0_key, RSA_set0_factors, RSA_set0_crt_params, RSA_get0_key,
 RSA_get0_factors, RSA_get0_crt_params,
 RSA_get0_n, RSA_get0_e, RSA_get0_d, RSA_get0_p, RSA_get0_q,
-RSA_get0_dmp1, RSA_get0_dmq1, RSA_get0_iqmp,
+RSA_get0_dmp1, RSA_get0_dmq1, RSA_get0_iqmp, RSA_get0_pss_params
 RSA_clear_flags,
 RSA_test_flags, RSA_set_flags, RSA_get0_engine, RSA_get_multi_prime_extra_count,
 RSA_get0_multi_prime_factors, RSA_get0_multi_prime_crt_params,
@@ -33,6 +33,7 @@ RSA_set0_multi_prime_params, RSA_get_version
  const BIGNUM *RSA_get0_dmp1(const RSA *r);
  const BIGNUM *RSA_get0_dmq1(const RSA *r);
  const BIGNUM *RSA_get0_iqmp(const RSA *r);
+ const RSA_PSS_PARAMS *RSA_get0_pss_params(const RSA *r);
  void RSA_clear_flags(RSA *r, int flags);
  int RSA_test_flags(const RSA *r, int flags);
  void RSA_set_flags(RSA *r, int flags);
@@ -97,6 +98,8 @@ Any of the values B<n>, B<e>, B<d>, B<p>, B<q>, B<dmp1>, B<dmq1>, and B<iqmp> ca
 retrieved separately by the corresponding function
 RSA_get0_n(), RSA_get0_e(), RSA_get0_d(), RSA_get0_p(), RSA_get0_q(),
 RSA_get0_dmp1(), RSA_get0_dmq1(), and RSA_get0_iqmp(), respectively.
+
+RSA_get0_pss_params() is used to retrieve the RSA-PSS parameters.
 
 RSA_set_flags() sets the flags in the B<flags> parameter on the RSA
 object. Multiple flags can be passed in one go (bitwise ORed together).

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -160,6 +160,8 @@ L<RSA_new(3)>, L<RSA_size(3)>
 
 =head1 HISTORY
 
+The RSA_get0_pss_params() function was added in OpenSSL 1.1.1e.
+
 The
 RSA_get_multi_prime_extra_count(), RSA_get0_multi_prime_factors(),
 RSA_get0_multi_prime_crt_params(), RSA_set0_multi_prime_params(),

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -5,7 +5,7 @@
 RSA_set0_key, RSA_set0_factors, RSA_set0_crt_params, RSA_get0_key,
 RSA_get0_factors, RSA_get0_crt_params,
 RSA_get0_n, RSA_get0_e, RSA_get0_d, RSA_get0_p, RSA_get0_q,
-RSA_get0_dmp1, RSA_get0_dmq1, RSA_get0_iqmp, RSA_get0_pss_params
+RSA_get0_dmp1, RSA_get0_dmq1, RSA_get0_iqmp, RSA_get0_pss_params,
 RSA_clear_flags,
 RSA_test_flags, RSA_set_flags, RSA_get0_engine, RSA_get_multi_prime_extra_count,
 RSA_get0_multi_prime_factors, RSA_get0_multi_prime_crt_params,

--- a/include/openssl/ossl_typ.h
+++ b/include/openssl/ossl_typ.h
@@ -109,6 +109,7 @@ typedef struct dsa_method DSA_METHOD;
 
 typedef struct rsa_st RSA;
 typedef struct rsa_meth_st RSA_METHOD;
+typedef struct rsa_pss_params_st RSA_PSS_PARAMS;
 
 typedef struct ec_key_st EC_KEY;
 typedef struct ec_key_method_st EC_KEY_METHOD;

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -280,14 +280,14 @@ int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2);
 DECLARE_ASN1_ENCODE_FUNCTIONS_const(RSA, RSAPublicKey)
 DECLARE_ASN1_ENCODE_FUNCTIONS_const(RSA, RSAPrivateKey)
 
-typedef struct rsa_pss_params_st {
+struct rsa_pss_params_st {
     X509_ALGOR *hashAlgorithm;
     X509_ALGOR *maskGenAlgorithm;
     ASN1_INTEGER *saltLength;
     ASN1_INTEGER *trailerField;
     /* Decoded hash algorithm from maskGenAlgorithm */
     X509_ALGOR *maskHash;
-} RSA_PSS_PARAMS;
+};
 
 DECLARE_ASN1_FUNCTIONS(RSA_PSS_PARAMS)
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -224,6 +224,7 @@ const BIGNUM *RSA_get0_q(const RSA *d);
 const BIGNUM *RSA_get0_dmp1(const RSA *r);
 const BIGNUM *RSA_get0_dmq1(const RSA *r);
 const BIGNUM *RSA_get0_iqmp(const RSA *r);
+const RSA_PSS_PARAMS *RSA_get0_pss_params(const RSA *r);
 void RSA_clear_flags(RSA *r, int flags);
 int RSA_test_flags(const RSA *r, int flags);
 void RSA_set_flags(RSA *r, int flags);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4586,3 +4586,4 @@ EVP_PKEY_meth_set_digestsign            4539	1_1_1e	EXIST::FUNCTION:
 EVP_PKEY_meth_set_digestverify          4540	1_1_1e	EXIST::FUNCTION:
 EVP_PKEY_meth_get_digestverify          4541	1_1_1e	EXIST::FUNCTION:
 EVP_PKEY_meth_get_digestsign            4542	1_1_1e	EXIST::FUNCTION:
+RSA_get0_pss_params                     4543	1_1_1e	EXIST::FUNCTION:RSA


### PR DESCRIPTION
This is a missing accessor in order to obtain PSS parameters from an
RSA key, which should also be available in 1.1.1.

Mostly this targets 1.1.1. However the second commit also updates the docs in master to add a HISTORY update, so that change will be applied to both branches.