### PR TITLE
CORE: make sure activated fallback providers stay activated

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -104,6 +104,23 @@ struct provider_store_st {
     unsigned int use_fallbacks:1;
 };
 
+/*
+ * provider_deactivate_free() is a wrapper around ossl_provider_free()
+ * that also makes sure that activated fallback providers are deactivated.
+ * This is simply done by freeing them an extra time, to compensate for the
+ * refcount that provider_activate_fallbacks() gives them.
+ * Since this is only called when the provider store is being emptied, we
+ * don't need to care about any lock.
+ */
+static void provider_deactivate_free(OSSL_PROVIDER *prov)
+{
+    int extra_free = (prov->flag_initialized && prov->flag_fallback);
+
+    if (extra_free)
+        ossl_provider_free(prov);
+    ossl_provider_free(prov);
+}
+
 static void provider_store_free(void *vstore)
 {
     struct provider_store_st *store = vstore;
@@ -111,7 +128,7 @@ static void provider_store_free(void *vstore)
     if (store == NULL)
         return;
     OPENSSL_free(store->default_path);
-    sk_OSSL_PROVIDER_pop_free(store->providers, ossl_provider_free);
+    sk_OSSL_PROVIDER_pop_free(store->providers, provider_deactivate_free);
     CRYPTO_THREAD_lock_free(store->lock);
     OPENSSL_free(store);
 }
@@ -654,13 +671,18 @@ static void provider_activate_fallbacks(struct provider_store_st *store)
             OSSL_PROVIDER *prov = sk_OSSL_PROVIDER_value(store->providers, i);
 
             /*
-             * Note that we don't care if the activation succeeds or not.
-             * If it doesn't succeed, then any attempt to use any of the
-             * fallback providers will fail anyway.
+             * Activated fallback providers get an extra refcount, to
+             * simulate a regular load.
+             * Note that we don't care if the activation succeeds or not,
+             * other than to maintain a correct refcount.  If the activation
+             * doesn't succeed, then any future attempt to use the fallback
+             * provider will fail anyway.
              */
             if (prov->flag_fallback) {
                 activated_fallback_count++;
-                provider_activate(prov);
+                if (ossl_provider_up_ref(prov)
+                    && !provider_activate(prov))
+                    ossl_provider_free(prov);
             }
         }
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -681,13 +681,14 @@ static void provider_activate_fallbacks(struct provider_store_st *store)
              * provider will fail anyway.
              */
             if (prov->flag_fallback) {
-                activated_fallback_count++;
-
-                if (ossl_provider_up_ref(prov)
-                    && !provider_activate(prov))
-                    ossl_provider_free(prov);
-                else
-                    prov->flag_activated_as_fallback = 1;
+                if (ossl_provider_up_ref(prov)) {
+                    if (!provider_activate(prov)) {
+                        ossl_provider_free(prov);
+                    } else {
+                        prov->flag_activated_as_fallback = 1;
+                        activated_fallback_count++;
+                    }
+                }
             }
         }
 

--- a/test/build.info
+++ b/test/build.info
@@ -731,6 +731,11 @@ IF[{- !$disabled{tests} -}]
   DEPEND[]=provider_internal_test.cnf
   GENERATE[provider_internal_test.cnf]=provider_internal_test.cnf.in
 
+  PROGRAMS{noinst}=provider_fallback_test
+  SOURCE[provider_fallback_test]=provider_fallback_test.c
+  INCLUDE[provider_fallback_test]=../include ../apps/include
+  DEPEND[provider_fallback_test]=../libcrypto libtestutil.a
+
   PROGRAMS{noinst}=params_test
   SOURCE[params_test]=params_test.c
   INCLUDE[params_test]=.. ../include ../apps/include

--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stddef.h>
+#include <openssl/provider.h>
+#include <openssl/evp.h>
+#include "testutil.h"
+
+static int test_fallback_provider(void)
+{
+    EVP_KEYMGMT *rsameth = NULL;
+    const OSSL_PROVIDER *prov = NULL;
+    int ok = 1;
+
+    if (!TEST_true(OSSL_PROVIDER_available(NULL, "default"))
+        || !TEST_ptr(rsameth = EVP_KEYMGMT_fetch(NULL, "RSA", NULL))
+        || !TEST_ptr(prov = EVP_KEYMGMT_provider(rsameth))
+        || !TEST_str_eq(OSSL_PROVIDER_name(prov), "default"))
+        ok = 0;
+
+    EVP_KEYMGMT_free(rsameth);
+    return ok;
+}
+
+int setup_tests(void)
+{
+    /*
+     * We must ensure that there is no OPENSSL_CONF defined.  Otherwise,
+     * we risk that the configuration file contains statements that load
+     * providers, which defeats the purpose of this test.
+     */
+    unsetenv("OPENSSL_CONF");
+
+    ADD_TEST(test_fallback_provider);
+    return 1;
+}
+

--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -50,22 +50,6 @@ static int test_explicit_provider(void)
 
 int setup_tests(void)
 {
-    /*
-     * We must ensure that there is no OPENSSL_CONF defined.  Otherwise,
-     * we risk that the configuration file contains statements that load
-     * providers, which defeats the purpose of this test.
-     */
-#ifndef _WIN32
-    unsetenv("OPENSSL_CONF");
-#else
-    /*
-     * Windows doesn't have unsetenv().  However, using _putenv() and giving
-     * the environment variable the empty value has the same effect, according
-     * to documentation.
-     */
-    _putenv("OPENSSL_CONF=");
-#endif
-
     ADD_TEST(test_fallback_provider);
     ADD_TEST(test_explicit_provider);
     return 1;

--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -55,7 +55,16 @@ int setup_tests(void)
      * we risk that the configuration file contains statements that load
      * providers, which defeats the purpose of this test.
      */
+#ifndef _WIN32
     unsetenv("OPENSSL_CONF");
+#else
+    /*
+     * Windows doesn't have unsetenv().  However, using _putenv() and giving
+     * the environment variable the empty value has the same effect, according
+     * to documentation.
+     */
+    _putenv("OPENSSL_CONF=");
+#endif
 
     ADD_TEST(test_fallback_provider);
     ADD_TEST(test_explicit_provider);

--- a/test/recipes/04-test_provider_fallback.t
+++ b/test/recipes/04-test_provider_fallback.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2019 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test::Simple;
+
+simple_test("test_provider_fallback", "provider_fallback_test");

--- a/test/recipes/04-test_provider_fallback.t
+++ b/test/recipes/04-test_provider_fallback.t
@@ -7,6 +7,12 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
+use File::Spec;
 use OpenSSL::Test::Simple;
+
+# We must ensure that OPENSSL_CONF points at an empty file.  Otherwise, we
+# risk that the configuration file contains statements that load providers,
+# which defeats the purpose of this test.  The NUL device is good enough.
+%ENV{OPENSSL_CONF} = File::Spec->devnull();
 
 simple_test("test_provider_fallback", "provider_fallback_test");

--- a/test/recipes/04-test_provider_fallback.t
+++ b/test/recipes/04-test_provider_fallback.t
@@ -13,6 +13,6 @@ use OpenSSL::Test::Simple;
 # We must ensure that OPENSSL_CONF points at an empty file.  Otherwise, we
 # risk that the configuration file contains statements that load providers,
 # which defeats the purpose of this test.  The NUL device is good enough.
-%ENV{OPENSSL_CONF} = File::Spec->devnull();
+$ENV{OPENSSL_CONF} = File::Spec->devnull();
 
 simple_test("test_provider_fallback", "provider_fallback_test");


### PR DESCRIPTION
Calling 'OSSL_PROVIDER_available(NULL, "default")' would search for
the "default" provider, and in doing so, activate it if necessary,
thereby detecting that it's available...  and then immediately free
it, which could deactivate that provider, even though it should stay
available.

We solve this by incrementing the refcount for activated fallbacks one
extra time, thereby simulating an explicit OSSL_PROVIDER_load(), and
compensate for it with an extra ossl_provider_free() when emptying the
provider store.