### PR TITLE
Move random-related defines to "crypto/rand.h"

### DIFF
--- a/crypto/info.c
+++ b/crypto/info.c
@@ -76,7 +76,7 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
                 const char **p;                                         \
                 int first = 1;                                          \
                                                                         \
-                for (p=dev; *p != NULL; p++) {                          \
+                for (p = dev; *p != NULL; p++) {                        \
                     if (!first)                                         \
                         OPENSSL_strlcat(seeds, " ", sizeof(seeds));     \
                     first = 0;                                          \

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -72,14 +72,15 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
         do {                                                            \
             add_seeds_string(label "(");                                \
             {                                                           \
-                const char *dev[] = strlist;                            \
+                const char *dev[] =  { strlist, NULL };                 \
+                const char **p;                                         \
                 int first = 1;                                          \
                                                                         \
-                for (; *dev != NULL; dev++) {                           \
+                for (p=dev; *p != NULL; p++) {                          \
                     if (!first)                                         \
                         OPENSSL_strlcat(seeds, " ", sizeof(seeds));     \
                     first = 0;                                          \
-                    OPENSSL_strlcat(seeds, *dev, sizeof(seeds));        \
+                    OPENSSL_strlcat(seeds, *p, sizeof(seeds));          \
                 }                                                       \
             }                                                           \
             OPENSSL_strlcat(seeds, ")", sizeof(seeds));                 \
@@ -101,10 +102,10 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
         add_seeds_string("getrandom-syscall");
 #endif
 #ifdef OPENSSL_RAND_SEED_DEVRANDOM
-        add_seeds_stringlist("random-device", { DEVRANDOM, NULL });
+        add_seeds_stringlist("random-device", DEVRANDOM);
 #endif
 #ifdef OPENSSL_RAND_SEED_EGD
-        add_seeds_stringlist("EGD", { DEVRANDOM_EGD, NULL });
+        add_seeds_stringlist("EGD", DEVRANDOM_EGD);
 #endif
 #ifdef OPENSSL_RAND_SEED_OS
         add_seeds_string("os-specific");

--- a/crypto/info.c
+++ b/crypto/info.c
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/crypto.h>
+#include "crypto/rand.h"
 #include "crypto/dso_conf.h"
 #include "internal/thread_once.h"
 #include "internal/cryptlib.h"

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -20,55 +20,6 @@
 #include <stdio.h>
 #include "internal/dso.h"
 
-/*
- * Defines related to seed sources
- */
-#ifndef DEVRANDOM
-/*
- * set this to a comma-separated list of 'random' device files to try out. By
- * default, we will try to read at least one of these files
- */
-# define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
-# if defined(__linux) && !defined(__ANDROID__)
-#  ifndef DEVRANDOM_WAIT
-#   define DEVRANDOM_WAIT   "/dev/random"
-#  endif
-/*
- * Linux kernels 4.8 and later changes how their random device works and there
- * is no reliable way to tell that /dev/urandom has been seeded -- getentropy(2)
- * should be used instead.
- */
-#  ifndef DEVRANDOM_SAFE_KERNEL
-#   define DEVRANDOM_SAFE_KERNEL        4, 8
-#  endif
-/*
- * Some operating systems do not permit select(2) on their random devices,
- * defining this to zero will force the use of read(2) to extract one byte
- * from /dev/random.
- */
-#  ifndef DEVRANDM_WAIT_USE_SELECT
-#   define DEVRANDM_WAIT_USE_SELECT     1
-#  endif
-/*
- * Define the shared memory identifier used to indicate if the operating
- * system has properly seeded the DEVRANDOM source.
- */
-#  ifndef OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID
-#   define OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID 114
-#  endif
-
-# endif
-#endif
-
-#if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
-/*
- * set this to a comma-separated list of 'egd' sockets to try out. These
- * sockets will be tried in the order listed in case accessing the device
- * files listed in DEVRANDOM did not return enough randomness.
- */
-# define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
-#endif
-
 #ifdef __linux
 # include <sys/syscall.h>
 # ifdef DEVRANDOM_WAIT

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -23,6 +23,55 @@
 /* forward declaration */
 typedef struct rand_pool_st RAND_POOL;
 
+/*
+ * Defines related to seed sources
+ */
+#ifndef DEVRANDOM
+/*
+ * set this to a comma-separated list of 'random' device files to try out. By
+ * default, we will try to read at least one of these files
+ */
+# define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
+# if defined(__linux) && !defined(__ANDROID__)
+#  ifndef DEVRANDOM_WAIT
+#   define DEVRANDOM_WAIT   "/dev/random"
+#  endif
+/*
+ * Linux kernels 4.8 and later changes how their random device works and there
+ * is no reliable way to tell that /dev/urandom has been seeded -- getentropy(2)
+ * should be used instead.
+ */
+#  ifndef DEVRANDOM_SAFE_KERNEL
+#   define DEVRANDOM_SAFE_KERNEL        4, 8
+#  endif
+/*
+ * Some operating systems do not permit select(2) on their random devices,
+ * defining this to zero will force the use of read(2) to extract one byte
+ * from /dev/random.
+ */
+#  ifndef DEVRANDM_WAIT_USE_SELECT
+#   define DEVRANDM_WAIT_USE_SELECT     1
+#  endif
+/*
+ * Define the shared memory identifier used to indicate if the operating
+ * system has properly seeded the DEVRANDOM source.
+ */
+#  ifndef OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID
+#   define OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID 114
+#  endif
+
+# endif
+#endif
+
+#if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
+/*
+ * set this to a comma-separated list of 'egd' sockets to try out. These
+ * sockets will be tried in the order listed in case accessing the device
+ * files listed in DEVRANDOM did not return enough randomness.
+ */
+# define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
+#endif
+
 void rand_cleanup_int(void);
 
 /* Hardware-based seeding functions. */


### PR DESCRIPTION
commit 7ec5c3109d5cea3d2b264ec1db61fd42ac97ec13
Author: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Date:   Mon Jan 6 01:50:43 2020 +0100

    Move random-related defines to "crypto/rand.h"
    
    This fixes commit 01036e2afbe116d608be048ed15930fc885ab2a8, which moved the
    DEVRANDOM and DEVRANDOM_EGD defines into rand_unix.c. That change introduced
    the regression that the compiler complains about missing declarations in
    crypto/info.c when OpenSSL is configured using `--with-rand-seed=devrandom`
    (resp. `--with-rand-seed=egd`)
    
    Fixes #10759


commit ee502fd524d52602a61b67425f5e7f1de6f98a11 (HEAD -> pr-move-random-defines-again, msp/pr-move-random-defines-again)
Author: Dr. Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
Date:   Mon Jan 6 02:38:14 2020 +0100

    Modify the add_seeds_stringlist() macro to fix a preprocessor error
    
    When OpenSSL is configured using `--with-rand-seed=devrandom`, the preprocessor
    reports the following error
    
        crypto/info.c:104:66: error:
                macro "add_seeds_stringlist" passed 3 arguments, but takes just 2
                add_seeds_stringlist("random-device", { DEVRANDOM, NULL });
    
    The reason why the preprocessor complains about three arguments being passed
    is that according to [1], balanced braces in macro arguments don't prevent the
    comma from acting as an argument separator:
    
        3.3 Macro Arguments
        ...
        Parentheses within each argument must balance;
        a comma within such parentheses does not end the argument.
        However, there is no requirement for square brackets or braces to balance,
        and they do not prevent a comma from separating arguments.
    
    Also introduced an iteration pointer `p`, because `dev` is not an lvalue:
    
        crypto/info.c:78:41: error:
                lvalue required as increment operand
                for (; *dev != NULL; dev++) {
    
    [1] https://gcc.gnu.org/onlinedocs/cpp/Macro-Arguments.html

