### PR TITLE
s_client: Show algorithms & validity period with "Certificate Chain"

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3277,9 +3277,9 @@ static void print_stuff(BIO *bio, SSL *s, int full)
                     EVP_PKEY_free(public_key);
                 }
                 BIO_printf(bio, "   v:NotBefore: ");
-                ASN1_TIME_print(bio, X509_get_notBefore(sk_X509_value(sk, i)));
+                ASN1_TIME_print(bio, X509_get0_notBefore(sk_X509_value(sk, i)));
                 BIO_printf(bio, "; NotAfter: ");
-                ASN1_TIME_print(bio, X509_get_notAfter(sk_X509_value(sk, i)));
+                ASN1_TIME_print(bio, X509_get0_notAfter(sk_X509_value(sk, i)));
                 BIO_puts(bio, "\n");
                 if (c_showcerts)
                     PEM_write_bio_X509(bio, sk_X509_value(sk, i));

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3272,8 +3272,10 @@ static void print_stuff(BIO *bio, SSL *s, int full)
                 BIO_puts(bio, "\n");
                 public_key = X509_get_pubkey(sk_X509_value(sk, i));
                 if (public_key != NULL) {
-                    BIO_printf(bio, "   a:PKEY: %s, %d (bit); sigalg: %s\n", OBJ_nid2sn(EVP_PKEY_base_id(public_key)), EVP_PKEY_bits(public_key),
-                        OBJ_nid2sn(X509_get_signature_nid(sk_X509_value(sk, i))));
+                    BIO_printf(bio, "   a:PKEY: %s, %d (bit); sigalg: %s\n",
+                               OBJ_nid2sn(EVP_PKEY_base_id(public_key)),
+                               EVP_PKEY_bits(public_key),
+                               OBJ_nid2sn(X509_get_signature_nid(sk_X509_value(sk, i))));
                     EVP_PKEY_free(public_key);
                 }
                 BIO_printf(bio, "   v:NotBefore: ");

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3244,6 +3244,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
     X509 *peer = NULL;
     STACK_OF(X509) *sk;
     const SSL_CIPHER *c;
+    EVP_PKEY *public_key;
     int i, istls13 = (SSL_version(s) == TLS1_3_VERSION);
     long verify_result;
 #ifndef OPENSSL_NO_COMP
@@ -3268,6 +3269,17 @@ static void print_stuff(BIO *bio, SSL *s, int full)
                 BIO_puts(bio, "\n");
                 BIO_printf(bio, "   i:");
                 X509_NAME_print_ex(bio, X509_get_issuer_name(sk_X509_value(sk, i)), 0, get_nameopt());
+                BIO_puts(bio, "\n");
+                public_key = X509_get_pubkey(sk_X509_value(sk, i));
+                if (public_key != NULL) {
+                    BIO_printf(bio, "   a:PKEY: %s, %d (bit); sigalg: %s\n", OBJ_nid2sn(EVP_PKEY_base_id(public_key)), EVP_PKEY_bits(public_key),
+                        OBJ_nid2sn(X509_get_signature_nid(sk_X509_value(sk, i))));
+                    EVP_PKEY_free(public_key);
+                }
+                BIO_printf(bio, "   v:NotBefore: ");
+                ASN1_TIME_print(bio, X509_get_notBefore(sk_X509_value(sk, i)));
+                BIO_printf(bio, "; NotAfter: ");
+                ASN1_TIME_print(bio, X509_get_notAfter(sk_X509_value(sk, i)));
                 BIO_puts(bio, "\n");
                 if (c_showcerts)
                     PEM_write_bio_X509(bio, sk_X509_value(sk, i));


### PR DESCRIPTION
Add certificate validity period (v) and public key & signature algorithms (a) to the s_client "Certificate Chain" output.

Example of connecting to www.google.com:443 showing new (a) & (v) lines:
```
Certificate chain
 0 s:C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com
   i:C = US, O = Google Trust Services, CN = GTS CA 1O1
   a:PKEY: id-ecPublicKey, 256 (bit); sigalg: RSA-SHA256
   v:NotBefore: Dec  3 14:49:26 2019 GMT; NotAfter: Feb 25 14:49:26 2020 GMT
 1 s:C = US, O = Google Trust Services, CN = GTS CA 1O1
   i:OU = GlobalSign Root CA - R2, O = GlobalSign, CN = GlobalSign
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 15 00:00:42 2017 GMT; NotAfter: Dec 15 00:00:42 2021 GMT
```