### PR TITLE
EVP: Adapt EVP_PKEY checking, comparing and copying for provider keys, take 3

### DIFF
--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -337,3 +337,8 @@ int DSA_bits(const DSA *dsa)
 {
     return BN_num_bits(dsa->params.p);
 }
+
+FFC_PARAMS *dsa_get0_params(DSA *dsa)
+{
+    return &dsa->params;
+}

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -92,6 +92,7 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_import_types_fn *import_types;
     OSSL_OP_keymgmt_export_fn *export;
     OSSL_OP_keymgmt_export_types_fn *export_types;
+    OSSL_OP_keymgmt_copy_fn *copy;
 } /* EVP_KEYMGMT */ ;
 
 struct evp_keyexch_st {

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -85,6 +85,7 @@ struct evp_keymgmt_st {
     OSSL_OP_keymgmt_query_operation_name_fn *query_operation_name;
     OSSL_OP_keymgmt_has_fn *has;
     OSSL_OP_keymgmt_validate_fn *validate;
+    OSSL_OP_keymgmt_match_fn *match;
 
     /* Import and export routines */
     OSSL_OP_keymgmt_import_fn *import;

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -214,3 +214,12 @@ void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
 
     return keydata;
 }
+
+int evp_keymgmt_util_has(EVP_PKEY *pk, int selection)
+{
+    /* Check if key is even assigned */
+    if (pk->keymgmt == NULL)
+        return 0;
+
+    return evp_keymgmt_has(pk->keymgmt, pk->keydata, selection);
+}

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -335,3 +335,13 @@ const OSSL_PARAM *evp_keymgmt_export_types(const EVP_KEYMGMT *keymgmt,
         return NULL;
     return keymgmt->export_types(selection);
 }
+
+int evp_keymgmt_copy(const EVP_KEYMGMT *keymgmt,
+                     void *keydata_to, const void *keydata_from,
+                     int selection)
+{
+    /* We assume no copy if the implementation doesn't have a function */
+    if (keymgmt->copy == NULL)
+        return 0;
+    return keymgmt->copy(keydata_to, keydata_from, selection);
+}

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -95,6 +95,10 @@ static void *keymgmt_from_dispatch(int name_id,
             if (keymgmt->validate == NULL)
                 keymgmt->validate = OSSL_get_OP_keymgmt_validate(fns);
             break;
+        case OSSL_FUNC_KEYMGMT_MATCH:
+            if (keymgmt->match == NULL)
+                keymgmt->match = OSSL_get_OP_keymgmt_match(fns);
+            break;
         case OSSL_FUNC_KEYMGMT_IMPORT:
             if (keymgmt->import == NULL) {
                 importfncnt++;
@@ -288,6 +292,16 @@ int evp_keymgmt_validate(const EVP_KEYMGMT *keymgmt, void *keydata,
     if (keymgmt->validate == NULL)
         return 1;
     return keymgmt->validate(keydata, selection);
+}
+
+int evp_keymgmt_match(const EVP_KEYMGMT *keymgmt,
+                      const void *keydata1, const void *keydata2,
+                      int selection)
+{
+    /* We assume no match if the implementation doesn't have a function */
+    if (keymgmt->match == NULL)
+        return 0;
+    return keymgmt->match(keydata1, keydata2, selection);
 }
 
 int evp_keymgmt_import(const EVP_KEYMGMT *keymgmt, void *keydata,

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -114,8 +114,13 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 
 int EVP_PKEY_missing_parameters(const EVP_PKEY *pkey)
 {
-    if (pkey != NULL && pkey->ameth && pkey->ameth->param_missing)
-        return pkey->ameth->param_missing(pkey);
+    if (pkey != NULL) {
+        if (pkey->keymgmt != NULL)
+            return !evp_keymgmt_util_has((EVP_PKEY *)pkey,
+                                         OSSL_KEYMGMT_SELECT_ALL_PARAMETERS);
+        else if (pkey->ameth != NULL && pkey->ameth->param_missing != NULL)
+            return pkey->ameth->param_missing(pkey);
+    }
     return 0;
 }
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -39,6 +39,9 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
                        OSSL_CALLBACK *param_cb, void *cbarg);
  const OSSL_PARAM *OP_keymgmt_export_types(int selection);
 
+ /* Key object copy */
+ int OP_keymgmt_copy(void *keydata_to, const void *keydata_from, int selection);
+
  /* Key object validation */
  int OP_keymgmt_validate(void *keydata, int selection);
 
@@ -93,6 +96,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
  OP_keymgmt_export               OSSL_FUNC_KEYMGMT_EXPORT
  OP_keymgmt_export_types         OSSL_FUNC_KEYMGMT_EXPORT_TYPES
 
+ OP_keymgmt_copy                 OSSL_FUNC_KEYMGMT_COPY
 
 =head2 Key Objects
 
@@ -247,7 +251,7 @@ I<selection> in I<keydata1> and I<keydata2> match.  It is assumed that
 the caller has ensured that I<keydata1> and I<keydata2> are both owned
 by the implementation of this function.
 
-=head2 Key Object Import and Export Functions
+=head2 Key Object Import, Export and Copy Functions
 
 OP_keymgmt_import() should import data indicated by I<selection> into
 I<keydata> with values taken from the B<OSSL_PARAM> array I<params>.
@@ -263,6 +267,11 @@ OP_keymgmt_import() can handle.
 OP_keymgmt_export_types() should return a constant array of descriptor
 B<OSSL_PARAM> for data indicated by I<selection>, that the
 OP_keymgmt_export() callback can expect to receive.
+
+OP_keymgmt_copy() should copy data subsets indicated by I<selection>
+from I<keydata_from> to I<keydata_to>.  It is assumed that the caller
+has ensured that I<keydata_to> and I<keydata_from> are both owned by
+the implementation of this function.
 
 =head2 Built-in RSA Import/Export Types
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -26,6 +26,8 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
 
  /* Key object content checks */
  int OP_keymgmt_has(void *keydata, int selection);
+ int OP_keymgmt_match(const void *keydata1, const void *keydata2,
+                      int selection);
 
  /* Discovery of supported operations */
  const char *OP_keymgmt_query_operation_name(int operation_id);
@@ -84,6 +86,7 @@ macros in L<openssl-core_numbers.h(7)>, as follows:
 
  OP_keymgmt_has                  OSSL_FUNC_KEYMGMT_HAS
  OP_keymgmt_validate             OSSL_FUNC_KEYMGMT_VALIDATE
+ OP_keymgmt_match                OSSL_FUNC_KEYMGMT_MATCH
 
  OP_keymgmt_import               OSSL_FUNC_KEYMGMT_IMPORT
  OP_keymgmt_import_types         OSSL_FUNC_KEYMGMT_IMPORT_TYPES
@@ -238,6 +241,11 @@ For example, the combination of B<OSSL_KEYMGMT_SELECT_PRIVATE_KEY> and
 B<OSSL_KEYMGMT_SELECT_PUBLIC_KEY> (or B<OSSL_KEYMGMT_SELECT_KEYPAIR>
 for short) is expected to check that the pairwise consistency of
 I<keydata> is valid.
+
+OP_keymgmt_match() should check if the data subset indicated by
+I<selection> in I<keydata1> and I<keydata2> match.  It is assumed that
+the caller has ensured that I<keydata1> and I<keydata2> are both owned
+by the implementation of this function.
 
 =head2 Key Object Import and Export Functions
 

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/dsa.h>
+#include "internal/ffc.h"
 
 #define DSA_PARAMGEN_TYPE_FIPS_186_2   1   /* Use legacy FIPS186-2 standard */
 #define DSA_PARAMGEN_TYPE_FIPS_186_4   2   /* Use FIPS186-4 standard */
@@ -21,6 +22,9 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type,
 int dsa_sign_int(int type, const unsigned char *dgst,
                  int dlen, unsigned char *sig, unsigned int *siglen, DSA *dsa);
 const unsigned char *dsa_algorithmidentifier_encoding(int md_nid, size_t *len);
+
+FFC_PARAMS *dsa_get0_params(DSA *dsa);
+
 int dsa_generate_public_key(BN_CTX *ctx, const DSA *dsa, const BIGNUM *priv_key,
                             BIGNUM *pub_key);
 int dsa_check_params(const DSA *dsa, int *ret);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -638,6 +638,9 @@ const OSSL_PARAM *evp_keymgmt_settable_params(const EVP_KEYMGMT *keymgmt);
 int evp_keymgmt_has(const EVP_KEYMGMT *keymgmt, void *keyddata, int selection);
 int evp_keymgmt_validate(const EVP_KEYMGMT *keymgmt, void *keydata,
                          int selection);
+int evp_keymgmt_match(const EVP_KEYMGMT *keymgmt,
+                      const void *keydata1, const void *keydata2,
+                      int selection);
 
 int evp_keymgmt_import(const EVP_KEYMGMT *keymgmt, void *keydata,
                        int selection, const OSSL_PARAM params[]);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -620,6 +620,7 @@ void evp_keymgmt_util_cache_keyinfo(EVP_PKEY *pk);
 void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                                 int selection, const OSSL_PARAM params[]);
 int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
+int evp_keymgmt_util_match(EVP_PKEY *pk1, EVP_PKEY *pk2, int selection);
 
 
 /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -619,6 +619,7 @@ int evp_keymgmt_util_cache_keydata(EVP_PKEY *pk, size_t index,
 void evp_keymgmt_util_cache_keyinfo(EVP_PKEY *pk);
 void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                                 int selection, const OSSL_PARAM params[]);
+int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
 
 
 /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -621,6 +621,7 @@ void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                                 int selection, const OSSL_PARAM params[]);
 int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
 int evp_keymgmt_util_match(EVP_PKEY *pk1, EVP_PKEY *pk2, int selection);
+int evp_keymgmt_util_copy(EVP_PKEY *to, EVP_PKEY *from, int selection);
 
 
 /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -651,6 +651,9 @@ int evp_keymgmt_export(const EVP_KEYMGMT *keymgmt, void *keydata,
                        int selection, OSSL_CALLBACK *param_cb, void *cbarg);
 const OSSL_PARAM *evp_keymgmt_export_types(const EVP_KEYMGMT *keymgmt,
                                            int selection);
+int evp_keymgmt_copy(const EVP_KEYMGMT *keymgmt,
+                     void *keydata_to, const void *keydata_from,
+                     int selection);
 
 /* Pulling defines out of C source files */
 

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -412,6 +412,12 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_has, (void *keydata, int selection))
 # define OSSL_FUNC_KEYMGMT_VALIDATE                   22
 OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_validate, (void *keydata, int selection))
 
+/* Key checks - matching */
+# define OSSL_FUNC_KEYMGMT_MATCH                      23
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_match,
+                    (const void *keydata1, const void *keydata2,
+                     int selection))
+
 /* Import and export functions, with ddiscovery */
 # define OSSL_FUNC_KEYMGMT_IMPORT                     40
 # define OSSL_FUNC_KEYMGMT_IMPORT_TYPES               41

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -418,7 +418,7 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_match,
                     (const void *keydata1, const void *keydata2,
                      int selection))
 
-/* Import and export functions, with ddiscovery */
+/* Import and export functions, with discovery */
 # define OSSL_FUNC_KEYMGMT_IMPORT                     40
 # define OSSL_FUNC_KEYMGMT_IMPORT_TYPES               41
 # define OSSL_FUNC_KEYMGMT_EXPORT                     42
@@ -432,6 +432,12 @@ OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_export,
                      OSSL_CALLBACK *param_cb, void *cbarg))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_keymgmt_export_types,
                     (int selection))
+
+/* Copy function, only works for matching keymgmt */
+# define OSSL_FUNC_KEYMGMT_COPY                       44
+OSSL_CORE_MAKE_FUNC(int, OP_keymgmt_copy,
+                    ( void *keydata_to, const void *keydata_from,
+                     int selection))
 
 /* Key Exchange */
 

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -32,6 +32,7 @@ static OSSL_OP_keymgmt_free_fn rsa_freedata;
 static OSSL_OP_keymgmt_get_params_fn rsa_get_params;
 static OSSL_OP_keymgmt_gettable_params_fn rsa_gettable_params;
 static OSSL_OP_keymgmt_has_fn rsa_has;
+static OSSL_OP_keymgmt_match_fn rsa_match;
 static OSSL_OP_keymgmt_validate_fn rsa_validate;
 static OSSL_OP_keymgmt_import_fn rsa_import;
 static OSSL_OP_keymgmt_import_types_fn rsa_import_types;
@@ -200,6 +201,21 @@ static int rsa_has(void *keydata, int selection)
         ok = ok && (RSA_get0_n(rsa) != NULL);
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
         ok = ok && (RSA_get0_d(rsa) != NULL);
+    return ok;
+}
+
+static int rsa_match(const void *keydata1, const void *keydata2, int selection)
+{
+    const RSA *rsa1 = keydata1;
+    const RSA *rsa2 = keydata2;
+    int ok = 1;
+
+    /* There is always an |e| */
+    ok = ok && BN_cmp(RSA_get0_e(rsa1), RSA_get0_e(rsa2)) == 0;
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
+        ok = ok && BN_cmp(RSA_get0_n(rsa1), RSA_get0_n(rsa2)) == 0;
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
+        ok = ok && BN_cmp(RSA_get0_d(rsa1), RSA_get0_d(rsa2)) == 0;
     return ok;
 }
 
@@ -399,6 +415,7 @@ const OSSL_DISPATCH rsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))rsa_get_params },
     { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void))rsa_gettable_params },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))rsa_has },
+    { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))rsa_match },
     { OSSL_FUNC_KEYMGMT_VALIDATE, (void (*)(void))rsa_validate },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))rsa_import },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))rsa_import_types },


### PR DESCRIPTION
This is an adaptation of the following functions for provided keys:

    EVP_PKEY_copy_parameters()
    EVP_PKEY_missing_parameters()
    EVP_PKEY_cmp_parameters()
    EVP_PKEY_cmp()

This also adds the necessary EVP_KEYMGMT interfaces to support those functions, and the implementations for RSA, DSA and DH.

This replaces #11025 and is built on top of #11148