### PR TITLE
s_time: Allow using -CAfile option as in other commands

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -62,6 +62,7 @@ const OPTIONS s_time_options[] = {
     {"key", OPT_KEY, '<', "File with key, PEM; default is -cert file"},
     {"CApath", OPT_CAPATH, '/', "PEM format directory of CA's"},
     {"cafile", OPT_CAFILE, '<', "PEM format file of CA's"},
+    {"CAfile", OPT_CAFILE, '<', "PEM format file of CA's"},
     {"no-CAfile", OPT_NOCAFILE, '-',
      "Do not load the default certificates file"},
     {"no-CApath", OPT_NOCAPATH, '-',

--- a/doc/man1/s_time.pod
+++ b/doc/man1/s_time.pod
@@ -14,7 +14,7 @@ B<openssl> B<s_time>
 [B<-cert filename>]
 [B<-key filename>]
 [B<-CApath directory>]
-[B<-cafile filename>]
+[B<-CAfile filename>]
 [B<-no-CAfile>]
 [B<-no-CApath>]
 [B<-reuse>]


### PR DESCRIPTION
The s_time command in difference from all the other similar
commands supported -cafile option instead of -CAfile.
Add the -CAfile option and keep -cafile only for backwards
compatibility.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
