### PR TITLE
The synthesized OPENSSL_VERSION_NUMBER must be long

### DIFF
--- a/include/openssl/opensslv.h.in
+++ b/include/openssl/opensslv.h.in
@@ -91,9 +91,9 @@ extern "C" {
 
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
 # ifdef OPENSSL_VERSION_PRE_RELEASE
-#  define _OPENSSL_VERSION_PRE_RELEASE 0x0
+#  define _OPENSSL_VERSION_PRE_RELEASE 0x0L
 # else
-#  define _OPENSSL_VERSION_PRE_RELEASE 0xf
+#  define _OPENSSL_VERSION_PRE_RELEASE 0xfL
 # endif
 # define OPENSSL_VERSION_NUMBER          \
     ( (OPENSSL_VERSION_MAJOR<<28)        \


### PR DESCRIPTION
(to keep API compatibility with older releases)

Fixes #11716
