### PR TITLE
pkey: update command line tool examples in light of deprecations.

### DIFF
--- a/doc/man1/openssl-dsa.pod.in
+++ b/doc/man1/openssl-dsa.pod.in
@@ -127,6 +127,9 @@ a public key.
 
 =head1 EXAMPLES
 
+Examples equivalent to these can be found in the documentation for the
+non-deprecated L<openssl-pkey(1)> command.
+
 To remove the pass phrase on a DSA private key:
 
  openssl dsa -in key.pem -out keyout.pem

--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -145,6 +145,9 @@ This option checks the consistency of an EC private or public key.
 
 =head1 EXAMPLES
 
+Examples equivalent to these can be found in the documentation for the
+non-deprecated L<openssl-pkey(1)> command.
+
 To encrypt a private key using triple DES:
 
  openssl ec -in key.pem -des3 -out keyout.pem

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -134,6 +134,9 @@ This option will generate an EC private key using the specified parameters.
 
 =head1 EXAMPLES
 
+Examples equivalent to these can be found in the documentation for the
+non-deprecated L<openssl-genpkey(1)> and L<openssl-pkeyparam(1)> commands.
+
 To create EC parameters with the group 'prime192v1':
 
   openssl ecparam -out ec_param.pem -name prime192v1

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -28,6 +28,8 @@ B<openssl> B<pkey>
 [B<-pubout>]
 [B<-check>]
 [B<-pubcheck>]
+[B<-ec_conv_form> I<arg>]
+[B<-ec_param_enc> I<arg>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 
 =for openssl ifdef engine
@@ -114,6 +116,30 @@ components.
 This option checks the correctness of either a public key or the public component
 of a key pair.
 
+=item B<-ec_conv_form> I<arg>
+
+This option only applies to elliptic curve based public and private keys.
+
+This specifies how the points on the elliptic curve are converted
+into octet strings. Possible values are: B<compressed> (the default
+value), B<uncompressed> and B<hybrid>. For more information regarding
+the point conversion forms please read the X9.62 standard.
+B<Note> Due to patent issues the B<compressed> option is disabled
+by default for binary curves and can be enabled by defining
+the preprocessor macro B<OPENSSL_EC_BIN_PT_COMP> at compile time.
+
+=item B<-ec_param_enc> I<arg>
+
+This option only applies to elliptic curve based public and private keys.
+
+This specifies how the elliptic curve parameters are encoded.
+Possible value are: B<named_curve>, i.e. the ec parameters are
+specified by an OID, or B<explicit> where the ec parameters are
+explicitly given (see RFC 3279 for the definition of the
+EC parameters structures). The default value is B<named_curve>.
+B<Note> the B<implicitlyCA> alternative, as specified in RFC 3279,
+is currently not implemented in OpenSSL.
+
 {- $OpenSSL::safe::opt_engine_item -}
 
 =back
@@ -143,6 +169,14 @@ To print out the public components of a private key to standard output:
 To just output the public part of a private key:
 
  openssl pkey -in key.pem -pubout -out pubkey.pem
+
+To change the EC parameters encoding to B<explicit>:
+
+ openssl pkey -in key.pem -ec_param_enc explicit -out keyout.pem
+
+To change the EC point conversion form to B<compressed>:
+
+ openssl pkey -in key.pem -ec_conv_form compressed -out keyout.pem
 
 =head1 SEE ALSO
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -120,7 +120,7 @@ of a key pair.
 
 =head1 EXAMPLES
 
-To remove the pass phrase on an RSA private key:
+To remove the pass phrase on a private key:
 
  openssl pkey -in key.pem -out keyout.pem
 

--- a/doc/man1/openssl-rsa.pod.in
+++ b/doc/man1/openssl-rsa.pod.in
@@ -140,6 +140,9 @@ Like B<-pubin> and B<-pubout> except B<RSAPublicKey> format is used instead.
 
 =head1 EXAMPLES
 
+Examples equivalent to these can be found in the documentation for the
+non-deprecated L<openssl-pkey(1)> command.
+
 To remove the pass phrase on an RSA private key:
 
  openssl rsa -in key.pem -out keyout.pem

--- a/doc/man1/openssl-rsautl.pod.in
+++ b/doc/man1/openssl-rsautl.pod.in
@@ -135,6 +135,9 @@ used to sign or verify small pieces of data.
 
 =head1 EXAMPLES
 
+Examples equivalent to these can be found in the documentation for the
+non-deprecated L<openssl-pkeyutl(1)> command.
+
 Sign some data using a private key:
 
  openssl rsautl -sign -in file -inkey key.pem -out sig


### PR DESCRIPTION
Specifically, refer from the deprecated tools to the pkey equivalents.

- [x] documentation is added or updated
- [ ] tests are added or updated
