### PR TITLE
Enable WPACKET to write to the end of the buffer first

### DIFF
--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -65,8 +65,11 @@ int WPACKET_reserve_bytes(WPACKET *pkt, size_t len, unsigned char **allocbytes)
         if (BUF_MEM_grow(pkt->buf, newlen) == 0)
             return 0;
     }
-    if (allocbytes != NULL)
+    if (allocbytes != NULL) {
         *allocbytes = WPACKET_get_curr(pkt);
+        if (pkt->endfirst)
+            *allocbytes -= len;
+    }
 
     return 1;
 }
@@ -74,6 +77,9 @@ int WPACKET_reserve_bytes(WPACKET *pkt, size_t len, unsigned char **allocbytes)
 int WPACKET_sub_reserve_bytes__(WPACKET *pkt, size_t len,
                                 unsigned char **allocbytes, size_t lenbytes)
 {
+    if (pkt->endfirst && lenbytes > 0)
+        return 0;
+
     if (!WPACKET_reserve_bytes(pkt, lenbytes + len, allocbytes))
         return 0;
 
@@ -131,8 +137,23 @@ int WPACKET_init_static_len(WPACKET *pkt, unsigned char *buf, size_t len,
     pkt->staticbuf = buf;
     pkt->buf = NULL;
     pkt->maxsize = (max < len) ? max : len;
+    pkt->endfirst = 0;
 
     return wpacket_intern_init_len(pkt, lenbytes);
+}
+
+int WPACKET_init_der(WPACKET *pkt, unsigned char *buf, size_t len)
+{
+    /* Internal API, so should not fail */
+    if (!ossl_assert(buf != NULL && len > 0))
+        return 0;
+
+    pkt->staticbuf = buf;
+    pkt->buf = NULL;
+    pkt->maxsize = len;
+    pkt->endfirst = 1;
+
+    return wpacket_intern_init_len(pkt, 0);
 }
 
 int WPACKET_init_len(WPACKET *pkt, BUF_MEM *buf, size_t lenbytes)
@@ -144,6 +165,7 @@ int WPACKET_init_len(WPACKET *pkt, BUF_MEM *buf, size_t lenbytes)
     pkt->staticbuf = NULL;
     pkt->buf = buf;
     pkt->maxsize = maxmaxsize(lenbytes);
+    pkt->endfirst = 0;
 
     return wpacket_intern_init_len(pkt, lenbytes);
 }
@@ -158,6 +180,7 @@ int WPACKET_init_null(WPACKET *pkt, size_t lenbytes)
     pkt->staticbuf = NULL;
     pkt->buf = NULL;
     pkt->maxsize = maxmaxsize(lenbytes);
+    pkt->endfirst = 0;
 
     return wpacket_intern_init_len(pkt, 0);
 }
@@ -232,6 +255,19 @@ static int wpacket_intern_close(WPACKET *pkt, WPACKET_SUB *sub, int doclose)
                 && !put_value(&buf[sub->packet_len], packlen,
                               sub->lenbytes))
             return 0;
+    } else if (pkt->endfirst && sub->parent != NULL) {
+        size_t tmplen = packlen;
+        size_t numlenbytes = 1;
+
+        while ((tmplen = tmplen >> 8) > 0)
+            numlenbytes++;
+        if (!WPACKET_put_bytes__(pkt, packlen, numlenbytes))
+            return 0;
+        if (packlen > 0x7f) {
+            numlenbytes |= 0x80;
+            if (!WPACKET_put_bytes_u8(pkt, numlenbytes))
+                return 0;
+        }
     }
 
     if (doclose) {
@@ -296,6 +332,10 @@ int WPACKET_start_sub_packet_len__(WPACKET *pkt, size_t lenbytes)
 
     /* Internal API, so should not fail */
     if (!ossl_assert(pkt->subs != NULL))
+        return 0;
+
+    /* We don't support lenbytes greater than 0 when doing endfirst writing */
+    if (lenbytes > 0 && pkt->endfirst)
         return 0;
 
     if ((sub = OPENSSL_zalloc(sizeof(*sub))) == NULL) {
@@ -435,6 +475,9 @@ unsigned char *WPACKET_get_curr(WPACKET *pkt)
 
     if (buf == NULL)
         return NULL;
+
+    if (pkt->endfirst)
+        return buf + pkt->maxsize - pkt->curr;
 
     return buf + pkt->curr;
 }

--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -67,7 +67,7 @@ int WPACKET_reserve_bytes(WPACKET *pkt, size_t len, unsigned char **allocbytes)
     }
     if (allocbytes != NULL) {
         *allocbytes = WPACKET_get_curr(pkt);
-        if (pkt->endfirst)
+        if (pkt->endfirst && *allocbytes != NULL)
             *allocbytes -= len;
     }
 
@@ -181,6 +181,16 @@ int WPACKET_init_null(WPACKET *pkt, size_t lenbytes)
     pkt->buf = NULL;
     pkt->maxsize = maxmaxsize(lenbytes);
     pkt->endfirst = 0;
+
+    return wpacket_intern_init_len(pkt, 0);
+}
+
+int WPACKET_init_null_der(WPACKET *pkt)
+{
+    pkt->staticbuf = NULL;
+    pkt->buf = NULL;
+    pkt->maxsize = SIZE_MAX;
+    pkt->endfirst = 1;
 
     return wpacket_intern_init_len(pkt, 0);
 }

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -680,6 +680,12 @@ int WPACKET_init(WPACKET *pkt, BUF_MEM *buf);
 int WPACKET_init_null(WPACKET *pkt, size_t lenbytes);
 
 /*
+ * Same as WPACKET_init_null except we set the WPACKET to assume DER length
+ * encoding for sub-packets.
+ */
+int WPACKET_init_null_der(WPACKET *pkt);
+
+/*
  * Same as WPACKET_init_len except we do not use a growable BUF_MEM structure.
  * A fixed buffer of memory |buf| of size |len| is used instead. A failure will
  * occur if you attempt to write beyond the end of the buffer
@@ -689,7 +695,8 @@ int WPACKET_init_static_len(WPACKET *pkt, unsigned char *buf, size_t len,
 
 /*
  * Same as WPACKET_init_static_len except lenbytes is always 0, and we set the
- * WPACKET to write to the end of the buffer moving towards the start.
+ * WPACKET to write to the end of the buffer moving towards the start and use
+ * DER length encoding for sub-packets.
  */
 int WPACKET_init_der(WPACKET *pkt, unsigned char *buf, size_t len);
 

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -638,6 +638,9 @@ struct wpacket_st {
 
     /* Our sub-packets (always at least one if not finished) */
     WPACKET_SUB *subs;
+
+    /* Writing from the end first? */
+    unsigned int endfirst : 1;
 };
 
 /* Flags */
@@ -683,6 +686,13 @@ int WPACKET_init_null(WPACKET *pkt, size_t lenbytes);
  */
 int WPACKET_init_static_len(WPACKET *pkt, unsigned char *buf, size_t len,
                             size_t lenbytes);
+
+/*
+ * Same as WPACKET_init_static_len except lenbytes is always 0, and we set the
+ * WPACKET to write to the end of the buffer moving towards the start.
+ */
+int WPACKET_init_der(WPACKET *pkt, unsigned char *buf, size_t len);
+
 /*
  * Set the flags to be applied to the current sub-packet
  */


### PR DESCRIPTION
This adds the ability to WPACKET to write to the end of the buffer first and fill the buffer backwards. It also adds the ability to support DER style length encoding.