### PR TITLE
Build: add a make target to build the openssl application [1.1.1]

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -407,11 +407,13 @@ NODEBUG=@
 {- dependmagic('build_libs'); -} : build_libs_nodep
 {- dependmagic('build_engines'); -} : build_engines_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
+{- dependmagic('build_the_app'); -} : build_the_app_nodep
 
 build_generated : $(GENERATED_MANDATORY)
 build_libs_nodep : $(LIBS), $(SHLIBS)
 build_engines_nodep : $(ENGINES)
 build_programs_nodep : $(PROGRAMS), $(SCRIPTS)
+build_the_app_nodep : $(APPS_OPENSSL), $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests : build_programs

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -448,11 +448,13 @@ LANG=C
 {- dependmagic('build_libs'); -}: build_libs_nodep
 {- dependmagic('build_engines'); -}: build_engines_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
+{- dependmagic('build_the_app'); -}: build_the_app_nodep
 
 build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: libcrypto.pc libssl.pc openssl.pc
 build_engines_nodep: $(ENGINES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
+build_the_app_nodep: $(APPS_OPENSSL) $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests: build_programs

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -312,11 +312,13 @@ PROCESSOR= {- $config{processor} -}
 {- dependmagic('build_libs'); -}: build_libs_nodep
 {- dependmagic('build_engines'); -}: build_engines_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
+{- dependmagic('build_the_app'); -}: build_the_app_nodep
 
 build_generated: $(GENERATED_MANDATORY)
 build_libs_nodep: $(LIBS) {- join(" ",map { shlib_import($_) } @{$unified_info{libraries}}) -}
 build_engines_nodep: $(ENGINES)
 build_programs_nodep: $(PROGRAMS) $(SCRIPTS)
+build_the_app_nodep: $(APPS_OPENSSL) $(SCRIPTS)
 
 # Kept around for backward compatibility
 build_apps build_tests: build_programs

--- a/apps/build.info
+++ b/apps/build.info
@@ -70,7 +70,7 @@ IF[{- !$disabled{apps} -}]
 
   {- join("\n  ", map { (my $x = $_) =~ s|\.c$|.o|; "DEPEND[$x]=progs.h" }
                   @apps_openssl_src) -}
-  GENERATE[progs.h]=progs.pl $(APPS_OPENSSL)
+  GENERATE[progs.h]=progs.pl "$(APPS_OPENSSL)"
   DEPEND[progs.h]=../configdata.pm
 
   SCRIPTS=CA.pl tsget.pl


### PR DESCRIPTION
This commit adds a `build_the_app` make target, which essentially
builds `apps/openssl`, respecting all dependencies.
This target is mainly intended to be used by developers in order
to speed up compilation time.

Fixes #11932

(Backport of #11946)
