### PR TITLE
ocsp.h: Fix backward compatibility decl for OCSP_parse_url() by including http.h

### DIFF
--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -17,6 +17,7 @@
 # endif
 
 # include <openssl/opensslconf.h>
+# include <openssl/http.h> /* for OSSL_HTTP_parse_url */
 
 /*
  * These definitions are outside the OPENSSL_NO_OCSP guard because although for


### PR DESCRIPTION
Fixes #12386
