### PR TITLE
Fix common test framework options

### DIFF
--- a/test/asynciotest.c
+++ b/test/asynciotest.c
@@ -397,6 +397,11 @@ OPT_TEST_DECLARE_USAGE("certname privkey\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -250,6 +250,11 @@ OPT_TEST_DECLARE_USAGE("sessionfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(sessionfile = test_get_argument(0)))
         return 0;
 

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -538,6 +538,11 @@ void cleanup_tests(void)
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(server_cert_f = test_get_argument(0))
             || !TEST_ptr(pkcs10_f = test_get_argument(1))) {
         TEST_error("usage: cmp_msg_test server.crt pkcs10.der\n");

--- a/test/cmp_protect_test.c
+++ b/test/cmp_protect_test.c
@@ -455,6 +455,11 @@ int setup_tests(void)
     char *root_f;
     char *intermediate_f;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     RAND_bytes(rand_data, OSSL_CMP_TRANSACTIONID_LENGTH);
     if (!TEST_ptr(server_f = test_get_argument(0))
             || !TEST_ptr(ir_protected_f = test_get_argument(1))

--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -65,6 +65,11 @@ int setup_tests(void)
     char *certin = NULL, *privkeyin = NULL;
     BIO *certbio = NULL, *privkeybio = NULL;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(certin = test_get_argument(0))
             || !TEST_ptr(privkeyin = test_get_argument(1)))
         return 0;

--- a/test/d2i_test.c
+++ b/test/d2i_test.c
@@ -127,6 +127,11 @@ int setup_tests(void)
         {"compare", ASN1_COMPARE}
     };
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(test_type_name = test_get_argument(0))
             || !TEST_ptr(expected_error_string = test_get_argument(1))
             || !TEST_ptr(test_file = test_get_argument(2)))

--- a/test/danetest.c
+++ b/test/danetest.c
@@ -413,6 +413,11 @@ OPT_TEST_DECLARE_USAGE("basedomain CAfile tlsafile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(basedomain = test_get_argument(0))
             || !TEST_ptr(CAfile = test_get_argument(1))
             || !TEST_ptr(tlsafile = test_get_argument(2)))

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -332,6 +332,11 @@ OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3258,8 +3258,14 @@ OPT_TEST_DECLARE_USAGE("file...\n")
 
 int setup_tests(void)
 {
-    size_t n = test_get_argument_count();
+    size_t n;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    n = test_get_argument_count();
     if (n == 0)
         return 0;
 

--- a/test/fatalerrtest.c
+++ b/test/fatalerrtest.c
@@ -86,6 +86,11 @@ OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/gosttest.c
+++ b/test/gosttest.c
@@ -82,6 +82,11 @@ OPT_TEST_DECLARE_USAGE("certfile1 privkeyfile1 certfile2 privkeyfile2\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert1 = test_get_argument(0))
             || !TEST_ptr(privkey1 = test_get_argument(1))
             || !TEST_ptr(cert2 = test_get_argument(2))

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -215,6 +215,11 @@ OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(certstr = test_get_argument(0))
         || !TEST_ptr(privkeystr = test_get_argument(1)))
         return 0;

--- a/test/params_conversion_test.c
+++ b/test/params_conversion_test.c
@@ -328,8 +328,14 @@ OPT_TEST_DECLARE_USAGE("file...\n")
 
 int setup_tests(void)
 {
-    size_t n = test_get_argument_count();
+    size_t n;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    n = test_get_argument_count();
     if (n == 0)
         return 0;
 

--- a/test/recordlentest.c
+++ b/test/recordlentest.c
@@ -185,6 +185,11 @@ OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/servername_test.c
+++ b/test/servername_test.c
@@ -239,6 +239,11 @@ static int test_servername(int test)
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -506,6 +506,11 @@ int setup_tests(void)
 {
     long num_tests;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(conf = NCONF_new(NULL))
             /* argv[1] should point to the test conf file */
             || !TEST_int_gt(NCONF_load(conf, test_get_argument(0), NULL), 0)

--- a/test/ssl_test_ctx_test.c
+++ b/test/ssl_test_ctx_test.c
@@ -244,6 +244,11 @@ OPT_TEST_DECLARE_USAGE("conf_file\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(conf = NCONF_new(NULL)))
         return 0;
     /* argument should point to test/ssl_test_ctx_test.conf */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -6972,6 +6972,11 @@ OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(certsdir = test_get_argument(0))
             || !TEST_ptr(srpvfile = test_get_argument(1))
             || !TEST_ptr(tmpfilename = test_get_argument(2)))

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -156,6 +156,11 @@ int setup_tests(void)
 {
     char *cert, *pkey;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(pkey = test_get_argument(1)))
         return 0;

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -250,6 +250,11 @@ int setup_tests(void)
 {
     int n;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -194,6 +194,12 @@ char *test_get_argument(size_t n);
 size_t test_get_argument_count(void);
 
 /*
+ * Skip over common test options. Should be called before calling
+ * test_get_argument()
+ */
+int test_skip_common_options(void);
+
+/*
  * Internal helpers. Test programs shouldn't use these directly, but should
  * rather link to one of the helper main() methods.
  */

--- a/test/testutil/options.c
+++ b/test/testutil/options.c
@@ -15,6 +15,21 @@
 
 static int used[100] = { 0 };
 
+int test_skip_common_options(void)
+{
+    OPTION_CHOICE_DEFAULT o;
+
+    while ((o = (OPTION_CHOICE_DEFAULT)opt_next()) != OPT_EOF) {
+        switch (o) {
+        case OPT_TEST_CASES:
+           break;
+        default:
+        case OPT_ERR:
+            return 0;
+        }
+    }
+    return 1;
+}
 
 size_t test_get_argument_count(void)
 {

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -492,6 +492,11 @@ OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(cert = test_get_argument(0))
             || !TEST_ptr(privkey = test_get_argument(1)))
         return 0;

--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -41,6 +41,11 @@ OPT_TEST_DECLARE_USAGE("cert.pem\n")
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(infile = test_get_argument(0)))
         return 0;
 

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -263,6 +263,11 @@ static int test_req_sm2_id(void)
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(roots_f = test_get_argument(0))
             || !TEST_ptr(untrusted_f = test_get_argument(1))
             || !TEST_ptr(bad_f = test_get_argument(2))

--- a/test/x509_check_cert_pkey_test.c
+++ b/test/x509_check_cert_pkey_test.c
@@ -122,6 +122,11 @@ const OPTIONS *test_get_options(void)
 
 int setup_tests(void)
 {
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
     if (!TEST_ptr(c = test_get_argument(0))
             || !TEST_ptr(k = test_get_argument(1))
             || !TEST_ptr(t = test_get_argument(2))

--- a/test/x509_dup_cert_test.c
+++ b/test/x509_dup_cert_test.c
@@ -37,8 +37,14 @@ OPT_TEST_DECLARE_USAGE("cert.pem...\n")
 
 int setup_tests(void)
 {
-    size_t n = test_get_argument_count();
+    size_t n;
 
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    n = test_get_argument_count();
     if (!TEST_int_gt(n, 0))
         return 0;
 

--- a/test/x509aux.c
+++ b/test/x509aux.c
@@ -165,7 +165,14 @@ OPT_TEST_DECLARE_USAGE("certfile...\n")
 
 int setup_tests(void)
 {
-    size_t n = test_get_argument_count();
+    size_t n;
+
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    n = test_get_argument_count();
     if (n == 0)
         return 0;
 


### PR DESCRIPTION
PR #6975 added the ability to our test framework to have common options to
all tests. For example providing the option "-test 5" to one of our test
programs will just run test number 5. This can be useful when debugging
tests.

Unforuntately this does not work well for a number of tests. In particular
those test that call test_get_argument() without first skipping over these
common test options will not got the expected value. Some tests did this
correctly but a large number did not.

A helper function is introduced, test_skip_common_options(), to make this
easier for those tests which do not have their own specialised test option
handling, but yet still need to call test_get_argument(). This function
call is then added to all those tests that need it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
