### PR TITLE
Configuration: darwin64-arm64-cc for Apple silicon

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,9 @@
 
   *) The Oracle Developer Studio compiler will start reporting deprecated APIs
 
+  *) Add support for Apple Silicon M1 Macs with the darwin64-arm64-cc target.
+     [Stuart Carnie]
+
  Changes between 1.1.1f and 1.1.1g [21 Apr 2020]
 
   *) Fixed segmentation fault in SSL_check_chain()

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1557,6 +1557,14 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "macosx",
     },
+    "darwin64-arm64-cc" => {
+        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
+        CFLAGS           => add("-Wall"),
+        cflags           => add("-arch arm64"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "ios64",
+    },
 
 ##### GNU Hurd
     "hurd-x86" => {

--- a/config
+++ b/config
@@ -253,11 +253,8 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
 	    Power*)
 		echo "ppc-apple-darwin${VERSION}"
 		;;
-	    x86_64)
-		echo "x86_64-apple-darwin${VERSION}"
-		;;
 	    *)
-		echo "i686-apple-darwin${VERSION}"
+		echo "${MACHINE}-apple-darwin${VERSION}"
 		;;
 	esac
 	exit 0
@@ -497,6 +494,9 @@ case "$GUESSOS" in
 	else
 	    OUT="darwin64-x86_64-cc"
 	fi ;;
+  $MACHINE-apple-darwin*)
+	OUT="darwin64-$MACHINE-cc"
+	;;
   armv6+7-*-iphoneos)
 	__CNF_CFLAGS="$__CNF_CFLAGS -arch armv6 -arch armv7"
 	__CNF_CXXFLAGS="$__CNF_CXXFLAGS -arch armv6 -arch armv7"


### PR DESCRIPTION
The PR adds a new configuration, `darwin64-arm64-cc` for targeting Apple silicon (tested on DTK).