### PR TITLE
TTY_get() in crypto/ui/ui_openssl.c open_console() can also return errno 1 (EPERM, Linux)

### DIFF
--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -439,6 +439,16 @@ static int open_console(UI *ui)
             is_a_tty = 0;
         else
 #  endif
+#  ifdef EPERM
+            /*
+             * Linux can return EPERM (Operation not permitted),
+             * e.g. if a daemon executes openssl via fork()+execve()
+             * This should be ok
+             */
+        if (errno == EPERM)
+            is_a_tty = 0;
+        else
+#  endif
 #  ifdef ENODEV
             /*
              * MacOS X returns ENODEV (Operation not supported by device),


### PR DESCRIPTION
Signed-off-by: Maxim Zakharov <5158255+Maxime2@users.noreply.github.com>

CLA: trivial


I am porting a daemon which executes `openssl` from LibreSSL using fork()+execl().
When I have switched to `openssl` from OpenSSL (version 1.1.1f with Ubuntu patches) I have got the following errors:
`
User interface error
139953222812992:error:2807206C:UI routines:open_console:unknown ttyget errno value:../crypto/ui/ui_openssl.c:454:errno=1
139953222812992:error:2807106B:UI routines:UI_process:processing error:../crypto/ui/ui_lib.c:545:while opening session
unable to load CA private key
139953222812992:error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt:../crypto/evp/evp_enc.c:588:
139953222812992:error:0906A065:PEM routines:PEM_do_header:bad decrypt:../crypto/pem/pem_lib.c:461:
`

It looks like TTY_get() in crypto/ui/ui_openssl.c open_console() can also return errno 1 (EPERM) on Linux, which should be ok.

The proposed patch fixes the issue.

