### PR TITLE
mac: always pass a non-NULL output size pointer to providers.

### DIFF
--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -120,15 +120,14 @@ int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen)
 int EVP_MAC_final(EVP_MAC_CTX *ctx,
                   unsigned char *out, size_t *outl, size_t outsize)
 {
-    int l = EVP_MAC_size(ctx);
+    size_t l = EVP_MAC_size(ctx);
+    int res = 1;
 
-    if (l < 0)
-        return 0;
+    if (out != NULL)
+        res = ctx->meth->final(ctx->data, out, &l, outsize);
     if (outl != NULL)
         *outl = l;
-    if (out == NULL)
-        return 1;
-    return ctx->meth->final(ctx->data, out, outl, outsize);
+    return res;
 }
 
 /*


### PR DESCRIPTION
The backend code varies for the different MACs and sometimes sets the output
length, sometimes checks the return pointer and sometimes neither/either.

Fixes #12425
