### PR TITLE
Remove explicit dependency on configdata.pm when processing .in files

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -94,7 +94,6 @@ DEFINE[../providers/libcommon.a]=$UTIL_DEFINE
 DEPEND[info.o]=buildinf.h
 DEPEND[cversion.o]=buildinf.h
 GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
-DEPEND[buildinf.h]=../configdata.pm
 
 GENERATE[uplink-x86.s]=../ms/uplink-x86.pl
 GENERATE[uplink-x86_64.s]=../ms/uplink-x86_64.pl

--- a/doc/build.info
+++ b/doc/build.info
@@ -56,7 +56,6 @@ DEPEND[$manfile]=$podfile
 GENERATE[$manfile]=$podfile
 _____
          $OUT .= << "_____" if $podinfile;
-DEPEND[$podfile]=$podinfile ../configdata.pm
 GENERATE[$podfile]=$podinfile
 _____
      }


### PR DESCRIPTION
For those files, the dependence on configdata.pm is automatic, adding
it explicitly only results in having that dependency twice.

Fixes #11786
