### PR TITLE
x86: Add endbranch to indirect branch targets for Intel CET

### DIFF
--- a/crypto/perlasm/cbc.pl
+++ b/crypto/perlasm/cbc.pl
@@ -165,21 +165,28 @@ sub cbc
 	&jmp_ptr($count);
 
 &set_label("ej7");
+	&endbranch()
 	&movb(&HB("edx"),	&BP(6,$in,"",0));
 	&shl("edx",8);
 &set_label("ej6");
+	&endbranch()
 	&movb(&HB("edx"),	&BP(5,$in,"",0));
 &set_label("ej5");
+	&endbranch()
 	&movb(&LB("edx"),	&BP(4,$in,"",0));
 &set_label("ej4");
+	&endbranch()
 	&mov("ecx",		&DWP(0,$in,"",0));
 	&jmp(&label("ejend"));
 &set_label("ej3");
+	&endbranch()
 	&movb(&HB("ecx"),	&BP(2,$in,"",0));
 	&shl("ecx",8);
 &set_label("ej2");
+	&endbranch()
 	&movb(&HB("ecx"),	&BP(1,$in,"",0));
 &set_label("ej1");
+	&endbranch()
 	&movb(&LB("ecx"),	&BP(0,$in,"",0));
 &set_label("ejend");
 

--- a/crypto/perlasm/x86gas.pl
+++ b/crypto/perlasm/x86gas.pl
@@ -124,6 +124,7 @@ sub ::function_begin_B
     push(@out,".align\t$align\n");
     push(@out,"$func:\n");
     push(@out,"$begin:\n")		if ($global);
+    &::endbranch();
     $::stack=4;
 }
 


### PR DESCRIPTION
To support Intel CET, all indirect branch targets must start with
endbranch.  Here is a patch to add endbranch to all function entries
in x86 assembly codes which are indirect branch targets as discovered
by running openssl testsuite on Intel CET machine and visual inspection.

Since x86 cbc.pl uses indirect branch with a jump table, we also need
to add endbranch to all jump targets.