### PR TITLE
[WIP] EVP: retrieve EVP_CIPHER constants in the evp_cipher_from_dispatch()

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1306,6 +1306,35 @@ static void set_legacy_nid(const char *name, void *vlegacy_nid)
 }
 #endif
 
+static int evp_cipher_cache_constants(EVP_CIPHER *cipher)
+{
+    int ok;
+    size_t ivlen = 0;
+    size_t blksz = 0;
+    size_t keylen = 0;
+    unsigned int mode = 0;
+    unsigned long flags = 0;
+    OSSL_PARAM params[6];
+
+    params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_BLOCK_SIZE, &blksz);
+    params[1] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
+    params[2] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &keylen);
+    params[3] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_MODE, &mode);
+    params[4] = OSSL_PARAM_construct_ulong(OSSL_CIPHER_PARAM_FLAGS, &flags);
+    params[5] = OSSL_PARAM_construct_end();
+    ok = evp_do_ciph_getparams(cipher, params);
+    if (ok) {
+        /* Provided implementations may have a custom cipher_cipher */
+        if (cipher->prov != NULL && cipher->ccipher != NULL)
+            flags |= EVP_CIPH_FLAG_CUSTOM_CIPHER;
+        cipher->block_size = blksz;
+        cipher->iv_len = ivlen;
+        cipher->key_len = keylen;
+        cipher->flags = flags | mode;
+    }
+    return ok;
+}
+
 static void *evp_cipher_from_dispatch(const int name_id,
                                       const OSSL_DISPATCH *fns,
                                       OSSL_PROVIDER *prov)
@@ -1430,6 +1459,11 @@ static void *evp_cipher_from_dispatch(const int name_id,
     if (prov != NULL)
         ossl_provider_up_ref(prov);
 
+    if (!evp_cipher_cache_constants(cipher)) {
+        EVP_CIPHER_free(cipher);
+        cipher = NULL;
+    }
+
     return cipher;
 }
 
@@ -1446,16 +1480,9 @@ static void evp_cipher_free(void *cipher)
 EVP_CIPHER *EVP_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                              const char *properties)
 {
-    EVP_CIPHER *cipher =
-        evp_generic_fetch(ctx, OSSL_OP_CIPHER, algorithm, properties,
-                          evp_cipher_from_dispatch, evp_cipher_up_ref,
-                          evp_cipher_free);
-
-    if (cipher != NULL && !evp_cipher_cache_constants(cipher)) {
-        EVP_CIPHER_free(cipher);
-        cipher = NULL;
-    }
-    return cipher;
+    return evp_generic_fetch(ctx, OSSL_OP_CIPHER, algorithm, properties,
+                             evp_cipher_from_dispatch, evp_cipher_up_ref,
+                             evp_cipher_free);
 }
 
 int EVP_CIPHER_up_ref(EVP_CIPHER *cipher)

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -274,35 +274,6 @@ int EVP_CIPHER_type(const EVP_CIPHER *ctx)
     }
 }
 
-int evp_cipher_cache_constants(EVP_CIPHER *cipher)
-{
-    int ok;
-    size_t ivlen = 0;
-    size_t blksz = 0;
-    size_t keylen = 0;
-    unsigned int mode = 0;
-    unsigned long flags = 0;
-    OSSL_PARAM params[6];
-
-    params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_BLOCK_SIZE, &blksz);
-    params[1] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &ivlen);
-    params[2] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &keylen);
-    params[3] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_MODE, &mode);
-    params[4] = OSSL_PARAM_construct_ulong(OSSL_CIPHER_PARAM_FLAGS, &flags);
-    params[5] = OSSL_PARAM_construct_end();
-    ok = evp_do_ciph_getparams(cipher, params);
-    if (ok) {
-        /* Provided implementations may have a custom cipher_cipher */
-        if (cipher->prov != NULL && cipher->ccipher != NULL)
-            flags |= EVP_CIPH_FLAG_CUSTOM_CIPHER;
-        cipher->block_size = blksz;
-        cipher->iv_len = ivlen;
-        cipher->key_len = keylen;
-        cipher->flags = flags | mode;
-    }
-    return ok;
-}
-
 int EVP_CIPHER_block_size(const EVP_CIPHER *cipher)
 {
     return cipher->block_size;

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -285,4 +285,3 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
 void evp_names_do_all(OSSL_PROVIDER *prov, int number,
                       void (*fn)(const char *name, void *data),
                       void *data);
-int evp_cipher_cache_constants(EVP_CIPHER *cipher);


### PR DESCRIPTION
This avoids a race condition when the same method is fetched by more
than one thread at the same time.

Fixes #11974

-----

This is an alternative to #11977