### PR TITLE
Rename EVP_PKEY_cmp() to EVP_PKEY_eq() and EVP_PKEY_cmp_parameters()  to EVP_PKEY_parameters_eq()

### DIFF
--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -368,13 +368,13 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
 
     /*
      * For clarity.  The error is if parameters in peer are
-     * present (!missing) but don't match.  EVP_PKEY_cmp_parameters may return
+     * present (!missing) but don't match.  EVP_PKEY_parameters_eq may return
      * 1 (match), 0 (don't match) and -2 (comparison is not defined).  -1
      * (different key types) is impossible here because it is checked earlier.
      * -2 is OK for us here, as well as 1, so we can check for 0 only.
      */
     if (!EVP_PKEY_missing_parameters(peer) &&
-        !EVP_PKEY_cmp_parameters(ctx->pkey, peer)) {
+        !EVP_PKEY_parameters_eq(ctx->pkey, peer)) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE_SET_PEER, EVP_R_DIFFERENT_PARAMETERS);
         return -1;
     }

--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -236,8 +236,8 @@ int evp_keymgmt_util_has(EVP_PKEY *pk, int selection)
  * but also in the operation cache to see if there's any common keymgmt that
  * supplies OP_keymgmt_match.
  *
- * evp_keymgmt_util_match() adheres to the return values that EVP_PKEY_cmp()
- * and EVP_PKEY_cmp_parameters() return, i.e.:
+ * evp_keymgmt_util_match() adheres to the return values that EVP_PKEY_eq()
+ * and EVP_PKEY_parameters_eq() return, i.e.:
  *
  *  1   same key
  *  0   not same key

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -156,7 +156,7 @@ int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
     }
 
     if (!EVP_PKEY_missing_parameters(to)) {
-        if (EVP_PKEY_cmp_parameters(to, from) == 1)
+        if (EVP_PKEY_parameters_eq(to, from) == 1)
             return 1;
         EVPerr(EVP_F_EVP_PKEY_COPY_PARAMETERS, EVP_R_DIFFERENT_PARAMETERS);
         return 0;
@@ -272,7 +272,14 @@ static int evp_pkey_cmp_any(const EVP_PKEY *a, const EVP_PKEY *b,
     return evp_keymgmt_match(keymgmt1, keydata1, keydata2, selection);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
+{
+    return EVP_PKEY_parameters_eq(a, b);
+}
+#endif
+
+int EVP_PKEY_parameters_eq(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     /*
      * TODO: clean up legacy stuff from this function when legacy support
@@ -290,7 +297,14 @@ int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
     return -2;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
+{
+    return EVP_PKEY_eq(a, b);
+}
+#endif
+
+int EVP_PKEY_eq(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     /*
      * TODO: clean up legacy stuff from this function when legacy support

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -300,7 +300,7 @@ int X509_check_private_key(const X509 *x, const EVP_PKEY *k)
     xk = X509_get0_pubkey(x);
 
     if (xk)
-        ret = EVP_PKEY_cmp(xk, k);
+        ret = EVP_PKEY_eq(xk, k);
     else
         ret = -2;
 

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -85,7 +85,7 @@ int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k)
     int ok = 0;
 
     xk = X509_REQ_get_pubkey(x);
-    switch (EVP_PKEY_cmp(xk, k)) {
+    switch (EVP_PKEY_eq(xk, k)) {
     case 1:
         ok = 1;
         break;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -491,5 +491,5 @@ int X509_PUBKEY_eq(const X509_PUBKEY *a, const X509_PUBKEY *b)
     if ((pA = X509_PUBKEY_get0(a)) == NULL
         || (pB = X509_PUBKEY_get0(b)) == NULL)
         return -2;
-    return EVP_PKEY_cmp(pA, pB);
+    return EVP_PKEY_eq(pA, pB);
 }

--- a/doc/man3/EVP_PKEY_ASN1_METHOD.pod
+++ b/doc/man3/EVP_PKEY_ASN1_METHOD.pod
@@ -170,7 +170,7 @@ They're called by L<X509_PUBKEY_get0(3)> and L<X509_PUBKEY_set(3)>.
 The pub_cmp() method is called when two public keys are to be
 compared.
 It MUST return 1 when the keys are equal, 0 otherwise.
-It's called by L<EVP_PKEY_cmp(3)>.
+It's called by L<EVP_PKEY_eq(3)>.
 
 The pub_print() method is called to print a public key in humanly
 readable text to B<out>, indented B<indent> spaces.
@@ -228,7 +228,7 @@ It's called by L<EVP_PKEY_copy_parameters(3)>.
 The param_cmp() method compares the parameters of keys B<a> and B<b>.
 It MUST return 1 when the keys are equal, 0 when not equal, or a
 negative number on error.
-It's called by L<EVP_PKEY_cmp_parameters(3)>.
+It's called by L<EVP_PKEY_parameters_eq(3)>.
 
 The param_print() method prints the private key parameters in humanly
 readable text to B<out>, indented B<indent> spaces.

--- a/doc/man3/EVP_PKEY_copy_parameters.pod
+++ b/doc/man3/EVP_PKEY_copy_parameters.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-EVP_PKEY_copy_parameters, EVP_PKEY_missing_parameters, EVP_PKEY_cmp_parameters,
+EVP_PKEY_missing_parameters, EVP_PKEY_copy_parameters, EVP_PKEY_parameters_eq,
+EVP_PKEY_cmp_parameters, EVP_PKEY_eq,
 EVP_PKEY_cmp - public key parameter and comparison functions
 
 =head1 SYNOPSIS
@@ -12,7 +13,9 @@ EVP_PKEY_cmp - public key parameter and comparison functions
  int EVP_PKEY_missing_parameters(const EVP_PKEY *pkey);
  int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from);
 
+ int EVP_PKEY_parameters_eq(const EVP_PKEY *a, const EVP_PKEY *b);
  int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b);
+ int EVP_PKEY_eq(const EVP_PKEY *a, const EVP_PKEY *b);
  int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b);
 
 =head1 DESCRIPTION
@@ -26,11 +29,11 @@ B<from> to key B<to>. An error is returned if the parameters are missing in
 B<from> or present in both B<from> and B<to> and mismatch. If the parameters
 in B<from> and B<to> are both present and match this function has no effect.
 
-The function EVP_PKEY_cmp_parameters() compares the parameters of keys
-B<a> and B<b>.
+The function EVP_PKEY_parameters_eq() checks the parameters of keys
+B<a> and B<b> for equality.
 
-The function EVP_PKEY_cmp() compares the public key components and parameters
-(if present) of keys B<a> and B<b>.
+The function EVP_PKEY_eq() checks the public key components and parameters
+(if present) of keys B<a> and B<b> for equality.
 
 =head1 NOTES
 
@@ -40,7 +43,7 @@ parameters are sometimes omitted from a public key if they are inherited from
 the CA that signed it.
 
 Since OpenSSL private keys contain public key components too the function
-EVP_PKEY_cmp() can also be used to determine if a private key matches
+EVP_PKEY_eq() can also be used to determine if a private key matches
 a public key.
 
 =head1 RETURN VALUES
@@ -52,14 +55,22 @@ doesn't use parameters.
 These functions EVP_PKEY_copy_parameters() returns 1 for success and 0 for
 failure.
 
-The function EVP_PKEY_cmp_parameters() and EVP_PKEY_cmp() return 1 if the
-keys match, 0 if they don't match, -1 if the key types are different and
+The function EVP_PKEY_parameters_eq() and EVP_PKEY_eq() return 1 if their
+inputs match, 0 if they don't match, -1 if the key types are different and
 -2 if the operation is not supported.
 
 =head1 SEE ALSO
 
 L<EVP_PKEY_CTX_new(3)>,
 L<EVP_PKEY_keygen(3)>
+
+=head1 HISTORY
+
+The function EVP_PKEY_cmp was deprecated and renamed to B<EVP_PKEY_eq> and
+EVP_PKEY_cmp_parameters was deprecated and renamed to B<EVP_PKEY_parameters_eq>
+(without changing semantics) in OpenSSL 3.0.
+This was done to avoid confusion on their return values with other _cmp()
+functions that return 0 in case their arguments are equal.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1191,9 +1191,15 @@ EVP_PKEY *d2i_KeyParams_bio(int type, EVP_PKEY **a, BIO *in);
 int EVP_PKEY_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from);
 int EVP_PKEY_missing_parameters(const EVP_PKEY *pkey);
 int EVP_PKEY_save_parameters(EVP_PKEY *pkey, int mode);
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b);
+#endif
+int EVP_PKEY_parameters_eq(const EVP_PKEY *a, const EVP_PKEY *b);
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b);
+#endif
+int EVP_PKEY_eq(const EVP_PKEY *a, const EVP_PKEY *b);
 
 int EVP_PKEY_print_public(BIO *out, const EVP_PKEY *pkey,
                           int indent, ASN1_PCTX *pctx);

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -1115,7 +1115,7 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
         else
 #endif
         /* check that key <-> cert match */
-        if (EVP_PKEY_cmp(pubkey, privatekey) != 1) {
+        if (EVP_PKEY_eq(pubkey, privatekey) != 1) {
             SSLerr(SSL_F_SSL_SET_CERT_AND_KEY, SSL_R_PRIVATE_KEY_MISMATCH);
             goto out;
         }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2404,7 +2404,7 @@ static int keypair_test_run(EVP_TEST *t)
         goto end;
     }
 
-    if ((rv = EVP_PKEY_cmp(pair->privk, pair->pubk)) != 1 ) {
+    if ((rv = EVP_PKEY_eq(pair->privk, pair->pubk)) != 1 ) {
         if ( 0 == rv ) {
             t->err = "KEYPAIR_MISMATCH";
         } else if ( -1 == rv ) {

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -190,7 +190,7 @@ EVP_DigestInit                          193	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_find                      194	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_count             195	3_0_0	EXIST::FUNCTION:
 ASN1_BIT_STRING_get_bit                 196	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_cmp                            197	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_cmp                            197	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 d2i_X509_ALGORS                         198	3_0_0	EXIST::FUNCTION:
 EVP_PKEY2PKCS8                          199	3_0_0	EXIST::FUNCTION:
 BN_nist_mod_256                         200	3_0_0	EXIST::FUNCTION:
@@ -3461,7 +3461,7 @@ ERR_print_errors_cb                     3531	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_string               3532	3_0_0	EXIST::FUNCTION:ENGINE
 BIO_number_read                         3533	3_0_0	EXIST::FUNCTION:
 CRYPTO_zalloc                           3534	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_cmp_parameters                 3535	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_cmp_parameters                 3535	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_PKEY_CTX_new_id                     3537	3_0_0	EXIST::FUNCTION:
 TLS_FEATURE_free                        3538	3_0_0	EXIST::FUNCTION:
 d2i_BASIC_CONSTRAINTS                   3539	3_0_0	EXIST::FUNCTION:
@@ -5095,3 +5095,5 @@ EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md_name ?	3_0_0	EXIST::FUNCTION:RSA
 OSSL_PROVIDER_do_all                    ?	3_0_0	EXIST::FUNCTION:
 X509_PUBKEY_eq                          ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_eq                             ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_parameters_eq                  ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
As discussed in #11870

- [x] documentation is added or updated
- [x] tests are added or updated
