### PR TITLE
Move U64 macro from sha.h to sha512.c

### DIFF
--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -60,6 +60,14 @@
 # define SHA512_BLOCK_CAN_MANAGE_UNALIGNED_DATA
 #endif
 
+#if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
+# define U64(C)     C##UI64
+#elif defined(__arch64__)
+# define U64(C)     C##UL
+#else
+# define U64(C)     C##ULL
+#endif
+
 int sha512_224_init(SHA512_CTX *c)
 {
     c->h[0] = U64(0x8c3d37c819544da2);

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -89,13 +89,10 @@ void SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
 # define SHA512_CBLOCK   (SHA_LBLOCK*8)
 # if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
 #  define SHA_LONG64 unsigned __int64
-#  define U64(C)     C##UI64
 # elif defined(__arch64__)
 #  define SHA_LONG64 unsigned long
-#  define U64(C)     C##UL
 # else
 #  define SHA_LONG64 unsigned long long
-#  define U64(C)     C##ULL
 # endif
 
 typedef struct SHA512state_st {


### PR DESCRIPTION
Summary:
U64 is too common name for macro, being in public header sha.h it
conflicts with other projects (WAVM in my case). Moving macro from
public header to the only .c file using it.

Fixes #7935

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
