### PR TITLE
"DTLS over SCTP"  support for sending ApplicationData on multiple sct…

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -133,6 +133,7 @@ typedef struct bio_dgram_sctp_data_st {
     int ccs_sent;
     int save_shutdown;
     int peer_auth_tested;
+    int record_type;
 } bio_dgram_sctp_data;
 # endif
 
@@ -1571,6 +1572,9 @@ static long dgram_sctp_ctrl(BIO *b, int cmd, long num, void *ptr)
         return dgram_sctp_wait_for_dry(b);
     case BIO_CTRL_DGRAM_SCTP_MSG_WAITING:
         return dgram_sctp_msg_waiting(b);
+    case BIO_CTRL_DGRAM_SAVE_RECORD_TYPE:
+        data->record_type = (int)num;
+        break;
 
     default:
         /*

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -165,6 +165,8 @@ extern "C" {
 # define BIO_CTRL_SET_INDENT                    80
 # define BIO_CTRL_GET_INDENT                    81
 
+#define BIO_CTRL_DGRAM_SAVE_RECORD_TYPE        82
+
 # ifndef OPENSSL_NO_KTLS
 #  define BIO_get_ktls_send(b)         \
      BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL)


### PR DESCRIPTION
`DTLS over SCTP` support for sending ApplicationData on multiple sctp streams.

Description:
As per RFC 6083, section 4.4, all DTLS messages of the ChangeCipherSpec, Alert, or Handshake
MUST be transported on stream 0 and for ApplicationData, there is a provision to use multiple
streams. When custom SCTP implementation (not lksctp) is used then custom BIO METHODS are
registered to OpenSSL. Before calling the write method, we can save the record_type and based on whether it is DTLS control messages or ApplicationData, stream_id can be selected to send out the message finally.

RFC Snippet:
4.4.  Stream Usage

   All DTLS messages of the ChangeCipherSpec, Alert, or Handshake
   protocol MUST be transported on stream 0 with unlimited reliability
   and with the ordered delivery feature.

   DTLS messages of the ApplicationData protocol SHOULD use `multiple
   streams` other than stream 0; they MAY use stream 0 for everything if
   they do not care about minimizing head of line blocking.