### PR TITLE
Fix an ENGINE leak in asn1_item_digest_with_libctx

### DIFF
--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -68,7 +68,11 @@ int asn1_item_digest_with_libctx(const ASN1_ITEM *it, const EVP_MD *md,
 
     if (EVP_MD_provider(md) == NULL) {
 #if !defined(OPENSSL_NO_ENGINE)
-        if (ENGINE_get_digest_engine(EVP_MD_type(md)) == NULL)
+        ENGINE *tmpeng = ENGINE_get_digest_engine(EVP_MD_type(md));
+
+        if (tmpeng != NULL)
+            ENGINE_finish(tmpeng);
+        else
 #endif
             fetched_md = EVP_MD_fetch(libctx, EVP_MD_name(md), propq);
     }


### PR DESCRIPTION
Commit 6725682d introduced a call to ENGINE_get_digest_engine() into
the function asn1_item_digest_with_libctx() to determine whether there
is an ENGINE registered to handle the specified digest. However that
function increases the ref count on the returned ENGINE object, so it
must be freed.

Fixes #12558

[extended tests]

Note there are other unrelated extended test failures besides this one. Therefore I expect the extended tests to still fail even after this PR.