### PR TITLE
Fix egd and devrandom source configs

### DIFF
--- a/Configure
+++ b/Configure
@@ -1124,6 +1124,9 @@ if (scalar(@seed_sources) == 0) {
     print "Using os-specific seed configuration\n";
     push @seed_sources, 'os';
 }
+if (scalar(grep { $_ eq 'egd' } @seed_sources) > 0) {
+    delete $disabled{'egd'};
+}
 if (scalar(grep { $_ eq 'none' } @seed_sources) > 0) {
     die "Cannot seed with none and anything else" if scalar(@seed_sources) > 1;
     warn <<_____ if scalar(@seed_sources) == 1;

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -391,7 +391,8 @@ static struct random_device {
 } random_devices[OSSL_NELEM(random_device_paths)];
 static int keep_random_devices_open = 1;
 
-#   if defined(__linux) && defined(DEVRANDOM_WAIT)
+#   if defined(__linux) && defined(DEVRANDOM_WAIT) \
+       && defined(OPENSSL_RAND_SEED_GETRANDOM)
 static void *shm_addr;
 
 #    if !defined(FIPS_MODULE)

--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -475,7 +475,7 @@ static int wait_random_seeded(void)
     }
     return seeded;
 }
-#   else /* defined __linux */
+#   else /* defined __linux && DEVRANDOM_WAIT && OPENSSL_RAND_SEED_GETRANDOM */
 static int wait_random_seeded(void)
 {
     return 1;


### PR DESCRIPTION
./config --with-rand-seed=egd

need to defines OPENSSL_RAND_SEED_EGD and OPENSSL_NO_EGD
so get rid of OPENSSL_NO_EGD (compiles but I did not really test EGD)

./config --with-rand-seed=devrandom

does not work since wait_random_seeded works under the assumption
that OPENSSL_RAND_SEED_GETRANDOM is supposed to be enabled as well,
that is usually the case, but not when only devrandom is enabled.
Skip the wait code in this special case.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
