### PR TITLE
Configuration: Add post module building check

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -29,14 +29,19 @@ my %shared_info;
         shared_sonameflag     => '-Wl,-soname=',
     },
     'linux-shared' => sub {
+        my $zdefs =
+            (grep /(?:^|\s)-fsanitize/,
+             @{$config{CFLAGS}}, @{$config{cflags}})
+            ? ''
+            : '-z defs';
         return {
             %{$shared_info{'gnu-shared'}},
             shared_defflag    => '-Wl,--version-script=',
-            dso_ldflags       =>
-                (grep /(?:^|\s)-fsanitize/,
-                 @{$config{CFLAGS}}, @{$config{cflags}})
-                ? ''
-                : '-z defs',
+            dso_ldflags       => $zdefs,
+            dso_post_cmd      =>
+                $zdefs
+                ? 'test `nm -u $@ | grep -v @@GLIBC | grep -v " _" | wc -l` = 0'
+                : undef,
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1455,13 +1455,17 @@ EOF
                       fill_lines(' ', $COLUMNS - length($dso) - 2,
                                  @objs, @defs, @deps));
 
-      return <<"EOF";
+      my $out = <<"EOF";
 $dso: $deps
 	\$(CC) \$(DSO_CFLAGS) $linkflags\$(DSO_LDFLAGS) \\
 		-o $dso$shared_def \\
 		$objs \\
 		$linklibs\$(DSO_EX_LIBS)
 EOF
+      if (defined $target{dso_post_cmd}) {
+          $out .= "\t" . $target{dso_post_cmd} . "\n";
+      }
+      return $out;
   }
   sub obj2lib {
       my %args = @_;


### PR DESCRIPTION
We want an extra check that the FIPS provider module has resolved all
symbols except the standard library ones.  This is generalized with
the addition of a 'dso_post_cmd' config target attribute, that holds
the command line to do the check.

For the moment, we only do this for module building with the
'linux-shared' shared library scheme and its derivatives.

Fixes #11020
