### PR TITLE
apps x509: passing PKCS#11 URL as -signkey

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -128,7 +128,7 @@ const OPTIONS x509_options[] = {
     {"setalias", OPT_SETALIAS, 's', "Set certificate alias"},
     {"days", OPT_DAYS, 'n',
      "How long till expiry of a signed certificate - def 30 days"},
-    {"signkey", OPT_SIGNKEY, '<', "Self sign cert with arg"},
+    {"signkey", OPT_SIGNKEY, 's', "Self sign cert with arg"},
     {"set_serial", OPT_SET_SERIAL, 's', "Serial number to use"},
     {"extensions", OPT_EXTENSIONS, 's', "Section from config file to use"},
     {"certopt", OPT_CERTOPT, 's', "Various certificate text options"},

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -45,7 +45,7 @@ B<openssl> B<x509>
 [B<-setalias> I<arg>]
 [B<-days> I<arg>]
 [B<-set_serial> I<n>]
-[B<-signkey> I<filename>]
+[B<-signkey> I<arg>]
 [B<-badsig>]
 [B<-passin> I<arg>]
 [B<-x509toreq>]
@@ -348,10 +348,11 @@ can thus behave like a "mini CA".
 
 =over 4
 
-=item B<-signkey> I<filename>
+=item B<-signkey> I<arg>
 
 This option causes the input file to be self signed using the supplied
-private key.
+private key or engine. The private key's format is specified with the
+B<-keyform> option.
 
 It sets the issuer name to the subject name (i.e., makes it self-issued)
 and changes the public key to the supplied value (unless overridden by


### PR DESCRIPTION
OpenSSL 1.1.0 has extended option checking, and rejects passing a PKCS#11
engine URL to "-signkey" option. The actual code is ready to take it.

Change the option parsing to allow an engine URL to be passed and modify
the manpage accordingly.

##### Checklist
- [x] documentation is added or updated