### PR TITLE
Update CHANGES and NEWS for 1.1.1e release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -938,7 +938,33 @@ OpenSSL 3.0
 OpenSSL 1.1.1
 -------------
 
-### Changes between 1.1.1d and 1.1.1e [xx XXX xxxx] ###
+### Changes between 1.1.1e and 1.1.1f [xx XXX xxxx] ###
+
+
+### Changes between 1.1.1d and 1.1.1e [17 Mar 2020] ###
+
+ * Properly detect EOF while reading in libssl. Previously if we hit an EOF
+   while reading in libssl then we would report an error back to the
+   application (SSL_ERROR_SYSCALL) but errno would be 0. We now add
+   an error to the stack (which means we instead return SSL_ERROR_SSL) and
+   therefore give a hint as to what went wrong.
+
+   *Matt Caswell*
+
+ * Check that ed25519 and ed448 are allowed by the security level. Previously
+   signature algorithms not using an MD were not being checked that they were
+   allowed by the security level.
+
+   *Kurt Roeckx*
+
+ * Fixed SSL_get_servername() behaviour. The behaviour of SSL_get_servername()
+   was not quite right. The behaviour was not consistent between resumption
+   and normal handshakes, and also not quite consistent with historical
+   behaviour. The behaviour in various scenarios has been clarified and
+   it has been updated to make it match historical behaviour as closely as
+   possible.
+
+   *Matt Caswell*
 
  * *[VMS only]* The header files that the VMS compilers include automatically,
    `__DECC_INCLUDE_PROLOGUE.H` and `__DECC_INCLUDE_EPILOGUE.H`, use pragmas

--- a/NEWS.md
+++ b/NEWS.md
@@ -1301,10 +1301,10 @@ OpenSSL 0.9.x
 
 <!-- Links -->
 
-[CVE-2019-1551]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1551
 [CVE-2019-1563]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1563
 [CVE-2019-1559]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1559
 [CVE-2019-1552]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1552
+[CVE-2019-1551]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1551
 [CVE-2019-1549]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1549
 [CVE-2019-1547]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1547
 [CVE-2019-1543]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1543

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,15 @@ OpenSSL 3.0
 OpenSSL 1.1.1
 -------------
 
+### Major changes between OpenSSL 1.1.1e and OpenSSL 1.1.1f [under development] ###
+
+  * 
+
+### Major changes between OpenSSL 1.1.1d and OpenSSL 1.1.1e [17 Mar 2020] ###
+
+  * Fixed an overflow bug in the x64_64 Montgomery squaring procedure
+    used in exponentiation with 512-bit moduli ([CVE-2019-1551][])
+
 ### Major changes between OpenSSL 1.1.1c and OpenSSL 1.1.1d [10 Sep 2019] ###
 
   * Fixed a fork protection issue ([CVE-2019-1549][])
@@ -1292,6 +1301,7 @@ OpenSSL 0.9.x
 
 <!-- Links -->
 
+[CVE-2019-1551]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1551
 [CVE-2019-1563]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1563
 [CVE-2019-1559]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1559
 [CVE-2019-1552]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1552


### PR DESCRIPTION
Since the grand markdown revamping in #10545,  the CHANGES and NEWS files contain notes for _all_ releases, so they need to be updated, too.

As long as there is only one stable branch, I can take care of it every time a release has happened.

_Note:  For 3.0 and beyond, the ideal solution would be to update the CHANGES and NEWS files on master only, and backport the relevant sections to the respecitve stable branches using a script when creating the release. But that's a task for a separate pull request in the future..._

cc @mattcaswell