### PR TITLE
EVP: Have evp_pkey_cmp_any() detect if export wasn't possible

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -269,6 +269,10 @@ static int evp_pkey_cmp_any(const EVP_PKEY *a, const EVP_PKEY *b,
     if (keymgmt1 != keymgmt2)
         return -2;
 
+    /* If the keymgmt implementations are NULL, the export failed */
+    if (keymgmt1 == NULL)
+        return -2;
+
     return evp_keymgmt_match(keymgmt1, keydata1, keydata2, selection);
 }
 


### PR DESCRIPTION
There are some EC keys that can't be exported to provider keymgmt,
because the keymgmt implementation doesn't support certain forms of EC
keys.  This could lead to a crash caused by dereferencing a NULL
pointer, so we need to cover that case by returning an error instead.
