### PR TITLE
docs: fix typo in SSL functions

### DIFF
--- a/doc/man3/SSL_accept.pod
+++ b/doc/man3/SSL_accept.pod
@@ -56,7 +56,7 @@ established.
 
 The TLS/SSL handshake was not successful because a fatal error occurred either
 at the protocol level or a connection failure occurred. The shutdown was
-not clean. It can also occur of action is need to continue the operation
+not clean. It can also occur if action is needed to continue the operation
 for non-blocking BIOs. Call SSL_get_error() with the return value B<ret>
 to find out the reason.
 
@@ -72,7 +72,7 @@ L<SSL_CTX_new(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_connect.pod
+++ b/doc/man3/SSL_connect.pod
@@ -71,7 +71,7 @@ established.
 
 The TLS/SSL handshake was not successful, because a fatal error occurred either
 at the protocol level or a connection failure occurred. The shutdown was
-not clean. It can also occur of action is need to continue the operation
+not clean. It can also occur if action is needed to continue the operation
 for non-blocking BIOs. Call SSL_get_error() with the return value B<ret>
 to find out the reason.
 
@@ -87,7 +87,7 @@ L<SSL_CTX_new(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_do_handshake.pod
+++ b/doc/man3/SSL_do_handshake.pod
@@ -57,7 +57,7 @@ established.
 
 The TLS/SSL handshake was not successful because a fatal error occurred either
 at the protocol level or a connection failure occurred. The shutdown was
-not clean. It can also occur of action is need to continue the operation
+not clean. It can also occur if action is needed to continue the operation
 for non-blocking BIOs. Call SSL_get_error() with the return value B<ret>
 to find out the reason.
 
@@ -71,7 +71,7 @@ L<SSL_set_connect_state(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2002-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy


### PR DESCRIPTION
fixing a typo in some documentation.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
