### PR TITLE
Configure: Avoid SIXTY_FOUR_BIT for linux-mips64

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -790,7 +790,7 @@ my %targets = (
         inherit_from     => [ "linux-generic32" ],
         cflags           => add("-mabi=n32"),
         cxxflags         => add("-mabi=n32"),
-        bn_ops           => "SIXTY_FOUR_BIT RC4_CHAR",
+        bn_ops           => "RC4_CHAR",
         asm_arch         => 'mips64',
         perlasm_scheme   => "n32",
         multilib         => "32",


### PR DESCRIPTION
This is a 32-bit ABI build (as opposed to linux64-mips64).

Setting SIXTY_FOUR_BIT breaks hardware optimizations, at least on octeon processors.
