### PR TITLE
Do not allow dropping Extended Master Secret extension on renegotiaton

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Handshake now fails if Extended Master Secret extension is dropped
+   on renegotiation.
+
+   *Tomas Mraz*
+
  * Dropped interactive mode from the 'openssl' program.  From now on,
    the `openssl` command without arguments is equivalent to `openssl
    help`.

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -297,6 +297,9 @@ extern "C" {
 
 # define TLS1_FLAGS_STATELESS                    0x0800
 
+/* Set if extended master secret extension required on renegotiation */
+# define TLS1_FLAGS_REQUIRED_EXTMS               0x1000
+
 # define SSL3_MT_HELLO_REQUEST                   0
 # define SSL3_MT_CLIENT_HELLO                    1
 # define SSL3_MT_SERVER_HELLO                    2

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1169,13 +1169,26 @@ static int init_etm(SSL *s, unsigned int context)
 
 static int init_ems(SSL *s, unsigned int context)
 {
-    s->s3.flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
+    if (s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS) {
+        s->s3.flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
+        s->s3.flags |= TLS1_FLAGS_REQUIRED_EXTMS;
+    }
 
     return 1;
 }
 
 static int final_ems(SSL *s, unsigned int context, int sent)
 {
+    /*
+     * Check extended master secret extension is not dropped on
+     * renegotiation.
+     */
+    if (!(s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS)
+        && (s->s3.flags & TLS1_FLAGS_REQUIRED_EXTMS)) {
+        SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_FINAL_EMS,
+                 SSL_R_INCONSISTENT_EXTMS);
+        return 0;
+    }
     if (!s->server && s->hit) {
         /*
          * Check extended master secret extension is consistent with

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -938,16 +938,24 @@ static void do_reneg_setup_step(const SSL_TEST_CTX *test_ctx, PEER *peer)
             if (SSL_is_server(peer->ssl)) {
                 ret = SSL_renegotiate(peer->ssl);
             } else {
+                int full_reneg = 0;
+
+                if (test_ctx->extra.client.no_extms_on_reneg) {
+                    SSL_set_options(peer->ssl, SSL_OP_NO_EXTENDED_MASTER_SECRET);
+                    full_reneg = 1;
+                }
                 if (test_ctx->extra.client.reneg_ciphers != NULL) {
                     if (!SSL_set_cipher_list(peer->ssl,
                                 test_ctx->extra.client.reneg_ciphers)) {
                         peer->status = PEER_ERROR;
                         return;
                     }
-                    ret = SSL_renegotiate(peer->ssl);
-                } else {
-                    ret = SSL_renegotiate_abbreviated(peer->ssl);
+                    full_reneg = 1;
                 }
+                if (full_reneg)
+                    ret = SSL_renegotiate(peer->ssl);
+                else
+                    ret = SSL_renegotiate_abbreviated(peer->ssl);
             }
             if (!ret) {
                 peer->status = PEER_ERROR;

--- a/test/ssl-tests/17-renegotiate.cnf
+++ b/test/ssl-tests/17-renegotiate.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 14
+num_tests = 15
 
 test-0 = 0-renegotiate-client-no-resume
 test-1 = 1-renegotiate-client-resume
@@ -16,6 +16,7 @@ test-10 = 10-no-renegotiation-server-by-client
 test-11 = 11-no-renegotiation-server-by-server
 test-12 = 12-no-renegotiation-client-by-server
 test-13 = 13-no-renegotiation-client-by-client
+test-14 = 14-no-extms-on-renegotiation
 # ===========================================================
 
 [0-renegotiate-client-no-resume]
@@ -428,5 +429,37 @@ ExpectedResult = ClientFail
 HandshakeMode = RenegotiateClient
 Method = TLS
 ResumptionExpected = No
+
+
+# ===========================================================
+
+[14-no-extms-on-renegotiation]
+ssl_conf = 14-no-extms-on-renegotiation-ssl
+
+[14-no-extms-on-renegotiation-ssl]
+server = 14-no-extms-on-renegotiation-server
+client = 14-no-extms-on-renegotiation-client
+
+[14-no-extms-on-renegotiation-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[14-no-extms-on-renegotiation-client]
+CipherString = DEFAULT
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-14]
+ExpectedResult = ServerFail
+HandshakeMode = RenegotiateClient
+Method = TLS
+ResumptionExpected = No
+client = 14-no-extms-on-renegotiation-client-extra
+
+[14-no-extms-on-renegotiation-client-extra]
+RenegotiateNoExtms = Yes
 
 

--- a/test/ssl-tests/17-renegotiate.cnf.in
+++ b/test/ssl-tests/17-renegotiate.cnf.in
@@ -243,6 +243,24 @@ our @tests_tls1_2 = (
             "ResumptionExpected" => "No",
             "ExpectedResult" => "ClientFail"
         }
+    },
+    {
+        name => "no-extms-on-renegotiation",
+        server => {
+            "MaxProtocol" => "TLSv1.2"
+        },
+        client => {
+            "MaxProtocol" => "TLSv1.2",
+            extra => {
+                "RenegotiateNoExtms" => "Yes"
+            }
+        },
+        test => {
+            "Method" => "TLS",
+            "HandshakeMode" => "RenegotiateClient",
+            "ResumptionExpected" => "No",
+            "ExpectedResult" => "ServerFail"
+        }
     }
 );
 

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -638,6 +638,7 @@ IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, expected_cipher)
 
 IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_CLIENT_CONF, client, enable_pha)
 IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_SERVER_CONF, server, force_pha)
+IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_CLIENT_CONF, client, no_extms_on_reneg)
 
 /* Known test options and their corresponding parse methods. */
 
@@ -697,6 +698,7 @@ static const ssl_test_client_option ssl_test_client_options[] = {
     { "SRPPassword", &parse_client_srp_password },
     { "MaxFragmentLenExt", &parse_max_fragment_len_mode },
     { "EnablePHA", &parse_client_enable_pha },
+    { "RenegotiateNoExtms", &parse_client_no_extms_on_reneg },
 };
 
 /* Nested server options. */

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -110,6 +110,8 @@ typedef struct {
     char *srp_password;
     /* PHA enabled */
     int enable_pha;
+    /* Do not send extms on renegotiation */
+    int no_extms_on_reneg;
 } SSL_TEST_CLIENT_CONF;
 
 typedef struct {


### PR DESCRIPTION
I've verified with tlsfuzzer that the handshake failure alert is properly sent.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
