### PR TITLE
Handle the case where there is no digest in an EVP_MD_CTX

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -657,12 +657,12 @@ int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
     size_t sz;
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
-    if (ctx == NULL || ctx->digest == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_MESSAGE_DIGEST_IS_NULL);
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
 
-    if (ctx->digest->prov == NULL)
+    if (ctx->digest != NULL && ctx->digest->prov == NULL)
         goto legacy;
 
     switch (cmd) {


### PR DESCRIPTION
EVP_MD_CTX_ctrl assumes that a digest has always been set. However in a
non-legacy EVP_DigestSign* operation this is not the case because the
digest is handled entirely by the underlying signature implementation.

This fixes one of the travis failures on the master branch.

[extended tests]

