### PR TITLE
PEM: Make PKCS8 serializing functions aware of OSSL_SERIALIZERs

### DIFF
--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -78,7 +78,7 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
 
     /*
      * If no keystring or callback is set, OpenSSL traditionally uses the
-     * user cb argument as a password string, or if that's NULL, it falls
+     * user's cb argument as a password string, or if that's NULL, it falls
      * back on PEM_def_callback().
      */
     if (kstr == NULL && cb == NULL) {
@@ -98,6 +98,12 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                                                NULL)) {
                 const unsigned char *ukstr = (const unsigned char *)kstr;
 
+                /*
+                 * Try to pass the passphrase if one was given, of the
+                 * passphrase callback if one was given.  If none of them
+                 * are given and that's wrong, we rely on the _to_bio()
+                 * call to generate errors.
+                 */
                 ret = 1;
                 if (kstr != NULL
                     && !OSSL_SERIALIZER_CTX_set_passphrase(ctx, ukstr, klen))

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -99,7 +99,7 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                 const unsigned char *ukstr = (const unsigned char *)kstr;
 
                 /*
-                 * Try to pass the passphrase if one was given, of the
+                 * Try to pass the passphrase if one was given, or the
                  * passphrase callback if one was given.  If none of them
                  * are given and that's wrong, we rely on the _to_bio()
                  * call to generate errors.
@@ -122,9 +122,8 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
 
         if ((p8inf = EVP_PKEY2PKCS8(x)) == NULL) {
             PEMerr(PEM_F_DO_PK8PKEY, PEM_R_ERROR_CONVERTING_PRIVATE_KEY);
-            return 0;
-        }
-        if (enc || (nid != -1)) {
+            ret = 0;
+        } else if (enc || (nid != -1)) {
             if (kstr == NULL) {
                 klen = cb(buf, PEM_BUFSIZE, 1, u);
                 if (klen <= 0) {

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -15,6 +15,7 @@
 #include <openssl/x509.h>
 #include <openssl/pkcs12.h>
 #include <openssl/pem.h>
+#include <openssl/serializer.h>
 
 static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder,
                       int nid, const EVP_CIPHER *enc,
@@ -66,49 +67,89 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                       const EVP_CIPHER *enc, const char *kstr, int klen,
                       pem_password_cb *cb, void *u)
 {
-    X509_SIG *p8;
-    PKCS8_PRIV_KEY_INFO *p8inf;
-    char buf[PEM_BUFSIZE];
-    int ret;
+    int ret = 0;
+    const char *pq = isder
+        ? OSSL_SERIALIZER_PrivateKey_TO_DER_PQ
+        : OSSL_SERIALIZER_PrivateKey_TO_PEM_PQ;
+    OSSL_SERIALIZER_CTX *ctx = OSSL_SERIALIZER_CTX_new_by_EVP_PKEY(x, pq);
 
-    if ((p8inf = EVP_PKEY2PKCS8(x)) == NULL) {
-        PEMerr(PEM_F_DO_PK8PKEY, PEM_R_ERROR_CONVERTING_PRIVATE_KEY);
+    if (ctx == NULL)
         return 0;
-    }
-    if (enc || (nid != -1)) {
-        if (!kstr) {
-            if (!cb)
-                klen = PEM_def_callback(buf, PEM_BUFSIZE, 1, u);
-            else
-                klen = cb(buf, PEM_BUFSIZE, 1, u);
-            if (klen <= 0) {
-                PEMerr(PEM_F_DO_PK8PKEY, PEM_R_READ_KEY);
-                PKCS8_PRIV_KEY_INFO_free(p8inf);
-                return 0;
-            }
 
-            kstr = buf;
+    /*
+     * If no keystring or callback is set, OpenSSL traditionally uses the
+     * user cb argument as a password string, or if that's NULL, it falls
+     * back on PEM_def_callback().
+     */
+    if (kstr == NULL && cb == NULL) {
+        if (u != NULL) {
+            kstr = u;
+            klen = strlen(u);
+        } else {
+            cb = PEM_def_callback;
         }
-        p8 = PKCS8_encrypt(nid, enc, kstr, klen, NULL, 0, 0, p8inf);
-        if (kstr == buf)
-            OPENSSL_cleanse(buf, klen);
-        PKCS8_PRIV_KEY_INFO_free(p8inf);
-        if (p8 == NULL)
-            return 0;
-        if (isder)
-            ret = i2d_PKCS8_bio(bp, p8);
-        else
-            ret = PEM_write_bio_PKCS8(bp, p8);
-        X509_SIG_free(p8);
-        return ret;
-    } else {
-        if (isder)
-            ret = i2d_PKCS8_PRIV_KEY_INFO_bio(bp, p8inf);
-        else
-            ret = PEM_write_bio_PKCS8_PRIV_KEY_INFO(bp, p8inf);
-        PKCS8_PRIV_KEY_INFO_free(p8inf);
-        return ret;
     }
+
+    if (OSSL_SERIALIZER_CTX_get_serializer(ctx) != NULL) {
+        ret = 1;
+        if (enc != NULL) {
+            ret = 0;
+            if (OSSL_SERIALIZER_CTX_set_cipher(ctx, EVP_CIPHER_name(enc),
+                                               NULL)) {
+                const unsigned char *ukstr = (const unsigned char *)kstr;
+
+                ret = 1;
+                if (kstr != NULL
+                    && !OSSL_SERIALIZER_CTX_set_passphrase(ctx, ukstr, klen))
+                    ret = 0;
+                else if (cb != NULL
+                         && !OSSL_SERIALIZER_CTX_set_passphrase_cb(ctx, 1,
+                                                                   cb, u))
+                    ret = 0;
+            }
+        }
+        ret = ret && OSSL_SERIALIZER_to_bio(ctx, bp);
+    } else {
+        X509_SIG *p8;
+        PKCS8_PRIV_KEY_INFO *p8inf;
+        char buf[PEM_BUFSIZE];
+
+        if ((p8inf = EVP_PKEY2PKCS8(x)) == NULL) {
+            PEMerr(PEM_F_DO_PK8PKEY, PEM_R_ERROR_CONVERTING_PRIVATE_KEY);
+            return 0;
+        }
+        if (enc || (nid != -1)) {
+            if (kstr == NULL) {
+                klen = cb(buf, PEM_BUFSIZE, 1, u);
+                if (klen <= 0) {
+                    PEMerr(PEM_F_DO_PK8PKEY, PEM_R_READ_KEY);
+                    PKCS8_PRIV_KEY_INFO_free(p8inf);
+                    return 0;
+                }
+
+                kstr = buf;
+            }
+            p8 = PKCS8_encrypt(nid, enc, kstr, klen, NULL, 0, 0, p8inf);
+            if (kstr == buf)
+                OPENSSL_cleanse(buf, klen);
+            PKCS8_PRIV_KEY_INFO_free(p8inf);
+            if (p8 == NULL)
+                return 0;
+            if (isder)
+                ret = i2d_PKCS8_bio(bp, p8);
+            else
+                ret = PEM_write_bio_PKCS8(bp, p8);
+            X509_SIG_free(p8);
+        } else {
+            if (isder)
+                ret = i2d_PKCS8_PRIV_KEY_INFO_bio(bp, p8inf);
+            else
+                ret = PEM_write_bio_PKCS8_PRIV_KEY_INFO(bp, p8inf);
+            PKCS8_PRIV_KEY_INFO_free(p8inf);
+        }
+    }
+    OSSL_SERIALIZER_CTX_free(ctx);
+    return ret;
 }
 
 EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -120,16 +120,17 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
         PKCS8_PRIV_KEY_INFO *p8inf;
         char buf[PEM_BUFSIZE];
 
+        ret = 0;
         if ((p8inf = EVP_PKEY2PKCS8(x)) == NULL) {
             PEMerr(PEM_F_DO_PK8PKEY, PEM_R_ERROR_CONVERTING_PRIVATE_KEY);
-            ret = 0;
-        } else if (enc || (nid != -1)) {
+            goto legacy_end;
+        }
+        if (enc || (nid != -1)) {
             if (kstr == NULL) {
                 klen = cb(buf, PEM_BUFSIZE, 1, u);
                 if (klen <= 0) {
                     PEMerr(PEM_F_DO_PK8PKEY, PEM_R_READ_KEY);
-                    PKCS8_PRIV_KEY_INFO_free(p8inf);
-                    return 0;
+                    goto legacy_end;
                 }
 
                 kstr = buf;
@@ -137,9 +138,8 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
             p8 = PKCS8_encrypt(nid, enc, kstr, klen, NULL, 0, 0, p8inf);
             if (kstr == buf)
                 OPENSSL_cleanse(buf, klen);
-            PKCS8_PRIV_KEY_INFO_free(p8inf);
             if (p8 == NULL)
-                return 0;
+                goto legacy_end;
             if (isder)
                 ret = i2d_PKCS8_bio(bp, p8);
             else
@@ -150,8 +150,9 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                 ret = i2d_PKCS8_PRIV_KEY_INFO_bio(bp, p8inf);
             else
                 ret = PEM_write_bio_PKCS8_PRIV_KEY_INFO(bp, p8inf);
-            PKCS8_PRIV_KEY_INFO_free(p8inf);
         }
+     legacy_end:
+        PKCS8_PRIV_KEY_INFO_free(p8inf);
     }
     OSSL_SERIALIZER_CTX_free(ctx);
     return ret;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -770,8 +770,8 @@ static int test_EVP_PKCS82PKEY(void)
 /* This uses kExampleRSAKeyDER and kExampleRSAKeyPKCS8 to verify encoding */
 static int test_privatekey_to_pkcs8(void)
 {
-    EVP_PKEY *pkey;
-    BIO *membio;
+    EVP_PKEY *pkey = NULL;
+    BIO *membio = NULL;
     char *membuf = NULL;
     size_t membuf_len = 0;
     int ok = 0;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -767,6 +767,40 @@ static int test_EVP_PKCS82PKEY(void)
 }
 #endif
 
+/* This uses kExampleRSAKeyDER and kExampleRSAKeyPKCS8 to verify encoding */
+static int test_privatekey_to_pkcs8(void)
+{
+    EVP_PKEY *pkey;
+    BIO *membio;
+    char *membuf = NULL;
+    size_t membuf_len = 0;
+    int ok = 0;
+
+    if (!TEST_ptr(membio = BIO_new(BIO_s_mem()))
+        || !TEST_ptr(pkey = load_example_rsa_key())
+        || !TEST_int_gt(i2d_PKCS8PrivateKey_bio(membio, pkey, NULL,
+                                                NULL, 0, NULL, NULL),
+                        0)
+        || !TEST_ptr((membuf_len = (size_t)BIO_get_mem_data(membio, &membuf),
+                      membuf))
+        || !TEST_mem_eq(membuf, membuf_len,
+                        kExampleRSAKeyPKCS8, sizeof(kExampleRSAKeyPKCS8))
+        /*
+         * We try to write PEM as well, just to see that it doesn't err, but
+         * assume that the result is correct.
+         */
+        || !TEST_int_gt(PEM_write_bio_PKCS8PrivateKey(membio, pkey, NULL,
+                                                      NULL, 0, NULL, NULL),
+                        0))
+        goto done;
+
+    ok = 1;
+ done:
+    EVP_PKEY_free(pkey);
+    BIO_free_all(membio);
+    return ok;
+}
+
 #if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODULE)
 
 static int test_EVP_SM2_verify(void)
@@ -1636,6 +1670,7 @@ int setup_tests(void)
     ADD_TEST(test_EVP_DigestVerifyInit);
     ADD_TEST(test_EVP_Enveloped);
     ADD_ALL_TESTS(test_d2i_AutoPrivateKey, OSSL_NELEM(keydata));
+    ADD_TEST(test_privatekey_to_pkcs8);
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_EVP_PKCS82PKEY);
 #endif


### PR DESCRIPTION
PEM_write_bio_PKCS8PrivateKey(), i2d_PKCS8PrivateKey_bio(),
PEM_write_PKCS8PrivateKey(), and i2d_PKCS8PrivateKey_fp() are affected
by this.

Fixes #11845
