### PR TITLE
Free unused ex data nodes

### DIFF
--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -152,13 +152,12 @@ int crypto_get_ex_new_index_ex(OPENSSL_CTX *ctx, int class_index, long argl,
     a->dup_func = dup_func;
     a->free_func = free_func;
 
-    if (!sk_EX_CALLBACK_push(ip->meth, NULL)) {
+    if (!sk_EX_CALLBACK_push(ip->meth, a)) {
         CRYPTOerr(CRYPTO_F_CRYPTO_GET_EX_NEW_INDEX_EX, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(a);
         goto err;
     }
     toret = sk_EX_CALLBACK_num(ip->meth) - 1;
-    (void)sk_EX_CALLBACK_set(ip->meth, toret, a);
  err:
     CRYPTO_THREAD_unlock(global->ex_data_lock);
     return toret;


### PR DESCRIPTION
Instead of using dummy callbacks and leave unused stuff around,  let the `CRYPTO_free_ex_index` free the malloced `EX_CALLBACK` structure.

---

Removed superfluous two steps EX_CALLBACK structure push in the EX_CALLBACKS stack.

---

CLA trivial