### PR TITLE
Windows build: (1) string pooling only for release (2) default stack …

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1293,8 +1293,8 @@ my %targets = (
         inherit_from     => [ "VC-common" ],
         template         => 1,
         CFLAGS           => add(picker(debug   => '/Od',
-                                       release => '/O2')),
-        cflags           => add(picker(default => '/Gs0 /GF /Gy',
+                                       release => '/O2 /GF')),
+        cflags           => add(picker(default => ' /Gy',
                                        debug   =>
                                        sub {
                                            ($disabled{shared} ? "" : "/MDd");
@@ -1383,7 +1383,7 @@ my %targets = (
         CPPDEFINES       => picker(debug   => [ "DEBUG", "_DEBUG" ]),
         LDFLAGS          => add("/nologo /opt:ref"),
         cflags           =>
-            combine('/GF /Gy',
+            combine('/Gy',
                     sub { vc_wince_info()->{cflags}; },
                     sub { `cl 2>&1` =~ /Version ([0-9]+)\./ && $1>=14
                               ? ($disabled{shared} ? " /MT" : " /MD")


### PR DESCRIPTION
…probes

Without these changes, Visual Studio's debugger cannot be used to step through code for "openssl s_server -WWW".  These changes fix that.  With string pooling, code is so optimized that execution stepping is confusing and ineffective.  The use of /Gs0 is contrary to Microsoft documentation, which states that nondefault stack probing should only be used if you know exactly why you need to do it.  Worse, /Gs0 appears to break Visual Studio's debugger.  (The workaround is to use the disassembler window and step into and through _chkstk.)