### PR TITLE
Add assembly config targets for UEFI build

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1483,6 +1483,16 @@ my %targets = (
         lib_cppflags     => "-DL_ENDIAN",
         sys_id           => "UEFI",
     },
+    "UEFI-x86" => {
+        inherit_from     => [ "UEFI" ],
+        asm_arch         => 'x86',
+        perlasm_scheme   => "win32n",
+    },
+    "UEFI-x86_64" => {
+        inherit_from     => [ "UEFI" ],
+        asm_arch         => 'x86_64',
+        perlasm_scheme   => "nasm",
+    },
 
 #### UWIN
     "UWIN" => {


### PR DESCRIPTION
UEFI builds are currently limited to the basic algorithms. This adds assembly builds in the UEFI environment for x86 and x86_64 build targets.