### PR TITLE
rand: Coverity fixes

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -3186,8 +3186,7 @@ int cmp_main(int argc, char **argv)
     X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
     OSSL_CMP_CTX_free(cmp_ctx);
     X509_VERIFY_PARAM_free(vpm);
-    if (engine != NULL) /* workaround for Coverity false positive */
-        release_engine(engine);
+    release_engine(engine);
 
     NCONF_free(conf); /* must not do as long as opt_... variables are used */
     OSSL_CMP_log_close();

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1156,9 +1156,8 @@ ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug)
 void release_engine(ENGINE *e)
 {
 #ifndef OPENSSL_NO_ENGINE
-    if (e != NULL)
-        /* Free our "structural" reference. */
-        ENGINE_free(e);
+    /* Free our "structural" reference. */
+    ENGINE_free(e);
 #endif
 }
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -324,7 +324,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
                             const char *prop_query,
                             void **method)
 {
-    OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(store->ctx);
+    OSSL_PROPERTY_LIST **plp;
     ALGORITHM *alg;
     IMPLEMENTATION *impl;
     OSSL_PROPERTY_LIST *pq = NULL, *p2 = NULL;
@@ -350,9 +350,9 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
         return 0;
     }
 
-    if (prop_query != NULL) {
+    if (prop_query != NULL)
         p2 = pq = ossl_parse_query(store->ctx, prop_query);
-    }
+    plp = ossl_ctx_global_properties(store->ctx);
     if (plp != NULL && *plp != NULL) {
         if (pq == NULL) {
             pq = *plp;

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -503,7 +503,7 @@ int PROV_DRBG_instantiate(PROV_DRBG *drbg, unsigned int strength,
                                                drbg->min_noncelen,
                                                drbg->max_noncelen)) {
                 PROVerr(0, PROV_R_ERROR_RETRIEVING_NONCE);
-                OPENSSL_free(nonce);
+                goto end;
             }
 #ifndef PROV_RAND_GET_RANDOM_NONCE
         } else if (drbg->parent != NULL) {


### PR DESCRIPTION
Mostly fixing problems with the provider friendly rand work.

Also includes a fix for a null pointer dereference in properties and the removal of an unnecessary NULL check in apps/cmp.c

- [x] tests are added or updated
