### PR TITLE
Type casting (remove warning)

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -155,7 +155,7 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b)
 
 int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 {
-    *ret = InterlockedExchangeAdd(val, amount) + amount;
+    *ret = (int)InterlockedExchangeAdd((long volatile *)val, (long)amount) + amount;
     return 1;
 }
 


### PR DESCRIPTION
CLA:trivial
Trivial modification, one liner, type casting
Related to pull-request #10231 that have no CLA