### PR TITLE
Fix aes_platform.h missing issue

### DIFF
--- a/providers/implementations/ciphers/ciphercommon_gcm_hw.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm_hw.c
@@ -7,9 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * This file uses the low level AES functions (which are deprecated for
+ * non-internal use) in order to implement provider AES ciphers.
+ */
+#include "internal/deprecated.h"
 #include "prov/ciphercommon.h"
 #include "prov/ciphercommon_gcm.h"
-
+#include "crypto/aes_platform.h"
 
 int gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv, size_t ivlen)
 {


### PR DESCRIPTION
This came from commit "cc731bc3f". 'aes_platform.h' is supposed to replace
'ciphermode_platform.h'. Without aes_platform.h included, AES_GCM_ASM is
undefined so that hardware accelerated AES implementation won't be used.
Affects x86 and arm64.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
