### PR TITLE
Explicitly cache X509v3 extensions in libssl

### DIFF
--- a/doc/man3/X509_check_ca.pod
+++ b/doc/man3/X509_check_ca.pod
@@ -24,6 +24,8 @@ B<keyUsage> extension with bit B<keyCertSign> set, but without
 B<basicConstraints>, and 5 if it has outdated Netscape Certificate Type
 extension telling that it is CA certificate.
 
+This function will also return 0 on error.
+
 Actually, any nonzero value means that this certificate could have been
 used to sign other certificates.
 

--- a/doc/man3/X509v3_cache_extensions.pod
+++ b/doc/man3/X509v3_cache_extensions.pod
@@ -1,0 +1,43 @@
+=pod
+
+=head1 NAME
+
+X509v3_cache_extensions
+- process any extensions in an X509 object
+
+=head1 SYNOPSIS
+
+ #include <openssl/x509v3.h>
+
+ int X509v3_cache_extensions(X509 *x, OPENSSL_CTX *libctx, const char *propq);
+
+=head1 DESCRIPTION
+
+This function processes any X509v3 extensions that might be present in an X509
+object and caches the result of that processing. Many OpenSSL functions that use
+an X509 object will cause extensions to be processed and cached implicitly. If
+this is done implicitly then the default library context and property query
+string will be used. In some cases it may be desirable to use some other library
+context and property query string. If so then an application can call
+X509v3_cache_extensions() explicitly. This should be done before any function
+that needs to use those extensions is called - otherwise calling
+X509v3_cache_extensions() will have no effect. Typically this means calling this
+soon after creation of the X509 object. The X509 object to be processed is
+given in I<x> and the library context and property query string to use are given
+in I<libctx> and I<propq>.
+
+=head1 RETURN VALUES
+
+This function returns 0 if the extensions are invalid or an error occurred.
+Otherwise it returns 1.
+
+=head1 COPYRIGHT
+
+Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/x509v3.h
+++ b/include/openssl/x509v3.h
@@ -572,6 +572,9 @@ GENERAL_NAME *v2i_GENERAL_NAME_ex(GENERAL_NAME *out,
                                   const X509V3_EXT_METHOD *method,
                                   X509V3_CTX *ctx, CONF_VALUE *cnf,
                                   int is_nc);
+
+int X509v3_cache_extensions(X509 *x, OPENSSL_CTX *libctx, const char *propq);
+
 void X509V3_conf_free(CONF_VALUE *val);
 
 X509_EXTENSION *X509V3_EXT_nconf_nid(CONF *conf, X509V3_CTX *ctx, int ext_nid,

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -17,6 +17,7 @@
 #include <openssl/dh.h>
 #include <openssl/rand.h>
 #include <openssl/trace.h>
+#include <openssl/x509v3.h>
 #include "internal/cryptlib.h"
 
 #define TLS13_NUM_CIPHERS       OSSL_NELEM(tls13_ciphers)
@@ -3946,6 +3947,10 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
                 SSLerr(SSL_F_SSL3_CTX_CTRL, ERR_R_MALLOC_FAILURE);
                 return 0;
             }
+        }
+        if (!X509v3_cache_extensions((X509 *)parg, ctx->libctx, ctx->propq)) {
+            SSLerr(0, ERR_LIB_X509);
+            return 0;
         }
         if (!sk_X509_push(ctx->extra_certs, (X509 *)parg)) {
             SSLerr(SSL_F_SSL3_CTX_CTRL, ERR_R_MALLOC_FAILURE);

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -253,11 +253,20 @@ void ssl_cert_free(CERT *c)
 int ssl_cert_set0_chain(SSL *s, SSL_CTX *ctx, STACK_OF(X509) *chain)
 {
     int i, r;
-    CERT_PKEY *cpk = s ? s->cert->key : ctx->cert->key;
+    CERT_PKEY *cpk = s != NULL ? s->cert->key : ctx->cert->key;
+    SSL_CTX *realctx = s != NULL ? s->ctx : ctx;
+
     if (!cpk)
         return 0;
     for (i = 0; i < sk_X509_num(chain); i++) {
-        r = ssl_security_cert(s, ctx, sk_X509_value(chain, i), 0, 0);
+        X509 *x = sk_X509_value(chain, i);
+
+        if (!X509v3_cache_extensions(x, realctx->libctx, realctx->propq)) {
+            SSLerr(0, ERR_LIB_X509);
+            return 0;
+        }
+
+        r = ssl_security_cert(s, ctx, x, 0, 0);
         if (r != 1) {
             SSLerr(SSL_F_SSL_CERT_SET0_CHAIN, r);
             return 0;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -14,6 +14,7 @@
 #include <openssl/objects.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 #include <openssl/pem.h>
 
 static int ssl_set_cert(CERT *c, X509 *x509);
@@ -29,6 +30,10 @@ int SSL_use_certificate(SSL *ssl, X509 *x)
     int rv;
     if (x == NULL) {
         SSLerr(SSL_F_SSL_USE_CERTIFICATE, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    if (!X509v3_cache_extensions(x, ssl->ctx->libctx, ssl->ctx->propq)) {
+        SSLerr(0, ERR_LIB_X509);
         return 0;
     }
     rv = ssl_security_cert(ssl, NULL, x, 0, 1);
@@ -303,6 +308,10 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x)
     int rv;
     if (x == NULL) {
         SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    if (!X509v3_cache_extensions(x, ctx->libctx, ctx->propq)) {
+        SSLerr(0, ERR_LIB_X509);
         return 0;
     }
     rv = ssl_security_cert(NULL, ctx, x, 0, 1);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5009,3 +5009,4 @@ SRP_Calc_B_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_Calc_u_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_Calc_x_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_Calc_client_key_ex                  ?	3_0_0	EXIST::FUNCTION:SRP
+X509v3_cache_extensions                 ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
A by product of processing the X509v3 extensions in an X509 object results in a SHA1 hash being calculated and stored for later use. Lots of X509 functions end up in the implicit processing of the X509v3 extensions and could result in this SHA1 hash being calculated. Prior to this PR the SHA1 hash would just use the default libctx and property query. However libssl needs to be able to specify a non-default libctx. Rather than modifying large numbers of X509 functions to add an OPENSSL_CTX parameter, we expose a new function to explicitly process the X509v3 extensions. This can be called up-front before other X509 functions are called.
