### PR TITLE
AES CTR-DRGB: do not leak timing information

### DIFF
--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -12,6 +12,7 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include "crypto/modes.h"
 #include "internal/thread_once.h"
 #include "rand_local.h"
 
@@ -20,19 +21,15 @@
  */
 static void inc_128(RAND_DRBG_CTR *ctr)
 {
-    int i;
-    unsigned char c;
-    unsigned char *p = &ctr->V[15];
+    unsigned char *p = &ctr->V[0];
+    u32 n = 16, c = 1;
 
-    for (i = 0; i < 16; i++, p--) {
-        c = *p;
-        c++;
-        *p = c;
-        if (c != 0) {
-            /* If we didn't wrap around, we're done. */
-            break;
-        }
-    }
+    do {
+        --n;
+        c += p[n];
+        p[n] = (u8)c;
+        c >>= 8;
+    } while (n);
 }
 
 static void ctr_XOR(RAND_DRBG_CTR *ctr, const unsigned char *in, size_t inlen)


### PR DESCRIPTION
10.2.1.1 CTR_DRBG Internal State, NIST SP 800-90A Rev. 1 :
> The values of V and Key are the critical values of the internal state upon which the security of this DRBG mechanism depends (i.e., V and Key are the “secret values” of the internal state). 

So better not leak any timing information when incrementing V.