### PR TITLE
Add OSSL_SERIALIZER_PUBKEY_TO_DER_PQ and friends

### DIFF
--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -93,7 +93,7 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
         }
     } else if (pkey->pkeys[0].keymgmt != NULL) {
         BIO *bmem = BIO_new(BIO_s_mem());
-        const char *serprop = "format=der,type=public";
+        const char *serprop = OSSL_SERIALIZER_PUBKEY_TO_DER_PQ;
         OSSL_SERIALIZER_CTX *sctx =
             OSSL_SERIALIZER_CTX_new_by_EVP_PKEY(pkey, serprop);
 

--- a/include/openssl/serializer.h
+++ b/include/openssl/serializer.h
@@ -89,6 +89,10 @@ OSSL_SERIALIZER_CTX *OSSL_SERIALIZER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
 # define OSSL_SERIALIZER_PrivateKey_TO_PEM_PQ "format=pem,type=private"
 # define OSSL_SERIALIZER_Parameters_TO_PEM_PQ "format=pem,type=parameters"
 
+# define OSSL_SERIALIZER_PUBKEY_TO_DER_PQ "format=der,type=public"
+# define OSSL_SERIALIZER_PrivateKey_TO_DER_PQ "format=der,type=private"
+# define OSSL_SERIALIZER_Parameters_TO_DER_PQ "format=der,type=parameters"
+
 /* Corresponding macros for text output */
 # define OSSL_SERIALIZER_PUBKEY_TO_TEXT_PQ "format=text,type=public"
 # define OSSL_SERIALIZER_PrivateKey_TO_TEXT_PQ "format=text,type=private"


### PR DESCRIPTION
It's already used internally, there's no reason the DER serializer
propqueries shouldn't be present alongside the PEM and TEXT ones.
