### PR TITLE
Fix NULL pointer access caused by X509_ATTRIBUTE_create()

### DIFF
--- a/crypto/x509/x_attrib.c
+++ b/crypto/x509/x_attrib.c
@@ -39,10 +39,13 @@ X509_ATTRIBUTE *X509_ATTRIBUTE_create(int nid, int atrtype, void *value)
 {
     X509_ATTRIBUTE *ret = NULL;
     ASN1_TYPE *val = NULL;
+    ASN1_OBJECT *oid;
 
+    if ((oid = OBJ_nid2obj(nid)) == NULL)
+        return NULL;
     if ((ret = X509_ATTRIBUTE_new()) == NULL)
         return NULL;
-    ret->object = OBJ_nid2obj(nid);
+    ret->object = oid;
     if ((val = ASN1_TYPE_new()) == NULL)
         goto err;
     if (!sk_ASN1_TYPE_push(ret->set, val))


### PR DESCRIPTION
When X509_ATTRIBUTE_create() receives an invalid NID (e.g., -1), return
failure rather than silently constructing a broken X509_ATTRIBUTE object
that might cause NULL pointer accesses later on.  This matters because
X509_ATTRIBUTE_create() is used by API functions like PKCS7_add_attribute(3)
and the NID comes straight from the user.

This bug was found while working on LibreSSL documentation.

Reviewed-by: Theo Buehler <tb@openbsd.org>

CLA: trivial

Original commit: https://cvsweb.openbsd.org/src/lib/libcrypto/asn1/x_attrib.c#rev1.14
Regression test available: https://cvsweb.openbsd.org/src/regress/lib/libcrypto/x509/x509attribute.c

I expect you also need to merge this to 1.1.1-stable.
