### PR TITLE
Fix coverity issues in EC after #11807

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -1095,6 +1095,7 @@ int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *g_scalar,
                  const EC_POINT *point, const BIGNUM *p_scalar, BN_CTX *ctx)
 {
     int ret = 0;
+    size_t num;
 #ifndef FIPS_MODULE
     BN_CTX *new_ctx = NULL;
 #endif
@@ -1117,13 +1118,12 @@ int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *g_scalar,
         return 0;
     }
 
+    num = (point != NULL && p_scalar != NULL) ? 1 : 0;
     if (group->meth->mul != NULL)
-        ret = group->meth->mul(group, r, g_scalar, point != NULL
-                               && p_scalar != NULL, &point, &p_scalar, ctx);
+        ret = group->meth->mul(group, r, g_scalar, num, &point, &p_scalar, ctx);
     else
         /* use default */
-        ret = ec_wNAF_mul(group, r, g_scalar, point != NULL
-                          && p_scalar != NULL, &point, &p_scalar, ctx);
+        ret = ec_wNAF_mul(group, r, g_scalar, num, &point, &p_scalar, ctx);
 
 #ifndef FIPS_MODULE
     BN_CTX_free(new_ctx);


### PR DESCRIPTION
This should fix 2 issues detected by Coverity and introduced with
https://github.com/openssl/openssl/pull/11807

- CID 1463577:  Memory - corruptions  (ARRAY_VS_SINGLETON)
- CID 1463573:  Memory - corruptions  (ARRAY_VS_SINGLETON)

In practice the tests seem to show that they both aren't real issues,
yet I believe this small change should appease the scanner and at the
same time improve clarity for the reader.

Here is the original report:

```
** CID 1463577:  Memory - corruptions  (ARRAY_VS_SINGLETON)

________________________________________________________________________________________________________
*** CID 1463577:  Memory - corruptions  (ARRAY_VS_SINGLETON)
/crypto/ec/ec_lib.c: 1123 in EC_POINT_mul()
1117
1118         if (group->meth->mul != NULL)
1119             ret = group->meth->mul(group, r, g_scalar, point != NULL
1120                                    && p_scalar != NULL, &point, &p_scalar, ctx);
1121         else
1122             /* use default */
   CID 1463577:  Memory - corruptions  (ARRAY_VS_SINGLETON)
   Passing "&point" to function "ec_wNAF_mul" which uses it as an array. This might corrupt or misinterpret adjacent memory locations.
1123             ret = ec_wNAF_mul(group, r, g_scalar, point != NULL
1124                               && p_scalar != NULL, &point, &p_scalar, ctx);
1125
1126     #ifndef FIPS_MODULE
1127         BN_CTX_free(new_ctx);
1128     #endif

** CID 1463573:  Memory - corruptions  (ARRAY_VS_SINGLETON)

________________________________________________________________________________________________________
*** CID 1463573:  Memory - corruptions  (ARRAY_VS_SINGLETON)
/crypto/ec/ec_lib.c: 1123 in EC_POINT_mul()
1117
1118         if (group->meth->mul != NULL)
1119             ret = group->meth->mul(group, r, g_scalar, point != NULL
1120                                    && p_scalar != NULL, &point, &p_scalar, ctx);
1121         else
1122             /* use default */
   CID 1463573:  Memory - corruptions  (ARRAY_VS_SINGLETON)
   Passing "&p_scalar" to function "ec_wNAF_mul" which uses it as an array. This might corrupt or misinterpret adjacent memory locations.
1123             ret = ec_wNAF_mul(group, r, g_scalar, point != NULL
1124                               && p_scalar != NULL, &point, &p_scalar, ctx);
1125
1126     #ifndef FIPS_MODULE
1127         BN_CTX_free(new_ctx);
1128     #endif
```

