### PR TITLE
Improve run-tests.pl modes VFO and VFP, make VFO replace VF

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1603,9 +1603,9 @@ that isn't a problem in OpenSSL itself (like an OS malfunction or a Perl issue).
 You may want increased verbosity, that can be accomplished as described in
 section [Test Failures of test/README.md](test/README.md#test-failures).
 
-You may want to selectively specify which test(s) to perform. This can be done
-sing the `make` variable `TESTS` as described in section [Running Selected Tests
-of test/README.md](test/README.md#running-selected-tests).
+You may also want to selectively specify which test(s) to perform. This can be
+done using the `make` variable `TESTS` as described in section [Running
+Selected Tests of test/README.md](test/README.md#running-selected-tests).
 
 If you find a problem with OpenSSL itself, try removing any
 compiler optimization flags from the `CFLAGS` line in the Makefile and

--- a/test/README.md
+++ b/test/README.md
@@ -27,21 +27,17 @@ Full verbosity, showing full output of all successful and failed test cases
     $ mms /macro=(V=1) test                          ! OpenVMS
     $ nmake V=1 test                                 # Windows
 
-Verbosity on test failure (`VERBOSE_FAILURE` or `VF`, Unix example shown):
+Verbosity on failed (sub-)tests only (`VERBOSE_FAILURE` or `VF`):
 
     $ make test VF=1
 
-Verbosity on failed (sub-)tests only (`VERBOSE_FAILURES_ONLY` or `VFO`):
-
-    $ make test VFO=1
-
 Verbosity on failed (sub-)tests, in addition progress on succeeded (sub-)tests
-(`VERBOSE_FAILURES_PROGRESS` or `VFP`):
+(`VERBOSE_FAILURE_PROGRESS` or `VFP`):
 
     $ make test VFP=1
 
 If you want to run just one or a few specific tests, you can use
-the `make` variable `TESTS` to specify them, like this:
+the make variable TESTS to specify them, like this:
 
     $ make TESTS='test_rsa test_dsa' test            # Unix
     $ mms/macro="TESTS=test_rsa test_dsa" test       ! OpenVMS
@@ -50,7 +46,7 @@ the `make` variable `TESTS` to specify them, like this:
 And of course, you can combine (Unix examples shown):
 
     $ make test TESTS='test_rsa test_dsa' VF=1
-    $ make test TESTS="test_cmp_*" VFO=1
+    $ make test TESTS="test_cmp_*" VFP=1
 
 You can find the list of available tests like this:
 

--- a/test/README.md
+++ b/test/README.md
@@ -27,12 +27,13 @@ Full verbosity, showing full output of all successful and failed test cases
     $ mms /macro=(V=1) test                          ! OpenVMS
     $ nmake V=1 test                                 # Windows
 
-Verbosity on failed (sub-)tests only (`VERBOSE_FAILURE` or `VF`):
+Verbosity on failed (sub-)tests only
+(`VERBOSE_FAILURE` or `VF` or `REPORT_FAILURES`):
 
     $ make test VF=1
 
 Verbosity on failed (sub-)tests, in addition progress on succeeded (sub-)tests
-(`VERBOSE_FAILURE_PROGRESS` or `VFP`):
+(`VERBOSE_FAILURE_PROGRESS` or `VFP` or `REPORT_FAILURES_PROGRESS`):
 
     $ make test VFP=1
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -10,13 +10,15 @@ use strict;
 use warnings;
 
 # Recognise VERBOSE aka V which is common on other projects.
-# Additionally, recognise VERBOSE_FAILURE aka VF.
-# and recognise VERBOSE_FAILURE_PROGRESS aka VFP.
+# Additionally, recognise VERBOSE_FAILURE aka VF aka REPORT_FAILURES
+# and recognise VERBOSE_FAILURE_PROGRESS aka VFP aka REPORT_FAILURES_PROGRESS.
 BEGIN {
     $ENV{HARNESS_VERBOSE} = "yes" if $ENV{VERBOSE} || $ENV{V};
-    $ENV{HARNESS_VERBOSE_FAILURE} = "yes" if $ENV{VERBOSE_FAILURE} || $ENV{VF};
+    $ENV{HARNESS_VERBOSE_FAILURE} = "yes"
+        if $ENV{VERBOSE_FAILURE} || $ENV{VF} || $ENV{REPORT_FAILURES};
     $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} = "yes"
-        if $ENV{VERBOSE_FAILURE_PROGRESS} || $ENV{VFP};
+        if ($ENV{VERBOSE_FAILURE_PROGRESS} || $ENV{VFP}
+            || $ENV{REPORT_FAILURES_PROGRESS});
 }
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -9,15 +9,14 @@
 use strict;
 use warnings;
 
-# Recognise VERBOSE and V which is common on other projects.
-# Additionally, also recognise VERBOSE_FAILURE and VF.
+# Recognise VERBOSE aka V which is common on other projects.
+# Additionally, recognise VERBOSE_FAILURE aka VF.
+# and recognise VERBOSE_FAILURE_PROGRESS aka VFP.
 BEGIN {
     $ENV{HARNESS_VERBOSE} = "yes" if $ENV{VERBOSE} || $ENV{V};
     $ENV{HARNESS_VERBOSE_FAILURE} = "yes" if $ENV{VERBOSE_FAILURE} || $ENV{VF};
-    $ENV{HARNESS_VERBOSE_FAILURES_ONLY} = "yes"
-        if $ENV{VERBOSE_FAILURES_ONLY} || $ENV{VFO};
-    $ENV{HARNESS_VERBOSE_FAILURES_PROGRESS} = "yes"
-        if $ENV{VERBOSE_FAILURES_PROGRESS} || $ENV{VFP};
+    $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} = "yes"
+        if $ENV{VERBOSE_FAILURE_PROGRESS} || $ENV{VFP};
 }
 
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
@@ -50,9 +49,13 @@ my %tapargs =
 my %openssl_args = ();
 
 $openssl_args{'failure_verbosity'} = $ENV{HARNESS_VERBOSE} ? 0 :
-    $ENV{HARNESS_VERBOSE_FAILURE} ? 3 :
-    $ENV{HARNESS_VERBOSE_FAILURES_PROGRESS} ? 2 :
-    $ENV{HARNESS_VERBOSE_FAILURES_ONLY} ? 1 : 0;
+    $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} ? 2 :
+    1; # $ENV{HARNESS_VERBOSE_FAILURE}
+print "Warning: HARNESS_VERBOSE overrides HARNESS_VERBOSE_FAILURE*\n"
+    if ($ENV{HARNESS_VERBOSE} && ($ENV{HARNESS_VERBOSE_FAILURE}
+                                  || $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS}));
+print "Warning: HARNESS_VERBOSE_FAILURE_PROGRESS overrides HARNESS_VERBOSE_FAILURE\n"
+    if ($ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} && $ENV{HARNESS_VERBOSE_FAILURE});
 
 my $outfilename = $ENV{HARNESS_TAP_COPY};
 open $openssl_args{'tap_copy'}, ">$outfilename"
@@ -150,9 +153,7 @@ $eres = eval {
                     if defined $fh;
 
                 my $failure_verbosity = $openssl_args{failure_verbosity};
-                if ($failure_verbosity == 3) {
-                    push @failure_output, $self->as_string;
-                } elsif ($failure_verbosity > 0) {
+                if ($failure_verbosity > 0) {
                     my $is_plan = $self->is_plan;
                     my $tests_planned = $is_plan && $self->tests_planned;
                     my $is_test = $self->is_test;
@@ -198,7 +199,7 @@ $eres = eval {
                     print $_, "\n" foreach (("", @failure_output));
                 }
                 # Echo any trailing comments etc.
-                print "$output_buffer" if $failure_verbosity != 3;
+                print "$output_buffer";
             };
         }
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -178,6 +178,7 @@ $eres = eval {
                         print $output_buffer if !$is_ok;
                         print "\n".$self->as_string
                             if !$is_ok || $failure_verbosity == 2;
+                        print "\n# ------------------------------------------------------------------------------" if !$is_ok;
                         $output_buffer = "";
                     } elsif ($self->as_string ne "") {
                         # typically is_comment or is_unknown


### PR DESCRIPTION
Add a visual separator after the output of each failed test in VFO and VFP mode.

Also add a warning in case VFO (HARNESS_VERBOSE_FAILURES_ONLY) or VFP (HARNESS_VERBOSE_FAILURES_PROGRESS) is used along with VF or V overriding it,
and in case VF (HARNESS_VERBOSE_FAILURE) is used along with V (VERBOSE) overriding it.