### PR TITLE
Configuration and build:  Fix solaris tags

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -225,7 +225,7 @@ my %targets = (
     "solaris-common-gcc" => {
         inherit_from     => [ "solaris-common" ],
         template         => 1,
-        shared_target    => "solaris-gcc", # The rest is on shared_info.pl
+        shared_target    => "solaris-gcc-shared", # The rest is on shared_info.pl
     },
 #### Solaris x86 with GNU C setups
     "solaris-x86-gcc" => {

--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -107,6 +107,7 @@ my %OS_data = (
     solaris     => { writer     => \&writer_linux,
                      sort       => sorter_linux(),
                      platforms  => { UNIX                       => 1 } },
+    "solaris-gcc" => 'solaris', # alias
     linux       => 'solaris',   # alias
     "bsd-gcc"   => 'solaris',   # alias
     aix         => { writer     => \&writer_aix,


### PR DESCRIPTION
The shared_target attrribute for Solaris built with gcc wasn't right
and shared libraries couldn't be properly built.

Fixes #12356
