### PR TITLE
Define FIPS_MODE in providers/fips directory

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -84,7 +84,7 @@ SOURCE[../providers/libfips.a]=$UTIL_COMMON
 # need to be applied to all affected libraries and modules.
 DEFINE[../libcrypto]=$UTIL_DEFINE $UPLINKDEF
 DEFINE[../providers/libfips.a]=$UTIL_DEFINE
-DEFINE[../providers/fips]=$UTIL_DEFINE
+DEFINE[../providers/fips]=$UTIL_DEFINE FIPS_MODE
 DEFINE[../providers/libimplementations.a]=$UTIL_DEFINE
 DEFINE[../providers/libcommon.a]=$UTIL_DEFINE
 


### PR DESCRIPTION
It is confusing in the debugger and potentially dangerous if the
FIPS self tests don't get to see the correct memory layout of
structures like the RAND_DRBG structure.

Alternative to #11089
