### PR TITLE
Fix for #7717

### DIFF
--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -150,7 +150,7 @@ static int acpt_free(BIO *a)
 static int acpt_state(BIO *b, BIO_ACCEPT *c)
 {
     BIO *bio = NULL, *dbio;
-    int s = -1, ret = -1;
+    int s = -1, ret = -1, sock = -1;
 
     for (;;) {
         switch (c->state) {
@@ -222,18 +222,18 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
             break;
 
         case ACPT_S_CREATE_SOCKET:
-            ret = BIO_socket(BIO_ADDRINFO_family(c->addr_iter),
-                             BIO_ADDRINFO_socktype(c->addr_iter),
-                             BIO_ADDRINFO_protocol(c->addr_iter), 0);
-            if (ret == (int)INVALID_SOCKET) {
+            sock = BIO_socket(BIO_ADDRINFO_family(c->addr_iter),
+                              BIO_ADDRINFO_socktype(c->addr_iter),
+                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
+            if (sock == (int)INVALID_SOCKET) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                "calling socket(%s, %s)",
                                 c->param_addr, c->param_serv);
                 BIOerr(BIO_F_ACPT_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;
             }
-            c->accept_sock = ret;
-            b->num = ret;
+            c->accept_sock = sock;
+            b->num = sock;
             c->state = ACPT_S_LISTEN;
             break;
 

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -150,7 +150,7 @@ static int acpt_free(BIO *a)
 static int acpt_state(BIO *b, BIO_ACCEPT *c)
 {
     BIO *bio = NULL, *dbio;
-    int s = -1, ret = -1, sock = -1;
+    int s = -1, ret = -1;
 
     for (;;) {
         switch (c->state) {
@@ -222,19 +222,20 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
             break;
 
         case ACPT_S_CREATE_SOCKET:
-            sock = BIO_socket(BIO_ADDRINFO_family(c->addr_iter),
-                              BIO_ADDRINFO_socktype(c->addr_iter),
-                              BIO_ADDRINFO_protocol(c->addr_iter), 0);
-            if (sock == (int)INVALID_SOCKET) {
+            s = BIO_socket(BIO_ADDRINFO_family(c->addr_iter),
+                           BIO_ADDRINFO_socktype(c->addr_iter),
+                           BIO_ADDRINFO_protocol(c->addr_iter), 0);
+            if (s == (int)INVALID_SOCKET) {
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                "calling socket(%s, %s)",
                                 c->param_addr, c->param_serv);
                 BIOerr(BIO_F_ACPT_STATE, BIO_R_UNABLE_TO_CREATE_SOCKET);
                 goto exit_loop;
             }
-            c->accept_sock = sock;
-            b->num = sock;
+            c->accept_sock = s;
+            b->num = s;
             c->state = ACPT_S_LISTEN;
+            s = -1;
             break;
 
         case ACPT_S_LISTEN:

--- a/doc/man3/RAND_set_rand_method.pod
+++ b/doc/man3/RAND_set_rand_method.pod
@@ -33,10 +33,10 @@ RAND_get_rand_method() returns a pointer to the current B<RAND_METHOD>.
 =head1 THE RAND_METHOD STRUCTURE
 
  typedef struct rand_meth_st {
-     void (*seed)(const void *buf, int num);
+     int (*seed)(const void *buf, int num);
      int (*bytes)(unsigned char *buf, int num);
      void (*cleanup)(void);
-     void (*add)(const void *buf, int num, int randomness);
+     int (*add)(const void *buf, int num, double entropy);
      int (*pseudorand)(unsigned char *buf, int num);
      int (*status)(void);
  } RAND_METHOD;


### PR DESCRIPTION
Fixes #7717
CLA: trivial

`BIO_do_accept` was returning incorrect values when unable to bind to a port.

Problem in `acpt_state` assigning a temp value to the return var and not resetting it.