### PR TITLE
Fix small misspelling in doc for OCSP_response_status

### DIFF
--- a/doc/man3/OCSP_response_status.pod
+++ b/doc/man3/OCSP_response_status.pod
@@ -58,7 +58,7 @@ with the X509 certificate B<cert>.
 
 OCSP_basic_sign() signs OCSP response B<brsp> using certificate B<signer>, private key
 B<key>, digest B<dgst> and additional certificates B<certs>. If the B<flags> option
-B<OCSP_NOCERTS> is set then no certificates will be included in the request. If the
+B<OCSP_NOCERTS> is set then no certificates will be included in the response. If the
 B<flags> option B<OCSP_RESPID_KEY> is set then the responder is identified by key ID
 rather than by name. OCSP_basic_sign_ctx() also signs OCSP response B<brsp> but
 uses the parameters contained in digest context B<ctx>.


### PR DESCRIPTION
The manpage for OCSP_response_status has a small misspelling.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

