### PR TITLE
Use OSSL_STORE for load_key() and load_pubkey() in apps/lib/apps.c

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -573,8 +573,7 @@ end_of_options:
         }
     }
     pkey = load_key(keyfile, keyformat, 0, key, e, "CA private key");
-    if (key != NULL)
-        OPENSSL_cleanse(key, strlen(key));
+    cleanse(key);
     if (pkey == NULL)
         /* load_key() has already printed an appropriate message */
         goto end;

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -538,7 +538,7 @@ int enc_main(int argc, char **argv)
                 goto end;
             }
             /* wiping secret data as we no longer need it */
-            OPENSSL_cleanse(hkey, strlen(hkey));
+            cleanse(hkey);
         }
 
         if ((benc = BIO_new(BIO_f_cipher())) == NULL)

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -102,11 +102,14 @@ int set_cert_ex(unsigned long *flags, const char *arg);
 int set_name_ex(unsigned long *flags, const char *arg);
 int set_ext_copy(int *copy_type, const char *arg);
 int copy_extensions(X509 *x, X509_REQ *req, int copy_type);
+char *get_passwd(const char *pass, const char *desc);
 int app_passwd(const char *arg1, const char *arg2, char **pass1, char **pass2);
 int add_oid_section(CONF *conf);
 X509_REQ *load_csr(const char *file, int format, const char *desc);
 X509 *load_cert(const char *file, int format, const char *desc);
 X509_CRL *load_crl(const char *infile, int format, const char *desc);
+void cleanse(char *str);
+void clear_free(char *str);
 EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
                    const char *pass, ENGINE *e, const char *desc);
 EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
@@ -115,6 +118,11 @@ int load_certs(const char *file, STACK_OF(X509) **certs, int format,
                const char *pass, const char *desc);
 int load_crls(const char *file, STACK_OF(X509_CRL) **crls, int format,
               const char *pass, const char *desc);
+int STORE_load_key_cert_crl(const char *uri, const char *pass, const char *desc,
+                            EVP_PKEY **ppkey, X509 **pcert, X509_CRL **pcrl);
+EVP_PKEY *STORE_load_pkey(const char *uri, const char *pass, const char *desc);
+X509 *STORE_load_cert(const char *uri, const char *pass, const char *desc);
+X509_CRL *STORE_load_crl(const char *uri, const char *desc);
 X509_STORE *setup_verify(const char *CAfile, int noCAfile,
                          const char *CApath, int noCApath,
                          const char *CAstore, int noCAstore);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -29,6 +29,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>
+#include <openssl/store.h>
 #include <openssl/pkcs12.h>
 #include <openssl/ui.h>
 #include <openssl/safestack.h>
@@ -208,6 +209,24 @@ int wrap_password_callback(char *buf, int bufsiz, int verify, void *userdata)
 
 
 static char *app_get_pass(const char *arg, int keepbio);
+
+char *get_passwd(const char *pass, const char *desc)
+{
+    char *result = NULL;
+
+    if (desc == NULL)
+        desc = "<unknown>";
+    if (!app_passwd(pass, NULL, &result, NULL))
+        BIO_printf(bio_err, "Error getting password for %s\n", desc);
+    if (pass != NULL && result == NULL) {
+        BIO_printf(bio_err,
+                   "Trying plain input string (better precede with 'pass:')\n");
+        result = OPENSSL_strdup(pass);
+        if (result == NULL)
+        BIO_printf(bio_err, "Out of memory getting password for %s\n", desc);
+    }
+    return result;
+}
 
 int app_passwd(const char *arg1, const char *arg2, char **pass1, char **pass2)
 {
@@ -419,16 +438,13 @@ static int load_pkcs12(BIO *in, const char *desc,
     const char *pass;
     char tpass[PEM_BUFSIZE];
     int len, ret = 0;
+    const char *error = NULL;
     PKCS12 *p12;
 
     p12 = d2i_PKCS12_bio(in, NULL);
-    if (p12 == NULL) {
-        if (desc != NULL)
-            BIO_printf(bio_err, "Error loading PKCS12 file for %s\n", desc);
-        else
-            BIO_printf(bio_err, "Error loading PKCS12 file\n");
-        goto die;
-    }
+    error = "Error loading PKCS12 file";
+    if (p12 == NULL)
+        goto end;
     /* See if an empty password will do */
     if (PKCS12_verify_mac(p12, "", 0) || PKCS12_verify_mac(p12, NULL, 0)) {
         pass = "";
@@ -436,23 +452,24 @@ static int load_pkcs12(BIO *in, const char *desc,
         if (pem_cb == NULL)
             pem_cb = (pem_password_cb *)password_callback;
         len = pem_cb(tpass, PEM_BUFSIZE, 0, cb_data);
-        if (len < 0) {
-            BIO_printf(bio_err, "Passphrase callback error for %s\n",
-                                desc != NULL ? desc : "PKCS12 input");
-            goto die;
-        }
+        error = "Passphrase callback error\n";
+        if (len < 0)
+            goto end;
         if (len < PEM_BUFSIZE)
             tpass[len] = 0;
-        if (!PKCS12_verify_mac(p12, tpass, len)) {
-            BIO_printf(bio_err,
-                       "Mac verify error (wrong password?) in PKCS12 file for %s\n",
-                       desc != NULL ? desc : "PKCS12 input");
-            goto die;
-        }
+        error = "Mac verify error (wrong password?) in PKCS12 file";
+        if (!PKCS12_verify_mac(p12, tpass, len))
+            goto end;
         pass = tpass;
     }
     ret = PKCS12_parse(p12, pass, pkey, cert, ca);
- die:
+    error = NULL;
+
+ end:
+    if (error != NULL)
+        BIO_printf(bio_err, "%s%s%s", error,
+                   desc != NULL ? "for " : "",
+                   desc != NULL ? desc : "");
     PKCS12_free(p12);
     return ret;
 }
@@ -462,6 +479,8 @@ X509 *load_cert(const char *file, int format, const char *desc)
     X509 *x = NULL;
     BIO *cert;
 
+    if (desc == NULL)
+        desc = "certificate";
     if (format == FORMAT_HTTP) {
 #if !defined(OPENSSL_NO_SOCK)
         x = X509_load_http(file, NULL, NULL, 0 /* timeout */);
@@ -495,7 +514,7 @@ X509 *load_cert(const char *file, int format, const char *desc)
     }
 
  end:
-    if (x == NULL && desc != NULL) {
+    if (x == NULL) {
         BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
@@ -539,6 +558,8 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
     X509_REQ *req = NULL;
     BIO *in;
 
+    if (desc == NULL)
+        desc = "CRL";
     in = bio_open_default(file, 'r', format);
     if (in == NULL)
         goto end;
@@ -551,7 +572,7 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
         print_format_error(format, OPT_FMT_PEMDER);
 
  end:
-    if (req == NULL && desc != NULL) {
+    if (req == NULL) {
         BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
@@ -559,63 +580,88 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
     return req;
 }
 
-EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
+void cleanse(char *str)
+{
+    if (str != NULL)
+        OPENSSL_cleanse(str, strlen(str));
+}
+
+void clear_free(char *str)
+{
+    if (str != NULL)
+        OPENSSL_clear_free(str, strlen(str));
+}
+
+EVP_PKEY *load_key(const char *uri, int format, int maybe_stdin,
                    const char *pass, ENGINE *e, const char *desc)
 {
-    BIO *key = NULL;
+    BIO *bio = NULL;
     EVP_PKEY *pkey = NULL;
     PW_CB_DATA cb_data;
 
+    if (desc == NULL)
+        desc = "private key";
     cb_data.password = pass;
-    cb_data.prompt_info = file;
+    cb_data.prompt_info = uri;
 
-    if (file == NULL && (!maybe_stdin || format == FORMAT_ENGINE)) {
-        BIO_printf(bio_err, "No keyfile specified\n");
-        goto end;
-    }
     if (format == FORMAT_ENGINE) {
         if (e == NULL) {
-            BIO_printf(bio_err, "No engine specified\n");
+            BIO_printf(bio_err, "No engine specified for loading %s\n", desc);
         } else {
 #ifndef OPENSSL_NO_ENGINE
             if (ENGINE_init(e)) {
-                pkey = ENGINE_load_private_key(e, file,
+                pkey = ENGINE_load_private_key(e, uri,
                                                (UI_METHOD *)get_ui_method(),
                                                &cb_data);
                 ENGINE_finish(e);
             }
-            if (pkey == NULL && desc != NULL) {
+            if (pkey == NULL) {
                 BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
 #else
-            BIO_printf(bio_err, "Engines not supported\n");
+            BIO_printf(bio_err, "Engines not supported for loading %s\n", desc);
 #endif
         }
         goto end;
     }
-    if (file == NULL && maybe_stdin) {
+    if (uri == NULL) {
+        if (!maybe_stdin) {
+            BIO_printf(bio_err, "No filename or uri specified for loading %s\n",
+                       desc);
+            goto end;
+        }
         unbuffer(stdin);
-        key = dup_bio_in(format);
-    } else {
-        key = bio_open_default(file, 'r', format);
+        bio = dup_bio_in(format);
+        if (bio == NULL) {
+            BIO_printf(bio_err, "Error opening stdin for reading %s\n", desc);
+            goto end;
+        }
+    } else if (format == FORMAT_MSBLOB || format == FORMAT_PVK) {
+        bio = bio_open_default(uri, 'r', format);
+        if (bio == NULL) {
+            BIO_printf(bio_err, "Error opening %s for reading %s\n", uri, desc);
+            goto end;
+        }
     }
-    if (key == NULL)
-        goto end;
     if (format == FORMAT_ASN1) {
-        pkey = d2i_PrivateKey_bio(key, NULL);
+        pkey = bio == NULL ? STORE_load_pkey(uri, pass, desc) :
+            d2i_PrivateKey_bio(bio, NULL);
     } else if (format == FORMAT_PEM) {
-        pkey = PEM_read_bio_PrivateKey(key, NULL, wrap_password_callback, &cb_data);
+        pkey = bio == NULL ? STORE_load_pkey(uri, pass, desc) :
+            PEM_read_bio_PrivateKey(bio, NULL, wrap_password_callback, &cb_data);
     } else if (format == FORMAT_PKCS12) {
-        if (!load_pkcs12(key, desc,
-                         (pem_password_cb *)password_callback, &cb_data,
-                         &pkey, NULL, NULL))
+        if (bio == NULL)
+            pkey = STORE_load_pkey(uri, pass, desc);
+        else if (!load_pkcs12(bio, desc,
+                              (pem_password_cb *)password_callback, &cb_data,
+                              &pkey, NULL, NULL))
             goto end;
 #if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DSA) && !defined (OPENSSL_NO_RC4)
     } else if (format == FORMAT_MSBLOB) {
-        pkey = b2i_PrivateKey_bio(key);
+        pkey = b2i_PrivateKey_bio(bio);
     } else if (format == FORMAT_PVK) {
-        pkey = b2i_PVK_bio(key, wrap_password_callback, &cb_data);
+        pkey = b2i_PVK_bio(bio, wrap_password_callback, &cb_data);
 #endif
     } else {
         print_format_error(format, OPT_FMT_PEMDER | OPT_FMT_PKCS12
@@ -629,103 +675,119 @@ EVP_PKEY *load_key(const char *file, int format, int maybe_stdin,
     }
 
  end:
-    BIO_free(key);
-    if (pkey == NULL && desc != NULL) {
+    BIO_free(bio);
+    if (pkey == NULL) {
         BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
     return pkey;
 }
 
-EVP_PKEY *load_pubkey(const char *file, int format, int maybe_stdin,
+EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
                       const char *pass, ENGINE *e, const char *desc)
 {
-    BIO *key = NULL;
+    BIO *bio = NULL;
     EVP_PKEY *pkey = NULL;
     PW_CB_DATA cb_data;
 
+    if (desc == NULL)
+        desc = "public key";
     cb_data.password = pass;
-    cb_data.prompt_info = file;
+    cb_data.prompt_info = uri;
 
-    if (file == NULL && (!maybe_stdin || format == FORMAT_ENGINE)) {
-        BIO_printf(bio_err, "No keyfile specified\n");
-        goto end;
-    }
     if (format == FORMAT_ENGINE) {
         if (e == NULL) {
-            BIO_printf(bio_err, "No engine specified\n");
+            BIO_printf(bio_err, "No engine specified for loading %s\n", desc);
         } else {
 #ifndef OPENSSL_NO_ENGINE
-            pkey = ENGINE_load_public_key(e, file, (UI_METHOD *)get_ui_method(),
+            pkey = ENGINE_load_public_key(e, uri, (UI_METHOD *)get_ui_method(),
                                           &cb_data);
-            if (pkey == NULL && desc != NULL) {
+            if (pkey == NULL) {
                 BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
 #else
-            BIO_printf(bio_err, "Engines not supported\n");
+            BIO_printf(bio_err, "Engines not supported for loading %s\n", desc);
 #endif
         }
         goto end;
     }
-    if (file == NULL && maybe_stdin) {
+    if (uri == NULL){
+        if (!maybe_stdin) {
+            BIO_printf(bio_err, "No filename or uri specified for loading %s\n",
+                       desc);
+        }
         unbuffer(stdin);
-        key = dup_bio_in(format);
-    } else {
-        key = bio_open_default(file, 'r', format);
+        bio = dup_bio_in(format);
+        if (bio == NULL) {
+            BIO_printf(bio_err, "Error opening stdin for reading %s\n", desc);
+            goto end;
+        }
+    } else if (format == FORMAT_MSBLOB) {
+        bio = bio_open_default(uri, 'r', format);
+        if (bio == NULL) {
+            BIO_printf(bio_err, "Error opening %s for reading %s\n", uri, desc);
+            goto end;
+        }
     }
-    if (key == NULL)
-        goto end;
     if (format == FORMAT_ASN1) {
-        pkey = d2i_PUBKEY_bio(key, NULL);
+        pkey = bio == NULL ? STORE_load_pkey(uri, pass, desc) :
+            d2i_PUBKEY_bio(bio, NULL);
     } else if (format == FORMAT_ASN1RSA) {
+        if (bio == NULL) {
+            pkey = STORE_load_pkey(uri, pass, desc);
+        } else {
 #ifndef OPENSSL_NO_RSA
-        RSA *rsa;
-        rsa = d2i_RSAPublicKey_bio(key, NULL);
-        if (rsa) {
-            pkey = EVP_PKEY_new();
-            if (pkey != NULL)
-                EVP_PKEY_set1_RSA(pkey, rsa);
-            RSA_free(rsa);
-        } else
+            RSA *rsa;
+            rsa = d2i_RSAPublicKey_bio(bio, NULL);
+            if (rsa) {
+                pkey = EVP_PKEY_new();
+                if (pkey != NULL)
+                    EVP_PKEY_set1_RSA(pkey, rsa);
+                RSA_free(rsa);
+            } else
 #else
-        BIO_printf(bio_err, "RSA keys not supported\n");
+            BIO_printf(bio_err, "RSA keys not supported\n");
 #endif
-            pkey = NULL;
+                pkey = NULL;
+        }
     } else if (format == FORMAT_PEMRSA) {
+        if (bio == NULL) {
+            pkey = STORE_load_pkey(uri, pass, desc);
+        } else {
 #ifndef OPENSSL_NO_RSA
-        RSA *rsa;
-        rsa = PEM_read_bio_RSAPublicKey(key, NULL,
-                                        (pem_password_cb *)password_callback,
-                                        &cb_data);
-        if (rsa != NULL) {
-            pkey = EVP_PKEY_new();
-            if (pkey != NULL)
-                EVP_PKEY_set1_RSA(pkey, rsa);
-            RSA_free(rsa);
-        } else
+            RSA *rsa;
+            rsa = PEM_read_bio_RSAPublicKey(bio, NULL, (pem_password_cb *)
+                                            password_callback, &cb_data);
+            if (rsa != NULL) {
+                pkey = EVP_PKEY_new();
+                if (pkey != NULL)
+                    EVP_PKEY_set1_RSA(pkey, rsa);
+                RSA_free(rsa);
+            } else
 #else
-        BIO_printf(bio_err, "RSA keys not supported\n");
+            BIO_printf(bio_err, "RSA keys not supported\n");
 #endif
-            pkey = NULL;
+                pkey = NULL;
+        }
     } else if (format == FORMAT_PEM) {
-        pkey = PEM_read_bio_PUBKEY(key, NULL,
-                                   (pem_password_cb *)password_callback,
-                                   &cb_data);
+        pkey = bio == NULL ? STORE_load_pkey(uri, pass, desc) :
+            PEM_read_bio_PUBKEY(bio, NULL, (pem_password_cb *)password_callback,
+                                &cb_data);
 #if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DSA)
     } else if (format == FORMAT_MSBLOB) {
-        pkey = b2i_PublicKey_bio(key);
+        pkey = b2i_PublicKey_bio(bio);
 #endif
     } else {
-        print_format_error(format, OPT_FMT_PEMDER
+        print_format_error(format, OPT_FMT_PEMDER | OPT_FMT_PKCS12
 #if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DSA)
                                  | OPT_FMT_MSBLOB
 #endif
                            );
     }
  end:
-    BIO_free(key);
-    if (pkey == NULL && desc != NULL) {
+    BIO_free(bio);
+    if (pkey == NULL) {
         BIO_printf(bio_err, "Unable to load %s\n", desc);
         ERR_print_errors(bio_err);
     }
@@ -807,11 +869,8 @@ static int load_certs_crls(const char *file, int format,
             sk_X509_CRL_pop_free(*pcrls, X509_CRL_free);
             *pcrls = NULL;
         }
-        if (desc != NULL) {
-            BIO_printf(bio_err, "Unable to load %s for %s\n",
-                       pcerts ? "certificates" : "CRLs", desc);
-            ERR_print_errors(bio_err);
-        }
+        BIO_printf(bio_err, "Unable to load %s\n", desc != NULL ? desc :
+                   pcerts != NULL ? "certificates" : "CRLs", desc);
     }
     return rv;
 }
@@ -846,6 +905,111 @@ int load_crls(const char *file, STACK_OF(X509_CRL) **crls, int format,
 {
     return load_certs_crls(file, format, pass, desc, NULL, crls);
 }
+
+/*
+ * Load those types of credentials for which the result pointer is not NULL.
+ * For each type the first credential found in the store is loaded.
+ * May yield partial result even if rv == 0.
+ */
+int STORE_load_key_cert_crl(const char *uri, const char *pass, const char *desc,
+                            EVP_PKEY **ppkey, X509 **pcert, X509_CRL **pcrl)
+{
+    PW_CB_DATA uidata;
+    OSSL_STORE_CTX *ctx = NULL;
+    int ret = 0;
+    /* TODO make use of the engine reference 'eng' when loading pkeys */
+
+    if (ppkey != NULL)
+        *ppkey = NULL;
+    if (pcert != NULL)
+        *pcert = NULL;
+    if (pcrl != NULL)
+        *pcrl = NULL;
+
+    if (desc == NULL)
+        desc = "private key/certificate/CRL";
+    uidata.password = pass;
+    uidata.prompt_info = uri;
+    ctx = OSSL_STORE_open(uri, get_ui_method(), &uidata, NULL, NULL);
+    if (ctx == NULL) {
+        BIO_printf(bio_err, "Could not open file or uri %s for loading %s\n",
+                   uri, desc);
+        goto end;
+    }
+
+    for (;;) {
+        OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);
+        int type = info == NULL ? 0 : OSSL_STORE_INFO_get_type(info);
+        const char *infostr =
+            info == NULL ? NULL : OSSL_STORE_INFO_type_string(type);
+        int err = 0;
+
+        if (info == NULL) {
+            if (OSSL_STORE_eof(ctx))
+                ret = 1;
+            break;
+        }
+
+        switch (type) {
+        case OSSL_STORE_INFO_PKEY:
+            if (ppkey != NULL && *ppkey == NULL)
+                err = ((*ppkey = OSSL_STORE_INFO_get1_PKEY(info)) == NULL);
+            break;
+        case OSSL_STORE_INFO_CERT:
+            if (pcert != NULL && *pcert == NULL)
+                err = ((*pcert = OSSL_STORE_INFO_get1_CERT(info)) == NULL);
+            break;
+        case OSSL_STORE_INFO_CRL:
+            if (pcrl != NULL && *pcrl == NULL)
+                err = ((*pcrl = OSSL_STORE_INFO_get1_CRL(info)) == NULL);
+            break;
+        default:
+            /* skip any other type */
+            break;
+        }
+        OSSL_STORE_INFO_free(info);
+        if (err) {
+            BIO_printf(bio_err, "Could not read %s of %s from %s\n",
+                       infostr, desc, uri);
+            break;
+        }
+    }
+
+ end:
+    OSSL_STORE_close(ctx);
+    if (!ret)
+        ERR_print_errors(bio_err);
+    return ret;
+}
+
+EVP_PKEY *STORE_load_pkey(const char *uri, const char *pass, const char *desc)
+{
+    EVP_PKEY *pkey;
+    char *pass_string = get_passwd(pass, desc);
+
+    (void)STORE_load_key_cert_crl(uri, pass_string, desc, &pkey, NULL, NULL);
+    clear_free(pass_string);
+    return pkey;
+}
+
+X509 *STORE_load_cert(const char *uri, const char *pass, const char *desc)
+{
+    X509 *cert;
+    char *pass_string = get_passwd(pass, desc);
+
+    (void)STORE_load_key_cert_crl(uri, pass_string, desc, NULL, &cert, NULL);
+    clear_free(pass_string);
+    return cert;
+}
+
+inline X509_CRL *STORE_load_crl(const char *uri, const char *desc)
+{
+    X509_CRL *crl;
+
+    (void)STORE_load_key_cert_crl(uri, NULL, desc, NULL, NULL, &crl);
+    return crl;
+}
+
 
 #define X509V3_EXT_UNKNOWN_MASK         (0xfL << 16)
 /* Return error for unknown extensions */

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3158,8 +3158,7 @@ int s_client_main(int argc, char **argv)
     OPENSSL_clear_free(cbuf, BUFSIZZ);
     OPENSSL_clear_free(sbuf, BUFSIZZ);
     OPENSSL_clear_free(mbuf, BUFSIZZ);
-    if (proxypass != NULL)
-        OPENSSL_clear_free(proxypass, strlen(proxypass));
+    clear_free(proxypass);
     release_engine(e);
     BIO_free(bio_c_out);
     bio_c_out = NULL;


### PR DESCRIPTION
This is a further spin-off of PR #11470 according to https://github.com/openssl/openssl/pull/11470#discussion_r416669564 by @mattcaswell.

This also adds
STORE_load_key_cert_crl(), STORE_load_pkey(), 
STORE_load_cert(), STORE_load_crl(),
get_passwd(), cleanse(), and clear_free()
to be used also in `apps/cmp.c` etc.