### PR TITLE
Fix make distclean

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -524,6 +524,7 @@ clean: libclean
 
 distclean: clean
 	$(RM) configdata.pm
+	$(RM) -r doc/man doc/html
 	$(RM) Makefile
 
 # We check if any depfile is newer than Makefile and decide to

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -520,6 +520,7 @@ clean: libclean
 	$(RM) -r test/test-runs
 	$(RM) openssl.pc libcrypto.pc libssl.pc
 	-$(RM) `find . -type l \! -name '.*' -print`
+	$(RM) pod2htmd.tmp
 	$(RM) $(TARFILE)
 
 distclean: clean

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -416,23 +416,32 @@ libclean:
 	-del /Q /F $(LIBS) libcrypto.* libssl.* ossl_static.pdb
 
 clean: libclean
-	-rmdir /Q /S $(HTMLDOCS1_BLDDIRS)
-	-rmdir /Q /S $(HTMLDOCS3_BLDDIRS)
-	-rmdir /Q /S $(HTMLDOCS5_BLDDIRS)
-	-rmdir /Q /S $(HTMLDOCS7_BLDDIRS)
 	{- join("\n\t", map { "-del /Q /F $_" } @PROGRAMS) -}
-	-del /Q /F $(MODULES)
-	-del /Q /F $(SCRIPTS)
-	-del /Q /F $(GENERATED_MANDATORY)
-	-del /Q /F $(GENERATED)
+	-"$(PERL)" -e "while (<>) { chomp; @list = split(' ', $$_); foreach $$file (@list) { unlink $$file; } }" < <<
+$(MODULES)
+$(SCRIPTS)
+$(GENERATED_MANDATORY)
+$(GENERATED)
+pod2htmd.tmp pod2htmi.tmp
+<<
 	-del /Q /S /F *.d *.obj *.pdb *.ilk *.manifest
 	-del /Q /S /F engines\*.lib engines\*.exp
+	-del /Q /S /F providers\*.lib providers\*.exp
 	-del /Q /S /F apps\*.lib apps\*.rc apps\*.res apps\*.exp
-	-del /Q /S /F test\*.exp
-	-rmdir /Q /S test\test-runs
+	-del /Q /S /F test\*.lib test\*.exp .\*.res
+	-"$(PERL)" -e "use File::Path; while (<>) { chomp; @list = split(' ', $$_); foreach $$file (@list) { rmtree($$file); } }" < <<
+$(HTMLDOCS1_BLDDIRS)
+$(HTMLDOCS3_BLDDIRS)
+$(HTMLDOCS5_BLDDIRS)
+$(HTMLDOCS7_BLDDIRS)
+test\test-runs
+<<
 
 distclean: clean
 	-del /Q /F configdata.pm
+	-"$(PERL)" -e "use File::Path; while (<>) { chomp; @list = split(' ', $$_); foreach $$file (@list) { rmtree($$file); } }" < <<
+doc\man doc\html
+<<
 	-del /Q /F makefile
 
 depend:

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -115,8 +115,6 @@ DEFINE[../../libcrypto]=$BNDEF
 DEFINE[../../providers/libfips.a]=$BNDEF
 DEFINE[../../providers/libimplementations.a]=$BNDEF
 
-INCLUDE[../../libcrypto]=../../crypto/include
-
 INCLUDE[bn_exp.o]=..
 
 GENERATE[bn-586.s]=asm/bn-586.pl

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -34,7 +34,7 @@ SOURCE[../../libcrypto]=poly1305_ameth.c poly1305.c $POLY1305ASM
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$POLY1305DEF
-DEFINE[../providers/libimplementations.a]=$POLY1305DEF
+DEFINE[../../providers/libimplementations.a]=$POLY1305DEF
 
 GENERATE[poly1305-sparcv9.S]=asm/poly1305-sparcv9.pl
 INCLUDE[poly1305-sparcv9.o]=..

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -14,7 +14,7 @@ ENDIF
 
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules
-DEFINE[../providers/libimplementations.a]=$RMD160DEF
+DEFINE[../../providers/libimplementations.a]=$RMD160DEF
 
 SOURCE[../../libcrypto]=rmd_dgst.c rmd_one.c $RMD160ASM
 DEFINE[../../libcrypto]=$RMD160DEF

--- a/test/build.info
+++ b/test/build.info
@@ -170,11 +170,11 @@ IF[{- !$disabled{tests} -}]
   ENDIF
 
   SOURCE[evp_extra_test]=evp_extra_test.c
-  INCLUDE[evp_extra_test]=../include ../apps/include ../crypto/include
+  INCLUDE[evp_extra_test]=../include ../apps/include
   DEPEND[evp_extra_test]=../libcrypto libtestutil.a
 
   SOURCE[evp_fetch_prov_test]=evp_fetch_prov_test.c
-  INCLUDE[evp_fetch_prov_test]=../include ../apps/include ../crypto/include
+  INCLUDE[evp_fetch_prov_test]=../include ../apps/include
   DEPEND[evp_fetch_prov_test]=../libcrypto libtestutil.a
   IF[{- $disabled{fips} || !$target{dso_scheme} -}]
     DEFINE[evp_extra_test]=NO_FIPS_MODULE
@@ -375,13 +375,13 @@ IF[{- !$disabled{tests} -}]
   DEPEND[recordlentest]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[drbgtest]=drbgtest.c
-  INCLUDE[drbgtest]=../include ../apps/include ../crypto/include
+  INCLUDE[drbgtest]=../include ../apps/include
   DEPEND[drbgtest]=../libcrypto.a libtestutil.a
 
   SOURCE[drbg_cavs_test]=drbg_cavs_test.c drbg_cavs_data_ctr.c \
                          drbg_cavs_data_hash.c drbg_cavs_data_hmac.c
 
-  INCLUDE[drbg_cavs_test]=../include ../apps/include . .. ../crypto/include
+  INCLUDE[drbg_cavs_test]=../include ../apps/include . ..
   DEPEND[drbg_cavs_test]=../libcrypto libtestutil.a
 
   SOURCE[x509_dup_cert_test]=x509_dup_cert_test.c
@@ -425,7 +425,7 @@ IF[{- !$disabled{tests} -}]
   IF[{- !$disabled{shared} -}]
     PROGRAMS{noinst}=shlibloadtest
     SOURCE[shlibloadtest]=shlibloadtest.c
-    INCLUDE[shlibloadtest]=../include ../apps/include ../crypto/include
+    INCLUDE[shlibloadtest]=../include ../apps/include
   ENDIF
 
   # cipher_overhead_test uses internal symbols, so it must be linked with
@@ -526,19 +526,19 @@ IF[{- !$disabled{tests} -}]
     ENDIF
 
     SOURCE[poly1305_internal_test]=poly1305_internal_test.c
-    INCLUDE[poly1305_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[poly1305_internal_test]=.. ../include ../apps/include
     DEPEND[poly1305_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[chacha_internal_test]=chacha_internal_test.c
-    INCLUDE[chacha_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[chacha_internal_test]=.. ../include ../apps/include
     DEPEND[chacha_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[asn1_internal_test]=asn1_internal_test.c
-    INCLUDE[asn1_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[asn1_internal_test]=.. ../include ../apps/include
     DEPEND[asn1_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[modes_internal_test]=modes_internal_test.c
-    INCLUDE[modes_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[modes_internal_test]=.. ../include ../apps/include
     DEPEND[modes_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[x509_internal_test]=x509_internal_test.c
@@ -566,19 +566,19 @@ IF[{- !$disabled{tests} -}]
     DEPEND[ctype_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[sparse_array_test]=sparse_array_test.c
-    INCLUDE[sparse_array_test]=../crypto/include ../include ../apps/include
+    INCLUDE[sparse_array_test]=../include ../apps/include
     DEPEND[sparse_array_test]=../libcrypto.a libtestutil.a
 
     SOURCE[siphash_internal_test]=siphash_internal_test.c
-    INCLUDE[siphash_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[siphash_internal_test]=.. ../include ../apps/include
     DEPEND[siphash_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[sm2_internal_test]=sm2_internal_test.c
-    INCLUDE[sm2_internal_test]=../include ../apps/include ../crypto/include
+    INCLUDE[sm2_internal_test]=../include ../apps/include
     DEPEND[sm2_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[sm4_internal_test]=sm4_internal_test.c
-    INCLUDE[sm4_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[sm4_internal_test]=.. ../include ../apps/include
     DEPEND[sm4_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[rc2test]=rc2test.c
@@ -594,7 +594,7 @@ IF[{- !$disabled{tests} -}]
     DEPEND[rc5test]=../libcrypto.a libtestutil.a
 
     SOURCE[ec_internal_test]=ec_internal_test.c
-    INCLUDE[ec_internal_test]=../include ../crypto/ec ../apps/include ../crypto/include
+    INCLUDE[ec_internal_test]=../include ../crypto/ec ../apps/include
     DEPEND[ec_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[curve448_internal_test]=curve448_internal_test.c
@@ -618,7 +618,7 @@ IF[{- !$disabled{tests} -}]
     DEPEND[bn_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[asn1_dsa_internal_test]=asn1_dsa_internal_test.c
-    INCLUDE[asn1_dsa_internal_test]=.. ../include ../apps/include ../crypto/include
+    INCLUDE[asn1_dsa_internal_test]=.. ../include ../apps/include
     DEPEND[asn1_dsa_internal_test]=../libcrypto.a libtestutil.a
 
     SOURCE[keymgmt_internal_test]=keymgmt_internal_test.c


### PR DESCRIPTION
This makes distclean work correctly in master.
The windows issue is complicated by two effects,
which may be due to the specific windows machine.
First it has one of the commands to delete all generated targets
exceed the command line limit of windows.
And this machine has a cygwin somewhere in the path
almost at the end but its /usr/bin/rmdir nevetheless
overrides the builtin rmdir which makes the rmdir fail,
because it does not recognize "/S" and "/Q".