### PR TITLE
CORE: Fix a couple of bugs in algorithm_do_this()

### DIFF
--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -37,11 +37,11 @@ static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
          cur_operation <= last_operation;
          cur_operation++) {
         const OSSL_ALGORITHM *map =
-            ossl_provider_query_operation(provider, data->operation_id,
+            ossl_provider_query_operation(provider, cur_operation,
                                           &no_store);
 
         if (map == NULL)
-            break;
+            continue;
 
         ok = 1;                  /* As long as we've found *something* */
         while (map->algorithm_names != NULL) {


### PR DESCRIPTION
The call of ossl_provider_query_operation() used |data->operation_id|,
when |cur_operation| should be used.

If any ossl_provider_query_operation() call returned NULL, the loop
was stopped, when it should just continue on to the next operation.
