### PR TITLE
Fix errtest for older compilers

### DIFF
--- a/test/errtest.c
+++ b/test/errtest.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <openssl/opensslconf.h>
 #include <openssl/err.h>
+#include <openssl/macros.h>
 
 #include "testutil.h"
 
@@ -24,16 +25,19 @@
 
 static int test_print_error_format(void)
 {
-    static const char expected[] =
-        ":error::system library:test_print_error_format:Operation not permitted:"
+    static const char expected_format[] =
+        ":error::system library:%s:Operation not permitted:"
 # ifndef OPENSSL_NO_FILENAMES
         "errtest.c:30:";
 # else
         ":0:";
 # endif
+    char expected[256];
     char *out = NULL, *p = NULL;
     int ret = 0, len;
     BIO *bio = NULL;
+
+    BIO_snprintf(expected, sizeof(expected), expected_format, OPENSSL_FUNC);
 
     if (!TEST_ptr(bio = BIO_new(BIO_s_mem())))
         return 0;


### PR DESCRIPTION
Some older compilers use "unknown function" if they dont support __func, so the
test using ERR_PUT_error needed to compensate for this when comparing against the
expected value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [X] tests are added or updated
