### PR TITLE
Fix a buffer overflow in drbg_ctr_generate

### DIFF
--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -369,8 +369,8 @@ __owur static int drbg_ctr_generate(RAND_DRBG *drbg,
             if (ctr32 != 0) {
                 blocks -= ctr32;
                 buflen = blocks * 16;
+                ctr32 = 0;
             }
-            ctr32 = 0;
             ctr96_inc(ctr->V);
         }
         PUTU32(ctr->V + 12, ctr32);

--- a/crypto/rand/drbg_ctr.c
+++ b/crypto/rand/drbg_ctr.c
@@ -366,8 +366,10 @@ __owur static int drbg_ctr_generate(RAND_DRBG *drbg,
         ctr32 = GETU32(ctr->V + 12) + blocks;
         if (ctr32 < blocks) {
             /* 32-bit counter overflow into V. */
-            blocks -= ctr32;
-            buflen = blocks * 16;
+            if (ctr32 != 0) {
+                blocks -= ctr32;
+                buflen = blocks * 16;
+            }
             ctr32 = 0;
             ctr96_inc(ctr->V);
         }


### PR DESCRIPTION
This can happen if the 32-bit counter overflows
and the last block is not a multiple of 16 bytes.

Fixes #12012

[extended tests]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
