### PR TITLE
Fix no-dh and no-dsa

### DIFF
--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -399,6 +399,7 @@ static const OSSL_ALGORITHM deflt_serializer[] = {
     { "RSA", "default=yes,format=pem,type=public",
       rsa_pub_pem_serializer_functions },
 
+#ifndef OPENSSL_NO_DH
     { "DH", "default=yes,format=text,type=private",
       dh_priv_text_serializer_functions },
     { "DH", "default=yes,format=text,type=public",
@@ -417,6 +418,7 @@ static const OSSL_ALGORITHM deflt_serializer[] = {
       dh_pub_pem_serializer_functions },
     { "DH", "default=yes,format=pem,type=domainparams",
       dh_param_pem_serializer_functions },
+#endif
 
     { NULL, NULL, NULL }
 };

--- a/providers/implementations/serializers/build.info
+++ b/providers/implementations/serializers/build.info
@@ -11,4 +11,6 @@ SOURCE[$RSA_GOAL]=serializer_rsa.c serializer_rsa_priv.c serializer_rsa_pub.c
 IF[{- !$disabled{dh} -}]
   SOURCE[$DH_GOAL]=serializer_dh.c serializer_dh_priv.c serializer_dh_pub.c serializer_dh_param.c
 ENDIF
-SOURCE[$DSA_GOAL]=serializer_dsa.c serializer_dsa_priv.c serializer_dsa_pub.c serializer_dsa_param.c
+IF[{- !$disabled{dsa} -}]
+  SOURCE[$DSA_GOAL]=serializer_dsa.c serializer_dsa_priv.c serializer_dsa_pub.c serializer_dsa_param.c
+ENDIF

--- a/providers/implementations/serializers/build.info
+++ b/providers/implementations/serializers/build.info
@@ -8,5 +8,7 @@ $DSA_GOAL=../../libimplementations.a
 
 SOURCE[$SERIALIZER_GOAL]=serializer_common.c
 SOURCE[$RSA_GOAL]=serializer_rsa.c serializer_rsa_priv.c serializer_rsa_pub.c
-SOURCE[$DH_GOAL]=serializer_dh.c serializer_dh_priv.c serializer_dh_pub.c serializer_dh_param.c
+IF[{- !$disabled{dh} -}]
+  SOURCE[$DH_GOAL]=serializer_dh.c serializer_dh_priv.c serializer_dh_pub.c serializer_dh_param.c
+ENDIF
 SOURCE[$DSA_GOAL]=serializer_dsa.c serializer_dsa_priv.c serializer_dsa_pub.c serializer_dsa_param.c

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1413,6 +1413,7 @@ static int test_decrypt_null_chunks(void)
 }
 #endif /* !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) */
 
+#ifndef OPENSSL_NO_DH
 static int test_EVP_PKEY_set1_DH(void)
 {
     DH *x942dh, *pkcs3dh;
@@ -1447,6 +1448,7 @@ static int test_EVP_PKEY_set1_DH(void)
 
     return ret;
 }
+#endif
 
 int setup_tests(void)
 {
@@ -1483,7 +1485,9 @@ int setup_tests(void)
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     ADD_TEST(test_decrypt_null_chunks);
 #endif
+#ifndef OPENSSL_NO_DH
     ADD_TEST(test_EVP_PKEY_set1_DH);
+#endif
 
     return 1;
 }

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -139,6 +139,7 @@ static int test_fromdata_rsa(void)
     return ret;
 }
 
+#ifndef OPENSSL_NO_DH
 /* Array indexes used in test_fromdata_dh */
 #define PRIV_KEY        0
 #define PUB_KEY         1
@@ -187,10 +188,13 @@ static int test_fromdata_dh(void)
 
     return ret;
 }
+#endif
 
 int setup_tests(void)
 {
     ADD_TEST(test_fromdata_rsa);
+#ifndef OPENSSL_NO_DH
     ADD_TEST(test_fromdata_dh);
+#endif
     return 1;
 }


### PR DESCRIPTION
Fix various miscellaneous missing guards for no-dh and no-dsa.

The first commit (i.e. the changes to evp_extra_test.c) will also be applied to the 1.1.1 branch. The other changes are only relevant in master.