### PR TITLE
Adapt X509_PUBKEY_set() for use with provided implementations

### DIFF
--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -67,45 +67,41 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
     if (x == NULL)
         return 0;
 
-    if ((pk = X509_PUBKEY_new()) == NULL)
-        goto error;
+    if (pkey == NULL)
+        goto unsupported;
 
-    if (pkey != NULL) {
-        if (pkey->ameth != NULL) {
-            if (pkey->ameth->pub_encode != NULL) {
-                if (!pkey->ameth->pub_encode(pk, pkey)) {
-                    X509err(X509_F_X509_PUBKEY_SET,
-                            X509_R_PUBLIC_KEY_ENCODE_ERROR);
-                    goto error;
-                }
-            } else {
-                X509err(X509_F_X509_PUBKEY_SET, X509_R_METHOD_NOT_SUPPORTED);
+    if (pkey->ameth != NULL) {
+        if ((pk = X509_PUBKEY_new()) == NULL)
+            goto error;
+        if (pkey->ameth->pub_encode != NULL) {
+            if (!pkey->ameth->pub_encode(pk, pkey)) {
+                X509err(X509_F_X509_PUBKEY_SET,
+                        X509_R_PUBLIC_KEY_ENCODE_ERROR);
                 goto error;
             }
-        } else if (pkey->pkeys[0].keymgmt != NULL) {
-            BIO *bmem = BIO_new(BIO_s_mem());
-            const char *serprop = "format=der,type=public";
-            OSSL_SERIALIZER_CTX *sctx =
-                OSSL_SERIALIZER_CTX_new_by_EVP_PKEY(pkey, serprop);
-
-            if (OSSL_SERIALIZER_to_bio(sctx, bmem)) {
-                const unsigned char *der = NULL;
-                long derlen = BIO_get_mem_data(bmem, (char **)&der);
-
-                pk = d2i_X509_PUBKEY(NULL, &der, derlen);
-            }
-
-            OSSL_SERIALIZER_CTX_free(sctx);
-            BIO_free(bmem);
-
-            if (pk == NULL)
-                goto unsupported;
         } else {
-            goto unsupported;
+            X509err(X509_F_X509_PUBKEY_SET, X509_R_METHOD_NOT_SUPPORTED);
+            goto error;
         }
-    } else {
-        goto unsupported;
+    } else if (pkey->pkeys[0].keymgmt != NULL) {
+        BIO *bmem = BIO_new(BIO_s_mem());
+        const char *serprop = "format=der,type=public";
+        OSSL_SERIALIZER_CTX *sctx =
+            OSSL_SERIALIZER_CTX_new_by_EVP_PKEY(pkey, serprop);
+
+        if (OSSL_SERIALIZER_to_bio(sctx, bmem)) {
+            const unsigned char *der = NULL;
+            long derlen = BIO_get_mem_data(bmem, (char **)&der);
+
+            pk = d2i_X509_PUBKEY(NULL, &der, derlen);
+        }
+
+        OSSL_SERIALIZER_CTX_free(sctx);
+        BIO_free(bmem);
     }
+
+    if (pk == NULL)
+        goto unsupported;
 
     X509_PUBKEY_free(*x);
     *x = pk;


### PR DESCRIPTION
We do this by letting a serializer serialize the provider side key to
a DER blob formatted according to the SubjectPublicKeyInfo structure
(see RFC 5280), and deserialize it in libcrypto using the usual d2i
function.
