### PR TITLE
doc: Update the reference from draft to RFC

### DIFF
--- a/doc/man7/Ed25519.pod
+++ b/doc/man7/Ed25519.pod
@@ -11,7 +11,7 @@ Ed448
 The B<Ed25519> and B<Ed448> EVP_PKEY implementation supports key generation,
 one-shot digest sign and digest verify using PureEdDSA and B<Ed25519> or B<Ed448>
 (see RFC8032). It has associated private and public key formats compatible with
-draft-ietf-curdle-pkix-04.
+RFC 8410.
 
 No additional parameters can be set during key generation, one-shot signing or
 verification. In particular, because PureEdDSA is used, a digest must B<NOT> be

--- a/doc/man7/X25519.pod
+++ b/doc/man7/X25519.pod
@@ -10,7 +10,7 @@ X448
 
 The B<X25519> and B<X448> EVP_PKEY implementation supports key generation and
 key derivation using B<X25519> and B<X448>. It has associated private and public
-key formats compatible with draft-ietf-curdle-pkix-03.
+key formats compatible with RFC 8410.
 
 No additional parameters can be set during key generation.
 


### PR DESCRIPTION
The [RFC 8410](https://tools.ietf.org/html/rfc8410) was published more than a year ago and referring to old draft versions is at least confusing.