### PR TITLE
CORE: perform post-condition in algorithm_do_this() under all circumstances

### DIFF
--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -58,13 +58,12 @@ static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
 
         map = ossl_provider_query_operation(provider, cur_operation,
                                             &no_store);
-        if (map == NULL)
-            continue;
+        if (map != NULL) {
+            while (map->algorithm_names != NULL) {
+                const OSSL_ALGORITHM *thismap = map++;
 
-        while (map->algorithm_names != NULL) {
-            const OSSL_ALGORITHM *thismap = map++;
-
-            data->fn(provider, thismap, no_store, data->data);
+                data->fn(provider, thismap, no_store, data->data);
+            }
         }
 
         /* Do we fulfill post-conditions? */


### PR DESCRIPTION
When ossl_provider_query_operation() returned NULL, the post-condition
callback wasn't called, and could make algorithm_do_this() falsely
tell the caller that there was an error.  Because of this, a provider
that answered with NULL for a particular operation identity would
effectively block the same query on all following providers.

Fixes #12293
