### PR TITLE
Return correct code on operation not supported

### DIFF
--- a/crypto/ec/ecdsa_vrf.c
+++ b/crypto/ec/ecdsa_vrf.c
@@ -23,7 +23,7 @@ int ECDSA_do_verify(const unsigned char *dgst, int dgst_len,
     if (eckey->meth->verify_sig != NULL)
         return eckey->meth->verify_sig(dgst, dgst_len, sig, eckey);
     ECerr(EC_F_ECDSA_DO_VERIFY, EC_R_OPERATION_NOT_SUPPORTED);
-    return 0;
+    return -1;
 }
 
 /*-
@@ -39,5 +39,5 @@ int ECDSA_verify(int type, const unsigned char *dgst, int dgst_len,
         return eckey->meth->verify(type, dgst, dgst_len, sigbuf, sig_len,
                                    eckey);
     ECerr(EC_F_ECDSA_VERIFY, EC_R_OPERATION_NOT_SUPPORTED);
-    return 0;
+    return -1;
 }


### PR DESCRIPTION
Fixes #8766 by returning -1 when an eckey does not have a verify_sig function as the function signature specifies -1.