### PR TITLE
[WIP][bp-1.1.1] Run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,6 +218,7 @@ before_script:
           fi;
       fi
     - ./configdata.pm --dump
+    - export HARNESS_JOBS=${HARNESS_JOBS:-4}
     - cd $top
 
 script:

--- a/INSTALL
+++ b/INSTALL
@@ -1206,6 +1206,25 @@
 
  $ make TESTS='[89]? -90'
 
+ Running Tests in Parallel
+ -------------------------
+
+ By default the test harness will execute the selected tests sequentially.
+ Depending on the platform characteristics, running more than one test job in
+ parallel may speed up test execution.
+ This can be requested by setting the `HARNESS_JOBS` environment variable to a
+ positive integer value. This specifies the maximum number of test jobs to run
+ in parallel.
+
+ Depending on the Perl version different strategies could be adopted to select
+ which test recipes can be run in parallel.  In recent versions of Perl, unless
+ specified otherwise, any task can be run in parallel. Consult the documentation
+ for `TAP::Harness` to know more.
+
+ To run up to four tests in parallel at any given time:
+
+ $ make HARNESS_JOBS=4 test
+
  Note on multi-threading
  -----------------------
 

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -27,6 +27,7 @@ my $srctop = $ENV{SRCTOP} || $ENV{TOP};
 my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
+my $jobs = $ENV{HARNESS_JOBS};
 
 $ENV{OPENSSL_CONF} = catdir($srctop, "apps", "openssl.cnf");
 
@@ -36,6 +37,8 @@ my %tapargs =
       switches  => '-w',
       merge     => 1
     );
+
+$tapargs{jobs} = $jobs if defined $jobs;
 
 my @alltests = find_matching_tests("*");
 my %tests = ();


### PR DESCRIPTION
This is a tentative backport of #12326 to `1.1.1`.

~~~
Run tests in parallel

The environment variable `HARNESS_JOBS` can be used to control how many
jobs to run in parallel.  The default is still to run jobs sequentially.

This commit does not define custom `rules`, and different versions of
`TAP::Harness` come with different strategies regarding the default
`rules` that define which test recipes can be run in parallel.
In recent versions of Perl, unless specified otherwise, any task can be
run in parallel.

(cherry picked from commit a20c9075d6a72f484d1f27d99a54483a7e96fc51)
~~~

~~~
Travis: default to HARNESS_JOBS=4

We can run tests in parallel by setting the HARNESS_JOBS environment
variable.

(cherry picked from commit af3e8c298ab9fcee47d2d4a54f8be084990f9382)
~~~


### WIP

Notice that while in `master` each test job gets its own work directory in `/test-runs/<test_name>`, in `1.1.1` at the moment all test jobs get executed inside the same work directory `/test/test-runs/`.
This means that running test jobs in parallel can lead to conflicts, and that there might be hidden dependencies between tests so that the order in which they are run matters.

