### PR TITLE
PROV: Add a proper provider context structure for OpenSSL providers

### DIFF
--- a/crypto/property/build.info
+++ b/crypto/property/build.info
@@ -2,3 +2,4 @@ LIBS=../../libcrypto
 $COMMON=property_string.c property_parse.c property.c defn_cache.c
 SOURCE[../../libcrypto]=$COMMON property_err.c
 SOURCE[../../providers/libfips.a]=$COMMON
+SOURCE[../../providers/liblegacy.a]=$COMMON

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=der
 
-SOURCE[../libcommon.a]=provider_err.c bio_prov.c
+SOURCE[../libcommon.a]=provider_err.c bio_prov.c provider_ctx.c
 $FIPSCOMMON=provider_util.c
 SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
 SOURCE[../libfips.a]=$FIPSCOMMON

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -7,8 +7,24 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/types.h>
+#include <openssl/crypto.h>
+
+typedef struct prov_ctx_st {
+    const OSSL_PROVIDER *provider;
+    OPENSSL_CTX *libctx;         /* For all provider modules */
+} PROV_CTX;
+
 /*
  * To be used anywhere the library context needs to be passed, such as to
  * fetching functions.
  */
-#define PROV_LIBRARY_CONTEXT_OF(provctx)        (provctx)
+#define PROV_LIBRARY_CONTEXT_OF(provctx)        \
+    PROV_CTX_get0_library_context((provctx))
+
+PROV_CTX *PROV_CTX_new(void);
+void PROV_CTX_free(PROV_CTX *ctx);
+void PROV_CTX_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx);
+void PROV_CTX_set0_provider(PROV_CTX *ctx, const OSSL_PROVIDER *libctx);
+OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx);
+const OSSL_PROVIDER *PROV_CTX_get0_provider(PROV_CTX *ctx);

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include "prov/provider_ctx.h"
+
+PROV_CTX *PROV_CTX_new(void)
+{
+    return OPENSSL_zalloc(sizeof(PROV_CTX));
+}
+
+void PROV_CTX_free(PROV_CTX *ctx)
+{
+    OPENSSL_free(ctx);
+}
+
+void PROV_CTX_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx)
+{
+    if (ctx != NULL)
+        ctx->libctx = libctx;
+}
+
+void PROV_CTX_set0_provider(PROV_CTX *ctx, const OSSL_PROVIDER *provider)
+{
+    if (ctx != NULL)
+        ctx->provider = provider;
+}
+
+
+OPENSSL_CTX *PROV_CTX_get0_library_context(PROV_CTX *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+    return ctx->libctx;
+}
+
+const OSSL_PROVIDER *PROV_CTX_get0_provider(PROV_CTX *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+    return ctx->provider;
+}

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -516,6 +516,16 @@ static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
 static void fips_teardown(void *provctx)
 {
     OPENSSL_CTX_free(PROV_LIBRARY_CONTEXT_OF(provctx));
+    PROV_CTX_free(provctx);
+}
+
+static void fips_intern_teardown(void *provctx)
+{
+    /*
+     * We know that the library context is the same as for the outer provider,
+     * so no need to destroy it here.
+     */
+    PROV_CTX_free(provctx);
 }
 
 /* Functions we provide to the core */
@@ -529,6 +539,7 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
 
 /* Functions we provide to ourself */
 static const OSSL_DISPATCH intern_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))fips_intern_teardown },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fips_query },
     { 0, NULL }
 };
@@ -647,9 +658,18 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
         return 0;
 
     /*  Create a context. */
-    if ((libctx = OPENSSL_CTX_new()) == NULL)
-        return 0;
-    *provctx = libctx;
+    if ((*provctx = PROV_CTX_new()) == NULL
+        || (libctx = OPENSSL_CTX_new()) == NULL) {
+        /*
+         * We free libctx separately here and only here because it hasn't
+         * been attached to *provctx.  All other error paths below rely
+         * solely on fips_teardown.
+         */
+        OPENSSL_CTX_free(libctx);
+        goto err;
+    }
+    PROV_CTX_set0_library_context(*provctx, libctx);
+    PROV_CTX_set0_provider(*provctx, provider);
 
     if ((fgbl = openssl_ctx_get_data(libctx, OPENSSL_CTX_FIPS_PROV_INDEX,
                                      &fips_prov_ossl_ctx_method)) == NULL)
@@ -705,14 +725,10 @@ int fips_intern_provider_init(const OSSL_PROVIDER *provider,
     if (c_get_libctx == NULL)
         return 0;
 
-    *provctx = c_get_libctx(provider);
-
-    /*
-     * Safety measure...  we should get the library context that was
-     * created up in OSSL_provider_init().
-     */
-    if (*provctx == NULL)
+    if ((*provctx = PROV_CTX_new()) == NULL)
         return 0;
+    PROV_CTX_set0_library_context(*provctx, c_get_libctx(provider));
+    PROV_CTX_set0_provider(*provctx, provider);
 
     *out = intern_dispatch_table;
     return 1;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -551,7 +551,7 @@ int OSSL_provider_init(const OSSL_PROVIDER *provider,
                        void **provctx)
 {
     FIPS_GLOBAL *fgbl;
-    OPENSSL_CTX *libctx;
+    OPENSSL_CTX *libctx = NULL;
     OSSL_self_test_cb_fn *stcbfn = NULL;
     OSSL_core_get_library_context_fn *c_get_libctx = NULL;
 


### PR DESCRIPTION
The provider context structure is made to include the following information:

- The core provider handle (first argument to the provider init
  function).  This handle is meant to be used in all upcalls that need
  it.

- A library context, used for any libcrypto calls that need it, done in
  the provider itself.

Regarding the library context, that's generally only needed if the
provider makes any libcrypto calls, i.e. is linked with libcrypto.  That
happens to be the case for all OpenSSL providers, but is applicable for
other providers that use libcrypto internally as well.

The normal thing to do for a provider init function is to create its own
library context.  For a provider that's meant to become a dynamically
loadable module, this is what MUST be done.
However, we do not do that in the default provider; it uses the library
context associated with the core provider handle instead.  This is
permissible, although generally discouraged, as long as the provider in
question is guaranteed to be built-in, into libcrypto or into the
application that uses it.