### PR TITLE
FIPS: set the ECX algotihms to "fips=yes".

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,8 +22,7 @@ OpenSSL 3.0
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 3.0 [under development] ###
 
   * The X25519, X448, Ed25519, Ed448 and SHAKE256 algorithms are included in
-    the FIPS provider.  None have the "fips=yes" property set and, as such,
-    will not be accidentially used.
+    the FIPS provider.
   * The algorithm specific public key command line applications have
     been deprecated.  These include dhparam, gendsa and others.  The pkey
     alternatives should be used intead: pkey, pkeyparam and genpkey.

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -276,8 +276,8 @@ Should it be needed (if other providers are loaded and offer
 implementations of the same algorithms), the property "provider=fips" can
 be used as a search criterion for these implementations. All approved algorithm
 implementations in the FIPS provider can also be selected with the property
-"fips=yes". The FIPS provider also contains a number of non-approved algorithm
-implementations and these can be selected with the property "fips=no".
+"fips=yes". The FIPS provider could also contain some non-approved
+algorithm implementations and these can be selected with the property "fips=no".
 
 =head2 Legacy provider
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -369,7 +369,7 @@ static const OSSL_ALGORITHM fips_digests[] = {
     { "SHA3-512", "provider=fips,fips=yes", sha3_512_functions },
 
     /* Non-FIPS algorithm to support oneshot_hash in the Ed448 code */
-    { "SHAKE-256:SHAKE256", "provider=fips,fips=no", shake_256_functions },
+    { "SHAKE-256:SHAKE256", "provider=fips,fips=yes", shake_256_functions },
     { NULL, NULL, NULL }
 };
 
@@ -437,8 +437,8 @@ static const OSSL_ALGORITHM fips_keyexch[] = {
 #endif
 #ifndef OPENSSL_NO_EC
     { "ECDH", "provider=fips,fips=yes", ecdh_keyexch_functions },
-    { "X25519", "provider=fips,fips=no", x25519_keyexch_functions },
-    { "X448", "provider=fips,fips=no", x448_keyexch_functions },
+    { "X25519", "provider=fips,fips=yes", x25519_keyexch_functions },
+    { "X448", "provider=fips,fips=yes", x448_keyexch_functions },
 #endif
     { NULL, NULL, NULL }
 };
@@ -449,8 +449,8 @@ static const OSSL_ALGORITHM fips_signature[] = {
 #endif
     { "RSA:rsaEncryption", "provider=fips,fips=yes", rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
-    { "ED25519", "provider=fips,fips=no", ed25519_signature_functions },
-    { "ED448", "provider=fips,fips=no", ed448_signature_functions },
+    { "ED25519", "provider=fips,fips=yes", ed25519_signature_functions },
+    { "ED448", "provider=fips,fips=yes", ed448_signature_functions },
     { "ECDSA", "provider=fips,fips=yes", ecdsa_signature_functions },
 #endif
     { NULL, NULL, NULL }
@@ -471,10 +471,10 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
     { "RSA:rsaEncryption", "provider=fips,fips=yes", rsa_keymgmt_functions },
 #ifndef OPENSSL_NO_EC
     { "EC:id-ecPublicKey", "provider=fips,fips=yes", ec_keymgmt_functions },
-    { "X25519", "provider=fips,fips=no", x25519_keymgmt_functions },
-    { "X448", "provider=fips,fips=no", x448_keymgmt_functions },
-    { "ED25519", "provider=fips,fips=no", ed25519_keymgmt_functions },
-    { "ED448", "provider=fips,fips=no", ed448_keymgmt_functions },
+    { "X25519", "provider=fips,fips=yes", x25519_keymgmt_functions },
+    { "X448", "provider=fips,fips=yes", x448_keymgmt_functions },
+    { "ED25519", "provider=fips,fips=yes", ed25519_keymgmt_functions },
+    { "ED448", "provider=fips,fips=yes", ed448_keymgmt_functions },
 #endif
     { NULL, NULL, NULL }
 };


### PR DESCRIPTION
It seems likely that these can be vendor affirmed and if so, they are better being
tagged as FIPS approved.

- [x] documentation is added or updated
- [ ] tests are added or updated
