### PR TITLE
util/mktar.pl: Change 'VERSION' to 'VERSION.dat'

### DIFF
--- a/util/mktar.sh
+++ b/util/mktar.sh
@@ -9,7 +9,7 @@
 HERE=`dirname $0`
 
 # Get all version data as shell variables
-. $HERE/../VERSION
+. $HERE/../VERSION.dat
 
 if [ -n "$PRE_RELEASE_TAG" ]; then PRE_RELEASE_TAG=-$PRE_RELEASE_TAG; fi
 version=$MAJOR.$MINOR.$PATCH$PRE_RELEASE_TAG$BUILD_METADATA


### PR DESCRIPTION
This was forgotten when that file changed name, and that unfortunately
disrupts releases.
