### PR TITLE
Fix memory leak in drbgtest

### DIFF
--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -531,10 +531,10 @@ static EVP_RAND_CTX *new_drbg(EVP_RAND_CTX *parent)
     if (!TEST_ptr(rand = EVP_RAND_fetch(NULL, "CTR-DRBG", NULL))
             || !TEST_ptr(drbg = EVP_RAND_CTX_new(rand, parent))
             || !TEST_true(EVP_RAND_set_ctx_params(drbg, params))) {
-        EVP_RAND_CTX_rand(drbg);
-        EVP_RAND_free(rand);
+        EVP_RAND_CTX_free(drbg);
         drbg = NULL;
     }
+    EVP_RAND_free(rand);
     return drbg;
 }
 
@@ -627,13 +627,6 @@ err:
 
 int setup_tests(void)
 {
-    /*
-     * TODO(3.0): figure out why and fix.
-     * Create the primary DRBG here to avoid a memory leak if it is done in
-     * the test cases.
-     */
-    if (RAND_get0_primary(NULL) == NULL)
-        return 0;
     ADD_TEST(test_rand_drbg_reseed);
     ADD_TEST(test_rand_drbg_prediction_resistance);
 #if defined(OPENSSL_THREADS)


### PR DESCRIPTION
Valgrind showed that the second test contains a memory leak.
new_drbg() increased the ref count for the CTR_DRBG for both the EVP_RAND_fetch() and EVP_RAND_CTX_new().
it was then only decremented once by the EVP_RAND_CTX_free().


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
