### PR TITLE
bugfix in cmac calculation example

### DIFF
--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -331,7 +331,7 @@ EVP_MAC_do_all_provided() returns nothing at all.
       if (!EVP_MAC_init(ctx))
           goto err;
 
-      while ( (read_l = read(STDIN_FILENO, buf, sizeof(buf))) < 0) {
+      while ( (read_l = read(STDIN_FILENO, buf, sizeof(buf))) > 0) {
           if (!EVP_MAC_update(ctx, buf, read_l))
               goto err;
       }
@@ -361,7 +361,7 @@ look like this:
 
   $ MY_MAC=cmac MY_KEY=secret0123456789 MY_MAC_CIPHER=aes-128-cbc \
     LD_LIBRARY_PATH=. ./foo < foo.c
-  Result: ECCAAFF041B22A2299EB90A1B53B6D45
+  Result: C5C06683CD9DDEF904D754505C560A4E
 
 (in this example, that program was stored in F<foo.c> and compiled to
 F<./foo>)


### PR DESCRIPTION
The example never executes code inside of the while loop, as read()
returns bigger number than 0. Thus the end result is wrong.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
