### PR TITLE
Add OCSP_check_validity() RetVal documentation

### DIFF
--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -156,6 +156,10 @@ occurred.
 OCSP_resp_get0_signer() returns 1 if the signing certificate was located,
 or 0 on error.
 
+OCSP_check_validity() returns 1 if B<thisupd> and B<nextupd> are valid time 
+bounds for an OCSP response given the current time and the constraints
+specified by B<sec> and B<maxsec>; otherwise, returns 0 to indicate an error.
+
 OCSP_basic_verify() returns 1 on success, 0 on error, or -1 on fatal error such
 as malloc failure.
 

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -157,8 +157,8 @@ OCSP_resp_get0_signer() returns 1 if the signing certificate was located,
 or 0 on error.
 
 OCSP_check_validity() returns 1 if B<thisupd> and B<nextupd> are valid time 
-bounds for an OCSP response given the current time and the constraints
-specified by B<sec> and B<maxsec>; otherwise, returns 0 to indicate an error.
+values for an OCSP response given the current time and the constraints
+specified by B<sec> and B<maxsec>, or 0 to indicate an error.
 
 OCSP_basic_verify() returns 1 on success, 0 on error, or -1 on fatal error such
 as malloc failure.


### PR DESCRIPTION
CLA: trivial

There is currently no documentation on what values OCSP_check_validity() returns to indicate success or failure, or what would constitute a successful return. Without it, one would need to search the OpenSSL source code to determine the behavior of the function. This change adds such explanatory documentation.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
