### PR TITLE
PROV: Move bio_prov.c from libcommon.a to libfips.a / libnonfips.a

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -33,7 +33,7 @@
 # FIPS:
 #     -o fips.so {object files...} libimplementations.a libcommon.a libfips.a
 # Non-FIPS:
-#     -o fips.so {object files...} libimplementations.a libcommon.a libnonfips.a
+#     -o module.so {object files...} libimplementations.a libcommon.a libnonfips.a
 #
 # It is crucial that code that checks for the FIPS_MODULE macro end up in
 # libfips.a and libnonfips.a, never in libcommon.a.

--- a/providers/build.info
+++ b/providers/build.info
@@ -27,6 +27,26 @@
 # libnonfips.a          Corresponds to libfips.a, but built with
 #                       FIPS_MODULE undefined.  The default and legacy
 #                       providers use this.
+#
+# This is how different provider modules should be linked:
+#
+# FIPS:
+#     -o fips.so {object files...} libimplementations.a libcommon.a libfips.a
+# Non-FIPS:
+#     -o fips.so {object files...} libimplementations.a libcommon.a libnonfips.a
+#
+# It is crucial that code that checks for the FIPS_MODULE macro end up in
+# libfips.a and libnonfips.a, never in libcommon.a.
+# It is crucial that such code is written so libfips.a and libnonfips.a doesn't
+# end up depending on libimplementations.a or libcommon.a.
+# It is crucial that such code is written so libcommon.a doesn't end up
+# depending on libimplementations.a.
+#
+# Code in providers/implementations/ should be written in such a way that the
+# OSSL_DISPATCH arrays (and preferably the majority of the actual code) ends
+# up in either libimplementations.a or liblegacy.a.
+# If need be, write an abstraction layer in separate source files and make them
+# libfips.a / libnonfips.a sources.
 
 SUBDIRS=common implementations
 

--- a/providers/common/build.info
+++ b/providers/common/build.info
@@ -1,6 +1,6 @@
 SUBDIRS=der
 
-SOURCE[../libcommon.a]=provider_err.c bio_prov.c provider_ctx.c
-$FIPSCOMMON=provider_util.c capabilities.c
+SOURCE[../libcommon.a]=provider_err.c provider_ctx.c
+$FIPSCOMMON=provider_util.c capabilities.c bio_prov.c
 SOURCE[../libnonfips.a]=$FIPSCOMMON nid_to_name.c
 SOURCE[../libfips.a]=$FIPSCOMMON


### PR DESCRIPTION
libcommon.a is FIPS agnostic, while libfips.a and libnonfips.a are
FIPS / non-FIPS specific.  Since bio_prov.c checks FIPS_MODULE, it
belongs to the latter.

Along with this, a bit more instruction commentary is added to
providers/build.info.
