### PR TITLE
Fix travis timeout by excluding arm64 gcc -fsanitize=address build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,6 +150,12 @@ matrix:
           compiler: gcc
         - arch: arm64
           os: osx
+        # arm64 times out when using -fsanitize=address
+        # The amd64 build should be sufficient to test this.
+        # Note the env line must exactly match the env setting above 
+        - arch: arm64
+          env: CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-rc5 enable-md2 -fsanitize=address" LSAN_OPTIONS="report_objects=1"
+
 
 before_script:
     - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ compiler:
 
 env:
     - CONFIG_OPTS="" DESTDIR="_install"
+    # Note: This CONFIG_OPTS entry must match the value in the exclude: table below that contains env: CONFIG_OPTS , otherwise it will not find a match.
     - CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-rc5 enable-md2 -fsanitize=address" LSAN_OPTIONS="report_objects=1"
     - CONFIG_OPTS="no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE" BUILDONLY="yes" CHECKDOCS="yes" GENERATE="yes" CPPFLAGS="-ansi"
 
@@ -152,7 +153,9 @@ matrix:
           os: osx
         # arm64 times out when using -fsanitize=address
         # The amd64 build should be sufficient to test this.
-        # Note the env line must exactly match the env setting above 
+        # Note: the env line must exactly match the env line from the build
+        # matrix above which contains the `-fsanitize=address` option.
+        # TODO: come up with a better way of doing this that is less error prone.
         - arch: arm64
           env: CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-rc5 enable-md2 -fsanitize=address" LSAN_OPTIONS="report_objects=1"
 


### PR DESCRIPTION
Travis constantly timing out after 50 minutes has finally annoyed me enough to fix it..

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
