### PR TITLE
Update README.ssltests.md

### DIFF
--- a/test/README.ssltest.md
+++ b/test/README.ssltest.md
@@ -227,16 +227,17 @@ client => {
 ```
 $ ./config
 $ cd test
-$ TOP=.. perl -I ../util/perl/ generate_ssl_tests.pl ssl-tests/my.cnf.in \
+$ TOP=.. perl -I ../util/perl/ generate_ssl_tests.pl ssl-tests/my.cnf.in default \
   > ssl-tests/my.cnf
 ```
 
-where `my.cnf.in` is your test input file.
+where `my.cnf.in` is your test input file and `default` is the provider to use.
+For all the pre-generated test files you should use the default provider.
 
 For example, to generate the test cases in `ssl-tests/01-simple.cnf.in`, do
 
 ```
-$ TOP=.. perl -I ../util/perl/ generate_ssl_tests.pl ssl-tests/01-simple.cnf.in > ssl-tests/01-simple.cnf
+$ TOP=.. perl -I ../util/perl/ generate_ssl_tests.pl ssl-tests/01-simple.cnf.in default > ssl-tests/01-simple.cnf
 ```
 
 Alternatively (hackish but simple), you can comment out


### PR DESCRIPTION
The ssltest docs were out of date because gneerate_ssl_tests now needs
a provider to be specified on the command line.

Fixes #11639