### PR TITLE
Fix unwind info for some trivial functions

### DIFF
--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -41,6 +41,7 @@ print<<___;
 .type	OPENSSL_atomic_add,\@abi-omnipotent
 .align	16
 OPENSSL_atomic_add:
+.cfi_startproc
 	movl	($arg1),%eax
 .Lspin:	leaq	($arg2,%rax),%r8
 	.byte	0xf0		# lock
@@ -49,16 +50,19 @@ OPENSSL_atomic_add:
 	movl	%r8d,%eax
 	.byte	0x48,0x98	# cltq/cdqe
 	ret
+.cfi_endproc
 .size	OPENSSL_atomic_add,.-OPENSSL_atomic_add
 
 .globl	OPENSSL_rdtsc
 .type	OPENSSL_rdtsc,\@abi-omnipotent
 .align	16
 OPENSSL_rdtsc:
+.cfi_startproc
 	rdtsc
 	shl	\$32,%rdx
 	or	%rdx,%rax
 	ret
+.cfi_endproc
 .size	OPENSSL_rdtsc,.-OPENSSL_rdtsc
 
 .globl	OPENSSL_ia32_cpuid
@@ -234,6 +238,7 @@ OPENSSL_ia32_cpuid:
 .type   OPENSSL_cleanse,\@abi-omnipotent
 .align  16
 OPENSSL_cleanse:
+.cfi_startproc
 	xor	%rax,%rax
 	cmp	\$15,$arg2
 	jae	.Lot
@@ -263,12 +268,14 @@ OPENSSL_cleanse:
 	cmp	\$0,$arg2
 	jne	.Little
 	ret
+.cfi_endproc
 .size	OPENSSL_cleanse,.-OPENSSL_cleanse
 
 .globl  CRYPTO_memcmp
 .type   CRYPTO_memcmp,\@abi-omnipotent
 .align  16
 CRYPTO_memcmp:
+.cfi_startproc
 	xor	%rax,%rax
 	xor	%r10,%r10
 	cmp	\$0,$arg3
@@ -297,6 +304,7 @@ CRYPTO_memcmp:
 	shr	\$63,%rax
 .Lno_data:
 	ret
+.cfi_endproc
 .size	CRYPTO_memcmp,.-CRYPTO_memcmp
 ___
 
@@ -305,6 +313,7 @@ print<<___ if (!$win64);
 .type	OPENSSL_wipe_cpu,\@abi-omnipotent
 .align	16
 OPENSSL_wipe_cpu:
+.cfi_startproc
 	pxor	%xmm0,%xmm0
 	pxor	%xmm1,%xmm1
 	pxor	%xmm2,%xmm2
@@ -331,6 +340,7 @@ OPENSSL_wipe_cpu:
 	xorq	%r11,%r11
 	leaq	8(%rsp),%rax
 	ret
+.cfi_endproc
 .size	OPENSSL_wipe_cpu,.-OPENSSL_wipe_cpu
 ___
 print<<___ if ($win64);
@@ -367,6 +377,7 @@ print<<___;
 .type	OPENSSL_instrument_bus,\@abi-omnipotent
 .align	16
 OPENSSL_instrument_bus:
+.cfi_startproc
 	mov	$arg1,$out	# tribute to Win64
 	mov	$arg2,$cnt
 	mov	$arg2,$max
@@ -393,12 +404,14 @@ OPENSSL_instrument_bus:
 
 	mov	$max,%rax
 	ret
+.cfi_endproc
 .size	OPENSSL_instrument_bus,.-OPENSSL_instrument_bus
 
 .globl	OPENSSL_instrument_bus2
 .type	OPENSSL_instrument_bus2,\@abi-omnipotent
 .align	16
 OPENSSL_instrument_bus2:
+.cfi_startproc
 	mov	$arg1,$out	# tribute to Win64
 	mov	$arg2,$cnt
 	mov	$arg3,$max
@@ -441,6 +454,7 @@ OPENSSL_instrument_bus2:
 	mov	$redzone(%rsp),%rax
 	sub	$cnt,%rax
 	ret
+.cfi_endproc
 .size	OPENSSL_instrument_bus2,.-OPENSSL_instrument_bus2
 ___
 }
@@ -452,6 +466,7 @@ print<<___;
 .type	OPENSSL_ia32_${rdop}_bytes,\@abi-omnipotent
 .align	16
 OPENSSL_ia32_${rdop}_bytes:
+.cfi_startproc
 	xor	%rax, %rax	# return value
 	cmp	\$0,$arg2
 	je	.Ldone_${rdop}_bytes
@@ -488,6 +503,7 @@ OPENSSL_ia32_${rdop}_bytes:
 .Ldone_${rdop}_bytes:
 	xor	%r10,%r10	# Clear sensitive data from register
 	ret
+.cfi_endproc
 .size	OPENSSL_ia32_${rdop}_bytes,.-OPENSSL_ia32_${rdop}_bytes
 ___
 }


### PR DESCRIPTION
While stack unwinding works with gdb here, the
function _Unwind_Backtrace gives up when something outside
.cfi_startproc/.cfi_endproc is found in the call stack, like
OPENSSL_cleanse, OPENSSL_atomic_add, OPENSSL_rdtsc, CRYPTO_memcmp
and other trivial functions which don't save anything in the stack.

I played around with this
```
diff --git a/apps/speed.c b/apps/speed.c
index e4b104e..6b0cef0 100644
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -8,6 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <unwind.h>
 #undef SECONDS
 #define SECONDS                 3
 #define RSA_SECONDS             10
@@ -225,8 +226,44 @@ static const int aead_lengths_list[] = {
 
 #ifdef SIGALRM
 
+struct ctxt
+{
+  void **res;
+  int cnt;
+  int max;
+};
+
+_Unwind_Reason_Code bt (struct _Unwind_Context *c, void *x)
+{
+  struct ctxt *ct = x;
+  if (ct->cnt < ct->max)
+    ct->res[ct->cnt++] = (void*)_Unwind_GetIP(c);
+  return _URC_NO_REASON;
+}
+
 static void alarmed(int sig)
 {
+    void *res[20];
+    struct ctxt ct;
+    int i;
+    ct.res = res;
+    ct.cnt = 0;
+    ct.max = 20;
+    write(1,"alarmed\n", 8);
+    _Unwind_Backtrace(bt, &ct);
+    for (i = 0; i < ct.cnt; i++)
+    {
+       unsigned long p = (unsigned long) res[i];
+       char q[18];
+       int j = sizeof(q);
+       q[--j] = 10;
+       do {
+          q[--j] = (p & 15) < 10 ? '0' + (p & 15) : 'A' + (p & 15) - 10;
+          p >>= 4;
+       } while(p && j > 0);
+       write(1, q+j, sizeof(q)-j);
+    }
+    write(1,"finally\n", 8);
     signal(SIGALRM, alarmed);
     run = 0;
 }
```

and noticed the stack trace stops in OPENSSL_cleanse, when that is
interrupted by a signal. (as it may happen)