### PR TITLE
Add some missing cfi frame info in x25519-x86_64.pl

### DIFF
--- a/crypto/ec/asm/x25519-x86_64.pl
+++ b/crypto/ec/asm/x25519-x86_64.pl
@@ -490,12 +490,14 @@ $code.=<<___;
 .type	x25519_fe64_eligible,\@abi-omnipotent
 .align	32
 x25519_fe64_eligible:
+.cfi_startproc
 	mov	OPENSSL_ia32cap_P+8(%rip),%ecx
 	xor	%eax,%eax
 	and	\$0x80100,%ecx
 	cmp	\$0x80100,%ecx
 	cmove	%ecx,%eax
 	ret
+.cfi_endproc
 .size	x25519_fe64_eligible,.-x25519_fe64_eligible
 
 .globl	x25519_fe64_mul
@@ -724,6 +726,7 @@ x25519_fe64_sqr:
 .align	32
 x25519_fe64_mul121666:
 .Lfe64_mul121666_body:
+.cfi_startproc
 	mov	\$121666,%edx
 	mulx	8*0(%rsi),$acc0,%rcx
 	mulx	8*1(%rsi),$acc1,%rax
@@ -752,6 +755,7 @@ x25519_fe64_mul121666:
 
 .Lfe64_mul121666_epilogue:
 	ret
+.cfi_endproc
 .size	x25519_fe64_mul121666,.-x25519_fe64_mul121666
 
 .globl	x25519_fe64_add
@@ -759,6 +763,7 @@ x25519_fe64_mul121666:
 .align	32
 x25519_fe64_add:
 .Lfe64_add_body:
+.cfi_startproc
 	mov	8*0(%rsi),$acc0
 	mov	8*1(%rsi),$acc1
 	mov	8*2(%rsi),$acc2
@@ -787,6 +792,7 @@ x25519_fe64_add:
 
 .Lfe64_add_epilogue:
 	ret
+.cfi_endproc
 .size	x25519_fe64_add,.-x25519_fe64_add
 
 .globl	x25519_fe64_sub
@@ -794,6 +800,7 @@ x25519_fe64_add:
 .align	32
 x25519_fe64_sub:
 .Lfe64_sub_body:
+.cfi_startproc
 	mov	8*0(%rsi),$acc0
 	mov	8*1(%rsi),$acc1
 	mov	8*2(%rsi),$acc2
@@ -822,6 +829,7 @@ x25519_fe64_sub:
 
 .Lfe64_sub_epilogue:
 	ret
+.cfi_endproc
 .size	x25519_fe64_sub,.-x25519_fe64_sub
 
 .globl	x25519_fe64_tobytes
@@ -829,6 +837,7 @@ x25519_fe64_sub:
 .align	32
 x25519_fe64_tobytes:
 .Lfe64_to_body:
+.cfi_startproc
 	mov	8*0(%rsi),$acc0
 	mov	8*1(%rsi),$acc1
 	mov	8*2(%rsi),$acc2
@@ -864,6 +873,7 @@ x25519_fe64_tobytes:
 
 .Lfe64_to_epilogue:
 	ret
+.cfi_endproc
 .size	x25519_fe64_tobytes,.-x25519_fe64_tobytes
 ___
 } else {
@@ -872,8 +882,10 @@ $code.=<<___;
 .type	x25519_fe64_eligible,\@abi-omnipotent
 .align	32
 x25519_fe64_eligible:
+.cfi_startproc
 	xor	%eax,%eax
 	ret
+.cfi_endproc
 .size	x25519_fe64_eligible,.-x25519_fe64_eligible
 
 .globl	x25519_fe64_mul
@@ -889,8 +901,10 @@ x25519_fe64_mul121666:
 x25519_fe64_add:
 x25519_fe64_sub:
 x25519_fe64_tobytes:
+.cfi_startproc
 	.byte	0x0f,0x0b	# ud2
 	ret
+.cfi_endproc
 .size	x25519_fe64_mul,.-x25519_fe64_mul
 ___
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
