### PR TITLE
util/wrap.pl: do not look at EXE_SHELL

### DIFF
--- a/util/wrap.pl
+++ b/util/wrap.pl
@@ -19,11 +19,7 @@ $ENV{OPENSSL_MODULES} = $std_providers
 my $use_system = 0;
 my @cmd;
 
-if (($ENV{EXE_SHELL} // '') ne '') {
-    # We don't know what $ENV{EXE_SHELL} contains, so we must use the one
-    # string form to ensure that exec invokes a shell as needed.
-    @cmd = ( join(' ', $ENV{EXE_SHELL}, @ARGV) );
-} elsif (-x $unix_shlib_wrap) {
+if (-x $unix_shlib_wrap) {
     @cmd = ( $unix_shlib_wrap, @ARGV );
 } else {
     # Hope for the best


### PR DESCRIPTION
Acting on EXE_SHELL was a bit over the top, especially in light of
instructions like this (from NOTES.VALGRIND):

    EXE_SHELL="`/bin/pwd`/util/wrap.pl valgrind --error-exitcode=1 --leak-check=full -q"

Fixes #11255