### PR TITLE
Configure DEPs for FIPS provider on AIX.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1165,6 +1165,7 @@ my %targets = (
         module_ldflags   => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_ldflag    => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_defflag   => "-Wl,-bE:",
+        shared_fipsflag  => "-Wl,-binitfini:init:cleanup,-bE:",
         perl_platform    => 'AIX',
     },
     "aix-gcc" => {

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1165,7 +1165,7 @@ my %targets = (
         module_ldflags   => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_ldflag    => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_defflag   => "-Wl,-bE:",
-        shared_fipsflag  => "-Wl,-binitfini:init:cleanup,-bE:",
+        shared_fipsflag  => "-Wl,-binitfini:init:cleanup",
         perl_platform    => 'AIX',
     },
     "aix-gcc" => {

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1484,11 +1484,8 @@ EOF
                  grep { platform->isdef($_) }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
-      if (m/providers\/fips/ && defined $target{shared_fipsflag}) {
-        $shared_def = join("", map { ' '.$target{shared_fipsflag}.$_ } @defs);
-      } else {
-        $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
-      }
+      my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
+      $shared_def .= ' '.$target{shared_fipsflag} if (m/providers\/fips/ && defined $target{shared_fipsflag});
       my $objs = join(" \\\n\t\t", fill_lines(' ', $COLUMNS - 16, @objs));
       my $deps = join(" \\\n" . ' ' x (length($dso) + 2),
                       fill_lines(' ', $COLUMNS - length($dso) - 2,

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1485,6 +1485,7 @@ EOF
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
+      # TODO(3.0): next line needs to become "less magic" (see PR #11950)
       $shared_def .= ' '.$target{shared_fipsflag} if (m/providers\/fips/ && defined $target{shared_fipsflag});
       my $objs = join(" \\\n\t\t", fill_lines(' ', $COLUMNS - 16, @objs));
       my $deps = join(" \\\n" . ' ' x (length($dso) + 2),

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1484,8 +1484,11 @@ EOF
                  grep { platform->isdef($_) }
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
-      my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
-
+      if (m/providers\/fips/ && defined $target{shared_fipsflag}) {
+        $shared_def = join("", map { ' '.$target{shared_fipsflag}.$_ } @defs);
+      } else {
+        $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
+      }
       my $objs = join(" \\\n\t\t", fill_lines(' ', $COLUMNS - 16, @objs));
       my $deps = join(" \\\n" . ' ' x (length($dso) + 2),
                       fill_lines(' ', $COLUMNS - length($dso) - 2,

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -92,7 +92,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     }
     return TRUE;
 }
-#elif defined(__sun)
+#elif defined(__sun) || defined(_AIX)
 
 DEP_DECLARE() /* must be declared before pragma */
 # define DEP_INIT_ATTRIBUTE


### PR DESCRIPTION
The binder of the AIX linker needs to be told which functions to call on
loading and initializing a shared object. Therefore another configuration
variable shared_fipsflag is introduced, which replaces shared_defflag, when
the providers/fips module gets configured.

Fixes #11762 

Suggested replacement for #11802 
