### PR TITLE
Add -section option to 'req' command

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -177,6 +177,7 @@ const OPTIONS ca_options[] = {
     OPT_SECTION("Configuration"),
     {"config", OPT_CONFIG, 's', "A config file"},
     {"name", OPT_NAME, 's', "The particular CA definition to use"},
+    {"section", OPT_NAME, 's', "An alias for -name"},
     {"policy", OPT_POLICY, 's', "The CA 'policy' to support"},
 
     OPT_SECTION("Certificate"),

--- a/apps/req.c
+++ b/apps/req.c
@@ -111,7 +111,7 @@ const OPTIONS req_options[] = {
     OPT_SECTION("Certificate"),
     {"new", OPT_NEW, '-', "New request"},
     {"config", OPT_CONFIG, '<', "Request template file"},
-    {"section", OPT_SECTION, 's', "Config section to use (default req)"},
+    {"section", OPT_SECTION, 's', "Config section to use (default \"req\")"},
     {"utf8", OPT_UTF8, '-', "Input characters are UTF8 (default ASCII)"},
     {"nameopt", OPT_NAMEOPT, 's', "Various certificate name options"},
     {"reqopt", OPT_REQOPT, 's', "Various request text options"},

--- a/apps/req.c
+++ b/apps/req.c
@@ -32,7 +32,6 @@
 # include <openssl/dsa.h>
 #endif
 
-#define SECTION         "req"
 
 #define BITS            "default_bits"
 #define KEYFILE         "default_keyfile"
@@ -77,6 +76,8 @@ static int join(char buf[], size_t buf_size, const char *name,
 static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
                                     int *pkey_type, long *pkeylen,
                                     char **palgnam, ENGINE *keygen_engine);
+
+static const char *section = "req";
 static CONF *req_conf = NULL;
 static CONF *addext_conf = NULL;
 static int batch = 0;
@@ -91,6 +92,7 @@ typedef enum OPTION_choice {
     OPT_NAMEOPT, OPT_REQOPT, OPT_SUBJ, OPT_SUBJECT, OPT_TEXT, OPT_X509,
     OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_ADDEXT, OPT_EXTENSIONS,
     OPT_REQEXTS, OPT_PRECERT, OPT_MD, OPT_SM2ID, OPT_SM2HEXID,
+    OPT_SECTION,
     OPT_R_ENUM
 } OPTION_CHOICE;
 
@@ -109,6 +111,7 @@ const OPTIONS req_options[] = {
     OPT_SECTION("Certificate"),
     {"new", OPT_NEW, '-', "New request"},
     {"config", OPT_CONFIG, '<', "Request template file"},
+    {"section", OPT_SECTION, 's', "Config section to use (default req)"},
     {"utf8", OPT_UTF8, '-', "Input characters are UTF8 (default ASCII)"},
     {"nameopt", OPT_NAMEOPT, 's', "Various certificate name options"},
     {"reqopt", OPT_REQOPT, 's', "Various request text options"},
@@ -307,6 +310,9 @@ int req_main(int argc, char **argv)
             break;
         case OPT_CONFIG:
             template = opt_arg();
+            break;
+        case OPT_SECTION:
+            section = opt_arg();
             break;
         case OPT_KEYFORM:
             if (!opt_format(opt_arg(), OPT_FMT_ANY, &keyform))
@@ -514,7 +520,7 @@ int req_main(int argc, char **argv)
         goto end;
 
     if (md_alg == NULL) {
-        p = NCONF_get_string(req_conf, SECTION, "default_md");
+        p = NCONF_get_string(req_conf, section, "default_md");
         if (p == NULL) {
             ERR_clear_error();
         } else {
@@ -525,7 +531,7 @@ int req_main(int argc, char **argv)
     }
 
     if (extensions == NULL) {
-        extensions = NCONF_get_string(req_conf, SECTION, V3_EXTENSIONS);
+        extensions = NCONF_get_string(req_conf, section, V3_EXTENSIONS);
         if (extensions == NULL)
             ERR_clear_error();
     }
@@ -553,19 +559,19 @@ int req_main(int argc, char **argv)
 
     if (passin == NULL) {
         passin = nofree_passin =
-            NCONF_get_string(req_conf, SECTION, "input_password");
+            NCONF_get_string(req_conf, section, "input_password");
         if (passin == NULL)
             ERR_clear_error();
     }
 
     if (passout == NULL) {
         passout = nofree_passout =
-            NCONF_get_string(req_conf, SECTION, "output_password");
+            NCONF_get_string(req_conf, section, "output_password");
         if (passout == NULL)
             ERR_clear_error();
     }
 
-    p = NCONF_get_string(req_conf, SECTION, STRING_MASK);
+    p = NCONF_get_string(req_conf, section, STRING_MASK);
     if (p == NULL)
         ERR_clear_error();
 
@@ -575,7 +581,7 @@ int req_main(int argc, char **argv)
     }
 
     if (chtype != MBSTRING_UTF8) {
-        p = NCONF_get_string(req_conf, SECTION, UTF8_IN);
+        p = NCONF_get_string(req_conf, section, UTF8_IN);
         if (p == NULL)
             ERR_clear_error();
         else if (strcmp(p, "yes") == 0)
@@ -583,7 +589,7 @@ int req_main(int argc, char **argv)
     }
 
     if (req_exts == NULL) {
-        req_exts = NCONF_get_string(req_conf, SECTION, REQ_EXTENSIONS);
+        req_exts = NCONF_get_string(req_conf, section, REQ_EXTENSIONS);
         if (req_exts == NULL)
             ERR_clear_error();
     }
@@ -606,14 +612,14 @@ int req_main(int argc, char **argv)
             /* load_key() has already printed an appropriate message */
             goto end;
         } else {
-            app_RAND_load_conf(req_conf, SECTION);
+            app_RAND_load_conf(req_conf, section);
         }
     }
 
     if (newreq && (pkey == NULL)) {
-        app_RAND_load_conf(req_conf, SECTION);
+        app_RAND_load_conf(req_conf, section);
 
-        if (!NCONF_get_number(req_conf, SECTION, BITS, &newkey)) {
+        if (!NCONF_get_number(req_conf, section, BITS, &newkey)) {
             newkey = DEFAULT_KEY_LENGTH;
         }
 
@@ -683,7 +689,7 @@ int req_main(int argc, char **argv)
         genctx = NULL;
 
         if (keyout == NULL) {
-            keyout = NCONF_get_string(req_conf, SECTION, KEYFILE);
+            keyout = NCONF_get_string(req_conf, section, KEYFILE);
             if (keyout == NULL)
                 ERR_clear_error();
         }
@@ -696,10 +702,10 @@ int req_main(int argc, char **argv)
         if (out == NULL)
             goto end;
 
-        p = NCONF_get_string(req_conf, SECTION, "encrypt_rsa_key");
+        p = NCONF_get_string(req_conf, section, "encrypt_rsa_key");
         if (p == NULL) {
             ERR_clear_error();
-            p = NCONF_get_string(req_conf, SECTION, "encrypt_key");
+            p = NCONF_get_string(req_conf, section, "encrypt_key");
             if (p == NULL)
                 ERR_clear_error();
         }
@@ -1057,13 +1063,13 @@ static int make_REQ(X509_REQ *req, EVP_PKEY *pkey, char *subj, int multirdn,
     STACK_OF(CONF_VALUE) *dn_sk, *attr_sk = NULL;
     char *tmp, *dn_sect, *attr_sect;
 
-    tmp = NCONF_get_string(req_conf, SECTION, PROMPT);
+    tmp = NCONF_get_string(req_conf, section, PROMPT);
     if (tmp == NULL)
         ERR_clear_error();
     if ((tmp != NULL) && strcmp(tmp, "no") == 0)
         no_prompt = 1;
 
-    dn_sect = NCONF_get_string(req_conf, SECTION, DISTINGUISHED_NAME);
+    dn_sect = NCONF_get_string(req_conf, section, DISTINGUISHED_NAME);
     if (dn_sect == NULL) {
         BIO_printf(bio_err, "unable to find '%s' in config\n",
                    DISTINGUISHED_NAME);
@@ -1075,7 +1081,7 @@ static int make_REQ(X509_REQ *req, EVP_PKEY *pkey, char *subj, int multirdn,
         goto err;
     }
 
-    attr_sect = NCONF_get_string(req_conf, SECTION, ATTRIBUTES);
+    attr_sect = NCONF_get_string(req_conf, section, ATTRIBUTES);
     if (attr_sect == NULL) {
         ERR_clear_error();
         attr_sk = NULL;

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -12,6 +12,7 @@ B<openssl> B<ca>
 [B<-verbose>]
 [B<-config> I<filename>]
 [B<-name> I<section>]
+[B<-section> I<section>]
 [B<-gencrl>]
 [B<-revoke> I<file>]
 [B<-valid> I<file>]
@@ -93,7 +94,7 @@ Specifies the configuration file to use.
 Optional; for a description of the default value,
 see L<openssl(1)/COMMAND SUMMARY>.
 
-=item B<-name> I<section>
+=item B<-name> I<section>, B<-section> I<section>
 
 Specifies the configuration file section to use (overrides
 B<default_ca> in the B<ca> section).
@@ -768,6 +769,8 @@ OpenSSL 1.1.1 introduced a new random generator (CSPRNG) with an improved
 seeding mechanism. The new seeding mechanism makes it unnecessary to
 define a RANDFILE for saving and restoring randomness. This option is
 retained mainly for compatibility reasons.
+
+The B<-section> option was added in OpenSSL 3.0.0.
 
 =head1 SEE ALSO
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -30,6 +30,7 @@ B<openssl> B<req>
 [B<-keygen_engine> I<id>]
 [B<-I<digest>>]
 [B<-config> I<filename>]
+[B<-section> I<name>]
 [B<-multivalue-rdn>]
 [B<-x509>]
 [B<-days> I<n>]
@@ -205,6 +206,10 @@ This allows an alternative configuration file to be specified.
 Optional; for a description of the default value,
 see L<openssl(1)/COMMAND SUMMARY>.
 
+=item B<-section> I<name>
+
+Specifies the name of the section to use; the default is B<req>.
+
 =item B<-subj> I<arg>
 
 Sets subject name for new request or supersedes the subject name
@@ -328,8 +333,10 @@ argument for this option is string of hexadecimal digits.
 =head1 CONFIGURATION FILE FORMAT
 
 The configuration options are specified in the B<req> section of
-the configuration file. As with all configuration files if no
-value is specified in the specific section (i.e. B<req>) then
+the configuration file. An alternate name be specified by using the
+B<-setion> option.
+As with all configuration files, if no
+value is specified in the specific section then
 the initial unnamed or B<default> section is searched too.
 
 The options available are described in detail below.
@@ -674,6 +681,10 @@ L<openssl-genrsa(1)>,
 L<openssl-gendsa(1)>,
 L<config(5)>,
 L<x509v3_config(5)>
+
+=head1 HISTORY
+
+The B<-section> option was added in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -334,7 +334,7 @@ argument for this option is string of hexadecimal digits.
 
 The configuration options are specified in the B<req> section of
 the configuration file. An alternate name be specified by using the
-B<-setion> option.
+B<-section> option.
 As with all configuration files, if no
 value is specified in the specific section then
 the initial unnamed or B<default> section is searched too.

--- a/test/test.cnf
+++ b/test/test.cnf
@@ -1,7 +1,3 @@
-#
-# SSLeay example configuration file.
-# This is mostly being used for generation of certificate requests.
-#
 
 ####################################################################
 [ ca ]
@@ -58,28 +54,25 @@ default_keyfile 	= testkey.pem
 distinguished_name	= req_distinguished_name
 encrypt_rsa_key		= no
 
+# Make altreq be identical to req
+[ altreq ]
+default_bits		= 2048
+default_keyfile 	= testkey.pem
+distinguished_name	= req_distinguished_name
+encrypt_rsa_key		= no
+
 [ req_distinguished_name ]
-countryName			= Country Name (2 letter code)
-countryName_default		= AU
+countryName			= C field
 countryName_value		= AU
-
-stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= Queensland
+stateOrProvinceName		= SP field
 stateOrProvinceName_value	=
-
-localityName			= Locality Name (eg, city)
+localityName			= L field
 localityName_value		= Brisbane
-
-organizationName		= Organization Name (eg, company)
-organizationName_default	= 
+organizationName		= O field
 organizationName_value		= CryptSoft Pty Ltd
-
-organizationalUnitName		= Organizational Unit Name (eg, section)
-organizationalUnitName_default	=
+organizationalUnitName		= OU field
 organizationalUnitName_value	= .
-
-commonName			= Common Name (eg, YOUR name)
+commonName			= CN field
 commonName_value		= Eric Young
-
-emailAddress			= Email Address
+emailAddress			= email field
 emailAddress_value		= eay@mincom.oz.au


### PR DESCRIPTION
This removes "req" as the hardwired section for the req command.
Doing this will let us merge some test configs which will make fips/non-fips testing easier
It is analogous to the CA "-name" option; I added -section as an option to ca.c

- [X] documentation is added or updated
- [X] tests are added or updated
