### PR TITLE
APPS: Create a library context in the main app, and pass it to commands 

### DIFF
--- a/apps/asn1pars.c
+++ b/apps/asn1pars.c
@@ -61,7 +61,7 @@ const OPTIONS asn1parse_options[] = {
 
 static int do_generate(char *genstr, const char *genconf, BUF_MEM *buf);
 
-int asn1parse_main(int argc, char **argv)
+int asn1parse_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ASN1_TYPE *at = NULL;
     BIO *in = NULL, *b64 = NULL, *derout = NULL;

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -487,7 +487,11 @@ end_of_options:
 
     if ((conf = app_load_config(configfile)) == NULL)
         goto end;
-    if (configfile != default_config_file && !app_load_modules(conf))
+    /*
+     * TODO(3.0) When we feel confident enough, use |libctx| as first
+     * argument for app_load_modules()
+     */
+    if (configfile != default_config_file && !app_load_modules(NULL, conf))
         goto end;
 
     /* Lets get the config section we are using */

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -254,7 +254,7 @@ const OPTIONS ca_options[] = {
     {NULL}
 };
 
-int ca_main(int argc, char **argv)
+int ca_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     CONF *conf = NULL;
     ENGINE *e = NULL;

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -92,7 +92,7 @@ static char *dummy_srp(SSL *ssl, void *arg)
 }
 #endif
 
-int ciphers_main(int argc, char **argv)
+int ciphers_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     SSL_CTX *ctx = NULL;
     SSL *ssl = NULL;

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2847,7 +2847,7 @@ static int get_opts(int argc, char **argv)
     return 0;
 }
 
-int cmp_main(int argc, char **argv)
+int cmp_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     char *configfile = NULL;
     int i;

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -234,7 +234,7 @@ const OPTIONS cms_options[] = {
     {NULL}
 };
 
-int cms_main(int argc, char **argv)
+int cms_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ASN1_OBJECT *econtent_type = NULL;
     BIO *in = NULL, *out = NULL, *indata = NULL, *rctin = NULL;

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -73,7 +73,7 @@ const OPTIONS crl_options[] = {
     {NULL}
 };
 
-int crl_main(int argc, char **argv)
+int crl_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     X509_CRL *x = NULL;
     BIO *out = NULL;

--- a/apps/crl2p7.c
+++ b/apps/crl2p7.c
@@ -51,7 +51,7 @@ const OPTIONS crl2pkcs7_options[] = {
     {NULL}
 };
 
-int crl2pkcs7_main(int argc, char **argv)
+int crl2pkcs7_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     PKCS7 *p7 = NULL;

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -91,7 +91,7 @@ const OPTIONS dgst_options[] = {
     {NULL}
 };
 
-int dgst_main(int argc, char **argv)
+int dgst_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *inp, *bmd = NULL, *out = NULL;
     ENGINE *e = NULL, *impl = NULL;

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -81,7 +81,7 @@ const OPTIONS dhparam_options[] = {
     {NULL}
 };
 
-int dhparam_main(int argc, char **argv)
+int dhparam_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     DH *dh = NULL;

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -65,7 +65,7 @@ const OPTIONS dsa_options[] = {
     {NULL}
 };
 
-int dsa_main(int argc, char **argv)
+int dsa_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *out = NULL;
     DSA *dsa = NULL;

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -63,7 +63,7 @@ const OPTIONS dsaparam_options[] = {
     {NULL}
 };
 
-int dsaparam_main(int argc, char **argv)
+int dsaparam_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     DSA *dsa = NULL;

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -72,7 +72,7 @@ const OPTIONS ec_options[] = {
     {NULL}
 };
 
-int ec_main(int argc, char **argv)
+int ec_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -81,7 +81,7 @@ static OPT_PAIR encodings[] = {
     {NULL}
 };
 
-int ecparam_main(int argc, char **argv)
+int ecparam_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     BIGNUM *ec_gen = NULL, *ec_order = NULL, *ec_cofactor = NULL;

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -101,7 +101,7 @@ const OPTIONS enc_options[] = {
     {NULL}
 };
 
-int enc_main(int argc, char **argv)
+int enc_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     static char buf[128];
     static const char magic[] = "Salted__";

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -294,7 +294,7 @@ static void util_store_cap(const OSSL_STORE_LOADER *loader, void *arg)
     }
 }
 
-int engine_main(int argc, char **argv)
+int engine_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1, i;
     int verbose = 0, list_cap = 0, test_avail = 0, test_avail_noise = 0;

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -31,7 +31,7 @@ const OPTIONS errstr_options[] = {
     {NULL}
 };
 
-int errstr_main(int argc, char **argv)
+int errstr_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     OPTION_CHOICE o;
     char buf[256], *prog;

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -264,7 +264,7 @@ end:
     return ret;
 }
 
-int fipsinstall_main(int argc, char **argv)
+int fipsinstall_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1, verify = 0;
     BIO *module_bio = NULL, *mem_bio = NULL, *fout = NULL;

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -185,6 +185,12 @@ static CONF *generate_config_and_load(const char *prov_name,
     if (conf == NULL)
         goto end;
 
+    /* TODO(3.0) When we feel confident enough, assign |libctx| to |conf| */
+#if 0
+    if (!NCONF_set_libctx(conf, libctx))
+        goto end;
+#endif
+
     if (CONF_modules_load(conf, NULL, 0) <= 0)
         goto end;
     BIO_free(mem_bio);

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -50,7 +50,7 @@ const OPTIONS gendsa_options[] = {
     {NULL}
 };
 
-int gendsa_main(int argc, char **argv)
+int gendsa_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     BIO *out = NULL, *in = NULL;

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -55,7 +55,7 @@ const OPTIONS genpkey_options[] = {
     {NULL}
 };
 
-int genpkey_main(int argc, char **argv)
+int genpkey_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -67,7 +67,7 @@ const OPTIONS genrsa_options[] = {
     {NULL}
 };
 
-int genrsa_main(int argc, char **argv)
+int genrsa_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BN_GENCB *cb = BN_GENCB_new();
     ENGINE *eng = NULL;

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -63,7 +63,7 @@ BIO *bio_open_default_quiet(const char *filename, char mode, int format);
 CONF *app_load_config_bio(BIO *in, const char *filename);
 CONF *app_load_config(const char *filename);
 CONF *app_load_config_quiet(const char *filename);
-int app_load_modules(const CONF *config);
+int app_load_modules(OPENSSL_CTX *libctx, CONF *config);
 void unbuffer(FILE *fp);
 void wait_for_async(SSL *s);
 # if defined(OPENSSL_SYS_MSDOS)

--- a/apps/include/function.h
+++ b/apps/include/function.h
@@ -23,7 +23,7 @@ typedef enum FUNC_TYPE {
 typedef struct function_st {
     FUNC_TYPE type;
     const char *name;
-    int (*func)(int argc, char *argv[]);
+    int (*func)(OPENSSL_CTX *libctx, int argc, char *argv[]);
     const OPTIONS *help;
     const char *deprecated_alternative;
     const char *deprecated_version;

--- a/apps/info.c
+++ b/apps/info.c
@@ -35,7 +35,7 @@ const OPTIONS info_options[] = {
     {NULL}
 };
 
-int info_main(int argc, char **argv)
+int info_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1, dirty = 0, type = 0;
     char *prog;

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -46,7 +46,7 @@ const OPTIONS kdf_options[] = {
     {NULL}
 };
 
-int kdf_main(int argc, char **argv)
+int kdf_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1, out_bin = 0;
     OPTION_CHOICE o;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -386,7 +386,7 @@ CONF *app_load_config_quiet(const char *filename)
     return conf;
 }
 
-int app_load_modules(const CONF *config)
+int app_load_modules(OPENSSL_CTX *libctx, CONF *config)
 {
     CONF *to_free = NULL;
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -395,7 +395,8 @@ int app_load_modules(OPENSSL_CTX *libctx, CONF *config)
     if (config == NULL)
         return 1;
 
-    if (CONF_modules_load(config, NULL, 0) <= 0) {
+    if (!NCONF_set_libctx(config, libctx)
+        || CONF_modules_load(config, NULL, 0) <= 0) {
         BIO_printf(bio_err, "Error configuring OpenSSL modules\n");
         ERR_print_errors(bio_err);
         NCONF_free(to_free);

--- a/apps/list.c
+++ b/apps/list.c
@@ -663,7 +663,7 @@ const OPTIONS list_options[] = {
     {NULL}
 };
 
-int list_main(int argc, char **argv)
+int list_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     char *prog;
     HELPLIST_CHOICE o;

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -50,7 +50,7 @@ const OPTIONS mac_options[] = {
     {NULL}
 };
 
-int mac_main(int argc, char **argv)
+int mac_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1;
     char *prog;

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -37,7 +37,7 @@ const OPTIONS nseq_options[] = {
     {NULL}
 };
 
-int nseq_main(int argc, char **argv)
+int nseq_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     X509 *x509 = NULL;

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -199,7 +199,7 @@ const OPTIONS ocsp_options[] = {
     {NULL}
 };
 
-int ocsp_main(int argc, char **argv)
+int ocsp_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *acbio = NULL, *cbio = NULL, *derbio = NULL, *out = NULL;
     const EVP_MD *cert_id_md = NULL, *rsign_md = NULL;

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -97,7 +97,7 @@ const OPTIONS passwd_options[] = {
     {NULL}
 };
 
-int passwd_main(int argc, char **argv)
+int passwd_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL;
     char *infile = NULL, *salt = NULL, *passwd = NULL, **passwds = NULL;

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -137,7 +137,7 @@ const OPTIONS pkcs12_options[] = {
     {NULL}
 };
 
-int pkcs12_main(int argc, char **argv)
+int pkcs12_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     char *infile = NULL, *outfile = NULL, *keyname = NULL, *certfile = NULL;
     char *name = NULL, *csp_name = NULL;

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -54,7 +54,7 @@ const OPTIONS pkcs7_options[] = {
     {NULL}
 };
 
-int pkcs7_main(int argc, char **argv)
+int pkcs7_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     PKCS7 *p7 = NULL;

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -67,7 +67,7 @@ const OPTIONS pkcs8_options[] = {
     {NULL}
 };
 
-int pkcs8_main(int argc, char **argv)
+int pkcs8_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -77,7 +77,7 @@ const OPTIONS pkey_options[] = {
     {NULL}
 };
 
-int pkey_main(int argc, char **argv)
+int pkey_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -43,7 +43,7 @@ const OPTIONS pkeyparam_options[] = {
     {NULL}
 };
 
-int pkeyparam_main(int argc, char **argv)
+int pkeyparam_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     BIO *in = NULL, *out = NULL;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -98,7 +98,7 @@ const OPTIONS pkeyutl_options[] = {
     {NULL}
 };
 
-int pkeyutl_main(int argc, char **argv)
+int pkeyutl_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;

--- a/apps/prime.c
+++ b/apps/prime.c
@@ -40,7 +40,7 @@ const OPTIONS prime_options[] = {
     {NULL}
 };
 
-int prime_main(int argc, char **argv)
+int prime_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIGNUM *bn = NULL;
     int hex = 0, generate = 0, bits = 0, safe = 0, ret = 1;

--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -19,7 +19,9 @@ die "Unrecognised option, must be -C or -H\n"
     unless ($opt eq '-H' || $opt eq '-C');
 
 my %commands     = ();
-my $cmdre        = qr/^\s*int\s+([a-z_][a-z0-9_]*)_main\(\s*int\s+argc\s*,/;
+my $cmdre        = qr/^\s*int\s+([a-z_][a-z0-9_]*)_main\(
+                      \s*OPENSSL_CTX\s*\*\s*libctx\s*,
+                      \s*int\s+argc\s*,/x;
 my $apps_openssl = shift @ARGV;
 my $YEAR         = [localtime()]->[5] + 1900;
 
@@ -61,7 +63,7 @@ if ($opt eq '-H') {
 EOF
 
     foreach (@ARGV) {
-        printf "extern int %s_main(int argc, char *argv[]);\n", $_;
+        printf "extern int %s_main(OPENSSL_CTX *libctx, int argc, char *argv[]);\n", $_;
     }
     print "\n";
 

--- a/apps/provider.c
+++ b/apps/provider.c
@@ -239,7 +239,7 @@ static void do_signature(EVP_SIGNATURE *signature, void *meta)
               meta);
 }
 
-int provider_main(int argc, char **argv)
+int provider_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1, i;
     int verbose = 0;

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -46,7 +46,7 @@ const OPTIONS rand_options[] = {
     {NULL}
 };
 
-int rand_main(int argc, char **argv)
+int rand_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     BIO *out = NULL;

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -482,7 +482,7 @@ const OPTIONS rehash_options[] = {
 };
 
 
-int rehash_main(int argc, char **argv)
+int rehash_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     const char *env, *prog;
     char *e, *m;
@@ -546,7 +546,7 @@ const OPTIONS rehash_options[] = {
     {NULL}
 };
 
-int rehash_main(int argc, char **argv)
+int rehash_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO_printf(bio_err, "Not available; use c_rehash script\n");
     return 1;

--- a/apps/req.c
+++ b/apps/req.c
@@ -227,7 +227,7 @@ static int duplicated(LHASH_OF(OPENSSL_STRING) *addexts, char *kv)
     return 0;
 }
 
-int req_main(int argc, char **argv)
+int req_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ASN1_INTEGER *serial = NULL;
     BIO *out = NULL;

--- a/apps/req.c
+++ b/apps/req.c
@@ -476,7 +476,11 @@ int req_main(OPENSSL_CTX *libctx, int argc, char **argv)
         if ((addext_conf = app_load_config_bio(addext_bio, NULL)) == NULL)
             goto end;
     }
-    if (template != default_config_file && !app_load_modules(req_conf))
+    /*
+     * TODO(3.0) When we feel confident enough, use |libctx| as first
+     * argument for app_load_modules()
+     */
+    if (template != default_config_file && !app_load_modules(NULL, req_conf))
         goto end;
 
     if (req_conf != NULL) {

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -71,7 +71,7 @@ const OPTIONS rsa_options[] = {
     {NULL}
 };
 
-int rsa_main(int argc, char **argv)
+int rsa_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     BIO *out = NULL;

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -73,7 +73,7 @@ const OPTIONS rsautl_options[] = {
     {NULL}
 };
 
-int rsautl_main(int argc, char **argv)
+int rsautl_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -897,7 +897,7 @@ static int new_session_cb(SSL *s, SSL_SESSION *sess)
     return 0;
 }
 
-int s_client_main(int argc, char **argv)
+int s_client_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *sbio;
     EVP_PKEY *key = NULL;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1015,7 +1015,7 @@ const OPTIONS s_server_options[] = {
  (o == OPT_SSL3 || o == OPT_TLS1 || o == OPT_TLS1_1 || o == OPT_TLS1_2 \
   || o == OPT_TLS1_3 || o == OPT_DTLS || o == OPT_DTLS1 || o == OPT_DTLS1_2)
 
-int s_server_main(int argc, char *argv[])
+int s_server_main(OPENSSL_CTX *libctx, int argc, char *argv[])
 {
     ENGINE *engine = NULL;
     EVP_PKEY *s_key = NULL, *s_dkey = NULL;

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -112,7 +112,7 @@ static double tm_Time_F(int s)
     return app_tminterval(s, 1);
 }
 
-int s_time_main(int argc, char **argv)
+int s_time_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     char buf[1024 * 8];
     SSL *scon = NULL;

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -45,7 +45,7 @@ const OPTIONS sess_id_options[] = {
 
 static SSL_SESSION *load_sess_id(char *file, int format);
 
-int sess_id_main(int argc, char **argv)
+int sess_id_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     SSL_SESSION *x = NULL;
     X509 *peer = NULL;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -131,7 +131,7 @@ const OPTIONS smime_options[] = {
     {NULL}
 };
 
-int smime_main(int argc, char **argv)
+int smime_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL, *indata = NULL;
     EVP_PKEY *key = NULL;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1437,7 +1437,7 @@ static int run_benchmark(int async_jobs,
 #define stop_it(do_it, test_num)\
     memset(do_it + test_num, 0, OSSL_NELEM(do_it) - test_num);
 
-int speed_main(int argc, char **argv)
+int speed_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     loopargs_t *loopargs = NULL;

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -55,7 +55,7 @@ const OPTIONS spkac_options[] = {
     {NULL}
 };
 
-int spkac_main(int argc, char **argv)
+int spkac_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     BIO *out = NULL;
     CONF *conf = NULL;

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -342,7 +342,11 @@ int srp_main(OPENSSL_CTX *libctx, int argc, char **argv)
         conf = app_load_config(configfile);
         if (conf == NULL)
             goto end;
-        if (configfile != default_config_file && !app_load_modules(conf))
+        /*
+         * TODO(3.0) When we feel confident enough, use |libctx| as first
+         * argument for app_load_modules()
+         */
+        if (configfile != default_config_file && !app_load_modules(NULL, conf))
             goto end;
 
         /* Lets get the config section we are using */

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -226,7 +226,7 @@ const OPTIONS srp_options[] = {
     {NULL}
 };
 
-int srp_main(int argc, char **argv)
+int srp_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     CA_DB *db = NULL;

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -66,7 +66,7 @@ const OPTIONS storeutl_options[] = {
     {NULL}
 };
 
-int storeutl_main(int argc, char *argv[])
+int storeutl_main(OPENSSL_CTX *libctx, int argc, char *argv[])
 {
     int ret = 1, noout = 0, text = 0, recursive = 0;
     char *outfile = NULL, *passin = NULL, *passinarg = NULL;

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -297,7 +297,11 @@ int ts_main(OPENSSL_CTX *libctx, int argc, char **argv)
 
     if ((conf = load_config_file(configfile)) == NULL)
         goto end;
-    if (configfile != default_config_file && !app_load_modules(conf))
+    /*
+     * TODO(3.0) When we feel confident enough, use |libctx| as first
+     * argument for app_load_modules()
+     */
+    if (configfile != default_config_file && !app_load_modules(NULL, conf))
         goto end;
 
     /* Check parameter consistency and execute the appropriate function. */

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -155,7 +155,7 @@ static char* opt_helplist[] = {
     NULL,
 };
 
-int ts_main(int argc, char **argv)
+int ts_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     CONF *conf = NULL;
     const char *CAfile = NULL, *untrusted = NULL, *prog;

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -80,7 +80,7 @@ const OPTIONS verify_options[] = {
     {NULL}
 };
 
-int verify_main(int argc, char **argv)
+int verify_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ENGINE *e = NULL;
     STACK_OF(X509) *untrusted = NULL, *trusted = NULL;

--- a/apps/version.c
+++ b/apps/version.c
@@ -40,7 +40,7 @@ const OPTIONS version_options[] = {
     {NULL}
 };
 
-int version_main(int argc, char **argv)
+int version_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     int ret = 1, dirty = 0, seed = 0;
     int cflags = 0, version = 0, date = 0, options = 0, platform = 0, dir = 0;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -168,7 +168,7 @@ const OPTIONS x509_options[] = {
     {NULL}
 };
 
-int x509_main(int argc, char **argv)
+int x509_main(OPENSSL_CTX *libctx, int argc, char **argv)
 {
     ASN1_INTEGER *sno = NULL;
     ASN1_OBJECT *objtmp = NULL;

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -174,7 +174,7 @@ int CONF_dump_bio(LHASH_OF(CONF_VALUE) *conf, BIO *out)
  * the "CONF classic" functions, for consistency.
  */
 
-CONF *NCONF_new_with_libctx(OPENSSL_CTX *libctx, CONF_METHOD *meth)
+CONF *NCONF_new(CONF_METHOD *meth)
 {
     CONF *ret;
 
@@ -186,14 +186,23 @@ CONF *NCONF_new_with_libctx(OPENSSL_CTX *libctx, CONF_METHOD *meth)
         CONFerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    ret->libctx = libctx;
 
     return ret;
 }
 
-CONF *NCONF_new(CONF_METHOD *meth)
+int NCONF_set_libctx(CONF *conf, OPENSSL_CTX *libctx)
 {
-    return NCONF_new_with_libctx(NULL, meth);
+    if (conf == NULL)
+        return 0;
+    conf->libctx = libctx;
+    return 1;
+}
+
+OPENSSL_CTX *NCONF_get_libctx(const CONF *conf)
+{
+    if (conf == NULL)
+        return NULL;
+    return conf->libctx;
 }
 
 void NCONF_free(CONF *conf)

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -129,8 +129,7 @@ int CONF_modules_load_file_with_libctx(OPENSSL_CTX *libctx,
     CONF *conf = NULL;
     int ret = 0;
 
-    conf = NCONF_new_with_libctx(libctx, NULL);
-    if (conf == NULL)
+    if ((conf = NCONF_new(NULL)) == NULL || !NCONF_set_libctx(conf, libctx))
         goto err;
 
     if (filename == NULL) {

--- a/crypto/evp/evp_cnf.c
+++ b/crypto/evp/evp_cnf.c
@@ -22,6 +22,7 @@ DEFINE_STACK_OF(CONF_VALUE)
 static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
 {
     int i;
+    OPENSSL_CTX *libctx;
     const char *oid_section;
     STACK_OF(CONF_VALUE) *sktmp;
     CONF_VALUE *oval;
@@ -29,6 +30,7 @@ static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
     OSSL_TRACE2(CONF, "Loading EVP module: name %s, value %s\n",
                 CONF_imodule_get_name(md), CONF_imodule_get_value(md));
 
+    libctx = NCONF_get_libctx(cnf);
     oid_section = CONF_imodule_get_value(md);
     if ((sktmp = NCONF_get_section(cnf, oid_section)) == NULL) {
         EVPerr(EVP_F_ALG_MODULE_INIT, EVP_R_ERROR_LOADING_SECTION);
@@ -47,12 +49,12 @@ static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
              * fips_mode is deprecated and should not be used in new
              * configurations.
              */
-            if (!EVP_default_properties_enable_fips(cnf->libctx, m > 0)) {
+            if (!EVP_default_properties_enable_fips(libctx, m > 0)) {
                 EVPerr(EVP_F_ALG_MODULE_INIT, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }
         } else if (strcmp(oval->name, "default_properties") == 0) {
-            if (!EVP_set_default_properties(cnf->libctx, oval->value)) {
+            if (!EVP_set_default_properties(libctx, oval->value)) {
                 EVPerr(EVP_F_ALG_MODULE_INIT, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -148,12 +148,15 @@ static int provider_conf_load(OPENSSL_CTX *libctx, const char *name,
 
 static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)
 {
+    OPENSSL_CTX *libctx;
     STACK_OF(CONF_VALUE) *elist;
     CONF_VALUE *cval;
     int i;
 
     OSSL_TRACE1(CONF, "Loading providers module: section %s\n",
                 CONF_imodule_get_value(md));
+
+    libctx = NCONF_get_libctx(cnf);
 
     /* Value is a section containing PROVIDERs to configure */
     elist = NCONF_get_section(cnf, CONF_imodule_get_value(md));
@@ -166,7 +169,7 @@ static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)
 
     for (i = 0; i < sk_CONF_VALUE_num(elist); i++) {
         cval = sk_CONF_VALUE_value(elist, i);
-        if (!provider_conf_load(cnf->libctx, cval->name, cval->value, cnf))
+        if (!provider_conf_load(libctx, cval->name, cval->value, cnf))
             return 0;
     }
 

--- a/doc/man3/CONF_modules_load_file.pod
+++ b/doc/man3/CONF_modules_load_file.pod
@@ -122,7 +122,8 @@ Load and parse configuration file manually, custom error handling:
      fprintf(stderr, "Error opening configuration file\n");
      /* Other missing configuration file behaviour */
  } else {
-     cnf = NCONF_new_with_libctx(libctx, NULL);
+     cnf = NCONF_new(libctx);
+     NCONF_set_libctx(cnf, libctx);
      if (NCONF_load_fp(cnf, fp, &eline) == 0) {
          fprintf(stderr, "Error on line %ld of configuration file\n", eline);
          ERR_print_errors_fp(stderr);
@@ -140,7 +141,7 @@ Load and parse configuration file manually, custom error handling:
 
 L<config(5)>,
 L<OPENSSL_config(3)>,
-L<NCONF_new_with_libctx(3)>
+L<NCONF_new(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/NCONF_new.pod
+++ b/doc/man3/NCONF_new.pod
@@ -2,29 +2,34 @@
 
 =head1 NAME
 
-NCONF_new_with_libctx, NCONF_new, NCONF_free, NCONF_default, NCONF_load
+NCONF_new, NCONF_set_libctx, NCONF_get_libctx, NCONF_free, NCONF_default,
+NCONF_load
 - functionality to Load and parse configuration files manually
 
 =head1 SYNOPSIS
 
  #include <openssl/conf.h>
 
- CONF *NCONF_new_with_libctx(OPENSSL_CTX *libctx, CONF_METHOD *meth);
  CONF *NCONF_new(CONF_METHOD *meth);
+ int NCONF_set_libctx(CONF *conf, OPENSSL_CTX *libctx);
+ OPENSSL_CTX *NCONF_get_libctx(const CONF *conf);
  void NCONF_free(CONF *conf);
  CONF_METHOD *NCONF_default(void);
  int NCONF_load(CONF *conf, const char *file, long *eline);
 
 =head1 DESCRIPTION
 
-NCONF_new_with_libctx() creates a new CONF object in heap memory and assigns to
-it a context I<libctx> that can be used during loading. If the method table
-I<meth> is set to NULL then the default value of NCONF_default() is used.
-
-NCONF_new() is similar to NCONF_new_with_libctx() but sets the I<libctx> to NULL.
+NCONF_new() creates a new CONF object. If the method table I<meth> is set to
+NULL then the default value of NCONF_default() is used.
 
 NCONF_free() frees the data associated with I<conf> and then frees the I<conf>
 object.
+
+NCONF_set_libctx() assigns the context I<libctx> to the CONF object I<conf>.
+This library context can be used when needed when processing I<conf>, such
+as when calling L<CONF_modules_load(3)> with it.
+
+NCONF_get_libctx() returns the library context that is assigned to I<conf>.
 
 NCONF_load() parses the file named I<filename> and adds the values found to
 I<conf>. If an error occurs I<file> and I<eline> list the file and line that
@@ -34,10 +39,14 @@ NCONF_default() gets the default method table for processing a configuration fil
 
 =head1 RETURN VALUES
 
-NCONF_load() returns 1 on success or 0 on error.
+NCONF_new() return a newly created I<CONF> object or NULL if an error occurs.
 
-NCONF_new_with_libctx() and NCONF_new() return a newly created I<CONF> object
-or NULL if an error occurs.
+NCONF_set_libctx() returns 1 on success or 0 on error.
+
+NCONF_get_libctx() returns the library context assigned to the B<CONF>.
+NULL is the default library context.
+
+NCONF_load() returns 1 on success or 0 on error.
 
 =head1 SEE ALSO
 

--- a/include/openssl/conf.h
+++ b/include/openssl/conf.h
@@ -115,10 +115,11 @@ struct conf_st {
     OPENSSL_CTX *libctx;
 };
 
-CONF *NCONF_new_with_libctx(OPENSSL_CTX *libctx, CONF_METHOD *meth);
 CONF *NCONF_new(CONF_METHOD *meth);
 CONF_METHOD *NCONF_default(void);
 DEPRECATEDIN_3_0(CONF_METHOD *NCONF_WIN32(void))
+int NCONF_set_libctx(CONF *confxb, OPENSSL_CTX *libctx);
+OPENSSL_CTX *NCONF_get_libctx(const CONF *conf);
 void NCONF_free(CONF *conf);
 void NCONF_free_data(CONF *conf);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5000,7 +5000,6 @@ EVP_PKEY_gen                            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_rsa_keygen_bits        ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_keygen_pubexp      ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_keygen_primes      ?	3_0_0	EXIST::FUNCTION:RSA
-NCONF_new_with_libctx                   ?	3_0_0	EXIST::FUNCTION:
 CONF_modules_load_file_with_libctx      ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_CTX_load_config                 ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_to_param                 ?	3_0_0	EXIST::FUNCTION:
@@ -5097,3 +5096,5 @@ OSSL_PROVIDER_do_all                    ?	3_0_0	EXIST::FUNCTION:
 X509_PUBKEY_eq                          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_eq                             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_parameters_eq                  ?	3_0_0	EXIST::FUNCTION:
+NCONF_set_libctx                        ?	3_0_0	EXIST::FUNCTION:
+NCONF_get_libctx                        ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This turned out to have some consequences...  the NCONF functionality is slightly modified to give better flexibility.

Note that none of the sub-commands are modified to use the create library context, but it's there.  The subcommands can now be modified gradually to use it.