### PR TITLE
Deprecate -nodes in favor of -noenc in pkcs12 and req app

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -57,7 +57,7 @@ typedef enum OPTION_choice {
     OPT_CIPHER, OPT_NOKEYS, OPT_KEYEX, OPT_KEYSIG, OPT_NOCERTS, OPT_CLCERTS,
     OPT_CACERTS, OPT_NOOUT, OPT_INFO, OPT_CHAIN, OPT_TWOPASS, OPT_NOMACVER,
     OPT_DESCERT, OPT_EXPORT, OPT_ITER, OPT_NOITER, OPT_MACITER, OPT_NOMACITER,
-    OPT_NOMAC, OPT_LMK, OPT_NODES, OPT_MACALG, OPT_CERTPBE, OPT_KEYPBE,
+    OPT_NOMAC, OPT_LMK, OPT_NODES, OPT_NOENC, OPT_MACALG, OPT_CERTPBE, OPT_KEYPBE,
     OPT_INKEY, OPT_CERTFILE, OPT_NAME, OPT_CSP, OPT_CANAME,
     OPT_IN, OPT_OUT, OPT_PASSIN, OPT_PASSOUT, OPT_PASSWORD, OPT_CAPATH,
     OPT_CAFILE, OPT_CASTORE, OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE, OPT_ENGINE,
@@ -129,7 +129,8 @@ const OPTIONS pkcs12_options[] = {
     {"maciter", OPT_MACITER, '-', "Unused, kept for backwards compatibility"},
     {"nomaciter", OPT_NOMACITER, '-', "Don't use MAC iteration"},
     {"nomac", OPT_NOMAC, '-', "Don't generate MAC"},
-    {"nodes", OPT_NODES, '-', "Don't encrypt private keys"},
+    {"noenc", OPT_NOENC, '-', "Don't encrypt private keys"},
+    {"nodes", OPT_NODES, '-', "Don't encrypt private keys; deprecated"},
     {"", OPT_CIPHER, '-', "Any supported cipher"},
 
     OPT_R_OPTIONS,
@@ -240,6 +241,7 @@ int pkcs12_main(int argc, char **argv)
             macalg = opt_arg();
             break;
         case OPT_NODES:
+        case OPT_NOENC:
             enc = NULL;
             break;
         case OPT_CERTPBE:

--- a/apps/req.c
+++ b/apps/req.c
@@ -93,7 +93,7 @@ typedef enum OPTION_choice {
     OPT_PUBKEY, OPT_NEW, OPT_CONFIG, OPT_KEYFORM, OPT_IN, OPT_OUT,
     OPT_KEYOUT, OPT_PASSIN, OPT_PASSOUT, OPT_NEWKEY,
     OPT_PKEYOPT, OPT_SIGOPT, OPT_VFYOPT, OPT_BATCH, OPT_NEWHDR, OPT_MODULUS,
-    OPT_VERIFY, OPT_NODES, OPT_NOOUT, OPT_VERBOSE, OPT_UTF8,
+    OPT_VERIFY, OPT_NOENC, OPT_NODES, OPT_NOOUT, OPT_VERBOSE, OPT_UTF8,
     OPT_NAMEOPT, OPT_REQOPT, OPT_SUBJ, OPT_SUBJECT, OPT_TEXT, OPT_X509,
     OPT_MULTIVALUE_RDN, OPT_DAYS, OPT_SET_SERIAL, OPT_ADDEXT, OPT_EXTENSIONS,
     OPT_REQEXTS, OPT_PRECERT, OPT_MD,
@@ -157,7 +157,8 @@ const OPTIONS req_options[] = {
     {"batch", OPT_BATCH, '-',
      "Do not ask anything during request generation"},
     {"verbose", OPT_VERBOSE, '-', "Verbose output"},
-    {"nodes", OPT_NODES, '-', "Don't encrypt the output key"},
+    {"noenc", OPT_NOENC, '-', "Don't encrypt private keys"},
+    {"nodes", OPT_NODES, '-', "Don't encrypt private keys; deprecated"},
     {"noout", OPT_NOOUT, '-', "Do not output REQ"},
     {"newhdr", OPT_NEWHDR, '-', "Output \"NEW\" in the header lines"},
     {"modulus", OPT_MODULUS, '-', "RSA modulus"},
@@ -257,7 +258,7 @@ int req_main(int argc, char **argv)
     int pkey_type = -1, private = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, keyform = FORMAT_PEM;
     int modulus = 0, multirdn = 0, verify = 0, noout = 0, text = 0;
-    int nodes = 0, newhdr = 0, subject = 0, pubkey = 0, precert = 0;
+    int noenc = 0, newhdr = 0, subject = 0, pubkey = 0, precert = 0;
     long newkey = -1;
     unsigned long chtype = MBSTRING_ASC, reqflag = 0;
 
@@ -375,7 +376,8 @@ int req_main(int argc, char **argv)
             verify = 1;
             break;
         case OPT_NODES:
-            nodes = 1;
+        case OPT_NOENC:
+            noenc = 1;
             break;
         case OPT_NOOUT:
             noout = 1;
@@ -693,7 +695,7 @@ int req_main(int argc, char **argv)
         }
         if ((p != NULL) && (strcmp(p, "no") == 0))
             cipher = NULL;
-        if (nodes)
+        if (noenc)
             cipher = NULL;
 
         i = 0;

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -36,6 +36,7 @@ B<openssl> B<pkcs12>
 [B<-camellia128>]
 [B<-camellia192>]
 [B<-camellia256>]
+[B<-noenc>]
 [B<-nodes>]
 [B<-iter> I<count>]
 [B<-noiter>]
@@ -146,9 +147,13 @@ Use ARIA to encrypt private keys before outputting.
 
 Use Camellia to encrypt private keys before outputting.
 
-=item B<-nodes>
+=item B<-noenc>
 
 Don't encrypt the private keys at all.
+
+=item B<-nodes>
+
+This option is deprecated since OpenSSL 3.0; use B<-noenc> instead.
 
 =item B<-nomacver>
 
@@ -344,7 +349,7 @@ Output only client certificates to a file:
 
 Don't encrypt the private key:
 
- openssl pkcs12 -in file.p12 -out file.pem -nodes
+ openssl pkcs12 -in file.p12 -out file.pem -noenc
 
 Print some info about a PKCS#12 file:
 
@@ -368,6 +373,7 @@ L<ossl_store-file(7)>
 =head1 HISTORY
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
+The <-nodes> option was deprecated in OpenSSL 3.0, too; use B<-noenc> instead.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -23,6 +23,7 @@ B<openssl> B<req>
 [B<-new>]
 [B<-newkey> I<arg>]
 [B<-pkeyopt> I<opt>:I<value>]
+[B<-noenc>]
 [B<-nodes>]
 [B<-key> I<filename>]
 [B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
@@ -198,10 +199,14 @@ This gives the filename to write the newly created private key to.
 If this option is not specified then the filename present in the
 configuration file is used.
 
-=item B<-nodes>
+=item B<-noenc>
 
 If this option is specified then if a private key is created it
 will not be encrypted.
+
+=item B<-nodes>
+
+This option is deprecated since OpenSSL 3.0; use B<-noenc> instead.
 
 =item B<-I<digest>>
 
@@ -394,7 +399,7 @@ It is used for private key generation.
 =item B<encrypt_key>
 
 If this is set to B<no> then if a private key is generated it is
-B<not> encrypted. This is equivalent to the B<-nodes> command line
+B<not> encrypted. This is equivalent to the B<-noenc> command line
 option. For compatibility B<encrypt_rsa_key> is an equivalent option.
 
 =item B<default_md>
@@ -696,6 +701,7 @@ All B<-keyform> values except B<ENGINE> have become obsolete in OpenSSL 3.0.0
 and have no effect.
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
+The <-nodes> option was deprecated in OpenSSL 3.0, too; use B<-noenc> instead.
 
 =head1 COPYRIGHT
 

--- a/test/certs/setup.sh
+++ b/test/certs/setup.sh
@@ -375,7 +375,7 @@ OPENSSL_KEYALG=ec OPENSSL_KEYBITS=brainpoolP256r1 ./mkcert.sh genee \
     "Server ECDSA brainpoolP256r1 cert" server-ecdsa-brainpoolP256r1-key \
     server-ecdsa-brainpoolP256r1-cert rootkey rootcert
 
-openssl req -new -nodes -subj "/CN=localhost" \
+openssl req -new -noenc -subj "/CN=localhost" \
     -newkey rsa-pss -keyout server-pss-restrict-key.pem \
     -pkeyopt rsa_pss_keygen_md:sha256 -pkeyopt rsa_pss_keygen_saltlen:32 | \
     ./mkcert.sh geneenocsr "Server RSA-PSS restricted cert" \

--- a/test/recipes/80-test_tsa.t
+++ b/test/recipes/80-test_tsa.t
@@ -97,7 +97,7 @@ indir "tsa" => sub
      $ENV{TSDNSECT} = "ts_ca_dn";
      skip "failed", 19
          unless ok(run(app(["openssl", "req", "-config", $openssl_conf,
-                            "-new", "-x509", "-nodes",
+                            "-new", "-x509", "-noenc",
                             "-out", "tsaca.pem", "-keyout", "tsacakey.pem"])),
                    'creating a new CA for the TSA tests');
 

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -317,7 +317,7 @@ sub init {
                       }, grep(/-key-pkcs8-pbes2-sha256\.pem$/, @generated_files))
             # *-cert.pem (intermediary for the .p12 inits)
             && run(app(["openssl", "req", "-x509",
-                        "-config", $cnf, "-nodes",
+                        "-config", $cnf, "-noenc",
                         "-key", $cakey, "-out", "cacert.pem"]))
             && runall(sub {
                           my $srckey = shift;

--- a/test/smime-certs/mksmime-certs.sh
+++ b/test/smime-certs/mksmime-certs.sh
@@ -14,22 +14,22 @@ OPENSSL_CONF=./ca.cnf
 export OPENSSL_CONF
 
 # Root CA: create certificate directly
-CN="Test S/MIME RSA Root" $OPENSSL req -config ca.cnf -x509 -nodes \
+CN="Test S/MIME RSA Root" $OPENSSL req -config ca.cnf -x509 -noenc \
 	-keyout smroot.pem -out smroot.pem -newkey rsa:2048 -days 3650
 
 # EE RSA certificates: create request first
-CN="Test S/MIME EE RSA #1" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE RSA #1" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smrsa1.pem -out req.pem -newkey rsa:2048
 # Sign request: end entity extensions
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smrsa1.pem
 
-CN="Test S/MIME EE RSA #2" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE RSA #2" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smrsa2.pem -out req.pem -newkey rsa:2048
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smrsa2.pem
 
-CN="Test S/MIME EE RSA #3" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE RSA #3" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smrsa3.pem -out req.pem -newkey rsa:2048
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smrsa3.pem
@@ -38,15 +38,15 @@ $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 
 $OPENSSL dsaparam -out dsap.pem 2048
 
-CN="Test S/MIME EE DSA #1" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE DSA #1" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smdsa1.pem -out req.pem -newkey dsa:dsap.pem
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smdsa1.pem
-CN="Test S/MIME EE DSA #2" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE DSA #2" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smdsa2.pem -out req.pem -newkey dsa:dsap.pem
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smdsa2.pem
-CN="Test S/MIME EE DSA #3" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE DSA #3" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smdsa3.pem -out req.pem -newkey dsa:dsap.pem
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smdsa3.pem
@@ -56,15 +56,15 @@ $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 $OPENSSL ecparam -out ecp.pem -name P-256
 $OPENSSL ecparam -out ecp2.pem -name K-283
 
-CN="Test S/MIME EE EC #1" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE EC #1" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smec1.pem -out req.pem -newkey ec:ecp.pem
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smec1.pem
-CN="Test S/MIME EE EC #2" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE EC #2" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smec2.pem -out req.pem -newkey ec:ecp2.pem
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smec2.pem
-CN="Test S/MIME EE EC #3" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE EC #3" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smec3.pem -out req.pem -newkey ec:ecp.pem
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \
 	-extfile ca.cnf -extensions usr_cert -CAcreateserial >>smec3.pem
@@ -75,7 +75,7 @@ $OPENSSL genpkey -genparam -algorithm DH -pkeyopt dh_paramgen_type:2 \
 $OPENSSL genpkey -paramfile dhp.pem -out smdh.pem
 $OPENSSL pkey -pubout -in smdh.pem -out dhpub.pem
 # Generate dummy request.
-CN="Test S/MIME EE DH #1" $OPENSSL req -config ca.cnf -nodes \
+CN="Test S/MIME EE DH #1" $OPENSSL req -config ca.cnf -noenc \
 	-keyout smtmp.pem -out req.pem -newkey rsa:2048
 # Sign request but force public key to DH
 $OPENSSL x509 -req -in req.pem -CA smroot.pem -days 3600 \


### PR DESCRIPTION
The `-nodes` option has an anachronistic name.
Renaming it to `-noenc`, keeping but deprecating the old name.