### PR TITLE
Fix issue 11796

### DIFF
--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -230,6 +230,7 @@ DEFINE_LHASH_OF(OPENSSL_CSTRING);
  */
 # ifdef __SUNPRO_C
 #  pragma weak OPENSSL_LH_new
+#  pragma weak OPENSSL_LH_flush
 #  pragma weak OPENSSL_LH_free
 #  pragma weak OPENSSL_LH_insert
 #  pragma weak OPENSSL_LH_delete


### PR DESCRIPTION
Fix Issue 11796: Add missing pragma weak declaration to lhash.h for solaris builds
#  pragma weak OPENSSL_LH_flush