### PR TITLE
apps x509: restrict CAkeyform option to OPT_FMT_PDE

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -145,7 +145,7 @@ const OPTIONS x509_options[] = {
     {"extfile", OPT_EXTFILE, '<', "File with X509V3 extensions to add"},
     OPT_R_OPTIONS,
     {"CAform", OPT_CAFORM, 'F', "CA format - default PEM"},
-    {"CAkeyform", OPT_CAKEYFORM, 'f', "CA key format - default PEM"},
+    {"CAkeyform", OPT_CAKEYFORM, 'E', "CA key format - default PEM"},
     {"sigopt", OPT_SIGOPT, 's', "Signature parameter in n:v form"},
     {"CAcreateserial", OPT_CACREATESERIAL, '-',
      "Create serial number file if it does not exist"},
@@ -239,7 +239,7 @@ int x509_main(int argc, char **argv)
                 goto opthelp;
             break;
         case OPT_CAKEYFORM:
-            if (!opt_format(opt_arg(), OPT_FMT_ANY, &CAkeyformat))
+            if (!opt_format(opt_arg(), OPT_FMT_PDE, &CAkeyformat))
                 goto opthelp;
             break;
         case OPT_OUT:

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -382,12 +382,12 @@ certificate is being created from another certificate (for example with
 the B<-signkey> or the B<-CA> options). Normally all extensions are
 retained.
 
-=item B<-keyform> B<DER>|B<PEM>
+=item B<-keyform> B<DER>|B<PEM>|B<ENGINE>
 
 The key format; the default is B<PEM>.
 See L<openssl(1)/Format Options> for details.
 
-=item B<-CAform> B<DER>|B<PEM>, B<-CAkeyform> B<DER>|B<PEM>
+=item B<-CAform> B<DER>|B<PEM>, B<-CAkeyform> B<DER>|B<PEM>|B<ENGINE>
 
 The format for the CA certificate and key; the default is B<PEM>.
 See L<openssl(1)/Format Options> for details.


### PR DESCRIPTION
CAkeyform may be set to PEM, DER or ENGINE, but the current options
are not using the proper optionformat 'E' (OPT_FMT_PDE) for this.

Set the valtype for CAkeyform to 'E' and use OPT_FMT_PDE when extracting
the option value.

This amends 0ab6fc79a9a ("Fix regression on x509 keyform argument") which
did the same thing for keyform and changed the manpage synopsis entries
for both keyform and CAkeyform but did not change the option section.
Hence, change the option section for both of them.

Closes #8203.

##### Checklist
- [x] documentation is added or updated