### PR TITLE
Fix X509_ALGOR_copy if source algorithm parameter is provided

### DIFF
--- a/crypto/asn1/x_algor.c
+++ b/crypto/asn1/x_algor.c
@@ -110,13 +110,18 @@ int X509_ALGOR_copy(X509_ALGOR *dest, const X509_ALGOR *src)
         if ((dest->algorithm = OBJ_dup(src->algorithm)) == NULL)
 	    return 0;
 
-    if (src->parameter)
+    if (src->parameter) {
+        dest->parameter = ASN1_TYPE_new();
+        if (dest->parameter == NULL)
+            return 0;
+
         /* Assuming this is also correct for a BOOL.
          * set does copy as a side effect.
          */
         if (ASN1_TYPE_set1(dest->parameter, 
               src->parameter->type, src->parameter->value.ptr) == 0)
 	    return 0;
+    }
 
     return 1;
 }


### PR DESCRIPTION
The function X509_ALGOR_copy is lead to segfault if source algorithm parameter is given and ASN1_TYPE_set1 is trying to access to non allocated memory.