### PR TITLE
PROV: Ensure the AlgorithmIdentifier registers in DSA signature impl

### DIFF
--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -157,6 +157,8 @@ static int dsa_setup_md(PROV_DSA_CTX *ctx,
 
         ctx->md = md;
         OPENSSL_strlcpy(ctx->mdname, mdname, sizeof(ctx->mdname));
+        memcpy(ctx->aid, algorithmidentifier, algorithmidentifier_len);
+        ctx->aid_len = algorithmidentifier_len;
     }
     return 1;
 }


### PR DESCRIPTION
When setting up the hash function for DSA signature, the encoded
AlgorithmIdentifier for the DSA+hash combination is queried, but not
stored, which leads to problems when signing ASN.1 items in libcrypto.
