### PR TITLE
s_server: really force the handshake for /reneg requests.

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -488,6 +488,10 @@ void apps_ssl_info_callback(const SSL *s, int where, int ret)
         else if (ret < 0)
             BIO_printf(bio_err, "%s:error in %s\n",
                        str, SSL_state_string_long(s));
+    } else if (where & SSL_CB_HANDSHAKE_START) {
+        BIO_puts(bio_err, "TLS handshake: start\n");
+    } else if (where & SSL_CB_HANDSHAKE_DONE) {
+        BIO_puts(bio_err, "TLS handshake: done\n");
     }
 }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3183,7 +3183,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                  * we're expecting to come from the client. If they haven't
                  * sent one there's not much we can do.
                  */
-                BIO_gets(io, buf, bufsize - 1);
+                BIO_read(io, buf, bufsize - 1);
             }
 
             BIO_puts(io,


### PR DESCRIPTION
BIO_read() is needed to complete the renegotiation handshake with the
client, BIO_gets() fails at the job.

The original behaviour with BIO_gets() raises somes questions though, see below.

Basically with a "GET /reneg HTTP/1.0\r\n\r\n" request, the initial BIO_gets() will consume the request line and the second BIO_gets() (after starting the renegotiation) will consume the following "\r\n" from data already buffered. Thus the state machine is not called at this point, unlike with this patch's BIO_read() which uses a size (likely) greater than any buffered data causing the state machine (and full handshake) to trigger.

So what happens without this patch is that s_server starts the renegotiation (HelloRequest) and then fully executes until the final BIO_flush(), sending the entire/buffered HTTP response up to the client without having read anything. So the client receives the HelloRequest and then gets faced with some application data following immediately.

This seems to be only partly handled by the client's state machine though, because upon receipt of HelloRequest the client will send its ClientHello (ignored by s_server without this patch, but nevermind that here), and then when it receives the application data it will never transition from TLS_ST_CW_CLNT_HELLO back to TLS_ST_OK (remaining `in_init` too).
This results in SSL_is_init_finished() returning false forever which confuses the client application. So while it seems to be a valid case, it does not quite work as expected from the application point of view at least.

Below are the relevant s_client and s_server traces, with the original BIO_gets() in s_server to show the issue, but with this PR's changes to  apps_ssl_info_callback() to show more states. Note that -debug is used only to show read/write sizes, but I trimmed the binary/hex dumps and uninteresting outputs.

```
$ ~/src/openssl/install/master/bin/openssl s_server -state -port 8443 -www -tls1_2 -debug -cert /home/yle/src/apache/install/httpd/certs/sserver.pem 
Using default temp DH parameters
ACCEPT
TLS handshake: start
SSL_accept:before SSL initialization
read from 0x55fc8f1ae5a0 [0x55fc8f155bc3] (5 bytes => 5 (0x5))
read from 0x55fc8f1ae5a0 [0x55fc8f155bc8] (203 bytes => 203 (0xCB))
SSL_accept:before SSL initialization
SSL_accept:SSLv3/TLS read client hello
SSL_accept:SSLv3/TLS write server hello
SSL_accept:SSLv3/TLS write certificate
SSL_accept:SSLv3/TLS write key exchange
write to 0x55fc8f1ae5a0 [0x55fc8f159d10] (2008 bytes => 2008 (0x7D8))
SSL_accept:SSLv3/TLS write server done
read from 0x55fc8f1ae5a0 [0x55fc8f155bc3] (5 bytes => 5 (0x5))
read from 0x55fc8f1ae5a0 [0x55fc8f155bc8] (37 bytes => 37 (0x25))
SSL_accept:SSLv3/TLS write server done
read from 0x55fc8f1ae5a0 [0x55fc8f155bc3] (5 bytes => 5 (0x5))
read from 0x55fc8f1ae5a0 [0x55fc8f155bc8] (1 bytes => 1 (0x1))
SSL_accept:SSLv3/TLS read client key exchange
read from 0x55fc8f1ae5a0 [0x55fc8f155bc3] (5 bytes => 5 (0x5))
read from 0x55fc8f1ae5a0 [0x55fc8f155bc8] (40 bytes => 40 (0x28))
SSL_accept:SSLv3/TLS read change cipher spec
SSL_accept:SSLv3/TLS read finished
SSL_accept:SSLv3/TLS write session ticket
SSL_accept:SSLv3/TLS write change cipher spec
write to 0x55fc8f1ae5a0 [0x55fc8f159d10] (226 bytes => 226 (0xE2))
SSL_accept:SSLv3/TLS write finished
TLS handshake: done
read from 0x55fc8f1ae5a0 [0x55fc8f155bc3] (5 bytes => 5 (0x5))
read from 0x55fc8f1ae5a0 [0x55fc8f155bc8] (47 bytes => 47 (0x2F))
[ ^ GET /reneg HTTP/1.0\r\n\r\n ]
SSL_renegotiate -> 1
TLS handshake: start
SSL_accept:SSL negotiation finished successfully
write to 0x55fc8f1ae5a0 [0x55fc8f159d10] (33 bytes => 33 (0x21))
SSL_accept:SSLv3/TLS write hello request
TLS handshake: done
write to 0x55fc8f1ae5a0 [0x55fc8f132903] (5573 bytes => 5573 (0x15C5))
write to 0x55fc8f1ae5a0 [0x55fc8f132903] (31 bytes => 31 (0x1F))
SSL3 alert write:warning:close notify
read from 0x55fc8f1ae5a0 [0x55fc8f155bc3] (5 bytes => 5 (0x5))
read from 0x55fc8f1ae5a0 [0x55fc8f155bc8] (434 bytes => 434 (0x1B2))
[ ^ ClientHello lately read by shutdown ]
```
```
$ ~/src/openssl/install/master/bin/openssl s_client -connect localhost:8443 -tls1_2 -crlf -state -quiet -ign_eof -debug <<EOF
GET /reneg HTTP/1.0

EOF
CONNECTED(00000003)
TLS handshake: start
SSL_connect:before SSL initialization
write to 0x55a61f040460 [0x55a61efc2ca0] (208 bytes => 208 (0xD0))
SSL_connect:SSLv3/TLS write client hello
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (65 bytes => 65 (0x41))
SSL_connect:SSLv3/TLS write client hello
Can't use SSL_get_servername
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (1363 bytes => 1363 (0x553))
SSL_connect:SSLv3/TLS read server hello
depth=0 C = FR, ST = 34, L = Mtp, O = Org, CN = localhost
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 C = FR, ST = 34, L = Mtp, O = Org, CN = localhost
verify error:num=21:unable to verify the first certificate
verify return:1
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (556 bytes => 556 (0x22C))
SSL_connect:SSLv3/TLS read server certificate
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (4 bytes => 4 (0x4))
SSL_connect:SSLv3/TLS read server key exchange
SSL_connect:SSLv3/TLS read server done
SSL_connect:SSLv3/TLS write client key exchange
SSL_connect:SSLv3/TLS write change cipher spec
write to 0x55a61f040460 [0x55a61efc2ca0] (93 bytes => 93 (0x5D))
SSL_connect:SSLv3/TLS write finished
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (170 bytes => 170 (0xAA))
SSL_connect:SSLv3/TLS write finished
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (1 bytes => 1 (0x1))
SSL_connect:SSLv3/TLS read server session ticket
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (40 bytes => 40 (0x28))
SSL_connect:SSLv3/TLS read change cipher spec
SSL_connect:SSLv3/TLS read finished
TLS handshake: done
---
Certificate chain
[snip]
---
Server certificate
[snip]
---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: RSA-PSS
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 2234 bytes and written 301 bytes
Verification error: unable to verify the first certificate
---
New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
Server public key is 4096 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
[snip]
---
write to 0x55a61f040460 [0x55a61eff22d3] (52 bytes => 52 (0x34))
[ ^ GET / HTTP/1.0\r\n\r\n]
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (28 bytes => 28 (0x1C))
TLS handshake: start
SSL_connect:SSL negotiation finished successfully
SSL_connect:SSL negotiation finished successfully
SSL_connect:SSLv3/TLS read hello request
write to 0x55a61f040460 [0x55a61efc1c90] (439 bytes => 439 (0x1B7))
SSL_connect:SSLv3/TLS write client hello
read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (5568 bytes => 5568 (0x15C0))
[ ^ application data (HTTP response) ]
SSL_connect:error in SSLv3/TLS write client hello
[ ^ from here state is still/always TLS_ST_CW_CLNT_HELLO, error recovers thanks to s->s3->in_read_app_data = 2 ]
HTTP/1.0 200 ok
Content-type: text/html

<HTML><BODY BGCOLOR="#ffffff">
[snip]
</pre></BODY></HTML>

read from 0x55a61f040460 [0x55a61efee183] (5 bytes => 5 (0x5))
read from 0x55a61f040460 [0x55a61efee188] (26 bytes => 26 (0x1A))
SSL3 alert read:warning:close notify
SSL_connect:error in SSLv3/TLS write client hello
closed
read from 0x55a61f040460 [0x55a61ef78c10] (8192 bytes => 0 (0x0))
```

So finally s_clients manages to read the application data thanks to `s->s3->in_read_app_data = 2` handling here:
  https://github.com/openssl/openssl/blob/30af356df487b2dad571be15574b454daf70743c/ssl/record/rec_layer_s3.c#L1752-L1762
and here:
  https://github.com/openssl/openssl/blob/30af356df487b2dad571be15574b454daf70743c/ssl/s3_lib.c#L4505-L4519

But none of these paths resets `s->statem.hand_state = TLS_ST_OK` nor calls `ossl_statem_set_in_init(s, 0)` for the application to know that it is not handling a handshake anymore (per `SSL_in_init()` or `SSL_is_init_finished()`). For instance Apache httpd needs to know when to prepare and call SSL_do_handshake(), and mod_proxy (as a client) gets confused when talking to s_server /reneg mechanism.

So this patch makes s_server behave more correctly (possibly) by consuming the client handshake, but it looks like the state machine on the client side needs some adjustments for the ClientHello <= app-data transition during renegotiation (which presumably is allowed, besides this s_server /reneg case)...
