### PR TITLE
Check Port to Determine TLS Use

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -91,6 +91,8 @@ int OSSL_HTTP_parse_url(const char *url, char **phost, char **pport,
         goto err;
     if (pport != NULL && (*pport = OPENSSL_strdup(port)) == NULL)
         goto err;
+    if (pssl != NULL && strcmp(port, "443") == 0)
+        *pssl = 1;
 
     OPENSSL_free(buf);
     return 1;


### PR DESCRIPTION
I noticed that if one passes in a URL that doesn't have "https://" specified at the beginning, the function would not indicate the use of TLS, even if the port was specified as 443 (the standard port for HTTPS connections). So, I added a simple check to do this. If this is not in line with standard practices, feel free to discard it; I simply thought that it would be behavior a developer would expect out of the function.
Another thing to take into consideration--one unexpected side effect of my modification is that URLs such as http://example.com:443 would connect via https, despite the fact that only http was specified.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
