### PR TITLE
Make generated copyright year be "now"

### DIFF
--- a/crypto/asn1/charmap.pl
+++ b/crypto/asn1/charmap.pl
@@ -82,8 +82,8 @@ $arr[ord("?")] |= $PSTRING_CHAR;
 
 # Now generate the C code
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+# Year the file was generated.
+my $YEAR = [localtime()]->[5] + 1900;
 print <<EOF;
 /*
  * WARNING: do not edit!

--- a/crypto/bn/bn_prime.pl
+++ b/crypto/bn/bn_prime.pl
@@ -6,8 +6,8 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+# The year the output file is generated.
+my $YEAR = [localtime()]->[5] + 1900;
 print <<"EOF";
 /*
  * WARNING: do not edit!

--- a/crypto/conf/keysets.pl
+++ b/crypto/conf/keysets.pl
@@ -57,9 +57,8 @@ foreach (0 .. 127) {
     push(@V_w32, $v);
 }
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-
+# The year the output file is generated.
+my $YEAR = [localtime()]->[5] + 1900;
 print <<"EOF";
 /*
  * WARNING: do not edit!

--- a/crypto/objects/obj_dat.pl
+++ b/crypto/objects/obj_dat.pl
@@ -36,10 +36,8 @@ sub der_it
     return $ret;
 }
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($ARGV[0])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = [localtime()]->[5] + 1900;
 
 # Read input, parse all #define's into OID name and value.
 # Populate %ln and %sn with long and short names (%dupln and %dupsn)

--- a/crypto/objects/objects.pl
+++ b/crypto/objects/objects.pl
@@ -11,12 +11,8 @@ use Getopt::Std;
 our($opt_n);
 getopts('n');
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($ARGV[0])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
-$iYEAR = [localtime([stat($ARGV[1])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = [localtime()]->[5] + 1900;
 
 open (NUMIN,"$ARGV[1]") || die "Can't open number file $ARGV[1]";
 $max_nid=0;

--- a/crypto/objects/objxref.pl
+++ b/crypto/objects/objxref.pl
@@ -14,12 +14,8 @@ my %oid_tbl;
 
 my ($mac_file, $xref_file) = @ARGV;
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($mac_file)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
-$iYEAR = [localtime([stat($xref_file)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = [localtime()]->[5] + 1900;
 
 open(IN, $mac_file) || die "Can't open $mac_file, $!\n";
 

--- a/fuzz/mkfuzzoids.pl
+++ b/fuzz/mkfuzzoids.pl
@@ -8,10 +8,8 @@
 
 my $obj_dat_h = $ARGV[0];
 
-# Output year depends on the date on the input file and the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($obj_dat_h)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = [localtime()]->[5] + 1900;
 
 open IN, '<', $obj_dat_h
     || die "Couldn't open $obj_dat_h : $!\n";


### PR DESCRIPTION
Always use the current year in generating output files, rather than
trying to base is on the modtime of the script or input, as that can
vary depending on the ability of the local OS to keep those accurate.

Fixes #10744

-----

When I originally set up those scripts, I used the timestamp on the input file(s). I know realize that was too fragile, for systems that muck with or otherwise don't preserve timestamps very well.

This should backport easily.
