### PR TITLE
Fix wrong fipsinstall key used in test

### DIFF
--- a/test/recipes/30-test_evp_libctx.t
+++ b/test/recipes/30-test_evp_libctx.t
@@ -38,7 +38,6 @@ unless ($no_fips) {
                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
                '-module', $infile,
                '-provider_name', 'fips', '-mac_name', 'HMAC',
-               '-macopt', 'digest:SHA256', '-macopt', 'hexkey:00',
                '-section_name', 'fips_sect'])),
        "fipsinstall");
 }


### PR DESCRIPTION
This produces an error in the tests on master currently.

A newly merged test (in an old PR) was using the old fips install key.
Changed the test to use default values instead.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
