### PR TITLE
Remove remaining references to crypto/include

### DIFF
--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -6,7 +6,6 @@ SOURCE[../../libcrypto]=\
         {- $target{bn_asm_src} -} \
         bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c \
         bn_depr.c bn_const.c bn_x931p.c bn_intern.c bn_dh.c bn_srp.c
-INCLUDE[../../libcrypto]=../../crypto/include
 
 INCLUDE[bn_exp.o]=..
 

--- a/test/build.info
+++ b/test/build.info
@@ -185,7 +185,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   DEPEND[evp_test]=../libcrypto libtestutil.a
 
   SOURCE[evp_extra_test]=evp_extra_test.c
-  INCLUDE[evp_extra_test]=../include ../crypto/include
+  INCLUDE[evp_extra_test]=../include
   DEPEND[evp_extra_test]=../libcrypto libtestutil.a
 
   SOURCE[igetest]=igetest.c
@@ -393,7 +393,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   IF[{- !$disabled{shared} -}]
     PROGRAMS_NO_INST=shlibloadtest
     SOURCE[shlibloadtest]=shlibloadtest.c
-    INCLUDE[shlibloadtest]=../include ../crypto/include
+    INCLUDE[shlibloadtest]=../include
   ENDIF
 
   IF[{- $disabled{shared} -}]
@@ -463,15 +463,15 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
     ENDIF
 
     SOURCE[poly1305_internal_test]=poly1305_internal_test.c
-    INCLUDE[poly1305_internal_test]=.. ../include ../crypto/include
+    INCLUDE[poly1305_internal_test]=.. ../include
     DEPEND[poly1305_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[chacha_internal_test]=chacha_internal_test.c
-    INCLUDE[chacha_internal_test]=.. ../include ../crypto/include
+    INCLUDE[chacha_internal_test]=.. ../include
     DEPEND[chacha_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[asn1_internal_test]=asn1_internal_test.c
-    INCLUDE[asn1_internal_test]=.. ../include ../crypto/include
+    INCLUDE[asn1_internal_test]=.. ../include
     DEPEND[asn1_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[modes_internal_test]=modes_internal_test.c
@@ -495,19 +495,19 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
     DEPEND[ctype_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[siphash_internal_test]=siphash_internal_test.c
-    INCLUDE[siphash_internal_test]=.. ../include ../crypto/include
+    INCLUDE[siphash_internal_test]=.. ../include
     DEPEND[siphash_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[sm2_internal_test]=sm2_internal_test.c
-    INCLUDE[sm2_internal_test]=../include ../crypto/include
+    INCLUDE[sm2_internal_test]=../include
     DEPEND[sm2_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[sm4_internal_test]=sm4_internal_test.c
-    INCLUDE[sm4_internal_test]=.. ../include ../crypto/include
+    INCLUDE[sm4_internal_test]=.. ../include
     DEPEND[sm4_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[ec_internal_test]=ec_internal_test.c
-    INCLUDE[ec_internal_test]=../include ../crypto/ec ../crypto/include
+    INCLUDE[ec_internal_test]=../include ../crypto/ec
     DEPEND[ec_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[curve448_internal_test]=curve448_internal_test.c


### PR DESCRIPTION
Configure creates an empty crypto/include which
gets not cleaned up with make distclean.

This is for 1.1.1 only at the time, master has more to clean up.