### PR TITLE
Add test/bio_prefix_text to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ doc/man1/openssl-x509.pod
 /test/ossl_shim/ossl_shim
 /test/rsa_complex
 /test/confdump
+/test/bio_prefix_text
 # Other generated files in test/
 /test/provider_internal_test.conf
 /test/fipsinstall.conf


### PR DESCRIPTION
A new test binary was added as part of 51a7c4b5f2a0b2d0f6bc0c87ec2ee44b9697dc78 (from https://github.com/openssl/openssl/pull/10531 ).

This commit adds said binary to .gitignore to avoid cluttering of the worktree.