### PR TITLE
Cms print

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1168,7 +1168,7 @@ int cms_main(int argc, char **argv)
                         ASN1_PCTX_set_nm_flags(pctx, get_nameopt());
                     }
                 }
-                 CMS_ContentInfo_print_ctx(out, cms, 0, pctx);
+                CMS_ContentInfo_print_ctx(out, cms, 0, pctx);
                 ASN1_PCTX_free(pctx);
             }
         } else if (outformat == FORMAT_SMIME) {

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -82,7 +82,7 @@ typedef enum OPTION_choice {
     OPT_NOINDEF, OPT_CRLFEOL, OPT_NOOUT, OPT_RR_PRINT,
     OPT_RR_ALL, OPT_RR_FIRST, OPT_RCTFORM, OPT_CERTFILE, OPT_CAFILE,
     OPT_CAPATH, OPT_CASTORE, OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE,
-    OPT_CONTENT, OPT_PRINT,
+    OPT_CONTENT, OPT_PRINT, OPT_NAMEOPT,
     OPT_SECRETKEY, OPT_SECRETKEYID, OPT_PWRI_PASSWORD, OPT_ECONTENT_TYPE,
     OPT_PASSIN, OPT_TO, OPT_FROM, OPT_SUBJECT, OPT_SIGNER, OPT_RECIP,
     OPT_CERTSOUT, OPT_MD, OPT_INKEY, OPT_KEYFORM, OPT_KEYOPT, OPT_RR_FROM,
@@ -184,6 +184,8 @@ const OPTIONS cms_options[] = {
      "Supply or override content for detached signature"},
     {"print", OPT_PRINT, '-',
      "For the -cmsout operation print out all fields of the CMS structure"},
+    {"nameopt", OPT_NAMEOPT, 's',
+     "For the -print option specifies various strings printing options"},
     {"certsout", OPT_CERTSOUT, '>', "Certificate output file"},
 
     OPT_SECTION("Keying"),
@@ -465,6 +467,10 @@ int cms_main(int argc, char **argv)
             break;
         case OPT_PRINT:
             noout = print = 1;
+            break;
+        case OPT_NAMEOPT:
+            if (!set_nameopt(opt_arg()))
+                goto opthelp;
             break;
         case OPT_SECRETKEY:
             if (secret_key != NULL) {
@@ -1152,8 +1158,19 @@ int cms_main(int argc, char **argv)
         }
     } else {
         if (noout) {
-            if (print)
-                CMS_ContentInfo_print_ctx(out, cms, 0, NULL);
+            if (print) {
+                ASN1_PCTX *pctx = NULL;
+                if (get_nameopt() != XN_FLAG_ONELINE) {
+                    pctx = ASN1_PCTX_new();
+                    if (pctx) { /* Print anyway if malloc failed */
+                        ASN1_PCTX_set_flags(pctx, ASN1_PCTX_FLAGS_SHOW_ABSENT);
+                        ASN1_PCTX_set_str_flags(pctx, get_nameopt());
+                        ASN1_PCTX_set_nm_flags(pctx, get_nameopt());
+                    }
+                }
+                 CMS_ContentInfo_print_ctx(out, cms, 0, pctx);
+                ASN1_PCTX_free(pctx);
+            }
         } else if (outformat == FORMAT_SMIME) {
             if (to)
                 BIO_printf(out, "To: %s%s", to, mime_eol);

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1162,7 +1162,7 @@ int cms_main(int argc, char **argv)
                 ASN1_PCTX *pctx = NULL;
                 if (get_nameopt() != XN_FLAG_ONELINE) {
                     pctx = ASN1_PCTX_new();
-                    if (pctx) { /* Print anyway if malloc failed */
+                    if (pctx != NULL) { /* Print anyway if malloc failed */
                         ASN1_PCTX_set_flags(pctx, ASN1_PCTX_FLAGS_SHOW_ABSENT);
                         ASN1_PCTX_set_str_flags(pctx, get_nameopt());
                         ASN1_PCTX_set_nm_flags(pctx, get_nameopt());

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -44,6 +44,7 @@ B<openssl> B<cms>
 [B<-text>]
 [B<-noout>]
 [B<-print>]
+[B<-nameopt> I<option>]
 [B<-md> I<digest>]
 [B<-I<cipher>>]
 [B<-wrap> I<cipher>]
@@ -287,6 +288,12 @@ structure is being checked.
 
 For the B<-cmsout> operation print out all fields of the CMS structure. This
 is mainly useful for testing purposes.
+
+=item B<-nameopt> I<option>
+
+For the B<-cmsout> operation when B<-print> option is in use, specifies
+printing options for string fields. For most cases B<utf8> is reasonable value.
+See L<openssl(1)/Name Format Options> for details.
 
 =item B<-md> I<digest>
 
@@ -771,6 +778,8 @@ The -no_alt_chains option was added in OpenSSL 1.0.2b.
 
 All B<-keyform> values except B<ENGINE> have become obsolete in OpenSSL 3.0.0
 and have no effect.
+
+The B<-nameopt> option was added in OpenSSL 3.0.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
cms -cmsout -print currently has no option to print strings in human-readable representation.
This PR adds `-nameopt` option for this purpose.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
