### PR TITLE
Allow to continue with further checks on UNABLE_TO_VERIFY_LEAF_SIGNATURE

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1750,9 +1750,15 @@ static int internal_verify(X509_STORE_CTX *ctx)
             xs = xi;
             goto check_cert;
         }
-        if (n <= 0)
-            return verify_cb_cert(ctx, xi, 0,
-                                  X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE);
+        if (n <= 0) {
+            if (!verify_cb_cert(ctx, xi, 0,
+                                X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE))
+                return 0;
+
+            xs = xi;
+            goto check_cert;
+        }
+
         n--;
         ctx->error_depth = n;
         xs = sk_X509_value(ctx->chain, n);


### PR DESCRIPTION
This unifies the behaviour of a single certificate with
an unknown CA certificate with a self-signed certificate.
The user callback can mask that error to retrieve additional
error information. So the user application can decide to
abort the connection instead to be forced by openssl.

This change in behaviour is backward compatible as user callbacks
who don't want to ignore UNABLE_TO_VERIFY_LEAF_SIGNATURE will
still abort the connection by default.

CLA: trivial
Fixes #11297