### PR TITLE
PROV: Fix bignum printout in text serializers

### DIFF
--- a/providers/implementations/serializers/serializer_local.h
+++ b/providers/implementations/serializers/serializer_local.h
@@ -54,7 +54,7 @@ int ossl_prov_dsa_pub_to_der(const void *dsa, unsigned char **pder);
 int ossl_prov_dsa_priv_to_der(const void *dsa, unsigned char **pder);
 
 int ossl_prov_print_labeled_bignum(BIO *out, const char *label,
-                                   const BIGNUM *n);
+                                   const BIGNUM *bn);
 int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv);
 
 enum dh_print_type {


### PR DESCRIPTION
The common routine ossl_prov_print_labeled_bignum() didn't print the
BIGNUM quite the way it should.  It treated the limbs in a big endian
fashion, when they are really organised in a little endian fashion.

Furthermore, we make it inherit the behaviour from the print of legacy
keys, where a number starting with the high bit set gets an extra zero
printed first.
