### PR TITLE
fix doc typo in bn_dh.c

### DIFF
--- a/crypto/bn/bn_dh.c
+++ b/crypto/bn/bn_dh.c
@@ -29,7 +29,7 @@
  * The prime is: 2^1536 - 2^1472 - 1 + 2^64 * { [2^1406 pi] + 741804 }
  *
  * RFC3526 specifies a generator of 2.
- * RFC2312 specifies a generator of 22.
+ * RFC2412 specifies a generator of 22.
  */
 static const BN_ULONG modp_1536_p[] = {
     BN_DEF(0xFFFFFFFF, 0xFFFFFFFF), BN_DEF(0xCA237327, 0xF1746C08),


### PR DESCRIPTION
while RFC 2312 refers to S/MIME it doesn't actually declare any groups,
RFC 2412 actually talks about DH extensively and the group
defined in the code below is defined on page 47 of it

see also #12058
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

