### PR TITLE
Fix some CMP related msan failures

### DIFF
--- a/apps/lib/apps_ui.c
+++ b/apps/lib/apps_ui.c
@@ -37,7 +37,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
             {
                 const char *password =
                     ((PW_CB_DATA *)UI_get0_user_data(ui))->password;
-                if (password && password[0] != '\0') {
+                if (password != NULL) {
                     UI_set_result(ui, uis, password);
                     return 1;
                 }
@@ -54,6 +54,8 @@ static int ui_read(UI *ui, UI_STRING *uis)
     reader = UI_method_get_reader(ui_fallback_method);
     if (reader)
         return reader(ui, uis);
+    /* Default to the empty password if we've got nothing better */
+    UI_set_result(ui, uis, "");
     return 1;
 }
 

--- a/apps/lib/apps_ui.c
+++ b/apps/lib/apps_ui.c
@@ -20,7 +20,7 @@ static int ui_open(UI *ui)
 {
     int (*opener)(UI *ui) = UI_method_get_opener(ui_fallback_method);
 
-    if (opener)
+    if (opener != NULL)
         return opener(ui);
     return 1;
 }
@@ -37,6 +37,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
             {
                 const char *password =
                     ((PW_CB_DATA *)UI_get0_user_data(ui))->password;
+
                 if (password != NULL) {
                     UI_set_result(ui, uis, password);
                     return 1;
@@ -52,7 +53,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
     }
 
     reader = UI_method_get_reader(ui_fallback_method);
-    if (reader)
+    if (reader != NULL)
         return reader(ui, uis);
     /* Default to the empty password if we've got nothing better */
     UI_set_result(ui, uis, "");
@@ -84,7 +85,7 @@ static int ui_write(UI *ui, UI_STRING *uis)
     }
 
     writer = UI_method_get_writer(ui_fallback_method);
-    if (writer)
+    if (writer != NULL)
         return writer(ui, uis);
     return 1;
 }
@@ -93,7 +94,7 @@ static int ui_close(UI *ui)
 {
     int (*closer)(UI *ui) = UI_method_get_closer(ui_fallback_method);
 
-    if (closer)
+    if (closer != NULL)
         return closer(ui);
     return 1;
 }
@@ -114,7 +115,7 @@ int setup_ui_method(void)
 
 void destroy_ui_method(void)
 {
-    if (ui_method) {
+    if (ui_method != NULL) {
         UI_destroy_method(ui_method);
         ui_method = NULL;
     }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -712,10 +712,15 @@ static BIO *HTTP_new_bio(const char *server /* optionally includes ":port" */,
     }
 
     host_end = strchr(host, '/');
-    if (host_end != NULL && (size_t)(host_end - host) < sizeof(host_name)) {
-        /* chop trailing string starting with '/' */
-        strncpy(host_name, host, host_end - host + 1);
-        host = host_name;
+    if (host_end != NULL) {
+        size_t host_len = host_end - host;
+
+        if (host_len < sizeof(host_name)) {
+            /* chop trailing string starting with '/' */
+            strncpy(host_name, host, host_len);
+            host_name[host_len] = '\0';
+            host = host_name;
+        }
     }
 
     cbio = BIO_new_connect(host /* optionally includes ":port" */);

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -14,18 +14,23 @@ use warnings;
 use POSIX;
 use File::Spec::Functions qw/catfile/;
 use File::Compare qw/compare_text/;
-use OpenSSL::Test qw/:DEFAULT with data_file data_dir bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT with data_file data_dir srctop_dir bldtop_dir/;
 use OpenSSL::Test::Utils;
 use Data::Dumper; # for debugging purposes only
 
-setup("test_cmp_cli");
+BEGIN {
+    setup("test_cmp_cli");
+}
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
 
 plan skip_all => "These tests are not supported in a no-cmp build"
     if disabled("cmp");
 plan skip_all => "These tests are not supported in a no-ec build"
     if disabled("ec");
 plan skip_all => "These tests are not supported in a fuzz build"
-    if !disabled("fuzz-libfuzzer") || !disabled("fuzz-afl");
+    if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION/;
 plan skip_all => "Tests involving server not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
 


### PR DESCRIPTION
The cmp_cli test is failing in some travis builds on master due to msan failures. There are two separate problems fixed by this PR:

1) Ensure a string is properly terminated in http_client.c

In HTTP_new_bio(), if the host has a trailing '/' we took a copy of the hostname but failed to terminate it properly.

2) If an empty password is supplied still try to use it

If an empty password was supplied we ignored it and were trying to use the fallback method to read the password instead (i.e. read from stdin). However if that failed (which it always does if the cmp option -batch is used) then we were reporting that we had successfully read the password without actually setting one.

Instead, if an empty password is explicitly provided we should use it. If no password is supplied explicitly and we have no fallback method then we assume the empty password.

[extended tests]