### PR TITLE
Fix raw provider keys

### DIFF
--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -9,6 +9,8 @@
 
 #include <openssl/core_names.h>
 #include <openssl/params.h>
+#include <openssl/ec.h>
+#include <openssl/err.h>
 #include "crypto/ecx.h"
 #include "ecx_backend.h"
 
@@ -17,6 +19,31 @@
  * for legacy backends (EVP_PKEY_ASN1_METHOD and EVP_PKEY_METHOD) and provider
  * implementations alike.
  */
+
+int ecx_public_from_private(ECX_KEY *key)
+{
+    switch (key->type) {
+    case ECX_KEY_TYPE_X25519:
+        X25519_public_from_private(key->pubkey, key->privkey);
+        break;
+    case ECX_KEY_TYPE_ED25519:
+        if (!ED25519_public_from_private(key->libctx, key->pubkey, key->privkey)) {
+            ECerr(0, EC_R_FAILED_MAKING_PUBLIC_KEY);
+            return 0;
+        }
+        break;
+    case ECX_KEY_TYPE_X448:
+        X448_public_from_private(key->pubkey, key->privkey);
+        break;
+    case ECX_KEY_TYPE_ED448:
+        if (!ED448_public_from_private(key->libctx, key->pubkey, key->privkey)) {
+            ECerr(0, EC_R_FAILED_MAKING_PUBLIC_KEY);
+            return 0;
+        }
+        break;
+    }
+    return 1;
+}
 
 int ecx_key_fromdata(ECX_KEY *ecx, const OSSL_PARAM params[],
                      int include_private)
@@ -32,11 +59,8 @@ int ecx_key_fromdata(ECX_KEY *ecx, const OSSL_PARAM params[],
     if (include_private)
         param_priv_key =
             OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PRIV_KEY);
-    /*
-     * If a private key is present then a public key must also be present.
-     * Alternatively we've just got a public key.
-     */
-    if (param_pub_key == NULL)
+
+    if (param_pub_key == NULL && param_priv_key == NULL)
         return 0;
 
     if (param_priv_key != NULL
@@ -46,13 +70,17 @@ int ecx_key_fromdata(ECX_KEY *ecx, const OSSL_PARAM params[],
         return 0;
 
     pubkey = ecx->pubkey;
-    if (!OSSL_PARAM_get_octet_string(param_pub_key,
-                                     (void **)&pubkey,
-                                     sizeof(ecx->pubkey), &pubkeylen))
+    if (param_pub_key != NULL
+        && !OSSL_PARAM_get_octet_string(param_pub_key,
+                                        (void **)&pubkey,
+                                         sizeof(ecx->pubkey), &pubkeylen))
         return 0;
 
-    if (pubkeylen != ecx->keylen
+    if ((param_pub_key != NULL && pubkeylen != ecx->keylen)
         || (param_priv_key != NULL && privkeylen != ecx->keylen))
+        return 0;
+
+    if (param_pub_key == NULL && !ecx_public_from_private(ecx))
         return 0;
 
     ecx->haspubkey = 1;

--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -48,7 +48,7 @@ int ecx_public_from_private(ECX_KEY *key)
 int ecx_key_fromdata(ECX_KEY *ecx, const OSSL_PARAM params[],
                      int include_private)
 {
-    size_t privkeylen = 0, pubkeylen;
+    size_t privkeylen = 0, pubkeylen = 0;
     const OSSL_PARAM *param_priv_key = NULL, *param_pub_key;
     unsigned char *pubkey;
 

--- a/crypto/ec/ecx_backend.h
+++ b/crypto/ec/ecx_backend.h
@@ -13,8 +13,8 @@
                                      : ((id) == EVP_PKEY_X448 ? X448_KEYLEN \
                                                               : ED448_KEYLEN))
 #define KEYNID2TYPE(id) \
-    (IS25519(id) ?  ECX_KEY_TYPE_X25519 \
+    (IS25519(id) ? ((id) == EVP_PKEY_X25519 ? ECX_KEY_TYPE_X25519 \
+                                            : ECX_KEY_TYPE_ED25519) \
                  : ((id) == EVP_PKEY_X448 ? ECX_KEY_TYPE_X448 \
-                                          : ((id) == EVP_PKEY_ED25519 ? ECX_KEY_TYPE_ED25519 \
-                                                                      : ECX_KEY_TYPE_ED448)))
+                                          : ECX_KEY_TYPE_ED448))
 #define KEYLEN(p)       KEYLENID((p)->ameth->pkey_id)

--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -10,13 +10,14 @@
 #include <openssl/err.h>
 #include "crypto/ecx.h"
 
-ECX_KEY *ecx_key_new(ECX_KEY_TYPE type, int haspubkey)
+ECX_KEY *ecx_key_new(OPENSSL_CTX *libctx, ECX_KEY_TYPE type, int haspubkey)
 {
     ECX_KEY *ret = OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL)
         return NULL;
 
+    ret->libctx = libctx;
     ret->haspubkey = haspubkey;
     switch (type) {
     case ECX_KEY_TYPE_X25519:

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -59,7 +59,7 @@ static int ecx_key_op(EVP_PKEY *pkey, int id, const X509_ALGOR *palg,
         }
     }
 
-    key = ecx_key_new(KEYNID2TYPE(id), 1);
+    key = ecx_key_new(libctx, KEYNID2TYPE(id), 1);
     if (key == NULL) {
         ECerr(EC_F_ECX_KEY_OP, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -439,7 +439,7 @@ static int ecx_generic_import_from(const OSSL_PARAM params[], void *vpctx,
 {
     EVP_PKEY_CTX *pctx = vpctx;
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(pctx);
-    ECX_KEY *ecx = ecx_key_new(KEYNID2TYPE(keytype), 0);
+    ECX_KEY *ecx = ecx_key_new(pctx->libctx, KEYNID2TYPE(keytype), 0);
 
     if (ecx == NULL) {
         ERR_raise(ERR_LIB_DH, ERR_R_MALLOC_FAILURE);
@@ -947,7 +947,7 @@ static int s390x_pkey_ecx_keygen25519(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_X25519, 1);
+    ECX_KEY *key = ecx_key_new(ctx->libctx, ECX_KEY_TYPE_X25519, 1);
     unsigned char *privkey = NULL, *pubkey;
 
     if (key == NULL) {
@@ -989,7 +989,7 @@ static int s390x_pkey_ecx_keygen448(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_X448, 1);
+    ECX_KEY *key = ecx_key_new(ctx->libctx, ECX_KEY_TYPE_X448, 1);
     unsigned char *privkey = NULL, *pubkey;
 
     if (key == NULL) {
@@ -1034,7 +1034,7 @@ static int s390x_pkey_ecd_keygen25519(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
     };
     unsigned char x_dst[32], buff[SHA512_DIGEST_LENGTH];
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_ED25519, 1);
+    ECX_KEY *key = ecx_key_new(ctx->libctx, ECX_KEY_TYPE_ED25519, 1);
     unsigned char *privkey = NULL, *pubkey;
     unsigned int sz;
 
@@ -1091,7 +1091,7 @@ static int s390x_pkey_ecd_keygen448(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         0x24, 0xbc, 0xb6, 0x6e, 0x71, 0x46, 0x3f, 0x69, 0x00
     };
     unsigned char x_dst[57], buff[114];
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_ED448, 1);
+    ECX_KEY *key = ecx_key_new(ctx->libctx, ECX_KEY_TYPE_ED448, 1);
     unsigned char *privkey = NULL, *pubkey;
     EVP_MD_CTX *hashctx = NULL;
 

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -88,25 +88,9 @@ static int ecx_key_op(EVP_PKEY *pkey, int id, const X509_ALGOR *palg,
         } else {
             memcpy(privkey, p, KEYLENID(id));
         }
-        switch (id) {
-        case EVP_PKEY_X25519:
-            X25519_public_from_private(pubkey, privkey);
-            break;
-        case EVP_PKEY_ED25519:
-            if (!ED25519_public_from_private(libctx, pubkey, privkey)) {
-                ECerr(EC_F_ECX_KEY_OP, EC_R_FAILED_MAKING_PUBLIC_KEY);
-                goto err;
-            }
-            break;
-        case EVP_PKEY_X448:
-            X448_public_from_private(pubkey, privkey);
-            break;
-        case EVP_PKEY_ED448:
-            if (!ED448_public_from_private(libctx, pubkey, privkey)) {
-                ECerr(EC_F_ECX_KEY_OP, EC_R_FAILED_MAKING_PUBLIC_KEY);
-                goto err;
-            }
-            break;
+        if (!ecx_public_from_private(key)) {
+            ECerr(EC_F_ECX_KEY_OP, EC_R_FAILED_MAKING_PUBLIC_KEY);
+            goto err;
         }
     }
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -504,7 +504,7 @@ int EVP_PKEY_get_raw_private_key(const EVP_PKEY *pkey, unsigned char *priv,
     if (pkey->keymgmt != NULL) {
         struct raw_key_details_st raw_key;
 
-        raw_key.key = &priv;
+        raw_key.key = priv == NULL ? NULL : &priv;
         raw_key.len = len;
         raw_key.selection = OSSL_KEYMGMT_SELECT_PRIVATE_KEY;
 
@@ -537,7 +537,7 @@ int EVP_PKEY_get_raw_public_key(const EVP_PKEY *pkey, unsigned char *pub,
     if (pkey->keymgmt != NULL) {
         struct raw_key_details_st raw_key;
 
-        raw_key.key = &pub;
+        raw_key.key = pub == NULL ? NULL : &pub;
         raw_key.len = len;
         raw_key.selection = OSSL_KEYMGMT_SELECT_PUBLIC_KEY;
 

--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -125,6 +125,8 @@ static void free_all_params(OSSL_PARAM_BLD *bld)
 
 void OSSL_PARAM_BLD_free(OSSL_PARAM_BLD *bld)
 {
+    if (bld == NULL)
+        return;
     free_all_params(bld);
     sk_OSSL_PARAM_BLD_DEF_free(bld->params);
     OPENSSL_free(bld);

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -780,7 +780,7 @@ static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
 {
     size_t sz;
 
-    if (val == NULL || p == NULL || p->data_type != type)
+    if ((val == NULL && used_len == NULL) || p == NULL || p->data_type != type)
         return 0;
 
     sz = p->data_size;
@@ -792,6 +792,9 @@ static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
         return 1;
     if (p->data == NULL)
         return 0;
+
+    if (val == NULL)
+        return 1;
 
     if (*val == NULL) {
         char *const q = OPENSSL_malloc(sz);

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -59,7 +59,7 @@ EVP_PKEY_free() decrements the reference count of B<key> and, if the reference
 count is zero, frees it up. If B<key> is NULL, nothing is done.
 
 EVP_PKEY_new_raw_private_key_with_libctx() allocates a new B<EVP_PKEY>. Unless
-an engine should be used for the key type a provider for the key is found using
+an engine should be used for the key type, a provider for the key is found using
 the library context I<libctx> and the property query string I<propq>. The
 I<keytype> argument indicates what kind of key this is. The value should be a
 string for a public key algorithm that supports raw private keys, i.e one of
@@ -73,7 +73,7 @@ derived from the given private key data (if appropriate for the algorithm type).
 
 EVP_PKEY_new_raw_private_key() does the same as
 EVP_PKEY_new_raw_private_key_with_libctx() except that the default library
-context is and default property query is used instead. If B<e> is non-NULL then
+context and default property query are used instead. If B<e> is non-NULL then
 the new B<EVP_PKEY> structure is associated with the engine B<e>. The B<type>
 argument indicates what kind of key this is. The value should be a NID for a
 public key algorithm that supports raw private keys, i.e. one of

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -5,7 +5,9 @@
 EVP_PKEY_new,
 EVP_PKEY_up_ref,
 EVP_PKEY_free,
+EVP_PKEY_new_raw_private_key_with_libctx,
 EVP_PKEY_new_raw_private_key,
+EVP_PKEY_new_raw_public_key_with_libctx,
 EVP_PKEY_new_raw_public_key,
 EVP_PKEY_new_CMAC_key,
 EVP_PKEY_new_mac_key,
@@ -21,8 +23,18 @@ EVP_PKEY_get_raw_public_key
  int EVP_PKEY_up_ref(EVP_PKEY *key);
  void EVP_PKEY_free(EVP_PKEY *key);
 
+ EVP_PKEY *EVP_PKEY_new_raw_private_key_with_libctx(OPENSSL_CTX *libctx,
+                                                    const char *keytype,
+                                                    const char *propq,
+                                                    const unsigned char *key,
+                                                    size_t keylen);
  EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *e,
                                         const unsigned char *key, size_t keylen);
+ EVP_PKEY *EVP_PKEY_new_raw_public_key_with_libctx(OPENSSL_CTX *libctx,
+                                                   const char *keytype,
+                                                   const char *propq,
+                                                   const unsigned char *key,
+                                                   size_t keylen);
  EVP_PKEY *EVP_PKEY_new_raw_public_key(int type, ENGINE *e,
                                        const unsigned char *key, size_t keylen);
  EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
@@ -46,16 +58,34 @@ EVP_PKEY_up_ref() increments the reference count of B<key>.
 EVP_PKEY_free() decrements the reference count of B<key> and, if the reference
 count is zero, frees it up. If B<key> is NULL, nothing is done.
 
-EVP_PKEY_new_raw_private_key() allocates a new B<EVP_PKEY>. If B<e> is non-NULL
-then the new B<EVP_PKEY> structure is associated with the engine B<e>. The
-B<type> argument indicates what kind of key this is. The value should be a NID
-for a public key algorithm that supports raw private keys, i.e. one of
-B<EVP_PKEY_HMAC>, B<EVP_PKEY_POLY1305>, B<EVP_PKEY_SIPHASH>, B<EVP_PKEY_X25519>,
-B<EVP_PKEY_ED25519>, B<EVP_PKEY_X448> or B<EVP_PKEY_ED448>. B<key> points to the
-raw private key data for this B<EVP_PKEY> which should be of length B<keylen>.
-The length should be appropriate for the type of the key. The public key data
-will be automatically derived from the given private key data (if appropriate
-for the algorithm type).
+EVP_PKEY_new_raw_private_key_with_libctx() allocates a new B<EVP_PKEY>. Unless
+an engine should be used for the key type a provider for the key is found using
+the library context I<libctx> and the property query string I<propq>. The
+I<keytype> argument indicates what kind of key this is. The value should be a
+string for a public key algorithm that supports raw private keys, i.e one of
+"POLY1305", "SIPHASH", "X25519", "ED25519", "X448" or "ED448". Note that you may
+also use "HMAC" which is not a public key algorithm but is treated as such by
+some OpenSSL APIs. You are encouraged to use the EVP_MAC APIs instead for HMAC
+(see L<EVP_MAC(3)>). I<key> points to the raw private key data for this
+B<EVP_PKEY> which should be of length I<keylen>. The length should be
+appropriate for the type of the key. The public key data will be automatically
+derived from the given private key data (if appropriate for the algorithm type).
+
+EVP_PKEY_new_raw_private_key() does the same as
+EVP_PKEY_new_raw_private_key_with_libctx() except that the default library
+context is and default property query is used instead. If B<e> is non-NULL then
+the new B<EVP_PKEY> structure is associated with the engine B<e>. The B<type>
+argument indicates what kind of key this is. The value should be a NID for a
+public key algorithm that supports raw private keys, i.e. one of
+B<EVP_PKEY_POLY1305>, B<EVP_PKEY_SIPHASH>, B<EVP_PKEY_X25519>,
+B<EVP_PKEY_ED25519>, B<EVP_PKEY_X448> or B<EVP_PKEY_ED448>. As for
+EVP_PKEY_new_raw_private_key_with_libctx() you may also use B<EVP_PKEY_HMAC>.
+
+EVP_PKEY_new_raw_public_key_with_libctx() works in the same way as
+EVP_PKEY_new_raw_private_key_with_libctx() except that B<key> points to the raw
+public key data. The B<EVP_PKEY> structure will be initialised without any
+private key information. Algorithm types that support raw public keys are
+"X25519", "ED25519", "X448" or "ED448".
 
 EVP_PKEY_new_raw_public_key() works in the same way as
 EVP_PKEY_new_raw_private_key() except that B<key> points to the raw public key
@@ -126,6 +156,9 @@ The
 EVP_PKEY_new_raw_private_key(), EVP_PKEY_new_raw_public_key(),
 EVP_PKEY_new_CMAC_key(), EVP_PKEY_new_raw_private_key() and
 EVP_PKEY_get_raw_public_key() functions were added in OpenSSL 1.1.1.
+
+The EVP_PKEY_new_raw_private_key_with_libctx and
+EVP_PKEY_new_raw_public_key_with_libctx functions were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -233,7 +233,9 @@ OSSL_PARAM_get_octet_string() retrieves an OCTET string from the parameter
 pointed to by B<p>.
 The OCTETs are either stored into B<*val> with a length limit of B<max_len> or,
 in the case when B<*val> is B<NULL>, memory is allocated and
-B<max_len> is ignored.
+B<max_len> is ignored. B<*used_len> is populated with the number of OCTETs
+stored. If B<val> is NULL then the OCTETS are not stored, but B<*used_len> is
+still populated.
 If memory is allocated by this function, it must be freed by the caller.
 
 OSSL_PARAM_set_octet_string() sets an OCTET string from the parameter

--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -109,6 +109,7 @@ void X448_public_from_private(uint8_t out_public_value[56],
                               const uint8_t private_key[56]);
 
 /* Backend support */
+int ecx_public_from_private(ECX_KEY *key);
 int ecx_key_fromdata(ECX_KEY *ecx, const OSSL_PARAM params[],
                      int include_private);
 

--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -61,6 +61,7 @@ typedef enum {
            : EVP_PKEY_ED448)))
 
 struct ecx_key_st {
+    OPENSSL_CTX *libctx;
     unsigned int haspubkey:1;
     unsigned char pubkey[MAX_KEYLEN];
     unsigned char *privkey;
@@ -73,7 +74,7 @@ struct ecx_key_st {
 typedef struct ecx_key_st ECX_KEY;
 
 size_t ecx_key_length(ECX_KEY_TYPE type);
-ECX_KEY *ecx_key_new(ECX_KEY_TYPE type, int haspubkey);
+ECX_KEY *ecx_key_new(OPENSSL_CTX *libctx, ECX_KEY_TYPE type, int haspubkey);
 unsigned char *ecx_key_allocate_privkey(ECX_KEY *key);
 void ecx_key_free(ECX_KEY *key);
 int ecx_key_up_ref(ECX_KEY *key);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1516,9 +1516,19 @@ void EVP_PKEY_CTX_set0_keygen_info(EVP_PKEY_CTX *ctx, int *dat, int datlen);
 
 EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *e,
                                const unsigned char *key, int keylen);
+EVP_PKEY *EVP_PKEY_new_raw_private_key_with_libctx(OPENSSL_CTX *libctx,
+                                                   const char *keytype,
+                                                   const char *propq,
+                                                   const unsigned char *priv,
+                                                   size_t len);
 EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *e,
                                        const unsigned char *priv,
                                        size_t len);
+EVP_PKEY *EVP_PKEY_new_raw_public_key_with_libctx(OPENSSL_CTX *libctx,
+                                                  const char *keytype,
+                                                  const char *propq,
+                                                  const unsigned char *pub,
+                                                  size_t len);
 EVP_PKEY *EVP_PKEY_new_raw_public_key(int type, ENGINE *e,
                                       const unsigned char *pub,
                                       size_t len);

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -161,10 +161,6 @@ static int ecx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
          && !key_to_params(key, tmpl, NULL))
         goto err;
 
-    if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0
-         && !key_to_params(key, tmpl, NULL))
-        goto err;
-
     params = OSSL_PARAM_BLD_to_param(tmpl);
     if (params == NULL)
         goto err;

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -113,12 +113,11 @@ static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
     if (key == NULL)
         return 0;
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) == 0)
+    if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
         return 0;
 
     include_private = ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0);
-    if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0)
-        ok = ok && ecx_key_fromdata(key, params, include_private);
+    ok = ok && ecx_key_fromdata(key, params, include_private);
 
     return ok;
 }

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -68,22 +68,22 @@ static void *s390x_ecd_keygen448(struct ecx_gen_ctx *gctx);
 
 static void *x25519_new_key(void *provctx)
 {
-    return ecx_key_new(ECX_KEY_TYPE_X25519, 0);
+    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_X25519, 0);
 }
 
 static void *x448_new_key(void *provctx)
 {
-    return ecx_key_new(ECX_KEY_TYPE_X448, 0);
+    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_X448, 0);
 }
 
 static void *ed25519_new_key(void *provctx)
 {
-    return ecx_key_new(ECX_KEY_TYPE_ED25519, 0);
+    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_ED25519, 0);
 }
 
 static void *ed448_new_key(void *provctx)
 {
-    return ecx_key_new(ECX_KEY_TYPE_ED448, 0);
+    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_ED448, 0);
 }
 
 static int ecx_has(void *keydata, int selection)
@@ -325,7 +325,7 @@ static void *ecx_gen(struct ecx_gen_ctx *gctx)
 
     if (gctx == NULL)
         return NULL;
-    if ((key = ecx_key_new(gctx->type, 0)) == NULL) {
+    if ((key = ecx_key_new(gctx->libctx, gctx->type, 0)) == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -449,7 +449,7 @@ static void *s390x_ecx_keygen25519(struct ecx_gen_ctx *gctx)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_X25519, 1);
+    ECX_KEY *key = ecx_key_new(gctx->libctx, ECX_KEY_TYPE_X25519, 1);
     unsigned char *privkey = NULL, *pubkey;
 
     if (key == NULL) {
@@ -489,7 +489,7 @@ static void *s390x_ecx_keygen448(struct ecx_gen_ctx *gctx)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_X448, 1);
+    ECX_KEY *key = ecx_key_new(gctx->libctx, ECX_KEY_TYPE_X448, 1);
     unsigned char *privkey = NULL, *pubkey;
 
     if (key == NULL) {
@@ -532,7 +532,7 @@ static void *s390x_ecd_keygen25519(struct ecx_gen_ctx *gctx)
         0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
     };
     unsigned char x_dst[32], buff[SHA512_DIGEST_LENGTH];
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_ED25519, 1);
+    ECX_KEY *key = ecx_key_new(gctx->libctx, ECX_KEY_TYPE_ED25519, 1);
     unsigned char *privkey = NULL, *pubkey;
     unsigned int sz;
     EVP_MD *sha = NULL;
@@ -594,7 +594,7 @@ static void *s390x_ecd_keygen448(struct ecx_gen_ctx *gctx)
         0x24, 0xbc, 0xb6, 0x6e, 0x71, 0x46, 0x3f, 0x69, 0x00
     };
     unsigned char x_dst[57], buff[114];
-    ECX_KEY *key = ecx_key_new(ECX_KEY_TYPE_ED448, 1);
+    ECX_KEY *key = ecx_key_new(gctx->libctx, ECX_KEY_TYPE_ED448, 1);
     unsigned char *privkey = NULL, *pubkey;
     EVP_MD_CTX *hashctx = NULL;
     EVP_MD *shake = NULL;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5079,3 +5079,5 @@ X509_REQ_set0_signature                 ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set1_signature_algo            ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_modified                     ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_set_all_unmodified           ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_new_raw_private_key_with_libctx ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_new_raw_public_key_with_libctx ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The functions EVP_PKEY_get_raw_private_key and EVP_PKEY_get_raw_public_key fail with a NULL pointer deref if you pass a provider key to them. This also highlighted that EVP_PKEY_new_raw_private_key and EVP_PKEY_new_raw_public_key do not create provider side keys as you might expect.

This PR fixes both of those issues. Along the way a number of other issues were highlighted.

This is WIP because the tests are failing. At least one of those failures (possibly all of them) are because EVP_PKEY_cmp is not working with ECX provider side keys.

Fixes #11627