### PR TITLE
EVP & TLS: Add necessary EC_KEY data extraction functions, and use them

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1025,6 +1025,7 @@ errors:
        qw( include/internal/dso.h
            include/internal/o_dir.h
            include/internal/err.h
+           include/internal/evp.h
            include/internal/sslconf.h );
    our @cryptoskipheaders = ( @sslheaders,
        qw( include/openssl/conf_api.h

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -755,12 +755,16 @@ int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name)
          */
         int type;
 
-        if (strcasecmp(name, "EC") == 0)
-            type = EVP_PKEY_EC;
-        else if (strcasecmp(name, "RSA") == 0)
+        if (strcasecmp(name, "RSA") == 0)
             type = EVP_PKEY_RSA;
+#ifndef OPENSSL_NO_EC
+        else if (strcasecmp(name, "EC") == 0)
+            type = EVP_PKEY_EC;
+#endif
+#ifndef OPENSSL_NO_DSA
         else if (strcasecmp(name, "DSA") == 0)
             type = EVP_PKEY_DSA;
+#endif
         else
             type = EVP_PKEY_type(OBJ_sn2nid(name));
         return EVP_PKEY_type(pkey->type) == type;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -33,8 +33,11 @@
 
 #include "crypto/asn1.h"
 #include "crypto/evp.h"
+#include "internal/evp.h"
 #include "internal/provider.h"
 #include "evp_local.h"
+
+#include "crypto/ec.h"
 
 static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
                          int len, EVP_KEYMGMT *keymgmt);
@@ -779,6 +782,48 @@ int EVP_PKEY_can_sign(const EVP_PKEY *pkey)
     }
     return 0;
 }
+
+#ifndef OPENSSL_NO_EC
+/*
+ * TODO rewrite when we have proper data extraction functions
+ * Note: an octet pointer would be desirable!
+ */
+static OSSL_CALLBACK get_ec_curve_name_cb;
+static int get_ec_curve_name_cb(const OSSL_PARAM params[], void *arg)
+{
+    const OSSL_PARAM *p = NULL;
+
+    if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_EC_NAME)) != NULL)
+        return OSSL_PARAM_get_utf8_string(p, arg, 0);
+
+    /* If there is no curve name, this is not an EC key */
+    return 0;
+}
+
+int evp_pkey_get_EC_KEY_curve_nid(const EVP_PKEY *pkey)
+{
+    int ret = NID_undef;
+
+    if (pkey->keymgmt == NULL) {
+        if (EVP_PKEY_base_id(pkey) == EVP_PKEY_EC) {
+            EC_KEY *ec = EVP_PKEY_get0_EC_KEY(pkey);
+
+            ret = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
+        }
+    } else if (EVP_PKEY_is_a(pkey, "EC") || EVP_PKEY_is_a(pkey, "SM2")) {
+        char *curve_name = NULL;
+
+        ret = evp_keymgmt_export(pkey->keymgmt, pkey->keydata,
+                                 OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
+                                 get_ec_curve_name_cb, &curve_name);
+        if (ret)
+            ret = ec_curve_name2nid(curve_name);
+        OPENSSL_free(curve_name);
+    }
+
+    return ret;
+}
+#endif
 
 static int print_reset_indent(BIO **out, int pop_f_prefix, long saved_indent)
 {

--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -1,0 +1,72 @@
+=pod
+
+=head1 NAME
+
+EVP_PKEY_is_a, EVP_PKEY_can_sign
+- key type and capabilities functions
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
+ int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
+
+=head1 DESCRIPTION
+
+EVP_PKEY_is_a() checks if the key type of I<pkey> is I<name>.
+
+EVP_PKEY_can_sign() checks if the functionality for the key type of
+I<pkey> supports signing.  No other check is done, such as whether
+I<pkey> contains a private key.
+
+=head1 RETURN VALUES
+
+EVP_PKEY_is_a() returns 1 if I<pkey> has the key type I<name>,
+otherwise 0.
+
+EVP_PKEY_can_sign() returns 1 if the I<pkey> key type functionality
+supports signing, otherwise 0.
+
+=head1 EXAMPLES
+
+=head2 EVP_PKEY_is_a()
+
+The loaded providers and what key types they support will ultimately
+determine what I<name> is possible to use with EVP_PKEY_is_a().  We do know
+that the default provider supports RSA, DH, DSA and EC keys, so we can use
+this as an crude example:
+
+ #include <openssl/evp.h>
+
+ ...
+     /* |pkey| is an EVP_PKEY* */
+     if (EVP_PKEY_is_a(pkey, "RSA")) {
+         BIGNUM *modulus = NULL;
+         if (EVP_PKEY_get_bn_param(pkey, "n", &modulus))
+             /* do whatever with the modulus */
+         BN_free(modulus);
+     }
+
+=head2 EVP_PKEY_can_sign()
+
+ #include <openssl/evp.h>
+
+ ...
+     /* |pkey| is an EVP_PKEY* */
+     if (!EVP_PKEY_can_sign(pkey)) {
+         fprintf(stderr, "Not a signing key!");
+         exit(1);
+     }
+     /* Sign something... */
+
+=head1 COPYRIGHT
+
+Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -51,52 +51,61 @@ EVP_PKEY_set1_engine, EVP_PKEY_get0_engine - EVP_PKEY assignment functions
 =head1 DESCRIPTION
 
 EVP_PKEY_set1_RSA(), EVP_PKEY_set1_DSA(), EVP_PKEY_set1_DH() and
-EVP_PKEY_set1_EC_KEY() set the key referenced by B<pkey> to B<key>.
+EVP_PKEY_set1_EC_KEY() set the key referenced by I<pkey> to I<key>.
 
 EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and
-EVP_PKEY_get1_EC_KEY() return the referenced key in B<pkey> or
-B<NULL> if the key is not of the correct type.
+EVP_PKEY_get1_EC_KEY() return the referenced key in I<pkey> or
+NULL if the key is not of the correct type.
 
 EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305(), EVP_PKEY_get0_siphash(),
 EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH()
-and EVP_PKEY_get0_EC_KEY() also return the referenced key in B<pkey> or B<NULL>
+and EVP_PKEY_get0_EC_KEY() also return the referenced key in I<pkey> or NULL
 if the key is not of the correct type but the reference count of the
 returned key is B<not> incremented and so must not be freed up after use.
 
 EVP_PKEY_assign_RSA(), EVP_PKEY_assign_DSA(), EVP_PKEY_assign_DH(),
 EVP_PKEY_assign_EC_KEY(), EVP_PKEY_assign_POLY1305() and
-EVP_PKEY_assign_SIPHASH() also set the referenced key to B<key>
-however these use the supplied B<key> internally and so B<key>
-will be freed when the parent B<pkey> is freed.
+EVP_PKEY_assign_SIPHASH() also set the referenced key to I<key>
+however these use the supplied I<key> internally and so I<key>
+will be freed when the parent I<pkey> is freed.
 
-EVP_PKEY_base_id() returns the type of B<pkey>. For example
+EVP_PKEY_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
 
-EVP_PKEY_id() returns the actual OID associated with B<pkey>. Historically keys
+EVP_PKEY_id() returns the actual OID associated with I<pkey>. Historically keys
 using the same algorithm could use different OIDs. For example an RSA key could
 use the OIDs corresponding to the NIDs B<NID_rsaEncryption> (equivalent to
 B<EVP_PKEY_RSA>) or B<NID_rsa> (equivalent to B<EVP_PKEY_RSA2>). The use of
 alternative non-standard OIDs is now rare so B<EVP_PKEY_RSA2> et al are not
 often seen in practice.
 
-EVP_PKEY_type() returns the underlying type of the NID B<type>. For example
+EVP_PKEY_type() returns the underlying type of the NID I<type>. For example
 EVP_PKEY_type(EVP_PKEY_RSA2) will return B<EVP_PKEY_RSA>.
 
-EVP_PKEY_get0_engine() returns a reference to the ENGINE handling B<pkey>.
+EVP_PKEY_get0_engine() returns a reference to the ENGINE handling I<pkey>.
 
-EVP_PKEY_set1_engine() sets the ENGINE handling B<pkey> to B<engine>. It
+EVP_PKEY_set1_engine() sets the ENGINE handling I<pkey> to I<engine>. It
 must be called after the key algorithm and components are set up.
-If B<engine> does not include an B<EVP_PKEY_METHOD> for B<pkey> an
+If I<engine> does not include an B<EVP_PKEY_METHOD> for I<pkey> an
 error occurs.
 
 EVP_PKEY_set_alias_type() allows modifying a EVP_PKEY to use a
 different set of algorithms than the default.
 
+=head1 WARNINGS
+
+The following functions are only reliable with B<EVP_PKEY>s that have
+been assigned an internal key with EVP_PKEY_assign_*():
+
+EVP_PKEY_id(), EVP_PKEY_base_id(), EVP_PKEY_type(), EVP_PKEY_set_alias_type()
+
+For EVP_PKEY key type checking purposes, L<EVP_PKEY_is_a(3)> is more generic.
+
 =head1 NOTES
 
 In accordance with the OpenSSL naming convention the key obtained
-from or assigned to the B<pkey> using the B<1> functions must be
-freed as well as B<pkey>.
+from or assigned to the I<pkey> using the B<1> functions must be
+freed as well as I<pkey>.
 
 EVP_PKEY_assign_RSA(), EVP_PKEY_assign_DSA(), EVP_PKEY_assign_DH(),
 EVP_PKEY_assign_EC_KEY(), EVP_PKEY_assign_POLY1305()
@@ -129,7 +138,7 @@ EVP_PKEY_set1_RSA(), EVP_PKEY_set1_DSA(), EVP_PKEY_set1_DH() and
 EVP_PKEY_set1_EC_KEY() return 1 for success or 0 for failure.
 
 EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and
-EVP_PKEY_get1_EC_KEY() return the referenced key or B<NULL> if
+EVP_PKEY_get1_EC_KEY() return the referenced key or NULL if
 an error occurred.
 
 EVP_PKEY_assign_RSA(), EVP_PKEY_assign_DSA(), EVP_PKEY_assign_DH(),

--- a/include/internal/evp.h
+++ b/include/internal/evp.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_INTERNAL_EVP_H
+# define OSSL_INTERNAL_EVP_H
+
+# include <openssl/evp.h>
+
+/*
+ * TODO(3.0) While waiting for more generic getters, we have these functions
+ * as an interim solution.  This should be removed when the generic getters
+ * appear.
+ */
+int evp_pkey_get_EC_KEY_curve_nid(const EVP_PKEY *pkey);
+#endif

--- a/include/internal/evp.h
+++ b/include/internal/evp.h
@@ -12,10 +12,12 @@
 
 # include <openssl/evp.h>
 
+# ifndef OPENSSL_NO_EC
 /*
  * TODO(3.0) While waiting for more generic getters, we have these functions
  * as an interim solution.  This should be removed when the generic getters
  * appear.
  */
 int evp_pkey_get_EC_KEY_curve_nid(const EVP_PKEY *pkey);
+# endif
 #endif

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1111,6 +1111,7 @@ int EVP_PKEY_base_id(const EVP_PKEY *pkey);
 int EVP_PKEY_bits(const EVP_PKEY *pkey);
 int EVP_PKEY_security_bits(const EVP_PKEY *pkey);
 int EVP_PKEY_size(const EVP_PKEY *pkey);
+int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
 int EVP_PKEY_set_type(EVP_PKEY *pkey, int type);
 int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len);
 int EVP_PKEY_set_type_by_keymgmt(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1104,6 +1104,7 @@ DEPRECATEDIN_3_0(int EVP_PKEY_decrypt_old(unsigned char *dec_key,
 DEPRECATEDIN_3_0(int EVP_PKEY_encrypt_old(unsigned char *enc_key,
                                           const unsigned char *key,
                                           int key_len, EVP_PKEY *pub_key))
+int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
 int EVP_PKEY_type(int type);
 int EVP_PKEY_id(const EVP_PKEY *pkey);
 int EVP_PKEY_base_id(const EVP_PKEY *pkey);

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -352,13 +352,10 @@ int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if ((selection & OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS) != 0)
         ok = ok && otherparams_to_params(ec, tmpl, NULL);
 
-    if (!ok
-        || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL)
-        goto err;
+    if (ok && (params = OSSL_PARAM_BLD_to_param(tmpl)) != NULL)
+        ok = param_cb(params, cbarg);
 
-    ok = param_cb(params, cbarg);
     OSSL_PARAM_BLD_free_params(params);
-err:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_free(pub_key);
     return ok;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -338,7 +338,7 @@ static int ssl_set_cert(CERT *c, X509 *x)
         return 0;
     }
 #ifndef OPENSSL_NO_EC
-    if (i == SSL_PKEY_ECC && !EC_KEY_can_sign(EVP_PKEY_get0_EC_KEY(pkey))) {
+    if (i == SSL_PKEY_ECC && !EVP_PKEY_can_sign(pkey)) {
         SSLerr(SSL_F_SSL_SET_CERT, SSL_R_ECC_CERT_NOT_FOR_SIGNING);
         return 0;
     }

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -711,6 +711,21 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             return 0;
         }
 
+        /*
+         * TODO(3.0) Remove this when EVP_PKEY_get1_tls_encodedpoint()
+         * knows how to get a key from an encoded point with the help of
+         * a OSSL_SERIALIZER deserializer.  We know that EVP_PKEY_get0()
+         * downgrades an EVP_PKEY to contain a legacy key.
+         *
+         * THIS IS TEMPORARY
+         */
+        EVP_PKEY_get0(s->s3.peer_tmp);
+        if (EVP_PKEY_id(s->s3.peer_tmp) == EVP_PKEY_NONE) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_KEY_SHARE,
+                     ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+
         s->s3.group_id = group_id;
 
         if (!EVP_PKEY_set1_tls_encodedpoint(s->s3.peer_tmp,
@@ -1733,6 +1748,21 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
     if (skey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE,
                  ERR_R_MALLOC_FAILURE);
+        return EXT_RETURN_FAIL;
+    }
+
+    /*
+     * TODO(3.0) Remove this when EVP_PKEY_get1_tls_encodedpoint()
+     * knows how to get a key from an encoded point with the help of
+     * a OSSL_SERIALIZER deserializer.  We know that EVP_PKEY_get0()
+     * downgrades an EVP_PKEY to contain a legacy key.
+     *
+     * THIS IS TEMPORARY
+     */
+    EVP_PKEY_get0(skey);
+    if (EVP_PKEY_id(skey) == EVP_PKEY_NONE) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE,
+                 ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;
     }
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2227,6 +2227,21 @@ static int tls_process_ske_ecdhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
         return 0;
     }
 
+    /*
+     * TODO(3.0) Remove this when EVP_PKEY_get1_tls_encodedpoint()
+     * knows how to get a key from an encoded point with the help of
+     * a OSSL_SERIALIZER deserializer.  We know that EVP_PKEY_get0()
+     * downgrades an EVP_PKEY to contain a legacy key.
+     *
+     * THIS IS TEMPORARY
+     */
+    EVP_PKEY_get0(s->s3.peer_tmp);
+    if (EVP_PKEY_id(s->s3.peer_tmp) == EVP_PKEY_NONE) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_SKE_ECDHE,
+                 ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
     if (!EVP_PKEY_set1_tls_encodedpoint(s->s3.peer_tmp,
                                         PACKET_data(&encoded_pt),
                                         PACKET_remaining(&encoded_pt))) {
@@ -3126,6 +3141,21 @@ static int tls_construct_cke_ecdhe(SSL *s, WPACKET *pkt)
     if (ckey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_ECDHE,
                  ERR_R_MALLOC_FAILURE);
+        goto err;
+    }
+
+    /*
+     * TODO(3.0) Remove this when EVP_PKEY_get1_tls_encodedpoint()
+     * knows how to get a key from an encoded point with the help of
+     * a OSSL_SERIALIZER deserializer.  We know that EVP_PKEY_get0()
+     * downgrades an EVP_PKEY to contain a legacy key.
+     *
+     * THIS IS TEMPORARY
+     */
+    EVP_PKEY_get0(ckey);
+    if (EVP_PKEY_id(skey) == EVP_PKEY_NONE) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_ECDHE,
+                 ERR_R_INTERNAL_ERROR);
         goto err;
     }
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -14,6 +14,7 @@
 #include "../ssl_local.h"
 #include "statem_local.h"
 #include "internal/cryptlib.h"
+#include "internal/evp.h"
 #include <openssl/buffer.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>
@@ -1531,7 +1532,6 @@ static int is_tls13_capable(const SSL *s)
     int i;
 #ifndef OPENSSL_NO_EC
     int curve;
-    EC_KEY *eckey;
 #endif
 
 #ifndef OPENSSL_NO_PSK
@@ -1563,10 +1563,8 @@ static int is_tls13_capable(const SSL *s)
          * more restrictive so check that our sig algs are consistent with this
          * EC cert. See section 4.2.3 of RFC8446.
          */
-        eckey = EVP_PKEY_get0_EC_KEY(s->cert->pkeys[SSL_PKEY_ECC].privatekey);
-        if (eckey == NULL)
-            continue;
-        curve = EC_GROUP_get_curve_name(EC_KEY_get0_group(eckey));
+        curve = evp_pkey_get_EC_KEY_curve_nid(s->cert->pkeys[SSL_PKEY_ECC]
+                                              .privatekey);
         if (tls_check_sigalg_curve(s, curve))
             return 1;
 #else

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5037,3 +5037,5 @@ EVP_PKEY_get_size_t_param               ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_bn_param                   ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_utf8_string_param          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_octet_string_param         ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_is_a                           ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_can_sign                       ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5039,4 +5039,4 @@ EVP_PKEY_get_utf8_string_param          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_octet_string_param         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_is_a                           ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_can_sign                       ?	3_0_0	EXIST::FUNCTION:
-evp_pkey_get_EC_KEY_curve_nid           ?	3_0_0	EXIST::FUNCTION:
+evp_pkey_get_EC_KEY_curve_nid           ?	3_0_0	EXIST::FUNCTION:EC

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5039,3 +5039,4 @@ EVP_PKEY_get_utf8_string_param          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_octet_string_param         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_is_a                           ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_can_sign                       ?	3_0_0	EXIST::FUNCTION:
+evp_pkey_get_EC_KEY_curve_nid           ?	3_0_0	EXIST::FUNCTION:

--- a/util/missingcrypto.txt
+++ b/util/missingcrypto.txt
@@ -1558,6 +1558,8 @@ conf_ssl_name_find(3)
 d2i_X509_bio(3)
 d2i_X509_fp(3)
 err_free_strings_int(3)
+# The following is internal but exported by libcrypto
+evp_pkey_get_EC_KEY_curve_nid(3)
 i2a_ACCESS_DESCRIPTION(3)
 i2a_ASN1_ENUMERATED(3)
 i2a_ASN1_INTEGER(3)


### PR DESCRIPTION
libssl code uses EVP_PKEY_get0_EC_KEY() to extract certain basic data
from the EC_KEY.  We replace that with EVP_PKEY functions.

This may or may not be refactored later on.
