### PR TITLE
BN: Check endianness in run-time, in BN_native2bn() and BN_bn2nativepad()

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <limits.h>
 #include "internal/cryptlib.h"
+#include "internal/endian.h"
 #include "bn_local.h"
 #include <openssl/opensslconf.h>
 #include "internal/constant_time.h"
@@ -583,20 +584,20 @@ int BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, int tolen)
 
 BIGNUM *BN_native2bn(const unsigned char *s, int len, BIGNUM *ret)
 {
-#ifdef B_ENDIAN
+    DECLARE_IS_ENDIAN;
+
+    if (IS_LITTLE_ENDIAN)
+        return BN_lebin2bn(s, len, ret);
     return BN_bin2bn(s, len, ret);
-#else
-    return BN_lebin2bn(s, len, ret);
-#endif
 }
 
 int BN_bn2nativepad(const BIGNUM *a, unsigned char *to, int tolen)
 {
-#ifdef B_ENDIAN
+    DECLARE_IS_ENDIAN;
+
+    if (IS_LITTLE_ENDIAN)
+        return BN_bn2lebinpad(a, to, tolen);
     return BN_bn2binpad(a, to, tolen);
-#else
-    return BN_bn2lebinpad(a, to, tolen);
-#endif
 }
 
 int BN_ucmp(const BIGNUM *a, const BIGNUM *b)

--- a/crypto/chacha/chacha_enc.c
+++ b/crypto/chacha/chacha_enc.c
@@ -11,6 +11,7 @@
 
 #include <string.h>
 
+#include "internal/endian.h"
 #include "crypto/chacha.h"
 #include "crypto/ctype.h"
 
@@ -43,10 +44,7 @@ static void chacha20_core(chacha_buf *output, const u32 input[16])
 {
     u32 x[16];
     int i;
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
     memcpy(x, input, sizeof(x));
 
@@ -61,7 +59,7 @@ static void chacha20_core(chacha_buf *output, const u32 input[16])
         QUARTERROUND(3, 4, 9, 14);
     }
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         for (i = 0; i < 16; ++i)
             output->u[i] = x[i] + input[i];
     } else {

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -76,6 +76,7 @@
 #include "internal/bio.h"
 #include <openssl/evp.h>
 #include <openssl/rand.h>
+#include "internal/endian.h"
 #include "crypto/evp.h"
 
 static int ok_write(BIO *h, const char *buf, int num);
@@ -418,14 +419,9 @@ static long ok_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 
 static void longswap(void *_ptr, size_t len)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = {
-        1
-    };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         size_t i;
         unsigned char *p = _ptr, c;
 

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include "internal/endian.h"
 
 #ifndef OPENSSL_NO_CHACHA
 
@@ -310,12 +311,9 @@ static int chacha20_poly1305_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     }
 
     {
-        const union {
-            long one;
-            char little;
-        } is_endian = { 1 };
+        DECLARE_IS_ENDIAN;
 
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
             memcpy(ctr, (unsigned char *)&actx->len, POLY1305_BLOCK_SIZE);
         } else {
             ctr[0]  = (unsigned char)(actx->len.aad);
@@ -426,10 +424,7 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     }
     if (in == NULL                              /* explicit final */
         || plen != len) {                       /* or tls mode */
-        const union {
-            long one;
-            char little;
-        } is_endian = { 1 };
+        DECLARE_IS_ENDIAN;
         unsigned char temp[POLY1305_BLOCK_SIZE];
 
         if (actx->aad) {                        /* wrap up aad */
@@ -443,7 +438,7 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             Poly1305_Update(POLY1305_ctx(actx), zero,
                             POLY1305_BLOCK_SIZE - rem);
 
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
             Poly1305_Update(POLY1305_ctx(actx),
                             (unsigned char *)&actx->len, POLY1305_BLOCK_SIZE);
         } else {

--- a/crypto/modes/ctr128.c
+++ b/crypto/modes/ctr128.c
@@ -9,6 +9,7 @@
 
 #include <string.h>
 #include <openssl/crypto.h>
+#include "internal/endian.h"
 #include "crypto/modes.h"
 
 #if defined(__GNUC__) && !defined(STRICT_ALIGNMENT)
@@ -39,14 +40,9 @@ static void ctr128_inc(unsigned char *counter)
 static void ctr128_inc_aligned(unsigned char *counter)
 {
     size_t *data, c, d, n;
-    const union {
-        long one;
-        char little;
-    } is_endian = {
-        1
-    };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little || ((size_t)counter % sizeof(size_t)) != 0) {
+    if (IS_LITTLE_ENDIAN || ((size_t)counter % sizeof(size_t)) != 0) {
         ctr128_inc(counter);
         return;
     }

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
+#include "internal/endian.h"
 #include "crypto/modes.h"
 
 #if defined(__GNUC__) && !defined(STRICT_ALIGNMENT)
@@ -105,10 +106,7 @@ static void gcm_gmult_8bit(u64 Xi[2], const u128 Htable[256])
     u128 Z = { 0, 0 };
     const u8 *xi = (const u8 *)Xi + 15;
     size_t rem, n = *xi;
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     static const size_t rem_8bit[256] = {
         PACK(0x0000), PACK(0x01C2), PACK(0x0384), PACK(0x0246),
         PACK(0x0708), PACK(0x06CA), PACK(0x048C), PACK(0x054E),
@@ -194,7 +192,7 @@ static void gcm_gmult_8bit(u64 Xi[2], const u128 Htable[256])
             Z.hi ^= (u64)rem_8bit[rem] << 32;
     }
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
 # ifdef BSWAP8
         Xi[0] = BSWAP8(Z.hi);
         Xi[1] = BSWAP8(Z.lo);
@@ -274,12 +272,9 @@ static void gcm_init_4bit(u128 Htable[16], u64 H[2])
      */
     {
         int j;
-        const union {
-            long one;
-            char little;
-        } is_endian = { 1 };
+        DECLARE_IS_ENDIAN;
 
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
             for (j = 0; j < 16; ++j) {
                 V = Htable[j];
                 Htable[j].hi = V.lo;
@@ -307,10 +302,7 @@ static void gcm_gmult_4bit(u64 Xi[2], const u128 Htable[16])
     u128 Z;
     int cnt = 15;
     size_t rem, nlo, nhi;
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
     nlo = ((const u8 *)Xi)[15];
     nhi = nlo >> 4;
@@ -350,7 +342,7 @@ static void gcm_gmult_4bit(u64 Xi[2], const u128 Htable[16])
         Z.lo ^= Htable[nlo].lo;
     }
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
 #  ifdef BSWAP8
         Xi[0] = BSWAP8(Z.hi);
         Xi[1] = BSWAP8(Z.lo);
@@ -386,10 +378,7 @@ static void gcm_ghash_4bit(u64 Xi[2], const u128 Htable[16],
     u128 Z;
     int cnt;
     size_t rem, nlo, nhi;
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
 #   if 1
     do {
@@ -528,7 +517,7 @@ static void gcm_ghash_4bit(u64 Xi[2], const u128 Htable[16],
         Z.hi ^= ((u64)rem_8bit[rem << 4]) << 48;
 #   endif
 
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
 #   ifdef BSWAP8
             Xi[0] = BSWAP8(Z.hi);
             Xi[1] = BSWAP8(Z.lo);
@@ -576,16 +565,13 @@ static void gcm_gmult_1bit(u64 Xi[2], const u64 H[2])
     long X;
     int i, j;
     const long *xi = (const long *)Xi;
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
     V.hi = H[0];                /* H is in host byte order, no byte swapping */
     V.lo = H[1];
 
     for (j = 0; j < 16 / sizeof(long); ++j) {
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
             if (sizeof(long) == 8) {
 # ifdef BSWAP8
                 X = (long)(BSWAP8(xi[j]));
@@ -609,7 +595,7 @@ static void gcm_gmult_1bit(u64 Xi[2], const u64 H[2])
         }
     }
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
 # ifdef BSWAP8
         Xi[0] = BSWAP8(Z.hi);
         Xi[1] = BSWAP8(Z.lo);
@@ -718,10 +704,7 @@ void gcm_ghash_p8(u64 Xi[2], const u128 Htable[16], const u8 *inp,
 
 void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
     memset(ctx, 0, sizeof(*ctx));
     ctx->block = block;
@@ -729,7 +712,7 @@ void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)
 
     (*block) (ctx->H.c, ctx->H.c, key);
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         /* H is stored in host byte order */
 #ifdef BSWAP8
         ctx->H.u[0] = BSWAP8(ctx->H.u[0]);
@@ -833,10 +816,7 @@ void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)
 void CRYPTO_gcm128_setiv(GCM128_CONTEXT *ctx, const unsigned char *iv,
                          size_t len)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     unsigned int ctr;
 #ifdef GCM_FUNCREF_4BIT
     void (*gcm_gmult_p) (u64 Xi[2], const u128 Htable[16]) = ctx->gmult;
@@ -875,7 +855,7 @@ void CRYPTO_gcm128_setiv(GCM128_CONTEXT *ctx, const unsigned char *iv,
             GCM_MUL(ctx);
         }
         len0 <<= 3;
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
 #ifdef BSWAP8
             ctx->Xi.u[1] ^= BSWAP8(len0);
 #else
@@ -894,7 +874,7 @@ void CRYPTO_gcm128_setiv(GCM128_CONTEXT *ctx, const unsigned char *iv,
 
         GCM_MUL(ctx);
 
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 #ifdef BSWAP4
             ctr = BSWAP4(ctx->Xi.d[3]);
 #else
@@ -913,7 +893,7 @@ void CRYPTO_gcm128_setiv(GCM128_CONTEXT *ctx, const unsigned char *iv,
 
     (*ctx->block) (ctx->Yi.c, ctx->EK0.c, ctx->key);
     ++ctr;
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
 #ifdef BSWAP4
         ctx->Yi.d[3] = BSWAP4(ctr);
 #else
@@ -988,10 +968,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
                           const unsigned char *in, unsigned char *out,
                           size_t len)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     unsigned int n, ctr, mres;
     size_t i;
     u64 mlen = ctx->len.u[1];
@@ -1030,7 +1007,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
         ctx->ares = 0;
     }
 
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
 #ifdef BSWAP4
         ctr = BSWAP4(ctx->Yi.d[3]);
 #else
@@ -1091,7 +1068,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
 
                     (*block) (ctx->Yi.c, ctx->EKi.c, key);
                     ++ctr;
-                    if (is_endian.little)
+                    if (IS_LITTLE_ENDIAN)
 #   ifdef BSWAP4
                         ctx->Yi.d[3] = BSWAP4(ctr);
 #   else
@@ -1118,7 +1095,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
 
                     (*block) (ctx->Yi.c, ctx->EKi.c, key);
                     ++ctr;
-                    if (is_endian.little)
+                    if (IS_LITTLE_ENDIAN)
 #  ifdef BSWAP4
                         ctx->Yi.d[3] = BSWAP4(ctr);
 #  else
@@ -1141,7 +1118,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
 
                 (*block) (ctx->Yi.c, ctx->EKi.c, key);
                 ++ctr;
-                if (is_endian.little)
+                if (IS_LITTLE_ENDIAN)
 #  ifdef BSWAP4
                     ctx->Yi.d[3] = BSWAP4(ctr);
 #  else
@@ -1160,7 +1137,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
             if (len) {
                 (*block) (ctx->Yi.c, ctx->EKi.c, key);
                 ++ctr;
-                if (is_endian.little)
+                if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
                     ctx->Yi.d[3] = BSWAP4(ctr);
 # else
@@ -1191,7 +1168,7 @@ int CRYPTO_gcm128_encrypt(GCM128_CONTEXT *ctx,
         if (n == 0) {
             (*block) (ctx->Yi.c, ctx->EKi.c, key);
             ++ctr;
-            if (is_endian.little)
+            if (IS_LITTLE_ENDIAN)
 #ifdef BSWAP4
                 ctx->Yi.d[3] = BSWAP4(ctr);
 #else
@@ -1223,10 +1200,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
                           const unsigned char *in, unsigned char *out,
                           size_t len)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     unsigned int n, ctr, mres;
     size_t i;
     u64 mlen = ctx->len.u[1];
@@ -1265,7 +1239,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
         ctx->ares = 0;
     }
 
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
 #ifdef BSWAP4
         ctr = BSWAP4(ctx->Yi.d[3]);
 #else
@@ -1329,7 +1303,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
 
                     (*block) (ctx->Yi.c, ctx->EKi.c, key);
                     ++ctr;
-                    if (is_endian.little)
+                    if (IS_LITTLE_ENDIAN)
 #   ifdef BSWAP4
                         ctx->Yi.d[3] = BSWAP4(ctr);
 #   else
@@ -1354,7 +1328,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
 
                     (*block) (ctx->Yi.c, ctx->EKi.c, key);
                     ++ctr;
-                    if (is_endian.little)
+                    if (IS_LITTLE_ENDIAN)
 #  ifdef BSWAP4
                         ctx->Yi.d[3] = BSWAP4(ctr);
 #  else
@@ -1376,7 +1350,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
 
                 (*block) (ctx->Yi.c, ctx->EKi.c, key);
                 ++ctr;
-                if (is_endian.little)
+                if (IS_LITTLE_ENDIAN)
 #  ifdef BSWAP4
                     ctx->Yi.d[3] = BSWAP4(ctr);
 #  else
@@ -1398,7 +1372,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
             if (len) {
                 (*block) (ctx->Yi.c, ctx->EKi.c, key);
                 ++ctr;
-                if (is_endian.little)
+                if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
                     ctx->Yi.d[3] = BSWAP4(ctr);
 # else
@@ -1432,7 +1406,7 @@ int CRYPTO_gcm128_decrypt(GCM128_CONTEXT *ctx,
         if (n == 0) {
             (*block) (ctx->Yi.c, ctx->EKi.c, key);
             ++ctr;
-            if (is_endian.little)
+            if (IS_LITTLE_ENDIAN)
 #ifdef BSWAP4
                 ctx->Yi.d[3] = BSWAP4(ctr);
 #else
@@ -1469,10 +1443,7 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
 #if defined(OPENSSL_SMALL_FOOTPRINT)
     return CRYPTO_gcm128_encrypt(ctx, in, out, len);
 #else
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     unsigned int n, ctr, mres;
     size_t i;
     u64 mlen = ctx->len.u[1];
@@ -1510,7 +1481,7 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
         ctx->ares = 0;
     }
 
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
         ctr = BSWAP4(ctx->Yi.d[3]);
 # else
@@ -1558,7 +1529,7 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
     while (len >= GHASH_CHUNK) {
         (*stream) (in, out, GHASH_CHUNK / 16, key, ctx->Yi.c);
         ctr += GHASH_CHUNK / 16;
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 #   ifdef BSWAP4
             ctx->Yi.d[3] = BSWAP4(ctr);
 #   else
@@ -1578,7 +1549,7 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
 
         (*stream) (in, out, j, key, ctx->Yi.c);
         ctr += (unsigned int)j;
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
             ctx->Yi.d[3] = BSWAP4(ctr);
 # else
@@ -1603,7 +1574,7 @@ int CRYPTO_gcm128_encrypt_ctr32(GCM128_CONTEXT *ctx,
     if (len) {
         (*ctx->block) (ctx->Yi.c, ctx->EKi.c, key);
         ++ctr;
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
             ctx->Yi.d[3] = BSWAP4(ctr);
 # else
@@ -1633,10 +1604,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
 #if defined(OPENSSL_SMALL_FOOTPRINT)
     return CRYPTO_gcm128_decrypt(ctx, in, out, len);
 #else
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     unsigned int n, ctr, mres;
     size_t i;
     u64 mlen = ctx->len.u[1];
@@ -1674,7 +1642,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
         ctx->ares = 0;
     }
 
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
         ctr = BSWAP4(ctx->Yi.d[3]);
 # else
@@ -1725,7 +1693,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
         GHASH(ctx, in, GHASH_CHUNK);
         (*stream) (in, out, GHASH_CHUNK / 16, key, ctx->Yi.c);
         ctr += GHASH_CHUNK / 16;
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 #   ifdef BSWAP4
             ctx->Yi.d[3] = BSWAP4(ctr);
 #   else
@@ -1757,7 +1725,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
 # endif
         (*stream) (in, out, j, key, ctx->Yi.c);
         ctr += (unsigned int)j;
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
             ctx->Yi.d[3] = BSWAP4(ctr);
 # else
@@ -1772,7 +1740,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
     if (len) {
         (*ctx->block) (ctx->Yi.c, ctx->EKi.c, key);
         ++ctr;
-        if (is_endian.little)
+        if (IS_LITTLE_ENDIAN)
 # ifdef BSWAP4
             ctx->Yi.d[3] = BSWAP4(ctr);
 # else
@@ -1800,10 +1768,7 @@ int CRYPTO_gcm128_decrypt_ctr32(GCM128_CONTEXT *ctx,
 int CRYPTO_gcm128_finish(GCM128_CONTEXT *ctx, const unsigned char *tag,
                          size_t len)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
     u64 alen = ctx->len.u[0] << 3;
     u64 clen = ctx->len.u[1] << 3;
 #ifdef GCM_FUNCREF_4BIT
@@ -1835,7 +1800,7 @@ int CRYPTO_gcm128_finish(GCM128_CONTEXT *ctx, const unsigned char *tag,
         GCM_MUL(ctx);
 #endif
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
 #ifdef BSWAP8
         alen = BSWAP8(alen);
         clen = BSWAP8(clen);

--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -13,6 +13,7 @@
 #include <openssl/evp.h>
 #include <openssl/core_names.h>
 #include <openssl/params.h>
+#include "internal/endian.h"
 #include "crypto/modes.h"
 #include "crypto/siv.h"
 
@@ -40,24 +41,18 @@ __owur static ossl_inline uint64_t byteswap8(uint64_t x)
 
 __owur static ossl_inline uint64_t siv128_getword(SIV_BLOCK const *b, size_t i)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
         return byteswap8(b->word[i]);
     return b->word[i];
 }
 
 static ossl_inline void siv128_putword(SIV_BLOCK *b, size_t i, uint64_t x)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little)
+    if (IS_LITTLE_ENDIAN)
         b->word[i] = byteswap8(x);
     else
         b->word[i] = x;

--- a/crypto/modes/xts128.c
+++ b/crypto/modes/xts128.c
@@ -9,6 +9,7 @@
 
 #include <string.h>
 #include <openssl/crypto.h>
+#include "internal/endian.h"
 #include "crypto/modes.h"
 
 #ifndef STRICT_ALIGNMENT
@@ -24,12 +25,7 @@ int CRYPTO_xts128_encrypt(const XTS128_CONTEXT *ctx,
                           const unsigned char *inp, unsigned char *out,
                           size_t len, int enc)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = {
-        1
-    };
+    DECLARE_IS_ENDIAN;
     union {
         u64 u[2];
         u32 d[4];
@@ -72,7 +68,7 @@ int CRYPTO_xts128_encrypt(const XTS128_CONTEXT *ctx,
         if (len == 0)
             return 0;
 
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
             unsigned int carry, res;
 
             res = 0x87 & (((int)tweak.d[3]) >> 31);
@@ -111,7 +107,7 @@ int CRYPTO_xts128_encrypt(const XTS128_CONTEXT *ctx,
             u8 c[16];
         } tweak1;
 
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
             unsigned int carry, res;
 
             res = 0x87 & (((int)tweak.d[3]) >> 31);

--- a/crypto/sha/sha256.c
+++ b/crypto/sha/sha256.c
@@ -21,6 +21,7 @@
 #include <openssl/crypto.h>
 #include <openssl/sha.h>
 #include <openssl/opensslv.h>
+#include "internal/endian.h"
 
 int SHA224_Init(SHA256_CTX *c)
 {
@@ -256,12 +257,7 @@ static void sha256_block_data_order(SHA256_CTX *ctx, const void *in,
     SHA_LONG X[16];
     int i;
     const unsigned char *data = in;
-    const union {
-        long one;
-        char little;
-    } is_endian = {
-        1
-    };
+    DECLARE_IS_ENDIAN;
 
     while (num--) {
 
@@ -274,7 +270,7 @@ static void sha256_block_data_order(SHA256_CTX *ctx, const void *in,
         g = ctx->h[6];
         h = ctx->h[7];
 
-        if (!is_endian.little && sizeof(SHA_LONG) == 4
+        if (!IS_LITTLE_ENDIAN && sizeof(SHA_LONG) == 4
             && ((size_t)in % 4) == 0) {
             const SHA_LONG *W = (const SHA_LONG *)data;
 

--- a/crypto/sha/sha_local.h
+++ b/crypto/sha/sha_local.h
@@ -12,6 +12,7 @@
 
 #include <openssl/opensslconf.h>
 #include <openssl/sha.h>
+#include "internal/endian.h"
 
 #define DATA_ORDER_IS_BIG_ENDIAN
 
@@ -151,14 +152,9 @@ static void HASH_BLOCK_DATA_ORDER(SHA_CTX *c, const void *p, size_t num)
     E = c->h4;
 
     for (;;) {
-        const union {
-            long one;
-            char little;
-        } is_endian = {
-            1
-        };
+        DECLARE_IS_ENDIAN;
 
-        if (!is_endian.little && sizeof(SHA_LONG) == 4
+        if (!IS_LITTLE_ENDIAN && sizeof(SHA_LONG) == 4
             && ((size_t)p % 4) == 0) {
             const SHA_LONG *W = (const SHA_LONG *)data;
 

--- a/include/internal/endian.h
+++ b/include/internal/endian.h
@@ -7,8 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OSSL_TEST_OSSL_TEST_ENDIAN_H
-# define OSSL_TEST_OSSL_TEST_ENDIAN_H
+#ifndef OSSL_INTERNAL_ENDIAN_H
+# define OSSL_INTERNAL_ENDIAN_H
 
 # define DECLARE_IS_ENDIAN \
     const union { \

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -9,6 +9,7 @@
 
 /* chacha20_poly1305 cipher implementation */
 
+#include "internal/endian.h"
 #include "cipher_chacha20_poly1305.h"
 
 static int chacha_poly1305_tls_init(PROV_CIPHER_CTX *bctx,
@@ -117,10 +118,7 @@ static int chacha20_poly1305_tls_cipher(PROV_CIPHER_CTX *bctx,
     size_t tail, tohash_len, buf_len, plen = ctx->tls_payload_length;
     unsigned char *buf, *tohash, *ctr, storage[sizeof(zero) + 32];
 
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
     if (len != plen + POLY1305_BLOCK_SIZE)
         return 0;
@@ -214,7 +212,7 @@ static int chacha20_poly1305_tls_cipher(PROV_CIPHER_CTX *bctx,
         Poly1305_Update(poly, zero, tail);
     }
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         memcpy(ctr, (unsigned char *)&ctx->len, POLY1305_BLOCK_SIZE);
     } else {
         ctr[0]  = (unsigned char)(ctx->len.aad);
@@ -273,10 +271,7 @@ static int chacha20_poly1305_aead_cipher(PROV_CIPHER_CTX *bctx,
     size_t olen = 0;
     int rv = 0;
 
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
     if (!ctx->mac_inited) {
 #if !defined(OPENSSL_SMALL_FOOTPRINT)
@@ -347,7 +342,7 @@ static int chacha20_poly1305_aead_cipher(PROV_CIPHER_CTX *bctx,
         if ((rem = (size_t)ctx->len.text % POLY1305_BLOCK_SIZE))
             Poly1305_Update(poly, zero, POLY1305_BLOCK_SIZE - rem);
 
-        if (is_endian.little) {
+        if (IS_LITTLE_ENDIAN) {
             Poly1305_Update(poly, (unsigned char *)&ctx->len,
                             POLY1305_BLOCK_SIZE);
         } else {

--- a/providers/implementations/digests/blake2_impl.h
+++ b/providers/implementations/digests/blake2_impl.h
@@ -15,15 +15,13 @@
  */
 
 #include <string.h>
+#include "internal/endian.h"
 
 static ossl_inline uint32_t load32(const uint8_t *src)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         uint32_t w;
         memcpy(&w, src, sizeof(w));
         return w;
@@ -38,12 +36,9 @@ static ossl_inline uint32_t load32(const uint8_t *src)
 
 static ossl_inline uint64_t load64(const uint8_t *src)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         uint64_t w;
         memcpy(&w, src, sizeof(w));
         return w;
@@ -62,12 +57,9 @@ static ossl_inline uint64_t load64(const uint8_t *src)
 
 static ossl_inline void store32(uint8_t *dst, uint32_t w)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         memcpy(dst, &w, sizeof(w));
     } else {
         uint8_t *p = (uint8_t *)dst;
@@ -80,12 +72,9 @@ static ossl_inline void store32(uint8_t *dst, uint32_t w)
 
 static ossl_inline void store64(uint8_t *dst, uint64_t w)
 {
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (is_endian.little) {
+    if (IS_LITTLE_ENDIAN) {
         memcpy(dst, &w, sizeof(w));
     } else {
         uint8_t *p = (uint8_t *)dst;

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -37,6 +37,7 @@
 #include "internal/cryptlib.h"
 #include "crypto/evp.h"
 #include "internal/numbers.h"
+#include "internal/endian.h"
 #include "prov/implementations.h"
 #include "prov/provider_ctx.h"
 #include "prov/provider_util.h"
@@ -80,12 +81,9 @@ static OSSL_FUNC_kdf_set_ctx_params_fn kbkdf_set_ctx_params;
 static uint32_t be32(uint32_t host)
 {
     uint32_t big = 0;
-    const union {
-        long one;
-        char little;
-    } is_endian = { 1 };
+    DECLARE_IS_ENDIAN;
 
-    if (!is_endian.little)
+    if (!IS_LITTLE_ENDIAN)
         return host;
 
     big |= (host & 0xff000000) >> 24;

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include "testutil.h"
 #include "internal/nelem.h"
-#include "ossl_test_endian.h"
+#include "internal/endian.h"
 #include <openssl/params.h>
 #include <openssl/bn.h>
 


### PR DESCRIPTION
The code relied on B_ENDIAN being defined on all big-endian platform,
which turned out to not always be the case.

Fixes #12387

In doing this, test/ossl_test_endian.h is also moved to include/internal/endian.h
and thereby makes the macros in there our standard way to check endianness
in run-time.