### PR TITLE
Configure: Check source and build dir equality a little more thoroughly

### DIFF
--- a/Configure
+++ b/Configure
@@ -242,8 +242,10 @@ my $blddir = catdir(absolutedir("."));         # catdir ensures local syntax
 # File::Spec::Unix doesn't detect case insensitivity, so we make sure to
 # check if the source and build directory are really the same, and make
 # them so.  This avoids all kinds of confusion later on.
+# We must check @File::Spec::ISA rather than using File::Spec->isa() to
+# know if File::Spec ended up loading File::Spec::Unix.
 $srcdir = $blddir
-    if (File::Spec->isa('File::Spec::Unix')
+    if (grep(/::Unix$/, @File::Spec::ISA)
         && samedir($srcdir, $blddir));
 
 my $dofile = abs2rel(catfile($srcdir, "util/dofile.pl"));

--- a/Configure
+++ b/Configure
@@ -238,6 +238,14 @@ sub resolve_config;
 # Unified build supports separate build dir
 my $srcdir = catdir(absolutedir(dirname($0))); # catdir ensures local syntax
 my $blddir = catdir(absolutedir("."));         # catdir ensures local syntax
+
+# File::Spec::Unix doesn't detect case insensitivity, so we make sure to
+# check if the source and build directory are really the same, and make
+# them so.  This avoids all kinds of confusion later on.
+$srcdir = $blddir
+    if (File::Spec->isa('File::Spec::Unix')
+        && samedir($srcdir, $blddir));
+
 my $dofile = abs2rel(catfile($srcdir, "util/dofile.pl"));
 
 my $local_config_envname = 'OPENSSL_LOCAL_CONFIG_DIR';
@@ -3247,6 +3255,30 @@ sub absolutedir {
     use Cwd qw/realpath/;
 
     return realpath($dir);
+}
+
+# Check if all paths are one and the same, using stat.  They must both exist
+# We need this for the cases when File::Spec doesn't detect case insensitivity
+# (File::Spec::Unix assumes case sensitivity)
+sub samedir {
+    my @stat;
+
+    foreach (@_) {
+        die "$_ doesn't exist" unless -e $_;
+
+        my @stat2 = stat($_);
+        unless (@stat) {
+            @stat = @stat2;
+            next;
+        }
+
+        # Compare device number
+        return 0 unless ($stat[0] == $stat2[0]);
+        # Compare "inode".  The perl manual recommends comparing as
+        # string rather than as number.
+        return 0 unless ($stat[1] eq $stat2[1]);
+    }
+    return 1;                   # All the same
 }
 
 sub quotify {

--- a/Configure
+++ b/Configure
@@ -250,8 +250,8 @@ my $dofile = abs2rel(catfile($srcdir, "util/dofile.pl"));
 
 my $local_config_envname = 'OPENSSL_LOCAL_CONFIG_DIR';
 
-$config{sourcedir} = abs2rel($srcdir);
-$config{builddir} = abs2rel($blddir);
+$config{sourcedir} = abs2rel($srcdir, $blddir);
+$config{builddir} = abs2rel($blddir, $blddir);
 # echo -n 'holy hand grenade of antioch' | openssl sha256
 $config{FIPSKEY} =
     'f4556650ac31d35461610bac4ed81b1a181b2d8a43ea2854cbae22ca74560813';
@@ -3261,23 +3261,20 @@ sub absolutedir {
 # We need this for the cases when File::Spec doesn't detect case insensitivity
 # (File::Spec::Unix assumes case sensitivity)
 sub samedir {
-    my @stat;
+    die "samedir expects two arguments\n" unless scalar @_ == 2;
 
-    foreach (@_) {
-        die "$_ doesn't exist" unless -e $_;
+    my @stat0 = stat($_[0]);    # First argument
+    my @stat1 = stat($_[1]);    # Second argument
 
-        my @stat2 = stat($_);
-        unless (@stat) {
-            @stat = @stat2;
-            next;
-        }
+    die "Couldn't stat $_[0]" unless @stat0;
+    die "Couldn't stat $_[1]" unless @stat1;
 
-        # Compare device number
-        return 0 unless ($stat[0] == $stat2[0]);
-        # Compare "inode".  The perl manual recommends comparing as
-        # string rather than as number.
-        return 0 unless ($stat[1] eq $stat2[1]);
-    }
+    # Compare device number
+    return 0 unless ($stat0[0] == $stat1[0]);
+    # Compare "inode".  The perl manual recommends comparing as
+    # string rather than as number.
+    return 0 unless ($stat0[1] eq $stat1[1]);
+
     return 1;                   # All the same
 }
 


### PR DESCRIPTION
'absolutedir' does a thorough job ensuring that we have a "real" path
to both source and build directory, unencumbered by symbolic links.
However, that isn't enough on case insensitive file systems on Unix
flavored platforms, where it's possible to stand in, for example,
/PATH/TO/Work/openssl, and then do this:

    perl ../../work/openssl/Configure

... and thereby having it look like the source directory and the build
directory aren't the same.

We solve this by having a closer look at the computed source and build
directories, and making sure they are exactly the same strings if they
are in fact the same directory.

This is especially important when making symbolic links based on this
directories, but may have other ramifications as well.

Fixes #12323
