### PR TITLE
i2b_PVK_bio: don't set PEM_R_BIO_WRITE_FAILURE in case of success

### DIFF
--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -882,9 +882,9 @@ int i2b_PVK_bio(BIO *out, const EVP_PKEY *pk, int enclevel,
     wrlen = BIO_write(out, tmp, outlen);
     OPENSSL_free(tmp);
     if (wrlen == outlen) {
-        PEMerr(PEM_F_I2B_PVK_BIO, PEM_R_BIO_WRITE_FAILURE);
         return outlen;
     }
+    PEMerr(PEM_F_I2B_PVK_BIO, PEM_R_BIO_WRITE_FAILURE);
     return -1;
 }
 


### PR DESCRIPTION
but in case of an error

CLA: trivial
