### PR TITLE
config: ensure the perl Configure run is the last statement

### DIFF
--- a/config
+++ b/config
@@ -898,14 +898,12 @@ fi
 
 OUT="$OUT"
 
-$PERL $THERE/Configure LIST | grep "$OUT" > /dev/null
-
 if [ "$OUT" = "darwin64-x86_64-cc" ]; then
     echo "WARNING! If you wish to build 32-bit libraries, then you have to"
     echo "         invoke 'KERNEL_BITS=32 $THERE/config $options'."
 fi
 
-if [ $? = "0" ]; then
+if $PERL $THERE/Configure LIST | grep "$OUT" > /dev/null; then
   if [ "$VERBOSE" = "true" ]; then
     echo /usr/bin/env \
 	 __CNF_CPPDEFINES="'$__CNF_CPPDEFINES'" \

--- a/config
+++ b/config
@@ -899,6 +899,12 @@ fi
 OUT="$OUT"
 
 $PERL $THERE/Configure LIST | grep "$OUT" > /dev/null
+
+if [ "$OUT" = "darwin64-x86_64-cc" ]; then
+    echo "WARNING! If you wish to build 32-bit libraries, then you have to"
+    echo "         invoke 'KERNEL_BITS=32 $THERE/config $options'."
+fi
+
 if [ $? = "0" ]; then
   if [ "$VERBOSE" = "true" ]; then
     echo /usr/bin/env \
@@ -929,8 +935,5 @@ else
   exit 1
 fi
 
-if [ "$OUT" = "darwin64-x86_64-cc" ]; then
-    echo "WARNING! If you wish to build 32-bit libraries, then you have to"
-    echo "         invoke 'KERNEL_BITS=32 $THERE/config $options'."
-fi
+# Do not add anothing from here on, so we don't lose the Configure exit code
 )


### PR DESCRIPTION
Running any statement after Configure means we lose its exit code

Fixes #10951
