### PR TITLE
CRYPTO: split cipher_platform.h into algorithm specific headers

### DIFF
--- a/crypto/camellia/build.info
+++ b/crypto/camellia/build.info
@@ -10,10 +10,12 @@ IF[{- !$disabled{asm} -}]
   # appropriate one
   IF[$CMLLASM_{- $target{asm_arch} -}]
     $CMLLASM=$CMLLASM_{- $target{asm_arch} -}
+    $CMLLDEF=CMLL_ASM
   ENDIF
 ENDIF
 
 SOURCE[../../libcrypto]=cmll_ecb.c cmll_ofb.c cmll_cfb.c cmll_ctr.c $CMLLASM
+DEFINE[../../libcrypto]=$CMLLDEF
 
 GENERATE[cmll-x86.s]=asm/cmll-x86.pl
 DEPEND[cmll-x86.s]=../perlasm/x86asm.pl

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -9,6 +9,7 @@ IF[{- !$disabled{asm} -}]
   # appropriate one
   IF[$DESASM_{- $target{asm_arch} -}]
     $DESASM=$DESASM_{- $target{asm_arch} -}
+    $DESDEF=DES_ASM
   ENDIF
 ENDIF
 
@@ -21,6 +22,8 @@ SOURCE[../../libcrypto]=$COMMON\
         str2key.c  pcbc_enc.c qud_cksm.c rand_key.c \
         fcrypt.c xcbc_enc.c cbc_cksm.c
 SOURCE[../../providers/libfips.a]=$COMMON
+DEFINE[../../libcrypto]=$DESDEF
+DEFINE[../../providers/libfips.a]=$DESDEF
 
 GENERATE[des_enc-sparc.S]=asm/des_enc.m4
 GENERATE[dest4-sparcv9.S]=asm/dest4-sparcv9.pl

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -20,7 +20,7 @@
 #include "internal/cryptlib.h"
 #include "crypto/modes.h"
 #include "crypto/siv.h"
-#include "crypto/ciphermode_platform.h"
+#include "crypto/aes_platform.h"
 #include "evp_local.h"
 
 typedef struct {

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -19,7 +19,7 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <openssl/camellia.h>
 # include "crypto/evp.h"
 # include "crypto/modes.h"
-# include "crypto/ciphermode_platform.h"
+# include "crypto/cmll_platform.h"
 
 static int camellia_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                              const unsigned char *iv, int enc);

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OSSL_CRYPTO_CIPHERMODE_PLATFORM_H
-# define OSSL_CRYPTO_CIPHERMODE_PLATFORM_H
+#ifndef OSSL_AES_PLATFORM_H
+# define OSSL_AES_PLATFORM_H
 
 # include "openssl/aes.h"
 
@@ -223,39 +223,7 @@ void gcm_ghash_avx(u64 Xi[2], const u128 Htable[16], const u8 *in, size_t len);
 extern unsigned int OPENSSL_sparcv9cap_P[];
 #  include "sparc_arch.h"
 
-#  ifndef OPENSSL_NO_CAMELLIA
-#   define SPARC_CMLL_CAPABLE      (OPENSSL_sparcv9cap_P[1] & CFR_CAMELLIA)
-#   include "openssl/camellia.h"
-
-void cmll_t4_set_key(const unsigned char *key, int bits, CAMELLIA_KEY *ks);
-void cmll_t4_encrypt(const unsigned char *in, unsigned char *out,
-                     const CAMELLIA_KEY *key);
-void cmll_t4_decrypt(const unsigned char *in, unsigned char *out,
-                     const CAMELLIA_KEY *key);
-
-void cmll128_t4_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                            size_t len, const CAMELLIA_KEY *key,
-                            unsigned char *ivec);
-void cmll128_t4_cbc_decrypt(const unsigned char *in, unsigned char *out,
-                            size_t len, const CAMELLIA_KEY *key,
-                            unsigned char *ivec);
-void cmll256_t4_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                            size_t len, const CAMELLIA_KEY *key,
-                            unsigned char *ivec);
-void cmll256_t4_cbc_decrypt(const unsigned char *in, unsigned char *out,
-                            size_t len, const CAMELLIA_KEY *key,
-                            unsigned char *ivec);
-void cmll128_t4_ctr32_encrypt(const unsigned char *in, unsigned char *out,
-                              size_t blocks, const CAMELLIA_KEY *key,
-                              unsigned char *ivec);
-void cmll256_t4_ctr32_encrypt(const unsigned char *in, unsigned char *out,
-                              size_t blocks, const CAMELLIA_KEY *key,
-                              unsigned char *ivec);
-#  endif /* OPENSSL_NO_CAMELLIA */
-
-
 #  define SPARC_AES_CAPABLE       (OPENSSL_sparcv9cap_P[1] & CFR_AES)
-#  define SPARC_DES_CAPABLE       (OPENSSL_sparcv9cap_P[1] & CFR_DES)
 #  define HWAES_CAPABLE           (OPENSSL_sparcv9cap_P[0] & SPARCV9_FJAESX)
 #  define HWAES_set_encrypt_key aes_fx_set_encrypt_key
 #  define HWAES_set_decrypt_key aes_fx_set_decrypt_key
@@ -320,19 +288,6 @@ void aes256_t4_xts_encrypt(const unsigned char *in, unsigned char *out,
 void aes256_t4_xts_decrypt(const unsigned char *in, unsigned char *out,
                            size_t blocks, const AES_KEY *key1,
                            const AES_KEY *key2, const unsigned char *ivec);
-
-#  ifndef OPENSSL_NO_DES
-#   include <openssl/des.h>
-void des_t4_key_expand(const void *key, DES_key_schedule *ks);
-void des_t4_ede3_cbc_encrypt(const void *inp, void *out, size_t len,
-                             const DES_key_schedule ks[3], unsigned char iv[8]);
-void des_t4_ede3_cbc_decrypt(const void *inp, void *out, size_t len,
-                             const DES_key_schedule ks[3], unsigned char iv[8]);
-void des_t4_cbc_encrypt(const void *inp, void *out, size_t len,
-                        const DES_key_schedule *ks, unsigned char iv[8]);
-void des_t4_cbc_decrypt(const void *inp, void *out, size_t len,
-                        const DES_key_schedule *ks, unsigned char iv[8]);
-#  endif /*  OPENSSL_NO_DES */
 
 # elif defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
 /* IBM S390X support */
@@ -480,4 +435,4 @@ void HWAES_ocb_decrypt(const unsigned char *in, unsigned char *out,
 
 # endif /* HWAES_CAPABLE */
 
-#endif /* OSSL_CRYPTO_CIPHERMODE_PLATFORM_H */
+#endif /* OSSL_AES_PLATFORM_H */

--- a/include/crypto/cmll_platform.h
+++ b/include/crypto/cmll_platform.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_CMLL_PLATFORM_H
+# define OSSL_CMLL_PLATFORM_H
+
+# if defined(CMLL_ASM) && (defined(__sparc) || defined(__sparc__))
+
+/* Fujitsu SPARC64 X support */
+extern unsigned int OPENSSL_sparcv9cap_P[];
+#  include "sparc_arch.h"
+
+#  ifndef OPENSSL_NO_CAMELLIA
+#   define SPARC_CMLL_CAPABLE      (OPENSSL_sparcv9cap_P[1] & CFR_CAMELLIA)
+#   include <openssl/camellia.h>
+
+void cmll_t4_set_key(const unsigned char *key, int bits, CAMELLIA_KEY *ks);
+void cmll_t4_encrypt(const unsigned char *in, unsigned char *out,
+                     const CAMELLIA_KEY *key);
+void cmll_t4_decrypt(const unsigned char *in, unsigned char *out,
+                     const CAMELLIA_KEY *key);
+
+void cmll128_t4_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                            size_t len, const CAMELLIA_KEY *key,
+                            unsigned char *ivec);
+void cmll128_t4_cbc_decrypt(const unsigned char *in, unsigned char *out,
+                            size_t len, const CAMELLIA_KEY *key,
+                            unsigned char *ivec);
+void cmll256_t4_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                            size_t len, const CAMELLIA_KEY *key,
+                            unsigned char *ivec);
+void cmll256_t4_cbc_decrypt(const unsigned char *in, unsigned char *out,
+                            size_t len, const CAMELLIA_KEY *key,
+                            unsigned char *ivec);
+void cmll128_t4_ctr32_encrypt(const unsigned char *in, unsigned char *out,
+                              size_t blocks, const CAMELLIA_KEY *key,
+                              unsigned char *ivec);
+void cmll256_t4_ctr32_encrypt(const unsigned char *in, unsigned char *out,
+                              size_t blocks, const CAMELLIA_KEY *key,
+                              unsigned char *ivec);
+#  endif /* OPENSSL_NO_CAMELLIA */
+
+# endif /* CMLL_ASM && sparc */
+
+#endif /* OSSL_CRYPTO_CIPHERMODE_PLATFORM_H */

--- a/include/crypto/des_platform.h
+++ b/include/crypto/des_platform.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_DES_PLATFORM_H
+# define OSSL_DES_PLATFORM_H
+
+# if defined(DES_ASM) && (defined(__sparc) || defined(__sparc__))
+
+/* Fujitsu SPARC64 X support */
+extern unsigned int OPENSSL_sparcv9cap_P[];
+#  include "sparc_arch.h"
+
+#  ifndef OPENSSL_NO_DES
+#   define SPARC_DES_CAPABLE      (OPENSSL_sparcv9cap_P[1] & CFR_DES)
+#   include <openssl/des.h>
+void des_t4_key_expand(const void *key, DES_key_schedule *ks);
+void des_t4_ede3_cbc_encrypt(const void *inp, void *out, size_t len,
+                             const DES_key_schedule ks[3], unsigned char iv[8]);
+void des_t4_ede3_cbc_decrypt(const void *inp, void *out, size_t len,
+                             const DES_key_schedule ks[3], unsigned char iv[8]);
+void des_t4_cbc_encrypt(const void *inp, void *out, size_t len,
+                        const DES_key_schedule *ks, unsigned char iv[8]);
+void des_t4_cbc_decrypt(const void *inp, void *out, size_t len,
+                        const DES_key_schedule *ks, unsigned char iv[8]);
+#  endif /* OPENSSL_NO_DES */
+
+# endif /* DES_ASM && sparc */
+
+#endif /* OSSL_CRYPTO_CIPHERMODE_PLATFORM_H */

--- a/providers/build.info
+++ b/providers/build.info
@@ -40,7 +40,7 @@ $LIBNONFIPS=libnonfips.a
 $LIBFIPS=libfips.a
 
 # Enough of our implementations include prov/ciphercommon.h (present in
-# providers/implementations/include), which includes crypto/ciphermode_platform.h
+# providers/implementations/include), which includes crypto/*_platform.h
 # (present in include), which in turn may include very internal header
 # files in crypto/, so let's have a common include list for them all.
 $COMMON_INCLUDES=../crypto ../include implementations/include common/include

--- a/providers/implementations/ciphers/cipher_aes.h
+++ b/providers/implementations/ciphers/cipher_aes.h
@@ -9,6 +9,7 @@
 
 #include <openssl/aes.h>
 #include "prov/ciphercommon.h"
+#include "crypto/aes_platform.h"
 
 typedef struct prov_aes_ctx_st {
     PROV_CIPHER_CTX base;      /* Must be first */

--- a/providers/implementations/ciphers/cipher_aes_ccm.h
+++ b/providers/implementations/ciphers/cipher_aes_ccm.h
@@ -10,6 +10,7 @@
 #include <openssl/aes.h>
 #include "prov/ciphercommon.h"
 #include "prov/ciphercommon_ccm.h"
+#include "crypto/aes_platform.h"
 
 typedef struct prov_aes_ccm_ctx_st {
     PROV_CCM_CTX base;         /* Must be first */

--- a/providers/implementations/ciphers/cipher_aes_gcm.h
+++ b/providers/implementations/ciphers/cipher_aes_gcm.h
@@ -10,6 +10,7 @@
 #include <openssl/aes.h>
 #include "prov/ciphercommon.h"
 #include "prov/ciphercommon_gcm.h"
+#include "crypto/aes_platform.h"
 
 typedef struct prov_aes_gcm_ctx_st {
     PROV_GCM_CTX base;          /* must be first entry in struct */

--- a/providers/implementations/ciphers/cipher_aes_ocb.h
+++ b/providers/implementations/ciphers/cipher_aes_ocb.h
@@ -9,6 +9,7 @@
 
 #include <openssl/aes.h>
 #include "prov/ciphercommon.h"
+#include "crypto/aes_platform.h"
 
 #define OCB_MAX_TAG_LEN     AES_BLOCK_SIZE
 #define OCB_MAX_DATA_LEN    AES_BLOCK_SIZE

--- a/providers/implementations/ciphers/cipher_aes_siv.h
+++ b/providers/implementations/ciphers/cipher_aes_siv.h
@@ -8,7 +8,8 @@
  */
 
 #include "prov/ciphercommon.h"
-#include "include/crypto/siv.h"
+#include "crypto/aes_platform.h"
+#include "crypto/siv.h"
 
 typedef struct prov_cipher_hw_aes_siv_st {
     int (*initkey)(void *ctx, const uint8_t *key, size_t keylen);

--- a/providers/implementations/ciphers/cipher_aes_xts.h
+++ b/providers/implementations/ciphers/cipher_aes_xts.h
@@ -9,6 +9,7 @@
 
 #include <openssl/aes.h>
 #include "prov/ciphercommon.h"
+#include "crypto/aes_platform.h"
 
 /*
  * Available in cipher_fips.c, and compiled with different values depending

--- a/providers/implementations/ciphers/cipher_camellia.h
+++ b/providers/implementations/ciphers/cipher_camellia.h
@@ -9,6 +9,7 @@
 
 #include "openssl/camellia.h"
 #include "prov/ciphercommon.h"
+#include "crypto/cmll_platform.h"
 
 typedef struct prov_camellia_ctx_st {
     PROV_CIPHER_CTX base;      /* Must be first */

--- a/providers/implementations/ciphers/cipher_des.h
+++ b/providers/implementations/ciphers/cipher_des.h
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/des.h>
+#include "crypto/des_platform.h"
 
 /* TODO(3.0) Figure out what flags need to be here */
 #define TDES_FLAGS (EVP_CIPH_RAND_KEY)

--- a/providers/implementations/ciphers/cipher_tdes.h
+++ b/providers/implementations/ciphers/cipher_tdes.h
@@ -9,6 +9,7 @@
 
 #include <openssl/des.h>
 #include <openssl/core_numbers.h>
+#include "crypto/des_platform.h"
 
 #define DES_BLOCK_SIZE 8
 #define TDES_IVLEN 8

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -13,7 +13,6 @@
 #include <openssl/evp.h>
 #include "internal/cryptlib.h"
 #include "crypto/modes.h"
-#include "crypto/ciphermode_platform.h"
 
 #define MAXCHUNK    ((size_t)1 << (sizeof(long) * 8 - 2))
 #define MAXBITCHUNK ((size_t)1 << (sizeof(size_t) * 8 - 4))

--- a/util/fix-includes.sed
+++ b/util/fix-includes.sed
@@ -1,5 +1,5 @@
 s|internal/([a-z0-9_]+)_int\.h|crypto/\1.h|g ;
-s@internal/(aria.h|asn1_dsa.h|async.h|bn_conf.h|bn_conf.h|bn_dh.h|bn_srp.h|chacha.h|ciphermode_platform.h|ctype.h|__DECC_INCLUDE_EPILOGUE.H|__DECC_INCLUDE_PROLOGUE.H|dso_conf.h|dso_conf.h|engine.h|lhash.h|md32_common.h|objects.h|poly1305.h|sha.h|siphash.h|sm2err.h|sm2.h|sm4.h|sparse_array.h|store.h|foobar)@crypto/\1@g ;
+s@internal/(aria.h|asn1_dsa.h|async.h|bn_conf.h|bn_conf.h|bn_dh.h|bn_srp.h|chacha.h|(aes|des|cmll)_platform.h|ctype.h|__DECC_INCLUDE_EPILOGUE.H|__DECC_INCLUDE_PROLOGUE.H|dso_conf.h|dso_conf.h|engine.h|lhash.h|md32_common.h|objects.h|poly1305.h|sha.h|siphash.h|sm2err.h|sm2.h|sm4.h|sparse_array.h|store.h|foobar)@crypto/\1@g ;
 s/constant_time_locl/constant_time/g ;
 s/_lo?cl\.h/_local.h/g ;
 s/_int\.h/_local.h/g ;


### PR DESCRIPTION
aes_platform.h
cmll_platform.h
des_platform.h

To make this possible, we must also define DES_ASM and CMLL_ASM to
indicate that we have the necessary internal support.