### PR TITLE
Centralise Environment Variables for the tests

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -420,6 +420,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                     OPENSSL_strlcpy(include_path, include_dir, newlen);
                     OPENSSL_strlcat(include_path, "/", newlen);
                     OPENSSL_strlcat(include_path, include, newlen);
+                    OPENSSL_free(include);
                 } else {
                     include_path = include;
                 }
@@ -429,15 +430,11 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 next = process_include(include_path, &dirctx, &dirpath);
                 if (include_path != dirpath) {
                     /* dirpath will contain include in case of a directory */
-                    OPENSSL_free(include);
-                    if (include_path != include)
-                        OPENSSL_free(include_path);
+                    OPENSSL_free(include_path);
                 }
 #else
                 next = BIO_new_file(include_path, "r");
-                OPENSSL_free(include);
-                if (include_path != include)
-                    OPENSSL_free(include_path);
+                OPENSSL_free(include_path);
 #endif
 
                 if (next != NULL) {

--- a/test/README
+++ b/test/README
@@ -151,3 +151,7 @@ works fine and can be used in place of:
 
 The former produces a more meaningful message on failure than the latter.
 
+Note that the test infrastructure automatically sets up all required environment
+variables (such as OPENSSL_MODULES, OPENSSL_CONF etc) for the tests. Individual
+tests may choose to override the default settings as required.
+

--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -27,7 +27,6 @@ plan skip_all => "Test only supported in a fips build" if disabled("fips");
 plan tests => 12;
 
 my $infile = bldtop_file('providers', platform->dso('fips'));
-$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
 
 # fail if no module name
 ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.cnf', '-module',

--- a/test/recipes/30-test_afalg.t
+++ b/test/recipes/30-test_afalg.t
@@ -7,7 +7,7 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
-use OpenSSL::Test qw/:DEFAULT bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT/;
 use OpenSSL::Test::Utils;
 
 my $test_name = "test_afalg";
@@ -17,7 +17,5 @@ plan skip_all => "$test_name not supported for this build"
     if disabled("afalgeng");
 
 plan tests => 1;
-
-$ENV{OPENSSL_ENGINES} = bldtop_dir("engines");
 
 ok(run(test(["afalgtest"])), "running afalgtest");

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -80,8 +80,6 @@ plan tests =>
 
 unless ($no_fips) {
     my $infile = bldtop_file('providers', platform->dso('fips'));
-    $ENV{OPENSSL_MODULES} = bldtop_dir("providers");
-    $ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
 
     ok(run(app(['openssl', 'fipsinstall',
                 '-out', bldtop_file('providers', 'fipsmodule.cnf'),

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -24,9 +24,6 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 my @types = ( "digest", "cipher" );
 
-$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
-$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
-
 my @setups = ();
 my @testdata = (
     { config    => srctop_file("test", "default.cnf"),

--- a/test/recipes/70-test_comp.t
+++ b/test/recipes/70-test_comp.t
@@ -28,7 +28,6 @@ plan skip_all => "$test_name needs TLSv1.3 or TLSv1.2 enabled"
     if disabled("tls1_3") && disabled("tls1_2");
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 
 use constant {
     MULTIPLE_COMPRESSIONS => 0,

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -30,7 +30,6 @@ plan skip_all => "$test_name needs TLS enabled"
        || (!disabled("tls1_3") && disabled("tls1_2"));
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -32,7 +32,6 @@ plan skip_all => "$test_name needs EC enabled"
     if disabled("ec");
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 
 
 @handmessages = (

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -32,8 +32,6 @@ plan skip_all => "$test_name needs EC enabled"
     if disabled("ec");
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
-
 
 @handmessages = (
     [TLSProxy::Message::MT_CLIENT_HELLO,

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -28,7 +28,6 @@ plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3");
 
 $ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 
 my $proxy = TLSProxy::Proxy->new(
     undef,

--- a/test/recipes/80-test_ct.t
+++ b/test/recipes/80-test_ct.t
@@ -11,7 +11,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir/;
 use OpenSSL::Test::Simple;
 
 setup("test_ct");
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
+
 $ENV{CT_DIR} = srctop_dir("test", "ct");
 $ENV{CERTS_DIR} = srctop_dir("test", "certs");
 simple_test("test_ct", "ct_test", "ct", "ec");

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -26,10 +26,7 @@ use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
-$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
 $ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
 
 my @conf_srcs =  glob(srctop_file("test", "ssl-tests", "*.cnf.in"));
 map { s/;.*// } @conf_srcs if $^O eq "VMS";

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -24,10 +24,6 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
-$ENV{CTLOG_FILE} = srctop_file("test", "ct", "log_list.cnf");
-$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
-$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
-
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my ($no_rsa, $no_dsa, $no_dh, $no_ec, $no_psk,
     $no_ssl3, $no_tls1, $no_tls1_1, $no_tls1_2, $no_tls1_3,

--- a/test/recipes/90-test_includes.t
+++ b/test/recipes/90-test_includes.t
@@ -10,6 +10,8 @@ setup("test_includes");
 plan skip_all => "test_includes doesn't work without posix-io"
     if disabled("posix-io");
 
+delete $ENV{OPENSSL_CONF_INCLUDE};
+
 plan tests =>                   # The number of tests being performed
     5
     + ($^O eq "VMS" ? 2 : 0);

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -30,9 +30,6 @@ plan tests =>
 
 (undef, my $tmpfilename) = tempfile();
 
-$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
-$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
-
 ok(run(test(["sslapitest", srctop_dir("test", "certs"),
              srctop_file("test", "recipes", "90-test_sslapi_data",
                          "passwd.txt"), $tmpfilename, "default",

--- a/test/recipes/90-test_sslprovider.t
+++ b/test/recipes/90-test_sslprovider.t
@@ -23,9 +23,6 @@ plan skip_all => "No TLS/SSL protocols are supported by this OpenSSL build"
 
 plan tests => 3;
 
-$ENV{OPENSSL_MODULES} = bldtop_dir("providers");
-$ENV{OPENSSL_CONF_INCLUDE} = bldtop_dir("providers");
-
 SKIP: {
     skip "Skipping FIPS installation", 1
         if disabled("fips");

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -27,7 +27,11 @@ my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 
-$ENV{OPENSSL_CONF} = catdir($srctop, "apps", "openssl.cnf");
+$ENV{OPENSSL_CONF} = rel2abs(catdir($srctop, "apps", "openssl.cnf"));
+$ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "providers"));
+$ENV{OPENSSL_MODULES} = rel2abs(catdir($bldtop, "providers"));
+$ENV{OPENSSL_ENGINES} = rel2abs(catdir($bldtop, "engines"));
+$ENV{CTLOG_FILE} = rel2abs(catdir($srctop, "test", "ct", "log_list.cnf"));
 
 my %tapargs =
     ( verbosity         => $ENV{HARNESS_VERBOSE} ? 1 : 0,


### PR DESCRIPTION
The test_includes test was failing if OPENSSL_CONF_INCLUDE happened to
be set in the user's environment. To ensure that no tests accidentally
use this or other enviroment variables from the user's environment we
automatically set them centrally for all tests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
