### PR TITLE
deprecate EC precomputation functionality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,13 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+* Deprecated EC_GROUP_precompute_mult(), EC_GROUP_have_precompute_mult(), and
+  EC_KEY_precompute_mult() These functions are not widely used and applications
+  should instead switch to named curves which OpenSSL has hardcoded lookup
+  tables for.
+
+  *Billy Bob Brumley*
+
  * Deprecated EC_POINTs_mul(). This function is not widely used and applications
    should instead use the L<EC_POINT_mul(3)> function.
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3049,7 +3049,6 @@ int speed_main(int argc, char **argv)
             rsa_count = 1;
         } else {
             for (i = 0; i < loopargs_len; i++) {
-                EC_KEY_precompute_mult(loopargs[i].ecdsa[testnum], NULL);
                 /* Perform ECDSA signature test */
                 EC_KEY_generate_key(loopargs[i].ecdsa[testnum]);
                 st = ECDSA_sign(0, loopargs[i].buf, 20, loopargs[i].buf2,

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -781,12 +781,14 @@ void EC_KEY_set_asn1_flag(EC_KEY *key, int flag)
         EC_GROUP_set_asn1_flag(key->group, flag);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EC_KEY_precompute_mult(EC_KEY *key, BN_CTX *ctx)
 {
     if (key->group == NULL)
         return 0;
     return EC_GROUP_precompute_mult(key->group, ctx);
 }
+#endif
 
 int EC_KEY_get_flags(const EC_KEY *key)
 {

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -1129,6 +1129,7 @@ int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *g_scalar,
     return ret;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
 {
     if (group->meth->mul == 0)
@@ -1153,6 +1154,7 @@ int EC_GROUP_have_precompute_mult(const EC_GROUP *group)
         return 0;               /* cannot tell whether precomputation has
                                  * been performed */
 }
+#endif
 
 /*
  * ec_precompute_mont_data sets |group->mont_data| from |group->order| and

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -40,7 +40,6 @@ EC_KEY objects
  point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
  void EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
  void EC_KEY_set_asn1_flag(EC_KEY *eckey, int asn1_flag);
- int EC_KEY_precompute_mult(EC_KEY *key, BN_CTX *ctx);
  int EC_KEY_generate_key(EC_KEY *key);
  int EC_KEY_check_key(const EC_KEY *key);
  int EC_KEY_set_public_key_affine_coordinates(EC_KEY *key, BIGNUM *x, BIGNUM *y);
@@ -55,6 +54,10 @@ EC_KEY objects
  size_t EC_KEY_priv2oct(const EC_KEY *eckey, unsigned char *buf, size_t len);
 
  size_t EC_KEY_priv2buf(const EC_KEY *eckey, unsigned char **pbuf);
+
+Deprecated since OpenSSL 3.0:
+
+ int EC_KEY_precompute_mult(EC_KEY *key, BN_CTX *ctx);
 
 =head1 DESCRIPTION
 
@@ -136,8 +139,11 @@ EC_KEY_set_asn1_flag() sets the asn1_flag on the underlying EC_GROUP object
 (if set). Refer to L<EC_GROUP_copy(3)> for further information on the
 asn1_flag.
 
+Although deprecated in OpenSSL 3.0 and should no longer be used,
 EC_KEY_precompute_mult() stores multiples of the underlying EC_GROUP generator
 for faster point multiplication. See also L<EC_POINT_add(3)>.
+Modern versions should instead switch to named curves which OpenSSL has
+hardcoded lookup tables for.
 
 EC_KEY_oct2key() and EC_KEY_key2buf() are identical to the functions
 EC_POINT_oct2point() and EC_KEY_point2buf() except they use the public key
@@ -194,6 +200,10 @@ L<EC_POINT_add(3)>,
 L<EC_GFp_simple_method(3)>,
 L<d2i_ECPKParameters(3)>,
 L<OPENSSL_CTX(3)>
+
+=head1 HISTORY
+
+EC_KEY_precompute_mult() was deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_POINT_add.pod
+++ b/doc/man3/EC_POINT_add.pod
@@ -20,13 +20,13 @@ EC_POINT_add, EC_POINT_dbl, EC_POINT_invert, EC_POINT_is_at_infinity, EC_POINT_i
                            EC_POINT *points[], BN_CTX *ctx);
  int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n,
                   const EC_POINT *q, const BIGNUM *m, BN_CTX *ctx);
- int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx);
- int EC_GROUP_have_precompute_mult(const EC_GROUP *group);
 
  Deprecated since OpenSSL 3.0:
 
  int EC_POINTs_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n, size_t num,
                    const EC_POINT *p[], const BIGNUM *m[], BN_CTX *ctx);
+int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx);
+int EC_GROUP_have_precompute_mult(const EC_GROUP *group);
 
 =head1 DESCRIPTION
 
@@ -56,8 +56,9 @@ Modern versions should instead use EC_POINT_mul(), combined (if needed) with EC_
 
 The function EC_GROUP_precompute_mult stores multiples of the generator for faster point multiplication, whilst
 EC_GROUP_have_precompute_mult tests whether precomputation has already been done. See L<EC_GROUP_copy(3)> for information
-about the generator.
-
+about the generator. Precomputation functionality was deprecated in OpenSSL 3.0.
+Users of EC_GROUP_precompute_mult() and EC_GROUP_have_precompute_mult() should
+switch to named curves which OpenSSL has hardcoded lookup tables for.
 
 =head1 RETURN VALUES
 
@@ -80,7 +81,8 @@ L<EC_GFp_simple_method(3)>, L<d2i_ECPKParameters(3)>
 
 =head1 HISTORY
 
-EC_POINTs_mul() was deprecated in OpenSSL 3.0.
+EC_POINTs_mul(), EC_GROUP_precompute_mult(), and EC_GROUP_have_precompute_mult()
+were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_POINT_add.pod
+++ b/doc/man3/EC_POINT_add.pod
@@ -21,12 +21,12 @@ EC_POINT_add, EC_POINT_dbl, EC_POINT_invert, EC_POINT_is_at_infinity, EC_POINT_i
  int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n,
                   const EC_POINT *q, const BIGNUM *m, BN_CTX *ctx);
 
- Deprecated since OpenSSL 3.0:
+Deprecated since OpenSSL 3.0:
 
  int EC_POINTs_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n, size_t num,
                    const EC_POINT *p[], const BIGNUM *m[], BN_CTX *ctx);
-int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx);
-int EC_GROUP_have_precompute_mult(const EC_GROUP *group);
+ int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx);
+ int EC_GROUP_have_precompute_mult(const EC_GROUP *group);
 
 =head1 DESCRIPTION
 

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -797,13 +797,13 @@ int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n,
  *  \param  ctx    BN_CTX object (optional)
  *  \return 1 on success and 0 if an error occurred
  */
-int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx);
+DEPRECATEDIN_3_0(int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx))
 
 /** Reports whether a precomputation has been done
  *  \param  group  EC_GROUP object
  *  \return 1 if a pre-computation has been done and 0 otherwise
  */
-int EC_GROUP_have_precompute_mult(const EC_GROUP *group);
+DEPRECATEDIN_3_0(int EC_GROUP_have_precompute_mult(const EC_GROUP *group))
 
 /********************************************************************/
 /*                       ASN1 stuff                                 */
@@ -991,7 +991,7 @@ void EC_KEY_set_asn1_flag(EC_KEY *eckey, int asn1_flag);
  *  \param  ctx  BN_CTX object (optional)
  *  \return 1 on success and 0 if an error occurred.
  */
-int EC_KEY_precompute_mult(EC_KEY *key, BN_CTX *ctx);
+DEPRECATEDIN_3_0(int EC_KEY_precompute_mult(EC_KEY *key, BN_CTX *ctx))
 
 /** Creates a new ec private (and optional a new public) key.
  *  \param  key  EC_KEY object

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -9,7 +9,8 @@
  */
 
 /*
- * We need access to the deprecated EC_POINTs_mul for testing purposes
+ * We need access to the deprecated EC_POINTs_mul, EC_GROUP_precompute_mult,
+ * and EC_GROUP_have_precompute_mult for testing purposes
  * when the deprecated calls are not hidden
  */
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -58,7 +59,9 @@ static int group_order_tests(EC_GROUP *group)
     if (!TEST_true(EC_GROUP_get_order(group, order, ctx))
         || !TEST_true(EC_POINT_mul(group, Q, order, NULL, NULL, ctx))
         || !TEST_true(EC_POINT_is_at_infinity(group, Q))
+# ifndef OPENSSL_NO_DEPRECATED_3_0
         || !TEST_true(EC_GROUP_precompute_mult(group, ctx))
+# endif
         || !TEST_true(EC_POINT_mul(group, Q, order, NULL, NULL, ctx))
         || !TEST_true(EC_POINT_is_at_infinity(group, Q))
         || !TEST_true(EC_POINT_copy(P, G))
@@ -1388,16 +1391,14 @@ static int nistp_single_test(int idx)
     /* random point multiplication */
     EC_POINT_mul(NISTP, Q, NULL, P, m, ctx);
     if (!TEST_int_eq(0, EC_POINT_cmp(NISTP, Q, Q_CHECK, ctx))
-
-    /*
-     * We have not performed precomputation so have_precompute mult should be
-     * false
-     */
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+        /* We have not performed precomp so this should be false */
         || !TEST_false(EC_GROUP_have_precompute_mult(NISTP))
-
-    /* now repeat all tests with precomputation */
+        /* now repeat all tests with precomputation */
         || !TEST_true(EC_GROUP_precompute_mult(NISTP, ctx))
-        || !TEST_true(EC_GROUP_have_precompute_mult(NISTP)))
+        || !TEST_true(EC_GROUP_have_precompute_mult(NISTP))
+# endif
+        )
         goto err;
 
     /* fixed point multiplication */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1106,7 +1106,7 @@ EXTENDED_KEY_USAGE_it                   1132	3_0_0	EXIST::FUNCTION:
 EVP_CipherInit                          1133	3_0_0	EXIST::FUNCTION:
 PKCS12_add_safe                         1134	3_0_0	EXIST::FUNCTION:
 ENGINE_get_digest                       1135	3_0_0	EXIST::FUNCTION:ENGINE
-EC_GROUP_have_precompute_mult           1136	3_0_0	EXIST::FUNCTION:EC
+EC_GROUP_have_precompute_mult           1136	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 OPENSSL_gmtime                          1137	3_0_0	EXIST::FUNCTION:
 X509_set_issuer_name                    1138	3_0_0	EXIST::FUNCTION:
 RSA_new                                 1139	3_0_0	EXIST::FUNCTION:RSA
@@ -1232,7 +1232,7 @@ OPENSSL_sk_shift                        1259	3_0_0	EXIST::FUNCTION:
 i2d_X509_REVOKED                        1260	3_0_0	EXIST::FUNCTION:
 CMS_sign                                1261	3_0_0	EXIST::FUNCTION:CMS
 X509_STORE_add_cert                     1262	3_0_0	EXIST::FUNCTION:
-EC_GROUP_precompute_mult                1263	3_0_0	EXIST::FUNCTION:EC
+EC_GROUP_precompute_mult                1263	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 d2i_DISPLAYTEXT                         1265	3_0_0	EXIST::FUNCTION:
 HMAC_CTX_copy                           1266	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 CRYPTO_gcm128_init                      1267	3_0_0	EXIST::FUNCTION:
@@ -2786,7 +2786,7 @@ ASN1_TYPE_set1                          2846	3_0_0	EXIST::FUNCTION:
 d2i_X509_CRL_bio                        2847	3_0_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_get1_cert                2848	3_0_0	EXIST::FUNCTION:
 ASN1_UNIVERSALSTRING_free               2849	3_0_0	EXIST::FUNCTION:
-EC_KEY_precompute_mult                  2850	3_0_0	EXIST::FUNCTION:EC
+EC_KEY_precompute_mult                  2850	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 CRYPTO_mem_debug_realloc                2851	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0
 PKCS7_new                               2852	3_0_0	EXIST::FUNCTION:
 BASIC_CONSTRAINTS_it                    2853	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Reiterating from #8332:

* Deprecate `EC_GROUP_precompute_mult` `EC_GROUP_have_precompute_mult` and `EC_KEY_precompute_mult`. The `speed` app is the only software I've ever found using them. (Besides, with recent EC changes most use cases don't have access to this type of precomp anyway. Only the hard coded constants from the custom `EC_METHOD`s.)

Although I've dug several times in the past for linking applications using this functionality, I took another stab today. I found [python-cryptography](https://github.com/pyca/cryptography/commit/6639dd15a7847fae731b29ce01f98cba79757838#diff-c0b27d970c896efabfcb87ec21548a2d) used to have the bindings available, but as you can see they were removed because they weren't used.