### PR TITLE
also zero pad DHE public key in ClientKeyExchange message for interop

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3095,13 +3095,13 @@ static int tls_construct_cke_dhe(SSL *s, WPACKET *pkt)
      * stack, we need to zero pad the DHE pub key to the same length
      * as the prime, so use the length of the prime here.
      */
-    if (!WPACKET_sub_allocate_bytes_u16(pkt, prime_len, &keybytes)) {
+    if (!WPACKET_sub_allocate_bytes_u16(pkt, prime_len, &keybytes)
+            || BN_bn2binpad(DH_get0_pub_key(dh_clnt), keybytes, prime_len) < 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_DHE,
                  ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
-    BN_bn2binpad(DH_get0_pub_key(dh_clnt), keybytes, prime_len);
     EVP_PKEY_free(ckey);
 
     return 1;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3059,7 +3059,7 @@ static int tls_construct_cke_dhe(SSL *s, WPACKET *pkt)
     DH *dh_clnt = NULL;
     EVP_PKEY *ckey = NULL, *skey = NULL;
     unsigned char *keybytes = NULL;
-    int np;
+    int prime_len;
 
     skey = s->s3.peer_tmp;
     if (skey == NULL) {
@@ -3089,19 +3089,19 @@ static int tls_construct_cke_dhe(SSL *s, WPACKET *pkt)
     }
 
     /* send off the data */
-    np = BN_num_bytes(DH_get0_p(dh_clnt));
+    prime_len = BN_num_bytes(DH_get0_p(dh_clnt));
     /*
-     * for interoperability with some versions of the Microsoft TLS
+     * For interoperability with some versions of the Microsoft TLS
      * stack, we need to zero pad the DHE pub key to the same length
-     * as the prime, so use the length of the prime here
+     * as the prime, so use the length of the prime here.
      */
-    if (!WPACKET_sub_allocate_bytes_u16(pkt, np, &keybytes)) {
+    if (!WPACKET_sub_allocate_bytes_u16(pkt, prime_len, &keybytes)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_CONSTRUCT_CKE_DHE,
                  ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
-    BN_bn2binpad(DH_get0_pub_key(dh_clnt), keybytes, np);
+    BN_bn2binpad(DH_get0_pub_key(dh_clnt), keybytes, prime_len);
     EVP_PKEY_free(ckey);
 
     return 1;


### PR DESCRIPTION
The Windows SChannel TLS stack has problems when the DHE pub key is encoded with fewer bytes than the DHE prime.

In https://github.com/openssl/openssl/pull/1320 padding has already been added to work around this problem for the OpenSSL _server_ case, and I experimented a little and Microsoft seems to have also fixed this in their _client_ code.

I guess that OpenSSL server <-> windows client is the more common case, but the opposite case still causes handshakes to randomly fail when a DHE suite is selected. By adding padding for the OpenSSL client key exchange I hope to fix that.

This is my first contribution to OpenSSL, I tried to follow the style guide and conventions. Any corrections are much appreciated.