### PR TITLE
Add some missing cfi frame info in poly1305-x86_64.pl

### DIFF
--- a/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -170,6 +170,7 @@ $code.=<<___;
 .type	poly1305_init,\@function,3
 .align	32
 poly1305_init:
+.cfi_startproc
 	xor	%rax,%rax
 	mov	%rax,0($ctx)		# initialize hash value
 	mov	%rax,8($ctx)
@@ -221,6 +222,7 @@ $code.=<<___;
 	mov	\$1,%eax
 .Lno_key:
 	ret
+.cfi_endproc
 .size	poly1305_init,.-poly1305_init
 
 .type	poly1305_blocks,\@function,4
@@ -300,6 +302,7 @@ $code.=<<___;
 .type	poly1305_emit,\@function,3
 .align	32
 poly1305_emit:
+.cfi_startproc
 .Lemit:
 	mov	0($ctx),%r8	# load hash value
 	mov	8($ctx),%r9
@@ -320,6 +323,7 @@ poly1305_emit:
 	mov	%rcx,8($mac)
 
 	ret
+.cfi_endproc
 .size	poly1305_emit,.-poly1305_emit
 ___
 if ($avx) {
@@ -344,15 +348,18 @@ $code.=<<___;
 .type	__poly1305_block,\@abi-omnipotent
 .align	32
 __poly1305_block:
+.cfi_startproc
 ___
 	&poly1305_iteration();
 $code.=<<___;
 	ret
+.cfi_endproc
 .size	__poly1305_block,.-__poly1305_block
 
 .type	__poly1305_init_avx,\@abi-omnipotent
 .align	32
 __poly1305_init_avx:
+.cfi_startproc
 	mov	$r0,$h0
 	mov	$r1,$h1
 	xor	$h2,$h2
@@ -510,6 +517,7 @@ __poly1305_init_avx:
 
 	lea	-48-64($ctx),$ctx	# size [de-]optimization
 	ret
+.cfi_endproc
 .size	__poly1305_init_avx,.-__poly1305_init_avx
 
 .type	poly1305_blocks_avx,\@function,4
@@ -1375,6 +1383,7 @@ $code.=<<___;
 .type	poly1305_emit_avx,\@function,3
 .align	32
 poly1305_emit_avx:
+.cfi_startproc
 	cmpl	\$0,20($ctx)	# is_base2_26?
 	je	.Lemit
 
@@ -1425,6 +1434,7 @@ poly1305_emit_avx:
 	mov	%rcx,8($mac)
 
 	ret
+.cfi_endproc
 .size	poly1305_emit_avx,.-poly1305_emit_avx
 ___
 
@@ -2743,6 +2753,7 @@ $code.=<<___;
 .type	poly1305_init_base2_44,\@function,3
 .align	32
 poly1305_init_base2_44:
+.cfi_startproc
 	xor	%rax,%rax
 	mov	%rax,0($ctx)		# initialize hash value
 	mov	%rax,8($ctx)
@@ -2784,6 +2795,7 @@ ___
 $code.=<<___;
 	mov	\$1,%eax
 	ret
+.cfi_endproc
 .size	poly1305_init_base2_44,.-poly1305_init_base2_44
 ___
 {
@@ -2795,6 +2807,7 @@ $code.=<<___;
 .type	poly1305_blocks_vpmadd52,\@function,4
 .align	32
 poly1305_blocks_vpmadd52:
+.cfi_startproc
 	shr	\$4,$len
 	jz	.Lno_data_vpmadd52		# too short
 
@@ -2901,6 +2914,7 @@ poly1305_blocks_vpmadd52:
 
 .Lno_data_vpmadd52:
 	ret
+.cfi_endproc
 .size	poly1305_blocks_vpmadd52,.-poly1305_blocks_vpmadd52
 ___
 }
@@ -2918,6 +2932,7 @@ $code.=<<___;
 .type	poly1305_blocks_vpmadd52_4x,\@function,4
 .align	32
 poly1305_blocks_vpmadd52_4x:
+.cfi_startproc
 	shr	\$4,$len
 	jz	.Lno_data_vpmadd52_4x		# too short
 
@@ -3342,6 +3357,7 @@ poly1305_blocks_vpmadd52_4x:
 
 .Lno_data_vpmadd52_4x:
 	ret
+.cfi_endproc
 .size	poly1305_blocks_vpmadd52_4x,.-poly1305_blocks_vpmadd52_4x
 ___
 }
@@ -3360,6 +3376,7 @@ $code.=<<___;
 .type	poly1305_blocks_vpmadd52_8x,\@function,4
 .align	32
 poly1305_blocks_vpmadd52_8x:
+.cfi_startproc
 	shr	\$4,$len
 	jz	.Lno_data_vpmadd52_8x		# too short
 
@@ -3715,6 +3732,7 @@ $code.=<<___;
 
 .Lno_data_vpmadd52_8x:
 	ret
+.cfi_endproc
 .size	poly1305_blocks_vpmadd52_8x,.-poly1305_blocks_vpmadd52_8x
 ___
 }
@@ -3722,6 +3740,7 @@ $code.=<<___;
 .type	poly1305_emit_base2_44,\@function,3
 .align	32
 poly1305_emit_base2_44:
+.cfi_startproc
 	mov	0($ctx),%r8	# load hash value
 	mov	8($ctx),%r9
 	mov	16($ctx),%r10
@@ -3752,6 +3771,7 @@ poly1305_emit_base2_44:
 	mov	%rcx,8($mac)
 
 	ret
+.cfi_endproc
 .size	poly1305_emit_base2_44,.-poly1305_emit_base2_44
 ___
 }	}	}
@@ -3802,6 +3822,7 @@ $code.=<<___;
 .type	xor128_encrypt_n_pad,\@abi-omnipotent
 .align	16
 xor128_encrypt_n_pad:
+.cfi_startproc
 	sub	$otp,$inp
 	sub	$otp,$out
 	mov	$len,%r10		# put len aside
@@ -3843,12 +3864,14 @@ xor128_encrypt_n_pad:
 .Ldone_enc:
 	mov	$otp,%rax
 	ret
+.cfi_endproc
 .size	xor128_encrypt_n_pad,.-xor128_encrypt_n_pad
 
 .globl	xor128_decrypt_n_pad
 .type	xor128_decrypt_n_pad,\@abi-omnipotent
 .align	16
 xor128_decrypt_n_pad:
+.cfi_startproc
 	sub	$otp,$inp
 	sub	$otp,$out
 	mov	$len,%r10		# put len aside
@@ -3894,6 +3917,7 @@ xor128_decrypt_n_pad:
 .Ldone_dec:
 	mov	$otp,%rax
 	ret
+.cfi_endproc
 .size	xor128_decrypt_n_pad,.-xor128_decrypt_n_pad
 ___
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
