### PR TITLE
Fix the compile error once enabled Werror

### DIFF
--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -118,7 +118,7 @@ static int msg_total_size_log_cb(const char *func, const char *file, int line,
                                  OSSL_CMP_severity level, const char *msg)
 {
     msg_total_size += strlen(msg);
-    TEST_note("total=%d len=%ld msg='%s'\n", msg_total_size, strlen(msg), msg);
+    TEST_note("total=%d len=%zu msg='%s'\n", msg_total_size, strlen(msg), msg);
     return 1;
 }
 


### PR DESCRIPTION
On 32 bit operating system, execute the following command "linux32 ./config -Werror -g3 --prefix=xxx; make", it reported error "type mismatch in the file test/cmp_ctx_test.c: TEST_note("total=%d len=%ld msg='%s'\n", msg_total_size, strlen(msg), msg);". 
On 32 bit system, size_t is defined as unsigned int, this is the return type of strlen(), but the code use %ld to printf it, when compiling, type mismatch warning will be reported.  For printf, %zu should be the right specifier of size_t, change  to avoid the warning.

