### PR TITLE
doc/man3: fix types taken by HMAC(), HMAC_Update()

### DIFF
--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -25,7 +25,7 @@ B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
  unsigned char *HMAC(const EVP_MD *evp_md, const void *key,
-                     int key_len, const unsigned char *d, int n,
+                     int key_len, const unsigned char *d, size_t n,
                      unsigned char *md, unsigned int *md_len);
 
  HMAC_CTX *HMAC_CTX_new(void);
@@ -33,7 +33,7 @@ L<openssl_user_macros(7)>:
 
  int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int key_len,
                   const EVP_MD *md, ENGINE *impl);
- int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, int len);
+ int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, size_t len);
  int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len);
 
  void HMAC_CTX_free(HMAC_CTX *ctx);


### PR DESCRIPTION
HMAC() and HMAC_Update() take size_t for 'n' and 'len' respectively.

CLA: trivial