### PR TITLE
Run ssl_test_new in fips

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1270,7 +1270,7 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         header[j++] = (unsigned char)(rec->length & 0xff);
 
         /* Final param == is SSLv3 */
-        if (ssl3_cbc_digest_record(hash,
+        if (ssl3_cbc_digest_record(ssl, hash,
                                    md, &md_size,
                                    header, rec->input,
                                    rec->length + md_size, rec->orig_len,
@@ -1374,7 +1374,7 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
          * are hashing because that gives an attacker a timing-oracle.
          */
         /* Final param == not SSLv3 */
-        if (ssl3_cbc_digest_record(mac_ctx,
+        if (ssl3_cbc_digest_record(ssl, mac_ctx,
                                    md, &md_size,
                                    header, rec->input,
                                    rec->length + md_size, rec->orig_len,

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -168,7 +168,7 @@ int ssl3_cbc_digest_record(SSL *s,
     size_t md_length_size = 8;
     char length_is_big_endian = 1;
     int ret = 0;
-    const EVP_MD *md;
+    const EVP_MD *md = NULL;
 
     /*
      * This is a, hopefully redundant, check that allows us to forget about

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -131,7 +131,8 @@ char ssl3_cbc_record_digest_supported(const EVP_MD_CTX *ctx)
  * padding too. )
  * Returns 1 on success or 0 on error
  */
-int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
+int ssl3_cbc_digest_record(SSL *s,
+                           const EVP_MD_CTX *ctx,
                            unsigned char *md_out,
                            size_t *md_out_size,
                            const unsigned char header[13],
@@ -166,7 +167,8 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
      */
     size_t md_length_size = 8;
     char length_is_big_endian = 1;
-    int ret;
+    int ret = 0;
+    const EVP_MD *md;
 
     /*
      * This is a, hopefully redundant, check that allows us to forget about
@@ -461,7 +463,11 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
     md_ctx = EVP_MD_CTX_new();
     if (md_ctx == NULL)
         goto err;
-    if (EVP_DigestInit_ex(md_ctx, EVP_MD_CTX_md(ctx), NULL /* engine */ ) <= 0)
+    md = ssl_evp_md_fetch(s->ctx->libctx, EVP_MD_type(EVP_MD_CTX_md(ctx)),
+                          s->ctx->propq);
+    if (md == NULL)
+        goto err;
+    if (EVP_DigestInit_ex(md_ctx, md, NULL /* engine */ ) <= 0)
         goto err;
     if (is_sslv3) {
         /* We repurpose |hmac_pad| to contain the SSLv3 pad2 block. */
@@ -484,10 +490,10 @@ int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
     ret = EVP_DigestFinal(md_ctx, md_out, &md_out_size_u);
     if (ret && md_out_size)
         *md_out_size = md_out_size_u;
-    EVP_MD_CTX_free(md_ctx);
 
-    return 1;
+    ret = 1;
  err:
     EVP_MD_CTX_free(md_ctx);
-    return 0;
+    ssl_evp_md_free(md);
+    return ret;
 }

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2713,7 +2713,8 @@ __owur int ssl_log_secret(SSL *ssl, const char *label,
 
 /* s3_cbc.c */
 __owur char ssl3_cbc_record_digest_supported(const EVP_MD_CTX *ctx);
-__owur int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
+__owur int ssl3_cbc_digest_record(SSL *s,
+                                  const EVP_MD_CTX *ctx,
                                   unsigned char *md_out,
                                   size_t *md_out_size,
                                   const unsigned char header[13],

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -128,18 +128,13 @@ sub print_templates {
 sub read_config {
     my $fname = shift;
     my $provider = shift;
-    my $fips_mode = "0";
-    my $no_deflt_libctx = "0";
-
-    $fips_mode = "1" if $provider eq "fips";
-    $no_deflt_libctx = "1" if $provider eq "default" || $provider eq "fips";
+    local $ssltests::fips_mode = $provider eq "fips";
+    local $ssltests::no_deflt_libctx =
+        $provider eq "default" || $provider eq "fips";
 
     open(INPUT, "< $fname") or die "Can't open input file '$fname'!\n";
     local $/ = undef;
     my $content = <INPUT>;
-    $content =~ s/FIPS_MODE/$fips_mode/g;
-    $content =~ s/NO_DEFLT_LIBCTX/$no_deflt_libctx/g;
-
     close(INPUT);
     eval $content;
     warn $@ if $@;

--- a/test/generate_ssl_tests.pl
+++ b/test/generate_ssl_tests.pl
@@ -127,17 +127,28 @@ sub print_templates {
 # Shamelessly copied from Configure.
 sub read_config {
     my $fname = shift;
+    my $provider = shift;
+    my $fips_mode = "0";
+    my $no_deflt_libctx = "0";
+
+    $fips_mode = "1" if $provider eq "fips";
+    $no_deflt_libctx = "1" if $provider eq "default" || $provider eq "fips";
+
     open(INPUT, "< $fname") or die "Can't open input file '$fname'!\n";
     local $/ = undef;
     my $content = <INPUT>;
+    $content =~ s/FIPS_MODE/$fips_mode/g;
+    $content =~ s/NO_DEFLT_LIBCTX/$no_deflt_libctx/g;
+
     close(INPUT);
     eval $content;
     warn $@ if $@;
 }
 
 my $input_file = shift;
+my $provider = shift;
 # Reads the tests into ssltests::tests.
-read_config($input_file);
+read_config($input_file, $provider);
 print_templates();
 
 1;

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -129,7 +129,7 @@ unless ($no_fips) {
 
 foreach my $conf (@conf_files) {
     subtest "Test configuration $conf" => sub {
-        plan tests => 9;
+        plan tests => 6 + ($no_fips ? 0 : 3);
         test_conf($conf,
                   $conf_dependent_tests{$conf} || $^O eq "VMS" ?  0 : 1,
                   defined($skip{$conf}) ? $skip{$conf} : $no_tls,
@@ -141,7 +141,7 @@ foreach my $conf (@conf_files) {
         test_conf($conf,
                   0,
                   defined($skip{$conf}) ? $skip{$conf} : $no_tls,
-                  "fips");
+                  "fips") unless $no_fips;
     }
 }
 

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -13,11 +13,19 @@ use warnings;
 use File::Basename;
 use File::Compare qw/compare_text/;
 use OpenSSL::Glob;
-use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file bldtop_file bldtop_dir/;
 use OpenSSL::Test::Utils qw/disabled alldisabled available_protocols/;
 
+BEGIN {
 setup("test_ssl_new");
+}
 
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
+
+$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
+$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
 $ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 
@@ -28,7 +36,7 @@ map { s/\^// } @conf_files if $^O eq "VMS";
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 30;  # = scalar @conf_srcs
+plan tests => 31;  # = scalar @conf_srcs + fipsinstall
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.
@@ -106,9 +114,17 @@ my %skip = (
   "29-dtls-sctp-label-bug.cnf" => disabled("sctp") || disabled("sock"),
 );
 
+ok(run(app(['openssl', 'fipsinstall',
+            '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+            '-module', bldtop_file('providers', platform->dso('fips')),
+            '-provider_name', 'fips', '-mac_name', 'HMAC',
+            '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
+            '-section_name', 'fips_sect'])),
+   "fipsinstall");
+
 foreach my $conf (@conf_files) {
     subtest "Test configuration $conf" => sub {
-        plan tests => 6;
+        plan tests => 9;
         test_conf($conf,
                   $conf_dependent_tests{$conf} || $^O eq "VMS" ?  0 : 1,
                   defined($skip{$conf}) ? $skip{$conf} : $no_tls,
@@ -117,6 +133,10 @@ foreach my $conf (@conf_files) {
                   0,
                   defined($skip{$conf}) ? $skip{$conf} : $no_tls,
                   "default");
+        test_conf($conf,
+                  0,
+                  defined($skip{$conf}) ? $skip{$conf} : $no_tls,
+                  "fips");
     }
 }
 
@@ -149,8 +169,14 @@ sub test_conf {
       skip "No tests available; skipping tests", 1 if $skip;
       skip "Stale sources; skipping tests", 1 if !$run_test;
 
-      ok(run(test(["ssl_test", $output_file, $provider])),
-         "running ssl_test $conf");
+      if ($provider eq "fips") {
+          ok(run(test(["ssl_test", $output_file, $provider,
+                       srctop_file("test", "fips.cnf")])),
+             "running ssl_test $conf");
+      } else {
+          ok(run(test(["ssl_test", $output_file, $provider])),
+             "running ssl_test $conf");
+      }
     }
 }
 

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -145,7 +145,8 @@ sub test_conf {
       skip "No tests available; skipping tests", 1 if $skip;
       skip "Stale sources; skipping tests", 1 if !$run_test;
 
-      ok(run(test(["ssl_test", $output_file])), "running ssl_test $conf");
+      ok(run(test(["ssl_test", $output_file, "default"])),
+         "running ssl_test $conf");
     }
 }
 

--- a/test/ssl-tests/02-protocol-version.cnf.in
+++ b/test/ssl-tests/02-protocol-version.cnf.in
@@ -16,4 +16,9 @@ use warnings;
 
 use protocol_version;
 
-our @tests = generate_version_tests("TLS");
+our @tests;
+if (FIPS_MODE) {
+    @tests = generate_version_tests("TLS", 1);
+} else {
+    @tests = generate_version_tests("TLS", 0);
+}

--- a/test/ssl-tests/02-protocol-version.cnf.in
+++ b/test/ssl-tests/02-protocol-version.cnf.in
@@ -16,9 +16,6 @@ use warnings;
 
 use protocol_version;
 
-our @tests;
-if (FIPS_MODE) {
-    @tests = generate_version_tests("TLS", 1);
-} else {
-    @tests = generate_version_tests("TLS", 0);
-}
+our $fips_mode;
+
+our @tests = generate_version_tests("TLS", $fips_mode);

--- a/test/ssl-tests/04-client_auth.cnf.in
+++ b/test/ssl-tests/04-client_auth.cnf.in
@@ -11,11 +11,16 @@ use OpenSSL::Test;
 use OpenSSL::Test::Utils qw(anydisabled disabled);
 setup("no_test_here");
 
-# We test version-flexible negotiation (undef) and each protocol version.
-my @protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLSv1", "DTLSv1.2");
-
+my @protocols;
 my @is_disabled = (0);
 push @is_disabled, anydisabled("ssl3", "tls1", "tls1_1", "tls1_2", "dtls1", "dtls1_2");
+
+# We test version-flexible negotiation (undef) and each protocol version.
+if (FIPS_MODE) {
+    @protocols = (undef, "TLSv1.2", "DTLSv1.2");
+} else {
+    @protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLSv1", "DTLSv1.2");
+}
 
 our @tests = ();
 

--- a/test/ssl-tests/04-client_auth.cnf.in
+++ b/test/ssl-tests/04-client_auth.cnf.in
@@ -11,12 +11,14 @@ use OpenSSL::Test;
 use OpenSSL::Test::Utils qw(anydisabled disabled);
 setup("no_test_here");
 
+our $fips_mode;
+
 my @protocols;
 my @is_disabled = (0);
 push @is_disabled, anydisabled("ssl3", "tls1", "tls1_1", "tls1_2", "dtls1", "dtls1_2");
 
 # We test version-flexible negotiation (undef) and each protocol version.
-if (FIPS_MODE) {
+if ($fips_mode) {
     @protocols = (undef, "TLSv1.2", "DTLSv1.2");
 } else {
     @protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLSv1", "DTLSv1.2");

--- a/test/ssl-tests/05-sni.cnf.in
+++ b/test/ssl-tests/05-sni.cnf.in
@@ -166,4 +166,4 @@ our @tests_tls_1_1 = (
     },
 );
 
-push @tests, @tests_tls_1_1 unless disabled("tls1_1");
+push @tests, @tests_tls_1_1 unless disabled("tls1_1") || FIPS_MODE;

--- a/test/ssl-tests/05-sni.cnf.in
+++ b/test/ssl-tests/05-sni.cnf.in
@@ -15,6 +15,8 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
+our $fips_mode;
+
 our @tests = (
     {
         name => "SNI-switch-context",
@@ -166,4 +168,4 @@ our @tests_tls_1_1 = (
     },
 );
 
-push @tests, @tests_tls_1_1 unless disabled("tls1_1") || FIPS_MODE;
+push @tests, @tests_tls_1_1 unless disabled("tls1_1") || $fips_mode;

--- a/test/ssl-tests/07-dtls-protocol-version.cnf.in
+++ b/test/ssl-tests/07-dtls-protocol-version.cnf.in
@@ -16,9 +16,6 @@ use warnings;
 
 use protocol_version;
 
-our @tests;
-if (FIPS_MODE) {
-    @tests = generate_version_tests("DTLS", 1);
-} else {
-    @tests = generate_version_tests("DTLS", 0);
-}
+our $fips_mode;
+
+our @tests = generate_version_tests("DTLS", $fips_mode);

--- a/test/ssl-tests/07-dtls-protocol-version.cnf.in
+++ b/test/ssl-tests/07-dtls-protocol-version.cnf.in
@@ -16,4 +16,9 @@ use warnings;
 
 use protocol_version;
 
-our @tests = generate_version_tests("DTLS");
+our @tests;
+if (FIPS_MODE) {
+    @tests = generate_version_tests("DTLS", 1);
+} else {
+    @tests = generate_version_tests("DTLS", 0);
+}

--- a/test/ssl-tests/10-resumption.cnf.in
+++ b/test/ssl-tests/10-resumption.cnf.in
@@ -16,9 +16,6 @@ package ssltests;
 
 use protocol_version;
 
-our @tests;
-if (FIPS_MODE) {
-    @tests = generate_resumption_tests("TLS", 1);
-} else {
-    @tests = generate_resumption_tests("TLS", 0);
-}
+our $fips_mode;
+
+our @tests = generate_resumption_tests("TLS", $fips_mode);

--- a/test/ssl-tests/10-resumption.cnf.in
+++ b/test/ssl-tests/10-resumption.cnf.in
@@ -16,4 +16,9 @@ package ssltests;
 
 use protocol_version;
 
-our @tests = generate_resumption_tests("TLS");
+our @tests;
+if (FIPS_MODE) {
+    @tests = generate_resumption_tests("TLS", 1);
+} else {
+    @tests = generate_resumption_tests("TLS", 0);
+}

--- a/test/ssl-tests/11-dtls_resumption.cnf.in
+++ b/test/ssl-tests/11-dtls_resumption.cnf.in
@@ -16,9 +16,6 @@ package ssltests;
 
 use protocol_version;
 
-our @tests;
-if (FIPS_MODE) {
-    @tests = generate_resumption_tests("DTLS", 1);
-} else {
-    @tests = generate_resumption_tests("DTLS", 0);
-}
+our $fips_mode;
+
+our @tests = generate_resumption_tests("DTLS", $fips_mode);

--- a/test/ssl-tests/11-dtls_resumption.cnf.in
+++ b/test/ssl-tests/11-dtls_resumption.cnf.in
@@ -16,4 +16,9 @@ package ssltests;
 
 use protocol_version;
 
-our @tests = generate_resumption_tests("DTLS");
+our @tests;
+if (FIPS_MODE) {
+    @tests = generate_resumption_tests("DTLS", 1);
+} else {
+    @tests = generate_resumption_tests("DTLS", 0);
+}

--- a/test/ssl-tests/14-curves.cnf
+++ b/test/ssl-tests/14-curves.cnf
@@ -3,35 +3,35 @@
 num_tests = 30
 
 test-0 = 0-curve-sect163k1
-test-1 = 1-curve-sect163r1
-test-2 = 2-curve-sect163r2
-test-3 = 3-curve-sect193r1
-test-4 = 4-curve-sect193r2
-test-5 = 5-curve-sect233k1
-test-6 = 6-curve-sect233r1
-test-7 = 7-curve-sect239k1
-test-8 = 8-curve-sect283k1
-test-9 = 9-curve-sect283r1
-test-10 = 10-curve-sect409k1
-test-11 = 11-curve-sect409r1
-test-12 = 12-curve-sect571k1
-test-13 = 13-curve-sect571r1
-test-14 = 14-curve-secp160k1
-test-15 = 15-curve-secp160r1
-test-16 = 16-curve-secp160r2
-test-17 = 17-curve-secp192k1
-test-18 = 18-curve-prime192v1
-test-19 = 19-curve-secp224k1
-test-20 = 20-curve-secp224r1
-test-21 = 21-curve-secp256k1
-test-22 = 22-curve-prime256v1
-test-23 = 23-curve-secp384r1
-test-24 = 24-curve-secp521r1
-test-25 = 25-curve-brainpoolP256r1
-test-26 = 26-curve-brainpoolP384r1
-test-27 = 27-curve-brainpoolP512r1
-test-28 = 28-curve-X25519
-test-29 = 29-curve-X448
+test-1 = 1-curve-sect163r2
+test-2 = 2-curve-sect233k1
+test-3 = 3-curve-sect233r1
+test-4 = 4-curve-sect283k1
+test-5 = 5-curve-sect283r1
+test-6 = 6-curve-sect409k1
+test-7 = 7-curve-sect409r1
+test-8 = 8-curve-sect571k1
+test-9 = 9-curve-sect571r1
+test-10 = 10-curve-prime192v1
+test-11 = 11-curve-secp224r1
+test-12 = 12-curve-prime256v1
+test-13 = 13-curve-secp384r1
+test-14 = 14-curve-secp521r1
+test-15 = 15-curve-X25519
+test-16 = 16-curve-X448
+test-17 = 17-curve-sect163r1
+test-18 = 18-curve-sect193r1
+test-19 = 19-curve-sect193r2
+test-20 = 20-curve-sect239k1
+test-21 = 21-curve-secp160k1
+test-22 = 22-curve-secp160r1
+test-23 = 23-curve-secp160r2
+test-24 = 24-curve-secp192k1
+test-25 = 25-curve-secp224k1
+test-26 = 26-curve-secp256k1
+test-27 = 27-curve-brainpoolP256r1
+test-28 = 28-curve-brainpoolP384r1
+test-29 = 29-curve-brainpoolP512r1
 # ===========================================================
 
 [0-curve-sect163k1]
@@ -62,813 +62,813 @@ ExpectedTmpKeyType = sect163k1
 
 # ===========================================================
 
-[1-curve-sect163r1]
-ssl_conf = 1-curve-sect163r1-ssl
+[1-curve-sect163r2]
+ssl_conf = 1-curve-sect163r2-ssl
 
-[1-curve-sect163r1-ssl]
-server = 1-curve-sect163r1-server
-client = 1-curve-sect163r1-client
+[1-curve-sect163r2-ssl]
+server = 1-curve-sect163r2-server
+client = 1-curve-sect163r2-client
 
-[1-curve-sect163r1-server]
+[1-curve-sect163r2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect163r1
+Curves = sect163r2
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[1-curve-sect163r1-client]
+[1-curve-sect163r2-client]
 CipherString = ECDHE
-Curves = sect163r1
+Curves = sect163r2
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-1]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect163r1
+ExpectedTmpKeyType = sect163r2
 
 
 # ===========================================================
 
-[2-curve-sect163r2]
-ssl_conf = 2-curve-sect163r2-ssl
+[2-curve-sect233k1]
+ssl_conf = 2-curve-sect233k1-ssl
 
-[2-curve-sect163r2-ssl]
-server = 2-curve-sect163r2-server
-client = 2-curve-sect163r2-client
+[2-curve-sect233k1-ssl]
+server = 2-curve-sect233k1-server
+client = 2-curve-sect233k1-client
 
-[2-curve-sect163r2-server]
+[2-curve-sect233k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect163r2
+Curves = sect233k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[2-curve-sect163r2-client]
+[2-curve-sect233k1-client]
 CipherString = ECDHE
-Curves = sect163r2
+Curves = sect233k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-2]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect163r2
+ExpectedTmpKeyType = sect233k1
 
 
 # ===========================================================
 
-[3-curve-sect193r1]
-ssl_conf = 3-curve-sect193r1-ssl
+[3-curve-sect233r1]
+ssl_conf = 3-curve-sect233r1-ssl
 
-[3-curve-sect193r1-ssl]
-server = 3-curve-sect193r1-server
-client = 3-curve-sect193r1-client
+[3-curve-sect233r1-ssl]
+server = 3-curve-sect233r1-server
+client = 3-curve-sect233r1-client
 
-[3-curve-sect193r1-server]
+[3-curve-sect233r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect193r1
+Curves = sect233r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[3-curve-sect193r1-client]
+[3-curve-sect233r1-client]
 CipherString = ECDHE
-Curves = sect193r1
+Curves = sect233r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-3]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect193r1
+ExpectedTmpKeyType = sect233r1
 
 
 # ===========================================================
 
-[4-curve-sect193r2]
-ssl_conf = 4-curve-sect193r2-ssl
+[4-curve-sect283k1]
+ssl_conf = 4-curve-sect283k1-ssl
 
-[4-curve-sect193r2-ssl]
-server = 4-curve-sect193r2-server
-client = 4-curve-sect193r2-client
+[4-curve-sect283k1-ssl]
+server = 4-curve-sect283k1-server
+client = 4-curve-sect283k1-client
 
-[4-curve-sect193r2-server]
+[4-curve-sect283k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect193r2
+Curves = sect283k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[4-curve-sect193r2-client]
+[4-curve-sect283k1-client]
 CipherString = ECDHE
-Curves = sect193r2
+Curves = sect283k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-4]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect193r2
+ExpectedTmpKeyType = sect283k1
 
 
 # ===========================================================
 
-[5-curve-sect233k1]
-ssl_conf = 5-curve-sect233k1-ssl
+[5-curve-sect283r1]
+ssl_conf = 5-curve-sect283r1-ssl
 
-[5-curve-sect233k1-ssl]
-server = 5-curve-sect233k1-server
-client = 5-curve-sect233k1-client
+[5-curve-sect283r1-ssl]
+server = 5-curve-sect283r1-server
+client = 5-curve-sect283r1-client
 
-[5-curve-sect233k1-server]
+[5-curve-sect283r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect233k1
+Curves = sect283r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[5-curve-sect233k1-client]
+[5-curve-sect283r1-client]
 CipherString = ECDHE
-Curves = sect233k1
+Curves = sect283r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-5]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect233k1
+ExpectedTmpKeyType = sect283r1
 
 
 # ===========================================================
 
-[6-curve-sect233r1]
-ssl_conf = 6-curve-sect233r1-ssl
+[6-curve-sect409k1]
+ssl_conf = 6-curve-sect409k1-ssl
 
-[6-curve-sect233r1-ssl]
-server = 6-curve-sect233r1-server
-client = 6-curve-sect233r1-client
+[6-curve-sect409k1-ssl]
+server = 6-curve-sect409k1-server
+client = 6-curve-sect409k1-client
 
-[6-curve-sect233r1-server]
+[6-curve-sect409k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect233r1
+Curves = sect409k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[6-curve-sect233r1-client]
+[6-curve-sect409k1-client]
 CipherString = ECDHE
-Curves = sect233r1
+Curves = sect409k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-6]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect233r1
+ExpectedTmpKeyType = sect409k1
 
 
 # ===========================================================
 
-[7-curve-sect239k1]
-ssl_conf = 7-curve-sect239k1-ssl
+[7-curve-sect409r1]
+ssl_conf = 7-curve-sect409r1-ssl
 
-[7-curve-sect239k1-ssl]
-server = 7-curve-sect239k1-server
-client = 7-curve-sect239k1-client
+[7-curve-sect409r1-ssl]
+server = 7-curve-sect409r1-server
+client = 7-curve-sect409r1-client
 
-[7-curve-sect239k1-server]
+[7-curve-sect409r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect239k1
+Curves = sect409r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[7-curve-sect239k1-client]
+[7-curve-sect409r1-client]
 CipherString = ECDHE
-Curves = sect239k1
+Curves = sect409r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-7]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect239k1
+ExpectedTmpKeyType = sect409r1
 
 
 # ===========================================================
 
-[8-curve-sect283k1]
-ssl_conf = 8-curve-sect283k1-ssl
+[8-curve-sect571k1]
+ssl_conf = 8-curve-sect571k1-ssl
 
-[8-curve-sect283k1-ssl]
-server = 8-curve-sect283k1-server
-client = 8-curve-sect283k1-client
+[8-curve-sect571k1-ssl]
+server = 8-curve-sect571k1-server
+client = 8-curve-sect571k1-client
 
-[8-curve-sect283k1-server]
+[8-curve-sect571k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect283k1
+Curves = sect571k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[8-curve-sect283k1-client]
+[8-curve-sect571k1-client]
 CipherString = ECDHE
-Curves = sect283k1
+Curves = sect571k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-8]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect283k1
+ExpectedTmpKeyType = sect571k1
 
 
 # ===========================================================
 
-[9-curve-sect283r1]
-ssl_conf = 9-curve-sect283r1-ssl
+[9-curve-sect571r1]
+ssl_conf = 9-curve-sect571r1-ssl
 
-[9-curve-sect283r1-ssl]
-server = 9-curve-sect283r1-server
-client = 9-curve-sect283r1-client
+[9-curve-sect571r1-ssl]
+server = 9-curve-sect571r1-server
+client = 9-curve-sect571r1-client
 
-[9-curve-sect283r1-server]
+[9-curve-sect571r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect283r1
+Curves = sect571r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[9-curve-sect283r1-client]
+[9-curve-sect571r1-client]
 CipherString = ECDHE
-Curves = sect283r1
+Curves = sect571r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-9]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect283r1
+ExpectedTmpKeyType = sect571r1
 
 
 # ===========================================================
 
-[10-curve-sect409k1]
-ssl_conf = 10-curve-sect409k1-ssl
+[10-curve-prime192v1]
+ssl_conf = 10-curve-prime192v1-ssl
 
-[10-curve-sect409k1-ssl]
-server = 10-curve-sect409k1-server
-client = 10-curve-sect409k1-client
+[10-curve-prime192v1-ssl]
+server = 10-curve-prime192v1-server
+client = 10-curve-prime192v1-client
 
-[10-curve-sect409k1-server]
+[10-curve-prime192v1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect409k1
+Curves = prime192v1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[10-curve-sect409k1-client]
+[10-curve-prime192v1-client]
 CipherString = ECDHE
-Curves = sect409k1
+Curves = prime192v1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-10]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect409k1
+ExpectedTmpKeyType = prime192v1
 
 
 # ===========================================================
 
-[11-curve-sect409r1]
-ssl_conf = 11-curve-sect409r1-ssl
+[11-curve-secp224r1]
+ssl_conf = 11-curve-secp224r1-ssl
 
-[11-curve-sect409r1-ssl]
-server = 11-curve-sect409r1-server
-client = 11-curve-sect409r1-client
+[11-curve-secp224r1-ssl]
+server = 11-curve-secp224r1-server
+client = 11-curve-secp224r1-client
 
-[11-curve-sect409r1-server]
+[11-curve-secp224r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect409r1
+Curves = secp224r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[11-curve-sect409r1-client]
+[11-curve-secp224r1-client]
 CipherString = ECDHE
-Curves = sect409r1
+Curves = secp224r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-11]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect409r1
+ExpectedTmpKeyType = secp224r1
 
 
 # ===========================================================
 
-[12-curve-sect571k1]
-ssl_conf = 12-curve-sect571k1-ssl
+[12-curve-prime256v1]
+ssl_conf = 12-curve-prime256v1-ssl
 
-[12-curve-sect571k1-ssl]
-server = 12-curve-sect571k1-server
-client = 12-curve-sect571k1-client
+[12-curve-prime256v1-ssl]
+server = 12-curve-prime256v1-server
+client = 12-curve-prime256v1-client
 
-[12-curve-sect571k1-server]
+[12-curve-prime256v1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect571k1
+Curves = prime256v1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[12-curve-sect571k1-client]
+[12-curve-prime256v1-client]
 CipherString = ECDHE
-Curves = sect571k1
+Curves = prime256v1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-12]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect571k1
+ExpectedTmpKeyType = prime256v1
 
 
 # ===========================================================
 
-[13-curve-sect571r1]
-ssl_conf = 13-curve-sect571r1-ssl
+[13-curve-secp384r1]
+ssl_conf = 13-curve-secp384r1-ssl
 
-[13-curve-sect571r1-ssl]
-server = 13-curve-sect571r1-server
-client = 13-curve-sect571r1-client
+[13-curve-secp384r1-ssl]
+server = 13-curve-secp384r1-server
+client = 13-curve-secp384r1-client
 
-[13-curve-sect571r1-server]
+[13-curve-secp384r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = sect571r1
+Curves = secp384r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[13-curve-sect571r1-client]
+[13-curve-secp384r1-client]
 CipherString = ECDHE
-Curves = sect571r1
+Curves = secp384r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-13]
 ExpectedResult = Success
-ExpectedTmpKeyType = sect571r1
+ExpectedTmpKeyType = secp384r1
 
 
 # ===========================================================
 
-[14-curve-secp160k1]
-ssl_conf = 14-curve-secp160k1-ssl
+[14-curve-secp521r1]
+ssl_conf = 14-curve-secp521r1-ssl
 
-[14-curve-secp160k1-ssl]
-server = 14-curve-secp160k1-server
-client = 14-curve-secp160k1-client
+[14-curve-secp521r1-ssl]
+server = 14-curve-secp521r1-server
+client = 14-curve-secp521r1-client
 
-[14-curve-secp160k1-server]
+[14-curve-secp521r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp160k1
+Curves = secp521r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[14-curve-secp160k1-client]
+[14-curve-secp521r1-client]
 CipherString = ECDHE
-Curves = secp160k1
+Curves = secp521r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-14]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp160k1
+ExpectedTmpKeyType = secp521r1
 
 
 # ===========================================================
 
-[15-curve-secp160r1]
-ssl_conf = 15-curve-secp160r1-ssl
+[15-curve-X25519]
+ssl_conf = 15-curve-X25519-ssl
 
-[15-curve-secp160r1-ssl]
-server = 15-curve-secp160r1-server
-client = 15-curve-secp160r1-client
+[15-curve-X25519-ssl]
+server = 15-curve-X25519-server
+client = 15-curve-X25519-client
 
-[15-curve-secp160r1-server]
+[15-curve-X25519-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp160r1
+Curves = X25519
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[15-curve-secp160r1-client]
+[15-curve-X25519-client]
 CipherString = ECDHE
-Curves = secp160r1
+Curves = X25519
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-15]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp160r1
+ExpectedTmpKeyType = X25519
 
 
 # ===========================================================
 
-[16-curve-secp160r2]
-ssl_conf = 16-curve-secp160r2-ssl
+[16-curve-X448]
+ssl_conf = 16-curve-X448-ssl
 
-[16-curve-secp160r2-ssl]
-server = 16-curve-secp160r2-server
-client = 16-curve-secp160r2-client
+[16-curve-X448-ssl]
+server = 16-curve-X448-server
+client = 16-curve-X448-client
 
-[16-curve-secp160r2-server]
+[16-curve-X448-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp160r2
+Curves = X448
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[16-curve-secp160r2-client]
+[16-curve-X448-client]
 CipherString = ECDHE
-Curves = secp160r2
+Curves = X448
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-16]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp160r2
+ExpectedTmpKeyType = X448
 
 
 # ===========================================================
 
-[17-curve-secp192k1]
-ssl_conf = 17-curve-secp192k1-ssl
+[17-curve-sect163r1]
+ssl_conf = 17-curve-sect163r1-ssl
 
-[17-curve-secp192k1-ssl]
-server = 17-curve-secp192k1-server
-client = 17-curve-secp192k1-client
+[17-curve-sect163r1-ssl]
+server = 17-curve-sect163r1-server
+client = 17-curve-sect163r1-client
 
-[17-curve-secp192k1-server]
+[17-curve-sect163r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp192k1
+Curves = sect163r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[17-curve-secp192k1-client]
+[17-curve-sect163r1-client]
 CipherString = ECDHE
-Curves = secp192k1
+Curves = sect163r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-17]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp192k1
+ExpectedTmpKeyType = sect163r1
 
 
 # ===========================================================
 
-[18-curve-prime192v1]
-ssl_conf = 18-curve-prime192v1-ssl
+[18-curve-sect193r1]
+ssl_conf = 18-curve-sect193r1-ssl
 
-[18-curve-prime192v1-ssl]
-server = 18-curve-prime192v1-server
-client = 18-curve-prime192v1-client
+[18-curve-sect193r1-ssl]
+server = 18-curve-sect193r1-server
+client = 18-curve-sect193r1-client
 
-[18-curve-prime192v1-server]
+[18-curve-sect193r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = prime192v1
+Curves = sect193r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[18-curve-prime192v1-client]
+[18-curve-sect193r1-client]
 CipherString = ECDHE
-Curves = prime192v1
+Curves = sect193r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-18]
 ExpectedResult = Success
-ExpectedTmpKeyType = prime192v1
+ExpectedTmpKeyType = sect193r1
 
 
 # ===========================================================
 
-[19-curve-secp224k1]
-ssl_conf = 19-curve-secp224k1-ssl
+[19-curve-sect193r2]
+ssl_conf = 19-curve-sect193r2-ssl
 
-[19-curve-secp224k1-ssl]
-server = 19-curve-secp224k1-server
-client = 19-curve-secp224k1-client
+[19-curve-sect193r2-ssl]
+server = 19-curve-sect193r2-server
+client = 19-curve-sect193r2-client
 
-[19-curve-secp224k1-server]
+[19-curve-sect193r2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp224k1
+Curves = sect193r2
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[19-curve-secp224k1-client]
+[19-curve-sect193r2-client]
 CipherString = ECDHE
-Curves = secp224k1
+Curves = sect193r2
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-19]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp224k1
+ExpectedTmpKeyType = sect193r2
 
 
 # ===========================================================
 
-[20-curve-secp224r1]
-ssl_conf = 20-curve-secp224r1-ssl
+[20-curve-sect239k1]
+ssl_conf = 20-curve-sect239k1-ssl
 
-[20-curve-secp224r1-ssl]
-server = 20-curve-secp224r1-server
-client = 20-curve-secp224r1-client
+[20-curve-sect239k1-ssl]
+server = 20-curve-sect239k1-server
+client = 20-curve-sect239k1-client
 
-[20-curve-secp224r1-server]
+[20-curve-sect239k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp224r1
+Curves = sect239k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[20-curve-secp224r1-client]
+[20-curve-sect239k1-client]
 CipherString = ECDHE
-Curves = secp224r1
+Curves = sect239k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-20]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp224r1
+ExpectedTmpKeyType = sect239k1
 
 
 # ===========================================================
 
-[21-curve-secp256k1]
-ssl_conf = 21-curve-secp256k1-ssl
+[21-curve-secp160k1]
+ssl_conf = 21-curve-secp160k1-ssl
 
-[21-curve-secp256k1-ssl]
-server = 21-curve-secp256k1-server
-client = 21-curve-secp256k1-client
+[21-curve-secp160k1-ssl]
+server = 21-curve-secp160k1-server
+client = 21-curve-secp160k1-client
 
-[21-curve-secp256k1-server]
+[21-curve-secp160k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp256k1
+Curves = secp160k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[21-curve-secp256k1-client]
+[21-curve-secp160k1-client]
 CipherString = ECDHE
-Curves = secp256k1
+Curves = secp160k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-21]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp256k1
+ExpectedTmpKeyType = secp160k1
 
 
 # ===========================================================
 
-[22-curve-prime256v1]
-ssl_conf = 22-curve-prime256v1-ssl
+[22-curve-secp160r1]
+ssl_conf = 22-curve-secp160r1-ssl
 
-[22-curve-prime256v1-ssl]
-server = 22-curve-prime256v1-server
-client = 22-curve-prime256v1-client
+[22-curve-secp160r1-ssl]
+server = 22-curve-secp160r1-server
+client = 22-curve-secp160r1-client
 
-[22-curve-prime256v1-server]
+[22-curve-secp160r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = prime256v1
+Curves = secp160r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[22-curve-prime256v1-client]
+[22-curve-secp160r1-client]
 CipherString = ECDHE
-Curves = prime256v1
+Curves = secp160r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-22]
 ExpectedResult = Success
-ExpectedTmpKeyType = prime256v1
+ExpectedTmpKeyType = secp160r1
 
 
 # ===========================================================
 
-[23-curve-secp384r1]
-ssl_conf = 23-curve-secp384r1-ssl
+[23-curve-secp160r2]
+ssl_conf = 23-curve-secp160r2-ssl
 
-[23-curve-secp384r1-ssl]
-server = 23-curve-secp384r1-server
-client = 23-curve-secp384r1-client
+[23-curve-secp160r2-ssl]
+server = 23-curve-secp160r2-server
+client = 23-curve-secp160r2-client
 
-[23-curve-secp384r1-server]
+[23-curve-secp160r2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp384r1
+Curves = secp160r2
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[23-curve-secp384r1-client]
+[23-curve-secp160r2-client]
 CipherString = ECDHE
-Curves = secp384r1
+Curves = secp160r2
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-23]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp384r1
+ExpectedTmpKeyType = secp160r2
 
 
 # ===========================================================
 
-[24-curve-secp521r1]
-ssl_conf = 24-curve-secp521r1-ssl
+[24-curve-secp192k1]
+ssl_conf = 24-curve-secp192k1-ssl
 
-[24-curve-secp521r1-ssl]
-server = 24-curve-secp521r1-server
-client = 24-curve-secp521r1-client
+[24-curve-secp192k1-ssl]
+server = 24-curve-secp192k1-server
+client = 24-curve-secp192k1-client
 
-[24-curve-secp521r1-server]
+[24-curve-secp192k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = secp521r1
+Curves = secp192k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[24-curve-secp521r1-client]
+[24-curve-secp192k1-client]
 CipherString = ECDHE
-Curves = secp521r1
+Curves = secp192k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-24]
 ExpectedResult = Success
-ExpectedTmpKeyType = secp521r1
+ExpectedTmpKeyType = secp192k1
 
 
 # ===========================================================
 
-[25-curve-brainpoolP256r1]
-ssl_conf = 25-curve-brainpoolP256r1-ssl
+[25-curve-secp224k1]
+ssl_conf = 25-curve-secp224k1-ssl
 
-[25-curve-brainpoolP256r1-ssl]
-server = 25-curve-brainpoolP256r1-server
-client = 25-curve-brainpoolP256r1-client
+[25-curve-secp224k1-ssl]
+server = 25-curve-secp224k1-server
+client = 25-curve-secp224k1-client
 
-[25-curve-brainpoolP256r1-server]
+[25-curve-secp224k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = brainpoolP256r1
+Curves = secp224k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[25-curve-brainpoolP256r1-client]
+[25-curve-secp224k1-client]
 CipherString = ECDHE
-Curves = brainpoolP256r1
+Curves = secp224k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-25]
 ExpectedResult = Success
-ExpectedTmpKeyType = brainpoolP256r1
+ExpectedTmpKeyType = secp224k1
 
 
 # ===========================================================
 
-[26-curve-brainpoolP384r1]
-ssl_conf = 26-curve-brainpoolP384r1-ssl
+[26-curve-secp256k1]
+ssl_conf = 26-curve-secp256k1-ssl
 
-[26-curve-brainpoolP384r1-ssl]
-server = 26-curve-brainpoolP384r1-server
-client = 26-curve-brainpoolP384r1-client
+[26-curve-secp256k1-ssl]
+server = 26-curve-secp256k1-server
+client = 26-curve-secp256k1-client
 
-[26-curve-brainpoolP384r1-server]
+[26-curve-secp256k1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = brainpoolP384r1
+Curves = secp256k1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[26-curve-brainpoolP384r1-client]
+[26-curve-secp256k1-client]
 CipherString = ECDHE
-Curves = brainpoolP384r1
+Curves = secp256k1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-26]
 ExpectedResult = Success
-ExpectedTmpKeyType = brainpoolP384r1
+ExpectedTmpKeyType = secp256k1
 
 
 # ===========================================================
 
-[27-curve-brainpoolP512r1]
-ssl_conf = 27-curve-brainpoolP512r1-ssl
+[27-curve-brainpoolP256r1]
+ssl_conf = 27-curve-brainpoolP256r1-ssl
 
-[27-curve-brainpoolP512r1-ssl]
-server = 27-curve-brainpoolP512r1-server
-client = 27-curve-brainpoolP512r1-client
+[27-curve-brainpoolP256r1-ssl]
+server = 27-curve-brainpoolP256r1-server
+client = 27-curve-brainpoolP256r1-client
 
-[27-curve-brainpoolP512r1-server]
+[27-curve-brainpoolP256r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = brainpoolP512r1
+Curves = brainpoolP256r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[27-curve-brainpoolP512r1-client]
+[27-curve-brainpoolP256r1-client]
 CipherString = ECDHE
-Curves = brainpoolP512r1
+Curves = brainpoolP256r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-27]
 ExpectedResult = Success
-ExpectedTmpKeyType = brainpoolP512r1
+ExpectedTmpKeyType = brainpoolP256r1
 
 
 # ===========================================================
 
-[28-curve-X25519]
-ssl_conf = 28-curve-X25519-ssl
+[28-curve-brainpoolP384r1]
+ssl_conf = 28-curve-brainpoolP384r1-ssl
 
-[28-curve-X25519-ssl]
-server = 28-curve-X25519-server
-client = 28-curve-X25519-client
+[28-curve-brainpoolP384r1-ssl]
+server = 28-curve-brainpoolP384r1-server
+client = 28-curve-brainpoolP384r1-client
 
-[28-curve-X25519-server]
+[28-curve-brainpoolP384r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = X25519
+Curves = brainpoolP384r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[28-curve-X25519-client]
+[28-curve-brainpoolP384r1-client]
 CipherString = ECDHE
-Curves = X25519
+Curves = brainpoolP384r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-28]
 ExpectedResult = Success
-ExpectedTmpKeyType = X25519
+ExpectedTmpKeyType = brainpoolP384r1
 
 
 # ===========================================================
 
-[29-curve-X448]
-ssl_conf = 29-curve-X448-ssl
+[29-curve-brainpoolP512r1]
+ssl_conf = 29-curve-brainpoolP512r1-ssl
 
-[29-curve-X448-ssl]
-server = 29-curve-X448-server
-client = 29-curve-X448-client
+[29-curve-brainpoolP512r1-ssl]
+server = 29-curve-brainpoolP512r1-server
+client = 29-curve-brainpoolP512r1-client
 
-[29-curve-X448-server]
+[29-curve-brainpoolP512r1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-Curves = X448
+Curves = brainpoolP512r1
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[29-curve-X448-client]
+[29-curve-brainpoolP512r1-client]
 CipherString = ECDHE
-Curves = X448
+Curves = brainpoolP512r1
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-29]
 ExpectedResult = Success
-ExpectedTmpKeyType = X448
+ExpectedTmpKeyType = brainpoolP512r1
 
 

--- a/test/ssl-tests/14-curves.cnf.in
+++ b/test/ssl-tests/14-curves.cnf.in
@@ -10,9 +10,11 @@ use warnings;
 use OpenSSL::Test;
 use OpenSSL::Test::Utils qw(anydisabled);
 
+our $fips_mode;
+
 my @curves;
 
-if (FIPS_MODE) {
+if ($fips_mode) {
     @curves = ("sect163k1", "sect163r2", "sect233k1", "sect233r1",
                "sect283k1", "sect283r1", "sect409k1", "sect409r1",
                "sect571k1", "sect571r1", "prime192v1", "secp224r1",

--- a/test/ssl-tests/14-curves.cnf.in
+++ b/test/ssl-tests/14-curves.cnf.in
@@ -10,14 +10,24 @@ use warnings;
 use OpenSSL::Test;
 use OpenSSL::Test::Utils qw(anydisabled);
 
-my @curves = ("sect163k1", "sect163r1", "sect163r2", "sect193r1",
-              "sect193r2", "sect233k1", "sect233r1", "sect239k1",
-              "sect283k1", "sect283r1", "sect409k1", "sect409r1",
-              "sect571k1", "sect571r1", "secp160k1", "secp160r1",
-              "secp160r2", "secp192k1", "prime192v1", "secp224k1",
-              "secp224r1", "secp256k1", "prime256v1", "secp384r1",
-              "secp521r1", "brainpoolP256r1", "brainpoolP384r1",
-              "brainpoolP512r1", "X25519", "X448");
+my @curves;
+
+if (FIPS_MODE) {
+    @curves = ("sect163k1", "sect163r2", "sect233k1", "sect233r1",
+               "sect283k1", "sect283r1", "sect409k1", "sect409r1",
+               "sect571k1", "sect571r1", "prime192v1", "secp224r1",
+               "prime256v1", "secp384r1", "secp521r1", "X25519",
+               "X448");
+} else {
+    @curves = ("sect163k1", "sect163r1", "sect163r2", "sect193r1",
+               "sect193r2", "sect233k1", "sect233r1", "sect239k1",
+               "sect283k1", "sect283r1", "sect409k1", "sect409r1",
+               "sect571k1", "sect571r1", "secp160k1", "secp160r1",
+               "secp160r2", "secp192k1", "prime192v1", "secp224k1",
+               "secp224r1", "secp256k1", "prime256v1", "secp384r1",
+               "secp521r1", "brainpoolP256r1", "brainpoolP384r1",
+               "brainpoolP512r1", "X25519", "X448");
+}
 
 our @tests = ();
 

--- a/test/ssl-tests/14-curves.cnf.in
+++ b/test/ssl-tests/14-curves.cnf.in
@@ -12,24 +12,18 @@ use OpenSSL::Test::Utils qw(anydisabled);
 
 our $fips_mode;
 
-my @curves;
+my @curves = ("sect163k1", "sect163r2", "sect233k1", "sect233r1",
+              "sect283k1", "sect283r1", "sect409k1", "sect409r1",
+              "sect571k1", "sect571r1", "prime192v1", "secp224r1",
+              "prime256v1", "secp384r1", "secp521r1", "X25519",
+              "X448");
 
-if ($fips_mode) {
-    @curves = ("sect163k1", "sect163r2", "sect233k1", "sect233r1",
-               "sect283k1", "sect283r1", "sect409k1", "sect409r1",
-               "sect571k1", "sect571r1", "prime192v1", "secp224r1",
-               "prime256v1", "secp384r1", "secp521r1", "X25519",
-               "X448");
-} else {
-    @curves = ("sect163k1", "sect163r1", "sect163r2", "sect193r1",
-               "sect193r2", "sect233k1", "sect233r1", "sect239k1",
-               "sect283k1", "sect283r1", "sect409k1", "sect409r1",
-               "sect571k1", "sect571r1", "secp160k1", "secp160r1",
-               "secp160r2", "secp192k1", "prime192v1", "secp224k1",
-               "secp224r1", "secp256k1", "prime256v1", "secp384r1",
-               "secp521r1", "brainpoolP256r1", "brainpoolP384r1",
-               "brainpoolP512r1", "X25519", "X448");
-}
+my @curves_non_fips = ("sect163r1", "sect193r1", "sect193r2", "sect239k1",
+                       "secp160k1", "secp160r1", "secp160r2", "secp192k1",
+                       "secp224k1",  "secp256k1", "brainpoolP256r1",
+                       "brainpoolP384r1", "brainpoolP512r1");
+
+push @curves, @curves_non_fips if !$fips_mode;
 
 our @tests = ();
 

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -9,33 +9,33 @@ test-3 = 3-Ed25519 CipherString and Signature Algorithm Selection
 test-4 = 4-Ed448 CipherString and Signature Algorithm Selection
 test-5 = 5-ECDSA with brainpool
 test-6 = 6-RSA CipherString Selection
-test-7 = 7-RSA-PSS Certificate CipherString Selection
-test-8 = 8-P-256 CipherString and Signature Algorithm Selection
-test-9 = 9-Ed25519 CipherString and Curves Selection
-test-10 = 10-Ed448 CipherString and Curves Selection
-test-11 = 11-ECDSA CipherString Selection, no ECDSA certificate
-test-12 = 12-ECDSA Signature Algorithm Selection
-test-13 = 13-ECDSA Signature Algorithm Selection SHA384
-test-14 = 14-ECDSA Signature Algorithm Selection SHA1
-test-15 = 15-ECDSA Signature Algorithm Selection compressed point
-test-16 = 16-ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-17 = 17-RSA Signature Algorithm Selection
-test-18 = 18-RSA-PSS Signature Algorithm Selection
-test-19 = 19-RSA-PSS Certificate Legacy Signature Algorithm Selection
-test-20 = 20-RSA-PSS Certificate Unified Signature Algorithm Selection
-test-21 = 21-Only RSA-PSS Certificate
-test-22 = 22-Only RSA-PSS Certificate Valid Signature Algorithms
-test-23 = 23-RSA-PSS Certificate, no PSS signature algorithms
-test-24 = 24-Only RSA-PSS Restricted Certificate
-test-25 = 25-RSA-PSS Restricted Certificate Valid Signature Algorithms
-test-26 = 26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm
-test-27 = 27-RSA-PSS Restricted Certificate Invalid Signature Algorithms
-test-28 = 28-RSA key exchange with all RSA certificate types
-test-29 = 29-RSA key exchange with only RSA-PSS certificate
-test-30 = 30-Suite B P-256 Hash Algorithm Selection
-test-31 = 31-Suite B P-384 Hash Algorithm Selection
-test-32 = 32-TLS 1.2 Ed25519 Client Auth
-test-33 = 33-TLS 1.2 Ed448 Client Auth
+test-7 = 7-P-256 CipherString and Signature Algorithm Selection
+test-8 = 8-Ed25519 CipherString and Curves Selection
+test-9 = 9-Ed448 CipherString and Curves Selection
+test-10 = 10-ECDSA CipherString Selection, no ECDSA certificate
+test-11 = 11-ECDSA Signature Algorithm Selection
+test-12 = 12-ECDSA Signature Algorithm Selection SHA384
+test-13 = 13-ECDSA Signature Algorithm Selection SHA1
+test-14 = 14-ECDSA Signature Algorithm Selection compressed point
+test-15 = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-16 = 16-RSA Signature Algorithm Selection
+test-17 = 17-RSA-PSS Signature Algorithm Selection
+test-18 = 18-RSA key exchange with all RSA certificate types
+test-19 = 19-Suite B P-256 Hash Algorithm Selection
+test-20 = 20-Suite B P-384 Hash Algorithm Selection
+test-21 = 21-TLS 1.2 Ed25519 Client Auth
+test-22 = 22-TLS 1.2 Ed448 Client Auth
+test-23 = 23-RSA-PSS Certificate CipherString Selection
+test-24 = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection
+test-25 = 25-RSA-PSS Certificate Unified Signature Algorithm Selection
+test-26 = 26-Only RSA-PSS Certificate
+test-27 = 27-Only RSA-PSS Certificate Valid Signature Algorithms
+test-28 = 28-RSA-PSS Certificate, no PSS signature algorithms
+test-29 = 29-Only RSA-PSS Restricted Certificate
+test-30 = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms
+test-31 = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm
+test-32 = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms
+test-33 = 33-RSA key exchange with only RSA-PSS certificate
 test-34 = 34-Only RSA-PSS Certificate, TLS v1.1
 test-35 = 35-TLS 1.3 ECDSA Signature Algorithm Selection
 test-36 = 36-TLS 1.3 ECDSA Signature Algorithm Selection compressed point
@@ -292,49 +292,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[7-RSA-PSS Certificate CipherString Selection]
-ssl_conf = 7-RSA-PSS Certificate CipherString Selection-ssl
+[7-P-256 CipherString and Signature Algorithm Selection]
+ssl_conf = 7-P-256 CipherString and Signature Algorithm Selection-ssl
 
-[7-RSA-PSS Certificate CipherString Selection-ssl]
-server = 7-RSA-PSS Certificate CipherString Selection-server
-client = 7-RSA-PSS Certificate CipherString Selection-client
+[7-P-256 CipherString and Signature Algorithm Selection-ssl]
+server = 7-P-256 CipherString and Signature Algorithm Selection-server
+client = 7-P-256 CipherString and Signature Algorithm Selection-client
 
-[7-RSA-PSS Certificate CipherString Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.2
-PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[7-RSA-PSS Certificate CipherString Selection-client]
-CipherString = aRSA
-MaxProtocol = TLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-7]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[8-P-256 CipherString and Signature Algorithm Selection]
-ssl_conf = 8-P-256 CipherString and Signature Algorithm Selection-ssl
-
-[8-P-256 CipherString and Signature Algorithm Selection-ssl]
-server = 8-P-256 CipherString and Signature Algorithm Selection-server
-client = 8-P-256 CipherString and Signature Algorithm Selection-client
-
-[8-P-256 CipherString and Signature Algorithm Selection-server]
+[7-P-256 CipherString and Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -346,14 +311,14 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[8-P-256 CipherString and Signature Algorithm Selection-client]
+[7-P-256 CipherString and Signature Algorithm Selection-client]
 CipherString = aECDSA
 MaxProtocol = TLSv1.2
 SignatureAlgorithms = ECDSA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-8]
+[test-7]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -362,14 +327,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[9-Ed25519 CipherString and Curves Selection]
-ssl_conf = 9-Ed25519 CipherString and Curves Selection-ssl
+[8-Ed25519 CipherString and Curves Selection]
+ssl_conf = 8-Ed25519 CipherString and Curves Selection-ssl
 
-[9-Ed25519 CipherString and Curves Selection-ssl]
-server = 9-Ed25519 CipherString and Curves Selection-server
-client = 9-Ed25519 CipherString and Curves Selection-client
+[8-Ed25519 CipherString and Curves Selection-ssl]
+server = 8-Ed25519 CipherString and Curves Selection-server
+client = 8-Ed25519 CipherString and Curves Selection-client
 
-[9-Ed25519 CipherString and Curves Selection-server]
+[8-Ed25519 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -381,7 +346,7 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[9-Ed25519 CipherString and Curves Selection-client]
+[8-Ed25519 CipherString and Curves Selection-client]
 CipherString = aECDSA
 Curves = X25519
 MaxProtocol = TLSv1.2
@@ -389,7 +354,7 @@ SignatureAlgorithms = ECDSA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-9]
+[test-8]
 ExpectedResult = Success
 ExpectedServerCertType = Ed25519
 ExpectedServerSignType = Ed25519
@@ -397,14 +362,14 @@ ExpectedServerSignType = Ed25519
 
 # ===========================================================
 
-[10-Ed448 CipherString and Curves Selection]
-ssl_conf = 10-Ed448 CipherString and Curves Selection-ssl
+[9-Ed448 CipherString and Curves Selection]
+ssl_conf = 9-Ed448 CipherString and Curves Selection-ssl
 
-[10-Ed448 CipherString and Curves Selection-ssl]
-server = 10-Ed448 CipherString and Curves Selection-server
-client = 10-Ed448 CipherString and Curves Selection-client
+[9-Ed448 CipherString and Curves Selection-ssl]
+server = 9-Ed448 CipherString and Curves Selection-server
+client = 9-Ed448 CipherString and Curves Selection-client
 
-[10-Ed448 CipherString and Curves Selection-server]
+[9-Ed448 CipherString and Curves Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -416,7 +381,7 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[10-Ed448 CipherString and Curves Selection-client]
+[9-Ed448 CipherString and Curves Selection-client]
 CipherString = aECDSA
 Curves = X448
 MaxProtocol = TLSv1.2
@@ -424,7 +389,7 @@ SignatureAlgorithms = ECDSA+SHA256:ed448
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
 VerifyMode = Peer
 
-[test-10]
+[test-9]
 ExpectedResult = Success
 ExpectedServerCertType = Ed448
 ExpectedServerSignType = Ed448
@@ -432,39 +397,39 @@ ExpectedServerSignType = Ed448
 
 # ===========================================================
 
-[11-ECDSA CipherString Selection, no ECDSA certificate]
-ssl_conf = 11-ECDSA CipherString Selection, no ECDSA certificate-ssl
+[10-ECDSA CipherString Selection, no ECDSA certificate]
+ssl_conf = 10-ECDSA CipherString Selection, no ECDSA certificate-ssl
 
-[11-ECDSA CipherString Selection, no ECDSA certificate-ssl]
-server = 11-ECDSA CipherString Selection, no ECDSA certificate-server
-client = 11-ECDSA CipherString Selection, no ECDSA certificate-client
+[10-ECDSA CipherString Selection, no ECDSA certificate-ssl]
+server = 10-ECDSA CipherString Selection, no ECDSA certificate-server
+client = 10-ECDSA CipherString Selection, no ECDSA certificate-client
 
-[11-ECDSA CipherString Selection, no ECDSA certificate-server]
+[10-ECDSA CipherString Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[11-ECDSA CipherString Selection, no ECDSA certificate-client]
+[10-ECDSA CipherString Selection, no ECDSA certificate-client]
 CipherString = aECDSA
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-11]
+[test-10]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[12-ECDSA Signature Algorithm Selection]
-ssl_conf = 12-ECDSA Signature Algorithm Selection-ssl
+[11-ECDSA Signature Algorithm Selection]
+ssl_conf = 11-ECDSA Signature Algorithm Selection-ssl
 
-[12-ECDSA Signature Algorithm Selection-ssl]
-server = 12-ECDSA Signature Algorithm Selection-server
-client = 12-ECDSA Signature Algorithm Selection-client
+[11-ECDSA Signature Algorithm Selection-ssl]
+server = 11-ECDSA Signature Algorithm Selection-server
+client = 11-ECDSA Signature Algorithm Selection-client
 
-[12-ECDSA Signature Algorithm Selection-server]
+[11-ECDSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -476,13 +441,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[12-ECDSA Signature Algorithm Selection-client]
+[11-ECDSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-12]
+[test-11]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -491,14 +456,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[13-ECDSA Signature Algorithm Selection SHA384]
-ssl_conf = 13-ECDSA Signature Algorithm Selection SHA384-ssl
+[12-ECDSA Signature Algorithm Selection SHA384]
+ssl_conf = 12-ECDSA Signature Algorithm Selection SHA384-ssl
 
-[13-ECDSA Signature Algorithm Selection SHA384-ssl]
-server = 13-ECDSA Signature Algorithm Selection SHA384-server
-client = 13-ECDSA Signature Algorithm Selection SHA384-client
+[12-ECDSA Signature Algorithm Selection SHA384-ssl]
+server = 12-ECDSA Signature Algorithm Selection SHA384-server
+client = 12-ECDSA Signature Algorithm Selection SHA384-client
 
-[13-ECDSA Signature Algorithm Selection SHA384-server]
+[12-ECDSA Signature Algorithm Selection SHA384-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -510,13 +475,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[13-ECDSA Signature Algorithm Selection SHA384-client]
+[12-ECDSA Signature Algorithm Selection SHA384-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-13]
+[test-12]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA384
@@ -525,14 +490,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[14-ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 14-ECDSA Signature Algorithm Selection SHA1-ssl
+[13-ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 13-ECDSA Signature Algorithm Selection SHA1-ssl
 
-[14-ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 14-ECDSA Signature Algorithm Selection SHA1-server
-client = 14-ECDSA Signature Algorithm Selection SHA1-client
+[13-ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 13-ECDSA Signature Algorithm Selection SHA1-server
+client = 13-ECDSA Signature Algorithm Selection SHA1-client
 
-[14-ECDSA Signature Algorithm Selection SHA1-server]
+[13-ECDSA Signature Algorithm Selection SHA1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -544,13 +509,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[14-ECDSA Signature Algorithm Selection SHA1-client]
+[13-ECDSA Signature Algorithm Selection SHA1-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-14]
+[test-13]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA1
@@ -559,14 +524,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[15-ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 15-ECDSA Signature Algorithm Selection compressed point-ssl
+[14-ECDSA Signature Algorithm Selection compressed point]
+ssl_conf = 14-ECDSA Signature Algorithm Selection compressed point-ssl
 
-[15-ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 15-ECDSA Signature Algorithm Selection compressed point-server
-client = 15-ECDSA Signature Algorithm Selection compressed point-client
+[14-ECDSA Signature Algorithm Selection compressed point-ssl]
+server = 14-ECDSA Signature Algorithm Selection compressed point-server
+client = 14-ECDSA Signature Algorithm Selection compressed point-client
 
-[15-ECDSA Signature Algorithm Selection compressed point-server]
+[14-ECDSA Signature Algorithm Selection compressed point-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
@@ -574,13 +539,13 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[15-ECDSA Signature Algorithm Selection compressed point-client]
+[14-ECDSA Signature Algorithm Selection compressed point-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-15]
+[test-14]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -589,39 +554,39 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[16-ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 16-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
+[15-ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
 
-[16-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 16-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 16-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
+[15-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
 
-[16-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
+[15-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[16-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
+[15-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-16]
+[test-15]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[17-RSA Signature Algorithm Selection]
-ssl_conf = 17-RSA Signature Algorithm Selection-ssl
+[16-RSA Signature Algorithm Selection]
+ssl_conf = 16-RSA Signature Algorithm Selection-ssl
 
-[17-RSA Signature Algorithm Selection-ssl]
-server = 17-RSA Signature Algorithm Selection-server
-client = 17-RSA Signature Algorithm Selection-client
+[16-RSA Signature Algorithm Selection-ssl]
+server = 16-RSA Signature Algorithm Selection-server
+client = 16-RSA Signature Algorithm Selection-client
 
-[17-RSA Signature Algorithm Selection-server]
+[16-RSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -633,13 +598,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[17-RSA Signature Algorithm Selection-client]
+[16-RSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-17]
+[test-16]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -648,14 +613,14 @@ ExpectedServerSignType = RSA
 
 # ===========================================================
 
-[18-RSA-PSS Signature Algorithm Selection]
-ssl_conf = 18-RSA-PSS Signature Algorithm Selection-ssl
+[17-RSA-PSS Signature Algorithm Selection]
+ssl_conf = 17-RSA-PSS Signature Algorithm Selection-ssl
 
-[18-RSA-PSS Signature Algorithm Selection-ssl]
-server = 18-RSA-PSS Signature Algorithm Selection-server
-client = 18-RSA-PSS Signature Algorithm Selection-client
+[17-RSA-PSS Signature Algorithm Selection-ssl]
+server = 17-RSA-PSS Signature Algorithm Selection-server
+client = 17-RSA-PSS Signature Algorithm Selection-client
 
-[18-RSA-PSS Signature Algorithm Selection-server]
+[17-RSA-PSS Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -667,29 +632,178 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[18-RSA-PSS Signature Algorithm Selection-client]
+[17-RSA-PSS Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA-PSS+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-17]
+ExpectedResult = Success
+ExpectedServerCertType = RSA
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
+
+
+# ===========================================================
+
+[18-RSA key exchange with all RSA certificate types]
+ssl_conf = 18-RSA key exchange with all RSA certificate types-ssl
+
+[18-RSA key exchange with all RSA certificate types-ssl]
+server = 18-RSA key exchange with all RSA certificate types-server
+client = 18-RSA key exchange with all RSA certificate types-client
+
+[18-RSA key exchange with all RSA certificate types-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[18-RSA key exchange with all RSA certificate types-client]
+CipherString = kRSA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-18]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[19-RSA-PSS Certificate Legacy Signature Algorithm Selection]
-ssl_conf = 19-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl
+[19-Suite B P-256 Hash Algorithm Selection]
+ssl_conf = 19-Suite B P-256 Hash Algorithm Selection-ssl
 
-[19-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl]
-server = 19-RSA-PSS Certificate Legacy Signature Algorithm Selection-server
-client = 19-RSA-PSS Certificate Legacy Signature Algorithm Selection-client
+[19-Suite B P-256 Hash Algorithm Selection-ssl]
+server = 19-Suite B P-256 Hash Algorithm Selection-server
+client = 19-Suite B P-256 Hash Algorithm Selection-client
 
-[19-RSA-PSS Certificate Legacy Signature Algorithm Selection-server]
+[19-Suite B P-256 Hash Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = SUITEB128
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[19-Suite B P-256 Hash Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
+VerifyMode = Peer
+
+[test-19]
+ExpectedResult = Success
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[20-Suite B P-384 Hash Algorithm Selection]
+ssl_conf = 20-Suite B P-384 Hash Algorithm Selection-ssl
+
+[20-Suite B P-384 Hash Algorithm Selection-ssl]
+server = 20-Suite B P-384 Hash Algorithm Selection-server
+client = 20-Suite B P-384 Hash Algorithm Selection-client
+
+[20-Suite B P-384 Hash Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = SUITEB128
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[20-Suite B P-384 Hash Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
+VerifyMode = Peer
+
+[test-20]
+ExpectedResult = Success
+ExpectedServerCertType = P-384
+ExpectedServerSignHash = SHA384
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[21-TLS 1.2 Ed25519 Client Auth]
+ssl_conf = 21-TLS 1.2 Ed25519 Client Auth-ssl
+
+[21-TLS 1.2 Ed25519 Client Auth-ssl]
+server = 21-TLS 1.2 Ed25519 Client Auth-server
+client = 21-TLS 1.2 Ed25519 Client Auth-client
+
+[21-TLS 1.2 Ed25519 Client Auth-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[21-TLS 1.2 Ed25519 Client Auth-client]
+CipherString = DEFAULT
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-21]
+ExpectedClientCertType = Ed25519
+ExpectedClientSignType = Ed25519
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[22-TLS 1.2 Ed448 Client Auth]
+ssl_conf = 22-TLS 1.2 Ed448 Client Auth-ssl
+
+[22-TLS 1.2 Ed448 Client Auth-ssl]
+server = 22-TLS 1.2 Ed448 Client Auth-server
+client = 22-TLS 1.2 Ed448 Client Auth-client
+
+[22-TLS 1.2 Ed448 Client Auth-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[22-TLS 1.2 Ed448 Client Auth-client]
+CipherString = DEFAULT
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-22]
+ExpectedClientCertType = Ed448
+ExpectedClientSignType = Ed448
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[23-RSA-PSS Certificate CipherString Selection]
+ssl_conf = 23-RSA-PSS Certificate CipherString Selection-ssl
+
+[23-RSA-PSS Certificate CipherString Selection-ssl]
+server = 23-RSA-PSS Certificate CipherString Selection-server
+client = 23-RSA-PSS Certificate CipherString Selection-client
+
+[23-RSA-PSS Certificate CipherString Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -703,13 +817,48 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[19-RSA-PSS Certificate Legacy Signature Algorithm Selection-client]
+[23-RSA-PSS Certificate CipherString Selection-client]
+CipherString = aRSA
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-23]
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignType = RSA-PSS
+
+
+# ===========================================================
+
+[24-RSA-PSS Certificate Legacy Signature Algorithm Selection]
+ssl_conf = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl
+
+[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-ssl]
+server = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-server
+client = 24-RSA-PSS Certificate Legacy Signature Algorithm Selection-client
+
+[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[24-RSA-PSS Certificate Legacy Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = RSA-PSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-19]
+[test-24]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
@@ -718,14 +867,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[20-RSA-PSS Certificate Unified Signature Algorithm Selection]
-ssl_conf = 20-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl
+[25-RSA-PSS Certificate Unified Signature Algorithm Selection]
+ssl_conf = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl
 
-[20-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl]
-server = 20-RSA-PSS Certificate Unified Signature Algorithm Selection-server
-client = 20-RSA-PSS Certificate Unified Signature Algorithm Selection-client
+[25-RSA-PSS Certificate Unified Signature Algorithm Selection-ssl]
+server = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-server
+client = 25-RSA-PSS Certificate Unified Signature Algorithm Selection-client
 
-[20-RSA-PSS Certificate Unified Signature Algorithm Selection-server]
+[25-RSA-PSS Certificate Unified Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -739,139 +888,9 @@ PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[20-RSA-PSS Certificate Unified Signature Algorithm Selection-client]
+[25-RSA-PSS Certificate Unified Signature Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = rsa_pss_pss_sha256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-20]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[21-Only RSA-PSS Certificate]
-ssl_conf = 21-Only RSA-PSS Certificate-ssl
-
-[21-Only RSA-PSS Certificate-ssl]
-server = 21-Only RSA-PSS Certificate-server
-client = 21-Only RSA-PSS Certificate-client
-
-[21-Only RSA-PSS Certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[21-Only RSA-PSS Certificate-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-21]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[22-Only RSA-PSS Certificate Valid Signature Algorithms]
-ssl_conf = 22-Only RSA-PSS Certificate Valid Signature Algorithms-ssl
-
-[22-Only RSA-PSS Certificate Valid Signature Algorithms-ssl]
-server = 22-Only RSA-PSS Certificate Valid Signature Algorithms-server
-client = 22-Only RSA-PSS Certificate Valid Signature Algorithms-client
-
-[22-Only RSA-PSS Certificate Valid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[22-Only RSA-PSS Certificate Valid Signature Algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = rsa_pss_pss_sha512
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-22]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA512
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[23-RSA-PSS Certificate, no PSS signature algorithms]
-ssl_conf = 23-RSA-PSS Certificate, no PSS signature algorithms-ssl
-
-[23-RSA-PSS Certificate, no PSS signature algorithms-ssl]
-server = 23-RSA-PSS Certificate, no PSS signature algorithms-server
-client = 23-RSA-PSS Certificate, no PSS signature algorithms-client
-
-[23-RSA-PSS Certificate, no PSS signature algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[23-RSA-PSS Certificate, no PSS signature algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = RSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-23]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[24-Only RSA-PSS Restricted Certificate]
-ssl_conf = 24-Only RSA-PSS Restricted Certificate-ssl
-
-[24-Only RSA-PSS Restricted Certificate-ssl]
-server = 24-Only RSA-PSS Restricted Certificate-server
-client = 24-Only RSA-PSS Restricted Certificate-client
-
-[24-Only RSA-PSS Restricted Certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
-
-[24-Only RSA-PSS Restricted Certificate-client]
-CipherString = DEFAULT
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-24]
-ExpectedResult = Success
-ExpectedServerCertType = RSA-PSS
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[25-RSA-PSS Restricted Certificate Valid Signature Algorithms]
-ssl_conf = 25-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl
-
-[25-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl]
-server = 25-RSA-PSS Restricted Certificate Valid Signature Algorithms-server
-client = 25-RSA-PSS Restricted Certificate Valid Signature Algorithms-client
-
-[25-RSA-PSS Restricted Certificate Valid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
-CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
-
-[25-RSA-PSS Restricted Certificate Valid Signature Algorithms-client]
-CipherString = DEFAULT
-SignatureAlgorithms = rsa_pss_pss_sha256:rsa_pss_pss_sha512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -884,21 +903,20 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm]
-ssl_conf = 26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl
+[26-Only RSA-PSS Certificate]
+ssl_conf = 26-Only RSA-PSS Certificate-ssl
 
-[26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl]
-server = 26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server
-client = 26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client
+[26-Only RSA-PSS Certificate-ssl]
+server = 26-Only RSA-PSS Certificate-server
+client = 26-Only RSA-PSS Certificate-client
 
-[26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+[26-Only RSA-PSS Certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[26-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client]
+[26-Only RSA-PSS Certificate-client]
 CipherString = DEFAULT
-SignatureAlgorithms = rsa_pss_pss_sha512:rsa_pss_pss_sha256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -911,199 +929,181 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[27-RSA-PSS Restricted Certificate Invalid Signature Algorithms]
-ssl_conf = 27-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl
+[27-Only RSA-PSS Certificate Valid Signature Algorithms]
+ssl_conf = 27-Only RSA-PSS Certificate Valid Signature Algorithms-ssl
 
-[27-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl]
-server = 27-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server
-client = 27-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client
+[27-Only RSA-PSS Certificate Valid Signature Algorithms-ssl]
+server = 27-Only RSA-PSS Certificate Valid Signature Algorithms-server
+client = 27-Only RSA-PSS Certificate Valid Signature Algorithms-client
 
-[27-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+[27-Only RSA-PSS Certificate Valid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[27-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client]
+[27-Only RSA-PSS Certificate Valid Signature Algorithms-client]
 CipherString = DEFAULT
 SignatureAlgorithms = rsa_pss_pss_sha512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-27]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[28-RSA key exchange with all RSA certificate types]
-ssl_conf = 28-RSA key exchange with all RSA certificate types-ssl
-
-[28-RSA key exchange with all RSA certificate types-ssl]
-server = 28-RSA key exchange with all RSA certificate types-server
-client = 28-RSA key exchange with all RSA certificate types-client
-
-[28-RSA key exchange with all RSA certificate types-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[28-RSA key exchange with all RSA certificate types-client]
-CipherString = kRSA
-MaxProtocol = TLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-28]
 ExpectedResult = Success
-ExpectedServerCertType = RSA
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA512
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[29-RSA key exchange with only RSA-PSS certificate]
-ssl_conf = 29-RSA key exchange with only RSA-PSS certificate-ssl
+[28-RSA-PSS Certificate, no PSS signature algorithms]
+ssl_conf = 28-RSA-PSS Certificate, no PSS signature algorithms-ssl
 
-[29-RSA key exchange with only RSA-PSS certificate-ssl]
-server = 29-RSA key exchange with only RSA-PSS certificate-server
-client = 29-RSA key exchange with only RSA-PSS certificate-client
+[28-RSA-PSS Certificate, no PSS signature algorithms-ssl]
+server = 28-RSA-PSS Certificate, no PSS signature algorithms-server
+client = 28-RSA-PSS Certificate, no PSS signature algorithms-client
 
-[29-RSA key exchange with only RSA-PSS certificate-server]
+[28-RSA-PSS Certificate, no PSS signature algorithms-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[29-RSA key exchange with only RSA-PSS certificate-client]
-CipherString = kRSA
-MaxProtocol = TLSv1.2
+[28-RSA-PSS Certificate, no PSS signature algorithms-client]
+CipherString = DEFAULT
+SignatureAlgorithms = RSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-29]
+[test-28]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[30-Suite B P-256 Hash Algorithm Selection]
-ssl_conf = 30-Suite B P-256 Hash Algorithm Selection-ssl
+[29-Only RSA-PSS Restricted Certificate]
+ssl_conf = 29-Only RSA-PSS Restricted Certificate-ssl
 
-[30-Suite B P-256 Hash Algorithm Selection-ssl]
-server = 30-Suite B P-256 Hash Algorithm Selection-server
-client = 30-Suite B P-256 Hash Algorithm Selection-client
+[29-Only RSA-PSS Restricted Certificate-ssl]
+server = 29-Only RSA-PSS Restricted Certificate-server
+client = 29-Only RSA-PSS Restricted Certificate-client
 
-[30-Suite B P-256 Hash Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = SUITEB128
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[30-Suite B P-256 Hash Algorithm Selection-client]
+[29-Only RSA-PSS Restricted Certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+
+[29-Only RSA-PSS Restricted Certificate-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-29]
+ExpectedResult = Success
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
+
+
+# ===========================================================
+
+[30-RSA-PSS Restricted Certificate Valid Signature Algorithms]
+ssl_conf = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl
+
+[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-ssl]
+server = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-server
+client = 30-RSA-PSS Restricted Certificate Valid Signature Algorithms-client
+
+[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+
+[30-RSA-PSS Restricted Certificate Valid Signature Algorithms-client]
+CipherString = DEFAULT
+SignatureAlgorithms = rsa_pss_pss_sha256:rsa_pss_pss_sha512
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-30]
 ExpectedResult = Success
-ExpectedServerCertType = P-256
+ExpectedServerCertType = RSA-PSS
 ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[31-Suite B P-384 Hash Algorithm Selection]
-ssl_conf = 31-Suite B P-384 Hash Algorithm Selection-ssl
+[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm]
+ssl_conf = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl
 
-[31-Suite B P-384 Hash Algorithm Selection-ssl]
-server = 31-Suite B P-384 Hash Algorithm Selection-server
-client = 31-Suite B P-384 Hash Algorithm Selection-client
+[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-ssl]
+server = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server
+client = 31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client
 
-[31-Suite B P-384 Hash Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = SUITEB128
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[31-Suite B P-384 Hash Algorithm Selection-client]
+[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
+
+[31-RSA-PSS Restricted Cert client prefers invalid Signature Algorithm-client]
+CipherString = DEFAULT
+SignatureAlgorithms = rsa_pss_pss_sha512:rsa_pss_pss_sha256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-31]
 ExpectedResult = Success
-ExpectedServerCertType = P-384
-ExpectedServerSignHash = SHA384
-ExpectedServerSignType = EC
+ExpectedServerCertType = RSA-PSS
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[32-TLS 1.2 Ed25519 Client Auth]
-ssl_conf = 32-TLS 1.2 Ed25519 Client Auth-ssl
+[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms]
+ssl_conf = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl
 
-[32-TLS 1.2 Ed25519 Client Auth-ssl]
-server = 32-TLS 1.2 Ed25519 Client Auth-server
-client = 32-TLS 1.2 Ed25519 Client Auth-client
+[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-ssl]
+server = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server
+client = 32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client
 
-[32-TLS 1.2 Ed25519 Client Auth-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-restrict-key.pem
 
-[32-TLS 1.2 Ed25519 Client Auth-client]
+[32-RSA-PSS Restricted Certificate Invalid Signature Algorithms-client]
 CipherString = DEFAULT
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed25519-key.pem
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
+SignatureAlgorithms = rsa_pss_pss_sha512
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-32]
-ExpectedClientCertType = Ed25519
-ExpectedClientSignType = Ed25519
-ExpectedResult = Success
+ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[33-TLS 1.2 Ed448 Client Auth]
-ssl_conf = 33-TLS 1.2 Ed448 Client Auth-ssl
+[33-RSA key exchange with only RSA-PSS certificate]
+ssl_conf = 33-RSA key exchange with only RSA-PSS certificate-ssl
 
-[33-TLS 1.2 Ed448 Client Auth-ssl]
-server = 33-TLS 1.2 Ed448 Client Auth-server
-client = 33-TLS 1.2 Ed448 Client Auth-client
+[33-RSA key exchange with only RSA-PSS certificate-ssl]
+server = 33-RSA key exchange with only RSA-PSS certificate-server
+client = 33-RSA key exchange with only RSA-PSS certificate-client
 
-[33-TLS 1.2 Ed448 Client Auth-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+[33-RSA key exchange with only RSA-PSS certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyMode = Require
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[33-TLS 1.2 Ed448 Client Auth-client]
-CipherString = DEFAULT
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/client-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/client-ed448-key.pem
+[33-RSA key exchange with only RSA-PSS certificate-client]
+CipherString = kRSA
 MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-33]
-ExpectedClientCertType = Ed448
-ExpectedClientSignType = Ed448
-ExpectedResult = Success
+ExpectedResult = ServerFail
 
 
 # ===========================================================

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -5,24 +5,24 @@ num_tests = 56
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-ECDSA CipherString Selection
 test-2 = 2-ECDSA CipherString Selection
-test-3 = 3-Ed25519 CipherString and Signature Algorithm Selection
-test-4 = 4-Ed448 CipherString and Signature Algorithm Selection
-test-5 = 5-ECDSA with brainpool
-test-6 = 6-RSA CipherString Selection
-test-7 = 7-P-256 CipherString and Signature Algorithm Selection
-test-8 = 8-Ed25519 CipherString and Curves Selection
-test-9 = 9-Ed448 CipherString and Curves Selection
-test-10 = 10-ECDSA CipherString Selection, no ECDSA certificate
-test-11 = 11-ECDSA Signature Algorithm Selection
-test-12 = 12-ECDSA Signature Algorithm Selection SHA384
-test-13 = 13-ECDSA Signature Algorithm Selection SHA1
-test-14 = 14-ECDSA Signature Algorithm Selection compressed point
-test-15 = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate
-test-16 = 16-RSA Signature Algorithm Selection
-test-17 = 17-RSA-PSS Signature Algorithm Selection
-test-18 = 18-RSA key exchange with all RSA certificate types
-test-19 = 19-Suite B P-256 Hash Algorithm Selection
-test-20 = 20-Suite B P-384 Hash Algorithm Selection
+test-3 = 3-RSA CipherString Selection
+test-4 = 4-P-256 CipherString and Signature Algorithm Selection
+test-5 = 5-ECDSA CipherString Selection, no ECDSA certificate
+test-6 = 6-ECDSA Signature Algorithm Selection
+test-7 = 7-ECDSA Signature Algorithm Selection SHA384
+test-8 = 8-ECDSA Signature Algorithm Selection SHA1
+test-9 = 9-ECDSA Signature Algorithm Selection compressed point
+test-10 = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate
+test-11 = 11-RSA Signature Algorithm Selection
+test-12 = 12-RSA-PSS Signature Algorithm Selection
+test-13 = 13-RSA key exchange with all RSA certificate types
+test-14 = 14-Suite B P-256 Hash Algorithm Selection
+test-15 = 15-Suite B P-384 Hash Algorithm Selection
+test-16 = 16-Ed25519 CipherString and Signature Algorithm Selection
+test-17 = 17-Ed448 CipherString and Signature Algorithm Selection
+test-18 = 18-ECDSA with brainpool
+test-19 = 19-Ed25519 CipherString and Curves Selection
+test-20 = 20-Ed448 CipherString and Curves Selection
 test-21 = 21-TLS 1.2 Ed25519 Client Auth
 test-22 = 22-TLS 1.2 Ed448 Client Auth
 test-23 = 23-RSA-PSS Certificate CipherString Selection
@@ -45,13 +45,13 @@ test-39 = 39-TLS 1.3 RSA Signature Algorithm Selection SHA384 with PSS
 test-40 = 40-TLS 1.3 ECDSA Signature Algorithm Selection, no ECDSA certificate
 test-41 = 41-TLS 1.3 RSA Signature Algorithm Selection, no PSS
 test-42 = 42-TLS 1.3 RSA-PSS Signature Algorithm Selection
-test-43 = 43-TLS 1.3 Ed25519 Signature Algorithm Selection
-test-44 = 44-TLS 1.3 Ed448 Signature Algorithm Selection
-test-45 = 45-TLS 1.3 Ed25519 CipherString and Groups Selection
-test-46 = 46-TLS 1.3 Ed448 CipherString and Groups Selection
-test-47 = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection
-test-48 = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
-test-49 = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
+test-43 = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection
+test-44 = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names
+test-45 = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
+test-46 = 46-TLS 1.3 Ed25519 Signature Algorithm Selection
+test-47 = 47-TLS 1.3 Ed448 Signature Algorithm Selection
+test-48 = 48-TLS 1.3 Ed25519 CipherString and Groups Selection
+test-49 = 49-TLS 1.3 Ed448 CipherString and Groups Selection
 test-50 = 50-TLS 1.3 Ed25519 Client Auth
 test-51 = 51-TLS 1.3 Ed448 Client Auth
 test-52 = 52-TLS 1.3 ECDSA with brainpool
@@ -158,14 +158,14 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[3-Ed25519 CipherString and Signature Algorithm Selection]
-ssl_conf = 3-Ed25519 CipherString and Signature Algorithm Selection-ssl
+[3-RSA CipherString Selection]
+ssl_conf = 3-RSA CipherString Selection-ssl
 
-[3-Ed25519 CipherString and Signature Algorithm Selection-ssl]
-server = 3-Ed25519 CipherString and Signature Algorithm Selection-server
-client = 3-Ed25519 CipherString and Signature Algorithm Selection-client
+[3-RSA CipherString Selection-ssl]
+server = 3-RSA CipherString Selection-server
+client = 3-RSA CipherString Selection-client
 
-[3-Ed25519 CipherString and Signature Algorithm Selection-server]
+[3-RSA CipherString Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -177,114 +177,13 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[3-Ed25519 CipherString and Signature Algorithm Selection-client]
-CipherString = aECDSA
-MaxProtocol = TLSv1.2
-RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-SignatureAlgorithms = ed25519:ECDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-3]
-ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = Ed25519
-ExpectedServerSignType = Ed25519
-
-
-# ===========================================================
-
-[4-Ed448 CipherString and Signature Algorithm Selection]
-ssl_conf = 4-Ed448 CipherString and Signature Algorithm Selection-ssl
-
-[4-Ed448 CipherString and Signature Algorithm Selection-ssl]
-server = 4-Ed448 CipherString and Signature Algorithm Selection-server
-client = 4-Ed448 CipherString and Signature Algorithm Selection-client
-
-[4-Ed448 CipherString and Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[4-Ed448 CipherString and Signature Algorithm Selection-client]
-CipherString = aECDSA
-MaxProtocol = TLSv1.2
-RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
-SignatureAlgorithms = ed448:ECDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
-VerifyMode = Peer
-
-[test-4]
-ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = Ed448
-ExpectedServerSignType = Ed448
-
-
-# ===========================================================
-
-[5-ECDSA with brainpool]
-ssl_conf = 5-ECDSA with brainpool-ssl
-
-[5-ECDSA with brainpool-ssl]
-server = 5-ECDSA with brainpool-server
-client = 5-ECDSA with brainpool-client
-
-[5-ECDSA with brainpool-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
-CipherString = DEFAULT
-Groups = brainpoolP256r1
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
-
-[5-ECDSA with brainpool-client]
-CipherString = aECDSA
-Groups = brainpoolP256r1
-RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-5]
-ExpectedResult = Success
-ExpectedServerCANames = empty
-ExpectedServerCertType = brainpoolP256r1
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[6-RSA CipherString Selection]
-ssl_conf = 6-RSA CipherString Selection-ssl
-
-[6-RSA CipherString Selection-ssl]
-server = 6-RSA CipherString Selection-server
-client = 6-RSA CipherString Selection-client
-
-[6-RSA CipherString Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[6-RSA CipherString Selection-client]
+[3-RSA CipherString Selection-client]
 CipherString = aRSA
 MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-6]
+[test-3]
 ExpectedResult = Success
 ExpectedServerCertType = RSA
 ExpectedServerSignType = RSA-PSS
@@ -292,14 +191,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[7-P-256 CipherString and Signature Algorithm Selection]
-ssl_conf = 7-P-256 CipherString and Signature Algorithm Selection-ssl
+[4-P-256 CipherString and Signature Algorithm Selection]
+ssl_conf = 4-P-256 CipherString and Signature Algorithm Selection-ssl
 
-[7-P-256 CipherString and Signature Algorithm Selection-ssl]
-server = 7-P-256 CipherString and Signature Algorithm Selection-server
-client = 7-P-256 CipherString and Signature Algorithm Selection-client
+[4-P-256 CipherString and Signature Algorithm Selection-ssl]
+server = 4-P-256 CipherString and Signature Algorithm Selection-server
+client = 4-P-256 CipherString and Signature Algorithm Selection-client
 
-[7-P-256 CipherString and Signature Algorithm Selection-server]
+[4-P-256 CipherString and Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -311,14 +210,14 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[7-P-256 CipherString and Signature Algorithm Selection-client]
+[4-P-256 CipherString and Signature Algorithm Selection-client]
 CipherString = aECDSA
 MaxProtocol = TLSv1.2
 SignatureAlgorithms = ECDSA+SHA256:ed25519
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-7]
+[test-4]
 ExpectedResult = Success
 ExpectedServerCertType = P-256
 ExpectedServerSignHash = SHA256
@@ -327,14 +226,39 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[8-Ed25519 CipherString and Curves Selection]
-ssl_conf = 8-Ed25519 CipherString and Curves Selection-ssl
+[5-ECDSA CipherString Selection, no ECDSA certificate]
+ssl_conf = 5-ECDSA CipherString Selection, no ECDSA certificate-ssl
 
-[8-Ed25519 CipherString and Curves Selection-ssl]
-server = 8-Ed25519 CipherString and Curves Selection-server
-client = 8-Ed25519 CipherString and Curves Selection-client
+[5-ECDSA CipherString Selection, no ECDSA certificate-ssl]
+server = 5-ECDSA CipherString Selection, no ECDSA certificate-server
+client = 5-ECDSA CipherString Selection, no ECDSA certificate-client
 
-[8-Ed25519 CipherString and Curves Selection-server]
+[5-ECDSA CipherString Selection, no ECDSA certificate-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[5-ECDSA CipherString Selection, no ECDSA certificate-client]
+CipherString = aECDSA
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[6-ECDSA Signature Algorithm Selection]
+ssl_conf = 6-ECDSA Signature Algorithm Selection-ssl
+
+[6-ECDSA Signature Algorithm Selection-ssl]
+server = 6-ECDSA Signature Algorithm Selection-server
+client = 6-ECDSA Signature Algorithm Selection-client
+
+[6-ECDSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -346,73 +270,135 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[8-Ed25519 CipherString and Curves Selection-client]
-CipherString = aECDSA
-Curves = X25519
+[6-ECDSA Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+ExpectedResult = Success
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[7-ECDSA Signature Algorithm Selection SHA384]
+ssl_conf = 7-ECDSA Signature Algorithm Selection SHA384-ssl
+
+[7-ECDSA Signature Algorithm Selection SHA384-ssl]
+server = 7-ECDSA Signature Algorithm Selection SHA384-server
+client = 7-ECDSA Signature Algorithm Selection SHA384-client
+
+[7-ECDSA Signature Algorithm Selection SHA384-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
-SignatureAlgorithms = ECDSA+SHA256:ed25519
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-ECDSA Signature Algorithm Selection SHA384-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA384
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-7]
+ExpectedResult = Success
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA384
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[8-ECDSA Signature Algorithm Selection SHA1]
+ssl_conf = 8-ECDSA Signature Algorithm Selection SHA1-ssl
+
+[8-ECDSA Signature Algorithm Selection SHA1-ssl]
+server = 8-ECDSA Signature Algorithm Selection SHA1-server
+client = 8-ECDSA Signature Algorithm Selection SHA1-client
+
+[8-ECDSA Signature Algorithm Selection SHA1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[8-ECDSA Signature Algorithm Selection SHA1-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-8]
 ExpectedResult = Success
-ExpectedServerCertType = Ed25519
-ExpectedServerSignType = Ed25519
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA1
+ExpectedServerSignType = EC
 
 
 # ===========================================================
 
-[9-Ed448 CipherString and Curves Selection]
-ssl_conf = 9-Ed448 CipherString and Curves Selection-ssl
+[9-ECDSA Signature Algorithm Selection compressed point]
+ssl_conf = 9-ECDSA Signature Algorithm Selection compressed point-ssl
 
-[9-Ed448 CipherString and Curves Selection-ssl]
-server = 9-Ed448 CipherString and Curves Selection-server
-client = 9-Ed448 CipherString and Curves Selection-client
+[9-ECDSA Signature Algorithm Selection compressed point-ssl]
+server = 9-ECDSA Signature Algorithm Selection compressed point-server
+client = 9-ECDSA Signature Algorithm Selection compressed point-client
 
-[9-Ed448 CipherString and Curves Selection-server]
+[9-ECDSA Signature Algorithm Selection compressed point-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[9-Ed448 CipherString and Curves Selection-client]
-CipherString = aECDSA
-Curves = X448
-MaxProtocol = TLSv1.2
-SignatureAlgorithms = ECDSA+SHA256:ed448
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+[9-ECDSA Signature Algorithm Selection compressed point-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-9]
 ExpectedResult = Success
-ExpectedServerCertType = Ed448
-ExpectedServerSignType = Ed448
+ExpectedServerCertType = P-256
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = EC
 
 
 # ===========================================================
 
-[10-ECDSA CipherString Selection, no ECDSA certificate]
-ssl_conf = 10-ECDSA CipherString Selection, no ECDSA certificate-ssl
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate]
+ssl_conf = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
 
-[10-ECDSA CipherString Selection, no ECDSA certificate-ssl]
-server = 10-ECDSA CipherString Selection, no ECDSA certificate-server
-client = 10-ECDSA CipherString Selection, no ECDSA certificate-client
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
+server = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
+client = 10-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
 
-[10-ECDSA CipherString Selection, no ECDSA certificate-server]
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[10-ECDSA CipherString Selection, no ECDSA certificate-client]
-CipherString = aECDSA
-MaxProtocol = TLSv1.2
+[10-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -422,14 +408,14 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[11-ECDSA Signature Algorithm Selection]
-ssl_conf = 11-ECDSA Signature Algorithm Selection-ssl
+[11-RSA Signature Algorithm Selection]
+ssl_conf = 11-RSA Signature Algorithm Selection-ssl
 
-[11-ECDSA Signature Algorithm Selection-ssl]
-server = 11-ECDSA Signature Algorithm Selection-server
-client = 11-ECDSA Signature Algorithm Selection-client
+[11-RSA Signature Algorithm Selection-ssl]
+server = 11-RSA Signature Algorithm Selection-server
+client = 11-RSA Signature Algorithm Selection-client
 
-[11-ECDSA Signature Algorithm Selection-server]
+[11-RSA Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -441,29 +427,29 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[11-ECDSA Signature Algorithm Selection-client]
+[11-RSA Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA256
+SignatureAlgorithms = RSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-11]
 ExpectedResult = Success
-ExpectedServerCertType = P-256
+ExpectedServerCertType = RSA
 ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
+ExpectedServerSignType = RSA
 
 
 # ===========================================================
 
-[12-ECDSA Signature Algorithm Selection SHA384]
-ssl_conf = 12-ECDSA Signature Algorithm Selection SHA384-ssl
+[12-RSA-PSS Signature Algorithm Selection]
+ssl_conf = 12-RSA-PSS Signature Algorithm Selection-ssl
 
-[12-ECDSA Signature Algorithm Selection SHA384-ssl]
-server = 12-ECDSA Signature Algorithm Selection SHA384-server
-client = 12-ECDSA Signature Algorithm Selection SHA384-client
+[12-RSA-PSS Signature Algorithm Selection-ssl]
+server = 12-RSA-PSS Signature Algorithm Selection-server
+client = 12-RSA-PSS Signature Algorithm Selection-client
 
-[12-ECDSA Signature Algorithm Selection SHA384-server]
+[12-RSA-PSS Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
@@ -475,74 +461,67 @@ Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[12-ECDSA Signature Algorithm Selection SHA384-client]
+[12-RSA-PSS Signature Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA384
+SignatureAlgorithms = RSA-PSS+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-12]
 ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA384
-ExpectedServerSignType = EC
+ExpectedServerCertType = RSA
+ExpectedServerSignHash = SHA256
+ExpectedServerSignType = RSA-PSS
 
 
 # ===========================================================
 
-[13-ECDSA Signature Algorithm Selection SHA1]
-ssl_conf = 13-ECDSA Signature Algorithm Selection SHA1-ssl
+[13-RSA key exchange with all RSA certificate types]
+ssl_conf = 13-RSA key exchange with all RSA certificate types-ssl
 
-[13-ECDSA Signature Algorithm Selection SHA1-ssl]
-server = 13-ECDSA Signature Algorithm Selection SHA1-server
-client = 13-ECDSA Signature Algorithm Selection SHA1-client
+[13-RSA key exchange with all RSA certificate types-ssl]
+server = 13-RSA key exchange with all RSA certificate types-server
+client = 13-RSA key exchange with all RSA certificate types-client
 
-[13-ECDSA Signature Algorithm Selection SHA1-server]
+[13-RSA key exchange with all RSA certificate types-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.2
+PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
+PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[13-ECDSA Signature Algorithm Selection SHA1-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA1
+[13-RSA key exchange with all RSA certificate types-client]
+CipherString = kRSA
+MaxProtocol = TLSv1.2
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-13]
 ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA1
-ExpectedServerSignType = EC
+ExpectedServerCertType = RSA
 
 
 # ===========================================================
 
-[14-ECDSA Signature Algorithm Selection compressed point]
-ssl_conf = 14-ECDSA Signature Algorithm Selection compressed point-ssl
+[14-Suite B P-256 Hash Algorithm Selection]
+ssl_conf = 14-Suite B P-256 Hash Algorithm Selection-ssl
 
-[14-ECDSA Signature Algorithm Selection compressed point-ssl]
-server = 14-ECDSA Signature Algorithm Selection compressed point-server
-client = 14-ECDSA Signature Algorithm Selection compressed point-client
+[14-Suite B P-256 Hash Algorithm Selection-ssl]
+server = 14-Suite B P-256 Hash Algorithm Selection-server
+client = 14-Suite B P-256 Hash Algorithm Selection-client
 
-[14-ECDSA Signature Algorithm Selection compressed point-server]
+[14-Suite B P-256 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-cecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-cecdsa-key.pem
+CipherString = SUITEB128
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[14-ECDSA Signature Algorithm Selection compressed point-client]
+[14-Suite B P-256 Hash Algorithm Selection-client]
 CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
 [test-14]
@@ -554,164 +533,14 @@ ExpectedServerSignType = EC
 
 # ===========================================================
 
-[15-ECDSA Signature Algorithm Selection, no ECDSA certificate]
-ssl_conf = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl
+[15-Suite B P-384 Hash Algorithm Selection]
+ssl_conf = 15-Suite B P-384 Hash Algorithm Selection-ssl
 
-[15-ECDSA Signature Algorithm Selection, no ECDSA certificate-ssl]
-server = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate-server
-client = 15-ECDSA Signature Algorithm Selection, no ECDSA certificate-client
+[15-Suite B P-384 Hash Algorithm Selection-ssl]
+server = 15-Suite B P-384 Hash Algorithm Selection-server
+client = 15-Suite B P-384 Hash Algorithm Selection-client
 
-[15-ECDSA Signature Algorithm Selection, no ECDSA certificate-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[15-ECDSA Signature Algorithm Selection, no ECDSA certificate-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-15]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[16-RSA Signature Algorithm Selection]
-ssl_conf = 16-RSA Signature Algorithm Selection-ssl
-
-[16-RSA Signature Algorithm Selection-ssl]
-server = 16-RSA Signature Algorithm Selection-server
-client = 16-RSA Signature Algorithm Selection-client
-
-[16-RSA Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[16-RSA Signature Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = RSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-16]
-ExpectedResult = Success
-ExpectedServerCertType = RSA
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA
-
-
-# ===========================================================
-
-[17-RSA-PSS Signature Algorithm Selection]
-ssl_conf = 17-RSA-PSS Signature Algorithm Selection-ssl
-
-[17-RSA-PSS Signature Algorithm Selection-ssl]
-server = 17-RSA-PSS Signature Algorithm Selection-server
-client = 17-RSA-PSS Signature Algorithm Selection-client
-
-[17-RSA-PSS Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[17-RSA-PSS Signature Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = RSA-PSS+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-17]
-ExpectedResult = Success
-ExpectedServerCertType = RSA
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = RSA-PSS
-
-
-# ===========================================================
-
-[18-RSA key exchange with all RSA certificate types]
-ssl_conf = 18-RSA key exchange with all RSA certificate types-ssl
-
-[18-RSA key exchange with all RSA certificate types-ssl]
-server = 18-RSA key exchange with all RSA certificate types-server
-client = 18-RSA key exchange with all RSA certificate types-client
-
-[18-RSA key exchange with all RSA certificate types-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-PSS.Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-PSS.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[18-RSA key exchange with all RSA certificate types-client]
-CipherString = kRSA
-MaxProtocol = TLSv1.2
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-18]
-ExpectedResult = Success
-ExpectedServerCertType = RSA
-
-
-# ===========================================================
-
-[19-Suite B P-256 Hash Algorithm Selection]
-ssl_conf = 19-Suite B P-256 Hash Algorithm Selection-ssl
-
-[19-Suite B P-256 Hash Algorithm Selection-ssl]
-server = 19-Suite B P-256 Hash Algorithm Selection-server
-client = 19-Suite B P-256 Hash Algorithm Selection-client
-
-[19-Suite B P-256 Hash Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = SUITEB128
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p256-server-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p256-server-key.pem
-MaxProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[19-Suite B P-256 Hash Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ECDSA+SHA384:ECDSA+SHA256
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
-VerifyMode = Peer
-
-[test-19]
-ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignHash = SHA256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[20-Suite B P-384 Hash Algorithm Selection]
-ssl_conf = 20-Suite B P-384 Hash Algorithm Selection-ssl
-
-[20-Suite B P-384 Hash Algorithm Selection-ssl]
-server = 20-Suite B P-384 Hash Algorithm Selection-server
-client = 20-Suite B P-384 Hash Algorithm Selection-client
-
-[20-Suite B P-384 Hash Algorithm Selection-server]
+[15-Suite B P-384 Hash Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = SUITEB128
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/p384-server-cert.pem
@@ -719,17 +548,188 @@ ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/p384-server-key.pem
 MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[20-Suite B P-384 Hash Algorithm Selection-client]
+[15-Suite B P-384 Hash Algorithm Selection-client]
 CipherString = DEFAULT
 SignatureAlgorithms = ECDSA+SHA256:ECDSA+SHA384
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/p384-root.pem
 VerifyMode = Peer
 
-[test-20]
+[test-15]
 ExpectedResult = Success
 ExpectedServerCertType = P-384
 ExpectedServerSignHash = SHA384
 ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[16-Ed25519 CipherString and Signature Algorithm Selection]
+ssl_conf = 16-Ed25519 CipherString and Signature Algorithm Selection-ssl
+
+[16-Ed25519 CipherString and Signature Algorithm Selection-ssl]
+server = 16-Ed25519 CipherString and Signature Algorithm Selection-server
+client = 16-Ed25519 CipherString and Signature Algorithm Selection-client
+
+[16-Ed25519 CipherString and Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[16-Ed25519 CipherString and Signature Algorithm Selection-client]
+CipherString = aECDSA
+MaxProtocol = TLSv1.2
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+SignatureAlgorithms = ed25519:ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-16]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = Ed25519
+ExpectedServerSignType = Ed25519
+
+
+# ===========================================================
+
+[17-Ed448 CipherString and Signature Algorithm Selection]
+ssl_conf = 17-Ed448 CipherString and Signature Algorithm Selection-ssl
+
+[17-Ed448 CipherString and Signature Algorithm Selection-ssl]
+server = 17-Ed448 CipherString and Signature Algorithm Selection-server
+client = 17-Ed448 CipherString and Signature Algorithm Selection-client
+
+[17-Ed448 CipherString and Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[17-Ed448 CipherString and Signature Algorithm Selection-client]
+CipherString = aECDSA
+MaxProtocol = TLSv1.2
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+SignatureAlgorithms = ed448:ECDSA+SHA256
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+VerifyMode = Peer
+
+[test-17]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = Ed448
+ExpectedServerSignType = Ed448
+
+
+# ===========================================================
+
+[18-ECDSA with brainpool]
+ssl_conf = 18-ECDSA with brainpool-ssl
+
+[18-ECDSA with brainpool-ssl]
+server = 18-ECDSA with brainpool-server
+client = 18-ECDSA with brainpool-client
+
+[18-ECDSA with brainpool-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
+CipherString = DEFAULT
+Groups = brainpoolP256r1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
+
+[18-ECDSA with brainpool-client]
+CipherString = aECDSA
+Groups = brainpoolP256r1
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-18]
+ExpectedResult = Success
+ExpectedServerCANames = empty
+ExpectedServerCertType = brainpoolP256r1
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[19-Ed25519 CipherString and Curves Selection]
+ssl_conf = 19-Ed25519 CipherString and Curves Selection-ssl
+
+[19-Ed25519 CipherString and Curves Selection-ssl]
+server = 19-Ed25519 CipherString and Curves Selection-server
+client = 19-Ed25519 CipherString and Curves Selection-client
+
+[19-Ed25519 CipherString and Curves Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[19-Ed25519 CipherString and Curves Selection-client]
+CipherString = aECDSA
+Curves = X25519
+MaxProtocol = TLSv1.2
+SignatureAlgorithms = ECDSA+SHA256:ed25519
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-19]
+ExpectedResult = Success
+ExpectedServerCertType = Ed25519
+ExpectedServerSignType = Ed25519
+
+
+# ===========================================================
+
+[20-Ed448 CipherString and Curves Selection]
+ssl_conf = 20-Ed448 CipherString and Curves Selection-ssl
+
+[20-Ed448 CipherString and Curves Selection-ssl]
+server = 20-Ed448 CipherString and Curves Selection-server
+client = 20-Ed448 CipherString and Curves Selection-client
+
+[20-Ed448 CipherString and Curves Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[20-Ed448 CipherString and Curves Selection-client]
+CipherString = aECDSA
+Curves = X448
+MaxProtocol = TLSv1.2
+SignatureAlgorithms = ECDSA+SHA256:ed448
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+VerifyMode = Peer
+
+[test-20]
+ExpectedResult = Success
+ExpectedServerCertType = Ed448
+ExpectedServerSignType = Ed448
 
 
 # ===========================================================
@@ -1397,152 +1397,14 @@ ExpectedServerSignType = RSA-PSS
 
 # ===========================================================
 
-[43-TLS 1.3 Ed25519 Signature Algorithm Selection]
-ssl_conf = 43-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
+[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
+ssl_conf = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
 
-[43-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
-server = 43-TLS 1.3 Ed25519 Signature Algorithm Selection-server
-client = 43-TLS 1.3 Ed25519 Signature Algorithm Selection-client
+[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
+server = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
+client = 43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
 
-[43-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[43-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ed25519
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-43]
-ExpectedResult = Success
-ExpectedServerCertType = Ed25519
-ExpectedServerSignType = Ed25519
-
-
-# ===========================================================
-
-[44-TLS 1.3 Ed448 Signature Algorithm Selection]
-ssl_conf = 44-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
-
-[44-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
-server = 44-TLS 1.3 Ed448 Signature Algorithm Selection-server
-client = 44-TLS 1.3 Ed448 Signature Algorithm Selection-client
-
-[44-TLS 1.3 Ed448 Signature Algorithm Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[44-TLS 1.3 Ed448 Signature Algorithm Selection-client]
-CipherString = DEFAULT
-SignatureAlgorithms = ed448
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
-VerifyMode = Peer
-
-[test-44]
-ExpectedResult = Success
-ExpectedServerCertType = Ed448
-ExpectedServerSignType = Ed448
-
-
-# ===========================================================
-
-[45-TLS 1.3 Ed25519 CipherString and Groups Selection]
-ssl_conf = 45-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
-
-[45-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
-server = 45-TLS 1.3 Ed25519 CipherString and Groups Selection-server
-client = 45-TLS 1.3 Ed25519 CipherString and Groups Selection-client
-
-[45-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[45-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
-CipherString = DEFAULT
-Groups = X25519
-SignatureAlgorithms = ECDSA+SHA256:ed25519
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-45]
-ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[46-TLS 1.3 Ed448 CipherString and Groups Selection]
-ssl_conf = 46-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
-
-[46-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
-server = 46-TLS 1.3 Ed448 CipherString and Groups Selection-server
-client = 46-TLS 1.3 Ed448 CipherString and Groups Selection-client
-
-[46-TLS 1.3 Ed448 CipherString and Groups Selection-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
-Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
-Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
-Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-
-[46-TLS 1.3 Ed448 CipherString and Groups Selection-client]
-CipherString = DEFAULT
-Groups = X448
-SignatureAlgorithms = ECDSA+SHA256:ed448
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-46]
-ExpectedResult = Success
-ExpectedServerCertType = P-256
-ExpectedServerSignType = EC
-
-
-# ===========================================================
-
-[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection]
-ssl_conf = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl
-
-[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-ssl]
-server = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server
-client = 47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client
-
-[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
+[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = PSS+SHA256
@@ -1550,7 +1412,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[47-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
+[43-TLS 1.3 RSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1561,7 +1423,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-47]
+[test-43]
 ExpectedClientCANames = empty
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
@@ -1571,14 +1433,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
-ssl_conf = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
+[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names]
+ssl_conf = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl
 
-[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
-server = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
-client = 48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
+[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-ssl]
+server = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server
+client = 44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client
 
-[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
+[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = PSS+SHA256
@@ -1587,7 +1449,7 @@ RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[48-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
+[44-TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1598,7 +1460,7 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-48]
+[test-44]
 ExpectedClientCANames = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 ExpectedClientCertType = RSA
 ExpectedClientSignHash = SHA256
@@ -1608,14 +1470,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
-ssl_conf = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
+[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection]
+ssl_conf = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl
 
-[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
-server = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
-client = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
+[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-ssl]
+server = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server
+client = 45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client
 
-[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
+[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = ECDSA+SHA256
@@ -1623,7 +1485,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
-[49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
+[45-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection-client]
 CipherString = DEFAULT
 ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-client-chain.pem
 ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-ecdsa-key.pem
@@ -1634,11 +1496,149 @@ RSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-49]
+[test-45]
 ExpectedClientCertType = P-256
 ExpectedClientSignHash = SHA256
 ExpectedClientSignType = EC
 ExpectedResult = Success
+
+
+# ===========================================================
+
+[46-TLS 1.3 Ed25519 Signature Algorithm Selection]
+ssl_conf = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl
+
+[46-TLS 1.3 Ed25519 Signature Algorithm Selection-ssl]
+server = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-server
+client = 46-TLS 1.3 Ed25519 Signature Algorithm Selection-client
+
+[46-TLS 1.3 Ed25519 Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[46-TLS 1.3 Ed25519 Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ed25519
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-46]
+ExpectedResult = Success
+ExpectedServerCertType = Ed25519
+ExpectedServerSignType = Ed25519
+
+
+# ===========================================================
+
+[47-TLS 1.3 Ed448 Signature Algorithm Selection]
+ssl_conf = 47-TLS 1.3 Ed448 Signature Algorithm Selection-ssl
+
+[47-TLS 1.3 Ed448 Signature Algorithm Selection-ssl]
+server = 47-TLS 1.3 Ed448 Signature Algorithm Selection-server
+client = 47-TLS 1.3 Ed448 Signature Algorithm Selection-client
+
+[47-TLS 1.3 Ed448 Signature Algorithm Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[47-TLS 1.3 Ed448 Signature Algorithm Selection-client]
+CipherString = DEFAULT
+SignatureAlgorithms = ed448
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-ed448-cert.pem
+VerifyMode = Peer
+
+[test-47]
+ExpectedResult = Success
+ExpectedServerCertType = Ed448
+ExpectedServerSignType = Ed448
+
+
+# ===========================================================
+
+[48-TLS 1.3 Ed25519 CipherString and Groups Selection]
+ssl_conf = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl
+
+[48-TLS 1.3 Ed25519 CipherString and Groups Selection-ssl]
+server = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-server
+client = 48-TLS 1.3 Ed25519 CipherString and Groups Selection-client
+
+[48-TLS 1.3 Ed25519 CipherString and Groups Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[48-TLS 1.3 Ed25519 CipherString and Groups Selection-client]
+CipherString = DEFAULT
+Groups = X25519
+SignatureAlgorithms = ECDSA+SHA256:ed25519
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-48]
+ExpectedResult = Success
+ExpectedServerCertType = P-256
+ExpectedServerSignType = EC
+
+
+# ===========================================================
+
+[49-TLS 1.3 Ed448 CipherString and Groups Selection]
+ssl_conf = 49-TLS 1.3 Ed448 CipherString and Groups Selection-ssl
+
+[49-TLS 1.3 Ed448 CipherString and Groups Selection-ssl]
+server = 49-TLS 1.3 Ed448 CipherString and Groups Selection-server
+client = 49-TLS 1.3 Ed448 CipherString and Groups Selection-client
+
+[49-TLS 1.3 Ed448 CipherString and Groups Selection-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+ECDSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+ECDSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+Ed25519.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed25519-cert.pem
+Ed25519.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed25519-key.pem
+Ed448.Certificate = ${ENV::TEST_CERTS_DIR}/server-ed448-cert.pem
+Ed448.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ed448-key.pem
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[49-TLS 1.3 Ed448 CipherString and Groups Selection-client]
+CipherString = DEFAULT
+Groups = X448
+SignatureAlgorithms = ECDSA+SHA256:ed448
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-49]
+ExpectedResult = Success
+ExpectedServerCertType = P-256
+ExpectedServerSignType = EC
 
 
 # ===========================================================

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -9,15 +9,26 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
-my $server = {
-    "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
-    "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
-    "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
-    "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
-    "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
-    "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
-    "MaxProtocol" => "TLSv1.2"
-};
+my $server;
+
+if (FIPS_MODE) {
+    #TODO(3.0): No EdDSA support in FIPS mode at the moment
+    $server = {
+        "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
+        "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
+        "MaxProtocol" => "TLSv1.2"
+    };
+} else {
+    $server = {
+        "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
+        "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
+        "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
+        "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
+        "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
+        "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
+        "MaxProtocol" => "TLSv1.2"
+    };
+}
 
 my $server_pss = {
     "PSS.Certificate" => test_pem("server-pss-cert.pem"),
@@ -119,63 +130,6 @@ our @tests = (
         },
     },
     {
-        name => "Ed25519 CipherString and Signature Algorithm Selection",
-        server => $server,
-        client => {
-            "CipherString" => "aECDSA",
-            "MaxProtocol" => "TLSv1.2",
-            "SignatureAlgorithms" => "ed25519:ECDSA+SHA256",
-            "RequestCAFile" => test_pem("root-cert.pem"),
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "Ed25519",
-            "ExpectedServerSignType" =>, "Ed25519",
-            # Note: certificate_authorities not sent for TLS < 1.3
-            "ExpectedServerCANames" =>, "empty",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "Ed448 CipherString and Signature Algorithm Selection",
-        server => $server,
-        client => {
-            "CipherString" => "aECDSA",
-            "MaxProtocol" => "TLSv1.2",
-            "SignatureAlgorithms" => "ed448:ECDSA+SHA256",
-            "RequestCAFile" => test_pem("root-ed448-cert.pem"),
-            "VerifyCAFile" => test_pem("root-ed448-cert.pem"),
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "Ed448",
-            "ExpectedServerSignType" =>, "Ed448",
-            # Note: certificate_authorities not sent for TLS < 1.3
-            "ExpectedServerCANames" =>, "empty",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "ECDSA with brainpool",
-        server =>  {
-            "Certificate" => test_pem("server-ecdsa-brainpoolP256r1-cert.pem"),
-            "PrivateKey" => test_pem("server-ecdsa-brainpoolP256r1-key.pem"),
-            "Groups" => "brainpoolP256r1",
-        },
-        client => {
-            #We don't restrict this to TLSv1.2, although use of brainpool
-            #should force this anyway so that this should succeed
-            "CipherString" => "aECDSA",
-            "RequestCAFile" => test_pem("root-cert.pem"),
-            "Groups" => "brainpoolP256r1",
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "brainpoolP256r1",
-            "ExpectedServerSignType" =>, "EC",
-            # Note: certificate_authorities not sent for TLS < 1.3
-            "ExpectedServerCANames" =>, "empty",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
         name => "RSA CipherString Selection",
         server => $server,
         client => {
@@ -200,41 +154,6 @@ our @tests = (
             "ExpectedServerCertType" => "P-256",
             "ExpectedServerSignHash" => "SHA256",
             "ExpectedServerSignType" => "EC",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "Ed25519 CipherString and Curves Selection",
-        server => $server,
-        client => {
-            "CipherString" => "aECDSA",
-            "MaxProtocol" => "TLSv1.2",
-            "SignatureAlgorithms" => "ECDSA+SHA256:ed25519",
-            # Excluding P-256 from the supported curves list means server
-            # certificate should be Ed25519 and not P-256
-            "Curves" => "X25519"
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "Ed25519",
-            "ExpectedServerSignType" =>, "Ed25519",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "Ed448 CipherString and Curves Selection",
-        server => $server,
-        client => {
-            "CipherString" => "aECDSA",
-            "MaxProtocol" => "TLSv1.2",
-            "SignatureAlgorithms" => "ECDSA+SHA256:ed448",
-            "VerifyCAFile" => test_pem("root-ed448-cert.pem"),
-            # Excluding P-256 from the supported curves list means server
-            # certificate should be Ed25519 and not P-256
-            "Curves" => "X448"
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "Ed448",
-            "ExpectedServerSignType" =>, "Ed448",
             "ExpectedResult" => "Success"
         },
     },
@@ -392,6 +311,102 @@ our @tests = (
             "ExpectedServerCertType" => "P-384",
             "ExpectedServerSignHash" => "SHA384",
             "ExpectedServerSignType" => "EC",
+            "ExpectedResult" => "Success"
+        },
+    },
+);
+
+my @tests_non_fips = (
+    # TODO(3.0) No Ed25519/Ed448 in FIPS mode at the moment
+    {
+        name => "Ed25519 CipherString and Signature Algorithm Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
+            "SignatureAlgorithms" => "ed25519:ECDSA+SHA256",
+            "RequestCAFile" => test_pem("root-cert.pem"),
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed25519",
+            "ExpectedServerSignType" =>, "Ed25519",
+            # Note: certificate_authorities not sent for TLS < 1.3
+            "ExpectedServerCANames" =>, "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "Ed448 CipherString and Signature Algorithm Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
+            "SignatureAlgorithms" => "ed448:ECDSA+SHA256",
+            "RequestCAFile" => test_pem("root-ed448-cert.pem"),
+            "VerifyCAFile" => test_pem("root-ed448-cert.pem"),
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed448",
+            "ExpectedServerSignType" =>, "Ed448",
+            # Note: certificate_authorities not sent for TLS < 1.3
+            "ExpectedServerCANames" =>, "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "ECDSA with brainpool",
+        server =>  {
+            "Certificate" => test_pem("server-ecdsa-brainpoolP256r1-cert.pem"),
+            "PrivateKey" => test_pem("server-ecdsa-brainpoolP256r1-key.pem"),
+            "Groups" => "brainpoolP256r1",
+        },
+        client => {
+            #We don't restrict this to TLSv1.2, although use of brainpool
+            #should force this anyway so that this should succeed
+            "CipherString" => "aECDSA",
+            "RequestCAFile" => test_pem("root-cert.pem"),
+            "Groups" => "brainpoolP256r1",
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "brainpoolP256r1",
+            "ExpectedServerSignType" =>, "EC",
+            # Note: certificate_authorities not sent for TLS < 1.3
+            "ExpectedServerCANames" =>, "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "Ed25519 CipherString and Curves Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
+            "SignatureAlgorithms" => "ECDSA+SHA256:ed25519",
+            # Excluding P-256 from the supported curves list means server
+            # certificate should be Ed25519 and not P-256
+            "Curves" => "X25519"
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed25519",
+            "ExpectedServerSignType" =>, "Ed25519",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "Ed448 CipherString and Curves Selection",
+        server => $server,
+        client => {
+            "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
+            "SignatureAlgorithms" => "ECDSA+SHA256:ed448",
+            "VerifyCAFile" => test_pem("root-ed448-cert.pem"),
+            # Excluding P-256 from the supported curves list means server
+            # certificate should be Ed25519 and not P-256
+            "Curves" => "X448"
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "Ed448",
+            "ExpectedServerSignType" =>, "Ed448",
             "ExpectedResult" => "Success"
         },
     },
@@ -580,21 +595,34 @@ my @tests_tls_1_1 = (
     },
 );
 
+push @tests, @tests_non_fips unless FIPS_MODE;
+
 #TODO(3.0): Re-enable these PSS tests in a NO_DEFLT_LIBCTX build once we have
 #           support for it
 push @tests, @tests_pss unless NO_DEFLT_LIBCTX;
 push @tests, @tests_tls_1_1 unless disabled("tls1_1") || NO_DEFLT_LIBCTX;
 
-my $server_tls_1_3 = {
-    "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
-    "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
-    "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
-    "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
-    "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
-    "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
-    "MinProtocol" => "TLSv1.3",
-    "MaxProtocol" => "TLSv1.3"
-};
+my $server_tls_1_3;
+
+if (FIPS_MODE) {
+    $server_tls_1_3 = {
+        "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
+        "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
+        "MinProtocol" => "TLSv1.3",
+        "MaxProtocol" => "TLSv1.3"
+    };
+} else {
+    $server_tls_1_3 = {
+        "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
+        "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
+        "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
+        "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
+        "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
+        "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
+        "MinProtocol" => "TLSv1.3",
+        "MaxProtocol" => "TLSv1.3"
+    };
+}
 
 my $client_tls_1_3 = {
     "RSA.Certificate" => test_pem("ee-client-chain.pem"),
@@ -714,6 +742,57 @@ my @tests_tls_1_3 = (
         },
     },
     {
+        name => "TLS 1.3 RSA Client Auth Signature Algorithm Selection",
+        server => {
+            "ClientSignatureAlgorithms" => "PSS+SHA256",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => $client_tls_1_3,
+        test   => {
+            "ExpectedClientCertType" => "RSA",
+            "ExpectedClientSignHash" => "SHA256",
+            "ExpectedClientSignType" => "RSA-PSS",
+            "ExpectedClientCANames" => "empty",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names",
+        server => {
+            "ClientSignatureAlgorithms" => "PSS+SHA256",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "RequestCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => $client_tls_1_3,
+        test   => {
+            "ExpectedClientCertType" => "RSA",
+            "ExpectedClientSignHash" => "SHA256",
+            "ExpectedClientSignType" => "RSA-PSS",
+            "ExpectedClientCANames" => test_pem("root-cert.pem"),
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "TLS 1.3 ECDSA Client Auth Signature Algorithm Selection",
+        server => {
+            "ClientSignatureAlgorithms" => "ECDSA+SHA256",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => $client_tls_1_3,
+        test   => {
+            "ExpectedClientCertType" => "P-256",
+            "ExpectedClientSignHash" => "SHA256",
+            "ExpectedClientSignType" => "EC",
+            "ExpectedResult" => "Success"
+        },
+    },
+);
+
+my @tests_tls_1_3_non_fips = (
+    {
         name => "TLS 1.3 Ed25519 Signature Algorithm Selection",
         server => $server_tls_1_3,
         client => {
@@ -767,54 +846,6 @@ my @tests_tls_1_3 = (
         test   => {
             "ExpectedServerCertType" =>, "P-256",
             "ExpectedServerSignType" =>, "EC",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "TLS 1.3 RSA Client Auth Signature Algorithm Selection",
-        server => {
-            "ClientSignatureAlgorithms" => "PSS+SHA256",
-            "VerifyCAFile" => test_pem("root-cert.pem"),
-            "VerifyMode" => "Require"
-        },
-        client => $client_tls_1_3,
-        test   => {
-            "ExpectedClientCertType" => "RSA",
-            "ExpectedClientSignHash" => "SHA256",
-            "ExpectedClientSignType" => "RSA-PSS",
-            "ExpectedClientCANames" => "empty",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "TLS 1.3 RSA Client Auth Signature Algorithm Selection non-empty CA Names",
-        server => {
-            "ClientSignatureAlgorithms" => "PSS+SHA256",
-            "VerifyCAFile" => test_pem("root-cert.pem"),
-            "RequestCAFile" => test_pem("root-cert.pem"),
-            "VerifyMode" => "Require"
-        },
-        client => $client_tls_1_3,
-        test   => {
-            "ExpectedClientCertType" => "RSA",
-            "ExpectedClientSignHash" => "SHA256",
-            "ExpectedClientSignType" => "RSA-PSS",
-            "ExpectedClientCANames" => test_pem("root-cert.pem"),
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "TLS 1.3 ECDSA Client Auth Signature Algorithm Selection",
-        server => {
-            "ClientSignatureAlgorithms" => "ECDSA+SHA256",
-            "VerifyCAFile" => test_pem("root-cert.pem"),
-            "VerifyMode" => "Require"
-        },
-        client => $client_tls_1_3,
-        test   => {
-            "ExpectedClientCertType" => "P-256",
-            "ExpectedClientSignHash" => "SHA256",
-            "ExpectedClientSignType" => "EC",
             "ExpectedResult" => "Success"
         },
     },
@@ -874,6 +905,7 @@ my @tests_tls_1_3 = (
 );
 
 push @tests, @tests_tls_1_3 unless disabled("tls1_3");
+push @tests, @tests_tls_1_3_non_fips unless disabled("tls1_3") || FIPS_MODE;
 
 my @tests_dsa_tls_1_2 = (
     {

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -9,9 +9,12 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
+our $fips_mode;
+our $no_deflt_libctx;
+
 my $server;
 
-if (FIPS_MODE) {
+if ($fips_mode) {
     #TODO(3.0): No EdDSA support in FIPS mode at the moment
     $server = {
         "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
@@ -595,7 +598,7 @@ my @tests_tls_1_1 = (
     },
 );
 
-push @tests, @tests_non_fips unless FIPS_MODE;
+push @tests, @tests_non_fips unless $fips_mode;
 
 #TODO(3.0): Re-enable these PSS tests in a $no_deflt_libctx build once we have
 #           support for it
@@ -604,7 +607,7 @@ push @tests, @tests_tls_1_1 unless disabled("tls1_1") || $no_deflt_libctx;
 
 my $server_tls_1_3;
 
-if (FIPS_MODE) {
+if ($fips_mode) {
     $server_tls_1_3 = {
         "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
         "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
@@ -905,7 +908,7 @@ my @tests_tls_1_3_non_fips = (
 );
 
 push @tests, @tests_tls_1_3 unless disabled("tls1_3");
-push @tests, @tests_tls_1_3_non_fips unless disabled("tls1_3") || FIPS_MODE;
+push @tests, @tests_tls_1_3_non_fips unless disabled("tls1_3") || $fips_mode;
 
 my @tests_dsa_tls_1_2 = (
     {
@@ -961,6 +964,7 @@ my @tests_dsa_tls_1_3 = (
 );
 
 if (!disabled("dsa")) {
-    push @tests, @tests_dsa_tls_1_2 unless disabled("dh");
+    #TODO(3.0): Temporary workaround for DH issues in FIPS. Needs investigation
+    push @tests, @tests_dsa_tls_1_2 unless disabled("dh") || $fips_mode;
     push @tests, @tests_dsa_tls_1_3 unless disabled("tls1_3");
 }

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -41,13 +41,21 @@ my $server_pss_restrict_only = {
     "PrivateKey" => test_pem("server-pss-restrict-key.pem"),
 };
 
+my $server_rsa_all;
 
-my $server_rsa_all = {
-    "PSS.Certificate" => test_pem("server-pss-cert.pem"),
-    "PSS.PrivateKey" => test_pem("server-pss-key.pem"),
-    "Certificate" => test_pem("servercert.pem"),
-    "PrivateKey" => test_pem("serverkey.pem"),
-};
+if (NO_DEFLT_LIBCTX) {
+    $server_rsa_all = {
+        "Certificate" => test_pem("servercert.pem"),
+        "PrivateKey" => test_pem("serverkey.pem"),
+    };
+} else {
+    $server_rsa_all = {
+        "PSS.Certificate" => test_pem("server-pss-cert.pem"),
+        "PSS.PrivateKey" => test_pem("server-pss-key.pem"),
+        "Certificate" => test_pem("servercert.pem"),
+        "PrivateKey" => test_pem("serverkey.pem"),
+    };
+}
 
 our @tests = (
     {
@@ -176,19 +184,6 @@ our @tests = (
         },
         test   => {
             "ExpectedServerCertType" =>, "RSA",
-            "ExpectedServerSignType" =>, "RSA-PSS",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "RSA-PSS Certificate CipherString Selection",
-        server => $server_pss,
-        client => {
-            "CipherString" => "aRSA",
-            "MaxProtocol" => "TLSv1.2",
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "RSA-PSS",
             "ExpectedServerSignType" =>, "RSA-PSS",
             "ExpectedResult" => "Success"
         },
@@ -351,6 +346,108 @@ our @tests = (
         },
     },
     {
+        name => "RSA key exchange with all RSA certificate types",
+        server => $server_rsa_all,
+        client => {
+            "CipherString" => "kRSA",
+            "MaxProtocol" => "TLSv1.2",
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "RSA",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "Suite B P-256 Hash Algorithm Selection",
+        server =>  {
+            "ECDSA.Certificate" => test_pem("p256-server-cert.pem"),
+            "ECDSA.PrivateKey" => test_pem("p256-server-key.pem"),
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "SUITEB128"
+        },
+        client => {
+            "VerifyCAFile" => test_pem("p384-root.pem"),
+            "SignatureAlgorithms" => "ECDSA+SHA384:ECDSA+SHA256"
+        },
+        test   => {
+            "ExpectedServerCertType" => "P-256",
+            "ExpectedServerSignHash" => "SHA256",
+            "ExpectedServerSignType" => "EC",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "Suite B P-384 Hash Algorithm Selection",
+        server =>  {
+            "ECDSA.Certificate" => test_pem("p384-server-cert.pem"),
+            "ECDSA.PrivateKey" => test_pem("p384-server-key.pem"),
+            "MaxProtocol" => "TLSv1.2",
+            "CipherString" => "SUITEB128"
+        },
+        client => {
+            "VerifyCAFile" => test_pem("p384-root.pem"),
+            "SignatureAlgorithms" => "ECDSA+SHA256:ECDSA+SHA384"
+        },
+        test   => {
+            "ExpectedServerCertType" => "P-384",
+            "ExpectedServerSignHash" => "SHA384",
+            "ExpectedServerSignType" => "EC",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "TLS 1.2 Ed25519 Client Auth",
+        server => {
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => {
+            "Ed25519.Certificate" => test_pem("client-ed25519-cert.pem"),
+            "Ed25519.PrivateKey" => test_pem("client-ed25519-key.pem"),
+            "MinProtocol" => "TLSv1.2",
+            "MaxProtocol" => "TLSv1.2"
+        },
+        test   => {
+            "ExpectedClientCertType" => "Ed25519",
+            "ExpectedClientSignType" => "Ed25519",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
+        name => "TLS 1.2 Ed448 Client Auth",
+        server => {
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require"
+        },
+        client => {
+            "Ed448.Certificate" => test_pem("client-ed448-cert.pem"),
+            "Ed448.PrivateKey" => test_pem("client-ed448-key.pem"),
+            "MinProtocol" => "TLSv1.2",
+            "MaxProtocol" => "TLSv1.2"
+        },
+        test   => {
+            "ExpectedClientCertType" => "Ed448",
+            "ExpectedClientSignType" => "Ed448",
+            "ExpectedResult" => "Success"
+        },
+    },
+);
+
+my @tests_pss = (
+    {
+        name => "RSA-PSS Certificate CipherString Selection",
+        server => $server_pss,
+        client => {
+            "CipherString" => "aRSA",
+            "MaxProtocol" => "TLSv1.2",
+        },
+        test   => {
+            "ExpectedServerCertType" =>, "RSA-PSS",
+            "ExpectedServerSignType" =>, "RSA-PSS",
+            "ExpectedResult" => "Success"
+        },
+    },
+    {
         name => "RSA-PSS Certificate Legacy Signature Algorithm Selection",
         server => $server_pss,
         client => {
@@ -458,18 +555,6 @@ our @tests = (
         },
     },
     {
-        name => "RSA key exchange with all RSA certificate types",
-        server => $server_rsa_all,
-        client => {
-            "CipherString" => "kRSA",
-            "MaxProtocol" => "TLSv1.2",
-        },
-        test   => {
-            "ExpectedServerCertType" =>, "RSA",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
         name => "RSA key exchange with only RSA-PSS certificate",
         server => $server_pss_only,
         client => {
@@ -478,80 +563,6 @@ our @tests = (
         },
         test   => {
             "ExpectedResult" => "ServerFail"
-        },
-    },
-    {
-        name => "Suite B P-256 Hash Algorithm Selection",
-        server =>  {
-            "ECDSA.Certificate" => test_pem("p256-server-cert.pem"),
-            "ECDSA.PrivateKey" => test_pem("p256-server-key.pem"),
-            "MaxProtocol" => "TLSv1.2",
-            "CipherString" => "SUITEB128"
-        },
-        client => {
-            "VerifyCAFile" => test_pem("p384-root.pem"),
-            "SignatureAlgorithms" => "ECDSA+SHA384:ECDSA+SHA256"
-        },
-        test   => {
-            "ExpectedServerCertType" => "P-256",
-            "ExpectedServerSignHash" => "SHA256",
-            "ExpectedServerSignType" => "EC",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "Suite B P-384 Hash Algorithm Selection",
-        server =>  {
-            "ECDSA.Certificate" => test_pem("p384-server-cert.pem"),
-            "ECDSA.PrivateKey" => test_pem("p384-server-key.pem"),
-            "MaxProtocol" => "TLSv1.2",
-            "CipherString" => "SUITEB128"
-        },
-        client => {
-            "VerifyCAFile" => test_pem("p384-root.pem"),
-            "SignatureAlgorithms" => "ECDSA+SHA256:ECDSA+SHA384"
-        },
-        test   => {
-            "ExpectedServerCertType" => "P-384",
-            "ExpectedServerSignHash" => "SHA384",
-            "ExpectedServerSignType" => "EC",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "TLS 1.2 Ed25519 Client Auth",
-        server => {
-            "VerifyCAFile" => test_pem("root-cert.pem"),
-            "VerifyMode" => "Require"
-        },
-        client => {
-            "Ed25519.Certificate" => test_pem("client-ed25519-cert.pem"),
-            "Ed25519.PrivateKey" => test_pem("client-ed25519-key.pem"),
-            "MinProtocol" => "TLSv1.2",
-            "MaxProtocol" => "TLSv1.2"
-        },
-        test   => {
-            "ExpectedClientCertType" => "Ed25519",
-            "ExpectedClientSignType" => "Ed25519",
-            "ExpectedResult" => "Success"
-        },
-    },
-    {
-        name => "TLS 1.2 Ed448 Client Auth",
-        server => {
-            "VerifyCAFile" => test_pem("root-cert.pem"),
-            "VerifyMode" => "Require"
-        },
-        client => {
-            "Ed448.Certificate" => test_pem("client-ed448-cert.pem"),
-            "Ed448.PrivateKey" => test_pem("client-ed448-key.pem"),
-            "MinProtocol" => "TLSv1.2",
-            "MaxProtocol" => "TLSv1.2"
-        },
-        test   => {
-            "ExpectedClientCertType" => "Ed448",
-            "ExpectedClientSignType" => "Ed448",
-            "ExpectedResult" => "Success"
         },
     },
 );
@@ -569,7 +580,10 @@ my @tests_tls_1_1 = (
     },
 );
 
-push @tests, @tests_tls_1_1 unless disabled("tls1_1");
+#TODO(3.0): Re-enable these PSS tests in a NO_DEFLT_LIBCTX build once we have
+#           support for it
+push @tests, @tests_pss unless NO_DEFLT_LIBCTX;
+push @tests, @tests_tls_1_1 unless disabled("tls1_1") || NO_DEFLT_LIBCTX;
 
 my $server_tls_1_3 = {
     "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
@@ -578,19 +592,6 @@ my $server_tls_1_3 = {
     "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
     "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
     "Ed448.PrivateKey" => test_pem("server-ed448-key.pem"),
-    "MinProtocol" => "TLSv1.3",
-    "MaxProtocol" => "TLSv1.3"
-};
-
-my $server_tls_1_3_pss = {
-    "PSS.Certificate" => test_pem("server-pss-cert.pem"),
-    "PSS.PrivateKey" => test_pem("server-pss-key.pem"),
-    "ECDSA.Certificate" => test_pem("server-ecdsa-cert.pem"),
-    "ECDSA.PrivateKey" => test_pem("server-ecdsa-key.pem"),
-    "Ed25519.Certificate" => test_pem("server-ed25519-cert.pem"),
-    "Ed25519.PrivateKey" => test_pem("server-ed25519-key.pem"),
-    "Ed448.Certificate" => test_pem("server-ed448-cert.pem"),
-    "Ed448.PrivateKey" => test_pem("server-ed449-key.pem"),
     "MinProtocol" => "TLSv1.3",
     "MaxProtocol" => "TLSv1.3"
 };

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -54,7 +54,7 @@ my $server_pss_restrict_only = {
 
 my $server_rsa_all;
 
-if (NO_DEFLT_LIBCTX) {
+if ($no_deflt_libctx) {
     $server_rsa_all = {
         "Certificate" => test_pem("servercert.pem"),
         "PrivateKey" => test_pem("serverkey.pem"),
@@ -597,10 +597,10 @@ my @tests_tls_1_1 = (
 
 push @tests, @tests_non_fips unless FIPS_MODE;
 
-#TODO(3.0): Re-enable these PSS tests in a NO_DEFLT_LIBCTX build once we have
+#TODO(3.0): Re-enable these PSS tests in a $no_deflt_libctx build once we have
 #           support for it
-push @tests, @tests_pss unless NO_DEFLT_LIBCTX;
-push @tests, @tests_tls_1_1 unless disabled("tls1_1") || NO_DEFLT_LIBCTX;
+push @tests, @tests_pss unless $no_deflt_libctx;
+push @tests, @tests_tls_1_1 unless disabled("tls1_1") || $no_deflt_libctx;
 
 my $server_tls_1_3;
 

--- a/test/ssl-tests/25-cipher.cnf.in
+++ b/test/ssl-tests/25-cipher.cnf.in
@@ -153,4 +153,5 @@ my @tests_poly1305 = (
     },
 );
 
-push @tests, @tests_poly1305 unless disabled("poly1305") || disabled("chacha");
+push @tests, @tests_poly1305
+    unless disabled("poly1305") || disabled("chacha") || FIPS_MODE;

--- a/test/ssl-tests/25-cipher.cnf.in
+++ b/test/ssl-tests/25-cipher.cnf.in
@@ -15,6 +15,8 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
+our $fips_mode;
+
 our @tests = (
     {
         name => "cipher-server-1",
@@ -154,4 +156,4 @@ my @tests_poly1305 = (
 );
 
 push @tests, @tests_poly1305
-    unless disabled("poly1305") || disabled("chacha") || FIPS_MODE;
+    unless disabled("poly1305") || disabled("chacha") || $fips_mode;

--- a/test/ssl-tests/28-seclevel.cnf.in
+++ b/test/ssl-tests/28-seclevel.cnf.in
@@ -12,6 +12,8 @@
 package ssltests;
 use OpenSSL::Test::Utils;
 
+our $fips_mode;
+
 our @tests = (
     {
         name => "SECLEVEL 3 with default key",
@@ -80,5 +82,5 @@ our @tests_tls1_2 = (
 );
 
 #TODO(3.0): No Ed448 or X25519 in FIPS mode at the moment
-push @tests, @tests_ec unless disabled("ec") || FIPS_MODE;
-push @tests, @tests_tls1_2 unless disabled("tls1_2") || disabled("ec")|| FIPS_MODE;
+push @tests, @tests_ec unless disabled("ec") || $fips_mode;
+push @tests, @tests_tls1_2 unless disabled("tls1_2") || disabled("ec")|| $fips_mode;

--- a/test/ssl-tests/28-seclevel.cnf.in
+++ b/test/ssl-tests/28-seclevel.cnf.in
@@ -79,5 +79,6 @@ our @tests_tls1_2 = (
     },
 );
 
-push @tests, @tests_ec unless disabled("ec");
-push @tests, @tests_tls1_2 unless disabled("tls1_2") || disabled("ec");
+#TODO(3.0): No Ed448 or X25519 in FIPS mode at the moment
+push @tests, @tests_ec unless disabled("ec") || FIPS_MODE;
+push @tests, @tests_tls1_2 unless disabled("tls1_2") || disabled("ec")|| FIPS_MODE;

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -21,55 +21,82 @@ use OpenSSL::Test::Utils qw/anydisabled alldisabled disabled/;
 setup("no_test_here");
 
 my @tls_protocols = ("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3");
+my @tls_protocols_fips = ("TLSv1.2", "TLSv1.3");
 # undef stands for "no limit".
 my @min_tls_protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3");
+my @min_tls_protocols_fips = (undef, "TLSv1.2", "TLSv1.3");
 my @max_tls_protocols = ("SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3", undef);
+my @max_tls_protocols_fips = ("TLSv1.2", "TLSv1.3", undef);
 
 my @is_tls_disabled = anydisabled("ssl3", "tls1", "tls1_1", "tls1_2", "tls1_3");
+my @is_tls_disabled_fips = anydisabled("tls1_2", "tls1_3");
 
 my $min_tls_enabled; my $max_tls_enabled;
+my $min_tls_enabled_fips; my $max_tls_enabled_fips;
 
 # Protocol configuration works in cascades, i.e.,
 # $no_tls1_1 disables TLSv1.1 and below.
 #
 # $min_enabled and $max_enabled will be correct if there is at least one
 # protocol enabled.
-foreach my $i (0..$#tls_protocols) {
-    if (!$is_tls_disabled[$i]) {
-        $min_tls_enabled = $i;
-        last;
+
+sub min_prot_enabled {
+    my $protref = shift;
+    my $disabledref = shift;
+    my @protocols = @{$protref};
+    my @is_disabled = @{$disabledref};
+    my $min_enabled;
+
+    foreach my $i (0..$#protocols) {
+        if (!$is_disabled[$i]) {
+            $min_enabled = $i;
+            last;
+        }
     }
+    return $min_enabled;
 }
 
-foreach my $i (0..$#tls_protocols) {
-    if (!$is_tls_disabled[$i]) {
-        $max_tls_enabled = $i;
+sub max_prot_enabled {
+    my $protref = shift;
+    my $disabledref = shift;
+    my @protocols = @{$protref};
+    my @is_disabled = @{$disabledref};
+    my $max_enabled;
+
+    foreach my $i (0..$#protocols) {
+        if (!$is_disabled[$i]) {
+            $max_enabled = $i;
+        }
     }
+    return $max_enabled;
 }
+
+$min_tls_enabled = min_prot_enabled(\@tls_protocols, \@is_tls_disabled);
+$max_tls_enabled = max_prot_enabled(\@tls_protocols, \@is_tls_disabled);
+$min_tls_enabled_fips = min_prot_enabled(\@tls_protocols_fips, \@is_tls_disabled_fips);
+$max_tls_enabled_fips = max_prot_enabled(\@tls_protocols_fips, \@is_tls_disabled_fips);
+
 
 my @dtls_protocols = ("DTLSv1", "DTLSv1.2");
+my @dtls_protocols_fips = ("DTLSv1.2");
 # undef stands for "no limit".
 my @min_dtls_protocols = (undef, "DTLSv1", "DTLSv1.2");
+my @min_dtls_protocols_fips = (undef, "DTLSv1.2");
 my @max_dtls_protocols = ("DTLSv1", "DTLSv1.2", undef);
+my @max_dtls_protocols_fips = ("DTLSv1.2", undef);
 
 my @is_dtls_disabled = anydisabled("dtls1", "dtls1_2");
+my @is_dtls_disabled_fips = anydisabled("dtls1_2");
 
 my $min_dtls_enabled; my $max_dtls_enabled;
+my $min_dtls_enabled_fips; my $max_dtls_enabled_fips;
 
 # $min_enabled and $max_enabled will be correct if there is at least one
 # protocol enabled.
-foreach my $i (0..$#dtls_protocols) {
-    if (!$is_dtls_disabled[$i]) {
-        $min_dtls_enabled = $i;
-        last;
-    }
-}
-
-foreach my $i (0..$#dtls_protocols) {
-    if (!$is_dtls_disabled[$i]) {
-        $max_dtls_enabled = $i;
-    }
-}
+$min_dtls_enabled = min_prot_enabled(\@dtls_protocols, \@is_dtls_disabled);
+$max_dtls_enabled = max_prot_enabled(\@dtls_protocols, \@is_dtls_disabled);
+$min_dtls_enabled_fips = min_prot_enabled(\@dtls_protocols_fips, \@is_dtls_disabled_fips);
+$max_dtls_enabled_fips = max_prot_enabled(\@dtls_protocols_fips, \@is_dtls_disabled_fips);
 
 sub no_tests {
     my ($dtls) = @_;
@@ -78,17 +105,31 @@ sub no_tests {
 }
 
 sub generate_version_tests {
-    my ($method) = @_;
+    my $method = shift;
+    my $fips = shift;
 
     my $dtls = $method eq "DTLS";
     # Don't write the redundant "Method = TLS" into the configuration.
     undef $method if !$dtls;
 
-    my @protocols = $dtls ? @dtls_protocols : @tls_protocols;
-    my @min_protocols = $dtls ? @min_dtls_protocols : @min_tls_protocols;
-    my @max_protocols = $dtls ? @max_dtls_protocols : @max_tls_protocols;
-    my $min_enabled  = $dtls ? $min_dtls_enabled : $min_tls_enabled;
-    my $max_enabled  = $dtls ? $max_dtls_enabled : $max_tls_enabled;
+    my @protocols;
+    my @min_protocols;
+    my @max_protocols;
+    my $min_enabled;
+    my $max_enabled;
+    if ($fips) {
+        @protocols = $dtls ? @dtls_protocols_fips : @tls_protocols_fips;
+        @min_protocols = $dtls ? @min_dtls_protocols_fips : @min_tls_protocols_fips;
+        @max_protocols = $dtls ? @max_dtls_protocols_fips : @max_tls_protocols_fips;
+        $min_enabled  = $dtls ? $min_dtls_enabled_fips : $min_tls_enabled_fips;
+        $max_enabled  = $dtls ? $max_dtls_enabled_fips : $max_tls_enabled_fips;
+    } else {
+        @protocols = $dtls ? @dtls_protocols : @tls_protocols;
+        @min_protocols = $dtls ? @min_dtls_protocols : @min_tls_protocols;
+        @max_protocols = $dtls ? @max_dtls_protocols : @max_tls_protocols;
+        $min_enabled  = $dtls ? $min_dtls_enabled : $min_tls_enabled;
+        $max_enabled  = $dtls ? $max_dtls_enabled : $max_tls_enabled;
+    }
 
     if (no_tests($dtls)) {
         return;
@@ -166,15 +207,26 @@ sub generate_version_tests {
 }
 
 sub generate_resumption_tests {
-    my ($method) = @_;
+    my $method = shift;
+    my $fips = shift;
 
     my $dtls = $method eq "DTLS";
     # Don't write the redundant "Method = TLS" into the configuration.
     undef $method if !$dtls;
 
-    my @protocols = $dtls ? @dtls_protocols : @tls_protocols;
-    my $min_enabled  = $dtls ? $min_dtls_enabled : $min_tls_enabled;
-    my $max_enabled = $dtls ? $max_dtls_enabled : $max_tls_enabled;
+    my @protocols;
+    my $min_enabled;
+    my $max_enabled;
+
+    if ($fips) {
+        @protocols = $dtls ? @dtls_protocols_fips : @tls_protocols_fips;
+        $min_enabled  = $dtls ? $min_dtls_enabled_fips : $min_tls_enabled_fips;
+        $max_enabled = $dtls ? $max_dtls_enabled_fips : $max_tls_enabled_fips;
+    } else {
+        @protocols = $dtls ? @dtls_protocols : @tls_protocols;
+        $min_enabled  = $dtls ? $min_dtls_enabled : $min_tls_enabled;
+        $max_enabled = $dtls ? $max_dtls_enabled : $max_tls_enabled;
+    }
 
     if (no_tests($dtls)) {
         return;

--- a/test/ssl-tests/ssltests_base.pm
+++ b/test/ssl-tests/ssltests_base.pm
@@ -17,6 +17,9 @@ sub test_pem
     return "\${ENV::TEST_CERTS_DIR}" . $dir_sep . $file,
 }
 
+our $fips_mode = 0;
+our $no_deflt_libctx = 0;
+
 our %base_server = (
     "Certificate" => test_pem("servercert.pem"),
     "PrivateKey"  => test_pem("serverkey.pem"),

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -533,14 +533,16 @@ int setup_tests(void)
     if (!TEST_ptr(modulename = test_get_argument(1)))
         return 0;
 
-    defctxnull = OSSL_PROVIDER_load(NULL, "null");
-    libctx = OPENSSL_CTX_new();
-    if (!TEST_ptr(libctx))
-        return 0;
+    if (strcmp(modulename, "none") != 0) {
+        defctxnull = OSSL_PROVIDER_load(NULL, "null");
+        libctx = OPENSSL_CTX_new();
+        if (!TEST_ptr(libctx))
+            return 0;
 
-    thisprov = OSSL_PROVIDER_load(libctx, modulename);
-    if (!TEST_ptr(thisprov))
-        return 0;
+        thisprov = OSSL_PROVIDER_load(libctx, modulename);
+        if (!TEST_ptr(thisprov))
+            return 0;
+    }
 
     ADD_ALL_TESTS(test_handshake, (int)num_tests);
     return 1;

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -511,7 +511,7 @@ err:
     return ret;
 }
 
-OPT_TEST_DECLARE_USAGE("conf_file\n")
+OPT_TEST_DECLARE_USAGE("conf_file modulename [fips_conf_file]\n")
 
 int setup_tests(void)
 {
@@ -534,9 +534,15 @@ int setup_tests(void)
         return 0;
 
     if (strcmp(modulename, "none") != 0) {
+        const char *configfile = test_get_argument(2);
+
         defctxnull = OSSL_PROVIDER_load(NULL, "null");
         libctx = OPENSSL_CTX_new();
         if (!TEST_ptr(libctx))
+            return 0;
+
+        if (configfile != NULL
+                && !TEST_true(OPENSSL_CTX_load_config(libctx, configfile)))
             return 0;
 
         thisprov = OSSL_PROVIDER_load(libctx, modulename);


### PR DESCRIPTION
We run ssl_test_new three times:
- once with a default library context and no providers explicitly loaded
- once with a non-default library context with the default provider loaded into it, and
- once with a non-default library context with the FIPS provider loaded into it.

In both of the latter two cases we load the "null" provider into the default context to make sure we don't accidentally pick up algorithms from there.

We do the run with a default library context because there are some tests which only work in that configuration at the moment. Namely any which involve an RSA PSS cert/key - because we do not have provider support for that at the moment. Eventually I expect we can dispense with that run and just do the second two runs.

These tests will fail since they require all the key gen PRs to be merged first as well as #11494 and #11507 (and I have not included them here). However, aside from the dependencies this should be fairly complete and can be reviewed.