### PR TITLE
Minor SSL_CTX_sessions DOC improvement

### DIFF
--- a/doc/man3/SSL_CTX_sessions.pod
+++ b/doc/man3/SSL_CTX_sessions.pod
@@ -8,7 +8,7 @@ SSL_CTX_sessions - access internal session cache
 
  #include <openssl/ssl.h>
 
- struct lhash_st *SSL_CTX_sessions(SSL_CTX *ctx);
+ LHASH_OF(SSL_SESSION) *SSL_CTX_sessions(SSL_CTX *ctx);
 
 =head1 DESCRIPTION
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -351,6 +351,7 @@ sub name_synopsis {
 
         my $sym;
         my $is_prototype = 1;
+        $line =~ s/LHASH_OF\([^)]+\)/int/g;
         $line =~ s/STACK_OF\([^)]+\)/int/g;
         $line =~ s/SPARSE_ARRAY_OF\([^)]+\)/int/g;
         $line =~ s/__declspec\([^)]+\)//;


### PR DESCRIPTION
use LHASH_OF(TYPE) macro to make the example consistent with the declaration in ssl.h