### PR TITLE
Coverity issues 1458438 and 1458439.

### DIFF
--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -15,7 +15,7 @@
 
 void ffc_params_init(FFC_PARAMS *params)
 {
-    memset(params, 0, sizeof(FFC_PARAMS));
+    memset(params, 0, sizeof(*params));
     params->pcounter = -1;
     params->gindex = FFC_UNVERIFIABLE_GINDEX;
 }

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -119,6 +119,7 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
             return 0;
         }
         if (prsactx->oaep_md == NULL) {
+            OPENSSL_free(tbuf);
             prsactx->oaep_md = EVP_MD_fetch(prsactx->libctx, "SHA-1", NULL);
             PROVerr(0, ERR_R_INTERNAL_ERROR);
             return 0;

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -393,9 +393,9 @@ static int ffc_params_fips186_2_gen_validate_test(void)
     FFC_PARAMS params;
     BIGNUM *bn = NULL;
 
+    ffc_params_init(&params);
     if (!TEST_ptr(bn = BN_new()))
         goto err;
-    ffc_params_init(&params);
     if (!TEST_true(ffc_params_FIPS186_2_generate(NULL, &params, FFC_PARAM_TYPE_DH,
                                                  1024, 160, NULL, &res, NULL)))
         goto err;


### PR DESCRIPTION
Fix Coverity problems 1458438 and 1458439

1. CID 1458438:  Memory - illegal accesses
1. CID 1458439:  Resource leaks

Also convert a sizeof(struct) to be sizeof(*pointer) in accordance with the coding style.

- [x] tests are added or updated
