### PR TITLE
Remove pod2htmd.tmp in make clean

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -523,6 +523,7 @@ clean: libclean
 	$(RM) -r test/test-runs
 	$(RM) openssl.pc libcrypto.pc libssl.pc
 	-$(RM) `find . -type l \! -name '.*' -print`
+	$(RM) pod2htmd.tmp
 	$(RM) $(TARFILE)
 
 distclean: clean


### PR DESCRIPTION
This fixes make distclean for 1.1.1

After make install there is one additional file "pod2htmd.tmp"
which is not cleaned up by make clean / distclean

A similar PR for master has been #10895 but left unapproved for months,
and thus abandoned by now.

This PR is for 1.1.1 only, as make distclean is way more broken on master,
and IMHO it makes no sense to fix master's distclean until short before the
master branch is released.