### PR TITLE
Fix OSSL_PROVIDER_get_capabilities()

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -831,7 +831,7 @@ int ossl_provider_get_capabilities(const OSSL_PROVIDER *prov,
                                    void *arg)
 {
     return prov->get_capabilities == NULL
-        ? 0 : prov->get_capabilities(prov->provctx, capability, cb, arg);
+        ? 1 : prov->get_capabilities(prov->provctx, capability, cb, arg);
 }
 
 

--- a/providers/common/capabilities.c
+++ b/providers/common/capabilities.c
@@ -97,26 +97,34 @@ static const TLS_GROUP_CONSTANTS group_list[35] = {
 
 static const OSSL_PARAM param_group_list[][10] = {
 #ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect163k1", "sect163k1", "EC", 0),
+# endif
 # ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("sect163r1", "sect163r1", "EC", 1),
 # endif
+# ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect163r2", "sect163r2", "EC", 2),
+# endif
 # ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("sect193r1", "sect193r1", "EC", 3),
     TLS_GROUP_ENTRY("sect193r2", "sect193r2", "EC", 4),
 # endif
+# ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect233k1", "sect233k1", "EC", 5),
     TLS_GROUP_ENTRY("sect233r1", "sect233r1", "EC", 6),
+# endif
 # ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("sect239k1", "sect239k1", "EC", 7),
 # endif
+# ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect283k1", "sect283k1", "EC", 8),
     TLS_GROUP_ENTRY("sect283r1", "sect283r1", "EC", 9),
     TLS_GROUP_ENTRY("sect409k1", "sect409k1", "EC", 10),
     TLS_GROUP_ENTRY("sect409r1", "sect409r1", "EC", 11),
     TLS_GROUP_ENTRY("sect571k1", "sect571k1", "EC", 12),
     TLS_GROUP_ENTRY("sect571r1", "sect571r1", "EC", 13),
+# endif
 # ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("secp160k1", "secp160k1", "EC", 14),
     TLS_GROUP_ENTRY("secp160r1", "secp160r1", "EC", 15),

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -334,7 +334,7 @@ static int add_provider_groups(const OSSL_PARAM params[], void *data)
     p = OSSL_PARAM_locate_const(params, OSSL_CAPABILITY_TLS_GROUP_MAX_TLS);
     if (p == NULL || !OSSL_PARAM_get_int(p, &ginf->maxtls)) {
         SSLerr(0, ERR_R_PASSED_INVALID_ARGUMENT);
-        return 0;
+        goto err;
     }
 
     p = OSSL_PARAM_locate_const(params, OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8122,8 +8122,10 @@ static int test_pluggable_group(void)
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
     OSSL_PROVIDER *tlsprov = OSSL_PROVIDER_load(libctx, "tls-provider");
+    /* Check that we are not impacted by a provider without any groups */
+    OSSL_PROVIDER *legacyprov = OSSL_PROVIDER_load(libctx, "legacy");
 
-    if (!TEST_ptr(tlsprov))
+    if (!TEST_ptr(tlsprov) || !TEST_ptr(legacyprov))
         goto end;
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
@@ -8150,6 +8152,7 @@ static int test_pluggable_group(void)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     OSSL_PROVIDER_unload(tlsprov);
+    OSSL_PROVIDER_unload(legacyprov);
 
     return testresult;
 }


### PR DESCRIPTION
It is not a failure to call OSSL_PROVIDER_get_capabilities() with a
provider loaded that has no capabilities.

Fixes #12286

While I was at it I fixed a capabilities related typo in the man pages pointed out by @romen. Also a minor logic flow problem in an error path.