### PR TITLE
Apple Silicon Support

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1615,6 +1615,16 @@ my %targets = (
         asm_arch         => 'x86_64',
         perlasm_scheme   => "macosx",
     },
+    "darwin64-arm64-cc" => { inherit_from => [ "darwin64-arm64" ] }, # "Historic" alias
+    "darwin64-arm64" => {
+        inherit_from     => [ "darwin-common" ],
+        CFLAGS           => add("-Wall"),
+        cflags           => add("-arch arm64"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        asm_arch         => 'aarch64_asm',
+        perlasm_scheme   => "macosx",
+    },
 
 ##### GNU Hurd
     "hurd-x86" => {

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1623,7 +1623,7 @@ my %targets = (
         lib_cppflags     => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         asm_arch         => 'aarch64_asm',
-        perlasm_scheme   => "macosx",
+        perlasm_scheme   => "ios64",
     },
 
 ##### GNU Hurd


### PR DESCRIPTION
Related to #12369, but targets the current head.
Also closes #12254.
This adds a `darwin64-arm64` configuration for Apple Silicon, as well as a "legacy" `darwin64-arm64-cc` configuration.

This has *not* been tested on the DTK.