### PR TITLE
Fix no-ec

### DIFF
--- a/test/recipes/65-test_cmp_client.t
+++ b/test/recipes/65-test_cmp_client.t
@@ -14,8 +14,8 @@ use OpenSSL::Test::Utils;
 
 setup("test_cmp_client");
 
-plan skip_all => "This test is not supported in a no-cmp build"
-    if disabled("cmp");
+plan skip_all => "This test is not supported in a no-cmp or no-ec build"
+    if disabled("cmp") || disabled("ec");
 
 plan tests => 1;
 


### PR DESCRIPTION
This was missed by Travis because, although it has a no-ec build, the test
that failed only runs in a debug build. The Travis job with no-ec is not
a debug build and so the test was skipped.