### PR TITLE
WPACKET: don't write DER length when we don't want to

### DIFF
--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -267,7 +267,8 @@ static int wpacket_intern_close(WPACKET *pkt, WPACKET_SUB *sub, int doclose)
             return 0;
     } else if (pkt->endfirst && sub->parent != NULL
                && (packlen != 0
-                   || (sub->flags & WPACKET_FLAGS_NON_ZERO_LENGTH) == 0)) {
+                   || (sub->flags
+                       & WPACKET_FLAGS_ABANDON_ON_ZERO_LENGTH) == 0)) {
         size_t tmplen = packlen;
         size_t numlenbytes = 1;
 

--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -265,7 +265,9 @@ static int wpacket_intern_close(WPACKET *pkt, WPACKET_SUB *sub, int doclose)
                 && !put_value(&buf[sub->packet_len], packlen,
                               sub->lenbytes))
             return 0;
-    } else if (pkt->endfirst && sub->parent != NULL) {
+    } else if (pkt->endfirst && sub->parent != NULL
+               && (packlen != 0
+                   || (sub->flags & WPACKET_FLAGS_NON_ZERO_LENGTH) == 0)) {
         size_t tmplen = packlen;
         size_t numlenbytes = 1;
 


### PR DESCRIPTION
With endfirst writing, it could be that we want to abandon any zero
length sub-packet.  That's what WPACKET_FLAGS_ABANDON_ON_ZERO_LENGTH
was supposed to make happen, but the DER length writing code didn't
look at that flag.  Now it does.