### PR TITLE
util/perl/OpenSSL/config.pm: Fix /armv[7-9].*-.*-linux2/

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -621,7 +621,6 @@ EOF
       ],
       [ 'armv[1-3].*-.*-linux2',  { target => "linux-generic32" } ],
       [ 'armv[7-9].*-.*-linux2',  { target => "linux-armv4",
-                                    defines => [ 'B_ENDIAN' ],
                                     cflags => [ '-march=armv7-a' ],
                                     cxxflags => [ '-march=armv7-a' ] } ],
       [ 'arm.*-.*-linux2',        { target => "linux-armv4" } ],


### PR DESCRIPTION
This entry added the macro B_ENDIAN when it shouldn't have.

Fixes #12332
