### PR TITLE
Add missing section on asymmetric ciphers

### DIFF
--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -146,6 +146,14 @@ The number for this operation is B<OSSL_OP_KEYEXCH>.
 The functions the provider can offer are described in
 L<provider-keyexch(7)>
 
+=item Asymmetric Ciphers
+
+In the OpenSSL libraries, the corresponding method object is
+B<EVP_ASYM_CIPHER>.
+The number for this operation is B<OSSL_OP_ASYM_CIPHER>.
+The functions the provider can offer are described in
+L<provider-asym_cipher(7)>
+
 =item Serialization
 
 In the OpenSSL libraries, the corresponding method object is


### PR DESCRIPTION
Bugfix for missing section in provider(7) documentation.

Please check the 3 identifiers to be correct; not sure from the context if I got them all right from searching through the related sources.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
