### PR TITLE
Support for KTLS on FreeBSD for TLS 1.3.

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -32,6 +32,8 @@
 #   include <netinet/tcp.h>
 #   include <crypto/cryptodev.h>
 
+#   define OPENSSL_KTLS_TLS13
+
 /*
  * Only used by the tests in sslapitest.c.
  */


### PR DESCRIPTION
For TLS 1.3, only the final key used for application data is sent to
the kernel.  The kernel is responsible for framing the record
including placing the record type after the record payload and
appending any padding.

To avoid pulling in more dependencies for the tls13secretstest,
explicitly disable KTLS when building that test.

Note that only support for offloading TX is supported as FreeBSD's
KTLS only supports offloading TX.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
