### PR TITLE
Update RSA keygen to use sp800-56b by default and fix infinite loop.

### DIFF
--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -33,7 +33,10 @@ static int genrsa_cb(EVP_PKEY_CTX *ctx);
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
-    OPT_3, OPT_F4, OPT_ENGINE,
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+    OPT_3,
+#endif
+    OPT_F4, OPT_ENGINE,
     OPT_OUT, OPT_PASSOUT, OPT_CIPHER, OPT_PRIMES, OPT_VERBOSE,
     OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
@@ -48,7 +51,9 @@ const OPTIONS genrsa_options[] = {
 #endif
 
     OPT_SECTION("Input"),
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     {"3", OPT_3, '-', "(deprecated) Use 3 for the E value"},
+#endif
     {"F4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
     {"f4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
 
@@ -100,9 +105,11 @@ opthelp:
             ret = 0;
             opt_help(genrsa_options);
             goto end;
+#ifndef OPENSSL_NO_DEPRECATED_3_0
         case OPT_3:
             f4 = RSA_3;
             break;
+#endif
         case OPT_F4:
             f4 = RSA_F4;
             break;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -54,8 +54,8 @@ const OPTIONS genrsa_options[] = {
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     {"3", OPT_3, '-', "(deprecated) Use 3 for the E value"},
 #endif
-    {"F4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
-    {"f4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
+    {"F4", OPT_F4, '-', "Use the Fermat number F4 (0x10001) for the E value"},
+    {"f4", OPT_F4, '-', "Use the Fermat number F4 (0x10001) for the E value"},
 
     OPT_SECTION("Output"),
     {"out", OPT_OUT, '>', "Output the key to specified file"},

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -48,7 +48,7 @@ const OPTIONS genrsa_options[] = {
 #endif
 
     OPT_SECTION("Input"),
-    {"3", OPT_3, '-', "Use 3 for the E value"},
+    {"3", OPT_3, '-', "(deprecated) Use 3 for the E value"},
     {"F4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
     {"f4", OPT_F4, '-', "Use F4 (0x10001) for the E value"},
 

--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -65,7 +65,7 @@ int rsa_fips186_4_gen_prob_primes(RSA *rsa, BIGNUM *p1, BIGNUM *p2,
      * Signature Generation and Key Agree/Transport.
      */
     if (nbits < RSA_FIPS1864_MIN_KEYGEN_KEYSIZE) {
-        RSAerr(RSA_F_RSA_FIPS186_4_GEN_PROB_PRIMES, RSA_R_INVALID_KEY_LENGTH);
+        RSAerr(RSA_F_RSA_FIPS186_4_GEN_PROB_PRIMES, RSA_R_KEY_SIZE_TOO_SMALL);
         return 0;
     }
 
@@ -146,12 +146,13 @@ err:
 int rsa_sp800_56b_validate_strength(int nbits, int strength)
 {
     int s = (int)ifc_ffc_compute_security_bits(nbits);
-
+#ifdef FIPS_MODULE
     if (s < RSA_FIPS1864_MIN_KEYGEN_STRENGTH
             || s > RSA_FIPS1864_MAX_KEYGEN_STRENGTH) {
         RSAerr(RSA_F_RSA_SP800_56B_VALIDATE_STRENGTH, RSA_R_INVALID_MODULUS);
         return 0;
     }
+#endif
     if (strength != -1 && s != strength) {
         RSAerr(RSA_F_RSA_SP800_56B_VALIDATE_STRENGTH, RSA_R_INVALID_STRENGTH);
         return 0;

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -33,7 +33,7 @@ B<openssl> B<genrsa>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [B<numbits>]
 
-=for openssl ifdef engine
+=for openssl ifdef engine 3
 
 =head1 DESCRIPTION
 

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -70,6 +70,7 @@ for if it is not supplied via the B<-passout> argument.
 =item B<-F4>, B<-f4>, B<-3>
 
 The public exponent to use, either 65537 or 3. The default is 65537.
+The B<-3> option has been deprecated.
 
 =item B<-primes> I<num>
 

--- a/doc/man7/EVP_PKEY-RSA.pod
+++ b/doc/man7/EVP_PKEY-RSA.pod
@@ -123,6 +123,12 @@ default is 2.  It isn't permitted to specify a larger number of primes than
 being generated so the maximum number could be less.
 Some providers may only support a value of 2.
 
+=item "e" (B<OSSL_PKEY_PARAM_RSA_E>) <unsigned integer>
+
+The RSA "e" value. The value may be any odd number greater than or equal to
+65537. The default value is 65537.
+For legacy reasons a value of 3 is currently accepted but is deprecated.
+
 =back
 
 =head1 CONFORMING TO

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -40,7 +40,7 @@ extern "C" {
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 /* The types RSA and RSA_METHOD are defined in ossl_typ.h */
 
-#   define OPENSSL_RSA_FIPS_MIN_MODULUS_BITS 1024
+#   define OPENSSL_RSA_FIPS_MIN_MODULUS_BITS 2048
 
 #   ifndef OPENSSL_RSA_SMALL_MODULUS_BITS
 #    define OPENSSL_RSA_SMALL_MODULUS_BITS 3072

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -16,7 +16,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_genrsa");
 
-plan tests => 9;
+plan tests => 10;
 
 # We want to know that an absurdly small number of bits isn't support
 if (disabled("deprecated-3.0")) {
@@ -43,7 +43,7 @@ while ($good > $bad + 1) {
     my $bits = 2 ** $checked;
     if (disabled("deprecated-3.0")) {
         $fin = run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
-                         '-algorithm', 'RSA', '-pkeyopt', 'rsa_keygen_pubexp:3',
+                         '-algorithm', 'RSA', '-pkeyopt', 'rsa_keygen_pubexp:65537',
                          '-pkeyopt', "rsa_keygen_bits:$bits",
                        ], stderr => undef));
     } else {
@@ -64,7 +64,7 @@ $good = 2 ** $good;
 note "Found lowest allowed amount of bits to be $good";
 
 ok(run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
-             '-pkeyopt', 'rsa_keygen_pubexp:3',
+             '-pkeyopt', 'rsa_keygen_pubexp:65537',
              '-pkeyopt', "rsa_keygen_bits:$good",
              '-out', 'genrsatest.pem' ])),
    "genpkey -3 $good");
@@ -77,6 +77,11 @@ ok(run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
    "genpkey -f4 $good");
 ok(run(app([ 'openssl', 'pkey', '-check', '-in', 'genrsatest.pem', '-noout' ])),
    "pkey -check");
+
+ok(!run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
+             '-pkeyopt', 'hexe:02',
+             '-out', 'genrsatest.pem' ])),
+   "genpkey with a bad public exponent should fail");
 
  SKIP: {
     skip "Skipping rsa command line test", 4 if disabled("deprecated-3.0");

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -16,7 +16,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_genrsa");
 
-plan tests => 10;
+plan tests => 12;
 
 # We want to know that an absurdly small number of bits isn't support
 if (disabled("deprecated-3.0")) {
@@ -75,13 +75,23 @@ ok(run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
              '-pkeyopt', "rsa_keygen_bits:$good",
              '-out', 'genrsatest.pem' ])),
    "genpkey -f4 $good");
-ok(run(app([ 'openssl', 'pkey', '-check', '-in', 'genrsatest.pem', '-noout' ])),
+
+ok(run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
+             '-pkeyopt', 'rsa_keygen_bits:2048',
+             '-out', 'genrsatest2048.pem' ])),
+   "genpkey 2048 bits");
+ok(run(app([ 'openssl', 'pkey', '-check', '-in', 'genrsatest2048.pem', '-noout' ])),
    "pkey -check");
 
 ok(!run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
              '-pkeyopt', 'hexe:02',
              '-out', 'genrsatest.pem' ])),
    "genpkey with a bad public exponent should fail");
+ok(!run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
+             '-pkeyopt', 'e:65538',
+             '-out', 'genrsatest.pem' ])),
+   "genpkey with a even public exponent should fail");
+
 
  SKIP: {
     skip "Skipping rsa command line test", 4 if disabled("deprecated-3.0");


### PR DESCRIPTION
Fixes #11742
Fixes #11764

The newer RSA sp800-56b algorithm is being used for the normal case of a non multiprime key of at least length 2048.
Insecure key lengths and multiprime RSA will use the old method.

Bad public exponents are no longer allowed (i.e values less than 65537 or even). Values such as 2 that would cause a infinite loop now result in an error. The value of 3 has been marked as deprecated but is still allowed for legacy purposes.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
