### PR TITLE
Make ECDSA_size() use consistent asn1 encoder.

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1342,32 +1342,27 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
     return 1;
 }
 
-#ifndef FIPS_MODE
-int ECDSA_size(const EC_KEY *r)
+int ECDSA_size(const EC_KEY *ec)
 {
-    int ret, i;
-    ASN1_INTEGER bs;
-    unsigned char buf[4];
+    int ret;
+    ECDSA_SIG sig;
     const EC_GROUP *group;
+    const BIGNUM *bn;
 
-    if (r == NULL)
+    if (ec == NULL)
         return 0;
-    group = EC_KEY_get0_group(r);
+    group = EC_KEY_get0_group(ec);
     if (group == NULL)
         return 0;
 
-    i = EC_GROUP_order_bits(group);
-    if (i == 0)
+    bn = EC_GROUP_get0_order(group);
+    if (bn == NULL)
         return 0;
-    bs.length = (i + 7) / 8;
-    bs.data = buf;
-    bs.type = V_ASN1_INTEGER;
-    /* If the top bit is set the asn1 encoding is 1 larger. */
-    buf[0] = 0xff;
 
-    i = i2d_ASN1_INTEGER(&bs, NULL);
-    i += i;                     /* r and s */
-    ret = ASN1_object_size(1, i, V_ASN1_SEQUENCE);
+    sig.r = sig.s = (BIGNUM *)bn;
+    ret = i2d_ECDSA_SIG(&sig, NULL);
+
+    if (ret < 0)
+        ret = 0;
     return ret;
 }
-#endif


### PR DESCRIPTION
ECDSA signature lengths are calculated using i2d_ECDSA_SIG().
i2d_ECDSA_SIG() was changed in a previous PR to use a custom ASN1 encoder (using WPACKET)
so that the normal ASN1 encoder does not need to be pulled into the provider boundary.
For consistency ECDSA_size() has been changed to also use i2d_ECDSA_SIG() - this can now
be used directly inside the FIPS provider.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
