### PR TITLE
FIPS: remove algorithms that are not being validated.

### DIFF
--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -367,12 +367,6 @@ static const OSSL_ALGORITHM fips_digests[] = {
     { "SHA3-256", "provider=fips,fips=yes", sha3_256_functions },
     { "SHA3-384", "provider=fips,fips=yes", sha3_384_functions },
     { "SHA3-512", "provider=fips,fips=yes", sha3_512_functions },
-    /*
-     * KECCAK-KMAC-128 and KECCAK-KMAC-256 as hashes are mostly useful for
-     * KMAC128 and KMAC256.
-     */
-    { "KECCAK-KMAC-128:KECCAK-KMAC128", "provider=fips,fips=yes", keccak_kmac_128_functions },
-    { "KECCAK-KMAC-256:KECCAK-KMAC256", "provider=fips,fips=yes", keccak_kmac_256_functions },
 
     /* Non-FIPS algorithm to support oneshot_hash in the Ed448 code */
     { "SHAKE-256:SHAKE256", "provider=fips,fips=no", shake_256_functions },

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -424,13 +424,8 @@ static const OSSL_ALGORITHM_CAPABLE fips_ciphers[] = {
 static OSSL_ALGORITHM exported_fips_ciphers[OSSL_NELEM(fips_ciphers)];
 
 static const OSSL_ALGORITHM fips_macs[] = {
-#ifndef OPENSSL_NO_CMAC
-    { "CMAC", "provider=fips,fips=yes", cmac_functions },
-#endif
     { "GMAC", "provider=fips,fips=yes", gmac_functions },
     { "HMAC", "provider=fips,fips=yes", hmac_functions },
-    { "KMAC-128:KMAC128", "provider=fips,fips=yes", kmac128_functions },
-    { "KMAC-256:KMAC256", "provider=fips,fips=yes", kmac256_functions },
     { NULL, NULL, NULL }
 };
 
@@ -439,7 +434,6 @@ static const OSSL_ALGORITHM fips_kdfs[] = {
     { "SSKDF", "provider=fips,fips=yes", kdf_sskdf_functions },
     { "PBKDF2", "provider=fips,fips=yes", kdf_pbkdf2_functions },
     { "TLS1-PRF", "provider=fips,fips=yes", kdf_tls1_prf_functions },
-    { "KBKDF", "provider=fips,fips=yes", kdf_kbkdf_functions },
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
Several MACs and one KDF are included in the FIPS provider with the property
"fips=yes" set but are not listed as being part of the OpenSSL validation.

This removes them from the FIPS provider.

