### PR TITLE
Remove CRYPTO_secure_allocated from util/missingcrypto111.txt

### DIFF
--- a/util/missingcrypto111.txt
+++ b/util/missingcrypto111.txt
@@ -334,7 +334,6 @@ CRYPTO_ocb128_setiv
 CRYPTO_ocb128_tag
 CRYPTO_ofb128_encrypt
 CRYPTO_secure_actual_size
-CRYPTO_secure_allocated
 CRYPTO_xts128_encrypt
 Camellia_cbc_encrypt
 Camellia_cfb128_encrypt


### PR DESCRIPTION
Followup on #10523
