### PR TITLE
Use getauxval on Android with API level > 18

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -90,6 +90,15 @@ static unsigned long getauxval(unsigned long key)
 # endif
 
 /*
+ * Android: according to https://developer.android.com/ndk/guides/cpu-features,
+ * getauxval is supported starting with API level 18
+ */
+#  if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 18
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
+
+/*
  * ARM puts the feature bits for Crypto Extensions in AT_HWCAP2, whereas
  * AArch64 used AT_HWCAP.
  */


### PR DESCRIPTION
One of the android applications we work on received analytics that devices of the device family Oppo A37x were crashing with SIGILL when trying to load a bundled libcrypto.so built from OpenSSL_1_1_1c.

This device family has a SnapDragon 410 processor: https://www.qualcomm.com/products/snapdragon-processors-410, which is based upon an ARM Cortex A53

These crashes were fixed by using the system-supplied getauxval function.
