### PR TITLE
CRYPTO: Remove support for ex_data fields when building the FIPS module

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -78,8 +78,10 @@ DH *DH_new_method(ENGINE *engine)
 
     ret->flags = ret->meth->flags;
 
+#ifndef FIPS_MODE
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_DH, ret, &ret->ex_data))
         goto err;
+#endif
 
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         DHerr(DH_F_DH_NEW_METHOD, ERR_R_INIT_FAIL);
@@ -112,7 +114,9 @@ void DH_free(DH *r)
     ENGINE_finish(r->engine);
 #endif
 
+#ifndef FIPS_MODE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_DH, r, &r->ex_data);
+#endif
 
     CRYPTO_THREAD_lock_free(r->lock);
 
@@ -139,6 +143,7 @@ int DH_up_ref(DH *r)
     return ((i > 1) ? 1 : 0);
 }
 
+#ifndef FIPS_MODE
 int DH_set_ex_data(DH *d, int idx, void *arg)
 {
     return CRYPTO_set_ex_data(&d->ex_data, idx, arg);
@@ -148,6 +153,7 @@ void *DH_get_ex_data(DH *d, int idx)
 {
     return CRYPTO_get_ex_data(&d->ex_data, idx);
 }
+#endif
 
 int DH_bits(const DH *dh)
 {

--- a/crypto/dh/dh_local.h
+++ b/crypto/dh/dh_local.h
@@ -33,7 +33,9 @@ struct dh_st {
     int seedlen;
     BIGNUM *counter;
     CRYPTO_REF_COUNT references;
+#ifndef FIPS_MODE
     CRYPTO_EX_DATA ex_data;
+#endif
     const DH_METHOD *meth;
     ENGINE *engine;
     CRYPTO_RWLOCK *lock;

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -19,11 +19,6 @@
 
 #ifndef FIPS_MODE
 
-DSA *DSA_new(void)
-{
-    return DSA_new_method(NULL);
-}
-
 int DSA_set_ex_data(DSA *d, int idx, void *arg)
 {
     return CRYPTO_set_ex_data(&d->ex_data, idx, arg);
@@ -215,8 +210,10 @@ static DSA *dsa_new_method(OPENSSL_CTX *libctx, ENGINE *engine)
 
     ret->flags = ret->meth->flags & ~DSA_FLAG_NON_FIPS_ALLOW;
 
+#ifndef FIPS_MODE
     if (!crypto_new_ex_data_ex(libctx, CRYPTO_EX_INDEX_DSA, ret, &ret->ex_data))
         goto err;
+#endif
 
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         DSAerr(DSA_F_DSA_NEW_METHOD, ERR_R_INIT_FAIL);
@@ -235,9 +232,9 @@ DSA *DSA_new_method(ENGINE *engine)
     return dsa_new_method(NULL, engine);
 }
 
-DSA *dsa_new(OPENSSL_CTX *libctx)
+DSA *DSA_new(void)
 {
-    return dsa_new_method(libctx, NULL);
+    return DSA_new_method(NULL);
 }
 
 void DSA_free(DSA *r)
@@ -259,7 +256,9 @@ void DSA_free(DSA *r)
     ENGINE_finish(r->engine);
 #endif
 
+#ifndef FIPS_MODE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_DSA, r, &r->ex_data);
+#endif
 
     CRYPTO_THREAD_lock_free(r->lock);
 

--- a/crypto/dsa/dsa_local.h
+++ b/crypto/dsa/dsa_local.h
@@ -26,7 +26,9 @@ struct dsa_st {
     /* Normally used to cache montgomery values */
     BN_MONT_CTX *method_mont_p;
     CRYPTO_REF_COUNT references;
+#ifndef FIPS_MODE
     CRYPTO_EX_DATA ex_data;
+#endif
     const DSA_METHOD *meth;
     /* functional reference if 'meth' is ENGINE-provided */
     ENGINE *engine;

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -503,7 +503,9 @@ void RAND_DRBG_free(RAND_DRBG *drbg)
         drbg->meth->uninstantiate(drbg);
     rand_pool_free(drbg->adin_pool);
     CRYPTO_THREAD_lock_free(drbg->lock);
+#ifndef FIPS_MODE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_RAND_DRBG, drbg, &drbg->ex_data);
+#endif
 
     if (drbg->secure)
         OPENSSL_secure_clear_free(drbg, sizeof(*drbg));
@@ -1098,6 +1100,7 @@ int rand_drbg_enable_locking(RAND_DRBG *drbg)
     return 1;
 }
 
+#ifndef FIPS_MODE
 /*
  * Get and set the EXDATA
  */
@@ -1110,7 +1113,7 @@ void *RAND_DRBG_get_ex_data(const RAND_DRBG *drbg, int idx)
 {
     return CRYPTO_get_ex_data(&drbg->ex_data, idx);
 }
-
+#endif
 
 /*
  * The following functions provide a RAND_METHOD that works on the

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -308,8 +308,10 @@ struct rand_drbg_st {
     size_t seedlen;
     DRBG_STATUS state;
 
+#ifndef FIPS_MODE
     /* Application data, mainly used in the KATs. */
     CRYPTO_EX_DATA ex_data;
+#endif
 
     /* Implementation specific data */
     union {

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -88,9 +88,11 @@ RSA *RSA_new_method(ENGINE *engine)
 #endif
 
     ret->flags = ret->meth->flags & ~RSA_FLAG_NON_FIPS_ALLOW;
+#ifndef FIPS_MODE
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_RSA, ret, &ret->ex_data)) {
         goto err;
     }
+#endif
 
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         RSAerr(RSA_F_RSA_NEW_METHOD, ERR_R_INIT_FAIL);
@@ -123,7 +125,9 @@ void RSA_free(RSA *r)
     ENGINE_finish(r->engine);
 #endif
 
+#ifndef FIPS_MODE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_RSA, r, &r->ex_data);
+#endif
 
     CRYPTO_THREAD_lock_free(r->lock);
 
@@ -155,6 +159,7 @@ int RSA_up_ref(RSA *r)
     return i > 1 ? 1 : 0;
 }
 
+#ifndef FIPS_MODE
 int RSA_set_ex_data(RSA *r, int idx, void *arg)
 {
     return CRYPTO_set_ex_data(&r->ex_data, idx, arg);
@@ -164,6 +169,7 @@ void *RSA_get_ex_data(const RSA *r, int idx)
 {
     return CRYPTO_get_ex_data(&r->ex_data, idx);
 }
+#endif
 
 /*
  * Define a scaling constant for our fixed point arithmetic.

--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -50,8 +50,10 @@ struct rsa_st {
     STACK_OF(RSA_PRIME_INFO) *prime_infos;
     /* If a PSS only key this contains the parameter restrictions */
     RSA_PSS_PARAMS *pss;
+#ifndef FIPS_MODE
     /* be careful using this if the RSA structure is shared */
     CRYPTO_EX_DATA ex_data;
+#endif
     CRYPTO_REF_COUNT references;
     int flags;
     /* Used to cache montgomery values */

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -9,6 +9,5 @@
 
 #include <openssl/dsa.h>
 
-DSA *dsa_new(OPENSSL_CTX *libctx);
 int dsa_sign_int(OPENSSL_CTX *libctx, int type, const unsigned char *dgst,
                  int dlen, unsigned char *sig, unsigned int *siglen, DSA *dsa);

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -135,9 +135,8 @@ static int key_to_params(DSA *dsa, OSSL_PARAM_BLD *tmpl)
 static void *dsa_importdomparams(void *provctx, const OSSL_PARAM params[])
 {
     DSA *dsa;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
 
-    if ((dsa = dsa_new(libctx)) == NULL
+    if ((dsa = DSA_new()) == NULL
         || !params_to_domparams(dsa, params)) {
         DSA_free(dsa);
         dsa = NULL;
@@ -166,9 +165,8 @@ static int dsa_exportdomparams(void *domparams,
 static void *dsa_importkey(void *provctx, const OSSL_PARAM params[])
 {
     DSA *dsa;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
 
-    if ((dsa = dsa_new(libctx)) == NULL
+    if ((dsa = DSA_new()) == NULL
         || !params_to_key(dsa, params)) {
         DSA_free(dsa);
         dsa = NULL;


### PR DESCRIPTION
These fields are purely application data, and applications don't reach
into the bowels of the FIPS module, so these fields are never used
there.

Fixes #10835