### PR TITLE
Deprecate the low level MD2, MD4 and MDC2 functions.

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -329,7 +329,7 @@ static const char *names[ALGOR_NUM] = {
 
 /* list of configured algorithm (remaining), with some few alias */
 static const OPT_PAIR doit_choices[] = {
-#ifndef OPENSSL_NO_MD2
+#if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"md2", D_MD2},
 #endif
 #ifndef OPENSSL_NO_MDC2
@@ -570,7 +570,7 @@ static unsigned int testnum;
 /* Nb of iterations to do per algorithm and key-size */
 static long c[ALGOR_NUM][SIZE_NUM];
 
-#ifndef OPENSSL_NO_MD2
+#if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int EVP_Digest_MD2_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -2241,7 +2241,7 @@ int speed_main(int argc, char **argv)
     signal(SIGALRM, alarmed);
 #endif                          /* SIGALRM */
 
-#ifndef OPENSSL_NO_MD2
+#if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_MD2]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_MD2], c[D_MD2][testnum], lengths[testnum],
@@ -3487,7 +3487,7 @@ int speed_main(int argc, char **argv)
         printf("built on: %s\n", OpenSSL_version(OPENSSL_BUILT_ON));
         printf("options:");
         printf("%s ", BN_options());
-#ifndef OPENSSL_NO_MD2
+#if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         printf("%s ", MD2_options());
 #endif
 #ifndef OPENSSL_NO_RC4

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -332,7 +332,7 @@ static const OPT_PAIR doit_choices[] = {
 #if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"md2", D_MD2},
 #endif
-#ifndef OPENSSL_NO_MDC2
+#if !defined(OPENSSL_NO_MDC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"mdc2", D_MDC2},
 #endif
 #if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
@@ -587,7 +587,7 @@ static int EVP_Digest_MD2_loop(void *args)
 }
 #endif
 
-#ifndef OPENSSL_NO_MDC2
+#if !defined(OPENSSL_NO_MDC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int EVP_Digest_MDC2_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -2253,7 +2253,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_MDC2
+#if !defined(OPENSSL_NO_MDC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_MDC2]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_MDC2], c[D_MDC2][testnum], lengths[testnum],

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -335,7 +335,7 @@ static const OPT_PAIR doit_choices[] = {
 #ifndef OPENSSL_NO_MDC2
     {"mdc2", D_MDC2},
 #endif
-#ifndef OPENSSL_NO_MD4
+#if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"md4", D_MD4},
 #endif
 #ifndef OPENSSL_NO_MD5
@@ -604,7 +604,7 @@ static int EVP_Digest_MDC2_loop(void *args)
 }
 #endif
 
-#ifndef OPENSSL_NO_MD4
+#if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int EVP_Digest_MD4_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -2268,7 +2268,7 @@ int speed_main(int argc, char **argv)
     }
 #endif
 
-#ifndef OPENSSL_NO_MD4
+#if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_MD4]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_MD4], c[D_MD4][testnum], lengths[testnum],

--- a/apps/version.c
+++ b/apps/version.c
@@ -129,9 +129,6 @@ opthelp:
     if (options) {
         printf("options: ");
         printf(" %s", BN_options());
-#ifndef OPENSSL_NO_MD2
-        printf(" %s", MD2_options());
-#endif
 #ifndef OPENSSL_NO_RC4
         printf(" %s", RC4_options());
 #endif

--- a/crypto/evp/legacy_md2.c
+++ b/crypto/evp/legacy_md2.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/md2.h>
 #include "crypto/evp.h"
 #include "legacy_meth.h"

--- a/crypto/evp/legacy_md4.c
+++ b/crypto/evp/legacy_md4.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/md4.h>
 #include "crypto/evp.h"
 #include "legacy_meth.h"

--- a/crypto/evp/legacy_mdc2.c
+++ b/crypto/evp/legacy_mdc2.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MDC2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/mdc2.h>
 #include "crypto/evp.h"
 #include "legacy_meth.h"

--- a/crypto/md2/build.info
+++ b/crypto/md2/build.info
@@ -1,3 +1,10 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        md2_dgst.c md2_one.c
+
+SOURCE[../../libcrypto]=md2_dgst.c md2_one.c
+
+# When all deprecated symbols are removed, libcrypto doesn't export the
+# MD2 functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{"deprecated"}
+      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+  SOURCE[../../providers/liblegacy.a]=md2_dgst.c md2_one.c
+ENDIF

--- a/crypto/md2/md2_dgst.c
+++ b/crypto/md2/md2_dgst.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/crypto/md2/md2_one.c
+++ b/crypto/md2/md2_one.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/md2.h>

--- a/crypto/md4/build.info
+++ b/crypto/md4/build.info
@@ -1,3 +1,10 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        md4_dgst.c md4_one.c
+
+SOURCE[../../libcrypto]=md4_dgst.c md4_one.c
+
+# When all deprecated symbols are removed, libcrypto doesn't export the
+# MD4 functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{"deprecated"}
+      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+  SOURCE[../../providers/liblegacy.a]=md4_dgst.c md4_one.c
+ENDIF

--- a/crypto/md4/md4_dgst.c
+++ b/crypto/md4/md4_dgst.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <openssl/opensslv.h>
 #include "md4_local.h"

--- a/crypto/md4/md4_one.c
+++ b/crypto/md4/md4_one.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/md4.h>

--- a/crypto/mdc2/build.info
+++ b/crypto/mdc2/build.info
@@ -1,3 +1,10 @@
 LIBS=../../libcrypto
-SOURCE[../../libcrypto]=\
-        mdc2dgst.c mdc2_one.c
+
+SOURCE[../../libcrypto]=mdc2dgst.c mdc2_one.c
+
+# When all deprecated symbols are removed, libcrypto doesn't export the
+# MDC2 functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{"deprecated"}
+      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+  SOURCE[../../providers/liblegacy.a]=mdc2dgst.c mdc2_one.c
+ENDIF

--- a/crypto/mdc2/mdc2_one.c
+++ b/crypto/mdc2/mdc2_one.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/mdc2.h>

--- a/crypto/mdc2/mdc2dgst.c
+++ b/crypto/mdc2/mdc2dgst.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/doc/man3/MD5.pod
+++ b/doc/man3/MD5.pod
@@ -22,6 +22,10 @@ L<openssl_user_macros(7)>:
 
  #include <openssl/md4.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  unsigned char *MD4(const unsigned char *d, unsigned long n, unsigned char *md);
 
  int MD4_Init(MD4_CTX *c);

--- a/doc/man3/MD5.pod
+++ b/doc/man3/MD5.pod
@@ -9,6 +9,10 @@ MD4_Final, MD5_Init, MD5_Update, MD5_Final - MD2, MD4, and MD5 hash functions
 
  #include <openssl/md2.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  unsigned char *MD2(const unsigned char *d, unsigned long n, unsigned char *md);
 
  int MD2_Init(MD2_CTX *c);
@@ -34,6 +38,10 @@ MD4_Final, MD5_Init, MD5_Update, MD5_Final - MD2, MD4, and MD5 hash functions
  int MD5_Final(unsigned char *md, MD5_CTX *c);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated.
+Applications should instead use L<EVP_DigestInit_ex(3)>, L<EVP_DigestUpdate(3)>
+and L<EVP_DigestFinal_ex(3)>.
 
 MD2, MD4, and MD5 are cryptographic hash functions with a 128 bit output.
 
@@ -82,6 +90,10 @@ RFC 1319, RFC 1320, RFC 1321
 =head1 SEE ALSO
 
 L<EVP_DigestInit(3)>
+
+=head1 HISTORY
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/MDC2_Init.pod
+++ b/doc/man3/MDC2_Init.pod
@@ -8,6 +8,10 @@ MDC2, MDC2_Init, MDC2_Update, MDC2_Final - MDC2 hash function
 
  #include <openssl/mdc2.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  unsigned char *MDC2(const unsigned char *d, unsigned long n,
                      unsigned char *md);
 
@@ -17,6 +21,10 @@ MDC2, MDC2_Init, MDC2_Update, MDC2_Final - MDC2 hash function
  int MDC2_Final(unsigned char *md, MDC2_CTX *c);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated.
+Applications should instead use L<EVP_DigestInit_ex(3)>, L<EVP_DigestUpdate(3)>
+and L<EVP_DigestFinal_ex(3)>.
 
 MDC2 is a method to construct hash functions with 128 bit output from
 block ciphers.  These functions are an implementation of MDC2 with
@@ -55,6 +63,10 @@ ISO/IEC 10118-2:2000 Hash-Function 2, with DES as the underlying block cipher.
 =head1 SEE ALSO
 
 L<EVP_DigestInit(3)>
+
+=head1 HISTORY
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/md2.h
+++ b/include/openssl/md2.h
@@ -19,15 +19,15 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_MD2
-# include <stddef.h>
-# ifdef  __cplusplus
+#  include <stddef.h>
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
 typedef unsigned char MD2_INT;
 
-# define MD2_DIGEST_LENGTH       16
-# define MD2_BLOCK               16
+#  define MD2_DIGEST_LENGTH       16
+#  define MD2_BLOCK               16
 
 typedef struct MD2state_st {
     unsigned int num;
@@ -42,9 +42,9 @@ int MD2_Update(MD2_CTX *c, const unsigned char *data, size_t len);
 int MD2_Final(unsigned char *md, MD2_CTX *c);
 unsigned char *MD2(const unsigned char *d, size_t n, unsigned char *md);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/md2.h
+++ b/include/openssl/md2.h
@@ -24,10 +24,13 @@
 extern "C" {
 #  endif
 
+#  define MD2_DIGEST_LENGTH       16
+
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
+
 typedef unsigned char MD2_INT;
 
-#  define MD2_DIGEST_LENGTH       16
-#  define MD2_BLOCK               16
+#   define MD2_BLOCK               16
 
 typedef struct MD2state_st {
     unsigned int num;
@@ -35,16 +38,18 @@ typedef struct MD2state_st {
     MD2_INT cksm[MD2_BLOCK];
     MD2_INT state[MD2_BLOCK];
 } MD2_CTX;
+#  endif
 
-const char *MD2_options(void);
-int MD2_Init(MD2_CTX *c);
-int MD2_Update(MD2_CTX *c, const unsigned char *data, size_t len);
-int MD2_Final(unsigned char *md, MD2_CTX *c);
-unsigned char *MD2(const unsigned char *d, size_t n, unsigned char *md);
+DEPRECATEDIN_3_0(const char *MD2_options(void))
+DEPRECATEDIN_3_0(int MD2_Init(MD2_CTX *c))
+DEPRECATEDIN_3_0(int MD2_Update(MD2_CTX *c, const unsigned char *data,
+                                size_t len))
+DEPRECATEDIN_3_0(int MD2_Final(unsigned char *md, MD2_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *MD2(const unsigned char *d, size_t n,
+                 unsigned char *md))
 
 #  ifdef  __cplusplus
 }
 #  endif
 # endif
-
 #endif

--- a/include/openssl/md4.h
+++ b/include/openssl/md4.h
@@ -23,18 +23,21 @@
 #  include <stddef.h>
 #  ifdef  __cplusplus
 extern "C" {
-#  endif
+#   endif
+
+#  define MD4_DIGEST_LENGTH 16
+
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
 
 /*-
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! MD4_LONG has to be at least 32 bits wide.                     !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-#  define MD4_LONG unsigned int
+#   define MD4_LONG unsigned int
 
-#  define MD4_CBLOCK      64
-#  define MD4_LBLOCK      (MD4_CBLOCK/4)
-#  define MD4_DIGEST_LENGTH 16
+#   define MD4_CBLOCK      64
+#   define MD4_LBLOCK      (MD4_CBLOCK/4)
 
 typedef struct MD4state_st {
     MD4_LONG A, B, C, D;
@@ -42,12 +45,14 @@ typedef struct MD4state_st {
     MD4_LONG data[MD4_LBLOCK];
     unsigned int num;
 } MD4_CTX;
+#  endif
 
-int MD4_Init(MD4_CTX *c);
-int MD4_Update(MD4_CTX *c, const void *data, size_t len);
-int MD4_Final(unsigned char *md, MD4_CTX *c);
-unsigned char *MD4(const unsigned char *d, size_t n, unsigned char *md);
-void MD4_Transform(MD4_CTX *c, const unsigned char *b);
+DEPRECATEDIN_3_0(int MD4_Init(MD4_CTX *c))
+DEPRECATEDIN_3_0(int MD4_Update(MD4_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int MD4_Final(unsigned char *md, MD4_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *MD4(const unsigned char *d, size_t n,
+                 unsigned char *md))
+DEPRECATEDIN_3_0(void MD4_Transform(MD4_CTX *c, const unsigned char *b))
 
 #  ifdef  __cplusplus
 }

--- a/include/openssl/md4.h
+++ b/include/openssl/md4.h
@@ -19,22 +19,22 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_MD4
-# include <openssl/e_os2.h>
-# include <stddef.h>
-# ifdef  __cplusplus
+#  include <openssl/e_os2.h>
+#  include <stddef.h>
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
 /*-
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! MD4_LONG has to be at least 32 bits wide.                     !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-# define MD4_LONG unsigned int
+#  define MD4_LONG unsigned int
 
-# define MD4_CBLOCK      64
-# define MD4_LBLOCK      (MD4_CBLOCK/4)
-# define MD4_DIGEST_LENGTH 16
+#  define MD4_CBLOCK      64
+#  define MD4_LBLOCK      (MD4_CBLOCK/4)
+#  define MD4_DIGEST_LENGTH 16
 
 typedef struct MD4state_st {
     MD4_LONG A, B, C, D;
@@ -49,9 +49,9 @@ int MD4_Final(unsigned char *md, MD4_CTX *c);
 unsigned char *MD4(const unsigned char *d, size_t n, unsigned char *md);
 void MD4_Transform(MD4_CTX *c, const unsigned char *b);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/mdc2.h
+++ b/include/openssl/mdc2.h
@@ -25,8 +25,11 @@
 extern "C" {
 #  endif
 
-#  define MDC2_BLOCK              8
 #  define MDC2_DIGEST_LENGTH      16
+
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
+
+#   define MDC2_BLOCK              8
 
 typedef struct mdc2_ctx_st {
     unsigned int num;
@@ -34,11 +37,14 @@ typedef struct mdc2_ctx_st {
     DES_cblock h, hh;
     unsigned int pad_type;   /* either 1 or 2, default 1 */
 } MDC2_CTX;
+#  endif
 
-int MDC2_Init(MDC2_CTX *c);
-int MDC2_Update(MDC2_CTX *c, const unsigned char *data, size_t len);
-int MDC2_Final(unsigned char *md, MDC2_CTX *c);
-unsigned char *MDC2(const unsigned char *d, size_t n, unsigned char *md);
+DEPRECATEDIN_3_0(int MDC2_Init(MDC2_CTX *c))
+DEPRECATEDIN_3_0(int MDC2_Update(MDC2_CTX *c, const unsigned char *data,
+                 size_t len))
+DEPRECATEDIN_3_0(int MDC2_Final(unsigned char *md, MDC2_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *MDC2(const unsigned char *d, size_t n,
+                 unsigned char *md))
 
 #  ifdef  __cplusplus
 }

--- a/include/openssl/mdc2.h
+++ b/include/openssl/mdc2.h
@@ -18,15 +18,15 @@
 
 # include <openssl/opensslconf.h>
 
-#ifndef OPENSSL_NO_MDC2
-# include <stdlib.h>
-# include <openssl/des.h>
-# ifdef  __cplusplus
+# ifndef OPENSSL_NO_MDC2
+#  include <stdlib.h>
+#  include <openssl/des.h>
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
-# define MDC2_BLOCK              8
-# define MDC2_DIGEST_LENGTH      16
+#  define MDC2_BLOCK              8
+#  define MDC2_DIGEST_LENGTH      16
 
 typedef struct mdc2_ctx_st {
     unsigned int num;
@@ -40,9 +40,9 @@ int MDC2_Update(MDC2_CTX *c, const unsigned char *data, size_t len);
 int MDC2_Final(unsigned char *md, MDC2_CTX *c);
 unsigned char *MDC2(const unsigned char *d, size_t n, unsigned char *md);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/providers/implementations/digests/md2_prov.c
+++ b/providers/implementations/digests/md2_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/md2.h>
 #include "prov/digestcommon.h"

--- a/providers/implementations/digests/md4_prov.c
+++ b/providers/implementations/digests/md4_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/md4.h>
 #include "prov/digestcommon.h"

--- a/providers/implementations/digests/mdc2_prov.c
+++ b/providers/implementations/digests/mdc2_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MDC2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/params.h>
 #include <openssl/mdc2.h>

--- a/test/build.info
+++ b/test/build.info
@@ -624,15 +624,15 @@ IF[{- !$disabled{tests} -}]
     SOURCE[keymgmt_internal_test]=keymgmt_internal_test.c
     INCLUDE[keymgmt_internal_test]=.. ../include ../apps/include
     DEPEND[keymgmt_internal_test]=../libcrypto.a libtestutil.a
-  ENDIF
 
-  IF[{- !$disabled{mdc2} -}]
-    PROGRAMS{noinst}=mdc2_internal_test
-  ENDIF
+    IF[{- !$disabled{mdc2} -}]
+      PROGRAMS{noinst}=mdc2_internal_test
+    ENDIF
 
-  SOURCE[mdc2_internal_test]=mdc2_internal_test.c
-  INCLUDE[mdc2_internal_test]=.. ../include ../apps/include
-  DEPEND[mdc2_internal_test]=../libcrypto libtestutil.a
+    SOURCE[mdc2_internal_test]=mdc2_internal_test.c
+    INCLUDE[mdc2_internal_test]=.. ../include ../apps/include
+    DEPEND[mdc2_internal_test]=../libcrypto.a libtestutil.a
+  ENDIF
 
   PROGRAMS{noinst}=asn1_time_test
   SOURCE[asn1_time_test]=asn1_time_test.c

--- a/test/md2test.c
+++ b/test/md2test.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 
 #include <openssl/provider.h>

--- a/test/mdc2_internal_test.c
+++ b/test/mdc2_internal_test.c
@@ -9,6 +9,12 @@
 
 /* Internal tests for the mdc2 module */
 
+/*
+ * MDC2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 

--- a/test/mdc2test.c
+++ b/test/mdc2test.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MDC2 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/provider.h>
 #include <openssl/params.h>

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -237,7 +237,7 @@ SEED_set_key                            241	3_0_0	EXIST::FUNCTION:SEED
 EC_KEY_clear_flags                      242	3_0_0	EXIST::FUNCTION:EC
 CMS_RecipientInfo_ktri_get0_algs        243	3_0_0	EXIST::FUNCTION:CMS
 i2d_EC_PUBKEY                           244	3_0_0	EXIST::FUNCTION:EC
-MDC2                                    245	3_0_0	EXIST::FUNCTION:MDC2
+MDC2                                    245	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MDC2
 BN_clear_free                           246	3_0_0	EXIST::FUNCTION:
 ENGINE_get_pkey_asn1_meths              247	3_0_0	EXIST::FUNCTION:ENGINE
 DSO_merge                               248	3_0_0	EXIST::FUNCTION:
@@ -1112,7 +1112,7 @@ X509_set_issuer_name                    1138	3_0_0	EXIST::FUNCTION:
 RSA_new                                 1139	3_0_0	EXIST::FUNCTION:RSA
 ASN1_STRING_set_by_NID                  1140	3_0_0	EXIST::FUNCTION:
 PEM_write_bio_PKCS7                     1141	3_0_0	EXIST::FUNCTION:
-MDC2_Final                              1142	3_0_0	EXIST::FUNCTION:MDC2
+MDC2_Final                              1142	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MDC2
 SMIME_crlf_copy                         1143	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_get_ext_count              1144	3_0_0	EXIST::FUNCTION:OCSP
 OCSP_REQ_CTX_new                        1145	3_0_0	EXIST::FUNCTION:OCSP
@@ -1184,7 +1184,7 @@ X509_policy_tree_free                   1210	3_0_0	EXIST::FUNCTION:
 EC_GFp_simple_method                    1211	3_0_0	EXIST::FUNCTION:EC
 X509_it                                 1212	3_0_0	EXIST::FUNCTION:
 d2i_PROXY_POLICY                        1213	3_0_0	EXIST::FUNCTION:
-MDC2_Update                             1214	3_0_0	EXIST::FUNCTION:MDC2
+MDC2_Update                             1214	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MDC2
 EC_KEY_new_by_curve_name                1215	3_0_0	EXIST::FUNCTION:EC
 X509_CRL_free                           1216	3_0_0	EXIST::FUNCTION:
 i2d_PKCS7_SIGN_ENVELOPE                 1217	3_0_0	EXIST::FUNCTION:
@@ -2025,7 +2025,7 @@ BIO_new_CMS                             2071	3_0_0	EXIST::FUNCTION:CMS
 i2d_ASN1_ENUMERATED                     2072	3_0_0	EXIST::FUNCTION:
 PEM_read_DSAparams                      2073	3_0_0	EXIST::FUNCTION:DSA,STDIO
 TS_TST_INFO_set_ordering                2074	3_0_0	EXIST::FUNCTION:TS
-MDC2_Init                               2075	3_0_0	EXIST::FUNCTION:MDC2
+MDC2_Init                               2075	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MDC2
 i2o_SCT                                 2076	3_0_0	EXIST::FUNCTION:CT
 d2i_TS_STATUS_INFO                      2077	3_0_0	EXIST::FUNCTION:TS
 ERR_error_string_n                      2078	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2334,7 +2334,7 @@ ENGINE_get_pkey_asn1_meth_engine        2382	3_0_0	EXIST::FUNCTION:ENGINE
 d2i_ASN1_BMPSTRING                      2383	3_0_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_create0_p8inf            2384	3_0_0	EXIST::FUNCTION:
 OBJ_cmp                                 2385	3_0_0	EXIST::FUNCTION:
-MD2                                     2386	3_0_0	EXIST::FUNCTION:MD2
+MD2                                     2386	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 X509_PUBKEY_new                         2387	3_0_0	EXIST::FUNCTION:
 BN_CTX_end                              2388	3_0_0	EXIST::FUNCTION:
 BIO_get_retry_BIO                       2389	3_0_0	EXIST::FUNCTION:
@@ -2415,7 +2415,7 @@ OCSP_REQINFO_new                        2465	3_0_0	EXIST::FUNCTION:OCSP
 Camellia_decrypt                        2466	3_0_0	EXIST::FUNCTION:CAMELLIA
 X509_signature_print                    2467	3_0_0	EXIST::FUNCTION:
 EVP_camellia_128_ecb                    2468	3_0_0	EXIST::FUNCTION:CAMELLIA
-MD2_Final                               2469	3_0_0	EXIST::FUNCTION:MD2
+MD2_Final                               2469	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 OCSP_REQ_CTX_add1_header                2470	3_0_0	EXIST::FUNCTION:OCSP
 NETSCAPE_SPKAC_it                       2471	3_0_0	EXIST::FUNCTION:
 ASIdOrRange_free                        2472	3_0_0	EXIST::FUNCTION:RFC3779
@@ -3175,7 +3175,7 @@ i2d_PUBKEY                              3240	3_0_0	EXIST::FUNCTION:
 ERR_load_EVP_strings                    3241	3_0_0	EXIST::FUNCTION:
 X509_ATTRIBUTE_set1_data                3242	3_0_0	EXIST::FUNCTION:
 d2i_X509_fp                             3243	3_0_0	EXIST::FUNCTION:STDIO
-MD2_Init                                3244	3_0_0	EXIST::FUNCTION:MD2
+MD2_Init                                3244	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 ERR_get_error_line                      3245	3_0_0	EXIST::FUNCTION:
 X509_CRL_get_ext_by_NID                 3246	3_0_0	EXIST::FUNCTION:
 OPENSSL_INIT_free                       3247	3_0_0	EXIST::FUNCTION:
@@ -3514,7 +3514,7 @@ ENGINE_unregister_ciphers               3589	3_0_0	EXIST::FUNCTION:ENGINE
 X509_issuer_and_serial_cmp              3590	3_0_0	EXIST::FUNCTION:
 OCSP_response_create                    3591	3_0_0	EXIST::FUNCTION:OCSP
 SHA224                                  3592	3_0_0	EXIST::FUNCTION:
-MD2_options                             3593	3_0_0	EXIST::FUNCTION:MD2
+MD2_options                             3593	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 X509_REQ_it                             3595	3_0_0	EXIST::FUNCTION:
 RAND_bytes                              3596	3_0_0	EXIST::FUNCTION:
 PKCS7_free                              3597	3_0_0	EXIST::FUNCTION:
@@ -3546,7 +3546,7 @@ SRP_VBASE_get1_by_user                  3622	3_0_0	EXIST::FUNCTION:SRP
 UI_method_get_closer                    3623	3_0_0	EXIST::FUNCTION:
 ENGINE_get_ex_data                      3624	3_0_0	EXIST::FUNCTION:ENGINE
 BN_print_fp                             3625	3_0_0	EXIST::FUNCTION:STDIO
-MD2_Update                              3626	3_0_0	EXIST::FUNCTION:MD2
+MD2_Update                              3626	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 ENGINE_free                             3628	3_0_0	EXIST::FUNCTION:ENGINE
 d2i_X509_ATTRIBUTE                      3629	3_0_0	EXIST::FUNCTION:
 TS_RESP_free                            3630	3_0_0	EXIST::FUNCTION:TS

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -421,7 +421,7 @@ EVP_MD_CTX_md                           428	3_0_0	EXIST::FUNCTION:
 X509_REVOKED_get_ext                    429	3_0_0	EXIST::FUNCTION:
 d2i_RSA_PSS_PARAMS                      430	3_0_0	EXIST::FUNCTION:RSA
 USERNOTICE_free                         431	3_0_0	EXIST::FUNCTION:
-MD4_Transform                           432	3_0_0	EXIST::FUNCTION:MD4
+MD4_Transform                           432	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 EVP_CIPHER_block_size                   433	3_0_0	EXIST::FUNCTION:
 CERTIFICATEPOLICIES_new                 434	3_0_0	EXIST::FUNCTION:
 BIO_dump_fp                             435	3_0_0	EXIST::FUNCTION:STDIO
@@ -2541,7 +2541,7 @@ EC_GROUP_get_order                      2594	3_0_0	EXIST::FUNCTION:EC
 X509_REVOKED_add1_ext_i2d               2595	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_add1_host             2596	3_0_0	EXIST::FUNCTION:
 i2d_PUBKEY_bio                          2597	3_0_0	EXIST::FUNCTION:
-MD4_Update                              2598	3_0_0	EXIST::FUNCTION:MD4
+MD4_Update                              2598	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 X509_STORE_CTX_set_time                 2599	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_DH                   2600	3_0_0	EXIST::FUNCTION:ENGINE
 X509_ocspid_print                       2601	3_0_0	EXIST::FUNCTION:
@@ -2591,7 +2591,7 @@ ASN1_item_dup                           2646	3_0_0	EXIST::FUNCTION:
 GENERAL_NAMES_it                        2647	3_0_0	EXIST::FUNCTION:
 X509_issuer_name_hash                   2648	3_0_0	EXIST::FUNCTION:
 TS_TST_INFO_get_nonce                   2649	3_0_0	EXIST::FUNCTION:TS
-MD4_Init                                2650	3_0_0	EXIST::FUNCTION:MD4
+MD4_Init                                2650	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 X509_EXTENSION_create_by_OBJ            2651	3_0_0	EXIST::FUNCTION:
 EVP_aes_256_cbc_hmac_sha1               2652	3_0_0	EXIST::FUNCTION:
 SCT_validate                            2653	3_0_0	EXIST::FUNCTION:CT
@@ -3144,7 +3144,7 @@ i2d_PKCS12_SAFEBAG                      3209	3_0_0	EXIST::FUNCTION:
 BN_rand_range                           3210	3_0_0	EXIST::FUNCTION:
 SMIME_write_ASN1                        3211	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_new                      3212	3_0_0	EXIST::FUNCTION:
-MD4_Final                               3213	3_0_0	EXIST::FUNCTION:MD4
+MD4_Final                               3213	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 EVP_PKEY_id                             3214	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_get0_pkey_ctx         3215	3_0_0	EXIST::FUNCTION:CMS
 OCSP_REQINFO_free                       3216	3_0_0	EXIST::FUNCTION:OCSP
@@ -3187,7 +3187,7 @@ EVP_des_ede3_wrap                       3252	3_0_0	EXIST::FUNCTION:DES
 GENERAL_SUBTREE_it                      3253	3_0_0	EXIST::FUNCTION:
 EVP_read_pw_string_min                  3254	3_0_0	EXIST::FUNCTION:
 X509_set1_notBefore                     3255	3_0_0	EXIST::FUNCTION:
-MD4                                     3256	3_0_0	EXIST::FUNCTION:MD4
+MD4                                     3256	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 EVP_PKEY_CTX_dup                        3257	3_0_0	EXIST::FUNCTION:
 ENGINE_setup_bsd_cryptodev              3258	3_0_0	EXIST:__FreeBSD__:FUNCTION:DEPRECATEDIN_1_1_0,ENGINE
 PEM_read_bio_DHparams                   3259	3_0_0	EXIST::FUNCTION:DH


### PR DESCRIPTION
Use of the low level MD2, MD4 and MDC2 functions have been informally discouraged for a long time. We now formally deprecate them.

There is a change in the documentation which impacts MD5 as well but the corresponding code changes haven't been made yet.

- [x] documentation is added or updated
- [x] tests are added or updated
