### PR TITLE
EVP: clear error when falling back from failed EVP_KEYMGMT_fetch()

### DIFF
--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -217,6 +217,7 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
          * operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_KEYEXCH_free(exchange);
+        ERR_clear_error();
         goto legacy;
     }
 

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -175,6 +175,12 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
     evp_pkey_ctx_free_old_ops(ctx);
     ctx->operation = EVP_PKEY_OP_DERIVE;
 
+    /*
+     * TODO when we stop falling back to legacy, this and the ERR_pop_to_mark()
+     * calls can be removed.
+     */
+    ERR_set_mark();
+
     if (ctx->engine != NULL || ctx->keytype == NULL)
         goto legacy;
 
@@ -185,6 +191,7 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
     if (provkey == NULL)
         goto legacy;
     if (!EVP_KEYMGMT_up_ref(tmp_keymgmt)) {
+        ERR_clear_last_mark();
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
@@ -211,16 +218,21 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
         || (EVP_KEYMGMT_provider(ctx->keymgmt)
             != EVP_KEYEXCH_provider(exchange))) {
         /*
-         * We don't have the full support we need with provided methods,
-         * let's go see if legacy does.  Also, we don't need to free
-         * ctx->keymgmt here, as it's not necessarily tied to this
-         * operation.  It will be freed by EVP_PKEY_CTX_free().
+         * We don't need to free ctx->keymgmt here, as it's not necessarily
+         * tied to this operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_KEYEXCH_free(exchange);
-        ERR_clear_error();
         goto legacy;
     }
 
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
+    /* No more legacy from here down to legacy: */
 
     ctx->op.kex.exchange = exchange;
     ctx->op.kex.exchprovctx = exchange->newctx(ossl_provider_ctx(exchange->prov));
@@ -237,6 +249,13 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
     return 0;
 
  legacy:
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
     if (ctx->pmeth == NULL || ctx->pmeth->derive == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return -2;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -54,6 +54,12 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     locpctx = ctx->pctx;
     evp_pkey_ctx_free_old_ops(locpctx);
 
+    /*
+     * TODO when we stop falling back to legacy, this and the ERR_pop_to_mark()
+     * calls can be removed.
+     */
+    ERR_set_mark();
+
     if (locpctx->keytype == NULL)
         goto legacy;
 
@@ -80,6 +86,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     if (provkey == NULL)
         goto legacy;
     if (!EVP_KEYMGMT_up_ref(tmp_keymgmt)) {
+        ERR_clear_last_mark();
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
@@ -108,15 +115,19 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         || (EVP_KEYMGMT_provider(locpctx->keymgmt)
             != EVP_SIGNATURE_provider(signature))) {
         /*
-         * We don't have the full support we need with provided methods,
-         * let's go see if legacy does.  Also, we don't need to free
-         * ctx->keymgmt here, as it's not necessarily tied to this
-         * operation.  It will be freed by EVP_PKEY_CTX_free().
+         * We don't need to free ctx->keymgmt here, as it's not necessarily
+         * tied to this operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_SIGNATURE_free(signature);
-        ERR_clear_error();
         goto legacy;
     }
+
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
 
     /* No more legacy from here down to legacy: */
 
@@ -165,6 +176,13 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     return 0;
 
  legacy:
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
     if (ctx->pctx->pmeth == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return 0;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -114,6 +114,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
          * operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_SIGNATURE_free(signature);
+        ERR_clear_error();
         goto legacy;
     }
 

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -73,6 +73,7 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
          * operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_ASYM_CIPHER_free(cipher);
+        ERR_clear_error();
         goto legacy;
     }
 

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -32,6 +32,12 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
     evp_pkey_ctx_free_old_ops(ctx);
     ctx->operation = operation;
 
+    /*
+     * TODO when we stop falling back to legacy, this and the ERR_pop_to_mark()
+     * calls can be removed.
+     */
+    ERR_set_mark();
+
     if (ctx->keytype == NULL || ctx->engine != NULL)
         goto legacy;
 
@@ -41,7 +47,11 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
                                      &tmp_keymgmt, ctx->propquery, 0);
     if (provkey == NULL)
         goto legacy;
-    EVP_KEYMGMT_up_ref(tmp_keymgmt);
+    if (!EVP_KEYMGMT_up_ref(tmp_keymgmt)) {
+        ERR_clear_last_mark();
+        ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
+        goto err;
+    }
     EVP_KEYMGMT_free(ctx->keymgmt);
     ctx->keymgmt = tmp_keymgmt;
 
@@ -67,15 +77,21 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
         || (EVP_KEYMGMT_provider(ctx->keymgmt)
             != EVP_ASYM_CIPHER_provider(cipher))) {
         /*
-         * We don't have the full support we need with provided methods,
-         * let's go see if legacy does.  Also, we don't need to free
-         * ctx->keymgmt here, as it's not necessarily tied to this
-         * operation.  It will be freed by EVP_PKEY_CTX_free().
+         * We don't need to free ctx->keymgmt here, as it's not necessarily
+         * tied to this operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_ASYM_CIPHER_free(cipher);
-        ERR_clear_error();
         goto legacy;
     }
+
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
+    /* No more legacy from here down to legacy: */
 
     ctx->op.ciph.cipher = cipher;
     ctx->op.ciph.ciphprovctx = cipher->newctx(ossl_provider_ctx(cipher->prov));
@@ -115,6 +131,13 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
     return 1;
 
  legacy:
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
     if (ctx->pmeth == NULL || ctx->pmeth->encrypt == NULL) {
         EVPerr(0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
         return -2;

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -333,6 +333,12 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     evp_pkey_ctx_free_old_ops(ctx);
     ctx->operation = operation;
 
+    /*
+     * TODO when we stop falling back to legacy, this and the ERR_pop_to_mark()
+     * calls can be removed.
+     */
+    ERR_set_mark();
+
     if (ctx->keytype == NULL)
         goto legacy;
 
@@ -343,6 +349,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     if (provkey == NULL)
         goto legacy;
     if (!EVP_KEYMGMT_up_ref(tmp_keymgmt)) {
+        ERR_clear_last_mark();
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
@@ -370,15 +377,21 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
         || (EVP_KEYMGMT_provider(ctx->keymgmt)
             != EVP_SIGNATURE_provider(signature))) {
         /*
-         * We don't have the full support we need with provided methods,
-         * let's go see if legacy does.  Also, we don't need to free
-         * ctx->keymgmt here, as it's not necessarily tied to this
-         * operation.  It will be freed by EVP_PKEY_CTX_free().
+         * We don't need to free ctx->keymgmt here, as it's not necessarily
+         * tied to this operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_SIGNATURE_free(signature);
-        ERR_clear_error();
         goto legacy;
     }
+
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
+    /* No more legacy from here down to legacy: */
 
     ctx->op.sig.signature = signature;
     ctx->op.sig.sigprovctx = signature->newctx(ossl_provider_ctx(signature->prov));
@@ -426,6 +439,13 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     return 1;
 
  legacy:
+    /*
+     * TODO remove this when legacy is gone
+     * If we don't have the full support we need with provided methods,
+     * let's go see if legacy does.
+     */
+    ERR_pop_to_mark();
+
     if (ctx->pmeth == NULL
             || (operation == EVP_PKEY_OP_SIGN && ctx->pmeth->sign == NULL)
             || (operation == EVP_PKEY_OP_VERIFY && ctx->pmeth->verify == NULL)

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -376,6 +376,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
          * operation.  It will be freed by EVP_PKEY_CTX_free().
          */
         EVP_SIGNATURE_free(signature);
+        ERR_clear_error();
         goto legacy;
     }
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -774,7 +774,9 @@ static OSSL_core_get_library_context_fn core_get_libctx;
 static OSSL_core_new_error_fn core_new_error;
 static OSSL_core_set_error_debug_fn core_set_error_debug;
 static OSSL_core_vset_error_fn core_vset_error;
-static OSSL_core_clear_error_fn core_clear_error;
+static OSSL_core_set_error_mark_fn core_set_error_mark;
+static OSSL_core_clear_last_error_mark_fn core_clear_last_error_mark;
+static OSSL_core_pop_error_to_mark_fn core_pop_error_to_mark;
 #endif
 
 static const OSSL_PARAM *core_gettable_params(const OSSL_PROVIDER *prov)
@@ -859,9 +861,19 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
     }
 }
 
-static void core_clear_error(const OSSL_PROVIDER *prov)
+static int core_set_error_mark(const OSSL_PROVIDER *prov)
 {
-    ERR_clear_error();
+    return ERR_set_mark();
+}
+
+static int core_clear_last_error_mark(const OSSL_PROVIDER *prov)
+{
+    return ERR_clear_last_mark();
+}
+
+static int core_pop_error_to_mark(const OSSL_PROVIDER *prov)
+{
+    return ERR_pop_to_mark();
 }
 #endif
 
@@ -878,7 +890,11 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_NEW_ERROR, (void (*)(void))core_new_error },
     { OSSL_FUNC_CORE_SET_ERROR_DEBUG, (void (*)(void))core_set_error_debug },
     { OSSL_FUNC_CORE_VSET_ERROR, (void (*)(void))core_vset_error },
-    { OSSL_FUNC_CORE_CLEAR_ERROR, (void (*)(void))core_clear_error },
+    { OSSL_FUNC_CORE_SET_ERROR_MARK, (void (*)(void))core_set_error_mark },
+    { OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK,
+      (void (*)(void))core_clear_last_error_mark },
+    { OSSL_FUNC_CORE_POP_ERROR_TO_MARK,
+      (void (*)(void))core_pop_error_to_mark },
     { OSSL_FUNC_BIO_NEW_FILE, (void (*)(void))BIO_new_file },
     { OSSL_FUNC_BIO_NEW_MEMBUF, (void (*)(void))BIO_new_mem_buf },
     { OSSL_FUNC_BIO_READ_EX, (void (*)(void))BIO_read_ex },

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -774,6 +774,7 @@ static OSSL_core_get_library_context_fn core_get_libctx;
 static OSSL_core_new_error_fn core_new_error;
 static OSSL_core_set_error_debug_fn core_set_error_debug;
 static OSSL_core_vset_error_fn core_vset_error;
+static OSSL_core_clear_error_fn core_clear_error;
 #endif
 
 static const OSSL_PARAM *core_gettable_params(const OSSL_PROVIDER *prov)
@@ -857,6 +858,11 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
         ERR_vset_error(prov->error_lib, (int)reason, fmt, args);
     }
 }
+
+static void core_clear_error(const OSSL_PROVIDER *prov)
+{
+    ERR_clear_error();
+}
 #endif
 
 /*
@@ -872,6 +878,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_NEW_ERROR, (void (*)(void))core_new_error },
     { OSSL_FUNC_CORE_SET_ERROR_DEBUG, (void (*)(void))core_set_error_debug },
     { OSSL_FUNC_CORE_VSET_ERROR, (void (*)(void))core_vset_error },
+    { OSSL_FUNC_CORE_CLEAR_ERROR, (void (*)(void))core_clear_error },
     { OSSL_FUNC_BIO_NEW_FILE, (void (*)(void))BIO_new_file },
     { OSSL_FUNC_BIO_NEW_MEMBUF, (void (*)(void))BIO_new_mem_buf },
     { OSSL_FUNC_BIO_READ_EX, (void (*)(void))BIO_read_ex },

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -80,55 +80,60 @@ OSSL_CORE_MAKE_FUNC(void,core_set_error_debug,
 OSSL_CORE_MAKE_FUNC(void,core_vset_error,
                     (const OSSL_PROVIDER *prov,
                      uint32_t reason, const char *fmt, va_list args))
-# define OSSL_FUNC_CORE_CLEAR_ERROR            8
-OSSL_CORE_MAKE_FUNC(void, core_clear_error, (const OSSL_PROVIDER *prov))
+# define OSSL_FUNC_CORE_SET_ERROR_MARK         8
+OSSL_CORE_MAKE_FUNC(int, core_set_error_mark, (const OSSL_PROVIDER *prov))
+# define OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK  9
+OSSL_CORE_MAKE_FUNC(int, core_clear_last_error_mark,
+                    (const OSSL_PROVIDER *prov))
+# define OSSL_FUNC_CORE_POP_ERROR_TO_MARK 10
+OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_PROVIDER *prov))
 
 /* Memory allocation, freeing, clearing. */
-#define OSSL_FUNC_CRYPTO_MALLOC               10
+#define OSSL_FUNC_CRYPTO_MALLOC               20
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_malloc, (size_t num, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_ZALLOC               11
+#define OSSL_FUNC_CRYPTO_ZALLOC               21
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_zalloc, (size_t num, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_FREE                 12
+#define OSSL_FUNC_CRYPTO_FREE                 22
 OSSL_CORE_MAKE_FUNC(void,
         CRYPTO_free, (void *ptr, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_CLEAR_FREE           13
+#define OSSL_FUNC_CRYPTO_CLEAR_FREE           23
 OSSL_CORE_MAKE_FUNC(void,
         CRYPTO_clear_free, (void *ptr, size_t num, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_REALLOC              14
+#define OSSL_FUNC_CRYPTO_REALLOC              24
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_realloc, (void *addr, size_t num, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_CLEAR_REALLOC        15
+#define OSSL_FUNC_CRYPTO_CLEAR_REALLOC        25
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_clear_realloc, (void *addr, size_t old_num, size_t num,
                                const char *file, int line))
-#define OSSL_FUNC_CRYPTO_SECURE_MALLOC        16
+#define OSSL_FUNC_CRYPTO_SECURE_MALLOC        26
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_secure_malloc, (size_t num, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_SECURE_ZALLOC        17
+#define OSSL_FUNC_CRYPTO_SECURE_ZALLOC        27
 OSSL_CORE_MAKE_FUNC(void *,
         CRYPTO_secure_zalloc, (size_t num, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_SECURE_FREE          18
+#define OSSL_FUNC_CRYPTO_SECURE_FREE          28
 OSSL_CORE_MAKE_FUNC(void,
         CRYPTO_secure_free, (void *ptr, const char *file, int line))
-#define OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE    19
+#define OSSL_FUNC_CRYPTO_SECURE_CLEAR_FREE    29
 OSSL_CORE_MAKE_FUNC(void,
         CRYPTO_secure_clear_free, (void *ptr, size_t num, const char *file,
                                    int line))
-#define OSSL_FUNC_CRYPTO_SECURE_ALLOCATED     20
+#define OSSL_FUNC_CRYPTO_SECURE_ALLOCATED     30
 OSSL_CORE_MAKE_FUNC(int,
         CRYPTO_secure_allocated, (const void *ptr))
-#define OSSL_FUNC_OPENSSL_CLEANSE             21
+#define OSSL_FUNC_OPENSSL_CLEANSE             31
 OSSL_CORE_MAKE_FUNC(void,
         OPENSSL_cleanse, (void *ptr, size_t len))
 
 /* Bio functions provided by the core */
-#define OSSL_FUNC_BIO_NEW_FILE                23
-#define OSSL_FUNC_BIO_NEW_MEMBUF              24
-#define OSSL_FUNC_BIO_READ_EX                 25
-#define OSSL_FUNC_BIO_FREE                    26
-#define OSSL_FUNC_BIO_VPRINTF                 27
+#define OSSL_FUNC_BIO_NEW_FILE                40
+#define OSSL_FUNC_BIO_NEW_MEMBUF              41
+#define OSSL_FUNC_BIO_READ_EX                 42
+#define OSSL_FUNC_BIO_FREE                    43
+#define OSSL_FUNC_BIO_VPRINTF                 44
 
 OSSL_CORE_MAKE_FUNC(BIO *, BIO_new_file, (const char *filename, const char *mode))
 OSSL_CORE_MAKE_FUNC(BIO *, BIO_new_membuf, (const void *buf, int len))
@@ -138,7 +143,7 @@ OSSL_CORE_MAKE_FUNC(int, BIO_free, (BIO *bio))
 OSSL_CORE_MAKE_FUNC(int, BIO_vprintf, (BIO *bio, const char *format,
                                        va_list args))
 
-#define OSSL_FUNC_SELF_TEST_CB                28
+#define OSSL_FUNC_SELF_TEST_CB               100
 OSSL_CORE_MAKE_FUNC(void, self_test_cb, (OPENSSL_CTX *ctx, OSSL_CALLBACK **cb,
                                          void **cbarg))
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -80,6 +80,8 @@ OSSL_CORE_MAKE_FUNC(void,core_set_error_debug,
 OSSL_CORE_MAKE_FUNC(void,core_vset_error,
                     (const OSSL_PROVIDER *prov,
                      uint32_t reason, const char *fmt, va_list args))
+# define OSSL_FUNC_CORE_CLEAR_ERROR            8
+OSSL_CORE_MAKE_FUNC(void, core_clear_error, (const OSSL_PROVIDER *prov))
 
 /* Memory allocation, freeing, clearing. */
 #define OSSL_FUNC_CRYPTO_MALLOC               10

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -54,7 +54,9 @@ OSSL_core_thread_start_fn *c_thread_start;
 static OSSL_core_new_error_fn *c_new_error;
 static OSSL_core_set_error_debug_fn *c_set_error_debug;
 static OSSL_core_vset_error_fn *c_vset_error;
-static OSSL_core_clear_error_fn *c_clear_error;
+static OSSL_core_set_error_mark_fn *c_set_error_mark;
+static OSSL_core_clear_last_error_mark_fn *c_clear_last_error_mark;
+static OSSL_core_pop_error_to_mark_fn *c_pop_error_to_mark;
 static OSSL_CRYPTO_malloc_fn *c_CRYPTO_malloc;
 static OSSL_CRYPTO_zalloc_fn *c_CRYPTO_zalloc;
 static OSSL_CRYPTO_free_fn *c_CRYPTO_free;
@@ -676,8 +678,14 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_VSET_ERROR:
             c_vset_error = OSSL_get_core_vset_error(in);
             break;
-        case OSSL_FUNC_CORE_CLEAR_ERROR:
-            c_clear_error = OSSL_get_core_clear_error(in);
+        case OSSL_FUNC_CORE_SET_ERROR_MARK:
+            c_set_error_mark = OSSL_get_core_set_error_mark(in);
+            break;
+        case OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK:
+            c_clear_last_error_mark = OSSL_get_core_clear_last_error_mark(in);
+            break;
+        case OSSL_FUNC_CORE_POP_ERROR_TO_MARK:
+            c_pop_error_to_mark = OSSL_get_core_pop_error_to_mark(in);
             break;
         case OSSL_FUNC_CRYPTO_MALLOC:
             c_CRYPTO_malloc = OSSL_get_CRYPTO_malloc(in);
@@ -843,9 +851,19 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
     c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, args);
 }
 
-void ERR_clear_error(void)
+int ERR_set_mark(void)
 {
-    c_clear_error(NULL);
+    return c_set_error_mark(NULL);
+}
+
+int ERR_clear_last_mark(void)
+{
+    return c_clear_last_error_mark(NULL);
+}
+
+int ERR_pop_to_mark(void)
+{
+    return c_pop_error_to_mark(NULL);
 }
 
 const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx)

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -54,6 +54,7 @@ OSSL_core_thread_start_fn *c_thread_start;
 static OSSL_core_new_error_fn *c_new_error;
 static OSSL_core_set_error_debug_fn *c_set_error_debug;
 static OSSL_core_vset_error_fn *c_vset_error;
+static OSSL_core_clear_error_fn *c_clear_error;
 static OSSL_CRYPTO_malloc_fn *c_CRYPTO_malloc;
 static OSSL_CRYPTO_zalloc_fn *c_CRYPTO_zalloc;
 static OSSL_CRYPTO_free_fn *c_CRYPTO_free;
@@ -675,6 +676,9 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         case OSSL_FUNC_CORE_VSET_ERROR:
             c_vset_error = OSSL_get_core_vset_error(in);
             break;
+        case OSSL_FUNC_CORE_CLEAR_ERROR:
+            c_clear_error = OSSL_get_core_clear_error(in);
+            break;
         case OSSL_FUNC_CRYPTO_MALLOC:
             c_CRYPTO_malloc = OSSL_get_CRYPTO_malloc(in);
             break;
@@ -837,6 +841,11 @@ void ERR_set_error(int lib, int reason, const char *fmt, ...)
 void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
 {
     c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, args);
+}
+
+void ERR_clear_error(void)
+{
+    c_clear_error(NULL);
 }
 
 const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx)


### PR DESCRIPTION
Since we're falling back to legacy, this isn't an error any more.
Among others the failed EVP_KEYMGMT_fetch() error shadows other errors
produced by the legacy code, which disrupts our test/evp_test runs.
