### PR TITLE
SPKAC: Allow the message digest to be specified explicitly

### DIFF
--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -42,7 +42,7 @@ const OPTIONS spkac_options[] = {
     {"keyform", OPT_KEYFORM, 'f', "Private key file format - default PEM (PEM, DER, or ENGINE)"},
     {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
     {"challenge", OPT_CHALLENGE, 's', "Challenge string"},
-    {"md", OPT_MD, 's', "Digest algorithm to use when signing - default MD5, SHA256 recommended"},
+    {"md", OPT_MD, 's', "Digest algorithm to use when signing - default SHA256"},
     {"spkac", OPT_SPKAC, 's', "Alternative SPKAC name"},
 
     OPT_SECTION("Output"),
@@ -60,7 +60,7 @@ int spkac_main(int argc, char **argv)
     ENGINE *e = NULL;
     EVP_PKEY *pkey = NULL;
     NETSCAPE_SPKI *spki = NULL;
-    const EVP_MD *sign_md = EVP_md5();
+    const EVP_MD *sign_md = EVP_sha256();
     char *challenge = NULL, *keyfile = NULL;
     char *infile = NULL, *outfile = NULL, *passinarg = NULL, *passin = NULL;
     char *spkstr = NULL, *prog;

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -20,7 +20,7 @@ B<openssl> B<spkac>
 [B<-passin> I<arg>]
 [B<-challenge> I<string>]
 [B<-pubkey>]
-[B<-md>]
+[B<-md> I<digest>]
 [B<-spkac> I<spkacname>]
 [B<-spksect> I<section>]
 [B<-noout>]
@@ -94,10 +94,9 @@ SPKAC is being created).
 Output the public key of an SPKAC (not used if an SPKAC is
 being created).
 
-=item B<-md>
+=item B<-md> I<digest>
 
-The message digest used for signing. Historically the default value has
-been MD5, but SHA256 is recommended.
+The message digest used for signing. The default value is SHA256.
 
 =item B<-verify>
 

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -20,6 +20,7 @@ B<openssl> B<spkac>
 [B<-passin> I<arg>]
 [B<-challenge> I<string>]
 [B<-pubkey>]
+[B<-md>]
 [B<-spkac> I<spkacname>]
 [B<-spksect> I<section>]
 [B<-noout>]
@@ -92,6 +93,11 @@ SPKAC is being created).
 
 Output the public key of an SPKAC (not used if an SPKAC is
 being created).
+
+=item B<-md>
+
+The message digest used for signing. Historically the default value has
+been MD5, but SHA256 is recommended.
 
 =item B<-verify>
 


### PR DESCRIPTION
Right now, the spkac command hardcodes the message digest to MD5.

This patch adds the -md option following the pattern of other commands where a message digest is specified.

This brings openssl's spkac support in compliant with https://tools.ietf.org/html/rfc6151.

- [X] documentation is added or updated
