### PR TITLE
ossl_shim: add deprecation guards around the -use-ticket-callback option.

### DIFF
--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -7,6 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * HMAC low level APIs are deprecated for public use but might be used here.
+ */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #if !defined(__STDC_FORMAT_MACROS)
 #define __STDC_FORMAT_MACROS
 #endif
@@ -369,6 +374,7 @@ static int NewSessionCallback(SSL *ssl, SSL_SESSION *session) {
   return 1;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 static int TicketKeyCallback(SSL *ssl, uint8_t *key_name, uint8_t *iv,
                              EVP_CIPHER_CTX *ctx, HMAC_CTX *hmac_ctx,
                              int encrypt) {
@@ -401,6 +407,7 @@ static int TicketKeyCallback(SSL *ssl, uint8_t *key_name, uint8_t *iv,
   }
   return 1;
 }
+#endif
 
 // kCustomExtensionValue is the extension value that the custom extension
 // callbacks will add.
@@ -624,9 +631,11 @@ static bssl::UniquePtr<SSL_CTX> SetupCtx(const TestConfig *config) {
   SSL_CTX_set_info_callback(ssl_ctx.get(), InfoCallback);
   SSL_CTX_sess_set_new_cb(ssl_ctx.get(), NewSessionCallback);
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
   if (config->use_ticket_callback) {
     SSL_CTX_set_tlsext_ticket_key_cb(ssl_ctx.get(), TicketKeyCallback);
   }
+#endif
 
   if (config->enable_client_custom_extension &&
       !SSL_CTX_add_client_custom_ext(

--- a/test/ossl_shim/test_config.cc
+++ b/test/ossl_shim/test_config.cc
@@ -63,7 +63,9 @@ const Flag<bool> kBoolFlags[] = {
   { "-use-export-context", &TestConfig::use_export_context },
   { "-expect-ticket-renewal", &TestConfig::expect_ticket_renewal },
   { "-expect-no-session", &TestConfig::expect_no_session },
+#ifndef OPENSSL_NO_DEPRECATED_3_0
   { "-use-ticket-callback", &TestConfig::use_ticket_callback },
+#endif
   { "-renew-ticket", &TestConfig::renew_ticket },
   { "-enable-client-custom-extension",
     &TestConfig::enable_client_custom_extension },

--- a/test/ossl_shim/test_config.h
+++ b/test/ossl_shim/test_config.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+#include <openssl/configuration.h>
+
 
 struct TestConfig {
   int port = 0;
@@ -60,7 +62,9 @@ struct TestConfig {
   bool use_export_context = false;
   bool expect_ticket_renewal = false;
   bool expect_no_session = false;
+#ifndef OPENSSL_NO_DEPRECATED_3_0
   bool use_ticket_callback = false;
+#endif
   bool renew_ticket = false;
   bool enable_client_custom_extension = false;
   bool enable_server_custom_extension = false;


### PR DESCRIPTION
The ticket callback is deprecated in 3.0 and can't be used in a no-deprecated build.

Fixes #11942

- [ ] documentation is added or updated
- [x] tests are added or updated
