### PR TITLE
Fix no-dh and no-dsa

### DIFF
--- a/crypto/ffc/ffc_backend.c
+++ b/crypto/ffc/ffc_backend.c
@@ -31,7 +31,13 @@ int ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
     if (prm != NULL) {
         if (prm->data_type != OSSL_PARAM_UTF8_STRING)
             goto err;
+#ifndef OPENSSL_NO_DH
+        /*
+         * In a no-dh build we just go straight to err because we have no
+         * support for this.
+         */
         if (!ffc_set_group_pqg(ffc, prm->data))
+#endif
             goto err;
     }
 

--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -215,6 +215,7 @@ int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
                                               ffc->seed, ffc->seedlen))
         return 0;
     if (ffc->nid != NID_undef) {
+#ifndef OPENSSL_NO_DH
         const char *name = ffc_named_group_from_uid(ffc->nid);
 
         if (name == NULL
@@ -222,6 +223,10 @@ int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
                                                  OSSL_PKEY_PARAM_FFC_GROUP,
                                                  name))
             return 0;
+#else
+        /* How could this be? We should not have a nid in a no-dh build. */
+        return 0;
+#endif
     }
     return 1;
 }

--- a/providers/implementations/serializers/serializer_ffc_params.c
+++ b/providers/implementations/serializers/serializer_ffc_params.c
@@ -15,6 +15,7 @@
 int ffc_params_prov_print(BIO *out, const FFC_PARAMS *ffc)
 {
     if (ffc->nid != NID_undef) {
+#ifndef OPENSSL_NO_DH
         const char *name = ffc_named_group_from_uid(ffc->nid);
 
         if (name == NULL)
@@ -22,6 +23,10 @@ int ffc_params_prov_print(BIO *out, const FFC_PARAMS *ffc)
         if (ossl_prov_bio_printf(out, "GROUP: %s\n", name) <= 0)
             goto err;
         return 1;
+#else
+        /* How could this be? We should not have a nid in a no-dh build. */
+        goto err;
+#endif
     }
 
     if (!ossl_prov_print_labeled_bignum(out, "P:   ", ffc->p))

--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -101,13 +101,18 @@ ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.cnf', '-module', $infile,
    "fipsinstall fails when the DRBG CTR result is corrupted");
 
 # corrupt a KAS test
-ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.conf', '-module', $infile,
-            '-provider_name', 'fips', '-mac_name', 'HMAC',
-            '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
-            '-section_name', 'fips_install',
-            '-corrupt_desc', 'DH',
-            '-corrupt_type', 'KAT_KA'])),
-   "fipsinstall fails when the kas result is corrupted");
+SKIP: {
+    skip "Skipping KAS DH corruption test because of no dh in this build", 1
+        if disabled("dh");
+
+    ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.conf', '-module', $infile,
+                '-provider_name', 'fips', '-mac_name', 'HMAC',
+                '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
+                '-section_name', 'fips_install',
+                '-corrupt_desc', 'DH',
+                '-corrupt_type', 'KAT_KA'])),
+       "fipsinstall fails when the kas result is corrupted");
+}
 
 # corrupt a Signature test
 ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.conf', '-module', $infile,

--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -115,10 +115,14 @@ SKIP: {
 }
 
 # corrupt a Signature test
-ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.conf', '-module', $infile,
-            '-provider_name', 'fips', '-mac_name', 'HMAC',
-            '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
-            '-section_name', 'fips_install',
-            '-corrupt_desc', 'DSA',
-            '-corrupt_type', 'KAT_Signature'])),
-   "fipsinstall fails when the signature result is corrupted");
+SKIP: {
+    skip "Skipping Signature DSA corruption test because of no dsa in this build", 1
+        if disabled("dsa");
+    ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.conf', '-module', $infile,
+                '-provider_name', 'fips', '-mac_name', 'HMAC',
+                '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
+                '-section_name', 'fips_install',
+                '-corrupt_desc', 'DSA',
+                '-corrupt_type', 'KAT_Signature'])),
+       "fipsinstall fails when the signature result is corrupted");
+}


### PR DESCRIPTION
Add some missing OPENSSL_NO_DH guards.

Also, one of the sub-tests in the fipsinstall test corrupts a DH test to
confirm that fipsinstall fails. However that is never noticed in a
no-dh build - so we just skip that test in a no-dh build.