### PR TITLE
Prevent oversize TLS labels.

### DIFF
--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -13,7 +13,27 @@
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 
-#define TLS13_MAX_LABEL_LEN     249
+/*
+ * RFC 8446, 7.1 Key Schedule, says:
+ * Note: With common hash functions, any label longer than 12 characters
+ * requires an additional iteration of the hash function to compute.
+ * The labels in this specification have all been chosen to fit within
+ * this limit.
+ *
+ * The longest IANA assigned label is:
+ * "EXPORTER-ETSI-TC-M2M-Connection"
+ *
+ * Please do not use longer labels than this, their use is not supported.
+ *
+ * Bernd Edlinger, 20.04.2020.
+ */
+#ifndef TLS13_MAX_LABEL_LEN
+# define TLS13_MAX_LABEL_LEN    31
+#elif TLS13_MAX_LABEL_LEN < 12
+# error TLS13_MAX_LABEL_LEN is too short
+#elif TLS13_MAX_LABEL_LEN > 249
+# error TLS13_MAX_LABEL_LEN is too long
+#endif
 
 /* Always filled with zeros */
 static const unsigned char default_zeros[EVP_MAX_MD_SIZE];

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4385,13 +4385,23 @@ static int test_serverinfo(int tst)
  * produce the same results for different protocol versions.
  */
 #define SMALL_LABEL_LEN 10
-#define LONG_LABEL_LEN  249
+#if !defined(TLS13_MAX_LABEL_LEN) || TLS13_MAX_LABEL_LEN >= 31
+# define LONG_LABEL_LEN 31
+#else
+# define LONG_LABEL_LEN 12
+#endif
 static int test_export_key_mat(int tst)
 {
     int testresult = 0;
     SSL_CTX *cctx = NULL, *sctx = NULL, *sctx2 = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
-    const char label[LONG_LABEL_LEN + 1] = "test label";
+#if LONG_LABEL_LEN >= 31
+    /* longest IANA assigned label */
+    const char label[LONG_LABEL_LEN + 1] = "EXPORTER-ETSI-TC-M2M-Connection";
+#else
+    /* longest RFC 8446 assigned label */
+    const char label[LONG_LABEL_LEN + 1] = "e exp master";
+#endif
     const unsigned char context[] = "context";
     const unsigned char *emptycontext = NULL;
     unsigned char ckeymat1[80], ckeymat2[80], ckeymat3[80];
@@ -4444,7 +4454,7 @@ static int test_export_key_mat(int tst)
          */
         if (!TEST_int_le(SSL_export_keying_material(clientssl, ckeymat1,
                                                     sizeof(ckeymat1), label,
-                                                    LONG_LABEL_LEN + 1, context,
+                                                    249 + 1, context,
                                                     sizeof(context) - 1, 1), 0))
             goto end;
 


### PR DESCRIPTION
I see no valid use case in such labels.

[extended tests]
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
