### PR TITLE
openssl speed fixes and documentation updates regarding legacy provider

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1995,6 +1995,15 @@ int speed_main(int argc, char **argv)
     if (argc == 0 && !doit[D_EVP] && !doit[D_EVP_HMAC] && !doit[D_EVP_CMAC]) {
         memset(doit, 1, sizeof(doit));
         doit[D_EVP] = doit[D_EVP_HMAC] = doit[D_EVP_CMAC] = 0;
+#if !defined(OPENSSL_NO_MDC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+	doit[D_MDC2] = 0;
+#endif
+#if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+	doit[D_MD4] = 0;
+#endif
+#if !defined(OPENSSL_NO_RMD160) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+	doit[D_RMD160] = 0;
+#endif
 #if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         memset(rsa_doit, 1, sizeof(rsa_doit));
 #endif

--- a/doc/man3/EVP_md2.pod
+++ b/doc/man3/EVP_md2.pod
@@ -14,7 +14,7 @@ EVP_md2
 =head1 DESCRIPTION
 
 MD2 is a cryptographic hash function standardized in RFC 1319 and designed by
-Ronald Rivest.
+Ronald Rivest. This implementation is only available with the legacy provider.
 
 =over 4
 
@@ -38,6 +38,7 @@ IETF RFC 1319.
 =head1 SEE ALSO
 
 L<evp(7)>,
+L<provider(7)>,
 L<EVP_DigestInit(3)>
 
 =head1 COPYRIGHT

--- a/doc/man3/EVP_md4.pod
+++ b/doc/man3/EVP_md4.pod
@@ -14,7 +14,8 @@ EVP_md4
 =head1 DESCRIPTION
 
 MD4 is a cryptographic hash function standardized in RFC 1320 and designed by
-Ronald Rivest, first published in 1990.
+Ronald Rivest, first published in 1990. This implementation is only available
+with the legacy provider.
 
 =over 4
 
@@ -38,6 +39,7 @@ IETF RFC 1320.
 =head1 SEE ALSO
 
 L<evp(7)>,
+L<provider(7)>,
 L<EVP_DigestInit(3)>
 
 =head1 COPYRIGHT

--- a/doc/man3/EVP_mdc2.pod
+++ b/doc/man3/EVP_mdc2.pod
@@ -14,7 +14,8 @@ EVP_mdc2
 =head1 DESCRIPTION
 
 MDC-2 (Modification Detection Code 2 or Meyer-Schilling) is a cryptographic
-hash function based on a block cipher.
+hash function based on a block cipher. This implementation is only available
+with the legacy provider.
 
 =over 4
 
@@ -38,6 +39,7 @@ ISO/IEC 10118-2:2000 Hash-Function 2, with DES as the underlying block cipher.
 =head1 SEE ALSO
 
 L<evp(7)>,
+L<provider(7)>,
 L<EVP_DigestInit(3)>
 
 =head1 COPYRIGHT

--- a/doc/man3/EVP_ripemd160.pod
+++ b/doc/man3/EVP_ripemd160.pod
@@ -15,6 +15,7 @@ EVP_ripemd160
 
 RIPEMD-160 is a cryptographic hash function first published in 1996 belonging
 to the RIPEMD family (RACE Integrity Primitives Evaluation Message Digest).
+This implementation is only available with the legacy provider.
 
 =over 4
 
@@ -37,6 +38,7 @@ ISO/IEC 10118-3:2016 Dedicated Hash-Function 1 (RIPEMD-160).
 =head1 SEE ALSO
 
 L<evp(7)>,
+L<provider(7)>,
 L<EVP_DigestInit(3)>
 
 =head1 COPYRIGHT

--- a/doc/man3/EVP_whirlpool.pod
+++ b/doc/man3/EVP_whirlpool.pod
@@ -14,7 +14,8 @@ EVP_whirlpool
 =head1 DESCRIPTION
 
 WHIRLPOOL is a cryptographic hash function standardized in ISO/IEC 10118-3:2004
-designed by Vincent Rijmen and Paulo S. L. M. Barreto.
+designed by Vincent Rijmen and Paulo S. L. M. Barreto. This implementation is
+only available with the legacy provider.
 
 =over 4
 
@@ -39,6 +40,7 @@ ISO/IEC 10118-3:2004.
 =head1 SEE ALSO
 
 L<evp(7)>,
+L<provider(7)>,
 L<EVP_DigestInit(3)>
 
 =head1 COPYRIGHT


### PR DESCRIPTION
This addresses the warnings I noticed in `openssl speed' and reported in #11650.
I also added a note about the "legacy provider" to the EVP_$hash(3) man page.