### PR TITLE
Fix coverity issues CID 1457745...1457752, 1457853, 1457854

### DIFF
--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -82,8 +82,10 @@ int nseq_main(int argc, char **argv)
         seq->certs = sk_X509_new_null();
         if (seq->certs == NULL)
             goto end;
-        while ((x509 = PEM_read_bio_X509(in, NULL, NULL, NULL)))
-            sk_X509_push(seq->certs, x509);
+        while ((x509 = PEM_read_bio_X509(in, NULL, NULL, NULL))) {
+            if (!sk_X509_push(seq->certs, x509))
+                goto end;
+        }
 
         if (!sk_X509_num(seq->certs)) {
             BIO_printf(bio_err, "%s: Error reading certs file %s\n",

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -451,7 +451,8 @@ int ocsp_main(int argc, char **argv)
                 if ((issuers = sk_X509_new_null()) == NULL)
                     goto end;
             }
-            sk_X509_push(issuers, issuer);
+            if (!sk_X509_push(issuers, issuer))
+                goto end;
             break;
         case OPT_CERT:
             X509_free(cert);

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -893,12 +893,13 @@ static int alg_print(const X509_ALGOR *alg)
 
 int cert_load(BIO *in, STACK_OF(X509) *sk)
 {
-    int ret;
+    int ret = 0;
     X509 *cert;
-    ret = 0;
+
     while ((cert = PEM_read_bio_X509(in, NULL, NULL, NULL))) {
         ret = 1;
-        sk_X509_push(sk, cert);
+        if (!sk_X509_push(sk, cert))
+            return 0;
     }
     if (ret)
         ERR_clear_error();

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -131,7 +131,8 @@ void *evp_keymgmt_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt,
      * have to think about a cache aging scheme, though, if |i| indexes
      * outside the array.
      */
-    j = ossl_assert(i < OSSL_NELEM(pk->pkeys));
+    if (!ossl_assert(i < OSSL_NELEM(pk->pkeys)))
+        return NULL;
 
     evp_keymgmt_cache_pkey(pk, i, keymgmt, provdata, want_domainparams);
 

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -280,7 +280,7 @@ static void aes_cbc_hmac_sha1_freectx(void *vctx)
     PROV_AES_HMAC_SHA1_CTX *ctx = (PROV_AES_HMAC_SHA1_CTX *)vctx;
 
     if (ctx != NULL)
-        OPENSSL_clear_free(ctx, sizeof(ctx));
+        OPENSSL_clear_free(ctx, sizeof(*ctx));
 }
 
 static void *aes_cbc_hmac_sha256_newctx(void *provctx, size_t kbits,
@@ -301,7 +301,7 @@ static void aes_cbc_hmac_sha256_freectx(void *vctx)
     PROV_AES_HMAC_SHA256_CTX *ctx = (PROV_AES_HMAC_SHA256_CTX *)vctx;
 
     if (ctx != NULL)
-        OPENSSL_clear_free(ctx, sizeof(ctx));
+        OPENSSL_clear_free(ctx, sizeof(*ctx));
 }
 
 # define IMPLEMENT_CIPHER(nm, sub, kbits, blkbits, ivbits, flags)               \


### PR DESCRIPTION
CID 1457854 - keymgmt_lib.c : OVERRUN
CID 1457853 - self_test_kats.c : UNINT
CID 1457752 - fipsprov.c RESOURCE_LEAK
CID 1457751 - apps/pkcs12.c CHECKED_RETURN
CID 1457750 - dsa_ossl.c RESOURCE_LEAK (marked as false positive since tmp != NULL)
CID 1457749 - apps/nseq.c : CHECKED_RETURN
CID 1457748 - cipher_aes_cbc_hmac_sha.c : SIZEOF_MISMATCH
CID 1457747 - cipher_aes_cbc_hmac_sha.c : SIZEOF_MISMATCH
CID 1457746 - same as 1457752
CID 1457745 - apps/ocsp  : CHECKED_RETURN

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
