### PR TITLE
config, Configure: move the check of removed crypto/ sub-systems

### DIFF
--- a/Configure
+++ b/Configure
@@ -265,6 +265,19 @@ if (grep /^reconf(igure)?$/, @argvcopy) {
 
 $config{perlargv} = [ @argvcopy ];
 
+# Historical: if known directories in crypto/ have been removed, it means
+# that those sub-systems are disabled.
+# (the other option would be to removed them from the SUBDIRS statement in
+# crypto/build.info)
+# We reverse the input list for cosmetic purely reasons, to compensate that
+# 'unshift' adds at the front of the list (i.e. in reverse input order).
+foreach ( reverse sort( 'aes', 'aria', 'bf', 'camellia', 'cast', 'des', 'dh',
+                        'dsa', 'ec', 'hmac', 'idea', 'md2', 'md5', 'mdc2',
+                        'rc2', 'rc4', 'rc5', 'ripemd', 'rsa', 'seed', 'sha',
+                        'sm2', 'sm3', 'sm4') ) {
+    unshift @argvcopy, "no-$_" if ! -d catdir($srcdir, 'crypto', $_);
+}
+
 # Collect version numbers
 my %version = ();
 

--- a/config
+++ b/config
@@ -847,14 +847,6 @@ case "$GUESSOS" in
   i386-*) options="$options 386" ;;
 esac
 
-for i in aes aria bf camellia cast des dh dsa ec hmac idea md2 md5 mdc2 rc2 rc4 rc5 ripemd rsa seed sha sm2 sm3 sm4
-do
-  if [ ! -d $THERE/crypto/$i ]
-  then
-    options="$options no-$i"
-  fi
-done
-
 if [ -z "$OUT" ]; then
   OUT="$CC"
 fi


### PR DESCRIPTION
The 'config' script checked for a bunch of crypto/ sub-system
directories, and added 'no-' options if they weren't there.

We move it to 'Configure' in an effort to simplify 'config' for
further work.

Note: this is pretty much a historical thing.  In modern OpenSSL, it's
much simpler to edit the SUBDIRS statement in crypto/build.info.
However, it's been claimed the there are those who still remove some
of these sub-system sources.
