### PR TITLE
CORE: Implement unconditional provider autoactivation

### DIFF
--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -12,6 +12,10 @@
 struct predefined_providers_st {
     const char *name;
     OSSL_provider_init_fn *init;
+
+    /* Auto-activated */
+    unsigned int is_autoactivate:1;
+    /* Only auto-activated if no loaders has been explictly loaded yet */
     unsigned int is_fallback:1;
 };
 

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -18,13 +18,13 @@ OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
 const struct predefined_providers_st predefined_providers[] = {
 #ifdef FIPS_MODULE
-    { "fips", fips_intern_provider_init, 1 },
+    { "fips", fips_intern_provider_init, 1, 1 },
 #else
-    { "default", ossl_default_provider_init, 1 },
+    { "default", ossl_default_provider_init, 1, 1 },
 # ifdef STATIC_LEGACY
-    { "legacy", ossl_legacy_provider_init, 0 },
+    { "legacy", ossl_legacy_provider_init, 0, 0 },
 # endif
-    { "null", ossl_null_provider_init, 0 },
+    { "null", ossl_null_provider_init, 1, 0 },
 #endif
     { NULL, NULL, 0 }
 };

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -37,6 +37,7 @@ void ossl_provider_free(OSSL_PROVIDER *prov);
 
 /* Setters */
 int ossl_provider_set_fallback(OSSL_PROVIDER *prov);
+int ossl_provider_set_autoactivate(OSSL_PROVIDER *prov);
 int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *module_path);
 int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
                                 const char *value);


### PR DESCRIPTION
We now have two flags to keep track of:

1.  'autoactivation', which simply tells that the provider in question
    should be autoactivated.
2.  'fallback', which tells that autoactivation should only be done
    when no providers have been explicitly activated.  This flag is
    only useful together with a set 'autoactivation' flag.
