### PR TITLE
EdDSA support for DTLSv1.2

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3527,16 +3527,20 @@ void ssl_set_masks(SSL *s)
         if (ecdsa_ok)
             mask_a |= SSL_aECDSA;
     }
-    /* Allow Ed25519 for TLS 1.2 if peer supports it */
+    /* Allow Ed25519 for (D)TLS 1.2 if peer supports it */
     if (!(mask_a & SSL_aECDSA) && ssl_has_cert(s, SSL_PKEY_ED25519)
             && pvalid[SSL_PKEY_ED25519] & CERT_PKEY_EXPLICIT_SIGN
-            && TLS1_get_version(s) == TLS1_2_VERSION)
+            && (TLS1_get_version(s) == TLS1_2_VERSION
+                || (SSL_IS_DTLS(s)
+                    && DTLS_VERSION_GE(s->version, DTLS1_2_VERSION))))
             mask_a |= SSL_aECDSA;
 
-    /* Allow Ed448 for TLS 1.2 if peer supports it */
+    /* Allow Ed448 for (D)TLS 1.2 if peer supports it */
     if (!(mask_a & SSL_aECDSA) && ssl_has_cert(s, SSL_PKEY_ED448)
             && pvalid[SSL_PKEY_ED448] & CERT_PKEY_EXPLICIT_SIGN
-            && TLS1_get_version(s) == TLS1_2_VERSION)
+            && (TLS1_get_version(s) == TLS1_2_VERSION
+                || (SSL_IS_DTLS(s)
+                    && DTLS_VERSION_GE(s->version, DTLS1_2_VERSION))))
             mask_a |= SSL_aECDSA;
 #endif
 


### PR DESCRIPTION
This patch enables EdDSA support for DTLSv1.2 as specified in RFC 8422. While
the RFC does not explicitly state that these algorithms are applicable
to DTLS, the IANA registry contains DTLS-OK for the following entries:

  - Cipher Suites [1]

    TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (RFC5289)
    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA    (RFC8422)

  - Signature Algorithms [2]

    ed25519 (RFC8422)
    ed448   (RFC8422)

Testing:

  - TLSv1.2 handshake passes with the cipher suites of interest:

    $ openssl genpkey -algorithm ed25519 -out key.pem
    $ openssl req -new -out cert.csr -key key.pem
    $ openssl x509 -req -days 700 -in cert.csr -signkey key.pem -out cert.pem
    $ openssl s_server -tls1_2 -cert cert.pem -key key.pem -accept :12345
    $ openssl s_client -tls1_2 -connect localhost:12345

      New, TLSv1.2, Cipher is ECDHE-ECDSA-AES256-GCM-SHA384

  - DTLSv1.2 handshake fails with the cipher suites of interest

    $ openssl s_server -dtls1_2 -cert cert.pem -key key.pem -accept :12345
    $ openssl s_client -dtls1_2 -connect localhost:12345

      Server: [...]tls_post_process_client_hello:no shared cipher[...]
      Client: [...]dtls1_read_bytes:sslv3 alert handshake failure[...]

After the application of this patch DTLSv1.2 handshake succeeds.

[1] https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
[2] https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16