### PR TITLE
Fix FreeBSD build with --strict-warnings

### DIFF
--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -17,6 +17,7 @@
 # define _POSIX_C_SOURCE 2
 #endif
 
+#include <string.h>
 #include <ctype.h>
 #include "http_server.h"
 #include "internal/sockets.h"


### PR DESCRIPTION
apps/lib/http_server.c needs to include string.h in order to get a prototype
for strerror().

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
