### PR TITLE
Fix a CMS_get0_signers() description in CMS_verify.pod

### DIFF
--- a/doc/man3/CMS_verify.pod
+++ b/doc/man3/CMS_verify.pod
@@ -24,7 +24,7 @@ present in B<cms>. The content is written to B<out> if it is not NULL.
 B<flags> is an optional set of flags, which can be used to modify the verify
 operation.
 
-CMS_get0_signers() retrieves the signing certificate(s) from B<cms>, it must
+CMS_get0_signers() retrieves the signing certificate(s) from B<cms>, it may only
 be called after a successful CMS_verify() operation.
 
 =head1 VERIFY PROCESS


### PR DESCRIPTION
The original wording suggests that it is required to execute CMS_get0_signers() after CMS_verify(), while it is CMS_get0_signers() that requires prior successful invocation of CMS_verify().

[skip ci]
CLA: trivial