### PR TITLE
Fix R_AARCH64_PREL64 relocation error when statically linking on aarch64

### DIFF
--- a/crypto/sha/asm/sha1-armv8.pl
+++ b/crypto/sha/asm/sha1-armv8.pl
@@ -324,7 +324,7 @@ $code.=<<___;
 .asciz	"SHA1 block transform for ARMv8, CRYPTOGAMS by <appro\@openssl.org>"
 .align	2
 #if !defined(__KERNELL__) && !defined(_WIN64)
-.comm	OPENSSL_armcap_P,4,4
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 }}}

--- a/crypto/sha/asm/sha512-armv8.pl
+++ b/crypto/sha/asm/sha512-armv8.pl
@@ -831,7 +831,7 @@ ___
 
 $code.=<<___;
 #if !defined(__KERNEL__) && !defined(_WIN64)
-.comm	OPENSSL_armcap_P,4,4
+.hidden	OPENSSL_armcap_P
 #endif
 ___
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This PR fixes the first half of https://github.com/openssl/openssl/issues/10842. The second half (relocations in poly1305-armv8) was apparently already fixed in an almost identical manner to my proposed patch in https://github.com/openssl/openssl/commit/db42bb440e76399b89fc8ae04644441a2a5f6821.
