### PR TITLE
Don't compile AESNI code if we're not AESNI capable

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.h
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.h
@@ -13,10 +13,6 @@
 int cipher_capable_aes_cbc_hmac_sha1(void);
 int cipher_capable_aes_cbc_hmac_sha256(void);
 
-#ifdef AES_CBC_HMAC_SHA_CAPABLE
-# include <openssl/aes.h>
-# include <openssl/sha.h>
-
 typedef struct prov_cipher_hw_aes_hmac_sha_ctx_st {
     PROV_CIPHER_HW base; /* must be first */
     void (*init_mac_key)(void *ctx, const unsigned char *inkey, size_t inlen);
@@ -29,6 +25,13 @@ typedef struct prov_cipher_hw_aes_hmac_sha_ctx_st {
         void *ctx, EVP_CTRL_TLS1_1_MULTIBLOCK_PARAM *param);
 # endif /* OPENSSL_NO_MULTIBLOCK) */
 } PROV_CIPHER_HW_AES_HMAC_SHA;
+
+const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha1(void);
+const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha256(void);
+
+#ifdef AES_CBC_HMAC_SHA_CAPABLE
+# include <openssl/aes.h>
+# include <openssl/sha.h>
 
 typedef struct prov_aes_hmac_sha_ctx_st {
     PROV_CIPHER_CTX base;
@@ -58,8 +61,5 @@ typedef struct prov_aes_hmac_sha256_ctx_st {
 } PROV_AES_HMAC_SHA256_CTX;
 
 # define NO_PAYLOAD_LENGTH ((size_t)-1)
-
-const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha1(void);
-const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha256(void);
 
 #endif /* AES_CBC_HMAC_SHA_CAPABLE */

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
@@ -16,10 +16,15 @@
 
 #include "cipher_aes_cbc_hmac_sha.h"
 
-#ifndef AES_CBC_HMAC_SHA_CAPABLE
+#if  !defined(AES_CBC_HMAC_SHA_CAPABLE) || !defined(AESNI_CAPABLE)
 int cipher_capable_aes_cbc_hmac_sha1(void)
 {
     return 0;
+}
+
+const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha1(void)
+{
+    return NULL;
 }
 #else
 
@@ -765,7 +770,7 @@ static int aesni_cbc_hmac_sha1_tls1_multiblock_encrypt(
                                          param->interleave / 4);
 }
 
-#endif /* OPENSSL_NO_MULTIBLOCK */
+# endif /* OPENSSL_NO_MULTIBLOCK */
 
 static const PROV_CIPHER_HW_AES_HMAC_SHA cipher_hw_aes_hmac_sha1 = {
     {
@@ -786,4 +791,4 @@ const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha1(void)
     return &cipher_hw_aes_hmac_sha1;
 }
 
-#endif /* AES_CBC_HMAC_SHA_CAPABLE */
+#endif /* !defined(AES_CBC_HMAC_SHA_CAPABLE) || !defined(AESNI_CAPABLE) */

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
@@ -16,10 +16,15 @@
 
 #include "cipher_aes_cbc_hmac_sha.h"
 
-#ifndef AES_CBC_HMAC_SHA_CAPABLE
+#if !defined(AES_CBC_HMAC_SHA_CAPABLE) || !defined(AESNI_CAPABLE)
 int cipher_capable_aes_cbc_hmac_sha256(void)
 {
     return 0;
+}
+
+const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha256(void)
+{
+    return NULL;
 }
 #else
 
@@ -814,7 +819,7 @@ static int aesni_cbc_hmac_sha256_tls1_multiblock_encrypt(
                                          param->inp, param->len,
                                          param->interleave / 4);
 }
-#endif
+# endif
 
 static const PROV_CIPHER_HW_AES_HMAC_SHA cipher_hw_aes_hmac_sha256 = {
     {
@@ -835,4 +840,4 @@ const PROV_CIPHER_HW_AES_HMAC_SHA *PROV_CIPHER_HW_aes_cbc_hmac_sha256(void)
     return &cipher_hw_aes_hmac_sha256;
 }
 
-#endif /* AES_CBC_HMAC_SHA_CAPABLE */
+#endif /* !defined(AES_CBC_HMAC_SHA_CAPABLE) || !defined(AESNI_CAPABLE) */


### PR DESCRIPTION
Compile failures were occuring on systems that weren't AESNI capable
because the detection wasn't quite right in a couple of files.

This fixes a run-checker build failure for the 386 compile option.