### PR TITLE
Deprecate ASN1_sign(), ASN1_verify() and ASN1_digest()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx] ###
 
+ * `ASN1_verify()`, `ASN1_digest()` and `ASN1_sign()` have been deprecated.
+   They are old functions that we don't use, and that you could disable with
+   the macro `NO_ASN1_OLD`.  This goes all the way back to OpenSSL 0.9.7.
+
+   *Richard Levitte*
 
  * The main project documents (README, NEWS, CHANGES, INSTALL, SUPPORT)
    have been converted to Markdown with the goal to produce documents

--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -18,7 +18,7 @@
 #include <openssl/buffer.h>
 #include <openssl/x509.h>
 
-#ifndef NO_ASN1_OLD
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 
 int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type, char *data,
                 unsigned char *md, unsigned int *len)

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -22,7 +22,7 @@
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
 
-#ifndef NO_ASN1_OLD
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 
 int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
               ASN1_BIT_STRING *signature, char *data, EVP_PKEY *pkey,

--- a/crypto/asn1/a_verify.c
+++ b/crypto/asn1/a_verify.c
@@ -21,7 +21,7 @@
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
 
-#ifndef NO_ASN1_OLD
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 
 int ASN1_verify(i2d_of_void *i2d, X509_ALGOR *a, ASN1_BIT_STRING *signature,
                 char *data, EVP_PKEY *pkey)

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -623,15 +623,17 @@ X509_INFO *X509_INFO_new(void);
 void X509_INFO_free(X509_INFO *a);
 char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
 
-int ASN1_verify(i2d_of_void *i2d, X509_ALGOR *algor1,
-                ASN1_BIT_STRING *signature, char *data, EVP_PKEY *pkey);
+DEPRECATEDIN_3_0(int ASN1_verify(i2d_of_void *i2d, X509_ALGOR *algor1,
+                                 ASN1_BIT_STRING *signature, char *data,
+                                 EVP_PKEY *pkey))
 
-int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type, char *data,
-                unsigned char *md, unsigned int *len);
+DEPRECATEDIN_3_0(int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type,
+                                 char *data,
+                                 unsigned char *md, unsigned int *len))
 
-int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1,
-              X509_ALGOR *algor2, ASN1_BIT_STRING *signature,
-              char *data, EVP_PKEY *pkey, const EVP_MD *type);
+DEPRECATEDIN_3_0(int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1,
+                               X509_ALGOR *algor2, ASN1_BIT_STRING *signature,
+                               char *data, EVP_PKEY *pkey, const EVP_MD *type))
 
 int ASN1_item_digest(const ASN1_ITEM *it, const EVP_MD *type, void *data,
                      unsigned char *md, unsigned int *len);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -555,7 +555,7 @@ CT_POLICY_EVAL_CTX_get0_issuer          566	3_0_0	EXIST::FUNCTION:CT
 TLS_FEATURE_new                         567	3_0_0	EXIST::FUNCTION:
 RSA_get_default_method                  568	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RSA
 CRYPTO_cts128_encrypt_block             569	3_0_0	EXIST::FUNCTION:
-ASN1_digest                             570	3_0_0	EXIST::FUNCTION:
+ASN1_digest                             570	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ERR_load_X509V3_strings                 571	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get_cleanup               572	3_0_0	EXIST::FUNCTION:
 d2i_X509                                574	3_0_0	EXIST::FUNCTION:
@@ -2723,7 +2723,7 @@ OPENSSL_sk_value                        2781	3_0_0	EXIST::FUNCTION:
 NCONF_get_section                       2782	3_0_0	EXIST::FUNCTION:
 PKCS12_MAC_DATA_it                      2783	3_0_0	EXIST::FUNCTION:
 X509_REQ_add1_attr_by_NID               2784	3_0_0	EXIST::FUNCTION:
-ASN1_sign                               2785	3_0_0	EXIST::FUNCTION:
+ASN1_sign                               2785	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 CMS_RecipientInfo_encrypt               2786	3_0_0	EXIST::FUNCTION:CMS
 X509_get_pubkey_parameters              2787	3_0_0	EXIST::FUNCTION:
 PKCS12_setup_mac                        2788	3_0_0	EXIST::FUNCTION:
@@ -3596,7 +3596,7 @@ X509v3_asid_canonize                    3675	3_0_0	EXIST::FUNCTION:RFC3779
 i2d_ASIdOrRange                         3676	3_0_0	EXIST::FUNCTION:RFC3779
 OCSP_url_svcloc_new                     3677	3_0_0	EXIST::FUNCTION:OCSP
 CRYPTO_mem_ctrl                         3678	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0
-ASN1_verify                             3679	3_0_0	EXIST::FUNCTION:
+ASN1_verify                             3679	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 DSA_generate_parameters_ex              3680	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
 X509_sign                               3681	3_0_0	EXIST::FUNCTION:
 SHA256_Transform                        3682	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
These are old functions that fell out of use with OpenSL 0.9.7.
It's more than time to deprecate them.
