### PR TITLE
TEST: Provide a default openssl.cnf for tests

### DIFF
--- a/test/default.cnf
+++ b/test/default.cnf
@@ -1,10 +1,1 @@
-openssl_conf = openssl_init
-
-[openssl_init]
-providers = provider_sect
-
-[provider_sect]
-default = default_sect
-
-[default_sect]
-activate = 1
+# This file intentionally left empty.

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -25,7 +25,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $no_legacy = disabled('legacy') || ($ENV{NO_LEGACY} // 0);
 
 # Default config depends on if the legacy module is built or not
-my $defaultcnf = $no_legacy ? 'default.cnf' : 'default-and-legacy.cnf';
+my $defaultcnf = $no_legacy ? 'default-provider.cnf' : 'default-and-legacy.cnf';
 
 my @configs = ( $defaultcnf );
 # Only add the FIPS config if the FIPS module has been built

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -26,7 +26,7 @@ my @types = ( "digest", "cipher" );
 
 my @setups = ();
 my @testdata = (
-    { config    => srctop_file("test", "default.cnf"),
+    { config    => srctop_file("test", "default-provider.cnf"),
       providers => [ 'default' ],
       tests  => [ { providers => [] },
                   { },

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -42,7 +42,7 @@ my @reqcmd = ("openssl", "req");
 my @x509cmd = ("openssl", "x509", $digest);
 my @verifycmd = ("openssl", "verify");
 my @genpkeycmd = ("openssl", "genpkey");
-my $dummycnf = srctop_file("apps", "openssl.cnf");
+my $dummycnf = srctop_file("test", "default.cnf");
 
 my $cnf = srctop_file("test", "ca-and-certs.cnf");
 my $CAkey = "keyCA.ss";
@@ -105,7 +105,7 @@ subtest 'test_ss' => sub {
 };
 
 note('test_ssl -- key U');
-testssl("keyU.ss", $Ucert, $CAcert, "default", srctop_file("test","default.cnf"));
+testssl("keyU.ss", $Ucert, $CAcert, "default", srctop_file("test","default-provider.cnf"));
 unless ($no_fips) {
     testssl("keyU.ss", $Ucert, $CAcert, "fips", srctop_file("test","fips.cnf"));
 }

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -33,7 +33,7 @@ plan tests =>
 ok(run(test(["sslapitest", srctop_dir("test", "certs"),
              srctop_file("test", "recipes", "90-test_sslapi_data",
                          "passwd.txt"), $tmpfilename, "default",
-             srctop_file("test", "default.cnf")])),
+             srctop_file("test", "default-provider.cnf")])),
              "running sslapitest");
 
 unless ($no_fips) {

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -31,7 +31,7 @@ my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 
-$ENV{OPENSSL_CONF} = rel2abs(catdir($srctop, "apps", "openssl.cnf"));
+$ENV{OPENSSL_CONF} = rel2abs(catdir($srctop, "test", "default.cnf"));
 $ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "providers"));
 $ENV{OPENSSL_MODULES} = rel2abs(catdir($bldtop, "providers"));
 $ENV{OPENSSL_ENGINES} = rel2abs(catdir($bldtop, "engines"));


### PR DESCRIPTION
In Debian the apps/openssl.cnf gets patched to provide a system wide
policy for TLSv1.2+ and SECLEVEL=2.
Somewhere between alpha1 and alpha3 the testsuite started failing
because the tests requiring < TLSv1.2 failed due to the restriction in
the modified .cnf file.
As far as I can tell, there is no need use the whole .cnf file from
apps which contains mainly certificate related options. Also the
testsuite should not depend on files outside of the testsuite.

Provide an empty .cnf file for the testsuite if none is specified. This
is enough to pass the testsuite.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>