### PR TITLE
Use the param modified sentinel in existing code.

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -76,13 +76,15 @@ int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type)
             goto err;
 
         /* ... but, we should get a return size too! */
-        if (params[0].return_size != 0
+        if (OSSL_PARAM_modified(params)
+            && params[0].return_size != 0
             && (der = OPENSSL_malloc(params[0].return_size)) != NULL) {
             params[0].data = der;
             params[0].data_size = params[0].return_size;
-            params[0].return_size = 0;
+            OSSL_PARAM_set_all_unmodified(params);
             derp = der;
             if (EVP_CIPHER_CTX_get_params(c, params)
+                && OSSL_PARAM_modified(params)
                 && d2i_ASN1_TYPE(&type, (const unsigned char **)&derp,
                                  params[0].return_size) != NULL) {
                 ret = 1;

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -432,25 +432,23 @@ int evp_keymgmt_util_get_deflt_digest_name(EVP_KEYMGMT *keymgmt,
     params[0] =
         OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_DEFAULT_DIGEST,
                                          mddefault, sizeof(mddefault));
-    params[0].return_size = sizeof(mddefault) + 1;
     params[1] =
         OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_MANDATORY_DIGEST,
                                          mdmandatory,
                                          sizeof(mdmandatory));
-    params[1].return_size = sizeof(mdmandatory) + 1;
     params[2] = OSSL_PARAM_construct_end();
 
     if (!evp_keymgmt_get_params(keymgmt, keydata, params))
         return 0;
 
-    if (params[1].return_size != sizeof(mdmandatory) + 1) {
-        if (params[1].return_size == 1) /* Only a NUL byte */
+    if (OSSL_PARAM_modified(params + 1)) {
+        if (params[1].return_size <= 1) /* Only a NUL byte */
             result = SN_undef;
         else
             result = mdmandatory;
         rv = 2;
-    } else if (params[0].return_size != sizeof(mddefault) + 1) {
-        if (params[0].return_size == 1) /* Only a NUL byte */
+    } else if (OSSL_PARAM_modified(params)) {
+        if (params[0].return_size <= 1) /* Only a NUL byte */
             result = SN_undef;
         else
             result = mddefault;

--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -312,7 +312,7 @@ static OSSL_PARAM *param_bld_convert(OSSL_PARAM_BLD *bld, OSSL_PARAM *param,
         param[i].key = pd->key;
         param[i].data_type = pd->type;
         param[i].data_size = pd->size;
-        param[i].return_size = 0;
+        param[i].return_size = OSSL_PARAM_UNMODIFIED;
 
         if (pd->secure) {
             p = secure;

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -45,10 +45,11 @@ int OSSL_PARAM_modified(const OSSL_PARAM *p)
     return p != NULL && p->return_size != OSSL_PARAM_UNMODIFIED;
 }
 
-void OSSL_PARAM_set_unmodified(OSSL_PARAM *p)
+void OSSL_PARAM_set_all_unmodified(OSSL_PARAM *p)
 {
     if (p != NULL)
-        p->return_size = OSSL_PARAM_UNMODIFIED;
+        while (p->key != NULL)
+            p++->return_size = OSSL_PARAM_UNMODIFIED;
 }
 
 int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val)

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -157,7 +157,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
     *to = *paramdef;
     to->data = buf;
     to->data_size = buf_n;
-    to->return_size = 0;
+    to->return_size = OSSL_PARAM_UNMODIFIED;
 
     return 1;
 }

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -93,8 +93,8 @@ OSSL_PARAM_set_octet_ptr, OSSL_PARAM_UNMODIFIED
  int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                               size_t used_len);
 
- int OSSL_PARAM_modified(const OSSL_PARAM *p);
- void OSSL_PARAM_set_unmodified(OSSL_PARAM *p);
+ int OSSL_PARAM_modified(const OSSL_PARAM *param);
+ void OSSL_PARAM_set_all_unmodified(OSSL_PARAM *params);
 
 =head1 DESCRIPTION
 
@@ -260,10 +260,11 @@ creation, via either the macros or construct calls, the I<return_size> field
 is set to this.  If the parameter is set using the calls defined herein, the
 I<return_size> field is changed.
 
-OSSL_PARAM_modified() queries if the parameter has been set or not using the
-calls defined herein.
+OSSL_PARAM_modified() queries if the parameter B<param> has been set or not
+using the calls defined herein.
 
-OSSL_PARAM_set_unmodified() is used to reset unused indicator.
+OSSL_PARAM_set_all_unmodified() resets the unused indicator for all parameters
+in the array B<params>.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -138,7 +138,7 @@ int OSSL_PARAM_set_octet_ptr(OSSL_PARAM *p, const void *val,
                              size_t used_len);
 
 int OSSL_PARAM_modified(const OSSL_PARAM *p);
-void OSSL_PARAM_set_unmodified(OSSL_PARAM *p);
+void OSSL_PARAM_set_all_unmodified(OSSL_PARAM *p);
 
 # ifdef  __cplusplus
 }

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -69,7 +69,11 @@ static int test_param_type_extra(OSSL_PARAM *param, const unsigned char *cmp,
     const int sizet = bit32 && sizeof(size_t) > sizeof(int32_t);
     const int signd = param->data_type == OSSL_PARAM_INTEGER;
 
-    OSSL_PARAM_set_all_unmodified(param);
+    /* 
+     * Set the unmodified sentinal directly because there is no param array
+     * for these tests.
+     */
+    param->return_size = OSSL_PARAM_UNMODIFIED;
     if (signd) {
         if ((bit32 && !TEST_true(OSSL_PARAM_get_int32(param, &i32)))
             || !TEST_true(OSSL_PARAM_get_int64(param, &i64)))
@@ -568,6 +572,33 @@ err:
     return ret;
 }
 
+static int test_param_modified(void)
+{
+    OSSL_PARAM param[3] = { OSSL_PARAM_int("a", NULL),
+                            OSSL_PARAM_int("b", NULL),
+                            OSSL_PARAM_END };
+    int a, b;
+
+    param->data = &a;
+    param[1].data = &b;
+    if (!TEST_false(OSSL_PARAM_modified(param))
+            && !TEST_true(OSSL_PARAM_set_int32(param, 1234))
+            && !TEST_true(OSSL_PARAM_modified(param))
+            && !TEST_false(OSSL_PARAM_modified(param + 1))
+            && !TEST_true(OSSL_PARAM_set_int32(param + 1, 1))
+            && !TEST_true(OSSL_PARAM_modified(param + 1)))
+        return 0;
+    OSSL_PARAM_set_all_unmodified(param);
+    if (!TEST_false(OSSL_PARAM_modified(param))
+            && !TEST_true(OSSL_PARAM_set_int32(param, 4321))
+            && !TEST_true(OSSL_PARAM_modified(param))
+            && !TEST_false(OSSL_PARAM_modified(param + 1))
+            && !TEST_true(OSSL_PARAM_set_int32(param + 1, 2))
+            && !TEST_true(OSSL_PARAM_modified(param + 1)))
+        return 0;
+    return 1;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_param_int, OSSL_NELEM(raw_values));
@@ -582,5 +613,6 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_param_bignum, OSSL_NELEM(raw_values));
     ADD_TEST(test_param_real);
     ADD_TEST(test_param_construct);
+    ADD_TEST(test_param_modified);
     return 1;
 }

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -69,7 +69,7 @@ static int test_param_type_extra(OSSL_PARAM *param, const unsigned char *cmp,
     const int sizet = bit32 && sizeof(size_t) > sizeof(int32_t);
     const int signd = param->data_type == OSSL_PARAM_INTEGER;
 
-    /* 
+    /*
      * Set the unmodified sentinal directly because there is no param array
      * for these tests.
      */

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -69,7 +69,7 @@ static int test_param_type_extra(OSSL_PARAM *param, const unsigned char *cmp,
     const int sizet = bit32 && sizeof(size_t) > sizeof(int32_t);
     const int signd = param->data_type == OSSL_PARAM_INTEGER;
 
-    OSSL_PARAM_set_unmodified(param);
+    OSSL_PARAM_set_all_unmodified(param);
     if (signd) {
         if ((bit32 && !TEST_true(OSSL_PARAM_get_int32(param, &i32)))
             || !TEST_true(OSSL_PARAM_get_int64(param, &i64)))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5078,4 +5078,4 @@ X509_ALGOR_copy                         ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set0_signature                 ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set1_signature_algo            ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_modified                     ?	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_set_unmodified               ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_set_all_unmodified           ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION

Update existing code so that the param modified sentinel is using instead of fiddling with the return size directly.

Also added the sentinel to the param builder.
