### PR TITLE
TEST: add util/wrap.pl and use it

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -351,6 +351,9 @@ CPPFLAGS_Q={- (my $c = $lib_cppflags.$cppflags2.$cppflags1) =~ s|"|""|g;
 # given with /INCLUDE is a fantasy, unfortunately.
 NODEBUG=@
 .FIRST :
+        $(NODEBUG) sourcetop = F$PARSE("$(SRCDIR)","[]A.;",,"SYNTAX_ONLY,NO_CONCEAL") - ".][000000" - "[000000." - "][" - "]A.;" + ".]"
+        $(NODEBUG) DEFINE ossl_sourceroot 'sourcetop'
+        $(NODEBUG) !
         $(NODEBUG) openssl_inc1 = F$PARSE("[.include.openssl]","A.;",,,"syntax_only") - "A.;"
         $(NODEBUG) openssl_inc2 = F$PARSE("{- catdir($config{sourcedir},"[.include.openssl]") -}","A.;",,,"SYNTAX_ONLY") - "A.;"
         $(NODEBUG) internal_inc1 = F$PARSE("[.crypto.include.internal]","A.;",,,"SYNTAX_ONLY") - "A.;"
@@ -401,7 +404,7 @@ NODEBUG=@
 
 # The main targets ###################################################
 
-{- dependmagic('build_sw'); -} : build_libs_nodep, build_modules_nodep, build_programs_nodep
+{- dependmagic('build_sw'); -} : build_libs_nodep, build_modules_nodep, build_programs_nodep copy-utils
 {- dependmagic('build_libs'); -} : build_libs_nodep
 {- dependmagic('build_modules'); -} : build_modules_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
@@ -429,16 +432,12 @@ build_all_generated : $(GENERATED_MANDATORY) $(GENERATED) build_docs
 all : build_sw build_docs
 
 test : tests
-{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep
+{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep copy-utils
         @ ! {- output_off() if $disabled{tests}; "" -}
         DEFINE SRCTOP {- sourcedir() -}
         DEFINE BLDTOP {- builddir() -}
-        DEFINE OPENSSL_ENGINES {- builddir("engines") -}
-        DEFINE OPENSSL_MODULES {- builddir("providers") -}
         IF "$(VERBOSE)" .NES. "" THEN DEFINE VERBOSE "$(VERBOSE)"
         $(PERL) {- sourcefile("test", "run_tests.pl") -} $(TESTS)
-        DEASSIGN OPENSSL_MODULES
-        DEASSIGN OPENSSL_ENGINES
         DEASSIGN BLDTOP
         DEASSIGN SRCTOP
         @ ! {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}
@@ -683,6 +682,14 @@ check_INSTALLTOP :
                 EXIT %x10000002
 
 # Helper targets #####################################################
+
+copy-utils : [.util]wrap.pl
+
+[.util]wrap.pl : configdata.pm
+	@ IF "$(SRCDIR)" .NES. "$(BLDDIR)" THEN -
+		CREATE/DIR/LOG [.util]
+	@ IF "$(SRCDIR)" .NES. "$(BLDDIR)" THEN -
+		COPY/LOG ossl_sourceroot:[util]wrap.pl [.util]
 
 # Developer targets ##################################################
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -468,8 +468,6 @@ test: tests
 	  BLDTOP=$(BLDDIR) \
 	  PERL="$(PERL)" \
 	  EXE_EXT={- platform->binext() -} \
-	  OPENSSL_ENGINES=`cd $(BLDDIR)/engines 2>/dev/null && pwd` \
-	  OPENSSL_MODULES=`cd $(BLDDIR)/providers 2>/dev/null && pwd` \
 	  $(PERL) $(SRCDIR)/test/run_tests.pl $(TESTS) )
 	@ : {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}
 	@echo "Tests are not supported with your chosen Configure options"
@@ -1080,12 +1078,12 @@ tar:
 
 # Helper targets #####################################################
 
-link-utils: $(BLDDIR)/util/opensslwrap.sh
+link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl
 
-$(BLDDIR)/util/opensslwrap.sh: configdata.pm
+$(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/util"; \
-	    ln -sf "../$(SRCDIR)/util/opensslwrap.sh" "$(BLDDIR)/util"; \
+	    ln -sf "../$(SRCDIR)/util/`basename "$@"`" "$(BLDDIR)/util"; \
 	fi
 
 FORCE:

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -357,7 +357,7 @@ PROCESSOR= {- $config{processor} -}
 
 # The main targets ###################################################
 
-{- dependmagic('build_sw'); -}: build_libs_nodep build_modules_nodep build_programs_nodep
+{- dependmagic('build_sw'); -}: build_libs_nodep build_modules_nodep build_programs_nodep copy-utils
 {- dependmagic('build_libs'); -}: build_libs_nodep
 {- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
@@ -385,13 +385,11 @@ build_all_generated: $(GENERATED_MANDATORY) $(GENERATED) build_docs
 all: build_sw build_docs
 
 test: tests
-{- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep
+{- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep copy-utils
 	@{- output_off() if $disabled{tests}; "" -}
 	set SRCTOP=$(SRCDIR)
 	set BLDTOP=$(BLDDIR)
 	set PERL=$(PERL)
-	set OPENSSL_ENGINES=$(MAKEDIR)\engines
-	set OPENSSL_MODULES=$(MAKEDIR)\providers
 	"$(PERL)" "$(SRCDIR)\test\run_tests.pl" $(TESTS)
 	@{- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}
 	@$(ECHO) "Tests are not supported with your chosen Configure options"
@@ -543,6 +541,14 @@ install_html_docs: build_html_docs
                                         "$(INSTALLTOP)\html\man7"
 
 uninstall_html_docs:
+
+# Helper targets #####################################################
+
+copy-utils: $(BLDDIR)\util\wrap.pl
+
+$(BLDDIR)\util\wrap.pl: configdata.pm
+	@if NOT EXIST "$(BLDDIR)\util" mkdir "$(BLDDIR)\util"
+	@if NOT "$(SRCDIR)"=="$(BLDDIR)" copy "$(SRCDIR)\util\$(@F)" "$(BLDDIR)\util"
 
 # Building targets ###################################################
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1545,7 +1545,7 @@ Run all tests in test groups 80 to 99 except for tests in group 90:
 To stochastically verify that the algorithm that produces uniformly distributed
 random numbers is operating correctly (with a false positive rate of 0.01%):
 
-    $ ./util/shlib_wrap.sh test/bntest -stochastic
+    $ ./util/wrap.sh test/bntest -stochastic
 
 Troubleshooting
 ===============

--- a/NOTES.VALGRIND
+++ b/NOTES.VALGRIND
@@ -28,11 +28,11 @@ Test behavior can be modified by adjusting environment variables.
 EXE_SHELL
 
 This variable is used to specify the shell used to execute OpenSSL test
-programs. The default program (util/shlib_wrap.sh) initializes the
-environment to allow programs to find shared libraries. The variable can
-be modified to specify a different executable environment.
+programs. The default wrapper (util/wrap.pl) initializes the environment
+to allow programs to find shared libraries. The variable can be modified
+to specify a different executable environment.
 
-   EXE_SHELL="`/bin/pwd`/util/shlib_wrap.sh valgrind --error-exitcode=1 --leak-check=full -q"
+   EXE_SHELL="`/bin/pwd`/util/wrap.pl valgrind --error-exitcode=1 --leak-check=full -q"
 
 This will start up Valgrind with the default checker (memcheck).
 The --error-exitcode=1 option specifies that Valgrind should exit with an
@@ -62,9 +62,9 @@ INSTALL file in the root of the OpenSSL source tree.
 
 Example command line:
 
-   make test EXE_SHELL="`/bin/pwd`/util/shlib_wrap.sh valgrind --error-exitcode=1 --leak-check=full -q" OPENSSL_ia32cap=":0"
+   make test EXE_SHELL="`/bin/pwd`/util/wrap.pl valgrind --error-exitcode=1 --leak-check=full -q" OPENSSL_ia32cap=":0"
 
 If an error occurs, you can then run the specific test via the TESTS
 variable with the VERBOSE option to gather additional information.
 
-   make test VERBOSE=1 TESTS=test_test EXE_SHELL="`/bin/pwd`/util/shlib_wrap.sh valgrind --error-exitcode=1 --leak-check=full -q" OPENSSL_ia32cap=":0"
+   make test VERBOSE=1 TESTS=test_test EXE_SHELL="`/bin/pwd`/util/wrap.pl valgrind --error-exitcode=1 --leak-check=full -q" OPENSSL_ia32cap=":0"

--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -281,7 +281,7 @@ or for shared builds
 
 ```
 $ CTLOG_FILE=test/ct/log_list.conf  TEST_CERTS_DIR=test/certs \
-  util/shlib_wrap.sh test/ssl_test test/ssl-tests/01-simple.conf
+  util/wrap.pl test/ssl_test test/ssl-tests/01-simple.conf
 ```
 
 Note that the test expectations sometimes depend on the Configure settings. For

--- a/util/wrap.pl
+++ b/util/wrap.pl
@@ -1,0 +1,43 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+
+use File::Basename;
+use File::Spec::Functions;
+
+my $there = canonpath(catdir(dirname($0), updir()));
+my $std_engines = catdir($there, 'engines');
+my $std_providers = catdir($there, 'providers');
+my $unix_shlib_wrap = catfile($there, 'util/shlib_wrap.sh');
+
+$ENV{OPENSSL_ENGINES} = $std_engines
+    if ($ENV{OPENSSL_ENGINES} // '') eq '' && -d $std_engines;
+$ENV{OPENSSL_MODULES} = $std_providers
+    if ($ENV{OPENSSL_MODULES} // '') eq '' && -d $std_providers;
+
+my $use_system = 0;
+my @cmd;
+
+if (($ENV{EXE_SHELL} // '') ne '') {
+    # We don't know what $ENV{EXE_SHELL} contains, so we must use the one
+    # string form to ensure that exec invokes a shell as needed.
+    @cmd = ( join(' ', $ENV{EXE_SHELL}, @ARGV) );
+} elsif (-x $unix_shlib_wrap) {
+    @cmd = ( $unix_shlib_wrap, @ARGV );
+} else {
+    # Hope for the best
+    @cmd = ( @ARGV );
+}
+
+# The exec() statement on MSWin32 doesn't seem to give back the exit code
+# from the call, so we resort to using system() instead.
+my $waitcode = system @cmd;
+
+# According to documentation, -1 means that system() couldn't run the command,
+# otherwise, the value is similar to the Unix wait() status value
+# (exitcode << 8 | signalcode)
+die "wrap.pl: Failed to execute '", join(' ', @cmd), "': $!\n"
+    if $waitcode == -1;
+exit($? & 255) if ($? & 255) != 0;
+exit($? >> 8);


### PR DESCRIPTION
util/wrap.pl is a script that defines the environment variables
OPENSSL_ENGINES and OPENSSL_MODULES, then calls the command line
that's given as its arguments.

On a POSIX platform, the command line call is done via
util/shlib_wrap.sh to ensure that the shared library paths are
correct.  For other platforms, util/wrap.pl currently assumes that
similar things are already in place through other means.

-----

This is an alternative to #11100 