### PR TITLE
Fix dev/release-aux-openssl-announce-pre-release.tmpl

### DIFF
--- a/dev/release-aux/openssl-announce-pre-release.tmpl
+++ b/dev/release-aux/openssl-announce-pre-release.tmpl
@@ -7,10 +7,7 @@
 
    OpenSSL $series is currently in $label.
 
-   OpenSSL $release_text has now been made available.  For details of
-   the changes, see the release notes at:
-
-        https://www.openssl.org/news/openssl-$series-notes.html
+   OpenSSL $release_text has now been made available.
 
    Note: This OpenSSL pre-release has been provided for testing ONLY.
    It should NOT be used for security critical purposes.
@@ -39,7 +36,7 @@
     openssl sha1 $tarfile
     openssl sha256 $tarfile
 
-   Please download and check this $LABEL release as soon as possible.
+   Please download and check this $label release as soon as possible.
    To report a bug, open an issue on GitHub:
 
     https://github.com/openssl/openssl/issues


### PR DESCRIPTION
$LABEL -> $label

Removed link to release notes, as we don't produce them for master.
