### PR TITLE
Deprecate the Low Level Blowfish APIs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,15 @@
 
  Changes between 1.1.1 and 3.0.0 [xx XXX xxxx]
 
+  *) All of the low level Blowfish functions have been deprecated including:
+     BF_set_key, BF_encrypt, BF_decrypt, BF_ecb_encrypt, BF_cbc_encrypt,
+     BF_cfb64_encrypt, BF_ofb64_encrypt, and BF_options.
+     Use of these low level functions has been informally discouraged for a long
+     time. Instead applications should use the high level EVP APIs, e.g.
+     EVP_EncryptInit_ex, EVP_EncryptUpdate, EVP_EncryptFinal_ex, and the
+     equivalently named decrypt functions.
+     [Matt Caswell]
+
   *) Removed include/openssl/opensslconf.h.in and replaced it with
      include/openssl/configuration.h.in, which differs in not including
      <openssl/macros.h>.  A short header include/openssl/opensslconf.h

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -384,7 +384,7 @@ static const OPT_PAIR doit_choices[] = {
     {"seed-cbc", D_CBC_SEED},
     {"seed", D_CBC_SEED},
 #endif
-#ifndef OPENSSL_NO_BF
+#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"bf-cbc", D_CBC_BF},
     {"blowfish", D_CBC_BF},
     {"bf", D_CBC_BF},
@@ -1461,7 +1461,7 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_SEED
     SEED_KEY_SCHEDULE seed_ks;
 #endif
-#ifndef OPENSSL_NO_BF
+#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     BF_KEY bf_ks;
 #endif
 #ifndef OPENSSL_NO_CAST
@@ -1986,7 +1986,7 @@ int speed_main(int argc, char **argv)
             goto end;
         }
 #endif
-#ifndef OPENSSL_NO_BF
+#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_BF])
         BF_set_key(&bf_ks, 16, key16);
 #endif
@@ -2650,7 +2650,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_BF
+#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_BF]) {
         if (async_jobs > 0) {
             BIO_printf(bio_err, "Async mode is not supported with %s\n",
@@ -3502,7 +3502,7 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_IDEA
         printf("%s ", IDEA_options());
 #endif
-#ifndef OPENSSL_NO_BF
+#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         printf("%s ", BF_options());
 #endif
         printf("\n%s\n", OpenSSL_version(OPENSSL_CFLAGS));

--- a/apps/version.c
+++ b/apps/version.c
@@ -141,9 +141,6 @@ opthelp:
 #ifndef OPENSSL_NO_IDEA
         printf(" %s", IDEA_options());
 #endif
-#ifndef OPENSSL_NO_BF
-        printf(" %s", BF_options());
-#endif
         printf("\n");
     }
     if (cflags)

--- a/crypto/bf/bf_cfb64.c
+++ b/crypto/bf/bf_cfb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/blowfish.h>
 #include "bf_local.h"
 

--- a/crypto/bf/bf_ecb.c
+++ b/crypto/bf/bf_ecb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/blowfish.h>
 #include "bf_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/bf/bf_enc.c
+++ b/crypto/bf/bf_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/blowfish.h>
 #include "bf_local.h"
 

--- a/crypto/bf/bf_ofb64.c
+++ b/crypto/bf/bf_ofb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/blowfish.h>
 #include "bf_local.h"
 

--- a/crypto/bf/bf_skey.c
+++ b/crypto/bf/bf_skey.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/blowfish.h>

--- a/crypto/evp/e_bf.c
+++ b/crypto/evp/e_bf.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_BF

--- a/doc/man3/BF_encrypt.pod
+++ b/doc/man3/BF_encrypt.pod
@@ -9,6 +9,10 @@ BF_cfb64_encrypt, BF_ofb64_encrypt, BF_options - Blowfish encryption
 
  #include <openssl/blowfish.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  void BF_set_key(BF_KEY *key, int len, const unsigned char *data);
 
  void BF_ecb_encrypt(const unsigned char *in, unsigned char *out,
@@ -28,6 +32,10 @@ BF_cfb64_encrypt, BF_ofb64_encrypt, BF_options - Blowfish encryption
  void BF_decrypt(BF_LONG *data, const BF_KEY *key);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. Applications should
+instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate(3)> and
+L<EVP_EncryptFinal_ex(3)> or the equivalently named decrypt functions.
 
 This library implements the Blowfish cipher, which was invented and described
 by Counterpane (see http://www.counterpane.com/blowfish.html ).
@@ -106,6 +114,10 @@ functions directly.
 
 L<EVP_EncryptInit(3)>,
 L<des_modes(7)>
+
+=head1 HISTORY
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/blowfish.h
+++ b/include/openssl/blowfish.h
@@ -24,40 +24,51 @@
 extern "C" {
 # endif
 
-# define BF_ENCRYPT      1
-# define BF_DECRYPT      0
+# define BF_BLOCK        8
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+
+#  define BF_ENCRYPT      1
+#  define BF_DECRYPT      0
 
 /*-
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! BF_LONG has to be at least 32 bits wide.                     !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-# define BF_LONG unsigned int
+#  define BF_LONG unsigned int
 
-# define BF_ROUNDS       16
-# define BF_BLOCK        8
+#  define BF_ROUNDS       16
 
 typedef struct bf_key_st {
     BF_LONG P[BF_ROUNDS + 2];
     BF_LONG S[4 * 256];
 } BF_KEY;
 
-void BF_set_key(BF_KEY *key, int len, const unsigned char *data);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
-void BF_encrypt(BF_LONG *data, const BF_KEY *key);
-void BF_decrypt(BF_LONG *data, const BF_KEY *key);
+DEPRECATEDIN_3_0(void BF_set_key(BF_KEY *key, int len,
+                                 const unsigned char *data))
 
-void BF_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                    const BF_KEY *key, int enc);
-void BF_cbc_encrypt(const unsigned char *in, unsigned char *out, long length,
-                    const BF_KEY *schedule, unsigned char *ivec, int enc);
-void BF_cfb64_encrypt(const unsigned char *in, unsigned char *out,
-                      long length, const BF_KEY *schedule,
-                      unsigned char *ivec, int *num, int enc);
-void BF_ofb64_encrypt(const unsigned char *in, unsigned char *out,
-                      long length, const BF_KEY *schedule,
-                      unsigned char *ivec, int *num);
-const char *BF_options(void);
+DEPRECATEDIN_3_0(void BF_encrypt(BF_LONG *data, const BF_KEY *key))
+DEPRECATEDIN_3_0(void BF_decrypt(BF_LONG *data, const BF_KEY *key))
+
+DEPRECATEDIN_3_0(void BF_ecb_encrypt(const unsigned char *in,
+                                     unsigned char *out, const BF_KEY *key,
+                                     int enc))
+DEPRECATEDIN_3_0(void BF_cbc_encrypt(const unsigned char *in,
+                                     unsigned char *out, long length,
+                                     const BF_KEY *schedule,
+                                     unsigned char *ivec, int enc))
+DEPRECATEDIN_3_0(void BF_cfb64_encrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       long length, const BF_KEY *schedule,
+                                       unsigned char *ivec, int *num, int enc))
+DEPRECATEDIN_3_0(void BF_ofb64_encrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       long length, const BF_KEY *schedule,
+                                       unsigned char *ivec, int *num))
+DEPRECATEDIN_3_0(const char *BF_options(void))
 
 # ifdef  __cplusplus
 }

--- a/providers/implementations/ciphers/cipher_blowfish.c
+++ b/providers/implementations/ciphers/cipher_blowfish.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for Blowfish cipher modes ecb, cbc, ofb, cfb */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_blowfish.h"
 #include "prov/implementations.h"
 

--- a/providers/implementations/ciphers/cipher_blowfish_hw.c
+++ b/providers/implementations/ciphers/cipher_blowfish_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_blowfish.h"
 
 static int cipher_hw_blowfish_initkey(PROV_CIPHER_CTX *ctx,

--- a/test/bftest.c
+++ b/test/bftest.c
@@ -8,9 +8,10 @@
  */
 
 /*
- * This has been a quickly hacked 'ideatest.c'.  When I add tests for other
- * RC2 modes, more of the code will be uncommented.
+ * BF low level APIs are deprecated for public use, but still ok for internal
+ * use.
  */
+#include "internal/deprecated.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/test/build.info
+++ b/test/build.info
@@ -38,7 +38,7 @@ IF[{- !$disabled{tests} -}]
           rc2test rc4test rc5test \
           destest mdc2test \
           dhtest enginetest casttest \
-          bftest ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
+          ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
           evp_pkey_provided_test evp_test evp_extra_test evp_fetch_prov_test \
           v3nametest v3ext \
           crltest danetest bad_dtls_test lhash_test sparse_array_test \
@@ -156,10 +156,6 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[casttest]=../include ../apps/include
   DEPEND[casttest]=../libcrypto libtestutil.a
 
-  SOURCE[bftest]=bftest.c
-  INCLUDE[bftest]=../include ../apps/include
-  DEPEND[bftest]=../libcrypto libtestutil.a
-
   SOURCE[ssltest_old]=ssltest_old.c
   INCLUDE[ssltest_old]=.. ../include ../apps/include
   DEPEND[ssltest_old]=../libcrypto ../libssl
@@ -216,10 +212,14 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{"deprecated"}
         || (defined $config{"api"} && $config{"api"} < 30000) -}]
-    PROGRAMS{noinst}=igetest
+    PROGRAMS{noinst}=igetest bftest
     SOURCE[igetest]=igetest.c
     INCLUDE[igetest]=../include ../apps/include
     DEPEND[igetest]=../libcrypto libtestutil.a
+
+    SOURCE[bftest]=bftest.c
+    INCLUDE[bftest]=../include ../apps/include
+    DEPEND[bftest]=../libcrypto libtestutil.a
   ENDIF
 
   SOURCE[v3nametest]=v3nametest.c

--- a/test/recipes/05-test_bf.t
+++ b/test/recipes/05-test_bf.t
@@ -6,7 +6,17 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+use strict;
+use warnings;
 
 use OpenSSL::Test::Simple;
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_bf");
+
+plan skip_all => "Low-level Blowfish APIs are disabled in this build"
+    if disabled("deprecated")
+       && (!defined config("api") || config("api") >= 30000);
 
 simple_test("test_bf", "bftest", "bf");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -34,7 +34,7 @@ EVP_PBE_alg_add_type                    34	3_0_0	EXIST::FUNCTION:
 EVP_cast5_ofb                           35	3_0_0	EXIST::FUNCTION:CAST
 d2i_PUBKEY_fp                           36	3_0_0	EXIST::FUNCTION:STDIO
 PKCS7_set_cipher                        37	3_0_0	EXIST::FUNCTION:
-BF_decrypt                              38	3_0_0	EXIST::FUNCTION:BF
+BF_decrypt                              38	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 PEM_read_bio_PUBKEY                     39	3_0_0	EXIST::FUNCTION:
 X509_NAME_delete_entry                  40	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_verify_recover        41	3_0_0	EXIST::FUNCTION:
@@ -97,7 +97,7 @@ SCT_set0_extensions                     98	3_0_0	EXIST::FUNCTION:CT
 PKCS5_pbe2_set_scrypt                   99	3_0_0	EXIST::FUNCTION:SCRYPT
 X509_find_by_subject                    100	3_0_0	EXIST::FUNCTION:
 DSAparams_print                         101	3_0_0	EXIST::FUNCTION:DSA
-BF_set_key                              102	3_0_0	EXIST::FUNCTION:BF
+BF_set_key                              102	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 d2i_DHparams                            103	3_0_0	EXIST::FUNCTION:DH
 i2d_PKCS7_ENC_CONTENT                   104	3_0_0	EXIST::FUNCTION:
 DH_generate_key                         105	3_0_0	EXIST::FUNCTION:DH
@@ -446,7 +446,7 @@ BIO_sock_should_retry                   454	3_0_0	EXIST::FUNCTION:SOCK
 ENGINE_get_digests                      455	3_0_0	EXIST::FUNCTION:ENGINE
 TS_MSG_IMPRINT_get_algo                 456	3_0_0	EXIST::FUNCTION:TS
 DH_new_method                           457	3_0_0	EXIST::FUNCTION:DH
-BF_ecb_encrypt                          458	3_0_0	EXIST::FUNCTION:BF
+BF_ecb_encrypt                          458	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 PEM_write_bio_DHparams                  459	3_0_0	EXIST::FUNCTION:DH
 EVP_DigestFinal                         460	3_0_0	EXIST::FUNCTION:
 CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE 461	3_0_0	EXIST::FUNCTION:CT
@@ -839,7 +839,7 @@ ECDSA_sign_ex                           859	3_0_0	EXIST::FUNCTION:EC
 TXT_DB_insert                           860	3_0_0	EXIST::FUNCTION:
 EC_POINTs_make_affine                   861	3_0_0	EXIST::FUNCTION:EC
 RSA_padding_add_PKCS1_PSS               862	3_0_0	EXIST::FUNCTION:RSA
-BF_options                              863	3_0_0	EXIST::FUNCTION:BF
+BF_options                              863	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 OCSP_BASICRESP_it                       864	3_0_0	EXIST::FUNCTION:OCSP
 X509_VERIFY_PARAM_get0_name             865	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_set_signer_digest           866	3_0_0	EXIST::FUNCTION:TS
@@ -1677,7 +1677,7 @@ RC5_32_set_key                          1715	3_0_0	EXIST::FUNCTION:RC5
 AES_unwrap_key                          1716	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_Cipher                              1717	3_0_0	EXIST::FUNCTION:
 AES_set_decrypt_key                     1718	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-BF_ofb64_encrypt                        1719	3_0_0	EXIST::FUNCTION:BF
+BF_ofb64_encrypt                        1719	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 d2i_TS_TST_INFO_fp                      1720	3_0_0	EXIST::FUNCTION:STDIO,TS
 X509_find_by_issuer_and_serial          1721	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_type                           1722	3_0_0	EXIST::FUNCTION:
@@ -2230,7 +2230,7 @@ TS_STATUS_INFO_get0_text                2277	3_0_0	EXIST::FUNCTION:TS
 CRYPTO_get_ex_new_index                 2278	3_0_0	EXIST::FUNCTION:
 ASN1_PCTX_set_flags                     2279	3_0_0	EXIST::FUNCTION:
 PEM_write_X509_CRL                      2280	3_0_0	EXIST::FUNCTION:STDIO
-BF_cbc_encrypt                          2281	3_0_0	EXIST::FUNCTION:BF
+BF_cbc_encrypt                          2281	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 BN_num_bits_word                        2282	3_0_0	EXIST::FUNCTION:
 EVP_DecodeInit                          2283	3_0_0	EXIST::FUNCTION:
 BN_ucmp                                 2284	3_0_0	EXIST::FUNCTION:
@@ -3002,7 +3002,7 @@ d2i_TS_RESP                             3066	3_0_0	EXIST::FUNCTION:TS
 EVP_des_ede_cfb64                       3067	3_0_0	EXIST::FUNCTION:DES
 d2i_RSAPrivateKey                       3068	3_0_0	EXIST::FUNCTION:RSA
 ERR_load_BN_strings                     3069	3_0_0	EXIST::FUNCTION:
-BF_encrypt                              3070	3_0_0	EXIST::FUNCTION:BF
+BF_encrypt                              3070	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 MD5                                     3071	3_0_0	EXIST::FUNCTION:MD5
 BN_GF2m_arr2poly                        3072	3_0_0	EXIST::FUNCTION:EC2M
 EVP_PKEY_meth_get_ctrl                  3073	3_0_0	EXIST::FUNCTION:
@@ -3079,7 +3079,7 @@ OPENSSL_LH_stats                        3143	3_0_0	EXIST::FUNCTION:STDIO
 NCONF_dump_fp                           3144	3_0_0	EXIST::FUNCTION:STDIO
 TS_STATUS_INFO_print_bio                3145	3_0_0	EXIST::FUNCTION:TS
 OPENSSL_sk_dup                          3146	3_0_0	EXIST::FUNCTION:
-BF_cfb64_encrypt                        3147	3_0_0	EXIST::FUNCTION:BF
+BF_cfb64_encrypt                        3147	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 ASN1_GENERALIZEDTIME_adj                3148	3_0_0	EXIST::FUNCTION:
 ECDSA_verify                            3149	3_0_0	EXIST::FUNCTION:EC
 EVP_camellia_256_cfb128                 3150	3_0_0	EXIST::FUNCTION:CAMELLIA


### PR DESCRIPTION
Applications should instead use the higher level EVP APIs, e.g.
EVP_Encrypt*() and EVP_Decrypt*().

This is marked as WIP because it builds on the commits from #10580. Once that is merged I will rebase this and take it out of WIP.

Please only look at the last commit.