### PR TITLE
Add *.d.tmp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ Makefile.save
 *.bak
 cscope.*
 *.d
+*.d.tmp
 pod2htmd.tmp
 
 # Windows manifest files


### PR DESCRIPTION
These are temporary files generated by the build process that should not
be checked in.