### PR TITLE
Fix drop of const qualifier

### DIFF
--- a/include/openssl/asn1t.h
+++ b/include/openssl/asn1t.h
@@ -814,13 +814,13 @@ typedef struct ASN1_STREAM_ARG_st {
         } \
         int i2d_##fname(const stname *a, unsigned char **out) \
         { \
-                return ASN1_item_i2d((ASN1_VALUE *)a, out, ASN1_ITEM_rptr(itname));\
+                return ASN1_item_i2d((const ASN1_VALUE *)a, out, ASN1_ITEM_rptr(itname));\
         }
 
 # define IMPLEMENT_ASN1_NDEF_FUNCTION(stname) \
         int i2d_##stname##_NDEF(const stname *a, unsigned char **out) \
         { \
-                return ASN1_item_ndef_i2d((ASN1_VALUE *)a, out, ASN1_ITEM_rptr(stname));\
+                return ASN1_item_ndef_i2d((const ASN1_VALUE *)a, out, ASN1_ITEM_rptr(stname));\
         }
 
 # define IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(stname) \
@@ -832,7 +832,7 @@ typedef struct ASN1_STREAM_ARG_st {
         } \
         static int i2d_##stname(const stname *a, unsigned char **out) \
         { \
-                return ASN1_item_i2d((ASN1_VALUE *)a, out, \
+                return ASN1_item_i2d((const ASN1_VALUE *)a, out, \
                                      ASN1_ITEM_rptr(stname)); \
         }
 
@@ -849,7 +849,7 @@ typedef struct ASN1_STREAM_ARG_st {
         int fname##_print_ctx(BIO *out, const stname *x, int indent, \
                                                 const ASN1_PCTX *pctx) \
         { \
-                return ASN1_item_print(out, (ASN1_VALUE *)x, indent, \
+                return ASN1_item_print(out, (const ASN1_VALUE *)x, indent, \
                         ASN1_ITEM_rptr(itname), pctx); \
         }
 


### PR DESCRIPTION
The parameter got "const" in 9fdcc21fdc9 but that was not added
to cast. So this throws a -Wcast-qual in user code.

error: cast from 'const DUMMY *' to 'ASN1_VALUE_st *' drops const qualifier [-Werror,-Wcast-qual]

CLA: trivial
