### PR TITLE
Docs typo fixes

### DIFF
--- a/doc/internal/man3/ossl_cmp_asn1_octet_string_set1.pod
+++ b/doc/internal/man3/ossl_cmp_asn1_octet_string_set1.pod
@@ -39,7 +39,7 @@ the variable pointed to by I<level> with the severity level or -1,
 the variable pointed to by I<func> with the function name string or NULL,
 the variable pointed to by I<file> with the filename string or NULL, and
 the variable pointed to by I<line> with the line number or -1.
-Any string returned via I<*func> and I<*file> must be freeed by the caller.
+Any string returned via I<*func> and I<*file> must be freed by the caller.
 
 ossl_cmp_add_error_txt() appends text to the extra data field of the last
 error message in the OpenSSL error queue, after adding the optional separator

--- a/doc/internal/man3/ossl_param_bld_init.pod
+++ b/doc/internal/man3/ossl_param_bld_init.pod
@@ -75,7 +75,7 @@ I<val> is stored by value and an expression or auto variable can be used.
 
 ossl_param_bld_push_BN() is a function that will create an OSSL_PARAM object
 that holds the specified BIGNUM I<bn>.
-If I<bn> is marked as being securely allocated,s its OSSL_PARAM representation
+If I<bn> is marked as being securely allocated, its OSSL_PARAM representation
 will also be securely allocated.
 The I<bn> argument is stored by reference and the underlying BIGNUM object
 must exist until after ossl_param_bld_to_param() has been called.

--- a/doc/internal/man3/ossl_param_bld_init.pod
+++ b/doc/internal/man3/ossl_param_bld_init.pod
@@ -75,7 +75,7 @@ I<val> is stored by value and an expression or auto variable can be used.
 
 ossl_param_bld_push_BN() is a function that will create an OSSL_PARAM object
 that holds the specified BIGNUM I<bn>.
-If I<bn> is marked as being securely allocated, it's OSSL_PARAM representation
+If I<bn> is marked as being securely allocated,s its OSSL_PARAM representation
 will also be securely allocated.
 The I<bn> argument is stored by reference and the underlying BIGNUM object
 must exist until after ossl_param_bld_to_param() has been called.
@@ -84,7 +84,7 @@ ossl_param_bld_push_BN_pad() is a function that will create an OSSL_PARAM object
 that holds the specified BIGNUM I<bn>.
 The object will be padded to occupy exactly I<sz> bytes, if insufficient space
 is specified an error results.
-If I<bn> is marked as being securely allocated, it's OSSL_PARAM representation
+If I<bn> is marked as being securely allocated, its OSSL_PARAM representation
 will also be securely allocated.
 The I<bn> argument is stored by reference and the underlying BIGNUM object
 must exist until after ossl_param_bld_to_param() has been called.

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -261,7 +261,7 @@ This command does not support authenticated encryption modes
 like CCM and GCM, and will not support such modes in the future.
 This is due to having to begin streaming output (e.g., to standard output
 when B<-out> is not used) before the authentication tag could be validated.
-When this command is used in a pipeline, the receiveing end will not be
+When this command is used in a pipeline, the receiving end will not be
 able to roll back upon authentication failure.  The AEAD modes currently in
 common use also suffer from catastrophic failure of confidentiality and/or
 integrity upon reuse of key/iv/nonce, and since B<openssl enc> places the

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -795,7 +795,7 @@ B<-xcert>, and B<-xchain> options.
 
 =item B<-xcertform> B<DER>|B<PEM>, B<-xkeyform> B<DER>|B<PEM>
 
-The input format for the extra certifcate and key, respectively.
+The input format for the extra certificate and key, respectively.
 See L<openssl(1)/Format Options> for details.
 
 =back
@@ -1047,7 +1047,7 @@ OpenSSL provides fine-grain control over how the subject and issuer DN's are
 displayed.
 This is specified by using the B<-nameopt> option, which takes a
 comma-separated list of options from the following set.
-An option may be preceeded by a minus sign, C<->, to turn it off.
+An option may be preceded by a minus sign, C<->, to turn it off.
 The default value is C<oneline>.
 The first four are the most commonly used.
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -51,7 +51,7 @@ if the B<=> character is not present but with it they just ignore
 the include.
 
 Pragmas can be specified with the B<.pragma> directive.
-See L</PRAGMAS> for mor information.
+See L</PRAGMAS> for more information.
 
 Each section in a configuration file consists of a number of name and
 value pairs of the form B<name=value>

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -60,7 +60,7 @@ The following sections describe each supported extension in detail.
 
 This is a multi valued extension which indicates whether a certificate is
 a CA certificate. The first (mandatory) name is B<CA> followed by B<TRUE> or
-B<FALSE>. If B<CA> is B<TRUE> then an optional B<pathlen> name followed by an
+B<FALSE>. If B<CA> is B<TRUE> then an optional B<pathlen> name followed by a
 non-negative value can be included.
 
 For example:


### PR DESCRIPTION
This PR solves some typos detected in the following documentation files:

- `internal/man3/ossl_cmp_asn1_octet_string_set1.pod`
- `internal/man3/ossl_param_bld_init.pod`
- `man1/openssl-enc.pod.in`
- `man1/openssl.pod`
- `man5/config.pod`
- `man5/x509v3_config.pod`
