### PR TITLE
Add internal maxsize macros

### DIFF
--- a/include/internal/sizes.h
+++ b/include/internal/sizes.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_INTERNAL_SIZES_H
+# define OSSL_INTERNAL_SIZES_H
+
+/*
+ * Max sizes used to allocate buffers with a fixed sizes, for example for
+ * stack allocations, structure fields, ...
+ */
+# define OSSL_MAX_NAME_SIZE           50 /* Algorithm name */
+# define OSSL_MAX_PROPQUERY_SIZE     256 /* Property query strings */
+
+#endif

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -17,6 +17,7 @@
 /* Just for SSL_MAX_MASTER_KEY_LENGTH */
 #include <openssl/ssl.h>
 #include "internal/constant_time.h"
+#include "internal/sizes.h"
 #include "crypto/rsa.h"
 #include "prov/providercommonerr.h"
 #include "prov/provider_ctx.h"
@@ -323,7 +324,8 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
     const OSSL_PARAM *p;
     /* Should be big enough */
-    char mdname[80], mdprops[80] = { '\0' };
+    char mdname[OSSL_MAX_NAME_SIZE];
+    char mdprops[OSSL_MAX_PROPQUERY_SIZE] = { '\0' };
     char *str = mdname;
     int pad_mode;
 

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -323,7 +323,6 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
     const OSSL_PARAM *p;
-    /* Should be big enough */
     char mdname[OSSL_MAX_NAME_SIZE];
     char mdprops[OSSL_MAX_PROPQUERY_SIZE] = { '\0' };
     char *str = mdname;

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -50,7 +50,6 @@ typedef struct {
     OPENSSL_CTX *libctx;
     DSA *dsa;
     size_t mdsize;
-    /* Should be big enough */
     char mdname[OSSL_MAX_NAME_SIZE];
     EVP_MD *md;
     EVP_MD_CTX *mdctx;

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -13,6 +13,7 @@
 #include <openssl/dsa.h>
 #include <openssl/params.h>
 #include <openssl/evp.h>
+#include "internal/sizes.h"
 #include "prov/implementations.h"
 #include "prov/provider_ctx.h"
 #include "crypto/dsa.h"
@@ -50,7 +51,7 @@ typedef struct {
     DSA *dsa;
     size_t mdsize;
     /* Should be big enough */
-    char mdname[80];
+    char mdname[OSSL_MAX_NAME_SIZE];
     EVP_MD *md;
     EVP_MD_CTX *mdctx;
 } PROV_DSA_CTX;


### PR DESCRIPTION
We've started to see "magic" numbers being used for certain sizes,
such as algorithm names and property query strings.

This change takes care of the few items where buffers for algorithm
names and property query strings are used.
