### PR TITLE
Move the definition of OPENSSL_BUILDING_OPENSSL

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -10,7 +10,7 @@ my %targets=(
 	includes	=> [],
 	lib_cflags	=> "",
 	lib_cppflags	=> "",
-	lib_defines	=> [ 'OPENSSL_BUILDING_OPENSSL' ],
+	lib_defines	=> [],
 	thread_scheme	=> "(unknown)", # Assume we don't know
 	thread_defines	=> [],
 

--- a/build.info
+++ b/build.info
@@ -7,6 +7,11 @@ INCLUDE[libcrypto]=. include
 INCLUDE[libssl]=. include
 DEPEND[libssl]=libcrypto
 
+# Marker to show that we're building the OpenSSL libraries.  This is usefull
+# for source that has multiple usage (specifically, header files).
+DEFINE[libcrypto]=OPENSSL_BUILDING_OPENSSL
+DEFINE[libssl]=OPENSSL_BUILDING_OPENSSL
+
 # Empty DEPEND "indices" means the dependencies are expected to be built
 # unconditionally before anything else.
 DEPEND[]=include/openssl/configuration.h include/openssl/opensslv.h \


### PR DESCRIPTION
It was placed in a spot that works as fallback, and would therefore
not at all for config targets that define library macros of their own.

Furthermore, this should be attached specifically to our public
libraries, and that's done more precisely in our build.info files.

We ddo not attach it to anything else, so that our programs and engine
become and therefore are closer to what our users are exposed to...
in the spirit of eating our own dog food.
