### PR TITLE
[crypto/ec] deprecate Jprojective_coordinates_GFp functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,14 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx] ###
 
+ * Deprecated EC_POINT_set_Jprojective_coordinates_GFp() and
+   EC_POINT_get_Jprojective_coordinates_GFp(). These functions are not widely
+   used and applications should instead use the
+   L<EC_POINT_set_affine_coordinates(3)> and
+   L<EC_POINT_get_affine_coordinates(3)> functions.
+
+   *Billy Bob Brumley*
+
  * Added OSSL_PARAM_BLD to the public interface.  This allows OSSL_PARAM
    arrays to be more easily constructed via a series of utility functions.
    Create a parameter builder using OSSL_PARAM_BLD_new(), add parameters using

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -956,8 +956,6 @@ const EC_METHOD *EC_GF2m_simple_method(void)
         ec_GF2m_simple_point_clear_finish,
         ec_GF2m_simple_point_copy,
         ec_GF2m_simple_point_set_to_infinity,
-        0, /* set_Jprojective_coordinates_GFp */
-        0, /* get_Jprojective_coordinates_GFp */
         ec_GF2m_simple_point_set_affine_coordinates,
         ec_GF2m_simple_point_get_affine_coordinates,
         0, /* point_set_compressed_coordinates */

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -796,12 +796,13 @@ int EC_POINT_set_to_infinity(const EC_GROUP *group, EC_POINT *point)
     return group->meth->point_set_to_infinity(group, point);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
                                              EC_POINT *point, const BIGNUM *x,
                                              const BIGNUM *y, const BIGNUM *z,
                                              BN_CTX *ctx)
 {
-    if (group->meth->point_set_Jprojective_coordinates_GFp == 0) {
+    if (group->meth->field_type != NID_X9_62_prime_field) {
         ECerr(EC_F_EC_POINT_SET_JPROJECTIVE_COORDINATES_GFP,
               ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
         return 0;
@@ -811,8 +812,7 @@ int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
               EC_R_INCOMPATIBLE_OBJECTS);
         return 0;
     }
-    return group->meth->point_set_Jprojective_coordinates_GFp(group, point, x,
-                                                              y, z, ctx);
+    return ec_GFp_simple_set_Jprojective_coordinates_GFp(group, point, x, y, z, ctx);
 }
 
 int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
@@ -820,7 +820,7 @@ int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
                                              BIGNUM *y, BIGNUM *z,
                                              BN_CTX *ctx)
 {
-    if (group->meth->point_get_Jprojective_coordinates_GFp == 0) {
+    if (group->meth->field_type != NID_X9_62_prime_field) {
         ECerr(EC_F_EC_POINT_GET_JPROJECTIVE_COORDINATES_GFP,
               ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
         return 0;
@@ -830,9 +830,9 @@ int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
               EC_R_INCOMPATIBLE_OBJECTS);
         return 0;
     }
-    return group->meth->point_get_Jprojective_coordinates_GFp(group, point, x,
-                                                              y, z, ctx);
+    return ec_GFp_simple_get_Jprojective_coordinates_GFp(group, point, x, y, z, ctx);
 }
+#endif
 
 int EC_POINT_set_affine_coordinates(const EC_GROUP *group, EC_POINT *point,
                                     const BIGNUM *x, const BIGNUM *y,

--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -76,14 +76,6 @@ struct ec_method_st {
      * EC_POINT_set_compressed_coordinates:
      */
     int (*point_set_to_infinity) (const EC_GROUP *, EC_POINT *);
-    int (*point_set_Jprojective_coordinates_GFp) (const EC_GROUP *,
-                                                  EC_POINT *, const BIGNUM *x,
-                                                  const BIGNUM *y,
-                                                  const BIGNUM *z, BN_CTX *);
-    int (*point_get_Jprojective_coordinates_GFp) (const EC_GROUP *,
-                                                  const EC_POINT *, BIGNUM *x,
-                                                  BIGNUM *y, BIGNUM *z,
-                                                  BN_CTX *);
     int (*point_set_affine_coordinates) (const EC_GROUP *, EC_POINT *,
                                          const BIGNUM *x, const BIGNUM *y,
                                          BN_CTX *);

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -37,8 +37,6 @@ const EC_METHOD *EC_GFp_mont_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ec_GFp_simple_point_get_affine_coordinates,
         0, 0, 0,

--- a/crypto/ec/ecp_nist.c
+++ b/crypto/ec/ecp_nist.c
@@ -39,8 +39,6 @@ const EC_METHOD *EC_GFp_nist_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ec_GFp_simple_point_get_affine_coordinates,
         0, 0, 0,

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -264,8 +264,6 @@ const EC_METHOD *EC_GFp_nistp224_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ec_GFp_nistp224_point_get_affine_coordinates,
         0 /* point_set_compressed_coordinates */ ,
@@ -1468,9 +1466,8 @@ int ec_GFp_nistp224_points_mul(const EC_GROUP *group, EC_POINT *r,
             ECerr(EC_F_EC_GFP_NISTP224_POINTS_MUL, ERR_R_BN_LIB);
             goto err;
         }
-        if (!EC_POINT_set_Jprojective_coordinates_GFp(group,
-                                                      generator, x, y, z,
-                                                      ctx))
+        if (!ec_GFp_simple_set_Jprojective_coordinates_GFp(group, generator, x,
+                                                           y, z, ctx))
             goto err;
         if (0 == EC_POINT_cmp(group, generator, group->generator, ctx))
             /* precomputation matches generator */
@@ -1604,7 +1601,7 @@ int ec_GFp_nistp224_points_mul(const EC_GROUP *group, EC_POINT *r,
         ECerr(EC_F_EC_GFP_NISTP224_POINTS_MUL, ERR_R_BN_LIB);
         goto err;
     }
-    ret = EC_POINT_set_Jprojective_coordinates_GFp(group, r, x, y, z, ctx);
+    ret = ec_GFp_simple_set_Jprojective_coordinates_GFp(group, r, x, y, z, ctx);
 
  err:
     BN_CTX_end(ctx);

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1801,8 +1801,6 @@ const EC_METHOD *EC_GFp_nistp256_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ec_GFp_nistp256_point_get_affine_coordinates,
         0 /* point_set_compressed_coordinates */ ,
@@ -2083,9 +2081,8 @@ int ec_GFp_nistp256_points_mul(const EC_GROUP *group, EC_POINT *r,
             ECerr(EC_F_EC_GFP_NISTP256_POINTS_MUL, ERR_R_BN_LIB);
             goto err;
         }
-        if (!EC_POINT_set_Jprojective_coordinates_GFp(group,
-                                                      generator, x, y, z,
-                                                      ctx))
+        if (!ec_GFp_simple_set_Jprojective_coordinates_GFp(group, generator, x,
+                                                           y, z, ctx))
             goto err;
         if (0 == EC_POINT_cmp(group, generator, group->generator, ctx))
             /* precomputation matches generator */
@@ -2225,7 +2222,7 @@ int ec_GFp_nistp256_points_mul(const EC_GROUP *group, EC_POINT *r,
         ECerr(EC_F_EC_GFP_NISTP256_POINTS_MUL, ERR_R_BN_LIB);
         goto err;
     }
-    ret = EC_POINT_set_Jprojective_coordinates_GFp(group, r, x, y, z, ctx);
+    ret = ec_GFp_simple_set_Jprojective_coordinates_GFp(group, r, x, y, z, ctx);
 
  err:
     BN_CTX_end(ctx);

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1641,8 +1641,6 @@ const EC_METHOD *EC_GFp_nistp521_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ec_GFp_nistp521_point_get_affine_coordinates,
         0 /* point_set_compressed_coordinates */ ,
@@ -1922,9 +1920,8 @@ int ec_GFp_nistp521_points_mul(const EC_GROUP *group, EC_POINT *r,
             ECerr(EC_F_EC_GFP_NISTP521_POINTS_MUL, ERR_R_BN_LIB);
             goto err;
         }
-        if (!EC_POINT_set_Jprojective_coordinates_GFp(group,
-                                                      generator, x, y, z,
-                                                      ctx))
+        if (!ec_GFp_simple_set_Jprojective_coordinates_GFp(group, generator, x,
+                                                           y, z, ctx))
             goto err;
         if (0 == EC_POINT_cmp(group, generator, group->generator, ctx))
             /* precomputation matches generator */
@@ -2062,7 +2059,7 @@ int ec_GFp_nistp521_points_mul(const EC_GROUP *group, EC_POINT *r,
         ECerr(EC_F_EC_GFP_NISTP521_POINTS_MUL, ERR_R_BN_LIB);
         goto err;
     }
-    ret = EC_POINT_set_Jprojective_coordinates_GFp(group, r, x, y, z, ctx);
+    ret = ec_GFp_simple_set_Jprojective_coordinates_GFp(group, r, x, y, z, ctx);
 
  err:
     BN_CTX_end(ctx);

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -1694,8 +1694,6 @@ const EC_METHOD *EC_GFp_nistz256_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ecp_nistz256_get_affine,
         0, 0, 0,

--- a/crypto/ec/ecp_s390x_nistp.c
+++ b/crypto/ec/ecp_s390x_nistp.c
@@ -332,8 +332,6 @@ const EC_METHOD *EC_GFp_s390x_nistp##bits##_method(void)                \
         ec_GFp_simple_point_clear_finish,                               \
         ec_GFp_simple_point_copy,                                       \
         ec_GFp_simple_point_set_to_infinity,                            \
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,                  \
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,                  \
         ec_GFp_simple_point_set_affine_coordinates,                     \
         ec_GFp_simple_point_get_affine_coordinates,                     \
         NULL, /* point_set_compressed_coordinates */                    \

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -38,8 +38,6 @@ const EC_METHOD *EC_GFp_simple_method(void)
         ec_GFp_simple_point_clear_finish,
         ec_GFp_simple_point_copy,
         ec_GFp_simple_point_set_to_infinity,
-        ec_GFp_simple_set_Jprojective_coordinates_GFp,
-        ec_GFp_simple_get_Jprojective_coordinates_GFp,
         ec_GFp_simple_point_set_affine_coordinates,
         ec_GFp_simple_point_get_affine_coordinates,
         0, 0, 0,

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -256,7 +256,8 @@ EC_POINT_set_compressed_coordinates_GFp(),
 EC_POINT_set_affine_coordinates_GF2m(), EC_POINT_get_affine_coordinates_GF2m(),
 EC_POINT_set_compressed_coordinates_GF2m() were deprecated in OpenSSL 3.0.
 
-B<EC_POINT_set_affine_coordinates> and B<EC_POINT_get_affine_coordinates> were
+B<EC_POINT_set_affine_coordinates>, B<EC_POINT_get_affine_coordinates>,
+and B<EC_POINT_set_compressed_coordinates> were
 added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -40,14 +40,6 @@ EC_POINT_hex2point
  EC_POINT *EC_POINT_dup(const EC_POINT *src, const EC_GROUP *group);
  const EC_METHOD *EC_POINT_method_of(const EC_POINT *point);
  int EC_POINT_set_to_infinity(const EC_GROUP *group, EC_POINT *point);
- int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
-                                              EC_POINT *p,
-                                              const BIGNUM *x, const BIGNUM *y,
-                                              const BIGNUM *z, BN_CTX *ctx);
- int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
-                                              const EC_POINT *p,
-                                              BIGNUM *x, BIGNUM *y, BIGNUM *z,
-                                              BN_CTX *ctx);
  int EC_POINT_set_affine_coordinates(const EC_GROUP *group, EC_POINT *p,
                                      const BIGNUM *x, const BIGNUM *y,
                                      BN_CTX *ctx);
@@ -56,6 +48,34 @@ EC_POINT_hex2point
  int EC_POINT_set_compressed_coordinates(const EC_GROUP *group, EC_POINT *p,
                                          const BIGNUM *x, int y_bit,
                                          BN_CTX *ctx);
+ size_t EC_POINT_point2oct(const EC_GROUP *group, const EC_POINT *p,
+                           point_conversion_form_t form,
+                           unsigned char *buf, size_t len, BN_CTX *ctx);
+ size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
+                           point_conversion_form_t form,
+                           unsigned char **pbuf, BN_CTX *ctx);
+ int EC_POINT_oct2point(const EC_GROUP *group, EC_POINT *p,
+                        const unsigned char *buf, size_t len, BN_CTX *ctx);
+ BIGNUM *EC_POINT_point2bn(const EC_GROUP *group, const EC_POINT *p,
+                           point_conversion_form_t form, BIGNUM *bn,
+                           BN_CTX *ctx);
+ EC_POINT *EC_POINT_bn2point(const EC_GROUP *group, const BIGNUM *bn,
+                             EC_POINT *p, BN_CTX *ctx);
+ char *EC_POINT_point2hex(const EC_GROUP *group, const EC_POINT *p,
+                          point_conversion_form_t form, BN_CTX *ctx);
+ EC_POINT *EC_POINT_hex2point(const EC_GROUP *group, const char *hex,
+                              EC_POINT *p, BN_CTX *ctx);
+
+Deprecated since OpenSSL 3.0:
+
+ int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
+                                              EC_POINT *p,
+                                              const BIGNUM *x, const BIGNUM *y,
+                                              const BIGNUM *z, BN_CTX *ctx);
+ int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
+                                              const EC_POINT *p,
+                                              BIGNUM *x, BIGNUM *y, BIGNUM *z,
+                                              BN_CTX *ctx);
  int EC_POINT_set_affine_coordinates_GFp(const EC_GROUP *group, EC_POINT *p,
                                          const BIGNUM *x, const BIGNUM *y,
                                          BN_CTX *ctx);
@@ -76,24 +96,6 @@ EC_POINT_hex2point
                                               EC_POINT *p,
                                               const BIGNUM *x, int y_bit,
                                               BN_CTX *ctx);
- size_t EC_POINT_point2oct(const EC_GROUP *group, const EC_POINT *p,
-                           point_conversion_form_t form,
-                           unsigned char *buf, size_t len, BN_CTX *ctx);
- size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
-                           point_conversion_form_t form,
-                           unsigned char **pbuf, BN_CTX *ctx);
- int EC_POINT_oct2point(const EC_GROUP *group, EC_POINT *p,
-                        const unsigned char *buf, size_t len, BN_CTX *ctx);
- BIGNUM *EC_POINT_point2bn(const EC_GROUP *group, const EC_POINT *p,
-                           point_conversion_form_t form, BIGNUM *bn,
-                           BN_CTX *ctx);
- EC_POINT *EC_POINT_bn2point(const EC_GROUP *group, const BIGNUM *bn,
-                             EC_POINT *p, BN_CTX *ctx);
- char *EC_POINT_point2hex(const EC_GROUP *group, const EC_POINT *p,
-                          point_conversion_form_t form, BN_CTX *ctx);
- EC_POINT *EC_POINT_hex2point(const EC_GROUP *group, const char *hex,
-                              EC_POINT *p, BN_CTX *ctx);
-
 
 =head1 DESCRIPTION
 
@@ -142,9 +144,13 @@ operations.  A mapping exists between Jacobian projective co-ordinates and
 affine co-ordinates. A Jacobian projective co-ordinate (x, y, z) can be written
 as an affine co-ordinate as (x/(z^2), y/(z^3)). Conversion to Jacobian
 projective from affine co-ordinates is simple. The co-ordinate (x, y) is mapped
-to (x, y, 1). To set or get the projective co-ordinates use
+to (x, y, 1). Although deprecated in OpenSSL 3.0 and should no longer be used,
+to set or get the projective co-ordinates in older versions use
 EC_POINT_set_Jprojective_coordinates_GFp() and
 EC_POINT_get_Jprojective_coordinates_GFp() respectively.
+Modern versions should instead use EC_POINT_set_affine_coordinates() and
+EC_POINT_get_affine_coordinates(), performing the conversion manually using the
+above maps if necessary.
 
 Points can also be described in terms of their compressed co-ordinates. For a
 point (x, y), for any given value for x such that the point is on the curve
@@ -240,6 +246,18 @@ error.
 L<crypto(7)>, L<EC_GROUP_new(3)>, L<EC_GROUP_copy(3)>,
 L<EC_POINT_add(3)>, L<EC_KEY_new(3)>,
 L<EC_GFp_simple_method(3)>, L<d2i_ECPKParameters(3)>
+
+=head1 HISTORY
+
+EC_POINT_set_Jprojective_coordinates_GFp(),
+EC_POINT_get_Jprojective_coordinates_GFp(),
+EC_POINT_set_affine_coordinates_GFp(), EC_POINT_get_affine_coordinates_GFp(),
+EC_POINT_set_compressed_coordinates_GFp(),
+EC_POINT_set_affine_coordinates_GF2m(), EC_POINT_get_affine_coordinates_GF2m(),
+EC_POINT_set_compressed_coordinates_GF2m() were deprecated in OpenSSL 3.0.
+
+B<EC_POINT_set_affine_coordinates> and B<EC_POINT_set_affine_coordinates> were
+added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -150,7 +150,7 @@ EC_POINT_set_Jprojective_coordinates_GFp() and
 EC_POINT_get_Jprojective_coordinates_GFp() respectively.
 Modern versions should instead use EC_POINT_set_affine_coordinates() and
 EC_POINT_get_affine_coordinates(), performing the conversion manually using the
-above maps if necessary.
+above maps in such rare circumstances.
 
 Points can also be described in terms of their compressed co-ordinates. For a
 point (x, y), for any given value for x such that the point is on the curve
@@ -256,7 +256,7 @@ EC_POINT_set_compressed_coordinates_GFp(),
 EC_POINT_set_affine_coordinates_GF2m(), EC_POINT_get_affine_coordinates_GF2m(),
 EC_POINT_set_compressed_coordinates_GF2m() were deprecated in OpenSSL 3.0.
 
-B<EC_POINT_set_affine_coordinates> and B<EC_POINT_set_affine_coordinates> were
+B<EC_POINT_set_affine_coordinates> and B<EC_POINT_get_affine_coordinates> were
 added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -511,10 +511,10 @@ int EC_POINT_set_to_infinity(const EC_GROUP *group, EC_POINT *point);
  *  \param  ctx    BN_CTX object (optional)
  *  \return 1 on success and 0 if an error occurred
  */
-int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
+DEPRECATEDIN_3_0(int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
                                              EC_POINT *p, const BIGNUM *x,
                                              const BIGNUM *y, const BIGNUM *z,
-                                             BN_CTX *ctx);
+                                             BN_CTX *ctx))
 
 /** Gets the jacobian projective coordinates of a EC_POINT over GFp
  *  \param  group  underlying EC_GROUP object
@@ -525,10 +525,10 @@ int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
  *  \param  ctx    BN_CTX object (optional)
  *  \return 1 on success and 0 if an error occurred
  */
-int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
+DEPRECATEDIN_3_0(int EC_POINT_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
                                              const EC_POINT *p, BIGNUM *x,
                                              BIGNUM *y, BIGNUM *z,
-                                             BN_CTX *ctx);
+                                             BN_CTX *ctx))
 
 /** Sets the affine coordinates of an EC_POINT
  *  \param  group  underlying EC_GROUP object

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -188,6 +188,77 @@ static int field_tests_default(int n)
     return ret;
 }
 
+#ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
+/*
+ * Tests a point known to cause an incorrect underflow in an old version of
+ * ecp_nist521.c
+ */
+static int underflow_test(void)
+{
+    BN_CTX *ctx = NULL;
+    EC_GROUP *grp = NULL;
+    EC_POINT *P = NULL, *Q = NULL, *R = NULL;
+    BIGNUM *x1 = NULL, *y1 = NULL, *z1 = NULL, *x2 = NULL, *y2 = NULL;
+    BIGNUM *k = NULL;
+    int testresult = 0;
+    const char *x1str =
+        "1534f0077fffffe87e9adcfe000000000000000000003e05a21d2400002e031b1f4"
+        "b80000c6fafa4f3c1288798d624a247b5e2ffffffffffffffefe099241900004";
+    const char *p521m1 =
+        "1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe";
+
+    ctx = BN_CTX_new();
+    if (!TEST_ptr(ctx))
+        return 0;
+
+    BN_CTX_start(ctx);
+    x1 = BN_CTX_get(ctx);
+    y1 = BN_CTX_get(ctx);
+    z1 = BN_CTX_get(ctx);
+    x2 = BN_CTX_get(ctx);
+    y2 = BN_CTX_get(ctx);
+    k = BN_CTX_get(ctx);
+    if (!TEST_ptr(k))
+        goto err;
+
+    grp = EC_GROUP_new_by_curve_name(NID_secp521r1);
+    P = EC_POINT_new(grp);
+    Q = EC_POINT_new(grp);
+    R = EC_POINT_new(grp);
+    if (!TEST_ptr(grp) || !TEST_ptr(P) || !TEST_ptr(Q) || !TEST_ptr(R))
+        goto err;
+
+    if (!TEST_int_gt(BN_hex2bn(&x1, x1str), 0)
+            || !TEST_int_gt(BN_hex2bn(&y1, p521m1), 0)
+            || !TEST_int_gt(BN_hex2bn(&z1, p521m1), 0)
+            || !TEST_int_gt(BN_hex2bn(&k, "02"), 0)
+            || !TEST_true(ec_GFp_simple_set_Jprojective_coordinates_GFp(grp, P, x1,
+                                                                        y1, z1, ctx))
+            || !TEST_true(EC_POINT_mul(grp, Q, NULL, P, k, ctx))
+            || !TEST_true(EC_POINT_get_affine_coordinates(grp, Q, x1, y1, ctx))
+            || !TEST_true(EC_POINT_dbl(grp, R, P, ctx))
+            || !TEST_true(EC_POINT_get_affine_coordinates(grp, R, x2, y2, ctx)))
+        goto err;
+
+    if (!TEST_int_eq(BN_cmp(x1, x2), 0)
+            || !TEST_int_eq(BN_cmp(y1, y2), 0))
+        goto err;
+
+    testresult = 1;
+
+ err:
+    BN_CTX_end(ctx);
+    EC_POINT_free(P);
+    EC_POINT_free(Q);
+    EC_POINT_free(R);
+    EC_GROUP_free(grp);
+    BN_CTX_free(ctx);
+
+    return testresult;
+}
+#endif
+
 int setup_tests(void)
 {
     crv_len = EC_get_builtin_curves(NULL, 0);
@@ -201,6 +272,9 @@ int setup_tests(void)
     ADD_TEST(field_tests_ec2_simple);
 #endif
     ADD_ALL_TESTS(field_tests_default, crv_len);
+#ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
+    ADD_TEST(underflow_test);
+#endif
     return 1;
 }
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -223,7 +223,7 @@ EVP_MD_meth_set_input_blocksize         226	3_0_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_get0_attrs               227	3_0_0	EXIST::FUNCTION:
 PKCS8_get_attr                          228	3_0_0	EXIST::FUNCTION:
 DSAparams_print_fp                      229	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA,STDIO
-EC_POINT_set_Jprojective_coordinates_GFp 230	3_0_0	EXIST::FUNCTION:EC
+EC_POINT_set_Jprojective_coordinates_GFp 230	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 DIST_POINT_NAME_new                     231	3_0_0	EXIST::FUNCTION:
 X509_LOOKUP_file                        232	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_decrypt               233	3_0_0	EXIST::FUNCTION:
@@ -2419,7 +2419,7 @@ MD2_Final                               2469	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 OCSP_REQ_CTX_add1_header                2470	3_0_0	EXIST::FUNCTION:
 NETSCAPE_SPKAC_it                       2471	3_0_0	EXIST::FUNCTION:
 ASIdOrRange_free                        2472	3_0_0	EXIST::FUNCTION:RFC3779
-EC_POINT_get_Jprojective_coordinates_GFp 2473	3_0_0	EXIST::FUNCTION:EC
+EC_POINT_get_Jprojective_coordinates_GFp 2473	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_aes_128_cbc_hmac_sha256             2474	3_0_0	EXIST::FUNCTION:
 i2d_PKCS7_SIGNED                        2475	3_0_0	EXIST::FUNCTION:
 TS_VERIFY_CTX_set_data                  2476	3_0_0	EXIST::FUNCTION:TS


### PR DESCRIPTION
Reiterating from #8332:

Deprecate the following two functions:

1. `EC_POINT_set_Jprojective_coordinates_GFp`
2. `EC_POINT_get_Jprojective_coordinates_GFp`

Whether a point has 3, 4, 5, ... coordinates, and what coordinate system the `EC_METHOD` uses, should not be public facing.

Before I sat down to write this PR, I used my Google-fu to search for linking applications using these functions. I only found one: `ec_test`.

Disclaimer: This is my first time marking something deprecated. I don't really know what I'm doing. Please tell me what I did wrong. (Including documenting the deprecation.)

Tagging @mattcaswell who seemed to like the suggestion. I reckon you have to vote on it.