### PR TITLE
Silence gcc false positive warning on alpn_protos_len in test/handshake_helper.c in 1.1.1

### DIFF
--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -637,7 +637,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
     }
     if (extra->client.alpn_protocols != NULL) {
         unsigned char *alpn_protos = NULL;
-        size_t alpn_protos_len;
+        size_t alpn_protos_len = 0;
+
         if (!TEST_true(parse_protos(extra->client.alpn_protocols,
                                     &alpn_protos, &alpn_protos_len))
                 /* Reversed return value convention... */

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -288,7 +288,7 @@ static int test_record(SSL3_RECORD *rec, RECORD_DATA *recd, int enc)
 {
     int ret = 0;
     unsigned char *refd;
-    size_t refdatalen;
+    size_t refdatalen = 0;
 
     if (enc)
         refd = multihexstr2buf(recd->ciphertext, &refdatalen);


### PR DESCRIPTION
As agreed with @bernd-edlinger in https://github.com/openssl/openssl/pull/12036#discussion_r435153089