### PR TITLE
Remove unneeded switch statement to fix warning

### DIFF
--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -534,17 +534,12 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 static long b64_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
-    long ret = 1;
     BIO *next = BIO_next(b);
 
     if (next == NULL)
         return 0;
-    switch (cmd) {
-    default:
-        ret = BIO_callback_ctrl(next, cmd, fp);
-        break;
-    }
-    return ret;
+
+    return BIO_callback_ctrl(next, cmd, fp);
 }
 
 static int b64_puts(BIO *b, const char *str)

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -388,17 +388,12 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 static long enc_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
-    long ret = 1;
     BIO *next = BIO_next(b);
 
     if (next == NULL)
         return 0;
-    switch (cmd) {
-    default:
-        ret = BIO_callback_ctrl(next, cmd, fp);
-        break;
-    }
-    return ret;
+    
+    return BIO_callback_ctrl(next, cmd, fp);
 }
 
 int BIO_set_cipher(BIO *b, const EVP_CIPHER *c, const unsigned char *k,

--- a/crypto/evp/bio_md.c
+++ b/crypto/evp/bio_md.c
@@ -197,7 +197,6 @@ static long md_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 static long md_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
-    long ret = 1;
     BIO *next;
 
     next = BIO_next(b);
@@ -205,12 +204,7 @@ static long md_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
     if (next == NULL)
         return 0;
 
-    switch (cmd) {
-    default:
-        ret = BIO_callback_ctrl(next, cmd, fp);
-        break;
-    }
-    return ret;
+    return BIO_callback_ctrl(next, cmd, fp);
 }
 
 static int md_gets(BIO *bp, char *buf, int size)

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -406,7 +406,6 @@ static long ok_ctrl(BIO *b, int cmd, long num, void *ptr)
 
 static long ok_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 {
-    long ret = 1;
     BIO *next;
 
     next = BIO_next(b);
@@ -414,13 +413,7 @@ static long ok_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
     if (next == NULL)
         return 0;
 
-    switch (cmd) {
-    default:
-        ret = BIO_callback_ctrl(next, cmd, fp);
-        break;
-    }
-
-    return ret;
+    return BIO_callback_ctrl(next, cmd, fp);
 }
 
 static void longswap(void *_ptr, size_t len)


### PR DESCRIPTION
https://github.com/openssl/openssl/issues/10958

This is a trivial change which has no functional impact, just to fix a couple of warnings.
