### PR TITLE
Fix linking against non-system zlib on macOS

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1563,7 +1563,7 @@ my %targets = (
         CFLAGS           => picker(debug   => "-g -O0",
                                    release => "-O3"),
         cppflags         => threads("-D_REENTRANT"),
-        lflags           => "-Wl,-search_paths_first",
+        lflags           => add("-Wl,-search_paths_first"),
         sys_id           => "MACOSX",
         bn_ops           => "BN_LLONG RC4_CHAR",
         thread_scheme    => "pthreads",


### PR DESCRIPTION
This commit ensures the `-L/path/to/zlib` flag associated with `ldflags`
property set in `Configurations/00-base-templates.conf` (under `BASE_unix`)
is inherited when defining `darwin-common` configuration.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
NA