### PR TITLE
Fix build with clang assembler

### DIFF
--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -110,6 +110,11 @@ elsif (`$ENV{CC} -Wa,-v -c -o /dev/null -x assembler /dev/null 2>&1`
 {
     $gnuas=1;
 }
+elsif (`$ENV{CC} --version 2>/dev/null`
+		=~ /clang .*/)
+{
+    $gnuas=1;
+}
 
 my $cet_property;
 if ($flavour =~ /elf/) {


### PR DESCRIPTION
Fixes build bug introduced by https://github.com/openssl/openssl/commit/ccceeb48000d5fae95f38d2c4dd02cdd89ca1ee1

Build is no longer possible with clang (used by oss-fuzz).
My steps to reproduce are on Linux ubuntu:
```
export CC=clang
./config no-poly1305 no-shared no-threads
make build_generated libcrypto.a
```
gives following error :
```
CC="clang" /usr/bin/perl crypto/aes/asm/aes-x86_64.pl "elf" -I. -Iinclude -Iproviders/common/include -Iproviders/implementations/include -Icrypto/include -fPIC -m64 -Wa,--noexecstack -Qunused-arguments -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_BUILDING_OPENSSL -DOPENSSL_PIC -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib/engines-3\"" -DMODULESDIR="\"/usr/local/lib/ossl-modules\"" -DNDEBUG  -DAES_ASM -DBSAES_ASM -DCMLL_ASM -DECP_NISTZ256_ASM -DGHASH_ASM -DKECCAK1600_ASM -DMD5_ASM -DOPENSSL_BN_ASM_GF2m -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_CPUID_OBJ -DOPENSSL_IA32_SSE2 -DPADLOCK_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DVPAES_ASM -DWHIRLPOOL_ASM -DX25519_ASM  crypto/aes/aes-x86_64.s
clang -fPIC -m64 -Wa,--noexecstack -Qunused-arguments -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_BUILDING_OPENSSL -DOPENSSL_PIC -DOPENSSLDIR="\"/usr/local/ssl\"" -DENGINESDIR="\"/usr/local/lib/engines-3\"" -DMODULESDIR="\"/usr/local/lib/ossl-modules\"" -DNDEBUG  -c -o crypto/aes/libcrypto-lib-aes-x86_64.o crypto/aes/aes-x86_64.s
crypto/aes/aes-x86_64.s:2659:33: error: expected string in directive
        .section ".note.gnu.property", #alloc
```

Reason is that clang does not answer to arguments `-Wa,-v` cf https://bugs.llvm.org/show_bug.cgi?id=24200

Proposed workaround is to test for clang compiler directly