### PR TITLE
Fix no-deprecated tests where the GOST engine is present

### DIFF
--- a/test/recipes/90-test_gost.t
+++ b/test/recipes/90-test_gost.t
@@ -24,6 +24,9 @@ plan skip_all => "TLSv1.3 or TLSv1.2 are disabled in this OpenSSL build"
 plan skip_all => "EC is disabled in this OpenSSL build"
     if disabled("ec");
 
+#Gost engine uses some deprecated functions
+plan skip_all => "Deprecated functions are disabled in this OpenSSL build"
+    if disabled("deprecated");
 
 plan skip_all => "No test GOST engine found"
     if !$ENV{OPENSSL_GOST_ENGINE_SO};


### PR DESCRIPTION
The GOST test only runs if it detects that the GOST engine is present.
This is the case for the run-checker environment. The GOST engine uses
some deprecated functions, so we disable that test in a no-deprecated
build.
