### PR TITLE
CORE & EVP: Adapt KEYEXCH, SIGNATURE and ASYM_CIPHER to handle key types better

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -89,6 +89,7 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_exportkey_fn *exportkey;
     OSSL_OP_keymgmt_importkey_types_fn *importkey_types;
     OSSL_OP_keymgmt_exportkey_types_fn *exportkey_types;
+    OSSL_OP_keymgmt_query_operation_name_fn *query_operation_name;
 } /* EVP_KEYMGMT */ ;
 
 struct keymgmt_data_st {

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -173,20 +173,32 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
     evp_pkey_ctx_free_old_ops(ctx);
     ctx->operation = EVP_PKEY_OP_DERIVE;
 
-    if (ctx->engine != NULL || ctx->algorithm == NULL)
+    if (ctx->engine != NULL || ctx->keytype == NULL)
         goto legacy;
 
-    /*
-     * Because we cleared out old ops, we shouldn't need to worry about
-     * checking if exchange is already there.  Keymgmt is a different
-     * matter, as it isn't tied to a specific EVP_PKEY op.
-     */
-    exchange = EVP_KEYEXCH_fetch(ctx->libctx, ctx->algorithm, ctx->propquery);
-    if (exchange != NULL && ctx->keymgmt == NULL) {
-        int name_id = EVP_KEYEXCH_number(exchange);
-
+    if (ctx->keymgmt == NULL)
         ctx->keymgmt =
-            evp_keymgmt_fetch_by_number(ctx->libctx, name_id, ctx->propquery);
+            EVP_KEYMGMT_fetch(ctx->libctx, ctx->keytype, ctx->propquery);
+    if (ctx->keymgmt != NULL) {
+        const char *supported_exch = NULL;
+
+        if (ctx->keymgmt->query_operation_name != NULL)
+            supported_exch =
+                ctx->keymgmt->query_operation_name(OSSL_OP_KEYEXCH);
+
+        /*
+         * If we didn't get a supported exch, assume there is one with the
+         * same name as the key type.
+         */
+        if (supported_exch == NULL)
+            supported_exch = ctx->keytype;
+
+        /*
+         * Because we cleared out old ops, we shouldn't need to worry about
+         * checking if exchange is already there.
+         */
+        exchange =
+            EVP_KEYEXCH_fetch(ctx->libctx, supported_exch, ctx->propquery);
     }
 
     if (ctx->keymgmt == NULL

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -118,6 +118,12 @@ static void *keymgmt_from_dispatch(int name_id,
             keymgmt->exportkey_types =
                 OSSL_get_OP_keymgmt_exportkey_types(fns);
             break;
+        case OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME:
+            if (keymgmt->query_operation_name != NULL)
+                break;
+            keymgmt->query_operation_name =
+                OSSL_get_OP_keymgmt_query_operation_name(fns);
+            break;
         }
     }
     /*

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -19,13 +19,13 @@
 
 static int fromdata_init(EVP_PKEY_CTX *ctx, int operation)
 {
-    if (ctx == NULL || ctx->algorithm == NULL)
+    if (ctx == NULL || ctx->keytype == NULL)
         goto not_supported;
 
     evp_pkey_ctx_free_old_ops(ctx);
     ctx->operation = operation;
     if (ctx->keymgmt == NULL)
-        ctx->keymgmt = EVP_KEYMGMT_fetch(NULL, ctx->algorithm, ctx->propquery);
+        ctx->keymgmt = EVP_KEYMGMT_fetch(NULL, ctx->keytype, ctx->propquery);
     if (ctx->keymgmt == NULL)
         goto not_supported;
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -221,7 +221,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
         return NULL;
     }
     ret->libctx = libctx;
-    ret->algorithm = name;
+    ret->keytype = name;
     ret->propquery = propquery;
     ret->engine = e;
     ret->pmeth = pmeth;
@@ -382,7 +382,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
     rctx->pkey = pctx->pkey;
     rctx->operation = pctx->operation;
     rctx->libctx = pctx->libctx;
-    rctx->algorithm = pctx->algorithm;
+    rctx->keytype = pctx->keytype;
     rctx->propquery = pctx->propquery;
 
     if (EVP_PKEY_CTX_IS_DERIVE_OP(pctx)) {

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -21,14 +21,14 @@ EVP_PKEY_CTX_dup, EVP_PKEY_CTX_free
 =head1 DESCRIPTION
 
 The EVP_PKEY_CTX_new() function allocates public key algorithm context using
-the algorithm specified in I<pkey> and ENGINE I<e>.
+the I<pkey> key type and ENGINE I<e>.
 
 The EVP_PKEY_CTX_new_id() function allocates public key algorithm context
-using the algorithm specified by I<id> and ENGINE I<e>.
+using the key type specified by I<id> and ENGINE I<e>.
 
 The EVP_PKEY_CTX_new_provided() function allocates a public key algorithm
 context using the library context I<libctx> (see L<OPENSSL_CTX(3)>), the
-algorithm specified by I<name> and the property query I<propquery>.  None
+key type specified by I<name> and the property query I<propquery>.  None
 of the arguments are duplicated, so they  must remain unchanged for the
 lifetime of the returned B<EVP_PKEY_CTX> or of any of its duplicates.
 
@@ -44,10 +44,24 @@ If I<ctx> is NULL, nothing is done.
 
 =head1 NOTES
 
+=over 4
+
+=item 1.
+
 The B<EVP_PKEY_CTX> structure is an opaque public key algorithm context used
 by the OpenSSL high level public key API. Contexts B<MUST NOT> be shared between
 threads: that is it is not permissible to use the same context simultaneously
 in two threads.
+
+=item 2.
+
+We mention "key type" in this manual, which is the same
+as "algorithm" in most cases, allowing either term to be used
+interchangeably.  There are algorithms when they I<key type> and the
+I<algorithm> of the operations that use the keys are not the same,
+such as EC keys being used for ECDSA and ECDH operations.
+
+=back
 
 =head1 RETURN VALUES
 

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -57,7 +57,7 @@ in two threads.
 
 We mention "key type" in this manual, which is the same
 as "algorithm" in most cases, allowing either term to be used
-interchangeably.  There are algorithms when the I<key type> and the
+interchangeably.  There are algorithms where the I<key type> and the
 I<algorithm> of the operations that use the keys are not the same,
 such as EC keys being used for ECDSA and ECDH operations.
 

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -57,7 +57,7 @@ in two threads.
 
 We mention "key type" in this manual, which is the same
 as "algorithm" in most cases, allowing either term to be used
-interchangeably.  There are algorithms when they I<key type> and the
+interchangeably.  There are algorithms when the I<key type> and the
 I<algorithm> of the operations that use the keys are not the same,
 such as EC keys being used for ECDSA and ECDH operations.
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -40,6 +40,9 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  const OSSL_PARAM *OP_keymgmt_importkey_types(void);
  const OSSL_PARAM *OP_keymgmt_exportkey_types(void);
 
+ /* Discovery of supported operations */
+ const char *OP_keymgmt_query_operation_name(int operation_id);
+
 =head1 DESCRIPTION
 
 The KEYMGMT operation doesn't have much public visibility in OpenSSL
@@ -157,6 +160,16 @@ as well...
 OP_keymgmt_exportkey_types() should return a constant array of
 descriptor B<OSSL_PARAM>, for parameters that can be exported with
 OP_keymgmt_exportkeys().
+
+=head2 Supported operations
+
+OP_keymgmt_query_operation_name() should return the name of the
+supported algorithm for the operation I<operation_id>.  This is
+similar to provider_query_operation() (see L<provider-base(7)>),
+but only works as an advisory.  If this function is not present, or
+returns NULL, the caller is free to assume that there's an algorithm
+from the same provider, of the same name as the one used to fetch the
+keymgmt and try to use that.
 
 =head1 SEE ALSO
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -22,11 +22,11 @@ struct evp_pkey_ctx_st {
     int operation;
 
     /*
-     * Library context, Algorithm name and properties associated
+     * Library context, Key type name and properties associated
      * with this context
      */
     OPENSSL_CTX *libctx;
-    const char *algorithm;
+    const char *keytype;
     const char *propquery;
 
     /* cached key manager */

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -395,6 +395,11 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_exportkey,
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_importkey_types, (void))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_exportkey_types, (void))
 
+/* Discovery of supported operations */
+# define OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME    17
+OSSL_CORE_MAKE_FUNC(const char *,OP_keymgmt_query_operation_name,
+                    (int operation_id))
+
 /* Key Exchange */
 
 # define OSSL_FUNC_KEYEXCH_NEWCTX                      1

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -388,12 +388,12 @@ static const OSSL_ALGORITHM deflt_asym_cipher[] = {
 
 static const OSSL_ALGORITHM deflt_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH", "default=yes", dh_keymgmt_functions },
+    { "DH:dhKeyAgreement", "default=yes", dh_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA", "default=yes", dsa_keymgmt_functions },
+    { "DSA:dsaEncryption", "default=yes", dsa_keymgmt_functions },
 #endif
-    { "RSA", "default=yes", rsa_keymgmt_functions },
+    { "RSA:rsaEncryption", "default=yes", rsa_keymgmt_functions },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
The adaptation is to handle the case when key types and operations
that use these keys have different names.  For example, EC keys can be
used for ECDSA and ECDH.

This also involves specifying OP_query_operation_name() for KEYMGMT

This will allow keymgmt implementation for key types that need it to
specify the names of the diverse operation algorithms it can be used
with.  Currently, only one name per key type and operation is allowed.