### PR TITLE
x86 SHA: ask for help demystifying some comments.

### DIFF
--- a/crypto/aes/asm/aesni-sha1-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha1-x86_64.pl
@@ -1817,11 +1817,11 @@ $code.=<<___;
 	paddd		@MSG[0],$E
 	movdqu		0x20($inp),@MSG[2]
 	lea		0x40($inp),$inp
-	pxor		$E_SAVE,@MSG[0]		# black magic
+	pxor		$E_SAVE,@MSG[0]		# magic: could somebody add a note explaining what is being done?
 ___
 	&$aesenc();
 $code.=<<___;
-	pxor		$E_SAVE,@MSG[0]		# black magic
+	pxor		$E_SAVE,@MSG[0]		# magic: could somebody add a note explaining what is being done?
 	movdqa		$ABCD,$E_
 	pshufb		$BSWAP,@MSG[2]
 	sha1rnds4	\$0,$E,$ABCD		# 0-3

--- a/crypto/aes/asm/aesni-sha256-x86_64.pl
+++ b/crypto/aes/asm/aesni-sha256-x86_64.pl
@@ -1549,11 +1549,11 @@ ___
 	&$aesenc();
 $code.=<<___;
 	sha256rnds2	$CDGH,$ABEF
-	#pxor		$CDGH,$rndkey0		# black magic
+	#pxor		$CDGH,$rndkey0		# magic: could somebody add a note explaining what is being done?
 ___
 	while ($r<40)	{ &$aesenc(); }		# remaining aesenc's
 $code.=<<___;
-	#xorps		$CDGH,$rndkey0		# black magic
+	#xorps		$CDGH,$rndkey0		# magic: could somebody add a note explaining what is being done?
 	paddd		$CDGH_SAVE,$CDGH
 	paddd		$ABEF_SAVE,$ABEF
 

--- a/crypto/sha/asm/sha256-mb-x86_64.pl
+++ b/crypto/sha/asm/sha256-mb-x86_64.pl
@@ -542,23 +542,23 @@ $code.=<<___;
 	movdqa		0*16-0x80($Tbl),$Wi
 	pshufb		$TMPx,@MSG0[1]
 	paddd		@MSG0[0],$Wi
-	pxor		$ABEF0,@MSG0[0]		# black magic
+	pxor		$ABEF0,@MSG0[0]		# magic: could somebody add a note explaining what is being done?
 	movdqa		$Wi,$TMP0
 	 movdqa		0*16-0x80($Tbl),$TMP1
 	 pshufb		$TMPx,@MSG1[1]
 	 paddd		@MSG1[0],$TMP1
 	movdqa		$CDGH0,0x50(%rsp)	# offload
 	sha256rnds2	$ABEF0,$CDGH0		# 0-3
-	 pxor		$ABEF1,@MSG1[0]		# black magic
+	 pxor		$ABEF1,@MSG1[0]		# magic: could somebody add a note explaining what is being done?
 	 movdqa		$TMP1,$Wi
 	 movdqa		$CDGH1,0x70(%rsp)
 	 sha256rnds2	$ABEF1,$CDGH1		# 0-3
 	pshufd		\$0x0e,$TMP0,$Wi
-	pxor		$ABEF0,@MSG0[0]		# black magic
+	pxor		$ABEF0,@MSG0[0]		# magic: could somebody add a note explaining what is being done?
 	movdqa		$ABEF0,0x40(%rsp)	# offload
 	sha256rnds2	$CDGH0,$ABEF0
 	 pshufd		\$0x0e,$TMP1,$Wi
-	 pxor		$ABEF1,@MSG1[0]		# black magic
+	 pxor		$ABEF1,@MSG1[0]		# magic: could somebody add a note explaining what is being done?
 	 movdqa		$ABEF1,0x60(%rsp)
 	movdqa		1*16-0x80($Tbl),$TMP0
 	paddd		@MSG0[1],$TMP0


### PR DESCRIPTION
There were a number of comments "black magic" in the assembly code
which are unhelpful.

These have been replaced by a request for somebody to add a note explaining
what is happening.


This should cherrypick to 1.1.1.