### PR TITLE
Configurations: PowerPC is big endian

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -706,6 +706,7 @@ my %targets = (
         inherit_from     => [ "linux-generic32" ],
         asm_arch         => 'ppc32',
         perlasm_scheme   => "linux32",
+        lib_cppflags     => add("-DB_ENDIAN"),
     },
     "linux-ppc64" => {
         inherit_from     => [ "linux-generic64" ],


### PR DESCRIPTION
Define B_ENDIAN on PowerPC because it is a big endian architecture. With
this change the BN* related tests pass.

Fixes: #12199

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>