### PR TITLE
Removed unused ssl_dane struct declaration.

### DIFF
--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -78,7 +78,7 @@ typedef struct asn1_sctx_st ASN1_SCTX;
 # ifdef BIGNUM
 #  undef BIGNUM
 # endif
-struct dane_st;
+
 typedef struct bio_st BIO;
 typedef struct bignum_st BIGNUM;
 typedef struct bignum_ctx BN_CTX;
@@ -227,4 +227,5 @@ typedef unsigned long ossl_uintmax_t;
 #ifdef  __cplusplus
 }
 #endif
-#endif                          /* def OPENSSL_TYPES_H */
+
+#endif /* OPENSSL_TYPES_H */


### PR DESCRIPTION
The actually used structure is named ssl_dane_st.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


