### PR TITLE
Add CBC cipher list

### DIFF
--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -406,8 +406,8 @@ permissible.
 =item B<CBC>
 
 All cipher suites using encryption algorithm in Cipher Block Chaining (CBC)
-mode. These cipher suites are only supported in TLS v1.2. Currently it's alias
-for following cipherstrings: B<SSL_DES>, B<SSL_3DES>, B<SSL_RC2>, B<SSL_IDEA>,
+mode. These cipher suites are only supported in TLS v1.2 and earlier. Currently
+it's alias for following cipherstrings: B<SSL_DES>, B<SSL_3DES>, B<SSL_RC2>, B<SSL_IDEA>,
 B<SSL_AES128>, B<SSL_AES256>, B<SSL_CAMELLIA128>, B<SSL_CAMELLIA256>, B<SSL_SEED>.
 
 =back

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -403,6 +403,13 @@ used and only the two suite B compliant cipher suites
 (ECDHE-ECDSA-AES128-GCM-SHA256 and ECDHE-ECDSA-AES256-GCM-SHA384) are
 permissible.
 
+=item B<CBC>
+
+All cipher suites using encryption algorithm in Cipher Block Chaining (CBC)
+mode. These cipher suites are only supported in TLS v1.2. Currently it's alias
+for following cipherstrings: B<SSL_DES>, B<SSL_3DES>, B<SSL_RC2>, B<SSL_IDEA>,
+B<SSL_AES128>, B<SSL_AES256>, B<SSL_CAMELLIA128>, B<SSL_CAMELLIA256>, B<SSL_SEED>.
+
 =back
 
 =head1 CIPHER SUITE NAMES

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -138,6 +138,7 @@ extern "C" {
 # define SSL_TXT_ARIA128         "ARIA128"
 # define SSL_TXT_ARIA256         "ARIA256"
 # define SSL_TXT_GOST2012_GOST8912_GOST8912 "GOST2012-GOST8912-GOST8912"
+# define SSL_TXT_CBC             "CBC"
 
 # define SSL_TXT_MD5             "MD5"
 # define SSL_TXT_SHA1            "SHA1"

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -253,6 +253,7 @@ static const SSL_CIPHER cipher_aliases[] = {
     {0, SSL_TXT_ARIA_GCM, NULL, 0, 0, 0, SSL_ARIA128GCM | SSL_ARIA256GCM},
     {0, SSL_TXT_ARIA128, NULL, 0, 0, 0, SSL_ARIA128GCM},
     {0, SSL_TXT_ARIA256, NULL, 0, 0, 0, SSL_ARIA256GCM},
+    {0, SSL_TXT_CBC, NULL, 0, 0, 0, SSL_CBC},
 
     /* MAC aliases */
     {0, SSL_TXT_MD5, NULL, 0, 0, 0, 0, SSL_MD5},

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -246,6 +246,9 @@
 # define SSL_CHACHA20            (SSL_CHACHA20POLY1305)
 # define SSL_ARIAGCM             (SSL_ARIA128GCM | SSL_ARIA256GCM)
 # define SSL_ARIA                (SSL_ARIAGCM)
+# define SSL_CBC                 (SSL_DES | SSL_3DES | SSL_RC2 | SSL_IDEA \
+                                  | SSL_AES128 | SSL_AES256 | SSL_CAMELLIA128 \
+                                  | SSL_CAMELLIA256 | SSL_SEED)
 
 /* Bits for algorithm_mac (symmetric authentication) */
 


### PR DESCRIPTION
Add cipher list for ciphersuites which using encryption algorithm in mode CBC.

Cipher list `CBC` is alias for following cipherstrings:
* `SSL_DES`
* `SSL_3DES`
* `SSL_RC2`
* `SSL_IDEA`
* `SSL_AES256`
* `SSL_CAMELLIA128`
* `SSL_CAMELLIA256`
* `SSL_SEED`


This commit adds this feature https://github.com/openssl/openssl/issues/9706