### PR TITLE
Don't forget our provider ctx when resetting

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -90,12 +90,14 @@ static void kdf_hkdf_free(void *vctx)
 static void kdf_hkdf_reset(void *vctx)
 {
     KDF_HKDF *ctx = (KDF_HKDF *)vctx;
+    void *provctx = ctx->provctx;
 
     ossl_prov_digest_reset(&ctx->digest);
     OPENSSL_free(ctx->salt);
     OPENSSL_clear_free(ctx->key, ctx->key_len);
     OPENSSL_cleanse(ctx->info, ctx->info_len);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 static size_t kdf_hkdf_size(KDF_HKDF *ctx)

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -122,6 +122,7 @@ static void kbkdf_free(void *vctx)
 static void kbkdf_reset(void *vctx)
 {
     KBKDF *ctx = (KBKDF *)vctx;
+    void *provctx = ctx->provctx;
 
     EVP_MAC_free_ctx(ctx->ctx_init);
     OPENSSL_clear_free(ctx->context, ctx->context_len);
@@ -129,6 +130,7 @@ static void kbkdf_reset(void *vctx)
     OPENSSL_clear_free(ctx->ki, ctx->ki_len);
     OPENSSL_clear_free(ctx->iv, ctx->iv_len);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 /* SP800-108 section 5.1 or section 5.2 depending on mode. */

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -78,11 +78,13 @@ static void krb5kdf_free(void *vctx)
 static void krb5kdf_reset(void *vctx)
 {
     KRB5KDF_CTX *ctx = (KRB5KDF_CTX *)vctx;
+    void *provctx = ctx->provctx;
 
     ossl_prov_cipher_reset(&ctx->cipher);
     OPENSSL_clear_free(ctx->key, ctx->key_len);
     OPENSSL_clear_free(ctx->constant, ctx->constant_len);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 static int krb5kdf_set_membuf(unsigned char **dst, size_t *dst_len,

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -95,8 +95,10 @@ static void kdf_pbkdf2_free(void *vctx)
 static void kdf_pbkdf2_reset(void *vctx)
 {
     KDF_PBKDF2 *ctx = (KDF_PBKDF2 *)vctx;
+    void *provctx = ctx->provctx;
 
     kdf_pbkdf2_cleanup(ctx);
+    ctx->provctx = provctx;
     kdf_pbkdf2_init(ctx);
 }
 

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -72,12 +72,14 @@ static void kdf_sshkdf_free(void *vctx)
 static void kdf_sshkdf_reset(void *vctx)
 {
     KDF_SSHKDF *ctx = (KDF_SSHKDF *)vctx;
+    void *provctx = ctx->provctx;
 
     ossl_prov_digest_reset(&ctx->digest);
     OPENSSL_clear_free(ctx->key, ctx->key_len);
     OPENSSL_clear_free(ctx->xcghash, ctx->xcghash_len);
     OPENSSL_clear_free(ctx->session_id, ctx->session_id_len);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 static int sshkdf_set_membuf(unsigned char **dst, size_t *dst_len,

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -302,6 +302,7 @@ static void *sskdf_new(void *provctx)
 static void sskdf_reset(void *vctx)
 {
     KDF_SSKDF *ctx = (KDF_SSKDF *)vctx;
+    void *provctx = ctx->provctx;
 
     EVP_MAC_free_ctx(ctx->macctx);
     ossl_prov_digest_reset(&ctx->digest);
@@ -309,6 +310,7 @@ static void sskdf_reset(void *vctx)
     OPENSSL_clear_free(ctx->info, ctx->info_len);
     OPENSSL_clear_free(ctx->salt, ctx->salt_len);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 static void sskdf_free(void *vctx)

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -115,12 +115,14 @@ static void kdf_tls1_prf_free(void *vctx)
 static void kdf_tls1_prf_reset(void *vctx)
 {
     TLS1_PRF *ctx = (TLS1_PRF *)vctx;
+    void *provctx = ctx->provctx;
 
     EVP_MAC_free_ctx(ctx->P_hash);
     EVP_MAC_free_ctx(ctx->P_sha1);
     OPENSSL_clear_free(ctx->sec, ctx->seclen);
     OPENSSL_cleanse(ctx->seed, ctx->seedlen);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 static int kdf_tls1_prf_derive(void *vctx, unsigned char *key,

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -255,11 +255,13 @@ static void *x942kdf_new(void *provctx)
 static void x942kdf_reset(void *vctx)
 {
     KDF_X942 *ctx = (KDF_X942 *)vctx;
+    void *provctx = ctx->provctx;
 
     ossl_prov_digest_reset(&ctx->digest);
     OPENSSL_clear_free(ctx->secret, ctx->secret_len);
     OPENSSL_clear_free(ctx->ukm, ctx->ukm_len);
     memset(ctx, 0, sizeof(*ctx));
+    ctx->provctx = provctx;
 }
 
 static void x942kdf_free(void *vctx)


### PR DESCRIPTION
kdf_tls1_prf_reset and kdf_hkdf_reset were resetting a little too much.

We also update evp_test to run the KDF tests for the FIPS provider as well.

Fixes #12225

