### PR TITLE
WIP: Do fips-mode-only test

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -475,6 +475,11 @@ test: tests
 	@echo "Tests are not supported with your chosen Configure options"
 	@ : {- output_on() if !$disabled{tests}; "" -}
 
+test-environ:
+	@echo export SRCTOP="$(SRCDIR)" ';'
+	@echo export BLDTOP="$(BLDDIR)" ';'
+	@echo export PERL="$(PERL)"
+
 list-tests:
 	@ : {- output_off() if $disabled{tests}; "" -}
 	@SRCTOP="$(SRCDIR)" \

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -31,12 +31,13 @@ static OSSL_CALLBACK self_test_events;
 static char *self_test_corrupt_desc = NULL;
 static char *self_test_corrupt_type = NULL;
 static int self_test_log = 1;
+static int quiet = 0;
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_IN, OPT_OUT, OPT_MODULE,
     OPT_PROV_NAME, OPT_SECTION_NAME, OPT_MAC_NAME, OPT_MACOPT, OPT_VERIFY,
-    OPT_NO_LOG, OPT_CORRUPT_DESC, OPT_CORRUPT_TYPE
+    OPT_NO_LOG, OPT_CORRUPT_DESC, OPT_CORRUPT_TYPE, OPT_QUIET
 } OPTION_CHOICE;
 
 const OPTIONS fipsinstall_options[] = {
@@ -60,6 +61,7 @@ const OPTIONS fipsinstall_options[] = {
     {"noout", OPT_NO_LOG, '-', "Disable logging of self test events"},
     {"corrupt_desc", OPT_CORRUPT_DESC, 's', "Corrupt a self test by description"},
     {"corrupt_type", OPT_CORRUPT_TYPE, 's', "Corrupt a self test by type"},
+    {"quiet", OPT_QUIET, '-', "No messages, just exit status"},
     {NULL}
 };
 
@@ -298,6 +300,9 @@ opthelp:
         case OPT_OUT:
             out_fname = opt_arg();
             break;
+        case OPT_QUIET:
+            quiet = 1;
+            /* FALLTHROUGH */
         case OPT_NO_LOG:
             self_test_log = 0;
             break;
@@ -405,7 +410,8 @@ opthelp:
         if (!verify_config(in_fname, section_name, module_mac, module_mac_len,
                            install_mac, install_mac_len))
             goto end;
-        BIO_printf(bio_out, "VERIFY PASSED\n");
+        if (!quiet)
+            BIO_printf(bio_out, "VERIFY PASSED\n");
     } else {
 
         conf = generate_config_and_load(prov_name, section_name, module_mac,
@@ -424,12 +430,13 @@ opthelp:
                                        module_mac_len, install_mac,
                                        install_mac_len))
             goto end;
-        BIO_printf(bio_out, "INSTALL PASSED\n");
+        if (!quiet)
+            BIO_printf(bio_out, "INSTALL PASSED\n");
     }
 
     ret = 0;
 end:
-    if (ret == 1) {
+    if (ret == 1 && !quiet) {
         BIO_printf(bio_err, "%s FAILED\n", verify ? "VERIFY" : "INSTALL");
         ERR_print_errors(bio_err);
     }

--- a/doc/man1/openssl-fipsinstall.pod
+++ b/doc/man1/openssl-fipsinstall.pod
@@ -17,6 +17,7 @@ B<openssl fipsinstall>
 [B<-mac_name> I<macname>]
 [B<-macopt> I<nm>:I<v>]
 [B<-noout>]
+[B<-quiet>]
 [B<-corrupt_desc> I<selftest_description>]
 [B<-corrupt_type> I<selftest_type>]
 
@@ -113,9 +114,12 @@ C<openssl list -digest-commands>.
 
 Disable logging of the self tests.
 
-=item B<-corrupt_desc> I<selftest_description>
+=item B<-quiet>
 
-=item B<-corrupt_type> I<selftest_type>
+Do not output pass/fail messages. Implies B<-noout>.
+
+=item B<-corrupt_desc> I<selftest_description>,
+B<-corrupt_type> I<selftest_type>
 
 The corrupt options can be used to test failure of one or more self test(s) by
 name.

--- a/test/test-fips-only
+++ b/test/test-fips-only
@@ -1,0 +1,51 @@
+#! /bin/bash
+ 
+# Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# Exit on errors.
+set -e
+exec 2>&1
+
+HERE=$(/bin/pwd)
+WORKDIR=$HERE/test/fips-test
+MODULE=$WORKDIR/fips.so
+FIPSCONF=$WORKDIR/fips.conf
+export LD_LIBRARY_PATH=.:..
+
+# Make a working directory
+mkdir -p $WORKDIR
+trap "rm -rf $WORKDIR" 1 2 3 15
+
+cp providers/fips.so $MODULE
+
+# Create a config file with HMAC and verify it.
+./apps/openssl fipsinstall -quiet -out $FIPSCONF -module $MODULE \
+    -provider_name fips -mac_name HMAC -section_name fips_install \
+    -macopt digest:SHA256 -macopt hexkey:00
+./apps/openssl fipsinstall -quiet -in $FIPSCONF -module $MODULE -verify \
+    -provider_name fips -mac_name HMAC -section_name fips_install \
+    -macopt digest:SHA256 -macopt hexkey:00
+
+# Build up full OpenSSL config file
+cat <<EOF >$WORKDIR/openssl.cnf
+openssl_conf = openssl_init
+.include $FIPSCONF
+[openssl_init]
+    providers = provider_sect
+[provider_sect]
+    fips = fips_sect
+EOF
+# cat $WORKDIR/openssl.cnf
+
+# Set up environment
+eval $(make test-environ)
+export OPENSSL_MODULES=$WORKDIR
+export OPENSSL_CONF=$WORKDIR/openssl.cnf
+
+
+$PERL $SRCTOP/test/run_tests.pl test_enc


### PR DESCRIPTION
This is intended to, eventually, be a complete roundtrip testing of OpenSSL with the FIPS module, and only the FIPS module, installed.

The script could eventually become a Perl script.

Thoughts?  Everything passes so I think I have some of the configuration wrong.