### PR TITLE
Missing "obj_mac" header file in "dh_lib"

### DIFF
--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -7,14 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdio.h>
+#include "dh_local.h"
+#include "crypto/dh.h"
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
 #include <openssl/bn.h>
-#include "dh_local.h"
-#include "crypto/dh.h"
 #include <openssl/engine.h>
-#include "crypto/dh.h"
+#include <openssl/obj_mac.h>
+#include <stdio.h>
+
 
 #ifndef FIPS_MODE
 int DH_set_method(DH *dh, const DH_METHOD *meth)

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -7,15 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "dh_local.h"
-#include "crypto/dh.h"
-#include "internal/cryptlib.h"
-#include "internal/refcount.h"
+#include <stdio.h>
 #include <openssl/bn.h>
 #include <openssl/engine.h>
 #include <openssl/obj_mac.h>
-#include <stdio.h>
-
+#include "internal/cryptlib.h"
+#include "internal/refcount.h"
+#include "crypto/dh.h"
+#include "dh_local.h"
 
 #ifndef FIPS_MODE
 int DH_set_method(DH *dh, const DH_METHOD *meth)


### PR DESCRIPTION
Usage of `NID_undef` symbol without including its definition was causing
a build fail

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
