### PR TITLE
gendsa: remove unnecessary OPENSSL_SUPPRESS_DEPRECATED definition

### DIFF
--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -7,9 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* We need to use some deprecated APIs */
-#define OPENSSL_SUPPRESS_DEPRECATED
-
 #include <openssl/opensslconf.h>
 
 #include <stdio.h>


### PR DESCRIPTION
A leftover from the deprecation of this command that wasn't properly excised from the code base.

This isn't essential for ɑ1.
