### PR TITLE
PROV: Move AES_CCM specialisation away from common cipher header

### DIFF
--- a/providers/implementations/ciphers/cipher_aes.h
+++ b/providers/implementations/ciphers/cipher_aes.h
@@ -59,4 +59,3 @@ const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_cfb128(size_t keybits);
 const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_cfb1(size_t keybits);
 const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_cfb8(size_t keybits);
 const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_ctr(size_t keybits);
-

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -9,8 +9,7 @@
 
 /* Dispatch functions for AES CCM mode */
 
-#include "prov/ciphercommon.h"
-#include "prov/ciphercommon_ccm.h"
+#include "cipher_aes_ccm.h"
 #include "prov/implementations.h"
 
 static void *aes_ccm_newctx(void *provctx, size_t keybits)

--- a/providers/implementations/ciphers/cipher_aes_ccm.h
+++ b/providers/implementations/ciphers/cipher_aes_ccm.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/aes.h>
+#include "prov/ciphercommon.h"
+#include "prov/ciphercommon_ccm.h"
+
+typedef struct prov_aes_ccm_ctx_st {
+    PROV_CCM_CTX base;         /* Must be first */
+    union {
+        OSSL_UNION_ALIGN;
+        /*-
+         * Padding is chosen so that s390x.kmac.k overlaps with ks.ks and
+         * fc with ks.ks.rounds. Remember that on s390x, an AES_KEY's
+         * rounds field is used to store the function code and that the key
+         * schedule is not stored (if aes hardware support is detected).
+         */
+        struct {
+            unsigned char pad[16];
+            AES_KEY ks;
+        } ks;
+#if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
+        struct {
+            S390X_KMAC_PARAMS kmac;
+            unsigned long long blocks;
+            union {
+                unsigned long long g[2];
+                unsigned char b[AES_BLOCK_SIZE];
+            } nonce;
+            union {
+                unsigned long long g[2];
+                unsigned char b[AES_BLOCK_SIZE];
+            } buf;
+            unsigned char dummy_pad[168];
+            unsigned int fc;   /* fc has same offset as ks.ks.rounds */
+        } s390x;
+#endif /* defined(OPENSSL_CPUID_OBJ) && defined(__s390__) */
+    } ccm;
+} PROV_AES_CCM_CTX;
+
+const PROV_CCM_HW *PROV_AES_HW_ccm(size_t keylen);

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw.c
@@ -9,8 +9,7 @@
 
 /* AES CCM mode */
 
-#include "prov/ciphercommon.h"
-#include "prov/ciphercommon_ccm.h"
+#include "cipher_aes_ccm.h"
 
 #define AES_HW_CCM_SET_KEY_FN(fn_set_enc_key, fn_blk, fn_ccm_enc, fn_ccm_dec)  \
     fn_set_enc_key(key, keylen * 8, &actx->ccm.ks.ks);                         \

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -9,8 +9,7 @@
 
 /* Dispatch functions for AES GCM mode */
 
-#include "prov/ciphercommon.h"
-#include "prov/ciphercommon_gcm.h"
+#include "cipher_aes_gcm.h"
 #include "prov/implementations.h"
 
 static void *aes_gcm_newctx(void *provctx, size_t keybits)

--- a/providers/implementations/ciphers/cipher_aes_gcm.h
+++ b/providers/implementations/ciphers/cipher_aes_gcm.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/aes.h>
+#include "prov/ciphercommon.h"
+#include "prov/ciphercommon_gcm.h"
+
+typedef struct prov_aes_gcm_ctx_st {
+    PROV_GCM_CTX base;          /* must be first entry in struct */
+    union {
+        OSSL_UNION_ALIGN;
+        AES_KEY ks;
+    } ks;                       /* AES key schedule to use */
+
+    /* Platform specific data */
+    union {
+        int dummy;
+#if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
+        struct {
+            union {
+                OSSL_UNION_ALIGN;
+                S390X_KMA_PARAMS kma;
+            } param;
+            unsigned int fc;
+            unsigned char ares[16];
+            unsigned char mres[16];
+            unsigned char kres[16];
+            int areslen;
+            int mreslen;
+            int kreslen;
+            int res;
+        } s390x;
+#endif /* defined(OPENSSL_CPUID_OBJ) && defined(__s390__) */
+    } plat;
+} PROV_AES_GCM_CTX;
+
+const PROV_GCM_HW *PROV_AES_HW_gcm(size_t keybits);

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -9,8 +9,7 @@
 
 /* Dispatch functions for AES GCM mode */
 
-#include "prov/ciphercommon.h"
-#include "prov/ciphercommon_gcm.h"
+#include "cipher_aes_gcm.h"
 
 static int generic_aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
                                    size_t keylen)

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -79,35 +79,6 @@ typedef struct prov_gcm_ctx_st {
     const void *ks;
 } PROV_GCM_CTX;
 
-typedef struct prov_aes_gcm_ctx_st {
-    PROV_GCM_CTX base;          /* must be first entry in struct */
-    union {
-        OSSL_UNION_ALIGN;
-        AES_KEY ks;
-    } ks;                       /* AES key schedule to use */
-
-    /* Platform specific data */
-    union {
-        int dummy;
-#if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
-        struct {
-            union {
-                OSSL_UNION_ALIGN;
-                S390X_KMA_PARAMS kma;
-            } param;
-            unsigned int fc;
-            unsigned char ares[16];
-            unsigned char mres[16];
-            unsigned char kres[16];
-            int areslen;
-            int mreslen;
-            int kreslen;
-            int res;
-        } s390x;
-#endif /* defined(OPENSSL_CPUID_OBJ) && defined(__s390__) */
-    } plat;
-} PROV_AES_GCM_CTX;
-
 PROV_CIPHER_FUNC(int, GCM_setkey, (PROV_GCM_CTX *ctx, const unsigned char *key,
                                    size_t keylen));
 PROV_CIPHER_FUNC(int, GCM_setiv, (PROV_GCM_CTX *dat, const unsigned char *iv,
@@ -130,7 +101,6 @@ struct prov_gcm_hw_st {
   OSSL_GCM_cipherfinal_fn cipherfinal;
   OSSL_GCM_oneshot_fn oneshot;
 };
-const PROV_GCM_HW *PROV_AES_HW_gcm(size_t keybits);
 
 OSSL_OP_cipher_encrypt_init_fn gcm_einit;
 OSSL_OP_cipher_decrypt_init_fn gcm_dinit;


### PR DESCRIPTION
The AES_CCM specialisation was defined in the common cipher header
providers/implementations/include/prov/ciphercommon_ccm.h, when it
should in fact be in a local providers/implementations/ciphers/
header.
