### PR TITLE
Do not silently truncate files on perlasm errors

### DIFF
--- a/crypto/aes/asm/aes-586.pl
+++ b/crypto/aes/asm/aes-586.pl
@@ -2995,4 +2995,4 @@ sub deckey()
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aes-armv4.pl
+++ b/crypto/aes/asm/aes-armv4.pl
@@ -1245,4 +1245,4 @@ while(<SELF>) {
 close SELF;
 
 print $code;
-close STDOUT;	# enforce flush
+close STDOUT or die "error closing STDOUT";	# enforce flush

--- a/crypto/aes/asm/aes-c64xplus.pl
+++ b/crypto/aes/asm/aes-c64xplus.pl
@@ -1378,4 +1378,4 @@ AES_Td4:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aes-mips.pl
+++ b/crypto/aes/asm/aes-mips.pl
@@ -2203,4 +2203,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aes-parisc.pl
+++ b/crypto/aes/asm/aes-parisc.pl
@@ -1038,4 +1038,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aes-ppc.pl
+++ b/crypto/aes/asm/aes-ppc.pl
@@ -1460,4 +1460,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aes-s390x.pl
+++ b/crypto/aes/asm/aes-s390x.pl
@@ -2281,4 +2281,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;	# force flush
+close STDOUT or die "error closing STDOUT";	# force flush

--- a/crypto/aes/asm/aes-sparcv9.pl
+++ b/crypto/aes/asm/aes-sparcv9.pl
@@ -1188,4 +1188,4 @@ ___
 $code =~ s/fmovs.*$//gm;
 
 print $code;
-close STDOUT;	# ensure flush
+close STDOUT or die "error closing STDOUT";	# ensure flush

--- a/crypto/aes/asm/aes-x86_64.pl
+++ b/crypto/aes/asm/aes-x86_64.pl
@@ -2919,4 +2919,4 @@ $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesfx-sparcv9.pl
+++ b/crypto/aes/asm/aesfx-sparcv9.pl
@@ -1266,4 +1266,4 @@ foreach (split("\n",$code)) {
     print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesni-mb-x86_64.pl
+++ b/crypto/aes/asm/aesni-mb-x86_64.pl
@@ -1473,4 +1473,4 @@ $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 $code =~ s/\b(aes.*%xmm[0-9]+).*$/aesni($1)/gem;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -2145,4 +2145,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesni-sha256-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha256-x86_64.pl
@@ -1801,4 +1801,4 @@ sub rex {
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 $code =~ s/\b(sha256[^\s]*)\s+(.*)/sha256op38($1,$2)/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesni-x86.pl
+++ b/crypto/aes/asm/aesni-x86.pl
@@ -3410,4 +3410,4 @@ my ($l_,$block,$i1,$i3,$i5) = ($rounds_,$key_,$rounds,$len,$out);
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesni-x86_64.pl
+++ b/crypto/aes/asm/aesni-x86_64.pl
@@ -5156,4 +5156,4 @@ $code =~ s/\bmovbe\s+%eax,\s*([0-9]+)\(%rsp\)/movbe($1)/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesp8-ppc.pl
+++ b/crypto/aes/asm/aesp8-ppc.pl
@@ -3808,4 +3808,4 @@ foreach(split("\n",$code)) {
         print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aest4-sparcv9.pl
+++ b/crypto/aes/asm/aest4-sparcv9.pl
@@ -925,4 +925,4 @@ ___
 
 &emit_assembler();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -2237,4 +2237,4 @@ if ($flavour =~ /64/) {			######## 64-bit code
     }
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/bsaes-armv7.pl
+++ b/crypto/aes/asm/bsaes-armv7.pl
@@ -2491,4 +2491,4 @@ close SELF;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/bsaes-x86_64.pl
+++ b/crypto/aes/asm/bsaes-x86_64.pl
@@ -3238,4 +3238,4 @@ $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/vpaes-armv8.pl
+++ b/crypto/aes/asm/vpaes-armv8.pl
@@ -1278,4 +1278,4 @@ ___
 }	}
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/vpaes-ppc.pl
+++ b/crypto/aes/asm/vpaes-ppc.pl
@@ -1595,4 +1595,4 @@ foreach  (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/vpaes-x86.pl
+++ b/crypto/aes/asm/vpaes-x86.pl
@@ -911,4 +911,4 @@ $k_dsbo=0x2c0;		# decryption sbox final output
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/aes/asm/vpaes-x86_64.pl
+++ b/crypto/aes/asm/vpaes-x86_64.pl
@@ -1240,4 +1240,4 @@ $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/alphacpuid.pl
+++ b/crypto/alphacpuid.pl
@@ -253,4 +253,4 @@ OPENSSL_instrument_bus2:
 ___
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/arm64cpuid.pl
+++ b/crypto/arm64cpuid.pl
@@ -147,4 +147,4 @@ CRYPTO_memcmp:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/armv4cpuid.pl
+++ b/crypto/armv4cpuid.pl
@@ -297,4 +297,4 @@ atomic_add_spinlock:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bf/asm/bf-586.pl
+++ b/crypto/bf/asm/bf-586.pl
@@ -31,7 +31,7 @@ $tmp4="edx";
 &cbc("BF_cbc_encrypt","BF_encrypt","BF_decrypt",1,4,5,3,-1,-1);
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub BF_encrypt
 	{

--- a/crypto/bn/asm/alpha-mont.pl
+++ b/crypto/bn/asm/alpha-mont.pl
@@ -324,4 +324,4 @@ bn_mul_mont:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/armv4-gf2m.pl
+++ b/crypto/bn/asm/armv4-gf2m.pl
@@ -338,4 +338,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;   # enforce flush
+close STDOUT or die "error closing STDOUT";   # enforce flush

--- a/crypto/bn/asm/armv4-mont.pl
+++ b/crypto/bn/asm/armv4-mont.pl
@@ -763,4 +763,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/armv8-mont.pl
+++ b/crypto/bn/asm/armv8-mont.pl
@@ -1514,4 +1514,4 @@ ___
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/bn-586.pl
+++ b/crypto/bn/asm/bn-586.pl
@@ -30,7 +30,7 @@ for (@ARGV) { $sse2=1 if (/-DOPENSSL_IA32_SSE2/); }
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub bn_mul_add_words
 	{

--- a/crypto/bn/asm/c64xplus-gf2m.pl
+++ b/crypto/bn/asm/c64xplus-gf2m.pl
@@ -156,4 +156,4 @@ $code.=<<___;
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/co-586.pl
+++ b/crypto/bn/asm/co-586.pl
@@ -21,7 +21,7 @@ $output = pop and open STDOUT,">$output";
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub mul_add_c
 	{

--- a/crypto/bn/asm/ia64-mont.pl
+++ b/crypto/bn/asm/ia64-mont.pl
@@ -858,4 +858,4 @@ ___
 
 open STDOUT,">$output" if $output;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/mips-mont.pl
+++ b/crypto/bn/asm/mips-mont.pl
@@ -433,4 +433,4 @@ ___
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/mips.pl
+++ b/crypto/bn/asm/mips.pl
@@ -2262,4 +2262,4 @@ $code.=<<___;
 .end	bn_sqr_comba4
 ___
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/parisc-mont.pl
+++ b/crypto/bn/asm/parisc-mont.pl
@@ -1005,4 +1005,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/ppc-mont.pl
+++ b/crypto/bn/asm/ppc-mont.pl
@@ -1991,4 +1991,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/ppc.pl
+++ b/crypto/bn/asm/ppc.pl
@@ -2013,4 +2013,4 @@ Lppcasm_maw_adios:
 EOF
 $data =~ s/\`([^\`]*)\`/eval $1/gem;
 print $data;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/ppc64-mont.pl
+++ b/crypto/bn/asm/ppc64-mont.pl
@@ -1653,4 +1653,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/rsaz-avx2.pl
+++ b/crypto/bn/asm/rsaz-avx2.pl
@@ -1981,4 +1981,4 @@ rsaz_1024_gather5_avx2:
 ___
 }}}
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/rsaz-x86_64.pl
+++ b/crypto/bn/asm/rsaz-x86_64.pl
@@ -2430,4 +2430,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/s390x-gf2m.pl
+++ b/crypto/bn/asm/s390x-gf2m.pl
@@ -227,4 +227,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/s390x-mont.pl
+++ b/crypto/bn/asm/s390x-mont.pl
@@ -283,4 +283,4 @@ foreach (split("\n",$code)) {
 	s/_dswap\s+(%r[0-9]+)/sprintf("rllg\t%s,%s,32",$1,$1) if($SIZE_T==4)/e;
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/sparct4-mont.pl
+++ b/crypto/bn/asm/sparct4-mont.pl
@@ -1224,4 +1224,4 @@ ___
 
 &emit_assembler();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/sparcv9-gf2m.pl
+++ b/crypto/bn/asm/sparcv9-gf2m.pl
@@ -196,4 +196,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/sparcv9-mont.pl
+++ b/crypto/bn/asm/sparcv9-mont.pl
@@ -616,4 +616,4 @@ $code.=<<___;
 ___
 $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/sparcv9a-mont.pl
+++ b/crypto/bn/asm/sparcv9a-mont.pl
@@ -886,4 +886,4 @@ $code =~ s/fzeros\s+%f([0-9]+)/
 
 print $code;
 # flush
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/via-mont.pl
+++ b/crypto/bn/asm/via-mont.pl
@@ -247,4 +247,4 @@ $sp=&DWP(28,"esp");
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/vis3-mont.pl
+++ b/crypto/bn/asm/vis3-mont.pl
@@ -380,4 +380,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/x86-gf2m.pl
+++ b/crypto/bn/asm/x86-gf2m.pl
@@ -321,4 +321,4 @@ if ($sse2) {
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/x86-mont.pl
+++ b/crypto/bn/asm/x86-mont.pl
@@ -627,4 +627,4 @@ $sbit=$num;
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/x86_64-gf2m.pl
+++ b/crypto/bn/asm/x86_64-gf2m.pl
@@ -423,4 +423,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/x86_64-mont.pl
+++ b/crypto/bn/asm/x86_64-mont.pl
@@ -1591,4 +1591,4 @@ ___
 }
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/bn/asm/x86_64-mont5.pl
+++ b/crypto/bn/asm/x86_64-mont5.pl
@@ -3962,4 +3962,4 @@ ___
 $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/c64xpluscpuid.pl
+++ b/crypto/c64xpluscpuid.pl
@@ -284,4 +284,4 @@ bus_loop2_done?:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/camellia/asm/cmll-x86.pl
+++ b/crypto/camellia/asm/cmll-x86.pl
@@ -1146,4 +1146,4 @@ my ($s0,$s1,$s2,$s3) = @T;
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/camellia/asm/cmll-x86_64.pl
+++ b/crypto/camellia/asm/cmll-x86_64.pl
@@ -1152,4 +1152,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/camellia/asm/cmllt4-sparcv9.pl
+++ b/crypto/camellia/asm/cmllt4-sparcv9.pl
@@ -935,4 +935,4 @@ ___
 
 &emit_assembler();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/cast/asm/cast-586.pl
+++ b/crypto/cast/asm/cast-586.pl
@@ -45,7 +45,7 @@ $S4="CAST_S_table3";
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub CAST_encrypt {
     local($name,$enc)=@_;

--- a/crypto/chacha/asm/chacha-armv4.pl
+++ b/crypto/chacha/asm/chacha-armv4.pl
@@ -1166,4 +1166,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/chacha/asm/chacha-armv8.pl
+++ b/crypto/chacha/asm/chacha-armv8.pl
@@ -1289,4 +1289,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;	# flush
+close STDOUT or die "error closing STDOUT";	# flush

--- a/crypto/chacha/asm/chacha-c64xplus.pl
+++ b/crypto/chacha/asm/chacha-c64xplus.pl
@@ -922,4 +922,4 @@ $code.=<<___;
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/chacha/asm/chacha-ia64.pl
+++ b/crypto/chacha/asm/chacha-ia64.pl
@@ -288,4 +288,4 @@ stringz "ChaCha20 for IA64, CRYPTOGAMS by \@dot-asm"
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/chacha/asm/chacha-ppc.pl
+++ b/crypto/chacha/asm/chacha-ppc.pl
@@ -1349,4 +1349,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/chacha/asm/chacha-x86.pl
+++ b/crypto/chacha/asm/chacha-x86.pl
@@ -1151,4 +1151,4 @@ sub XOPROUND {
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -4004,4 +4004,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/des/asm/crypt586.pl
+++ b/crypto/des/asm/crypt586.pl
@@ -24,7 +24,7 @@ $R="esi";
 &fcrypt_body("fcrypt_body");
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub fcrypt_body
 	{

--- a/crypto/des/asm/des-586.pl
+++ b/crypto/des/asm/des-586.pl
@@ -46,7 +46,7 @@ $small_footprint=1 if (grep(/\-DOPENSSL_SMALL_FOOTPRINT/,@ARGV));
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub DES_encrypt_internal()
 	{

--- a/crypto/des/asm/dest4-sparcv9.pl
+++ b/crypto/des/asm/dest4-sparcv9.pl
@@ -623,4 +623,4 @@ ___
 
 &emit_assembler();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ec/asm/ecp_nistz256-armv4.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv4.pl
@@ -1853,4 +1853,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;	# enforce flush
+close STDOUT or die "error closing STDOUT";	# enforce flush

--- a/crypto/ec/asm/ecp_nistz256-armv8.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv8.pl
@@ -1874,4 +1874,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;	# enforce flush
+close STDOUT or die "error closing STDOUT";	# enforce flush

--- a/crypto/ec/asm/ecp_nistz256-avx2.pl
+++ b/crypto/ec/asm/ecp_nistz256-avx2.pl
@@ -2079,4 +2079,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ec/asm/ecp_nistz256-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistz256-ppc64.pl
@@ -2382,4 +2382,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;	# enforce flush
+close STDOUT or die "error closing STDOUT";	# enforce flush

--- a/crypto/ec/asm/ecp_nistz256-sparcv9.pl
+++ b/crypto/ec/asm/ecp_nistz256-sparcv9.pl
@@ -3056,4 +3056,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ec/asm/ecp_nistz256-x86.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86.pl
@@ -1858,4 +1858,4 @@ for ($i=0;$i<7;$i++) {
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ec/asm/ecp_nistz256-x86_64.pl
+++ b/crypto/ec/asm/ecp_nistz256-x86_64.pl
@@ -4738,4 +4738,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ec/asm/x25519-ppc64.pl
+++ b/crypto/ec/asm/x25519-ppc64.pl
@@ -824,4 +824,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ec/asm/x25519-x86_64.pl
+++ b/crypto/ec/asm/x25519-x86_64.pl
@@ -1130,4 +1130,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/md5/asm/md5-586.pl
+++ b/crypto/md5/asm/md5-586.pl
@@ -45,7 +45,7 @@ $X="esi";
 &md5_block("md5_block_asm_data_order");
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub Np
 	{

--- a/crypto/md5/asm/md5-sparcv9.pl
+++ b/crypto/md5/asm/md5-sparcv9.pl
@@ -436,4 +436,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/md5/asm/md5-x86_64.pl
+++ b/crypto/md5/asm/md5-x86_64.pl
@@ -392,4 +392,4 @@ ___
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/aes-gcm-armv8_64.pl
+++ b/crypto/modes/asm/aes-gcm-armv8_64.pl
@@ -5719,4 +5719,4 @@ if ($flavour =~ /64/) {         ######## 64-bit code
     }
 }
 
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/modes/asm/aesni-gcm-x86_64.pl
+++ b/crypto/modes/asm/aesni-gcm-x86_64.pl
@@ -1106,4 +1106,4 @@ $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghash-alpha.pl
+++ b/crypto/modes/asm/ghash-alpha.pl
@@ -463,5 +463,5 @@ rem_4bit:
 ___
 $output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 

--- a/crypto/modes/asm/ghash-armv4.pl
+++ b/crypto/modes/asm/ghash-armv4.pl
@@ -551,4 +551,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/modes/asm/ghash-c64xplus.pl
+++ b/crypto/modes/asm/ghash-c64xplus.pl
@@ -243,4 +243,4 @@ $code.=<<___;
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghash-ia64.pl
+++ b/crypto/modes/asm/ghash-ia64.pl
@@ -467,4 +467,4 @@ $code =~ s/mux1(\s+)\S+\@rev/nop.i$1 0x0/gm      if ($big_endian);
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghash-parisc.pl
+++ b/crypto/modes/asm/ghash-parisc.pl
@@ -748,4 +748,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghash-s390x.pl
+++ b/crypto/modes/asm/ghash-s390x.pl
@@ -261,4 +261,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghash-sparcv9.pl
+++ b/crypto/modes/asm/ghash-sparcv9.pl
@@ -577,4 +577,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghash-x86.pl
+++ b/crypto/modes/asm/ghash-x86.pl
@@ -1377,7 +1377,7 @@ my ($Xhi,$Xi)=@_;
 &asciz("GHASH for x86, CRYPTOGAMS by <appro\@openssl.org>");
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 # A question was risen about choice of vanilla MMX. Or rather why wasn't
 # SSE2 chosen instead? In addition to the fact that MMX runs on legacy

--- a/crypto/modes/asm/ghash-x86_64.pl
+++ b/crypto/modes/asm/ghash-x86_64.pl
@@ -1817,4 +1817,4 @@ $code =~ s/\`([^\`]*)\`/eval($1)/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/modes/asm/ghashp8-ppc.pl
+++ b/crypto/modes/asm/ghashp8-ppc.pl
@@ -671,4 +671,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/modes/asm/ghashv8-armx.pl
+++ b/crypto/modes/asm/ghashv8-armx.pl
@@ -794,4 +794,4 @@ if ($flavour =~ /64/) {			######## 64-bit code
     }
 }
 
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/pariscid.pl
+++ b/crypto/pariscid.pl
@@ -275,5 +275,5 @@ foreach(split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 

--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -191,4 +191,4 @@ while(my $line=<>) {
     print "\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/perlasm/ppc-xlate.pl
+++ b/crypto/perlasm/ppc-xlate.pl
@@ -343,4 +343,4 @@ while($line=<>) {
     print "\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/poly1305/asm/poly1305-armv4.pl
+++ b/crypto/poly1305/asm/poly1305-armv4.pl
@@ -1252,4 +1252,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/poly1305/asm/poly1305-armv8.pl
+++ b/crypto/poly1305/asm/poly1305-armv8.pl
@@ -940,4 +940,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/poly1305/asm/poly1305-mips.pl
+++ b/crypto/poly1305/asm/poly1305-mips.pl
@@ -437,5 +437,5 @@ ___
 
 $output and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 

--- a/crypto/poly1305/asm/poly1305-ppc.pl
+++ b/crypto/poly1305/asm/poly1305-ppc.pl
@@ -1978,4 +1978,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/poly1305/asm/poly1305-ppcfp.pl
+++ b/crypto/poly1305/asm/poly1305-ppcfp.pl
@@ -740,4 +740,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/poly1305/asm/poly1305-sparcv9.pl
+++ b/crypto/poly1305/asm/poly1305-sparcv9.pl
@@ -1116,4 +1116,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/poly1305/asm/poly1305-x86.pl
+++ b/crypto/poly1305/asm/poly1305-x86.pl
@@ -1811,4 +1811,4 @@ sub vlazy_reduction {
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/poly1305/asm/poly1305-x86_64.pl
+++ b/crypto/poly1305/asm/poly1305-x86_64.pl
@@ -4182,4 +4182,4 @@ foreach (split('\n',$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/ppccpuid.pl
+++ b/crypto/ppccpuid.pl
@@ -383,4 +383,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/rc4/asm/rc4-586.pl
+++ b/crypto/rc4/asm/rc4-586.pl
@@ -422,4 +422,4 @@ $idx="edx";
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/rc4/asm/rc4-c64xplus.pl
+++ b/crypto/rc4/asm/rc4-c64xplus.pl
@@ -188,4 +188,4 @@ ___
 
 $output = pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/rc4/asm/rc4-md5-x86_64.pl
+++ b/crypto/rc4/asm/rc4-md5-x86_64.pl
@@ -662,4 +662,4 @@ $code =~ s/#rc4#//gm	if ($rc4);
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/rc4/asm/rc4-parisc.pl
+++ b/crypto/rc4/asm/rc4-parisc.pl
@@ -333,4 +333,4 @@ foreach(split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/rc4/asm/rc4-s390x.pl
+++ b/crypto/rc4/asm/rc4-s390x.pl
@@ -240,4 +240,4 @@ RC4_options:
 ___
 
 print $code;
-close STDOUT;	# force flush
+close STDOUT or die "error closing STDOUT";	# force flush

--- a/crypto/rc4/asm/rc4-x86_64.pl
+++ b/crypto/rc4/asm/rc4-x86_64.pl
@@ -697,4 +697,4 @@ $code =~ s/\`([^\`]*)\`/eval $1/gem;
 
 print $code;
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/rc5/asm/rc5-586.pl
+++ b/crypto/rc5/asm/rc5-586.pl
@@ -31,7 +31,7 @@ $tmp4="edx";
 &cbc("RC5_32_cbc_encrypt","RC5_32_encrypt","RC5_32_decrypt",0,4,5,3,-1,-1);
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub RC5_32_encrypt
 	{

--- a/crypto/ripemd/asm/rmd-586.pl
+++ b/crypto/ripemd/asm/rmd-586.pl
@@ -69,7 +69,7 @@ $KR3=0x7A6D76E9;
 &ripemd160_block("ripemd160_block_asm_data_order");
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";
 
 sub Xv
 	{

--- a/crypto/s390xcpuid.pl
+++ b/crypto/s390xcpuid.pl
@@ -558,4 +558,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;	# force flush
+close STDOUT or die "error closing STDOUT";	# force flush

--- a/crypto/sha/asm/keccak1600-armv4.pl
+++ b/crypto/sha/asm/keccak1600-armv4.pl
@@ -1633,4 +1633,4 @@ foreach (split($/,$code)) {
 	print $_,"\n";
 }
 
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/sha/asm/keccak1600-armv8.pl
+++ b/crypto/sha/asm/keccak1600-armv8.pl
@@ -873,4 +873,4 @@ foreach(split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-avx2.pl
+++ b/crypto/sha/asm/keccak1600-avx2.pl
@@ -478,4 +478,4 @@ ___
 
 $output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-avx512.pl
+++ b/crypto/sha/asm/keccak1600-avx512.pl
@@ -547,4 +547,4 @@ ___
 
 $output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-avx512vl.pl
+++ b/crypto/sha/asm/keccak1600-avx512vl.pl
@@ -388,4 +388,4 @@ ___
 
 $output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-c64x.pl
+++ b/crypto/sha/asm/keccak1600-c64x.pl
@@ -881,4 +881,4 @@ ___
 
 $output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-mmx.pl
+++ b/crypto/sha/asm/keccak1600-mmx.pl
@@ -436,4 +436,4 @@ sub Rho() {				######### regular Rho step
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-ppc64.pl
+++ b/crypto/sha/asm/keccak1600-ppc64.pl
@@ -759,4 +759,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-s390x.pl
+++ b/crypto/sha/asm/keccak1600-s390x.pl
@@ -559,4 +559,4 @@ ___
 $code =~ s/(srlg\s+)(%r[0-9]+),/$1$2,$2,/gm;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600-x86_64.pl
+++ b/crypto/sha/asm/keccak1600-x86_64.pl
@@ -608,4 +608,4 @@ foreach (split("\n",$code)) {
 	print $_, "\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/keccak1600p8-ppc.pl
+++ b/crypto/sha/asm/keccak1600p8-ppc.pl
@@ -851,4 +851,4 @@ foreach  (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-586.pl
+++ b/crypto/sha/asm/sha1-586.pl
@@ -1487,4 +1487,4 @@ sub Xtail_avx()
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-alpha.pl
+++ b/crypto/sha/asm/sha1-alpha.pl
@@ -326,4 +326,4 @@ $code.=<<___;
 ___
 $output=pop and open STDOUT,">$output";
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-armv4-large.pl
+++ b/crypto/sha/asm/sha1-armv4-large.pl
@@ -749,4 +749,4 @@ foreach (split($/,$code)) {
 	print $_,$/;
 }
 
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/sha/asm/sha1-armv8.pl
+++ b/crypto/sha/asm/sha1-armv8.pl
@@ -357,4 +357,4 @@ foreach(split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-c64xplus.pl
+++ b/crypto/sha/asm/sha1-c64xplus.pl
@@ -333,4 +333,4 @@ $code.=<<___;
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-mb-x86_64.pl
+++ b/crypto/sha/asm/sha1-mb-x86_64.pl
@@ -1627,4 +1627,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-mips.pl
+++ b/crypto/sha/asm/sha1-mips.pl
@@ -461,4 +461,4 @@ $code.=<<___;
 .asciiz	"SHA1 for MIPS, CRYPTOGAMS by <appro\@openssl.org>"
 ___
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-parisc.pl
+++ b/crypto/sha/asm/sha1-parisc.pl
@@ -279,4 +279,4 @@ foreach(split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-ppc.pl
+++ b/crypto/sha/asm/sha1-ppc.pl
@@ -352,4 +352,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-s390x.pl
+++ b/crypto/sha/asm/sha1-s390x.pl
@@ -248,4 +248,4 @@ ___
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-sparcv9.pl
+++ b/crypto/sha/asm/sha1-sparcv9.pl
@@ -430,4 +430,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-sparcv9a.pl
+++ b/crypto/sha/asm/sha1-sparcv9a.pl
@@ -604,4 +604,4 @@ $code =~ s/\b(alignaddr)\s+(%[goli][0-7]),(%[goli][0-7]),(%[goli][0-7])/
 		&unalignaddr($1,$2,$3,$4)
 	  /gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha1-thumb.pl
+++ b/crypto/sha/asm/sha1-thumb.pl
@@ -262,4 +262,4 @@ $code.=<<___;
 ___
 
 print $code;
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/sha/asm/sha1-x86_64.pl
+++ b/crypto/sha/asm/sha1-x86_64.pl
@@ -2131,4 +2131,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha256-586.pl
+++ b/crypto/sha/asm/sha256-586.pl
@@ -1292,4 +1292,4 @@ sub bodyx_00_15 () {			# +10%
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha256-armv4.pl
+++ b/crypto/sha/asm/sha256-armv4.pl
@@ -739,4 +739,4 @@ foreach (split($/,$code)) {
 	print $_,"\n";
 }
 
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/sha/asm/sha256-c64xplus.pl
+++ b/crypto/sha/asm/sha256-c64xplus.pl
@@ -316,4 +316,4 @@ K256:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha256-mb-x86_64.pl
+++ b/crypto/sha/asm/sha256-mb-x86_64.pl
@@ -1613,4 +1613,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-586.pl
+++ b/crypto/sha/asm/sha512-586.pl
@@ -921,4 +921,4 @@ sub BODY_00_15_ssse3 {		# "phase-less" copy of BODY_00_15_sse2
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-armv4.pl
+++ b/crypto/sha/asm/sha512-armv4.pl
@@ -677,4 +677,4 @@ while(<SELF>) {
 close SELF;
 
 print $code;
-close STDOUT; # enforce flush
+close STDOUT or die "error closing STDOUT"; # enforce flush

--- a/crypto/sha/asm/sha512-armv8.pl
+++ b/crypto/sha/asm/sha512-armv8.pl
@@ -891,4 +891,4 @@ foreach(split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-c64xplus.pl
+++ b/crypto/sha/asm/sha512-c64xplus.pl
@@ -434,4 +434,4 @@ K512:
 ___
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-mips.pl
+++ b/crypto/sha/asm/sha512-mips.pl
@@ -524,4 +524,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-parisc.pl
+++ b/crypto/sha/asm/sha512-parisc.pl
@@ -807,4 +807,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-ppc.pl
+++ b/crypto/sha/asm/sha512-ppc.pl
@@ -799,4 +799,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-s390x.pl
+++ b/crypto/sha/asm/sha512-s390x.pl
@@ -323,4 +323,4 @@ $code =~ s/\`([^\`]*)\`/eval $1/gem;
 $code =~ s/(srlg\s+)(%r[0-9]+),/$1$2,$2,/gm;
 
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-sparcv9.pl
+++ b/crypto/sha/asm/sha512-sparcv9.pl
@@ -856,4 +856,4 @@ foreach (split("\n",$code)) {
 	print $_,"\n";
 }
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512-x86_64.pl
+++ b/crypto/sha/asm/sha512-x86_64.pl
@@ -2557,4 +2557,4 @@ foreach (split("\n",$code)) {
 
 	print $_,"\n";
 }
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/sha/asm/sha512p8-ppc.pl
+++ b/crypto/sha/asm/sha512p8-ppc.pl
@@ -420,4 +420,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/whrlpool/asm/wp-mmx.pl
+++ b/crypto/whrlpool/asm/wp-mmx.pl
@@ -503,4 +503,4 @@ for($i=0;$i<8;$i++) {
 &function_end_B("whirlpool_block_mmx");
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/whrlpool/asm/wp-x86_64.pl
+++ b/crypto/whrlpool/asm/wp-x86_64.pl
@@ -616,4 +616,4 @@ ___
 
 $code =~ s/\`([^\`]*)\`/eval $1/gem;
 print $code;
-close STDOUT;
+close STDOUT or die "error closing STDOUT";

--- a/crypto/x86_64cpuid.pl
+++ b/crypto/x86_64cpuid.pl
@@ -510,4 +510,4 @@ ___
 gen_random("rdrand");
 gen_random("rdseed");
 
-close STDOUT;	# flush
+close STDOUT or die "error closing STDOUT";	# flush

--- a/crypto/x86cpuid.pl
+++ b/crypto/x86cpuid.pl
@@ -504,4 +504,4 @@ my $rdop = shift;
 
 &asm_finish();
 
-close STDOUT;
+close STDOUT or die "error closing STDOUT";


### PR DESCRIPTION
If one of the perlasm xlate drivers crashes, OpenSSL's build will currently swallow the error and silently truncate the output to however far the driver got. This will hopefully fail to build, but better to check such things.

Handle this by checking for errors when closing `STDOUT` (which is a pipe to the xlate driver).