### PR TITLE
Make X509_STORE_CTX libctx aware

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -104,11 +104,12 @@ static int null_callback(int ok, X509_STORE_CTX *e)
     return ok;
 }
 
-/* Return 1 is a certificate is self signed */
-static int cert_self_signed(X509 *x)
+/* Return 1 is a certificate is self signed, 0 if not, or -1 on error */
+static int cert_self_signed(X509_STORE_CTX *ctx, X509 *x)
 {
-    if (X509_check_purpose(x, -1, 0) != 1)
-        return 0;
+    if (!X509v3_cache_extensions(x, ctx->libctx, ctx->propq))
+        return -1;
+
     if (x->ex_flags & EXFLAG_SS)
         return 1;
     else
@@ -324,14 +325,26 @@ static X509 *find_issuer(X509_STORE_CTX *ctx, STACK_OF(X509) *sk, X509 *x)
 static int check_issued(X509_STORE_CTX *ctx, X509 *x, X509 *issuer)
 {
     int ret;
-    if (x == issuer)
-        return cert_self_signed(x);
+    int ss;
+
+    if (x == issuer) {
+        ss = cert_self_signed(ctx, x);
+        if (ss < 0)
+            return X509_V_ERR_UNSPECIFIED;
+        return ss;
+    }
+
     ret = X509_check_issued(issuer, x);
     if (ret == X509_V_OK) {
         int i;
         X509 *ch;
+
+        ss = cert_self_signed(ctx, x);
+        if (ss < 0)
+            return X509_V_ERR_UNSPECIFIED;
+
         /* Special case: single self signed certificate */
-        if (cert_self_signed(x) && sk_X509_num(ctx->chain) == 1)
+        if (ss > 0 && sk_X509_num(ctx->chain) == 1)
             return 1;
         for (i = 0; i < sk_X509_num(ctx->chain); i++) {
             ch = sk_X509_value(ctx->chain, i);
@@ -2914,7 +2927,7 @@ static int build_chain(X509_STORE_CTX *ctx)
     SSL_DANE *dane = ctx->dane;
     int num = sk_X509_num(ctx->chain);
     X509 *cert = sk_X509_value(ctx->chain, num - 1);
-    int ss = cert_self_signed(cert);
+    int ss;
     STACK_OF(X509) *sktmp = NULL;
     unsigned int search;
     int may_trusted = 0;
@@ -2927,6 +2940,13 @@ static int build_chain(X509_STORE_CTX *ctx)
 
     /* Our chain starts with a single untrusted element. */
     if (!ossl_assert(num == 1 && ctx->num_untrusted == num))  {
+        X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
+        ctx->error = X509_V_ERR_UNSPECIFIED;
+        return 0;
+    }
+
+    ss = cert_self_signed(ctx, cert);
+    if (ss == -1) {
         X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
         ctx->error = X509_V_ERR_UNSPECIFIED;
         return 0;
@@ -3104,7 +3124,12 @@ static int build_chain(X509_STORE_CTX *ctx)
                         search = 0;
                         continue;
                     }
-                    ss = cert_self_signed(x);
+                    ss = cert_self_signed(ctx, x);
+                    if (ss == -1) {
+                        X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
+                        ctx->error = X509_V_ERR_UNSPECIFIED;
+                        return 0;
+                    }
                 } else if (num == ctx->num_untrusted) {
                     /*
                      * We have a self-signed certificate that has the same
@@ -3216,7 +3241,12 @@ static int build_chain(X509_STORE_CTX *ctx)
 
             X509_up_ref(x = xtmp);
             ++ctx->num_untrusted;
-            ss = cert_self_signed(xtmp);
+            ss = cert_self_signed(ctx, xtmp);
+            if (ss == -1) {
+                X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
+                ctx->error = X509_V_ERR_UNSPECIFIED;
+                return 0;
+            }
 
             /*
              * Check for DANE-TA trust of the topmost untrusted certificate.

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2946,7 +2946,7 @@ static int build_chain(X509_STORE_CTX *ctx)
     }
 
     ss = cert_self_signed(ctx, cert);
-    if (ss == -1) {
+    if (ss < 0) {
         X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
         ctx->error = X509_V_ERR_UNSPECIFIED;
         return 0;
@@ -3125,7 +3125,7 @@ static int build_chain(X509_STORE_CTX *ctx)
                         continue;
                     }
                     ss = cert_self_signed(ctx, x);
-                    if (ss == -1) {
+                    if (ss < 0) {
                         X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
                         ctx->error = X509_V_ERR_UNSPECIFIED;
                         return 0;
@@ -3242,7 +3242,7 @@ static int build_chain(X509_STORE_CTX *ctx)
             X509_up_ref(x = xtmp);
             ++ctx->num_untrusted;
             ss = cert_self_signed(ctx, xtmp);
-            if (ss == -1) {
+            if (ss < 0) {
                 X509err(X509_F_BUILD_CHAIN, ERR_R_INTERNAL_ERROR);
                 ctx->error = X509_V_ERR_UNSPECIFIED;
                 return 0;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -330,7 +330,7 @@ static int check_issued(X509_STORE_CTX *ctx, X509 *x, X509 *issuer)
     if (x == issuer) {
         ss = cert_self_signed(ctx, x);
         if (ss < 0)
-            return X509_V_ERR_UNSPECIFIED;
+            return 0;
         return ss;
     }
 
@@ -341,7 +341,7 @@ static int check_issued(X509_STORE_CTX *ctx, X509 *x, X509 *issuer)
 
         ss = cert_self_signed(ctx, x);
         if (ss < 0)
-            return X509_V_ERR_UNSPECIFIED;
+            return 0;
 
         /* Special case: single self signed certificate */
         if (ss > 0 && sk_X509_num(ctx->chain) == 1)

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -53,7 +53,7 @@ by X509_verify_cert().
 
 X509_STORE_CTX_new_with_libctx() returns a newly initialised B<X509_STORE_CTX>
 structure associated with the specified library context I<libctx> and property
-quuery string I<propq>. Any cryptographic algorithms fetched while performing
+query string I<propq>. Any cryptographic algorithms fetched while performing
 processing with the X509_STORE_CTX will use that library context and property
 query string.
 

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -2,9 +2,9 @@
 
 =head1 NAME
 
-X509_STORE_CTX_new, X509_STORE_CTX_cleanup, X509_STORE_CTX_free,
-X509_STORE_CTX_init, X509_STORE_CTX_set0_trusted_stack, X509_STORE_CTX_set_cert,
-X509_STORE_CTX_set0_crls,
+X509_STORE_CTX_new_with_libctx, X509_STORE_CTX_new, X509_STORE_CTX_cleanup,
+X509_STORE_CTX_free, X509_STORE_CTX_init, X509_STORE_CTX_set0_trusted_stack,
+X509_STORE_CTX_set_cert, X509_STORE_CTX_set0_crls,
 X509_STORE_CTX_get0_chain, X509_STORE_CTX_set0_verified_chain,
 X509_STORE_CTX_get0_param, X509_STORE_CTX_set0_param,
 X509_STORE_CTX_get0_untrusted, X509_STORE_CTX_set0_untrusted,
@@ -18,6 +18,8 @@ X509_STORE_CTX_verify_fn
 
  #include <openssl/x509_vfy.h>
 
+ X509_STORE_CTX *X509_STORE_CTX_new_with_libctx(OPENSSL_CTX *libctx,
+                                                const char *propq);
  X509_STORE_CTX *X509_STORE_CTX_new(void);
  void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
  void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
@@ -49,61 +51,68 @@ X509_STORE_CTX_verify_fn
 These functions initialise an B<X509_STORE_CTX> structure for subsequent use
 by X509_verify_cert().
 
-X509_STORE_CTX_new() returns a newly initialised B<X509_STORE_CTX> structure.
+X509_STORE_CTX_new_with_libctx() returns a newly initialised B<X509_STORE_CTX>
+structure associated with the specified library context I<libctx> and property
+quuery string I<propq>. Any cryptographic algorithms fetched while performing
+processing with the X509_STORE_CTX will use that library context and property
+query string.
+
+X509_STORE_CTX_new() is the same as X509_STORE_CTX_new_with_libctx() except that
+the default library context and a NULL property query string are used.
 
 X509_STORE_CTX_cleanup() internally cleans up an B<X509_STORE_CTX> structure.
 The context can then be reused with an new call to X509_STORE_CTX_init().
 
-X509_STORE_CTX_free() completely frees up B<ctx>. After this call B<ctx>
+X509_STORE_CTX_free() completely frees up I<ctx>. After this call I<ctx>
 is no longer valid.
-If B<ctx> is NULL nothing is done.
+If I<ctx> is NULL nothing is done.
 
-X509_STORE_CTX_init() sets up B<ctx> for a subsequent verification operation.
-It must be called before each call to X509_verify_cert(), i.e. a B<ctx> is only
+X509_STORE_CTX_init() sets up I<ctx> for a subsequent verification operation.
+It must be called before each call to X509_verify_cert(), i.e. a I<ctx> is only
 good for one call to X509_verify_cert(); if you want to verify a second
-certificate with the same B<ctx> then you must call X509_STORE_CTX_cleanup()
+certificate with the same I<ctx> then you must call X509_STORE_CTX_cleanup()
 and then X509_STORE_CTX_init() again before the second call to
-X509_verify_cert(). The trusted certificate store is set to B<store>, the end
-entity certificate to be verified is set to B<x509> and a set of additional
+X509_verify_cert(). The trusted certificate store is set to I<store>, the end
+entity certificate to be verified is set to I<x509> and a set of additional
 certificates (which will be untrusted but may be used to build the chain) in
-B<chain>. Any or all of the B<store>, B<x509> and B<chain> parameters can be
+I<chain>. Any or all of the I<store>, I<x509> and I<chain> parameters can be
 B<NULL>.
 
 X509_STORE_CTX_set0_trusted_stack() sets the set of trusted certificates of
-B<ctx> to B<sk>. This is an alternative way of specifying trusted certificates
+I<ctx> to I<sk>. This is an alternative way of specifying trusted certificates
 instead of using an B<X509_STORE>.
 
-X509_STORE_CTX_set_cert() sets the certificate to be verified in B<ctx> to
-B<x>.
+X509_STORE_CTX_set_cert() sets the certificate to be verified in I<ctx> to
+I<x>.
 
 X509_STORE_CTX_set0_verified_chain() sets the validated chain used
-by B<ctx> to be B<chain>.
-Ownership of the chain is transferred to B<ctx> and should not be
+by I<ctx> to be I<chain>.
+Ownership of the chain is transferred to I<ctx> and should not be
 free'd by the caller.
 X509_STORE_CTX_get0_chain() returns a the internal pointer used by the
-B<ctx> that contains the validated chain.
+I<ctx> that contains the validated chain.
 
 X509_STORE_CTX_set0_crls() sets a set of CRLs to use to aid certificate
-verification to B<sk>. These CRLs will only be used if CRL verification is
+verification to I<sk>. These CRLs will only be used if CRL verification is
 enabled in the associated B<X509_VERIFY_PARAM> structure. This might be
 used where additional "useful" CRLs are supplied as part of a protocol,
 for example in a PKCS#7 structure.
 
 X509_STORE_CTX_get0_param() retrieves an internal pointer
-to the verification parameters associated with B<ctx>.
+to the verification parameters associated with I<ctx>.
 
 X509_STORE_CTX_get0_untrusted() retrieves an internal pointer to the
-stack of untrusted certificates associated with B<ctx>.
+stack of untrusted certificates associated with I<ctx>.
 
 X509_STORE_CTX_set0_untrusted() sets the internal point to the stack
-of untrusted certificates associated with B<ctx> to B<sk>.
+of untrusted certificates associated with I<ctx> to I<sk>.
 
 X509_STORE_CTX_set0_param() sets the internal verification parameter pointer
-to B<param>. After this call B<param> should not be used.
+to I<param>. After this call B<param> should not be used.
 
 X509_STORE_CTX_set_default() looks up and sets the default verification
-method to B<name>. This uses the function X509_VERIFY_PARAM_lookup() to
-find an appropriate set of parameters from B<name>.
+method to I<name>. This uses the function X509_VERIFY_PARAM_lookup() to
+find an appropriate set of parameters from I<name>.
 
 X509_STORE_CTX_get_num_untrusted() returns the number of untrusted certificates
 that were used in building the chain following a call to X509_verify_cert().
@@ -161,6 +170,7 @@ L<X509_VERIFY_PARAM_set_flags(3)>
 
 The X509_STORE_CTX_set0_crls() function was added in OpenSSL 1.0.0.
 The X509_STORE_CTX_get_num_untrusted() function was added in OpenSSL 1.1.0.
+The X509_STORE_CTX_new_with_libctx() function was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -262,6 +262,9 @@ struct x509_store_ctx_st {      /* X509_STORE_CTX */
     SSL_DANE *dane;
     /* signed via bare TA public key, rather than CA certificate */
     int bare_ta_signed;
+
+    OPENSSL_CTX *libctx;
+    char *propq;
 };
 
 /* PKCS#8 private key info structure */

--- a/include/openssl/x509_vfy.h
+++ b/include/openssl/x509_vfy.h
@@ -352,6 +352,8 @@ X509_STORE_CTX_cleanup_fn X509_STORE_get_cleanup(const X509_STORE *ctx);
 int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data);
 void *X509_STORE_get_ex_data(const X509_STORE *ctx, int idx);
 
+X509_STORE_CTX *X509_STORE_CTX_new_with_libctx(OPENSSL_CTX *libctx,
+                                               const char *propq);
 X509_STORE_CTX *X509_STORE_CTX_new(void);
 
 int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x);

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -386,7 +386,7 @@ int ssl_verify_cert_chain(SSL *s, STACK_OF(X509) *sk)
     else
         verify_store = s->ctx->cert_store;
 
-    ctx = X509_STORE_CTX_new();
+    ctx = X509_STORE_CTX_new_with_libctx(s->ctx->libctx, s->ctx->propq);
     if (ctx == NULL) {
         SSLerr(SSL_F_SSL_VERIFY_CERT_CHAIN, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -869,7 +869,7 @@ int ssl_build_cert_chain(SSL *s, SSL_CTX *ctx, int flags)
             untrusted = cpk->chain;
     }
 
-    xs_ctx = X509_STORE_CTX_new();
+    xs_ctx = X509_STORE_CTX_new_with_libctx(s->ctx->libctx, s->ctx->propq);
     if (xs_ctx == NULL) {
         SSLerr(SSL_F_SSL_BUILD_CERT_CHAIN, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -1055,8 +1055,14 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
     int j;
     int rv;
     CERT *c = ssl != NULL ? ssl->cert : ctx->cert;
+    SSL_CTX *actualctx = ssl == NULL ? ctx : ssl->ctx;
     STACK_OF(X509) *dup_chain = NULL;
     EVP_PKEY *pubkey = NULL;
+
+    if (!X509v3_cache_extensions(x509, actualctx->libctx, actualctx->propq)) {
+        SSLerr(0, ERR_R_X509_LIB);
+        goto out;
+    }
 
     /* Do all security checks before anything else */
     rv = ssl_security_cert(ssl, ctx, x509, 0, 1);

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -953,7 +953,8 @@ static int ssl_add_cert_chain(SSL *s, WPACKET *pkt, CERT_PKEY *cpk)
         chain_store = s->ctx->cert_store;
 
     if (chain_store != NULL) {
-        X509_STORE_CTX *xs_ctx = X509_STORE_CTX_new();
+        X509_STORE_CTX *xs_ctx = X509_STORE_CTX_new_with_libctx(s->ctx->libctx,
+                                                                s->ctx->propq);
 
         if (xs_ctx == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_ADD_CERT_CHAIN,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5036,3 +5036,4 @@ EVP_PKEY_get_size_t_param               ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_bn_param                   ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_utf8_string_param          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_octet_string_param         ?	3_0_0	EXIST::FUNCTION:
+X509_STORE_CTX_new_with_libctx          ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
We introduce X509_STORE_CTX_with_libctx() so that we can make subsequent operations that use the X509_STORE_CTX library context aware. We then use this new function in libssl, which is already library context aware.

Finally we also fix a related issue in libssl where there was a missing call to X509v3_cache_extensions().