### PR TITLE
Configurations: make Makefile tmpl files non-links 

### DIFF
--- a/Configurations/README.md
+++ b/Configurations/README.md
@@ -481,11 +481,9 @@ template file in `Configurations/` named like the build file, with
 `.tmpl` appended, or in case of possible ambiguity, a combination of
 the second `build_scheme` list item and the `build_file` name.  For
 example, if `build_file` is set to `Makefile`, the template could be
-[`Configurations/Makefile.tmpl`](Makefile.tmpl) or
-[`Configurations/unix-Makefile.tmpl`](unix-Makefile.tmpl).
-In case both [`Configurations/unix-Makefile.tmpl`](Makefile.tmpl) and
-[`Configurations/Makefile.tmpl`](Makefile.tmpl) are present, the former takes
-precedence.
+`Configurations/Makefile.tmpl` or `Configurations/unix-Makefile.tmpl`.
+In case both `Configurations/unix-Makefile.tmpl` and
+`Configurations/Makefile.tmpl` are present, the former takes precedence.
 
 The build-file template is processed with the perl module
 Text::Template, using `{-` and `-}` as delimiters that enclose the

--- a/Configurations/README.md
+++ b/Configurations/README.md
@@ -480,8 +480,12 @@ For any name given by `build_file`, the "unified" system expects a
 template file in `Configurations/` named like the build file, with
 `.tmpl` appended, or in case of possible ambiguity, a combination of
 the second `build_scheme` list item and the `build_file` name.  For
-example, if `build_file` is set to `Makefile`, the template would be
+example, if `build_file` is set to `Makefile`, the template could be
+[`Configurations/Makefile.tmpl`](Makefile.tmpl) or
 [`Configurations/unix-Makefile.tmpl`](unix-Makefile.tmpl).
+In case both [`Configurations/unix-Makefile.tmpl`](Makefile.tmpl) and
+[`Configurations/Makefile.tmpl`](Makefile.tmpl) are present, the former takes
+precedence.
 
 The build-file template is processed with the perl module
 Text::Template, using `{-` and `-}` as delimiters that enclose the

--- a/Configurations/README.md
+++ b/Configurations/README.md
@@ -480,12 +480,8 @@ For any name given by `build_file`, the "unified" system expects a
 template file in `Configurations/` named like the build file, with
 `.tmpl` appended, or in case of possible ambiguity, a combination of
 the second `build_scheme` list item and the `build_file` name.  For
-example, if `build_file` is set to `Makefile`, the template could be
-[`Configurations/Makefile.tmpl`](Makefile.tmpl) or
+example, if `build_file` is set to `Makefile`, the template would be
 [`Configurations/unix-Makefile.tmpl`](unix-Makefile.tmpl).
-In case both [`Configurations/unix-Makefile.tmpl`](Makefile.tmpl) and
-[`Configurations/Makefile.tmpl`](Makefile.tmpl) are present, the former takes
-precedence.
 
 The build-file template is processed with the perl module
 Text::Template, using `{-` and `-}` as delimiters that enclose the

--- a/Configure
+++ b/Configure
@@ -1830,8 +1830,7 @@ if ($builder eq "unified") {
     # Store the name of the template file we will build the build file from
     # in %config.  This may be useful for the build file itself.
     my @build_file_template_names =
-        ( $builder_platform."-".$target{build_file}.".tmpl",
-          $target{build_file}.".tmpl" );
+        ( $builder_platform."-".$target{build_file}.".tmpl" );
     my @build_file_templates = ();
 
     # First, look in the user provided directory, if given

--- a/Configure
+++ b/Configure
@@ -1830,7 +1830,8 @@ if ($builder eq "unified") {
     # Store the name of the template file we will build the build file from
     # in %config.  This may be useful for the build file itself.
     my @build_file_template_names =
-        ( $builder_platform."-".$target{build_file}.".tmpl" );
+        ( $builder_platform."-".$target{build_file}.".tmpl",
+          $target{build_file}.".tmpl" );
     my @build_file_templates = ();
 
     # First, look in the user provided directory, if given


### PR DESCRIPTION
This commit updates Configurations/README.md and turns the Makefile
templates into non-links.

The motivation for this is that not all template exist in the directory
leading to 404 Not found errors when accessed.
