### PR TITLE
Fix spelling error of SSL_get_peer_certificate

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1710,7 +1710,7 @@ __owur X509 *SSL_get0_peer_certificate(const SSL *s);
 __owur X509 *SSL_get1_peer_certificate(const SSL *s);
 /* Deprecated in 3.0.0 */
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
-#   define SSL_get_peer_certificate SSL_get1_peer_certifiate
+#   define SSL_get_peer_certificate SSL_get1_peer_certificate
 #  endif
 # endif
 


### PR DESCRIPTION
This commit fixes the error of macro SSL_get_peer_certificate which was SSL_get1_peer_certifiate and is ow SSL_get1_peer_certificate

What happened?
I was trying to compile Tor trunk with OpenSSL trunk, but I noticed the build failing because of this spelling error.

What changed?
I changed the macro to point to the correct name. Tor now compiles again.

Tristan
