### PR TITLE
Remove getenv(OPENSSL_FIPS) in openssl command

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -261,11 +261,6 @@ int main(int argc, char *argv[])
     setup_trace(getenv("OPENSSL_TRACE"));
 #endif
 
-    if (getenv("OPENSSL_FIPS")) {
-        BIO_printf(bio_err, "FIPS mode not supported.\n");
-        return 1;
-    }
-
     if (!apps_startup()) {
         BIO_printf(bio_err,
                    "FATAL: Startup failure (dev note: apps_startup() failed)\n");


### PR DESCRIPTION
This is left over from the past.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
