### PR TITLE
[1.1.1][test] Avoid missing EC_GROUP wrappers

### DIFF
--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2123,9 +2123,7 @@ static int custom_generator_test(int id)
         goto err;
 
     /* expected byte length of encoded points */
-    bsize = (EC_GROUP_get_field_type(group) == NID_X9_62_prime_field) ?
-             BN_num_bytes(EC_GROUP_get0_field(group)) :
-             (EC_GROUP_get_degree(group) + 7) / 8;
+    bsize = (EC_GROUP_get_degree(group) + 7) / 8;
     bsize = 2 * bsize + 1;
 
     if (!TEST_ptr(k = BN_CTX_get(ctx))


### PR DESCRIPTION
Backport of https://github.com/openssl/openssl/pull/12096 to 1.1.1 broke
the build as the following functions are missing:

    const BIGNUM *EC_GROUP_get0_field(const EC_GROUP *group);
    int EC_GROUP_get_field_type(const EC_GROUP *group);

Turns out that for the purposes of the test code, we don't really need
to differentiate between prime and binary fields, and we can directly
use the existing `EC_GROUP_get_degree()` in the same fashion as was
being done for binary fields also for prime fields.

Fixes https://github.com/openssl/openssl/issues/12432

##### Checklist

- [x] tests are added or updated
