### PR TITLE
Fix test_cmp_cli for extended tests

### DIFF
--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -34,6 +34,8 @@ plan skip_all => "These tests are not supported in a no-ec build"
 
 plan skip_all => "Tests involving CMP server not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
+plan skip_all => "Tests involving CMP server not available in cross-compile builds"
+    if defined $ENV{EXE_SHELL};
 plan skip_all => "Tests involving CMP server require 'kill' command"
     unless `which kill`;
 plan skip_all => "Tests involving CMP server require 'lsof' command"


### PR DESCRIPTION
The test_cmp_cli was failing in the extended tests on cross-compiled
mingw builds. This was due to the test not using wine when it should do.
The simplest solution is to just skip the test in this case.

[extended tests]

I am expecting some extended tests to still fail. That is due to other issues not addressed by this PR.
