### PR TITLE
Fix set_ciphersuites ignore unknown ciphers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Changed behavior of SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites()
+   to ignore unknown ciphers.
+
+   *Otto Hollmann*
+
  * The -cipher-commands and -digest-commands options of the command line
    utility list has been deprecated.
    Instead use the -cipher-algorithms and -digest-algorithms options.

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -65,11 +65,11 @@ cipher string for TLSv1.3 ciphersuites.
 
 =head1 NOTES
 
-The control string B<str> for SSL_CTX_set_cipher_list() and
-SSL_set_cipher_list() should be universally usable and not depend
-on details of the library configuration (ciphers compiled in). Thus no
-syntax checking takes place. Items that are not recognized, because the
-corresponding ciphers are not compiled in or because they are mistyped,
+The control string B<str> for SSL_CTX_set_cipher_list(), SSL_set_cipher_list(),
+SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() should be universally
+usable and not depend on details of the library configuration (ciphers compiled
+in). Thus no syntax checking takes place. Items that are not recognized, because
+the corresponding ciphers are not compiled in or because they are mistyped,
 are simply ignored. Failure is only flagged if no ciphers could be collected
 at all.
 

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1300,6 +1300,8 @@ static int ciphersuite_cb(const char *elem, int len, void *arg)
     if (cipher == NULL) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         return 0;
+        /* Ciphersuite not found but return 1 to parse rest of the list */
+        return 1;
     }
 
     if (!sk_SSL_CIPHER_push(ciphersuites, cipher)) {
@@ -1319,7 +1321,8 @@ static __owur int set_ciphersuites(STACK_OF(SSL_CIPHER) **currciphers, const cha
 
     /* Parse the list. We explicitly allow an empty list */
     if (*str != '\0'
-            && !CONF_parse_list(str, ':', 1, ciphersuite_cb, newciphers)) {
+            && (CONF_parse_list(str, ':', 1, ciphersuite_cb, newciphers) <= 0
+                || sk_SSL_CIPHER_num(newciphers) == 0 )) {
         sk_SSL_CIPHER_free(newciphers);
         return 0;
     }

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1318,7 +1318,7 @@ static __owur int set_ciphersuites(STACK_OF(SSL_CIPHER) **currciphers, const cha
     /* Parse the list. We explicitly allow an empty list */
     if (*str != '\0'
             && (CONF_parse_list(str, ':', 1, ciphersuite_cb, newciphers) <= 0
-                || sk_SSL_CIPHER_num(newciphers) == 0 )) {
+                || sk_SSL_CIPHER_num(newciphers) == 0)) {
         ERR_raise(ERR_LIB_SSL, SSL_R_NO_CIPHER_MATCH);
         sk_SSL_CIPHER_free(newciphers);
         return 0;


### PR DESCRIPTION
Fix SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() to ignore unknown cipehrs.
These functions now should behave like SSL_CTX_set_cipher_list() and SSL_set_cipher_list().

This commit fixes bug/feature https://github.com/openssl/openssl/issues/9335