### PR TITLE
EVP: Fix method to determine if a PKEY is legacy or not

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -131,7 +131,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
      * If the key doesn't contain anything legacy, then it must be provided,
      * so we extract the necessary information and use that.
      */
-    if (pkey != NULL && pkey->pkey.ptr == NULL) {
+    if (pkey != NULL && pkey->ameth == NULL) {
         /* If we have an engine, something went wrong somewhere... */
         if (!ossl_assert(e == NULL))
             return NULL;


### PR DESCRIPTION
For the implementation of EVP_PKEY_CTX_new(), we determined if an
EVP_PKEY wass legacy or not by looking at 'pkey->pkey.ptr'.  It turns
out that this code could get an unassigned EVP_PKEY, with that pointer
being NULL, and the determination proven incorrect.

The check now looks at 'pkey->ameth' instead.

Fixes #10704
