### PR TITLE
Final set of doc-nits fixes for commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -228,6 +228,10 @@ script:
           echo -e '\052\052 FAILED -- MAKE';
           travis_terminate 1;
       fi;
+    - if test -n "$CHECKDOCS" && ! $make cmd-nits; then
+          echo -e '\052\052 FAILED -- MAKE CMD-NITS';
+          travis_terminate 1;
+      fi
     - if [ -z "$BUILDONLY" ]; then
           if [ -n "$CROSS_COMPILE" ]; then
               sudo dpkg --add-architecture i386;

--- a/CHANGES
+++ b/CHANGES
@@ -45,12 +45,14 @@
      [Paul Dale]
 
   *) Over two thousand fixes were made to the documentation, including:
-     common options (such as -rand/-writerand, TLS version control, etc)
-     were refactored and point to newly-enhanced descriptions in openssl.pod,
-     documented all missing options, added a CI build target to make
-     sure all options are documented, have style conformance (with help
-     from Richard Levitte), documented many internals, and addressed all
-     internal broken L<> references.
+     - Common options (such as -rand/-writerand, TLS version control, etc)
+       were refactored and point to newly-enhanced descriptions in openssl.pod.
+     - Added style conformance for all options (with help from Richard Levitte),
+       documented all reported missing options, added a CI build to check
+       that all options are documented and that no unimplemented options
+       are documented.
+     - Documented some internals, such as all use of environment variables.
+     - Addressed all internal broken L<> references.
      [Rich Salz]
 
   *) All of the low level MD2, MD4, MD5, MDC2, RIPEMD160, SHA1, SHA224, SHA256,

--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,15 @@
      and L<EVP_MAC_final(3)>.
      [Paul Dale]
 
+  *) Over two thousand fixes were made to the documentation, including:
+     common options (such as -rand/-writerand, TLS version control, etc)
+     were refactored and point to newly-enhanced descriptions in openssl.pod,
+     documented all missing options, added a CI build target to make
+     sure all options are documented, have style conformance (with help
+     from Richard Levitte), documented many internals, and addressed all
+     internal broken L<> references.
+     [Rich Salz]
+
   *) All of the low level MD2, MD4, MD5, MDC2, RIPEMD160, SHA1, SHA224, SHA256,
      SHA384, SHA512 and Whirlpool digest functions have been deprecated.
      These include:
@@ -254,15 +263,6 @@
      EVP_DigestVerifyUpdate() have been converted to functions. See the man
      pages for further details.
      [Matt Caswell]
-
-  *) Most common options (such as -rand/-writerand, TLS version control, etc)
-     were refactored and point to newly-enhanced descriptions in openssl.pod
-     [Rich Salz]
-
-  *) Over two thousand fixes were made to the documentation, including:
-     adding missing command flags, better style conformance, documentation
-     of internals, etc.
-     [Rich Salz, Richard Levitte]
 
   *) s390x assembly pack: add hardware-support for P-256, P-384, P-521,
      X25519, X448, Ed25519 and Ed448.

--- a/apps/list.c
+++ b/apps/list.c
@@ -629,6 +629,7 @@ const OPTIONS list_options[] = {
     {"1", OPT_ONE, '-', "List in one column"},
     {"verbose", OPT_VERBOSE, '-', "Verbose listing"},
     {"commands", OPT_COMMANDS, '-', "List of standard commands"},
+    {"standard-commands", OPT_COMMANDS, '-', "List of standard commands"},
     {"digest-commands", OPT_DIGEST_COMMANDS, '-',
      "List of message digest commands"},
     {"digest-algorithms", OPT_DIGEST_ALGORITHMS, '-',

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -614,7 +614,7 @@ const OPTIONS s_client_options[] = {
     {"ssl_client_engine", OPT_SSL_CLIENT_ENGINE, 's',
      "Specify engine to be used for client certificate operations"},
 #endif
-    {"ssl_config", OPT_SSL_CONFIG, 's', "Use specified configuration file"},
+    {"ssl_config", OPT_SSL_CONFIG, 's', "Use specified section for SSL_CTX configuration"},
 #ifndef OPENSSL_NO_CT
     {"ct", OPT_CT, '-', "Request and parse SCTs (also enables OCSP stapling)"},
     {"noct", OPT_NOCT, '-', "Do not request or parse SCTs (default)"},

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -449,7 +449,7 @@ Export keying material using the specified label.
 
 =item B<-keymatexportlen> I<len>
 
-Export the specified number of bytes of keyint material; default is 20.
+Export the specified number of bytes of keying material; default is 20.
 
 Show all protocol messages with hex dump.
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -9,7 +9,10 @@ openssl-s_client - SSL/TLS client program
 
 B<openssl> B<s_client>
 [B<-help>]
+[B<-ssl_config> I<file>]
 [B<-connect> I<host:port>]
+[B<-host> I<hostname>]
+[B<-port> I<port>]
 [B<-bind> I<host:port>]
 [B<-proxy> I<host:port>]
 [B<-proxy_user> I<userid>]
@@ -21,9 +24,15 @@ B<openssl> B<s_client>
 [B<-noservername>]
 [B<-verify> I<depth>]
 [B<-verify_return_error>]
+[B<-verify_quiet>]
+[B<-verifyCAfile> I<filename>]
+[B<-verifyCApath> I<dir>]
+[B<-verifyCAstore> I<uri>]
 [B<-cert> I<filename>]
 [B<-certform> B<DER>|B<PEM>]
+[B<-CRL> I<filename>]
 [B<-CRLform> B<DER>|B<PEM>]
+[B<-crl_download>]
 [B<-key> I<filename>]
 [B<-keyform> B<DER>|B<PEM>]
 [B<-cert_chain> I<filename>]
@@ -39,8 +48,18 @@ B<openssl> B<s_client>
 [B<-build_chain>]
 [B<-reconnect>]
 [B<-showcerts>]
+[B<-prexit>]
 [B<-debug>]
+[B<-trace>]
+[B<-nocommands>]
+[B<-security_debug>]
+[B<-security_debug_verbose>]
 [B<-msg>]
+[B<-timeout>]
+[B<-mtu> I<size>]
+[B<-keymatexport> I<label>]
+[B<-keymatexportlen> I<len>]
+[B<-msgfile> I<filename>]
 [B<-nbio_test>]
 [B<-state>]
 [B<-nbio>]
@@ -55,6 +74,7 @@ B<openssl> B<s_client>
 [B<-sctp_label_bug>]
 [B<-fallback_scsv>]
 [B<-async>]
+[B<-maxfraglen> I<len>]
 [B<-max_send_frag>]
 [B<-split_send_frag>]
 [B<-max_pipelines>]
@@ -62,6 +82,7 @@ B<openssl> B<s_client>
 [B<-bugs>]
 [B<-comp>]
 [B<-no_comp>]
+[B<-brief>]
 [B<-allow_no_dhe_kex>]
 [B<-sigalgs> I<sigalglist>]
 [B<-curves> I<curvelist>]
@@ -69,11 +90,13 @@ B<openssl> B<s_client>
 [B<-ciphersuites> I<val>]
 [B<-serverpref>]
 [B<-starttls> I<protocol>]
+[B<-name> I<hostname>]
 [B<-xmpphost> I<hostname>]
 [B<-name> I<hostname>]
 [B<-tlsextdebug>]
 [B<-no_ticket>]
 [B<-sess_out> I<filename>]
+[B<-serverinfo> I<types>]
 [B<-sess_in> I<filename>]
 [B<-serverinfo> I<types>]
 [B<-status>]
@@ -85,12 +108,20 @@ B<openssl> B<s_client>
 [B<-keylogfile> I<file>]
 [B<-early_data> I<file>]
 [B<-enable_pha>]
+[B<-use_srtp> I<value>]
+[B<-srpuser> I<value>]
+[B<-srppass> I<value>]
+[B<-srp_lateuser>]
+[B<-srp_moregroups>]
+[B<-srp_strength> I<number>]
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_version_synopsis -}
 {- $OpenSSL::safe::opt_x_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_s_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+[B<-ssl_client_engine> I<id>]
 {- $OpenSSL::safe::opt_v_synopsis -}
 [I<host>:I<port>]
 
@@ -123,12 +154,24 @@ manual page.
 
 Print out a usage message.
 
+=item B<-ssl_config> I<filename>
+
+Use the specified configuration file.
+
 =item B<-connect> I<host>:I<port>
 
 This specifies the host and optional port to connect to. It is possible to
 select the host and port using the optional target positional argument instead.
 If neither this nor the target positional argument are specified then an attempt
 is made to connect to the local host on port 4433.
+
+=item B<-host> I<hostname>
+
+Host to connect to; use B<-connect> instead.
+
+=item B<-port> I<port>
+
+Connect to the specified port; use B<-connect> instead.
 
 =item B<-bind> I<host:port>
 
@@ -199,10 +242,18 @@ not to use a certificate.
 
 The certificate format to use: DER or PEM. PEM is the default.
 
+=item B<-CRL> I<filename>
+
+CRL file to use to check the server's certificate.
+
 =item B<-CRLform> B<DER>|B<PEM>
 
 The CRL format; the default is B<PEM>.
 See L<openssl(1)/Format Options> for details.
+
+=item B<-crl_download>
+
+Download CRL from distribution points in the certificate.
 
 =item B<-key> I<keyfile>
 
@@ -242,6 +293,24 @@ will never fail due to a server certificate verify failure.
 
 Return verification errors instead of continuing. This will typically
 abort the handshake with a fatal error.
+
+=item B<-verify_quiet>
+
+Limit verify output to only errors.
+
+=item B<-verifyCAfile> I<filename>
+
+CA file for verifying the server's certificate, in PEM format.
+
+=item B<-verifyCApath> I<dir>
+
+Use the specified directory as a certificate store path to verify
+the server's CA certificate.
+
+=item B<-verifyCAstore> I<uri>
+
+Use the specified URI as a store URI to verify the server's certificate.
+
 
 =item B<-chainCApath> I<directory>
 
@@ -350,7 +419,37 @@ Prints out the SSL session states.
 
 Print extensive debugging information including a hex dump of all traffic.
 
+=item B<-nocommands>
+
+Do not use interactive command letters.
+
+=item B<-security_debug>
+
+Enable security debug messages.
+
+=item B<-security_debug_verbose>
+
+Output more security debug output.
+
 =item B<-msg>
+
+Show protocol messages.
+
+=item B<-timeout>
+
+Enable send/receive timeout on DTLS connections.
+
+=item B<-mtu> I<size>
+
+Set MTU of the link layer to the specified size.
+
+=item B<-keymatexport> I<label>
+
+Export keying material using the specified label.
+
+=item B<-keymatexportlen> I<len>
+
+Export the specified number of bytes of keyint material; default is 20.
 
 Show all protocol messages with hex dump.
 
@@ -359,7 +458,7 @@ Show all protocol messages with hex dump.
 Show verbose trace output of protocol messages. OpenSSL needs to be compiled
 with B<enable-ssl-trace> for this option to work.
 
-=item B<-msgfile>
+=item B<-msgfile> I<filename>
 
 File to send output of B<-msg> or B<-trace> to, default standard output.
 
@@ -432,6 +531,11 @@ Switch on asynchronous mode. Cryptographic operations will be performed
 asynchronously. This will only have an effect if an asynchronous capable engine
 is also used via the B<-engine> option. For test purposes the dummy async engine
 (dasync) can be used (if available).
+
+=item B<-maxfraglen> I<len>
+
+Enable Maximum Fragment Length Negotiation; allowed values are
+C<512>, C<1024>, C<2048>, and C<4096>.
 
 =item B<-max_send_frag> I<int>
 
@@ -618,6 +722,30 @@ data and when the server accepts the early data.
 For TLSv1.3 only, send the Post-Handshake Authentication extension. This will
 happen whether or not a certificate has been provided via B<-cert>.
 
+=item B<-use_srtp> I<value>
+
+Offer SRTP key management, where B<value> is a colon-separated profile list.
+
+=item B<-srpuser> I<value>
+
+Set the SRP username to the specified value.
+
+=item B<-srppass> I<value>
+
+Set the SRP password to the specified value.
+
+=item B<-srp_lateuser>
+
+SRP username for the second ClientHello message.
+
+=item B<-srp_moregroups>
+
+Tolerate other than the known B<g> and B<N> values.
+
+=item B<-srp_strength> I<number>
+
+Set the minimal acceptable length, in bits, for B<N>.
+
 {- $OpenSSL::safe::opt_version_item -}
 
 {- $OpenSSL::safe::opt_name_item -}
@@ -626,9 +754,15 @@ happen whether or not a certificate has been provided via B<-cert>.
 
 {- $OpenSSL::safe::opt_trust_item -}
 
+{- $OpenSSL::safe::opt_s_item -}
+
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+=item B<-ssl_client_engine> I<id>
+
+Specify engine to be used for client certificate operations.
 
 {- $OpenSSL::safe::opt_v_item -}
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -9,7 +9,7 @@ openssl-s_client - SSL/TLS client program
 
 B<openssl> B<s_client>
 [B<-help>]
-[B<-ssl_config> I<file>]
+[B<-ssl_config> I<section>]
 [B<-connect> I<host:port>]
 [B<-host> I<hostname>]
 [B<-port> I<port>]
@@ -154,9 +154,9 @@ manual page.
 
 Print out a usage message.
 
-=item B<-ssl_config> I<filename>
+=item B<-ssl_config> I<section>
 
-Use the specified configuration file.
+Use the specified section of the configuration file to configure the B<SSL_CTX> object.
 
 =item B<-connect> I<host>:I<port>
 

--- a/doc/man1/openssl-speed.pod.in
+++ b/doc/man1/openssl-speed.pod.in
@@ -27,7 +27,7 @@ B<openssl speed>
 {- $OpenSSL::safe::opt_engine_synopsis -}
 [I<algorithm> ...]
 
-=for openssl ifdef cmac multi async_jobs engine
+=for openssl ifdef hmac cmac multi async_jobs engine
 
 =head1 DESCRIPTION
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -119,11 +119,6 @@ CRL to PKCS#7 Conversion.
 Message Digest calculation. MAC calculations are superseded by
 L<openssl-mac(1)>.
 
-=item B<dh>
-
-Diffie-Hellman Parameter Management.
-Obsoleted by L<openssl-dhparam(1)>.
-
 =item B<dhparam>
 
 Generation and Management of Diffie-Hellman Parameters. Superseded by
@@ -158,10 +153,9 @@ Engine (loadable module) information and manipulation.
 
 Error Number to Error String Conversion.
 
-=item B<gendh>
+=item B<fipsinstall>
 
-Generation of Diffie-Hellman Parameters.
-Obsoleted by L<openssl-dhparam(1)>.
+FIPS configuration installation.
 
 =item B<gendsa>
 
@@ -176,6 +170,10 @@ Generation of Private Key or Parameters.
 
 Generation of RSA Private Key. Superseded by L<openssl-genpkey(1)>.
 
+=item B<help>
+
+Display information about a command's options.
+
 =item B<info>
 
 Display diverse information built into the OpenSSL libraries.
@@ -183,6 +181,10 @@ Display diverse information built into the OpenSSL libraries.
 =item B<kdf>
 
 Key Derivation Functions.
+
+=item B<list>
+
+List algorithms and features.
 
 =item B<mac>
 
@@ -227,6 +229,10 @@ Public key algorithm cryptographic operation utility.
 =item B<prime>
 
 Compute prime numbers.
+
+=item B<provider>
+
+Load and query providers.
 
 =item B<rand>
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -22,6 +22,10 @@ use OpenSSL::Util::Pod;
 # Set to 1 for debug output
 my $debug = 0;
 
+# Where to find openssl command
+my $BLDTOP  = $ENV{BLDTOP} || ".";
+my $openssl = "$BLDTOP/util/opensslwrap.sh";
+
 # Options.
 our($opt_d);
 our($opt_e);
@@ -787,7 +791,7 @@ sub checkflags {
     my %localskips;
 
     # Get the list of options in the command.
-    open CFH, "./apps/openssl list --options $cmd|"
+    open CFH, "$openssl list --options $cmd|"
         or die "Can list options for $cmd, $!";
     while ( <CFH> ) {
         chop;
@@ -847,7 +851,7 @@ if ( $opt_c ) {
     my @commands = ();
 
     # Get list of commands.
-    open FH, "./apps/openssl list -1 -commands|"
+    open FH, "$openssl list -1 -commands|"
         or die "Can't list commands, $!";
     while ( <FH> ) {
         chop;
@@ -869,7 +873,7 @@ if ( $opt_c ) {
     }
 
     # See what help is missing.
-    open FH, "./apps/openssl list --missing-help |"
+    open FH, "$openssl list --missing-help |"
         or die "Can't list missing help, $!";
     while ( <FH> ) {
         chop;


### PR DESCRIPTION
This is the final set of documentation fixes for now. It adds all missing options and adds to the CI build to make sure that doesn't happen again.  (We keep "raising the bar" on requiring complete documentation.)

This is based on #10191, **which needs another reviewer**. It also needs #10873, which is just waiting for the timeout, to be merged before the builds will pass.
