### PR TITLE
Run apps/progs.pl from the build tree

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -965,10 +965,10 @@ generate_apps:
 	( cd $(SRCDIR); $(PERL) VMS/VMSify-conf.pl \
 				< apps/openssl.cnf > apps/openssl-vms.cnf )
 	@ : {- output_off() if $disabled{apps}; "" -}
-	( b=`pwd`; cd $(SRCDIR); \
-	  $(PERL) -I$$b apps/progs.pl -H $(APPS_OPENSSL) > apps/progs.h )
-	( b=`pwd`; cd $(SRCDIR); \
-	  $(PERL) -I$$b apps/progs.pl -C $(APPS_OPENSSL) > apps/progs.c )
+	( b=`pwd`; \
+	  $(PERL) -I$$b $(SRCDIR)/apps/progs.pl -H $(APPS_OPENSSL) > $(SRCDIR)/apps/progs.h )
+	( b=`pwd`; \
+	  $(PERL) -I$$b $(SRCDIR)/apps/progs.pl -C $(APPS_OPENSSL) > $(SRCDIR)/apps/progs.c )
 	@ : {- output_on() if $disabled{apps}; "" -}
 
 generate_crypto_bn:


### PR DESCRIPTION
`apps/progs.pl` is optimized to be run from the build tree, but `make update` currently runs it from the src tree.

This can lead to failures in out-of-tree builds if the build tree is nested deeper than the src tree compared to the common ancestor node.

This commit fixes the Makefile template to run `apps/progs.pl` from the build tree instead.

