### PR TITLE
3.0.0-alpha6: "openssl pkcs12" is unable to parse or create PKCS#12 archives with default ciphers

### DIFF
--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -44,6 +44,7 @@ B<openssl> B<pkcs12>
 [B<-maciter>]
 [B<-nomac>]
 [B<-twopass>]
+[B<-legacy>]
 [B<-descert>]
 [B<-certpbe> I<cipher>]
 [B<-keypbe> I<cipher>]
@@ -166,6 +167,16 @@ always assumes these are the same so this option will render such
 PKCS#12 files unreadable. Cannot be used in combination with the options
 B<-password>, B<-passin> if importing, or B<-passout> if exporting.
 
+=item B<-legacy>
+
+Use legacy mode of operation and automatically load the legacy provider.
+In the legacy mode, the default algorithm for certificate encryption
+is RC2_CBC or 3DES_CBC depending on whether the RC2 cipher is enabled
+in the build. The default algorithm for private key encryption is 3DES_CBC.
+If the legacy option is not specified, then the legacy provider is not loaded
+and the default encryption algorithm for both certificates and private keys is
+AES_256_CBC with PBKDF2 for key derivation by default.
+
 =back
 
 =head1 FILE CREATION OPTIONS
@@ -229,8 +240,9 @@ for this search. If the search fails it is considered a fatal error.
 
 Encrypt the certificate using triple DES, this may render the PKCS#12
 file unreadable by some "export grade" software. By default the private
-key is encrypted using triple DES and the certificate using 40 bit RC2
-unless RC2 is disabled in which case triple DES is used.
+key is encrypted using AES and the certificate using triple DES unless
+the '-legacy' option is used. If '-descert' is used with the '-legacy'
+then both, the private key and the certificate are encrypted using triple DES.
 
 =item B<-keypbe> I<alg>, B<-certpbe> I<alg>
 
@@ -355,6 +367,10 @@ Print some info about a PKCS#12 file:
 
  openssl pkcs12 -in file.p12 -info -noout
 
+Print some info about a PKCS#12 file in legacy mode:
+
+ openssl pkcs12 -in file.p12 -info -noout -legacy
+
 Create a PKCS#12 file:
 
  openssl pkcs12 -export -in file.pem -out file.p12 -name "My Certificate"
@@ -363,6 +379,10 @@ Include some extra certificates:
 
  openssl pkcs12 -export -in file.pem -out file.p12 -name "My Certificate" \
   -certfile othercerts.pem
+
+Export a PKCS#12 file with default encryption algorithms as in the legacy provider:
+
+ openssl pkcs12 -export -in cert.pem -inkey key.pem -out file.p12 -legacy
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
This PR makes the following two changes in openssl-pkcs12 to fix #11672 :

1. Changes the default encryption algorithms for certificates and private keys from RC2 to AES_256_CBC in OpenSSL 3.0
2. Add a new option "-legacy" to the pkcs12 cli which loads the legacy provider and restores the default algorithms
    The default algorithm for private key encryption is 3DES_CBC. If the legacy option is not specified, then 
     the legacy provider is not loaded and the default encryption algorithm for both certificates and private keys is
    AES_256_CBC by default.

The above design was proposed by @t8m as per the comments in the discussion #11672 that were agreed upon.

Documentation and example section is updated.
No new tests are added. The cli usage is documented under examples.

Usage:

openssl pkcs12 -in cert.pem -inkey key.pem -out foo.p12 -export
openssl pkcs12 -info -in foo.p12

with the legacy option:

openssl pkcs12 -in cert.pem -inkey key.pem -out foo.p12 -export **-legacy**
openssl pkcs12 -info -in foo.p12 **-legacy**

Note: certs and keys can be generated using the below command
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365



<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
