### PR TITLE
Do not allow dropping Extended Master Secret extension on renegotiaton [1.1.1]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,10 @@
 
  Changes between 1.1.1g and 1.1.1h [xx XXX xxxx]
 
+  *) Handshake now fails if Extended Master Secret extension is dropped
+     on renegotiation.
+     [Tomas Mraz]
+
   *) The Oracle Developer Studio compiler will start reporting deprecated APIs
 
  Changes between 1.1.1f and 1.1.1g [21 Apr 2020]

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -292,6 +292,9 @@ extern "C" {
 
 # define TLS1_FLAGS_STATELESS                    0x0800
 
+/* Set if extended master secret extension required on renegotiation */
+# define TLS1_FLAGS_REQUIRED_EXTMS               0x1000
+
 # define SSL3_MT_HELLO_REQUEST                   0
 # define SSL3_MT_CLIENT_HELLO                    1
 # define SSL3_MT_SERVER_HELLO                    2

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1168,14 +1168,26 @@ static int init_etm(SSL *s, unsigned int context)
 
 static int init_ems(SSL *s, unsigned int context)
 {
-    if (!s->server)
+    if (s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS) {
         s->s3->flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
+        s->s3->flags |= TLS1_FLAGS_REQUIRED_EXTMS;
+    }
 
     return 1;
 }
 
 static int final_ems(SSL *s, unsigned int context, int sent)
 {
+    /*
+     * Check extended master secret extension is not dropped on
+     * renegotiation.
+     */
+    if (!(s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS)
+        && (s->s3->flags & TLS1_FLAGS_REQUIRED_EXTMS)) {
+        SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_FINAL_EMS,
+                 SSL_R_INCONSISTENT_EXTMS);
+        return 0;
+    }
     if (!s->server && s->hit) {
         /*
          * Check extended master secret extension is consistent with


### PR DESCRIPTION
This is a cherry-pick of the #12045 for the 1.1.1 branch.

The test cannot be added as it depends on SSL_OP_NO_EXTENDED_MASTER_SECRET which we do not have on 1.1.1.