### PR TITLE
Add solaris assembler fixes for legacy provider

### DIFF
--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -112,16 +112,18 @@ $COMMON=bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_mul.c \
         bn_kron.c bn_sqrt.c bn_gcd.c bn_prime.c bn_sqr.c \
         bn_recp.c bn_mont.c bn_mpi.c bn_exp2.c bn_gf2m.c bn_nist.c \
         bn_x931p.c bn_intern.c bn_dh.c \
-        bn_rsa_fips186_4.c $BNDH $BNASM
-SOURCE[../../libcrypto]=$COMMON bn_print.c bn_err.c bn_srp.c
+        bn_rsa_fips186_4.c $BNDH
+SOURCE[../../libcrypto]=$COMMON $BNASM bn_print.c bn_err.c bn_srp.c
 IF[{- !$disabled{'deprecated-3.0'} -}]
   SOURCE[../../libcrypto]=bn_depr.c
 ENDIF
-SOURCE[../../providers/libfips.a]=$COMMON
+SOURCE[../../providers/libfips.a]=$COMMON $BNASM
+SOURCE[../../providers/liblegacy.a]=$BNASM
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$BNDEF
 DEFINE[../../providers/libfips.a]=$BNDEF
+DEFINE[../../providers/liblegacy.a]=$BNDEF
 DEFINE[../../providers/libimplementations.a]=$BNDEF
 
 INCLUDE[../../libcrypto]=../../crypto/include

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -14,7 +14,7 @@ IF[{- !$disabled{asm} -}]
 ENDIF
 
 LIBS=../../libcrypto
-$COMMON=set_key.c ecb3_enc.c $DESASM
+$COMMON=set_key.c ecb3_enc.c
 $ALL=$COMMON\
      ecb_enc.c  cbc_enc.c \
      cfb64enc.c cfb64ede.c cfb_enc.c \
@@ -22,8 +22,10 @@ $ALL=$COMMON\
      str2key.c  pcbc_enc.c qud_cksm.c rand_key.c \
      fcrypt.c xcbc_enc.c cbc_cksm.c
 
-SOURCE[../../libcrypto]=$ALL
-SOURCE[../../providers/libfips.a]=$COMMON
+SOURCE[../../libcrypto]=$ALL $DESASM
+SOURCE[../../providers/libfips.a]=$COMMON $DESASM
+SOURCE[../../providers/liblegacy.a]=$DESASM
+
 DEFINE[../../libcrypto]=$DESDEF
 DEFINE[../../providers/libfips.a]=$DESDEF
 DEFINE[../../providers/liblegacy.a]=$DESDEF

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -65,7 +65,13 @@ static int cipher_hw_des_ecb_cipher(PROV_CIPHER_CTX *ctx, unsigned char *out,
 static int cipher_hw_des_cbc_cipher(PROV_CIPHER_CTX *ctx, unsigned char *out,
                                     const unsigned char *in, size_t len)
 {
-    DES_key_schedule *key = &(((PROV_DES_CTX *)ctx)->dks.ks);
+    PROV_DES_CTX *dctx = (PROV_DES_CTX *)ctx;
+    DES_key_schedule *key = &(dctx->dks.ks);
+
+    if (dctx->dstream.cbc != NULL) {
+        (*dctx->dstream.cbc) (in, out, len, key, ctx->iv);
+        return 1;
+    }
 
     while (len >= MAXCHUNK) {
         DES_ncbc_encrypt(in, out, MAXCHUNK, key, (DES_cblock *)ctx->iv,


### PR DESCRIPTION
The legacy provider contains assembler references. Most code is automagically pulled in from libcrypto - but the platform specific assembler functions will not be visible in the symbol table. Copying BNASM and DESASM into liblegacy seems to be a better solution than exposing platform specific function in libcrypto.num.

Added a missing call in the des_cbc code for sparc.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
