### PR TITLE
Skip test_cmp_cli if 'lsof' or 'kill' command is not available

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2924,15 +2924,13 @@ int cmp_main(int argc, char **argv)
     ret = 0;
 
     if (opt_batch) {
-#ifndef OPENSSL_NO_ENGINE
         UI_METHOD *ui_fallback_method;
-# ifndef OPENSSL_NO_UI_CONSOLE
+#ifndef OPENSSL_NO_UI_CONSOLE
         ui_fallback_method = UI_OpenSSL();
-# else
+#else
         ui_fallback_method = (UI_METHOD *)UI_null();
-# endif
-        UI_method_set_reader(ui_fallback_method, NULL);
 #endif
+        UI_method_set_reader(ui_fallback_method, NULL);
     }
 
     if (opt_engine != NULL)

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -24,15 +24,20 @@ BEGIN {
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
+plan skip_all => "These tests are not supported in a fuzz build"
+    if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION/;
 
 plan skip_all => "These tests are not supported in a no-cmp build"
     if disabled("cmp");
 plan skip_all => "These tests are not supported in a no-ec build"
     if disabled("ec");
-plan skip_all => "These tests are not supported in a fuzz build"
-    if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION/;
-plan skip_all => "Tests involving server not available on Windows or VMS"
+
+plan skip_all => "Tests involving CMP server not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
+plan skip_all => "Tests involving CMP server require 'kill' command"
+    unless `which kill`;
+plan skip_all => "Tests involving CMP server require 'lsof' command"
+    unless `which lsof`; # this typically excludes Solaris
 
 sub chop_dblquot { # chop any leading & trailing '"' (needed for Windows)
     my $str = shift;

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -219,7 +219,7 @@ indir data_dir() => sub {
         if ($server_name eq "Mock") {
             indir "Mock" => sub {
                 $pid = start_mock_server("");
-                die "Cannot start CMP mock server" unless $pid;
+                die "Cannot start or find the started CMP mock server" unless $pid;
             }
         }
         foreach my $aspect (@all_aspects) {
@@ -294,7 +294,7 @@ sub load_tests {
 }
 
 sub mock_server_pid {
-    return `lsof -iTCP:$server_port -sTCP:LISTEN | tail -n 1 | awk '{ print \$2 }'`;
+    return `lsof -iTCP:$server_port` =~ m/\n\S+\s+(\d+)\s+[^\n]+LISTEN/s ? $1 : 0;
 }
 
 sub start_mock_server {


### PR DESCRIPTION
This fixes the CMP CLI test aspects of #12378 and ~~likely~~ fixes #12324.

This hopefully also fixes #12355.