### PR TITLE
RAND_DRBG: Restore the unused EX_DATA field in the FIPS provider

### DIFF
--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -311,6 +311,9 @@ struct rand_drbg_st {
 #ifndef FIPS_MODE
     /* Application data, mainly used in the KATs. */
     CRYPTO_EX_DATA ex_data;
+#else
+    /* Unused in the FIPS provider, but retained here to preserve the structure size */
+    CRYPTO_EX_DATA unused;
 #endif
 
     /* Implementation specific data */


### PR DESCRIPTION
    Having structures in the FIPS and the default provider with the
    same name but different memory layouts is possible in theory,
    since the objects are not shared between those two providers.

    However, it can have very confusing side effects in the debugger,
    because the members can slip out of place and the debugger will
    show misleading information.

    For that reason, it is better to keep the EX_DATA field even though
    it is not used in the FIPS provider.


## Background

This almost drove me crazy when debugging the FIPS DRBG self tests #11010. The debugger's output of the RAND_DRBG_METHOD is very confusing, for example it shows that RAND_DRBG_METHOD pointer points to the cleanup entropy callback:

```
(gdb) frame
+frame
#0  self_test_drbg (t=0x7ffff78c7540 <st_kat_drbg_tests>, ... ) at providers/fips/self_test_kats.c:247
247	    if (drbg == NULL)

(gdb) p drbg->meth
+p drbg->meth
$33 = (RAND_DRBG_METHOD *) 0x7ffff78354bd <rand_crngt_cleanup_entropy>    <<<=== ?!?!?
```

This confusion is caused by the fact that the RAND_DRBG_METHOD structure has different sizes in the FIPS provider and elsewhere since commit a3327784d95.

https://github.com/openssl/openssl/blob/0618b62ca2a9c5fb7bf8421deabaee240c709040/crypto/rand/rand_local.h#L311-L314

As you can see below, the debugger correctly reports `sizeof(RAND_DRBG) == 576` in frames 1 and 2, and `sizeof(RAND_DRBG) == 592` in the other frames. The problem could be partially fixed by defining FIPS_MODE in the self tests, `providers/fips/self_test_kats.c`. But OTOH, using structures with the same name but different layouts means looking for trouble.




### Callstack

```
+bt
#0  rand_drbg_new (ctx=0x55555569e390, secure=0, type=672, flags=0, parent=0x0) at crypto/rand/drbg_lib.c:436
#1  0x00007ffff7833453 in RAND_DRBG_new_ex (ctx=0x55555569e390, type=672, flags=0, parent=0x0) at crypto/rand/drbg_lib.c:504
#2  0x00007ffff77b6d7f in self_test_drbg (t=0x7ffff78c7540 <st_kat_drbg_tests>, event=0x7fffffffcae0, libctx=0x55555569e390) at providers/fips/self_test_kats.c:246
#3  0x00007ffff77b72d5 in self_test_drbgs (event=0x7fffffffcae0, libctx=0x55555569e390) at providers/fips/self_test_kats.c:357
#4  0x00007ffff77b7373 in SELF_TEST_kats (event=0x7fffffffcae0, libctx=0x55555569e390) at providers/fips/self_test_kats.c:380
#5  0x00007ffff77b5890 in SELF_TEST_post (st=0x7ffff78cf7a0 <selftest_params>, on_demand_test=0) at providers/fips/self_test.c:269
#6  0x00007ffff77b4be1 in OSSL_provider_init (provider=0x5555556b10f0, in=0x7ffff7efd960 <core_dispatch_+448>, out=0x7fffffffcc30, provctx=0x5555556b1168) at providers/fips/fipsprov.c:984
#7  0x00007ffff7cfbee5 in provider_activate (prov=0x5555556b10f0) at crypto/provider_core.c:454
#8  0x00007ffff7cfc1bc in ossl_provider_activate (prov=0x5555556b10f0) at crypto/provider_core.c:547
#9  0x00007ffff7cfadfd in provider_conf_load (libctx=0x0, name=0x55555569f050 "fips", value=0x55555569f070 "fips_install", cnf=0x55555569bf70) at crypto/provider_conf.c:131
#10 0x00007ffff7cfaf1a in provider_conf_init (md=0x555555671230, cnf=0x55555569bf70) at crypto/provider_conf.c:167
#11 0x00007ffff7c1f6f6 in module_init (pmod=0x5555556425f0, name=0x55555569d610 "providers", value=0x55555569de90 "provider_section", cnf=0x55555569bf70) at crypto/conf/conf_mod.c:317
#12 0x00007ffff7c1f1ac in module_run (cnf=0x55555569bf70, name=0x55555569d610 "providers", value=0x55555569de90 "provider_section", flags=0) at crypto/conf/conf_mod.c:175
#13 0x00007ffff7c1ef74 in CONF_modules_load (cnf=0x55555569bf70, appname=0x0, flags=0) at crypto/conf/conf_mod.c:104
#14 0x00005555555a20a8 in generate_config_and_load (prov_name=0x7fffffffda93 "fips", section=0x7fffffffdadd "fips_install", module_mac=0x7fffffffcf70 "\031\216\"\337\062綌", module_mac_len=32) at apps/fipsinstall.c:184
#15 0x00005555555a2a58 in fipsinstall_main (argc=0, argv=0x7fffffffd600) at apps/fipsinstall.c:411
#16 0x00005555555abb2e in do_cmd (prog=0x55555564fba0, argc=15, argv=0x7fffffffd600) at apps/openssl.c:473
#17 0x00005555555ab4c5 in main (argc=15, argv=0x7fffffffd600) at apps/openssl.c:288
```

### Frame 0

```
+p sizeof(RAND_DRBG)
$12 = 576
+fin
Run till exit from #0  rand_drbg_new (ctx=0x55555569e390, secure=0, type=672, flags=0, parent=0x0) at crypto/rand/drbg_lib.c:436
```

### Frame 1

```
RAND_DRBG_new_ex (ctx=0x55555569e390, type=672, flags=0, parent=0x0) at crypto/rand/drbg_lib.c:505
505	}
Value returned is $13 = (RAND_DRBG *) 0x5555556d1fe0
+p sizeof(*$13)
$15 = 576
+p sizeof(RAND_DRBG)
$16 = 576
+fin
Run till exit from #0  RAND_DRBG_new_ex (ctx=0x55555569e390, type=672, flags=0, parent=0x0) at crypto/rand/drbg_lib.c:505
```

### Frame 2

The return value of Frame 1, which is still displayed correctly by the gdb...

```
0x00007ffff77b6d7f in self_test_drbg (t=0x7ffff78c7540 <st_kat_drbg_tests>, event=0x7fffffffcae0, libctx=0x55555569e390) at providers/fips/self_test_kats.c:246
246	    drbg = RAND_DRBG_new_ex(libctx, t->nid, flags, NULL);
Value returned is $17 = (RAND_DRBG *) 0x5555556d1fe0
+p sizeof(*$17)
$18 = 576
+p sizeof(RAND_DRBG)
$19 = 592
+print(*$17)
$20 = {
  lock = 0x0, 
  libctx = 0x55555569e390, 
  parent = 0x0, 
  secure = 0, 
  type = 672, 
  fork_id = 6960, 
  flags = 0, 
  seed_pool = 0x0, 
  adin_pool = 0x0, 
  strength = 256, 
  max_request = 65536, 
  min_entropylen = 32, 
  max_entropylen = 2147483647, 
  min_noncelen = 16, 
  max_noncelen = 2147483647, 
  max_perslen = 2147483647, 
  max_adinlen = 2147483647, 
  reseed_gen_counter = 0, 
  reseed_interval = 256, 
  reseed_time = 0, 
  reseed_time_interval = 3600, 
  reseed_prop_counter = 0, 
  reseed_next_counter = 0, 
  seedlen = 55, 
  state = DRBG_UNINITIALISED, 
  data = {
    ctr = {
      ctx = 0x5555556ab2a0, 
      ctx_df = 0x5555556aad30, 
      cipher = 0x20, 
      keylen = 0, 
      K = '\000' <repeats 31 times>, 
      V = '\000' <repeats 15 times>, 
      bltmp = '\000' <repeats 15 times>, 
      bltmp_pos = 0, 
      KX = '\000' <repeats 47 times>
    }, 
    hash = {
      md = 0x5555556ab2a0, 
      ctx = 0x5555556aad30, 
      blocklen = 32, 
      V = '\000' <repeats 110 times>, 
      C = '\000' <repeats 110 times>, 
      vtmp = '\000' <repeats 110 times>
    }, 
    hmac = {
      md = 0x5555556ab2a0, 
      ctx = 0x5555556aad30, 
      blocklen = 32, 
      K = '\000' <repeats 63 times>, 
      V = '\000' <repeats 63 times>
    }
  }, 
  meth = 0x7ffff78cf740 <drbg_hash_meth>,                      <<<=== CORRECT
  get_entropy = 0x7ffff7835291 <rand_crngt_get_entropy>, 
  cleanup_entropy = 0x7ffff78354bd <rand_crngt_cleanup_entropy>, 
  get_nonce = 0x7ffff7832cdf <rand_drbg_get_nonce>, 
  cleanup_nonce = 0x7ffff7832e33 <rand_drbg_cleanup_nonce>, 
  callback_data = 0x0
}
```

...is assigned to the local variable drbg, which is displayed incorrectly:

```
+n
247	    if (drbg == NULL)
+print(*drbg)
$21 = {
  lock = 0x0, 
  libctx = 0x55555569e390, 
  parent = 0x0, 
  secure = 0, 
  type = 672, 
  fork_id = 6960, 
  flags = 0, 
  seed_pool = 0x0, 
  adin_pool = 0x0, 
  strength = 256, 
  max_request = 65536, 
  min_entropylen = 32, 
  max_entropylen = 2147483647, 
  min_noncelen = 16, 
  max_noncelen = 2147483647, 
  max_perslen = 2147483647, 
  max_adinlen = 2147483647, 
  reseed_gen_counter = 0, 
  reseed_interval = 256, 
  reseed_time = 0, 
  reseed_time_interval = 3600, 
  reseed_prop_counter = 0, 
  reseed_next_counter = 0, 
  seedlen = 55, 
  state = DRBG_UNINITIALISED, 
  ex_data = {                             <<===  EX_DATA !!!  (REMOVED IN FIPS_MODE)
    ctx = 0x5555556ab2a0, 
    sk = 0x5555556aad30
  }, 
  data = {
    ctr = {
      ctx = 0x20, 
      ctx_df = 0x0, 
      cipher = 0x0, 
      keylen = 0, 
      K = '\000' <repeats 31 times>, 
      V = '\000' <repeats 15 times>, 
      bltmp = '\000' <repeats 15 times>, 
      bltmp_pos = 0, 
      KX = '\000' <repeats 47 times>
    }, 
    hash = {
      md = 0x20, 
      ctx = 0x0, 
      blocklen = 0, 
      V = '\000' <repeats 110 times>, 
      C = '\000' <repeats 110 times>, 
      vtmp = '\000' <repeats 98 times>, "@\367\214\367\377\177\000\000\221R\203\367\377"
    }, 
    hmac = {
      md = 0x20, 
      ctx = 0x0, 
      blocklen = 0, 
      K = '\000' <repeats 63 times>, 
      V = '\000' <repeats 63 times>
    }
  },
  
  meth = 0x7ffff78354bd <rand_crngt_cleanup_entropy>,             <<<=== RAND_DRBG_METH ?!?
  
  get_entropy = 0x7ffff7832cdf <rand_drbg_get_nonce>, 
  cleanup_entropy = 0x7ffff7832e33 <rand_drbg_cleanup_nonce>, 
  get_nonce = 0x0, 
  cleanup_nonce = 0x0, 
  callback_data = 0x7811
}
+set logging off
```

cc @levitte @slontis