### PR TITLE
Refactor err codes

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -457,8 +457,8 @@ static void build_SYS_str_reasons(void)
         return;
     }
 
-    for (i = 1; i <= NUM_SYS_STR_REASONS; i++) {
-        ERR_STRING_DATA *str = &SYS_str_reasons[i - 1];
+    for (i = 0; i < NUM_SYS_STR_REASONS; i++) {
+        ERR_STRING_DATA *str = &SYS_str_reasons[i];
         int known_code = known_codes[i];
 
         str->error = err_pack(ERR_LIB_SYS, known_code);

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -209,10 +209,7 @@ static ossl_inline int ERR_GET_RFLAGS(int l)
 }
 static ossl_inline int ERR_GET_REASON(int l)
 {
-    int mask = ERR_REASON_MASK;
-    if (ERR_GET_LIB(l) == ERR_LIB_SYS)
-        mask |= ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET;
-    return l & mask;
+    return l & (ERR_REASON_MASK | (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET));
 }
 # define ERR_FATAL_ERROR(l) (int)((l) & ERR_RFLAG_FATAL)
 

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -108,7 +108,7 @@ static int raised_error(void)
     file = __FILE__;
     line = __LINE__ + 2; /* The error is generated on the ERR_raise_data line */
 #endif
-    ERR_raise_data(ERR_LIB_SYS, ERR_R_INTERNAL_ERROR,
+    ERR_raise_data(ERR_LIB_NONE, ERR_R_INTERNAL_ERROR,
                    "calling exit()");
     if (!TEST_ulong_ne(e = ERR_get_error_all(&f, &l, NULL, &data, NULL), 0)
             || !TEST_int_eq(ERR_GET_REASON(e), ERR_R_INTERNAL_ERROR)

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -26,7 +26,7 @@
 static int test_print_error_format(void)
 {
     static const char expected_format[] =
-        ":error::system library:%s:Operation not permitted:"
+        ":error::system library:%s:%s:"
 # ifndef OPENSSL_NO_FILENAMES
         "errtest.c:30:";
 # else
@@ -36,13 +36,15 @@ static int test_print_error_format(void)
     char *out = NULL, *p = NULL;
     int ret = 0, len;
     BIO *bio = NULL;
+    int code = EPERM;
 
-    BIO_snprintf(expected, sizeof(expected), expected_format, OPENSSL_FUNC);
+    BIO_snprintf(expected, sizeof(expected), expected_format,
+                 OPENSSL_FUNC, strerror(code));
 
     if (!TEST_ptr(bio = BIO_new(BIO_s_mem())))
         return 0;
 
-    ERR_PUT_error(ERR_LIB_SYS, 0, 1, "errtest.c", 30);
+    ERR_PUT_error(ERR_LIB_SYS, 0, code, "errtest.c", 30);
     ERR_print_errors(bio);
 
     if (!TEST_int_gt(len = BIO_get_mem_data(bio, &out), 0))


### PR DESCRIPTION
#12217 an #12276 taught us that errno codes aren't necessarily organised as a small sequential set of numbers.  In fact, POSIX stipulates that the macros should be used for the codes and that no other assumptions can be made.

We therefore need to rethink how we pack errno codes into our own `ERR_LIB_SYS` codes.  This may prove more dodgy than we can handle somewhere in the future, but for the moment, the changes made here are hopefully enough to handle what we currently know.

This change also deals with an overlap of `ERR_R_` codes (which has already appeared as strange error messages)

Finally, we change `test/errtest.c` to use `EPERM` instead of `1`.

Fixes #12217 
Fixes #12276 

-----

This is an alternative to #12289, using similar ideas for the codes.