### PR TITLE
[doc/man3] finish EC_GROUP_get_field_type documentation

### DIFF
--- a/doc/man3/EC_GROUP_copy.pod
+++ b/doc/man3/EC_GROUP_copy.pod
@@ -12,7 +12,8 @@ EC_GROUP_get_seed_len, EC_GROUP_set_seed, EC_GROUP_get_degree,
 EC_GROUP_check, EC_GROUP_check_named_curve,
 EC_GROUP_check_discriminant, EC_GROUP_cmp,
 EC_GROUP_get_basis_type, EC_GROUP_get_trinomial_basis,
-EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field
+EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field,
+EC_GROUP_get_field_type
 - Functions for manipulating EC_GROUP objects
 
 =head1 SYNOPSIS
@@ -42,9 +43,9 @@ EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field
  void EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form);
  point_conversion_form_t EC_GROUP_get_point_conversion_form(const EC_GROUP *group);
 
- unsigned char *EC_GROUP_get0_seed(const EC_GROUP *x);
- size_t EC_GROUP_get_seed_len(const EC_GROUP *);
- size_t EC_GROUP_set_seed(EC_GROUP *, const unsigned char *, size_t len);
+ unsigned char *EC_GROUP_get0_seed(const EC_GROUP *group);
+ size_t EC_GROUP_get_seed_len(const EC_GROUP *group);
+ size_t EC_GROUP_set_seed(EC_GROUP *group, const unsigned char *, size_t len);
 
  int EC_GROUP_get_degree(const EC_GROUP *group);
 
@@ -56,10 +57,12 @@ EC_GROUP_get_pentanomial_basis, EC_GROUP_get0_field
 
  int EC_GROUP_cmp(const EC_GROUP *a, const EC_GROUP *b, BN_CTX *ctx);
 
- int EC_GROUP_get_basis_type(const EC_GROUP *);
- int EC_GROUP_get_trinomial_basis(const EC_GROUP *, unsigned int *k);
- int EC_GROUP_get_pentanomial_basis(const EC_GROUP *, unsigned int *k1,
+ int EC_GROUP_get_basis_type(const EC_GROUP *group);
+ int EC_GROUP_get_trinomial_basis(const EC_GROUP *group, unsigned int *k);
+ int EC_GROUP_get_pentanomial_basis(const EC_GROUP *group, unsigned int *k1,
                                     unsigned int *k2, unsigned int *k3);
+
+ int EC_GROUP_get_field_type(const EC_GROUP *group);
 
 Deprecated since OpenSSL 3.0:
 


### PR DESCRIPTION
#11928 documented `EC_GROUP_get_field_type` behavior in the `man` page but did not add the name to the function list.

Fixes #12189.