### PR TITLE
[WIP] APPS: Refactoring dsaparam and dhparam

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -310,6 +310,13 @@ int dhparam_main(int argc, char **argv)
         EVP_PKEY_print_params(out, pkey, 4, NULL);
 
     if (check) {
+        EVP_PKEY_CTX_free(ctx);
+        ctx = EVP_PKEY_CTX_new(pkey. NULL);
+        if (ctx == NULL) {
+            BIO_printf(bio_err,
+                       "Error, DH key check context allocation failed\n");
+            goto end;
+        }
         if (!EVP_PKEY_param_check(ctx) /* DH_check(dh, &i) */) {
             BIO_printf(bio_err, "Error, invalid parameters generated\n");
             goto end;

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -297,6 +297,15 @@ int dhparam_main(int argc, char **argv)
     if (dh == NULL)
         goto end;
 
+    /* If |pkey| is non-NULL, we know it contains |dh| */
+    if (pkey == NULL) {
+        if ((pkey = EVP_PKEY_new()) == NULL
+            || !EVP_PKEY_assign_DH(pkey, dh))
+            goto end;
+    }
+
+    /* At this point, |pkey| contains |dh|, without a doubt */
+
     if (text)
         EVP_PKEY_print_params(out, pkey, 4, NULL);
 

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -228,8 +228,6 @@ int dhparam_main(int argc, char **argv)
                            "Error, DH key generation context allocation failed\n");
                 goto end;
             }
-            EVP_PKEY_CTX_set_cb(ctx, gendh_cb);
-            EVP_PKEY_CTX_set_app_data(ctx, bio_err);
             BIO_printf(bio_err,
                        "Generating DH parameters, %d bit long safe prime, generator %d\n",
                        num, g);
@@ -240,8 +238,14 @@ int dhparam_main(int argc, char **argv)
                 goto end;
             }
 
+            EVP_PKEY_CTX_set_cb(ctx, gendh_cb);
+            EVP_PKEY_CTX_set_app_data(ctx, bio_err);
             if (!EVP_PKEY_CTX_set_dh_paramgen_prime_len(ctx, num)) {
                 BIO_printf(bio_err, "Error, unable to set DH prime length\n");
+                goto end;
+            }
+            if (!EVP_PKEY_CTX_set_dh_paramgen_generator(ctx, g)) {
+                BIO_printf(bio_err, "Error, unable to set DH generator\n");
                 goto end;
             }
             if (!EVP_PKEY_paramgen(ctx, &pkey)) {

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -317,19 +317,11 @@ int dhparam_main(int argc, char **argv)
                        "Error, DH key check context allocation failed\n");
             goto end;
         }
-        if (!EVP_PKEY_param_check(ctx) /* DH_check(dh, &i) */) {
+        if (!EVP_PKEY_param_check(ctx)) {
             BIO_printf(bio_err, "Error, invalid parameters generated\n");
             goto end;
         }
         BIO_printf(bio_err, "DH parameters appear to be ok.\n");
-        if (num != 0) {
-            /*
-             * We have generated parameters but DH_check() indicates they are
-             * invalid! This should never happen!
-             */
-            BIO_printf(bio_err, "Error, invalid parameters generated\n");
-            goto end;
-        }
     }
     if (C) {
         unsigned char *data;

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -160,8 +160,6 @@ int dsaparam_main(int argc, char **argv)
                        "         Your key size is %d! Larger key size may behave not as expected.\n",
                        OPENSSL_DSA_MAX_MODULUS_BITS, numbits);
 
-        EVP_PKEY_CTX_set_cb(ctx, gendsa_cb);
-        EVP_PKEY_CTX_set_app_data(ctx, bio_err);
         if (verbose) {
             BIO_printf(bio_err, "Generating DSA parameters, %d bit long prime\n",
                        num);
@@ -172,6 +170,8 @@ int dsaparam_main(int argc, char **argv)
                        "Error, DSA key generation paramgen init failed\n");
             goto end;
         }
+        EVP_PKEY_CTX_set_cb(ctx, gendsa_cb);
+        EVP_PKEY_CTX_set_app_data(ctx, bio_err);
         if (!EVP_PKEY_CTX_set_dsa_paramgen_bits(ctx, num)) {
             BIO_printf(bio_err,
                        "Error, DSA key generation setting bit length failed\n");

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -217,6 +217,7 @@ int do_X509_REQ_verify(X509_REQ *x, EVP_PKEY *pkey,
                        STACK_OF(OPENSSL_STRING) *vfyopts);
 int do_X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md,
                      STACK_OF(OPENSSL_STRING) *sigopts);
+EVP_PKEY *do_gendsa_params(EVP_PKEY_CTX *ctx, int numbits, int verbose);
 
 extern char *psk_key;
 


### PR DESCRIPTION
## APPS: Refactoring dsaparam and dhparam - error printing

Move all 'ERR_print_errors(bio_err)' calls to one spot, make sure it's
only called on failure.

## APPS: Refactoring dsaparam and dhparam - set EVP_PKEY_CTX params after init

Calling any EVP_PKEY_CTX_set function before the EVP_PKEY_CTX has been
properly initialized (in this case with EVP_PKEY_paramgen_init()) is
dodgy.  The recommended order is init, set all extra params, perform.

While we're at it, we set the param generation generator.

## APPS: Refactoring dhparam - simplify the transfer of dsa params to dh 

## APPS: Refactoring dhparam - make sure |pkey| is always set

|pkey| would be assigned the DH key when it was generated, but not
otherwise.  This ensures it's always assigned the DH key.

## APPS: Refactoring dhparam - make sure |ctx| is correct when checking

|ctx| was the context that |pkey| was created with, but wouldn't contain
|pkey| as a result.  When using |ctx| to validate the params, it must be
recreated from the |pkey|.

## APPS: Refactoring dhparam - remove duplicate check failure message 

## APPS: Refactoring dhparam - refactor in EVP_PKEY and EVP_PKEY_CTX terms

This also implements do_gendsa_params(), a function shared between
dsaparam.c and dhparam.c.
For good measure, we also add do_gendh_params(), but leave it to be
for dhparam.c only for now.