### PR TITLE
Deprecate the Low Level Camellia APIs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,16 @@
      equivalently named decrypt functions.
      [Matt Caswell]
 
+  *) All of the low level Camelllia functions have been deprecated including:
+     Camellia_set_key, Camellia_encrypt, Camellia_decrypt, Camellia_ecb_encrypt,
+     Camellia_cbc_encrypt, Camellia_cfb128_encrypt, Camellia_cfb1_encrypt,
+     Camellia_cfb8_encrypt, Camellia_ofb128_encrypt and Camellia_ctr128_encrypt.
+     Use of these low level functions has been informally discouraged for a long
+     time. Instead applications should use the high level EVP APIs, e.g.
+     EVP_EncryptInit_ex, EVP_EncryptUpdate, EVP_EncryptFinal_ex, and the
+     equivalently named decrypt functions.
+     [Matt Caswell]
+
   *) Removed include/openssl/opensslconf.h.in and replaced it with
      include/openssl/configuration.h.in, which differs in not including
      <openssl/macros.h>.  A short header include/openssl/opensslconf.h

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1471,6 +1471,7 @@ int speed_main(int argc, char **argv)
         0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
         0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12
     };
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     static const unsigned char key24[24] = {
         0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
         0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12,
@@ -1482,7 +1483,8 @@ int speed_main(int argc, char **argv)
         0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34,
         0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56
     };
-#ifndef OPENSSL_NO_CAMELLIA
+#endif
+#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     CAMELLIA_KEY camellia_ks[3];
 #endif
 #ifndef OPENSSL_NO_RSA
@@ -1758,7 +1760,7 @@ int speed_main(int argc, char **argv)
             continue;
         }
 #endif
-#ifndef OPENSSL_NO_CAMELLIA
+#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (strcmp(algo, "camellia") == 0) {
             doit[D_CBC_128_CML] = doit[D_CBC_192_CML] = doit[D_CBC_256_CML] = 1;
             continue;
@@ -1956,7 +1958,7 @@ int speed_main(int argc, char **argv)
     AES_set_encrypt_key(key24, 192, &aes_ks2);
     AES_set_encrypt_key(key32, 256, &aes_ks3);
 #endif
-#ifndef OPENSSL_NO_CAMELLIA
+#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_128_CML] || doit[D_CBC_192_CML] || doit[D_CBC_256_CML]) {
         Camellia_set_key(key16, 128, &camellia_ks[0]);
         Camellia_set_key(key24, 192, &camellia_ks[1]);
@@ -2503,7 +2505,7 @@ int speed_main(int argc, char **argv)
             CRYPTO_gcm128_release(loopargs[i].gcm_ctx);
     }
 #endif /* OPENSSL_NO_DEPRECATED_3_0 */
-#ifndef OPENSSL_NO_CAMELLIA
+#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_128_CML]) {
         if (async_jobs > 0) {
             BIO_printf(bio_err, "Async mode is not supported with %s\n",

--- a/crypto/camellia/camellia.c
+++ b/crypto/camellia/camellia.c
@@ -39,6 +39,12 @@
  * words reasonable performance even with not so modern compilers.
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/camellia.h>
 #include "cmll_local.h"
 #include <string.h>

--- a/crypto/camellia/cmll_cbc.c
+++ b/crypto/camellia/cmll_cbc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 

--- a/crypto/camellia/cmll_cfb.c
+++ b/crypto/camellia/cmll_cfb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 

--- a/crypto/camellia/cmll_ctr.c
+++ b/crypto/camellia/cmll_ctr.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 

--- a/crypto/camellia/cmll_ecb.c
+++ b/crypto/camellia/cmll_ecb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/camellia.h>
 #include "cmll_local.h"
 

--- a/crypto/camellia/cmll_misc.c
+++ b/crypto/camellia/cmll_misc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/opensslv.h>
 #include <openssl/camellia.h>
 #include "cmll_local.h"

--- a/crypto/camellia/cmll_ofb.c
+++ b/crypto/camellia/cmll_ofb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/opensslconf.h>
 #ifdef OPENSSL_NO_CAMELLIA
 NON_EMPTY_TRANSLATION_UNIT

--- a/include/openssl/camellia.h
+++ b/include/openssl/camellia.h
@@ -24,8 +24,12 @@
 extern "C" {
 #endif
 
-# define CAMELLIA_ENCRYPT        1
-# define CAMELLIA_DECRYPT        0
+# define CAMELLIA_BLOCK_SIZE 16
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+
+#  define CAMELLIA_ENCRYPT        1
+#  define CAMELLIA_DECRYPT        0
 
 /*
  * Because array size can't be a const in C, the following two are macros.
@@ -34,9 +38,8 @@ extern "C" {
 
 /* This should be a hidden type, but EVP requires that the size be known */
 
-# define CAMELLIA_BLOCK_SIZE 16
-# define CAMELLIA_TABLE_BYTE_LEN 272
-# define CAMELLIA_TABLE_WORD_LEN (CAMELLIA_TABLE_BYTE_LEN / 4)
+#  define CAMELLIA_TABLE_BYTE_LEN 272
+#  define CAMELLIA_TABLE_WORD_LEN (CAMELLIA_TABLE_BYTE_LEN / 4)
 
 typedef unsigned int KEY_TABLE_TYPE[CAMELLIA_TABLE_WORD_LEN]; /* to match
                                                                * with WORD */
@@ -50,36 +53,62 @@ struct camellia_key_st {
 };
 typedef struct camellia_key_st CAMELLIA_KEY;
 
-int Camellia_set_key(const unsigned char *userKey, const int bits,
-                     CAMELLIA_KEY *key);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
-void Camellia_encrypt(const unsigned char *in, unsigned char *out,
-                      const CAMELLIA_KEY *key);
-void Camellia_decrypt(const unsigned char *in, unsigned char *out,
-                      const CAMELLIA_KEY *key);
+DEPRECATEDIN_3_0(int Camellia_set_key(const unsigned char *userKey,
+                                      const int bits,
+                                      CAMELLIA_KEY *key))
 
-void Camellia_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                          const CAMELLIA_KEY *key, const int enc);
-void Camellia_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                          size_t length, const CAMELLIA_KEY *key,
-                          unsigned char *ivec, const int enc);
-void Camellia_cfb128_encrypt(const unsigned char *in, unsigned char *out,
-                             size_t length, const CAMELLIA_KEY *key,
-                             unsigned char *ivec, int *num, const int enc);
-void Camellia_cfb1_encrypt(const unsigned char *in, unsigned char *out,
-                           size_t length, const CAMELLIA_KEY *key,
-                           unsigned char *ivec, int *num, const int enc);
-void Camellia_cfb8_encrypt(const unsigned char *in, unsigned char *out,
-                           size_t length, const CAMELLIA_KEY *key,
-                           unsigned char *ivec, int *num, const int enc);
-void Camellia_ofb128_encrypt(const unsigned char *in, unsigned char *out,
-                             size_t length, const CAMELLIA_KEY *key,
-                             unsigned char *ivec, int *num);
-void Camellia_ctr128_encrypt(const unsigned char *in, unsigned char *out,
-                             size_t length, const CAMELLIA_KEY *key,
-                             unsigned char ivec[CAMELLIA_BLOCK_SIZE],
-                             unsigned char ecount_buf[CAMELLIA_BLOCK_SIZE],
-                             unsigned int *num);
+DEPRECATEDIN_3_0(void Camellia_encrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       const CAMELLIA_KEY *key))
+DEPRECATEDIN_3_0(void Camellia_decrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       const CAMELLIA_KEY *key))
+
+DEPRECATEDIN_3_0(void Camellia_ecb_encrypt(const unsigned char *in,
+                                           unsigned char *out,
+                                           const CAMELLIA_KEY *key,
+                                           const int enc))
+DEPRECATEDIN_3_0(void Camellia_cbc_encrypt(const unsigned char *in,
+                                           unsigned char *out,
+                                           size_t length, const
+                                           CAMELLIA_KEY *key,
+                                           unsigned char *ivec, const int enc))
+DEPRECATEDIN_3_0(void Camellia_cfb128_encrypt(const unsigned char *in,
+                                              unsigned char *out,
+                                              size_t length,
+                                              const CAMELLIA_KEY *key,
+                                              unsigned char *ivec,
+                                              int *num,
+                                              const int enc))
+DEPRECATEDIN_3_0(void Camellia_cfb1_encrypt(const unsigned char *in,
+                                            unsigned char *out,
+                                            size_t length,
+                                            const CAMELLIA_KEY *key,
+                                            unsigned char *ivec,
+                                            int *num,
+                                            const int enc))
+DEPRECATEDIN_3_0(void Camellia_cfb8_encrypt(const unsigned char *in,
+                                            unsigned char *out,
+                                            size_t length,
+                                            const CAMELLIA_KEY *key,
+                                            unsigned char *ivec,
+                                            int *num,
+                                            const int enc))
+DEPRECATEDIN_3_0(void Camellia_ofb128_encrypt(const unsigned char *in,
+                                              unsigned char *out,
+                                              size_t length,
+                                              const CAMELLIA_KEY *key,
+                                              unsigned char *ivec,
+                                              int *num))
+DEPRECATEDIN_3_0(void Camellia_ctr128_encrypt(const unsigned char *in,
+                                              unsigned char *out,
+                                              size_t length,
+                                              const CAMELLIA_KEY *key,
+                                              unsigned char ivec[CAMELLIA_BLOCK_SIZE],
+                                              unsigned char ecount_buf[CAMELLIA_BLOCK_SIZE],
+                                              unsigned int *num))
 
 # ifdef  __cplusplus
 }

--- a/providers/implementations/ciphers/cipher_camellia.c
+++ b/providers/implementations/ciphers/cipher_camellia.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 /* Dispatch functions for CAMELLIA cipher modes ecb, cbc, ofb, cfb, ctr */
 
 #include "cipher_camellia.h"

--- a/providers/implementations/ciphers/cipher_camellia_hw.c
+++ b/providers/implementations/ciphers/cipher_camellia_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Camellia low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_camellia.h"
 #include <openssl/camellia.h>
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -17,7 +17,7 @@ PKCS12_it                               16	3_0_0	EXIST::FUNCTION:
 i2d_ASN1_OCTET_STRING                   17	3_0_0	EXIST::FUNCTION:
 EC_KEY_set_private_key                  18	3_0_0	EXIST::FUNCTION:EC
 SRP_VBASE_get_by_user                   19	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SRP
-Camellia_cfb128_encrypt                 21	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_cfb128_encrypt                 21	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 DES_ncbc_encrypt                        22	3_0_0	EXIST::FUNCTION:DES
 TS_REQ_get_ext_count                    23	3_0_0	EXIST::FUNCTION:TS
 EVP_aes_128_ocb                         24	3_0_0	EXIST::FUNCTION:OCB
@@ -1305,7 +1305,7 @@ i2d_ASN1_OBJECT                         1333	3_0_0	EXIST::FUNCTION:
 d2i_PKCS8_PRIV_KEY_INFO_bio             1334	3_0_0	EXIST::FUNCTION:
 X509V3_add_value_int                    1335	3_0_0	EXIST::FUNCTION:
 TS_REQ_set_nonce                        1336	3_0_0	EXIST::FUNCTION:TS
-Camellia_ctr128_encrypt                 1337	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_ctr128_encrypt                 1337	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 X509_LOOKUP_new                         1338	3_0_0	EXIST::FUNCTION:
 AUTHORITY_INFO_ACCESS_new               1339	3_0_0	EXIST::FUNCTION:
 CRYPTO_mem_leaks_fp                     1340	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0,STDIO
@@ -1883,7 +1883,7 @@ EVP_camellia_128_ofb                    1928	3_0_0	EXIST::FUNCTION:CAMELLIA
 PEM_write_X509_AUX                      1929	3_0_0	EXIST::FUNCTION:STDIO
 X509_LOOKUP_by_subject                  1930	3_0_0	EXIST::FUNCTION:
 X509_REQ_add_extensions                 1931	3_0_0	EXIST::FUNCTION:
-Camellia_cbc_encrypt                    1932	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_cbc_encrypt                    1932	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 EC_KEY_METHOD_new                       1933	3_0_0	EXIST::FUNCTION:EC
 RSA_flags                               1934	3_0_0	EXIST::FUNCTION:RSA
 X509_NAME_add_entry                     1935	3_0_0	EXIST::FUNCTION:
@@ -1923,7 +1923,7 @@ PKCS12_PBE_keyivgen                     1968	3_0_0	EXIST::FUNCTION:
 BIO_test_flags                          1969	3_0_0	EXIST::FUNCTION:
 EC_POINT_get_affine_coordinates_GF2m    1970	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC2M
 EVP_ENCODE_CTX_num                      1971	3_0_0	EXIST::FUNCTION:
-Camellia_cfb1_encrypt                   1972	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_cfb1_encrypt                   1972	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 NCONF_load_fp                           1973	3_0_0	EXIST::FUNCTION:STDIO
 i2d_OCSP_REQINFO                        1974	3_0_0	EXIST::FUNCTION:OCSP
 EVP_PKEY_sign                           1975	3_0_0	EXIST::FUNCTION:
@@ -2280,7 +2280,7 @@ PEM_write_bio                           2327	3_0_0	EXIST::FUNCTION:
 CMS_signed_get_attr_by_OBJ              2329	3_0_0	EXIST::FUNCTION:CMS
 X509_REVOKED_add_ext                    2330	3_0_0	EXIST::FUNCTION:
 EVP_CipherUpdate                        2331	3_0_0	EXIST::FUNCTION:
-Camellia_cfb8_encrypt                   2332	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_cfb8_encrypt                   2332	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 EVP_aes_256_xts                         2333	3_0_0	EXIST::FUNCTION:
 EVP_DigestSignFinal                     2334	3_0_0	EXIST::FUNCTION:
 ASN1_STRING_cmp                         2335	3_0_0	EXIST::FUNCTION:
@@ -2316,7 +2316,7 @@ X509at_add1_attr_by_txt                 2364	3_0_0	EXIST::FUNCTION:
 PKCS7_SIGN_ENVELOPE_free                2365	3_0_0	EXIST::FUNCTION:
 BIO_dgram_is_sctp                       2366	3_0_0	EXIST::FUNCTION:DGRAM,SCTP
 DH_check                                2367	3_0_0	EXIST::FUNCTION:DH
-Camellia_set_key                        2368	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_set_key                        2368	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 X509_LOOKUP_by_issuer_serial            2369	3_0_0	EXIST::FUNCTION:
 ASN1_BMPSTRING_free                     2370	3_0_0	EXIST::FUNCTION:
 BIO_new_accept                          2371	3_0_0	EXIST::FUNCTION:SOCK
@@ -2412,7 +2412,7 @@ SXNET_add_id_asc                        2462	3_0_0	EXIST::FUNCTION:
 X509_print_fp                           2463	3_0_0	EXIST::FUNCTION:STDIO
 TS_REQ_set_version                      2464	3_0_0	EXIST::FUNCTION:TS
 OCSP_REQINFO_new                        2465	3_0_0	EXIST::FUNCTION:OCSP
-Camellia_decrypt                        2466	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_decrypt                        2466	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 X509_signature_print                    2467	3_0_0	EXIST::FUNCTION:
 EVP_camellia_128_ecb                    2468	3_0_0	EXIST::FUNCTION:CAMELLIA
 MD2_Final                               2469	3_0_0	EXIST::FUNCTION:MD2
@@ -3034,7 +3034,7 @@ BIO_ADDR_rawaddress                     3098	3_0_0	EXIST::FUNCTION:SOCK
 PKCS7_ENCRYPT_new                       3099	3_0_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKey_fp                  3100	3_0_0	EXIST::FUNCTION:STDIO
 SRP_user_pwd_free                       3101	3_0_0	EXIST::FUNCTION:SRP
-Camellia_encrypt                        3102	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_encrypt                        3102	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 BIO_ADDR_hostname_string                3103	3_0_0	EXIST::FUNCTION:SOCK
 USERNOTICE_new                          3104	3_0_0	EXIST::FUNCTION:
 POLICY_MAPPING_new                      3105	3_0_0	EXIST::FUNCTION:
@@ -3572,7 +3572,7 @@ ASN1_const_check_infinite_end           3650	3_0_0	EXIST::FUNCTION:
 RSA_null_method                         3651	3_0_0	EXIST::FUNCTION:RSA
 TS_REQ_ext_free                         3652	3_0_0	EXIST::FUNCTION:TS
 EVP_PKEY_meth_get_encrypt               3653	3_0_0	EXIST::FUNCTION:
-Camellia_ecb_encrypt                    3654	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_ecb_encrypt                    3654	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 ENGINE_set_default_RSA                  3655	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_EncodeBlock                         3656	3_0_0	EXIST::FUNCTION:
 SXNETID_free                            3657	3_0_0	EXIST::FUNCTION:
@@ -3700,7 +3700,7 @@ X509_STORE_CTX_get_error_depth          3780	3_0_0	EXIST::FUNCTION:
 ASN1_GENERALIZEDTIME_set_string         3781	3_0_0	EXIST::FUNCTION:
 EC_GROUP_new_curve_GFp                  3782	3_0_0	EXIST::FUNCTION:EC
 UI_new_method                           3783	3_0_0	EXIST::FUNCTION:
-Camellia_ofb128_encrypt                 3784	3_0_0	EXIST::FUNCTION:CAMELLIA
+Camellia_ofb128_encrypt                 3784	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 X509_new                                3785	3_0_0	EXIST::FUNCTION:
 EC_KEY_get_conv_form                    3786	3_0_0	EXIST::FUNCTION:EC
 CTLOG_STORE_get0_log_by_id              3787	3_0_0	EXIST::FUNCTION:CT


### PR DESCRIPTION
Applications should instead use the higher level EVP APIs, e.g.
EVP_Encrypt*() and EVP_Decrypt*().

This is marked as WIP because it builds on the commits from #10580. Once that is merged I will rebase this and take it out of WIP.

Please only look at the last commit.