### PR TITLE
[Pending #11074] EVP: Adapt EVP_PKEY checking, comparing and copying for provider keys, take 2

### DIFF
--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -337,3 +337,8 @@ int DSA_bits(const DSA *dsa)
 {
     return BN_num_bits(dsa->params.p);
 }
+
+FFC_PARAMS *dsa_get0_params(DSA *dsa)
+{
+    return &dsa->params;
+}

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -90,6 +90,7 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_import_types_fn *import_types;
     OSSL_OP_keymgmt_export_fn *export;
     OSSL_OP_keymgmt_export_types_fn *export_types;
+    OSSL_OP_keymgmt_copy_fn *copy;
 } /* EVP_KEYMGMT */ ;
 
 struct evp_keyexch_st {

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -83,6 +83,7 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_query_operation_name_fn *query_operation_name;
     OSSL_OP_keymgmt_has_fn *has;
     OSSL_OP_keymgmt_validate_fn *validate;
+    OSSL_OP_keymgmt_match_fn *match;
 
     /* Import and export routines */
     OSSL_OP_keymgmt_import_fn *import;

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -211,3 +211,29 @@ void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
 
     return keydata;
 }
+
+int evp_keymgmt_util_has(EVP_PKEY *pk, int selection)
+{
+    size_t i, end = OSSL_NELEM(pk->pkeys);
+
+    for (i = 0; i < end && pk->pkeys[i].keymgmt != NULL; i++) {
+        const EVP_KEYMGMT *keymgmt = pk->pkeys[i].keymgmt;
+        void *keydata = pk->pkeys[i].keydata;
+
+        if (keymgmt->has != NULL)
+            return evp_keymgmt_has(keymgmt, keydata, selection);
+    }
+    /*
+     * TODO(3.0) investigate whether the lack of any |has| function should
+     * mean that the key has the components indicated by |selection| (i.e.
+     * they are assumed to be the empty set) or not.
+     * TODO(3.0) Investigate if we should return a value that indicates that
+     * this function is unsupported, leaving it to the caller to decide what
+     * to do.
+     *
+     * We currently assume that if there is no |has| function, the components
+     * indicated by |selection| are present, because that's how
+     * EVP_PKEY_missing_parameters() behaves for legacy EVP_PKEYs.
+     */
+    return 1;
+}

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -306,3 +306,13 @@ const OSSL_PARAM *evp_keymgmt_export_types(const EVP_KEYMGMT *keymgmt,
         return NULL;
     return keymgmt->export_types(selection);
 }
+
+int evp_keymgmt_copy(const EVP_KEYMGMT *keymgmt,
+                     void *keydata_to, const void *keydata_from,
+                     int selection)
+{
+    /* We assume no copy if the implementation doesn't have a function */
+    if (keymgmt->copy == NULL)
+        return 0;
+    return keymgmt->copy(keydata_to, keydata_from, selection);
+}

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -82,6 +82,10 @@ static void *keymgmt_from_dispatch(int name_id,
             if (keymgmt->validate == NULL)
                 keymgmt->validate = OSSL_get_OP_keymgmt_validate(fns);
             break;
+        case OSSL_FUNC_KEYMGMT_MATCH:
+            if (keymgmt->match == NULL)
+                keymgmt->match = OSSL_get_OP_keymgmt_match(fns);
+            break;
         case OSSL_FUNC_KEYMGMT_IMPORT:
             if (keymgmt->import == NULL) {
                 importfncnt++;
@@ -259,6 +263,16 @@ int evp_keymgmt_validate(const EVP_KEYMGMT *keymgmt, void *keydata,
     if (keymgmt->validate == NULL)
         return 1;
     return keymgmt->validate(keydata, selection);
+}
+
+int evp_keymgmt_match(const EVP_KEYMGMT *keymgmt,
+                      const void *keydata1, const void *keydata2,
+                      int selection)
+{
+    /* We assume no match if the implementation doesn't have a function */
+    if (keymgmt->match == NULL)
+        return 0;
+    return keymgmt->match(keydata1, keydata2, selection);
 }
 
 int evp_keymgmt_import(const EVP_KEYMGMT *keymgmt, void *keydata,

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -942,7 +942,6 @@ int EVP_PKEY_up_ref(EVP_PKEY *pkey)
 
 static void evp_pkey_free_legacy(EVP_PKEY *x)
 {
-
     if (x->ameth != NULL) {
         if (x->ameth->pkey_free != NULL)
             x->ameth->pkey_free(x);
@@ -955,6 +954,7 @@ static void evp_pkey_free_legacy(EVP_PKEY *x)
     ENGINE_finish(x->pmeth_engine);
     x->pmeth_engine = NULL;
 #endif
+    x->type = x->save_type = NID_undef;
 }
 
 static void evp_pkey_free_it(EVP_PKEY *x)

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -24,6 +24,8 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
 
  /* Key object content checks */
  int OP_keymgmt_has(void *keydata, int selection);
+ int OP_keymgmt_match(const void *keydata1, const void *keydata2,
+                      int selection);
 
  /* Discovery of supported operations */
  const char *OP_keymgmt_query_operation_name(int operation_id);
@@ -83,6 +85,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 
  OP_keymgmt_has                  OSSL_FUNC_KEYMGMT_HAS
  OP_keymgmt_validate             OSSL_FUNC_KEYMGMT_VALIDATE
+ OP_keymgmt_match                OSSL_FUNC_KEYMGMT_MATCH
 
  OP_keymgmt_import               OSSL_FUNC_KEYMGMT_IMPORT
  OP_keymgmt_import_types         OSSL_FUNC_KEYMGMT_IMPORT_TYPES
@@ -227,6 +230,11 @@ For example, the combination of B<OSSL_KEYMGMT_SELECT_PRIVATE_KEY> and
 B<OSSL_KEYMGMT_SELECT_PUBLIC_KEY> (or B<OSSL_KEYMGMT_SELECT_KEYPAIR>
 for short) is expected to check that the pairwise consistency of
 I<keydata> is valid.
+
+OP_keymgmt_match() should check if the data subset indicated by
+I<selection> in I<keydata1> and I<keydata2> match.  It is assumed that
+the caller has ensured that I<keydata1> and I<keydata2> are both owned
+by the implementation of this function.
 
 =head2 Key Object Import and Export Functions
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -37,6 +37,9 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
                        OSSL_CALLBACK *param_cb, void *cbarg);
  const OSSL_PARAM *OP_keymgmt_export_types(int selection);
 
+ /* Key object copy */
+ int OP_keymgmt_copy(void *keydata_to, const void *keydata_from, int selection);
+
  /* Key object validation */
  int OP_keymgmt_validate(void *keydata, int selection);
 
@@ -92,6 +95,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_keymgmt_export               OSSL_FUNC_KEYMGMT_EXPORT
  OP_keymgmt_export_types         OSSL_FUNC_KEYMGMT_EXPORT_TYPES
 
+ OP_keymgmt_copy                 OSSL_FUNC_KEYMGMT_COPY
 
 =head2 Key Objects
 
@@ -236,7 +240,7 @@ I<selection> in I<keydata1> and I<keydata2> match.  It is assumed that
 the caller has ensured that I<keydata1> and I<keydata2> are both owned
 by the implementation of this function.
 
-=head2 Key Object Import and Export Functions
+=head2 Key Object Import, Export and Copy Functions
 
 OP_keymgmt_import() should import data indicated by I<selection> into
 I<keydata> with values taken from the B<OSSL_PARAM> array I<params>.
@@ -252,6 +256,11 @@ OP_keymgmt_import() can handle.
 OP_keymgmt_export_types() should return a constant array of descriptor
 B<OSSL_PARAM> for data indicated by I<selection>, that the
 OP_keymgmt_export() callback can expect to receive.
+
+OP_keymgmt_copy() should copy data subsets indicated by I<selection>
+from I<keydata_from> to I<keydata_to>.  It is assumed that the caller
+has ensured that I<keydata_to> and I<keydata_from> are both owned by
+the implementation of this function.
 
 =head2 Information Parameters
 

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/dsa.h>
+#include "internal/ffc.h"
 
 #define DSA_PARAMGEN_TYPE_FIPS_186_2   1   /* Use legacy FIPS186-2 standard */
 #define DSA_PARAMGEN_TYPE_FIPS_186_4   2   /* Use FIPS186-4 standard */
@@ -21,6 +22,9 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type,
 int dsa_sign_int(int type, const unsigned char *dgst,
                  int dlen, unsigned char *sig, unsigned int *siglen, DSA *dsa);
 const unsigned char *dsa_algorithmidentifier_encoding(int md_nid, size_t *len);
+
+FFC_PARAMS *dsa_get0_params(DSA *dsa);
+
 int dsa_generate_public_key(BN_CTX *ctx, const DSA *dsa, const BIGNUM *priv_key,
                             BIGNUM *pub_key);
 int dsa_check_params(const DSA *dsa, int *ret);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -600,6 +600,9 @@ const OSSL_PARAM *evp_keymgmt_gettable_params(const EVP_KEYMGMT *keymgmt);
 int evp_keymgmt_has(const EVP_KEYMGMT *keymgmt, void *keyddata, int selection);
 int evp_keymgmt_validate(const EVP_KEYMGMT *keymgmt, void *keydata,
                          int selection);
+int evp_keymgmt_match(const EVP_KEYMGMT *keymgmt,
+                      const void *keydata1, const void *keydata2,
+                      int selection);
 
 int evp_keymgmt_import(const EVP_KEYMGMT *keymgmt, void *keydata,
                        int selection, const OSSL_PARAM params[]);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -586,6 +586,7 @@ void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                                 int selection, const OSSL_PARAM params[]);
 int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
 int evp_keymgmt_util_match(EVP_PKEY *pk1, EVP_PKEY *pk2, int selection);
+int evp_keymgmt_util_copy(EVP_PKEY *to, EVP_PKEY *from, int selection);
 
 
 /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -585,6 +585,7 @@ void evp_keymgmt_util_cache_pkey(EVP_PKEY *pk, size_t index,
 void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                                 int selection, const OSSL_PARAM params[]);
 int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
+int evp_keymgmt_util_match(EVP_PKEY *pk1, EVP_PKEY *pk2, int selection);
 
 
 /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -584,6 +584,7 @@ void evp_keymgmt_util_cache_pkey(EVP_PKEY *pk, size_t index,
                                  EVP_KEYMGMT *keymgmt, void *keydata);
 void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                                 int selection, const OSSL_PARAM params[]);
+int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
 
 
 /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -613,6 +613,9 @@ int evp_keymgmt_export(const EVP_KEYMGMT *keymgmt, void *keydata,
                        int selection, OSSL_CALLBACK *param_cb, void *cbarg);
 const OSSL_PARAM *evp_keymgmt_export_types(const EVP_KEYMGMT *keymgmt,
                                            int selection);
+int evp_keymgmt_copy(const EVP_KEYMGMT *keymgmt,
+                     void *keydata_to, const void *keydata_from,
+                     int selection);
 
 /* Pulling defines out of C source files */
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -412,7 +412,7 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_match,
                     (const void *keydata1, const void *keydata2,
                      int selection))
 
-/* Import and export functions, with ddiscovery */
+/* Import and export functions, with discovery */
 # define OSSL_FUNC_KEYMGMT_IMPORT                     40
 # define OSSL_FUNC_KEYMGMT_IMPORT_TYPES               41
 # define OSSL_FUNC_KEYMGMT_EXPORT                     42
@@ -426,6 +426,12 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_export,
                      OSSL_CALLBACK *param_cb, void *cbarg))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_export_types,
                     (int selection))
+
+/* Copy function, only works for matching keymgmt */
+# define OSSL_FUNC_KEYMGMT_COPY                       44
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_copy,
+                    ( void *keydata_to, const void *keydata_from,
+                     int selection))
 
 /* Key Exchange */
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -406,6 +406,12 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_has, (void *keydata, int selection))
 # define OSSL_FUNC_KEYMGMT_VALIDATE                   22
 OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_validate, (void *keydata, int selection))
 
+/* Key checks - matching */
+# define OSSL_FUNC_KEYMGMT_MATCH                      23
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_match,
+                    (const void *keydata1, const void *keydata2,
+                     int selection))
+
 /* Import and export functions, with ddiscovery */
 # define OSSL_FUNC_KEYMGMT_IMPORT                     40
 # define OSSL_FUNC_KEYMGMT_IMPORT_TYPES               41

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -23,6 +23,7 @@ static OSSL_OP_keymgmt_free_fn dh_freedata;
 static OSSL_OP_keymgmt_get_params_fn dh_get_params;
 static OSSL_OP_keymgmt_gettable_params_fn dh_gettable_params;
 static OSSL_OP_keymgmt_has_fn dh_has;
+static OSSL_OP_keymgmt_match_fn dh_match;
 static OSSL_OP_keymgmt_import_fn dh_import;
 static OSSL_OP_keymgmt_import_types_fn dh_import_types;
 static OSSL_OP_keymgmt_export_fn dh_export;
@@ -163,6 +164,25 @@ static int dh_has(void *keydata, int selection)
     return ok;
 }
 
+static int dh_match(const void *keydata1, const void *keydata2, int selection)
+{
+    const DH *dh1 = keydata1;
+    const DH *dh2 = keydata2;
+    int ok = 1;
+
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
+        ok = ok && BN_cmp(DH_get0_pub_key(dh1), DH_get0_pub_key(dh2)) == 0;
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
+        ok = ok && BN_cmp(DH_get0_priv_key(dh1), DH_get0_priv_key(dh2)) == 0;
+    if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) {
+        FFC_PARAMS *dhparams1 = dh_get0_params((DH *)dh1);
+        FFC_PARAMS *dhparams2 = dh_get0_params((DH *)dh2);
+
+        ok = ok && ffc_params_cmp(dhparams1, dhparams2, 1);
+    }
+    return ok;
+}
+
 static int dh_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
     DH *dh = keydata;
@@ -296,6 +316,7 @@ const OSSL_DISPATCH dh_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))dh_get_params },
     { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void))dh_gettable_params },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))dh_has },
+    { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))dh_match },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))dh_import },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))dh_import_types },
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))dh_export },

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -26,6 +26,7 @@ static OSSL_OP_keymgmt_free_fn rsa_freedata;
 static OSSL_OP_keymgmt_get_params_fn rsa_get_params;
 static OSSL_OP_keymgmt_gettable_params_fn rsa_gettable_params;
 static OSSL_OP_keymgmt_has_fn rsa_has;
+static OSSL_OP_keymgmt_match_fn rsa_match;
 static OSSL_OP_keymgmt_validate_fn rsa_validate;
 static OSSL_OP_keymgmt_import_fn rsa_import;
 static OSSL_OP_keymgmt_import_types_fn rsa_import_types;
@@ -194,6 +195,21 @@ static int rsa_has(void *keydata, int selection)
         ok = ok && (RSA_get0_n(rsa) != NULL);
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
         ok = ok && (RSA_get0_d(rsa) != NULL);
+    return ok;
+}
+
+static int rsa_match(const void *keydata1, const void *keydata2, int selection)
+{
+    const RSA *rsa1 = keydata1;
+    const RSA *rsa2 = keydata2;
+    int ok = 1;
+
+    /* There is always an |e| */
+    ok = ok && BN_cmp(RSA_get0_e(rsa1), RSA_get0_e(rsa2)) == 0;
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
+        ok = ok && BN_cmp(RSA_get0_n(rsa1), RSA_get0_n(rsa2)) == 0;
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
+        ok = ok && BN_cmp(RSA_get0_d(rsa1), RSA_get0_d(rsa2)) == 0;
     return ok;
 }
 
@@ -393,6 +409,7 @@ const OSSL_DISPATCH rsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))rsa_get_params },
     { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void))rsa_gettable_params },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))rsa_has },
+    { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))rsa_match },
     { OSSL_FUNC_KEYMGMT_VALIDATE, (void (*)(void))rsa_validate },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))rsa_import },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))rsa_import_types },


### PR DESCRIPTION
This is an adaptation of the following functions for provided keys:

-   EVP_PKEY_copy_parameters()
-   EVP_PKEY_missing_parameters()
-   EVP_PKEY_cmp_parameters()
-   EVP_PKEY_cmp()

This also adds the necessary EVP_KEYMGMT interfaces to support those functions, and the implementations for RSA, DSA and DH.

This replaces #10807 and is built on top of #11006