### PR TITLE
[test] Vertically test explicit EC params API patterns

### DIFF
--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2430,7 +2430,7 @@ static int custom_params_test(int id)
     const char *curve_name = NULL;
     EC_GROUP *group = NULL, *altgroup = NULL;
     EC_POINT *G2 = NULL, *Q1 = NULL, *Q2 = NULL;
-    const EC_POINT *P = NULL;
+    const EC_POINT *Q = NULL;
     BN_CTX *ctx = NULL;
     BIGNUM *k = NULL;
     unsigned char *buf1 = NULL, *buf2 = NULL;
@@ -2582,12 +2582,12 @@ static int custom_params_test(int id)
         goto err;
 
     /* retrieve bytes for pub2 for later */
-    if (!TEST_ptr(P = EC_KEY_get0_public_key(eckey2))
-            || !TEST_int_eq(EC_POINT_point2oct(altgroup, P,
+    if (!TEST_ptr(Q = EC_KEY_get0_public_key(eckey2))
+            || !TEST_int_eq(EC_POINT_point2oct(altgroup, Q,
                                                POINT_CONVERSION_UNCOMPRESSED,
                                                NULL, 0, ctx), bsize)
             || !TEST_ptr(pub2 = OPENSSL_malloc(bsize))
-            || !TEST_int_eq(EC_POINT_point2oct(altgroup, P,
+            || !TEST_int_eq(EC_POINT_point2oct(altgroup, Q,
                                                POINT_CONVERSION_UNCOMPRESSED,
                                                pub2, bsize, ctx), bsize))
         goto err;

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2363,10 +2363,8 @@ static int custom_generator_test(int id)
         goto err;
 
     /* expected byte length of encoded points */
-    bsize = (EC_GROUP_get_field_type(group) == NID_X9_62_prime_field) ?
-             BN_num_bytes(EC_GROUP_get0_field(group)) :
-             (EC_GROUP_get_degree(group) + 7) / 8;
-    bsize = 2 * bsize + 1;
+    bsize = (EC_GROUP_get_degree(group) + 7) / 8;
+    bsize = 1 + 2 * bsize; /* UNCOMPRESSED_POINT format */
 
     if (!TEST_ptr(k = BN_CTX_get(ctx))
         /* fetch a testing scalar k != 0,1 */

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -20,8 +20,6 @@
 #include <string.h>
 #include "internal/nelem.h"
 #include "testutil.h"
-#include "openssl/core_names.h"
-#include "openssl/param_build.h"
 
 #ifndef OPENSSL_NO_EC
 # include <openssl/ec.h>
@@ -34,6 +32,9 @@
 # include <openssl/rand.h>
 # include <openssl/bn.h>
 # include <openssl/opensslconf.h>
+# include "openssl/core_names.h"
+# include "openssl/param_build.h"
+# include "openssl/evp.h"
 
 static size_t crv_len = 0;
 static EC_builtin_curve *curves = NULL;

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2596,13 +2596,11 @@ static int custom_params_test(int id)
     if(!TEST_ptr(pkey1 = EVP_PKEY_new())
             || !TEST_int_eq(EVP_PKEY_assign_EC_KEY(pkey1, eckey1), 1))
         goto err;
-    else
-        eckey1 = NULL; /* ownership passed to pkey1 */
+    eckey1 = NULL; /* ownership passed to pkey1 */
     if(!TEST_ptr(pkey2 = EVP_PKEY_new())
             || !TEST_int_eq(EVP_PKEY_assign_EC_KEY(pkey2, eckey2), 1))
         goto err;
-    else
-        eckey2 = NULL; /* ownership passed to pkey2 */
+    eckey2 = NULL; /* ownership passed to pkey2 */
 
     /* Compute keyexchange in both directions */
     if (!TEST_ptr(pctx1 = EVP_PKEY_CTX_new(pkey1, NULL))

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2403,7 +2403,7 @@ static int custom_generator_test(int id)
                                            POINT_CONVERSION_UNCOMPRESSED, b2,
                                            bsize, ctx), bsize)
         /* Q1 = kG = k/2 G2 = Q2 should hold */
-        || !TEST_int_eq(CRYPTO_memcmp(b1, b2, bsize), 0))
+        || !TEST_mem_eq(b1, bsize, b2, bsize))
         goto err;
 
     ret = 1;
@@ -2549,7 +2549,7 @@ static int custom_params_test(int id)
                                                POINT_CONVERSION_UNCOMPRESSED,
                                                buf2, bsize, ctx), bsize)
             /* Q1 = kG = k/2 G2 = Q2 should hold */
-            || !TEST_int_eq(CRYPTO_memcmp(buf1, buf2, bsize), 0))
+            || !TEST_mem_eq(buf1, bsize, buf2, bsize))
         goto err;
 
     /* create two `EC_KEY`s on altgroup */
@@ -2618,12 +2618,11 @@ static int custom_params_test(int id)
             || !TEST_int_eq(EVP_PKEY_derive(pctx2, NULL, &t), 1)
             || !TEST_int_gt(bsize, t)
             || !TEST_int_le(sslen, t)
-            || !TEST_int_eq(EVP_PKEY_derive(pctx2, buf2, &t), 1)
-            || !TEST_int_eq(t, sslen))
+            || !TEST_int_eq(EVP_PKEY_derive(pctx2, buf2, &t), 1))
         goto err;
 
     /* Both sides should expect the same shared secret */
-    if (!TEST_int_eq(CRYPTO_memcmp(buf1, buf2, sslen), 0))
+    if (!TEST_mem_eq(buf1, sslen, buf2, t))
         goto err;
 
     /* Build parameters for provider-native keys */
@@ -2668,9 +2667,8 @@ static int custom_params_test(int id)
             || !TEST_int_gt(bsize, t)
             || !TEST_int_le(sslen, t)
             || !TEST_int_eq(EVP_PKEY_derive(pctx1, buf1, &t), 1)
-            || !TEST_int_eq(t, sslen)
             /* compare with previous result */
-            || !TEST_int_eq(CRYPTO_memcmp(buf1, buf2, sslen), 0))
+            || !TEST_mem_eq(buf1, t, buf2, sslen))
         goto err;
 
     ret = 1;


### PR DESCRIPTION
This commit adds a new test (run on all the built-in curves) to create `EC_GROUP` with **unknown** *explicit parameters*: from a built-in group we create an alternative group from scratch that differs in the generator used.

At the `EC_GROUP` layer we perform a basic math check to ensure that the math on the alternative group still makes sense, using comparable results from the origin group.

We then create two `EC_KEY` objects on top of this alternative group and run key generation from the `EC_KEY` layer.

Finally we promote these two `EC_KEY`s to `EVP_PKEY` objects and try to run the derive operation at the highest abstraction layer, comparing results in both directions.

##### Checklist
- [x] tests are added or updated
