### PR TITLE
Build file templates: Use explicit files instead of $< or $? for pods

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -781,10 +781,11 @@ reconfigure reconf :
 
       if ($args{src} =~ /\.html$/) {
 	  my $title = basename($args{src}, ".html");
+	  my $pod = $args{generator}->[0];
 	  return <<"EOF";
-$args{src}: $args{generator}->[0]
+$args{src}: $pod
 	pipe pod2html "--podroot=\$(SRCDIR)/doc" --htmldir=.. -
-		       --podpath=man1:man3:man5:man7 "--infile=\$<" -
+		       --podpath=man1:man3:man5:man7 "--infile=$pod" -
 		      "--title=$title" -
 	| \$(PERL) -pe "s|href=""http://man\\.he\\.net/(man\d/[^""]+)(?:\\.html)?""|href=""../\$1.html|g;" -
 	> \$\@

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1188,7 +1188,7 @@ reconfigure reconf:
 	  return <<"EOF";
 $args{src}: $pod
 	pod2html "--podroot=\$(SRCDIR)/doc" --htmldir=.. \\
-		 --podpath=man1:man3:man5:man7 "--infile=$pod" "--title=$title" \\
+		 --podpath=man1:man3:man5:man7 --infile=$pod "--title=$title" \\
 	| \$(PERL) -pe 's|href="http://man\\.he\\.net/(man\\d/[^"]+)(?:\\.html)?"|href="../\$1.html|g;' \\
 	> \$\@
 EOF
@@ -1199,7 +1199,7 @@ EOF
 	  return <<"EOF";
 $args{src}: $pod
 	pod2man --name=$name --section=$section --center=OpenSSL \\
-		--release=\$(VERSION) "$pod" \\
+		--release=\$(VERSION) $pod \\
 	> \$\@
 EOF
       } elsif (platform->isdef($args{src})) {

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1184,20 +1184,22 @@ reconfigure reconf:
 
       if ($args{src} =~ /\.html$/) {
 	  my $title = basename($args{src}, ".html");
+	  my $pod = $args{generator}->[0];
 	  return <<"EOF";
-$args{src}: $args{generator}->[0]
+$args{src}: $pod
 	pod2html "--podroot=\$(SRCDIR)/doc" --htmldir=.. \\
-		 --podpath=man1:man3:man5:man7 "--infile=\$<" "--title=$title" \\
+		 --podpath=man1:man3:man5:man7 "--infile=$pod" "--title=$title" \\
 	| \$(PERL) -pe 's|href="http://man\\.he\\.net/(man\\d/[^"]+)(?:\\.html)?"|href="../\$1.html|g;' \\
 	> \$\@
 EOF
       } elsif ($args{src} =~ /\.(\d)$/) {
 	  my $section = $1;
 	  my $name = uc basename($args{src}, ".$section");
+	  my $pod = $args{generator}->[0];
 	  return <<"EOF";
-$args{src}: $args{generator}->[0]
+$args{src}: $pod
 	pod2man --name=$name --section=$section --center=OpenSSL \\
-		--release=\$(VERSION) \$< \\
+		--release=\$(VERSION) "$pod" \\
 	> \$\@
 EOF
       } elsif (platform->isdef($args{src})) {

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -588,7 +588,7 @@ reconfigure reconf:
 	  my $title = basename($args{src}, ".html");
 	  my $pod = $args{generator}->[0];
 	  return <<"EOF";
-$args{src}: $pod
+$args{src}: "$pod"
 	pod2html "--podroot=\$(SRCDIR)/doc" --htmldir=.. \\
 		 --podpath=man1:man3:man5:man7 "--infile=$pod" "--title=$title" \\
 	| \$(PERL) -pe ^"s^|href=\\^"http://man\\.he\\.net/^(man\\d/[^^\\^"]+^)^(?:\.html^)?^"^|href=\\^"../\$\$1.html^|g;^" \\

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -586,10 +586,11 @@ reconfigure reconf:
 
       if ($args{src} =~ /\.html$/) {
 	  my $title = basename($args{src}, ".html");
+	  my $pod = $args{generator}->[0];
 	  return <<"EOF";
-$args{src}: $args{generator}->[0]
+$args{src}: $pod
 	pod2html "--podroot=\$(SRCDIR)/doc" --htmldir=.. \\
-		 --podpath=man1:man3:man5:man7 "--infile=\$?" "--title=$title" \\
+		 --podpath=man1:man3:man5:man7 "--infile=$pod" "--title=$title" \\
 	| \$(PERL) -pe ^"s^|href=\\^"http://man\\.he\\.net/^(man\\d/[^^\\^"]+^)^(?:\.html^)?^"^|href=\\^"../\$\$1.html^|g;^" \\
 	> \$\@
 EOF


### PR DESCRIPTION
When generating html or manpages from POD files, we used $< or $? to
get the file name to process.  It turns out, though, that some make
implementations only define $< with implicit rules, so its expansion
remains empty in explicit rules.  $? is a fine replacement, but only
as long as we have one dependency, so it may cause problems in the
future.

The final solution seems to be to use explicit POD file names
instead.  That leaves no doubts.

Fixes #10817
