### PR TITLE
Fix builds with new HTTP client configured with no-ocsp and no-cmp

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -883,8 +883,11 @@ BIO *OSSL_HTTP_transfer(const char *server, const char *port, const char *path,
             if (lib == ERR_LIB_SSL || lib == ERR_LIB_HTTP
                     || (lib == ERR_LIB_BIO && reason == BIO_R_CONNECT_TIMEOUT)
                     || (lib == ERR_LIB_BIO && reason == BIO_R_CONNECT_ERROR)
+# ifndef OPENSSL_NO_CMP
                     || (lib == ERR_LIB_CMP
-                        && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)) {
+                        && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)
+# endif
+                ) {
                 BIO_snprintf(buf, 200, "server=%s:%s", server, port);
                 ERR_add_error_data(1, buf);
                 if (err == 0) {

--- a/crypto/http/http_local.h
+++ b/crypto/http/http_local.h
@@ -16,18 +16,18 @@
 /* name aliases for legacy names with name prefix "OCSP_" */
 typedef OCSP_REQ_CTX OSSL_HTTP_REQ_CTX;
 /* functions meanwhile only used internally */
-# define OSSL_HTTP_REQ_CTX_new          OCSP_REQ_CTX_new
-# define OSSL_HTTP_REQ_CTX_free         OCSP_REQ_CTX_free
-# define OSSL_HTTP_REQ_CTX_header       OCSP_REQ_CTX_http
-# define OSSL_HTTP_REQ_CTX_add1_header  OCSP_REQ_CTX_add1_header
-# define OSSL_HTTP_REQ_CTX_i2d          OCSP_REQ_CTX_i2d
-# define OSSL_HTTP_REQ_CTX_nbio         OCSP_REQ_CTX_nbio
-# ifndef OPENSSL_NO_SOCK
-#  define OSSL_HTTP_REQ_CTX_sendreq_d2i OCSP_REQ_CTX_nbio_d2i
-# endif
+#  define OSSL_HTTP_REQ_CTX_new         OCSP_REQ_CTX_new
+#  define OSSL_HTTP_REQ_CTX_free        OCSP_REQ_CTX_free
+#  define OSSL_HTTP_REQ_CTX_header      OCSP_REQ_CTX_http
+#  define OSSL_HTTP_REQ_CTX_add1_header OCSP_REQ_CTX_add1_header
+#  define OSSL_HTTP_REQ_CTX_i2d         OCSP_REQ_CTX_i2d
+#  define OSSL_HTTP_REQ_CTX_nbio        OCSP_REQ_CTX_nbio
+#  ifndef OPENSSL_NO_SOCK
+#   define OSSL_HTTP_REQ_CTX_sendreq_d2i OCSP_REQ_CTX_nbio_d2i
+#  endif
 /* functions that are meanwhile unused */
-# define OSSL_HTTP_REQ_CTX_get0_mem_bio OCSP_REQ_CTX_get0_mem_bio /* undoc'd */
-# define OSSL_HTTP_REQ_CTX_set_max_response_length OCSP_set_max_response_length
+#  define OSSL_HTTP_REQ_CTX_get0_mem_bio OCSP_REQ_CTX_get0_mem_bio /* undoc'd */
+#  define OSSL_HTTP_REQ_CTX_set_max_response_length OCSP_set_max_response_length
 
 BIO *HTTP_asn1_item2bio(const ASN1_ITEM *it, ASN1_VALUE *val);
 OSSL_HTTP_REQ_CTX *HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio, int use_http_proxy,

--- a/crypto/http/http_local.h
+++ b/crypto/http/http_local.h
@@ -16,18 +16,18 @@
 /* name aliases for legacy names with name prefix "OCSP_" */
 typedef OCSP_REQ_CTX OSSL_HTTP_REQ_CTX;
 /* functions meanwhile only used internally */
-#  define OSSL_HTTP_REQ_CTX_new         OCSP_REQ_CTX_new
-#  define OSSL_HTTP_REQ_CTX_free        OCSP_REQ_CTX_free
-#  define OSSL_HTTP_REQ_CTX_header      OCSP_REQ_CTX_http
-#  define OSSL_HTTP_REQ_CTX_add1_header OCSP_REQ_CTX_add1_header
-#  define OSSL_HTTP_REQ_CTX_i2d         OCSP_REQ_CTX_i2d
-#  define OSSL_HTTP_REQ_CTX_nbio        OCSP_REQ_CTX_nbio
-#  ifndef OPENSSL_NO_SOCK
-#   define OSSL_HTTP_REQ_CTX_sendreq_d2i OCSP_REQ_CTX_nbio_d2i
-#  endif
+# define OSSL_HTTP_REQ_CTX_new         OCSP_REQ_CTX_new
+# define OSSL_HTTP_REQ_CTX_free        OCSP_REQ_CTX_free
+# define OSSL_HTTP_REQ_CTX_header      OCSP_REQ_CTX_http
+# define OSSL_HTTP_REQ_CTX_add1_header OCSP_REQ_CTX_add1_header
+# define OSSL_HTTP_REQ_CTX_i2d         OCSP_REQ_CTX_i2d
+# define OSSL_HTTP_REQ_CTX_nbio        OCSP_REQ_CTX_nbio
+# ifndef OPENSSL_NO_SOCK
+#  define OSSL_HTTP_REQ_CTX_sendreq_d2i OCSP_REQ_CTX_nbio_d2i
+# endif
 /* functions that are meanwhile unused */
-#  define OSSL_HTTP_REQ_CTX_get0_mem_bio OCSP_REQ_CTX_get0_mem_bio /* undoc'd */
-#  define OSSL_HTTP_REQ_CTX_set_max_response_length OCSP_set_max_response_length
+# define OSSL_HTTP_REQ_CTX_get0_mem_bio OCSP_REQ_CTX_get0_mem_bio /* undoc'd */
+# define OSSL_HTTP_REQ_CTX_set_max_response_length OCSP_set_max_response_length
 
 BIO *HTTP_asn1_item2bio(const ASN1_ITEM *it, ASN1_VALUE *val);
 OSSL_HTTP_REQ_CTX *HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio, int use_http_proxy,

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -16,7 +16,7 @@
 #  define HEADER_OCSP_H
 # endif
 
-#include <openssl/opensslconf.h>
+# include <openssl/opensslconf.h>
 
 /*
  * These definitions are outside the OPENSSL_NO_OCSP guard because although for
@@ -37,30 +37,55 @@
  *        privilegeWithdrawn      (9),
  *        aACompromise           (10) }
  */
-#  define OCSP_REVOKED_STATUS_NOSTATUS               -1
-#  define OCSP_REVOKED_STATUS_UNSPECIFIED             0
-#  define OCSP_REVOKED_STATUS_KEYCOMPROMISE           1
-#  define OCSP_REVOKED_STATUS_CACOMPROMISE            2
-#  define OCSP_REVOKED_STATUS_AFFILIATIONCHANGED      3
-#  define OCSP_REVOKED_STATUS_SUPERSEDED              4
-#  define OCSP_REVOKED_STATUS_CESSATIONOFOPERATION    5
-#  define OCSP_REVOKED_STATUS_CERTIFICATEHOLD         6
-#  define OCSP_REVOKED_STATUS_REMOVEFROMCRL           8
-#  define OCSP_REVOKED_STATUS_PRIVILEGEWITHDRAWN      9
-#  define OCSP_REVOKED_STATUS_AACOMPROMISE           10
+# define OCSP_REVOKED_STATUS_NOSTATUS                -1
+# define OCSP_REVOKED_STATUS_UNSPECIFIED             0
+# define OCSP_REVOKED_STATUS_KEYCOMPROMISE           1
+# define OCSP_REVOKED_STATUS_CACOMPROMISE            2
+# define OCSP_REVOKED_STATUS_AFFILIATIONCHANGED      3
+# define OCSP_REVOKED_STATUS_SUPERSEDED              4
+# define OCSP_REVOKED_STATUS_CESSATIONOFOPERATION    5
+# define OCSP_REVOKED_STATUS_CERTIFICATEHOLD         6
+# define OCSP_REVOKED_STATUS_REMOVEFROMCRL           8
+# define OCSP_REVOKED_STATUS_PRIVILEGEWITHDRAWN      9
+# define OCSP_REVOKED_STATUS_AACOMPROMISE            10
+
+/*
+ * These definitions are outside the OPENSSL_NO_OCSP guard because although for
+ * historical reasons they have OCSP_* names, they are used for the HTTP client.
+ */
+# include <openssl/asn1.h>
+/* The following functions are used only internally */
+OCSP_REQ_CTX *OCSP_REQ_CTX_new(BIO *wbio, BIO *rbio,
+                               int method_GET, int maxline,
+                               unsigned long max_resp_len, int timeout,
+                               const char *expected_content_type,
+                               int expect_asn1);
+void OCSP_REQ_CTX_free(OCSP_REQ_CTX *rctx);
+int OCSP_REQ_CTX_http(OCSP_REQ_CTX *rctx,
+                      const char *server, const char *port, const char *path);
+int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
+                             const char *name, const char *value);
+int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const char *content_type,
+                     const ASN1_ITEM *it, ASN1_VALUE *req);
+int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx);
+# ifndef OPENSSL_NO_SOCK
+ASN1_VALUE *OCSP_REQ_CTX_nbio_d2i(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it);
+# endif
+BIO *OCSP_REQ_CTX_get0_mem_bio(OCSP_REQ_CTX *rctx);
+void OCSP_set_max_response_length(OCSP_REQ_CTX *rctx, unsigned long len);
+/* End of functions used only internally */
 
 
 # ifndef OPENSSL_NO_OCSP
 
-#  include <openssl/types.h>
 #  include <openssl/x509.h>
 #  include <openssl/x509v3.h>
 #  include <openssl/safestack.h>
 #  include <openssl/ocsperr.h>
 
-#ifdef  __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
 /* Various flags and values */
 
@@ -165,26 +190,6 @@ OCSP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path, OCSP_REQUEST *req,
 #  ifndef OPENSSL_NO_SOCK
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OCSP_REQ_CTX *rctx);
 #  endif
-/* The following functions are used only internally */
-int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx);
-OCSP_REQ_CTX *OCSP_REQ_CTX_new(BIO *wbio, BIO *rbio,
-                               int method_GET, int maxline,
-                               unsigned long max_resp_len, int timeout,
-                               const char *expected_content_type,
-                               int expect_asn1);
-void OCSP_REQ_CTX_free(OCSP_REQ_CTX *rctx);
-void OCSP_set_max_response_length(OCSP_REQ_CTX *rctx, unsigned long len);
-int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const char *content_type,
-                     const ASN1_ITEM *it, ASN1_VALUE *req);
-#  ifndef OPENSSL_NO_SOCK
-ASN1_VALUE *OCSP_REQ_CTX_nbio_d2i(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it);
-#  endif
-BIO *OCSP_REQ_CTX_get0_mem_bio(OCSP_REQ_CTX *rctx);
-int OCSP_REQ_CTX_http(OCSP_REQ_CTX *rctx,
-                      const char *server, const char *port, const char *path);
-int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
-                             const char *name, const char *value);
-/* End of functions used only internally */
 
 /* TODO: remove this (documented but) meanwhile obsolete function? */
 int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, const OCSP_REQUEST *req);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -133,7 +133,7 @@ d2i_OCSP_BASICRESP                      134	3_0_0	EXIST::FUNCTION:OCSP
 X509v3_add_ext                          135	3_0_0	EXIST::FUNCTION:
 X509v3_addr_subset                      136	3_0_0	EXIST::FUNCTION:RFC3779
 CRYPTO_strndup                          137	3_0_0	EXIST::FUNCTION:
-OCSP_REQ_CTX_free                       138	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_free                       138	3_0_0	EXIST::FUNCTION:
 X509_STORE_new                          140	3_0_0	EXIST::FUNCTION:
 ASN1_TYPE_free                          141	3_0_0	EXIST::FUNCTION:
 PKCS12_BAGS_new                         142	3_0_0	EXIST::FUNCTION:
@@ -615,7 +615,7 @@ UI_get0_result_string                   629	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_add_policy                  630	3_0_0	EXIST::FUNCTION:TS
 X509_REQ_dup                            631	3_0_0	EXIST::FUNCTION:
 d2i_DSA_PUBKEY_fp                       633	3_0_0	EXIST::FUNCTION:DSA,STDIO
-OCSP_REQ_CTX_nbio_d2i                   634	3_0_0	EXIST::FUNCTION:OCSP,SOCK
+OCSP_REQ_CTX_nbio_d2i                   634	3_0_0	EXIST::FUNCTION:SOCK
 d2i_X509_REQ_fp                         635	3_0_0	EXIST::FUNCTION:STDIO
 DH_OpenSSL                              636	3_0_0	EXIST::FUNCTION:DH
 BN_get_rfc3526_prime_8192               637	3_0_0	EXIST::FUNCTION:DH
@@ -1115,7 +1115,7 @@ PEM_write_bio_PKCS7                     1141	3_0_0	EXIST::FUNCTION:
 MDC2_Final                              1142	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MDC2
 SMIME_crlf_copy                         1143	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_get_ext_count              1144	3_0_0	EXIST::FUNCTION:OCSP
-OCSP_REQ_CTX_new                        1145	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_new                        1145	3_0_0	EXIST::FUNCTION:
 X509_load_cert_crl_file                 1146	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_new_mac_key                    1147	3_0_0	EXIST::FUNCTION:
 DIST_POINT_new                          1148	3_0_0	EXIST::FUNCTION:
@@ -1379,7 +1379,7 @@ BIO_set_ex_data                         1411	3_0_0	EXIST::FUNCTION:
 SHA512                                  1412	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_get_explicit_policy      1413	3_0_0	EXIST::FUNCTION:
 EVP_DecodeBlock                         1414	3_0_0	EXIST::FUNCTION:
-OCSP_REQ_CTX_http                       1415	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_http                       1415	3_0_0	EXIST::FUNCTION:
 EVP_MD_CTX_reset                        1416	3_0_0	EXIST::FUNCTION:
 X509_NAME_new                           1417	3_0_0	EXIST::FUNCTION:
 ASN1_item_pack                          1418	3_0_0	EXIST::FUNCTION:
@@ -1577,7 +1577,7 @@ BIO_ADDRINFO_address                    1613	3_0_0	EXIST::FUNCTION:SOCK
 ASN1_STRING_print_ex                    1614	3_0_0	EXIST::FUNCTION:
 i2d_CMS_ReceiptRequest                  1615	3_0_0	EXIST::FUNCTION:CMS
 d2i_TS_REQ_fp                           1616	3_0_0	EXIST::FUNCTION:STDIO,TS
-OCSP_REQ_CTX_i2d                        1617	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_i2d                        1617	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_default_digest_nid         1618	3_0_0	EXIST::FUNCTION:
 ASIdOrRange_new                         1619	3_0_0	EXIST::FUNCTION:RFC3779
 ASN1_SCTX_new                           1620	3_0_0	EXIST::FUNCTION:
@@ -1593,7 +1593,7 @@ CRYPTO_ocb128_cleanup                   1629	3_0_0	EXIST::FUNCTION:OCB
 EVP_des_ede_cbc                         1630	3_0_0	EXIST::FUNCTION:DES
 i2d_ASN1_TIME                           1631	3_0_0	EXIST::FUNCTION:
 ENGINE_register_all_pkey_asn1_meths     1632	3_0_0	EXIST::FUNCTION:ENGINE
-OCSP_set_max_response_length            1633	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_set_max_response_length            1633	3_0_0	EXIST::FUNCTION:
 d2i_ISSUING_DIST_POINT                  1634	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_set0_key              1635	3_0_0	EXIST::FUNCTION:CMS
 NCONF_new                               1636	3_0_0	EXIST::FUNCTION:
@@ -1850,7 +1850,7 @@ OCSP_ONEREQ_add_ext                     1892	3_0_0	EXIST::FUNCTION:OCSP
 CMS_uncompress                          1893	3_0_0	EXIST::FUNCTION:CMS
 CRYPTO_mem_debug_pop                    1895	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0
 EVP_aes_192_cfb128                      1896	3_0_0	EXIST::FUNCTION:
-OCSP_REQ_CTX_nbio                       1897	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_nbio                       1897	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_copy                     1898	3_0_0	EXIST::FUNCTION:
 CRYPTO_secure_allocated                 1899	3_0_0	EXIST::FUNCTION:
 UI_UTIL_read_pw_string                  1900	3_0_0	EXIST::FUNCTION:
@@ -2416,7 +2416,7 @@ Camellia_decrypt                        2466	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPR
 X509_signature_print                    2467	3_0_0	EXIST::FUNCTION:
 EVP_camellia_128_ecb                    2468	3_0_0	EXIST::FUNCTION:CAMELLIA
 MD2_Final                               2469	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
-OCSP_REQ_CTX_add1_header                2470	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_add1_header                2470	3_0_0	EXIST::FUNCTION:
 NETSCAPE_SPKAC_it                       2471	3_0_0	EXIST::FUNCTION:
 ASIdOrRange_free                        2472	3_0_0	EXIST::FUNCTION:RFC3779
 EC_POINT_get_Jprojective_coordinates_GFp 2473	3_0_0	EXIST::FUNCTION:EC
@@ -3762,7 +3762,7 @@ i2d_PrivateKey_bio                      3843	3_0_0	EXIST::FUNCTION:
 RSA_padding_add_PKCS1_type_1            3844	3_0_0	EXIST::FUNCTION:RSA
 i2d_re_X509_tbs                         3845	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_iv_length                    3846	3_0_0	EXIST::FUNCTION:
-OCSP_REQ_CTX_get0_mem_bio               3847	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_REQ_CTX_get0_mem_bio               3847	3_0_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKeyInfo_bio             3848	3_0_0	EXIST::FUNCTION:
 d2i_OCSP_CERTID                         3849	3_0_0	EXIST::FUNCTION:OCSP
 EVP_CIPHER_meth_set_init                3850	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is a fixup of #10667 for build issues newly detected by Travis due to #9982. 
* fix build for new HTTP client in case `OPENSSL_NO_CMP`
* fix build with new HTTP client in case `OPENSSL_NO_OCSP`
* on this occasion, fix formatting nits w.r.t. #if indentations in `ocsp.h`



