### PR TITLE
Deprecate the low level Whirlpool functions.

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -345,7 +345,7 @@ static const OPT_PAIR doit_choices[] = {
     {"sha1", D_SHA1},
     {"sha256", D_SHA256},
     {"sha512", D_SHA512},
-#ifndef OPENSSL_NO_WHIRLPOOL
+#if !defined(OPENSSL_NO_WHIRLPOOL) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"whirlpool", D_WHIRLPOOL},
 #endif
 #ifndef OPENSSL_NO_RMD160
@@ -683,7 +683,7 @@ static int SHA512_loop(void *args)
     return count;
 }
 
-#ifndef OPENSSL_NO_WHIRLPOOL
+#if !defined(OPENSSL_NO_WHIRLPOOL) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int WHIRLPOOL_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -2350,7 +2350,7 @@ int speed_main(int argc, char **argv)
             print_result(D_SHA512, testnum, count, d);
         }
     }
-#ifndef OPENSSL_NO_WHIRLPOOL
+#if !defined(OPENSSL_NO_WHIRLPOOL) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_WHIRLPOOL]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_WHIRLPOOL], c[D_WHIRLPOOL][testnum],

--- a/crypto/evp/legacy_wp.c
+++ b/crypto/evp/legacy_wp.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Whirlpool low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/whrlpool.h>
 #include "crypto/evp.h"
 #include "legacy_meth.h"

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -17,12 +17,20 @@ IF[{- !$disabled{asm} -}]
   ENDIF
 ENDIF
 
-SOURCE[../../libcrypto]=wp_dgst.c $WPASM
-
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules.
-DEFINE[../../libcrypto]=$WPDEF
 DEFINE[../../providers/libimplementations.a]=$WPDEF
+
+SOURCE[../../libcrypto]=wp_dgst.c $WPASM
+DEFINE[../../libcrypto]=$WPDEF
+
+# When all deprecated symbols are removed, libcrypto doesn't export the
+# WHIRLPOOL functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{"deprecated"}
+      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+  SOURCE[../../providers/liblegacy.a]=wp_dgst.c $WPASM
+  DEFINE[../../providers/liblegacy.a]=$WPDEF
+ENDIF
 
 GENERATE[wp-mmx.s]=asm/wp-mmx.pl
 DEPEND[wp-mmx.s]=../perlasm/x86asm.pl

--- a/crypto/whrlpool/wp_block.c
+++ b/crypto/whrlpool/wp_block.c
@@ -36,6 +36,12 @@
  *
  */
 
+/*
+ * Whirlpool low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "internal/cryptlib.h"
 #include "wp_local.h"
 #include <string.h>

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -52,6 +52,12 @@
  * input. This is done for performance.
  */
 
+/*
+ * Whirlpool low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include "wp_local.h"
 #include <string.h>

--- a/include/openssl/whrlpool.h
+++ b/include/openssl/whrlpool.h
@@ -16,18 +16,18 @@
 #  define HEADER_WHRLPOOL_H
 # endif
 
-#include <openssl/opensslconf.h>
+# include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_WHIRLPOOL
-# include <openssl/e_os2.h>
-# include <stddef.h>
-# ifdef __cplusplus
+#  include <openssl/e_os2.h>
+#  include <stddef.h>
+#  ifdef __cplusplus
 extern "C" {
-# endif
+#  endif
 
-# define WHIRLPOOL_DIGEST_LENGTH (512/8)
-# define WHIRLPOOL_BBLOCK        512
-# define WHIRLPOOL_COUNTER       (256/8)
+#  define WHIRLPOOL_DIGEST_LENGTH (512/8)
+#  define WHIRLPOOL_BBLOCK        512
+#  define WHIRLPOOL_COUNTER       (256/8)
 
 typedef struct {
     union {
@@ -46,9 +46,9 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *inp, size_t bits);
 int WHIRLPOOL_Final(unsigned char *md, WHIRLPOOL_CTX *c);
 unsigned char *WHIRLPOOL(const void *inp, size_t bytes, unsigned char *md);
 
-# ifdef __cplusplus
+#  ifdef __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/whrlpool.h
+++ b/include/openssl/whrlpool.h
@@ -26,8 +26,11 @@ extern "C" {
 #  endif
 
 #  define WHIRLPOOL_DIGEST_LENGTH (512/8)
-#  define WHIRLPOOL_BBLOCK        512
-#  define WHIRLPOOL_COUNTER       (256/8)
+
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
+
+#   define WHIRLPOOL_BBLOCK        512
+#   define WHIRLPOOL_COUNTER       (256/8)
 
 typedef struct {
     union {
@@ -39,15 +42,21 @@ typedef struct {
     unsigned int bitoff;
     size_t bitlen[WHIRLPOOL_COUNTER / sizeof(size_t)];
 } WHIRLPOOL_CTX;
+#  endif
 
-int WHIRLPOOL_Init(WHIRLPOOL_CTX *c);
-int WHIRLPOOL_Update(WHIRLPOOL_CTX *c, const void *inp, size_t bytes);
-void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *inp, size_t bits);
-int WHIRLPOOL_Final(unsigned char *md, WHIRLPOOL_CTX *c);
-unsigned char *WHIRLPOOL(const void *inp, size_t bytes, unsigned char *md);
+DEPRECATEDIN_3_0(int WHIRLPOOL_Init(WHIRLPOOL_CTX *c))
+DEPRECATEDIN_3_0(int WHIRLPOOL_Update(WHIRLPOOL_CTX *c,
+                                      const void *inp, size_t bytes))
+DEPRECATEDIN_3_0(void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *inp,
+                                          size_t bits))
+DEPRECATEDIN_3_0(int WHIRLPOOL_Final(unsigned char *md, WHIRLPOOL_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *WHIRLPOOL(const void *inp, size_t bytes,
+                                          unsigned char *md))
 
-#  ifdef __cplusplus
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
+#   ifdef __cplusplus
 }
+#   endif
 #  endif
 # endif
 

--- a/providers/implementations/digests/wp_prov.c
+++ b/providers/implementations/digests/wp_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Whirlpool low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/whrlpool.h>
 #include "prov/digestcommon.h"

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -110,7 +110,7 @@ OCSP_CERTID_dup                         111	3_0_0	EXIST::FUNCTION:OCSP
 RSA_PSS_PARAMS_free                     112	3_0_0	EXIST::FUNCTION:RSA
 i2d_TS_MSG_IMPRINT                      113	3_0_0	EXIST::FUNCTION:TS
 EC_POINT_mul                            114	3_0_0	EXIST::FUNCTION:EC
-WHIRLPOOL_Final                         115	3_0_0	EXIST::FUNCTION:WHIRLPOOL
+WHIRLPOOL_Final                         115	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,WHIRLPOOL
 CMS_get1_ReceiptRequest                 116	3_0_0	EXIST::FUNCTION:CMS
 BIO_sock_non_fatal_error                117	3_0_0	EXIST::FUNCTION:SOCK
 HMAC_Update                             118	3_0_0	EXIST::FUNCTION:
@@ -262,7 +262,7 @@ EVP_seed_ecb                            267	3_0_0	EXIST::FUNCTION:SEED
 BIO_dgram_sctp_wait_for_dry             268	3_0_0	EXIST::FUNCTION:DGRAM,SCTP
 ASN1_OCTET_STRING_NDEF_it               269	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_get_count                 270	3_0_0	EXIST::FUNCTION:
-WHIRLPOOL_Init                          271	3_0_0	EXIST::FUNCTION:WHIRLPOOL
+WHIRLPOOL_Init                          271	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,WHIRLPOOL
 EVP_OpenInit                            272	3_0_0	EXIST::FUNCTION:RSA
 OCSP_response_get1_basic                273	3_0_0	EXIST::FUNCTION:OCSP
 CRYPTO_gcm128_tag                       274	3_0_0	EXIST::FUNCTION:
@@ -487,7 +487,7 @@ BN_get_rfc3526_prime_3072               496	3_0_0	EXIST::FUNCTION:
 X509_INFO_new                           497	3_0_0	EXIST::FUNCTION:
 OCSP_RESPDATA_it                        498	3_0_0	EXIST::FUNCTION:OCSP
 X509_CRL_print                          499	3_0_0	EXIST::FUNCTION:
-WHIRLPOOL_Update                        500	3_0_0	EXIST::FUNCTION:WHIRLPOOL
+WHIRLPOOL_Update                        500	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,WHIRLPOOL
 DSA_get_ex_data                         501	3_0_0	EXIST::FUNCTION:DSA
 BN_copy                                 502	3_0_0	EXIST::FUNCTION:
 FIPS_mode_set                           503	3_0_0	EXIST::FUNCTION:
@@ -2157,7 +2157,7 @@ TS_ACCURACY_set_millis                  2204	3_0_0	EXIST::FUNCTION:TS
 X509V3_EXT_conf                         2205	3_0_0	EXIST::FUNCTION:
 i2d_DHxparams                           2206	3_0_0	EXIST::FUNCTION:DH
 EVP_CIPHER_CTX_free                     2207	3_0_0	EXIST::FUNCTION:
-WHIRLPOOL_BitUpdate                     2208	3_0_0	EXIST::FUNCTION:WHIRLPOOL
+WHIRLPOOL_BitUpdate                     2208	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,WHIRLPOOL
 EVP_idea_ecb                            2209	3_0_0	EXIST::FUNCTION:IDEA
 i2d_TS_ACCURACY                         2210	3_0_0	EXIST::FUNCTION:TS
 ASN1_VISIBLESTRING_free                 2211	3_0_0	EXIST::FUNCTION:
@@ -2484,7 +2484,7 @@ CMS_signed_get0_data_by_OBJ             2536	3_0_0	EXIST::FUNCTION:CMS
 X509_PURPOSE_add                        2537	3_0_0	EXIST::FUNCTION:
 PKCS7_ENVELOPE_free                     2538	3_0_0	EXIST::FUNCTION:
 PKCS12_key_gen_uni                      2539	3_0_0	EXIST::FUNCTION:
-WHIRLPOOL                               2540	3_0_0	EXIST::FUNCTION:WHIRLPOOL
+WHIRLPOOL                               2540	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,WHIRLPOOL
 UI_set_default_method                   2542	3_0_0	EXIST::FUNCTION:
 EC_POINT_is_at_infinity                 2543	3_0_0	EXIST::FUNCTION:EC
 i2d_NOTICEREF                           2544	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use of the low level Whirlpool functions has been informally discouraged for a
long time.  We now formally deprecate them.

Applications should instead use the EVP APIs, e.g. EVP_Digest,
EVP_DigestInit_ex, EVP_DigestUpdate and EVP_DigestFinal_ex.

- [x] documentation is added or updated

