### PR TITLE
bio printf: Avoid using rounding errors in range check

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -635,7 +635,7 @@ fmtfp(char **sbuffer,
             fvalue = tmpvalue;
     }
     ufvalue = abs_val(fvalue);
-    if (ufvalue > ULONG_MAX) {
+    if (ufvalue >= (double)(ULONG_MAX - 65535) + 65536.0) {
         /* Number too big */
         return 0;
     }

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -635,7 +635,13 @@ fmtfp(char **sbuffer,
             fvalue = tmpvalue;
     }
     ufvalue = abs_val(fvalue);
-    if (ufvalue >= (double)(ULONG_MAX - 65535) + 65536.0) {
+    /*
+     * By subtracting 65535 (2^16-1) we canel the low order 15 bits
+     * of ULONG_MAX to avoid using imprecise floating point values.
+     * The second condition is necessary to catch NaN values.
+     */
+    if (ufvalue >= (double)(ULONG_MAX - 65535) + 65536.0
+            || ufvalue != ufvalue /* NaN */) {
         /* Number too big */
         return 0;
     }

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -636,12 +636,12 @@ fmtfp(char **sbuffer,
     }
     ufvalue = abs_val(fvalue);
     /*
-     * By subtracting 65535 (2^16-1) we canel the low order 15 bits
+     * By subtracting 65535 (2^16-1) we cancel the low order 15 bits
      * of ULONG_MAX to avoid using imprecise floating point values.
      * The second condition is necessary to catch NaN values.
      */
     if (ufvalue >= (double)(ULONG_MAX - 65535) + 65536.0
-            || ufvalue != ufvalue /* NaN */) {
+            || !(ufvalue == ufvalue) /* NaN */) {
         /* Number too big */
         return 0;
     }

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -244,7 +244,7 @@ static int test_fp(int i)
 static int test_big(void)
 {
     char buf[80];
-    double d, z, inf, nan;
+    volatile double d, z, inf, nan;
 
     /* Test excessively big number. Should fail */
     if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -241,10 +241,12 @@ static int test_fp(int i)
     return r;
 }
 
+double zero_value = 0.0;
+
 static int test_big(void)
 {
     char buf[80];
-    volatile double d, z, inf, nan;
+    double d, z, inf, nan;
 
     /* Test excessively big number. Should fail */
     if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
@@ -252,7 +254,7 @@ static int test_big(void)
         return 0;
 
     d = 1.0;
-    z = 0.0;
+    z = zero_value;
     inf = d / z;
     nan = z / z;
 

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -244,11 +244,42 @@ static int test_fp(int i)
 static int test_big(void)
 {
     char buf[80];
+    double d, z, inf, nan;
 
     /* Test excessively big number. Should fail */
     if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
                                   "%f\n", 2 * (double)ULONG_MAX), -1))
         return 0;
+
+    d = 1.0;
+    z = 0.0;
+    inf = d / z;
+    nan = z / z;
+
+    /*
+     * Test +/-inf, nan. Should fail.
+     * Test +/-1.0, +/-0.0. Should work.
+     */
+    if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                  "%f", inf), -1)
+            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                         "%f", -inf), -1)
+            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                         "%f", nan), -1)
+            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                         "%f", d), 8)
+            || !TEST_str_eq(buf, "1.000000")
+            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                         "%f", z), 8)
+            || !TEST_str_eq(buf, "0.000000")
+            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                         "%f", -d), 9)
+            || !TEST_str_eq(buf, "-1.000000")
+            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
+                                         "%f", -z), 8)
+            || !TEST_str_eq(buf, "0.000000"))
+        return 0;
+
     return 1;
 }
 

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -241,6 +241,7 @@ static int test_fp(int i)
     return r;
 }
 
+extern double zero_value;
 double zero_value = 0.0;
 
 static int test_big(void)


### PR DESCRIPTION
There is a problem casting ULONG_MAX to double which clang-10 is warning about.
ULONG_MAX typically cannot be exactly represented as a double.  ULONG_MAX + 1
can be and this fix uses the latter, however since ULONG_MAX cannot be
represented exactly as a double number we subtract 65535 from this number,
and the result has at most 48 leading one bits, and can therefore be
represented as a double integer without rounding error.  By adding
65536.0 to this number we achive the correct result, which should avoid the
warning.

The addresses a symptom of the underlying problem: we print doubles via an
unsigned long integer.  Doubles have a far greater range and should be printed
better.

This is an alternate fix avoiding dependency to libm and using
inexact floating point numbers with rounding errors.