### PR TITLE
Implement blinding for scalar multiplication

### DIFF
--- a/crypto/ec/ec.h
+++ b/crypto/ec/ec.h
@@ -1182,6 +1182,7 @@ void ERR_load_EC_strings(void);
 # define EC_F_EC_KEY_PRINT                                180
 # define EC_F_EC_KEY_PRINT_FP                             181
 # define EC_F_EC_KEY_SET_PUBLIC_KEY_AFFINE_COORDINATES    229
+# define EC_F_EC_MUL_CONSTTIME                            246
 # define EC_F_EC_POINTS_MAKE_AFFINE                       136
 # define EC_F_EC_POINT_ADD                                112
 # define EC_F_EC_POINT_CMP                                113

--- a/crypto/ec/ec2_mult.c
+++ b/crypto/ec/ec2_mult.c
@@ -317,7 +317,7 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
 
     /* blinding: make sure z1 and z2 are independently blinded. */
     do {
-        if (!BN_rand(z1, BN_num_bits(&group->field), 0, 0)) {
+        if (!BN_rand(z1, BN_num_bits(&group->field) - 1, -1, 0)) {
             ECerr(EC_F_EC_GF2M_MONTGOMERY_POINT_MULTIPLY, ERR_R_BN_LIB);
             return 0;
         }
@@ -332,7 +332,7 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
 
     /* now generate another random field element to blind (x1,z1) */
     do {
-        if (!BN_rand(z1, BN_num_bits(&group->field), 0, 0)) {
+        if (!BN_rand(z1, BN_num_bits(&group->field) - 1, -1, 0)) {
             ECerr(EC_F_EC_GF2M_MONTGOMERY_POINT_MULTIPLY, ERR_R_BN_LIB);
             return 0;
         }

--- a/crypto/ec/ec2_mult.c
+++ b/crypto/ec/ec2_mult.c
@@ -421,11 +421,9 @@ int ec_GF2m_simple_mul(const EC_GROUP *group, EC_POINT *r,
     /*
      * This implementation is more efficient than the wNAF implementation for
      * 2 or fewer points.  Use the ec_wNAF_mul implementation for 3 or more
-     * points, or if we can perform a fast multiplication based on
-     * precomputation.
+     * points.
      */
-    if ((scalar && (num > 1)) || (num > 2)
-        || (num == 0 && EC_GROUP_have_precompute_mult(group))) {
+    if ((scalar && (num > 1)) || (num > 2)) {
         ret = ec_wNAF_mul(group, r, scalar, num, points, scalars, ctx);
         goto err;
     }

--- a/crypto/ec/ec2_mult.c
+++ b/crypto/ec/ec2_mult.c
@@ -317,7 +317,7 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
 
     /* blinding: make sure z1 and z2 are independently blinded. */
     do {
-        if (!BN_rand(z1, BN_num_bits(&group->order), 0, 0)) {
+        if (!BN_rand(z1, BN_num_bits(&group->field), 0, 0)) {
             ECerr(EC_F_EC_GF2M_MONTGOMERY_POINT_MULTIPLY, ERR_R_BN_LIB);
             return 0;
         }
@@ -332,7 +332,7 @@ static int ec_GF2m_montgomery_point_multiply(const EC_GROUP *group,
 
     /* now generate another random field element to blind (x1,z1) */
     do {
-        if (!BN_rand(z1, BN_num_bits(&group->order), 0, 0)) {
+        if (!BN_rand(z1, BN_num_bits(&group->field), 0, 0)) {
             ECerr(EC_F_EC_GF2M_MONTGOMERY_POINT_MULTIPLY, ERR_R_BN_LIB);
             return 0;
         }

--- a/crypto/ec/ec_err.c
+++ b/crypto/ec/ec_err.c
@@ -1,6 +1,6 @@
 /* crypto/ec/ec_err.c */
 /* ====================================================================
- * Copyright (c) 1999-2019 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1999-2020 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -205,6 +205,7 @@ static ERR_STRING_DATA EC_str_functs[] = {
     {ERR_FUNC(EC_F_EC_KEY_PRINT_FP), "EC_KEY_print_fp"},
     {ERR_FUNC(EC_F_EC_KEY_SET_PUBLIC_KEY_AFFINE_COORDINATES),
      "EC_KEY_set_public_key_affine_coordinates"},
+    {ERR_FUNC(EC_F_EC_MUL_CONSTTIME), "EC_MUL_CONSTTIME"},
     {ERR_FUNC(EC_F_EC_POINTS_MAKE_AFFINE), "EC_POINTs_make_affine"},
     {ERR_FUNC(EC_F_EC_POINT_ADD), "EC_POINT_add"},
     {ERR_FUNC(EC_F_EC_POINT_CMP), "EC_POINT_cmp"},

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -439,7 +439,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
         /* first randomize r->Z to blind s. */
         do {
-            if (!BN_rand(&r->Z, BN_num_bits(&group->field), -1, 0)) {
+            if (!BN_rand_range(&r->Z, &group->field)) {
                 ECerr(EC_F_EC_MUL_CONSTTIME, ERR_R_BN_LIB);
                 goto err;
             }
@@ -466,7 +466,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
         /* blinding: now rerandomize r->Z to make r a blinded copy of s. */
         do {
-            if (!BN_rand(&r->Z, BN_num_bits(&group->field), -1, 0)) {
+            if (!BN_rand_range(&r->Z, &group->field)) {
                 ECerr(EC_F_EC_MUL_CONSTTIME, ERR_R_BN_LIB);
                 goto err;
             }

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -421,8 +421,21 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
         || (bn_wexpand(&r->Z, group_top) == NULL))
         goto err;
 
-    /* blinding for prime curves: use point r as temporary variable. */
     if (group->meth->field_type == NID_X9_62_prime_field) {
+        /*
+         * Apply blinding independently to r and s: use point r as temporary
+         * variable.
+         *
+         * Blinding requires using a projective representation, and later we
+         * implement the ladder step using EC_POINT_add() and EC_POINT_dbl():
+         * this requires EC_METHODs that support projective coordinates in their
+         * point addition and point doubling implementations.
+         *
+         * All the built-in EC_METHODs for prime curves at the moment satisfy
+         * this condition, while the EC_METHOD for binary curves does not.
+         *
+         * This is why we check for a prime field to apply blinding.
+         */
 
         /* first randomize r->Z to blind s. */
         do {

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -421,34 +421,36 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
         || (bn_wexpand(&r->Z, group_top) == NULL))
         goto err;
 
-    /* blinding: use point r as temporary variable. */
+    /* blinding for prime curves: use point r as temporary variable. */
+    if (group->meth->field_type == NID_X9_62_prime_field) {
 
-    /* first randomize r->Z and later adjust s accordingly. */
-    do {
-        if (!BN_rand(&r->Z, BN_num_bits(&group->order), 0, 0)) {
-            ECerr(EC_F_EC_POINT_MUL, ERR_R_BN_LIB);
+        /* first randomize r->Z and later adjust s accordingly. */
+        do {
+            if (!BN_rand(&r->Z, BN_num_bits(&group->order), 0, 0)) {
+                ECerr(EC_F_EC_POINT_MUL, ERR_R_BN_LIB);
+                goto err;
+            }
+        } while (BN_is_zero(&r->Z));
+
+        /* convert r->Z to the correct field representation. */
+        if (group->meth->field_encode != NULL
+            && !group->meth->field_encode(group, &r->Z, &r->Z, ctx)) {
             goto err;
         }
-    } while (BN_is_zero(&r->Z));
 
-    /* convert r->Z to the correct field representation. */
-    if (group->meth->field_encode != NULL
-        && !group->meth->field_encode(group, &r->Z, &r->Z, ctx)) {
-        goto err;
+        /* scale s->X and s->Y by r->Z^2 and r->Z^3, respectively. */
+        if (!group->meth->field_sqr(group, &r->X, &r->Z, ctx)
+            || !group->meth->field_mul(group, &r->Y, &r->X, &r->Z, ctx)) {
+            goto err;
+        }
+        if (!group->meth->field_mul(group, &s->X, &s->X, &r->X, ctx)
+            || !group->meth->field_mul(group, &s->Y, &s->Y, &r->Y, ctx)
+            || !group->meth->field_mul(group, &s->Z, &s->Z, &r->Z, ctx)) {
+            goto err;
+        }
+        /* mark the flag in s to full projective coordinates. */
+        s->Z_is_one = 0;
     }
-
-    /* scale s->X and s->Y by r->Z^2 and r->Z^3, respectively. */
-    if (!group->meth->field_sqr(group, &r->X, &r->Z, ctx)
-        || !group->meth->field_mul(group, &r->Y, &r->X, &r->Z, ctx)) {
-        goto err;
-    }
-    if (!group->meth->field_mul(group, &s->X, &s->X, &r->X, ctx)
-        || !group->meth->field_mul(group, &s->Y, &s->Y, &r->Y, ctx)
-        || !group->meth->field_mul(group, &s->Z, &s->Z, &r->Z, ctx)) {
-        goto err;
-    }
-    /* mark the flag in s to full projective coordinates. */
-    s->Z_is_one = 0;
 
     /* top bit is a 1, in a fixed pos; blinding makes r projective as well */
     if (!EC_POINT_copy(r, s))

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -439,7 +439,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
         /* first randomize r->Z to blind s. */
         do {
-            if (!BN_rand(&r->Z, BN_num_bits(&group->field), 0, 0)) {
+            if (!BN_rand(&r->Z, BN_num_bits(&group->field), -1, 0)) {
                 ECerr(EC_F_EC_MUL_CONSTTIME, ERR_R_BN_LIB);
                 goto err;
             }
@@ -466,7 +466,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
         /* blinding: now rerandomize r->Z to make r a blinded copy of s. */
         do {
-            if (!BN_rand(&r->Z, BN_num_bits(&group->field), 0, 0)) {
+            if (!BN_rand(&r->Z, BN_num_bits(&group->field), -1, 0)) {
                 ECerr(EC_F_EC_MUL_CONSTTIME, ERR_R_BN_LIB);
                 goto err;
             }

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -426,7 +426,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
         /* first randomize r->Z to blind s. */
         do {
-            if (!BN_rand(&r->Z, BN_num_bits(&group->order), 0, 0)) {
+            if (!BN_rand(&r->Z, BN_num_bits(&group->field), 0, 0)) {
                 ECerr(EC_F_EC_MUL_CONSTTIME, ERR_R_BN_LIB);
                 goto err;
             }
@@ -453,7 +453,7 @@ static int ec_mul_consttime(const EC_GROUP *group, EC_POINT *r,
 
         /* blinding: now rerandomize r->Z to make r a blinded copy of s. */
         do {
-            if (!BN_rand(&r->Z, BN_num_bits(&group->order), 0, 0)) {
+            if (!BN_rand(&r->Z, BN_num_bits(&group->field), 0, 0)) {
                 ECerr(EC_F_EC_MUL_CONSTTIME, ERR_R_BN_LIB);
                 goto err;
             }


### PR DESCRIPTION
We are a group of security researchers and cryptographers from academia and industry, and would like to continue the report of a security vulnerability in OpenSSL's implementation of binary/prime field ECDSA signatures. We initiated contact by e-mail in December 2019 and decided to open a pull request publicly to collaborate further with a fix.
* Affected versions: `1.0.2u` and `1.1.0l` (current stable releases except `1.1.1` branch)
* Affected curve parameters:
    - `sect163r1`, `sect283r1`, `sect571r1` (i.e. binary curves with group order slightly below the power of two) for `1.0.2u` and `1.1.0l`
    - `secp192r1`, `secp224r1`, `secp256r1`, `secp384r1`, `secp521r1` (i.e. prime curves with group order slightly below the power of two) for `1.0.2u`

#### Severity: full key exposure via cache timing attack

### Executive summary

We discovered non-constant time implementations of Montgomery ladder scalar multiplication in the aforementioned releases, which enable the attacker to learn 1-bit of secret nonce with high precision making use of FLUSH+RELOAD cache timing attack technique [1]. Such a small leakage of nonces yields to key-recovery attacks from sufficiently many ECDSA signatures, due to our optimized version of Bleichenbacher's technique [2,3].

[1] Y. Yarom, K. Falkner. "FLUSH+RELOAD: a High Resolution, Low Noise,L3 Cache Side-Channel Attack". USENIX Security 2014.

[2] D. Bleichenbacher. "On the generation of one-time keys in DL signature schemes". Presentation at IEEE P1363 working group meeting. 2000.

[3] A. Takahashi, M. Tibouchi, M. Abe. "New Bleichenbacher records: fault attacks on qDSA signatures". TCHES 2018(3), pp. 331–371, 2018.

### Overview of the vulnerability

The attack starts with the detection based on the second topmost bit using a cache-timing attack and follows with the Bleichenbacher methodology. Although the vulnerabilities are similar we split the discussion in the binary and prime curve cases. 
  * For the **binary curve case**, the Montomery ladder is implemented in function `ec_GF2m_montgomery_point_multiply()` within file `ec2_mult.c` using López-Dahab coordinates. The function computes scalar multiplication kP for fixed-length scalar *k* and input point *P = (x,y)*. The ladder starts by initializing two points *(X1,Z1) = (X, 1)* and *(X2,Z2) = 2P = (x^4 + b, x^2)*. The first loop iteration follows after a conditional swap function that exchanges these two points based on the value of the second topmost key bit. The first function to be called within the first iteration is `gf2m_Madd()`, which starts by multiplying by value *Z1*. However, since the finite field arithmetic is not implemented in constant-time for binary fields, there is a timing difference between multiplying by *(1)* or *(x^2)*, since modular reduction is only needed in the second case. In particular, a modular reduction will be computed when *Z1* is *x^2* after the conditional swap. This happens when the second topmost bit is 1 because the conditional swap effectively swapped the two sets of values. Although the timing difference is very small, it can be amplified by running a FLUSH-RELOAD attack that measures the amount of time the first multiplication takes while multiple threads in the background penalize the modular reduction code by evicting it from the cache. We observed that it is possible to amplify the timing difference to more than 100,000 cycles on multiple processors, which allows for a detection probability of success above 95% when FLUSH-RELOAD is used.

 * For the **prime curve case**, the analysis is a little more involved. OpenSSL implements the Montgomery Ladder by using optimized formulas for elliptic curve arithmetic in the Weierstrass model. The algorithm is implemented in function `ec_mul_consttime()`, but which does not run in constant-time from a cache perspective. The ladder starts again by initializing two accumulators `r = P` (in affine coordinates) and `s = 2P` (in projective coordinates). The first loop iteration is non-trivial and computes a point addition and a point doubling after a conditional swap. Depending on the key bit, the conditional swap is effective and only one point will remain stored in projective coordinates. Both the point addition and point doubling functions have optimizations in place for mixed addition, and our detection works on the point doubling case implemented in function `ec_GFp_simple_dbl()`. When the input point for the doubling function is in affine coordinates, a field multiplication is replaced by a faster call to `BN_copy()`. This happens when the two accumulators are not swapped in the ladder, which means that point `r` in affine coordinates is doubled and the second topmost bit is 0. The timing difference is again very small, but can be amplified to at least 15,000 cycles using performance degradation threads that evict the `BN_copy()` code from the cache. Our detection code implements the FLUSH-RELOAD technique and correctly determines the second topmost bit with around 99% probability of success.

### Validation of the attack
​
We have conducted an experiment that recovers the signing key of a `sect163r1` ECDSA key pair given about 2^26 signatures generated by OpenSSL, with relatively modest computational resources (around 3000 CPU hours and 720GB on a high-performance workstation). Even fewer signatures would suffice with a slightly bigger computation.

Our attack code also generalizes to other larger parameters in theory, although the required number of signatures and time complexity are orders of magnitude larger. We're currently executing a practical experiment of our attack against `secp192r1`.

### Impact of the vulnerability

The vulnerability impacts private keys for ECDSA signatures instantiated with the affected curves. The most likely attack scenario is targeting a server's private key, in which the attacker has execution capabilities in the same machine.

### How to fix

A possible fix amounts to implementing coordinate randomization to balance the two possibilities for the key bit in the first loop iteration of the Montgomery ladder. This way, the Z coordinates of both accumulator points will be non-trivial and the multiplication latency will be similar, with a tiny performance penalty.

This pull request implement such a countermeasure for the binary case in version `1.0.2`, but we are happy to contribute additional patches for prime curves and version `1.1.0` if necessary.

### Contact information

  * Diego F. Aranha @dfaranha (Aarhus University)
  * Akira Takahashi @akiratk0355 (Aarhus University)
  * Mehdi Tibouchi @mti (NTT Corporation)
  * Yuval Yarom @javali7 (University of Adelaide)