### PR TITLE
Configurations: Fix "android" configuration target

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -168,7 +168,8 @@ my %targets = (
         cppflags         => add(sub { android_ndk()->{cppflags} }),
         cxxflags         => add(sub { android_ndk()->{cflags} }),
         bn_ops           => sub { android_ndk()->{bn_ops} },
-        bin_cflags       => "-pie",
+        bin_cflags       => "-fPIE",
+        bin_lflags       => "-pie",
         enable           => [ ],
     },
     "android-arm" => {


### PR DESCRIPTION
This target gave '-pie' as a C flag when it should be a linker flag.
Additionally, we add '-fPIE' as C flag for binaries.

Fixes #11237
