### PR TITLE
81-test_cmp_cli.t: Skip tests with mock server if server cannot be started

### DIFF
--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -215,23 +215,27 @@ indir data_dir() => sub {
     foreach my $server_name (@server_configurations) {
         $server_name = chop_dblquot($server_name);
         load_config($server_name, $server_name);
-        my $pid;
-        if ($server_name eq "Mock") {
-            indir "Mock" => sub {
-                $pid = start_mock_server("");
-                die "Cannot start or find the started CMP mock server" unless $pid;
+      SKIP:
+        {
+            my $pid;
+            if ($server_name eq "Mock") {
+                indir "Mock" => sub {
+                    $pid = start_mock_server("");
+                    skip "Cannot start or find the started CMP mock server",
+                        scalar @all_aspects unless $pid;
+                }
             }
-        }
-        foreach my $aspect (@all_aspects) {
-            $aspect = chop_dblquot($aspect);
-            next if $server_name eq "Mock" && $aspect eq "certstatus";
-            load_config($server_name, $aspect); # update with any aspect-specific settings
-            indir $server_name => sub {
-                my $tests = load_tests($server_name, $aspect);
-                test_cmp_cli_aspect($server_name, $aspect, $tests);
+            foreach my $aspect (@all_aspects) {
+                $aspect = chop_dblquot($aspect);
+                next if $server_name eq "Mock" && $aspect eq "certstatus";
+                load_config($server_name, $aspect); # update with any aspect-specific settings
+                indir $server_name => sub {
+                    my $tests = load_tests($server_name, $aspect);
+                    test_cmp_cli_aspect($server_name, $aspect, $tests);
+                };
             };
-        };
-        stop_mock_server($pid) if $pid;
+            stop_mock_server($pid) if $pid;
+        }
     };
 };
 


### PR DESCRIPTION
It turns out that there are still issues launching a server reliably on non-Linux platforms
without proper support by a Perl module such as `Proc::Background`.
This PR now simply skps the tests that need the mock server 
if launching the server process or determining its PID goes wrong for any reason.

Fixes #12514

- [x] tests are added or updated
