### PR TITLE
crypto/x509/v3_alt.c: make 'othername' a bit bigger

### DIFF
--- a/crypto/x509/v3_alt.c
+++ b/crypto/x509/v3_alt.c
@@ -82,7 +82,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
                                        STACK_OF(CONF_VALUE) *ret)
 {
     unsigned char *p;
-    char othername[256];
+    char othername[300];
     char oline[256], htmp[5];
     int i;
 


### PR DESCRIPTION
We want to fill 'othername' with the contents of 'oline' (256 bytes)
plus some additional text.  We need to ensure that 'othername' is
large enough to contain this.
