### PR TITLE
Misc apps fixes [2020-05-28]

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -15,6 +15,7 @@
 # include "internal/sockets.h" /* for openssl_fdset() */
 # include <assert.h>
 
+# include <stdarg.h>
 # include <sys/types.h>
 # ifndef OPENSSL_NO_POSIX_IO
 #  include <sys/stat.h>
@@ -179,6 +180,7 @@ typedef struct ca_db_st {
 # endif
 } CA_DB;
 
+void app_bail_out(char *fmt, ...);
 void* app_malloc(int sz, const char *what);
 BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai);
 int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -671,16 +671,24 @@ static int load_certs_crls(const char *file, int format,
     return rv;
 }
 
+void app_bail_out(char *fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    BIO_vprintf(bio_err, fmt, args);
+    va_end(args);
+    ERR_print_errors(bio_err);
+    exit(1);
+}
+
 void* app_malloc(int sz, const char *what)
 {
     void *vp = OPENSSL_malloc(sz);
 
-    if (vp == NULL) {
-        BIO_printf(bio_err, "%s: Could not allocate %d bytes for %s\n",
-                opt_getprog(), sz, what);
-        ERR_print_errors(bio_err);
-        exit(1);
-    }
+    if (vp == NULL)
+        app_bail_out("%s: Could not allocate %d bytes for %s\n",
+                     opt_getprog(), sz, what);
     return vp;
 }
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -222,7 +222,6 @@ int main(int argc, char *argv[])
     arg.size = 0;
 
     /* Set up some of the environment. */
-    default_config_file = CONF_get1_default_config_file();
     bio_in = dup_bio_in(FORMAT_TEXT);
     bio_out = dup_bio_out(FORMAT_TEXT);
     bio_err = dup_bio_err(FORMAT_TEXT);
@@ -262,6 +261,10 @@ int main(int argc, char *argv[])
         goto end;
     }
     pname = opt_progname(argv[0]);
+
+    default_config_file = CONF_get1_default_config_file();
+    if (default_config_file == NULL)
+        app_bail_out("%s: could not get default config file\n", pname);
 
     /* first check the program name */
     f.name = pname;

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -80,27 +80,6 @@ static void apps_shutdown(void)
     destroy_ui_method();
 }
 
-static char *make_config_name(void)
-{
-    const char *t;
-    size_t len;
-    char *p;
-
-    if ((t = getenv("OPENSSL_CONF")) != NULL)
-        return OPENSSL_strdup(t);
-
-    t = X509_get_default_cert_area();
-    len = strlen(t) + 1 + strlen(OPENSSL_CONF) + 1;
-    p = app_malloc(len, "config filename buffer");
-    strcpy(p, t);
-#ifndef OPENSSL_SYS_VMS
-    strcat(p, "/");
-#endif
-    strcat(p, OPENSSL_CONF);
-
-    return p;
-}
-
 
 #ifndef OPENSSL_NO_TRACE
 typedef struct tracedata_st {
@@ -243,7 +222,7 @@ int main(int argc, char *argv[])
     arg.size = 0;
 
     /* Set up some of the environment. */
-    default_config_file = make_config_name();
+    default_config_file = CONF_get1_default_config_file();
     bio_in = dup_bio_in(FORMAT_TEXT);
     bio_out = dup_bio_out(FORMAT_TEXT);
     bio_err = dup_bio_err(FORMAT_TEXT);

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -516,25 +516,23 @@ void CONF_module_set_usr_data(CONF_MODULE *pmod, void *usr_data)
 
 char *CONF_get1_default_config_file(void)
 {
+    const char *t;
     char *file, *sep = "";
-    int len;
+    int size;
 
     if ((file = ossl_safe_getenv("OPENSSL_CONF")) != NULL)
         return OPENSSL_strdup(file);
 
-    len = strlen(X509_get_default_cert_area());
+    t = X509_get_default_cert_area();
 #ifndef OPENSSL_SYS_VMS
-    len++;
     sep = "/";
 #endif
-    len += strlen(OPENSSL_CONF);
-
-    file = OPENSSL_malloc(len + 1);
+    size = strlen(t) + strlen(sep) + strlen(OPENSSL_CONF) + 1;
+    file = OPENSSL_malloc(size);
 
     if (file == NULL)
         return NULL;
-    BIO_snprintf(file, len + 1, "%s%s%s", X509_get_default_cert_area(),
-                 sep, OPENSSL_CONF);
+    BIO_snprintf(file, size, "%s%s%s", t, sep, OPENSSL_CONF);
 
     return file;
 }

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -518,7 +518,7 @@ char *CONF_get1_default_config_file(void)
 {
     const char *t;
     char *file, *sep = "";
-    int size;
+    size_t size;
 
     if ((file = ossl_safe_getenv("OPENSSL_CONF")) != NULL)
         return OPENSSL_strdup(file);


### PR DESCRIPTION
`make_config_name()` is a duplicate of `CONF_get1_default_config_file()`, so drop it.

`apps/progs.pl` has strange results when it's running in a national locale.  For example, `w` isn't matched by the regular expression `[a-z]` in the Swedish locale (which means `passwd_main` isn't matched, for example).  To avoid that sort of surprise, we set the "C" locale.