### PR TITLE
Remove unused KDF_R_xxx error codes

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2524,34 +2524,6 @@ EVP_R_WRAP_MODE_NOT_ALLOWED:170:wrap mode not allowed
 EVP_R_WRONG_FINAL_BLOCK_LENGTH:109:wrong final block length
 EVP_R_XTS_DATA_UNIT_IS_TOO_LARGE:191:xts data unit is too large
 EVP_R_XTS_DUPLICATED_KEYS:192:xts duplicated keys
-KDF_R_BAD_ENCODING:122:bad encoding
-KDF_R_BAD_LENGTH:123:bad length
-KDF_R_BOTH_MODE_AND_MODE_INT:127:both mode and mode int
-KDF_R_INVALID_DIGEST:100:invalid digest
-KDF_R_INVALID_ITERATION_COUNT:119:invalid iteration count
-KDF_R_INVALID_KEY_LEN:120:invalid key len
-KDF_R_INVALID_MAC_TYPE:116:invalid mac type
-KDF_R_INVALID_MODE:128:invalid mode
-KDF_R_INVALID_MODE_INT:129:invalid mode int
-KDF_R_MISSING_CEK_ALG:125:missing cek alg
-KDF_R_MISSING_ITERATION_COUNT:109:missing iteration count
-KDF_R_MISSING_KEY:104:missing key
-KDF_R_MISSING_MESSAGE_DIGEST:105:missing message digest
-KDF_R_MISSING_PARAMETER:101:missing parameter
-KDF_R_MISSING_PASS:110:missing pass
-KDF_R_MISSING_SALT:111:missing salt
-KDF_R_MISSING_SECRET:107:missing secret
-KDF_R_MISSING_SEED:106:missing seed
-KDF_R_MISSING_SESSION_ID:113:missing session id
-KDF_R_MISSING_TYPE:114:missing type
-KDF_R_MISSING_XCGHASH:115:missing xcghash
-KDF_R_NOT_SUPPORTED:118:not supported
-KDF_R_UNKNOWN_PARAMETER_TYPE:103:unknown parameter type
-KDF_R_UNSUPPORTED_CEK_ALG:126:unsupported cek alg
-KDF_R_UNSUPPORTED_MAC_TYPE:117:unsupported mac type
-KDF_R_VALUE_ERROR:108:value error
-KDF_R_VALUE_MISSING:102:value missing
-KDF_R_WRONG_OUTPUT_BUFFER_SIZE:112:wrong output buffer size
 OBJ_R_OID_EXISTS:102:oid exists
 OBJ_R_UNKNOWN_NID:101:unknown nid
 OCSP_R_CERTIFICATE_VERIFY_ERROR:101:certificate verify error

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -83,36 +83,6 @@ DEPRECATEDIN_3_0(int ERR_load_KDF_strings(void))
  * KDF reason codes.
  */
 # ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define KDF_R_BAD_ENCODING                               122
-#  define KDF_R_BAD_LENGTH                                 123
-#  define KDF_R_BOTH_MODE_AND_MODE_INT                     127
-#  define KDF_R_INAVLID_UKM_LEN                            124
-#  define KDF_R_INVALID_DIGEST                             100
-#  define KDF_R_INVALID_ITERATION_COUNT                    119
-#  define KDF_R_INVALID_KEY_LEN                            120
-#  define KDF_R_INVALID_MAC_TYPE                           116
-#  define KDF_R_INVALID_MODE                               128
-#  define KDF_R_INVALID_MODE_INT                           129
-#  define KDF_R_INVALID_SALT_LEN                           121
-#  define KDF_R_MISSING_CEK_ALG                            125
-#  define KDF_R_MISSING_ITERATION_COUNT                    109
-#  define KDF_R_MISSING_KEY                                104
-#  define KDF_R_MISSING_MESSAGE_DIGEST                     105
-#  define KDF_R_MISSING_PARAMETER                          101
-#  define KDF_R_MISSING_PASS                               110
-#  define KDF_R_MISSING_SALT                               111
-#  define KDF_R_MISSING_SECRET                             107
-#  define KDF_R_MISSING_SEED                               106
-#  define KDF_R_MISSING_SESSION_ID                         113
-#  define KDF_R_MISSING_TYPE                               114
-#  define KDF_R_MISSING_XCGHASH                            115
-#  define KDF_R_NOT_SUPPORTED                              118
-#  define KDF_R_UNKNOWN_PARAMETER_TYPE                     103
-#  define KDF_R_UNSUPPORTED_CEK_ALG                        126
-#  define KDF_R_UNSUPPORTED_MAC_TYPE                       117
-#  define KDF_R_VALUE_ERROR                                108
-#  define KDF_R_VALUE_MISSING                              102
-#  define KDF_R_WRONG_OUTPUT_BUFFER_SIZE                   112
 # endif
 
 #endif


### PR DESCRIPTION
These were created during 3.0 development and aren't used.
