### PR TITLE
Fix trailing whitespace mismatch error when running 02-test_errstr.

### DIFF
--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2018 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2018-2020 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -49,7 +49,7 @@ use constant ERR_LIB_NONE => 1;
 plan tests => scalar @Errno::EXPORT_OK
     +1                          # Checking that error 128 gives 'reason(128)'
     +1                          # Checking that error 0 gives the library name
-    ;
+    +1;                         # Check trailing whitespace is removed.
 
 # Test::More:ok() has a sub prototype, which means we need to use the '&ok'
 # syntax to force it to accept a list as a series of arguments.
@@ -66,6 +66,7 @@ foreach my $errname (@Errno::EXPORT_OK) {
 # Reason code 0 of any library gives the library name as reason
 &ok(match_opensslerr_reason(ERR_LIB_NONE << ERR_LIB_OFFSET |   0,
                             "unknown library"));
+&ok(match_any("Trailing whitespace  \n\t", "?", ( "Trailing whitespace" )));
 
 exit 0;
 
@@ -92,6 +93,9 @@ sub match_any {
     my $first = shift;
     my $desc = shift;
     my @strings = @_;
+
+    # ignore trailing whitespace
+    $first =~ s/\s+$//;
 
     if (scalar @strings > 1) {
         $desc = "match '$first' ($desc) with one of ( '"


### PR DESCRIPTION
Fixes #12449

On a aix7_ppc32 machine the error was of the form
match 'Previous owner died ' (2147483743) with one of ( 'Previous owner died', 'reason(95)' )
Stripping the trailing whitespace from the system error will address this issue.

Suggested fix by @pauldale.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
