### PR TITLE
Configure: Add easy to use disabled deprecated functionality indicators

### DIFF
--- a/Configure
+++ b/Configure
@@ -561,8 +561,7 @@ my @disable_cascades = (
     "cmp"               => [ "crmf" ],
 
     # Padlock engine uses low-level AES APIs which are deprecated
-    sub { $disabled{"deprecated"}
-          && (!defined $config{"api"} || $config{"api"} >= 30000) }
+    sub { $disabled{"deprecated-3.0"} }
           => [ "padlockeng" ]
     );
 
@@ -1477,6 +1476,12 @@ die "Exactly one of SIXTY_FOUR_BIT|SIXTY_FOUR_BIT_LONG|THIRTY_TWO_BIT can be set
 
 $config{api} = $config{major} * 10000 + $config{minor} * 100
     unless $config{api};
+foreach (keys %$apitable) {
+    $disabled{"deprecated-$_"} = "deprecation"
+        if $disabled{deprecated} && $config{api} >= $apitable->{$_};
+}
+
+disable();                      # Run a cascade now
 
 # Hack cflags for better warnings (dev option) #######################
 
@@ -1488,7 +1493,7 @@ $config{cxxflags} = [ map { (my $x = $_) =~ s/([\\\"])/\\$1/g; $x }
                           @{$config{cxxflags}} ] if $config{CXX};
 
 $config{openssl_api_defines} = [
-    "OPENSSL_CONFIGURED_API=".$config{api}
+    "OPENSSL_CONFIGURED_API=".$config{api},
 ];
 
 my @strict_warnings_collection=();
@@ -1647,6 +1652,9 @@ foreach my $what (sort keys %disabled) {
     # There are deprecated disablables that translate to themselves.
     # They cause disabling cascades, but should otherwise not regiter.
     next if $deprecated_disablables{$what};
+    # The generated $disabled{"deprecated-x.y"} entries are special
+    # and treated properly elsewhere
+    next if $what =~ m|^deprecated-|;
 
     $config{options} .= " no-$what";
 

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -25,9 +25,9 @@ SOURCE[../../providers/libfips.a]=$COMMON
 DEFINE[../../libcrypto]=$DESDEF
 DEFINE[../../providers/libfips.a]=$DESDEF
 
-IF[{- $disabled{"deprecated"}
-      && !$disabled{"mdc2"}
-      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+# When all deprecated symbols are removed, libcrypto doesn't export the
+# DES functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{"mdc2"} -}]
   SOURCE[../../providers/liblegacy.a]=set_key.c $DESASM
   DEFINE[../../providers/liblegacy.a]=$DESDEF
 ENDIF

--- a/crypto/evp/build.info
+++ b/crypto/evp/build.info
@@ -19,7 +19,7 @@ SOURCE[../../libcrypto]=$COMMON\
         pkey_mac.c \
         legacy_sha.c
 
-IF[{- !$disabled{deprecated} || $config{api} < 30000 -}]
+IF[{- !$disabled{'deprecated-3.0'} -}]
   SOURCE[../../libcrypto]=p_enc.c p_dec.c
 ENDIF
 

--- a/crypto/md2/build.info
+++ b/crypto/md2/build.info
@@ -4,7 +4,6 @@ SOURCE[../../libcrypto]=md2_dgst.c md2_one.c
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # MD2 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{"deprecated"}
-      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=md2_dgst.c md2_one.c
 ENDIF

--- a/crypto/md4/build.info
+++ b/crypto/md4/build.info
@@ -4,7 +4,6 @@ SOURCE[../../libcrypto]=md4_dgst.c md4_one.c
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # MD4 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{"deprecated"}
-      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=md4_dgst.c md4_one.c
 ENDIF

--- a/crypto/mdc2/build.info
+++ b/crypto/mdc2/build.info
@@ -4,7 +4,6 @@ SOURCE[../../libcrypto]=mdc2dgst.c mdc2_one.c
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # MDC2 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{"deprecated"}
-      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=mdc2dgst.c mdc2_one.c
 ENDIF

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -21,8 +21,7 @@ DEFINE[../../libcrypto]=$RMD160DEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # RIPEMD160 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{"deprecated"}
-      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=rmd_dgst.c rmd_one.c $RMD160ASM
   DEFINE[../../providers/liblegacy.a]=$RMD160DEF
 ENDIF

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -26,8 +26,7 @@ DEFINE[../../libcrypto]=$WPDEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # WHIRLPOOL functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{"deprecated"}
-      && (defined $config{"api"} && $config{"api"} >= 30000) -}]
+IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=wp_dgst.c $WPASM
   DEFINE[../../providers/liblegacy.a]=$WPDEF
 ENDIF

--- a/test/build.info
+++ b/test/build.info
@@ -171,8 +171,7 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[evp_pkey_provided_test]=../include ../apps/include
   DEPEND[evp_pkey_provided_test]=../libcrypto libtestutil.a
 
-  IF[{- !$disabled{"deprecated"}
-        || (defined $config{"api"} && $config{"api"} < 30000) -}]
+  IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=igetest bftest casttest
 
     SOURCE[igetest]=igetest.c

--- a/test/recipes/05-test_bf.t
+++ b/test/recipes/05-test_bf.t
@@ -16,7 +16,6 @@ use OpenSSL::Test::Utils;
 setup("test_bf");
 
 plan skip_all => "Low-level Blowfish APIs are disabled in this build"
-    if disabled("deprecated")
-       && (!defined config("api") || config("api") >= 30000);
+    if disabled('deprecated-3.0');
 
 simple_test("test_bf", "bftest", "bf");

--- a/test/recipes/05-test_cast.t
+++ b/test/recipes/05-test_cast.t
@@ -17,7 +17,6 @@ use OpenSSL::Test::Utils;
 setup("test_cast");
 
 plan skip_all => "Low-level CAST APIs are disabled in this build"
-    if disabled("deprecated")
-       && (!defined config("api") || config("api") >= 30000);
+    if disabled('deprecated-3.0');
 
 simple_test("test_cast", "casttest", "cast");

--- a/test/recipes/20-test_passwd.t
+++ b/test/recipes/20-test_passwd.t
@@ -76,11 +76,12 @@ my @sha_tests =
        expected => '$6$rounds=1000$roundstoolow$kUMsbe306n21p9R.FRkW3IGn.S9NPN0x50YhH1xhLsPuWGsUSklZt58jaTfF4ZEQpyUNGc0dqbpBYYBaHHrsX.' }
     );
 
-plan tests => (disabled("des") || disabled("deprecated") ? 9 : 11) + scalar @sha_tests;
+plan tests => (disabled("des") || disabled('deprecated-3.0') ? 9 : 11) + scalar @sha_tests;
 
 
 ok(compare1stline_re([qw{openssl passwd password}], '^.{13}\R$'),
-   'crypt password with random salt') if !disabled("des") && !disabled("deprecated");
+   'crypt password with random salt')
+    if !disabled("des") && !disabled('deprecated-3.0');
 ok(compare1stline_re([qw{openssl passwd -1 password}], '^\$1\$.{8}\$.{22}\R$'),
    'BSD style MD5 password with random salt');
 ok(compare1stline_re([qw{openssl passwd -apr1 password}], '^\$apr1\$.{8}\$.{22}\R$'),
@@ -91,7 +92,8 @@ ok(compare1stline_re([qw{openssl passwd -6 password}], '^\$6\$.{16}\$.{86}\R$'),
    'Apache SHA512 password with random salt');
 
 ok(compare1stline([qw{openssl passwd -salt xx password}], 'xxj31ZMTZzkVA'),
-   'crypt password with salt xx') if !disabled("des") && !disabled("deprecated");
+   'crypt password with salt xx')
+    if !disabled("des") && !disabled('deprecated-3.0');
 ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -1 password}], '$1$xxxxxxxx$UYCIxa628.9qXjpQCjM4a.'),
    'BSD style MD5 password with salt xxxxxxxx');
 ok(compare1stline([qw{openssl passwd -salt xxxxxxxx -apr1 password}], '$apr1$xxxxxxxx$dxHfLAsjHkDRmG83UXe8K0'),

--- a/test/recipes/90-test_ige.t
+++ b/test/recipes/90-test_ige.t
@@ -17,7 +17,6 @@ use OpenSSL::Test::Utils;
 setup("test_ige");
 
 plan skip_all => "AES_ige support is disabled in this build"
-    if disabled("deprecated")
-       && (!defined config("api") || config("api") >= 30000);
+    if disabled('deprecated-3.0');
 
 simple_test("test_ige", "igetest");


### PR DESCRIPTION
In C, we have macros like OPENSSL_NO_DEPRECATED_3_0 to check if some
section of code should be disabled to simulate a removal of things
deprecated in the version.

In perl, we had to check $disabled{deprecated} and compare
$config{api} with the proper version code, which is doable but tedious
and error prone.

This change adds $disabled{'deprecated-x.y'} (x.y being a version
number) which directly corresponds to OPENSSL_NO_DEPRECATED_x_y, for
use in build.info conditions, test recipes and other perl stuff.