### PR TITLE
Don't attempt to up-ref an EVP_CIPHER if it is NULL

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -457,7 +457,10 @@ int ssl_cipher_get_evp_cipher(SSL_CTX *ctx, const SSL_CIPHER *sslc,
             if (*enc == NULL)
                 return 0;
         } else {
-            if (!ssl_evp_cipher_up_ref(ctx->ssl_cipher_methods[i]))
+            const EVP_CIPHER *cipher = ctx->ssl_cipher_methods[i];
+
+            if (cipher == NULL
+                    || !ssl_evp_cipher_up_ref(cipher))
                 return 0;
             *enc = ctx->ssl_cipher_methods[i];
         }


### PR DESCRIPTION
EVP_CIPHERs in the ssl_cipher_methods table can be NULL if
they are not available. We shouldn't attempt to up-ref a
cipher if it is NULL.