### PR TITLE
Pass zero-length parameters to providers

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -788,8 +788,6 @@ static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
     if (used_len != NULL)
         *used_len = sz;
 
-    if (sz == 0)
-        return 1;
     if (p->data == NULL)
         return 0;
 
@@ -797,12 +795,13 @@ static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
         return 1;
 
     if (*val == NULL) {
-        char *const q = OPENSSL_malloc(sz);
+        char *const q = OPENSSL_malloc(sz > 0 ? sz : 1);
 
         if (q == NULL)
             return 0;
         *val = q;
-        memcpy(q, p->data, sz);
+        if (sz != 0)
+            memcpy(q, p->data, sz);
         return 1;
     }
     if (max_len < sz)

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -1007,7 +1007,8 @@ static int rsa_cms_decrypt(CMS_RecipientInfo *ri)
         goto err;
     if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkctx, mgf1md) <= 0)
         goto err;
-    if (EVP_PKEY_CTX_set0_rsa_oaep_label(pkctx, label, labellen) <= 0)
+    if (label != NULL
+            && EVP_PKEY_CTX_set0_rsa_oaep_label(pkctx, label, labellen) <= 0)
         goto err;
     /* Carry on */
     rv = 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1246,6 +1246,47 @@ static int test_HKDF(void)
     return ret;
 }
 
+static int test_emptyikm_HKDF(void)
+{
+    EVP_PKEY_CTX *pctx;
+    unsigned char out[20];
+    size_t outlen;
+    int ret = 0;
+    unsigned char salt[] = "9876543210";
+    unsigned char key[] = "";
+    unsigned char info[] = "stringinfo";
+    const unsigned char expected[] = {
+        0x68, 0x81, 0xa5, 0x3e, 0x5b, 0x9c, 0x7b, 0x6f, 0x2e, 0xec, 0xc8, 0x47,
+        0x7c, 0xfa, 0x47, 0x35, 0x66, 0x82, 0x15, 0x30
+    };
+    size_t expectedlen = sizeof(expected);
+
+    if (!TEST_ptr(pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL)))
+        goto done;
+
+    outlen = sizeof(out);
+    memset(out, 0, outlen);
+
+    if (!TEST_int_gt(EVP_PKEY_derive_init(pctx), 0)
+            || !TEST_int_gt(EVP_PKEY_CTX_set_hkdf_md(pctx, EVP_sha256()), 0)
+            || !TEST_int_gt(EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt,
+                                                        sizeof(salt) - 1), 0)
+            || !TEST_int_gt(EVP_PKEY_CTX_set1_hkdf_key(pctx, key,
+                                                       sizeof(key) - 1), 0)
+            || !TEST_int_gt(EVP_PKEY_CTX_add1_hkdf_info(pctx, info,
+                                                        sizeof(info) - 1), 0)
+            || !TEST_int_gt(EVP_PKEY_derive(pctx, out, &outlen), 0)
+            || !TEST_mem_eq(out, outlen, expected, expectedlen))
+        goto done;
+
+    ret = 1;
+
+ done:
+    EVP_PKEY_CTX_free(pctx);
+
+    return ret;
+}
+
 #ifndef OPENSSL_NO_EC
 static int test_X509_PUBKEY_inplace(void)
 {
@@ -1657,6 +1698,7 @@ int setup_tests(void)
     ADD_TEST(test_CMAC_keygen);
 #endif
     ADD_TEST(test_HKDF);
+    ADD_TEST(test_emptyikm_HKDF);
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_X509_PUBKEY_inplace);
     ADD_ALL_TESTS(test_invalide_ec_char2_pub_range_decode,


### PR DESCRIPTION
This was reported to me as a failure of HKDF with empty IKM (that appears to be a regression from 1.1.1), but also can manifest in other places, such as the RSA OAEP CMS test that I had to provide a fix for.

In general, we have to be able to differentiate between parameter-absent and parameter-present-but-zero-length: some protocols exist that mandate different behavior in these cases.  This approach currently feels the most natural to me, though I could be persuaded that an alternate approach is preferred, as I also think that there are aspects of this approach that are ... not exactly pretty.