### PR TITLE
Update the CT code to be library context aware

### DIFF
--- a/crypto/ct/ct_local.h
+++ b/crypto/ct/ct_local.h
@@ -100,6 +100,9 @@ struct sct_ctx_st {
     size_t prederlen;
     /* milliseconds since epoch (to check that the SCT isn't from the future) */
     uint64_t epoch_time_in_ms;
+
+    OPENSSL_CTX *libctx;
+    char *propq;
 };
 
 /* Context when evaluating whether a Certificate Transparency policy is met */
@@ -109,12 +112,15 @@ struct ct_policy_eval_ctx_st {
     CTLOG_STORE *log_store;
     /* milliseconds since epoch (to check that SCTs aren't from the future) */
     uint64_t epoch_time_in_ms;
+
+    OPENSSL_CTX *libctx;
+    char *propq;
 };
 
 /*
  * Creates a new context for verifying an SCT.
  */
-SCT_CTX *SCT_CTX_new(void);
+SCT_CTX *SCT_CTX_new(OPENSSL_CTX *ctx, const char *propq);
 /*
  * Deletes an SCT verification context.
  */

--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -112,13 +112,17 @@ CTLOG_STORE *CTLOG_STORE_new_with_libctx(OPENSSL_CTX *libctx, const char *propq)
     ret->libctx = libctx;
     if (propq != NULL) {
         ret->propq = OPENSSL_strdup(propq);
-        if (ret->propq == NULL)
+        if (ret->propq == NULL) {
+            CTerr(0, ERR_R_MALLOC_FAILURE);
             goto err;
+        }
     }
 
     ret->logs = sk_CTLOG_new_null();
-    if (ret->logs == NULL)
+    if (ret->logs == NULL) {
+        CTerr(0, ERR_R_MALLOC_FAILURE);
         goto err;
+    }
 
     return ret;
 err:

--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -22,6 +22,8 @@
  * Information about a CT log server.
  */
 struct ctlog_st {
+    OPENSSL_CTX *libctx;
+    char *propq;
     char *name;
     uint8_t log_id[CT_V1_HASHLEN];
     EVP_PKEY *public_key;
@@ -32,6 +34,8 @@ struct ctlog_st {
  * It takes ownership of any CTLOG instances added to it.
  */
 struct ctlog_store_st {
+    OPENSSL_CTX *libctx;
+    char *propq;
     STACK_OF(CTLOG) *logs;
 };
 
@@ -70,32 +74,46 @@ static void ctlog_store_load_ctx_free(CTLOG_STORE_LOAD_CTX* ctx)
 }
 
 /* Converts a log's public key into a SHA256 log ID */
-static int ct_v1_log_id_from_pkey(EVP_PKEY *pkey,
-                                  unsigned char log_id[CT_V1_HASHLEN])
+static int ct_v1_log_id_from_pkey(CTLOG *log, EVP_PKEY *pkey)
 {
     int ret = 0;
     unsigned char *pkey_der = NULL;
     int pkey_der_len = i2d_PUBKEY(pkey, &pkey_der);
     unsigned int len;
+    EVP_MD *sha256 = NULL;
 
     if (pkey_der_len <= 0) {
         CTerr(CT_F_CT_V1_LOG_ID_FROM_PKEY, CT_R_LOG_KEY_INVALID);
         goto err;
     }
+    sha256 = EVP_MD_fetch(log->libctx, "SHA2-256", log->propq);
+    if (sha256 == NULL) {
+        CTerr(CT_F_CT_V1_LOG_ID_FROM_PKEY, ERR_LIB_EVP);
+        goto err;
+    }
 
-    ret = EVP_Digest(pkey_der, pkey_der_len, log_id, &len, EVP_sha256(), NULL);
+    ret = EVP_Digest(pkey_der, pkey_der_len, log->log_id, &len, sha256,
+                     NULL);
 err:
+    EVP_MD_free(sha256);
     OPENSSL_free(pkey_der);
     return ret;
 }
 
-CTLOG_STORE *CTLOG_STORE_new(void)
+CTLOG_STORE *CTLOG_STORE_new_with_libctx(OPENSSL_CTX *libctx, const char *propq)
 {
     CTLOG_STORE *ret = OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
-        CTerr(CT_F_CTLOG_STORE_NEW, ERR_R_MALLOC_FAILURE);
+        CTerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
+
+    ret->libctx = libctx;
+    if (propq != NULL) {
+        ret->propq = OPENSSL_strdup(propq);
+        if (ret->propq == NULL)
+            goto err;
     }
 
     ret->logs = sk_CTLOG_new_null();
@@ -104,19 +122,26 @@ CTLOG_STORE *CTLOG_STORE_new(void)
 
     return ret;
 err:
-    OPENSSL_free(ret);
+    CTLOG_STORE_free(ret);
     return NULL;
+}
+
+CTLOG_STORE *CTLOG_STORE_new(void)
+{
+    return CTLOG_STORE_new_with_libctx(NULL, NULL);
 }
 
 void CTLOG_STORE_free(CTLOG_STORE *store)
 {
     if (store != NULL) {
+        OPENSSL_free(store->propq);
         sk_CTLOG_pop_free(store->logs, CTLOG_free);
         OPENSSL_free(store);
     }
 }
 
-static int ctlog_new_from_conf(CTLOG **ct_log, const CONF *conf, const char *section)
+static int ctlog_new_from_conf(CTLOG_STORE *store, CTLOG **ct_log,
+                               const CONF *conf, const char *section)
 {
     const char *description = NCONF_get_string(conf, section, "description");
     char *pkey_base64;
@@ -132,7 +157,8 @@ static int ctlog_new_from_conf(CTLOG **ct_log, const CONF *conf, const char *sec
         return 0;
     }
 
-    return CTLOG_new_from_base64(ct_log, pkey_base64, description);
+    return CTLOG_new_from_base64_with_libctx(ct_log, pkey_base64, description,
+                                             store->libctx, store->propq);
 }
 
 int CTLOG_STORE_load_default_file(CTLOG_STORE *store)
@@ -168,7 +194,7 @@ static int ctlog_store_load_log(const char *log_name, int log_name_len,
     if (tmp == NULL)
         goto mem_err;
 
-    ret = ctlog_new_from_conf(&ct_log, load_ctx->conf, tmp);
+    ret = ctlog_new_from_conf(load_ctx->log_store, &ct_log, load_ctx->conf, tmp);
     OPENSSL_free(tmp);
 
     if (ret < 0) {
@@ -234,22 +260,32 @@ end:
  * Takes ownership of the public key.
  * Copies the name.
  */
-CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name)
+CTLOG *CTLOG_new_with_libctx(EVP_PKEY *public_key, const char *name,
+                             OPENSSL_CTX *libctx, const char *propq)
 {
     CTLOG *ret = OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
-        CTerr(CT_F_CTLOG_NEW, ERR_R_MALLOC_FAILURE);
+        CTerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
+
+    ret->libctx = libctx;
+    if (propq != NULL) {
+        ret->name = OPENSSL_strdup(propq);
+        if (ret->propq == NULL) {
+            CTerr(0, ERR_R_MALLOC_FAILURE);
+            goto err;
+        }
     }
 
     ret->name = OPENSSL_strdup(name);
     if (ret->name == NULL) {
-        CTerr(CT_F_CTLOG_NEW, ERR_R_MALLOC_FAILURE);
+        CTerr(0, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
-    if (ct_v1_log_id_from_pkey(public_key, ret->log_id) != 1)
+    if (ct_v1_log_id_from_pkey(ret, public_key) != 1)
         goto err;
 
     ret->public_key = public_key;
@@ -259,12 +295,18 @@ err:
     return NULL;
 }
 
+CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name)
+{
+    return CTLOG_new_with_libctx(public_key, name, NULL, NULL);
+}
+
 /* Frees CT log and associated structures */
 void CTLOG_free(CTLOG *log)
 {
     if (log != NULL) {
         OPENSSL_free(log->name);
         EVP_PKEY_free(log->public_key);
+        OPENSSL_free(log->propq);
         OPENSSL_free(log);
     }
 }

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -25,13 +25,23 @@
  */
 static const time_t SCT_CLOCK_DRIFT_TOLERANCE = 300;
 
-CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
+CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_with_libctx(OPENSSL_CTX *libctx,
+                                                       const char *propq)
 {
     CT_POLICY_EVAL_CTX *ctx = OPENSSL_zalloc(sizeof(CT_POLICY_EVAL_CTX));
 
     if (ctx == NULL) {
-        CTerr(CT_F_CT_POLICY_EVAL_CTX_NEW, ERR_R_MALLOC_FAILURE);
+        CTerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
+
+    ctx->libctx = libctx;
+    if (propq != NULL) {
+        ctx->propq = OPENSSL_strdup(propq);
+        if (ctx->propq == NULL) {
+            CTerr(0, ERR_R_MALLOC_FAILURE);
+            return NULL;
+        }
     }
 
     /* time(NULL) shouldn't ever fail, so don't bother checking for -1. */
@@ -41,12 +51,18 @@ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
     return ctx;
 }
 
+CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void)
+{
+    return CT_POLICY_EVAL_CTX_new_with_libctx(NULL, NULL);
+}
+
 void CT_POLICY_EVAL_CTX_free(CT_POLICY_EVAL_CTX *ctx)
 {
     if (ctx == NULL)
         return;
     X509_free(ctx->cert);
     X509_free(ctx->issuer);
+    OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
 }
 

--- a/crypto/ct/ct_sct.c
+++ b/crypto/ct/ct_sct.c
@@ -312,7 +312,7 @@ int SCT_validate(SCT *sct, const CT_POLICY_EVAL_CTX *ctx)
         return 0;
     }
 
-    sctx = SCT_CTX_new();
+    sctx = SCT_CTX_new(ctx->libctx, ctx->propq);
     if (sctx == NULL)
         goto err;
 

--- a/crypto/ct/ct_sct_ctx.c
+++ b/crypto/ct/ct_sct_ctx.c
@@ -20,12 +20,22 @@
 
 #include "ct_local.h"
 
-SCT_CTX *SCT_CTX_new(void)
+SCT_CTX *SCT_CTX_new(OPENSSL_CTX *libctx, const char *propq)
 {
     SCT_CTX *sctx = OPENSSL_zalloc(sizeof(*sctx));
 
     if (sctx == NULL)
         CTerr(CT_F_SCT_CTX_NEW, ERR_R_MALLOC_FAILURE);
+
+    sctx->libctx = libctx;
+    if (propq != NULL) {
+        sctx->propq = OPENSSL_strdup(propq);
+        if (sctx->propq == NULL) {
+            CTerr(CT_F_SCT_CTX_NEW, ERR_R_MALLOC_FAILURE);
+            OPENSSL_free(sctx);
+            return NULL;
+        }
+    }
 
     return sctx;
 }
@@ -39,6 +49,7 @@ void SCT_CTX_free(SCT_CTX *sctx)
     OPENSSL_free(sctx->ihash);
     OPENSSL_free(sctx->certder);
     OPENSSL_free(sctx->preder);
+    OPENSSL_free(sctx->propq);
     OPENSSL_free(sctx);
 }
 
@@ -191,13 +202,17 @@ err:
     return 0;
 }
 
-__owur static int ct_public_key_hash(X509_PUBKEY *pkey, unsigned char **hash,
-                                     size_t *hash_len)
+__owur static int ct_public_key_hash(SCT_CTX *sctx, X509_PUBKEY *pkey,
+                                     unsigned char **hash, size_t *hash_len)
 {
     int ret = 0;
     unsigned char *md = NULL, *der = NULL;
     int der_len;
     unsigned int md_len;
+    EVP_MD *sha256 = EVP_MD_fetch(sctx->libctx, "SHA2-256", sctx->propq);
+
+    if (sha256 == NULL)
+        goto err;
 
     /* Reuse buffer if possible */
     if (*hash != NULL && *hash_len >= SHA256_DIGEST_LENGTH) {
@@ -213,7 +228,7 @@ __owur static int ct_public_key_hash(X509_PUBKEY *pkey, unsigned char **hash,
     if (der_len <= 0)
         goto err;
 
-    if (!EVP_Digest(der, der_len, md, &md_len, EVP_sha256(), NULL))
+    if (!EVP_Digest(der, der_len, md, &md_len, sha256, NULL))
         goto err;
 
     if (md != *hash) {
@@ -225,6 +240,7 @@ __owur static int ct_public_key_hash(X509_PUBKEY *pkey, unsigned char **hash,
     md = NULL;
     ret = 1;
  err:
+    EVP_MD_free(sha256);
     OPENSSL_free(md);
     OPENSSL_free(der);
     return ret;
@@ -237,7 +253,7 @@ int SCT_CTX_set1_issuer(SCT_CTX *sctx, const X509 *issuer)
 
 int SCT_CTX_set1_issuer_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey)
 {
-    return ct_public_key_hash(pubkey, &sctx->ihash, &sctx->ihashlen);
+    return ct_public_key_hash(sctx, pubkey, &sctx->ihash, &sctx->ihashlen);
 }
 
 int SCT_CTX_set1_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey)
@@ -247,7 +263,7 @@ int SCT_CTX_set1_pubkey(SCT_CTX *sctx, X509_PUBKEY *pubkey)
     if (pkey == NULL)
         return 0;
 
-    if (!ct_public_key_hash(pubkey, &sctx->pkeyhash, &sctx->pkeyhashlen)) {
+    if (!ct_public_key_hash(sctx, pubkey, &sctx->pkeyhash, &sctx->pkeyhashlen)) {
         EVP_PKEY_free(pkey);
         return 0;
     }

--- a/crypto/ct/ct_vfy.c
+++ b/crypto/ct/ct_vfy.c
@@ -122,7 +122,8 @@ int SCT_CTX_verify(const SCT_CTX *sctx, const SCT *sct)
     if (ctx == NULL)
         goto end;
 
-    if (!EVP_DigestVerifyInit(ctx, NULL, EVP_sha256(), NULL, sctx->pkey))
+    if (!EVP_DigestVerifyInit_ex(ctx, NULL, "SHA2-256", sctx->propq, sctx->pkey,
+                                 sctx->libctx))
         goto end;
 
     if (!sct_ctx_update(ctx, sctx, sct))

--- a/doc/man3/CTLOG_STORE_new.pod
+++ b/doc/man3/CTLOG_STORE_new.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+CTLOG_STORE_new_with_libctx,
 CTLOG_STORE_new, CTLOG_STORE_free,
 CTLOG_STORE_load_default_file, CTLOG_STORE_load_file -
 Create and populate a Certificate Transparency log list
@@ -10,6 +11,8 @@ Create and populate a Certificate Transparency log list
 
  #include <openssl/ct.h>
 
+ CTLOG_STORE *CTLOG_STORE_new_with_libctx(OPENSSL_CTX *libctx,
+                                          const char *propq);
  CTLOG_STORE *CTLOG_STORE_new(void);
  void CTLOG_STORE_free(CTLOG_STORE *store);
 
@@ -22,13 +25,19 @@ A CTLOG_STORE is a container for a list of CTLOGs (Certificate Transparency
 logs). The list can be loaded from one or more files and then searched by LogID
 (see RFC 6962, Section 3.2, for the definition of a LogID).
 
-CTLOG_STORE_new() creates an empty list of CT logs. This is then populated
-by CTLOG_STORE_load_default_file() or CTLOG_STORE_load_file().
-CTLOG_STORE_load_default_file() loads from the default file, which is named
-F<ct_log_list.cnf> in OPENSSLDIR (see the output of L<openssl-version(1)>).
-This can be overridden using an environment variable named B<CTLOG_FILE>.
-CTLOG_STORE_load_file() loads from a caller-specified file path instead.
-Both of these functions append any loaded CT logs to the CTLOG_STORE.
+CTLOG_STORE_new_with_libctx() creates an empty list of CT logs associated with
+the library context I<libctx> and the property query string I<propq>.
+
+CTLOG_STORE_new() does the same thing as CTLOG_STORE_new_with_libctx() but with
+the default library context and property query string.
+
+The CTLOG_STORE is then populated by CTLOG_STORE_load_default_file() or
+CTLOG_STORE_load_file(). CTLOG_STORE_load_default_file() loads from the default
+file, which is named F<ct_log_list.cnf> in OPENSSLDIR (see the output of
+L<openssl-version(1)>). This can be overridden using an environment variable
+named B<CTLOG_FILE>. CTLOG_STORE_load_file() loads from a caller-specified file
+path instead. Both of these functions append any loaded CT logs to the
+CTLOG_STORE.
 
 The expected format of the file is:
 
@@ -65,7 +74,8 @@ L<SSL_CTX_set_ctlog_list_file(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.1.0.
+CTLOG_STORE_new_with_libctx was added in OpenSSL 3.0. All other functions were
+added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CTLOG_new.pod
+++ b/doc/man3/CTLOG_new.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-CTLOG_new, CTLOG_new_from_base64, CTLOG_free,
+CTLOG_new_with_libctx, CTLOG_new, CTLOG_new_from_base64,
+CTLOG_new_from_base64_with_libctx, CTLOG_free,
 CTLOG_get0_name, CTLOG_get0_log_id, CTLOG_get0_public_key -
 encapsulates information about a Certificate Transparency log
 
@@ -10,7 +11,13 @@ encapsulates information about a Certificate Transparency log
 
  #include <openssl/ct.h>
 
+ CTLOG *CTLOG_new_with_libctx(EVP_PKEY *public_key, const char *name,
+                              OPENSSL_CTX *libctx, const char *propq);
  CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
+
+ int CTLOG_new_from_base64_with_libctx(CTLOG **ct_log, const char *pkey_base64,
+                                       const char *name, OPENSSL_CTX *libctx,
+                                       const char *propq);
  int CTLOG_new_from_base64(CTLOG ** ct_log,
                            const char *pkey_base64, const char *name);
  void CTLOG_free(CTLOG *log);
@@ -21,14 +28,24 @@ encapsulates information about a Certificate Transparency log
 
 =head1 DESCRIPTION
 
-CTLOG_new() returns a new CTLOG that represents the Certificate Transparency
-(CT) log with the given public key. A name must also be provided that can be
-used to help users identify this log. Ownership of the public key is
-transferred.
+CTLOG_new_with_libctx() returns a new CTLOG that represents the Certificate
+Transparency (CT) log with the given public key and associates it with the
+library context I<libctx> and property query string I<propq>. A name must also
+be provided that can be used to help users identify this log. Ownership of the
+public key is transferred.
 
-CTLOG_new_from_base64() also creates a new CTLOG, but takes the public key in
-base64-encoded DER form and sets the ct_log pointer to point to the new CTLOG.
-The base64 will be decoded and the public key parsed.
+CTLOG_new() does the same thing as CTLOG_new_with_libctx() but with the default
+library context and the default property query string.
+
+CTLOG_new_from_base64_with_libctx() also creates a new CTLOG, but takes the
+public key in base64-encoded DER form and sets the ct_log pointer to point to
+the new CTLOG. The base64 will be decoded and the public key parsed. The CTLOG
+will be associated with the give library context I<libctx> and property query
+string I<propq>.
+
+CTLOG_new_from_base64() does the same thing as
+CTLOG_new_from_base64_with_libctx() except that the default library context and
+property query string are used.
 
 Regardless of whether CTLOG_new() or CTLOG_new_from_base64() is used, it is the
 caller's responsibility to pass the CTLOG to CTLOG_free() once it is no longer
@@ -58,7 +75,8 @@ L<ct(7)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.1.0.
+The functions CTLOG_new_with_libctx() and CTLOG_new_from_base64_with_libctx()
+were added in OpenSSL 3.0. All other functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/CTLOG_new.pod
+++ b/doc/man3/CTLOG_new.pod
@@ -40,7 +40,7 @@ library context and the default property query string.
 CTLOG_new_from_base64_with_libctx() also creates a new CTLOG, but takes the
 public key in base64-encoded DER form and sets the ct_log pointer to point to
 the new CTLOG. The base64 will be decoded and the public key parsed. The CTLOG
-will be associated with the give library context I<libctx> and property query
+will be associated with the given library context I<libctx> and property query
 string I<propq>.
 
 CTLOG_new_from_base64() does the same thing as

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -59,7 +59,7 @@ the current time
 The above requirements are met using the setters described below.
 
 CT_POLICY_EVAL_CTX_new_with_libctx() creates an empty policy evaluation context
-and associates it with the give library context I<libctx> and property query
+and associates it with the given library context I<libctx> and property query
 string I<propq>.
 
 CT_POLICY_EVAL_CTX_new() does the same thing as

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+CT_POLICY_EVAL_CTX_new_with_libctx,
 CT_POLICY_EVAL_CTX_new, CT_POLICY_EVAL_CTX_free,
 CT_POLICY_EVAL_CTX_get0_cert, CT_POLICY_EVAL_CTX_set1_cert,
 CT_POLICY_EVAL_CTX_get0_issuer, CT_POLICY_EVAL_CTX_set1_issuer,
@@ -13,6 +14,8 @@ Encapsulates the data required to evaluate whether SCTs meet a Certificate Trans
 
  #include <openssl/ct.h>
 
+ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_with_libctx(OPENSSL_CTX *libctx,
+                                                        const char *propq);
  CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void);
  void CT_POLICY_EVAL_CTX_free(CT_POLICY_EVAL_CTX *ctx);
  X509* CT_POLICY_EVAL_CTX_get0_cert(const CT_POLICY_EVAL_CTX *ctx);
@@ -55,8 +58,15 @@ the current time
 
 The above requirements are met using the setters described below.
 
-CT_POLICY_EVAL_CTX_new() creates an empty policy evaluation context. This
-should then be populated using:
+CT_POLICY_EVAL_CTX_new_with_libctx() creates an empty policy evaluation context
+and associates it with the give library context I<libctx> and property query
+string I<propq>.
+
+CT_POLICY_EVAL_CTX_new() does the same thing as
+CT_POLICY_EVAL_CTX_new_with_libctx() except that it uses the default library
+context and property query string.
+
+The CT_POLICY_EVAL_CTX should then be populated using:
 
 =over 2
 
@@ -106,7 +116,8 @@ found in the TLS SCT extension or OCSP response.
 
 =head1 RETURN VALUES
 
-CT_POLICY_EVAL_CTX_new() will return NULL if malloc fails.
+CT_POLICY_EVAL_CTX_new_with_libctx() and CT_POLICY_EVAL_CTX_new() will return
+NULL if malloc fails.
 
 =head1 SEE ALSO
 
@@ -114,7 +125,8 @@ L<ct(7)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.1.0.
+CT_POLICY_EVAL_CTX_new_with_libctx was added in OpenSSL 3.0. All other
+functions were added in OpenSSL 1.1.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -69,9 +69,17 @@ DEFINE_STACK_OF(CTLOG)
  ******************************************/
 
 /*
- * Creates a new, empty policy evaluation context.
+ * Creates a new, empty policy evaluation context associated with the given
+ * library context and property query string.
  * The caller is responsible for calling CT_POLICY_EVAL_CTX_free when finished
  * with the CT_POLICY_EVAL_CTX.
+ */
+CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_with_libctx(OPENSSL_CTX *libctx,
+                                                       const char *propq);
+                                                       
+/*
+ * The same as CT_POLICY_EVAL_CTX_new_with_libctx() but the default library
+ * context and property query string is used.
  */
 CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void);
 
@@ -409,18 +417,38 @@ SCT *o2i_SCT(SCT **psct, const unsigned char **in, size_t len);
  ********************/
 
 /*
- * Creates a new CT log instance with the given |public_key| and |name|.
+ * Creates a new CT log instance with the given |public_key| and |name| and
+ * associates it with the give library context |libctx| and property query
+ * string |propq|.
  * Takes ownership of |public_key| but copies |name|.
  * Returns NULL if malloc fails or if |public_key| cannot be converted to DER.
  * Should be deleted by the caller using CTLOG_free when no longer needed.
+ */
+CTLOG *CTLOG_new_with_libctx(EVP_PKEY *public_key, const char *name,
+                             OPENSSL_CTX *libctx, const char *propq);
+
+/*
+ * The same as CTLOG_new_with_libctx except that the default library context and
+ * property query string are used.
  */
 CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
 
 /*
  * Creates a new CTLOG instance with the base64-encoded SubjectPublicKeyInfo DER
- * in |pkey_base64|. The |name| is a string to help users identify this log.
+ * in |pkey_base64| and associated with the give library context |libctx| and
+ * property query string |propq|. The |name| is a string to help users identify
+ * this log.
  * Returns 1 on success, 0 on failure.
  * Should be deleted by the caller using CTLOG_free when no longer needed.
+ */
+int CTLOG_new_from_base64_with_libctx(CTLOG **ct_log, const char *pkey_base64,
+                                      const char *name, OPENSSL_CTX *libctx,
+                                      const char *propq);
+
+/*
+ * The same as CTLOG_new_from_base64_with_libctx() except that the default
+ * library context and property query string are used.
+ * Returns 1 on success, 0 on failure.
  */
 int CTLOG_new_from_base64(CTLOG ** ct_log,
                           const char *pkey_base64, const char *name);
@@ -443,7 +471,15 @@ EVP_PKEY *CTLOG_get0_public_key(const CTLOG *log);
  **************************/
 
 /*
- * Creates a new CT log store.
+ * Creates a new CT log store and associates it with the given libctx and
+ * property query string.
+ * Should be deleted by the caller using CTLOG_STORE_free when no longer needed.
+ */
+CTLOG_STORE *CTLOG_STORE_new_with_libctx(OPENSSL_CTX *libctx, const char *propq);
+
+/*
+ * Same as CTLOG_STORE_new_with_libctx except that the default libctx and
+ * property query string are used.
  * Should be deleted by the caller using CTLOG_STORE_free when no longer needed.
  */
 CTLOG_STORE *CTLOG_STORE_new(void);

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -435,7 +435,7 @@ CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
 
 /*
  * Creates a new CTLOG instance with the base64-encoded SubjectPublicKeyInfo DER
- * in |pkey_base64| and associated with the give library context |libctx| and
+ * in |pkey_base64| and associated with the given library context |libctx| and
  * property query string |propq|. The |name| is a string to help users identify
  * this log.
  * Returns 1 on success, 0 on failure.

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3141,7 +3141,7 @@ SSL_CTX *SSL_CTX_new_with_libctx(OPENSSL_CTX *libctx, const char *propq,
     if (ret->cert_store == NULL)
         goto err;
 #ifndef OPENSSL_NO_CT
-    ret->ctlog_store = CTLOG_STORE_new();
+    ret->ctlog_store = CTLOG_STORE_new_with_libctx(libctx, propq);
     if (ret->ctlog_store == NULL)
         goto err;
 #endif
@@ -5145,7 +5145,7 @@ int ssl_validate_ct(SSL *s)
         }
     }
 
-    ctx = CT_POLICY_EVAL_CTX_new();
+    ctx = CT_POLICY_EVAL_CTX_new_with_libctx(s->ctx->libctx, s->ctx->propq);
     if (ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_SSL_VALIDATE_CT,
                  ERR_R_MALLOC_FAILURE);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5037,3 +5037,7 @@ EVP_PKEY_get_size_t_param               ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_bn_param                   ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_utf8_string_param          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_octet_string_param         ?	3_0_0	EXIST::FUNCTION:
+CTLOG_new_with_libctx                   ?	3_0_0	EXIST::FUNCTION:CT
+CTLOG_new_from_base64_with_libctx       ?	3_0_0	EXIST::FUNCTION:CT
+CTLOG_STORE_new_with_libctx             ?	3_0_0	EXIST::FUNCTION:CT
+CT_POLICY_EVAL_CTX_new_with_libctx      ?	3_0_0	EXIST::FUNCTION:CT


### PR DESCRIPTION
This updates the CT code to be aware of library contexts and use them for any cryptographic operations it performs. We also update libssl to use the new code.