### PR TITLE
Rename FIPS_MODE to FIPS_MODULE

### DIFF
--- a/crypto/bn/bn_conv.c
+++ b/crypto/bn/bn_conv.c
@@ -46,8 +46,8 @@ char *BN_bn2hex(const BIGNUM *a)
     return buf;
 }
 
-#ifndef FIPS_MODE
-/* No BIO_snprintf in FIPS_MODE */
+#ifndef FIPS_MODULE
+/* No BIO_snprintf in FIPS_MODULE */
 /* Must 'OPENSSL_free' the returned data */
 char *BN_bn2dec(const BIGNUM *a)
 {

--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -90,7 +90,7 @@ struct bignum_ctx {
     OPENSSL_CTX *libctx;
 };
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /* Debugging functionality */
 static void ctxdbg(BIO *channel, const char *text, BN_CTX *ctx)
 {
@@ -126,7 +126,7 @@ static void ctxdbg(BIO *channel, const char *text, BN_CTX *ctx)
 #else
 /* TODO(3.0): Consider if we want to do this in FIPS mode */
 # define CTXDBG(str, ctx) do {} while(0)
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 BN_CTX *BN_CTX_new_ex(OPENSSL_CTX *ctx)
 {
@@ -143,7 +143,7 @@ BN_CTX *BN_CTX_new_ex(OPENSSL_CTX *ctx)
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 BN_CTX *BN_CTX_new(void)
 {
     return BN_CTX_new_ex(NULL);
@@ -159,7 +159,7 @@ BN_CTX *BN_CTX_secure_new_ex(OPENSSL_CTX *ctx)
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 BN_CTX *BN_CTX_secure_new(void)
 {
     return BN_CTX_secure_new_ex(NULL);
@@ -170,7 +170,7 @@ void BN_CTX_free(BN_CTX *ctx)
 {
     if (ctx == NULL)
         return;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     OSSL_TRACE_BEGIN(BN_CTX) {
         BN_POOL_ITEM *pool = ctx->pool.head;
         BIO_printf(trc_out,

--- a/crypto/bn/bn_dh.c
+++ b/crypto/bn/bn_dh.c
@@ -22,7 +22,7 @@
 
 /* DH parameters from RFC3526 */
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 /*
  * "1536-bit MODP Group" from RFC3526, Section 2.
  *
@@ -60,7 +60,7 @@ static const BN_ULONG modp_1536_q[] = {
     BN_DEF(0x4533E63A, 0x94812704), BN_DEF(0xC06E0E68, 0x62633145),
     BN_DEF(0x10B4611A, 0xE487ED51), BN_DEF(0xFFFFFFFF, 0x7FFFFFFF)
 };
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 
 /*-
  * "2048-bit MODP Group" from RFC3526, Section 3.
@@ -1037,7 +1037,7 @@ make_dh_bn(ffdhe6144_q)
 make_dh_bn(ffdhe8192_p)
 make_dh_bn(ffdhe8192_q)
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 make_dh_bn(modp_1536_p)
 make_dh_bn(modp_1536_q)
 # endif

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -207,7 +207,7 @@ int BN_generate_prime_ex2(BIGNUM *ret, int bits, int safe,
     return found;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int BN_generate_prime_ex(BIGNUM *ret, int bits, int safe,
                          const BIGNUM *add, const BIGNUM *rem, BN_GENCB *cb)
 {
@@ -265,7 +265,7 @@ static int bn_is_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
                            int do_trial_division, BN_GENCB *cb)
 {
     int i, status, ret = -1;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *ctxlocal = NULL;
 #else
 
@@ -301,7 +301,7 @@ static int bn_is_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
         if (!BN_GENCB_call(cb, 1, -1))
             return -1;
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL && (ctxlocal = ctx = BN_CTX_new()) == NULL)
         goto err;
 #endif
@@ -311,7 +311,7 @@ static int bn_is_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
         goto err;
     ret = (status == BN_PRIMETEST_PROBABLY_PRIME);
 err:
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(ctxlocal);
 #endif
     return ret;

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -103,7 +103,7 @@ int BN_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx)
 {
     return bnrand(NORMAL, rnd, bits, top, bottom, ctx);
 }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int BN_rand(BIGNUM *rnd, int bits, int top, int bottom)
 {
     return bnrand(NORMAL, rnd, bits, top, bottom, NULL);
@@ -120,7 +120,7 @@ int BN_priv_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx)
     return bnrand(PRIVATE, rnd, bits, top, bottom, ctx);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int BN_priv_rand(BIGNUM *rnd, int bits, int top, int bottom)
 {
     return bnrand(PRIVATE, rnd, bits, top, bottom, NULL);
@@ -199,7 +199,7 @@ int BN_rand_range_ex(BIGNUM *r, const BIGNUM *range, BN_CTX *ctx)
     return bnrand_range(NORMAL, r, range, ctx);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int BN_rand_range(BIGNUM *r, const BIGNUM *range)
 {
     return bnrand_range(NORMAL, r, range, NULL);
@@ -211,7 +211,7 @@ int BN_priv_rand_range_ex(BIGNUM *r, const BIGNUM *range, BN_CTX *ctx)
     return bnrand_range(PRIVATE, r, range, ctx);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int BN_priv_rand_range(BIGNUM *r, const BIGNUM *range)
 {
     return bnrand_range(PRIVATE, r, range, NULL);

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -39,7 +39,7 @@ struct openssl_ctx_st {
     struct openssl_ctx_onfree_list_st *onfreelist;
 };
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static OPENSSL_CTX default_context_int;
 
 /* Always points at default_context_int if it has been initialised */
@@ -119,7 +119,7 @@ static int context_deinit(OPENSSL_CTX *ctx)
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 void openssl_ctx_default_deinit(void)
 {
     context_deinit(default_context);
@@ -146,7 +146,7 @@ OPENSSL_CTX *OPENSSL_CTX_new(void)
     return ctx;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int OPENSSL_CTX_load_config(OPENSSL_CTX *ctx, const char *config_file)
 {
     return CONF_modules_load_file_with_libctx(ctx, config_file, NULL, 0) > 0;
@@ -162,7 +162,7 @@ void OPENSSL_CTX_free(OPENSSL_CTX *ctx)
 
 OPENSSL_CTX *openssl_ctx_get_concrete(OPENSSL_CTX *ctx)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL) {
         if (!RUN_ONCE(&default_context_init, do_default_context_init))
             return 0;
@@ -174,7 +174,7 @@ OPENSSL_CTX *openssl_ctx_get_concrete(OPENSSL_CTX *ctx)
 
 int openssl_ctx_is_default(OPENSSL_CTX *ctx)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL || ctx == default_context)
         return 1;
 #endif

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -136,7 +136,7 @@ int ossl_namemap_name2num_n(const OSSL_NAMEMAP *namemap,
     NAMENUM_ENTRY *namenum_entry, namenum_tmpl;
     int number = 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (namemap == NULL)
         namemap = ossl_namemap_stored(NULL);
 #endif
@@ -198,7 +198,7 @@ int ossl_namemap_add_name_n(OSSL_NAMEMAP *namemap, int number,
     NAMENUM_ENTRY *namenum = NULL;
     int tmp_number;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (namemap == NULL)
         namemap = ossl_namemap_stored(NULL);
 #endif
@@ -309,7 +309,7 @@ int ossl_namemap_add_names(OSSL_NAMEMAP *namemap, int number,
  * ==============
  */
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 #include <openssl/evp.h>
 
 /* Creates an initial namemap with names found in the legacy method db */
@@ -366,7 +366,7 @@ OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx)
         openssl_ctx_get_data(libctx, OPENSSL_CTX_NAMEMAP_INDEX,
                              &stored_namemap_method);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (namemap != NULL && ossl_namemap_empty(namemap)) {
         /* Before pilfering, we make sure the legacy database is populated */
         OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS

--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -44,7 +44,7 @@ int DH_check_params_ex(const DH *dh)
     return errflags == 0;
 }
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 int DH_check_params(const DH *dh, int *ret)
 {
     int nid;
@@ -102,7 +102,7 @@ int DH_check_params(const DH *dh, int *ret)
     BN_CTX_free(ctx);
     return ok;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 /*-
  * Check that p is a safe prime and
@@ -140,7 +140,7 @@ int DH_check_ex(const DH *dh)
 /* Note: according to documentation - this only checks the params */
 int DH_check(const DH *dh, int *ret)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return DH_check_params(dh, ret);
 #else
     int ok = 0, r;
@@ -210,7 +210,7 @@ int DH_check(const DH *dh, int *ret)
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
     return ok;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 }
 
 int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key)

--- a/crypto/dh/dh_gen.c
+++ b/crypto/dh/dh_gen.c
@@ -30,10 +30,10 @@
 #include "crypto/dh.h"
 #include "dh_local.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static int dh_builtin_genparams(DH *ret, int prime_len, int generator,
                                 BN_GENCB *cb);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 int dh_generate_ffc_parameters(DH *dh, int type, int pbits,
                                int qbits, EVP_MD *md, BN_GENCB *cb)
@@ -47,7 +47,7 @@ int dh_generate_ffc_parameters(DH *dh, int type, int pbits,
             qbits = (pbits >= 2048 ? SHA256_DIGEST_LENGTH :
                                      SHA_DIGEST_LENGTH) * 8;
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (type == DH_PARAMGEN_TYPE_FIPS_186_2)
         ret = ffc_params_FIPS186_2_generate(dh->libctx, &dh->params,
                                             FFC_PARAM_TYPE_DH,
@@ -96,7 +96,7 @@ int dh_get_named_group_uid_from_size(int pbits)
     return nid;
 }
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 
 static int dh_gen_named_group(OPENSSL_CTX *libctx, DH *ret, int prime_len)
 {
@@ -116,12 +116,12 @@ static int dh_gen_named_group(OPENSSL_CTX *libctx, DH *ret, int prime_len)
     DH_free(dh);
     return ok;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 int DH_generate_parameters_ex(DH *ret, int prime_len, int generator,
                               BN_GENCB *cb)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     if (generator != 2)
         return 0;
     return dh_gen_named_group(ret->libctx, ret, prime_len);
@@ -129,10 +129,10 @@ int DH_generate_parameters_ex(DH *ret, int prime_len, int generator,
     if (ret->meth->generate_params)
         return ret->meth->generate_params(ret, prime_len, generator, cb);
     return dh_builtin_genparams(ret, prime_len, generator, cb);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /*-
  * We generate DH parameters as follows
  * find a prime p which is prime_len bits long,
@@ -238,4 +238,4 @@ static int dh_builtin_genparams(DH *ret, int prime_len, int generator,
     BN_CTX_free(ctx);
     return ok;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -59,7 +59,7 @@ static const DH_NAMED_GROUP dh_named_groups[] = {
     FFDHE(4096),
     FFDHE(6144),
     FFDHE(8192),
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     MODP(1536),
 #endif
     MODP(2048),
@@ -71,7 +71,7 @@ static const DH_NAMED_GROUP dh_named_groups[] = {
      * Additional dh named groups from RFC 5114 that have a different g.
      * The uid can be any unique identifier.
      */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     RFC5114("dh_1024_160", 1, 1024, 1024_160),
     RFC5114("dh_2048_224", 2, 2048, 2048_224),
     RFC5114("dh_2048_256", 3, 2048, 2048_256),

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -20,7 +20,7 @@
 #include "crypto/dh.h"
 #include "crypto/security_bits.h"
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 # define MIN_STRENGTH 112
 #else
 # define MIN_STRENGTH 80
@@ -39,7 +39,7 @@ static int compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
     BN_MONT_CTX *mont = NULL;
     BIGNUM *tmp;
     int ret = -1;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     int check_result;
 #endif
 
@@ -74,7 +74,7 @@ static int compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
             goto err;
     }
 /* TODO(3.0) : Solve in a PR related to Key validation for DH */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!DH_check_pub_key(dh, pub_key, &check_result) || check_result) {
         DHerr(0, DH_R_INVALID_PUBKEY);
         goto err;
@@ -95,7 +95,7 @@ static int compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
 
 int DH_compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return compute_key(key, pub_key, dh);
 #else
     return dh->meth->compute_key(key, pub_key, dh);
@@ -106,7 +106,7 @@ int DH_compute_key_padded(unsigned char *key, const BIGNUM *pub_key, DH *dh)
 {
     int rv, pad;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     rv = compute_key(key, pub_key, dh);
 #else
     rv = dh->meth->compute_key(key, pub_key, dh);
@@ -166,16 +166,16 @@ static int dh_finish(DH *dh)
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 void DH_set_default_method(const DH_METHOD *meth)
 {
     default_DH_method = meth;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 int DH_generate_key(DH *dh)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return generate_key(dh);
 #else
     return dh->meth->generate_key(dh);
@@ -214,7 +214,7 @@ static int generate_key(DH *dh)
 {
     int ok = 0;
     int generate_new_key = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     unsigned l;
 #endif
     BN_CTX *ctx = NULL;
@@ -264,7 +264,7 @@ static int generate_key(DH *dh)
                                           max_strength, priv_key))
                 goto err;
         } else {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
             if (dh->params.q == NULL)
                 goto err;
 #else

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -26,7 +26,7 @@
 
 static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int DH_set_method(DH *dh, const DH_METHOD *meth)
 {
     /*
@@ -61,7 +61,7 @@ DH *DH_new_method(ENGINE *engine)
 {
     return dh_new_intern(engine, NULL);
 }
-#endif /* !FIPS_MODE */
+#endif /* !FIPS_MODULE */
 
 DH *dh_new_with_libctx(OPENSSL_CTX *libctx)
 {
@@ -87,7 +87,7 @@ static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 
     ret->libctx = libctx;
     ret->meth = DH_get_default_method();
-#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_ENGINE)
     ret->flags = ret->meth->flags;  /* early default init */
     if (engine) {
         if (!ENGINE_init(engine)) {
@@ -108,10 +108,10 @@ static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 
     ret->flags = ret->meth->flags;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_DH, ret, &ret->ex_data))
         goto err;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     if ((ret->meth->init != NULL) && !ret->meth->init(ret)) {
         DHerr(0, ERR_R_INIT_FAIL);
@@ -140,7 +140,7 @@ void DH_free(DH *r)
 
     if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
 # if !defined(OPENSSL_NO_ENGINE)
     ENGINE_finish(r->engine);
 # endif
@@ -167,7 +167,7 @@ int DH_up_ref(DH *r)
     return ((i > 1) ? 1 : 0);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int DH_set_ex_data(DH *d, int idx, void *arg)
 {
     return CRYPTO_set_ex_data(&d->ex_data, idx, arg);
@@ -310,12 +310,12 @@ void DH_set_flags(DH *dh, int flags)
     dh->flags |= flags;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 ENGINE *DH_get0_engine(DH *dh)
 {
     return dh->engine;
 }
-#endif /*FIPS_MODE */
+#endif /*FIPS_MODULE */
 
 FFC_PARAMS *dh_get0_params(DH *dh)
 {
@@ -400,7 +400,7 @@ int EVP_PKEY_CTX_set_dh_paramgen_type(EVP_PKEY_CTX *ctx, int typ)
     if ((ret = dh_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DH, EVP_PKEY_OP_PARAMGEN,
@@ -426,7 +426,7 @@ int EVP_PKEY_CTX_set_dh_paramgen_prime_len(EVP_PKEY_CTX *ctx, int pbits)
     if ((ret = dh_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DH, EVP_PKEY_OP_PARAMGEN,
@@ -447,7 +447,7 @@ int EVP_PKEY_CTX_set_dh_paramgen_subprime_len(EVP_PKEY_CTX *ctx, int qbits)
     if ((ret = dh_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DH, EVP_PKEY_OP_PARAMGEN,
@@ -468,7 +468,7 @@ int EVP_PKEY_CTX_set_dh_paramgen_generator(EVP_PKEY_CTX *ctx, int gen)
     if ((ret = dh_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DH, EVP_PKEY_OP_PARAMGEN,
@@ -490,7 +490,7 @@ int EVP_PKEY_CTX_set_dh_rfc5114(EVP_PKEY_CTX *ctx, int gen)
     if ((ret = dh_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DHX, EVP_PKEY_OP_PARAMGEN,
@@ -520,7 +520,7 @@ int EVP_PKEY_CTX_set_dh_nid(EVP_PKEY_CTX *ctx, int nid)
     if ((ret = dh_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DH,

--- a/crypto/dh/dh_local.h
+++ b/crypto/dh/dh_local.h
@@ -28,7 +28,7 @@ struct dh_st {
     int flags;
     BN_MONT_CTX *method_mont_p;
     CRYPTO_REF_COUNT references;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_EX_DATA ex_data;
     ENGINE *engine;
 #endif

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -306,7 +306,7 @@ static DH *ffc_params_generate(OPENSSL_CTX *libctx, DH_PKEY_CTX *dctx,
         else
             md = EVP_sha1();
     }
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
     if (dctx->paramgen_type == DH_PARAMGEN_TYPE_FIPS_186_2)
         rv = ffc_params_FIPS186_2_generate(libctx, &ret->params,
                                            FFC_PARAM_TYPE_DH,
@@ -346,7 +346,7 @@ static int pkey_dh_paramgen(EVP_PKEY_CTX *ctx,
         return 1;
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (dctx->rfc5114_param) {
         switch (dctx->rfc5114_param) {
         case 1:
@@ -367,7 +367,7 @@ static int pkey_dh_paramgen(EVP_PKEY_CTX *ctx,
         EVP_PKEY_assign(pkey, EVP_PKEY_DHX, dh);
         return 1;
     }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     if (ctx->pkey_gencb != NULL) {
         pcb = BN_GENCB_new();
@@ -375,9 +375,9 @@ static int pkey_dh_paramgen(EVP_PKEY_CTX *ctx,
             return 0;
         evp_pkey_set_cb_translate(pcb, ctx);
     }
-# ifdef FIPS_MODE
+# ifdef FIPS_MODULE
     dctx->paramgen_type = DH_PARAMGEN_TYPE_FIPS_186_4;
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
     if (dctx->paramgen_type >= DH_PARAMGEN_TYPE_FIPS_186_2) {
         dh = ffc_params_generate(NULL, dctx, pcb);
         BN_GENCB_free(pcb);

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -36,7 +36,7 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type,
             qbits = (pbits >= 2048 ? SHA256_DIGEST_LENGTH :
                                      SHA_DIGEST_LENGTH) * 8;
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (type == DSA_PARAMGEN_TYPE_FIPS_186_2)
         ret = ffc_params_FIPS186_2_generate(dsa->libctx, &dsa->params,
                                             FFC_PARAM_TYPE_DSA,
@@ -51,13 +51,13 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type,
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int DSA_generate_parameters_ex(DSA *dsa, int bits,
                                const unsigned char *seed_in, int seed_len,
                                int *counter_ret, unsigned long *h_ret,
                                BN_GENCB *cb)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (dsa->meth->dsa_paramgen)
         return dsa->meth->dsa_paramgen(dsa, bits, seed_in, seed_len,
                                        counter_ret, h_ret, cb);
@@ -66,7 +66,7 @@ int DSA_generate_parameters_ex(DSA *dsa, int bits,
         && !ffc_params_set_validate_params(&dsa->params, seed_in, seed_len, -1))
         return 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* The old code used FIPS 186-2 DSA Parameter generation */
     if (bits <= 1024 && seed_len == 20) {
         if (!dsa_generate_ffc_parameters(dsa, DSA_PARAMGEN_TYPE_FIPS_186_2,

--- a/crypto/dsa/dsa_key.c
+++ b/crypto/dsa/dsa_key.c
@@ -21,7 +21,7 @@
 #include "crypto/dsa.h"
 #include "dsa_local.h"
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 # define MIN_STRENGTH 112
 #else
 # define MIN_STRENGTH 80
@@ -32,7 +32,7 @@ static int dsa_keygen_pairwise_test(DSA *dsa, OSSL_CALLBACK *cb, void *cbarg);
 
 int DSA_generate_key(DSA *dsa)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (dsa->meth->dsa_keygen != NULL)
         return dsa->meth->dsa_keygen(dsa);
 #endif
@@ -96,9 +96,9 @@ static int dsa_keygen(DSA *dsa, int pairwise_test)
     dsa->priv_key = priv_key;
     dsa->pub_key = pub_key;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     pairwise_test = 1;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     ok = 1;
     if (pairwise_test) {

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -27,7 +27,7 @@
 
 static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 int DSA_set_ex_data(DSA *d, int idx, void *arg)
 {
@@ -124,7 +124,7 @@ int DSA_set_method(DSA *dsa, const DSA_METHOD *meth)
         meth->init(dsa);
     return 1;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 
 const DSA_METHOD *DSA_get_method(DSA *d)
@@ -151,7 +151,7 @@ static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 
     ret->libctx = libctx;
     ret->meth = DSA_get_default_method();
-#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_ENGINE)
     ret->flags = ret->meth->flags & ~DSA_FLAG_NON_FIPS_ALLOW; /* early default init */
     if (engine) {
         if (!ENGINE_init(engine)) {
@@ -172,7 +172,7 @@ static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 
     ret->flags = ret->meth->flags & ~DSA_FLAG_NON_FIPS_ALLOW;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!crypto_new_ex_data_ex(libctx, CRYPTO_EX_INDEX_DSA, ret, &ret->ex_data))
         goto err;
 #endif
@@ -199,7 +199,7 @@ DSA *dsa_new_with_ctx(OPENSSL_CTX *libctx)
     return dsa_new_intern(NULL, libctx);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 DSA *DSA_new(void)
 {
     return dsa_new_intern(NULL, NULL);
@@ -221,11 +221,11 @@ void DSA_free(DSA *r)
 
     if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
-#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_ENGINE)
     ENGINE_finish(r->engine);
 #endif
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_DSA, r, &r->ex_data);
 #endif
 
@@ -430,7 +430,7 @@ int EVP_PKEY_CTX_set_dsa_paramgen_bits(EVP_PKEY_CTX *ctx, int nbits)
     if ((ret = dsa_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA,  EVP_PKEY_OP_PARAMGEN,
@@ -452,7 +452,7 @@ int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx, int qbits)
     if ((ret = dsa_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DSA,  EVP_PKEY_OP_PARAMGEN,
@@ -475,7 +475,7 @@ int EVP_PKEY_CTX_set_dsa_paramgen_md_props(EVP_PKEY_CTX *ctx,
     if ((ret = dsa_paramgen_check(ctx)) <= 0)
         return ret;
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
     /* TODO(3.0): Remove this eventually when no more legacy */
     if (ctx->op.keymgmt.genctx == NULL) {
         const EVP_MD *md = EVP_get_digestbyname(md_name);
@@ -495,7 +495,7 @@ int EVP_PKEY_CTX_set_dsa_paramgen_md_props(EVP_PKEY_CTX *ctx,
     return EVP_PKEY_CTX_set_params(ctx, params);
 }
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
 int EVP_PKEY_CTX_set_dsa_paramgen_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
 {
     const char *md_name = (md == NULL) ? "" : EVP_MD_name(md);

--- a/crypto/dsa/dsa_local.h
+++ b/crypto/dsa/dsa_local.h
@@ -25,7 +25,7 @@ struct dsa_st {
     /* Normally used to cache montgomery values */
     BN_MONT_CTX *method_mont_p;
     CRYPTO_REF_COUNT references;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_EX_DATA ex_data;
 #endif
     const DSA_METHOD *meth;

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -50,12 +50,12 @@ static DSA_METHOD openssl_dsa_meth = {
 
 static const DSA_METHOD *default_DSA_method = &openssl_dsa_meth;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 void DSA_set_default_method(const DSA_METHOD *meth)
 {
     default_DSA_method = meth;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 const DSA_METHOD *DSA_get_default_method(void)
 {

--- a/crypto/ec/ec2_oct.c
+++ b/crypto/ec/ec2_oct.c
@@ -43,7 +43,7 @@ int ec_GF2m_simple_set_compressed_coordinates(const EC_GROUP *group,
 {
     BIGNUM *tmp, *x, *y, *z;
     int ret = 0, z0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 
     /* clear error queue */
@@ -81,7 +81,7 @@ int ec_GF2m_simple_set_compressed_coordinates(const EC_GROUP *group,
         if (!BN_GF2m_add(tmp, x, tmp))
             goto err;
         if (!BN_GF2m_mod_solve_quad_arr(z, tmp, group->poly, ctx)) {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
             unsigned long err = ERR_peek_last_error();
 
             if (ERR_GET_LIB(err) == ERR_LIB_BN
@@ -113,7 +113,7 @@ int ec_GF2m_simple_set_compressed_coordinates(const EC_GROUP *group,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -132,7 +132,7 @@ size_t ec_GF2m_simple_point2oct(const EC_GROUP *group, const EC_POINT *point,
     int used_ctx = 0;
     BIGNUM *x, *y, *yxi;
     size_t field_len, i, skip;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -168,7 +168,7 @@ size_t ec_GF2m_simple_point2oct(const EC_GROUP *group, const EC_POINT *point,
             goto err;
         }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         if (ctx == NULL) {
             ctx = new_ctx = BN_CTX_new();
             if (ctx == NULL)
@@ -236,7 +236,7 @@ size_t ec_GF2m_simple_point2oct(const EC_GROUP *group, const EC_POINT *point,
 
     if (used_ctx)
         BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -244,7 +244,7 @@ size_t ec_GF2m_simple_point2oct(const EC_GROUP *group, const EC_POINT *point,
  err:
     if (used_ctx)
         BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return 0;
@@ -263,7 +263,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     BIGNUM *x, *y, *yxi;
     size_t field_len, enc_len;
     int ret = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -305,7 +305,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
         return 0;
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL) {
         ctx = new_ctx = BN_CTX_new();
         if (ctx == NULL)
@@ -358,7 +358,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -182,7 +182,7 @@ int ec_GF2m_simple_group_check_discriminant(const EC_GROUP *group,
 {
     int ret = 0;
     BIGNUM *b;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL) {
@@ -213,7 +213,7 @@ int ec_GF2m_simple_group_check_discriminant(const EC_GROUP *group,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -361,7 +361,7 @@ int ec_GF2m_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a,
 {
     BIGNUM *x0, *y0, *x1, *y1, *x2, *y2, *s, *t;
     int ret = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -377,7 +377,7 @@ int ec_GF2m_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a,
         return 1;
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL) {
         ctx = new_ctx = BN_CTX_new();
         if (ctx == NULL)
@@ -467,7 +467,7 @@ int ec_GF2m_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -514,7 +514,7 @@ int ec_GF2m_simple_is_on_curve(const EC_GROUP *group, const EC_POINT *point,
     int (*field_mul) (const EC_GROUP *, BIGNUM *, const BIGNUM *,
                       const BIGNUM *, BN_CTX *);
     int (*field_sqr) (const EC_GROUP *, BIGNUM *, const BIGNUM *, BN_CTX *);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -528,7 +528,7 @@ int ec_GF2m_simple_is_on_curve(const EC_GROUP *group, const EC_POINT *point,
     if (!point->Z_is_one)
         return -1;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL) {
         ctx = new_ctx = BN_CTX_new();
         if (ctx == NULL)
@@ -566,7 +566,7 @@ int ec_GF2m_simple_is_on_curve(const EC_GROUP *group, const EC_POINT *point,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -584,7 +584,7 @@ int ec_GF2m_simple_cmp(const EC_GROUP *group, const EC_POINT *a,
 {
     BIGNUM *aX, *aY, *bX, *bY;
     int ret = -1;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -599,7 +599,7 @@ int ec_GF2m_simple_cmp(const EC_GROUP *group, const EC_POINT *a,
         return ((BN_cmp(a->X, b->X) == 0) && BN_cmp(a->Y, b->Y) == 0) ? 0 : 1;
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL) {
         ctx = new_ctx = BN_CTX_new();
         if (ctx == NULL)
@@ -623,7 +623,7 @@ int ec_GF2m_simple_cmp(const EC_GROUP *group, const EC_POINT *a,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -635,14 +635,14 @@ int ec_GF2m_simple_make_affine(const EC_GROUP *group, EC_POINT *point,
 {
     BIGNUM *x, *y;
     int ret = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
     if (point->Z_is_one || EC_POINT_is_at_infinity(group, point))
         return 1;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL) {
         ctx = new_ctx = BN_CTX_new();
         if (ctx == NULL)
@@ -670,7 +670,7 @@ int ec_GF2m_simple_make_affine(const EC_GROUP *group, EC_POINT *point,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -21,7 +21,7 @@
 #include "internal/nelem.h"
 #include "crypto/asn1_dsa.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 int EC_GROUP_get_basis_type(const EC_GROUP *group)
 {
@@ -1237,7 +1237,7 @@ int i2o_ECPublicKey(const EC_KEY *a, unsigned char **out)
 DECLARE_ASN1_FUNCTIONS(ECDSA_SIG)
 DECLARE_ASN1_ENCODE_FUNCTIONS_name(ECDSA_SIG, ECDSA_SIG)
 
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 ECDSA_SIG *ECDSA_SIG_new(void)
 {

--- a/crypto/ec/ec_check.c
+++ b/crypto/ec/ec_check.c
@@ -45,7 +45,7 @@ int EC_GROUP_check_named_curve(const EC_GROUP *group, int nist_only,
 
 int EC_GROUP_check(const EC_GROUP *group, BN_CTX *ctx)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     /*
     * ECC domain parameter validation.
     * See SP800-56A R3 5.5.2 "Assurances of Domain-Parameter Validity" Part 1b.
@@ -114,5 +114,5 @@ int EC_GROUP_check(const EC_GROUP *group, BN_CTX *ctx)
     BN_CTX_free(new_ctx);
     EC_POINT_free(point);
     return ret;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 }

--- a/crypto/ec/ec_ctrl.c
+++ b/crypto/ec/ec_ctrl.c
@@ -463,7 +463,7 @@ int EVP_PKEY_CTX_get_ec_paramgen_curve_name(EVP_PKEY_CTX *ctx,
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid)
 {
     if (ctx == NULL || !EVP_PKEY_CTX_IS_GEN_OP(ctx)) {

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -200,7 +200,7 @@ static const struct {
     }
 };
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 /* the x9.62 prime curves (minus the nist prime curves) */
 static const struct {
     EC_CURVE_DATA h;
@@ -379,7 +379,7 @@ static const struct {
         0x43, 0x21, 0x46, 0x52, 0x65, 0x51
     }
 };
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 static const struct {
     EC_CURVE_DATA h;
@@ -419,7 +419,7 @@ static const struct {
     }
 };
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /* the secg prime curves (minus the nist and x9.62 prime curves) */
 static const struct {
     EC_CURVE_DATA h;
@@ -841,13 +841,13 @@ static const struct {
         0x5C, 0x5C, 0x2A, 0x3D
     }
 };
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 #ifndef OPENSSL_NO_EC2M
 
 /* characteristic two curves */
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[20 + 15 * 6];
@@ -975,7 +975,7 @@ static const struct {
         0x33, 0x04, 0x9B, 0xA9, 0x8F
     }
 };
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 
 static const struct {
     EC_CURVE_DATA h;
@@ -1007,7 +1007,7 @@ static const struct {
     }
 };
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[0 + 21 * 6];
@@ -1036,7 +1036,7 @@ static const struct {
         0xAA, 0xB6, 0x89, 0xC2, 0x9C, 0xA7, 0x10, 0x27, 0x9B
     }
 };
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 
 static const struct {
     EC_CURVE_DATA h;
@@ -1067,7 +1067,7 @@ static const struct {
     }
 };
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[20 + 25 * 6];
@@ -1143,7 +1143,7 @@ static const struct {
         0xD5
     }
 };
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 
 static const struct {
     EC_CURVE_DATA h;
@@ -1219,7 +1219,7 @@ static const struct {
     }
 };
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[0 + 30 * 6];
@@ -1255,7 +1255,7 @@ static const struct {
         0x1D, 0xA8, 0x00, 0xE4, 0x78, 0xA5
     }
 };
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 
 static const struct {
     EC_CURVE_DATA h;
@@ -1539,7 +1539,7 @@ static const struct {
     }
 };
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[20 + 21 * 6];
@@ -2224,7 +2224,7 @@ static const struct {
         0xED, 0xF9, 0x7C, 0x44, 0xDB, 0x9F, 0x24, 0x20, 0xBA, 0xFC, 0xA7, 0x5E
     }
 };
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 #endif /* OPENSSL_NO_EC2M */
 
 /*
@@ -2235,7 +2235,7 @@ static const struct {
  * generation mechanism is different from those defined in ANSI X9.62.
  */
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[0 + 20 * 6];
@@ -2775,9 +2775,9 @@ static const struct {
         0x9C, 0xA9, 0x00, 0x69
     }
 };
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
-#if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODULE)
 static const struct {
     EC_CURVE_DATA h;
     unsigned char data[0 + 32 * 6];
@@ -2824,7 +2824,7 @@ typedef struct _ec_list_element_st {
     const char *comment;
 } ec_list_element;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 static const ec_list_element curve_list[] = {
     /* prime field curves */
     /* secg curves */
@@ -3113,7 +3113,7 @@ static const ec_list_element curve_list[] = {
      "SM2 curve over a 256 bit prime field"},
 # endif
 };
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 #define curve_list_length OSSL_NELEM(curve_list)
 
@@ -3165,7 +3165,7 @@ int ec_curve_name2nid(const char *name)
     if ((nid = EC_curve_nist2nid(name)) != NID_undef)
         return nid;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * TODO(3.0) Figure out if we can use other names than the NIST names
      * ("B-163", "K-163" & "P-192") in the FIPS module, or if other names
@@ -3302,7 +3302,7 @@ EC_GROUP *EC_GROUP_new_by_curve_name_ex(OPENSSL_CTX *libctx, int nid)
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 EC_GROUP *EC_GROUP_new_by_curve_name(int nid)
 {
     return EC_GROUP_new_by_curve_name_ex(NULL, nid);

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -26,7 +26,7 @@
 static int ecdsa_keygen_pairwise_test(EC_KEY *eckey, OSSL_CALLBACK *cb,
                                       void *cbarg);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 EC_KEY *EC_KEY_new(void)
 {
     return ec_key_new_method_int(NULL, NULL);
@@ -56,7 +56,7 @@ EC_KEY *EC_KEY_new_by_curve_name_ex(OPENSSL_CTX *ctx, int nid)
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 EC_KEY *EC_KEY_new_by_curve_name(int nid)
 {
     return EC_KEY_new_by_curve_name_ex(NULL, nid);
@@ -79,14 +79,14 @@ void EC_KEY_free(EC_KEY *r)
     if (r->meth != NULL && r->meth->finish != NULL)
         r->meth->finish(r);
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     ENGINE_finish(r->engine);
 #endif
 
     if (r->group && r->group->meth->keyfinish)
         r->group->meth->keyfinish(r);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_EC_KEY, r, &r->ex_data);
 #endif
     CRYPTO_THREAD_lock_free(r->lock);
@@ -108,7 +108,7 @@ EC_KEY *EC_KEY_copy(EC_KEY *dest, const EC_KEY *src)
             dest->meth->finish(dest);
         if (dest->group && dest->group->meth->keyfinish)
             dest->group->meth->keyfinish(dest);
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
         if (ENGINE_finish(dest->engine) == 0)
             return 0;
         dest->engine = NULL;
@@ -156,14 +156,14 @@ EC_KEY *EC_KEY_copy(EC_KEY *dest, const EC_KEY *src)
     dest->conv_form = src->conv_form;
     dest->version = src->version;
     dest->flags = src->flags;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!CRYPTO_dup_ex_data(CRYPTO_EX_INDEX_EC_KEY,
                             &dest->ex_data, &src->ex_data))
         return NULL;
 #endif
 
     if (src->meth != dest->meth) {
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
         if (src->engine != NULL && ENGINE_init(src->engine) == 0)
             return NULL;
         dest->engine = src->engine;
@@ -312,9 +312,9 @@ int ec_generate_key(OPENSSL_CTX *libctx, EC_KEY *eckey, int pairwise_test)
 
     eckey->dirty_cnt++;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     pairwise_test = 1;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     ok = 1;
     if (pairwise_test) {

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -65,7 +65,7 @@ int EC_KEY_set_method(EC_KEY *key, const EC_KEY_METHOD *meth)
     if (finish != NULL)
         finish(key);
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     ENGINE_finish(key->engine);
     key->engine = NULL;
 #endif
@@ -96,7 +96,7 @@ EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, ENGINE *engine)
     }
 
     ret->meth = EC_KEY_get_default_method();
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     if (engine != NULL) {
         if (!ENGINE_init(engine)) {
             ECerr(EC_F_EC_KEY_NEW_METHOD_INT, ERR_R_ENGINE_LIB);
@@ -118,7 +118,7 @@ EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, ENGINE *engine)
     ret->conv_form = POINT_CONVERSION_UNCOMPRESSED;
 
 /* No ex_data inside the FIPS provider */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_EC_KEY, ret, &ret->ex_data)) {
         goto err;
     }
@@ -135,7 +135,7 @@ EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, ENGINE *engine)
     return NULL;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 EC_KEY *EC_KEY_new_method(ENGINE *engine)
 {
     return ec_key_new_method_int(NULL, engine);

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -65,7 +65,7 @@ EC_GROUP *EC_GROUP_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth)
     return NULL;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 EC_GROUP *EC_GROUP_new(const EC_METHOD *meth)
 {
     return EC_GROUP_new_ex(NULL, meth);
@@ -597,7 +597,7 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx)
 {
     int r = 0;
     BIGNUM *a1, *a2, *a3, *b1, *b2, *b3;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *ctx_new = NULL;
 #endif
 
@@ -612,7 +612,7 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx)
     if (a->meth->flags & EC_FLAGS_CUSTOM_CURVE)
         return 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx_new = ctx = BN_CTX_new();
 #endif
@@ -628,7 +628,7 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx)
     b3 = BN_CTX_get(ctx);
     if (b3 == NULL) {
         BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         BN_CTX_free(ctx_new);
 #endif
         return -1;
@@ -680,7 +680,7 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx)
     }
 end:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(ctx_new);
 #endif
     return r;
@@ -1047,7 +1047,7 @@ int EC_POINTs_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 {
     int ret = 0;
     size_t i = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -1066,7 +1066,7 @@ int EC_POINTs_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         }
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx = new_ctx = BN_CTX_secure_new();
 #endif
@@ -1081,7 +1081,7 @@ int EC_POINTs_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         /* use default */
         ret = ec_wNAF_mul(group, r, scalar, num, points, scalars, ctx);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -1161,7 +1161,7 @@ static int ec_precompute_mont_data(EC_GROUP *group)
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int EC_KEY_set_ex_data(EC_KEY *key, int idx, void *arg)
 {
     return CRYPTO_set_ex_data(&key->ex_data, idx, arg);
@@ -1185,14 +1185,14 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
 {
     BIGNUM *e = NULL;
     int ret = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
     if (group->mont_data == NULL)
         return 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx = new_ctx = BN_CTX_secure_new();
 #endif
@@ -1222,7 +1222,7 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;

--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -288,7 +288,7 @@ struct ec_key_st {
     point_conversion_form_t conv_form;
     CRYPTO_REF_COUNT references;
     int flags;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_EX_DATA ex_data;
 #endif
     CRYPTO_RWLOCK *lock;

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -833,7 +833,7 @@ int ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     EC_POINT **points = NULL;
     EC_PRE_COMP *pre_comp;
     int ret = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
@@ -848,7 +848,7 @@ int ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
         goto err;
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx = new_ctx = BN_CTX_new();
 #endif
@@ -965,7 +965,7 @@ int ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
 
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     EC_ec_pre_comp_free(pre_comp);

--- a/crypto/ec/ecp_nistp224.c
+++ b/crypto/ec/ecp_nistp224.c
@@ -1299,7 +1299,7 @@ int ec_GFp_nistp224_group_set_curve(EC_GROUP *group, const BIGNUM *p,
 {
     int ret = 0;
     BIGNUM *curve_p, *curve_a, *curve_b;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
@@ -1326,7 +1326,7 @@ int ec_GFp_nistp224_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     ret = ec_GFp_simple_group_set_curve(group, p, a, b, ctx);
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -1617,14 +1617,14 @@ int ec_GFp_nistp224_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     BIGNUM *x, *y;
     EC_POINT *generator = NULL;
     felem tmp_felems[32];
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
     /* throw away old precomputation */
     EC_pre_comp_free(group);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx = new_ctx = BN_CTX_new();
 #endif
@@ -1738,7 +1738,7 @@ int ec_GFp_nistp224_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
  err:
     BN_CTX_end(ctx);
     EC_POINT_free(generator);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     EC_nistp224_pre_comp_free(pre);

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -1912,7 +1912,7 @@ int ec_GFp_nistp256_group_set_curve(EC_GROUP *group, const BIGNUM *p,
 {
     int ret = 0;
     BIGNUM *curve_p, *curve_a, *curve_b;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
@@ -1939,7 +1939,7 @@ int ec_GFp_nistp256_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     ret = ec_GFp_simple_group_set_curve(group, p, a, b, ctx);
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -2239,14 +2239,14 @@ int ec_GFp_nistp256_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     EC_POINT *generator = NULL;
     smallfelem tmp_smallfelems[32];
     felem x_tmp, y_tmp, z_tmp;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
     /* throw away old precomputation */
     EC_pre_comp_free(group);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx = new_ctx = BN_CTX_new();
 #endif
@@ -2370,7 +2370,7 @@ int ec_GFp_nistp256_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
  err:
     BN_CTX_end(ctx);
     EC_POINT_free(generator);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     EC_nistp256_pre_comp_free(pre);

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -1752,7 +1752,7 @@ int ec_GFp_nistp521_group_set_curve(EC_GROUP *group, const BIGNUM *p,
 {
     int ret = 0;
     BIGNUM *curve_p, *curve_a, *curve_b;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
@@ -1779,7 +1779,7 @@ int ec_GFp_nistp521_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     ret = ec_GFp_simple_group_set_curve(group, p, a, b, ctx);
  err:
     BN_CTX_end(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     return ret;
@@ -2075,14 +2075,14 @@ int ec_GFp_nistp521_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     BIGNUM *x, *y;
     EC_POINT *generator = NULL;
     felem tmp_felems[16];
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
 
     /* throw away old precomputation */
     EC_pre_comp_free(group);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (ctx == NULL)
         ctx = new_ctx = BN_CTX_new();
 #endif
@@ -2176,7 +2176,7 @@ int ec_GFp_nistp521_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
  err:
     BN_CTX_end(ctx);
     EC_POINT_free(generator);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);
 #endif
     EC_nistp521_pre_comp_free(pre);

--- a/crypto/ec/ecp_oct.c
+++ b/crypto/ec/ecp_oct.c
@@ -28,7 +28,7 @@ int ec_GFp_simple_set_compressed_coordinates(const EC_GROUP *group,
     BIGNUM *tmp1, *tmp2, *x, *y;
     int ret = 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* clear error queue */
     ERR_clear_error();
 #endif
@@ -107,7 +107,7 @@ int ec_GFp_simple_set_compressed_coordinates(const EC_GROUP *group,
     }
 
     if (!BN_mod_sqrt(y, tmp1, group->field, ctx)) {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         unsigned long err = ERR_peek_last_error();
 
         if (ERR_GET_LIB(err) == ERR_LIB_BN

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -24,7 +24,7 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
     if (ctx == NULL)
         return 1;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* TODO(3.0): Temporarily no support for EVP_DigestSign* in FIPS module */
     /*
      * pctx should be freed by the user of EVP_MD_CTX
@@ -59,7 +59,7 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
         OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
     }
 
-#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_ENGINE)
     ENGINE_finish(ctx->engine);
 #endif
 
@@ -94,7 +94,7 @@ int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type)
 
 int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 {
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     ENGINE *tmpimpl = NULL;
 #endif
 
@@ -114,7 +114,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
         ctx->reqdigest = type;
 
     /* TODO(3.0): Legacy work around code below. Remove this */
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     /*
      * Whether it's nice or not, "Inits" can be used on "Final"'d contexts so
      * this context may already have an ENGINE! Try to avoid releasing the
@@ -145,7 +145,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
      */
     if (ctx->engine != NULL
             || impl != NULL
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
             || tmpimpl != NULL
 #endif
             || (ctx->flags & EVP_MD_CTX_FLAG_NO_INIT) != 0) {
@@ -164,7 +164,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
     /* TODO(3.0): Start of non-legacy code below */
 
     if (type->prov == NULL) {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
         /* We only do explicit fetches inside the FIPS module */
         EVPerr(EVP_F_EVP_DIGESTINIT_EX, EVP_R_INITIALIZATION_ERROR);
         return 0;
@@ -205,7 +205,7 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
     /* TODO(3.0): Remove legacy code below */
  legacy:
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     if (type) {
         if (impl != NULL) {
             if (!ENGINE_init(impl)) {
@@ -257,10 +257,10 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
             }
         }
     }
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
  skip_to_init:
 #endif
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * TODO(3.0): Temporarily no support for EVP_DigestSign* inside FIPS module
      * or when using providers.
@@ -452,7 +452,7 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
 
     /* copied EVP_MD_CTX should free the copied EVP_PKEY_CTX */
     EVP_MD_CTX_clear_flags(out, EVP_MD_CTX_FLAG_KEEP_PKEY_CTX);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* TODO(3.0): Temporarily no support for EVP_DigestSign* in FIPS module */
     if (in->pctx != NULL) {
         out->pctx = EVP_PKEY_CTX_dup(in->pctx);
@@ -468,7 +468,7 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
 
     /* TODO(3.0): Remove legacy code below */
  legacy:
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     /* Make sure it's safe to copy a digest context using an ENGINE */
     if (in->engine && !ENGINE_init(in->engine)) {
         EVPerr(EVP_F_EVP_MD_CTX_COPY_EX, ERR_R_ENGINE_LIB);
@@ -509,7 +509,7 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
 
     out->update = in->update;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* TODO(3.0): Temporarily no support for EVP_DigestSign* in FIPS module */
     if (in->pctx) {
         out->pctx = EVP_PKEY_CTX_dup(in->pctx);
@@ -724,7 +724,7 @@ EVP_MD *evp_md_new(void)
  * provider based, we know that none of its code depends on legacy
  * NIDs or any functionality that use them.
  */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /* TODO(3.x) get rid of the need for legacy NIDs */
 static void set_legacy_nid(const char *name, void *vlegacy_nid)
 {
@@ -764,7 +764,7 @@ static void *evp_md_from_dispatch(int name_id,
         return NULL;
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* TODO(3.x) get rid of the need for legacy NIDs */
     md->type = NID_undef;
     evp_names_do_all(prov, name_id, set_legacy_nid, &md->type);

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -71,7 +71,7 @@ typedef struct {
                     const unsigned char iv[16]);
 } EVP_AES_XTS_CTX;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 static const int allow_insecure_decrypt = 0;
 #else
 static const int allow_insecure_decrypt = 1;
@@ -2901,7 +2901,7 @@ static int aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     return rv;
 }
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 /*
  * See SP800-38D (GCM) Section 8 "Uniqueness requirement on IVS and keys"
  *
@@ -2923,7 +2923,7 @@ static int aes_gcm_iv_generate(EVP_AES_GCM_CTX *gctx, int offset)
         return 0;
     return 1;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                           const unsigned char *in, size_t len)
@@ -2937,7 +2937,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (gctx->tls_aad_len >= 0)
         return aes_gcm_tls_cipher(ctx, out, in, len);
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     /*
      * FIPS requires generation of AES-GCM IV's inside the FIPS module.
      * The IV can still be set externally (the security policy will state that
@@ -2954,7 +2954,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 #else
     if (!gctx->iv_set)
         return -1;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     if (in) {
         if (out == NULL) {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -301,7 +301,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
     if (ret == NULL) {
         int code = EVP_R_FETCH_FAILED;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
         ERR_raise(ERR_LIB_EVP, code);
 #else
         ERR_raise_data(ERR_LIB_EVP, code,
@@ -339,7 +339,7 @@ void *evp_generic_fetch_by_number(OPENSSL_CTX *libctx, int operation_id,
     if (ret == NULL) {
         int code = EVP_R_FETCH_FAILED;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
         ERR_raise(ERR_LIB_EVP, code);
 #else
         {

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -18,7 +18,7 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
 int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
 {
     int ret = -1;                /* Assume the worst */
@@ -206,7 +206,7 @@ int EVP_CIPHER_set_asn1_iv(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
     }
     return i;
 }
-#endif /* !defined(FIPS_MODE) */
+#endif /* !defined(FIPS_MODULE) */
 
 /* Convert the various cipher NIDs and dummies to a proper OID NID */
 int EVP_CIPHER_type(const EVP_CIPHER *ctx)
@@ -258,7 +258,7 @@ int EVP_CIPHER_type(const EVP_CIPHER *ctx)
         return NID_des_cfb64;
 
     default:
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
         return NID_undef;
 #else
         {
@@ -548,7 +548,7 @@ const char *EVP_CIPHER_name(const EVP_CIPHER *cipher)
 {
     if (cipher->prov != NULL)
         return evp_first_name(cipher->prov, cipher->name_id);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     return OBJ_nid2sn(EVP_CIPHER_nid(cipher));
 #else
     return NULL;
@@ -589,7 +589,7 @@ const char *EVP_MD_name(const EVP_MD *md)
 {
     if (md->prov != NULL)
         return evp_first_name(md->prov, md->name_id);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     return OBJ_nid2sn(EVP_MD_nid(md));
 #else
     return NULL;
@@ -844,7 +844,7 @@ EVP_PKEY_CTX *EVP_MD_CTX_pkey_ctx(const EVP_MD_CTX *ctx)
     return ctx->pctx;
 }
 
-#if !defined(FIPS_MODE)
+#if !defined(FIPS_MODULE)
 /* TODO(3.0): EVP_DigestSign* not yet supported in FIPS module */
 void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pctx)
 {
@@ -864,7 +864,7 @@ void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pctx)
         EVP_MD_CTX_clear_flags(ctx, EVP_MD_CTX_FLAG_KEEP_PKEY_CTX);
     }
 }
-#endif /* !defined(FIPS_MODE) */
+#endif /* !defined(FIPS_MODULE) */
 
 void *EVP_MD_CTX_md_data(const EVP_MD_CTX *ctx)
 {

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -275,7 +275,7 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
      */
     ERR_pop_to_mark();
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return 0;
 #else
     if (ctx->pmeth == NULL || ctx->pmeth->derive == NULL) {
@@ -323,7 +323,7 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
     return ctx->op.kex.exchange->set_peer(ctx->op.kex.exchprovctx, provkey);
 
  legacy:
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return ret;
 #else
     /*

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -16,7 +16,7 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 static int update(EVP_MD_CTX *ctx, const void *data, size_t datalen)
 {
@@ -354,7 +354,7 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     return EVP_DigestUpdate(ctx, data, dsize);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
                         size_t *siglen)
 {
@@ -550,4 +550,4 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
         return -1;
     return EVP_DigestVerifyFinal(ctx, sigret, siglen);
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -47,7 +47,7 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
                          int len, EVP_KEYMGMT *keymgmt);
 static void evp_pkey_free_it(EVP_PKEY *key);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 /* The type of parameters selected in key parameter functions */
 # define SELECT_PARAMETERS OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS
@@ -656,9 +656,9 @@ DSA *EVP_PKEY_get1_DSA(EVP_PKEY *pkey)
     return ret;
 }
 # endif /*  OPENSSL_NO_DSA */
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # ifndef OPENSSL_NO_EC
 int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key)
 {
@@ -752,7 +752,7 @@ int EVP_PKEY_base_id(const EVP_PKEY *pkey)
 
 int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (pkey->keymgmt == NULL) {
         /*
          * These hard coded cases are pure hackery to get around the fact
@@ -1064,9 +1064,9 @@ size_t EVP_PKEY_get1_tls_encodedpoint(EVP_PKEY *pkey, unsigned char **ppt)
     return rv;
 }
 
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
-/*- All methods below can also be used in FIPS_MODE */
+/*- All methods below can also be used in FIPS_MODULE */
 
 EVP_PKEY *EVP_PKEY_new(void)
 {
@@ -1085,7 +1085,7 @@ EVP_PKEY *EVP_PKEY_new(void)
         EVPerr(EVP_F_EVP_PKEY_NEW, ERR_R_MALLOC_FAILURE);
         goto err;
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_EVP_PKEY, ret, &ret->ex_data)) {
         EVPerr(EVP_F_EVP_PKEY_NEW, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -1115,7 +1115,7 @@ EVP_PKEY *EVP_PKEY_new(void)
 static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
                          int len, EVP_KEYMGMT *keymgmt)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     const EVP_PKEY_ASN1_METHOD *ameth = NULL;
     ENGINE **eptr = (e == NULL) ? &e :  NULL;
 #endif
@@ -1133,13 +1133,13 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
     if (pkey != NULL) {
         int free_it = 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         free_it = free_it || pkey->pkey.ptr != NULL;
 #endif
         free_it = free_it || pkey->keydata != NULL;
         if (free_it)
             evp_pkey_free_it(pkey);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         /*
          * If key type matches and a method exists then this lookup has
          * succeeded once so just indicate success.
@@ -1157,7 +1157,7 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
 # endif
 #endif
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (str != NULL)
         ameth = EVP_PKEY_asn1_find_str(eptr, str, len);
     else if (type != EVP_PKEY_NONE)
@@ -1172,7 +1172,7 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
     {
         int check = 1;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         check = check && ameth == NULL;
 #endif
         check = check && keymgmt == NULL;
@@ -1192,7 +1192,7 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
         pkey->save_type = type;
         pkey->type = type;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         /*
          * If the internal "origin" key is provider side, don't save |ameth|.
          * The main reason is that |ameth| is one factor to detect that the
@@ -1219,7 +1219,7 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static void find_ameth(const char *name, void *data)
 {
     const char **str = data;
@@ -1244,7 +1244,7 @@ static void find_ameth(const char *name, void *data)
 
 int EVP_PKEY_set_type_by_keymgmt(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # define EVP_PKEY_TYPE_STR str[0]
 # define EVP_PKEY_TYPE_STRLEN (str[0] == NULL ? -1 : (int)strlen(str[0]))
     /*
@@ -1283,7 +1283,7 @@ int EVP_PKEY_up_ref(EVP_PKEY *pkey)
     return ((i > 1) ? 1 : 0);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 void evp_pkey_free_legacy(EVP_PKEY *x)
 {
     if (x->ameth != NULL) {
@@ -1299,14 +1299,14 @@ void evp_pkey_free_legacy(EVP_PKEY *x)
 # endif
     x->type = EVP_PKEY_NONE;
 }
-#endif  /* FIPS_MODE */
+#endif  /* FIPS_MODULE */
 
 static void evp_pkey_free_it(EVP_PKEY *x)
 {
     /* internal function; x is never NULL */
 
     evp_keymgmt_util_clear_operation_cache(x);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     evp_pkey_free_legacy(x);
 #endif
 
@@ -1331,11 +1331,11 @@ void EVP_PKEY_free(EVP_PKEY *x)
         return;
     REF_ASSERT_ISNT(i < 0);
     evp_pkey_free_it(x);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_EVP_PKEY, x, &x->ex_data);
 #endif
     CRYPTO_THREAD_lock_free(x->lock);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     sk_X509_ATTRIBUTE_pop_free(x->attributes, X509_ATTRIBUTE_free);
 #endif
     OPENSSL_free(x);
@@ -1347,7 +1347,7 @@ int EVP_PKEY_size(const EVP_PKEY *pkey)
 
     if (pkey != NULL) {
         size = pkey->cache.size;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         if (pkey->ameth != NULL && pkey->ameth->pkey_size != NULL)
             size = pkey->ameth->pkey_size(pkey);
 #endif
@@ -1369,14 +1369,14 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
 
     /* No key data => nothing to export */
     check = 1;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     check = check && pk->pkey.ptr == NULL;
 #endif
     check = check && pk->keydata == NULL;
     if (check)
         return NULL;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (pk->pkey.ptr != NULL) {
         /*
          * If the legacy key doesn't have an dirty counter or export function,
@@ -1408,7 +1408,7 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
     if (tmp_keymgmt == NULL)
         goto end;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (pk->pkey.ptr != NULL) {
         size_t i = 0;
 
@@ -1480,7 +1480,7 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
         pk->dirty_cnt_copy = pk->ameth->dirty_cnt(pk);
         goto end;
     }
-#endif  /* FIPS_MODE */
+#endif  /* FIPS_MODULE */
 
     keydata = evp_keymgmt_util_export_to_provider(pk, tmp_keymgmt);
 
@@ -1500,7 +1500,7 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
     return keydata;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int evp_pkey_downgrade(EVP_PKEY *pk)
 {
     EVP_KEYMGMT *keymgmt = pk->keymgmt;
@@ -1606,7 +1606,7 @@ int evp_pkey_downgrade(EVP_PKEY *pk)
     evp_keymgmt_util_cache_keyinfo(pk);
     return 0;     /* No downgrade, but at least the key is restored */
 }
-#endif  /* FIPS_MODE */
+#endif  /* FIPS_MODULE */
 
 const OSSL_PARAM *EVP_PKEY_gettable_params(EVP_PKEY *pkey)
 {

--- a/crypto/evp/pmeth_check.c
+++ b/crypto/evp/pmeth_check.c
@@ -38,7 +38,7 @@ int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx)
     if (pkey->type == EVP_PKEY_NONE)
         goto not_supported;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* legacy */
     /* call customized public key check function first */
     if (ctx->pmeth->public_check != NULL)
@@ -76,7 +76,7 @@ int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx)
     if (pkey->type == EVP_PKEY_NONE)
         goto not_supported;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* legacy */
     /* call customized param check function first */
     if (ctx->pmeth->param_check != NULL)
@@ -156,7 +156,7 @@ int EVP_PKEY_check(EVP_PKEY_CTX *ctx)
     if (pkey->type == EVP_PKEY_NONE)
         goto not_supported;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* legacy */
     /* call customized check function first */
     if (ctx->pmeth->check != NULL)

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -20,7 +20,7 @@
 #include "crypto/evp.h"
 #include "evp_local.h"
 
-#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_EC)
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_EC)
 # define TMP_SM2_HACK
 #endif
 
@@ -69,7 +69,7 @@ static int gen_init(EVP_PKEY_CTX *ctx, int operation)
     goto end;
 
  legacy:
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     goto not_supported;
 #else
     if (ctx->pmeth == NULL
@@ -189,7 +189,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
                                  ossl_callback_to_pkey_gencb, ctx)
             != NULL);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* In case |*ppkey| was originally a legacy key */
     if (ret)
         evp_pkey_free_legacy(*ppkey);
@@ -223,7 +223,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     goto end;
 
  legacy:
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     goto not_supported;
 #else
     if (ctx->pkey && !evp_pkey_downgrade(ctx->pkey))
@@ -256,7 +256,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     ERR_raise(ERR_LIB_EVP, EVP_R_OPERATON_NOT_INITIALIZED);
     ret = -1;
     goto end;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
  not_accessible:
     ERR_raise(ERR_LIB_EVP, EVP_R_INACCESSIBLE_DOMAIN_PARAMETERS);
     ret = -1;
@@ -319,7 +319,7 @@ int EVP_PKEY_CTX_get_keygen_info(EVP_PKEY_CTX *ctx, int idx)
     return ctx->keygen_info[idx];
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *e,
                                const unsigned char *key, int keylen)
@@ -340,9 +340,9 @@ EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *e,
     return mac_key;
 }
 
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
-/*- All methods below can also be used in FIPS_MODE */
+/*- All methods below can also be used in FIPS_MODULE */
 
 static int fromdata_init(EVP_PKEY_CTX *ctx, int operation)
 {

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -30,7 +30,7 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 typedef const EVP_PKEY_METHOD *(*pmeth_fn)(void);
 typedef int sk_cmp_fn_type(const char *const *a, const char *const *b);
@@ -135,7 +135,7 @@ EVP_PKEY_METHOD *EVP_PKEY_meth_new(int id, int flags)
     pmeth->flags = flags | EVP_PKEY_FLAG_DYNAMIC;
     return pmeth;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
                                  EVP_PKEY *pkey, ENGINE *e,
@@ -165,7 +165,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
         keytype = evp_first_name(pkey->keymgmt->prov, pkey->keymgmt->name_id);
         goto common;
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* TODO(3.0) Legacy code should be removed when all is provider based */
     /* BEGIN legacy */
     if (id == -1) {
@@ -221,7 +221,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
         return NULL;
     }
     /* END legacy */
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
  common:
     /*
      * If there's no engine and there's a name, we try fetching a provider
@@ -237,7 +237,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
     ret = OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         EVP_KEYMGMT_free(keymgmt);
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
         ENGINE_finish(e);
 #endif
         EVPerr(EVP_F_INT_CTX_NEW, ERR_R_MALLOC_FAILURE);
@@ -265,7 +265,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
     return ret;
 }
 
-/*- All methods below can also be used in FIPS_MODE */
+/*- All methods below can also be used in FIPS_MODULE */
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OPENSSL_CTX *libctx,
                                          const char *name,
@@ -296,7 +296,7 @@ void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx)
         ctx->op.kex.exchange = NULL;
     }
 /* TODO(3.0): add dependancies and uncomment this when available for fips mode */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     else if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)) {
         if (ctx->op.ciph.ciphprovctx != NULL && ctx->op.ciph.cipher != NULL)
             ctx->op.ciph.cipher->freectx(ctx->op.ciph.ciphprovctx);
@@ -322,13 +322,13 @@ void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx)
 
     EVP_PKEY_free(ctx->pkey);
     EVP_PKEY_free(ctx->peerkey);
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     ENGINE_finish(ctx->engine);
 #endif
     OPENSSL_free(ctx);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 
 void EVP_PKEY_meth_get0_info(int *ppkey_id, int *pflags,
                              const EVP_PKEY_METHOD *meth)
@@ -592,7 +592,7 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
     return 0;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
 {
     if (EVP_PKEY_CTX_IS_DERIVE_OP(ctx)
@@ -670,7 +670,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(EVP_PKEY_CTX *ctx)
  *
  * In particular they return -2 if any of the params is not supported.
  *
- * They are not available in FIPS_MODE as they depend on
+ * They are not available in FIPS_MODULE as they depend on
  *      - EVP_PKEY_CTX_{get,set}_params()
  *      - EVP_PKEY_CTX_{gettable,settable}_params()
  *
@@ -1592,4 +1592,4 @@ void EVP_PKEY_meth_get_digest_custom(EVP_PKEY_METHOD *pmeth,
         *pdigest_custom = pmeth->digest_custom;
 }
 
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -12,7 +12,7 @@
 #include "internal/ffc.h"
 #include "internal/param_build_set.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # include <openssl/asn1.h> /* ffc_params_print */
 #endif
 
@@ -231,7 +231,7 @@ int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent)
 {
     if (!ASN1_bn_print(bp, "prime P:", ffc->p, NULL, indent))
@@ -270,4 +270,4 @@ int ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent)
 err:
     return 0;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -772,7 +772,7 @@ int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
     EVP_MD *evpmd_fetch = NULL;
 
     *res = 0;
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     /*
      * FIPS 186-4 states that validation can only be done for this pair.
      * (Even though the original spec allowed L = 512 + 64*j (j = 0.. 8))

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -13,7 +13,7 @@
 #include "prov/providercommon.h"
 #include "internal/thread_once.h"
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 /*
  * Thread aware code may want to be told about thread stop events. We register
  * to hear about those thread stop events when we see a new thread has started.
@@ -37,7 +37,7 @@ struct thread_event_handler_st {
     THREAD_EVENT_HANDLER *next;
 };
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 DEFINE_SPECIAL_STACK_OF(THREAD_EVENT_HANDLER_PTR, THREAD_EVENT_HANDLER *)
 
 typedef struct global_tevent_register_st GLOBAL_TEVENT_REGISTER;
@@ -77,7 +77,7 @@ static GLOBAL_TEVENT_REGISTER *get_global_tevent_register(void)
 }
 #endif
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static int  init_thread_push_handlers(THREAD_EVENT_HANDLER **hands);
 static void init_thread_remove_handlers(THREAD_EVENT_HANDLER **handsin);
 static void init_thread_destructor(void *hands);
@@ -101,7 +101,7 @@ init_get_thread_local(CRYPTO_THREAD_LOCAL *local, int alloc, int keep)
                 return NULL;
             }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
             if (!init_thread_push_handlers(hands)) {
                 CRYPTO_THREAD_set_local(local, NULL);
                 OPENSSL_free(hands);
@@ -116,7 +116,7 @@ init_get_thread_local(CRYPTO_THREAD_LOCAL *local, int alloc, int keep)
     return hands;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /*
  * Since per-thread-specific-data destructors are not universally
  * available, i.e. not on Windows, only below CRYPTO_THREAD_LOCAL key
@@ -292,7 +292,7 @@ void ossl_ctx_thread_stop(void *arg)
     init_thread_stop(arg, hands);
     OPENSSL_free(hands);
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 
 static void init_thread_stop(void *arg, THREAD_EVENT_HANDLER **hands)
@@ -328,7 +328,7 @@ int ossl_init_thread_start(const void *index, void *arg,
 {
     THREAD_EVENT_HANDLER **hands;
     THREAD_EVENT_HANDLER *hand;
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     OPENSSL_CTX *ctx = arg;
 
     /*
@@ -353,7 +353,7 @@ int ossl_init_thread_start(const void *index, void *arg,
     if (hands == NULL)
         return 0;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     if (*hands == NULL) {
         /*
          * We've not yet registered any handlers for this thread. We need to get
@@ -378,7 +378,7 @@ int ossl_init_thread_start(const void *index, void *arg,
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static int init_thread_deregister(void *index, int all)
 {
     GLOBAL_TEVENT_REGISTER *gtr;

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -23,7 +23,7 @@ static CRYPTO_malloc_fn malloc_impl = CRYPTO_malloc;
 static CRYPTO_realloc_fn realloc_impl = CRYPTO_realloc;
 static CRYPTO_free_fn free_impl = CRYPTO_free;
 
-#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODULE)
 # include "internal/tsan_assist.h"
 
 static TSAN_QUALIFIER int malloc_count;
@@ -75,7 +75,7 @@ void CRYPTO_get_mem_functions(CRYPTO_malloc_fn *malloc_fn,
         *free_fn = free_impl;
 }
 
-#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_CRYPTO_MDEBUG) && !defined(FIPS_MODULE)
 void CRYPTO_get_alloc_counts(int *mcount, int *rcount, int *fcount)
 {
     if (mcount != NULL)

--- a/crypto/o_fips.c
+++ b/crypto/o_fips.c
@@ -19,6 +19,6 @@ int FIPS_mode_set(int r)
 {
     if (r == 0)
         return 1;
-    CRYPTOerr(CRYPTO_F_FIPS_MODE_SET, CRYPTO_R_FIPS_MODE_NOT_SUPPORTED);
+    CRYPTOerr(CRYPTO_F_FIPS_MODULE_SET, CRYPTO_R_FIPS_MODULE_NOT_SUPPORTED);
     return 0;
 }

--- a/crypto/o_fips.c
+++ b/crypto/o_fips.c
@@ -19,6 +19,6 @@ int FIPS_mode_set(int r)
 {
     if (r == 0)
         return 1;
-    CRYPTOerr(CRYPTO_F_FIPS_MODULE_SET, CRYPTO_R_FIPS_MODULE_NOT_SUPPORTED);
+    CRYPTOerr(CRYPTO_F_FIPS_MODE_SET, CRYPTO_R_FIPS_MODE_NOT_SUPPORTED);
     return 0;
 }

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -87,7 +87,7 @@ void sha512_block_data_order(void *ctx, const void *inp, size_t len)
  * TODO(3.0): Temporarily disabled some assembler that hasn't been brought into
  * the FIPS module yet.
  */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # ifndef OPENSSL_NO_CHACHA
 void ChaCha20_ctr32_int(unsigned char *out, const unsigned char *inp,
                         size_t len, const unsigned int key[8],
@@ -145,7 +145,7 @@ int poly1305_init(void *ctx, const unsigned char key[16], void *func[2])
     return 1;
 }
 # endif
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 #ifdef ECP_NISTZ256_ASM
 void ecp_nistz256_mul_mont(unsigned long res[4], const unsigned long a[4],

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -305,7 +305,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
     int ret = 0;
     int j, best = -1, score, optional;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
 #endif
 

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -17,7 +17,7 @@ OSSL_provider_init_fn fips_intern_provider_init;
 OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
 const struct predefined_providers_st predefined_providers[] = {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     { "fips", fips_intern_provider_init, 1 },
 #else
     { "default", ossl_default_provider_init, 1 },

--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -480,7 +480,7 @@ int drbg_ctr_init(RAND_DRBG *drbg)
         drbg->max_perslen = DRBG_MAX_LENGTH;
         drbg->max_adinlen = DRBG_MAX_LENGTH;
     } else {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
         RANDerr(RAND_F_DRBG_CTR_INIT,
                 RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS);
         return 0;

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -161,7 +161,7 @@ static void *drbg_ossl_ctx_new(OPENSSL_CTX *libctx)
     if (dgbl == NULL)
         return NULL;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * We need to ensure that base libcrypto thread handling has been
      * initialised.
@@ -468,7 +468,7 @@ static RAND_DRBG *rand_drbg_new(OPENSSL_CTX *ctx,
     drbg->parent = parent;
 
     if (parent == NULL) {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
         drbg->get_entropy = rand_crngt_get_entropy;
         drbg->cleanup_entropy = rand_crngt_cleanup_entropy;
 #else
@@ -552,7 +552,7 @@ void RAND_DRBG_free(RAND_DRBG *drbg)
         drbg->meth->uninstantiate(drbg);
     rand_pool_free(drbg->adin_pool);
     CRYPTO_THREAD_lock_free(drbg->lock);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_RAND_DRBG, drbg, &drbg->ex_data);
 #endif
 
@@ -1143,7 +1143,7 @@ int rand_drbg_enable_locking(RAND_DRBG *drbg)
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /*
  * Get and set the EXDATA
  */
@@ -1287,7 +1287,7 @@ static int drbg_add(const void *buf, int num, double randomness)
 
     buflen = (size_t)num;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     /*
      * NIST SP-800-90A mandates that entropy *shall not* be provided
      * by the consuming application. By setting the randomness to zero,
@@ -1458,7 +1458,7 @@ RAND_METHOD rand_meth = {
 
 RAND_METHOD *RAND_OpenSSL(void)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     return &rand_meth;
 #else
     return NULL;

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -17,7 +17,7 @@
 #include "rand_local.h"
 #include "e_os.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # ifndef OPENSSL_NO_ENGINE
 /* non-NULL if default_RAND_meth is ENGINE-provided */
 static ENGINE *funct_ref;
@@ -28,7 +28,7 @@ static const RAND_METHOD *default_RAND_meth;
 static CRYPTO_ONCE rand_init = CRYPTO_ONCE_STATIC_INIT;
 
 static int rand_inited = 0;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 #ifdef OPENSSL_RAND_SEED_RDTSC
 /*
@@ -238,7 +238,7 @@ void rand_drbg_cleanup_additional_data(RAND_POOL *pool, unsigned char *out)
     rand_pool_reattach(pool, out);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 DEFINE_RUN_ONCE_STATIC(do_rand_init)
 {
 # ifndef OPENSSL_NO_ENGINE
@@ -354,7 +354,7 @@ int RAND_poll(void)
 
     return ret;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 /*
  * Allocate memory and initialize a new random pool
@@ -753,7 +753,7 @@ int rand_pool_add_end(RAND_POOL *pool, size_t len, size_t entropy)
     return 1;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int RAND_set_rand_method(const RAND_METHOD *meth)
 {
     if (!RUN_ONCE(&rand_init, do_rand_init))
@@ -772,7 +772,7 @@ int RAND_set_rand_method(const RAND_METHOD *meth)
 
 const RAND_METHOD *RAND_get_rand_method(void)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return NULL;
 #else
     const RAND_METHOD *tmp_meth = NULL;
@@ -804,7 +804,7 @@ const RAND_METHOD *RAND_get_rand_method(void)
 #endif
 }
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
 int RAND_set_rand_engine(ENGINE *engine)
 {
     const RAND_METHOD *tmp_meth = NULL;
@@ -899,7 +899,7 @@ int RAND_bytes(unsigned char *buf, int num)
     return RAND_bytes_ex(NULL, buf, num);
 }
 
-#if !defined(OPENSSL_NO_DEPRECATED_1_1_0) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_DEPRECATED_1_1_0) && !defined(FIPS_MODULE)
 int RAND_pseudo_bytes(unsigned char *buf, int num)
 {
     const RAND_METHOD *meth = RAND_get_rand_method();

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -310,7 +310,7 @@ struct rand_drbg_st {
     size_t seedlen;
     DRBG_STATUS state;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* Application data, mainly used in the KATs. */
     CRYPTO_EX_DATA ex_data;
 #endif

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -349,7 +349,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
 
     if (getentropy != NULL)
         return getentropy(buf, buflen) == 0 ? (ssize_t)buflen : -1;
-#  elif !defined(FIPS_MODE)
+#  elif !defined(FIPS_MODULE)
     union {
         void *p;
         int (*f)(void *buffer, size_t length);
@@ -392,7 +392,7 @@ static int keep_random_devices_open = 1;
 #   if defined(__linux) && defined(DEVRANDOM_WAIT)
 static void *shm_addr;
 
-#    if !defined(FIPS_MODE)
+#    if !defined(FIPS_MODULE)
 static void cleanup_shm(void)
 {
     shmdt(shm_addr);
@@ -463,7 +463,7 @@ static int wait_random_seeded(void)
              * If this call fails, it isn't a big problem.
              */
             shm_addr = shmat(shm_id, NULL, SHM_RDONLY);
-#    ifndef FIPS_MODE
+#    ifndef FIPS_MODULE
             /* TODO 3.0: The FIPS provider doesn't have OPENSSL_atexit */
             if (shm_addr != (void *)-1)
                 OPENSSL_atexit(&cleanup_shm);

--- a/crypto/rand/rand_win.c
+++ b/crypto/rand/rand_win.c
@@ -163,7 +163,7 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     return rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-# if !defined(OPENSSL_NO_DEPRECATED_1_1_0) && !defined(FIPS_MODE)
+# if !defined(OPENSSL_NO_DEPRECATED_1_1_0) && !defined(FIPS_MODULE)
 int RAND_event(UINT iMsg, WPARAM wParam, LPARAM lParam)
 {
     RAND_poll();

--- a/crypto/rsa/rsa_chk.c
+++ b/crypto/rsa/rsa_chk.c
@@ -18,7 +18,7 @@
 #include "crypto/rsa.h"
 #include "rsa_local.h"
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static int rsa_validate_keypair_multiprime(const RSA *key, BN_GENCB *cb)
 {
     BIGNUM *i, *j, *k, *l, *m;
@@ -228,7 +228,7 @@ static int rsa_validate_keypair_multiprime(const RSA *key, BN_GENCB *cb)
     BN_CTX_free(ctx);
     return ret;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 int rsa_validate_public(const RSA *key)
 {
@@ -242,7 +242,7 @@ int rsa_validate_private(const RSA *key)
 
 int rsa_validate_pairwise(const RSA *key)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return rsa_sp800_56b_check_keypair(key, NULL, -1, RSA_bits(key));
 #else
     return rsa_validate_keypair_multiprime(key, NULL);
@@ -256,11 +256,11 @@ int RSA_check_key(const RSA *key)
 
 int RSA_check_key_ex(const RSA *key, BN_GENCB *cb)
 {
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     return rsa_validate_public(key)
            && rsa_validate_private(key)
            && rsa_validate_pairwise(key);
 #else
     return rsa_validate_keypair_multiprime(key, cb);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 }

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -49,7 +49,7 @@ int RSA_generate_key_ex(RSA *rsa, int bits, BIGNUM *e_value, BN_GENCB *cb)
 int RSA_generate_multi_prime_key(RSA *rsa, int bits, int primes,
                                  BIGNUM *e_value, BN_GENCB *cb)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* multi-prime is only supported with the builtin key generation */
     if (rsa->meth->rsa_multi_prime_keygen != NULL) {
         return rsa->meth->rsa_multi_prime_keygen(rsa, bits, primes,
@@ -66,7 +66,7 @@ int RSA_generate_multi_prime_key(RSA *rsa, int bits, int primes,
         else
             return 0;
     }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
     return rsa_keygen(NULL, rsa, bits, primes, e_value, cb, 0);
 }
 
@@ -74,7 +74,7 @@ static int rsa_keygen(OPENSSL_CTX *libctx, RSA *rsa, int bits, int primes,
                       BIGNUM *e_value, BN_GENCB *cb, int pairwise_test)
 {
     int ok = -1;
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     if (primes != 2)
         return 0;
     ok = rsa_sp800_56b_generate_key(rsa, bits, e_value, cb);
@@ -407,7 +407,7 @@ static int rsa_keygen(OPENSSL_CTX *libctx, RSA *rsa, int bits, int primes,
     }
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     if (pairwise_test && ok > 0) {
         OSSL_CALLBACK *stcb = NULL;

--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -52,7 +52,7 @@ struct rsa_st {
     BIGNUM *iqmp;
     /* If a PSS only key this contains the parameter restrictions */
     RSA_PSS_PARAMS *pss;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* for multi-prime RSA, defined in RFC 8017 */
     STACK_OF(RSA_PRIME_INFO) *prime_infos;
     /* Be careful using this if the RSA structure is shared */

--- a/crypto/rsa/rsa_mp_names.c
+++ b/crypto/rsa/rsa_mp_names.c
@@ -23,7 +23,7 @@
 const char *rsa_mp_factor_names[] = {
     OSSL_PKEY_PARAM_RSA_FACTOR1,
     OSSL_PKEY_PARAM_RSA_FACTOR2,
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     OSSL_PKEY_PARAM_RSA_FACTOR3,
     OSSL_PKEY_PARAM_RSA_FACTOR4,
     OSSL_PKEY_PARAM_RSA_FACTOR5,
@@ -43,7 +43,7 @@ const char *rsa_mp_factor_names[] = {
 const char *rsa_mp_exp_names[] = {
     OSSL_PKEY_PARAM_RSA_EXPONENT1,
     OSSL_PKEY_PARAM_RSA_EXPONENT2,
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     OSSL_PKEY_PARAM_RSA_EXPONENT3,
     OSSL_PKEY_PARAM_RSA_EXPONENT4,
     OSSL_PKEY_PARAM_RSA_EXPONENT5,
@@ -63,7 +63,7 @@ const char *rsa_mp_exp_names[] = {
 const char *rsa_mp_coeff_names[] = {
     OSSL_PKEY_PARAM_RSA_COEFFICIENT1,
     OSSL_PKEY_PARAM_RSA_COEFFICIENT2,
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     OSSL_PKEY_PARAM_RSA_COEFFICIENT3,
     OSSL_PKEY_PARAM_RSA_COEFFICIENT4,
     OSSL_PKEY_PARAM_RSA_COEFFICIENT5,

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -67,7 +67,7 @@ int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
     unsigned char seedmask[EVP_MAX_MD_SIZE];
     int mdlen, dbmask_len = 0;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (md == NULL)
         md = EVP_sha1();
 #else
@@ -171,7 +171,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     int mdlen;
 
     if (md == NULL) {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         md = EVP_sha1();
 #else
         RSAerr(0, ERR_R_PASSED_NULL_PARAMETER);
@@ -302,7 +302,7 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
         to[i] = constant_time_select_8(mask, db[i + mdlen + 1], to[i]);
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * To avoid chosen ciphertext attacks, the error message should not
      * reveal which kind of decoding error happened.

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -119,7 +119,7 @@ static int rsa_ossl_public_encrypt(int flen, const unsigned char *from,
                                                         from, flen, NULL, 0,
                                                         NULL, NULL);
         break;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     case RSA_SSLV23_PADDING:
         i = rsa_padding_add_SSLv23_with_libctx(rsa->libctx, buf, num, from,
                                                flen);
@@ -492,7 +492,7 @@ static int rsa_ossl_private_decrypt(int flen, const unsigned char *from,
     case RSA_PKCS1_OAEP_PADDING:
         r = RSA_padding_check_PKCS1_OAEP(to, num, buf, j, num, NULL, 0);
         break;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     case RSA_SSLV23_PADDING:
         r = RSA_padding_check_SSLv23(to, num, buf, j, num);
         break;
@@ -504,7 +504,7 @@ static int rsa_ossl_private_decrypt(int flen, const unsigned char *from,
         RSAerr(RSA_F_RSA_OSSL_PRIVATE_DECRYPT, RSA_R_UNKNOWN_PADDING_TYPE);
         goto err;
     }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * This trick doesn't work in the FIPS provider because libcrypto manages
      * the error stack. Instead we opt not to put an error on the stack at all
@@ -623,7 +623,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
 {
     BIGNUM *r1, *m1, *vrfy;
     int ret = 0, smooth = 0;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     BIGNUM *r2, *m[RSA_MAX_PRIME_NUM - 2];
     int i, ex_primes = 0;
     RSA_PRIME_INFO *pinfo;
@@ -632,7 +632,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
     BN_CTX_start(ctx);
 
     r1 = BN_CTX_get(ctx);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     r2 = BN_CTX_get(ctx);
 #endif
     m1 = BN_CTX_get(ctx);
@@ -640,7 +640,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
     if (vrfy == NULL)
         goto err;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (rsa->version == RSA_ASN1_VERSION_MULTI
         && ((ex_primes = sk_RSA_PRIME_INFO_num(rsa->prime_infos)) <= 0
              || ex_primes > RSA_MAX_PRIME_NUM - 2))
@@ -666,7 +666,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
             BN_free(factor);
             goto err;
         }
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         for (i = 0; i < ex_primes; i++) {
             pinfo = sk_RSA_PRIME_INFO_value(rsa->prime_infos, i);
             BN_with_flags(factor, pinfo->r, BN_FLG_CONSTTIME);
@@ -682,7 +682,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
         BN_free(factor);
 
         smooth = (rsa->meth->bn_mod_exp == BN_mod_exp_mont)
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
                  && (ex_primes == 0)
 #endif
                  && (BN_num_bits(rsa->q) == BN_num_bits(rsa->p));
@@ -790,7 +790,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
         BN_free(dmp1);
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * calculate m_i in multi-prime case
      *
@@ -884,7 +884,7 @@ static int rsa_ossl_mod_exp(BIGNUM *r0, const BIGNUM *I, RSA *rsa, BN_CTX *ctx)
     if (!BN_add(r0, r1, m1))
         goto err;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* add m_i to m in multi-prime case */
     if (ex_primes > 0) {
         BIGNUM *pr2 = BN_new();
@@ -1003,7 +1003,7 @@ static int rsa_ossl_init(RSA *rsa)
 
 static int rsa_ossl_finish(RSA *rsa)
 {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     int i;
     RSA_PRIME_INFO *pinfo;
 

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -265,7 +265,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     }
 
     OPENSSL_clear_free(em, num);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * This trick doesn't work in the FIPS provider because libcrypto manages
      * the error stack. Instead we opt not to put an error on the stack at all

--- a/crypto/rsa/rsa_sign.c
+++ b/crypto/rsa/rsa_sign.c
@@ -93,7 +93,7 @@ static const unsigned char digestinfo_##name##_der[] = {                       \
       ASN1_OCTET_STRING, sz                                                    \
 };
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # ifndef OPENSSL_NO_MD2
 ENCODE_DIGESTINFO_MD(md2, 0x02, MD2_DIGEST_LENGTH)
 # endif
@@ -123,7 +123,7 @@ static const unsigned char digestinfo_ripemd160_der[] = {
       ASN1_OCTET_STRING, RIPEMD160_DIGEST_LENGTH
 };
 # endif
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 /* SHA-1 (1 3 14 3 2 26) */
 static const unsigned char digestinfo_sha1_der[] = {
@@ -153,7 +153,7 @@ ENCODE_DIGESTINFO_SHA(sha3_512, 0x0a, SHA512_DIGEST_LENGTH)
 const unsigned char *rsa_digestinfo_encoding(int md_nid, size_t *len)
 {
     switch (md_nid) {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # ifndef OPENSSL_NO_MDC2
     MD_CASE(mdc2)
 # endif
@@ -169,7 +169,7 @@ const unsigned char *rsa_digestinfo_encoding(int md_nid, size_t *len)
 # ifndef OPENSSL_NO_RMD160
     MD_CASE(ripemd160)
 # endif
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
     MD_CASE(sha1)
     MD_CASE(sha224)
     MD_CASE(sha256)
@@ -193,7 +193,7 @@ const unsigned char *rsa_digestinfo_encoding(int md_nid, size_t *len)
 static int digest_sz_from_nid(int nid)
 {
     switch (nid) {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 # ifndef OPENSSL_NO_MDC2
     MD_NID_CASE(mdc2, MDC2_DIGEST_LENGTH)
 # endif
@@ -209,7 +209,7 @@ static int digest_sz_from_nid(int nid)
 # ifndef OPENSSL_NO_RMD160
     MD_NID_CASE(ripemd160, RIPEMD160_DIGEST_LENGTH)
 # endif
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
     MD_NID_CASE(sha1, SHA_DIGEST_LENGTH)
     MD_NID_CASE(sha224, SHA224_DIGEST_LENGTH)
     MD_NID_CASE(sha256, SHA256_DIGEST_LENGTH)
@@ -278,10 +278,10 @@ int RSA_sign(int type, const unsigned char *m, unsigned int m_len,
     unsigned char *tmps = NULL;
     const unsigned char *encoded = NULL;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (rsa->meth->rsa_sign != NULL)
         return rsa->meth->rsa_sign(type, m, m_len, sigret, siglen, rsa);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     /* Compute the encoded digest. */
     if (type == NID_md5_sha1) {
@@ -354,7 +354,7 @@ int int_rsa_verify(int type, const unsigned char *m, unsigned int m_len,
         goto err;
     decrypt_len = len;
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (type == NID_md5_sha1) {
         /*
          * NID_md5_sha1 corresponds to the MD5/SHA1 combination in TLS 1.1 and
@@ -401,7 +401,7 @@ int int_rsa_verify(int type, const unsigned char *m, unsigned int m_len,
             }
         }
     } else
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
     {
         /*
          * If recovering the digest, extract a digest-sized output from the end

--- a/crypto/rsa/rsa_sp800_56b_check.c
+++ b/crypto/rsa/rsa_sp800_56b_check.c
@@ -238,7 +238,7 @@ int rsa_get_lcm(BN_CTX *ctx, const BIGNUM *p, const BIGNUM *q,
 int rsa_sp800_56b_check_public(const RSA *rsa)
 {
     int ret = 0, status;
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     int nbits;
 #endif
     BN_CTX *ctx = NULL;
@@ -247,7 +247,7 @@ int rsa_sp800_56b_check_public(const RSA *rsa)
     if (rsa->n == NULL || rsa->e == NULL)
         return 0;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     /*
      * (Step a): modulus must be 2048 or 3072 (caveat from SP800-56Br1)
      * NOTE: changed to allow keys >= 2048

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -55,7 +55,7 @@ static SELF_TEST_CB *get_self_test_callback(OPENSSL_CTX *libctx)
                                 &self_test_set_callback_method);
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
                                  void *cbarg)
 {
@@ -66,7 +66,7 @@ void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
         stcb->cbarg = cbarg;
     }
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK **cb,
                                  void **cbarg)

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -190,7 +190,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 /* TODO(3.0): No fork protection in FIPS module yet! */
 
 #  ifdef OPENSSL_SYS_UNIX
@@ -211,7 +211,7 @@ int openssl_init_fork_handlers(void)
 #  endif
     return 0;
 }
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 
 int openssl_get_fork_id(void)
 {

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -526,7 +526,7 @@ struct evp_pkey_st {
     int type;
     int save_type;
 
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
     /*
      * Legacy key "origin" is composed of a pointer to an EVP_PKEY_ASN1_METHOD,
      * a pointer to a low level key and possibly a pointer to an engine.
@@ -557,7 +557,7 @@ struct evp_pkey_st {
     CRYPTO_RWLOCK *lock;
     STACK_OF(X509_ATTRIBUTE) *attributes; /* [ 0 ] */
     int save_parameters;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     CRYPTO_EX_DATA ex_data;
 #endif
 
@@ -633,7 +633,7 @@ void evp_app_cleanup_int(void);
 void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
                                   EVP_KEYMGMT **keymgmt,
                                   const char *propquery);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int evp_pkey_downgrade(EVP_PKEY *pk);
 void evp_pkey_free_legacy(EVP_PKEY *x);
 #endif
@@ -723,7 +723,7 @@ void evp_encode_ctx_set_flags(EVP_ENCODE_CTX *ctx, unsigned int flags);
 const EVP_CIPHER *evp_get_cipherbyname_ex(OPENSSL_CTX *libctx, const char *name);
 const EVP_MD *evp_get_digestbyname_ex(OPENSSL_CTX *libctx, const char *name);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 /*
  * Internal helpers for stricter EVP_PKEY_CTX_{set,get}_params().
  *
@@ -731,7 +731,7 @@ const EVP_MD *evp_get_digestbyname_ex(OPENSSL_CTX *libctx, const char *name);
  *
  * In particular they return -2 if any of the params is not supported.
  *
- * They are not available in FIPS_MODE as they depend on
+ * They are not available in FIPS_MODULE as they depend on
  *      - EVP_PKEY_CTX_{get,set}_params()
  *      - EVP_PKEY_CTX_{gettable,settable}_params()
  *
@@ -741,4 +741,4 @@ int evp_pkey_ctx_get_params_strict(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 
 EVP_PKEY *evp_pkcs82pkey_int(const PKCS8_PRIV_KEY_INFO *p8, OPENSSL_CTX *libctx,
                              const char *propq);
-#endif /* !defined(FIPS_MODE) */
+#endif /* !defined(FIPS_MODULE) */

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -118,9 +118,9 @@ void ffc_params_get_validate_params(const FFC_PARAMS *params,
 int ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src);
 int ffc_params_cmp(const FFC_PARAMS *a, const FFC_PARAMS *b, int ignore_q);
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 int ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 
 int ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,

--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -15,7 +15,7 @@
  * OPENSSL_CTX object. In this way data will get cleaned up correctly when the
  * module gets unloaded.
  */
-#if !defined(FIPS_MODE) || defined(ALLOW_RUN_ONCE_IN_FIPS)
+#if !defined(FIPS_MODULE) || defined(ALLOW_RUN_ONCE_IN_FIPS)
 /*
  * DEFINE_RUN_ONCE: Define an initialiser function that should be run exactly
  * once. It takes no arguments and returns and int result (1 for success or
@@ -143,4 +143,4 @@
 # define RUN_ONCE_ALT(once, initalt, init)                               \
     (CRYPTO_THREAD_run_once(once, initalt##_ossl_) ? init##_ossl_ret_ : 0)
 
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/providers/build.info
+++ b/providers/build.info
@@ -21,11 +21,11 @@
 # libfips.a             Contains all things needed to support
 #                       FIPS implementations, such as code from
 #                       crypto/ and object files that contain
-#                       FIPS-specific code.  FIPS_MODE is defined
+#                       FIPS-specific code.  FIPS_MODULE is defined
 #                       for this library.  The FIPS module uses
 #                       this.
 # libnonfips.a          Corresponds to libfips.a, but built with
-#                       FIPS_MODE undefined.  The default and legacy
+#                       FIPS_MODULE undefined.  The default and legacy
 #                       providers use this.
 
 SUBDIRS=common implementations
@@ -50,7 +50,7 @@ INCLUDE[$LIBIMPLEMENTATIONS]=.. $COMMON_INCLUDES
 INCLUDE[$LIBLEGACY]=.. $COMMON_INCLUDES
 INCLUDE[$LIBNONFIPS]=$COMMON_INCLUDES
 INCLUDE[$LIBFIPS]=.. $COMMON_INCLUDES
-DEFINE[$LIBFIPS]=FIPS_MODE
+DEFINE[$LIBFIPS]=FIPS_MODULE
 
 # Weak dependencies to provide library order information.
 # We make it weak so they aren't both used always; what is
@@ -101,7 +101,7 @@ SUBDIRS=fips
 $FIPSGOAL=fips
 DEPEND[$FIPSGOAL]=$LIBIMPLEMENTATIONS $LIBFIPS
 INCLUDE[$FIPSGOAL]=../include
-DEFINE[$FIPSGOAL]=FIPS_MODE
+DEFINE[$FIPSGOAL]=FIPS_MODULE
 IF[{- defined $target{shared_defflag} -}]
   SOURCE[$FIPSGOAL]=fips.ld
   GENERATE[fips.ld]=../util/providers.num

--- a/providers/common/der/der_rsa.c.in
+++ b/providers/common/der/der_rsa.c.in
@@ -50,7 +50,7 @@ int DER_w_algorithmIdentifier_RSA_with(WPACKET *pkt, int tag,
     size_t precompiled_sz = 0;
 
     switch (mdnid) {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         MD_CASE(md2);
         MD_CASE(md5);
 #endif

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -46,7 +46,7 @@ static int load_common(const OSSL_PARAM params[], const char **propquery,
     *engine = NULL;
     /* TODO legacy stuff, to be removed */
     /* Inside the FIPS module, we don't support legacy ciphers */
-#if !defined(FIPS_MODE) && !defined(OPENSSL_NO_ENGINE)
+#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_ENGINE)
     p = OSSL_PARAM_locate_const(params, "engine");
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
@@ -80,7 +80,7 @@ int ossl_prov_cipher_load_from_params(PROV_CIPHER *pc,
     ERR_set_mark();
     pc->cipher = pc->alloc_cipher = EVP_CIPHER_fetch(ctx, p->data, propquery);
     /* TODO legacy stuff, to be removed */
-#ifndef FIPS_MODE /* Inside the FIPS module, we don't support legacy ciphers */
+#ifndef FIPS_MODULE /* Inside the FIPS module, we don't support legacy ciphers */
     if (pc->cipher == NULL)
         pc->cipher = EVP_get_cipherbyname(p->data);
 #endif
@@ -140,7 +140,7 @@ int ossl_prov_digest_load_from_params(PROV_DIGEST *pd,
     ERR_set_mark();
     pd->md = pd->alloc_md = EVP_MD_fetch(ctx, p->data, propquery);
     /* TODO legacy stuff, to be removed */
-#ifndef FIPS_MODE /* Inside the FIPS module, we don't support legacy digests */
+#ifndef FIPS_MODULE /* Inside the FIPS module, we don't support legacy digests */
     if (pd->md == NULL)
         pd->md = EVP_get_digestbyname(p->data);
 #endif
@@ -231,7 +231,7 @@ int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
         *mp++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_PROPERTIES,
                                                  (char *)properties, 0);
 
-#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
     if ((p = OSSL_PARAM_locate_const(params, "engine")) != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -233,7 +233,7 @@ static int fips_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
 /* FIPS specific version of the function of the same name in provlib.c */
 const char *ossl_prov_util_nid_to_name(int nid)
 {
-    /* We don't have OBJ_nid2n() in FIPS_MODE so we have an explicit list */
+    /* We don't have OBJ_nid2n() in FIPS_MODULE so we have an explicit list */
 
     switch (nid) {
     /* Digests */

--- a/providers/implementations/ciphers/cipher_aes_xts_fips.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_fips.c
@@ -16,8 +16,8 @@
 
 #include "cipher_aes_xts.h"
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 const int allow_insecure_decrypt = 0;
 #else
 const int allow_insecure_decrypt = 1;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -458,7 +458,7 @@ int ecdh_plain_derive(void *vpecdhctx, unsigned char *secret,
     return ret;
 }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
 static ossl_inline
 int ecdh_X9_63_kdf_derive(void *vpecdhctx, unsigned char *secret,
                           size_t *psecretlen, size_t outlen)
@@ -498,7 +498,7 @@ int ecdh_X9_63_kdf_derive(void *vpecdhctx, unsigned char *secret,
     OPENSSL_secure_clear_free(stmp, stmplen);
     return ret;
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 static
 int ecdh_derive(void *vpecdhctx, unsigned char *secret,
@@ -509,11 +509,11 @@ int ecdh_derive(void *vpecdhctx, unsigned char *secret,
     switch (pecdhctx->kdf_type) {
         case PROV_ECDH_KDF_NONE:
             return ecdh_plain_derive(vpecdhctx, secret, psecretlen, outlen);
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         case PROV_ECDH_KDF_X9_63:
             return ecdh_X9_63_kdf_derive(vpecdhctx, secret, psecretlen, outlen);
 
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
         default:
             break;
     }

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -181,7 +181,7 @@ extern const OSSL_DISPATCH rc2128ofb128_functions[];
 #ifndef OPENSSL_NO_DES
 extern const OSSL_DISPATCH tdes_ede3_ecb_functions[];
 extern const OSSL_DISPATCH tdes_ede3_cbc_functions[];
-# ifndef FIPS_MODE
+# ifndef FIPS_MODULE
 extern const OSSL_DISPATCH tdes_ede3_ofb_functions[];
 extern const OSSL_DISPATCH tdes_ede3_cfb_functions[];
 extern const OSSL_DISPATCH tdes_ede3_cfb8_functions[];
@@ -201,7 +201,7 @@ extern const OSSL_DISPATCH des_ofb64_functions[];
 extern const OSSL_DISPATCH des_cfb64_functions[];
 extern const OSSL_DISPATCH des_cfb1_functions[];
 extern const OSSL_DISPATCH des_cfb8_functions[];
-# endif /* FIPS_MODE */
+# endif /* FIPS_MODULE */
 #endif /* OPENSSL_NO_DES */
 
 #ifndef OPENSSL_NO_RC4

--- a/providers/implementations/kdfs/pbkdf2_fips.c
+++ b/providers/implementations/kdfs/pbkdf2_fips.c
@@ -13,8 +13,8 @@
  * For backwards compatibility reasons,
  * Extra checks are done by default in fips mode only.
  */
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 const int kdf_pbkdf2_default_checks = 1;
 #else
 const int kdf_pbkdf2_default_checks = 0;
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -176,7 +176,7 @@ err:
     return ok;
 }
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 /* In fips mode there are no multi-primes. */
 # define RSA_KEY_MP_TYPES()                                                    \
 OSSL_PARAM_BN(OSSL_PKEY_PARAM_RSA_FACTOR1, NULL, 0),                           \

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -313,7 +313,7 @@ static int rsa_sign(void *vprsactx, unsigned char *sig, size_t *siglen,
             return 0;
         }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
         if (EVP_MD_is_a(prsactx->md, OSSL_DIGEST_NAME_MDC2)) {
             unsigned int sltmp;
 
@@ -407,7 +407,7 @@ static int rsa_sign(void *vprsactx, unsigned char *sig, size_t *siglen,
                                   prsactx->pad_mode);
     }
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
  end:
 #endif
     if (ret <= 0) {

--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -116,7 +116,7 @@ static int badkeylen_test(void)
     return ret;
 }
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
 static int ivgen_test(void)
 {
     unsigned char iv_gen[16];
@@ -127,14 +127,14 @@ static int ivgen_test(void)
     return do_encrypt(iv_gen, ct, &ctlen, tag, &taglen)
            && do_decrypt(iv_gen, ct, ctlen, tag, taglen);
 }
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
 int setup_tests(void)
 {
     ADD_TEST(kat_test);
     ADD_TEST(badkeylen_test);
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     ADD_TEST(ivgen_test);
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
     return 1;
 }

--- a/test/drbg_cavs_test.c
+++ b/test/drbg_cavs_test.c
@@ -254,7 +254,7 @@ static int test_cavs_kats(const struct drbg_kat *test[], int i)
     const struct drbg_kat *td = test[i];
     int rv = 0;
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     /* FIPS mode doesn't support instantiating without a derivation function */
     if ((td->flags & USE_DF) == 0)
         return TEST_skip("instantiating without derivation function "

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -111,7 +111,7 @@ typedef struct drbg_selftest_data_st {
     make_drbg_test_data(nid, 0, pr, p)
 
 static DRBG_SELFTEST_DATA drbg_test[] = {
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /* FIPS mode doesn't support CTR DRBG without a derivation function */
     make_drbg_test_data_no_df (NID_aes_128_ctr, aes_128_no_df,  0),
     make_drbg_test_data_no_df (NID_aes_192_ctr, aes_192_no_df,  0),
@@ -850,7 +850,7 @@ static int test_rand_drbg_reseed(void)
     /* fill 'randomness' buffer with some arbitrary data */
     memset(rand_add_buf, 'r', sizeof(rand_add_buf));
 
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     /*
      * Test whether all three DRBGs are reseeded by RAND_add().
      * The before_reseed time has to be measured here and passed into the
@@ -876,7 +876,7 @@ static int test_rand_drbg_reseed(void)
     if (!TEST_true(test_drbg_reseed(0, master, public, private, 0, 0, 0, 0)))
         goto error;
     reset_drbg_hook_ctx();
-#else /* FIPS_MODE */
+#else /* FIPS_MODULE */
     /*
      * In FIPS mode, random data provided by the application via RAND_add()
      * is not considered a trusted entropy source. It is only treated as
@@ -1251,7 +1251,7 @@ static int test_set_defaults(void)
            && TEST_int_eq(public->flags, RAND_DRBG_FLAG_PUBLIC)
 
           /* FIPS mode doesn't support CTR DRBG without a derivation function */
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
           /* Change DRBG defaults and change master and check again */
            && TEST_true(RAND_DRBG_set_defaults(NID_aes_256_ctr,
                                                RAND_DRBG_FLAG_CTR_NO_DF))
@@ -1347,7 +1347,7 @@ static int test_crngt(int n)
     crngt_case = n % crngt_num_cases;
     crngt_idx = 0;
     crngt_get_entropy = &crngt_entropy_cb;
-#ifndef FIPS_MODE
+#ifndef FIPS_MODULE
     if (!TEST_true(RAND_DRBG_set_callbacks(drbg, &rand_crngt_get_entropy,
                                            &rand_crngt_cleanup_entropy,
                                            &rand_drbg_get_nonce,

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -123,10 +123,10 @@ static int x9_62_tests(int n)
 
     TEST_info("ECDSA KATs for curve %s", OBJ_nid2sn(nid));
 
-#ifdef FIPS_MODE
+#ifdef FIPS_MODULE
     if (EC_curve_nid2nist(nid) == NULL)
         return TEST_skip("skip non approved curves");
-#endif /* FIPS_MODE */
+#endif /* FIPS_MODULE */
 
     if (!TEST_ptr(mctx = EVP_MD_CTX_new())
         /* get the message digest */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -765,7 +765,7 @@ static int test_EVP_PKCS82PKEY(void)
 }
 #endif
 
-#if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODULE)
 
 static int test_EVP_SM2_verify(void)
 {
@@ -1590,7 +1590,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_EVP_PKCS82PKEY);
 #endif
-#if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODE)
+#if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODULE)
     ADD_TEST(test_EVP_SM2);
     ADD_TEST(test_EVP_SM2_verify);
 #endif


### PR DESCRIPTION
This macro is used to determine if certain pieces of code should
become part of the FIPS module or not.  The old name was confusing.

Fixes #11538
