### PR TITLE
Fix krb5 external test

### DIFF
--- a/test/recipes/95-test_external_krb5.t
+++ b/test/recipes/95-test_external_krb5.t
@@ -21,7 +21,7 @@ plan skip_all => "krb5 not available"
 
 plan tests => 1;
 
-$ENV{OPENSSL_MODULES} = abs_path($ENV{OPENSSL_MODULES});
+$ENV{OPENSSL_MODULES} = abs_path(bldtop_dir("providers"));
 $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "default-and-legacy.cnf"));
 
 ok(run(cmd([data_file("krb5.sh")])), "running krb5 tests");


### PR DESCRIPTION
Since commit c3845ceba84aab9ddeb43f043549238fd10de63b ("Build file
templates: don't set OPENSSL_{ENGINES,MODULES}") the krb5 external test
has been failing.  This is because it relied on OPENSSL_MODULES already
being set -- even though it did assign to OPENSSL_MODULES itself (and
thus got skipped by the cleanup pass in that commit), it was doing so
only to canonicalize the existing value to an absolute path, not as a de
novo assignment.

Catch up to the rest of the tree and just set it directly as the
"providers" path from the build top (but still canonicalized to an
absolute path).

[extended tests]

Fixes: 11492
