### PR TITLE
appveyor.yml: speed up the extended test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,6 @@ test_script:
     - ps: >-
         if ($env:EXTENDED_TESTS) {
             mkdir ..\_install
-            cmd /c "nmake install DESTDIR=..\_install 2>&1"
+            cmd /c "nmake install_sw install_ssldirs DESTDIR=..\_install 2>&1"
         }
     - cd ..


### PR DESCRIPTION
OpenSSL is installed to a temporary folder when the extended tests
are enabled. We omit the documentation to save some time.

[extended tests]
