### PR TITLE
Maintain strict type discipline between the core and providers

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -360,7 +360,7 @@ int ossl_init_thread_start(const void *index, void *arg,
          * libcrypto to tell us about later thread stop events. c_thread_start
          * is a callback to libcrypto defined in fipsprov.c
          */
-        if (!c_thread_start(FIPS_get_provider(ctx), ossl_ctx_thread_stop))
+        if (!c_thread_start(FIPS_get_core_handle(ctx), ossl_ctx_thread_stop))
             return 0;
     }
 #endif

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -488,7 +488,7 @@ static int provider_activate(OSSL_PROVIDER *prov)
 
     /* Call the initialise function for the provider. */
     if (prov->init_function == NULL
-        || !prov->init_function((OSSL_CORE_PROVIDER *)prov, core_dispatch,
+        || !prov->init_function((OSSL_CORE_HANDLE *)prov, core_dispatch,
                                 &provider_dispatch, &tmp_provctx)) {
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INIT_FAIL, NULL,
                        "name=%s", prov->name);
@@ -818,12 +818,12 @@ static OSSL_core_clear_last_error_mark_fn core_clear_last_error_mark;
 static OSSL_core_pop_error_to_mark_fn core_pop_error_to_mark;
 #endif
 
-static const OSSL_PARAM *core_gettable_params(const OSSL_CORE_PROVIDER *prov)
+static const OSSL_PARAM *core_gettable_params(const OSSL_CORE_HANDLE *handle)
 {
     return param_types;
 }
 
-static int core_get_params(const OSSL_CORE_PROVIDER *cprov, OSSL_PARAM params[])
+static int core_get_params(const OSSL_CORE_HANDLE *handle, OSSL_PARAM params[])
 {
     int i;
     OSSL_PARAM *p;
@@ -831,7 +831,7 @@ static int core_get_params(const OSSL_CORE_PROVIDER *cprov, OSSL_PARAM params[])
      * We created this object originally and we know it is actually an
      * OSSL_PROVIDER *, so the cast is safe
      */
-    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
     if ((p = OSSL_PARAM_locate(params, "openssl-version")) != NULL)
         OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR);
@@ -855,25 +855,25 @@ static int core_get_params(const OSSL_CORE_PROVIDER *cprov, OSSL_PARAM params[])
     return 1;
 }
 
-static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_PROVIDER *cprov)
+static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
 {
     /*
      * We created this object originally and we know it is actually an
      * OSSL_PROVIDER *, so the cast is safe
      */
-    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
     return (OPENSSL_CORE_CTX *)ossl_provider_library_context(prov);
 }
 
-static int core_thread_start(const OSSL_CORE_PROVIDER *cprov,
+static int core_thread_start(const OSSL_CORE_HANDLE *handle,
                              OSSL_thread_stop_handler_fn handfn)
 {
     /*
      * We created this object originally and we know it is actually an
      * OSSL_PROVIDER *, so the cast is safe
      */
-    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
     return ossl_init_thread_start(prov, prov->provctx, handfn);
 }
@@ -885,31 +885,31 @@ static int core_thread_start(const OSSL_CORE_PROVIDER *cprov,
  */
 #ifndef FIPS_MODULE
 /*
- * TODO(3.0) These error functions should use |prov| to select the proper
+ * TODO(3.0) These error functions should use |handle| to select the proper
  * library context to report in the correct error stack, at least if error
  * stacks become tied to the library context.
  * We cannot currently do that since there's no support for it in the
  * ERR subsystem.
  */
-static void core_new_error(const OSSL_CORE_PROVIDER *prov)
+static void core_new_error(const OSSL_CORE_HANDLE *handle)
 {
     ERR_new();
 }
 
-static void core_set_error_debug(const OSSL_CORE_PROVIDER *prov,
+static void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
                                  const char *file, int line, const char *func)
 {
     ERR_set_debug(file, line, func);
 }
 
-static void core_vset_error(const OSSL_CORE_PROVIDER *cprov,
+static void core_vset_error(const OSSL_CORE_HANDLE *handle,
                             uint32_t reason, const char *fmt, va_list args)
 {
     /*
      * We created this object originally and we know it is actually an
      * OSSL_PROVIDER *, so the cast is safe
      */
-    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
     /*
      * If the uppermost 8 bits are non-zero, it's an OpenSSL library
@@ -923,17 +923,17 @@ static void core_vset_error(const OSSL_CORE_PROVIDER *cprov,
     }
 }
 
-static int core_set_error_mark(const OSSL_CORE_PROVIDER *prov)
+static int core_set_error_mark(const OSSL_CORE_HANDLE *handle)
 {
     return ERR_set_mark();
 }
 
-static int core_clear_last_error_mark(const OSSL_CORE_PROVIDER *prov)
+static int core_clear_last_error_mark(const OSSL_CORE_HANDLE *handle)
 {
     return ERR_clear_last_mark();
 }
 
-static int core_pop_error_to_mark(const OSSL_CORE_PROVIDER *prov)
+static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
 {
     return ERR_pop_to_mark();
 }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -488,8 +488,8 @@ static int provider_activate(OSSL_PROVIDER *prov)
 
     /* Call the initialise function for the provider. */
     if (prov->init_function == NULL
-        || !prov->init_function(prov, core_dispatch, &provider_dispatch,
-                                &tmp_provctx)) {
+        || !prov->init_function((OSSL_CORE_PROVIDER *)prov, core_dispatch,
+                                &provider_dispatch, &tmp_provctx)) {
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INIT_FAIL, NULL,
                        "name=%s", prov->name);
 #ifndef FIPS_MODULE
@@ -818,15 +818,20 @@ static OSSL_core_clear_last_error_mark_fn core_clear_last_error_mark;
 static OSSL_core_pop_error_to_mark_fn core_pop_error_to_mark;
 #endif
 
-static const OSSL_PARAM *core_gettable_params(const OSSL_PROVIDER *prov)
+static const OSSL_PARAM *core_gettable_params(const OSSL_CORE_PROVIDER *prov)
 {
     return param_types;
 }
 
-static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
+static int core_get_params(const OSSL_CORE_PROVIDER *cprov, OSSL_PARAM params[])
 {
     int i;
     OSSL_PARAM *p;
+    /*
+     * We created this object originally and we know it is actually an
+     * OSSL_PROVIDER *, so the cast is safe
+     */
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
 
     if ((p = OSSL_PARAM_locate(params, "openssl-version")) != NULL)
         OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR);
@@ -850,14 +855,26 @@ static int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     return 1;
 }
 
-static OPENSSL_CTX *core_get_libctx(const OSSL_PROVIDER *prov)
+static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_PROVIDER *cprov)
 {
-    return ossl_provider_library_context(prov);
+    /*
+     * We created this object originally and we know it is actually an
+     * OSSL_PROVIDER *, so the cast is safe
+     */
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+
+    return (OPENSSL_CORE_CTX *)ossl_provider_library_context(prov);
 }
 
-static int core_thread_start(const OSSL_PROVIDER *prov,
+static int core_thread_start(const OSSL_CORE_PROVIDER *cprov,
                              OSSL_thread_stop_handler_fn handfn)
 {
+    /*
+     * We created this object originally and we know it is actually an
+     * OSSL_PROVIDER *, so the cast is safe
+     */
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+
     return ossl_init_thread_start(prov, prov->provctx, handfn);
 }
 
@@ -874,20 +891,26 @@ static int core_thread_start(const OSSL_PROVIDER *prov,
  * We cannot currently do that since there's no support for it in the
  * ERR subsystem.
  */
-static void core_new_error(const OSSL_PROVIDER *prov)
+static void core_new_error(const OSSL_CORE_PROVIDER *prov)
 {
     ERR_new();
 }
 
-static void core_set_error_debug(const OSSL_PROVIDER *prov,
+static void core_set_error_debug(const OSSL_CORE_PROVIDER *prov,
                                  const char *file, int line, const char *func)
 {
     ERR_set_debug(file, line, func);
 }
 
-static void core_vset_error(const OSSL_PROVIDER *prov,
+static void core_vset_error(const OSSL_CORE_PROVIDER *cprov,
                             uint32_t reason, const char *fmt, va_list args)
 {
+    /*
+     * We created this object originally and we know it is actually an
+     * OSSL_PROVIDER *, so the cast is safe
+     */
+    OSSL_PROVIDER *prov = (OSSL_PROVIDER *)cprov;
+
     /*
      * If the uppermost 8 bits are non-zero, it's an OpenSSL library
      * error and will be treated as such.  Otherwise, it's a new style
@@ -900,17 +923,17 @@ static void core_vset_error(const OSSL_PROVIDER *prov,
     }
 }
 
-static int core_set_error_mark(const OSSL_PROVIDER *prov)
+static int core_set_error_mark(const OSSL_CORE_PROVIDER *prov)
 {
     return ERR_set_mark();
 }
 
-static int core_clear_last_error_mark(const OSSL_PROVIDER *prov)
+static int core_clear_last_error_mark(const OSSL_CORE_PROVIDER *prov)
 {
     return ERR_clear_last_mark();
 }
 
-static int core_pop_error_to_mark(const OSSL_PROVIDER *prov)
+static int core_pop_error_to_mark(const OSSL_CORE_PROVIDER *prov)
 {
     return ERR_pop_to_mark();
 }
@@ -936,6 +959,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_BIO_NEW_FILE, (void (*)(void))BIO_new_file },
     { OSSL_FUNC_BIO_NEW_MEMBUF, (void (*)(void))BIO_new_mem_buf },
     { OSSL_FUNC_BIO_READ_EX, (void (*)(void))BIO_read_ex },
+    { OSSL_FUNC_BIO_WRITE_EX, (void (*)(void))BIO_write_ex },
     { OSSL_FUNC_BIO_FREE, (void (*)(void))BIO_free },
     { OSSL_FUNC_BIO_VPRINTF, (void (*)(void))BIO_vprintf },
     { OSSL_FUNC_BIO_VSNPRINTF, (void (*)(void))BIO_vsnprintf },

--- a/crypto/serializer/serializer_pkey.c
+++ b/crypto/serializer/serializer_pkey.c
@@ -255,7 +255,7 @@ static int serializer_write_cb(const OSSL_PARAM params[], void *arg)
     OSSL_SERIALIZER_CTX *ctx = write_data->ctx;
     BIO *out = write_data->out;
 
-    return ctx->ser->serialize_data(ctx->serctx, params, out,
+    return ctx->ser->serialize_data(ctx->serctx, params, (OSSL_CORE_BIO *)out,
                                     serializer_passphrase_out_cb, ctx);
 }
 
@@ -291,7 +291,8 @@ static int serializer_EVP_PKEY_to_bio(OSSL_SERIALIZER_CTX *ctx, BIO *out)
                                   &serializer_write_cb, &write_data);
     }
 
-    return ctx->ser->serialize_object(ctx->serctx, keydata, out,
+    return ctx->ser->serialize_object(ctx->serctx, keydata,
+                                      (OSSL_CORE_BIO *)out,
                                       serializer_passphrase_out_cb, ctx);
 }
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -16,15 +16,15 @@ provider-base
   */
 
  /* Functions offered by libcrypto to the providers */
- const OSSL_ITEM *core_gettable_params(const OSSL_PROVIDER *prov);
+ const OSSL_ITEM *core_gettable_params(const OSSL_CORE_PROVIDER *prov);
  int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
- int core_thread_start(const OSSL_PROVIDER *prov,
+ int core_thread_start(const OSSL_CORE_PROVIDER *prov,
                        OSSL_thread_stop_handler_fn handfn);
- OPENSSL_CTX *core_get_library_context(const OSSL_PROVIDER *prov);
- void core_new_error(const OSSL_PROVIDER *prov);
- void core_set_error_debug(const OSSL_PROVIDER *prov,
+ OPENSSL_CORE_CTX *core_get_library_context(const OSSL_CORE_PROVIDER *prov);
+ void core_new_error(const OSSL_CORE_PROVIDER *prov);
+ void core_set_error_debug(const OSSL_CORE_PROVIDER *prov,
                            const char *file, int line, const char *func);
- void core_vset_error(const OSSL_PROVIDER *prov,
+ void core_vset_error(const OSSL_CORE_PROVIDER *prov,
                       uint32_t reason, const char *fmt, va_list args);
 
  /*
@@ -52,7 +52,19 @@ provider-base
                                const char *file, int line);
  int CRYPTO_secure_allocated(const void *ptr);
  void OPENSSL_cleanse(void *ptr, size_t len);
- unsigned char *OPENSSL_hexstr2buf(const char *str, long *len);
+
+ OSSL_CORE_BIO * BIO_new_file(const char *filename, const char *mode)
+ OSSL_CORE_BIO * BIO_new_membuf(const void *buf, int len)
+ int BIO_read_ex(OSSL_CORE_BIO *bio, void *data, size_t data_len,
+                 size_t *bytes_read))
+ int BIO_write_ex(OSSL_CORE_BIO *bio, const void *data, size_t data_len,
+                  size_t *written)
+ int BIO_free(OSSL_CORE_BIO *bio))
+ int BIO_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list args)
+ int BIO_vsnprintf(char *buf, size_t n, const char *fmt, va_list args)
+
+ void self_test_cb(OPENSSL_CORE_CTX *ctx, OSSL_CALLBACK **cb, void **cbarg)
+
 
  /* Functions offered by the provider to libcrypto */
  void provider_teardown(void *provctx);
@@ -114,7 +126,6 @@ provider):
  BIO_free                       OSSL_FUNC_BIO_FREE
  BIO_vprintf                    OSSL_FUNC_BIO_VPRINTF
  OPENSSL_cleanse                OSSL_FUNC_OPENSSL_CLEANSE
- OPENSSL_hexstr2buf             OSSL_FUNC_OPENSSL_HEXSTR2BUF
  OSSL_SELF_TEST_set_callback    OSSL_FUNC_SELF_TEST_CB
 
 For I<*out> (the B<OSSL_DISPATCH> array passed from the provider to
@@ -188,7 +199,10 @@ BIO_new_file(), BIO_new_mem_buf(), BIO_read_ex(), BIO_free(),
 BIO_vprintf(), OPENSSL_cleanse(), and OPENSSL_hexstr2buf()
 correspond exactly to the public functions with the same name.
 As a matter of fact, the pointers in the B<OSSL_DISPATCH> array are
-direct pointers to those public functions.
+direct pointers to those public functions. Note that the BIO functions take an
+B<OSSL_CORE_BIO> type rather than the standard B<BIO> type. This is to ensure
+that a provider does not mix BIOs from the core with BIOs used on the provider
+side (the two are not compatible).
 OSSL_SELF_TEST_set_callback() is used to set an optional callback that can be
 passed into a provider. This may be ignored by a provider.
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -88,7 +88,7 @@ function pointer from a B<OSSL_DISPATCH> element named
 B<OSSL_get_{name}>.
 For example, the "function" core_gettable_params() has these:
 
- typedef OSSL_ITEM *
+ typedef OSSL_PARAM *
      (OSSL_core_gettable_params_fn)(const OSSL_CORE_HANDLE *handle);
  static ossl_inline OSSL_NAME_core_gettable_params_fn
      OSSL_get_core_gettable_params(const OSSL_DISPATCH *opf);
@@ -148,14 +148,14 @@ parameters.
 
 =for comment core_thread_start() TBA
 
-core_get_library_context() retrieves the library context in which the
-B<OSSL_CORE_HANDLE> object I<handle> is stored.
+core_get_library_context() retrieves the library context in which the library
+object for the current provider is stored, accessible through the I<handle>.
 This may sometimes be useful if the provider wishes to store a
 reference to its context in the same library context.
 
 core_new_error(), core_set_error_debug() and core_set_error() are
 building blocks for reporting an error back to the core, with
-reference to the handle object I<handle>.
+reference to the I<handle>.
 
 =over 4
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -16,15 +16,15 @@ provider-base
   */
 
  /* Functions offered by libcrypto to the providers */
- const OSSL_ITEM *core_gettable_params(const OSSL_CORE_PROVIDER *prov);
- int core_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[]);
- int core_thread_start(const OSSL_CORE_PROVIDER *prov,
+ const OSSL_ITEM *core_gettable_params(const OSSL_CORE_HANDLE *handle);
+ int core_get_params(const OSSL_CORE_HANDLE *handle, OSSL_PARAM params[]);
+ int core_thread_start(const OSSL_CORE_HANDLE *handle,
                        OSSL_thread_stop_handler_fn handfn);
- OPENSSL_CORE_CTX *core_get_library_context(const OSSL_CORE_PROVIDER *prov);
- void core_new_error(const OSSL_CORE_PROVIDER *prov);
- void core_set_error_debug(const OSSL_CORE_PROVIDER *prov,
+ OPENSSL_CORE_CTX *core_get_library_context(const OSSL_CORE_HANDLE *handle);
+ void core_new_error(const OSSL_CORE_HANDLE *handle);
+ void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
                            const char *file, int line, const char *func);
- void core_vset_error(const OSSL_CORE_PROVIDER *prov,
+ void core_vset_error(const OSSL_CORE_HANDLE *handle,
                       uint32_t reason, const char *fmt, va_list args);
 
  /*
@@ -89,7 +89,7 @@ B<OSSL_get_{name}>.
 For example, the "function" core_gettable_params() has these:
 
  typedef OSSL_ITEM *
-     (OSSL_core_gettable_params_fn)(const OSSL_PROVIDER *prov);
+     (OSSL_core_gettable_params_fn)(const OSSL_CORE_HANDLE *handle);
  static ossl_inline OSSL_NAME_core_gettable_params_fn
      OSSL_get_core_gettable_params(const OSSL_DISPATCH *opf);
 
@@ -142,20 +142,20 @@ F<libcrypto>):
 core_gettable_params() returns a constant array of descriptor
 B<OSSL_PARAM>, for parameters that core_get_params() can handle.
 
-core_get_params() retrieves I<prov> parameters from the core.
+core_get_params() retrieves parameters from the core for the given I<handle>.
 See L</Core parameters> below for a description of currently known
 parameters.
 
 =for comment core_thread_start() TBA
 
 core_get_library_context() retrieves the library context in which the
-B<OSSL_PROVIDER> object I<prov> is stored.
+B<OSSL_CORE_HANDLE> object I<handle> is stored.
 This may sometimes be useful if the provider wishes to store a
 reference to its context in the same library context.
 
 core_new_error(), core_set_error_debug() and core_set_error() are
 building blocks for reporting an error back to the core, with
-reference to the provider object I<prov>.
+reference to the handle object I<handle>.
 
 =over 4
 
@@ -341,7 +341,7 @@ operation C<BAR>.
 
  /* Provider context */
  struct prov_ctx_st {
-     OSSL_PROVIDER *prov;
+     OSSL_CORE_HANDLE *handle;
  }
 
  /* operation context for the algorithm FOO */
@@ -357,7 +357,7 @@ operation C<BAR>.
      if (fooctx != NULL)
          fooctx->provctx = provctx;
      else
-         c_put_error(provctx->prov, E_MALLOC, __FILE__, __LINE__);
+         c_put_error(provctx->handle, E_MALLOC, __FILE__, __LINE__);
      return fooctx;
  }
 
@@ -433,7 +433,7 @@ operation C<BAR>.
      { 0, NULL }
  };
 
- int OSSL_provider_init(const OSSL_PROVIDER *provider,
+ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                         const OSSL_DISPATCH *in,
                         const OSSL_DISPATCH **out,
                         void **provctx)
@@ -454,9 +454,10 @@ operation C<BAR>.
           * ALEA IACTA EST, if the core retrieves the reason table
           * regardless, that string will be displayed, otherwise not.
           */
-         c_put_error(provider, E_MALLOC, __FILE__, __LINE__);
+         c_put_error(handle, E_MALLOC, __FILE__, __LINE__);
          return 0;
      }
+     pctx->handle = handle;
      return 1;
  }
 

--- a/doc/man7/provider-serializer.pod
+++ b/doc/man7/provider-serializer.pod
@@ -28,10 +28,10 @@ Future development will also include deserializing functions.
 
  /* Functions to serialize object data */
  int OP_serializer_serialize_data(void *ctx, const OSSL_PARAM *data,
-                                  BIO *out,
+                                  OSSL_CORE_BIO *out,
                                   OSSL_PASSPHRASE_CALLBACK *cb,
                                   void *cbarg);
- int OP_serializer_serialize_object(void *ctx, void *obj, BIO *out,
+ int OP_serializer_serialize_object(void *ctx, void *obj, OSSL_CORE_BIO *out,
                                     OSSL_PASSPHRASE_CALLBACK *cb,
                                     void *cbarg);
 
@@ -39,11 +39,11 @@ Future development will also include deserializing functions.
 
 The SERIALIZER is a generic method to serialize any set of object data
 in L<OSSL_PARAM(3)> array form, or any provider side object into
-serialized form, and write it to the given BIO.  If the caller wants
+serialized form, and write it to the given OSSL_CORE_BIO.  If the caller wants
 to get the serialized stream to memory, it should provide a
 L<BIO_s_membuf(3)>.
 
-The serializer doesn't need to know more about the B<BIO> pointer than
+The serializer doesn't need to know more about the B<OSSL_CORE_BIO> pointer than
 being able to pass it to the appropriate BIO upcalls (see
 L<provider-base(7)/Core functions>).
 
@@ -71,7 +71,7 @@ For example, the "function" OP_serializer_serialize_data() has these:
  typedef int
      (OSSL_OP_serializer_serialize_data_fn)(void *provctx,
                                             const OSSL_PARAM params[],
-                                            BIO *out);
+                                            OSSL_CORE_BIO *out);
  static ossl_inline OSSL_OP_serializer_serialize_data_fn
      OSSL_get_OP_serializer_serialize_data(const OSSL_DISPATCH *opf);
 
@@ -180,11 +180,11 @@ by OP_serializer_set_ctx_params() and OP_serializer_settable_ctx_params().
 OP_serializer_serialize_data() should take an array of B<OSSL_PARAM>,
 I<data>, and if it contains the data necessary for the object type
 that the implementation handles, it should output the object in
-serialized form to the B<BIO>.
+serialized form to the B<OSSL_CORE_BIO>.
 
 OP_serializer_serialize_object() should take a pointer to an object
 that it knows intimately, and output that object in serialized form to
-the B<BIO>.  The caller I<must> ensure that this function is called
+the B<OSSL_CORE_BIO>.  The caller I<must> ensure that this function is called
 with a pointer that the provider of this function is familiar with.
 It is not suitable to use with object pointers coming from other
 providers.

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -42,7 +42,7 @@ If it's built-in, the initialization function may have any name.
 
 The initialization function must have the following signature:
 
- int NAME(const OSSL_PROVIDER *provider,
+ int NAME(const OSSL_CORE_PROVIDER *provider,
           const OSSL_DISPATCH *in, const OSSL_DISPATCH **out,
           void **provctx);
 
@@ -287,6 +287,13 @@ be loaded explicitly, either in code or through OpenSSL configuration
 Should it be needed (if other providers are loaded and offer
 implementations of the same algorithms), the property "provider=legacy" can be
 used as a search criterion for these implementations.
+
+=head2 Null provider
+
+The null provider is built in as part of the F<libcrypto> library. It contains
+no algorithms in it at all. When fetching algorithms the default provider will
+be automatically loaded if no other provider has been explicitly loaded. To
+prevent that from happening you can explicitly load the null provider.
 
 =head1 EXAMPLES
 

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -42,16 +42,15 @@ If it's built-in, the initialization function may have any name.
 
 The initialization function must have the following signature:
 
- int NAME(const OSSL_CORE_PROVIDER *provider,
+ int NAME(const OSSL_CORE_HANDLE *handle,
           const OSSL_DISPATCH *in, const OSSL_DISPATCH **out,
           void **provctx);
 
-I<provider> is the OpenSSL library object for the provider, and works
+I<handle> is the OpenSSL library object for the provider, and works
 as a handle for everything the OpenSSL libraries need to know about
 the provider.
-For the provider itself, it may hold some interesting information,
-and is also passed to some of the functions given in the dispatch
-array I<in>.
+For the provider itself, it is passed to some of the functions given in the
+dispatch array I<in>.
 
 I<in> is a dispatch array of base functions offered by the OpenSSL
 libraries, and the available functions are further described in

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -157,7 +157,8 @@ typedef struct ossl_ex_data_global_st {
 # define OPENSSL_CTX_FIPS_PROV_INDEX                9
 # define OPENSSL_CTX_SERIALIZER_STORE_INDEX        10
 # define OPENSSL_CTX_SELF_TEST_CB_INDEX            11
-# define OPENSSL_CTX_MAX_INDEXES                   12
+# define OPENSSL_CTX_BIO_PROV_INDEX                12
+# define OPENSSL_CTX_MAX_INDEXES                   13
 
 typedef struct openssl_ctx_method {
     void *(*new_func)(OPENSSL_CTX *ctx);

--- a/include/openssl/bio.h
+++ b/include/openssl/bio.h
@@ -61,6 +61,7 @@ extern "C" {
 # ifndef OPENSSL_NO_SCTP
 #  define BIO_TYPE_DGRAM_SCTP    (24|BIO_TYPE_SOURCE_SINK|BIO_TYPE_DESCRIPTOR)
 # endif
+# define BIO_TYPE_CORE_TO_PROV   (25|BIO_TYPE_FILTER)
 
 #define BIO_TYPE_START           128
 

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -25,6 +25,11 @@ extern "C" {
  * to communicate data between them.
  */
 
+/* Opaque handles used by functions from the core */
+typedef void *OSSL_CORE_PROVIDER;
+typedef void *OPENSSL_CORE_CTX;
+typedef void *OSSL_CORE_BIO;
+
 /*
  * Dispatch table element.  function_id numbers are defined further down,
  * see macros with '_FUNC' in their names.
@@ -180,7 +185,7 @@ typedef void (*OSSL_thread_stop_handler_fn)(void *arg);
  *              provider needs it.  This value is passed to other provider
  *              functions, notably other context constructors.
  */
-typedef int (OSSL_provider_init_fn)(const OSSL_PROVIDER *provider,
+typedef int (OSSL_provider_init_fn)(const OSSL_CORE_PROVIDER *provider,
                                     const OSSL_DISPATCH *in,
                                     const OSSL_DISPATCH **out,
                                     void **provctx);

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -25,11 +25,6 @@ extern "C" {
  * to communicate data between them.
  */
 
-/* Opaque handles to be used with core upcall functions */
-typedef void *OSSL_CORE_HANDLE;
-typedef void *OPENSSL_CORE_CTX;
-typedef void *OSSL_CORE_BIO;
-
 /*
  * Dispatch table element.  function_id numbers are defined further down,
  * see macros with '_FUNC' in their names.

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -25,8 +25,8 @@ extern "C" {
  * to communicate data between them.
  */
 
-/* Opaque handles used by functions from the core */
-typedef void *OSSL_CORE_PROVIDER;
+/* Opaque handles to be used with core upcall functions */
+typedef void *OSSL_CORE_HANDLE;
 typedef void *OPENSSL_CORE_CTX;
 typedef void *OSSL_CORE_BIO;
 
@@ -176,7 +176,7 @@ typedef void (*OSSL_thread_stop_handler_fn)(void *arg);
  * module, that module is not an OpenSSL provider module.
  */
 /*-
- * |provider|   pointer to opaque type OSSL_PROVIDER.  This can be used
+ * |handle|     pointer to opaque type OSSL_CORE_HANDLE.  This can be used
  *              together with some functions passed via |in| to query data.
  * |in|         is the array of functions that the Core passes to the provider.
  * |out|        will be the array of base functions that the provider passes
@@ -185,7 +185,7 @@ typedef void (*OSSL_thread_stop_handler_fn)(void *arg);
  *              provider needs it.  This value is passed to other provider
  *              functions, notably other context constructors.
  */
-typedef int (OSSL_provider_init_fn)(const OSSL_CORE_PROVIDER *provider,
+typedef int (OSSL_provider_init_fn)(const OSSL_CORE_HANDLE *handle,
                                     const OSSL_DISPATCH *in,
                                     const OSSL_DISPATCH **out,
                                     void **provctx);

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -25,6 +25,11 @@ extern "C" {
  * to communicate data between them.
  */
 
+/* Opaque handles to be used with core upcall functions from providers */
+typedef struct ossl_core_handle_st OSSL_CORE_HANDLE;
+typedef struct openssl_core_ctx_st OPENSSL_CORE_CTX;
+typedef struct ossl_core_bio_st OSSL_CORE_BIO;
+
 /*
  * Dispatch table element.  function_id numbers are defined further down,
  * see macros with '_FUNC' in their names.

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -12,7 +12,6 @@
 
 # include <stdarg.h>
 # include <openssl/core.h>
-# include <openssl/self_test.h>
 
 # ifdef __cplusplus
 extern "C" {
@@ -60,33 +59,33 @@ extern "C" {
 /* Functions provided by the Core to the provider, reserved numbers 1-1023 */
 # define OSSL_FUNC_CORE_GETTABLE_PARAMS        1
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    core_gettable_params,(const OSSL_PROVIDER *prov))
+                    core_gettable_params,(const OSSL_CORE_PROVIDER *prov))
 # define OSSL_FUNC_CORE_GET_PARAMS             2
-OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_PROVIDER *prov,
+OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_CORE_PROVIDER *prov,
                                          OSSL_PARAM params[]))
 # define OSSL_FUNC_CORE_THREAD_START           3
-OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_PROVIDER *prov,
+OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_CORE_PROVIDER *prov,
                                            OSSL_thread_stop_handler_fn handfn))
 # define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    4
-OSSL_CORE_MAKE_FUNC(OPENSSL_CTX *,core_get_library_context,
-                    (const OSSL_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(OPENSSL_CORE_CTX *,core_get_library_context,
+                    (const OSSL_CORE_PROVIDER *prov))
 # define OSSL_FUNC_CORE_NEW_ERROR              5
-OSSL_CORE_MAKE_FUNC(void,core_new_error,(const OSSL_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(void,core_new_error,(const OSSL_CORE_PROVIDER *prov))
 # define OSSL_FUNC_CORE_SET_ERROR_DEBUG        6
 OSSL_CORE_MAKE_FUNC(void,core_set_error_debug,
-                    (const OSSL_PROVIDER *prov,
+                    (const OSSL_CORE_PROVIDER *prov,
                      const char *file, int line, const char *func))
 # define OSSL_FUNC_CORE_VSET_ERROR             7
 OSSL_CORE_MAKE_FUNC(void,core_vset_error,
-                    (const OSSL_PROVIDER *prov,
+                    (const OSSL_CORE_PROVIDER *prov,
                      uint32_t reason, const char *fmt, va_list args))
 # define OSSL_FUNC_CORE_SET_ERROR_MARK         8
-OSSL_CORE_MAKE_FUNC(int, core_set_error_mark, (const OSSL_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(int, core_set_error_mark, (const OSSL_CORE_PROVIDER *prov))
 # define OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK  9
 OSSL_CORE_MAKE_FUNC(int, core_clear_last_error_mark,
-                    (const OSSL_PROVIDER *prov))
+                    (const OSSL_CORE_PROVIDER *prov))
 # define OSSL_FUNC_CORE_POP_ERROR_TO_MARK     10
-OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_CORE_PROVIDER *prov))
 
 /* Memory allocation, freeing, clearing. */
 #define OSSL_FUNC_CRYPTO_MALLOC               20
@@ -132,22 +131,26 @@ OSSL_CORE_MAKE_FUNC(void,
 #define OSSL_FUNC_BIO_NEW_FILE                40
 #define OSSL_FUNC_BIO_NEW_MEMBUF              41
 #define OSSL_FUNC_BIO_READ_EX                 42
-#define OSSL_FUNC_BIO_FREE                    43
-#define OSSL_FUNC_BIO_VPRINTF                 44
-#define OSSL_FUNC_BIO_VSNPRINTF               45
+#define OSSL_FUNC_BIO_WRITE_EX                43
+#define OSSL_FUNC_BIO_FREE                    44
+#define OSSL_FUNC_BIO_VPRINTF                 45
+#define OSSL_FUNC_BIO_VSNPRINTF               46
 
-OSSL_CORE_MAKE_FUNC(BIO *, BIO_new_file, (const char *filename, const char *mode))
-OSSL_CORE_MAKE_FUNC(BIO *, BIO_new_membuf, (const void *buf, int len))
-OSSL_CORE_MAKE_FUNC(int, BIO_read_ex, (BIO *bio, void *data, size_t data_len,
-                                       size_t *bytes_read))
-OSSL_CORE_MAKE_FUNC(int, BIO_free, (BIO *bio))
-OSSL_CORE_MAKE_FUNC(int, BIO_vprintf, (BIO *bio, const char *format,
+OSSL_CORE_MAKE_FUNC(OSSL_CORE_BIO *, BIO_new_file, (const char *filename,
+                                                    const char *mode))
+OSSL_CORE_MAKE_FUNC(OSSL_CORE_BIO *, BIO_new_membuf, (const void *buf, int len))
+OSSL_CORE_MAKE_FUNC(int, BIO_read_ex, (OSSL_CORE_BIO *bio, void *data,
+                                       size_t data_len, size_t *bytes_read))
+OSSL_CORE_MAKE_FUNC(int, BIO_write_ex, (OSSL_CORE_BIO *bio, const void *data,
+                                        size_t data_len, size_t *written))
+OSSL_CORE_MAKE_FUNC(int, BIO_free, (OSSL_CORE_BIO *bio))
+OSSL_CORE_MAKE_FUNC(int, BIO_vprintf, (OSSL_CORE_BIO *bio, const char *format,
                                        va_list args))
 OSSL_CORE_MAKE_FUNC(int, BIO_vsnprintf,
                    (char *buf, size_t n, const char *fmt, va_list args))
 
 #define OSSL_FUNC_SELF_TEST_CB               100
-OSSL_CORE_MAKE_FUNC(void, self_test_cb, (OPENSSL_CTX *ctx, OSSL_CALLBACK **cb,
+OSSL_CORE_MAKE_FUNC(void, self_test_cb, (OPENSSL_CORE_CTX *ctx, OSSL_CALLBACK **cb,
                                          void **cbarg))
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
@@ -637,10 +640,10 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, OP_serializer_settable_ctx_params,
                     (void))
 
 OSSL_CORE_MAKE_FUNC(int, OP_serializer_serialize_data,
-                    (void *ctx, const OSSL_PARAM[], BIO *out,
+                    (void *ctx, const OSSL_PARAM[], OSSL_CORE_BIO *out,
                      OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg))
 OSSL_CORE_MAKE_FUNC(int, OP_serializer_serialize_object,
-                    (void *ctx, void *obj, BIO *out,
+                    (void *ctx, void *obj, OSSL_CORE_BIO *out,
                      OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg))
 
 # ifdef __cplusplus

--- a/include/openssl/core_numbers.h
+++ b/include/openssl/core_numbers.h
@@ -59,33 +59,33 @@ extern "C" {
 /* Functions provided by the Core to the provider, reserved numbers 1-1023 */
 # define OSSL_FUNC_CORE_GETTABLE_PARAMS        1
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    core_gettable_params,(const OSSL_CORE_PROVIDER *prov))
+                    core_gettable_params,(const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_GET_PARAMS             2
-OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_CORE_PROVIDER *prov,
+OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_CORE_HANDLE *prov,
                                          OSSL_PARAM params[]))
 # define OSSL_FUNC_CORE_THREAD_START           3
-OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_CORE_PROVIDER *prov,
+OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_CORE_HANDLE *prov,
                                            OSSL_thread_stop_handler_fn handfn))
 # define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    4
 OSSL_CORE_MAKE_FUNC(OPENSSL_CORE_CTX *,core_get_library_context,
-                    (const OSSL_CORE_PROVIDER *prov))
+                    (const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_NEW_ERROR              5
-OSSL_CORE_MAKE_FUNC(void,core_new_error,(const OSSL_CORE_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(void,core_new_error,(const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_SET_ERROR_DEBUG        6
 OSSL_CORE_MAKE_FUNC(void,core_set_error_debug,
-                    (const OSSL_CORE_PROVIDER *prov,
+                    (const OSSL_CORE_HANDLE *prov,
                      const char *file, int line, const char *func))
 # define OSSL_FUNC_CORE_VSET_ERROR             7
 OSSL_CORE_MAKE_FUNC(void,core_vset_error,
-                    (const OSSL_CORE_PROVIDER *prov,
+                    (const OSSL_CORE_HANDLE *prov,
                      uint32_t reason, const char *fmt, va_list args))
 # define OSSL_FUNC_CORE_SET_ERROR_MARK         8
-OSSL_CORE_MAKE_FUNC(int, core_set_error_mark, (const OSSL_CORE_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(int, core_set_error_mark, (const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK  9
 OSSL_CORE_MAKE_FUNC(int, core_clear_last_error_mark,
-                    (const OSSL_CORE_PROVIDER *prov))
+                    (const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_POP_ERROR_TO_MARK     10
-OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_CORE_PROVIDER *prov))
+OSSL_CORE_MAKE_FUNC(int, core_pop_error_to_mark, (const OSSL_CORE_HANDLE *prov))
 
 /* Memory allocation, freeing, clearing. */
 #define OSSL_FUNC_CRYPTO_MALLOC               20

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -229,6 +229,11 @@ typedef long ossl_intmax_t;
 typedef unsigned long ossl_uintmax_t;
 #endif
 
+/* Opaque handles to be used with core upcall functions from providers */
+typedef struct ossl_core_handle_st OSSL_CORE_HANDLE;
+typedef struct openssl_core_ctx_st OPENSSL_CORE_CTX;
+typedef struct ossl_core_bio_st OSSL_CORE_BIO;
+
 #ifdef  __cplusplus
 }
 #endif

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -229,11 +229,6 @@ typedef long ossl_intmax_t;
 typedef unsigned long ossl_uintmax_t;
 #endif
 
-/* Opaque handles to be used with core upcall functions from providers */
-typedef struct ossl_core_handle_st OSSL_CORE_HANDLE;
-typedef struct openssl_core_ctx_st OPENSSL_CORE_CTX;
-typedef struct ossl_core_bio_st OSSL_CORE_BIO;
-
 #ifdef  __cplusplus
 }
 #endif

--- a/providers/common/bio_prov.c
+++ b/providers/common/bio_prov.c
@@ -7,12 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <assert.h>
 #include <openssl/core_numbers.h>
+#include "internal/cryptlib.h"
 #include "prov/bio.h"
 
 static OSSL_BIO_new_file_fn *c_bio_new_file = NULL;
 static OSSL_BIO_new_membuf_fn *c_bio_new_membuf = NULL;
 static OSSL_BIO_read_ex_fn *c_bio_read_ex = NULL;
+static OSSL_BIO_write_ex_fn *c_bio_write_ex = NULL;
 static OSSL_BIO_free_fn *c_bio_free = NULL;
 static OSSL_BIO_vprintf_fn *c_bio_vprintf = NULL;
 
@@ -32,6 +35,10 @@ int ossl_prov_bio_from_dispatch(const OSSL_DISPATCH *fns)
             if (c_bio_read_ex == NULL)
                 c_bio_read_ex = OSSL_get_BIO_read_ex(fns);
             break;
+        case OSSL_FUNC_BIO_WRITE_EX:
+            if (c_bio_write_ex == NULL)
+                c_bio_write_ex = OSSL_get_BIO_write_ex(fns);
+            break;
         case OSSL_FUNC_BIO_FREE:
             if (c_bio_free == NULL)
                 c_bio_free = OSSL_get_BIO_free(fns);
@@ -46,21 +53,21 @@ int ossl_prov_bio_from_dispatch(const OSSL_DISPATCH *fns)
     return 1;
 }
 
-BIO *ossl_prov_bio_new_file(const char *filename, const char *mode)
+OSSL_CORE_BIO *ossl_prov_bio_new_file(const char *filename, const char *mode)
 {
     if (c_bio_new_file == NULL)
         return NULL;
     return c_bio_new_file(filename, mode);
 }
 
-BIO *ossl_prov_bio_new_membuf(const char *filename, int len)
+OSSL_CORE_BIO *ossl_prov_bio_new_membuf(const char *filename, int len)
 {
     if (c_bio_new_membuf == NULL)
         return NULL;
     return c_bio_new_membuf(filename, len);
 }
 
-int ossl_prov_bio_read_ex(BIO *bio, void *data, size_t data_len,
+int ossl_prov_bio_read_ex(OSSL_CORE_BIO *bio, void *data, size_t data_len,
                           size_t *bytes_read)
 {
     if (c_bio_read_ex == NULL)
@@ -68,21 +75,29 @@ int ossl_prov_bio_read_ex(BIO *bio, void *data, size_t data_len,
     return c_bio_read_ex(bio, data, data_len, bytes_read);
 }
 
-int ossl_prov_bio_free(BIO *bio)
+int ossl_prov_bio_write_ex(OSSL_CORE_BIO *bio, const void *data, size_t data_len,
+                           size_t *written)
+{
+    if (c_bio_write_ex == NULL)
+        return 0;
+    return c_bio_write_ex(bio, data, data_len, written);
+}
+
+int ossl_prov_bio_free(OSSL_CORE_BIO *bio)
 {
     if (c_bio_free == NULL)
         return 0;
     return c_bio_free(bio);
 }
 
-int ossl_prov_bio_vprintf(BIO *bio, const char *format, va_list ap)
+int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list ap)
 {
     if (c_bio_vprintf == NULL)
         return -1;
     return c_bio_vprintf(bio, format, ap);
 }
 
-int ossl_prov_bio_printf(BIO *bio, const char *format, ...)
+int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *format, ...)
 {
     va_list ap;
     int ret;
@@ -94,3 +109,110 @@ int ossl_prov_bio_printf(BIO *bio, const char *format, ...)
     return ret;
 }
 
+#ifndef FIPS_MODULE
+
+/* No direct BIO support in the FIPS module */
+
+static int bio_core_read_ex(BIO *bio, char *data, size_t data_len,
+                            size_t *bytes_read)
+{
+    return ossl_prov_bio_read_ex(BIO_get_data(bio), data, data_len, bytes_read);
+}
+
+static int bio_core_write_ex(BIO *bio, const char *data, size_t data_len,
+                             size_t *written)
+{
+    return ossl_prov_bio_write_ex(BIO_get_data(bio), data, data_len, written);
+}
+
+static long bio_core_ctrl(BIO *bio, int cmd, long num, void *ptr)
+{
+    /* We don't support this */
+    assert(0);
+    return 0;
+}
+
+static int bio_core_gets(BIO *bio, char *buf, int size)
+{
+    /* We don't support this */
+    assert(0);
+    return -1;
+}
+
+static int bio_core_puts(BIO *bio, const char *str)
+{
+    /* We don't support this */
+    assert(0);
+    return -1;
+}
+
+static int bio_core_new(BIO *bio)
+{
+    BIO_set_init(bio, 1);
+
+    return 1;
+}
+
+static int bio_core_free(BIO *bio)
+{
+    BIO_set_init(bio, 0);
+
+    return 1;
+}
+
+typedef struct bio_prov_global_st {
+    BIO_METHOD *biocoremeth;
+} BIO_PROV_GLOBAL;
+
+static void *bio_prov_ossl_ctx_new(OPENSSL_CTX *libctx)
+{
+    BIO_PROV_GLOBAL *bpgbl = OPENSSL_zalloc(sizeof(*bpgbl));
+    BIO_METHOD *biocoremeth = NULL;
+
+    biocoremeth = BIO_meth_new(BIO_TYPE_CORE_TO_PROV, "BIO to Core filter");
+    if (biocoremeth == NULL
+            || !BIO_meth_set_write_ex(biocoremeth, bio_core_write_ex)
+            || !BIO_meth_set_read_ex(biocoremeth, bio_core_read_ex)
+            || !BIO_meth_set_puts(biocoremeth, bio_core_puts)
+            || !BIO_meth_set_gets(biocoremeth, bio_core_gets)
+            || !BIO_meth_set_ctrl(biocoremeth, bio_core_ctrl)
+            || !BIO_meth_set_create(biocoremeth, bio_core_new)
+            || !BIO_meth_set_destroy(biocoremeth, bio_core_free)) {
+        OPENSSL_free(bpgbl);
+        BIO_meth_free(biocoremeth);
+        return NULL;
+    }
+
+    bpgbl->biocoremeth = biocoremeth;
+
+    return bpgbl;
+}
+
+static void bio_prov_ossl_ctx_free(void *vbpgbl)
+{
+    BIO_PROV_GLOBAL *bpgbl = vbpgbl;
+
+    BIO_meth_free(bpgbl->biocoremeth);
+    OPENSSL_free(bpgbl);
+}
+
+static const OPENSSL_CTX_METHOD bio_prov_ossl_ctx_method = {
+    bio_prov_ossl_ctx_new,
+    bio_prov_ossl_ctx_free,
+};
+
+BIO *BIO_new_from_core_bio(OPENSSL_CTX *libctx, OSSL_CORE_BIO *corebio)
+{
+    BIO_PROV_GLOBAL *bpgbl = openssl_ctx_get_data(libctx,
+                                                  OPENSSL_CTX_BIO_PROV_INDEX,
+                                                  &bio_prov_ossl_ctx_method);
+
+    BIO *outbio = BIO_new(bpgbl->biocoremeth);
+
+    if (outbio != NULL)
+        BIO_set_data(outbio, corebio);
+
+    return outbio;
+}
+
+#endif

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=der
 
-SOURCE[../libcommon.a]=provider_err.c bio_prov.c provider_ctx.c
-$FIPSCOMMON=provider_util.c
-SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
+SOURCE[../libcommon.a]=provider_err.c
+$FIPSCOMMON=provider_util.c provider_ctx.c
+SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c bio_prov.c
 SOURCE[../libfips.a]=$FIPSCOMMON

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=der
 
-SOURCE[../libcommon.a]=provider_err.c
-$FIPSCOMMON=provider_util.c provider_ctx.c
-SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c bio_prov.c
+SOURCE[../libcommon.a]=provider_err.c bio_prov.c provider_ctx.c
+$FIPSCOMMON=provider_util.c
+SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
 SOURCE[../libfips.a]=$FIPSCOMMON

--- a/providers/common/include/prov/bio.h
+++ b/providers/common/include/prov/bio.h
@@ -13,10 +13,14 @@
 
 int ossl_prov_bio_from_dispatch(const OSSL_DISPATCH *fns);
 
-BIO *ossl_prov_bio_new_file(const char *filename, const char *mode);
-BIO *ossl_prov_bio_new_membuf(const char *filename, int len);
-int ossl_prov_bio_read_ex(BIO *bio, void *data, size_t data_len,
+OSSL_CORE_BIO *ossl_prov_bio_new_file(const char *filename, const char *mode);
+OSSL_CORE_BIO *ossl_prov_bio_new_membuf(const char *filename, int len);
+int ossl_prov_bio_read_ex(OSSL_CORE_BIO *bio, void *data, size_t data_len,
                           size_t *bytes_read);
-int ossl_prov_bio_free(BIO *bio);
-int ossl_prov_bio_vprintf(BIO *bio, const char *format, va_list ap);
-int ossl_prov_bio_printf(BIO *bio, const char *format, ...);
+int ossl_prov_bio_write_ex(OSSL_CORE_BIO *bio, const void *data, size_t data_len,
+                           size_t *written);
+int ossl_prov_bio_free(OSSL_CORE_BIO *bio);
+int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list ap);
+int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *format, ...);
+
+BIO *BIO_new_from_core_bio(OPENSSL_CTX *libctx, OSSL_CORE_BIO *corebio);

--- a/providers/common/include/prov/bio.h
+++ b/providers/common/include/prov/bio.h
@@ -10,6 +10,7 @@
 #include <stdarg.h>
 #include <openssl/bio.h>
 #include <openssl/core.h>
+#include "prov/provider_ctx.h"
 
 int ossl_prov_bio_from_dispatch(const OSSL_DISPATCH *fns);
 
@@ -23,4 +24,5 @@ int ossl_prov_bio_free(OSSL_CORE_BIO *bio);
 int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list ap);
 int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *format, ...);
 
-BIO *BIO_new_from_core_bio(OPENSSL_CTX *libctx, OSSL_CORE_BIO *corebio);
+BIO_METHOD *bio_prov_init_bio_method(void);
+BIO *bio_new_from_core_bio(PROV_CTX *provctx, OSSL_CORE_BIO *corebio);

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -11,7 +11,7 @@
 #include <openssl/crypto.h>
 
 typedef struct prov_ctx_st {
-    const OSSL_PROVIDER *provider;
+    const OSSL_CORE_HANDLE *handle;
     OPENSSL_CTX *libctx;         /* For all provider modules */
 } PROV_CTX;
 
@@ -25,6 +25,6 @@ typedef struct prov_ctx_st {
 PROV_CTX *PROV_CTX_new(void);
 void PROV_CTX_free(PROV_CTX *ctx);
 void PROV_CTX_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx);
-void PROV_CTX_set0_provider(PROV_CTX *ctx, const OSSL_PROVIDER *libctx);
+void PROV_CTX_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle);
 OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx);
-const OSSL_PROVIDER *PROV_CTX_get0_provider(PROV_CTX *ctx);
+const OSSL_CORE_HANDLE *PROV_CTX_get0_handle(PROV_CTX *ctx);

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -7,19 +7,24 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/types.h>
-#include <openssl/crypto.h>
+#ifndef OSSL_PROV_PROVIDER_CTX_H
+# define OSSL_PROV_PROVIDER_CTX_H
+
+# include <openssl/types.h>
+# include <openssl/crypto.h>
+# include <openssl/bio.h>
 
 typedef struct prov_ctx_st {
     const OSSL_CORE_HANDLE *handle;
     OPENSSL_CTX *libctx;         /* For all provider modules */
+    BIO_METHOD *corebiometh;
 } PROV_CTX;
 
 /*
  * To be used anywhere the library context needs to be passed, such as to
  * fetching functions.
  */
-#define PROV_LIBRARY_CONTEXT_OF(provctx)        \
+# define PROV_LIBRARY_CONTEXT_OF(provctx)        \
     PROV_CTX_get0_library_context((provctx))
 
 PROV_CTX *PROV_CTX_new(void);
@@ -28,3 +33,6 @@ void PROV_CTX_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx);
 void PROV_CTX_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle);
 OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx);
 const OSSL_CORE_HANDLE *PROV_CTX_get0_handle(PROV_CTX *ctx);
+BIO_METHOD *PROV_CTX_get0_core_bio_method(PROV_CTX *ctx);
+
+#endif

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -13,6 +13,7 @@
 # include <openssl/types.h>
 # include <openssl/crypto.h>
 # include <openssl/bio.h>
+# include <openssl/core.h>
 
 typedef struct prov_ctx_st {
     const OSSL_CORE_HANDLE *handle;
@@ -31,6 +32,7 @@ PROV_CTX *PROV_CTX_new(void);
 void PROV_CTX_free(PROV_CTX *ctx);
 void PROV_CTX_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx);
 void PROV_CTX_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle);
+void PROV_CTX_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh);
 OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx);
 const OSSL_CORE_HANDLE *PROV_CTX_get0_handle(PROV_CTX *ctx);
 BIO_METHOD *PROV_CTX_get0_core_bio_method(PROV_CTX *ctx);

--- a/providers/common/include/prov/providercommon.h
+++ b/providers/common/include/prov/providercommon.h
@@ -9,7 +9,7 @@
 
 #include <openssl/provider.h>
 
-const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx);
+const OSSL_CORE_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx);
 
 const char *ossl_prov_util_nid_to_name(int nid);
 

--- a/providers/common/include/prov/providercommon.h
+++ b/providers/common/include/prov/providercommon.h
@@ -9,7 +9,7 @@
 
 #include <openssl/provider.h>
 
-const OSSL_CORE_PROVIDER *FIPS_get_provider(OPENSSL_CTX *ctx);
+const OSSL_CORE_HANDLE *FIPS_get_core_handle(OPENSSL_CTX *ctx);
 
 const char *ossl_prov_util_nid_to_name(int nid);
 

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -13,27 +13,11 @@
 
 PROV_CTX *PROV_CTX_new(void)
 {
-    PROV_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
-
-    if (ctx == NULL)
-        return NULL;
-
-# ifndef FIPS_MODULE
-    ctx->corebiometh = bio_prov_init_bio_method();
-    if (ctx->corebiometh == NULL) {
-        OPENSSL_free(ctx);
-        return NULL;
-    }
-# endif
-
-    return ctx;
+    return OPENSSL_zalloc(sizeof(PROV_CTX));
 }
 
 void PROV_CTX_free(PROV_CTX *ctx)
 {
-# ifndef FIPS_MODULE
-    BIO_meth_free(ctx->corebiometh);
-# endif
     OPENSSL_free(ctx);
 }
 
@@ -49,6 +33,11 @@ void PROV_CTX_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle)
         ctx->handle = handle;
 }
 
+void PROV_CTX_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh)
+{
+    if (ctx != NULL)
+        ctx->corebiometh = corebiometh;
+}
 
 OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx)
 {

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -26,10 +26,10 @@ void PROV_CTX_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx)
         ctx->libctx = libctx;
 }
 
-void PROV_CTX_set0_provider(PROV_CTX *ctx, const OSSL_PROVIDER *provider)
+void PROV_CTX_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle)
 {
     if (ctx != NULL)
-        ctx->provider = provider;
+        ctx->handle = handle;
 }
 
 
@@ -40,9 +40,9 @@ OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx)
     return ctx->libctx;
 }
 
-const OSSL_PROVIDER *PROV_CTX_get0_provider(PROV_CTX *ctx)
+const OSSL_CORE_HANDLE *PROV_CTX_get0_handle(PROV_CTX *ctx)
 {
     if (ctx == NULL)
         return NULL;
-    return ctx->provider;
+    return ctx->handle;
 }

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -605,11 +605,8 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
      * This only works for built-in providers.  Most providers should
      * create their own library context.
      */
-    if ((*provctx = PROV_CTX_new()) == NULL)
-        return 0;
-
-    corebiometh = bio_prov_init_bio_method();
-    if (corebiometh == NULL) {
+    if ((*provctx = PROV_CTX_new()) == NULL
+            || (corebiometh = bio_prov_init_bio_method()) == NULL) {
         PROV_CTX_free(*provctx);
         *provctx = NULL;
         return 0;

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -19,7 +19,6 @@
 #include "prov/providercommon.h"
 #include "prov/implementations.h"
 #include "prov/provider_util.h"
-#include "prov/provider_ctx.h"
 #include "internal/nelem.h"
 
 /*
@@ -599,14 +598,14 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
     /*
      * We want to make sure that all calls from this provider that requires
      * a library context use the same context as the one used to call our
-     * functions.  We do that by passing it along as the provider context.
+     * functions.  We do that by passing it along in the provider context.
      *
-     * This is special for built-in providers.  External providers should
+     * This only works for built-in providers.  Most providers should
      * create their own library context.
      */
     if ((*provctx = PROV_CTX_new()) == NULL)
         return 0;
-    PROV_CTX_set0_library_context(*provctx, c_get_libctx(handle));
+    PROV_CTX_set0_library_context(*provctx, (OPENSSL_CTX *)c_get_libctx(handle));
     PROV_CTX_set0_handle(*provctx, handle);
 
     *out = deflt_dispatch_table;

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -19,6 +19,7 @@
 #include "prov/providercommon.h"
 #include "prov/implementations.h"
 #include "prov/provider_util.h"
+#include "prov/provider_ctx.h"
 #include "internal/nelem.h"
 
 /*
@@ -566,7 +567,7 @@ static const OSSL_DISPATCH deflt_dispatch_table[] = {
 
 OSSL_provider_init_fn ossl_default_provider_init;
 
-int ossl_default_provider_init(const OSSL_PROVIDER *provider,
+int ossl_default_provider_init(const OSSL_CORE_PROVIDER *provider,
                                const OSSL_DISPATCH *in,
                                const OSSL_DISPATCH **out,
                                void **provctx)

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -567,7 +567,7 @@ static const OSSL_DISPATCH deflt_dispatch_table[] = {
 
 OSSL_provider_init_fn ossl_default_provider_init;
 
-int ossl_default_provider_init(const OSSL_CORE_PROVIDER *provider,
+int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
                                const OSSL_DISPATCH *in,
                                const OSSL_DISPATCH **out,
                                void **provctx)
@@ -606,8 +606,8 @@ int ossl_default_provider_init(const OSSL_CORE_PROVIDER *provider,
      */
     if ((*provctx = PROV_CTX_new()) == NULL)
         return 0;
-    PROV_CTX_set0_library_context(*provctx, c_get_libctx(provider));
-    PROV_CTX_set0_provider(*provctx, provider);
+    PROV_CTX_set0_library_context(*provctx, c_get_libctx(handle));
+    PROV_CTX_set0_handle(*provctx, handle);
 
     *out = deflt_dispatch_table;
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -670,7 +670,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         goto err;
     }
     PROV_CTX_set0_library_context(*provctx, libctx);
-    PROV_CTX_set0_provider(*provctx, provider);
+    PROV_CTX_set0_handle(*provctx, handle);
 
     if ((fgbl = openssl_ctx_get_data(libctx, OPENSSL_CTX_FIPS_PROV_INDEX,
                                      &fips_prov_ossl_ctx_method)) == NULL)
@@ -732,7 +732,7 @@ int fips_intern_provider_init(const OSSL_CORE_HANDLE *handle,
      * Only works because we are a built-in internal provider. This is not
      * something that most providers would be able to do.
      */
-    PROV_CTX_set0_library_context(*provctx, c_get_libctx(handle));
+    PROV_CTX_set0_library_context(*provctx, (OPENSSL_CTX *)c_get_libctx(handle));
     PROV_CTX_set0_handle(*provctx, handle);
 
     *out = intern_dispatch_table;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -785,7 +785,7 @@ int ERR_pop_to_mark(void)
  * is also called from other parts of libcrypto, which all pass around a
  * OPENSSL_CTX pointer)
  */
-const OSSL_CORE_HANDLE *FIPS_get_provider(OPENSSL_CTX *libctx)
+const OSSL_CORE_HANDLE *FIPS_get_core_handle(OPENSSL_CTX *libctx)
 {
     FIPS_GLOBAL *fgbl = openssl_ctx_get_data(libctx,
                                              OPENSSL_CTX_FIPS_PROV_INDEX,

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -729,8 +729,9 @@ int fips_intern_provider_init(const OSSL_CORE_HANDLE *handle,
     if ((*provctx = PROV_CTX_new()) == NULL)
         return 0;
     /*
-     * Only works because we are a built-in internal provider. This is not
-     * something that most providers would be able to do.
+     * Using the parent library context only works because we are a built-in
+     * internal provider. This is not something that most providers would be
+     * able to do.
      */
     PROV_CTX_set0_library_context(*provctx, (OPENSSL_CTX *)c_get_libctx(handle));
     PROV_CTX_set0_handle(*provctx, handle);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -81,7 +81,7 @@ static OSSL_CRYPTO_secure_allocated_fn *c_CRYPTO_secure_allocated;
 static OSSL_BIO_vsnprintf_fn *c_BIO_vsnprintf;
 
 typedef struct fips_global_st {
-    const OSSL_CORE_PROVIDER *prov;
+    const OSSL_CORE_HANDLE *handle;
 } FIPS_GLOBAL;
 
 static void *fips_prov_ossl_ctx_new(OPENSSL_CTX *libctx)
@@ -546,7 +546,7 @@ static const OSSL_DISPATCH intern_dispatch_table[] = {
 };
 
 
-int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out,
                        void **provctx)
@@ -647,7 +647,7 @@ int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
     }
 
     if (stcbfn != NULL && c_get_libctx != NULL) {
-        stcbfn(c_get_libctx(provider), &selftest_params.cb,
+        stcbfn(c_get_libctx(handle), &selftest_params.cb,
                &selftest_params.cb_arg);
     }
     else {
@@ -655,7 +655,7 @@ int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
         selftest_params.cb_arg = NULL;
     }
 
-    if (!c_get_params(provider, core_params))
+    if (!c_get_params(handle, core_params))
         return 0;
 
     /*  Create a context. */
@@ -676,7 +676,7 @@ int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
                                      &fips_prov_ossl_ctx_method)) == NULL)
         goto err;
 
-    fgbl->prov = provider;
+    fgbl->handle = handle;
 
     selftest_params.libctx = libctx;
     if (!SELF_TEST_post(&selftest_params, 0))
@@ -706,7 +706,7 @@ int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
  * that was used in the EVP call that initiated this recursive call.
  */
 OSSL_provider_init_fn fips_intern_provider_init;
-int fips_intern_provider_init(const OSSL_CORE_PROVIDER *provider,
+int fips_intern_provider_init(const OSSL_CORE_HANDLE *handle,
                               const OSSL_DISPATCH *in,
                               const OSSL_DISPATCH **out,
                               void **provctx)
@@ -728,8 +728,12 @@ int fips_intern_provider_init(const OSSL_CORE_PROVIDER *provider,
 
     if ((*provctx = PROV_CTX_new()) == NULL)
         return 0;
-    PROV_CTX_set0_library_context(*provctx, c_get_libctx(provider));
-    PROV_CTX_set0_provider(*provctx, provider);
+    /*
+     * Only works because we are a built-in internal provider. This is not
+     * something that most providers would be able to do.
+     */
+    PROV_CTX_set0_library_context(*provctx, c_get_libctx(handle));
+    PROV_CTX_set0_handle(*provctx, handle);
 
     *out = intern_dispatch_table;
     return 1;
@@ -781,7 +785,7 @@ int ERR_pop_to_mark(void)
  * is also called from other parts of libcrypto, which all pass around a
  * OPENSSL_CTX pointer)
  */
-const OSSL_CORE_PROVIDER *FIPS_get_provider(OPENSSL_CTX *libctx)
+const OSSL_CORE_HANDLE *FIPS_get_provider(OPENSSL_CTX *libctx)
 {
     FIPS_GLOBAL *fgbl = openssl_ctx_get_data(libctx,
                                              OPENSSL_CTX_FIPS_PROV_INDEX,
@@ -790,7 +794,7 @@ const OSSL_CORE_PROVIDER *FIPS_get_provider(OPENSSL_CTX *libctx)
     if (fgbl == NULL)
         return NULL;
 
-    return fgbl->prov;
+    return fgbl->handle;
 }
 
 void *CRYPTO_malloc(size_t num, const char *file, int line)

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -81,7 +81,7 @@ static OSSL_CRYPTO_secure_allocated_fn *c_CRYPTO_secure_allocated;
 static OSSL_BIO_vsnprintf_fn *c_BIO_vsnprintf;
 
 typedef struct fips_global_st {
-    const OSSL_PROVIDER *prov;
+    const OSSL_CORE_PROVIDER *prov;
 } FIPS_GLOBAL;
 
 static void *fips_prov_ossl_ctx_new(OPENSSL_CTX *libctx)
@@ -546,7 +546,7 @@ static const OSSL_DISPATCH intern_dispatch_table[] = {
 };
 
 
-int OSSL_provider_init(const OSSL_PROVIDER *provider,
+int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
                        const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out,
                        void **provctx)
@@ -706,7 +706,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
  * that was used in the EVP call that initiated this recursive call.
  */
 OSSL_provider_init_fn fips_intern_provider_init;
-int fips_intern_provider_init(const OSSL_PROVIDER *provider,
+int fips_intern_provider_init(const OSSL_CORE_PROVIDER *provider,
                               const OSSL_DISPATCH *in,
                               const OSSL_DISPATCH **out,
                               void **provctx)
@@ -781,7 +781,7 @@ int ERR_pop_to_mark(void)
  * is also called from other parts of libcrypto, which all pass around a
  * OPENSSL_CTX pointer)
  */
-const OSSL_PROVIDER *FIPS_get_provider(OPENSSL_CTX *libctx)
+const OSSL_CORE_PROVIDER *FIPS_get_provider(OPENSSL_CTX *libctx)
 {
     FIPS_GLOBAL *fgbl = openssl_ctx_get_data(libctx,
                                              OPENSSL_CTX_FIPS_PROV_INDEX,

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -130,7 +130,7 @@ DEP_FINI_ATTRIBUTE void cleanup(void)
  * the result matches the expected value.
  * Return 1 if verified, or 0 if it fails.
  */
-static int verify_integrity(BIO *bio, OSSL_BIO_read_ex_fn read_ex_cb,
+static int verify_integrity(OSSL_CORE_BIO *bio, OSSL_BIO_read_ex_fn read_ex_cb,
                             unsigned char *expected, size_t expected_len,
                             OPENSSL_CTX *libctx, OSSL_SELF_TEST *ev,
                             const char *event_type)
@@ -188,7 +188,7 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
     int ok = 0;
     int kats_already_passed = 0;
     long checksum_len;
-    BIO *bio_module = NULL, *bio_indicator = NULL;
+    OSSL_CORE_BIO *bio_module = NULL, *bio_indicator = NULL;
     unsigned char *module_checksum = NULL;
     unsigned char *indicator_checksum = NULL;
     int loclstate;

--- a/providers/implementations/serializers/serializer_common.c
+++ b/providers/implementations/serializers/serializer_common.c
@@ -178,7 +178,7 @@ int ossl_prov_print_labeled_bignum(BIO *out, const char *label,
     }
 
     if (BN_is_zero(bn))
-        return ossl_prov_bio_printf(out, "%s%s0\n", label, post_label_spc);
+        return BIO_printf(out, "%s%s0\n", label, post_label_spc);
 
     if (BN_num_bytes(bn) <= BN_BYTES) {
         BN_ULONG *words = bn_get_words(bn);
@@ -186,10 +186,8 @@ int ossl_prov_print_labeled_bignum(BIO *out, const char *label,
         if (BN_is_negative(bn))
             neg = "-";
 
-        return ossl_prov_bio_printf(out,
-                                    "%s%s%s" BN_FMTu " (%s0x" BN_FMTx ")\n",
-                                    label, post_label_spc, neg, words[0],
-                                    neg, words[0]);
+        return BIO_printf(out, "%s%s%s" BN_FMTu " (%s0x" BN_FMTx ")\n",
+                          label, post_label_spc, neg, words[0], neg, words[0]);
     }
 
     hex_str = BN_bn2hex(bn);
@@ -198,18 +196,18 @@ int ossl_prov_print_labeled_bignum(BIO *out, const char *label,
         ++p;
         neg = " (Negative)";
     }
-    if (ossl_prov_bio_printf(out, "%s%s\n", label, neg) <= 0)
+    if (BIO_printf(out, "%s%s\n", label, neg) <= 0)
         goto err;
 
     /* Keep track of how many bytes we have printed out so far */
     bytes = 0;
 
-    if (ossl_prov_bio_printf(out, "%s", spaces) <= 0)
+    if (BIO_printf(out, "%s", spaces) <= 0)
         goto err;
 
     /* Add a leading 00 if the top bit is set */
     if (*p >= '8') {
-        if (ossl_prov_bio_printf(out, "%02x", 0) <= 0)
+        if (BIO_printf(out, "%02x", 0) <= 0)
             goto err;
         ++bytes;
         use_sep = 1;
@@ -217,18 +215,18 @@ int ossl_prov_print_labeled_bignum(BIO *out, const char *label,
     while (*p != '\0') {
         /* Do a newline after every 15 hex bytes + add the space indent */
         if ((bytes % 15) == 0 && bytes > 0) {
-            if (ossl_prov_bio_printf(out, ":\n%s", spaces) <= 0)
+            if (BIO_printf(out, ":\n%s", spaces) <= 0)
                 goto err;
             use_sep = 0; /* The first byte on the next line doesnt have a : */
         }
-        if (ossl_prov_bio_printf(out, "%s%c%c", use_sep ? ":" : "",
-                                 ossl_tolower(p[0]), ossl_tolower(p[1])) <= 0)
+        if (BIO_printf(out, "%s%c%c", use_sep ? ":" : "",
+                       ossl_tolower(p[0]), ossl_tolower(p[1])) <= 0)
             goto err;
         ++bytes;
         p += 2;
         use_sep = 1;
     }
-    if (ossl_prov_bio_printf(out, "\n") <= 0)
+    if (BIO_printf(out, "\n") <= 0)
         goto err;
     ret = 1;
 err:
@@ -244,22 +242,22 @@ int ossl_prov_print_labeled_buf(BIO *out, const char *label,
 {
     size_t i;
 
-    if (ossl_prov_bio_printf(out, "%s\n", label) <= 0)
+    if (BIO_printf(out, "%s\n", label) <= 0)
         return 0;
 
     for (i = 0; i < buflen; i++) {
         if ((i % LABELED_BUF_PRINT_WIDTH) == 0) {
-            if (i > 0 && ossl_prov_bio_printf(out, "\n") <= 0)
+            if (i > 0 && BIO_printf(out, "\n") <= 0)
                 return 0;
-            if (ossl_prov_bio_printf(out, "    ") <= 0)
+            if (BIO_printf(out, "    ") <= 0)
                 return 0;
         }
 
-        if (ossl_prov_bio_printf(out, "%02x%s", buf[i],
+        if (BIO_printf(out, "%02x%s", buf[i],
                                  (i == buflen - 1) ? "" : ":") <= 0)
             return 0;
     }
-    if (ossl_prov_bio_printf(out, "\n") <= 0)
+    if (BIO_printf(out, "\n") <= 0)
         return 0;
 
     return 1;

--- a/providers/implementations/serializers/serializer_dh.c
+++ b/providers/implementations/serializers/serializer_dh.c
@@ -70,7 +70,7 @@ int ossl_prov_print_dh(BIO *out, DH *dh, enum dh_print_type type)
     if (p == NULL)
         goto null_err;
 
-    if (ossl_prov_bio_printf(out, "%s: (%d bit)\n", type_label, BN_num_bits(p))
+    if (BIO_printf(out, "%s: (%d bit)\n", type_label, BN_num_bits(p))
         <= 0)
         goto err;
     if (priv_key != NULL

--- a/providers/implementations/serializers/serializer_dh_param.c
+++ b/providers/implementations/serializers/serializer_dh_param.c
@@ -74,7 +74,7 @@ static int dh_param_der_data(void *ctx, const OSSL_PARAM params[],
 static int dh_param_der(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -111,7 +111,7 @@ static int dh_param_pem_data(void *ctx, const OSSL_PARAM params[],
 static int dh_param_pem(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -148,7 +148,7 @@ static int dh_param_print_data(void *ctx, const OSSL_PARAM params[],
 static int dh_param_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_dh_param.c
+++ b/providers/implementations/serializers/serializer_dh_param.c
@@ -21,6 +21,7 @@
 #include "prov/bio.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn dh_param_newctx;
@@ -48,7 +49,8 @@ static void dh_param_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int dh_param_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dh_param_der_data(void *ctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dh_new = ossl_prov_get_keymgmt_dh_new();
@@ -69,14 +71,23 @@ static int dh_param_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dh_param_der(void *ctx, void *dh, BIO *out,
+static int dh_param_der(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return i2d_DHparams_bio(out, dh);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+    ret = i2d_DHparams_bio(out, dh);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int dh_param_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dh_param_pem_data(void *ctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dh_new = ossl_prov_get_keymgmt_dh_new();
@@ -97,13 +108,23 @@ static int dh_param_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dh_param_pem(void *ctx, void *dh, BIO *out,
+static int dh_param_pem(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return PEM_write_bio_DHparams(out, dh);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = PEM_write_bio_DHparams(out, dh);
+    BIO_free(out);
+
+    return ret;
 }
 
-static int dh_param_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dh_param_print_data(void *ctx, const OSSL_PARAM params[],
+                               OSSL_CORE_BIO *out,
                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dh_new = ossl_prov_get_keymgmt_dh_new();
@@ -124,10 +145,19 @@ static int dh_param_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dh_param_print(void *ctx, void *dh, BIO *out,
+static int dh_param_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_dh(out, dh, dh_print_params);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_dh(out, dh, dh_print_params);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH dh_param_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_dh_priv.c
+++ b/providers/implementations/serializers/serializer_dh_priv.c
@@ -145,8 +145,7 @@ static int dh_priv_der(void *vctx, void *dh, OSSL_CORE_BIO *cout,
 {
     struct dh_priv_ctx_st *ctx = vctx;
     int ret;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
 
     if (out == NULL)
         return 0;
@@ -191,8 +190,7 @@ static int dh_pem_priv(void *vctx, void *dh, OSSL_CORE_BIO *cout,
 {
     struct dh_priv_ctx_st *ctx = vctx;
     int ret;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
 
     if (out == NULL)
         return 0;
@@ -246,8 +244,7 @@ static int dh_priv_print_data(void *vctx, const OSSL_PARAM params[],
 static int dh_priv_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_dh_pub.c
+++ b/providers/implementations/serializers/serializer_dh_pub.c
@@ -74,8 +74,7 @@ static int dh_pub_der_data(void *ctx, const OSSL_PARAM params[],
 static int dh_pub_der(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -115,8 +114,7 @@ static int dh_pub_pem_data(void *ctx, const OSSL_PARAM params[],
 static int dh_pub_pem(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -155,8 +153,7 @@ static int dh_pub_print_data(void *ctx, const OSSL_PARAM params[],
 static int dh_pub_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_dh_pub.c
+++ b/providers/implementations/serializers/serializer_dh_pub.c
@@ -21,6 +21,7 @@
 #include <openssl/params.h>
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn dh_pub_newctx;
@@ -48,7 +49,8 @@ static void dh_pub_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int dh_pub_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dh_pub_der_data(void *ctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dh_new = ossl_prov_get_keymgmt_dh_new();
@@ -69,17 +71,28 @@ static int dh_pub_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dh_pub_der(void *ctx, void *dh, BIO *out,
+static int dh_pub_der(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_der_from_obj(out, dh, EVP_PKEY_DH,
-                                            ossl_prov_prepare_dh_params,
-                                            ossl_prov_dh_pub_to_der);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_der_from_obj(out, dh, EVP_PKEY_DH,
+                                           ossl_prov_prepare_dh_params,
+                                           ossl_prov_dh_pub_to_der);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int dh_pub_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
-                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int dh_pub_pem_data(void *ctx, const OSSL_PARAM params[],
+                           OSSL_CORE_BIO *out,
+                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dh_new = ossl_prov_get_keymgmt_dh_new();
     OSSL_OP_keymgmt_free_fn *dh_free = ossl_prov_get_keymgmt_dh_free();
@@ -99,17 +112,27 @@ static int dh_pub_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dh_pub_pem(void *ctx, void *dh, BIO *out,
+static int dh_pub_pem(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_pem_from_obj(out, dh, EVP_PKEY_DH,
-                                            ossl_prov_prepare_dh_params,
-                                            ossl_prov_dh_pub_to_der);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
 
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_pem_from_obj(out, dh, EVP_PKEY_DH,
+                                           ossl_prov_prepare_dh_params,
+                                           ossl_prov_dh_pub_to_der);
+    BIO_free(out);
+
+    return ret;
 }
 
-static int dh_pub_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
-                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int dh_pub_print_data(void *ctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
+                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dh_new = ossl_prov_get_keymgmt_dh_new();
     OSSL_OP_keymgmt_free_fn *dh_free = ossl_prov_get_keymgmt_dh_free();
@@ -129,10 +152,20 @@ static int dh_pub_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dh_pub_print(void *ctx, void *dh, BIO *out,
+static int dh_pub_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_dh(out, dh, dh_print_pub);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_dh(out, dh, dh_print_pub);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH dh_pub_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_dsa.c
+++ b/providers/implementations/serializers/serializer_dsa.c
@@ -73,8 +73,7 @@ int ossl_prov_print_dsa(BIO *out, DSA *dsa, enum dsa_print_type type)
     if (p == NULL)
         goto null_err;
 
-    if (ossl_prov_bio_printf(out, "%s: (%d bit)\n", type_label,
-                             BN_num_bits(p)) <= 0)
+    if (BIO_printf(out, "%s: (%d bit)\n", type_label, BN_num_bits(p)) <= 0)
         goto err;
     if (priv_key != NULL
         && !ossl_prov_print_labeled_bignum(out, "priv:", priv_key))

--- a/providers/implementations/serializers/serializer_dsa_param.c
+++ b/providers/implementations/serializers/serializer_dsa_param.c
@@ -74,8 +74,7 @@ static int dsa_param_der_data(void *ctx, const OSSL_PARAM params[],
 static int dsa_param_der(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -113,8 +112,7 @@ static int dsa_param_pem_data(void *ctx, const OSSL_PARAM params[],
 static int dsa_param_pem(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -151,8 +149,7 @@ static int dsa_param_print_data(void *ctx, const OSSL_PARAM params[],
 static int dsa_param_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_dsa_param.c
+++ b/providers/implementations/serializers/serializer_dsa_param.c
@@ -21,6 +21,7 @@
 #include "prov/bio.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn dsa_param_newctx;
@@ -48,7 +49,8 @@ static void dsa_param_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int dsa_param_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_param_der_data(void *ctx, const OSSL_PARAM params[],
+                              OSSL_CORE_BIO *out,
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dsa_new = ossl_prov_get_keymgmt_dsa_new();
@@ -69,14 +71,25 @@ static int dsa_param_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_param_der(void *ctx, void *dsa, BIO *out,
+static int dsa_param_der(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return i2d_DSAparams_bio(out, dsa);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = i2d_DSAparams_bio(out, dsa);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int dsa_param_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_param_pem_data(void *ctx, const OSSL_PARAM params[],
+                              OSSL_CORE_BIO *out,
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dsa_new = ossl_prov_get_keymgmt_dsa_new();
@@ -97,13 +110,24 @@ static int dsa_param_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_param_pem(void *ctx, void *dsa, BIO *out,
+static int dsa_param_pem(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return PEM_write_bio_DSAparams(out, dsa);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = PEM_write_bio_DSAparams(out, dsa);
+    BIO_free(out);
+
+    return ret;
 }
 
-static int dsa_param_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_param_print_data(void *ctx, const OSSL_PARAM params[],
+                                OSSL_CORE_BIO *out,
                                 OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dsa_new = ossl_prov_get_keymgmt_dsa_new();
@@ -124,10 +148,20 @@ static int dsa_param_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_param_print(void *ctx, void *dsa, BIO *out,
+static int dsa_param_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_dsa(out, dsa, dsa_print_params);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_dsa(out, dsa, dsa_print_params);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH dsa_param_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_dsa_priv.c
+++ b/providers/implementations/serializers/serializer_dsa_priv.c
@@ -144,8 +144,7 @@ static int dsa_priv_der(void *vctx, void *dsa, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)
@@ -190,8 +189,7 @@ static int dsa_pem_priv(void *vctx, void *dsa, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)
@@ -246,8 +244,7 @@ static int dsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
 static int dsa_priv_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_dsa_priv.c
+++ b/providers/implementations/serializers/serializer_dsa_priv.c
@@ -22,6 +22,7 @@
 #include <openssl/params.h>
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn dsa_priv_newctx;
@@ -117,7 +118,8 @@ static int dsa_priv_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 /* Private key : DER */
-static int dsa_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_priv_der_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
@@ -138,22 +140,32 @@ static int dsa_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_priv_der(void *vctx, void *dsa, BIO *out,
+static int dsa_priv_der(void *vctx, void *dsa, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
 
-    return ossl_prov_write_priv_der_from_obj(out, dsa, EVP_PKEY_DSA,
-                                             ossl_prov_prepare_dsa_params,
-                                             ossl_prov_dsa_priv_to_der,
-                                             &ctx->sc);
+    ret = ossl_prov_write_priv_der_from_obj(out, dsa, EVP_PKEY_DSA,
+                                            ossl_prov_prepare_dsa_params,
+                                            ossl_prov_dsa_priv_to_der,
+                                            &ctx->sc);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Private key : PEM */
-static int dsa_pem_priv_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_pem_priv_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
@@ -174,18 +186,27 @@ static int dsa_pem_priv_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_pem_priv(void *vctx, void *dsa, BIO *out,
+static int dsa_pem_priv(void *vctx, void *dsa, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
 
-    return ossl_prov_write_priv_pem_from_obj(out, dsa, EVP_PKEY_DSA,
-                                             ossl_prov_prepare_dsa_params,
-                                             ossl_prov_dsa_priv_to_der,
-                                             &ctx->sc);
+    ret = ossl_prov_write_priv_pem_from_obj(out, dsa, EVP_PKEY_DSA,
+                                            ossl_prov_prepare_dsa_params,
+                                            ossl_prov_dsa_priv_to_der,
+                                            &ctx->sc);
+    BIO_free(out);
+
+    return ret;
 }
 
 /*
@@ -201,7 +222,7 @@ static void dsa_print_freectx(void *ctx)
 }
 
 static int dsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
-                               BIO *out,
+                               OSSL_CORE_BIO *out,
                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct dsa_priv_ctx_st *ctx = vctx;
@@ -222,10 +243,20 @@ static int dsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
     return ok;
 }
 
-static int dsa_priv_print(void *ctx, void *dsa, BIO *out,
+static int dsa_priv_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_dsa(out, dsa, dsa_print_priv);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_dsa(out, dsa, dsa_print_priv);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH dsa_priv_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_dsa_pub.c
+++ b/providers/implementations/serializers/serializer_dsa_pub.c
@@ -79,7 +79,7 @@ static int dsa_pub_der(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
      * in crypto/dsa/dsa_ameth.c
      */
     int save_parameters = 1;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -125,7 +125,7 @@ static int dsa_pub_pem_data(void *ctx, const OSSL_PARAM params[],
 static int dsa_pub_pem(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -165,7 +165,7 @@ static int dsa_pub_print_data(void *ctx, const OSSL_PARAM params[],
 static int dsa_pub_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_dsa_pub.c
+++ b/providers/implementations/serializers/serializer_dsa_pub.c
@@ -21,6 +21,7 @@
 #include <openssl/params.h>
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn dsa_pub_newctx;
@@ -48,7 +49,8 @@ static void dsa_pub_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int dsa_pub_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_pub_der_data(void *ctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dsa_new = ossl_prov_get_keymgmt_dsa_new();
@@ -69,7 +71,7 @@ static int dsa_pub_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_pub_der(void *ctx, void *dsa, BIO *out,
+static int dsa_pub_der(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     /*
@@ -77,8 +79,13 @@ static int dsa_pub_der(void *ctx, void *dsa, BIO *out,
      * in crypto/dsa/dsa_ameth.c
      */
     int save_parameters = 1;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
 
-    return
+    if (out == NULL)
+        return 0;
+
+    ret =
         save_parameters
         ? ossl_prov_write_pub_der_from_obj(out, dsa, EVP_PKEY_DSA,
                                            ossl_prov_prepare_all_dsa_params,
@@ -87,10 +94,14 @@ static int dsa_pub_der(void *ctx, void *dsa, BIO *out,
                                            ossl_prov_prepare_dsa_params,
                                            ossl_prov_dsa_pub_to_der);
 
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int dsa_pub_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_pub_pem_data(void *ctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dsa_new = ossl_prov_get_keymgmt_dsa_new();
@@ -111,15 +122,26 @@ static int dsa_pub_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_pub_pem(void *ctx, void *dsa, BIO *out,
+static int dsa_pub_pem(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_pem_from_obj(out, dsa, EVP_PKEY_DSA,
-                                            ossl_prov_prepare_dsa_params,
-                                            ossl_prov_dsa_pub_to_der);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_pem_from_obj(out, dsa, EVP_PKEY_DSA,
+                                           ossl_prov_prepare_dsa_params,
+                                           ossl_prov_dsa_pub_to_der);
+
+    BIO_free(out);
+
+    return ret;
 }
 
-static int dsa_pub_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int dsa_pub_print_data(void *ctx, const OSSL_PARAM params[],
+                              OSSL_CORE_BIO *out,
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *dsa_new = ossl_prov_get_keymgmt_dsa_new();
@@ -140,10 +162,19 @@ static int dsa_pub_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int dsa_pub_print(void *ctx, void *dsa, BIO *out,
+static int dsa_pub_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_dsa(out, dsa, 0);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_dsa(out, dsa, 0);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH dsa_pub_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_ec.c
+++ b/providers/implementations/serializers/serializer_ec.c
@@ -31,15 +31,13 @@ static int ossl_prov_print_ec_param(BIO *out, const EC_GROUP *group)
     if (curve_nid == NID_undef)
         return 0;
 
-    if (ossl_prov_bio_printf(out, "%s: %s\n", "ASN1 OID",
-                             OBJ_nid2sn(curve_nid)) <= 0)
+    if (BIO_printf(out, "%s: %s\n", "ASN1 OID", OBJ_nid2sn(curve_nid)) <= 0)
         return 0;
 
     /* TODO(3.0): Only named curves are currently supported */
     curve_name = EC_curve_nid2nist(curve_nid);
     return (curve_name == NULL
-            || ossl_prov_bio_printf(out, "%s: %s\n", "NIST CURVE",
-                                    curve_name) > 0);
+            || BIO_printf(out, "%s: %s\n", "NIST CURVE", curve_name) > 0);
 }
 
 int ossl_prov_print_eckey(BIO *out, EC_KEY *eckey, enum ec_print_type type)
@@ -86,8 +84,8 @@ int ossl_prov_print_eckey(BIO *out, EC_KEY *eckey, enum ec_print_type type)
             goto err;
     }
 
-    if (ossl_prov_bio_printf(out, "%s: (%d bit)\n", type_label,
-                             EC_GROUP_order_bits(group)) <= 0)
+    if (BIO_printf(out, "%s: (%d bit)\n", type_label,
+                   EC_GROUP_order_bits(group)) <= 0)
         goto err;
     if (priv != NULL
         && !ossl_prov_print_labeled_buf(out, "priv:", priv, priv_len))

--- a/providers/implementations/serializers/serializer_ec_param.c
+++ b/providers/implementations/serializers/serializer_ec_param.c
@@ -15,6 +15,7 @@
 #include "prov/bio.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn ec_param_newctx;
@@ -39,8 +40,9 @@ static void ec_param_freectx(void *vctx)
 }
 
 /* Public key : DER */
-static int ec_param_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
-                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int ec_param_der_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
+                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *ec_new;
     OSSL_OP_keymgmt_free_fn *ec_free;
@@ -62,15 +64,25 @@ static int ec_param_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_param_der(void *vctx, void *eckey, BIO *out,
+static int ec_param_der(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return i2d_ECPKParameters_bio(out, EC_KEY_get0_group(eckey));
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = i2d_ECPKParameters_bio(out, EC_KEY_get0_group(eckey));
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int ec_param_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
-                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int ec_param_pem_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
+                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *ec_new;
     OSSL_OP_keymgmt_free_fn *ec_free;
@@ -92,14 +104,24 @@ static int ec_param_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_param_pem(void *vctx, void *eckey, BIO *out,
+static int ec_param_pem(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return PEM_write_bio_ECPKParameters(out, EC_KEY_get0_group(eckey));
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = PEM_write_bio_ECPKParameters(out, EC_KEY_get0_group(eckey));
+    BIO_free(out);
+
+    return ret;
 }
 
-static int ec_param_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
-                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int ec_param_print_data(void *vctx, const OSSL_PARAM params[],
+                               OSSL_CORE_BIO *out,
+                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *ec_new;
     OSSL_OP_keymgmt_free_fn *ec_free;
@@ -121,10 +143,19 @@ static int ec_param_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_param_print(void *vctx, void *eckey, BIO *out,
+static int ec_param_print(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_eckey(out, eckey, ec_print_params);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_eckey(out, eckey, ec_print_params);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH ec_param_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_ec_param.c
+++ b/providers/implementations/serializers/serializer_ec_param.c
@@ -67,7 +67,7 @@ static int ec_param_der_data(void *vctx, const OSSL_PARAM params[],
 static int ec_param_der(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
 
     if (out == NULL)
@@ -107,7 +107,7 @@ static int ec_param_pem_data(void *vctx, const OSSL_PARAM params[],
 static int ec_param_pem(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
 
     if (out == NULL)
@@ -146,7 +146,7 @@ static int ec_param_print_data(void *vctx, const OSSL_PARAM params[],
 static int ec_param_print(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_ec_priv.c
+++ b/providers/implementations/serializers/serializer_ec_priv.c
@@ -16,6 +16,7 @@
 #include <openssl/params.h>
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn ec_priv_newctx;
@@ -111,8 +112,9 @@ static int ec_priv_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 /* Private key : DER */
-static int ec_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
-                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int ec_priv_der_data(void *vctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
+                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
     OSSL_OP_keymgmt_new_fn *ec_new;
@@ -134,23 +136,33 @@ static int ec_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_priv_der(void *vctx, void *eckey, BIO *out,
+static int ec_priv_der(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
 
-    return ossl_prov_write_priv_der_from_obj(out, eckey, EVP_PKEY_EC,
-                                             ossl_prov_prepare_ec_params,
-                                             ossl_prov_ec_priv_to_der,
-                                             &ctx->sc);
+    ret = ossl_prov_write_priv_der_from_obj(out, eckey, EVP_PKEY_EC,
+                                            ossl_prov_prepare_ec_params,
+                                            ossl_prov_ec_priv_to_der,
+                                            &ctx->sc);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Private key : PEM */
-static int ec_pem_priv_data(void *vctx, const OSSL_PARAM params[], BIO *out,
-                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+static int ec_pem_priv_data(void *vctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
+                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
     OSSL_OP_keymgmt_new_fn *ec_new;
@@ -172,18 +184,27 @@ static int ec_pem_priv_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_pem_priv(void *vctx, void *eckey, BIO *out,
+static int ec_pem_priv(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
 
-    return ossl_prov_write_priv_pem_from_obj(out, eckey, EVP_PKEY_EC,
-                                             ossl_prov_prepare_ec_params,
-                                             ossl_prov_ec_priv_to_der,
-                                             &ctx->sc);
+    ret = ossl_prov_write_priv_pem_from_obj(out, eckey, EVP_PKEY_EC,
+                                            ossl_prov_prepare_ec_params,
+                                            ossl_prov_ec_priv_to_der,
+                                            &ctx->sc);
+    BIO_free(out);
+
+    return ret;
 }
 
 /*
@@ -198,7 +219,8 @@ static void ec_print_freectx(void *ctx)
 {
 }
 
-static int ec_priv_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ec_priv_print_data(void *vctx, const OSSL_PARAM params[],
+                              OSSL_CORE_BIO *out,
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
@@ -221,10 +243,20 @@ static int ec_priv_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_priv_print(void *vctx, void *eckey, BIO *out,
+static int ec_priv_print(void *ctx, void *eckey, OSSL_CORE_BIO *cout,
                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_eckey(out, eckey, ec_print_priv);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_eckey(out, eckey, ec_print_priv);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH ec_priv_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_ec_priv.c
+++ b/providers/implementations/serializers/serializer_ec_priv.c
@@ -140,8 +140,7 @@ static int ec_priv_der(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)
@@ -188,8 +187,7 @@ static int ec_pem_priv(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ec_priv_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)
@@ -246,8 +244,7 @@ static int ec_priv_print_data(void *vctx, const OSSL_PARAM params[],
 static int ec_priv_print(void *ctx, void *eckey, OSSL_CORE_BIO *cout,
                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_ec_pub.c
+++ b/providers/implementations/serializers/serializer_ec_pub.c
@@ -69,7 +69,7 @@ static int ec_pub_der_data(void *vctx, const OSSL_PARAM params[],
 static int ec_pub_der(void *ctx, void *eckey, OSSL_CORE_BIO *cout,
                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -111,7 +111,7 @@ static int ec_pub_pem_data(void *vctx, const OSSL_PARAM params[],
 static int ec_pub_pem(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
 
     if (out == NULL)
@@ -152,7 +152,7 @@ static int ec_pub_print_data(void *vctx, const OSSL_PARAM params[],
 static int ec_pub_print(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_ec_pub.c
+++ b/providers/implementations/serializers/serializer_ec_pub.c
@@ -14,6 +14,7 @@
 #include <openssl/params.h>
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn ec_pub_newctx;
@@ -41,7 +42,8 @@ static void ec_pub_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int ec_pub_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ec_pub_der_data(void *vctx, const OSSL_PARAM params[],
+                           OSSL_CORE_BIO *out,
                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *ec_new;
@@ -64,16 +66,26 @@ static int ec_pub_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_pub_der(void *ctx, void *eckey, BIO *out,
+static int ec_pub_der(void *ctx, void *eckey, OSSL_CORE_BIO *cout,
                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_der_from_obj(out, eckey, EVP_PKEY_EC,
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_der_from_obj(out, eckey, EVP_PKEY_EC,
                                            ossl_prov_prepare_ec_params,
                                            ossl_prov_ec_pub_to_der);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int ec_pub_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ec_pub_pem_data(void *vctx, const OSSL_PARAM params[],
+                           OSSL_CORE_BIO *out,
                            OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *ec_new;
@@ -96,15 +108,25 @@ static int ec_pub_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_pub_pem(void *vctx, void *eckey, BIO *out,
+static int ec_pub_pem(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_pem_from_obj(out, eckey, EVP_PKEY_EC,
-                                            ossl_prov_prepare_ec_params,
-                                            ossl_prov_ec_pub_to_der);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_pem_from_obj(out, eckey, EVP_PKEY_EC,
+                                           ossl_prov_prepare_ec_params,
+                                           ossl_prov_ec_pub_to_der);
+    BIO_free(out);
+
+    return ret;
 }
 
-static int ec_pub_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ec_pub_print_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *ec_new;
@@ -127,10 +149,19 @@ static int ec_pub_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ec_pub_print(void *vctx, void *eckey, BIO *out,
+static int ec_pub_print(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_eckey(out, eckey, ec_print_pub);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(vctx), cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_eckey(out, eckey, ec_print_pub);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH ec_pub_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_ecx.c
+++ b/providers/implementations/serializers/serializer_ecx.c
@@ -86,7 +86,7 @@ int ossl_prov_print_ecx(BIO *out, ECX_KEY *ecxkey, enum ecx_print_type type)
         return 0;
     }
 
-    if (ossl_prov_bio_printf(out, "%s:\n", type_label) <= 0)
+    if (BIO_printf(out, "%s:\n", type_label) <= 0)
         return 0;
     if (type == ecx_print_priv
             && !ossl_prov_print_labeled_buf(out, "priv:", ecxkey->privkey,

--- a/providers/implementations/serializers/serializer_ecx_priv.c
+++ b/providers/implementations/serializers/serializer_ecx_priv.c
@@ -166,8 +166,7 @@ static int ecx_priv_der(void *vctx, void *vecxkey, OSSL_CORE_BIO *cout,
     ECX_KEY *ecxkey = vecxkey;
     int ret;
     int nid = KEYTYPE2NID(ctx->type);
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
 
     if (out == NULL)
         return 0;
@@ -216,8 +215,7 @@ static int ecx_priv_pem(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
     struct ecx_priv_ctx_st *ctx = vctx;
     int ret;
     int nid = KEYTYPE2NID(ctx->type);
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
 
     if (out == NULL)
         return 0;
@@ -263,8 +261,7 @@ static int ecx_priv_print(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_ecx_priv.c
+++ b/providers/implementations/serializers/serializer_ecx_priv.c
@@ -16,6 +16,7 @@
 #include "crypto/ecx.h"
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn x25519_priv_newctx;
@@ -134,7 +135,8 @@ static int ecx_priv_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 /* Private key : DER */
-static int ecx_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ecx_priv_der_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
@@ -157,13 +159,18 @@ static int ecx_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ecx_priv_der(void *vctx, void *vecxkey, BIO *out,
+static int ecx_priv_der(void *vctx, void *vecxkey, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
     ECX_KEY *ecxkey = vecxkey;
     int ret;
     int nid = KEYTYPE2NID(ctx->type);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
@@ -173,12 +180,14 @@ static int ecx_priv_der(void *vctx, void *vecxkey, BIO *out,
                                             NULL,
                                             ossl_prov_ecx_priv_to_der,
                                             &ctx->sc);
+    BIO_free(out);
 
     return ret;
 }
 
 /* Private key : PEM */
-static int ecx_priv_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ecx_priv_pem_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
@@ -201,12 +210,17 @@ static int ecx_priv_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ecx_priv_pem(void *vctx, void *ecxkey, BIO *out,
+static int ecx_priv_pem(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
     int ret;
     int nid = KEYTYPE2NID(ctx->type);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
@@ -216,11 +230,13 @@ static int ecx_priv_pem(void *vctx, void *ecxkey, BIO *out,
                                             NULL,
                                             ossl_prov_ecx_priv_to_der,
                                             &ctx->sc);
+    BIO_free(out);
 
     return ret;
 }
 
-static int ecx_priv_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ecx_priv_print_data(void *vctx, const OSSL_PARAM params[],
+                               OSSL_CORE_BIO *out,
                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
@@ -243,10 +259,21 @@ static int ecx_priv_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ecx_priv_print(void *ctx, void *ecxkey, BIO *out,
+static int ecx_priv_print(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_ecx(out, ecxkey, ecx_print_priv);
+    struct ecx_priv_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_ecx(out, ecxkey, ecx_print_priv);
+    BIO_free(out);
+
+    return ret;
 }
 
 #define MAKE_SERIALIZER_FUNCTIONS(alg, type) \

--- a/providers/implementations/serializers/serializer_ecx_pub.c
+++ b/providers/implementations/serializers/serializer_ecx_pub.c
@@ -105,8 +105,7 @@ static int ecx_pub_der(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)
@@ -150,8 +149,7 @@ static int ecx_pub_pem(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)
@@ -194,8 +192,7 @@ static int ecx_pub_print(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_ecx_pub.c
+++ b/providers/implementations/serializers/serializer_ecx_pub.c
@@ -15,6 +15,7 @@
 #include "crypto/ecx.h"
 #include "prov/bio.h"
 #include "prov/implementations.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn x25519_pub_newctx;
@@ -76,7 +77,8 @@ static void ecx_pub_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int ecx_pub_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ecx_pub_der_data(void *vctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
@@ -99,19 +101,29 @@ static int ecx_pub_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ecx_pub_der(void *vctx, void *ecxkey, BIO *out,
+static int ecx_pub_der(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
 
-    return ossl_prov_write_pub_der_from_obj(out, ecxkey,
-                                            KEYTYPE2NID(ctx->type),
-                                            NULL,
-                                            ossl_prov_ecx_pub_to_der);
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_der_from_obj(out, ecxkey,
+                                           KEYTYPE2NID(ctx->type),
+                                           NULL,
+                                           ossl_prov_ecx_pub_to_der);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int ecx_pub_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ecx_pub_pem_data(void *vctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
@@ -134,19 +146,28 @@ static int ecx_pub_pem_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ecx_pub_pem(void *vctx, void *ecxkey, BIO *out,
+static int ecx_pub_pem(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
 
-    return ossl_prov_write_pub_pem_from_obj(out, ecxkey,
-                                            KEYTYPE2NID(ctx->type),
-                                            NULL,
-                                            ossl_prov_ecx_pub_to_der);
+    if (out == NULL)
+        return 0;
 
+    ret = ossl_prov_write_pub_pem_from_obj(out, ecxkey,
+                                           KEYTYPE2NID(ctx->type),
+                                           NULL,
+                                           ossl_prov_ecx_pub_to_der);
+    BIO_free(out);
+
+    return ret;
 }
 
-static int ecx_pub_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int ecx_pub_print_data(void *vctx, const OSSL_PARAM params[],
+                              OSSL_CORE_BIO *out,
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
@@ -169,10 +190,21 @@ static int ecx_pub_print_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int ecx_pub_print(void *ctx, void *ecxkey, BIO *out,
+static int ecx_pub_print(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_ecx(out, ecxkey, ecx_print_pub);
+    struct ecx_pub_ctx_st *ctx = vctx;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_ecx(out, ecxkey, ecx_print_pub);
+    BIO_free(out);
+
+    return ret;
 }
 
 #define MAKE_SERIALIZER_FUNCTIONS(alg, type) \

--- a/providers/implementations/serializers/serializer_ffc_params.c
+++ b/providers/implementations/serializers/serializer_ffc_params.c
@@ -20,7 +20,7 @@ int ffc_params_prov_print(BIO *out, const FFC_PARAMS *ffc)
 
         if (name == NULL)
             goto err;
-        if (ossl_prov_bio_printf(out, "GROUP: %s\n", name) <= 0)
+        if (BIO_printf(out, "GROUP: %s\n", name) <= 0)
             goto err;
         return 1;
 #else
@@ -46,15 +46,15 @@ int ffc_params_prov_print(BIO *out, const FFC_PARAMS *ffc)
             goto err;
     }
     if (ffc->gindex != -1) {
-        if (ossl_prov_bio_printf(out, "gindex: %d\n", ffc->gindex) <= 0)
+        if (BIO_printf(out, "gindex: %d\n", ffc->gindex) <= 0)
             goto err;
     }
     if (ffc->pcounter != -1) {
-        if (ossl_prov_bio_printf(out, "pcounter: %d\n", ffc->pcounter) <= 0)
+        if (BIO_printf(out, "pcounter: %d\n", ffc->pcounter) <= 0)
             goto err;
     }
     if (ffc->h != 0) {
-        if (ossl_prov_bio_printf(out, "h: %d\n", ffc->h) <= 0)
+        if (BIO_printf(out, "h: %d\n", ffc->h) <= 0)
             goto err;
     }
     return 1;

--- a/providers/implementations/serializers/serializer_rsa.c
+++ b/providers/implementations/serializers/serializer_rsa.c
@@ -115,14 +115,13 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
     switch (RSA_test_flags(rsa, RSA_FLAG_TYPE_MASK)) {
     case RSA_FLAG_TYPE_RSA:
         if (!rsa_pss_params_30_is_unrestricted(pss_params)) {
-            if (ossl_prov_bio_printf(out, "(INVALID PSS PARAMETERS)\n") <= 0)
+            if (BIO_printf(out, "(INVALID PSS PARAMETERS)\n") <= 0)
                 goto err;
         }
         break;
     case RSA_FLAG_TYPE_RSASSAPSS:
         if (rsa_pss_params_30_is_unrestricted(pss_params)) {
-            if (ossl_prov_bio_printf(out,
-                                     "No PSS parameter restrictions\n") <= 0)
+            if (BIO_printf(out, "No PSS parameter restrictions\n") <= 0)
                 goto err;
         } else {
             int hashalg_nid = rsa_pss_params_30_hashalg(pss_params);
@@ -132,23 +131,23 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
             int saltlen = rsa_pss_params_30_saltlen(pss_params);
             int trailerfield = rsa_pss_params_30_trailerfield(pss_params);
 
-            if (ossl_prov_bio_printf(out, "PSS parameter restrictions:\n") <= 0)
+            if (BIO_printf(out, "PSS parameter restrictions:\n") <= 0)
                 goto err;
-            if (ossl_prov_bio_printf(out, "  Hash Algorithm: %s%s\n",
-                                     rsa_oaeppss_nid2name(hashalg_nid),
-                                     (hashalg_nid == NID_sha1
-                                      ? " (default)" : "")) <= 0)
+            if (BIO_printf(out, "  Hash Algorithm: %s%s\n",
+                           rsa_oaeppss_nid2name(hashalg_nid),
+                           (hashalg_nid == NID_sha1
+                           ? " (default)" : "")) <= 0)
                 goto err;
-            if (ossl_prov_bio_printf(out, "  Mask Algorithm: %s with %s%s\n",
-                                     rsa_mgf_nid2name(maskgenalg_nid),
-                                     rsa_oaeppss_nid2name(maskgenhashalg_nid),
-                                     (maskgenalg_nid == NID_mgf1
-                                      && maskgenhashalg_nid == NID_sha1
-                                      ? " (default)" : "")) <= 0)
+            if (BIO_printf(out, "  Mask Algorithm: %s with %s%s\n",
+                           rsa_mgf_nid2name(maskgenalg_nid),
+                           rsa_oaeppss_nid2name(maskgenhashalg_nid),
+                           (maskgenalg_nid == NID_mgf1
+                            && maskgenhashalg_nid == NID_sha1
+                            ? " (default)" : "")) <= 0)
                 goto err;
-            if (ossl_prov_bio_printf(out, "  Minimum Salt Length: %d%s\n",
-                                     saltlen,
-                                     (saltlen == 20 ? " (default)" : "")) <= 0)
+            if (BIO_printf(out, "  Minimum Salt Length: %d%s\n",
+                           saltlen,
+                           (saltlen == 20 ? " (default)" : "")) <= 0)
                 goto err;
             /*
              * TODO(3.0) Should we show the ASN.1 trailerField value, or
@@ -157,9 +156,9 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
              * does display 0xBC when the default applies, but the ASN.1
              * trailerField value otherwise...
              */
-            if (ossl_prov_bio_printf(out, "  Trailer Field: 0x%x%s\n",
-                                     trailerfield,
-                                     (trailerfield == 1 ? " (default)" : ""))
+            if (BIO_printf(out, "  Trailer Field: 0x%x%s\n",
+                           trailerfield,
+                           (trailerfield == 1 ? " (default)" : ""))
                 <= 0)
                 goto err;
         }

--- a/providers/implementations/serializers/serializer_rsa.c
+++ b/providers/implementations/serializers/serializer_rsa.c
@@ -55,15 +55,14 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
     rsa_get0_all_params(rsa, factors, exps, coeffs);
 
     if (priv && rsa_d != NULL) {
-        if (ossl_prov_bio_printf(out, "Private-Key: (%d bit, %d primes)\n",
-                                 BN_num_bits(rsa_n),
-                                 sk_BIGNUM_const_num(factors)) <= 0)
+        if (BIO_printf(out, "Private-Key: (%d bit, %d primes)\n",
+                       BN_num_bits(rsa_n),
+                       sk_BIGNUM_const_num(factors)) <= 0)
             goto err;
         modulus_label = "modulus:";
         exponent_label = "publicExponent:";
     } else {
-        if (ossl_prov_bio_printf(out, "Public-Key: (%d bit)\n",
-                                 BN_num_bits(rsa_n)) <= 0)
+        if (BIO_printf(out, "Public-Key: (%d bit)\n", BN_num_bits(rsa_n)) <= 0)
             goto err;
         modulus_label = "Modulus:";
         exponent_label = "Exponent:";
@@ -93,18 +92,18 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
                                             sk_BIGNUM_const_value(coeffs, 0)))
             goto err;
         for (i = 2; i < sk_BIGNUM_const_num(factors); i++) {
-            if (ossl_prov_bio_printf(out, "prime%d:", i + 1) <= 0)
+            if (BIO_printf(out, "prime%d:", i + 1) <= 0)
                 goto err;
             if (!ossl_prov_print_labeled_bignum(out, NULL,
                                                 sk_BIGNUM_const_value(factors,
                                                                       i)))
                 goto err;
-            if (ossl_prov_bio_printf(out, "exponent%d:", i + 1) <= 0)
+            if (BIO_printf(out, "exponent%d:", i + 1) <= 0)
                 goto err;
             if (!ossl_prov_print_labeled_bignum(out, NULL,
                                                 sk_BIGNUM_const_value(exps, i)))
                 goto err;
-            if (ossl_prov_bio_printf(out, "coefficient%d:", i + 1) <= 0)
+            if (BIO_printf(out, "coefficient%d:", i + 1) <= 0)
                 goto err;
             if (!ossl_prov_print_labeled_bignum(out, NULL,
                                                 sk_BIGNUM_const_value(coeffs,

--- a/providers/implementations/serializers/serializer_rsa_priv.c
+++ b/providers/implementations/serializers/serializer_rsa_priv.c
@@ -25,6 +25,7 @@
 #include "prov/bio.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn rsa_priv_newctx;
@@ -119,7 +120,8 @@ static int rsa_priv_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 /* Private key : DER */
-static int rsa_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int rsa_priv_der_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct rsa_priv_ctx_st *ctx = vctx;
@@ -140,11 +142,16 @@ static int rsa_priv_der_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int rsa_priv_der(void *vctx, void *rsa, BIO *out,
+static int rsa_priv_der(void *vctx, void *rsa, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct rsa_priv_ctx_st *ctx = vctx;
     int ret;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
@@ -154,12 +161,14 @@ static int rsa_priv_der(void *vctx, void *rsa, BIO *out,
                                             ossl_prov_prepare_rsa_params,
                                             (i2d_of_void *)i2d_RSAPrivateKey,
                                             &ctx->sc);
+    BIO_free(out);
 
     return ret;
 }
 
 /* Private key : PEM */
-static int rsa_pem_priv_data(void *vctx, const OSSL_PARAM params[], BIO *out,
+static int rsa_pem_priv_data(void *vctx, const OSSL_PARAM params[],
+                             OSSL_CORE_BIO *out,
                              OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct rsa_priv_ctx_st *ctx = vctx;
@@ -180,11 +189,16 @@ static int rsa_pem_priv_data(void *vctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int rsa_pem_priv(void *vctx, void *rsa, BIO *out,
+static int rsa_pem_priv(void *vctx, void *rsa, OSSL_CORE_BIO *cout,
                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct rsa_priv_ctx_st *ctx = vctx;
     int ret;
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
+                                     cout);
+
+    if (out == NULL)
+        return 0;
 
     ctx->sc.cb = cb;
     ctx->sc.cbarg = cbarg;
@@ -194,6 +208,7 @@ static int rsa_pem_priv(void *vctx, void *rsa, BIO *out,
                                             ossl_prov_prepare_rsa_params,
                                             (i2d_of_void *)i2d_RSAPrivateKey,
                                             &ctx->sc);
+    BIO_free(out);
 
     return ret;
 }
@@ -211,7 +226,7 @@ static void rsa_print_freectx(void *ctx)
 }
 
 static int rsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
-                               BIO *out,
+                               OSSL_CORE_BIO *out,
                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     struct rsa_priv_ctx_st *ctx = vctx;
@@ -232,10 +247,20 @@ static int rsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
     return ok;
 }
 
-static int rsa_priv_print(void *ctx, void *rsa, BIO *out,
+static int rsa_priv_print(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_rsa(out, rsa, 1);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_rsa(out, rsa, 1);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH rsa_priv_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_rsa_priv.c
+++ b/providers/implementations/serializers/serializer_rsa_priv.c
@@ -147,8 +147,7 @@ static int rsa_priv_der(void *vctx, void *rsa, OSSL_CORE_BIO *cout,
 {
     struct rsa_priv_ctx_st *ctx = vctx;
     int ret;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
 
     if (out == NULL)
         return 0;
@@ -194,8 +193,7 @@ static int rsa_pem_priv(void *vctx, void *rsa, OSSL_CORE_BIO *cout,
 {
     struct rsa_priv_ctx_st *ctx = vctx;
     int ret;
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx->provctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
 
     if (out == NULL)
         return 0;
@@ -250,8 +248,7 @@ static int rsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
 static int rsa_priv_print(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/implementations/serializers/serializer_rsa_pub.c
+++ b/providers/implementations/serializers/serializer_rsa_pub.c
@@ -21,6 +21,7 @@
 #include "prov/bio.h"
 #include "prov/implementations.h"
 #include "prov/providercommonerr.h"
+#include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
 static OSSL_OP_serializer_newctx_fn rsa_pub_newctx;
@@ -48,7 +49,8 @@ static void rsa_pub_freectx(void *ctx)
 }
 
 /* Public key : DER */
-static int rsa_pub_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int rsa_pub_der_data(void *ctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *rsa_new = ossl_prov_get_keymgmt_rsa_new();
@@ -69,17 +71,28 @@ static int rsa_pub_der_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int rsa_pub_der(void *ctx, void *rsa, BIO *out,
+static int rsa_pub_der(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_der_from_obj(out, rsa,
-                                            ossl_prov_rsa_type_to_evp(rsa),
-                                            ossl_prov_prepare_rsa_params,
-                                            (i2d_of_void *)i2d_RSAPublicKey);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_der_from_obj(out, rsa,
+                                           ossl_prov_rsa_type_to_evp(rsa),
+                                           ossl_prov_prepare_rsa_params,
+                                           (i2d_of_void *)i2d_RSAPublicKey);
+    BIO_free(out);
+
+    return ret;
 }
 
 /* Public key : PEM */
-static int rsa_pub_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int rsa_pub_pem_data(void *ctx, const OSSL_PARAM params[],
+                            OSSL_CORE_BIO *out,
                             OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *rsa_new = ossl_prov_get_keymgmt_rsa_new();
@@ -100,16 +113,27 @@ static int rsa_pub_pem_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int rsa_pub_pem(void *ctx, void *rsa, BIO *out,
+static int rsa_pub_pem(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_write_pub_pem_from_obj(out, rsa,
-                                            ossl_prov_rsa_type_to_evp(rsa),
-                                            ossl_prov_prepare_rsa_params,
-                                            (i2d_of_void *)i2d_RSAPublicKey);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_write_pub_pem_from_obj(out, rsa,
+                                           ossl_prov_rsa_type_to_evp(rsa),
+                                           ossl_prov_prepare_rsa_params,
+                                           (i2d_of_void *)i2d_RSAPublicKey);
+    BIO_free(out);
+
+    return ret;
 }
 
-static int rsa_pub_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
+static int rsa_pub_print_data(void *ctx, const OSSL_PARAM params[],
+                              OSSL_CORE_BIO *out,
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     OSSL_OP_keymgmt_new_fn *rsa_new = ossl_prov_get_keymgmt_rsa_new();
@@ -130,10 +154,20 @@ static int rsa_pub_print_data(void *ctx, const OSSL_PARAM params[], BIO *out,
     return ok;
 }
 
-static int rsa_pub_print(void *ctx, void *rsa, BIO *out,
+static int rsa_pub_print(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    return ossl_prov_print_rsa(out, rsa, 0);
+    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
+                                     cout);
+    int ret;
+
+    if (out == NULL)
+        return 0;
+
+    ret = ossl_prov_print_rsa(out, rsa, 0);
+    BIO_free(out);
+
+    return ret;
 }
 
 const OSSL_DISPATCH rsa_pub_der_serializer_functions[] = {

--- a/providers/implementations/serializers/serializer_rsa_pub.c
+++ b/providers/implementations/serializers/serializer_rsa_pub.c
@@ -74,8 +74,7 @@ static int rsa_pub_der_data(void *ctx, const OSSL_PARAM params[],
 static int rsa_pub_der(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -116,8 +115,7 @@ static int rsa_pub_pem_data(void *ctx, const OSSL_PARAM params[],
 static int rsa_pub_pem(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)
@@ -157,8 +155,7 @@ static int rsa_pub_print_data(void *ctx, const OSSL_PARAM params[],
 static int rsa_pub_print(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
-    BIO *out = BIO_new_from_core_bio(PROV_LIBRARY_CONTEXT_OF(ctx),
-                                     cout);
+    BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
 
     if (out == NULL)

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -170,7 +170,7 @@ static const OSSL_DISPATCH legacy_dispatch_table[] = {
     { 0, NULL }
 };
 
-int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out,
                        void **provctx)
@@ -206,7 +206,7 @@ int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
         return 0;
     }
     PROV_CTX_set0_library_context(*provctx, libctx);
-    PROV_CTX_set0_provider(*provctx, provider);
+    PROV_CTX_set0_handle(*provctx, handle);
 
     *out = legacy_dispatch_table;
 

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -170,7 +170,7 @@ static const OSSL_DISPATCH legacy_dispatch_table[] = {
     { 0, NULL }
 };
 
-int OSSL_provider_init(const OSSL_PROVIDER *provider,
+int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
                        const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out,
                        void **provctx)

--- a/providers/nullprov.c
+++ b/providers/nullprov.c
@@ -17,10 +17,6 @@
 
 OSSL_provider_init_fn ossl_null_provider_init;
 
-/* Functions provided by the core */
-static OSSL_core_gettable_params_fn *c_gettable_params = NULL;
-static OSSL_core_get_params_fn *c_get_params = NULL;
-
 /* Parameters we provide to the core */
 static const OSSL_ITEM null_param_types[] = {
     { OSSL_PARAM_UTF8_PTR, OSSL_PROV_PARAM_NAME },
@@ -67,40 +63,14 @@ static const OSSL_DISPATCH null_dispatch_table[] = {
     { 0, NULL }
 };
 
-int ossl_null_provider_init(const OSSL_CORE_PROVIDER *provider,
+int ossl_null_provider_init(const OSSL_CORE_HANDLE *handle,
                             const OSSL_DISPATCH *in,
                             const OSSL_DISPATCH **out,
                             void **provctx)
 {
-    OSSL_core_get_library_context_fn *c_get_libctx = NULL;
-
-    for (; in->function_id != 0; in++) {
-        switch (in->function_id) {
-        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
-            c_gettable_params = OSSL_get_core_gettable_params(in);
-            break;
-        case OSSL_FUNC_CORE_GET_PARAMS:
-            c_get_params = OSSL_get_core_get_params(in);
-            break;
-        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
-            c_get_libctx = OSSL_get_core_get_library_context(in);
-            break;
-        /* Just ignore anything we don't understand */
-        default:
-            break;
-        }
-    }
-
-    if (c_get_libctx == NULL)
-        return 0;
-
     *out = null_dispatch_table;
 
-    /*
-     * We want to make sure that all calls from this provider that requires
-     * a library context use the same context as the one used to call our
-     * functions.  We do that by passing it along as the provider context.
-     */
-    *provctx = c_get_libctx(provider);
+    /* Could be anything - we don't use it */
+    *provctx = (void *)handle;
     return 1;
 }

--- a/providers/nullprov.c
+++ b/providers/nullprov.c
@@ -67,7 +67,7 @@ static const OSSL_DISPATCH null_dispatch_table[] = {
     { 0, NULL }
 };
 
-int ossl_null_provider_init(const OSSL_PROVIDER *provider,
+int ossl_null_provider_init(const OSSL_CORE_PROVIDER *provider,
                             const OSSL_DISPATCH *in,
                             const OSSL_DISPATCH **out,
                             void **provctx)

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -48,9 +48,9 @@ static const OSSL_PARAM *p_gettable_params(void *_)
     return p_param_types;
 }
 
-static int p_get_params(void *vprov, OSSL_PARAM params[])
+static int p_get_params(void *vhand, OSSL_PARAM params[])
 {
-    const OSSL_CORE_PROVIDER *prov = vprov;
+    const OSSL_CORE_HANDLE *hand = vhand;
     OSSL_PARAM *p = params;
     int ok = 1;
 
@@ -77,7 +77,7 @@ static int p_get_params(void *vprov, OSSL_PARAM params[])
 
             opensslv = provname = greeting = NULL;
 
-            if (c_get_params(prov, counter_request)) {
+            if (c_get_params(hand, counter_request)) {
                 if (greeting) {
                     strcpy(buf, greeting);
                 } else {
@@ -119,7 +119,7 @@ static const OSSL_DISPATCH p_test_table[] = {
     { 0, NULL }
 };
 
-int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out,
                        void **provctx)
@@ -139,7 +139,7 @@ int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
     }
 
     /* Because we use this in get_params, we need to pass it back */
-    *provctx = (void *)provider;
+    *provctx = (void *)handle;
 
     *out = p_test_table;
     return 1;

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -50,7 +50,7 @@ static const OSSL_PARAM *p_gettable_params(void *_)
 
 static int p_get_params(void *vprov, OSSL_PARAM params[])
 {
-    const OSSL_PROVIDER *prov = vprov;
+    const OSSL_CORE_PROVIDER *prov = vprov;
     OSSL_PARAM *p = params;
     int ok = 1;
 
@@ -119,7 +119,7 @@ static const OSSL_DISPATCH p_test_table[] = {
     { 0, NULL }
 };
 
-int OSSL_provider_init(const OSSL_PROVIDER *provider,
+int OSSL_provider_init(const OSSL_CORE_PROVIDER *provider,
                        const OSSL_DISPATCH *in,
                        const OSSL_DISPATCH **out,
                        void **provctx)


### PR DESCRIPTION
A provider could be linked against a different version of libcrypto than
the version of libcrypto that loaded the provider. Different versions of
libcrypto could define opaque types differently. It must never occur that
a type created in one libcrypto is used directly by the other libcrypto.
This will cause crashes.

We can "cheat" for "built-in" providers that are part of libcrypto itself,
because we know that the two libcrypto versions are the same - but not for
other providers.

To ensure this does not occur we use different types names for the handful
of opaque types that are passed between the core and providers.