### PR TITLE
Refactor OSSL_PARAM_allocate_from_text() for better flexibility

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2699,7 +2699,7 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
         return NULL;
 
     for (params_n = 0; params_n < sz; params_n++) {
-        int text_flags = 0;
+        unsigned int tflags = 0;
         const OSSL_PARAM *tmpl;
 
         opt = sk_OPENSSL_STRING_value(opts, (int)params_n);
@@ -2711,9 +2711,9 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
         /* Skip over the separator so that vmtp points to the value */
         vtmp++;
         if ((tmpl = OSSL_PARAM_parse_locate_const(paramdefs, stmp,
-                                                  &text_flags)) == NULL
+                                                  &tflags)) == NULL
             || !OSSL_PARAM_allocate_from_text(&params[params_n], tmpl,
-                                              vtmp, strlen(vtmp), text_flags))
+                                              vtmp, strlen(vtmp), tflags))
             goto err;
         OPENSSL_free(stmp);
     }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2699,6 +2699,9 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
         return NULL;
 
     for (params_n = 0; params_n < sz; params_n++) {
+        int text_flags = 0;
+        const OSSL_PARAM *tmpl;
+
         opt = sk_OPENSSL_STRING_value(opts, (int)params_n);
         if ((stmp = OPENSSL_strdup(opt)) == NULL
             || (vtmp = strchr(stmp, ':')) == NULL)
@@ -2707,8 +2710,10 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
         *vtmp = 0;
         /* Skip over the separator so that vmtp points to the value */
         vtmp++;
-        if (!OSSL_PARAM_allocate_from_text(&params[params_n], paramdefs,
-                                           stmp, vtmp, strlen(vtmp)))
+        if ((tmpl = OSSL_PARAM_parse_locate_const(paramdefs, stmp,
+                                                  &text_flags)) == NULL
+            || !OSSL_PARAM_allocate_from_text(&params[params_n], tmpl,
+                                              vtmp, strlen(vtmp), text_flags))
             goto err;
         OPENSSL_free(stmp);
     }

--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -212,9 +212,9 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     EVP_KDF_CTX *kctx = pkctx->kctx;
     const EVP_KDF *kdf = EVP_KDF_CTX_kdf(kctx);
     BUF_MEM **collector = NULL;
-    const OSSL_PARAM *defs = EVP_KDF_settable_ctx_params(kdf);
+    const OSSL_PARAM *tmpl = NULL, *defs = EVP_KDF_settable_ctx_params(kdf);
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
-    int ok = 0;
+    int ok = 0, text_flags = 0;
 
     /* Deal with ctrl name aliasing */
     if (strcmp(type, "md") == 0)
@@ -223,8 +223,9 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     if (strcmp(type, "N") == 0)
         type = OSSL_KDF_PARAM_SCRYPT_N;
 
-    if (!OSSL_PARAM_allocate_from_text(&params[0], defs, type,
-                                       value, strlen(value)))
+    if ((tmpl = OSSL_PARAM_parse_locate_const(defs, type, &text_flags)) == NULL
+        || !OSSL_PARAM_allocate_from_text(&params[0], tmpl,
+                                          value, strlen(value), text_flags))
         return 0;
 
     /*

--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -214,7 +214,8 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     BUF_MEM **collector = NULL;
     const OSSL_PARAM *tmpl = NULL, *defs = EVP_KDF_settable_ctx_params(kdf);
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
-    int ok = 0, text_flags = 0;
+    int ok = 0;
+    unsigned int tflags = 0;
 
     /* Deal with ctrl name aliasing */
     if (strcmp(type, "md") == 0)
@@ -223,9 +224,9 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     if (strcmp(type, "N") == 0)
         type = OSSL_KDF_PARAM_SCRYPT_N;
 
-    if ((tmpl = OSSL_PARAM_parse_locate_const(defs, type, &text_flags)) == NULL
+    if ((tmpl = OSSL_PARAM_parse_locate_const(defs, type, &tflags)) == NULL
         || !OSSL_PARAM_allocate_from_text(&params[0], tmpl,
-                                          value, strlen(value), text_flags))
+                                          value, strlen(value), tflags))
         return 0;
 
     /*

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -434,8 +434,9 @@ static int pkey_mac_ctrl_str(EVP_PKEY_CTX *ctx,
 {
     MAC_PKEY_CTX *hctx = EVP_PKEY_CTX_get_data(ctx);
     const EVP_MAC *mac = EVP_MAC_CTX_mac(hctx->ctx);
+    const OSSL_PARAM *tmpl = NULL;
     OSSL_PARAM params[2];
-    int ok = 0;
+    int ok = 0, tflags = 0;
 
     /*
      * Translation of some control names that are equivalent to a single
@@ -451,9 +452,10 @@ static int pkey_mac_ctrl_str(EVP_PKEY_CTX *ctx,
     else if (strcmp(type, "digestsize") == 0)
         type = OSSL_MAC_PARAM_SIZE;
 
-    if (!OSSL_PARAM_allocate_from_text(&params[0],
-                                       EVP_MAC_settable_ctx_params(mac),
-                                       type, value, strlen(value) + 1))
+    if ((tmpl = OSSL_PARAM_parse_locate_const(EVP_MAC_settable_ctx_params(mac),
+                                              type, &tflags)) == NULL
+        || !OSSL_PARAM_allocate_from_text(&params[0], tmpl,
+                                          value, strlen(value) + 1, tflags))
         return 0;
     params[1] = OSSL_PARAM_construct_end();
     ok = EVP_MAC_CTX_set_params(hctx->ctx, params);

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -436,7 +436,8 @@ static int pkey_mac_ctrl_str(EVP_PKEY_CTX *ctx,
     const EVP_MAC *mac = EVP_MAC_CTX_mac(hctx->ctx);
     const OSSL_PARAM *tmpl = NULL;
     OSSL_PARAM params[2];
-    int ok = 0, tflags = 0;
+    int ok = 0;
+    unsigned int tflags = 0;
 
     /*
      * Translation of some control names that are equivalent to a single

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -931,7 +931,8 @@ static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
          */
         const OSSL_PARAM *tmpl, *settable = EVP_PKEY_CTX_settable_params(ctx);
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
-        int rv = 0, tflags = 0;
+        int rv = 0;
+        unsigned int tflags = 0;
 
         if ((tmpl = OSSL_PARAM_parse_locate_const(settable, name, &tflags))
             == NULL) {

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -23,7 +23,8 @@
  */
 
 static int prepare_from_text(const OSSL_PARAM *template,
-                             const char *value, size_t value_n, int flags,
+                             const char *value, size_t value_n,
+                             unsigned int flags,
                              /* Output parameters */
                              size_t *buf_n, BIGNUM **tmpbn)
 {
@@ -87,7 +88,8 @@ static int prepare_from_text(const OSSL_PARAM *template,
 }
 
 static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
-                               const char *value, size_t value_n, int flags,
+                               const char *value, size_t value_n,
+                               unsigned int flags,
                                void *buf, size_t buf_n, BIGNUM *tmpbn)
 {
     if (buf == NULL)
@@ -151,7 +153,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
 
 const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
                                                 const char *key,
-                                                int *flags)
+                                                unsigned int *flags)
 {
     if (params == NULL || key == NULL || flags == NULL)
         return NULL;
@@ -166,7 +168,8 @@ const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
 }
 
 int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
-                                  const char *value, size_t value_n, int flags)
+                                  const char *value, size_t value_n,
+                                  unsigned int flags)
 {
     void *buf = NULL;
     size_t buf_n = 0;

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -12,6 +12,8 @@
 #include <openssl/err.h>
 #include <openssl/params.h>
 
+#define FLAG_HEX               1
+
 /*
  * When processing text to params, we're trying to be smart with numbers.
  * Instead of handling each specific separate integer type, we use a bignum
@@ -20,31 +22,15 @@
  * (if the size can be arbitrary, then we give whatever we have)
  */
 
-static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
-                             const char *value, size_t value_n,
+static int prepare_from_text(const OSSL_PARAM *template,
+                             const char *value, size_t value_n, int flags,
                              /* Output parameters */
-                             const OSSL_PARAM **paramdef, int *ishex,
                              size_t *buf_n, BIGNUM **tmpbn)
 {
-    const OSSL_PARAM *p;
-
-    /*
-     * ishex is used to translate legacy style string controls in hex format
-     * to octet string parameters.
-     */
-    *ishex = strncmp(key, "hex", 3) == 0;
-
-    if (*ishex)
-        key += 3;
-
-    p = *paramdef = OSSL_PARAM_locate_const(paramdefs, key);
-    if (p == NULL)
-        return 0;
-
-    switch (p->data_type) {
+    switch (template->data_type) {
     case OSSL_PARAM_INTEGER:
     case OSSL_PARAM_UNSIGNED_INTEGER:
-        if (*ishex)
+        if ((flags & FLAG_HEX) != 0)
             BN_hex2bn(tmpbn, value);
         else
             BN_dec2bn(tmpbn, value);
@@ -60,7 +46,7 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
          * it by subtracting 1 here and inverting the bytes in
          * construct_from_text() below.
          */
-        if (p->data_type == OSSL_PARAM_INTEGER && BN_is_negative(*tmpbn)
+        if (template->data_type == OSSL_PARAM_INTEGER && BN_is_negative(*tmpbn)
             && !BN_sub_word(*tmpbn, 1)) {
             return 0;
         }
@@ -71,25 +57,25 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
          * TODO(v3.0) is this the right way to do this?  This code expects
          * a zero data size to simply mean "arbitrary size".
          */
-        if (p->data_size > 0) {
-            if (*buf_n >= p->data_size) {
+        if (template->data_size > 0) {
+            if (*buf_n >= template->data_size) {
                 CRYPTOerr(0, CRYPTO_R_TOO_SMALL_BUFFER);
                 /* Since this is a different error, we don't break */
                 return 0;
             }
             /* Change actual size to become the desired size. */
-            *buf_n = p->data_size;
+            *buf_n = template->data_size;
         }
         break;
     case OSSL_PARAM_UTF8_STRING:
-        if (*ishex) {
+        if ((flags & FLAG_HEX) != 0) {
             CRYPTOerr(0, ERR_R_PASSED_INVALID_ARGUMENT);
             return 0;
         }
         *buf_n = strlen(value) + 1;
         break;
     case OSSL_PARAM_OCTET_STRING:
-        if (*ishex) {
+        if ((flags & FLAG_HEX) != 0) {
             *buf_n = strlen(value) >> 1;
         } else {
             *buf_n = value_n;
@@ -100,15 +86,15 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
     return 1;
 }
 
-static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
-                               const char *value, size_t value_n, int ishex,
+static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
+                               const char *value, size_t value_n, int flags,
                                void *buf, size_t buf_n, BIGNUM *tmpbn)
 {
     if (buf == NULL)
         return 0;
 
     if (buf_n > 0) {
-        switch (paramdef->data_type) {
+        switch (template->data_type) {
         case OSSL_PARAM_INTEGER:
         case OSSL_PARAM_UNSIGNED_INTEGER:
             /*
@@ -127,7 +113,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
              * Because we did the first part on the BIGNUM itself, we can just
              * invert all the bytes here and be done with it.
              */
-            if (paramdef->data_type == OSSL_PARAM_INTEGER
+            if (template->data_type == OSSL_PARAM_INTEGER
                 && BN_is_negative(tmpbn)) {
                 unsigned char *cp;
                 size_t i = buf_n;
@@ -140,7 +126,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
             strncpy(buf, value, buf_n);
             break;
         case OSSL_PARAM_OCTET_STRING:
-            if (ishex) {
+            if ((flags & FLAG_HEX) != 0) {
                 size_t l = 0;
 
                 if (!OPENSSL_hexstr2buf_ex(buf, buf_n, &l, value))
@@ -152,7 +138,8 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
         }
     }
 
-    *to = *paramdef;
+    to->key = template->key;
+    to->data_type = template->data_type;
     to->data = buf;
     to->data_size = buf_n;
     to->return_size = 0;
@@ -160,23 +147,37 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
     return 1;
 }
 
-int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
-                                  const OSSL_PARAM *paramdefs,
-                                  const char *key, const char *value,
-                                  size_t value_n)
+#define FLAG_ISHEX             1
+
+const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
+                                                const char *key,
+                                                int *flags)
 {
-    const OSSL_PARAM *paramdef = NULL;
-    int ishex = 0;
+    if (params == NULL || key == NULL || flags == NULL)
+        return NULL;
+
+    *flags = 0;
+    if (strncmp(key, "hex", 3) == 0) {
+        *flags |= FLAG_ISHEX;
+        key += 3;
+    }
+
+    return OSSL_PARAM_locate_const(params, key);
+}
+
+int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
+                                  const char *value, size_t value_n, int flags)
+{
     void *buf = NULL;
     size_t buf_n = 0;
     BIGNUM *tmpbn = NULL;
     int ok = 0;
 
-    if (to == NULL || paramdefs == NULL)
+    if (to == NULL || template == NULL)
         return 0;
 
-    if (!prepare_from_text(paramdefs, key, value, value_n,
-                           &paramdef, &ishex, &buf_n, &tmpbn))
+    if (!prepare_from_text(template, value, value_n, flags,
+                           &buf_n, &tmpbn))
         return 0;
 
     if ((buf = OPENSSL_zalloc(buf_n > 0 ? buf_n : 1)) == NULL) {
@@ -184,7 +185,7 @@ int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
         return 0;
     }
 
-    ok = construct_from_text(to, paramdef, value, value_n, ishex,
+    ok = construct_from_text(to, template, value, value_n, flags,
                              buf, buf_n, tmpbn);
     BN_free(tmpbn);
     if (!ok)

--- a/doc/man3/OSSL_PARAM_allocate_from_text.pod
+++ b/doc/man3/OSSL_PARAM_allocate_from_text.pod
@@ -11,11 +11,11 @@ OSSL_PARAM_parse_locate_const, OSSL_PARAM_allocate_from_text
 
  const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
                                                  const char *key,
-                                                 int *flags);
+                                                 unsigned int *flags);
  int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
                                    const OSSL_PARAM *template,
                                    const char *value, size_t value_n,
-                                   int flags);
+                                   unsigned int flags);
 
 =head1 DESCRIPTION
 
@@ -138,7 +138,7 @@ Can be written like this instead:
        params_n++) {
       const OSSL_PARAM *tmpl;
       char *stmp, *vtmp = NULL;
-      int tflags = 0;
+      unsigned int tflags = 0;
 
       opt = sk_OPENSSL_STRING_value(opts, (int)params_n);
       if ((stmp = OPENSSL_strdup(opt)) == NULL

--- a/doc/man3/OSSL_PARAM_allocate_from_text.pod
+++ b/doc/man3/OSSL_PARAM_allocate_from_text.pod
@@ -13,7 +13,7 @@ OSSL_PARAM_parse_locate_const, OSSL_PARAM_allocate_from_text
                                                  const char *key,
                                                  unsigned int *flags);
  int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
-                                   const OSSL_PARAM *template,
+                                   const OSSL_PARAM *tmpl,
                                    const char *value, size_t value_n,
                                    unsigned int flags);
 
@@ -36,7 +36,7 @@ for OSSL_PARAM_construct_from_text() and OSSL_PARAM_allocate_from_text().
 
 OSSL_PARAM_allocate_from_text() builds the B<OSSL_PARAM> item passed as
 I<to> by parsing I<value_n> bytes of I<value> according to the data type
-from I<template> and the given I<flags>.
+from I<tmpl> and the given I<flags>.
 The I<flags> should be the value given back by OSSL_PARAM_parse_locate_const(),
 or zero.
 The data for I<to> gets allocated with L<OPENSSL_zalloc(3)> and must be
@@ -60,7 +60,7 @@ example, if the I<key> is "hexsalt", the key that will be looked up in the
 B<OSSL_PARAM> array is "salt".
 
 This affects how OSSL_PARAM_construct_from_text() and
-OSSL_PARAM_allocate_from_text() parse the I<value> for I<template> types
+OSSL_PARAM_allocate_from_text() parse the I<value> for I<tmpl> types
 B<OSSL_PARAM_INTEGER>, B<OSSL_PARAM_UNSIGNED_INTEGER>, and
 B<OSSL_PARAM_OCTET_STRING>.
 

--- a/doc/man3/OSSL_PARAM_allocate_from_text.pod
+++ b/doc/man3/OSSL_PARAM_allocate_from_text.pod
@@ -2,17 +2,20 @@
 
 =head1 NAME
 
-OSSL_PARAM_allocate_from_text
+OSSL_PARAM_parse_locate_const, OSSL_PARAM_allocate_from_text
 - OSSL_PARAM construction utilities
 
 =head1 SYNOPSIS
 
  #include <openssl/params.h>
 
+ const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
+                                                 const char *key,
+                                                 int *flags);
  int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
-                                   const OSSL_PARAM *paramdefs,
-                                   const char *key, const char *value,
-                                   size_t value_n);
+                                   const OSSL_PARAM *template,
+                                   const char *value, size_t value_n,
+                                   int flags);
 
 =head1 DESCRIPTION
 
@@ -25,27 +28,43 @@ OpenSSL 3.0 introduces a new mechanism to do the same thing with an
 array of parameters that contain name, value, value type and value
 size (see L<OSSL_PARAM(3)> for more information).
 
-OSSL_PARAM_allocate_from_text() takes a control I<key>, I<value> and
-value size I<value_n>, and given a parameter descriptor array
-I<paramdefs>, it converts the value to something suitable for
-L<OSSL_PARAM(3)> and stores that in the buffer I<buf>, and modifies
-the parameter I<to> to match.
-I<buf_n>, if not NULL, will be assigned the number of bytes used in
-I<buf>.
-If I<buf> is NULL, only I<buf_n> will be modified, everything else is
-left untouched, allowing a caller to find out how large the buffer
-should be.
-I<buf> needs to be correctly aligned for the type of the B<OSSL_PARAM>
-I<key>.
-The caller must remember to free the data of I<to> when it's not
-useful any more.
+OSSL_PARAM_parse_locate_const() works like L<OSSL_PARAM_locate_const(3)>,
+but will additionally parse the I<key> string and set flags in I<*flags>
+according to what it found.  The flags must be initialized with zero by
+the caller.  The returned B<OSSL_PARAM> pointer can be used as a template
+for OSSL_PARAM_construct_from_text() and OSSL_PARAM_allocate_from_text().
 
-For parameters having the type B<OSSL_PARAM_INTEGER>,
-B<OSSL_PARAM_UNSIGNED_INTEGER>, or B<OSSL_PARAM_OCTET_STRING>, both
-functions will interpret the I<value> differently if the key starts
-with "hex".
-In that case, the value is decoded first, and the result will be used
-as parameter value.
+OSSL_PARAM_allocate_from_text() builds the B<OSSL_PARAM> item passed as
+I<to> by parsing I<value_n> bytes of I<value> according to the data type
+from I<template> and the given I<flags>.
+The I<flags> should be the value given back by OSSL_PARAM_parse_locate_const(),
+or zero.
+The data for I<to> gets allocated with L<OPENSSL_zalloc(3)> and must be
+freed by the caller when it's not useful any more, using L<OPENSSL_free(3)>.
+
+=head2 Details on key parsing
+
+OSSL_PARAM_parse_locate_const() parses the I<key> for indicators that the
+value may come in a non-default form.  This affects the I<*flags> as well
+as what key is looked up in the descriptor B<OSSL_PARAM> array I<params>.
+
+The following is recognised:
+
+=over 4
+
+=item The key starts with "hex"
+
+This indicates that the I<value> is hex-encoded.  The rest of the I<key>
+string will be used to locate the corresponding B<OSSL_PARAM>, so for
+example, if the I<key> is "hexsalt", the key that will be looked up in the
+B<OSSL_PARAM> array is "salt".
+
+This affects how OSSL_PARAM_construct_from_text() and
+OSSL_PARAM_allocate_from_text() parse the I<value> for I<template> types
+B<OSSL_PARAM_INTEGER>, B<OSSL_PARAM_UNSIGNED_INTEGER>, and
+B<OSSL_PARAM_OCTET_STRING>.
+
+=back
 
 =head1 RETURN VALUES
 
@@ -53,8 +72,8 @@ OSSL_PARAM_allocate_from_text() returns 1 on success, and 0 on error.
 
 =head1 NOTES
 
-The parameter descriptor array comes from functions dedicated to
-return them.
+The parameter descriptor array given to OSSL_PARAM_parse_locate_const()
+comes from functions dedicated to return them.
 The following B<OSSL_PARAM> attributes are used:
 
 =over 4
@@ -117,7 +136,9 @@ Can be written like this instead:
 
   for (params_n = 0; params_n < (size_t)sk_OPENSSL_STRING_num(opts);
        params_n++) {
+      const OSSL_PARAM *tmpl;
       char *stmp, *vtmp = NULL;
+      int tflags = 0;
 
       opt = sk_OPENSSL_STRING_value(opts, (int)params_n);
       if ((stmp = OPENSSL_strdup(opt)) == NULL
@@ -125,9 +146,11 @@ Can be written like this instead:
           goto err;
 
       *vtmp++ = '\0';
-      if (!OSSL_PARAM_allocate_from_text(&params[params_n],
-                                         paramdefs, stmp,
-                                         vtmp, strlen(vtmp)))
+
+      tmpl = OSSL_PARAM_parse_locate_const(paramdefs, stmp, &tflags);
+      if (tmpl == NULL
+          || !OSSL_PARAM_allocate_from_text(&params[params_n],
+                                            vtmp, strlen(vtmp), tflags))
           goto err;
   }
   params[params_n] = OSSL_PARAM_construct_end();

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -92,7 +92,7 @@ OSSL_PARAM OSSL_PARAM_construct_end(void);
 const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
                                                 const char *key,
                                                 unsigned int *flags);
-int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
+int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to, const OSSL_PARAM *tmpl,
                                   const char *value, size_t value_n,
                                   unsigned int flags);
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -89,10 +89,10 @@ OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
                                           size_t bsize);
 OSSL_PARAM OSSL_PARAM_construct_end(void);
 
-int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
-                                  const OSSL_PARAM *paramdefs,
-                                  const char *key, const char *value,
-                                  size_t value_n);
+const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
+                                                const char *key, int *flags);
+int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
+                                  const char *value, size_t value_n, int flags);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val);

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -90,9 +90,11 @@ OSSL_PARAM OSSL_PARAM_construct_octet_ptr(const char *key, void **buf,
 OSSL_PARAM OSSL_PARAM_construct_end(void);
 
 const OSSL_PARAM *OSSL_PARAM_parse_locate_const(const OSSL_PARAM *params,
-                                                const char *key, int *flags);
+                                                const char *key,
+                                                unsigned int *flags);
 int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to, const OSSL_PARAM *template,
-                                  const char *value, size_t value_n, int flags);
+                                  const char *value, size_t value_n,
+                                  unsigned int flags);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val);

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -162,12 +162,17 @@ static int self_test_kdf(const ST_KAT_KDF *t, OSSL_ST_EVENT *event,
 
     settables = EVP_KDF_settable_ctx_params(kdf);
     for (i = 0; t->ctrls[i].name != NULL; ++i) {
+        const OSSL_PARAM *tmpl;
+        int tflags = 0;
+
         if (!ossl_assert(i < (numparams - 1)))
             goto end;
-        if (!OSSL_PARAM_allocate_from_text(&params[i], settables,
-                                           t->ctrls[i].name,
-                                           t->ctrls[i].value,
-                                           strlen(t->ctrls[i].value)))
+        if ((tmpl = OSSL_PARAM_parse_locate_const(settables, t->ctrls[i].name,
+                                                  &tflags)) == NULL
+            || !OSSL_PARAM_allocate_from_text(&params[i], tmpl,
+                                              t->ctrls[i].value,
+                                              strlen(t->ctrls[i].value),
+                                              tflags))
             goto end;
     }
     if (!EVP_KDF_CTX_set_params(ctx, params))

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -163,7 +163,7 @@ static int self_test_kdf(const ST_KAT_KDF *t, OSSL_ST_EVENT *event,
     settables = EVP_KDF_settable_ctx_params(kdf);
     for (i = 0; t->ctrls[i].name != NULL; ++i) {
         const OSSL_PARAM *tmpl;
-        int tflags = 0;
+        unsigned int tflags = 0;
 
         if (!ossl_assert(i < (numparams - 1)))
             goto end;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1298,7 +1298,7 @@ static int mac_test_run_mac(EVP_TEST *t)
         char *tmpkey, *tmpval;
         char *value = sk_OPENSSL_STRING_value(expected->controls, i);
         const OSSL_PARAM *tmpl = NULL;
-        int tflags = 0;
+        unsigned int tflags = 0;
 
         if (!TEST_ptr(tmpkey = OPENSSL_strdup(value))) {
             t->err = "MAC_PARAM_ERROR";
@@ -2122,7 +2122,7 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
                          const char *value)
 {
     KDF_DATA *kdata = t->data;
-    int tflags = 0;
+    unsigned int tflags = 0;
     char *p, *name;
     const OSSL_PARAM *defs = EVP_KDF_settable_ctx_params(EVP_KDF_CTX_kdf(kctx));
     const OSSL_PARAM *tmpl;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4945,3 +4945,4 @@ EVP_PKEY_CTX_set_ecdh_kdf_outlen        ?	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_CTX_get_ecdh_kdf_outlen        ?	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_CTX_set0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_CTX_get0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:EC
+OSSL_PARAM_parse_locate_const           ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
OSSL_PARAM_allocate_from_text() and OSSL_PARAM_construct_from_text()
were "do-it-all" kind of functions, which didn't allow much
flexibility in code that wants to adapt to situations such as the key
not being found in the descriptor OSSL_PARAM array.

We therefore split the functionality to make key lookup and value
processing two different functions, thus resulting in the following
functions:

- OSSL_PARAM_parse_locate_const(), which parses the key and sets flags
  accordingly, but otherwise works like OSSL_PARAM_locate_const().
- OSSL_PARAM_construct_from_text(), which doesn't look up the key any
  more, but rather only parses the given value, with direction from a
  template OSSL_PARAM item, which could come from a call of
  OSSL_PARAM_parse_locate_const().
- OSSL_PARAM_allocate_from_text(), which is modified exactly like
  OSSL_PARAM_construct_from_text().

With this split, callers can also ignore OSSL_PARAM_parse_locate_const()
completely, and work with an descriptor OSSL_PARAM item of their own
choosing.