### PR TITLE
Fix EVP_CIPHER_fetch race condition

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -878,11 +878,9 @@ static void evp_md_free(void *md)
 EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                      const char *properties)
 {
-    EVP_MD *md =
-        evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
-                          evp_md_from_dispatch, evp_md_up_ref, evp_md_free);
-
-    return md;
+    return evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
+                             evp_md_from_dispatch, NULL, evp_md_up_ref,
+                             evp_md_free);
 }
 
 int EVP_MD_up_ref(EVP_MD *md)
@@ -914,5 +912,5 @@ void EVP_MD_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_DIGEST,
                        (void (*)(void *, void *))fn, arg,
-                       evp_md_from_dispatch, evp_md_free);
+                       evp_md_from_dispatch, NULL, evp_md_free);
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -274,35 +274,6 @@ int EVP_CIPHER_type(const EVP_CIPHER *ctx)
     }
 }
 
-int evp_cipher_cache_constants(EVP_CIPHER *cipher)
-{
-    int ok;
-    size_t ivlen = 0;
-    size_t blksz = 0;
-    size_t keylen = 0;
-    unsigned int mode = 0;
-    unsigned long flags = 0;
-    OSSL_PARAM params[6];
-
-    params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_BLOCK_SIZE, &blksz);
-    params[1] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
-    params[2] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &keylen);
-    params[3] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_MODE, &mode);
-    params[4] = OSSL_PARAM_construct_ulong(OSSL_CIPHER_PARAM_FLAGS, &flags);
-    params[5] = OSSL_PARAM_construct_end();
-    ok = evp_do_ciph_getparams(cipher, params);
-    if (ok) {
-        /* Provided implementations may have a custom cipher_cipher */
-        if (cipher->prov != NULL && cipher->ccipher != NULL)
-            flags |= EVP_CIPH_FLAG_CUSTOM_CIPHER;
-        cipher->block_size = blksz;
-        cipher->iv_len = ivlen;
-        cipher->key_len = keylen;
-        cipher->flags = flags | mode;
-    }
-    return ok;
-}
-
 int EVP_CIPHER_block_size(const EVP_CIPHER *cipher)
 {
     return cipher->block_size;

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -207,6 +207,7 @@ void *evp_generic_fetch(OPENSSL_CTX *ctx, int operation_id,
                         void *(*new_method)(int name_id,
                                             const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
+                        int (*post_new_method)(void *),
                         int (*up_ref_method)(void *),
                         void (*free_method)(void *));
 void *evp_generic_fetch_by_number(OPENSSL_CTX *ctx, int operation_id,
@@ -214,6 +215,7 @@ void *evp_generic_fetch_by_number(OPENSSL_CTX *ctx, int operation_id,
                                   void *(*new_method)(int name_id,
                                                       const OSSL_DISPATCH *fns,
                                                       OSSL_PROVIDER *prov),
+                                  int (*post_new_method)(void *),
                                   int (*up_ref_method)(void *),
                                   void (*free_method)(void *));
 void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
@@ -222,6 +224,7 @@ void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
                         void *(*new_method)(int name_id,
                                             const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
+                        int (*post_new_method)(void *),
                         void (*free_method)(void *));
 
 /* Internal fetchers for method types that are to be combined with others */
@@ -285,4 +288,3 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
 void evp_names_do_all(OSSL_PROVIDER *prov, int number,
                       void (*fn)(const char *name, void *data),
                       void *data);
-int evp_cipher_cache_constants(EVP_CIPHER *cipher);

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -170,7 +170,7 @@ EVP_KEYEXCH *EVP_KEYEXCH_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYEXCH, algorithm, properties,
-                             evp_keyexch_from_dispatch,
+                             evp_keyexch_from_dispatch, NULL,
                              (int (*)(void *))EVP_KEYEXCH_up_ref,
                              (void (*)(void *))EVP_KEYEXCH_free);
 }
@@ -443,7 +443,7 @@ void EVP_KEYEXCH_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KEYEXCH,
                        (void (*)(void *, void *))fn, arg,
-                       evp_keyexch_from_dispatch,
+                       evp_keyexch_from_dispatch, NULL,
                        (void (*)(void *))EVP_KEYEXCH_free);
 }
 

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -151,7 +151,7 @@ EVP_KDF *EVP_KDF_fetch(OPENSSL_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_KDF, algorithm, properties,
-                             evp_kdf_from_dispatch, evp_kdf_up_ref,
+                             evp_kdf_from_dispatch, NULL, evp_kdf_up_ref,
                              evp_kdf_free);
 }
 
@@ -192,5 +192,5 @@ void EVP_KDF_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KDF,
                        (void (*)(void *, void *))fn, arg,
-                       evp_kdf_from_dispatch, evp_kdf_free);
+                       evp_kdf_from_dispatch, NULL, evp_kdf_free);
 }

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -193,7 +193,7 @@ EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OPENSSL_CTX *ctx, int name_id,
 {
     return evp_generic_fetch_by_number(ctx,
                                        OSSL_OP_KEYMGMT, name_id, properties,
-                                       keymgmt_from_dispatch,
+                                       keymgmt_from_dispatch, NULL,
                                        (int (*)(void *))EVP_KEYMGMT_up_ref,
                                        (void (*)(void *))EVP_KEYMGMT_free);
 }
@@ -202,7 +202,7 @@ EVP_KEYMGMT *EVP_KEYMGMT_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYMGMT, algorithm, properties,
-                             keymgmt_from_dispatch,
+                             keymgmt_from_dispatch, NULL,
                              (int (*)(void *))EVP_KEYMGMT_up_ref,
                              (void (*)(void *))EVP_KEYMGMT_free);
 }
@@ -251,7 +251,7 @@ void EVP_KEYMGMT_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KEYMGMT,
                        (void (*)(void *, void *))fn, arg,
-                       keymgmt_from_dispatch,
+                       keymgmt_from_dispatch, NULL,
                        (void (*)(void *))EVP_KEYMGMT_free);
 }
 

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -153,7 +153,7 @@ EVP_MAC *EVP_MAC_fetch(OPENSSL_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_MAC, algorithm, properties,
-                             evp_mac_from_dispatch, evp_mac_up_ref,
+                             evp_mac_from_dispatch, NULL, evp_mac_up_ref,
                              evp_mac_free);
 }
 
@@ -199,5 +199,5 @@ void EVP_MAC_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_MAC,
                        (void (*)(void *, void *))fn, arg,
-                       evp_mac_from_dispatch, evp_mac_free);
+                       evp_mac_from_dispatch, NULL, evp_mac_free);
 }

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -409,7 +409,7 @@ EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                        const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_ASYM_CIPHER, algorithm, properties,
-                             evp_asym_cipher_from_dispatch,
+                             evp_asym_cipher_from_dispatch, NULL,
                              (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
                              (void (*)(void *))EVP_ASYM_CIPHER_free);
 }
@@ -431,7 +431,7 @@ void EVP_ASYM_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_ASYM_CIPHER,
                        (void (*)(void *, void *))fn, arg,
-                       evp_asym_cipher_from_dispatch,
+                       evp_asym_cipher_from_dispatch, NULL,
                        (void (*)(void *))EVP_ASYM_CIPHER_free);
 }
 

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -302,7 +302,7 @@ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                    const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
-                             evp_signature_from_dispatch,
+                             evp_signature_from_dispatch, NULL,
                              (int (*)(void *))EVP_SIGNATURE_up_ref,
                              (void (*)(void *))EVP_SIGNATURE_free);
 }
@@ -324,7 +324,7 @@ void EVP_SIGNATURE_do_all_provided(OPENSSL_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_SIGNATURE,
                        (void (*)(void *, void *))fn, arg,
-                       evp_signature_from_dispatch,
+                       evp_signature_from_dispatch, NULL,
                        (void (*)(void *))EVP_SIGNATURE_free);
 }
 

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -14,9 +14,8 @@ evp_generic_fetch, evp_generic_fetch_by_number
                          const char *name, const char *properties,
                          void *(*new_method)(int name_id,
                                              const OSSL_DISPATCH *fns,
-                                             OSSL_PROVIDER *prov,
-                                             void *method_data),
-                         void *method_data,
+                                             OSSL_PROVIDER *prov),
+                         int (*post_new_method)(void *),
                          int (*up_ref_method)(void *),
                          void (*free_method)(void *));
 
@@ -24,9 +23,8 @@ evp_generic_fetch, evp_generic_fetch_by_number
                                    int name_id, const char *properties,
                                    void *(*new_method)(int name_id,
                                                        const OSSL_DISPATCH *fns,
-                                                       OSSL_PROVIDER *prov,
-                                                       void *method_data),
-                                   void *method_data,
+                                                       OSSL_PROVIDER *prov),
+                                   int (*post_new_method)(void *),
                                    int (*up_ref_method)(void *),
                                    void (*free_method)(void *));
 
@@ -35,7 +33,8 @@ evp_generic_fetch, evp_generic_fetch_by_number
 evp_generic_fetch() calls ossl_method_construct() with the given
 I<libctx>, I<operation_id>, I<name>, and I<properties> and uses
 it to create an EVP method with the help of the functions
-I<new_method>, I<up_ref_method>, and I<free_method>.
+I<new_method>, I<post_new_method>, I<up_ref_method>, and
+I<free_method>.
 
 evp_generic_fetch_by_number() does the same thing as evp_generic_fetch(), 
 but takes a I<name_id> instead of a number.
@@ -45,8 +44,8 @@ This is meant to be used when one method needs to fetch an associated
 other method, and is typically called from inside the given function
 I<new_method>.
 
-The three functions I<new_method>, I<up_ref_method>, and
-I<free_method> are supposed to:
+The four functions I<new_method>, I<post_new_method>,
+I<up_ref_method>, and I<free_method> are supposed to:
 
 =over 4
 
@@ -56,6 +55,12 @@ creates an internal method from function pointers found in the
 dispatch table I<fns>, with name identity I<name_id>.
 The provider I<prov> and I<method_data> are also passed to be used as
 new_method() sees fit.
+
+=item post_new_method()
+
+on a successfully created method, perform arbitrary additional work.
+This function may return 1 for success or 0 for failure.  If it
+returns 0 the method is freed.
 
 =item up_ref_method()
 
@@ -115,8 +120,7 @@ And here's the implementation of the FOO method fetcher:
      */
     EVP_FOO *EVP_FOO_meth_from_dispatch(int name_id,
                                         const OSSL_DISPATCH *fns,
-                                        OSSL_PROVIDER *prov,
-                                        void *data)
+                                        OSSL_PROVIDER *prov)
     {
         EVP_FOO *foo = NULL;
 
@@ -161,7 +165,8 @@ And here's the implementation of the FOO method fetcher:
         }
     }
 
-    static void *foo_from_dispatch(const OSSL_DISPATCH *fns,
+    static void *foo_from_dispatch(int name_id,
+                                   const OSSL_DISPATCH *fns,
                                    OSSL_PROVIDER *prov)
     {
         return EVP_FOO_meth_from_dispatch(fns, prov);
@@ -187,7 +192,7 @@ And here's the implementation of the FOO method fetcher:
     {
         EVP_FOO *foo =
             evp_generic_fetch(ctx, OSSL_OP_FOO, name, properties,
-                              foo_from_dispatch, foo_up_ref, foo_free);
+                              foo_from_dispatch, NULL, foo_up_ref, foo_free);
 
         /*
          * If this method exists in legacy form, with a constant NID for the


### PR DESCRIPTION
## EVP: add a post new_method to evp_generic_fetch() and friends

This new function allows the caller to perform some additional
arbitrary work on a newly constructed method.

## EVP: convert evp_cipher_cache_constants() into a post new_method function

This ensures that the constants are only retrieved once, when the
method is newly created, rather than every time the same method is
fetched.

Fixes #11974

## EVP: For all other fetchers, simply pass NULL as post new_method function