### PR TITLE
Completely remove "func" from ERR state.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -641,8 +641,7 @@ OpenSSL 3.0
  * Added ERR functionality to give callers access to the stored function
    names that have replaced the older function code based functions.
 
-   New functions are ERR_get_error_func(), ERR_peek_error_func(),
-   ERR_peek_last_error_func(), ERR_get_error_data(), ERR_peek_error_data(),
+   New functions are ERR_get_error_data(), ERR_peek_error_data(),
    ERR_peek_last_error_data(), ERR_get_error_all(), ERR_peek_error_all()
    and ERR_peek_last_error_all().
 
@@ -651,6 +650,11 @@ OpenSSL 3.0
    ERR_func_error_string().
 
    *Richard Levitte*
+
+ * ERR state no longer includes the function name, and is documented
+   as such.
+
+   *Rich Salz*
 
  * Extended testing to be verbose for failing tests only.  The make variables
    VERBOSE_FAILURE or VF can be used to enable this:

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -142,8 +142,7 @@ typedef enum ERR_GET_ACTION_e {
 
 static unsigned long get_error_values(ERR_GET_ACTION g,
                                       const char **file, int *line,
-                                      const char **func, const char **data,
-                                      int *flags);
+                                      const char **data, int *flags);
 
 static unsigned long err_string_data_hash(const ERR_STRING_DATA *a)
 {
@@ -174,11 +173,10 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 }
 
 #ifndef OPENSSL_NO_ERR
-/* 2019-05-21: Russian and Ukrainian locales on Linux require more than 6,5 kB */
+/* Russian and Ukrainian locales on Linux require more than 6,5 kB */
 # define SPACE_SYS_STR_REASONS 8 * 1024
 # define NUM_SYS_STR_REASONS 127
 
-static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
 /*
  * SYS_str_reasons is filled with copies of strerror() results at
  * initialization. 'errno' values up to 127 should cover all usual errors,
@@ -191,11 +189,12 @@ static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
 
 static void build_SYS_str_reasons(void)
 {
+    static int init = 1;
     /* OPENSSL_malloc cannot be used here, use static storage instead */
     static char strerror_pool[SPACE_SYS_STR_REASONS];
+    static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
     char *cur = strerror_pool;
     size_t cnt = 0;
-    static int init = 1;
     int i;
     int saveerrno = get_last_sys_error();
 
@@ -302,7 +301,7 @@ static void err_patch(int lib, ERR_STRING_DATA *str)
 }
 
 /*
- * Hash in |str| error strings. Assumes the URN_ONCE was done.
+ * Hash in |str| error strings. Assumes the RUN_ONCE was done.
  */
 static int err_load_strings(const ERR_STRING_DATA *str)
 {
@@ -387,112 +386,102 @@ void ERR_clear_error(void)
 
 unsigned long ERR_get_error(void)
 {
-    return get_error_values(EV_POP, NULL, NULL, NULL, NULL, NULL);
+    return get_error_values(EV_POP, NULL, NULL, NULL, NULL);
 }
 
 unsigned long ERR_get_error_line(const char **file, int *line)
 {
-    return get_error_values(EV_POP, file, line, NULL, NULL, NULL);
-}
-
-unsigned long ERR_get_error_func(const char **func)
-{
-    return get_error_values(EV_POP, NULL, NULL, func, NULL, NULL);
+    return get_error_values(EV_POP, file, line, NULL, NULL);
 }
 
 unsigned long ERR_get_error_data(const char **data, int *flags)
 {
-    return get_error_values(EV_POP, NULL, NULL, NULL, data, flags);
+    return get_error_values(EV_POP, NULL, NULL, data, flags);
 }
 
 unsigned long ERR_get_error_all(const char **file, int *line,
                                 const char **func,
                                 const char **data, int *flags)
 {
-    return get_error_values(EV_POP, file, line, func, data, flags);
+    if (func != NULL)
+        *func = "";
+    return get_error_values(EV_POP, file, line, data, flags);
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 unsigned long ERR_get_error_line_data(const char **file, int *line,
                                       const char **data, int *flags)
 {
-    return get_error_values(EV_POP, file, line, NULL, data, flags);
+    return get_error_values(EV_POP, file, line, data, flags);
 }
 #endif
 
 unsigned long ERR_peek_error(void)
 {
-    return get_error_values(EV_PEEK, NULL, NULL, NULL, NULL, NULL);
+    return get_error_values(EV_PEEK, NULL, NULL, NULL, NULL);
 }
 
 unsigned long ERR_peek_error_line(const char **file, int *line)
 {
-    return get_error_values(EV_PEEK, file, line, NULL, NULL, NULL);
-}
-
-unsigned long ERR_peek_error_func(const char **func)
-{
-    return get_error_values(EV_PEEK, NULL, NULL, func, NULL, NULL);
+    return get_error_values(EV_PEEK, file, line, NULL, NULL);
 }
 
 unsigned long ERR_peek_error_data(const char **data, int *flags)
 {
-    return get_error_values(EV_PEEK, NULL, NULL, NULL, data, flags);
+    return get_error_values(EV_PEEK, NULL, NULL, data, flags);
 }
 
 unsigned long ERR_peek_error_all(const char **file, int *line,
                                  const char **func,
                                  const char **data, int *flags)
 {
-    return get_error_values(EV_PEEK, file, line, func, data, flags);
+    if (func != NULL)
+        *func = "";
+    return get_error_values(EV_PEEK, file, line, data, flags);
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 unsigned long ERR_peek_error_line_data(const char **file, int *line,
                                        const char **data, int *flags)
 {
-    return get_error_values(EV_PEEK, file, line, NULL, data, flags);
+    return get_error_values(EV_PEEK, file, line, data, flags);
 }
 #endif
 
 unsigned long ERR_peek_last_error(void)
 {
-    return get_error_values(EV_PEEK_LAST, NULL, NULL, NULL, NULL, NULL);
+    return get_error_values(EV_PEEK_LAST, NULL, NULL, NULL, NULL);
 }
 
 unsigned long ERR_peek_last_error_line(const char **file, int *line)
 {
-    return get_error_values(EV_PEEK_LAST, file, line, NULL, NULL, NULL);
-}
-
-unsigned long ERR_peek_last_error_func(const char **func)
-{
-    return get_error_values(EV_PEEK_LAST, NULL, NULL, func, NULL, NULL);
+    return get_error_values(EV_PEEK_LAST, file, line, NULL, NULL);
 }
 
 unsigned long ERR_peek_last_error_data(const char **data, int *flags)
 {
-    return get_error_values(EV_PEEK_LAST, NULL, NULL, NULL, data, flags);
+    return get_error_values(EV_PEEK_LAST, NULL, NULL, data, flags);
 }
 
 unsigned long ERR_peek_last_error_all(const char **file, int *line,
                                       const char **func,
                                       const char **data, int *flags)
 {
-    return get_error_values(EV_PEEK_LAST, file, line, func, data, flags);
+    if (func != NULL)
+        *func = "";
+    return get_error_values(EV_PEEK_LAST, file, line, data, flags);
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 unsigned long ERR_peek_last_error_line_data(const char **file, int *line,
                                             const char **data, int *flags)
 {
-    return get_error_values(EV_PEEK_LAST, file, line, NULL, data, flags);
+    return get_error_values(EV_PEEK_LAST, file, line, data, flags);
 }
 #endif
 
 static unsigned long get_error_values(ERR_GET_ACTION g,
                                       const char **file, int *line,
-                                      const char **func,
                                       const char **data, int *flags)
 {
     int i = 0;
@@ -545,11 +534,6 @@ static unsigned long get_error_values(ERR_GET_ACTION g,
     }
     if (line != NULL)
         *line = es->err_line[i];
-    if (func != NULL) {
-        *func = es->err_func[i];
-        if (*func == NULL)
-            *func = "";
-    }
     if (flags != NULL)
         *flags = es->err_data_flags[i];
     if (data == NULL) {

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -35,7 +35,7 @@ void ERR_set_debug(const char *file, int line, const char *func)
     if (es == NULL)
         return;
 
-    err_set_debug(es, es->top, file, line, func);
+    err_set_debug(es, es->top, file, line);
 }
 
 void ERR_set_error(int lib, int reason, const char *fmt, ...)

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -42,12 +42,10 @@ static ossl_inline void err_set_error(ERR_STATE *es, size_t i,
 }
 
 static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
-                                      const char *file, int line,
-                                      const char *fn)
+                                      const char *file, int line)
 {
     es->err_file[i] = file;
     es->err_line[i] = line;
-    es->err_func[i] = fn;
 }
 
 static ossl_inline void err_set_data(ERR_STATE *es, size_t i,

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -51,7 +51,7 @@ static void put_error(int lib, const char *func, int reason,
                       const char *file, int line)
 {
     ERR_new();
-    ERR_set_debug(file, line, func);
+    ERR_set_debug(file, line, NULL);
     ERR_set_error(lib, reason, NULL /* no data here, so fmt is NULL */);
 }
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1001,7 +1001,7 @@ static void core_new_error(const OSSL_CORE_HANDLE *handle)
 static void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
                                  const char *file, int line, const char *func)
 {
-    ERR_set_debug(file, line, func);
+    ERR_set_debug(file, line, NULL);
 }
 
 static void core_vset_error(const OSSL_CORE_HANDLE *handle,

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -4,7 +4,6 @@
 
 ERR_get_error, ERR_peek_error, ERR_peek_last_error,
 ERR_get_error_line, ERR_peek_error_line, ERR_peek_last_error_line,
-ERR_get_error_func, ERR_peek_error_func, ERR_peek_last_error_func,
 ERR_get_error_data, ERR_peek_error_data, ERR_peek_last_error_data,
 ERR_get_error_all, ERR_peek_error_all, ERR_peek_last_error_all,
 ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
@@ -21,10 +20,6 @@ ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
  unsigned long ERR_get_error_line(const char **file, int *line);
  unsigned long ERR_peek_error_line(const char **file, int *line);
  unsigned long ERR_peek_last_error_line(const char **file, int *line);
-
- unsigned long ERR_get_error_func(const char **func);
- unsigned long ERR_peek_error_func(const char **func);
- unsigned long ERR_peek_last_error_func(const char **func);
 
  unsigned long ERR_get_error_data(const char **data, int *flags);
  unsigned long ERR_peek_error_data(const char **data, int *flags);
@@ -76,13 +71,6 @@ An unset line number is indicated as B<0>.
 A pointer returned this way by these functions and the ones below
 is valid until the respective entry is removed from the error queue.
 
-ERR_get_error_func(), ERR_peek_error_func() and
-ERR_peek_last_error_func() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but on success they
-additionally store the name of the function where the error occurred
-in *B<func>, unless it is B<NULL>.
-An unset function name is indicated as B<"">.
-
 ERR_get_error_data(), ERR_peek_error_data() and
 ERR_peek_last_error_data() are the same as ERR_get_error(),
 ERR_peek_error() and ERR_peek_last_error(), but on success they
@@ -115,7 +103,6 @@ L<ERR_GET_LIB(3)>
 
 =head1 HISTORY
 
-ERR_get_error_func(), ERR_peek_error_func(), ERR_peek_last_error_func(),
 ERR_get_error_data(), ERR_peek_error_data(), ERR_peek_last_error_data(),
 ERR_get_error_all(), ERR_peek_error_all() and ERR_peek_last_error_all()
 were added in OpenSSL 3.0.

--- a/doc/man3/ERR_load_strings.pod
+++ b/doc/man3/ERR_load_strings.pod
@@ -46,6 +46,10 @@ library number.
 
 L<ERR_load_strings(3)>
 
+=head1 HISTORY
+
+Starting with OpenSSL 3.0, the B<func> argument is ignored.
+
 =head1 COPYRIGHT
 
 Copyright 2000-2018 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man3/ERR_new.pod
+++ b/doc/man3/ERR_new.pod
@@ -25,9 +25,8 @@ ERR_new() allocates a new slot in the thread's error queue.
 
 ERR_set_debug() sets the debug information related to the current
 error in the thread's error queue.
-The values that can be given are the filename I<file>, line in the
-file I<line> and the name of the function I<func> where the error
-occurred.
+The values that can be given are the filename I<file> and line in the
+file I<line>; the I<func> parameter is ignored.
 The names must be constant, this function will only save away the
 pointers, not copy the strings.
 
@@ -43,7 +42,7 @@ argument instead of a variable number of arguments.
 
 =head1 RETURN VALUES
 
-ERR_new, ERR_set_debug, ERR_set_error and ERR_vset_error
+ERR_new(), ERR_set_debug(), ERR_set_error() and ERR_vset_error()
 do not return any values.
 
 =head1 NOTES

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -168,13 +168,14 @@ struct err_state_st {
  * library (L), function (F, not used as of 3.0), and reason (R). It is
  * split as follows:
  *      LL FFF RRR
- * The top two bits of LL are zero and fatal-error-flag.
- * This is part of the ABI, and therefore an implied part of the API.
- * Since the function is not used, a future release might re-partition the code.
+ * This is an implied part of the API. Since the function sub-part is not
+ * used, a future release might re-partition the code.  The first two bigs
+ * of the first nibble of RRR are reserved for ERR_R_FATAL and another
+ * flag that is currently zero.
  */
-# define ERR_MAX_LIB             0x3F
+# define ERR_MAX_LIB             0xFF
 # define ERR_MAX_FUNC            0
-# define ERR_MAX_REASON          0xFFF
+# define ERR_MAX_REASON          0x3FF
 # define ERR_R_FATAL             0x40
 
 # define ERR_PACK(l,f,r) ( \

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -163,12 +163,25 @@ struct err_state_st {
 #  define X509err(f, r) ERR_raise_data(ERR_LIB_X509, (r), NULL)
 # endif
 
+/*
+ * Error codes are packed into a single 32-bit number, and have three parts,
+ * library (L), function (F, not used as of 3.0), and reason (R). It is
+ * split as follows:
+ *      LL FFF RRR
+ * The top two bits of LL are zero and fatal-error-flag.
+ * This is part of the ABI, and therefore an implied part of the API.
+ * Since the function is not used, a future release might re-partition the code.
+ */
+# define ERR_MAX_LIB             0x3F
+# define ERR_MAX_FUNC            0
+# define ERR_MAX_REASON          0xFFF
+# define ERR_R_FATAL             0x40
+
 # define ERR_PACK(l,f,r) ( \
         (((unsigned int)(l) & 0x0FF) << 24L) | \
-        (((unsigned int)(f) & 0xFFF) << 12L) | \
         (((unsigned int)(r) & 0xFFF)       ) )
 # define ERR_GET_LIB(l)          (int)(((l) >> 24L) & 0x0FFL)
-# define ERR_GET_FUNC(l)         (int)(((l) >> 12L) & 0xFFFL)
+# define ERR_GET_FUNC(l)         0
 # define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)
 # define ERR_FATAL_ERROR(l)      (int)( (l)         & ERR_R_FATAL)
 
@@ -225,7 +238,6 @@ struct err_state_st {
 # define ERR_R_MISSING_ASN1_EOS                  63
 
 /* fatal error */
-# define ERR_R_FATAL                             64
 # define ERR_R_MALLOC_FAILURE                    (1|ERR_R_FATAL)
 # define ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED       (2|ERR_R_FATAL)
 # define ERR_R_PASSED_NULL_PARAMETER             (3|ERR_R_FATAL)
@@ -284,7 +296,6 @@ unsigned long ERR_get_error(void);
  * additional data.
  */
 unsigned long ERR_get_error_line(const char **file, int *line);
-unsigned long ERR_get_error_func(const char **func);
 unsigned long ERR_get_error_data(const char **data, int *flags);
 unsigned long ERR_get_error_all(const char **file, int *line,
                                 const char **func,
@@ -295,7 +306,6 @@ DEPRECATEDIN_3_0(unsigned long ERR_get_error_line_data(const char **file,
                                                      int *flags))
 unsigned long ERR_peek_error(void);
 unsigned long ERR_peek_error_line(const char **file, int *line);
-unsigned long ERR_peek_error_func(const char **func);
 unsigned long ERR_peek_error_data(const char **data, int *flags);
 unsigned long ERR_peek_error_all(const char **file, int *line,
                                  const char **func,
@@ -306,7 +316,6 @@ DEPRECATEDIN_3_0(unsigned long ERR_peek_error_line_data(const char **file,
                                                       int *flags))
 unsigned long ERR_peek_last_error(void);
 unsigned long ERR_peek_last_error_line(const char **file, int *line);
-unsigned long ERR_peek_last_error_func(const char **func);
 unsigned long ERR_peek_last_error_data(const char **data, int *flags);
 unsigned long ERR_peek_last_error_all(const char **file, int *line,
                                       const char **func,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4732,13 +4732,10 @@ EVP_PKEY_CTX_get_params                 ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_gettable_params            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_settable_params            ?	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_tag_length               ?	3_0_0	EXIST::FUNCTION:
-ERR_get_error_func                      ?	3_0_0	EXIST::FUNCTION:
 ERR_get_error_data                      ?	3_0_0	EXIST::FUNCTION:
 ERR_get_error_all                       ?	3_0_0	EXIST::FUNCTION:
-ERR_peek_error_func                     ?	3_0_0	EXIST::FUNCTION:
 ERR_peek_error_data                     ?	3_0_0	EXIST::FUNCTION:
 ERR_peek_error_all                      ?	3_0_0	EXIST::FUNCTION:
-ERR_peek_last_error_func                ?	3_0_0	EXIST::FUNCTION:
 ERR_peek_last_error_data                ?	3_0_0	EXIST::FUNCTION:
 ERR_peek_last_error_all                 ?	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_is_a                         ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Use EPERM not "1" in errtest.
Add comments on error code format, update documentation.
Clean up some code in err library.

This started because I gave an obscure comment https://github.com/openssl/openssl/issues/12276#issuecomment-650166747 and I was challenged to make a PR.  So here it is.  I think this fixes #12217, but it does it by fully removing
the function name (which we removed internally anyway).
