### PR TITLE
Pass "-z defs" to the linker via "-Wl,-z,defs"

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -36,7 +36,7 @@ my %shared_info;
                 (grep /(?:^|\s)-fsanitize/,
                  @{$config{CFLAGS}}, @{$config{cflags}})
                 ? ''
-                : '-z defs',
+                : '-Wl,-z,defs',
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },


### PR DESCRIPTION
Older versions of gcc do not support the -z flag. Use -Wl,-z,defs instead.

CLA: trivial
