### PR TITLE
Deprecate the low level DES functions.

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* We need to use some deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <string.h>
 
 #include "apps.h"
@@ -16,7 +19,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 # include <openssl/des.h>
 #endif
 #include <openssl/md5.h>
@@ -82,7 +85,7 @@ const OPTIONS passwd_options[] = {
     {"apr1", OPT_APR1, '-', "MD5-based password algorithm, Apache variant"},
     {"1", OPT_1, '-', "MD5-based password algorithm"},
     {"aixmd5", OPT_AIXMD5, '-', "AIX MD5-based password algorithm"},
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"crypt", OPT_CRYPT, '-', "Standard Unix password algorithm (default)"},
 #endif
 
@@ -168,7 +171,7 @@ int passwd_main(int argc, char **argv)
             mode = passwd_aixmd5;
             break;
         case OPT_CRYPT:
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
             if (mode != passwd_unset)
                 goto opthelp;
             mode = passwd_crypt;
@@ -205,7 +208,7 @@ int passwd_main(int argc, char **argv)
         mode = passwd_crypt;
     }
 
-#ifdef OPENSSL_NO_DES
+#if defined(OPENSSL_NO_DES) || defined(OPENSSL_NO_DEPRECATED_3_0)
     if (mode == passwd_crypt)
         goto opthelp;
 #endif
@@ -798,7 +801,7 @@ static int do_passwd(int passed_salt, char **salt_p, char **salt_malloc_p,
         size_t saltlen = 0;
         size_t i;
 
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (mode == passwd_crypt)
             saltlen = 2;
 #endif                         /* !OPENSSL_NO_DES */
@@ -841,7 +844,7 @@ static int do_passwd(int passed_salt, char **salt_p, char **salt_malloc_p,
     assert(strlen(passwd) <= pw_maxlen);
 
     /* now compute password hash */
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (mode == passwd_crypt)
         hash = DES_crypt(passwd, *salt_p);
 #endif

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -358,7 +358,7 @@ static const OPT_PAIR doit_choices[] = {
 #if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"rc4", D_RC4},
 #endif
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"des-cbc", D_CBC_DES},
     {"des-ede3", D_EDE3_DES},
 #endif
@@ -729,7 +729,7 @@ static int RC4_loop(void *args)
 }
 #endif
 
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static unsigned char DES_iv[8];
 static DES_key_schedule sch[3];
 static int DES_ncbc_encrypt_loop(void *args)
@@ -1722,7 +1722,7 @@ int speed_main(int argc, char **argv)
             doit[i] = 1;
             continue;
         }
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (strcmp(algo, "des") == 0) {
             doit[D_CBC_DES] = doit[D_EDE3_DES] = 1;
             continue;
@@ -1945,7 +1945,7 @@ int speed_main(int argc, char **argv)
         loopargs[i].dsa_key[2] = get_dsa(2048);
     }
 #endif
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_DES] || doit[D_EDE3_DES]) {
         static DES_cblock keys[] = {
             { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0 }, /* keys[0] */
@@ -2001,7 +2001,7 @@ int speed_main(int argc, char **argv)
         CAST_set_key(&cast_ks, 16, key16);
 #endif
 #ifndef SIGALRM
-# ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     BIO_printf(bio_err, "First we calculate the approximate speed ...\n");
     count = 10;
     do {
@@ -2397,7 +2397,7 @@ int speed_main(int argc, char **argv)
         }
     }
 #endif
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_DES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_CBC_DES], c[D_CBC_DES][testnum],
@@ -3501,7 +3501,7 @@ int speed_main(int argc, char **argv)
 #if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         printf("%s ", RC4_options());
 #endif
-#ifndef OPENSSL_NO_DES
+#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         printf("%s ", DES_options());
 #endif
 #ifndef OPENSSL_NO_DEPRECATED_3_0

--- a/apps/version.c
+++ b/apps/version.c
@@ -15,9 +15,6 @@
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/bn.h>
-#ifndef OPENSSL_NO_DES
-# include <openssl/des.h>
-#endif
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -117,9 +114,6 @@ opthelp:
     if (options) {
         printf("options: ");
         printf(" %s", BN_options());
-#ifndef OPENSSL_NO_DES
-        printf(" %s", DES_options());
-#endif
         printf("\n");
     }
     if (cflags)

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -25,6 +25,13 @@ SOURCE[../../providers/libfips.a]=$COMMON
 DEFINE[../../libcrypto]=$DESDEF
 DEFINE[../../providers/libfips.a]=$DESDEF
 
+IF[{- $disabled{"deprecated"}
+      && !$disabled{"mdc2"}
+      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+  SOURCE[../../providers/liblegacy.a]=set_key.c $DESASM
+  DEFINE[../../providers/liblegacy.a]=$DESDEF
+ENDIF
+
 GENERATE[des_enc-sparc.S]=asm/des_enc.m4
 GENERATE[dest4-sparcv9.S]=asm/dest4-sparcv9.pl
 INCLUDE[dest4-sparcv9.o]=..

--- a/crypto/des/cbc_cksm.c
+++ b/crypto/des/cbc_cksm.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 DES_LONG DES_cbc_cksum(const unsigned char *in, DES_cblock *output,

--- a/crypto/des/cbc_enc.c
+++ b/crypto/des/cbc_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #define CBC_ENC_C__DONT_UPDATE_IV
 
 #include "ncbc_enc.c"           /* des_cbc_encrypt */

--- a/crypto/des/cfb64ede.c
+++ b/crypto/des/cfb64ede.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 /*

--- a/crypto/des/cfb64enc.c
+++ b/crypto/des/cfb64enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 /*

--- a/crypto/des/cfb_enc.c
+++ b/crypto/des/cfb_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "e_os.h"
 #include "des_local.h"
 #include <assert.h>

--- a/crypto/des/des_enc.c
+++ b/crypto/des/des_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include "des_local.h"
 #include "spr.h"

--- a/crypto/des/ecb3_enc.c
+++ b/crypto/des/ecb3_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 void DES_ecb3_encrypt(const_DES_cblock *input, DES_cblock *output,

--- a/crypto/des/ecb_enc.c
+++ b/crypto/des/ecb_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 #include <openssl/opensslv.h>
 #include <openssl/bio.h>

--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 /* NOCW */
 #include <stdio.h>
 #ifdef _OSD_POSIX

--- a/crypto/des/fcrypt_b.c
+++ b/crypto/des/fcrypt_b.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 
 #define DES_FCRYPT

--- a/crypto/des/ofb64ede.c
+++ b/crypto/des/ofb64ede.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 /*

--- a/crypto/des/ofb64enc.c
+++ b/crypto/des/ofb64enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 /*

--- a/crypto/des/ofb_enc.c
+++ b/crypto/des/ofb_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 /*

--- a/crypto/des/pcbc_enc.c
+++ b/crypto/des/pcbc_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 void DES_pcbc_encrypt(const unsigned char *input, unsigned char *output,

--- a/crypto/des/qud_cksm.c
+++ b/crypto/des/qud_cksm.c
@@ -13,6 +13,13 @@
  * only based on the code in this paper and is almost definitely not the same
  * as the MIT implementation.
  */
+
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 #define Q_B0(a) (((DES_LONG)(a)))

--- a/crypto/des/rand_key.c
+++ b/crypto/des/rand_key.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/des.h>
 #include <openssl/rand.h>
 

--- a/crypto/des/set_key.c
+++ b/crypto/des/set_key.c
@@ -15,6 +15,13 @@
  * 1.1 added norm_expand_bits
  * 1.0 First working version
  */
+
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include "des_local.h"
 

--- a/crypto/des/str2key.c
+++ b/crypto/des/str2key.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include "des_local.h"
 

--- a/crypto/des/xcbc_enc.c
+++ b/crypto/des/xcbc_enc.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "des_local.h"
 
 /* RSA's DESX */

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_DES

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_DES

--- a/crypto/evp/e_xcbc_d.c
+++ b/crypto/evp/e_xcbc_d.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 

--- a/doc/man3/DES_random_key.pod
+++ b/doc/man3/DES_random_key.pod
@@ -16,6 +16,10 @@ DES_fcrypt, DES_crypt - DES encryption
 
  #include <openssl/des.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  void DES_random_key(DES_cblock *ret);
 
  int DES_set_key(const_DES_cblock *key, DES_key_schedule *schedule);
@@ -93,6 +97,10 @@ DES_fcrypt, DES_crypt - DES encryption
  char *DES_crypt(const char *buf, const char *salt);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. Applications should
+instead use L<EVP_EncryptInit_ex(3)>, L<EVP_EncryptUpdate(3)> and
+L<EVP_EncryptFinal_ex(3)> or the equivalently named decrypt functions.
 
 This library contains a fast implementation of the DES encryption
 algorithm.
@@ -302,6 +310,8 @@ L<EVP_EncryptInit(3)>
 
 =head1 HISTORY
 
+All of these functions were deprecated in OpenSSL 3.0.
+
 The requirement that the B<salt> parameter to DES_crypt() and DES_fcrypt()
 be two ASCII characters was first enforced in
 OpenSSL 1.1.0.  Previous versions tried to use the letter uppercase B<A>
@@ -310,7 +320,7 @@ on some platforms.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/des.h
+++ b/include/openssl/des.h
@@ -19,17 +19,17 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_DES
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 extern "C" {
-# endif
-# include <openssl/e_os2.h>
+#  endif
+#  include <openssl/e_os2.h>
 
 typedef unsigned int DES_LONG;
 
-# ifdef OPENSSL_BUILD_SHLIBCRYPTO
-#  undef OPENSSL_EXTERN
-#  define OPENSSL_EXTERN OPENSSL_EXPORT
-# endif
+#  ifdef OPENSSL_BUILD_SHLIBCRYPTO
+#   undef OPENSSL_EXTERN
+#   define OPENSSL_EXTERN OPENSSL_EXPORT
+#  endif
 
 typedef unsigned char DES_cblock[8];
 typedef /* const */ unsigned char const_DES_cblock[8];
@@ -48,25 +48,25 @@ typedef struct DES_ks {
     } ks[16];
 } DES_key_schedule;
 
-# define DES_KEY_SZ      (sizeof(DES_cblock))
-# define DES_SCHEDULE_SZ (sizeof(DES_key_schedule))
+#  define DES_KEY_SZ      (sizeof(DES_cblock))
+#  define DES_SCHEDULE_SZ (sizeof(DES_key_schedule))
 
-# define DES_ENCRYPT     1
-# define DES_DECRYPT     0
+#  define DES_ENCRYPT     1
+#  define DES_DECRYPT     0
 
-# define DES_CBC_MODE    0
-# define DES_PCBC_MODE   1
+#  define DES_CBC_MODE    0
+#  define DES_PCBC_MODE   1
 
-# define DES_ecb2_encrypt(i,o,k1,k2,e) \
+#  define DES_ecb2_encrypt(i,o,k1,k2,e) \
         DES_ecb3_encrypt((i),(o),(k1),(k2),(k1),(e))
 
-# define DES_ede2_cbc_encrypt(i,o,l,k1,k2,iv,e) \
+#  define DES_ede2_cbc_encrypt(i,o,l,k1,k2,iv,e) \
         DES_ede3_cbc_encrypt((i),(o),(l),(k1),(k2),(k1),(iv),(e))
 
-# define DES_ede2_cfb64_encrypt(i,o,l,k1,k2,iv,n,e) \
+#  define DES_ede2_cfb64_encrypt(i,o,l,k1,k2,iv,n,e) \
         DES_ede3_cfb64_encrypt((i),(o),(l),(k1),(k2),(k1),(iv),(n),(e))
 
-# define DES_ede2_ofb64_encrypt(i,o,l,k1,k2,iv,n) \
+#  define DES_ede2_ofb64_encrypt(i,o,l,k1,k2,iv,n) \
         DES_ede3_ofb64_encrypt((i),(o),(l),(k1),(k2),(k1),(iv),(n))
 
 const char *DES_options(void);
@@ -166,11 +166,11 @@ void DES_ofb64_encrypt(const unsigned char *in, unsigned char *out,
                        long length, DES_key_schedule *schedule,
                        DES_cblock *ivec, int *num);
 
-# define DES_fixup_key_parity DES_set_odd_parity
+#  define DES_fixup_key_parity DES_set_odd_parity
 
-# ifdef  __cplusplus
+#  ifdef  __cplusplus
 }
-# endif
+#  endif
 # endif
 
 #endif

--- a/include/openssl/des.h
+++ b/include/openssl/des.h
@@ -24,12 +24,13 @@ extern "C" {
 #  endif
 #  include <openssl/e_os2.h>
 
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef unsigned int DES_LONG;
 
-#  ifdef OPENSSL_BUILD_SHLIBCRYPTO
-#   undef OPENSSL_EXTERN
-#   define OPENSSL_EXTERN OPENSSL_EXPORT
-#  endif
+#   ifdef OPENSSL_BUILD_SHLIBCRYPTO
+#    undef OPENSSL_EXTERN
+#    define OPENSSL_EXTERN OPENSSL_EXPORT
+#   endif
 
 typedef unsigned char DES_cblock[8];
 typedef /* const */ unsigned char const_DES_cblock[8];
@@ -48,50 +49,61 @@ typedef struct DES_ks {
     } ks[16];
 } DES_key_schedule;
 
-#  define DES_KEY_SZ      (sizeof(DES_cblock))
-#  define DES_SCHEDULE_SZ (sizeof(DES_key_schedule))
+#   define DES_KEY_SZ      (sizeof(DES_cblock))
+#   define DES_SCHEDULE_SZ (sizeof(DES_key_schedule))
 
-#  define DES_ENCRYPT     1
-#  define DES_DECRYPT     0
+#   define DES_ENCRYPT     1
+#   define DES_DECRYPT     0
 
-#  define DES_CBC_MODE    0
-#  define DES_PCBC_MODE   1
+#   define DES_CBC_MODE    0
+#   define DES_PCBC_MODE   1
 
-#  define DES_ecb2_encrypt(i,o,k1,k2,e) \
+#   define DES_ecb2_encrypt(i,o,k1,k2,e) \
         DES_ecb3_encrypt((i),(o),(k1),(k2),(k1),(e))
 
-#  define DES_ede2_cbc_encrypt(i,o,l,k1,k2,iv,e) \
+#   define DES_ede2_cbc_encrypt(i,o,l,k1,k2,iv,e) \
         DES_ede3_cbc_encrypt((i),(o),(l),(k1),(k2),(k1),(iv),(e))
 
-#  define DES_ede2_cfb64_encrypt(i,o,l,k1,k2,iv,n,e) \
+#   define DES_ede2_cfb64_encrypt(i,o,l,k1,k2,iv,n,e) \
         DES_ede3_cfb64_encrypt((i),(o),(l),(k1),(k2),(k1),(iv),(n),(e))
 
-#  define DES_ede2_ofb64_encrypt(i,o,l,k1,k2,iv,n) \
+#   define DES_ede2_ofb64_encrypt(i,o,l,k1,k2,iv,n) \
         DES_ede3_ofb64_encrypt((i),(o),(l),(k1),(k2),(k1),(iv),(n))
 
-const char *DES_options(void);
-void DES_ecb3_encrypt(const_DES_cblock *input, DES_cblock *output,
-                      DES_key_schedule *ks1, DES_key_schedule *ks2,
-                      DES_key_schedule *ks3, int enc);
-DES_LONG DES_cbc_cksum(const unsigned char *input, DES_cblock *output,
-                       long length, DES_key_schedule *schedule,
-                       const_DES_cblock *ivec);
+#   define DES_fixup_key_parity DES_set_odd_parity
+#  endif
+
+DEPRECATEDIN_3_0(const char *DES_options(void))
+DEPRECATEDIN_3_0(void DES_ecb3_encrypt(const_DES_cblock *input,
+                                       DES_cblock *output,
+                                       DES_key_schedule *ks1,
+                                       DES_key_schedule *ks2,
+                                       DES_key_schedule *ks3, int enc))
+DEPRECATEDIN_3_0(DES_LONG DES_cbc_cksum(const unsigned char *input,
+                                        DES_cblock *output, long length,
+                                        DES_key_schedule *schedule,
+                                        const_DES_cblock *ivec))
 /* DES_cbc_encrypt does not update the IV!  Use DES_ncbc_encrypt instead. */
-void DES_cbc_encrypt(const unsigned char *input, unsigned char *output,
-                     long length, DES_key_schedule *schedule,
-                     DES_cblock *ivec, int enc);
-void DES_ncbc_encrypt(const unsigned char *input, unsigned char *output,
-                      long length, DES_key_schedule *schedule,
-                      DES_cblock *ivec, int enc);
-void DES_xcbc_encrypt(const unsigned char *input, unsigned char *output,
-                      long length, DES_key_schedule *schedule,
-                      DES_cblock *ivec, const_DES_cblock *inw,
-                      const_DES_cblock *outw, int enc);
-void DES_cfb_encrypt(const unsigned char *in, unsigned char *out, int numbits,
-                     long length, DES_key_schedule *schedule,
-                     DES_cblock *ivec, int enc);
-void DES_ecb_encrypt(const_DES_cblock *input, DES_cblock *output,
-                     DES_key_schedule *ks, int enc);
+DEPRECATEDIN_3_0(void DES_cbc_encrypt(const unsigned char *input,
+                                      unsigned char *output, long length,
+                                      DES_key_schedule *schedule,
+                                      DES_cblock *ivec, int enc))
+DEPRECATEDIN_3_0(void DES_ncbc_encrypt(const unsigned char *input,
+                                       unsigned char *output, long length,
+                                       DES_key_schedule *schedule,
+                                       DES_cblock *ivec, int enc))
+DEPRECATEDIN_3_0(void DES_xcbc_encrypt(const unsigned char *input,
+                                       unsigned char *output, long length,
+                                       DES_key_schedule *schedule,
+                                       DES_cblock *ivec, const_DES_cblock *inw,
+                                       const_DES_cblock *outw, int enc))
+DEPRECATEDIN_3_0(void DES_cfb_encrypt(const unsigned char *in,
+                                      unsigned char *out, int numbits,
+                                      long length, DES_key_schedule *schedule,
+                                      DES_cblock *ivec, int enc))
+DEPRECATEDIN_3_0(void DES_ecb_encrypt(const_DES_cblock *input,
+                                      DES_cblock *output, DES_key_schedule *ks,
+                                      int enc))
 
 /*
  * This is the DES encryption function that gets called by just about every
@@ -103,7 +115,8 @@ void DES_ecb_encrypt(const_DES_cblock *input, DES_cblock *output,
  * long's and ks is the DES_key_schedule to use.  enc, is non zero specifies
  * encryption, zero if decryption.
  */
-void DES_encrypt1(DES_LONG *data, DES_key_schedule *ks, int enc);
+DEPRECATEDIN_3_0(void DES_encrypt1(DES_LONG *data, DES_key_schedule *ks,
+                                   int enc))
 
 /*
  * This functions is the same as DES_encrypt1() except that the DES initial
@@ -113,60 +126,78 @@ void DES_encrypt1(DES_LONG *data, DES_key_schedule *ks, int enc);
  * DES_encrypt2() DES_encrypt2() FP() is the same as DES_encrypt1()
  * DES_encrypt1() DES_encrypt1() except faster :-).
  */
-void DES_encrypt2(DES_LONG *data, DES_key_schedule *ks, int enc);
+DEPRECATEDIN_3_0(void DES_encrypt2(DES_LONG *data, DES_key_schedule *ks,
+                                   int enc))
 
-void DES_encrypt3(DES_LONG *data, DES_key_schedule *ks1,
-                  DES_key_schedule *ks2, DES_key_schedule *ks3);
-void DES_decrypt3(DES_LONG *data, DES_key_schedule *ks1,
-                  DES_key_schedule *ks2, DES_key_schedule *ks3);
-void DES_ede3_cbc_encrypt(const unsigned char *input, unsigned char *output,
-                          long length,
-                          DES_key_schedule *ks1, DES_key_schedule *ks2,
-                          DES_key_schedule *ks3, DES_cblock *ivec, int enc);
-void DES_ede3_cfb64_encrypt(const unsigned char *in, unsigned char *out,
-                            long length, DES_key_schedule *ks1,
-                            DES_key_schedule *ks2, DES_key_schedule *ks3,
-                            DES_cblock *ivec, int *num, int enc);
-void DES_ede3_cfb_encrypt(const unsigned char *in, unsigned char *out,
-                          int numbits, long length, DES_key_schedule *ks1,
-                          DES_key_schedule *ks2, DES_key_schedule *ks3,
-                          DES_cblock *ivec, int enc);
-void DES_ede3_ofb64_encrypt(const unsigned char *in, unsigned char *out,
-                            long length, DES_key_schedule *ks1,
-                            DES_key_schedule *ks2, DES_key_schedule *ks3,
-                            DES_cblock *ivec, int *num);
-char *DES_fcrypt(const char *buf, const char *salt, char *ret);
-char *DES_crypt(const char *buf, const char *salt);
-void DES_ofb_encrypt(const unsigned char *in, unsigned char *out, int numbits,
-                     long length, DES_key_schedule *schedule,
-                     DES_cblock *ivec);
-void DES_pcbc_encrypt(const unsigned char *input, unsigned char *output,
-                      long length, DES_key_schedule *schedule,
-                      DES_cblock *ivec, int enc);
-DES_LONG DES_quad_cksum(const unsigned char *input, DES_cblock output[],
-                        long length, int out_count, DES_cblock *seed);
-int DES_random_key(DES_cblock *ret);
-void DES_set_odd_parity(DES_cblock *key);
-int DES_check_key_parity(const_DES_cblock *key);
-int DES_is_weak_key(const_DES_cblock *key);
+DEPRECATEDIN_3_0(void DES_encrypt3(DES_LONG *data, DES_key_schedule *ks1,
+                  DES_key_schedule *ks2, DES_key_schedule *ks3))
+DEPRECATEDIN_3_0(void DES_decrypt3(DES_LONG *data, DES_key_schedule *ks1,
+                  DES_key_schedule *ks2, DES_key_schedule *ks3))
+DEPRECATEDIN_3_0(void DES_ede3_cbc_encrypt(const unsigned char *input,
+                                           unsigned char *output, long length,
+                                           DES_key_schedule *ks1,
+                                           DES_key_schedule *ks2,
+                                           DES_key_schedule *ks3,
+                                           DES_cblock *ivec, int enc))
+DEPRECATEDIN_3_0(void DES_ede3_cfb64_encrypt(const unsigned char *in,
+                                             unsigned char *out, long length,
+                                             DES_key_schedule *ks1,
+                                             DES_key_schedule *ks2,
+                                             DES_key_schedule *ks3,
+                                             DES_cblock *ivec, int *num,
+                                             int enc))
+DEPRECATEDIN_3_0(void DES_ede3_cfb_encrypt(const unsigned char *in,
+                                           unsigned char *out, int numbits,
+                                           long length, DES_key_schedule *ks1,
+                                           DES_key_schedule *ks2,
+                                           DES_key_schedule *ks3,
+                                           DES_cblock *ivec, int enc))
+DEPRECATEDIN_3_0(void DES_ede3_ofb64_encrypt(const unsigned char *in,
+                                             unsigned char *out, long length,
+                                             DES_key_schedule *ks1,
+                                             DES_key_schedule *ks2,
+                                             DES_key_schedule *ks3,
+                                             DES_cblock *ivec, int *num))
+DEPRECATEDIN_3_0(char *DES_fcrypt(const char *buf, const char *salt, char *ret))
+DEPRECATEDIN_3_0(char *DES_crypt(const char *buf, const char *salt))
+DEPRECATEDIN_3_0(void DES_ofb_encrypt(const unsigned char *in,
+                                      unsigned char *out, int numbits,
+                                      long length, DES_key_schedule *schedule,
+                                      DES_cblock *ivec))
+DEPRECATEDIN_3_0(void DES_pcbc_encrypt(const unsigned char *input,
+                                       unsigned char *output, long length,
+                                       DES_key_schedule *schedule,
+                                       DES_cblock *ivec, int enc))
+DEPRECATEDIN_3_0(DES_LONG DES_quad_cksum(const unsigned char *input,
+                                         DES_cblock output[], long length,
+                                         int out_count, DES_cblock *seed))
+DEPRECATEDIN_3_0(int DES_random_key(DES_cblock *ret))
+DEPRECATEDIN_3_0(void DES_set_odd_parity(DES_cblock *key))
+DEPRECATEDIN_3_0(int DES_check_key_parity(const_DES_cblock *key))
+DEPRECATEDIN_3_0(int DES_is_weak_key(const_DES_cblock *key))
 /*
  * DES_set_key (= set_key = DES_key_sched = key_sched) calls
  * DES_set_key_checked
  */
-int DES_set_key(const_DES_cblock *key, DES_key_schedule *schedule);
-int DES_key_sched(const_DES_cblock *key, DES_key_schedule *schedule);
-int DES_set_key_checked(const_DES_cblock *key, DES_key_schedule *schedule);
-void DES_set_key_unchecked(const_DES_cblock *key, DES_key_schedule *schedule);
-void DES_string_to_key(const char *str, DES_cblock *key);
-void DES_string_to_2keys(const char *str, DES_cblock *key1, DES_cblock *key2);
-void DES_cfb64_encrypt(const unsigned char *in, unsigned char *out,
-                       long length, DES_key_schedule *schedule,
-                       DES_cblock *ivec, int *num, int enc);
-void DES_ofb64_encrypt(const unsigned char *in, unsigned char *out,
-                       long length, DES_key_schedule *schedule,
-                       DES_cblock *ivec, int *num);
-
-#  define DES_fixup_key_parity DES_set_odd_parity
+DEPRECATEDIN_3_0(int DES_set_key(const_DES_cblock *key,
+                                 DES_key_schedule *schedule))
+DEPRECATEDIN_3_0(int DES_key_sched(const_DES_cblock *key,
+                                   DES_key_schedule *schedule))
+DEPRECATEDIN_3_0(int DES_set_key_checked(const_DES_cblock *key,
+                                         DES_key_schedule *schedule))
+DEPRECATEDIN_3_0(void DES_set_key_unchecked(const_DES_cblock *key,
+                                            DES_key_schedule *schedule))
+DEPRECATEDIN_3_0(void DES_string_to_key(const char *str, DES_cblock *key))
+DEPRECATEDIN_3_0(void DES_string_to_2keys(const char *str, DES_cblock *key1,
+                                          DES_cblock *key2))
+DEPRECATEDIN_3_0(void DES_cfb64_encrypt(const unsigned char *in,
+                                        unsigned char *out, long length,
+                                        DES_key_schedule *schedule,
+                                        DES_cblock *ivec, int *num, int enc))
+DEPRECATEDIN_3_0(void DES_ofb64_encrypt(const unsigned char *in,
+                                        unsigned char *out, long length,
+                                        DES_key_schedule *schedule,
+                                        DES_cblock *ivec, int *num))
 
 #  ifdef  __cplusplus
 }

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "prov/ciphercommon.h"
 #include "cipher_des.h"
 #include <openssl/rand.h>

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "prov/ciphercommon.h"
 #include "cipher_des.h"
 

--- a/providers/implementations/ciphers/cipher_desx.c
+++ b/providers/implementations/ciphers/cipher_desx.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_tdes_default.h"
 #include "prov/implementations.h"
 

--- a/providers/implementations/ciphers/cipher_desx_hw.c
+++ b/providers/implementations/ciphers/cipher_desx_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/des.h>
 #include "cipher_tdes_default.h"
 

--- a/providers/implementations/ciphers/cipher_tdes.c
+++ b/providers/implementations/ciphers/cipher_tdes.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "prov/ciphercommon.h"
 #include "cipher_tdes.h"
 #include <openssl/rand.h>

--- a/providers/implementations/ciphers/cipher_tdes_default.c
+++ b/providers/implementations/ciphers/cipher_tdes_default.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_tdes_default.h"
 #include "prov/implementations.h"
 

--- a/providers/implementations/ciphers/cipher_tdes_default_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_default_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_tdes_default.h"
 
 #define ks1 tks.ks[0]

--- a/providers/implementations/ciphers/cipher_tdes_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "prov/ciphercommon.h"
 #include "cipher_tdes.h"
 

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * SHA-1 low level APIs are deprecated for public use, but still ok for
+ * DES and SHA-1 low level APIs are deprecated for public use, but still ok for
  * internal use.
  */
 #include "internal/deprecated.h"

--- a/providers/implementations/ciphers/cipher_tdes_wrap_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap_hw.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include "cipher_tdes_default.h"
 
 #define cipher_hw_tdes_wrap_initkey cipher_hw_tdes_ede3_initkey

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.  We access the DES_set_odd_parity(3) function here.
+ */
+#include "internal/deprecated.h"
+
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>

--- a/test/build.info
+++ b/test/build.info
@@ -114,10 +114,6 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[hmactest]=../include ../apps/include
   DEPEND[hmactest]=../libcrypto libtestutil.a
 
-  SOURCE[destest]=destest.c
-  INCLUDE[destest]=../include ../apps/include
-  DEPEND[destest]=../libcrypto libtestutil.a
-
   SOURCE[mdc2test]=mdc2test.c
   INCLUDE[mdc2test]=../include ../apps/include
   DEPEND[mdc2test]=../libcrypto libtestutil.a
@@ -580,6 +576,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[sm4_internal_test]=sm4_internal_test.c
     INCLUDE[sm4_internal_test]=.. ../include ../apps/include ../crypto/include
     DEPEND[sm4_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[destest]=destest.c
+    INCLUDE[destest]=../include ../apps/include
+    DEPEND[destest]=../libcrypto.a libtestutil.a
 
     SOURCE[rc2test]=rc2test.c
     INCLUDE[rc2test]=../include ../apps/include

--- a/test/destest.c
+++ b/test/destest.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * DES low level APIs are deprecated for public use, but still ok for internal
+ * use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/e_os2.h>
 #include <string.h>
 

--- a/test/recipes/20-test_passwd.t
+++ b/test/recipes/20-test_passwd.t
@@ -76,11 +76,11 @@ my @sha_tests =
        expected => '$6$rounds=1000$roundstoolow$kUMsbe306n21p9R.FRkW3IGn.S9NPN0x50YhH1xhLsPuWGsUSklZt58jaTfF4ZEQpyUNGc0dqbpBYYBaHHrsX.' }
     );
 
-plan tests => (disabled("des") ? 9 : 11) + scalar @sha_tests;
+plan tests => (disabled("des") || disabled("deprecated") ? 9 : 11) + scalar @sha_tests;
 
 
 ok(compare1stline_re([qw{openssl passwd password}], '^.{13}\R$'),
-   'crypt password with random salt') if !disabled("des");
+   'crypt password with random salt') if !disabled("des") && !disabled("deprecated");
 ok(compare1stline_re([qw{openssl passwd -1 password}], '^\$1\$.{8}\$.{22}\R$'),
    'BSD style MD5 password with random salt');
 ok(compare1stline_re([qw{openssl passwd -apr1 password}], '^\$apr1\$.{8}\$.{22}\R$'),
@@ -91,7 +91,7 @@ ok(compare1stline_re([qw{openssl passwd -6 password}], '^\$6\$.{16}\$.{86}\R$'),
    'Apache SHA512 password with random salt');
 
 ok(compare1stline([qw{openssl passwd -salt xx password}], 'xxj31ZMTZzkVA'),
-   'crypt password with salt xx') if !disabled("des");
+   'crypt password with salt xx') if !disabled("des") && !disabled("deprecated");
 ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -1 password}], '$1$xxxxxxxx$UYCIxa628.9qXjpQCjM4a.'),
    'BSD style MD5 password with salt xxxxxxxx');
 ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -apr1 password}], '$apr1$xxxxxxxx$dxHfLAsjHkDRmG83UXe8K0'),

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5,7 +5,7 @@ X509_STORE_CTX_get0_chain               4	3_0_0	EXIST::FUNCTION:
 COMP_expand_block                       5	3_0_0	EXIST::FUNCTION:COMP
 X509V3_get_string                       6	3_0_0	EXIST::FUNCTION:
 TS_MSG_IMPRINT_free                     7	3_0_0	EXIST::FUNCTION:TS
-DES_xcbc_encrypt                        8	3_0_0	EXIST::FUNCTION:DES
+DES_xcbc_encrypt                        8	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 TS_RESP_CTX_new                         9	3_0_0	EXIST::FUNCTION:TS
 PKCS5_PBE_add                           10	3_0_0	EXIST::FUNCTION:
 i2d_DSAparams                           11	3_0_0	EXIST::FUNCTION:DSA
@@ -18,7 +18,7 @@ i2d_ASN1_OCTET_STRING                   17	3_0_0	EXIST::FUNCTION:
 EC_KEY_set_private_key                  18	3_0_0	EXIST::FUNCTION:EC
 SRP_VBASE_get_by_user                   19	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SRP
 Camellia_cfb128_encrypt                 21	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
-DES_ncbc_encrypt                        22	3_0_0	EXIST::FUNCTION:DES
+DES_ncbc_encrypt                        22	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 TS_REQ_get_ext_count                    23	3_0_0	EXIST::FUNCTION:TS
 EVP_aes_128_ocb                         24	3_0_0	EXIST::FUNCTION:OCB
 ASN1_item_d2i_fp                        25	3_0_0	EXIST::FUNCTION:STDIO
@@ -243,7 +243,7 @@ ENGINE_get_pkey_asn1_meths              247	3_0_0	EXIST::FUNCTION:ENGINE
 DSO_merge                               248	3_0_0	EXIST::FUNCTION:
 RSA_get_ex_data                         249	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_meth_get_decrypt               250	3_0_0	EXIST::FUNCTION:
-DES_cfb_encrypt                         251	3_0_0	EXIST::FUNCTION:DES
+DES_cfb_encrypt                         251	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 CMS_SignerInfo_set1_signer_cert         252	3_0_0	EXIST::FUNCTION:CMS
 X509_CRL_http_nbio                      253	3_0_0	EXIST::FUNCTION:OCSP
 ENGINE_register_all_ciphers             254	3_0_0	EXIST::FUNCTION:ENGINE
@@ -478,7 +478,7 @@ EVP_PKEY_set1_RSA                       487	3_0_0	EXIST::FUNCTION:RSA
 CMS_SignerInfo_get0_md_ctx              488	3_0_0	EXIST::FUNCTION:CMS
 X509_STORE_set_trust                    489	3_0_0	EXIST::FUNCTION:
 d2i_POLICYINFO                          490	3_0_0	EXIST::FUNCTION:
-DES_cbc_encrypt                         491	3_0_0	EXIST::FUNCTION:DES
+DES_cbc_encrypt                         491	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 BN_GF2m_mod_sqr_arr                     492	3_0_0	EXIST::FUNCTION:EC2M
 ASN1_PRINTABLESTRING_it                 493	3_0_0	EXIST::FUNCTION:
 BIO_f_cipher                            494	3_0_0	EXIST::FUNCTION:
@@ -494,7 +494,7 @@ FIPS_mode_set                           503	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_add0_policy           504	3_0_0	EXIST::FUNCTION:
 PKCS7_cert_from_signer_info             505	3_0_0	EXIST::FUNCTION:
 X509_TRUST_get_trust                    506	3_0_0	EXIST::FUNCTION:
-DES_string_to_key                       507	3_0_0	EXIST::FUNCTION:DES
+DES_string_to_key                       507	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 ERR_error_string                        508	3_0_0	EXIST::FUNCTION:
 BIO_new_connect                         509	3_0_0	EXIST::FUNCTION:SOCK
 DSA_new_method                          511	3_0_0	EXIST::FUNCTION:DSA
@@ -602,7 +602,7 @@ EVP_PKEY_get_attr_count                 616	3_0_0	EXIST::FUNCTION:
 X509_REVOKED_get_ext_by_critical        617	3_0_0	EXIST::FUNCTION:
 X509at_get_attr                         618	3_0_0	EXIST::FUNCTION:
 X509_PUBKEY_it                          619	3_0_0	EXIST::FUNCTION:
-DES_ede3_ofb64_encrypt                  620	3_0_0	EXIST::FUNCTION:DES
+DES_ede3_ofb64_encrypt                  620	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EC_KEY_METHOD_get_compute_key           621	3_0_0	EXIST::FUNCTION:EC
 RC2_cfb64_encrypt                       622	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 EVP_EncryptFinal_ex                     623	3_0_0	EXIST::FUNCTION:
@@ -823,7 +823,7 @@ OPENSSL_LH_doall_arg                    842	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_get_ext_by_NID             843	3_0_0	EXIST::FUNCTION:OCSP
 X509_REQ_get_attr_by_NID                844	3_0_0	EXIST::FUNCTION:
 PBE2PARAM_new                           845	3_0_0	EXIST::FUNCTION:
-DES_ecb_encrypt                         846	3_0_0	EXIST::FUNCTION:DES
+DES_ecb_encrypt                         846	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_camellia_256_ecb                    847	3_0_0	EXIST::FUNCTION:CAMELLIA
 PEM_read_RSA_PUBKEY                     848	3_0_0	EXIST::FUNCTION:RSA,STDIO
 d2i_NETSCAPE_SPKAC                      849	3_0_0	EXIST::FUNCTION:
@@ -886,7 +886,7 @@ EVP_camellia_128_cbc                    907	3_0_0	EXIST::FUNCTION:CAMELLIA
 COMP_zlib                               908	3_0_0	EXIST::FUNCTION:COMP
 EVP_read_pw_string                      909	3_0_0	EXIST::FUNCTION:
 i2d_ASN1_NULL                           910	3_0_0	EXIST::FUNCTION:
-DES_encrypt1                            911	3_0_0	EXIST::FUNCTION:DES
+DES_encrypt1                            911	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 BN_mod_lshift1_quick                    912	3_0_0	EXIST::FUNCTION:
 BN_get_rfc3526_prime_6144               913	3_0_0	EXIST::FUNCTION:
 OBJ_obj2txt                             914	3_0_0	EXIST::FUNCTION:
@@ -942,7 +942,7 @@ d2i_RSA_PUBKEY_bio                      965	3_0_0	EXIST::FUNCTION:RSA
 TS_RESP_dup                             966	3_0_0	EXIST::FUNCTION:TS
 ERR_set_error_data                      967	3_0_0	EXIST::FUNCTION:
 BN_RECP_CTX_new                         968	3_0_0	EXIST::FUNCTION:
-DES_options                             969	3_0_0	EXIST::FUNCTION:DES
+DES_options                             969	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 IPAddressChoice_it                      970	3_0_0	EXIST::FUNCTION:RFC3779
 ASN1_UNIVERSALSTRING_it                 971	3_0_0	EXIST::FUNCTION:
 d2i_DSAPublicKey                        972	3_0_0	EXIST::FUNCTION:DSA
@@ -1027,7 +1027,7 @@ EC_KEY_METHOD_set_keygen                1053	3_0_0	EXIST::FUNCTION:EC
 CRYPTO_free                             1054	3_0_0	EXIST::FUNCTION:
 BN_GF2m_mod_exp                         1055	3_0_0	EXIST::FUNCTION:EC2M
 OPENSSL_buf2hexstr                      1056	3_0_0	EXIST::FUNCTION:
-DES_encrypt2                            1057	3_0_0	EXIST::FUNCTION:DES
+DES_encrypt2                            1057	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 DH_up_ref                               1058	3_0_0	EXIST::FUNCTION:DH
 RC2_ofb64_encrypt                       1059	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 PKCS12_pbe_crypt                        1060	3_0_0	EXIST::FUNCTION:
@@ -1046,7 +1046,7 @@ ENGINE_get_EC                           1072	3_0_0	EXIST::FUNCTION:ENGINE
 ASN1_STRING_copy                        1073	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_encrypt_old                    1074	3_0_0	EXIST::FUNCTION:
 OPENSSL_LH_free                         1075	3_0_0	EXIST::FUNCTION:
-DES_is_weak_key                         1076	3_0_0	EXIST::FUNCTION:DES
+DES_is_weak_key                         1076	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_PKEY_verify                         1077	3_0_0	EXIST::FUNCTION:
 ERR_load_BIO_strings                    1078	3_0_0	EXIST::FUNCTION:
 BIO_nread                               1079	3_0_0	EXIST::FUNCTION:
@@ -1123,7 +1123,7 @@ BN_is_prime_fasttest                    1149	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 EC_POINT_dup                            1150	3_0_0	EXIST::FUNCTION:EC
 PKCS5_v2_scrypt_keyivgen                1151	3_0_0	EXIST::FUNCTION:SCRYPT
 X509_STORE_CTX_set0_param               1152	3_0_0	EXIST::FUNCTION:
-DES_check_key_parity                    1153	3_0_0	EXIST::FUNCTION:DES
+DES_check_key_parity                    1153	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_aes_256_ocb                         1154	3_0_0	EXIST::FUNCTION:OCB
 X509_VAL_free                           1155	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_get1_certs               1156	3_0_0	EXIST::FUNCTION:
@@ -1166,12 +1166,12 @@ PEM_bytes_read_bio                      1192	3_0_0	EXIST::FUNCTION:
 X509_signature_dump                     1193	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_set_def_policy              1194	3_0_0	EXIST::FUNCTION:TS
 RAND_pseudo_bytes                       1195	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0
-DES_ofb_encrypt                         1196	3_0_0	EXIST::FUNCTION:DES
+DES_ofb_encrypt                         1196	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_add_digest                          1197	3_0_0	EXIST::FUNCTION:
 ASN1_item_sign_ctx                      1198	3_0_0	EXIST::FUNCTION:
 BIO_dump_indent_cb                      1199	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_set_depth             1200	3_0_0	EXIST::FUNCTION:
-DES_ecb3_encrypt                        1201	3_0_0	EXIST::FUNCTION:DES
+DES_ecb3_encrypt                        1201	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 OBJ_obj2nid                             1202	3_0_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_free                     1203	3_0_0	EXIST::FUNCTION:
 EVP_cast5_cfb64                         1204	3_0_0	EXIST::FUNCTION:CAST
@@ -1309,7 +1309,7 @@ Camellia_ctr128_encrypt                 1337	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPR
 X509_LOOKUP_new                         1338	3_0_0	EXIST::FUNCTION:
 AUTHORITY_INFO_ACCESS_new               1339	3_0_0	EXIST::FUNCTION:
 CRYPTO_mem_leaks_fp                     1340	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0,STDIO
-DES_set_key_unchecked                   1341	3_0_0	EXIST::FUNCTION:DES
+DES_set_key_unchecked                   1341	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 BN_free                                 1342	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_cfb1                        1343	3_0_0	EXIST::FUNCTION:
 EC_KEY_get0_group                       1344	3_0_0	EXIST::FUNCTION:EC
@@ -1531,7 +1531,7 @@ OPENSSL_sk_delete                       1564	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_set_extension_cb            1565	3_0_0	EXIST::FUNCTION:TS
 EVP_CIPHER_CTX_nid                      1566	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_add_md                      1567	3_0_0	EXIST::FUNCTION:TS
-DES_set_key                             1568	3_0_0	EXIST::FUNCTION:DES
+DES_set_key                             1568	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 X509V3_extensions_print                 1569	3_0_0	EXIST::FUNCTION:
 PEM_do_header                           1570	3_0_0	EXIST::FUNCTION:
 i2d_re_X509_CRL_tbs                     1571	3_0_0	EXIST::FUNCTION:
@@ -1624,9 +1624,9 @@ X509V3_add_value_uchar                  1661	3_0_0	EXIST::FUNCTION:
 BIO_asn1_get_suffix                     1662	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_clear_flags           1663	3_0_0	EXIST::FUNCTION:
 X509_NAME_add_entry_by_txt              1664	3_0_0	EXIST::FUNCTION:
-DES_ede3_cfb_encrypt                    1665	3_0_0	EXIST::FUNCTION:DES
+DES_ede3_cfb_encrypt                    1665	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 i2d_CMS_bio_stream                      1667	3_0_0	EXIST::FUNCTION:CMS
-DES_quad_cksum                          1668	3_0_0	EXIST::FUNCTION:DES
+DES_quad_cksum                          1668	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 X509_ATTRIBUTE_create_by_NID            1669	3_0_0	EXIST::FUNCTION:
 TS_VERIFY_CTX_free                      1670	3_0_0	EXIST::FUNCTION:TS
 EC_KEY_up_ref                           1671	3_0_0	EXIST::FUNCTION:EC
@@ -2310,7 +2310,7 @@ BN_bn2lebinpad                          2358	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_up_ref                         2359	3_0_0	EXIST::FUNCTION:
 X509_getm_notBefore                     2360	3_0_0	EXIST::FUNCTION:
 BN_nist_mod_224                         2361	3_0_0	EXIST::FUNCTION:
-DES_decrypt3                            2362	3_0_0	EXIST::FUNCTION:DES
+DES_decrypt3                            2362	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 OTHERNAME_it                            2363	3_0_0	EXIST::FUNCTION:
 X509at_add1_attr_by_txt                 2364	3_0_0	EXIST::FUNCTION:
 PKCS7_SIGN_ENVELOPE_free                2365	3_0_0	EXIST::FUNCTION:
@@ -2321,7 +2321,7 @@ X509_LOOKUP_by_issuer_serial            2369	3_0_0	EXIST::FUNCTION:
 ASN1_BMPSTRING_free                     2370	3_0_0	EXIST::FUNCTION:
 BIO_new_accept                          2371	3_0_0	EXIST::FUNCTION:SOCK
 GENERAL_NAME_new                        2372	3_0_0	EXIST::FUNCTION:
-DES_encrypt3                            2373	3_0_0	EXIST::FUNCTION:DES
+DES_encrypt3                            2373	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 PKCS7_get_signer_info                   2374	3_0_0	EXIST::FUNCTION:
 ASN1_OCTET_STRING_set                   2375	3_0_0	EXIST::FUNCTION:
 BN_mask_bits                            2376	3_0_0	EXIST::FUNCTION:
@@ -2508,7 +2508,7 @@ d2i_EC_PUBKEY_fp                        2561	3_0_0	EXIST::FUNCTION:EC,STDIO
 i2d_OCSP_SIGNATURE                      2562	3_0_0	EXIST::FUNCTION:OCSP
 i2d_X509_EXTENSION                      2563	3_0_0	EXIST::FUNCTION:
 PEM_read_bio_X509                       2564	3_0_0	EXIST::FUNCTION:
-DES_key_sched                           2565	3_0_0	EXIST::FUNCTION:DES
+DES_key_sched                           2565	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 GENERAL_NAME_dup                        2566	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_get1_crls                2567	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_verify                2568	3_0_0	EXIST::FUNCTION:
@@ -2668,7 +2668,7 @@ PEM_write_PKCS8PrivateKey               2724	3_0_0	EXIST::FUNCTION:STDIO
 ENGINE_new                              2725	3_0_0	EXIST::FUNCTION:ENGINE
 X509_check_issued                       2726	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_iv_length                2727	3_0_0	EXIST::FUNCTION:
-DES_string_to_2keys                     2728	3_0_0	EXIST::FUNCTION:DES
+DES_string_to_2keys                     2728	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_PKEY_copy_parameters                2729	3_0_0	EXIST::FUNCTION:
 CMS_ContentInfo_print_ctx               2730	3_0_0	EXIST::FUNCTION:CMS
 d2i_PKCS7_SIGNED                        2731	3_0_0	EXIST::FUNCTION:
@@ -2732,7 +2732,7 @@ SHA512_Final                            2790	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_set1_host             2791	3_0_0	EXIST::FUNCTION:
 OCSP_resp_find_status                   2792	3_0_0	EXIST::FUNCTION:OCSP
 d2i_ASN1_T61STRING                      2793	3_0_0	EXIST::FUNCTION:
-DES_pcbc_encrypt                        2794	3_0_0	EXIST::FUNCTION:DES
+DES_pcbc_encrypt                        2794	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_PKEY_print_params                   2795	3_0_0	EXIST::FUNCTION:
 BN_get0_nist_prime_192                  2796	3_0_0	EXIST::FUNCTION:
 EVP_SealInit                            2798	3_0_0	EXIST::FUNCTION:RSA
@@ -2754,7 +2754,7 @@ i2b_PVK_bio                             2813	3_0_0	EXIST::FUNCTION:DSA,RC4
 OCSP_ONEREQ_free                        2814	3_0_0	EXIST::FUNCTION:OCSP
 X509V3_EXT_print_fp                     2815	3_0_0	EXIST::FUNCTION:STDIO
 OBJ_bsearch_ex_                         2816	3_0_0	EXIST::FUNCTION:
-DES_ofb64_encrypt                       2817	3_0_0	EXIST::FUNCTION:DES
+DES_ofb64_encrypt                       2817	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 i2d_IPAddressOrRange                    2818	3_0_0	EXIST::FUNCTION:RFC3779
 CRYPTO_secure_used                      2819	3_0_0	EXIST::FUNCTION:
 d2i_X509_CRL_INFO                       2820	3_0_0	EXIST::FUNCTION:
@@ -2817,7 +2817,7 @@ SCT_set0_signature                      2878	3_0_0	EXIST::FUNCTION:CT
 X509_CRL_sign                           2879	3_0_0	EXIST::FUNCTION:
 X509_CINF_it                            2880	3_0_0	EXIST::FUNCTION:
 TS_CONF_set_accuracy                    2881	3_0_0	EXIST::FUNCTION:TS
-DES_crypt                               2882	3_0_0	EXIST::FUNCTION:DES
+DES_crypt                               2882	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 BN_BLINDING_create_param                2883	3_0_0	EXIST::FUNCTION:
 OCSP_SERVICELOC_free                    2884	3_0_0	EXIST::FUNCTION:OCSP
 DIST_POINT_NAME_free                    2885	3_0_0	EXIST::FUNCTION:
@@ -2861,7 +2861,7 @@ i2d_X509_REQ_INFO                       2922	3_0_0	EXIST::FUNCTION:
 EVP_des_cfb1                            2923	3_0_0	EXIST::FUNCTION:DES
 OBJ_NAME_cleanup                        2924	3_0_0	EXIST::FUNCTION:
 OCSP_BASICRESP_get1_ext_d2i             2925	3_0_0	EXIST::FUNCTION:OCSP
-DES_cfb64_encrypt                       2926	3_0_0	EXIST::FUNCTION:DES
+DES_cfb64_encrypt                       2926	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 CAST_cfb64_encrypt                      2927	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 EVP_PKEY_asn1_set_param                 2928	3_0_0	EXIST::FUNCTION:
 BN_RECP_CTX_free                        2929	3_0_0	EXIST::FUNCTION:
@@ -2946,7 +2946,7 @@ EVP_PKEY_meth_get0_info                 3008	3_0_0	EXIST::FUNCTION:
 PEM_read_bio_RSAPublicKey               3009	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_asn1_set_private               3010	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_RSA                       3011	3_0_0	EXIST::FUNCTION:RSA
-DES_ede3_cfb64_encrypt                  3012	3_0_0	EXIST::FUNCTION:DES
+DES_ede3_cfb64_encrypt                  3012	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 POLICY_MAPPING_free                     3014	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_gcm                         3015	3_0_0	EXIST::FUNCTION:
 BIO_dgram_non_fatal_error               3016	3_0_0	EXIST::FUNCTION:DGRAM
@@ -3403,7 +3403,7 @@ RIPEMD160_Init                          3473	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 ASYNC_WAIT_CTX_get_changed_fds          3474	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_save_parameters                3475	3_0_0	EXIST::FUNCTION:
 SCT_set_source                          3476	3_0_0	EXIST::FUNCTION:CT
-DES_set_odd_parity                      3477	3_0_0	EXIST::FUNCTION:DES
+DES_set_odd_parity                      3477	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 CMAC_CTX_free                           3478	3_0_0	EXIST::FUNCTION:CMAC
 d2i_ESS_ISSUER_SERIAL                   3479	3_0_0	EXIST::FUNCTION:
 HMAC_CTX_set_flags                      3480	3_0_0	EXIST::FUNCTION:
@@ -3519,7 +3519,7 @@ X509_REQ_it                             3595	3_0_0	EXIST::FUNCTION:
 RAND_bytes                              3596	3_0_0	EXIST::FUNCTION:
 PKCS7_free                              3597	3_0_0	EXIST::FUNCTION:
 X509_NAME_ENTRY_create_by_txt           3598	3_0_0	EXIST::FUNCTION:
-DES_cbc_cksum                           3599	3_0_0	EXIST::FUNCTION:DES
+DES_cbc_cksum                           3599	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 UI_free                                 3600	3_0_0	EXIST::FUNCTION:
 BN_is_prime                             3601	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_0_9_8
 CMS_get0_signers                        3602	3_0_0	EXIST::FUNCTION:CMS
@@ -3591,7 +3591,7 @@ EC_POINT_invert                         3670	3_0_0	EXIST::FUNCTION:EC
 CAST_set_key                            3671	3_0_0	EXIST::FUNCTION:CAST,DEPRECATEDIN_3_0
 ENGINE_get_pkey_meth                    3672	3_0_0	EXIST::FUNCTION:ENGINE
 BIO_ADDRINFO_free                       3673	3_0_0	EXIST::FUNCTION:SOCK
-DES_ede3_cbc_encrypt                    3674	3_0_0	EXIST::FUNCTION:DES
+DES_ede3_cbc_encrypt                    3674	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 X509v3_asid_canonize                    3675	3_0_0	EXIST::FUNCTION:RFC3779
 i2d_ASIdOrRange                         3676	3_0_0	EXIST::FUNCTION:RFC3779
 OCSP_url_svcloc_new                     3677	3_0_0	EXIST::FUNCTION:OCSP
@@ -3644,7 +3644,7 @@ CMAC_CTX_cleanup                        3723	3_0_0	EXIST::FUNCTION:CMAC
 i2d_PKCS7_NDEF                          3724	3_0_0	EXIST::FUNCTION:
 OPENSSL_sk_pop_free                     3725	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_get0_policy_tree         3726	3_0_0	EXIST::FUNCTION:
-DES_set_key_checked                     3727	3_0_0	EXIST::FUNCTION:DES
+DES_set_key_checked                     3727	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 EVP_PKEY_meth_free                      3728	3_0_0	EXIST::FUNCTION:
 EVP_sha224                              3729	3_0_0	EXIST::FUNCTION:
 ENGINE_set_id                           3730	3_0_0	EXIST::FUNCTION:ENGINE
@@ -3665,7 +3665,7 @@ EVP_PBE_scrypt                          3744	3_0_0	EXIST::FUNCTION:SCRYPT
 d2i_TS_REQ_bio                          3745	3_0_0	EXIST::FUNCTION:TS
 ENGINE_set_default_ciphers              3746	3_0_0	EXIST::FUNCTION:ENGINE
 X509_get_signature_nid                  3747	3_0_0	EXIST::FUNCTION:
-DES_fcrypt                              3748	3_0_0	EXIST::FUNCTION:DES
+DES_fcrypt                              3748	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 PEM_write_bio_X509_REQ                  3749	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_sign                  3750	3_0_0	EXIST::FUNCTION:
 TS_REQ_get_nonce                        3751	3_0_0	EXIST::FUNCTION:TS
@@ -3745,7 +3745,7 @@ ECDSA_sign_setup                        3826	3_0_0	EXIST::FUNCTION:EC
 EVP_camellia_192_cfb128                 3827	3_0_0	EXIST::FUNCTION:CAMELLIA
 d2i_AUTHORITY_KEYID                     3828	3_0_0	EXIST::FUNCTION:
 RIPEMD160_Transform                     3829	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160
-DES_random_key                          3830	3_0_0	EXIST::FUNCTION:DES
+DES_random_key                          3830	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 i2d_PKCS12_MAC_DATA                     3831	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_EC_KEY                    3832	3_0_0	EXIST::FUNCTION:EC
 ASN1_SCTX_get_item                      3833	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use of the low level DES functions has been informally discouraged for a
long time. We now formally deprecate them.  Applications should instead use the EVP APIs, e.g. `EVP_EncryptInit_ex`, `EVP_EncryptUpdate`, `EVP_EncryptFinal_ex`, and the equivalently named decrypt functions.

- [x] documentation is added or updated
- [x] tests are added or updated
