### PR TITLE
CIFuzz turning dry_run off

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'openssl'
-        dry-run: true
+        dry-run: false
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'openssl'
         fuzz-seconds: 600
-        dry-run: true
+        dry-run: false
     - name: Upload Crash
       uses: actions/upload-artifact@v1
       if: failure()


### PR DESCRIPTION
CIFuzz is working well with OpenSSL detecting bugs such as: 

https://github.com/openssl/openssl/actions/runs/56917737
https://github.com/openssl/openssl/runs/504787714?check_suite_focus=true

This PR will allow CIFuzz to report errors.