### PR TITLE
Fix a typo in the i2d_TYPE_fp documentation

### DIFF
--- a/doc/man3/d2i_X509.pod
+++ b/doc/man3/d2i_X509.pod
@@ -453,7 +453,7 @@ the encoding of the structure I<a> to BIO I<bp> and it
 returns 1 for success and 0 for failure.
 
 B<i2d_I<TYPE>_fp>() is similar to B<i2d_I<TYPE>>() except it writes
-the encoding of the structure I<a> to BIO I<bp> and it
+the encoding of the structure I<a> to FILE pointer I<fp> and it
 returns 1 for success and 0 for failure.
 
 These routines do not encrypt private keys and therefore offer no


### PR DESCRIPTION
Thanks to Michael Mueller on the openssl-users list for the suggested
improvement.

