### PR TITLE
Add run_tests.pl options VERBOSE_FAILURES_ONLY etc. for output focused on failed (sub-)test cases

### DIFF
--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -35,6 +35,8 @@ OpenSSL::Test - a private extension of Test::More
 
   setup("my_test_name");
 
+  plan tests => 2;
+
   ok(run(app(["openssl", "version"])), "check for openssl presence");
 
   indir "subdir" => sub {


### PR DESCRIPTION
This PR solves an issue that has been nagging at least me for long time:
When a test contains many test cases, potentially nested in sub-tests,
and a few of them fail, it is often pretty cumbersome to navigate through verbose test output
to find which test cases failed for which reason and with which invocation parameters.

This PR adds to `run_tests.pl` options activated via the following environment variables: 
* `VERBOSE_FAILURES_ONLY` (`VFO`): verbose output only of failed (sub-)tests
* `VERBOSE_FAILURES_PROGRESS` (`VFP`): in addition summary for passed tests

There have been already at least the following attempts to solve the issue to some extent:
* Optionally suppress verbose output of passed tests by `VERBOSE=2` #6425
* Turn off `HARNESS_VERBOSE` #9854
* Rework `test/run_tests.pl` to support selective verbosity and TAP copy #9862

The latter one is the most advanced and the only of these that has been merged.
Yet it was not going far enough because when any (sub-)test case fails then the whole test output is printed. 
Moreover, there was a deeper problem in case that sub-tests are involved, which is pretty common, using for instance `simple_test()` of `Simple.pm`: It looks like `TAP::Parser` does not cope well with indented output of sub-tests due to some bug/limitation. 
This lead to the unpleasant situation that when a test case within a sub-test fails then all the test cases of that sub-test were printed verbosely, including all those that passed. It took me quite a while to analyze this situation and to come up with a viable workaround, which is part of this PR.

