### PR TITLE
INSTALL: document 'no-ui-console' rather than 'no-ui' [1.1.1]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -535,9 +535,9 @@
                    conjunction with the "-DPEDANTIC" option (or the
                    --strict-warnings option).
 
-  no-ui
-                   Don't build with the "UI" capability (i.e. the set of
-                   features enabling text based prompts).
+  no-ui-console
+                   Don't build with the "UI" console method (i.e. the "UI"
+                   method that enables text based console prompts).
 
   enable-unit-test
                    Enable additional unit test APIs. This should not typically


### PR DESCRIPTION
The UI interface itself is never disabled, but the console backend may
be. 'no-ui' is a deprecated backward compatibility alias for
'no-ui-console'.

Fixes #11551
