### PR TITLE
Add some missing cfi frame info in ecp_nistz256-x86_64.pl

### DIFF
--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -1581,6 +1581,7 @@ $code.=<<___;
 .type	ecp_nistz256_to_mont,\@function,2
 .align	32
 ecp_nistz256_to_mont:
+.cfi_startproc
 ___
 $code.=<<___	if ($addx);
 	mov	\$0x80100, %ecx
@@ -1589,6 +1590,7 @@ ___
 $code.=<<___;
 	lea	.LRR(%rip), $b_org
 	jmp	.Lmul_mont
+.cfi_endproc
 .size	ecp_nistz256_to_mont,.-ecp_nistz256_to_mont
 
 ################################################################################
@@ -2564,6 +2566,7 @@ $code.=<<___;
 .type	ecp_nistz256_scatter_w5,\@abi-omnipotent
 .align	32
 ecp_nistz256_scatter_w5:
+.cfi_startproc
 	lea	-3($index,$index,2), $index
 	movdqa	0x00($in_t), %xmm0
 	shl	\$5, $index
@@ -2580,6 +2583,7 @@ ecp_nistz256_scatter_w5:
 	movdqa	%xmm5, 0x50($val,$index)
 
 	ret
+.cfi_endproc
 .size	ecp_nistz256_scatter_w5,.-ecp_nistz256_scatter_w5
 
 ################################################################################
@@ -2687,6 +2691,7 @@ $code.=<<___;
 .type	ecp_nistz256_scatter_w7,\@abi-omnipotent
 .align	32
 ecp_nistz256_scatter_w7:
+.cfi_startproc
 	movdqu	0x00($in_t), %xmm0
 	shl	\$6, $index
 	movdqu	0x10($in_t), %xmm1
@@ -2698,6 +2703,7 @@ ecp_nistz256_scatter_w7:
 	movdqa	%xmm3, 0x30($val,$index)
 
 	ret
+.cfi_endproc
 .size	ecp_nistz256_scatter_w7,.-ecp_nistz256_scatter_w7
 
 ################################################################################
@@ -3022,8 +3028,10 @@ $code.=<<___;
 .type	ecp_nistz256_avx2_gather_w7,\@function,3
 .align	32
 ecp_nistz256_avx2_gather_w7:
+.cfi_startproc
 	.byte	0x0f,0x0b	# ud2
 	ret
+.cfi_endproc
 .size	ecp_nistz256_avx2_gather_w7,.-ecp_nistz256_avx2_gather_w7
 ___
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
