### PR TITLE
WIP: Additional tests for CVE-2020-1967

### DIFF
--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -5582,18 +5582,8 @@ int ED25519_public_from_private(OPENSSL_CTX *ctx, uint8_t out_public_key[32],
 {
     uint8_t az[SHA512_DIGEST_LENGTH];
     ge_p3 A;
-    int r;
-    EVP_MD *sha512 = NULL;
 
-    sha512 = EVP_MD_fetch(ctx, SN_sha512, NULL);
-    if (sha512 == NULL)
-        return 0;
-    r = EVP_Digest(private_key, 32, az, NULL, sha512, NULL);
-    EVP_MD_free(sha512);
-    if (!r) {
-        OPENSSL_cleanse(az, sizeof(az));
-        return 0;
-    }
+    SHA512(private_key, 32, az);
 
     az[0] &= 248;
     az[31] &= 63;

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -46,7 +46,9 @@ use constant {
     SIGALGS_CERT_PKCS => 8,
     SIGALGS_CERT_INVALID => 9,
     UNRECOGNIZED_SIGALGS_CERT => 10,
-    UNRECOGNIZED_SIGALG => 11
+    UNRECOGNIZED_SIGALG => 11,
+    UNRECOGNIZED_CR_SIGALGS_CERT => 12,
+    UNRECOGNIZED_CR_SIGALG => 13
 };
 
 #Note: Throughout this test we override the default ciphersuites where TLSv1.2
@@ -55,7 +57,7 @@ use constant {
 
 #Test 1: Default sig algs should succeed
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 26;
+plan tests => 28;
 ok(TLSProxy::Message->success, "Default sigalgs");
 my $testtype;
 
@@ -285,7 +287,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip "TLS 1.3 disabled", 2 if disabled("tls1_3");
+    skip "TLS 1.3 disabled", 4 if disabled("tls1_3");
     #Test 25: Send an unrecognized signature_algorithms_cert
     #        We should be able to skip over the unrecognized value and use a
     #        valid one that appears later in the list.
@@ -313,6 +315,38 @@ SKIP: {
             " -xkey " . srctop_file("test", "certs", "serverkey.pem") .
             " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
     $testtype = UNRECOGNIZED_SIGALG;
+    $proxy->start();
+    ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
+
+    #Test 27: Send an unrecognized signature_algorithms_cert in CR
+    #        We should be able to skip over the unrecognized value and use a
+    #        valid one that appears later in the list.
+    $proxy->clear();
+    $proxy->filter(\&inject_unrecognized_sigalg);
+    # Use -xcert to get SSL_check_chain() to run in the cert_cb.  This is
+    # needed to trigger (e.g.) CVE-2020-1967
+    $proxy->clientflags("-tls1_3" .
+            " -xcert " . srctop_file("test", "certs", "client-ed25519-cert.pem") .
+            " -xkey " . srctop_file("test", "certs", "client-ed25519-key.pem") .
+            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
+    # Request a certificate from the client
+    $proxy->serverflags("-verify 3");
+    $testtype = UNRECOGNIZED_CR_SIGALGS_CERT;
+    $proxy->start();
+    ok(TLSProxy::Message->success(),
+       "Unrecognized sigalg_cert in CertificateRequest");
+
+    #Test 28: Send an unrecognized signature_algorithms in CR
+    #        We should be able to skip over the unrecognized value and use a
+    #        valid one that appears later in the list.
+    $proxy->clear();
+    $proxy->filter(\&inject_unrecognized_sigalg);
+    $proxy->clientflags("-tls1_3" .
+            " -xcert " . srctop_file("test", "certs", "client-ed25519-cert.pem") .
+            " -xkey " . srctop_file("test", "certs", "client-ed25519-key.pem") .
+            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
+    $proxy->serverflags("-verify 3");
+    $testtype = UNRECOGNIZED_CR_SIGALG;
     $proxy->start();
     ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
 }
@@ -467,14 +501,23 @@ sub inject_unrecognized_sigalg
 {
     my $proxy = shift;
     my $type;
+    my $message;
 
-    # We're only interested in the initial ClientHello
-    if ($proxy->flight != 0) {
+    # We're only interested in the ClientHello and CertificateRequest
+    if ($proxy->flight == 0 && ($testtype == UNRECOGNIZED_SIGALGS_CERT
+                                  || $testtype == UNRECOGNIZED_SIGALG)) {
+        $message = ${$proxy->message_list}[0];
+    } elsif ($proxy->flight == 1 && ($testtype == UNRECOGNIZED_CR_SIGALGS_CERT
+                                     || $testtype == UNRECOGNIZED_CR_SIGALG)) {
+        $message = ${$proxy->message_list}[3];
+    } else {
         return;
     }
-    if ($testtype == UNRECOGNIZED_SIGALGS_CERT) {
+    if ($testtype == UNRECOGNIZED_SIGALGS_CERT
+        || $testtype == UNRECOGNIZED_CR_SIGALGS_CERT) {
         $type = TLSProxy::Message::EXT_SIG_ALGS_CERT;
-    } elsif ($testtype == UNRECOGNIZED_SIGALG) {
+    } elsif ($testtype == UNRECOGNIZED_SIGALG
+             || $testtype == UNRECOGNIZED_CR_SIGALG) {
         $type = TLSProxy::Message::EXT_SIG_ALGS;
     } else {
         return;
@@ -485,7 +528,6 @@ sub inject_unrecognized_sigalg
         0xfe, 0x18, #private use
         0x04, 0x01, #rsa_pkcs1_sha256
         0x08, 0x04; #rsa_pss_rsae_sha256;
-    my $message = ${$proxy->message_list}[0];
     $message->set_extension($type, $ext);
     $message->repack;
 }

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -286,70 +286,65 @@ SKIP: {
     ok(TLSProxy::Message->fail, "No matching certificate for sigalgs_cert");
 }
 
-SKIP: {
-    skip "TLS 1.3 disabled", 4 if disabled("tls1_3");
-    #Test 25: Send an unrecognized signature_algorithms_cert
-    #        We should be able to skip over the unrecognized value and use a
-    #        valid one that appears later in the list.
-    $proxy->clear();
-    $proxy->filter(\&inject_unrecognized_sigalg);
-    $proxy->clientflags("-tls1_3");
-    # Use -xcert to get SSL_check_chain() to run in the cert_cb.  This is
-    # needed to trigger (e.g.) CVE-2020-1967
-    $proxy->serverflags("" .
-            " -xcert " . srctop_file("test", "certs", "servercert.pem") .
-            " -xkey " . srctop_file("test", "certs", "serverkey.pem") .
-            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
-    $testtype = UNRECOGNIZED_SIGALGS_CERT;
-    $proxy->start();
-    ok(TLSProxy::Message->success(), "Unrecognized sigalg_cert in ClientHello");
+#Test 25: Send an unrecognized signature_algorithms_cert
+#        We should be able to skip over the unrecognized value and use a
+#        valid one that appears later in the list.
+$proxy->clear();
+$proxy->filter(\&inject_unrecognized_sigalg);
+# Use -xcert to get SSL_check_chain() to run in the cert_cb.  This is
+# needed to trigger (e.g.) CVE-2020-1967
+$proxy->serverflags("" .
+	" -xcert " . srctop_file("test", "certs", "servercert.pem") .
+	" -xkey " . srctop_file("test", "certs", "serverkey.pem") .
+	" -xchain " . srctop_file("test", "certs", "rootcert.pem"));
+$testtype = UNRECOGNIZED_SIGALGS_CERT;
+$proxy->start();
+ok(TLSProxy::Message->success(), "Unrecognized sigalg_cert in ClientHello");
 
-    #Test 26: Send an unrecognized signature_algorithms
-    #        We should be able to skip over the unrecognized value and use a
-    #        valid one that appears later in the list.
-    $proxy->clear();
-    $proxy->filter(\&inject_unrecognized_sigalg);
-    $proxy->clientflags("-tls1_3");
-    $proxy->serverflags("" .
-            " -xcert " . srctop_file("test", "certs", "servercert.pem") .
-            " -xkey " . srctop_file("test", "certs", "serverkey.pem") .
-            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
-    $testtype = UNRECOGNIZED_SIGALG;
-    $proxy->start();
-    ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
+#Test 26: Send an unrecognized signature_algorithms
+#        We should be able to skip over the unrecognized value and use a
+#        valid one that appears later in the list.
+$proxy->clear();
+$proxy->filter(\&inject_unrecognized_sigalg);
+$proxy->serverflags("" .
+	" -xcert " . srctop_file("test", "certs", "servercert.pem") .
+	" -xkey " . srctop_file("test", "certs", "serverkey.pem") .
+	" -xchain " . srctop_file("test", "certs", "rootcert.pem"));
+$testtype = UNRECOGNIZED_SIGALG;
+$proxy->start();
+ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
 
-    #Test 27: Send an unrecognized signature_algorithms_cert in CR
-    #        We should be able to skip over the unrecognized value and use a
-    #        valid one that appears later in the list.
-    $proxy->clear();
-    $proxy->filter(\&inject_unrecognized_sigalg);
-    # Use -xcert to get SSL_check_chain() to run in the cert_cb.  This is
-    # needed to trigger (e.g.) CVE-2020-1967
-    $proxy->clientflags("-tls1_3" .
-            " -xcert " . srctop_file("test", "certs", "client-ed25519-cert.pem") .
-            " -xkey " . srctop_file("test", "certs", "client-ed25519-key.pem") .
-            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
-    # Request a certificate from the client
-    $proxy->serverflags("-verify 3");
-    $testtype = UNRECOGNIZED_CR_SIGALGS_CERT;
-    $proxy->start();
-    ok(TLSProxy::Message->success(),
-       "Unrecognized sigalg_cert in CertificateRequest");
+#Test 27: Send an unrecognized signature_algorithms_cert in CR
+#        We should be able to skip over the unrecognized value and use a
+#        valid one that appears later in the list.
+$proxy->clear();
+$proxy->filter(\&inject_unrecognized_sigalg);
+# Use -xcert to get SSL_check_chain() to run in the cert_cb.  This is
+# needed to trigger (e.g.) CVE-2020-1967
+$proxy->clientflags("-xcert " .
+        srctop_file("test", "certs", "client-ed25519-cert.pem") .
+	" -xkey " . srctop_file("test", "certs", "client-ed25519-key.pem") .
+	" -xchain " . srctop_file("test", "certs", "rootcert.pem"));
+# Request a certificate from the client
+$proxy->serverflags("-verify 3");
+$testtype = UNRECOGNIZED_CR_SIGALGS_CERT;
+$proxy->start();
+ok(TLSProxy::Message->success(),
+   "Unrecognized sigalg_cert in CertificateRequest");
 
-    #Test 28: Send an unrecognized signature_algorithms in CR
-    #        We should be able to skip over the unrecognized value and use a
-    #        valid one that appears later in the list.
-    $proxy->clear();
-    $proxy->filter(\&inject_unrecognized_sigalg);
-    $proxy->clientflags("-tls1_3" .
-            " -xcert " . srctop_file("test", "certs", "client-ed25519-cert.pem") .
-            " -xkey " . srctop_file("test", "certs", "client-ed25519-key.pem") .
-            " -xchain " . srctop_file("test", "certs", "rootcert.pem"));
-    $proxy->serverflags("-verify 3");
-    $testtype = UNRECOGNIZED_CR_SIGALG;
-    $proxy->start();
-    ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
-}
+#Test 28: Send an unrecognized signature_algorithms in CR
+#        We should be able to skip over the unrecognized value and use a
+#        valid one that appears later in the list.
+$proxy->clear();
+$proxy->filter(\&inject_unrecognized_sigalg);
+$proxy->clientflags("-xcert " .
+        srctop_file("test", "certs", "client-ed25519-cert.pem") .
+	" -xkey " . srctop_file("test", "certs", "client-ed25519-key.pem") .
+	" -xchain " . srctop_file("test", "certs", "rootcert.pem"));
+$proxy->serverflags("-verify 3");
+$testtype = UNRECOGNIZED_CR_SIGALG;
+$proxy->start();
+ok(TLSProxy::Message->success(), "Unrecognized sigalg in ClientHello");
 
 
 

--- a/util/perl/TLSProxy/CertificateRequest.pm
+++ b/util/perl/TLSProxy/CertificateRequest.pm
@@ -29,6 +29,8 @@ sub new
         $startoffset,
         $message_frag_lens);
 
+    $self->{request_ctx_len} = 0;
+    $self->{request_ctx} = "";
     $self->{extension_data} = "";
 
     return $self;
@@ -42,6 +44,8 @@ sub parse
     if (TLSProxy::Proxy->is_tls13()) {
         my $request_ctx_len = unpack('C', $self->data);
         my $request_ctx = substr($self->data, $ptr, $request_ctx_len);
+        $self->{request_ctx_len} = $request_ctx_len;
+        $self->{request_ctx} = $request_ctx;
         $ptr += $request_ctx_len;
 
         my $extensions_len = unpack('n', substr($self->data, $ptr));
@@ -78,7 +82,9 @@ sub set_message_contents
         $extensions .= $extdata;
     }
 
-    $data = pack('n', length($extensions));
+    $data = pack('C', $self->{request_ctx_len});
+    $data .= $self->{request_ctx};
+    $data .= pack('n', length($extensions));
     $data .= $extensions;
     $self->data($data);
 }


### PR DESCRIPTION
Add some tests for the client-side part of CVE-2020-1967.
In order to make them work, some bugfixes and improvements to TLSProxy are also necessary.
Furthermore, while the bug was specific to TLS 1.3, the scenarios being tested should succeed regardless of TLS version, so remove the specificity from the tests.

This is WIP because the last commit reverts a change that was needed for 3.0 (making things libctx-aware) but the tests fail without it.  When using an Ed25519 client cert (for `SSL_check_chain()`), the computation of public key from private key produces an incorrect result and so the client fails the handshake for reasons unrelated to the test scenario, but none of the relevant code in https://github.com/openssl/openssl/pull/11371/commits/bde75d75028ce551d383d0ec9d3275836ffd27f7 seems obviously erroneous to me.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
