### PR TITLE
Add missing inclusion of "internal/deprecated.h"

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -7,8 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* Dispatch functions for AES_CBC_HMAC_SHA ciphers */
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
 
+/* Dispatch functions for AES_CBC_HMAC_SHA ciphers */
 
 #include "cipher_aes_cbc_hmac_sha.h"
 #include "prov/implementations.h"

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_cbc_hmac_sha.h"
 
 #ifndef AES_CBC_HMAC_SHA_CAPABLE

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * AES low level APIs are deprecated for public use, but still ok for internal
+ * use where we're using them to implement the higher level EVP interface, as is
+ * the case here.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_aes_cbc_hmac_sha.h"
 
 #ifndef AES_CBC_HMAC_SHA_CAPABLE


### PR DESCRIPTION
A few provider implementations need this to build correctly with a
'no-deprecated' configuration.
