### PR TITLE
Fix off-by-1 bug on provider_activate with custom error strings

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -540,12 +540,13 @@ static int provider_activate(OSSL_PROVIDER *prov)
          * with the error library number, so we need to make a copy of that
          * array either way.
          */
-        cnt = 1;                 /* One for the terminating item */
+        cnt = 0;
         while (reasonstrings[cnt].id != 0) {
             if (ERR_GET_LIB(reasonstrings[cnt].id) != 0)
                 return 0;
             cnt++;
         }
+        cnt++;                   /* One for the terminating item */
 
         /* Allocate one extra item for the "library" name */
         prov->error_strings =

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -41,6 +41,7 @@ static const OSSL_PARAM p_param_types[] = {
 /* This is a trick to ensure we define the provider functions correctly */
 static OSSL_provider_gettable_params_fn p_gettable_params;
 static OSSL_provider_get_params_fn p_get_params;
+static OSSL_provider_get_reason_strings_fn p_get_reason_strings;
 
 static const OSSL_PARAM *p_gettable_params(void *_)
 {
@@ -100,9 +101,21 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
     return ok;
 }
 
+static const OSSL_ITEM *p_get_reason_strings(void *_)
+{
+    static const OSSL_ITEM reason_strings[] = {
+        {1, "dummy reason string"},
+        {0, NULL}
+    };
+
+    return reason_strings;
+}
+
 static const OSSL_DISPATCH p_test_table[] = {
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))p_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p_get_params },
+    { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS,
+        (void (*)(void))p_get_reason_strings},
     { 0, NULL }
 };
 


### PR DESCRIPTION
Starting `cnt` from 1 would work if we weren't using cnt itself to access elements of the array returned calling the provider callback.

As it is before this commit, we have 2 problems:
- first, in the unlikely case that the incoming array was "empty" (only contains the terminator item) we would skip past it and potentially end up with oob reads;
- otherwise, at the end of the while loop, `cnt` will be equal to the number of items in the input array, not 1 more. We then add 1 more to the zalloc call to account for the library name item, and we fill all of it (relying on zalloc to have zeroed the terminator item).
  The first read access that will read the list up to the terminator will result in a OOB read as we did not allocate enough space to also contain the terminator.

##### Checklist
- [x] tests are added or updated
