### PR TITLE
ASYNC: Fixes for nested job creation

### DIFF
--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -22,32 +22,13 @@ int ASYNC_is_capable(void)
 
 void async_local_cleanup(void)
 {
-    async_ctx *ctx = async_get_ctx();
-    if (ctx != NULL) {
-        async_fibre *fibre = &ctx->dispatcher;
-        if (fibre != NULL && fibre->fibre != NULL && fibre->converted) {
-            ConvertFiberToThread();
-            fibre->fibre = NULL;
-        }
-    }
+    if (GetCurrentFiber())
+        ConvertFiberToThread();
 }
 
-int async_fibre_init_dispatcher(async_fibre *fibre)
+int async_fibre_init_dispatcher(async_ctx *ctx)
 {
-# if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
-    fibre->fibre = ConvertThreadToFiberEx(NULL, FIBER_FLAG_FLOAT_SWITCH);
-# else
-    fibre->fibre = ConvertThreadToFiber(NULL);
-# endif
-    if (fibre->fibre == NULL) {
-        fibre->converted = 0;
-        fibre->fibre = GetCurrentFiber();
-        if (fibre->fibre == NULL)
-            return 0;
-    } else {
-        fibre->converted = 1;
-    }
-
+    ConvertThreadToFiber(NULL);
     return 1;
 }
 

--- a/crypto/async/arch/async_win.h
+++ b/crypto/async/arch/async_win.h
@@ -25,7 +25,7 @@ typedef struct async_fibre_st {
 } async_fibre;
 
 # define async_fibre_swapcontext(o,n,r) \
-        (SwitchToFiber((n)->fibre), 1)
+        ((o)->fibre = GetCurrentFiber(), SwitchToFiber((n)->fibre), 1)
 
 # if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
 #   define async_fibre_makecontext(c) \
@@ -38,7 +38,7 @@ typedef struct async_fibre_st {
 
 # define async_fibre_free(f)             (DeleteFiber((f)->fibre))
 
-int async_fibre_init_dispatcher(async_fibre *fibre);
+int async_fibre_init_dispatcher(async_ctx *ctx);
 VOID CALLBACK async_start_func_win(PVOID unused);
 
 #endif

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -45,7 +45,7 @@ static async_ctx *async_ctx_new(void)
         goto err;
     }
 
-    async_fibre_init_dispatcher(&nctx->dispatcher);
+    async_fibre_init_dispatcher(nctx);
     nctx->currjob = NULL;
     nctx->blocked = 0;
     if (!CRYPTO_THREAD_set_local(&ctxkey, nctx))
@@ -155,8 +155,7 @@ void async_start_func(void)
 
         /* Stop the job */
         job->status = ASYNC_JOB_STOPPING;
-        if (!async_fibre_swapcontext(&job->fibrectx,
-                                     &ctx->dispatcher, 1)) {
+        if (!async_fibre_swapcontext(&job->fibrectx, &job->back, 1)) {
             /*
              * Should not happen. Getting here will close the thread...can't do
              * much about it
@@ -171,6 +170,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
 {
     async_ctx *ctx;
     OSSL_LIB_CTX *libctx;
+    ASYNC_JOB *newjob;
 
     if (!OPENSSL_init_crypto(OPENSSL_INIT_ASYNC, NULL))
         return ASYNC_ERR;
@@ -181,16 +181,14 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
     if (ctx == NULL)
         return ASYNC_ERR;
 
-    if (*job != NULL)
-        ctx->currjob = *job;
-
     for (;;) {
-        if (ctx->currjob != NULL) {
+        if (*job) {
+            ctx->currjob = *job;
             if (ctx->currjob->status == ASYNC_JOB_STOPPING) {
                 *ret = ctx->currjob->ret;
                 ctx->currjob->waitctx = NULL;
                 async_release_job(ctx->currjob);
-                ctx->currjob = NULL;
+                ctx->currjob = ctx->currjob->prevjob;
                 *job = NULL;
                 return ASYNC_FINISH;
             }
@@ -198,13 +196,15 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
             if (ctx->currjob->status == ASYNC_JOB_PAUSING) {
                 *job = ctx->currjob;
                 ctx->currjob->status = ASYNC_JOB_PAUSED;
-                ctx->currjob = NULL;
+                ctx->currjob = ctx->currjob->prevjob;
                 return ASYNC_PAUSE;
             }
 
             if (ctx->currjob->status == ASYNC_JOB_PAUSED) {
                 if (*job == NULL)
                     return ASYNC_ERR;
+                if (*job != ctx->currjob)
+                    (*job)->prevjob = ctx->currjob;
                 ctx->currjob = *job;
 
                 /*
@@ -217,8 +217,10 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
                     ERR_raise(ERR_LIB_ASYNC, ERR_R_INTERNAL_ERROR);
                     goto err;
                 }
+
+                ctx->currjob->status = ASYNC_JOB_RUNNING;
                 /* Resume previous job */
-                if (!async_fibre_swapcontext(&ctx->dispatcher,
+                if (!async_fibre_swapcontext(&ctx->currjob->back,
                         &ctx->currjob->fibrectx, 1)) {
                     ctx->currjob->libctx = OSSL_LIB_CTX_set0_default(libctx);
                     ERR_raise(ERR_LIB_ASYNC, ASYNC_R_FAILED_TO_SWAP_CONTEXT);
@@ -230,38 +232,34 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
                  * been changed to.
                  */
                 ctx->currjob->libctx = OSSL_LIB_CTX_set0_default(libctx);
+                ctx->currjob = (*job)->prevjob;
                 continue;
             }
-
-            /* Should not happen */
-            ERR_raise(ERR_LIB_ASYNC, ERR_R_INTERNAL_ERROR);
-            async_release_job(ctx->currjob);
-            ctx->currjob = NULL;
-            *job = NULL;
-            return ASYNC_ERR;
         }
 
         /* Start a new job */
-        if ((ctx->currjob = async_get_pool_job()) == NULL)
+        if ((newjob = async_get_pool_job()) == NULL)
             return ASYNC_NO_JOBS;
 
         if (args != NULL) {
-            ctx->currjob->funcargs = OPENSSL_malloc(size);
-            if (ctx->currjob->funcargs == NULL) {
+            newjob->funcargs = OPENSSL_malloc(size);
+            if (newjob->funcargs == NULL) {
                 ERR_raise(ERR_LIB_ASYNC, ERR_R_MALLOC_FAILURE);
-                async_release_job(ctx->currjob);
-                ctx->currjob = NULL;
+                async_release_job(newjob);
                 return ASYNC_ERR;
             }
-            memcpy(ctx->currjob->funcargs, args, size);
+            memcpy(newjob->funcargs, args, size);
         } else {
-            ctx->currjob->funcargs = NULL;
+            newjob->funcargs = NULL;
         }
 
-        ctx->currjob->func = func;
-        ctx->currjob->waitctx = wctx;
+        newjob->func = func;
+        newjob->waitctx = wctx;
+        newjob->prevjob = ctx->currjob;
+        ctx->currjob = newjob;
+        *job = newjob;
         libctx = ossl_lib_ctx_get_concrete(NULL);
-        if (!async_fibre_swapcontext(&ctx->dispatcher,
+        if (!async_fibre_swapcontext(&ctx->currjob->back,
                 &ctx->currjob->fibrectx, 1)) {
             ERR_raise(ERR_LIB_ASYNC, ASYNC_R_FAILED_TO_SWAP_CONTEXT);
             goto err;
@@ -298,8 +296,7 @@ int ASYNC_pause_job(void)
     job = ctx->currjob;
     job->status = ASYNC_JOB_PAUSING;
 
-    if (!async_fibre_swapcontext(&job->fibrectx,
-                                 &ctx->dispatcher, 1)) {
+    if (!async_fibre_swapcontext(&job->fibrectx, &job->back, 1)) {
         ERR_raise(ERR_LIB_ASYNC, ASYNC_R_FAILED_TO_SWAP_CONTEXT);
         return 0;
     }

--- a/crypto/async/async_local.h
+++ b/crypto/async/async_local.h
@@ -31,13 +31,14 @@ typedef struct async_pool_st async_pool;
 #include "arch/async_null.h"
 
 struct async_ctx_st {
-    async_fibre dispatcher;
     ASYNC_JOB *currjob;
     unsigned int blocked;
 };
 
 struct async_job_st {
     async_fibre fibrectx;
+    async_fibre back;
+    struct async_job_st *prevjob;
     int (*func) (void *);
     void *funcargs;
     int ret;

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -409,6 +409,7 @@ static int test_ASYNC_start_job_ex(void)
     ret = 1;
  err:
     ASYNC_WAIT_CTX_free(waitctx);
+    ASYNC_cleanup_thread();
     OSSL_LIB_CTX_free(libctx);
     return ret;
 }


### PR DESCRIPTION
In such a scenario, calling ASYNC_start_job() in a job again to create
a new job will cause the program to crash. This scenario is common in
coroutines, such as a web server, a coroutine listener, and a new client,
a new coroutine service, after accept () is created.

The current design of ASYNC does not support this scenario. Each coroutine
eventually falls back to the dispatcher. There are multiple coroutines,
and there is only one context for saving the coroutine exit, which is the
dispatcher. At this time, the context will be Being covered, this also
determines that only one coroutine can be running at the same time. And it
is dispatched by the dispatcher, which limits the application scenario
of ASYNC to a certain extent. In the traditional sense of coroutines,
dispatching is done by the users themselves, and there is no need for a
so-called dispatching center, dispatcher.

This patch solves this problem. For each coroutine, a context called back
is used for exit or pause (), so the dispatcher is not needed. This patch
does not change the ASYNC API.

There is also a simple example in the test code, which fully illustrates the
problems I described.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
