### PR TITLE
[test] ectest: check custom generators

### DIFF
--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2337,6 +2337,89 @@ static int ec_point_hex2point_test(int id)
     return ret;
 }
 
+/*
+ * check the EC_METHOD respects the supplied EC_GROUP_set_generator G
+ */
+static int custom_generator_test(int id)
+{
+    int ret = 0, nid, bsize;
+    EC_GROUP *group = NULL;
+    EC_POINT *G2 = NULL, *Q1 = NULL, *Q2 = NULL;
+    BN_CTX *ctx = NULL;
+    BIGNUM *k = NULL;
+    unsigned char *b1 = NULL, *b2 = NULL;
+
+    /* Do some setup */
+    nid = curves[id].nid;
+    TEST_note("Curve %s", OBJ_nid2sn(nid));
+    if (!TEST_ptr(ctx = BN_CTX_new()))
+        return 0;
+
+    BN_CTX_start(ctx);
+
+    if (!TEST_ptr(group = EC_GROUP_new_by_curve_name(nid)))
+        goto err;
+
+    /* expected byte length of encoded points */
+    bsize = (EC_GROUP_get_field_type(group) == NID_X9_62_prime_field) ?
+             BN_num_bytes(EC_GROUP_get0_field(group)) :
+             (EC_GROUP_get_degree(group) + 7) / 8;
+    bsize = 2 * bsize + 1;
+
+    if (!TEST_ptr(k = BN_CTX_get(ctx))
+        /* fetch a testing scalar k != 0,1 */
+        || !TEST_true(BN_rand(k, EC_GROUP_order_bits(group) - 1,
+                              BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY))
+        /* make k even */
+        || !TEST_true(BN_clear_bit(k, 0))
+        || !TEST_ptr(G2 = EC_POINT_new(group))
+        || !TEST_ptr(Q1 = EC_POINT_new(group))
+        /* Q1 := kG */
+        || !TEST_true(EC_POINT_mul(group, Q1, k, NULL, NULL, ctx))
+        /* pull out the bytes of that */
+        || !TEST_int_eq(EC_POINT_point2oct(group, Q1,
+                                           POINT_CONVERSION_UNCOMPRESSED, NULL,
+                                           0, ctx), bsize)
+        || !TEST_ptr(b1 = OPENSSL_malloc(bsize))
+        || !TEST_int_eq(EC_POINT_point2oct(group, Q1,
+                                           POINT_CONVERSION_UNCOMPRESSED, b1,
+                                           bsize, ctx), bsize)
+        /* new generator is G2 := 2G */
+        || !TEST_true(EC_POINT_dbl(group, G2, EC_GROUP_get0_generator(group),
+                                   ctx))
+        || !TEST_true(EC_GROUP_set_generator(group, G2,
+                                             EC_GROUP_get0_order(group),
+                                             EC_GROUP_get0_cofactor(group)))
+        || !TEST_ptr(Q2 = EC_POINT_new(group))
+        || !TEST_true(BN_rshift1(k, k))
+        /* Q2 := k/2 G2 */
+        || !TEST_true(EC_POINT_mul(group, Q2, k, NULL, NULL, ctx))
+        || !TEST_int_eq(EC_POINT_point2oct(group, Q2,
+                                           POINT_CONVERSION_UNCOMPRESSED, NULL,
+                                           0, ctx), bsize)
+        || !TEST_ptr(b2 = OPENSSL_malloc(bsize))
+        || !TEST_int_eq(EC_POINT_point2oct(group, Q2,
+                                           POINT_CONVERSION_UNCOMPRESSED, b2,
+                                           bsize, ctx), bsize)
+        /* Q1 = kG = k/2 G2 = Q2 should hold */
+        || !TEST_int_eq(CRYPTO_memcmp(b1, b2, bsize), 0))
+        goto err;
+
+    ret = 1;
+
+ err:
+    BN_CTX_end(ctx);
+    EC_POINT_free(Q1);
+    EC_POINT_free(Q2);
+    EC_POINT_free(G2);
+    EC_GROUP_free(group);
+    BN_CTX_free(ctx);
+    OPENSSL_free(b1);
+    OPENSSL_free(b2);
+
+    return ret;
+}
+
 #endif /* OPENSSL_NO_EC */
 
 int setup_tests(void)
@@ -2364,6 +2447,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(check_ec_key_field_public_range_test, crv_len);
     ADD_ALL_TESTS(check_named_curve_from_ecparameters, crv_len);
     ADD_ALL_TESTS(ec_point_hex2point_test, crv_len);
+    ADD_ALL_TESTS(custom_generator_test, crv_len);
 #endif /* OPENSSL_NO_EC */
     return 1;
 }


### PR DESCRIPTION
I was doing some custom `EC_METHOD` work that should've obviously failed because it was oblivious to `EC_GROUP_set_generator`.

But it passed all tests.

So here's a PR for that.

A handful of the NIST curves have similar tests in `ectest.c` that I'll deprecate as part of a larger cleanup of this test harness in the future.