### PR TITLE
Configure: fix handling of build.info attributes with value

### DIFF
--- a/Configure
+++ b/Configure
@@ -1968,10 +1968,10 @@ if ($builder eq "unified") {
                 my $ac = 1;
                 my $ak = $a;
                 my $av = 1;
-                if ($a =~ m|^(!)?(.*?)\s* = \s*(.*?)$|) {
+                if ($a =~ m|^(!)?(.*?)\s* = \s*(.*?)$|x) {
                     $ac = ! $1;
-                    $ak = $1;
-                    $av = $2;
+                    $ak = $2;
+                    $av = $3;
                 }
                 foreach my $g (@goals) {
                     if ($ac) {


### PR DESCRIPTION
This line wasn't properly handled:

    SCRIPTS{misc,linkname=tsget}=tsget.pl

It generated an attribute "linkname=tsget" with the value 1, instead of
what it should have, an attribute "linkname" with the value "tsget".

Fixes #12341
