### PR TITLE
Params: Add OSSL_PARAM_set_BN_pad() function.

### DIFF
--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -25,9 +25,9 @@ OSSL_PARAM_get_octet_ptr,
 OSSL_PARAM_set_double, OSSL_PARAM_set_int, OSSL_PARAM_set_int32,
 OSSL_PARAM_set_int64, OSSL_PARAM_set_long, OSSL_PARAM_set_size_t,
 OSSL_PARAM_set_uint, OSSL_PARAM_set_uint32, OSSL_PARAM_set_uint64,
-OSSL_PARAM_set_ulong, OSSL_PARAM_set_BN, OSSL_PARAM_set_utf8_string,
-OSSL_PARAM_set_octet_string, OSSL_PARAM_set_utf8_ptr,
-OSSL_PARAM_set_octet_ptr
+OSSL_PARAM_set_ulong, OSSL_PARAM_set_BN, OSSL_PARAM_set_BN_pad,
+OSSL_PARAM_set_utf8_string, OSSL_PARAM_set_octet_string,
+OSSL_PARAM_set_utf8_ptr, OSSL_PARAM_set_octet_ptr
 - OSSL_PARAM helpers
 
 =head1 SYNOPSIS
@@ -74,6 +74,7 @@ OSSL_PARAM_set_octet_ptr
 
  int OSSL_PARAM_get_BN(const OSSL_PARAM *p, BIGNUM **val);
  int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val);
+ int OSSL_PARAM_set_BN_pad(OSSL_PARAM *p, const BIGNUM *val, size_t sz);
 
  int OSSL_PARAM_get_utf8_string(const OSSL_PARAM *p, char **val,
                                 size_t max_len);
@@ -209,6 +210,11 @@ The BIGNUM referenced by B<val> is updated and is allocated if B<*val> is
 B<NULL>.
 
 OSSL_PARAM_set_BN() stores the BIGNUM B<val> into the parameter B<p>.
+If the parameter's I<data> field is NULL, then only its I<return_size> field
+will be assigned the size the parameter's I<data> buffer should have.
+
+OSSL_PARAM_set_BN_pad() stores the BIGNUM B<val> into the parameter B<p>
+padding to a width of B<sz> bytes.
 If the parameter's I<data> field is NULL, then only its I<return_size> field
 will be assigned the size the parameter's I<data> buffer should have.
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -119,6 +119,7 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val);
 
 int OSSL_PARAM_get_BN(const OSSL_PARAM *p, BIGNUM **val);
 int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val);
+int OSSL_PARAM_set_BN_pad(OSSL_PARAM *p, const BIGNUM *val, size_t sz);
 
 int OSSL_PARAM_get_utf8_string(const OSSL_PARAM *p, char **val, size_t max_len);
 int OSSL_PARAM_set_utf8_string(OSSL_PARAM *p, const char *val);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4987,3 +4987,4 @@ EVP_PKEY_CTX_set_rsa_keygen_primes      ?	3_0_0	EXIST::FUNCTION:RSA
 NCONF_new_with_libctx                   ?	3_0_0	EXIST::FUNCTION:
 CONF_modules_load_file_with_libctx      ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_load_config                 ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_set_BN_pad                   ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This allows constant width number to be passed more easily across the
provider boundary without compromising the constness of the data_size field.


- [x] documentation is added or updated
- [x] tests are added or updated
