### PR TITLE
Rand: document that the output is cryptographically secure.

### DIFF
--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -22,6 +22,13 @@ I<num>
 
 This command outputs I<num> pseudo-random bytes after seeding
 the random number generator once.
+There bytes are generated using the L<RAND_bytes(3)> function.
+
+The random bytes that are output will have the same level of security as the
+seed material used.
+For most targets, the seed material can be considered cryptographically
+secure.
+However, it is possible to configure OpenSSL where this is not the case.
 
 =head1 OPTIONS
 
@@ -52,7 +59,9 @@ Show the output as a hex string.
 =head1 SEE ALSO
 
 L<openssl(1)>,
-L<RAND_bytes(3)>
+L<RAND_bytes(3)>,
+L<RAND_DRBG(7)>,
+L<RAND(7)>
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Add a note that indicates that the the rand command produces cryptographically secure output if the seed material is of that quality.

Fixes #11201

- [x] documentation is added or updated
- [ ] tests are added or updated
