### PR TITLE
TLS Cipher Suite 0xC102 Support

### DIFF
--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -509,6 +509,19 @@ distribution.
  TLS_GOSTR341094_WITH_NULL_GOSTR3411 GOST94-NULL-GOST94
  TLS_GOSTR341001_WITH_NULL_GOSTR3411 GOST2001-NULL-GOST94
 
+=head2 GOST cipher suites, extending TLS v1.2
+
+Note: these ciphers require an engine which including GOST cryptographic
+algorithms, such as the B<gost> engine, which isn't part of the OpenSSL
+distribution.
+
+ TLS_GOSTR341112_256_WITH_28147_CNT_IMIT GOST2012-GOST8912-GOST8912
+ TLS_GOSTR341112_256_WITH_NULL_GOSTR3411 GOST2012-NULL-GOST12
+
+Note: GOST2012-GOST8912-GOST8912 is an alias for two ciphers ID
+old LEGACY-GOST2012-GOST8912-GOST8912 and new IANA-GOST2012-GOST8912-GOST8912
+
+
 =head2 Additional Export 1024 and other cipher suites
 
 Note: these ciphers can also be used in SSL v3.

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  * Copyright 2005 Nokia. All rights reserved.
  *
@@ -136,6 +136,7 @@ extern "C" {
 # define SSL_TXT_ARIA_GCM        "ARIAGCM"
 # define SSL_TXT_ARIA128         "ARIA128"
 # define SSL_TXT_ARIA256         "ARIA256"
+# define SSL_TXT_GOST2012_GOST8912_GOST8912 "GOST2012-GOST8912-GOST8912"
 
 # define SSL_TXT_MD5             "MD5"
 # define SSL_TXT_SHA1            "SHA1"

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  * Copyright 2005 Nokia. All rights reserved.
  *
@@ -2637,7 +2637,23 @@ static SSL_CIPHER ssl3_ciphers[] = {
      },
     {
      1,
-     "GOST2012-GOST8912-GOST8912",
+     "IANA-GOST2012-GOST8912-GOST8912",
+     NULL,
+     0x0300c102,
+     SSL_kGOST,
+     SSL_aGOST12 | SSL_aGOST01,
+     SSL_eGOST2814789CNT12,
+     SSL_GOST89MAC12,
+     TLS1_VERSION, TLS1_2_VERSION,
+     0, 0,
+     SSL_HIGH,
+     SSL_HANDSHAKE_MAC_GOST12_256 | TLS1_PRF_GOST12_256 | TLS1_STREAM_MAC,
+     256,
+     256,
+     },
+    {
+     1,
+     "LEGACY-GOST2012-GOST8912-GOST8912",
      NULL,
      0x0300ff85,
      SSL_kGOST,

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved
  * Copyright 2005 Nokia. All rights reserved.
  *
@@ -237,6 +237,7 @@ static const SSL_CIPHER cipher_aliases[] = {
     {0, SSL_TXT_CAMELLIA256, NULL, 0, 0, 0, SSL_CAMELLIA256},
     {0, SSL_TXT_CAMELLIA, NULL, 0, 0, 0, SSL_CAMELLIA},
     {0, SSL_TXT_CHACHA20, NULL, 0, 0, 0, SSL_CHACHA20},
+    {0, SSL_TXT_GOST2012_GOST8912_GOST8912, NULL, 0, 0, 0, SSL_eGOST2814789CNT12},
 
     {0, SSL_TXT_ARIA, NULL, 0, 0, 0, SSL_ARIA},
     {0, SSL_TXT_ARIA_GCM, NULL, 0, 0, 0, SSL_ARIA128GCM | SSL_ARIA256GCM},

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2012-2020 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -427,6 +427,7 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
     {0xC0AD, "TLS_ECDHE_ECDSA_WITH_AES_256_CCM"},
     {0xC0AE, "TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8"},
     {0xC0AF, "TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8"},
+    {0xC102, "IANA-GOST2012-GOST8912-GOST8912"},
     {0xCCA8, "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"},
     {0xCCA9, "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"},
     {0xCCAA, "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256"},
@@ -441,7 +442,7 @@ static const ssl_trace_tbl ssl_ciphers_tbl[] = {
     {0x1305, "TLS_AES_128_CCM_8_SHA256"},
     {0xFEFE, "SSL_RSA_FIPS_WITH_DES_CBC_SHA"},
     {0xFEFF, "SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA"},
-    {0xFF85, "GOST2012-GOST8912-GOST8912"},
+    {0xFF85, "LEGACY-GOST2012-GOST8912-GOST8912"},
     {0xFF87, "GOST2012-NULL-GOST12"},
 };
 

--- a/test/ciphername_test.c
+++ b/test/ciphername_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017-2020 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright 2017 BaishanCloud. All rights reserved.
  *
  * Licensed under the Apache License 2.0 (the "License");
@@ -431,7 +431,7 @@ static int test_cipher_name(void)
     for (i = 0; i < sk_SSL_CIPHER_num(sk); i++) {
         c = sk_SSL_CIPHER_value(sk, i);
         id = SSL_CIPHER_get_id(c) & 0xFFFF;
-        if ((id == 0xFF85) || (id == 0xFF87))
+        if ((id == 0xC102) || (id == 0xFF85) ||(id == 0xFF87))
             /* skip GOST2012-GOST8912-GOST891 and GOST2012-NULL-GOST12 */
             continue;
         p = SSL_CIPHER_standard_name(c);

--- a/test/gosttest.c
+++ b/test/gosttest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2018-2020 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -27,6 +27,14 @@ static struct {
     {"GOST2012-GOST8912-GOST8912", TLS1_2_VERSION, 0},
     /* Server doesn't have a TLSv1.3 capable cert - should use TLSv1.2 */
     {"GOST2012-GOST8912-GOST8912", TLS1_2_VERSION, 1},
+    /* Server doesn't have a TLSv1.3 capable cert - should use TLSv1.2 */
+    {"IANA-GOST2012-GOST8912-GOST8912", TLS1_2_VERSION, 0},
+    /* Server doesn't have a TLSv1.3 capable cert - should use TLSv1.2 */
+    {"IANA-GOST2012-GOST8912-GOST8912", TLS1_2_VERSION, 1},
+    /* Server doesn't have a TLSv1.3 capable cert - should use TLSv1.2 */
+    {"LEGACY-GOST2012-GOST8912-GOST8912", TLS1_2_VERSION, 0},
+    /* Server doesn't have a TLSv1.3 capable cert - should use TLSv1.2 */
+    {"LEGACY-GOST2012-GOST8912-GOST8912", TLS1_2_VERSION, 1},
     /* Server doesn't have a TLSv1.3 capable cert - should use TLSv1.2 */
     {"GOST2001-GOST89-GOST89", TLS1_2_VERSION, 0},
 };


### PR DESCRIPTION
For GOST2012-GOST8912-GOST8912 was used 0xFF85 identifier,
but new identifier 0xc102 was assigned.
Because of old software we will support both numbers.

https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-2
https://datatracker.ietf.org/doc/draft-smyshlyaev-tls12-gost-suites/

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
