### PR TITLE
Add send_alert method to ssl lib

### DIFF
--- a/doc/man3/SSL_send_alert.pod
+++ b/doc/man3/SSL_send_alert.pod
@@ -1,0 +1,46 @@
+=pod
+
+=head1 NAME
+
+SSL_send_alert - send ssl alert to ssl connection
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ int SSL_send_alert(SSL * ssl, int level, int desc);
+
+=head1 DESCRIPTION
+
+SSL_send_alert() sends alert to the ssl connection, and terminates session in case level is B<SSL3_AL_FATAL>.
+
+=head1 RETURN VALUES
+
+The following return values can occur:
+
+=over 4
+
+=item E<gt> 0
+
+The send alert operation was succeeded, the return value is the number of bytes actually written to the TLS/SSL connection. (see L<SSL_write(3)>)
+
+=item Z<><= 0
+
+The send alert operation was not successful, because either the connection was closed, an error occurred or desc is unknown.
+
+=back
+
+=head1 SEE ALSO
+
+L<SSL_write(3)>, L<SSL_shutdown(3)>, L<SSL_alert_desc_string(3)>, L<ssl(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -2473,6 +2473,7 @@ void SSL_CTX_set_allow_early_data_cb(SSL_CTX *ctx,
 void SSL_set_allow_early_data_cb(SSL *s,
                                  SSL_allow_early_data_cb_fn cb,
                                  void *arg);
+int SSL_send_alert(SSL * s, int level, int desc);
 
 /* store the default cipher strings inside the library */
 const char *OSSL_default_cipher_list(void);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5867,6 +5867,11 @@ void SSL_set_allow_early_data_cb(SSL *s,
     s->allow_early_data_cb_data = arg;
 }
 
+int SSL_send_alert(SSL * s, int level, int desc)
+{
+    return ssl3_send_alert(s, level, desc);
+}
+
 const EVP_CIPHER *ssl_evp_cipher_fetch(OPENSSL_CTX *libctx,
                                        int nid,
                                        const char *properties)

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -514,3 +514,4 @@ SSL_CTX_load_verify_store               ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set_tlsext_ticket_key_evp_cb    ?	3_0_0	EXIST::FUNCTION:
 SSL_CTX_new_with_libctx                 ?	3_0_0	EXIST::FUNCTION:
 SSL_new_session_ticket                  ?	3_0_0	EXIST::FUNCTION:
+SSL_send_alert                          ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add send_alert method to ssl lib

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
