### PR TITLE
[1.1.1] Fix documentation of return value for EVP_Digest{Sign,Verify}Init()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,15 @@
 
  Changes between 1.1.1d and 1.1.1e [xx XXX xxxx]
 
+  *) Corrected the documentation of the return values from the EVP_DigestSign*
+     set of functions.  The documentation mentioned negative values for some
+     errors, but this was never the case, so the mention of negative values
+     was removed.
+
+     Code that followed the documentation and thereby check with something
+     like 'EVP_DigestSignInit(...) <= 0' will continue to work undisturbed.
+     [Richard Levitte]
+
   *) Fixed an an overflow bug in the x64_64 Montgomery squaring procedure
      used in exponentiation with 512-bit moduli. No EC algorithms are
      affected. Analysis suggests that attacks against 2-prime RSA1024,

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -103,9 +103,7 @@ EVP_DigestSignFinal().
 =head1 RETURN VALUES
 
 EVP_DigestSignInit(), EVP_DigestSignUpdate(), EVP_DigestSignaFinal() and
-EVP_DigestSign() return 1 for success and 0 or a negative value for failure. In
-particular, a return value of -2 indicates the operation is not supported by the
-public key algorithm.
+EVP_DigestSign() return 1 for success and 0 for failure.
 
 The error codes can be obtained from L<ERR_get_error(3)>.
 


### PR DESCRIPTION
They never returned the negative values that the documentation stated.

-----

This is a backport of the documentation from #10815