### PR TITLE
GOST2012 TLS ClientCertificateType Identifiers support

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -190,7 +190,7 @@ static STRINT_PAIR cert_type_list[] = {
     {"RSA fixed ECDH", TLS_CT_RSA_FIXED_ECDH},
     {"ECDSA fixed ECDH", TLS_CT_ECDSA_FIXED_ECDH},
     {"GOST01 Sign", TLS_CT_GOST01_SIGN},
-    {"GOST12 Sign", TLS_CT_GOST12_SIGN},
+    {"GOST12 Sign", TLS_CT_GOST12_IANA_SIGN},
     {NULL}
 };
 

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -270,7 +270,7 @@ extern "C" {
  * SSL3_CT_NUMBER is used to size arrays and it must be large enough to
  * contain all of the cert types defined for *either* SSLv3 and TLSv1.
  */
-# define SSL3_CT_NUMBER                  10
+# define SSL3_CT_NUMBER                  12
 
 # if defined(TLS_CT_NUMBER)
 #  if TLS_CT_NUMBER != SSL3_CT_NUMBER

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -1116,14 +1116,16 @@ int SSL_CTX_set_tlsext_ticket_key_evp_cb
 # define TLS_CT_RSA_FIXED_ECDH           65
 # define TLS_CT_ECDSA_FIXED_ECDH         66
 # define TLS_CT_GOST01_SIGN              22
-# define TLS_CT_GOST12_SIGN              238
-# define TLS_CT_GOST12_512_SIGN          239
+# define TLS_CT_GOST12_IANA_SIGN         67
+# define TLS_CT_GOST12_IANA_512_SIGN     68
+# define TLS_CT_GOST12_LEGACY_SIGN       238
+# define TLS_CT_GOST12_LEGACY_512_SIGN   239
 
 /*
  * when correcting this number, correct also SSL3_CT_NUMBER in ssl3.h (see
  * comment there)
  */
-# define TLS_CT_NUMBER                   10
+# define TLS_CT_NUMBER                   12
 
 # if defined(SSL3_CT_NUMBER)
 #  if TLS_CT_NUMBER != SSL3_CT_NUMBER

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4371,8 +4371,10 @@ int ssl3_get_req_cert_type(SSL *s, WPACKET *pkt)
 #ifndef OPENSSL_NO_GOST
     if (s->version >= TLS1_VERSION && (alg_k & SSL_kGOST))
             return WPACKET_put_bytes_u8(pkt, TLS_CT_GOST01_SIGN)
-                    && WPACKET_put_bytes_u8(pkt, TLS_CT_GOST12_SIGN)
-                    && WPACKET_put_bytes_u8(pkt, TLS_CT_GOST12_512_SIGN);
+                    && WPACKET_put_bytes_u8(pkt, TLS_CT_GOST12_IANA_SIGN)
+                    && WPACKET_put_bytes_u8(pkt, TLS_CT_GOST12_IANA_512_SIGN)
+                    && WPACKET_put_bytes_u8(pkt, TLS_CT_GOST12_LEGACY_SIGN)
+                    && WPACKET_put_bytes_u8(pkt, TLS_CT_GOST12_LEGACY_512_SIGN);
 #endif
 
     if ((s->version == SSL3_VERSION) && (alg_k & SSL_kDHE)) {


### PR DESCRIPTION
For GOST2012-GOST8912-GOST8912 IANA introduce ClientCertificateType Identifiers
https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-2

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
