### PR TITLE
Refactor BN_R_NO_INVERSE logic in internal functions

### DIFF
--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -17,9 +17,10 @@
  * This is a static function, we ensure all callers in this file pass valid
  * arguments: all passed pointers here are non-NULL.
  */
-static BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
-                                        const BIGNUM *a, const BIGNUM *n,
-                                        BN_CTX *ctx, int *pnoinv)
+static ossl_inline
+BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
+                                 const BIGNUM *a, const BIGNUM *n,
+                                 BN_CTX *ctx, int *pnoinv)
 {
     BIGNUM *A, *B, *X, *Y, *M, *D, *T, *R = NULL;
     BIGNUM *ret = NULL;

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -515,7 +515,7 @@ BIGNUM *BN_mod_inverse(BIGNUM *in,
 {
     BN_CTX *new_ctx = NULL;
     BIGNUM *rv;
-    int noinv;
+    int noinv = 0;
 
     if (ctx == NULL) {
         ctx = new_ctx = BN_CTX_new_ex(NULL);

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -18,11 +18,22 @@ static BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
 BIGNUM *BN_mod_inverse(BIGNUM *in,
                        const BIGNUM *a, const BIGNUM *n, BN_CTX *ctx)
 {
+    BN_CTX *new_ctx = NULL;
     BIGNUM *rv;
     int noinv;
+
+    if (ctx == NULL) {
+        ctx = new_ctx = BN_CTX_new_ex(NULL);
+        if (ctx == NULL) {
+            BNerr(BN_F_BN_MOD_INVERSE, ERR_R_MALLOC_FAILURE);
+            return NULL;
+        }
+    }
+
     rv = int_bn_mod_inverse(in, a, n, ctx, &noinv);
     if (noinv)
         BNerr(BN_F_BN_MOD_INVERSE, BN_R_NO_INVERSE);
+    BN_CTX_free(new_ctx);
     return rv;
 }
 

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -10,11 +10,11 @@
 #include "internal/cryptlib.h"
 #include "bn_local.h"
 
-/* solves ax == 1 (mod n) */
-static BIGNUM *BN_mod_inverse_no_branch(BIGNUM *in,
+static BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
                                         const BIGNUM *a, const BIGNUM *n,
-                                        BN_CTX *ctx);
+                                        BN_CTX *ctx, int *pnoinv);
 
+/* solves ax == 1 (mod n) */
 BIGNUM *BN_mod_inverse(BIGNUM *in,
                        const BIGNUM *a, const BIGNUM *n, BN_CTX *ctx)
 {
@@ -26,6 +26,10 @@ BIGNUM *BN_mod_inverse(BIGNUM *in,
     return rv;
 }
 
+/*
+ * This is an internal function, we assume all callers pass valid arguments:
+ * all pointers passed here are assumed non-NULL.
+ */
 BIGNUM *int_bn_mod_inverse(BIGNUM *in,
                            const BIGNUM *a, const BIGNUM *n, BN_CTX *ctx,
                            int *pnoinv)
@@ -36,17 +40,15 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
 
     /* This is invalid input so we don't worry about constant time here */
     if (BN_abs_is_word(n, 1) || BN_is_zero(n)) {
-        if (pnoinv != NULL)
-            *pnoinv = 1;
+        *pnoinv = 1;
         return NULL;
     }
 
-    if (pnoinv != NULL)
-        *pnoinv = 0;
+    *pnoinv = 0;
 
     if ((BN_get_flags(a, BN_FLG_CONSTTIME) != 0)
         || (BN_get_flags(n, BN_FLG_CONSTTIME) != 0)) {
-        return BN_mod_inverse_no_branch(in, a, n, ctx);
+        return bn_mod_inverse_no_branch(in, a, n, ctx, pnoinv);
     }
 
     bn_check_top(a);
@@ -332,8 +334,7 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
                 goto err;
         }
     } else {
-        if (pnoinv)
-            *pnoinv = 1;
+        *pnoinv = 1;
         goto err;
     }
     ret = R;
@@ -346,12 +347,15 @@ BIGNUM *int_bn_mod_inverse(BIGNUM *in,
 }
 
 /*
- * BN_mod_inverse_no_branch is a special version of BN_mod_inverse. It does
+ * bn_mod_inverse_no_branch is a special version of BN_mod_inverse. It does
  * not contain branches that may leak sensitive information.
+ *
+ * This is a static function, we ensure all callers in this file pass valid
+ * arguments: all passed pointers here are non-NULL.
  */
-static BIGNUM *BN_mod_inverse_no_branch(BIGNUM *in,
+static BIGNUM *bn_mod_inverse_no_branch(BIGNUM *in,
                                         const BIGNUM *a, const BIGNUM *n,
-                                        BN_CTX *ctx)
+                                        BN_CTX *ctx, int *pnoinv)
 {
     BIGNUM *A, *B, *X, *Y, *M, *D, *T, *R = NULL;
     BIGNUM *ret = NULL;
@@ -504,10 +508,14 @@ static BIGNUM *BN_mod_inverse_no_branch(BIGNUM *in,
                 goto err;
         }
     } else {
-        BNerr(BN_F_BN_MOD_INVERSE_NO_BRANCH, BN_R_NO_INVERSE);
+        *pnoinv = 1;
+        /* caller sets the BN_R_NO_INVERSE error */
         goto err;
     }
+
     ret = R;
+    *pnoinv = 0;
+
  err:
     if ((ret == NULL) && (in == NULL))
         BN_free(R);

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -221,7 +221,6 @@ BN_F_BN_MOD_EXP_MONT_WORD:117:BN_mod_exp_mont_word
 BN_F_BN_MOD_EXP_RECP:125:BN_mod_exp_recp
 BN_F_BN_MOD_EXP_SIMPLE:126:BN_mod_exp_simple
 BN_F_BN_MOD_INVERSE:110:BN_mod_inverse
-BN_F_BN_MOD_INVERSE_NO_BRANCH:139:BN_mod_inverse_no_branch
 BN_F_BN_MOD_LSHIFT_QUICK:119:BN_mod_lshift_quick
 BN_F_BN_MOD_SQRT:121:BN_mod_sqrt
 BN_F_BN_MONT_CTX_NEW:149:BN_MONT_CTX_new

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -62,7 +62,7 @@ extern "C" {
  * avoid leaking exponent information through timing,
  * BN_mod_exp_mont() will call BN_mod_exp_mont_consttime,
  * BN_div() will call BN_div_no_branch,
- * BN_mod_inverse() will call BN_mod_inverse_no_branch.
+ * BN_mod_inverse() will call bn_mod_inverse_no_branch.
  */
 # define BN_FLG_CONSTTIME        0x04
 # define BN_FLG_SECURE           0x08

--- a/include/openssl/bnerr.h
+++ b/include/openssl/bnerr.h
@@ -61,7 +61,6 @@ int ERR_load_BN_strings(void);
 #  define BN_F_BN_MOD_EXP_RECP                             0
 #  define BN_F_BN_MOD_EXP_SIMPLE                           0
 #  define BN_F_BN_MOD_INVERSE                              0
-#  define BN_F_BN_MOD_INVERSE_NO_BRANCH                    0
 #  define BN_F_BN_MOD_LSHIFT_QUICK                         0
 #  define BN_F_BN_MOD_SQRT                                 0
 #  define BN_F_BN_MONT_CTX_NEW                             0


### PR DESCRIPTION
Closes #12129

_**NOTE for reviewers**: I strongly suggest reviewing commit by commit, as one of the separate commits is reordering function definitions, which makes it look like a big set of changes even when the changes are quite minimal._

As described in https://github.com/openssl/openssl/issues/12129 the readability of the internal functions providing the two alternative implementations for `BN_mod_inverse()` is a bit lacking.

Both these functions are now completely internal, so we have the flexibility needed to slightly improve readability and remove unnecessary NULL checks.

The main changes here are:
- rename `BN_mod_inverse_no_branch()` as `bn_mod_inverse_no_branch()`: this function is `static` so it is not even visible within the rest of libcrypto. By convention upcase prefixes are reserved for public functions.
- remove `if (pnoinv == NULL)` checks in `int_bn_mod_inverse()`: this function is internal to the BN module and we can guarantee that all callers pass non-NULL arguments.
- `bn_mod_inverse_no_branch()` takes an extra `int *pnoinv` argument, so that it can signal if no inverse exists for the given inputs: in this way the caller is in charge of raising `BN_R_NO_INVERSE` as it is the case for the non-consttime implementation of `int_bn_mod_inverse()`.

I kept the following 3 commits separated as they might require further discussion.

## Create a temporary `BN_CTX` if needed in the public function

> commit 1824fadc9dc2e1bcaf8cc217c445efbf5134d476
> 
>     - `BN_mod_inverse()` is a public function and must guarantee that the
>       internal functions providing the actual implementation receive valid
>       arguments. If the caller passes a NULL `BN_CTX` we create a temporary
>       one for internal use.

## Reorder function definitions to avid forward declarations

> commit f22d828c5c708b5276c756a4f0523479d1bd85a9
> 
>     @ This commit only reorders the existing functions, no other edit is
>     @ included.
>     @
>     - reorder function definitions in `crypto/bn/bn_gcd.c` to avoid forward
>       declaration of `static` functions (in preparation for inlining)

## Inline `bn_mod_inverse_no_branch()`

> commit 7e7cb711b5585827e1722736c85aeffef5fa6b23
> 
>     - inline `bn_mod_inverse_no_branch()`.
