### PR TITLE
[URGENT] Add common internal crypto/ modules in liblegacy.a

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -80,6 +80,7 @@ SOURCE[../libcrypto]=$UTIL_COMMON \
         o_fopen.c getenv.c o_init.c o_fips.c init.c trace.c provider.c \
         $UPLINKSRC
 SOURCE[../providers/libfips.a]=$UTIL_COMMON
+SOURCE[../providers/liblegacy.a]=$UTIL_COMMON
 
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules.
@@ -87,6 +88,7 @@ DEFINE[../libcrypto]=$UTIL_DEFINE $UPLINKDEF
 DEFINE[../providers/libfips.a]=$UTIL_DEFINE
 DEFINE[../providers/fips]=$UTIL_DEFINE
 DEFINE[../providers/libimplementations.a]=$UTIL_DEFINE
+DEFINE[../providers/liblegacy.a]=$UTIL_DEFINE
 DEFINE[../providers/libcommon.a]=$UTIL_DEFINE
 
 DEPEND[info.o]=buildinf.h


### PR DESCRIPTION
Just as for the FIPS module, there's code in the legacy module that need
this.
