### PR TITLE
test/namemap_internal_test.c: use "cookie" instead of "foo"...

### DIFF
--- a/test/namemap_internal_test.c
+++ b/test/namemap_internal_test.c
@@ -26,7 +26,7 @@ static int test_namemap(OSSL_NAMEMAP *nm)
     int check2 = ossl_namemap_name2num(nm, NAME2);
     int check3 = ossl_namemap_name2num(nm, ALIAS1);
     int check4 = ossl_namemap_name2num(nm, ALIAS1_UC);
-    int false1 = ossl_namemap_name2num(nm, "foo");
+    int false1 = ossl_namemap_name2num(nm, "cookie");
 
     return TEST_int_ne(num1, 0)
         && TEST_int_ne(num2, 0)


### PR DESCRIPTION
... in test_namemap()

Because tests may sometimes run in random order (subject of the
environment variable OPENSSL_TEST_RAND_ORDER being defined), and we're
dealing with the global namemap, each test must use names that are
globally unique for that test.  Unfortunately, we used "foo" in two of
them, which might lead to surprising results.

Fixes #10401
