### PR TITLE
Avoid errors with a priori inapplicable protocol bounds (1.1.1 backport)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,21 @@
 
  Changes between 1.1.1g and 1.1.1h [xx XXX xxxx]
 
+  *) The 'MinProtocol' and 'MaxProtocol' configuration commands now silently
+     ignore TLS protocol version bounds when configuring DTLS-based contexts, and
+     conversely, silently ignore DTLS protocol version bounds when configuring
+     TLS-based contexts.  The commands can be repeated to set bounds of both
+     types.  The same applies with the corresponding "min_protocol" and
+     "max_protocol" command-line switches, in case some application uses both TLS
+     and DTLS.
+  
+     SSL_CTX instances that are created for a fixed protocol version (e.g.
+     TLSv1_server_method()) also silently ignore version bounds.  Previously
+     attempts to apply bounds to these protocol versions would result in an
+     error.  Now only the "version-flexible" SSL_CTX instances are subject to
+     limits in configuration files in command-line options.
+     [Viktor Dukhovni]
+
   *) Handshake now fails if Extended Master Secret extension is dropped
      on renegotiation.
      [Tomas Mraz]

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -147,13 +147,16 @@ B<SSL_OP_NO_RENEGOTIATION>.
 =item B<-min_protocol>, B<-max_protocol>
 
 Sets the minimum and maximum supported protocol.
-Currently supported protocol values are B<SSLv3>, B<TLSv1>,
-B<TLSv1.1>, B<TLSv1.2>, B<TLSv1.3> for TLS and B<DTLSv1>, B<DTLSv1.2> for DTLS,
-and B<None> for no limit.
-If either bound is not specified then only the other bound applies,
-if specified.
-To restrict the supported protocol versions use these commands rather
-than the deprecated alternative commands below.
+Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
+B<TLSv1.2>, B<TLSv1.3> for TLS; B<DTLSv1>, B<DTLSv1.2> for DTLS, and B<None>
+for no limit.
+If either the lower or upper bound is not specified then only the other bound
+applies, if specified.
+If your application supports both TLS and DTLS you can specify any of these
+options twice, once with a bound for TLS and again with an appropriate bound
+for DTLS.
+To restrict the supported protocol versions use these commands rather than the
+deprecated alternative commands below.
 
 =item B<-no_ssl3>, B<-no_tls1>, B<-no_tls1_1>, B<-no_tls1_2>, B<-no_tls1_3>
 
@@ -370,7 +373,11 @@ This sets the minimum supported SSL, TLS or DTLS version.
 
 Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
 B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1> and B<DTLSv1.2>.
-The value B<None> will disable the limit.
+The SSL and TLS bounds apply only to TLS-based contexts, while the DTLS bounds
+apply only to DTLS-based contexts.
+The command can be repeated with one instance setting a TLS bound, and the
+other setting a DTLS bound.
+The value B<None> applies to both types of contexts and disables the limits.
 
 =item B<MaxProtocol>
 
@@ -378,7 +385,11 @@ This sets the maximum supported SSL, TLS or DTLS version.
 
 Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
 B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1> and B<DTLSv1.2>.
-The value B<None> will disable the limit.
+The SSL and TLS bounds apply only to TLS-based contexts, while the DTLS bounds
+apply only to DTLS-based contexts.
+The command can be repeated with one instance setting a TLS bound, and the
+other setting a DTLS bound.
+The value B<None> applies to both types of contexts and disables the limits.
 
 =item B<Protocol>
 

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -262,13 +262,11 @@ Example of a configuration with the system default:
  ssl_conf = ssl_sect
 
  [ssl_sect]
-
  system_default = system_default_sect
 
  [system_default_sect]
-
  MinProtocol = TLSv1.2
-
+ MinProtocol = DTLSv1.2
 
 =head1 NOTES
 
@@ -355,8 +353,8 @@ Simple OpenSSL library configuration example to enter FIPS mode:
 Note: in the above example you will get an error in non FIPS capable versions
 of OpenSSL.
 
-Simple OpenSSL library configuration to make TLS 1.3 the system-default
-minimum TLS version:
+Simple OpenSSL library configuration to make TLS 1.2 and DTLS 1.2 the
+system-default minimum TLS and DTLS versions, respectively:
 
  # Toplevel section for openssl (including libssl)
  openssl_conf = default_conf_section
@@ -369,7 +367,12 @@ minimum TLS version:
  system_default = system_default_section
 
  [system_default_section]
- MinProtocol = TLSv1.3
+ MinProtocol = TLSv1.2
+ MinProtocol = DTLSv1.2
+
+The minimum TLS protocol is applied to B<SSL_CTX> objects that are TLS-based,
+and the minimum DTLS protocol to those are DTLS-based.
+The same applies also to maximum versions set with B<MaxProtocol>.
 
 More complex OpenSSL library configuration. Add OID and don't enter FIPS mode:
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -305,6 +305,13 @@ static int protocol_from_string(const char *value)
         const char *name;
         int version;
     };
+    /*
+     * Note: To avoid breaking previously valid configurations, we must retain
+     * legacy entries in this table even if the underlying protocol is no
+     * longer supported.  This also means that the constants SSL3_VERSION, ...
+     * need to be retained indefinitely.  This table can only grow, never
+     * shrink.
+     */
     static const struct protocol_versions versions[] = {
         {"None", 0},
         {"SSLv3", SSL3_VERSION},

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1656,10 +1656,21 @@ int ssl_check_version_downgrade(SSL *s)
  */
 int ssl_set_version_bound(int method_version, int version, int *bound)
 {
+    int valid_tls;
+    int valid_dtls;
+
     if (version == 0) {
         *bound = version;
         return 1;
     }
+
+    valid_tls = version >= SSL3_VERSION && version <= TLS_MAX_VERSION;
+    valid_dtls =
+        DTLS_VERSION_LE(version, DTLS_MAX_VERSION) &&
+        DTLS_VERSION_GE(version, DTLS1_BAD_VER);
+
+    if (!valid_tls && !valid_dtls)
+        return 0;
 
     /*-
      * Restrict TLS methods to TLS protocol versions.
@@ -1671,31 +1682,24 @@ int ssl_set_version_bound(int method_version, int version, int *bound)
      * configurations.  If the MIN (supported) version ever rises, the user's
      * "floor" remains valid even if no longer available.  We don't expect the
      * MAX ceiling to ever get lower, so making that variable makes sense.
+     *
+     * We ignore attempts to set bounds on version-inflexible methods,
+     * returning success.
      */
     switch (method_version) {
     default:
-        /*
-         * XXX For fixed version methods, should we always fail and not set any
-         * bounds, always succeed and not set any bounds, or set the bounds and
-         * arrange to fail later if they are not met?  At present fixed-version
-         * methods are not subject to controls that disable individual protocol
-         * versions.
-         */
-        return 0;
+        break;
 
     case TLS_ANY_VERSION:
-        if (version < SSL3_VERSION || version > TLS_MAX_VERSION)
-            return 0;
+        if (valid_tls)
+            *bound = version;
         break;
 
     case DTLS_ANY_VERSION:
-        if (DTLS_VERSION_GT(version, DTLS_MAX_VERSION) ||
-            DTLS_VERSION_LT(version, DTLS1_BAD_VER))
-            return 0;
+        if (valid_dtls)
+            *bound = version;
         break;
     }
-
-    *bound = version;
     return 1;
 }
 


### PR DESCRIPTION
The 'MinProtocol' and 'MaxProtocol' configuration commands now silently
ignore TLS protocol version bounds when configurign DTLS-based contexts,
and conversely, silently ignore DTLS protocol version bounds when
configuring TLS-based contexts.  The commands can be repeated to set
bounds of both types.  The same applies with the corresponding
"min_protocol" and "max_protocol" command-line switches, in case some
application uses both TLS and DTLS.

SSL_CTX instances that are created for a fixed protocol version (e.g.
TLSv1_server_method()) also silently ignore version bounds.  Previously
attempts to apply bounds to these protocol versions would result in an
error.  Now only the "version-flexible" SSL_CTX instances are subject to
limits in configuration files in command-line options.

Backport of #12472
Expected to resolve #12394

##### Checklist
- [ x] documentation is added or updated
