### PR TITLE
Apps: don't build deprecated DH and DSA apps.

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -12,8 +12,8 @@ ENDIF
 # Source for the 'openssl' program
 $OPENSSLSRC=\
         openssl.c progs.c \
-        asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c dhparam.c \
-        dsa.c dsaparam.c ec.c ecparam.c enc.c engine.c errstr.c gendsa.c \
+        asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c \
+        ec.c ecparam.c enc.c engine.c errstr.c \
         genpkey.c genrsa.c kdf.c mac.c nseq.c ocsp.c passwd.c pkcs12.c pkcs7.c \
         pkcs8.c pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c rsa.c \
         rsautl.c s_client.c s_server.c s_time.c sess_id.c smime.c speed.c \

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -11,7 +11,7 @@
 #define OPENSSL_SUPPRESS_DEPRECATED
 
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_NO_DH) || defined(OPENSSL_NO_DEPRECATED_3_0)
+#ifdef OPENSSL_NO_DH
 NON_EMPTY_TRANSLATION_UNIT
 #else
 

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -11,7 +11,7 @@
 #define OPENSSL_SUPPRESS_DEPRECATED
 
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_NO_DSA) || defined(OPENSSL_NO_DEPRECATED_3_0)
+#ifdef OPENSSL_NO_DSA
 NON_EMPTY_TRANSLATION_UNIT
 #else
 

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -11,7 +11,7 @@
 #define OPENSSL_SUPPRESS_DEPRECATED
 
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_NO_DSA) || defined(OPENSSL_NO_DEPRECATED_3_0)
+#ifdef OPENSSL_NO_DSA
 NON_EMPTY_TRANSLATION_UNIT
 #else
 

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -11,7 +11,7 @@
 #define OPENSSL_SUPPRESS_DEPRECATED
 
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_NO_DSA) || defined(OPENSSL_NO_DEPRECATED_3_0)
+#ifdef OPENSSL_NO_DSA
 NON_EMPTY_TRANSLATION_UNIT
 #else
 


### PR DESCRIPTION
This also means that there doesn't need to be any conditional checks in the .c
files to avoid deprecated builds.

