### PR TITLE
ossl_shim: const cast the param arguments to avoid errors

### DIFF
--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -393,8 +393,10 @@ static int TicketKeyCallback(SSL *ssl, uint8_t *key_name, uint8_t *iv,
     return 0;
   }
 
-  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, "SHA256", 0);
-  *p++ = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, kZeros,
+  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                          const_cast<char *>("SHA256"), 0);
+  *p++ = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
+                                           (void *)kZeros,
                                            sizeof(kZeros));
   *p = OSSL_PARAM_construct_end();
 


### PR DESCRIPTION
Use const_cast<> to remove the _const_ nature of arguments to the OSSL_PARAM calls.

Refer #12018

- [x] tests are added or updated
