### PR TITLE
Update RAND_METHOD definition in man page

### DIFF
--- a/doc/man3/RAND_set_rand_method.pod
+++ b/doc/man3/RAND_set_rand_method.pod
@@ -33,10 +33,10 @@ RAND_get_rand_method() returns a pointer to the current B<RAND_METHOD>.
 =head1 THE RAND_METHOD STRUCTURE
 
  typedef struct rand_meth_st {
-     void (*seed)(const void *buf, int num);
+     int (*seed)(const void *buf, int num);
      int (*bytes)(unsigned char *buf, int num);
      void (*cleanup)(void);
-     void (*add)(const void *buf, int num, int randomness);
+     int (*add)(const void *buf, int num, double entropy);
      int (*pseudorand)(unsigned char *buf, int num);
      int (*status)(void);
  } RAND_METHOD;


### PR DESCRIPTION
The `add` and `seed` callbacks were changed to return `int` instead of
`void` in b6dcdbfc94c482f6c15ba725754fc9e827e41851 (first included in
tag OpenSSL_1_1_0-pre1).

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated