### PR TITLE
Add some missing cfi frame info in aesni-sha and sha-x86_64.pl

### DIFF
--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -135,6 +135,7 @@ $code.=<<___;
 .type	aesni_cbc_sha1_enc,\@abi-omnipotent
 .align	32
 aesni_cbc_sha1_enc:
+.cfi_startproc
 	# caller should check for SSSE3 and AES-NI bits
 	mov	OPENSSL_ia32cap_P+0(%rip),%r10d
 	mov	OPENSSL_ia32cap_P+4(%rip),%r11
@@ -153,6 +154,7 @@ ___
 $code.=<<___;
 	jmp	aesni_cbc_sha1_enc_ssse3
 	ret
+.cfi_endproc
 .size	aesni_cbc_sha1_enc,.-aesni_cbc_sha1_enc
 ___
 
@@ -842,6 +844,7 @@ $code.=<<___;
 .type	aesni256_cbc_sha1_dec,\@abi-omnipotent
 .align	32
 aesni256_cbc_sha1_dec:
+.cfi_startproc
 	# caller should check for SSSE3 and AES-NI bits
 	mov	OPENSSL_ia32cap_P+0(%rip),%r10d
 	mov	OPENSSL_ia32cap_P+4(%rip),%r11d
@@ -856,6 +859,7 @@ ___
 $code.=<<___;
 	jmp	aesni256_cbc_sha1_dec_ssse3
 	ret
+.cfi_endproc
 .size	aesni256_cbc_sha1_dec,.-aesni256_cbc_sha1_dec
 
 .type	aesni256_cbc_sha1_dec_ssse3,\@function,6
@@ -1762,6 +1766,7 @@ $code.=<<___;
 .type	aesni_cbc_sha1_enc_shaext,\@function,6
 .align	32
 aesni_cbc_sha1_enc_shaext:
+.cfi_startproc
 	mov	`($win64?56:8)`(%rsp),$inp	# load 7th argument
 ___
 $code.=<<___ if ($win64);
@@ -1913,6 +1918,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	aesni_cbc_sha1_enc_shaext,.-aesni_cbc_sha1_enc_shaext
 ___
 						}}}

--- a/crypto/aes/asm/aesni-sha256-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha256-x86_64.pl
@@ -125,6 +125,7 @@ $code=<<___;
 .type	$func,\@abi-omnipotent
 .align	16
 $func:
+.cfi_startproc
 ___
 						if ($avx) {
 $code.=<<___;
@@ -164,6 +165,7 @@ $code.=<<___;
 	ud2
 .Lprobe:
 	ret
+.cfi_endproc
 .size	$func,.-$func
 
 .align	64

--- a/crypto/sha/asm/sha1-x86_64.pl
+++ b/crypto/sha/asm/sha1-x86_64.pl
@@ -470,8 +470,8 @@ $code.=<<___ if ($win64);
 .Lepilogue_shaext:
 ___
 $code.=<<___;
-.cfi_endproc
 	ret
+.cfi_endproc
 .size	sha1_block_data_order_shaext,.-sha1_block_data_order_shaext
 ___
 }}}

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -571,6 +571,7 @@ $code.=<<___;
 .align	64
 sha256_block_data_order_shaext:
 _shaext_shortcut:
+.cfi_startproc
 ___
 $code.=<<___ if ($win64);
 	lea	`-8-5*16`(%rsp),%rsp
@@ -714,6 +715,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	sha256_block_data_order_shaext,.-sha256_block_data_order_shaext
 ___
 }}}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
