### PR TITLE
Revert the check for NaN in %f format

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -638,10 +638,8 @@ fmtfp(char **sbuffer,
     /*
      * By subtracting 65535 (2^16-1) we cancel the low order 15 bits
      * of ULONG_MAX to avoid using imprecise floating point values.
-     * The second condition is necessary to catch NaN values.
      */
-    if (ufvalue >= (double)(ULONG_MAX - 65535) + 65536.0
-            || !(ufvalue == ufvalue) /* NaN */) {
+    if (ufvalue >= (double)(ULONG_MAX - 65535) + 65536.0) {
         /* Number too big */
         return 0;
     }

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -241,46 +241,13 @@ static int test_fp(int i)
     return r;
 }
 
-extern double zero_value;
-double zero_value = 0.0;
-
 static int test_big(void)
 {
     char buf[80];
-    double d, z, inf, nan;
 
     /* Test excessively big number. Should fail */
     if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
                                   "%f\n", 2 * (double)ULONG_MAX), -1))
-        return 0;
-
-    d = 1.0;
-    z = zero_value;
-    inf = d / z;
-    nan = z / z;
-
-    /*
-     * Test +/-inf, nan. Should fail.
-     * Test +/-1.0, +/-0.0. Should work.
-     */
-    if (!TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                  "%f", inf), -1)
-            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                         "%f", -inf), -1)
-            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                         "%f", nan), -1)
-            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                         "%f", d), 8)
-            || !TEST_str_eq(buf, "1.000000")
-            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                         "%f", z), 8)
-            || !TEST_str_eq(buf, "0.000000")
-            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                         "%f", -d), 9)
-            || !TEST_str_eq(buf, "-1.000000")
-            || !TEST_int_eq(BIO_snprintf(buf, sizeof(buf),
-                                         "%f", -z), 8)
-            || !TEST_str_eq(buf, "0.000000"))
         return 0;
 
     return 1;


### PR DESCRIPTION
Unfortunately -Ofast seems to break that check.

Fixes #11994

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
