### PR TITLE
Fix the s_server -dtls option

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -745,6 +745,7 @@ int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
     EVP_MAC *hmac = NULL;
     EVP_MAC_CTX *ctx = NULL;
     OSSL_PARAM params[3], *p = params;
+    size_t mac_len;
 
     /* Initialize a random secret */
     if (!cookie_initialized) {
@@ -808,10 +809,11 @@ int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
             BIO_printf(bio_err, "HMAC context update failed\n");
             goto end;
     }
-    if (!EVP_MAC_final(ctx, cookie, NULL, (size_t)cookie_len)) {
+    if (!EVP_MAC_final(ctx, cookie, &mac_len, DTLS1_COOKIE_LENGTH)) {
             BIO_printf(bio_err, "HMAC context final failed\n");
             goto end;
     }
+    *cookie_len = (int)mac_len;
     res = 1;
 end:
     OPENSSL_free(buffer);

--- a/include/openssl/dtls1.h
+++ b/include/openssl/dtls1.h
@@ -36,11 +36,8 @@ extern "C" {
 # define DTLS_ANY_VERSION                0x1FFFF
 
 /* lengths of messages */
-/*
- * Actually the max cookie length in DTLS is 255. But we can't change this now
- * due to compatibility concerns.
- */
-# define DTLS1_COOKIE_LENGTH                     256
+
+# define DTLS1_COOKIE_LENGTH                     255
 
 # define DTLS1_RT_HEADER_LENGTH                  13
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1312,7 +1312,7 @@ int dtls_construct_hello_verify_request(SSL *s, WPACKET *pkt)
     if (s->ctx->app_gen_cookie_cb == NULL ||
         s->ctx->app_gen_cookie_cb(s, s->d1->cookie,
                                   &cookie_leni) == 0 ||
-        cookie_leni > 255) {
+        cookie_leni > DTLS1_COOKIE_LENGTH) {
         SSLfatal(s, SSL_AD_NO_ALERT, SSL_F_DTLS_CONSTRUCT_HELLO_VERIFY_REQUEST,
                  SSL_R_COOKIE_GEN_CALLBACK_FAILURE);
         return 0;


### PR DESCRIPTION
DTLS in s_server was failing due to problems with the cookie generate callback which was recently converted to use EVP_MAC. The new code was failing to return the length of the generated cookie, and so libssl aborted the connection.

While I was at this fix I also corrected the value of the DTLS1_COOKIE_LENGTH value in the public header. This was known to be off-by-one, but could not be fixed due to ABI compat concerns. Since 3.0 is not ABI compatible we can fix it.
