### PR TITLE
Enable Ed25519 signing/verifying to use the libctx

### DIFF
--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -5438,13 +5438,14 @@ static void sc_muladd(uint8_t *s, const uint8_t *a, const uint8_t *b,
 }
 
 int ED25519_sign(uint8_t *out_sig, const uint8_t *message, size_t message_len,
-                 const uint8_t public_key[32], const uint8_t private_key[32])
+                 const uint8_t public_key[32], const uint8_t private_key[32],
+                 OPENSSL_CTX *libctx, const char *propq)
 {
     uint8_t az[SHA512_DIGEST_LENGTH];
     uint8_t nonce[SHA512_DIGEST_LENGTH];
     ge_p3 R;
     uint8_t hram[SHA512_DIGEST_LENGTH];
-    EVP_MD *sha512 = EVP_MD_fetch(NULL, SN_sha512, NULL);
+    EVP_MD *sha512 = EVP_MD_fetch(libctx, SN_sha512, propq);
     EVP_MD_CTX *hash_ctx = EVP_MD_CTX_new();
     unsigned int sz;
     int res = 0;
@@ -5493,7 +5494,8 @@ err:
 static const char allzeroes[15];
 
 int ED25519_verify(const uint8_t *message, size_t message_len,
-                   const uint8_t signature[64], const uint8_t public_key[32])
+                   const uint8_t signature[64], const uint8_t public_key[32],
+                   OPENSSL_CTX *libctx, const char *propq)
 {
     int i;
     ge_p3 A;
@@ -5548,7 +5550,7 @@ int ED25519_verify(const uint8_t *message, size_t message_len,
     fe_neg(A.X, A.X);
     fe_neg(A.T, A.T);
 
-    sha512 = EVP_MD_fetch(NULL, SN_sha512, NULL);
+    sha512 = EVP_MD_fetch(libctx, SN_sha512, propq);
     if (sha512 == NULL)
         return 0;
     hash_ctx = EVP_MD_CTX_new();

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -836,7 +836,8 @@ static int pkey_ecd_digestsign25519(EVP_MD_CTX *ctx, unsigned char *sig,
         return 0;
     }
 
-    if (ED25519_sign(sig, tbs, tbslen, edkey->pubkey, edkey->privkey) == 0)
+    if (ED25519_sign(sig, tbs, tbslen, edkey->pubkey, edkey->privkey, NULL,
+                     NULL) == 0)
         return 0;
     *siglen = ED25519_SIGSIZE;
     return 1;
@@ -877,7 +878,7 @@ static int pkey_ecd_digestverify25519(EVP_MD_CTX *ctx, const unsigned char *sig,
     if (siglen != ED25519_SIGSIZE)
         return 0;
 
-    return ED25519_verify(tbs, tbslen, sig, edkey->pubkey);
+    return ED25519_verify(tbs, tbslen, sig, edkey->pubkey, NULL, NULL);
 }
 
 static int pkey_ecd_digestverify448(EVP_MD_CTX *ctx, const unsigned char *sig,

--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -83,9 +83,11 @@ void X25519_public_from_private(uint8_t out_public_value[32],
                                 const uint8_t private_key[32]);
 
 int ED25519_sign(uint8_t *out_sig, const uint8_t *message, size_t message_len,
-                 const uint8_t public_key[32], const uint8_t private_key[32]);
+                 const uint8_t public_key[32], const uint8_t private_key[32],
+                 OPENSSL_CTX *libctx, const char *propq);
 int ED25519_verify(const uint8_t *message, size_t message_len,
-                   const uint8_t signature[64], const uint8_t public_key[32]);
+                   const uint8_t signature[64], const uint8_t public_key[32],
+                   OPENSSL_CTX *libctx, const char *propq);
 
 int ED448_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t *message,
                size_t message_len, const uint8_t public_key[57],

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -87,7 +87,8 @@ int ed25519_digest_sign(void *vpeddsactx, unsigned char *sigret,
         return 0;
     }
 
-    if (ED25519_sign(sigret, tbs, tbslen, edkey->pubkey, edkey->privkey) == 0) {
+    if (ED25519_sign(sigret, tbs, tbslen, edkey->pubkey, edkey->privkey,
+                     peddsactx->libctx, NULL) == 0) {
         PROVerr(0, PROV_R_FAILED_TO_SIGN);
         return 0;
     }
@@ -130,7 +131,8 @@ int ed25519_digest_verify(void *vpeddsactx, const unsigned char *sig,
     if (siglen != ED25519_SIGSIZE)
         return 0;
 
-    return ED25519_verify(tbs, tbslen, sig, edkey->pubkey);
+    return ED25519_verify(tbs, tbslen, sig, edkey->pubkey, peddsactx->libctx,
+                          NULL);
 }
 
 int ed448_digest_verify(void *vpeddsactx, const unsigned char *sig,


### PR DESCRIPTION
Ed25519 needs to fetch a digest and so needs to use the correct libctx.

This is needed for alpha1