### PR TITLE
nmake: fix install_html_docs target

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -588,8 +588,8 @@ reconfigure reconf:
 	  return <<"EOF";
 $args{src}: $args{generator}->[0]
 	pod2html "--podroot=\$(SRCDIR)/doc" --htmldir=.. \\
-		 --podpath=man1:man3:man5:man7 "--infile=\$<" "--title=$title" \\
-	| \$(PERL) -pe "s|href=\\"http://man\\.he\\.net/(man\d/[^\\"]+)(?:\\.html)?\\"|href=\\"../\$1.html|g;" \\
+		 --podpath=man1:man3:man5:man7 "--infile=\$?" "--title=$title" \\
+	| \$(PERL) -pe ^"s^|href=\\^"http://man\\.he\\.net/^(man\\d/[^^\\^"]+^)^(?:\.html^)?^"^|href=\\^"../\$\$1.html^|g;^" \\
 	> \$\@
 EOF
       } elsif (platform->isdef($args{src})) {


### PR DESCRIPTION
The $< target[1] does not work for regular rules and is expanded to an empty string after issuing the warning

    NMAKE : warning U4006: special macro undefined : '$<"'

This leads to the following error message by pod2html:

    'href' is not recognized as an internal or external command,
    operable program or batch file.

[1] https://docs.microsoft.com/en-us/cpp/build/reference/filename-macros


_Edit: an updated description of the error can be found [further down](https://github.com/openssl/openssl/pull/10719#issuecomment-569456069)._

Fixes #10648
Fixes #10749

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
