### PR TITLE
Fix potential double free in rsa_keygen pairwise test.

### DIFF
--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -445,6 +445,12 @@ static int rsa_keygen(OPENSSL_CTX *libctx, RSA *rsa, int bits, int primes,
             BN_clear_free(rsa->dmp1);
             BN_clear_free(rsa->dmq1);
             BN_clear_free(rsa->iqmp);
+            rsa->d = NULL;
+            rsa->p = NULL;
+            rsa->q = NULL;
+            rsa->dmp1 = NULL;
+            rsa->dmq1 = NULL;
+            rsa->iqmp = NULL;
         }
     }
     return ok;


### PR DESCRIPTION
It should never hit this branch of code, so there is no feasible test.
Found due to a similar issue in PR #12176.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
