### PR TITLE
Remove disabled TLS 1.3 ciphers from the SSL(_CTX)

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1625,8 +1625,11 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(SSL_CTX *ctx,
         if ((sslc->algorithm_enc & disabled_enc) != 0
                 || (ssl_cipher_table_mac[sslc->algorithm2
                                          & SSL_HANDSHAKE_MAC_MASK].mask
-                    & ctx->disabled_mac_mask) != 0)
+                    & ctx->disabled_mac_mask) != 0) {
+            sk_SSL_CIPHER_delete(tls13_ciphersuites, i);
+            i--;
             continue;
+        }
 
         if (!sk_SSL_CIPHER_push(cipherstack, sslc)) {
             sk_SSL_CIPHER_free(cipherstack);


### PR DESCRIPTION
In ssl_create_cipher_list() we make a pass through the ciphers to
remove those which are disabled in the current libctx.  We are
careful to not include such disabled TLS 1.3 ciphers in the final
consolidated cipher list that we produce, but the disabled ciphers
are still kept in the separate stack of TLS 1.3 ciphers associated
with the SSL or SSL_CTX in question.  This leads to confusing
results where a cipher is present in the tls13_cipherlist but absent
from the actual cipher list in use.  Keep the books in order and
remove the disabled ciphers from the 1.3 cipherlist at the same time
we skip adding them to the active cipher list.

