### PR TITLE
DOC: New file for EVP_PKEY_size(), EVP_PKEY_bits() and EVP_PKEY_security_bits() [1.1.1]

### DIFF
--- a/doc/man3/EVP_PKEY_size.pod
+++ b/doc/man3/EVP_PKEY_size.pod
@@ -1,0 +1,80 @@
+=pod
+
+=head1 NAME
+
+EVP_PKEY_size, EVP_PKEY_bits, EVP_PKEY_security_bits
+- EVP_PKEY information functions
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ int EVP_PKEY_size(const EVP_PKEY *pkey);
+ int EVP_PKEY_bits(const EVP_PKEY *pkey);
+ int EVP_PKEY_security_bits(const EVP_PKEY *pkey);
+
+=head1 DESCRIPTION
+
+EVP_PKEY_size() returns the maximum suitable size for the output
+buffers for almost all operations that can be done with I<pkey>.
+The primary documented use is with L<EVP_SignFinal(3)> and
+L<EVP_SealInit(3)>, but it isn't limited there.  The returned size is
+also large enough for the output buffer of L<EVP_PKEY_sign(3)>,
+L<EVP_PKEY_encrypt(3)>, L<EVP_PKEY_decrypt(3)>, L<EVP_PKEY_derive(3)>.
+
+It must be stressed that, unless the documentation for the operation
+that's being performed says otherwise, the size returned by
+EVP_PKEY_size() is only preliminary and not exact, so the final
+contents of the target buffer may be smaller.  It is therefore crucial
+to take note of the size given back by the function that performs the
+operation, such as L<EVP_PKEY_sign(3)> (the I<siglen> argument will
+receive that length), to avoid bugs.
+
+EVP_PKEY_bits() returns the cryptographic length of the cryptosystem
+to which the key in I<pkey> belongs, in bits.  Note that the definition
+of cryptographic length is specific to the key cryptosystem.
+
+EVP_PKEY_security_bits() returns the number of security bits of the given
+I<pkey>, bits of security is defined in NIST SP800-57.
+
+=head1 RETURN VALUES
+
+EVP_PKEY_size(), EVP_PKEY_bits() and EVP_PKEY_security_bits() return a
+positive number, or 0 if this size isn't available.
+
+=head1 NOTES
+
+Most functions that have an output buffer and are mentioned with
+EVP_PKEY_size() have a functionality where you can pass NULL for the
+buffer and still pass a pointer to an integer and get the exact size
+that this function call delivers in the context that it's called in.
+This allows those functions to be called twice, once to find out the
+exact buffer size, then allocate the buffer in between, and call that
+function again actually output the data.  For those functions, it
+isn't strictly necessary to call EVP_PKEY_size() to find out the
+buffer size, but may be useful in cases where it's desirable to know
+the upper limit in advance.
+
+It should also be especially noted that EVP_PKEY_size() shouldn't be
+used to get the output size for EVP_DigestSignFinal(), according to
+L<EVP_DigestSignFinal(3)/NOTES>.
+
+=head1 SEE ALSO
+
+L<EVP_SignFinal(3)>,
+L<EVP_SealInit(3)>,
+L<EVP_PKEY_sign(3)>,
+L<EVP_PKEY_encrypt(3)>,
+L<EVP_PKEY_decrypt(3)>,
+L<EVP_PKEY_derive(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -20,23 +20,23 @@ EVP_SignInit, EVP_SignInit_ex, EVP_SignUpdate, EVP_SignFinal
 The EVP signature routines are a high level interface to digital
 signatures.
 
-EVP_SignInit_ex() sets up signing context B<ctx> to use digest
-B<type> from ENGINE B<impl>. B<ctx> must be created with
+EVP_SignInit_ex() sets up signing context I<ctx> to use digest
+I<type> from B<ENGINE> I<impl>. I<ctx> must be created with
 EVP_MD_CTX_new() before calling this function.
 
-EVP_SignUpdate() hashes B<cnt> bytes of data at B<d> into the
-signature context B<ctx>. This function can be called several times on the
-same B<ctx> to include additional data.
+EVP_SignUpdate() hashes I<cnt> bytes of data at I<d> into the
+signature context I<ctx>. This function can be called several times on the
+same I<ctx> to include additional data.
 
-EVP_SignFinal() signs the data in B<ctx> using the private key B<pkey> and
-places the signature in B<sig>. B<sig> must be at least C<EVP_PKEY_size(pkey)>
-bytes in size. B<s> is an OUT parameter, and not used as an IN parameter.
+EVP_SignFinal() signs the data in I<ctx> using the private key I<pkey> and
+places the signature in I<sig>. I<sig> must be at least C<EVP_PKEY_size(pkey)>
+bytes in size. I<s> is an OUT parameter, and not used as an IN parameter.
 The number of bytes of data written (i.e. the length of the signature)
-will be written to the integer at B<s>, at most C<EVP_PKEY_size(pkey)> bytes
+will be written to the integer at I<s>, at most C<EVP_PKEY_size(pkey)> bytes
 will be written.
 
-EVP_SignInit() initializes a signing context B<ctx> to use the default
-implementation of digest B<type>.
+EVP_SignInit() initializes a signing context I<ctx> to use the default
+implementation of digest I<type>.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -2,10 +2,8 @@
 
 =head1 NAME
 
-EVP_PKEY_size,
-EVP_SignInit, EVP_SignInit_ex, EVP_SignUpdate, EVP_SignFinal,
-EVP_PKEY_security_bits - EVP signing
-functions
+EVP_SignInit, EVP_SignInit_ex, EVP_SignUpdate, EVP_SignFinal
+- EVP signing functions
 
 =head1 SYNOPSIS
 
@@ -16,9 +14,6 @@ functions
  int EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *sig, unsigned int *s, EVP_PKEY *pkey);
 
  void EVP_SignInit(EVP_MD_CTX *ctx, const EVP_MD *type);
-
- int EVP_PKEY_size(const EVP_PKEY *pkey);
- int EVP_PKEY_security_bits(const EVP_PKEY *pkey);
 
 =head1 DESCRIPTION
 
@@ -34,31 +29,21 @@ signature context B<ctx>. This function can be called several times on the
 same B<ctx> to include additional data.
 
 EVP_SignFinal() signs the data in B<ctx> using the private key B<pkey> and
-places the signature in B<sig>. B<sig> must be at least EVP_PKEY_size(pkey)
+places the signature in B<sig>. B<sig> must be at least C<EVP_PKEY_size(pkey)>
 bytes in size. B<s> is an OUT parameter, and not used as an IN parameter.
 The number of bytes of data written (i.e. the length of the signature)
-will be written to the integer at B<s>, at most EVP_PKEY_size(pkey) bytes
+will be written to the integer at B<s>, at most C<EVP_PKEY_size(pkey)> bytes
 will be written.
 
 EVP_SignInit() initializes a signing context B<ctx> to use the default
 implementation of digest B<type>.
-
-EVP_PKEY_size() returns the maximum size of a signature in bytes. The actual
-signature returned by EVP_SignFinal() may be smaller.
-
-EVP_PKEY_security_bits() returns the number of security bits of the given B<pkey>,
-bits of security is defined in NIST SP800-57.
 
 =head1 RETURN VALUES
 
 EVP_SignInit_ex(), EVP_SignUpdate() and EVP_SignFinal() return 1
 for success and 0 for failure.
 
-EVP_PKEY_size() returns the maximum size of a signature in bytes.
-
 The error codes can be obtained by L<ERR_get_error(3)>.
-
-EVP_PKEY_security_bits() returns the number of security bits.
 
 =head1 NOTES
 
@@ -95,6 +80,7 @@ The previous two bugs are fixed in the newer EVP_SignDigest*() function.
 
 =head1 SEE ALSO
 
+L<EVP_PKEY_size(3)>, L<EVP_PKEY_bits(3)>, L<EVP_PKEY_security_bits(3)>,
 L<EVP_VerifyInit(3)>,
 L<EVP_DigestInit(3)>,
 L<evp(7)>, L<HMAC(3)>, L<MD2(3)>,


### PR DESCRIPTION
This is a backport of pull request #10778. It was a clean cherry-pick, except for the following tree conflict, which could be trivially resolved.

```
Unmerged paths:
  (use "git add/rm <file>..." as appropriate to mark resolution)
	deleted by us:   util/missingcrypto.txt
```

The reason why I stumbled over this is because I noticed that `EVP_PKEY_bits()` is undocumented in 1.1.1. When attempting to add it, I noticed that documentation had been added only recently to master. Since I don't see any parts of the manual pages which are specific to master only, I think this can and should be backported.

cc @levitte @romen 


### Commit Message

We change the description to be about the key rather than the
signature.  How the key size is related to the signature is explained
in the description of EVP_SignFinal() anyway.

Reviewed-by: Nicola Tuveri <nic.tuv@gmail.com>
(Merged from https://github.com/openssl/openssl/pull/10778)

(cherry picked from commit 6942a0d6feb8d3dcbbc6a1ec6be9de7ab2df1530)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
