### PR TITLE
Deprecate the low level RIPEMD160 functions.

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -348,7 +348,7 @@ static const OPT_PAIR doit_choices[] = {
 #ifndef OPENSSL_NO_WHIRLPOOL
     {"whirlpool", D_WHIRLPOOL},
 #endif
-#ifndef OPENSSL_NO_RMD160
+#if !defined(OPENSSL_NO_RMD160) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"ripemd", D_RMD160},
     {"rmd160", D_RMD160},
     {"ripemd160", D_RMD160},
@@ -696,7 +696,7 @@ static int WHIRLPOOL_loop(void *args)
 }
 #endif
 
-#ifndef OPENSSL_NO_RMD160
+#if !defined(OPENSSL_NO_RMD160) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int EVP_Digest_RMD160_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -2363,7 +2363,7 @@ int speed_main(int argc, char **argv)
     }
 #endif
 
-#ifndef OPENSSL_NO_RMD160
+#if !defined(OPENSSL_NO_RMD160) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_RMD160]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_RMD160], c[D_RMD160][testnum],

--- a/crypto/evp/legacy_ripemd.c
+++ b/crypto/evp/legacy_ripemd.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RIPEMD160 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/ripemd.h>
 #include "crypto/evp.h"
 #include "legacy_meth.h"

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -12,12 +12,20 @@ IF[{- !$disabled{asm} -}]
   ENDIF
 ENDIF
 
-SOURCE[../../libcrypto]=rmd_dgst.c rmd_one.c $RMD160ASM
-
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules
-DEFINE[../../libcrypto]=$RMD160DEF
 DEFINE[../providers/libimplementations.a]=$RMD160DEF
+
+SOURCE[../../libcrypto]=rmd_dgst.c rmd_one.c $RMD160ASM
+DEFINE[../../libcrypto]=$RMD160DEF
+
+# When all deprecated symbols are removed, libcrypto doesn't export the
+# RIPEMD160 functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{"deprecated"}
+      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+  SOURCE[../../providers/liblegacy.a]=rmd_dgst.c rmd_one.c $RMD160ASM
+  DEFINE[../../providers/liblegacy.a]=$RMD160DEF
+ENDIF
 
 GENERATE[rmd-586.s]=asm/rmd-586.pl
 DEPEND[rmd-586.s]=../perlasm/x86asm.pl

--- a/crypto/ripemd/rmd_dgst.c
+++ b/crypto/ripemd/rmd_dgst.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RIPEMD160 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "rmd_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/ripemd/rmd_one.c
+++ b/crypto/ripemd/rmd_one.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RIPEMD160 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/ripemd.h>

--- a/doc/man3/RIPEMD160_Init.pod
+++ b/doc/man3/RIPEMD160_Init.pod
@@ -9,6 +9,10 @@ RIPEMD-160 hash function
 
  #include <openssl/ripemd.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  unsigned char *RIPEMD160(const unsigned char *d, unsigned long n,
                           unsigned char *md);
 
@@ -17,6 +21,10 @@ RIPEMD-160 hash function
  int RIPEMD160_Final(unsigned char *md, RIPEMD160_CTX *c);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated.
+Applications should instead use L<EVP_DigestInit_ex(3)>, L<EVP_DigestUpdate(3)>
+and L<EVP_DigestFinal_ex(3)>.
 
 RIPEMD-160 is a cryptographic hash function with a
 160 bit output.
@@ -58,6 +66,10 @@ ISO/IEC 10118-3:2016 Dedicated Hash-Function 1 (RIPEMD-160).
 =head1 SEE ALSO
 
 L<EVP_DigestInit(3)>
+
+=head1 HISTORY
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ripemd.h
+++ b/include/openssl/ripemd.h
@@ -18,18 +18,18 @@
 
 # include <openssl/opensslconf.h>
 
-#ifndef OPENSSL_NO_RMD160
-# include <openssl/e_os2.h>
-# include <stddef.h>
-# ifdef  __cplusplus
+# ifndef OPENSSL_NO_RMD160
+#  include <openssl/e_os2.h>
+#  include <stddef.h>
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
-# define RIPEMD160_LONG unsigned int
+#  define RIPEMD160_LONG unsigned int
 
-# define RIPEMD160_CBLOCK        64
-# define RIPEMD160_LBLOCK        (RIPEMD160_CBLOCK/4)
-# define RIPEMD160_DIGEST_LENGTH 20
+#  define RIPEMD160_CBLOCK        64
+#  define RIPEMD160_LBLOCK        (RIPEMD160_CBLOCK/4)
+#  define RIPEMD160_DIGEST_LENGTH 20
 
 typedef struct RIPEMD160state_st {
     RIPEMD160_LONG A, B, C, D, E;
@@ -44,10 +44,8 @@ int RIPEMD160_Final(unsigned char *md, RIPEMD160_CTX *c);
 unsigned char *RIPEMD160(const unsigned char *d, size_t n, unsigned char *md);
 void RIPEMD160_Transform(RIPEMD160_CTX *c, const unsigned char *b);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
+#  endif
 # endif
-# endif
-
-
 #endif

--- a/include/openssl/ripemd.h
+++ b/include/openssl/ripemd.h
@@ -21,15 +21,18 @@
 # ifndef OPENSSL_NO_RMD160
 #  include <openssl/e_os2.h>
 #  include <stddef.h>
+
+#  define RIPEMD160_DIGEST_LENGTH 20
+
 #  ifdef  __cplusplus
 extern "C" {
 #  endif
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
 
-#  define RIPEMD160_LONG unsigned int
+#   define RIPEMD160_LONG unsigned int
 
-#  define RIPEMD160_CBLOCK        64
-#  define RIPEMD160_LBLOCK        (RIPEMD160_CBLOCK/4)
-#  define RIPEMD160_DIGEST_LENGTH 20
+#   define RIPEMD160_CBLOCK        64
+#   define RIPEMD160_LBLOCK        (RIPEMD160_CBLOCK/4)
 
 typedef struct RIPEMD160state_st {
     RIPEMD160_LONG A, B, C, D, E;
@@ -37,12 +40,16 @@ typedef struct RIPEMD160state_st {
     RIPEMD160_LONG data[RIPEMD160_LBLOCK];
     unsigned int num;
 } RIPEMD160_CTX;
+#  endif
 
-int RIPEMD160_Init(RIPEMD160_CTX *c);
-int RIPEMD160_Update(RIPEMD160_CTX *c, const void *data, size_t len);
-int RIPEMD160_Final(unsigned char *md, RIPEMD160_CTX *c);
-unsigned char *RIPEMD160(const unsigned char *d, size_t n, unsigned char *md);
-void RIPEMD160_Transform(RIPEMD160_CTX *c, const unsigned char *b);
+DEPRECATEDIN_3_0(int RIPEMD160_Init(RIPEMD160_CTX *c))
+DEPRECATEDIN_3_0(int RIPEMD160_Update(RIPEMD160_CTX *c, const void *data,
+                                      size_t len))
+DEPRECATEDIN_3_0(int RIPEMD160_Final(unsigned char *md, RIPEMD160_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *RIPEMD160(const unsigned char *d, size_t n,
+                                          unsigned char *md))
+DEPRECATEDIN_3_0(void RIPEMD160_Transform(RIPEMD160_CTX *c,
+                                          const unsigned char *b))
 
 #  ifdef  __cplusplus
 }

--- a/providers/implementations/digests/ripemd_prov.c
+++ b/providers/implementations/digests/ripemd_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RIPEMD160 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/ripemd.h>
 #include "prov/digestcommon.h"

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -381,7 +381,7 @@ OPENSSL_strlcpy                         388	3_0_0	EXIST::FUNCTION:
 BIO_get_port                            389	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SOCK
 DISPLAYTEXT_free                        390	3_0_0	EXIST::FUNCTION:
 BN_div                                  391	3_0_0	EXIST::FUNCTION:
-RIPEMD160_Update                        392	3_0_0	EXIST::FUNCTION:RMD160
+RIPEMD160_Update                        392	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160
 PEM_write_bio_CMS                       393	3_0_0	EXIST::FUNCTION:CMS
 ASN1_OBJECT_new                         394	3_0_0	EXIST::FUNCTION:
 EVP_des_ede3_cfb8                       395	3_0_0	EXIST::FUNCTION:DES
@@ -412,7 +412,7 @@ d2i_EXTENDED_KEY_USAGE                  419	3_0_0	EXIST::FUNCTION:
 ASYNC_unblock_pause                     420	3_0_0	EXIST::FUNCTION:
 i2d_X509_VAL                            421	3_0_0	EXIST::FUNCTION:
 ASN1_SCTX_get_flags                     422	3_0_0	EXIST::FUNCTION:
-RIPEMD160                               423	3_0_0	EXIST::FUNCTION:RMD160
+RIPEMD160                               423	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160
 CRYPTO_ocb128_setiv                     424	3_0_0	EXIST::FUNCTION:OCB
 X509_CRL_digest                         425	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_cbc_hmac_sha1               426	3_0_0	EXIST::FUNCTION:
@@ -3399,7 +3399,7 @@ EVP_PKEY_meth_set_init                  3469	3_0_0	EXIST::FUNCTION:
 X509_REQ_extension_nid                  3470	3_0_0	EXIST::FUNCTION:
 ENGINE_up_ref                           3471	3_0_0	EXIST::FUNCTION:ENGINE
 BN_BLINDING_invert_ex                   3472	3_0_0	EXIST::FUNCTION:
-RIPEMD160_Init                          3473	3_0_0	EXIST::FUNCTION:RMD160
+RIPEMD160_Init                          3473	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160
 ASYNC_WAIT_CTX_get_changed_fds          3474	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_save_parameters                3475	3_0_0	EXIST::FUNCTION:
 SCT_set_source                          3476	3_0_0	EXIST::FUNCTION:CT
@@ -3744,7 +3744,7 @@ X509_supported_extension                3825	3_0_0	EXIST::FUNCTION:
 ECDSA_sign_setup                        3826	3_0_0	EXIST::FUNCTION:EC
 EVP_camellia_192_cfb128                 3827	3_0_0	EXIST::FUNCTION:CAMELLIA
 d2i_AUTHORITY_KEYID                     3828	3_0_0	EXIST::FUNCTION:
-RIPEMD160_Transform                     3829	3_0_0	EXIST::FUNCTION:RMD160
+RIPEMD160_Transform                     3829	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160
 DES_random_key                          3830	3_0_0	EXIST::FUNCTION:DES
 i2d_PKCS12_MAC_DATA                     3831	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_EC_KEY                    3832	3_0_0	EXIST::FUNCTION:EC
@@ -3766,7 +3766,7 @@ OCSP_REQ_CTX_get0_mem_bio               3847	3_0_0	EXIST::FUNCTION:OCSP
 i2d_PKCS8PrivateKeyInfo_bio             3848	3_0_0	EXIST::FUNCTION:
 d2i_OCSP_CERTID                         3849	3_0_0	EXIST::FUNCTION:OCSP
 EVP_CIPHER_meth_set_init                3850	3_0_0	EXIST::FUNCTION:
-RIPEMD160_Final                         3851	3_0_0	EXIST::FUNCTION:RMD160
+RIPEMD160_Final                         3851	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160
 NETSCAPE_SPKI_free                      3852	3_0_0	EXIST::FUNCTION:
 BIO_asn1_get_prefix                     3853	3_0_0	EXIST::FUNCTION:
 d2i_OCSP_ONEREQ                         3854	3_0_0	EXIST::FUNCTION:OCSP


### PR DESCRIPTION
Use of the low level RIPEMD160 functions has been informally discouraged for a long time. We now formally deprecate them.

- [x] documentation is added or updated

