### PR TITLE
Add better support for using deprecated symbols internally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 # Auto generated headers
 /crypto/buildinf.h
 /include/crypto/*_conf.h
-/include/openssl/opensslconf.h
+/include/openssl/configuration.h
 /include/openssl/opensslv.h
 
 # Auto generated doc files

--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,7 @@
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
   *) Removed include/openssl/opensslconf.h.in and replaced it with
-     include/openssl/opensslconf.h.in, which differs in not including
+     include/openssl/configuration.h.in, which differs in not including
      <openssl/macros.h>.  A short header include/openssl/opensslconf.h
      was added to include both.
 

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,26 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) Removed include/openssl/opensslconf.h.in and replaced it with
+     include/openssl/opensslconf.h.in, which differs in not including
+     <openssl/macros.h>.  A short header include/openssl/opensslconf.h
+     was added to include both.
+
+     This allows internal hacks where one might need to modify the set
+     of configured macros, for example this if deprecated symbols are
+     still supposed to be available internally:
+
+         #include <openssl/configuration.h>
+
+         #undef OPENSSL_NO_DEPRECATED
+         #define OPENSSL_SUPPRESS_DEPRECATED
+
+         #include <openssl/macros.h>
+
+     This should not be used by applications that use the exported
+     symbols, as that will lead to linking errors.
+     [Richard Levitte]
+
   *) Fixed an an overflow bug in the x64_64 Montgomery squaring procedure
      used in exponentiation with 512-bit moduli. No EC algorithms are
      affected. Analysis suggests that attacks against 2-prime RSA1024,

--- a/INSTALL
+++ b/INSTALL
@@ -836,8 +836,8 @@
 
      Configure creates a build file ("Makefile" on Unix, "makefile" on Windows
      and "descrip.mms" on OpenVMS) from a suitable template in Configurations,
-     and defines various macros in include/openssl/opensslconf.h (generated from
-     include/openssl/opensslconf.h.in).
+     and defines various macros in include/openssl/configuration.h (generated
+     from include/openssl/configuration.h.in).
 
  1c. Configure OpenSSL for building outside of the source tree.
 

--- a/build.info
+++ b/build.info
@@ -9,11 +9,11 @@ DEPEND[libssl]=libcrypto
 
 # Empty DEPEND "indices" means the dependencies are expected to be built
 # unconditionally before anything else.
-DEPEND[]=include/openssl/opensslconf.h include/openssl/opensslv.h \
+DEPEND[]=include/openssl/configuration.h include/openssl/opensslv.h \
          include/crypto/bn_conf.h include/crypto/dso_conf.h \
          doc/man7/openssl_user_macros.pod
 
-GENERATE[include/openssl/opensslconf.h]=include/openssl/opensslconf.h.in
+GENERATE[include/openssl/configuration.h]=include/openssl/configuration.h.in
 GENERATE[include/openssl/opensslv.h]=include/openssl/opensslv.h.in
 GENERATE[include/crypto/bn_conf.h]=include/crypto/bn_conf.h.in
 GENERATE[include/crypto/dso_conf.h]=include/crypto/dso_conf.h.in

--- a/include/openssl/configuration.h.in
+++ b/include/openssl/configuration.h.in
@@ -9,8 +9,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OPENSSL_OPENSSLCONF_H
-# define OPENSSL_OPENSSLCONF_H
+#ifndef OPENSSL_CONFIGURATION_H
+# define OPENSSL_CONFIGURATION_H
 
 # ifdef  __cplusplus
 extern "C" {
@@ -65,6 +65,4 @@ extern "C" {
 }
 # endif
 
-# include <openssl/macros.h>
-
-#endif                          /* OPENSSL_OPENSSLCONF_H */
+#endif                          /* OPENSSL_CONFIGURATION_H */

--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OPENSSL_OPENSSLCONF_H
+# define OPENSSL_OPENSSLCONF_H
+
+#include <openssl/configuration.h>
+#include <openssl/macros.h>
+
+#endif  /* OPENSSL_OPENSSLCONF_H */


### PR DESCRIPTION
OPENSSL_SUPPRESS_DEPRECATED only does half the job, in telling the
deprecation macros not to add the warning attribute.  However, with
'no-deprecated', the symbols are still removed entirely, while we
might still want to use them internally.

The solution is to permit <openssl/opensslconf.h> macros to be
modified internally, such as undefining OPENSSL_NO_DEPRECATED in this
case.

However, with the way <openssl/opensslconf.h> includes
<openssl/macros.h>, that's easier said than done.  That's solved by
generating <openssl/configuration.h> instead, and add a new
<openssl/opensslconf.h> that includes <openssl/configuration.h> as
well as <openssl/macros.h>, thus allowing to replace an inclusion of
<openssl/opensslconf.h> with this:

    #include <openssl/configuration.h>

    #undef OPENSSL_NO_DEPRECATED
    #define OPENSSL_SUPPRESS_DEPRECATED

    #include <openssl/macros.h>

Or simply add the following prior to any other openssl inclusion:

    #include <openssl/configuration.h>

    #undef OPENSSL_NO_DEPRECATED
    #define OPENSSL_SUPPRESS_DEPRECATED

Note that undefining OPENSSL_NO_DEPRECATED must never be done by
applications, since the symbols must still be exported by the
library.  Internal test programs are excempt of this rule, though.
