### PR TITLE
SSL: refactor ssl_cert_lookup_by_pkey() to work with provider side keys

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1068,19 +1068,19 @@ int ssl_cert_lookup_by_nid(int nid, size_t *pidx)
 
 const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx)
 {
-    int nid = EVP_PKEY_id(pk);
-    size_t tmpidx;
+    size_t i;
 
-    if (nid == NID_undef)
-        return NULL;
+    for (i = 0; i < OSSL_NELEM(ssl_cert_info); i++) {
+        const SSL_CERT_LOOKUP *tmp_lu = &ssl_cert_info[i];
 
-    if (!ssl_cert_lookup_by_nid(nid, &tmpidx))
-        return NULL;
+        if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->nid))
+            || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->nid))) {
+            *pidx = i;
+            return tmp_lu;
+        }
+    }
 
-    if (pidx != NULL)
-        *pidx = tmpidx;
-
-    return &ssl_cert_info[tmpidx];
+    return NULL;
 }
 
 const SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx)

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1075,7 +1075,8 @@ const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk, size_t *pidx)
 
         if (EVP_PKEY_is_a(pk, OBJ_nid2sn(tmp_lu->nid))
             || EVP_PKEY_is_a(pk, OBJ_nid2ln(tmp_lu->nid))) {
-            *pidx = i;
+            if (pidx != NULL)
+                *pidx = i;
             return tmp_lu;
         }
     }


### PR DESCRIPTION
Fixes #11720
