### PR TITLE
Fix for the bug in ssl_version_supported()

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1609,14 +1609,16 @@ int ssl_version_supported(const SSL *s, int version, const SSL_METHOD **meth)
     for (vent = table;
          vent->version != 0 && version_cmp(s, version, vent->version) <= 0;
          ++vent) {
-        if (vent->cmeth != NULL
+        const SSL_METHOD *(*ret_meth) (void);
+        ret_meth = s->server ? vent->smeth : vent->cmeth;
+        if ( ret_meth != NULL
                 && version_cmp(s, version, vent->version) == 0
-                && ssl_method_error(s, vent->cmeth()) == 0
+                && ssl_method_error(s, ret_meth()) == 0
                 && (!s->server
                     || version != TLS1_3_VERSION
                     || is_tls13_capable(s))) {
             if (meth != NULL)
-                *meth = vent->cmeth();
+                *meth = ret_meth();
             return 1;
         }
     }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1611,7 +1611,7 @@ int ssl_version_supported(const SSL *s, int version, const SSL_METHOD **meth)
          ++vent) {
         const SSL_METHOD *(*ret_meth) (void);
         ret_meth = s->server ? vent->smeth : vent->cmeth;
-        if ( ret_meth != NULL
+        if (ret_meth != NULL
                 && version_cmp(s, version, vent->version) == 0
                 && ssl_method_error(s, ret_meth()) == 0
                 && (!s->server

--- a/test/build.info
+++ b/test/build.info
@@ -54,7 +54,7 @@ IF[{- !$disabled{tests} -}]
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest drbg_cavs_test drbg_extra_test sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
-          http_test servername_test ocspapitest fatalerrtest tls13ccstest \
+          http_test servername_test method_test ocspapitest fatalerrtest tls13ccstest \
           sysdefaulttest errtest ssl_ctx_test gosttest \
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test
@@ -400,6 +400,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[servername_test]=servername_test.c ssltestlib.c
   INCLUDE[servername_test]=../include ../apps/include
   DEPEND[servername_test]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[method_test]=method_test.c ssltestlib.c
+  INCLUDE[method_test]=.. ../include ../apps/include
+  DEPEND[method_test]=../libcrypto ../libssl libtestutil.a
 
   IF[{- !$disabled{cms} -}]
     PROGRAMS{noinst}=cmsapitest

--- a/test/method_test.c
+++ b/test/method_test.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2017 BaishanCloud. All rights reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/ssl.h>
+
+#include "testutil.h"
+#include "../ssl/ssl_local.h"
+#include "ssltestlib.h"
+
+static char *cert = NULL;
+static char *pvk = NULL;
+
+struct subtest {
+	int min_version;
+	int max_version;
+	const SSL_METHOD* server_method;
+	const SSL_METHOD* client_method;
+};
+
+#define SUBTEST_TLS1_2_VERSION	0
+#define SUBTEST_TLS1_3_VERSION	1
+#define SUBTEST_QUANTITY		2
+
+static struct subtest subtests[] = {
+	{ TLS1_VERSION, TLS1_2_VERSION, NULL, NULL }, 
+	{ TLS1_VERSION, TLS1_3_VERSION, NULL, NULL }};
+
+static int test_method(int test)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(), TLS_client_method(), subtests[test].min_version, subtests[test].max_version, &sctx, &cctx, cert, pvk))
+     || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_get_ssl_method(serverssl)->ssl_accept == ossl_statem_accept && SSL_get_ssl_method(serverssl)->ssl_connect == ssl_undefined_function &&
+   	    		   SSL_get_ssl_method(clientssl)->ssl_accept == ssl_undefined_function && SSL_get_ssl_method(clientssl)->ssl_connect == ossl_statem_connect))
+        goto end;
+
+	if (!TEST_true(SSL_get_ssl_method(serverssl) == subtests[test].server_method && SSL_get_ssl_method(clientssl) == subtests[test].client_method))	
+        goto end;
+	
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
+int setup_tests(void)
+{
+	subtests[SUBTEST_TLS1_2_VERSION].server_method = tlsv1_2_server_method();
+	subtests[SUBTEST_TLS1_2_VERSION].client_method = tlsv1_2_client_method();
+	subtests[SUBTEST_TLS1_3_VERSION].server_method = tlsv1_3_server_method();
+	subtests[SUBTEST_TLS1_3_VERSION].client_method = tlsv1_3_client_method();
+
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(cert = test_get_argument(0)) || !TEST_ptr(pvk = test_get_argument(1)))
+        return 0;
+
+    ADD_ALL_TESTS(test_method, SUBTEST_QUANTITY);
+    return 1;
+}

--- a/test/recipes/70-test_method.t
+++ b/test/recipes/70-test_method.t
@@ -1,0 +1,23 @@
+#! /usr/bin/env perl
+# Copyright 2020-2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License 2.0 (the "License").  You may not use
+#  this file except in compliance with the License.  You can obtain a copy
+#  in the file LICENSE in the source distribution or at
+#  https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test::Simple;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils qw(alldisabled available_protocols);
+
+setup("test_method");
+
+plan skip_all => "No TLS/SSL protocols are supported by this OpenSSL build"
+    if alldisabled(grep { $_ ne "ssl3" } available_protocols("tls"));
+
+plan tests => 1;
+
+ok(run(test(["method_test", srctop_file("apps", "server.pem"), srctop_file("apps", "server.pem")])), "running method_test");


### PR DESCRIPTION
Bug in ssl_version_supported() - the chosen SSL_METHOD returned from the function is always a client side method, ever for the server side.

This is a typical sequence for TLS server side code to reproduce the bug:
1. Create new SSL_CTX_new( TLS_server_method() );
2. Call SSL_accept() that calls SSL_set_accept_state() that sets s->handshake_func = s->method->ssl_accept; i.e. initialises handshake_func of SSL* to the correct ssl_accept function of TLS_server_method()
3. Afterwards in the flow ssl_choose_server_version() is called that calls ssl_version_supported() that changes s->method to the method of the best suitable version but always to the client method, even for the server side
4. Therefore say we are using min and max TLS version TLS 1.2 - for the server side SSL* we have get s->method == tlsv1_2_client_method() nevertheless s->server == 1
This is not harmful meanwhile but could cause a bug in the further code development.

##### Checklist
- [x] tests are added