### PR TITLE
Configure: Avoid SIXTY_FOUR_BIT for linux-mips64

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -741,7 +741,7 @@ my %targets = (
         inherit_from     => [ "linux-generic32", asm("mips64_asm") ],
         cflags           => add("-mabi=n32"),
         cxxflags         => add("-mabi=n32"),
-        bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR",
+        bn_ops           => "RC4_CHAR",
         perlasm_scheme   => "n32",
         multilib         => "32",
     },


### PR DESCRIPTION
This is a 32-bit ABI build (as opposed to linux64-mips64).
Setting SIXTY_FOUR_BIT breaks hardware optimizations, at least on
octeon processors.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
