### PR TITLE
dsa/dh_validate_private. return early if there is no private key

### DIFF
--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -322,6 +322,8 @@ static int dh_validate_public(DH *dh)
     const BIGNUM *pub_key = NULL;
 
     DH_get0_key(dh, &pub_key, NULL);
+    if (pub_key == NULL)
+        return 0;
     return DH_check_pub_key_ex(dh, pub_key);
 }
 

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -331,6 +331,8 @@ static int dh_validate_private(DH *dh)
     const BIGNUM *priv_key = NULL;
 
     DH_get0_key(dh, NULL, &priv_key);
+    if (priv_key == NULL)
+        return 0;
     return dh_check_priv_key(dh, priv_key, &status);;
 }
 

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -321,6 +321,8 @@ static int dsa_validate_private(DSA *dsa)
     const BIGNUM *priv_key = NULL;
 
     DSA_get0_key(dsa, NULL, &priv_key);
+    if (priv_key == NULL)
+        return 0;
     return dsa_check_priv_key(dsa, priv_key, &status);
 }
 

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -312,6 +312,8 @@ static int dsa_validate_public(DSA *dsa)
     const BIGNUM *pub_key = NULL;
 
     DSA_get0_key(dsa, &pub_key, NULL);
+    if (pub_key == NULL)
+        return 0;
     return dsa_check_pub_key(dsa, pub_key, &status);
 }
 

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1211,6 +1211,25 @@ static int test_fromdata_dsa_fips186_4(void)
 
     return ret;
 }
+
+static int test_check_dsa(void)
+{
+    int ret = 0;
+    EVP_PKEY_CTX *ctx = NULL;
+
+    if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL))
+        || !TEST_false(EVP_PKEY_check(key_ctx))
+        || !TEST_false(EVP_PKEY_public_check(key_ctx))
+        || !TEST_false(EVP_PKEY_private_check(key_ctx))
+        || !TEST_false(EVP_PKEY_pairwise_check(key_ctx)))
+       goto err;
+
+    ret = 1;
+ err:
+    EVP_PKEY_CTX_free(ctx);
+
+    return ret;
+}
 #endif /* OPENSSL_NO_DSA */
 
 
@@ -1231,6 +1250,7 @@ int setup_tests(void)
     ADD_TEST(test_fromdata_dh_named_group);
 #endif
 #ifndef OPENSSL_NO_DSA
+    ADD_TEST(test_check_dsa);
     ADD_TEST(test_fromdata_dsa_fips186_4);
 #endif
 #ifndef OPENSSL_NO_EC

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1218,10 +1218,10 @@ static int test_check_dsa(void)
     EVP_PKEY_CTX *ctx = NULL;
 
     if (!TEST_ptr(ctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL))
-        || !TEST_false(EVP_PKEY_check(key_ctx))
-        || !TEST_false(EVP_PKEY_public_check(key_ctx))
-        || !TEST_false(EVP_PKEY_private_check(key_ctx))
-        || !TEST_false(EVP_PKEY_pairwise_check(key_ctx)))
+        || !TEST_false(EVP_PKEY_check(ctx))
+        || !TEST_false(EVP_PKEY_public_check(ctx))
+        || !TEST_false(EVP_PKEY_private_check(ctx))
+        || !TEST_false(EVP_PKEY_pairwise_check(ctx)))
        goto err;
 
     ret = 1;


### PR DESCRIPTION
When a private key is validated and there is no private key, return early.
Affected functions: dsa_validate_private and dh_validate_private.
