### PR TITLE
Add OCSP_RESPID_set_by_key_ex() and OCSP_RESPID_match_ex()

### DIFF
--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -259,45 +259,67 @@ int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert)
     return 1;
 }
 
-int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert)
+int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
+                              OPENSSL_CTX *libctx, const char *propq)
 {
     ASN1_OCTET_STRING *byKey = NULL;
     unsigned char md[SHA_DIGEST_LENGTH];
+    EVP_MD *sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
+    int ret = 0;
+
+    if (sha1 == NULL)
+        return 0;
 
     /* RFC2560 requires SHA1 */
-    if (!X509_pubkey_digest(cert, EVP_sha1(), md, NULL))
-        return 0;
+    if (!X509_pubkey_digest(cert, sha1, md, NULL))
+        goto err;
 
     byKey = ASN1_OCTET_STRING_new();
     if (byKey == NULL)
-        return 0;
+        goto err;
 
     if (!(ASN1_OCTET_STRING_set(byKey, md, SHA_DIGEST_LENGTH))) {
         ASN1_OCTET_STRING_free(byKey);
-        return 0;
+        goto err;
     }
 
     respid->type = V_OCSP_RESPID_KEY;
     respid->value.byKey = byKey;
 
-    return 1;
+    ret = 1;
+ err:
+    EVP_MD_free(sha1);
+    return ret;
 }
 
-int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert)
+int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert)
 {
+    return OCSP_RESPID_set_by_key_ex(respid, cert, NULL, NULL);
+}
+
+int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OPENSSL_CTX *libctx,
+                         const char *propq)
+{
+    EVP_MD *sha1 = NULL;
+    int ret = 0;
+
     if (respid->type == V_OCSP_RESPID_KEY) {
         unsigned char md[SHA_DIGEST_LENGTH];
 
+        sha1 = EVP_MD_fetch(libctx, "SHA1", propq);
+        if (sha1 == NULL)
+            goto err;
+
         if (respid->value.byKey == NULL)
-            return 0;
+            goto err;
 
         /* RFC2560 requires SHA1 */
-        if (!X509_pubkey_digest(cert, EVP_sha1(), md, NULL))
-            return 0;
+        if (!X509_pubkey_digest(cert, sha1, md, NULL))
+            goto err;
 
-        return (ASN1_STRING_length(respid->value.byKey) == SHA_DIGEST_LENGTH)
-            && (memcmp(ASN1_STRING_get0_data(respid->value.byKey), md,
-                       SHA_DIGEST_LENGTH) == 0);
+        ret = (ASN1_STRING_length(respid->value.byKey) == SHA_DIGEST_LENGTH)
+              && (memcmp(ASN1_STRING_get0_data(respid->value.byKey), md,
+                         SHA_DIGEST_LENGTH) == 0);
     } else if (respid->type == V_OCSP_RESPID_NAME) {
         if (respid->value.byName == NULL)
             return 0;
@@ -306,5 +328,12 @@ int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert)
                              X509_get_subject_name(cert)) == 0;
     }
 
-    return 0;
+ err:
+    EVP_MD_free(sha1);
+    return ret;
+}
+
+int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert)
+{
+    return OCSP_RESPID_match_ex(respid, cert, NULL, NULL);
 }

--- a/doc/man3/OCSP_response_status.pod
+++ b/doc/man3/OCSP_response_status.pod
@@ -4,8 +4,9 @@
 
 OCSP_response_status, OCSP_response_get1_basic, OCSP_response_create,
 OCSP_RESPONSE_free, OCSP_RESPID_set_by_name,
-OCSP_RESPID_set_by_key, OCSP_RESPID_match,
-OCSP_basic_sign, OCSP_basic_sign_ctx - OCSP response functions
+OCSP_RESPID_set_by_key_ex, OCSP_RESPID_set_by_key, OCSP_RESPID_match_ex,
+OCSP_RESPID_match, OCSP_basic_sign, OCSP_basic_sign_ctx
+- OCSP response functions
 
 =head1 SYNOPSIS
 
@@ -17,7 +18,11 @@ OCSP_basic_sign, OCSP_basic_sign_ctx - OCSP response functions
  void OCSP_RESPONSE_free(OCSP_RESPONSE *resp);
 
  int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert);
+ int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
+                               OPENSSL_CTX *libctx, const char *propq);
  int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert);
+ int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OPENSSL_CTX *libctx,
+                          const char *propq);
  int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert);
 
  int OCSP_basic_sign(OCSP_BASICRESP *brsp, X509 *signer, EVP_PKEY *key,
@@ -28,49 +33,60 @@ OCSP_basic_sign, OCSP_basic_sign_ctx - OCSP response functions
 
 =head1 DESCRIPTION
 
-OCSP_response_status() returns the OCSP response status of B<resp>. It returns
-one of the values: B<OCSP_RESPONSE_STATUS_SUCCESSFUL>,
-B<OCSP_RESPONSE_STATUS_MALFORMEDREQUEST>,
-B<OCSP_RESPONSE_STATUS_INTERNALERROR>, B<OCSP_RESPONSE_STATUS_TRYLATER>
-B<OCSP_RESPONSE_STATUS_SIGREQUIRED>, or B<OCSP_RESPONSE_STATUS_UNAUTHORIZED>.
+OCSP_response_status() returns the OCSP response status of I<resp>. It returns
+one of the values: I<OCSP_RESPONSE_STATUS_SUCCESSFUL>,
+I<OCSP_RESPONSE_STATUS_MALFORMEDREQUEST>,
+I<OCSP_RESPONSE_STATUS_INTERNALERROR>, I<OCSP_RESPONSE_STATUS_TRYLATER>
+I<OCSP_RESPONSE_STATUS_SIGREQUIRED>, or I<OCSP_RESPONSE_STATUS_UNAUTHORIZED>.
 
-OCSP_response_get1_basic() decodes and returns the B<OCSP_BASICRESP> structure
-contained in B<resp>.
+OCSP_response_get1_basic() decodes and returns the I<OCSP_BASICRESP> structure
+contained in I<resp>.
 
-OCSP_response_create() creates and returns an B<OCSP_RESPONSE> structure for
-B<status> and optionally including basic response B<bs>.
+OCSP_response_create() creates and returns an I<OCSP_RESPONSE> structure for
+I<status> and optionally including basic response I<bs>.
 
-OCSP_RESPONSE_free() frees up OCSP response B<resp>.
+OCSP_RESPONSE_free() frees up OCSP response I<resp>.
 
 OCSP_RESPID_set_by_name() sets the name of the OCSP_RESPID to be the same as the
-subject name in the supplied X509 certificate B<cert> for the OCSP responder.
+subject name in the supplied X509 certificate I<cert> for the OCSP responder.
 
-OCSP_RESPID_set_by_key() sets the key of the OCSP_RESPID to be the same as the
-key in the supplied X509 certificate B<cert> for the OCSP responder. The key is
-stored as a SHA1 hash.
+OCSP_RESPID_set_by_key_ex() sets the key of the OCSP_RESPID to be the same as the
+key in the supplied X509 certificate I<cert> for the OCSP responder. The key is
+stored as a SHA1 hash. To calculate the hash the SHA1 algorithm is fetched using
+the library ctx I<libctx> and the property query string I<propq> (see
+L<provider(7)/Fetching algorithms> for further information).
+
+OCSP_RESPID_set_by_key() does the same as OCSP_RESPID_set_by_key_ex() except
+that the default library context is used with an empty property query string.
 
 Note that an OCSP_RESPID can only have one of the name, or the key set. Calling
 OCSP_RESPID_set_by_name() or OCSP_RESPID_set_by_key() will clear any existing
 setting.
 
-OCSP_RESPID_match() tests whether the OCSP_RESPID given in B<respid> matches
-with the X509 certificate B<cert>.
+OCSP_RESPID_match_ex() tests whether the OCSP_RESPID given in I<respid> matches
+with the X509 certificate I<cert> based on the SHA1 hash. To calculate the hash
+the SHA1 algorithm is fetched using the library ctx I<libctx> and the property
+query string I<propq> (see L<provider(7)/Fetching algorithms> for further
+information).
 
-OCSP_basic_sign() signs OCSP response B<brsp> using certificate B<signer>, private key
-B<key>, digest B<dgst> and additional certificates B<certs>. If the B<flags> option
-B<OCSP_NOCERTS> is set then no certificates will be included in the response. If the
-B<flags> option B<OCSP_RESPID_KEY> is set then the responder is identified by key ID
-rather than by name. OCSP_basic_sign_ctx() also signs OCSP response B<brsp> but
-uses the parameters contained in digest context B<ctx>.
+OCSP_RESPID_match() does the same as OCSP_RESPID_match_ex() except that the
+default library context is used with an empty property query string.
+
+OCSP_basic_sign() signs OCSP response I<brsp> using certificate I<signer>, private key
+I<key>, digest I<dgst> and additional certificates I<certs>. If the I<flags> option
+I<OCSP_NOCERTS> is set then no certificates will be included in the response. If the
+I<flags> option I<OCSP_RESPID_KEY> is set then the responder is identified by key ID
+rather than by name. OCSP_basic_sign_ctx() also signs OCSP response I<brsp> but
+uses the parameters contained in digest context I<ctx>.
 
 =head1 RETURN VALUES
 
 OCSP_RESPONSE_status() returns a status value.
 
-OCSP_response_get1_basic() returns an B<OCSP_BASICRESP> structure pointer or
-B<NULL> if an error occurred.
+OCSP_response_get1_basic() returns an I<OCSP_BASICRESP> structure pointer or
+I<NULL> if an error occurred.
 
-OCSP_response_create() returns an B<OCSP_RESPONSE> structure pointer or B<NULL>
+OCSP_response_create() returns an I<OCSP_RESPONSE> structure pointer or I<NULL>
 if an error occurred.
 
 OCSP_RESPONSE_free() does not return a value.
@@ -85,7 +101,7 @@ or 0 otherwise.
 =head1 NOTES
 
 OCSP_response_get1_basic() is only called if the status of a response is
-B<OCSP_RESPONSE_STATUS_SUCCESSFUL>.
+I<OCSP_RESPONSE_STATUS_SUCCESSFUL>.
 
 =head1 SEE ALSO
 

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -277,7 +277,11 @@ int OCSP_basic_sign_ctx(OCSP_BASICRESP *brsp,
                         X509 *signer, EVP_MD_CTX *ctx,
                         STACK_OF(X509) *certs, unsigned long flags);
 int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert);
+int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
+                              OPENSSL_CTX *libctx, const char *propq);
 int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert);
+int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OPENSSL_CTX *libctx,
+                         const char *propq);
 int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert);
 
 X509_EXTENSION *OCSP_crlID_new(const char *url, long *n, char *tim);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1278,7 +1278,7 @@ static int ocsp_server_cb(SSL *s, void *arg)
             return SSL_TLSEXT_ERR_ALERT_FATAL;
 
         id = sk_OCSP_RESPID_value(ids, 0);
-        if (id == NULL || !OCSP_RESPID_match(id, ocspcert))
+        if (id == NULL || !OCSP_RESPID_match_ex(id, ocspcert, NULL, NULL))
             return SSL_TLSEXT_ERR_ALERT_FATAL;
     } else if (*argi != 1) {
         return SSL_TLSEXT_ERR_ALERT_FATAL;
@@ -1406,7 +1406,7 @@ static int test_tlsext_status_type(void)
             || !TEST_ptr(ids = sk_OCSP_RESPID_new_null())
             || !TEST_ptr(ocspcert = PEM_read_bio_X509(certbio,
                                                       NULL, NULL, NULL))
-            || !TEST_true(OCSP_RESPID_set_by_key(id, ocspcert))
+            || !TEST_true(OCSP_RESPID_set_by_key_ex(id, ocspcert, NULL, NULL))
             || !TEST_true(sk_OCSP_RESPID_push(ids, id)))
         goto end;
     id = NULL;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5001,3 +5001,5 @@ NCONF_new_with_libctx                   ?	3_0_0	EXIST::FUNCTION:
 CONF_modules_load_file_with_libctx      ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_load_config                 ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_set_type_by_keymgmt            ?	3_0_0	EXIST::FUNCTION:
+OCSP_RESPID_set_by_key_ex               ?	3_0_0	EXIST::FUNCTION:OCSP
+OCSP_RESPID_match_ex                    ?	3_0_0	EXIST::FUNCTION:OCSP


### PR DESCRIPTION
OCSP_RESPID_set_by_key() calculates a SHA1 hash of the supplied
certificate. We need to be able to specify which libctx and property
query string is used to fetch that algorithm so we introduce
OCSP_RESPID_set_by_key_ex() which does the same thing but enables you to
speicfy the library context and propery query string explicitly.

OCSP_RESPID_match() matches with certificates based on the SHA1 hash.
Therefore for the same reason we introduce OCSP_RESPID_match_ex().

This will be needed in a later PR where we will make ssapitest run with a non-default libctx.