### PR TITLE
fix a docs typo

### DIFF
--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -146,7 +146,7 @@ Modern versions should instead switch to named curves which OpenSSL has
 hardcoded lookup tables for.
 
 EC_KEY_oct2key() and EC_KEY_key2buf() are identical to the functions
-EC_POINT_oct2point() and EC_KEY_point2buf() except they use the public key
+EC_POINT_oct2point() and EC_POINT_point2buf() except they use the public key
 EC_POINT in B<eckey>.
 
 EC_KEY_oct2priv() and EC_KEY_priv2oct() convert between the private key


### PR DESCRIPTION
Correct "EC_KEY_point2buf" to "EC_POINT_point2buf". The former does not exist.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
