### PR TITLE
Fix `no-ts` builds.

### DIFF
--- a/crypto/ess/build.info
+++ b/crypto/ess/build.info
@@ -1,6 +1,7 @@
 LIBS=../../libcrypto
 
-IF[{- !$disabled{'cms'} and !$disabled{'ts'} -}]
+# compile ess_lib.c when cms or ts are enabled
+IF[{- !$disabled{'cms'} or !$disabled{'ts'} -}]
   SOURCE[../../libcrypto]= ess_lib.c
 ENDIF
 

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -145,7 +145,7 @@ static __inline int CRYPTO_DOWN_REF(volatile int *val, int *ret, void *lock)
 
 /*
  * All the refcounting implementations above define HAVE_ATOMICS, so if it's
- * still undefined here (such as when OPENSSL_DEV_NO_ATMOICS is defined), it
+ * still undefined here (such as when OPENSSL_DEV_NO_ATOMICS is defined), it
  * means we need to implement a fallback.  This fallback uses locks.
  */
 # ifndef HAVE_ATOMICS


### PR DESCRIPTION
`ess_lib.c` is called from `cms` and `ts` modules.

Fixes #12155

Plus a small typo fixup.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
