### PR TITLE
Fix use-after-free in BIO_C_SET_SSL callback

### DIFF
--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -284,6 +284,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
             ssl_free(b);
             if (!ssl_new(b))
                 return 0;
+            bs = BIO_get_data(b);
         }
         BIO_set_shutdown(b, num);
         ssl = (SSL *)ptr;


### PR DESCRIPTION
Since the BIO_SSL structure was renewed by `ssl_free(b)/ssl_new(b)`,
the `bs` pointer needs to be updated before assigning to `bs->ssl`.

Thanks to @suishixingkong for reporting the issue and providing a fix.

Closes #10539
