### PR TITLE
Fix provider cipher reinit after init/update with a partial update block

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -103,6 +103,8 @@ static int aes_ocb_init(void *vctx, const unsigned char *key, size_t keylen,
 {
    PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
 
+   ctx->aad_buf_len = 0;
+   ctx->data_buf_len = 0;
    ctx->base.enc = enc;
 
    if (iv != NULL) {

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -68,6 +68,7 @@ static int des_init(void *vctx, const unsigned char *key, size_t keylen,
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
 
     ctx->num = 0;
+    ctx->bufsz = 0;
     ctx->enc = enc;
 
     if (iv != NULL) {

--- a/providers/implementations/ciphers/cipher_tdes_common.c
+++ b/providers/implementations/ciphers/cipher_tdes_common.c
@@ -58,6 +58,7 @@ static int tdes_init(void *vctx, const unsigned char *key, size_t keylen,
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
 
     ctx->num = 0;
+    ctx->bufsz = 0;
     ctx->enc = enc;
 
     if (iv != NULL) {

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -150,6 +150,7 @@ static int cipher_generic_init_internal(PROV_CIPHER_CTX *ctx,
                                         int enc)
 {
     ctx->num = 0;
+    ctx->bufsz = 0;
     ctx->updated = 0;
     ctx->enc = enc ? 1 : 0;
 

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -263,6 +263,77 @@ err:
     return ret;
 }
 
+/*
+ * This test only uses a partial block (8 bytes) of input for each
+ * EVP_EncryptUpdate() in order to test that the second init/update is not using
+ * a leftover buffer from the first init/update.
+ * Note: some ciphers don't need a full 16 byte block to produce output.
+ */
+static int test_cipher_reinit_partialupdate(int test_id)
+{
+    int ret = 0, out1_len = 0, out2_len = 0;
+    EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER_CTX *ctx = NULL;
+    unsigned char out1[256];
+    unsigned char out2[256];
+    static const unsigned char in[8] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+    };
+    static const unsigned char key[64] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x01, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x02, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x03, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    };
+    static const unsigned char iv[16] = {
+        0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08,
+        0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00
+    };
+    const char *name = sk_OPENSSL_CSTRING_value(cipher_names, test_id);
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new()))
+        goto err;
+
+    TEST_note("Fetching %s\n", name);
+    if (!TEST_ptr(cipher = EVP_CIPHER_fetch(libctx, name, NULL)))
+        goto err;
+
+    /* skip any ciphers that don't allow partial updates */
+    if (((EVP_CIPHER_flags(cipher)
+          & (EVP_CIPH_FLAG_CTS | EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK)) != 0)
+        || EVP_CIPHER_mode(cipher) == EVP_CIPH_CCM_MODE
+        || EVP_CIPHER_mode(cipher) == EVP_CIPH_XTS_MODE
+        || EVP_CIPHER_mode(cipher) == EVP_CIPH_WRAP_MODE) {
+        ret = 1;
+        goto err;
+    }
+
+    if (!TEST_true(EVP_EncryptInit_ex(ctx, cipher, NULL, key, iv))
+        || !TEST_true(EVP_EncryptUpdate(ctx, out1, &out1_len, in, sizeof(in)))
+        || !TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
+        || !TEST_true(EVP_EncryptUpdate(ctx, out2, &out2_len, in, sizeof(in))))
+        goto err;
+
+    /* DES3-WRAP uses random every update - so it will give a different value */
+    if (EVP_CIPHER_is_a(cipher, "DES3-WRAP")) {
+        if (!TEST_mem_ne(out1, out1_len, out2, out2_len))
+            goto err;
+    } else {
+        if (!TEST_mem_eq(out1, out1_len, out2, out2_len))
+            goto err;
+    }
+    ret = 1;
+err:
+    EVP_CIPHER_free(cipher);
+    EVP_CIPHER_CTX_free(ctx);
+    return ret;
+}
+
+
 static int name_cmp(const char * const *a, const char * const *b)
 {
     return strcasecmp(*a, *b);
@@ -327,6 +398,8 @@ int setup_tests(void)
     EVP_CIPHER_do_all_provided(libctx, collect_cipher_names, cipher_names);
 
     ADD_ALL_TESTS(test_cipher_reinit, sk_OPENSSL_CSTRING_num(cipher_names));
+    ADD_ALL_TESTS(test_cipher_reinit_partialupdate,
+                  sk_OPENSSL_CSTRING_num(cipher_names));
     return 1;
 }
 


### PR DESCRIPTION
The test added previously used a 16 byte block during the update which does not cause internal buffering.
Some internal variables related to the buffering were not being cleared in the init, which meant that the second
update would use the buffered data from the first update.
Added test for this scenario with exclusions for ciphers that do not support partial block updates.

Found by @guidovranken 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
