### PR TITLE
TLSv1.2 connection using only FIPS crypto (v2)

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4723,19 +4723,33 @@ EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id)
      */
 # ifndef OPENSSL_NO_DH
     if (gtype == TLS_GROUP_FFDHE)
+#  if 0
+        pctx = EVP_PKEY_CTX_new_from_name(s->ctx->libctx, "DH", s->ctx->propq);
+#  else
         pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DH, NULL);
+#  endif
 #  ifndef OPENSSL_NO_EC
     else
-#  endif
-# endif
+#  endif /* OPENSSL_NO_EC */
+# endif /* OPENSSL_NO_DH */
 # ifndef OPENSSL_NO_EC
     {
+        /*
+         * TODO(3.0): When provider based EC key gen is present we can enable
+         * this code.
+         */
         if (gtype == TLS_GROUP_CURVE_CUSTOM)
             pctx = EVP_PKEY_CTX_new_id(ginf->nid, NULL);
         else
+#  if 0
+            pctx = EVP_PKEY_CTX_new_from_name(s->ctx->libctx, "EC",
+                                              s->ctx->propq);
+#  else
             pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+#  endif
+
     }
-# endif
+# endif /* OPENSSL_NO_EC */
     if (pctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_GENERATE_PKEY_GROUP,
                  ERR_R_MALLOC_FAILURE);
@@ -4801,7 +4815,11 @@ EVP_PKEY *ssl_generate_param_group(SSL *s, uint16_t id)
     EVP_PKEY_CTX *pctx = NULL;
     EVP_PKEY *pkey = NULL;
     const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(id);
+#if 0
+    const char * pkey_ctx_name;
+#else
     int pkey_ctx_id;
+#endif
 
     if (ginf == NULL)
         goto err;
@@ -4819,9 +4837,16 @@ EVP_PKEY *ssl_generate_param_group(SSL *s, uint16_t id)
      * s->ctx->libctx and s->ctx->propq when paramgen has been updated to be
      * provider aware.
      */
+#if 0
+    pkey_ctx_name = (ginf->flags & TLS_GROUP_FFDHE) ? "DH" : "EC";
+    pctx = EVP_PKEY_CTX_new_from_name(s->ctx->libctx, pkey_ctx_name,
+                                      s->ctx->propq);
+#else
     pkey_ctx_id = (ginf->flags & TLS_GROUP_FFDHE)
                         ? EVP_PKEY_DH : EVP_PKEY_EC;
     pctx = EVP_PKEY_CTX_new_id(pkey_ctx_id, NULL);
+#endif
+
     if (pctx == NULL)
         goto err;
     if (EVP_PKEY_paramgen_init(pctx) <= 0)

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4816,7 +4816,7 @@ EVP_PKEY *ssl_generate_param_group(SSL *s, uint16_t id)
     EVP_PKEY *pkey = NULL;
     const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(id);
 #if 0
-    const char * pkey_ctx_name;
+    const char *pkey_ctx_name;
 #else
     int pkey_ctx_id;
 #endif
@@ -4838,7 +4838,7 @@ EVP_PKEY *ssl_generate_param_group(SSL *s, uint16_t id)
      * provider aware.
      */
 #if 0
-    pkey_ctx_name = (ginf->flags & TLS_GROUP_FFDHE) ? "DH" : "EC";
+    pkey_ctx_name = (ginf->flags & TLS_GROUP_FFDHE) != 0 ? "DH" : "EC";
     pctx = EVP_PKEY_CTX_new_from_name(s->ctx->libctx, pkey_ctx_name,
                                       s->ctx->propq);
 #else

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1595,7 +1595,8 @@ int tls_psk_do_binder(SSL *s, const EVP_MD *md, const unsigned char *msgstart,
         binderout = tmpbinder;
 
     bindersize = hashsize;
-    if (EVP_DigestSignInit(mctx, NULL, md, NULL, mackey) <= 0
+    if (EVP_DigestSignInit_ex(mctx, NULL, EVP_MD_name(md), s->ctx->propq,
+                              mackey, s->ctx->libctx) <= 0
             || EVP_DigestSignUpdate(mctx, hash, hashsize) <= 0
             || EVP_DigestSignFinal(mctx, binderout, &bindersize) <= 0
             || bindersize != hashsize) {

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -780,7 +780,8 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     }
 
     hmaclen = SHA256_DIGEST_LENGTH;
-    if (EVP_DigestSignInit(hctx, NULL, EVP_sha256(), NULL, pkey) <= 0
+    if (EVP_DigestSignInit_ex(hctx, NULL, "SHA2-256", s->ctx->propq, pkey,
+                              s->ctx->libctx) <= 0
             || EVP_DigestSign(hctx, hmac, &hmaclen, data,
                               rawlen - SHA256_DIGEST_LENGTH) <= 0
             || hmaclen != SHA256_DIGEST_LENGTH) {
@@ -1864,7 +1865,8 @@ EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
         goto err;
     }
 
-    if (EVP_DigestSignInit(hctx, NULL, EVP_sha256(), NULL, pkey) <= 0
+    if (EVP_DigestSignInit_ex(hctx, NULL, "SHA2-256", s->ctx->propq, pkey,
+                              s->ctx->libctx) <= 0
             || EVP_DigestSign(hctx, hmac, &hmaclen, cookie,
                               totcookielen) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_STOC_COOKIE,

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2361,7 +2361,9 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt)
             goto err;
         }
 
-        if (EVP_DigestVerifyInit(md_ctx, &pctx, md, NULL, pkey) <= 0) {
+        if (EVP_DigestVerifyInit_ex(md_ctx, &pctx,
+                                    md == NULL ? NULL : EVP_MD_name(md),
+                                    s->ctx->propq, pkey, s->ctx->libctx) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_KEY_EXCHANGE,
                      ERR_R_EVP_LIB);
             goto err;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -272,7 +272,9 @@ int tls_construct_cert_verify(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    if (EVP_DigestSignInit(mctx, &pctx, md, NULL, pkey) <= 0) {
+    if (EVP_DigestSignInit_ex(mctx, &pctx,
+                              md == NULL ? NULL : EVP_MD_name(md),
+                              s->ctx->propq, pkey, s->ctx->libctx) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CERT_VERIFY,
                  ERR_R_EVP_LIB);
         goto err;
@@ -465,7 +467,9 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt)
     OSSL_TRACE1(TLS, "Using client verify alg %s\n",
                 md == NULL ? "n/a" : EVP_MD_name(md));
 
-    if (EVP_DigestVerifyInit(mctx, &pctx, md, NULL, pkey) <= 0) {
+    if (EVP_DigestVerifyInit_ex(mctx, &pctx,
+                                md == NULL ? NULL : EVP_MD_name(md),
+                                s->ctx->propq, pkey, s->ctx->libctx) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_CERT_VERIFY,
                  ERR_R_EVP_LIB);
         goto err;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2795,7 +2795,9 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
             goto err;
         }
 
-        if (EVP_DigestSignInit(md_ctx, &pctx, md, NULL, pkey) <= 0) {
+        if (EVP_DigestSignInit_ex(md_ctx, &pctx,
+                                  md == NULL ? NULL : EVP_MD_name(md),
+                                  s->ctx->propq, pkey, s->ctx->libctx) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_SERVER_KEY_EXCHANGE,
                      ERR_R_INTERNAL_ERROR);

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -326,7 +326,9 @@ int tls1_change_cipher_state(SSL *s, int which)
         mac_key = EVP_PKEY_new_mac_key(mac_type, NULL, mac_secret,
                                                (int)*mac_secret_size);
         if (mac_key == NULL
-            || EVP_DigestSignInit(mac_ctx, NULL, m, NULL, mac_key) <= 0) {
+            || EVP_DigestSignInit_ex(mac_ctx, NULL,
+                                     EVP_MD_name(m), s->ctx->propq,
+                                     mac_key, s->ctx->libctx) <= 0) {
             EVP_PKEY_free(mac_key);
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS1_CHANGE_CIPHER_STATE,
                      ERR_R_INTERNAL_ERROR);

--- a/test/recipes/90-test_sslprovider.t
+++ b/test/recipes/90-test_sslprovider.t
@@ -8,14 +8,36 @@
 
 
 use OpenSSL::Test::Utils;
-use OpenSSL::Test qw/:DEFAULT srctop_dir/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_file bldtop_dir/;
 
+BEGIN {
 setup("test_sslprovider");
+}
+
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
 
 plan skip_all => "No TLS/SSL protocols are supported by this OpenSSL build"
     if alldisabled(grep { $_ ne "ssl3" } available_protocols("tls"));
 
-plan tests => 1;
+plan tests => 3;
 
-ok(run(test(["sslprovidertest", srctop_dir("test", "certs")])),
+$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
+$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
+
+ok(run(app(['openssl', 'fipsinstall',
+            '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+            '-module', bldtop_file('providers', platform->dso('fips')),
+            '-provider_name', 'fips', '-mac_name', 'HMAC',
+            '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
+            '-section_name', 'fips_sect'])),
+   "fipsinstall");
+
+ok(run(test(["sslprovidertest", srctop_dir("test", "certs"), "default",
+             srctop_file("test", "default.cnf")])),
+             "running sslprovidertest");
+
+ok(run(test(["sslprovidertest", srctop_dir("test", "certs"), "fips",
+             srctop_file("test", "fips.cnf")])),
              "running sslprovidertest");

--- a/test/recipes/90-test_sslprovider.t
+++ b/test/recipes/90-test_sslprovider.t
@@ -26,18 +26,28 @@ plan tests => 3;
 $ENV{OPENSSL_MODULES} = bldtop_dir("providers");
 $ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
 
-ok(run(app(['openssl', 'fipsinstall',
-            '-out', bldtop_file('providers', 'fipsinstall.cnf'),
-            '-module', bldtop_file('providers', platform->dso('fips')),
-            '-provider_name', 'fips', '-mac_name', 'HMAC',
-            '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
-            '-section_name', 'fips_sect'])),
-   "fipsinstall");
+SKIP: {
+    skip "Skipping FIPS installation", 1
+        if disabled("fips");
+
+    ok(run(app(['openssl', 'fipsinstall',
+                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+                '-module', bldtop_file('providers', platform->dso('fips')),
+                '-provider_name', 'fips', '-mac_name', 'HMAC',
+                '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
+                '-section_name', 'fips_sect'])),
+       "fipsinstall");
+}
 
 ok(run(test(["sslprovidertest", srctop_dir("test", "certs"), "default",
              srctop_file("test", "default.cnf")])),
              "running sslprovidertest");
 
-ok(run(test(["sslprovidertest", srctop_dir("test", "certs"), "fips",
-             srctop_file("test", "fips.cnf")])),
-             "running sslprovidertest");
+SKIP: {
+    skip "Skipping FIPS provider test", 1
+        if disabled("fips");
+
+    ok(run(test(["sslprovidertest", srctop_dir("test", "certs"), "fips",
+                 srctop_file("test", "fips.cnf")])),
+                 "running sslprovidertest");
+}

--- a/test/sslprovidertest.c
+++ b/test/sslprovidertest.c
@@ -18,8 +18,7 @@ static char *privkey = NULL;
 static char *modulename = NULL;
 static char *configfile = NULL;
 
-/* TODO(3.0): Re-enable this code. See comment in setup_tests() */
-OSSL_PROVIDER *defctxlegacy = NULL;
+static OSSL_PROVIDER *defctxlegacy = NULL;
 
 static int test_different_libctx(void)
 {
@@ -43,9 +42,9 @@ static int test_different_libctx(void)
     prov = OSSL_PROVIDER_load(libctx, modulename);
     if (!TEST_ptr(prov)
                /* Check we have the provider available */
-            || !TEST_true(OSSL_PROVIDER_available(libctx, modulename))
-               /* Check the default provider is not available */)
+            || !TEST_true(OSSL_PROVIDER_available(libctx, modulename)))
         goto end;
+    /* Check the default provider is not available */
     if (strcmp(modulename, "default") != 0
             && !TEST_false(OSSL_PROVIDER_available(libctx, "default")))
         goto end;
@@ -146,6 +145,5 @@ int setup_tests(void)
 
 void cleanup_tests(void)
 {
-    /* TODO(3.0): Re-enable this code. See comment in setup_tests() */
     OSSL_PROVIDER_unload(defctxlegacy);
 }

--- a/test/sslprovidertest.c
+++ b/test/sslprovidertest.c
@@ -29,7 +29,7 @@ static int test_different_libctx(void)
     OSSL_PROVIDER *prov = NULL;
 
     /*
-     * Verify that the default and fips providers in the default libctx iare not
+     * Verify that the default and fips providers in the default libctx are not
      * available
      */
     if (!TEST_false(OSSL_PROVIDER_available(NULL, "default"))
@@ -107,14 +107,6 @@ static int test_different_libctx(void)
 int setup_tests(void)
 {
     char *certsdir = NULL;
-    /*
-     * For tests in this file we want to ensure the default ctx does not have
-     * the default provider loaded into the default ctx. So we load "legacy" to
-     * prevent default from being auto-loaded. This tests that there is no
-     * "leakage", i.e. when using SSL_CTX_new_with_libctx() we expect only the
-     * specific libctx to be used - nothing should fall back to the default
-     * libctx
-     */
 
     if (!test_skip_common_options()) {
         TEST_error("Error parsing test options\n");
@@ -136,6 +128,14 @@ int setup_tests(void)
         return 0;
     }
 
+    /*
+     * For tests in this file we want to ensure the default ctx does not have
+     * the default provider loaded into the default ctx. So we load "legacy" to
+     * prevent default from being auto-loaded. This tests that there is no
+     * "leakage", i.e. when using SSL_CTX_new_with_libctx() we expect only the
+     * specific libctx to be used - nothing should fall back to the default
+     * libctx
+     */
     defctxlegacy = OSSL_PROVIDER_load(NULL, "legacy");
 
     ADD_TEST(test_different_libctx);

--- a/test/sslprovidertest.c
+++ b/test/sslprovidertest.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <string.h>
 #include <openssl/provider.h>
 
 #include "ssltestlib.h"
@@ -14,6 +15,8 @@
 
 static char *cert = NULL;
 static char *privkey = NULL;
+static char *modulename = NULL;
+static char *configfile = NULL;
 
 /* TODO(3.0): Re-enable this code. See comment in setup_tests() */
 OSSL_PROVIDER *defctxlegacy = NULL;
@@ -24,10 +27,29 @@ static int test_different_libctx(void)
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
     OPENSSL_CTX *libctx = OPENSSL_CTX_new();
+    OSSL_PROVIDER *prov = NULL;
 
-    /* Verify that the default provider in the default libctx is not available */
-    if (!TEST_false(OSSL_PROVIDER_available(NULL, "default")))
+    /*
+     * Verify that the default and fips providers in the default libctx iare not
+     * available
+     */
+    if (!TEST_false(OSSL_PROVIDER_available(NULL, "default"))
+            || !TEST_false(OSSL_PROVIDER_available(NULL, "fips")))
         goto end;
+
+    if (!TEST_true(OPENSSL_CTX_load_config(libctx, configfile)))
+        goto end;
+
+    prov = OSSL_PROVIDER_load(libctx, modulename);
+    if (!TEST_ptr(prov)
+               /* Check we have the provider available */
+            || !TEST_true(OSSL_PROVIDER_available(libctx, modulename))
+               /* Check the default provider is not available */)
+        goto end;
+    if (strcmp(modulename, "default") != 0
+            && !TEST_false(OSSL_PROVIDER_available(libctx, "default")))
+        goto end;
+    TEST_note("%s provider loaded", modulename);
 
     cctx = SSL_CTX_new_with_libctx(libctx, NULL, TLS_client_method());
     if (!TEST_ptr(cctx))
@@ -62,10 +84,11 @@ static int test_different_libctx(void)
         goto end;
 
     /*
-     * Verify that the default provider in the default libctx is still not
-     * available
+     * Verify that the default and fips providers in the default libctx are
+     * still not available
      */
-    if (!TEST_false(OSSL_PROVIDER_available(NULL, "default")))
+    if (!TEST_false(OSSL_PROVIDER_available(NULL, "default"))
+            || !TEST_false(OSSL_PROVIDER_available(NULL, "fips")))
         goto end;
 
     testresult = 1;
@@ -76,6 +99,7 @@ static int test_different_libctx(void)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
 
+    OSSL_PROVIDER_unload(prov);
     OPENSSL_CTX_free(libctx);
 
     return testresult;
@@ -92,9 +116,15 @@ int setup_tests(void)
      * specific libctx to be used - nothing should fall back to the default
      * libctx
      */
-    defctxlegacy = OSSL_PROVIDER_load(NULL, "legacy");
 
-    if (!TEST_ptr(certsdir = test_get_argument(0)))
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(certsdir = test_get_argument(0))
+            || !TEST_ptr(modulename = test_get_argument(1))
+            || !TEST_ptr(configfile = test_get_argument(2)))
         return 0;
 
     cert = test_mk_file_path(certsdir, "servercert.pem");
@@ -106,6 +136,8 @@ int setup_tests(void)
         OPENSSL_free(cert);
         return 0;
     }
+
+    defctxlegacy = OSSL_PROVIDER_load(NULL, "legacy");
 
     ADD_TEST(test_different_libctx);
 


### PR DESCRIPTION
This PR contains the final commits from #11334 to get a TLS connection working using only crypto from the FIPS module.

Some things to note:

- It is TLSv1.2 only at the moment because I can only do RSA key exchange. We don't have the necessary provider EC/DH key gen/param gen in place yet for anything else. However, TLSv1.3 does not support RSA key exchange.

- This only does a very simple handshake, i.e. it doesn't include resumption, PSKs, etc. 

- In #11334 I included changes to libssl to use the new EVP_MAC API. This had the unexpected impact of breaking the GOST engine. I have not included those commits here because I have solved the problem I was trying to get over in a different way - so we don't need to make those changes just yet. However, we might want to still consider making that change in 3.0 - but not right now.

- We don't currently have fetchable RAND. This means that where libssl generates random numbers directly (as opposed to say an algorithm generating random numbers itself as part of its operation), we use the libcrypto DRBG - not the one in the FIPS module. The underlying cipher is still fetched from the FIPS module, but the DRBG itself is not.

In order to get more tests working using only FIPS we need to get EC/ECX/DH/DSA key generation in (#11328, #11371, #11332). I have a "hacked" local branch which is enabling me to make some progress towards this goal, so I expect to be raising various libssl fixes needed for the more complete libssl with FIPS support.