### PR TITLE
Mem sec cond code readability

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -439,12 +439,15 @@ static int sh_init(size_t size, size_t minsize)
     sh.map_result = mmap(NULL, sh.map_size,
                          PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE, -1, 0);
 #else
-    sh.map_result = MAP_FAILED;
-    /* Temporary use |ret| for file descriptor (assumes goto err returns 0) */
-    if ((ret = open("/dev/zero", O_RDWR)) >= 0) {
-        sh.map_result = mmap(NULL, sh.map_size,
-                             PROT_READ|PROT_WRITE, MAP_PRIVATE, ret, 0);
-        close(ret);
+    {
+        int fd;
+
+        sh.map_result = MAP_FAILED;
+        if ((fd = open("/dev/zero", O_RDWR)) >= 0) {
+            sh.map_result = mmap(NULL, sh.map_size,
+                                 PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
+            close(fd);
+        }
     }
 #endif
     if (sh.map_result == MAP_FAILED)

--- a/include/openssl/crypto.h
+++ b/include/openssl/crypto.h
@@ -192,8 +192,7 @@ DEFINE_STACK_OF(void)
 # define CRYPTO_EX_INDEX_RAND_DRBG       15
 # define CRYPTO_EX_INDEX_DRBG            CRYPTO_EX_INDEX_RAND_DRBG
 # define CRYPTO_EX_INDEX_OPENSSL_CTX     16
-# define CRYPTO_EX_INDEX_COUNT           17
-# define CRYPTO_EX_INDEX__COUNT          CRYPTO_EX_INDEX_COUNT
+# define CRYPTO_EX_INDEX__COUNT          17
 
 typedef void CRYPTO_EX_new (void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                            int idx, long argl, void *argp);


### PR DESCRIPTION
Mem -sec conditional code readability improvement.

Removed an apparently superfluous `if(1)` statement block.

-------

Commit #11042 has introduced a new, unused, `CRYPTO_EX_INDEX` macro to keep track of the number of available indices (`CRYPTO_EX_INDEX_COUNT`).

Maybe is better to keep the old `CRYPTO_EX_INDEX__COUNT` instead of the new introduced `CRYPTO_EX_INDEX_COUNT`

