### PR TITLE
Add PKEY_get_params support for accessing RSA key fields

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1307,3 +1307,12 @@ void *evp_pkey_upgrade_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
     return keydata;
 }
 #endif  /* FIPS_MODE */
+
+int EVP_PKEY_get_params(EVP_PKEY *pkey, OSSL_PARAM params[])
+{
+    if (pkey == NULL
+        || pkey->keymgmt == NULL
+        || pkey->keydata == NULL)
+        return 0;
+    return evp_keymgmt_get_params(pkey->keymgmt, pkey->keydata, params);
+}

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -678,81 +678,62 @@ int RSA_pkey_ctx_ctrl(EVP_PKEY_CTX *ctx, int optype, int cmd, int p1, void *p2)
 }
 #endif
 
+#ifndef FIPS_MODE
 DEFINE_STACK_OF(BIGNUM)
 
-int rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
-                        const STACK_OF(BIGNUM) *exps,
-                        const STACK_OF(BIGNUM) *coeffs)
+int rsa_set0_all_mp_params(RSA *r, const STACK_OF(BIGNUM) *primes,
+                           const STACK_OF(BIGNUM) *exps,
+                           const STACK_OF(BIGNUM) *coeffs)
 {
-#ifndef FIPS_MODE
     STACK_OF(RSA_PRIME_INFO) *prime_infos, *old_infos = NULL;
-#endif
     int pnum;
+    int i;
 
     if (primes == NULL || exps == NULL || coeffs == NULL)
         return 0;
 
     pnum = sk_BIGNUM_num(primes);
-    if (pnum < 2
+    if (pnum == 0
         || pnum != sk_BIGNUM_num(exps)
-        || pnum != sk_BIGNUM_num(coeffs) + 1)
+        || pnum != sk_BIGNUM_num(coeffs))
         return 0;
-
-    if (!RSA_set0_factors(r, sk_BIGNUM_value(primes, 0),
-                          sk_BIGNUM_value(primes, 1))
-        || !RSA_set0_crt_params(r, sk_BIGNUM_value(exps, 0),
-                                sk_BIGNUM_value(exps, 1),
-                                sk_BIGNUM_value(coeffs, 0)))
-        return 0;
-
-#ifndef FIPS_MODE
     old_infos = r->prime_infos;
-#endif
 
-    if (pnum > 2) {
-#ifndef FIPS_MODE
-        int i;
+    prime_infos = sk_RSA_PRIME_INFO_new_reserve(NULL, pnum);
+    if (prime_infos == NULL)
+        return 0;
 
-        prime_infos = sk_RSA_PRIME_INFO_new_reserve(NULL, pnum);
-        if (prime_infos == NULL)
-            return 0;
+    for (i = 0; i < pnum; i++) {
+        BIGNUM *prime = sk_BIGNUM_value(primes, i);
+        BIGNUM *exp = sk_BIGNUM_value(exps, i);
+        BIGNUM *coeff = sk_BIGNUM_value(coeffs, i);
+        RSA_PRIME_INFO *pinfo = NULL;
 
-        for (i = 2; i < pnum; i++) {
-            BIGNUM *prime = sk_BIGNUM_value(primes, i);
-            BIGNUM *exp = sk_BIGNUM_value(exps, i);
-            BIGNUM *coeff = sk_BIGNUM_value(coeffs, i - 1);
-            RSA_PRIME_INFO *pinfo = NULL;
+        if (!ossl_assert(prime != NULL && exp != NULL && coeff != NULL))
+            goto err;
 
-            if (!ossl_assert(prime != NULL && exp != NULL && coeff != NULL))
-                goto err;
-
-            /* Using rsa_multip_info_new() is wasteful, so allocate directly */
-            if ((pinfo = OPENSSL_zalloc(sizeof(*pinfo))) == NULL) {
-                ERR_raise(ERR_LIB_RSA, ERR_R_MALLOC_FAILURE);
-                goto err;
-            }
-
-            pinfo->r = prime;
-            pinfo->d = exp;
-            pinfo->t = coeff;
-            BN_set_flags(pinfo->r, BN_FLG_CONSTTIME);
-            BN_set_flags(pinfo->d, BN_FLG_CONSTTIME);
-            BN_set_flags(pinfo->t, BN_FLG_CONSTTIME);
-            (void)sk_RSA_PRIME_INFO_push(prime_infos, pinfo);
-        }
-
-        r->prime_infos = prime_infos;
-
-        if (!rsa_multip_calc_product(r)) {
-            r->prime_infos = old_infos;
+        /* Using rsa_multip_info_new() is wasteful, so allocate directly */
+        if ((pinfo = OPENSSL_zalloc(sizeof(*pinfo))) == NULL) {
+            ERR_raise(ERR_LIB_RSA, ERR_R_MALLOC_FAILURE);
             goto err;
         }
-#else
-        return 0;
-#endif
+
+        pinfo->r = prime;
+        pinfo->d = exp;
+        pinfo->t = coeff;
+        BN_set_flags(pinfo->r, BN_FLG_CONSTTIME);
+        BN_set_flags(pinfo->d, BN_FLG_CONSTTIME);
+        BN_set_flags(pinfo->t, BN_FLG_CONSTTIME);
+        (void)sk_RSA_PRIME_INFO_push(prime_infos, pinfo);
     }
 
-#ifndef FIPS_MODE
+    r->prime_infos = prime_infos;
+
+    if (!rsa_multip_calc_product(r)) {
+        r->prime_infos = old_infos;
+        goto err;
+    }
+
     if (old_infos != NULL) {
         /*
          * This is hard to deal with, since the old infos could
@@ -762,30 +743,25 @@ int rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
          */
         sk_RSA_PRIME_INFO_pop_free(old_infos, rsa_multip_info_free);
     }
-#endif
 
-    r->version = pnum > 2 ? RSA_ASN1_VERSION_MULTI : RSA_ASN1_VERSION_DEFAULT;
+    r->version = RSA_ASN1_VERSION_MULTI;
     r->dirty_cnt++;
 
     return 1;
-#ifndef FIPS_MODE
  err:
     /* r, d, t should not be freed */
     sk_RSA_PRIME_INFO_pop_free(prime_infos, rsa_multip_info_free_ex);
     return 0;
-#endif
 }
 
 DEFINE_SPECIAL_STACK_OF_CONST(BIGNUM_const, BIGNUM)
 
-int rsa_get0_all_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
-                        STACK_OF(BIGNUM_const) *exps,
-                        STACK_OF(BIGNUM_const) *coeffs)
+int rsa_get0_all_mp_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
+                           STACK_OF(BIGNUM_const) *exps,
+                           STACK_OF(BIGNUM_const) *coeffs)
 {
-#ifndef FIPS_MODE
     RSA_PRIME_INFO *pinfo;
     int i, pnum;
-#endif
 
     if (r == NULL)
         return 0;
@@ -794,13 +770,6 @@ int rsa_get0_all_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
     if (RSA_get0_p(r) == NULL)
         return 1;
 
-    sk_BIGNUM_const_push(primes, RSA_get0_p(r));
-    sk_BIGNUM_const_push(primes, RSA_get0_q(r));
-    sk_BIGNUM_const_push(exps, RSA_get0_dmp1(r));
-    sk_BIGNUM_const_push(exps, RSA_get0_dmq1(r));
-    sk_BIGNUM_const_push(coeffs, RSA_get0_iqmp(r));
-
-#ifndef FIPS_MODE
     pnum = RSA_get_multi_prime_extra_count(r);
     for (i = 0; i < pnum; i++) {
         pinfo = sk_RSA_PRIME_INFO_value(r->prime_infos, i);
@@ -808,12 +777,9 @@ int rsa_get0_all_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
         sk_BIGNUM_const_push(exps, pinfo->d);
         sk_BIGNUM_const_push(coeffs, pinfo->t);
     }
-#endif
-
     return 1;
 }
 
-#ifndef FIPS_MODE
 int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad_mode)
 {
     OSSL_PARAM pad_params[2], *p = pad_params;

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -14,12 +14,12 @@
 
 RSA *rsa_new_with_ctx(OPENSSL_CTX *libctx);
 
-int rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
-                        const STACK_OF(BIGNUM) *exps,
-                        const STACK_OF(BIGNUM) *coeffs);
-int rsa_get0_all_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
-                        STACK_OF(BIGNUM_const) *exps,
-                        STACK_OF(BIGNUM_const) *coeffs);
+int rsa_set0_all_mp_params(RSA *r, const STACK_OF(BIGNUM) *primes,
+                           const STACK_OF(BIGNUM) *exps,
+                           const STACK_OF(BIGNUM) *coeffs);
+int rsa_get0_all_mp_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
+                           STACK_OF(BIGNUM_const) *exps,
+                           STACK_OF(BIGNUM_const) *coeffs);
 
 int rsa_padding_check_PKCS1_type_2_TLS(unsigned char *to, size_t tlen,
                                        const unsigned char *from, size_t flen,

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -214,12 +214,17 @@ extern "C" {
  * (the base i for the coefficients is 2, not 1, at least as implied by
  * RFC 8017)
  */
-#define OSSL_PKEY_PARAM_RSA_N           "n"
-#define OSSL_PKEY_PARAM_RSA_E           "e"
-#define OSSL_PKEY_PARAM_RSA_D           "d"
-#define OSSL_PKEY_PARAM_RSA_FACTOR      "rsa-factor"
-#define OSSL_PKEY_PARAM_RSA_EXPONENT    "rsa-exponent"
-#define OSSL_PKEY_PARAM_RSA_COEFFICIENT "rsa-coefficient"
+#define OSSL_PKEY_PARAM_RSA_N              "n"
+#define OSSL_PKEY_PARAM_RSA_E              "e"
+#define OSSL_PKEY_PARAM_RSA_D              "d"
+#define OSSL_PKEY_PARAM_RSA_P              "p"
+#define OSSL_PKEY_PARAM_RSA_Q              "q"
+#define OSSL_PKEY_PARAM_RSA_DP             "dp"
+#define OSSL_PKEY_PARAM_RSA_DQ             "dq"
+#define OSSL_PKEY_PARAM_RSA_QINV           "qinv"
+#define OSSL_PKEY_PARAM_RSA_MP_FACTOR      "rsa-factor"
+#define OSSL_PKEY_PARAM_RSA_MP_EXPONENT    "rsa-exponent"
+#define OSSL_PKEY_PARAM_RSA_MP_COEFFICIENT "rsa-coefficient"
 /* Key generation parameters */
 #define OSSL_PKEY_PARAM_RSA_BITS        OSSL_PKEY_PARAM_BITS
 #define OSSL_PKEY_PARAM_RSA_PRIMES      "primes"

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1592,6 +1592,8 @@ int EVP_PKEY_key_fromdata_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM param[]);
 const OSSL_PARAM *EVP_PKEY_param_fromdata_settable(EVP_PKEY_CTX *ctx);
 const OSSL_PARAM *EVP_PKEY_key_fromdata_settable(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_get_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
+
 int EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx);

--- a/providers/implementations/keymgmt/build.info
+++ b/providers/implementations/keymgmt/build.info
@@ -4,7 +4,6 @@
 $DH_GOAL=../../libimplementations.a
 $DSA_GOAL=../../libimplementations.a
 $EC_GOAL=../../libimplementations.a
-$RSA_GOAL=../../libimplementations.a
 $ECX_GOAL=../../libimplementations.a
 
 IF[{- !$disabled{dh} -}]
@@ -16,7 +15,9 @@ ENDIF
 IF[{- !$disabled{ec} -}]
   SOURCE[$EC_GOAL]=ec_kmgmt.c
 ENDIF
-SOURCE[$RSA_GOAL]=rsa_kmgmt.c
 IF[{- !$disabled{ec} -}]
   SOURCE[$ECX_GOAL]=ecx_kmgmt.c
 ENDIF
+
+SOURCE[../../libfips.a]=rsa_kmgmt.c
+SOURCE[../../libnonfips.a]=rsa_kmgmt.c

--- a/providers/implementations/serializers/serializer_rsa.c
+++ b/providers/implementations/serializers/serializer_rsa.c
@@ -13,7 +13,7 @@
  */
 #include "internal/deprecated.h"
 
-#include "crypto/rsa.h"           /* rsa_get0_all_params() */
+#include "crypto/rsa.h"           /* rsa_get0_all_mp_params() */
 #include "prov/bio.h"             /* ossl_prov_bio_printf() */
 #include "prov/implementations.h" /* rsa_keymgmt_functions */
 #include "serializer_local.h"
@@ -37,9 +37,12 @@ OSSL_OP_keymgmt_import_fn *ossl_prov_get_keymgmt_rsa_import(void)
 
 int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
 {
+    int primes = 0;
     const char *modulus_label;
     const char *exponent_label;
     const BIGNUM *rsa_d = NULL, *rsa_n = NULL, *rsa_e = NULL;
+    const BIGNUM *rsa_p = NULL, *rsa_q = NULL;
+    const BIGNUM *rsa_dp = NULL, *rsa_dq = NULL, *rsa_qinv = NULL;;
     STACK_OF(BIGNUM_const) *factors = sk_BIGNUM_const_new_null();
     STACK_OF(BIGNUM_const) *exps = sk_BIGNUM_const_new_null();
     STACK_OF(BIGNUM_const) *coeffs = sk_BIGNUM_const_new_null();
@@ -49,12 +52,16 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
         goto err;
 
     RSA_get0_key(rsa, &rsa_n, &rsa_e, &rsa_d);
-    rsa_get0_all_params(rsa, factors, exps, coeffs);
+    RSA_get0_factors(rsa, &rsa_p, &rsa_q);
+    if (rsa_p != NULL)
+        primes = 2;
+    RSA_get0_crt_params(rsa, &rsa_dp, &rsa_dq, &rsa_qinv);
+    rsa_get0_all_mp_params(rsa, factors, exps, coeffs);
 
     if (priv && rsa_d != NULL) {
         if (ossl_prov_bio_printf(out, "Private-Key: (%d bit, %d primes)\n",
                                  BN_num_bits(rsa_n),
-                                 sk_BIGNUM_const_num(factors)) <= 0)
+                                 primes + sk_BIGNUM_const_num(factors)) <= 0)
             goto err;
         modulus_label = "modulus:";
         exponent_label = "publicExponent:";
@@ -74,22 +81,17 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
 
         if (!ossl_prov_print_labeled_bignum(out, "privateExponent:", rsa_d))
             goto err;
-        if (!ossl_prov_print_labeled_bignum(out, "prime1:",
-                                            sk_BIGNUM_const_value(factors, 0)))
+        if (!ossl_prov_print_labeled_bignum(out, "prime1:", rsa_p))
             goto err;
-        if (!ossl_prov_print_labeled_bignum(out, "prime2:",
-                                            sk_BIGNUM_const_value(factors, 1)))
+        if (!ossl_prov_print_labeled_bignum(out, "prime2:", rsa_q))
             goto err;
-        if (!ossl_prov_print_labeled_bignum(out, "exponent1:",
-                                            sk_BIGNUM_const_value(exps, 0)))
+        if (!ossl_prov_print_labeled_bignum(out, "exponent1:", rsa_dp))
             goto err;
-        if (!ossl_prov_print_labeled_bignum(out, "exponent2:",
-                                            sk_BIGNUM_const_value(exps, 1)))
+        if (!ossl_prov_print_labeled_bignum(out, "exponent2:", rsa_dq))
             goto err;
-        if (!ossl_prov_print_labeled_bignum(out, "coefficient:",
-                                            sk_BIGNUM_const_value(coeffs, 0)))
+        if (!ossl_prov_print_labeled_bignum(out, "coefficient:", rsa_qinv))
             goto err;
-        for (i = 2; i < sk_BIGNUM_const_num(factors); i++) {
+        for (i = 0; i < sk_BIGNUM_const_num(factors); i++) {
             if (ossl_prov_bio_printf(out, "prime%d:", i + 1) <= 0)
                 goto err;
             if (!ossl_prov_print_labeled_bignum(out, NULL,
@@ -105,7 +107,7 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
                 goto err;
             if (!ossl_prov_print_labeled_bignum(out, NULL,
                                                 sk_BIGNUM_const_value(coeffs,
-                                                                      i - 1)))
+                                                                      i)))
                 goto err;
         }
     }
@@ -116,4 +118,3 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
     sk_BIGNUM_const_free(coeffs);
     return ret;
 }
-

--- a/test/keymgmt_internal_test.c
+++ b/test/keymgmt_internal_test.c
@@ -92,9 +92,6 @@ static int export_cb(const OSSL_PARAM *params, void *arg)
 {
     unsigned long *keydata = arg;
     const OSSL_PARAM *p = NULL;
-    int factors_idx;
-    int exponents_idx;
-    int coefficients_idx;
     int ret = 1;                 /* Ever so hopeful */
 
     if (keydata == NULL)
@@ -105,35 +102,25 @@ static int export_cb(const OSSL_PARAM *params, void *arg)
         || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_E))
         || !TEST_true(get_ulong_via_BN(p, &keydata[E]))
         || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_D))
-        || !TEST_true(get_ulong_via_BN(p, &keydata[D])))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[D]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_P))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[P]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_Q))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[Q]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_DP))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[DP]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_DQ))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[DQ]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_QINV))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[QINV]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_MP_FACTOR))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[F3]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_MP_EXPONENT))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[E3]))
+        || !TEST_ptr(p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_MP_COEFFICIENT))
+        || !TEST_true(get_ulong_via_BN(p, &keydata[C3])))
         ret = 0;
 
-    for (p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_FACTOR),
-             factors_idx = P;
-         p != NULL && factors_idx <= F3;
-         p = OSSL_PARAM_locate_const(p + 1, OSSL_PKEY_PARAM_RSA_FACTOR),
-         factors_idx++)
-        if (!TEST_true(get_ulong_via_BN(p, &keydata[factors_idx])))
-            ret = 0;
-    for (p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_EXPONENT),
-             exponents_idx = DP;
-         p != NULL && exponents_idx <= E3;
-         p = OSSL_PARAM_locate_const(p + 1, OSSL_PKEY_PARAM_RSA_EXPONENT),
-         exponents_idx++)
-        if (!TEST_true(get_ulong_via_BN(p, &keydata[exponents_idx])))
-            ret = 0;
-    for (p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_COEFFICIENT),
-             coefficients_idx = QINV;
-         p != NULL && coefficients_idx <= C3;
-         p = OSSL_PARAM_locate_const(p + 1, OSSL_PKEY_PARAM_RSA_COEFFICIENT),
-         coefficients_idx++)
-        if (!TEST_true(get_ulong_via_BN(p, &keydata[coefficients_idx])))
-            ret = 0;
-
-    if (!TEST_int_le(factors_idx, F3)
-        || !TEST_int_le(exponents_idx, E3)
-        || !TEST_int_le(coefficients_idx, C3))
-        ret = 0;
     return ret;
 }
 
@@ -146,6 +133,9 @@ static int test_pass_rsa(FIXTURE *fixture)
     EVP_PKEY *pk = NULL;
     EVP_KEYMGMT *km1 = NULL, *km2 = NULL;
     void *provkey = NULL;
+    BIGNUM *bn_primes[1] = { NULL };
+    BIGNUM *bn_exps[1] = { NULL };
+    BIGNUM *bn_coeffs[1] = { NULL };
     /*
      * 32-bit RSA key, extracted from this command,
      * executed with OpenSSL 1.0.2:
@@ -158,12 +148,12 @@ static int test_pass_rsa(FIXTURE *fixture)
         0x7b133399,              /* D */
         0xe963,                  /* P */
         0xceb7,                  /* Q */
-        0,                       /* F3 */
+        1,                       /* F3 */
         0x8599,                  /* DP */
         0xbd87,                  /* DQ */
-        0,                       /* E3 */
+        2,                       /* E3 */
         0xcc3b,                  /* QINV */
-        0,                       /* C3 */
+        3,                       /* C3 */
         0                        /* Extra, should remain zero */
     };
     static unsigned long keydata[OSSL_NELEM(expected)] = { 0, };
@@ -196,6 +186,16 @@ static int test_pass_rsa(FIXTURE *fixture)
         || !TEST_true(RSA_set0_crt_params(rsa, bn1, bn2, bn3)))
         goto err;
     bn1 = bn2 = bn3 = NULL;
+
+    if (!TEST_ptr(bn_primes[0] = BN_new())
+        || !TEST_true(BN_set_word(bn_primes[0], expected[F3]))
+        || !TEST_ptr(bn_exps[0] = BN_new())
+        || !TEST_true(BN_set_word(bn_exps[0], expected[E3]))
+        || !TEST_ptr(bn_coeffs[0] = BN_new())
+        || !TEST_true(BN_set_word(bn_coeffs[0], expected[C3]))
+        || !TEST_true(RSA_set0_multi_prime_params(rsa, bn_primes, bn_exps,
+                                                  bn_coeffs, 1)))
+        goto err;
 
     if (!TEST_ptr(pk = EVP_PKEY_new())
         || !TEST_true(EVP_PKEY_assign_RSA(pk, rsa)))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4984,3 +4984,4 @@ EVP_PKEY_gen                            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_rsa_keygen_bits        ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_keygen_pubexp      ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_keygen_primes      ?	3_0_0	EXIST::FUNCTION:RSA
+EVP_PKEY_get_params                     ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Made the export and get_params functions share the same code by supplying
support functions that work for both a OSSL_PARAM_BLD as well as a OSSL_PARAM[].
This approach means that complex code is not required to build an
empty OSSL_PARAM[] with the correct sized fields before then doing a second
pass to populate the array.
Added P, Q, DP, DQ, QINV as base fields for RSA keys instead of using the
prime factor fields. These additional fields are now only used for multi primes
and give a clear seperation for the fips module. It is also simpler because the
stacks should now be all the same size.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
