### PR TITLE
EVP: Only use the engine when one is defined, in pkey_mac_ctrl()

### DIFF
--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -308,11 +308,14 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 OSSL_PARAM params[3];
                 size_t params_n = 0;
                 char *ciphname = (char *)OBJ_nid2sn(EVP_CIPHER_nid(p2));
-#ifndef OPENSSL_NO_ENGINE
-                char *engineid = (char *)ENGINE_get_id(ctx->engine);
 
-                params[params_n++] =
-                    OSSL_PARAM_construct_utf8_string("engine", engineid, 0);
+#ifndef OPENSSL_NO_ENGINE
+                if (ctx->engine != NULL) {
+                    char *engid = (char *)ENGINE_get_id(ctx->engine);
+
+                    params[params_n++] =
+                        OSSL_PARAM_construct_utf8_string("engine", engid, 0);
+                }
 #endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_CIPHER,
@@ -458,13 +461,14 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 size_t params_n = 0;
                 char *mdname =
                     (char *)OBJ_nid2sn(EVP_MD_nid(hctx->raw_data.md));
-#ifndef OPENSSL_NO_ENGINE
-                char *engineid = ctx->engine == NULL
-                    ? NULL : (char *)ENGINE_get_id(ctx->engine);
 
-                if (engineid != NULL)
+#ifndef OPENSSL_NO_ENGINE
+                if (ctx->engine != NULL) {
+                    char *engid = (char *)ENGINE_get_id(ctx->engine);
+
                     params[params_n++] =
-                        OSSL_PARAM_construct_utf8_string("engine", engineid, 0);
+                        OSSL_PARAM_construct_utf8_string("engine", engid, 0);
+                }
 #endif
                 params[params_n++] =
                     OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1179,6 +1179,27 @@ static int test_EVP_PKEY_check(int i)
     return ret;
 }
 
+static int test_CMAC_keygen(void)
+{
+    /*
+     * This is a legacy method for CMACs, but should still work.
+     * This verifies that it works without an ENGINE.
+     */
+    EVP_PKEY_CTX *kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_CMAC, NULL);
+    int ret = 0;
+
+    if (!TEST_true(EVP_PKEY_keygen_init(kctx) > 0)
+        && !TEST_true(EVP_PKEY_CTX_ctrl(kctx, -1, EVP_PKEY_OP_KEYGEN,
+                                        EVP_PKEY_CTRL_CIPHER,
+                                        0, (void *)EVP_aes_256_ecb()) > 0))
+        goto done;
+    ret = 1;
+
+ done:
+    EVP_PKEY_CTX_free(kctx);
+    return ret;
+}
+
 static int test_HKDF(void)
 {
     EVP_PKEY_CTX *pctx;
@@ -1630,6 +1651,7 @@ int setup_tests(void)
     if (!TEST_int_eq(EVP_PKEY_meth_add0(custom_pmeth), 1))
         return 0;
     ADD_ALL_TESTS(test_EVP_PKEY_check, OSSL_NELEM(keycheckdata));
+    ADD_TEST(test_CMAC_keygen);
     ADD_TEST(test_HKDF);
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_X509_PUBKEY_inplace);


### PR DESCRIPTION
Fixes #11671
