### PR TITLE
[crypto/ec] respect enable-ec_nistp_64_gcc_128 option

### DIFF
--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -2858,12 +2858,12 @@ static const ec_list_element curve_list[] = {
     {"prime192v1", NID_X9_62_prime192v1, &_EC_NIST_PRIME_192.h, 0,
      "NIST/X9.62/SECG curve over a 192 bit prime field"},
     {"prime256v1", NID_X9_62_prime256v1, &_EC_X9_62_PRIME_256V1.h,
-# if defined(ECP_NISTZ256_ASM)
+# if !defined(OPENSSL_NO_EC_NISTP_64_GCC_128)
+     EC_GFp_nistp256_method,
+# elif defined(ECP_NISTZ256_ASM)
      EC_GFp_nistz256_method,
 # elif defined(S390X_EC_ASM)
      EC_GFp_s390x_nistp256_method,
-# elif !defined(OPENSSL_NO_EC_NISTP_64_GCC_128)
-     EC_GFp_nistp256_method,
 # else
      0,
 # endif


### PR DESCRIPTION
Quoting from `INSTALL.md`:

```
### enable-ec_nistp_64_gcc_128

Enable support for optimised implementations of some commonly used NIST
elliptic curves.
```

But changes from 4d3fa06fce52682bfbc503c7ded2d0289e3f8cde trump that user option, which is misleading.

If I explictly say `enable-ec_nistp_64_gcc_128`, I expect to get the `EC_METHOD` from `ecp_nistp256.c`.

Getting the `EC_METHOD` in `ecp_nistz256.c` (if your arch supports it) is easy -- just don't pass `enable-ec_nistp_64_gcc_128` and it defaults to false. Making OpenSSL not trump your explicit configure option is not.

If users prefer tried and true pure C implementations versus manually written assembly, you should respect that option.