### PR TITLE
Use "command" not "tool" or "utility"

### DIFF
--- a/doc/man1/openssl-asn1parse.pod.in
+++ b/doc/man1/openssl-asn1parse.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-asn1parse - ASN.1 parsing tool
+openssl-asn1parse - ASN.1 parsing command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -156,7 +156,7 @@ Names and values of these options are algorithm-specific.
 
 The password used to encrypt the private key. Since on some
 systems the command line arguments are visible (e.g. Unix with
-the L<ps(1)> utility) this option should be used with caution.
+the L<ps(1)> command) this option should be used with caution.
 
 =item B<-selfsign>
 
@@ -712,8 +712,8 @@ numbers of certificates are present because, as the name implies
 the database has to be kept in memory.
 
 This command really needs rewriting or the required functionality
-exposed at either a command or interface level so a more friendly utility
-(perl script or GUI) can handle things properly. The script
+exposed at either a command or interface level so that a more user-friendly
+replacement could handle things properly. The script
 B<CA.pl> helps a little but not very much.
 
 Any fields in a request that are not present in a policy are silently

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -155,8 +155,9 @@ Names and values of these options are algorithm-specific.
 =for openssl foreign manual ps(1)
 
 The password used to encrypt the private key. Since on some
-systems the command line arguments are visible (e.g. Unix with
-the L<ps(1)> command) this option should be used with caution.
+systems the command line arguments are visible (e.g., when using
+L<ps(1)> on Unix),
+this option should be used with caution.
 
 =item B<-selfsign>
 

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-ciphers - SSL cipher display and cipher list tool
+openssl-ciphers - SSL cipher display and cipher list command
 
 =head1 SYNOPSIS
 
@@ -31,7 +31,7 @@ B<openssl> B<ciphers>
 =head1 DESCRIPTION
 
 This command converts textual OpenSSL cipher lists into
-ordered SSL cipher preference lists. It can be used as a test tool to
+ordered SSL cipher preference lists. It can be used when testing to
 determine the appropriate cipherlist.
 
 =head1 OPTIONS

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -31,7 +31,7 @@ B<openssl> B<ciphers>
 =head1 DESCRIPTION
 
 This command converts textual OpenSSL cipher lists into
-ordered SSL cipher preference lists. It can be used when testing to
+ordered SSL cipher preference lists. It can be used to
 determine the appropriate cipherlist.
 
 =head1 OPTIONS

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-cms - CMS utility
+openssl-cms - CMS command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-crl - CRL utility
+openssl-crl - CRL command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-ocsp - Online Certificate Status Protocol utility
+openssl-ocsp - Online Certificate Status Protocol command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-pkcs12 - PKCS#12 file utility
+openssl-pkcs12 - PKCS#12 file command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-pkcs7.pod.in
+++ b/doc/man1/openssl-pkcs7.pod.in
@@ -7,7 +7,7 @@
 
 =head1 NAME
 
-openssl-pkcs7 - PKCS#7 utility
+openssl-pkcs7 - PKCS#7 command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-pkcs8 - PKCS#8 format private key conversion tool
+openssl-pkcs8 - PKCS#8 format private key conversion command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -7,7 +7,7 @@
 
 =head1 NAME
 
-openssl-pkey - public or private key processing tool
+openssl-pkey - public or private key processing command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-pkeyparam.pod.in
+++ b/doc/man1/openssl-pkeyparam.pod.in
@@ -7,7 +7,7 @@
 
 =head1 NAME
 
-openssl-pkeyparam - public key algorithm parameter processing tool
+openssl-pkeyparam - public key algorithm parameter processing command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-pkeyutl - public key algorithm utility
+openssl-pkeyutl - public key algorithm command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-req - PKCS#10 certificate request and certificate generating utility
+openssl-req - PKCS#10 certificate request and certificate generating command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-rsa.pod.in
+++ b/doc/man1/openssl-rsa.pod.in
@@ -7,7 +7,7 @@
 
 =head1 NAME
 
-openssl-rsa - RSA key processing tool
+openssl-rsa - RSA key processing command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-rsautl.pod.in
+++ b/doc/man1/openssl-rsautl.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-rsautl - RSA utility
+openssl-rsautl - RSA command
 
 =head1 SYNOPSIS
 
@@ -167,7 +167,7 @@ encrypt and decrypt the block would have been of type 2 (the second byte)
 and random padding data visible instead of the 0xff bytes.
 
 It is possible to analyse the signature of certificates using this
-utility in conjunction with L<openssl-asn1parse(1)>. Consider the self signed
+command in conjunction with L<openssl-asn1parse(1)>. Consider the self signed
 example in F<certs/pca-cert.pem>. Running L<openssl-asn1parse(1)> as follows
 yields:
 

--- a/doc/man1/openssl-sess_id.pod.in
+++ b/doc/man1/openssl-sess_id.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-sess_id - SSL/TLS session handling utility
+openssl-sess_id - SSL/TLS session handling command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-smime - S/MIME utility
+openssl-smime - S/MIME command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -7,7 +7,7 @@
 
 =head1 NAME
 
-openssl-spkac - SPKAC printing and generating utility
+openssl-spkac - SPKAC printing and generating command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-storeutl.pod.in
+++ b/doc/man1/openssl-storeutl.pod.in
@@ -7,7 +7,7 @@
 
 =head1 NAME
 
-openssl-storeutl - STORE utility
+openssl-storeutl - STORE command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-ts - Time Stamping Authority tool (client/server)
+openssl-ts - Time Stamping Authority command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-verify - Utility to verify certificates
+openssl-verify - certificate verification command
 
 =head1 SYNOPSIS
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-x509 - Certificate display and signing utility
+openssl-x509 - Certificate display and signing command
 
 =head1 SYNOPSIS
 
@@ -81,7 +81,7 @@ B<openssl> B<x509>
 
 =head1 DESCRIPTION
 
-This command is a multi purpose certificate utility. It can
+This command is a multi-purposes certificate utility. It can
 be used to display certificate information, convert certificates to
 various forms, sign certificate requests like a "mini CA" or edit
 certificate trust settings.

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -81,7 +81,7 @@ B<openssl> B<x509>
 
 =head1 DESCRIPTION
 
-This command is a multi-purposes certificate utility. It can
+This command is a multi-purposes certificate command. It can
 be used to display certificate information, convert certificates to
 various forms, sign certificate requests like a "mini CA" or edit
 certificate trust settings.

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-openssl - OpenSSL command line tool
+openssl - OpenSSL command line program
 
 =head1 SYNOPSIS
 
@@ -29,7 +29,7 @@ OpenSSL is a cryptography toolkit implementing the Secure Sockets Layer (SSL
 v2/v3) and Transport Layer Security (TLS v1) network protocols and related
 cryptography standards required by them.
 
-The B<openssl> program is a command line tool for using the various
+The B<openssl> program is a command line program for using the various
 cryptography functions of OpenSSL's B<crypto> library from the shell.
 It can be used for
 
@@ -104,7 +104,7 @@ Cipher Suite Description Determination.
 
 =item B<cms>
 
-CMS (Cryptographic Message Syntax) utility.
+CMS (Cryptographic Message Syntax) command.
 
 =item B<crl>
 
@@ -196,7 +196,7 @@ Create or examine a Netscape certificate sequence.
 
 =item B<ocsp>
 
-Online Certificate Status Protocol utility.
+Online Certificate Status Protocol command.
 
 =item B<passwd>
 
@@ -212,7 +212,7 @@ PKCS#7 Data Management.
 
 =item B<pkcs8>
 
-PKCS#8 format private key conversion tool.
+PKCS#8 format private key conversion command.
 
 =item B<pkey>
 
@@ -224,7 +224,7 @@ Public key algorithm parameter management.
 
 =item B<pkeyutl>
 
-Public key algorithm cryptographic operation utility.
+Public key algorithm cryptographic operation command.
 
 =item B<prime>
 
@@ -252,7 +252,7 @@ RSA key management.
 
 =item B<rsautl>
 
-RSA utility for signing, verification, encryption, and decryption. Superseded
+RSA command for signing, verification, encryption, and decryption. Superseded
 by  L<openssl-pkeyutl(1)>.
 
 =item B<s_client>
@@ -289,7 +289,7 @@ Algorithm Speed Measurement.
 
 =item B<spkac>
 
-SPKAC printing and generating utility.
+SPKAC printing and generating command.
 
 =item B<srp>
 
@@ -297,11 +297,11 @@ Maintain SRP password file.
 
 =item B<storeutl>
 
-Utility to list and display certificates, keys, CRLs, etc.
+Command to list and display certificates, keys, CRLs, etc.
 
 =item B<ts>
 
-Time Stamping Authority tool (client/server).
+Time Stamping Authority command.
 
 =item B<verify>
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -603,9 +603,9 @@ sub wording {
         if $contents =~ /\bepoch\b/;
     if ( $id =~ m@man1/@ ) {
         err($id, "found 'tool' in NAME, should use 'command'")
-            if $contents =~ /=head1 NAME.*tool.*=head1 SYNOPSIS/s;
+            if $contents =~ /=head1 NAME.*\btool\b.*=head1 SYNOPSIS/s;
         err($id, "found 'utility' in NAME, should use 'command'")
-            if $contents =~ /NAME.*utility.*=head1 SYNOPSIS/s;
+            if $contents =~ /NAME.*\butility\b.*=head1 SYNOPSIS/s;
 
     }
 }

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -601,6 +601,13 @@ sub wording {
     }
     err($id, "found 'epoch' should use 'Epoch'")
         if $contents =~ /\bepoch\b/;
+    if ( $id =~ m@man1/@ ) {
+        err($id, "found 'tool' in NAME, should use 'command'")
+            if $contents =~ /=head1 NAME.*tool.*=head1 SYNOPSIS/s;
+        err($id, "found 'utility' in NAME, should use 'command'")
+            if $contents =~ /NAME.*utility.*=head1 SYNOPSIS/s;
+
+    }
 }
 
 # Perform all sorts of nit/error checks on a manpage


### PR DESCRIPTION
I think this might be doing too much.

I would be happy to remove the find-doc-nits change, and roll back any other editing that wasn't strictly necessary to say "they are called commands"
