### PR TITLE
Universal Windows Platform compatibility fixes

### DIFF
--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -36,13 +36,14 @@ my %targets = (
         # /NODEFAULTLIB:kernel32.lib is needed, because MSVCRT.LIB has
         # hidden reference to kernel32.lib, but we don't actually want
         # it in "onecore" build.
-        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
+        # /APPCONTAINER is needed for Universal Windows Platform compat
+        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
         defines         => add("OPENSSL_SYS_WIN_CORE"),
         ex_libs         => "onecore.lib",
     },
     "VC-WIN64A-ONECORE" => {
         inherit_from    => [ "VC-WIN64A" ],
-        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
         defines         => add("OPENSSL_SYS_WIN_CORE"),
         ex_libs         => "onecore.lib",
     },
@@ -68,7 +69,7 @@ my %targets = (
         defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
                                "OPENSSL_SYS_WIN_CORE"),
         bn_ops          => "BN_LLONG RC4_CHAR",
-        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
         ex_libs         => "onecore.lib",
         multilib        => "-arm",
     },
@@ -77,7 +78,7 @@ my %targets = (
         defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
                                "OPENSSL_SYS_WIN_CORE"),
         bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR",
-        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
         ex_libs         => "onecore.lib",
         multilib        => "-arm64",
     },

--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -34,7 +34,11 @@ void async_local_cleanup(void)
 
 int async_fibre_init_dispatcher(async_fibre *fibre)
 {
+# if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
+    fibre->fibre = ConvertThreadToFiberEx(NULL, FIBER_FLAG_FLOAT_SWITCH);
+# else
     fibre->fibre = ConvertThreadToFiber(NULL);
+# endif
     if (fibre->fibre == NULL) {
         fibre->converted = 0;
         fibre->fibre = GetCurrentFiber();

--- a/crypto/async/arch/async_win.h
+++ b/crypto/async/arch/async_win.h
@@ -26,8 +26,16 @@ typedef struct async_fibre_st {
 
 # define async_fibre_swapcontext(o,n,r) \
         (SwitchToFiber((n)->fibre), 1)
-# define async_fibre_makecontext(c) \
+
+# if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
+#   define async_fibre_makecontext(c) \
+        ((c)->fibre = CreateFiberEx(0, 0, FIBER_FLAG_FLOAT_SWITCH, \
+                                    async_start_func_win, 0))
+# else
+#   define async_fibre_makecontext(c) \
         ((c)->fibre = CreateFiber(0, async_start_func_win, 0))
+# endif
+
 # define async_fibre_free(f)             (DeleteFiber((f)->fibre))
 
 int async_fibre_init_dispatcher(async_fibre *fibre);


### PR DESCRIPTION
These patches fix errors emitted by the [Windows App Certification Kit](https://developer.microsoft.com/en-us/windows/downloads/app-certification-kit/), which is required before an app can be published to the Windows Store.

* `CreateFiber` and `ConvertThreadToFiber` not available when targeting the Universal Windows Platform, but the `Ex` versions of the same are.

* All libraries that target the Universal Windows Platform must be linked with [`/APPCONTAINER`](https://docs.microsoft.com/en-us/cpp/build/reference/appcontainer-windows-store-app)