### PR TITLE
s_client: Fix -proxy flag regression

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1602,7 +1602,7 @@ int s_client_main(int argc, char **argv)
 #endif
 
     if (connectstr != NULL) {
-        int res = 0;
+        int res;
         char *tmp_host = host, *tmp_port = port;
 
         res = BIO_parse_hostserv(connectstr, &host, &port, BIO_PARSE_PRIO_HOST);
@@ -1619,17 +1619,17 @@ int s_client_main(int argc, char **argv)
     }
 
     if (proxystr != NULL) {
-        int res = 0;
+        int res;
         char *tmp_host = host, *tmp_port = port;
 
-        if (connectstr == NULL) {
+        if (host == NULL || port == NULL) {
             BIO_printf(bio_err, "%s: -proxy requires use of -connect or target parameter\n", prog);
             goto opthelp;
         }
 
         /* Retain the original target host:port for use in the HTTP proxy connect string */
-        thost=OPENSSL_strdup(host);
-        tport=OPENSSL_strdup(port);
+        thost = OPENSSL_strdup(host);
+        tport = OPENSSL_strdup(port);
         if (thost == NULL || tport == NULL) {
             BIO_printf(bio_err, "%s: out of memory\n", prog);
             goto end;


### PR DESCRIPTION
s_client: connection via an HTTP proxy broke somewhere prior to openssl-3.0.0-alpha2.

`openssl s_client -connect <target> -proxy <proxy_host:proxy_port>`

Results in s_client making a TCP connection to proxy_host:proxy_port and then issuing an HTTP CONNECT to the proxy, instead of the target.

Fixes #11879 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
