### PR TITLE
scrypt/pmeth: free the MD references correctly.

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -835,7 +835,7 @@ static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
         if (md == NULL)
             return 0;
         ret = EVP_PKEY_CTX_set_signature_md(ctx, md);
-        EVP_MD_meth_free(md);
+        EVP_MD_free(md);
         return ret;
     }
 

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -75,7 +75,7 @@ static void kdf_scrypt_free(void *vctx)
     KDF_SCRYPT *ctx = (KDF_SCRYPT *)vctx;
 
     if (ctx != NULL) {
-        EVP_MD_meth_free(ctx->sha256);
+        EVP_MD_free(ctx->sha256);
         kdf_scrypt_reset(ctx);
         OPENSSL_free(ctx);
     }


### PR DESCRIPTION
The code was calling EVP_MD_meth_free which is incorrect.  It should call
EVP_MD_free.  It happened to work but by luck rather than design.


