### PR TITLE
params: add a warning about the PTR types.

### DIFF
--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -159,6 +159,9 @@ The parameter data is a pointer to a printable string.
 The difference between this and B<OSSL_PARAM_UTF8_STRING> is that I<data>
 doesn't point directly at the data, but to a pointer that points to the data.
 
+If there is any uncertainty about which to use, B<OSSL_PARAM_UTF8_STRING> is
+almost certainly the correct choice.
+
 This is used to indicate that constant data is or will be passed,
 and there is therefore no need to copy the data that is passed, just
 the pointer to it.
@@ -181,6 +184,9 @@ The parameter data is a pointer to an arbitrary string of bytes.
 The difference between this and B<OSSL_PARAM_OCTET_STRING> is that
 I<data> doesn't point directly at the data, but to a pointer that
 points to the data.
+
+If there is any uncertainty about which to use, B<OSSL_PARAM_OCTET_STRING> is
+almost certainly the correct choice.
 
 This is used to indicate that constant data is or will be passed, and
 there is therefore no need to copy the data that is passed, just the

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -125,8 +125,8 @@ struct ossl_param_st {
  * WARNING!  Using these is FRAGILE, as it assumes that the actual
  * data and its location are constant.
  *
- * EXTRA WARNING!  If you think you should use this type, you most
- * likely want to use the OSSL_PARAM_UTF8_STRING type instead.
+ * EXTRA WARNING!  If you are not completely sure you most likely want
+ * to use the OSSL_PARAM_UTF8_STRING type.
  */
 # define OSSL_PARAM_UTF8_PTR             6
 /*-
@@ -144,8 +144,8 @@ struct ossl_param_st {
  * WARNING!  Using these is FRAGILE, as it assumes that the actual
  * data and its location are constant.
  *
- * EXTRA WARNING!  If you think you should use this type, you most
- * likely want to use the OSSL_PARAM_OCTET_STRING type instead.
+ * EXTRA WARNING!  If you are not completely sure you most likely want
+ * to use the OSSL_PARAM_OCTET_STRING type.
  */
 # define OSSL_PARAM_OCTET_PTR            7
 

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -124,6 +124,9 @@ struct ossl_param_st {
  *
  * WARNING!  Using these is FRAGILE, as it assumes that the actual
  * data and its location are constant.
+ *
+ * EXTRA WARNING!  If you think you should use this type, you most
+ * likely want to use the OSSL_PARAM_UTF8_STRING type instead.
  */
 # define OSSL_PARAM_UTF8_PTR             6
 /*-
@@ -140,6 +143,9 @@ struct ossl_param_st {
  *
  * WARNING!  Using these is FRAGILE, as it assumes that the actual
  * data and its location are constant.
+ *
+ * EXTRA WARNING!  If you think you should use this type, you most
+ * likely want to use the OSSL_PARAM_OCTET_STRING type instead.
  */
 # define OSSL_PARAM_OCTET_PTR            7
 


### PR DESCRIPTION
The warning is to deter the unsure -- if in doubt the PTR type is almost certainly
**not** what you should be using.

- [x] documentation is added or updated
- [ ] tests are added or updated
