### PR TITLE
apps: avoid memory overrun.

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -205,7 +205,7 @@ static void setup_trace(const char *str)
 }
 #endif /* OPENSSL_NO_TRACE */
 
-static char *help_argv[] = { "help" };
+static char *help_argv[] = { "help", NULL };
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
NULL terminate the built in "help" `argv` array to avoid reading beyond the end.

Fixes #12246