### PR TITLE
x86_64: Replace .asciz "GNU" with .byte

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -115,7 +115,12 @@ if ($flavour =~ /elf/) {
 	.long 4f - 1f
 	.long 5
 0:
-	.asciz "GNU"
+	# "GNU" encoded with .byte, since .asciz isn't supported
+	# on Solaris.
+	.byte 0x47
+	.byte 0x4e
+	.byte 0x55
+	.byte 0
 1:
 	.p2align $p2align
 	.long 0xc0000002


### PR DESCRIPTION
Replace .asciz "GNU" with .byte since .asciz isn't supported on Solaris.
This should fix

https://github.com/openssl/openssl/issues/11132

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
