### PR TITLE
VMS: mitigate for the C++ compiler that doesn't understand certain pragmas

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,18 @@
 
  Changes between 1.1.1d and 1.1.1e [xx XXX xxxx]
 
+  *) [VMS only] The header files that the VMS compilers include automatically,
+     __DECC_INCLUDE_PROLOGUE.H and __DECC_INCLUDE_EPILOGUE.H, use pragmas that
+     the C++ compiler doesn't understand.  This is a shortcoming in the
+     compiler, but can be worked around with __cplusplus guards.
+
+     C++ applications that use OpenSSL libraries must be compiled using the
+     qualifier '/NAMES=(AS_IS,SHORTENED)' to be able to use all the OpenSSL
+     functions.  Otherwise, only functions with symbols of less than 31
+     characters can be used, as the linker will not be able to successfully
+     resolve symbols with longer names.
+     [Richard Levitte]
+
   *) X509 certificates signed using SHA1 are no longer allowed at security
      level 1 and above.
      In TLS/SSL the default security level is 1. It can be set either

--- a/include/openssl/__DECC_INCLUDE_EPILOGUE.H
+++ b/include/openssl/__DECC_INCLUDE_EPILOGUE.H
@@ -8,9 +8,15 @@
  */
 
 /*
- * This file is only used by HP C on VMS, and is included automatically
+ * This file is only used by HP C/C++ on VMS, and is included automatically
  * after each header file from this directory
  */
 
+/*
+ * The C++ compiler doesn't understand these pragmas, even though it
+ * understands the corresponding command line qualifier.
+ */
+#ifndef __cplusplus
 /* restore state.  Must correspond to the save in __decc_include_prologue.h */
-#pragma names restore
+# pragma names restore
+#endif

--- a/include/openssl/__DECC_INCLUDE_PROLOGUE.H
+++ b/include/openssl/__DECC_INCLUDE_PROLOGUE.H
@@ -8,13 +8,19 @@
  */
 
 /*
- * This file is only used by HP C on VMS, and is included automatically
+ * This file is only used by HP C/C++ on VMS, and is included automatically
  * after each header file from this directory
  */
 
+/*
+ * The C++ compiler doesn't understand these pragmas, even though it
+ * understands the corresponding command line qualifier.
+ */
+#ifndef __cplusplus
 /* save state */
-#pragma names save
+# pragma names save
 /* have the compiler shorten symbols larger than 31 chars to 23 chars
  * followed by a 8 hex char CRC
  */
-#pragma names as_is,shortened
+# pragma names as_is,shortened
+#endif


### PR DESCRIPTION
This only affects __DECC_INCLUDE_EPILOGUE.H and __DECC_INCLUDE_PROLOGUE.H,
which are used automatically by HP and VSI C/C++ compilers.
