### PR TITLE
Update some FIPS module things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,14 +67,13 @@ providers/common/include/prov/der_rsa.h
 /test/rsa_complex
 /test/confdump
 /test/bio_prefix_text
-# Other generated files in test/
-/test/provider_internal_test.cnf
-/test/fipsinstall.cnf
-/providers/fipsinstall.cnf
 
 # Certain files that get created by tests on the fly
 /test-runs
 /test/buildtest_*
+/test/provider_internal_test.cnf
+/test/fipsmodule.cnf
+/providers/fipsmodule.cnf
 
 # Fuzz stuff.
 # Anything without an extension is an executable on Unix, so we keep files

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -31,12 +31,13 @@ static OSSL_CALLBACK self_test_events;
 static char *self_test_corrupt_desc = NULL;
 static char *self_test_corrupt_type = NULL;
 static int self_test_log = 1;
+static int quiet = 0;
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_IN, OPT_OUT, OPT_MODULE,
     OPT_PROV_NAME, OPT_SECTION_NAME, OPT_MAC_NAME, OPT_MACOPT, OPT_VERIFY,
-    OPT_NO_LOG, OPT_CORRUPT_DESC, OPT_CORRUPT_TYPE
+    OPT_NO_LOG, OPT_CORRUPT_DESC, OPT_CORRUPT_TYPE, OPT_QUIET
 } OPTION_CHOICE;
 
 const OPTIONS fipsinstall_options[] = {
@@ -60,6 +61,7 @@ const OPTIONS fipsinstall_options[] = {
     {"noout", OPT_NO_LOG, '-', "Disable logging of self test events"},
     {"corrupt_desc", OPT_CORRUPT_DESC, 's', "Corrupt a self test by description"},
     {"corrupt_type", OPT_CORRUPT_TYPE, 's', "Corrupt a self test by type"},
+    {"quiet", OPT_QUIET, '-', "No messages, just exit status"},
     {NULL}
 };
 
@@ -287,7 +289,7 @@ int fipsinstall_main(int argc, char **argv)
         case OPT_ERR:
 opthelp:
             BIO_printf(bio_err, "%s: Use -help for summary.\n", prog);
-            goto end;
+            goto cleanup;
         case OPT_HELP:
             opt_help(fipsinstall_options);
             ret = 0;
@@ -298,6 +300,9 @@ opthelp:
         case OPT_OUT:
             out_fname = opt_arg();
             break;
+        case OPT_QUIET:
+            quiet = 1;
+            /* FALLTHROUGH */
         case OPT_NO_LOG:
             self_test_log = 0;
             break;
@@ -405,7 +410,8 @@ opthelp:
         if (!verify_config(in_fname, section_name, module_mac, module_mac_len,
                            install_mac, install_mac_len))
             goto end;
-        BIO_printf(bio_out, "VERIFY PASSED\n");
+        if (!quiet)
+            BIO_printf(bio_out, "VERIFY PASSED\n");
     } else {
 
         conf = generate_config_and_load(prov_name, section_name, module_mac,
@@ -424,16 +430,19 @@ opthelp:
                                        module_mac_len, install_mac,
                                        install_mac_len))
             goto end;
-        BIO_printf(bio_out, "INSTALL PASSED\n");
+        if (!quiet)
+            BIO_printf(bio_out, "INSTALL PASSED\n");
     }
 
     ret = 0;
 end:
     if (ret == 1) {
-        BIO_printf(bio_err, "%s FAILED\n", verify ? "VERIFY" : "INSTALL");
+        if (!quiet)
+            BIO_printf(bio_err, "%s FAILED\n", verify ? "VERIFY" : "INSTALL");
         ERR_print_errors(bio_err);
     }
 
+cleanup:
     BIO_free(fout);
     BIO_free(mem_bio);
     BIO_free(module_bio);

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -18,6 +18,7 @@ B<openssl fipsinstall>
 [B<-mac_name> I<macname>]
 [B<-macopt> I<nm>:I<v>]
 [B<-noout>]
+[B<-quiet>]
 [B<-corrupt_desc> I<selftest_description>]
 [B<-corrupt_type> I<selftest_type>]
 
@@ -114,9 +115,12 @@ C<openssl list -digest-commands>.
 
 Disable logging of the self tests.
 
-=item B<-corrupt_desc> I<selftest_description>
+=item B<-quiet>
 
-=item B<-corrupt_type> I<selftest_type>
+Do not output pass/fail messages. Implies B<-noout>.
+
+=item B<-corrupt_desc> I<selftest_description>,
+B<-corrupt_type> I<selftest_type>
 
 The corrupt options can be used to test failure of one or more self test(s) by
 name.

--- a/test/default-and-fips.cnf
+++ b/test/default-and-fips.cnf
@@ -1,6 +1,6 @@
 openssl_conf = openssl_init
 
-.include fipsinstall.cnf
+.include fipsmodule.cnf
 
 [openssl_init]
 providers = provider_sect

--- a/test/fips.cnf
+++ b/test/fips.cnf
@@ -1,6 +1,6 @@
 openssl_conf = openssl_init
 
-.include fipsinstall.cnf
+.include fipsmodule.cnf
 
 [openssl_init]
 providers = provider_sect

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -84,7 +84,7 @@ unless ($no_fips) {
     $ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
 
     ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                 '-module', $infile,
                 '-provider_name', 'fips', '-mac_name', 'HMAC',
                 '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -48,7 +48,7 @@ my @testdata = (
 unless ($no_fips) {
     push @setups, {
         cmd     => app(['openssl', 'fipsinstall',
-                        '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                        '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                         '-module', bldtop_file('providers', platform->dso('fips')),
                         '-provider_name', 'fips', '-mac_name', 'HMAC',
                         '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -119,7 +119,7 @@ my %skip = (
 
 unless ($no_fips) {
     ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                 '-module', bldtop_file('providers', platform->dso('fips')),
                 '-provider_name', 'fips', '-mac_name', 'HMAC',
                 '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -94,7 +94,7 @@ plan tests =>
 
 unless ($no_fips) {
     ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                 '-module', bldtop_file('providers', platform->dso('fips')),
                 '-provider_name', 'fips', '-mac_name', 'HMAC',
                 '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -41,7 +41,7 @@ ok(run(test(["sslapitest", srctop_dir("test", "certs"),
 
 unless ($no_fips) {
     ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                 '-module', bldtop_file('providers', platform->dso('fips')),
                 '-provider_name', 'fips', '-mac_name', 'HMAC',
                 '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',

--- a/test/recipes/90-test_sslprovider.t
+++ b/test/recipes/90-test_sslprovider.t
@@ -31,7 +31,7 @@ SKIP: {
         if disabled("fips");
 
     ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                 '-module', bldtop_file('providers', platform->dso('fips')),
                 '-provider_name', 'fips', '-mac_name', 'HMAC',
                 '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',


### PR DESCRIPTION
- The generated config for the module signature is "fipsmodule.conf",
since it's about the module.  This is a more sensible name for the user community.
- Add -q option to fipsinstall command, to stop chatty verbose status
messages. This is normally done at install/boot time, and we don't want extra status/noise messages.
- Document env var OPENSSL_CONF_INCLUDE. This is just a doc bug.
