### PR TITLE
.github/PULL_REQUEST_TEMPLATE.md: Fix link to contributors guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thank you for your pull request. Please review these requirements:
 
-Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
+Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md
 
 Other than that, provide a description above this comment if there isn't one already
 


### PR DESCRIPTION
The file was converted to Markdown and renamed appropriately in
2e07506a12e126894cd820304465162bc0e732b4.

CLA: trivial
