### PR TITLE
Fipsinstall defaults

### DIFF
--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -22,7 +22,6 @@
 DEFINE_STACK_OF_STRING()
 
 #define BUFSIZE 4096
-#define DEFAULT_MAC_NAME "HMAC"
 #define DEFAULT_FIPS_SECTION "fips_check_section"
 
 /* Configuration file values */
@@ -268,10 +267,12 @@ end:
 int fipsinstall_main(int argc, char **argv)
 {
     int ret = 1, verify = 0, gotkey = 0, gotdigest = 0;
+    const char *section_name = "fips_sect";
+    const char *mac_name = "HMAC";
+    const char *prov_name = "fips";
     BIO *module_bio = NULL, *mem_bio = NULL, *fout = NULL;
-    char *in_fname = NULL, *out_fname = NULL, *prog, *section_name = NULL;
-    char *prov_name = NULL, *module_fname = NULL;
-    static const char *mac_name = DEFAULT_MAC_NAME;
+    char *in_fname = NULL, *out_fname = NULL, *prog;
+    char *module_fname = NULL;
     EVP_MAC_CTX *ctx = NULL, *ctx2 = NULL;
     STACK_OF(OPENSSL_STRING) *opts = NULL;
     OPTION_CHOICE o;
@@ -283,7 +284,6 @@ int fipsinstall_main(int argc, char **argv)
     EVP_MAC *mac = NULL;
     CONF *conf = NULL;
 
-    section_name = DEFAULT_FIPS_SECTION;
     if ((opts = sk_OPENSSL_STRING_new_null()) == NULL)
         goto end;
 
@@ -345,7 +345,7 @@ opthelp:
     argc = opt_num_rest();
     if (module_fname == NULL
         || (verify && in_fname == NULL)
-        || (!verify && (out_fname == NULL || prov_name == NULL))
+        || (!verify && out_fname == NULL)
         || argc != 0)
         goto opthelp;
 

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -357,6 +357,7 @@ opthelp:
     /* Use the default FIPS HMAC digest and key if not specified. */
     if (!gotdigest && !sk_OPENSSL_STRING_push(opts, "digest:SHA256"))
         goto end;
+    /* Use the default FIPS HMAC key if not specified. */
     if (!gotkey && !sk_OPENSSL_STRING_push(opts, "hexkey:" FIPS_KEY_STRING))
         goto end;
 

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -22,7 +22,6 @@
 DEFINE_STACK_OF_STRING()
 
 #define BUFSIZE 4096
-#define DEFAULT_FIPS_SECTION "fips_check_section"
 
 /* Configuration file values */
 #define VERSION_KEY  "version"
@@ -357,7 +356,6 @@ opthelp:
     /* Use the default FIPS HMAC digest and key if not specified. */
     if (!gotdigest && !sk_OPENSSL_STRING_push(opts, "digest:SHA256"))
         goto end;
-    /* Use the default FIPS HMAC key if not specified. */
     if (!gotkey && !sk_OPENSSL_STRING_push(opts, "hexkey:" FIPS_KEY_STRING))
         goto end;
 

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -74,12 +74,12 @@ Verify that the input configuration file contains the correct information.
 =item B<-provider_name> I<providername>
 
 Name of the provider inside the configuration file.
-This must be specified.
+The default value is C<fips>.
 
 =item B<-section_name> I<sectionname>
 
 Name of the section inside the configuration file.
-This must be specified.
+The default value is C<fips_sect>.
 
 =item B<-mac_name> I<name>
 

--- a/test/recipes/30-test_acvp.t
+++ b/test/recipes/30-test_acvp.t
@@ -31,9 +31,7 @@ plan tests => 2;
 
 ok(run(app(['openssl', 'fipsinstall',
            '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-           '-module', $infile,
-           '-provider_name', 'fips',
-           '-section_name', 'fips_sect'])),
+           '-module', $infile])),
    "fipsinstall");
 
 ok(run(test(["acvp_test", "-config", srctop_file("test","fips.cnf")])),

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -84,9 +84,7 @@ unless ($no_fips) {
 
     ok(run(app(['openssl', 'fipsinstall',
                 '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile,
-                '-provider_name', 'fips',
-                '-section_name', 'fips_sect'])),
+                '-module', $infile])),
        "fipsinstall");
 }
 

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -21,6 +21,7 @@ use lib bldtop_dir('.');
 use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
+my $infile = bldtop_file('providers', platform->dso('fips'));
 
 my @types = ( "digest", "cipher" );
 
@@ -46,9 +47,7 @@ unless ($no_fips) {
     push @setups, {
         cmd     => app(['openssl', 'fipsinstall',
                         '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                        '-module', bldtop_file('providers', platform->dso('fips')),
-                        '-provider_name', 'fips',
-                        '-section_name', 'fips_sect']),
+                        '-module', $infile]),
         message => "fipsinstall"
     };
     push @testdata, (

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -25,6 +25,7 @@ use lib bldtop_dir('.');
 use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
+my $infile = bldtop_file('providers', platform->dso('fips'));
 
 $ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
 
@@ -117,9 +118,7 @@ my %skip = (
 unless ($no_fips) {
     ok(run(app(['openssl', 'fipsinstall',
                 '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips')),
-                '-provider_name', 'fips',
-                '-section_name', 'fips_sect'])),
+                '-module', $infile])),
        "fipsinstall");
 }
 

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -25,6 +25,8 @@ use lib bldtop_dir('.');
 use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
+my $infile = bldtop_file('providers', platform->dso('fips'));
+
 my ($no_rsa, $no_dsa, $no_dh, $no_ec, $no_psk,
     $no_ssl3, $no_tls1, $no_tls1_1, $no_tls1_2, $no_tls1_3,
     $no_dtls, $no_dtls1, $no_dtls1_2, $no_ct) =
@@ -85,9 +87,7 @@ plan tests =>
 unless ($no_fips) {
     ok(run(app(['openssl', 'fipsinstall',
                 '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips')),
-                '-provider_name', 'fips',
-                '-section_name', 'fips_sect'])),
+                '-module', $infile])),
        "fipsinstall");
 }
 

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -39,9 +39,7 @@ ok(run(test(["sslapitest", srctop_dir("test", "certs"),
 unless ($no_fips) {
     ok(run(app(['openssl', 'fipsinstall',
                 '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips')),
-                '-provider_name', 'fips',
-                '-section_name', 'fips_sect'])),
+                '-module', bldtop_file('providers', platform->dso('fips'))])),
        "fipsinstall");
 
     ok(run(test(["sslapitest", srctop_dir("test", "certs"),


### PR DESCRIPTION
This is based on #12335, but that's already got approval and I didn't want to restart the cycle.

This fixes the doc, and makes -section_name and and -provider_name be completely optional.
All tests except fipsinstall test now use those defaults.
