### PR TITLE
kdf: make function naming consistent.

### DIFF
--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -104,7 +104,7 @@ opthelp:
         goto opthelp;
     }
 
-    ctx = EVP_KDF_CTX_new(kdf);
+    ctx = EVP_KDF_new_ctx(kdf);
     if (ctx == NULL)
         goto err;
 
@@ -116,7 +116,7 @@ opthelp:
         if (params == NULL)
             goto err;
 
-        if (!EVP_KDF_CTX_set_params(ctx, params)) {
+        if (!EVP_KDF_set_ctx_params(ctx, params)) {
             BIO_printf(bio_err, "KDF parameter error\n");
             ERR_print_errors(bio_err);
             ok = 0;
@@ -161,7 +161,7 @@ err:
     OPENSSL_clear_free(dkm_bytes, dkm_len);
     sk_OPENSSL_STRING_free(opts);
     EVP_KDF_free(kdf);
-    EVP_KDF_CTX_free(ctx);
+    EVP_KDF_free_ctx(ctx);
     BIO_free(out);
     OPENSSL_free(hexout);
     return ret;

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -46,7 +46,7 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
         return 0;
 
     kdf = EVP_KDF_fetch(provctx, OSSL_KDF_NAME_X942KDF, NULL);
-    if ((kctx = EVP_KDF_CTX_new(kdf)) == NULL)
+    if ((kctx = EVP_KDF_new_ctx(kdf)) == NULL)
         goto err;
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
                                             (char *)mdname, 0);
@@ -58,10 +58,10 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CEK_ALG,
                                             (char *)oid_sn, 0);
     *p = OSSL_PARAM_construct_end();
-    ret = EVP_KDF_CTX_set_params(kctx, params) > 0
+    ret = EVP_KDF_set_ctx_params(kctx, params) > 0
         && EVP_KDF_derive(kctx, out, outlen) > 0;
 err:
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     EVP_KDF_free(kdf);
     return ret;
 }

--- a/crypto/ec/ecdh_kdf.c
+++ b/crypto/ec/ecdh_kdf.c
@@ -32,7 +32,7 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
     const char *mdname = EVP_MD_name(md);
     EVP_KDF *kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_X963KDF, NULL);
 
-    if ((kctx = EVP_KDF_CTX_new(kdf)) != NULL) {
+    if ((kctx = EVP_KDF_new_ctx(kdf)) != NULL) {
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
                                                 (char *)mdname, 0);
         *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
@@ -41,9 +41,9 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
                                                  (void *)sinfo, sinfolen);
         *p = OSSL_PARAM_construct_end();
 
-        ret = EVP_KDF_CTX_set_params(kctx, params) > 0
+        ret = EVP_KDF_set_ctx_params(kctx, params) > 0
             && EVP_KDF_derive(kctx, out, outlen) > 0;
-        EVP_KDF_CTX_free(kctx);
+        EVP_KDF_free_ctx(kctx);
     }
     EVP_KDF_free(kdf);
     return ret;

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -23,7 +23,7 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf)
+EVP_KDF_CTX *EVP_KDF_new_ctx(EVP_KDF *kdf)
 {
     EVP_KDF_CTX *ctx = NULL;
 
@@ -34,7 +34,7 @@ EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf)
     if (ctx == NULL
         || (ctx->data = kdf->newctx(ossl_provider_ctx(kdf->prov))) == NULL
         || !EVP_KDF_up_ref(kdf)) {
-        EVPerr(EVP_F_EVP_KDF_CTX_NEW, ERR_R_MALLOC_FAILURE);
+        EVPerr(0, ERR_R_MALLOC_FAILURE);
         if (ctx != NULL)
             kdf->freectx(ctx->data);
         OPENSSL_free(ctx);
@@ -45,7 +45,7 @@ EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf)
     return ctx;
 }
 
-void EVP_KDF_CTX_free(EVP_KDF_CTX *ctx)
+void EVP_KDF_free_ctx(EVP_KDF_CTX *ctx)
 {
     if (ctx != NULL) {
         ctx->meth->freectx(ctx->data);
@@ -55,7 +55,7 @@ void EVP_KDF_CTX_free(EVP_KDF_CTX *ctx)
     }
 }
 
-EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src)
+EVP_KDF_CTX *EVP_KDF_dup_ctx(const EVP_KDF_CTX *src)
 {
     EVP_KDF_CTX *dst;
 
@@ -64,20 +64,20 @@ EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src)
 
     dst = OPENSSL_malloc(sizeof(*dst));
     if (dst == NULL) {
-        EVPerr(EVP_F_EVP_KDF_CTX_DUP, ERR_R_MALLOC_FAILURE);
+        EVPerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
     memcpy(dst, src, sizeof(*dst));
     if (!EVP_KDF_up_ref(dst->meth)) {
-        EVPerr(EVP_F_EVP_KDF_CTX_DUP, ERR_R_MALLOC_FAILURE);
+        EVPerr(0, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(dst);
         return NULL;
     }
 
     dst->data = src->meth->dupctx(src->data);
     if (dst->data == NULL) {
-        EVP_KDF_CTX_free(dst);
+        EVP_KDF_free_ctx(dst);
         return NULL;
     }
     return dst;
@@ -98,7 +98,7 @@ const OSSL_PROVIDER *EVP_KDF_provider(const EVP_KDF *kdf)
     return kdf->prov;
 }
 
-const EVP_KDF *EVP_KDF_CTX_kdf(EVP_KDF_CTX *ctx)
+const EVP_KDF *EVP_KDF_get_ctx_kdf(EVP_KDF_CTX *ctx)
 {
     return ctx->meth;
 }
@@ -151,14 +151,14 @@ int EVP_KDF_get_params(EVP_KDF *kdf, OSSL_PARAM params[])
     return 1;
 }
 
-int EVP_KDF_CTX_get_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[])
+int EVP_KDF_get_ctx_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[])
 {
     if (ctx->meth->get_ctx_params != NULL)
         return ctx->meth->get_ctx_params(ctx->data, params);
     return 1;
 }
 
-int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[])
+int EVP_KDF_set_ctx_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[])
 {
     if (ctx->meth->set_ctx_params != NULL)
         return ctx->meth->set_ctx_params(ctx->data, params);

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -41,7 +41,7 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
         salt = (unsigned char *)empty;
 
     kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_PBKDF2, NULL);
-    kctx = EVP_KDF_CTX_new(kdf);
+    kctx = EVP_KDF_new_ctx(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL)
         return 0;
@@ -54,11 +54,11 @@ int PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
                                             (char *)mdname, 0);
     *p = OSSL_PARAM_construct_end();
-    if (EVP_KDF_CTX_set_params(kctx, params) != 1
+    if (EVP_KDF_set_ctx_params(kctx, params) != 1
             || EVP_KDF_derive(kctx, out, keylen) != 1)
         rv = 0;
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
 
     OSSL_TRACE_BEGIN(PKCS5V2) {
         BIO_printf(trc_out, "Password:\n");

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -63,7 +63,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
         maxmem = SCRYPT_MAX_MEM;
 
     kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_SCRYPT, NULL);
-    kctx = EVP_KDF_CTX_new(kdf);
+    kctx = EVP_KDF_new_ctx(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL)
         return 0;
@@ -78,11 +78,11 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     *z++ = OSSL_PARAM_construct_uint64(OSSL_KDF_PARAM_SCRYPT_P, &p);
     *z++ = OSSL_PARAM_construct_uint64(OSSL_KDF_PARAM_SCRYPT_MAXMEM, &maxmem);
     *z = OSSL_PARAM_construct_end();
-    if (EVP_KDF_CTX_set_params(kctx, params) != 1
+    if (EVP_KDF_set_ctx_params(kctx, params) != 1
             || EVP_KDF_derive(kctx, key, keylen) != 1)
         rv = 0;
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return rv;
 }
 

--- a/crypto/evp/pkey_kdf.c
+++ b/crypto/evp/pkey_kdf.c
@@ -50,7 +50,7 @@ static int pkey_kdf_init(EVP_PKEY_CTX *ctx)
         return 0;
 
     kdf = EVP_KDF_fetch(NULL, kdf_name, NULL);
-    kctx = EVP_KDF_CTX_new(kdf);
+    kctx = EVP_KDF_new_ctx(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL) {
         OPENSSL_free(pkctx);
@@ -66,7 +66,7 @@ static void pkey_kdf_cleanup(EVP_PKEY_CTX *ctx)
 {
     EVP_PKEY_KDF_CTX *pkctx = ctx->data;
 
-    EVP_KDF_CTX_free(pkctx->kctx);
+    EVP_KDF_free_ctx(pkctx->kctx);
     pkey_kdf_free_collected(pkctx);
     OPENSSL_free(pkctx);
 }
@@ -202,7 +202,7 @@ static int pkey_kdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         break;
     }
 
-    return EVP_KDF_CTX_set_params(kctx, params);
+    return EVP_KDF_set_ctx_params(kctx, params);
 }
 
 static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
@@ -210,7 +210,7 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
 {
     EVP_PKEY_KDF_CTX *pkctx = ctx->data;
     EVP_KDF_CTX *kctx = pkctx->kctx;
-    const EVP_KDF *kdf = EVP_KDF_CTX_kdf(kctx);
+    const EVP_KDF *kdf = EVP_KDF_get_ctx_kdf(kctx);
     BUF_MEM **collector = NULL;
     const OSSL_PARAM *defs = EVP_KDF_settable_ctx_params(kdf);
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
@@ -239,7 +239,7 @@ static int pkey_kdf_ctrl_str(EVP_PKEY_CTX *ctx, const char *type,
     if (collector != NULL)
         ok = collect(collector, params[0].data, params[0].data_size);
     else
-        ok = EVP_KDF_CTX_set_params(kctx, params);
+        ok = EVP_KDF_set_ctx_params(kctx, params);
     OPENSSL_free(params[0].data);
     return ok;
 }
@@ -274,7 +274,7 @@ static int pkey_kdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
                                               pkctx->collected_seed->data,
                                               pkctx->collected_seed->length);
 
-        r = EVP_KDF_CTX_set_params(kctx, params);
+        r = EVP_KDF_set_ctx_params(kctx, params);
         pkey_kdf_free_collected(pkctx);
         if (!r)
             return 0;
@@ -287,7 +287,7 @@ static int pkey_kdf_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
                                               pkctx->collected_info->data,
                                               pkctx->collected_info->length);
 
-        r = EVP_KDF_CTX_set_params(kctx, params);
+        r = EVP_KDF_set_ctx_params(kctx, params);
         pkey_kdf_free_collected(pkctx);
         if (!r)
             return 0;

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -46,7 +46,7 @@ Output the derived key in binary form. Uses hexadecimal text format if not speci
 Passes options to the KDF algorithm.
 A comprehensive list of parameters can be found in the EVP_KDF_CTX
 implementation documentation.
-Common parameter names used by EVP_KDF_CTX_set_params() are:
+Common parameter names used by EVP_KDF_set_ctx_params() are:
 
 =over 4
 

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -3,11 +3,11 @@
 =head1 NAME
 
 EVP_KDF, EVP_KDF_fetch, EVP_KDF_free, EVP_KDF_up_ref,
-EVP_KDF_CTX, EVP_KDF_CTX_new, EVP_KDF_CTX_free, EVP_KDF_CTX_dup,
+EVP_KDF_CTX, EVP_KDF_new_ctx, EVP_KDF_free_ctx, EVP_KDF_dup_ctx,
 EVP_KDF_reset, EVP_KDF_derive,
-EVP_KDF_size, EVP_KDF_provider, EVP_KDF_CTX_kdf, EVP_KDF_is_a,
+EVP_KDF_size, EVP_KDF_provider, EVP_KDF_get_ctx_kdf, EVP_KDF_is_a,
 EVP_KDF_number, EVP_KDF_names_do_all,
-EVP_KDF_CTX_get_params, EVP_KDF_CTX_set_params, EVP_KDF_do_all_provided,
+EVP_KDF_get_ctx_params, EVP_KDF_set_ctx_params, EVP_KDF_do_all_provided,
 EVP_KDF_get_params, EVP_KDF_gettable_ctx_params, EVP_KDF_settable_ctx_params,
 EVP_KDF_gettable_params - EVP KDF routines
 
@@ -18,10 +18,10 @@ EVP_KDF_gettable_params - EVP KDF routines
  typedef struct evp_kdf_st EVP_KDF;
  typedef struct evp_kdf_ctx_st EVP_KDF_CTX;
 
- EVP_KDF_CTX *EVP_KDF_CTX_new(const EVP_KDF *kdf);
- const EVP_KDF *EVP_KDF_CTX_kdf(EVP_KDF_CTX *ctx);
- void EVP_KDF_CTX_free(EVP_KDF_CTX *ctx);
- EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src);
+ EVP_KDF_CTX *EVP_KDF_new_ctx(const EVP_KDF *kdf);
+ const EVP_KDF *EVP_KDF_get_ctx_kdf(EVP_KDF_CTX *ctx);
+ void EVP_KDF_free_ctx(EVP_KDF_CTX *ctx);
+ EVP_KDF_CTX *EVP_KDF_dup_ctx(const EVP_KDF_CTX *src);
  void EVP_KDF_reset(EVP_KDF_CTX *ctx);
  size_t EVP_KDF_size(EVP_KDF_CTX *ctx);
  int EVP_KDF_derive(EVP_KDF_CTX *ctx, unsigned char *key, size_t keylen);
@@ -39,8 +39,8 @@ EVP_KDF_gettable_params - EVP KDF routines
                            void (*fn)(const char *name, void *data),
                            void *data);
  int EVP_KDF_get_params(EVP_KDF *kdf, OSSL_PARAM params[]);
- int EVP_KDF_CTX_get_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[]);
- int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[]);
+ int EVP_KDF_get_ctx_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[]);
+ int EVP_KDF_set_ctx_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[]);
  const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf);
  const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf);
  const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf);
@@ -52,8 +52,8 @@ The EVP KDF routines are a high level interface to Key Derivation Function
 algorithms and should be used instead of algorithm-specific functions.
 
 After creating a B<EVP_KDF_CTX> for the required algorithm using
-EVP_KDF_CTX_new(), inputs to the algorithm are supplied
-using calls to EVP_KDF_CTX_set_params() before
+EVP_KDF_new_ctx(), inputs to the algorithm are supplied
+using calls to EVP_KDF_set_ctx_params() before
 calling EVP_KDF_derive() to derive the key.
 
 =head2 Types
@@ -82,12 +82,12 @@ NULL is a valid parameter, for which this function is a no-op.
 
 =head2 Context manipulation functions
 
-EVP_KDF_CTX_new() creates a new context for the KDF implementation I<kdf>.
+EVP_KDF_new_ctx() creates a new context for the KDF implementation I<kdf>.
 
-EVP_KDF_CTX_free() frees up the context I<ctx>.  If I<ctx> is NULL, nothing
+EVP_KDF_free_ctx() frees up the context I<ctx>.  If I<ctx> is NULL, nothing
 is done.
 
-EVP_KDF_CTX_kdf() returns the B<EVP_KDF> associated with the context
+EVP_KDF_get_ctx_kdf() returns the B<EVP_KDF> associated with the context
 I<ctx>.
 
 =head2 Computing functions
@@ -107,14 +107,14 @@ parameters should be retrieved.
 Note that a parameter that is unknown in the underlying context is
 simply ignored.
 
-EVP_KDF_CTX_get_params() retrieves chosen parameters, given the
+EVP_KDF_get_ctx_params() retrieves chosen parameters, given the
 context I<ctx> and its underlying context.
 The set of parameters given with I<params> determine exactly what
 parameters should be retrieved.
 Note that a parameter that is unknown in the underlying context is
 simply ignored.
 
-EVP_KDF_CTX_set_params() passes chosen parameters to the underlying
+EVP_KDF_set_ctx_params() passes chosen parameters to the underlying
 context, given a context I<ctx>.
 The set of parameters given with I<params> determine exactly what
 parameters are passed down.
@@ -126,8 +126,8 @@ defined by the implementation.
 EVP_KDF_gettable_params(), EVP_KDF_gettable_ctx_params() and
 EVP_KDF_settable_ctx_params() get a constant B<OSSL_PARAM> array that
 describes the retrievable and settable parameters, i.e. parameters that
-can be used with EVP_KDF_get_params(), EVP_KDF_CTX_get_params()
-and EVP_KDF_CTX_set_params(), respectively.
+can be used with EVP_KDF_get_params(), EVP_KDF_get_ctx_params()
+and EVP_KDF_set_ctx_params(), respectively.
 See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
 
 =head2 Information functions
@@ -237,10 +237,10 @@ NULL on error.
 
 EVP_KDF_up_ref() returns 1 on success, 0 on error.
 
-EVP_KDF_CTX_new() returns either the newly allocated
+EVP_KDF_new_ctx() returns either the newly allocated
 B<EVP_KDF_CTX> structure or NULL if an error occurred.
 
-EVP_KDF_CTX_free() and EVP_KDF_reset() do not return a value.
+EVP_KDF_free_ctx() and EVP_KDF_reset() do not return a value.
 
 EVP_KDF_size() returns the output size.  B<SIZE_MAX> is returned to indicate
 that the algorithm produces a variable amount of output; 0 to indicate failure.

--- a/doc/man7/EVP_KDF-HKDF.pod
+++ b/doc/man7/EVP_KDF-HKDF.pod
@@ -87,7 +87,7 @@ an error will occur.
 A context for HKDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "HKDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of an HKDF expand operation is specified via the I<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.  When using
@@ -107,7 +107,7 @@ salt value "salt" and info value "label":
  OSSL_PARAM params[5], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "HKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -119,14 +119,14 @@ salt value "salt" and info value "label":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                           "salt", (size_t)4);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
  }
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -135,10 +135,10 @@ RFC 5869
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
 L<EVP_KDF_size(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>
 

--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -57,7 +57,7 @@ Depending on whether mac is CMAC or HMAC, either digest or cipher is required
 A context for KBKDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of an KBKDF is specified via the C<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.
@@ -76,7 +76,7 @@ Label "label", and Context "context".
  OSSL_PARAM params[6], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -90,12 +90,12 @@ Label "label", and Context "context".
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "context", strlen("context"));
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0)
+     error("EVP_KDF_set_ctx_params");
  else if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0)
      error("EVP_KDF_derive");
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 This example derives 10 bytes using FEEDBACK-CMAC-AES256, with KI "secret",
 Label "label", and IV "sixteen bytes iv".
@@ -107,7 +107,7 @@ Label "label", and IV "sixteen bytes iv".
  unsigned char *iv = "sixteen bytes iv";
 
  kdf = EVP_KDF_fetch(NULL, "KBKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER, "AES256", 0);
@@ -122,12 +122,12 @@ Label "label", and IV "sixteen bytes iv".
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
                                           iv, strlen(iv));
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0)
+     error("EVP_KDF_set_ctx_params");
  else if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0)
      error("EVP_KDF_derive");
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -136,7 +136,7 @@ NIST SP800-108, IETF RFC 6803, IETF RFC 8009.
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_free(3)>,
+L<EVP_KDF_free_ctx(3)>,
 L<EVP_KDF_size(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>

--- a/doc/man7/EVP_KDF-KRB5KDF.pod
+++ b/doc/man7/EVP_KDF-KRB5KDF.pod
@@ -44,7 +44,7 @@ If a value is already set, the contents are replaced.
 A context for KRB5KDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "KRB5KDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of the KRB5KDF derivation is specified via the I<keylen>
 parameter to the L<EVP_KDF_derive(3)> function, and MUST match the key
@@ -70,7 +70,7 @@ This example derives a key using the AES-128-CBC cipher:
  OSSL_PARAM params[4], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "KRB5KDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER,
@@ -87,7 +87,7 @@ This example derives a key using the AES-128-CBC cipher:
  if (EVP_KDF_derive(kctx, out, outlen) <= 0)
      /* Error */
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -96,7 +96,7 @@ RFC 3961
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_free(3)>,
+L<EVP_KDF_free_ctx(3)>,
 L<EVP_KDF_ctrl(3)>,
 L<EVP_KDF_size(3)>,
 L<EVP_KDF_derive(3)>,

--- a/doc/man7/EVP_KDF-PBKDF2.pod
+++ b/doc/man7/EVP_KDF-PBKDF2.pod
@@ -82,9 +82,9 @@ SP800-132
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>
 

--- a/doc/man7/EVP_KDF-SCRYPT.pod
+++ b/doc/man7/EVP_KDF-SCRYPT.pod
@@ -66,7 +66,7 @@ Both r and p are parameters of type B<uint32_t>.
 A context for scrypt can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "SCRYPT", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of an scrypt key derivation is specified via the
 "keylen" parameter to the L<EVP_KDF_derive(3)> function.
@@ -82,7 +82,7 @@ This example derives a 64-byte long test vector using scrypt with the password
  OSSL_PARAM params[6], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "SCRYPT", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
@@ -93,8 +93,8 @@ This example derives a 64-byte long test vector using scrypt with the password
  *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_SCRYPT_R, (uint32_t)8);
  *p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_SCRYPT_P, (uint32_t)16);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
@@ -115,7 +115,7 @@ This example derives a 64-byte long test vector using scrypt with the password
      assert(!memcmp(out, expected, sizeof(out)));
  }
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -124,9 +124,9 @@ RFC 7914
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>
 

--- a/doc/man7/EVP_KDF-SS.pod
+++ b/doc/man7/EVP_KDF-SS.pod
@@ -66,7 +66,7 @@ This parameter sets an optional value for fixedinfo, also known as otherinfo.
 A context for SSKDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "SSKDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of an SSKDF is specified via the I<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.
@@ -82,7 +82,7 @@ and fixedinfo value "label":
  OSSL_PARAM params[4], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "SSKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -92,14 +92,14 @@ and fixedinfo value "label":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "label", (size_t)5);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
  }
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 This example derives 10 bytes using H(x) = HMAC(SHA-256), with the secret key "secret",
 fixedinfo value "label" and salt "salt":
@@ -110,7 +110,7 @@ fixedinfo value "label" and salt "salt":
  OSSL_PARAM params[6], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "SSKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC,
@@ -124,14 +124,14 @@ fixedinfo value "label" and salt "salt":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                           "salt", (size_t)4);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
  }
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 This example derives 10 bytes using H(x) = KMAC128(x,salt,outlen), with the secret key "secret"
 fixedinfo value "label", salt of "salt" and KMAC outlen of 20:
@@ -142,7 +142,7 @@ fixedinfo value "label", salt of "salt" and KMAC outlen of 20:
  OSSL_PARAM params[7], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "SSKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC,
@@ -157,14 +157,14 @@ fixedinfo value "label", salt of "salt" and KMAC outlen of 20:
                                           "salt", (size_t)4);
  *p++ = OSSL_PARAM_construct_size_t(OSSL_KDF_PARAM_MAC_SIZE, (size_t)20);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
  }
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -173,9 +173,9 @@ NIST SP800-56Cr1.
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_size(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>

--- a/doc/man7/EVP_KDF-SSHKDF.pod
+++ b/doc/man7/EVP_KDF-SSHKDF.pod
@@ -87,7 +87,7 @@ A single char of value 70 (ASCII char 'F').
 A context for SSHKDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "SSHKDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of the SSHKDF derivation is specified via the I<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.
@@ -111,7 +111,7 @@ This example derives an 8 byte IV using SHA-256 with a 1K "key" and appropriate
  OSSL_PARAM params[6], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "SSHKDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -125,7 +125,7 @@ This example derives an 8 byte IV using SHA-256 with a 1K "key" and appropriate
  *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_SSHKDF_TYPE,
                                  EVP_KDF_SSHKDF_TYPE_INITIAL_IV_CLI_TO_SRV);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0)
      /* Error */
 
  if (EVP_KDF_derive(kctx, out, &outlen) <= 0)
@@ -139,9 +139,9 @@ RFC 4253
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_size(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>

--- a/doc/man7/EVP_KDF-TLS1_PRF.pod
+++ b/doc/man7/EVP_KDF-TLS1_PRF.pod
@@ -51,7 +51,7 @@ this should be more than enough for any normal use of the TLS PRF.
 A context for the TLS PRF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "TLS1-PRF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The digest, secret value and seed must be set before a key is derived otherwise
 an error will occur.
@@ -70,7 +70,7 @@ and seed value "seed":
  OSSL_PARAM params[4], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "TLS1-PRF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -80,13 +80,13 @@ and seed value "seed":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
                                           "seed", (size_t)4);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
  }
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -95,9 +95,9 @@ RFC 2246, RFC 5246 and NIST SP 800-135 r1
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>
 

--- a/doc/man7/EVP_KDF-X942.pod
+++ b/doc/man7/EVP_KDF-X942.pod
@@ -49,7 +49,7 @@ This parameter sets the CEK wrapping algorithm name.
 A context for X942KDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "X942KDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of an X942KDF is specified via the I<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.
@@ -71,9 +71,9 @@ keying material:
  kdf = EVP_KDF_fetch(NULL, "X942KDF", NULL);
  if (kctx == NULL)
      error("EVP_KDF_fetch");
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  if (kctx == NULL)
-     error("EVP_KDF_CTX_new");
+     error("EVP_KDF_new_ctx");
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -85,12 +85,12 @@ keying material:
                                          SN_id_smime_alg_CMS3DESwrap,
                                          strlen(SN_id_smime_alg_CMS3DESwrap));
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0)
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0)
+     error("EVP_KDF_set_ctx_params");
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0)
      error("EVP_KDF_derive");
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -99,9 +99,9 @@ RFC 2631
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_size(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>

--- a/doc/man7/EVP_KDF-X963.pod
+++ b/doc/man7/EVP_KDF-X963.pod
@@ -46,7 +46,7 @@ X963KDF appends the counter to the secret, whereas SSKDF prepends the counter.
 A context for X963KDF can be obtained by calling:
 
  EVP_KDF *kdf = EVP_KDF_fetch(NULL, "X963KDF", NULL);
- EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+ EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
 The output length of an X963KDF is specified via the I<keylen>
 parameter to the L<EVP_KDF_derive(3)> function.
@@ -62,7 +62,7 @@ value "label":
  OSSL_PARAM params[4], *p = params;
 
  kdf = EVP_KDF_fetch(NULL, "X963KDF", NULL);
- kctx = EVP_KDF_CTX_new(kdf);
+ kctx = EVP_KDF_new_ctx(kdf);
  EVP_KDF_free(kdf);
 
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
@@ -72,14 +72,14 @@ value "label":
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                           "label", (size_t)5);
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_CTX_set_params(kctx, params) <= 0) {
-     error("EVP_KDF_CTX_set_params");
+ if (EVP_KDF_set_ctx_params(kctx, params) <= 0) {
+     error("EVP_KDF_set_ctx_params");
  }
  if (EVP_KDF_derive(kctx, out, sizeof(out)) <= 0) {
      error("EVP_KDF_derive");
  }
 
- EVP_KDF_CTX_free(kctx);
+ EVP_KDF_free_ctx(kctx);
 
 =head1 CONFORMING TO
 
@@ -88,9 +88,9 @@ value "label":
 =head1 SEE ALSO
 
 L<EVP_KDF(3)>,
-L<EVP_KDF_CTX_new(3)>,
-L<EVP_KDF_CTX_free(3)>,
-L<EVP_KDF_CTX_set_params(3)>,
+L<EVP_KDF_new_ctx(3)>,
+L<EVP_KDF_free_ctx(3)>,
+L<EVP_KDF_set_ctx_params(3)>,
 L<EVP_KDF_size(3)>,
 L<EVP_KDF_derive(3)>,
 L<EVP_KDF(3)/PARAMETERS>

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -30,20 +30,20 @@ void EVP_KDF_free(EVP_KDF *kdf);
 EVP_KDF *EVP_KDF_fetch(OPENSSL_CTX *libctx, const char *algorithm,
                        const char *properties);
 
-EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf);
-void EVP_KDF_CTX_free(EVP_KDF_CTX *ctx);
-EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src);
+EVP_KDF_CTX *EVP_KDF_new_ctx(EVP_KDF *kdf);
+void EVP_KDF_free_ctx(EVP_KDF_CTX *ctx);
+EVP_KDF_CTX *EVP_KDF_dup_ctx(const EVP_KDF_CTX *src);
 int EVP_KDF_number(const EVP_KDF *kdf);
 int EVP_KDF_is_a(const EVP_KDF *kdf, const char *name);
 const OSSL_PROVIDER *EVP_KDF_provider(const EVP_KDF *kdf);
-const EVP_KDF *EVP_KDF_CTX_kdf(EVP_KDF_CTX *ctx);
+const EVP_KDF *EVP_KDF_get_ctx_kdf(EVP_KDF_CTX *ctx);
 
 void EVP_KDF_reset(EVP_KDF_CTX *ctx);
 size_t EVP_KDF_size(EVP_KDF_CTX *ctx);
 int EVP_KDF_derive(EVP_KDF_CTX *ctx, unsigned char *key, size_t keylen);
 int EVP_KDF_get_params(EVP_KDF *kdf, OSSL_PARAM params[]);
-int EVP_KDF_CTX_get_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[]);
-int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[]);
+int EVP_KDF_get_ctx_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[]);
+int EVP_KDF_set_ctx_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[]);
 const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf);
 const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf);
 const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf);

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -204,7 +204,7 @@ static int self_test_kdf(const ST_KAT_KDF *t, OSSL_SELF_TEST *st,
     if (kdf == NULL)
         goto err;
 
-    ctx = EVP_KDF_CTX_new(kdf);
+    ctx = EVP_KDF_new_ctx(kdf);
     if (ctx == NULL)
         goto err;
 
@@ -216,7 +216,7 @@ static int self_test_kdf(const ST_KAT_KDF *t, OSSL_SELF_TEST *st,
     params = OSSL_PARAM_BLD_to_param(bld);
     if (params == NULL)
         goto err;
-    if (!EVP_KDF_CTX_set_params(ctx, params))
+    if (!EVP_KDF_set_ctx_params(ctx, params))
         goto err;
 
     if (t->expected_len > sizeof(out))
@@ -232,7 +232,7 @@ static int self_test_kdf(const ST_KAT_KDF *t, OSSL_SELF_TEST *st,
     ret = 1;
 err:
     EVP_KDF_free(kdf);
-    EVP_KDF_CTX_free(ctx);
+    EVP_KDF_free_ctx(ctx);
     BN_CTX_free(bnctx);
     OSSL_PARAM_BLD_free_params(params);
     OSSL_PARAM_BLD_free(bld);

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -49,7 +49,7 @@ static int tls1_PRF(SSL *s,
     kdf = EVP_KDF_fetch(s->ctx->libctx, OSSL_KDF_NAME_TLS1_PRF, s->ctx->propq);
     if (kdf == NULL)
         goto err;
-    kctx = EVP_KDF_CTX_new(kdf);
+    kctx = EVP_KDF_new_ctx(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL)
         goto err;
@@ -70,9 +70,9 @@ static int tls1_PRF(SSL *s,
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
                                              (void *)seed5, (size_t)seed5_len);
     *p = OSSL_PARAM_construct_end();
-    if (EVP_KDF_CTX_set_params(kctx, params)
+    if (EVP_KDF_set_ctx_params(kctx, params)
             && EVP_KDF_derive(kctx, out, olen)) {
-        EVP_KDF_CTX_free(kctx);
+        EVP_KDF_free_ctx(kctx);
         return 1;
     }
 
@@ -82,7 +82,7 @@ static int tls1_PRF(SSL *s,
                  ERR_R_INTERNAL_ERROR);
     else
         SSLerr(SSL_F_TLS1_PRF, ERR_R_INTERNAL_ERROR);
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return 0;
 }
 

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -21,7 +21,7 @@
 static EVP_KDF_CTX *get_kdfbyname(const char *name)
 {
     EVP_KDF *kdf = EVP_KDF_fetch(NULL, name, NULL);
-    EVP_KDF_CTX *kctx = EVP_KDF_CTX_new(kdf);
+    EVP_KDF_CTX *kctx = EVP_KDF_new_ctx(kdf);
 
     EVP_KDF_free(kdf);
     return kctx;
@@ -50,11 +50,11 @@ static int test_kdf_tls1_prf(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -80,11 +80,11 @@ static int test_kdf_hkdf(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -121,10 +121,10 @@ static int test_kdf_pbkdf2(void)
     *p = OSSL_PARAM_construct_end();
 
     if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
-        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        || !TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         || !TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))
-        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        || !TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         /* A key length that is too small should fail */
         || !TEST_int_eq(EVP_KDF_derive(kctx, out, 112 / 8 - 1), 0)
         /* A key length that is too large should fail */
@@ -156,7 +156,7 @@ static int test_kdf_pbkdf2(void)
 #endif
     ret = 1;
 err:
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -191,15 +191,15 @@ static int test_kdf_scrypt(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SCRYPT))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         /* failure test *//*
         && TEST_int_le(EVP_KDF_derive(kctx, out, sizeof(out)), 0)*/
         && TEST_true(OSSL_PARAM_set_uint(p - 1, 10 * 1024 * 1024))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, p - 1))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, p - 1))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 #endif /* OPENSSL_NO_SCRYPT */
@@ -235,11 +235,11 @@ static int test_kdf_ss_hash(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSKDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -289,11 +289,11 @@ static int test_kdf_x963(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_X963KDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -345,11 +345,11 @@ static int test_kdf_kbkdf_6803_128(void)
 
         kctx = get_kdfbyname("KBKDF");
         ret = TEST_ptr(kctx)
-            && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+            && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
             && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
             && TEST_mem_eq(result, sizeof(result), outputs[i],
                            sizeof(outputs[i]));
-        EVP_KDF_CTX_free(kctx);
+        EVP_KDF_free_ctx(kctx);
         if (ret != 1)
             return ret;
     }
@@ -411,11 +411,11 @@ static int test_kdf_kbkdf_6803_256(void)
 
         kctx = get_kdfbyname("KBKDF");
         ret = TEST_ptr(kctx)
-            && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+            && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
             && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
             && TEST_mem_eq(result, sizeof(result), outputs[i],
                            sizeof(outputs[i]));
-        EVP_KDF_CTX_free(kctx);
+        EVP_KDF_free_ctx(kctx);
         if (ret != 1)
             return ret;
     }
@@ -459,11 +459,11 @@ static int test_kdf_kbkdf_8009_prf1(void)
 
     kctx = get_kdfbyname("KBKDF");
     ret = TEST_ptr(kctx)
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
         && TEST_mem_eq(result, sizeof(result), output, sizeof(output));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -504,11 +504,11 @@ static int test_kdf_kbkdf_8009_prf2(void)
 
     kctx = get_kdfbyname("KBKDF");
     ret = TEST_ptr(kctx)
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0)
         && TEST_mem_eq(result, sizeof(result), output, sizeof(output));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -547,11 +547,11 @@ static int test_kdf_ss_hmac(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSKDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -593,11 +593,11 @@ static int test_kdf_ss_kmac(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSKDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -651,11 +651,11 @@ static int test_kdf_sshkdf(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_SSHKDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 
@@ -725,11 +725,11 @@ static int test_kdf_x942_asn1(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_X942KDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 #endif /* OPENSSL_NO_CMS */
@@ -763,11 +763,11 @@ static int test_kdf_krb5kdf(void)
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_KRB5KDF))
-        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_true(EVP_KDF_set_ctx_params(kctx, params))
         && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
-    EVP_KDF_CTX_free(kctx);
+    EVP_KDF_free_ctx(kctx);
     return ret;
 }
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2095,7 +2095,7 @@ static int kdf_test_init(EVP_TEST *t, const char *name)
         OPENSSL_free(kdata);
         return 0;
     }
-    kdata->ctx = EVP_KDF_CTX_new(kdf);
+    kdata->ctx = EVP_KDF_new_ctx(kdf);
     EVP_KDF_free(kdf);
     if (kdata->ctx == NULL) {
         OPENSSL_free(kdata);
@@ -2113,7 +2113,7 @@ static void kdf_test_cleanup(EVP_TEST *t)
     for (p = kdata->params; p->key != NULL; p++)
         OPENSSL_free(p->data);
     OPENSSL_free(kdata->output);
-    EVP_KDF_CTX_free(kdata->ctx);
+    EVP_KDF_free_ctx(kdata->ctx);
 }
 
 static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
@@ -2122,7 +2122,8 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
     KDF_DATA *kdata = t->data;
     int rv;
     char *p, *name;
-    const OSSL_PARAM *defs = EVP_KDF_settable_ctx_params(EVP_KDF_CTX_kdf(kctx));
+    const OSSL_PARAM *defs =
+        EVP_KDF_settable_ctx_params(EVP_KDF_get_ctx_kdf(kctx));
 
     if (!TEST_ptr(name = OPENSSL_strdup(value)))
         return 0;
@@ -2178,7 +2179,7 @@ static int kdf_test_run(EVP_TEST *t)
     unsigned char *got = NULL;
     size_t got_len = expected->output_len;
 
-    if (!EVP_KDF_CTX_set_params(expected->ctx, expected->params)) {
+    if (!EVP_KDF_set_ctx_params(expected->ctx, expected->params)) {
         t->err = "KDF_CTRL_ERROR";
         return 1;
     }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4467,7 +4467,7 @@ ASYNC_WAIT_CTX_set_callback             ?	3_0_0	EXIST::FUNCTION:
 ASYNC_WAIT_CTX_set_status               ?	3_0_0	EXIST::FUNCTION:
 ASYNC_WAIT_CTX_get_status               ?	3_0_0	EXIST::FUNCTION:
 ERR_load_ESS_strings                    ?	3_0_0	EXIST::FUNCTION:
-EVP_KDF_CTX_free                        ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_free_ctx                        ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_reset                           ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_size                            ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_derive                          ?	3_0_0	EXIST::FUNCTION:
@@ -4617,8 +4617,8 @@ EVP_CIPHER_up_ref                       ?	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_fetch                        ?	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_mode                         ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_info                            ?	3_0_0	EXIST::FUNCTION:
-EVP_KDF_CTX_new                         ?	3_0_0	EXIST::FUNCTION:
-EVP_KDF_CTX_kdf                         ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_new_ctx                         ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_get_ctx_kdf                     ?	3_0_0	EXIST::FUNCTION:
 i2d_KeyParams                           ?	3_0_0	EXIST::FUNCTION:
 d2i_KeyParams                           ?	3_0_0	EXIST::FUNCTION:
 i2d_KeyParams_bio                       ?	3_0_0	EXIST::FUNCTION:
@@ -4715,11 +4715,11 @@ EVP_CIPHER_free                         ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_up_ref                          ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_free                            ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_fetch                           ?	3_0_0	EXIST::FUNCTION:
-EVP_KDF_CTX_dup                         ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_dup_ctx                         ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_provider                        ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_get_params                      ?	3_0_0	EXIST::FUNCTION:
-EVP_KDF_CTX_get_params                  ?	3_0_0	EXIST::FUNCTION:
-EVP_KDF_CTX_set_params                  ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_get_ctx_params                  ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_set_ctx_params                  ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_gettable_params                 ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_gettable_ctx_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_settable_ctx_params             ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The EVP_KDF_CTX functions have been renamed to bring consistency to the KDF naming.

Before 3.0 is released, the names are mutable and this prevents more inconsistencies being introduced.

There are no functional or code changes.  Just the renaming and a little reformatting.

- [x] documentation is added or updated
- [x] tests are added or updated
