### PR TITLE
Fix no-err

### DIFF
--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -114,8 +114,9 @@ const char *ossl_cmp_log_parse_metadata(const char *buf,
  */
 static const char *improve_location_name(const char *func, const char *fallback)
 {
-    if (!ossl_assert(fallback != NULL))
-        return NULL;
+    if (fallback == NULL)
+        return func == NULL ? UNKNOWN_FUNC : func;
+
     return func == NULL || *func == '\0' || strcmp(func, UNKNOWN_FUNC) == 0
         ? fallback : func;
 }


### PR DESCRIPTION
This fixes an assertion failure that can occur in the CMP code in the
event of a no-err build. The "improve_location_name" function assumed
that the fallback argument was always populated with something. However
in a no-err build this is not the case.
