### PR TITLE
Fix no-engine

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5848,12 +5848,14 @@ const EVP_CIPHER *ssl_evp_cipher_fetch(OPENSSL_CTX *libctx,
                                        int nid,
                                        const char *properties)
 {
+#ifndef OPENSSL_NO_ENGINE
     /*
      * If there is an Engine available for this cipher we use the "implicit"
      * form to ensure we use that engine later.
      */
     if (ENGINE_get_cipher_engine(nid) != NULL)
         return EVP_get_cipherbynid(nid);
+#endif
 
     /* Otherwise we do an explicit fetch */
     return EVP_CIPHER_fetch(libctx, OBJ_nid2sn(nid), properties);
@@ -5891,12 +5893,14 @@ const EVP_MD *ssl_evp_md_fetch(OPENSSL_CTX *libctx,
                                int nid,
                                const char *properties)
 {
+#ifndef OPENSSL_NO_ENGINE
     /*
      * If there is an Engine available for this digest we use the "implicit"
      * form to ensure we use that engine later.
      */
     if (ENGINE_get_digest_engine(nid) != NULL)
         return EVP_get_digestbynid(nid);
+#endif
 
     /* Otherwise we do an explicit fetch */
     return EVP_MD_fetch(libctx, OBJ_nid2sn(nid), properties);


### PR DESCRIPTION
We don't need to check if an engine has a cipher/digest in a no-engine
build.