### PR TITLE
DH, DSA, EC_KEY: Fix exporters to allow domain parameter keys

### DIFF
--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -526,6 +526,7 @@ static int dsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     const BIGNUM *q = DSA_get0_q(dsa), *pub_key = DSA_get0_pub_key(dsa);
     const BIGNUM *priv_key = DSA_get0_priv_key(dsa);
     OSSL_PARAM *params;
+    int selection = 0;
     int rv;
 
     /*
@@ -543,21 +544,25 @@ static int dsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
         || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_Q, q)
         || !ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_FFC_G, g))
         return 0;
-    if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_PUB_KEY,
-                                pub_key))
-        return 0;
+    selection |= OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS;
+    if (pub_key != NULL) {
+        if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_PUB_KEY,
+                                    pub_key))
+            return 0;
+        selection |= OSSL_KEYMGMT_SELECT_PUBLIC_KEY;
+    }
     if (priv_key != NULL) {
         if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_PRIV_KEY,
                                     priv_key))
             return 0;
+        selection |= OSSL_KEYMGMT_SELECT_PRIVATE_KEY;
     }
 
     if ((params = ossl_param_bld_to_param(&tmpl)) == NULL)
         return 0;
 
     /* We export, the provider imports */
-    rv = evp_keymgmt_import(to_keymgmt, to_keydata, OSSL_KEYMGMT_SELECT_ALL,
-                            params);
+    rv = evp_keymgmt_import(to_keymgmt, to_keydata, selection, params);
 
     ossl_param_bld_free(params);
 

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -423,6 +423,7 @@ static int ecx_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     const ECX_KEY *key = from->pkey.ecx;
     OSSL_PARAM_BLD tmpl;
     OSSL_PARAM *params = NULL;
+    int selection = 0;
     int rv = 0;
 
     ossl_param_bld_init(&tmpl);
@@ -431,19 +432,20 @@ static int ecx_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     if (!ossl_param_bld_push_octet_string(&tmpl, OSSL_PKEY_PARAM_PUB_KEY,
                                           key->pubkey, key->keylen))
         goto err;
+    selection |= OSSL_KEYMGMT_SELECT_PUBLIC_KEY;
 
     if (key->privkey != NULL) {
         if (!ossl_param_bld_push_octet_string(&tmpl,
                                               OSSL_PKEY_PARAM_PRIV_KEY,
                                               key->privkey, key->keylen))
             goto err;
+        selection |= OSSL_KEYMGMT_SELECT_PRIVATE_KEY;
     }
 
     params = ossl_param_bld_to_param(&tmpl);
 
     /* We export, the provider imports */
-    rv = evp_keymgmt_import(to_keymgmt, to_keydata, OSSL_KEYMGMT_SELECT_ALL,
-                            params);
+    rv = evp_keymgmt_import(to_keymgmt, to_keydata, selection, params);
 
  err:
     ossl_param_bld_free(params);

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -1090,6 +1090,7 @@ static int rsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     STACK_OF(BIGNUM_const) *primes = NULL, *exps = NULL, *coeffs = NULL;
     int numprimes = 0, numexps = 0, numcoeffs = 0;
     OSSL_PARAM *params = NULL;
+    int selection = 0;
     int rv = 0;
 
     /*
@@ -1110,6 +1111,7 @@ static int rsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
         goto err;
     if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_RSA_N, n))
         goto err;
+    selection |= OSSL_KEYMGMT_SELECT_PUBLIC_KEY;
 
     if (d != NULL) {
         int i;
@@ -1144,6 +1146,7 @@ static int rsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
 
         if (!ossl_param_bld_push_BN(&tmpl, OSSL_PKEY_PARAM_RSA_D, d))
             goto err;
+        selection |= OSSL_KEYMGMT_SELECT_PRIVATE_KEY;
 
         for (i = 0; i < numprimes; i++) {
             const BIGNUM *num = sk_BIGNUM_const_value(primes, i);
@@ -1174,8 +1177,7 @@ static int rsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
         goto err;
 
     /* We export, the provider imports */
-    rv = evp_keymgmt_import(to_keymgmt, to_keydata, OSSL_KEYMGMT_SELECT_ALL,
-                            params);
+    rv = evp_keymgmt_import(to_keymgmt, to_keydata, selection, params);
 
  err:
     sk_BIGNUM_const_free(primes);


### PR DESCRIPTION
The export-to-provider functions for DH, DSA and EC_KEY assumed that a
public key is always present, and would fail if not.  This blocks any
attempt to export a key structure with only domain parameters.

While fixing this, we also modify the selection declaration to
evp_keymgmt_import() to be more adaptive, the diverse selection bits
are now added when the corresponding data is added to the OSSL_PARAM
array.
