### PR TITLE
If SOURCE_DATE_EPOCH is defined, use it for copyright year

### DIFF
--- a/util/mkrc.pl
+++ b/util/mkrc.pl
@@ -25,7 +25,7 @@ if ( $filename =~ /openssl/i ) {
     $vft = "VFT_APP";
 }
 
-my $YEAR = [localtime()]->[5] + 1900;
+my $YEAR = [gmtime($ENV{SOURCE_DATE_EPOCH} || time())]->[5] + 1900;
 print <<___;
 #include <winver.h>
 


### PR DESCRIPTION
Using the date from SOURCE_DATE_EPOCH instead of the current date makes
it possible to reproduce a build that was built on a different year:
https://reproducible-builds.org/specs/source-date-epoch/

This is fixing an issue we had while building Tor Browser:
https://trac.torproject.org/projects/tor/ticket/33535