### PR TITLE
LibSSL was ignoring the OPENSSL_NO_ENGINE macro

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5848,7 +5848,7 @@ const EVP_CIPHER *ssl_evp_cipher_fetch(OPENSSL_CTX *libctx,
                                        int nid,
                                        const char *properties)
 {
-#if !defined(OPENSSL_NO_ENGINE)
+#ifndef OPENSSL_NO_ENGINE
     /*
      * If there is an Engine available for this cipher we use the "implicit"
      * form to ensure we use that engine later.
@@ -5892,7 +5892,7 @@ const EVP_MD *ssl_evp_md_fetch(OPENSSL_CTX *libctx,
                                int nid,
                                const char *properties)
 {
-#if !defined(OPENSSL_NO_ENGINE)
+#ifndef OPENSSL_NO_ENGINE
     /*
      * If there is an Engine available for this digest we use the "implicit"
      * form to ensure we use that engine later.

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5848,13 +5848,14 @@ const EVP_CIPHER *ssl_evp_cipher_fetch(OPENSSL_CTX *libctx,
                                        int nid,
                                        const char *properties)
 {
+#if !defined(OPENSSL_NO_ENGINE)
     /*
      * If there is an Engine available for this cipher we use the "implicit"
      * form to ensure we use that engine later.
      */
     if (ENGINE_get_cipher_engine(nid) != NULL)
         return EVP_get_cipherbynid(nid);
-
+#endif
     /* Otherwise we do an explicit fetch */
     return EVP_CIPHER_fetch(libctx, OBJ_nid2sn(nid), properties);
 }
@@ -5891,13 +5892,14 @@ const EVP_MD *ssl_evp_md_fetch(OPENSSL_CTX *libctx,
                                int nid,
                                const char *properties)
 {
+#if !defined(OPENSSL_NO_ENGINE)
     /*
      * If there is an Engine available for this digest we use the "implicit"
      * form to ensure we use that engine later.
      */
     if (ENGINE_get_digest_engine(nid) != NULL)
         return EVP_get_digestbynid(nid);
-
+#endif
     /* Otherwise we do an explicit fetch */
     return EVP_MD_fetch(libctx, OBJ_nid2sn(nid), properties);
 }


### PR DESCRIPTION
If OPENSSL_NO_ENGINE was defined via the "no_engine" config parameter
both the `ENGINE_get_cipher_engine()` and `ENGINE_get_digest_engine` were
not defined.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

