### PR TITLE
apps x509: passing PKCS#11 URL as -signkey [1.1.1]

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -107,7 +107,7 @@ const OPTIONS x509_options[] = {
     {"checkend", OPT_CHECKEND, 'M',
      "Check whether the cert expires in the next arg seconds"},
     {OPT_MORE_STR, 1, 1, "Exit 1 if so, 0 if not"},
-    {"signkey", OPT_SIGNKEY, '<', "Self sign cert with arg"},
+    {"signkey", OPT_SIGNKEY, 's', "Self sign cert with arg"},
     {"x509toreq", OPT_X509TOREQ, '-',
      "Output a certification request object"},
     {"req", OPT_REQ, '-', "Input is a certificate request, sign and output"},

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -44,7 +44,7 @@ B<openssl> B<x509>
 [B<-setalias arg>]
 [B<-days arg>]
 [B<-set_serial n>]
-[B<-signkey filename>]
+[B<-signkey arg>]
 [B<-passin arg>]
 [B<-x509toreq>]
 [B<-req>]
@@ -350,10 +350,11 @@ can thus behave like a "mini CA".
 
 =over 4
 
-=item B<-signkey filename>
+=item B<-signkey arg>
 
 This option causes the input file to be self signed using the supplied
-private key.
+private key or engine. The private key's format is specified with the
+B<-keyform> option.
 
 If the input file is a certificate it sets the issuer name to the
 subject name (i.e.  makes it self signed) changes the public key to the


### PR DESCRIPTION
OpenSSL 1.1.0 has extended option checking, and rejects passing a PKCS#11
engine URL to "-signkey" option. The actual code is ready to take it.

Change the option parsing to allow an engine URL to be passed and modify
the manpage accordingly.

Backports #11086.

##### Checklist
- [x] documentation is added or updated