### PR TITLE
[crypto/ec] Ladder tweaks

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -266,17 +266,10 @@ int ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
         goto err;
     }
 
-    /*-
-     * Apply coordinate blinding for EC_POINT.
-     *
-     * The underlying EC_METHOD can optionally implement this function:
-     * ec_point_blind_coordinates() returns 0 in case of errors or 1 on
-     * success or if coordinate blinding is not implemented for this
-     * group.
-     */
-    if (!ec_point_blind_coordinates(group, p, ctx)) {
-        ECerr(EC_F_EC_SCALAR_MUL_LADDER, EC_R_POINT_COORDINATES_BLIND_FAILURE);
-        goto err;
+    /* ensure input point is in affine coords for ladder step efficiency */
+    if (!p->Z_is_one && !EC_POINT_make_affine(group, p, ctx)) {
+            ECerr(EC_F_EC_SCALAR_MUL_LADDER, ERR_R_EC_LIB);
+            goto err;
     }
 
     /* Initialize the Montgomery ladder */

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1509,11 +1509,13 @@ int ec_GFp_simple_ladder_pre(const EC_GROUP *group,
         || !group->meth->field_sqr(group, t4, t4, ctx)
         || !group->meth->field_mul(group, t5, p->X, group->b, ctx)
         || !BN_mod_lshift_quick(t5, t5, 3, group->field)
-        || !BN_mod_sub_quick(t4, t4, t5, group->field)
+        /* r->X coord output */
+        || !BN_mod_sub_quick(r->X, t4, t5, group->field)
         || !BN_mod_add_quick(t1, t3, group->a, group->field)
         || !group->meth->field_mul(group, t2, p->X, t1, ctx)
         || !BN_mod_add_quick(t2, group->b, t2, group->field)
-        || !BN_mod_lshift_quick(t2, t2, 2, group->field))
+        /* r->Z coord output */
+        || !BN_mod_lshift_quick(r->Z, t2, 2, group->field))
         return 0;
 
     /* make sure lambda (r->Y here for storage) is not zero */
@@ -1615,7 +1617,7 @@ int ec_GFp_simple_ladder_step(const EC_GROUP *group,
         || !BN_mod_lshift1_quick(t1, t1, group->field)
         /* r->Z coord output */
         || !BN_mod_add_quick(r->Z, t4, t1, group->field))
-            goto err;
+        goto err;
 
     ret = 1;
 

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1477,12 +1477,19 @@ int ec_GFp_simple_blind_coordinates(const EC_GROUP *group, EC_POINT *p,
 }
 
 /*-
- * Set s := p, r := 2p. Assumes p is in affine coords.
+ * Input:
+ * - p: affine coordinates
+ *
+ * Output:
+ * - s := p, r := 2p: blinded projective (homogeneous) coordinates
  *
  * For doubling we use Formula 3 from Izu-Takagi "A fast parallel elliptic curve
  * multiplication resistant against side channel attacks" appendix, described at
  * https://hyperelliptic.org/EFD/g1p/auto-shortw-xz.html#doubling-dbl-2002-it-2
  * simplified for Z1=1.
+ *
+ * Blinding uses the equivalence relation (\lambda X, \lambda Y, \lambda Z)
+ * for any non-zero \lambda that holds for projective (homogeneous) coords.
  */
 int ec_GFp_simple_ladder_pre(const EC_GROUP *group,
                              EC_POINT *r, EC_POINT *s,
@@ -1540,13 +1547,17 @@ int ec_GFp_simple_ladder_pre(const EC_GROUP *group,
 }
 
 /*-
+ * Input:
+ * - s, r: projective (homogeneous) coordinates
+ * - p: affine coordinates
+ *
+ * Output:
+ * - s := r + s, r := 2r: projective (homogeneous) coordinates
+ *
  * Differential addition-and-doubling using Eq. (9) and (10) from Izu-Takagi
  * "A fast parallel elliptic curve multiplication resistant against side channel
  * attacks", as described at
  * https://hyperelliptic.org/EFD/g1p/auto-shortw-xz.html#ladder-mladd-2002-it-4
- * s := r + s, r := 2r
- * s, r: projective (homogeneous) coordinates
- * p: affine coordinates
  */
 int ec_GFp_simple_ladder_step(const EC_GROUP *group,
                               EC_POINT *r, EC_POINT *s,
@@ -1614,6 +1625,13 @@ int ec_GFp_simple_ladder_step(const EC_GROUP *group,
 }
 
 /*-
+ * Input:
+ * - s, r: projective (homogeneous) coordinates
+ * - p: affine coordinates
+ *
+ * Output:
+ * - r := (x,y): affine coordinates
+ *
  * Recovers the y-coordinate of r using Eq. (8) from Brier-Joye, "Weierstrass
  * Elliptic Curves and Side-Channel Attacks", modified to work in mixed
  * projective coords, i.e. p is affine and (r,s) in projective (homogeneous)

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1381,6 +1381,7 @@ int ec_GFp_simple_field_sqr(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a,
  * Computes the multiplicative inverse of a in GF(p), storing the result in r.
  * If a is zero (or equivalent), you'll get a EC_R_CANNOT_INVERT error.
  * Since we don't have a Mont structure here, SCA hardening is with blinding.
+ * NB: "a" must be in _decoded_ form. (i.e. field_decode must precede.)
  */
 int ec_GFp_simple_field_inv(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a,
                             BN_CTX *ctx)
@@ -1476,61 +1477,64 @@ int ec_GFp_simple_blind_coordinates(const EC_GROUP *group, EC_POINT *p,
 }
 
 /*-
- * Set s := p, r := 2p.
+ * Set s := p, r := 2p. Assumes p is in affine coords.
  *
  * For doubling we use Formula 3 from Izu-Takagi "A fast parallel elliptic curve
- * multiplication resistant against side channel attacks" appendix, as described
- * at
+ * multiplication resistant against side channel attacks" appendix, described at
  * https://hyperelliptic.org/EFD/g1p/auto-shortw-xz.html#doubling-dbl-2002-it-2
- *
- * The input point p will be in randomized Jacobian projective coords:
- *      x = X/Z**2, y=Y/Z**3
- *
- * The output points p, s, and r are converted to standard (homogeneous)
- * projective coords:
- *      x = X/Z, y=Y/Z
+ * simplified for Z1=1.
  */
 int ec_GFp_simple_ladder_pre(const EC_GROUP *group,
                              EC_POINT *r, EC_POINT *s,
                              EC_POINT *p, BN_CTX *ctx)
 {
-    BIGNUM *t1, *t2, *t3, *t4, *t5, *t6 = NULL;
+    BIGNUM *t1, *t2, *t3, *t4, *t5 = NULL;
 
-    t1 = r->Z;
-    t2 = r->Y;
+    t1 = s->Z;
+    t2 = r->Z;
     t3 = s->X;
     t4 = r->X;
     t5 = s->Y;
-    t6 = s->Z;
 
-    /* convert p: (X,Y,Z) -> (XZ,Y,Z**3) */
-    if (!group->meth->field_mul(group, p->X, p->X, p->Z, ctx)
-        || !group->meth->field_sqr(group, t1, p->Z, ctx)
-        || !group->meth->field_mul(group, p->Z, p->Z, t1, ctx)
-        /* r := 2p */
-        || !group->meth->field_sqr(group, t2, p->X, ctx)
-        || !group->meth->field_sqr(group, t3, p->Z, ctx)
-        || !group->meth->field_mul(group, t4, t3, group->a, ctx)
-        || !BN_mod_sub_quick(t5, t2, t4, group->field)
-        || !BN_mod_add_quick(t2, t2, t4, group->field)
-        || !group->meth->field_sqr(group, t5, t5, ctx)
-        || !group->meth->field_mul(group, t6, t3, group->b, ctx)
-        || !group->meth->field_mul(group, t1, p->X, p->Z, ctx)
-        || !group->meth->field_mul(group, t4, t1, t6, ctx)
-        || !BN_mod_lshift_quick(t4, t4, 3, group->field)
-        /* r->X coord output */
-        || !BN_mod_sub_quick(r->X, t5, t4, group->field)
-        || !group->meth->field_mul(group, t1, t1, t2, ctx)
-        || !group->meth->field_mul(group, t2, t3, t6, ctx)
-        || !BN_mod_add_quick(t1, t1, t2, group->field)
-        /* r->Z coord output */
-        || !BN_mod_lshift_quick(r->Z, t1, 2, group->field)
-        || !EC_POINT_copy(s, p))
+    if (!p->Z_is_one
+        || !group->meth->field_sqr(group, t3, p->X, ctx)
+        || !BN_mod_sub_quick(t4, t3, group->a, group->field)
+        || !group->meth->field_sqr(group, t4, t4, ctx)
+        || !group->meth->field_mul(group, t5, p->X, group->b, ctx)
+        || !BN_mod_lshift_quick(t5, t5, 3, group->field)
+        || !BN_mod_sub_quick(t4, t4, t5, group->field)
+        || !BN_mod_add_quick(t1, t3, group->a, group->field)
+        || !group->meth->field_mul(group, t2, p->X, t1, ctx)
+        || !BN_mod_add_quick(t2, group->b, t2, group->field)
+        || !BN_mod_lshift_quick(t2, t2, 2, group->field))
+        return 0;
+
+    /* make sure lambda (r->Y here for storage) is not zero */
+    do {
+        if (!BN_priv_rand_range_ex(r->Y, group->field, ctx))
+            return 0;
+    } while (BN_is_zero(r->Y));
+
+    /* make sure lambda (s->Z here for storage) is not zero */
+    do {
+        if (!BN_priv_rand_range_ex(s->Z, group->field, ctx))
+            return 0;
+    } while (BN_is_zero(s->Z));
+
+    /* if field_encode defined convert between representations */
+    if (group->meth->field_encode != NULL
+        && (!group->meth->field_encode(group, r->Y, r->Y, ctx)
+            || !group->meth->field_encode(group, s->Z, s->Z, ctx)))
+        return 0;
+
+    /* blind r and s independently */
+    if (!group->meth->field_mul(group, r->Z, r->Z, r->Y, ctx)
+        || !group->meth->field_mul(group, r->X, r->X, r->Y, ctx)
+        || !group->meth->field_mul(group, s->X, p->X, s->Z, ctx))
         return 0;
 
     r->Z_is_one = 0;
     s->Z_is_one = 0;
-    p->Z_is_one = 0;
 
     return 1;
 }
@@ -1539,14 +1543,15 @@ int ec_GFp_simple_ladder_pre(const EC_GROUP *group,
  * Differential addition-and-doubling using  Eq. (9) and (10) from Izu-Takagi
  * "A fast parallel elliptic curve multiplication resistant against side channel
  * attacks", as described at
- * https://hyperelliptic.org/EFD/g1p/auto-shortw-xz.html#ladder-ladd-2002-it-4
+ * https://hyperelliptic.org/EFD/g1p/auto-shortw-xz.html#ladder-mladd-2002-it-4
+ * s := r + s, r := 2r
  */
 int ec_GFp_simple_ladder_step(const EC_GROUP *group,
                               EC_POINT *r, EC_POINT *s,
                               EC_POINT *p, BN_CTX *ctx)
 {
     int ret = 0;
-    BIGNUM *t0, *t1, *t2, *t3, *t4, *t5, *t6, *t7 = NULL;
+    BIGNUM *t0, *t1, *t2, *t3, *t4, *t5, *t6 = NULL;
 
     BN_CTX_start(ctx);
     t0 = BN_CTX_get(ctx);
@@ -1556,51 +1561,44 @@ int ec_GFp_simple_ladder_step(const EC_GROUP *group,
     t4 = BN_CTX_get(ctx);
     t5 = BN_CTX_get(ctx);
     t6 = BN_CTX_get(ctx);
-    t7 = BN_CTX_get(ctx);
 
-    if (t7 == NULL
-        || !group->meth->field_mul(group, t0, r->X, s->X, ctx)
-        || !group->meth->field_mul(group, t1, r->Z, s->Z, ctx)
-        || !group->meth->field_mul(group, t2, r->X, s->Z, ctx)
+    if (t6 == NULL
+        || !group->meth->field_mul(group, t6, r->X, s->X, ctx)
+        || !group->meth->field_mul(group, t0, r->Z, s->Z, ctx)
+        || !group->meth->field_mul(group, t4, r->X, s->Z, ctx)
         || !group->meth->field_mul(group, t3, r->Z, s->X, ctx)
-        || !group->meth->field_mul(group, t4, group->a, t1, ctx)
-        || !BN_mod_add_quick(t0, t0, t4, group->field)
-        || !BN_mod_add_quick(t4, t3, t2, group->field)
-        || !group->meth->field_mul(group, t0, t4, t0, ctx)
-        || !group->meth->field_sqr(group, t1, t1, ctx)
-        || !BN_mod_lshift_quick(t7, group->b, 2, group->field)
-        || !group->meth->field_mul(group, t1, t7, t1, ctx)
-        || !BN_mod_lshift1_quick(t0, t0, group->field)
-        || !BN_mod_add_quick(t0, t1, t0, group->field)
-        || !BN_mod_sub_quick(t1, t2, t3, group->field)
-        || !group->meth->field_sqr(group, t1, t1, ctx)
-        || !group->meth->field_mul(group, t3, t1, p->X, ctx)
-        || !group->meth->field_mul(group, t0, p->Z, t0, ctx)
-        /* s->X coord output */
-        || !BN_mod_sub_quick(s->X, t0, t3, group->field)
-        /* s->Z coord output */
-        || !group->meth->field_mul(group, s->Z, p->Z, t1, ctx)
-        || !group->meth->field_sqr(group, t3, r->X, ctx)
-        || !group->meth->field_sqr(group, t2, r->Z, ctx)
-        || !group->meth->field_mul(group, t4, t2, group->a, ctx)
-        || !BN_mod_add_quick(t5, r->X, r->Z, group->field)
-        || !group->meth->field_sqr(group, t5, t5, ctx)
-        || !BN_mod_sub_quick(t5, t5, t3, group->field)
-        || !BN_mod_sub_quick(t5, t5, t2, group->field)
-        || !BN_mod_sub_quick(t6, t3, t4, group->field)
-        || !group->meth->field_sqr(group, t6, t6, ctx)
-        || !group->meth->field_mul(group, t0, t2, t5, ctx)
-        || !group->meth->field_mul(group, t0, t7, t0, ctx)
-        /* r->X coord output */
-        || !BN_mod_sub_quick(r->X, t6, t0, group->field)
+        || !group->meth->field_mul(group, t5, group->a, t0, ctx)
+        || !BN_mod_add_quick(t5, t6, t5, group->field)
         || !BN_mod_add_quick(t6, t3, t4, group->field)
-        || !group->meth->field_sqr(group, t3, t2, ctx)
-        || !group->meth->field_mul(group, t7, t3, t7, ctx)
-        || !group->meth->field_mul(group, t5, t5, t6, ctx)
+        || !group->meth->field_mul(group, t5, t6, t5, ctx)
+        || !group->meth->field_sqr(group, t0, t0, ctx)
+        || !BN_mod_lshift_quick(t2, group->b, 2, group->field)
+        || !group->meth->field_mul(group, t0, t2, t0, ctx)
         || !BN_mod_lshift1_quick(t5, t5, group->field)
-        /* r->Z coord output */
-        || !BN_mod_add_quick(r->Z, t7, t5, group->field))
-        goto err;
+        || !BN_mod_sub_quick(t3, t4, t3, group->field)
+        || !group->meth->field_sqr(group, s->Z, t3, ctx)
+        || !group->meth->field_mul(group, t4, s->Z, p->X, ctx)
+        || !BN_mod_add_quick(t0, t0, t5, group->field)
+        || !BN_mod_sub_quick(s->X, t0, t4, group->field)
+        || !group->meth->field_sqr(group, t4, r->X, ctx)
+        || !group->meth->field_sqr(group, t5, r->Z, ctx)
+        || !group->meth->field_mul(group, t6, t5, group->a, ctx)
+        || !BN_mod_add_quick(t1, r->X, r->Z, group->field)
+        || !group->meth->field_sqr(group, t1, t1, ctx)
+        || !BN_mod_sub_quick(t1, t1, t4, group->field)
+        || !BN_mod_sub_quick(t1, t1, t5, group->field)
+        || !BN_mod_sub_quick(t3, t4, t6, group->field)
+        || !group->meth->field_sqr(group, t3, t3, ctx)
+        || !group->meth->field_mul(group, t0, t5, t1, ctx)
+        || !group->meth->field_mul(group, t0, t2, t0, ctx)
+        || !BN_mod_sub_quick(r->X, t3, t0, group->field)
+        || !BN_mod_add_quick(t3, t4, t6, group->field)
+        || !group->meth->field_sqr(group, t4, t5, ctx)
+        || !group->meth->field_mul(group, t4, t4, t2, ctx)
+        || !group->meth->field_mul(group, t1, t1, t3, ctx)
+        || !BN_mod_lshift1_quick(t1, t1, group->field)
+        || !BN_mod_add_quick(r->Z, t4, t1, group->field))
+            goto err;
 
     ret = 1;
 
@@ -1611,16 +1609,14 @@ int ec_GFp_simple_ladder_step(const EC_GROUP *group,
 
 /*-
  * Recovers the y-coordinate of r using Eq. (8) from Brier-Joye, "Weierstrass
- * Elliptic Curves and Side-Channel Attacks", modified to work in projective
- * coordinates and return r in Jacobian projective coordinates.
+ * Elliptic Curves and Side-Channel Attacks", modified to work in mixed
+ * projective coordinates and return r in affine coordinates.
  *
- * X4 = two*Y1*X2*Z3*Z2*Z1;
- * Y4 = two*b*Z3*SQR(Z2*Z1) + Z3*(a*Z2*Z1+X1*X2)*(X1*Z2+X2*Z1) - X3*SQR(X1*Z2-X2*Z1);
- * Z4 = two*Y1*Z3*SQR(Z2)*Z1;
+ * X4 = two*Y1*X2*Z3*Z2;
+ * Y4 = two*b*Z3*SQR(Z2) + Z3*(a*Z2+X1*X2)*(X1*Z2+X2) - X3*SQR(X1*Z2-X2);
+ * Z4 = two*Y1*Z3*SQR(Z2);
  *
  * Z4 != 0 because:
- *  - Z1==0 implies p is at infinity, which would have caused an early exit in
- *    the caller;
  *  - Z2==0 implies r is at infinity (handled by the BN_is_zero(r->Z) branch);
  *  - Z3==0 implies s is at infinity (handled by the BN_is_zero(s->Z) branch);
  *  - Y1==0 implies p has order 2, so either r or s are infinity and handled by
@@ -1637,11 +1633,7 @@ int ec_GFp_simple_ladder_post(const EC_GROUP *group,
         return EC_POINT_set_to_infinity(group, r);
 
     if (BN_is_zero(s->Z)) {
-        /* (X,Y,Z) -> (XZ,YZ**2,Z) */
-        if (!group->meth->field_mul(group, r->X, p->X, p->Z, ctx)
-            || !group->meth->field_sqr(group, r->Z, p->Z, ctx)
-            || !group->meth->field_mul(group, r->Y, p->Y, r->Z, ctx)
-            || !BN_copy(r->Z, p->Z)
+        if (!EC_POINT_copy(r, p)
             || !EC_POINT_invert(group, r, ctx))
             return 0;
         return 1;
@@ -1657,38 +1649,46 @@ int ec_GFp_simple_ladder_post(const EC_GROUP *group,
     t6 = BN_CTX_get(ctx);
 
     if (t6 == NULL
-        || !BN_mod_lshift1_quick(t0, p->Y, group->field)
-        || !group->meth->field_mul(group, t1, r->X, p->Z, ctx)
-        || !group->meth->field_mul(group, t2, r->Z, s->Z, ctx)
-        || !group->meth->field_mul(group, t2, t1, t2, ctx)
-        || !group->meth->field_mul(group, t3, t2, t0, ctx)
-        || !group->meth->field_mul(group, t2, r->Z, p->Z, ctx)
-        || !group->meth->field_sqr(group, t4, t2, ctx)
-        || !BN_mod_lshift1_quick(t5, group->b, group->field)
-        || !group->meth->field_mul(group, t4, t4, t5, ctx)
-        || !group->meth->field_mul(group, t6, t2, group->a, ctx)
-        || !group->meth->field_mul(group, t5, r->X, p->X, ctx)
-        || !BN_mod_add_quick(t5, t6, t5, group->field)
-        || !group->meth->field_mul(group, t6, r->Z, p->X, ctx)
-        || !BN_mod_add_quick(t2, t6, t1, group->field)
-        || !group->meth->field_mul(group, t5, t5, t2, ctx)
-        || !BN_mod_sub_quick(t6, t6, t1, group->field)
-        || !group->meth->field_sqr(group, t6, t6, ctx)
-        || !group->meth->field_mul(group, t6, t6, s->X, ctx)
-        || !BN_mod_add_quick(t4, t5, t4, group->field)
-        || !group->meth->field_mul(group, t4, t4, s->Z, ctx)
-        || !BN_mod_sub_quick(t4, t4, t6, group->field)
-        || !group->meth->field_sqr(group, t5, r->Z, ctx)
-        || !group->meth->field_mul(group, r->Z, p->Z, s->Z, ctx)
-        || !group->meth->field_mul(group, r->Z, t5, r->Z, ctx)
-        || !group->meth->field_mul(group, r->Z, r->Z, t0, ctx)
-        /* t3 := X, t4 := Y */
-        /* (X,Y,Z) -> (XZ,YZ**2,Z) */
-        || !group->meth->field_mul(group, r->X, t3, r->Z, ctx)
+        || !BN_mod_lshift1_quick(t4, p->Y, group->field)
+        || !group->meth->field_mul(group, t6, r->X, t4, ctx)
+        || !group->meth->field_mul(group, t6, s->Z, t6, ctx)
+        || !group->meth->field_mul(group, t5, r->Z, t6, ctx)
+        || !BN_mod_lshift1_quick(t1, group->b, group->field)
+        || !group->meth->field_mul(group, t1, s->Z, t1, ctx)
         || !group->meth->field_sqr(group, t3, r->Z, ctx)
-        || !group->meth->field_mul(group, r->Y, t4, t3, ctx))
+        || !group->meth->field_mul(group, t2, t3, t1, ctx)
+        || !group->meth->field_mul(group, t6, r->Z, group->a, ctx)
+        || !group->meth->field_mul(group, t1, p->X, r->X, ctx)
+        || !BN_mod_add_quick(t1, t1, t6, group->field)
+        || !group->meth->field_mul(group, t1, s->Z, t1, ctx)
+        || !group->meth->field_mul(group, t0, p->X, r->Z, ctx)
+        || !BN_mod_add_quick(t6, r->X, t0, group->field)
+        || !group->meth->field_mul(group, t6, t6, t1, ctx)
+        || !BN_mod_add_quick(t6, t6, t2, group->field)
+        || !BN_mod_sub_quick(t0, t0, r->X, group->field)
+        || !group->meth->field_sqr(group, t0, t0, ctx)
+        || !group->meth->field_mul(group, t0, t0, s->X, ctx)
+        || !BN_mod_sub_quick(t0, t6, t0, group->field)
+        || !group->meth->field_mul(group, t1, s->Z, t4, ctx)
+        || !group->meth->field_mul(group, t1, t3, t1, ctx)
+        || (group->meth->field_decode != NULL
+            && !group->meth->field_decode(group, t1, t1, ctx))
+        || !group->meth->field_inv(group, t1, t1, ctx)
+        || (group->meth->field_encode != NULL
+            && !group->meth->field_encode(group, t1, t1, ctx))
+        || !group->meth->field_mul(group, r->X, t5, t1, ctx)
+        || !group->meth->field_mul(group, r->Y, t0, t1, ctx))
         goto err;
 
+    if (group->meth->field_set_to_one != NULL) {
+        if (!group->meth->field_set_to_one(group, r->Z, ctx))
+            goto err;
+    } else {
+        if (!BN_one(r->Z))
+            goto err;
+    }
+
+    r->Z_is_one = 1;
     ret = 1;
 
  err:

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -37,17 +37,18 @@ static size_t fake_rand_size = 0;
 
 static int get_faked_bytes(unsigned char *buf, int num)
 {
-    int i;
-
     if (fake_rand_bytes == NULL)
         return saved_rand->bytes(buf, num);
 
-    if (!TEST_size_t_le(fake_rand_bytes_offset + num, fake_rand_size))
+    if (!TEST_size_t_gt(fake_rand_size, 0))
         return 0;
 
-    for (i = 0; i != num; ++i)
-        buf[i] = fake_rand_bytes[fake_rand_bytes_offset + i];
-    fake_rand_bytes_offset += num;
+    while (num-- > 0) {
+        if (fake_rand_bytes_offset >= fake_rand_size)
+            fake_rand_bytes_offset = 0;
+        *buf++ = fake_rand_bytes[fake_rand_bytes_offset++];
+    }
+
     return 1;
 }
 
@@ -180,8 +181,7 @@ static int test_sm2_crypt(const EC_GROUP *group,
 
     start_fake_rand(k_hex);
     if (!TEST_true(sm2_encrypt(key, digest, (const uint8_t *)message, msg_len,
-                               ctext, &ctext_len))
-            || !TEST_size_t_eq(fake_rand_bytes_offset, fake_rand_size)) {
+                               ctext, &ctext_len))) {
         restore_rand();
         goto done;
     }
@@ -301,8 +301,7 @@ static int test_sm2_sign(const EC_GROUP *group,
     start_fake_rand(k_hex);
     sig = sm2_do_sign(key, EVP_sm3(), (const uint8_t *)userid, strlen(userid),
                       (const uint8_t *)message, msg_len);
-    if (!TEST_ptr(sig)
-            || !TEST_size_t_eq(fake_rand_bytes_offset, fake_rand_size)) {
+    if (!TEST_ptr(sig)) {
         restore_rand();
         goto done;
     }


### PR DESCRIPTION
So #11361 prompted this PR -- it's been on my plate for a while. Recent work from my team (not on OpenSSL) tells our guts this is a better approach. Tagging @acaldaya for a sanity check.

It also recovers a tiny bit of the performance regression mentioned in #6512. Limited evidence below.

NB the actual curve math BN arithmetic parts are auto generated from tooling.

IMO master and 1.1.1.

Edit: Oh and I did not test `no-asm` which I think is important here, since all the arithmetic without that is handled by `ecp_mont` and not `ecp_smpl`.

Side note: this took me longer than I'd like to admit -- too long away from the OpenSSL codebase! I'll try to be more active.

## Before

```
bbrumley:~/svnrepos/openssl$ apps/openssl speed ecdhp384
Doing 384 bits  ecdh's for 10s: 9437 384-bits ECDH ops in 10.00s
version: 3.0.0-dev
built on: built on: Sat Mar 28 18:29:00 2020 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr) 
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_BUILDING_OPENSSL -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffef3ffffebffff:0x18d39efffb
                              op      op/s
 384 bits ecdh (nistp384)   0.0011s    943.7
bbrumley:~/svnrepos/openssl$ apps/openssl speed ecdsap384
Doing 384 bits sign ecdsa's for 10s: 8733 384 bits ECDSA signs in 10.00s 
Doing 384 bits verify ecdsa's for 10s: 11723 384 bits ECDSA verify in 10.00s
version: 3.0.0-dev
built on: built on: Sat Mar 28 18:29:00 2020 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr) 
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_BUILDING_OPENSSL -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffef3ffffebffff:0x18d39efffb
                              sign    verify    sign/s verify/s
 384 bits ecdsa (nistp384)   0.0011s   0.0009s    873.3   1172.3
```

## After

```
bbrumley:~/svnrepos/openssl$ apps/openssl speed ecdhp384
Doing 384 bits  ecdh's for 10s: 10183 384-bits ECDH ops in 10.01s
version: 3.0.0-dev
built on: built on: Sat Mar 28 18:36:26 2020 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr) 
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_BUILDING_OPENSSL -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffef3ffffebffff:0x18d39efffb
                              op      op/s
 384 bits ecdh (nistp384)   0.0010s   1017.3
bbrumley:~/svnrepos/openssl$ apps/openssl speed ecdsap384
Doing 384 bits sign ecdsa's for 10s: 9678 384 bits ECDSA signs in 10.00s 
Doing 384 bits verify ecdsa's for 10s: 12008 384 bits ECDSA verify in 10.00s
version: 3.0.0-dev
built on: built on: Sat Mar 28 18:36:26 2020 UTC
options:bn(64,64) rc4(16x,int) des(int) aes(partial) idea(int) blowfish(ptr) 
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_BUILDING_OPENSSL -DOPENSSL_PIC -DNDEBUG
CPUINFO: OPENSSL_ia32cap=0x7ffef3ffffebffff:0x18d39efffb
                              sign    verify    sign/s verify/s
 384 bits ecdsa (nistp384)   0.0010s   0.0008s    967.8   1200.8
```

## Machine

```
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                48
On-line CPU(s) list:   0-47
Thread(s) per core:    2
Core(s) per socket:    12
Socket(s):             2
NUMA node(s):          2
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 85
Model name:            Intel(R) Xeon(R) Silver 4116 CPU @ 2.10GHz
Stepping:              4
CPU MHz:               800.337
CPU max MHz:           3000.0000
CPU min MHz:           800.0000
BogoMIPS:              4201.70
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              1024K
L3 cache:              16896K
NUMA node0 CPU(s):     0-11,24-35
NUMA node1 CPU(s):     12-23,36-47
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single pti intel_ppin ssbd mba ibrs ibpb stibp tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts hwp hwp_act_window hwp_pkg_req pku ospke flush_l1d
```