### PR TITLE
Fix type name typo in d2i/i2d documentation.

### DIFF
--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -491,7 +491,7 @@ Represents an ASN1 OBJECT IDENTIFIER.
 
 Represents a PKCS#3 DH parameters structure.
 
-=item B<DHparamx>
+=item B<DHxparams>
 
 Represents an ANSI X9.42 DH parameters structure.
 


### PR DESCRIPTION
Changed `DHparamx` to `DHxparams`.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
