### PR TITLE
Add -DOPENSSL_BUILDING_OPENSSL to our builds

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -10,7 +10,7 @@ my %targets=(
 	includes	=> [],
 	lib_cflags	=> "",
 	lib_cppflags	=> "",
-	lib_defines	=> [],
+	lib_defines	=> [ 'OPENSSL_BUILDING_OPENSSL' ],
 	thread_scheme	=> "(unknown)", # Assume we don't know
 	thread_defines	=> [],
 

--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -10,7 +10,7 @@ my %targets=(
 	includes	=> [],
 	lib_cflags	=> "",
 	lib_cppflags	=> "",
-	lib_defines	=> [ 'OPENSSL_BUILDING_OPENSSL' ],
+	lib_defines	=> [],
 	thread_scheme	=> "(unknown)", # Assume we don't know
 	thread_defines	=> [],
 

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -179,7 +179,8 @@ MODULESDIR_C={- platform->osslprefix() -}MODULES{- $sover_dirname.$target{pointe
 
 CC={- $config{CC} -}
 CPP={- $config{CPP} -}
-DEFINES={- our $defines1 = join('', map { ",$_" } @{$config{CPPDEFINES}}) -}
+DEFINES={- our $defines1 = join('', map { ",$_" } ('OPENSSL_BUILDING_OPENSSL',
+                                                   @{$config{CPPDEFINES}})) -}
 INCLUDES={- our $includes1 = join(',', @{$config{CPPINCLUDES}}) -}
 CPPFLAGS={- our $cppflags1 = join('', @{$config{CPPFLAGS}}) -}
 CFLAGS={- join('', @{$config{CFLAGS}}) -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -274,6 +274,7 @@ CROSS_COMPILE={- $config{CROSS_COMPILE} -}
 CC=$(CROSS_COMPILE){- $config{CC} -}
 CXX={- $config{CXX} ? "\$(CROSS_COMPILE)$config{CXX}" : '' -}
 CPPFLAGS={- our $cppflags1 = join(" ",
+                                  ("-DOPENSSL_BUILDING_OPENSSL"),
                                   (map { "-D".$_} @{$config{CPPDEFINES}}),
                                   (map { "-I".$_} @{$config{CPPINCLUDES}}),
                                   @{$config{CPPFLAGS}}) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -204,6 +204,7 @@ libdir={- file_name_is_absolute($libdir)
 CC="{- $config{CC} -}"
 CPP="{- $config{CPP} -}"
 CPPFLAGS={- our $cppflags1 = join(" ",
+                                  ("-D\"OPENSSL_BUILDING_OPENSSL\""),
                                   (map { "-D".$_} @{$config{CPPDEFINES}}),
                                   (map { " -I ".$_} @{$config{CPPINCLUDES}}),
                                   @{$config{CPPFLAGS}}) -}


### PR DESCRIPTION
Our public header files are also used internally. This can cause issues when we want things "slightly different" when building internally: for example, we want to build with no-deprecated *for some things* but we want to allow users to have a choice.

See https://github.com/openssl/openssl/issues/10657#issuecomment-567836928 and the links it points to, etc.

This PR adds a define OPENSSL_BUILDING_OPENSSL which is only set in our internal Makefiles.
This means we can do things like this in files that use lhash.h but don't want the static inline functions declared when building openssl.
```
#if defined(OPENSSL_BUILDING_OPENSSL) || !defined(OPENSSL_NO_DEPRECATED_3)
... old code ...
DEFINE_STACK_OF(xxxx)
#else
... new code ...
STACK_OF(xxxx);
#endif 
```

This can be used in other places when we want to deprecate internally but not externally, such as perhaps the recent AES low-level functions #10587 