### PR TITLE
OpenSSL::Test: bring back the relative paths

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -66,7 +66,7 @@ use File::Spec::Functions qw/file_name_is_absolute curdir canonpath splitdir
                              rel2abs/;
 use File::Path 2.00 qw/rmtree mkpath/;
 use File::Basename;
-use Cwd qw/abs_path/;
+use Cwd qw/getcwd abs_path/;
 
 my $level = 0;
 
@@ -977,26 +977,26 @@ sub __srctop_file {
     BAIL_OUT("Must run setup() first") if (! $test_name);
 
     my $f = pop;
-    return catfile($directories{SRCTOP},@_,$f);
+    return abs2rel(catfile($directories{SRCTOP},@_,$f),getcwd);
 }
 
 sub __srctop_dir {
     BAIL_OUT("Must run setup() first") if (! $test_name);
 
-    return catdir($directories{SRCTOP},@_);
+    return abs2rel(catdir($directories{SRCTOP},@_), getcwd);
 }
 
 sub __bldtop_file {
     BAIL_OUT("Must run setup() first") if (! $test_name);
 
     my $f = pop;
-    return catfile($directories{BLDTOP},@_,$f);
+    return abs2rel(catfile($directories{BLDTOP},@_,$f), getcwd);
 }
 
 sub __bldtop_dir {
     BAIL_OUT("Must run setup() first") if (! $test_name);
 
-    return catdir($directories{BLDTOP},@_);
+    return abs2rel(catdir($directories{BLDTOP},@_), getcwd);
 }
 
 # __exeext is a function that returns the platform dependent file extension


### PR DESCRIPTION
Because there was a bug in File::Spec::Unix' abs2rel when it was given
relative paths as both PATH and BASE arguments, the directories we
deal with were made to be all absolute.  Unfortunately, this meant
getting paths in our verbose test output which are difficult to use
anywhere else (such as a separate test build made for comparison), due
to the constant need to edit all the paths all the time.

We're therefore getting back the relative paths, by doing an extra
abs2rel() in __srctop_file, __srctop_dir, __bldtop_file and
__bldtop_dir, with a 'Cwd::getcwd' call as BASE argument.

Fixes #10628
