### PR TITLE
Serialisation: add a built-in serialisation provider.

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3647,7 +3647,7 @@ static int generate_session_id(SSL *ssl, unsigned char *id,
 
 /*
  * By default s_server uses an in-memory cache which caches SSL_SESSION
- * structures without any serialisation. This hides some bugs which only
+ * structures without any serialization. This hides some bugs which only
  * become apparent in deployed servers. By implementing a basic external
  * session cache some issues can be debugged using s_server.
  */

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -437,7 +437,7 @@ BN_MONT_CTX *BN_MONT_CTX_set_locked(BN_MONT_CTX **pmont, CRYPTO_RWLOCK *lock,
         return ret;
 
     /*
-     * We don't want to serialise globally while doing our lazy-init math in
+     * We don't want to serialize globally while doing our lazy-init math in
      * BN_MONT_CTX_set. That punishes threads that are doing independent
      * things. Instead, punish the case where more than one thread tries to
      * lazy-init the same 'pmont', by having each do the lazy-init math work

--- a/crypto/ec/curve448/eddsa.c
+++ b/crypto/ec/curve448/eddsa.c
@@ -169,7 +169,7 @@ c448_error_t c448_ed448_sign(
 
     {
         /*
-         * Schedule the secret key, First EDDSA_448_PRIVATE_BYTES is serialised
+         * Schedule the secret key, First EDDSA_448_PRIVATE_BYTES is serialized
          * secret scalar,next EDDSA_448_PRIVATE_BYTES bytes is the seed.
          */
         uint8_t expanded[EDDSA_448_PRIVATE_BYTES * 2];

--- a/crypto/ec/ecp_nistp256.c
+++ b/crypto/ec/ecp_nistp256.c
@@ -59,7 +59,7 @@ typedef uint64_t u64;
 
 /*
  * The underlying field. P256 operates over GF(2^256-2^224+2^192+2^96-1). We
- * can serialise an element of this field into 32 bytes. We call this an
+ * can serialize an element of this field into 32 bytes. We call this an
  * felem_bytearray.
  */
 
@@ -138,7 +138,7 @@ static void bin32_to_felem(felem out, const u8 in[32])
 }
 
 /*
- * smallfelem_to_bin32 takes a smallfelem and serialises into a little
+ * smallfelem_to_bin32 takes a smallfelem and serializes into a little
  * endian, 32 byte array. This assumes that the CPU is little-endian.
  */
 static void smallfelem_to_bin32(u8 out[32], const smallfelem in)

--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -55,7 +55,7 @@ typedef uint8_t u8;
 typedef uint64_t u64;
 
 /*
- * The underlying field. P521 operates over GF(2^521-1). We can serialise an
+ * The underlying field. P521 operates over GF(2^521-1). We can serialize an
  * element of this field into 66 bytes where the most significant byte
  * contains only a single bit. We call this an felem_bytearray.
  */
@@ -156,7 +156,7 @@ static void bin66_to_felem(felem out, const u8 in[66])
 }
 
 /*
- * felem_to_bin66 takes an felem and serialises into a little endian, 66 byte
+ * felem_to_bin66 takes an felem and serializes into a little endian, 66 byte
  * array. This assumes that the CPU is little-endian.
  */
 static void felem_to_bin66(u8 out[66], const felem in)

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -11,6 +11,7 @@
 #include "provider_local.h"
 
 OSSL_provider_init_fn ossl_default_provider_init;
+OSSL_provider_init_fn ossl_base_provider_init;
 OSSL_provider_init_fn ossl_null_provider_init;
 OSSL_provider_init_fn fips_intern_provider_init;
 #ifdef STATIC_LEGACY
@@ -24,6 +25,7 @@ const struct predefined_providers_st predefined_providers[] = {
 # ifdef STATIC_LEGACY
     { "legacy", ossl_legacy_provider_init, 0 },
 # endif
+    { "base", ossl_base_provider_init, 0 },
     { "null", ossl_null_provider_init, 0 },
 #endif
     { NULL, NULL, 0 }

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -19,6 +19,7 @@ B<openssl list>
 [B<-random-generators>]
 [B<-cipher-commands>]
 [B<-cipher-algorithms>]
+[B<-serializers>]
 [B<-public-key-algorithms>]
 {- output_off() if $disabled{"deprecated-3.0"}; ""
 -}[B<-public-key-methods>]
@@ -79,7 +80,12 @@ information on what parameters each implementation supports.
 =item B<-random-generators>
 
 Display a list of random number generators.
+See L</Display of algorithm names> for a description of how names are
+displayed.
 
+=item B<-serializers>
+
+Display a list of serializers.
 See L</Display of algorithm names> for a description of how names are
 displayed.
 

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -20,6 +20,7 @@ B<openssl list>
 [B<-cipher-commands>]
 [B<-cipher-algorithms>]
 [B<-serializers>]
+[B<-deserializers>]
 [B<-public-key-algorithms>]
 {- output_off() if $disabled{"deprecated-3.0"}; ""
 -}[B<-public-key-methods>]
@@ -86,6 +87,15 @@ displayed.
 =item B<-serializers>
 
 Display a list of serializers.
+See L</Display of algorithm names> for a description of how names are
+displayed.
+
+In verbose mode, the algorithms provided by a provider will get additional
+information on what parameters each implementation supports.
+
+=item B<-deserializers>
+
+Display a list of deserializers.
 See L</Display of algorithm names> for a description of how names are
 displayed.
 

--- a/doc/man7/OSSL_PROVIDER-base.pod
+++ b/doc/man7/OSSL_PROVIDER-base.pod
@@ -1,0 +1,96 @@
+=pod
+
+=head1 NAME
+
+OSSL_PROVIDER-base - OpenSSL base provider
+
+=head1 DESCRIPTION
+
+The OpenSSL base provider supplies the serialization for OpenSSL's
+asymmetric cryptography.
+
+=head2 Properties
+
+The implementations in this provider specifically have this property
+defined:
+
+=over 4
+
+=item "provider=base"
+
+=back
+
+It may be used in a property query string with fetching functions.
+
+It isn't mandatory to query for this property, except to make sure to get
+implementations of this provider and none other.
+
+=over 4
+
+=item "type=parameters"
+
+=item "type=private"
+
+=item "type=public"
+
+=back
+
+These may be used in a property query string with fetching functions to select
+which data are to be serialized.  Either the private key material, the public
+key material or the domain parameters can be selected.
+
+=over 4
+
+=item "format=der"
+
+=item "format=pem"
+
+=item "format=text"
+
+=back
+
+These may be used in a property query string with fetching functions to select
+the serialization output format.  Either the DER, PEM and plaintext are
+currently permitted.
+
+=head1 OPERATIONS AND ALGORITHMS
+
+The OpenSSL base provider supports these operations and algorithms:
+
+=head2 Asymmetric Key Serializer
+
+In addition to "provider=base", some of these serializers define the
+property "fips=yes", to allow them to be used together with the FIPS
+provider.
+
+=over 4
+
+=item RSA, see L<OSSL_SERIALIZER-RSA(7)>
+
+=item DH, see L<OSSL_SERIALIZER-DH(7)>
+
+=item DSA, see L<OSSL_SERIALIZER-DSA(7)>
+
+=item EC, see L<OSSL_SERIALIZER-EC(7)>
+
+=item X25519, see L<OSSL_SERIALIZER-X25519(7)>
+
+=item X448, see L<OSSL_SERIALIZER-X448(7)>
+
+=back
+
+=head1 SEE ALSO
+
+L<OSSL_PROVIDER-default(7)>, L<openssl-core.h(7)>,
+L<openssl-core_dispatch.h(7)>, L<provider(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man7/OSSL_PROVIDER-default.pod
+++ b/doc/man7/OSSL_PROVIDER-default.pod
@@ -192,9 +192,9 @@ The OpenSSL default provider supports these operations and algorithms:
 
 =head2 Asymmetric Key Serializer
 
-In addition to "provider=default", this set of implementations define the
-property "fips=yes", to allow them to be used together with the FIPS
-provider.
+The default provider also includes all of the serialization algorithms
+present in the base provider.  Some of these have the property "fips=yes",
+to allow them to be used together with the FIPS provider.
 
 =over 4
 
@@ -214,7 +214,8 @@ provider.
 
 =head1 SEE ALSO
 
-L<openssl-core.h(7)>, L<openssl-core_dispatch.h(7)>, L<provider(7)>
+L<openssl-core.h(7)>, L<openssl-core_dispatch.h(7)>, L<provider(7)>,
+L<OSSL_PROVIDER-base(7)>
 
 =head1 COPYRIGHT
 

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -268,6 +268,14 @@ algorithm identifier to the appropriate fetching function.
 The default provider is built in as part of the F<libcrypto> library.
 Should it be needed (if other providers are loaded and offer
 implementations of the same algorithms), the property "provider=default"
+can be used as a search criterion for these implementations.  The default
+provider includes all the functionality of the base provider below.
+
+=head2 Base provider
+
+The base provider is built in as part of the F<libcrypto> library.
+Should it be needed (if other providers are loaded and offer
+implementations of the same algorithms), the property "provider=base"
 can be used as a search criterion for these implementations. Some
 non-cryptographic algorithms (such as serializers for loading keys and
 parameters from files) are not FIPS algorithm implementations in themselves but

--- a/include/openssl/ct.h
+++ b/include/openssl/ct.h
@@ -331,7 +331,7 @@ __owur int SCT_LIST_validate(const STACK_OF(SCT) *scts,
 
 
 /*********************************
- * SCT parsing and serialisation *
+ * SCT parsing and serialization *
  *********************************/
 
 /*

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -76,7 +76,7 @@ typedef struct DSA_SIG_st DSA_SIG;
 
 /*
  * TODO(3.0): consider removing the ASN.1 encoding and decoding when
- * deserialisation is completed elsewhere.
+ * deserialization is completed elsewhere.
  */
 #  define d2i_DSAparams_fp(fp, x) \
         (DSA *)ASN1_d2i_fp((char *(*)())DSA_new, \

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <openssl/opensslconf.h>
+#include <openssl/core.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include "prov/bio.h"
+#include "prov/provider_ctx.h"
+#include "prov/providercommon.h"
+#include "prov/implementations.h"
+#include "prov/provider_util.h"
+#include "internal/nelem.h"
+
+/*
+ * Forward declarations to ensure that interface functions are correctly
+ * defined.
+ */
+static OSSL_FUNC_provider_gettable_params_fn base_gettable_params;
+static OSSL_FUNC_provider_get_params_fn base_get_params;
+static OSSL_FUNC_provider_query_operation_fn base_query;
+
+/* Functions provided by the core */
+static OSSL_FUNC_core_gettable_params_fn *c_gettable_params = NULL;
+static OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
+
+/* Parameters we provide to the core */
+static const OSSL_PARAM base_param_types[] = {
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *base_gettable_params(void *provctx)
+{
+    return base_param_types;
+}
+
+static int base_get_params(void *provctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
+    if (p != NULL
+            && !OSSL_PARAM_set_utf8_ptr(p, "OpenSSL Base Provider"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_VERSION_STR))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, OPENSSL_FULL_VERSION_STR))
+        return 0;
+
+    return 1;
+}
+
+static const OSSL_ALGORITHM base_serializer[] = {
+#define SER(name, fips, format, type, func_table)                           \
+    { name,                                                                 \
+      "provider=base,fips=" fips ",format=" format ",type=" type,           \
+      (func_table) }
+
+#include "serializers.inc"
+    { NULL, NULL, NULL }
+};
+#undef SER
+
+static const OSSL_ALGORITHM *base_query(void *provctx, int operation_id,
+                                         int *no_cache)
+{
+    *no_cache = 0;
+    return operation_id == OSSL_OP_SERIALIZER ? base_serializer : NULL;
+}
+
+static void base_teardown(void *provctx)
+{
+    BIO_meth_free(PROV_CTX_get0_core_bio_method(provctx));
+    PROV_CTX_free(provctx);
+}
+
+/* Functions we provide to the core */
+static const OSSL_DISPATCH base_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))base_teardown },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS,
+      (void (*)(void))base_gettable_params },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))base_get_params },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))base_query },
+    { 0, NULL }
+};
+
+OSSL_provider_init_fn ossl_base_provider_init;
+
+int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
+                            const OSSL_DISPATCH *in, const OSSL_DISPATCH **out,
+                            void **provctx)
+{
+    OSSL_FUNC_core_get_library_context_fn *c_get_libctx = NULL;
+    BIO_METHOD *corebiometh;
+
+    if (!ossl_prov_bio_from_dispatch(in))
+        return 0;
+    for (; in->function_id != 0; in++) {
+        switch (in->function_id) {
+        case OSSL_FUNC_CORE_GETTABLE_PARAMS:
+            c_gettable_params = OSSL_FUNC_core_gettable_params(in);
+            break;
+        case OSSL_FUNC_CORE_GET_PARAMS:
+            c_get_params = OSSL_FUNC_core_get_params(in);
+            break;
+        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
+            c_get_libctx = OSSL_FUNC_core_get_library_context(in);
+            break;
+        default:
+            /* Just ignore anything we don't understand */
+            break;
+        }
+    }
+
+    if (c_get_libctx == NULL)
+        return 0;
+
+    /*
+     * We want to make sure that all calls from this provider that requires
+     * a library context use the same context as the one used to call our
+     * functions.  We do that by passing it along in the provider context.
+     *
+     * This only works for built-in providers.  Most providers should
+     * create their own library context.
+     */
+    if ((*provctx = PROV_CTX_new()) == NULL
+            || (corebiometh = bio_prov_init_bio_method()) == NULL) {
+        PROV_CTX_free(*provctx);
+        *provctx = NULL;
+        return 0;
+    }
+    PROV_CTX_set0_library_context(*provctx, (OPENSSL_CTX *)c_get_libctx(handle));
+    PROV_CTX_set0_handle(*provctx, handle);
+    PROV_CTX_set0_core_bio_method(*provctx, corebiometh);
+
+    *out = base_dispatch_table;
+
+    return 1;
+}

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -75,11 +75,28 @@ static const OSSL_ALGORITHM base_serializer[] = {
 };
 #undef SER
 
+static const OSSL_ALGORITHM base_deserializer[] = {
+#define DESER(name, fips, input, func_table)                                \
+    { name,                                                                 \
+      "provider=base,fips=" fips ",input=" input,                           \
+      (func_table) }
+
+#include "deserializers.inc"
+    { NULL, NULL, NULL }
+};
+#undef DESER
+
 static const OSSL_ALGORITHM *base_query(void *provctx, int operation_id,
                                          int *no_cache)
 {
     *no_cache = 0;
-    return operation_id == OSSL_OP_SERIALIZER ? base_serializer : NULL;
+    switch (operation_id) {
+    case OSSL_OP_SERIALIZER:
+        return base_serializer;
+    case OSSL_OP_DESERIALIZER:
+        return base_deserializer;
+    }
+    return NULL;
 }
 
 static void base_teardown(void *provctx)

--- a/providers/build.info
+++ b/providers/build.info
@@ -109,6 +109,16 @@ INCLUDE[$DEFAULTGOAL]=implementations/include
 LIBS=$DEFAULTGOAL
 
 #
+# Base provider stuff
+#
+# Because the base provider is built in, it means that libcrypto
+# must include all of the object files that are needed.
+$BASEGOAL=../libcrypto
+SOURCE[$BASEGOAL]=$LIBIMPLEMENTATIONS $LIBNONFIPS
+SOURCE[$BASEGOAL]=baseprov.c
+INCLUDE[$BASEGOAL]=implementations/include
+
+#
 # FIPS provider stuff
 #
 # We define it this way to ensure that configdata.pm will have all the

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -385,154 +385,16 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
     { NULL, NULL, NULL }
 };
 
-/*
- * Unlike most algorithms in the default provider, the serializers are allowed
- * for use in FIPS mode because they are not FIPS relevant, and therefore have
- * the "fips=yes" property.
- */
 static const OSSL_ALGORITHM deflt_serializer[] = {
-    { "RSA", "provider=default,fips=yes,format=text,type=private",
-      rsa_priv_text_serializer_functions },
-    { "RSA", "provider=default,fips=yes,format=text,type=public",
-      rsa_pub_text_serializer_functions },
-    { "RSA", "provider=default,fips=yes,format=der,type=private",
-      rsa_priv_der_serializer_functions },
-    { "RSA", "provider=default,fips=yes,format=der,type=public",
-      rsa_pub_der_serializer_functions },
-    { "RSA", "provider=default,fips=yes,format=pem,type=private",
-      rsa_priv_pem_serializer_functions },
-    { "RSA", "provider=default,fips=yes,format=pem,type=public",
-      rsa_pub_pem_serializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,format=text,type=private",
-      rsa_priv_text_serializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,format=text,type=public",
-      rsa_pub_text_serializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,format=der,type=private",
-      rsa_priv_der_serializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,format=der,type=public",
-      rsa_pub_der_serializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,format=pem,type=private",
-      rsa_priv_pem_serializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,format=pem,type=public",
-      rsa_pub_pem_serializer_functions },
+#define SER(name, fips, format, type, func_table)                           \
+    { name,                                                                 \
+      "provider=default,fips=" fips ",format=" format ",type=" type,  \
+      (func_table) }
 
-#ifndef OPENSSL_NO_DH
-    { "DH", "provider=default,fips=yes,format=text,type=private",
-      dh_priv_text_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=text,type=public",
-      dh_pub_text_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=text,type=parameters",
-      dh_param_text_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=der,type=private",
-      dh_priv_der_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=der,type=public",
-      dh_pub_der_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=der,type=parameters",
-      dh_param_der_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=pem,type=private",
-      dh_priv_pem_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=pem,type=public",
-      dh_pub_pem_serializer_functions },
-    { "DH", "provider=default,fips=yes,format=pem,type=parameters",
-      dh_param_pem_serializer_functions },
-#endif
-
-#ifndef OPENSSL_NO_DSA
-    { "DSA", "provider=default,fips=yes,format=text,type=private",
-      dsa_priv_text_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=text,type=public",
-      dsa_pub_text_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=text,type=parameters",
-      dsa_param_text_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=der,type=private",
-      dsa_priv_der_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=der,type=public",
-      dsa_pub_der_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=der,type=parameters",
-      dsa_param_der_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=pem,type=private",
-      dsa_priv_pem_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=pem,type=public",
-      dsa_pub_pem_serializer_functions },
-    { "DSA", "provider=default,fips=yes,format=pem,type=parameters",
-      dsa_param_pem_serializer_functions },
-#endif
-
-#ifndef OPENSSL_NO_EC
-    { "X25519", "provider=default,fips=yes,format=text,type=private",
-      x25519_priv_print_serializer_functions },
-    { "X25519", "provider=default,fips=yes,format=text,type=public",
-      x25519_pub_print_serializer_functions },
-    { "X25519", "provider=default,fips=yes,format=der,type=private",
-      x25519_priv_der_serializer_functions },
-    { "X25519", "provider=default,fips=yes,format=der,type=public",
-      x25519_pub_der_serializer_functions },
-    { "X25519", "provider=default,fips=yes,format=pem,type=private",
-      x25519_priv_pem_serializer_functions },
-    { "X25519", "provider=default,fips=yes,format=pem,type=public",
-      x25519_pub_pem_serializer_functions },
-
-    { "X448", "provider=default,format=text,type=private",
-      x448_priv_print_serializer_functions },
-    { "X448", "provider=default,format=text,type=public",
-      x448_pub_print_serializer_functions },
-    { "X448", "provider=default,format=der,type=private",
-      x448_priv_der_serializer_functions },
-    { "X448", "provider=default,format=der,type=public",
-      x448_pub_der_serializer_functions },
-    { "X448", "provider=default,format=pem,type=private",
-      x448_priv_pem_serializer_functions },
-    { "X448", "provider=default,format=pem,type=public",
-      x448_pub_pem_serializer_functions },
-
-    { "ED25519", "provider=default,fips=yes,format=text,type=private",
-      ed25519_priv_print_serializer_functions },
-    { "ED25519", "provider=default,fips=yes,format=text,type=public",
-      ed25519_pub_print_serializer_functions },
-    { "ED25519", "provider=default,fips=yes,format=der,type=private",
-      ed25519_priv_der_serializer_functions },
-    { "ED25519", "provider=default,fips=yes,format=der,type=public",
-      ed25519_pub_der_serializer_functions },
-    { "ED25519", "provider=default,fips=yes,format=pem,type=private",
-      ed25519_priv_pem_serializer_functions },
-    { "ED25519", "provider=default,fips=yes,format=pem,type=public",
-      ed25519_pub_pem_serializer_functions },
-
-    { "ED448", "provider=default,format=text,type=private",
-      ed448_priv_print_serializer_functions },
-    { "ED448", "provider=default,format=text,type=public",
-      ed448_pub_print_serializer_functions },
-    { "ED448", "provider=default,format=der,type=private",
-      ed448_priv_der_serializer_functions },
-    { "ED448", "provider=default,format=der,type=public",
-      ed448_pub_der_serializer_functions },
-    { "ED448", "provider=default,format=pem,type=private",
-      ed448_priv_pem_serializer_functions },
-    { "ED448", "provider=default,format=pem,type=public",
-      ed448_pub_pem_serializer_functions },
-
-    { "EC", "provider=default,fips=yes,format=text,type=private",
-      ec_priv_text_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=text,type=public",
-      ec_pub_text_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=text,type=parameters",
-      ec_param_text_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=der,type=private",
-      ec_priv_der_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=der,type=public",
-      ec_pub_der_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=der,type=parameters",
-      ec_param_der_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=pem,type=private",
-      ec_priv_pem_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=pem,type=public",
-      ec_pub_pem_serializer_functions },
-    { "EC", "provider=default,fips=yes,format=pem,type=parameters",
-      ec_param_pem_serializer_functions },
-#endif
-
+#include "serializers.inc"
     { NULL, NULL, NULL }
 };
+#undef SER
 
 static const OSSL_ALGORITHM deflt_deserializer[] = {
     { "RSA", "provider=default,fips=yes,input=der",

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -388,7 +388,7 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
 static const OSSL_ALGORITHM deflt_serializer[] = {
 #define SER(name, fips, format, type, func_table)                           \
     { name,                                                                 \
-      "provider=default,fips=" fips ",format=" format ",type=" type,  \
+      "provider=default,fips=" fips ",format=" format ",type=" type,        \
       (func_table) }
 
 #include "serializers.inc"
@@ -397,16 +397,15 @@ static const OSSL_ALGORITHM deflt_serializer[] = {
 #undef SER
 
 static const OSSL_ALGORITHM deflt_deserializer[] = {
-    { "RSA", "provider=default,fips=yes,input=der",
-      der_to_rsa_deserializer_functions },
-    { "RSA-PSS", "provider=default,fips=yes,input=der",
-      der_to_rsapss_deserializer_functions },
+#define DESER(name, fips, input, func_table)                                \
+    { name,                                                                 \
+      "provider=default,fips=" fips ",input=" input,                        \
+      (func_table) }
 
-    { "DER", "provider=default,fips=yes,input=pem",
-      pem_to_der_deserializer_functions },
-
+#include "deserializers.inc"
     { NULL, NULL, NULL }
 };
+#undef DESER
 
 static const OSSL_ALGORITHM *deflt_query(void *provctx, int operation_id,
                                          int *no_cache)

--- a/providers/deserializers.inc
+++ b/providers/deserializers.inc
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef DESER
+# error Macro DESER undefined
+#endif
+
+    DESER("RSA", "yes", "der", der_to_rsa_deserializer_functions),
+    DESER("RSA-PSS", "yes", "der", der_to_rsapss_deserializer_functions),
+    DESER("DER", "yes", "pem", pem_to_der_deserializer_functions),

--- a/providers/serializers.inc
+++ b/providers/serializers.inc
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef SER
+# error Macro SER undefined
+#endif
+
+    SER("RSA", "yes", "text", "private", rsa_priv_text_serializer_functions),
+    SER("RSA", "yes", "text", "public", rsa_pub_text_serializer_functions),
+    SER("RSA", "yes", "der", "private", rsa_priv_der_serializer_functions),
+    SER("RSA", "yes", "der", "public", rsa_pub_der_serializer_functions),
+    SER("RSA", "yes", "pem", "private", rsa_priv_pem_serializer_functions),
+    SER("RSA", "yes", "pem", "public", rsa_pub_pem_serializer_functions),
+    SER("RSA-PSS", "yes", "text", "private",
+        rsa_priv_text_serializer_functions),
+    SER("RSA-PSS", "yes", "text", "public", rsa_pub_text_serializer_functions),
+    SER("RSA-PSS", "yes", "der", "private", rsa_priv_der_serializer_functions),
+    SER("RSA-PSS", "yes", "der", "public", rsa_pub_der_serializer_functions),
+    SER("RSA-PSS", "yes", "pem", "private", rsa_priv_pem_serializer_functions),
+    SER("RSA-PSS", "yes", "pem", "public", rsa_pub_pem_serializer_functions),
+
+#ifndef OPENSSL_NO_DH
+    SER("DH", "yes", "text", "private", dh_priv_text_serializer_functions),
+    SER("DH", "yes", "text", "public", dh_pub_text_serializer_functions),
+    SER("DH", "yes", "text", "parameters", dh_param_text_serializer_functions),
+    SER("DH", "yes", "der", "private", dh_priv_der_serializer_functions),
+    SER("DH", "yes", "der", "public", dh_pub_der_serializer_functions),
+    SER("DH", "yes", "der", "parameters", dh_param_der_serializer_functions),
+    SER("DH", "yes", "pem", "private", dh_priv_pem_serializer_functions),
+    SER("DH", "yes", "pem", "public", dh_pub_pem_serializer_functions),
+    SER("DH", "yes", "pem", "parameters", dh_param_pem_serializer_functions),
+#endif
+
+#ifndef OPENSSL_NO_DSA
+    SER("DSA", "yes", "text", "private", dsa_priv_text_serializer_functions),
+    SER("DSA", "yes", "text", "public", dsa_pub_text_serializer_functions),
+    SER("DSA", "yes", "text", "parameters",
+        dsa_param_text_serializer_functions),
+    SER("DSA", "yes", "der", "private", dsa_priv_der_serializer_functions),
+    SER("DSA", "yes", "der", "public", dsa_pub_der_serializer_functions),
+    SER("DSA", "yes", "der", "parameters", dsa_param_der_serializer_functions),
+    SER("DSA", "yes", "pem", "private", dsa_priv_pem_serializer_functions),
+    SER("DSA", "yes", "pem", "public", dsa_pub_pem_serializer_functions),
+    SER("DSA", "yes", "pem", "parameters", dsa_param_pem_serializer_functions),
+#endif
+
+#ifndef OPENSSL_NO_EC
+    SER("X25519", "yes", "text", "private",
+        x25519_priv_print_serializer_functions),
+    SER("X25519", "yes", "text", "public",
+        x25519_pub_print_serializer_functions),
+    SER("X25519", "yes", "der", "private",
+        x25519_priv_der_serializer_functions),
+    SER("X25519", "yes", "der", "public", x25519_pub_der_serializer_functions),
+    SER("X25519", "yes", "pem", "private",
+        x25519_priv_pem_serializer_functions),
+    SER("X25519", "yes", "pem", "public", x25519_pub_pem_serializer_functions),
+
+    SER("X448", "no", "text", "private", x448_priv_print_serializer_functions),
+    SER("X448", "no", "text", "public", x448_pub_print_serializer_functions),
+    SER("X448", "no", "der", "private", x448_priv_der_serializer_functions),
+    SER("X448", "no", "der", "public", x448_pub_der_serializer_functions),
+    SER("X448", "no", "pem", "private", x448_priv_pem_serializer_functions),
+    SER("X448", "no", "pem", "public", x448_pub_pem_serializer_functions),
+
+    SER("ED25519", "yes", "text", "private",
+        ed25519_priv_print_serializer_functions),
+    SER("ED25519", "yes", "text", "public",
+        ed25519_pub_print_serializer_functions),
+    SER("ED25519", "yes", "der", "private",
+        ed25519_priv_der_serializer_functions),
+    SER("ED25519", "yes", "der", "public",
+        ed25519_pub_der_serializer_functions),
+    SER("ED25519", "yes", "pem", "private",
+        ed25519_priv_pem_serializer_functions),
+    SER("ED25519", "yes", "pem", "public",
+        ed25519_pub_pem_serializer_functions),
+
+    SER("ED448", "no", "text", "private",
+        ed448_priv_print_serializer_functions),
+    SER("ED448", "no", "text", "public", ed448_pub_print_serializer_functions),
+    SER("ED448", "no", "der", "private", ed448_priv_der_serializer_functions),
+    SER("ED448", "no", "der", "public", ed448_pub_der_serializer_functions),
+    SER("ED448", "no", "pem", "private", ed448_priv_pem_serializer_functions),
+    SER("ED448", "no", "pem", "public", ed448_pub_pem_serializer_functions),
+
+    SER("EC", "yes", "text", "private", ec_priv_text_serializer_functions),
+    SER("EC", "yes", "text", "public", ec_pub_text_serializer_functions),
+    SER("EC", "yes", "text", "parameters", ec_param_text_serializer_functions),
+    SER("EC", "yes", "der", "private", ec_priv_der_serializer_functions),
+    SER("EC", "yes", "der", "public", ec_pub_der_serializer_functions),
+    SER("EC", "yes", "der", "parameters", ec_param_der_serializer_functions),
+    SER("EC", "yes", "pem", "private", ec_priv_pem_serializer_functions),
+    SER("EC", "yes", "pem", "public", ec_pub_pem_serializer_functions),
+    SER("EC", "yes", "pem", "parameters", ec_param_pem_serializer_functions),
+#endif

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -34,7 +34,7 @@
 #define MAX_HASH_BLOCK_SIZE 128
 
 /*
- * u32toLE serialises an unsigned, 32-bit number (n) as four bytes at (p) in
+ * u32toLE serializes an unsigned, 32-bit number (n) as four bytes at (p) in
  * little-endian order. The value of p is advanced by four.
  */
 #define u32toLE(n, p) \


### PR DESCRIPTION
Move the libcrypto serialisation functionality into a place where it can be provided at some point.  The serialisation still remains native in the default provider.

Add additional code to the _list_ command to display what kind of serialisation each entry is capable of.

Having the FIPS provider auto load the serialisation provider is a future (but necessary) enhancement.

- [x] documentation is added or updated
- [ ] tests are added or updated
