### PR TITLE
Enhance test runner scripts

### DIFF
--- a/util/opensslwrap.sh
+++ b/util/opensslwrap.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-HERE="`echo $0 | sed -e 's|[^/]*$||'`"
-OPENSSL="${HERE}../apps/openssl"
+HERE="`echo $0 | sed -e 's|[^/]*$||'`.."
+OPENSSL="${HERE}/apps/openssl"
 
-if [ -d "${HERE}../engines" -a "x$OPENSSL_ENGINES" = "x" ]; then
-	OPENSSL_ENGINES="${HERE}../engines"; export OPENSSL_ENGINES
+if [ -z "$OPENSSL_ENGINES" ] && [ -d "${HERE}/engines" ] ; then
+	OPENSSL_ENGINES="${HERE}/engines"; export OPENSSL_ENGINES
 fi
-if [ -d "${HERE}../providers" -a "x$OPENSSL_MODULES" = "x" ]; then
-	OPENSSL_MODULES="${HERE}../providers"; export OPENSSL_MODULES
+if [ -z "$OPENSSL_MODULES" ] && [ -d "${HERE}/providers" ] ; then
+	OPENSSL_MODULES="${HERE}/providers"; export OPENSSL_MODULES
 fi
 
 if [ -x "${OPENSSL}.exe" ]; then
@@ -19,11 +19,11 @@ if [ -x "${OPENSSL}.exe" ]; then
 	# and test/, which is now done elsewhere... The $PATH is adjusted
 	# for backward compatibility (and nostagical reasons:-).
 	if [ "$OSTYPE" != msdosdjgpp ]; then
-		PATH="${HERE}..:$PATH"; export PATH
+		PATH="${HERE}:$PATH"; export PATH
 	fi
 	exec "${OPENSSL}.exe" "$@"
-elif [ -x "${OPENSSL}" -a -x "${HERE}shlib_wrap.sh" ]; then
-	exec "${HERE}shlib_wrap.sh" "${OPENSSL}" "$@"
+elif [ -x "${OPENSSL}" ] && [ -x "${HERE}/util/shlib_wrap.sh" ]; then
+	exec "${HERE}/util/shlib_wrap.sh" "${OPENSSL}" "$@"
 else
 	exec "${OPENSSL}" "$@"	# hope for the best...
 fi

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -37,8 +37,8 @@ if [ -z "$OPENSSL_MODULES" ] && [ -d "${THERE}/providers" ] ; then
 	OPENSSL_MODULES="${THERE}/providers"; export OPENSSL_MODULES
 fi
 
-LIBCRYPTOSO="${THERE}/libcrypto.so.3"
-LIBSSLSO="${THERE}/libssl.so.3"
+LIBCRYPTOSO="${THERE}/{- platform->sharedlib('libcrypto') -}"
+LIBSSLSO="${THERE}/{- platform->sharedlib('libssl') -}"
 
 SYSNAME=`(uname -s) 2>/dev/null`;
 case "$SYSNAME" in

--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -30,8 +30,15 @@ fi
 THERE="`echo $0 | sed -e 's|[^/]*$||' 2>/dev/null`.."
 [ -d "${THERE}" ] || exec "$@"	# should never happen...
 
-LIBCRYPTOSO="${THERE}/{- platform->sharedlib('libcrypto') -}"
-LIBSSLSO="${THERE}/{- platform->sharedlib('libssl') -}"
+if [ -z "$OPENSSL_ENGINES" ] && [ -d "${THERE}/engines" ] ; then
+	OPENSSL_ENGINES="${THERE}/engines"; export OPENSSL_ENGINES
+fi
+if [ -z "$OPENSSL_MODULES" ] && [ -d "${THERE}/providers" ] ; then
+	OPENSSL_MODULES="${THERE}/providers"; export OPENSSL_MODULES
+fi
+
+LIBCRYPTOSO="${THERE}/libcrypto.so.3"
+LIBSSLSO="${THERE}/libssl.so.3"
 
 SYSNAME=`(uname -s) 2>/dev/null`;
 case "$SYSNAME" in


### PR DESCRIPTION
Two commits:

#### shlib_wrap.sh: add module and engine paths to environment if unset
    
The testsuite invokes many openssl commands using the shlib_wrap.sh script.
It used to be possible to copy those commands for testing them standalone
or run them in the debugger (see also description of issue #10628).
With providers this did not work anymore, because the script did not
set the `OPENSSL_MODULES` and `OPENSSL_ENGINES` environment variables,
they were already set by the `_tests` make target.

To make `shlib_wrap.sh` self-contained again, we set the `OPENSSL_MODULES`
and `OPENSSL_ENGINES` environment variables if they are unset. In fact,
that's just what `opensslwrap.sh` already does.

#### opensslwrap.sh: make implementation more consistent with shlib_wrap.sh
