### PR TITLE
apps: -msg flag enhancement

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1106,14 +1106,14 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
         if (s->msg_callback) {
             recordstart = WPACKET_get_curr(thispkt) - len
                           - SSL3_RT_HEADER_LENGTH;
-            s->msg_callback(1, 0, SSL3_RT_HEADER, recordstart,
+            s->msg_callback(1, thiswr->rec_version, SSL3_RT_HEADER, recordstart,
                             SSL3_RT_HEADER_LENGTH, s,
                             s->msg_callback_arg);
 
             if (SSL_TREAT_AS_TLS13(s) && s->enc_write_ctx != NULL) {
                 unsigned char ctype = type;
 
-                s->msg_callback(1, s->version, SSL3_RT_INNER_CONTENT_TYPE,
+                s->msg_callback(1, thiswr->rec_version, SSL3_RT_INNER_CONTENT_TYPE,
                                 &ctype, 1, s, s->msg_callback_arg);
             }
         }

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -286,20 +286,24 @@ int ssl3_get_record(SSL *s)
                 }
             } else {
                 /* SSLv3+ style record */
-                if (s->msg_callback)
-                    s->msg_callback(0, 0, SSL3_RT_HEADER, p, 5, s,
-                                    s->msg_callback_arg);
 
                 /* Pull apart the header into the SSL3_RECORD */
                 if (!PACKET_get_1(&pkt, &type)
                         || !PACKET_get_net_2(&pkt, &version)
                         || !PACKET_get_net_2_len(&pkt, &thisrr->length)) {
+                    if (s->msg_callback)
+                        s->msg_callback(0, 0, SSL3_RT_HEADER, p, 5, s,
+                                        s->msg_callback_arg);
                     SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_SSL3_GET_RECORD,
                              ERR_R_INTERNAL_ERROR);
                     return -1;
                 }
                 thisrr->type = type;
                 thisrr->rec_version = version;
+
+                if (s->msg_callback)
+                    s->msg_callback(0, version, SSL3_RT_HEADER, p, 5, s,
+                                    s->msg_callback_arg);
 
                 /*
                  * Lets check version. In TLSv1.3 we only check this field


### PR DESCRIPTION
The s_client "-msg" flag currently output lots of short records like:
```
>>> ??? [length 0005]
    16 03 01 01 3b
```
and
```
<<< ??? [length 0005]
    16 03 03 00 7a
```

The "???" is confusing, as end users may think something is wrong. It turns out these are usually TLS record headers.
This patch improves the reporting of these record headers, and also replaces some "magic values" in apps/lib/s_cb.c with the appropriate #define labels.

Example without:
```
$ ./apps/openssl s_client -connect www.google.com:443 -msg
CONNECTED(00000003)
>>> ??? [length 0005]
    16 03 01 01 3b
>>> TLS 1.3, Handshake [length 013b], ClientHello
    01 00 01 37 03 03 9f a8 aa d4 8e e2 86 9c 6b 1a
    [...]
<<< ??? [length 0005]
    16 03 03 00 7a
<<< TLS 1.3, Handshake [length 007a], ServerHello
    02 00 00 76 03 03 f0 b9 3c d9 95 73 eb 29 ae c0
    [...]
<<< ??? [length 0005]
    14 03 03 00 01
<<< ??? [length 0005]
    17 03 03 09 c6
<<< TLS 1.3 [length 0001]
    16
<<< TLS 1.3, Handshake [length 0006], EncryptedExtensions
    08 00 00 02 00 00
<<< TLS 1.3, Handshake [length 092c], Certificate
    0b 00 09 28 00 00 09 24 00 04 cc 30 82 04 c8 30
    82 03 b0 a0 03 02 01 02 02 11 00 d6 7d e6 ca a5
    [...]
depth=1 C = US, O = Google Trust Services, CN = GTS CA 1O1
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com
verify return:1
<<< TLS 1.3, Handshake [length 004f], CertificateVerify
    0f 00 00 4b 04 03 00 47 30 45 02 20 22 9b 35 f7
    [...]
<<< TLS 1.3, Handshake [length 0034], Finished
    14 00 00 30 c1 a4 c2 12 da 3d f3 5c 93 0b 9c 2e
    [...]
>>> ??? [length 0005]
    14 03 03 00 01
>>> TLS 1.3, ChangeCipherSpec [length 0001]
    01
>>> ??? [length 0005]
    17 03 03 00 45
>>> TLS 1.3 [length 0001]
    16
>>> TLS 1.3, Handshake [length 0034], Finished
    14 00 00 30 5a ac 29 fa 3e f1 2a 79 bb 94 ae d9
    [...]
---
Certificate chain
 0 s:C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com
   i:C = US, O = Google Trust Services, CN = GTS CA 1O1
   a:PKEY: id-ecPublicKey, 256 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 10 09:29:11 2020 GMT; NotAfter: Sep  2 09:29:11 2020 GMT
 1 s:C = US, O = Google Trust Services, CN = GTS CA 1O1
   i:OU = GlobalSign Root CA - R2, O = GlobalSign, CN = GlobalSign
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 15 00:00:42 2017 GMT; NotAfter: Dec 15 00:00:42 2021 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIEyDCCA7CgAwIBAgIRANZ95sqlyjj2CAAAAABGdOMwDQYJKoZIhvcNAQELBQAw
[...]
-----END CERTIFICATE-----
subject=C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com

issuer=C = US, O = Google Trust Services, CN = GTS CA 1O1

---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: ECDSA
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 2640 bytes and written 400 bytes
Verification error: unable to get local issuer certificate
---
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
Server public key is 256 bit
Secure Renegotiation IS NOT supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 20 (unable to get local issuer certificate)
---
DONE
>>> ??? [length 0005]
    17 03 03 00 13
>>> TLS 1.3 [length 0001]
    15
>>> TLS 1.3, Alert [length 0002], warning close_notify
    01 00
```

Example with:
```
$ ./apps/openssl s_client -connect www.google.com:443 -msg
CONNECTED(00000003)
>>> TLS 1.0, RecordHeader [length 0005]
    16 03 01 01 3b
>>> TLS 1.3, Handshake [length 013b], ClientHello
    01 00 01 37 03 03 cd 63 f0 6e 75 bc b2 f8 a1 6d
    [...]
<<< TLS 1.2, RecordHeader [length 0005]
    16 03 03 00 7a
<<< TLS 1.3, Handshake [length 007a], ServerHello
    02 00 00 76 03 03 f2 3b 68 51 33 fb 0e 5f 22 5d
    [...]
<<< TLS 1.2, RecordHeader [length 0005]
    14 03 03 00 01
<<< TLS 1.2, RecordHeader [length 0005]
    17 03 03 09 c5
<<< TLS 1.3 [length 0001]
    16
<<< TLS 1.3, Handshake [length 0006], EncryptedExtensions
    08 00 00 02 00 00
<<< TLS 1.3, Handshake [length 092b], Certificate
    0b 00 09 27 00 00 09 23 00 04 cb 30 82 04 c7 30
    [...]
depth=1 C = US, O = Google Trust Services, CN = GTS CA 1O1
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com
verify return:1
<<< TLS 1.3, Handshake [length 004f], CertificateVerify
    0f 00 00 4b 04 03 00 47 30 45 02 21 00 ae b1 48
    [...]
<<< TLS 1.3, Handshake [length 0034], Finished
    14 00 00 30 70 02 7a 83 c7 bb d2 e4 eb 47 b9 69
    [...]
>>> TLS 1.2, RecordHeader [length 0005]
    14 03 03 00 01
>>> TLS 1.3, ChangeCipherSpec [length 0001]
    01
>>> TLS 1.2, RecordHeader [length 0005]
    17 03 03 00 45
>>> TLS 1.2 [length 0001]
    16
>>> TLS 1.3, Handshake [length 0034], Finished
    14 00 00 30 85 04 a1 4d eb 43 f9 08 be 9d dc 27
    [...]
---
Certificate chain
 0 s:C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com
   i:C = US, O = Google Trust Services, CN = GTS CA 1O1
   a:PKEY: id-ecPublicKey, 256 (bit); sigalg: RSA-SHA256
   v:NotBefore: May 26 15:30:03 2020 GMT; NotAfter: Aug 18 15:30:03 2020 GMT
 1 s:C = US, O = Google Trust Services, CN = GTS CA 1O1
   i:OU = GlobalSign Root CA - R2, O = GlobalSign, CN = GlobalSign
   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
   v:NotBefore: Jun 15 00:00:42 2017 GMT; NotAfter: Dec 15 00:00:42 2021 GMT
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIExzCCA6+gAwIBAgIRALJsaMAobZ6SCAAAAABDVSUwDQYJKoZIhvcNAQELBQAw
[...]
-----END CERTIFICATE-----
subject=C = US, ST = California, L = Mountain View, O = Google LLC, CN = www.google.com

issuer=C = US, O = Google Trust Services, CN = GTS CA 1O1

---
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: ECDSA
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 2639 bytes and written 400 bytes
Verification error: unable to get local issuer certificate
---
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
Server public key is 256 bit
Secure Renegotiation IS NOT supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 20 (unable to get local issuer certificate)
---
DONE
>>> TLS 1.2, RecordHeader [length 0005]
    17 03 03 00 13
>>> TLS 1.2 [length 0001]
    15
>>> TLS 1.3, Alert [length 0002], warning close_notify
    01 00

```