### PR TITLE
Fix memory leaks in tests

### DIFF
--- a/crypto/bn/bntest.c
+++ b/crypto/bn/bntest.c
@@ -345,6 +345,9 @@ int main(int argc, char *argv[])
     (void)BIO_flush(out);
 
     BN_CTX_free(ctx);
+    ERR_remove_thread_state(NULL);
+    CRYPTO_cleanup_all_ex_data();
+    CRYPTO_mem_leaks(out);
     BIO_free(out);
 
     EXIT(0);

--- a/crypto/bn/exptest.c
+++ b/crypto/bn/exptest.c
@@ -293,7 +293,9 @@ int main(int argc, char *argv[])
     BN_free(b);
     BN_free(m);
     BN_CTX_free(ctx);
+    ERR_free_strings();
     ERR_remove_thread_state(NULL);
+    CRYPTO_cleanup_all_ex_data();
     CRYPTO_mem_leaks(out);
     BIO_free(out);
     printf("\n");

--- a/crypto/hmac/hmactest.c
+++ b/crypto/hmac/hmactest.c
@@ -317,6 +317,7 @@ test6:
     }
 end:
     HMAC_CTX_cleanup(&ctx);
+    HMAC_CTX_cleanup(&ctx2);
     EXIT(err);
     return (0);
 }

--- a/crypto/mem_dbg.c
+++ b/crypto/mem_dbg.c
@@ -794,6 +794,7 @@ void CRYPTO_mem_leaks_fp(FILE *fp)
     if (!b)
         return;
     BIO_set_fp(b, fp, BIO_NOCLOSE);
+    CRYPTO_cleanup_all_ex_data();
     CRYPTO_mem_leaks(b);
     BIO_free(b);
 }

--- a/crypto/x509v3/v3nametest.c
+++ b/crypto/x509v3/v3nametest.c
@@ -342,5 +342,6 @@ int main(void)
         }
         ++pfn;
     }
+    CRYPTO_cleanup_all_ex_data();
     return errors > 0 ? 1 : 0;
 }

--- a/ssl/bad_dtls_test.c
+++ b/ssl/bad_dtls_test.c
@@ -922,5 +922,7 @@ int main(int argc, char *argv[])
     CRYPTO_mem_leaks(err);
     BIO_free(err);
 
+    SSL_COMP_free_compression_methods();
+
     return testresult?0:1;
 }

--- a/ssl/clienthellotest.c
+++ b/ssl/clienthellotest.c
@@ -215,5 +215,7 @@ int main(int argc, char *argv[])
     CRYPTO_mem_leaks(err);
     BIO_free(err);
 
+    SSL_COMP_free_compression_methods();
+
     return testresult?0:1;
 }


### PR DESCRIPTION
CLA: trivial

This pull request aims to fix memory leaks in some tests. Leaky tests are annoying, because you can never be 100%
sure if it's the test or the actual library code which leaks memory, until you completely fix the problem.
I found them with the help of a proprietary memory leak detection tool, but in retrospect I think most of them are quite visible.
For example, I'm no OpenSSL expert, but if I think about it, it's very obvious that if we create a `ctx` and a `ctx2` context we will have to cleanup both of them.
In case you cannot accept this PR without a publicly available software assisted method of validating it, can you please point me to some free memory leak detection tools? I tried [https://drmemory.org/](url), and it seems to find a few memory issues (like use of unintialized memory), but none of them are leaks.