### PR TITLE
Add some missing cfi frame info in keccak1600-x86_64.pl

### DIFF
--- a/crypto/sha/asm/keccak1600-x86_64.pl
+++ b/crypto/sha/asm/keccak1600-x86_64.pl
@@ -86,6 +86,7 @@ $code.=<<___;
 .type	__KeccakF1600,\@abi-omnipotent
 .align	32
 __KeccakF1600:
+.cfi_startproc
 	mov	$A[4][0](%rdi),@C[0]
 	mov	$A[4][1](%rdi),@C[1]
 	mov	$A[4][2](%rdi),@C[2]
@@ -344,6 +345,7 @@ $code.=<<___;
 
 	lea	-192($iotas),$iotas	# rewind iotas
 	ret
+.cfi_endproc
 .size	__KeccakF1600,.-__KeccakF1600
 
 .type	KeccakF1600,\@abi-omnipotent


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
