### PR TITLE
apps/openssl: clean-up of unused fallback code

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -312,12 +312,6 @@ int help_main(int argc, char **argv)
     DISPLAY_COLUMNS dc;
     char *new_argv[3];
 
-    if (argc == 0) {
-        new_argv[0] = "help";
-        new_argv[1] = NULL;
-        return do_cmd(prog_init(), 1, new_argv);
-    }
-
     prog = opt_init(argc, argv, help_options);
     while ((o = opt_next()) != OPT_hEOF) {
         switch (o) {


### PR DESCRIPTION
Remove code in help_main() that duplicates the case when 'openssl' is
called with no arguments, which is now handled in main().
