### PR TITLE
test/drbgtest.c: Fix error check test

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -296,6 +296,11 @@ int RAND_DRBG_set(RAND_DRBG *drbg, int type, unsigned int flags)
     EVP_RAND_CTX *pctx;
     int use_df;
 
+    RAND_DRBG_get_entropy_fn get_entropy = drbg->get_entropy;
+    RAND_DRBG_cleanup_entropy_fn cleanup_entropy = drbg->cleanup_entropy;
+    RAND_DRBG_get_nonce_fn get_nonce = drbg->get_nonce;
+    RAND_DRBG_cleanup_nonce_fn cleanup_nonce = drbg->cleanup_nonce;
+
     if (type == 0 && flags == 0) {
         type = rand_drbg_type[RAND_DRBG_TYPE_PRIMARY];
         flags = rand_drbg_flags[RAND_DRBG_TYPE_PRIMARY];
@@ -344,6 +349,14 @@ int RAND_DRBG_set(RAND_DRBG *drbg, int type, unsigned int flags)
         RANDerr(0, RAND_R_ERROR_INITIALISING_DRBG);
         goto err;
     }
+
+    if (!RAND_DRBG_set_callbacks(drbg,
+                                 get_entropy, cleanup_entropy,
+                                 get_nonce, cleanup_nonce)) {
+        RANDerr(0, RAND_R_ERROR_INITIALISING_DRBG);
+        goto err;
+    }
+
     return 1;
 err:
     EVP_RAND_CTX_free(drbg->rand);

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -742,7 +742,7 @@ int PROV_DRBG_generate(PROV_DRBG *drbg, unsigned char *out, size_t outlen,
     }
 
     if (drbg->reseed_interval > 0) {
-        if (drbg->reseed_gen_counter > drbg->reseed_interval)
+        if (drbg->reseed_gen_counter >= drbg->reseed_interval)
             reseed_required = 1;
     }
     if (drbg->reseed_time_interval > 0) {

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -515,7 +515,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     if (!instantiate(drbg, td, &t))
         goto err;
     reseed_counter_tmp = reseed_counter(drbg);
-    set_reseed_counter(drbg, reseed_requests(drbg) + 1);
+    set_reseed_counter(drbg, reseed_requests(drbg));
 
     /* Generate output and check entropy has been requested for reseed */
     t.entropycnt = 0;
@@ -540,7 +540,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     if (!instantiate(drbg, td, &t))
         goto err;
     reseed_counter_tmp = reseed_counter(drbg);
-    set_reseed_counter(drbg, reseed_requests(drbg) + 1);
+    set_reseed_counter(drbg, reseed_requests(drbg));
 
     /* Generate output and check entropy has been requested for reseed */
     t.entropycnt = 0;

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -176,7 +176,6 @@ DRBG_SIZE_T(min_noncelen)
 DRBG_SIZE_T(max_noncelen)
 DRBG_SIZE_T(max_perslen)
 DRBG_SIZE_T(max_adinlen)
-DRBG_SIZE_T(max_request)
 
 #define DRBG_UINT(name)                                 \
     static unsigned int name(RAND_DRBG *drbg)           \

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -190,6 +190,13 @@ static PROV_DRBG *prov_rand(RAND_DRBG *drbg)
     return (PROV_DRBG *)drbg->rand->data;
 }
 
+static void set_generate_counter(RAND_DRBG *drbg, unsigned int n)
+{
+    PROV_DRBG *p = prov_rand(drbg);
+
+    p->reseed_gen_counter = n;
+}
+
 static void set_reseed_counter(RAND_DRBG *drbg, unsigned int n)
 {
     PROV_DRBG *p = prov_rand(drbg);
@@ -509,7 +516,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     if (!instantiate(drbg, td, &t))
         goto err;
     reseed_counter_tmp = reseed_counter(drbg);
-    set_reseed_counter(drbg, reseed_requests(drbg));
+    set_generate_counter(drbg, reseed_requests(drbg));
 
     /* Generate output and check entropy has been requested for reseed */
     t.entropycnt = 0;

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -541,7 +541,7 @@ static int error_check(DRBG_SELFTEST_DATA *td)
     if (!instantiate(drbg, td, &t))
         goto err;
     reseed_counter_tmp = reseed_counter(drbg);
-    set_reseed_counter(drbg, reseed_requests(drbg));
+    set_generate_counter(drbg, reseed_requests(drbg));
 
     /* Generate output and check entropy has been requested for reseed */
     t.entropycnt = 0;

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -491,11 +491,6 @@ static int error_check(DRBG_SELFTEST_DATA *td)
                                              td->adin, td->adinlen)))
         goto err;
 
-    /* Request too much data for one request */
-    if (!TEST_false(RAND_DRBG_generate(drbg, buff, max_request(drbg) + 1, 0,
-                                       td->adin, td->adinlen)))
-        goto err;
-
     /* Try too large additional input */
     if (!TEST_false(RAND_DRBG_generate(drbg, buff, td->exlen, 0,
                                        td->adin, max_adinlen(drbg) + 1)))


### PR DESCRIPTION
The condition in test_error_checks() was inverted, so the test succeeded
as long as error_check() failed. Incidently, error_check() contained
several bugs that assured it always failed, thus giving overall drbg
test success.

- [x] tests are added or updated