### PR TITLE
Fix some SSL_dup issues and provide better documentation for it (1.1.1)

### DIFF
--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -73,9 +73,6 @@ L<SSL_set_info_callback(3)>
 
 =item any configured Cipher List
 
-=item any BIOs configured on I<s> will have new BIO's created and the BIO state
-duplicated via BIO_dup_state().
-
 =item initial accept (server) or connect (client) state
 
 =item the max cert list value set via L<SSL_set_max_cert_list(3)>

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -31,8 +31,8 @@ B<SSL_CTX> that was used to create I<s>. It additionally duplicates a subset of
 the settings in I<s> into the new B<SSL> object.
 
 For SSL_dup() to work, the connection MUST be in its initial state and
-MUST NOT have not yet have started the SSL handshake.  For connections
-that are not in their initial state SSL_dup() just increments an internal
+MUST NOT have yet started the SSL handshake.  For connections that are not in
+their initial state SSL_dup() just increments an internal
 reference count and returns the I<same> handle.  It may be possible to
 use L<SSL_clear(3)> to recycle an SSL handle that is not in its initial
 state for re-use, but this is best avoided.  Instead, save and restore

--- a/doc/man3/SSL_new.pod
+++ b/doc/man3/SSL_new.pod
@@ -26,10 +26,78 @@ structure are freed.
 SSL_up_ref() increments the reference count for an
 existing B<SSL> structure.
 
-SSL_dup() duplicates an existing B<SSL> structure into a new allocated one. All
-settings are inherited from the original B<SSL> structure. Dynamic data (i.e.
-existing connection details) are not copied, the new B<SSL> is set into an
-initial accept (server) or connect (client) state.
+The function SSL_dup() creates and returns a new B<SSL> structure from the same
+B<SSL_CTX> that was used to create I<s>. It additionally duplicates a subset of
+the settings in I<s> into the new B<SSL> object.
+
+For SSL_dup() to work, the connection MUST be in its initial state and
+MUST NOT have not yet have started the SSL handshake.  For connections
+that are not in their initial state SSL_dup() just increments an internal
+reference count and returns the I<same> handle.  It may be possible to
+use L<SSL_clear(3)> to recycle an SSL handle that is not in its initial
+state for re-use, but this is best avoided.  Instead, save and restore
+the session, if desired, and construct a fresh handle for each connection.
+
+The subset of settings in I<s> that are duplicated are:
+
+=over 4
+
+=item any session data if configured (including the session_id_context)
+
+=item any tmp_dh settings set via L<SSL_set_tmp_dh(3)>,
+L<SSL_set_tmp_dh_callback(3)>, or L<SSL_set_dh_auto(3)>
+
+=item any configured certificates, private keys or certificate chains
+
+=item any configured signature algorithms, or client signature algorithms
+
+=item any DANE settings
+
+=item any Options set via L<SSL_set_options(3)>
+
+=item any Mode set via L<SSL_set_mode(3)>
+
+=item any minimum or maximum protocol settings set via
+L<SSL_set_min_proto_version(3)> or L<SSL_set_max_proto_version(3)> (Note: Only
+from OpenSSL 1.1.1h and above)
+
+=item any Verify mode, callback or depth set via L<SSL_set_verify(3)> or
+L<SSL_set_verify_depth(3)> or any configured X509 verification parameters
+
+=item any msg callback or info callback set via L<SSL_set_msg_callback(3)> or
+L<SSL_set_info_callback(3)>
+
+=item any default password callback set via L<SSL_set_default_passwd_cb(3)>
+
+=item any session id generation callback set via L<SSL_set_generate_session_id(3)>
+
+=item any configured Cipher List
+
+=item any BIOs configured on I<s> will have new BIO's created and the BIO state
+duplicated via BIO_dup_state().
+
+=item initial accept (server) or connect (client) state
+
+=item the max cert list value set via L<SSL_set_max_cert_list(3)>
+
+=item the read_ahead value set via L<SSL_set_read_ahead(3)>
+
+=item application specific data set via L<SSL_set_ex_data(3)>
+
+=item any CA list or client CA list set via L<SSL_set0_CA_list(3)>,
+SSL_set0_client_CA_list() or similar functions
+
+=item any security level settings or callbacks
+
+=item any configured serverinfo data
+
+=item any configured PSK identity hint
+
+=item any configured custom extensions
+
+=item any client certificate types configured via SSL_set1_client_certificate_types
+
+=back
 
 =head1 RETURN VALUES
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3841,21 +3841,6 @@ SSL *SSL_dup(SSL *s)
     if (!CRYPTO_dup_ex_data(CRYPTO_EX_INDEX_SSL, &ret->ex_data, &s->ex_data))
         goto err;
 
-    /* setup rbio, and wbio */
-    if (s->rbio != NULL) {
-        if (!BIO_dup_state(s->rbio, (char *)&ret->rbio))
-            goto err;
-    }
-    if (s->wbio != NULL) {
-        if (s->wbio != s->rbio) {
-            if (!BIO_dup_state(s->wbio, (char *)&ret->wbio))
-                goto err;
-        } else {
-            BIO_up_ref(ret->rbio);
-            ret->wbio = ret->rbio;
-        }
-    }
-
     ret->server = s->server;
     if (s->handshake_func) {
         if (s->server)

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3824,6 +3824,8 @@ SSL *SSL_dup(SSL *s)
         goto err;
     ret->version = s->version;
     ret->options = s->options;
+    ret->min_proto_version = s->min_proto_version;
+    ret->max_proto_version = s->max_proto_version;
     ret->mode = s->mode;
     SSL_set_max_cert_list(ret, SSL_get_max_cert_list(s));
     SSL_set_read_ahead(ret, SSL_get_read_ahead(s));


### PR DESCRIPTION
This is a backport to 1.1.1 of #12180. That PR had this description:

SSL_dup() is a very strange function and it doesn't behave the way one might expect it to, and not in accordance with the man page. There are two primary code paths:

1) If the SSL object is in a state where the first handshake has started or completed then we up ref the SSL and return back a reference to the same SSL, i.e. it does not do a dup.

2) If the SSL object has not yet started the first handshake then

We create a new SSL object from the same SSL_CTX
We copy some selected settings from the src SSL object to the dest SSL object
Probably when SSL_dup was first written it dup'd all of the setting in the SSL object. But it doesn't do that any more and hasn't done so for a very long time. For example a selection of settings that it doesn't "dup" include:

tlsext_host_name
tlsext_debug_callback
tlsext_status_type
mtu
psk_client_callback
psk_server_callback
psk_find_session_callback
psk_use_session_callback
max_early_data
sigalgs
client_sigalgs
min_proto_version
max_proto_version
groups
max_pipelines
...
(this is just a small selection the list goes on...)

Keeping SSL_dup maintained and current is a hard job. In practice I believe this function to be rarely used. IMO the best way forward is to simply document what it does do and not attempt to fix all the various settings.

Potentially we might consider deprecating it entirely. However I have not taken that step in this PR, as I thought that might be controversial. That could be a follow up PR.

One setting that I have fixed is that for min_proto_version/max_proto_version. This probably really should be "dup'd". Thanks to Rebekah Johnson for reporting this issue.

While looking into this problem I realised that the current BIO handling in SSL_dup is broken to the extent that if you call SSL_dup before a handshake has started, but after you have set BIOs on your SSL object, then it is likely to crash, or at least fail in some unexpected way:

Firstly the SSL_dup code was passing a BIO ** as the destination argument for BIO_dup_state. However BIO_dup_state expects a BIO * for that parameter. Any attempt to use this will either (1) fail silently, (2) crash or fail in some other strange way.

Secondly many BIOs do not implement the BIO_CTRL_DUP ctrl required to make this work.

Thirdly, if rbio == wbio in the original SSL object, then an attempt is made to up-ref the BIO in the new SSL object - even though it hasn't been set yet and is NULL. This results in a crash.

This appears to have been broken for a very long time with at least some of the problems described above coming from SSLeay. The simplest approach is to just remove this BIO dup capability from the function.
