### PR TITLE
util/find-doc-nits: read full declarations as one line in name_synopsis()

### DIFF
--- a/doc/internal/man3/ossl_algorithm_do_all.pod
+++ b/doc/internal/man3/ossl_algorithm_do_all.pod
@@ -11,7 +11,7 @@ ossl_algorithm_do_all - generic algorithm implementation iterator
                             void (*fn)(OSSL_PROVIDER *provider,
                                        const OSSL_ALGORITHM *algo,
                                        int no_store, void *data),
-                            void *data)
+                            void *data);
 
 =head1 DESCRIPTION
 

--- a/doc/internal/man3/ossl_cmp_certReq_new.pod
+++ b/doc/internal/man3/ossl_cmp_certReq_new.pod
@@ -61,13 +61,13 @@ ossl_cmp_error_new
                                      const char *text);
  OSSL_CMP_MSG *ossl_cmp_pkiconf_new(OSSL_CMP_CTX *ctx);
  OSSL_CMP_MSG *ossl_cmp_pollReq_new(OSSL_CMP_CTX *ctx, int crid);
- OSSL_CMP_MSG *ossl_cmp_pollRep_new(OSSL_CMP_CTX *ctx, int crid, int poll_after)
+ OSSL_CMP_MSG *ossl_cmp_pollRep_new(OSSL_CMP_CTX *ctx, int crid, int poll_after);
  OSSL_CMP_MSG *ossl_cmp_genm_new(OSSL_CMP_CTX *ctx);
  OSSL_CMP_MSG *ossl_cmp_genp_new(OSSL_CMP_CTX *ctx);
  OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
                                   int errorCode,
                                   OSSL_CMP_PKIFREETEXT *errorDetails,
-                                  int unprotected)
+                                  int unprotected);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/BIO_f_cipher.pod
+++ b/doc/man3/BIO_f_cipher.pod
@@ -14,8 +14,8 @@ BIO_f_cipher, BIO_set_cipher, BIO_get_cipher_status, BIO_get_cipher_ctx - cipher
  const BIO_METHOD *BIO_f_cipher(void);
  void BIO_set_cipher(BIO *b, const EVP_CIPHER *cipher,
                      unsigned char *key, unsigned char *iv, int enc);
- int BIO_get_cipher_status(BIO *b)
- int BIO_get_cipher_ctx(BIO *b, EVP_CIPHER_CTX **pctx)
+ int BIO_get_cipher_status(BIO *b);
+ int BIO_get_cipher_ctx(BIO *b, EVP_CIPHER_CTX **pctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/BIO_printf.pod
+++ b/doc/man3/BIO_printf.pod
@@ -9,11 +9,11 @@ BIO_printf, BIO_vprintf, BIO_snprintf, BIO_vsnprintf
 
  #include <openssl/bio.h>
 
- int BIO_printf(BIO *bio, const char *format, ...)
- int BIO_vprintf(BIO *bio, const char *format, va_list args)
+ int BIO_printf(BIO *bio, const char *format, ...);
+ int BIO_vprintf(BIO *bio, const char *format, va_list args);
 
- int BIO_snprintf(char *buf, size_t n, const char *format, ...)
- int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)
+ int BIO_snprintf(char *buf, size_t n, const char *format, ...);
+ int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/BIO_s_file.pod
+++ b/doc/man3/BIO_s_file.pod
@@ -17,10 +17,10 @@ BIO_rw_filename - FILE bio
  BIO_set_fp(BIO *b, FILE *fp, int flags);
  BIO_get_fp(BIO *b, FILE **fpp);
 
- int BIO_read_filename(BIO *b, char *name)
- int BIO_write_filename(BIO *b, char *name)
- int BIO_append_filename(BIO *b, char *name)
- int BIO_rw_filename(BIO *b, char *name)
+ int BIO_read_filename(BIO *b, char *name);
+ int BIO_write_filename(BIO *b, char *name);
+ int BIO_append_filename(BIO *b, char *name);
+ int BIO_rw_filename(BIO *b, char *name);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -13,10 +13,10 @@ BIO_get_mem_ptr, BIO_new_mem_buf - memory BIO
  const BIO_METHOD *BIO_s_mem(void);
  const BIO_METHOD *BIO_s_secmem(void);
 
- BIO_set_mem_eof_return(BIO *b, int v)
- long BIO_get_mem_data(BIO *b, char **pp)
- BIO_set_mem_buf(BIO *b, BUF_MEM *bm, int c)
- BIO_get_mem_ptr(BIO *b, BUF_MEM **pp)
+ BIO_set_mem_eof_return(BIO *b, int v);
+ long BIO_get_mem_data(BIO *b, char **pp);
+ BIO_set_mem_buf(BIO *b, BUF_MEM *bm, int c);
+ BIO_get_mem_ptr(BIO *b, BUF_MEM **pp);
 
  BIO *BIO_new_mem_buf(const void *buf, int len);
 

--- a/doc/man3/CONF_modules_free.pod
+++ b/doc/man3/CONF_modules_free.pod
@@ -16,7 +16,7 @@ Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- void CONF_modules_free(void)
+ void CONF_modules_free(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -25,7 +25,7 @@ CRYPTO_free_ex_data, CRYPTO_new_ex_data
  typedef int CRYPTO_EX_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
                            void **from_d, int idx, long argl, void *argp);
 
- int CRYPTO_new_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
+ int CRYPTO_new_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad);
 
  int CRYPTO_alloc_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad,
                           int idx);

--- a/doc/man3/DH_get_1024_160.pod
+++ b/doc/man3/DH_get_1024_160.pod
@@ -23,24 +23,24 @@ BN_get_rfc3526_prime_8192
 =head1 SYNOPSIS
 
  #include <openssl/dh.h>
- DH *DH_get_1024_160(void)
- DH *DH_get_2048_224(void)
- DH *DH_get_2048_256(void)
+ DH *DH_get_1024_160(void);
+ DH *DH_get_2048_224(void);
+ DH *DH_get_2048_256(void);
 
- const BIGNUM *BN_get0_nist_prime_192(void)
- const BIGNUM *BN_get0_nist_prime_224(void)
- const BIGNUM *BN_get0_nist_prime_256(void)
- const BIGNUM *BN_get0_nist_prime_384(void)
- const BIGNUM *BN_get0_nist_prime_521(void)
+ const BIGNUM *BN_get0_nist_prime_192(void);
+ const BIGNUM *BN_get0_nist_prime_224(void);
+ const BIGNUM *BN_get0_nist_prime_256(void);
+ const BIGNUM *BN_get0_nist_prime_384(void);
+ const BIGNUM *BN_get0_nist_prime_521(void);
 
- BIGNUM *BN_get_rfc2409_prime_768(BIGNUM *bn)
- BIGNUM *BN_get_rfc2409_prime_1024(BIGNUM *bn)
- BIGNUM *BN_get_rfc3526_prime_1536(BIGNUM *bn)
- BIGNUM *BN_get_rfc3526_prime_2048(BIGNUM *bn)
- BIGNUM *BN_get_rfc3526_prime_3072(BIGNUM *bn)
- BIGNUM *BN_get_rfc3526_prime_4096(BIGNUM *bn)
- BIGNUM *BN_get_rfc3526_prime_6144(BIGNUM *bn)
- BIGNUM *BN_get_rfc3526_prime_8192(BIGNUM *bn)
+ BIGNUM *BN_get_rfc2409_prime_768(BIGNUM *bn);
+ BIGNUM *BN_get_rfc2409_prime_1024(BIGNUM *bn);
+ BIGNUM *BN_get_rfc3526_prime_1536(BIGNUM *bn);
+ BIGNUM *BN_get_rfc3526_prime_2048(BIGNUM *bn);
+ BIGNUM *BN_get_rfc3526_prime_3072(BIGNUM *bn);
+ BIGNUM *BN_get_rfc3526_prime_4096(BIGNUM *bn);
+ BIGNUM *BN_get_rfc3526_prime_6144(BIGNUM *bn);
+ BIGNUM *BN_get_rfc3526_prime_8192(BIGNUM *bn);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -26,8 +26,8 @@ objects
 
  #include <openssl/ec.h>
 
- EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
- EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params)
+ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params);
+ EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params);
  void EC_GROUP_free(EC_GROUP *group);
 
  EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
@@ -51,8 +51,10 @@ objects
  int EC_GROUP_get_curve_GF2m(const EC_GROUP *group, BIGNUM *p,
                              BIGNUM *a, BIGNUM *b, BN_CTX *ctx);
 
- ECPARAMETERS *EC_GROUP_get_ecparameters(const EC_GROUP *group, ECPARAMETERS *params)
- ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group, ECPKPARAMETERS *params)
+ ECPARAMETERS *EC_GROUP_get_ecparameters(const EC_GROUP *group,
+                                         ECPARAMETERS *params);
+ ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group,
+                                             ECPKPARAMETERS *params);
 
  size_t EC_get_builtin_curves(EC_builtin_curve *r, size_t nitems);
 

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -158,7 +158,7 @@ Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- void ENGINE_cleanup(void)
+ void ENGINE_cleanup(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/ERR_print_errors.pod
+++ b/doc/man3/ERR_print_errors.pod
@@ -11,8 +11,8 @@ ERR_print_errors, ERR_print_errors_fp, ERR_print_errors_cb
 
  void ERR_print_errors(BIO *bp);
  void ERR_print_errors_fp(FILE *fp);
- void ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u), void *u)
-
+ void ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u),
+                          void *u);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -111,8 +111,9 @@ EVP_PKEY_CTX_set1_id, EVP_PKEY_CTX_get1_id, EVP_PKEY_CTX_get1_id_len
  int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
  int EVP_PKEY_CTX_get_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD **md);
  int EVP_PKEY_CTX_get_rsa_oaep_md_name(EVP_PKEY_CTX *ctx, char *name,
-                                       size_t namelen)
- int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *label, int len);
+                                       size_t namelen);
+ int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *label,
+                                      int len);
  int EVP_PKEY_CTX_get0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char **label);
 
  #include <openssl/dsa.h>

--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -10,7 +10,7 @@ EVP_PKEY_get_default_digest_nid, EVP_PKEY_get_default_digest_name
  #include <openssl/evp.h>
 
  int EVP_PKEY_get_default_digest_name(EVP_PKEY *pkey,
-                                      char *mdname, size_t mdname_sz)
+                                      char *mdname, size_t mdname_sz);
  int EVP_PKEY_get_default_digest_nid(EVP_PKEY *pkey, int *pnid);
 
 =head1 DESCRIPTION

--- a/doc/man3/EVP_bf_cbc.pod
+++ b/doc/man3/EVP_bf_cbc.pod
@@ -13,11 +13,11 @@ EVP_bf_ofb
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_bf_cbc(void)
- const EVP_CIPHER *EVP_bf_cfb(void)
- const EVP_CIPHER *EVP_bf_cfb64(void)
- const EVP_CIPHER *EVP_bf_ecb(void)
- const EVP_CIPHER *EVP_bf_ofb(void)
+ const EVP_CIPHER *EVP_bf_cbc(void);
+ const EVP_CIPHER *EVP_bf_cfb(void);
+ const EVP_CIPHER *EVP_bf_cfb64(void);
+ const EVP_CIPHER *EVP_bf_ecb(void);
+ const EVP_CIPHER *EVP_bf_ofb(void);
 
 =head1 DESCRIPTION
 
@@ -59,4 +59,3 @@ in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.
 
 =cut
-

--- a/doc/man3/EVP_cast5_cbc.pod
+++ b/doc/man3/EVP_cast5_cbc.pod
@@ -13,11 +13,11 @@ EVP_cast5_ofb
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_cast5_cbc(void)
- const EVP_CIPHER *EVP_cast5_cfb(void)
- const EVP_CIPHER *EVP_cast5_cfb64(void)
- const EVP_CIPHER *EVP_cast5_ecb(void)
- const EVP_CIPHER *EVP_cast5_ofb(void)
+ const EVP_CIPHER *EVP_cast5_cbc(void);
+ const EVP_CIPHER *EVP_cast5_cfb(void);
+ const EVP_CIPHER *EVP_cast5_cfb64(void);
+ const EVP_CIPHER *EVP_cast5_ecb(void);
+ const EVP_CIPHER *EVP_cast5_ofb(void);
 
 =head1 DESCRIPTION
 
@@ -59,4 +59,3 @@ in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.
 
 =cut
-

--- a/doc/man3/EVP_chacha20.pod
+++ b/doc/man3/EVP_chacha20.pod
@@ -10,8 +10,8 @@ EVP_chacha20_poly1305
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_chacha20(void)
- const EVP_CIPHER *EVP_chacha20_poly1305(void)
+ const EVP_CIPHER *EVP_chacha20(void);
+ const EVP_CIPHER *EVP_chacha20_poly1305(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/EVP_desx_cbc.pod
+++ b/doc/man3/EVP_desx_cbc.pod
@@ -9,7 +9,7 @@ EVP_desx_cbc
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_desx_cbc(void)
+ const EVP_CIPHER *EVP_desx_cbc(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/EVP_idea_cbc.pod
+++ b/doc/man3/EVP_idea_cbc.pod
@@ -13,11 +13,11 @@ EVP_idea_ofb
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_idea_cbc(void)
- const EVP_CIPHER *EVP_idea_cfb(void)
- const EVP_CIPHER *EVP_idea_cfb64(void)
- const EVP_CIPHER *EVP_idea_ecb(void)
- const EVP_CIPHER *EVP_idea_ofb(void)
+ const EVP_CIPHER *EVP_idea_cbc(void);
+ const EVP_CIPHER *EVP_idea_cfb(void);
+ const EVP_CIPHER *EVP_idea_cfb64(void);
+ const EVP_CIPHER *EVP_idea_ecb(void);
+ const EVP_CIPHER *EVP_idea_ofb(void);
 
 =head1 DESCRIPTION
 
@@ -57,4 +57,3 @@ in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.
 
 =cut
-

--- a/doc/man3/EVP_rc2_cbc.pod
+++ b/doc/man3/EVP_rc2_cbc.pod
@@ -15,13 +15,13 @@ EVP_rc2_64_cbc
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_rc2_cbc(void)
- const EVP_CIPHER *EVP_rc2_cfb(void)
- const EVP_CIPHER *EVP_rc2_cfb64(void)
- const EVP_CIPHER *EVP_rc2_ecb(void)
- const EVP_CIPHER *EVP_rc2_ofb(void)
- const EVP_CIPHER *EVP_rc2_40_cbc(void)
- const EVP_CIPHER *EVP_rc2_64_cbc(void)
+ const EVP_CIPHER *EVP_rc2_cbc(void);
+ const EVP_CIPHER *EVP_rc2_cfb(void);
+ const EVP_CIPHER *EVP_rc2_cfb64(void);
+ const EVP_CIPHER *EVP_rc2_ecb(void);
+ const EVP_CIPHER *EVP_rc2_ofb(void);
+ const EVP_CIPHER *EVP_rc2_40_cbc(void);
+ const EVP_CIPHER *EVP_rc2_64_cbc(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/EVP_rc4.pod
+++ b/doc/man3/EVP_rc4.pod
@@ -11,9 +11,9 @@ EVP_rc4_hmac_md5
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_rc4(void)
- const EVP_CIPHER *EVP_rc4_40(void)
- const EVP_CIPHER *EVP_rc4_hmac_md5(void)
+ const EVP_CIPHER *EVP_rc4(void);
+ const EVP_CIPHER *EVP_rc4_40(void);
+ const EVP_CIPHER *EVP_rc4_hmac_md5(void);
 
 =head1 DESCRIPTION
 
@@ -65,4 +65,3 @@ in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.
 
 =cut
-

--- a/doc/man3/EVP_rc5_32_12_16_cbc.pod
+++ b/doc/man3/EVP_rc5_32_12_16_cbc.pod
@@ -13,11 +13,11 @@ EVP_rc5_32_12_16_ofb
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_rc5_32_12_16_cbc(void)
- const EVP_CIPHER *EVP_rc5_32_12_16_cfb(void)
- const EVP_CIPHER *EVP_rc5_32_12_16_cfb64(void)
- const EVP_CIPHER *EVP_rc5_32_12_16_ecb(void)
- const EVP_CIPHER *EVP_rc5_32_12_16_ofb(void)
+ const EVP_CIPHER *EVP_rc5_32_12_16_cbc(void);
+ const EVP_CIPHER *EVP_rc5_32_12_16_cfb(void);
+ const EVP_CIPHER *EVP_rc5_32_12_16_cfb64(void);
+ const EVP_CIPHER *EVP_rc5_32_12_16_ecb(void);
+ const EVP_CIPHER *EVP_rc5_32_12_16_ofb(void);
 
 =head1 DESCRIPTION
 
@@ -79,4 +79,3 @@ in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.
 
 =cut
-

--- a/doc/man3/EVP_seed_cbc.pod
+++ b/doc/man3/EVP_seed_cbc.pod
@@ -13,11 +13,11 @@ EVP_seed_ofb
 
  #include <openssl/evp.h>
 
- const EVP_CIPHER *EVP_seed_cbc(void)
- const EVP_CIPHER *EVP_seed_cfb(void)
- const EVP_CIPHER *EVP_seed_cfb128(void)
- const EVP_CIPHER *EVP_seed_ecb(void)
- const EVP_CIPHER *EVP_seed_ofb(void)
+ const EVP_CIPHER *EVP_seed_cbc(void);
+ const EVP_CIPHER *EVP_seed_cfb(void);
+ const EVP_CIPHER *EVP_seed_cfb128(void);
+ const EVP_CIPHER *EVP_seed_ecb(void);
+ const EVP_CIPHER *EVP_seed_ofb(void);
 
 =head1 DESCRIPTION
 
@@ -59,4 +59,3 @@ in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.
 
 =cut
-

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -39,7 +39,7 @@ Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- void OBJ_cleanup(void)
+ void OBJ_cleanup(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -48,7 +48,7 @@ OPENSSL_MALLOC_FD
  char *CRYPTO_strndup(const char *p, size_t num, const char *file, int line);
  void *CRYPTO_clear_realloc(void *p, size_t old_len, size_t num,
                             const char *file, int line);
- void CRYPTO_clear_free(void *str, size_t num, const char *, int)
+ void CRYPTO_clear_free(void *str, size_t num, const char *, int);
 
  typedef void *(*CRYPTO_malloc_fn)(size_t num, const char *file, int line);
  typedef void *(*CRYPTO_realloc_fn)(void *addr, size_t num, const char *file,
@@ -73,9 +73,9 @@ Deprecated:
  int CRYPTO_mem_leaks_cb(int (*cb)(const char *str, size_t len, void *u),
                          void *u);
 
- int CRYPTO_set_mem_debug(int onoff)
+ int CRYPTO_set_mem_debug(int onoff);
  int CRYPTO_mem_ctrl(int mode);
- int OPENSSL_mem_debug_push(const char *info)
+ int OPENSSL_mem_debug_push(const char *info);
  int OPENSSL_mem_debug_pop(void);
  int CRYPTO_mem_debug_push(const char *info, const char *file, int line);
  int CRYPTO_mem_debug_pop(void);

--- a/doc/man3/OpenSSL_add_all_algorithms.pod
+++ b/doc/man3/OpenSSL_add_all_algorithms.pod
@@ -17,7 +17,7 @@ L<openssl_user_macros(7)>:
  void OpenSSL_add_all_ciphers(void);
  void OpenSSL_add_all_digests(void);
 
- void EVP_cleanup(void)
+ void EVP_cleanup(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -17,8 +17,11 @@ OPENSSL_VERSION_NUMBER, OpenSSL_version_num, OPENSSL_info
  #define OPENSSL_VERSION_MAJOR  x
  #define OPENSSL_VERSION_MINOR  y
  #define OPENSSL_VERSION_PATCH  z
+
+ /* The definitions here are typical release values */
  #define OPENSSL_VERSION_PRE_RELEASE ""
  #define OPENSSL_VERSION_BUILD_METADATA ""
+
  #define OPENSSL_VERSION_TEXT "OpenSSL x.y.z xx XXX xxxx"
 
  #include <openssl/crypto.h>
@@ -28,13 +31,17 @@ OPENSSL_VERSION_NUMBER, OpenSSL_version_num, OPENSSL_info
  unsigned int OPENSSL_version_patch(void);
  const char *OPENSSL_version_pre_release(void);
  const char *OPENSSL_version_build_metadata(void);
+
  const char *OpenSSL_version(int t);
+
  const char *OPENSSL_info(int t);
 
 Deprecated:
 
+ /* from openssl/opensslv.h */
  #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnnL
 
+ /* from openssl/crypto.h */
  unsigned long OpenSSL_version_num();
 
 =head1 DESCRIPTION

--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -17,11 +17,8 @@ OPENSSL_VERSION_NUMBER, OpenSSL_version_num, OPENSSL_info
  #define OPENSSL_VERSION_MAJOR  x
  #define OPENSSL_VERSION_MINOR  y
  #define OPENSSL_VERSION_PATCH  z
-
- /* The definitions here are typical release values */
  #define OPENSSL_VERSION_PRE_RELEASE ""
  #define OPENSSL_VERSION_BUILD_METADATA ""
-
  #define OPENSSL_VERSION_TEXT "OpenSSL x.y.z xx XXX xxxx"
 
  #include <openssl/crypto.h>
@@ -31,17 +28,13 @@ OPENSSL_VERSION_NUMBER, OpenSSL_version_num, OPENSSL_info
  unsigned int OPENSSL_version_patch(void);
  const char *OPENSSL_version_pre_release(void);
  const char *OPENSSL_version_build_metadata(void);
-
  const char *OpenSSL_version(int t);
-
  const char *OPENSSL_info(int t);
 
 Deprecated:
 
- /* from openssl/opensslv.h */
  #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnnL
 
- /* from openssl/crypto.h */
  unsigned long OpenSSL_version_num();
 
 =head1 DESCRIPTION

--- a/doc/man3/PEM_read.pod
+++ b/doc/man3/PEM_read.pod
@@ -11,9 +11,9 @@ PEM_read, PEM_read_bio, PEM_do_header, PEM_get_EVP_CIPHER_INFO
  #include <openssl/pem.h>
 
  int PEM_write(FILE *fp, const char *name, const char *header,
-               const unsigned char *data, long len)
+               const unsigned char *data, long len);
  int PEM_write_bio(BIO *bp, const char *name, const char *header,
-                   const unsigned char *data, long len)
+                   const unsigned char *data, long len);
 
  int PEM_read(FILE *fp, char **name, char **header,
               unsigned char **data, long *len);

--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen - Retrieve attributes from a PKCS#12 safeBag
+PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen
+- Retrieve attributes from a PKCS#12 safeBag
 
 =head1 SYNOPSIS
 
@@ -11,7 +12,7 @@ PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen - Retrieve attributes from a PKCS
  const STACK_OF(X509_ATTRIBUTE) *PKCS12_SAFEBAG_get0_attrs(const PKCS12_SAFEBAG *bag);
 
  ASN1_TYPE *PKCS12_get_attr_gen(const STACK_OF(X509_ATTRIBUTE) *attrs,
-                                int attr_nid)
+                                int attr_nid);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/RAND_cleanup.pod
+++ b/doc/man3/RAND_cleanup.pod
@@ -12,7 +12,7 @@ Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- void RAND_cleanup(void)
+ void RAND_cleanup(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/RSA_size.pod
+++ b/doc/man3/RSA_size.pod
@@ -16,7 +16,7 @@ L<openssl_user_macros(7)>:
 
  int RSA_size(const RSA *rsa);
 
- int RSA_security_bits(const RSA *rsa)
+ int RSA_security_bits(const RSA *rsa);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -19,7 +19,7 @@ Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- void SSL_COMP_free_compression_methods(void)
+ void SSL_COMP_free_compression_methods(void);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_CTX_get0_param.pod
+++ b/doc/man3/SSL_CTX_get0_param.pod
@@ -9,10 +9,10 @@ get and set verification parameters
 
  #include <openssl/ssl.h>
 
- X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx)
- X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl)
- int SSL_CTX_set1_param(SSL_CTX *ctx, X509_VERIFY_PARAM *vpm)
- int SSL_set1_param(SSL *ssl, X509_VERIFY_PARAM *vpm)
+ X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx);
+ X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl);
+ int SSL_CTX_set1_param(SSL_CTX *ctx, X509_VERIFY_PARAM *vpm);
+ int SSL_set1_param(SSL *ssl, X509_VERIFY_PARAM *vpm);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_CTX_set_alpn_select_cb.pod
+++ b/doc/man3/SSL_CTX_set_alpn_select_cb.pod
@@ -43,7 +43,7 @@ SSL_select_next_proto, SSL_get0_alpn_selected, SSL_get0_next_proto_negotiated
                            const unsigned char *server,
                            unsigned int server_len,
                            const unsigned char *client,
-                           unsigned int client_len)
+                           unsigned int client_len);
  void SSL_get0_next_proto_negotiated(const SSL *s, const unsigned char **data,
                              unsigned *len);
 

--- a/doc/man3/SSL_CTX_set_tmp_dh_callback.pod
+++ b/doc/man3/SSL_CTX_set_tmp_dh_callback.pod
@@ -2,7 +2,9 @@
 
 =head1 NAME
 
-SSL_CTX_set_tmp_dh_callback, SSL_CTX_set_tmp_dh, SSL_set_tmp_dh_callback, SSL_set_tmp_dh - handle DH keys for ephemeral key exchange
+SSL_CTX_set_tmp_dh_callback, SSL_CTX_set_tmp_dh,
+SSL_set_tmp_dh_callback, SSL_set_tmp_dh
+- handle DH keys for ephemeral key exchange
 
 =head1 SYNOPSIS
 
@@ -16,7 +18,7 @@ SSL_CTX_set_tmp_dh_callback, SSL_CTX_set_tmp_dh, SSL_set_tmp_dh_callback, SSL_se
  void SSL_set_tmp_dh_callback(SSL *ctx,
                               DH *(*tmp_dh_callback)(SSL *ssl, int is_export,
                                                      int keylength));
- long SSL_set_tmp_dh(SSL *ssl, DH *dh)
+ long SSL_set_tmp_dh(SSL *ssl, DH *dh);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/SSL_SESSION_get0_id_context.pod
+++ b/doc/man3/SSL_SESSION_get0_id_context.pod
@@ -11,7 +11,7 @@ SSL_SESSION_set1_id_context
  #include <openssl/ssl.h>
 
  const unsigned char *SSL_SESSION_get0_id_context(const SSL_SESSION *s,
-                                                  unsigned int *len)
+                                                  unsigned int *len);
  int SSL_SESSION_set1_id_context(SSL_SESSION *s, const unsigned char *sid_ctx,
                                 unsigned int sid_ctx_len);
 

--- a/doc/man3/SSL_SESSION_set1_id.pod
+++ b/doc/man3/SSL_SESSION_set1_id.pod
@@ -11,7 +11,7 @@ SSL_SESSION_set1_id
  #include <openssl/ssl.h>
 
  const unsigned char *SSL_SESSION_get_id(const SSL_SESSION *s,
-                                         unsigned int *len)
+                                         unsigned int *len);
  int SSL_SESSION_set1_id(SSL_SESSION *s, const unsigned char *sid,
                          unsigned int sid_len);
 

--- a/doc/man3/SSL_load_client_CA_file.pod
+++ b/doc/man3/SSL_load_client_CA_file.pod
@@ -15,11 +15,11 @@ SSL_add_store_cert_subjects_to_stack
  STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file);
 
  int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
-                                         const char *file)
+                                         const char *file);
  int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
-                                        const char *dir)
+                                        const char *dir);
  int SSL_add_store_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
-                                          const char *store)
+                                          const char *store);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/X509_NAME_get0_der.pod
+++ b/doc/man3/X509_NAME_get0_der.pod
@@ -9,7 +9,7 @@ X509_NAME_get0_der - get X509_NAME DER encoding
  #include <openssl/x509.h>
 
  int X509_NAME_get0_der(const X509_NAME *nm, const unsigned char **pder,
-                        size_t *pderlen)
+                        size_t *pderlen);
 
 
 =head1 DESCRIPTION

--- a/doc/man3/X509_SIG_get0.pod
+++ b/doc/man3/X509_SIG_get0.pod
@@ -11,7 +11,7 @@ X509_SIG_get0, X509_SIG_getm - DigestInfo functions
  void X509_SIG_get0(const X509_SIG *sig, const X509_ALGOR **palg,
                     const ASN1_OCTET_STRING **pdigest);
  void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
-                    ASN1_OCTET_STRING **pdigest,
+                    ASN1_OCTET_STRING **pdigest);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/X509_check_purpose.pod
+++ b/doc/man3/X509_check_purpose.pod
@@ -8,7 +8,7 @@ X509_check_purpose - Check the purpose of a certificate
 
  #include <openssl/x509v3.h>
 
- int X509_check_purpose(X509 *x, int id, int ca)
+ int X509_check_purpose(X509 *x, int id, int ca);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -42,7 +42,7 @@ i2d_PrivateKey_fp
  EVP_PKEY *d2i_PrivateKey_bio(BIO *bp, EVP_PKEY **a);
  EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OPENSSL_CTX *libctx,
                                 const char *propq);
- EVP_PKEY *d2i_PrivateKey_fp(FILE *fp, EVP_PKEY **a)
+ EVP_PKEY *d2i_PrivateKey_fp(FILE *fp, EVP_PKEY **a);
 
  int i2d_PrivateKey_bio(BIO *bp, const EVP_PKEY *pkey);
  int i2d_PrivateKey_fp(FILE *fp, const EVP_PKEY *pkey);

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -313,6 +313,8 @@ sub name_synopsis {
     my $syn = $1;
     # Remove all non-code lines
     $syn =~ s/^(?:\s*?|\S.*?)$//msg;
+    # Remove all comments
+    $syn =~ s/\/\*.*?\*\///msg;
     while ( $syn ) {
         # "env" lines end at a newline.
         # Preprocessor lines start with a # and end at a newline.

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -311,8 +311,20 @@ sub name_synopsis {
     # Find all functions in SYNOPSIS
     return unless $contents =~ /=head1 SYNOPSIS(.*)=head1 DESCRIPTION/ms;
     my $syn = $1;
-    foreach my $line ( split /\n+/, $syn ) {
-        next unless $line =~ /^\s/;
+    # Remove all non-code lines
+    $syn =~ s/^(?:\s*?|\S.*?)$//msg;
+    while ( $syn ) {
+        # "env" lines end at a newline.
+        # Preprocessor lines start with a # and end at a newline.
+        # Other lines end with a semicolon, and may cover more than
+        # one physical line.
+        if ( $syn !~ /^ \s*(env .*?|#.*?|.*?;)\s*$/ms ) {
+            err($id, "Can't parse rest of synopsis:\n$syn\n(declarations not ending with a semicolon (;)?)");
+            last;
+        }
+        my $line = $1;
+        $syn = $';
+
         my $sym;
         my $is_prototype = 1;
         $line =~ s/STACK_OF\([^)]+\)/int/g;

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -330,16 +330,26 @@ sub name_synopsis {
         $line =~ s/STACK_OF\([^)]+\)/int/g;
         $line =~ s/SPARSE_ARRAY_OF\([^)]+\)/int/g;
         $line =~ s/__declspec\([^)]+\)//;
-        if ( $line =~ /typedef.*\(\*\S+\)\s+\(/ ) {
-            # a callback function with whitespace before the argument list:
-            # typedef ... (*NAME) (...
-            err($id, "Function typedef has space before arg list: $line");
-        }
+
+        ## We don't prohibit that space, to allow typedefs looking like
+        ## this:
+        ##
+        ## typedef int (fantastically_long_name_breaks_80char_limit)
+        ##     (fantastically_long_name_breaks_80char_limit *something);
+        ##
+        #if ( $line =~ /typedef.*\(\*?\S+\)\s+\(/ ) {
+        #    # a callback function with whitespace before the argument list:
+        #    # typedef ... (*NAME) (...
+        #    # typedef ... (NAME) (...
+        #    err($id, "Function typedef has space before arg list: $line");
+        #}
+
         if ( $line =~ /env (\S*)=/ ) {
             # environment variable env NAME=...
             $sym = $1;
-        } elsif ( $line =~ /typedef.*\(\*(\S+)\)\s*\(/ ) {
+        } elsif ( $line =~ /typedef.*\(\*?(\S+)\)\s*\(/ ) {
             # a callback function pointer: typedef ... (*NAME)(...
+            # a callback function signature: typedef ... (NAME)(...
             $sym = $1;
         } elsif ( $line =~ /typedef.* (\S+)\(/ ) {
             # a callback function signature: typedef ... NAME(...
@@ -351,7 +361,7 @@ sub name_synopsis {
         } elsif ( $line =~ /enum (\S*) \{/ ) {
             # an enumeration: enum ... {
             $sym = $1;
-        } elsif ( $line =~ /#(?:define|undef) ([A-Za-z0-9_]+)/ ) {
+        } elsif ( $line =~ /#\s*(?:define|undef) ([A-Za-z0-9_]+)/ ) {
             $is_prototype = 0;
             $sym = $1;
         } elsif ( $line =~ /([A-Za-z0-9_]+)\(/ ) {
@@ -366,7 +376,7 @@ sub name_synopsis {
 
         # Do some sanity checks on the prototype.
         err($id, "Prototype missing spaces around commas: $line")
-            if $is_prototype && $line =~ /[a-z0-9],[^ ]/;
+            if $is_prototype && $line =~ /[a-z0-9],[^\s]/;
     }
 
     foreach my $n ( keys %names ) {


### PR DESCRIPTION
name_synopsis was reading physical SYNOPSIS lines.  This changes it to
consider a declaration at a time, so we treat a C declaration that's
been broken up in several lines as one.

This makes it mandatory to end all C declarations in the SYNOPSIS with
a semicolon.  Those can be detected in two ways:

1.  Parsing an individual .pod file outputs this error:

    doc/man3/SOMETHING.pod:1: Can't parse rest of synopsis:

     int SOMETHING_status(SOMETHING *s)
     int SOMETHING_start(SOMETHING *s)

    (declarations not ending with a semicolon (;)?)

2.  Errors like this:

    doc/man3/SOMETHING.pod:1: SOMETHING_status missing from SYNOPSIS
    doc/man3/SOMETHING.pod:1: SOMETHING_start missing from SYNOPSIS