### PR TITLE
Fix logic error for building x86 CAST assembly

### DIFF
--- a/crypto/cast/build.info
+++ b/crypto/cast/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $CASTASM=c_enc.c
 # CAST assembly source is not PIC
-IF[{- !$disabled{asm} && !$disabled{pic} -}]
+IF[{- !$disabled{asm} && $disabled{pic} -}]
   $CASTASM_x86=cast-586.s
 
   # Now that we have defined all the arch specific variables, use the


### PR DESCRIPTION
The assembly code is not PIC, so we should only try to build it
when the configuration has disabled PIC, not the other way around.

Noted by @kroeckx at https://github.com/openssl/openssl/issues/12050#issuecomment-640253738