### PR TITLE
Modify EVP_PKEY_CTX_new_from_pkey() to add a propquery parameter

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -915,7 +915,7 @@ void *evp_pkey_make_provided(EVP_PKEY *pk, OPENSSL_CTX *libctx,
     }
 
     if (tmp_keymgmt == NULL) {
-        EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_pkey(libctx, pk);
+        EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_pkey(libctx, pk, propquery);
 
         if (ctx != NULL && ctx->keytype != NULL)
             tmp_keymgmt = allocated_keymgmt =

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -186,17 +186,6 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
         return NULL;
     if (e == NULL)
         name = OBJ_nid2sn(id);
-    propquery = NULL;
-    /*
-     * We were called using legacy data, or an EVP_PKEY, but an EVP_PKEY
-     * isn't tied to a specific library context, so we fall back to the
-     * default library context.
-     * TODO(v3.0): an EVP_PKEY that doesn't originate from a leagacy key
-     * structure only has the pkeys[] cache, where the first element is
-     * considered the "origin".  Investigate if that could be a suitable
-     * way to find a library context.
-     */
-    libctx = NULL;
 
 # ifndef OPENSSL_NO_ENGINE
     if (e == NULL && pkey != NULL)
@@ -269,9 +258,10 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OPENSSL_CTX *libctx,
     return int_ctx_new(libctx, NULL, NULL, name, propquery, -1);
 }
 
-EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OPENSSL_CTX *libctx, EVP_PKEY *pkey)
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OPENSSL_CTX *libctx, EVP_PKEY *pkey,
+                                         const char *propquery)
 {
-    return int_ctx_new(libctx, pkey, NULL, NULL, NULL, -1);
+    return int_ctx_new(libctx, pkey, NULL, NULL, propquery, -1);
 }
 
 void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx)

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -38,7 +38,7 @@ The EVP_PKEY_CTX_new_from_pkey() function allocates a public key algorithm
 context using the library context I<libctx> (see L<OPENSSL_CTX(3)>) and the
 algorithm specified by I<pkey> and the property query I<propquery>. None of the
 arguments are duplicated, so they must remain unchanged for the lifetime of the
-returned B<EVP_PKEY_CTX> or of any of its duplicates.
+returned B<EVP_PKEY_CTX> or any of its duplicates.
 
 EVP_PKEY_CTX_new_id() and EVP_PKEY_CTX_new_from_name() are normally
 used when no B<EVP_PKEY> structure is associated with the operations,

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -36,9 +36,9 @@ lifetime of the returned B<EVP_PKEY_CTX> or of any of its duplicates.
 
 The EVP_PKEY_CTX_new_from_pkey() function allocates a public key algorithm
 context using the library context I<libctx> (see L<OPENSSL_CTX(3)>) and the
-algorithm specified by I<pkey> . None of the arguments are duplicated, so they
-must remain unchanged for the lifetime of the returned B<EVP_PKEY_CTX> or of
-any of its duplicates.
+algorithm specified by I<pkey> and the property query I<propquery>. None of the
+arguments are duplicated, so they must remain unchanged for the lifetime of the
+returned B<EVP_PKEY_CTX> or of any of its duplicates.
 
 EVP_PKEY_CTX_new_id() and EVP_PKEY_CTX_new_from_name() are normally
 used when no B<EVP_PKEY> structure is associated with the operations,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1472,7 +1472,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OPENSSL_CTX *libctx,
                                          const char *name,
                                          const char *propquery);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OPENSSL_CTX *libctx,
-                                         EVP_PKEY *pkey);
+                                         EVP_PKEY *pkey, const char *propquery);
 EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *ctx);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -268,7 +268,7 @@ static int dsa_key_signature_test(OPENSSL_CTX *libctx)
         goto err;
 
     /* Create a EVP_PKEY_CTX to use for the signing operation */
-    sctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey);
+    sctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, NULL);
     if (sctx == NULL
         || EVP_PKEY_sign_init(sctx) <= 0)
         goto err;
@@ -433,7 +433,7 @@ static int dh_key_exchange_test(OPENSSL_CTX *libctx)
         goto err;
 
     /* Create a EVP_PKEY_CTX to perform key derivation */
-    dctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey);
+    dctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, NULL);
     if (dctx == NULL)
         goto err;
 


### PR DESCRIPTION
The function EVP_PKEY_CTX_new_from_pkey() infers the name of the
algorithm to fetch from the EVP_PKEY that has been supplied as an
argument. But there was no way to specify properties to be used during
that fetch.