### PR TITLE
PROV: Use rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx() in RSA-OAEP

### DIFF
--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -187,12 +187,5 @@ int rsa_padding_add_PKCS1_type_2_with_libctx(OPENSSL_CTX *libctx,
                                              unsigned char *to, int tlen,
                                              const unsigned char *from,
                                              int flen);
-int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
-                                                unsigned char *to, int tlen,
-                                                const unsigned char *from,
-                                                int flen,
-                                                const unsigned char *param,
-                                                int plen, const EVP_MD *md,
-                                                const EVP_MD *mgf1md);
 
 #endif /* OSSL_CRYPTO_RSA_LOCAL_H */

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -69,6 +69,13 @@ int rsa_padding_check_PKCS1_type_2_TLS(OPENSSL_CTX *ctx, unsigned char *to,
                                        size_t tlen, const unsigned char *from,
                                        size_t flen, int client_version,
                                        int alt_version);
+int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
+                                                unsigned char *to, int tlen,
+                                                const unsigned char *from,
+                                                int flen,
+                                                const unsigned char *param,
+                                                int plen, const EVP_MD *md,
+                                                const EVP_MD *mgf1md);
 
 int rsa_validate_public(const RSA *key);
 int rsa_validate_private(const RSA *key);

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -138,11 +138,13 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
             PROVerr(0, ERR_R_INTERNAL_ERROR);
             return 0;
         }
-        ret = RSA_padding_add_PKCS1_OAEP_mgf1(tbuf, rsasize, in, inlen,
-                                              prsactx->oaep_label,
-                                              prsactx->oaep_labellen,
-                                              prsactx->oaep_md,
-                                              prsactx->mgf1_md);
+        ret =
+            rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(prsactx->libctx, tbuf,
+                                                        rsasize, in, inlen,
+                                                        prsactx->oaep_label,
+                                                        prsactx->oaep_labellen,
+                                                        prsactx->oaep_md,
+                                                        prsactx->mgf1_md);
 
         if (!ret) {
             OPENSSL_free(tbuf);


### PR DESCRIPTION
Fixes #11904
