### PR TITLE
EC: deprecate the low level ECDH, ECDSA and EC_KEY_METHOD functions.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,30 @@
      However, code that does the latter will still work as before.
      [Richard Levitte]
 
+  *) Deprecated low level ECDH and ECDSA functions.  These include:
+
+     ECDH_compute_key, ECDSA_do_sign, ECDSA_do_sign_ex, ECDSA_do_verify,
+     ECDSA_sign_setup, ECDSA_sign, ECDSA_sign_ex, ECDSA_verify and
+     ECDSA_size.
+
+     Use of these low level functions has been informally discouraged for a long
+     time.  Instead applications should use the EVP_PKEY_derive(3),
+     EVP_DigestSign(3) and EVP_DigestVerify(3) functions.
+     [Paul Dale]
+
+  *) Deprecated the EC_KEY_METHOD functions.  These include:
+
+     EC_KEY_METHOD_new, EC_KEY_METHOD_free, EC_KEY_METHOD_set_init,
+     EC_KEY_METHOD_set_keygen, EC_KEY_METHOD_set_compute_key,
+     EC_KEY_METHOD_set_sign, EC_KEY_METHOD_set_verify,
+     EC_KEY_METHOD_get_init, EC_KEY_METHOD_get_keygen,
+     EC_KEY_METHOD_get_compute_key, EC_KEY_METHOD_get_sign and
+     EC_KEY_METHOD_get_verify.
+
+     Instead applications and extension writers should use the OSSL_PROVIDER
+     APIs.
+     [Paul Dale]
+
   *) Deprecated EVP_PKEY_decrypt_old(), please use EVP_PKEY_decrypt_init()
      and EVP_PKEY_decrypt() instead.
      Deprecated EVP_PKEY_encrypt_old(), please use EVP_PKEY_encrypt_init()
@@ -60,21 +84,21 @@
   *) All of the low level MD2, MD4, MD5, MDC2, RIPEMD160, SHA1, SHA224, SHA256,
      SHA384, SHA512 and Whirlpool digest functions have been deprecated.
      These include:
-         MD2, MD2_options, MD2_Init, MD2_Update, MD2_Final, MD4, MD4_Init,
-         MD4_Update, MD4_Final, MD4_Transform, MD5, MD5_Init, MD5_Update,
-         MD5_Final, MD5_Transform, MDC2, MDC2_Init, MDC2_Update, MDC2_Final,
-         RIPEMD160, RIPEMD160_Init, RIPEMD160_Update, RIPEMD160_Final,
-         RIPEMD160_Transform, SHA1_Init, SHA1_Update, SHA1_Final,
-         SHA1_Transform, SHA224_Init, SHA224_Update, SHA224_Final,
-         SHA224_Transform, SHA256_Init, SHA256_Update, SHA256_Final,
-         SHA256_Transform, SHA384, SHA384_Init, SHA384_Update, SHA384_Final,
-         SHA512, SHA512_Init, SHA512_Update, SHA512_Final, SHA512_Transform,
-         WHIRLPOOL, WHIRLPOOL_Init, WHIRLPOOL_Update, WHIRLPOOL_BitUpdate
-         and WHIRLPOOL_Final.
 
-     Use of these low level functions has been informally discouraged for a long
-     time.  Instead applications should instead use the EVP_DigestInit_ex,
-     EVP_DigestUpdate(3) and EVP_DigestFinal_ex(3) functions.
+     MD2, MD2_options, MD2_Init, MD2_Update, MD2_Final, MD4, MD4_Init,
+     MD4_Update, MD4_Final, MD4_Transform, MD5, MD5_Init, MD5_Update,
+     MD5_Final, MD5_Transform, MDC2, MDC2_Init, MDC2_Update, MDC2_Final,
+     RIPEMD160, RIPEMD160_Init, RIPEMD160_Update, RIPEMD160_Final,
+     RIPEMD160_Transform, SHA1_Init, SHA1_Update, SHA1_Final, SHA1_Transform,
+     SHA224_Init, SHA224_Update, SHA224_Final, SHA224_Transform, SHA256_Init,
+     SHA256_Update, SHA256_Final, SHA256_Transform, SHA384, SHA384_Init,
+     SHA384_Update, SHA384_Final, SHA512, SHA512_Init, SHA512_Update,
+     SHA512_Final, SHA512_Transform, WHIRLPOOL, WHIRLPOOL_Init,
+     WHIRLPOOL_Update, WHIRLPOOL_BitUpdate and WHIRLPOOL_Final.
+
+     Use of these low level functions has been informally discouraged
+     for a long time.  Applications should use the EVP_DigestInit_ex(3),
+     EVP_DigestUpdate(3) and EVP_DigestFinal_ex(3) functions instead.
      [Paul Dale]
 
   *) Corrected the documentation of the return values from the EVP_DigestSign*
@@ -87,6 +111,7 @@
      [Richard Levitte]
 
   *) All of the low level cipher functions have been deprecated including:
+
      AES_options, AES_set_encrypt_key, AES_set_decrypt_key, AES_encrypt,
      AES_decrypt, AES_ecb_encrypt, AES_cbc_encrypt, AES_cfb128_encrypt,
      AES_cfb1_encrypt, AES_cfb8_encrypt, AES_ofb128_encrypt,
@@ -117,10 +142,10 @@
      SEED_set_key, SEED_encrypt, SEED_decrypt, SEED_ecb_encrypt,
      SEED_cbc_encrypt, SEED_cfb128_encrypt and SEED_ofb128_encrypt.
 
-     Use of these low level functions has been informally discouraged for a long
-     time. Instead applications should use the high level EVP APIs, e.g.
+     Use of these low level functions has been informally discouraged for
+     a long time. Applications should use the high level EVP APIs, e.g.
      EVP_EncryptInit_ex, EVP_EncryptUpdate, EVP_EncryptFinal_ex, and the
-     equivalently named decrypt functions.
+     equivalently named decrypt functions instead.
      [Matt Caswell and Paul Dale]
 
   *) Removed include/openssl/opensslconf.h.in and replaced it with

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1110,6 +1110,7 @@ static int DSA_verify_loop(void *args)
 #endif
 
 #ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 static long ecdsa_c[ECDSA_NUM][2];
 static int ECDSA_sign_loop(void *args)
 {
@@ -1150,6 +1151,7 @@ static int ECDSA_verify_loop(void *args)
     }
     return count;
 }
+# endif
 
 /* ******************************************************************** */
 static long ecdh_c[EC_NUM][1];
@@ -3020,6 +3022,7 @@ int speed_main(int argc, char **argv)
 #endif                          /* OPENSSL_NO_DSA */
 
 #ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_DEPRECATED_3_0
     for (testnum = 0; testnum < ECDSA_NUM; testnum++) {
         int st = 1;
 
@@ -3102,6 +3105,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
+# endif
 
     for (testnum = 0; testnum < EC_NUM; testnum++) {
         int ecdh_checks = 1;
@@ -3398,7 +3402,7 @@ int speed_main(int argc, char **argv)
             st = 0; /* set back to zero */
             /* attach it sooner to rely on main final cleanup */
             loopargs[i].sm2_pkey[testnum] = sm2_pkey;
-            loopargs[i].sigsize = ECDSA_size(EVP_PKEY_get0_EC_KEY(sm2_pkey));
+            loopargs[i].sigsize = EVP_PKEY_size(sm2_pkey);
 
             sm2_pctx = EVP_PKEY_CTX_new(sm2_pkey, NULL);
             sm2_vfy_pctx = EVP_PKEY_CTX_new(sm2_pkey, NULL);
@@ -3406,6 +3410,7 @@ int speed_main(int argc, char **argv)
                 EVP_PKEY_CTX_free(sm2_vfy_pctx);
                 break;
             }
+
             /* attach them directly to respective ctx */
             EVP_MD_CTX_set_pkey_ctx(loopargs[i].sm2_ctx[testnum], sm2_pctx);
             EVP_MD_CTX_set_pkey_ctx(loopargs[i].sm2_vfy_ctx[testnum], sm2_vfy_pctx);

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include "ec_local.h"
 #include <openssl/evp.h>

--- a/crypto/ec/ec2_oct.c
+++ b/crypto/ec/ec2_oct.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/err.h>
 
 #include "ec_local.h"

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/err.h>
 
 #include "crypto/bn.h"

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDH and ECDSA low level APIs are deprecated for public use, but still ok
+ * for internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/x509.h>

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include "ec_local.h"
 #include <openssl/err.h>

--- a/crypto/ec/ec_check.c
+++ b/crypto/ec/ec_check.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "ec_local.h"
 #include <openssl/err.h>
 

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include "ec_local.h"
 #include <openssl/err.h>

--- a/crypto/ec/ec_cvt.c
+++ b/crypto/ec/ec_cvt.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/err.h>
 #include "crypto/bn.h"
 #include "ec_local.h"

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "internal/cryptlib.h"
 #include <string.h>
 #include "ec_local.h"

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDH and ECDSA low level APIs are deprecated for public use, but still ok
+ * for internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/ec.h>
 #include <openssl/engine.h>

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 
 #include <openssl/err.h>

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/err.h>
 

--- a/crypto/ec/ec_oct.c
+++ b/crypto/ec/ec_oct.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 
 #include <openssl/err.h>

--- a/crypto/ec/ec_pmeth.c
+++ b/crypto/ec/ec_pmeth.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDH and ECDSA low level APIs are deprecated for public use, but still ok
+ * for internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/asn1t.h>

--- a/crypto/ec/ec_print.c
+++ b/crypto/ec/ec_print.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include "ec_local.h"

--- a/crypto/ec/ecdh_kdf.c
+++ b/crypto/ec/ecdh_kdf.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDH low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/core_names.h>
 #include <openssl/ec.h>

--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDH low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <limits.h>
 

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/obj_mac.h>

--- a/crypto/ec/ecdsa_sign.c
+++ b/crypto/ec/ecdsa_sign.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/ec.h>
 #include "ec_local.h"
 #include <openssl/err.h>

--- a/crypto/ec/ecdsa_vrf.c
+++ b/crypto/ec/ecdsa_vrf.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/ec.h>
 #include "ec_local.h"
 #include <openssl/err.h>

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/err.h>
 
 #include "ec_local.h"

--- a/crypto/ec/ecp_nist.c
+++ b/crypto/ec/ecp_nist.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <limits.h>
 
 #include <openssl/err.h>

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -24,6 +24,12 @@
  */
 
 /*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
+/*
  * A 64-bit implementation of the NIST P-224 elliptic curve point multiplication
  *
  * Inspired by Daniel J. Bernstein's public domain nistp224 implementation

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -24,6 +24,12 @@
  */
 
 /*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
+/*
  * A 64-bit implementation of the NIST P-256 elliptic curve point multiplication
  *
  * OpenSSL integration was taken from Emilia Kasper's work in ecp_nistp224.c.

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -24,6 +24,12 @@
  */
 
 /*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
+/*
  * A 64-bit implementation of the NIST P-521 elliptic curve point multiplication
  *
  * OpenSSL integration was taken from Emilia Kasper's work in ecp_nistp224.c.

--- a/crypto/ec/ecp_nistputil.c
+++ b/crypto/ec/ecp_nistputil.c
@@ -23,6 +23,12 @@
  *  limitations under the License.
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/opensslconf.h>
 #ifdef OPENSSL_NO_EC_NISTP_64_GCC_128
 NON_EMPTY_TRANSLATION_UNIT

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -18,6 +18,12 @@
  *                          256 Bit Primes"
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <string.h>
 
 #include "internal/cryptlib.h"

--- a/crypto/ec/ecp_oct.c
+++ b/crypto/ec/ecp_oct.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/err.h>
 #include <openssl/symhacks.h>
 

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -8,6 +8,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/err.h>
 #include <openssl/symhacks.h>
 

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/x509.h>

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -9,6 +9,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "crypto/sm2.h"
 #include "crypto/sm2err.h"
 #include "crypto/ec.h" /* ecdh_KDF_X9_63() */

--- a/crypto/sm2/sm2_pmeth.c
+++ b/crypto/sm2/sm2_pmeth.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * ECDSA low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "internal/cryptlib.h"
 #include <openssl/asn1t.h>
 #include <openssl/ec.h>

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/buffer.h>

--- a/doc/man3/ECDSA_SIG_new.pod
+++ b/doc/man3/ECDSA_SIG_new.pod
@@ -18,6 +18,11 @@ functions
  const BIGNUM *ECDSA_SIG_get0_r(const ECDSA_SIG *sig);
  const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
  int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  int ECDSA_size(const EC_KEY *eckey);
 
  int ECDSA_sign(int type, const unsigned char *dgst, int dgstlen,
@@ -39,10 +44,6 @@ functions
                    const BIGNUM *kinv, const BIGNUM *rp, EC_KEY *eckey);
 
 =head1 DESCRIPTION
-
-Note: these functions provide a low level interface to ECDSA. Most
-applications should use the higher level B<EVP> interface such as
-L<EVP_DigestSignInit(3)> or L<EVP_DigestVerifyInit(3)> instead.
 
 B<ECDSA_SIG> is an opaque structure consisting of two BIGNUMs for the
 B<r> and B<s> value of an ECDSA signature (see X9.62 or FIPS 186-2).
@@ -69,8 +70,13 @@ after this function has been called.
 See L<i2d_ECDSA_SIG(3)> and L<d2i_ECDSA_SIG(3)> for information about encoding
 and decoding ECDSA signatures to/from DER.
 
+All of the functions described below are deprecated. Applications should
+use the higher level B<EVP> interface such as L<EVP_DigestSignInit(3)>
+or L<EVP_DigestVerifyInit(3)> instead.
+
 ECDSA_size() returns the maximum length of a DER encoded ECDSA signature
-created with the private EC key B<eckey>.
+created with the private EC key B<eckey>. To obtain the actual signature
+size use L<EVP_PKEY_sign(3)> with a NULL B<sig> parameter.
 
 ECDSA_sign() computes a digital signature of the B<dgstlen> bytes hash value
 B<dgst> using the private EC key B<eckey>. The DER encoded signatures is
@@ -194,8 +200,15 @@ ANSI X9.62, US Federal Information Processing Standard FIPS 186-2
 L<EC_KEY_new(3)>,
 L<EVP_DigestSignInit(3)>,
 L<EVP_DigestVerifyInit(3)>,
+L<EVP_PKEY_sign(3)>
 L<i2d_ECDSA_SIG(3)>,
 L<d2i_ECDSA_SIG(3)>
+
+=head1 HISTORY
+
+The ECDSA_size(), ECDSA_sign(), ECDSA_do_sign(), ECDSA_verify(),
+ECDSA_do_verify(), ECDSA_sign_setup(), ECDSA_sign_ex() and ECDSA_do_sign_ex()
+functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -15,6 +15,9 @@
  * asn1 <data structure>
  */
 
+/* We need to use some deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/asn1.h>
@@ -340,7 +343,9 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     DO_TEST_PRINT_OFFSET(EC_GROUP, d2i_ECPKParameters, i2d_ECPKParameters, ECPKParameters_print);
     DO_TEST_PRINT_OFFSET(EC_KEY, d2i_ECPrivateKey, i2d_ECPrivateKey, EC_KEY_print);
     DO_TEST(EC_KEY, d2i_ECParameters, i2d_ECParameters, ECParameters_print);
+# ifndef OPENSSL_NO_DEPRECATED_3_0
     DO_TEST_NO_PRINT(ECDSA_SIG, d2i_ECDSA_SIG, i2d_ECDSA_SIG);
+# endif
 #endif
     DO_TEST_PRINT_PCTX(EVP_PKEY, d2i_AutoPrivateKey, i2d_PrivateKey, EVP_PKEY_print_private);
     DO_TEST(SSL_SESSION, d2i_SSL_SESSION, i2d_SSL_SESSION, SSL_SESSION_print);

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1246,8 +1246,8 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
  *  \param  eckey     EC_KEY object containing a private EC key
  *  \return pointer to a ECDSA_SIG structure or NULL if an error occurred
  */
-ECDSA_SIG *ECDSA_do_sign(const unsigned char *dgst, int dgst_len,
-                         EC_KEY *eckey);
+DEPRECATEDIN_3_0(ECDSA_SIG *ECDSA_do_sign(const unsigned char *dgst,
+                                          int dgst_len, EC_KEY *eckey))
 
 /** Computes ECDSA signature of a given hash value using the supplied
  *  private key (note: sig must point to ECDSA_size(eckey) bytes of memory).
@@ -1259,9 +1259,9 @@ ECDSA_SIG *ECDSA_do_sign(const unsigned char *dgst, int dgst_len,
  *  \param  eckey    EC_KEY object containing a private EC key
  *  \return pointer to a ECDSA_SIG structure or NULL if an error occurred
  */
-ECDSA_SIG *ECDSA_do_sign_ex(const unsigned char *dgst, int dgstlen,
-                            const BIGNUM *kinv, const BIGNUM *rp,
-                            EC_KEY *eckey);
+DEPRECATEDIN_3_0(ECDSA_SIG *ECDSA_do_sign_ex(const unsigned char *dgst,
+                                             int dgstlen, const BIGNUM *kinv,
+                                             const BIGNUM *rp, EC_KEY *eckey))
 
 /** Verifies that the supplied signature is a valid ECDSA
  *  signature of the supplied hash value using the supplied public key.
@@ -1272,8 +1272,8 @@ ECDSA_SIG *ECDSA_do_sign_ex(const unsigned char *dgst, int dgstlen,
  *  \return 1 if the signature is valid, 0 if the signature is invalid
  *          and -1 on error
  */
-int ECDSA_do_verify(const unsigned char *dgst, int dgst_len,
-                    const ECDSA_SIG *sig, EC_KEY *eckey);
+DEPRECATEDIN_3_0(int ECDSA_do_verify(const unsigned char *dgst, int dgst_len,
+                                     const ECDSA_SIG *sig, EC_KEY *eckey))
 
 /** Precompute parts of the signing operation
  *  \param  eckey  EC_KEY object containing a private EC key
@@ -1282,7 +1282,8 @@ int ECDSA_do_verify(const unsigned char *dgst, int dgst_len,
  *  \param  rp     BIGNUM pointer for x coordinate of k * generator
  *  \return 1 on success and 0 otherwise
  */
-int ECDSA_sign_setup(EC_KEY *eckey, BN_CTX *ctx, BIGNUM **kinv, BIGNUM **rp);
+DEPRECATEDIN_3_0(int ECDSA_sign_setup(EC_KEY *eckey, BN_CTX *ctx,
+                                      BIGNUM **kinv, BIGNUM **rp))
 
 /** Computes ECDSA signature of a given hash value using the supplied
  *  private key (note: sig must point to ECDSA_size(eckey) bytes of memory).
@@ -1294,8 +1295,9 @@ int ECDSA_sign_setup(EC_KEY *eckey, BN_CTX *ctx, BIGNUM **kinv, BIGNUM **rp);
  *  \param  eckey    EC_KEY object containing a private EC key
  *  \return 1 on success and 0 otherwise
  */
-int ECDSA_sign(int type, const unsigned char *dgst, int dgstlen,
-               unsigned char *sig, unsigned int *siglen, EC_KEY *eckey);
+DEPRECATEDIN_3_0(int ECDSA_sign(int type, const unsigned char *dgst,
+                                int dgstlen, unsigned char *sig,
+                                unsigned int *siglen, EC_KEY *eckey))
 
 /** Computes ECDSA signature of a given hash value using the supplied
  *  private key (note: sig must point to ECDSA_size(eckey) bytes of memory).
@@ -1310,9 +1312,10 @@ int ECDSA_sign(int type, const unsigned char *dgst, int dgstlen,
  *  \param  eckey    EC_KEY object containing a private EC key
  *  \return 1 on success and 0 otherwise
  */
-int ECDSA_sign_ex(int type, const unsigned char *dgst, int dgstlen,
-                  unsigned char *sig, unsigned int *siglen,
-                  const BIGNUM *kinv, const BIGNUM *rp, EC_KEY *eckey);
+DEPRECATEDIN_3_0(int ECDSA_sign_ex(int type, const unsigned char *dgst,
+                                   int dgstlen, unsigned char *sig,
+                                   unsigned int *siglen, const BIGNUM *kinv,
+                                   const BIGNUM *rp, EC_KEY *eckey))
 
 /** Verifies that the given signature is valid ECDSA signature
  *  of the supplied hash value using the specified public key.
@@ -1325,8 +1328,9 @@ int ECDSA_sign_ex(int type, const unsigned char *dgst, int dgstlen,
  *  \return 1 if the signature is valid, 0 if the signature is invalid
  *          and -1 on error
  */
-int ECDSA_verify(int type, const unsigned char *dgst, int dgstlen,
-                 const unsigned char *sig, int siglen, EC_KEY *eckey);
+DEPRECATEDIN_3_0(int ECDSA_verify(int type, const unsigned char *dgst,
+                                  int dgstlen, const unsigned char *sig,
+                                  int siglen, EC_KEY *eckey))
 
 /** Returns the maximum length of the DER encoded signature
  *  \param  eckey  EC_KEY object
@@ -1338,96 +1342,105 @@ DEPRECATEDIN_3_0(int ECDSA_size(const EC_KEY *eckey))
 /*  EC_KEY_METHOD constructors, destructors, writers and accessors  */
 /********************************************************************/
 
-EC_KEY_METHOD *EC_KEY_METHOD_new(const EC_KEY_METHOD *meth);
-void EC_KEY_METHOD_free(EC_KEY_METHOD *meth);
-void EC_KEY_METHOD_set_init(EC_KEY_METHOD *meth,
-                            int (*init)(EC_KEY *key),
-                            void (*finish)(EC_KEY *key),
-                            int (*copy)(EC_KEY *dest, const EC_KEY *src),
-                            int (*set_group)(EC_KEY *key, const EC_GROUP *grp),
-                            int (*set_private)(EC_KEY *key,
-                                               const BIGNUM *priv_key),
-                            int (*set_public)(EC_KEY *key,
-                                              const EC_POINT *pub_key));
+DEPRECATEDIN_3_0(EC_KEY_METHOD *EC_KEY_METHOD_new(const EC_KEY_METHOD *meth))
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_free(EC_KEY_METHOD *meth))
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_set_init
+                 (EC_KEY_METHOD *meth,
+                  int (*init)(EC_KEY *key),
+                  void (*finish)(EC_KEY *key),
+                  int (*copy)(EC_KEY *dest, const EC_KEY *src),
+                  int (*set_group)(EC_KEY *key, const EC_GROUP *grp),
+                  int (*set_private)(EC_KEY *key,
+                                     const BIGNUM *priv_key),
+                  int (*set_public)(EC_KEY *key,
+                                    const EC_POINT *pub_key)))
 
-void EC_KEY_METHOD_set_keygen(EC_KEY_METHOD *meth,
-                              int (*keygen)(EC_KEY *key));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_set_keygen(EC_KEY_METHOD *meth,
+                                               int (*keygen)(EC_KEY *key)))
 
-void EC_KEY_METHOD_set_compute_key(EC_KEY_METHOD *meth,
-                                   int (*ckey)(unsigned char **psec,
-                                               size_t *pseclen,
-                                               const EC_POINT *pub_key,
-                                               const EC_KEY *ecdh));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_set_compute_key
+                 (EC_KEY_METHOD *meth,
+                  int (*ckey)(unsigned char **psec,
+                              size_t *pseclen,
+                              const EC_POINT *pub_key,
+                              const EC_KEY *ecdh)))
 
-void EC_KEY_METHOD_set_sign(EC_KEY_METHOD *meth,
-                            int (*sign)(int type, const unsigned char *dgst,
-                                        int dlen, unsigned char *sig,
-                                        unsigned int *siglen,
-                                        const BIGNUM *kinv, const BIGNUM *r,
-                                        EC_KEY *eckey),
-                            int (*sign_setup)(EC_KEY *eckey, BN_CTX *ctx_in,
-                                              BIGNUM **kinvp, BIGNUM **rp),
-                            ECDSA_SIG *(*sign_sig)(const unsigned char *dgst,
-                                                   int dgst_len,
-                                                   const BIGNUM *in_kinv,
-                                                   const BIGNUM *in_r,
-                                                   EC_KEY *eckey));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_set_sign
+                 (EC_KEY_METHOD *meth,
+                  int (*sign)(int type, const unsigned char *dgst,
+                              int dlen, unsigned char *sig,
+                              unsigned int *siglen,
+                              const BIGNUM *kinv, const BIGNUM *r,
+                              EC_KEY *eckey),
+                  int (*sign_setup)(EC_KEY *eckey, BN_CTX *ctx_in,
+                                    BIGNUM **kinvp, BIGNUM **rp),
+                  ECDSA_SIG *(*sign_sig)(const unsigned char *dgst,
+                                         int dgst_len,
+                                         const BIGNUM *in_kinv,
+                                         const BIGNUM *in_r,
+                                         EC_KEY *eckey)))
 
-void EC_KEY_METHOD_set_verify(EC_KEY_METHOD *meth,
-                              int (*verify)(int type, const unsigned
-                                            char *dgst, int dgst_len,
-                                            const unsigned char *sigbuf,
-                                            int sig_len, EC_KEY *eckey),
-                              int (*verify_sig)(const unsigned char *dgst,
-                                                int dgst_len,
-                                                const ECDSA_SIG *sig,
-                                                EC_KEY *eckey));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_set_verify
+                 (EC_KEY_METHOD *meth,
+                  int (*verify)(int type, const unsigned
+                                char *dgst, int dgst_len,
+                                const unsigned char *sigbuf,
+                                int sig_len, EC_KEY *eckey),
+                  int (*verify_sig)(const unsigned char *dgst,
+                                    int dgst_len,
+                                    const ECDSA_SIG *sig,
+                                    EC_KEY *eckey)))
 
-void EC_KEY_METHOD_get_init(const EC_KEY_METHOD *meth,
-                            int (**pinit)(EC_KEY *key),
-                            void (**pfinish)(EC_KEY *key),
-                            int (**pcopy)(EC_KEY *dest, const EC_KEY *src),
-                            int (**pset_group)(EC_KEY *key,
-                                               const EC_GROUP *grp),
-                            int (**pset_private)(EC_KEY *key,
-                                                 const BIGNUM *priv_key),
-                            int (**pset_public)(EC_KEY *key,
-                                                const EC_POINT *pub_key));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_get_init
+                 (const EC_KEY_METHOD *meth,
+                  int (**pinit)(EC_KEY *key),
+                  void (**pfinish)(EC_KEY *key),
+                  int (**pcopy)(EC_KEY *dest, const EC_KEY *src),
+                  int (**pset_group)(EC_KEY *key,
+                                     const EC_GROUP *grp),
+                  int (**pset_private)(EC_KEY *key,
+                                       const BIGNUM *priv_key),
+                  int (**pset_public)(EC_KEY *key,
+                                      const EC_POINT *pub_key)))
 
-void EC_KEY_METHOD_get_keygen(const EC_KEY_METHOD *meth,
-                              int (**pkeygen)(EC_KEY *key));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_get_keygen(const EC_KEY_METHOD *meth,
+                                               int (**pkeygen)(EC_KEY *key)))
 
-void EC_KEY_METHOD_get_compute_key(const EC_KEY_METHOD *meth,
-                                   int (**pck)(unsigned char **psec,
-                                               size_t *pseclen,
-                                               const EC_POINT *pub_key,
-                                               const EC_KEY *ecdh));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_get_compute_key
+                 (const EC_KEY_METHOD *meth,
+                  int (**pck)(unsigned char **psec,
+                              size_t *pseclen,
+                              const EC_POINT *pub_key,
+                              const EC_KEY *ecdh)))
 
-void EC_KEY_METHOD_get_sign(const EC_KEY_METHOD *meth,
-                            int (**psign)(int type, const unsigned char *dgst,
-                                          int dlen, unsigned char *sig,
-                                          unsigned int *siglen,
-                                          const BIGNUM *kinv, const BIGNUM *r,
-                                          EC_KEY *eckey),
-                            int (**psign_setup)(EC_KEY *eckey, BN_CTX *ctx_in,
-                                                BIGNUM **kinvp, BIGNUM **rp),
-                            ECDSA_SIG *(**psign_sig)(const unsigned char *dgst,
-                                                     int dgst_len,
-                                                     const BIGNUM *in_kinv,
-                                                     const BIGNUM *in_r,
-                                                     EC_KEY *eckey));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_get_sign
+                 (const EC_KEY_METHOD *meth,
+                  int (**psign)(int type, const unsigned char *dgst,
+                                int dlen, unsigned char *sig,
+                                unsigned int *siglen,
+                                const BIGNUM *kinv, const BIGNUM *r,
+                                EC_KEY *eckey),
+                  int (**psign_setup)(EC_KEY *eckey, BN_CTX *ctx_in,
+                                      BIGNUM **kinvp, BIGNUM **rp),
+                  ECDSA_SIG *(**psign_sig)(const unsigned char *dgst,
+                                           int dgst_len,
+                                           const BIGNUM *in_kinv,
+                                           const BIGNUM *in_r,
+                                           EC_KEY *eckey)))
 
-void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
-                              int (**pverify)(int type, const unsigned
-                                              char *dgst, int dgst_len,
-                                              const unsigned char *sigbuf,
-                                              int sig_len, EC_KEY *eckey),
-                              int (**pverify_sig)(const unsigned char *dgst,
-                                                  int dgst_len,
-                                                  const ECDSA_SIG *sig,
-                                                  EC_KEY *eckey));
+DEPRECATEDIN_3_0(void EC_KEY_METHOD_get_verify
+                 (const EC_KEY_METHOD *meth,
+                  int (**pverify)(int type, const unsigned
+                                  char *dgst, int dgst_len,
+                                  const unsigned char *sigbuf,
+                                  int sig_len, EC_KEY *eckey),
+                  int (**pverify_sig)(const unsigned char *dgst,
+                                      int dgst_len,
+                                      const ECDSA_SIG *sig,
+                                      EC_KEY *eckey)))
 
-#  define ECParameters_dup(x) ASN1_dup_of(EC_KEY,i2d_ECParameters,d2i_ECParameters,x)
+#  define ECParameters_dup(x) ASN1_dup_of(EC_KEY, i2d_ECParameters, \
+                                           d2i_ECParameters, x)
 
 #  ifndef __cplusplus
 #   if defined(__SUNPRO_C)
@@ -1439,76 +1452,75 @@ void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
 
 #  define EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_PARAMGEN|EVP_PKEY_OP_KEYGEN, \
-                                EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, NULL)
+                          EVP_PKEY_OP_PARAMGEN|EVP_PKEY_OP_KEYGEN, \
+                          EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, NULL)
 
 #  define EVP_PKEY_CTX_set_ec_param_enc(ctx, flag) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_PARAMGEN|EVP_PKEY_OP_KEYGEN, \
-                                EVP_PKEY_CTRL_EC_PARAM_ENC, flag, NULL)
+                          EVP_PKEY_OP_PARAMGEN|EVP_PKEY_OP_KEYGEN, \
+                          EVP_PKEY_CTRL_EC_PARAM_ENC, flag, NULL)
 
 #  define EVP_PKEY_CTX_set_ecdh_cofactor_mode(ctx, flag) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_ECDH_COFACTOR, flag, NULL)
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_ECDH_COFACTOR, flag, NULL)
 
 #  define EVP_PKEY_CTX_get_ecdh_cofactor_mode(ctx) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_ECDH_COFACTOR, -2, NULL)
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_ECDH_COFACTOR, -2, NULL)
 
 #  define EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, kdf) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_KDF_TYPE, kdf, NULL)
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_KDF_TYPE, kdf, NULL)
 
 #  define EVP_PKEY_CTX_get_ecdh_kdf_type(ctx) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_KDF_TYPE, -2, NULL)
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_KDF_TYPE, -2, NULL)
 
 #  define EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, md) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_KDF_MD, 0, (void *)(md))
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_KDF_MD, 0, (void *)(md))
 
 #  define EVP_PKEY_CTX_get_ecdh_kdf_md(ctx, pmd) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_GET_EC_KDF_MD, 0, (void *)(pmd))
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_GET_EC_KDF_MD, 0, (void *)(pmd))
 
 #  define EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, len) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_KDF_OUTLEN, len, NULL)
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_KDF_OUTLEN, len, NULL)
 
 #  define EVP_PKEY_CTX_get_ecdh_kdf_outlen(ctx, plen) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN, 0, \
-                                (void *)(plen))
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN, 0, (void *)(plen))
 
 #  define EVP_PKEY_CTX_set0_ecdh_kdf_ukm(ctx, p, plen) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_EC_KDF_UKM, plen, (void *)(p))
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_EC_KDF_UKM, plen, (void *)(p))
 
 #  define EVP_PKEY_CTX_get0_ecdh_kdf_ukm(ctx, p) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
-                                EVP_PKEY_OP_DERIVE, \
-                                EVP_PKEY_CTRL_GET_EC_KDF_UKM, 0, (void *)(p))
+                          EVP_PKEY_OP_DERIVE, \
+                          EVP_PKEY_CTRL_GET_EC_KDF_UKM, 0, (void *)(p))
 
 /* SM2 will skip the operation check so no need to pass operation here */
 #  define EVP_PKEY_CTX_set1_id(ctx, id, id_len) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
-                                EVP_PKEY_CTRL_SET1_ID, (int)id_len, (void*)(id))
+                          EVP_PKEY_CTRL_SET1_ID, (int)id_len, (void*)(id))
 #  define EVP_PKEY_CTX_get1_id(ctx, id) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
-                                EVP_PKEY_CTRL_GET1_ID, 0, (void*)(id))
+                          EVP_PKEY_CTRL_GET1_ID, 0, (void*)(id))
 
 #  define EVP_PKEY_CTX_get1_id_len(ctx, id_len) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
-                                EVP_PKEY_CTRL_GET1_ID_LEN, 0, (void*)(id_len))
+                          EVP_PKEY_CTRL_GET1_ID_LEN, 0, (void*)(id_len))
 
 #  define EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID         (EVP_PKEY_ALG_CTRL + 1)
 #  define EVP_PKEY_CTRL_EC_PARAM_ENC                  (EVP_PKEY_ALG_CTRL + 2)
@@ -1523,15 +1535,16 @@ void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
 #  define EVP_PKEY_CTRL_SET1_ID                       (EVP_PKEY_ALG_CTRL + 11)
 #  define EVP_PKEY_CTRL_GET1_ID                       (EVP_PKEY_ALG_CTRL + 12)
 #  define EVP_PKEY_CTRL_GET1_ID_LEN                   (EVP_PKEY_ALG_CTRL + 13)
+
 /* KDF types */
-#  define EVP_PKEY_ECDH_KDF_NONE                     1
-#  define EVP_PKEY_ECDH_KDF_X9_63                    2
+#  define EVP_PKEY_ECDH_KDF_NONE                      1
+#  define EVP_PKEY_ECDH_KDF_X9_63                     2
 /** The old name for EVP_PKEY_ECDH_KDF_X9_63
  *  The ECDH KDF specification has been mistakingly attributed to ANSI X9.62,
  *  it is actually specified in ANSI X9.63.
  *  This identifier is retained for backwards compatibility
  */
-#   define EVP_PKEY_ECDH_KDF_X9_62   EVP_PKEY_ECDH_KDF_X9_63
+#  define EVP_PKEY_ECDH_KDF_X9_62   EVP_PKEY_ECDH_KDF_X9_63
 
 #  ifdef  __cplusplus
 }

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1180,10 +1180,11 @@ DEPRECATEDIN_3_0(int ECDH_KDF_X9_62(unsigned char *out, size_t outlen,
                                     const unsigned char *sinfo, size_t sinfolen,
                                     const EVP_MD *md))
 
-int ECDH_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
-                     const EC_KEY *ecdh,
-                     void *(*KDF) (const void *in, size_t inlen,
-                                   void *out, size_t *outlen));
+DEPRECATEDIN_3_0(int ECDH_compute_key(void *out, size_t outlen,
+                                      const EC_POINT *pub_key,
+                                      const EC_KEY *ecdh,
+                                      void *(*KDF)(const void *in, size_t inlen,
+                                                   void *out, size_t *outlen)))
 
 typedef struct ECDSA_SIG_st ECDSA_SIG;
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -20,19 +20,19 @@
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_EC
-# include <openssl/asn1.h>
-# include <openssl/symhacks.h>
-# ifndef OPENSSL_NO_DEPRECATED_1_1_0
-#  include <openssl/bn.h>
-# endif
-# include <openssl/ecerr.h>
-# ifdef  __cplusplus
+#  include <openssl/asn1.h>
+#  include <openssl/symhacks.h>
+#  ifndef OPENSSL_NO_DEPRECATED_1_1_0
+#   include <openssl/bn.h>
+#  endif
+#  include <openssl/ecerr.h>
+#  ifdef  __cplusplus
 extern "C" {
-# endif
+#  endif
 
-# ifndef OPENSSL_ECC_MAX_FIELD_BITS
-#  define OPENSSL_ECC_MAX_FIELD_BITS 661
-# endif
+#  ifndef OPENSSL_ECC_MAX_FIELD_BITS
+#   define OPENSSL_ECC_MAX_FIELD_BITS 661
+#  endif
 
 /** Enum for the point conversion form as defined in X9.62 (ECDSA)
  *  for the encoding of a elliptic curve point (x,y) */
@@ -73,7 +73,7 @@ const EC_METHOD *EC_GFp_mont_method(void);
  */
 const EC_METHOD *EC_GFp_nist_method(void);
 
-# ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
+#  ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
 /** Returns 64-bit optimized methods for nistp224
  *  \return  EC_METHOD object
  */
@@ -88,9 +88,9 @@ const EC_METHOD *EC_GFp_nistp256_method(void);
  *  \return  EC_METHOD object
  */
 const EC_METHOD *EC_GFp_nistp521_method(void);
-# endif
+#  endif
 
-# ifndef OPENSSL_NO_EC2M
+#  ifndef OPENSSL_NO_EC2M
 /********************************************************************/
 /*           EC_METHOD for curves over GF(2^m)                      */
 /********************************************************************/
@@ -100,7 +100,7 @@ const EC_METHOD *EC_GFp_nistp521_method(void);
  */
 const EC_METHOD *EC_GF2m_simple_method(void);
 
-# endif
+#  endif
 
 /********************************************************************/
 /*                   EC_GROUP functions                             */
@@ -298,7 +298,7 @@ DEPRECATEDIN_3_0(int EC_GROUP_get_curve_GFp(const EC_GROUP *group, BIGNUM *p,
                                           BIGNUM *a, BIGNUM *b,
                                           BN_CTX *ctx))
 
-# ifndef OPENSSL_NO_EC2M
+#  ifndef OPENSSL_NO_EC2M
 /** Sets the parameter of an ec curve. Synonym for EC_GROUP_set_curve
  *  \param  group  EC_GROUP object
  *  \param  p      BIGNUM with the prime number (GFp) or the polynomial
@@ -324,7 +324,7 @@ DEPRECATEDIN_3_0(int EC_GROUP_set_curve_GF2m(EC_GROUP *group, const BIGNUM *p,
 DEPRECATEDIN_3_0(int EC_GROUP_get_curve_GF2m(const EC_GROUP *group, BIGNUM *p,
                                            BIGNUM *a, BIGNUM *b,
                                            BN_CTX *ctx))
-# endif
+#  endif
 /** Returns the number of bits needed to represent a field element
  *  \param  group  EC_GROUP object
  *  \return number of bits needed to represent a field element
@@ -368,7 +368,7 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx);
  */
 EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
                                  const BIGNUM *b, BN_CTX *ctx);
-# ifndef OPENSSL_NO_EC2M
+#  ifndef OPENSSL_NO_EC2M
 /** Creates a new EC_GROUP object with the specified parameters defined
  *  over GF2m (defined by the equation y^2 + x*y = x^3 + a*x^2 + b)
  *  \param  p    BIGNUM with the polynomial defining the underlying field
@@ -379,7 +379,7 @@ EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
  */
 EC_GROUP *EC_GROUP_new_curve_GF2m(const BIGNUM *p, const BIGNUM *a,
                                   const BIGNUM *b, BN_CTX *ctx);
-# endif
+#  endif
 
 /**
  * Creates a EC_GROUP object with a curve specified by a NID
@@ -609,7 +609,7 @@ DEPRECATEDIN_3_0(int EC_POINT_set_compressed_coordinates_GFp(const EC_GROUP *gro
                                                            const BIGNUM *x,
                                                            int y_bit,
                                                            BN_CTX *ctx))
-# ifndef OPENSSL_NO_EC2M
+#  ifndef OPENSSL_NO_EC2M
 /** Sets the affine coordinates of an EC_POINT. A synonym of
  *  EC_POINT_set_affine_coordinates
  *  \param  group  underlying EC_GROUP object
@@ -654,7 +654,7 @@ DEPRECATEDIN_3_0(int EC_POINT_set_compressed_coordinates_GF2m(const EC_GROUP *gr
                                                             const BIGNUM *x,
                                                             int y_bit,
                                                             BN_CTX *ctx))
-# endif
+#  endif
 /** Encodes a EC_POINT object to a octet string
  *  \param  group  underlying EC_GROUP object
  *  \param  p      EC_POINT object
@@ -818,42 +818,45 @@ DECLARE_ASN1_ALLOC_FUNCTIONS(ECPARAMETERS)
  * represent the field elements
  */
 int EC_GROUP_get_basis_type(const EC_GROUP *);
-# ifndef OPENSSL_NO_EC2M
+#  ifndef OPENSSL_NO_EC2M
 int EC_GROUP_get_trinomial_basis(const EC_GROUP *, unsigned int *k);
 int EC_GROUP_get_pentanomial_basis(const EC_GROUP *, unsigned int *k1,
                                    unsigned int *k2, unsigned int *k3);
-# endif
+#  endif
 
-# define OPENSSL_EC_EXPLICIT_CURVE  0x000
-# define OPENSSL_EC_NAMED_CURVE     0x001
+#  define OPENSSL_EC_EXPLICIT_CURVE  0x000
+#  define OPENSSL_EC_NAMED_CURVE     0x001
 
 EC_GROUP *d2i_ECPKParameters(EC_GROUP **, const unsigned char **in, long len);
 int i2d_ECPKParameters(const EC_GROUP *, unsigned char **out);
 
-# define d2i_ECPKParameters_bio(bp,x) ASN1_d2i_bio_of(EC_GROUP,NULL,d2i_ECPKParameters,bp,x)
-# define i2d_ECPKParameters_bio(bp,x) ASN1_i2d_bio_of(EC_GROUP,i2d_ECPKParameters,bp,x)
-# define d2i_ECPKParameters_fp(fp,x) (EC_GROUP *)ASN1_d2i_fp(NULL, \
-                (char *(*)())d2i_ECPKParameters,(fp),(unsigned char **)(x))
-# define i2d_ECPKParameters_fp(fp,x) ASN1_i2d_fp(i2d_ECPKParameters,(fp), \
-                (unsigned char *)(x))
+#  define d2i_ECPKParameters_bio(bp,x) \
+    ASN1_d2i_bio_of(EC_GROUP, NULL, d2i_ECPKParameters, bp, x)
+#  define i2d_ECPKParameters_bio(bp,x) \
+    ASN1_i2d_bio_of(EC_GROUP, i2d_ECPKParameters, bp, x)
+#  define d2i_ECPKParameters_fp(fp,x) \
+    (EC_GROUP *)ASN1_d2i_fp(NULL, (char *(*)())d2i_ECPKParameters, (fp), \
+                            (unsigned char **)(x))
+#  define i2d_ECPKParameters_fp(fp,x) \
+    ASN1_i2d_fp(i2d_ECPKParameters,(fp), (unsigned char *)(x))
 
 int ECPKParameters_print(BIO *bp, const EC_GROUP *x, int off);
-# ifndef OPENSSL_NO_STDIO
+#  ifndef OPENSSL_NO_STDIO
 int ECPKParameters_print_fp(FILE *fp, const EC_GROUP *x, int off);
-# endif
+#  endif
 
 /********************************************************************/
 /*                      EC_KEY functions                            */
 /********************************************************************/
 
 /* some values for the encoding_flag */
-# define EC_PKEY_NO_PARAMETERS   0x001
-# define EC_PKEY_NO_PUBKEY       0x002
+#  define EC_PKEY_NO_PARAMETERS   0x001
+#  define EC_PKEY_NO_PUBKEY       0x002
 
 /* some values for the flags field */
-# define EC_FLAG_NON_FIPS_ALLOW  0x1
-# define EC_FLAG_FIPS_CHECKED    0x2
-# define EC_FLAG_COFACTOR_ECDH   0x1000
+#  define EC_FLAG_NON_FIPS_ALLOW  0x1
+#  define EC_FLAG_FIPS_CHECKED    0x2
+#  define EC_FLAG_COFACTOR_ECDH   0x1000
 
 /**
  *  Creates a new EC_KEY object.
@@ -973,7 +976,7 @@ void EC_KEY_set_enc_flags(EC_KEY *eckey, unsigned int flags);
 point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
 void EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
 
-#define EC_KEY_get_ex_new_index(l, p, newf, dupf, freef) \
+# define EC_KEY_get_ex_new_index(l, p, newf, dupf, freef) \
     CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_EC_KEY, l, p, newf, dupf, freef)
 int EC_KEY_set_ex_data(EC_KEY *key, int idx, void *arg);
 void *EC_KEY_get_ex_data(const EC_KEY *key, int idx);
@@ -1142,7 +1145,7 @@ int ECParameters_print(BIO *bp, const EC_KEY *key);
  */
 int EC_KEY_print(BIO *bp, const EC_KEY *key, int off);
 
-# ifndef OPENSSL_NO_STDIO
+#  ifndef OPENSSL_NO_STDIO
 /** Prints out the ec parameters on human readable form.
  *  \param  fp   file descriptor to which the information is printed
  *  \param  key  EC_KEY object
@@ -1158,7 +1161,7 @@ int ECParameters_print_fp(FILE *fp, const EC_KEY *key);
  */
 int EC_KEY_print_fp(FILE *fp, const EC_KEY *key, int off);
 
-# endif
+#  endif
 
 const EC_KEY_METHOD *EC_KEY_OpenSSL(void);
 const EC_KEY_METHOD *EC_KEY_get_default_method(void);
@@ -1328,7 +1331,7 @@ int ECDSA_verify(int type, const unsigned char *dgst, int dgstlen,
  *  \param  eckey  EC_KEY object
  *  \return numbers of bytes required for the DER encoded signature
  */
-int ECDSA_size(const EC_KEY *eckey);
+DEPRECATEDIN_3_0(int ECDSA_size(const EC_KEY *eckey))
 
 /********************************************************************/
 /*  EC_KEY_METHOD constructors, destructors, writers and accessors  */
@@ -1423,112 +1426,111 @@ void EC_KEY_METHOD_get_verify(const EC_KEY_METHOD *meth,
                                                   const ECDSA_SIG *sig,
                                                   EC_KEY *eckey));
 
-# define ECParameters_dup(x) ASN1_dup_of(EC_KEY,i2d_ECParameters,d2i_ECParameters,x)
+#  define ECParameters_dup(x) ASN1_dup_of(EC_KEY,i2d_ECParameters,d2i_ECParameters,x)
 
-# ifndef __cplusplus
-#  if defined(__SUNPRO_C)
-#   if __SUNPRO_C >= 0x520
-#    pragma error_messages (default,E_ARRAY_OF_INCOMPLETE_NONAME,E_ARRAY_OF_INCOMPLETE)
+#  ifndef __cplusplus
+#   if defined(__SUNPRO_C)
+#    if __SUNPRO_C >= 0x520
+#     pragma error_messages (default,E_ARRAY_OF_INCOMPLETE_NONAME,E_ARRAY_OF_INCOMPLETE)
+#    endif
 #   endif
 #  endif
-# endif
 
-# define EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid) \
+#  define EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_PARAMGEN|EVP_PKEY_OP_KEYGEN, \
                                 EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID, nid, NULL)
 
-# define EVP_PKEY_CTX_set_ec_param_enc(ctx, flag) \
+#  define EVP_PKEY_CTX_set_ec_param_enc(ctx, flag) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_PARAMGEN|EVP_PKEY_OP_KEYGEN, \
                                 EVP_PKEY_CTRL_EC_PARAM_ENC, flag, NULL)
 
-# define EVP_PKEY_CTX_set_ecdh_cofactor_mode(ctx, flag) \
+#  define EVP_PKEY_CTX_set_ecdh_cofactor_mode(ctx, flag) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_ECDH_COFACTOR, flag, NULL)
 
-# define EVP_PKEY_CTX_get_ecdh_cofactor_mode(ctx) \
+#  define EVP_PKEY_CTX_get_ecdh_cofactor_mode(ctx) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_ECDH_COFACTOR, -2, NULL)
 
-# define EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, kdf) \
+#  define EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, kdf) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_KDF_TYPE, kdf, NULL)
 
-# define EVP_PKEY_CTX_get_ecdh_kdf_type(ctx) \
+#  define EVP_PKEY_CTX_get_ecdh_kdf_type(ctx) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_KDF_TYPE, -2, NULL)
 
-# define EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, md) \
+#  define EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, md) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_KDF_MD, 0, (void *)(md))
 
-# define EVP_PKEY_CTX_get_ecdh_kdf_md(ctx, pmd) \
+#  define EVP_PKEY_CTX_get_ecdh_kdf_md(ctx, pmd) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_GET_EC_KDF_MD, 0, (void *)(pmd))
 
-# define EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, len) \
+#  define EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, len) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_KDF_OUTLEN, len, NULL)
 
-# define EVP_PKEY_CTX_get_ecdh_kdf_outlen(ctx, plen) \
+#  define EVP_PKEY_CTX_get_ecdh_kdf_outlen(ctx, plen) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN, 0, \
                                 (void *)(plen))
 
-# define EVP_PKEY_CTX_set0_ecdh_kdf_ukm(ctx, p, plen) \
+#  define EVP_PKEY_CTX_set0_ecdh_kdf_ukm(ctx, p, plen) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_EC_KDF_UKM, plen, (void *)(p))
 
-# define EVP_PKEY_CTX_get0_ecdh_kdf_ukm(ctx, p) \
+#  define EVP_PKEY_CTX_get0_ecdh_kdf_ukm(ctx, p) \
         EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, \
                                 EVP_PKEY_OP_DERIVE, \
                                 EVP_PKEY_CTRL_GET_EC_KDF_UKM, 0, (void *)(p))
 
 /* SM2 will skip the operation check so no need to pass operation here */
-# define EVP_PKEY_CTX_set1_id(ctx, id, id_len) \
+#  define EVP_PKEY_CTX_set1_id(ctx, id, id_len) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
                                 EVP_PKEY_CTRL_SET1_ID, (int)id_len, (void*)(id))
-# define EVP_PKEY_CTX_get1_id(ctx, id) \
+#  define EVP_PKEY_CTX_get1_id(ctx, id) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
                                 EVP_PKEY_CTRL_GET1_ID, 0, (void*)(id))
 
-# define EVP_PKEY_CTX_get1_id_len(ctx, id_len) \
+#  define EVP_PKEY_CTX_get1_id_len(ctx, id_len) \
         EVP_PKEY_CTX_ctrl(ctx, -1, -1, \
                                 EVP_PKEY_CTRL_GET1_ID_LEN, 0, (void*)(id_len))
 
-# define EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID             (EVP_PKEY_ALG_CTRL + 1)
-# define EVP_PKEY_CTRL_EC_PARAM_ENC                      (EVP_PKEY_ALG_CTRL + 2)
-# define EVP_PKEY_CTRL_EC_ECDH_COFACTOR                  (EVP_PKEY_ALG_CTRL + 3)
-# define EVP_PKEY_CTRL_EC_KDF_TYPE                       (EVP_PKEY_ALG_CTRL + 4)
-# define EVP_PKEY_CTRL_EC_KDF_MD                         (EVP_PKEY_ALG_CTRL + 5)
-# define EVP_PKEY_CTRL_GET_EC_KDF_MD                     (EVP_PKEY_ALG_CTRL + 6)
-# define EVP_PKEY_CTRL_EC_KDF_OUTLEN                     (EVP_PKEY_ALG_CTRL + 7)
-# define EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN                 (EVP_PKEY_ALG_CTRL + 8)
-# define EVP_PKEY_CTRL_EC_KDF_UKM                        (EVP_PKEY_ALG_CTRL + 9)
-# define EVP_PKEY_CTRL_GET_EC_KDF_UKM                    (EVP_PKEY_ALG_CTRL + 10)
-# define EVP_PKEY_CTRL_SET1_ID                           (EVP_PKEY_ALG_CTRL + 11)
-# define EVP_PKEY_CTRL_GET1_ID                           (EVP_PKEY_ALG_CTRL + 12)
-# define EVP_PKEY_CTRL_GET1_ID_LEN                       (EVP_PKEY_ALG_CTRL + 13)
+#  define EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID         (EVP_PKEY_ALG_CTRL + 1)
+#  define EVP_PKEY_CTRL_EC_PARAM_ENC                  (EVP_PKEY_ALG_CTRL + 2)
+#  define EVP_PKEY_CTRL_EC_ECDH_COFACTOR              (EVP_PKEY_ALG_CTRL + 3)
+#  define EVP_PKEY_CTRL_EC_KDF_TYPE                   (EVP_PKEY_ALG_CTRL + 4)
+#  define EVP_PKEY_CTRL_EC_KDF_MD                     (EVP_PKEY_ALG_CTRL + 5)
+#  define EVP_PKEY_CTRL_GET_EC_KDF_MD                 (EVP_PKEY_ALG_CTRL + 6)
+#  define EVP_PKEY_CTRL_EC_KDF_OUTLEN                 (EVP_PKEY_ALG_CTRL + 7)
+#  define EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN             (EVP_PKEY_ALG_CTRL + 8)
+#  define EVP_PKEY_CTRL_EC_KDF_UKM                    (EVP_PKEY_ALG_CTRL + 9)
+#  define EVP_PKEY_CTRL_GET_EC_KDF_UKM                (EVP_PKEY_ALG_CTRL + 10)
+#  define EVP_PKEY_CTRL_SET1_ID                       (EVP_PKEY_ALG_CTRL + 11)
+#  define EVP_PKEY_CTRL_GET1_ID                       (EVP_PKEY_ALG_CTRL + 12)
+#  define EVP_PKEY_CTRL_GET1_ID_LEN                   (EVP_PKEY_ALG_CTRL + 13)
 /* KDF types */
-# define EVP_PKEY_ECDH_KDF_NONE                          1
-# define EVP_PKEY_ECDH_KDF_X9_63                         2
+#  define EVP_PKEY_ECDH_KDF_NONE                     1
+#  define EVP_PKEY_ECDH_KDF_X9_63                    2
 /** The old name for EVP_PKEY_ECDH_KDF_X9_63
  *  The ECDH KDF specification has been mistakingly attributed to ANSI X9.62,
  *  it is actually specified in ANSI X9.63.
  *  This identifier is retained for backwards compatibility
  */
-# define EVP_PKEY_ECDH_KDF_X9_62   EVP_PKEY_ECDH_KDF_X9_63
-
+#   define EVP_PKEY_ECDH_KDF_X9_62   EVP_PKEY_ECDH_KDF_X9_63
 
 #  ifdef  __cplusplus
 }

--- a/test/build.info
+++ b/test/build.info
@@ -32,7 +32,7 @@ IF[{- !$disabled{tests} -}]
           versions \
           aborttest test_test \
           sanitytest rsa_complex exdatatest bntest \
-          ectest ecstresstest ecdsatest gmdifftest pbelutest \
+          ectest ecstresstest gmdifftest pbelutest \
           destest mdc2test \
           dhtest enginetest \
           ssltest_old dsatest dsa_no_digest_size_test exptest rsa_test \
@@ -96,10 +96,6 @@ IF[{- !$disabled{tests} -}]
   SOURCE[ecstresstest]=ecstresstest.c
   INCLUDE[ecstresstest]=../include ../apps/include
   DEPEND[ecstresstest]=../libcrypto libtestutil.a
-
-  SOURCE[ecdsatest]=ecdsatest.c
-  INCLUDE[ecdsatest]=../include ../apps/include
-  DEPEND[ecdsatest]=../libcrypto libtestutil.a
 
   SOURCE[gmdifftest]=gmdifftest.c
   INCLUDE[gmdifftest]=../include ../apps/include
@@ -493,7 +489,7 @@ IF[{- !$disabled{tests} -}]
     PROGRAMS{noinst}=asn1_internal_test modes_internal_test x509_internal_test \
                      tls13encryptiontest wpackettest ctype_internal_test \
                      rdrand_sanitytest property_test ideatest \
-                     rsa_sp800_56b_test bn_internal_test \
+                     rsa_sp800_56b_test bn_internal_test ecdsatest \
                      rc2test rc4test rc5test hmactest \
                      asn1_dsa_internal_test
 
@@ -535,6 +531,10 @@ IF[{- !$disabled{tests} -}]
     SOURCE[x509_internal_test]=x509_internal_test.c
     INCLUDE[x509_internal_test]=.. ../include ../apps/include
     DEPEND[x509_internal_test]=../libcrypto.a libtestutil.a
+
+    SOURCE[ecdsatest]=ecdsatest.c
+    INCLUDE[ecdsatest]=../include ../apps/include
+    DEPEND[ecdsatest]=../libcrypto.a libtestutil.a
 
     SOURCE[tls13encryptiontest]=tls13encryptiontest.c
     INCLUDE[tls13encryptiontest]=.. ../include ../apps/include

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -7,6 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Low level APIs are deprecated for public use, but still ok for internal use.
+ */
+#include "internal/deprecated.h"
+
 #include "internal/nelem.h"
 #include "testutil.h"
 #include <openssl/ec.h>

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -8,6 +8,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Low level APIs are deprecated for public use, but still ok for internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <openssl/opensslconf.h> /* To see if OPENSSL_NO_EC is defined */
 #include "testutil.h"
 

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -7,6 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Low level APIs are deprecated for public use, but still ok for internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -406,7 +406,7 @@ BN_CTX_get                              413	3_0_0	EXIST::FUNCTION:
 BN_to_montgomery                        414	3_0_0	EXIST::FUNCTION:
 X509_OBJECT_get0_X509_CRL               415	3_0_0	EXIST::FUNCTION:
 EVP_camellia_128_cfb8                   416	3_0_0	EXIST::FUNCTION:CAMELLIA
-EC_KEY_METHOD_free                      417	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_free                      417	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 TS_TST_INFO_set_policy_id               418	3_0_0	EXIST::FUNCTION:TS
 d2i_EXTENDED_KEY_USAGE                  419	3_0_0	EXIST::FUNCTION:
 ASYNC_unblock_pause                     420	3_0_0	EXIST::FUNCTION:
@@ -452,7 +452,7 @@ EVP_DigestFinal                         460	3_0_0	EXIST::FUNCTION:
 CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE 461	3_0_0	EXIST::FUNCTION:CT
 X509v3_asid_add_id_or_range             462	3_0_0	EXIST::FUNCTION:RFC3779
 X509_NAME_ENTRY_create_by_NID           463	3_0_0	EXIST::FUNCTION:
-EC_KEY_METHOD_get_init                  464	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_get_init                  464	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 ASN1_INTEGER_to_BN                      465	3_0_0	EXIST::FUNCTION:
 OPENSSL_memcmp                          466	3_0_0	NOEXIST::FUNCTION:
 BUF_MEM_new                             467	3_0_0	EXIST::FUNCTION:
@@ -603,7 +603,7 @@ X509_REVOKED_get_ext_by_critical        617	3_0_0	EXIST::FUNCTION:
 X509at_get_attr                         618	3_0_0	EXIST::FUNCTION:
 X509_PUBKEY_it                          619	3_0_0	EXIST::FUNCTION:
 DES_ede3_ofb64_encrypt                  620	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
-EC_KEY_METHOD_get_compute_key           621	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_get_compute_key           621	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 RC2_cfb64_encrypt                       622	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RC2
 EVP_EncryptFinal_ex                     623	3_0_0	EXIST::FUNCTION:
 ERR_load_RSA_strings                    624	3_0_0	EXIST::FUNCTION:
@@ -835,7 +835,7 @@ EVP_PKEY_keygen                         855	3_0_0	EXIST::FUNCTION:
 X509_CRL_dup                            856	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get_cb                     857	3_0_0	EXIST::FUNCTION:
 X509_STORE_free                         858	3_0_0	EXIST::FUNCTION:
-ECDSA_sign_ex                           859	3_0_0	EXIST::FUNCTION:EC
+ECDSA_sign_ex                           859	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 TXT_DB_insert                           860	3_0_0	EXIST::FUNCTION:
 EC_POINTs_make_affine                   861	3_0_0	EXIST::FUNCTION:EC
 RSA_padding_add_PKCS1_PSS               862	3_0_0	EXIST::FUNCTION:RSA
@@ -853,7 +853,7 @@ RSA_verify                              873	3_0_0	EXIST::FUNCTION:RSA
 ASN1_FBOOLEAN_it                        874	3_0_0	EXIST::FUNCTION:
 d2i_ASN1_TIME                           875	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_signctx               876	3_0_0	EXIST::FUNCTION:
-EC_KEY_METHOD_set_compute_key           877	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_set_compute_key           877	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 X509_REQ_INFO_free                      878	3_0_0	EXIST::FUNCTION:
 CMS_ReceiptRequest_create0              879	3_0_0	EXIST::FUNCTION:CMS
 EVP_MD_meth_set_cleanup                 880	3_0_0	EXIST::FUNCTION:
@@ -1023,7 +1023,7 @@ X509_ALGOR_dup                          1049	3_0_0	EXIST::FUNCTION:
 d2i_X509_REQ_INFO                       1050	3_0_0	EXIST::FUNCTION:
 d2i_EC_PUBKEY_bio                       1051	3_0_0	EXIST::FUNCTION:EC
 X509_STORE_CTX_set_error                1052	3_0_0	EXIST::FUNCTION:
-EC_KEY_METHOD_set_keygen                1053	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_set_keygen                1053	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 CRYPTO_free                             1054	3_0_0	EXIST::FUNCTION:
 BN_GF2m_mod_exp                         1055	3_0_0	EXIST::FUNCTION:EC2M
 OPENSSL_buf2hexstr                      1056	3_0_0	EXIST::FUNCTION:
@@ -1061,7 +1061,7 @@ OBJ_nid2sn                              1087	3_0_0	EXIST::FUNCTION:
 X509_gmtime_adj                         1088	3_0_0	EXIST::FUNCTION:
 X509_add_ext                            1089	3_0_0	EXIST::FUNCTION:
 ENGINE_set_DSA                          1090	3_0_0	EXIST::FUNCTION:ENGINE
-EC_KEY_METHOD_set_sign                  1091	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_set_sign                  1091	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 d2i_TS_MSG_IMPRINT                      1092	3_0_0	EXIST::FUNCTION:TS
 X509_print_ex_fp                        1093	3_0_0	EXIST::FUNCTION:STDIO
 ERR_load_PEM_strings                    1094	3_0_0	EXIST::FUNCTION:
@@ -1498,7 +1498,7 @@ ASN1_GENERALSTRING_free                 1531	3_0_0	EXIST::FUNCTION:
 BN_MONT_CTX_set_locked                  1532	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_set_num                  1533	3_0_0	EXIST::FUNCTION:
 CONF_load                               1534	3_0_0	EXIST::FUNCTION:
-EC_KEY_METHOD_get_keygen                1535	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_get_keygen                1535	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_PKEY_add1_attr_by_txt               1536	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_set_uint64                 1537	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_attr_by_OBJ                1538	3_0_0	EXIST::FUNCTION:
@@ -1752,7 +1752,7 @@ BN_mod_exp_mont_consttime               1793	3_0_0	EXIST::FUNCTION:
 X509V3_parse_list                       1794	3_0_0	EXIST::FUNCTION:
 ACCESS_DESCRIPTION_new                  1795	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_clear_flags              1796	3_0_0	EXIST::FUNCTION:
-ECDSA_size                              1797	3_0_0	EXIST::FUNCTION:EC
+ECDSA_size                              1797	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 X509_ALGOR_get0                         1798	3_0_0	EXIST::FUNCTION:
 d2i_ACCESS_DESCRIPTION                  1799	3_0_0	EXIST::FUNCTION:
 OCSP_SINGLERESP_get_ext_by_NID          1800	3_0_0	EXIST::FUNCTION:OCSP
@@ -1884,7 +1884,7 @@ PEM_write_X509_AUX                      1929	3_0_0	EXIST::FUNCTION:STDIO
 X509_LOOKUP_by_subject                  1930	3_0_0	EXIST::FUNCTION:
 X509_REQ_add_extensions                 1931	3_0_0	EXIST::FUNCTION:
 Camellia_cbc_encrypt                    1932	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
-EC_KEY_METHOD_new                       1933	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_new                       1933	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 RSA_flags                               1934	3_0_0	EXIST::FUNCTION:RSA
 X509_NAME_add_entry                     1935	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_get_asn1_iv                  1936	3_0_0	EXIST::FUNCTION:
@@ -1903,7 +1903,7 @@ EVP_seed_cbc                            1948	3_0_0	EXIST::FUNCTION:SEED
 d2i_PKCS12                              1949	3_0_0	EXIST::FUNCTION:
 X509_policy_node_get0_policy            1950	3_0_0	EXIST::FUNCTION:
 PKCS12_unpack_p7data                    1951	3_0_0	EXIST::FUNCTION:
-ECDSA_sign                              1952	3_0_0	EXIST::FUNCTION:EC
+ECDSA_sign                              1952	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 d2i_PKCS12_fp                           1953	3_0_0	EXIST::FUNCTION:STDIO
 CMS_unsigned_get_attr_by_NID            1954	3_0_0	EXIST::FUNCTION:CMS
 UI_add_user_data                        1955	3_0_0	EXIST::FUNCTION:
@@ -1933,7 +1933,7 @@ X509_EXTENSION_it                       1978	3_0_0	EXIST::FUNCTION:
 i2d_PKCS8_fp                            1979	3_0_0	EXIST::FUNCTION:STDIO
 UTF8_getc                               1980	3_0_0	EXIST::FUNCTION:
 ASN1_IA5STRING_free                     1981	3_0_0	EXIST::FUNCTION:
-EC_KEY_METHOD_get_verify                1982	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_get_verify                1982	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 OBJ_NAME_do_all                         1983	3_0_0	EXIST::FUNCTION:
 d2i_TS_MSG_IMPRINT_fp                   1984	3_0_0	EXIST::FUNCTION:STDIO,TS
 X509_CRL_verify                         1985	3_0_0	EXIST::FUNCTION:
@@ -2045,7 +2045,7 @@ TS_CONF_set_policies                    2091	3_0_0	EXIST::FUNCTION:TS
 CMS_SignerInfo_cert_cmp                 2092	3_0_0	EXIST::FUNCTION:CMS
 PEM_read                                2093	3_0_0	EXIST::FUNCTION:STDIO
 X509_STORE_set_depth                    2094	3_0_0	EXIST::FUNCTION:
-EC_KEY_METHOD_get_sign                  2095	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_get_sign                  2095	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_CIPHER_CTX_iv                       2096	3_0_0	EXIST::FUNCTION:
 i2d_ESS_SIGNING_CERT                    2097	3_0_0	EXIST::FUNCTION:
 TS_RESP_set_tst_info                    2098	3_0_0	EXIST::FUNCTION:TS
@@ -2127,7 +2127,7 @@ X509_STORE_load_locations               2172	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 OBJ_find_sigid_algs                     2173	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_set_accuracy                2174	3_0_0	EXIST::FUNCTION:TS
 NETSCAPE_SPKI_get_pubkey                2175	3_0_0	EXIST::FUNCTION:
-ECDSA_do_sign_ex                        2176	3_0_0	EXIST::FUNCTION:EC
+ECDSA_do_sign_ex                        2176	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 OCSP_ONEREQ_get_ext                     2177	3_0_0	EXIST::FUNCTION:OCSP
 BN_get_rfc3526_prime_4096               2179	3_0_0	EXIST::FUNCTION:
 d2i_PKCS7_fp                            2180	3_0_0	EXIST::FUNCTION:STDIO
@@ -2370,7 +2370,7 @@ i2d_X509_CRL_INFO                       2420	3_0_0	EXIST::FUNCTION:
 i2d_OCSP_CERTSTATUS                     2421	3_0_0	EXIST::FUNCTION:OCSP
 X509_REVOKED_get0_revocationDate        2422	3_0_0	EXIST::FUNCTION:
 PKCS7_add_crl                           2423	3_0_0	EXIST::FUNCTION:
-ECDSA_do_sign                           2424	3_0_0	EXIST::FUNCTION:EC
+ECDSA_do_sign                           2424	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 ASN1_GENERALIZEDTIME_it                 2425	3_0_0	EXIST::FUNCTION:
 PKCS8_pkey_get0                         2426	3_0_0	EXIST::FUNCTION:
 OCSP_sendreq_new                        2427	3_0_0	EXIST::FUNCTION:OCSP
@@ -2679,7 +2679,7 @@ CMS_verify_receipt                      2735	3_0_0	EXIST::FUNCTION:CMS
 CRYPTO_THREAD_lock_new                  2736	3_0_0	EXIST::FUNCTION:
 BIO_get_ex_data                         2737	3_0_0	EXIST::FUNCTION:
 CMS_digest_create                       2738	3_0_0	EXIST::FUNCTION:CMS
-EC_KEY_METHOD_set_verify                2739	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_set_verify                2739	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 PEM_read_RSAPublicKey                   2740	3_0_0	EXIST::FUNCTION:RSA,STDIO
 ENGINE_pkey_asn1_find_str               2741	3_0_0	EXIST::FUNCTION:ENGINE
 ENGINE_get_load_privkey_function        2742	3_0_0	EXIST::FUNCTION:ENGINE
@@ -2916,7 +2916,7 @@ CRYPTO_secure_malloc                    2978	3_0_0	EXIST::FUNCTION:
 TS_RESP_get_status_info                 2979	3_0_0	EXIST::FUNCTION:TS
 HMAC_CTX_new                            2980	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ENGINE_get_default_DH                   2981	3_0_0	EXIST::FUNCTION:ENGINE
-ECDSA_do_verify                         2982	3_0_0	EXIST::FUNCTION:EC
+ECDSA_do_verify                         2982	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 DSO_flags                               2983	3_0_0	EXIST::FUNCTION:
 RAND_add                                2984	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_do_all_sorted                2985	3_0_0	EXIST::FUNCTION:
@@ -3081,7 +3081,7 @@ TS_STATUS_INFO_print_bio                3145	3_0_0	EXIST::FUNCTION:TS
 OPENSSL_sk_dup                          3146	3_0_0	EXIST::FUNCTION:
 BF_cfb64_encrypt                        3147	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 ASN1_GENERALIZEDTIME_adj                3148	3_0_0	EXIST::FUNCTION:
-ECDSA_verify                            3149	3_0_0	EXIST::FUNCTION:EC
+ECDSA_verify                            3149	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_camellia_256_cfb128                 3150	3_0_0	EXIST::FUNCTION:CAMELLIA
 CMAC_Init                               3151	3_0_0	EXIST::FUNCTION:CMAC,DEPRECATEDIN_3_0
 OCSP_basic_add1_status                  3152	3_0_0	EXIST::FUNCTION:OCSP
@@ -3679,7 +3679,7 @@ BN_GF2m_poly2arr                        3758	3_0_0	EXIST::FUNCTION:EC2M
 CMS_unsigned_get_attr_count             3759	3_0_0	EXIST::FUNCTION:CMS
 EVP_aes_256_gcm                         3760	3_0_0	EXIST::FUNCTION:
 RSA_padding_check_X931                  3761	3_0_0	EXIST::FUNCTION:RSA
-ECDH_compute_key                        3762	3_0_0	EXIST::FUNCTION:EC
+ECDH_compute_key                        3762	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 ASN1_TIME_print                         3763	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get0_peerkey               3764	3_0_0	EXIST::FUNCTION:
 BN_mod_lshift1                          3765	3_0_0	EXIST::FUNCTION:
@@ -3693,7 +3693,7 @@ ENGINE_set_ctrl_function                3773	3_0_0	EXIST::FUNCTION:ENGINE
 OCSP_id_get0_info                       3774	3_0_0	EXIST::FUNCTION:OCSP
 BIO_ADDRINFO_next                       3775	3_0_0	EXIST::FUNCTION:SOCK
 OCSP_RESPBYTES_free                     3776	3_0_0	EXIST::FUNCTION:OCSP
-EC_KEY_METHOD_set_init                  3777	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_METHOD_set_init                  3777	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_PKEY_asn1_copy                      3778	3_0_0	EXIST::FUNCTION:
 RSA_PSS_PARAMS_it                       3779	3_0_0	EXIST::FUNCTION:RSA
 X509_STORE_CTX_get_error_depth          3780	3_0_0	EXIST::FUNCTION:
@@ -3741,7 +3741,7 @@ BN_mod_inverse                          3822	3_0_0	EXIST::FUNCTION:
 ASN1_STRING_TABLE_get                   3823	3_0_0	EXIST::FUNCTION:
 BN_bn2binpad                            3824	3_0_0	EXIST::FUNCTION:
 X509_supported_extension                3825	3_0_0	EXIST::FUNCTION:
-ECDSA_sign_setup                        3826	3_0_0	EXIST::FUNCTION:EC
+ECDSA_sign_setup                        3826	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_camellia_192_cfb128                 3827	3_0_0	EXIST::FUNCTION:CAMELLIA
 d2i_AUTHORITY_KEYID                     3828	3_0_0	EXIST::FUNCTION:
 RIPEMD160_Transform                     3829	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RMD160


### PR DESCRIPTION
Deprecate the low level EC functions.

- [x] documentation is added or updated
- [x] tests are added or updated
