### PR TITLE
Use swapcontext for Intel CET

### DIFF
--- a/crypto/async/arch/async_posix.c
+++ b/crypto/async/arch/async_posix.c
@@ -34,7 +34,9 @@ void async_local_cleanup(void)
 
 int async_fibre_makecontext(async_fibre *fibre)
 {
+#ifndef USE_SWAPCONTEXT
     fibre->env_init = 0;
+#endif
     if (getcontext(&fibre->fibre) == 0) {
         fibre->fibre.uc_stack.ss_sp = OPENSSL_malloc(STACKSIZE);
         if (fibre->fibre.uc_stack.ss_sp != NULL) {

--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -25,17 +25,33 @@
 #  define ASYNC_POSIX
 #  define ASYNC_ARCH
 
+#  ifdef __CET__
+/*
+ * When Intel CET is enabled, makecontext will create a different
+ * shadow stack for each context.  async_fibre_swapcontext cannot
+ * use _longjmp.  It must call swapcontext to swap shadow stack as
+ * well as normal stack.
+ */
+#   define USE_SWAPCONTEXT
+#  endif
 #  include <ucontext.h>
-#  include <setjmp.h>
+#  ifndef USE_SWAPCONTEXT
+#   include <setjmp.h>
+#  endif
 
 typedef struct async_fibre_st {
     ucontext_t fibre;
+#  ifndef USE_SWAPCONTEXT
     jmp_buf env;
     int env_init;
+#  endif
 } async_fibre;
 
 static ossl_inline int async_fibre_swapcontext(async_fibre *o, async_fibre *n, int r)
 {
+#  ifdef USE_SWAPCONTEXT
+    swapcontext(&o->fibre, &n->fibre);
+#  else
     o->env_init = 1;
 
     if (!r || !_setjmp(o->env)) {
@@ -44,6 +60,7 @@ static ossl_inline int async_fibre_swapcontext(async_fibre *o, async_fibre *n, i
         else
             setcontext(&n->fibre);
     }
+#  endif
 
     return 1;
 }


### PR DESCRIPTION
When Intel CET is enabled, makecontext will create a different shadow
stack for each context.  async_fibre_swapcontext cannot use _longjmp.
It must call swapcontext to swap shadow stack as well as normal stack.
