### PR TITLE
PROV: Make the DER to KEY deserializer decode parameters too

### DIFF
--- a/providers/implementations/serializers/deserialize_der2key.c
+++ b/providers/implementations/serializers/deserialize_der2key.c
@@ -130,6 +130,11 @@ static int der2key_deserialize(void *vctx, OSSL_CORE_BIO *cin,
         pkey = d2i_PUBKEY(NULL, &derp, der_len);
     }
 
+    if (pkey == NULL) {
+        derp = der;
+        pkey = d2i_KeyParams(ctx->desc->type, NULL, &derp, der_len);
+    }
+
     if (pkey != NULL) {
         /*
          * Tear out the low-level key pointer from the pkey,


### PR DESCRIPTION
It should be noted that this may be dodgy if we ever encounter
parameter objects that look like something else.  However, experience
with the OSSL_STORE 'file:' loader, which does exactly this kind of
thing, has worked fine so far.

A possibility could be that to decode parameters specifically, we
demand that there's an incoming data type specifying this, which
demands by extension that parameters can only come from a file format
that has the parameter type encoded, such as PEM.  This would be a
future effort.

Fixes #12568
