### PR TITLE
Look for man1/XXX.pod in build tree

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -955,7 +955,7 @@ doc-nits: build_generated
 	(cd $(SRCDIR); $(PERL) util/find-doc-nits -n -l -e )
 
 cmd-nits: build_generated apps/openssl
-	(cd $(SRCDIR); $(PERL) util/find-doc-nits -c )
+	(SRCDIR=$(SRCDIR) BLDDIR=$(BLDDIR) $(PERL) util/find-doc-nits -c )
 
 # Test coverage is a good idea for the future
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)

--- a/doc/internal/man3/evp_keymgmt_newdata.pod
+++ b/doc/internal/man3/evp_keymgmt_newdata.pod
@@ -18,12 +18,12 @@ evp_keymgmt_export, evp_keymgmt_export_types
  int evp_keymgmt_get_params(const EVP_KEYMGMT *keymgmt,
                             void *keydata, OSSL_PARAM params[]);
  const OSSL_PARAM *evp_keymgmt_gettable_params(const EVP_KEYMGMT *keymgmt);
- 
- 
+
+
  int evp_keymgmt_has(const EVP_KEYMGMT *keymgmt, void *keyddata, int selection);
  int evp_keymgmt_validate(const EVP_KEYMGMT *keymgmt, void *keydata,
                           int selection);
- 
+
  int evp_keymgmt_import(const EVP_KEYMGMT *keymgmt, void *keydata,
                         int selection, const OSSL_PARAM params[]);
  const OSSL_PARAM *evp_keymgmt_import_types(const EVP_KEYMGMT *keymgmt,

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -23,8 +23,9 @@ use OpenSSL::Util::Pod;
 my $debug = 0;
 
 # Where to find openssl command
-my $BLDTOP  = $ENV{BLDTOP} || ".";
-my $openssl = "$BLDTOP/util/opensslwrap.sh";
+my $SRCDIR  = $ENV{SRCDIR} || '.';
+my $BLDDIR  = $ENV{BLDDIR} || '.';
+my $openssl = "$BLDDIR/util/opensslwrap.sh";
 
 # Options.
 our($opt_d);
@@ -859,14 +860,23 @@ if ( $opt_c ) {
     # See if each has a manpage.
     foreach my $cmd ( @commands ) {
         next if $cmd eq 'help' || $cmd eq 'exit';
-        my $doc = "doc/man1/openssl-$cmd.pod";
-        # Handle "tsget" and "CA.pl" pod pages
+        my $doc = "$SRCDIR/doc/man1/openssl-$cmd.pod";
+        # Handle "tsget" and "CA.pl" pod pages which don't have .in files
         $doc = "doc/man1/$cmd.pod" if -f "doc/man1/$cmd.pod";
         if ( ! -f "$doc" ) {
-            err("$doc does not exist");
-        } else {
-            checkflags($cmd, $doc);
+            # Fallback, see if pod.in exists and then try the build tree.
+            if ( ! -f "$doc.in") {
+                err("$doc does not exist");
+                next;
+            }
+            my $blt = "$BLDDIR/doc/man1/openssl-$cmd.pod";
+            if ( ! -f $blt ) {
+                err "$doc.in exists, but $blt does not exists";
+                next;
+            }
+            $doc = $blt;
         }
+        checkflags($cmd, $doc);
     }
 
     # See what help is missing.
@@ -884,7 +894,20 @@ if ( $opt_c ) {
 
 # Preparation for some options, populate %name_map and %link_map
 if ( $opt_l || $opt_u || $opt_v ) {
-    foreach ( glob('doc/*/*.pod doc/internal/*/*.pod') ) {
+    if ( $SRCDIR ne $BLDDIR ) {
+        # If building out-of-tree, foo.pod.in in $SRCDIR should be found as
+        # foo.pod in $BLDDIR;
+        foreach my $in ( glob("$SRCDIR/doc/*/*.pod.in $SRCDIR/doc/internal/*/*.pod.in") ) {
+            my $pod = "$BLDDIR/$in";
+            $pod =~ s/\.in$//;
+            if ( -f $pod ) {
+                collectnames($pod);
+            } else {
+                err("$in exists but $pod does not exist")
+            }
+        }
+    }
+    foreach ( glob("$SRCDIR/doc/*/*.pod $SRCDIR/doc/internal/*/*.pod") ) {
         collectnames($_);
     }
 }
@@ -898,13 +921,31 @@ if ( $opt_l ) {
 
 if ( $opt_n ) {
     publicize();
-    foreach ( @ARGV ? @ARGV : glob('doc/*/*.pod doc/internal/*/*.pod') ) {
-        check($_);
-    }
+    if ( scalar @ARGV != 0 ) {
+        foreach ( @ARGV ) {
+            check($_);
+        }
+    } else {
+        foreach ( glob('doc/*/*.pod doc/internal/*/*.pod') ) {
+            check($_);
+        }
 
-    # If not given args, check that all man1 commands are named properly.
-    if ( scalar @ARGV == 0 ) {
-        foreach ( glob('doc/man1/*.pod') ) {
+        if ( $SRCDIR ne $BLDDIR ) {
+            # If building out-of-tree, foo.pod.in in $SRCDIR should be found as
+            # foo.pod in $BLDDIR;
+            foreach my $in ( glob('doc/*/*.pod.in doc/internal/*/*.pod.in') ) {
+                my $pod = "$BLDDIR/$in";
+                $pod =~ s/\.in$//;
+                if ( -f $pod ) {
+                    check($pod);
+                } else {
+                    err("$in exists but $pod does not exist")
+                }
+            }
+        }
+
+        # If not given args, check that all man1 commands are named properly.
+        foreach ( glob('doc/man1/*.pod doc/man1/*.pod.in') ) {
             next if /CA.pl/ || /openssl\.pod/ || /tsget\.pod/;
             err("$_ doesn't start with openssl-") unless /openssl-/;
         }


### PR DESCRIPTION
When doing cmd-nits, the files foo.pod (for the commands) end up
in the build tree, not the source tree.

This is an alternative to #11045.  It doesn't handle the man7 .pod.in file, yet.  If this isn't going to get looked at and #11045 is going in then I won't bother. But at least, @paulidale can you see if this fixes your 'cmd-nits' problems?
