### PR TITLE
Fix no-tls1_3

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -110,6 +110,17 @@ static unsigned char serverinfov2[] = {
     0xff        /* Dummy extension data */
 };
 
+static int hostname_cb(SSL *s, int *al, void *arg)
+{
+    const char *hostname = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+
+    if (hostname != NULL && (strcmp(hostname, "goodhost") == 0
+                             || strcmp(hostname, "altgoodhost") == 0))
+        return  SSL_TLSEXT_ERR_OK;
+
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
 static void client_keylog_callback(const SSL *ssl, const char *line)
 {
     int line_length = strlen(line);
@@ -3194,17 +3205,6 @@ static int test_early_data_not_sent(int idx)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     return testresult;
-}
-
-static int hostname_cb(SSL *s, int *al, void *arg)
-{
-    const char *hostname = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
-
-    if (hostname != NULL && (strcmp(hostname, "goodhost") == 0
-                             || strcmp(hostname, "altgoodhost") == 0))
-        return  SSL_TLSEXT_ERR_OK;
-
-    return SSL_TLSEXT_ERR_NOACK;
 }
 
 static const char *servalpn;


### PR DESCRIPTION
The hostname_cb in sslapitest.c was originally only defined if TLSv1.3
was enabled. A recently added test now uses this unconditionally, so we
move the function implementation earlier in the file, and always compile
it in.