### PR TITLE
Rename OSSL_{d2i,i2d}_CMP_MSG_bio to {d2i,id2}_OSSL_CMP_MSG_bio

### DIFF
--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -976,18 +976,18 @@ OSSL_CMP_MSG *ossl_cmp_msg_load(const char *file)
 
     if ((bio = BIO_new_file(file, "rb")) == NULL)
         return NULL;
-    msg = OSSL_d2i_CMP_MSG_bio(bio, NULL);
+    msg = d2i_OSSL_CMP_MSG_bio(bio, NULL);
     BIO_free(bio);
     return msg;
 }
 
-OSSL_CMP_MSG *OSSL_d2i_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg)
+OSSL_CMP_MSG *d2i_OSSL_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg)
 {
     return ASN1_d2i_bio_of(OSSL_CMP_MSG, OSSL_CMP_MSG_new,
                            d2i_OSSL_CMP_MSG, bio, msg);
 }
 
-int OSSL_i2d_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg)
+int i2d_OSSL_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg)
 {
     return ASN1_i2d_bio_of(OSSL_CMP_MSG, i2d_OSSL_CMP_MSG, bio, msg);
 }

--- a/doc/man3/OSSL_CMP_MSG_get0_header.pod
+++ b/doc/man3/OSSL_CMP_MSG_get0_header.pod
@@ -3,8 +3,8 @@
 =head1 NAME
 
 OSSL_CMP_MSG_get0_header,
-OSSL_d2i_CMP_MSG_bio,
-OSSL_i2d_CMP_MSG_bio
+d2i_OSSL_CMP_MSG_bio,
+i2d_OSSL_CMP_MSG_bio
 - function(s) manipulating CMP messages
 
 =head1 SYNOPSIS
@@ -12,17 +12,18 @@ OSSL_i2d_CMP_MSG_bio
   #include <openssl/cmp.h>
 
   OSSL_CMP_PKIHEADER *OSSL_CMP_MSG_get0_header(const OSSL_CMP_MSG *msg);
-  OSSL_CMP_MSG *OSSL_d2i_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg);
-  int OSSL_i2d_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg);
+  OSSL_CMP_MSG *d2i_OSSL_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg);
+  int i2d_OSSL_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg);
 
 =head1 DESCRIPTION
 
 OSSL_CMP_MSG_get0_header returns the header of the given CMP message.
 
-OSSL_d2i_CMP_MSG_bio parses an ASN.1-encoded OSSL_CMP_MSG from the BIO I<bio>.
+d2i_OSSL_CMP_MSG_bio parses an ASN.1-encoded OSSL_CMP_MSG from the BIO I<bio>.
 It assigns a pointer to the new structure to I<*msg> if I<msg> is not NULL.
 
-OSSL_i2d_CMP_MSG_bio writes the OSSL_CMP_MSG I<msg> in ASN.1 encoding to BIO I<bio>.
+i2d_OSSL_CMP_MSG_bio writes the OSSL_CMP_MSG I<msg> in ASN.1 encoding
+to BIO I<bio>.
 
 =head1 NOTES
 
@@ -33,9 +34,9 @@ CMP is defined in RFC 4210.
 OSSL_CMP_MSG_get0_header() returns the intended pointer value as described above
 or NULL if the respective entry does not exist and on error.
 
-OSSL_d2i_CMP_MSG_bio() returns the parsed message or NULL on error.
+d2i_OSSL_CMP_MSG_bio() returns the parsed message or NULL on error.
 
-OSSL_i2d_CMP_MSG_bio() returns 1 on success or 0 on error.
+i2d_OSSL_CMP_MSG_bio() returns 1 on success or 0 on error.
 
 =head1 HISTORY
 

--- a/include/openssl/cmp.h
+++ b/include/openssl/cmp.h
@@ -352,8 +352,8 @@ ASN1_OCTET_STRING *OSSL_CMP_HDR_get0_recipNonce(const OSSL_CMP_PKIHEADER *hdr);
 
 /* from cmp_msg.c */
 OSSL_CMP_PKIHEADER *OSSL_CMP_MSG_get0_header(const OSSL_CMP_MSG *msg);
-OSSL_CMP_MSG *OSSL_d2i_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg);
-int OSSL_i2d_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg);
+OSSL_CMP_MSG *d2i_OSSL_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg);
+int i2d_OSSL_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg);
 
 /* from cmp_vfy.c */
 int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4967,8 +4967,8 @@ OSSL_CMP_PKISI_it                       ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_PKISI_dup                      ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_snprint_PKIStatusInfo          ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_STATUSINFO_new                 ?	3_0_0	EXIST::FUNCTION:CMP
-OSSL_d2i_CMP_MSG_bio                    ?	3_0_0	EXIST::FUNCTION:CMP
-OSSL_i2d_CMP_MSG_bio                    ?	3_0_0	EXIST::FUNCTION:CMP
+d2i_OSSL_CMP_MSG_bio                    ?	3_0_0	EXIST::FUNCTION:CMP
+i2d_OSSL_CMP_MSG_bio                    ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_process_request            ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_server_perform             ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_new                    ?	3_0_0	EXIST::FUNCTION:CMP


### PR DESCRIPTION
This fixes the issue https://github.com/openssl/openssl/pull/11142#pullrequestreview-372337918 mentioned by @levitte.