### PR TITLE
Configure: Better detection of '-static' in @{$config{LDFLAGS}}

### DIFF
--- a/Configure
+++ b/Configure
@@ -1513,7 +1513,7 @@ if ($strict_warnings)
                 }
         }
 
-if (grep { $_ eq '-static' } @{$config{LDFLAGS}}) {
+if (grep { $_ =~ /(?:^|\s)-static(?:\s|$)/ } @{$config{LDFLAGS}}) {
     disable('static', 'pic', 'threads');
 }
 


### PR DESCRIPTION
`@{$config{LDFLAGS}}` isn't necessarily split up in pieces, so we need
to check for '-static' with a regexp rather than with an exact string
match.

Fixes #10867
