### PR TITLE
Revert "Move random-related defines from e_os.h to rand_unix.c" [1.1.1]

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -19,56 +19,6 @@
 #include "crypto/rand.h"
 #include <stdio.h>
 #include "internal/dso.h"
-
-/*
- * Defines related to seed sources
- */
-#ifndef DEVRANDOM
-/*
- * set this to a comma-separated list of 'random' device files to try out. By
- * default, we will try to read at least one of these files
- */
-# define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
-# if defined(__linux) && !defined(__ANDROID__)
-#  ifndef DEVRANDOM_WAIT
-#   define DEVRANDOM_WAIT   "/dev/random"
-#  endif
-/*
- * Linux kernels 4.8 and later changes how their random device works and there
- * is no reliable way to tell that /dev/urandom has been seeded -- getentropy(2)
- * should be used instead.
- */
-#  ifndef DEVRANDOM_SAFE_KERNEL
-#   define DEVRANDOM_SAFE_KERNEL        4, 8
-#  endif
-/*
- * Some operating systems do not permit select(2) on their random devices,
- * defining this to zero will force the use of read(2) to extract one byte
- * from /dev/random.
- */
-#  ifndef DEVRANDM_WAIT_USE_SELECT
-#   define DEVRANDM_WAIT_USE_SELECT     1
-#  endif
-/*
- * Define the shared memory identifier used to indicate if the operating
- * system has properly seeded the DEVRANDOM source.
- */
-#  ifndef OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID
-#   define OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID 114
-#  endif
-
-# endif
-#endif
-
-#if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
-/*
- * set this to a comma-separated list of 'egd' sockets to try out. These
- * sockets will be tried in the order listed in case accessing the device
- * files listed in DEVRANDOM did not return enough randomness.
- */
-# define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
-#endif
-
 #ifdef __linux
 # include <sys/syscall.h>
 # ifdef DEVRANDOM_WAIT

--- a/e_os.h
+++ b/e_os.h
@@ -22,6 +22,51 @@
  * outside; this file e_os.h is not part of the exported interface.
  */
 
+# ifndef DEVRANDOM
+/*
+ * set this to a comma-separated list of 'random' device files to try out. By
+ * default, we will try to read at least one of these files
+ */
+#  define DEVRANDOM "/dev/urandom", "/dev/random", "/dev/hwrng", "/dev/srandom"
+#  if defined(__linux) && !defined(__ANDROID__)
+#   ifndef DEVRANDOM_WAIT
+#    define DEVRANDOM_WAIT   "/dev/random"
+#   endif
+/*
+ * Linux kernels 4.8 and later changes how their random device works and there
+ * is no reliable way to tell that /dev/urandom has been seeded -- getentropy(2)
+ * should be used instead.
+ */
+#   ifndef DEVRANDOM_SAFE_KERNEL
+#    define DEVRANDOM_SAFE_KERNEL        4, 8
+#   endif
+/*
+ * Some operating systems do not permit select(2) on their random devices,
+ * defining this to zero will force the use of read(2) to extract one byte
+ * from /dev/random.
+ */
+#   ifndef DEVRANDM_WAIT_USE_SELECT
+#    define DEVRANDM_WAIT_USE_SELECT     1
+#   endif
+/*
+ * Define the shared memory identifier used to indicate if the operating
+ * system has properly seeded the DEVRANDOM source.
+ */
+#   ifndef OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID
+#    define OPENSSL_RAND_SEED_DEVRANDOM_SHM_ID 114
+#   endif
+
+#  endif
+# endif
+# if !defined(OPENSSL_NO_EGD) && !defined(DEVRANDOM_EGD)
+/*
+ * set this to a comma-separated list of 'egd' sockets to try out. These
+ * sockets will be tried in the order listed in case accessing the device
+ * files listed in DEVRANDOM did not return enough randomness.
+ */
+#  define DEVRANDOM_EGD "/var/run/egd-pool", "/dev/egd-pool", "/etc/egd-pool", "/etc/entropy"
+# endif
+
 # if defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
 #  define NO_CHMOD
 #  define NO_SYSLOG


### PR DESCRIPTION
This reverts commit 7b18d1a53f932391bbc599a4717d6f98a597849c, which moved the
DEVRANDOM and DEVRANDOM_EGD defines into rand_unix.c. That change introduced
the regression that the compiler complains about missing declarations in
apps/version.c when OpenSSL is configured using `--with-rand-seed=devrandom`
(resp. `--with-rand-seed=egd`):

apps/version.c:173:42: error: 'DEVRANDOM' undeclared
             static const char *dev[] = { DEVRANDOM, NULL };
                                          ^~~~~~~~~

Fixes #10759

Alternative to #10761

