### PR TITLE
move EC_METHOD to internal-only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,26 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Deprecated EC_METHOD_get_field_type(). Applications should switch to
+   EC_GROUP_get_field_type().
+
+   *Billy Bob Brumley*
+
+ * Deprecated EC_GFp_simple_method(), EC_GFp_mont_method(),
+   EC_GF2m_simple_method(), EC_GFp_nist_method(), EC_GFp_nistp224_method()
+   EC_GFp_nistp256_method(), and EC_GFp_nistp521_method().
+   Applications should rely on the library automatically assigning a suitable
+   EC_METHOD internally upon EC_GROUP construction.
+
+   *Billy Bob Brumley*
+
+ * Deprecated EC_GROUP_new(), EC_GROUP_method_of(), and EC_POINT_method_of().
+   EC_METHOD is now an internal-only concept and a suitable EC_METHOD is
+   assigned internally without application intervention.
+   Users of EC_GROUP_new() should switch to a different suitable constructor.
+
+   *Billy Bob Brumley*
+
  * Add CAdES-BES signature verification support, mostly derived
    from ESSCertIDv2 TS (RFC 5816) contribution by Marek Klein.
 

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -305,7 +305,6 @@ int ecparam_main(int argc, char **argv)
         size_t buf_len = 0, tmp_len = 0;
         const EC_POINT *point;
         int is_prime, len = 0;
-        const EC_METHOD *meth = EC_GROUP_method_of(group);
 
         if ((ec_p = BN_new()) == NULL
                 || (ec_a = BN_new()) == NULL
@@ -317,7 +316,7 @@ int ecparam_main(int argc, char **argv)
             goto end;
         }
 
-        is_prime = (EC_METHOD_get_field_type(meth) == NID_X9_62_prime_field);
+        is_prime = (EC_GROUP_get_field_type(group) == NID_X9_62_prime_field);
         if (!is_prime) {
             BIO_printf(bio_err, "Can only handle X9.62 prime fields\n");
             goto end;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -27,8 +27,7 @@ int EC_GROUP_get_basis_type(const EC_GROUP *group)
 {
     int i;
 
-    if (EC_METHOD_get_field_type(EC_GROUP_method_of(group)) !=
-        NID_X9_62_characteristic_two_field)
+    if (EC_GROUP_get_field_type(group) != NID_X9_62_characteristic_two_field)
         /* everything else is currently not supported */
         return 0;
 
@@ -53,8 +52,7 @@ int EC_GROUP_get_trinomial_basis(const EC_GROUP *group, unsigned int *k)
     if (group == NULL)
         return 0;
 
-    if (EC_METHOD_get_field_type(EC_GROUP_method_of(group)) !=
-        NID_X9_62_characteristic_two_field
+    if (EC_GROUP_get_field_type(group) != NID_X9_62_characteristic_two_field
         || !((group->poly[0] != 0) && (group->poly[1] != 0)
              && (group->poly[2] == 0))) {
         ECerr(EC_F_EC_GROUP_GET_TRINOMIAL_BASIS,
@@ -74,8 +72,7 @@ int EC_GROUP_get_pentanomial_basis(const EC_GROUP *group, unsigned int *k1,
     if (group == NULL)
         return 0;
 
-    if (EC_METHOD_get_field_type(EC_GROUP_method_of(group)) !=
-        NID_X9_62_characteristic_two_field
+    if (EC_GROUP_get_field_type(group) != NID_X9_62_characteristic_two_field
         || !((group->poly[0] != 0) && (group->poly[1] != 0)
              && (group->poly[2] != 0) && (group->poly[3] != 0)
              && (group->poly[4] == 0))) {
@@ -262,7 +259,7 @@ static int ec_asn1_group2fieldid(const EC_GROUP *group, X9_62_FIELDID *field)
     ASN1_OBJECT_free(field->fieldType);
     ASN1_TYPE_free(field->p.other);
 
-    nid = EC_METHOD_get_field_type(EC_GROUP_method_of(group));
+    nid = EC_GROUP_get_field_type(group);
     /* set OID for the field */
     if ((field->fieldType = OBJ_nid2obj(nid)) == NULL) {
         ECerr(EC_F_EC_ASN1_GROUP2FIELDID, ERR_R_OBJ_LIB);

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3195,7 +3195,7 @@ static EC_GROUP *ec_group_new_from_data(OPENSSL_CTX *libctx,
 
     /* If no curve data curve method must handle everything */
     if (curve.data == NULL)
-        return EC_GROUP_new_ex(libctx,
+        return ec_group_new_ex(libctx,
                                curve.meth != NULL ? curve.meth() : NULL);
 
     if ((ctx = BN_CTX_new_ex(libctx)) == NULL) {
@@ -3218,7 +3218,7 @@ static EC_GROUP *ec_group_new_from_data(OPENSSL_CTX *libctx,
 
     if (curve.meth != 0) {
         meth = curve.meth();
-        if (((group = EC_GROUP_new_ex(libctx, meth)) == NULL) ||
+        if (((group = ec_group_new_ex(libctx, meth)) == NULL) ||
             (!(group->meth->group_set_curve(group, p, a, b, ctx)))) {
             ECerr(EC_F_EC_GROUP_NEW_FROM_DATA, ERR_R_EC_LIB);
             goto err;
@@ -3388,17 +3388,13 @@ int ec_curve_nid_from_params(const EC_GROUP *group, BN_CTX *ctx)
     unsigned char *param_bytes = NULL;
     const EC_CURVE_DATA *data;
     const EC_POINT *generator = NULL;
-    const EC_METHOD *meth;
     const BIGNUM *cofactor = NULL;
     /* An array of BIGNUMs for (p, a, b, x, y, order) */
     BIGNUM *bn[NUM_BN_FIELDS] = {NULL, NULL, NULL, NULL, NULL, NULL};
 
-    meth = EC_GROUP_method_of(group);
-    if (meth == NULL)
-        return -1;
     /* Use the optional named curve nid as a search field */
     nid = EC_GROUP_get_curve_name(group);
-    field_type = EC_METHOD_get_field_type(meth);
+    field_type = EC_GROUP_get_field_type(group);
     seed_len = EC_GROUP_get_seed_len(group);
     seed = EC_GROUP_get0_seed(group);
     cofactor = EC_GROUP_get0_cofactor(group);

--- a/crypto/ec/ec_cvt.c
+++ b/crypto/ec/ec_cvt.c
@@ -54,7 +54,7 @@ EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
         meth = EC_GFp_mont_method();
 #endif
 
-    ret = EC_GROUP_new_ex(bn_get_lib_ctx(ctx), meth);
+    ret = ec_group_new_ex(bn_get_lib_ctx(ctx), meth);
     if (ret == NULL)
         return NULL;
 
@@ -75,7 +75,7 @@ EC_GROUP *EC_GROUP_new_curve_GF2m(const BIGNUM *p, const BIGNUM *a,
 
     meth = EC_GF2m_simple_method();
 
-    ret = EC_GROUP_new_ex(bn_get_lib_ctx(ctx), meth);
+    ret = ec_group_new_ex(bn_get_lib_ctx(ctx), meth);
     if (ret == NULL)
         return NULL;
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -117,10 +117,9 @@ EC_KEY *EC_KEY_copy(EC_KEY *dest, const EC_KEY *src)
     dest->libctx = src->libctx;
     /* copy the parameters */
     if (src->group != NULL) {
-        const EC_METHOD *meth = EC_GROUP_method_of(src->group);
         /* clear the old group */
         EC_GROUP_free(dest->group);
-        dest->group = EC_GROUP_new_ex(src->libctx, meth);
+        dest->group = ec_group_new_ex(src->libctx, src->group->meth);
         if (dest->group == NULL)
             return NULL;
         if (!EC_GROUP_copy(dest->group, src->group))
@@ -398,7 +397,7 @@ static int ec_key_public_range_check(BN_CTX *ctx, const EC_KEY *key)
     if (!EC_POINT_get_affine_coordinates(key->group, key->pub_key, x, y, ctx))
         goto err;
 
-    if (EC_METHOD_get_field_type(key->group->meth) == NID_X9_62_prime_field) {
+    if (EC_GROUP_get_field_type(key->group) == NID_X9_62_prime_field) {
         if (BN_is_negative(x)
             || BN_cmp(x, key->group->field) >= 0
             || BN_is_negative(y)

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -23,7 +23,7 @@
 
 /* functions for EC_GROUP objects */
 
-EC_GROUP *EC_GROUP_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth)
+EC_GROUP *ec_group_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth)
 {
     EC_GROUP *ret;
 
@@ -65,11 +65,13 @@ EC_GROUP *EC_GROUP_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth)
     return NULL;
 }
 
-#ifndef FIPS_MODULE
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# ifndef FIPS_MODULE
 EC_GROUP *EC_GROUP_new(const EC_METHOD *meth)
 {
-    return EC_GROUP_new_ex(NULL, meth);
+    return ec_group_new_ex(NULL, meth);
 }
+# endif
 #endif
 
 void EC_pre_comp_free(EC_GROUP *group)
@@ -255,7 +257,7 @@ EC_GROUP *EC_GROUP_dup(const EC_GROUP *a)
     if (a == NULL)
         return NULL;
 
-    if ((t = EC_GROUP_new_ex(a->libctx, a->meth)) == NULL)
+    if ((t = ec_group_new_ex(a->libctx, a->meth)) == NULL)
         return NULL;
     if (!EC_GROUP_copy(t, a))
         goto err;
@@ -270,6 +272,7 @@ EC_GROUP *EC_GROUP_dup(const EC_GROUP *a)
         return t;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group)
 {
     return group->meth;
@@ -279,6 +282,7 @@ int EC_METHOD_get_field_type(const EC_METHOD *meth)
 {
     return meth->field_type;
 }
+#endif
 
 static int ec_precompute_mont_data(EC_GROUP *);
 
@@ -475,6 +479,11 @@ const BIGNUM *EC_GROUP_get0_field(const EC_GROUP *group)
     return group->field;
 }
 
+int EC_GROUP_get_field_type(const EC_GROUP *group)
+{
+    return group->meth->field_type;
+}
+
 void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag)
 {
     group->asn1_flag = flag;
@@ -602,8 +611,7 @@ int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx)
 #endif
 
     /* compare the field types */
-    if (EC_METHOD_get_field_type(EC_GROUP_method_of(a)) !=
-        EC_METHOD_get_field_type(EC_GROUP_method_of(b)))
+    if (EC_GROUP_get_field_type(a) != EC_GROUP_get_field_type(b))
         return 1;
     /* compare the curve name (if present in both) */
     if (EC_GROUP_get_curve_name(a) && EC_GROUP_get_curve_name(b) &&
@@ -777,10 +785,12 @@ EC_POINT *EC_POINT_dup(const EC_POINT *a, const EC_GROUP *group)
     return t;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 const EC_METHOD *EC_POINT_method_of(const EC_POINT *point)
 {
     return point->meth;
 }
+#endif
 
 int EC_POINT_set_to_infinity(const EC_GROUP *group, EC_POINT *point)
 {

--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -31,6 +31,10 @@
 /* Curve does not support signing operations */
 #define EC_FLAGS_NO_SIGN        0x4
 
+#ifdef OPENSSL_NO_DEPRECATED_3_0
+typedef struct ec_method_st EC_METHOD;
+#endif
+
 /*
  * Structure details are not part of the exported interface, so all this may
  * change in future versions.
@@ -584,6 +588,15 @@ void ec_GFp_nistp_recode_scalar_bits(unsigned char *sign,
                                      unsigned char *digit, unsigned char in);
 #endif
 int ec_group_simple_order_bits(const EC_GROUP *group);
+
+/**
+ *  Creates a new EC_GROUP object
+ *  \param   libctx The associated library context or NULL for the default
+ *                  library context
+ *  \param   meth   EC_METHOD to use
+ *  \return  newly created EC_GROUP object or NULL in case of an error.
+ */
+EC_GROUP *ec_group_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth);
 
 #ifdef ECP_NISTZ256_ASM
 /** Returns GFp methods using montgomery multiplication, with x86-64 optimized

--- a/crypto/ec/eck_prn.c
+++ b/crypto/ec/eck_prn.c
@@ -115,7 +115,7 @@ int ECPKParameters_print(BIO *bp, const EC_GROUP *x, int off)
         /* explicit parameters */
         int is_char_two = 0;
         point_conversion_form_t form;
-        int tmp_nid = EC_METHOD_get_field_type(EC_GROUP_method_of(x));
+        int tmp_nid = EC_GROUP_get_field_type(x);
 
         if (tmp_nid == NID_X9_62_characteristic_two_field)
             is_char_two = 1;

--- a/crypto/ec/ecp_s390x_nistp.c
+++ b/crypto/ec/ecp_s390x_nistp.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * EC_METHOD low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <openssl/err.h>

--- a/doc/man3/EC_GFp_simple_method.pod
+++ b/doc/man3/EC_GFp_simple_method.pod
@@ -8,6 +8,8 @@ EC_GFp_simple_method, EC_GFp_mont_method, EC_GFp_nist_method, EC_GFp_nistp224_me
 
  #include <openssl/ec.h>
 
+Deprecated since OpenSSL 3.0:
+
  const EC_METHOD *EC_GFp_simple_method(void);
  const EC_METHOD *EC_GFp_mont_method(void);
  const EC_METHOD *EC_GFp_nist_method(void);
@@ -20,6 +22,10 @@ EC_GFp_simple_method, EC_GFp_mont_method, EC_GFp_nist_method, EC_GFp_nistp224_me
  int EC_METHOD_get_field_type(const EC_METHOD *meth);
 
 =head1 DESCRIPTION
+
+
+All const EC_METHOD *EC_GF* functions were deprecated in OpenSSL 3.0, since
+EC_METHOD is no longer a public concept.
 
 The Elliptic Curve library provides a number of different implementations through a single common interface.
 When constructing a curve using EC_GROUP_new (see L<EC_GROUP_new(3)>) an
@@ -39,10 +45,8 @@ The functions EC_GFp_nistp224_method, EC_GFp_nistp256_method and EC_GFp_nistp521
 optimised implementations for the NIST P224, P256 and P521 curves respectively. Note, however, that these
 implementations are not available on all platforms.
 
-EC_METHOD_get_field_type identifies what type of field the EC_METHOD structure supports, which will be either
-F2^m or Fp. If the field type is Fp then the value B<NID_X9_62_prime_field> is returned. If the field type is
-F2^m then the value B<NID_X9_62_characteristic_two_field> is returned. These values are defined in the
-obj_mac.h header file.
+EC_METHOD_get_field_type() was deprecated in OpenSSL 3.0.
+Applications should use EC_GROUP_get_field_type() as a replacement (see L<EC_GROUP_copy(3)>).
 
 =head1 RETURN VALUES
 
@@ -56,6 +60,14 @@ L<crypto(7)>, L<EC_GROUP_new(3)>, L<EC_GROUP_copy(3)>,
 L<EC_POINT_new(3)>, L<EC_POINT_add(3)>, L<EC_KEY_new(3)>,
 L<d2i_ECPKParameters(3)>,
 L<BN_mod_mul_montgomery(3)>
+
+=head1 HISTORY
+
+EC_GFp_simple_method(), EC_GFp_mont_method(void),
+EC_GFp_nist_method(), EC_GFp_nistp224_method(),
+EC_GFp_nistp256_method(), EC_GFp_nistp521_method(),
+EC_GF2m_simple_method(), and EC_METHOD_get_field_type()
+were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_GROUP_copy.pod
+++ b/doc/man3/EC_GROUP_copy.pod
@@ -22,8 +22,6 @@ EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field
  int EC_GROUP_copy(EC_GROUP *dst, const EC_GROUP *src);
  EC_GROUP *EC_GROUP_dup(const EC_GROUP *src);
 
- const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
-
  int EC_GROUP_set_generator(EC_GROUP *group, const EC_POINT *generator,
                             const BIGNUM *order, const BIGNUM *cofactor);
  const EC_POINT *EC_GROUP_get0_generator(const EC_GROUP *group);
@@ -63,6 +61,10 @@ EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field
  int EC_GROUP_get_pentanomial_basis(const EC_GROUP *, unsigned int *k1,
                                     unsigned int *k2, unsigned int *k3);
 
+Deprecated since OpenSSL 3.0:
+
+ const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
+
 =head1 DESCRIPTION
 
 EC_GROUP_copy() copies the curve B<src> into B<dst>. Both B<src> and B<dst> must use the same EC_METHOD.
@@ -71,6 +73,7 @@ EC_GROUP_dup() creates a new EC_GROUP object and copies the content from B<src> 
 EC_GROUP object.
 
 EC_GROUP_method_of() obtains the EC_METHOD of B<group>.
+This function was deprecated in OpenSSL 3.0, since EC_METHOD is no longer a public concept.
 
 EC_GROUP_set_generator() sets curve parameters that must be agreed by all participants using the curve. These
 parameters include the B<generator>, the B<order> and the B<cofactor>. The B<generator> is a well defined point on the
@@ -140,8 +143,12 @@ built-in curves within the library provide seed values that can be obtained. It 
 EC_GROUP_set_seed() and passing a pointer to a memory block, along with the length of the seed. Again, the EC library will not use
 this seed value, although it will be preserved in any ASN1 based communications.
 
-EC_GROUP_get_degree() gets the degree of the field. For Fp fields this will be the number of bits in p.  For F2^m fields this will be
-the value m.
+EC_GROUP_get_degree() gets the degree of the field.
+For Fp fields this will be the number of bits in p.
+For F2^m fields this will be the value m.
+
+EC_GROUP_get_field_type() identifies what type of field the EC_GROUP structure supports,
+which will be either F2^m or Fp.
 
 The function EC_GROUP_check_discriminant() calculates the discriminant for the curve and verifies that it is valid.
 For a curve defined over Fp the discriminant is given by the formula 4*a^3 + 27*b^2 whilst for F2^m curves the discriminant is
@@ -202,6 +209,10 @@ EC_GROUP_get_point_conversion_form() returns the point_conversion_form for B<gro
 
 EC_GROUP_get_degree() returns the degree for B<group> or 0 if the operation is not supported by the underlying group implementation.
 
+EC_GROUP_get_field_type() returns either B<NID_X9_62_prime_field> for prime curves
+or B<NID_X9_62_characteristic_two_field> for binary curves;
+these values are defined in the obj_mac.h header file.
+
 EC_GROUP_check_named_curve() returns the nid of the matching named curve, otherwise it returns 0 for no match, or -1 on error.
 
 EC_GROUP_get0_order() returns an internal pointer to the group order.
@@ -229,7 +240,9 @@ L<EC_GFp_simple_method(3)>, L<d2i_ECPKParameters(3)>
 
 =head1 HISTORY
 
-The EC_GROUP_check_named_curve() function was added in OpenSSL 3.0.
+EC_GROUP_method_of() was deprecated in OpenSSL 3.0.
+
+EC_GROUP_check_named_curve() and EC_GROUP_get_field_type() were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -4,7 +4,6 @@
 
 EC_GROUP_get_ecparameters,
 EC_GROUP_get_ecpkparameters,
-EC_GROUP_new_ex,
 EC_GROUP_new,
 EC_GROUP_new_from_ecparameters,
 EC_GROUP_new_from_ecpkparameters,
@@ -27,8 +26,6 @@ objects
 
  #include <openssl/ec.h>
 
- EC_GROUP *EC_GROUP_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth);
- EC_GROUP *EC_GROUP_new(const EC_METHOD *meth);
  EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
  EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params)
  void EC_GROUP_free(EC_GROUP *group);
@@ -62,6 +59,7 @@ Deprecated since OpenSSL 3.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
+ EC_GROUP *EC_GROUP_new(const EC_METHOD *meth);
  void EC_GROUP_clear_free(EC_GROUP *group);
 
 =head1 DESCRIPTION
@@ -83,19 +81,19 @@ Operations in a binary field are performed relative to an
 B<irreducible polynomial>. All such curves with OpenSSL use a trinomial or a
 pentanomial for this parameter.
 
-A new curve can be constructed by calling EC_GROUP_new_ex(), using the
+Although deprecated since OpenSSL 3.0 and should no longer be used,
+a new curve can be constructed by calling EC_GROUP_new(), using the
 implementation provided by B<meth> (see L<EC_GFp_simple_method(3)>) and
 associated with the library context B<ctx> (see L<OPENSSL_CTX(3)>).
 The B<ctx> parameter may be NULL in which case the default library context is
 used.
 It is then necessary to call EC_GROUP_set_curve() to set the curve parameters.
+Applications should instead use one of the other EC_GROUP_new_* constructors.
+
 EC_GROUP_new_from_ecparameters() will create a group from the
 specified B<params> and
 EC_GROUP_new_from_ecpkparameters() will create a group from the specific PK
 B<params>.
-
-EC_GROUP_new() is the same as EC_GROUP_new_ex() except that the library context
-used is always the default library context.
 
 EC_GROUP_set_curve() sets the curve parameters B<p>, B<a> and B<b>. For a curve
 over Fp B<p> is the prime for the field. For a curve over F2^m B<p> represents
@@ -182,7 +180,9 @@ L<OPENSSL_CTX(3)>
 
 =item *
 
-EC_GROUP_new_ex() and EC_GROUP_new_by_curve_name_ex() were added in OpenSSL 3.0.
+EC_GROUP_new() was deprecated in OpenSSL 3.0.
+
+EC_GROUP_new_by_curve_name_ex() was added in OpenSSL 3.0.
 
 =item *
 

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -38,7 +38,6 @@ EC_POINT_hex2point
  void EC_POINT_clear_free(EC_POINT *point);
  int EC_POINT_copy(EC_POINT *dst, const EC_POINT *src);
  EC_POINT *EC_POINT_dup(const EC_POINT *src, const EC_GROUP *group);
- const EC_METHOD *EC_POINT_method_of(const EC_POINT *point);
  int EC_POINT_set_to_infinity(const EC_GROUP *group, EC_POINT *point);
  int EC_POINT_set_affine_coordinates(const EC_GROUP *group, EC_POINT *p,
                                      const BIGNUM *x, const BIGNUM *y,
@@ -68,6 +67,7 @@ EC_POINT_hex2point
 
 Deprecated since OpenSSL 3.0:
 
+ const EC_METHOD *EC_POINT_method_of(const EC_POINT *point);
  int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
                                               EC_POINT *p,
                                               const BIGNUM *x, const BIGNUM *y,
@@ -116,6 +116,8 @@ EC_POINT_dup() creates a new B<EC_POINT> object and copies the content from
 B<src> to the newly created B<EC_POINT> object.
 
 EC_POINT_method_of() obtains the B<EC_METHOD> associated with B<point>.
+This function was deprecated in OpenSSL 3.0, since EC_METHOD is no longer a
+public concept.
 
 A valid point on a curve is the special point at infinity. A point is set to
 be at infinity by calling EC_POINT_set_to_infinity().
@@ -249,6 +251,7 @@ L<EC_GFp_simple_method(3)>, L<d2i_ECPKParameters(3)>
 
 =head1 HISTORY
 
+EC_POINT_method_of(),
 EC_POINT_set_Jprojective_coordinates_GFp(),
 EC_POINT_get_Jprojective_coordinates_GFp(),
 EC_POINT_set_affine_coordinates_GFp(), EC_POINT_get_affine_coordinates_GFp(),

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -47,7 +47,9 @@ typedef enum {
     POINT_CONVERSION_HYBRID = 6
 } point_conversion_form_t;
 
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef struct ec_method_st EC_METHOD;
+#  endif
 typedef struct ec_group_st EC_GROUP;
 typedef struct ec_point_st EC_POINT;
 typedef struct ecpk_parameters_st ECPKPARAMETERS;
@@ -61,33 +63,33 @@ typedef struct ec_parameters_st ECPARAMETERS;
  *  optimized methods.
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GFp_simple_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GFp_simple_method(void))
 
 /** Returns GFp methods using montgomery multiplication.
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GFp_mont_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GFp_mont_method(void))
 
 /** Returns GFp methods using optimized methods for NIST recommended curves
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GFp_nist_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GFp_nist_method(void))
 
 #  ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
 /** Returns 64-bit optimized methods for nistp224
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GFp_nistp224_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GFp_nistp224_method(void))
 
 /** Returns 64-bit optimized methods for nistp256
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GFp_nistp256_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GFp_nistp256_method(void))
 
 /** Returns 64-bit optimized methods for nistp521
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GFp_nistp521_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GFp_nistp521_method(void))
 #  endif
 
 #  ifndef OPENSSL_NO_EC2M
@@ -98,7 +100,7 @@ const EC_METHOD *EC_GFp_nistp521_method(void);
 /** Returns the basic GF2m ec method
  *  \return  EC_METHOD object
  */
-const EC_METHOD *EC_GF2m_simple_method(void);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GF2m_simple_method(void))
 
 #  endif
 
@@ -108,20 +110,10 @@ const EC_METHOD *EC_GF2m_simple_method(void);
 
 /**
  *  Creates a new EC_GROUP object
- *  \param   libctx The associated library context or NULL for the default
- *                  library context
  *  \param   meth   EC_METHOD to use
  *  \return  newly created EC_GROUP object or NULL in case of an error.
  */
-EC_GROUP *EC_GROUP_new_ex(OPENSSL_CTX *libctx, const EC_METHOD *meth);
-
-/**
- *  Creates a new EC_GROUP object. Same as EC_GROUP_new_ex with NULL for the
- *  library context.
- *  \param   meth   EC_METHOD to use
- *  \return  newly created EC_GROUP object or NULL in case of an error.
- */
-EC_GROUP *EC_GROUP_new(const EC_METHOD *meth);
+DEPRECATEDIN_3_0(EC_GROUP *EC_GROUP_new(const EC_METHOD *meth))
 
 /** Frees a EC_GROUP object
  *  \param  group  EC_GROUP object to be freed.
@@ -151,13 +143,13 @@ EC_GROUP *EC_GROUP_dup(const EC_GROUP *src);
  *  \param  group  EC_GROUP object
  *  \return EC_METHOD used in this EC_GROUP object.
  */
-const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group))
 
 /** Returns the field type of the EC_METHOD.
  *  \param  meth  EC_METHOD object
  *  \return NID of the underlying field type OID.
  */
-int EC_METHOD_get_field_type(const EC_METHOD *meth);
+DEPRECATEDIN_3_0(int EC_METHOD_get_field_type(const EC_METHOD *meth))
 
 /** Sets the generator and its order/cofactor of a EC_GROUP object.
  *  \param  group      EC_GROUP object
@@ -234,6 +226,12 @@ int EC_GROUP_get_curve_name(const EC_GROUP *group);
  *  \return the group field
  */
 const BIGNUM *EC_GROUP_get0_field(const EC_GROUP *group);
+
+/** Returns the field type of the EC_GROUP.
+ *  \param  group  EC_GROUP object
+ *  \return NID of the underlying field type OID.
+ */
+int EC_GROUP_get_field_type(const EC_GROUP *group);
 
 void EC_GROUP_set_asn1_flag(EC_GROUP *group, int flag);
 int EC_GROUP_get_asn1_flag(const EC_GROUP *group);
@@ -493,7 +491,7 @@ EC_POINT *EC_POINT_dup(const EC_POINT *src, const EC_GROUP *group);
  *  \param  point  EC_POINT object
  *  \return the EC_METHOD used
  */
-const EC_METHOD *EC_POINT_method_of(const EC_POINT *point);
+DEPRECATEDIN_3_0(const EC_METHOD *EC_POINT_method_of(const EC_POINT *point))
 
 /** Sets a point to infinity (neutral element)
  *  \param  group  underlying EC_GROUP object

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -621,7 +621,7 @@ static int tls1_check_pkey_comp(SSL *s, EVP_PKEY *pkey)
              */
             return 1;
     } else {
-        int field_type = EC_METHOD_get_field_type(EC_GROUP_method_of(grp));
+        int field_type = EC_GROUP_get_field_type(grp);
 
         if (field_type == NID_X9_62_prime_field)
             comp_id = TLSEXT_ECPOINTFORMAT_ansiX962_compressed_prime;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -40,7 +40,7 @@ X509_NAME_delete_entry                  40	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_verify_recover        41	3_0_0	EXIST::FUNCTION:
 UI_set_method                           42	3_0_0	EXIST::FUNCTION:
 PKCS7_ISSUER_AND_SERIAL_it              43	3_0_0	EXIST::FUNCTION:
-EC_GROUP_method_of                      44	3_0_0	EXIST::FUNCTION:EC
+EC_GROUP_method_of                      44	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 RSA_blinding_on                         45	3_0_0	EXIST::FUNCTION:RSA
 X509_get0_signature                     47	3_0_0	EXIST::FUNCTION:
 X509_REVOKED_get0_extensions            48	3_0_0	EXIST::FUNCTION:
@@ -1181,7 +1181,7 @@ PKCS7_add_attribute                     1207	3_0_0	EXIST::FUNCTION:
 ENGINE_register_DSA                     1208	3_0_0	EXIST::FUNCTION:ENGINE
 OPENSSL_LH_node_stats                   1209	3_0_0	EXIST::FUNCTION:STDIO
 X509_policy_tree_free                   1210	3_0_0	EXIST::FUNCTION:
-EC_GFp_simple_method                    1211	3_0_0	EXIST::FUNCTION:EC
+EC_GFp_simple_method                    1211	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 X509_it                                 1212	3_0_0	EXIST::FUNCTION:
 d2i_PROXY_POLICY                        1213	3_0_0	EXIST::FUNCTION:
 MDC2_Update                             1214	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MDC2
@@ -1197,7 +1197,7 @@ X509_time_adj                           1223	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_find_str                  1224	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_flags             1225	3_0_0	EXIST::FUNCTION:
 OPENSSL_DIR_end                         1226	3_0_0	EXIST::FUNCTION:
-EC_GROUP_new                            1227	3_0_0	EXIST::FUNCTION:EC
+EC_GROUP_new                            1227	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 CMS_SignerInfo_get0_pkey_ctx            1228	3_0_0	EXIST::FUNCTION:CMS
 d2i_ASN1_PRINTABLESTRING                1229	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_ktri_cert_cmp         1230	3_0_0	EXIST::FUNCTION:CMS
@@ -2116,7 +2116,7 @@ EVP_MD_flags                            2161	3_0_0	EXIST::FUNCTION:
 OPENSSL_sk_set                          2162	3_0_0	EXIST::FUNCTION:
 OCSP_request_sign                       2163	3_0_0	EXIST::FUNCTION:OCSP
 BN_GF2m_mod_solve_quad                  2164	3_0_0	EXIST::FUNCTION:EC2M
-EC_POINT_method_of                      2165	3_0_0	EXIST::FUNCTION:EC
+EC_POINT_method_of                      2165	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 PKCS7_ENCRYPT_it                        2166	3_0_0	EXIST::FUNCTION:
 AUTHORITY_INFO_ACCESS_it                2167	3_0_0	EXIST::FUNCTION:
 X509_EXTENSION_create_by_NID            2168	3_0_0	EXIST::FUNCTION:
@@ -2183,7 +2183,7 @@ POLICY_CONSTRAINTS_new                  2230	3_0_0	EXIST::FUNCTION:
 OTHERNAME_new                           2231	3_0_0	EXIST::FUNCTION:
 BN_rshift                               2232	3_0_0	EXIST::FUNCTION:
 i2d_GENERAL_NAMES                       2233	3_0_0	EXIST::FUNCTION:
-EC_METHOD_get_field_type                2234	3_0_0	EXIST::FUNCTION:EC
+EC_METHOD_get_field_type                2234	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 ENGINE_set_name                         2235	3_0_0	EXIST::FUNCTION:ENGINE
 TS_TST_INFO_get_policy_id               2236	3_0_0	EXIST::FUNCTION:TS
 PKCS7_SIGNER_INFO_set                   2237	3_0_0	EXIST::FUNCTION:
@@ -2607,7 +2607,7 @@ EVP_PKEY_assign                         2662	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_ofb                         2663	3_0_0	EXIST::FUNCTION:
 CMS_data                                2664	3_0_0	EXIST::FUNCTION:CMS
 X509_load_cert_file                     2665	3_0_0	EXIST::FUNCTION:
-EC_GFp_nistp521_method                  2667	3_0_0	EXIST::FUNCTION:EC,EC_NISTP_64_GCC_128
+EC_GFp_nistp521_method                  2667	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC_NISTP_64_GCC_128
 ECDSA_SIG_free                          2668	3_0_0	EXIST::FUNCTION:EC
 d2i_PKCS12_BAGS                         2669	3_0_0	EXIST::FUNCTION:
 RSA_public_encrypt                      2670	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RSA
@@ -2743,7 +2743,7 @@ CMS_dataFinal                           2802	3_0_0	EXIST::FUNCTION:CMS
 ASN1_TIME_it                            2803	3_0_0	EXIST::FUNCTION:
 ENGINE_get_static_state                 2804	3_0_0	EXIST::FUNCTION:ENGINE
 EC_KEY_set_asn1_flag                    2805	3_0_0	EXIST::FUNCTION:EC
-EC_GFp_mont_method                      2806	3_0_0	EXIST::FUNCTION:EC
+EC_GFp_mont_method                      2806	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 OPENSSL_asc2uni                         2807	3_0_0	EXIST::FUNCTION:
 TS_REQ_new                              2808	3_0_0	EXIST::FUNCTION:TS
 ENGINE_register_all_DH                  2809	3_0_0	EXIST::FUNCTION:ENGINE
@@ -2760,7 +2760,7 @@ CRYPTO_secure_used                      2819	3_0_0	EXIST::FUNCTION:
 d2i_X509_CRL_INFO                       2820	3_0_0	EXIST::FUNCTION:
 X509_CRL_get_issuer                     2821	3_0_0	EXIST::FUNCTION:
 d2i_SCT_LIST                            2822	3_0_0	EXIST::FUNCTION:CT
-EC_GFp_nist_method                      2823	3_0_0	EXIST::FUNCTION:EC
+EC_GFp_nist_method                      2823	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 SCT_free                                2824	3_0_0	EXIST::FUNCTION:CT
 TS_TST_INFO_get_msg_imprint             2825	3_0_0	EXIST::FUNCTION:TS
 X509v3_addr_add_range                   2826	3_0_0	EXIST::FUNCTION:RFC3779
@@ -2800,7 +2800,7 @@ X509_EXTENSION_dup                      2861	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_new                       2862	3_0_0	EXIST::FUNCTION:
 BIO_socket_nbio                         2863	3_0_0	EXIST::FUNCTION:SOCK
 EVP_CIPHER_set_asn1_iv                  2864	3_0_0	EXIST::FUNCTION:
-EC_GFp_nistp224_method                  2865	3_0_0	EXIST::FUNCTION:EC,EC_NISTP_64_GCC_128
+EC_GFp_nistp224_method                  2865	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC_NISTP_64_GCC_128
 BN_swap                                 2866	3_0_0	EXIST::FUNCTION:
 d2i_ECParameters                        2867	3_0_0	EXIST::FUNCTION:EC
 X509_NAME_add_entry_by_OBJ              2868	3_0_0	EXIST::FUNCTION:
@@ -3013,7 +3013,7 @@ X509_REQ_get_X509_PUBKEY                3077	3_0_0	EXIST::FUNCTION:
 ENGINE_load_private_key                 3078	3_0_0	EXIST::FUNCTION:ENGINE
 GENERAL_NAMES_new                       3079	3_0_0	EXIST::FUNCTION:
 i2d_POLICYQUALINFO                      3080	3_0_0	EXIST::FUNCTION:
-EC_GF2m_simple_method                   3081	3_0_0	EXIST::FUNCTION:EC,EC2M
+EC_GF2m_simple_method                   3081	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC2M
 RSA_get_method                          3082	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RSA
 d2i_ASRange                             3083	3_0_0	EXIST::FUNCTION:RFC3779
 CMS_ContentInfo_new                     3084	3_0_0	EXIST::FUNCTION:CMS
@@ -3376,7 +3376,7 @@ ERR_get_next_error_library              3446	3_0_0	EXIST::FUNCTION:
 OCSP_RESPONSE_print                     3447	3_0_0	EXIST::FUNCTION:OCSP
 BN_get_rfc3526_prime_2048               3448	3_0_0	EXIST::FUNCTION:DH
 BIO_new_bio_pair                        3449	3_0_0	EXIST::FUNCTION:
-EC_GFp_nistp256_method                  3450	3_0_0	EXIST::FUNCTION:EC,EC_NISTP_64_GCC_128
+EC_GFp_nistp256_method                  3450	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC_NISTP_64_GCC_128
 BIO_method_type                         3451	3_0_0	EXIST::FUNCTION:
 ECPKParameters_print                    3452	3_0_0	EXIST::FUNCTION:EC
 EVP_rc4                                 3453	3_0_0	EXIST::FUNCTION:RC4
@@ -4683,7 +4683,6 @@ ERR_set_error                           ?	3_0_0	EXIST::FUNCTION:
 ERR_vset_error                          ?	3_0_0	EXIST::FUNCTION:
 X509_get0_authority_issuer              ?	3_0_0	EXIST::FUNCTION:
 X509_get0_authority_serial              ?	3_0_0	EXIST::FUNCTION:
-EC_GROUP_new_ex                         ?	3_0_0	EXIST::FUNCTION:EC
 EC_GROUP_new_by_curve_name_ex           ?	3_0_0	EXIST::FUNCTION:EC
 EC_KEY_new_ex                           ?	3_0_0	EXIST::FUNCTION:EC
 EC_KEY_new_by_curve_name_ex             ?	3_0_0	EXIST::FUNCTION:EC
@@ -5094,6 +5093,7 @@ EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md_name ?	3_0_0	EXIST::FUNCTION:RSA
 OSSL_PROVIDER_do_all                    ?	3_0_0	EXIST::FUNCTION:
+EC_GROUP_get_field_type                 ?	3_0_0	EXIST::FUNCTION:EC
 X509_PUBKEY_eq                          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_eq                             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_parameters_eq                  ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Last TODO item from #8332! Quoting from there:

* Entire concept of `EC_METHOD` should not be public facing.

It was surprisingly easy to update the tests.

~~It's WiP because I'll document everything when I get some high level confirmation that:~~

1. ~~It's OK to deprecate all these functions~~
2. ~~It's OK to add `EC_GROUP_get_field_type`~~

Edit: finally out of WiP after ea1cd6bfbce0a10102a275fa73536c91896e990f. Thanks @levitte @t8m and @romen for the feedback.