### PR TITLE
Fix wrong return value check of mmap function

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -514,7 +514,7 @@ static void sh_done(void)
     OPENSSL_free(sh.freelist);
     OPENSSL_free(sh.bittable);
     OPENSSL_free(sh.bitmalloc);
-    if (sh.map_result != NULL && sh.map_size)
+    if (sh.map_result != MAP_FAILED && sh.map_size)
         munmap(sh.map_result, sh.map_size);
     memset(&sh, 0, sizeof(sh));
 }


### PR DESCRIPTION
The mmap function never returns NULL. If an error occurs, the function returns MAP_FAILED.

CLA: trivial