### PR TITLE
README.md: fix two leftovers from pull request #10545

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,6 @@ Contributing
 If you are interested and willing to contribute to the OpenSSL project,
 please take a look at the [CONTRIBUTING](CONTRIBUTING.md) file.
 
-Since 2016, development takes place in public on the GitHub open source
-platform. The OpenSSL Project Pages at [openssl.github.io][] are a
-valuable source of information if you want to get familiar with our
-development process on GitHub.
-
 Legalities
 ==========
 
@@ -194,10 +189,6 @@ All rights reserved.
 [github.com/openssl/openssl]:
     <https://github.com/openssl/openssl>
     "OpenSSL GitHub Mirror"
-
-[openssl.github.io]:
-    <https://mspncp.github.io>
-    "OpenSSL Project Pages"
 
 [wiki.openssl.org]:
     <https://wiki.openssl.org>

--- a/README.md
+++ b/README.md
@@ -207,13 +207,6 @@ All rights reserved.
      <https://tools.ietf.org/html/rfc8446>
 
 <!-- Logos and Badges -->
-<!--
-  Note: The security token for the appveyor badge (the random number in
-  the URL below) was obtained for the mspncp/openssl project.
-  It needs to be replaced by the correct token by some core member
-  (@levitte, @mattcaswell?). It can be obtained for project members at
-  https://ci.appveyor.com/project/openssl/openssl/settings/badges.
--->
 
 [openssl logo]:
     doc/images/openssl.svg
@@ -228,7 +221,7 @@ All rights reserved.
     "Travis Jobs"
 
 [appveyor badge]:
-    <https://ci.appveyor.com/api/projects/status/ikn2l4u1xsume63u/branch/master?svg=true>
+    <https://ci.appveyor.com/api/projects/status/8e10o7xfrg73v98f/branch/master?svg=true>
     "AppVeyor Build Status"
 
 [appveyor jobs]:


### PR DESCRIPTION
commit 02054d791a52f02de66844ef6f9384378fb2877d (master)
Author: Dr. Matthias St. Pierre <matthias.st.pierre@ncp-e.com>
Date:   Thu Jul 2 20:00:03 2020 +0200

    README.md: replace incorrect access token for the AppVeyor badge

    The AppVeyor badge was still showing the build state for
    the mspncp/openssl fork.

    This commit fixes a forgotten todo from #10545.

Author: Dr. Matthias St. Pierre <matthias.st.pierre@ncp-e.com>
Date:   Thu Jul 2 20:04:44 2020 +0200

    README.md: remove incorrect link to openssl.github.io

    The link to the OpenSSL Project Pages <openssl.github.io>
    actually points to an unfinished draft <mspncp.github.io>.

    The original intention of this pet project of mine was to
    have a website dedicated to describing the OpenSSL workflow
    on GitHub and to answer frequently asked questions related
    to pull requests and the review process.

    The progress on that project has stalled and I'm not so sure
    anymore whether it is good idea to have yet another project
    website. In particular since the OpenSSL Wiki has seen some
    revival and increased activity caused by the upcoming
    OpenSSL 3.0 release.

