### PR TITLE
Fix links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,18 +70,20 @@ guidelines:
     documentation changes are clean.
 
  7. For user visible changes (API changes, behaviour changes, ...),
-    consider adding a note in [CHANGES](CHANGES).  This could be a summarising
-    description of the change, and could explain the grander details.
+    consider adding a note in [CHANGES.md](CHANGES.md).
+    This could be a summarising description of the change, and could
+    explain the grander details.
     Have a look through existing entries for inspiration.
     Please note that this is NOT simply a copy of git-log one-liners.
-    Also note that security fixes get an entry in CHANGES.
+    Also note that security fixes get an entry in CHANGES.md.
     This file helps users get more in depth information of what comes
     with a specific release without having to sift through the higher
     noise ratio in git-log.
 
  8. For larger or more important user visible changes, as well as
-    security fixes, please add a line in [NEWS](NEWS).  On exception, it might be
-    worth adding a multi-line entry (such as the entry that announces all
-    the types that became opaque with OpenSSL 1.1.0).
+    security fixes, please add a line in [NEWS.md](NEWS.md).
+    On exception, it might be worth adding a multi-line entry (such as
+    the entry that announces all the types that became opaque with
+    OpenSSL 1.1.0).
     This file helps users get a very quick summary of what comes with a
     specific release, to see if an upgrade is worth the effort.


### PR DESCRIPTION
CHANGES and NEWS were renamed into CHANGES.md and NEWS.md; this commit
updates the references inside CONTRIBUTING.md to fix broken links.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
