### PR TITLE
Don't exclude quite so much in a no-sock build

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -715,6 +715,7 @@ static BIO *HTTP_new_bio(const char *server, const char *server_port,
  end:
     return cbio;
 }
+#endif /* OPENSSL_NO_SOCK */
 
 static ASN1_VALUE *BIO_mem_d2i(BIO *mem, const ASN1_ITEM *it)
 {
@@ -731,6 +732,9 @@ static BIO *OSSL_HTTP_REQ_CTX_transfer(OSSL_HTTP_REQ_CTX *rctx)
 {
     int sending = 1;
     int rv;
+#ifndef OPENSSL_NO_SOCK
+    int issock = BIO_get_fd(rctx->rbio, NULL) > 0;
+#endif
 
     if (rctx == NULL) {
         HTTPerr(0, ERR_R_PASSED_NULL_PARAMETER);
@@ -743,9 +747,11 @@ static BIO *OSSL_HTTP_REQ_CTX_transfer(OSSL_HTTP_REQ_CTX *rctx)
             break;
         /* BIO_should_retry was true */
         sending = 0;
+#ifndef OPENSSL_NO_SOCK
         /* will not actually wait if rctx->max_time == 0 */
-        if (BIO_wait(rctx->rbio, rctx->max_time) <= 0)
+        if (issock && BIO_wait(rctx->rbio, rctx->max_time) <= 0)
             return NULL;
+#endif
     }
 
     if (rv == 0) {
@@ -840,12 +846,19 @@ BIO *OSSL_HTTP_transfer(const char *server, const char *port, const char *path,
 
     if (bio != NULL)
         cbio = bio;
+#ifndef OPENSSL_NO_SOCK
     else if ((cbio = HTTP_new_bio(server, port, proxy, proxy_port)) == NULL)
         return NULL;
+#else
+    else
+        return NULL;
+#endif
 
     (void)ERR_set_mark(); /* prepare removing any spurious libssl errors */
-    if (rbio == NULL && BIO_connect_retry(cbio, timeout) <= 0)
+#ifndef OPENSSL_NO_SOCK
+    if (bio == NULL && rbio == NULL && BIO_connect_retry(cbio, timeout) <= 0)
         goto end;
+#endif
     /* now timeout is guaranteed to be >= 0 */
 
     /* callback can be used to wrap or prepend TLS session */
@@ -1106,16 +1119,23 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
     char *mbuf = OPENSSL_malloc(BUF_SIZE);
     char *mbufp;
     int read_len = 0;
-    int rv;
     int ret = 0;
     BIO *fbio = BIO_new(BIO_f_buffer());
+#ifndef OPENSSL_NO_SOCK
+    int rv;
     time_t max_time = timeout > 0 ? time(NULL) + timeout : 0;
+    int issocket;
+#endif
 
     if (bio == NULL || server == NULL || port == NULL
             || (bio_err != NULL && prog == NULL)) {
         HTTPerr(0, ERR_R_PASSED_NULL_PARAMETER);
         goto end;
     }
+
+#ifndef OPENSSL_NO_SOCK
+    issocket = BIO_get_fd(bio, NULL) > 0;
+#endif
 
     if (mbuf == NULL || fbio == NULL) {
         BIO_printf(bio_err /* may be NULL */, "%s: out of memory", prog);
@@ -1168,12 +1188,16 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
 
     for (;;) {
         /* will not actually wait if timeout == 0 */
-        rv = BIO_wait(fbio, max_time);
-        if (rv <= 0) {
-            BIO_printf(bio_err, "%s: HTTP CONNECT %s\n", prog,
-                       rv == 0 ? "timed out" : "failed waiting for data");
-            goto end;
+#ifndef OPENSSL_NO_SOCK
+        if (issocket) {
+            rv = BIO_wait(fbio, max_time);
+            if (rv <= 0) {
+                BIO_printf(bio_err, "%s: HTTP CONNECT %s\n", prog,
+                           rv == 0 ? "timed out" : "failed waiting for data");
+                goto end;
+            }
         }
+#endif
 
         /*-
          * The first line is the HTTP response.
@@ -1238,4 +1262,3 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
 # undef BUF_SIZE
 }
 
-#endif /* !defined(OPENSSL_NO_SOCK) */

--- a/crypto/http/http_local.h
+++ b/crypto/http/http_local.h
@@ -22,9 +22,7 @@ typedef OCSP_REQ_CTX OSSL_HTTP_REQ_CTX;
 # define OSSL_HTTP_REQ_CTX_add1_header OCSP_REQ_CTX_add1_header
 # define OSSL_HTTP_REQ_CTX_i2d         OCSP_REQ_CTX_i2d
 # define OSSL_HTTP_REQ_CTX_nbio        OCSP_REQ_CTX_nbio
-# ifndef OPENSSL_NO_SOCK
-#  define OSSL_HTTP_REQ_CTX_sendreq_d2i OCSP_REQ_CTX_nbio_d2i
-# endif
+# define OSSL_HTTP_REQ_CTX_sendreq_d2i OCSP_REQ_CTX_nbio_d2i
 /* functions that are meanwhile unused */
 # define OSSL_HTTP_REQ_CTX_get0_mem_bio OCSP_REQ_CTX_get0_mem_bio /* undoc'd */
 # define OSSL_HTTP_REQ_CTX_set_max_response_length OCSP_set_max_response_length

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -35,7 +35,6 @@ OCSP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path, OCSP_REQUEST *req,
     return res;
 }
 
-# ifndef OPENSSL_NO_SOCK
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OCSP_REQ_CTX *rctx)
 {
     *presp = (OCSP_RESPONSE *)
@@ -60,6 +59,4 @@ OCSP_RESPONSE *OCSP_sendreq_bio(BIO *b, const char *path, OCSP_REQUEST *req)
 
     return rv == 1 ? resp : NULL;
 }
-# endif /* !defined(OPENSSL_NO_SOCK) */
-
 #endif /* !defined(OPENSSL_NO_OCSP) */

--- a/include/openssl/http.h
+++ b/include/openssl/http.h
@@ -24,7 +24,7 @@ extern "C" {
 # endif
 
 typedef BIO *(*OSSL_HTTP_bio_cb_t)(BIO *bio, void *arg, int connect, int detail);
-# ifndef OPENSSL_NO_SOCK
+
 BIO *OSSL_HTTP_get(const char *url, const char *proxy, const char *proxy_port,
                    BIO *bio, BIO *rbio,
                    OSSL_HTTP_bio_cb_t bio_update_fn, void *arg,
@@ -62,7 +62,7 @@ BIO *OSSL_HTTP_transfer(const char *server, const char *port, const char *path,
 int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
                             const char *proxyuser, const char *proxypass,
                             int timeout, BIO *bio_err, const char *prog);
-# endif
+
 int OSSL_HTTP_parse_url(const char *url, char **phost, char **pport,
                         char **ppath, int *pssl);
 

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -68,9 +68,7 @@ int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
 int OCSP_REQ_CTX_i2d(OCSP_REQ_CTX *rctx, const char *content_type,
                      const ASN1_ITEM *it, ASN1_VALUE *req);
 int OCSP_REQ_CTX_nbio(OCSP_REQ_CTX *rctx);
-# ifndef OPENSSL_NO_SOCK
 ASN1_VALUE *OCSP_REQ_CTX_nbio_d2i(OCSP_REQ_CTX *rctx, const ASN1_ITEM *it);
-# endif
 BIO *OCSP_REQ_CTX_get0_mem_bio(OCSP_REQ_CTX *rctx);
 void OCSP_set_max_response_length(OCSP_REQ_CTX *rctx, unsigned long len);
 /* End of functions used only internally */
@@ -187,9 +185,7 @@ DECLARE_ASN1_DUP_FUNCTION(OCSP_CERTID)
 OCSP_RESPONSE *OCSP_sendreq_bio(BIO *b, const char *path, OCSP_REQUEST *req);
 OCSP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path, OCSP_REQUEST *req,
                                int maxline);
-#  ifndef OPENSSL_NO_SOCK
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OCSP_REQ_CTX *rctx);
-#  endif
 
 /* TODO: remove this (documented but) meanwhile obsolete function? */
 int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, const OCSP_REQUEST *req);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -615,7 +615,7 @@ UI_get0_result_string                   629	3_0_0	EXIST::FUNCTION:
 TS_RESP_CTX_add_policy                  630	3_0_0	EXIST::FUNCTION:TS
 X509_REQ_dup                            631	3_0_0	EXIST::FUNCTION:
 d2i_DSA_PUBKEY_fp                       633	3_0_0	EXIST::FUNCTION:DSA,STDIO
-OCSP_REQ_CTX_nbio_d2i                   634	3_0_0	EXIST::FUNCTION:SOCK
+OCSP_REQ_CTX_nbio_d2i                   634	3_0_0	EXIST::FUNCTION:
 d2i_X509_REQ_fp                         635	3_0_0	EXIST::FUNCTION:STDIO
 DH_OpenSSL                              636	3_0_0	EXIST::FUNCTION:DH
 BN_get_rfc3526_prime_8192               637	3_0_0	EXIST::FUNCTION:DH
@@ -3615,7 +3615,7 @@ EVP_CIPHER_CTX_encrypting               3694	3_0_0	EXIST::FUNCTION:
 EC_KEY_can_sign                         3695	3_0_0	EXIST::FUNCTION:EC
 PEM_write_bio_RSAPublicKey              3696	3_0_0	EXIST::FUNCTION:RSA
 X509_CRL_set1_lastUpdate                3697	3_0_0	EXIST::FUNCTION:
-OCSP_sendreq_nbio                       3698	3_0_0	EXIST::FUNCTION:OCSP,SOCK
+OCSP_sendreq_nbio                       3698	3_0_0	EXIST::FUNCTION:OCSP
 PKCS8_encrypt                           3699	3_0_0	EXIST::FUNCTION:
 i2d_PKCS7_fp                            3700	3_0_0	EXIST::FUNCTION:STDIO
 i2d_X509_REQ                            3701	3_0_0	EXIST::FUNCTION:
@@ -4923,11 +4923,11 @@ BIO_wait                                ?	3_0_0	EXIST::FUNCTION:SOCK
 BIO_socket_wait                         ?	3_0_0	EXIST::FUNCTION:SOCK
 BIO_connect_retry                       ?	3_0_0	EXIST::FUNCTION:SOCK
 ERR_load_HTTP_strings                   ?	3_0_0	EXIST::FUNCTION:
-OSSL_HTTP_get                           ?	3_0_0	EXIST::FUNCTION:SOCK
-OSSL_HTTP_get_asn1                      ?	3_0_0	EXIST::FUNCTION:SOCK
-OSSL_HTTP_post_asn1                     ?	3_0_0	EXIST::FUNCTION:SOCK
-OSSL_HTTP_transfer                      ?	3_0_0	EXIST::FUNCTION:SOCK
-OSSL_HTTP_proxy_connect                 ?	3_0_0	EXIST::FUNCTION:SOCK
+OSSL_HTTP_get                           ?	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_get_asn1                      ?	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_post_asn1                     ?	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_transfer                      ?	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_proxy_connect                 ?	3_0_0	EXIST::FUNCTION:
 ERR_add_error_txt                       ?	3_0_0	EXIST::FUNCTION:
 ERR_add_error_mem_bio                   ?	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_print_verify_cb          ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
We were excluding more code than we needed to in the OCSP/HTTP code in
the event of no-sock. We should also not assume that a BIO passed to our
API is socket based.

This fixes the no-sock build