### PR TITLE
Deprecate the low level SHA* functions.

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -338,7 +338,7 @@ static const OPT_PAIR doit_choices[] = {
 #if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"md4", D_MD4},
 #endif
-#ifndef OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_MD5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"md5", D_MD5},
     {"hmac", D_HMAC},
 #endif
@@ -623,7 +623,7 @@ static int EVP_Digest_MD4_loop(void *args)
 }
 #endif
 
-#ifndef OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_MD5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int MD5_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -2289,7 +2289,7 @@ int speed_main(int argc, char **argv)
     }
 #endif
 
-#ifndef OPENSSL_NO_MD5
+#if !defined(OPENSSL_NO_MD5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_MD5]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_MD5], c[D_MD5][testnum], lengths[testnum],

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -342,9 +342,11 @@ static const OPT_PAIR doit_choices[] = {
     {"md5", D_MD5},
     {"hmac", D_HMAC},
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     {"sha1", D_SHA1},
     {"sha256", D_SHA256},
     {"sha512", D_SHA512},
+#endif
 #if !defined(OPENSSL_NO_WHIRLPOOL) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"whirlpool", D_WHIRLPOOL},
 #endif
@@ -650,6 +652,7 @@ static int HMAC_loop(void *args)
 }
 #endif
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 static int SHA1_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
@@ -682,6 +685,7 @@ static int SHA512_loop(void *args)
         SHA512(buf, lengths[testnum], sha512);
     return count;
 }
+#endif
 
 #if !defined(OPENSSL_NO_WHIRLPOOL) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static int WHIRLPOOL_loop(void *args)
@@ -2322,6 +2326,7 @@ int speed_main(int argc, char **argv)
             HMAC_CTX_free(loopargs[i].hctx);
     }
 #endif
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     if (doit[D_SHA1]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_SHA1], c[D_SHA1][testnum], lengths[testnum],
@@ -2352,6 +2357,7 @@ int speed_main(int argc, char **argv)
             print_result(D_SHA512, testnum, count, d);
         }
     }
+#endif
 #if !defined(OPENSSL_NO_WHIRLPOOL) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_WHIRLPOOL]) {
         for (testnum = 0; testnum < size_num; testnum++) {

--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -76,14 +76,14 @@ static int ct_v1_log_id_from_pkey(EVP_PKEY *pkey,
     int ret = 0;
     unsigned char *pkey_der = NULL;
     int pkey_der_len = i2d_PUBKEY(pkey, &pkey_der);
+    unsigned int len;
 
     if (pkey_der_len <= 0) {
         CTerr(CT_F_CT_V1_LOG_ID_FROM_PKEY, CT_R_LOG_KEY_INVALID);
         goto err;
     }
 
-    SHA256(pkey_der, pkey_der_len, log_id);
-    ret = 1;
+    ret = EVP_Digest(pkey_der, pkey_der_len, log_id, &len, EVP_sha256(), NULL);
 err:
     OPENSSL_free(pkey_der);
     return ret;

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -1156,6 +1156,7 @@ static int s390x_pkey_ecd_keygen25519(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     unsigned char x_dst[32], buff[SHA512_DIGEST_LENGTH];
     ECX_KEY *key;
     unsigned char *privkey = NULL, *pubkey;
+    unsigned int sz;
 
     key = OPENSSL_zalloc(sizeof(*key));
     if (key == NULL) {
@@ -1174,7 +1175,9 @@ static int s390x_pkey_ecd_keygen25519(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
     if (RAND_priv_bytes(privkey, ED25519_KEYLEN) <= 0)
         goto err;
 
-    SHA512(privkey, 32, buff);
+    if (!EVP_Digest(privkey, 32, buff, &sz, EVP_sha512(), NULL))
+        goto err;
+
     buff[0] &= 248;
     buff[31] &= 63;
     buff[31] |= 64;

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -9,8 +9,8 @@
  */
 
 /*
- * RC4 low level APIs are deprecated for public use, but still ok for internal
- * use.
+ * RC4 and SHA-1 low level APIs are deprecated for public use, but still ok
+ * for internal use.
  */
 #include "internal/deprecated.h"
 

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -8,8 +8,8 @@
  */
 
 /*
- * RC4 low level APIs are deprecated for public use, but still ok for internal
- * use.
+ * MD5 and RC4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
  */
 #include "internal/deprecated.h"
 

--- a/crypto/evp/legacy_md5.c
+++ b/crypto/evp/legacy_md5.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD5 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/md5.h>
 #include "crypto/evp.h"
 #include "legacy_meth.h"

--- a/crypto/evp/legacy_md5_sha1.c
+++ b/crypto/evp/legacy_md5_sha1.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.  The prov/md5_sha1.h include requires this, but this must
+ * be the first include loaded.
+ */
+#include "internal/deprecated.h"
+
 #include "crypto/evp.h"
 #include "prov/md5_sha1.h"   /* diverse MD5_SHA1 macros */
 #include "legacy_meth.h"

--- a/crypto/evp/legacy_md5_sha1.c
+++ b/crypto/evp/legacy_md5_sha1.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * MD5 and SHA-1 low level APIs are deprecated for public use, but still ok for
  * internal use.  The prov/md5_sha1.h include requires this, but this must
  * be the first include loaded.
  */

--- a/crypto/evp/legacy_sha.c
+++ b/crypto/evp/legacy_sha.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * All SHA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/sha.h>         /* diverse SHA macros */
 #include "internal/sha3.h"       /* KECCAK1600_WIDTH */
 #include "crypto/evp.h"

--- a/crypto/md5/md5_dgst.c
+++ b/crypto/md5/md5_dgst.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD5 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "md5_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/md5/md5_one.c
+++ b/crypto/md5/md5_one.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD5 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/md5.h>

--- a/crypto/md5/md5_sha1.c
+++ b/crypto/md5/md5_sha1.c
@@ -6,6 +6,13 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include "prov/md5_sha1.h"
 #include <openssl/evp.h>

--- a/crypto/md5/md5_sha1.c
+++ b/crypto/md5/md5_sha1.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * MD5 and SHA-1 low level APIs are deprecated for public use, but still ok for
  * internal use.
  */
 #include "internal/deprecated.h"

--- a/crypto/sha/sha1_one.c
+++ b/crypto/sha/sha1_one.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/crypto.h>

--- a/crypto/sha/sha1dgst.c
+++ b/crypto/sha/sha1dgst.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/opensslconf.h>
 

--- a/crypto/sha/sha256.c
+++ b/crypto/sha/sha256.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA256 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/opensslconf.h>
 
 #include <stdlib.h>

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA512 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
+#include <stdio.h>
 #include <openssl/opensslconf.h>
 /*-
  * IMPLEMENTATION NOTES.

--- a/doc/man3/MD5.pod
+++ b/doc/man3/MD5.pod
@@ -35,6 +35,10 @@ L<openssl_user_macros(7)>:
 
  #include <openssl/md5.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  unsigned char *MD5(const unsigned char *d, unsigned long n, unsigned char *md);
 
  int MD5_Init(MD5_CTX *c);

--- a/doc/man3/SHA256_Init.pod
+++ b/doc/man3/SHA256_Init.pod
@@ -11,6 +11,10 @@ SHA512_Final - Secure Hash Algorithm
 
  #include <openssl/sha.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  int SHA1_Init(SHA_CTX *c);
  int SHA1_Update(SHA_CTX *c, const void *data, size_t len);
  int SHA1_Final(unsigned char *md, SHA_CTX *c);
@@ -43,9 +47,9 @@ SHA512_Final - Secure Hash Algorithm
 
 =head1 DESCRIPTION
 
-Applications should use the higher level functions
-L<EVP_DigestInit(3)> etc. instead of calling the hash
-functions directly.
+All of the functions described on this page are deprecated.
+Applications should instead use L<EVP_DigestInit_ex(3)>, L<EVP_DigestUpdate(3)>
+and L<EVP_DigestFinal_ex(3)>.
 
 SHA-1 (Secure Hash Algorithm) is a cryptographic hash function with a
 160 bit output.
@@ -95,6 +99,10 @@ ANSI X9.30
 =head1 SEE ALSO
 
 L<EVP_DigestInit(3)>
+
+=head1 HISTORY
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -7,6 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.  Note, that due to symbols not being exported, only the
+ * #defines and strucures can be accessed, in this case SHA_CBLOCK and
+ * sizeof(SHA_CTX).
+ */
+#include "internal/deprecated.h"
+
 #if defined(_WIN32)
 # include <windows.h>
 #endif
@@ -492,13 +500,11 @@ static void dummy_pause_job(void) {
  * SHA1 implementation. At the moment we just defer to the standard
  * implementation
  */
-#undef data
-#define data(ctx) ((SHA_CTX *)EVP_MD_CTX_md_data(ctx))
 static int dasync_sha1_init(EVP_MD_CTX *ctx)
 {
     dummy_pause_job();
 
-    return SHA1_Init(data(ctx));
+    return EVP_MD_meth_get_init(EVP_sha1())(ctx);
 }
 
 static int dasync_sha1_update(EVP_MD_CTX *ctx, const void *data,
@@ -506,14 +512,14 @@ static int dasync_sha1_update(EVP_MD_CTX *ctx, const void *data,
 {
     dummy_pause_job();
 
-    return SHA1_Update(data(ctx), data, (size_t)count);
+    return EVP_MD_meth_get_update(EVP_sha1())(ctx, data, count);
 }
 
 static int dasync_sha1_final(EVP_MD_CTX *ctx, unsigned char *md)
 {
     dummy_pause_job();
 
-    return SHA1_Final(md, data(ctx));
+    return EVP_MD_meth_get_final(EVP_sha1())(ctx, md);
 }
 
 /*

--- a/include/openssl/md5.h
+++ b/include/openssl/md5.h
@@ -19,22 +19,24 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_MD5
-# include <openssl/e_os2.h>
-# include <stddef.h>
-# ifdef  __cplusplus
+#  include <openssl/e_os2.h>
+#  include <stddef.h>
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
+#  define MD5_DIGEST_LENGTH 16
+
+#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
 /*
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! MD5_LONG has to be at least 32 bits wide.                     !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-# define MD5_LONG unsigned int
+#   define MD5_LONG unsigned int
 
-# define MD5_CBLOCK      64
-# define MD5_LBLOCK      (MD5_CBLOCK/4)
-# define MD5_DIGEST_LENGTH 16
+#   define MD5_CBLOCK      64
+#   define MD5_LBLOCK      (MD5_CBLOCK/4)
 
 typedef struct MD5state_st {
     MD5_LONG A, B, C, D;
@@ -42,15 +44,18 @@ typedef struct MD5state_st {
     MD5_LONG data[MD5_LBLOCK];
     unsigned int num;
 } MD5_CTX;
+#  endif
 
-int MD5_Init(MD5_CTX *c);
-int MD5_Update(MD5_CTX *c, const void *data, size_t len);
-int MD5_Final(unsigned char *md, MD5_CTX *c);
-unsigned char *MD5(const unsigned char *d, size_t n, unsigned char *md);
-void MD5_Transform(MD5_CTX *c, const unsigned char *b);
-# ifdef  __cplusplus
+DEPRECATEDIN_3_0(int MD5_Init(MD5_CTX *c))
+DEPRECATEDIN_3_0(int MD5_Update(MD5_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int MD5_Final(unsigned char *md, MD5_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *MD5(const unsigned char *d, size_t n,
+                                    unsigned char *md))
+DEPRECATEDIN_3_0(void MD5_Transform(MD5_CTX *c, const unsigned char *b))
+
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/md5.h
+++ b/include/openssl/md5.h
@@ -19,24 +19,22 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_MD5
-#  include <openssl/e_os2.h>
-#  include <stddef.h>
-#  ifdef  __cplusplus
+# include <openssl/e_os2.h>
+# include <stddef.h>
+# ifdef  __cplusplus
 extern "C" {
-#  endif
+# endif
 
-#  define MD5_DIGEST_LENGTH 16
-
-#  if !defined(OPENSSL_NO_DEPRECATED_3_0)
 /*
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! MD5_LONG has to be at least 32 bits wide.                     !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-#   define MD5_LONG unsigned int
+# define MD5_LONG unsigned int
 
-#   define MD5_CBLOCK      64
-#   define MD5_LBLOCK      (MD5_CBLOCK/4)
+# define MD5_CBLOCK      64
+# define MD5_LBLOCK      (MD5_CBLOCK/4)
+# define MD5_DIGEST_LENGTH 16
 
 typedef struct MD5state_st {
     MD5_LONG A, B, C, D;
@@ -44,18 +42,15 @@ typedef struct MD5state_st {
     MD5_LONG data[MD5_LBLOCK];
     unsigned int num;
 } MD5_CTX;
-#  endif
 
-DEPRECATEDIN_3_0(int MD5_Init(MD5_CTX *c))
-DEPRECATEDIN_3_0(int MD5_Update(MD5_CTX *c, const void *data, size_t len))
-DEPRECATEDIN_3_0(int MD5_Final(unsigned char *md, MD5_CTX *c))
-DEPRECATEDIN_3_0(unsigned char *MD5(const unsigned char *d, size_t n,
-                                    unsigned char *md))
-DEPRECATEDIN_3_0(void MD5_Transform(MD5_CTX *c, const unsigned char *b))
-
-#  ifdef  __cplusplus
+int MD5_Init(MD5_CTX *c);
+int MD5_Update(MD5_CTX *c, const void *data, size_t len);
+int MD5_Final(unsigned char *md, MD5_CTX *c);
+unsigned char *MD5(const unsigned char *d, size_t n, unsigned char *md);
+void MD5_Transform(MD5_CTX *c, const unsigned char *b);
+# ifdef  __cplusplus
 }
-#  endif
+# endif
 # endif
 
 #endif

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -19,9 +19,9 @@
 # include <openssl/e_os2.h>
 # include <stddef.h>
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 extern "C" {
-#endif
+# endif
 
 /*-
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -115,8 +115,8 @@ int SHA512_Final(unsigned char *md, SHA512_CTX *c);
 unsigned char *SHA512(const unsigned char *d, size_t n, unsigned char *md);
 void SHA512_Transform(SHA512_CTX *c, const unsigned char *data);
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 }
-#endif
+# endif
 
 #endif

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -23,19 +23,21 @@
 extern "C" {
 # endif
 
+# define SHA_DIGEST_LENGTH 20
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 /*-
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! SHA_LONG has to be at least 32 bits wide.                    !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-# define SHA_LONG unsigned int
+#  define SHA_LONG unsigned int
 
-# define SHA_LBLOCK      16
-# define SHA_CBLOCK      (SHA_LBLOCK*4)/* SHA treats input data as a
-                                        * contiguous array of 32 bit wide
-                                        * big-endian values. */
-# define SHA_LAST_BLOCK  (SHA_CBLOCK-8)
-# define SHA_DIGEST_LENGTH 20
+#  define SHA_LBLOCK      16
+#  define SHA_CBLOCK      (SHA_LBLOCK*4)/* SHA treats input data as a
+                                         * contiguous array of 32 bit wide
+                                         * big-endian values. */
+#  define SHA_LAST_BLOCK  (SHA_CBLOCK-8)
 
 typedef struct SHAstate_st {
     SHA_LONG h0, h1, h2, h3, h4;
@@ -43,14 +45,17 @@ typedef struct SHAstate_st {
     SHA_LONG data[SHA_LBLOCK];
     unsigned int num;
 } SHA_CTX;
+# endif /* !defined(OPENSSL_NO_DEPRECATED_3_0) */
 
-int SHA1_Init(SHA_CTX *c);
-int SHA1_Update(SHA_CTX *c, const void *data, size_t len);
-int SHA1_Final(unsigned char *md, SHA_CTX *c);
-unsigned char *SHA1(const unsigned char *d, size_t n, unsigned char *md);
-void SHA1_Transform(SHA_CTX *c, const unsigned char *data);
+DEPRECATEDIN_3_0(int SHA1_Init(SHA_CTX *c))
+DEPRECATEDIN_3_0(int SHA1_Update(SHA_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int SHA1_Final(unsigned char *md, SHA_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *SHA1(const unsigned char *d, size_t n,
+                 unsigned char *md))
+DEPRECATEDIN_3_0(void SHA1_Transform(SHA_CTX *c, const unsigned char *data))
 
-# define SHA256_CBLOCK   (SHA_LBLOCK*4)/* SHA-256 treats input data as a
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define SHA256_CBLOCK   (SHA_LBLOCK*4)/* SHA-256 treats input data as a
                                         * contiguous array of 32 bit wide
                                         * big-endian values. */
 
@@ -60,22 +65,27 @@ typedef struct SHA256state_st {
     SHA_LONG data[SHA_LBLOCK];
     unsigned int num, md_len;
 } SHA256_CTX;
+# endif /* !defined(OPENSSL_NO_DEPRECATED_3_0) */
 
-int SHA224_Init(SHA256_CTX *c);
-int SHA224_Update(SHA256_CTX *c, const void *data, size_t len);
-int SHA224_Final(unsigned char *md, SHA256_CTX *c);
-unsigned char *SHA224(const unsigned char *d, size_t n, unsigned char *md);
-int SHA256_Init(SHA256_CTX *c);
-int SHA256_Update(SHA256_CTX *c, const void *data, size_t len);
-int SHA256_Final(unsigned char *md, SHA256_CTX *c);
-unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md);
-void SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
+DEPRECATEDIN_3_0(int SHA224_Init(SHA256_CTX *c))
+DEPRECATEDIN_3_0(int SHA224_Update(SHA256_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int SHA224_Final(unsigned char *md, SHA256_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *SHA224(const unsigned char *d, size_t n,
+                                       unsigned char *md))
+DEPRECATEDIN_3_0(int SHA256_Init(SHA256_CTX *c))
+DEPRECATEDIN_3_0(int SHA256_Update(SHA256_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int SHA256_Final(unsigned char *md, SHA256_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *SHA256(const unsigned char *d, size_t n,
+                                       unsigned char *md))
+DEPRECATEDIN_3_0(void SHA256_Transform(SHA256_CTX *c,
+                                       const unsigned char *data))
 
 # define SHA224_DIGEST_LENGTH    28
 # define SHA256_DIGEST_LENGTH    32
 # define SHA384_DIGEST_LENGTH    48
 # define SHA512_DIGEST_LENGTH    64
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 /*
  * Unlike 32-bit digest algorithms, SHA-512 *relies* on SHA_LONG64
  * being exactly 64-bit wide. See Implementation Notes in sha512.c
@@ -86,14 +96,14 @@ void SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
  * contiguous array of 64 bit
  * wide big-endian values.
  */
-# define SHA512_CBLOCK   (SHA_LBLOCK*8)
-# if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-#  define SHA_LONG64 unsigned __int64
-# elif defined(__arch64__)
-#  define SHA_LONG64 unsigned long
-# else
-#  define SHA_LONG64 unsigned long long
-# endif
+#  define SHA512_CBLOCK   (SHA_LBLOCK*8)
+#  if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
+#   define SHA_LONG64 unsigned __int64
+#  elif defined(__arch64__)
+#   define SHA_LONG64 unsigned long
+#  else
+#   define SHA_LONG64 unsigned long long
+#  endif
 
 typedef struct SHA512state_st {
     SHA_LONG64 h[8];
@@ -104,16 +114,20 @@ typedef struct SHA512state_st {
     } u;
     unsigned int num, md_len;
 } SHA512_CTX;
+# endif /* !defined(OPENSSL_NO_DEPRECATED_3_0) */
 
-int SHA384_Init(SHA512_CTX *c);
-int SHA384_Update(SHA512_CTX *c, const void *data, size_t len);
-int SHA384_Final(unsigned char *md, SHA512_CTX *c);
-unsigned char *SHA384(const unsigned char *d, size_t n, unsigned char *md);
-int SHA512_Init(SHA512_CTX *c);
-int SHA512_Update(SHA512_CTX *c, const void *data, size_t len);
-int SHA512_Final(unsigned char *md, SHA512_CTX *c);
-unsigned char *SHA512(const unsigned char *d, size_t n, unsigned char *md);
-void SHA512_Transform(SHA512_CTX *c, const unsigned char *data);
+DEPRECATEDIN_3_0(int SHA384_Init(SHA512_CTX *c))
+DEPRECATEDIN_3_0(int SHA384_Update(SHA512_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int SHA384_Final(unsigned char *md, SHA512_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *SHA384(const unsigned char *d, size_t n,
+                                       unsigned char *md))
+DEPRECATEDIN_3_0(int SHA512_Init(SHA512_CTX *c))
+DEPRECATEDIN_3_0(int SHA512_Update(SHA512_CTX *c, const void *data, size_t len))
+DEPRECATEDIN_3_0(int SHA512_Final(unsigned char *md, SHA512_CTX *c))
+DEPRECATEDIN_3_0(unsigned char *SHA512(const unsigned char *d, size_t n,
+                                       unsigned char *md))
+DEPRECATEDIN_3_0(void SHA512_Transform(SHA512_CTX *c,
+                                       const unsigned char *data))
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -23,21 +23,19 @@
 extern "C" {
 # endif
 
-# define SHA_DIGEST_LENGTH 20
-
-# ifndef OPENSSL_NO_DEPRECATED_3_0
 /*-
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  * ! SHA_LONG has to be at least 32 bits wide.                    !
  * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  */
-#  define SHA_LONG unsigned int
+# define SHA_LONG unsigned int
 
-#  define SHA_LBLOCK      16
-#  define SHA_CBLOCK      (SHA_LBLOCK*4)/* SHA treats input data as a
-                                         * contiguous array of 32 bit wide
-                                         * big-endian values. */
-#  define SHA_LAST_BLOCK  (SHA_CBLOCK-8)
+# define SHA_LBLOCK      16
+# define SHA_CBLOCK      (SHA_LBLOCK*4)/* SHA treats input data as a
+                                        * contiguous array of 32 bit wide
+                                        * big-endian values. */
+# define SHA_LAST_BLOCK  (SHA_CBLOCK-8)
+# define SHA_DIGEST_LENGTH 20
 
 typedef struct SHAstate_st {
     SHA_LONG h0, h1, h2, h3, h4;
@@ -45,17 +43,14 @@ typedef struct SHAstate_st {
     SHA_LONG data[SHA_LBLOCK];
     unsigned int num;
 } SHA_CTX;
-# endif /* !defined(OPENSSL_NO_DEPRECATED_3_0) */
 
-DEPRECATEDIN_3_0(int SHA1_Init(SHA_CTX *c))
-DEPRECATEDIN_3_0(int SHA1_Update(SHA_CTX *c, const void *data, size_t len))
-DEPRECATEDIN_3_0(int SHA1_Final(unsigned char *md, SHA_CTX *c))
-DEPRECATEDIN_3_0(unsigned char *SHA1(const unsigned char *d, size_t n,
-                 unsigned char *md))
-DEPRECATEDIN_3_0(void SHA1_Transform(SHA_CTX *c, const unsigned char *data))
+int SHA1_Init(SHA_CTX *c);
+int SHA1_Update(SHA_CTX *c, const void *data, size_t len);
+int SHA1_Final(unsigned char *md, SHA_CTX *c);
+unsigned char *SHA1(const unsigned char *d, size_t n, unsigned char *md);
+void SHA1_Transform(SHA_CTX *c, const unsigned char *data);
 
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define SHA256_CBLOCK   (SHA_LBLOCK*4)/* SHA-256 treats input data as a
+# define SHA256_CBLOCK   (SHA_LBLOCK*4)/* SHA-256 treats input data as a
                                         * contiguous array of 32 bit wide
                                         * big-endian values. */
 
@@ -65,27 +60,22 @@ typedef struct SHA256state_st {
     SHA_LONG data[SHA_LBLOCK];
     unsigned int num, md_len;
 } SHA256_CTX;
-# endif /* !defined(OPENSSL_NO_DEPRECATED_3_0) */
 
-DEPRECATEDIN_3_0(int SHA224_Init(SHA256_CTX *c))
-DEPRECATEDIN_3_0(int SHA224_Update(SHA256_CTX *c, const void *data, size_t len))
-DEPRECATEDIN_3_0(int SHA224_Final(unsigned char *md, SHA256_CTX *c))
-DEPRECATEDIN_3_0(unsigned char *SHA224(const unsigned char *d, size_t n,
-                                       unsigned char *md))
-DEPRECATEDIN_3_0(int SHA256_Init(SHA256_CTX *c))
-DEPRECATEDIN_3_0(int SHA256_Update(SHA256_CTX *c, const void *data, size_t len))
-DEPRECATEDIN_3_0(int SHA256_Final(unsigned char *md, SHA256_CTX *c))
-DEPRECATEDIN_3_0(unsigned char *SHA256(const unsigned char *d, size_t n,
-                                       unsigned char *md))
-DEPRECATEDIN_3_0(void SHA256_Transform(SHA256_CTX *c,
-                                       const unsigned char *data))
+int SHA224_Init(SHA256_CTX *c);
+int SHA224_Update(SHA256_CTX *c, const void *data, size_t len);
+int SHA224_Final(unsigned char *md, SHA256_CTX *c);
+unsigned char *SHA224(const unsigned char *d, size_t n, unsigned char *md);
+int SHA256_Init(SHA256_CTX *c);
+int SHA256_Update(SHA256_CTX *c, const void *data, size_t len);
+int SHA256_Final(unsigned char *md, SHA256_CTX *c);
+unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md);
+void SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
 
 # define SHA224_DIGEST_LENGTH    28
 # define SHA256_DIGEST_LENGTH    32
 # define SHA384_DIGEST_LENGTH    48
 # define SHA512_DIGEST_LENGTH    64
 
-# ifndef OPENSSL_NO_DEPRECATED_3_0
 /*
  * Unlike 32-bit digest algorithms, SHA-512 *relies* on SHA_LONG64
  * being exactly 64-bit wide. See Implementation Notes in sha512.c
@@ -96,14 +86,14 @@ DEPRECATEDIN_3_0(void SHA256_Transform(SHA256_CTX *c,
  * contiguous array of 64 bit
  * wide big-endian values.
  */
-#  define SHA512_CBLOCK   (SHA_LBLOCK*8)
-#  if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-#   define SHA_LONG64 unsigned __int64
-#  elif defined(__arch64__)
-#   define SHA_LONG64 unsigned long
-#  else
-#   define SHA_LONG64 unsigned long long
-#  endif
+# define SHA512_CBLOCK   (SHA_LBLOCK*8)
+# if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
+#  define SHA_LONG64 unsigned __int64
+# elif defined(__arch64__)
+#  define SHA_LONG64 unsigned long
+# else
+#  define SHA_LONG64 unsigned long long
+# endif
 
 typedef struct SHA512state_st {
     SHA_LONG64 h[8];
@@ -114,20 +104,16 @@ typedef struct SHA512state_st {
     } u;
     unsigned int num, md_len;
 } SHA512_CTX;
-# endif /* !defined(OPENSSL_NO_DEPRECATED_3_0) */
 
-DEPRECATEDIN_3_0(int SHA384_Init(SHA512_CTX *c))
-DEPRECATEDIN_3_0(int SHA384_Update(SHA512_CTX *c, const void *data, size_t len))
-DEPRECATEDIN_3_0(int SHA384_Final(unsigned char *md, SHA512_CTX *c))
-DEPRECATEDIN_3_0(unsigned char *SHA384(const unsigned char *d, size_t n,
-                                       unsigned char *md))
-DEPRECATEDIN_3_0(int SHA512_Init(SHA512_CTX *c))
-DEPRECATEDIN_3_0(int SHA512_Update(SHA512_CTX *c, const void *data, size_t len))
-DEPRECATEDIN_3_0(int SHA512_Final(unsigned char *md, SHA512_CTX *c))
-DEPRECATEDIN_3_0(unsigned char *SHA512(const unsigned char *d, size_t n,
-                                       unsigned char *md))
-DEPRECATEDIN_3_0(void SHA512_Transform(SHA512_CTX *c,
-                                       const unsigned char *data))
+int SHA384_Init(SHA512_CTX *c);
+int SHA384_Update(SHA512_CTX *c, const void *data, size_t len);
+int SHA384_Final(unsigned char *md, SHA512_CTX *c);
+unsigned char *SHA384(const unsigned char *d, size_t n, unsigned char *md);
+int SHA512_Init(SHA512_CTX *c);
+int SHA512_Update(SHA512_CTX *c, const void *data, size_t len);
+int SHA512_Final(unsigned char *md, SHA512_CTX *c);
+unsigned char *SHA512(const unsigned char *d, size_t n, unsigned char *md);
+void SHA512_Transform(SHA512_CTX *c, const unsigned char *data);
 
 # ifdef  __cplusplus
 }

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * AES low level APIs are deprecated for public use, but still ok for internal
+ * All low level APIs are deprecated for public use, but still ok for internal
  * use where we're using them to implement the higher level EVP interface, as is
  * the case here.
  */

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * AES low level APIs are deprecated for public use, but still ok for internal
+ * All low level APIs are deprecated for public use, but still ok for internal
  * use where we're using them to implement the higher level EVP interface, as is
  * the case here.
  */

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -10,8 +10,8 @@
 /* Dispatch functions for RC4_HMAC_MD5 cipher */
 
 /*
- * RC4 low level APIs are deprecated for public use, but still ok for internal
- * use.
+ * MD5 and RC4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
  */
 #include "internal/deprecated.h"
 

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
@@ -10,8 +10,8 @@
 /* RC4_HMAC_MD5 cipher implementation */
 
 /*
- * RC4 low level APIs are deprecated for public use, but still ok for internal
- * use.
+ * MD5 and RC4 low level APIs are deprecated for public use, but still ok for
+ * internal use.
  */
 #include "internal/deprecated.h"
 

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/sha.h>
 #include "cipher_tdes_default.h"
 #include "crypto/evp.h"

--- a/providers/implementations/digests/md5_prov.c
+++ b/providers/implementations/digests/md5_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * MD5 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/md5.h>
 #include "prov/digestcommon.h"

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * MD5 and SHA-1 low level APIs are deprecated for public use, but still ok for
  * internal use.
  */
 #include "internal/deprecated.h"

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/crypto.h>
 #include <openssl/evp.h>

--- a/providers/implementations/digests/sha2_prov.c
+++ b/providers/implementations/digests/sha2_prov.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/core_numbers.h>
 #include <openssl/evp.h>

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "internal/constant_time.h"
 #include "ssl_local.h"
 #include "internal/cryptlib.h"

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * MD5 and SHA-1 low level APIs are deprecated for public use, but still ok for
  * internal use.
  */
 #include "internal/deprecated.h"

--- a/test/build.info
+++ b/test/build.info
@@ -34,7 +34,6 @@ IF[{- !$disabled{tests} -}]
           sanitytest rsa_complex exdatatest bntest \
           ectest ecstresstest ecdsatest gmdifftest pbelutest ideatest \
           hmactest \
-          rc2test rc4test rc5test \
           destest mdc2test \
           dhtest enginetest \
           ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
@@ -508,6 +507,7 @@ IF[{- !$disabled{tests} -}]
                      tls13encryptiontest wpackettest ctype_internal_test \
                      rdrand_sanitytest property_test \
                      rsa_sp800_56b_test bn_internal_test \
+                     rc2test rc4test rc5test \
                      asn1_dsa_internal_test
 
     IF[{- !$disabled{poly1305} -}]
@@ -600,6 +600,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[curve448_internal_test]=curve448_internal_test.c
     INCLUDE[curve448_internal_test]=.. ../include ../apps/include ../crypto/ec/curve448
     DEPEND[curve448_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[rc4test]=rc4test.c
+    INCLUDE[rc4test]=../include ../apps/include
+    DEPEND[rc4test]=../libcrypto.a libtestutil.a
 
     SOURCE[rdrand_sanitytest]=rdrand_sanitytest.c
     INCLUDE[rdrand_sanitytest]=../include ../apps/include

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SHA256 low level APIs are deprecated for public use, but still ok for
+ * internal use.  Note, that due to symbols not being exported, only the
+ * #defines can be accessed.  In this case SHA256_CBLOCK.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/sha.h>
 #include <openssl/evp.h>

--- a/test/rc4test.c
+++ b/test/rc4test.c
@@ -8,8 +8,8 @@
  */
 
 /*
- * RC4 low level APIs are deprecated for public use, but still ok for internal
- * use.
+ * RC4 and SHA-1 low level APIs are deprecated for public use, but still ok for
+ * internal use.
  */
 #include "internal/deprecated.h"
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1001,7 +1001,7 @@ i2d_PKCS8PrivateKey_nid_bio             1026	3_0_0	EXIST::FUNCTION:
 ERR_put_error                           1027	3_0_0	NOEXIST::FUNCTION:
 ERR_add_error_data                      1028	3_0_0	EXIST::FUNCTION:
 X509_ALGORS_it                          1029	3_0_0	EXIST::FUNCTION:
-MD5_Update                              1030	3_0_0	EXIST::FUNCTION:MD5
+MD5_Update                              1030	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
 X509_policy_check                       1031	3_0_0	EXIST::FUNCTION:
 X509_CRL_METHOD_new                     1032	3_0_0	EXIST::FUNCTION:
 ASN1_ANY_it                             1033	3_0_0	EXIST::FUNCTION:
@@ -1252,7 +1252,7 @@ ASN1_INTEGER_set_int64                  1280	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_free                          1281	3_0_0	EXIST::FUNCTION:
 i2o_SCT_LIST                            1282	3_0_0	EXIST::FUNCTION:CT
 AES_encrypt                             1283	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-MD5_Init                                1284	3_0_0	EXIST::FUNCTION:MD5
+MD5_Init                                1284	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
 UI_add_error_string                     1285	3_0_0	EXIST::FUNCTION:
 X509_TRUST_cleanup                      1286	3_0_0	EXIST::FUNCTION:
 PEM_read_X509                           1287	3_0_0	EXIST::FUNCTION:STDIO
@@ -1835,7 +1835,7 @@ RSA_verify_ASN1_OCTET_STRING            1877	3_0_0	EXIST::FUNCTION:RSA
 SCT_set_log_entry_type                  1878	3_0_0	EXIST::FUNCTION:CT
 BN_new                                  1879	3_0_0	EXIST::FUNCTION:
 X509_OBJECT_retrieve_by_subject         1880	3_0_0	EXIST::FUNCTION:
-MD5_Final                               1881	3_0_0	EXIST::FUNCTION:MD5
+MD5_Final                               1881	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
 X509_STORE_set_verify_cb                1882	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_print                      1883	3_0_0	EXIST::FUNCTION:OCSP
 CMS_add1_crl                            1884	3_0_0	EXIST::FUNCTION:CMS
@@ -1876,7 +1876,7 @@ CMS_SignedData_init                     1920	3_0_0	EXIST::FUNCTION:CMS
 X509_REQ_free                           1921	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_set                        1922	3_0_0	EXIST::FUNCTION:
 EVP_DecodeFinal                         1923	3_0_0	EXIST::FUNCTION:
-MD5_Transform                           1925	3_0_0	EXIST::FUNCTION:MD5
+MD5_Transform                           1925	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
 SRP_create_verifier_BN                  1926	3_0_0	EXIST::FUNCTION:SRP
 ENGINE_register_all_EC                  1927	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_camellia_128_ofb                    1928	3_0_0	EXIST::FUNCTION:CAMELLIA
@@ -3003,7 +3003,7 @@ EVP_des_ede_cfb64                       3067	3_0_0	EXIST::FUNCTION:DES
 d2i_RSAPrivateKey                       3068	3_0_0	EXIST::FUNCTION:RSA
 ERR_load_BN_strings                     3069	3_0_0	EXIST::FUNCTION:
 BF_encrypt                              3070	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
-MD5                                     3071	3_0_0	EXIST::FUNCTION:MD5
+MD5                                     3071	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
 BN_GF2m_arr2poly                        3072	3_0_0	EXIST::FUNCTION:EC2M
 EVP_PKEY_meth_get_ctrl                  3073	3_0_0	EXIST::FUNCTION:
 i2d_X509_REQ_bio                        3074	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1001,7 +1001,7 @@ i2d_PKCS8PrivateKey_nid_bio             1026	3_0_0	EXIST::FUNCTION:
 ERR_put_error                           1027	3_0_0	NOEXIST::FUNCTION:
 ERR_add_error_data                      1028	3_0_0	EXIST::FUNCTION:
 X509_ALGORS_it                          1029	3_0_0	EXIST::FUNCTION:
-MD5_Update                              1030	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
+MD5_Update                              1030	3_0_0	EXIST::FUNCTION:MD5
 X509_policy_check                       1031	3_0_0	EXIST::FUNCTION:
 X509_CRL_METHOD_new                     1032	3_0_0	EXIST::FUNCTION:
 ASN1_ANY_it                             1033	3_0_0	EXIST::FUNCTION:
@@ -1145,7 +1145,7 @@ BN_security_bits                        1171	3_0_0	EXIST::FUNCTION:
 X509_PURPOSE_get0_name                  1172	3_0_0	EXIST::FUNCTION:
 TS_TST_INFO_get_serial                  1173	3_0_0	EXIST::FUNCTION:TS
 ASN1_PCTX_get_str_flags                 1174	3_0_0	EXIST::FUNCTION:
-SHA256                                  1175	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA256                                  1175	3_0_0	EXIST::FUNCTION:
 X509_LOOKUP_hash_dir                    1176	3_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_check                   1177	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_RAND                 1178	3_0_0	EXIST::FUNCTION:ENGINE
@@ -1252,7 +1252,7 @@ ASN1_INTEGER_set_int64                  1280	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_free                          1281	3_0_0	EXIST::FUNCTION:
 i2o_SCT_LIST                            1282	3_0_0	EXIST::FUNCTION:CT
 AES_encrypt                             1283	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-MD5_Init                                1284	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
+MD5_Init                                1284	3_0_0	EXIST::FUNCTION:MD5
 UI_add_error_string                     1285	3_0_0	EXIST::FUNCTION:
 X509_TRUST_cleanup                      1286	3_0_0	EXIST::FUNCTION:
 PEM_read_X509                           1287	3_0_0	EXIST::FUNCTION:STDIO
@@ -1376,7 +1376,7 @@ EVP_MD_meth_get_cleanup                 1408	3_0_0	EXIST::FUNCTION:
 SRP_Calc_server_key                     1409	3_0_0	EXIST::FUNCTION:SRP
 BN_mod_exp_simple                       1410	3_0_0	EXIST::FUNCTION:
 BIO_set_ex_data                         1411	3_0_0	EXIST::FUNCTION:
-SHA512                                  1412	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA512                                  1412	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_get_explicit_policy      1413	3_0_0	EXIST::FUNCTION:
 EVP_DecodeBlock                         1414	3_0_0	EXIST::FUNCTION:
 OCSP_REQ_CTX_http                       1415	3_0_0	EXIST::FUNCTION:OCSP
@@ -1441,7 +1441,7 @@ X509V3_section_free                     1474	3_0_0	EXIST::FUNCTION:
 CRYPTO_mem_debug_free                   1475	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0
 d2i_OCSP_REQUEST                        1476	3_0_0	EXIST::FUNCTION:OCSP
 ENGINE_get_cipher_engine                1477	3_0_0	EXIST::FUNCTION:ENGINE
-SHA384_Final                            1478	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA384_Final                            1478	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_set_certs                   1479	3_0_0	EXIST::FUNCTION:TS
 BN_MONT_CTX_free                        1480	3_0_0	EXIST::FUNCTION:
 BN_GF2m_mod_solve_quad_arr              1481	3_0_0	EXIST::FUNCTION:EC2M
@@ -1467,7 +1467,7 @@ ASYNC_get_wait_ctx                      1500	3_0_0	EXIST::FUNCTION:
 ENGINE_set_load_privkey_function        1501	3_0_0	EXIST::FUNCTION:ENGINE
 CRYPTO_ccm128_setiv                     1502	3_0_0	EXIST::FUNCTION:
 PKCS7_dataFinal                         1503	3_0_0	EXIST::FUNCTION:
-SHA1_Final                              1504	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA1_Final                              1504	3_0_0	EXIST::FUNCTION:
 i2a_ASN1_STRING                         1505	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_rand_key                 1506	3_0_0	EXIST::FUNCTION:
 AES_set_encrypt_key                     1507	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
@@ -1835,7 +1835,7 @@ RSA_verify_ASN1_OCTET_STRING            1877	3_0_0	EXIST::FUNCTION:RSA
 SCT_set_log_entry_type                  1878	3_0_0	EXIST::FUNCTION:CT
 BN_new                                  1879	3_0_0	EXIST::FUNCTION:
 X509_OBJECT_retrieve_by_subject         1880	3_0_0	EXIST::FUNCTION:
-MD5_Final                               1881	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
+MD5_Final                               1881	3_0_0	EXIST::FUNCTION:MD5
 X509_STORE_set_verify_cb                1882	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_print                      1883	3_0_0	EXIST::FUNCTION:OCSP
 CMS_add1_crl                            1884	3_0_0	EXIST::FUNCTION:CMS
@@ -1876,7 +1876,7 @@ CMS_SignedData_init                     1920	3_0_0	EXIST::FUNCTION:CMS
 X509_REQ_free                           1921	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_set                        1922	3_0_0	EXIST::FUNCTION:
 EVP_DecodeFinal                         1923	3_0_0	EXIST::FUNCTION:
-MD5_Transform                           1925	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
+MD5_Transform                           1925	3_0_0	EXIST::FUNCTION:MD5
 SRP_create_verifier_BN                  1926	3_0_0	EXIST::FUNCTION:SRP
 ENGINE_register_all_EC                  1927	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_camellia_128_ofb                    1928	3_0_0	EXIST::FUNCTION:CAMELLIA
@@ -1893,7 +1893,7 @@ PKCS5_PBE_keyivgen                      1938	3_0_0	EXIST::FUNCTION:
 i2d_OCSP_SERVICELOC                     1939	3_0_0	EXIST::FUNCTION:OCSP
 EC_POINT_copy                           1940	3_0_0	EXIST::FUNCTION:EC
 X509V3_EXT_CRL_add_nconf                1941	3_0_0	EXIST::FUNCTION:
-SHA256_Init                             1942	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA256_Init                             1942	3_0_0	EXIST::FUNCTION:
 X509_NAME_ENTRY_get_object              1943	3_0_0	EXIST::FUNCTION:
 ASN1_ENUMERATED_free                    1944	3_0_0	EXIST::FUNCTION:
 X509_CRL_set_meth_data                  1945	3_0_0	EXIST::FUNCTION:
@@ -1914,7 +1914,7 @@ EVP_PKEY_add1_attr                      1959	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_purpose_inherit          1960	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_keygen                1961	3_0_0	EXIST::FUNCTION:
 ENGINE_get_pkey_asn1_meth               1962	3_0_0	EXIST::FUNCTION:ENGINE
-SHA256_Update                           1963	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA256_Update                           1963	3_0_0	EXIST::FUNCTION:
 d2i_PKCS7_ISSUER_AND_SERIAL             1964	3_0_0	EXIST::FUNCTION:
 PKCS12_unpack_authsafes                 1965	3_0_0	EXIST::FUNCTION:
 X509_CRL_it                             1966	3_0_0	EXIST::FUNCTION:
@@ -2073,7 +2073,7 @@ BIO_s_file                              2118	3_0_0	EXIST::FUNCTION:
 RSA_X931_derive_ex                      2119	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_decrypt_init                   2120	3_0_0	EXIST::FUNCTION:
 ENGINE_get_destroy_function             2121	3_0_0	EXIST::FUNCTION:ENGINE
-SHA224_Init                             2122	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA224_Init                             2122	3_0_0	EXIST::FUNCTION:
 X509V3_EXT_add_conf                     2123	3_0_0	EXIST::FUNCTION:
 ASN1_object_size                        2124	3_0_0	EXIST::FUNCTION:
 X509_REVOKED_free                       2125	3_0_0	EXIST::FUNCTION:
@@ -2191,7 +2191,7 @@ PEM_write_bio_PKCS8_PRIV_KEY_INFO       2238	3_0_0	EXIST::FUNCTION:
 EC_GROUP_set_curve_GF2m                 2239	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC2M
 ENGINE_load_builtin_engines             2240	3_0_0	EXIST::FUNCTION:ENGINE
 SRP_VBASE_init                          2241	3_0_0	EXIST::FUNCTION:SRP
-SHA224_Final                            2242	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA224_Final                            2242	3_0_0	EXIST::FUNCTION:
 OCSP_CERTSTATUS_free                    2243	3_0_0	EXIST::FUNCTION:OCSP
 d2i_TS_TST_INFO                         2244	3_0_0	EXIST::FUNCTION:TS
 IPAddressOrRange_it                     2245	3_0_0	EXIST::FUNCTION:RFC3779
@@ -2201,7 +2201,7 @@ TS_OBJ_print_bio                        2248	3_0_0	EXIST::FUNCTION:TS
 X509_time_adj_ex                        2249	3_0_0	EXIST::FUNCTION:
 OCSP_request_add1_cert                  2250	3_0_0	EXIST::FUNCTION:OCSP
 ERR_load_X509_strings                   2251	3_0_0	EXIST::FUNCTION:
-SHA1_Transform                          2252	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA1_Transform                          2252	3_0_0	EXIST::FUNCTION:
 CMS_signed_get_attr_by_NID              2253	3_0_0	EXIST::FUNCTION:CMS
 X509_STORE_CTX_get_by_subject           2254	3_0_0	EXIST::FUNCTION:
 ASN1_OCTET_STRING_it                    2255	3_0_0	EXIST::FUNCTION:
@@ -2461,7 +2461,7 @@ BN_generate_dsa_nonce                   2512	3_0_0	EXIST::FUNCTION:
 X509_verify_cert                        2513	3_0_0	EXIST::FUNCTION:
 X509_policy_level_get0_node             2514	3_0_0	EXIST::FUNCTION:
 X509_REQ_get_attr                       2515	3_0_0	EXIST::FUNCTION:
-SHA1                                    2516	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA1                                    2516	3_0_0	EXIST::FUNCTION:
 X509_print                              2517	3_0_0	EXIST::FUNCTION:
 d2i_AutoPrivateKey                      2518	3_0_0	EXIST::FUNCTION:
 X509_REQ_new                            2519	3_0_0	EXIST::FUNCTION:
@@ -2497,7 +2497,7 @@ d2i_NETSCAPE_CERT_SEQUENCE              2550	3_0_0	EXIST::FUNCTION:
 X509_CRL_set_version                    2551	3_0_0	EXIST::FUNCTION:
 ASN1_PCTX_set_cert_flags                2552	3_0_0	EXIST::FUNCTION:
 PKCS8_PRIV_KEY_INFO_free                2553	3_0_0	EXIST::FUNCTION:
-SHA224_Update                           2554	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA224_Update                           2554	3_0_0	EXIST::FUNCTION:
 EC_GROUP_new_by_curve_name              2555	3_0_0	EXIST::FUNCTION:EC
 X509_STORE_set_purpose                  2556	3_0_0	EXIST::FUNCTION:
 X509_CRL_get0_signature                 2557	3_0_0	EXIST::FUNCTION:
@@ -2728,7 +2728,7 @@ CMS_RecipientInfo_encrypt               2786	3_0_0	EXIST::FUNCTION:CMS
 X509_get_pubkey_parameters              2787	3_0_0	EXIST::FUNCTION:
 PKCS12_setup_mac                        2788	3_0_0	EXIST::FUNCTION:
 PEM_read_bio_PKCS7                      2789	3_0_0	EXIST::FUNCTION:
-SHA512_Final                            2790	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA512_Final                            2790	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_set1_host             2791	3_0_0	EXIST::FUNCTION:
 OCSP_resp_find_status                   2792	3_0_0	EXIST::FUNCTION:OCSP
 d2i_ASN1_T61STRING                      2793	3_0_0	EXIST::FUNCTION:
@@ -2902,14 +2902,14 @@ EC_curve_nid2nist                       2964	3_0_0	EXIST::FUNCTION:EC
 ENGINE_get_finish_function              2965	3_0_0	EXIST::FUNCTION:ENGINE
 EC_POINT_add                            2966	3_0_0	EXIST::FUNCTION:EC
 EC_KEY_oct2key                          2967	3_0_0	EXIST::FUNCTION:EC
-SHA384_Init                             2968	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA384_Init                             2968	3_0_0	EXIST::FUNCTION:
 ASN1_UNIVERSALSTRING_new                2969	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_print_private                  2970	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_new                        2971	3_0_0	EXIST::FUNCTION:
 NAME_CONSTRAINTS_it                     2972	3_0_0	EXIST::FUNCTION:
 TS_REQ_get_cert_req                     2973	3_0_0	EXIST::FUNCTION:TS
 BIO_pop                                 2974	3_0_0	EXIST::FUNCTION:
-SHA256_Final                            2975	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA256_Final                            2975	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_set1_DH                        2976	3_0_0	EXIST::FUNCTION:DH
 DH_get_ex_data                          2977	3_0_0	EXIST::FUNCTION:DH
 CRYPTO_secure_malloc                    2978	3_0_0	EXIST::FUNCTION:
@@ -2929,7 +2929,7 @@ EC_GROUP_set_asn1_flag                  2991	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_new                            2992	3_0_0	EXIST::FUNCTION:
 i2d_POLICYINFO                          2993	3_0_0	EXIST::FUNCTION:
 BN_get_flags                            2994	3_0_0	EXIST::FUNCTION:
-SHA384                                  2995	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA384                                  2995	3_0_0	EXIST::FUNCTION:
 NCONF_get_string                        2996	3_0_0	EXIST::FUNCTION:
 d2i_PROXY_CERT_INFO_EXTENSION           2997	3_0_0	EXIST::FUNCTION:
 EC_POINT_point2buf                      2998	3_0_0	EXIST::FUNCTION:EC
@@ -2981,7 +2981,7 @@ i2d_X509_PUBKEY                         3045	3_0_0	EXIST::FUNCTION:
 EVP_DecryptUpdate                       3046	3_0_0	EXIST::FUNCTION:
 CAST_cbc_encrypt                        3047	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 BN_BLINDING_invert                      3048	3_0_0	EXIST::FUNCTION:
-SHA512_Update                           3049	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA512_Update                           3049	3_0_0	EXIST::FUNCTION:
 ESS_ISSUER_SERIAL_new                   3050	3_0_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_get0_pkcs8               3051	3_0_0	EXIST::FUNCTION:
 X509_get_ext_by_NID                     3052	3_0_0	EXIST::FUNCTION:
@@ -3003,7 +3003,7 @@ EVP_des_ede_cfb64                       3067	3_0_0	EXIST::FUNCTION:DES
 d2i_RSAPrivateKey                       3068	3_0_0	EXIST::FUNCTION:RSA
 ERR_load_BN_strings                     3069	3_0_0	EXIST::FUNCTION:
 BF_encrypt                              3070	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
-MD5                                     3071	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
+MD5                                     3071	3_0_0	EXIST::FUNCTION:MD5
 BN_GF2m_arr2poly                        3072	3_0_0	EXIST::FUNCTION:EC2M
 EVP_PKEY_meth_get_ctrl                  3073	3_0_0	EXIST::FUNCTION:
 i2d_X509_REQ_bio                        3074	3_0_0	EXIST::FUNCTION:
@@ -3326,7 +3326,7 @@ d2i_PKCS8_PRIV_KEY_INFO_fp              3395	3_0_0	EXIST::FUNCTION:STDIO
 X509_OBJECT_retrieve_match              3396	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_ctr                         3397	3_0_0	EXIST::FUNCTION:
 EVP_PBE_find                            3398	3_0_0	EXIST::FUNCTION:
-SHA512_Transform                        3399	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA512_Transform                        3399	3_0_0	EXIST::FUNCTION:
 ERR_add_error_vdata                     3400	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_get_ext                    3401	3_0_0	EXIST::FUNCTION:OCSP
 NETSCAPE_SPKAC_new                      3402	3_0_0	EXIST::FUNCTION:
@@ -3363,7 +3363,7 @@ EVP_OpenFinal                           3432	3_0_0	EXIST::FUNCTION:RSA
 RAND_egd_bytes                          3433	3_0_0	EXIST::FUNCTION:EGD
 UI_method_get_writer                    3434	3_0_0	EXIST::FUNCTION:
 BN_secure_new                           3435	3_0_0	EXIST::FUNCTION:
-SHA1_Update                             3437	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA1_Update                             3437	3_0_0	EXIST::FUNCTION:
 BIO_s_connect                           3438	3_0_0	EXIST::FUNCTION:SOCK
 EVP_MD_meth_get_init                    3439	3_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_free                    3440	3_0_0	EXIST::FUNCTION:
@@ -3513,7 +3513,7 @@ EVP_MD_meth_dup                         3588	3_0_0	EXIST::FUNCTION:
 ENGINE_unregister_ciphers               3589	3_0_0	EXIST::FUNCTION:ENGINE
 X509_issuer_and_serial_cmp              3590	3_0_0	EXIST::FUNCTION:
 OCSP_response_create                    3591	3_0_0	EXIST::FUNCTION:OCSP
-SHA224                                  3592	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA224                                  3592	3_0_0	EXIST::FUNCTION:
 MD2_options                             3593	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 X509_REQ_it                             3595	3_0_0	EXIST::FUNCTION:
 RAND_bytes                              3596	3_0_0	EXIST::FUNCTION:
@@ -3554,7 +3554,7 @@ PKCS5_pbe_set                           3631	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_free                        3632	3_0_0	EXIST::FUNCTION:TS
 d2i_PUBKEY                              3633	3_0_0	EXIST::FUNCTION:
 ASYNC_cleanup_thread                    3634	3_0_0	EXIST::FUNCTION:
-SHA384_Update                           3635	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA384_Update                           3635	3_0_0	EXIST::FUNCTION:
 CRYPTO_cfb128_1_encrypt                 3636	3_0_0	EXIST::FUNCTION:
 BIO_set_cipher                          3637	3_0_0	EXIST::FUNCTION:
 PEM_read_PUBKEY                         3638	3_0_0	EXIST::FUNCTION:STDIO
@@ -3576,7 +3576,7 @@ Camellia_ecb_encrypt                    3654	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPR
 ENGINE_set_default_RSA                  3655	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_EncodeBlock                         3656	3_0_0	EXIST::FUNCTION:
 SXNETID_free                            3657	3_0_0	EXIST::FUNCTION:
-SHA1_Init                               3658	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA1_Init                               3658	3_0_0	EXIST::FUNCTION:
 CRYPTO_atomic_add                       3659	3_0_0	EXIST::FUNCTION:
 TS_CONF_load_certs                      3660	3_0_0	EXIST::FUNCTION:TS
 PEM_write_bio_DSAPrivateKey             3661	3_0_0	EXIST::FUNCTION:DSA
@@ -3599,7 +3599,7 @@ CRYPTO_mem_ctrl                         3678	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG
 ASN1_verify                             3679	3_0_0	EXIST::FUNCTION:
 DSA_generate_parameters_ex              3680	3_0_0	EXIST::FUNCTION:DSA
 X509_sign                               3681	3_0_0	EXIST::FUNCTION:
-SHA256_Transform                        3682	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA256_Transform                        3682	3_0_0	EXIST::FUNCTION:
 BIO_ADDR_free                           3683	3_0_0	EXIST::FUNCTION:SOCK
 ASN1_STRING_free                        3684	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_inherit               3685	3_0_0	EXIST::FUNCTION:
@@ -3816,7 +3816,7 @@ CRL_DIST_POINTS_free                    3899	3_0_0	EXIST::FUNCTION:
 d2i_OCSP_SINGLERESP                     3900	3_0_0	EXIST::FUNCTION:OCSP
 EVP_CIPHER_CTX_num                      3901	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_verify_recover_init            3902	3_0_0	EXIST::FUNCTION:
-SHA512_Init                             3903	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+SHA512_Init                             3903	3_0_0	EXIST::FUNCTION:
 TS_MSG_IMPRINT_set_msg                  3904	3_0_0	EXIST::FUNCTION:TS
 CMS_unsigned_add1_attr                  3905	3_0_0	EXIST::FUNCTION:CMS
 OPENSSL_LH_doall                        3906	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1145,7 +1145,7 @@ BN_security_bits                        1171	3_0_0	EXIST::FUNCTION:
 X509_PURPOSE_get0_name                  1172	3_0_0	EXIST::FUNCTION:
 TS_TST_INFO_get_serial                  1173	3_0_0	EXIST::FUNCTION:TS
 ASN1_PCTX_get_str_flags                 1174	3_0_0	EXIST::FUNCTION:
-SHA256                                  1175	3_0_0	EXIST::FUNCTION:
+SHA256                                  1175	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_LOOKUP_hash_dir                    1176	3_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_check                   1177	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_RAND                 1178	3_0_0	EXIST::FUNCTION:ENGINE
@@ -1376,7 +1376,7 @@ EVP_MD_meth_get_cleanup                 1408	3_0_0	EXIST::FUNCTION:
 SRP_Calc_server_key                     1409	3_0_0	EXIST::FUNCTION:SRP
 BN_mod_exp_simple                       1410	3_0_0	EXIST::FUNCTION:
 BIO_set_ex_data                         1411	3_0_0	EXIST::FUNCTION:
-SHA512                                  1412	3_0_0	EXIST::FUNCTION:
+SHA512                                  1412	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_STORE_CTX_get_explicit_policy      1413	3_0_0	EXIST::FUNCTION:
 EVP_DecodeBlock                         1414	3_0_0	EXIST::FUNCTION:
 OCSP_REQ_CTX_http                       1415	3_0_0	EXIST::FUNCTION:OCSP
@@ -1441,7 +1441,7 @@ X509V3_section_free                     1474	3_0_0	EXIST::FUNCTION:
 CRYPTO_mem_debug_free                   1475	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0
 d2i_OCSP_REQUEST                        1476	3_0_0	EXIST::FUNCTION:OCSP
 ENGINE_get_cipher_engine                1477	3_0_0	EXIST::FUNCTION:ENGINE
-SHA384_Final                            1478	3_0_0	EXIST::FUNCTION:
+SHA384_Final                            1478	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 TS_RESP_CTX_set_certs                   1479	3_0_0	EXIST::FUNCTION:TS
 BN_MONT_CTX_free                        1480	3_0_0	EXIST::FUNCTION:
 BN_GF2m_mod_solve_quad_arr              1481	3_0_0	EXIST::FUNCTION:EC2M
@@ -1467,7 +1467,7 @@ ASYNC_get_wait_ctx                      1500	3_0_0	EXIST::FUNCTION:
 ENGINE_set_load_privkey_function        1501	3_0_0	EXIST::FUNCTION:ENGINE
 CRYPTO_ccm128_setiv                     1502	3_0_0	EXIST::FUNCTION:
 PKCS7_dataFinal                         1503	3_0_0	EXIST::FUNCTION:
-SHA1_Final                              1504	3_0_0	EXIST::FUNCTION:
+SHA1_Final                              1504	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 i2a_ASN1_STRING                         1505	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_rand_key                 1506	3_0_0	EXIST::FUNCTION:
 AES_set_encrypt_key                     1507	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
@@ -1893,7 +1893,7 @@ PKCS5_PBE_keyivgen                      1938	3_0_0	EXIST::FUNCTION:
 i2d_OCSP_SERVICELOC                     1939	3_0_0	EXIST::FUNCTION:OCSP
 EC_POINT_copy                           1940	3_0_0	EXIST::FUNCTION:EC
 X509V3_EXT_CRL_add_nconf                1941	3_0_0	EXIST::FUNCTION:
-SHA256_Init                             1942	3_0_0	EXIST::FUNCTION:
+SHA256_Init                             1942	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_NAME_ENTRY_get_object              1943	3_0_0	EXIST::FUNCTION:
 ASN1_ENUMERATED_free                    1944	3_0_0	EXIST::FUNCTION:
 X509_CRL_set_meth_data                  1945	3_0_0	EXIST::FUNCTION:
@@ -1914,7 +1914,7 @@ EVP_PKEY_add1_attr                      1959	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_purpose_inherit          1960	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_keygen                1961	3_0_0	EXIST::FUNCTION:
 ENGINE_get_pkey_asn1_meth               1962	3_0_0	EXIST::FUNCTION:ENGINE
-SHA256_Update                           1963	3_0_0	EXIST::FUNCTION:
+SHA256_Update                           1963	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 d2i_PKCS7_ISSUER_AND_SERIAL             1964	3_0_0	EXIST::FUNCTION:
 PKCS12_unpack_authsafes                 1965	3_0_0	EXIST::FUNCTION:
 X509_CRL_it                             1966	3_0_0	EXIST::FUNCTION:
@@ -2073,7 +2073,7 @@ BIO_s_file                              2118	3_0_0	EXIST::FUNCTION:
 RSA_X931_derive_ex                      2119	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_decrypt_init                   2120	3_0_0	EXIST::FUNCTION:
 ENGINE_get_destroy_function             2121	3_0_0	EXIST::FUNCTION:ENGINE
-SHA224_Init                             2122	3_0_0	EXIST::FUNCTION:
+SHA224_Init                             2122	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509V3_EXT_add_conf                     2123	3_0_0	EXIST::FUNCTION:
 ASN1_object_size                        2124	3_0_0	EXIST::FUNCTION:
 X509_REVOKED_free                       2125	3_0_0	EXIST::FUNCTION:
@@ -2191,7 +2191,7 @@ PEM_write_bio_PKCS8_PRIV_KEY_INFO       2238	3_0_0	EXIST::FUNCTION:
 EC_GROUP_set_curve_GF2m                 2239	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC2M
 ENGINE_load_builtin_engines             2240	3_0_0	EXIST::FUNCTION:ENGINE
 SRP_VBASE_init                          2241	3_0_0	EXIST::FUNCTION:SRP
-SHA224_Final                            2242	3_0_0	EXIST::FUNCTION:
+SHA224_Final                            2242	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 OCSP_CERTSTATUS_free                    2243	3_0_0	EXIST::FUNCTION:OCSP
 d2i_TS_TST_INFO                         2244	3_0_0	EXIST::FUNCTION:TS
 IPAddressOrRange_it                     2245	3_0_0	EXIST::FUNCTION:RFC3779
@@ -2201,7 +2201,7 @@ TS_OBJ_print_bio                        2248	3_0_0	EXIST::FUNCTION:TS
 X509_time_adj_ex                        2249	3_0_0	EXIST::FUNCTION:
 OCSP_request_add1_cert                  2250	3_0_0	EXIST::FUNCTION:OCSP
 ERR_load_X509_strings                   2251	3_0_0	EXIST::FUNCTION:
-SHA1_Transform                          2252	3_0_0	EXIST::FUNCTION:
+SHA1_Transform                          2252	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 CMS_signed_get_attr_by_NID              2253	3_0_0	EXIST::FUNCTION:CMS
 X509_STORE_CTX_get_by_subject           2254	3_0_0	EXIST::FUNCTION:
 ASN1_OCTET_STRING_it                    2255	3_0_0	EXIST::FUNCTION:
@@ -2461,7 +2461,7 @@ BN_generate_dsa_nonce                   2512	3_0_0	EXIST::FUNCTION:
 X509_verify_cert                        2513	3_0_0	EXIST::FUNCTION:
 X509_policy_level_get0_node             2514	3_0_0	EXIST::FUNCTION:
 X509_REQ_get_attr                       2515	3_0_0	EXIST::FUNCTION:
-SHA1                                    2516	3_0_0	EXIST::FUNCTION:
+SHA1                                    2516	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_print                              2517	3_0_0	EXIST::FUNCTION:
 d2i_AutoPrivateKey                      2518	3_0_0	EXIST::FUNCTION:
 X509_REQ_new                            2519	3_0_0	EXIST::FUNCTION:
@@ -2497,7 +2497,7 @@ d2i_NETSCAPE_CERT_SEQUENCE              2550	3_0_0	EXIST::FUNCTION:
 X509_CRL_set_version                    2551	3_0_0	EXIST::FUNCTION:
 ASN1_PCTX_set_cert_flags                2552	3_0_0	EXIST::FUNCTION:
 PKCS8_PRIV_KEY_INFO_free                2553	3_0_0	EXIST::FUNCTION:
-SHA224_Update                           2554	3_0_0	EXIST::FUNCTION:
+SHA224_Update                           2554	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EC_GROUP_new_by_curve_name              2555	3_0_0	EXIST::FUNCTION:EC
 X509_STORE_set_purpose                  2556	3_0_0	EXIST::FUNCTION:
 X509_CRL_get0_signature                 2557	3_0_0	EXIST::FUNCTION:
@@ -2728,7 +2728,7 @@ CMS_RecipientInfo_encrypt               2786	3_0_0	EXIST::FUNCTION:CMS
 X509_get_pubkey_parameters              2787	3_0_0	EXIST::FUNCTION:
 PKCS12_setup_mac                        2788	3_0_0	EXIST::FUNCTION:
 PEM_read_bio_PKCS7                      2789	3_0_0	EXIST::FUNCTION:
-SHA512_Final                            2790	3_0_0	EXIST::FUNCTION:
+SHA512_Final                            2790	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_VERIFY_PARAM_set1_host             2791	3_0_0	EXIST::FUNCTION:
 OCSP_resp_find_status                   2792	3_0_0	EXIST::FUNCTION:OCSP
 d2i_ASN1_T61STRING                      2793	3_0_0	EXIST::FUNCTION:
@@ -2902,14 +2902,14 @@ EC_curve_nid2nist                       2964	3_0_0	EXIST::FUNCTION:EC
 ENGINE_get_finish_function              2965	3_0_0	EXIST::FUNCTION:ENGINE
 EC_POINT_add                            2966	3_0_0	EXIST::FUNCTION:EC
 EC_KEY_oct2key                          2967	3_0_0	EXIST::FUNCTION:EC
-SHA384_Init                             2968	3_0_0	EXIST::FUNCTION:
+SHA384_Init                             2968	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ASN1_UNIVERSALSTRING_new                2969	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_print_private                  2970	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_new                        2971	3_0_0	EXIST::FUNCTION:
 NAME_CONSTRAINTS_it                     2972	3_0_0	EXIST::FUNCTION:
 TS_REQ_get_cert_req                     2973	3_0_0	EXIST::FUNCTION:TS
 BIO_pop                                 2974	3_0_0	EXIST::FUNCTION:
-SHA256_Final                            2975	3_0_0	EXIST::FUNCTION:
+SHA256_Final                            2975	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_PKEY_set1_DH                        2976	3_0_0	EXIST::FUNCTION:DH
 DH_get_ex_data                          2977	3_0_0	EXIST::FUNCTION:DH
 CRYPTO_secure_malloc                    2978	3_0_0	EXIST::FUNCTION:
@@ -2929,7 +2929,7 @@ EC_GROUP_set_asn1_flag                  2991	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_new                            2992	3_0_0	EXIST::FUNCTION:
 i2d_POLICYINFO                          2993	3_0_0	EXIST::FUNCTION:
 BN_get_flags                            2994	3_0_0	EXIST::FUNCTION:
-SHA384                                  2995	3_0_0	EXIST::FUNCTION:
+SHA384                                  2995	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 NCONF_get_string                        2996	3_0_0	EXIST::FUNCTION:
 d2i_PROXY_CERT_INFO_EXTENSION           2997	3_0_0	EXIST::FUNCTION:
 EC_POINT_point2buf                      2998	3_0_0	EXIST::FUNCTION:EC
@@ -2981,7 +2981,7 @@ i2d_X509_PUBKEY                         3045	3_0_0	EXIST::FUNCTION:
 EVP_DecryptUpdate                       3046	3_0_0	EXIST::FUNCTION:
 CAST_cbc_encrypt                        3047	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 BN_BLINDING_invert                      3048	3_0_0	EXIST::FUNCTION:
-SHA512_Update                           3049	3_0_0	EXIST::FUNCTION:
+SHA512_Update                           3049	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ESS_ISSUER_SERIAL_new                   3050	3_0_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_get0_pkcs8               3051	3_0_0	EXIST::FUNCTION:
 X509_get_ext_by_NID                     3052	3_0_0	EXIST::FUNCTION:
@@ -3326,7 +3326,7 @@ d2i_PKCS8_PRIV_KEY_INFO_fp              3395	3_0_0	EXIST::FUNCTION:STDIO
 X509_OBJECT_retrieve_match              3396	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_ctr                         3397	3_0_0	EXIST::FUNCTION:
 EVP_PBE_find                            3398	3_0_0	EXIST::FUNCTION:
-SHA512_Transform                        3399	3_0_0	EXIST::FUNCTION:
+SHA512_Transform                        3399	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ERR_add_error_vdata                     3400	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_get_ext                    3401	3_0_0	EXIST::FUNCTION:OCSP
 NETSCAPE_SPKAC_new                      3402	3_0_0	EXIST::FUNCTION:
@@ -3363,7 +3363,7 @@ EVP_OpenFinal                           3432	3_0_0	EXIST::FUNCTION:RSA
 RAND_egd_bytes                          3433	3_0_0	EXIST::FUNCTION:EGD
 UI_method_get_writer                    3434	3_0_0	EXIST::FUNCTION:
 BN_secure_new                           3435	3_0_0	EXIST::FUNCTION:
-SHA1_Update                             3437	3_0_0	EXIST::FUNCTION:
+SHA1_Update                             3437	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BIO_s_connect                           3438	3_0_0	EXIST::FUNCTION:SOCK
 EVP_MD_meth_get_init                    3439	3_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_free                    3440	3_0_0	EXIST::FUNCTION:
@@ -3513,7 +3513,7 @@ EVP_MD_meth_dup                         3588	3_0_0	EXIST::FUNCTION:
 ENGINE_unregister_ciphers               3589	3_0_0	EXIST::FUNCTION:ENGINE
 X509_issuer_and_serial_cmp              3590	3_0_0	EXIST::FUNCTION:
 OCSP_response_create                    3591	3_0_0	EXIST::FUNCTION:OCSP
-SHA224                                  3592	3_0_0	EXIST::FUNCTION:
+SHA224                                  3592	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 MD2_options                             3593	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
 X509_REQ_it                             3595	3_0_0	EXIST::FUNCTION:
 RAND_bytes                              3596	3_0_0	EXIST::FUNCTION:
@@ -3554,7 +3554,7 @@ PKCS5_pbe_set                           3631	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_free                        3632	3_0_0	EXIST::FUNCTION:TS
 d2i_PUBKEY                              3633	3_0_0	EXIST::FUNCTION:
 ASYNC_cleanup_thread                    3634	3_0_0	EXIST::FUNCTION:
-SHA384_Update                           3635	3_0_0	EXIST::FUNCTION:
+SHA384_Update                           3635	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 CRYPTO_cfb128_1_encrypt                 3636	3_0_0	EXIST::FUNCTION:
 BIO_set_cipher                          3637	3_0_0	EXIST::FUNCTION:
 PEM_read_PUBKEY                         3638	3_0_0	EXIST::FUNCTION:STDIO
@@ -3576,7 +3576,7 @@ Camellia_ecb_encrypt                    3654	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPR
 ENGINE_set_default_RSA                  3655	3_0_0	EXIST::FUNCTION:ENGINE
 EVP_EncodeBlock                         3656	3_0_0	EXIST::FUNCTION:
 SXNETID_free                            3657	3_0_0	EXIST::FUNCTION:
-SHA1_Init                               3658	3_0_0	EXIST::FUNCTION:
+SHA1_Init                               3658	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 CRYPTO_atomic_add                       3659	3_0_0	EXIST::FUNCTION:
 TS_CONF_load_certs                      3660	3_0_0	EXIST::FUNCTION:TS
 PEM_write_bio_DSAPrivateKey             3661	3_0_0	EXIST::FUNCTION:DSA
@@ -3599,7 +3599,7 @@ CRYPTO_mem_ctrl                         3678	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG
 ASN1_verify                             3679	3_0_0	EXIST::FUNCTION:
 DSA_generate_parameters_ex              3680	3_0_0	EXIST::FUNCTION:DSA
 X509_sign                               3681	3_0_0	EXIST::FUNCTION:
-SHA256_Transform                        3682	3_0_0	EXIST::FUNCTION:
+SHA256_Transform                        3682	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BIO_ADDR_free                           3683	3_0_0	EXIST::FUNCTION:SOCK
 ASN1_STRING_free                        3684	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_inherit               3685	3_0_0	EXIST::FUNCTION:
@@ -3816,7 +3816,7 @@ CRL_DIST_POINTS_free                    3899	3_0_0	EXIST::FUNCTION:
 d2i_OCSP_SINGLERESP                     3900	3_0_0	EXIST::FUNCTION:OCSP
 EVP_CIPHER_CTX_num                      3901	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_verify_recover_init            3902	3_0_0	EXIST::FUNCTION:
-SHA512_Init                             3903	3_0_0	EXIST::FUNCTION:
+SHA512_Init                             3903	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 TS_MSG_IMPRINT_set_msg                  3904	3_0_0	EXIST::FUNCTION:TS
 CMS_unsigned_add1_attr                  3905	3_0_0	EXIST::FUNCTION:CMS
 OPENSSL_LH_doall                        3906	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use of the low level SHA-1 and SHA-2 functions has been informally discouraged for a long time. We now formally deprecate them.

- [x] documentation is added or updated
- [x] tests are added or updated
