### PR TITLE
Fixes #11139, making some helpful P7 functions public

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -19,7 +19,7 @@ static int add_attribute(STACK_OF(X509_ATTRIBUTE) **sk, int nid, int atrtype,
                          void *value);
 static ASN1_TYPE *get_attribute(STACK_OF(X509_ATTRIBUTE) *sk, int nid);
 
-static int PKCS7_type_is_other(PKCS7 *p7)
+int PKCS7_type_is_other(PKCS7 *p7)
 {
     int isOther = 1;
 
@@ -42,7 +42,7 @@ static int PKCS7_type_is_other(PKCS7 *p7)
 
 }
 
-static ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7)
+ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7)
 {
     if (PKCS7_type_is_data(p7))
         return p7->d.data;

--- a/include/openssl/pkcs7.h
+++ b/include/openssl/pkcs7.h
@@ -319,6 +319,9 @@ PKCS7 *SMIME_read_PKCS7(BIO *bio, BIO **bcont);
 
 BIO *BIO_new_PKCS7(BIO *out, PKCS7 *p7);
 
+int PKCS7_type_is_other(PKCS7 *p7);
+ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7);
+
 # ifdef  __cplusplus
 }
 # endif


### PR DESCRIPTION
Fixes #11139, making some helpful P7 functions public

Remove static and declare helpful P7 functions for all to use.  This will enable others to leverage these helper functions rather than manipulating the structure themselves, resulting in more readable and compact code elsewhere.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
