### PR TITLE
WIP: Build: add a make target to build the openssl application

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -145,8 +145,8 @@ HTMLDOCS3={- join(", ", map { "-\n\t".$_ } @{$unified_info{htmldocs}->{man3}}) -
 HTMLDOCS5={- join(", ", map { "-\n\t".$_ } @{$unified_info{htmldocs}->{man5}}) -}
 HTMLDOCS7={- join(", ", map { "-\n\t".$_ } @{$unified_info{htmldocs}->{man7}}) -}
 
-APPS_OPENSSL="{- use File::Spec::Functions;
-                 catfile("apps","openssl") -}"
+APPS_OPENSSL={- use File::Spec::Functions;
+                 catfile("apps","openssl") -}
 
 # DESTDIR is for package builders so that they can configure for, say,
 # SYS$COMMON:[OPENSSL] and yet have everything installed in STAGING:[USER].
@@ -413,11 +413,13 @@ NODEBUG=@
 {- dependmagic('build_libs'); -} : build_libs_nodep
 {- dependmagic('build_modules'); -} : build_modules_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
+{- dependmagic('build_the_app'); -} : build_the_app_nodep
 
 build_generated : $(GENERATED_MANDATORY)
 build_libs_nodep : $(LIBS), $(SHLIBS)
 build_modules_nodep : $(MODULES)
 build_programs_nodep : $(PROGRAMS), $(SCRIPTS)
+build_the_app_nodep : $(APPS_OPENSSL), $(SCRIPTS)
 
 build_docs: build_html_docs
 build_html_docs: $(HTMLDOCS1) $(HTMLDOCS3) $(HTMLDOCS5) $(HTMLDOCS7)

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -203,8 +203,8 @@ MANDOCS7={-
              fill_lines(" ", $COLUMNS - 9, map { platform->bin($_) }
                         @{$unified_info{mandocs}->{man7}})) -}
 
-APPS_OPENSSL="{- use File::Spec::Functions;
-                 catfile("apps","openssl") -}"
+APPS_OPENSSL={- use File::Spec::Functions;
+                 catfile("apps","openssl") -}
 
 # DESTDIR is for package builders so that they can configure for, say,
 # /usr/ and yet have everything installed to /tmp/somedir/usr/.
@@ -445,6 +445,7 @@ LANG=C
 {- dependmagic('build_libs'); -}: build_libs_nodep
 {- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
+{- dependmagic('build_the_app'); -}: build_the_app_nodep
 
 build_docs: build_man_docs build_html_docs
 build_man_docs: $(MANDOCS1) $(MANDOCS3) $(MANDOCS5) $(MANDOCS7)
@@ -454,6 +455,7 @@ build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: libcrypto.pc libssl.pc openssl.pc
 build_modules_nodep: $(MODULES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
+build_the_app_nodep: $(APPS_OPENSSL) $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests: build_programs

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -145,8 +145,8 @@ HTMLDOCS5_BLDDIRS={- my %dirs = map { dirname($_) => 1 } @HTMLDOCS5;
 HTMLDOCS7_BLDDIRS={- my %dirs = map { dirname($_) => 1 } @HTMLDOCS7;
                      join(' ', sort keys %dirs) -}
 
-APPS_OPENSSL="{- use File::Spec::Functions;
-                 catfile("apps","openssl") -}"
+APPS_OPENSSL={- use File::Spec::Functions;
+                 catfile("apps","openssl") -}
 
 # Do not edit these manually. Use Configure with --prefix or --openssldir
 # to change this!  Short explanation in the top comment in Configure
@@ -376,6 +376,7 @@ PROCESSOR= {- $config{processor} -}
 {- dependmagic('build_libs'); -}: build_libs_nodep
 {- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
+{- dependmagic('build_the_app'); -}: build_the_app_nodep
 
 build_docs: build_html_docs
 build_html_docs: $(HTMLDOCS1) $(HTMLDOCS3) $(HTMLDOCS5) $(HTMLDOCS7)
@@ -384,6 +385,7 @@ build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: $(LIBS) {- join(" ",map { platform->sharedlib_import($_) // () } @{$unified_info{libraries}}) -}
 build_modules_nodep: $(MODULES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
+build_the_app_nodep: $(APPS_OPENSSL) $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests: build_programs

--- a/apps/build.info
+++ b/apps/build.info
@@ -62,8 +62,8 @@ IF[{- !$disabled{apps} -}]
   DEPEND[openssl]=libapps.a ../libssl
 
   DEPEND[${OPENSSLSRC/.c/.o}]=progs.h
-  GENERATE[progs.c]=progs.pl -C $(APPS_OPENSSL)
-  GENERATE[progs.h]=progs.pl -H $(APPS_OPENSSL)
+  GENERATE[progs.c]=progs.pl -C "$(APPS_OPENSSL)"
+  GENERATE[progs.h]=progs.pl -H "$(APPS_OPENSSL)"
   # progs.pl tries to read all 'openssl' sources, including progs.c, so we make
   # sure things are generated in the correct order.
   DEPEND[progs.h]=progs.c


### PR DESCRIPTION
This commit adds a `build_the_app` make target, which essentially
builds `apps/openssl`, respecting all dependencies.
This target is mainly intended to be used by developers in order
to speed up compilation time.

Fixes #11932