### PR TITLE
Fix d2i_PrivateKey() to work as documented [1.1.1]

### DIFF
--- a/crypto/asn1/d2i_pr.c
+++ b/crypto/asn1/d2i_pr.c
@@ -56,6 +56,8 @@ EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
                 goto err;
             EVP_PKEY_free(ret);
             ret = tmp;
+            if (EVP_PKEY_type(type) != EVP_PKEY_base_id(ret))
+                goto err;
         } else {
             ASN1err(ASN1_F_D2I_PRIVATEKEY, ERR_R_ASN1_LIB);
             goto err;


### PR DESCRIPTION
d2i_PrivateKey() is documented to return keys of the type given as
first argument |type|, unconditionally.  Most specifically, the manual
says this:

> An error occurs if the decoded key does not match type.

However, when faced of a PKCS#8 wrapped key, |type| was ignored, which
may lead to unexpected results.

(cherry picked from commit b2952366dd0248bf35c83e1736cd203033a22378)
