### PR TITLE
Fix incorrect default keysize for CAST ofb and cfb modes.

### DIFF
--- a/providers/implementations/ciphers/cipher_cast5.c
+++ b/providers/implementations/ciphers/cipher_cast5.c
@@ -49,7 +49,7 @@ static void *cast5_dupctx(void *ctx)
 IMPLEMENT_var_keylen_cipher(cast5, CAST, ecb, ECB, CAST5_FLAGS, 128, 64, 0, block)
 /* cast5128cbc_functions */
 IMPLEMENT_var_keylen_cipher(cast5, CAST, cbc, CBC, CAST5_FLAGS, 128, 64, 64, block)
-/* cast564ofb64_functions */
-IMPLEMENT_var_keylen_cipher(cast5, CAST, ofb64, OFB, CAST5_FLAGS, 64, 8, 64, stream)
-/* cast564cfb64_functions */
-IMPLEMENT_var_keylen_cipher(cast5, CAST, cfb64,  CFB, CAST5_FLAGS, 64, 8, 64, stream)
+/* cast5128ofb64_functions */
+IMPLEMENT_var_keylen_cipher(cast5, CAST, ofb64, OFB, CAST5_FLAGS, 128, 8, 64, stream)
+/* cast5128cfb64_functions */
+IMPLEMENT_var_keylen_cipher(cast5, CAST, cfb64,  CFB, CAST5_FLAGS, 128, 8, 64, stream)

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -148,8 +148,8 @@ extern const OSSL_DISPATCH idea128cfb64_functions[];
 #ifndef OPENSSL_NO_CAST
 extern const OSSL_DISPATCH cast5128ecb_functions[];
 extern const OSSL_DISPATCH cast5128cbc_functions[];
-extern const OSSL_DISPATCH cast564ofb64_functions[];
-extern const OSSL_DISPATCH cast564cfb64_functions[];
+extern const OSSL_DISPATCH cast5128ofb64_functions[];
+extern const OSSL_DISPATCH cast5128cfb64_functions[];
 #endif /* OPENSSL_NO_CAST */
 #ifndef OPENSSL_NO_SEED
 extern const OSSL_DISPATCH seed128ecb_functions[];

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -79,8 +79,8 @@ static const OSSL_ALGORITHM legacy_ciphers[] = {
 #ifndef OPENSSL_NO_CAST
     ALG("CAST5-ECB", cast5128ecb_functions),
     ALG("CAST5-CBC:CAST-CBC:CAST", cast5128cbc_functions),
-    ALG("CAST5-OFB", cast564ofb64_functions),
-    ALG("CAST5-CFB", cast564cfb64_functions),
+    ALG("CAST5-OFB", cast5128ofb64_functions),
+    ALG("CAST5-CFB", cast5128cfb64_functions),
 #endif /* OPENSSL_NO_CAST */
 #ifndef OPENSSL_NO_BF
     ALG("BF-ECB", blowfish128ecb_functions),


### PR DESCRIPTION
Fixes #11459

It was incorrectly using 8 bytes instead of 16 as the default.
This was verified by expanding the macros used in e_cast.c.
The issue occurs if EVP_CIPHER_CTX_set_key_length() is not called.
evp_test.c hides this issue as it always calls EVP_CIPHER_CTX_set_key_length() before
using EVP_CipherInit_ex(...., key, ..).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
