### PR TITLE
Document pkcs12 alg NONE

### DIFF
--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -236,6 +236,8 @@ can be used (see L</NOTES> section for more information). If a cipher name
 is used with PKCS#5 v2.0. For interoperability reasons it is advisable to only
 use PKCS#12 algorithms.
 
+Special value C<NONE> disables encryption of the private key and certificate.
+
 =item B<-keyex>|B<-keysig>
 
 Specifies that the private key is to be used for key exchange or just signing.


### PR DESCRIPTION
To generate unencrypted PKCS#12 file it is needed to use options: -keypbe NONE -certpbe NONE

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
