### PR TITLE
OCSP Response Processing

### DIFF
--- a/crypto/ocsp/ocsp_lib.c
+++ b/crypto/ocsp/ocsp_lib.c
@@ -38,6 +38,34 @@ OCSP_CERTID *OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject,
     return OCSP_cert_id_new(dgst, iname, ikey, serial);
 }
 
+/*
+ * Convert a certificate and its issuer to an OCSP_CERTID
+ * based on the digest algorithm pulled from the response
+ */
+
+OCSP_CERTID *OCSP_resp_cert_to_id(OCSP_BASICRESP *br,
+                                  const X509 *subject,
+                                  const X509 *issuer)
+{
+    const EVP_MD *dgst;
+    ASN1_OBJECT  *pmd;
+    OCSP_CERTID  *cid;
+    const OCSP_SINGLERESP *single;
+
+    single = OCSP_resp_get0(br, 0);
+    if (single == NULL)
+        return NULL;
+
+    cid = (OCSP_CERTID *)OCSP_SINGLERESP_get0_id(single);
+    if (cid == NULL)
+        return NULL;
+
+    if (OCSP_id_get0_info(NULL, &pmd, NULL, NULL, cid))
+        dgst = EVP_get_digestbyobj(pmd);
+
+    return (OCSP_cert_to_id(dgst, subject, issuer));
+}
+
 OCSP_CERTID *OCSP_cert_id_new(const EVP_MD *dgst,
                               const X509_NAME *issuerName,
                               const ASN1_BIT_STRING *issuerKey,

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -169,6 +169,10 @@ int OCSP_REQ_CTX_add1_header(OCSP_REQ_CTX *rctx,
 OCSP_CERTID *OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject,
                              const X509 *issuer);
 
+OCSP_CERTID *OCSP_resp_cert_to_id(OCSP_BASICRESP *br,
+                                  const X509 *subject,
+                                  const X509 *issuer);
+
 OCSP_CERTID *OCSP_cert_id_new(const EVP_MD *dgst,
                               const X509_NAME *issuerName,
                               const ASN1_BIT_STRING *issuerKey,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4590,3 +4590,4 @@ RSA_get0_pss_params                     4543	1_1_1e	EXIST::FUNCTION:RSA
 X509_ALGOR_copy                         4544	1_1_1h	EXIST::FUNCTION:
 X509_REQ_set0_signature                 4545	1_1_1h	EXIST::FUNCTION:
 X509_REQ_set1_signature_algo            4546	1_1_1h	EXIST::FUNCTION:
+OCSP_resp_cert_to_id                    4547	1_1_1h	EXIST::FUNCTION:OCSP


### PR DESCRIPTION
Create OCSP_CERTID based on the digest algorithm pulled from the OCSP response.
Since the OCSP responder may use a hash other than SHA-1, allow a cert ID to be generated based on the hash used from the OCSP response.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
