### PR TITLE
Cast to at least 32 bit unsigned type when shifting left 24 places

### DIFF
--- a/crypto/bn/bn_mpi.c
+++ b/crypto/bn/bn_mpi.c
@@ -45,7 +45,7 @@ BIGNUM *BN_mpi2bn(const unsigned char *d, int n, BIGNUM *ain)
     int neg = 0;
     BIGNUM *a = NULL;
 
-    if (n < 4) {
+    if (n < 4 || (d[0] & 0x80) != 0) {
         BNerr(BN_F_BN_MPI2BN, BN_R_INVALID_LENGTH);
         return NULL;
     }

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -36,10 +36,10 @@ static unsigned int read_ledword(const unsigned char **in)
 {
     const unsigned char *p = *in;
     unsigned int ret;
-    ret = *p++;
-    ret |= (*p++ << 8);
-    ret |= (*p++ << 16);
-    ret |= (*p++ << 24);
+    ret = (unsigned int)*p++;
+    ret |= (unsigned int)*p++ << 8;
+    ret |= (unsigned int)*p++ << 16;
+    ret |= (unsigned int)*p++ << 24;
     *in = p;
     return ret;
 }

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -665,8 +665,10 @@ static int ssl_print_random(BIO *bio, int indent,
 
     if (*pmsglen < 32)
         return 0;
-    tm = ((unsigned int)p[0] << 24) | ((unsigned int)p[1] << 16)
-         | ((unsigned int)p[2] << 8) | (unsigned int)p[3];
+    tm = ((unsigned int)p[0] << 24)
+         | ((unsigned int)p[1] << 16)
+         | ((unsigned int)p[2] << 8)
+         | (unsigned int)p[3];
     p += 4;
     BIO_indent(bio, indent, 80);
     BIO_puts(bio, "Random:\n");
@@ -1369,8 +1371,10 @@ static int ssl_print_ticket(BIO *bio, int indent, const SSL *ssl,
     }
     if (msglen < 4)
         return 0;
-    tick_life = ((unsigned int)msg[0] << 24) | ((unsigned int)msg[1] << 16)
-                | ((unsigned int)msg[2] << 8) | (unsigned int)msg[3];
+    tick_life = ((unsigned int)msg[0] << 24)
+                | ((unsigned int)msg[1] << 16)
+                | ((unsigned int)msg[2] << 8)
+                | (unsigned int)msg[3];
     msglen -= 4;
     msg += 4;
     BIO_indent(bio, indent + 2, 80);
@@ -1381,8 +1385,10 @@ static int ssl_print_ticket(BIO *bio, int indent, const SSL *ssl,
         if (msglen < 4)
             return 0;
         ticket_age_add =
-            ((unsigned int)msg[0] << 24) | ((unsigned int)msg[1] << 16)
-            | ((unsigned int)msg[2] << 8) | (unsigned int)msg[3];
+            ((unsigned int)msg[0] << 24)
+            | ((unsigned int)msg[1] << 16)
+            | ((unsigned int)msg[2] << 8)
+            | (unsigned int)msg[3];
         msglen -= 4;
         msg += 4;
         BIO_indent(bio, indent + 2, 80);

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -665,7 +665,8 @@ static int ssl_print_random(BIO *bio, int indent,
 
     if (*pmsglen < 32)
         return 0;
-    tm = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+    tm = ((unsigned int)p[0] << 24) | ((unsigned int)p[1] << 16)
+         | ((unsigned int)p[2] << 8) | (unsigned int)p[3];
     p += 4;
     BIO_indent(bio, indent, 80);
     BIO_puts(bio, "Random:\n");
@@ -870,8 +871,10 @@ static int ssl_print_extension(BIO *bio, int indent, int server,
             break;
         if (extlen != 4)
             return 0;
-        max_early_data = (ext[0] << 24) | (ext[1] << 16) | (ext[2] << 8)
-                         | ext[3];
+        max_early_data = ((unsigned int)ext[0] << 24)
+                         | ((unsigned int)ext[1] << 16)
+                         | ((unsigned int)ext[2] << 8)
+                         | (unsigned int)ext[3];
         BIO_indent(bio, indent + 2, 80);
         BIO_printf(bio, "max_early_data=%u\n", max_early_data);
         break;
@@ -1366,7 +1369,8 @@ static int ssl_print_ticket(BIO *bio, int indent, const SSL *ssl,
     }
     if (msglen < 4)
         return 0;
-    tick_life = (msg[0] << 24) | (msg[1] << 16) | (msg[2] << 8) | msg[3];
+    tick_life = ((unsigned int)msg[0] << 24) | ((unsigned int)msg[1] << 16)
+                | ((unsigned int)msg[2] << 8) | (unsigned int)msg[3];
     msglen -= 4;
     msg += 4;
     BIO_indent(bio, indent + 2, 80);
@@ -1377,7 +1381,8 @@ static int ssl_print_ticket(BIO *bio, int indent, const SSL *ssl,
         if (msglen < 4)
             return 0;
         ticket_age_add =
-            (msg[0] << 24) | (msg[1] << 16) | (msg[2] << 8) | msg[3];
+            ((unsigned int)msg[0] << 24) | ((unsigned int)msg[1] << 16)
+            | ((unsigned int)msg[2] << 8) | (unsigned int)msg[3];
         msglen -= 4;
         msg += 4;
         BIO_indent(bio, indent + 2, 80);


### PR DESCRIPTION
Fixes #11853

Implicit C promotion rules apply so the value is promoted to int otherwise and that might not be big enough when the value is then left-shifted 24 places.