### PR TITLE
man: openssl-ocsp: separate client and server options

### DIFF
--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -7,6 +7,8 @@ openssl-ocsp - Online Certificate Status Protocol utility
 
 =head1 SYNOPSIS
 
+=head2 OCSP Client
+
 B<openssl> B<ocsp>
 [B<-help>]
 [B<-out> I<file>]
@@ -16,16 +18,16 @@ B<openssl> B<ocsp>
 [B<-signer> I<file>]
 [B<-signkey> I<file>]
 [B<-sign_other> I<file>]
-[B<-no_certs>]
+[B<-nonce>]
+[B<-no_nonce>]
 [B<-req_text>]
 [B<-resp_text>]
 [B<-text>]
+[B<-no_certs>]
 [B<-reqout> I<file>]
 [B<-respout> I<file>]
 [B<-reqin> I<file>]
 [B<-respin> I<file>]
-[B<-nonce>]
-[B<-no_nonce>]
 [B<-url> I<URL>]
 [B<-host> I<host>:I<port>]
 [B<-multi> I<process-count>]
@@ -46,6 +48,10 @@ B<openssl> B<ocsp>
 [B<-no_explicit>]
 [B<-port> I<num>]
 [B<-ignore_err>]
+
+=head2 OCSP Server
+
+B<openssl> B<ocsp>
 [B<-index> I<file>]
 [B<-CA> I<file>]
 [B<-rsigner> I<file>]
@@ -76,10 +82,12 @@ This command performs many common OCSP tasks. It can be used
 to print out requests and responses, create requests and send queries
 to an OCSP responder and behave like a mini OCSP server itself.
 
-=head1 OPTIONS
-
 This command operates as either a client or a server.
-The options are described below, divided into those two modes.
+This first entry in the L</SYNOPSIS> section lists the client options,
+the second entry the server options. The options are described in detail
+below, divided into client and server options.
+
+=head1 OPTIONS
 
 =head2 OCSP Client Options
 
@@ -170,17 +178,6 @@ On POSIX systems, when running as an OCSP responder, this option also limits
 the time that the responder is willing to wait for the client request.
 This time is measured from the time the responder accepts the connection until
 the complete request is received.
-
-=item B<-multi> I<process-count>
-
-Run the specified number of OCSP responder child processes, with the parent
-process respawning child processes as needed.
-Child processes will detect changes in the CA index file and automatically
-reload it.
-When running as a responder B<-timeout> option is recommended to limit the time
-each child is willing to wait for the client's OCSP response.
-This option is available on POSIX systems (that support the fork() and other
-required unix system-calls).
 
 =item B<-verify_other> I<file>
 
@@ -303,19 +300,6 @@ file given with B<-index>.
 
 The certificate to sign OCSP responses with.
 
-=item B<-rother> I<file>
-
-Additional certificates to include in the OCSP response.
-
-=item B<-resp_no_certs>
-
-Don't include any certificates in the OCSP response.
-
-=item B<-resp_key_id>
-
-Identify the signer certificate using the key ID, default is to use the
-subject name.
-
 =item B<-rkey> I<file>
 
 The private key to sign OCSP responses with: if not present the file
@@ -325,6 +309,10 @@ specified in the B<-rsigner> option is used.
 
 The private key password source. For more information about the format of I<arg>
 see L<openssl(1)/Pass Phrase Options>.
+
+=item B<-rother> I<file>
+
+Additional certificates to include in the OCSP response.
 
 =item B<-rsigopt> I<nm>:I<v>
 
@@ -340,6 +328,15 @@ The digest to use when signing the response.
 Corrupt the response signature before writing it; this can be useful
 for testing.
 
+=item B<-resp_no_certs>
+
+Don't include any certificates in the OCSP response.
+
+=item B<-resp_key_id>
+
+Identify the signer certificate using the key ID, default is to use the
+subject name.
+
 =item B<-port> I<portnum>
 
 Port to listen for OCSP requests on. The port may also be specified
@@ -354,6 +351,18 @@ running instead of terminating upon receiving a malformed request.
 =item B<-nrequest> I<number>
 
 The OCSP server will exit after receiving I<number> requests, default unlimited.
+
+=item B<-multi> I<process-count>
+
+Run the specified number of OCSP responder child processes, with the parent
+process respawning child processes as needed.
+Child processes will detect changes in the CA index file and automatically
+reload it.
+When running as a responder B<-timeout> option is recommended to limit the time
+each child is willing to wait for the client's OCSP response.
+This option is available on POSIX systems (that support the fork() and other
+required unix system-calls).
+
 
 =item B<-nmin> I<minutes>, B<-ndays> I<days>
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -83,7 +83,7 @@ to print out requests and responses, create requests and send queries
 to an OCSP responder and behave like a mini OCSP server itself.
 
 This command operates as either a client or a server.
-This first entry in the L</SYNOPSIS> section lists the client options,
+The first entry in the L</SYNOPSIS> section lists the client options,
 the second entry the server options. The options are described in detail
 below, divided into client and server options.
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -82,12 +82,10 @@ This command performs many common OCSP tasks. It can be used
 to print out requests and responses, create requests and send queries
 to an OCSP responder and behave like a mini OCSP server itself.
 
-This command operates as either a client or a server.
-The first entry in the L</SYNOPSIS> section lists the client options,
-the second entry the server options. The options are described in detail
-below, divided into client and server options.
-
 =head1 OPTIONS
+
+This command operates as either a client or a server.
+The options are described below, divided into those two modes.
 
 =head2 OCSP Client Options
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -30,7 +30,6 @@ B<openssl> B<ocsp>
 [B<-respin> I<file>]
 [B<-url> I<URL>]
 [B<-host> I<host>:I<port>]
-[B<-multi> I<process-count>]
 [B<-header>]
 [B<-timeout> I<seconds>]
 [B<-path>]
@@ -66,6 +65,7 @@ B<openssl> B<ocsp>
 [B<-ndays> I<n>]
 [B<-resp_key_id>]
 [B<-nrequest> I<n>]
+[B<-multi> I<process-count>]
 [B<-rcid> I<digest>]
 [B<-I<digest>>]
 {- $OpenSSL::safe::opt_trust_synopsis -}


### PR DESCRIPTION

Instead of a lengthy description, I just show the result: 

The output of `man openssl-ocsp` on an 80 char terminal, New vs. Old:


### New

```
OPENSSL-OCSP(1)                     OpenSSL                    OPENSSL-OCSP(1)

NAME
       openssl-ocsp - Online Certificate Status Protocol utility

SYNOPSIS
   OCSP Client
       openssl ocsp [-help] [-out file] [-issuer file] [-cert file] [-serial
       n] [-signer file] [-signkey file] [-sign_other file] [-nonce]
       [-no_nonce] [-req_text] [-resp_text] [-text] [-no_certs] [-reqout file]
       [-respout file] [-reqin file] [-respin file] [-url URL] [-host
       host:port] [-multi process-count] [-header] [-timeout seconds] [-path]
       [-VAfile file] [-validity_period n] [-status_age n] [-noverify]
       [-verify_other file] [-trust_other] [-no_intern] [-no_signature_verify]
       [-no_cert_verify] [-no_chain] [-no_cert_checks] [-no_explicit] [-port
       num] [-ignore_err]

   OCSP Server
       openssl ocsp [-index file] [-CA file] [-rsigner file] [-rkey file]
       [-passin arg] [-rother file] [-rsigopt nm:v] [-rmd digest] [-badsig]
       [-resp_no_certs] [-nmin n] [-ndays n] [-resp_key_id] [-nrequest n]
       [-rcid digest] [-digest] [-CAfile file] [-no-CAfile] [-CApath dir]
       [-no-CApath] [-CAstore uri] [-no-CAstore] [-allow_proxy_certs] [-attime
       timestamp] [-no_check_time] [-check_ss_sig] [-crl_check]
       [-crl_check_all] [-explicit_policy] [-extended_crl] [-ignore_critical]
       [-inhibit_any] [-inhibit_map] [-partial_chain] [-policy arg]
       [-policy_check] [-policy_print] [-purpose purpose] [-suiteB_128]
       [-suiteB_128_only] [-suiteB_192] [-trusted_first] [-no_alt_chains]
       [-use_deltas] [-auth_level num] [-verify_depth num] [-verify_email
       email] [-verify_hostname hostname] [-verify_ip ip] [-verify_name name]
       [-x509_strict] [-issuer_checks]

DESCRIPTION
       The Online Certificate Status Protocol (OCSP) enables applications to
       determine the (revocation) state of an identified certificate (RFC
       2560).

       This command performs many common OCSP tasks. It can be used to print
       out requests and responses, create requests and send queries to an OCSP
       responder and behave like a mini OCSP server itself.

       This command operates as either a client or a server.  This first entry
       in the "SYNOPSIS" section lists the client options, the second entry
       the server options. The options are described in detail below, divided
       into client and server options.


       ...
```



### Old

```
OCSP(1)                            OpenSSL                            OCSP(1)

NAME
       openssl-ocsp, ocsp - Online Certificate Status Protocol utility

SYNOPSIS
       openssl ocsp [-help] [-out file] [-issuer file] [-cert file] [-serial
       n] [-signer file] [-signkey file] [-sign_other file] [-no_certs]
       [-req_text] [-resp_text] [-text] [-reqout file] [-respout file]
       [-reqin file] [-respin file] [-nonce] [-no_nonce] [-url URL] [-host
       host:port] [-multi process-count] [-header] [-path] [-CApath dir]
       [-CAfile file] [-no-CAfile] [-no-CApath] [-attime timestamp]
       [-check_ss_sig] [-crl_check] [-crl_check_all] [-explicit_policy]
       [-extended_crl] [-ignore_critical] [-inhibit_any] [-inhibit_map]
       [-no_check_time] [-partial_chain] [-policy arg] [-policy_check]
       [-policy_print] [-purpose purpose] [-suiteB_128] [-suiteB_128_only]
       [-suiteB_192] [-trusted_first] [-no_alt_chains] [-use_deltas]
       [-auth_level num] [-verify_depth num] [-verify_email email]
       [-verify_hostname hostname] [-verify_ip ip] [-verify_name name]
       [-x509_strict] [-VAfile file] [-validity_period n] [-status_age n]
       [-noverify] [-verify_other file] [-trust_other] [-no_intern]
       [-no_signature_verify] [-no_cert_verify] [-no_chain] [-no_cert_checks]
       [-no_explicit] [-port num] [-ignore_err] [-index file] [-CA file]
       [-rsigner file] [-rkey file] [-rother file] [-rsigopt nm:v]
       [-resp_no_certs] [-nmin n] [-ndays n] [-resp_key_id] [-nrequest n]
       [-digest]

DESCRIPTION
       The Online Certificate Status Protocol (OCSP) enables applications to
       determine the (revocation) state of an identified certificate (RFC
       2560).

       The ocsp command performs many common OCSP tasks. It can be used to
       print out requests and responses, create requests and send queries to
       an OCSP responder and behave like a mini OCSP server itself.
```