### PR TITLE
Fix test_ocsp with installed certificates

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -117,7 +117,7 @@ const OPTIONS ocsp_options[] = {
      "Do not load the default certificates file"},
     {"no-CApath", OPT_NOCAPATH, '-',
      "Do not load certificates from the default certificates directory"},
-    {"no-CAstore", OPT_NOCAPATH, '-',
+    {"no-CAstore", OPT_NOCASTORE, '-',
      "Do not load certificates from the default certificates store"},
 
     OPT_SECTION("Responder"),

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -60,7 +60,7 @@ const OPTIONS verify_options[] = {
      "Do not load the default trusted certificates file"},
     {"no-CApath", OPT_NOCAPATH, '-',
      "Do not load trusted certificates from the default directory"},
-    {"no-CAstore", OPT_NOCAPATH, '-',
+    {"no-CAstore", OPT_NOCASTORE, '-',
      "Do not load trusted certificates from the default certificates store"},
     {"untrusted", OPT_UNTRUSTED, '<', "A file of untrusted certificates"},
     {"CRLfile", OPT_CRLFILE, '<',

--- a/test/recipes/80-test_ocsp.t
+++ b/test/recipes/80-test_ocsp.t
@@ -45,7 +45,7 @@ sub test_ocsp {
                            "-partial_chain", @check_time,
                            "-CAfile", catfile($ocspdir, $CAfile),
                            "-verify_other", catfile($ocspdir, $untrusted),
-                           "-no-CApath"])),
+                           "-no-CApath", "-no-CAstore"])),
                   $title); });
 }
 


### PR DESCRIPTION
First patch fixes the -no-CAstore for "openssl ocsp" (and "verify" while at it).
The second patch uses the new option in the test so it passes on system which has the certificates installed in the default path.

- [X] tests are added or updated

Sebastian