### PR TITLE
doc: remove reference to the predecessor of SHA-1.

### DIFF
--- a/doc/man3/SHA256_Init.pod
+++ b/doc/man3/SHA256_Init.pod
@@ -79,9 +79,6 @@ SHA512_DIGEST_LENGTH). Also note that, as for the SHA1() function above, the
 SHA224(), SHA256(), SHA384() and SHA512() functions are not thread safe if
 B<md> is NULL.
 
-The predecessor of SHA-1, SHA, is also implemented, but it should be
-used only when backward compatibility is required.
-
 =head1 RETURN VALUES
 
 SHA1(), SHA224(), SHA256(), SHA384() and SHA512() return a pointer to the hash


### PR DESCRIPTION
Removal of stale documentation.

- [x] documentation is added or updated

Fixes #8407

