### PR TITLE
EVP: Fix evp_keymgmt_util_copy() for to->keymgmt == NULL

### DIFF
--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -378,8 +378,10 @@ int evp_keymgmt_util_copy(EVP_PKEY *to, EVP_PKEY *from, int selection)
         import_data.selection = selection;
 
         if (!evp_keymgmt_export(from->keymgmt, from->keydata, selection,
-                                &try_import, &import_data))
+                                &try_import, &import_data)) {
+            evp_keymgmt_freedata(to_keymgmt, alloc_keydata);
             return 0;
+        }
 
         /*
          * In case to_keydata was previously unallocated, try_import()


### PR DESCRIPTION
evp_keymgmt_util_copy() didn't treat the case to->keymgmt correctly.
The proper change is to use from->keymgmt when to->keymgmt is NULL.

Fixes coverity #1462553
