### PR TITLE
EVP: Adapt EVP_PKEY checking, comparing and copying for provider keys

### DIFF
--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -75,31 +75,6 @@ DH *DSA_dup_DH(const DSA *r)
 }
 # endif /*  OPENSSL_NO_DH */
 
-const BIGNUM *DSA_get0_p(const DSA *d)
-{
-    return d->params.p;
-}
-
-const BIGNUM *DSA_get0_q(const DSA *d)
-{
-    return d->params.q;
-}
-
-const BIGNUM *DSA_get0_g(const DSA *d)
-{
-    return d->params.g;
-}
-
-const BIGNUM *DSA_get0_pub_key(const DSA *d)
-{
-    return d->pub_key;
-}
-
-const BIGNUM *DSA_get0_priv_key(const DSA *d)
-{
-    return d->priv_key;
-}
-
 void DSA_clear_flags(DSA *d, int flags)
 {
     d->flags &= ~flags;
@@ -320,4 +295,29 @@ int DSA_security_bits(const DSA *d)
 int DSA_bits(const DSA *dsa)
 {
     return BN_num_bits(dsa->params.p);
+}
+
+const BIGNUM *DSA_get0_p(const DSA *d)
+{
+    return d->p;
+}
+
+const BIGNUM *DSA_get0_q(const DSA *d)
+{
+    return d->q;
+}
+
+const BIGNUM *DSA_get0_g(const DSA *d)
+{
+    return d->g;
+}
+
+const BIGNUM *DSA_get0_pub_key(const DSA *d)
+{
+    return d->pub_key;
+}
+
+const BIGNUM *DSA_get0_priv_key(const DSA *d)
+{
+    return d->priv_key;
 }

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -82,6 +82,9 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_exportdomparam_types_fn *exportdomparam_types;
     OSSL_OP_keymgmt_get_domparam_params_fn *get_domparam_params;
     OSSL_OP_keymgmt_gettable_domparam_params_fn *gettable_domparam_params;
+    OSSL_OP_keymgmt_isdomparams_fn *isdomparams;
+    OSSL_OP_keymgmt_cmpdomparams_fn *cmpdomparams;
+    OSSL_OP_keymgmt_dupdomparams_fn *dupdomparams;
 
     /* Key routines */
     OSSL_OP_keymgmt_importkey_fn *importkey;
@@ -93,6 +96,9 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_exportkey_types_fn *exportkey_types;
     OSSL_OP_keymgmt_get_key_params_fn *get_key_params;
     OSSL_OP_keymgmt_gettable_key_params_fn *gettable_key_params;
+    OSSL_OP_keymgmt_iskey_fn *iskey;
+    OSSL_OP_keymgmt_cmpkey_fn *cmpkey;
+    OSSL_OP_keymgmt_dupkey_fn *dupkey;
 
     OSSL_OP_keymgmt_query_operation_name_fn *query_operation_name;
 } /* EVP_KEYMGMT */ ;

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -278,6 +278,24 @@ evp_keymgmt_gettable_domparam_params(const EVP_KEYMGMT *keymgmt)
     return keymgmt->gettable_domparam_params();
 }
 
+int evp_keymgmt_isdomparams(const EVP_KEYMGMT *keymgmt,
+                            const void *domparams)
+{
+    return keymgmt->isdomparams(domparams);
+}
+
+int evp_keymgmt_cmpdomparams(const EVP_KEYMGMT *keymgmt,
+                             const void *domparams1, const void *domparams2)
+{
+    return keymgmt->cmpdomparams(domparams1, domparams2);
+}
+
+void *evp_keymgmt_dupdomparams(const EVP_KEYMGMT *keymgmt,
+                               void *domparams, int do_copy)
+{
+    return keymgmt->dupdomparams(domparams, do_copy);
+}
+
 
 void *evp_keymgmt_importkey(const EVP_KEYMGMT *keymgmt,
                             const OSSL_PARAM params[])
@@ -341,4 +359,20 @@ const OSSL_PARAM *evp_keymgmt_gettable_key_params(const EVP_KEYMGMT *keymgmt)
     if (keymgmt->gettable_key_params == NULL)
         return NULL;
     return keymgmt->gettable_key_params();
+}
+
+int evp_keymgmt_iskey(const EVP_KEYMGMT *keymgmt, const void *key)
+{
+    return keymgmt->iskey(key);
+}
+
+int evp_keymgmt_cmpkey(const EVP_KEYMGMT *keymgmt,
+                       const void *key1, const void *key2)
+{
+    return keymgmt->cmpkey(key1, key2);
+}
+
+void *evp_keymgmt_dupkey(const EVP_KEYMGMT *keymgmt, void *key, int do_copy)
+{
+    return keymgmt->dupkey(key, do_copy);
 }

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -91,6 +91,24 @@ static void *keymgmt_from_dispatch(int name_id,
                 keymgmt->gettable_domparam_params =
                     OSSL_get_OP_keymgmt_gettable_domparam_params(fns);
             break;
+        case OSSL_FUNC_KEYMGMT_ISDOMPARAMS:
+            if (keymgmt->isdomparams != NULL)
+                break;
+            keymgmt->isdomparams =
+                OSSL_get_OP_keymgmt_isdomparams(fns);
+            break;
+        case OSSL_FUNC_KEYMGMT_CMPDOMPARAMS:
+            if (keymgmt->cmpdomparams != NULL)
+                break;
+            keymgmt->cmpdomparams =
+                OSSL_get_OP_keymgmt_cmpdomparams(fns);
+            break;
+        case OSSL_FUNC_KEYMGMT_DUPDOMPARAMS:
+            if (keymgmt->dupdomparams != NULL)
+                break;
+            keymgmt->dupdomparams =
+                OSSL_get_OP_keymgmt_dupdomparams(fns);
+            break;
         case OSSL_FUNC_KEYMGMT_IMPORTKEY:
             if (keymgmt->importkey != NULL)
                 break;
@@ -138,6 +156,24 @@ static void *keymgmt_from_dispatch(int name_id,
                 keymgmt->gettable_key_params =
                     OSSL_get_OP_keymgmt_gettable_key_params(fns);
             break;
+        case OSSL_FUNC_KEYMGMT_ISKEY:
+            if (keymgmt->iskey != NULL)
+                break;
+            keymgmt->iskey =
+                OSSL_get_OP_keymgmt_iskey(fns);
+            break;
+        case OSSL_FUNC_KEYMGMT_CMPKEY:
+            if (keymgmt->cmpkey != NULL)
+                break;
+            keymgmt->cmpkey =
+                OSSL_get_OP_keymgmt_cmpkey(fns);
+            break;
+        case OSSL_FUNC_KEYMGMT_DUPKEY:
+            if (keymgmt->dupkey != NULL)
+                break;
+            keymgmt->dupkey =
+                OSSL_get_OP_keymgmt_dupkey(fns);
+            break;
         case OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME:
             if (keymgmt->query_operation_name != NULL)
                 break;
@@ -155,10 +191,6 @@ static void *keymgmt_from_dispatch(int name_id,
     if ((keymgmt->freedomparams != NULL
          && (keymgmt->importdomparams == NULL
              && keymgmt->gendomparams == NULL))
-        || (keymgmt->freekey != NULL
-            && (keymgmt->importkey == NULL
-                && keymgmt->genkey == NULL
-                && keymgmt->loadkey == NULL))
         || (keymgmt->importdomparam_types != NULL
             && keymgmt->importdomparams == NULL)
         || (keymgmt->exportdomparam_types != NULL
@@ -170,7 +202,23 @@ static void *keymgmt_from_dispatch(int name_id,
         || (keymgmt->exportkey_types != NULL
             && keymgmt->exportkey == NULL)
         || (keymgmt->gettable_key_params != NULL
-            && keymgmt->get_key_params == NULL)) {
+            && keymgmt->get_key_params == NULL)
+        || (keymgmt->freedomparams == NULL
+            && !(keymgmt->isdomparams == NULL
+                 && keymgmt->cmpdomparams == NULL
+                 && keymgmt->dupdomparams == NULL))
+        || (keymgmt->freedomparams != NULL
+            && !(keymgmt->isdomparams != NULL
+                 && keymgmt->cmpdomparams != NULL
+                 && keymgmt->dupdomparams != NULL))
+        /* Fundamentals, some things simply *must* be present */
+        || keymgmt->freekey == NULL
+        || (keymgmt->importkey == NULL
+            && keymgmt->genkey == NULL
+            && keymgmt->loadkey == NULL)
+        || keymgmt->iskey == NULL
+        || keymgmt->cmpkey == NULL
+        || keymgmt->dupkey == NULL) {
         EVP_KEYMGMT_free(keymgmt);
         EVPerr(0, EVP_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -83,7 +83,8 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 {
     int is_provided = 0;
 
-    if (evp_pkey_make_provided((EVP_PKEY *)from, NULL, NULL, NULL, 1)) {
+    if (from->ameth == NULL
+        && evp_pkey_make_provided((EVP_PKEY *)from, NULL, NULL, NULL, 1)) {
         /*
          * It's fine if the destination hasn't cached anything yet, that
          * simply makes it a blank page to be filled in with the

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -84,7 +84,7 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
     int is_provided = 0;
 
     if (from->ameth == NULL
-        && evp_pkey_make_provided((EVP_PKEY *)from, NULL, NULL, NULL, 1)) {
+        && evp_pkey_make_provided((EVP_PKEY *)from, NULL, NULL, NULL, -1)) {
         /*
          * It's fine if the destination hasn't cached anything yet, that
          * simply makes it a blank page to be filled in with the

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -83,7 +83,7 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 {
     int is_provided = 0;
 
-    if (evp_pkey_make_provided((EVP_PKEY *)from, NULL, NULL, 1)) {
+    if (evp_pkey_make_provided((EVP_PKEY *)from, NULL, NULL, NULL, 1)) {
         /*
          * It's fine if the destination hasn't cached anything yet, that
          * simply makes it a blank page to be filled in with the
@@ -169,8 +169,9 @@ static int cmp_provided(const EVP_PKEY *a, const EVP_PKEY *b, int domainparams)
      * To do so, we must break constness to be able to cache keymgmt data,
      * but since we know that EVP_PKEYs are dynamically allocated, it's ok.
      */
-    if (!evp_pkey_make_provided((EVP_PKEY *)a, NULL, NULL, domainparams)
-        || !evp_pkey_make_provided((EVP_PKEY *)b, NULL, NULL, domainparams))
+    if (!evp_pkey_make_provided((EVP_PKEY *)a, NULL, NULL, NULL, domainparams)
+        || !evp_pkey_make_provided((EVP_PKEY *)b, NULL, NULL, NULL,
+                                   domainparams))
         return -2;
 
     return evp_keymgmt_cmp(a, b, 1);

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -127,7 +127,7 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
     if (is_provided) {
         return evp_keymgmt_copy(to, from, 1);
     } else {
-        if (from->ameth->param_copy == NULL)
+        if (from->ameth->param_copy != NULL)
             return from->ameth->param_copy(to, from);
     }
  err:
@@ -136,7 +136,7 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 
 int EVP_PKEY_missing_parameters(const EVP_PKEY *pkey)
 {
-    if (pkey == NULL) {
+    if (pkey != NULL) {
         if (pkey->ameth == NULL)
             return !evp_keymgmt_is(pkey, 1);
         if (pkey->ameth->param_missing != NULL)
@@ -154,7 +154,7 @@ int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
     /* All legacy keys */
     if (a->type != b->type)
         return -1;
-    if (a->ameth && a->ameth->param_cmp)
+    if (a->ameth->param_cmp != NULL)
         return a->ameth->param_cmp(a, b);
     return -2;
 }
@@ -168,18 +168,15 @@ int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
     if (a->type != b->type)
         return -1;
 
-    if (a->ameth) {
-        int ret;
-        /* Compare parameters if the algorithm has them */
-        if (a->ameth->param_cmp) {
-            ret = a->ameth->param_cmp(a, b);
-            if (ret <= 0)
-                return ret;
-        }
-
-        if (a->ameth->pub_cmp)
-            return a->ameth->pub_cmp(a, b);
+    /* Compare parameters if the algorithm has them */
+    if (a->ameth->param_cmp != NULL) {
+        int ret = a->ameth->param_cmp(a, b);
+        if (ret <= 0)
+            return ret;
     }
+
+    if (a->ameth->pub_cmp != NULL)
+        return a->ameth->pub_cmp(a, b);
 
     return -2;
 }

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -30,6 +30,11 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  int OP_keymgmt_get_domparam_params(void *domparams, OSSL_PARAM params[]);
  const OSSL_PARAM *OP_keymgmt_gettable_domparam_params(void);
 
+ /* Key domain parameter status and duplication */
+ int OP_keymgmt_isdomparams(const void *domparams);
+ int OP_keymgmt_cmpdomparams(const void *domparams1, const void *domparams2);
+ void *OP_keymgmt_dupdomparams(void *domparams, int do_copy);
+
  /* Key creation and destruction */
  void *OP_keymgmt_importkey(void *provctx, const OSSL_PARAM params[]);
  void *OP_keymgmt_genkey(void *provctx,
@@ -47,6 +52,11 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  /* Key information */
  int OP_keymgmt_get_key_params(void *key, OSSL_PARAM params[]);
  const OSSL_PARAM *OP_keymgmt_gettable_key_params(void);
+
+ /* Key status and duplication */
+ int OP_keymgmt_iskey(const void *key);
+ int OP_keymgmt_cmpkey(const void *key1, const void *key2);
+ void *OP_keymgmt_dupkey(void *key, int do_copy);
 
  /* Discovery of supported operations */
  const char *OP_keymgmt_query_operation_name(int operation_id);
@@ -95,6 +105,9 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_keymgmt_get_domparam_params  OSSL_FUNC_KEYMGMT_GET_DOMPARAM_PARAMS
  OP_keymgmt_gettable_domparam_params
                                  OSSL_FUNC_KEYMGMT_GETTABLE_DOMPARAM_PARAMS
+ OP_keymgmt_isdomparams          OSSL_FUNC_KEYMGMT_ISDOMPARAMS
+ OP_keymgmt_cmpdomparams         OSSL_FUNC_KEYMGMT_CMPDOMPARAMS
+ OP_keymgmt_dupdomparams         OSSL_FUNC_KEYMGMT_DUPDOMPARAMS
 
  OP_keymgmt_importkey            OSSL_FUNC_KEYMGMT_IMPORTKEY
  OP_keymgmt_genkey               OSSL_FUNC_KEYMGMT_GENKEY
@@ -105,6 +118,9 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_keymgmt_exportkey_types      OSSL_FUNC_KEYMGMT_EXPORTKEY_TYPES
  OP_keymgmt_get_key_params       OSSL_FUNC_KEYMGMT_GET_KEY_PARAMS
  OP_keymgmt_gettable_key_params  OSSL_FUNC_KEYMGMT_GETTABLE_KEY_PARAMS
+ OP_keymgmt_iskey                OSSL_FUNC_KEYMGMT_ISKEY
+ OP_keymgmt_cmpkey               OSSL_FUNC_KEYMGMT_CMPKEY
+ OP_keymgmt_dupkey               OSSL_FUNC_KEYMGMT_DUPKEY
 
  OP_keymgmt_query_operation_name OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME
 
@@ -142,6 +158,22 @@ see L</Information Parameters>.
 OP_keymgmt_gettable_domparam_params() should return a constant array
 of descriptor B<OSSL_PARAM>, for parameters that
 OP_keymgmt_get_domparam_params() can handle.
+
+OP_keymgmt_isdomparams() should check if the structure I<domparams> is
+or contains domain parameters, and return 1 if it is, otherwise 0.
+
+OP_keymgmt_cmpdomparams() should check if the structures I<domparams1>
+and I<domainparams2> contain the same domain parameters, and return 1
+if they do, otherwise 0.
+
+OP_keymgmt_dupdomparams() should make a new reference to an existing
+provider side domain parameter structure I<domparams>.
+If I<do_copy> is false (zero), it's sufficient but not mandatory to
+return a pointer to the same structure, and the implementation must
+take precautions to ensure freeing it later will not cause an error
+(such as reference counting).
+If I<do_copy> is true (one), the implementation must make an actual
+separate copy.
 
 =head2 Key functions
 
@@ -184,6 +216,21 @@ with the given I<key>, see L</Information Parameters>.
 OP_keymgmt_gettable_key_params() should return a constant array of
 descriptor B<OSSL_PARAM>, for parameters that
 OP_keymgmt_get_key_params() can handle.
+
+OP_keymgmt_iskey() should check if the structure I<key> is or contains
+a key pair, and return 1 if it is, otherwise 0.
+
+OP_keymgmt_cmpkey() should check if the structures I<key1> and I<key2>
+contain the same public key, and return 1 if they do, otherwise 0.
+
+OP_keymgmt_dupkey() should make a new reference to an existing
+provider side key structure I<key>.
+If I<do_copy> is false (zero), it's sufficient but not mandatory to
+return a pointer to the same structure, and the implementation must
+take precautions to ensure freeing it later will not cause an error
+(such as reference counting).
+If I<do_copy> is true (one), the implementation must make an actual
+separate copy.
 
 =head2 Supported operations
 
@@ -230,6 +277,18 @@ The value should be the number of security bits of the given key.
 Bits of security is defined in SP800-57.
 
 =back
+
+=head1 NOTES
+
+A provider side key should be able to hold at least the public key,
+and domain parameters as well when the key type supports them.  The
+implementation must be able to import and export them, even if they're
+independent from anything else that the implementation supports.
+
+Functions such as OP_keymgmt_cmpkey() depend on this, in case
+EVP_PKEY_cmp() wants to compare two domain parameter sets or two keys
+that only differ in coming from two different providers, but have the
+same data.
 
 =head1 SEE ALSO
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -601,6 +601,10 @@ void evp_keymgmt_cache_pkey(EVP_PKEY *pk, size_t index, EVP_KEYMGMT *keymgmt,
                             void *provdata, int domainparams);
 void *evp_keymgmt_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                            const OSSL_PARAM params[], int domainparams);
+int evp_keymgmt_is(const EVP_PKEY *pkey, int domainparams);
+int evp_keymgmt_cmp(const EVP_PKEY *pkey1, const EVP_PKEY *pkey2,
+                    int domainparams);
+int evp_keymgmt_copy(EVP_PKEY *to, const EVP_PKEY *from, int domainparams);
 
 
 /* KEYMGMT provider interface functions */

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -621,6 +621,12 @@ int evp_keymgmt_get_domparam_params(const EVP_KEYMGMT *keymgmt,
                                     void *provdomparam, OSSL_PARAM params[]);
 const OSSL_PARAM *
 evp_keymgmt_gettable_domparam_params(const EVP_KEYMGMT *keymgmt);
+int evp_keymgmt_isdomparams(const EVP_KEYMGMT *keymgmt,
+                            const void *domparams);
+int evp_keymgmt_cmpdomparams(const EVP_KEYMGMT *keymgmt,
+                             const void *domparams1, const void *domparams2);
+void *evp_keymgmt_dupdomparams(const EVP_KEYMGMT *keymgmt, void *domparams,
+                               int do_copy);
 
 void *evp_keymgmt_importkey(const EVP_KEYMGMT *keymgmt,
                             const OSSL_PARAM params[]);
@@ -636,6 +642,10 @@ const OSSL_PARAM *evp_keymgmt_exportkey_types(const EVP_KEYMGMT *keymgmt);
 int evp_keymgmt_get_key_params(const EVP_KEYMGMT *keymgmt,
                                void *provkey, OSSL_PARAM params[]);
 const OSSL_PARAM *evp_keymgmt_gettable_key_params(const EVP_KEYMGMT *keymgmt);
+int evp_keymgmt_iskey(const EVP_KEYMGMT *keymgmt, const void *key);
+int evp_keymgmt_cmpkey(const EVP_KEYMGMT *keymgmt,
+                       const void *key1, const void *key2);
+void *evp_keymgmt_dupkey(const EVP_KEYMGMT *keymgmt, void *key, int do_copy);
 
 /* Pulling defines out of C source files */
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -386,6 +386,15 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_get_domparam_params,
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_gettable_domparam_params,
                     (void))
 
+# define OSSL_FUNC_KEYMGMT_ISDOMPARAMS               9
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_isdomparams, (const void *domparams))
+# define OSSL_FUNC_KEYMGMT_CMPDOMPARAMS             10
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_cmpdomparams,
+                    (const void *domparams1, const void *domparams2))
+# define OSSL_FUNC_KEYMGMT_DUPDOMPARAMS             11
+OSSL_CORE_MAKE_FUNC(void *, OP_keymgmt_dupdomparams,
+                    (void *domparams, int do_copy))
+
 /* Key creation and destruction */
 # define OSSL_FUNC_KEYMGMT_IMPORTKEY                20
 # define OSSL_FUNC_KEYMGMT_GENKEY                   21
@@ -421,6 +430,14 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_exportkey_types, (void))
 OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_get_key_params,
                     (void *key, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_gettable_key_params, (void))
+
+# define OSSL_FUNC_KEYMGMT_ISKEY                    29
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_iskey, (const void *key))
+# define OSSL_FUNC_KEYMGMT_CMPKEY                   30
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_cmpkey,
+                    (const void *key1, const void *key2))
+# define OSSL_FUNC_KEYMGMT_DUPKEY                   31
+OSSL_CORE_MAKE_FUNC(void *, OP_keymgmt_dupkey, (void *key, int do_copy))
 
 /* Discovery of supported operations */
 # define OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME     40

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -197,10 +197,27 @@ static void *dsa_dupdomparams(void *domparams, int do_copy)
 {
     DSA *new = domparams;
 
-    if (do_copy)
-        new = DSAparams_dup(domparams);
-    else
-        DSA_up_ref(new);
+    if (do_copy) {
+        new = DSA_new();
+
+        if (new != NULL) {
+            BIGNUM *p = BN_dup(DSA_get0_p(domparams));
+            BIGNUM *g = BN_dup(DSA_get0_g(domparams));
+            BIGNUM *q = BN_dup(DSA_get0_q(domparams));
+
+            if (!DSA_set0_pqg(new, p, q, g)) {
+                BN_free(p);
+                BN_free(g);
+                BN_free(q);
+                DSA_free(new);
+                new = NULL;
+            }
+        }
+    } else {
+        if (!DSA_up_ref(new))
+            new = NULL;
+    }
+
     return new;
 }
 

--- a/providers/implementations/keymgmt/rsa_kmgmt.c.orig
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c.orig
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core_numbers.h>
+#include <openssl/core_names.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#include <openssl/params.h>
+#include <openssl/types.h>
+#include "internal/param_build.h"
+#include "prov/implementations.h"
+#include "prov/providercommon.h"
+#include "crypto/rsa.h"
+
+static OSSL_OP_keymgmt_importkey_fn rsa_importkey;
+static OSSL_OP_keymgmt_exportkey_fn rsa_exportkey;
+static OSSL_OP_keymgmt_get_key_params_fn rsa_get_key_params;
+
+DEFINE_STACK_OF(BIGNUM)
+DEFINE_SPECIAL_STACK_OF_CONST(BIGNUM_const, BIGNUM)
+
+static int collect_numbers(STACK_OF(BIGNUM) *numbers,
+                           const OSSL_PARAM params[], const char *key)
+{
+    const OSSL_PARAM *p = NULL;
+
+    if (numbers == NULL)
+        return 0;
+
+    for (p = params; (p = OSSL_PARAM_locate_const(p, key)) != NULL; p++) {
+        BIGNUM *tmp = NULL;
+
+        if (!OSSL_PARAM_get_BN(p, &tmp))
+            return 0;
+        sk_BIGNUM_push(numbers, tmp);
+    }
+
+    return 1;
+}
+
+static int params_to_key(RSA *rsa, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *param_n, *param_e,  *param_d;
+    BIGNUM *n = NULL, *e = NULL, *d = NULL;
+    STACK_OF(BIGNUM) *factors = NULL, *exps = NULL, *coeffs = NULL;
+    int is_private = 0;
+
+    if (rsa == NULL)
+        return 0;
+
+    param_n = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_N);
+    param_e = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E);
+    param_d = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_D);
+
+    if ((param_n != NULL && !OSSL_PARAM_get_BN(param_n, &n))
+        || (param_e != NULL && !OSSL_PARAM_get_BN(param_e, &e))
+        || (param_d != NULL && !OSSL_PARAM_get_BN(param_d, &d)))
+        goto err;
+
+    is_private = (d != NULL);
+
+    if (!RSA_set0_key(rsa, n, e, d))
+        goto err;
+    n = e = d = NULL;
+
+    if (is_private) {
+        if (!collect_numbers(factors = sk_BIGNUM_new_null(), params,
+                             OSSL_PKEY_PARAM_RSA_FACTOR)
+            || !collect_numbers(exps = sk_BIGNUM_new_null(), params,
+                                OSSL_PKEY_PARAM_RSA_EXPONENT)
+            || !collect_numbers(coeffs = sk_BIGNUM_new_null(), params,
+                                OSSL_PKEY_PARAM_RSA_COEFFICIENT))
+            goto err;
+
+        /* It's ok if this private key just has n, e and d */
+        if (sk_BIGNUM_num(factors) != 0
+            && !rsa_set0_all_params(rsa, factors, exps, coeffs))
+            goto err;
+    }
+
+    sk_BIGNUM_free(factors);
+    sk_BIGNUM_free(exps);
+    sk_BIGNUM_free(coeffs);
+    return 1;
+
+ err:
+    BN_free(n);
+    BN_free(e);
+    BN_free(d);
+    sk_BIGNUM_pop_free(factors, BN_free);
+    sk_BIGNUM_pop_free(exps, BN_free);
+    sk_BIGNUM_pop_free(coeffs, BN_free);
+    return 0;
+}
+
+static int export_numbers(OSSL_PARAM_BLD *tmpl, const char *key,
+                          STACK_OF(BIGNUM_const) *numbers)
+{
+    int i, nnum;
+
+    if (numbers == NULL)
+        return 0;
+
+    nnum = sk_BIGNUM_const_num(numbers);
+
+    for (i = 0; i < nnum; i++) {
+        if (!ossl_param_bld_push_BN(tmpl, key,
+                                    sk_BIGNUM_const_value(numbers, i)))
+            return 0;
+    }
+
+    return 1;
+}
+
+static int key_to_params(RSA *rsa, OSSL_PARAM_BLD *tmpl)
+{
+    int ret = 0;
+    const BIGNUM *rsa_d = NULL, *rsa_n = NULL, *rsa_e = NULL;
+    STACK_OF(BIGNUM_const) *factors = sk_BIGNUM_const_new_null();
+    STACK_OF(BIGNUM_const) *exps = sk_BIGNUM_const_new_null();
+    STACK_OF(BIGNUM_const) *coeffs = sk_BIGNUM_const_new_null();
+
+    if (rsa == NULL || factors == NULL || exps == NULL || coeffs == NULL)
+        goto err;
+
+    RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
+    rsa_get0_all_params(rsa, factors, exps, coeffs);
+
+    if (rsa_n != NULL
+        && !ossl_param_bld_push_BN(tmpl, OSSL_PKEY_PARAM_RSA_N, rsa_n))
+        goto err;
+    if (rsa_e != NULL
+        && !ossl_param_bld_push_BN(tmpl, OSSL_PKEY_PARAM_RSA_E, rsa_e))
+        goto err;
+    if (rsa_d != NULL
+        && !ossl_param_bld_push_BN(tmpl, OSSL_PKEY_PARAM_RSA_D, rsa_d))
+        goto err;
+
+    if (!export_numbers(tmpl, OSSL_PKEY_PARAM_RSA_FACTOR, factors)
+        || !export_numbers(tmpl, OSSL_PKEY_PARAM_RSA_EXPONENT, exps)
+        || !export_numbers(tmpl, OSSL_PKEY_PARAM_RSA_COEFFICIENT, coeffs))
+        goto err;
+
+    ret = 1;
+ err:
+    sk_BIGNUM_const_free(factors);
+    sk_BIGNUM_const_free(exps);
+    sk_BIGNUM_const_free(coeffs);
+    return ret;
+}
+
+static void *rsa_importkey(void *provctx, const OSSL_PARAM params[])
+{
+    RSA *rsa;
+
+    if ((rsa = RSA_new()) == NULL
+        || !params_to_key(rsa, params)) {
+        RSA_free(rsa);
+        rsa = NULL;
+    }
+    return rsa;
+}
+
+static int rsa_exportkey(void *key, OSSL_CALLBACK *param_callback, void *cbarg)
+{
+    RSA *rsa = key;
+    OSSL_PARAM_BLD tmpl;
+    OSSL_PARAM *params = NULL;
+    int ret;
+
+    ossl_param_bld_init(&tmpl);
+    if (rsa == NULL
+        || !key_to_params(rsa, &tmpl)
+        || (params = ossl_param_bld_to_param(&tmpl)) == NULL)
+        return 0;
+    ret = param_callback(params, cbarg);
+    ossl_param_bld_free(params);
+    return ret;
+}
+
+/*
+ * This provider can export everything in an RSA key, so we use the exact
+ * same type description for export as for import.  Other providers might
+ * choose to import full keys, but only export the public parts, and will
+ * therefore have the importkey_types and importkey_types functions return
+ * different arrays.
+ */
+static const OSSL_PARAM rsa_key_types[] = {
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_N, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_E, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_D, NULL, 0),
+    /* We tolerate up to 10 factors... */
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR, NULL, 0),
+    /* ..., up to 10 CRT exponents... */
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_EXPONENT, NULL, 0),
+    /* ..., and up to 9 CRT coefficients */
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_COEFFICIENT, NULL, 0),
+};
+/*
+ * We lied about the amount of factors, exponents and coefficients, the
+ * export and import functions can really deal with an infinite amount
+ * of these numbers.  However, RSA keys with too many primes are futile,
+ * so we at least pretend to have some limits.
+ */
+
+static const OSSL_PARAM *rsa_exportkey_types(void)
+{
+    return rsa_key_types;
+}
+
+static const OSSL_PARAM *rsa_importkey_types(void)
+{
+    return rsa_key_types;
+}
+
+static int rsa_get_key_params(void *key, OSSL_PARAM params[])
+{
+    RSA *rsa = key;
+    OSSL_PARAM *p;
+
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS)) != NULL
+        && !OSSL_PARAM_set_int(p, RSA_bits(rsa)))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SECURITY_BITS)) != NULL
+        && !OSSL_PARAM_set_int(p, RSA_security_bits(rsa)))
+        return 0;
+    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SIZE)) != NULL
+        && !OSSL_PARAM_set_int(p, RSA_size(rsa)))
+        return 0;
+    return 1;
+}
+
+const OSSL_DISPATCH rsa_keymgmt_functions[] = {
+    { OSSL_FUNC_KEYMGMT_IMPORTKEY, (void (*)(void))rsa_importkey },
+    { OSSL_FUNC_KEYMGMT_IMPORTKEY_TYPES, (void (*)(void))rsa_importkey_types },
+    { OSSL_FUNC_KEYMGMT_EXPORTKEY, (void (*)(void))rsa_exportkey },
+    { OSSL_FUNC_KEYMGMT_EXPORTKEY_TYPES, (void (*)(void))rsa_exportkey_types },
+    { OSSL_FUNC_KEYMGMT_FREEKEY, (void (*)(void))RSA_free },
+    { OSSL_FUNC_KEYMGMT_GET_KEY_PARAMS,  (void (*) (void))rsa_get_key_params },
+    { 0, NULL }
+};

--- a/providers/implementations/keymgmt/rsa_kmgmt.c.rej
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c.rej
@@ -1,0 +1,31 @@
+--- providers/implementations/keymgmt/rsa_kmgmt.c
++++ providers/implementations/keymgmt/rsa_kmgmt.c
+@@ -268,6 +272,28 @@ static int rsa_get_key_params(void *key, OSSL_PARAM params[])
+     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_SIZE)) != NULL
+         && !OSSL_PARAM_set_int(p, RSA_size(rsa)))
+         return 0;
++# if 0                           /* PSS support pending */
++    if ((p = OSSL_PARAM_locate(params,
++                               OSSL_PKEY_PARAM_MANDATORY_DIGEST)) != NULL
++        && RSA_get0_pss_params(rsa) != NULL) {
++        const EVP_MD *md, *mgf1md;
++        int min_saltlen;
++
++        if (!rsa_pss_get_param(RSA_get0_pss_params(rsa),
++                               &md, &mgf1md, &min_saltlen)) {
++            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
++            return 0;
++        }
++        if (!OSSL_PARAM_set_utf8_string(p, EVP_MD_name(md)))
++            return 0;
++    }
++#endif
++    if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DEFAULT_DIGEST)) != NULL
++        && RSA_get0_pss_params(rsa) == NULL) {
++        if (!OSSL_PARAM_set_utf8_string(p, RSA_DEFAULT_MD))
++            return 0;
++    }
++
+     return 1;
+ }
+ 


### PR DESCRIPTION
This affects the following function, which can now deal with provider
side domain parameters and keys:

- EVP_PKEY_copy_parameters()
- EVP_PKEY_missing_parameters()
- EVP_PKEY_cmp_parameters()
- EVP_PKEY_cmp()

This also adds the necessary EVP_KEYMGMT interfaces to support those functions, and the implementations for RSA, DSA and DH.