### PR TITLE
Add some missing cfi frame info in camellia-x86_64.pl

### DIFF
--- a/crypto/camellia/asm/cmll-x86_64.pl
+++ b/crypto/camellia/asm/cmll-x86_64.pl
@@ -127,11 +127,13 @@ $code=<<___;
 .type	Camellia_EncryptBlock,\@abi-omnipotent
 .align	16
 Camellia_EncryptBlock:
+.cfi_startproc
 	movl	\$128,%eax
 	subl	$arg0d,%eax
 	movl	\$3,$arg0d
 	adcl	\$0,$arg0d	# keyBitLength==128?3:4
 	jmp	.Lenc_rounds
+.cfi_endproc
 .size	Camellia_EncryptBlock,.-Camellia_EncryptBlock
 # V2
 .globl	Camellia_EncryptBlock_Rounds
@@ -200,6 +202,7 @@ Camellia_EncryptBlock_Rounds:
 .type	_x86_64_Camellia_encrypt,\@abi-omnipotent
 .align	16
 _x86_64_Camellia_encrypt:
+.cfi_startproc
 	xor	0($key),@S[1]
 	xor	4($key),@S[0]		# ^=key[0-3]
 	xor	8($key),@S[3]
@@ -243,6 +246,7 @@ $code.=<<___;
 	mov	$t3,@S[3]
 
 	.byte	0xf3,0xc3		# rep ret
+.cfi_endproc
 .size	_x86_64_Camellia_encrypt,.-_x86_64_Camellia_encrypt
 
 # V1.x API
@@ -250,11 +254,13 @@ $code.=<<___;
 .type	Camellia_DecryptBlock,\@abi-omnipotent
 .align	16
 Camellia_DecryptBlock:
+.cfi_startproc
 	movl	\$128,%eax
 	subl	$arg0d,%eax
 	movl	\$3,$arg0d
 	adcl	\$0,$arg0d	# keyBitLength==128?3:4
 	jmp	.Ldec_rounds
+.cfi_endproc
 .size	Camellia_DecryptBlock,.-Camellia_DecryptBlock
 # V2
 .globl	Camellia_DecryptBlock_Rounds
@@ -323,6 +329,7 @@ Camellia_DecryptBlock_Rounds:
 .type	_x86_64_Camellia_decrypt,\@abi-omnipotent
 .align	16
 _x86_64_Camellia_decrypt:
+.cfi_startproc
 	xor	0($key),@S[1]
 	xor	4($key),@S[0]		# ^=key[0-3]
 	xor	8($key),@S[3]
@@ -367,6 +374,7 @@ $code.=<<___;
 	mov	$t1,@S[3]
 
 	.byte	0xf3,0xc3		# rep ret
+.cfi_endproc
 .size	_x86_64_Camellia_decrypt,.-_x86_64_Camellia_decrypt
 ___
 


### PR DESCRIPTION
A few functions missed cfi instrumentation in this assembler module