### PR TITLE
util/wrap.pl: Correct exit code when signalled

### DIFF
--- a/util/wrap.pl
+++ b/util/wrap.pl
@@ -35,5 +35,12 @@ my $waitcode = system @cmd;
 # (exitcode << 8 | signalcode)
 die "wrap.pl: Failed to execute '", join(' ', @cmd), "': $!\n"
     if $waitcode == -1;
-exit($? & 255) if ($? & 255) != 0;
+
+# When the subprocess aborted on a signal, mimic what Unix shells do, by
+# converting the signal code to an exit code by setting the high bit.
+# This only happens on Unix flavored operating systems, the others don't
+# have this sort of signaling to date, and simply leave the low byte zero.
+exit(($? & 255) | 128) if ($? & 255) != 0;
+
+# When not a signal, just shift down the subprocess exit code and use that.
 exit($? >> 8);


### PR DESCRIPTION
On Unix, a caught signal that exits the process does so with an exit
code that is 'signal | 128'.  This modifies util/wrap.pl to mimic
that.
