### PR TITLE
mkerr: remove legacy guards from generated error headers

### DIFF
--- a/include/openssl/asn1err.h
+++ b/include/openssl/asn1err.h
@@ -12,11 +12,6 @@
 # define OPENSSL_ASN1ERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_ASN1ERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/asyncerr.h
+++ b/include/openssl/asyncerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_ASYNCERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_ASYNCERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/bioerr.h
+++ b/include/openssl/bioerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_BIOERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_BIOERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/bnerr.h
+++ b/include/openssl/bnerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_BNERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_BNERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/buffererr.h
+++ b/include/openssl/buffererr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_BUFFERERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_BUFERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/cmserr.h
+++ b/include/openssl/cmserr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_CMSERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_CMSERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/comperr.h
+++ b/include/openssl/comperr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_COMPERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_COMPERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/conferr.h
+++ b/include/openssl/conferr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_CONFERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_CONFERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/cryptoerr.h
+++ b/include/openssl/cryptoerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_CRYPTOERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_CRYPTOERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/cterr.h
+++ b/include/openssl/cterr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_CTERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_CTERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/dherr.h
+++ b/include/openssl/dherr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_DHERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_DHERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/dsaerr.h
+++ b/include/openssl/dsaerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_DSAERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_DSAERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/ecerr.h
+++ b/include/openssl/ecerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_ECERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_ECERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/engineerr.h
+++ b/include/openssl/engineerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_ENGINEERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_ENGINEERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_KDFERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_OSSL_KDFERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/objectserr.h
+++ b/include/openssl/objectserr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_OBJECTSERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_OBJERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/ocsperr.h
+++ b/include/openssl/ocsperr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_OCSPERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_OCSPERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/pemerr.h
+++ b/include/openssl/pemerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_PEMERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_PEMERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/pkcs12err.h
+++ b/include/openssl/pkcs12err.h
@@ -12,11 +12,6 @@
 # define OPENSSL_PKCS12ERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_PKCS12ERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/pkcs7err.h
+++ b/include/openssl/pkcs7err.h
@@ -12,11 +12,6 @@
 # define OPENSSL_PKCS7ERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_PKCS7ERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/randerr.h
+++ b/include/openssl/randerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_RANDERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_RANDERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/rsaerr.h
+++ b/include/openssl/rsaerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_RSAERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_RSAERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/sslerr.h
+++ b/include/openssl/sslerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_SSLERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_SSLERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/storeerr.h
+++ b/include/openssl/storeerr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_STOREERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_OSSL_STOREERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/tserr.h
+++ b/include/openssl/tserr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_TSERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_TSERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/uierr.h
+++ b/include/openssl/uierr.h
@@ -12,11 +12,6 @@
 # define OPENSSL_UIERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_UIERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/x509err.h
+++ b/include/openssl/x509err.h
@@ -12,11 +12,6 @@
 # define OPENSSL_X509ERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_X509ERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/include/openssl/x509v3err.h
+++ b/include/openssl/x509v3err.h
@@ -12,11 +12,6 @@
 # define OPENSSL_X509V3ERR_H
 # pragma once
 
-# include <openssl/macros.h>
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HEADER_X509V3ERR_H
-# endif
-
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>
 

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -450,6 +450,7 @@ foreach my $lib ( keys %errorfile ) {
 
 #ifndef OPENSSL_${lib}ERR_H
 # define OPENSSL_${lib}ERR_H
+# pragma once
 
 # include <openssl/opensslconf.h>
 # include <openssl/symhacks.h>


### PR DESCRIPTION
In pull request #9333, legacy guards were added to the generated
error headers, but the mkerr.pl script was not adjusted accordingly.
So the legacy guards were removed by subsequent `make update` calls.

Fixing the mkerr.pl script properly was disproportionately complicated
by the fact that adding legacy guards only made sense for files which
already existed in version 1.1.1. To keep things simple, it was decided
to drop the legacy guards from the generated headers entirely.

Fixes #10569
