### PR TITLE
Fix API rename issue in shim layer that calls EVP_MAC_CTX_set_params

### DIFF
--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -403,7 +403,7 @@ static int TicketKeyCallback(SSL *ssl, uint8_t *key_name, uint8_t *iv,
 
   if (!EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, kZeros, iv, encrypt)
       || !EVP_MAC_init(hmac_ctx)
-      || !EVP_MAC_set_ctx_params(hmac_ctx, params)) {
+      || !EVP_MAC_CTX_set_params(hmac_ctx, params)) {
     return -1;
   }
 


### PR DESCRIPTION
Master is currently failng due to a compile issue related to this.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
