### PR TITLE
Pass the provider context to gettable and settable functions.

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -557,7 +557,8 @@ int EVP_MD_get_params(const EVP_MD *digest, OSSL_PARAM params[])
 const OSSL_PARAM *EVP_MD_gettable_params(const EVP_MD *digest)
 {
     if (digest != NULL && digest->gettable_params != NULL)
-        return digest->gettable_params();
+        return digest->gettable_params(
+                           ossl_provider_ctx(EVP_MD_provider(digest)));
     return NULL;
 }
 
@@ -581,7 +582,7 @@ int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[])
 const OSSL_PARAM *EVP_MD_settable_ctx_params(const EVP_MD *md)
 {
     if (md != NULL && md->settable_ctx_params != NULL)
-        return md->settable_ctx_params();
+        return md->settable_ctx_params(ossl_provider_ctx(EVP_MD_provider(md)));
     return NULL;
 }
 
@@ -589,10 +590,12 @@ const OSSL_PARAM *EVP_MD_CTX_settable_params(EVP_MD_CTX *ctx)
 {
     EVP_PKEY_CTX *pctx;
 
-    if (ctx != NULL
-            && ctx->digest != NULL
-            && ctx->digest->settable_ctx_params != NULL)
-        return ctx->digest->settable_ctx_params();
+    if (ctx == NULL)
+        return NULL;
+
+    if (ctx->digest != NULL && ctx->digest->settable_ctx_params != NULL)
+        return ctx->digest->settable_ctx_params(
+                  ossl_provider_ctx(EVP_MD_provider(ctx->digest)));
 
     pctx = ctx->pctx;
     if (pctx != NULL
@@ -627,7 +630,7 @@ int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, OSSL_PARAM params[])
 const OSSL_PARAM *EVP_MD_gettable_ctx_params(const EVP_MD *md)
 {
     if (md != NULL && md->gettable_ctx_params != NULL)
-        return md->gettable_ctx_params();
+        return md->gettable_ctx_params(ossl_provider_ctx(EVP_MD_provider(md)));
     return NULL;
 }
 
@@ -638,7 +641,8 @@ const OSSL_PARAM *EVP_MD_CTX_gettable_params(EVP_MD_CTX *ctx)
     if (ctx != NULL
             && ctx->digest != NULL
             && ctx->digest->gettable_ctx_params != NULL)
-        return ctx->digest->gettable_ctx_params();
+        return ctx->digest->gettable_ctx_params(
+                   ossl_provider_ctx(EVP_MD_provider(ctx->digest)));
 
     pctx = ctx->pctx;
     if (pctx != NULL

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1160,21 +1160,24 @@ int EVP_CIPHER_CTX_get_params(EVP_CIPHER_CTX *ctx, OSSL_PARAM params[])
 const OSSL_PARAM *EVP_CIPHER_gettable_params(const EVP_CIPHER *cipher)
 {
     if (cipher != NULL && cipher->gettable_params != NULL)
-        return cipher->gettable_params();
+        return cipher->gettable_params(
+                   ossl_provider_ctx(EVP_CIPHER_provider(cipher)));
     return NULL;
 }
 
 const OSSL_PARAM *EVP_CIPHER_settable_ctx_params(const EVP_CIPHER *cipher)
 {
     if (cipher != NULL && cipher->settable_ctx_params != NULL)
-        return cipher->settable_ctx_params();
+        return cipher->settable_ctx_params(
+                   ossl_provider_ctx(EVP_CIPHER_provider(cipher)));
     return NULL;
 }
 
 const OSSL_PARAM *EVP_CIPHER_gettable_ctx_params(const EVP_CIPHER *cipher)
 {
     if (cipher != NULL && cipher->gettable_ctx_params != NULL)
-        return cipher->gettable_ctx_params();
+        return cipher->gettable_ctx_params(
+                   ossl_provider_ctx(EVP_CIPHER_provider(cipher)));
     return NULL;
 }
 

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -377,19 +377,25 @@ int EVP_RAND_set_ctx_params(EVP_RAND_CTX *ctx, const OSSL_PARAM params[])
 
 const OSSL_PARAM *EVP_RAND_gettable_params(const EVP_RAND *rand)
 {
-    return rand->gettable_params == NULL ? NULL : rand->gettable_params();
+    if (rand->gettable_params == NULL)
+        return NULL;
+    return rand->gettable_params(ossl_provider_ctx(EVP_RAND_provider(rand)));
 }
 
 const OSSL_PARAM *EVP_RAND_gettable_ctx_params(const EVP_RAND *rand)
 {
-    return rand->gettable_ctx_params == NULL ? NULL
-                                             : rand->gettable_ctx_params();
+    if (rand->gettable_params == NULL)
+        return NULL;
+    return rand->gettable_ctx_params(
+               ossl_provider_ctx(EVP_RAND_provider(rand)));
 }
 
 const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand)
 {
-    return rand->settable_ctx_params == NULL ? NULL
-                                             : rand->settable_ctx_params();
+    if (rand->gettable_params == NULL)
+        return NULL;
+    return rand->settable_ctx_params(
+               ossl_provider_ctx(EVP_RAND_provider(rand)));
 }
 
 void EVP_RAND_do_all_provided(OPENSSL_CTX *libctx,

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -169,21 +169,21 @@ const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf)
 {
     if (kdf->gettable_params == NULL)
         return NULL;
-    return kdf->gettable_params();
+    return kdf->gettable_params(ossl_provider_ctx(EVP_KDF_provider(kdf)));
 }
 
 const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf)
 {
     if (kdf->gettable_ctx_params == NULL)
         return NULL;
-    return kdf->gettable_ctx_params();
+    return kdf->gettable_ctx_params(ossl_provider_ctx(EVP_KDF_provider(kdf)));
 }
 
 const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf)
 {
     if (kdf->settable_ctx_params == NULL)
         return NULL;
-    return kdf->settable_ctx_params();
+    return kdf->settable_ctx_params(ossl_provider_ctx(EVP_KDF_provider(kdf)));
 }
 
 void EVP_KDF_do_all_provided(OPENSSL_CTX *libctx,

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -369,9 +369,11 @@ int evp_keymgmt_get_params(const EVP_KEYMGMT *keymgmt, void *keydata,
 
 const OSSL_PARAM *evp_keymgmt_gettable_params(const EVP_KEYMGMT *keymgmt)
 {
+    void *provctx = ossl_provider_ctx(EVP_KEYMGMT_provider(keymgmt));
+
     if (keymgmt->gettable_params == NULL)
         return NULL;
-    return keymgmt->gettable_params();
+    return keymgmt->gettable_params(provctx);
 }
 
 int evp_keymgmt_set_params(const EVP_KEYMGMT *keymgmt, void *keydata,
@@ -384,9 +386,11 @@ int evp_keymgmt_set_params(const EVP_KEYMGMT *keymgmt, void *keydata,
 
 const OSSL_PARAM *evp_keymgmt_settable_params(const EVP_KEYMGMT *keymgmt)
 {
+    void *provctx = ossl_provider_ctx(EVP_KEYMGMT_provider(keymgmt));
+
     if (keymgmt->settable_params == NULL)
         return NULL;
-    return keymgmt->settable_params();
+    return keymgmt->settable_params(provctx);
 }
 
 int evp_keymgmt_has(const EVP_KEYMGMT *keymgmt, void *keydata, int selection)

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -176,21 +176,21 @@ const OSSL_PARAM *EVP_MAC_gettable_params(const EVP_MAC *mac)
 {
     if (mac->gettable_params == NULL)
         return NULL;
-    return mac->gettable_params();
+    return mac->gettable_params(ossl_provider_ctx(EVP_MAC_provider(mac)));
 }
 
 const OSSL_PARAM *EVP_MAC_gettable_ctx_params(const EVP_MAC *mac)
 {
     if (mac->gettable_ctx_params == NULL)
         return NULL;
-    return mac->gettable_ctx_params();
+    return mac->gettable_ctx_params(ossl_provider_ctx(EVP_MAC_provider(mac)));
 }
 
 const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac)
 {
     if (mac->settable_ctx_params == NULL)
         return NULL;
-    return mac->settable_ctx_params();
+    return mac->settable_ctx_params(ossl_provider_ctx(EVP_MAC_provider(mac)));
 }
 
 void EVP_MAC_do_all_provided(OPENSSL_CTX *libctx,

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -631,35 +631,55 @@ int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
 #ifndef FIPS_MODULE
 const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(EVP_PKEY_CTX *ctx)
 {
+    void *provctx;
+
     if (EVP_PKEY_CTX_IS_DERIVE_OP(ctx)
             && ctx->op.kex.exchange != NULL
-            && ctx->op.kex.exchange->gettable_ctx_params != NULL)
-        return ctx->op.kex.exchange->gettable_ctx_params();
+            && ctx->op.kex.exchange->gettable_ctx_params != NULL) {
+        provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(ctx->op.kex.exchange));
+        return ctx->op.kex.exchange->gettable_ctx_params(provctx);
+    }
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
             && ctx->op.sig.signature != NULL
-            && ctx->op.sig.signature->gettable_ctx_params != NULL)
-        return ctx->op.sig.signature->gettable_ctx_params();
+            && ctx->op.sig.signature->gettable_ctx_params != NULL) {
+        provctx = ossl_provider_ctx(
+                      EVP_SIGNATURE_provider(ctx->op.sig.signature));
+        return ctx->op.sig.signature->gettable_ctx_params(provctx);
+    }
     if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
             && ctx->op.ciph.cipher != NULL
-            && ctx->op.ciph.cipher->gettable_ctx_params != NULL)
-        return ctx->op.ciph.cipher->gettable_ctx_params();
+            && ctx->op.ciph.cipher->gettable_ctx_params != NULL) {
+        provctx = ossl_provider_ctx(
+                      EVP_ASYM_CIPHER_provider(ctx->op.ciph.cipher));
+        return ctx->op.ciph.cipher->gettable_ctx_params(provctx);
+    }
     return NULL;
 }
 
 const OSSL_PARAM *EVP_PKEY_CTX_settable_params(EVP_PKEY_CTX *ctx)
 {
+    void *provctx;
+
     if (EVP_PKEY_CTX_IS_DERIVE_OP(ctx)
             && ctx->op.kex.exchange != NULL
-            && ctx->op.kex.exchange->settable_ctx_params != NULL)
-        return ctx->op.kex.exchange->settable_ctx_params();
+            && ctx->op.kex.exchange->settable_ctx_params != NULL) {
+        provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(ctx->op.kex.exchange));
+        return ctx->op.kex.exchange->settable_ctx_params(provctx);
+    }
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
             && ctx->op.sig.signature != NULL
-            && ctx->op.sig.signature->settable_ctx_params != NULL)
-        return ctx->op.sig.signature->settable_ctx_params();
+            && ctx->op.sig.signature->settable_ctx_params != NULL) {
+        provctx = ossl_provider_ctx(
+                      EVP_SIGNATURE_provider(ctx->op.sig.signature));
+        return ctx->op.sig.signature->settable_ctx_params(provctx);
+    }
     if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
             && ctx->op.ciph.cipher != NULL
-            && ctx->op.ciph.cipher->settable_ctx_params != NULL)
-        return ctx->op.ciph.cipher->settable_ctx_params();
+            && ctx->op.ciph.cipher->settable_ctx_params != NULL) {
+        provctx = ossl_provider_ctx(
+                      EVP_ASYM_CIPHER_provider(ctx->op.ciph.cipher));
+        return ctx->op.ciph.cipher->settable_ctx_params(provctx);
+    }
     if (EVP_PKEY_CTX_IS_GEN_OP(ctx)
             && ctx->keymgmt != NULL)
         return evp_keymgmt_gen_settable_params(ctx->keymgmt);

--- a/crypto/serializer/deserializer_meth.c
+++ b/crypto/serializer/deserializer_meth.c
@@ -452,7 +452,8 @@ const OSSL_PARAM *
 OSSL_DESERIALIZER_gettable_params(OSSL_DESERIALIZER *deser)
 {
     if (deser != NULL && deser->gettable_params != NULL)
-        return deser->gettable_params();
+        return deser->gettable_params(
+                   ossl_provider_ctx(OSSL_DESERIALIZER_provider(deser)));
     return NULL;
 }
 
@@ -467,7 +468,8 @@ const OSSL_PARAM *
 OSSL_DESERIALIZER_settable_ctx_params(OSSL_DESERIALIZER *deser)
 {
     if (deser != NULL && deser->settable_ctx_params != NULL)
-        return deser->settable_ctx_params();
+        return deser->settable_ctx_params(
+                   ossl_provider_ctx(OSSL_DESERIALIZER_provider(deser)));
     return NULL;
 }
 

--- a/crypto/serializer/serializer_meth.c
+++ b/crypto/serializer/serializer_meth.c
@@ -444,7 +444,8 @@ void OSSL_SERIALIZER_names_do_all(const OSSL_SERIALIZER *ser,
 const OSSL_PARAM *OSSL_SERIALIZER_settable_ctx_params(OSSL_SERIALIZER *ser)
 {
     if (ser != NULL && ser->settable_ctx_params != NULL)
-        return ser->settable_ctx_params();
+        return ser->settable_ctx_params(
+                   ossl_provider_ctx(OSSL_SERIALIZER_provider(ser)));
     return NULL;
 }
 

--- a/doc/man7/provider-asym_cipher.pod
+++ b/doc/man7/provider-asym_cipher.pod
@@ -36,9 +36,9 @@ provider-asym_cipher - The asym_cipher library E<lt>-E<gt> provider functions
 
  /* Asymmetric Cipher parameters */
  int OSSL_FUNC_asym_cipher_get_ctx_params(void *ctx, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_asym_cipher_gettable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_asym_cipher_gettable_ctx_params(void *provctx);
  int OSSL_FUNC_asym_cipher_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_asym_cipher_settable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_asym_cipher_settable_ctx_params(void *provctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -37,11 +37,11 @@ provider-cipher - The cipher library E<lt>-E<gt> provider functions
                              size_t outsize, const unsigned char *in, size_t inl);
 
  /* Cipher parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_cipher_gettable_params(void);
+ const OSSL_PARAM *OSSL_FUNC_cipher_gettable_params(void *provctx);
 
  /* Cipher operation parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_cipher_gettable_ctx_params(void);
- const OSSL_PARAM *OSSL_FUNC_cipher_settable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_cipher_gettable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_cipher_settable_ctx_params(void *provctx);
 
  /* Cipher parameters */
  int OSSL_FUNC_cipher_get_params(OSSL_PARAM params[]);

--- a/doc/man7/provider-digest.pod
+++ b/doc/man7/provider-digest.pod
@@ -30,11 +30,11 @@ provider-digest - The digest library E<lt>-E<gt> provider functions
                              unsigned char *out, size_t *outl, size_t outsz);
 
  /* Digest parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_digest_gettable_params(void);
+ const OSSL_PARAM *OSSL_FUNC_digest_gettable_params(void *provctx);
 
  /* Digest operation parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_digest_gettable_ctx_params(void);
- const OSSL_PARAM *OSSL_FUNC_digest_settable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_digest_gettable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_digest_settable_ctx_params(void *provctx);
 
  /* Digest parameters */
  int OSSL_FUNC_digest_get_params(OSSL_PARAM params[]);

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -30,9 +30,9 @@ provider-keyexch - The keyexch library E<lt>-E<gt> provider functions
 
  /* Key Exchange parameters */
  int OSSL_FUNC_keyexch_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keyexch_settable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_keyexch_settable_ctx_params(void *provctx);
  int OSSL_FUNC_keyexch_get_ctx_params(void *ctx, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keyexch_gettable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_keyexch_gettable_ctx_params(void *provctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -31,9 +31,9 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
 
  /* Key object information */
  int OSSL_FUNC_keymgmt_get_params(void *keydata, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keymgmt_gettable_params(void);
+ const OSSL_PARAM *OSSL_FUNC_keymgmt_gettable_params(void *provctx);
  int OSSL_FUNC_keymgmt_set_params(void *keydata, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keymgmt_settable_params(void);
+ const OSSL_PARAM *OSSL_FUNC_keymgmt_settable_params(void *provctx);
 
  /* Key object content checks */
  int OSSL_FUNC_keymgmt_has(void *keydata, int selection);

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -28,9 +28,9 @@ provider-mac - The mac library E<lt>-E<gt> provider functions
  int OSSL_FUNC_mac_final(void *mctx, unsigned char *out, size_t *outl, size_t outsize);
 
  /* MAC parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_mac_get_params(void);
- const OSSL_PARAM *OSSL_FUNC_mac_get_ctx_params(void);
- const OSSL_PARAM *OSSL_FUNC_mac_set_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_mac_get_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_mac_get_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_mac_set_ctx_params(void *provctx);
 
  /* MAC parameters */
  int OSSL_FUNC_mac_get_params(OSSL_PARAM params[]);

--- a/doc/man7/provider-rand.pod
+++ b/doc/man7/provider-rand.pod
@@ -50,9 +50,9 @@ functions
  void OSSL_FUNC_rand_unlock(void *ctx);
 
  /* RAND parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_rand_gettable_params(void);
- const OSSL_PARAM *OSSL_FUNC_rand_gettable_ctx_params(void);
- const OSSL_PARAM *OSSL_FUNC_rand_settable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_rand_gettable_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_rand_gettable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_rand_settable_ctx_params(void *provctx);
 
  /* RAND parameters */
  int OSSL_FUNC_rand_get_params(OSSL_PARAM params[]);

--- a/doc/man7/provider-serializer.pod
+++ b/doc/man7/provider-serializer.pod
@@ -24,7 +24,7 @@ Future development will also include deserializing functions.
  void *OSSL_FUNC_serializer_newctx(void *provctx);
  void OSSL_FUNC_serializer_freectx(void *ctx);
  int OSSL_FUNC_serializer_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_serializer_settable_ctx_params(void)
+ const OSSL_PARAM *OSSL_FUNC_serializer_settable_ctx_params(void *provctx)
 
  /* Functions to serialize object data */
  int OSSL_FUNC_serializer_serialize_data(void *ctx, const OSSL_PARAM *data,

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -64,9 +64,9 @@ provider-signature - The signature library E<lt>-E<gt> provider functions
 
  /* Signature parameters */
  int OSSL_FUNC_signature_get_ctx_params(void *ctx, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_signature_gettable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_signature_gettable_ctx_params(void *provctx);
  int OSSL_FUNC_signature_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_signature_settable_ctx_params(void);
+ const OSSL_PARAM *OSSL_FUNC_signature_settable_ctx_params(void *provctx);
 
  /* MD parameters */
  int OSSL_FUNC_signature_get_ctx_md_params(void *ctx, OSSL_PARAM params[]);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -229,9 +229,12 @@ OSSL_CORE_MAKE_FUNC(int, digest_set_ctx_params,
                     (void *vctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, digest_get_ctx_params,
                     (void *vctx, OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_settable_ctx_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_ctx_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_settable_ctx_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_ctx_params,
+                    (void *provctx))
 
 /* Symmetric Ciphers */
 
@@ -279,9 +282,12 @@ OSSL_CORE_MAKE_FUNC(int, cipher_get_ctx_params, (void *cctx,
                                                     OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, cipher_set_ctx_params, (void *cctx,
                                                     const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_params,     (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_settable_ctx_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_ctx_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_settable_ctx_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_ctx_params,
+                    (void *provctx))
 
 /* MACs */
 
@@ -308,9 +314,11 @@ OSSL_CORE_MAKE_FUNC(int, mac_update,
 OSSL_CORE_MAKE_FUNC(int, mac_final,
                     (void *mctx,
                      unsigned char *out, size_t *outl, size_t outsize))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_gettable_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_gettable_ctx_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_settable_ctx_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_gettable_params, (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_gettable_ctx_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_settable_ctx_params,
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, mac_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, mac_get_ctx_params,
                     (void *mctx, OSSL_PARAM params[]))
@@ -337,9 +345,11 @@ OSSL_CORE_MAKE_FUNC(void, kdf_freectx, (void *kctx))
 OSSL_CORE_MAKE_FUNC(void, kdf_reset, (void *kctx))
 OSSL_CORE_MAKE_FUNC(int, kdf_derive, (void *kctx, unsigned char *key,
                                           size_t keylen))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_ctx_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_settable_ctx_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_params, (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_ctx_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_settable_ctx_params,
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, kdf_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, kdf_get_ctx_params,
                     (void *kctx, OSSL_PARAM params[]))
@@ -390,9 +400,11 @@ OSSL_CORE_MAKE_FUNC(size_t,rand_nonce,
 OSSL_CORE_MAKE_FUNC(int,rand_enable_locking, (void *vctx))
 OSSL_CORE_MAKE_FUNC(int,rand_lock, (void *vctx))
 OSSL_CORE_MAKE_FUNC(void,rand_unlock, (void *vctx))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_ctx_params, (void))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_settable_ctx_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_params, (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_ctx_params,
+                    (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_settable_ctx_params,
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int,rand_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int,rand_get_ctx_params,
                     (void *vctx, OSSL_PARAM params[]))
@@ -497,13 +509,13 @@ OSSL_CORE_MAKE_FUNC(void, keymgmt_free, (void *keydata))
 #define OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS             12
 OSSL_CORE_MAKE_FUNC(int, keymgmt_get_params,
                     (void *keydata, OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_gettable_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_gettable_params, (void *))
 
 #define OSSL_FUNC_KEYMGMT_SET_PARAMS                  13
 #define OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS             14
 OSSL_CORE_MAKE_FUNC(int, keymgmt_set_params,
                     (void *keydata, const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_settable_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_settable_params, (void *))
 
 /* Key checks - discovery of supported operations */
 # define OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME       20
@@ -568,11 +580,11 @@ OSSL_CORE_MAKE_FUNC(void *, keyexch_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, keyexch_set_ctx_params, (void *ctx,
                                                      const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keyexch_settable_ctx_params,
-                    (void))
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, keyexch_get_ctx_params, (void *ctx,
                                                      OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keyexch_gettable_ctx_params,
-                    (void))
+                    (void *provctx))
 
 /* Signature */
 
@@ -647,11 +659,11 @@ OSSL_CORE_MAKE_FUNC(void *, signature_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, signature_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, signature_gettable_ctx_params,
-                    (void))
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, signature_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, signature_settable_ctx_params,
-                    (void))
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, signature_get_ctx_md_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, signature_gettable_ctx_md_params,
@@ -694,11 +706,11 @@ OSSL_CORE_MAKE_FUNC(void *, asym_cipher_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, asym_cipher_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, asym_cipher_gettable_ctx_params,
-                    (void))
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, asym_cipher_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, asym_cipher_settable_ctx_params,
-                    (void))
+                    (void *provctx))
 
 /* Serializers and deserializers */
 # define OSSL_FUNC_SERIALIZER_NEWCTX                1
@@ -712,7 +724,7 @@ OSSL_CORE_MAKE_FUNC(void, serializer_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, serializer_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, serializer_settable_ctx_params,
-                    (void))
+                    (void *provctx))
 
 OSSL_CORE_MAKE_FUNC(int, serializer_serialize_data,
                     (void *ctx, const OSSL_PARAM[], OSSL_CORE_BIO *out,
@@ -732,11 +744,12 @@ OSSL_CORE_MAKE_FUNC(int, serializer_serialize_object,
 OSSL_CORE_MAKE_FUNC(void *, deserializer_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void, deserializer_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, deserializer_get_params, (OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, deserializer_gettable_params, (void))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, deserializer_gettable_params,
+                    (void *provctx))
 OSSL_CORE_MAKE_FUNC(int, deserializer_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, deserializer_settable_ctx_params,
-                    (void))
+                    (void *provctx))
 
 OSSL_CORE_MAKE_FUNC(int, deserializer_deserialize,
                     (void *ctx, OSSL_CORE_BIO *in,

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -382,7 +382,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_ctx_params(void)
+static const OSSL_PARAM *rsa_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -526,7 +526,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_settable_ctx_params(void)
+static const OSSL_PARAM *rsa_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -59,7 +59,7 @@ static const OSSL_PARAM cipher_aes_known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_KEYLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *aes_settable_ctx_params(void)
+const OSSL_PARAM *aes_settable_ctx_params(void *provctx)
 {
     return cipher_aes_known_settable_ctx_params;
 }
@@ -250,7 +250,7 @@ static const OSSL_PARAM cipher_aes_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_IV, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *aes_gettable_ctx_params(void)
+const OSSL_PARAM *aes_gettable_ctx_params(void *provctx)
 {
     return cipher_aes_known_gettable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -39,6 +39,8 @@ static OSSL_FUNC_cipher_freectx_fn aes_ocb_freectx;
 static OSSL_FUNC_cipher_dupctx_fn aes_ocb_dupctx;
 static OSSL_FUNC_cipher_get_ctx_params_fn aes_ocb_get_ctx_params;
 static OSSL_FUNC_cipher_set_ctx_params_fn aes_ocb_set_ctx_params;
+static OSSL_FUNC_cipher_gettable_ctx_params_fn cipher_ocb_gettable_ctx_params;
+static OSSL_FUNC_cipher_settable_ctx_params_fn cipher_ocb_settable_ctx_params;
 
 /*
  * The following methods could be moved into PROV_AES_OCB_HW if
@@ -437,7 +439,7 @@ static const OSSL_PARAM cipher_ocb_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cipher_ocb_gettable_ctx_params(void)
+static const OSSL_PARAM *cipher_ocb_gettable_ctx_params(void *provctx)
 {
     return cipher_ocb_known_gettable_ctx_params;
 }
@@ -448,7 +450,7 @@ static const OSSL_PARAM cipher_ocb_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cipher_ocb_settable_ctx_params(void)
+static const OSSL_PARAM *cipher_ocb_settable_ctx_params(void *provctx)
 {
     return cipher_ocb_known_settable_ctx_params;
 }
@@ -513,4 +515,3 @@ const OSSL_DISPATCH aes##kbits##mode##_functions[] = {                         \
 IMPLEMENT_cipher(ocb, OCB, AES_OCB_FLAGS, 256, 128, OCB_DEFAULT_IV_LEN * 8);
 IMPLEMENT_cipher(ocb, OCB, AES_OCB_FLAGS, 192, 128, OCB_DEFAULT_IV_LEN * 8);
 IMPLEMENT_cipher(ocb, OCB, AES_OCB_FLAGS, 128, 128, OCB_DEFAULT_IV_LEN * 8);
-

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -166,7 +166,7 @@ static const OSSL_PARAM aes_siv_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *aes_siv_gettable_ctx_params(void)
+static const OSSL_PARAM *aes_siv_gettable_ctx_params(void *provctx)
 {
     return aes_siv_known_gettable_ctx_params;
 }
@@ -216,19 +216,33 @@ static const OSSL_PARAM aes_siv_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *aes_siv_settable_ctx_params(void)
+static const OSSL_PARAM *aes_siv_settable_ctx_params(void *provctx)
 {
     return aes_siv_known_settable_ctx_params;
 }
 
 #define IMPLEMENT_cipher(alg, lc, UCMODE, flags, kbits, blkbits, ivbits)       \
+static OSSL_FUNC_cipher_newctx_fn alg##kbits##lc##_newctx;                     \
+static OSSL_FUNC_cipher_freectx_fn alg##_##lc##_freectx;                       \
+static OSSL_FUNC_cipher_dupctx_fn lc##_dupctx;                                 \
+static OSSL_FUNC_cipher_encrypt_init_fn lc##_einit;                            \
+static OSSL_FUNC_cipher_decrypt_init_fn lc##_dinit;                            \
+static OSSL_FUNC_cipher_update_fn lc##_stream_update;                          \
+static OSSL_FUNC_cipher_final_fn lc##_stream_final;                            \
+static OSSL_FUNC_cipher_cipher_fn lc##_cipher;                                 \
 static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lc##_get_params;       \
+static OSSL_FUNC_cipher_gettable_params_fn alg##_##lc##_gettable_ctx_params;   \
+static OSSL_FUNC_cipher_get_ctx_params_fn alg##_##lc##_get_ctx_params;         \
+static OSSL_FUNC_cipher_gettable_ctx_params_fn                                 \
+            alg##_##lc##_gettable_ctx_params;                                  \
+static OSSL_FUNC_cipher_set_ctx_params_fn alg##_##lc##_set_ctx_params;         \
+static OSSL_FUNC_cipher_settable_ctx_params_fn                                 \
+            alg##_##lc##_settable_ctx_params;                                  \
 static int alg##_##kbits##_##lc##_get_params(OSSL_PARAM params[])              \
 {                                                                              \
     return cipher_generic_get_params(params, EVP_CIPH_##UCMODE##_MODE,         \
                                      flags, 2*kbits, blkbits, ivbits);         \
 }                                                                              \
-static OSSL_FUNC_cipher_newctx_fn alg##kbits##lc##_newctx;                     \
 static void * alg##kbits##lc##_newctx(void *provctx)                           \
 {                                                                              \
     return alg##_##lc##_newctx(provctx, 2*kbits, EVP_CIPH_##UCMODE##_MODE,     \

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -211,7 +211,7 @@ static const OSSL_PARAM aes_xts_known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *aes_xts_settable_ctx_params(void)
+static const OSSL_PARAM *aes_xts_settable_ctx_params(void *provctx)
 {
     return aes_xts_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -91,7 +91,7 @@ static const OSSL_PARAM chacha20_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *chacha20_gettable_ctx_params(void)
+const OSSL_PARAM *chacha20_gettable_ctx_params(void *provctx)
 {
     return chacha20_known_gettable_ctx_params;
 }
@@ -131,7 +131,7 @@ static const OSSL_PARAM chacha20_known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *chacha20_settable_ctx_params(void)
+const OSSL_PARAM *chacha20_settable_ctx_params(void *provctx)
 {
     return chacha20_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -135,7 +135,7 @@ static const OSSL_PARAM chacha20_poly1305_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *chacha20_poly1305_gettable_ctx_params(void)
+static const OSSL_PARAM *chacha20_poly1305_gettable_ctx_params(void *provctx)
 {
     return chacha20_poly1305_known_gettable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_null.c
+++ b/providers/implementations/ciphers/cipher_null.c
@@ -95,7 +95,7 @@ static const OSSL_PARAM null_known_gettable_ctx_params[] = {
 };
 
 static OSSL_FUNC_cipher_gettable_ctx_params_fn null_gettable_ctx_params;
-static const OSSL_PARAM *null_gettable_ctx_params(void)
+static const OSSL_PARAM *null_gettable_ctx_params(void *provctx)
 {
     return null_known_gettable_ctx_params;
 }
@@ -131,7 +131,7 @@ static const OSSL_PARAM null_known_settable_ctx_params[] = {
 };
 
 static OSSL_FUNC_cipher_settable_ctx_params_fn null_settable_ctx_params;
-static const OSSL_PARAM *null_settable_ctx_params(void)
+static const OSSL_PARAM *null_settable_ctx_params(void *provctx)
 {
     return null_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -72,7 +72,7 @@ static const OSSL_PARAM rc4_hmac_md5_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *rc4_hmac_md5_gettable_ctx_params(void)
+const OSSL_PARAM *rc4_hmac_md5_gettable_ctx_params(void *provctx)
 {
     return rc4_hmac_md5_known_gettable_ctx_params;
 }
@@ -107,7 +107,7 @@ static const OSSL_PARAM rc4_hmac_md5_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *rc4_hmac_md5_settable_ctx_params(void)
+const OSSL_PARAM *rc4_hmac_md5_settable_ctx_params(void *provctx)
 {
     return rc4_hmac_md5_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -29,7 +29,7 @@ static const OSSL_PARAM cipher_known_gettable_params[] = {
     { OSSL_CIPHER_PARAM_TLS_MAC, OSSL_PARAM_OCTET_PTR, NULL, 0, OSSL_PARAM_UNMODIFIED },
     OSSL_PARAM_END
 };
-const OSSL_PARAM *cipher_generic_gettable_params(void)
+const OSSL_PARAM *cipher_generic_gettable_params(void *provctx)
 {
     return cipher_known_gettable_params;
 }
@@ -117,7 +117,7 @@ static const OSSL_PARAM cipher_aead_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_GET_IV_GEN, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *cipher_aead_gettable_ctx_params(void)
+const OSSL_PARAM *cipher_aead_gettable_ctx_params(void *provctx)
 {
     return cipher_aead_known_gettable_ctx_params;
 }
@@ -130,7 +130,7 @@ static const OSSL_PARAM cipher_aead_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_SET_IV_INV, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *cipher_aead_settable_ctx_params(void)
+const OSSL_PARAM *cipher_aead_settable_ctx_params(void *provctx)
 {
     return cipher_aead_known_settable_ctx_params;
 }

--- a/providers/implementations/digests/digestcommon.c
+++ b/providers/implementations/digests/digestcommon.c
@@ -40,7 +40,7 @@ static const OSSL_PARAM digest_default_known_gettable_params[] = {
     OSSL_PARAM_ulong(OSSL_DIGEST_PARAM_FLAGS, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *digest_default_gettable_params(void)
+const OSSL_PARAM *digest_default_gettable_params(void *provctx)
 {
     return digest_default_known_gettable_params;
 }

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -30,7 +30,7 @@ static const OSSL_PARAM known_md5_sha1_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *md5_sha1_settable_ctx_params(void)
+static const OSSL_PARAM *md5_sha1_settable_ctx_params(void *provctx)
 {
     return known_md5_sha1_settable_ctx_params;
 }

--- a/providers/implementations/digests/mdc2_prov.c
+++ b/providers/implementations/digests/mdc2_prov.c
@@ -30,7 +30,7 @@ static const OSSL_PARAM known_mdc2_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *mdc2_settable_ctx_params(void)
+static const OSSL_PARAM *mdc2_settable_ctx_params(void *provctx)
 {
     return known_mdc2_settable_ctx_params;
 }

--- a/providers/implementations/digests/sha2_prov.c
+++ b/providers/implementations/digests/sha2_prov.c
@@ -31,7 +31,7 @@ static const OSSL_PARAM known_sha1_settable_ctx_params[] = {
     {OSSL_DIGEST_PARAM_SSL3_MS, OSSL_PARAM_OCTET_STRING, NULL, 0, 0},
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *sha1_settable_ctx_params(void)
+static const OSSL_PARAM *sha1_settable_ctx_params(void *provctx)
 {
     return known_sha1_settable_ctx_params;
 }

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -250,7 +250,7 @@ static const OSSL_PARAM known_shake_settable_ctx_params[] = {
     {OSSL_DIGEST_PARAM_XOFLEN, OSSL_PARAM_UNSIGNED_INTEGER, NULL, 0, 0},
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *shake_settable_ctx_params(void)
+static const OSSL_PARAM *shake_settable_ctx_params(void *provctx)
 {
     return known_shake_settable_ctx_params;
 }

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -163,7 +163,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_settable_ctx_params(void)
+static const OSSL_PARAM *dh_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -279,7 +279,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
 };
 
 static
-const OSSL_PARAM *ecdh_settable_ctx_params(void)
+const OSSL_PARAM *ecdh_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }
@@ -360,7 +360,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
 };
 
 static
-const OSSL_PARAM *ecdh_gettable_ctx_params(void)
+const OSSL_PARAM *ecdh_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -319,7 +319,7 @@ static const OSSL_PARAM name##_known_gettable_ctx_params[] = {                 \
 #define CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_END(name)                           \
     OSSL_PARAM_END                                                             \
 };                                                                             \
-const OSSL_PARAM * name##_gettable_ctx_params(void)                            \
+const OSSL_PARAM * name##_gettable_ctx_params(void *provctx)                   \
 {                                                                              \
     return name##_known_gettable_ctx_params;                                   \
 }
@@ -331,7 +331,7 @@ static const OSSL_PARAM name##_known_settable_ctx_params[] = {                 \
 #define CIPHER_DEFAULT_SETTABLE_CTX_PARAMS_END(name)                           \
     OSSL_PARAM_END                                                             \
 };                                                                             \
-const OSSL_PARAM * name##_settable_ctx_params(void)                            \
+const OSSL_PARAM * name##_settable_ctx_params(void *provctx)                   \
 {                                                                              \
     return name##_known_settable_ctx_params;                                   \
 }

--- a/providers/implementations/include/prov/digestcommon.h
+++ b/providers/implementations/include/prov/digestcommon.h
@@ -93,7 +93,7 @@ PROV_DISPATCH_FUNC_DIGEST_CONSTRUCT_START(name, CTX, blksize, dgstsize, flags, \
 PROV_DISPATCH_FUNC_DIGEST_CONSTRUCT_END
 
 
-const OSSL_PARAM *digest_default_gettable_params(void);
+const OSSL_PARAM *digest_default_gettable_params(void *provctx);
 int digest_default_get_params(OSSL_PARAM params[], size_t blksz, size_t paramsz,
                               unsigned long flags);
 

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -225,7 +225,7 @@ static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_hkdf_settable_ctx_params(void)
+static const OSSL_PARAM *kdf_hkdf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MODE, NULL, 0),
@@ -250,7 +250,7 @@ static int kdf_hkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(void)
+static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -76,6 +76,8 @@ static OSSL_FUNC_kdf_reset_fn kbkdf_reset;
 static OSSL_FUNC_kdf_derive_fn kbkdf_derive;
 static OSSL_FUNC_kdf_settable_ctx_params_fn kbkdf_settable_ctx_params;
 static OSSL_FUNC_kdf_set_ctx_params_fn kbkdf_set_ctx_params;
+static OSSL_FUNC_kdf_gettable_ctx_params_fn kbkdf_gettable_ctx_params;
+static OSSL_FUNC_kdf_get_ctx_params_fn kbkdf_get_ctx_params;
 
 /* Not all platforms have htobe32(). */
 static uint32_t be32(uint32_t host)
@@ -296,7 +298,7 @@ static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kbkdf_settable_ctx_params(void)
+static const OSSL_PARAM *kbkdf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
@@ -326,7 +328,7 @@ static int kbkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return OSSL_PARAM_set_size_t(p, SIZE_MAX);
 }
 
-static const OSSL_PARAM *kbkdf_gettable_ctx_params(void)
+static const OSSL_PARAM *kbkdf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] =
         { OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL), OSSL_PARAM_END };

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -140,7 +140,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *krb5kdf_settable_ctx_params(void)
+static const OSSL_PARAM *krb5kdf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -170,7 +170,7 @@ static int krb5kdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *krb5kdf_gettable_ctx_params(void)
+static const OSSL_PARAM *krb5kdf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -41,6 +41,8 @@ static OSSL_FUNC_kdf_reset_fn kdf_pbkdf2_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_pbkdf2_derive;
 static OSSL_FUNC_kdf_settable_ctx_params_fn kdf_pbkdf2_settable_ctx_params;
 static OSSL_FUNC_kdf_set_ctx_params_fn kdf_pbkdf2_set_ctx_params;
+static OSSL_FUNC_kdf_gettable_ctx_params_fn kdf_pbkdf2_gettable_ctx_params;
+static OSSL_FUNC_kdf_get_ctx_params_fn kdf_pbkdf2_get_ctx_params;
 
 static int  pbkdf2_derive(const char *pass, size_t passlen,
                           const unsigned char *salt, int saltlen, uint64_t iter,
@@ -198,7 +200,7 @@ static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(void)
+static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -221,7 +223,7 @@ static int kdf_pbkdf2_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(void)
+static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -29,6 +29,8 @@ static OSSL_FUNC_kdf_reset_fn kdf_scrypt_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_scrypt_derive;
 static OSSL_FUNC_kdf_settable_ctx_params_fn kdf_scrypt_settable_ctx_params;
 static OSSL_FUNC_kdf_set_ctx_params_fn kdf_scrypt_set_ctx_params;
+static OSSL_FUNC_kdf_gettable_ctx_params_fn kdf_scrypt_gettable_ctx_params;
+static OSSL_FUNC_kdf_get_ctx_params_fn kdf_scrypt_get_ctx_params;
 
 static int scrypt_alg(const char *pass, size_t passlen,
                       const unsigned char *salt, size_t saltlen,
@@ -190,7 +192,7 @@ static int kdf_scrypt_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(void)
+static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_PASSWORD, NULL, 0),
@@ -213,7 +215,7 @@ static int kdf_scrypt_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(void)
+static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -160,7 +160,7 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(void)
+static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -183,7 +183,7 @@ static int kdf_sshkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(void)
+static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -478,7 +478,7 @@ static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *sskdf_settable_ctx_params(void)
+static const OSSL_PARAM *sskdf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SECRET, NULL, 0),
@@ -504,7 +504,7 @@ static int sskdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *sskdf_gettable_ctx_params(void)
+static const OSSL_PARAM *sskdf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -67,6 +67,8 @@ static OSSL_FUNC_kdf_reset_fn kdf_tls1_prf_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_tls1_prf_derive;
 static OSSL_FUNC_kdf_settable_ctx_params_fn kdf_tls1_prf_settable_ctx_params;
 static OSSL_FUNC_kdf_set_ctx_params_fn kdf_tls1_prf_set_ctx_params;
+static OSSL_FUNC_kdf_gettable_ctx_params_fn kdf_tls1_prf_gettable_ctx_params;
+static OSSL_FUNC_kdf_get_ctx_params_fn kdf_tls1_prf_get_ctx_params;
 
 static int tls1_prf_alg(EVP_MAC_CTX *mdctx, EVP_MAC_CTX *sha1ctx,
                         const unsigned char *sec, size_t slen,
@@ -201,7 +203,7 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(void)
+static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -222,7 +224,7 @@ static int kdf_tls1_prf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(void)
+static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -402,7 +402,7 @@ static int x942kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *x942kdf_settable_ctx_params(void)
+static const OSSL_PARAM *x942kdf_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -426,7 +426,7 @@ static int x942kdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *x942kdf_gettable_ctx_params(void)
+static const OSSL_PARAM *x942kdf_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -326,7 +326,7 @@ static const OSSL_PARAM dh_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_gettable_params(void)
+static const OSSL_PARAM *dh_gettable_params(void *provctx)
 {
     return dh_params;
 }
@@ -336,7 +336,7 @@ static const OSSL_PARAM dh_known_settable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_settable_params(void)
+static const OSSL_PARAM *dh_settable_params(void *provctx)
 {
     return dh_known_settable_params;
 }

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -295,7 +295,7 @@ static const OSSL_PARAM dsa_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_gettable_params(void)
+static const OSSL_PARAM *dsa_gettable_params(void *provctx)
 {
     return dsa_params;
 }

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -570,7 +570,7 @@ static const OSSL_PARAM ec_known_gettable_params[] = {
 };
 
 static
-const OSSL_PARAM *ec_gettable_params(void)
+const OSSL_PARAM *ec_gettable_params(void *provctx)
 {
     return ec_known_gettable_params;
 }
@@ -582,7 +582,7 @@ static const OSSL_PARAM ec_known_settable_params[] = {
 };
 
 static
-const OSSL_PARAM *ec_settable_params(void)
+const OSSL_PARAM *ec_settable_params(void *provctx)
 {
     return ec_known_settable_params;
 }

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -314,22 +314,22 @@ static const OSSL_PARAM ed_gettable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *x25519_gettable_params(void)
+static const OSSL_PARAM *x25519_gettable_params(void *provctx)
 {
     return ecx_gettable_params;
 }
 
-static const OSSL_PARAM *x448_gettable_params(void)
+static const OSSL_PARAM *x448_gettable_params(void *provctx)
 {
     return ecx_gettable_params;
 }
 
-static const OSSL_PARAM *ed25519_gettable_params(void)
+static const OSSL_PARAM *ed25519_gettable_params(void *provctx)
 {
     return ed_gettable_params;
 }
 
-static const OSSL_PARAM *ed448_gettable_params(void)
+static const OSSL_PARAM *ed448_gettable_params(void *provctx)
 {
     return ed_gettable_params;
 }
@@ -384,22 +384,22 @@ static const OSSL_PARAM ed_settable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *x25519_settable_params(void)
+static const OSSL_PARAM *x25519_settable_params(void *provctx)
 {
     return ecx_settable_params;
 }
 
-static const OSSL_PARAM *x448_settable_params(void)
+static const OSSL_PARAM *x448_settable_params(void *provctx)
 {
     return ecx_settable_params;
 }
 
-static const OSSL_PARAM *ed25519_settable_params(void)
+static const OSSL_PARAM *ed25519_settable_params(void *provctx)
 {
     return ed_settable_params;
 }
 
-static const OSSL_PARAM *ed448_settable_params(void)
+static const OSSL_PARAM *ed448_settable_params(void *provctx)
 {
     return ed_settable_params;
 }

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -341,7 +341,7 @@ static const OSSL_PARAM rsa_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_params(void)
+static const OSSL_PARAM *rsa_gettable_params(void *provctx)
 {
     return rsa_params;
 }

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -108,7 +108,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *blake2_gettable_ctx_params(void)
+static const OSSL_PARAM *blake2_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -130,7 +130,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_SALT, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *blake2_mac_settable_ctx_params()
+static const OSSL_PARAM *blake2_mac_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -125,7 +125,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cmac_gettable_ctx_params(void)
+static const OSSL_PARAM *cmac_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -146,7 +146,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cmac_settable_ctx_params(void)
+static const OSSL_PARAM *cmac_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -136,7 +136,7 @@ static const OSSL_PARAM known_gettable_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *gmac_gettable_params(void)
+static const OSSL_PARAM *gmac_gettable_params(void *provctx)
 {
     return known_gettable_params;
 }
@@ -158,7 +158,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_IV, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *gmac_settable_ctx_params(void)
+static const OSSL_PARAM *gmac_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -139,7 +139,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *hmac_gettable_ctx_params(void)
+static const OSSL_PARAM *hmac_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -161,7 +161,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_int(OSSL_MAC_PARAM_FLAGS, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *hmac_settable_ctx_params(void)
+static const OSSL_PARAM *hmac_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -307,7 +307,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *kmac_gettable_ctx_params(void)
+static const OSSL_PARAM *kmac_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -329,7 +329,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_CUSTOM, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *kmac_settable_ctx_params(void)
+static const OSSL_PARAM *kmac_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -101,7 +101,7 @@ static const OSSL_PARAM known_gettable_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *poly1305_gettable_params(void)
+static const OSSL_PARAM *poly1305_gettable_params(void *provctx)
 {
     return known_gettable_params;
 }
@@ -120,7 +120,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *poly1305_settable_ctx_params(void)
+static const OSSL_PARAM *poly1305_settable_ctx_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -112,7 +112,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *siphash_gettable_ctx_params(void)
+static const OSSL_PARAM *siphash_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -132,7 +132,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *siphash_settable_params(void)
+static const OSSL_PARAM *siphash_settable_params(void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -635,7 +635,7 @@ static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(void)
+static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETABLE_CTX_COMMON,
@@ -701,7 +701,7 @@ static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_ctr_settable_ctx_params(void)
+static const OSSL_PARAM *drbg_ctr_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -432,7 +432,7 @@ static int drbg_hash_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_hash_gettable_ctx_params(void)
+static const OSSL_PARAM *drbg_hash_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETABLE_CTX_COMMON,
@@ -476,7 +476,7 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_hash_settable_ctx_params(void)
+static const OSSL_PARAM *drbg_hash_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -329,7 +329,7 @@ static int drbg_hmac_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(void)
+static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETABLE_CTX_COMMON,
@@ -378,7 +378,7 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_hmac_settable_ctx_params(void)
+static const OSSL_PARAM *drbg_hmac_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -186,7 +186,7 @@ static int test_rng_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *test_rng_gettable_ctx_params(void)
+static const OSSL_PARAM *test_rng_gettable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETABLE_CTX_COMMON,
@@ -264,7 +264,7 @@ static int test_rng_set_ctx_params(void *vdrbg, const OSSL_PARAM params[])
     return drbg_set_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *test_rng_settable_ctx_params(void)
+static const OSSL_PARAM *test_rng_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, NULL, 0),

--- a/providers/implementations/serializers/deserialize_der2key.c
+++ b/providers/implementations/serializers/deserialize_der2key.c
@@ -72,7 +72,7 @@ static void der2key_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *der2key_gettable_params(void)
+static const OSSL_PARAM *der2key_gettable_params(void *provctx)
 {
     static const OSSL_PARAM gettables[] = {
         { OSSL_DESERIALIZER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },

--- a/providers/implementations/serializers/deserialize_pem2der.c
+++ b/providers/implementations/serializers/deserialize_pem2der.c
@@ -55,7 +55,7 @@ static void pem2der_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *pem2der_gettable_params(void)
+static const OSSL_PARAM *pem2der_gettable_params(void *provctx)
 {
     static const OSSL_PARAM gettables[] = {
         { OSSL_DESERIALIZER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },

--- a/providers/implementations/serializers/serializer_dh_priv.c
+++ b/providers/implementations/serializers/serializer_dh_priv.c
@@ -71,7 +71,7 @@ static void dh_priv_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *dh_priv_settable_ctx_params(void)
+static const OSSL_PARAM *dh_priv_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_SERIALIZER_PARAM_CIPHER, NULL, 0),

--- a/providers/implementations/serializers/serializer_dsa_priv.c
+++ b/providers/implementations/serializers/serializer_dsa_priv.c
@@ -71,7 +71,7 @@ static void dsa_priv_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *dsa_priv_settable_ctx_params(void)
+static const OSSL_PARAM *dsa_priv_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_SERIALIZER_PARAM_CIPHER, NULL, 0),

--- a/providers/implementations/serializers/serializer_ec_priv.c
+++ b/providers/implementations/serializers/serializer_ec_priv.c
@@ -65,7 +65,7 @@ static void ec_priv_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *ec_priv_settable_ctx_params(void)
+static const OSSL_PARAM *ec_priv_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_SERIALIZER_PARAM_CIPHER, NULL, 0),

--- a/providers/implementations/serializers/serializer_ecx_priv.c
+++ b/providers/implementations/serializers/serializer_ecx_priv.c
@@ -88,7 +88,7 @@ static void ecx_priv_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *ecx_priv_settable_ctx_params(void)
+static const OSSL_PARAM *ecx_priv_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_SERIALIZER_PARAM_CIPHER, NULL, 0),

--- a/providers/implementations/serializers/serializer_rsa_priv.c
+++ b/providers/implementations/serializers/serializer_rsa_priv.c
@@ -73,7 +73,7 @@ static void rsa_priv_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *rsa_priv_settable_ctx_params(void)
+static const OSSL_PARAM *rsa_priv_settable_ctx_params(void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_SERIALIZER_PARAM_CIPHER, NULL, 0),

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -412,7 +412,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_gettable_ctx_params(void)
+static const OSSL_PARAM *dsa_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -454,7 +454,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_settable_ctx_params(void)
+static const OSSL_PARAM *dsa_settable_ctx_params(void *provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -399,7 +399,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *ecdsa_gettable_ctx_params(void)
+static const OSSL_PARAM *ecdsa_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -451,7 +451,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *ecdsa_settable_ctx_params(void)
+static const OSSL_PARAM *ecdsa_settable_ctx_params(void *provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -983,7 +983,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_ctx_params(void)
+static const OSSL_PARAM *rsa_gettable_ctx_params(void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -1233,7 +1233,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_settable_ctx_params(void)
+static const OSSL_PARAM *rsa_settable_ctx_params(void *provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -286,7 +286,7 @@ static const OSSL_PARAM xor_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *xor_gettable_params(void)
+static const OSSL_PARAM *xor_gettable_params(void *provctx)
 {
     return xor_params;
 }
@@ -313,7 +313,7 @@ static const OSSL_PARAM xor_known_settable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *xor_settable_params(void)
+static const OSSL_PARAM *xor_settable_params(void *provctx)
 {
     return xor_known_settable_params;
 }


### PR DESCRIPTION
In some instances it is necessary for the provider context to be known when returning the gettable and settable params.  Rather than add the provider context just for these, it is added across the board.

- [x] documentation is added or updated
- [x] tests are added or updated
