### PR TITLE
Mark an argument of an inline function as unused

### DIFF
--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -220,7 +220,7 @@ static ossl_inline int ERR_GET_LIB(unsigned long errcode)
     return (errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK;
 }
 
-static ossl_inline int ERR_GET_FUNC(unsigned long errcode)
+static ossl_inline int ERR_GET_FUNC(unsigned long errcode ossl_unused)
 {
     return 0;
 }


### PR DESCRIPTION
This allows users of this header file to compile their own code with the gcc option `-Wunused-parameter`.

CLA: trivial