### PR TITLE
Fix two additional instances of the old EVP_MAC_CTX_ functions being used.

### DIFF
--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -400,7 +400,7 @@ static int pkey_mac_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 return 0;
 
             /*
-             * Since EVP_MAC_CTX_{get,set}_params() returned successfully,
+             * Since EVP_MAC_{get,set}_ctx_params() returned successfully,
              * we can only assume that the size was ignored, i.e. this
              * control is unsupported.
              */

--- a/include/openssl/mac.h
+++ b/include/openssl/mac.h
@@ -17,6 +17,10 @@
 # include <openssl/types.h>
 # include <openssl/core.h>
 
+# ifdef __cplusplus
+extern "C" {
+# endif
+
 EVP_MAC *EVP_MAC_fetch(OPENSSL_CTX *libctx, const char *algorithm,
                        const char *properties);
 int EVP_MAC_up_ref(EVP_MAC *mac);
@@ -49,4 +53,7 @@ void EVP_MAC_names_do_all(const EVP_MAC *mac,
                           void (*fn)(const char *name, void *data),
                           void *data);
 
+# ifdef __cplusplus
+}
+# endif
 #endif /* OPENSSL_EVP_MAC_H */

--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -403,7 +403,7 @@ static int TicketKeyCallback(SSL *ssl, uint8_t *key_name, uint8_t *iv,
 
   if (!EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, kZeros, iv, encrypt)
       || !EVP_MAC_init(hmac_ctx)
-      || !EVP_MAC_CTX_set_params(hmac_ctx, params)) {
+      || !EVP_MAC_set_ctx_params(hmac_ctx, params)) {
     return -1;
   }
 


### PR DESCRIPTION
EVP_MAC_CTX_set_params was still used in two places, albeit once in a comment.

[extended tests]

