### PR TITLE
mkbuildinf: Strip fdebug-prefix-map from saved CFLAGS

### DIFF
--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -124,7 +124,9 @@ The value of B<OPENSSL_FULL_VERSION_STR>
 
 The compiler flags set for the compilation process in the form
 C<compiler: ...>  if available, or C<compiler: information not available>
-otherwise.
+otherwise. The path specified in C<-fdebug-prefix-map=>,
+C<-fmacro-prefix-map=> and C<-ffile-prefix-map=> is replaced with a
+fixed string to avoid recording the build path.
 
 =item OPENSSL_BUILT_ON
 

--- a/util/mkbuildinf.pl
+++ b/util/mkbuildinf.pl
@@ -10,6 +10,10 @@ use strict;
 use warnings;
 
 my ($cflags, $platform) = @ARGV;
+
+$cflags =~ s@-fdebug-prefix-map=[^=]+=[^ ]+@-fdebug-prefix-map=<REPRODUCIBLE>@;
+$cflags =~ s@-fmacro-prefix-map=[^=]+=[^ ]+@-fmacro-prefix-map=<REPRODUCIBLE>@;
+$cflags =~ s@-ffile-prefix-map=[^=]+=[^ ]+@-ffile-prefix-map=<REPRODUCIBLE>@;
 $cflags = "compiler: $cflags";
 
 my $date = gmtime($ENV{'SOURCE_DATE_EPOCH'} || time()) . " UTC";


### PR DESCRIPTION
The saved `CFLAGS` may contain the `-fdebug-prefix-map=` which is used
to strip the build path from the debug info. If this information remains
recorded then the binary is no longer reproducible if the build
directory changes.

Replace the recorded CFLAG parameter `-fdebug-prefix-map=$OLD=$NEW` with
`-fdebug-prefix-map=<REPRODUCIBLE>`.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>

##### Checklist
- [x] documentation is added or updated