### PR TITLE
Fix segfault in openssl app called with no args.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -308,6 +308,13 @@ int help_main(int argc, char **argv)
     char *prog;
     HELP_CHOICE o;
     DISPLAY_COLUMNS dc;
+    char *new_argv[3];
+
+    if (argc == 0) {
+        new_argv[0] = "help";
+        new_argv[1] = NULL;
+        return do_cmd(prog_init(), 1, new_argv);
+    }
 
     prog = opt_init(argc, argv, help_options);
     while ((o = opt_next()) != OPT_hEOF) {
@@ -323,8 +330,6 @@ int help_main(int argc, char **argv)
     }
 
     if (opt_num_rest() == 1) {
-        char *new_argv[3];
-
         new_argv[0] = opt_rest()[0];
         new_argv[1] = "--help";
         new_argv[2] = NULL;

--- a/test/recipes/20-test_app.t
+++ b/test/recipes/20-test_app.t
@@ -1,0 +1,25 @@
+#! /usr/bin/env perl
+# Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test;
+
+setup("test_app");
+
+plan tests => 3;
+
+ok(run(app(["openssl"])),
+   "Run openssl app with no args");
+
+ok(run(app(["openssl", "help"])),
+   "Run openssl app with help");
+
+ok(!run(app(["openssl", "-help"])),
+   "Run openssl app with incorrect arg");


### PR DESCRIPTION
This is a result of removal of interactive mode.
Redirected it to now use 'openssl help'.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md
Other than that, provide a description above this comment if there isn't one already
If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
