### PR TITLE
sslapitest: only compile test when it will be used

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -649,7 +649,6 @@ end:
 
     return testresult;
 }
-#endif
 
 /*
  * Very focused test to exercise a single case in the server-side state
@@ -761,6 +760,7 @@ end:
 
     return testresult;
 }
+#endif
 
 static int execute_test_large_message(const SSL_METHOD *smeth,
                                       const SSL_METHOD *cmeth,


### PR DESCRIPTION
The test_ccs_change_cipher() test routine is used only when TLS 1.2
is enabled; to fix the strict-warnings build we should not try to
compile it when TLS 1.2 is disabled, either.

