### PR TITLE
Fix ssl_test_new and ssl_test_old when SSLv3 is enabled

### DIFF
--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -359,7 +359,7 @@ sub testssl {
 
       SKIP: {
 	  skip "SSLv3 is not supported by this OpenSSL build", 4
-	      if disabled("ssl3");
+	      if disabled("ssl3") || $provider eq "fips";
 
 	  ok(run(test([@ssltest, "-bio_pair", "-ssl3"])),
 	     'test sslv3 via BIO pair');

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -359,7 +359,10 @@ sub testssl {
 
       SKIP: {
 	  skip "SSLv3 is not supported by this OpenSSL build", 4
-	      if disabled("ssl3") || $provider eq "fips";
+	      if disabled("ssl3");
+
+	  skip "SSLv3 is not supported by the FIPS provider", 4
+	      if $provider eq "fips";
 
 	  ok(run(test([@ssltest, "-bio_pair", "-ssl3"])),
 	     'test sslv3 via BIO pair');


### PR DESCRIPTION
The ssl_test_new and ssl_test_old tests are failing when SSLv3 is enabled.

There are a couple of fetches, that only occur in those codepaths and weren't using the correct libctx. Also we need to disable some tests in ssl_test_old when using the FIPS provider.

Marking this as urgent because it is one of the causes for the current travis failures (other fixes for travis failures in #11585 and #11573.

I've marked this with "extended tests". I do expect some of those tests to fail because of the other issues - but hopefully it won't fail due to ssl_test_new/ssl_test_old.