### PR TITLE
Introduce SSL_CTX_new_ex()

### DIFF
--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 TLSv1_2_method, TLSv1_2_server_method, TLSv1_2_client_method,
-SSL_CTX_new, SSL_CTX_new_from_ctx, SSL_CTX_up_ref, SSLv3_method,
+SSL_CTX_new, SSL_CTX_new_with_libctx, SSL_CTX_up_ref, SSLv3_method,
 SSLv3_server_method, SSLv3_client_method, TLSv1_method, TLSv1_server_method,
 TLSv1_client_method, TLSv1_1_method, TLSv1_1_server_method,
 TLSv1_1_client_method, TLS_method, TLS_server_method, TLS_client_method,
@@ -18,8 +18,8 @@ functions
 
  #include <openssl/ssl.h>
 
- SSL_CTX *SSL_CTX_new_from_ctx(OPENSSL_CTX *libctx, const char *propq,
-                               const SSL_METHOD *method);
+ SSL_CTX *SSL_CTX_new_with_libctx(OPENSSL_CTX *libctx, const char *propq,
+                                  const SSL_METHOD *method);
  SSL_CTX *SSL_CTX_new(const SSL_METHOD *method);
  int SSL_CTX_up_ref(SSL_CTX *ctx);
 
@@ -73,7 +73,7 @@ functions
 
 =head1 DESCRIPTION
 
-SSL_CTX_new_from_ctx() creates a new B<SSL_CTX> object as a framework to
+SSL_CTX_new_with_libctx() creates a new B<SSL_CTX> object as a framework to
 establish TLS/SSL or DTLS enabled connections using the library context
 I<libctx> (see L<OPENSSL_CTX(3)>). Any cryptographic algorithms that are used
 by any B<SSL> objects created from this B<SSL_CTX> will be fetched from the
@@ -81,7 +81,7 @@ I<libctx> using the property query string I<propq> (see
 L<provider(7)/Fetching algorithms>. Either or both the I<libctx> or I<propq>
 parameters may be NULL.
 
-SSL_CTX_new() does the same as SSL_CTX_new_from_ctx() except that the default
+SSL_CTX_new() does the same as SSL_CTX_new_with_libctx() except that the default
 library context is used and no property query string is specified.
 
 An B<SSL_CTX> object is reference counted. Creating an B<SSL_CTX> object for the
@@ -224,7 +224,7 @@ and TLS_client_method() functions were added in OpenSSL 1.1.0.
 
 All version-specific methods were deprecated in OpenSSL 1.1.0.
 
-SSL_CTX_new_from_ctx() was added in OpenSSL 3.0.
+SSL_CTX_new_with_libctx() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -3,13 +3,14 @@
 =head1 NAME
 
 TLSv1_2_method, TLSv1_2_server_method, TLSv1_2_client_method,
-SSL_CTX_new, SSL_CTX_new_ex, SSL_CTX_up_ref, SSLv3_method, SSLv3_server_method,
-SSLv3_client_method, TLSv1_method, TLSv1_server_method, TLSv1_client_method,
-TLSv1_1_method, TLSv1_1_server_method, TLSv1_1_client_method, TLS_method,
-TLS_server_method, TLS_client_method, SSLv23_method, SSLv23_server_method,
-SSLv23_client_method, DTLS_method, DTLS_server_method, DTLS_client_method,
-DTLSv1_method, DTLSv1_server_method, DTLSv1_client_method,
-DTLSv1_2_method, DTLSv1_2_server_method, DTLSv1_2_client_method
+SSL_CTX_new, SSL_CTX_new_from_ctx, SSL_CTX_up_ref, SSLv3_method,
+SSLv3_server_method, SSLv3_client_method, TLSv1_method, TLSv1_server_method,
+TLSv1_client_method, TLSv1_1_method, TLSv1_1_server_method,
+TLSv1_1_client_method, TLS_method, TLS_server_method, TLS_client_method,
+SSLv23_method, SSLv23_server_method, SSLv23_client_method, DTLS_method,
+DTLS_server_method, DTLS_client_method, DTLSv1_method, DTLSv1_server_method,
+DTLSv1_client_method, DTLSv1_2_method, DTLSv1_2_server_method,
+DTLSv1_2_client_method
 - create a new SSL_CTX object as framework for TLS/SSL or DTLS enabled
 functions
 
@@ -17,8 +18,8 @@ functions
 
  #include <openssl/ssl.h>
 
- SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
-                         const SSL_METHOD *method);
+ SSL_CTX *SSL_CTX_new_from_ctx(OPENSSL_CTX *libctx, const char *propq,
+                               const SSL_METHOD *method);
  SSL_CTX *SSL_CTX_new(const SSL_METHOD *method);
  int SSL_CTX_up_ref(SSL_CTX *ctx);
 
@@ -72,22 +73,22 @@ functions
 
 =head1 DESCRIPTION
 
-SSL_CTX_new_ex() creates a new B<SSL_CTX> object as a framework to
+SSL_CTX_new_from_ctx() creates a new B<SSL_CTX> object as a framework to
 establish TLS/SSL or DTLS enabled connections using the library context
 I<libctx> (see L<OPENSSL_CTX(3)>). Any cryptographic algorithms that are used
-by any SSL objects will be fetched from the I<libctx> using the property query
-string I<propq> (see L<provider(7)/Fetching algorithms>. Either the I<libctx>
-or I<propq> parameters may be NULL. Note that the I<propq> value is not
-duplicated and is assumed to exist for the lifetime of the SSL_CTX object.
+by any B<SSL> objects created from this B<SSL_CTX> will be fetched from the
+I<libctx> using the property query string I<propq> (see
+L<provider(7)/Fetching algorithms>. Either or both the I<libctx> or I<propq>
+parameters may be NULL.
 
-SSL_CTX_new() does the same as SSL_CTX_new_ex() except that the default library
-context is used and no property query string is specified.
+SSL_CTX_new() does the same as SSL_CTX_new_from_ctx() except that the default
+library context is used and no property query string is specified.
 
 An B<SSL_CTX> object is reference counted. Creating an B<SSL_CTX> object for the
-first time increments the reference count. Freeing it (using SSL_CTX_free)
-decrements it. When the reference count drops to zero, any memory or resources
-allocated to the B<SSL_CTX> object are freed. SSL_CTX_up_ref() increments the
-reference count for an existing B<SSL_CTX> structure.
+first time increments the reference count. Freeing the B<SSL_CTX> (using
+SSL_CTX_free) decrements it. When the reference count drops to zero, any memory
+or resources allocated to the B<SSL_CTX> object are freed. SSL_CTX_up_ref()
+increments the reference count for an existing B<SSL_CTX> structure.
 
 =head1 NOTES
 
@@ -223,7 +224,7 @@ and TLS_client_method() functions were added in OpenSSL 1.1.0.
 
 All version-specific methods were deprecated in OpenSSL 1.1.0.
 
-SSL_CTX_new_ex() was added in OpenSSL 3.0.
+SSL_CTX_new_from_ctx() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 TLSv1_2_method, TLSv1_2_server_method, TLSv1_2_client_method,
-SSL_CTX_new, SSL_CTX_up_ref, SSLv3_method, SSLv3_server_method,
+SSL_CTX_new, SSL_CTX_new_ex, SSL_CTX_up_ref, SSLv3_method, SSLv3_server_method,
 SSLv3_client_method, TLSv1_method, TLSv1_server_method, TLSv1_client_method,
 TLSv1_1_method, TLSv1_1_server_method, TLSv1_1_client_method, TLS_method,
 TLS_server_method, TLS_client_method, SSLv23_method, SSLv23_server_method,
@@ -17,6 +17,8 @@ functions
 
  #include <openssl/ssl.h>
 
+ SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
+                         const SSL_METHOD *method);
  SSL_CTX *SSL_CTX_new(const SSL_METHOD *method);
  int SSL_CTX_up_ref(SSL_CTX *ctx);
 
@@ -70,20 +72,29 @@ functions
 
 =head1 DESCRIPTION
 
-SSL_CTX_new() creates a new B<SSL_CTX> object as framework to
-establish TLS/SSL or DTLS enabled connections. An B<SSL_CTX> object is
-reference counted. Creating an B<SSL_CTX> object for the first time increments
-the reference count. Freeing it (using SSL_CTX_free) decrements it. When the
-reference count drops to zero, any memory or resources allocated to the
-B<SSL_CTX> object are freed. SSL_CTX_up_ref() increments the reference count for
-an existing B<SSL_CTX> structure.
+SSL_CTX_new_ex() creates a new B<SSL_CTX> object as a framework to
+establish TLS/SSL or DTLS enabled connections using the library context
+I<libctx> (see L<OPENSSL_CTX(3)>). Any cryptographic algorithms that are used
+by any SSL objects will be fetched from the I<libctx> using the property query
+string I<propq> (see L<provider(7)/Fetching algorithms>. Either the I<libctx>
+or I<propq> parameters may be NULL. Note that the I<propq> value is not
+duplicated and is assumed to exist for the lifetime of the SSL_CTX object.
+
+SSL_CTX_new() does the same as SSL_CTX_new_ex() except that the default library
+context is used and no property query string is specified.
+
+An B<SSL_CTX> object is reference counted. Creating an B<SSL_CTX> object for the
+first time increments the reference count. Freeing it (using SSL_CTX_free)
+decrements it. When the reference count drops to zero, any memory or resources
+allocated to the B<SSL_CTX> object are freed. SSL_CTX_up_ref() increments the
+reference count for an existing B<SSL_CTX> structure.
 
 =head1 NOTES
 
-The SSL_CTX object uses B<method> as connection method.
+The SSL_CTX object uses I<method> as the connection method.
 The methods exist in a generic type (for client and server use), a server only
 type, and a client only type.
-B<method> can be of the following types:
+B<method> can be one of the following types:
 
 =over 4
 
@@ -211,6 +222,8 @@ were deprecated and the preferred TLS_method(), TLS_server_method()
 and TLS_client_method() functions were added in OpenSSL 1.1.0.
 
 All version-specific methods were deprecated in OpenSSL 1.1.0.
+
+SSL_CTX_new_ex() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1524,6 +1524,8 @@ void BIO_ssl_shutdown(BIO *ssl_bio);
 
 __owur int SSL_CTX_set_cipher_list(SSL_CTX *, const char *str);
 __owur SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);
+__owur SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
+                               const SSL_METHOD *meth);
 int SSL_CTX_up_ref(SSL_CTX *ctx);
 void SSL_CTX_free(SSL_CTX *);
 __owur long SSL_CTX_set_timeout(SSL_CTX *ctx, long t);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1524,8 +1524,8 @@ void BIO_ssl_shutdown(BIO *ssl_bio);
 
 __owur int SSL_CTX_set_cipher_list(SSL_CTX *, const char *str);
 __owur SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);
-__owur SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
-                               const SSL_METHOD *meth);
+__owur SSL_CTX *SSL_CTX_new_from_ctx(OPENSSL_CTX *libctx, const char *propq,
+                                     const SSL_METHOD *meth);
 int SSL_CTX_up_ref(SSL_CTX *ctx);
 void SSL_CTX_free(SSL_CTX *);
 __owur long SSL_CTX_set_timeout(SSL_CTX *ctx, long t);

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1524,8 +1524,8 @@ void BIO_ssl_shutdown(BIO *ssl_bio);
 
 __owur int SSL_CTX_set_cipher_list(SSL_CTX *, const char *str);
 __owur SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);
-__owur SSL_CTX *SSL_CTX_new_from_ctx(OPENSSL_CTX *libctx, const char *propq,
-                                     const SSL_METHOD *meth);
+__owur SSL_CTX *SSL_CTX_new_with_libctx(OPENSSL_CTX *libctx, const char *propq,
+                                        const SSL_METHOD *meth);
 int SSL_CTX_up_ref(SSL_CTX *ctx);
 void SSL_CTX_free(SSL_CTX *);
 __owur long SSL_CTX_set_timeout(SSL_CTX *ctx, long t);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3032,8 +3032,8 @@ static int ssl_session_cmp(const SSL_SESSION *a, const SSL_SESSION *b)
  * via ssl.h.
  */
 
-SSL_CTX *SSL_CTX_new_from_ctx(OPENSSL_CTX *libctx, const char *propq,
-                              const SSL_METHOD *meth)
+SSL_CTX *SSL_CTX_new_with_libctx(OPENSSL_CTX *libctx, const char *propq,
+                                 const SSL_METHOD *meth)
 {
     SSL_CTX *ret = NULL;
 
@@ -3231,7 +3231,7 @@ SSL_CTX *SSL_CTX_new_from_ctx(OPENSSL_CTX *libctx, const char *propq,
 
 SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
 {
-    return SSL_CTX_new_from_ctx(NULL, NULL, meth);
+    return SSL_CTX_new_with_libctx(NULL, NULL, meth);
 }
 
 int SSL_CTX_up_ref(SSL_CTX *ctx)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3032,12 +3032,13 @@ static int ssl_session_cmp(const SSL_SESSION *a, const SSL_SESSION *b)
  * via ssl.h.
  */
 
-SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
+SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
+                        const SSL_METHOD *meth)
 {
     SSL_CTX *ret = NULL;
 
     if (meth == NULL) {
-        SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_NULL_SSL_METHOD_PASSED);
+        SSLerr(0, SSL_R_NULL_SSL_METHOD_PASSED);
         return NULL;
     }
 
@@ -3045,12 +3046,15 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         return NULL;
 
     if (SSL_get_ex_data_X509_STORE_CTX_idx() < 0) {
-        SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_X509_VERIFICATION_SETUP_PROBLEMS);
+        SSLerr(0, SSL_R_X509_VERIFICATION_SETUP_PROBLEMS);
         goto err;
     }
     ret = OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL)
         goto err;
+
+    ret->libctx = libctx;
+    ret->propq = propq;
 
     ret->method = meth;
     ret->min_proto_version = 0;
@@ -3063,7 +3067,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
     ret->references = 1;
     ret->lock = CRYPTO_THREAD_lock_new();
     if (ret->lock == NULL) {
-        SSLerr(SSL_F_SSL_CTX_NEW, ERR_R_MALLOC_FAILURE);
+        SSLerr(0, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(ret);
         return NULL;
     }
@@ -3092,7 +3096,7 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
                                 &ret->cipher_list, &ret->cipher_list_by_id,
                                 OSSL_default_cipher_list(), ret->cert)
         || sk_SSL_CIPHER_num(ret->cipher_list) <= 0) {
-        SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_LIBRARY_HAS_NO_CIPHERS);
+        SSLerr(0, SSL_R_LIBRARY_HAS_NO_CIPHERS);
         goto err2;
     }
 
@@ -3101,11 +3105,11 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
         goto err;
 
     if ((ret->md5 = EVP_get_digestbyname("ssl3-md5")) == NULL) {
-        SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_UNABLE_TO_LOAD_SSL3_MD5_ROUTINES);
+        SSLerr(0, SSL_R_UNABLE_TO_LOAD_SSL3_MD5_ROUTINES);
         goto err2;
     }
     if ((ret->sha1 = EVP_get_digestbyname("ssl3-sha1")) == NULL) {
-        SSLerr(SSL_F_SSL_CTX_NEW, SSL_R_UNABLE_TO_LOAD_SSL3_SHA1_ROUTINES);
+        SSLerr(0, SSL_R_UNABLE_TO_LOAD_SSL3_SHA1_ROUTINES);
         goto err2;
     }
 
@@ -3215,10 +3219,15 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
 
     return ret;
  err:
-    SSLerr(SSL_F_SSL_CTX_NEW, ERR_R_MALLOC_FAILURE);
+    SSLerr(0, ERR_R_MALLOC_FAILURE);
  err2:
     SSL_CTX_free(ret);
     return NULL;
+}
+
+SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
+{
+    return SSL_CTX_new_ex(NULL, NULL, meth);
 }
 
 int SSL_CTX_up_ref(SSL_CTX *ctx)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -738,6 +738,8 @@ typedef struct ssl_ctx_ext_secure_st {
 } SSL_CTX_EXT_SECURE;
 
 struct ssl_ctx_st {
+    OPENSSL_CTX *libctx;
+
     const SSL_METHOD *method;
     STACK_OF(SSL_CIPHER) *cipher_list;
     /* same as above but sorted for lookup */
@@ -1073,6 +1075,8 @@ struct ssl_ctx_st {
     /* Callback for SSL async handling */
     SSL_async_callback_fn async_cb;
     void *async_cb_arg;
+
+    const char *propq;
 };
 
 typedef struct cert_pkey_st CERT_PKEY;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1076,7 +1076,7 @@ struct ssl_ctx_st {
     SSL_async_callback_fn async_cb;
     void *async_cb_arg;
 
-    const char *propq;
+    char *propq;
 };
 
 typedef struct cert_pkey_st CERT_PKEY;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -511,3 +511,4 @@ SSL_CTX_set_default_verify_store        ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_file                ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_dir                 ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_store               ?	3_0_0	EXIST::FUNCTION:
+SSL_CTX_new_ex                          ?	3_0_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -511,4 +511,4 @@ SSL_CTX_set_default_verify_store        ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_file                ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_dir                 ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_store               ?	3_0_0	EXIST::FUNCTION:
-SSL_CTX_new_ex                          ?	3_0_0	EXIST::FUNCTION:
+SSL_CTX_new_from_ctx                    ?	3_0_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -511,4 +511,4 @@ SSL_CTX_set_default_verify_store        ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_file                ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_dir                 ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_load_verify_store               ?	3_0_0	EXIST::FUNCTION:
-SSL_CTX_new_from_ctx                    ?	3_0_0	EXIST::FUNCTION:
+SSL_CTX_new_with_libctx                 ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add the ability to specify an OPENSSL_CTX (which may be NULL for the
default context) and a property query string for use during algorithm
fetch operations.

For example, in this way one SSL_CTX could be used the default provider,
and another one could be used with the FIPS provider.

At this stage we don't use these values. That will come later. For the same reason there is no test (it doesn't do anything yet, so nothing to test).

See #10854 for the big picture of where this is heading.