### PR TITLE
Make X509_verify() libctx aware

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -334,7 +334,7 @@ static int check_issued(X509_STORE_CTX *ctx, X509 *x, X509 *issuer)
         return ss;
     }
 
-    ret = X509_check_issued(issuer, x);
+    ret = x509_check_issued_int(issuer, x, ctx->libctx, ctx->propq);
     if (ret == X509_V_OK) {
         int i;
         X509 *ch;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1763,7 +1763,7 @@ static int internal_verify(X509_STORE_CTX *ctx)
                 if (!verify_cb_cert(ctx, xi, xi != xs ? n+1 : n,
                         X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY))
                     return 0;
-            } else if (X509_verify(xs, pkey) <= 0) {
+            } else if (X509_verify_ex(xs, pkey, ctx->libctx, ctx->propq) <= 0) {
                 if (!verify_cb_cert(ctx, xs, n,
                                     X509_V_ERR_CERT_SIGNATURE_FAILURE))
                     return 0;
@@ -2809,7 +2809,7 @@ static int check_dane_pkeys(X509_STORE_CTX *ctx)
         if (t->usage != DANETLS_USAGE_DANE_TA ||
             t->selector != DANETLS_SELECTOR_SPKI ||
             t->mtype != DANETLS_MATCHING_FULL ||
-            X509_verify(cert, t->spki) <= 0)
+            X509_verify_ex(cert, t->spki, ctx->libctx, ctx->propq) <= 0)
             continue;
 
         /* Clear any PKIX-?? matches that failed to extend to a full chain */

--- a/doc/man3/X509_sign.pod
+++ b/doc/man3/X509_sign.pod
@@ -13,8 +13,8 @@ X509_CRL_sign_ctx, X509_CRL_verify
 
  int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx);
- int X509_verify_ex(X509 *a, EVP_PKEY *pkey, OPENSSL_CTX *libctx, const char *propq);
- int X509_verify(X509 *a, EVP_PKEY *pkey;
+ int X509_verify_ex(X509 *x, EVP_PKEY *pkey, OPENSSL_CTX *libctx, const char *propq);
+ int X509_verify(X509 *x, EVP_PKEY *pkey;
 
  int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx);

--- a/doc/man3/X509_sign.pod
+++ b/doc/man3/X509_sign.pod
@@ -86,7 +86,8 @@ L<X509_NAME_get_index_by_NID(3)>,
 L<X509_NAME_print_ex(3)>,
 L<X509_new(3)>,
 L<X509V3_get_d2i(3)>,
-L<X509_verify_cert(3)>
+L<X509_verify_cert(3)>,
+L<OPENSSL_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/X509_sign.pod
+++ b/doc/man3/X509_sign.pod
@@ -2,9 +2,10 @@
 
 =head1 NAME
 
-X509_sign, X509_sign_ctx, X509_verify, X509_REQ_sign, X509_REQ_sign_ctx,
-X509_REQ_verify, X509_CRL_sign, X509_CRL_sign_ctx, X509_CRL_verify -
-sign or verify certificate, certificate request or CRL signature
+X509_sign, X509_sign_ctx, X509_verify_ex, X509_verify, X509_REQ_sign,
+X509_REQ_sign_ctx, X509_REQ_verify_ex, X509_REQ_verify, X509_CRL_sign,
+X509_CRL_sign_ctx, X509_CRL_verify
+- sign or verify certificate, certificate request or CRL signature
 
 =head1 SYNOPSIS
 
@@ -12,11 +13,14 @@ sign or verify certificate, certificate request or CRL signature
 
  int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx);
+ int X509_verify_ex(X509 *a, EVP_PKEY *r, OPENSSL_CTX *libctx, const char *propq);
  int X509_verify(X509 *a, EVP_PKEY *r);
 
  int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx);
  int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r);
+ int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OPENSSL_CTX *libctx,
+                        const char *propq);
 
  int X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx);
@@ -28,11 +32,16 @@ X509_sign() signs certificate B<x> using private key B<pkey> and message
 digest B<md> and sets the signature in B<x>. X509_sign_ctx() also signs
 certificate B<x> but uses the parameters contained in digest context B<ctx>.
 
-X509_verify() verifies the signature of certificate B<x> using public key
-B<pkey>. Only the signature is checked: no other checks (such as certificate
-chain validity) are performed.
+X509_verify_ex() verifies the signature of certificate B<x> using public key
+B<pkey>. Any cryptographic algorithms required for the verification are fetched
+using the library context I<libctx> and the property query string I<propq>. Only
+the signature is checked: no other checks (such as certificate chain validity)
+are performed.
 
-X509_REQ_sign(), X509_REQ_sign_ctx(), X509_REQ_verify(),
+X509_verify() is the same as X509_verify_ex() except that the default library
+context and property query string are used.
+
+X509_REQ_sign(), X509_REQ_sign_ctx(), X509_REQ_verify_ex(), X509_REQ_verify(),
 X509_CRL_sign(), X509_CRL_sign_ctx() and X509_CRL_verify() sign and verify
 certificate requests and CRLs respectively.
 
@@ -55,10 +64,10 @@ X509_sign(), X509_sign_ctx(), X509_REQ_sign(), X509_REQ_sign_ctx(),
 X509_CRL_sign() and X509_CRL_sign_ctx() return the size of the signature
 in bytes for success and zero for failure.
 
-X509_verify(), X509_REQ_verify() and X509_CRL_verify() return 1 if the
-signature is valid and 0 if the signature check fails. If the signature
-could not be checked at all because it was invalid or some other error
-occurred then -1 is returned.
+X509_verify_ex(), X509_verify(), X509_REQ_verify_ex(), X509_REQ_verify() and
+X509_CRL_verify() return 1 if the signature is valid and 0 if the signature
+check fails. If the signature could not be checked at all because it was invalid
+or some other error occurred then -1 is returned.
 
 =head1 SEE ALSO
 
@@ -86,6 +95,8 @@ available in all versions of OpenSSL.
 
 The X509_sign_ctx(), X509_REQ_sign_ctx()
 and X509_CRL_sign_ctx() functions were added OpenSSL 1.0.1.
+
+X509_verify_ex() and X509_REQ_verify_ex() were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_sign.pod
+++ b/doc/man3/X509_sign.pod
@@ -13,27 +13,27 @@ X509_CRL_sign_ctx, X509_CRL_verify
 
  int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx);
- int X509_verify_ex(X509 *a, EVP_PKEY *r, OPENSSL_CTX *libctx, const char *propq);
- int X509_verify(X509 *a, EVP_PKEY *r);
+ int X509_verify_ex(X509 *a, EVP_PKEY *pkey, OPENSSL_CTX *libctx, const char *propq);
+ int X509_verify(X509 *a, EVP_PKEY *pkey;
 
  int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx);
- int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r);
- int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OPENSSL_CTX *libctx,
+ int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey, OPENSSL_CTX *libctx,
                         const char *propq);
+ int X509_REQ_verify(X509_REQ *a, EVP_PKEY *pkey);
 
  int X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx);
- int X509_CRL_verify(X509_CRL *a, EVP_PKEY *r);
+ int X509_CRL_verify(X509_CRL *a, EVP_PKEY *pkey);
 
 =head1 DESCRIPTION
 
-X509_sign() signs certificate B<x> using private key B<pkey> and message
-digest B<md> and sets the signature in B<x>. X509_sign_ctx() also signs
-certificate B<x> but uses the parameters contained in digest context B<ctx>.
+X509_sign() signs certificate I<x> using private key I<pkey> and message
+digest I<md> and sets the signature in I<x>. X509_sign_ctx() also signs
+certificate I<x> but uses the parameters contained in digest context I<ctx>.
 
-X509_verify_ex() verifies the signature of certificate B<x> using public key
-B<pkey>. Any cryptographic algorithms required for the verification are fetched
+X509_verify_ex() verifies the signature of certificate I<x> using public key
+I<pkey>. Any cryptographic algorithms required for the verification are fetched
 using the library context I<libctx> and the property query string I<propq>. Only
 the signature is checked: no other checks (such as certificate chain validity)
 are performed.

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -297,3 +297,7 @@ int x509_set1_time(ASN1_TIME **ptm, const ASN1_TIME *tm);
 int x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags);
 
 void x509_init_sig_info(X509 *x);
+
+
+int x509_check_issued_int(X509 *issuer, X509 *subject, OPENSSL_CTX *libctx,
+                          const char *propq);

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -355,8 +355,11 @@ void *X509_CRL_get_meth_data(X509_CRL *crl);
 
 const char *X509_verify_cert_error_string(long n);
 
+int X509_verify_ex(X509 *a, EVP_PKEY *r, OPENSSL_CTX *libctx, const char *propq);
 int X509_verify(X509 *a, EVP_PKEY *r);
 
+int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OPENSSL_CTX *libctx,
+                       const char *propq);
 int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r);
 int X509_CRL_verify(X509_CRL *a, EVP_PKEY *r);
 int NETSCAPE_SPKI_verify(NETSCAPE_SPKI *a, EVP_PKEY *r);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5063,3 +5063,5 @@ EVP_PKEY_CTX_set_dsa_paramgen_gindex    ?	3_0_0	EXIST::FUNCTION:DSA
 EVP_PKEY_CTX_set_dsa_paramgen_type      ?	3_0_0	EXIST::FUNCTION:DSA
 EVP_PKEY_CTX_set_dsa_paramgen_seed      ?	3_0_0	EXIST::FUNCTION:DSA
 EVP_PKEY_CTX_set_dsa_paramgen_md        ?	3_0_0	EXIST::FUNCTION:DSA
+X509_verify_ex                          ?	3_0_0	EXIST::FUNCTION:
+X509_REQ_verify_ex                      ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
X509_verify() validates the signature in an X509 cert. We should make sure we use a library ctx and property query string for fetching any algorithms. Therefore we introduce X509_verify_ex().

I've also included a second loosely related commit which gives us an internal version of X509_check_issued() which is library ctx aware. We don't actually *need* this to be public (you can achieve the same thing via other means) - but it makes our internal code a bit neater doing things this way.

This is required for alpha1.