### PR TITLE
Fix compiler warning about unused variable in err.h

### DIFF
--- a/include/openssl/err.h
+++ b/include/openssl/err.h
@@ -222,6 +222,7 @@ static ossl_inline int ERR_GET_LIB(unsigned long errcode)
 
 static ossl_inline int ERR_GET_FUNC(unsigned long errcode)
 {
+    (void)errcode;
     return 0;
 }
 


### PR DESCRIPTION
When using the err.h header with GCC 10 and -Wunused, the compiler
warns that ERR_GET_FUNC() no longer uses its argument.  This patch
adds a (void) cast to keep the compiler from complaining.

