### PR TITLE
s_server: Properly indicate ALPN protocol mismatch

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -707,7 +707,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     if (SSL_select_next_proto
         ((unsigned char **)out, outlen, alpn_ctx->data, alpn_ctx->len, in,
          inlen) != OPENSSL_NPN_NEGOTIATED) {
-        return SSL_TLSEXT_ERR_NOACK;
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
     }
 
     if (!s_quiet) {


### PR DESCRIPTION
Return SSL_TLSEXT_ERR_ALERT_FATAL from alpn_select_cb so that
an alert is sent to the client on ALPN protocol mismatch.
