### PR TITLE
Params: change UTF8 construct calls to avoid explicit strlen(3) calls.

### DIFF
--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -43,14 +43,14 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
     if ((kctx = EVP_KDF_CTX_new(kdf)) == NULL)
         goto err;
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)mdname, strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                              (unsigned char *)Z, Zlen);
     if (ukm != NULL)
         *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_UKM,
                                                  (unsigned char *)ukm, ukmlen);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CEK_ALG,
-                                            (char *)oid_sn, strlen(oid_sn) + 1);
+                                            (char *)oid_sn, 0);
     *p = OSSL_PARAM_construct_end();
     ret = EVP_KDF_CTX_set_params(kctx, params) > 0
         && EVP_KDF_derive(kctx, out, outlen) > 0;

--- a/crypto/ec/ecdh_kdf.c
+++ b/crypto/ec/ecdh_kdf.c
@@ -34,8 +34,7 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
 
     if ((kctx = EVP_KDF_CTX_new(kdf)) != NULL) {
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                                (char *)mdname,
-                                                strlen(mdname) + 1);
+                                                (char *)mdname, 0);
         *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                                  (void *)Z, Zlen);
         *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -52,7 +52,7 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
                                              (unsigned char *)salt, saltlen);
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_ITER, &iter);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)mdname, strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     *p = OSSL_PARAM_construct_end();
     if (EVP_KDF_CTX_set_params(kctx, params) != 1
             || EVP_KDF_derive(kctx, out, keylen) != 1)

--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -186,8 +186,7 @@ static int pkey_kdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 
     case T_DIGEST:
         mdname = EVP_MD_name((const EVP_MD *)p2);
-        params[0] = OSSL_PARAM_construct_utf8_string(name, (char *)mdname,
-                                                     strlen(mdname) + 1);
+        params[0] = OSSL_PARAM_construct_utf8_string(name, (char *)mdname, 0);
         break;
 
         /*

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -704,8 +704,7 @@ int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
                                              * Cast away the const. This is read
                                              * only so should be safe
                                              */
-                                            (char *)name,
-                                            strlen(name) + 1);
+                                            (char *)name, 0);
     *p++ = OSSL_PARAM_construct_end();
 
     return EVP_PKEY_CTX_set_params(ctx, sig_md_params);

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -851,8 +851,7 @@ int EVP_PKEY_CTX_set_rsa_oaep_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
                                              * Cast away the const. This is read
                                              * only so should be safe
                                              */
-                                            (char *)mdname,
-                                            strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     if (mdprops != NULL) {
         *p++ = OSSL_PARAM_construct_utf8_string(
                     OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST_PROPS,
@@ -860,8 +859,7 @@ int EVP_PKEY_CTX_set_rsa_oaep_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
                      * Cast away the const. This is read
                      * only so should be safe
                      */
-                    (char *)mdprops,
-                    strlen(mdprops) + 1);
+                    (char *)mdprops, 0);
     }
     *p++ = OSSL_PARAM_construct_end();
 
@@ -979,8 +977,7 @@ int EVP_PKEY_CTX_set_rsa_mgf1_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
                                              * Cast away the const. This is read
                                              * only so should be safe
                                              */
-                                            (char *)mdname,
-                                            strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     if (mdprops != NULL) {
         *p++ = OSSL_PARAM_construct_utf8_string(
                     OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST_PROPS,
@@ -988,8 +985,7 @@ int EVP_PKEY_CTX_set_rsa_mgf1_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
                      * Cast away the const. This is read
                      * only so should be safe
                      */
-                    (char *)mdprops,
-                    strlen(mdprops) + 1);
+                    (char *)mdprops, 0);
     }
     *p++ = OSSL_PARAM_construct_end();
 

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -167,7 +167,9 @@ size B<rsize> is created.
 OSSL_PARAM_construct_utf8_string() is a function that constructs a UTF8
 string OSSL_PARAM structure.
 A parameter with name B<key>, storage B<buf> and size B<bsize> is created.
-If B<bsize> is zero, the string length is determined using strlen(3).
+If B<bsize> is zero, the string length is determined using strlen(3) + 1 for the
+null termination byte.
+Generally pass zero for B<bsize> instead of calling strlen(3) yourself.
 
 OSSL_PARAM_construct_octet_string() is a function that constructs an OCTET
 string OSSL_PARAM structure.

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -55,7 +55,7 @@ static int tls1_PRF(SSL *s,
         goto err;
     mdname = EVP_MD_name(md);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)mdname, strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET,
                                              (unsigned char *)sec,
                                              (size_t)slen);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -97,7 +97,7 @@ int tls13_hkdf_expand(SSL *s, const EVP_MD *md, const unsigned char *secret,
 
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &mode);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)mdname, strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                              (unsigned char *)secret, hashlen);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
@@ -252,7 +252,7 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
 
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_MODE, &mode);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)mdname, strlen(mdname) + 1);
+                                            (char *)mdname, 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
                                              (unsigned char *)insecret,
                                              insecretlen);


### PR DESCRIPTION
It is better, safer and smaller to let the library routine handle the `strlen(3)` call.

Added a note to the documentation suggesting this.

- [x] documentation is added or updated
- [ ] tests are added or updated
