### PR TITLE
Revert "Guard use of struct tms with #ifdef __TMS"

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2270,30 +2270,17 @@ double app_tminterval(int stop, int usertime)
 double app_tminterval(int stop, int usertime)
 {
     double ret = 0;
-    clock_t now;
-    static clock_t tmstart;
-    long int tck = sysconf(_SC_CLK_TCK);
-# ifdef __TMS
     struct tms rus;
+    clock_t now = times(&rus);
+    static clock_t tmstart;
 
-    now = times(&rus);
     if (usertime)
         now = rus.tms_utime;
-# else
-    if (usertime)
-        now = clock();          /* sum of user and kernel times */
-    else {
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        now = (clock_t)((unsigned long long)tv.tv_sec * tck +
-                        (unsigned long long)tv.tv_usec * (1000000 / tck)
-            );
-    }
-# endif
 
     if (stop == TM_START) {
         tmstart = now;
     } else {
+        long int tck = sysconf(_SC_CLK_TCK);
         ret = (now - tmstart) / (double)tck;
     }
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2230,40 +2230,6 @@ double app_tminterval(int stop, int usertime)
     return ret;
 }
 
-#elif defined(OPENSSL_SYSTEM_VMS)
-# include <time.h>
-# include <times.h>
-
-double app_tminterval(int stop, int usertime)
-{
-    static clock_t tmstart;
-    double ret = 0;
-    clock_t now;
-# ifdef __TMS
-    struct tms rus;
-
-    now = times(&rus);
-    if (usertime)
-        now = rus.tms_utime;
-# else
-    if (usertime)
-        now = clock();          /* sum of user and kernel times */
-    else {
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        now = (clock_t)((unsigned long long)tv.tv_sec * CLK_TCK +
-                        (unsigned long long)tv.tv_usec * (1000000 / CLK_TCK)
-            );
-    }
-# endif
-    if (stop == TM_START)
-        tmstart = now;
-    else
-        ret = (now - tmstart) / (double)(CLK_TCK);
-
-    return ret;
-}
-
 #elif defined(_SC_CLK_TCK)      /* by means of unistd.h */
 # include <sys/times.h>
 


### PR DESCRIPTION
The __TMS might be necessary on VMS however there is no such
define on glibc even though the times() function is fully supported.
    
Fixes #11903