### PR TITLE
backport to v1.1.0: fix a glitch in the documentation of OCSP_sendreq_bio()

### DIFF
--- a/doc/crypto/OCSP_sendreq_new.pod
+++ b/doc/crypto/OCSP_sendreq_new.pod
@@ -24,8 +24,7 @@ OCSP_REQ_CTX_set1_req, OCSP_sendreq_bio - OCSP responder query functions
 
  int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, OCSP_REQUEST *req);
 
- OCSP_RESPONSE *OCSP_sendreq_bio(BIO *io, const char *path, OCSP_REQUEST *req,
-                                 int maxline);
+ OCSP_RESPONSE *OCSP_sendreq_bio(BIO *io, const char *path, OCSP_REQUEST *req);
 
 =head1 DESCRIPTION
 
@@ -54,8 +53,8 @@ OCSP_REQ_CTX_set1_req() sets the OCSP request in B<rctx> to B<req>. This
 function should be called after any calls to OCSP_REQ_CTX_add1_header().
 
 OCSP_sendreq_bio() performs an OCSP request using the responder B<io>, the URL
-path B<path>, the OCSP request B<req> and with a response header maximum line
-length of B<maxline>. If B<maxline> is zero a default value of 4k is used.
+path B<path>, and the OCSP request B<req> with a response header maximum line
+length 4k. It waits indefinitely on a response.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
Backport of doc fix for `OCSP_sendreq_bio()`, as requested by @FdaSilvaYY in https://github.com/openssl/openssl/pull/10667#discussion_r361557697

- [x] documentation is added or updated

