### PR TITLE
rand: detect if FIPS approved randomness sources are being used.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -446,6 +446,7 @@ on most unix-ish operating systems.
 ### egd
 
 Check for an entropy generating daemon.
+This source is ignored by the FIPS provider.
 
 ### rdcpu
 
@@ -454,11 +455,13 @@ Use the `RDSEED` or `RDRAND` command if provided by the CPU.
 ### librandom
 
 Use librandom (not implemented yet).
+This source is ignored by the FIPS provider.
 
 ### none
 
 Disable automatic seeding.  This is the default on some operating systems where
 no suitable entropy source exists, or no support for it is implemented yet.
+This option is ignored by the FIPS provider.
 
 For more information, see the section [Notes on random number generation][rng]
 at the end of this document.
@@ -1671,7 +1674,8 @@ The seeding method can be configured using the `--with-rand-seed` option,
 which can be used to specify a comma separated list of seed methods.
 However in most cases OpenSSL will choose a suitable default method,
 so it is not necessary to explicitly provide this option.  Note also
-that not all methods are available on all platforms.
+that not all methods are available on all platforms.  The FIPS provider will
+silently ignore seed sources that were not validated.
 
 I) On operating systems which provide a suitable randomness source (in
 form  of a system call or system device), OpenSSL will use the optimal

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -38,7 +38,7 @@
 #endif
 
 /*
- * Provide a compile time error if the FIPS module is being build and none
+ * Provide a compile time error if the FIPS module is being built and none
  * of the supported entropy sources are available.
  */
 #if defined(FIPS_MODULE)
@@ -49,10 +49,22 @@
 #  error FIPS mode without supported randomness source
 # endif
 /* Remove the sources that are not permitted in FIPS */
-# undef OPENSSL_RAND_SEED_LIBRANDOM
-# undef OPENSSL_RAND_SEED_RDTSC
-# undef OPENSSL_RAND_SEED_EGD
-# undef OPENSSL_RAND_SEED_NONE
+# ifdef OPENSSL_RAND_SEED_LIBRANDOM
+#  undef OPENSSL_RAND_SEED_LIBRANDOM
+#  warning FIPS mode does not support the _librandom_ randomness source
+# endif
+# ifdef OPENSSL_RAND_SEED_RDTSC
+#  undef OPENSSL_RAND_SEED_RDTSC
+#  warning FIPS mode does not support the _RDTSC_ randomness source
+# endif
+# ifdef OPENSSL_RAND_SEED_EGD
+#  undef OPENSSL_RAND_SEED_EGD
+#  warning FIPS mode does not support the _EGD_ randomness source
+# endif
+# ifdef OPENSSL_RAND_SEED_NONE
+#  undef OPENSSL_RAND_SEED_NONE
+#  warning FIPS mode does not support the _none_ randomness source
+# endif
 #endif
 
 #if (defined(OPENSSL_SYS_UNIX) && !defined(OPENSSL_SYS_VXWORKS)) \
@@ -715,7 +727,7 @@ size_t prov_pool_acquire_entropy(RAND_POOL *pool)
         return entropy_available;
 #   endif
 
-#   if defined(OPENSSL_RAND_SEED_EGD) && !defined(FIPS_MODULE)
+#   if defined(OPENSSL_RAND_SEED_EGD)
     {
         static const char *paths[] = { DEVRANDOM_EGD, NULL };
         size_t bytes_needed;


### PR DESCRIPTION
As mentioned in #12267, the EGD source doesn't build with FIPS enabled.

The only permitted sources for the FIPS provider are the operating system sources and RDRAND.  All other sources are not available in the FIPS module.

