### PR TITLE
Return 1 when -addext kv is duplicated

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -214,9 +214,12 @@ static int duplicated(LHASH_OF(OPENSSL_STRING) *addexts, char *kv)
     *p = '\0';
 
     /* Finally have a clean "key"; see if it's there [by attempt to add it]. */
-    if ((p = (char *)lh_OPENSSL_STRING_insert(addexts, (OPENSSL_STRING*)kv))
-        != NULL || lh_OPENSSL_STRING_error(addexts)) {
-        OPENSSL_free(p != NULL ? p : kv);
+    p = (char *)lh_OPENSSL_STRING_insert(addexts, (OPENSSL_STRING*)kv);
+    if (p != NULL) {
+        OPENSSL_free(p);
+        return 1;
+    } else if (lh_OPENSSL_STRING_error(addexts)) {
+        OPENSSL_free(kv);
         return -1;
     }
 


### PR DESCRIPTION
Fixes #10273 

About the function duplicated() in apps/req.c .
Comment says "1 if found or a syntax error",
but it returns -1 if -addext kv is duplicated  after commit https://github.com/openssl/openssl/commit/750d5587d1d688df964cb37e86942da7e639d47b .
To detect duplicated, it should return 1 if p != NULL.

