### PR TITLE
[WIP] Remove OPENSSL_ia32cap overrides in various test scripts

### DIFF
--- a/engines/e_ossltest.c
+++ b/engines/e_ossltest.c
@@ -378,6 +378,7 @@ static int bind_ossltest(ENGINE *e)
         return 0;
     }
 
+    OBJ_NAME_remove("AES-128-CBC-HMAC-SHA1", OBJ_NAME_TYPE_CIPHER_METH);
     return 1;
 }
 

--- a/test/recipes/70-test_comp.t
+++ b/test/recipes/70-test_comp.t
@@ -27,8 +27,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.3 or TLSv1.2 enabled"
     if disabled("tls1_3") && disabled("tls1_2");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 use constant {
     MULTIPLE_COMPRESSIONS => 0,
     NON_NULL_COMPRESSION => 1

--- a/test/recipes/70-test_key_share.t
+++ b/test/recipes/70-test_key_share.t
@@ -63,8 +63,6 @@ plan skip_all => "$test_name needs TLS1.3 enabled"
 plan skip_all => "$test_name needs EC or DH enabled"
     if disabled("ec") && disabled("dh");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_renegotiation.t
+++ b/test/recipes/70-test_renegotiation.t
@@ -28,7 +28,6 @@ plan skip_all => "$test_name needs TLS <= 1.2 enabled"
 
 plan tests => 5;
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslcbcpadding.t
+++ b/test/recipes/70-test_sslcbcpadding.t
@@ -28,7 +28,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.2 enabled"
     if disabled("tls1_2");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     \&add_maximal_padding_filter,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslcertstatus.t
+++ b/test/recipes/70-test_sslcertstatus.t
@@ -30,7 +30,6 @@ plan skip_all => "$test_name needs TLS enabled"
     if alldisabled(available_protocols("tls"))
        || (!disabled("tls1_3") && disabled("tls1_2"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     \&certstatus_filter,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -41,7 +41,6 @@ use constant {
 my $testtype;
 my $fatal_alert = 0;    # set by filter on fatal alert
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     \&inject_duplicate_extension_clienthello,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslmessages.t
+++ b/test/recipes/70-test_sslmessages.t
@@ -29,8 +29,6 @@ plan skip_all => "$test_name needs TLS enabled"
     if alldisabled(available_protocols("tls"))
        || (!disabled("tls1_3") && disabled("tls1_2"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -28,7 +28,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.2 enabled"
     if disabled("tls1_2");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     \&add_empty_recs_filter,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslsessiontick.t
+++ b/test/recipes/70-test_sslsessiontick.t
@@ -27,8 +27,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs SSLv3, TLSv1, TLSv1.1 or TLSv1.2 enabled"
     if alldisabled(("ssl3", "tls1", "tls1_1", "tls1_2"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 sub checkmessages($$$$$$);
 sub clearclient();
 sub clearall();

--- a/test/recipes/70-test_sslsigalgs.t
+++ b/test/recipes/70-test_sslsigalgs.t
@@ -26,7 +26,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS1.2 or TLS1.3 enabled"
     if disabled("tls1_2") && disabled("tls1_3");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslsignature.t
+++ b/test/recipes/70-test_sslsignature.t
@@ -26,7 +26,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS enabled"
     if alldisabled(available_protocols("tls"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslskewith0p.t
+++ b/test/recipes/70-test_sslskewith0p.t
@@ -29,7 +29,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS enabled"
     if alldisabled(available_protocols("tls"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     \&ske_0_p_filter,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslversions.t
+++ b/test/recipes/70-test_sslversions.t
@@ -42,8 +42,6 @@ plan skip_all => "$test_name needs TLS1.3, TLS1.2 and TLS1.1 enabled"
        || disabled("tls1_2")
        || disabled("tls1_1");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_sslvertol.t
+++ b/test/recipes/70-test_sslvertol.t
@@ -26,7 +26,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS enabled"
     if alldisabled(available_protocols("tls"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
 my $proxy = TLSProxy::Proxy->new(
     \&vers_tolerance_filter,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_tls13alerts.t
+++ b/test/recipes/70-test_tls13alerts.t
@@ -26,8 +26,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS1.3 enabled"
     if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_tls13cookie.t
+++ b/test/recipes/70-test_tls13cookie.t
@@ -26,8 +26,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS1.3 enabled"
     if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 use constant {
     COOKIE_ONLY => 0,
     COOKIE_AND_KEY_SHARE => 1

--- a/test/recipes/70-test_tls13downgrade.t
+++ b/test/recipes/70-test_tls13downgrade.t
@@ -28,8 +28,6 @@ plan skip_all => "$test_name needs TLS1.3 and TLS1.2 enabled"
        || (disabled("ec") && disabled("dh"))
        || disabled("tls1_2");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -26,8 +26,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLS1.3 enabled"
     if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_tls13kexmodes.t
+++ b/test/recipes/70-test_tls13kexmodes.t
@@ -31,9 +31,6 @@ plan skip_all => "$test_name needs TLSv1.3 enabled"
 plan skip_all => "$test_name needs EC enabled"
     if disabled("ec");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
-
 @handmessages = (
     [TLSProxy::Message::MT_CLIENT_HELLO,
         checkhandshake::ALL_HANDSHAKES],

--- a/test/recipes/70-test_tls13messages.t
+++ b/test/recipes/70-test_tls13messages.t
@@ -31,8 +31,6 @@ plan skip_all => "$test_name needs TLSv1.3 enabled"
 plan skip_all => "$test_name needs EC enabled"
     if disabled("ec");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 @handmessages = (
     [TLSProxy::Message::MT_CLIENT_HELLO,
         checkhandshake::ALL_HANDSHAKES],

--- a/test/recipes/70-test_tls13psk.t
+++ b/test/recipes/70-test_tls13psk.t
@@ -27,8 +27,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.3 enabled"
     if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 my $proxy = TLSProxy::Proxy->new(
     undef,
     cmdstr(app(["openssl"]), display => 1),

--- a/test/recipes/70-test_tlsextms.t
+++ b/test/recipes/70-test_tlsextms.t
@@ -27,8 +27,6 @@ plan skip_all => "$test_name needs the sock feature enabled"
 plan skip_all => "$test_name needs TLSv1.0, TLSv1.1 or TLSv1.2 enabled"
     if disabled("tls1") && disabled("tls1_1") && disabled("tls1_2");
 
-$ENV{OPENSSL_ia32cap} = '~0x200000200000000';
-
 sub checkmessages($$$$$);
 sub setrmextms($$);
 sub clearall();


### PR DESCRIPTION
The removed override was: OPENSSL_ia32cap=~0x200000200000000
which disables AESNI codepaths and PCLMULQDQ (useful for ghash).
It is unclear why this was done, but it probably just hides bugs.

[extended tests]

It is unclear to me why some test cases are failing due to the AESNI bit.
@mattcaswell any ideas?