### PR TITLE
Don't compile commands if disabled

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -24,30 +24,44 @@ IF[{- !$disabled{apps} -}]
   DEPEND[openssl]=libapps.a ../libssl
   IF[{- !$disabled{'des'} -}]
     SOURCE[openssl]=pkcs12.c
+    DEPEND[pkcs12.o]=progs.h
   ENDIF
   IF[{- !$disabled{'ec'} -}]
     SOURCE[openssl]=ec.c ecparam.c
+    DEPEND[ec.o]=progs.h
+    DEPEND[ecparam.o]=progs.h
   ENDIF
   IF[{- !$disabled{'ocsp'} -}]
     SOURCE[openssl]=ocsp.c
+    DEPEND[ocsp.o]=progs.h
   ENDIF
   IF[{- !$disabled{'srp'} -}]
     SOURCE[openssl]=srp.c
+    DEPEND[srp.o]=progs.h
   ENDIF
   IF[{- !$disabled{'ts'} -}]
     SOURCE[openssl]=ts.c
+    DEPEND[ts.o]=progs.h
   ENDIF
   IF[{- !$disabled{'dh'} -}]
     SOURCE[openssl]=dhparam.c
+    DEPEND[dhparam.o]=progs.h
   ENDIF
   IF[{- !$disabled{'dsa'} -}]
     SOURCE[openssl]=dsa.c dsaparam.c gendsa.c
+    DEPEND[dsa.o]=progs.h
+    DEPEND[dsaparam.o]=progs.h
+    DEPEND[gendsa.o]=progs.h
   ENDIF
   IF[{- !$disabled{'engine'} -}]
     SOURCE[openssl]=engine.c
+    DEPEND[engine.o]=progs.h
   ENDIF
   IF[{- !$disabled{'rsa'} -}]
     SOURCE[openssl]=rsa.c rsautl.c genrsa.c
+    DEPEND[rsa.o]=progs.h
+    DEPEND[rsautl.o]=progs.h
+    DEPEND[genrsa.o]=progs.h
   ENDIF
   IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
     GENERATE[openssl.rc]=../util/mkrc.pl openssl

--- a/apps/build.info
+++ b/apps/build.info
@@ -1,16 +1,17 @@
 {- our @apps_openssl_src =
        qw(openssl.c
-          asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c dhparam.c
-          dsa.c dsaparam.c ec.c ecparam.c enc.c engine.c errstr.c gendsa.c
-          genpkey.c genrsa.c nseq.c ocsp.c passwd.c pkcs12.c pkcs7.c pkcs8.c
-          pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c rsa.c rsautl.c
+          asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c
+          dsa.c enc.c errstr.c
+          genpkey.c nseq.c passwd.c pkcs7.c pkcs8.c
+          pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c
           s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c
-          srp.c ts.c verify.c version.c x509.c rehash.c storeutl.c);
+          verify.c version.c x509.c rehash.c storeutl.c);
    our @apps_lib_src =
        ( qw(apps.c opt.c s_cb.c s_socket.c app_rand.c bf_prefix.c),
          split(/\s+/, $target{apps_aux_src}) );
    our @apps_init_src = split(/\s+/, $target{apps_init_src});
    "" -}
+
 IF[{- !$disabled{apps} -}]
   LIBS_NO_INST=libapps.a
   SOURCE[libapps.a]={- join(" ", @apps_lib_src) -}
@@ -21,11 +22,37 @@ IF[{- !$disabled{apps} -}]
   SOURCE[openssl]={- join(" ", @apps_openssl_src) -}
   INCLUDE[openssl]=.. ../include
   DEPEND[openssl]=libapps.a ../libssl
-
-IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
-  GENERATE[openssl.rc]=../util/mkrc.pl openssl
-  SOURCE[openssl]=openssl.rc
-ENDIF
+  IF[{- !$disabled{'des'} -}]
+    SOURCE[openssl]=pkcs12.c
+  ENDIF
+  IF[{- !$disabled{'ec'} -}]
+    SOURCE[openssl]=ec.c ecparam.c
+  ENDIF
+  IF[{- !$disabled{'ocsp'} -}]
+    SOURCE[openssl]=ocsp.c
+  ENDIF
+  IF[{- !$disabled{'srp'} -}]
+    SOURCE[openssl]=srp.c
+  ENDIF
+  IF[{- !$disabled{'ts'} -}]
+    SOURCE[openssl]=ts.c
+  ENDIF
+  IF[{- !$disabled{'dh'} -}]
+    SOURCE[openssl]=dhparam.c
+  ENDIF
+  IF[{- !$disabled{'dsa'} -}]
+    SOURCE[openssl]=dsa.c dsaparam.c gendsa.c
+  ENDIF
+  IF[{- !$disabled{'engine'} -}]
+    SOURCE[openssl]=engine.c
+  ENDIF
+  IF[{- !$disabled{'rsa'} -}]
+    SOURCE[openssl]=rsa.c rsautl.c genrsa.c
+  ENDIF
+  IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
+    GENERATE[openssl.rc]=../util/mkrc.pl openssl
+    SOURCE[openssl]=openssl.rc
+  ENDIF
 
   {- join("\n  ", map { (my $x = $_) =~ s|\.c$|.o|; "DEPEND[$x]=progs.h" }
                   @apps_openssl_src) -}

--- a/apps/build.info
+++ b/apps/build.info
@@ -1,7 +1,7 @@
 {- our @apps_openssl_src =
        qw(openssl.c
           asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c
-          dsa.c enc.c errstr.c
+          enc.c errstr.c
           genpkey.c nseq.c passwd.c pkcs7.c pkcs8.c
           pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c
           s_client.c s_server.c s_time.c sess_id.c smime.c speed.c spkac.c

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -8,28 +8,24 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_DH
-NON_EMPTY_TRANSLATION_UNIT
-#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
 
-# include <stdio.h>
-# include <stdlib.h>
-# include <time.h>
-# include <string.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/bn.h>
-# include <openssl/dh.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
+#ifndef OPENSSL_NO_DSA
+# include <openssl/dsa.h>
+#endif
 
-# ifndef OPENSSL_NO_DSA
-#  include <openssl/dsa.h>
-# endif
-
-# define DEFBITS 2048
+#define DEFBITS 2048
 
 static int dh_cb(int p, int n, BN_GENCB *cb);
 
@@ -56,13 +52,13 @@ const OPTIONS dhparam_options[] = {
     {"C", OPT_C, '-', "Print C code"},
     {"2", OPT_2, '-', "Generate parameters using 2 as the generator value"},
     {"5", OPT_5, '-', "Generate parameters using 5 as the generator value"},
-# ifndef OPENSSL_NO_DSA
+#ifndef OPENSSL_NO_DSA
     {"dsaparam", OPT_DSAPARAM, '-',
      "Read or generate DSA parameters, convert to DH"},
-# endif
-# ifndef OPENSSL_NO_ENGINE
+#endif
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine e, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -146,13 +142,13 @@ int dhparam_main(int argc, char **argv)
     if (g && !num)
         num = DEFBITS;
 
-# ifndef OPENSSL_NO_DSA
+#ifndef OPENSSL_NO_DSA
     if (dsaparam && g) {
         BIO_printf(bio_err,
                    "generator may not be chosen for DSA parameters\n");
         goto end;
     }
-# endif
+#endif
 
     out = bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
@@ -173,7 +169,7 @@ int dhparam_main(int argc, char **argv)
 
         BN_GENCB_set(cb, dh_cb, bio_err);
 
-# ifndef OPENSSL_NO_DSA
+#ifndef OPENSSL_NO_DSA
         if (dsaparam) {
             DSA *dsa = DSA_new();
 
@@ -196,7 +192,7 @@ int dhparam_main(int argc, char **argv)
                 goto end;
             }
         } else
-# endif
+#endif
         {
             dh = DH_new();
             BIO_printf(bio_err,
@@ -217,7 +213,7 @@ int dhparam_main(int argc, char **argv)
         if (in == NULL)
             goto end;
 
-# ifndef OPENSSL_NO_DSA
+#ifndef OPENSSL_NO_DSA
         if (dsaparam) {
             DSA *dsa;
 
@@ -239,7 +235,7 @@ int dhparam_main(int argc, char **argv)
                 goto end;
             }
         } else
-# endif
+#endif
         {
             if (informat == FORMAT_ASN1) {
                 /*
@@ -376,4 +372,3 @@ static int dh_cb(int p, int n, BN_GENCB *cb)
     (void)BIO_flush(BN_GENCB_get_arg(cb));
     return 1;
 }
-#endif

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -8,23 +8,19 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_DSA
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include <time.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/dsa.h>
-# include <openssl/evp.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
-# include <openssl/bn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/dsa.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/bn.h>
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -49,14 +45,14 @@ const OPTIONS dsa_options[] = {
     {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
-# ifndef OPENSSL_NO_RC4
+#ifndef OPENSSL_NO_RC4
     {"pvk-strong", OPT_PVK_STRONG, '-', "Enable 'Strong' PVK encoding level (default)"},
     {"pvk-weak", OPT_PVK_WEAK, '-', "Enable 'Weak' PVK encoding level"},
     {"pvk-none", OPT_PVK_NONE, '-', "Don't enforce PVK encoding"},
-# endif
-# ifndef OPENSSL_NO_ENGINE
+#endif
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine e, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -71,9 +67,9 @@ int dsa_main(int argc, char **argv)
     OPTION_CHOICE o;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, text = 0, noout = 0;
     int i, modulus = 0, pubin = 0, pubout = 0, ret = 1;
-# ifndef OPENSSL_NO_RC4
+#ifndef OPENSSL_NO_RC4
     int pvk_encr = 2;
-# endif
+#endif
     int private = 0;
 
     prog = opt_init(argc, argv, dsa_options);
@@ -214,7 +210,7 @@ int dsa_main(int argc, char **argv)
             i = PEM_write_bio_DSAPrivateKey(out, dsa, enc,
                                             NULL, 0, NULL, passout);
         }
-# ifndef OPENSSL_NO_RSA
+#ifndef OPENSSL_NO_RSA
     } else if (outformat == FORMAT_MSBLOB || outformat == FORMAT_PVK) {
         EVP_PKEY *pk;
         pk = EVP_PKEY_new();
@@ -229,13 +225,13 @@ int dsa_main(int argc, char **argv)
                 goto end;
             }
             assert(private);
-#  ifdef OPENSSL_NO_RC4
+# ifdef OPENSSL_NO_RC4
             BIO_printf(bio_err, "PVK format not supported\n");
             EVP_PKEY_free(pk);
             goto end;
-#  else
+# else
             i = i2b_PVK_bio(out, pk, pvk_encr, 0, passout);
-#  endif
+# endif
         } else if (pubin || pubout) {
             i = i2b_PublicKey_bio(out, pk);
         } else {
@@ -243,7 +239,7 @@ int dsa_main(int argc, char **argv)
             i = i2b_PrivateKey_bio(out, pk);
         }
         EVP_PKEY_free(pk);
-# endif
+#endif
     } else {
         BIO_printf(bio_err, "bad output format specified for outfile\n");
         goto end;
@@ -262,4 +258,3 @@ int dsa_main(int argc, char **argv)
     OPENSSL_free(passout);
     return ret;
 }
-#endif

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -8,22 +8,18 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_DSA
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include <stdio.h>
-# include <stdlib.h>
-# include <time.h>
-# include <string.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/bn.h>
-# include <openssl/dsa.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/dsa.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
 
 static int dsa_cb(int p, int n, BN_GENCB *cb);
 
@@ -44,9 +40,9 @@ const OPTIONS dsaparam_options[] = {
     {"noout", OPT_NOOUT, '-', "No output"},
     {"genkey", OPT_GENKEY, '-', "Generate a DSA key"},
     OPT_R_OPTIONS,
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine e, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -255,4 +251,3 @@ static int dsa_cb(int p, int n, BN_GENCB *cb)
     (void)BIO_flush(BN_GENCB_get_arg(cb));
     return 1;
 }
-#endif

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -8,19 +8,15 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_EC
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/evp.h>
-# include <openssl/pem.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
 
 static OPT_PAIR conv_forms[] = {
     {"compressed", POINT_CONVERSION_COMPRESSED},
@@ -62,9 +58,9 @@ const OPTIONS ec_options[] = {
      "Specifies the way the ec parameters are encoded"},
     {"conv_form", OPT_CONV_FORM, 's', "Specifies the point conversion form "},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -280,4 +276,3 @@ int ec_main(int argc, char **argv)
     OPENSSL_free(passout);
     return ret;
 }
-#endif

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -9,22 +9,18 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_EC
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include <stdio.h>
-# include <stdlib.h>
-# include <time.h>
-# include <string.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/bn.h>
-# include <openssl/ec.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -55,9 +51,9 @@ const OPTIONS ecparam_options[] = {
      "Specifies the way the ec parameters are encoded"},
     {"genkey", OPT_GENKEY, '-', "Generate ec key"},
     OPT_R_OPTIONS,
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -446,5 +442,3 @@ int ecparam_main(int argc, char **argv)
     BIO_free_all(out);
     return ret;
 }
-
-#endif

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -8,19 +8,15 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_ENGINE
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include "apps.h"
-# include "progs.h"
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include <openssl/err.h>
-# include <openssl/engine.h>
-# include <openssl/ssl.h>
-# include <openssl/store.h>
+#include "apps.h"
+#include "progs.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/err.h>
+#include <openssl/engine.h>
+#include <openssl/ssl.h>
+#include <openssl/store.h>
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -486,4 +482,3 @@ int engine_main(int argc, char **argv)
     BIO_free_all(out);
     return ret;
 }
-#endif

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -8,22 +8,18 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_DSA
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include <stdio.h>
-# include <string.h>
-# include <sys/types.h>
-# include <sys/stat.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/bn.h>
-# include <openssl/dsa.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/dsa.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -39,9 +35,9 @@ const OPTIONS gendsa_options[] = {
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     OPT_R_OPTIONS,
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -143,4 +139,3 @@ int gendsa_main(int argc, char **argv)
     OPENSSL_free(passout);
     return ret;
 }
-#endif

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -8,27 +8,23 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_RSA
-NON_EMPTY_TRANSLATION_UNIT
-#else
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
 
-# include <stdio.h>
-# include <string.h>
-# include <sys/types.h>
-# include <sys/stat.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/bn.h>
-# include <openssl/rsa.h>
-# include <openssl/evp.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
-# include <openssl/rand.h>
-
-# define DEFBITS 2048
-# define DEFPRIMES 2
+#define DEFBITS 2048
+#define DEFPRIMES 2
 
 static int genrsa_cb(int p, int n, BN_GENCB *cb);
 
@@ -48,9 +44,9 @@ const OPTIONS genrsa_options[] = {
     OPT_R_OPTIONS,
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {"primes", OPT_PRIMES, 'p', "Specify number of primes"},
     {NULL}
 };
@@ -198,4 +194,3 @@ static int genrsa_cb(int p, int n, BN_GENCB *cb)
     (void)BIO_flush(BN_GENCB_get_arg(cb));
     return 1;
 }
-#endif

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -9,65 +9,62 @@
 
 #include <openssl/opensslconf.h>
 
-#ifdef OPENSSL_NO_OCSP
-NON_EMPTY_TRANSLATION_UNIT
-#else
-# ifdef OPENSSL_SYS_VMS
-#  define _XOPEN_SOURCE_EXTENDED/* So fd_set and friends get properly defined
+#ifdef OPENSSL_SYS_VMS
+# define _XOPEN_SOURCE_EXTENDED/* So fd_set and friends get properly defined
                                  * on OpenVMS */
-# endif
+#endif
 
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include <time.h>
-# include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <ctype.h>
 
 /* Needs to be included before the openssl headers */
-# include "apps.h"
-# include "progs.h"
-# include "internal/sockets.h"
-# include <openssl/e_os2.h>
-# include <openssl/crypto.h>
-# include <openssl/err.h>
-# include <openssl/ssl.h>
-# include <openssl/evp.h>
-# include <openssl/bn.h>
-# include <openssl/x509v3.h>
-# include <openssl/rand.h>
+#include "apps.h"
+#include "progs.h"
+#include "internal/sockets.h"
+#include <openssl/e_os2.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/evp.h>
+#include <openssl/bn.h>
+#include <openssl/x509v3.h>
+#include <openssl/rand.h>
 
 #ifndef HAVE_FORK
-# if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS)
-#  define HAVE_FORK 0
-# else
-#  define HAVE_FORK 1
-# endif
+#if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS)
+# define HAVE_FORK 0
+#else
+# define HAVE_FORK 1
+#endif
 #endif
 
 #if HAVE_FORK
-# undef NO_FORK
+#undef NO_FORK
 #else
-# define NO_FORK
+#define NO_FORK
 #endif
 
-# if !defined(NO_FORK) && !defined(OPENSSL_NO_SOCK) \
+#if !defined(NO_FORK) && !defined(OPENSSL_NO_SOCK) \
      && !defined(OPENSSL_NO_POSIX_IO)
-#  define OCSP_DAEMON
-#  include <sys/types.h>
-#  include <sys/wait.h>
-#  include <syslog.h>
-#  include <signal.h>
-#  define MAXERRLEN 1000 /* limit error text sent to syslog to 1000 bytes */
-# else
-#  undef LOG_INFO
-#  undef LOG_WARNING
-#  undef LOG_ERR
-#  define LOG_INFO      0
-#  define LOG_WARNING   1
-#  define LOG_ERR       2
-# endif
+# define OCSP_DAEMON
+# include <sys/types.h>
+# include <sys/wait.h>
+# include <syslog.h>
+# include <signal.h>
+# define MAXERRLEN 1000 /* limit error text sent to syslog to 1000 bytes */
+#else
+# undef LOG_INFO
+# undef LOG_WARNING
+# undef LOG_ERR
+# define LOG_INFO      0
+# define LOG_WARNING   1
+# define LOG_ERR       2
+#endif
 
-# if defined(OPENSSL_SYS_VXWORKS)
+#if defined(OPENSSL_SYS_VXWORKS)
 /* not supported */
 int setpgid(pid_t pid, pid_t pgid)
 {
@@ -80,9 +77,9 @@ pid_t fork(void)
     errno = ENOSYS;
     return (pid_t) -1;
 }
-# endif
+#endif
 /* Maximum leeway in validity period: default 5 minutes */
-# define MAX_VALIDITY_PERIOD    (5 * 60)
+#define MAX_VALIDITY_PERIOD    (5 * 60)
 
 static int add_ocsp_cert(OCSP_REQUEST **req, X509 *cert,
                          const EVP_MD *cert_id_md, X509 *issuer,
@@ -109,20 +106,20 @@ static void log_message(int level, const char *fmt, ...);
 static char *prog;
 static int multi = 0;
 
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
 static int acfd = (int) INVALID_SOCKET;
 static int index_changed(CA_DB *);
 static void spawn_loop(void);
 static int print_syslog(const char *str, size_t len, void *levPtr);
 static void socket_timeout(int signum);
-# endif
+#endif
 
-# ifndef OPENSSL_NO_SOCK
+#ifndef OPENSSL_NO_SOCK
 static OCSP_RESPONSE *query_responder(BIO *cbio, const char *host,
                                       const char *path,
                                       const STACK_OF(CONF_VALUE) *headers,
                                       OCSP_REQUEST *req, int req_timeout);
-# endif
+#endif
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -160,9 +157,9 @@ const OPTIONS ocsp_options[] = {
      "Don't include any certificates in response"},
     {"resp_key_id", OPT_RESP_KEY_ID, '-',
      "Identify response by signing certificate key ID"},
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
     {"multi", OPT_MULTI, 'p', "run multiple responder processes"},
-# endif
+#endif
     {"no_certs", OPT_NO_CERTS, '-',
      "Don't include any certificates in signed request"},
     {"no_signature_verify", OPT_NO_SIGNATURE_VERIFY, '-',
@@ -511,9 +508,9 @@ int ocsp_main(int argc, char **argv)
             trailing_md = 1;
             break;
         case OPT_MULTI:
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
             multi = atoi(opt_arg());
-# endif
+#endif
             break;
         }
     }
@@ -593,7 +590,7 @@ int ocsp_main(int argc, char **argv)
         }
     }
 
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
     if (multi && acbio != NULL)
         spawn_loop();
     if (acbio != NULL && req_timeout > 0)
@@ -606,7 +603,7 @@ int ocsp_main(int argc, char **argv)
 redo_accept:
 
     if (acbio != NULL) {
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
         if (index_changed(rdb)) {
             CA_DB *newrdb = load_index(ridx_filename, NULL);
 
@@ -619,7 +616,7 @@ redo_accept:
                             ridx_filename);
             }
         }
-# endif
+#endif
 
         req = NULL;
         if (!do_responder(&req, &cbio, acbio, req_timeout))
@@ -688,16 +685,16 @@ redo_accept:
         if (cbio != NULL)
             send_ocsp_response(cbio, resp);
     } else if (host != NULL) {
-# ifndef OPENSSL_NO_SOCK
+#ifndef OPENSSL_NO_SOCK
         resp = process_responder(req, host, path,
                                  port, use_ssl, headers, req_timeout);
         if (resp == NULL)
             goto end;
-# else
+#else
         BIO_printf(bio_err,
                    "Error creating connect BIO - sockets not supported.\n");
         goto end;
-# endif
+#endif
     } else if (respin != NULL) {
         derbio = bio_open_default(respin, 'r', FORMAT_ASN1);
         if (derbio == NULL)
@@ -840,7 +837,7 @@ log_message(int level, const char *fmt, ...)
     va_list ap;
 
     va_start(ap, fmt);
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
     if (multi) {
         char buf[1024];
         if (vsnprintf(buf, sizeof(buf), fmt, ap) > 0) {
@@ -849,7 +846,7 @@ log_message(int level, const char *fmt, ...)
         if (level >= LOG_ERR)
             ERR_print_errors_cb(print_syslog, &level);
     }
-# endif
+#endif
     if (!multi) {
         BIO_printf(bio_err, "%s: ", prog);
         BIO_vprintf(bio_err, fmt, ap);
@@ -858,7 +855,7 @@ log_message(int level, const char *fmt, ...)
     va_end(ap);
 }
 
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
 
 static int print_syslog(const char *str, size_t len, void *levPtr)
 {
@@ -1011,7 +1008,7 @@ static void spawn_loop(void)
     syslog(LOG_INFO, "terminating on signal: %d", termsig);
     killall(0, kidpids);
 }
-# endif
+#endif
 
 static int add_ocsp_cert(OCSP_REQUEST **req, X509 *cert,
                          const EVP_MD *cert_id_md, X509 *issuer,
@@ -1291,11 +1288,11 @@ static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser)
 
 static BIO *init_responder(const char *port)
 {
-# ifdef OPENSSL_NO_SOCK
+#ifdef OPENSSL_NO_SOCK
     BIO_printf(bio_err,
                "Error setting up accept BIO - sockets not supported.\n");
     return NULL;
-# else
+#else
     BIO *acbio = NULL, *bufbio = NULL;
 
     bufbio = BIO_new(BIO_f_buffer());
@@ -1322,10 +1319,10 @@ static BIO *init_responder(const char *port)
     BIO_free_all(acbio);
     BIO_free(bufbio);
     return NULL;
-# endif
+#endif
 }
 
-# ifndef OPENSSL_NO_SOCK
+#ifndef OPENSSL_NO_SOCK
 /*
  * Decode %xx URL-decoding in-place. Ignores mal-formed sequences.
  */
@@ -1349,22 +1346,22 @@ static int urldecode(char *p)
     *out = '\0';
     return (int)(out - save);
 }
-# endif
+#endif
 
-# ifdef OCSP_DAEMON
+#ifdef OCSP_DAEMON
 static void socket_timeout(int signum)
 {
     if (acfd != (int)INVALID_SOCKET)
         (void)shutdown(acfd, SHUT_RD);
 }
-# endif
+#endif
 
 static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
                         int timeout)
 {
-# ifdef OPENSSL_NO_SOCK
+#ifdef OPENSSL_NO_SOCK
     return 0;
-# else
+#else
     int len;
     OCSP_REQUEST *req = NULL;
     char inbuf[2048], reqbuf[2048];
@@ -1382,12 +1379,12 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
     *pcbio = cbio;
     client = BIO_get_peer_name(cbio);
 
-#  ifdef OCSP_DAEMON
+# ifdef OCSP_DAEMON
     if (timeout > 0) {
         (void) BIO_get_fd(cbio, &acfd);
         alarm(timeout);
     }
-#  endif
+# endif
 
     /* Read the request line. */
     len = BIO_gets(cbio, reqbuf, sizeof(reqbuf));
@@ -1450,11 +1447,11 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
             break;
     }
 
-#  ifdef OCSP_DAEMON
+# ifdef OCSP_DAEMON
     /* Clear alarm before we close the client socket */
     alarm(0);
     timeout = 0;
-#  endif
+# endif
 
     /* Try to read OCSP request */
     if (getbio != NULL) {
@@ -1470,13 +1467,13 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
     *preq = req;
 
 out:
-#  ifdef OCSP_DAEMON
+# ifdef OCSP_DAEMON
     if (timeout > 0)
         alarm(0);
     acfd = (int)INVALID_SOCKET;
-#  endif
-    return 1;
 # endif
+    return 1;
+#endif
 }
 
 static int send_ocsp_response(BIO *cbio, OCSP_RESPONSE *resp)
@@ -1492,7 +1489,7 @@ static int send_ocsp_response(BIO *cbio, OCSP_RESPONSE *resp)
     return 1;
 }
 
-# ifndef OPENSSL_NO_SOCK
+#ifndef OPENSSL_NO_SOCK
 static OCSP_RESPONSE *query_responder(BIO *cbio, const char *host,
                                       const char *path,
                                       const STACK_OF(CONF_VALUE) *headers,
@@ -1623,6 +1620,4 @@ OCSP_RESPONSE *process_responder(OCSP_REQUEST *req,
     SSL_CTX_free(ctx);
     return resp;
 }
-# endif
-
 #endif

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -8,25 +8,21 @@
  */
 
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_NO_DES)
-NON_EMPTY_TRANSLATION_UNIT
-#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs12.h>
 
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/crypto.h>
-# include <openssl/err.h>
-# include <openssl/pem.h>
-# include <openssl/pkcs12.h>
-
-# define NOKEYS          0x1
-# define NOCERTS         0x2
-# define INFO            0x4
-# define CLCERTS         0x8
-# define CACERTS         0x10
+#define NOKEYS          0x1
+#define NOCERTS         0x2
+#define INFO            0x4
+#define CLCERTS         0x8
+#define CACERTS         0x10
 
 #define PASSWD_BUF_SIZE 2048
 
@@ -74,15 +70,15 @@ const OPTIONS pkcs12_options[] = {
     {"chain", OPT_CHAIN, '-', "Add certificate chain"},
     {"twopass", OPT_TWOPASS, '-', "Separate MAC, encryption passwords"},
     {"nomacver", OPT_NOMACVER, '-', "Don't verify MAC"},
-# ifndef OPENSSL_NO_RC2
+#ifndef OPENSSL_NO_RC2
     {"descert", OPT_DESCERT, '-',
      "Encrypt output with 3DES (default RC2-40)"},
     {"certpbe", OPT_CERTPBE, 's',
      "Certificate PBE algorithm (default RC2-40)"},
-# else
+#else
     {"descert", OPT_DESCERT, '-', "Encrypt output with 3DES (the default)"},
     {"certpbe", OPT_CERTPBE, 's', "Certificate PBE algorithm (default 3DES)"},
-# endif
+#endif
     {"export", OPT_EXPORT, '-', "Output PKCS12 file"},
     {"noiter", OPT_NOITER, '-', "Don't use encryption iteration"},
     {"maciter", OPT_MACITER, '-', "Use MAC iteration"},
@@ -113,9 +109,9 @@ const OPTIONS pkcs12_options[] = {
     {"no-CApath", OPT_NOCAPATH, '-',
      "Do not load certificates from the default certificates directory"},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -126,11 +122,11 @@ int pkcs12_main(int argc, char **argv)
     char pass[PASSWD_BUF_SIZE] = "", macpass[PASSWD_BUF_SIZE] = "";
     int export_cert = 0, options = 0, chain = 0, twopass = 0, keytype = 0;
     int iter = PKCS12_DEFAULT_ITER, maciter = PKCS12_DEFAULT_ITER;
-# ifndef OPENSSL_NO_RC2
+#ifndef OPENSSL_NO_RC2
     int cert_pbe = NID_pbe_WithSHA1And40BitRC2_CBC;
-# else
+#else
     int cert_pbe = NID_pbe_WithSHA1And3_Key_TripleDES_CBC;
-# endif
+#endif
     int key_pbe = NID_pbe_WithSHA1And3_Key_TripleDES_CBC;
     int ret = 1, macver = 1, add_lmk = 0, private = 0;
     int noprompt = 0;
@@ -976,5 +972,3 @@ static int set_pbe(int *ppbe, const char *str)
     }
     return 1;
 }
-
-#endif

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -8,23 +8,19 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_RSA
-NON_EMPTY_TRANSLATION_UNIT
-#else
-
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include <time.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/rsa.h>
-# include <openssl/evp.h>
-# include <openssl/x509.h>
-# include <openssl/pem.h>
-# include <openssl/bn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/bn.h>
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -53,14 +49,14 @@ const OPTIONS rsa_options[] = {
     {"modulus", OPT_MODULUS, '-', "Print the RSA key modulus"},
     {"check", OPT_CHECK, '-', "Verify key consistency"},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
-# if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_RC4)
+#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_RC4)
     {"pvk-strong", OPT_PVK_STRONG, '-', "Enable 'Strong' PVK encoding level (default)"},
     {"pvk-weak", OPT_PVK_WEAK, '-', "Enable 'Weak' PVK encoding level"},
     {"pvk-none", OPT_PVK_NONE, '-', "Don't enforce PVK encoding"},
-# endif
-# ifndef OPENSSL_NO_ENGINE
+#endif
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -75,9 +71,9 @@ int rsa_main(int argc, char **argv)
     int i, private = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, text = 0, check = 0;
     int noout = 0, modulus = 0, pubin = 0, pubout = 0, ret = 1;
-# if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_RC4)
+#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_RC4)
     int pvk_encr = 2;
-# endif
+#endif
     OPTION_CHOICE o;
 
     prog = opt_init(argc, argv, rsa_options);
@@ -130,9 +126,9 @@ int rsa_main(int argc, char **argv)
         case OPT_PVK_STRONG:    /* pvk_encr:= 2 */
         case OPT_PVK_WEAK:      /* pvk_encr:= 1 */
         case OPT_PVK_NONE:      /* pvk_encr:= 0 */
-# if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_RC4)
+#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_RC4)
             pvk_encr = (o - OPT_PVK_NONE);
-# endif
+#endif
             break;
         case OPT_NOOUT:
             noout = 1;
@@ -265,7 +261,7 @@ int rsa_main(int argc, char **argv)
             i = PEM_write_bio_RSAPrivateKey(out, rsa,
                                             enc, NULL, 0, NULL, passout);
         }
-# ifndef OPENSSL_NO_DSA
+#ifndef OPENSSL_NO_DSA
     } else if (outformat == FORMAT_MSBLOB || outformat == FORMAT_PVK) {
         EVP_PKEY *pk;
         pk = EVP_PKEY_new();
@@ -280,13 +276,13 @@ int rsa_main(int argc, char **argv)
                 goto end;
             }
             assert(private);
-#  ifdef OPENSSL_NO_RC4
+# ifdef OPENSSL_NO_RC4
             BIO_printf(bio_err, "PVK format not supported\n");
             EVP_PKEY_free(pk);
             goto end;
-#  else
+# else
             i = i2b_PVK_bio(out, pk, pvk_encr, 0, passout);
-#  endif
+# endif
         } else if (pubin || pubout) {
             i = i2b_PublicKey_bio(out, pk);
         } else {
@@ -294,7 +290,7 @@ int rsa_main(int argc, char **argv)
             i = i2b_PrivateKey_bio(out, pk);
         }
         EVP_PKEY_free(pk);
-# endif
+#endif
     } else {
         BIO_printf(bio_err, "bad output format specified for outfile\n");
         goto end;
@@ -313,4 +309,3 @@ int rsa_main(int argc, char **argv)
     OPENSSL_free(passout);
     return ret;
 }
-#endif

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -8,25 +8,21 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_RSA
-NON_EMPTY_TRANSLATION_UNIT
-#else
+#include "apps.h"
+#include "progs.h"
+#include <string.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
 
-# include "apps.h"
-# include "progs.h"
-# include <string.h>
-# include <openssl/err.h>
-# include <openssl/pem.h>
-# include <openssl/rsa.h>
+#define RSA_SIGN        1
+#define RSA_VERIFY      2
+#define RSA_ENCRYPT     3
+#define RSA_DECRYPT     4
 
-# define RSA_SIGN        1
-# define RSA_VERIFY      2
-# define RSA_ENCRYPT     3
-# define RSA_DECRYPT     4
-
-# define KEY_PRIVKEY     1
-# define KEY_PUBKEY      2
-# define KEY_CERT        3
+#define KEY_PRIVKEY     1
+#define KEY_PUBKEY      2
+#define KEY_CERT        3
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -60,9 +56,9 @@ const OPTIONS rsautl_options[] = {
     {"decrypt", OPT_DECRYPT, '-', "Decrypt with private key"},
     {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
     OPT_R_OPTIONS,
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -279,4 +275,3 @@ int rsautl_main(int argc, char **argv)
     OPENSSL_free(passin);
     return ret;
 }
-#endif

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -12,28 +12,24 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_SRP
-NON_EMPTY_TRANSLATION_UNIT
-#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/conf.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/txt_db.h>
+#include <openssl/buffer.h>
+#include <openssl/srp.h>
+#include "apps.h"
+#include "progs.h"
 
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include <openssl/conf.h>
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/txt_db.h>
-# include <openssl/buffer.h>
-# include <openssl/srp.h>
-# include "apps.h"
-# include "progs.h"
-
-# define BASE_SECTION    "srp"
-# define CONFIG_FILE "openssl.cnf"
+#define BASE_SECTION    "srp"
+#define CONFIG_FILE "openssl.cnf"
 
 
-# define ENV_DATABASE            "srpvfile"
-# define ENV_DEFAULT_SRP         "default_srp"
+#define ENV_DATABASE            "srpvfile"
+#define ENV_DEFAULT_SRP         "default_srp"
 
 static int get_index(CA_DB *db, char *id, char type)
 {
@@ -212,9 +208,9 @@ const OPTIONS srp_options[] = {
     {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     OPT_R_OPTIONS,
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {NULL}
 };
 
@@ -610,4 +606,3 @@ int srp_main(int argc, char **argv)
     release_engine(e);
     return ret;
 }
-#endif

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -8,29 +8,26 @@
  */
 
 #include <openssl/opensslconf.h>
-#ifdef OPENSSL_NO_TS
-NON_EMPTY_TRANSLATION_UNIT
-#else
-# include <stdio.h>
-# include <stdlib.h>
-# include <string.h>
-# include "apps.h"
-# include "progs.h"
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/pem.h>
-# include <openssl/rand.h>
-# include <openssl/ts.h>
-# include <openssl/bn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "apps.h"
+#include "progs.h"
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
+#include <openssl/ts.h>
+#include <openssl/bn.h>
 
 /* Request nonce length, in bits (must be a multiple of 8). */
-# define NONCE_LENGTH            64
+#define NONCE_LENGTH            64
 
 /* Name of config entry that defines the OID file. */
-# define ENV_OID_FILE            "oid_file"
+#define ENV_OID_FILE            "oid_file"
 
 /* Is |EXACTLY_ONE| of three pointers set? */
-# define EXACTLY_ONE(a, b, c) \
+#define EXACTLY_ONE(a, b, c) \
         (( a && !b && !c) || \
          ( b && !a && !c) || \
          ( c && !a && !b))
@@ -114,9 +111,9 @@ const OPTIONS ts_options[] = {
     {"CAfile", OPT_CAFILE, '<', "File with trusted CA certs"},
     {"untrusted", OPT_UNTRUSTED, '<', "File with untrusted certs"},
     {"", OPT_MD, '-', "Any supported digest"},
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
-# endif
+#endif
     {OPT_HELP_STR, 1, '-', "\nOptions specific to 'ts -verify': \n"},
     OPT_V_OPTIONS,
     {OPT_HELP_STR, 1, '-', "\n"},
@@ -137,11 +134,11 @@ static char* opt_helplist[] = {
     "          [-signer tsa_cert.pem] [-inkey private_key.pem]",
     "          [-chain certs_file.pem] [-tspolicy oid]",
     "          [-in file] [-token_in] [-out file] [-token_out]",
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     "          [-text] [-engine id]",
-# else
+#else
     "          [-text]",
-# endif
+#endif
     "  or",
     "ts -verify -CApath dir -CAfile file.pem -untrusted file.pem",
     "           [-data file] [-digest hexstring]",
@@ -682,10 +679,10 @@ static TS_RESP *create_response(CONF *conf, const char *section, const char *eng
         goto end;
     if (!TS_CONF_set_serial(conf, section, serial_cb, resp_ctx))
         goto end;
-# ifndef OPENSSL_NO_ENGINE
+#ifndef OPENSSL_NO_ENGINE
     if (!TS_CONF_set_crypto_device(conf, section, engine))
         goto end;
-# endif
+#endif
     if (!TS_CONF_set_signer_cert(conf, section, signer, resp_ctx))
         goto end;
     if (!TS_CONF_set_certs(conf, section, chain, resp_ctx))
@@ -984,4 +981,3 @@ static int verify_cb(int ok, X509_STORE_CTX *ctx)
 {
     return ok;
 }
-#endif  /* ndef OPENSSL_NO_TS */


### PR DESCRIPTION
Rather than wrapping whole files in "ifndef OPENSSL_NO_xxx" we handle
the changes in build.info

This is a backport of #11250.  @bernd-edlinger convinced me to create it.