### PR TITLE
Fix a few more tests to use the new fipsinstall script

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -13,16 +13,11 @@ use warnings;
 use File::Basename;
 use File::Compare qw/compare_text/;
 use OpenSSL::Glob;
-use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file bldtop_file bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file bldtop_dir/;
 use OpenSSL::Test::Utils qw/disabled alldisabled available_protocols/;
 
-BEGIN {
 setup("test_ssl_new");
-}
 
-use lib srctop_dir('Configurations');
-use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
@@ -118,13 +113,7 @@ my %skip = (
 );
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips')),
-                '-provider_name', 'fips', '-mac_name', 'HMAC',
-                '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
-                '-section_name', 'fips_sect'])),
-       "fipsinstall");
+    ok(run(perltest(['fipsinstall.pl', bldtop_dir()])), 'fipsinstall');
 }
 
 foreach my $conf (@conf_files) {

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -13,16 +13,10 @@ use warnings;
 use POSIX;
 use File::Basename;
 use File::Copy;
-use OpenSSL::Test qw/:DEFAULT with bldtop_file bldtop_dir srctop_file srctop_dir cmdstr/;
+use OpenSSL::Test qw/:DEFAULT with bldtop_dir srctop_file srctop_dir cmdstr/;
 use OpenSSL::Test::Utils;
 
-BEGIN {
 setup("test_ssl");
-}
-
-use lib srctop_dir('Configurations');
-use lib bldtop_dir('.');
-use platform;
 
 $ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 $ENV{OPENSSL_MODULES} = bldtop_dir("providers");
@@ -93,13 +87,7 @@ plan tests =>
     ;
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips')),
-                '-provider_name', 'fips', '-mac_name', 'HMAC',
-                '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
-                '-section_name', 'fips_sect'])),
-       "fipsinstall");
+    ok(run(perltest(['fipsinstall.pl', bldtop_dir()])), 'fipsinstall');
 }
 
 subtest 'test_ss' => sub {

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -8,16 +8,10 @@
 
 
 use OpenSSL::Test::Utils;
-use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir bldtop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_dir/;
 use File::Temp qw(tempfile);
 
-BEGIN {
 setup("test_sslapi");
-}
-
-use lib srctop_dir('Configurations');
-use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
@@ -40,13 +34,7 @@ ok(run(test(["sslapitest", srctop_dir("test", "certs"),
              "running sslapitest");
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsinstall.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips')),
-                '-provider_name', 'fips', '-mac_name', 'HMAC',
-                '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
-                '-section_name', 'fips_sect'])),
-       "fipsinstall");
+    ok(run(perltest(['fipsinstall.pl', bldtop_dir()])), 'fipsinstall');
 
     ok(run(test(["sslapitest", srctop_dir("test", "certs"),
                  srctop_file("test", "recipes", "90-test_sslapi_data",


### PR DESCRIPTION
Commit ae6b654b6 introduced a new script to make running fipsinstall
easier. A few tests were added around the same time as that commit that
still do it the old way - so we fix those up.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
