### PR TITLE
openssl-config: add example libssl system-defaults

### DIFF
--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -469,6 +469,22 @@ Simple OpenSSL library configuration example to enter FIPS mode:
 Note: in the above example you will get an error in non FIPS capable versions
 of OpenSSL.
 
+Simple OpenSSL library configuration to make TLS 1.3 the system-default
+minimum TLS version:
+
+ # Toplevel section for openssl (including libssl)
+ openssl_conf = default_conf_section
+
+ [default_conf_section]
+ # We only specify configuration for the "ssl module"
+ ssl_conf = ssl_section
+
+ [ssl_section]
+ system_default = system_default_section
+
+ [system_default_section]
+ MinProtocol = TLSv1.3
+
 More complex OpenSSL library configuration. Add OID and don't enter FIPS mode:
 
  # Default appname: should match "appname" parameter (if any)


### PR DESCRIPTION
Provide a "simple" example for affecting the systemwide default behavior
of libssl.  The large number of mandatory nested sections makes this
less simple than the main description might suggest.


- [x] documentation is added or updated
