### PR TITLE
util/mkerr.pl: revert accidental change of header guards [1.1.1]

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -450,8 +450,8 @@ foreach my $lib ( keys %errorfile ) {
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OPENSSL_${lib}ERR_H
-# define OPENSSL_${lib}ERR_H
+#ifndef HEADER_${lib}ERR_H
+# define HEADER_${lib}ERR_H
 
 # include <openssl/symhacks.h>
 


### PR DESCRIPTION
This change was backported accidentally from master in commit fbbfd128c9aa.
