### PR TITLE
rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(): fix check of |md|

### DIFF
--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -67,13 +67,14 @@ int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
     unsigned char seedmask[EVP_MAX_MD_SIZE];
     int mdlen, dbmask_len = 0;
 
+    if (md == NULL) {
 #ifndef FIPS_MODULE
-    if (md == NULL)
         md = EVP_sha1();
 #else
         RSAerr(0, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
 #endif
+    }
     if (mgf1md == NULL)
         mgf1md = md;
 


### PR DESCRIPTION
In the FIPS module, the code as written generate an unconditional
error.

Fixes #11865
