### PR TITLE
Introduce additional -subj override, utf8 and multivalue RDN support

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -626,7 +626,7 @@ int x509_main(int argc, char **argv)
 
         if (req == NULL) {
             if (fsubj == NULL) {
-                BIO_printf(bio_err, "We need either a request/certificate to extract a subject fomr; or one set with -subj\n");
+                BIO_printf(bio_err, "We need either a request/certificate to extract a subject from; or one set with -subj\n");
                 goto end;
             }
             n = fsubj;
@@ -641,7 +641,7 @@ int x509_main(int argc, char **argv)
 
         if (n == fsubj) {
             X509_NAME_free(fsubj);
-	    fsubj = NULL;
+            fsubj = NULL;
         }
         if (!set_cert_times(x, NULL, NULL, days))
             goto end;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -633,10 +633,12 @@ int x509_main(int argc, char **argv)
             // Supress Overwritten warning below.
             fsubj = NULL;
         } else {
-           n = X509_REQ_get_subject_name(req);
+            n = X509_REQ_get_subject_name(req);
         }
 
         if (!X509_set_issuer_name(x, n))
+            goto end;
+        if (!X509_set_subject_name(x, n))
             goto end;
         if (!set_cert_times(x, NULL, NULL, days))
             goto end;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -630,8 +630,6 @@ int x509_main(int argc, char **argv)
                 goto end;
             }
             n = fsubj;
-            // Supress Overwritten warning below.
-            fsubj = NULL;
         } else {
             n = X509_REQ_get_subject_name(req);
         }
@@ -640,11 +638,17 @@ int x509_main(int argc, char **argv)
             goto end;
         if (!X509_set_subject_name(x, n))
             goto end;
+
+        if (n == fsubj) {
+            X509_NAME_free(fsubj);
+	    fsubj = NULL;
+        }
         if (!set_cert_times(x, NULL, NULL, days))
             goto end;
 
         if (!X509_set_pubkey(x, fkey != NULL ? fkey : X509_REQ_get0_pubkey(req)))
             goto end;
+
     } else {
         x = load_cert(infile, informat, "Certificate");
         if (x == NULL)

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -54,7 +54,7 @@ typedef enum OPTION_choice {
     OPT_ADDTRUST, OPT_ADDREJECT, OPT_SETALIAS, OPT_CERTOPT, OPT_NAMEOPT,
     OPT_C, OPT_EMAIL, OPT_OCSP_URI, OPT_SERIAL, OPT_NEXT_SERIAL,
     OPT_MODULUS, OPT_PUBKEY, OPT_X509TOREQ, OPT_TEXT, OPT_HASH,
-    OPT_ISSUER_HASH, OPT_SUBJECT, OPT_UTF8, OPT_MULTIVALUE_RDN,
+    OPT_ISSUER_HASH, OPT_SUBJECT, OPT_MULTIVALUE_RDN,
     OPT_ISSUER, OPT_FINGERPRINT, OPT_DATES,
     OPT_PURPOSE, OPT_STARTDATE, OPT_ENDDATE, OPT_CHECKEND, OPT_CHECKHOST,
     OPT_CHECKEMAIL, OPT_CHECKIP, OPT_NOOUT, OPT_TRUSTOUT, OPT_CLRTRUST,
@@ -85,8 +85,6 @@ const OPTIONS x509_options[] = {
     OPT_SECTION("Output"),
     {"serial", OPT_SERIAL, '-', "Print serial number value"},
     {"subject_hash", OPT_HASH, '-', "Print subject hash value"},
-    {"utf8", OPT_UTF8, '-',
-     "Input characters in subject set/modify are UTF8 (default ASCII)"},
     {"multivalue-rdn", OPT_MULTIVALUE_RDN, '-',
      "Enable support for multivalued RDNs in subject set/modify"},
     {"issuer_hash", OPT_ISSUER_HASH, '-', "Print issuer hash value"},
@@ -309,9 +307,6 @@ int x509_main(int argc, char **argv)
         case OPT_SUBJ:
             subj = opt_arg();
             break;
-        case OPT_UTF8:
-             chtype = MBSTRING_UTF8;
-             break;
         case OPT_MULTIVALUE_RDN:
              multirdn = 1;
              break;

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -490,14 +490,6 @@ This option can be used in conjunction with the B<-force_pubkey> option
 to create a certificate even without providing an input certificate
 or certificate request.
 
-=item B<-utf8>
-
-This option causes field values to be interpreted as UTF8 strings, by
-default they are interpreted as ASCII. This means that the field
-values, whether prompted from a terminal or obtained from a
-configuration file, must be valid UTF8 strings. Applies to the
-value set by the B<-subj> and B<-subject> flags.
-
 =item B<-multivalue-rdn>
 
 This option causes the B<-subj> argument to be interpreted with full

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -490,6 +490,26 @@ This option can be used in conjunction with the B<-force_pubkey> option
 to create a certificate even without providing an input certificate
 or certificate request.
 
+=item B<-utf8>
+
+This option causes field values to be interpreted as UTF8 strings, by
+default they are interpreted as ASCII. This means that the field
+values, whether prompted from a terminal or obtained from a
+configuration file, must be valid UTF8 strings. Applies to the
+value set by the B<-subj> and B<-subject> flags.
+
+=item B<-multivalue-rdn>
+
+This option causes the B<-subj> argument to be interpreted with full
+support for multivalued RDNs. Applies to the value set by the
+B<-subj> and B<-subject> flags.
+
+Example:
+
+I</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
+
+If -multi-rdn is not used then the UID value is I<123456+CN=John Doe>.
+
 =back
 
 =head2 Name Options

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -59,6 +59,7 @@ SKIP: {
     unlink $pubkey;
     unlink $selfout;
 }
+# X509 -subj override tests.
 {
     my @path = qw(test certs);
     my $signkey = srctop_file(@path, "rootCA.key");


### PR DESCRIPTION
Replaces what was still left from PR # 1729 from 2016 (as https://github.com/openssl/openssl/commit/529586085e38487d45974817d4f3ff40f30e19f6 introduced most of this code for a slightly different usecase already).

Note to the reviewer - I am not clear why that patch also changes the Issuer around line 609. But have not changed that.

- [X] documentation is added or updated
- [X] tests are added and updated
