### PR TITLE
Run ssl_test_old in fips

### DIFF
--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -13,12 +13,20 @@ use warnings;
 use POSIX;
 use File::Basename;
 use File::Copy;
-use OpenSSL::Test qw/:DEFAULT with bldtop_file srctop_file cmdstr/;
+use OpenSSL::Test qw/:DEFAULT with bldtop_file bldtop_dir srctop_file srctop_dir cmdstr/;
 use OpenSSL::Test::Utils;
 
+BEGIN {
 setup("test_ssl");
+}
+
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
 
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
+$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
+$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
 
 my ($no_rsa, $no_dsa, $no_dh, $no_ec, $no_psk,
     $no_ssl3, $no_tls1, $no_tls1_1, $no_tls1_2, $no_tls1_3,
@@ -78,9 +86,19 @@ my $client_sess="client.ss";
 # If you're adding tests here, you probably want to convert them to the
 # new format in ssl_test.c and add recipes to 80-test_ssl_new.t instead.
 plan tests =>
-    1				# For testss
-    +5  			# For the first testssl
+    1				# For fipsinstall
+    +1				# For testss
+    +5  			# For the testssl with default provider
+    +5  			# For the testssl with fips provider
     ;
+
+ok(run(app(['openssl', 'fipsinstall',
+            '-out', bldtop_file('providers', 'fipsinstall.cnf'),
+            '-module', bldtop_file('providers', platform->dso('fips')),
+            '-provider_name', 'fips', '-mac_name', 'HMAC',
+            '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
+            '-section_name', 'fips_sect'])),
+   "fipsinstall");
 
 subtest 'test_ss' => sub {
     if (testss()) {
@@ -95,7 +113,8 @@ subtest 'test_ss' => sub {
 };
 
 note('test_ssl -- key U');
-testssl("keyU.ss", $Ucert, $CAcert);
+testssl("keyU.ss", $Ucert, $CAcert, "default", srctop_file("test","default.cnf"));
+testssl("keyU.ss", $Ucert, $CAcert, "fips", srctop_file("test","fips.cnf"));
 
 # -----------
 # subtest functions
@@ -310,12 +329,14 @@ sub testss {
 }
 
 sub testssl {
-    my ($key, $cert, $CAtmp) = @_;
+    my ($key, $cert, $CAtmp, $provider, $configfile) = @_;
     my @CA = $CAtmp ? ("-CAfile", $CAtmp) : ("-CApath", bldtop_dir("certs"));
 
     my @ssltest = ("ssltest_old",
 		   "-s_key", $key, "-s_cert", $cert,
-		   "-c_key", $key, "-c_cert", $cert);
+		   "-c_key", $key, "-c_cert", $cert,
+           "-provider", $provider,
+           "-config", $configfile);
 
     my $serverinfo = srctop_file("test","serverinfo.pem");
 
@@ -409,8 +430,8 @@ sub testssl {
 	# We only use the flags that ssltest_old understands
 	push @protocols, "-tls1_3" unless $no_tls1_3;
 	push @protocols, "-tls1_2" unless $no_tls1_2;
-	push @protocols, "-tls1" unless $no_tls1;
-	push @protocols, "-ssl3" unless $no_ssl3;
+	push @protocols, "-tls1" unless $no_tls1 || $provider eq "fips";
+	push @protocols, "-ssl3" unless $no_ssl3 || $provider eq "fips";
 	my $protocolciphersuitecount = 0;
 	my %ciphersuites = ();
 	my %ciphersstatus = ();
@@ -419,6 +440,7 @@ sub testssl {
 	    my @ciphers = run(app(["openssl", "ciphers", "-s", $protocol,
 				   "ALL:$ciphers"]),
 			      capture => 1, statusvar => \$ciphersstatus);
+	    @ciphers = grep {!/CAMELLIA|ARIA|CHACHA/} @ciphers;
 	    $ciphersstatus{$protocol} = $ciphersstatus;
 	    if ($ciphersstatus) {
 		$ciphersuites{$protocol} = [ map { s|\R||; split(/:/, $_) }
@@ -479,7 +501,7 @@ sub testssl {
 
       SKIP: {
 	  skip "TLSv1.0 is not supported by this OpenSSL build", 5
-	      if $no_tls1;
+	      if $no_tls1 || $provider eq "fips";
 
 	SKIP: {
 	    skip "skipping anonymous DH tests", 1
@@ -493,13 +515,13 @@ sub testssl {
 	    skip "skipping RSA tests", 2
 		if $no_rsa;
 
-	    ok(run(test(["ssltest_old", "-v", "-bio_pair", "-tls1", "-s_cert", srctop_file("apps","server2.pem"), "-no_dhe", "-no_ecdhe", "-num", "10", "-f", "-time"])),
+	    ok(run(test(["ssltest_old", "-provider", "default", "-v", "-bio_pair", "-tls1", "-s_cert", srctop_file("apps","server2.pem"), "-no_dhe", "-no_ecdhe", "-num", "10", "-f", "-time"])),
 	       'test tlsv1 with 1024bit RSA, no (EC)DHE, multiple handshakes');
 
 	    skip "skipping RSA+DHE tests", 1
 		if $no_dh;
 
-	    ok(run(test(["ssltest_old", "-v", "-bio_pair", "-tls1", "-s_cert", srctop_file("apps","server2.pem"), "-dhe1024dsa", "-num", "10", "-f", "-time"])),
+	    ok(run(test(["ssltest_old", "-provider", "default", "-v", "-bio_pair", "-tls1", "-s_cert", srctop_file("apps","server2.pem"), "-dhe1024dsa", "-num", "10", "-f", "-time"])),
 	       'test tlsv1 with 1024bit RSA, 1024bit DHE, multiple handshakes');
 	  }
 
@@ -524,7 +546,7 @@ sub testssl {
 
       SKIP: {
 	  skip "TLSv1.0 is not supported by this OpenSSL build", 1
-	      if $no_tls1;
+	      if $no_tls1 || $provider eq "fips";
 
 	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-custom_ext"])),
 	     'test tls1 with custom extensions');
@@ -538,7 +560,7 @@ sub testssl {
 
       SKIP: {
 	  skip "TLSv1.0 is not supported by this OpenSSL build", 5
-	      if $no_tls1;
+	      if $no_tls1 || $provider eq "fips";
 
 	  note('echo test tls1 with serverinfo');
 	  ok(run(test([@ssltest, "-bio_pair", "-tls1", "-serverinfo_file", $serverinfo])));

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -335,8 +335,8 @@ sub testssl {
     my @ssltest = ("ssltest_old",
 		   "-s_key", $key, "-s_cert", $cert,
 		   "-c_key", $key, "-c_cert", $cert,
-           "-provider", $provider,
-           "-config", $configfile);
+		   "-provider", $provider,
+		   "-config", $configfile);
 
     my $serverinfo = srctop_file("test","serverinfo.pem");
 

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -727,6 +727,7 @@ static void sv_usage(void)
     fprintf(stderr, " -should_reuse <number>     - The expected state of reusing the session\n");
     fprintf(stderr, " -no_ticket    - do not issue TLS session ticket\n");
     fprintf(stderr, " -provider <name>    - Load the given provider into the library context\n");
+    fprintf(stderr, " -config <cnf>    - Load the given config file into the library context\n");
 }
 
 static void print_key_details(BIO *out, EVP_PKEY *key)
@@ -1192,6 +1193,10 @@ int main(int argc, char *argv[])
             if (--argc < 1)
                 goto bad;
             provider = *(++argv);
+        } else if (strcmp(*argv, "-config") == 0) {
+            if (--argc < 1)
+                goto bad;
+            config = *(++argv);
         } else {
             int rv;
             arg = argv[0];
@@ -1365,6 +1370,10 @@ int main(int argc, char *argv[])
             goto end;
         libctx = OPENSSL_CTX_new();
         if (libctx == NULL)
+            goto end;
+
+        if (config != NULL
+                && !OPENSSL_CTX_load_config(libctx, config))
             goto end;
 
         thisprov = OSSL_PROVIDER_load(libctx, provider);


### PR DESCRIPTION
In a similar way to #11511 and #11508, we run ssl_test_old twice: once with a non-default library context with the default provider loaded into it, and once with a non-default library context with the FIPS provider loaded into it. In both cases we load the "null" provider into the default context to make sure we don't accidentally pick up algorithms from there.

These tests will fail since they require all the key gen PRs to be merged first as well as #11494 and #11507 (and I have not included them here). However, aside from the dependencies this should be fairly complete and can be reviewed.