### PR TITLE
Deprecate the Low Level CAST APIs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,15 @@
      equivalently named decrypt functions.
      [Matt Caswell]
 
+  *) All of the low level CAST functions have been deprecated including:
+     CAST_set_key, CAST_ecb_encrypt, CAST_encrypt, CAST_decrypt,
+     CAST_cbc_encrypt, CAST_cfb64_encrypt and CAST_ofb64_encrypt
+     Use of these low level functions has been informally discouraged for a long
+     time. Instead applications should use the high level EVP APIs, e.g.
+     EVP_EncryptInit_ex, EVP_EncryptUpdate, EVP_EncryptFinal_ex, and the
+     equivalently named decrypt functions.
+     [Matt Caswell]
+
   *) Removed include/openssl/opensslconf.h.in and replaced it with
      include/openssl/configuration.h.in, which differs in not including
      <openssl/macros.h>.  A short header include/openssl/opensslconf.h

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -389,7 +389,7 @@ static const OPT_PAIR doit_choices[] = {
     {"blowfish", D_CBC_BF},
     {"bf", D_CBC_BF},
 #endif
-#ifndef OPENSSL_NO_CAST
+#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"cast-cbc", D_CBC_CAST},
     {"cast", D_CBC_CAST},
     {"cast5", D_CBC_CAST},
@@ -1464,7 +1464,7 @@ int speed_main(int argc, char **argv)
 #if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     BF_KEY bf_ks;
 #endif
-#ifndef OPENSSL_NO_CAST
+#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     CAST_KEY cast_ks;
 #endif
     static const unsigned char key16[16] = {
@@ -1990,7 +1990,7 @@ int speed_main(int argc, char **argv)
     if (doit[D_CBC_BF])
         BF_set_key(&bf_ks, 16, key16);
 #endif
-#ifndef OPENSSL_NO_CAST
+#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_CAST]) 
         CAST_set_key(&cast_ks, 16, key16);
 #endif
@@ -2670,7 +2670,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_CAST
+#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_CAST]) {
         if (async_jobs > 0) {
             BIO_printf(bio_err, "Async mode is not supported with %s\n",

--- a/crypto/cast/c_cfb64.c
+++ b/crypto/cast/c_cfb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/cast.h>
 #include "cast_local.h"
 

--- a/crypto/cast/c_ecb.c
+++ b/crypto/cast/c_ecb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/cast.h>
 #include "cast_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/cast/c_enc.c
+++ b/crypto/cast/c_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/cast.h>
 #include "cast_local.h"
 

--- a/crypto/cast/c_ofb64.c
+++ b/crypto/cast/c_ofb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/cast.h>
 #include "cast_local.h"
 

--- a/crypto/cast/c_skey.c
+++ b/crypto/cast/c_skey.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/cast.h>
 #include "cast_local.h"
 #include "cast_s.h"

--- a/crypto/evp/e_cast.c
+++ b/crypto/evp/e_cast.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 

--- a/include/openssl/cast.h
+++ b/include/openssl/cast.h
@@ -23,33 +23,52 @@
 extern "C" {
 # endif
 
-# define CAST_ENCRYPT    1
-# define CAST_DECRYPT    0
-
-# define CAST_LONG unsigned int
-
 # define CAST_BLOCK      8
 # define CAST_KEY_LENGTH 16
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+
+#  define CAST_ENCRYPT    1
+#  define CAST_DECRYPT    0
+
+#  define CAST_LONG unsigned int
 
 typedef struct cast_key_st {
     CAST_LONG data[32];
     int short_key;              /* Use reduced rounds for short key */
 } CAST_KEY;
 
-void CAST_set_key(CAST_KEY *key, int len, const unsigned char *data);
-void CAST_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                      const CAST_KEY *key, int enc);
-void CAST_encrypt(CAST_LONG *data, const CAST_KEY *key);
-void CAST_decrypt(CAST_LONG *data, const CAST_KEY *key);
-void CAST_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                      long length, const CAST_KEY *ks, unsigned char *iv,
-                      int enc);
-void CAST_cfb64_encrypt(const unsigned char *in, unsigned char *out,
-                        long length, const CAST_KEY *schedule,
-                        unsigned char *ivec, int *num, int enc);
-void CAST_ofb64_encrypt(const unsigned char *in, unsigned char *out,
-                        long length, const CAST_KEY *schedule,
-                        unsigned char *ivec, int *num);
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
+
+DEPRECATEDIN_3_0(void CAST_set_key(CAST_KEY *key, int len,
+                                   const unsigned char *data))
+DEPRECATEDIN_3_0(void CAST_ecb_encrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       const CAST_KEY *key,
+                                       int enc))
+DEPRECATEDIN_3_0(void CAST_encrypt(CAST_LONG *data,
+                                   const CAST_KEY *key))
+DEPRECATEDIN_3_0(void CAST_decrypt(CAST_LONG *data,
+                                   const CAST_KEY *key))
+DEPRECATEDIN_3_0(void CAST_cbc_encrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       long length,
+                                       const CAST_KEY *ks,
+                                       unsigned char *iv,
+                                       int enc))
+DEPRECATEDIN_3_0(void CAST_cfb64_encrypt(const unsigned char *in,
+                                         unsigned char *out,
+                                         long length,
+                                         const CAST_KEY *schedule,
+                                         unsigned char *ivec,
+                                         int *num,
+                                         int enc))
+DEPRECATEDIN_3_0(void CAST_ofb64_encrypt(const unsigned char *in,
+                                         unsigned char *out,
+                                         long length,
+                                         const CAST_KEY *schedule,
+                                         unsigned char *ivec,
+                                         int *num))
 
 # ifdef  __cplusplus
 }

--- a/providers/implementations/ciphers/cipher_cast5.c
+++ b/providers/implementations/ciphers/cipher_cast5.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 /* Dispatch functions for cast cipher modes ecb, cbc, ofb, cfb */
 
 #include "cipher_cast.h"

--- a/providers/implementations/ciphers/cipher_cast5_hw.c
+++ b/providers/implementations/ciphers/cipher_cast5_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_cast.h"
 
 static int cipher_hw_cast5_initkey(PROV_CIPHER_CTX *ctx,

--- a/test/build.info
+++ b/test/build.info
@@ -37,7 +37,7 @@ IF[{- !$disabled{tests} -}]
           hmactest \
           rc2test rc4test rc5test \
           destest mdc2test \
-          dhtest enginetest casttest \
+          dhtest enginetest \
           ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
           evp_pkey_provided_test evp_test evp_extra_test evp_fetch_prov_test \
           v3nametest v3ext \
@@ -152,10 +152,6 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[enginetest]=../include ../apps/include
   DEPEND[enginetest]=../libcrypto libtestutil.a
 
-  SOURCE[casttest]=casttest.c
-  INCLUDE[casttest]=../include ../apps/include
-  DEPEND[casttest]=../libcrypto libtestutil.a
-
   SOURCE[ssltest_old]=ssltest_old.c
   INCLUDE[ssltest_old]=.. ../include ../apps/include
   DEPEND[ssltest_old]=../libcrypto ../libssl
@@ -212,7 +208,8 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{"deprecated"}
         || (defined $config{"api"} && $config{"api"} < 30000) -}]
-    PROGRAMS{noinst}=igetest bftest
+    PROGRAMS{noinst}=igetest bftest casttest
+
     SOURCE[igetest]=igetest.c
     INCLUDE[igetest]=../include ../apps/include
     DEPEND[igetest]=../libcrypto libtestutil.a
@@ -220,6 +217,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[bftest]=bftest.c
     INCLUDE[bftest]=../include ../apps/include
     DEPEND[bftest]=../libcrypto libtestutil.a
+
+    SOURCE[casttest]=casttest.c
+    INCLUDE[casttest]=../include ../apps/include
+    DEPEND[casttest]=../libcrypto libtestutil.a
   ENDIF
 
   SOURCE[v3nametest]=v3nametest.c

--- a/test/casttest.c
+++ b/test/casttest.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * CAST low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/test/recipes/05-test_cast.t
+++ b/test/recipes/05-test_cast.t
@@ -7,6 +7,17 @@
 # https://www.openssl.org/source/license.html
 
 
+use strict;
+use warnings;
+
 use OpenSSL::Test::Simple;
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_cast");
+
+plan skip_all => "Low-level CAST APIs are disabled in this build"
+    if disabled("deprecated")
+       && (!defined config("api") || config("api") >= 30000);
 
 simple_test("test_cast", "casttest", "cast");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -712,7 +712,7 @@ DSA_sign_setup                          730	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 OPENSSL_sk_new_null                     731	3_0_0	EXIST::FUNCTION:
 PEM_read_PKCS8                          732	3_0_0	EXIST::FUNCTION:STDIO
 BN_mod_sqr                              733	3_0_0	EXIST::FUNCTION:
-CAST_ofb64_encrypt                      734	3_0_0	EXIST::FUNCTION:CAST
+CAST_ofb64_encrypt                      734	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 TXT_DB_write                            735	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_get1_ext_d2i               736	3_0_0	EXIST::FUNCTION:OCSP
 CMS_unsigned_add1_attr_by_NID           737	3_0_0	EXIST::FUNCTION:CMS
@@ -1684,7 +1684,7 @@ EVP_PKEY_type                           1722	3_0_0	EXIST::FUNCTION:
 ENGINE_ctrl                             1723	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_cast5_ecb                           1724	3_0_0	EXIST::FUNCTION:CAST
 BIO_nwrite0                             1725	3_0_0	EXIST::FUNCTION:
-CAST_encrypt                            1726	3_0_0	EXIST::FUNCTION:CAST
+CAST_encrypt                            1726	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 a2d_ASN1_OBJECT                         1727	3_0_0	EXIST::FUNCTION:
 OCSP_ONEREQ_delete_ext                  1728	3_0_0	EXIST::FUNCTION:OCSP
 UI_method_get_reader                    1729	3_0_0	EXIST::FUNCTION:
@@ -2068,7 +2068,7 @@ X509_REQ_set_version                    2113	3_0_0	EXIST::FUNCTION:
 d2i_ASN1_GENERALSTRING                  2114	3_0_0	EXIST::FUNCTION:
 i2d_ASIdentifiers                       2115	3_0_0	EXIST::FUNCTION:RFC3779
 X509V3_EXT_cleanup                      2116	3_0_0	EXIST::FUNCTION:
-CAST_ecb_encrypt                        2117	3_0_0	EXIST::FUNCTION:CAST
+CAST_ecb_encrypt                        2117	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 BIO_s_file                              2118	3_0_0	EXIST::FUNCTION:
 RSA_X931_derive_ex                      2119	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_decrypt_init                   2120	3_0_0	EXIST::FUNCTION:
@@ -2449,7 +2449,7 @@ AES_cfb128_encrypt                      2499	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 ENGINE_set_EC                           2500	3_0_0	EXIST::FUNCTION:ENGINE
 d2i_ECPKParameters                      2501	3_0_0	EXIST::FUNCTION:EC
 IDEA_ofb64_encrypt                      2502	3_0_0	EXIST::FUNCTION:IDEA
-CAST_decrypt                            2503	3_0_0	EXIST::FUNCTION:CAST
+CAST_decrypt                            2503	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 TS_STATUS_INFO_get0_failure_info        2504	3_0_0	EXIST::FUNCTION:TS
 ENGINE_unregister_pkey_meths            2506	3_0_0	EXIST::FUNCTION:ENGINE
 DISPLAYTEXT_new                         2507	3_0_0	EXIST::FUNCTION:
@@ -2862,7 +2862,7 @@ EVP_des_cfb1                            2923	3_0_0	EXIST::FUNCTION:DES
 OBJ_NAME_cleanup                        2924	3_0_0	EXIST::FUNCTION:
 OCSP_BASICRESP_get1_ext_d2i             2925	3_0_0	EXIST::FUNCTION:OCSP
 DES_cfb64_encrypt                       2926	3_0_0	EXIST::FUNCTION:DES
-CAST_cfb64_encrypt                      2927	3_0_0	EXIST::FUNCTION:CAST
+CAST_cfb64_encrypt                      2927	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 EVP_PKEY_asn1_set_param                 2928	3_0_0	EXIST::FUNCTION:
 BN_RECP_CTX_free                        2929	3_0_0	EXIST::FUNCTION:
 BN_with_flags                           2930	3_0_0	EXIST::FUNCTION:
@@ -2979,7 +2979,7 @@ PKCS12_item_pack_safebag                3043	3_0_0	EXIST::FUNCTION:
 i2d_OCSP_RESPDATA                       3044	3_0_0	EXIST::FUNCTION:OCSP
 i2d_X509_PUBKEY                         3045	3_0_0	EXIST::FUNCTION:
 EVP_DecryptUpdate                       3046	3_0_0	EXIST::FUNCTION:
-CAST_cbc_encrypt                        3047	3_0_0	EXIST::FUNCTION:CAST
+CAST_cbc_encrypt                        3047	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 BN_BLINDING_invert                      3048	3_0_0	EXIST::FUNCTION:
 SHA512_Update                           3049	3_0_0	EXIST::FUNCTION:
 ESS_ISSUER_SERIAL_new                   3050	3_0_0	EXIST::FUNCTION:
@@ -3588,7 +3588,7 @@ TS_X509_ALGOR_print_bio                 3666	3_0_0	EXIST::FUNCTION:TS
 d2i_PKCS7_ENVELOPE                      3667	3_0_0	EXIST::FUNCTION:
 ESS_CERT_ID_new                         3669	3_0_0	EXIST::FUNCTION:
 EC_POINT_invert                         3670	3_0_0	EXIST::FUNCTION:EC
-CAST_set_key                            3671	3_0_0	EXIST::FUNCTION:CAST
+CAST_set_key                            3671	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 ENGINE_get_pkey_meth                    3672	3_0_0	EXIST::FUNCTION:ENGINE
 BIO_ADDRINFO_free                       3673	3_0_0	EXIST::FUNCTION:SOCK
 DES_ede3_cbc_encrypt                    3674	3_0_0	EXIST::FUNCTION:DES


### PR DESCRIPTION
Applications should instead use the higher level EVP APIs, e.g.
EVP_Encrypt*() and EVP_Decrypt*().

This is marked as WIP because it builds on the commits from #10580. Once that is merged I will rebase this and take it out of WIP.

Please only look at the last commit.