### PR TITLE
bio printf: Safely range check real overflow on output.

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include "internal/cryptlib.h"
 #include "crypto/ctype.h"
 #include "internal/numbers.h"
@@ -635,10 +636,16 @@ fmtfp(char **sbuffer,
             fvalue = tmpvalue;
     }
     ufvalue = abs_val(fvalue);
-    if (ufvalue > ULONG_MAX) {
-        /* Number too big */
+    /*
+     * Check if the real value is too large to be displayed via an
+     * unsigned long int.
+     *
+     * The obvious comparison ufvalue > ULONG_MAX doesn't work because
+     * ULONG_MAX cannot be converted to a double without accuracy loss.
+     */
+    if (ufvalue >= ldexp(1., sizeof(unsigned long) * 8))
         return 0;
-    }
+
     intpart = (unsigned long)ufvalue;
 
     /*


### PR DESCRIPTION
There is a problem casting ULONG_MAX to double which gcc-10 is warning about.
ULONG_MAX typically cannot be exactly represented as a double.  ULONG_MAX + 1
can be and this fix uses the latter, however constructing this number cannot
be done using integer arithmetic.

This is an alternative fix to #11909 

The same problem exists in 1.1.1.

- [ ] documentation is added or updated
- [ ] tests are added or updated
