### PR TITLE
.travis.yml: where it matters, have build and source nesting levels differ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,10 +170,10 @@ before_script:
     - if [ -n "$DESTDIR" ]; then
           sh .travis-create-release.sh $TRAVIS_OS_NAME;
           tar -xzf _srcdist.tar.gz;
-          mkdir _build;
-          cd _build;
-          srcdir=../_srcdist;
-          top=..;
+          mkdir -p _build/tree;
+          cd _build/tree;
+          srcdir=../../_srcdist;
+          top=../..;
       else
           srcdir=.;
           top=.;
@@ -210,7 +210,7 @@ script:
       fi
     - top=${PWD}
     - if [ -n "$DESTDIR" ]; then
-          cd _build;
+          cd _build/tree;
       fi
     - if ! $make update; then
           echo -e '\052\052 FAILED -- MAKE UPDATE';


### PR DESCRIPTION
Where we build out of source, the source directory was _srcdist and
the build directory was _build.  That gives the same nesting level for
both, which doesn't quite exercise all aspects of relative back
references from build to source tree.

Changing the build tree to be in _build/tree will challenge back
references a bit more, and ensure a bit more that we got it right.
