### PR TITLE
Fix a typo in SSL_CTX_set_session_ticket_cb.pod

### DIFF
--- a/doc/man3/SSL_CTX_set_session_ticket_cb.pod
+++ b/doc/man3/SSL_CTX_set_session_ticket_cb.pod
@@ -177,7 +177,7 @@ L<SSL_get_session(3)>
 
 =head1 HISTORY
 
-The SSL_CTX_set_session_ticket_cb(), SSSL_SESSION_set1_ticket_appdata()
+The SSL_CTX_set_session_ticket_cb(), SSL_SESSION_set1_ticket_appdata()
 and SSL_SESSION_get_ticket_appdata() functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT


### PR DESCRIPTION
"SSL" takes two esses, not three.

[skip ci]

