### PR TITLE
doc: fix trace category names

### DIFF
--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -1297,9 +1297,9 @@ General SSL/TLS.
 
 SSL/TLS cipher.
 
-=item B<ENGINE_CONF>
+=item B<CONF>
 
-ENGINE configuration.
+Show details about provider and engine configuration.
 
 =item B<ENGINE_TABLE>
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -178,9 +178,9 @@ point during evaluation.
 
 Traces BIGNUM context operations.
 
-=item C<OSSL_TRACE_CATEGORY_PROVIDER_CONF>
+=item C<OSSL_TRACE_CATEGORY_CONF>
 
-Traces the OSSL_PROVIDER configuration.
+Traces details about the provider and engine configuration.
 
 =back
 


### PR DESCRIPTION
The `ENGINE_CONF` and `PROVIDER_CONF` trace categories were merged
into a single `CONF` category (see bc362b9b7202 and 71849dff56d6).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
