### PR TITLE
Adjust length of some strncpy() calls

### DIFF
--- a/crypto/LPdir_unix.c
+++ b/crypto/LPdir_unix.c
@@ -121,7 +121,7 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
 
 #ifdef __VMS
     strncpy((*ctx)->previous_entry_name, (*ctx)->entry_name,
-            sizeof((*ctx)->previous_entry_name) - 1);
+            sizeof((*ctx)->previous_entry_name));
 
  again:
 #endif

--- a/crypto/LPdir_unix.c
+++ b/crypto/LPdir_unix.c
@@ -121,7 +121,7 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
 
 #ifdef __VMS
     strncpy((*ctx)->previous_entry_name, (*ctx)->entry_name,
-            sizeof((*ctx)->previous_entry_name));
+            sizeof((*ctx)->previous_entry_name) - 1);
 
  again:
 #endif

--- a/crypto/x509/v3_alt.c
+++ b/crypto/x509/v3_alt.c
@@ -128,7 +128,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
                 BIO_snprintf(othername, sizeof(othername), "othername: %s:",
                              oline);
             else
-                strncpy(othername, "othername:", sizeof(othername) - 1);
+                OPENSSL_strlcpy(othername, "othername:", sizeof(othername));
 
             /* check if the value is something printable */
             if (gen->d.otherName->value->type == V_ASN1_IA5STRING) {

--- a/crypto/x509/v3_alt.c
+++ b/crypto/x509/v3_alt.c
@@ -128,7 +128,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
                 BIO_snprintf(othername, sizeof(othername), "othername: %s:",
                              oline);
             else
-                strncpy(othername, "othername:", sizeof(othername));
+                strncpy(othername, "othername:", sizeof(othername) - 1);
 
             /* check if the value is something printable */
             if (gen->d.otherName->value->type == V_ASN1_IA5STRING) {

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -336,9 +336,20 @@ static int rsa_signature_init(void *vprsactx, void *vrsa, int operation)
                     return 0;
                 }
 
-                strncpy(prsactx->mdname, mdname, sizeof(prsactx->mdname) - 1);
-                strncpy(prsactx->mgf1_mdname, mgf1mdname,
-                        sizeof(prsactx->mgf1_mdname) - 1);
+                if (OPENSSL_strlcpy(prsactx->mdname, mdname,
+                                    sizeof(prsactx->mdname))
+                        >= sizeof(prsactx->mdname)) {
+                    ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST,
+                                   "hash algorithm name too long");
+                    return 0;
+                }
+                if (OPENSSL_strlcpy(prsactx->mgf1_mdname, mgf1mdname,
+                                sizeof(prsactx->mgf1_mdname))
+                        >= sizeof(prsactx->mgf1_mdname)) {
+                    ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST,
+                                   "MGF1 hash algorithm name too long");
+                    return 0;
+                }
                 prsactx->saltlen = min_saltlen;
 
                 return rsa_setup_md(prsactx, mdname, prsactx->propq)

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -320,6 +320,7 @@ static int rsa_signature_init(void *vprsactx, void *vrsa, int operation)
                 int mgf1md_nid = rsa_pss_params_30_maskgenhashalg(pss);
                 int min_saltlen = rsa_pss_params_30_saltlen(pss);
                 const char *mdname, *mgf1mdname;
+                size_t len;
 
                 mdname = rsa_oaeppss_nid2name(md_nid);
                 mgf1mdname = rsa_oaeppss_nid2name(mgf1md_nid);
@@ -336,16 +337,16 @@ static int rsa_signature_init(void *vprsactx, void *vrsa, int operation)
                     return 0;
                 }
 
-                if (OPENSSL_strlcpy(prsactx->mdname, mdname,
-                                    sizeof(prsactx->mdname))
-                        >= sizeof(prsactx->mdname)) {
+                len = OPENSSL_strlcpy(prsactx->mdname, mdname,
+                                      sizeof(prsactx->mdname));
+                if (len >= sizeof(prsactx->mdname)) {
                     ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST,
                                    "hash algorithm name too long");
                     return 0;
                 }
-                if (OPENSSL_strlcpy(prsactx->mgf1_mdname, mgf1mdname,
-                                sizeof(prsactx->mgf1_mdname))
-                        >= sizeof(prsactx->mgf1_mdname)) {
+                len = OPENSSL_strlcpy(prsactx->mgf1_mdname, mgf1mdname,
+                                      sizeof(prsactx->mgf1_mdname));
+                if (len >= sizeof(prsactx->mgf1_mdname)) {
                     ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST,
                                    "MGF1 hash algorithm name too long");
                     return 0;

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -336,9 +336,9 @@ static int rsa_signature_init(void *vprsactx, void *vrsa, int operation)
                     return 0;
                 }
 
-                strncpy(prsactx->mdname, mdname, sizeof(prsactx->mdname));
+                strncpy(prsactx->mdname, mdname, sizeof(prsactx->mdname) - 1);
                 strncpy(prsactx->mgf1_mdname, mgf1mdname,
-                        sizeof(prsactx->mgf1_mdname));
+                        sizeof(prsactx->mgf1_mdname) - 1);
                 prsactx->saltlen = min_saltlen;
 
                 return rsa_setup_md(prsactx, mdname, prsactx->propq)


### PR DESCRIPTION
This fixes warnings detected by `-Wstringop-truncation`.