### PR TITLE
fuzz/asn1.c: Add missing #include

### DIFF
--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -23,6 +23,7 @@
 #include <openssl/asn1.h>
 #include <openssl/asn1t.h>
 #include <openssl/dh.h>
+#include <openssl/dsa.h>
 #include <openssl/ec.h>
 #include <openssl/ocsp.h>
 #include <openssl/pkcs12.h>


### PR DESCRIPTION
<openssl/dsa.h> gets included via ts.h...  except when 'no-ts' has been
configured.

Fixes #11597
