### PR TITLE
Fix a gcc-10 warning

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -426,10 +426,10 @@ char *sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text, const char *sep,
         current = sk_ASN1_UTF8STRING_value(text, i);
         length = ASN1_STRING_length(current);
         if (i > 0 && sep_len > 0) {
-            strncpy(p, sep, sep_len);
+            memcpy(p, sep, sep_len);
             p += sep_len;
         }
-        strncpy(p, (const char *)ASN1_STRING_get0_data(current), length);
+        memcpy(p, (const char *)ASN1_STRING_get0_data(current), length);
         p += length;
     }
     *p = '\0';


### PR DESCRIPTION
Use memcpy when zero-termination is not requred
to make it explict for the compiler to see what
we are doing here.

Fixes #11392

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
