### PR TITLE
EVP: Let EVP_PKEY_gen() initialize ctx->keygen_info

### DIFF
--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -67,7 +67,7 @@ int dsaparam_main(int argc, char **argv)
 {
     ENGINE *e = NULL;
     BIO *in = NULL, *out = NULL;
-    EVP_PKEY *params, *pkey = NULL;
+    EVP_PKEY *params = NULL, *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     int numbits = -1, num = 0, genkey = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, noout = 0, C = 0;

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -66,9 +66,8 @@ const OPTIONS dsaparam_options[] = {
 int dsaparam_main(int argc, char **argv)
 {
     ENGINE *e = NULL;
-    DSA *dsa = NULL;
     BIO *in = NULL, *out = NULL;
-    EVP_PKEY *pkey = NULL;
+    EVP_PKEY *params, *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     int numbits = -1, num = 0, genkey = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, noout = 0, C = 0;
@@ -181,51 +180,34 @@ int dsaparam_main(int argc, char **argv)
                        "Error, DSA key generation setting bit length failed\n");
             goto end;
         }
-        if (EVP_PKEY_paramgen(ctx, &pkey) <= 0) {
+        if (EVP_PKEY_paramgen(ctx, &params) <= 0) {
             ERR_print_errors(bio_err);
             BIO_printf(bio_err, "Error, DSA key generation failed\n");
             goto end;
         }
-        dsa = EVP_PKEY_get1_DSA(pkey);
-        if (dsa == NULL) {
-            ERR_print_errors(bio_err);
-            BIO_printf(bio_err, "Error, DSA key extraction failed\n");
-            goto end;
-        }
     } else if (informat == FORMAT_ASN1) {
-        dsa = d2i_DSAparams_bio(in, NULL);
+        params = d2i_KeyParams_bio(EVP_PKEY_DSA, NULL, in);
     } else {
-        dsa = PEM_read_bio_DSAparams(in, NULL, NULL, NULL);
+        params = PEM_read_bio_Parameters(in, NULL);
     }
-    if (dsa == NULL) {
+    if (params == NULL) {
         BIO_printf(bio_err, "unable to load DSA parameters\n");
         ERR_print_errors(bio_err);
         goto end;
     }
 
-    if (pkey == NULL) {
-        pkey = EVP_PKEY_new();
-        if (pkey == NULL) {
-            BIO_printf(bio_err, "Error, unable to allocate PKEY object\n");
-            ERR_print_errors(bio_err);
-            goto end;
-        }
-        if (!EVP_PKEY_set1_DSA(pkey, dsa)) {
-            BIO_printf(bio_err, "Error, unable to set DSA parameters\n");
-            ERR_print_errors(bio_err);
-            goto end;
-        }
-    }
     if (text) {
-        EVP_PKEY_print_params(out, pkey, 0, NULL);
+        EVP_PKEY_print_params(out, params, 0, NULL);
     }
 
     if (C) {
-        const BIGNUM *p = NULL, *q = NULL, *g = NULL;
+        BIGNUM *p = NULL, *q = NULL, *g = NULL;
         unsigned char *data;
         int len, bits_p;
 
-        DSA_get0_pqg(dsa, &p, &q, &g);
+        EVP_PKEY_get_bn_param(params, "p", &p);
+        EVP_PKEY_get_bn_param(params, "q", &q);
+        EVP_PKEY_get_bn_param(params, "g", &g);
         len = BN_num_bytes(p);
         bits_p = BN_num_bits(p);
 
@@ -261,9 +243,9 @@ int dsaparam_main(int argc, char **argv)
 
     if (!noout) {
         if (outformat == FORMAT_ASN1)
-            i = i2d_DSAparams_bio(out, dsa);
+            i = i2d_KeyParams_bio(out, params);
         else
-            i = PEM_write_bio_DSAparams(out, dsa);
+            i = PEM_write_bio_Parameters(out, params);
         if (!i) {
             BIO_printf(bio_err, "unable to write DSA parameters\n");
             ERR_print_errors(bio_err);
@@ -271,10 +253,8 @@ int dsaparam_main(int argc, char **argv)
         }
     }
     if (genkey) {
-        DSA *dsakey;
-
         EVP_PKEY_CTX_free(ctx);
-        ctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL);
+        ctx = EVP_PKEY_CTX_new(params, NULL);
         if (ctx == NULL) {
             ERR_print_errors(bio_err);
             BIO_printf(bio_err,
@@ -291,18 +271,11 @@ int dsaparam_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             goto end;
         }
-        dsakey = EVP_PKEY_get0_DSA(pkey);
-        if (dsakey == NULL) {
-            BIO_printf(bio_err, "unable to extract generated key\n");
-            ERR_print_errors(bio_err);
-            goto end;
-        }
         assert(private);
         if (outformat == FORMAT_ASN1)
-            i = i2d_DSAPrivateKey_bio(out, dsakey);
+            i = i2d_PrivateKey_bio(out, pkey);
         else
-            i = PEM_write_bio_DSAPrivateKey(out, dsakey, NULL, NULL, 0, NULL,
-                                            NULL);
+            i = PEM_write_bio_PrivateKey(out, pkey, NULL, NULL, 0, NULL, NULL);
     }
     ret = 0;
  end:
@@ -310,7 +283,7 @@ int dsaparam_main(int argc, char **argv)
     BIO_free_all(out);
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
-    DSA_free(dsa);
+    EVP_PKEY_free(params);
     release_engine(e);
     return ret;
 }

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -144,6 +144,8 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     int ret = 0;
     OSSL_CALLBACK cb;
     EVP_PKEY *allocated_pkey = NULL;
+    /* Legacy compatible keygen callback info, only used with provider impls */
+    int gentmp[2];
 
     if (ppkey == NULL)
         return -1;
@@ -164,6 +166,17 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 
     if (ctx->op.keymgmt.genctx == NULL)
         goto legacy;
+
+    /*
+     * Asssigning gentmp to ctx->keygen_info is something our legacy
+     * implementations do.  Because the provider implementations aren't
+     * allowed to reach into our EVP_PKEY_CTX, we need to provide similar
+     * space for backward compatibility.  It's ok that we attach a local
+     * variable, as it should only be useful in the calls down from here.
+     * This is cleared as soon as it isn't useful any more, i.e. directly
+     * after the evp_keymgmt_util_gen() call.
+     */
+    ctx->keygen_info = gentmp;
 
     ret = 1;
     if (ctx->pkey != NULL) {
@@ -190,6 +203,8 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
         && (evp_keymgmt_util_gen(*ppkey, ctx->keymgmt, ctx->op.keymgmt.genctx,
                                  ossl_callback_to_pkey_gencb, ctx)
             != NULL);
+
+    ctx->keygen_info = NULL;
 
 #ifndef FIPS_MODULE
     /* In case |*ppkey| was originally a legacy key */

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -177,6 +177,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
      * after the evp_keymgmt_util_gen() call.
      */
     ctx->keygen_info = gentmp;
+    ctx->keygen_info_count = 2;
 
     ret = 1;
     if (ctx->pkey != NULL) {


### PR DESCRIPTION
In EVP_PKEY_METHOD code, the backend initializes ctx->keygen_info.
With provider side code, it's not possible to reach back into the
EVP_PKEY_CTX in the same manner, so we need to make that
initialization in the central generation function, EVP_PKEY_gen().

This isn't quite compatible with the idea that keygen_info could have
an arbitrary amount of elements, but since all our legacy backends use
exactly two elements, that's what we go for.

Fixes #12047

## APPS: Fix 'openssl dsaparam -genkey'

Using a parameter EVP_PKEY for key generation with EVP_PKEY routines
works a little differently than the raw DSA routines that were used
before.

While fixing that, clean away all remaining use of the DSA type, which
simplifies the code a bit more.

## APPS: Fix 'openssl dhparam'

'dhparam' can't be completely rewritten in terms of EVP_PKEY functions
yet, because we lack X9.42 support.  However, we do when generating,
but forgot to extract a DH pointer with EVP_PKEY_get0_DH().