### PR TITLE
Deprecate low level calls to RC2, RC4 and RC5.

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -353,7 +353,7 @@ static const OPT_PAIR doit_choices[] = {
     {"rmd160", D_RMD160},
     {"ripemd160", D_RMD160},
 #endif
-#ifndef OPENSSL_NO_RC4
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"rc4", D_RC4},
 #endif
 #ifndef OPENSSL_NO_DES
@@ -712,7 +712,7 @@ static int EVP_Digest_RMD160_loop(void *args)
 }
 #endif
 
-#ifndef OPENSSL_NO_RC4
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static RC4_KEY rc4_ks;
 static int RC4_loop(void *args)
 {
@@ -1973,7 +1973,7 @@ int speed_main(int argc, char **argv)
     if (doit[D_CBC_SEED])
         SEED_set_key(key16, &seed_ks);
 #endif
-#ifndef OPENSSL_NO_RC4
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_RC4])
         RC4_set_key(&rc4_ks, 16, key16);
 #endif
@@ -2379,7 +2379,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_RC4
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_RC4]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_RC4], c[D_RC4][testnum], lengths[testnum],
@@ -3492,7 +3492,7 @@ int speed_main(int argc, char **argv)
 #if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         printf("%s ", MD2_options());
 #endif
-#ifndef OPENSSL_NO_RC4
+#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         printf("%s ", RC4_options());
 #endif
 #ifndef OPENSSL_NO_DES

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -368,7 +368,7 @@ static const OPT_PAIR doit_choices[] = {
     {"aes-192-ige", D_IGE_192_AES},
     {"aes-256-ige", D_IGE_256_AES},
 #endif
-#ifndef OPENSSL_NO_RC2
+#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"rc2-cbc", D_CBC_RC2},
     {"rc2", D_CBC_RC2},
 #endif
@@ -1452,7 +1452,7 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_RC5
     RC5_32_KEY rc5_ks;
 #endif
-#ifndef OPENSSL_NO_RC2
+#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     RC2_KEY rc2_ks;
 #endif
 #ifndef OPENSSL_NO_IDEA
@@ -1977,7 +1977,7 @@ int speed_main(int argc, char **argv)
     if (doit[D_RC4])
         RC4_set_key(&rc4_ks, 16, key16);
 #endif
-#ifndef OPENSSL_NO_RC2
+#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_RC2])
         RC2_set_key(&rc2_ks, 16, key16, 128);
 #endif
@@ -2604,7 +2604,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_RC2
+#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_RC2]) {
         if (async_jobs > 0) {
             BIO_printf(bio_err, "Async mode is not supported with %s\n",

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -372,7 +372,7 @@ static const OPT_PAIR doit_choices[] = {
     {"rc2-cbc", D_CBC_RC2},
     {"rc2", D_CBC_RC2},
 #endif
-#ifndef OPENSSL_NO_RC5
+#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"rc5-cbc", D_CBC_RC5},
     {"rc5", D_CBC_RC5},
 #endif
@@ -1449,7 +1449,7 @@ int speed_main(int argc, char **argv)
                                     EdDSA_SECONDS, SM2_SECONDS };
 
     /* What follows are the buffers and key material. */
-#ifndef OPENSSL_NO_RC5
+#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     RC5_32_KEY rc5_ks;
 #endif
 #if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
@@ -1981,7 +1981,7 @@ int speed_main(int argc, char **argv)
     if (doit[D_CBC_RC2])
         RC2_set_key(&rc2_ks, 16, key16, 128);
 #endif
-#ifndef OPENSSL_NO_RC5
+#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_RC5])
         if (!RC5_32_set_key(&rc5_ks, 16, key16, 12)) {
             BIO_printf(bio_err, "Failed setting RC5 key\n");
@@ -2628,7 +2628,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_RC5
+#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_RC5]) {
         if (async_jobs > 0) {
             BIO_printf(bio_err, "Async mode is not supported with %s\n",

--- a/apps/version.c
+++ b/apps/version.c
@@ -18,9 +18,6 @@
 #ifndef OPENSSL_NO_MD2
 # include <openssl/md2.h>
 #endif
-#ifndef OPENSSL_NO_RC4
-# include <openssl/rc4.h>
-#endif
 #ifndef OPENSSL_NO_DES
 # include <openssl/des.h>
 #endif
@@ -129,9 +126,6 @@ opthelp:
     if (options) {
         printf("options: ");
         printf(" %s", BN_options());
-#ifndef OPENSSL_NO_RC4
-        printf(" %s", RC4_options());
-#endif
 #ifndef OPENSSL_NO_DES
         printf(" %s", DES_options());
 #endif

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 

--- a/crypto/evp/e_rc4.c
+++ b/crypto/evp/e_rc4.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <internal/cryptlib.h>
 #include <openssl/opensslconf.h>
 

--- a/crypto/evp/e_rc5.c
+++ b/crypto/evp/e_rc5.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 

--- a/crypto/rc2/rc2_cbc.c
+++ b/crypto/rc2/rc2_cbc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 

--- a/crypto/rc2/rc2_ecb.c
+++ b/crypto/rc2/rc2_ecb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/rc2/rc2_skey.c
+++ b/crypto/rc2/rc2_skey.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 

--- a/crypto/rc2/rc2cfb64.c
+++ b/crypto/rc2/rc2cfb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 

--- a/crypto/rc2/rc2ofb64.c
+++ b/crypto/rc2/rc2ofb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 

--- a/crypto/rc4/rc4_enc.c
+++ b/crypto/rc4/rc4_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc4.h>
 #include "rc4_local.h"
 

--- a/crypto/rc4/rc4_skey.c
+++ b/crypto/rc4/rc4_skey.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc4.h>
 #include "rc4_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/rc5/rc5_ecb.c
+++ b/crypto/rc5/rc5_ecb.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 #include <openssl/opensslv.h>

--- a/crypto/rc5/rc5_enc.c
+++ b/crypto/rc5/rc5_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <openssl/rc5.h>
 #include "rc5_local.h"

--- a/crypto/rc5/rc5_skey.c
+++ b/crypto/rc5/rc5_skey.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 

--- a/crypto/rc5/rc5cfb64.c
+++ b/crypto/rc5/rc5cfb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 

--- a/crypto/rc5/rc5ofb64.c
+++ b/crypto/rc5/rc5ofb64.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 

--- a/doc/man3/RC4_set_key.pod
+++ b/doc/man3/RC4_set_key.pod
@@ -8,12 +8,20 @@ RC4_set_key, RC4 - RC4 encryption
 
  #include <openssl/rc4.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  void RC4_set_key(RC4_KEY *key, int len, const unsigned char *data);
 
  void RC4(RC4_KEY *key, unsigned long len, const unsigned char *indata,
           unsigned char *outdata);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. Applications should
+instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate(3)> and
+L<EVP_EncryptFinal_ex(3)> or the equivalently named decrypt functions.
 
 This library implements the Alleged RC4 cipher, which is described for
 example in I<Applied Cryptography>.  It is believed to be compatible
@@ -53,6 +61,10 @@ multiple encryptions using the same key stream.
 =head1 SEE ALSO
 
 L<EVP_EncryptInit(3)>
+
+=head1 HISTORY
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/rc2.h
+++ b/include/openssl/rc2.h
@@ -19,17 +19,17 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_RC2
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
 typedef unsigned int RC2_INT;
 
-# define RC2_ENCRYPT     1
-# define RC2_DECRYPT     0
+#  define RC2_ENCRYPT     1
+#  define RC2_DECRYPT     0
 
-# define RC2_BLOCK       8
-# define RC2_KEY_LENGTH  16
+#  define RC2_BLOCK       8
+#  define RC2_KEY_LENGTH  16
 
 typedef struct rc2_key_st {
     RC2_INT data[64];
@@ -49,9 +49,9 @@ void RC2_ofb64_encrypt(const unsigned char *in, unsigned char *out,
                        long length, RC2_KEY *schedule, unsigned char *ivec,
                        int *num);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/rc2.h
+++ b/include/openssl/rc2.h
@@ -23,31 +23,38 @@
 extern "C" {
 #  endif
 
-typedef unsigned int RC2_INT;
-
-#  define RC2_ENCRYPT     1
-#  define RC2_DECRYPT     0
-
 #  define RC2_BLOCK       8
 #  define RC2_KEY_LENGTH  16
+
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+typedef unsigned int RC2_INT;
+
+#   define RC2_ENCRYPT     1
+#   define RC2_DECRYPT     0
 
 typedef struct rc2_key_st {
     RC2_INT data[64];
 } RC2_KEY;
+#  endif
 
-void RC2_set_key(RC2_KEY *key, int len, const unsigned char *data, int bits);
-void RC2_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                     RC2_KEY *key, int enc);
-void RC2_encrypt(unsigned long *data, RC2_KEY *key);
-void RC2_decrypt(unsigned long *data, RC2_KEY *key);
-void RC2_cbc_encrypt(const unsigned char *in, unsigned char *out, long length,
-                     RC2_KEY *ks, unsigned char *iv, int enc);
-void RC2_cfb64_encrypt(const unsigned char *in, unsigned char *out,
-                       long length, RC2_KEY *schedule, unsigned char *ivec,
-                       int *num, int enc);
-void RC2_ofb64_encrypt(const unsigned char *in, unsigned char *out,
-                       long length, RC2_KEY *schedule, unsigned char *ivec,
-                       int *num);
+DEPRECATEDIN_3_0(void RC2_set_key(RC2_KEY *key, int len,
+                                  const unsigned char *data, int bits))
+DEPRECATEDIN_3_0(void RC2_ecb_encrypt(const unsigned char *in,
+                                      unsigned char *out, RC2_KEY *key,
+                                      int enc))
+DEPRECATEDIN_3_0(void RC2_encrypt(unsigned long *data, RC2_KEY *key))
+DEPRECATEDIN_3_0(void RC2_decrypt(unsigned long *data, RC2_KEY *key))
+DEPRECATEDIN_3_0(void RC2_cbc_encrypt(const unsigned char *in,
+                                      unsigned char *out, long length,
+                                      RC2_KEY *ks, unsigned char *iv, int enc))
+DEPRECATEDIN_3_0(void RC2_cfb64_encrypt(const unsigned char *in,
+                                        unsigned char *out, long length,
+                                        RC2_KEY *schedule, unsigned char *ivec,
+                                        int *num, int enc))
+DEPRECATEDIN_3_0(void RC2_ofb64_encrypt(const unsigned char *in,
+                                        unsigned char *out, long length,
+                                        RC2_KEY *schedule, unsigned char *ivec,
+                                        int *num))
 
 #  ifdef  __cplusplus
 }

--- a/include/openssl/rc4.h
+++ b/include/openssl/rc4.h
@@ -24,15 +24,18 @@
 extern "C" {
 #  endif
 
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef struct rc4_key_st {
     RC4_INT x, y;
     RC4_INT data[256];
 } RC4_KEY;
+#  endif
 
-const char *RC4_options(void);
-void RC4_set_key(RC4_KEY *key, int len, const unsigned char *data);
-void RC4(RC4_KEY *key, size_t len, const unsigned char *indata,
-         unsigned char *outdata);
+DEPRECATEDIN_3_0(const char *RC4_options(void))
+DEPRECATEDIN_3_0(void RC4_set_key(RC4_KEY *key, int len,
+                                  const unsigned char *data))
+DEPRECATEDIN_3_0(void RC4(RC4_KEY *key, size_t len, const unsigned char *indata,
+                          unsigned char *outdata))
 
 #  ifdef  __cplusplus
 }

--- a/include/openssl/rc4.h
+++ b/include/openssl/rc4.h
@@ -19,10 +19,10 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_RC4
-# include <stddef.h>
-#ifdef  __cplusplus
+#  include <stddef.h>
+#  ifdef  __cplusplus
 extern "C" {
-#endif
+#  endif
 
 typedef struct rc4_key_st {
     RC4_INT x, y;
@@ -34,9 +34,9 @@ void RC4_set_key(RC4_KEY *key, int len, const unsigned char *data);
 void RC4(RC4_KEY *key, size_t len, const unsigned char *indata,
          unsigned char *outdata);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/rc5.h
+++ b/include/openssl/rc5.h
@@ -23,43 +23,50 @@
 extern "C" {
 #  endif
 
-#  define RC5_ENCRYPT     1
-#  define RC5_DECRYPT     0
-
-#  define RC5_32_INT unsigned int
-
 #  define RC5_32_BLOCK            8
 #  define RC5_32_KEY_LENGTH       16/* This is a default, max is 255 */
+
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+#   define RC5_ENCRYPT     1
+#   define RC5_DECRYPT     0
+
+#   define RC5_32_INT unsigned int
 
 /*
  * This are the only values supported.  Tweak the code if you want more The
  * most supported modes will be RC5-32/12/16 RC5-32/16/8
  */
-#  define RC5_8_ROUNDS    8
-#  define RC5_12_ROUNDS   12
-#  define RC5_16_ROUNDS   16
+#   define RC5_8_ROUNDS    8
+#   define RC5_12_ROUNDS   12
+#   define RC5_16_ROUNDS   16
 
 typedef struct rc5_key_st {
     /* Number of rounds */
     int rounds;
     RC5_32_INT data[2 * (RC5_16_ROUNDS + 1)];
 } RC5_32_KEY;
+#  endif
 
-int RC5_32_set_key(RC5_32_KEY *key, int len, const unsigned char *data,
-                   int rounds);
-void RC5_32_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                        RC5_32_KEY *key, int enc);
-void RC5_32_encrypt(unsigned long *data, RC5_32_KEY *key);
-void RC5_32_decrypt(unsigned long *data, RC5_32_KEY *key);
-void RC5_32_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                        long length, RC5_32_KEY *ks, unsigned char *iv,
-                        int enc);
-void RC5_32_cfb64_encrypt(const unsigned char *in, unsigned char *out,
-                          long length, RC5_32_KEY *schedule,
-                          unsigned char *ivec, int *num, int enc);
-void RC5_32_ofb64_encrypt(const unsigned char *in, unsigned char *out,
-                          long length, RC5_32_KEY *schedule,
-                          unsigned char *ivec, int *num);
+DEPRECATEDIN_3_0(int RC5_32_set_key(RC5_32_KEY *key, int len,
+                                    const unsigned char *data, int rounds))
+DEPRECATEDIN_3_0(void RC5_32_ecb_encrypt(const unsigned char *in,
+                                         unsigned char *out, RC5_32_KEY *key,
+                                         int enc))
+DEPRECATEDIN_3_0(void RC5_32_encrypt(unsigned long *data, RC5_32_KEY *key))
+DEPRECATEDIN_3_0(void RC5_32_decrypt(unsigned long *data, RC5_32_KEY *key))
+DEPRECATEDIN_3_0(void RC5_32_cbc_encrypt(const unsigned char *in,
+                                         unsigned char *out, long length,
+                                         RC5_32_KEY *ks, unsigned char *iv,
+                                         int enc))
+DEPRECATEDIN_3_0(void RC5_32_cfb64_encrypt(const unsigned char *in,
+                                           unsigned char *out, long length,
+                                           RC5_32_KEY *schedule,
+                                           unsigned char *ivec, int *num,
+                                           int enc))
+DEPRECATEDIN_3_0(void RC5_32_ofb64_encrypt(const unsigned char *in,
+                                           unsigned char *out, long length,
+                                           RC5_32_KEY *schedule,
+                                           unsigned char *ivec, int *num))
 
 #  ifdef  __cplusplus
 }

--- a/include/openssl/rc5.h
+++ b/include/openssl/rc5.h
@@ -19,25 +19,25 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_RC5
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
-# define RC5_ENCRYPT     1
-# define RC5_DECRYPT     0
+#  define RC5_ENCRYPT     1
+#  define RC5_DECRYPT     0
 
-# define RC5_32_INT unsigned int
+#  define RC5_32_INT unsigned int
 
-# define RC5_32_BLOCK            8
-# define RC5_32_KEY_LENGTH       16/* This is a default, max is 255 */
+#  define RC5_32_BLOCK            8
+#  define RC5_32_KEY_LENGTH       16/* This is a default, max is 255 */
 
 /*
  * This are the only values supported.  Tweak the code if you want more The
  * most supported modes will be RC5-32/12/16 RC5-32/16/8
  */
-# define RC5_8_ROUNDS    8
-# define RC5_12_ROUNDS   12
-# define RC5_16_ROUNDS   16
+#  define RC5_8_ROUNDS    8
+#  define RC5_12_ROUNDS   12
+#  define RC5_16_ROUNDS   16
 
 typedef struct rc5_key_st {
     /* Number of rounds */
@@ -61,9 +61,9 @@ void RC5_32_ofb64_encrypt(const unsigned char *in, unsigned char *out,
                           long length, RC5_32_KEY *schedule,
                           unsigned char *ivec, int *num);
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for RC2 cipher modes ecb, cbc, ofb, cfb */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc2.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"

--- a/providers/implementations/ciphers/cipher_rc2_hw.c
+++ b/providers/implementations/ciphers/cipher_rc2_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc2.h"
 
 static int cipher_hw_rc2_initkey(PROV_CIPHER_CTX *ctx,

--- a/providers/implementations/ciphers/cipher_rc4.c
+++ b/providers/implementations/ciphers/cipher_rc4.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for RC4 ciphers */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc4.h"
 #include "prov/implementations.h"
 

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for RC4_HMAC_MD5 cipher */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc4_hmac_md5.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
@@ -9,6 +9,12 @@
 
 /* RC4_HMAC_MD5 cipher implementation */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc4_hmac_md5.h"
 
 #define NO_PAYLOAD_LENGTH ((size_t)-1)

--- a/providers/implementations/ciphers/cipher_rc4_hw.c
+++ b/providers/implementations/ciphers/cipher_rc4_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc4.h"
 
 static int cipher_hw_rc4_initkey(PROV_CIPHER_CTX *ctx,

--- a/providers/implementations/ciphers/cipher_rc5.c
+++ b/providers/implementations/ciphers/cipher_rc5.c
@@ -9,6 +9,12 @@
 
 /* Dispatch functions for RC5 cipher modes ecb, cbc, ofb, cfb */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc5.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"

--- a/providers/implementations/ciphers/cipher_rc5_hw.c
+++ b/providers/implementations/ciphers/cipher_rc5_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_rc5.h"
 
 static int cipher_hw_rc5_initkey(PROV_CIPHER_CTX *ctx,

--- a/test/build.info
+++ b/test/build.info
@@ -124,10 +124,6 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[hmactest]=../include ../apps/include
   DEPEND[hmactest]=../libcrypto libtestutil.a
 
-  SOURCE[rc5test]=rc5test.c
-  INCLUDE[rc5test]=../include ../apps/include
-  DEPEND[rc5test]=../libcrypto libtestutil.a
-
   SOURCE[destest]=destest.c
   INCLUDE[destest]=../include ../apps/include
   DEPEND[destest]=../libcrypto libtestutil.a
@@ -597,6 +593,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[rc4test]=rc4test.c
     INCLUDE[rc4test]=../include ../apps/include
     DEPEND[rc4test]=../libcrypto.a libtestutil.a
+
+    SOURCE[rc5test]=rc5test.c
+    INCLUDE[rc5test]=../include ../apps/include
+    DEPEND[rc5test]=../libcrypto.a libtestutil.a
 
     SOURCE[ec_internal_test]=ec_internal_test.c
     INCLUDE[ec_internal_test]=../include ../crypto/ec ../apps/include ../crypto/include

--- a/test/build.info
+++ b/test/build.info
@@ -124,10 +124,6 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[hmactest]=../include ../apps/include
   DEPEND[hmactest]=../libcrypto libtestutil.a
 
-  SOURCE[rc4test]=rc4test.c
-  INCLUDE[rc4test]=../include ../apps/include
-  DEPEND[rc4test]=../libcrypto libtestutil.a
-
   SOURCE[rc5test]=rc5test.c
   INCLUDE[rc5test]=../include ../apps/include
   DEPEND[rc5test]=../libcrypto libtestutil.a
@@ -597,6 +593,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[rc2test]=rc2test.c
     INCLUDE[rc2test]=../include ../apps/include
     DEPEND[rc2test]=../libcrypto.a libtestutil.a
+
+    SOURCE[rc4test]=rc4test.c
+    INCLUDE[rc4test]=../include ../apps/include
+    DEPEND[rc4test]=../libcrypto.a libtestutil.a
 
     SOURCE[ec_internal_test]=ec_internal_test.c
     INCLUDE[ec_internal_test]=../include ../crypto/ec ../apps/include ../crypto/include

--- a/test/build.info
+++ b/test/build.info
@@ -124,10 +124,6 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[hmactest]=../include ../apps/include
   DEPEND[hmactest]=../libcrypto libtestutil.a
 
-  SOURCE[rc2test]=rc2test.c
-  INCLUDE[rc2test]=../include ../apps/include
-  DEPEND[rc2test]=../libcrypto libtestutil.a
-
   SOURCE[rc4test]=rc4test.c
   INCLUDE[rc4test]=../include ../apps/include
   DEPEND[rc4test]=../libcrypto libtestutil.a
@@ -597,6 +593,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[sm4_internal_test]=sm4_internal_test.c
     INCLUDE[sm4_internal_test]=.. ../include ../apps/include ../crypto/include
     DEPEND[sm4_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[rc2test]=rc2test.c
+    INCLUDE[rc2test]=../include ../apps/include
+    DEPEND[rc2test]=../libcrypto.a libtestutil.a
 
     SOURCE[ec_internal_test]=ec_internal_test.c
     INCLUDE[ec_internal_test]=../include ../crypto/ec ../apps/include ../crypto/include

--- a/test/rc2test.c
+++ b/test/rc2test.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC2 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "internal/nelem.h"
 #include "testutil.h"
 

--- a/test/rc4test.c
+++ b/test/rc4test.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC4 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 
 #include "internal/nelem.h"

--- a/test/rc5test.c
+++ b/test/rc5test.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * RC5 low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 
 #include "internal/nelem.h"

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1238,7 +1238,7 @@ HMAC_CTX_copy                           1266	3_0_0	EXIST::FUNCTION:
 CRYPTO_gcm128_init                      1267	3_0_0	EXIST::FUNCTION:
 i2d_X509_CINF                           1268	3_0_0	EXIST::FUNCTION:
 X509_REVOKED_delete_ext                 1269	3_0_0	EXIST::FUNCTION:
-RC5_32_cfb64_encrypt                    1270	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_cfb64_encrypt                    1270	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 TS_REQ_set_cert_req                     1271	3_0_0	EXIST::FUNCTION:TS
 TXT_DB_get_by_index                     1272	3_0_0	EXIST::FUNCTION:
 X509_check_ca                           1273	3_0_0	EXIST::FUNCTION:
@@ -1673,7 +1673,7 @@ UI_dup_verify_string                    1711	3_0_0	EXIST::FUNCTION:
 d2i_PKCS7_bio                           1712	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_digests              1713	3_0_0	EXIST::FUNCTION:ENGINE
 i2d_PublicKey                           1714	3_0_0	EXIST::FUNCTION:
-RC5_32_set_key                          1715	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_set_key                          1715	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 AES_unwrap_key                          1716	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_Cipher                              1717	3_0_0	EXIST::FUNCTION:
 AES_set_decrypt_key                     1718	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
@@ -1771,7 +1771,7 @@ OPENSSL_LH_delete                       1812	3_0_0	EXIST::FUNCTION:
 TS_STATUS_INFO_dup                      1813	3_0_0	EXIST::FUNCTION:TS
 X509v3_addr_get_range                   1814	3_0_0	EXIST::FUNCTION:RFC3779
 X509_EXTENSION_get_data                 1815	3_0_0	EXIST::FUNCTION:
-RC5_32_encrypt                          1816	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_encrypt                          1816	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 DIST_POINT_set_dpname                   1817	3_0_0	EXIST::FUNCTION:
 BIO_sock_info                           1818	3_0_0	EXIST::FUNCTION:SOCK
 OPENSSL_hexstr2buf                      1819	3_0_0	EXIST::FUNCTION:
@@ -1946,7 +1946,7 @@ GENERAL_NAME_it                         1991	3_0_0	EXIST::FUNCTION:
 EVP_des_ede_ecb                         1992	3_0_0	EXIST::FUNCTION:DES
 i2d_CRL_DIST_POINTS                     1993	3_0_0	EXIST::FUNCTION:
 PEM_write_bio_X509_REQ_NEW              1994	3_0_0	EXIST::FUNCTION:
-RC5_32_ofb64_encrypt                    1995	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_ofb64_encrypt                    1995	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 i2d_PKCS7                               1996	3_0_0	EXIST::FUNCTION:
 BN_mod_lshift_quick                     1997	3_0_0	EXIST::FUNCTION:
 DIST_POINT_NAME_it                      1998	3_0_0	EXIST::FUNCTION:
@@ -2694,7 +2694,7 @@ X509_REQ_to_X509                        2750	3_0_0	EXIST::FUNCTION:
 EVP_aes_192_wrap_pad                    2751	3_0_0	EXIST::FUNCTION:
 PKCS7_SIGN_ENVELOPE_new                 2752	3_0_0	EXIST::FUNCTION:
 TS_REQ_get_policy_id                    2753	3_0_0	EXIST::FUNCTION:TS
-RC5_32_cbc_encrypt                      2754	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_cbc_encrypt                      2754	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 BN_is_zero                              2755	3_0_0	EXIST::FUNCTION:
 CT_POLICY_EVAL_CTX_new                  2756	3_0_0	EXIST::FUNCTION:CT
 NETSCAPE_SPKI_it                        2757	3_0_0	EXIST::FUNCTION:
@@ -2856,7 +2856,7 @@ X509_STORE_CTX_free                     2917	3_0_0	EXIST::FUNCTION:
 AUTHORITY_KEYID_it                      2918	3_0_0	EXIST::FUNCTION:
 X509V3_get_value_int                    2919	3_0_0	EXIST::FUNCTION:
 ASN1_UTCTIME_set_string                 2920	3_0_0	EXIST::FUNCTION:
-RC5_32_decrypt                          2921	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_decrypt                          2921	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 i2d_X509_REQ_INFO                       2922	3_0_0	EXIST::FUNCTION:
 EVP_des_cfb1                            2923	3_0_0	EXIST::FUNCTION:DES
 OBJ_NAME_cleanup                        2924	3_0_0	EXIST::FUNCTION:
@@ -3477,7 +3477,7 @@ BN_dec2bn                               3549	3_0_0	EXIST::FUNCTION:
 CMS_decrypt                             3550	3_0_0	EXIST::FUNCTION:CMS
 BN_mpi2bn                               3551	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_cfb128                      3552	3_0_0	EXIST::FUNCTION:
-RC5_32_ecb_encrypt                      3554	3_0_0	EXIST::FUNCTION:RC5
+RC5_32_ecb_encrypt                      3554	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC5
 EVP_CIPHER_meth_new                     3555	3_0_0	EXIST::FUNCTION:
 i2d_RSA_OAEP_PARAMS                     3556	3_0_0	EXIST::FUNCTION:RSA
 SXNET_get_id_ulong                      3557	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -341,7 +341,7 @@ OPENSSL_sk_sort                         346	3_0_0	EXIST::FUNCTION:
 CTLOG_STORE_load_file                   347	3_0_0	EXIST::FUNCTION:CT
 ASN1_SEQUENCE_it                        348	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_get_tst_info                349	3_0_0	EXIST::FUNCTION:TS
-RC4                                     350	3_0_0	EXIST::FUNCTION:RC4
+RC4                                     350	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC4
 PKCS7_stream                            352	3_0_0	EXIST::FUNCTION:
 i2t_ASN1_OBJECT                         353	3_0_0	EXIST::FUNCTION:
 EC_GROUP_get0_generator                 354	3_0_0	EXIST::FUNCTION:EC
@@ -778,7 +778,7 @@ PKCS7_dataInit                          797	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_app_data               798	3_0_0	EXIST::FUNCTION:
 a2i_GENERAL_NAME                        799	3_0_0	EXIST::FUNCTION:
 SXNETID_new                             800	3_0_0	EXIST::FUNCTION:
-RC4_options                             801	3_0_0	EXIST::FUNCTION:RC4
+RC4_options                             801	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC4
 BIO_f_null                              802	3_0_0	EXIST::FUNCTION:
 EC_GROUP_set_curve_name                 803	3_0_0	EXIST::FUNCTION:EC
 d2i_PBE2PARAM                           804	3_0_0	EXIST::FUNCTION:
@@ -2960,7 +2960,7 @@ ASN1_TYPE_unpack_sequence               3024	3_0_0	EXIST::FUNCTION:
 X509_CRL_sign_ctx                       3025	3_0_0	EXIST::FUNCTION:
 X509_STORE_add_crl                      3026	3_0_0	EXIST::FUNCTION:
 PEM_write_RSAPrivateKey                 3027	3_0_0	EXIST::FUNCTION:RSA,STDIO
-RC4_set_key                             3028	3_0_0	EXIST::FUNCTION:RC4
+RC4_set_key                             3028	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC4
 EVP_CIPHER_CTX_cipher                   3029	3_0_0	EXIST::FUNCTION:
 PEM_write_bio_PKCS8PrivateKey_nid       3030	3_0_0	EXIST::FUNCTION:
 BN_MONT_CTX_new                         3031	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -251,7 +251,7 @@ SXNET_new                               255	3_0_0	EXIST::FUNCTION:
 EVP_camellia_256_ctr                    256	3_0_0	EXIST::FUNCTION:CAMELLIA
 d2i_PKCS8_PRIV_KEY_INFO                 257	3_0_0	EXIST::FUNCTION:
 EVP_md2                                 259	3_0_0	EXIST::FUNCTION:MD2
-RC2_ecb_encrypt                         260	3_0_0	EXIST::FUNCTION:RC2
+RC2_ecb_encrypt                         260	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 ENGINE_register_DH                      261	3_0_0	EXIST::FUNCTION:ENGINE
 ASN1_NULL_free                          262	3_0_0	EXIST::FUNCTION:
 EC_KEY_copy                             263	3_0_0	EXIST::FUNCTION:EC
@@ -604,7 +604,7 @@ X509at_get_attr                         618	3_0_0	EXIST::FUNCTION:
 X509_PUBKEY_it                          619	3_0_0	EXIST::FUNCTION:
 DES_ede3_ofb64_encrypt                  620	3_0_0	EXIST::FUNCTION:DES
 EC_KEY_METHOD_get_compute_key           621	3_0_0	EXIST::FUNCTION:EC
-RC2_cfb64_encrypt                       622	3_0_0	EXIST::FUNCTION:RC2
+RC2_cfb64_encrypt                       622	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 EVP_EncryptFinal_ex                     623	3_0_0	EXIST::FUNCTION:
 ERR_load_RSA_strings                    624	3_0_0	EXIST::FUNCTION:
 CRYPTO_secure_malloc_done               625	3_0_0	EXIST::FUNCTION:
@@ -1029,7 +1029,7 @@ BN_GF2m_mod_exp                         1055	3_0_0	EXIST::FUNCTION:EC2M
 OPENSSL_buf2hexstr                      1056	3_0_0	EXIST::FUNCTION:
 DES_encrypt2                            1057	3_0_0	EXIST::FUNCTION:DES
 DH_up_ref                               1058	3_0_0	EXIST::FUNCTION:DH
-RC2_ofb64_encrypt                       1059	3_0_0	EXIST::FUNCTION:RC2
+RC2_ofb64_encrypt                       1059	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 PKCS12_pbe_crypt                        1060	3_0_0	EXIST::FUNCTION:
 ASIdentifiers_free                      1061	3_0_0	EXIST::FUNCTION:RFC3779
 X509_VERIFY_PARAM_get0                  1062	3_0_0	EXIST::FUNCTION:
@@ -1097,7 +1097,7 @@ PKCS8_PRIV_KEY_INFO_it                  1123	3_0_0	EXIST::FUNCTION:
 RSA_OAEP_PARAMS_free                    1124	3_0_0	EXIST::FUNCTION:RSA
 ASN1_item_new                           1125	3_0_0	EXIST::FUNCTION:
 CRYPTO_cts128_encrypt                   1126	3_0_0	EXIST::FUNCTION:
-RC2_encrypt                             1127	3_0_0	EXIST::FUNCTION:RC2
+RC2_encrypt                             1127	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 PEM_write                               1128	3_0_0	EXIST::FUNCTION:STDIO
 EVP_CIPHER_meth_get_get_asn1_params     1129	3_0_0	EXIST::FUNCTION:
 i2d_OCSP_RESPBYTES                      1130	3_0_0	EXIST::FUNCTION:OCSP
@@ -1278,7 +1278,7 @@ UI_get_result_maxsize                   1306	3_0_0	EXIST::FUNCTION:
 PBEPARAM_it                             1307	3_0_0	EXIST::FUNCTION:
 TS_ACCURACY_set_seconds                 1308	3_0_0	EXIST::FUNCTION:TS
 UI_get0_action_string                   1309	3_0_0	EXIST::FUNCTION:
-RC2_decrypt                             1310	3_0_0	EXIST::FUNCTION:RC2
+RC2_decrypt                             1310	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 OPENSSL_atexit                          1311	3_0_0	EXIST::FUNCTION:
 CMS_add_standard_smimecap               1312	3_0_0	EXIST::FUNCTION:CMS
 PKCS7_add_attrib_content_type           1313	3_0_0	EXIST::FUNCTION:
@@ -1557,7 +1557,7 @@ UI_get0_output_string                   1591	3_0_0	EXIST::FUNCTION:
 ERR_get_error_line_data                 1592	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 CTLOG_get0_name                         1593	3_0_0	EXIST::FUNCTION:CT
 ASN1_TBOOLEAN_it                        1594	3_0_0	EXIST::FUNCTION:
-RC2_set_key                             1595	3_0_0	EXIST::FUNCTION:RC2
+RC2_set_key                             1595	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 X509_REVOKED_get_ext_by_NID             1596	3_0_0	EXIST::FUNCTION:
 RSA_padding_add_none                    1597	3_0_0	EXIST::FUNCTION:RSA
 EVP_rc5_32_12_16_cbc                    1599	3_0_0	EXIST::FUNCTION:RC5
@@ -1692,7 +1692,7 @@ CMS_unsigned_get_attr                   1730	3_0_0	EXIST::FUNCTION:CMS
 EVP_aes_256_cbc                         1731	3_0_0	EXIST::FUNCTION:
 X509_check_ip_asc                       1732	3_0_0	EXIST::FUNCTION:
 PEM_write_bio_X509_AUX                  1733	3_0_0	EXIST::FUNCTION:
-RC2_cbc_encrypt                         1734	3_0_0	EXIST::FUNCTION:RC2
+RC2_cbc_encrypt                         1734	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 TS_MSG_IMPRINT_new                      1735	3_0_0	EXIST::FUNCTION:TS
 EVP_ENCODE_CTX_new                      1736	3_0_0	EXIST::FUNCTION:
 BIO_f_base64                            1737	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use of the low level RC2, RC4 and RC5 functions has been informally discouraged for a long time.  We now formally deprecate them.

- [x] documentation is added or updated
- [x] tests are added or updated
