### PR TITLE
Correct two small documentation issues

### DIFF
--- a/doc/internal/man3/s2i_ASN1_UTF8STRING.pod
+++ b/doc/internal/man3/s2i_ASN1_UTF8STRING.pod
@@ -14,6 +14,7 @@ s2i_ASN1_UTF8STRING,
                            ASN1_UTF8STRING *utf8);
  ASN1_UTF8STRING *s2i_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
                                       X509V3_CTX *ctx, const char *str);
+
 =head1 DESCRIPTION
 
 These functions convert OpenSSL objects to and from their ASN.1/string

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -26,7 +26,7 @@ secure pseudo random number generator (CSPRNG).
 The random bytes are generated using the L<RAND_bytes(3)> function,
 which provides a security level of 256 bits, provided it managed to
 seed itself successfully from a trusted operating system entropy source.
-Otherwise, the command will fail with a non-zero error code.
+Otherwise, the command will fail with a nonzero error code.
 For more details, see L<RAND_bytes(3)>, L<RAND(7)>, and L<RAND_DRBG(7)>.
 
 =head1 OPTIONS


### PR DESCRIPTION
The find-doc-nits complains about non-zero word and about missing
line before =head1 which causes build failure.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
