### PR TITLE
Move random-related defines to "crypto/rand.h" [1.1.1]

### DIFF
--- a/apps/version.c
+++ b/apps/version.c
@@ -31,6 +31,8 @@
 # include <openssl/blowfish.h>
 #endif
 
+#include "crypto/rand.h"
+
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_B, OPT_D, OPT_E, OPT_F, OPT_O, OPT_P, OPT_V, OPT_A, OPT_R

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -20,55 +20,6 @@
 #include <stdio.h>
 #include "internal/dso.h"
 
-/*
- * Defines related to seed sources
- */
-#ifndef DEVRANDOM
-/*
- * set this to a comma-separated list of 'random' device files to try out. By
- * default, we will try to read at least one of these files
- */
-# define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
-# if defined(__linux) && !defined(__ANDROID__)
-#  ifndef DEVRANDOM_WAIT
-#   define DEVRANDOM_WAIT   "/dev/random"
-#  endif
-/*
- * Linux kernels 4.8 and later changes how their random device works and there
- * is no reliable way to tell that /dev/urandom has been seeded -- getentropy(2)
- * should be used instead.
- */
-#  ifndef DEVRANDOM_SAFE_KERNEL
-#   define DEVRANDOM_SAFE_KERNEL        4, 8
-#  endif
-/*
- * Some operating systems do not permit select(2) on their random devices,
- * defining this to zero will force the use of read(2) to extract one byte
- * from /dev/random.
- */
-#  ifndef DEVRANDM_WAIT_USE_SELECT
-#   define DEVRANDM_WAIT_USE_SELECT     1
-#  endif
-/*
- * Define the shared memory identifier used to indicate if the operating
- * system has properly seeded the DEVRANDOM source.
- */
-#  ifndef OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID
-#   define OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID 114
-#  endif
-
-# endif
-#endif
-
-#if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
-/*
- * set this to a comma-separated list of 'egd' sockets to try out. These
- * sockets will be tried in the order listed in case accessing the device
- * files listed in DEVRANDOM did not return enough randomness.
- */
-# define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
-#endif
-
 #ifdef __linux
 # include <sys/syscall.h>
 # ifdef DEVRANDOM_WAIT

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -23,6 +23,55 @@
 /* forward declaration */
 typedef struct rand_pool_st RAND_POOL;
 
+/*
+ * Defines related to seed sources
+ */
+#ifndef DEVRANDOM
+/*
+ * set this to a comma-separated list of 'random' device files to try out. By
+ * default, we will try to read at least one of these files
+ */
+# define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
+# if defined(__linux) && !defined(__ANDROID__)
+#  ifndef DEVRANDOM_WAIT
+#   define DEVRANDOM_WAIT   "/dev/random"
+#  endif
+/*
+ * Linux kernels 4.8 and later changes how their random device works and there
+ * is no reliable way to tell that /dev/urandom has been seeded -- getentropy(2)
+ * should be used instead.
+ */
+#  ifndef DEVRANDOM_SAFE_KERNEL
+#   define DEVRANDOM_SAFE_KERNEL        4, 8
+#  endif
+/*
+ * Some operating systems do not permit select(2) on their random devices,
+ * defining this to zero will force the use of read(2) to extract one byte
+ * from /dev/random.
+ */
+#  ifndef DEVRANDM_WAIT_USE_SELECT
+#   define DEVRANDM_WAIT_USE_SELECT     1
+#  endif
+/*
+ * Define the shared memory identifier used to indicate if the operating
+ * system has properly seeded the DEVRANDOM source.
+ */
+#  ifndef OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID
+#   define OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID 114
+#  endif
+
+# endif
+#endif
+
+#if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
+/*
+ * set this to a comma-separated list of 'egd' sockets to try out. These
+ * sockets will be tried in the order listed in case accessing the device
+ * files listed in DEVRANDOM did not return enough randomness.
+ */
+# define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
+#endif
+
 void rand_cleanup_int(void);
 void rand_drbg_cleanup_int(void);
 void drbg_delete_thread_state(void);


### PR DESCRIPTION
This fixes commit 7b18d1a53f932391bbc599a4717d6f98a597849c, which moved the
DEVRANDOM and DEVRANDOM_EGD defines into rand_unix.c. That change introduced
the regression that the compiler complains about missing declarations in
crypto/info.c when OpenSSL is configured using `--with-rand-seed=devrandom`
(resp. `--with-rand-seed=egd`)

Fixes #10759
