### PR TITLE
  Add fix for RSA keygen in FIPS using keysizes 2048 < bits < 3072 

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -293,7 +293,7 @@ int dgst_main(int argc, char **argv)
     if (mac_name != NULL) {
         EVP_PKEY_CTX *mac_ctx = NULL;
         int r = 0;
-        if (!init_gen_str(&mac_ctx, mac_name, impl, 0))
+        if (!init_gen_str(&mac_ctx, mac_name, impl, 0, NULL, NULL))
             goto mac_end;
         if (macopts != NULL) {
             char *macopt;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -169,7 +169,7 @@ opthelp:
     if (out == NULL)
         goto end;
 
-    if (!init_gen_str(&ctx, "RSA", eng, 0))
+    if (!init_gen_str(&ctx, "RSA", eng, 0, NULL, NULL))
         goto end;
 
     EVP_PKEY_CTX_set_cb(ctx, genrsa_cb);

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -209,7 +209,8 @@ int pkey_ctrl_string(EVP_PKEY_CTX *ctx, const char *value);
 int x509_ctrl_string(X509 *x, const char *value);
 int x509_req_ctrl_string(X509_REQ *x, const char *value);
 int init_gen_str(EVP_PKEY_CTX **pctx,
-                 const char *algname, ENGINE *e, int do_param);
+                 const char *algname, ENGINE *e, int do_param,
+                 OPENSSL_CTX *libctx, const char *propq);
 int do_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md,
                  STACK_OF(OPENSSL_STRING) *sigopts);
 int do_X509_verify(X509 *x, EVP_PKEY *pkey, STACK_OF(OPENSSL_STRING) *vfyopts);

--- a/crypto/bn/bn_rsa_fips186_4.c
+++ b/crypto/bn/bn_rsa_fips186_4.c
@@ -65,7 +65,7 @@ static int bn_rsa_fips186_4_aux_prime_min_size(int nbits)
 {
     if (nbits >= 3072)
         return 171;
-    if (nbits == 2048)
+    if (nbits >= 2048)
         return 141;
     return 0;
 }
@@ -83,7 +83,7 @@ static int bn_rsa_fips186_4_aux_prime_max_sum_size_for_prob_primes(int nbits)
 {
     if (nbits >= 3072)
         return 1518;
-    if (nbits == 2048)
+    if (nbits >= 2048)
         return 1007;
     return 0;
 }

--- a/crypto/serializer/serializer_pkey.c
+++ b/crypto/serializer/serializer_pkey.c
@@ -150,7 +150,8 @@ static int serializer_EVP_PKEY_to_bio(OSSL_SERIALIZER_CTX *ctx, BIO *out)
     if (ctx->ser == NULL)
         return 0;
 
-    if (ctx->ser->serialize_object == NULL) {
+    if (ctx->ser->serialize_object == NULL
+        || OSSL_SERIALIZER_provider(ctx->ser) != EVP_KEYMGMT_provider(keymgmt)) {
         struct serializer_write_data_st write_data;
 
         write_data.ctx = ctx;

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -24,6 +24,7 @@ B<openssl> B<genpkey>
 [B<-text>]
 {- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_config_synopsis -}
 
 =for openssl ifdef engine
 
@@ -106,6 +107,8 @@ parameters along with the PEM or DER structure.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_provider_item -}
+
+{- $OpenSSL::safe::opt_config_item -}
 
 =back
 


### PR DESCRIPTION
Fixes #11863

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
