### PR TITLE
Cast ULONG_MAX to LDOUBLE before comparing

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -635,7 +635,7 @@ fmtfp(char **sbuffer,
             fvalue = tmpvalue;
     }
     ufvalue = abs_val(fvalue);
-    if (ufvalue > ULONG_MAX) {
+    if (ufvalue > (LDOUBLE)ULONG_MAX) {
         /* Number too big */
         return 0;
     }


### PR DESCRIPTION
clang-10 gives the following error:
crypto/bio/b_print.c:638:19: error: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-int-float-conversion]
    if (ufvalue > ULONG_MAX) {
                ~ ^~~~~~~~~
/usr/lib/llvm-10/lib/clang/10.0.0/include/limits.h:57:37: note: expanded from macro 'ULONG_MAX'
                   ~~~~~~~~~~~~~~~~~^~~~

A double can only reperesent integers up to 2^53-1, a long double 2^65-1.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
