### PR TITLE
[crypto/ec] blind coordinates in ec_wNAF_mul for robustness

### DIFF
--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -746,6 +746,20 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
                     if (r_is_at_infinity) {
                         if (!EC_POINT_copy(r, val_sub[i][digit >> 1]))
                             goto err;
+
+                        /*-
+                         * Apply coordinate blinding for EC_POINT.
+                         *
+                         * The underlying EC_METHOD can optionally implement this function:
+                         * ec_point_blind_coordinates() returns 0 in case of errors or 1 on
+                         * success or if coordinate blinding is not implemented for this
+                         * group.
+                         */
+                        if (!ec_point_blind_coordinates(group, r, ctx)) {
+                            ECerr(EC_F_EC_WNAF_MUL, EC_R_POINT_COORDINATES_BLIND_FAILURE);
+                            goto err;
+                        }
+
                         r_is_at_infinity = 0;
                     } else {
                         if (!EC_POINT_add


### PR DESCRIPTION
See #11435. This PR makes the `ec_wNAF_mul` algorithm state less predictable. It's a good cheap hardening against bug attacks.

Deja vu -- [it's 2011 all over again](https://marc.info/?l=openssl-dev&m=131194808413635).