### PR TITLE
add info on the CMP implementation and HTTP client to NEWS and CHANGES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,18 @@ OpenSSL 3.0
 
    *Richard Levitte*
 
+ * Added an implementation of CMP and CRMF (RFC 4210, RFC 4211 RFC 6712).
+   This adds crypto/cmp/, crpyto/crmf/, and test/cmp_*.
+   See L<OSSL_CMP_exec_IR_ses(3)> as starting point.
+
+   *David von Oheimb*
+
+ * Generalized the HTTP client code from crypto/ocsp/ into crpyto/http/.
+   The legacy OCSP-focused and only partly documented API is retained.
+   See L<OSSL_CMP_MSG_http_perform(3)> etc. for details.
+
+   *David von Oheimb*
+
  * All of the low level RSA functions have been deprecated including:
 
    RSA_new_method, RSA_bits, RSA_size, RSA_security_bits,

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,12 @@ OpenSSL 3.0
     authenticate servers or clients.
   * enable-crypto-mdebug and enable-crypto-mdebug-backtrace were mostly
     disabled; the project uses address sanitize/leak-detect instead.
+  * Added a Certificate Management Protocol (CMP, RFC 4210) implementation
+    also covering CRMF (RFC 4211) and HTTP transfer (RFC 6712).
+    It is part of the crypto lib, while a 'cmp' app using it is in preparation.
+    All widely used CMP features are supported for both clients and servers.
+  * Added a proper HTTP(S) client to libcrypto supporting GET and POST,
+    redirection, plain and ASN.1-encoded contents, proxies, and timeouts.
   * Added OSSL_SERIALIZER, a generic serializer API.
   * Added OSSL_PARAM_BLD, an easier to use API to OSSL_PARAM.
   * Added error raising macros, ERR_raise() and ERR_raise_data().


### PR DESCRIPTION
This fixes most of #11606 
and in addition mentions also the generalized HTTP client #10667, which came up along with the CMP and CRMF contribution (#7646, #11470 etc.).

- [x] documentation is added or updated

