### PR TITLE
Fix --strict-warnings build

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -426,7 +426,7 @@ char *sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text, const char *sep,
         current = sk_ASN1_UTF8STRING_value(text, i);
         length = ASN1_STRING_length(current);
         if (i > 0 && sep_len > 0) {
-            strncpy(p, sep, sep_len);
+            memcpy(p, sep, sep_len);
             p += sep_len;
         }
         strncpy(p, (const char *)ASN1_STRING_get0_data(current), length);


### PR DESCRIPTION
Appease -Werror=stringop-truncation

```
crypto/asn1/asn1_lib.c: In function 'sk_ASN1_UTF8STRING2text':
crypto/asn1/asn1_lib.c:429:13: error: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
  429 |             strncpy(p, sep, sep_len);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~
crypto/asn1/asn1_lib.c:412:15: note: length computed here
  412 |     sep_len = strlen(sep);
      |               ^~~~~~~~~~~


```

I think the warning is right: strncpy(target,source,strlen(source)) makes no sense. You probably want a simple memcpy here.
