### PR TITLE
[WIP] EVP: Make it possible to have keymgmt name that differs from the algo

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -108,6 +108,8 @@ struct evp_keyexch_st {
     OSSL_OP_keyexch_derive_fn *derive;
     OSSL_OP_keyexch_freectx_fn *freectx;
     OSSL_OP_keyexch_dupctx_fn *dupctx;
+    OSSL_OP_keyexch_get_params_fn *get_params;
+    OSSL_OP_keyexch_gettable_params_fn *gettable_params;
     OSSL_OP_keyexch_set_ctx_params_fn *set_ctx_params;
     OSSL_OP_keyexch_settable_ctx_params_fn *settable_ctx_params;
 } /* EVP_KEYEXCH */;
@@ -133,6 +135,8 @@ struct evp_signature_st {
     OSSL_OP_signature_digest_verify_final_fn *digest_verify_final;
     OSSL_OP_signature_freectx_fn *freectx;
     OSSL_OP_signature_dupctx_fn *dupctx;
+    OSSL_OP_signature_get_params_fn *get_params;
+    OSSL_OP_signature_gettable_params_fn *gettable_params;
     OSSL_OP_signature_get_ctx_params_fn *get_ctx_params;
     OSSL_OP_signature_gettable_ctx_params_fn *gettable_ctx_params;
     OSSL_OP_signature_set_ctx_params_fn *set_ctx_params;
@@ -156,6 +160,8 @@ struct evp_asym_cipher_st {
     OSSL_OP_asym_cipher_decrypt_fn *decrypt;
     OSSL_OP_asym_cipher_freectx_fn *freectx;
     OSSL_OP_asym_cipher_dupctx_fn *dupctx;
+    OSSL_OP_asym_cipher_get_params_fn *get_params;
+    OSSL_OP_asym_cipher_gettable_params_fn *gettable_params;
     OSSL_OP_asym_cipher_get_ctx_params_fn *get_ctx_params;
     OSSL_OP_asym_cipher_gettable_ctx_params_fn *gettable_ctx_params;
     OSSL_OP_asym_cipher_set_ctx_params_fn *set_ctx_params;

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -280,3 +280,8 @@ void evp_names_do_all(OSSL_PROVIDER *prov, int number,
                       void (*fn)(const char *name, void *data),
                       void *data);
 int evp_cipher_cache_constants(EVP_CIPHER *cipher);
+
+EVP_KEYMGMT *evp_signature_get_keymgmt(EVP_SIGNATURE *signature,
+                                       int fallback_id,
+                                       OPENSSL_CTX *libctx,
+                                       const char *propquery);

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -44,7 +44,7 @@ static void *evp_keyexch_from_dispatch(int name_id,
                                        OSSL_PROVIDER *prov)
 {
     EVP_KEYEXCH *exchange = NULL;
-    int fncnt = 0, paramfncnt = 0;
+    int fncnt = 0, paramfncnt = 0, ctxparamfncnt = 0;
 
     if ((exchange = evp_keyexch_new(prov)) == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
@@ -93,29 +93,33 @@ static void *evp_keyexch_from_dispatch(int name_id,
             if (exchange->get_params != NULL)
                 break;
             exchange->get_params = OSSL_get_OP_keyexch_get_params(fns);
+            paramfncnt++;
             break;
         case OSSL_FUNC_KEYEXCH_GETTABLE_PARAMS:
             if (exchange->gettable_params != NULL)
                 break;
             exchange->gettable_params
                 = OSSL_get_OP_keyexch_gettable_params(fns);
+            paramfncnt++;
             break;
         case OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS:
             if (exchange->set_ctx_params != NULL)
                 break;
             exchange->set_ctx_params = OSSL_get_OP_keyexch_set_ctx_params(fns);
-            paramfncnt++;
+            ctxparamfncnt++;
             break;
         case OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS:
             if (exchange->settable_ctx_params != NULL)
                 break;
             exchange->settable_ctx_params
                 = OSSL_get_OP_keyexch_settable_ctx_params(fns);
-            paramfncnt++;
+            ctxparamfncnt++;
             break;
         }
     }
-    if (fncnt != 4 || (paramfncnt != 0 && paramfncnt != 2)) {
+    if (fncnt != 4
+        || (paramfncnt != 0 && paramfncnt != 2)
+        || (ctxparamfncnt != 0 && ctxparamfncnt != 2)) {
         /*
          * In order to be a consistent set of functions we must have at least
          * a complete set of "exchange" functions: init, derive, newctx,

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -88,6 +88,17 @@ static void *evp_keyexch_from_dispatch(int name_id,
                 break;
             exchange->dupctx = OSSL_get_OP_keyexch_dupctx(fns);
             break;
+        case OSSL_FUNC_KEYEXCH_GET_PARAMS:
+            if (exchange->get_params != NULL)
+                break;
+            exchange->get_params = OSSL_get_OP_keyexch_get_params(fns);
+            break;
+        case OSSL_FUNC_KEYEXCH_GETTABLE_PARAMS:
+            if (exchange->gettable_params != NULL)
+                break;
+            exchange->gettable_params
+                = OSSL_get_OP_keyexch_gettable_params(fns);
+            break;
         case OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS:
             if (exchange->set_ctx_params != NULL)
                 break;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -12,6 +12,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
+#include <openssl/core_names.h>
 #include "crypto/evp.h"
 #include "internal/provider.h"
 #include "evp_local.h"
@@ -78,13 +79,11 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
      */
     signature = EVP_SIGNATURE_fetch(locpctx->libctx, locpctx->algorithm,
                                     locpctx->propquery);
-    if (signature != NULL && locpctx->keymgmt == NULL) {
-        int name_id = EVP_SIGNATURE_number(signature);
-
+    if (signature != NULL && locpctx->keymgmt == NULL)
         locpctx->keymgmt =
-            evp_keymgmt_fetch_by_number(locpctx->libctx, name_id,
-                                        locpctx->propquery);
-    }
+            evp_signature_get_keymgmt(signature,
+                                      EVP_SIGNATURE_number(signature),
+                                      locpctx->libctx, locpctx->propquery);
 
     if (locpctx->keymgmt == NULL
         || signature == NULL

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -46,7 +46,8 @@ static void *evp_signature_from_dispatch(int name_id,
     EVP_SIGNATURE *signature = NULL;
     int ctxfncnt = 0, signfncnt = 0, verifyfncnt = 0, verifyrecfncnt = 0;
     int digsignfncnt = 0, digverifyfncnt = 0;
-    int gparamfncnt = 0, sparamfncnt = 0, gmdparamfncnt = 0, smdparamfncnt = 0;
+    int gparamfncnt = 0, gctxparamfncnt = 0, sctxparamfncnt = 0;
+    int gmdparamfncnt = 0, smdparamfncnt = 0;
 
     if ((signature = evp_signature_new(prov)) == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
@@ -158,40 +159,42 @@ static void *evp_signature_from_dispatch(int name_id,
             if (signature->get_params != NULL)
                 break;
             signature->get_params = OSSL_get_OP_signature_get_params(fns);
+            gparamfncnt++;
             break;
         case OSSL_FUNC_SIGNATURE_GETTABLE_PARAMS:
             if (signature->gettable_params != NULL)
                 break;
             signature->gettable_params
                 = OSSL_get_OP_signature_gettable_params(fns);
+            gparamfncnt++;
             break;
         case OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS:
             if (signature->get_ctx_params != NULL)
                 break;
             signature->get_ctx_params
                 = OSSL_get_OP_signature_get_ctx_params(fns);
-            gparamfncnt++;
+            gctxparamfncnt++;
             break;
         case OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS:
             if (signature->gettable_ctx_params != NULL)
                 break;
             signature->gettable_ctx_params
                 = OSSL_get_OP_signature_gettable_ctx_params(fns);
-            gparamfncnt++;
+            gctxparamfncnt++;
             break;
         case OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS:
             if (signature->set_ctx_params != NULL)
                 break;
             signature->set_ctx_params
                 = OSSL_get_OP_signature_set_ctx_params(fns);
-            sparamfncnt++;
+            sctxparamfncnt++;
             break;
         case OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS:
             if (signature->settable_ctx_params != NULL)
                 break;
             signature->settable_ctx_params
                 = OSSL_get_OP_signature_settable_ctx_params(fns);
-            sparamfncnt++;
+            sctxparamfncnt++;
             break;
         case OSSL_FUNC_SIGNATURE_GET_CTX_MD_PARAMS:
             if (signature->get_ctx_md_params != NULL)
@@ -235,7 +238,8 @@ static void *evp_signature_from_dispatch(int name_id,
         || (digsignfncnt != 0 && digsignfncnt != 3)
         || (digverifyfncnt != 0 && digverifyfncnt != 3)
         || (gparamfncnt != 0 && gparamfncnt != 2)
-        || (sparamfncnt != 0 && sparamfncnt != 2)
+        || (gctxparamfncnt != 0 && gctxparamfncnt != 2)
+        || (sctxparamfncnt != 0 && sctxparamfncnt != 2)
         || (gmdparamfncnt != 0 && gmdparamfncnt != 2)
         || (smdparamfncnt != 0 && smdparamfncnt != 2)) {
         /*
@@ -837,7 +841,7 @@ static void *evp_asym_cipher_from_dispatch(int name_id,
 {
     EVP_ASYM_CIPHER *cipher = NULL;
     int ctxfncnt = 0, encfncnt = 0, decfncnt = 0;
-    int gparamfncnt = 0, sparamfncnt = 0;
+    int gparamfncnt = 0, gctxparamfncnt = 0, sctxparamfncnt = 0;
 
     if ((cipher = evp_asym_cipher_new(prov)) == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
@@ -893,40 +897,42 @@ static void *evp_asym_cipher_from_dispatch(int name_id,
             if (cipher->get_params != NULL)
                 break;
             cipher->get_params = OSSL_get_OP_asym_cipher_get_params(fns);
+            gparamfncnt++;
             break;
         case OSSL_FUNC_ASYM_CIPHER_GETTABLE_PARAMS:
             if (cipher->gettable_params != NULL)
                 break;
             cipher->gettable_params
                 = OSSL_get_OP_asym_cipher_gettable_params(fns);
+            gparamfncnt++;
             break;
         case OSSL_FUNC_ASYM_CIPHER_GET_CTX_PARAMS:
             if (cipher->get_ctx_params != NULL)
                 break;
             cipher->get_ctx_params
                 = OSSL_get_OP_asym_cipher_get_ctx_params(fns);
-            gparamfncnt++;
+            gctxparamfncnt++;
             break;
         case OSSL_FUNC_ASYM_CIPHER_GETTABLE_CTX_PARAMS:
             if (cipher->gettable_ctx_params != NULL)
                 break;
             cipher->gettable_ctx_params
                 = OSSL_get_OP_asym_cipher_gettable_ctx_params(fns);
-            gparamfncnt++;
+            gctxparamfncnt++;
             break;
         case OSSL_FUNC_ASYM_CIPHER_SET_CTX_PARAMS:
             if (cipher->set_ctx_params != NULL)
                 break;
             cipher->set_ctx_params
                 = OSSL_get_OP_asym_cipher_set_ctx_params(fns);
-            sparamfncnt++;
+            sctxparamfncnt++;
             break;
         case OSSL_FUNC_ASYM_CIPHER_SETTABLE_CTX_PARAMS:
             if (cipher->settable_ctx_params != NULL)
                 break;
             cipher->settable_ctx_params
                 = OSSL_get_OP_asym_cipher_settable_ctx_params(fns);
-            sparamfncnt++;
+            sctxparamfncnt++;
             break;
         }
     }
@@ -935,7 +941,8 @@ static void *evp_asym_cipher_from_dispatch(int name_id,
         || (decfncnt != 0 && decfncnt != 2)
         || (encfncnt != 2 && decfncnt != 2)
         || (gparamfncnt != 0 && gparamfncnt != 2)
-        || (sparamfncnt != 0 && sparamfncnt != 2)) {
+        || (gctxparamfncnt != 0 && gctxparamfncnt != 2)
+        || (sctxparamfncnt != 0 && sctxparamfncnt != 2)) {
         /*
          * In order to be a consistent set of functions we must have at least
          * a set of context functions (newctx and freectx) as well as a pair of

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -153,6 +153,17 @@ static void *evp_signature_from_dispatch(int name_id,
                 break;
             signature->dupctx = OSSL_get_OP_signature_dupctx(fns);
             break;
+        case OSSL_FUNC_SIGNATURE_GET_PARAMS:
+            if (signature->get_params != NULL)
+                break;
+            signature->get_params = OSSL_get_OP_signature_get_params(fns);
+            break;
+        case OSSL_FUNC_SIGNATURE_GETTABLE_PARAMS:
+            if (signature->gettable_params != NULL)
+                break;
+            signature->gettable_params
+                = OSSL_get_OP_signature_gettable_params(fns);
+            break;
         case OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS:
             if (signature->get_ctx_params != NULL)
                 break;
@@ -841,6 +852,17 @@ static void *evp_asym_cipher_from_dispatch(int name_id,
             if (cipher->dupctx != NULL)
                 break;
             cipher->dupctx = OSSL_get_OP_asym_cipher_dupctx(fns);
+            break;
+        case OSSL_FUNC_ASYM_CIPHER_GET_PARAMS:
+            if (cipher->get_params != NULL)
+                break;
+            cipher->get_params = OSSL_get_OP_asym_cipher_get_params(fns);
+            break;
+        case OSSL_FUNC_ASYM_CIPHER_GETTABLE_PARAMS:
+            if (cipher->gettable_params != NULL)
+                break;
+            cipher->gettable_params
+                = OSSL_get_OP_asym_cipher_gettable_params(fns);
             break;
         case OSSL_FUNC_ASYM_CIPHER_GET_CTX_PARAMS:
             if (cipher->get_ctx_params != NULL)

--- a/doc/man7/provider-asymcipher.pod
+++ b/doc/man7/provider-asymcipher.pod
@@ -35,6 +35,8 @@ provider-asym_cipher - The asym_cipher library E<lt>-E<gt> provider functions
                             size_t inlen);
 
  /* Asymmetric Cipher parameters */
+ int OP_asym_cipher_get_params(OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_asym_cipher_gettable_params(void);
  int OP_asym_cipher_get_ctx_params(void *ctx, OSSL_PARAM params[]);
  const OSSL_PARAM *OP_asym_cipher_gettable_ctx_params(void);
  int OP_asym_cipher_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
@@ -80,6 +82,8 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_asym_cipher_decrypt_init         OSSL_FUNC_ASYM_CIPHER_DECRYPT_INIT
  OP_asym_cipher_decrypt              OSSL_FUNC_ASYM_CIPHER_DECRYPT
 
+ OP_asym_cipher_get_params           OSSL_FUNC_ASYM_CIPHER_GET_PARAMS
+ OP_asym_cipher_gettable_params      OSSL_FUNC_ASYM_CIPHER_GETTABLE_PARAMS
  OP_asym_cipher_get_ctx_params       OSSL_FUNC_ASYM_CIPHER_GET_CTX_PARAMS
  OP_asym_cipher_gettable_ctx_params  OSSL_FUNC_ASYM_CIPHER_GETTABLE_CTX_PARAMS
  OP_asym_cipher_set_ctx_params       OSSL_FUNC_ASYM_CIPHER_SET_CTX_PARAMS
@@ -165,9 +169,13 @@ See L<OSSL_PARAM(3)> for further details on the parameters structure used by
 the OP_asym_cipher_get_ctx_params() and OP_asym_cipher_set_ctx_params()
 functions.
 
+OP_asym_cipher_get_params() gets details of the algorithm implementation
+and stores them in I<params>.
+
 OP_asym_cipher_get_ctx_params() gets asymmetric cipher parameters associated
 with the given provider side asymmetric cipher context I<ctx> and stores them in
 I<params>.
+
 OP_asym_cipher_set_ctx_params() sets the asymmetric cipher parameters associated
 with the given provider side asymmetric cipher context I<ctx> to I<params>.
 Any parameter settings are additional to any that were previously set.

--- a/doc/man7/provider-asymcipher.pod
+++ b/doc/man7/provider-asymcipher.pod
@@ -187,6 +187,13 @@ algorithms:
 
 =over 4
 
+=item "keytype" (B<OSSL_ALG_PARAM_KEYTYPE>) <utf8 pointer>
+
+Gets the keytype name for the associated asymmetric cipher algorithm.
+This allows the EVP_PKEY API to get an appropriate L<EVP_KEYMGMT(3)>
+for the algorithm.  If an algorithm doesn't respond to this parameter,
+the keytype name is assumed to be the same as the algorithm name.
+
 =item "pad-mode" (B<OSSL_ASYM_CIPHER_PARAM_PAD_MODE>) <integer>
 
 The type of padding to be used. The interpretation of this value will depend

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -146,6 +146,13 @@ algorithms:
 
 =over 4
 
+=item "keytype" (B<OSSL_ALG_PARAM_KEYTYPE>) <utf8 pointer>
+
+Gets the keytype name for the associated key exchange algorithm.
+This allows the EVP_PKEY API to get an appropriate L<EVP_KEYMGMT(3)>
+for the algorithm.  If an algorithm doesn't respond to this parameter,
+the keytype name is assumed to be the same as the algorithm name.
+
 =item "pad" (B<OSSL_EXCHANGE_PARAM_PAD>) <unsigned integer>
 
 Sets the padding mode for the associated key exchange ctx.

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -29,7 +29,7 @@ provider-keyexch - The keyexch library E<lt>-E<gt> provider functions
                        size_t outlen);
 
  /* Key Exchange parameters */
- int OP_keyexch_get_params(const OSSL_PARAM params[]);
+ int OP_keyexch_get_params(OSSL_PARAM params[]);
  const OSSL_PARAM *OP_keyexch_gettable_params(void);
  int OP_keyexch_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
  const OSSL_PARAM *OP_keyexch_settable_ctx_params(void);

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -29,6 +29,8 @@ provider-keyexch - The keyexch library E<lt>-E<gt> provider functions
                        size_t outlen);
 
  /* Key Exchange parameters */
+ int OP_keyexch_get_params(const OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_keyexch_gettable_params(void);
  int OP_keyexch_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
  const OSSL_PARAM *OP_keyexch_settable_ctx_params(void);
 
@@ -69,6 +71,8 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_keyexch_set_peer              OSSL_FUNC_KEYEXCH_SET_PEER
  OP_keyexch_derive                OSSL_FUNC_KEYEXCH_DERIVE
 
+ OP_keyexch_get_params            OSSL_FUNC_KEYEXCH_GET_PARAMS
+ OP_keyexch_gettable_params       OSSL_FUNC_KEYEXCH_GETTABLE_PARAMS
  OP_keyexch_set_ctx_params        OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS
  OP_keyexch_settable_ctx_params   OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS
 
@@ -127,6 +131,9 @@ written to I<*secretlen>.
 
 See L<OSSL_PARAM(3)> for further details on the parameters structure used by
 the OP_keyexch_set_params() function.
+
+OP_keyexch_get_params() gets details of the algorithm implementation
+and stores them in I<params>.
 
 OP_keyexch_set_ctx_params() sets key exchange parameters associated with the
 given provider side key exchange context I<ctx> to I<params>.

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -202,6 +202,13 @@ algorithms:
 
 =over 4
 
+=item "keytype" (B<OSSL_ALG_PARAM_KEYTYPE>) <utf8 pointer>
+
+Gets the keytype name for the associated signature algorithm.
+This allows the EVP_PKEY API to get an appropriate L<EVP_KEYMGMT(3)>
+for the algorithm.  If an algorithm doesn't respond to this parameter,
+the keytype name is assumed to be the same as the algorithm name.
+
 =item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
 Get or sets the name of the digest algorithm used for the input to the signature

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -39,6 +39,8 @@ provider-signature - The signature library E<lt>-E<gt> provider functions
                                  const unsigned char *sig, size_t siglen);
 
  /* Signature parameters */
+ int OP_signature_get_params(OSSL_PARAM params[]);
+ const OSSL_PARAM *OP_signature_gettable_params(void);
  int OP_signature_get_ctx_params(void *ctx, OSSL_PARAM params[]);
  const OSSL_PARAM *OP_signature_gettable_ctx_params(void);
  int OP_signature_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
@@ -88,6 +90,8 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_signature_verify_recover_init    OSSL_FUNC_SIGNATURE_VERIFY_RECOVER_INIT
  OP_signature_verify_recover         OSSL_FUNC_SIGNATURE_VERIFY_RECOVER
 
+ OP_signature_get_params             OSSL_FUNC_SIGNATURE_GET_PARAMS
+ OP_signature_gettable_params        OSSL_FUNC_SIGNATURE_GETTABLE_PARAMS
  OP_signature_get_ctx_params         OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS
  OP_signature_gettable_ctx_params    OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS
  OP_signature_set_ctx_params         OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS
@@ -181,8 +185,12 @@ the I<routlen> parameter.
 See L<OSSL_PARAM(3)> for further details on the parameters structure used by
 the OP_signature_get_ctx_params() and OP_signature_set_ctx_params() functions.
 
+OP_signature_get_params() gets details of the algorithm implementation
+and stores them in I<params>.
+
 OP_signature_get_ctx_params() gets signature parameters associated with the
 given provider side signature context I<ctx> and stored them in I<params>.
+
 OP_signature_set_ctx_params() sets the signature parameters associated with the
 given provider side signature context I<ctx> to I<params>.
 Any parameter settings are additional to any that were previously set.

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -49,6 +49,12 @@ extern "C" {
 #define OSSL_ALG_PARAM_CIPHER       "cipher"    /* utf8_string */
 #define OSSL_ALG_PARAM_MAC          "mac"       /* utf8_string */
 #define OSSL_ALG_PARAM_PROPERTIES   "properties"/* utf8_string */
+/*
+ * Any algorithm that has some kind of key can, at their option, respond
+ * with a key type name to this parameter.  libcrypto will then use that
+ * name instead of the algorithm name to find a keymgmt implementation.
+ */
+#define OSSL_ALG_PARAM_KEYTYPE      "keytype"
 
 /* cipher parameters */
 #define OSSL_CIPHER_PARAM_PADDING   "padding"    /* uint */

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -403,8 +403,10 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_exportkey_types, (void))
 # define OSSL_FUNC_KEYEXCH_SET_PEER                    4
 # define OSSL_FUNC_KEYEXCH_FREECTX                     5
 # define OSSL_FUNC_KEYEXCH_DUPCTX                      6
-# define OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS              7
-# define OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS         8
+# define OSSL_FUNC_KEYEXCH_GET_PARAMS                  7
+# define OSSL_FUNC_KEYEXCH_GETTABLE_PARAMS             8
+# define OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS              9
+# define OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS        10
 
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_init, (void *ctx, void *provkey))
@@ -413,6 +415,8 @@ OSSL_CORE_MAKE_FUNC(int, OP_keyexch_derive, (void *ctx,  unsigned char *secret,
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_peer, (void *ctx, void *provkey))
 OSSL_CORE_MAKE_FUNC(void, OP_keyexch_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_dupctx, (void *ctx))
+OSSL_CORE_MAKE_FUNC(int, OP_keyexch_get_params, (const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keyexch_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_ctx_params, (void *ctx,
                                                      const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keyexch_settable_ctx_params,
@@ -435,14 +439,16 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keyexch_settable_ctx_params,
 # define OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_FINAL    13
 # define OSSL_FUNC_SIGNATURE_FREECTX                14
 # define OSSL_FUNC_SIGNATURE_DUPCTX                 15
-# define OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS         16
-# define OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS    17
-# define OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS         18
-# define OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS    19
-# define OSSL_FUNC_SIGNATURE_GET_CTX_MD_PARAMS      20
-# define OSSL_FUNC_SIGNATURE_GETTABLE_CTX_MD_PARAMS 21
-# define OSSL_FUNC_SIGNATURE_SET_CTX_MD_PARAMS      22
-# define OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS 23
+# define OSSL_FUNC_SIGNATURE_GET_PARAMS             16
+# define OSSL_FUNC_SIGNATURE_GETTABLE_PARAMS        17
+# define OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS         18
+# define OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS    19
+# define OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS         20
+# define OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS    21
+# define OSSL_FUNC_SIGNATURE_GET_CTX_MD_PARAMS      22
+# define OSSL_FUNC_SIGNATURE_GETTABLE_CTX_MD_PARAMS 23
+# define OSSL_FUNC_SIGNATURE_SET_CTX_MD_PARAMS      24
+# define OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS 25
 
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_sign_init, (void *ctx, void *provkey))
@@ -481,6 +487,8 @@ OSSL_CORE_MAKE_FUNC(int, OP_signature_digest_verify_final,
                     (void *ctx, const unsigned char *sig, size_t siglen))
 OSSL_CORE_MAKE_FUNC(void, OP_signature_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_dupctx, (void *ctx))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_get_params, (const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_signature_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_signature_gettable_ctx_params,
@@ -508,10 +516,12 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_signature_settable_ctx_md_params,
 # define OSSL_FUNC_ASYM_CIPHER_DECRYPT                 5
 # define OSSL_FUNC_ASYM_CIPHER_FREECTX                 6
 # define OSSL_FUNC_ASYM_CIPHER_DUPCTX                  7
-# define OSSL_FUNC_ASYM_CIPHER_GET_CTX_PARAMS          8
-# define OSSL_FUNC_ASYM_CIPHER_GETTABLE_CTX_PARAMS     9
-# define OSSL_FUNC_ASYM_CIPHER_SET_CTX_PARAMS         10
-# define OSSL_FUNC_ASYM_CIPHER_SETTABLE_CTX_PARAMS    11
+# define OSSL_FUNC_ASYM_CIPHER_GET_PARAMS              8
+# define OSSL_FUNC_ASYM_CIPHER_GETTABLE_PARAMS         9
+# define OSSL_FUNC_ASYM_CIPHER_GET_CTX_PARAMS         10
+# define OSSL_FUNC_ASYM_CIPHER_GETTABLE_CTX_PARAMS    11
+# define OSSL_FUNC_ASYM_CIPHER_SET_CTX_PARAMS         12
+# define OSSL_FUNC_ASYM_CIPHER_SETTABLE_CTX_PARAMS    13
 
 OSSL_CORE_MAKE_FUNC(void *, OP_asym_cipher_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_encrypt_init, (void *ctx, void *provkey))
@@ -528,6 +538,8 @@ OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_decrypt, (void *ctx, unsigned char *out,
                                                   size_t inlen))
 OSSL_CORE_MAKE_FUNC(void, OP_asym_cipher_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_asym_cipher_dupctx, (void *ctx))
+OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_get_params, (const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_asym_cipher_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_asym_cipher_gettable_ctx_params,

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -415,7 +415,7 @@ OSSL_CORE_MAKE_FUNC(int, OP_keyexch_derive, (void *ctx,  unsigned char *secret,
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_peer, (void *ctx, void *provkey))
 OSSL_CORE_MAKE_FUNC(void, OP_keyexch_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_keyexch_dupctx, (void *ctx))
-OSSL_CORE_MAKE_FUNC(int, OP_keyexch_get_params, (const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_keyexch_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keyexch_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_keyexch_set_ctx_params, (void *ctx,
                                                      const OSSL_PARAM params[]))
@@ -487,7 +487,7 @@ OSSL_CORE_MAKE_FUNC(int, OP_signature_digest_verify_final,
                     (void *ctx, const unsigned char *sig, size_t siglen))
 OSSL_CORE_MAKE_FUNC(void, OP_signature_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_signature_dupctx, (void *ctx))
-OSSL_CORE_MAKE_FUNC(int, OP_signature_get_params, (const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_signature_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_signature_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_signature_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
@@ -538,7 +538,7 @@ OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_decrypt, (void *ctx, unsigned char *out,
                                                   size_t inlen))
 OSSL_CORE_MAKE_FUNC(void, OP_asym_cipher_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, OP_asym_cipher_dupctx, (void *ctx))
-OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_get_params, (const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_asym_cipher_gettable_params, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_asym_cipher_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))


### PR DESCRIPTION
In some cases, the key has a different type name than the algorithms
that use them.  For example, both ECDH and ECDSA uses EC keys.

To accomodate this, we give the algorithms the possibility to give
back the type name they expect for their keys.

Since the resulting keymgmt MUST be from the same provider, it's up to
the provider authors to make sure the names match.