### PR TITLE
EVP: Fix calls to evp_pkey_export_to_provider()

### DIFF
--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -313,8 +313,15 @@ void *evp_keymgmt_gen_init(const EVP_KEYMGMT *keymgmt, int selection)
 int evp_keymgmt_gen_set_template(const EVP_KEYMGMT *keymgmt, void *genctx,
                                  void *template)
 {
+    /*
+     * It's arguable if we actually should return success in this case, as
+     * it allows the caller to set a template key, which is then ignored.
+     * However, this is how the legacy methods (EVP_PKEY_METHOD) operate,
+     * so we do this in the interest of backward compatibility.
+     * TODO(3.0) Investigate if we should change this behaviour.
+     */
     if (keymgmt->gen_set_template == NULL)
-        return 0;
+        return 1;
     return keymgmt->gen_set_template(genctx, template);
 }
 

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -170,10 +170,15 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
             evp_pkey_export_to_provider(ctx->pkey, ctx->libctx,
                                         &tmp_keymgmt, ctx->propquery);
 
-        if (keydata == NULL)
+        if (tmp_keymgmt == NULL)
             goto not_supported;
-        ret = evp_keymgmt_gen_set_template(ctx->keymgmt,
-                                           ctx->op.keymgmt.genctx, keydata);
+        /*
+         * If there is no keydata, then the given pkey is empty, so
+         * there is no template to set
+         */
+        if (keydata != NULL)
+            ret = evp_keymgmt_gen_set_template(ctx->keymgmt,
+                                               ctx->op.keymgmt.genctx, keydata);
     }
 
     /*

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -173,12 +173,11 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
         if (tmp_keymgmt == NULL)
             goto not_supported;
         /*
-         * If there is no keydata, then the given pkey is empty, so
-         * there is no template to set
+         * It's ok if keydata is NULL here.  The backend is expected to deal
+         * with that as it sees fit.
          */
-        if (keydata != NULL)
-            ret = evp_keymgmt_gen_set_template(ctx->keymgmt,
-                                               ctx->op.keymgmt.genctx, keydata);
+        ret = evp_keymgmt_gen_set_template(ctx->keymgmt,
+                                           ctx->op.keymgmt.genctx, keydata);
     }
 
     /*

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -369,7 +369,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
     tmp_keymgmt = ctx->keymgmt;
     provkey = evp_pkey_export_to_provider(ctx->pkey, ctx->libctx,
                                           &tmp_keymgmt, ctx->propquery);
-    if (provkey == NULL)
+    if (tmp_keymgmt == NULL)
         goto legacy;
     if (!EVP_KEYMGMT_up_ref(tmp_keymgmt)) {
         ERR_clear_last_mark();

--- a/doc/internal/man3/evp_pkey_export_to_provider.pod
+++ b/doc/internal/man3/evp_pkey_export_to_provider.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-evp_pkey_export_to_provider, evp_pkey_upgrade_to_provider
+evp_pkey_export_to_provider, evp_pkey_downgrade
 - internal EVP_PKEY support functions for providers
 
 =head1 SYNOPSIS
@@ -13,9 +13,7 @@ evp_pkey_export_to_provider, evp_pkey_upgrade_to_provider
  void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
                                    EVP_KEYMGMT **keymgmt,
                                    const char *propquery);
- void *evp_pkey_upgrade_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
-                                    EVP_KEYMGMT **keymgmt,
-                                    const char *propquery);
+ int evp_pkey_downgrade(EVP_PKEY *pk);
 
 =head1 DESCRIPTION
 
@@ -31,29 +29,26 @@ default context), the name of the legacy type of I<pk>, and the I<propquery>
 If I<keymgmt> isn't NULL but I<*keymgmt> is, and the "origin" was successfully
 exported, then I<*keymgmt> is assigned the implicitly fetched B<EVP_KEYMGMT>.
 
-evp_pkey_upgrade_to_provider() exports the legacy "origin" key contained in
-I<pk> to it's provider side counterpart, then clears the legacy "origin" key
-along with other legacy data, and resets all the caches.  Otherwise, it works
-like evp_pkey_export_to_provider().
-
-I<evp_pkey_upgrade_to_provider() must be used with great care, only if there's
-no other way.>
-Most of the time, it's sufficient to use evp_pkey_export_to_provider(), but in
-case the key needs modification with data coming from a provided key, the key
-will need an upgrade.
+evp_pkey_downgrade() converts an B<EVP_PKEY> with a provider side "origin" key
+to one with a legacy "origin", if there's a corresponding legacy implementation.
+This clears the operation cache, except for the provider side "origin" key.
+This function is used in spots where provider side keys aren't yet supported,
+in an attempt to keep operating with available implementations.
 
 =head1 RETURN VALUES
 
-evp_pkey_export_to_provider() and evp_pkey_upgrade_to_provider() both return
-the provider key data that was exported if the "origin" was successfully
-exported to its target.  Otherwise, NULL is returned.
+evp_pkey_export_to_provider() returns the provider key data if there was any
+allocated.  It also either sets I<*keymgmt> to the B<EVP_KEYMGMT> associated
+with the returned key data, or NULL on error.
+
+evp_pkey_downgrade() returns 1 on success or 0 on error.
 
 =head1 NOTES
 
-Some functions calling evp_pkey_export_to_provider() or
-evp_pkey_upgrade_to_provider() may have received a const key, and may
-therefore have to cast the key to non-const form to call this function.  Since
-B<EVP_PKEY> is always dynamically allocated, this is OK.
+Some functions calling evp_pkey_export_to_provider() or evp_pkey_downgrade()
+may have received a const key, and may therefore have to cast the key to
+non-const form to call this function.  Since B<EVP_PKEY> is always dynamically
+allocated, this is OK.
 
 =head1 SEE ALSO
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1561,7 +1561,7 @@ static int test_keygen_with_empty_template(int n)
             goto err;
         break;
     case 1:
-        /* Here we create an empty RSA key that serves as ou template */
+        /* Here we create an empty RSA key that serves as our template */
         if (!TEST_ptr(tkey = EVP_PKEY_new())
             || !TEST_true(EVP_PKEY_set_type(tkey, EVP_PKEY_RSA))
             || !TEST_ptr(ctx = EVP_PKEY_CTX_new(tkey, NULL)))

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1540,6 +1540,47 @@ static int test_EVP_PKEY_set1_DH(void)
 }
 #endif
 
+/*
+ * We test what happens with an empty template.  For the sake of this test,
+ * the template must be ignored, and we know that's the case for RSA keys
+ * (this might arguably be a misfeature, but that's what we currently do,
+ * even in provider code, since that's how the legacy RSA implementation
+ * does things)
+ */
+static int test_keygen_with_empty_template(int n)
+{
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY *tkey = NULL;
+    int ret = 0;
+
+    switch (n) {
+    case 0:
+        /* We do test with no template at all as well */
+        if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL)))
+            goto err;
+        break;
+    case 1:
+        /* Here we create an empty RSA key that serves as ou template */
+        if (!TEST_ptr(tkey = EVP_PKEY_new())
+            || !TEST_true(EVP_PKEY_set_type(tkey, EVP_PKEY_RSA))
+            || !TEST_ptr(ctx = EVP_PKEY_CTX_new(tkey, NULL)))
+            goto err;
+        break;
+    }
+
+    if (!TEST_int_le(EVP_PKEY_keygen_init(ctx), 0)
+        || !TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
+        goto err;
+
+    ret = 1;
+ err:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    EVP_PKEY_free(tkey);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_EVP_DigestSignInit, 9);
@@ -1579,6 +1620,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DH
     ADD_TEST(test_EVP_PKEY_set1_DH);
 #endif
+    ADD_ALL_TESTS(test_keygen_with_empty_template, 2);
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1569,8 +1569,8 @@ static int test_keygen_with_empty_template(int n)
         break;
     }
 
-    if (!TEST_int_le(EVP_PKEY_keygen_init(ctx), 0)
-        || !TEST_int_le(EVP_PKEY_keygen(ctx, &pkey), 0))
+    if (!TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
+        || !TEST_int_gt(EVP_PKEY_keygen(ctx, &pkey), 0))
         goto err;
 
     ret = 1;


### PR DESCRIPTION
The calls weren't quite right, as this function has changed its behaviour.
We also change the internal documentation of this function, and document
evp_pkey_downgrade().

Fixes #11549
