### PR TITLE
Enable brainpool curves for TLS1.3

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3609,7 +3609,10 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
                 int *cptr = parg;
 
                 for (i = 0; i < clistlen; i++) {
-                    const TLS_GROUP_INFO *cinf = tls1_group_id_lookup(clist[i]);
+                    uint16_t cid = SSL_IS_TLS13(s)
+                                   ? ssl_group_id_tls13_to_internal(clist[i])
+                                   : clist[i];
+                    const TLS_GROUP_INFO *cinf = tls1_group_id_lookup(cid);
 
                     if (cinf != NULL)
                         cptr[i] = cinf->nid;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2048,6 +2048,22 @@ typedef enum downgrade_en {
 
 #define TLSEXT_SIGALG_ed25519                                   0x0807
 #define TLSEXT_SIGALG_ed448                                     0x0808
+#define TLSEXT_SIGALG_ecdsa_brainpoolP256r1_sha256              0x081a
+#define TLSEXT_SIGALG_ecdsa_brainpoolP384r1_sha384              0x081b
+#define TLSEXT_SIGALG_ecdsa_brainpoolP512r1_sha512              0x081c
+
+/* EC curve group ids */
+#define TLSEXT_GROUPID_secp256r1                                23
+#define TLSEXT_GROUPID_secp384r1                                24
+#define TLSEXT_GROUPID_secp521r1                                25
+#define TLSEXT_GROUPID_brainpoolP256r1                          26
+#define TLSEXT_GROUPID_brainpoolP384r1                          27
+#define TLSEXT_GROUPID_brainpoolP512r1                          28
+#define TLSEXT_GROUPID_X25519                                   29
+#define TLSEXT_GROUPID_X448                                     30
+#define TLSEXT_GROUPID_brainpoolP256r1_tls13                    31
+#define TLSEXT_GROUPID_brainpoolP384r1_tls13                    32
+#define TLSEXT_GROUPID_brainpoolP512r1_tls13                    33
 
 /* Known PSK key exchange modes */
 #define TLSEXT_KEX_MODE_KE                                      0x00
@@ -2509,7 +2525,8 @@ __owur int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL *s);
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 
 #  ifndef OPENSSL_NO_EC
-
+__owur uint16_t ssl_group_id_internal_to_tls13(uint16_t curve_id);
+__owur uint16_t ssl_group_id_tls13_to_internal(uint16_t curve_id);
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t curve_id);
 __owur int tls1_check_group_id(SSL *s, uint16_t group_id, int check_own_curves);
 __owur uint16_t tls1_shared_group(SSL *s, int nmatch);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1400,7 +1400,7 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
                     group_id = pgroups[i];
 
                     if (check_in_list(s, group_id, clntgroups, clnt_num_groups,
-                                      1))
+                                      2))
                         break;
                 }
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -198,12 +198,34 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
         uint16_t ctmp = pgroups[i];
 
         if (tls_curve_allowed(s, ctmp, SSL_SECOP_CURVE_SUPPORTED)) {
-            if (!WPACKET_put_bytes_u16(pkt, ctmp)) {
+#ifndef OPENSSL_NO_TLS1_3
+            int ctmp13 = ssl_group_id_internal_to_tls13(ctmp);
+
+            if (ctmp13 != 0 && ctmp13 != ctmp) {
+                int ver_min, ver_max;
+                if (ssl_get_min_max_version(s, &ver_min, &ver_max, NULL)) {
                     SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                              SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS,
                              ERR_R_INTERNAL_ERROR);
                     return EXT_RETURN_FAIL;
                 }
+                if (ver_max >= TLS1_3_VERSION
+                        && !WPACKET_put_bytes_u16(pkt, ctmp13)) {
+                    SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                             SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS,
+                             ERR_R_INTERNAL_ERROR);
+                    return EXT_RETURN_FAIL;
+                }
+                if (ver_min >= TLS1_3_VERSION)
+                    continue;
+            }
+#endif
+            if (!WPACKET_put_bytes_u16(pkt, ctmp)) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                         SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS,
+                         ERR_R_INTERNAL_ERROR);
+                return EXT_RETURN_FAIL;
+            }
         }
     }
     if (!WPACKET_close(pkt) || !WPACKET_close(pkt)) {
@@ -615,7 +637,7 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
     }
 
     /* Create KeyShareEntry */
-    if (!WPACKET_put_bytes_u16(pkt, curve_id)
+    if (!WPACKET_put_bytes_u16(pkt, ssl_group_id_internal_to_tls13(curve_id))
             || !WPACKET_sub_memcpy_u16(pkt, encoded_point, encodedlen)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE,
                  ERR_R_INTERNAL_ERROR);
@@ -670,6 +692,9 @@ EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
         curve_id = s->s3->group_id;
     } else {
         for (i = 0; i < num_groups; i++) {
+
+            if (ssl_group_id_internal_to_tls13(pgroups[i]) == 0)
+                continue;
 
             if (!tls_curve_allowed(s, pgroups[i], SSL_SECOP_CURVE_SUPPORTED))
                 continue;
@@ -1812,6 +1837,7 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         return 0;
     }
 
+    group_id = ssl_group_id_tls13_to_internal(group_id);
     if ((context & SSL_EXT_TLS1_3_HELLO_RETRY_REQUEST) != 0) {
         const uint16_t *pgroups = NULL;
         size_t i, num_groups;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -685,7 +685,7 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
          * we requested, and must be the only key_share sent.
          */
         if (s->s3->group_id != 0
-                && (group_id != s->s3->group_id
+                && (ssl_group_id_tls13_to_internal(group_id) != s->s3->group_id
                     || PACKET_remaining(&key_share_list) != 0)) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                      SSL_F_TLS_PARSE_CTOS_KEY_SHARE, SSL_R_BAD_KEY_SHARE);
@@ -705,13 +705,14 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
             continue;
         }
 
+        s->s3->group_id = group_id;
+        group_id = ssl_group_id_tls13_to_internal(group_id);
+
         if ((s->s3->peer_tmp = ssl_generate_param_group(group_id)) == NULL) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_CTOS_KEY_SHARE,
                    SSL_R_UNABLE_TO_FIND_ECDH_PARAMETERS);
             return 0;
         }
-
-        s->s3->group_id = group_id;
 
         if (!EVP_PKEY_set1_tls_encodedpoint(s->s3->peer_tmp,
                 PACKET_data(&encoded_pt),
@@ -1694,7 +1695,8 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
         }
         if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_key_share)
                 || !WPACKET_start_sub_packet_u16(pkt)
-                || !WPACKET_put_bytes_u16(pkt, s->s3->group_id)
+                || !WPACKET_put_bytes_u16(pkt, ssl_group_id_internal_to_tls13(
+                                          s->s3->group_id))
                 || !WPACKET_close(pkt)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE,

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2179,8 +2179,14 @@ int check_in_list(SSL *s, uint16_t group_id, const uint16_t *groups,
     if (groups == NULL || num_groups == 0)
         return 0;
 
+    if (checkallow == 1)
+        group_id = ssl_group_id_tls13_to_internal(group_id);
+
     for (i = 0; i < num_groups; i++) {
         uint16_t group = groups[i];
+
+        if (checkallow == 2)
+            group = ssl_group_id_tls13_to_internal(group);
 
         if (group_id == group
                 && (!checkallow

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -166,7 +166,7 @@ static const TLS_GROUP_INFO nid_list[] = {
     {NID_secp521r1, 256, TLS_CURVE_PRIME}, /* secp521r1 (25) */
     {NID_brainpoolP256r1, 128, TLS_CURVE_PRIME}, /* brainpoolP256r1 (26) */
     {NID_brainpoolP384r1, 192, TLS_CURVE_PRIME}, /* brainpoolP384r1 (27) */
-    {NID_brainpoolP512r1, 256, TLS_CURVE_PRIME}, /* brainpool512r1 (28) */
+    {NID_brainpoolP512r1, 256, TLS_CURVE_PRIME}, /* brainpoolP512r1 (28) */
     {EVP_PKEY_X25519, 128, TLS_CURVE_CUSTOM}, /* X25519 (29) */
     {EVP_PKEY_X448, 224, TLS_CURVE_CUSTOM}, /* X448 (30) */
 };
@@ -179,17 +179,65 @@ static const unsigned char ecformats_default[] = {
 
 /* The default curves */
 static const uint16_t eccurves_default[] = {
-    29,                      /* X25519 (29) */
-    23,                      /* secp256r1 (23) */
-    30,                      /* X448 (30) */
-    25,                      /* secp521r1 (25) */
-    24,                      /* secp384r1 (24) */
+    TLSEXT_GROUPID_X25519,           /* X25519 (29) */
+    TLSEXT_GROUPID_secp256r1,        /* secp256r1 (23) */
+    TLSEXT_GROUPID_X448,             /* X448 (30) */
+    TLSEXT_GROUPID_secp521r1,        /* secp521r1 (25) */
+    TLSEXT_GROUPID_secp384r1,        /* secp384r1 (24) */
 };
 
 static const uint16_t suiteb_curves[] = {
-    TLSEXT_curve_P_256,
-    TLSEXT_curve_P_384
+    TLSEXT_GROUPID_secp256r1,
+    TLSEXT_GROUPID_secp384r1,
 };
+
+uint16_t ssl_group_id_internal_to_tls13(uint16_t curve_id)
+{
+    switch(curve_id) {
+    case TLSEXT_GROUPID_secp256r1:
+        return TLSEXT_GROUPID_secp256r1;
+    case TLSEXT_GROUPID_secp384r1:
+        return TLSEXT_GROUPID_secp384r1;
+    case TLSEXT_GROUPID_secp521r1:
+        return TLSEXT_GROUPID_secp521r1;
+    case TLSEXT_GROUPID_X25519:
+        return TLSEXT_GROUPID_X25519;
+    case TLSEXT_GROUPID_X448:
+        return TLSEXT_GROUPID_X448;
+    case TLSEXT_GROUPID_brainpoolP256r1:
+        return TLSEXT_GROUPID_brainpoolP256r1_tls13;
+    case TLSEXT_GROUPID_brainpoolP384r1:
+        return TLSEXT_GROUPID_brainpoolP384r1_tls13;
+    case TLSEXT_GROUPID_brainpoolP512r1:
+        return TLSEXT_GROUPID_brainpoolP512r1_tls13;
+    default:
+        return 0;
+    }
+}
+
+uint16_t ssl_group_id_tls13_to_internal(uint16_t curve_id)
+{
+    switch(curve_id) {
+    case TLSEXT_GROUPID_secp256r1:
+        return TLSEXT_GROUPID_secp256r1;
+    case TLSEXT_GROUPID_secp384r1:
+        return TLSEXT_GROUPID_secp384r1;
+    case TLSEXT_GROUPID_secp521r1:
+        return TLSEXT_GROUPID_secp521r1;
+    case TLSEXT_GROUPID_X25519:
+        return TLSEXT_GROUPID_X25519;
+    case TLSEXT_GROUPID_X448:
+        return TLSEXT_GROUPID_X448;
+    case TLSEXT_GROUPID_brainpoolP256r1_tls13:
+        return TLSEXT_GROUPID_brainpoolP256r1;
+    case TLSEXT_GROUPID_brainpoolP384r1_tls13:
+        return TLSEXT_GROUPID_brainpoolP384r1;
+    case TLSEXT_GROUPID_brainpoolP512r1_tls13:
+        return TLSEXT_GROUPID_brainpoolP512r1;
+    default:
+        return 0;
+    }
+}
 
 const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t group_id)
 {
@@ -298,9 +346,9 @@ uint16_t tls1_shared_group(SSL *s, int nmatch)
             unsigned long cid = s->s3->tmp.new_cipher->id;
 
             if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
-                return TLSEXT_curve_P_256;
+                return TLSEXT_GROUPID_secp256r1;
             if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)
-                return TLSEXT_curve_P_384;
+                return TLSEXT_GROUPID_secp384r1;
             /* Should never happen */
             return 0;
         }
@@ -321,10 +369,17 @@ uint16_t tls1_shared_group(SSL *s, int nmatch)
 
     for (k = 0, i = 0; i < num_pref; i++) {
         uint16_t id = pref[i];
+        uint16_t cid = id;
 
-        if (!tls1_in_list(id, supp, num_supp)
-            || !tls_curve_allowed(s, id, SSL_SECOP_CURVE_SHARED))
-                    continue;
+        if (SSL_IS_TLS13(s)) {
+            if (s->options & SSL_OP_CIPHER_SERVER_PREFERENCE)
+                cid = ssl_group_id_internal_to_tls13(id);
+            else
+                cid = id = ssl_group_id_tls13_to_internal(id);
+        }
+        if (!tls1_in_list(cid, supp, num_supp)
+                || !tls_curve_allowed(s, id, SSL_SECOP_CURVE_SHARED))
+            continue;
         if (nmatch == k)
             return id;
          k++;
@@ -492,10 +547,10 @@ int tls1_check_group_id(SSL *s, uint16_t group_id, int check_own_groups)
         unsigned long cid = s->s3->tmp.new_cipher->id;
 
         if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256) {
-            if (group_id != TLSEXT_curve_P_256)
+            if (group_id != TLSEXT_GROUPID_secp256r1)
                 return 0;
         } else if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384) {
-            if (group_id != TLSEXT_curve_P_384)
+            if (group_id != TLSEXT_GROUPID_secp384r1)
                 return 0;
         } else {
             /* Should never happen */
@@ -583,9 +638,9 @@ static int tls1_check_cert_param(SSL *s, X509 *x, int check_ee_md)
         size_t i;
 
         /* Check to see we have necessary signing algorithm */
-        if (group_id == TLSEXT_curve_P_256)
+        if (group_id == TLSEXT_GROUPID_secp256r1)
             check_md = NID_ecdsa_with_SHA256;
-        else if (group_id == TLSEXT_curve_P_384)
+        else if (group_id == TLSEXT_GROUPID_secp384r1)
             check_md = NID_ecdsa_with_SHA384;
         else
             return 0;           /* Should never happen */
@@ -618,9 +673,9 @@ int tls1_check_ec_tmp_key(SSL *s, unsigned long cid)
      * curves permitted.
      */
     if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
-        return tls1_check_group_id(s, TLSEXT_curve_P_256, 1);
+        return tls1_check_group_id(s, TLSEXT_GROUPID_secp256r1, 1);
     if (cid == TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384)
-        return tls1_check_group_id(s, TLSEXT_curve_P_384, 1);
+        return tls1_check_group_id(s, TLSEXT_GROUPID_secp384r1, 1);
 
     return 0;
 }
@@ -642,6 +697,9 @@ static const uint16_t tls12_sigalgs[] = {
     TLSEXT_SIGALG_ecdsa_secp521r1_sha512,
     TLSEXT_SIGALG_ed25519,
     TLSEXT_SIGALG_ed448,
+    TLSEXT_SIGALG_ecdsa_brainpoolP256r1_sha256,
+    TLSEXT_SIGALG_ecdsa_brainpoolP384r1_sha384,
+    TLSEXT_SIGALG_ecdsa_brainpoolP512r1_sha512,
 #endif
 
     TLSEXT_SIGALG_rsa_pss_pss_sha256,
@@ -706,6 +764,15 @@ static const SIGALG_LOOKUP sigalg_lookup_tbl[] = {
     {NULL, TLSEXT_SIGALG_ecdsa_sha1,
      NID_sha1, SSL_MD_SHA1_IDX, EVP_PKEY_EC, SSL_PKEY_ECC,
      NID_ecdsa_with_SHA1, NID_undef},
+    {"ecdsa_brainpoolP256r1_sha256", TLSEXT_SIGALG_ecdsa_brainpoolP256r1_sha256,
+     NID_sha256, SSL_MD_SHA256_IDX, EVP_PKEY_EC, SSL_PKEY_ECC,
+     NID_ecdsa_with_SHA256, NID_brainpoolP256r1},
+    {"ecdsa_brainpoolP384r1_sha384", TLSEXT_SIGALG_ecdsa_brainpoolP384r1_sha384,
+     NID_sha384, SSL_MD_SHA384_IDX, EVP_PKEY_EC, SSL_PKEY_ECC,
+     NID_ecdsa_with_SHA384, NID_brainpoolP384r1},
+    {"ecdsa_brainpoolP512r1_sha512", TLSEXT_SIGALG_ecdsa_brainpoolP512r1_sha512,
+     NID_sha512, SSL_MD_SHA512_IDX, EVP_PKEY_EC, SSL_PKEY_ECC,
+     NID_ecdsa_with_SHA512, NID_brainpoolP512r1},
 #endif
     {"rsa_pss_rsae_sha256", TLSEXT_SIGALG_rsa_pss_rsae_sha256,
      NID_sha256, SSL_MD_SHA256_IDX, EVP_PKEY_RSA_PSS, SSL_PKEY_RSA,

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -572,6 +572,9 @@ static const ssl_trace_tbl ssl_sigalg_tbl[] = {
     {TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256, "gost2012_256"},
     {TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512, "gost2012_512"},
     {TLSEXT_SIGALG_gostr34102001_gostr3411, "gost2001_gost94"},
+    {TLSEXT_SIGALG_ecdsa_brainpoolP256r1_sha256, "ecdsa_brainpoolP256r1_sha256"},
+    {TLSEXT_SIGALG_ecdsa_brainpoolP384r1_sha384, "ecdsa_brainpoolP384r1_sha384"},
+    {TLSEXT_SIGALG_ecdsa_brainpoolP512r1_sha512, "ecdsa_brainpoolP512r1_sha512"},
 };
 
 static const ssl_trace_tbl ssl_ctype_tbl[] = {

--- a/test/ssl-tests/20-cert-select.conf
+++ b/test/ssl-tests/20-cert-select.conf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 56
+num_tests = 57
 
 test-0 = 0-ECDSA CipherString Selection
 test-1 = 1-ECDSA CipherString Selection
@@ -55,9 +55,10 @@ test-49 = 49-TLS 1.3 ECDSA Client Auth Signature Algorithm Selection
 test-50 = 50-TLS 1.3 Ed25519 Client Auth
 test-51 = 51-TLS 1.3 Ed448 Client Auth
 test-52 = 52-TLS 1.3 ECDSA with brainpool
-test-53 = 53-TLS 1.2 DSA Certificate Test
-test-54 = 54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
-test-55 = 55-TLS 1.3 DSA Certificate Test
+test-53 = 53-TLS 1.3 ECDSA with brainpool 2
+test-54 = 54-TLS 1.2 DSA Certificate Test
+test-55 = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms
+test-56 = 56-TLS 1.3 DSA Certificate Test
 # ===========================================================
 
 [0-ECDSA CipherString Selection]
@@ -246,6 +247,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 [5-ECDSA with brainpool-client]
 CipherString = aECDSA
 Groups = brainpoolP256r1
+MaxProtocol = TLSv1.2
 RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -1716,6 +1718,7 @@ client = 52-TLS 1.3 ECDSA with brainpool-client
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
 CipherString = DEFAULT
 Groups = brainpoolP256r1
+MaxProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
 [52-TLS 1.3 ECDSA with brainpool-client]
@@ -1733,26 +1736,26 @@ ExpectedResult = ServerFail
 
 # ===========================================================
 
-[53-TLS 1.2 DSA Certificate Test]
-ssl_conf = 53-TLS 1.2 DSA Certificate Test-ssl
+[53-TLS 1.3 ECDSA with brainpool 2]
+ssl_conf = 53-TLS 1.3 ECDSA with brainpool 2-ssl
 
-[53-TLS 1.2 DSA Certificate Test-ssl]
-server = 53-TLS 1.2 DSA Certificate Test-server
-client = 53-TLS 1.2 DSA Certificate Test-client
+[53-TLS 1.3 ECDSA with brainpool 2-ssl]
+server = 53-TLS 1.3 ECDSA with brainpool 2-server
+client = 53-TLS 1.3 ECDSA with brainpool 2-client
 
-[53-TLS 1.2 DSA Certificate Test-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = ALL
-DHParameters = ${ENV::TEST_CERTS_DIR}/dhp2048.pem
-DSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-dsa-cert.pem
-DSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-dsa-key.pem
-MaxProtocol = TLSv1.2
-MinProtocol = TLSv1.2
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+[53-TLS 1.3 ECDSA with brainpool 2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-cert.pem
+CipherString = DEFAULT
+Groups = brainpoolP256r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-brainpoolP256r1-key.pem
 
-[53-TLS 1.2 DSA Certificate Test-client]
-CipherString = ALL
-SignatureAlgorithms = DSA+SHA256:DSA+SHA1
+[53-TLS 1.3 ECDSA with brainpool 2-client]
+CipherString = DEFAULT
+Groups = brainpoolP256r1
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+RequestCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -1762,14 +1765,43 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
-ssl_conf = 54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
+[54-TLS 1.2 DSA Certificate Test]
+ssl_conf = 54-TLS 1.2 DSA Certificate Test-ssl
 
-[54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
-server = 54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
-client = 54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
+[54-TLS 1.2 DSA Certificate Test-ssl]
+server = 54-TLS 1.2 DSA Certificate Test-server
+client = 54-TLS 1.2 DSA Certificate Test-client
 
-[54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
+[54-TLS 1.2 DSA Certificate Test-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = ALL
+DHParameters = ${ENV::TEST_CERTS_DIR}/dhp2048.pem
+DSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-dsa-cert.pem
+DSA.PrivateKey = ${ENV::TEST_CERTS_DIR}/server-dsa-key.pem
+MaxProtocol = TLSv1.2
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[54-TLS 1.2 DSA Certificate Test-client]
+CipherString = ALL
+SignatureAlgorithms = DSA+SHA256:DSA+SHA1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-54]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms]
+ssl_conf = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl
+
+[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-ssl]
+server = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server
+client = 55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client
+
+[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 ClientSignatureAlgorithms = ECDSA+SHA1:DSA+SHA256:RSA+SHA256
@@ -1777,25 +1809,25 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Request
 
-[54-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
+[55-TLS 1.3 Client Auth No TLS 1.3 Signature Algorithms-client]
 CipherString = DEFAULT
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-54]
+[test-55]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[55-TLS 1.3 DSA Certificate Test]
-ssl_conf = 55-TLS 1.3 DSA Certificate Test-ssl
+[56-TLS 1.3 DSA Certificate Test]
+ssl_conf = 56-TLS 1.3 DSA Certificate Test-ssl
 
-[55-TLS 1.3 DSA Certificate Test-ssl]
-server = 55-TLS 1.3 DSA Certificate Test-server
-client = 55-TLS 1.3 DSA Certificate Test-client
+[56-TLS 1.3 DSA Certificate Test-ssl]
+server = 56-TLS 1.3 DSA Certificate Test-server
+client = 56-TLS 1.3 DSA Certificate Test-client
 
-[55-TLS 1.3 DSA Certificate Test-server]
+[56-TLS 1.3 DSA Certificate Test-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ALL
 DSA.Certificate = ${ENV::TEST_CERTS_DIR}/server-dsa-cert.pem
@@ -1804,13 +1836,13 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[55-TLS 1.3 DSA Certificate Test-client]
+[56-TLS 1.3 DSA Certificate Test-client]
 CipherString = ALL
 SignatureAlgorithms = DSA+SHA1:DSA+SHA256:ECDSA+SHA256
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-55]
+[test-56]
 ExpectedResult = ServerFail
 
 

--- a/test/ssl-tests/20-cert-select.conf.in
+++ b/test/ssl-tests/20-cert-select.conf.in
@@ -153,9 +153,8 @@ our @tests = (
             "Groups" => "brainpoolP256r1",
         },
         client => {
-            #We don't restrict this to TLSv1.2, although use of brainpool
-            #should force this anyway so that this should succeed
             "CipherString" => "aECDSA",
+            "MaxProtocol" => "TLSv1.2",
             "RequestCAFile" => test_pem("root-cert.pem"),
             "Groups" => "brainpoolP256r1",
         },
@@ -859,6 +858,7 @@ my @tests_tls_1_3 = (
             "Certificate" => test_pem("server-ecdsa-brainpoolP256r1-cert.pem"),
             "PrivateKey" => test_pem("server-ecdsa-brainpoolP256r1-key.pem"),
             "Groups" => "brainpoolP256r1",
+            "MaxProtocol" => "TLSv1.2"
         },
         client => {
             "RequestCAFile" => test_pem("root-cert.pem"),
@@ -868,6 +868,24 @@ my @tests_tls_1_3 = (
         },
         test   => {
             "ExpectedResult" => "ServerFail"
+        },
+    },
+    {
+        name => "TLS 1.3 ECDSA with brainpool 2",
+        server =>  {
+            "Certificate" => test_pem("server-ecdsa-brainpoolP256r1-cert.pem"),
+            "PrivateKey" => test_pem("server-ecdsa-brainpoolP256r1-key.pem"),
+            "Groups" => "brainpoolP256r1",
+            "MaxProtocol" => "TLSv1.3"
+        },
+        client => {
+            "RequestCAFile" => test_pem("root-cert.pem"),
+            "Groups" => "brainpoolP256r1",
+            "MinProtocol" => "TLSv1.3",
+            "MaxProtocol" => "TLSv1.3"
+        },
+        test   => {
+            "ExpectedResult" => "Success"
         },
     },
 );


### PR DESCRIPTION
This adds (optional) support for brainpool curves in TLS1.3

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated

back-port of #7485 for 1.1.1