### PR TITLE
Don't complain about documented symbols with find-doc-nits -e -o

### DIFF
--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -607,7 +607,7 @@ sub loadmissing($)
 
     for (@missing) {
         err("$missingfile:", "$_ is documented in $name_map{$_}")
-            if exists $name_map{$_} && defined $name_map{$_};
+            if !$opt_o && exists $name_map{$_} && defined $name_map{$_};
     }
 
     return @missing;


### PR DESCRIPTION
find-doc-nits can give a list of symbols that were added since 1.1.1 and
are undocumented (using -o). To do this it uses the missingcrypto111.txt
and missingssl111.txt files which give a snapshot of the undocumented
symbols at the time of the 1.1.1 release. Currently it complains about
symbols that are in those files that have subsequently been documented.
This isn't particularly helpful so we suppress that feature when "-o"
is being used.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
