### PR TITLE
Add const to 'ppin' function parameter in d2i_X509.pod and d2i_DHparams.pod

### DIFF
--- a/doc/man3/d2i_DHparams.pod
+++ b/doc/man3/d2i_DHparams.pod
@@ -8,7 +8,7 @@ d2i_DHparams, i2d_DHparams - PKCS#3 DH parameter functions
 
  #include <openssl/dh.h>
 
- DH *d2i_DHparams(DH **a, unsigned char **pp, long length);
+ DH *d2i_DHparams(DH **a, const unsigned char **pp, long length);
  int i2d_DHparams(DH *a, unsigned char **pp);
 
 =head1 DESCRIPTION

--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -397,7 +397,7 @@ i2d_X509_VAL,
 
 =for openssl generic
 
- TYPE *d2i_TYPE(TYPE **a, unsigned char **ppin, long length);
+ TYPE *d2i_TYPE(TYPE **a, const unsigned char **ppin, long length);
  TYPE *d2i_TYPE_bio(BIO *bp, TYPE **a);
  TYPE *d2i_TYPE_fp(FILE *fp, TYPE **a);
 
@@ -564,7 +564,8 @@ Allocate and encode the DER encoding of an X509 structure:
 Attempt to decode a buffer:
 
  X509 *x;
- unsigned char *buf, *p;
+ unsigned char *buf;
+ const unsigned char *p;
  int len;
 
  /* Set up buf and len to point to the input buffer. */
@@ -576,7 +577,8 @@ Attempt to decode a buffer:
 Alternative technique:
 
  X509 *x;
- unsigned char *buf, *p;
+ unsigned char *buf;
+ const unsigned char *p;
  int len;
 
  /* Set up buf and len to point to the input buffer. */


### PR DESCRIPTION
The function parameter *ppin* should be declared as the *const unsigned char* type according to this declaration
````
# define DECLARE_ASN1_ENCODE_FUNCTIONS_only(type, name) \
        type *d2i_##name(type **a, const unsigned char **in, long len); 
````
[skip ci]
CLA: trivial