### PR TITLE
[1.1.1] Fix d2i_ECPKParameters_fp and i2d_ECPKParameters_fp macroes

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -548,7 +548,7 @@ ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group,
             ECPARAMETERS_free(ret->value.parameters);
     }
 
-    if (EC_GROUP_get_asn1_flag(group)) {
+    if (EC_GROUP_get_asn1_flag(group) == OPENSSL_EC_NAMED_CURVE) {
         /*
          * use the asn1 OID to describe the elliptic curve parameters
          */

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -12,6 +12,7 @@
 #include "ec_local.h"
 #include <openssl/err.h>
 #include <openssl/obj_mac.h>
+#include <openssl/objects.h>
 #include <openssl/opensslconf.h>
 #include "internal/nelem.h"
 
@@ -3097,6 +3098,32 @@ static EC_GROUP *ec_group_new_from_data(const ec_list_element curve)
             goto err;
         }
     }
+
+    if (EC_GROUP_get_asn1_flag(group) == OPENSSL_EC_NAMED_CURVE) {
+        /*
+         * Some curves don't have an associated OID: for those we should not
+         * default to `OPENSSL_EC_NAMED_CURVE` encoding of parameters and
+         * instead set the ASN1 flag to `OPENSSL_EC_EXPLICIT_CURVE`.
+         *
+         * Note that `OPENSSL_EC_NAMED_CURVE` is set as the default ASN1 flag on
+         * `EC_GROUP_new()`, when we don't have enough elements to determine if
+         * an OID for the curve name actually exists.
+         * We could implement this check on `EC_GROUP_set_curve_name()` but
+         * overloading the simple setter with this lookup could have a negative
+         * performance impact and unexpected consequences.
+         */
+        ASN1_OBJECT *asn1obj = OBJ_nid2obj(curve.nid);
+
+        if (asn1obj == NULL) {
+            ECerr(EC_F_EC_GROUP_NEW_FROM_DATA, ERR_R_OBJ_LIB);
+            goto err;
+        }
+        if (OBJ_length(asn1obj) == 0)
+            EC_GROUP_set_asn1_flag(group, OPENSSL_EC_EXPLICIT_CURVE);
+
+        ASN1_OBJECT_free(asn1obj);
+    }
+
     ok = 1;
  err:
     if (!ok) {

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -793,12 +793,15 @@ int EC_GROUP_get_pentanomial_basis(const EC_GROUP *, unsigned int *k1,
 EC_GROUP *d2i_ECPKParameters(EC_GROUP **, const unsigned char **in, long len);
 int i2d_ECPKParameters(const EC_GROUP *, unsigned char **out);
 
-# define d2i_ECPKParameters_bio(bp,x) ASN1_d2i_bio_of(EC_GROUP,NULL,d2i_ECPKParameters,bp,x)
-# define i2d_ECPKParameters_bio(bp,x) ASN1_i2d_bio_of_const(EC_GROUP,i2d_ECPKParameters,bp,x)
-# define d2i_ECPKParameters_fp(fp,x) (EC_GROUP *)ASN1_d2i_fp(NULL, \
-                (char *(*)())d2i_ECPKParameters,(fp),(unsigned char **)(x))
-# define i2d_ECPKParameters_fp(fp,x) ASN1_i2d_fp(i2d_ECPKParameters,(fp), \
-                (unsigned char *)(x))
+# define d2i_ECPKParameters_bio(bp,x) \
+    ASN1_d2i_bio_of(EC_GROUP, NULL, d2i_ECPKParameters, bp, x)
+# define i2d_ECPKParameters_bio(bp,x) \
+    ASN1_i2d_bio_of_const(EC_GROUP, i2d_ECPKParameters, bp, x)
+# define d2i_ECPKParameters_fp(fp,x) \
+    (EC_GROUP *)ASN1_d2i_fp(NULL, (d2i_of_void *)d2i_ECPKParameters, (fp), \
+                            (void **)(x))
+# define i2d_ECPKParameters_fp(fp,x) \
+    ASN1_i2d_fp((i2d_of_void *)i2d_ECPKParameters, (fp), (void *)(x))
 
 int ECPKParameters_print(BIO *bp, const EC_GROUP *x, int off);
 # ifndef OPENSSL_NO_STDIO

--- a/test/build.info
+++ b/test/build.info
@@ -515,7 +515,9 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
     INCLUDE[sm4_internal_test]=.. ../include
     DEPEND[sm4_internal_test]=../libcrypto.a libtestutil.a
 
-    SOURCE[ec_internal_test]=ec_internal_test.c
+    SOURCE[ec_internal_test]=ec_internal_test.c \
+                             {- rebase_files("../apps",
+                                  split(/\s+/, $target{apps_init_src})) -}
     INCLUDE[ec_internal_test]=../include ../crypto/ec
     DEPEND[ec_internal_test]=../libcrypto.a libtestutil.a
 

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -283,6 +283,47 @@ static int decoded_flag_test(void)
     return testresult;
 }
 
+static
+int ecpkparams_i2d2i_test(int n)
+{
+    EC_GROUP *g1 = NULL, *g2 = NULL;
+    FILE *fp = NULL;
+    int nid = curves[n].nid;
+    int testresult = 0;
+
+    /* create group */
+    if (!TEST_ptr(g1 = EC_GROUP_new_by_curve_name(nid)))
+        goto end;
+
+    /* encode params to file */
+    if (!TEST_ptr(fp = fopen("params.der", "wb"))
+            || !TEST_true(i2d_ECPKParameters_fp(fp, g1)))
+        goto end;
+
+    /* flush and close file */
+    if (!TEST_int_eq(fclose(fp), 0)) {
+        fp = NULL;
+        goto end;
+    }
+    fp = NULL;
+
+    /* decode params from file */
+    if (!TEST_ptr(fp = fopen("params.der", "rb"))
+            || !TEST_ptr(g2 = d2i_ECPKParameters_fp(fp, NULL)))
+        goto end;
+
+    testresult = 1; /* PASS */
+
+end:
+    if (fp != NULL)
+        fclose(fp);
+
+    EC_GROUP_free(g1);
+    EC_GROUP_free(g2);
+
+    return testresult;
+}
+
 int setup_tests(void)
 {
     crv_len = EC_get_builtin_curves(NULL, 0);
@@ -297,6 +338,8 @@ int setup_tests(void)
 #endif
     ADD_ALL_TESTS(field_tests_default, crv_len);
     ADD_TEST(decoded_flag_test);
+    ADD_ALL_TESTS(ecpkparams_i2d2i_test, crv_len);
+
     return 1;
 }
 


### PR DESCRIPTION
These functions are part of the public API but we don't have tests covering their usage.
They are actually implemented as macroes and the absence of tests has caused them to fall out-of-sync with the latest changes to ASN1 related functions and cause compilation warnings.

This PR fixes the public headers to reflect these changes.

Fixes #12443

### `1.1.1` first

Unusually I am proposing to fix first this issue as a `1.1.1` issue, and then forward-port the changes to `master` (see #16355). The reason is that master has inherited this bug from `1.1.1` and has compounded it with the current inability of handling serialization with the `OPENSSL_EC_EXPLICIT_CURVE` ASN1 flag.

This means that anyway we would have to review the changes separately as the cherry-picks are not trivial, and it makes sense to address this issue in `1.1.1` first and then apply incremental changes to adapt to the new architecture in `master`.

### Additional related commits included in this PR

- `Add tests for i2d_TYPE_fp and d2i_TYPE_fp`

  This commit add tesst to trigger the issue and make sure these macroes have at least a caller in our test suite to avoid this to happen again in the future.
  
  At the moment the test only covers ECPKParameters as a type, but this should probably be extended similarly to DH, DSA and (maybe) RSA equivalents.

- `[ec] Do not default to OPENSSL_EC_NAMED_CURVE for curves without OID`

  Some curves don't have an associated OID: for those we should not default to `OPENSSL_EC_NAMED_CURVE` encoding of parameters and instead set the ASN1 flag to `OPENSSL_EC_EXPLICIT_CURVE`.
  
  This is a follow-up to https://github.com/openssl/openssl/pull/12312


### Checklist

- [x] tests are added or updated
