### PR TITLE
Fix init_thread_stop

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -297,7 +297,7 @@ void ossl_ctx_thread_stop(void *arg)
 
 static void init_thread_stop(void *arg, THREAD_EVENT_HANDLER **hands)
 {
-    THREAD_EVENT_HANDLER *curr, *prev = NULL;
+    THREAD_EVENT_HANDLER *curr, *prev = NULL, *tmp;
 
     /* Can't do much about this */
     if (hands == NULL)
@@ -306,15 +306,20 @@ static void init_thread_stop(void *arg, THREAD_EVENT_HANDLER **hands)
     curr = *hands;
     while (curr != NULL) {
         if (arg != NULL && curr->arg != arg) {
+            prev = curr;
             curr = curr->next;
             continue;
         }
         curr->handfn(curr->arg);
-        prev = curr;
+        if (prev == NULL)
+            *hands = curr->next;
+        else
+            prev->next = curr->next;
+
+        tmp = curr;
         curr = curr->next;
-        if (prev == *hands)
-            *hands = curr;
-        OPENSSL_free(prev);
+
+        OPENSSL_free(tmp);
     }
 }
 


### PR DESCRIPTION
init_thread_stop maintains a linked lists of handlers that it should
call when a thread finishes. The linked list handling wasn't quite right
resulting in corrupted data.