### PR TITLE
Prevent use after free of global_engine_lock

### DIFF
--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -171,6 +171,7 @@ void engine_cleanup_int(void)
         cleanup_stack = NULL;
     }
     CRYPTO_THREAD_lock_free(global_engine_lock);
+    global_engine_lock = NULL;
 }
 
 /* Now the "ex_data" support */


### PR DESCRIPTION
If buggy application calls engine functions after cleanup of engines
already happened the global_engine_lock will be used although
already freed.

See for example:
https://bugzilla.redhat.com/show_bug.cgi?id=1831086
