### PR TITLE
Expand the XTS documentation

### DIFF
--- a/doc/man3/EVP_aes_128_gcm.pod
+++ b/doc/man3/EVP_aes_128_gcm.pod
@@ -160,6 +160,13 @@ In particular, XTS-AES-128 (B<EVP_aes_128_xts>) takes input of a 256-bit key to
 achieve AES 128-bit security, and XTS-AES-256 (B<EVP_aes_256_xts>) takes input
 of a 512-bit key to achieve AES 256-bit security.
 
+The XTS implementation in OpenSSL does not support streaming. That is there must
+only be one L<EVP_EncryptUpdate(3)> call per L<EVP_EncryptInit_ex(3)> call (and
+similarly with the "Decrypt" functions).
+
+The I<iv> parameter to L<EVP_EncryptInit_ex(3)> or L<EVP_DecryptInit_ex(3)> is
+the XTS "tweak" value.
+
 =back
 
 =head1 RETURN VALUES


### PR DESCRIPTION
Explain that XTS does not support streaming, and that the IV value is the
tweak.
