### PR TITLE
Ensure CMAC_CTX is correctly initialised (1.1.1)

### DIFF
--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -135,7 +135,7 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
         if (!EVP_EncryptInit_ex(ctx->cctx, NULL, NULL, key, zero_iv))
             return 0;
         bl = EVP_CIPHER_CTX_block_size(ctx->cctx);
-        if (!EVP_Cipher(ctx->cctx, ctx->tbl, zero_iv, bl))
+        if (EVP_Cipher(ctx->cctx, ctx->tbl, zero_iv, bl) <= 0)
             return 0;
         make_kn(ctx->k1, ctx->tbl, bl);
         make_kn(ctx->k2, ctx->k1, bl);
@@ -173,12 +173,12 @@ int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
             return 1;
         data += nleft;
         /* Else not final block so encrypt it */
-        if (!EVP_Cipher(ctx->cctx, ctx->tbl, ctx->last_block, bl))
+        if (EVP_Cipher(ctx->cctx, ctx->tbl, ctx->last_block, bl) <= 0)
             return 0;
     }
     /* Encrypt all but one of the complete blocks left */
     while (dlen > bl) {
-        if (!EVP_Cipher(ctx->cctx, ctx->tbl, data, bl))
+        if (EVP_Cipher(ctx->cctx, ctx->tbl, data, bl) <= 0)
             return 0;
         dlen -= bl;
         data += bl;

--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -116,11 +116,18 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
         return 1;
     }
     /* Initialise context */
-    if (cipher && !EVP_EncryptInit_ex(ctx->cctx, cipher, impl, NULL, NULL))
-        return 0;
+    if (cipher != NULL) {
+        /* Ensure we can't use this ctx until we also have a key */
+        ctx->nlast_block = -1;
+        if (!EVP_EncryptInit_ex(ctx->cctx, cipher, impl, NULL, NULL))
+            return 0;
+    }
     /* Non-NULL key means initialisation complete */
-    if (key) {
+    if (key != NULL) {
         int bl;
+
+        /* If anything fails then ensure we can't use this ctx */
+        ctx->nlast_block = -1;
         if (!EVP_CIPHER_CTX_cipher(ctx->cctx))
             return 0;
         if (!EVP_CIPHER_CTX_set_key_length(ctx->cctx, keylen))

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -66,7 +66,8 @@ B<EVP_PKEY_X25519>, B<EVP_PKEY_ED25519>, B<EVP_PKEY_X448> or B<EVP_PKEY_ED448>.
 EVP_PKEY_new_CMAC_key() works in the same way as EVP_PKEY_new_raw_private_key()
 except it is only for the B<EVP_PKEY_CMAC> algorithm type. In addition to the
 raw private key data, it also takes a cipher algorithm to be used during
-creation of a CMAC in the B<cipher> argument.
+creation of a CMAC in the B<cipher> argument. The cipher should be a standard
+encryption only cipher. For example AEAD and XTS ciphers should not be used.
 
 EVP_PKEY_new_mac_key() works in the same way as EVP_PKEY_new_raw_private_key().
 New applications should use EVP_PKEY_new_raw_private_key() instead.

--- a/test/build.info
+++ b/test/build.info
@@ -461,6 +461,9 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
     IF[{- !$disabled{ec} -}]
       PROGRAMS_NO_INST=ec_internal_test curve448_internal_test
     ENDIF
+    IF[{- !$disabled{cmac} -}]
+      PROGRAMS_NO_INST=cmactest
+    ENDIF
 
     SOURCE[poly1305_internal_test]=poly1305_internal_test.c
     INCLUDE[poly1305_internal_test]=.. ../include
@@ -493,6 +496,12 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
     SOURCE[ctype_internal_test]=ctype_internal_test.c
     INCLUDE[ctype_internal_test]=.. ../include
     DEPEND[ctype_internal_test]=../libcrypto.a libtestutil.a
+
+    IF[{- !$disabled{cmac} -}]
+      SOURCE[cmactest]=cmactest.c
+      INCLUDE[cmactest]=../include ../apps/include
+      DEPEND[cmactest]=../libcrypto.a libtestutil.a
+    ENDIF
 
     SOURCE[siphash_internal_test]=siphash_internal_test.c
     INCLUDE[siphash_internal_test]=.. ../include

--- a/test/cmactest.c
+++ b/test/cmactest.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright 1995-2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "internal/nelem.h"
+
+#include <openssl/cmac.h>
+#include <openssl/aes.h>
+#include <openssl/evp.h>
+
+#include "testutil.h"
+
+static const char xtskey[32] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+};
+
+static struct test_st {
+    const char key[32];
+    int key_len;
+    const unsigned char data[64];
+    int data_len;
+    const char *mac;
+} test[3] = {
+    {
+        {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+        },
+        16,
+        "My test data",
+        12,
+        "29cec977c48f63c200bd5c4a6881b224"
+    },
+    {
+        {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+            0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+        },
+        32,
+        "My test data",
+        12,
+        "db6493aa04e4761f473b2b453c031c9a"
+    },
+    {
+        {
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+            0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
+        },
+        32,
+        "My test data again",
+        18,
+        "65c11c75ecf590badd0a5e56cbb8af60"
+    },
+};
+
+static char *pt(unsigned char *md, unsigned int len);
+
+static int test_cmac_bad(void)
+{
+    CMAC_CTX *ctx = NULL;
+    int ret = 0;
+
+    ctx = CMAC_CTX_new();
+    if (!TEST_ptr(ctx)
+        || !TEST_false(CMAC_Init(ctx, NULL, 0, NULL, NULL))
+        || !TEST_false(CMAC_Update(ctx, test[0].data, test[0].data_len))
+           /* Should be able to pass cipher first, and then key */
+        || !TEST_true(CMAC_Init(ctx, NULL, 0, EVP_aes_128_cbc(), NULL))
+           /* Must have a key */
+        || !TEST_false(CMAC_Update(ctx, test[0].data, test[0].data_len))
+           /* Now supply the key */
+        || !TEST_true(CMAC_Init(ctx, test[0].key, test[0].key_len, NULL, NULL))
+           /* Update should now work */
+        || !TEST_true(CMAC_Update(ctx, test[0].data, test[0].data_len))
+           /* XTS is not a suitable cipher to use */
+        || !TEST_false(CMAC_Init(ctx, xtskey, sizeof(xtskey), EVP_aes_128_xts(),
+                                 NULL))
+        || !TEST_false(CMAC_Update(ctx, test[0].data, test[0].data_len)))
+        goto err;
+
+    ret = 1;
+err:
+    CMAC_CTX_free(ctx);
+    return ret;
+}
+
+static int test_cmac_run(void)
+{
+    char *p;
+    CMAC_CTX *ctx = NULL;
+    unsigned char buf[AES_BLOCK_SIZE];
+    size_t len;
+    int ret = 0;
+
+    ctx = CMAC_CTX_new();
+
+    if (!TEST_true(CMAC_Init(ctx, test[0].key, test[0].key_len,
+                             EVP_aes_128_cbc(), NULL))
+        || !TEST_true(CMAC_Update(ctx, test[0].data, test[0].data_len))
+        || !TEST_true(CMAC_Final(ctx, buf, &len)))
+        goto err;
+
+    p = pt(buf, len);
+    if (!TEST_str_eq(p, test[0].mac))
+        goto err;
+
+    if (!TEST_true(CMAC_Init(ctx, test[1].key, test[1].key_len,
+                             EVP_aes_256_cbc(), NULL))
+        || !TEST_true(CMAC_Update(ctx, test[1].data, test[1].data_len))
+        || !TEST_true(CMAC_Final(ctx, buf, &len)))
+        goto err;
+
+    p = pt(buf, len);
+    if (!TEST_str_eq(p, test[1].mac))
+        goto err;
+
+    if (!TEST_true(CMAC_Init(ctx, test[2].key, test[2].key_len, NULL, NULL))
+        || !TEST_true(CMAC_Update(ctx, test[2].data, test[2].data_len))
+        || !TEST_true(CMAC_Final(ctx, buf, &len)))
+        goto err;
+    p = pt(buf, len);
+    if (!TEST_str_eq(p, test[2].mac))
+        goto err;
+    /* Test reusing a key */
+    if (!TEST_true(CMAC_Init(ctx, NULL, 0, NULL, NULL))
+        || !TEST_true(CMAC_Update(ctx, test[2].data, test[2].data_len))
+        || !TEST_true(CMAC_Final(ctx, buf, &len)))
+        goto err;
+    p = pt(buf, len);
+    if (!TEST_str_eq(p, test[2].mac))
+        goto err;
+
+    /* Test setting the cipher and key separately */
+    if (!TEST_true(CMAC_Init(ctx, NULL, 0, EVP_aes_256_cbc(), NULL))
+        || !TEST_true(CMAC_Init(ctx, test[2].key, test[2].key_len, NULL, NULL))
+        || !TEST_true(CMAC_Update(ctx, test[2].data, test[2].data_len))
+        || !TEST_true(CMAC_Final(ctx, buf, &len)))
+        goto err;
+    p = pt(buf, len);
+    if (!TEST_str_eq(p, test[2].mac))
+        goto err;
+
+    ret = 1;
+err:
+    CMAC_CTX_free(ctx);
+    return ret;
+}
+
+static int test_cmac_copy(void)
+{
+    char *p;
+    CMAC_CTX *ctx = NULL, *ctx2 = NULL;
+    unsigned char buf[AES_BLOCK_SIZE];
+    size_t len;
+    int ret = 0;
+
+    ctx = CMAC_CTX_new();
+    ctx2 = CMAC_CTX_new();
+    if (!TEST_ptr(ctx) || !TEST_ptr(ctx2))
+        goto err;
+
+    if (!TEST_true(CMAC_Init(ctx, test[0].key, test[0].key_len,
+                             EVP_aes_128_cbc(), NULL))
+        || !TEST_true(CMAC_Update(ctx, test[0].data, test[0].data_len))
+        || !TEST_true(CMAC_CTX_copy(ctx2, ctx))
+        || !TEST_true(CMAC_Final(ctx2, buf, &len)))
+        goto err;
+
+    p = pt(buf, len);
+    if (!TEST_str_eq(p, test[0].mac))
+        goto err;
+
+    ret = 1;
+err:
+    CMAC_CTX_free(ctx2);
+    CMAC_CTX_free(ctx);
+    return ret;
+}
+
+static char *pt(unsigned char *md, unsigned int len)
+{
+    unsigned int i;
+    static char buf[80];
+
+    for (i = 0; i < len; i++)
+        sprintf(&(buf[i * 2]), "%02x", md[i]);
+    return buf;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_cmac_bad);
+    ADD_TEST(test_cmac_run);
+    ADD_TEST(test_cmac_copy);
+    return 1;
+}
+

--- a/test/recipes/05-test_cmac.t
+++ b/test/recipes/05-test_cmac.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_cmac", "cmactest", "cmac");


### PR DESCRIPTION
This is a backport of #11972 to the 1.1.1 branch. That PR had the following description:

The function EVP_Cipher() is very low level and has some rather odd return value semantics (see the docs). Essentially we need to treat any return value from that of 0 or less as an error - however the CMAC code was treating it as a boolean.

In fixing this issue I discovered that although we have EVP level CMAC tests we have no tests for the low level API. So I have created a simple test, heavily based on the existing hmactest. This actually uncovered a couple more bugs in CMAC initialisation, where we would attempt to use a CMAC_CTX that has only been partially initialised.
