### PR TITLE
Doc updates related to TLSv1.3 PSK early data

### DIFF
--- a/doc/man3/SSL_CTX_set_psk_client_callback.pod
+++ b/doc/man3/SSL_CTX_set_psk_client_callback.pod
@@ -123,7 +123,9 @@ and it will use that in preference. If no such callback is present then it will
 check to see if a callback has been set via SSL_CTX_set_psk_client_callback() or
 SSL_set_psk_client_callback() and use that. In this case the B<hint> value will
 always be NULL and the handshake digest will default to SHA-256 for any returned
-PSK.
+PSK. TLSv1.3 early data exchanges are possible in PSK connections only with the
+B<SSL_psk_use_session_cb_func> callback, and are not possible with the
+B<SSL_psk_client_cb_func> callback.
 
 =head1 NOTES
 

--- a/doc/man3/SSL_CTX_use_psk_identity_hint.pod
+++ b/doc/man3/SSL_CTX_use_psk_identity_hint.pod
@@ -83,7 +83,9 @@ via SSL_CTX_set_psk_find_session_callback() or SSL_set_psk_find_session_callback
 and it will use that in preference. If no such callback is present then it will
 check to see if a callback has been set via SSL_CTX_set_psk_server_callback() or
 SSL_set_psk_server_callback() and use that. In this case the handshake digest
-will default to SHA-256 for any returned PSK.
+will default to SHA-256 for any returned PSK. TLSv1.3 early data exchanges are
+possible in PSK connections only with the B<SSL_psk_find_session_cb_func>
+callback, and are not possible with the B<SSL_psk_server_cb_func> callback.
 
 A connection established via a TLSv1.3 PSK will appear as if session resumption
 has occurred so that L<SSL_session_reused(3)> will return true.

--- a/doc/man3/SSL_read_early_data.pod
+++ b/doc/man3/SSL_read_early_data.pod
@@ -58,10 +58,11 @@ SSL_set_allow_early_data_cb
 These functions are used to send and receive early data where TLSv1.3 has been
 negotiated. Early data can be sent by the client immediately after its initial
 ClientHello without having to wait for the server to complete the handshake.
-Early data can only be sent if a session has previously been established with
-the server, and the server is known to support it. Additionally these functions
-can be used to send data from the server to the client when the client has not
-yet completed the authentication stage of the handshake.
+Early data can be sent if a session has previously been established with the
+server or when establishing a new session using an out-of-band PSK, and only
+when the server is known to support it. Additionally these functions can be used
+to send data from the server to the client when the client has not yet completed
+the authentication stage of the handshake.
 
 Early data has weaker security properties than other data sent over an SSL/TLS
 connection. In particular the data does not have forward secrecy. There are also


### PR DESCRIPTION
- 498e961fb90ac825961a168412a8303d42cac5e7 For TLSv1.3 out-of-band PSK handshake recommendation is to use new callback (`SSL_psk_use_session_cb_func` and `SSL_psk_find_session_cb_func`) but older callback (`SSL_psk_client_cb_func` and `SSL_psk_server_cb_func`) also gets supported with AES_128_GCM ciphersuite. But TLSv1.3 early data is not allowed to exchange with older callback usage. This limiation of older callback is updated in doc.
- 4342cb75fd7512f247f31ce5b004e170f3dd9f1c Updated the doc as early data can be exchanged while resuming previous session or during out-of-band PSK session.

Needs backport to `1.1.1` also.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
