### PR TITLE
Fix build and runtime issues for WinCE

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1417,9 +1417,9 @@ my %targets = (
             }
             push @ex_libs, '$(PORTSDK_LIBPATH)/portlib.lib'
                 if (defined(env('PORTSDK_LIBPATH')));
-            push @ex_libs, ' /nodefaultlib coredll.lib corelibc.lib'
-                if (env('TARGETCPU') eq "X86");
-            return @ex_libs;
+            push @ex_libs, '/nodefaultlib coredll.lib corelibc.lib'
+                if (env('TARGETCPU') =~ /^X86|^ARMV4[IT]/);
+            return join(" ", @ex_libs);
         }),
     },
 

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -251,8 +251,8 @@ CNF_CPPFLAGS={- our $cppfags2 =
                     join(' ', $target{cppflags} || (),
                               (map { '-D'.quotify1($_) } @{$target{defines}},
                                                          @{$config{defines}}),
-                              (map { '-I'.quotify1($_) } @{$target{includes}},
-                                                         @{$config{includes}}),
+                              (map { '-I'.'"'.$_.'"' } @{$target{includes}},
+                                                       @{$config{includes}}),
                               @{$config{cppflags}}) -}
 CNF_CFLAGS={- join(' ', $target{cflags} || (),
                         @{$config{cflags}}) -}

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -87,6 +87,15 @@ const BIGNUM *BN_value_one(void)
     return &const_one;
 }
 
+/*
+ * Old Visual Studio ARM compiler miscompiles BN_num_bits_word()
+ * https://mta.openssl.org/pipermail/openssl-users/2018-August/008465.html
+ */
+#if defined(_MSC_VER) && defined(_ARM_) && defined(_WIN32_WCE) \
+    && _MSC_VER>=1400 && _MSC_VER<1501
+# define MS_BROKEN_BN_num_bits_word
+# pragma optimize("", off)
+#endif
 int BN_num_bits_word(BN_ULONG l)
 {
     BN_ULONG x, mask;
@@ -131,6 +140,9 @@ int BN_num_bits_word(BN_ULONG l)
 
     return bits;
 }
+#ifdef MS_BROKEN_BN_num_bits_word
+# pragma optimize("", on)
+#endif
 
 /*
  * This function still leaks `a->dmax`: it's caller's responsibility to

--- a/crypto/dso/dso_win32.c
+++ b/crypto/dso/dso_win32.c
@@ -565,8 +565,8 @@ static int win32_pathbyaddr(void *addr, char *path, int sz)
 
     /* Enumerate the modules to find one which includes me. */
     do {
-        if ((uintptr_t) addr >= (uintptr_t) me32.modBaseAddr &&
-            (uintptr_t) addr < (uintptr_t) (me32.modBaseAddr + me32.modBaseSize)) {
+        if ((size_t) addr >= (size_t) me32.modBaseAddr &&
+            (size_t) addr < (size_t) (me32.modBaseAddr + me32.modBaseSize)) {
             (*close_snap) (hModuleSnap);
             FreeLibrary(dll);
 # ifdef _WIN32_WCE

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -255,7 +255,7 @@ char *OPENSSL_buf2hexstr(const unsigned char *buf, long buflen)
 
 int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 {
-#if defined(_MSC_VER) && _MSC_VER>=1400
+#if defined(_MSC_VER) && _MSC_VER>=1400 && !defined(_WIN32_WCE)
     return !strerror_s(buf, buflen, errnum);
 #elif defined(_GNU_SOURCE)
     char *err;

--- a/crypto/o_time.c
+++ b/crypto/o_time.c
@@ -41,7 +41,7 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
     if (gmtime_r(timer, result) == NULL)
         return NULL;
     ts = result;
-#elif defined (OPENSSL_SYS_WINDOWS) && defined(_MSC_VER) && _MSC_VER >= 1400
+#elif defined (OPENSSL_SYS_WINDOWS) && defined(_MSC_VER) && _MSC_VER >= 1400 && !defined(_WIN32_WCE)
     if (gmtime_s(result, timer))
         return NULL;
     ts = result;

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -26,7 +26,7 @@
 #ifndef OPENSSL_NO_POSIX_IO
 # include <sys/stat.h>
 # include <fcntl.h>
-# ifdef _WIN32
+# if defined(_WIN32) && !defined(_WIN32_WCE)
 #  include <windows.h>
 #  include <io.h>
 #  define stat    _stat

--- a/e_os.h
+++ b/e_os.h
@@ -258,7 +258,7 @@ extern FILE *_imp___iob;
 # if defined(OPENSSL_SYS_WINDOWS)
 #  define strcasecmp _stricmp
 #  define strncasecmp _strnicmp
-#  if (_MSC_VER >= 1310)
+#  if (_MSC_VER >= 1310) && !defined(_WIN32_WCE)
 #   define open _open
 #   define fdopen _fdopen
 #   define close _close

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -220,7 +220,7 @@ typedef UINT64 uint64_t;
 #  undef OPENSSL_NO_INTTYPES_H
 /* Because the specs say that inttypes.h includes stdint.h if present */
 #  undef OPENSSL_NO_STDINT_H
-# elif defined(_MSC_VER) && _MSC_VER<=1500
+# elif defined(_MSC_VER) && _MSC_VER<1600
 /*
  * minimally required typdefs for systems not supporting inttypes.h or
  * stdint.h: currently just older VC++


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

Fixes #11466

#11466-1
WinCE6 + VS2005 environment doesn't seem to have a definition of _uintptr_t_ so I changed it to _size_t_ (989c183).

#11466-2
As @bjorn-lg says, BN_num_bits_word() is miscompiled on WinCE6 + VS2005 with optimization enabled. @asitde saw his test program caused error:"0306E06C:bignum routines:BN_mod_inverse:no inverse" at _EVP_DigestSignFinal()_ while the same program runs correctly on x86/Windows10. Disabling optimization have solved their runtime error. This problem is reported at:
https://mta.openssl.org/pipermail/openssl-users/2018-August/008465.html
@asitde and I also found openssl library built on WinCE7 + VS2008 with cl.exe v15.01.50304.03 for ARM (_MSC_VER==1501) which is bundled with CE7 Platform Builder works perfectly. But cl.exe v15.00.20720 (_MSC_VER==1500) which is included in VS2008 makes the same error. Hence we should disable the function's optimization when compiler version is between 1400 <= _MSC_VER < 1501. 8979de1 is this fix.

#11466-3
When I configure for WinCE according to a procedure below , 2 parameters aren't set correctly on makefile:
https://qiita.com/souju/items/94117c024862f57459c3#build-openssl
Therefore makefile need to be manually modified each time configure is performed. f92955b fixes this problem. Using _quotify1()_ here have a problem because it escapes '$'. Diff of generated makefile is:
```diff
- CNF_CPPFLAGS=-D_WIN32_WCE=700 -DUNDER_CE=700 -DWCE_PLATFORM_VC-CE -DARM -D_ARM_ -DARMV4I -QRarch4T -QRinterwork-return -D"OPENSSL_SYS_WIN32" -D"WIN32_LEAN_AND_MEAN" -D"UNICODE" -D"_UNICODE" -D"_CRT_SECURE_NO_DEPRECATE" -D"_WINSOCK_DEPRECATED_NO_WARNINGS" -D"NDEBUG" -I"\$(WCECOMPAT)/include"
+ CNF_CPPFLAGS=-D_WIN32_WCE=700 -DUNDER_CE=700 -DWCE_PLATFORM_VC-CE -DARM -D_ARM_ -DARMV4I -QRarch4T -QRinterwork-return -D"OPENSSL_SYS_WIN32" -D"WIN32_LEAN_AND_MEAN" -D"UNICODE" -D"_UNICODE" -D"_CRT_SECURE_NO_DEPRECATE" -D"_WINSOCK_DEPRECATED_NO_WARNINGS" -D"NDEBUG" -I"$(WCECOMPAT)/include"
..
- CNF_EX_LIBS=3
+ CNF_EX_LIBS=ws2.lib crypt32.lib $(WCECOMPAT)/lib/wcecompatex.lib /nodefaultlib coredll.lib corelibc.lib
```
Furthermore I had to deceive _MSC_VER by addig -"-D_MSC_VER=1300" to CFLAGS to build successfully. 4b8ba84 makes this workaround unnecessary and eliminates some warnings.