### PR TITLE
mac: add some consistency to setting the XXX_final output length.

### DIFF
--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -120,11 +120,13 @@ int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen)
 int EVP_MAC_final(EVP_MAC_CTX *ctx,
                   unsigned char *out, size_t *outl, size_t outsize)
 {
-    size_t l = EVP_MAC_size(ctx);
+    size_t l;
     int res = 1;
 
     if (out != NULL)
         res = ctx->meth->final(ctx->data, out, &l, outsize);
+    else
+        l = EVP_MAC_size(ctx);
     if (outl != NULL)
         *outl = l;
     return res;

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -101,6 +101,7 @@ static int blake2_mac_final(void *vmacctx,
 {
     struct blake2_mac_data_st *macctx = vmacctx;
 
+    *outl = blake2_mac_size(macctx);
     return BLAKE2_FINAL(out, &macctx->ctx);
 }
 

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -130,8 +130,7 @@ static int hmac_final(void *vmacctx, unsigned char *out, size_t *outl,
 
     if (!HMAC_Final(macctx->ctx, out, &hlen))
         return 0;
-    if (outl != NULL)
-        *outl = hlen;
+    *outl = hlen;
     return 1;
 }
 

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -298,8 +298,7 @@ static int kmac_final(void *vmacctx, unsigned char *out, size_t *outl,
     ok = right_encode(encoded_outlen, &len, lbits)
         && EVP_DigestUpdate(ctx, encoded_outlen, len)
         && EVP_DigestFinalXOF(ctx, out, kctx->out_len);
-    if (ok && outl != NULL)
-        *outl = kctx->out_len;
+    *outl = kctx->out_len;
     return ok;
 }
 

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -94,6 +94,7 @@ static int poly1305_final(void *vmacctx, unsigned char *out, size_t *outl,
     struct poly1305_data_st *ctx = vmacctx;
 
     Poly1305_Final(&ctx->poly1305, out);
+    *outl = poly1305_size();
     return 1;
 }
 


### PR DESCRIPTION
The various MACs were all over the place with respects to what they did with the output length in the final call.  Now they all unconditionally set the output length and the EVP layer handles the possibility of a NULL pointer.

The variations were first noted in #12425.

