### PR TITLE
Fix aesni_cbc_sha256_enc_avx2 backtrace info

### DIFF
--- a/crypto/aes/asm/aesni-sha256-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha256-x86_64.pl
@@ -1088,7 +1088,23 @@ $code.=<<___;
 	vmovdqa	$t0,0x00(%rsp)
 	xor	$a1,$a1
 	vmovdqa	$t1,0x20(%rsp)
+___
+$code.=<<___ if (!$win64);
+# temporarily use %rsi as frame pointer
+        mov     $_rsp,%rsi
+.cfi_def_cfa    %rsi,8
+___
+$code.=<<___;
 	lea	-$PUSH8(%rsp),%rsp
+___
+$code.=<<___ if (!$win64);
+# the frame info is at $_rsp, but the stack is moving...
+# so a second frame pointer is saved at -8(%rsp)
+# that is in the red zone
+        mov     %rsi,-8(%rsp)
+.cfi_cfa_expression     %rsp-8,deref,+8
+___
+$code.=<<___;
 	mov	$B,$a3
 	vmovdqa	$t2,0x00(%rsp)
 	xor	$C,$a3			# magic
@@ -1110,7 +1126,17 @@ my @X = @_;
 my @insns = (&$body,&$body,&$body,&$body);	# 96 instructions
 my $base = "+2*$PUSH8(%rsp)";
 
-	&lea	("%rsp","-$PUSH8(%rsp)")	if (($j%2)==0);
+	if (($j%2)==0) {
+	&lea	("%rsp","-$PUSH8(%rsp)");
+$code.=<<___ if (!$win64);
+.cfi_cfa_expression     %rsp+`$PUSH8-8`,deref,+8
+# copy secondary frame pointer to new location again at -8(%rsp)
+        pushq   $PUSH8-8(%rsp)
+.cfi_cfa_expression     %rsp,deref,+8
+        lea     8(%rsp),%rsp
+.cfi_cfa_expression     %rsp-8,deref,+8
+___
+	}
 	foreach (Xupdate_256_AVX()) {		# 29 instructions
 	    eval;
 	    eval(shift(@insns));
@@ -1236,26 +1262,28 @@ $code.=<<___;
 
 	jbe	.Loop_avx2
 	lea	(%rsp),$Tbl
+# temporarily use $Tbl as index to $_rsp
+# this avoids the need to save a secondary frame pointer at -8(%rsp)
+.cfi_cfa_expression     $Tbl+`16*$SZ+7*8`,deref,+8
 
 .Ldone_avx2:
-	lea	($Tbl),%rsp
-	mov	$_ivp,$ivp
-	mov	$_rsp,%rsi
+	mov	16*$SZ+4*8($Tbl),$ivp
+	mov	16*$SZ+7*8($Tbl),%rsi
 .cfi_def_cfa	%rsi,8
 	vmovdqu	$iv,($ivp)		# output IV
 	vzeroall
 ___
 $code.=<<___ if ($win64);
-	movaps	`$framesz+16*0`(%rsp),%xmm6
-	movaps	`$framesz+16*1`(%rsp),%xmm7
-	movaps	`$framesz+16*2`(%rsp),%xmm8
-	movaps	`$framesz+16*3`(%rsp),%xmm9
-	movaps	`$framesz+16*4`(%rsp),%xmm10
-	movaps	`$framesz+16*5`(%rsp),%xmm11
-	movaps	`$framesz+16*6`(%rsp),%xmm12
-	movaps	`$framesz+16*7`(%rsp),%xmm13
-	movaps	`$framesz+16*8`(%rsp),%xmm14
-	movaps	`$framesz+16*9`(%rsp),%xmm15
+	movaps	`$framesz+16*0`($Tbl),%xmm6
+	movaps	`$framesz+16*1`($Tbl),%xmm7
+	movaps	`$framesz+16*2`($Tbl),%xmm8
+	movaps	`$framesz+16*3`($Tbl),%xmm9
+	movaps	`$framesz+16*4`($Tbl),%xmm10
+	movaps	`$framesz+16*5`($Tbl),%xmm11
+	movaps	`$framesz+16*6`($Tbl),%xmm12
+	movaps	`$framesz+16*7`($Tbl),%xmm13
+	movaps	`$framesz+16*8`($Tbl),%xmm14
+	movaps	`$framesz+16*9`($Tbl),%xmm15
 ___
 $code.=<<___;
 	mov	-48(%rsi),%r15
@@ -1343,6 +1371,7 @@ $code.=<<___;
 .type	${func}_shaext,\@function,6
 .align	32
 ${func}_shaext:
+.cfi_startproc
 	mov	`($win64?56:8)`(%rsp),$inp	# load 7th argument
 ___
 $code.=<<___ if ($win64);
@@ -1559,6 +1588,7 @@ $code.=<<___ if ($win64);
 ___
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	${func}_shaext,.-${func}_shaext
 ___
 }


### PR DESCRIPTION
This fixes a crash in the unwinder when the function aesni_cbc_sha256_enc_avx2
is interrupted.

It is reproducibly with `openssl speed -evp aes-128-cbc-hmac-sha256` and this patch
```
diff --git a/apps/speed.c b/apps/speed.c
index fa306c9..19f660b 100644
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -8,6 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <unwind.h>
 #undef SECONDS
 #define SECONDS                 3
 #define RSA_SECONDS             10
@@ -163,8 +164,44 @@ static const int aead_lengths_list[] = {
 
 #ifdef SIGALRM
 
+struct ctxt
+{
+  void **res;
+  int cnt;
+  int max;
+};
+
+_Unwind_Reason_Code bt (struct _Unwind_Context *c, void *x)
+{
+  struct ctxt *ct = x;
+  if (ct->cnt < ct->max)
+    ct->res[ct->cnt++] = (void*)_Unwind_GetIP(c);
+  return _URC_NO_REASON;
+}
+
 static void alarmed(int sig)
 {
+    void *res[20];
+    struct ctxt ct;
+    int i;
+    ct.res = res;
+    ct.cnt = 0;
+    ct.max = 20;
+    write(1,"alarmed\n", 8);
+    _Unwind_Backtrace(bt, &ct);
+    for (i = 0; i < ct.cnt; i++)
+    {
+       unsigned long p = (unsigned long) res[i];
+       char q[18];
+       int j = sizeof(q);
+       q[--j] = 10;
+       do {
+          q[--j] = (p & 15) < 10 ? '0' + (p & 15) : 'A' + (p & 15) - 10;
+          p >>= 4;
+       } while(p && j > 0);
+       write(1, q+j, sizeof(q)-j);
+    }
+    write(1,"finally\n", 8);
     signal(SIGALRM, alarmed);
     run = 0;
 }
```

The change in aesni_cbc_sha256_enc_shaext is trivial, but
the other one is not.  But it is almost 1:1 identical to #9624