### PR TITLE
OSSL_PARAM_allocate_from_text(): Allow detection of unsupported param keys

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2690,6 +2690,7 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
     size_t sz = (size_t)sk_OPENSSL_STRING_num(opts);
     size_t params_n;
     char *opt = "", *stmp, *vtmp = NULL;
+    int found = 1;
 
     if (opts == NULL)
         return NULL;
@@ -2708,7 +2709,7 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
         /* Skip over the separator so that vmtp points to the value */
         vtmp++;
         if (!OSSL_PARAM_allocate_from_text(&params[params_n], paramdefs,
-                                           stmp, vtmp, strlen(vtmp), NULL))
+                                           stmp, vtmp, strlen(vtmp), &found))
             goto err;
         OPENSSL_free(stmp);
     }
@@ -2716,7 +2717,8 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
     return params;
 err:
     OPENSSL_free(stmp);
-    BIO_printf(bio_err, "Parameter error '%s'\n", opt);
+    BIO_printf(bio_err, "Parameter %s '%s'\n", found ? "error" : "unknown",
+               opt);
     ERR_print_errors(bio_err);
     app_params_free(params);
     return NULL;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2708,7 +2708,7 @@ OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
         /* Skip over the separator so that vmtp points to the value */
         vtmp++;
         if (!OSSL_PARAM_allocate_from_text(&params[params_n], paramdefs,
-                                           stmp, vtmp, strlen(vtmp)))
+                                           stmp, vtmp, strlen(vtmp), NULL))
             goto err;
         OPENSSL_free(stmp);
     }

--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -224,7 +224,7 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
         type = OSSL_KDF_PARAM_SCRYPT_N;
 
     if (!OSSL_PARAM_allocate_from_text(&params[0], defs, type,
-                                       value, strlen(value)))
+                                       value, strlen(value), NULL))
         return 0;
 
     /*

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -453,7 +453,7 @@ static int pkey_mac_ctrl_str(EVP_PKEY_CTX *ctx,
 
     if (!OSSL_PARAM_allocate_from_text(&params[0],
                                        EVP_MAC_settable_ctx_params(mac),
-                                       type, value, strlen(value) + 1))
+                                       type, value, strlen(value) + 1, NULL))
         return 0;
     params[1] = OSSL_PARAM_construct_end();
     ok = EVP_MAC_CTX_set_params(hctx->ctx, params);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -831,10 +831,16 @@ static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
         const OSSL_PARAM *settable = EVP_PKEY_CTX_settable_params(ctx);
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
         int rv = 0;
+        int exists = 0;
 
         if (!OSSL_PARAM_allocate_from_text(&params[0], settable, name, value,
-                                           strlen(value), NULL))
+                                           strlen(value), &exists)) {
+            if (!exists) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
+                return -2;
+            }
             return 0;
+        }
         if (EVP_PKEY_CTX_set_params(ctx, params))
             rv = 1;
         OPENSSL_free(params[0].data);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -833,7 +833,7 @@ static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
         int rv = 0;
 
         if (!OSSL_PARAM_allocate_from_text(&params[0], settable, name, value,
-                                           strlen(value)))
+                                           strlen(value), NULL))
             return 0;
         if (EVP_PKEY_CTX_set_params(ctx, params))
             rv = 1;

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -24,7 +24,7 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
                              const char *value, size_t value_n,
                              /* Output parameters */
                              const OSSL_PARAM **paramdef, int *ishex,
-                             size_t *buf_n, BIGNUM **tmpbn)
+                             size_t *buf_n, BIGNUM **tmpbn, int *found)
 {
     const OSSL_PARAM *p;
 
@@ -38,6 +38,8 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
         key += 3;
 
     p = *paramdef = OSSL_PARAM_locate_const(paramdefs, key);
+    if (found != NULL)
+        *found = p != NULL;
     if (p == NULL)
         return 0;
 
@@ -163,7 +165,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
 int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
                                   const OSSL_PARAM *paramdefs,
                                   const char *key, const char *value,
-                                  size_t value_n)
+                                  size_t value_n, int *found)
 {
     const OSSL_PARAM *paramdef = NULL;
     int ishex = 0;
@@ -176,7 +178,7 @@ int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
         return 0;
 
     if (!prepare_from_text(paramdefs, key, value, value_n,
-                           &paramdef, &ishex, &buf_n, &tmpbn))
+                           &paramdef, &ishex, &buf_n, &tmpbn, found))
         return 0;
 
     if ((buf = OPENSSL_zalloc(buf_n > 0 ? buf_n : 1)) == NULL) {

--- a/doc/man3/OSSL_PARAM_allocate_from_text.pod
+++ b/doc/man3/OSSL_PARAM_allocate_from_text.pod
@@ -12,7 +12,8 @@ OSSL_PARAM_allocate_from_text
  int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
                                    const OSSL_PARAM *paramdefs,
                                    const char *key, const char *value,
-                                   size_t value_n);
+                                   size_t value_n,
+                                   int *found);
 
 =head1 DESCRIPTION
 
@@ -37,6 +38,9 @@ left untouched, allowing a caller to find out how large the buffer
 should be.
 I<buf> needs to be correctly aligned for the type of the B<OSSL_PARAM>
 I<key>.
+If <found> is not NULL, it is set to 1 if the parameter can be located and
+to 0 otherwise.
+
 The caller must remember to free the data of I<to> when it's not
 useful any more.
 
@@ -127,7 +131,7 @@ Can be written like this instead:
       *vtmp++ = '\0';
       if (!OSSL_PARAM_allocate_from_text(&params[params_n],
                                          paramdefs, stmp,
-                                         vtmp, strlen(vtmp)))
+                                         vtmp, strlen(vtmp), NULL))
           goto err;
   }
   params[params_n] = OSSL_PARAM_construct_end();

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -92,7 +92,7 @@ OSSL_PARAM OSSL_PARAM_construct_end(void);
 int OSSL_PARAM_allocate_from_text(OSSL_PARAM *to,
                                   const OSSL_PARAM *paramdefs,
                                   const char *key, const char *value,
-                                  size_t value_n);
+                                  size_t value_n, int *found);
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val);
 int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val);

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -167,7 +167,7 @@ static int self_test_kdf(const ST_KAT_KDF *t, OSSL_ST_EVENT *event,
         if (!OSSL_PARAM_allocate_from_text(&params[i], settables,
                                            t->ctrls[i].name,
                                            t->ctrls[i].value,
-                                           strlen(t->ctrls[i].value)))
+                                           strlen(t->ctrls[i].value), NULL))
             goto end;
     }
     if (!EVP_KDF_CTX_set_params(ctx, params))

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1310,7 +1310,7 @@ static int mac_test_run_mac(EVP_TEST *t)
             || !OSSL_PARAM_allocate_from_text(&params[params_n],
                                               defined_params,
                                               tmpkey, tmpval,
-                                              strlen(tmpval))) {
+                                              strlen(tmpval), NULL)) {
             OPENSSL_free(tmpkey);
             t->err = "MAC_PARAM_ERROR";
             goto err;
@@ -2129,7 +2129,7 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
         *p++ = '\0';
 
     rv = OSSL_PARAM_allocate_from_text(kdata->p, defs, name, p,
-                                       p != NULL ? strlen(p) : 0);
+                                       p != NULL ? strlen(p) : 0, NULL);
     *++kdata->p = OSSL_PARAM_construct_end();
     if (!rv) {
         t->err = "KDF_PARAM_ERROR";


### PR DESCRIPTION
Alternative to  #11046

- [x] documentation is added or updated
- [x] tests are added or updated
