### PR TITLE
test/recipes/30-test_evp.t: Fix multiple definition of @bffiles

### DIFF
--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -67,11 +67,11 @@ push @defltfiles, @chachafiles unless disabled("chacha");
 my @bffiles = qw( evpciph_bf.txt );
 push @defltfiles, @bffiles unless disabled("bf");
 
-my @bffiles = qw( evpmd_md2.txt );
-push @defltfiles, @bffiles unless disabled("md2");
+my @md2files = qw( evpmd_md2.txt );
+push @defltfiles, @md2files unless disabled("md2");
 
-my @bffiles = qw( evpmd_mdc2.txt );
-push @defltfiles, @bffiles unless disabled("mdc2");
+my @mdc2files = qw( evpmd_mdc2.txt );
+push @defltfiles, @mdc2files unless disabled("mdc2");
 
 plan tests =>
     ($no_fips ? 0 : 1)          # FIPS install test


### PR DESCRIPTION
Curiously enough, perl only warned about the shadowing.  However, the
following 'plan' statement got disturbed somehow, as one could notice
the test counter say "11/?" instead of "11/25".
