### PR TITLE
Make minimum size for secure memory a size_t.

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -57,7 +57,7 @@ static CRYPTO_RWLOCK *sec_malloc_lock = NULL;
 /*
  * These are the functions that must be implemented by a secure heap (sh).
  */
-static int sh_init(size_t size, int minsize);
+static int sh_init(size_t size, size_t minsize);
 static void *sh_malloc(size_t size);
 static void sh_free(void *ptr);
 static void sh_done(void);
@@ -65,7 +65,7 @@ static size_t sh_actual_size(char *ptr);
 static int sh_allocated(const char *ptr);
 #endif
 
-int CRYPTO_secure_malloc_init(size_t size, int minsize)
+int CRYPTO_secure_malloc_init(size_t size, size_t minsize)
 {
 #ifdef OPENSSL_SECURE_MEMORY
     int ret = 0;
@@ -373,7 +373,7 @@ static void sh_remove_from_list(char *ptr)
 }
 
 
-static int sh_init(size_t size, int minsize)
+static int sh_init(size_t size, size_t minsize)
 {
     int ret;
     size_t i;
@@ -385,11 +385,10 @@ static int sh_init(size_t size, int minsize)
     /* make sure size and minsize are powers of 2 */
     OPENSSL_assert(size > 0);
     OPENSSL_assert((size & (size - 1)) == 0);
-    OPENSSL_assert(minsize > 0);
     OPENSSL_assert((minsize & (minsize - 1)) == 0);
     if (size <= 0 || (size & (size - 1)) != 0)
         goto err;
-    if (minsize <= 0 || (minsize & (minsize - 1)) != 0)
+    if (minsize == 0 || (minsize & (minsize - 1)) != 0)
         goto err;
 
     while (minsize < (int)sizeof(SH_LIST))

--- a/doc/man3/OPENSSL_secure_malloc.pod
+++ b/doc/man3/OPENSSL_secure_malloc.pod
@@ -14,7 +14,7 @@ CRYPTO_secure_used - secure heap storage
 
  #include <openssl/crypto.h>
 
- int CRYPTO_secure_malloc_init(size_t size, int minsize);
+ int CRYPTO_secure_malloc_init(size_t size, size_t minsize);
 
  int CRYPTO_secure_malloc_initialized();
 
@@ -125,6 +125,9 @@ L<BN_new(3)>
 =head1 HISTORY
 
 The OPENSSL_secure_clear_free() function was added in OpenSSL 1.1.0g.
+
+The second argument to CRYPTO_secure_malloc_init() was changed from an B<int> to
+a B<size_t> in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -317,7 +317,7 @@ void *CRYPTO_realloc(void *addr, size_t num, const char *file, int line);
 void *CRYPTO_clear_realloc(void *addr, size_t old_num, size_t num,
                            const char *file, int line);
 
-int CRYPTO_secure_malloc_init(size_t sz, int minsize);
+int CRYPTO_secure_malloc_init(size_t sz, size_t minsize);
 int CRYPTO_secure_malloc_done(void);
 void *CRYPTO_secure_malloc(size_t num, const char *file, int line);
 void *CRYPTO_secure_zalloc(size_t num, const char *file, int line);

--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -92,7 +92,7 @@ static int test_sec_mem(void)
      * elements was 1<<31, as |int i| was set to that, which is a
      * negative number. However, it requires minimum input values:
      *
-     * CRYPTO_secure_malloc_init((size_t)1<<34, (size_t)1<<4);
+     * CRYPTO_secure_malloc_init((size_t)1<<34, 1<<4);
      *
      * Which really only works on 64-bit systems, since it took 16 GB
      * secure memory arena to trigger the problem. It naturally takes
@@ -113,7 +113,7 @@ static int test_sec_mem(void)
      */
     if (sizeof(size_t) > 4) {
         TEST_info("Possible infinite loop: 1<<31 limit");
-        if (TEST_true(CRYPTO_secure_malloc_init((size_t)1<<34, (size_t)1<<4) != 0))
+        if (TEST_true(CRYPTO_secure_malloc_init((size_t)1<<34, 1<<4) != 0))
             TEST_true(CRYPTO_secure_malloc_done());
     }
 # endif


### PR DESCRIPTION
The minimum size argument to CRYPTO_secure_malloc_init() was an int but ought
to be a size_t since it is a size.

From an API perspective, this is a change.  However, the minimum size is
verified as being a positive power of two and it will typically be a small
constant, so impact should be low to none.

- [x] documentation is added or updated
- [x] tests are added or updated
