### PR TITLE
Add X509_self_signed(), splitting doc/man3/X509_sign.pod

### DIFF
--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -218,7 +218,7 @@ int ossl_cmp_sk_X509_add1_cert(STACK_OF(X509) *sk, X509 *cert,
 }
 
 int ossl_cmp_sk_X509_add1_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs,
-                                int no_self_issued, int no_dups, int prepend)
+                                int no_self_signed, int no_dups, int prepend)
 /* compiler would allow 'const' for the list of certs, yet they are up-ref'ed */
 {
     int i;
@@ -230,7 +230,7 @@ int ossl_cmp_sk_X509_add1_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs,
     for (i = 0; i < sk_X509_num(certs); i++) { /* certs may be NULL */
         X509 *cert = sk_X509_value(certs, i);
 
-        if (!no_self_issued || X509_check_issued(cert, cert) != X509_V_OK) {
+        if (!no_self_signed || X509_self_signed(cert, 0) != 1) {
             if (!ossl_cmp_sk_X509_add1_cert(sk, cert, no_dups, prepend))
                 return 0;
         }
@@ -239,7 +239,7 @@ int ossl_cmp_sk_X509_add1_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs,
 }
 
 int ossl_cmp_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
-                                   int only_self_issued)
+                                   int only_self_signed)
 {
     int i;
 
@@ -252,7 +252,7 @@ int ossl_cmp_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
     for (i = 0; i < sk_X509_num(certs); i++) {
         X509 *cert = sk_X509_value(certs, i);
 
-        if (!only_self_issued || X509_check_issued(cert, cert) == X509_V_OK)
+        if (!only_self_signed || X509_self_signed(cert, 0) == 1)
             if (!X509_STORE_add_cert(store, cert)) /* ups cert ref counter */
                 return 0;
     }

--- a/doc/internal/man3/ossl_cmp_sk_X509_add1_cert.pod
+++ b/doc/internal/man3/ossl_cmp_sk_X509_add1_cert.pod
@@ -15,9 +15,9 @@ ossl_cmp_X509_STORE_get1_certs
   int ossl_cmp_sk_X509_add1_cert(STACK_OF(X509) *sk, X509 *cert,
                                  int no_dup, int prepend);
   int ossl_cmp_sk_X509_add1_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs,
-                                  int no_self_issued, int no_dups, int prepend);
+                                  int no_self_signed, int no_dups, int prepend);
   int ossl_cmp_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
-                                     int only_self_issued);
+                                     int only_self_signed);
   STACK_OF(X509) *ossl_cmp_X509_STORE_get1_certs(X509_STORE *store);
 
 =head1 DESCRIPTION
@@ -29,10 +29,10 @@ On success the reference count of the certificate is increased.
 
 ossl_cmp_sk_X509_add1_certs() appends or prepends (depending on the I<prepend>
 argument) a list of certificates to the given list,
-optionally only if not self-issued and optionally only if not already contained.
+optionally only if not self-signed and optionally only if not already contained.
 The reference counts of those certificates appended successfully are increased.
 
-ossl_cmp_X509_STORE_add1_certs() adds all or only self-issued certificates from
+ossl_cmp_X509_STORE_add1_certs() adds all or only self-signed certificates from
 the given stack to given store. The I<certs> parameter may be NULL.
 
 ossl_cmp_X509_STORE_get1_certs() retrieves a copy of all certificates in the

--- a/doc/man3/X509_check_issued.pod
+++ b/doc/man3/X509_check_issued.pod
@@ -29,9 +29,8 @@ I<issuer> or some B<X509_V_ERR*> constant to indicate an error.
 
 =head1 SEE ALSO
 
-L<X509_verify_cert(3)>,
-L<X509_check_ca(3)>,
-L<openssl-verify(1)>
+L<X509_verify_cert(3)>, L<X509_verify(3)>, L<X509_check_ca(3)>,
+L<openssl-verify(1)>, L<X509_self_signed(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_sign.pod
+++ b/doc/man3/X509_sign.pod
@@ -2,10 +2,10 @@
 
 =head1 NAME
 
-X509_sign, X509_sign_ctx, X509_verify_ex, X509_verify, X509_REQ_sign,
-X509_REQ_sign_ctx, X509_REQ_verify_ex, X509_REQ_verify, X509_CRL_sign,
-X509_CRL_sign_ctx, X509_CRL_verify
-- sign or verify certificate, certificate request or CRL signature
+X509_sign, X509_sign_ctx,
+X509_REQ_sign, X509_REQ_sign_ctx,
+X509_CRL_sign, X509_CRL_sign_ctx -
+sign certificate, certificate request, or CRL signature
 
 =head1 SYNOPSIS
 
@@ -13,18 +13,12 @@ X509_CRL_sign_ctx, X509_CRL_verify
 
  int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx);
- int X509_verify_ex(X509 *x, EVP_PKEY *pkey, OPENSSL_CTX *libctx, const char *propq);
- int X509_verify(X509 *x, EVP_PKEY *pkey;
 
  int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx);
- int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey, OPENSSL_CTX *libctx,
-                        const char *propq);
- int X509_REQ_verify(X509_REQ *a, EVP_PKEY *pkey);
 
  int X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md);
  int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx);
- int X509_CRL_verify(X509_CRL *a, EVP_PKEY *pkey);
 
 =head1 DESCRIPTION
 
@@ -32,18 +26,9 @@ X509_sign() signs certificate I<x> using private key I<pkey> and message
 digest I<md> and sets the signature in I<x>. X509_sign_ctx() also signs
 certificate I<x> but uses the parameters contained in digest context I<ctx>.
 
-X509_verify_ex() verifies the signature of certificate I<x> using public key
-I<pkey>. Any cryptographic algorithms required for the verification are fetched
-using the library context I<libctx> and the property query string I<propq>. Only
-the signature is checked: no other checks (such as certificate chain validity)
-are performed.
-
-X509_verify() is the same as X509_verify_ex() except that the default library
-context and property query string are used.
-
-X509_REQ_sign(), X509_REQ_sign_ctx(), X509_REQ_verify_ex(), X509_REQ_verify(),
-X509_CRL_sign(), X509_CRL_sign_ctx() and X509_CRL_verify() sign and verify
-certificate requests and CRLs respectively.
+X509_REQ_sign(), X509_REQ_sign_ctx(),
+X509_CRL_sign(), and X509_CRL_sign_ctx()
+sign certificate requests and CRLs, respectively.
 
 =head1 NOTES
 
@@ -60,34 +45,18 @@ signature and signing will always update the encoding.
 
 =head1 RETURN VALUES
 
-X509_sign(), X509_sign_ctx(), X509_REQ_sign(), X509_REQ_sign_ctx(),
-X509_CRL_sign() and X509_CRL_sign_ctx() return the size of the signature
+All functions return the size of the signature
 in bytes for success and zero for failure.
-
-X509_verify_ex(), X509_verify(), X509_REQ_verify_ex(), X509_REQ_verify() and
-X509_CRL_verify() return 1 if the signature is valid and 0 if the signature
-check fails. If the signature could not be checked at all because it was invalid
-or some other error occurred then -1 is returned.
 
 =head1 SEE ALSO
 
-L<d2i_X509(3)>,
 L<ERR_get_error(3)>,
-L<X509_CRL_get0_by_serial(3)>,
-L<X509_get0_signature(3)>,
-L<X509_get_ext_d2i(3)>,
-L<X509_get_extension_flags(3)>,
-L<X509_get_pubkey(3)>,
-L<X509_get_subject_name(3)>,
-L<X509_get_version(3)>,
 L<X509_NAME_add_entry_by_txt(3)>,
-L<X509_NAME_ENTRY_get_object(3)>,
-L<X509_NAME_get_index_by_NID(3)>,
-L<X509_NAME_print_ex(3)>,
 L<X509_new(3)>,
-L<X509V3_get_d2i(3)>,
 L<X509_verify_cert(3)>,
-L<OPENSSL_CTX(3)>
+L<X509_verify_ex(3)>, L<X509_verify(3)>,
+L<X509_REQ_verify_ex(3)>, L<X509_REQ_verify(3)>,
+L<X509_CRL_verify(3)>
 
 =head1 HISTORY
 
@@ -95,9 +64,7 @@ The X509_sign(), X509_REQ_sign() and X509_CRL_sign() functions are
 available in all versions of OpenSSL.
 
 The X509_sign_ctx(), X509_REQ_sign_ctx()
-and X509_CRL_sign_ctx() functions were added OpenSSL 1.0.1.
-
-X509_verify_ex() and X509_REQ_verify_ex() were added in OpenSSL 3.0.
+and X509_CRL_sign_ctx() functions were added in OpenSSL 1.0.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_verify.pod
+++ b/doc/man3/X509_verify.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-X509_verify_ex, X509_verify,
+X509_verify_ex, X509_verify, X509_self_signed,
 X509_REQ_verify_ex, X509_REQ_verify,
 X509_CRL_verify -
 verify certificate, certificate request, or CRL signature
@@ -14,6 +14,7 @@ verify certificate, certificate request, or CRL signature
  int X509_verify_ex(X509 *x, EVP_PKEY *pkey,
                     OPENSSL_CTX *libctx, const char *propq);
  int X509_verify(X509 *x, EVP_PKEY *pkey);
+ int X509_self_signed(X509 *cert, int verify_signature);
 
  int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey,
                         OPENSSL_CTX *libctx, const char *propq);
@@ -31,6 +32,12 @@ no other checks (such as certificate chain validity) are performed.
 X509_verify() is the same as X509_verify_ex() except that the default library
 context and property query string are used.
 
+X509_self_signed() checks whether a certificate is self-signed.
+For success the issuer and subject names must match, the components of the
+authority key identifier (if present) must match the subject key identifier etc.
+The signature itself is actually verified only if B<verify_signature> is 1, as
+for explicitly trusted certificates this verification is not worth the effort.
+
 X509_REQ_verify_ex(), X509_REQ_verify() and X509_CRL_verify()
 verify the signatures of certificate requests and CRLs, respectively.
 
@@ -41,6 +48,9 @@ X509_REQ_verify_ex(), X509_REQ_verify() and X509_CRL_verify()
 return 1 if the signature is valid and 0 if the signature check fails.
 If the signature could not be checked at all because it was ill-formed
 or some other error occurred then -1 is returned.
+
+X509_self_signed() returns the same values but also returns 1
+if all respective fields match and B<verify_signature> is 0.
 
 =head1 SEE ALSO
 
@@ -65,7 +75,7 @@ L<OPENSSL_CTX(3)>
 The X509_verify(), X509_REQ_verify(), and X509_CRL_verify()
 functions are available in all versions of OpenSSL.
 
-X509_verify_ex() and X509_REQ_verify_ex()
+X509_verify_ex(), X509_REQ_verify_ex(), and X509_self_signed()
 were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT

--- a/doc/man3/X509_verify.pod
+++ b/doc/man3/X509_verify.pod
@@ -1,0 +1,80 @@
+=pod
+
+=head1 NAME
+
+X509_verify_ex, X509_verify,
+X509_REQ_verify_ex, X509_REQ_verify,
+X509_CRL_verify -
+verify certificate, certificate request, or CRL signature
+
+=head1 SYNOPSIS
+
+ #include <openssl/x509.h>
+
+ int X509_verify_ex(X509 *x, EVP_PKEY *pkey,
+                    OPENSSL_CTX *libctx, const char *propq);
+ int X509_verify(X509 *x, EVP_PKEY *pkey);
+
+ int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey,
+                        OPENSSL_CTX *libctx, const char *propq);
+ int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r);
+ int X509_CRL_verify(X509_CRL *a, EVP_PKEY *r);
+
+=head1 DESCRIPTION
+
+X509_verify_ex() verifies the signature of certificate I<x> using public key
+I<pkey>. Any cryptographic algorithms required for the verification are fetched
+using the library context I<libctx> and the property query string I<propq>.
+Only the signature is checked:
+no other checks (such as certificate chain validity) are performed.
+
+X509_verify() is the same as X509_verify_ex() except that the default library
+context and property query string are used.
+
+X509_REQ_verify_ex(), X509_REQ_verify() and X509_CRL_verify()
+verify the signatures of certificate requests and CRLs, respectively.
+
+=head1 RETURN VALUES
+
+X509_verify_ex(), X509_verify(),
+X509_REQ_verify_ex(), X509_REQ_verify() and X509_CRL_verify()
+return 1 if the signature is valid and 0 if the signature check fails.
+If the signature could not be checked at all because it was ill-formed
+or some other error occurred then -1 is returned.
+
+=head1 SEE ALSO
+
+L<d2i_X509(3)>,
+L<ERR_get_error(3)>,
+L<X509_CRL_get0_by_serial(3)>,
+L<X509_get0_signature(3)>,
+L<X509_get_ext_d2i(3)>,
+L<X509_get_extension_flags(3)>,
+L<X509_get_pubkey(3)>,
+L<X509_get_subject_name(3)>,
+L<X509_get_version(3)>,
+L<X509_NAME_ENTRY_get_object(3)>,
+L<X509_NAME_get_index_by_NID(3)>,
+L<X509_NAME_print_ex(3)>,
+L<X509V3_get_d2i(3)>,
+L<X509_verify_cert(3)>,
+L<OPENSSL_CTX(3)>
+
+=head1 HISTORY
+
+The X509_verify(), X509_REQ_verify(), and X509_CRL_verify()
+functions are available in all versions of OpenSSL.
+
+X509_verify_ex() and X509_REQ_verify_ex()
+were added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2015-2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -345,6 +345,7 @@ const char *X509_verify_cert_error_string(long n);
 
 int X509_verify_ex(X509 *a, EVP_PKEY *r, OPENSSL_CTX *libctx, const char *propq);
 int X509_verify(X509 *a, EVP_PKEY *r);
+int X509_self_signed(X509 *cert, int verify_signature);
 
 int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OPENSSL_CTX *libctx,
                        const char *propq);

--- a/test/recipes/70-test_verify_extra.t
+++ b/test/recipes/70-test_verify_extra.t
@@ -14,6 +14,7 @@ setup("test_verify_extra");
 plan tests => 1;
 
 ok(run(test(["verify_extra_test",
+             srctop_file("test", "certs", "rootCA.pem"),
              srctop_file("test", "certs", "roots.pem"),
              srctop_file("test", "certs", "untrusted.pem"),
              srctop_file("test", "certs", "bad.pem"),

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4681,6 +4681,7 @@ ERR_set_error                           ?	3_0_0	EXIST::FUNCTION:
 ERR_vset_error                          ?	3_0_0	EXIST::FUNCTION:
 X509_get0_authority_issuer              ?	3_0_0	EXIST::FUNCTION:
 X509_get0_authority_serial              ?	3_0_0	EXIST::FUNCTION:
+X509_self_signed                        ?	3_0_0	EXIST::FUNCTION:
 EC_GROUP_new_by_curve_name_ex           ?	3_0_0	NOEXIST::FUNCTION:EC
 EC_KEY_new_ex                           ?	3_0_0	NOEXIST::FUNCTION:EC
 EC_KEY_new_by_curve_name_ex             ?	3_0_0	NOEXIST::FUNCTION:EC


### PR DESCRIPTION
This off-loads some topics that can be handled independently of PR #10587:
* Move doc of `X509{,_REQ,_CRL}_verify{,_ex}()` from `X509_sign.pod` to new file `X509_verify.pod`
* Add `X509_self_signed()`, extending and improving documentation and tests and using it in `cmp_util.c`

- [x] documentation is added or updated
- [x] tests are added or updated
