### PR TITLE
Fix type cast in SSL_CTX_set1_groups macro

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1417,7 +1417,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_get1_groups(s, glist) \
         SSL_ctrl(s,SSL_CTRL_GET_GROUPS,0,(int*)(glist))
 # define SSL_CTX_set1_groups(ctx, glist, glistlen) \
-        SSL_CTX_ctrl(ctx,SSL_CTRL_SET_GROUPS,glistlen,(char *)(glist))
+        SSL_CTX_ctrl(ctx,SSL_CTRL_SET_GROUPS,glistlen,(int *)(glist))
 # define SSL_CTX_set1_groups_list(ctx, s) \
         SSL_CTX_ctrl(ctx,SSL_CTRL_SET_GROUPS_LIST,0,(char *)(s))
 # define SSL_set1_groups(s, glist, glistlen) \


### PR DESCRIPTION
The macro casts the glist parameter to char*
instead of (int *) like the documentation of the function suggest.

Also the function tls1_set_groups that is called from SSL_CTX_ctrl
takes an int * argument. This looks like a copy&paste error from
SSL_CTX_set1_groups_list function.

CLA: trivial
Signed-off-by: Arne Schwabe <arne@rfc2549.org>
