### PR TITLE
property: default properties don't work with a NULL query.

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2521,6 +2521,7 @@ EVP_R_CTRL_NOT_IMPLEMENTED:132:ctrl not implemented
 EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED:133:ctrl operation not implemented
 EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH:138:data not multiple of block length
 EVP_R_DECODE_ERROR:114:decode error
+EVP_R_DEFAULT_QUERY_PARSE_ERROR:210:default query parse error
 EVP_R_DIFFERENT_KEY_TYPES:101:different key types
 EVP_R_DIFFERENT_PARAMETERS:153:different parameters
 EVP_R_ERROR_LOADING_SECTION:165:error loading section

--- a/crypto/evp/evp_err.c
+++ b/crypto/evp/evp_err.c
@@ -44,6 +44,8 @@ static const ERR_STRING_DATA EVP_str_reasons[] = {
     {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH),
     "data not multiple of block length"},
     {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_DECODE_ERROR), "decode error"},
+    {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_DEFAULT_QUERY_PARSE_ERROR),
+    "default query parse error"},
     {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_DIFFERENT_KEY_TYPES),
     "different key types"},
     {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_DIFFERENT_PARAMETERS),

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -60,7 +60,6 @@ struct ossl_method_store_st {
     OPENSSL_CTX *ctx;
     size_t nelem;
     SPARSE_ARRAY_OF(ALGORITHM) *algs;
-    OSSL_PROPERTY_LIST *global_properties;
     int need_flush;
     CRYPTO_RWLOCK *lock;
 };
@@ -74,7 +73,34 @@ typedef struct {
 DEFINE_SPARSE_ARRAY_OF(ALGORITHM);
 
 static void ossl_method_cache_flush(OSSL_METHOD_STORE *store, int nid);
-static void ossl_method_cache_flush_all(OSSL_METHOD_STORE *c);
+
+/* Global properties are stored per library context */
+static void ossl_ctx_global_properties_free(void *vstore)
+{
+    OSSL_PROPERTY_LIST **plp = vstore;
+
+    if (plp != NULL) {
+        ossl_property_free(*plp);
+        OPENSSL_free(plp);
+    }
+}
+
+static void *ossl_ctx_global_properties_new(OPENSSL_CTX *ctx)
+{
+    return OPENSSL_zalloc(sizeof(OSSL_PROPERTY_LIST **));
+}
+
+
+static const OPENSSL_CTX_METHOD ossl_ctx_global_properties_method = {
+    ossl_ctx_global_properties_new,
+    ossl_ctx_global_properties_free,
+};
+
+OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OPENSSL_CTX *libctx)
+{
+    return openssl_ctx_get_data(libctx, OPENSSL_CTX_GLOBAL_PROPERTIES,
+                                &ossl_ctx_global_properties_method);
+}
 
 static int ossl_method_up_ref(METHOD *method)
 {
@@ -166,7 +192,6 @@ void ossl_method_store_free(OSSL_METHOD_STORE *store)
     if (store != NULL) {
         ossl_sa_ALGORITHM_doall(store->algs, &alg_cleanup);
         ossl_sa_ALGORITHM_free(store->algs);
-        ossl_property_free(store->global_properties);
         CRYPTO_THREAD_lock_free(store->lock);
         OPENSSL_free(store);
     }
@@ -296,8 +321,10 @@ int ossl_method_store_remove(OSSL_METHOD_STORE *store, int nid,
 }
 
 int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
-                            const char *prop_query, void **method)
+                            const char *prop_query,
+                            void **method)
 {
+    OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(store->ctx);
     ALGORITHM *alg;
     IMPLEMENTATION *impl;
     OSSL_PROPERTY_LIST *pq = NULL, *p2 = NULL;
@@ -326,11 +353,11 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
     if (prop_query != NULL) {
         p2 = pq = ossl_parse_query(store->ctx, prop_query);
     }
-    if (store->global_properties != NULL) {
+    if (plp != NULL && *plp != NULL) {
         if (pq == NULL) {
-            pq = store->global_properties;
+            pq = *plp;
         } else {
-            p2 = ossl_property_merge(pq, store->global_properties);
+            p2 = ossl_property_merge(pq, *plp);
             if (p2 == NULL)
                 goto fin;
             ossl_property_free(pq);
@@ -367,84 +394,6 @@ fin:
     return ret;
 }
 
-int ossl_method_store_global_property_is_enabled(OSSL_METHOD_STORE *store,
-                                                 const char *prop_name)
-{
-    int ret = 0;
-
-    if (store == NULL)
-        return 0;
-
-    ossl_property_read_lock(store);
-    ret = ossl_property_is_enabled(store->ctx, prop_name,
-                                   store->global_properties);
-    ossl_property_unlock(store);
-    return ret;
-}
-
-int ossl_method_store_set_global_properties(OSSL_METHOD_STORE *store,
-                                            const char *prop_query)
-{
-    int ret = 0;
-
-    if (store == NULL)
-        return 1;
-
-    ossl_property_write_lock(store);
-    ossl_method_cache_flush_all(store);
-
-    ossl_property_free(store->global_properties);
-    store->global_properties = NULL;
-
-    if (prop_query == NULL) {
-        ossl_property_unlock(store);
-        return 1;
-    }
-    store->global_properties = ossl_parse_query(store->ctx, prop_query);
-    ret = store->global_properties != NULL;
-    ossl_property_unlock(store);
-    return ret;
-}
-
-int ossl_method_store_merge_global_properties(OSSL_METHOD_STORE *store,
-                                              const char *prop_query)
-{
-    int ret = 0;
-    OSSL_PROPERTY_LIST *prop = NULL, *global;
-
-    if (store == NULL)
-        return 1;
-
-    ossl_property_write_lock(store);
-    ossl_method_cache_flush_all(store);
-    if (prop_query == NULL) {
-        ossl_property_free(store->global_properties);
-        store->global_properties = NULL;
-        goto success;
-    }
-    prop = ossl_parse_query(store->ctx, prop_query);
-    if (prop == NULL)
-        goto end;
-
-    if (store->global_properties == NULL) {
-        store->global_properties = prop;
-        prop = NULL;
-        goto success;
-    }
-    global = ossl_property_merge(prop, store->global_properties);
-    if (global == NULL)
-        goto end;
-    ossl_property_free(store->global_properties);
-    store->global_properties = global;
- success:
-    ret = 1;
- end:
-    ossl_property_unlock(store);
-    ossl_property_free(prop);
-    return ret;
-}
-
-
 static void impl_cache_flush_alg(ossl_uintmax_t idx, ALGORITHM *alg)
 {
     lh_QUERY_doall(alg->cache, &impl_cache_free);
@@ -461,10 +410,12 @@ static void ossl_method_cache_flush(OSSL_METHOD_STORE *store, int nid)
     }
 }
 
-static void ossl_method_cache_flush_all(OSSL_METHOD_STORE *store)
+void ossl_method_store_flush_cache(OSSL_METHOD_STORE *store)
 {
+    ossl_property_write_lock(store);
     ossl_sa_ALGORITHM_doall(store->algs, &impl_cache_flush_alg);
     store->nelem = 0;
+    ossl_property_unlock(store);
 }
 
 IMPLEMENT_LHASH_DOALL_ARG(QUERY, IMPL_CACHE_FLUSH);

--- a/crypto/property/property_local.h
+++ b/crypto/property/property_local.h
@@ -22,8 +22,6 @@ OSSL_PROPERTY_IDX ossl_property_value(OPENSSL_CTX *ctx, const char *s,
 /* Property list functions */
 void ossl_property_free(OSSL_PROPERTY_LIST *p);
 int ossl_property_has_optional(const OSSL_PROPERTY_LIST *query);
-OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
-                                        const OSSL_PROPERTY_LIST *b);
 
 /* Property definition cache functions */
 OSSL_PROPERTY_LIST *ossl_prop_defn_get(OPENSSL_CTX *ctx, const char *prop);

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -568,6 +568,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
     if (r == NULL)
         return NULL;
 
+    r->has_optional = 0;
     for (i = j = n = 0; i < a->n || j < b->n; n++) {
         if (i >= a->n) {
             copy = &bp[j++];
@@ -581,6 +582,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
             copy = &bp[j++];
         }
         memcpy(r->properties + n, copy, sizeof(r->properties[0]));
+        r->has_optional |= copy->optional;
     }
     r->n = n;
     if (n != t)

--- a/doc/internal/man3/OSSL_METHOD_STORE.pod
+++ b/doc/internal/man3/OSSL_METHOD_STORE.pod
@@ -5,8 +5,8 @@
 OSSL_METHOD_STORE, ossl_method_store_new, ossl_method_store_free,
 ossl_method_store_init, ossl_method_store_cleanup,
 ossl_method_store_add, ossl_method_store_remove, ossl_method_store_fetch,
-ossl_method_store_set_global_properties,
-ossl_method_store_cache_get, ossl_method_store_cache_set
+ossl_method_store_cache_get, ossl_method_store_cache_set,
+ossl_method_store_flush_cache
 - implementation method store and query
 
 =head1 SYNOPSIS
@@ -28,14 +28,13 @@ ossl_method_store_cache_get, ossl_method_store_cache_set
  int ossl_method_store_fetch(OSSL_METHOD_STORE *store,
                              int nid, const char *properties,
                              void **method);
- int ossl_method_store_set_global_properties(OSSL_METHOD_STORE *store,
-                                            const char *prop_query);
  int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, int nid,
                                  const char *prop_query, void **method);
  int ossl_method_store_cache_set(OSSL_METHOD_STORE *store, int nid,
                                  const char *prop_query, void *method,
                                  int (*method_up_ref)(void *),
                                  void (*method_destruct)(void *));
+ void ossl_method_store_flush_cache(OSSL_METHOD_STORE *store);
 
 =head1 DESCRIPTION
 
@@ -82,10 +81,8 @@ ossl_method_store_fetch() queries I<store> for a method identified by I<nid>
 that matches the property query I<prop_query>.
 The result, if any, is returned in I<method>.
 
-ossl_method_store_set_global_properties() sets method I<store> wide query
-properties to I<prop_query>.
-All subsequent fetches will need to meet both these global query properties
-and the ones passed to the ossl_method_store_free().
+ossl_method_store_flush_cache() flushes all cached entries associated with
+I<store>.
 
 =head2 Cache Functions
 
@@ -107,7 +104,7 @@ ossl_method_store_new() returns a new method store object or NULL on failure.
 
 ossl_method_store_free(), ossl_method_store_add(),
 ossl_method_store_remove(), ossl_method_store_fetch(),
-ossl_method_store_set_global_properties(), ossl_method_store_cache_get()
+ossl_method_store_cache_get()
 and ossl_method_store_cache_set() return B<1> on success and B<0> on error.
 
 ossl_method_store_free() and ossl_method_store_cleanup() do not return any value.

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -158,7 +158,8 @@ typedef struct ossl_ex_data_global_st {
 # define OPENSSL_CTX_SERIALIZER_STORE_INDEX        10
 # define OPENSSL_CTX_SELF_TEST_CB_INDEX            11
 # define OPENSSL_CTX_BIO_PROV_INDEX                12
-# define OPENSSL_CTX_MAX_INDEXES                   13
+# define OPENSSL_CTX_GLOBAL_PROPERTIES             13
+# define OPENSSL_CTX_MAX_INDEXES                   14
 
 typedef struct openssl_ctx_method {
     void *(*new_func)(OPENSSL_CTX *ctx);

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -42,13 +42,10 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
 int ossl_method_store_remove(OSSL_METHOD_STORE *store, int nid,
                              const void *method);
 int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
-                            const char *prop_query, void **result);
-int ossl_method_store_set_global_properties(OSSL_METHOD_STORE *store,
-                                            const char *prop_query);
-int ossl_method_store_merge_global_properties(OSSL_METHOD_STORE *store,
-                                              const char *prop_query);
-int ossl_method_store_global_property_is_enabled(OSSL_METHOD_STORE *store,
-                                                 const char *prop_name);
+                            const char *prop_query, void **method);
+
+/* Get the global properties associate with the specified library context */
+OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OPENSSL_CTX *ctx);
 
 /* property query cache functions */
 int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, int nid,
@@ -57,4 +54,10 @@ int ossl_method_store_cache_set(OSSL_METHOD_STORE *store, int nid,
                                 const char *prop_query, void *result,
                                 int (*method_up_ref)(void *),
                                 void (*method_destruct)(void *));
+void ossl_method_store_flush_cache(OSSL_METHOD_STORE *store);
+
+/* Merge two property queries together */
+OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
+                                        const OSSL_PROPERTY_LIST *b);
+
 #endif

--- a/include/openssl/evperr.h
+++ b/include/openssl/evperr.h
@@ -72,8 +72,6 @@ int ERR_load_EVP_strings(void);
 #  define EVP_F_EVP_KEYEXCH_FROM_DISPATCH                  0
 #  define EVP_F_EVP_MAC_CTRL                               0
 #  define EVP_F_EVP_MAC_CTRL_STR                           0
-#  define EVP_F_EVP_MAC_CTX_DUP                            0
-#  define EVP_F_EVP_MAC_CTX_NEW                            0
 #  define EVP_F_EVP_MAC_INIT                               0
 #  define EVP_F_EVP_MD_BLOCK_SIZE                          0
 #  define EVP_F_EVP_MD_CTX_COPY_EX                         0
@@ -178,6 +176,7 @@ int ERR_load_EVP_strings(void);
 # define EVP_R_CTRL_OPERATION_NOT_IMPLEMENTED             133
 # define EVP_R_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH          138
 # define EVP_R_DECODE_ERROR                               114
+# define EVP_R_DEFAULT_QUERY_PARSE_ERROR                  210
 # define EVP_R_DIFFERENT_KEY_TYPES                        101
 # define EVP_R_DIFFERENT_PARAMETERS                       153
 # define EVP_R_ERROR_LOADING_SECTION                      165


### PR DESCRIPTION
Specifying an algorithm with a NULL query ignores the default properties.


Fixes #11594

- [x] documentation is added or updated
- [x] tests are added or updated
