### PR TITLE
Enable legacy AES API to use AESNI or VPAES if available

### DIFF
--- a/crypto/aes/aes_cbc.c
+++ b/crypto/aes/aes_cbc.c
@@ -10,6 +10,13 @@
 #include <openssl/aes.h>
 #include <openssl/modes.h>
 
+#if defined(OPENSSL_CPUID_OBJ) && !defined(AES_ASM)
+void aes_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                     size_t len, const AES_KEY *key,
+                     unsigned char *ivec, const int enc);
+# define AES_cbc_encrypt aes_cbc_encrypt
+#endif
+
 void AES_cbc_encrypt(const unsigned char *in, unsigned char *out,
                      size_t len, const AES_KEY *key,
                      unsigned char *ivec, const int enc)

--- a/crypto/aes/aes_core.c
+++ b/crypto/aes/aes_core.c
@@ -43,6 +43,21 @@
 #include <openssl/aes.h>
 #include "aes_local.h"
 
+#if defined(OPENSSL_CPUID_OBJ) && !defined(AES_ASM)
+int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
+                        AES_KEY *key);
+int aes_set_decrypt_key(const unsigned char *userKey, const int bits,
+                        AES_KEY *key);
+void aes_encrypt(const unsigned char *in, unsigned char *out,
+                 const AES_KEY *key);
+void aes_decrypt(const unsigned char *in, unsigned char *out,
+                 const AES_KEY *key);
+# define AES_set_encrypt_key aes_set_encrypt_key
+# define AES_set_decrypt_key aes_set_decrypt_key
+# define AES_encrypt aes_encrypt
+# define AES_decrypt aes_decrypt
+#endif
+
 #if defined(OPENSSL_AES_CONST_TIME) && !defined(AES_ASM)
 typedef union {
     unsigned char b[8];

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -109,10 +109,14 @@ void aes_encrypt(const unsigned char *in, unsigned char *out,
                  const AES_KEY *key);
 void aes_decrypt(const unsigned char *in, unsigned char *out,
                  const AES_KEY *key);
+void aes_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                     size_t len, const AES_KEY *key,
+                     unsigned char *ivec, const int enc);
 # define AES_set_encrypt_key aes_set_encrypt_key
 # define AES_set_dncrypt_key aes_set_decrypt_key
 # define AES_encrypt aes_encrypt
 # define AES_dncrypt aes_dncrypt
+# define AES_cbc_encrypt aes_cbc_encrypt
 #endif
 
 #ifdef VPAES_ASM
@@ -4308,6 +4312,7 @@ BLOCK_CIPHER_custom(NID_aes, 256, 16, 12, ocb, OCB,
 # undef AES_set_decrypt_key
 # undef AES_encrypt
 # undef AES_decrypt
+# undef AES_cbc_encrypt
 
 int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
                         AES_KEY *key)
@@ -4367,5 +4372,22 @@ void AES_decrypt(const unsigned char *in, unsigned char *out,
     else
 # endif
     aes_decrypt(in, out, key);
+}
+
+void AES_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                     size_t len, const AES_KEY *key,
+                     unsigned char *ivec, const int enc)
+{
+# ifdef AESNI_CAPABLE
+    if (AESNI_CAPABLE)
+        aesni_cbc_encrypt(in, out, len, key, ivec, enc);
+    else
+# endif
+# ifdef VPAES_CAPABLE
+    if (VPAES_CAPABLE)
+        vpaes_cbc_encrypt(in, out, len, key, ivec, enc);
+    else
+# endif
+    aes_cbc_encrypt(in, out, len, key, ivec, enc);
 }
 #endif

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -100,6 +100,21 @@ typedef struct {
 
 #define MAXBITCHUNK     ((size_t)1<<(sizeof(size_t)*8-4))
 
+#if defined(OPENSSL_CPUID_OBJ) && !defined(AES_ASM)
+int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
+                        AES_KEY *key);
+int aes_set_decrypt_key(const unsigned char *userKey, const int bits,
+                        AES_KEY *key);
+void aes_encrypt(const unsigned char *in, unsigned char *out,
+                 const AES_KEY *key);
+void aes_decrypt(const unsigned char *in, unsigned char *out,
+                 const AES_KEY *key);
+# define AES_set_encrypt_key aes_set_encrypt_key
+# define AES_set_dncrypt_key aes_set_decrypt_key
+# define AES_encrypt aes_encrypt
+# define AES_dncrypt aes_dncrypt
+#endif
+
 #ifdef VPAES_ASM
 int vpaes_set_encrypt_key(const unsigned char *userKey, int bits,
                           AES_KEY *key);
@@ -4287,3 +4302,70 @@ BLOCK_CIPHER_custom(NID_aes, 192, 16, 12, ocb, OCB,
 BLOCK_CIPHER_custom(NID_aes, 256, 16, 12, ocb, OCB,
                     EVP_CIPH_FLAG_AEAD_CIPHER | CUSTOM_FLAGS)
 #endif                         /* OPENSSL_NO_OCB */
+
+#if defined(OPENSSL_CPUID_OBJ) && !defined(AES_ASM)
+# undef AES_set_encrypt_key
+# undef AES_set_decrypt_key
+# undef AES_encrypt
+# undef AES_decrypt
+
+int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
+                        AES_KEY *key)
+{
+# ifdef AESNI_CAPABLE
+    if (AESNI_CAPABLE)
+        return aesni_set_encrypt_key(userKey, bits, key);
+# endif
+# ifdef VPAES_CAPABLE
+    if (VPAES_CAPABLE)
+        return vpaes_set_encrypt_key(userKey, bits, key);
+# endif
+    return aes_set_encrypt_key(userKey, bits, key);
+}
+
+int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
+                        AES_KEY *key)
+{
+# ifdef AESNI_CAPABLE
+    if (AESNI_CAPABLE)
+        return aesni_set_decrypt_key(userKey, bits, key);
+# endif
+# ifdef VPAES_CAPABLE
+    if (VPAES_CAPABLE)
+        return vpaes_set_decrypt_key(userKey, bits, key);
+# endif
+    return aes_set_decrypt_key(userKey, bits, key);
+}
+
+void AES_encrypt(const unsigned char *in, unsigned char *out,
+                 const AES_KEY *key)
+{
+# ifdef AESNI_CAPABLE
+    if (AESNI_CAPABLE)
+        aesni_encrypt(in, out, key);
+    else
+# endif
+# ifdef VPAES_CAPABLE
+    if (VPAES_CAPABLE)
+        vpaes_encrypt(in, out, key);
+    else
+# endif
+    aes_encrypt(in, out, key);
+}
+
+void AES_decrypt(const unsigned char *in, unsigned char *out,
+                 const AES_KEY *key)
+{
+# ifdef AESNI_CAPABLE
+    if (AESNI_CAPABLE)
+        aesni_decrypt(in, out, key);
+    else
+# endif
+# ifdef VPAES_CAPABLE
+    if (VPAES_CAPABLE)
+        vpaes_decrypt(in, out, key);
+    else
+# endif
+    aes_decrypt(in, out, key);
+}
+#endif


### PR DESCRIPTION
When no assembler support is available, we fall back
to either the constant time implementation or the non-constant time
C code implementation.

This is controlled by -DOPENSSL_AES_CONST_TIME.
So this makes the legacy API completely constant time,
if OPENSSL_AES_CONST_TIME is defined, otherwise it uses constant time
assembler implementaions when available, and may fall back to the
non-constant time implementaion.

This works so far only for intel and aarch64 CPUs.

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
