### PR TITLE
Deprecate EC command line apps.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,10 @@
      test recipes are created in the build tree for this purpose.
      [Richard Levitte]
 
+  *) The command line utilities ecparam and ec have been deprecated.  Instead
+     use the pkeyparam, pkey and genpkey programs.
+     [Paul Dale]
+
   *) X509 certificates signed using SHA1 are no longer allowed at security
      level 1 and above.
      In TLS/SSL the default security level is 1. It can be set either

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include "apps.h"
 #include "progs.h"
 #include <openssl/pem.h>
@@ -44,9 +45,11 @@ int pkeyparam_main(int argc, char **argv)
     ENGINE *e = NULL;
     BIO *in = NULL, *out = NULL;
     EVP_PKEY *pkey = NULL;
-    int text = 0, noout = 0, ret = 1, check = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+    int text = 0, noout = 0, ret = EXIT_FAILURE, check = 0, r;
     OPTION_CHOICE o;
     char *infile = NULL, *outfile = NULL, *prog;
+    unsigned long err;
 
     prog = opt_init(argc, argv, pkeyparam_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -98,9 +101,6 @@ int pkeyparam_main(int argc, char **argv)
     }
 
     if (check) {
-        int r;
-        EVP_PKEY_CTX *ctx;
-
         ctx = EVP_PKEY_CTX_new(pkey, e);
         if (ctx == NULL) {
             ERR_print_errors(bio_err);
@@ -116,8 +116,6 @@ int pkeyparam_main(int argc, char **argv)
              * Note: at least for RSA keys if this function returns
              * -1, there will be no error reasons.
              */
-            unsigned long err;
-
             BIO_printf(out, "Parameters are invalid\n");
 
             while ((err = ERR_peek_error()) != 0) {
@@ -125,8 +123,8 @@ int pkeyparam_main(int argc, char **argv)
                            ERR_reason_error_string(err));
                 ERR_get_error(); /* remove err from error stack */
             }
+            goto end;
         }
-        EVP_PKEY_CTX_free(ctx);
     }
 
     if (!noout)
@@ -135,9 +133,10 @@ int pkeyparam_main(int argc, char **argv)
     if (text)
         EVP_PKEY_print_params(out, pkey, 0, NULL);
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  end:
+    EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
     release_engine(e);
     BIO_free_all(out);

--- a/apps/progs.c
+++ b/apps/progs.c
@@ -33,11 +33,11 @@ FUNCTION functions[] = {
 #if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {FT_general, "dsaparam", dsaparam_main, dsaparam_options, "pkeyparam"},
 #endif
-#ifndef OPENSSL_NO_EC
-    {FT_general, "ec", ec_main, ec_options, NULL},
+#if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+    {FT_general, "ec", ec_main, ec_options, "pkey"},
 #endif
-#ifndef OPENSSL_NO_EC
-    {FT_general, "ecparam", ecparam_main, ecparam_options, NULL},
+#if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+    {FT_general, "ecparam", ecparam_main, ecparam_options, "pkeyparam"},
 #endif
     {FT_general, "enc", enc_main, enc_options, NULL},
 #ifndef OPENSSL_NO_ENGINE

--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -95,7 +95,6 @@ EOF
         genrsa   => "rsa",
         rsautl   => "rsa",
         gendh    => "dh",
-        ecparam  => "ec",
         pkcs12   => "des",
     );
     my %cmd_deprecated = (
@@ -103,6 +102,8 @@ EOF
         dsaparam => [ "3_0", "pkeyparam", "dsa" ],
         dsa      => [ "3_0", "pkey",      "dsa" ],
         gendsa   => [ "3_0", "genpkey",   "dsa" ],
+        ec       => [ "3_0", "pkey",      "ec" ],
+        ecparam  => [ "3_0", "pkeyparam", "ec" ],
     );
 
     print "FUNCTION functions[] = {\n";

--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -37,6 +37,9 @@ B<openssl> B<ec>
 
 =head1 DESCRIPTION
 
+This command has been deprecated.
+The L<openssl-pkey(1)> command should be used instead.
+
 The L<openssl-ec(1)> command processes EC keys. They can be converted between
 various forms and their components printed out. B<Note> OpenSSL uses the
 private key format specified in 'SEC 1: Elliptic Curve Cryptography'
@@ -169,13 +172,18 @@ To change the point conversion form to B<compressed>:
 =head1 SEE ALSO
 
 L<openssl(1)>,
+L<openssl-pkey(1)>,
 L<openssl-ecparam(1)>,
 L<openssl-dsa(1)>,
 L<openssl-rsa(1)>
 
+=head1 HISTORY
+
+This command was deprecated in OpenSSL 3.0.
+
 =head1 COPYRIGHT
 
-Copyright 2003-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2003-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -31,6 +31,10 @@ B<openssl ecparam>
 
 =head1 DESCRIPTION
 
+This command has been deprecated.
+The L<openssl-genpkey(1)> and L<openssl-pkeyparam(1)> commands
+should be used instead.
+
 This command is used to manipulate or generate EC parameter files.
 
 OpenSSL is currently not able to generate new groups and therefore
@@ -157,12 +161,18 @@ To print out the EC parameters to standard output:
 =head1 SEE ALSO
 
 L<openssl(1)>,
+L<openssl-pkeyparam(1)>,
+L<openssl-genpkey(1)>,
 L<openssl-ec(1)>,
 L<openssl-dsaparam(1)>
 
+=head1 HISTORY
+
+This command was deprecated in OpenSSL 3.0.
+
 =head1 COPYRIGHT
 
-Copyright 2003-2019 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2003-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/recipes/15-test_ec.t
+++ b/test/recipes/15-test_ec.t
@@ -16,15 +16,18 @@ use OpenSSL::Test::Utils;
 
 setup("test_ec");
 
-plan tests => 11;
+plan tests => 14;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
 ok(run(test(["ectest"])), "running ectest");
 
+# TODO: remove these when the 'ec' app is removed.
+# Also consider moving this to the 20-25 test section because it is testing
+# the command line tool in addition to the algorithm.
 SKIP: {
     skip "Skipping EC conversion test", 3
-        if disabled("ec");
+        if disabled("ec") || disabled('deprecated-3.0');
 
     subtest 'EC conversions -- private key' => sub {
         tconversion("ec", srctop_file("test","testec-p256.pem"));
@@ -39,28 +42,44 @@ SKIP: {
 }
 
 SKIP: {
+    skip "Skipping PKEY conversion test", 3
+        if disabled("ec");
+
+    subtest 'PKEY conversions -- private key' => sub {
+        tconversion("pkey", srctop_file("test","testec-p256.pem"));
+    };
+    subtest 'PKEY conversions -- private key PKCS#8' => sub {
+        tconversion("pkey", srctop_file("test","testec-p256.pem"), "pkey");
+    };
+    subtest 'PKEY conversions -- public key' => sub {
+        tconversion("pkey", srctop_file("test","testecpub-p256.pem"),
+                    "pkey", "-pubin", "-pubout");
+    };
+}
+
+SKIP: {
     skip "Skipping EdDSA conversion test", 6
         if disabled("ec");
 
     subtest 'Ed25519 conversions -- private key' => sub {
-        tconversion("pkey", srctop_file("test","tested25519.pem"));
+        tconversion("pkey", srctop_file("test", "tested25519.pem"));
     };
     subtest 'Ed25519 conversions -- private key PKCS#8' => sub {
-        tconversion("pkey", srctop_file("test","tested25519.pem"), "pkey");
+        tconversion("pkey", srctop_file("test", "tested25519.pem"), "pkey");
     };
     subtest 'Ed25519 conversions -- public key' => sub {
-        tconversion("pkey", srctop_file("test","tested25519pub.pem"),
+        tconversion("pkey", srctop_file("test", "tested25519pub.pem"),
                     "pkey", "-pubin", "-pubout");
     };
 
     subtest 'Ed448 conversions -- private key' => sub {
-        tconversion("pkey", srctop_file("test","tested448.pem"));
+        tconversion("pkey", srctop_file("test", "tested448.pem"));
     };
     subtest 'Ed448 conversions -- private key PKCS#8' => sub {
-        tconversion("pkey", srctop_file("test","tested448.pem"), "pkey");
+        tconversion("pkey", srctop_file("test", "tested448.pem"), "pkey");
     };
     subtest 'Ed448 conversions -- public key' => sub {
-        tconversion("pkey", srctop_file("test","tested448pub.pem"),
+        tconversion("pkey", srctop_file("test", "tested448pub.pem"),
                     "pkey", "-pubin", "-pubout");
     };
 }

--- a/test/recipes/15-test_ecparam.t
+++ b/test/recipes/15-test_ecparam.t
@@ -23,20 +23,34 @@ plan skip_all => "EC isn't supported in this build"
 my @valid = glob(data_file("valid", "*.pem"));
 my @invalid = glob(data_file("invalid", "*.pem"));
 
-plan tests => scalar @valid + scalar @invalid + scalar @valid + scalar @invalid;
+my $num_tests = scalar @valid + scalar @invalid;
+plan tests => 3 * $num_tests;
 
-foreach (@valid) {
-    ok(run(app([qw{openssl ecparam -noout -check -in}, $_])));
+ SKIP: {
+    skip "Skipping EC tests", 2 * $num_tests
+        if disabled('deprecated-3.0');
+
+    foreach (@valid) {
+        ok(run(app([qw{openssl ecparam -noout -check -in}, $_])));
+    }
+
+    foreach (@valid) {
+        ok(run(app([qw{openssl ecparam -noout -check_named -in}, $_])));
+    }
+
+    foreach (@invalid) {
+        ok(!run(app([qw{openssl ecparam -noout -check -in}, $_])));
+    }
+
+    foreach (@invalid) {
+        ok(!run(app([qw{openssl ecparam -noout -check_named -in}, $_])));
+    }
 }
 
 foreach (@valid) {
-    ok(run(app([qw{openssl ecparam -noout -check_named -in}, $_])));
+    ok(run(app([qw{openssl pkeyparam -noout -check -in}, $_])));
 }
 
 foreach (@invalid) {
-    ok(!run(app([qw{openssl ecparam -noout -check -in}, $_])));
-}
-
-foreach (@invalid) {
-    ok(!run(app([qw{openssl ecparam -noout -check_named -in}, $_])));
+    ok(!run(app([qw{openssl pkeyparam -noout -check -in}, $_])));
 }

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -221,7 +221,10 @@ sub testss {
             SKIP: {
                 $ENV{CN2} = "ECDSA Certificate";
                 skip 'failure', 4 unless
-                    ok(run(app(["openssl", "ecparam", "-name", "P-256",
+                    ok(run(app(["openssl", "genpkey", "-genparam",
+                                "-algorithm", "EC",
+                                "-pkeyopt", "ec_paramgen_curve:P-256",
+                                "-pkeyopt", "ec_param_enc:named_curve",
                                 "-out", "ecp.ss"])),
                        "make EC parameters");
                 skip 'failure', 3 unless


### PR DESCRIPTION
The _ec_ and _ecparam_ command line applications are deprecated.  Instead use the _pkey_, _genpkey_ and _pkeyparam_ commands.

- [x] documentation is added or updated
- [x] tests are added or updated
