### PR TITLE
PROV: Build the main FIPS module code with FIPS_MODE defined

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -101,6 +101,7 @@ SUBDIRS=fips
 $FIPSGOAL=fips
 DEPEND[$FIPSGOAL]=$LIBIMPLEMENTATIONS $LIBFIPS
 INCLUDE[$FIPSGOAL]=../include
+DEFINE[$FIPSGOAL]=FIPS_MODE
 IF[{- defined $target{shared_defflag} -}]
   SOURCE[$FIPSGOAL]=fips.ld
   GENERATE[fips.ld]=../util/providers.num


### PR DESCRIPTION
Without that, its main source wasn't compiled correctly.
