### PR TITLE
CORE: query for operations only once per provider (unless no_store is true)

### DIFF
--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -444,7 +444,13 @@ void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
     data.free_method = free_method;
     data.user_fn = user_fn;
     data.user_arg = user_arg;
-    ossl_algorithm_do_all(libctx, operation_id, NULL, do_one, &data);
+
+    /*
+     * No pre- or post-condition for this call, as this only creates methods
+     * temporarly and then promptly destroys them.
+     */
+    ossl_algorithm_do_all(libctx, operation_id, NULL, NULL, do_one, NULL,
+                          &data);
 }
 
 const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id)

--- a/crypto/serializer/serializer_meth.c
+++ b/crypto/serializer/serializer_meth.c
@@ -417,8 +417,13 @@ void OSSL_SERIALIZER_do_all_provided(OPENSSL_CTX *libctx,
 
     data.user_fn = (void (*)(void *, void *))fn;
     data.user_arg = arg;
-    ossl_algorithm_do_all(libctx, OSSL_OP_SERIALIZER, NULL,
-                          serializer_do_one, &data);
+
+    /*
+     * No pre- or post-condition for this call, as this only creates methods
+     * temporarly and then promptly destroys them.
+     */
+    ossl_algorithm_do_all(libctx, OSSL_OP_SERIALIZER, NULL, NULL,
+                          serializer_do_one, NULL, &data);
 }
 
 void OSSL_SERIALIZER_names_do_all(const OSSL_SERIALIZER *ser,

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -13,7 +13,8 @@ ossl_provider_name, ossl_provider_dso,
 ossl_provider_module_name, ossl_provider_module_path,
 ossl_provider_library_context,
 ossl_provider_teardown, ossl_provider_gettable_params,
-ossl_provider_get_params, ossl_provider_query_operation
+ossl_provider_get_params, ossl_provider_query_operation,
+ossl_provider_set_operation_bit, ossl_provider_test_operation_bit
 - internal provider routines
 
 =head1 SYNOPSIS
@@ -62,6 +63,10 @@ ossl_provider_get_params, ossl_provider_query_operation
  const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                      int operation_id,
                                                      int *no_cache);
+
+ int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum);
+ int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,
+                                      int *result);
 
 =head1 DESCRIPTION
 
@@ -208,6 +213,13 @@ I<query_operation> function, if the provider has one.
 It should return an array of I<OSSL_ALGORITHM> for the given
 I<operation_id>.
 
+ossl_provider_set_operation_bit() registers a 1 for operation I<bitnum>
+in a bitstring that's internal to I<provider>.
+
+ossl_provider_tests_operation_bit() checks if the bit operation I<bitnum>
+is set (1) or not (0) in the internal I<provider> bitstring, and sets
+I<*result> to 1 or 0 accorddingly. 
+
 =head1 NOTES
 
 Locating a provider module happens as follows:
@@ -269,6 +281,9 @@ otherwise NULL.
 
 ossl_provider_get_params() returns 1 on success, or 0 on error.
 If this function isn't available in the provider, 0 is returned.
+
+ossl_provider_set_operation_bit() and ossl_provider_test_operation_bit()
+return 1 on success, or 0 on error.
 
 =head1 SEE ALSO
 

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -50,9 +50,13 @@ void *ossl_method_construct(OPENSSL_CTX *ctx, int operation_id,
 
 void ossl_algorithm_do_all(OPENSSL_CTX *libctx, int operation_id,
                            OSSL_PROVIDER *provider,
+                           int (*pre)(OSSL_PROVIDER *, int operation_id,
+                                      void *data, int *result),
                            void (*fn)(OSSL_PROVIDER *provider,
                                       const OSSL_ALGORITHM *algo,
                                       int no_store, void *data),
+                           int (*post)(OSSL_PROVIDER *, int operation_id,
+                                       int no_store, void *data, int *result),
                            void *data);
 
 #endif

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -74,6 +74,11 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache);
 
+/* Cache of bits to see if we already queried an operation */
+int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum);
+int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,
+                                     int *result);
+
 /* Configuration */
 void ossl_provider_add_conf_module(void);
 


### PR DESCRIPTION
When a desired algorithm wasn't available, we didn't register anywhere
that an attempt had been made, with the result that next time the same
attempt was made, the whole process would be done again.

To avoid this churn, we register a bit for each operation that has
been queried in the libcrypto provider object, and test it before
trying the same query and method construction loop again.

If course, if the provider has told us not to cache, we don't register
this bit.

Fixes #11814