### PR TITLE
Deprecate the low level SEED functions

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -380,7 +380,7 @@ static const OPT_PAIR doit_choices[] = {
     {"idea-cbc", D_CBC_IDEA},
     {"idea", D_CBC_IDEA},
 #endif
-#ifndef OPENSSL_NO_SEED
+#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"seed-cbc", D_CBC_SEED},
     {"seed", D_CBC_SEED},
 #endif
@@ -1458,7 +1458,7 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_IDEA
     IDEA_KEY_SCHEDULE idea_ks;
 #endif
-#ifndef OPENSSL_NO_SEED
+#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     SEED_KEY_SCHEDULE seed_ks;
 #endif
 #if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
@@ -1969,7 +1969,7 @@ int speed_main(int argc, char **argv)
     if (doit[D_CBC_IDEA])
         IDEA_set_encrypt_key(key16, &idea_ks);
 #endif
-#ifndef OPENSSL_NO_SEED
+#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_SEED])
         SEED_set_key(key16, &seed_ks);
 #endif
@@ -2585,7 +2585,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_SEED
+#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_SEED]) {
         if (async_jobs > 0) {
             BIO_printf(bio_err, "Async mode is not supported with %s\n",

--- a/crypto/evp/e_seed.c
+++ b/crypto/evp/e_seed.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/opensslconf.h>
 #ifdef OPENSSL_NO_SEED
 NON_EMPTY_TRANSLATION_UNIT

--- a/crypto/seed/seed.c
+++ b/crypto/seed/seed.c
@@ -34,6 +34,12 @@
  */
 #ifndef OPENSSL_NO_SEED
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 # include <stdio.h>
 # include <stdlib.h>
 # include <string.h>

--- a/crypto/seed/seed_cbc.c
+++ b/crypto/seed/seed_cbc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/seed.h>
 #include <openssl/modes.h>
 

--- a/crypto/seed/seed_cfb.c
+++ b/crypto/seed/seed_cfb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/seed.h>
 #include <openssl/modes.h>
 

--- a/crypto/seed/seed_ecb.c
+++ b/crypto/seed/seed_ecb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/seed.h>
 
 void SEED_ecb_encrypt(const unsigned char *in, unsigned char *out,

--- a/crypto/seed/seed_ofb.c
+++ b/crypto/seed/seed_ofb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/seed.h>
 #include <openssl/modes.h>
 

--- a/include/openssl/seed.h
+++ b/include/openssl/seed.h
@@ -44,31 +44,31 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_SEED
-# include <openssl/e_os2.h>
-# include <openssl/crypto.h>
+#  include <openssl/e_os2.h>
+#  include <openssl/crypto.h>
 
-#ifdef  __cplusplus
+#  ifdef  __cplusplus
 extern "C" {
-#endif
+#  endif
 
 /* look whether we need 'long' to get 32 bits */
-# ifdef AES_LONG
-#  ifndef SEED_LONG
-#   define SEED_LONG 1
+#  ifdef AES_LONG
+#   ifndef SEED_LONG
+#    define SEED_LONG 1
+#   endif
 #  endif
-# endif
 
-# include <sys/types.h>
+#  include <sys/types.h>
 
-# define SEED_BLOCK_SIZE 16
-# define SEED_KEY_LENGTH 16
+#  define SEED_BLOCK_SIZE 16
+#  define SEED_KEY_LENGTH 16
 
 typedef struct seed_key_st {
-# ifdef SEED_LONG
+#  ifdef SEED_LONG
     unsigned long data[32];
-# else
+#  else
     unsigned int data[32];
-# endif
+#  endif
 } SEED_KEY_SCHEDULE;
 
 void SEED_set_key(const unsigned char rawkey[SEED_KEY_LENGTH],
@@ -94,9 +94,9 @@ void SEED_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                          size_t len, const SEED_KEY_SCHEDULE *ks,
                          unsigned char ivec[SEED_BLOCK_SIZE], int *num);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/seed.h
+++ b/include/openssl/seed.h
@@ -46,53 +46,61 @@
 # ifndef OPENSSL_NO_SEED
 #  include <openssl/e_os2.h>
 #  include <openssl/crypto.h>
+#  include <sys/types.h>
 
 #  ifdef  __cplusplus
 extern "C" {
 #  endif
 
-/* look whether we need 'long' to get 32 bits */
-#  ifdef AES_LONG
-#   ifndef SEED_LONG
-#    define SEED_LONG 1
-#   endif
-#  endif
-
-#  include <sys/types.h>
-
 #  define SEED_BLOCK_SIZE 16
 #  define SEED_KEY_LENGTH 16
 
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+/* look whether we need 'long' to get 32 bits */
+#   ifdef AES_LONG
+#    ifndef SEED_LONG
+#     define SEED_LONG 1
+#    endif
+#   endif
+
+
 typedef struct seed_key_st {
-#  ifdef SEED_LONG
+#   ifdef SEED_LONG
     unsigned long data[32];
-#  else
+#   else
     unsigned int data[32];
-#  endif
+#   endif
 } SEED_KEY_SCHEDULE;
+#  endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
-void SEED_set_key(const unsigned char rawkey[SEED_KEY_LENGTH],
-                  SEED_KEY_SCHEDULE *ks);
+DEPRECATEDIN_3_0(void SEED_set_key(const unsigned char rawkey[SEED_KEY_LENGTH],
+                                   SEED_KEY_SCHEDULE *ks))
 
-void SEED_encrypt(const unsigned char s[SEED_BLOCK_SIZE],
-                  unsigned char d[SEED_BLOCK_SIZE],
-                  const SEED_KEY_SCHEDULE *ks);
-void SEED_decrypt(const unsigned char s[SEED_BLOCK_SIZE],
-                  unsigned char d[SEED_BLOCK_SIZE],
-                  const SEED_KEY_SCHEDULE *ks);
+DEPRECATEDIN_3_0(void SEED_encrypt(const unsigned char s[SEED_BLOCK_SIZE],
+                                   unsigned char d[SEED_BLOCK_SIZE],
+                                   const SEED_KEY_SCHEDULE *ks))
+DEPRECATEDIN_3_0(void SEED_decrypt(const unsigned char s[SEED_BLOCK_SIZE],
+                                   unsigned char d[SEED_BLOCK_SIZE],
+                                   const SEED_KEY_SCHEDULE *ks))
 
-void SEED_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                      const SEED_KEY_SCHEDULE *ks, int enc);
-void SEED_cbc_encrypt(const unsigned char *in, unsigned char *out, size_t len,
-                      const SEED_KEY_SCHEDULE *ks,
-                      unsigned char ivec[SEED_BLOCK_SIZE], int enc);
-void SEED_cfb128_encrypt(const unsigned char *in, unsigned char *out,
-                         size_t len, const SEED_KEY_SCHEDULE *ks,
-                         unsigned char ivec[SEED_BLOCK_SIZE], int *num,
-                         int enc);
-void SEED_ofb128_encrypt(const unsigned char *in, unsigned char *out,
-                         size_t len, const SEED_KEY_SCHEDULE *ks,
-                         unsigned char ivec[SEED_BLOCK_SIZE], int *num);
+DEPRECATEDIN_3_0(void SEED_ecb_encrypt(const unsigned char *in,
+                                       unsigned char *out,
+                                       const SEED_KEY_SCHEDULE *ks, int enc))
+DEPRECATEDIN_3_0(void SEED_cbc_encrypt(const unsigned char *in,
+                                       unsigned char *out, size_t len,
+                                       const SEED_KEY_SCHEDULE *ks,
+                                       unsigned char ivec[SEED_BLOCK_SIZE],
+                                       int enc))
+DEPRECATEDIN_3_0(void SEED_cfb128_encrypt(const unsigned char *in,
+                                          unsigned char *out, size_t len,
+                                          const SEED_KEY_SCHEDULE *ks,
+                                          unsigned char ivec[SEED_BLOCK_SIZE],
+                                          int *num, int enc))
+DEPRECATEDIN_3_0(void SEED_ofb128_encrypt(const unsigned char *in,
+                                          unsigned char *out, size_t len,
+                                          const SEED_KEY_SCHEDULE *ks,
+                                          unsigned char ivec[SEED_BLOCK_SIZE],
+                                          int *num))
 
 #  ifdef  __cplusplus
 }

--- a/providers/implementations/ciphers/cipher_seed.c
+++ b/providers/implementations/ciphers/cipher_seed.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for Seed cipher modes ecb, cbc, ofb, cfb */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_seed.h"
 #include "prov/implementations.h"
 

--- a/providers/implementations/ciphers/cipher_seed_hw.c
+++ b/providers/implementations/ciphers/cipher_seed_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SEED low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_seed.h"
 
 static int cipher_hw_seed_initkey(PROV_CIPHER_CTX *ctx,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -233,7 +233,7 @@ d2i_ASN1_SET_ANY                        236	3_0_0	EXIST::FUNCTION:
 ASN1_item_i2d                           238	3_0_0	EXIST::FUNCTION:
 OCSP_copy_nonce                         239	3_0_0	EXIST::FUNCTION:OCSP
 OBJ_txt2nid                             240	3_0_0	EXIST::FUNCTION:
-SEED_set_key                            241	3_0_0	EXIST::FUNCTION:SEED
+SEED_set_key                            241	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 EC_KEY_clear_flags                      242	3_0_0	EXIST::FUNCTION:EC
 CMS_RecipientInfo_ktri_get0_algs        243	3_0_0	EXIST::FUNCTION:CMS
 i2d_EC_PUBKEY                           244	3_0_0	EXIST::FUNCTION:EC
@@ -360,7 +360,7 @@ CMS_signed_add1_attr_by_txt             366	3_0_0	EXIST::FUNCTION:CMS
 i2d_NETSCAPE_SPKAC                      367	3_0_0	EXIST::FUNCTION:
 X509V3_add_value_bool_nf                368	3_0_0	EXIST::FUNCTION:
 ASN1_item_verify                        369	3_0_0	EXIST::FUNCTION:
-SEED_ecb_encrypt                        370	3_0_0	EXIST::FUNCTION:SEED
+SEED_ecb_encrypt                        370	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 X509_PUBKEY_get0_param                  371	3_0_0	EXIST::FUNCTION:
 ASN1_i2d_fp                             372	3_0_0	EXIST::FUNCTION:STDIO
 BIO_new_mem_buf                         373	3_0_0	EXIST::FUNCTION:
@@ -971,7 +971,7 @@ BIO_printf                              995	3_0_0	EXIST::FUNCTION:
 a2i_IPADDRESS                           996	3_0_0	EXIST::FUNCTION:
 ERR_peek_error_line_data                997	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ERR_unload_strings                      998	3_0_0	EXIST::FUNCTION:
-SEED_cfb128_encrypt                     999	3_0_0	EXIST::FUNCTION:SEED
+SEED_cfb128_encrypt                     999	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 ASN1_BIT_STRING_it                      1000	3_0_0	EXIST::FUNCTION:
 PKCS12_decrypt_skey                     1001	3_0_0	EXIST::FUNCTION:
 ENGINE_register_EC                      1002	3_0_0	EXIST::FUNCTION:ENGINE
@@ -2094,7 +2094,7 @@ ASN1_PRINTABLE_new                      2139	3_0_0	EXIST::FUNCTION:
 OBJ_NAME_new_index                      2140	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_add_alias                 2141	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get1_DSA                       2142	3_0_0	EXIST::FUNCTION:DSA
-SEED_cbc_encrypt                        2143	3_0_0	EXIST::FUNCTION:SEED
+SEED_cbc_encrypt                        2143	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 EVP_rc2_40_cbc                          2144	3_0_0	EXIST::FUNCTION:RC2
 ECDSA_SIG_new                           2145	3_0_0	EXIST::FUNCTION:EC
 i2d_PKCS8PrivateKey_nid_fp              2146	3_0_0	EXIST::FUNCTION:STDIO
@@ -2559,7 +2559,7 @@ OPENSSL_LH_node_usage_stats             2613	3_0_0	EXIST::FUNCTION:STDIO
 DIRECTORYSTRING_it                      2614	3_0_0	EXIST::FUNCTION:
 BIO_write                               2615	3_0_0	EXIST::FUNCTION:
 OCSP_ONEREQ_get_ext_by_OBJ              2616	3_0_0	EXIST::FUNCTION:OCSP
-SEED_encrypt                            2617	3_0_0	EXIST::FUNCTION:SEED
+SEED_encrypt                            2617	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 IPAddressRange_it                       2618	3_0_0	EXIST::FUNCTION:RFC3779
 PEM_read_bio_DSAPrivateKey              2619	3_0_0	EXIST::FUNCTION:DSA
 CMS_get0_type                           2620	3_0_0	EXIST::FUNCTION:CMS
@@ -2663,7 +2663,7 @@ i2d_TS_TST_INFO_bio                     2719	3_0_0	EXIST::FUNCTION:TS
 CMS_sign_receipt                        2720	3_0_0	EXIST::FUNCTION:CMS
 ENGINE_set_RAND                         2721	3_0_0	EXIST::FUNCTION:ENGINE
 X509_REVOKED_get_ext_by_OBJ             2722	3_0_0	EXIST::FUNCTION:
-SEED_decrypt                            2723	3_0_0	EXIST::FUNCTION:SEED
+SEED_decrypt                            2723	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 PEM_write_PKCS8PrivateKey               2724	3_0_0	EXIST::FUNCTION:STDIO
 ENGINE_new                              2725	3_0_0	EXIST::FUNCTION:ENGINE
 X509_check_issued                       2726	3_0_0	EXIST::FUNCTION:
@@ -2937,7 +2937,7 @@ RSA_padding_add_PKCS1_OAEP_mgf1         2999	3_0_0	EXIST::FUNCTION:RSA
 COMP_CTX_get_type                       3000	3_0_0	EXIST::FUNCTION:COMP
 TS_RESP_CTX_set_status_info             3001	3_0_0	EXIST::FUNCTION:TS
 BIO_f_nbio_test                         3002	3_0_0	EXIST::FUNCTION:
-SEED_ofb128_encrypt                     3003	3_0_0	EXIST::FUNCTION:SEED
+SEED_ofb128_encrypt                     3003	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 d2i_RSAPrivateKey_bio                   3004	3_0_0	EXIST::FUNCTION:RSA
 DH_KDF_X9_42                            3005	3_0_0	EXIST::FUNCTION:CMS,DH
 EVP_PKEY_meth_set_signctx               3006	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use of the low level SEED functions has been informally discouraged for a long time. We now formally deprecate them.
