### PR TITLE
Fix maximum possible length of cipher text

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -212,7 +212,7 @@ writes the encrypted version to B<out>. This function can be called
 multiple times to encrypt successive blocks of data. The amount
 of data written depends on the block alignment of the encrypted data:
 as a result the amount of data written may be anything from zero bytes
-to (inl + cipher_block_size - 1) so B<out> should contain sufficient
+to (inl + cipher_block_size) so B<out> should contain sufficient
 room. The actual number of bytes written is placed in B<outl>. It also
 checks if B<in> and B<out> are partially overlapping, and if they are
 0 is returned to indicate failure.


### PR DESCRIPTION
For EVP_EncryptUpdate(), the amount of data written my be up to (inl + cipher_block_size) instead of (inl + cipher_block_size - 1). At least for AES128CBC, when "inl" is divisible by cipher_block_size (16), the space needed is (inl + cipher_block_size).

