### PR TITLE
Add a travis build that compiles with enable-trace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,10 @@ matrix:
           compiler: clang
           env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES no-deprecated" BUILDONLY="yes"
         - os: linux
+          arch: arm64
+          compiler: gcc
+          env: CONFIG_OPTS="--strict-warnings enable-trace" BUILDONLY="yes"
+        - os: linux
           addons:
               apt:
                   packages:


### PR DESCRIPTION
This option seems to get broken quite often - so a travis build should
hopefully prevent these creeping into new PRs.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
