### PR TITLE
man3: Drop warning about using security levels higher than 1.

### DIFF
--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -114,12 +114,6 @@ I<Documentation to be provided.>
 
 =head1 NOTES
 
-B<WARNING> at this time setting the security level higher than 1 for
-general internet use is likely to cause B<considerable> interoperability
-issues and is not recommended. This is because the B<SHA1> algorithm
-is very widely used in certificates and will be rejected at levels
-higher than 1 because it only offers 80 bits of security.
-
 The default security level can be configured when OpenSSL is compiled by
 setting B<-DOPENSSL_TLS_SECURITY_LEVEL=level>. If not set then 1 is used.
 


### PR DESCRIPTION
Today, majority of web-browsers reject communication as allowed by the
security level 1. Instead key sizes and algorithms from security level
2 are required. Thus remove the now obsolete warning against using
security levels higher than 1. For example Ubuntu, compiles OpenSSL
with security level set to 2, and further restricts algorithm versions
available at that security level.

##### Checklist
- [x] documentation is added or updated
