### PR TITLE
[apps/genpkey] exit status should not be 0 on output errors

### DIFF
--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -192,6 +192,7 @@ int genpkey_main(int argc, char **argv)
     if (rv <= 0) {
         BIO_puts(bio_err, "Error writing key\n");
         ERR_print_errors(bio_err);
+        goto end;
     }
 
     if (text) {
@@ -203,6 +204,7 @@ int genpkey_main(int argc, char **argv)
         if (rv <= 0) {
             BIO_puts(bio_err, "Error printing key\n");
             ERR_print_errors(bio_err);
+            goto end;
         }
     }
 

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -189,10 +189,12 @@ int genpkey_main(int argc, char **argv)
         goto end;
     }
 
+    ret = 0;
+
     if (rv <= 0) {
         BIO_puts(bio_err, "Error writing key\n");
         ERR_print_errors(bio_err);
-        goto end;
+        ret++;
     }
 
     if (text) {
@@ -204,11 +206,9 @@ int genpkey_main(int argc, char **argv)
         if (rv <= 0) {
             BIO_puts(bio_err, "Error printing key\n");
             ERR_print_errors(bio_err);
-            goto end;
+            ret++;
         }
     }
-
-    ret = 0;
 
  end:
     EVP_PKEY_free(pkey);

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -194,7 +194,7 @@ int genpkey_main(int argc, char **argv)
     if (rv <= 0) {
         BIO_puts(bio_err, "Error writing key\n");
         ERR_print_errors(bio_err);
-        ret++;
+        ret = 1;
     }
 
     if (text) {
@@ -206,7 +206,7 @@ int genpkey_main(int argc, char **argv)
         if (rv <= 0) {
             BIO_puts(bio_err, "Error printing key\n");
             ERR_print_errors(bio_err);
-            ret++;
+            ret = 1;
         }
     }
 


### PR DESCRIPTION
## TL;DR

If the key is to be serialized or printed as text and the framework returns an error, the app should signal the failure to the user using a non-zero exit status.

## History

From `1.1.1-stable` (this snippet did not change in `master`, only shifted by a few lines):
https://github.com/openssl/openssl/blob/7bdf1ee8ccb69a743e29e3d1a72194c30e8583ae/apps/genpkey.c#L180-L199

The code above has been unchanged (apart from formatting) for the last 14 years.

In case of an error writing the key to a file or in textual form to the terminal, the exit status of the command is still reset to 0.

## Branches

This should be fixed both in `master` and in `1.1.1`