### PR TITLE
Add some missing cfi frame info in aesni-x86_64.pl

### DIFF
--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -986,6 +986,7 @@ $code.=<<___;
 .type	aesni_ccm64_encrypt_blocks,\@function,6
 .align	16
 aesni_ccm64_encrypt_blocks:
+.cfi_startproc
 ___
 $code.=<<___ if ($win64);
 	lea	-0x58(%rsp),%rsp
@@ -1068,6 +1069,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	aesni_ccm64_encrypt_blocks,.-aesni_ccm64_encrypt_blocks
 ___
 ######################################################################
@@ -1076,6 +1078,7 @@ $code.=<<___;
 .type	aesni_ccm64_decrypt_blocks,\@function,6
 .align	16
 aesni_ccm64_decrypt_blocks:
+.cfi_startproc
 ___
 $code.=<<___ if ($win64);
 	lea	-0x58(%rsp),%rsp
@@ -1175,6 +1178,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	aesni_ccm64_decrypt_blocks,.-aesni_ccm64_decrypt_blocks
 ___
 }
@@ -3033,6 +3037,7 @@ $code.=<<___;
 .type	__ocb_encrypt6,\@abi-omnipotent
 .align	32
 __ocb_encrypt6:
+.cfi_startproc
 	 pxor		$rndkey0l,@offset[5]	# offset_i ^ round[0]
 	 movdqu		($L_p,$i1),@offset[1]
 	 movdqa		@offset[0],@offset[2]
@@ -3130,11 +3135,13 @@ __ocb_encrypt6:
 	aesenclast	@offset[4],$inout4
 	aesenclast	@offset[5],$inout5
 	ret
+.cfi_endproc
 .size	__ocb_encrypt6,.-__ocb_encrypt6
 
 .type	__ocb_encrypt4,\@abi-omnipotent
 .align	32
 __ocb_encrypt4:
+.cfi_startproc
 	 pxor		$rndkey0l,@offset[5]	# offset_i ^ round[0]
 	 movdqu		($L_p,$i1),@offset[1]
 	 movdqa		@offset[0],@offset[2]
@@ -3199,11 +3206,13 @@ __ocb_encrypt4:
 	aesenclast	@offset[2],$inout2
 	aesenclast	@offset[3],$inout3
 	ret
+.cfi_endproc
 .size	__ocb_encrypt4,.-__ocb_encrypt4
 
 .type	__ocb_encrypt1,\@abi-omnipotent
 .align	32
 __ocb_encrypt1:
+.cfi_startproc
 	 pxor		@offset[5],$inout5	# offset_i
 	 pxor		$rndkey0l,$inout5	# offset_i ^ round[0]
 	pxor		$inout0,$checksum	# accumulate checksum
@@ -3234,6 +3243,7 @@ __ocb_encrypt1:
 
 	aesenclast	$inout5,$inout0
 	ret
+.cfi_endproc
 .size	__ocb_encrypt1,.-__ocb_encrypt1
 
 .globl	aesni_ocb_decrypt
@@ -3515,6 +3525,7 @@ $code.=<<___;
 .type	__ocb_decrypt6,\@abi-omnipotent
 .align	32
 __ocb_decrypt6:
+.cfi_startproc
 	 pxor		$rndkey0l,@offset[5]	# offset_i ^ round[0]
 	 movdqu		($L_p,$i1),@offset[1]
 	 movdqa		@offset[0],@offset[2]
@@ -3606,11 +3617,13 @@ __ocb_decrypt6:
 	aesdeclast	@offset[4],$inout4
 	aesdeclast	@offset[5],$inout5
 	ret
+.cfi_endproc
 .size	__ocb_decrypt6,.-__ocb_decrypt6
 
 .type	__ocb_decrypt4,\@abi-omnipotent
 .align	32
 __ocb_decrypt4:
+.cfi_startproc
 	 pxor		$rndkey0l,@offset[5]	# offset_i ^ round[0]
 	 movdqu		($L_p,$i1),@offset[1]
 	 movdqa		@offset[0],@offset[2]
@@ -3671,11 +3684,13 @@ __ocb_decrypt4:
 	aesdeclast	@offset[2],$inout2
 	aesdeclast	@offset[3],$inout3
 	ret
+.cfi_endproc
 .size	__ocb_decrypt4,.-__ocb_decrypt4
 
 .type	__ocb_decrypt1,\@abi-omnipotent
 .align	32
 __ocb_decrypt1:
+.cfi_startproc
 	 pxor		@offset[5],$inout5	# offset_i
 	 pxor		$rndkey0l,$inout5	# offset_i ^ round[0]
 	pxor		$inout5,$inout0		# input ^ round[0] ^ offset_i
@@ -3705,6 +3720,7 @@ __ocb_decrypt1:
 
 	aesdeclast	$inout5,$inout0
 	ret
+.cfi_endproc
 .size	__ocb_decrypt1,.-__ocb_decrypt1
 ___
 } }}
@@ -4639,7 +4655,6 @@ __aesni_set_encrypt_key:
 	add	\$8,%rsp
 .cfi_adjust_cfa_offset	-8
 	ret
-.cfi_endproc
 .LSEH_end_set_encrypt_key:
 
 .align	16
@@ -4710,6 +4725,7 @@ __aesni_set_encrypt_key:
 	shufps	\$0b10101010,%xmm1,%xmm1	# critical path
 	xorps	%xmm1,%xmm2
 	ret
+.cfi_endproc
 .size	${PREFIX}_set_encrypt_key,.-${PREFIX}_set_encrypt_key
 .size	__aesni_set_encrypt_key,.-__aesni_set_encrypt_key
 ___


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
