### PR TITLE
Add `-passin` arg to `ocsp`

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -140,6 +140,7 @@ typedef enum OPTION_choice {
     OPT_RESPOUT, OPT_PATH, OPT_ISSUER, OPT_CERT, OPT_SERIAL,
     OPT_INDEX, OPT_CA, OPT_NMIN, OPT_REQUEST, OPT_NDAYS, OPT_RSIGNER,
     OPT_RKEY, OPT_ROTHER, OPT_RMD, OPT_RSIGOPT, OPT_HEADER,
+    OPT_PASSIN,
     OPT_RCID,
     OPT_V_ENUM,
     OPT_MD,
@@ -186,6 +187,7 @@ const OPTIONS ocsp_options[] = {
     {"rsigner", OPT_RSIGNER, '<',
      "Responder certificate to sign responses with"},
     {"rkey", OPT_RKEY, '<', "Responder key to sign responses with"},
+    {"passin", OPT_PASSIN, 's', "Responder key pass phrase source"},
     {"rother", OPT_ROTHER, '<', "Other certificates to include in response"},
     {"rmd", OPT_RMD, 's', "Digest Algorithm to use in signature of OCSP response"},
     {"rsigopt", OPT_RSIGOPT, 's', "OCSP response signature parameter in n:v form"},
@@ -266,6 +268,7 @@ int ocsp_main(int argc, char **argv)
     char *rca_filename = NULL, *reqin = NULL, *respin = NULL;
     char *reqout = NULL, *respout = NULL, *ridx_filename = NULL;
     char *rsignfile = NULL, *rkeyfile = NULL;
+    char *passinarg = NULL, *passin = NULL;
     char *sign_certfile = NULL, *verify_certfile = NULL, *rcertfile = NULL;
     char *signfile = NULL, *keyfile = NULL;
     char *thost = NULL, *tport = NULL, *tpath = NULL;
@@ -495,6 +498,9 @@ int ocsp_main(int argc, char **argv)
         case OPT_RKEY:
             rkeyfile = opt_arg();
             break;
+        case OPT_PASSIN:
+            passinarg = opt_arg();
+            break;
         case OPT_ROTHER:
             rcertfile = opt_arg();
             break;
@@ -597,7 +603,11 @@ int ocsp_main(int argc, char **argv)
                             "responder other certificates"))
                 goto end;
         }
-        rkey = load_key(rkeyfile, FORMAT_PEM, 0, NULL, NULL,
+        if (!app_passwd(passinarg, NULL, &passin, NULL)) {
+            BIO_printf(bio_err, "Error getting password\n");
+            goto end;
+        }
+        rkey = load_key(rkeyfile, FORMAT_PEM, 0, passin, NULL,
                         "responder private key");
         if (rkey == NULL)
             goto end;

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -77,6 +77,7 @@ B<openssl> B<ocsp>
 [B<-CA> I<file>]
 [B<-rsigner> I<file>]
 [B<-rkey> I<file>]
+[B<-passin> I<arg>]
 [B<-rother> I<file>]
 [B<-rsigopt> I<nm>:I<v>]
 [B<-resp_no_certs>]
@@ -352,6 +353,11 @@ subject name.
 
 The private key to sign OCSP responses with: if not present the file
 specified in the B<-rsigner> option is used.
+
+=item B<-passin> I<arg>
+
+The private key password source. For more information about the format of I<arg>
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-rsigopt> I<nm>:I<v>
 


### PR DESCRIPTION
Add support for `-passin` to `ocsp` so the ocsp responder can be started programmatically.

Docs are updated, but no testing was added since after a quick look at the tests, it didn't seem like command-line switches were explicitly tested. Happy to add a test if necessary.

I did test it manually.

Fixes #10682 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated