### PR TITLE
Reduce the security bits for MD5 and SHA1 based signatures in TLS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,14 @@ OpenSSL 3.0
 
    *Paul Dale*
 
+ * The security strength of SHA1 and MD5 based signatures in TLS has been
+   reduced. This results in SSL 3, TLS 1.0, TLS 1.1 and DTLS 1.0 no longer
+   working at the default security level of 1 and instead requires security
+   level 0. The security level can be changed either using the cipher string
+   with @SECLEVEL, or calling SSL_CTX_set_security_level().
+
+   *Kurt Roeckx*
+
  * EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH(), and
    EVP_PKEY_get0_EC_KEY() can now handle EVP_PKEYs with provider side
    internal keys, if they correspond to one of those built in types.

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,7 @@ OpenSSL 3.0
     RC4, RC5 and SEED cipher functions have been deprecated.
   * All of the low level DH, DSA, ECDH, ECDSA and RSA public key functions
     have been deprecated.
+  * SSL 3, TLS 1.0, TLS 1.1, and DTLS 1.0 only work at security level 0.
 
 OpenSSL 1.1.1
 -------------

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1119,8 +1119,26 @@ static int sigalg_security_bits(SSL_CTX *ctx, const SIGALG_LOOKUP *lu)
         return 0;
     if (md != NULL)
     {
+        int md_type = EVP_MD_type(md);
+
         /* Security bits: half digest bits */
         secbits = EVP_MD_size(md) * 4;
+        /*
+         * SHA1 and MD5 are known to be broken. Reduce security bits so that
+         * they're no longer accepted at security level 1. The real values don't
+         * really matter as long as they're lower than 80, which is our
+         * security level 1.
+         * https://eprint.iacr.org/2020/014 puts a chosen-prefix attack for
+         * SHA1 at 2^63.4 and MD5+SHA1 at 2^67.2
+         * https://documents.epfl.ch/users/l/le/lenstra/public/papers/lat.pdf
+         * puts a chosen-prefix attack for MD5 at 2^39.
+	 */
+        if (md_type == NID_sha1)
+            secbits = 64;
+        else if (md_type == NID_md5_sha1)
+            secbits = 67;
+        else if (md_type == NID_md5)
+            secbits = 39;
     } else {
         /* Values from https://tools.ietf.org/html/rfc8032#section-8.5 */
         if (lu->sigalg == TLSEXT_SIGALG_ed25519)

--- a/test/recipes/70-test_renegotiation.t
+++ b/test/recipes/70-test_renegotiation.t
@@ -56,7 +56,8 @@ SKIP: {
     #        handshake
     $proxy->clear();
     $proxy->filter(undef);
-    $proxy->clientflags("-no_tls1_3");
+    $proxy->ciphers("DEFAULT:\@SECLEVEL=0");
+    $proxy->clientflags("-no_tls1_3 -cipher AES128-SHA:\@SECLEVEL=0");
     $proxy->serverflags("-no_tls1_3 -no_tls1_2");
     $proxy->reneg(1);
     $proxy->start();

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -206,6 +206,7 @@ SKIP: {
     #Test 3: Sending a zero length extension block should pass
     $proxy->clear();
     $proxy->filter(\&extension_filter);
+    $proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
     $proxy->start();
     ok(TLSProxy::Message->success, "Zero extension length test");
 

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -82,11 +82,17 @@ use constant {
     FRAGMENTED_IN_SSLV2 => 3,
     ALERT_BEFORE_SSLV2 => 4
 };
+
+# The TLSv1.2 in SSLv2 ClientHello need to run at security level 0
+# because in a SSLv2 ClientHello we can't send extentions to indicate
+# which signature algorithm we want to use, and the default is SHA1.
+
 #Test 5: Inject an SSLv2 style record format for a TLSv1.2 ClientHello
 my $sslv2testtype = TLSV1_2_IN_SSLV2;
 $proxy->clear();
 $proxy->filter(\&add_sslv2_filter);
 $proxy->serverflags("-tls1_2");
+$proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $proxy->start();
 ok(TLSProxy::Message->success(), "TLSv1.2 in SSLv2 ClientHello test");
 
@@ -96,6 +102,7 @@ ok(TLSProxy::Message->success(), "TLSv1.2 in SSLv2 ClientHello test");
 $sslv2testtype = SSLV2_IN_SSLV2;
 $proxy->clear();
 $proxy->serverflags("-tls1_2");
+$proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "SSLv2 in SSLv2 ClientHello test");
 
@@ -105,6 +112,7 @@ ok(TLSProxy::Message->fail(), "SSLv2 in SSLv2 ClientHello test");
 $sslv2testtype = FRAGMENTED_IN_TLSV1_2;
 $proxy->clear();
 $proxy->serverflags("-tls1_2");
+$proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $proxy->start();
 ok(TLSProxy::Message->success(), "Fragmented ClientHello in TLSv1.2 test");
 
@@ -113,6 +121,7 @@ ok(TLSProxy::Message->success(), "Fragmented ClientHello in TLSv1.2 test");
 $sslv2testtype = FRAGMENTED_IN_SSLV2;
 $proxy->clear();
 $proxy->serverflags("-tls1_2");
+$proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Fragmented ClientHello in TLSv1.2/SSLv2 test");
 
@@ -121,6 +130,7 @@ ok(TLSProxy::Message->fail(), "Fragmented ClientHello in TLSv1.2/SSLv2 test");
 $sslv2testtype = ALERT_BEFORE_SSLV2;
 $proxy->clear();
 $proxy->serverflags("-tls1_2");
+$proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Alert before SSLv2 ClientHello test");
 
@@ -140,7 +150,8 @@ SKIP: {
     #Test 11: Sending an unrecognised record type in TLS1.1 should fail
     $fatal_alert = 0;
     $proxy->clear();
-    $proxy->clientflags("-tls1_1");
+    $proxy->clientflags("-tls1_1 -cipher DEFAULT:\@SECLEVEL=0");
+    $proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
     $proxy->start();
     ok($fatal_alert, "Unrecognised record type in TLS1.1");
 }

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -138,32 +138,32 @@ SKIP: {
 
     $proxy->filter(\&sigalgs_filter);
 
-    #Test 10: Sending no sig algs extension in TLSv1.2 should succeed at
-    #         security level 1
+    #Test 10: Sending no sig algs extension in TLSv1.2 will make it use
+    #         SHA1, which is only supported at security level 0.
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-no_tls1_3 -cipher DEFAULT:\@SECLEVEL=1");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA:\@SECLEVEL=1");
+    $proxy->clientflags("-no_tls1_3 -cipher DEFAULT:\@SECLEVEL=0");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA:\@SECLEVEL=0");
     $proxy->start();
-    ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs seclevel 1");
+    ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs seclevel 0");
 
     #Test 11: Sending no sig algs extension in TLSv1.2 should fail at security
-    #         level 2 since it will try to use SHA1. Testing client at level 1,
-    #         server level 2.
-    $proxy->clear();
-    $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-tls1_2 -cipher DEFAULT:\@SECLEVEL=1");
-    $proxy->ciphers("DEFAULT:\@SECLEVEL=2");
-    $proxy->start();
-    ok(TLSProxy::Message->fail, "No TLSv1.2 sigalgs server seclevel 2");
-
-    #Test 12: Sending no sig algs extension in TLSv1.2 should fail at security
-    #         level 2 since it will try to use SHA1. Testing client at level 2,
+    #         level 1 since it will try to use SHA1. Testing client at level 0,
     #         server level 1.
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-tls1_2 -cipher DEFAULT:\@SECLEVEL=2");
+    $proxy->clientflags("-tls1_2 -cipher DEFAULT:\@SECLEVEL=0");
     $proxy->ciphers("DEFAULT:\@SECLEVEL=1");
+    $proxy->start();
+    ok(TLSProxy::Message->fail, "No TLSv1.2 sigalgs server seclevel 1");
+
+    #Test 12: Sending no sig algs extension in TLSv1.2 should fail at security
+    #         level 1 since it will try to use SHA1. Testing client at level 1,
+    #         server level 0.
+    $proxy->clear();
+    $testtype = NO_SIG_ALGS_EXT;
+    $proxy->clientflags("-tls1_2 -cipher DEFAULT:\@SECLEVEL=1");
+    $proxy->ciphers("DEFAULT:\@SECLEVEL=0");
     $proxy->start();
     ok(TLSProxy::Message->fail, "No TLSv1.2 sigalgs client seclevel 2");
 
@@ -221,15 +221,16 @@ SKIP: {
     ok(TLSProxy::Message->fail, "No matching TLSv1.2 sigalgs");
     $proxy->filter(\&sigalgs_filter);
 
-    #Test 19: No sig algs extension, ECDSA cert, TLSv1.2 should succeed
+    #Test 19: No sig algs extension, ECDSA cert, will use SHA1,
+    #         TLSv1.2 should succeed at security level 0
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-no_tls1_3");
+    $proxy->clientflags("-no_tls1_3 -cipher DEFAULT:\@SECLEVEL=0");
     $proxy->serverflags("-cert " . srctop_file("test", "certs",
                                                "server-ecdsa-cert.pem") .
                         " -key " . srctop_file("test", "certs",
                                                "server-ecdsa-key.pem")),
-    $proxy->ciphers("ECDHE-ECDSA-AES128-SHA");
+    $proxy->ciphers("ECDHE-ECDSA-AES128-SHA:\@SECLEVEL=0");
     $proxy->start();
     ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs, ECDSA");
 }
@@ -245,7 +246,7 @@ SKIP: {
     $proxy->filter(\&modify_sigalgs_filter);
     $proxy->start();
     ok($dsa_status && $sha1_status && $sha224_status,
-       "DSA/SHA2 sigalg sent for 1.3-only ClientHello");
+       "DSA and SHA1 sigalgs not sent for 1.3-only ClientHello");
 
     #Test 21: signature_algorithms with backwards compatible ClientHello
     SKIP: {
@@ -253,10 +254,11 @@ SKIP: {
         $testtype = COMPAT_SIGALGS;
         $dsa_status = $sha1_status = $sha224_status = 0;
         $proxy->clear();
+        $proxy->clientflags("-cipher AES128-SHA\@SECLEVEL=0");
         $proxy->filter(\&modify_sigalgs_filter);
         $proxy->start();
         ok($dsa_status && $sha1_status && $sha224_status,
-           "DSA sigalg not sent for compat ClientHello");
+           "backwards compatible sigalg sent for compat ClientHello");
    }
 }
 

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -142,8 +142,8 @@ SKIP: {
     #         security level 1
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-no_tls1_3 -cipher DEFAULT\@SECLEVEL=1");
-    $proxy->ciphers("ECDHE-RSA-AES128-SHA\@SECLEVEL=1");
+    $proxy->clientflags("-no_tls1_3 -cipher DEFAULT:\@SECLEVEL=1");
+    $proxy->ciphers("ECDHE-RSA-AES128-SHA:\@SECLEVEL=1");
     $proxy->start();
     ok(TLSProxy::Message->success, "No TLSv1.2 sigalgs seclevel 1");
 
@@ -152,8 +152,8 @@ SKIP: {
     #         server level 2.
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-tls1_2 -cipher DEFAULT\@SECLEVEL=1");
-    $proxy->ciphers("DEFAULT\@SECLEVEL=2");
+    $proxy->clientflags("-tls1_2 -cipher DEFAULT:\@SECLEVEL=1");
+    $proxy->ciphers("DEFAULT:\@SECLEVEL=2");
     $proxy->start();
     ok(TLSProxy::Message->fail, "No TLSv1.2 sigalgs server seclevel 2");
 
@@ -162,8 +162,8 @@ SKIP: {
     #         server level 1.
     $proxy->clear();
     $testtype = NO_SIG_ALGS_EXT;
-    $proxy->clientflags("-tls1_2 -cipher DEFAULT\@SECLEVEL=2");
-    $proxy->ciphers("DEFAULT\@SECLEVEL=1");
+    $proxy->clientflags("-tls1_2 -cipher DEFAULT:\@SECLEVEL=2");
+    $proxy->ciphers("DEFAULT:\@SECLEVEL=1");
     $proxy->start();
     ok(TLSProxy::Message->fail, "No TLSv1.2 sigalgs client seclevel 2");
 

--- a/test/recipes/70-test_sslversions.t
+++ b/test/recipes/70-test_sslversions.t
@@ -95,6 +95,8 @@ ok(TLSProxy::Message->success()
 #Test 6: no TLSv1.3 or TLSv1.2 version in supported versions extension, but
 #TLSv1.1 and TLSv1.0 are present. Should just use TLSv1.1 and succeed
 $proxy->clear();
+$proxy->clientflags("-cipher DEFAULT:\@SECLEVEL=0");
+$proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $testtype = TLS1_1_AND_1_0_ONLY;
 $proxy->start();
 $record = pop @{$proxy->record_list};

--- a/test/recipes/70-test_tls13downgrade.t
+++ b/test/recipes/70-test_tls13downgrade.t
@@ -79,6 +79,7 @@ SKIP: {
     $proxy->clear();
     $proxy->filter(undef);
     $proxy->clientflags("-no_tls1_2");
+    $proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
     $proxy->start();
     ok(TLSProxy::Message->success(), "TLSv1.2 client-side protocol hole");
 

--- a/test/ssl-tests/02-protocol-version.cnf
+++ b/test/ssl-tests/02-protocol-version.cnf
@@ -691,12 +691,12 @@ client = 0-version-negotiation-client
 
 [0-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -716,12 +716,12 @@ client = 1-version-negotiation-client
 
 [1-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -741,12 +741,12 @@ client = 2-version-negotiation-client
 
 [2-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -766,12 +766,12 @@ client = 3-version-negotiation-client
 
 [3-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -791,12 +791,12 @@ client = 4-version-negotiation-client
 
 [4-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -816,11 +816,11 @@ client = 5-version-negotiation-client
 
 [5-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -840,13 +840,13 @@ client = 6-version-negotiation-client
 
 [6-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -866,13 +866,13 @@ client = 7-version-negotiation-client
 
 [7-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -892,13 +892,13 @@ client = 8-version-negotiation-client
 
 [8-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -918,13 +918,13 @@ client = 9-version-negotiation-client
 
 [9-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -944,13 +944,13 @@ client = 10-version-negotiation-client
 
 [10-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -970,12 +970,12 @@ client = 11-version-negotiation-client
 
 [11-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [11-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -995,13 +995,13 @@ client = 12-version-negotiation-client
 
 [12-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1021,13 +1021,13 @@ client = 13-version-negotiation-client
 
 [13-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [13-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1047,13 +1047,13 @@ client = 14-version-negotiation-client
 
 [14-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [14-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1073,13 +1073,13 @@ client = 15-version-negotiation-client
 
 [15-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [15-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1099,12 +1099,12 @@ client = 16-version-negotiation-client
 
 [16-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [16-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1124,13 +1124,13 @@ client = 17-version-negotiation-client
 
 [17-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [17-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1150,13 +1150,13 @@ client = 18-version-negotiation-client
 
 [18-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [18-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1176,13 +1176,13 @@ client = 19-version-negotiation-client
 
 [19-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [19-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1202,12 +1202,12 @@ client = 20-version-negotiation-client
 
 [20-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [20-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1227,13 +1227,13 @@ client = 21-version-negotiation-client
 
 [21-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [21-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1253,13 +1253,13 @@ client = 22-version-negotiation-client
 
 [22-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [22-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1279,12 +1279,12 @@ client = 23-version-negotiation-client
 
 [23-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [23-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1304,13 +1304,13 @@ client = 24-version-negotiation-client
 
 [24-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [24-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1330,12 +1330,12 @@ client = 25-version-negotiation-client
 
 [25-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [25-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1355,12 +1355,12 @@ client = 26-version-negotiation-client
 
 [26-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [26-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1380,12 +1380,12 @@ client = 27-version-negotiation-client
 
 [27-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [27-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1406,12 +1406,12 @@ client = 28-version-negotiation-client
 
 [28-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [28-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1432,12 +1432,12 @@ client = 29-version-negotiation-client
 
 [29-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [29-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1458,12 +1458,12 @@ client = 30-version-negotiation-client
 
 [30-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [30-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1484,11 +1484,11 @@ client = 31-version-negotiation-client
 
 [31-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [31-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1509,13 +1509,13 @@ client = 32-version-negotiation-client
 
 [32-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [32-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1535,13 +1535,13 @@ client = 33-version-negotiation-client
 
 [33-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [33-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1562,13 +1562,13 @@ client = 34-version-negotiation-client
 
 [34-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [34-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1589,13 +1589,13 @@ client = 35-version-negotiation-client
 
 [35-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [35-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1616,13 +1616,13 @@ client = 36-version-negotiation-client
 
 [36-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [36-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1643,12 +1643,12 @@ client = 37-version-negotiation-client
 
 [37-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [37-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1669,13 +1669,13 @@ client = 38-version-negotiation-client
 
 [38-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [38-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1696,13 +1696,13 @@ client = 39-version-negotiation-client
 
 [39-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [39-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1723,13 +1723,13 @@ client = 40-version-negotiation-client
 
 [40-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [40-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1750,13 +1750,13 @@ client = 41-version-negotiation-client
 
 [41-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [41-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1777,12 +1777,12 @@ client = 42-version-negotiation-client
 
 [42-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [42-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1803,13 +1803,13 @@ client = 43-version-negotiation-client
 
 [43-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [43-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1829,13 +1829,13 @@ client = 44-version-negotiation-client
 
 [44-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [44-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1855,13 +1855,13 @@ client = 45-version-negotiation-client
 
 [45-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [45-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1881,12 +1881,12 @@ client = 46-version-negotiation-client
 
 [46-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [46-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1906,13 +1906,13 @@ client = 47-version-negotiation-client
 
 [47-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [47-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1932,13 +1932,13 @@ client = 48-version-negotiation-client
 
 [48-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [48-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1958,12 +1958,12 @@ client = 49-version-negotiation-client
 
 [49-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [49-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1983,13 +1983,13 @@ client = 50-version-negotiation-client
 
 [50-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [50-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2009,12 +2009,12 @@ client = 51-version-negotiation-client
 
 [51-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [51-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2034,12 +2034,12 @@ client = 52-version-negotiation-client
 
 [52-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [52-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2059,12 +2059,12 @@ client = 53-version-negotiation-client
 
 [53-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [53-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2085,12 +2085,12 @@ client = 54-version-negotiation-client
 
 [54-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [54-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2111,12 +2111,12 @@ client = 55-version-negotiation-client
 
 [55-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [55-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2137,12 +2137,12 @@ client = 56-version-negotiation-client
 
 [56-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [56-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2163,11 +2163,11 @@ client = 57-version-negotiation-client
 
 [57-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [57-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2188,13 +2188,13 @@ client = 58-version-negotiation-client
 
 [58-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [58-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2214,13 +2214,13 @@ client = 59-version-negotiation-client
 
 [59-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [59-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2241,13 +2241,13 @@ client = 60-version-negotiation-client
 
 [60-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [60-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2268,13 +2268,13 @@ client = 61-version-negotiation-client
 
 [61-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [61-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2295,13 +2295,13 @@ client = 62-version-negotiation-client
 
 [62-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [62-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2322,12 +2322,12 @@ client = 63-version-negotiation-client
 
 [63-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [63-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2348,13 +2348,13 @@ client = 64-version-negotiation-client
 
 [64-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [64-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2375,13 +2375,13 @@ client = 65-version-negotiation-client
 
 [65-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [65-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2402,13 +2402,13 @@ client = 66-version-negotiation-client
 
 [66-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [66-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2429,13 +2429,13 @@ client = 67-version-negotiation-client
 
 [67-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [67-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2456,12 +2456,12 @@ client = 68-version-negotiation-client
 
 [68-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [68-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2482,13 +2482,13 @@ client = 69-version-negotiation-client
 
 [69-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [69-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2509,13 +2509,13 @@ client = 70-version-negotiation-client
 
 [70-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [70-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2536,13 +2536,13 @@ client = 71-version-negotiation-client
 
 [71-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [71-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2563,12 +2563,12 @@ client = 72-version-negotiation-client
 
 [72-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [72-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2589,13 +2589,13 @@ client = 73-version-negotiation-client
 
 [73-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [73-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2615,13 +2615,13 @@ client = 74-version-negotiation-client
 
 [74-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [74-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2641,12 +2641,12 @@ client = 75-version-negotiation-client
 
 [75-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [75-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2666,13 +2666,13 @@ client = 76-version-negotiation-client
 
 [76-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [76-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2692,12 +2692,12 @@ client = 77-version-negotiation-client
 
 [77-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [77-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2717,12 +2717,12 @@ client = 78-version-negotiation-client
 
 [78-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [78-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2742,12 +2742,12 @@ client = 79-version-negotiation-client
 
 [79-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [79-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2768,12 +2768,12 @@ client = 80-version-negotiation-client
 
 [80-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [80-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2794,12 +2794,12 @@ client = 81-version-negotiation-client
 
 [81-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [81-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2820,12 +2820,12 @@ client = 82-version-negotiation-client
 
 [82-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [82-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2846,11 +2846,11 @@ client = 83-version-negotiation-client
 
 [83-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [83-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2871,13 +2871,13 @@ client = 84-version-negotiation-client
 
 [84-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [84-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2897,13 +2897,13 @@ client = 85-version-negotiation-client
 
 [85-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [85-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2924,13 +2924,13 @@ client = 86-version-negotiation-client
 
 [86-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [86-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2951,13 +2951,13 @@ client = 87-version-negotiation-client
 
 [87-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [87-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2978,13 +2978,13 @@ client = 88-version-negotiation-client
 
 [88-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [88-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3005,12 +3005,12 @@ client = 89-version-negotiation-client
 
 [89-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [89-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3031,13 +3031,13 @@ client = 90-version-negotiation-client
 
 [90-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [90-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3058,13 +3058,13 @@ client = 91-version-negotiation-client
 
 [91-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [91-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3085,13 +3085,13 @@ client = 92-version-negotiation-client
 
 [92-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [92-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3112,13 +3112,13 @@ client = 93-version-negotiation-client
 
 [93-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [93-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3139,12 +3139,12 @@ client = 94-version-negotiation-client
 
 [94-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [94-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3165,13 +3165,13 @@ client = 95-version-negotiation-client
 
 [95-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [95-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3192,13 +3192,13 @@ client = 96-version-negotiation-client
 
 [96-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [96-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3219,13 +3219,13 @@ client = 97-version-negotiation-client
 
 [97-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [97-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3246,12 +3246,12 @@ client = 98-version-negotiation-client
 
 [98-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [98-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3272,13 +3272,13 @@ client = 99-version-negotiation-client
 
 [99-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [99-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3299,13 +3299,13 @@ client = 100-version-negotiation-client
 
 [100-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [100-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3326,12 +3326,12 @@ client = 101-version-negotiation-client
 
 [101-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [101-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3352,13 +3352,13 @@ client = 102-version-negotiation-client
 
 [102-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [102-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3378,12 +3378,12 @@ client = 103-version-negotiation-client
 
 [103-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [103-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3403,12 +3403,12 @@ client = 104-version-negotiation-client
 
 [104-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [104-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3428,12 +3428,12 @@ client = 105-version-negotiation-client
 
 [105-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [105-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3454,12 +3454,12 @@ client = 106-version-negotiation-client
 
 [106-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [106-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3480,12 +3480,12 @@ client = 107-version-negotiation-client
 
 [107-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [107-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3506,12 +3506,12 @@ client = 108-version-negotiation-client
 
 [108-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [108-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3532,11 +3532,11 @@ client = 109-version-negotiation-client
 
 [109-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [109-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3557,13 +3557,13 @@ client = 110-version-negotiation-client
 
 [110-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [110-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3583,13 +3583,13 @@ client = 111-version-negotiation-client
 
 [111-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [111-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3610,13 +3610,13 @@ client = 112-version-negotiation-client
 
 [112-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [112-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3637,13 +3637,13 @@ client = 113-version-negotiation-client
 
 [113-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [113-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3664,13 +3664,13 @@ client = 114-version-negotiation-client
 
 [114-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [114-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3691,12 +3691,12 @@ client = 115-version-negotiation-client
 
 [115-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [115-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3717,13 +3717,13 @@ client = 116-version-negotiation-client
 
 [116-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [116-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3744,13 +3744,13 @@ client = 117-version-negotiation-client
 
 [117-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [117-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3771,13 +3771,13 @@ client = 118-version-negotiation-client
 
 [118-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [118-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3798,13 +3798,13 @@ client = 119-version-negotiation-client
 
 [119-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [119-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3825,12 +3825,12 @@ client = 120-version-negotiation-client
 
 [120-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [120-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3851,13 +3851,13 @@ client = 121-version-negotiation-client
 
 [121-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [121-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3878,13 +3878,13 @@ client = 122-version-negotiation-client
 
 [122-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [122-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3905,13 +3905,13 @@ client = 123-version-negotiation-client
 
 [123-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [123-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3932,12 +3932,12 @@ client = 124-version-negotiation-client
 
 [124-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [124-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3958,13 +3958,13 @@ client = 125-version-negotiation-client
 
 [125-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [125-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -3985,13 +3985,13 @@ client = 126-version-negotiation-client
 
 [126-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [126-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -4012,12 +4012,12 @@ client = 127-version-negotiation-client
 
 [127-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [127-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -4038,13 +4038,13 @@ client = 128-version-negotiation-client
 
 [128-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [128-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -4065,12 +4065,12 @@ client = 129-version-negotiation-client
 
 [129-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [129-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -4091,12 +4091,12 @@ client = 130-version-negotiation-client
 
 [130-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [130-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4115,12 +4115,12 @@ client = 131-version-negotiation-client
 
 [131-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [131-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4140,12 +4140,12 @@ client = 132-version-negotiation-client
 
 [132-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [132-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4165,12 +4165,12 @@ client = 133-version-negotiation-client
 
 [133-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [133-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4190,12 +4190,12 @@ client = 134-version-negotiation-client
 
 [134-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [134-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4215,11 +4215,11 @@ client = 135-version-negotiation-client
 
 [135-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [135-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4239,13 +4239,13 @@ client = 136-version-negotiation-client
 
 [136-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [136-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4264,13 +4264,13 @@ client = 137-version-negotiation-client
 
 [137-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [137-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4290,13 +4290,13 @@ client = 138-version-negotiation-client
 
 [138-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [138-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4316,13 +4316,13 @@ client = 139-version-negotiation-client
 
 [139-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [139-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4342,13 +4342,13 @@ client = 140-version-negotiation-client
 
 [140-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [140-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4368,12 +4368,12 @@ client = 141-version-negotiation-client
 
 [141-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [141-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4393,13 +4393,13 @@ client = 142-version-negotiation-client
 
 [142-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [142-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4419,13 +4419,13 @@ client = 143-version-negotiation-client
 
 [143-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [143-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4445,13 +4445,13 @@ client = 144-version-negotiation-client
 
 [144-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [144-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4471,13 +4471,13 @@ client = 145-version-negotiation-client
 
 [145-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [145-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4497,12 +4497,12 @@ client = 146-version-negotiation-client
 
 [146-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [146-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4522,13 +4522,13 @@ client = 147-version-negotiation-client
 
 [147-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [147-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4548,13 +4548,13 @@ client = 148-version-negotiation-client
 
 [148-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [148-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4574,13 +4574,13 @@ client = 149-version-negotiation-client
 
 [149-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [149-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4600,12 +4600,12 @@ client = 150-version-negotiation-client
 
 [150-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [150-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4625,13 +4625,13 @@ client = 151-version-negotiation-client
 
 [151-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [151-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4651,13 +4651,13 @@ client = 152-version-negotiation-client
 
 [152-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [152-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4677,12 +4677,12 @@ client = 153-version-negotiation-client
 
 [153-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [153-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4702,13 +4702,13 @@ client = 154-version-negotiation-client
 
 [154-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [154-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4728,12 +4728,12 @@ client = 155-version-negotiation-client
 
 [155-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [155-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -4753,12 +4753,12 @@ client = 156-version-negotiation-client
 
 [156-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [156-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4779,12 +4779,12 @@ client = 157-version-negotiation-client
 
 [157-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [157-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4805,12 +4805,12 @@ client = 158-version-negotiation-client
 
 [158-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [158-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4831,12 +4831,12 @@ client = 159-version-negotiation-client
 
 [159-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [159-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4857,12 +4857,12 @@ client = 160-version-negotiation-client
 
 [160-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [160-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4883,11 +4883,11 @@ client = 161-version-negotiation-client
 
 [161-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [161-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4908,13 +4908,13 @@ client = 162-version-negotiation-client
 
 [162-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [162-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4935,13 +4935,13 @@ client = 163-version-negotiation-client
 
 [163-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [163-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4962,13 +4962,13 @@ client = 164-version-negotiation-client
 
 [164-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [164-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -4989,13 +4989,13 @@ client = 165-version-negotiation-client
 
 [165-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [165-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5016,13 +5016,13 @@ client = 166-version-negotiation-client
 
 [166-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [166-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5043,12 +5043,12 @@ client = 167-version-negotiation-client
 
 [167-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [167-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5069,13 +5069,13 @@ client = 168-version-negotiation-client
 
 [168-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [168-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5096,13 +5096,13 @@ client = 169-version-negotiation-client
 
 [169-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [169-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5123,13 +5123,13 @@ client = 170-version-negotiation-client
 
 [170-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [170-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5150,13 +5150,13 @@ client = 171-version-negotiation-client
 
 [171-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [171-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5177,12 +5177,12 @@ client = 172-version-negotiation-client
 
 [172-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [172-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5203,13 +5203,13 @@ client = 173-version-negotiation-client
 
 [173-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [173-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5230,13 +5230,13 @@ client = 174-version-negotiation-client
 
 [174-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [174-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5257,13 +5257,13 @@ client = 175-version-negotiation-client
 
 [175-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [175-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5284,12 +5284,12 @@ client = 176-version-negotiation-client
 
 [176-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [176-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5310,13 +5310,13 @@ client = 177-version-negotiation-client
 
 [177-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [177-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5337,13 +5337,13 @@ client = 178-version-negotiation-client
 
 [178-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [178-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5364,12 +5364,12 @@ client = 179-version-negotiation-client
 
 [179-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [179-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5390,13 +5390,13 @@ client = 180-version-negotiation-client
 
 [180-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [180-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5417,12 +5417,12 @@ client = 181-version-negotiation-client
 
 [181-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [181-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5443,12 +5443,12 @@ client = 182-version-negotiation-client
 
 [182-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [182-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5469,12 +5469,12 @@ client = 183-version-negotiation-client
 
 [183-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [183-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5496,12 +5496,12 @@ client = 184-version-negotiation-client
 
 [184-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [184-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5523,12 +5523,12 @@ client = 185-version-negotiation-client
 
 [185-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [185-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5550,12 +5550,12 @@ client = 186-version-negotiation-client
 
 [186-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [186-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5577,11 +5577,11 @@ client = 187-version-negotiation-client
 
 [187-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [187-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5603,13 +5603,13 @@ client = 188-version-negotiation-client
 
 [188-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [188-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5630,13 +5630,13 @@ client = 189-version-negotiation-client
 
 [189-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [189-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5658,13 +5658,13 @@ client = 190-version-negotiation-client
 
 [190-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [190-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5686,13 +5686,13 @@ client = 191-version-negotiation-client
 
 [191-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [191-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5714,13 +5714,13 @@ client = 192-version-negotiation-client
 
 [192-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [192-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5742,12 +5742,12 @@ client = 193-version-negotiation-client
 
 [193-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [193-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5769,13 +5769,13 @@ client = 194-version-negotiation-client
 
 [194-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [194-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5797,13 +5797,13 @@ client = 195-version-negotiation-client
 
 [195-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [195-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5825,13 +5825,13 @@ client = 196-version-negotiation-client
 
 [196-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [196-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5853,13 +5853,13 @@ client = 197-version-negotiation-client
 
 [197-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [197-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5881,12 +5881,12 @@ client = 198-version-negotiation-client
 
 [198-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [198-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5908,13 +5908,13 @@ client = 199-version-negotiation-client
 
 [199-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [199-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5935,13 +5935,13 @@ client = 200-version-negotiation-client
 
 [200-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [200-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5962,13 +5962,13 @@ client = 201-version-negotiation-client
 
 [201-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [201-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -5989,12 +5989,12 @@ client = 202-version-negotiation-client
 
 [202-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [202-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6015,13 +6015,13 @@ client = 203-version-negotiation-client
 
 [203-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [203-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6042,13 +6042,13 @@ client = 204-version-negotiation-client
 
 [204-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [204-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6069,12 +6069,12 @@ client = 205-version-negotiation-client
 
 [205-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [205-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6095,13 +6095,13 @@ client = 206-version-negotiation-client
 
 [206-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [206-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6122,12 +6122,12 @@ client = 207-version-negotiation-client
 
 [207-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [207-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6148,12 +6148,12 @@ client = 208-version-negotiation-client
 
 [208-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [208-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6174,12 +6174,12 @@ client = 209-version-negotiation-client
 
 [209-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [209-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6201,12 +6201,12 @@ client = 210-version-negotiation-client
 
 [210-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [210-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6228,12 +6228,12 @@ client = 211-version-negotiation-client
 
 [211-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [211-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6255,12 +6255,12 @@ client = 212-version-negotiation-client
 
 [212-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [212-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6282,11 +6282,11 @@ client = 213-version-negotiation-client
 
 [213-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [213-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6308,13 +6308,13 @@ client = 214-version-negotiation-client
 
 [214-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [214-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6335,13 +6335,13 @@ client = 215-version-negotiation-client
 
 [215-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [215-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6363,13 +6363,13 @@ client = 216-version-negotiation-client
 
 [216-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [216-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6391,13 +6391,13 @@ client = 217-version-negotiation-client
 
 [217-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [217-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6419,13 +6419,13 @@ client = 218-version-negotiation-client
 
 [218-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [218-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6447,12 +6447,12 @@ client = 219-version-negotiation-client
 
 [219-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [219-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6474,13 +6474,13 @@ client = 220-version-negotiation-client
 
 [220-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [220-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6502,13 +6502,13 @@ client = 221-version-negotiation-client
 
 [221-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [221-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6530,13 +6530,13 @@ client = 222-version-negotiation-client
 
 [222-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [222-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6558,13 +6558,13 @@ client = 223-version-negotiation-client
 
 [223-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [223-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6586,12 +6586,12 @@ client = 224-version-negotiation-client
 
 [224-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [224-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6613,13 +6613,13 @@ client = 225-version-negotiation-client
 
 [225-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [225-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6641,13 +6641,13 @@ client = 226-version-negotiation-client
 
 [226-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [226-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6669,13 +6669,13 @@ client = 227-version-negotiation-client
 
 [227-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [227-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6697,12 +6697,12 @@ client = 228-version-negotiation-client
 
 [228-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [228-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6724,13 +6724,13 @@ client = 229-version-negotiation-client
 
 [229-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [229-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6751,13 +6751,13 @@ client = 230-version-negotiation-client
 
 [230-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [230-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6778,12 +6778,12 @@ client = 231-version-negotiation-client
 
 [231-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [231-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6804,13 +6804,13 @@ client = 232-version-negotiation-client
 
 [232-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [232-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6831,12 +6831,12 @@ client = 233-version-negotiation-client
 
 [233-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [233-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6857,12 +6857,12 @@ client = 234-version-negotiation-client
 
 [234-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [234-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6883,12 +6883,12 @@ client = 235-version-negotiation-client
 
 [235-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [235-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6910,12 +6910,12 @@ client = 236-version-negotiation-client
 
 [236-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [236-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6937,12 +6937,12 @@ client = 237-version-negotiation-client
 
 [237-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [237-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6964,12 +6964,12 @@ client = 238-version-negotiation-client
 
 [238-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [238-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -6991,11 +6991,11 @@ client = 239-version-negotiation-client
 
 [239-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [239-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7017,13 +7017,13 @@ client = 240-version-negotiation-client
 
 [240-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [240-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7044,13 +7044,13 @@ client = 241-version-negotiation-client
 
 [241-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [241-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7072,13 +7072,13 @@ client = 242-version-negotiation-client
 
 [242-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [242-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7100,13 +7100,13 @@ client = 243-version-negotiation-client
 
 [243-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [243-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7128,13 +7128,13 @@ client = 244-version-negotiation-client
 
 [244-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [244-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7156,12 +7156,12 @@ client = 245-version-negotiation-client
 
 [245-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [245-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7183,13 +7183,13 @@ client = 246-version-negotiation-client
 
 [246-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [246-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7211,13 +7211,13 @@ client = 247-version-negotiation-client
 
 [247-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [247-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7239,13 +7239,13 @@ client = 248-version-negotiation-client
 
 [248-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [248-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7267,13 +7267,13 @@ client = 249-version-negotiation-client
 
 [249-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [249-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7295,12 +7295,12 @@ client = 250-version-negotiation-client
 
 [250-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [250-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7322,13 +7322,13 @@ client = 251-version-negotiation-client
 
 [251-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [251-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7350,13 +7350,13 @@ client = 252-version-negotiation-client
 
 [252-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [252-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7378,13 +7378,13 @@ client = 253-version-negotiation-client
 
 [253-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [253-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7406,12 +7406,12 @@ client = 254-version-negotiation-client
 
 [254-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [254-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7433,13 +7433,13 @@ client = 255-version-negotiation-client
 
 [255-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [255-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7461,13 +7461,13 @@ client = 256-version-negotiation-client
 
 [256-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [256-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7489,12 +7489,12 @@ client = 257-version-negotiation-client
 
 [257-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [257-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7516,13 +7516,13 @@ client = 258-version-negotiation-client
 
 [258-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [258-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7543,12 +7543,12 @@ client = 259-version-negotiation-client
 
 [259-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [259-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7569,12 +7569,12 @@ client = 260-version-negotiation-client
 
 [260-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [260-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7595,12 +7595,12 @@ client = 261-version-negotiation-client
 
 [261-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [261-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7622,12 +7622,12 @@ client = 262-version-negotiation-client
 
 [262-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [262-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7649,12 +7649,12 @@ client = 263-version-negotiation-client
 
 [263-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [263-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7676,12 +7676,12 @@ client = 264-version-negotiation-client
 
 [264-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [264-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7703,11 +7703,11 @@ client = 265-version-negotiation-client
 
 [265-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [265-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7729,13 +7729,13 @@ client = 266-version-negotiation-client
 
 [266-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [266-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7756,13 +7756,13 @@ client = 267-version-negotiation-client
 
 [267-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [267-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7784,13 +7784,13 @@ client = 268-version-negotiation-client
 
 [268-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [268-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7812,13 +7812,13 @@ client = 269-version-negotiation-client
 
 [269-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [269-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7840,13 +7840,13 @@ client = 270-version-negotiation-client
 
 [270-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [270-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7868,12 +7868,12 @@ client = 271-version-negotiation-client
 
 [271-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [271-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7895,13 +7895,13 @@ client = 272-version-negotiation-client
 
 [272-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [272-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7923,13 +7923,13 @@ client = 273-version-negotiation-client
 
 [273-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [273-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7951,13 +7951,13 @@ client = 274-version-negotiation-client
 
 [274-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [274-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -7979,13 +7979,13 @@ client = 275-version-negotiation-client
 
 [275-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [275-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8007,12 +8007,12 @@ client = 276-version-negotiation-client
 
 [276-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [276-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8034,13 +8034,13 @@ client = 277-version-negotiation-client
 
 [277-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [277-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8062,13 +8062,13 @@ client = 278-version-negotiation-client
 
 [278-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [278-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8090,13 +8090,13 @@ client = 279-version-negotiation-client
 
 [279-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [279-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8118,12 +8118,12 @@ client = 280-version-negotiation-client
 
 [280-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [280-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8145,13 +8145,13 @@ client = 281-version-negotiation-client
 
 [281-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [281-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8173,13 +8173,13 @@ client = 282-version-negotiation-client
 
 [282-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [282-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8201,12 +8201,12 @@ client = 283-version-negotiation-client
 
 [283-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [283-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8228,13 +8228,13 @@ client = 284-version-negotiation-client
 
 [284-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [284-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8256,12 +8256,12 @@ client = 285-version-negotiation-client
 
 [285-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [285-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8283,12 +8283,12 @@ client = 286-version-negotiation-client
 
 [286-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [286-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8308,12 +8308,12 @@ client = 287-version-negotiation-client
 
 [287-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [287-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8334,12 +8334,12 @@ client = 288-version-negotiation-client
 
 [288-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [288-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8360,12 +8360,12 @@ client = 289-version-negotiation-client
 
 [289-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [289-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8386,12 +8386,12 @@ client = 290-version-negotiation-client
 
 [290-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [290-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8412,11 +8412,11 @@ client = 291-version-negotiation-client
 
 [291-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [291-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8437,13 +8437,13 @@ client = 292-version-negotiation-client
 
 [292-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [292-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8463,13 +8463,13 @@ client = 293-version-negotiation-client
 
 [293-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [293-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8490,13 +8490,13 @@ client = 294-version-negotiation-client
 
 [294-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [294-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8517,13 +8517,13 @@ client = 295-version-negotiation-client
 
 [295-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [295-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8544,13 +8544,13 @@ client = 296-version-negotiation-client
 
 [296-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [296-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8571,12 +8571,12 @@ client = 297-version-negotiation-client
 
 [297-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [297-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8597,13 +8597,13 @@ client = 298-version-negotiation-client
 
 [298-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [298-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8624,13 +8624,13 @@ client = 299-version-negotiation-client
 
 [299-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [299-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8651,13 +8651,13 @@ client = 300-version-negotiation-client
 
 [300-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [300-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8678,13 +8678,13 @@ client = 301-version-negotiation-client
 
 [301-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [301-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8705,12 +8705,12 @@ client = 302-version-negotiation-client
 
 [302-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [302-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8731,13 +8731,13 @@ client = 303-version-negotiation-client
 
 [303-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [303-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8758,13 +8758,13 @@ client = 304-version-negotiation-client
 
 [304-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [304-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8785,13 +8785,13 @@ client = 305-version-negotiation-client
 
 [305-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [305-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8812,12 +8812,12 @@ client = 306-version-negotiation-client
 
 [306-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [306-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8838,13 +8838,13 @@ client = 307-version-negotiation-client
 
 [307-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [307-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8865,13 +8865,13 @@ client = 308-version-negotiation-client
 
 [308-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [308-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8892,12 +8892,12 @@ client = 309-version-negotiation-client
 
 [309-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [309-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8918,13 +8918,13 @@ client = 310-version-negotiation-client
 
 [310-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [310-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8945,12 +8945,12 @@ client = 311-version-negotiation-client
 
 [311-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [311-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -8971,12 +8971,12 @@ client = 312-version-negotiation-client
 
 [312-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [312-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -8997,12 +8997,12 @@ client = 313-version-negotiation-client
 
 [313-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [313-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9024,12 +9024,12 @@ client = 314-version-negotiation-client
 
 [314-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [314-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9051,12 +9051,12 @@ client = 315-version-negotiation-client
 
 [315-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [315-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9078,12 +9078,12 @@ client = 316-version-negotiation-client
 
 [316-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [316-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9105,11 +9105,11 @@ client = 317-version-negotiation-client
 
 [317-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [317-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9131,13 +9131,13 @@ client = 318-version-negotiation-client
 
 [318-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [318-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9158,13 +9158,13 @@ client = 319-version-negotiation-client
 
 [319-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [319-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9186,13 +9186,13 @@ client = 320-version-negotiation-client
 
 [320-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [320-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9214,13 +9214,13 @@ client = 321-version-negotiation-client
 
 [321-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [321-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9242,13 +9242,13 @@ client = 322-version-negotiation-client
 
 [322-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [322-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9270,12 +9270,12 @@ client = 323-version-negotiation-client
 
 [323-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [323-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9297,13 +9297,13 @@ client = 324-version-negotiation-client
 
 [324-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [324-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9325,13 +9325,13 @@ client = 325-version-negotiation-client
 
 [325-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [325-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9353,13 +9353,13 @@ client = 326-version-negotiation-client
 
 [326-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [326-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9381,13 +9381,13 @@ client = 327-version-negotiation-client
 
 [327-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [327-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9409,12 +9409,12 @@ client = 328-version-negotiation-client
 
 [328-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [328-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9436,13 +9436,13 @@ client = 329-version-negotiation-client
 
 [329-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [329-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9463,13 +9463,13 @@ client = 330-version-negotiation-client
 
 [330-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [330-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9490,13 +9490,13 @@ client = 331-version-negotiation-client
 
 [331-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [331-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9517,12 +9517,12 @@ client = 332-version-negotiation-client
 
 [332-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [332-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9543,13 +9543,13 @@ client = 333-version-negotiation-client
 
 [333-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [333-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9570,13 +9570,13 @@ client = 334-version-negotiation-client
 
 [334-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [334-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9597,12 +9597,12 @@ client = 335-version-negotiation-client
 
 [335-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [335-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9623,13 +9623,13 @@ client = 336-version-negotiation-client
 
 [336-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [336-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9650,12 +9650,12 @@ client = 337-version-negotiation-client
 
 [337-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [337-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9676,12 +9676,12 @@ client = 338-version-negotiation-client
 
 [338-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [338-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9702,12 +9702,12 @@ client = 339-version-negotiation-client
 
 [339-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [339-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9729,12 +9729,12 @@ client = 340-version-negotiation-client
 
 [340-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [340-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9756,12 +9756,12 @@ client = 341-version-negotiation-client
 
 [341-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [341-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9783,12 +9783,12 @@ client = 342-version-negotiation-client
 
 [342-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [342-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9810,11 +9810,11 @@ client = 343-version-negotiation-client
 
 [343-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [343-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9836,13 +9836,13 @@ client = 344-version-negotiation-client
 
 [344-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [344-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9863,13 +9863,13 @@ client = 345-version-negotiation-client
 
 [345-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [345-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9891,13 +9891,13 @@ client = 346-version-negotiation-client
 
 [346-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [346-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9919,13 +9919,13 @@ client = 347-version-negotiation-client
 
 [347-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [347-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9947,13 +9947,13 @@ client = 348-version-negotiation-client
 
 [348-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [348-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -9975,12 +9975,12 @@ client = 349-version-negotiation-client
 
 [349-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [349-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10002,13 +10002,13 @@ client = 350-version-negotiation-client
 
 [350-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [350-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10030,13 +10030,13 @@ client = 351-version-negotiation-client
 
 [351-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [351-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10058,13 +10058,13 @@ client = 352-version-negotiation-client
 
 [352-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [352-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10086,13 +10086,13 @@ client = 353-version-negotiation-client
 
 [353-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [353-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10114,12 +10114,12 @@ client = 354-version-negotiation-client
 
 [354-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [354-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10141,13 +10141,13 @@ client = 355-version-negotiation-client
 
 [355-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [355-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10169,13 +10169,13 @@ client = 356-version-negotiation-client
 
 [356-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [356-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10197,13 +10197,13 @@ client = 357-version-negotiation-client
 
 [357-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [357-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10225,12 +10225,12 @@ client = 358-version-negotiation-client
 
 [358-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [358-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10252,13 +10252,13 @@ client = 359-version-negotiation-client
 
 [359-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [359-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10279,13 +10279,13 @@ client = 360-version-negotiation-client
 
 [360-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [360-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10306,12 +10306,12 @@ client = 361-version-negotiation-client
 
 [361-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [361-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10332,13 +10332,13 @@ client = 362-version-negotiation-client
 
 [362-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [362-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10359,12 +10359,12 @@ client = 363-version-negotiation-client
 
 [363-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [363-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10385,12 +10385,12 @@ client = 364-version-negotiation-client
 
 [364-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [364-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10411,12 +10411,12 @@ client = 365-version-negotiation-client
 
 [365-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [365-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10438,12 +10438,12 @@ client = 366-version-negotiation-client
 
 [366-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [366-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10465,12 +10465,12 @@ client = 367-version-negotiation-client
 
 [367-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [367-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10492,12 +10492,12 @@ client = 368-version-negotiation-client
 
 [368-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [368-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10519,11 +10519,11 @@ client = 369-version-negotiation-client
 
 [369-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [369-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10545,13 +10545,13 @@ client = 370-version-negotiation-client
 
 [370-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [370-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10572,13 +10572,13 @@ client = 371-version-negotiation-client
 
 [371-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [371-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10600,13 +10600,13 @@ client = 372-version-negotiation-client
 
 [372-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [372-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10628,13 +10628,13 @@ client = 373-version-negotiation-client
 
 [373-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [373-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10656,13 +10656,13 @@ client = 374-version-negotiation-client
 
 [374-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [374-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10684,12 +10684,12 @@ client = 375-version-negotiation-client
 
 [375-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [375-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10711,13 +10711,13 @@ client = 376-version-negotiation-client
 
 [376-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [376-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10739,13 +10739,13 @@ client = 377-version-negotiation-client
 
 [377-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [377-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10767,13 +10767,13 @@ client = 378-version-negotiation-client
 
 [378-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [378-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10795,13 +10795,13 @@ client = 379-version-negotiation-client
 
 [379-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [379-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10823,12 +10823,12 @@ client = 380-version-negotiation-client
 
 [380-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [380-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10850,13 +10850,13 @@ client = 381-version-negotiation-client
 
 [381-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [381-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10878,13 +10878,13 @@ client = 382-version-negotiation-client
 
 [382-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [382-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10906,13 +10906,13 @@ client = 383-version-negotiation-client
 
 [383-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [383-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10934,12 +10934,12 @@ client = 384-version-negotiation-client
 
 [384-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [384-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10961,13 +10961,13 @@ client = 385-version-negotiation-client
 
 [385-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [385-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -10989,13 +10989,13 @@ client = 386-version-negotiation-client
 
 [386-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [386-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11017,12 +11017,12 @@ client = 387-version-negotiation-client
 
 [387-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [387-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11044,13 +11044,13 @@ client = 388-version-negotiation-client
 
 [388-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [388-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11071,12 +11071,12 @@ client = 389-version-negotiation-client
 
 [389-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [389-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11097,12 +11097,12 @@ client = 390-version-negotiation-client
 
 [390-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [390-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11123,12 +11123,12 @@ client = 391-version-negotiation-client
 
 [391-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [391-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11150,12 +11150,12 @@ client = 392-version-negotiation-client
 
 [392-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [392-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11177,12 +11177,12 @@ client = 393-version-negotiation-client
 
 [393-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [393-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11204,12 +11204,12 @@ client = 394-version-negotiation-client
 
 [394-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [394-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11231,11 +11231,11 @@ client = 395-version-negotiation-client
 
 [395-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [395-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11257,13 +11257,13 @@ client = 396-version-negotiation-client
 
 [396-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [396-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11284,13 +11284,13 @@ client = 397-version-negotiation-client
 
 [397-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [397-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11312,13 +11312,13 @@ client = 398-version-negotiation-client
 
 [398-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [398-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11340,13 +11340,13 @@ client = 399-version-negotiation-client
 
 [399-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [399-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11368,13 +11368,13 @@ client = 400-version-negotiation-client
 
 [400-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [400-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11396,12 +11396,12 @@ client = 401-version-negotiation-client
 
 [401-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [401-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11423,13 +11423,13 @@ client = 402-version-negotiation-client
 
 [402-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [402-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11451,13 +11451,13 @@ client = 403-version-negotiation-client
 
 [403-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [403-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11479,13 +11479,13 @@ client = 404-version-negotiation-client
 
 [404-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [404-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11507,13 +11507,13 @@ client = 405-version-negotiation-client
 
 [405-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [405-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11535,12 +11535,12 @@ client = 406-version-negotiation-client
 
 [406-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [406-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11562,13 +11562,13 @@ client = 407-version-negotiation-client
 
 [407-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [407-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11590,13 +11590,13 @@ client = 408-version-negotiation-client
 
 [408-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [408-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11618,13 +11618,13 @@ client = 409-version-negotiation-client
 
 [409-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [409-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11646,12 +11646,12 @@ client = 410-version-negotiation-client
 
 [410-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [410-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11673,13 +11673,13 @@ client = 411-version-negotiation-client
 
 [411-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [411-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11701,13 +11701,13 @@ client = 412-version-negotiation-client
 
 [412-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [412-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11729,12 +11729,12 @@ client = 413-version-negotiation-client
 
 [413-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [413-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11756,13 +11756,13 @@ client = 414-version-negotiation-client
 
 [414-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [414-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11784,12 +11784,12 @@ client = 415-version-negotiation-client
 
 [415-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [415-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -11811,12 +11811,12 @@ client = 416-version-negotiation-client
 
 [416-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [416-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11836,12 +11836,12 @@ client = 417-version-negotiation-client
 
 [417-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [417-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11862,12 +11862,12 @@ client = 418-version-negotiation-client
 
 [418-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [418-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11888,12 +11888,12 @@ client = 419-version-negotiation-client
 
 [419-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [419-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11914,12 +11914,12 @@ client = 420-version-negotiation-client
 
 [420-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [420-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11940,11 +11940,11 @@ client = 421-version-negotiation-client
 
 [421-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [421-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11965,13 +11965,13 @@ client = 422-version-negotiation-client
 
 [422-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [422-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -11991,13 +11991,13 @@ client = 423-version-negotiation-client
 
 [423-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [423-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12018,13 +12018,13 @@ client = 424-version-negotiation-client
 
 [424-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [424-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12045,13 +12045,13 @@ client = 425-version-negotiation-client
 
 [425-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [425-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12072,13 +12072,13 @@ client = 426-version-negotiation-client
 
 [426-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [426-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12099,12 +12099,12 @@ client = 427-version-negotiation-client
 
 [427-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [427-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12125,13 +12125,13 @@ client = 428-version-negotiation-client
 
 [428-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [428-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12152,13 +12152,13 @@ client = 429-version-negotiation-client
 
 [429-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [429-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12179,13 +12179,13 @@ client = 430-version-negotiation-client
 
 [430-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [430-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12206,13 +12206,13 @@ client = 431-version-negotiation-client
 
 [431-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [431-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12233,12 +12233,12 @@ client = 432-version-negotiation-client
 
 [432-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [432-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12259,13 +12259,13 @@ client = 433-version-negotiation-client
 
 [433-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [433-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12286,13 +12286,13 @@ client = 434-version-negotiation-client
 
 [434-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [434-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12313,13 +12313,13 @@ client = 435-version-negotiation-client
 
 [435-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [435-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12340,12 +12340,12 @@ client = 436-version-negotiation-client
 
 [436-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [436-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12366,13 +12366,13 @@ client = 437-version-negotiation-client
 
 [437-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [437-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12393,13 +12393,13 @@ client = 438-version-negotiation-client
 
 [438-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [438-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12420,12 +12420,12 @@ client = 439-version-negotiation-client
 
 [439-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [439-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12446,13 +12446,13 @@ client = 440-version-negotiation-client
 
 [440-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [440-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12473,12 +12473,12 @@ client = 441-version-negotiation-client
 
 [441-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [441-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -12499,12 +12499,12 @@ client = 442-version-negotiation-client
 
 [442-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [442-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12525,12 +12525,12 @@ client = 443-version-negotiation-client
 
 [443-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [443-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12551,12 +12551,12 @@ client = 444-version-negotiation-client
 
 [444-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [444-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12578,12 +12578,12 @@ client = 445-version-negotiation-client
 
 [445-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [445-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12605,12 +12605,12 @@ client = 446-version-negotiation-client
 
 [446-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [446-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12632,11 +12632,11 @@ client = 447-version-negotiation-client
 
 [447-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [447-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12658,13 +12658,13 @@ client = 448-version-negotiation-client
 
 [448-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [448-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12685,13 +12685,13 @@ client = 449-version-negotiation-client
 
 [449-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [449-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12712,13 +12712,13 @@ client = 450-version-negotiation-client
 
 [450-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [450-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12740,13 +12740,13 @@ client = 451-version-negotiation-client
 
 [451-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [451-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12768,13 +12768,13 @@ client = 452-version-negotiation-client
 
 [452-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [452-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12796,12 +12796,12 @@ client = 453-version-negotiation-client
 
 [453-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [453-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12823,13 +12823,13 @@ client = 454-version-negotiation-client
 
 [454-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [454-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12850,13 +12850,13 @@ client = 455-version-negotiation-client
 
 [455-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [455-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12878,13 +12878,13 @@ client = 456-version-negotiation-client
 
 [456-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [456-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12906,13 +12906,13 @@ client = 457-version-negotiation-client
 
 [457-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [457-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12934,12 +12934,12 @@ client = 458-version-negotiation-client
 
 [458-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [458-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12961,13 +12961,13 @@ client = 459-version-negotiation-client
 
 [459-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [459-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -12989,13 +12989,13 @@ client = 460-version-negotiation-client
 
 [460-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [460-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13017,13 +13017,13 @@ client = 461-version-negotiation-client
 
 [461-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [461-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13045,12 +13045,12 @@ client = 462-version-negotiation-client
 
 [462-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [462-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13072,13 +13072,13 @@ client = 463-version-negotiation-client
 
 [463-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [463-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13099,13 +13099,13 @@ client = 464-version-negotiation-client
 
 [464-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [464-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13126,12 +13126,12 @@ client = 465-version-negotiation-client
 
 [465-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [465-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13152,13 +13152,13 @@ client = 466-version-negotiation-client
 
 [466-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [466-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13179,12 +13179,12 @@ client = 467-version-negotiation-client
 
 [467-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [467-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13205,12 +13205,12 @@ client = 468-version-negotiation-client
 
 [468-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [468-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13231,12 +13231,12 @@ client = 469-version-negotiation-client
 
 [469-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [469-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13257,12 +13257,12 @@ client = 470-version-negotiation-client
 
 [470-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [470-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13284,12 +13284,12 @@ client = 471-version-negotiation-client
 
 [471-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [471-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13311,12 +13311,12 @@ client = 472-version-negotiation-client
 
 [472-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [472-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13338,11 +13338,11 @@ client = 473-version-negotiation-client
 
 [473-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [473-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13364,13 +13364,13 @@ client = 474-version-negotiation-client
 
 [474-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [474-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13391,13 +13391,13 @@ client = 475-version-negotiation-client
 
 [475-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [475-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13418,13 +13418,13 @@ client = 476-version-negotiation-client
 
 [476-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [476-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13446,13 +13446,13 @@ client = 477-version-negotiation-client
 
 [477-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [477-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13474,13 +13474,13 @@ client = 478-version-negotiation-client
 
 [478-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [478-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13502,12 +13502,12 @@ client = 479-version-negotiation-client
 
 [479-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [479-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13529,13 +13529,13 @@ client = 480-version-negotiation-client
 
 [480-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [480-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13556,13 +13556,13 @@ client = 481-version-negotiation-client
 
 [481-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [481-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13584,13 +13584,13 @@ client = 482-version-negotiation-client
 
 [482-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [482-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13612,13 +13612,13 @@ client = 483-version-negotiation-client
 
 [483-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [483-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13640,12 +13640,12 @@ client = 484-version-negotiation-client
 
 [484-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [484-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13667,13 +13667,13 @@ client = 485-version-negotiation-client
 
 [485-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [485-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13695,13 +13695,13 @@ client = 486-version-negotiation-client
 
 [486-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [486-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13723,13 +13723,13 @@ client = 487-version-negotiation-client
 
 [487-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [487-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13751,12 +13751,12 @@ client = 488-version-negotiation-client
 
 [488-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [488-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13778,13 +13778,13 @@ client = 489-version-negotiation-client
 
 [489-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [489-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13806,13 +13806,13 @@ client = 490-version-negotiation-client
 
 [490-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [490-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13834,12 +13834,12 @@ client = 491-version-negotiation-client
 
 [491-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [491-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13861,13 +13861,13 @@ client = 492-version-negotiation-client
 
 [492-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [492-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13888,12 +13888,12 @@ client = 493-version-negotiation-client
 
 [493-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [493-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13914,12 +13914,12 @@ client = 494-version-negotiation-client
 
 [494-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [494-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13940,12 +13940,12 @@ client = 495-version-negotiation-client
 
 [495-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [495-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13966,12 +13966,12 @@ client = 496-version-negotiation-client
 
 [496-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [496-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -13993,12 +13993,12 @@ client = 497-version-negotiation-client
 
 [497-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [497-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14020,12 +14020,12 @@ client = 498-version-negotiation-client
 
 [498-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [498-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14047,11 +14047,11 @@ client = 499-version-negotiation-client
 
 [499-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [499-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14073,13 +14073,13 @@ client = 500-version-negotiation-client
 
 [500-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [500-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14100,13 +14100,13 @@ client = 501-version-negotiation-client
 
 [501-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [501-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14127,13 +14127,13 @@ client = 502-version-negotiation-client
 
 [502-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [502-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14155,13 +14155,13 @@ client = 503-version-negotiation-client
 
 [503-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [503-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14183,13 +14183,13 @@ client = 504-version-negotiation-client
 
 [504-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [504-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14211,12 +14211,12 @@ client = 505-version-negotiation-client
 
 [505-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [505-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14238,13 +14238,13 @@ client = 506-version-negotiation-client
 
 [506-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [506-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14265,13 +14265,13 @@ client = 507-version-negotiation-client
 
 [507-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [507-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14293,13 +14293,13 @@ client = 508-version-negotiation-client
 
 [508-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [508-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14321,13 +14321,13 @@ client = 509-version-negotiation-client
 
 [509-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [509-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14349,12 +14349,12 @@ client = 510-version-negotiation-client
 
 [510-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [510-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14376,13 +14376,13 @@ client = 511-version-negotiation-client
 
 [511-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [511-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14404,13 +14404,13 @@ client = 512-version-negotiation-client
 
 [512-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [512-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14432,13 +14432,13 @@ client = 513-version-negotiation-client
 
 [513-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [513-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14460,12 +14460,12 @@ client = 514-version-negotiation-client
 
 [514-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [514-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14487,13 +14487,13 @@ client = 515-version-negotiation-client
 
 [515-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [515-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14515,13 +14515,13 @@ client = 516-version-negotiation-client
 
 [516-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [516-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14543,12 +14543,12 @@ client = 517-version-negotiation-client
 
 [517-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [517-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14570,13 +14570,13 @@ client = 518-version-negotiation-client
 
 [518-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [518-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14598,12 +14598,12 @@ client = 519-version-negotiation-client
 
 [519-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [519-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -14625,12 +14625,12 @@ client = 520-version-negotiation-client
 
 [520-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [520-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14650,12 +14650,12 @@ client = 521-version-negotiation-client
 
 [521-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [521-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14675,12 +14675,12 @@ client = 522-version-negotiation-client
 
 [522-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [522-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14701,12 +14701,12 @@ client = 523-version-negotiation-client
 
 [523-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [523-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14727,12 +14727,12 @@ client = 524-version-negotiation-client
 
 [524-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [524-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14753,11 +14753,11 @@ client = 525-version-negotiation-client
 
 [525-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [525-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14778,13 +14778,13 @@ client = 526-version-negotiation-client
 
 [526-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [526-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14804,13 +14804,13 @@ client = 527-version-negotiation-client
 
 [527-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [527-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14830,13 +14830,13 @@ client = 528-version-negotiation-client
 
 [528-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [528-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14857,13 +14857,13 @@ client = 529-version-negotiation-client
 
 [529-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [529-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14884,13 +14884,13 @@ client = 530-version-negotiation-client
 
 [530-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [530-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14911,12 +14911,12 @@ client = 531-version-negotiation-client
 
 [531-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [531-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14937,13 +14937,13 @@ client = 532-version-negotiation-client
 
 [532-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [532-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14963,13 +14963,13 @@ client = 533-version-negotiation-client
 
 [533-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [533-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -14990,13 +14990,13 @@ client = 534-version-negotiation-client
 
 [534-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [534-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15017,13 +15017,13 @@ client = 535-version-negotiation-client
 
 [535-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [535-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15044,12 +15044,12 @@ client = 536-version-negotiation-client
 
 [536-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [536-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15070,13 +15070,13 @@ client = 537-version-negotiation-client
 
 [537-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [537-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15097,13 +15097,13 @@ client = 538-version-negotiation-client
 
 [538-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [538-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15124,13 +15124,13 @@ client = 539-version-negotiation-client
 
 [539-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [539-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15151,12 +15151,12 @@ client = 540-version-negotiation-client
 
 [540-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [540-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15177,13 +15177,13 @@ client = 541-version-negotiation-client
 
 [541-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [541-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15204,13 +15204,13 @@ client = 542-version-negotiation-client
 
 [542-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [542-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15231,12 +15231,12 @@ client = 543-version-negotiation-client
 
 [543-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [543-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15257,13 +15257,13 @@ client = 544-version-negotiation-client
 
 [544-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [544-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15284,12 +15284,12 @@ client = 545-version-negotiation-client
 
 [545-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [545-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -15310,12 +15310,12 @@ client = 546-version-negotiation-client
 
 [546-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [546-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15336,12 +15336,12 @@ client = 547-version-negotiation-client
 
 [547-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [547-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15362,12 +15362,12 @@ client = 548-version-negotiation-client
 
 [548-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [548-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15388,12 +15388,12 @@ client = 549-version-negotiation-client
 
 [549-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [549-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15415,12 +15415,12 @@ client = 550-version-negotiation-client
 
 [550-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [550-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15442,11 +15442,11 @@ client = 551-version-negotiation-client
 
 [551-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [551-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15468,13 +15468,13 @@ client = 552-version-negotiation-client
 
 [552-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [552-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15495,13 +15495,13 @@ client = 553-version-negotiation-client
 
 [553-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [553-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15522,13 +15522,13 @@ client = 554-version-negotiation-client
 
 [554-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [554-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15549,13 +15549,13 @@ client = 555-version-negotiation-client
 
 [555-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [555-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15577,13 +15577,13 @@ client = 556-version-negotiation-client
 
 [556-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [556-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15605,12 +15605,12 @@ client = 557-version-negotiation-client
 
 [557-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [557-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15632,13 +15632,13 @@ client = 558-version-negotiation-client
 
 [558-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [558-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15659,13 +15659,13 @@ client = 559-version-negotiation-client
 
 [559-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [559-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15686,13 +15686,13 @@ client = 560-version-negotiation-client
 
 [560-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [560-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15714,13 +15714,13 @@ client = 561-version-negotiation-client
 
 [561-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [561-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15742,12 +15742,12 @@ client = 562-version-negotiation-client
 
 [562-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [562-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15769,13 +15769,13 @@ client = 563-version-negotiation-client
 
 [563-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [563-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15796,13 +15796,13 @@ client = 564-version-negotiation-client
 
 [564-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [564-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15824,13 +15824,13 @@ client = 565-version-negotiation-client
 
 [565-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [565-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15852,12 +15852,12 @@ client = 566-version-negotiation-client
 
 [566-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [566-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15879,13 +15879,13 @@ client = 567-version-negotiation-client
 
 [567-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [567-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15907,13 +15907,13 @@ client = 568-version-negotiation-client
 
 [568-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [568-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15935,12 +15935,12 @@ client = 569-version-negotiation-client
 
 [569-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [569-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15962,13 +15962,13 @@ client = 570-version-negotiation-client
 
 [570-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [570-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -15989,12 +15989,12 @@ client = 571-version-negotiation-client
 
 [571-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [571-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16015,12 +16015,12 @@ client = 572-version-negotiation-client
 
 [572-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [572-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16041,12 +16041,12 @@ client = 573-version-negotiation-client
 
 [573-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [573-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16067,12 +16067,12 @@ client = 574-version-negotiation-client
 
 [574-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [574-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16093,12 +16093,12 @@ client = 575-version-negotiation-client
 
 [575-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [575-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16120,12 +16120,12 @@ client = 576-version-negotiation-client
 
 [576-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [576-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16147,11 +16147,11 @@ client = 577-version-negotiation-client
 
 [577-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [577-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16173,13 +16173,13 @@ client = 578-version-negotiation-client
 
 [578-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [578-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16200,13 +16200,13 @@ client = 579-version-negotiation-client
 
 [579-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [579-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16227,13 +16227,13 @@ client = 580-version-negotiation-client
 
 [580-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [580-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16254,13 +16254,13 @@ client = 581-version-negotiation-client
 
 [581-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [581-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16282,13 +16282,13 @@ client = 582-version-negotiation-client
 
 [582-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [582-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16310,12 +16310,12 @@ client = 583-version-negotiation-client
 
 [583-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [583-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16337,13 +16337,13 @@ client = 584-version-negotiation-client
 
 [584-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [584-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16364,13 +16364,13 @@ client = 585-version-negotiation-client
 
 [585-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [585-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16391,13 +16391,13 @@ client = 586-version-negotiation-client
 
 [586-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [586-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16419,13 +16419,13 @@ client = 587-version-negotiation-client
 
 [587-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [587-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16447,12 +16447,12 @@ client = 588-version-negotiation-client
 
 [588-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [588-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16474,13 +16474,13 @@ client = 589-version-negotiation-client
 
 [589-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [589-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16501,13 +16501,13 @@ client = 590-version-negotiation-client
 
 [590-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [590-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16529,13 +16529,13 @@ client = 591-version-negotiation-client
 
 [591-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [591-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16557,12 +16557,12 @@ client = 592-version-negotiation-client
 
 [592-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [592-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16584,13 +16584,13 @@ client = 593-version-negotiation-client
 
 [593-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [593-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16612,13 +16612,13 @@ client = 594-version-negotiation-client
 
 [594-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [594-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16640,12 +16640,12 @@ client = 595-version-negotiation-client
 
 [595-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [595-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16667,13 +16667,13 @@ client = 596-version-negotiation-client
 
 [596-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [596-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16695,12 +16695,12 @@ client = 597-version-negotiation-client
 
 [597-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [597-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -16722,12 +16722,12 @@ client = 598-version-negotiation-client
 
 [598-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [598-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16747,12 +16747,12 @@ client = 599-version-negotiation-client
 
 [599-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [599-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16772,12 +16772,12 @@ client = 600-version-negotiation-client
 
 [600-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [600-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16797,12 +16797,12 @@ client = 601-version-negotiation-client
 
 [601-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [601-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16823,12 +16823,12 @@ client = 602-version-negotiation-client
 
 [602-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [602-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16849,11 +16849,11 @@ client = 603-version-negotiation-client
 
 [603-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [603-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16874,13 +16874,13 @@ client = 604-version-negotiation-client
 
 [604-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [604-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16900,13 +16900,13 @@ client = 605-version-negotiation-client
 
 [605-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [605-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16926,13 +16926,13 @@ client = 606-version-negotiation-client
 
 [606-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [606-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16952,13 +16952,13 @@ client = 607-version-negotiation-client
 
 [607-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [607-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -16979,13 +16979,13 @@ client = 608-version-negotiation-client
 
 [608-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [608-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17006,12 +17006,12 @@ client = 609-version-negotiation-client
 
 [609-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [609-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17032,13 +17032,13 @@ client = 610-version-negotiation-client
 
 [610-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [610-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17058,13 +17058,13 @@ client = 611-version-negotiation-client
 
 [611-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [611-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17084,13 +17084,13 @@ client = 612-version-negotiation-client
 
 [612-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [612-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17111,13 +17111,13 @@ client = 613-version-negotiation-client
 
 [613-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [613-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17138,12 +17138,12 @@ client = 614-version-negotiation-client
 
 [614-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [614-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17164,13 +17164,13 @@ client = 615-version-negotiation-client
 
 [615-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [615-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17190,13 +17190,13 @@ client = 616-version-negotiation-client
 
 [616-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [616-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17217,13 +17217,13 @@ client = 617-version-negotiation-client
 
 [617-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [617-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17244,12 +17244,12 @@ client = 618-version-negotiation-client
 
 [618-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [618-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17270,13 +17270,13 @@ client = 619-version-negotiation-client
 
 [619-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [619-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17297,13 +17297,13 @@ client = 620-version-negotiation-client
 
 [620-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [620-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17324,12 +17324,12 @@ client = 621-version-negotiation-client
 
 [621-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [621-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17350,13 +17350,13 @@ client = 622-version-negotiation-client
 
 [622-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [622-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17377,12 +17377,12 @@ client = 623-version-negotiation-client
 
 [623-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [623-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -17403,12 +17403,12 @@ client = 624-version-negotiation-client
 
 [624-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [624-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17429,12 +17429,12 @@ client = 625-version-negotiation-client
 
 [625-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [625-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17455,12 +17455,12 @@ client = 626-version-negotiation-client
 
 [626-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [626-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17481,12 +17481,12 @@ client = 627-version-negotiation-client
 
 [627-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [627-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17507,12 +17507,12 @@ client = 628-version-negotiation-client
 
 [628-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [628-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17534,11 +17534,11 @@ client = 629-version-negotiation-client
 
 [629-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [629-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17560,13 +17560,13 @@ client = 630-version-negotiation-client
 
 [630-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [630-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17587,13 +17587,13 @@ client = 631-version-negotiation-client
 
 [631-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [631-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17614,13 +17614,13 @@ client = 632-version-negotiation-client
 
 [632-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [632-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17641,13 +17641,13 @@ client = 633-version-negotiation-client
 
 [633-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [633-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17668,13 +17668,13 @@ client = 634-version-negotiation-client
 
 [634-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [634-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17696,12 +17696,12 @@ client = 635-version-negotiation-client
 
 [635-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [635-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17723,13 +17723,13 @@ client = 636-version-negotiation-client
 
 [636-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [636-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17750,13 +17750,13 @@ client = 637-version-negotiation-client
 
 [637-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [637-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17777,13 +17777,13 @@ client = 638-version-negotiation-client
 
 [638-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [638-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17804,13 +17804,13 @@ client = 639-version-negotiation-client
 
 [639-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [639-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17832,12 +17832,12 @@ client = 640-version-negotiation-client
 
 [640-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [640-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17859,13 +17859,13 @@ client = 641-version-negotiation-client
 
 [641-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [641-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17886,13 +17886,13 @@ client = 642-version-negotiation-client
 
 [642-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [642-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17913,13 +17913,13 @@ client = 643-version-negotiation-client
 
 [643-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [643-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17941,12 +17941,12 @@ client = 644-version-negotiation-client
 
 [644-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [644-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17968,13 +17968,13 @@ client = 645-version-negotiation-client
 
 [645-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [645-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -17995,13 +17995,13 @@ client = 646-version-negotiation-client
 
 [646-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [646-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -18023,12 +18023,12 @@ client = 647-version-negotiation-client
 
 [647-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [647-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -18050,13 +18050,13 @@ client = 648-version-negotiation-client
 
 [648-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [648-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -18078,12 +18078,12 @@ client = 649-version-negotiation-client
 
 [649-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [649-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -18105,12 +18105,12 @@ client = 650-version-negotiation-client
 
 [650-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [650-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18130,12 +18130,12 @@ client = 651-version-negotiation-client
 
 [651-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [651-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18155,12 +18155,12 @@ client = 652-version-negotiation-client
 
 [652-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [652-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18180,12 +18180,12 @@ client = 653-version-negotiation-client
 
 [653-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [653-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18205,12 +18205,12 @@ client = 654-version-negotiation-client
 
 [654-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [654-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18231,11 +18231,11 @@ client = 655-version-negotiation-client
 
 [655-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [655-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18256,13 +18256,13 @@ client = 656-version-negotiation-client
 
 [656-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = SSLv3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [656-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18282,13 +18282,13 @@ client = 657-version-negotiation-client
 
 [657-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [657-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18308,13 +18308,13 @@ client = 658-version-negotiation-client
 
 [658-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [658-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18334,13 +18334,13 @@ client = 659-version-negotiation-client
 
 [659-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [659-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18360,13 +18360,13 @@ client = 660-version-negotiation-client
 
 [660-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [660-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18387,12 +18387,12 @@ client = 661-version-negotiation-client
 
 [661-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = SSLv3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [661-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18413,13 +18413,13 @@ client = 662-version-negotiation-client
 
 [662-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [662-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18439,13 +18439,13 @@ client = 663-version-negotiation-client
 
 [663-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [663-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18465,13 +18465,13 @@ client = 664-version-negotiation-client
 
 [664-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [664-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18491,13 +18491,13 @@ client = 665-version-negotiation-client
 
 [665-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [665-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18518,12 +18518,12 @@ client = 666-version-negotiation-client
 
 [666-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [666-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18544,13 +18544,13 @@ client = 667-version-negotiation-client
 
 [667-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [667-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18570,13 +18570,13 @@ client = 668-version-negotiation-client
 
 [668-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [668-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18596,13 +18596,13 @@ client = 669-version-negotiation-client
 
 [669-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [669-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18623,12 +18623,12 @@ client = 670-version-negotiation-client
 
 [670-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [670-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18649,13 +18649,13 @@ client = 671-version-negotiation-client
 
 [671-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [671-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18675,13 +18675,13 @@ client = 672-version-negotiation-client
 
 [672-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [672-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18702,12 +18702,12 @@ client = 673-version-negotiation-client
 
 [673-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [673-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18728,13 +18728,13 @@ client = 674-version-negotiation-client
 
 [674-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [674-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -18755,12 +18755,12 @@ client = 675-version-negotiation-client
 
 [675-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [675-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/04-client_auth.cnf
+++ b/test/ssl-tests/04-client_auth.cnf
@@ -49,11 +49,11 @@ client = 0-server-auth-flex-client
 
 [0-server-auth-flex-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-server-auth-flex-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -72,12 +72,12 @@ client = 1-client-auth-flex-request-client
 
 [1-client-auth-flex-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
 [1-client-auth-flex-request-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -96,13 +96,13 @@ client = 2-client-auth-flex-require-fail-client
 
 [2-client-auth-flex-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [2-client-auth-flex-require-fail-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -122,14 +122,14 @@ client = 3-client-auth-flex-require-client
 
 [3-client-auth-flex-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
 [3-client-auth-flex-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -151,7 +151,7 @@ client = 4-client-auth-flex-require-non-empty-names-client
 
 [4-client-auth-flex-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
@@ -159,7 +159,7 @@ VerifyMode = Request
 
 [4-client-auth-flex-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -181,13 +181,13 @@ client = 5-client-auth-flex-noroot-client
 
 [5-client-auth-flex-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Require
 
 [5-client-auth-flex-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -208,13 +208,13 @@ client = 6-server-auth-TLSv1-client
 
 [6-server-auth-TLSv1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-server-auth-TLSv1-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -235,14 +235,14 @@ client = 7-client-auth-TLSv1-request-client
 
 [7-client-auth-TLSv1-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
 [7-client-auth-TLSv1-request-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -263,7 +263,7 @@ client = 8-client-auth-TLSv1-require-fail-client
 
 [8-client-auth-TLSv1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -271,7 +271,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [8-client-auth-TLSv1-require-fail-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -293,7 +293,7 @@ client = 9-client-auth-TLSv1-require-client
 
 [9-client-auth-TLSv1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -302,7 +302,7 @@ VerifyMode = Request
 
 [9-client-auth-TLSv1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -326,7 +326,7 @@ client = 10-client-auth-TLSv1-require-non-empty-names-client
 
 [10-client-auth-TLSv1-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
@@ -336,7 +336,7 @@ VerifyMode = Request
 
 [10-client-auth-TLSv1-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -360,7 +360,7 @@ client = 11-client-auth-TLSv1-noroot-client
 
 [11-client-auth-TLSv1-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -368,7 +368,7 @@ VerifyMode = Require
 
 [11-client-auth-TLSv1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -391,13 +391,13 @@ client = 12-server-auth-TLSv1.1-client
 
 [12-server-auth-TLSv1.1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-server-auth-TLSv1.1-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -418,14 +418,14 @@ client = 13-client-auth-TLSv1.1-request-client
 
 [13-client-auth-TLSv1.1-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
 [13-client-auth-TLSv1.1-request-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -446,7 +446,7 @@ client = 14-client-auth-TLSv1.1-require-fail-client
 
 [14-client-auth-TLSv1.1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -454,7 +454,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [14-client-auth-TLSv1.1-require-fail-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -476,7 +476,7 @@ client = 15-client-auth-TLSv1.1-require-client
 
 [15-client-auth-TLSv1.1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -485,7 +485,7 @@ VerifyMode = Request
 
 [15-client-auth-TLSv1.1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -509,7 +509,7 @@ client = 16-client-auth-TLSv1.1-require-non-empty-names-client
 
 [16-client-auth-TLSv1.1-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
@@ -519,7 +519,7 @@ VerifyMode = Request
 
 [16-client-auth-TLSv1.1-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -543,7 +543,7 @@ client = 17-client-auth-TLSv1.1-noroot-client
 
 [17-client-auth-TLSv1.1-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -551,7 +551,7 @@ VerifyMode = Require
 
 [17-client-auth-TLSv1.1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -574,13 +574,13 @@ client = 18-server-auth-TLSv1.2-client
 
 [18-server-auth-TLSv1.2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [18-server-auth-TLSv1.2-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -601,14 +601,14 @@ client = 19-client-auth-TLSv1.2-request-client
 
 [19-client-auth-TLSv1.2-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
 [19-client-auth-TLSv1.2-request-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -629,7 +629,7 @@ client = 20-client-auth-TLSv1.2-require-fail-client
 
 [20-client-auth-TLSv1.2-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -637,7 +637,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [20-client-auth-TLSv1.2-require-fail-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -659,7 +659,7 @@ client = 21-client-auth-TLSv1.2-require-client
 
 [21-client-auth-TLSv1.2-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientSignatureAlgorithms = SHA256+RSA
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
@@ -669,7 +669,7 @@ VerifyMode = Request
 
 [21-client-auth-TLSv1.2-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -695,7 +695,7 @@ client = 22-client-auth-TLSv1.2-require-non-empty-names-client
 
 [22-client-auth-TLSv1.2-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 ClientSignatureAlgorithms = SHA256+RSA
 MaxProtocol = TLSv1.2
@@ -706,7 +706,7 @@ VerifyMode = Request
 
 [22-client-auth-TLSv1.2-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -732,7 +732,7 @@ client = 23-client-auth-TLSv1.2-noroot-client
 
 [23-client-auth-TLSv1.2-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -740,7 +740,7 @@ VerifyMode = Require
 
 [23-client-auth-TLSv1.2-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -763,13 +763,13 @@ client = 24-server-auth-DTLSv1-client
 
 [24-server-auth-DTLSv1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [24-server-auth-DTLSv1-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -791,14 +791,14 @@ client = 25-client-auth-DTLSv1-request-client
 
 [25-client-auth-DTLSv1-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
 [25-client-auth-DTLSv1-request-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -820,7 +820,7 @@ client = 26-client-auth-DTLSv1-require-fail-client
 
 [26-client-auth-DTLSv1-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -828,7 +828,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [26-client-auth-DTLSv1-require-fail-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -851,7 +851,7 @@ client = 27-client-auth-DTLSv1-require-client
 
 [27-client-auth-DTLSv1-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -860,7 +860,7 @@ VerifyMode = Request
 
 [27-client-auth-DTLSv1-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -885,7 +885,7 @@ client = 28-client-auth-DTLSv1-require-non-empty-names-client
 
 [28-client-auth-DTLSv1-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
@@ -895,7 +895,7 @@ VerifyMode = Request
 
 [28-client-auth-DTLSv1-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -920,7 +920,7 @@ client = 29-client-auth-DTLSv1-noroot-client
 
 [29-client-auth-DTLSv1-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -928,7 +928,7 @@ VerifyMode = Require
 
 [29-client-auth-DTLSv1-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -952,13 +952,13 @@ client = 30-server-auth-DTLSv1.2-client
 
 [30-server-auth-DTLSv1.2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [30-server-auth-DTLSv1.2-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -980,14 +980,14 @@ client = 31-client-auth-DTLSv1.2-request-client
 
 [31-client-auth-DTLSv1.2-request-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyMode = Request
 
 [31-client-auth-DTLSv1.2-request-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1009,7 +1009,7 @@ client = 32-client-auth-DTLSv1.2-require-fail-client
 
 [32-client-auth-DTLSv1.2-require-fail-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -1017,7 +1017,7 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [32-client-auth-DTLSv1.2-require-fail-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1040,7 +1040,7 @@ client = 33-client-auth-DTLSv1.2-require-client
 
 [33-client-auth-DTLSv1.2-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -1049,7 +1049,7 @@ VerifyMode = Request
 
 [33-client-auth-DTLSv1.2-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -1074,7 +1074,7 @@ client = 34-client-auth-DTLSv1.2-require-non-empty-names-client
 
 [34-client-auth-DTLSv1.2-require-non-empty-names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ClientCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
@@ -1084,7 +1084,7 @@ VerifyMode = Request
 
 [34-client-auth-DTLSv1.2-require-non-empty-names-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
@@ -1109,7 +1109,7 @@ client = 35-client-auth-DTLSv1.2-noroot-client
 
 [35-client-auth-DTLSv1.2-noroot-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
@@ -1117,7 +1117,7 @@ VerifyMode = Require
 
 [35-client-auth-DTLSv1.2-noroot-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem

--- a/test/ssl-tests/04-client_auth.cnf.in
+++ b/test/ssl-tests/04-client_auth.cnf.in
@@ -58,10 +58,12 @@ sub generate_tests() {
                     name => "server-auth-${protocol_name}"
                             .($sctp ? "-sctp" : ""),
                     server => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol
                     },
                     client => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol
                     },
@@ -77,11 +79,13 @@ sub generate_tests() {
                     name => "client-auth-${protocol_name}-request"
                             .($sctp ? "-sctp" : ""),
                     server => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "VerifyMode" => "Request"
                     },
                     client => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol
                     },
@@ -97,12 +101,14 @@ sub generate_tests() {
                     name => "client-auth-${protocol_name}-require-fail"
                             .($sctp ? "-sctp" : ""),
                     server => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "VerifyCAFile" => test_pem("root-cert.pem"),
                         "VerifyMode" => "Require",
                     },
                     client => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol
                     },
@@ -121,6 +127,7 @@ sub generate_tests() {
                     name => "client-auth-${protocol_name}-require"
                              .($sctp ? "-sctp" : ""),
                     server => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "ClientSignatureAlgorithms" => $clisigalgs,
@@ -128,6 +135,7 @@ sub generate_tests() {
                         "VerifyMode" => "Request",
                     },
                     client => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "Certificate" => test_pem("ee-client-chain.pem"),
@@ -149,6 +157,7 @@ sub generate_tests() {
                     name => "client-auth-${protocol_name}-require-non-empty-names"
                             .($sctp ? "-sctp" : ""),
                     server => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "ClientSignatureAlgorithms" => $clisigalgs,
@@ -157,6 +166,7 @@ sub generate_tests() {
                         "VerifyMode" => "Request",
                     },
                     client => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "Certificate" => test_pem("ee-client-chain.pem"),
@@ -178,11 +188,13 @@ sub generate_tests() {
                     name => "client-auth-${protocol_name}-noroot"
                             .($sctp ? "-sctp" : ""),
                     server => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "VerifyMode" => "Require",
                     },
                     client => {
+                        "CipherString" => "DEFAULT:\@SECLEVEL=0",
                         "MinProtocol" => $protocol,
                         "MaxProtocol" => $protocol,
                         "Certificate" => test_pem("ee-client-chain.pem"),

--- a/test/ssl-tests/05-sni.cnf
+++ b/test/ssl-tests/05-sni.cnf
@@ -284,11 +284,11 @@ server2 = 8-SNI-clienthello-disable-v12-server
 
 [8-SNI-clienthello-disable-v12-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-SNI-clienthello-disable-v12-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/05-sni.cnf.in
+++ b/test/ssl-tests/05-sni.cnf.in
@@ -152,11 +152,13 @@ our @tests_tls_1_1 = (
     {
         name => "SNI-clienthello-disable-v12",
         server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             extra => {
                 "ServerNameCallback" => "ClientHelloNoV12",
             },
         },
         client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             extra => {
                 "ServerName" => "server2",
             },

--- a/test/ssl-tests/07-dtls-protocol-version.cnf
+++ b/test/ssl-tests/07-dtls-protocol-version.cnf
@@ -77,12 +77,12 @@ client = 0-version-negotiation-client
 
 [0-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -104,12 +104,12 @@ client = 1-version-negotiation-client
 
 [1-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -131,11 +131,11 @@ client = 2-version-negotiation-client
 
 [2-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -157,13 +157,13 @@ client = 3-version-negotiation-client
 
 [3-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -185,13 +185,13 @@ client = 4-version-negotiation-client
 
 [4-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -213,12 +213,12 @@ client = 5-version-negotiation-client
 
 [5-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -240,13 +240,13 @@ client = 6-version-negotiation-client
 
 [6-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -267,12 +267,12 @@ client = 7-version-negotiation-client
 
 [7-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -293,12 +293,12 @@ client = 8-version-negotiation-client
 
 [8-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -320,12 +320,12 @@ client = 9-version-negotiation-client
 
 [9-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -347,11 +347,11 @@ client = 10-version-negotiation-client
 
 [10-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -373,13 +373,13 @@ client = 11-version-negotiation-client
 
 [11-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [11-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -401,13 +401,13 @@ client = 12-version-negotiation-client
 
 [12-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -429,12 +429,12 @@ client = 13-version-negotiation-client
 
 [13-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [13-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -456,13 +456,13 @@ client = 14-version-negotiation-client
 
 [14-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [14-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -484,12 +484,12 @@ client = 15-version-negotiation-client
 
 [15-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [15-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -511,12 +511,12 @@ client = 16-version-negotiation-client
 
 [16-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [16-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -537,12 +537,12 @@ client = 17-version-negotiation-client
 
 [17-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [17-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -563,11 +563,11 @@ client = 18-version-negotiation-client
 
 [18-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [18-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -588,13 +588,13 @@ client = 19-version-negotiation-client
 
 [19-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [19-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -615,13 +615,13 @@ client = 20-version-negotiation-client
 
 [20-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [20-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -642,12 +642,12 @@ client = 21-version-negotiation-client
 
 [21-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [21-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -668,13 +668,13 @@ client = 22-version-negotiation-client
 
 [22-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [22-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -695,12 +695,12 @@ client = 23-version-negotiation-client
 
 [23-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [23-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -721,12 +721,12 @@ client = 24-version-negotiation-client
 
 [24-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [24-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -749,12 +749,12 @@ client = 25-version-negotiation-client
 
 [25-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [25-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -777,11 +777,11 @@ client = 26-version-negotiation-client
 
 [26-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [26-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -804,13 +804,13 @@ client = 27-version-negotiation-client
 
 [27-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [27-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -833,13 +833,13 @@ client = 28-version-negotiation-client
 
 [28-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [28-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -862,12 +862,12 @@ client = 29-version-negotiation-client
 
 [29-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [29-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -890,13 +890,13 @@ client = 30-version-negotiation-client
 
 [30-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [30-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -918,12 +918,12 @@ client = 31-version-negotiation-client
 
 [31-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [31-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -945,12 +945,12 @@ client = 32-version-negotiation-client
 
 [32-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [32-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -973,12 +973,12 @@ client = 33-version-negotiation-client
 
 [33-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [33-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1001,11 +1001,11 @@ client = 34-version-negotiation-client
 
 [34-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [34-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1028,13 +1028,13 @@ client = 35-version-negotiation-client
 
 [35-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [35-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1057,13 +1057,13 @@ client = 36-version-negotiation-client
 
 [36-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [36-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1086,12 +1086,12 @@ client = 37-version-negotiation-client
 
 [37-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [37-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1114,13 +1114,13 @@ client = 38-version-negotiation-client
 
 [38-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [38-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1143,12 +1143,12 @@ client = 39-version-negotiation-client
 
 [39-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [39-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1171,12 +1171,12 @@ client = 40-version-negotiation-client
 
 [40-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [40-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1198,12 +1198,12 @@ client = 41-version-negotiation-client
 
 [41-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [41-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1225,11 +1225,11 @@ client = 42-version-negotiation-client
 
 [42-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [42-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1251,13 +1251,13 @@ client = 43-version-negotiation-client
 
 [43-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [43-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1279,13 +1279,13 @@ client = 44-version-negotiation-client
 
 [44-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [44-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1307,12 +1307,12 @@ client = 45-version-negotiation-client
 
 [45-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [45-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1334,13 +1334,13 @@ client = 46-version-negotiation-client
 
 [46-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [46-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1362,12 +1362,12 @@ client = 47-version-negotiation-client
 
 [47-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [47-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1389,12 +1389,12 @@ client = 48-version-negotiation-client
 
 [48-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [48-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1416,12 +1416,12 @@ client = 49-version-negotiation-client
 
 [49-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [49-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1444,11 +1444,11 @@ client = 50-version-negotiation-client
 
 [50-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [50-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1471,13 +1471,13 @@ client = 51-version-negotiation-client
 
 [51-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [51-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1499,13 +1499,13 @@ client = 52-version-negotiation-client
 
 [52-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [52-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1528,12 +1528,12 @@ client = 53-version-negotiation-client
 
 [53-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [53-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1556,13 +1556,13 @@ client = 54-version-negotiation-client
 
 [54-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [54-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1585,12 +1585,12 @@ client = 55-version-negotiation-client
 
 [55-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [55-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
@@ -1613,12 +1613,12 @@ client = 56-version-negotiation-client
 
 [56-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [56-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1639,12 +1639,12 @@ client = 57-version-negotiation-client
 
 [57-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [57-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1666,11 +1666,11 @@ client = 58-version-negotiation-client
 
 [58-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [58-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1692,13 +1692,13 @@ client = 59-version-negotiation-client
 
 [59-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [59-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1719,13 +1719,13 @@ client = 60-version-negotiation-client
 
 [60-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [60-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1747,12 +1747,12 @@ client = 61-version-negotiation-client
 
 [61-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [61-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1774,13 +1774,13 @@ client = 62-version-negotiation-client
 
 [62-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [62-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1802,12 +1802,12 @@ client = 63-version-negotiation-client
 
 [63-version-negotiation-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [63-version-negotiation-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/10-resumption.cnf
+++ b/test/ssl-tests/10-resumption.cnf
@@ -80,7 +80,7 @@ resume-client = 0-resumption-client
 
 [0-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = SessionTicket
@@ -88,13 +88,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -117,7 +117,7 @@ resume-client = 1-resumption-client
 
 [1-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = -SessionTicket
@@ -125,13 +125,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -154,7 +154,7 @@ resume-client = 2-resumption-client
 
 [2-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = SessionTicket
@@ -162,13 +162,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -191,7 +191,7 @@ resume-client = 3-resumption-client
 
 [3-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = -SessionTicket
@@ -199,13 +199,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -228,7 +228,7 @@ resume-client = 4-resumption-client
 
 [4-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = SessionTicket
@@ -236,13 +236,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -265,7 +265,7 @@ resume-client = 5-resumption-client
 
 [5-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = -SessionTicket
@@ -273,13 +273,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -302,7 +302,7 @@ resume-client = 6-resumption-client
 
 [6-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = SessionTicket
@@ -310,13 +310,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -339,7 +339,7 @@ resume-client = 7-resumption-client
 
 [7-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 Options = -SessionTicket
@@ -347,13 +347,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -376,7 +376,7 @@ resume-client = 8-resumption-client
 
 [8-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = SessionTicket
@@ -384,13 +384,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -413,7 +413,7 @@ resume-client = 9-resumption-client
 
 [9-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = -SessionTicket
@@ -421,13 +421,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -450,7 +450,7 @@ resume-client = 10-resumption-client
 
 [10-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = SessionTicket
@@ -458,13 +458,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -487,7 +487,7 @@ resume-client = 11-resumption-client
 
 [11-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = -SessionTicket
@@ -495,13 +495,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [11-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [11-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -524,7 +524,7 @@ resume-client = 12-resumption-client
 
 [12-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = SessionTicket
@@ -532,13 +532,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -561,7 +561,7 @@ resume-client = 13-resumption-client
 
 [13-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = -SessionTicket
@@ -569,13 +569,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [13-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [13-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -598,7 +598,7 @@ resume-client = 14-resumption-client
 
 [14-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = SessionTicket
@@ -606,13 +606,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [14-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [14-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -635,7 +635,7 @@ resume-client = 15-resumption-client
 
 [15-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 Options = -SessionTicket
@@ -643,13 +643,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [15-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [15-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -672,7 +672,7 @@ resume-client = 16-resumption-client
 
 [16-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = SessionTicket
@@ -680,13 +680,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [16-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [16-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -709,7 +709,7 @@ resume-client = 17-resumption-client
 
 [17-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = -SessionTicket
@@ -717,13 +717,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [17-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [17-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -746,7 +746,7 @@ resume-client = 18-resumption-client
 
 [18-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = SessionTicket
@@ -754,13 +754,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [18-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [18-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -783,7 +783,7 @@ resume-client = 19-resumption-client
 
 [19-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = -SessionTicket
@@ -791,13 +791,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [19-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [19-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -820,7 +820,7 @@ resume-client = 20-resumption-client
 
 [20-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = SessionTicket
@@ -828,13 +828,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [20-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [20-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -857,7 +857,7 @@ resume-client = 21-resumption-client
 
 [21-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = -SessionTicket
@@ -865,13 +865,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [21-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [21-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -894,7 +894,7 @@ resume-client = 22-resumption-client
 
 [22-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = SessionTicket
@@ -902,13 +902,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [22-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [22-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -931,7 +931,7 @@ resume-client = 23-resumption-client
 
 [23-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 Options = -SessionTicket
@@ -939,13 +939,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [23-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [23-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -968,7 +968,7 @@ resume-client = 24-resumption-client
 
 [24-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = SessionTicket
@@ -976,13 +976,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [24-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [24-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1005,7 +1005,7 @@ resume-client = 25-resumption-client
 
 [25-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = -SessionTicket
@@ -1013,13 +1013,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [25-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [25-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1042,7 +1042,7 @@ resume-client = 26-resumption-client
 
 [26-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = SessionTicket
@@ -1050,13 +1050,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [26-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [26-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1079,7 +1079,7 @@ resume-client = 27-resumption-client
 
 [27-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = -SessionTicket
@@ -1087,13 +1087,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [27-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [27-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1116,7 +1116,7 @@ resume-client = 28-resumption-client
 
 [28-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = SessionTicket
@@ -1124,13 +1124,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [28-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [28-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1153,7 +1153,7 @@ resume-client = 29-resumption-client
 
 [29-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = -SessionTicket
@@ -1161,13 +1161,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [29-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [29-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1190,7 +1190,7 @@ resume-client = 30-resumption-client
 
 [30-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = SessionTicket
@@ -1198,13 +1198,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [30-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [30-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1227,7 +1227,7 @@ resume-client = 31-resumption-client
 
 [31-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 Options = -SessionTicket
@@ -1235,13 +1235,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [31-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [31-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1264,19 +1264,19 @@ resume-client = 32-resumption-resume-client
 
 [32-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [32-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [32-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1300,19 +1300,19 @@ resume-client = 33-resumption-resume-client
 
 [33-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [33-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [33-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1336,19 +1336,19 @@ resume-client = 34-resumption-resume-client
 
 [34-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [34-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [34-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1372,19 +1372,19 @@ resume-client = 35-resumption-resume-client
 
 [35-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [35-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [35-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1408,19 +1408,19 @@ resume-client = 36-resumption-resume-client
 
 [36-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [36-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [36-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1444,19 +1444,19 @@ resume-client = 37-resumption-resume-client
 
 [37-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [37-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [37-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1480,19 +1480,19 @@ resume-client = 38-resumption-resume-client
 
 [38-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [38-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [38-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1516,19 +1516,19 @@ resume-client = 39-resumption-resume-client
 
 [39-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [39-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 MinProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [39-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1552,19 +1552,19 @@ resume-client = 40-resumption-resume-client
 
 [40-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [40-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [40-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1588,19 +1588,19 @@ resume-client = 41-resumption-resume-client
 
 [41-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [41-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [41-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1624,19 +1624,19 @@ resume-client = 42-resumption-resume-client
 
 [42-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [42-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [42-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1660,19 +1660,19 @@ resume-client = 43-resumption-resume-client
 
 [43-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [43-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [43-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1696,19 +1696,19 @@ resume-client = 44-resumption-resume-client
 
 [44-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [44-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [44-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1732,19 +1732,19 @@ resume-client = 45-resumption-resume-client
 
 [45-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [45-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [45-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1768,19 +1768,19 @@ resume-client = 46-resumption-resume-client
 
 [46-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [46-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [46-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1804,19 +1804,19 @@ resume-client = 47-resumption-resume-client
 
 [47-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [47-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 MinProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [47-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1840,19 +1840,19 @@ resume-client = 48-resumption-resume-client
 
 [48-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [48-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [48-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1876,19 +1876,19 @@ resume-client = 49-resumption-resume-client
 
 [49-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [49-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [49-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1912,19 +1912,19 @@ resume-client = 50-resumption-resume-client
 
 [50-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [50-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [50-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1948,19 +1948,19 @@ resume-client = 51-resumption-resume-client
 
 [51-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [51-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [51-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1984,19 +1984,19 @@ resume-client = 52-resumption-resume-client
 
 [52-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [52-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [52-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2020,19 +2020,19 @@ resume-client = 53-resumption-resume-client
 
 [53-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [53-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [53-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2056,19 +2056,19 @@ resume-client = 54-resumption-resume-client
 
 [54-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [54-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [54-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2092,19 +2092,19 @@ resume-client = 55-resumption-resume-client
 
 [55-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [55-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [55-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2128,19 +2128,19 @@ resume-client = 56-resumption-resume-client
 
 [56-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [56-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [56-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2164,19 +2164,19 @@ resume-client = 57-resumption-resume-client
 
 [57-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [57-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [57-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2200,19 +2200,19 @@ resume-client = 58-resumption-resume-client
 
 [58-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [58-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [58-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2236,19 +2236,19 @@ resume-client = 59-resumption-resume-client
 
 [59-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [59-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [59-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2272,19 +2272,19 @@ resume-client = 60-resumption-resume-client
 
 [60-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [60-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [60-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2308,19 +2308,19 @@ resume-client = 61-resumption-resume-client
 
 [61-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [61-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [61-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2344,19 +2344,19 @@ resume-client = 62-resumption-resume-client
 
 [62-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [62-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [62-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -2380,19 +2380,19 @@ resume-client = 63-resumption-resume-client
 
 [63-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [63-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [63-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/11-dtls_resumption.cnf
+++ b/test/ssl-tests/11-dtls_resumption.cnf
@@ -31,7 +31,7 @@ resume-client = 0-resumption-client
 
 [0-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 Options = SessionTicket
@@ -39,13 +39,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -69,7 +69,7 @@ resume-client = 1-resumption-client
 
 [1-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 Options = -SessionTicket
@@ -77,13 +77,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -107,7 +107,7 @@ resume-client = 2-resumption-client
 
 [2-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 Options = SessionTicket
@@ -115,13 +115,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -145,7 +145,7 @@ resume-client = 3-resumption-client
 
 [3-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 Options = -SessionTicket
@@ -153,13 +153,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [3-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -183,7 +183,7 @@ resume-client = 4-resumption-client
 
 [4-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 Options = SessionTicket
@@ -191,13 +191,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [4-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -221,7 +221,7 @@ resume-client = 5-resumption-client
 
 [5-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 Options = -SessionTicket
@@ -229,13 +229,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [5-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -259,7 +259,7 @@ resume-client = 6-resumption-client
 
 [6-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 Options = SessionTicket
@@ -267,13 +267,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [6-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -297,7 +297,7 @@ resume-client = 7-resumption-client
 
 [7-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 Options = -SessionTicket
@@ -305,13 +305,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-resumption-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [7-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -335,19 +335,19 @@ resume-client = 8-resumption-resume-client
 
 [8-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [8-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -372,19 +372,19 @@ resume-client = 9-resumption-resume-client
 
 [9-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [9-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [9-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -409,19 +409,19 @@ resume-client = 10-resumption-resume-client
 
 [10-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [10-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [10-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -446,19 +446,19 @@ resume-client = 11-resumption-resume-client
 
 [11-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [11-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 MinProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [11-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -483,19 +483,19 @@ resume-client = 12-resumption-resume-client
 
 [12-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [12-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [12-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -520,19 +520,19 @@ resume-client = 13-resumption-resume-client
 
 [13-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [13-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [13-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -557,19 +557,19 @@ resume-client = 14-resumption-resume-client
 
 [14-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [14-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [14-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -594,19 +594,19 @@ resume-client = 15-resumption-resume-client
 
 [15-resumption-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = -SessionTicket
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [15-resumption-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 MinProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [15-resumption-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = DTLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -328,7 +328,7 @@ client = 8-ECDSA Signature Algorithm Selection SHA1-client
 
 [8-ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
@@ -339,7 +339,7 @@ MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [8-ECDSA Signature Algorithm Selection SHA1-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 SignatureAlgorithms = ECDSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1209,7 +1209,7 @@ client = 37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client
 
 [37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
@@ -1221,7 +1221,7 @@ MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [37-TLS 1.3 ECDSA Signature Algorithm Selection SHA1-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 SignatureAlgorithms = ECDSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -201,8 +201,18 @@ our @tests = (
     },
     {
         name => "ECDSA Signature Algorithm Selection SHA1",
-        server => $server,
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+            "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
+            "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
+            "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
+            "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
+            "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
+            "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
+            "MaxProtocol" => "TLSv1.2"
+        },
         client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             "SignatureAlgorithms" => "ECDSA+SHA1",
         },
         test   => {
@@ -672,8 +682,19 @@ my @tests_tls_1_3 = (
     },
     {
         name => "TLS 1.3 ECDSA Signature Algorithm Selection SHA1",
-        server => $server_tls_1_3,
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+            "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
+            "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
+            "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
+            "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
+            "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
+            "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
+            "MinProtocol" => "TLSv1.3",
+            "MaxProtocol" => "TLSv1.3"
+        },
         client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             "SignatureAlgorithms" => "ECDSA+SHA1",
         },
         test   => {

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -151,10 +151,12 @@ sub generate_version_tests {
                         push @tests, {
                             "name" => "version-negotiation",
                             "client" => {
+                                "CipherString" => "DEFAULT:\@SECLEVEL=0",
                                 "MinProtocol" => $min_protocols[$c_min],
                                 "MaxProtocol" => $max_protocols[$c_max],
                             },
                             "server" => {
+                                "CipherString" => "DEFAULT:\@SECLEVEL=0",
                                 "MinProtocol" => $min_protocols[$s_min],
                                 "MaxProtocol" => $max_protocols[$s_max],
                             },
@@ -254,13 +256,17 @@ sub generate_resumption_tests {
                     # Client is flexible, server upgrades/downgrades.
                     push @server_tests, {
                         "name" => "resumption",
-                        "client" => { },
+                        "client" => {
+                            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+                        },
                         "server" => {
+                            "CipherString" => "DEFAULT:\@SECLEVEL=0",
                             "MinProtocol" => $protocols[$original_protocol],
                             "MaxProtocol" => $protocols[$original_protocol],
                             "Options" => $ticket,
                         },
                         "resume_server" => {
+                            "CipherString" => "DEFAULT:\@SECLEVEL=0",
                             "MaxProtocol" => $protocols[$resume_protocol],
                             "Options" => $ticket,
                         },
@@ -276,13 +282,16 @@ sub generate_resumption_tests {
                     push @client_tests, {
                         "name" => "resumption",
                         "client" => {
+                            "CipherString" => "DEFAULT:\@SECLEVEL=0",
                             "MinProtocol" => $protocols[$original_protocol],
                             "MaxProtocol" => $protocols[$original_protocol],
                         },
                         "server" => {
+                            "CipherString" => "DEFAULT:\@SECLEVEL=0",
                             "Options" => $ticket,
                         },
                         "resume_client" => {
+                            "CipherString" => "DEFAULT:\@SECLEVEL=0",
                             "MaxProtocol" => $protocols[$resume_protocol],
                         },
                         "test" => {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4975,6 +4975,10 @@ static int test_export_key_mat(int tst)
     OPENSSL_assert(tst >= 0 && (size_t)tst < OSSL_NELEM(protocols));
     SSL_CTX_set_max_proto_version(cctx, protocols[tst]);
     SSL_CTX_set_min_proto_version(cctx, protocols[tst]);
+    if ((protocols[tst] < TLS1_2_VERSION) &&
+        (!SSL_CTX_set_cipher_list(cctx, "DEFAULT:@SECLEVEL=0")
+        || !SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0")))
+        goto end;
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL,
                                       NULL))


### PR DESCRIPTION
This has as effect that SHA1 and MD5+SHA1 are no longer supported at
security level 1. This has as effect that TLS < 1.2 is no longer
supported at the default security level of 1, and that you need to set
the security level to 0 to use TLS < 1.2.

The first commit is the commit from #10785.

This will probably not get applied to the 1.1.1 branch, only to master.

This currently has a lot of failing test, because all tests using TLS < 1.2 or DTLS < 1.2 now need to run at security level 0. I need to look at those tests again.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests are added or updated
