### PR TITLE
Fix omissions in providers/common/der/build.info

### DIFF
--- a/providers/common/der/build.info
+++ b/providers/common/der/build.info
@@ -1,36 +1,64 @@
-$FIPSABLE=\
-        der_rsa_gen.c der_rsa_key.c der_rsa_sig.c \
-        der_dsa_gen.c der_dsa_key.c der_dsa_sig.c \
-        der_ec_gen.c der_ec_key.c der_ec_sig.c \
-        der_digests_gen.c
+#----- Digests
+$DER_DIGESTS_H=../include/prov/der_digests.h
+$DER_DIGESTS_GEN=der_digests_gen.c
 
-SOURCE[../../libfips.a]=$FIPSABLE
-SOURCE[../../libnonfips.a]=$FIPSABLE
+GENERATE[$DER_DIGESTS_GEN]=der_digests_gen.c.in
+DEPEND[$DER_DIGESTS_GEN]=oids_to_c.pm
 
-GENERATE[der_rsa_gen.c]=der_rsa_gen.c.in
-DEPEND[der_rsa_gen.c]=oids_to_c.pm
+DEPEND[${DER_DIGESTS_GEN/.c/.o}]=$DER_DIGESTS_H
+GENERATE[$DER_DIGESTS_H]=der_digests.h.in
+DEPEND[$DER_DIGESTS_H]=oids_to_c.pm
 
-DEPEND[der_rsa_gen.o]=../include/prov/der_rsa.h ../include/prov/der_digests.h
-GENERATE[../include/prov/der_rsa.h]=der_rsa.h.in
-DEPEND[../include/prov/der_rsa.h]=oids_to_c.pm
+#----- RSA
+$DER_RSA_H=../include/prov/der_rsa.h
+$DER_RSA_GEN=der_rsa_gen.c
+$DER_RSA_AUX=der_rsa_key.c der_rsa_sig.c
+$DER_RSA_COMMON=$DER_RSA_GEN der_rsa_sig.c
+$DER_RSA_FIPSABLE=der_rsa_key.c
 
-GENERATE[der_dsa_gen.c]=der_dsa_gen.c.in
-DEPEND[der_dsa_gen.c]=oids_to_c.pm
+GENERATE[$DER_RSA_GEN]=der_rsa_gen.c.in
+DEPEND[$DER_RSA_GEN]=oids_to_c.pm
 
-DEPEND[der_dsa_gen.o]=../include/prov/der_dsa.h
-GENERATE[../include/prov/der_dsa.h]=der_dsa.h.in
-DEPEND[../include/prov/der_dsa.h]=oids_to_c.pm
+DEPEND[${DER_RSA_AUX/.c/.o}]=$DER_RSA_H $DER_DIGESTS_H
+DEPEND[${DER_RSA_GEN/.c/.o}]=$DER_RSA_H
+GENERATE[$DER_RSA_H]=der_rsa.h.in
+DEPEND[$DER_RSA_H]=oids_to_c.pm
 
-GENERATE[der_ec_gen.c]=der_ec_gen.c.in
-DEPEND[der_ec_gen.c]=oids_to_c.pm
+#----- DSA
+$DER_DSA_H=../include/prov/der_dsa.h
+$DER_DSA_GEN=der_dsa_gen.c
+$DER_DSA_AUX=der_dsa_key.c der_dsa_sig.c
 
-DEPEND[der_ec_gen.o]=../include/prov/der_ec.h
-GENERATE[../include/prov/der_ec.h]=der_ec.h.in
-DEPEND[../include/prov/der_ec.h]=oids_to_c.pm
+GENERATE[$DER_DSA_GEN]=der_dsa_gen.c.in
+DEPEND[$DER_DSA_GEN]=oids_to_c.pm
 
-GENERATE[der_digests_gen.c]=der_digests_gen.c.in
-DEPEND[der_digests_gen.c]=oids_to_c.pm
+DEPEND[${DER_DSA_AUX/.c/.o}]=$DER_DSA_H $DER_DIGESTS_H
+DEPEND[${DER_DSA_GEN/.c/.o}]=$DER_DSA_H
+GENERATE[$DER_DSA_H]=der_dsa.h.in
+DEPEND[$DER_DSA_H]=oids_to_c.pm
 
-DEPEND[der_digests_gen.o]=../include/prov/der_digests.h
-GENERATE[../include/prov/der_digests.h]=der_digests.h.in
-DEPEND[../include/prov/der_digests.h]=oids_to_c.pm
+#----- EC
+$DER_EC_H=../include/prov/der_ec.h
+$DER_EC_GEN=der_ec_gen.c
+$DER_EC_AUX=der_ec_key.c der_ec_sig.c
+
+GENERATE[$DER_EC_GEN]=der_ec_gen.c.in
+DEPEND[$DER_EC_GEN]=oids_to_c.pm
+
+DEPEND[${DER_EC_AUX/.c/.o}]=$DER_EC_H $DER_DIGESTS_H
+DEPEND[${DER_EC_GEN/.c/.o}]=$DER_EC_H
+GENERATE[$DER_EC_H]=der_ec.h.in
+DEPEND[$DER_EC_H]=oids_to_c.pm
+
+#----- Conclusion
+
+# TODO(3.0) $COMMON should go to libcommon.a, but this currently leads
+# to linking conflicts, so we add it to libfips.a and libnonfips.a for
+# the moment being
+$COMMON=\
+        $DER_RSA_COMMON \
+        $DER_DSA_GEN $DER_DSA_AUX \
+        $DER_EC_GEN $DER_EC_AUX \
+        $DER_DIGESTS_GEN
+SOURCE[../../libfips.a]=$COMMON $DER_RSA_FIPSABLE
+SOURCE[../../libnonfips.a]=$COMMON $DER_RSA_FIPSABLE


### PR DESCRIPTION
Dependencies on generated files must be declared explicitly.  When
refactoring the DER code in providers/common/der, a few of those
dependency declaration were omitted, which may lead to build errors in
a parallel build.

Some cleanup and extensive used of build.info variables is done while
at it, to avoid unnecessary repetition.
