### PR TITLE
cmdline app: add provider commandline options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,43 +26,7 @@
 /include/openssl/opensslv.h
 
 # Auto generated doc files
-# Keep this in sync with doc/man1/build.info
-doc/man1/openssl-ca.pod
-doc/man1/openssl-cms.pod
-doc/man1/openssl-crl.pod
-doc/man1/openssl-dgst.pod
-doc/man1/openssl-dhparam.pod
-doc/man1/openssl-dsa.pod
-doc/man1/openssl-dsaparam.pod
-doc/man1/openssl-ec.pod
-doc/man1/openssl-ecparam.pod
-doc/man1/openssl-enc.pod
-doc/man1/openssl-gendsa.pod
-doc/man1/openssl-genpkey.pod
-doc/man1/openssl-genrsa.pod
-doc/man1/openssl-ocsp.pod
-doc/man1/openssl-passwd.pod
-doc/man1/openssl-pkcs12.pod
-doc/man1/openssl-pkcs7.pod
-doc/man1/openssl-pkcs8.pod
-doc/man1/openssl-pkey.pod
-doc/man1/openssl-pkeyparam.pod
-doc/man1/openssl-pkeyutl.pod
-doc/man1/openssl-rand.pod
-doc/man1/openssl-req.pod
-doc/man1/openssl-rsa.pod
-doc/man1/openssl-rsautl.pod
-doc/man1/openssl-s_client.pod
-doc/man1/openssl-s_server.pod
-doc/man1/openssl-s_time.pod
-doc/man1/openssl-smime.pod
-doc/man1/openssl-speed.pod
-doc/man1/openssl-spkac.pod
-doc/man1/openssl-srp.pod
-doc/man1/openssl-storeutl.pod
-doc/man1/openssl-ts.pod
-doc/man1/openssl-verify.pod
-doc/man1/openssl-x509.pod
+doc/man1/openssl-*.pod
 
 # error code files
 /crypto/err/openssl.txt.old

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -148,7 +148,7 @@ typedef enum OPTION_choice {
     OPT_INFILES, OPT_SS_CERT, OPT_SPKAC, OPT_REVOKE, OPT_VALID,
     OPT_EXTENSIONS, OPT_EXTFILE, OPT_STATUS, OPT_UPDATEDB, OPT_CRLEXTS,
     OPT_RAND_SERIAL,
-    OPT_R_ENUM, OPT_SM2ID, OPT_SM2HEXID,
+    OPT_R_ENUM, OPT_SM2ID, OPT_SM2HEXID, OPT_PROV_ENUM,
     /* Do not change the order here; see related case statements below */
     OPT_CRL_REASON, OPT_CRL_HOLD, OPT_CRL_COMPROMISE, OPT_CRL_CA_COMPROMISE
 } OPTION_CHOICE;
@@ -237,6 +237,7 @@ const OPTIONS ca_options[] = {
     {"revoke", OPT_REVOKE, '<', "Revoke a cert (given in file)"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"certreq", 0, 0, "Certificate requests to be signed (optional)"},
@@ -359,6 +360,10 @@ opthelp:
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_KEY:

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -27,7 +27,7 @@ typedef enum OPTION_choice {
     OPT_PSK,
     OPT_SRP,
     OPT_CIPHERSUITES,
-    OPT_V, OPT_UPPER_V, OPT_S
+    OPT_V, OPT_UPPER_V, OPT_S, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS ciphers_options[] = {
@@ -67,6 +67,7 @@ const OPTIONS ciphers_options[] = {
 #endif
     {"ciphersuites", OPT_CIPHERSUITES, 's',
      "Configure the TLSv1.3 ciphersuites to use"},
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"cipher", 0, 0, "Cipher string to decode (optional)"},
@@ -168,6 +169,10 @@ int ciphers_main(int argc, char **argv)
             break;
         case OPT_CIPHERSUITES:
             ciphersuites = opt_arg();
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -83,6 +83,7 @@ typedef enum OPTION_choice {
     OPT_RR_TO, OPT_AES128_WRAP, OPT_AES192_WRAP, OPT_AES256_WRAP,
     OPT_3DES_WRAP, OPT_WRAP, OPT_ENGINE,
     OPT_R_ENUM,
+    OPT_PROV_ENUM,
     OPT_V_ENUM,
     OPT_CIPHER,
     OPT_ORIGINATOR
@@ -220,6 +221,7 @@ const OPTIONS cms_options[] = {
 
     OPT_R_OPTIONS,
     OPT_V_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"cert", 0, 0, "Recipient certs (optional; used only when encrypting)"},
@@ -619,6 +621,10 @@ int cms_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_3DES_WRAP:

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -24,7 +24,7 @@ typedef enum OPTION_choice {
     OPT_ISSUER, OPT_LASTUPDATE, OPT_NEXTUPDATE, OPT_FINGERPRINT,
     OPT_CRLNUMBER, OPT_BADSIG, OPT_GENDELTA, OPT_CAPATH, OPT_CAFILE, OPT_CASTORE,
     OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE, OPT_VERIFY, OPT_TEXT, OPT_HASH,
-    OPT_HASH_OLD, OPT_NOOUT, OPT_NAMEOPT, OPT_MD
+    OPT_HASH_OLD, OPT_NOOUT, OPT_NAMEOPT, OPT_MD, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS crl_options[] = {
@@ -69,6 +69,7 @@ const OPTIONS crl_options[] = {
      "Do not load certificates from the default certificates directory"},
     {"no-CAstore", OPT_NOCASTORE, '-',
      "Do not load certificates from the default certificates store"},
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -193,6 +194,11 @@ int crl_main(int argc, char **argv)
         case OPT_MD:
             if (!opt_md(opt_unknown(), &digest))
                 goto opthelp;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
+            break;
         }
     }
     argc = opt_num_rest();

--- a/apps/crl2p7.c
+++ b/apps/crl2p7.c
@@ -23,7 +23,8 @@ static int add_certs_from_file(STACK_OF(X509) *stack, char *certfile);
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_NOCRL, OPT_CERTFILE
+    OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_NOCRL, OPT_CERTFILE,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS crl2pkcs7_options[] = {
@@ -40,6 +41,8 @@ const OPTIONS crl2pkcs7_options[] = {
     OPT_SECTION("Output"),
     {"out", OPT_OUT, '>', "Output file"},
     {"outform", OPT_OUTFORM, 'F', "Output format - DER or PEM"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -91,6 +94,10 @@ int crl2pkcs7_main(int argc, char **argv)
                 && (certflst = sk_OPENSSL_STRING_new_null()) == NULL)
                 goto end;
             if (!sk_OPENSSL_STRING_push(certflst, opt_arg()))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -42,7 +42,7 @@ typedef enum OPTION_choice {
     OPT_HEX, OPT_BINARY, OPT_DEBUG, OPT_FIPS_FINGERPRINT,
     OPT_HMAC, OPT_MAC, OPT_SIGOPT, OPT_MACOPT,
     OPT_DIGEST,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS dgst_options[] = {
@@ -82,6 +82,7 @@ const OPTIONS dgst_options[] = {
      "Compute HMAC with the key used in OpenSSL-FIPS fingerprint"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"file", 0, 0, "Files to digest (optional; default is stdin)"},
@@ -207,6 +208,10 @@ int dgst_main(int argc, char **argv)
             if (!opt_md(opt_unknown(), &m))
                 goto opthelp;
             md = m;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -41,7 +41,7 @@ typedef enum OPTION_choice {
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT,
     OPT_ENGINE, OPT_CHECK, OPT_TEXT, OPT_NOOUT,
     OPT_DSAPARAM, OPT_C, OPT_2, OPT_3, OPT_5,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS dhparam_options[] = {
@@ -73,6 +73,7 @@ const OPTIONS dhparam_options[] = {
     {"5", OPT_5, '-', "Generate parameters using 5 as the generator value"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"numbits", 0, 0, "Number of bits if generating parameters (optional)"},
@@ -149,6 +150,10 @@ int dhparam_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -35,7 +35,8 @@ typedef enum OPTION_choice {
     /* Do not change the order here; see case statements below */
     OPT_PVK_NONE, OPT_PVK_WEAK, OPT_PVK_STRONG,
     OPT_NOOUT, OPT_TEXT, OPT_MODULUS, OPT_PUBIN,
-    OPT_PUBOUT, OPT_CIPHER, OPT_PASSIN, OPT_PASSOUT
+    OPT_PUBOUT, OPT_CIPHER, OPT_PASSIN, OPT_PASSOUT,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS dsa_options[] = {
@@ -66,6 +67,7 @@ const OPTIONS dsa_options[] = {
     {"pubout", OPT_PUBOUT, '-', "Output public key, not private"},
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
 
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -145,6 +147,10 @@ int dsa_main(int argc, char **argv)
             break;
         case OPT_CIPHER:
             if (!opt_cipher(opt_unknown(), &enc))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -36,7 +36,7 @@ typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_TEXT, OPT_C,
     OPT_NOOUT, OPT_GENKEY, OPT_ENGINE, OPT_VERBOSE,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS dsaparam_options[] = {
@@ -62,6 +62,7 @@ const OPTIONS dsaparam_options[] = {
     {"genkey", OPT_GENKEY, '-', "Generate a DSA key"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"numbits", 0, 0, "Number of bits if generating parameters (optional)"},
@@ -120,6 +121,10 @@ int dsaparam_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_NOOUT:

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -40,7 +40,7 @@ typedef enum OPTION_choice {
     OPT_INFORM, OPT_OUTFORM, OPT_ENGINE, OPT_IN, OPT_OUT,
     OPT_NOOUT, OPT_TEXT, OPT_PARAM_OUT, OPT_PUBIN, OPT_PUBOUT,
     OPT_PASSIN, OPT_PASSOUT, OPT_PARAM_ENC, OPT_CONV_FORM, OPT_CIPHER,
-    OPT_NO_PUBLIC, OPT_CHECK
+    OPT_NO_PUBLIC, OPT_CHECK, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS ec_options[] = {
@@ -70,6 +70,8 @@ const OPTIONS ec_options[] = {
     {"pubout", OPT_PUBOUT, '-', "Output public key, not private"},
     {"no_public", OPT_NO_PUBLIC, '-', "exclude public key from private key"},
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -160,6 +162,10 @@ int ec_main(int argc, char **argv)
             break;
         case OPT_CHECK:
             check = 1;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -31,7 +31,7 @@ typedef enum OPTION_choice {
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_TEXT, OPT_C,
     OPT_CHECK, OPT_LIST_CURVES, OPT_NO_SEED, OPT_NOOUT, OPT_NAME,
     OPT_CONV_FORM, OPT_PARAM_ENC, OPT_GENKEY, OPT_ENGINE, OPT_CHECK_NAMED,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS ecparam_options[] = {
@@ -67,6 +67,7 @@ const OPTIONS ecparam_options[] = {
     {"conv_form", OPT_CONV_FORM, 's', "Specifies the point conversion form "},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -167,6 +168,10 @@ int ecparam_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_ENGINE:

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -45,7 +45,7 @@ typedef enum OPTION_choice {
     OPT_NOPAD, OPT_SALT, OPT_NOSALT, OPT_DEBUG, OPT_UPPER_P, OPT_UPPER_A,
     OPT_A, OPT_Z, OPT_BUFSIZE, OPT_K, OPT_KFILE, OPT_UPPER_K, OPT_NONE,
     OPT_UPPER_S, OPT_IV, OPT_MD, OPT_ITER, OPT_PBKDF2, OPT_CIPHER,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS enc_options[] = {
@@ -97,6 +97,7 @@ const OPTIONS enc_options[] = {
     {"", OPT_CIPHER, '-', "Any supported cipher"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -286,6 +287,10 @@ int enc_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -31,7 +31,7 @@ NON_EMPTY_TRANSLATION_UNIT
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_CIPHER, OPT_VERBOSE,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS gendsa_options[] = {
@@ -47,6 +47,7 @@ const OPTIONS gendsa_options[] = {
     {"out", OPT_OUT, '>', "Output the key to the specified file"},
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
     {"verbose", OPT_VERBOSE, '-', "Verbose output"},
 
@@ -90,6 +91,10 @@ int gendsa_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_CIPHER:

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -24,7 +24,8 @@ static int genpkey_cb(EVP_PKEY_CTX *ctx);
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_ENGINE, OPT_OUTFORM, OPT_OUT, OPT_PASS, OPT_PARAMFILE,
-    OPT_ALGORITHM, OPT_PKEYOPT, OPT_GENPARAM, OPT_TEXT, OPT_CIPHER
+    OPT_ALGORITHM, OPT_PKEYOPT, OPT_GENPARAM, OPT_TEXT, OPT_CIPHER,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS genpkey_options[] = {
@@ -45,6 +46,8 @@ const OPTIONS genpkey_options[] = {
     {"genparam", OPT_GENPARAM, '-', "Generate parameters, not key"},
     {"text", OPT_TEXT, '-', "Print the in text"},
     {"", OPT_CIPHER, '-', "Cipher to use to encrypt the key"},
+
+    OPT_PROV_OPTIONS,
 
     /* This is deliberately last. */
     {OPT_HELP_STR, 1, 1,
@@ -131,6 +134,11 @@ int genpkey_main(int argc, char **argv)
                 BIO_printf(bio_err, "%s: cipher mode not supported\n", prog);
                 goto end;
             }
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
+            break;
         }
     }
     argc = opt_num_rest();

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -41,7 +41,7 @@ typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_3, OPT_F4, OPT_ENGINE,
     OPT_OUT, OPT_PASSOUT, OPT_CIPHER, OPT_PRIMES, OPT_VERBOSE,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS genrsa_options[] = {
@@ -66,6 +66,7 @@ const OPTIONS genrsa_options[] = {
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"numbits", 0, 0, "Size of key in bits"},
@@ -119,6 +120,10 @@ opthelp:
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_PASSOUT:

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -266,6 +266,24 @@
         case OPT_R_RAND: case OPT_R_WRITERAND
 
 /*
+ * Provider options.
+ */
+# define OPT_PROV_ENUM \
+        OPT_PROV__FIRST=1600, \
+        OPT_PROV_PROVIDER, OPT_PROV_PROVIDER_PATH, \
+        OPT_PROV__LAST
+
+# define OPT_PROV_OPTIONS \
+        OPT_SECTION("Provider"), \
+        { "provider", OPT_PROV_PROVIDER, 's', "Provder to load (can be specified multiple times)" }, \
+        { "provider_path", OPT_PROV_PROVIDER_PATH, 's', "Provider load path" }
+
+# define OPT_PROV_CASES \
+        OPT_PROV__FIRST: case OPT_PROV__LAST: break; \
+        case OPT_PROV_PROVIDER: \
+        case OPT_PROV_PROVIDER_PATH
+
+/*
  * Option parsing.
  */
 extern const char OPT_HELP_STR[];
@@ -348,6 +366,7 @@ char **opt_rest(void);
 int opt_num_rest(void);
 int opt_verify(int i, X509_VERIFY_PARAM *vpm);
 int opt_rand(int i);
+int opt_provider(int i);
 void opt_help(const OPTIONS * list);
 void opt_print(const OPTIONS * opt, int doingparams, int width);
 int opt_format_error(const char *s, unsigned long flags);

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -19,7 +19,8 @@
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_KDFOPT, OPT_BIN, OPT_KEYLEN, OPT_OUT
+    OPT_KDFOPT, OPT_BIN, OPT_KEYLEN, OPT_OUT,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS kdf_options[] = {
@@ -35,6 +36,8 @@ const OPTIONS kdf_options[] = {
     {"out", OPT_OUT, '>', "Output to filename rather than stdout"},
     {"binary", OPT_BIN, '-',
         "Output in binary format (default is hexadecimal)"},
+
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"kdf_name", 0, 0, "Name of the KDF algorithm"},
@@ -79,6 +82,10 @@ opthelp:
                 opts = sk_OPENSSL_STRING_new_null();
             if (opts == NULL || !sk_OPENSSL_STRING_push(opts, opt_arg()))
                 goto opthelp;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto err;
             break;
         }
     }

--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "apps.h"
+#include <openssl/err.h>
+#include <openssl/provider.h>
+
+/*
+ * See comments in opt_verify for explanation of this.
+ */
+enum prov_range { OPT_PROV_ENUM };
+
+static int opt_provider_load(const char *provider)
+{
+    OSSL_PROVIDER *prov;
+
+    prov = OSSL_PROVIDER_load(NULL, provider);
+    if (prov == NULL) {
+        opt_printf_stderr("%s: unable to load provider %s\n",
+                          opt_getprog(), provider);
+        return 0;
+    }
+    return 1;
+}
+
+static int opt_provider_path(const char *path)
+{
+    if (path != NULL && *path == '\0')
+        path = NULL;
+    return OSSL_PROVIDER_set_default_search_path(NULL, path);
+}
+
+int opt_provider(int opt)
+{
+    switch ((enum prov_range)opt) {
+    case OPT_PROV__FIRST:
+    case OPT_PROV__LAST:
+        return 1;
+    case OPT_PROV_PROVIDER:
+        return opt_provider_load(opt_arg());
+    case OPT_PROV_PROVIDER_PATH:
+        return opt_provider_path(opt_arg());
+    }
+    return 0;
+}

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -9,7 +9,7 @@ ENDIF
 
 # Source for libapps
 $LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
-        columns.c app_params.c names.c
+        columns.c app_params.c names.c app_provider.c
 
 IF[{- !$disabled{apps} -}]
   LIBS{noinst}=../libapps.a

--- a/apps/list.c
+++ b/apps/list.c
@@ -617,7 +617,8 @@ typedef enum HELPLIST_CHOICE {
     OPT_COMMANDS, OPT_DIGEST_COMMANDS, OPT_MAC_ALGORITHMS, OPT_OPTIONS,
     OPT_DIGEST_ALGORITHMS, OPT_CIPHER_COMMANDS, OPT_CIPHER_ALGORITHMS,
     OPT_PK_ALGORITHMS, OPT_PK_METHOD, OPT_ENGINES, OPT_DISABLED,
-    OPT_KDF_ALGORITHMS, OPT_MISSING_HELP, OPT_OBJECTS
+    OPT_KDF_ALGORITHMS, OPT_MISSING_HELP, OPT_OBJECTS,
+    OPT_PROV_ENUM
 } HELPLIST_CHOICE;
 
 const OPTIONS list_options[] = {
@@ -655,6 +656,8 @@ const OPTIONS list_options[] = {
      "List options for specified command"},
     {"objects", OPT_OBJECTS, '-',
      "List built in objects (OID<->name mappings)"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -740,6 +743,10 @@ opthelp:
             break;
         case OPT_VERBOSE:
             verbose = 1;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                return 1;
             break;
         }
         done = 1;

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -21,7 +21,8 @@
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_MACOPT, OPT_BIN, OPT_IN, OPT_OUT
+    OPT_MACOPT, OPT_BIN, OPT_IN, OPT_OUT,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS mac_options[] = {
@@ -39,6 +40,8 @@ const OPTIONS mac_options[] = {
     {"out", OPT_OUT, '>', "Output to filename rather than stdout"},
     {"binary", OPT_BIN, '-',
         "Output in binary format (default is hexadecimal)"},
+
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"mac_name", 0, 0, "MAC algorithm"},
@@ -88,6 +91,10 @@ opthelp:
                 opts = sk_OPENSSL_STRING_new_null();
             if (opts == NULL || !sk_OPENSSL_STRING_push(opts, opt_arg()))
                 goto opthelp;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto err;
             break;
         }
     }

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -16,7 +16,8 @@
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_TOSEQ, OPT_IN, OPT_OUT
+    OPT_TOSEQ, OPT_IN, OPT_OUT,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS nseq_options[] = {
@@ -29,6 +30,8 @@ const OPTIONS nseq_options[] = {
     OPT_SECTION("Output"),
     {"toseq", OPT_TOSEQ, '-', "Output NS Sequence file"},
     {"out", OPT_OUT, '>', "Output file"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -61,6 +64,10 @@ int nseq_main(int argc, char **argv)
             break;
         case OPT_OUT:
             outfile = opt_arg();
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -137,7 +137,7 @@ typedef enum OPTION_choice {
     OPT_RCID,
     OPT_V_ENUM,
     OPT_MD,
-    OPT_MULTI
+    OPT_MULTI, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS ocsp_options[] = {
@@ -230,6 +230,7 @@ const OPTIONS ocsp_options[] = {
     {"status_age", OPT_STATUS_AGE, 'p', "Maximum status age in seconds"},
 
     OPT_V_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -540,6 +541,10 @@ int ocsp_main(int argc, char **argv)
 # ifdef OCSP_DAEMON
             multi = atoi(opt_arg());
 # endif
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -58,7 +58,7 @@ typedef enum OPTION_choice {
     OPT_IN,
     OPT_NOVERIFY, OPT_QUIET, OPT_TABLE, OPT_REVERSE, OPT_APR1,
     OPT_1, OPT_5, OPT_6, OPT_CRYPT, OPT_AIXMD5, OPT_SALT, OPT_STDIN,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS passwd_options[] = {
@@ -90,6 +90,7 @@ const OPTIONS passwd_options[] = {
 #endif
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"password", 0, 0, "Password text to digest (optional)"},
@@ -189,6 +190,10 @@ int passwd_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -58,7 +58,7 @@ typedef enum OPTION_choice {
     OPT_INKEY, OPT_CERTFILE, OPT_NAME, OPT_CSP, OPT_CANAME,
     OPT_IN, OPT_OUT, OPT_PASSIN, OPT_PASSOUT, OPT_PASSWORD, OPT_CAPATH,
     OPT_CAFILE, OPT_CASTORE, OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE, OPT_ENGINE,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkcs12_options[] = {
@@ -130,6 +130,7 @@ const OPTIONS pkcs12_options[] = {
     {"", OPT_CIPHER, '-', "Any supported cipher"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -306,6 +307,10 @@ int pkcs12_main(int argc, char **argv)
             break;
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -23,7 +23,8 @@
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_NOOUT,
-    OPT_TEXT, OPT_PRINT, OPT_PRINT_CERTS, OPT_ENGINE
+    OPT_TEXT, OPT_PRINT, OPT_PRINT_CERTS, OPT_ENGINE,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkcs7_options[] = {
@@ -45,6 +46,8 @@ const OPTIONS pkcs7_options[] = {
     {"print", OPT_PRINT, '-', "Print out all fields of the PKCS7 structure"},
     {"print_certs", OPT_PRINT_CERTS, '-',
      "Print_certs  print any certs or crl in the input"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -98,6 +101,10 @@ int pkcs7_main(int argc, char **argv)
             break;
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -26,7 +26,7 @@ typedef enum OPTION_choice {
 #endif
     OPT_V2, OPT_V1, OPT_V2PRF, OPT_ITER, OPT_PASSIN, OPT_PASSOUT,
     OPT_TRADITIONAL,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkcs8_options[] = {
@@ -63,6 +63,7 @@ const OPTIONS pkcs8_options[] = {
 #endif
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -125,6 +126,10 @@ int pkcs8_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_TRADITIONAL:

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -37,7 +37,8 @@ typedef enum OPTION_choice {
     OPT_INFORM, OPT_OUTFORM, OPT_PASSIN, OPT_PASSOUT, OPT_ENGINE,
     OPT_IN, OPT_OUT, OPT_PUBIN, OPT_PUBOUT, OPT_TEXT_PUB,
     OPT_TEXT, OPT_NOOUT, OPT_MD, OPT_TRADITIONAL, OPT_CHECK, OPT_PUB_CHECK,
-    OPT_EC_PARAM_ENC, OPT_EC_CONV_FORM
+    OPT_EC_PARAM_ENC, OPT_EC_CONV_FORM,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkey_options[] = {
@@ -72,6 +73,7 @@ const OPTIONS pkey_options[] = {
     {"text", OPT_TEXT, '-', "Output in plaintext as well"},
     {"noout", OPT_NOOUT, '-', "Don't output the key"},
 
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -177,6 +179,10 @@ int pkey_main(int argc, char **argv)
             ec_asn1_flag = i;
             break;
 #endif
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
+            break;
         }
     }
     argc = opt_num_rest();

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -19,7 +19,8 @@
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_IN, OPT_OUT, OPT_TEXT, OPT_NOOUT,
-    OPT_ENGINE, OPT_CHECK
+    OPT_ENGINE, OPT_CHECK,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS pkeyparam_options[] = {
@@ -37,6 +38,8 @@ const OPTIONS pkeyparam_options[] = {
     {"out", OPT_OUT, '>', "Output file"},
     {"text", OPT_TEXT, '-', "Print parameters as text"},
     {"noout", OPT_NOOUT, '-', "Don't output encoded parameters"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -80,6 +83,10 @@ int pkeyparam_main(int argc, char **argv)
             break;
         case OPT_CHECK:
             check = 1;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -44,7 +44,7 @@ typedef enum OPTION_choice {
     OPT_VERIFY, OPT_VERIFYRECOVER, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
     OPT_DERIVE, OPT_SIGFILE, OPT_INKEY, OPT_PEERKEY, OPT_PASSIN,
     OPT_PEERFORM, OPT_KEYFORM, OPT_PKEYOPT, OPT_PKEYOPT_PASSIN, OPT_KDF,
-    OPT_KDFLEN, OPT_R_ENUM,
+    OPT_KDFLEN, OPT_R_ENUM, OPT_PROV_ENUM,
     OPT_RAWIN, OPT_DIGEST
 } OPTION_CHOICE;
 
@@ -92,6 +92,7 @@ const OPTIONS pkeyutl_options[] = {
     {"kdflen", OPT_KDFLEN, 'p', "KDF algorithm output length"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -163,6 +164,10 @@ int pkeyutl_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_ENGINE:

--- a/apps/prime.c
+++ b/apps/prime.c
@@ -15,7 +15,8 @@
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_HEX, OPT_GENERATE, OPT_BITS, OPT_SAFE, OPT_CHECKS
+    OPT_HEX, OPT_GENERATE, OPT_BITS, OPT_SAFE, OPT_CHECKS,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS prime_options[] = {
@@ -31,6 +32,8 @@ const OPTIONS prime_options[] = {
     {"generate", OPT_GENERATE, '-', "Generate a prime"},
     {"safe", OPT_SAFE, '-',
      "When used with -generate, generate a safe prime"},
+
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"number", 0, 0, "Number(s) to check for primality if not generating"},
@@ -71,6 +74,10 @@ opthelp:
         case OPT_CHECKS:
             /* ignore parameter and argument */
             opt_arg();
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -21,7 +21,7 @@
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_OUT, OPT_ENGINE, OPT_BASE64, OPT_HEX,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS rand_options[] = {
@@ -39,6 +39,7 @@ const OPTIONS rand_options[] = {
     {"hex", OPT_HEX, '-', "Hex encode output"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"num", 0, 0, "Number of bytes to generate"},
@@ -80,6 +81,10 @@ int rand_main(int argc, char **argv)
             break;
         case OPT_HEX:
             format = FORMAT_TEXT;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -447,7 +447,8 @@ static int do_dir(const char *dirname, enum Hash h)
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_COMPAT, OPT_OLD, OPT_N, OPT_VERBOSE
+    OPT_COMPAT, OPT_OLD, OPT_N, OPT_VERBOSE,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS rehash_options[] = {
@@ -462,6 +463,8 @@ const OPTIONS rehash_options[] = {
 
     OPT_SECTION("Output"),
     {"v", OPT_VERBOSE, '-', "Verbose output"},
+
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"directory", 0, 0, "One or more directories to process (optional)"},
@@ -498,6 +501,10 @@ int rehash_main(int argc, char **argv)
             break;
         case OPT_VERBOSE:
             verbose = 1;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/req.c
+++ b/apps/req.c
@@ -91,7 +91,7 @@ typedef enum OPTION_choice {
     OPT_NAMEOPT, OPT_REQOPT, OPT_SUBJ, OPT_SUBJECT, OPT_TEXT, OPT_X509,
     OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_ADDEXT, OPT_EXTENSIONS,
     OPT_REQEXTS, OPT_PRECERT, OPT_MD, OPT_SM2ID, OPT_SM2HEXID,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS req_options[] = {
@@ -160,6 +160,7 @@ const OPTIONS req_options[] = {
     {"modulus", OPT_MODULUS, '-', "RSA modulus"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -329,6 +330,10 @@ int req_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_NEWKEY:

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -36,7 +36,8 @@ typedef enum OPTION_choice {
     OPT_RSAPUBKEY_IN, OPT_RSAPUBKEY_OUT,
     /* Do not change the order here; see case statements below */
     OPT_PVK_NONE, OPT_PVK_WEAK, OPT_PVK_STRONG,
-    OPT_NOOUT, OPT_TEXT, OPT_MODULUS, OPT_CHECK, OPT_CIPHER
+    OPT_NOOUT, OPT_TEXT, OPT_MODULUS, OPT_CHECK, OPT_CIPHER,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS rsa_options[] = {
@@ -71,6 +72,8 @@ const OPTIONS rsa_options[] = {
     {"pvk-weak", OPT_PVK_WEAK, '-', "Enable 'Weak' PVK encoding level"},
     {"pvk-none", OPT_PVK_NONE, '-', "Don't enforce PVK encoding"},
 # endif
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -159,6 +162,10 @@ int rsa_main(int argc, char **argv)
         case OPT_CIPHER:
             if (!opt_cipher(opt_unknown(), &enc))
                 goto opthelp;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -37,7 +37,7 @@ typedef enum OPTION_choice {
     OPT_RSA_RAW, OPT_OAEP, OPT_SSL, OPT_PKCS, OPT_X931,
     OPT_SIGN, OPT_VERIFY, OPT_REV, OPT_ENCRYPT, OPT_DECRYPT,
     OPT_PUBIN, OPT_CERTIN, OPT_INKEY, OPT_PASSIN, OPT_KEYFORM,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS rsautl_options[] = {
@@ -72,6 +72,7 @@ const OPTIONS rsautl_options[] = {
     {"hexdump", OPT_HEXDUMP, '-', "Hex dump output"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -167,6 +168,10 @@ int rsautl_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -600,7 +600,7 @@ typedef enum OPTION_choice {
     OPT_DANE_TLSA_RRDATA, OPT_DANE_EE_NO_NAME,
     OPT_ENABLE_PHA,
     OPT_SCTP_LABEL_BUG,
-    OPT_R_ENUM
+    OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS s_client_options[] = {
@@ -817,6 +817,7 @@ const OPTIONS s_client_options[] = {
     {"chainCAfile", OPT_CHAINCAFILE, '<',
      "CA file for certificate chain (PEM format)"},
     OPT_X_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"host:port", 0, 0, "Where to connect; same as -connect option"},
@@ -1223,6 +1224,10 @@ int s_client_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_IGN_EOF:

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -757,7 +757,8 @@ typedef enum OPTION_choice {
     OPT_R_ENUM,
     OPT_S_ENUM,
     OPT_V_ENUM,
-    OPT_X_ENUM
+    OPT_X_ENUM,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS s_server_options[] = {
@@ -992,6 +993,7 @@ const OPTIONS s_server_options[] = {
     {"chainCAfile", OPT_CHAINCAFILE, '<',
      "CA file for certificate chain (PEM format)"},
     OPT_X_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -1564,6 +1566,10 @@ int s_server_main(int argc, char *argv[])
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_SERVERNAME:

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -48,7 +48,8 @@ typedef enum OPTION_choice {
     OPT_CAPATH, OPT_CAFILE, OPT_CASTORE,
     OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE,
     OPT_NEW, OPT_REUSE, OPT_BUGS, OPT_VERIFY, OPT_TIME, OPT_SSL3,
-    OPT_WWW, OPT_TLS1, OPT_TLS1_1, OPT_TLS1_2, OPT_TLS1_3
+    OPT_WWW, OPT_TLS1, OPT_TLS1_1, OPT_TLS1_2, OPT_TLS1_3,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS s_time_options[] = {
@@ -99,6 +100,7 @@ const OPTIONS s_time_options[] = {
     {"no-CAstore", OPT_NOCASTORE, '-',
      "Do not load certificates from the default certificates store URI"},
 
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -225,6 +227,10 @@ int s_time_main(int argc, char **argv)
         case OPT_TLS1_3:
             min_version = TLS1_3_VERSION;
             max_version = TLS1_3_VERSION;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -42,7 +42,7 @@ typedef enum OPTION_choice {
     OPT_TO, OPT_FROM, OPT_SUBJECT, OPT_SIGNER, OPT_RECIP, OPT_MD,
     OPT_CIPHER, OPT_INKEY, OPT_KEYFORM, OPT_CERTFILE, OPT_CAFILE,
     OPT_CAPATH, OPT_CASTORE, OPT_NOCAFILE, OPT_NOCAPATH, OPT_NOCASTORE,
-    OPT_R_ENUM,
+    OPT_R_ENUM, OPT_PROV_ENUM,
     OPT_V_ENUM,
     OPT_IN, OPT_INFORM, OPT_OUT,
     OPT_OUTFORM, OPT_CONTENT
@@ -121,6 +121,7 @@ const OPTIONS smime_options[] = {
 
     OPT_R_OPTIONS,
     OPT_V_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"cert", 0, 0, "Recipient certs, used when encrypting"},
@@ -242,6 +243,10 @@ int smime_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_ENGINE:

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -253,7 +253,7 @@ static int opt_found(const char *name, unsigned int *result,
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_ELAPSED, OPT_EVP, OPT_HMAC, OPT_DECRYPT, OPT_ENGINE, OPT_MULTI,
-    OPT_MR, OPT_MB, OPT_MISALIGN, OPT_ASYNCJOBS, OPT_R_ENUM,
+    OPT_MR, OPT_MB, OPT_MISALIGN, OPT_ASYNCJOBS, OPT_R_ENUM, OPT_PROV_ENUM,
     OPT_PRIMES, OPT_SECONDS, OPT_BYTES, OPT_AEAD, OPT_CMAC
 } OPTION_CHOICE;
 
@@ -301,6 +301,7 @@ const OPTIONS speed_options[] = {
      "Use specified offset to mis-align buffers"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"algorithm", 0, 0, "Algorithm(s) to test (optional; otherwise tests all)"},
@@ -1704,6 +1705,10 @@ int speed_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_PRIMES:

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -24,7 +24,8 @@ typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_NOOUT, OPT_PUBKEY, OPT_VERIFY, OPT_IN, OPT_OUT,
     OPT_ENGINE, OPT_KEY, OPT_CHALLENGE, OPT_PASSIN, OPT_SPKAC,
-    OPT_SPKSECT, OPT_KEYFORM
+    OPT_SPKSECT, OPT_KEYFORM,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS spkac_options[] = {
@@ -49,6 +50,8 @@ const OPTIONS spkac_options[] = {
     {"noout", OPT_NOOUT, '-', "Don't print SPKAC"},
     {"pubkey", OPT_PUBKEY, '-', "Output public key"},
     {"verify", OPT_VERIFY, '-', "Verify SPKAC signature"},
+
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -115,6 +118,10 @@ int spkac_main(int argc, char **argv)
             break;
         case OPT_ENGINE:
             e = setup_engine(opt_arg(), 0);
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -193,7 +193,7 @@ typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_VERBOSE, OPT_CONFIG, OPT_NAME, OPT_SRPVFILE, OPT_ADD,
     OPT_DELETE, OPT_MODIFY, OPT_LIST, OPT_GN, OPT_USERINFO,
-    OPT_PASSIN, OPT_PASSOUT, OPT_ENGINE, OPT_R_ENUM
+    OPT_PASSIN, OPT_PASSOUT, OPT_ENGINE, OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS srp_options[] = {
@@ -222,6 +222,7 @@ const OPTIONS srp_options[] = {
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
 
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"user", 0, 0, "Username(s) to process (optional)"},
@@ -295,6 +296,10 @@ int srp_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         }

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -27,7 +27,7 @@ typedef enum OPTION_choice {
     OPT_SEARCHFOR_CERTS, OPT_SEARCHFOR_KEYS, OPT_SEARCHFOR_CRLS,
     OPT_CRITERION_SUBJECT, OPT_CRITERION_ISSUER, OPT_CRITERION_SERIAL,
     OPT_CRITERION_FINGERPRINT, OPT_CRITERION_ALIAS,
-    OPT_MD
+    OPT_MD, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS storeutl_options[] = {
@@ -58,6 +58,8 @@ const OPTIONS storeutl_options[] = {
     {"out", OPT_OUT, '>', "Output file - default stdout"},
     {"text", OPT_TEXT, '-', "Print a text form of the objects"},
     {"noout", OPT_NOOUT, '-', "No PEM output, just status"},
+
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"uri", 0, 0, "URI of the store object"},
@@ -250,6 +252,10 @@ int storeutl_main(int argc, char *argv[])
         case OPT_MD:
             if (!opt_md(opt_unknown(), &digest))
                 goto opthelp;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
+            break;
         }
     }
     argc = opt_num_rest();

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -86,7 +86,7 @@ typedef enum OPTION_choice {
     OPT_IN, OPT_TOKEN_IN, OPT_OUT, OPT_TOKEN_OUT, OPT_TEXT,
     OPT_REPLY, OPT_QUERYFILE, OPT_PASSIN, OPT_INKEY, OPT_SIGNER,
     OPT_CHAIN, OPT_VERIFY, OPT_CAPATH, OPT_CAFILE, OPT_CASTORE, OPT_UNTRUSTED,
-    OPT_MD, OPT_V_ENUM, OPT_R_ENUM
+    OPT_MD, OPT_V_ENUM, OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS ts_options[] = {
@@ -127,6 +127,7 @@ const OPTIONS ts_options[] = {
 
     OPT_R_OPTIONS,
     OPT_V_OPTIONS,
+    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -217,6 +218,10 @@ int ts_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_TSPOLICY:

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -31,7 +31,8 @@ typedef enum OPTION_choice {
     OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE,
     OPT_UNTRUSTED, OPT_TRUSTED, OPT_CRLFILE, OPT_CRL_DOWNLOAD, OPT_SHOW_CHAIN,
     OPT_V_ENUM, OPT_NAMEOPT,
-    OPT_VERBOSE, OPT_SM2ID, OPT_SM2HEXID
+    OPT_VERBOSE, OPT_SM2ID, OPT_SM2HEXID,
+    OPT_PROV_ENUM
 } OPTION_CHOICE;
 
 const OPTIONS verify_options[] = {
@@ -72,6 +73,8 @@ const OPTIONS verify_options[] = {
     {"sm2-hex-id", OPT_SM2HEXID, 's',
      "Specify a hex ID string to verify an SM2 certificate"},
 #endif
+
+    OPT_PROV_OPTIONS,
 
     OPT_PARAMETERS(),
     {"cert", 0, 0, "Certificate(s) to verify (optional; stdin used otherwise)"},
@@ -208,6 +211,10 @@ int verify_main(int argc, char **argv)
                 BIO_printf(bio_err, "Invalid hex string input\n");
                 goto end;
             }
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
+                goto end;
             break;
         }
     }

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -61,7 +61,7 @@ typedef enum OPTION_choice {
     OPT_SUBJECT_HASH_OLD,
     OPT_ISSUER_HASH_OLD,
     OPT_BADSIG, OPT_MD, OPT_ENGINE, OPT_NOCERT, OPT_PRESERVE_DATES,
-    OPT_R_ENUM, OPT_EXT
+    OPT_R_ENUM, OPT_PROV_ENUM, OPT_EXT
 } OPTION_CHOICE;
 
 const OPTIONS x509_options[] = {
@@ -144,6 +144,7 @@ const OPTIONS x509_options[] = {
      "The CA key, must be PEM format; if not in CAfile"},
     {"extfile", OPT_EXTFILE, '<', "File with X509V3 extensions to add"},
     OPT_R_OPTIONS,
+    OPT_PROV_OPTIONS,
     {"CAform", OPT_CAFORM, 'F', "CA format - default PEM"},
     {"CAkeyform", OPT_CAKEYFORM, 'E', "CA key format - default PEM"},
     {"sigopt", OPT_SIGOPT, 's', "Signature parameter in n:v form"},
@@ -268,6 +269,10 @@ int x509_main(int argc, char **argv)
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
+                goto end;
+            break;
+        case OPT_PROV_CASES:
+            if (!opt_provider(o))
                 goto end;
             break;
         case OPT_EXTENSIONS:

--- a/doc/man1/build.info
+++ b/doc/man1/build.info
@@ -1,113 +1,163 @@
 
-# Keep this in sync with .gitignore!
 DEPEND[]= \
+         openssl-asn1parse.pod \
          openssl-ca.pod \
+         openssl-ciphers.pod \
+         openssl-cmds.pod \
          openssl-cms.pod \
+         openssl-crl2pkcs7.pod \
          openssl-crl.pod \
          openssl-dgst.pod \
          openssl-dhparam.pod \
-         openssl-dsa.pod \
          openssl-dsaparam.pod \
-         openssl-ec.pod \
+         openssl-dsa.pod \
          openssl-ecparam.pod \
+         openssl-ec.pod \
          openssl-enc.pod \
+         openssl-engine.pod \
+         openssl-errstr.pod \
+         openssl-fipsinstall.pod \
          openssl-gendsa.pod \
          openssl-genpkey.pod \
          openssl-genrsa.pod \
+         openssl-info.pod \
+         openssl-kdf.pod \
+         openssl-list.pod \
+         openssl-mac.pod \
+         openssl-nseq.pod \
          openssl-ocsp.pod \
          openssl-passwd.pod \
          openssl-pkcs12.pod \
          openssl-pkcs7.pod \
          openssl-pkcs8.pod \
-         openssl-pkey.pod \
          openssl-pkeyparam.pod \
+         openssl-pkey.pod \
          openssl-pkeyutl.pod \
+         openssl-prime.pod \
+         openssl-provider.pod \
          openssl-rand.pod \
+         openssl-rehash.pod \
          openssl-req.pod \
          openssl-rsa.pod \
          openssl-rsautl.pod \
          openssl-s_client.pod \
-         openssl-s_server.pod \
-         openssl-s_time.pod \
+         openssl-sess_id.pod \
          openssl-smime.pod \
          openssl-speed.pod \
          openssl-spkac.pod \
          openssl-srp.pod \
+         openssl-s_server.pod \
+         openssl-s_time.pod \
          openssl-storeutl.pod \
          openssl-ts.pod \
          openssl-verify.pod \
+         openssl-version.pod \
          openssl-x509.pod
 
+DEPEND[openssl-asn1parse.pod]=../perlvars.pm
 DEPEND[openssl-ca.pod]=../perlvars.pm
+DEPEND[openssl-ciphers.pod]=../perlvars.pm
+DEPEND[openssl-cmds.pod]=../perlvars.pm
 DEPEND[openssl-cms.pod]=../perlvars.pm
+DEPEND[openssl-crl2pkcs7.pod]=../perlvars.pm
 DEPEND[openssl-crl.pod]=../perlvars.pm
 DEPEND[openssl-dgst.pod]=../perlvars.pm
 DEPEND[openssl-dhparam.pod]=../perlvars.pm
-DEPEND[openssl-dsa.pod]=../perlvars.pm
 DEPEND[openssl-dsaparam.pod]=../perlvars.pm
-DEPEND[openssl-ec.pod]=../perlvars.pm
+DEPEND[openssl-dsa.pod]=../perlvars.pm
 DEPEND[openssl-ecparam.pod]=../perlvars.pm
+DEPEND[openssl-ec.pod]=../perlvars.pm
 DEPEND[openssl-enc.pod]=../perlvars.pm
+DEPEND[openssl-engine.pod]=../perlvars.pm
+DEPEND[openssl-errstr.pod]=../perlvars.pm
+DEPEND[openssl-fipsinstall.pod]=../perlvars.pm
 DEPEND[openssl-gendsa.pod]=../perlvars.pm
 DEPEND[openssl-genpkey.pod]=../perlvars.pm
 DEPEND[openssl-genrsa.pod]=../perlvars.pm
+DEPEND[openssl-info.pod]=../perlvars.pm
+DEPEND[openssl-kdf.pod]=../perlvars.pm
+DEPEND[openssl-list.pod]=../perlvars.pm
+DEPEND[openssl-mac.pod]=../perlvars.pm
+DEPEND[openssl-nseq.pod]=../perlvars.pm
 DEPEND[openssl-ocsp.pod]=../perlvars.pm
 DEPEND[openssl-passwd.pod]=../perlvars.pm
 DEPEND[openssl-pkcs12.pod]=../perlvars.pm
 DEPEND[openssl-pkcs7.pod]=../perlvars.pm
 DEPEND[openssl-pkcs8.pod]=../perlvars.pm
-DEPEND[openssl-pkey.pod]=../perlvars.pm
 DEPEND[openssl-pkeyparam.pod]=../perlvars.pm
+DEPEND[openssl-pkey.pod]=../perlvars.pm
 DEPEND[openssl-pkeyutl.pod]=../perlvars.pm
+DEPEND[openssl-prime.pod]=../perlvars.pm
+DEPEND[openssl-provider.pod]=../perlvars.pm
 DEPEND[openssl-rand.pod]=../perlvars.pm
+DEPEND[openssl-rehash.pod]=../perlvars.pm
 DEPEND[openssl-req.pod]=../perlvars.pm
 DEPEND[openssl-rsa.pod]=../perlvars.pm
 DEPEND[openssl-rsautl.pod]=../perlvars.pm
 DEPEND[openssl-s_client.pod]=../perlvars.pm
-DEPEND[openssl-s_server.pod]=../perlvars.pm
-DEPEND[openssl-s_time.pod]=../perlvars.pm
+DEPEND[openssl-sess_id.pod]=../perlvars.pm
 DEPEND[openssl-smime.pod]=../perlvars.pm
 DEPEND[openssl-speed.pod]=../perlvars.pm
 DEPEND[openssl-spkac.pod]=../perlvars.pm
 DEPEND[openssl-srp.pod]=../perlvars.pm
+DEPEND[openssl-s_server.pod]=../perlvars.pm
+DEPEND[openssl-s_time.pod]=../perlvars.pm
 DEPEND[openssl-storeutl.pod]=../perlvars.pm
 DEPEND[openssl-ts.pod]=../perlvars.pm
 DEPEND[openssl-verify.pod]=../perlvars.pm
+DEPEND[openssl-version.pod]=../perlvars.pm
 DEPEND[openssl-x509.pod]=../perlvars.pm
 
+GENERATE[openssl-asn1parse.pod]=openssl-asn1parse.pod.in
 GENERATE[openssl-ca.pod]=openssl-ca.pod.in
+GENERATE[openssl-ciphers.pod]=openssl-ciphers.pod.in
+GENERATE[openssl-cmds.pod]=openssl-cmds.pod.in
 GENERATE[openssl-cms.pod]=openssl-cms.pod.in
+GENERATE[openssl-crl2pkcs7.pod]=openssl-crl2pkcs7.pod.in
 GENERATE[openssl-crl.pod]=openssl-crl.pod.in
 GENERATE[openssl-dgst.pod]=openssl-dgst.pod.in
 GENERATE[openssl-dhparam.pod]=openssl-dhparam.pod.in
-GENERATE[openssl-dsa.pod]=openssl-dsa.pod.in
 GENERATE[openssl-dsaparam.pod]=openssl-dsaparam.pod.in
-GENERATE[openssl-ec.pod]=openssl-ec.pod.in
+GENERATE[openssl-dsa.pod]=openssl-dsa.pod.in
 GENERATE[openssl-ecparam.pod]=openssl-ecparam.pod.in
+GENERATE[openssl-ec.pod]=openssl-ec.pod.in
 GENERATE[openssl-enc.pod]=openssl-enc.pod.in
+GENERATE[openssl-engine.pod]=openssl-engine.pod.in
+GENERATE[openssl-errstr.pod]=openssl-errstr.pod.in
+GENERATE[openssl-fipsinstall.pod]=openssl-fipsinstall.pod.in
 GENERATE[openssl-gendsa.pod]=openssl-gendsa.pod.in
 GENERATE[openssl-genpkey.pod]=openssl-genpkey.pod.in
 GENERATE[openssl-genrsa.pod]=openssl-genrsa.pod.in
+GENERATE[openssl-info.pod]=openssl-info.pod.in
+GENERATE[openssl-kdf.pod]=openssl-kdf.pod.in
+GENERATE[openssl-list.pod]=openssl-list.pod.in
+GENERATE[openssl-mac.pod]=openssl-mac.pod.in
+GENERATE[openssl-nseq.pod]=openssl-nseq.pod.in
 GENERATE[openssl-ocsp.pod]=openssl-ocsp.pod.in
 GENERATE[openssl-passwd.pod]=openssl-passwd.pod.in
 GENERATE[openssl-pkcs12.pod]=openssl-pkcs12.pod.in
 GENERATE[openssl-pkcs7.pod]=openssl-pkcs7.pod.in
 GENERATE[openssl-pkcs8.pod]=openssl-pkcs8.pod.in
-GENERATE[openssl-pkey.pod]=openssl-pkey.pod.in
 GENERATE[openssl-pkeyparam.pod]=openssl-pkeyparam.pod.in
+GENERATE[openssl-pkey.pod]=openssl-pkey.pod.in
 GENERATE[openssl-pkeyutl.pod]=openssl-pkeyutl.pod.in
+GENERATE[openssl-prime.pod]=openssl-prime.pod.in
+GENERATE[openssl-provider.pod]=openssl-provider.pod.in
 GENERATE[openssl-rand.pod]=openssl-rand.pod.in
+GENERATE[openssl-rehash.pod]=openssl-rehash.pod.in
 GENERATE[openssl-req.pod]=openssl-req.pod.in
 GENERATE[openssl-rsa.pod]=openssl-rsa.pod.in
 GENERATE[openssl-rsautl.pod]=openssl-rsautl.pod.in
 GENERATE[openssl-s_client.pod]=openssl-s_client.pod.in
-GENERATE[openssl-s_server.pod]=openssl-s_server.pod.in
-GENERATE[openssl-s_time.pod]=openssl-s_time.pod.in
+GENERATE[openssl-sess_id.pod]=openssl-sess_id.pod.in
 GENERATE[openssl-smime.pod]=openssl-smime.pod.in
 GENERATE[openssl-speed.pod]=openssl-speed.pod.in
 GENERATE[openssl-spkac.pod]=openssl-spkac.pod.in
 GENERATE[openssl-srp.pod]=openssl-srp.pod.in
+GENERATE[openssl-s_server.pod]=openssl-s_server.pod.in
+GENERATE[openssl-s_time.pod]=openssl-s_time.pod.in
 GENERATE[openssl-storeutl.pod]=openssl-storeutl.pod.in
 GENERATE[openssl-ts.pod]=openssl-ts.pod.in
 GENERATE[openssl-verify.pod]=openssl-verify.pod.in
+GENERATE[openssl-version.pod]=openssl-version.pod.in
 GENERATE[openssl-x509.pod]=openssl-x509.pod.in

--- a/doc/man1/openssl-asn1parse.pod.in
+++ b/doc/man1/openssl-asn1parse.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -59,6 +59,7 @@ B<openssl> B<ca>
 [B<-sm2-hex-id> I<hex-string>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<certreq>...]
 
 =for openssl ifdef engine sm2-id sm2-hex-id
@@ -307,6 +308,8 @@ certificate. The argument for this option is string of hexadecimal digits.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -23,6 +23,7 @@ B<openssl> B<ciphers>
 [B<-stdname>]
 [B<-convert> I<name>]
 [B<-ciphersuites> I<val>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<cipherlist>]
 
 =for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 psk srp
@@ -40,6 +41,8 @@ determine the appropriate cipherlist.
 =item B<-help>
 
 Print a usage message.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item B<-s>
 

--- a/doc/man1/openssl-cmds.pod.in
+++ b/doc/man1/openssl-cmds.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -81,6 +81,7 @@ B<openssl> B<cms>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<cert.pem> ...]
 
 =for openssl ifdef des-wrap engine
@@ -489,6 +490,8 @@ Any verification errors cause the command to exit.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item I<cert.pem> ...
 

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -29,6 +29,7 @@ B<openssl> B<crl>
 [B<-nextupdate>]
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef hash_old
 
@@ -122,6 +123,8 @@ Output the nextUpdate field.
 {- $OpenSSL::safe::opt_name_item -}
 
 {- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-crl2pkcs7.pod.in
+++ b/doc/man1/openssl-crl2pkcs7.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-crl2pkcs7.pod.in
+++ b/doc/man1/openssl-crl2pkcs7.pod.in
@@ -15,6 +15,7 @@ B<openssl> B<crl2pkcs7>
 [B<-out> I<filename>]
 [B<-certfile> I<filename>]
 [B<-nocrl>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =head1 DESCRIPTION
 
@@ -61,6 +62,8 @@ files.
 
 Normally a CRL is included in the output file. With this option no CRL is
 included in the output file and a CRL is not read from the input file.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -32,6 +32,7 @@ B<openssl> B<dgst>|I<digest>
 {- $OpenSSL::safe::opt_engine_synopsis -}
 [B<-engine_impl> I<id>]
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<file> ...]
 
 =head1 DESCRIPTION
@@ -183,6 +184,8 @@ used or it is configured to do so, see L<config(5)/Engine Configuration Module>.
 
 When used with the B<-engine> option, it specifies to also use
 engine I<id> for digest operations.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item I<file> ...
 

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -23,6 +23,7 @@ B<openssl dhparam>
 [B<-5>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<numbits>]
 
 =for openssl ifdef dsaparam engine
@@ -108,6 +109,8 @@ be loaded by calling the get_dhNNNN() function.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-dsa.pod.in
+++ b/doc/man1/openssl-dsa.pod.in
@@ -37,6 +37,7 @@ B<openssl> B<dsa>
 [B<-pubin>]
 [B<-pubout>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef pvk-string pvk-weak pvk-none engine
 
@@ -122,6 +123,8 @@ key will be output instead. This option is automatically set if the input is
 a public key.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -20,6 +20,7 @@ B<openssl dsaparam>
 [B<-verbose>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<numbits>]
 
 =head1 DESCRIPTION
@@ -92,6 +93,8 @@ Print extra details about the operations being performed.
 This option specifies that a parameter set should be generated of size
 I<numbits>. It must be the last option. If this option is included then
 the input file (if any) is ignored.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -32,6 +32,7 @@ B<openssl> B<ec>
 [B<-no_public>]
 [B<-check>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -140,6 +141,8 @@ This option omits the public key components from the private key output.
 This option checks the consistency of an EC private or public key.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -26,6 +26,7 @@ B<openssl ecparam>
 [B<-genkey>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -129,6 +130,8 @@ This option will generate an EC private key using the specified parameters.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -40,6 +40,7 @@ B<openssl> B<enc>|I<cipher>
 [B<-none>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef z engine ciphers
 
@@ -196,6 +197,8 @@ or zlib-dynamic option.
 Use NULL cipher (no encryption or decryption of input).
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
 

--- a/doc/man1/openssl-engine.pod.in
+++ b/doc/man1/openssl-engine.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-errstr.pod.in
+++ b/doc/man1/openssl-errstr.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -26,6 +26,7 @@ B<openssl> B<gendsa>
 [B<-verbose>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<paramfile>]
 
 =for openssl ifdef engine
@@ -75,6 +76,8 @@ Print extra details about the operations being performed.
 The DSA parameter file to use. The parameters in this file determine
 the size of the private key. DSA parameters can be generated and
 examined using the L<openssl-dsaparam(1)> command.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -23,6 +23,7 @@ B<openssl> B<genpkey>
 [B<-genparam>]
 [B<-text>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -103,6 +104,8 @@ Print an (unencrypted) text representation of private and public keys and
 parameters along with the PEM or DER structure.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -30,6 +30,7 @@ B<openssl> B<genrsa>
 [B<-verbose>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [B<numbits>]
 
 =for openssl ifdef engine
@@ -84,6 +85,8 @@ Print extra details about the operations being performed.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item B<numbits>
 

--- a/doc/man1/openssl-info.pod.in
+++ b/doc/man1/openssl-info.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -13,6 +13,7 @@ B<openssl kdf>
 [B<-keylen> I<num>]
 [B<-out> I<filename>]
 [B<-binary>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 I<kdf_name>
 
 =head1 DESCRIPTION
@@ -79,6 +80,8 @@ Specifies the name of a digest as an alphanumeric string.
 To see the list of supported digests, use the command I<list -digest-commands>.
 
 =back
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item I<kdf_name>
 

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -24,6 +24,7 @@ B<openssl list>
 [B<-disabled>]
 [B<-objects>]
 [B<-options> I<command>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =head1 DESCRIPTION
 
@@ -102,6 +103,8 @@ The first is the option name, and the second is a one-character indication
 of what type of parameter it takes, if any.
 This is an internal option, used for checking that the documentation
 is complete.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-mac.pod.in
+++ b/doc/man1/openssl-mac.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-mac.pod.in
+++ b/doc/man1/openssl-mac.pod.in
@@ -13,6 +13,7 @@ B<openssl mac>
 [B<-in> I<filename>]
 [B<-out> I<filename>]
 [B<-binary>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 I<mac_name>
 
 =head1 DESCRIPTION
@@ -99,6 +100,8 @@ Used by KMAC128 or KMAC256 to specify a customization string.
 The default is the empty string "".
 
 =back
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item I<mac_name>
 

--- a/doc/man1/openssl-nseq.pod.in
+++ b/doc/man1/openssl-nseq.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-nseq.pod.in
+++ b/doc/man1/openssl-nseq.pod.in
@@ -12,6 +12,7 @@ B<openssl> B<nseq>
 [B<-in> I<filename>]
 [B<-out> I<filename>]
 [B<-toseq>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =head1 DESCRIPTION
 
@@ -48,6 +49,8 @@ Normally a Netscape certificate sequence will be input and the output
 is the certificates contained in it. With the B<-toseq> option the
 situation is reversed: a Netscape certificate sequence is created from
 a file of certificates.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -70,6 +70,7 @@ B<openssl> B<ocsp>
 [B<-I<digest>>]
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_v_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef multi
 
@@ -268,6 +269,8 @@ digest used by subsequent certificate identifiers.
 {- $OpenSSL::safe::opt_trust_item -}
 
 {- $OpenSSL::safe::opt_v_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-passwd.pod.in
+++ b/doc/man1/openssl-passwd.pod.in
@@ -23,6 +23,7 @@ B<openssl passwd>
 [B<-table>]
 [B<-reverse>]
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<password>]
 
 =for openssl ifdef crypt
@@ -99,6 +100,8 @@ to each password hash.
 When the B<-table> option is used, reverse the order of cleartext and hash.
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -57,6 +57,7 @@ B<openssl> B<pkcs12>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -292,6 +293,8 @@ Write I<name> as a Microsoft CSP name.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-pkcs7.pod.in
+++ b/doc/man1/openssl-pkcs7.pod.in
@@ -22,6 +22,7 @@ B<openssl> B<pkcs7>
 [B<-text>]
 [B<-noout>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -76,6 +77,8 @@ Don't output the encoded version of the PKCS#7 structure (or certificates
 if B<-print_certs> is set).
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -29,6 +29,7 @@ B<openssl> B<pkcs8>
 [B<-scrypt_p> I<p>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine scrypt scrypt_N scrypt_r scrypt_p
 
@@ -149,6 +150,8 @@ Sets the scrypt I<N>, I<r> or I<p> parameters.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -31,6 +31,7 @@ B<openssl> B<pkey>
 [B<-ec_conv_form> I<arg>]
 [B<-ec_param_enc> I<arg>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -141,6 +142,8 @@ B<Note> the B<implicitlyCA> alternative, as specified in RFC 3279,
 is currently not implemented in OpenSSL.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-pkeyparam.pod.in
+++ b/doc/man1/openssl-pkeyparam.pod.in
@@ -19,6 +19,7 @@ B<openssl> B<pkeyparam>
 [B<-noout>]
 [B<-check>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -58,6 +59,8 @@ Do not output the encoded version of the parameters.
 This option checks the correctness of parameters.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -37,6 +37,7 @@ B<openssl> B<pkeyutl>
 {- $OpenSSL::safe::opt_engine_synopsis -}
 [B<-engine_impl>]
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine engine_impl
 
@@ -187,6 +188,8 @@ When used with the B<-engine> option, it specifies to also use
 engine I<id> for crypto operations.
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-prime.pod.in
+++ b/doc/man1/openssl-prime.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-prime.pod.in
+++ b/doc/man1/openssl-prime.pod.in
@@ -13,6 +13,7 @@ B<openssl prime>
 [B<-generate>]
 [B<-bits> I<num>]
 [B<-safe>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [B<-checks> I<num>]
 [I<number> ...]
 
@@ -48,6 +49,8 @@ Generate a prime with I<num> bits.
 
 When used with B<-generate>, generates a "safe" prime. If the number
 generated is I<n>, then check that C<(I<n>-1)/2> is also prime.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item B<-checks> I<num>
 

--- a/doc/man1/openssl-provider.pod.in
+++ b/doc/man1/openssl-provider.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -14,6 +14,7 @@ B<openssl rand>
 [B<-hex>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 I<num>
 
 =for openssl ifdef engine
@@ -52,6 +53,8 @@ Show the output as a hex string.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -19,6 +19,7 @@ B<rehash>
 [B<-compat>]
 [B<-n>]
 [B<-v>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<directory>] ...
 
 B<c_rehash>
@@ -27,6 +28,7 @@ B<c_rehash>
 [B<-old>]
 [B<-n>]
 [B<-v>]
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<directory>] ...
 
 =head1 DESCRIPTION
@@ -116,6 +118,8 @@ releases.
 
 Print messages about old links removed and new links created.
 By default, this command only lists each directory as it is processed.
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-rehash.pod.in
+++ b/doc/man1/openssl-rehash.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =for comment
 Original text by James Westby, contributed under the OpenSSL license.

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -51,6 +51,7 @@ B<openssl> B<req>
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine keygen_engine sm2-id sm2-hex-id
 
@@ -322,6 +323,8 @@ argument for this option is string of hexadecimal digits.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-rsa.pod.in
+++ b/doc/man1/openssl-rsa.pod.in
@@ -40,6 +40,7 @@ B<openssl> B<rsa>
 [B<-RSAPublicKey_in>]
 [B<-RSAPublicKey_out>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef pvk-strong pvk-weak pvk-none engine
 
@@ -135,6 +136,8 @@ the input is a public key.
 Like B<-pubin> and B<-pubout> except B<RSAPublicKey> format is used instead.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-rsautl.pod.in
+++ b/doc/man1/openssl-rsautl.pod.in
@@ -33,6 +33,7 @@ B<openssl> B<rsautl>
 [B<-asn1parse>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -125,6 +126,8 @@ B<-verify> option.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -120,6 +120,7 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_s_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
 [B<-ssl_client_engine> I<id>]
 {- $OpenSSL::safe::opt_v_synopsis -}
@@ -757,6 +758,8 @@ Set the minimal acceptable length, in bits, for B<N>.
 {- $OpenSSL::safe::opt_s_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -140,6 +140,7 @@ B<openssl> B<s_server>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef unix 4 6 unlink no_dhe nextprotoneg use_srtp engine
 
@@ -660,6 +661,8 @@ data that was sent will be rejected.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 {- $OpenSSL::safe::opt_v_item -}
 

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -28,6 +28,7 @@ B<openssl> B<s_time>
 {- $OpenSSL::safe::opt_name_synopsis -}
 [B<-cafile> I<file>]
 {- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3
 
@@ -121,6 +122,8 @@ can establish.
 {- $OpenSSL::safe::opt_name_item -}
 
 {- $OpenSSL::safe::opt_trust_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item B<-cafile> I<file>
 

--- a/doc/man1/openssl-sess_id.pod.in
+++ b/doc/man1/openssl-sess_id.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -49,6 +49,7 @@ B<openssl> B<smime>
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_v_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 I<cert.pem> ...
 
 =for openssl ifdef engine
@@ -287,6 +288,8 @@ Any verification errors cause the command to exit.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item I<cert.pem> ...
 

--- a/doc/man1/openssl-speed.pod.in
+++ b/doc/man1/openssl-speed.pod.in
@@ -25,6 +25,7 @@ B<openssl speed>
 [B<-mr>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<algorithm> ...]
 
 =for openssl ifdef hmac cmac multi async_jobs engine
@@ -102,6 +103,8 @@ Produce the summary in a mechanical, machine-readable, format.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item I<algorithm> ...
 

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -25,6 +25,7 @@ B<openssl> B<spkac>
 [B<-noout>]
 [B<-verify>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -98,6 +99,8 @@ being created).
 Verifies the digital signature on the supplied SPKAC.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-srp.pod.in
+++ b/doc/man1/openssl-srp.pod.in
@@ -23,6 +23,7 @@ B<openssl srp>
 [B<-passout> I<arg>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<user> ...]
 
 =for openssl ifdef engine
@@ -73,6 +74,8 @@ For more information about the format of B<arg>
 see L<openssl(1)/Pass Phrase Options>.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 {- $OpenSSL::safe::opt_r_synopsis -}
 

--- a/doc/man1/openssl-storeutl.pod.in
+++ b/doc/man1/openssl-storeutl.pod.in
@@ -28,6 +28,7 @@ B<openssl> B<storeutl>
 [B<-fingerprint> I<arg>]
 [B<-I<digest>>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 I<uri> ...
 
 =head1 DESCRIPTION
@@ -109,6 +110,8 @@ Search for an object having the given fingerprint.
 The digest that was used to compute the fingerprint given with B<-fingerprint>.
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -23,6 +23,7 @@ B<-query>
 [B<-out> I<request.tsq>]
 [B<-text>]
 {- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 B<openssl> B<ts>
 B<-reply>
@@ -42,6 +43,7 @@ B<-reply>
 [B<-token_out>]
 [B<-text>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 B<openssl> B<ts>
 B<-verify>
@@ -54,6 +56,7 @@ B<-verify>
 [B<-CApath> I<dir>]
 [B<-CAstore> I<uri>]
 {- $OpenSSL::safe::opt_v_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -284,6 +287,8 @@ If this option is specified the output is human-readable text format
 instead of DER. (Optional)
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -21,6 +21,7 @@ B<openssl> B<verify>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_v_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 [B<-->]
 [I<certificate> ...]
 
@@ -90,6 +91,8 @@ B<-trusted>, B<-untrusted> or B<-CRLfile> options.
 {- $OpenSSL::safe::opt_trust_item -}
 
 {- $OpenSSL::safe::opt_v_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item B<-->
 

--- a/doc/man1/openssl-version.pod.in
+++ b/doc/man1/openssl-version.pod.in
@@ -1,4 +1,5 @@
 =pod
+{- OpenSSL::safe::output_do_not_edit_headers(); -}
 
 =head1 NAME
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -75,6 +75,7 @@ B<openssl> B<x509>
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}
+{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine subject_hash_old issuer_hash_old
 
@@ -134,6 +135,8 @@ Cannot be used with the B<-days> option.
 {- $OpenSSL::safe::opt_r_synopsis -}
 
 {- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -755,6 +755,26 @@ This file can be used in a subsequent command invocation.
 
 =back
 
+=head2 Provider Options
+
+With the move to provider based cryptographic operations in OpenSSL 3.0,
+options were added to allow specific providers or sets of providers to be used.
+
+=over 4
+
+=item B<-provider> I<name>
+
+Use the provider identified by I<name> and use all the methods it
+implements (algorithms, key storage, etc.).  This option can be specified
+multiple time to load more than one provider.
+
+=item B<-provider_path> I<path>
+
+Specify the search I<path> that is used to locate provider modules.  The format
+of I<path> varies depending on the operating system being used.
+
+=back
+
 =head2 Extended Verification Options
 
 Sometimes there may be more than one certificate chain leading to an

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+OSSL_PROVIDER_set_default_search_path,
 OSSL_PROVIDER, OSSL_PROVIDER_load, OSSL_PROVIDER_unload,
 OSSL_PROVIDER_available,
 OSSL_PROVIDER_gettable_params, OSSL_PROVIDER_get_params,
@@ -12,6 +13,9 @@ OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name - provider routines
  #include <openssl/provider.h>
 
  typedef struct ossl_provider_st OSSL_PROVIDER;
+
+ void OSSL_PROVIDER_set_default_search_path(OPENSSL_CTX *libctx,
+                                            const char *path);
 
  OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *libctx, const char *name);
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
@@ -38,6 +42,11 @@ Some of these functions operate within a library context, please see
 L<OPENSSL_CTX(3)> for further details.
 
 =head2 Functions
+
+OSSL_PROVIDER_set_default_search_path() specifies the default search B<path>
+that is to be used for looking for providers in the specified B<libctx>.
+If left unspecified, an environment variable and a fall back default value will
+be used instead.
 
 OSSL_PROVIDER_add_builtin() is used to add a built in provider to
 B<OSSL_PROVIDER> store in the given library context, by associating a

--- a/doc/perlvars.pm
+++ b/doc/perlvars.pm
@@ -88,6 +88,17 @@ $OpenSSL::safe::opt_r_item = ""
 . "\n"
 . "See L<openssl(1)/Random State Options> for details.";
 
+# Provider options
+$OpenSSL::safe::opt_provider_synopsis = ""
+. "[B<-provider> I<name>]\n"
+. "[B<-provider_path> I<path>]";
+$OpenSSL::safe::opt_provider_item = ""
+. "=item B<-provider> I<name>\n"
+. "\n"
+. "=item B<-provider_path> I<path>\n"
+. "\n"
+. "See L<openssl(1)/Provider Options>.";
+
 # Engine option
 $OpenSSL::safe::opt_engine_synopsis = ""
 . "[B<-engine> I<id>]";

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -16,6 +16,9 @@
 extern "C" {
 # endif
 
+/* Set the default provider search path */
+int OSSL_PROVIDER_set_default_search_path(OPENSSL_CTX *, const char *path);
+
 /* Load and unload a provider */
 OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4955,3 +4955,4 @@ OSSL_SELF_TEST_free                     ?	3_0_0	EXIST::FUNCTION:
 OSSL_SELF_TEST_onbegin                  ?	3_0_0	EXIST::FUNCTION:
 OSSL_SELF_TEST_oncorrupt_byte           ?	3_0_0	EXIST::FUNCTION:
 OSSL_SELF_TEST_onend                    ?	3_0_0	EXIST::FUNCTION:
+OSSL_PROVIDER_set_default_search_path   ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Compare with #11160.

Add a -provider option to allow providers to be loaded. This option can be
specified multiple times.

Add a -provider_path option to allow the path to providers to be specified.

- [ ] documentation is added or updated
- [ ] tests are added or updated
