### PR TITLE
Andoid cross compile: change ANDROID_NDK_HOME to ANDROID_NDK_ROOT

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -24,17 +24,17 @@
 
             my $ndk_var;
             my $ndk;
-            foreach (qw(ANDROID_NDK_HOME ANDROID_NDK)) {
+            foreach (qw(ANDROID_NDK_ROOT ANDROID_NDK)) {
                 $ndk_var = $_;
                 $ndk = $ENV{$ndk_var};
                 last if defined $ndk;
             }
-            die "\$ANDROID_NDK_HOME is not defined"  if (!$ndk);
+            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
             if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
                 # $ndk/platforms is traditional "all-inclusive" NDK, while
                 # $ndk/AndroidVersion.txt is so-called standalone toolchain
                 # tailored for specific target down to API level.
-                die "\$ANDROID_NDK_HOME=$ndk is invalid";
+                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
             }
             $ndk = canonpath($ndk);
 

--- a/NOTES.ANDROID
+++ b/NOTES.ANDROID
@@ -24,7 +24,7 @@
  need to know the prefix to extend your PATH, in order to invoke
  $(CROSS_COMPILE)clang [*gcc on NDK 19 and lower] and company. (Configure
  will fail and give you a hint if you get it wrong.) Apart from PATH
- adjustment you need to set ANDROID_NDK_HOME environment to point at the
+ adjustment you need to set ANDROID_NDK_ROOT environment to point at the
  NDK directory. If you're using a side-by-side NDK the path will look
  something like /some/where/android-sdk/ndk/<ver>, and for a standalone
  NDK the path will be something like /some/where/android-ndk-<ver>.
@@ -35,21 +35,21 @@
  with N being the numerical value of the target platform version. For example,
  to compile for Android 10 arm64 with a side-by-side NDK r20.0.5594570
 
-	export ANDROID_NDK_HOME=/home/whoever/Android/android-sdk/ndk/20.0.5594570
-	PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$ANDROID_NDK_HOME/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin:$PATH
+	export ANDROID_NDK_ROOT=/home/whoever/Android/android-sdk/ndk/20.0.5594570
+	PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$ANDROID_NDK_ROOT/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin:$PATH
 	./Configure android-arm64 -D__ANDROID_API__=29
 	make
 
  Older versions of the NDK have GCC under their common prebuilt tools directory, so the bin path
  will be slightly different. EG: to compile for ICS on ARM with NDK 10d:
 
-    export ANDROID_NDK_HOME=/some/where/android-ndk-10d
-    PATH=$ANDROID_NDK_HOME/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin:$PATH
+    export ANDROID_NDK_ROOT=/some/where/android-ndk-10d
+    PATH=$ANDROID_NDK_ROOT/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin:$PATH
     ./Configure android-arm -D__ANDROID_API__=14
     make
 
  Caveat lector! Earlier OpenSSL versions relied on additional CROSS_SYSROOT
- variable set to $ANDROID_NDK_HOME/platforms/android-<api>/arch-<arch> to
+ variable set to $ANDROID_NDK_ROOT/platforms/android-<api>/arch-<arch> to
  appoint headers-n-libraries' location. It's still recognized in order
  to facilitate migration from older projects. However, since API level
  appears in CROSS_SYSROOT value, passing -D__ANDROID_API__=N can be in
@@ -64,9 +64,9 @@
 
  Another option is to create so called "standalone toolchain" tailored
  for single specific platform including Android API level, and assign its
- location to ANDROID_NDK_HOME. In such case you have to pass matching
+ location to ANDROID_NDK_ROOT. In such case you have to pass matching
  target name to Configure and shouldn't use -D__ANDROID_API__=N. PATH
- adjustment becomes simpler, $ANDROID_NDK_HOME/bin:$PATH suffices.
+ adjustment becomes simpler, $ANDROID_NDK_ROOT/bin:$PATH suffices.
 
  Running tests (on Linux)
  ------------------------


### PR DESCRIPTION
According to forum discussions with NDK developers, ANDROID_NDK_HOME
is used for something else.

Fixes #11205