### PR TITLE
Use fips=yes consistently in documentation

### DIFF
--- a/doc/man3/EVP_set_default_properties.pod
+++ b/doc/man3/EVP_set_default_properties.pod
@@ -44,7 +44,7 @@ EVP_set_default_properties() and  EVP_default_properties_enable_fips() return 1
 on success, or 0 on failure. An error is placed on the the error stack if a
 failure occurs.
 
-EVP_default_properties_is_fips_enabled() returns 1 if the 'fips=true' default
+EVP_default_properties_is_fips_enabled() returns 1 if the 'fips=yes' default
 property is set for the given I<libctx>, otherwise it returns 0.
 
 =head1 SEE ALSO


### PR DESCRIPTION
The documentation for ``EVP_default_properties_is_fips_enabled()`` uses
``fips=yes`` in one place and ``fips=true`` in another place. Stick to
``fips=yes`` like everywhere else.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated

