### PR TITLE
Revert "Legacy digests can have custom control values"

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -663,7 +663,7 @@ int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
     }
 
     if (ctx->digest->prov == NULL
-        || (ctx->pctx == NULL
+        && (ctx->pctx == NULL
             || (ctx->pctx->operation != EVP_PKEY_OP_VERIFYCTX
                 && ctx->pctx->operation != EVP_PKEY_OP_SIGNCTX)))
         goto legacy;


### PR DESCRIPTION
This reverts commit 1f457256ce6a1b2fd7e3f62eee8faa74cd5c835e.

This is causing Travis failures.

[extended tests]
