### PR TITLE
Run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,7 @@ before_script:
           fi;
       fi
     - ./configdata.pm --dump
+    - export HARNESS_JOBS=${HARNESS_JOBS:-4}
     - cd $top
 
 script:

--- a/test/README.md
+++ b/test/README.md
@@ -114,15 +114,15 @@ starting with "test_ssl_":
 
 Run only test group 10:
 
-    $ make TESTS='10'
+    $ make TESTS='10' test
 
 Run all tests except the slow group (group 99):
 
-    $ make TESTS='-99'
+    $ make TESTS='-99' test
 
 Run all tests in test groups 80 to 99 except for tests in group 90:
 
-    $ make TESTS='[89]? -90'
+    $ make TESTS='[89]? -90' test
 
 To stochastically verify that the algorithm that produces uniformly distributed
 random numbers is operating correctly (with a false positive rate of 0.01%):

--- a/test/README.md
+++ b/test/README.md
@@ -134,10 +134,10 @@ Running Tests in Parallel
 
 By default the test harness will execute the selected tests sequentially.
 Depending on the platform characteristics, running more than one test job in
-parallel may speed up test execution. When desirable it is possible to run test
-jobs in parallel via the `HARNESS_JOBS` environment variable: its value should
-be set to the number (a positive integer equal or greater than 1) of maximum
-test jobs to run in parallel.
+parallel may speed up test execution.
+This can be requested by setting the `HARNESS_JOBS` environment variable to a
+positive integer value. This specifies the maximum number of test jobs to run in
+parallel.
 
 Depending on the Perl version different strategies could be adopted to select
 which test recipes can be run in parallel.  In recent versions of Perl, unless

--- a/test/README.md
+++ b/test/README.md
@@ -132,9 +132,12 @@ random numbers is operating correctly (with a false positive rate of 0.01%):
 Running Tests in Parallel
 -------------------------
 
-By default the test harness will execute the selected tests sequentially. When
-desirable it is possible to run test jobs in parallel via the `HARNESS_JOBS`
-environment variable.
+By default the test harness will execute the selected tests sequentially.
+Depending on the platform characteristics, running more than one test job in
+parallel may speed up test execution. When desirable it is possible to run test
+jobs in parallel via the `HARNESS_JOBS` environment variable: its value should
+be set to the number (a positive integer equal or greater than 1) of maximum
+test jobs to run in parallel.
 
 Depending on the Perl version different strategies could be adopted to select
 which test recipes can be run in parallel.  In recent versions of Perl, unless

--- a/test/README.md
+++ b/test/README.md
@@ -128,3 +128,19 @@ To stochastically verify that the algorithm that produces uniformly distributed
 random numbers is operating correctly (with a false positive rate of 0.01%):
 
     $ ./util/wrap.sh test/bntest -stochastic
+
+Running Tests in Parallel
+-------------------------
+
+By default the test harness will execute the selected tests sequentially. When
+desirable it is possible to run test jobs in parallel via the `HARNESS_JOBS`
+environment variable.
+
+Depending on the Perl version different strategies could be adopted to select
+which test recipes can be run in parallel.  In recent versions of Perl, unless
+specified otherwise, any task can be run in parallel. Consult the documentation
+for `TAP::Harness` to know more.
+
+To run up to four tests in parallel at any given time:
+
+    $ make HARNESS_JOBS=4 test

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -20,6 +20,11 @@ BEGIN {
         if $ENV{VERBOSE_FAILURES_PROGRESS} || $ENV{VFP};
 }
 
+# Support running jobs in parallel
+BEGIN {
+    $ENV{HARNESS_JOBS} = "4" if (!defined $ENV{HARNESS_JOBS});
+}
+
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
 use File::Basename;
 use FindBin;
@@ -42,6 +47,7 @@ my %tapargs =
       lib               => [ $libdir ],
       switches          => '-w',
       merge             => 1,
+      jobs              => $ENV{HARNESS_JOBS},
     );
 
 # Additional OpenSSL special TAP arguments.  Because we can't pass them via

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -20,11 +20,6 @@ BEGIN {
         if $ENV{VERBOSE_FAILURES_PROGRESS} || $ENV{VFP};
 }
 
-# Support running jobs in parallel
-BEGIN {
-    $ENV{HARNESS_JOBS} = "4" if (!defined $ENV{HARNESS_JOBS});
-}
-
 use File::Spec::Functions qw/catdir catfile curdir abs2rel rel2abs/;
 use File::Basename;
 use FindBin;

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -35,6 +35,7 @@ my $srctop = $ENV{SRCTOP} || $ENV{TOP};
 my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
+my $jobs = $ENV{HARNESS_JOBS};
 
 $ENV{OPENSSL_CONF} = rel2abs(catdir($srctop, "apps", "openssl.cnf"));
 $ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "providers"));
@@ -47,8 +48,9 @@ my %tapargs =
       lib               => [ $libdir ],
       switches          => '-w',
       merge             => 1,
-      jobs              => $ENV{HARNESS_JOBS},
     );
+
+$tapargs{jobs} = $jobs if defined $jobs;
 
 # Additional OpenSSL special TAP arguments.  Because we can't pass them via
 # TAP::Harness->new(), they will be accessed directly, see the


### PR DESCRIPTION
The environment variable `HARNESS_JOBS` can be used to control how many
jobs to run in parallel. It defaults to 4.

This commit does not define custom `rules`, and different versions of
`TAP::Harness` come with different strategies regarding the default
`rules` that define which test recipes can be run in parallel.
In recent versions of Perl, unless specified otherwise any task can be
run in parallel.


##### Checklist
- [x] tests are added or updated
