### PR TITLE
Deprecate the low level AES functions 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -363,7 +363,17 @@
      for scripting purposes.
      [Richard Levitte]
 
-  *) The functions AES_ige_encrypt() and AES_bi_ige_encrypt() have been
+  *) All of the low level AES functions have been deprecated including:
+     AES_options, AES_set_encrypt_key, AES_set_decrypt_key, AES_encrypt,
+     AES_decrypt, AES_ecb_encrypt, AES_cbc_encrypt, AES_cfb128_encrypt,
+     AES_cfb1_encrypt, AES_cfb8_encrypt, AES_ofb128_encrypt, AES_wrap_key and
+     AES_unwrap_key
+     Use of these low level functions has been informally discouraged for a long
+     time. Instead applications should use the high level EVP APIs, e.g.
+     EVP_EncryptInit_ex, EVP_EncryptUpdate, EVP_EncryptFinal_ex, and the
+     equivalently named decrypt functions.
+
+     The functions AES_ige_encrypt() and AES_bi_ige_encrypt() have also been
      deprecated. These undocumented functions were never integrated into the EVP
      layer and implement the AES Infinite Garble Extension (IGE) mode and AES
      Bi-directional IGE mode. These modes were never formally standardised and

--- a/Configure
+++ b/Configure
@@ -559,6 +559,11 @@ my @disable_cascades = (
     "legacy"                 => [ "md2" ],
 
     "cmp"               => [ "crmf" ],
+
+    # Padlock engine uses low-level AES APIs which are deprecated
+    sub { $disabled{"deprecated"}
+          && (!defined $config{"api"} || $config{"api"} >= 30000) }
+          => [ "padlockeng" ]
     );
 
 # Avoid protocol support holes.  Also disable all versions below N, if version

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -44,7 +44,9 @@
 #ifndef OPENSSL_NO_DES
 # include <openssl/des.h>
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 #include <openssl/aes.h>
+#endif
 #ifndef OPENSSL_NO_CAMELLIA
 # include <openssl/camellia.h>
 #endif
@@ -358,10 +360,10 @@ static const OPT_PAIR doit_choices[] = {
     {"des-cbc", D_CBC_DES},
     {"des-ede3", D_EDE3_DES},
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     {"aes-128-cbc", D_CBC_128_AES},
     {"aes-192-cbc", D_CBC_192_AES},
     {"aes-256-cbc", D_CBC_256_AES},
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     {"aes-128-ige", D_IGE_128_AES},
     {"aes-192-ige", D_IGE_192_AES},
     {"aes-256-ige", D_IGE_256_AES},
@@ -752,6 +754,8 @@ static int DES_ede3_cbc_encrypt_loop(void *args)
 #define MAX_BLOCK_SIZE 128
 
 static unsigned char iv[2 * MAX_BLOCK_SIZE / 8];
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 static AES_KEY aes_ks1, aes_ks2, aes_ks3;
 static int AES_cbc_128_encrypt_loop(void *args)
 {
@@ -786,7 +790,6 @@ static int AES_cbc_256_encrypt_loop(void *args)
     return count;
 }
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
 static int AES_ige_128_encrypt_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -822,7 +825,6 @@ static int AES_ige_256_encrypt_loop(void *args)
                         (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
     return count;
 }
-#endif
 
 static int CRYPTO_gcm128_aad_loop(void *args)
 {
@@ -834,6 +836,7 @@ static int CRYPTO_gcm128_aad_loop(void *args)
         CRYPTO_gcm128_aad(gcm_ctx, buf, lengths[testnum]);
     return count;
 }
+#endif
 
 static int RAND_bytes_loop(void *args)
 {
@@ -1751,10 +1754,12 @@ int speed_main(int argc, char **argv)
             }
         }
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
         if (strcmp(algo, "aes") == 0) {
             doit[D_CBC_128_AES] = doit[D_CBC_192_AES] = doit[D_CBC_256_AES] = 1;
             continue;
         }
+#endif
 #ifndef OPENSSL_NO_CAMELLIA
         if (strcmp(algo, "camellia") == 0) {
             doit[D_CBC_128_CML] = doit[D_CBC_192_CML] = doit[D_CBC_256_CML] = 1;
@@ -1948,9 +1953,11 @@ int speed_main(int argc, char **argv)
         DES_set_key_unchecked(&keys[2], &sch[2]);
     }
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     AES_set_encrypt_key(key16, 128, &aes_ks1);
     AES_set_encrypt_key(key24, 192, &aes_ks2);
     AES_set_encrypt_key(key32, 256, &aes_ks3);
+#endif
 #ifndef OPENSSL_NO_CAMELLIA
     if (doit[D_CBC_128_CML] || doit[D_CBC_192_CML] || doit[D_CBC_256_CML]) {
         Camellia_set_key(key16, 128, &camellia_ks[0]);
@@ -2409,6 +2416,7 @@ int speed_main(int argc, char **argv)
     }
 #endif
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     if (doit[D_CBC_128_AES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_CBC_128_AES], c[D_CBC_128_AES][testnum],
@@ -2443,7 +2451,7 @@ int speed_main(int argc, char **argv)
         }
     }
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+
     if (doit[D_IGE_128_AES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_IGE_128_AES], c[D_IGE_128_AES][testnum],
@@ -2477,7 +2485,6 @@ int speed_main(int argc, char **argv)
             print_result(D_IGE_256_AES, testnum, count, d);
         }
     }
-#endif
     if (doit[D_GHASH]) {
         for (i = 0; i < loopargs_len; i++) {
             loopargs[i].gcm_ctx =
@@ -2497,6 +2504,7 @@ int speed_main(int argc, char **argv)
         for (i = 0; i < loopargs_len; i++)
             CRYPTO_gcm128_release(loopargs[i].gcm_ctx);
     }
+#endif /* OPENSSL_NO_DEPRECATED_3_0 */
 #ifndef OPENSSL_NO_CAMELLIA
     if (doit[D_CBC_128_CML]) {
         if (async_jobs > 0) {
@@ -3490,7 +3498,9 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DES
         printf("%s ", DES_options());
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
         printf("%s ", AES_options());
+#endif
 #ifndef OPENSSL_NO_IDEA
         printf("%s ", IDEA_options());
 #endif

--- a/crypto/aes/aes_cbc.c
+++ b/crypto/aes/aes_cbc.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/aes.h>
 #include <openssl/modes.h>
 

--- a/crypto/aes/aes_cfb.c
+++ b/crypto/aes/aes_cfb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES_encrypt is deprecated - but we need to use it to implement these other
+ * deprecated APIs.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/aes.h>
 #include <openssl/modes.h>
 

--- a/crypto/aes/aes_core.c
+++ b/crypto/aes/aes_core.c
@@ -36,6 +36,13 @@
 /* Note: rewritten a little bit to provide error control and an OpenSSL-
    compatible API */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include <assert.h>
 
 #include <stdlib.h>

--- a/crypto/aes/aes_ecb.c
+++ b/crypto/aes/aes_ecb.c
@@ -9,6 +9,12 @@
 
 #include <assert.h>
 
+/*
+ * AES_encrypt/AES_decrypt are deprecated - but we need to use them to implement
+ * AES_ecb_encrypt
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/aes.h>
 #include "aes_local.h"
 

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES_encrypt/AES_decrypt are deprecated - but we need to use them to implement
+ * these functions
+ */
+#include "internal/deprecated.h"
+
 #include "internal/cryptlib.h"
 
 #ifdef OPENSSL_NO_DEPRECATED_3_0

--- a/crypto/aes/aes_misc.c
+++ b/crypto/aes/aes_misc.c
@@ -11,11 +11,13 @@
 #include <openssl/aes.h>
 #include "aes_local.h"
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 const char *AES_options(void)
 {
-#ifdef FULL_UNROLL
+# ifdef FULL_UNROLL
     return "aes(full)";
-#else
+# else
     return "aes(partial)";
-#endif
+# endif
 }
+#endif

--- a/crypto/aes/aes_ofb.c
+++ b/crypto/aes/aes_ofb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES_encrypt is deprecated - but we need to use it to implement
+ * AES_ofb128_encrypt
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/aes.h>
 #include <openssl/modes.h>
 

--- a/crypto/aes/aes_wrap.c
+++ b/crypto/aes/aes_wrap.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES_encrypt/AES_decrypt are deprecated - but we need to use them to implement
+ * these functions
+ */
+#include "internal/deprecated.h"
+
 #include "internal/cryptlib.h"
 #include <openssl/aes.h>
 #include <openssl/modes.h>

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -13,7 +13,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/cms.h>
-#include <openssl/aes.h>
+#include <openssl/evp.h>
 #include "cms_local.h"
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
@@ -625,6 +625,23 @@ int CMS_RecipientInfo_set0_key(CMS_RecipientInfo *ri,
     return 1;
 }
 
+static const EVP_CIPHER *cms_get_key_wrap_cipher(size_t keylen)
+{
+    switch(keylen) {
+    case 16:
+        return EVP_aes_128_wrap();
+
+    case 24:
+        return EVP_aes_192_wrap();
+
+    case 32:
+        return EVP_aes_256_wrap();
+    }
+
+    return NULL;
+}
+
+
 /* Encrypt content key in KEK recipient info */
 
 static int cms_RecipientInfo_kekri_encrypt(const CMS_ContentInfo *cms,
@@ -632,49 +649,56 @@ static int cms_RecipientInfo_kekri_encrypt(const CMS_ContentInfo *cms,
 {
     CMS_EncryptedContentInfo *ec;
     CMS_KEKRecipientInfo *kekri;
-    AES_KEY actx;
     unsigned char *wkey = NULL;
     int wkeylen;
     int r = 0;
+    const EVP_CIPHER *cipher = NULL;
+    int outlen = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
 
     ec = cms->d.envelopedData->encryptedContentInfo;
 
     kekri = ri->d.kekri;
 
-    if (!kekri->key) {
+    if (kekri->key == NULL) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, CMS_R_NO_KEY);
         return 0;
     }
 
-    if (AES_set_encrypt_key(kekri->key, kekri->keylen << 3, &actx)) {
-        CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT,
-               CMS_R_ERROR_SETTING_KEY);
+    cipher = cms_get_key_wrap_cipher(kekri->keylen);
+    if (cipher == NULL) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, CMS_R_INVALID_KEY_LENGTH);
         goto err;
     }
 
     wkey = OPENSSL_malloc(ec->keylen + 8);
-
     if (wkey == NULL) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
-    wkeylen = AES_wrap_key(&actx, NULL, wkey, ec->key, ec->keylen);
+    ctx = EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, ERR_R_MALLOC_FAILURE);
+        goto err;
+    }
 
-    if (wkeylen <= 0) {
+    if (!EVP_EncryptInit_ex(ctx, cipher, NULL, kekri->key, NULL)
+            || !EVP_EncryptUpdate(ctx, wkey, &wkeylen, ec->key, ec->keylen)
+            || !EVP_EncryptFinal_ex(ctx, wkey + wkeylen, &outlen)) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, CMS_R_WRAP_ERROR);
         goto err;
     }
+    wkeylen += outlen;
 
     ASN1_STRING_set0(kekri->encryptedKey, wkey, wkeylen);
 
     r = 1;
 
  err:
-
     if (!r)
         OPENSSL_free(wkey);
-    OPENSSL_cleanse(&actx, sizeof(actx));
+    EVP_CIPHER_CTX_free(ctx);
 
     return r;
 
@@ -687,10 +711,12 @@ static int cms_RecipientInfo_kekri_decrypt(CMS_ContentInfo *cms,
 {
     CMS_EncryptedContentInfo *ec;
     CMS_KEKRecipientInfo *kekri;
-    AES_KEY actx;
     unsigned char *ukey = NULL;
     int ukeylen;
     int r = 0, wrap_nid;
+    const EVP_CIPHER *cipher = NULL;
+    int outlen = 0;
+    EVP_CIPHER_CTX *ctx = NULL;
 
     ec = cms->d.envelopedData->encryptedContentInfo;
 
@@ -716,27 +742,33 @@ static int cms_RecipientInfo_kekri_decrypt(CMS_ContentInfo *cms,
         goto err;
     }
 
-    if (AES_set_decrypt_key(kekri->key, kekri->keylen << 3, &actx)) {
-        CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT,
-               CMS_R_ERROR_SETTING_KEY);
+    cipher = cms_get_key_wrap_cipher(kekri->keylen);
+    if (cipher == NULL) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT, CMS_R_INVALID_KEY_LENGTH);
         goto err;
     }
 
     ukey = OPENSSL_malloc(kekri->encryptedKey->length - 8);
-
     if (ukey == NULL) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
-    ukeylen = AES_unwrap_key(&actx, NULL, ukey,
-                             kekri->encryptedKey->data,
-                             kekri->encryptedKey->length);
+    ctx = EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT, ERR_R_MALLOC_FAILURE);
+        goto err;
+    }
 
-    if (ukeylen <= 0) {
+    if (!EVP_DecryptInit_ex(ctx, cipher, NULL, kekri->key, NULL)
+            || !EVP_DecryptUpdate(ctx, ukey, &ukeylen,
+                                  kekri->encryptedKey->data,
+                                  kekri->encryptedKey->length)
+            || !EVP_DecryptFinal_ex(ctx, ukey + ukeylen, &outlen)) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT, CMS_R_UNWRAP_ERROR);
         goto err;
     }
+    ukeylen += outlen;
 
     ec->key = ukey;
     ec->keylen = ukeylen;
@@ -744,10 +776,9 @@ static int cms_RecipientInfo_kekri_decrypt(CMS_ContentInfo *cms,
     r = 1;
 
  err:
-
     if (!r)
         OPENSSL_free(ukey);
-    OPENSSL_cleanse(&actx, sizeof(actx));
+    EVP_CIPHER_CTX_free(ctx);
 
     return r;
 

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement the EVP AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <assert.h>
 #include <openssl/opensslconf.h>

--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/opensslconf.h>

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/opensslconf.h>

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement the padlock engine AES ciphers.
+ */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <stdio.h>
 #include <string.h>
 

--- a/include/internal/deprecated.h
+++ b/include/internal/deprecated.h
@@ -16,8 +16,8 @@
  * This header *must* be the first OpenSSL header included by a source file.
  */
 
-#ifndef OSSL_INTERNAL_DEPRECTATED_H
-# define OSSL_INTERNAL_DEPRECTATED_H
+#ifndef OSSL_INTERNAL_DEPRECATED_H
+# define OSSL_INTERNAL_DEPRECATED_H
 
 # include <openssl/configuration.h>
 

--- a/include/internal/deprecated.h
+++ b/include/internal/deprecated.h
@@ -10,8 +10,8 @@
 /*
  * This header file should be included by internal code that needs to use APIs
  * that have been deprecated for public use, but where those symbols will still
- * be available internally. For example the EVP code need to use low level APIs
- * that are otherwise deprecated.
+ * be available internally. For example the EVP and provider code needs to use
+ * low level APIs that are otherwise deprecated.
  *
  * This header *must* be the first OpenSSL header included by a source file.
  */

--- a/include/internal/deprecated.h
+++ b/include/internal/deprecated.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This header file should be included by internal code that needs to use APIs
+ * that have been deprecated for public use, but where those symbols will still
+ * be available internally. For example the EVP code need to use low level APIs
+ * that are otherwise deprecated.
+ *
+ * This header *must* be the first OpenSSL header included by a source file.
+ */
+
+#ifndef OSSL_INTERNAL_DEPRECTATED_H
+# define OSSL_INTERNAL_DEPRECTATED_H
+
+# include <openssl/configuration.h>
+
+# undef OPENSSL_NO_DEPRECATED
+# define OPENSSL_SUPPRESS_DEPRECATED
+
+# include <openssl/macros.h>
+
+#endif

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -23,56 +23,69 @@
 extern "C" {
 # endif
 
-# define AES_ENCRYPT     1
-# define AES_DECRYPT     0
-
-/*
- * Because array size can't be a const in C, the following two are macros.
- * Both sizes are in bytes.
- */
-# define AES_MAXNR 14
 # define AES_BLOCK_SIZE 16
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+
+#  define AES_ENCRYPT     1
+#  define AES_DECRYPT     0
+
+#  define AES_MAXNR 14
+
 
 /* This should be a hidden type, but EVP requires that the size be known */
 struct aes_key_st {
-# ifdef AES_LONG
+#  ifdef AES_LONG
     unsigned long rd_key[4 * (AES_MAXNR + 1)];
-# else
+#  else
     unsigned int rd_key[4 * (AES_MAXNR + 1)];
-# endif
+#  endif
     int rounds;
 };
 typedef struct aes_key_st AES_KEY;
 
-const char *AES_options(void);
+# endif
 
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key);
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key);
+DEPRECATEDIN_3_0(const char *AES_options(void))
 
-void AES_encrypt(const unsigned char *in, unsigned char *out,
-                 const AES_KEY *key);
-void AES_decrypt(const unsigned char *in, unsigned char *out,
-                 const AES_KEY *key);
+DEPRECATEDIN_3_0(int
+                 AES_set_encrypt_key(const unsigned char *userKey,
+                                     const int bits, AES_KEY *key))
+DEPRECATEDIN_3_0(int
+                 AES_set_decrypt_key(const unsigned char *userKey,
+                                     const int bits, AES_KEY *key))
 
-void AES_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                     const AES_KEY *key, const int enc);
-void AES_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                     size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc);
-void AES_cfb128_encrypt(const unsigned char *in, unsigned char *out,
-                        size_t length, const AES_KEY *key,
-                        unsigned char *ivec, int *num, const int enc);
-void AES_cfb1_encrypt(const unsigned char *in, unsigned char *out,
-                      size_t length, const AES_KEY *key,
-                      unsigned char *ivec, int *num, const int enc);
-void AES_cfb8_encrypt(const unsigned char *in, unsigned char *out,
-                      size_t length, const AES_KEY *key,
-                      unsigned char *ivec, int *num, const int enc);
-void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
-                        size_t length, const AES_KEY *key,
-                        unsigned char *ivec, int *num);
+DEPRECATEDIN_3_0(void
+                 AES_encrypt(const unsigned char *in, unsigned char *out,
+                             const AES_KEY *key))
+DEPRECATEDIN_3_0(void
+                 AES_decrypt(const unsigned char *in, unsigned char *out,
+                             const AES_KEY *key))
+
+DEPRECATEDIN_3_0(void
+                 AES_ecb_encrypt(const unsigned char *in, unsigned char *out,
+                                 const AES_KEY *key, const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                                 size_t length, const AES_KEY *key,
+                                 unsigned char *ivec, const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_cfb128_encrypt(const unsigned char *in, unsigned char *out,
+                                    size_t length, const AES_KEY *key,
+                                    unsigned char *ivec, int *num,
+                                    const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_cfb1_encrypt(const unsigned char *in, unsigned char *out,
+                                  size_t length, const AES_KEY *key,
+                                  unsigned char *ivec, int *num, const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_cfb8_encrypt(const unsigned char *in, unsigned char *out,
+                                  size_t length, const AES_KEY *key,
+                                  unsigned char *ivec, int *num, const int enc))
+DEPRECATEDIN_3_0(void
+                 AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
+                                    size_t length, const AES_KEY *key,
+                                    unsigned char *ivec, int *num))
 
 /* NB: the IV is _two_ blocks long */
 DEPRECATEDIN_3_0(void
@@ -86,12 +99,14 @@ DEPRECATEDIN_3_0(void
                                     const AES_KEY *key2,
                                     const unsigned char *ivec, const int enc))
 
-int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
-                 unsigned char *out,
-                 const unsigned char *in, unsigned int inlen);
-int AES_unwrap_key(AES_KEY *key, const unsigned char *iv,
-                   unsigned char *out,
-                   const unsigned char *in, unsigned int inlen);
+DEPRECATEDIN_3_0(int
+                 AES_wrap_key(AES_KEY *key, const unsigned char *iv,
+                              unsigned char *out, const unsigned char *in,
+                              unsigned int inlen))
+DEPRECATEDIN_3_0(int
+                 AES_unwrap_key(AES_KEY *key, const unsigned char *iv,
+                                unsigned char *out, const unsigned char *in,
+                                unsigned int inlen))
 
 
 # ifdef  __cplusplus

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -25,6 +25,9 @@
 
 /*
  * Generic deprecation macro
+  *
+  * If OPENSSL_SUPPRESS_DEPRECATED is defined, then DECLARE_DEPRECATED
+  * becomes a no-op
  */
 # ifndef DECLARE_DEPRECATED
 #  define DECLARE_DEPRECATED(f)   f;

--- a/providers/implementations/ciphers/cipher_aes.c
+++ b/providers/implementations/ciphers/cipher_aes.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 /* Dispatch functions for AES cipher modes ecb, cbc, ofb, cfb, ctr */
 
 #include "cipher_aes.h"

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 /* Dispatch functions for AES CCM mode */
 
 #include "cipher_aes_ccm.h"

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw.c
@@ -9,6 +9,12 @@
 
 /* AES CCM mode */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_ccm.h"
 
 #define AES_HW_CCM_SET_KEY_FN(fn_set_enc_key, fn_blk, fn_ccm_enc, fn_ccm_dec)  \

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 /* Dispatch functions for AES GCM mode */
 
 #include "cipher_aes_gcm.h"

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for AES GCM mode */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_gcm.h"
 
 static int generic_aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes.h"
 #include "prov/providercommonerr.h"
 

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_ocb.h"
 #include "prov/providercommonerr.h"
 #include "prov/ciphercommon_aead.h"

--- a/providers/implementations/ciphers/cipher_aes_ocb_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_ocb.h"
 
 #define OCB_SET_KEY_FN(fn_set_enc_key, fn_set_dec_key,                         \

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for AES SIV mode */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_siv.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"

--- a/providers/implementations/ciphers/cipher_aes_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_siv_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_siv.h"
 
 static int aes_siv_initkey(void *vctx, const unsigned char *key, size_t keylen)

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes.h"
 #include "prov/providercommonerr.h"
 #include "prov/implementations.h"

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_xts.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"

--- a/providers/implementations/ciphers/cipher_aes_xts_fips.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_fips.c
@@ -7,8 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "cipher_aes_xts.h"
-
 #ifdef FIPS_MODE
 const int allow_insecure_decrypt = 0;
 #else

--- a/providers/implementations/ciphers/cipher_aes_xts_fips.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_fips.c
@@ -7,6 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
+#include "cipher_aes_xts.h"
+
 #ifdef FIPS_MODE
 const int allow_insecure_decrypt = 0;
 #else

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_xts.h"
 
 #define XTS_SET_KEY_FN(fn_set_enc_key, fn_set_dec_key,                         \

--- a/test/build.info
+++ b/test/build.info
@@ -40,7 +40,7 @@ IF[{- !$disabled{tests} -}]
           dhtest enginetest casttest \
           bftest ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
           evp_pkey_provided_test evp_test evp_extra_test evp_fetch_prov_test \
-          igetest v3nametest v3ext \
+          v3nametest v3ext \
           crltest danetest bad_dtls_test lhash_test sparse_array_test \
           conf_include_test params_api_test params_conversion_test \
           constant_time_test verify_extra_test clienthellotest \
@@ -214,9 +214,13 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[evp_pkey_provided_test]=../include ../apps/include
   DEPEND[evp_pkey_provided_test]=../libcrypto libtestutil.a
 
-  SOURCE[igetest]=igetest.c
-  INCLUDE[igetest]=../include ../apps/include
-  DEPEND[igetest]=../libcrypto libtestutil.a
+  IF[{- !$disabled{"deprecated"}
+        || (defined $config{"api"} && $config{"api"} < 30000) -}]
+    PROGRAMS{noinst}=igetest
+    SOURCE[igetest]=igetest.c
+    INCLUDE[igetest]=../include ../apps/include
+    DEPEND[igetest]=../libcrypto libtestutil.a
+  ENDIF
 
   SOURCE[v3nametest]=v3nametest.c
   INCLUDE[v3nametest]=../include ../apps/include

--- a/test/modes_internal_test.c
+++ b/test/modes_internal_test.c
@@ -9,6 +9,12 @@
 
 /* Internal tests for the modes module */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to test the modes code
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 

--- a/test/recipes/90-test_ige.t
+++ b/test/recipes/90-test_ige.t
@@ -7,6 +7,17 @@
 # https://www.openssl.org/source/license.html
 
 
+use strict;
+use warnings;
+
 use OpenSSL::Test::Simple;
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_ige");
+
+plan skip_all => "AES_ige support is disabled in this build"
+    if disabled("deprecated")
+       && (!defined config("api") || config("api") >= 30000);
 
 simple_test("test_ige", "igetest");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -745,7 +745,7 @@ PKCS7_ENC_CONTENT_free                  763	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_type                  764	3_0_0	EXIST::FUNCTION:CMS
 OCSP_BASICRESP_get_ext                  765	3_0_0	EXIST::FUNCTION:OCSP
 BN_lebin2bn                             766	3_0_0	EXIST::FUNCTION:
-AES_decrypt                             767	3_0_0	EXIST::FUNCTION:
+AES_decrypt                             767	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BIO_fd_should_retry                     768	3_0_0	EXIST::FUNCTION:
 ASN1_STRING_new                         769	3_0_0	EXIST::FUNCTION:
 ENGINE_init                             770	3_0_0	EXIST::FUNCTION:ENGINE
@@ -951,7 +951,7 @@ CRYPTO_THREAD_read_lock                 974	3_0_0	EXIST::FUNCTION:
 ASIdentifierChoice_free                 975	3_0_0	EXIST::FUNCTION:RFC3779
 BIO_dgram_sctp_msg_waiting              976	3_0_0	EXIST::FUNCTION:DGRAM,SCTP
 BN_is_bit_set                           978	3_0_0	EXIST::FUNCTION:
-AES_ofb128_encrypt                      979	3_0_0	EXIST::FUNCTION:
+AES_ofb128_encrypt                      979	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_STORE_add_lookup                   980	3_0_0	EXIST::FUNCTION:
 ASN1_GENERALSTRING_new                  981	3_0_0	EXIST::FUNCTION:
 IDEA_options                            982	3_0_0	EXIST::FUNCTION:IDEA
@@ -1251,7 +1251,7 @@ d2i_DIST_POINT_NAME                     1279	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_set_int64                  1280	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_free                          1281	3_0_0	EXIST::FUNCTION:
 i2o_SCT_LIST                            1282	3_0_0	EXIST::FUNCTION:CT
-AES_encrypt                             1283	3_0_0	EXIST::FUNCTION:
+AES_encrypt                             1283	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 MD5_Init                                1284	3_0_0	EXIST::FUNCTION:MD5
 UI_add_error_string                     1285	3_0_0	EXIST::FUNCTION:
 X509_TRUST_cleanup                      1286	3_0_0	EXIST::FUNCTION:
@@ -1470,9 +1470,9 @@ PKCS7_dataFinal                         1503	3_0_0	EXIST::FUNCTION:
 SHA1_Final                              1504	3_0_0	EXIST::FUNCTION:
 i2a_ASN1_STRING                         1505	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_rand_key                 1506	3_0_0	EXIST::FUNCTION:
-AES_set_encrypt_key                     1507	3_0_0	EXIST::FUNCTION:
+AES_set_encrypt_key                     1507	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ASN1_UTCTIME_new                        1508	3_0_0	EXIST::FUNCTION:
-AES_cbc_encrypt                         1509	3_0_0	EXIST::FUNCTION:
+AES_cbc_encrypt                         1509	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 OCSP_RESPDATA_free                      1510	3_0_0	EXIST::FUNCTION:OCSP
 EVP_PKEY_asn1_find                      1511	3_0_0	EXIST::FUNCTION:
 d2i_ASN1_GENERALIZEDTIME                1512	3_0_0	EXIST::FUNCTION:
@@ -1674,9 +1674,9 @@ d2i_PKCS7_bio                           1712	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_digests              1713	3_0_0	EXIST::FUNCTION:ENGINE
 i2d_PublicKey                           1714	3_0_0	EXIST::FUNCTION:
 RC5_32_set_key                          1715	3_0_0	EXIST::FUNCTION:RC5
-AES_unwrap_key                          1716	3_0_0	EXIST::FUNCTION:
+AES_unwrap_key                          1716	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_Cipher                              1717	3_0_0	EXIST::FUNCTION:
-AES_set_decrypt_key                     1718	3_0_0	EXIST::FUNCTION:
+AES_set_decrypt_key                     1718	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BF_ofb64_encrypt                        1719	3_0_0	EXIST::FUNCTION:BF
 d2i_TS_TST_INFO_fp                      1720	3_0_0	EXIST::FUNCTION:STDIO,TS
 X509_find_by_issuer_and_serial          1721	3_0_0	EXIST::FUNCTION:
@@ -1855,7 +1855,7 @@ EVP_CIPHER_CTX_copy                     1898	3_0_0	EXIST::FUNCTION:
 CRYPTO_secure_allocated                 1899	3_0_0	EXIST::FUNCTION:
 UI_UTIL_read_pw_string                  1900	3_0_0	EXIST::FUNCTION:
 NOTICEREF_free                          1901	3_0_0	EXIST::FUNCTION:
-AES_cfb1_encrypt                        1902	3_0_0	EXIST::FUNCTION:
+AES_cfb1_encrypt                        1902	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509v3_get_ext                          1903	3_0_0	EXIST::FUNCTION:
 CRYPTO_gcm128_encrypt_ctr32             1905	3_0_0	EXIST::FUNCTION:
 SCT_set1_signature                      1906	3_0_0	EXIST::FUNCTION:CT
@@ -1990,7 +1990,7 @@ d2i_CMS_bio                             2035	3_0_0	EXIST::FUNCTION:CMS
 OPENSSL_sk_num                          2036	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_set0_pkey             2038	3_0_0	EXIST::FUNCTION:CMS
 X509_STORE_CTX_set_default              2039	3_0_0	EXIST::FUNCTION:
-AES_wrap_key                            2040	3_0_0	EXIST::FUNCTION:
+AES_wrap_key                            2040	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_md_null                             2041	3_0_0	EXIST::FUNCTION:
 i2d_SCT_LIST                            2042	3_0_0	EXIST::FUNCTION:CT
 PKCS7_get_issuer_and_serial             2043	3_0_0	EXIST::FUNCTION:
@@ -2241,7 +2241,7 @@ TS_TST_INFO_set_nonce                   2288	3_0_0	EXIST::FUNCTION:TS
 PEM_read_ECPrivateKey                   2289	3_0_0	EXIST::FUNCTION:EC,STDIO
 RSA_free                                2290	3_0_0	EXIST::FUNCTION:RSA
 X509_CRL_INFO_new                       2291	3_0_0	EXIST::FUNCTION:
-AES_cfb8_encrypt                        2292	3_0_0	EXIST::FUNCTION:
+AES_cfb8_encrypt                        2292	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 d2i_ASN1_SEQUENCE_ANY                   2293	3_0_0	EXIST::FUNCTION:
 PKCS12_create                           2294	3_0_0	EXIST::FUNCTION:
 X509at_get_attr_count                   2295	3_0_0	EXIST::FUNCTION:
@@ -2445,7 +2445,7 @@ TS_STATUS_INFO_free                     2495	3_0_0	EXIST::FUNCTION:TS
 BN_mod_mul                              2496	3_0_0	EXIST::FUNCTION:
 CMS_add0_recipient_key                  2497	3_0_0	EXIST::FUNCTION:CMS
 BIO_f_zlib                              2498	3_0_0	EXIST::FUNCTION:COMP,ZLIB
-AES_cfb128_encrypt                      2499	3_0_0	EXIST::FUNCTION:
+AES_cfb128_encrypt                      2499	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ENGINE_set_EC                           2500	3_0_0	EXIST::FUNCTION:ENGINE
 d2i_ECPKParameters                      2501	3_0_0	EXIST::FUNCTION:EC
 IDEA_ofb64_encrypt                      2502	3_0_0	EXIST::FUNCTION:IDEA
@@ -2644,7 +2644,7 @@ OCSP_basic_add1_cert                    2700	3_0_0	EXIST::FUNCTION:OCSP
 ASN1_PRINTABLESTRING_new                2701	3_0_0	EXIST::FUNCTION:
 i2d_PBEPARAM                            2702	3_0_0	EXIST::FUNCTION:
 NETSCAPE_SPKI_new                       2703	3_0_0	EXIST::FUNCTION:
-AES_options                             2704	3_0_0	EXIST::FUNCTION:
+AES_options                             2704	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 POLICYINFO_free                         2705	3_0_0	EXIST::FUNCTION:
 PEM_read_bio_Parameters                 2706	3_0_0	EXIST::FUNCTION:
 BN_abs_is_word                          2707	3_0_0	EXIST::FUNCTION:
@@ -3472,7 +3472,7 @@ ERR_load_OBJ_strings                    3544	3_0_0	EXIST::FUNCTION:
 BIO_ctrl_get_read_request               3545	3_0_0	EXIST::FUNCTION:
 BN_from_montgomery                      3546	3_0_0	EXIST::FUNCTION:
 DSO_new                                 3547	3_0_0	EXIST::FUNCTION:
-AES_ecb_encrypt                         3548	3_0_0	EXIST::FUNCTION:
+AES_ecb_encrypt                         3548	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BN_dec2bn                               3549	3_0_0	EXIST::FUNCTION:
 CMS_decrypt                             3550	3_0_0	EXIST::FUNCTION:CMS
 BN_mpi2bn                               3551	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use of the low level AES functions has been informally discouraged for a
long time. We now formally deprecate them.

Applications should instead use the EVP APIs, e.g. EVP_EncryptInit_ex,
EVP_EncryptUpdate, EVP_EncryptFinal_ex, and the equivalently named decrypt
functions.