### PR TITLE
Consolidate doc of BIO_do_connect() and its alias BIO_do_handshake()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,7 +158,8 @@ OpenSSL 3.0
    *David von Oheimb*
 
  * BIO_do_connect and BIO_do_handshake have been extended:
-   if domain name resolution yields multiple IP addresses all of them are tried.
+   If domain name resolution yields multiple IP addresses all of them are tried
+   after connect() failures.
 
    *David von Oheimb*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -157,6 +157,11 @@ OpenSSL 3.0
 
    *David von Oheimb*
 
+ * BIO_do_connect and BIO_do_handshake have been extended:
+   if domain name resolution yields multiple IP addresses all of them are tried.
+
+   *David von Oheimb*
+
  * All of the low level RSA functions have been deprecated including:
 
    RSA_new_method, RSA_size, RSA_security_bits, RSA_get0_pss_params,

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -98,7 +98,8 @@ pointer.
 BIO_do_handshake() attempts to complete an SSL handshake on the
 -supplied BIO and establish the SSL connection.
 For non-SSL BIOs the connection is done typically at TCP level.
-If domain name resolution yields multiple IP addresses all of them are tried.
+If domain name resolution yields multiple IP addresses all of them are tried
+after connect() failures.
 The function returns 1 if the connection was established successfully.
 A zero or negative value is returned if the connection could not be established.
 The call BIO_should_retry() should be used for non-blocking connect BIOs

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -95,13 +95,15 @@ chain B<bio>. It does this by locating the SSL BIO in the
 chain and calling SSL_shutdown() on its internal SSL
 pointer.
 
-BIO_do_handshake() attempts to complete an SSL handshake on the
-supplied BIO and establish the SSL connection. It returns 1
-if the connection was established successfully. A zero or negative
-value is returned if the connection could not be established, the
-call BIO_should_retry() should be used for non blocking connect BIOs
-to determine if the call should be retried. If an SSL connection has
-already been established this call has no effect.
+BIO_do_handshake() attempts to connect the supplied BIO, doing an SSL handshake
+and establishing an SSL/TLS connection as far as supported by the BIO.
+For non-SSL BIOs the connection is done typically at TCP level.
+If domain name resolution yields multiple IP addresses all of them are tried.
+The function returns 1 if the connection was established successfully.
+A zero or negative value is returned if the connection could not be established.
+The call BIO_should_retry() should be used for non-blocking connect BIOs
+to determine if the call should be retried.
+If a connection has already been established this call has no effect.
 
 =head1 NOTES
 

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -95,8 +95,8 @@ chain B<bio>. It does this by locating the SSL BIO in the
 chain and calling SSL_shutdown() on its internal SSL
 pointer.
 
-BIO_do_handshake() attempts to connect the supplied BIO, doing an SSL handshake
-and establishing an SSL/TLS connection as far as supported by the BIO.
+BIO_do_handshake() attempts to complete an SSL handshake on the
+-supplied BIO and establish the SSL connection.
 For non-SSL BIOs the connection is done typically at TCP level.
 If domain name resolution yields multiple IP addresses all of them are tried.
 The function returns 1 if the connection was established successfully.

--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -94,11 +94,15 @@ non blocking I/O is set during the connect process.
 BIO_new_connect() combines BIO_new() and BIO_set_conn_hostname() into
 a single call: that is it creates a new connect BIO with B<name>.
 
-BIO_do_connect() attempts to connect the supplied BIO. It returns 1
-if the connection was established successfully. A zero or negative
-value is returned if the connection could not be established, the
-call BIO_should_retry() should be used for non blocking connect BIOs
+BIO_do_connect() attempts to connect the supplied BIO.
+This performs an SSL/TLS handshake as far as supported by the BIO.
+For non-SSL BIOs the connection is done typically at TCP level.
+If domain name resolution yields multiple IP addresses all of them are tried.
+The function returns 1 if the connection was established successfully.
+A zero or negative value is returned if the connection could not be established.
+The call BIO_should_retry() should be used for non blocking connect BIOs
 to determine if the call should be retried.
+If a connection has already been established this call has no effect.
 
 =head1 NOTES
 

--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -97,7 +97,8 @@ a single call: that is it creates a new connect BIO with B<name>.
 BIO_do_connect() attempts to connect the supplied BIO.
 This performs an SSL/TLS handshake as far as supported by the BIO.
 For non-SSL BIOs the connection is done typically at TCP level.
-If domain name resolution yields multiple IP addresses all of them are tried.
+If domain name resolution yields multiple IP addresses all of them are tried
+after connect() failures.
 The function returns 1 if the connection was established successfully.
 A zero or negative value is returned if the connection could not be established.
 The call BIO_should_retry() should be used for non blocking connect BIOs


### PR DESCRIPTION
As suggested by @richsalz https://github.com/openssl/openssl/pull/11971#issuecomment-636923583 this documents that these functions meanwhile try all IP addresses resolved for a given domain name.

Doing so I found that the documentation of these two functions, although they are just aliases for the same `BIO_ctrl(b,BIO_C_DO_STATE_MACHINE,0,NULL)` call, was differing.
This PR includes my suggestion for consolidating their description.

Should we explicitly mention that `BIO_do_connect()` and `BIO_do_handshake()` are essentially the same?

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
