### PR TITLE
Make secure-memory be a config option

### DIFF
--- a/Configure
+++ b/Configure
@@ -412,6 +412,7 @@ my @disablables = (
     "rmd160",
     "scrypt",
     "sctp",
+    "secure-memory",
     "seed",
     "shared",
     "siphash",

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -20,8 +20,7 @@
 
 #include <string.h>
 
-/* e_os.h defines OPENSSL_SECURE_MEMORY if secure memory can be implemented */
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
 # include <stdlib.h>
 # include <assert.h>
 # include <unistd.h>
@@ -47,7 +46,7 @@
 # define MAP_ANON MAP_ANONYMOUS
 #endif
 
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
 static size_t secure_mem_used;
 
 static int secure_mem_initialized;
@@ -67,7 +66,7 @@ static int sh_allocated(const char *ptr);
 
 int CRYPTO_secure_malloc_init(size_t size, size_t minsize)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     int ret = 0;
 
     if (!secure_mem_initialized) {
@@ -85,12 +84,12 @@ int CRYPTO_secure_malloc_init(size_t size, size_t minsize)
     return ret;
 #else
     return 0;
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 int CRYPTO_secure_malloc_done(void)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     if (secure_mem_used == 0) {
         sh_done();
         secure_mem_initialized = 0;
@@ -98,22 +97,22 @@ int CRYPTO_secure_malloc_done(void)
         sec_malloc_lock = NULL;
         return 1;
     }
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
     return 0;
 }
 
 int CRYPTO_secure_malloc_initialized(void)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     return secure_mem_initialized;
 #else
     return 0;
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 void *CRYPTO_secure_malloc(size_t num, const char *file, int line)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     void *ret;
     size_t actual_size;
 
@@ -128,12 +127,12 @@ void *CRYPTO_secure_malloc(size_t num, const char *file, int line)
     return ret;
 #else
     return CRYPTO_malloc(num, file, line);
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     if (secure_mem_initialized)
         /* CRYPTO_secure_malloc() zeroes allocations when it is implemented */
         return CRYPTO_secure_malloc(num, file, line);
@@ -143,7 +142,7 @@ void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
 
 void CRYPTO_secure_free(void *ptr, const char *file, int line)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifdef OPENSSL_NO_SECURE_MEMORY
     size_t actual_size;
 
     if (ptr == NULL)
@@ -160,13 +159,13 @@ void CRYPTO_secure_free(void *ptr, const char *file, int line)
     CRYPTO_THREAD_unlock(sec_malloc_lock);
 #else
     CRYPTO_free(ptr, file, line);
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 void CRYPTO_secure_clear_free(void *ptr, size_t num,
                               const char *file, int line)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     size_t actual_size;
 
     if (ptr == NULL)
@@ -187,12 +186,12 @@ void CRYPTO_secure_clear_free(void *ptr, size_t num,
         return;
     OPENSSL_cleanse(ptr, num);
     CRYPTO_free(ptr, file, line);
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 int CRYPTO_secure_allocated(const void *ptr)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     int ret;
 
     if (!secure_mem_initialized)
@@ -203,21 +202,21 @@ int CRYPTO_secure_allocated(const void *ptr)
     return ret;
 #else
     return 0;
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 size_t CRYPTO_secure_used(void)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     return secure_mem_used;
 #else
     return 0;
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */
 }
 
 size_t CRYPTO_secure_actual_size(void *ptr)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     size_t actual_size;
 
     CRYPTO_THREAD_write_lock(sec_malloc_lock);
@@ -235,7 +234,7 @@ size_t CRYPTO_secure_actual_size(void *ptr)
 /*
  * SECURE HEAP IMPLEMENTATION
  */
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
 
 
 /*
@@ -642,4 +641,4 @@ static size_t sh_actual_size(char *ptr)
     OPENSSL_assert(sh_testbit(ptr, list, sh.bittable));
     return sh.arena_size / (ONE << list);
 }
-#endif /* OPENSSL_SECURE_MEMORY */
+#endif /* OPENSSL_NO_SECURE_MEMORY */

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -142,7 +142,7 @@ void *CRYPTO_secure_zalloc(size_t num, const char *file, int line)
 
 void CRYPTO_secure_free(void *ptr, const char *file, int line)
 {
-#ifdef OPENSSL_NO_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     size_t actual_size;
 
     if (ptr == NULL)

--- a/e_os.h
+++ b/e_os.h
@@ -300,11 +300,16 @@ struct servent *getservbyname(const char *name, const char *proto);
 #  define CRYPTO_memcmp memcmp
 # endif
 
-/* unistd.h defines _POSIX_VERSION */
-# if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
-     && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
-          || defined(__sun) || defined(__hpux) || defined(__sgi)      \
-          || defined(__osf__) )
-#  define OPENSSL_SECURE_MEMORY  /* secure memory is implemented */
+# ifndef OPENSSL_NO_SECURE_MEMORY
+   /* unistd.h defines _POSIX_VERSION */
+#  if defined(OPENSSL_SYS_UNIX) \
+      && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
+           || defined(__sun) || defined(__hpux) || defined(__sgi)      \
+           || defined(__osf__) )
+      /* secure memory is implemented */
+#   else
+#     define OPENSSL_NO_SECURE_MEMORY
+#   endif
 # endif
+
 #endif

--- a/test/secmemtest.c
+++ b/test/secmemtest.c
@@ -14,7 +14,7 @@
 
 static int test_sec_mem(void)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     int testresult = 0;
     char *p = NULL, *q = NULL, *r = NULL, *s = NULL;
 
@@ -135,7 +135,7 @@ static int test_sec_mem(void)
 
 static int test_sec_mem_clear(void)
 {
-#ifdef OPENSSL_SECURE_MEMORY
+#ifndef OPENSSL_NO_SECURE_MEMORY
     const int size = 64;
     unsigned char *p = NULL;
     int i, res = 0;


### PR DESCRIPTION
Adding support for "no-secure-memory" was simple, a one-liner.
Fixing all the "ifdef OPENSSL_SECURE_MEMORY" to be "ifndef NO_xxx"
was a bit more work.  My original goof, for not following the OpenSSL
pattern "ifndef NO_" used everywhere else.

I don't know if this fixes 7207 or not.  But this is a code-cleanup issue. Should backport, I didn't try.
