### PR TITLE
params: avoid a core dump with a null pointer and a get string call

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -778,6 +778,8 @@ static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
 
     if (sz == 0)
         return 1;
+    if (p->data == NULL)
+        return 0;
 
     if (*val == NULL) {
         char *const q = OPENSSL_malloc(sz);


### PR DESCRIPTION
Rather than seg faulting, set the param size and return a failure.

- [ ] documentation is added or updated
- [ ] tests are added or updated
