### PR TITLE
Fix RSA structure

### DIFF
--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -29,13 +29,15 @@ DECLARE_ASN1_ITEM(RSA_PRIME_INFO)
 DEFINE_STACK_OF(RSA_PRIME_INFO)
 
 struct rsa_st {
-    OPENSSL_CTX *libctx;
-
     /*
-     * The first parameter is used to pickup errors where this is passed
-     * instead of an EVP_PKEY, it is set to 0
+     * #legacy
+     * The first field is used to pickup errors where this is passed
+     * instead of an EVP_PKEY.  It is always zero.
+     * THIS MUST REMAIN THE FIRST FIELD.
      */
-    int pad;
+    int dummy_zero;
+
+    OPENSSL_CTX *libctx;
     int32_t version;
     const RSA_METHOD *meth;
     /* functional reference if 'meth' is ENGINE-provided */


### PR DESCRIPTION
The first field was called 'pad', but not for the reason one might
think.  It was really a padding int that was always zero, and was
placed first on purpose.  This is to pick up programming errors where
an RSA pointer was passed when an EVP_PKEY pointer should have been,
an makes it look like an EVP_PKEY structure with type EVP_PKEY_NONE,
which effectively avoids any further processing (and unintended
corruption of the RSA structure).

This is only relevant for legacy structure and EVP_PKEY_METHODs.  With
providers, EVP_PKEYs aren't passed to the backend anyway.
