### PR TITLE
Fix documentation for EVP_DigestSign* and EVP_DigestVerify*

### DIFF
--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -117,14 +117,16 @@ in B<sig> of length B<siglen>.
 
 =head1 RETURN VALUES
 
-EVP_DigestVerifyInit() and EVP_DigestVerifyUpdate() return 1 for success and 0
-for failure.
+EVP_DigestVerifyInit(), EVP_DigestVerifyUpdate(), EVP_DigestVerifyaFinal() and
+EVP_DigestVerify() return 1 for success and 0 or a negative value for failure.
+In particular, a return value of -2 indicates the operation is not supported by
+the public key algorithm.
 
-EVP_DigestVerifyFinal() and EVP_DigestVerify() return 1 for success; any other
-value indicates failure.  A return value of zero indicates that the signature
-did not verify successfully (that is, B<tbs> did not match the original data or
-the signature had an invalid form), while other values indicate a more serious
-error (and sometimes also indicate an invalid signature form).
+A return value of zero from EVP_DigestVerifyFinal() and EVP_DigestVerify()
+indicates that the signature did not verify successfully (that is, B<tbs> did
+not match the original data or the signature had an invalid form), while
+negative values indicate a more serious error (and sometimes also indicate an
+invalid signature form).
 
 The error codes can be obtained from L<ERR_get_error(3)>.
 

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -117,7 +117,7 @@ in B<sig> of length B<siglen>.
 
 =head1 RETURN VALUES
 
-EVP_DigestVerifyInit(), EVP_DigestVerifyUpdate(), EVP_DigestVerifyaFinal() and
+EVP_DigestVerifyInit(), EVP_DigestVerifyUpdate(), EVP_DigestVerifyFinal() and
 EVP_DigestVerify() return 1 for success and 0 or a negative value for failure.
 In particular, a return value of -2 indicates the operation is not supported by
 the public key algorithm.

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1162,7 +1162,7 @@ static int mac_test_run_pkey(EVP_TEST *t)
         t->err = "INTERNAL_ERROR";
         goto err;
     }
-    if (!EVP_DigestSignInit(mctx, &pctx, md, NULL, key)) {
+    if (EVP_DigestSignInit(mctx, &pctx, md, NULL, key) <= 0) {
         t->err = "DIGESTSIGNINIT_ERROR";
         goto err;
     }
@@ -2611,13 +2611,13 @@ static int digestsigver_test_parse(EVP_TEST *t,
             return 1;
         }
         if (mdata->is_verify) {
-            if (!EVP_DigestVerifyInit(mdata->ctx, &mdata->pctx, mdata->md,
-                                      NULL, pkey))
+            if (EVP_DigestVerifyInit(mdata->ctx, &mdata->pctx, mdata->md,
+                                     NULL, pkey) <= 0)
                 t->err = "DIGESTVERIFYINIT_ERROR";
             return 1;
         }
-        if (!EVP_DigestSignInit(mdata->ctx, &mdata->pctx, mdata->md, NULL,
-                                pkey))
+        if (EVP_DigestSignInit(mdata->ctx, &mdata->pctx, mdata->md, NULL,
+                               pkey) <= 0)
             t->err = "DIGESTSIGNINIT_ERROR";
         return 1;
     }


### PR DESCRIPTION
The documentation doesn't match actual code.

We also fix the few cases in test/evp_test.c where the returned value
from these functions is interpreted incorrectly.
