### PR TITLE
x86_64: Don't assume 8-byte pointer size

### DIFF
--- a/crypto/perlasm/x86_64-support.pl
+++ b/crypto/perlasm/x86_64-support.pl
@@ -1,0 +1,51 @@
+#! /usr/bin/env perl
+# Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+package x86_64support;
+
+# require "x86_64-support.pl";
+# $ptr_size=&pointer_size($flavour);
+# $ptr_reg=&pointer_register($flavour,$reg);
+
+sub ::pointer_size
+{
+    my($flavour)=@_;
+    my $ptr_size=8; $ptr_size=4 if ($flavour eq "elf32");
+    return $ptr_size;
+}
+
+sub ::pointer_register
+{
+    my($flavour,$reg)=@_;
+    if ($flavour eq "elf32") {
+	if ($reg eq "%rax") {
+	    return "%eax";
+	} elsif ($reg eq "%rbx") {
+	    return "%ebx";
+	} elsif ($reg eq "%rcx") {
+	    return "%ecx";
+	} elsif ($reg eq "%rdx") {
+	    return "%edx";
+	} elsif ($reg eq "%rdi") {
+	    return "%edi";
+	} elsif ($reg eq "%rsi") {
+	    return "%esi";
+	} elsif ($reg eq "%rbp") {
+	    return "%ebp";
+	} elsif ($reg eq "%rsp") {
+	    return "%esp";
+	} else {
+	    return $reg."d";
+	}
+    } else {
+	return $reg;
+    }
+}
+
+1;


### PR DESCRIPTION
Since pointer in x32 is 4 bytes, add x86_64-support.pl to define pointer_size
and pointer_register based on flavour to support stuctures like:

struct {  void *ptr; int blocks;  }

This fixes 90-test_sslapi.t on x32.  Verified with

$ ./Configure shared linux-x86_64
$ make
$ make test

and

$ ./Configure shared linux-x32
$ make
$ make test