### PR TITLE
Use the inherited 'bsd-gcc-shared' config on 32-bit x86 BSDs.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1004,7 +1004,6 @@ my %targets = (
         CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
         lib_cppflags     => add("-DL_ENDIAN"),
         bn_ops           => "BN_LLONG",
-        shared_target    => "bsd-shared",
         asm_arch         => 'x86',
         perlasm_scheme   => "a.out",
     },

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -40,12 +40,6 @@ my %shared_info;
         };
     },
     'bsd-gcc-shared' => sub { return $shared_info{'linux-shared'}; },
-    'bsd-shared' => sub {
-        return $shared_info{'gnu-shared'} if detect_gnu_ld();
-        return {
-            shared_ldflag     => '-shared -nostdlib',
-        };
-    },
     'darwin-shared' => {
         module_ldflags        => '-bundle',
         shared_ldflag         => '-dynamiclib -current_version $(SHLIB_VERSION_NUMBER) -compatibility_version $(SHLIB_VERSION_NUMBER)',


### PR DESCRIPTION
BSD-generic32 already uses this for building shared libraries on other
32-bit BSD platforms.  Commit b7efa56 collapsed various *BSD targets
down to the BSD-generic ones and BSD-x86.  At the time only
OpenBSD/i386 used `bsd-shared` while both FreeBSD and NetBSD used
`bsd-gcc-shared`.  In practice, all of the BSDs are using either a
GCC/ld.bfd toolchain or a clang/lld toolchain both of which are
compatible with 'bsd-gcc-shared'.

Retire 'bsd-shared' since this removes the last user.

Fixes #12050.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
