### PR TITLE
Params: add float type parameters.

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -135,6 +135,12 @@ int ossl_param_bld_push_double(OSSL_PARAM_BLD *bld, const char *key,
     return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_REAL);
 }
 
+int ossl_param_bld_push_float(OSSL_PARAM_BLD *bld, const char *key,
+                              float num)
+{
+    return param_push_num(bld, key, &num, sizeof(num), OSSL_PARAM_REAL);
+}
+
 int ossl_param_bld_push_BN(OSSL_PARAM_BLD *bld, const char *key,
                            const BIGNUM *bn)
 {

--- a/doc/internal/man3/ossl_param_bld_init.pod
+++ b/doc/internal/man3/ossl_param_bld_init.pod
@@ -2,15 +2,15 @@
 
 =head1 NAME
 
-ossl_param_bld_init, ossl_param_bld_to_param,
-ossl_param_bld_free, ossl_param_bld_push_int, ossl_param_bld_push_uint,
-ossl_param_bld_push_long, ossl_param_bld_push_ulong,
-ossl_param_bld_push_int32, ossl_param_bld_push_uint32,
-ossl_param_bld_push_int64, ossl_param_bld_push_uint64,
-ossl_param_bld_push_size_t, ossl_param_bld_push_double,
-ossl_param_bld_push_BN, ossl_param_bld_push_BN_pad,
-ossl_param_bld_push_utf8_string, ossl_param_bld_push_utf8_ptr,
-ossl_param_bld_push_octet_string, ossl_param_bld_push_octet_ptr
+ossl_param_bld_init, ossl_param_bld_to_param, ossl_param_bld_free,
+ossl_param_bld_push_int, ossl_param_bld_push_uint, ossl_param_bld_push_long,
+ossl_param_bld_push_ulong, ossl_param_bld_push_int32,
+ossl_param_bld_push_uint32, ossl_param_bld_push_int64,
+ossl_param_bld_push_uint64, ossl_param_bld_push_size_t,
+ossl_param_bld_push_double, ossl_param_bld_push_float, ossl_param_bld_push_BN,
+ossl_param_bld_push_BN_pad, ossl_param_bld_push_utf8_string,
+ossl_param_bld_push_utf8_ptr, ossl_param_bld_push_octet_string,
+ossl_param_bld_push_octet_ptr
 - functions to assist in the creation of OSSL_PARAM arrays
 
 =head1 SYNOPSIS

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -2,32 +2,34 @@
 
 =head1 NAME
 
-OSSL_PARAM_double, OSSL_PARAM_int, OSSL_PARAM_int32, OSSL_PARAM_int64,
-OSSL_PARAM_long, OSSL_PARAM_size_t, OSSL_PARAM_uint, OSSL_PARAM_uint32,
-OSSL_PARAM_uint64, OSSL_PARAM_ulong, OSSL_PARAM_BN, OSSL_PARAM_utf8_string,
-OSSL_PARAM_octet_string, OSSL_PARAM_utf8_ptr, OSSL_PARAM_octet_ptr,
+OSSL_PARAM_double, OSSL_PARAM_float, OSSL_PARAM_int, OSSL_PARAM_int32,
+OSSL_PARAM_int64, OSSL_PARAM_long, OSSL_PARAM_size_t, OSSL_PARAM_uint,
+OSSL_PARAM_uint32, OSSL_PARAM_uint64, OSSL_PARAM_ulong, OSSL_PARAM_BN,
+OSSL_PARAM_utf8_string, OSSL_PARAM_octet_string, OSSL_PARAM_utf8_ptr,
+OSSL_PARAM_octet_ptr,
 OSSL_PARAM_END,
-OSSL_PARAM_construct_double, OSSL_PARAM_construct_int,
-OSSL_PARAM_construct_int32, OSSL_PARAM_construct_int64,
-OSSL_PARAM_construct_long, OSSL_PARAM_construct_size_t,
-OSSL_PARAM_construct_uint, OSSL_PARAM_construct_uint32,
-OSSL_PARAM_construct_uint64, OSSL_PARAM_construct_ulong,
-OSSL_PARAM_construct_BN, OSSL_PARAM_construct_utf8_string,
-OSSL_PARAM_construct_utf8_ptr, OSSL_PARAM_construct_octet_string,
-OSSL_PARAM_construct_octet_ptr, OSSL_PARAM_construct_end,
+OSSL_PARAM_construct_double, OSSL_PARAM_construct_float,
+OSSL_PARAM_construct_int, OSSL_PARAM_construct_int32,
+OSSL_PARAM_construct_int64, OSSL_PARAM_construct_long,
+OSSL_PARAM_construct_size_t, OSSL_PARAM_construct_uint,
+OSSL_PARAM_construct_uint32, OSSL_PARAM_construct_uint64,
+OSSL_PARAM_construct_ulong, OSSL_PARAM_construct_BN,
+OSSL_PARAM_construct_utf8_string, OSSL_PARAM_construct_utf8_ptr,
+OSSL_PARAM_construct_octet_string, OSSL_PARAM_construct_octet_ptr,
+OSSL_PARAM_construct_end,
 OSSL_PARAM_locate, OSSL_PARAM_locate_const,
-OSSL_PARAM_get_double, OSSL_PARAM_get_int, OSSL_PARAM_get_int32,
-OSSL_PARAM_get_int64, OSSL_PARAM_get_long, OSSL_PARAM_get_size_t,
-OSSL_PARAM_get_uint, OSSL_PARAM_get_uint32, OSSL_PARAM_get_uint64,
-OSSL_PARAM_get_ulong, OSSL_PARAM_get_BN, OSSL_PARAM_get_utf8_string,
-OSSL_PARAM_get_octet_string, OSSL_PARAM_get_utf8_ptr,
-OSSL_PARAM_get_octet_ptr,
-OSSL_PARAM_set_double, OSSL_PARAM_set_int, OSSL_PARAM_set_int32,
-OSSL_PARAM_set_int64, OSSL_PARAM_set_long, OSSL_PARAM_set_size_t,
-OSSL_PARAM_set_uint, OSSL_PARAM_set_uint32, OSSL_PARAM_set_uint64,
-OSSL_PARAM_set_ulong, OSSL_PARAM_set_BN, OSSL_PARAM_set_utf8_string,
-OSSL_PARAM_set_octet_string, OSSL_PARAM_set_utf8_ptr,
-OSSL_PARAM_set_octet_ptr
+OSSL_PARAM_get_double, OSSL_PARAM_get_float, OSSL_PARAM_get_int,
+OSSL_PARAM_get_int32, OSSL_PARAM_get_int64, OSSL_PARAM_get_long,
+OSSL_PARAM_get_size_t, OSSL_PARAM_get_uint, OSSL_PARAM_get_uint32,
+OSSL_PARAM_get_uint64, OSSL_PARAM_get_ulong, OSSL_PARAM_get_BN,
+OSSL_PARAM_get_utf8_string, OSSL_PARAM_get_octet_string,
+OSSL_PARAM_get_utf8_ptr, OSSL_PARAM_get_octet_ptr,
+OSSL_PARAM_set_double, OSSL_PARAM_set_float, OSSL_PARAM_set_int,
+OSSL_PARAM_set_int32, OSSL_PARAM_set_int64, OSSL_PARAM_set_long,
+OSSL_PARAM_set_size_t, OSSL_PARAM_set_uint, OSSL_PARAM_set_uint32,
+OSSL_PARAM_set_uint64, OSSL_PARAM_set_ulong, OSSL_PARAM_set_BN,
+OSSL_PARAM_set_utf8_string, OSSL_PARAM_set_octet_string,
+OSSL_PARAM_set_utf8_ptr, OSSL_PARAM_set_octet_ptr
 - OSSL_PARAM helpers
 
 =head1 SYNOPSIS
@@ -38,9 +40,9 @@ OSSL_PARAM_set_octet_ptr
 
  /*
   * TYPE in function names is one of:
-  * double, int, int32, int64, long, size_t, uint, uint32, uint64, ulong
+  * double, float, int, int32, int64, long, size_t, uint, uint32, uint64, ulong
   * Corresponding TYPE in function arguments is one of:
-  * double, int, int32_t, int64_t, long, size_t, unsigned int, uint32_t,
+  * double, float, int, int32_t, int64_t, long, size_t, unsigned int, uint32_t,
   * uint64_t, unsigned long
   */
 
@@ -101,6 +103,10 @@ OSSL_PARAM arrays.  The following B<TYPE> names are supported:
 =item *
 
 double
+
+=item *
+
+float
 
 =item *
 

--- a/include/internal/param_build.h
+++ b/include/internal/param_build.h
@@ -29,6 +29,7 @@ typedef struct {
         ossl_intmax_t i;
         ossl_uintmax_t u;
         double d;
+        float f;
     } num;
 } OSSL_PARAM_BLD_DEF;
 
@@ -62,6 +63,8 @@ int ossl_param_bld_push_size_t(OSSL_PARAM_BLD *bld, const char *key,
                                size_t val);
 int ossl_param_bld_push_double(OSSL_PARAM_BLD *bld, const char *key,
                                double val);
+int ossl_param_bld_push_float(OSSL_PARAM_BLD *bld, const char *key,
+                              float val);
 int ossl_param_bld_push_BN(OSSL_PARAM_BLD *bld, const char *key,
                            const BIGNUM *bn);
 int ossl_param_bld_push_BN_pad(OSSL_PARAM_BLD *bld, const char *key,

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -49,6 +49,8 @@ extern "C" {
     OSSL_PARAM_DEFN((key), OSSL_PARAM_UNSIGNED_INTEGER, (addr), sizeof(size_t))
 # define OSSL_PARAM_double(key, addr) \
     OSSL_PARAM_DEFN((key), OSSL_PARAM_REAL, (addr), sizeof(double))
+# define OSSL_PARAM_float(key, addr) \
+    OSSL_PARAM_DEFN((key), OSSL_PARAM_REAL, (addr), sizeof(float))
 
 # define OSSL_PARAM_BN(key, bn, sz) \
     OSSL_PARAM_DEFN((key), OSSL_PARAM_UNSIGNED_INTEGER, (bn), (sz))
@@ -79,6 +81,7 @@ OSSL_PARAM OSSL_PARAM_construct_size_t(const char *key, size_t *buf);
 OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
                                    size_t bsize);
 OSSL_PARAM OSSL_PARAM_construct_double(const char *key, double *buf);
+OSSL_PARAM OSSL_PARAM_construct_float(const char *key, float *buf);
 OSSL_PARAM OSSL_PARAM_construct_utf8_string(const char *key, char *buf,
                                             size_t bsize);
 OSSL_PARAM OSSL_PARAM_construct_utf8_ptr(const char *key, char **buf,
@@ -116,6 +119,8 @@ int OSSL_PARAM_set_size_t(OSSL_PARAM *p, size_t val);
 
 int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val);
 int OSSL_PARAM_set_double(OSSL_PARAM *p, double val);
+int OSSL_PARAM_get_float(const OSSL_PARAM *p, float *val);
+int OSSL_PARAM_set_float(OSSL_PARAM *p, float val);
 
 int OSSL_PARAM_get_BN(const OSSL_PARAM *p, BIGNUM **val);
 int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val);

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -24,6 +24,7 @@ static int template_public_test(void)
     int32_t i32;
     int64_t i64;
     double d;
+    float f;
     char *utf = NULL;
     const char *cutf;
     int res = 0;
@@ -34,6 +35,7 @@ static int template_public_test(void)
         || !TEST_true(ossl_param_bld_push_int32(&bld, "i32", 1532))
         || !TEST_true(ossl_param_bld_push_int64(&bld, "i64", -9999999))
         || !TEST_true(ossl_param_bld_push_double(&bld, "d", 1.61803398875))
+        || !TEST_true(ossl_param_bld_push_float(&bld, "f", 1.25))
         || !TEST_ptr(bn = BN_new())
         || !TEST_true(BN_set_word(bn, 1729))
         || !TEST_true(ossl_param_bld_push_BN(&bld, "bignumber", bn))
@@ -77,6 +79,13 @@ static int template_public_test(void)
         || !TEST_uint_eq(p->data_type, OSSL_PARAM_REAL)
         || !TEST_size_t_eq(p->data_size, sizeof(double))
         || !TEST_double_eq(d, 1.61803398875)
+        /* Check float */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "f"))
+        || !TEST_true(OSSL_PARAM_get_float(p, &f))
+        || !TEST_str_eq(p->key, "f")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_REAL)
+        || !TEST_size_t_eq(p->data_size, sizeof(float))
+        || !TEST_double_eq(f, 1.25)
         /* Check UTF8 string */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "utf8_s"))
         || !TEST_str_eq(p->data, "foo")

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -403,12 +403,17 @@ err:
 
 static int test_param_real(void)
 {
-    double p;
-    OSSL_PARAM param = OSSL_PARAM_double("r", NULL);
+    double d;
+    float f;
+    OSSL_PARAM param_d = OSSL_PARAM_double("d", NULL);
+    OSSL_PARAM param_f = OSSL_PARAM_float("f", NULL);
 
-    param.data = &p;
-    return TEST_true(OSSL_PARAM_set_double(&param, 3.14159))
-           && TEST_double_eq(p, 3.14159);
+    param_d.data = &d;
+    param_f.data = &f;
+    return TEST_true(OSSL_PARAM_set_double(&param_d, 3.14159))
+           && TEST_double_eq(d, 3.14159)
+           && TEST_true(OSSL_PARAM_set_float(&param_f, 16.125))
+           && TEST_double_eq(f, 16.125);
 }
 
 static int test_param_construct(void)

--- a/test/recipes/04-test_params_conversion_data/native_types.txt
+++ b/test/recipes/04-test_params_conversion_data/native_types.txt
@@ -4,6 +4,7 @@ int64=0
 uint32=0
 uint64=0
 double=0
+float=0
 
 type=int32
 int32=6
@@ -11,6 +12,7 @@ int64=6
 uint32=6
 uint64=6
 double=6
+float=6
 
 type=int32
 int32=-6
@@ -18,6 +20,43 @@ int64=-6
 uint32=invalid
 uint64=invalid
 double=-6
+float=-6
+
+# 2^24-1
+type=int32
+int32=16777215
+int64=16777215
+uint32=16777215
+uint64=16777215
+double=16777215
+float=16777215
+
+# 1-2^24
+type=int32
+int32=-16777215
+int64=-16777215
+uint32=invalid
+uint64=invalid
+double=-16777215
+float=-16777215
+
+# 2^24
+type=int32
+int32=16777216
+int64=16777216
+uint32=16777216
+uint64=16777216
+double=16777216
+float=invalid
+
+# -2^24
+type=int32
+int32=-16777216
+int64=-16777216
+uint32=invalid
+uint64=invalid
+double=-16777216
+float=invalid
 
 
 type=uint32
@@ -26,6 +65,7 @@ int64=0
 uint32=0
 uint64=0
 double=0
+float=0
 
 type=uint32
 int32=6
@@ -33,6 +73,25 @@ int64=6
 uint32=6
 uint64=6
 double=6
+float=6
+
+# 2^24-1
+type=uint32
+int32=16777215
+int64=16777215
+uint32=16777215
+uint64=16777215
+double=16777215
+float=16777215
+
+# 2^24
+type=uint32
+int32=16777216
+int64=16777216
+uint32=16777216
+uint64=16777216
+double=16777216
+float=invalid
 
 # 2^31-1
 type=uint32
@@ -41,6 +100,7 @@ int64=2147483647
 uint32=2147483647
 uint64=2147483647
 double=2147483647
+float=invalid
 
 # 2^31
 type=uint32
@@ -49,6 +109,7 @@ int64=2147483648
 uint32=2147483648
 uint64=2147483648
 double=2147483648
+float=invalid
 
 
 type=int64
@@ -57,6 +118,7 @@ int64=6
 uint32=6
 uint64=6
 double=6
+float=6
 
 type=int64
 int32=-6
@@ -64,6 +126,43 @@ int64=-6
 uint32=invalid
 uint64=invalid
 double=-6
+float=-6
+
+# 2^24
+type=int64
+int32=16777215
+int64=16777215
+uint32=16777215
+uint64=16777215
+double=16777215
+float=16777215
+
+# -2^24
+type=int64
+int32=-16777215
+int64=-16777215
+uint32=invalid
+uint64=invalid
+double=-16777215
+float=-16777215
+
+# 2^24-1
+type=int64
+int32=16777216
+int64=16777216
+uint32=16777216
+uint64=16777216
+double=16777216
+float=invalid
+
+# -2^24-1
+type=int64
+int32=-16777216
+int64=-16777216
+uint32=invalid
+uint64=invalid
+double=-16777216
+float=invalid
 
 # 2^31-1
 type=int64
@@ -72,6 +171,7 @@ int64=2147483647
 uint32=2147483647
 uint64=2147483647
 double=2147483647
+float=invalid
 
 # 2^31
 type=int64
@@ -80,6 +180,7 @@ int64=2147483648
 uint32=2147483648
 uint64=2147483648
 double=2147483648
+float=invalid
 
 # -2^31+1
 type=int64
@@ -88,6 +189,7 @@ int64=-2147483647
 uint32=invalid
 uint64=invalid
 double=-2147483647
+float=invalid
 
 # -2^31
 type=int64
@@ -96,6 +198,7 @@ int64=-2147483648
 uint32=invalid
 uint64=invalid
 double=-2147483648
+float=invalid
 
 # -2^31-1
 type=int64
@@ -104,6 +207,7 @@ int64=-2147483649
 uint32=invalid
 uint64=invalid
 double=-2147483649
+float=invalid
 
 # 2^32-1
 type=int64
@@ -112,6 +216,7 @@ int64=4294967295
 uint32=4294967295
 uint64=4294967295
 double=4294967295
+float=invalid
 
 # 2^32
 type=int64
@@ -120,6 +225,7 @@ int64=4294967296
 uint32=invalid
 uint64=4294967296
 double=4294967296
+float=invalid
 
 # -2^32
 type=int64
@@ -128,6 +234,7 @@ int64=-4294967296
 uint32=invalid
 uint64=invalid
 double=-4294967296
+float=invalid
 
 # 2^53-1
 type=int64
@@ -136,6 +243,7 @@ int64=9007199254740991
 uint32=invalid
 uint64=9007199254740991
 double=9007199254740991
+float=invalid
 
 # 2^53
 type=int64
@@ -144,6 +252,7 @@ int64=9007199254740992
 uint32=invalid
 uint64=9007199254740992
 double=invalid
+float=invalid
 
 # -2^53-1
 type=int64
@@ -152,6 +261,7 @@ int64=-9007199254740991
 uint32=invalid
 uint64=invalid
 double=-9007199254740991
+float=invalid
 
 # -2^53
 type=int64
@@ -160,6 +270,7 @@ int64=-9007199254740992
 uint32=invalid
 uint64=invalid
 double=invalid
+float=invalid
 
 
 type=uint64
@@ -168,6 +279,25 @@ int64=6
 uint32=6
 uint64=6
 double=6
+float=6
+
+# 2^24-1
+type=uint64
+int32=16777215
+int64=16777215
+uint32=16777215
+uint64=16777215
+double=16777215
+float=16777215
+
+# 2^24
+type=uint64
+int32=16777216
+int64=16777216
+uint32=16777216
+uint64=16777216
+double=16777216
+float=invalid
 
 # 2^31-1
 type=uint64
@@ -176,6 +306,7 @@ int64=2147483647
 uint32=2147483647
 uint64=2147483647
 double=2147483647
+float=invalid
 
 # 2^31
 type=uint64
@@ -184,6 +315,7 @@ int64=2147483648
 uint32=2147483648
 uint64=2147483648
 double=2147483648
+float=invalid
 
 # 2^32-1
 type=uint64
@@ -192,6 +324,7 @@ int64=4294967295
 uint32=4294967295
 uint64=4294967295
 double=4294967295
+float=invalid
 
 # 2^32
 type=uint64
@@ -200,6 +333,7 @@ int64=4294967296
 uint32=invalid
 uint64=4294967296
 double=4294967296
+float=invalid
 
 # 2^53-1
 type=uint64
@@ -208,6 +342,7 @@ int64=9007199254740991
 uint32=invalid
 uint64=9007199254740991
 double=9007199254740991
+float=invalid
 
 # 2^53
 type=uint64
@@ -216,6 +351,7 @@ int64=9007199254740992
 uint32=invalid
 uint64=9007199254740992
 double=invalid
+float=invalid
 
 # 2^63-1
 type=uint64
@@ -224,6 +360,7 @@ int64=9223372036854775807
 uint32=invalid
 uint64=9223372036854775807
 double=invalid
+float=invalid
 
 # 2^63-1
 type=uint64
@@ -232,6 +369,8 @@ int64=invalid
 uint32=invalid
 uint64=9223372036854775808
 double=invalid
+float=invalid
+
 
 type=double
 int32=0
@@ -239,6 +378,7 @@ int64=0
 uint32=0
 uint64=0
 double=0
+float=0
 
 type=double
 int32=6
@@ -246,6 +386,7 @@ int64=6
 uint32=6
 uint64=6
 double=6
+float=6
 
 type=double
 int32=-6
@@ -253,6 +394,43 @@ int64=-6
 uint32=invalid
 uint64=invalid
 double=-6
+float=-6
+
+# 2^24
+type=double
+int32=16777215
+int64=16777215
+uint32=16777215
+uint64=16777215
+double=16777215
+float=16777215
+
+# -2^24
+type=double
+int32=-16777215
+int64=-16777215
+uint32=invalid
+uint64=invalid
+double=-16777215
+float=-16777215
+
+# 2^24-1
+type=double
+int32=16777216
+int64=16777216
+uint32=16777216
+uint64=16777216
+double=16777216
+float=16777216
+
+# -2^24-1
+type=double
+int32=-16777216
+int64=-16777216
+uint32=invalid
+uint64=invalid
+double=-16777216
+float=-16777216
 
 # -2^31
 type=double
@@ -261,6 +439,7 @@ int64=-2147483648
 uint32=invalid
 uint64=invalid
 double=-2147483648
+float=-2147483648
 
 # -2^31-1
 type=double
@@ -269,6 +448,7 @@ int64=-2147483649
 uint32=invalid
 uint64=invalid
 double=-2147483649
+float=invalid
 
 # 2^32-1
 type=double
@@ -277,6 +457,7 @@ int64=4294967295
 uint32=4294967295
 uint64=4294967295
 double=4294967295
+float=invalid
 
 # 2^32
 type=double
@@ -285,6 +466,7 @@ int64=4294967296
 uint32=invalid
 uint64=4294967296
 double=4294967296
+float=4294967296
 
 # -2^32
 type=double
@@ -293,6 +475,7 @@ int64=-4294967296
 uint32=invalid
 uint64=invalid
 double=-4294967296
+float=-4294967296
 
 # 2^53-1
 type=double
@@ -301,6 +484,7 @@ int64=9007199254740991
 uint32=invalid
 uint64=9007199254740991
 double=9007199254740991
+float=invalid
 
 # -2^53+1
 type=double
@@ -309,6 +493,7 @@ int64=-9007199254740991
 uint32=invalid
 uint64=invalid
 double=-9007199254740991
+float=invalid
 
 # big
 type=double
@@ -317,6 +502,7 @@ int64=invalid
 uint32=invalid
 uint64=invalid
 double=1e100
+float=invalid
 
 # big
 type=double
@@ -325,6 +511,7 @@ int64=invalid
 uint32=invalid
 uint64=invalid
 double=-1e100
+float=invalid
 
 # infinite
 type=double
@@ -333,6 +520,7 @@ int64=invalid
 uint32=invalid
 uint64=invalid
 double=inf
+float=inf
 
 # fractional
 type=double
@@ -341,3 +529,83 @@ int64=invalid
 uint32=invalid
 uint64=invalid
 double=0.5
+float=0.5
+
+
+type=float
+int32=0
+int64=0
+uint32=0
+uint64=0
+double=0
+float=0
+
+type=float
+int32=6
+int64=6
+uint32=6
+uint64=6
+double=6
+float=6
+
+type=float
+int32=-6
+int64=-6
+uint32=invalid
+uint64=invalid
+double=-6
+float=-6
+
+# 2^24-1
+type=double
+int32=16777215
+int64=16777215
+uint32=16777215
+uint64=16777215
+double=16777215
+float=16777215
+
+# 1-2^24
+type=double
+int32=-16777215
+int64=-16777215
+uint32=invalid
+uint64=invalid
+double=-16777215
+float=-16777215
+
+# big
+type=double
+int32=invalid
+int64=invalid
+uint32=invalid
+uint64=invalid
+double=1e30
+float=invalid
+
+# big
+type=double
+int32=invalid
+int64=invalid
+uint32=invalid
+uint64=invalid
+double=-1e30
+float=invalid
+
+# infinite
+type=double
+int32=invalid
+int64=invalid
+uint32=invalid
+uint64=invalid
+double=inf
+float=inf
+
+# fractional
+type=double
+int32=invalid
+int64=invalid
+uint32=invalid
+uint64=invalid
+double=0.5
+float=0.5

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4947,3 +4947,6 @@ EVP_PKEY_CTX_set0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_CTX_get0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:EC
 EVP_PKEY_CTX_set_rsa_pss_saltlen        ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_get_rsa_pss_saltlen        ?	3_0_0	EXIST::FUNCTION:RSA
+OSSL_PARAM_construct_float              ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_get_float                    ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_set_float                    ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This adds single precision floating point parameters back again.

Inexact conversions from double to float are reported as failures, although they kind of make sense being successes since real values are almost always inexact.

Fixes: #11165

- [x] documentation is added or updated
- [x] tests are added or updated
