### PR TITLE
Refactor ERR codes 2 (without the Hurd specific bits)

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -187,7 +187,6 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
  * codes.
  */
 # define NUM_SYS_STR_REASONS 255
-static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
 
 /*
  * Russian and Ukrainian locales on Linux required more than 6,5 kB for the
@@ -195,11 +194,12 @@ static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
  * We defined the string space to be 8 KiB at the time.  Now that we double
  * the range, we double the string space.
  */
-# define SPACE_SYS_STR_REASONS 16 * 1024
+# define SPACE_SYS_STR_REASONS (16 * 1024)
 
 static void build_SYS_str_reasons(void)
 {
     /* OPENSSL_malloc cannot be used here, use static storage instead */
+    static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
     static char strerror_pool[SPACE_SYS_STR_REASONS];
     char *cur = strerror_pool;
     size_t cnt = 0;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -174,20 +174,28 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 }
 
 #ifndef OPENSSL_NO_ERR
-/* 2019-05-21: Russian and Ukrainian locales on Linux require more than 6,5 kB */
-# define SPACE_SYS_STR_REASONS 8 * 1024
-# define NUM_SYS_STR_REASONS 127
-
-static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
 /*
- * SYS_str_reasons is filled with copies of strerror() results at
- * initialization. 'errno' values up to 127 should cover all usual errors,
- * others will be displayed numerically by ERR_error_string. It is crucial
- * that we have something for each reason code that occurs in
+ * SYS_str_reasons is filled with pointers to copies of strerror() results
+ * at initialization. Although POSIX permits 'errno' to have any positive
+ * number that fits in an 'int', most systems use a range starting at 1,
+ * and the highest number we have observed is well below 255, which is
+ * our current upper limit.  Other codes will be displayed numerically
+ * by ERR_error_string.
+ * It is crucial that we have something for each reason code that occurs in
  * ERR_str_reasons, or bogus reason strings will be returned for SYSerr(),
  * which always gets an errno value and never one of those 'standard' reason
  * codes.
  */
+# define NUM_SYS_STR_REASONS 255
+static ERR_STRING_DATA SYS_str_reasons[NUM_SYS_STR_REASONS + 1];
+
+/*
+ * Russian and Ukrainian locales on Linux required more than 6,5 kB for the
+ * errno range 1..127 (observed 2019-05-21).
+ * We defined the string space to be 8 KiB at the time.  Now that we double
+ * the range, we double the string space.
+ */
+# define SPACE_SYS_STR_REASONS 16 * 1024
 
 static void build_SYS_str_reasons(void)
 {

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -504,6 +504,12 @@ void ERR_error_string_n(unsigned long e, char *buf, size_t len)
         ls = lsbuf;
     }
 
+    /*
+     * ERR_reason_error_string() can't safely return system error strings,
+     * since it would call openssl_strerror_r(), which needs a buffer for
+     * thread safety.  So for system errors, we call openssl_strerror_r()
+     * directly instead.
+     */
     r = ERR_GET_REASON(e);
     if (ERR_SYSTEM_ERROR(e)) {
         if (openssl_strerror_r(r, rsbuf, sizeof(rsbuf)))
@@ -568,6 +574,11 @@ const char *ERR_reason_error_string(unsigned long e)
         return NULL;
     }
 
+    /*
+     * ERR_reason_error_string() can't safely return system error strings,
+     * since openssl_strerror_r() needs a buffer for thread safety, and we
+     * haven't got one that would serve any sensible purpose.
+     */
     if (ERR_SYSTEM_ERROR(e))
         return NULL;
 

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -38,7 +38,10 @@ static ossl_inline void err_clear_data(ERR_STATE *es, size_t i, int deall)
 static ossl_inline void err_set_error(ERR_STATE *es, size_t i,
                                       int lib, int reason)
 {
-    es->err_buffer[i] = ERR_PACK(lib, 0, reason);
+    es->err_buffer[i] =
+        lib == ERR_LIB_SYS
+        ? (unsigned int)(ERR_SYSTEM_FLAG |  reason)
+        : ERR_PACK(lib, 0, reason);
 }
 
 static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -33,12 +33,20 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
         unsigned long r = ERR_GET_REASON(l);
 
         lib = ERR_lib_error_string(l);
+
+        /*
+         * ERR_reason_error_string() can't safely return system error strings,
+         * since it would call openssl_strerror_r(), which needs a buffer for
+         * thread safety.  So for system errors, we call openssl_strerror_r()
+         * directly instead.
+         */
         if (ERR_SYSTEM_ERROR(l)) {
             if (openssl_strerror_r(r, rsbuf, sizeof(rsbuf)))
                 reason = rsbuf;
         } else {
             reason = ERR_reason_error_string(l);
         }
+
         if (func == NULL)
             func = "unknown function";
         if (reason == NULL) {

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -23,16 +23,28 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
 {
     CRYPTO_THREAD_ID tid = CRYPTO_THREAD_get_current_id();
     unsigned long l;
-    char buf[ERR_PRINT_BUF_SIZE], *hex;
-    const char *lib, *reason;
     const char *file, *data, *func;
     int line, flags;
 
     while ((l = ERR_get_error_all(&file, &line, &func, &data, &flags)) != 0) {
+        char buf[ERR_PRINT_BUF_SIZE], *hex;
+        const char *lib, *reason = NULL;
+        char rsbuf[256];
+        unsigned long r = ERR_GET_REASON(l);
+
         lib = ERR_lib_error_string(l);
-        reason = ERR_reason_error_string(l);
+        if (ERR_SYSTEM_ERROR(l)) {
+            if (openssl_strerror_r(r, rsbuf, sizeof(rsbuf)))
+                reason = rsbuf;
+        } else {
+            reason = ERR_reason_error_string(l);
+        }
         if (func == NULL)
             func = "unknown function";
+        if (reason == NULL) {
+            BIO_snprintf(rsbuf, sizeof(rsbuf), "reason(%lu)", r);
+            reason = rsbuf;
+        }
         if ((flags & ERR_TXT_STRING) == 0)
             data = "";
         hex = openssl_buf2hexstr_sep((const unsigned char *)&tid, sizeof(tid),

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -195,51 +195,52 @@ struct err_state_st {
  */
 
 /* Macros to help decode recorded system errors */
-# define ERR_SYSTEM_FLAG        (1UL << (sizeof(unsigned int) * CHAR_BIT - 1))
-# define ERR_SYSTEM_MASK        (ERR_SYSTEM_FLAG - 1)
+# define ERR_SYSTEM_FLAG                ((unsigned int)INT_MAX + 1)
+# define ERR_SYSTEM_MASK                ((unsigned int)INT_MAX)
 
 /* Macros to help decode recorded OpenSSL errors */
-# define ERR_LIB_OFFSET         23L
-# define ERR_LIB_MASK           0xFF
-# define ERR_RFLAGS_OFFSET      19L
-# define ERR_RFLAGS_MASK        0xF
-# define ERR_REASON_MASK        0X7FFFFF
+# define ERR_LIB_OFFSET                 23L
+# define ERR_LIB_MASK                   0xFF
+# define ERR_RFLAGS_OFFSET              19L
+# define ERR_RFLAGS_MASK                0xF
+# define ERR_REASON_MASK                0X7FFFFF
 
 /*
  * Reason flags are defined pre-shifted to easily combine with the reason
  * number.
  */
-# define ERR_RFLAG_FATAL        (0x1 << ERR_RFLAGS_OFFSET)
+# define ERR_RFLAG_FATAL                (0x1 << ERR_RFLAGS_OFFSET)
 
-# define ERR_SYSTEM_ERROR(l)    (((l) & ERR_SYSTEM_FLAG) != 0)
+# define ERR_SYSTEM_ERROR(errcode)      (((errcode) & ERR_SYSTEM_FLAG) != 0)
 
-# define ERR_GET_LIB(l)                                         \
-    (int)(ERR_SYSTEM_ERROR(l)                                   \
+# define ERR_GET_LIB(errcode)                                   \
+    (int)(ERR_SYSTEM_ERROR(errcode)                             \
           ? ERR_LIB_SYS                                         \
-          : ((l) >> ERR_LIB_OFFSET) & ERR_LIB_MASK)
-# define ERR_GET_FUNC(l)        0
-# define ERR_GET_RFLAGS(l)                                      \
-    (int)(ERR_SYSTEM_ERROR(l)                                   \
+          : ((errcode) >> ERR_LIB_OFFSET) & ERR_LIB_MASK)
+# define ERR_GET_FUNC(errcode)        0
+# define ERR_GET_RFLAGS(errcode)                                \
+    (int)(ERR_SYSTEM_ERROR(errcode)                             \
           ? 0                                                   \
-          : (l) & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET))
-# define ERR_GET_REASON(l)                                      \
-    (int)(ERR_SYSTEM_ERROR(l)                                   \
-          ? (l) & ERR_SYSTEM_MASK                               \
-          : (l) & ERR_REASON_MASK)
+          : (errcode) & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET))
+# define ERR_GET_REASON(errcode)                                \
+    (int)(ERR_SYSTEM_ERROR(errcode)                             \
+          ? (errcode) & ERR_SYSTEM_MASK                         \
+          : (errcode) & ERR_REASON_MASK)
 
-# define ERR_FATAL_ERROR(l)                                     \
-    (int)(ERR_SYSTEM_ERROR(l)                                   \
-          ? (l) & 0                                             \
-          : (l) & ERR_RFLAG_FATAL)
+# define ERR_FATAL_ERROR(errcode)                               \
+    (int)(ERR_SYSTEM_ERROR(errcode)                             \
+          ? (errcode) & 0                                       \
+          : (errcode) & ERR_RFLAG_FATAL)
 
 /*
  * ERR_PACK is a helper macro to properly pack OpenSSL error codes and may
  * only be used for that purpose.  System errors are packed internally.
+ * ERR_PACK takes reason flags and reason code combined in |reason|.
+ * ERR_PACK ignores |func|, that parameter is just legacy from pre-3.0 OpenSSL.
  */
-/* ERR_PACK takes reason flags and reason code combined in |r| */
-# define ERR_PACK(l,f,r)                                                \
-    ( (((unsigned int)(l) & ERR_LIB_MASK) << ERR_LIB_OFFSET) |          \
-      (((unsigned int)(r) & ERR_REASON_MASK)) )
+# define ERR_PACK(lib,func,reason)                                      \
+    ( (((unsigned long)(lib)    & ERR_LIB_MASK   ) << ERR_LIB_OFFSET) | \
+      (((unsigned long)(reason) & ERR_REASON_MASK)) )
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define SYS_F_FOPEN             0

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -213,24 +213,36 @@ struct err_state_st {
 
 # define ERR_SYSTEM_ERROR(errcode)      (((errcode) & ERR_SYSTEM_FLAG) != 0)
 
-# define ERR_GET_LIB(errcode)                                   \
-    (int)(ERR_SYSTEM_ERROR(errcode)                             \
-          ? ERR_LIB_SYS                                         \
-          : ((errcode) >> ERR_LIB_OFFSET) & ERR_LIB_MASK)
-# define ERR_GET_FUNC(errcode)        0
-# define ERR_GET_RFLAGS(errcode)                                \
-    (int)(ERR_SYSTEM_ERROR(errcode)                             \
-          ? 0                                                   \
-          : (errcode) & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET))
-# define ERR_GET_REASON(errcode)                                \
-    (int)(ERR_SYSTEM_ERROR(errcode)                             \
-          ? (errcode) & ERR_SYSTEM_MASK                         \
-          : (errcode) & ERR_REASON_MASK)
+static ossl_inline int ERR_GET_LIB(unsigned long errcode)
+{
+    if (ERR_SYSTEM_ERROR(errcode))
+        return ERR_LIB_SYS;
+    return (errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK;
+}
 
-# define ERR_FATAL_ERROR(errcode)                               \
-    (int)(ERR_SYSTEM_ERROR(errcode)                             \
-          ? (errcode) & 0                                       \
-          : (errcode) & ERR_RFLAG_FATAL)
+static ossl_inline int ERR_GET_FUNC(unsigned long errcode)
+{
+    return 0;
+}
+
+static ossl_inline int ERR_GET_RFLAGS(unsigned long errcode)
+{
+    if (ERR_SYSTEM_ERROR(errcode))
+        return 0;
+    return errcode & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET);
+}
+
+static ossl_inline int ERR_GET_REASON(unsigned long errcode)
+{
+    if (ERR_SYSTEM_ERROR(errcode))
+        return errcode & ERR_SYSTEM_MASK;
+    return errcode & ERR_REASON_MASK;
+}
+
+static ossl_inline int ERR_FATAL_ERROR(unsigned long errcode)
+{
+    return (ERR_GET_RFLAGS(errcode) & ERR_RFLAG_FATAL) != 0;
+}
 
 /*
  * ERR_PACK is a helper macro to properly pack OpenSSL error codes and may

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -163,14 +163,43 @@ struct err_state_st {
 #  define X509err(f, r) ERR_raise_data(ERR_LIB_X509, (r), NULL)
 # endif
 
-# define ERR_PACK(l,f,r) ( \
-        (((unsigned int)(l) & 0x0FF) << 24L) | \
-        (((unsigned int)(f) & 0xFFF) << 12L) | \
-        (((unsigned int)(r) & 0xFFF)       ) )
-# define ERR_GET_LIB(l)          (int)(((l) >> 24L) & 0x0FFL)
-# define ERR_GET_FUNC(l)         (int)(((l) >> 12L) & 0xFFFL)
-# define ERR_GET_REASON(l)       (int)( (l)         & 0xFFFL)
-# define ERR_FATAL_ERROR(l)      (int)( (l)         & ERR_R_FATAL)
+/*
+ * The error code currently packs as follows (viewed as hex nibbles):
+ *
+ * LL rRRRRR
+ *
+ * Where LL is the library code, r is the reason flags, and rRRRRR is the
+ * reason code.
+ * Do note that the reason flags is part of the reason code, and could as
+ * well be seen as a section of all possible reason codes.  We do this for
+ * backward compatibility reasons, i.e. how ERR_R_FATAL was implemented.
+ *
+ * System errors (ERR_LIB_SYS) are structured the same way, except they
+ * don't have any reason flag.
+ *
+ * LL RRRRRR
+ */
+# define ERR_LIB_OFFSET     24L
+# define ERR_LIB_MASK       0xFF
+# define ERR_RFLAGS_OFFSET  20L
+# define ERR_RFLAGS_MASK    0xF
+# define ERR_REASON_MASK    0XFFFFFF
+
+/*
+ * Reason flags are defined pre-shifted to easily combine with the reason
+ * number.
+ */
+# define ERR_RFLAG_FATAL    (0x1 << ERR_RFLAGS_OFFSET)
+
+/* ERR_PACK takes reason flags and reason code combined in |r| */
+# define ERR_PACK(l,f,r)                                                \
+    ( (((unsigned int)(l) & ERR_LIB_MASK) << ERR_LIB_OFFSET) |          \
+      (((unsigned int)(r) & ERR_REASON_MASK)) )
+# define ERR_GET_LIB(l)     (int)(((l) >> ERR_LIB_OFFSET) & ERR_LIB_MASK)
+# define ERR_GET_FUNC(l)    0
+# define ERR_GET_RFLAGS(l)  (int)((l) & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET))
+# define ERR_GET_REASON(l)  (int)((l) & ERR_REASON_MASK)
+# define ERR_FATAL_ERROR(l) (int)((l) & ERR_RFLAG_FATAL)
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define SYS_F_FOPEN             0
@@ -200,7 +229,7 @@ struct err_state_st {
 #  define SYS_F_SENDFILE          0
 # endif
 
-/* reasons */
+/* "we came from here" global reason codes, range 1..63 */
 # define ERR_R_SYS_LIB   ERR_LIB_SYS/* 2 */
 # define ERR_R_BN_LIB    ERR_LIB_BN/* 3 */
 # define ERR_R_RSA_LIB   ERR_LIB_RSA/* 4 */
@@ -221,21 +250,26 @@ struct err_state_st {
 # define ERR_R_ECDSA_LIB ERR_LIB_ECDSA/* 42 */
 # define ERR_R_OSSL_STORE_LIB ERR_LIB_OSSL_STORE/* 44 */
 
-# define ERR_R_NESTED_ASN1_ERROR                 58
-# define ERR_R_MISSING_ASN1_EOS                  63
-
-/* fatal error */
-# define ERR_R_FATAL                             64
-# define ERR_R_MALLOC_FAILURE                    (1|ERR_R_FATAL)
-# define ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED       (2|ERR_R_FATAL)
-# define ERR_R_PASSED_NULL_PARAMETER             (3|ERR_R_FATAL)
-# define ERR_R_INTERNAL_ERROR                    (4|ERR_R_FATAL)
-# define ERR_R_DISABLED                          (5|ERR_R_FATAL)
-# define ERR_R_INIT_FAIL                         (6|ERR_R_FATAL)
-# define ERR_R_PASSED_INVALID_ARGUMENT           (7)
-# define ERR_R_OPERATION_FAIL                    (8|ERR_R_FATAL)
-# define ERR_R_INVALID_PROVIDER_FUNCTIONS        (9|ERR_R_FATAL)
-# define ERR_R_INTERRUPTED_OR_CANCELLED          (10)
+/*
+ * global reason codes, range 64..99 (sub-system specific codes start at 100)
+ *
+ * ERR_R_FATAL had dual purposes in pre-3.0 OpenSSL, as a standalone reason
+ * code as well as a fatal flag.  This is still possible to do, as 2**6 (64)
+ * is present in the whole range of global reason codes.
+ */
+# define ERR_R_FATAL                             (64|ERR_RFLAG_FATAL)
+# define ERR_R_MALLOC_FAILURE                    (65|ERR_RFLAG_FATAL)
+# define ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED       (66|ERR_RFLAG_FATAL)
+# define ERR_R_PASSED_NULL_PARAMETER             (67|ERR_RFLAG_FATAL)
+# define ERR_R_INTERNAL_ERROR                    (68|ERR_RFLAG_FATAL)
+# define ERR_R_DISABLED                          (69|ERR_RFLAG_FATAL)
+# define ERR_R_INIT_FAIL                         (70|ERR_RFLAG_FATAL)
+# define ERR_R_PASSED_INVALID_ARGUMENT           (71)
+# define ERR_R_OPERATION_FAIL                    (72|ERR_RFLAG_FATAL)
+# define ERR_R_INVALID_PROVIDER_FUNCTIONS        (73|ERR_RFLAG_FATAL)
+# define ERR_R_INTERRUPTED_OR_CANCELLED          (74)
+# define ERR_R_NESTED_ASN1_ERROR                 (76)
+# define ERR_R_MISSING_ASN1_EOS                  (77)
 
 /*
  * 99 is the maximum possible ERR_R_... code, higher values are reserved for

--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -39,6 +39,7 @@ extern "C" {
 #  endif
 # endif
 
+# include <limits.h>
 # include <errno.h>
 
 # define ERR_TXT_MALLOCED        0x01
@@ -163,43 +164,82 @@ struct err_state_st {
 #  define X509err(f, r) ERR_raise_data(ERR_LIB_X509, (r), NULL)
 # endif
 
-/*
- * The error code currently packs as follows (viewed as hex nibbles):
+/*-
+ * The error code packs differently depending on if it records a system
+ * error or an OpenSSL error.
  *
- * LL rRRRRR
+ * A system error packs like this (we follow POSIX and only allow positive
+ * numbers that fit in an |int|):
  *
- * Where LL is the library code, r is the reason flags, and rRRRRR is the
- * reason code.
- * Do note that the reason flags is part of the reason code, and could as
- * well be seen as a section of all possible reason codes.  We do this for
+ * +-+-------------------------------------------------------------+
+ * |1|                     system error number                     |
+ * +-+-------------------------------------------------------------+
+ *
+ * An OpenSSL error packs like this:
+ *
+ * <---------------------------- 32 bits -------------------------->
+ *    <--- 8 bits ---><------------------ 23 bits ----------------->
+ * +-+---------------+---------------------------------------------+
+ * |0|    library    |                    reason                   |
+ * +-+---------------+---------------------------------------------+
+ *
+ * A few of the reason bits are reserved as flags with special meaning:
+ *
+ *                    <4 bits><-------------- 19 bits ------------->
+ *                   +-------+-------------------------------------+
+ *                   | rflags|                reason               |
+ *                   +-------+-------------------------------------+
+ *
+ * We have the reason flags being part of the overall reason code for
  * backward compatibility reasons, i.e. how ERR_R_FATAL was implemented.
- *
- * System errors (ERR_LIB_SYS) are structured the same way, except they
- * don't have any reason flag.
- *
- * LL RRRRRR
  */
-# define ERR_LIB_OFFSET     24L
-# define ERR_LIB_MASK       0xFF
-# define ERR_RFLAGS_OFFSET  20L
-# define ERR_RFLAGS_MASK    0xF
-# define ERR_REASON_MASK    0XFFFFFF
+
+/* Macros to help decode recorded system errors */
+# define ERR_SYSTEM_FLAG        (1UL << (sizeof(unsigned int) * CHAR_BIT - 1))
+# define ERR_SYSTEM_MASK        (ERR_SYSTEM_FLAG - 1)
+
+/* Macros to help decode recorded OpenSSL errors */
+# define ERR_LIB_OFFSET         23L
+# define ERR_LIB_MASK           0xFF
+# define ERR_RFLAGS_OFFSET      19L
+# define ERR_RFLAGS_MASK        0xF
+# define ERR_REASON_MASK        0X7FFFFF
 
 /*
  * Reason flags are defined pre-shifted to easily combine with the reason
  * number.
  */
-# define ERR_RFLAG_FATAL    (0x1 << ERR_RFLAGS_OFFSET)
+# define ERR_RFLAG_FATAL        (0x1 << ERR_RFLAGS_OFFSET)
 
+# define ERR_SYSTEM_ERROR(l)    (((l) & ERR_SYSTEM_FLAG) != 0)
+
+# define ERR_GET_LIB(l)                                         \
+    (int)(ERR_SYSTEM_ERROR(l)                                   \
+          ? ERR_LIB_SYS                                         \
+          : ((l) >> ERR_LIB_OFFSET) & ERR_LIB_MASK)
+# define ERR_GET_FUNC(l)        0
+# define ERR_GET_RFLAGS(l)                                      \
+    (int)(ERR_SYSTEM_ERROR(l)                                   \
+          ? 0                                                   \
+          : (l) & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET))
+# define ERR_GET_REASON(l)                                      \
+    (int)(ERR_SYSTEM_ERROR(l)                                   \
+          ? (l) & ERR_SYSTEM_MASK                               \
+          : (l) & ERR_REASON_MASK)
+
+# define ERR_FATAL_ERROR(l)                                     \
+    (int)(ERR_SYSTEM_ERROR(l)                                   \
+          ? (l) & 0                                             \
+          : (l) & ERR_RFLAG_FATAL)
+
+/*
+ * ERR_PACK is a helper macro to properly pack OpenSSL error codes and may
+ * only be used for that purpose.  System errors are packed internally.
+ */
 /* ERR_PACK takes reason flags and reason code combined in |r| */
 # define ERR_PACK(l,f,r)                                                \
     ( (((unsigned int)(l) & ERR_LIB_MASK) << ERR_LIB_OFFSET) |          \
       (((unsigned int)(r) & ERR_REASON_MASK)) )
-# define ERR_GET_LIB(l)     (int)(((l) >> ERR_LIB_OFFSET) & ERR_LIB_MASK)
-# define ERR_GET_FUNC(l)    0
-# define ERR_GET_RFLAGS(l)  (int)((l) & (ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET))
-# define ERR_GET_REASON(l)  (int)((l) & ERR_REASON_MASK)
-# define ERR_FATAL_ERROR(l) (int)((l) & ERR_RFLAG_FATAL)
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define SYS_F_FOPEN             0

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2070,7 +2070,8 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
     }
 
 #ifdef OPENSSL_NO_KTLS
-    ERR_raise_data(ERR_LIB_SYS, ERR_R_INTERNAL_ERROR, "calling sendfile()");
+    ERR_raise_data(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR,
+                   "can't call ktls_sendfile(), ktls disabled");
     return -1;
 #else
     ret = ktls_sendfile(SSL_get_wfd(s), fd, offset, size, flags);

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -36,20 +36,23 @@ static int test_print_error_format(void)
     char *out = NULL, *p = NULL;
     int ret = 0, len;
     BIO *bio = NULL;
-    int code = EPERM;
-    int code2;
+    int syserr = EPERM;
+    int reasoncode;
 
-    ERR_PUT_error(ERR_LIB_SYS, 0, code, "errtest.c", 30);
-    code2 = ERR_GET_REASON(ERR_peek_error());
+    ERR_PUT_error(ERR_LIB_SYS, 0, syserr, "errtest.c", 30);
+    reasoncode = ERR_GET_REASON(ERR_peek_error());
 
-    if (code2 != code) {
+    if (reasoncode != syserr) {
         TEST_skip("libcrypto didn't register EPERM (%d) correctly (%d).  "
                   "This is a known limitation",
-                  code, code2);
+                  syserr, reasoncode);
         ERR_clear_error();
     } else {
+        char buf[256];
+
+        OPENSSL_strlcpy(buf, strerror(syserr), sizeof(buf));
         BIO_snprintf(expected, sizeof(expected), expected_format,
-                     OPENSSL_FUNC, strerror(code));
+                     OPENSSL_FUNC, buf);
 
         if (!TEST_ptr(bio = BIO_new(BIO_s_mem())))
             return 0;

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -11,15 +11,9 @@ no strict 'refs';               # To be able to use strings as function refs
 use OpenSSL::Test;
 use OpenSSL::Test::Utils;
 use Errno qw(:POSIX);
-use POSIX qw(strerror);
+use POSIX qw(:limits_h strerror);
 
-# We actually have space for up to 4095 error messages,
-# numerically speaking...  but we're currently only using
-# numbers 1 through 127.
-# This constant should correspond to the same constant
-# defined in crypto/err/err.c, or at least must not be
-# assigned a greater number.
-use constant NUM_SYS_STR_REASONS => 127;
+use Data::Dumper;
 
 setup('test_errstr');
 
@@ -50,47 +44,21 @@ plan tests => scalar @Errno::EXPORT_OK
     +1                          # Checking that error 0 gives the library name
     ;
 
+# Test::More:ok() has a sub prototype, which means we need to use the '&ok'
+# syntax to force it to accept a list as a series of arguments.
+
 foreach my $errname (@Errno::EXPORT_OK) {
     # The error names are perl constants, which are implemented as functions
     # returning the numeric value of that name.
-    my $errnum = "Errno::$errname"->();
-
-  SKIP: {
-      # ERR only handles errnos that fit in 24 bits.  Numbers beyond that are
-      # trunkated and give false results.
-      skip "$errnum is larger than a 24 bit value, not supported", 1
-          if ($errnum & ~0xFFFFFF) != 0;
-
-      my $perr = eval {
-          # Set $! to the error number...
-          local $! = $errnum;
-          # ... and $! will give you the error string back
-          $!
-      };
-
-      # We know that the system reasons are in OpenSSL error library 2
-      my @oerr = run(app([ qw(openssl errstr), sprintf("2%06x", $errnum) ]),
-                     capture => 1);
-      $oerr[0] =~ s|\R$||;
-      @oerr = split_error($oerr[0]);
-      # Optional, if libcrypto didn't capture the text
-      my $rerr = "reason($errnum)";
-      ok($oerr[3] eq $perr || $oerr[3] eq $rerr,
-         $oerr[3] eq $perr
-         ? "($errnum) '$oerr[3]' == '$perr'"
-         : "'$oerr[3]' == '$rerr'");
-    }
+    &ok(match_syserr_reason("Errno::$errname"->()))
 }
 
-my @after = run(app([ qw(openssl errstr 2000100) ]), capture => 1);
-$after[0] =~ s|\R$||;
-@after = split_error($after[0]);
-ok($after[3] eq "reason(256)", "(256) '$after[3]' == 'reason(256)'");
+# OpenSSL library 1 is the "unknown" library
+&ok(match_opensslerr_reason(0x1 << 23 | 0x100, "reason(256)"));
+# Reason code 0 of any library gives the library name as reason
+&ok(match_opensslerr_reason(0x1 << 23 |  0x00, "unknown library"));
 
-my @zero = run(app([ qw(openssl errstr 2000000) ]), capture => 1);
-$zero[0] =~ s|\R$||;
-@zero = split_error($zero[0]);
-ok($zero[3] eq "system library", "(0) '$zero[3]' == 'system library'");
+exit 0;
 
 # For an error string "error:xxxxxxxx:lib:func:reason", this returns
 # the following array:
@@ -104,4 +72,59 @@ sub split_error {
     shift @erritems;
 
     return @erritems;
+}
+
+# Compares the first argument as string to each of the arguments 3 and on,
+# and returns an array of two elements:
+# 0:  True if the first argument matched any of the others, otherwise false
+# 1:  A string describing the test
+# The returned array can be used as the arguments to Test::More::ok()
+sub match_any {
+    my $first = shift;
+    my $desc = shift;
+    my @strings = @_;
+
+    if (scalar @strings > 1) {
+        $desc = "match '$first' ($desc) with one of ( '"
+            . join("', '", @strings) . "' )";
+    } else {
+        $desc = "match '$first' ($desc) with '$strings[0]'";
+    }
+
+    return ( scalar( grep { $first eq $_ } @strings ) > 0,
+             $desc );
+}
+
+sub match_opensslerr_reason {
+    my $errnum = shift;
+    my @strings = @_;
+
+    my $errnum_hex = sprintf "%x", $errnum;
+    my $reason =
+        ( run(app([ qw(openssl errstr), $errnum_hex ]), capture => 1) )[0];
+    $reason =~ s|\R$||;
+    $reason = ( split_error($reason) )[3];
+
+    return match_any($reason, $errnum, @strings);
+}
+
+sub match_syserr_reason {
+    my $errnum = shift;
+
+    my @strings = ();
+    # The POSIX reason string
+    push @strings, eval {
+          # Set $! to the error number...
+          local $! = $errnum;
+          # ... and $! will give you the error string back
+          $!
+    };
+    # The OpenSSL fallback string
+    push @strings, "reason($errnum)";
+
+    # We know that the system reasons are recorded by OpenSSL as an 'int'
+    # with an added set high bit, which always is POSIX::INT_MAX + 1.
+    my $syserr_flag = INT_MAX + 1;
+
+    return match_opensslerr_reason($syserr_flag | $errnum, $errnum, @strings);
 }


### PR DESCRIPTION
This fixes a series of current problems with the ERR sub-system:

-   reason codes overlaps
-   known issues with recorded system errors (they get truncated to 24 bits, previously even fewer), which we now detect and skip over
-   look through a larger range of system errors, to try and catch them all (even though POSIX allows any number that fits in an **int**, most systems use a range within 1..255)

Fixes #12276
Fixes #12217
Fixes #12354