### PR TITLE
Avoid arm64 builds timeout due to silent make taking too long time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
 
 arch:
     - amd64
-    - arm64
 
 os:
     - linux
@@ -60,13 +59,20 @@ matrix:
                       - clang-6.0
           env: EXTENDED_TEST="yes" CONFIG_OPTS="no-asm enable-ubsan enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg no-shared enable-buildtest-c++ -fno-sanitize=alignment -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -D__NO_STRING_INLINES -Wno-unused-command-line-argument" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
         - os: linux
+          arch: arm64
+          compiler: gcc
+          env: CONFIG_OPTS="" MAKEVERBOSE="yes"
+        - os: linux
+          arch: arm64
+          compiler: gcc
+          env: CONFIG_OPTS="no-asm no-deprecated enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE" BUILDONLY="yes" NOUPDATE="yes" CHECKDOCS="yes" CPPFLAGS="-ansi"
+        - os: linux
           arch: s390x
           compiler: gcc
           env: CONFIG_OPTS="--strict-warnings"
         - os: linux-ppc64le
-          sudo: false
-          compiler: clang
-          env: CONFIG_OPTS="--strict-warnings -D__NO_STRING_INLINES"
+          compiler: gcc
+          env: CONFIG_OPTS="--strict-warnings"
         - os: linux
           compiler: gcc
           env: CONFIG_OPTS="--strict-warnings no-ec enable-trace enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd" COMMENT="Move to the BORINGTEST build when interoperable"
@@ -154,15 +160,6 @@ matrix:
           compiler: clang
         - os: osx
           compiler: gcc
-        - arch: arm64
-          os: osx
-        # arm64 times out when using -fsanitize=address
-        # The amd64 build should be sufficient to test this.
-        # Note: the env line must exactly match the env line from the build
-        # matrix above which contains the `-fsanitize=address` option.
-        # TODO: come up with a better way of doing this that is less error prone.
-        - arch: arm64
-          env: CONFIG_OPTS="no-asm -Werror --debug no-afalgeng no-shared enable-rc5 enable-md2 -fsanitize=address" LSAN_OPTIONS="report_objects=1"
 
 
 before_script:
@@ -201,7 +198,7 @@ before_script:
     - cd $top
 
 script:
-    - if [ -z "$BUILDONLY" ]; then
+    - if [ -z "$BUILDONLY" ] && [ -z "$MAKEVERBOSE" ] ; then
           make="make -s";
       else
           make="make";
@@ -215,7 +212,7 @@ script:
     - if [ -n "$DESTDIR" ]; then
           cd _build;
       fi
-    - if ! $make update; then
+    - if [ -z "$NOUPDATE" ] && ! $make update; then
           echo -e '\052\052 FAILED -- MAKE UPDATE';
           travis_terminate 1;
       fi


### PR DESCRIPTION
The arm64 builds timeout because the silent make takes too long time before
it outputs anything.
