### PR TITLE
Build: make apps/progs.c depend on configdata.pm

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -67,6 +67,9 @@ IF[{- !$disabled{apps} -}]
   # progs.pl tries to read all 'openssl' sources, including progs.c, so we make
   # sure things are generated in the correct order.
   DEPEND[progs.h]=progs.c
+  # Because the files to look through may change (depends on $OPENSSLSRC),
+  # always depend on a changed configuration.
+  DEPEND[progs.c]=configdata.pm
 
   IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
     GENERATE[openssl.rc]=../util/mkrc.pl openssl

--- a/apps/build.info
+++ b/apps/build.info
@@ -69,7 +69,7 @@ IF[{- !$disabled{apps} -}]
   DEPEND[progs.h]=progs.c
   # Because the files to look through may change (depends on $OPENSSLSRC),
   # always depend on a changed configuration.
-  DEPEND[progs.c]=configdata.pm
+  DEPEND[progs.c]=../configdata.pm
 
   IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-)/ -}]
     GENERATE[openssl.rc]=../util/mkrc.pl openssl


### PR DESCRIPTION
The reason for this change is this, which happened in a build on my machine:

```
../master/apps/cmp.c:3008:5: error: no previous prototype for 'cmp_main' [-Werror=missing-prototypes]
 3008 | int cmp_main(int argc, char **argv)
      |     ^~~~~~~~
```