### PR TITLE
param: Param add a modified indicator to OSSL_PARAM.

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -36,8 +36,19 @@ static OSSL_PARAM ossl_param_construct(const char *key, unsigned int data_type,
     res.data_type = data_type;
     res.data = data;
     res.data_size = data_size;
-    res.return_size = 0;
+    res.return_size = OSSL_PARAM_UNMODIFIED;
     return res;
+}
+
+int OSSL_PARAM_modified(const OSSL_PARAM *p)
+{
+    return p != NULL && p->return_size != OSSL_PARAM_UNMODIFIED;
+}
+
+void OSSL_PARAM_set_unmodified(OSSL_PARAM *p)
+{
+    if (p != NULL)
+        p->return_size = OSSL_PARAM_UNMODIFIED;
 }
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val)

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -27,7 +27,7 @@ OSSL_PARAM_set_int64, OSSL_PARAM_set_long, OSSL_PARAM_set_size_t,
 OSSL_PARAM_set_uint, OSSL_PARAM_set_uint32, OSSL_PARAM_set_uint64,
 OSSL_PARAM_set_ulong, OSSL_PARAM_set_BN, OSSL_PARAM_set_utf8_string,
 OSSL_PARAM_set_octet_string, OSSL_PARAM_set_utf8_ptr,
-OSSL_PARAM_set_octet_ptr
+OSSL_PARAM_set_octet_ptr, OSSL_PARAM_UNMODIFIED
 - OSSL_PARAM helpers
 
 =head1 SYNOPSIS
@@ -51,6 +51,8 @@ OSSL_PARAM_set_octet_ptr
  #define OSSL_PARAM_utf8_ptr(key, address, size)
  #define OSSL_PARAM_octet_ptr(key, address, size)
  #define OSSL_PARAM_END
+
+ #define OSSL_PARAM_UNMODIFIED
 
  OSSL_PARAM OSSL_PARAM_construct_TYPE(const char *key, TYPE *buf);
  OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
@@ -90,6 +92,9 @@ OSSL_PARAM_set_octet_ptr
                               size_t *used_len);
  int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                               size_t used_len);
+
+ int OSSL_PARAM_modified(const OSSL_PARAM *p);
+ void OSSL_PARAM_set_unmodified(OSSL_PARAM *p);
 
 =head1 DESCRIPTION
 
@@ -250,6 +255,16 @@ OSSL_PARAM_set_octet_ptr() sets the OCTET string pointer in the parameter
 referenced by B<p> to the values B<val>.
 The length of the OCTET string is provided by B<used_len>.
 
+The OSSL_PARAM_UNMODIFIED macro is used to detect if a parameter was set.  On
+creation, via either the macros or construct calls, the I<return_size> field
+is set to this.  If the parameter is set using the calls defined herein, the
+I<return_size> field is changed.
+
+OSSL_PARAM_modified() queries if the parameter has been set or not using the
+calls defined herein.
+
+OSSL_PARAM_set_unmodified() is used to reset unused indicator.
+
 =head1 RETURN VALUES
 
 OSSL_PARAM_construct_TYPE(), OSSL_PARAM_construct_BN(),
@@ -260,6 +275,8 @@ return a populated OSSL_PARAM structure.
 OSSL_PARAM_locate() and OSSL_PARAM_locate_const() return a pointer to
 the matching OSSL_PARAM object.  They return B<NULL> on error or when
 no object matching B<key> exists in the B<array>.
+
+OSSL_PARAM_modified() returns B<1> if the parameter was set and B<0> otherwise.
 
 All other functions return B<1> on success and B<0> on failure.
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -18,11 +18,13 @@
 extern "C" {
 # endif
 
+# define OSSL_PARAM_UNMODIFIED ((size_t)-1)
+
 # define OSSL_PARAM_END \
     { NULL, 0, NULL, 0, 0 }
 
 # define OSSL_PARAM_DEFN(key, type, addr, sz)    \
-    { (key), (type), (addr), (sz), 0 }
+    { (key), (type), (addr), (sz), OSSL_PARAM_UNMODIFIED }
 
 /* Basic parameter types without return sizes */
 # define OSSL_PARAM_int(key, addr) \
@@ -134,6 +136,9 @@ int OSSL_PARAM_get_octet_ptr(const OSSL_PARAM *p, const void **val,
                              size_t *used_len);
 int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                              size_t used_len);
+
+int OSSL_PARAM_modified(const OSSL_PARAM *p);
+void OSSL_PARAM_set_unmodified(OSSL_PARAM *p);
 
 # ifdef  __cplusplus
 }

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -69,6 +69,7 @@ static int test_param_type_extra(OSSL_PARAM *param, const unsigned char *cmp,
     const int sizet = bit32 && sizeof(size_t) > sizeof(int32_t);
     const int signd = param->data_type == OSSL_PARAM_INTEGER;
 
+    OSSL_PARAM_set_unmodified(param);
     if (signd) {
         if ((bit32 && !TEST_true(OSSL_PARAM_get_int32(param, &i32)))
             || !TEST_true(OSSL_PARAM_get_int64(param, &i64)))
@@ -80,6 +81,8 @@ static int test_param_type_extra(OSSL_PARAM *param, const unsigned char *cmp,
             || (sizet && !TEST_true(OSSL_PARAM_get_size_t(param, &s))))
             return 0;
     }
+    if (!TEST_false(OSSL_PARAM_modified(param)))
+        return 0;
 
     /* Check signed types */
     if (bit32) {
@@ -112,6 +115,8 @@ static int test_param_type_extra(OSSL_PARAM *param, const unsigned char *cmp,
                 || !TEST_size_t_eq((size_t)i64, 12345))
                 return 0;
         }
+        if (!TEST_true(OSSL_PARAM_modified(param)))
+            return 0;
     }
     return 1;
 }

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -467,8 +467,7 @@ static int test_case_variant(OSSL_PARAM *params, const struct provider_dispatch_
         || !TEST_size_t_eq(p->return_size, sizeof(p6_init)) /* "provider" value */
         || !TEST_str_eq(app_p6, p6_init)        /* "provider" value */
         || !TEST_char_eq(foo[0], app_foo_init)  /* Should remain untouched */
-        || !TEST_ptr(p = OSSL_PARAM_locate(params, "foo"))
-        || !TEST_int_eq(p->return_size, 0))
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "foo")))
         errcnt++;
 
     /*
@@ -519,8 +518,7 @@ static int test_case_variant(OSSL_PARAM *params, const struct provider_dispatch_
                            sizeof(app_p6_init)) /* app value */
         || !TEST_str_eq(app_p6, app_p6_init)    /* app value */
         || !TEST_char_eq(foo[0], app_foo_init)  /* Should remain untouched */
-        || !TEST_ptr(p = OSSL_PARAM_locate(params, "foo"))
-        || !TEST_int_eq(p->return_size, 0))
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "foo")))
         errcnt++;
 
  fin:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5077,3 +5077,5 @@ X509_REQ_verify_ex                      ?	3_0_0	EXIST::FUNCTION:
 X509_ALGOR_copy                         ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set0_signature                 ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set1_signature_algo            ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_modified                     ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_set_unmodified               ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Using the _return_size_ field as a sentinel for change detection.

- [x] documentation is added or updated
- [x] tests are added or updated
