### PR TITLE
deprecate EC_POINT_make_affine and EC_POINTs_make_affine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,12 +23,18 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
-* Deprecated EC_GROUP_precompute_mult(), EC_GROUP_have_precompute_mult(), and
-  EC_KEY_precompute_mult() These functions are not widely used and applications
-  should instead switch to named curves which OpenSSL has hardcoded lookup
-  tables for.
+ * Deprecated EC_POINT_make_affine() and EC_POINTs_make_affine(). These
+   functions are not widely used and now OpenSSL automatically perform this
+   conversion when needed.
 
-  *Billy Bob Brumley*
+   *Billy Bob Brumley*
+
+ * Deprecated EC_GROUP_precompute_mult(), EC_GROUP_have_precompute_mult(), and
+   EC_KEY_precompute_mult(). These functions are not widely used and
+   applications should instead switch to named curves which OpenSSL has
+   hardcoded lookup tables for.
+
+   *Billy Bob Brumley*
 
  * Deprecated EC_POINTs_mul(). This function is not widely used and applications
    should instead use the L<EC_POINT_mul(3)> function.

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -489,7 +489,8 @@ int ec_GF2m_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
         /* point is its own inverse */
         return 1;
 
-    if (!EC_POINT_make_affine(group, point, ctx))
+    if (group->meth->make_affine == NULL
+        || !group->meth->make_affine(group, point, ctx))
         return 0;
     return BN_GF2m_add(point->Y, point->X, point->Y);
 }

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -1004,6 +1004,7 @@ int EC_POINT_cmp(const EC_GROUP *group, const EC_POINT *a, const EC_POINT *b,
     return group->meth->point_cmp(group, a, b, ctx);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EC_POINT_make_affine(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
 {
     if (group->meth->make_affine == 0) {
@@ -1034,6 +1035,7 @@ int EC_POINTs_make_affine(const EC_GROUP *group, size_t num,
     }
     return group->meth->points_make_affine(group, num, points, ctx);
 }
+#endif
 
 /*
  * Functions for point multiplication. If group->meth->mul is 0, we use the

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -267,7 +267,8 @@ int ec_scalar_mul_ladder(const EC_GROUP *group, EC_POINT *r,
     }
 
     /* ensure input point is in affine coords for ladder step efficiency */
-    if (!p->Z_is_one && !EC_POINT_make_affine(group, p, ctx)) {
+    if (!p->Z_is_one && (group->meth->make_affine == NULL
+                         || !group->meth->make_affine(group, p, ctx))) {
             ECerr(EC_F_EC_SCALAR_MUL_LADDER, ERR_R_EC_LIB);
             goto err;
     }
@@ -711,7 +712,8 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         }
     }
 
-    if (!EC_POINTs_make_affine(group, num_val, val, ctx))
+    if (group->meth->points_make_affine == NULL
+        || !group->meth->points_make_affine(group, num_val, val, ctx))
         goto err;
 
     r_is_at_infinity = 1;
@@ -949,7 +951,8 @@ int ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
         }
     }
 
-    if (!EC_POINTs_make_affine(group, num, points, ctx))
+    if (group->meth->points_make_affine == NULL
+        || !group->meth->points_make_affine(group, num, points, ctx))
         goto err;
 
     pre_comp->group = group;

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -897,7 +897,8 @@ __owur static int ecp_nistz256_mult_precompute(EC_GROUP *group, BN_CTX *ctx)
              * It would be faster to use EC_POINTs_make_affine and
              * make multiple points affine at the same time.
              */
-            if (!EC_POINT_make_affine(group, P, ctx))
+            if (group->meth->make_affine == NULL
+                || !group->meth->make_affine(group, P, ctx))
                 goto err;
             if (!ecp_nistz256_bignum_to_field_elem(temp.X, P->X) ||
                 !ecp_nistz256_bignum_to_field_elem(temp.Y, P->Y)) {

--- a/doc/man3/EC_POINT_add.pod
+++ b/doc/man3/EC_POINT_add.pod
@@ -15,14 +15,14 @@ EC_POINT_add, EC_POINT_dbl, EC_POINT_invert, EC_POINT_is_at_infinity, EC_POINT_i
  int EC_POINT_is_at_infinity(const EC_GROUP *group, const EC_POINT *p);
  int EC_POINT_is_on_curve(const EC_GROUP *group, const EC_POINT *point, BN_CTX *ctx);
  int EC_POINT_cmp(const EC_GROUP *group, const EC_POINT *a, const EC_POINT *b, BN_CTX *ctx);
- int EC_POINT_make_affine(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx);
- int EC_POINTs_make_affine(const EC_GROUP *group, size_t num,
-                           EC_POINT *points[], BN_CTX *ctx);
  int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n,
                   const EC_POINT *q, const BIGNUM *m, BN_CTX *ctx);
 
 Deprecated since OpenSSL 3.0:
 
+ int EC_POINT_make_affine(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx);
+ int EC_POINTs_make_affine(const EC_GROUP *group, size_t num,
+                           EC_POINT *points[], BN_CTX *ctx);
  int EC_POINTs_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n, size_t num,
                    const EC_POINT *p[], const BIGNUM *m[], BN_CTX *ctx);
  int EC_GROUP_precompute_mult(EC_GROUP *group, BN_CTX *ctx);
@@ -43,7 +43,8 @@ EC_POINT_cmp compares the two supplied points and tests whether or not they are 
 
 The functions EC_POINT_make_affine and EC_POINTs_make_affine force the internal representation of the EC_POINT(s) into the affine
 co-ordinate system. In the case of EC_POINTs_make_affine the value B<num> provides the number of points in the array B<points> to be
-forced.
+forced. These functions were deprecated in OpenSSL 3.0 and should no longer be used.
+Modern versions automatically perform this conversion when needed.
 
 EC_POINT_mul calculates the value generator * B<n> + B<q> * B<m> and stores the result in B<r>.
 The value B<n> may be NULL in which case the result is just B<q> * B<m> (variable point multiplication). Alternatively, both B<q> and B<m> may be NULL, and B<n> non-NULL, in which case the result is just generator * B<n> (fixed point multiplication).
@@ -81,7 +82,8 @@ L<EC_GFp_simple_method(3)>, L<d2i_ECPKParameters(3)>
 
 =head1 HISTORY
 
-EC_POINTs_mul(), EC_GROUP_precompute_mult(), and EC_GROUP_have_precompute_mult()
+EC_POINT_make_affine(), EC_POINTs_make_affine(), EC_POINTs_mul(),
+EC_GROUP_precompute_mult(), and EC_GROUP_have_precompute_mult()
 were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -761,9 +761,10 @@ int EC_POINT_is_on_curve(const EC_GROUP *group, const EC_POINT *point,
 int EC_POINT_cmp(const EC_GROUP *group, const EC_POINT *a, const EC_POINT *b,
                  BN_CTX *ctx);
 
-int EC_POINT_make_affine(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx);
-int EC_POINTs_make_affine(const EC_GROUP *group, size_t num,
-                          EC_POINT *points[], BN_CTX *ctx);
+DEPRECATEDIN_3_0(int EC_POINT_make_affine(const EC_GROUP *group,
+                                          EC_POINT *point, BN_CTX *ctx))
+DEPRECATEDIN_3_0(int EC_POINTs_make_affine(const EC_GROUP *group, size_t num,
+                                           EC_POINT *points[], BN_CTX *ctx))
 
 /** Computes r = generator * n + sum_{i=0}^{num-1} p[i] * m[i]
  *  \param  group  underlying EC_GROUP object

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -837,7 +837,7 @@ EVP_PKEY_CTX_get_cb                     857	3_0_0	EXIST::FUNCTION:
 X509_STORE_free                         858	3_0_0	EXIST::FUNCTION:
 ECDSA_sign_ex                           859	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 TXT_DB_insert                           860	3_0_0	EXIST::FUNCTION:
-EC_POINTs_make_affine                   861	3_0_0	EXIST::FUNCTION:EC
+EC_POINTs_make_affine                   861	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 RSA_padding_add_PKCS1_PSS               862	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RSA
 BF_options                              863	3_0_0	EXIST::FUNCTION:BF,DEPRECATEDIN_3_0
 OCSP_BASICRESP_it                       864	3_0_0	EXIST::FUNCTION:OCSP
@@ -3318,7 +3318,7 @@ EVP_camellia_256_cfb1                   3385	3_0_0	EXIST::FUNCTION:CAMELLIA
 CRYPTO_secure_actual_size               3387	3_0_0	EXIST::FUNCTION:
 COMP_CTX_free                           3388	3_0_0	EXIST::FUNCTION:COMP
 i2d_PBE2PARAM                           3389	3_0_0	EXIST::FUNCTION:
-EC_POINT_make_affine                    3390	3_0_0	EXIST::FUNCTION:EC
+EC_POINT_make_affine                    3390	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 DSA_generate_parameters                 3391	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_0_9_8,DSA
 ASN1_BIT_STRING_num_asc                 3392	3_0_0	EXIST::FUNCTION:
 X509_INFO_free                          3394	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Related to what's going on in #8332.

* Deprecate `EC_POINTs_make_affine`. I have only ever seen one caller to this -- internally in `ec_mult.c`.
* Deprecate `EC_POINT_make_affine`. Since there is no longer any visibility inside an `EC_POINT` -- there is no noticeable state change for linking applications. Applications no longer reach in like `P->X` to get at the `BIGNUM`, but use the API like `EC_POINT_get_affine_coordinates` to fetch them -- where this conversion happens internally by the `EC_METHOD` automatically.

Apologies -- I fat fingered the `CHANGES.md` in the last PR. My glasses have been in my work office since quarantine started and the alignment was a little off :nerd_face: