### PR TITLE
DOCS: Add documentation for EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md_name()

### DIFF
--- a/doc/man3/EVP_PKEY_CTX_set_rsa_pss_keygen_md.pod
+++ b/doc/man3/EVP_PKEY_CTX_set_rsa_pss_keygen_md.pod
@@ -4,6 +4,7 @@
 
 EVP_PKEY_CTX_set_rsa_pss_keygen_md,
 EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md,
+EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md_name,
 EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen
 - EVP_PKEY RSA-PSS algorithm support functions
 

--- a/doc/man3/EVP_PKEY_CTX_set_rsa_pss_keygen_md.pod
+++ b/doc/man3/EVP_PKEY_CTX_set_rsa_pss_keygen_md.pod
@@ -15,6 +15,8 @@ EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen
                                         const EVP_MD *md);
  int EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(EVP_PKEY_CTX *pctx,
                                              const EVP_MD *md);
+ int EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md_name(EVP_PKEY_CTX *pctx,
+                                                  const char *mdname);
  int EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(EVP_PKEY_CTX *pctx,
                                              int saltlen);
 
@@ -36,7 +38,7 @@ RSA_PSS_SALTLEN_AUTO) is not supported for verification if the key has
 usage restrictions.
 
 The L<EVP_PKEY_CTX_set_signature_md(3)> and L<EVP_PKEY_CTX_set_rsa_mgf1_md(3)>
-fuunctions are used to set the digest and MGF1 algorithms respectively. If the
+functions are used to set the digest and MGF1 algorithms respectively. If the
 key has usage restrictions then an error is returned if an attempt is made to
 set the digest to anything other than the restricted value. Otherwise these are
 similar to the B<RSA> versions.
@@ -55,13 +57,15 @@ then they are reflected in the corresponding parameters of the public key
 when (for example) a certificate request is signed.
 
 EVP_PKEY_CTX_set_rsa_pss_keygen_md() restricts the digest algorithm the
-generated key can use to B<md>.
+generated key can use to I<md>.
 
 EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md() restricts the MGF1 algorithm the
-generated key can use to B<md>.
+generated key can use to I<md>.
+EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md_name() does the same thing, but
+passes the algorithm by name rather than by B<EVP_MD>.
 
 EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen() restricts the minimum salt length
-to B<saltlen>.
+to I<saltlen>.
 
 =head1 NOTES
 


### PR DESCRIPTION
At the same, align documentation markup to be closer to man-pages(7)
recommendations.
