### PR TITLE
Fix AES-CTR_DRBG on 1.1.1.

### DIFF
--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -2,3 +2,5 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         randfile.c rand_lib.c rand_err.c rand_egd.c \
         rand_win.c rand_unix.c rand_vms.c drbg_lib.c drbg_ctr.c
+
+INCLUDE[drbg_ctr.o]=../modes

--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -12,9 +12,10 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
-#include "internal/thread_once.h"
+#include "modes_local.h"
 #include "internal/thread_once.h"
 #include "rand_local.h"
+
 /*
  * Implementation of NIST SP 800-90A CTR DRBG.
  */


### PR DESCRIPTION
The back port of the timing information leak fix uses `u32` which is defined in `crypto/modes/modes_local.h` in 1.1.1 and `include/crypto/modes.h` for 3.0.


- [ ] documentation is added or updated
- [ ] tests are added or updated

Fixes #11487

Bug introduced in cherry picking of #11147
