### PR TITLE
Fix build issue in generated fipskey.h when building with c++

### DIFF
--- a/include/openssl/fipskey.h.in
+++ b/include/openssl/fipskey.h.in
@@ -27,4 +27,8 @@ extern "C" {
  */
 #define FIPS_KEY_STRING "{- $config{FIPSKEY} -}"
 
+# ifdef  __cplusplus
+}
+# endif
+
 #endif


### PR DESCRIPTION
When configuring/building with these options the compile fails due to a missing closing brace in fipskey.h:

./Configure no-deprecated enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE

