### PR TITLE
Make TAP::Harness and TAP::Parser optional.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -146,7 +146,8 @@ my $eres;
 
 $eres = eval {
     package TAP::Parser::OpenSSL;
-    use parent 'TAP::Parser';
+    use parent -norequire, 'TAP::Parser';
+    require TAP::Parser;
 
     sub new {
         my $class = shift;
@@ -229,7 +230,8 @@ $eres = eval {
     }
 
     package TAP::Harness::OpenSSL;
-    use parent 'TAP::Harness';
+    use parent -norequire, 'TAP::Harness';
+    require TAP::Harness;
 
     package main;
 


### PR DESCRIPTION
In OpenSSL 1.1.1 the script run_tests.pl has an effectiver
workaround to fall back to Test::Harness, if TAP::Harness
is not available. That code has substantially changed,
but it seems it should still fall back but doesn't.

Observed on SuSE Linux Enterprise Server 11 (SLES11).

Error messages:

Can't locate TAP/Parser.pm in @inc (@inc contains: /path/to/bld/openssl300/test/../util/perl /path/to/local/perl/lib/perl5 /usr/lib/perl5/5.10.0/x86_64-linux-thread-multi /usr/lib/perl5/5.10.0 /usr/lib/perl5/site_perl/5.10.0/x86_64-linux-thread-multi /usr/lib/perl5/site_perl/5.10.0 /usr/lib/perl5/vendor_perl/5.10.0/x86_64-linux-thread-multi /usr/lib/perl5/vendor_perl/5.10.0 /usr/lib/perl5/vendor_perl .) at /path/to/local/perl/lib/perl5/parent.pm line 20.
BEGIN failed--compilation aborted at /path/to/bld/openssl300/test/run_tests.pl line 131.

and

Can't locate TAP/Harness.pm in @inc (@inc contains: /path/to/bld/openssl300/test/../util/perl /path/to/local/perl/lib/perl5 /usr/lib/perl5/5.10.0/x86_64-linux-thread-multi /usr/lib/perl5/5.10.0 /usr/lib/perl5/site_perl/5.10.0/x86_64-linux-thread-multi /usr/lib/perl5/site_perl/5.10.0 /usr/lib/perl5/vendor_perl/5.10.0/x86_64-linux-thread-multi /usr/lib/perl5/vendor_perl/5.10.0 /usr/lib/perl5/vendor_perl .) at /path/to/local/perl/lib/perl5/parent.pm line 20.
BEGIN failed--compilation aborted at /path/to/bld/openssl300/test/run_tests.pl line 215.

Concerning the fix: the docs for parent.pm show, that without
the "-norequire" it puts the require statement in a BEGIN block
which probably runs before the eval, to the loading is no
longer encapsulated by the eval. Without the additional require
line, the loading doesn't happen at all, so the availability
testing fails. Combining the "-norequire" and an explicit
"require" worked for me.

Tested on the original problem platform SLES 11, but also on
SLES 12 and 15, RHEL 6, 7 and 8 plus Solaris 10 Sparc.

Fixes #12352 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
