### PR TITLE
Add support to zeroize plaintext in S3 record layer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1060,8 +1060,8 @@ OpenSSL 3.0
  * The SSL option SSL_OP_CLEANSE_PLAINTEXT is introduced. If that
    option is set, openssl cleanses (zeroize) plaintext bytes from
    internal buffers after delivering them to the application. Note,
-   the application is still responsible to cleanse other copies (e.g.:
-   data received by SSL_read(3)).
+   the application is still responsible for cleansing other copies
+   (e.g.: data received by SSL_read(3)).
 
    *Martin Elshuber*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1057,6 +1057,12 @@ OpenSSL 3.0
 
    *Boris Pismenny*
 
+ * The SSL option SSL_OP_CLEANSE_PLAINTEXT is introduced. If that
+   option is set, openssl cleanses plaintext bytes after delivering
+   them to the application.
+
+   *Martin Elshuber*
+
 OpenSSL 1.1.1
 -------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1058,8 +1058,10 @@ OpenSSL 3.0
    *Boris Pismenny*
 
  * The SSL option SSL_OP_CLEANSE_PLAINTEXT is introduced. If that
-   option is set, openssl cleanses plaintext bytes after delivering
-   them to the application.
+   option is set, openssl cleanses (zeroize) plaintext bytes from
+   internal buffers after delivering them to the application. Note,
+   the application is still responsible to cleanse other copies (e.g.:
+   data received by SSL_read(3)).
 
    *Martin Elshuber*
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -267,12 +267,12 @@ clients.
 
 =item SSL_OP_CLEANSE_PLAINTEXT
 
-By default TLS connections keep a copy of received plaintext data in a
-static buffer until it is overwritten by the next portion of
-data. When enabling SSL_OP_CLEANSE_PLAINTEXT this plaintext is
-cleansed by calling OPENSSL_cleanse(3) after passing data to the
-application. Data is also cleansed when releasing the connection
-(eg. L<SSL_free(3)>).
+By default TLS connections keep a copy of received plaintext
+application data in a static buffer until it is overwritten by the
+next portion of data. When enabling SSL_OP_CLEANSE_PLAINTEXT
+deciphered application data is cleansed by calling OPENSSL_cleanse(3)
+after passing data to the application. Data is also cleansed when
+releasing the connection (eg. L<SSL_free(3)>).
 
 Since OpenSSL only cleanses internal buffers, the application is
 still responsible for cleansing all other buffers. Most notable this

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -265,6 +265,14 @@ functionality is not required. Those applications can turn this feature off by
 setting this option. This is a server-side opton only. It is ignored by
 clients.
 
+=item SSL_OP_CLEANSE_PLAINTEXT
+
+By default TLS connections keep a copy of received plaintext data in a
+static buffer until it is overwritten by followup data. When enabling
+SSL_OP_CLEANSE_PLAINTEXT this plaintext is cleansed by calling
+OPENSSL_cleanse(3) after passing data to the application. Data is also
+cleansed when releasing the connection (eg. L<SSL_free(3)>).
+
 =back
 
 The following options no longer have any effect but their identifiers are

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -275,9 +275,9 @@ after passing data to the application. Data is also cleansed when
 releasing the connection (eg. L<SSL_free(3)>).
 
 Since OpenSSL only cleanses internal buffers, the application is still
-responsible for cleansing all other buffers. Most notable this applies
-to buffers passed to functions like L<SSL_read(3)>,
-L<SSL_peek(3)|SSL_read(3)> but also like L<SSL_write(3)>.
+responsible for cleansing all other buffers. Most notably, this
+applies to buffers passed to functions like L<SSL_read(3)>,
+L<SSL_peek(3)> but also like L<SSL_write(3)>.
 
 =back
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -268,10 +268,16 @@ clients.
 =item SSL_OP_CLEANSE_PLAINTEXT
 
 By default TLS connections keep a copy of received plaintext data in a
-static buffer until it is overwritten by followup data. When enabling
-SSL_OP_CLEANSE_PLAINTEXT this plaintext is cleansed by calling
-OPENSSL_cleanse(3) after passing data to the application. Data is also
-cleansed when releasing the connection (eg. L<SSL_free(3)>).
+static buffer until it is overwritten by the next portion of
+data. When enabling SSL_OP_CLEANSE_PLAINTEXT this plaintext is
+cleansed by calling OPENSSL_cleanse(3) after passing data to the
+application. Data is also cleansed when releasing the connection
+(eg. L<SSL_free(3)>).
+
+Since OpenSSL only cleanses internal buffers, the application is
+still responsible for cleansing all other buffers. Most notable this
+applies to buffers passed to functions like L<SSL_read(3)>,
+SSL_peek(3) but also like L<SSL_write(3)>.
 
 =back
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -274,10 +274,10 @@ deciphered application data is cleansed by calling OPENSSL_cleanse(3)
 after passing data to the application. Data is also cleansed when
 releasing the connection (eg. L<SSL_free(3)>).
 
-Since OpenSSL only cleanses internal buffers, the application is
-still responsible for cleansing all other buffers. Most notable this
-applies to buffers passed to functions like L<SSL_read(3)>,
-SSL_peek(3) but also like L<SSL_write(3)>.
+Since OpenSSL only cleanses internal buffers, the application is still
+responsible for cleansing all other buffers. Most notable this applies
+to buffers passed to functions like L<SSL_read(3)>,
+L<SSL_peek(3)|SSL_read(3)> but also like L<SSL_write(3)>.
 
 =back
 

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -321,7 +321,8 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
 /* Disable Extended master secret */
 # define SSL_OP_NO_EXTENDED_MASTER_SECRET                0x00000001U
 
-/* Reserved value (until OpenSSL 3.0.0)                  0x00000002U */
+/* Cleanse plaintext copies of data delivered to the application */
+# define SSL_OP_CLEANSE_PLAINTEXT                        0x00000002U
 
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1477,15 +1477,14 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
                 n = len - totalbytes;
 
             memcpy(buf, &(rr->data[rr->off]), n);
-            if (s->options & SSL_OP_CLEANSE_PLAINTEXT)
-                OPENSSL_cleanse( &(rr->data[rr->off]), n);
-
             buf += n;
             if (peek) {
                 /* Mark any zero length record as consumed CVE-2016-6305 */
                 if (SSL3_RECORD_get_length(rr) == 0)
                     SSL3_RECORD_set_read(rr);
             } else {
+                if (s->options & SSL_OP_CLEANSE_PLAINTEXT)
+                    OPENSSL_cleanse(&(rr->data[rr->off]), n);
                 SSL3_RECORD_sub_length(rr, n);
                 SSL3_RECORD_add_off(rr, n);
                 if (SSL3_RECORD_get_length(rr) == 0) {

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1477,6 +1477,9 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
                 n = len - totalbytes;
 
             memcpy(buf, &(rr->data[rr->off]), n);
+            if (s->options & SSL_OP_CLEANSE_PLAINTEXT)
+                OPENSSL_cleanse( &(rr->data[rr->off]), n);
+
             buf += n;
             if (peek) {
                 /* Mark any zero length record as consumed CVE-2016-6305 */

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -180,6 +180,8 @@ int ssl3_release_read_buffer(SSL *s)
     SSL3_BUFFER *b;
 
     b = RECORD_LAYER_get_rbuf(&s->rlayer);
+    if (s->options & SSL_OP_CLEANSE_PLAINTEXT)
+        OPENSSL_cleanse(b->buf, b->len);
     OPENSSL_free(b->buf);
     b->buf = NULL;
     return 1;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1641,9 +1641,9 @@ static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
         goto end;
 
     /*
-     * Since we called SSL_peek(), we know the data is stored as
-     * plaintext record. We can gather the pointer to check for
-     * zerozation after SSL_read().
+     * Since we called SSL_peek(), we know the data in the record
+     * layer is a plaintext record. We can gather the pointer to check
+     * for zeroization after SSL_read().
      */
     rr = serverssl->rlayer.rrec;
     zbuf = &rr->data[rr->off];

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1637,7 +1637,7 @@ static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
     if (!TEST_int_eq(SSL_peek(serverssl, &sbuf, sizeof(sbuf)), sizeof(sbuf)))
         goto end;
 
-    if (memcmp(cbuf, sbuf, sizeof(cbuf)))
+    if (!TEST_mem_eq(cbuf, sizeof(cbuf), sbuf, sizeof(sbuf)))
         goto end;
 
     /*
@@ -1654,19 +1654,19 @@ static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
      * After SSL_peek() the plaintext must still be stored in the
      * record.
      */
-    if (memcmp(cbuf, zbuf, sizeof(cbuf)))
+    if (!TEST_mem_eq(cbuf, sizeof(cbuf), zbuf, sizeof(cbuf)))
         goto end;
 
     memset(sbuf, 0, sizeof(sbuf));
     if (!TEST_int_eq(SSL_read(serverssl, &sbuf, sizeof(sbuf)), sizeof(sbuf)))
         goto end;
 
-    if (memcmp(cbuf, sbuf, sizeof(cbuf)))
+    if (!TEST_mem_eq(cbuf, sizeof(cbuf), sbuf, sizeof(cbuf)))
         goto end;
 
     /* Check if rbuf is cleansed */
     memset(cbuf, 0, sizeof(cbuf));
-    if (memcmp(cbuf, zbuf, sizeof(cbuf)))
+    if (!TEST_mem_eq(cbuf, sizeof(cbuf), zbuf, sizeof(cbuf)))
         goto end;
 
     testresult = 1;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1582,6 +1582,19 @@ static int test_large_message_tls_read_ahead(void)
                                       TLS1_VERSION, 0, 1);
 }
 
+#ifndef OPENSSL_NO_DTLS
+static int test_large_message_dtls(void)
+{
+    /*
+     * read_ahead is not relevant to DTLS because DTLS always acts as if
+     * read_ahead is set.
+     */
+    return execute_test_large_message(DTLS_server_method(),
+                                      DTLS_client_method(),
+                                      DTLS1_VERSION, 0, 0);
+}
+#endif
+
 static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
                                      const SSL_METHOD *cmeth,
                                      int min_version, int max_version)
@@ -1694,19 +1707,6 @@ static int test_cleanse_plaintext(void)
 #endif
     return 1;
 }
-
-#ifndef OPENSSL_NO_DTLS
-static int test_large_message_dtls(void)
-{
-    /*
-     * read_ahead is not relevant to DTLS because DTLS always acts as if
-     * read_ahead is set.
-     */
-    return execute_test_large_message(DTLS_server_method(),
-                                      DTLS_client_method(),
-                                      DTLS1_VERSION, 0, 0);
-}
-#endif
 
 #ifndef OPENSSL_NO_OCSP
 static int ocsp_server_cb(SSL *s, void *arg)
@@ -8430,10 +8430,10 @@ int setup_tests(void)
 #endif
     ADD_TEST(test_large_message_tls);
     ADD_TEST(test_large_message_tls_read_ahead);
-    ADD_TEST(test_cleanse_plaintext);
 #ifndef OPENSSL_NO_DTLS
     ADD_TEST(test_large_message_dtls);
 #endif
+    ADD_TEST(test_cleanse_plaintext);
 #ifndef OPENSSL_NO_OCSP
     ADD_TEST(test_tlsext_status_type);
 #endif


### PR DESCRIPTION
Some applications want even all plaintext copies beeing
zeroized. However, currently plaintext residuals are kept in rbuf
within the s3 record layer.

This patch add the option SSL_OP_CLEANSE_PLAINTEXT to its friends to
optionally enable cleansing of decrypted plaintext data.

* This patch is a followup of the discussion with Matt on openssl-users
https://mta.openssl.org/pipermail/openssl-users/2020-June/012604.html

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
