### PR TITLE
Don't double free a DH object

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2152,15 +2152,14 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
                  ERR_R_EVP_LIB);
         goto err;
     }
+    dh = NULL;
 
     if (!ssl_security(s, SSL_SECOP_TMP_DH, EVP_PKEY_security_bits(peer_tmp),
-                      0, dh)) {
+                      0, EVP_PKEY_get0_DH(peer_tmp))) {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_TLS_PROCESS_SKE_DHE,
                  SSL_R_DH_KEY_TOO_SMALL);
-        dh = NULL;
         goto err;
     }
-    dh = NULL;
 
     s->s3.peer_tmp = peer_tmp;
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2157,8 +2157,10 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
                       0, dh)) {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_TLS_PROCESS_SKE_DHE,
                  SSL_R_DH_KEY_TOO_SMALL);
+        dh = NULL;
         goto err;
     }
+    dh = NULL;
 
     s->s3.peer_tmp = peer_tmp;
 


### PR DESCRIPTION
Having created a DH object and assigned it to an EVP_PKEY - we should
not free both the EVP_PKEY and the original DH. This will lead to a
double free occurring.

This issue was discovered and reported by GitHub Security Lab team member
Agustin Gianni.
