### PR TITLE
Rename OPENSSL_CTX type  to OSSL_LIB_CTX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,14 +122,14 @@ OpenSSL 3.0
      such an argument, such as `EVP_CIPHER_fetch` and similar algorithm
      fetching functions.
    - Indirectly, by creating a new library context and then assigning
-     it as the new default, with `OPENSSL_CTX_set0_default`.
+     it as the new default, with `OSSL_LIB_CTX_set0_default`.
 
-   All public OpenSSL functions that take an `OPENSSL_CTX` pointer,
-   apart from the functions directly related to `OPENSSL_CTX`, accept
+   All public OpenSSL functions that take an `OSSL_LIB_CTX` pointer,
+   apart from the functions directly related to `OSSL_LIB_CTX`, accept
    NULL to indicate that the default library context should be used.
 
    Library code that changes the default library context using
-   `OPENSSL_CTX_set0_default` should take care to restore it with a
+   `OSSL_LIB_CTX_set0_default` should take care to restore it with a
    second call before returning to the caller.
 
    *Richard Levitte*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,7 +133,7 @@ OpenSSL 3.0
    second call before returning to the caller.
 
    _(Note: the library context was initially called `OPENSSL_CTX` and
-   renamed to `OSSL_LIB_CTX` in version 3.0.0 beta7.)_
+   renamed to `OSSL_LIB_CTX` in version 3.0.0 alpha7.)_
 
    *Richard Levitte*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,9 +112,9 @@ OpenSSL 3.0
 
    *Rich Salz and Richard Levitte*
 
- * Added a library context that applications as well as other
-   libraries can use to form a separate context within which libcrypto
-   operations are performed.
+ * Added a library context `OSSL_LIB_CTX` that applications as well as
+   other libraries can use to form a separate context within which
+   libcrypto operations are performed.
 
    There are two ways this can be used:
 
@@ -131,6 +131,9 @@ OpenSSL 3.0
    Library code that changes the default library context using
    `OSSL_LIB_CTX_set0_default` should take care to restore it with a
    second call before returning to the caller.
+
+   _(Note: the library context was initially called `OPENSSL_CTX` and
+   renamed to `OSSL_LIB_CTX` in version 3.0.0 beta7.)_
 
    *Richard Levitte*
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ OpenSSL 3.0
 
   * Remove the `RAND_DRBG` API.
   * Deprecated the `ENGINE` API.
-  * Added `OPENSSL_CTX`, a libcrypto library context.
+  * Added `OSSL_LIB_CTX`, a libcrypto library context.
   * Interactive mode is removed from the 'openssl' program.
   * The X25519, X448, Ed25519, Ed448 and SHAKE256 algorithms are included in
     the FIPS provider.  None have the "fips=yes" property set and, as such,

--- a/apps/cmp_mock_srv.c
+++ b/apps/cmp_mock_srv.c
@@ -384,7 +384,7 @@ static int process_pollReq(OSSL_CMP_SRV_CTX *srv_ctx,
     return 1;
 }
 
-OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OPENSSL_CTX *libctx, const char *propq)
+OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_CMP_SRV_CTX *srv_ctx = OSSL_CMP_SRV_CTX_new(libctx, propq);
     mock_srv_ctx *ctx = mock_srv_ctx_new();

--- a/apps/cmp_mock_srv.h
+++ b/apps/cmp_mock_srv.h
@@ -16,7 +16,7 @@
 
 #  include <openssl/cmp.h>
 
-OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OPENSSL_CTX *libctx, const char *propq);
+OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx, const char *propq);
 void ossl_cmp_mock_srv_free(OSSL_CMP_SRV_CTX *srv_ctx);
 
 int ossl_cmp_mock_srv_set1_certOut(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);

--- a/apps/cmp_mock_srv.h
+++ b/apps/cmp_mock_srv.h
@@ -16,7 +16,8 @@
 
 #  include <openssl/cmp.h>
 
-OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx, const char *propq);
+OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx,
+                                        const char *propq);
 void ossl_cmp_mock_srv_free(OSSL_CMP_SRV_CTX *srv_ctx);
 
 int ossl_cmp_mock_srv_set1_certOut(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -233,7 +233,8 @@ const OPTIONS cms_options[] = {
 
 static CMS_ContentInfo *load_content_info(int informat, BIO *in, BIO **indata,
                                           const char *name,
-                                          OSSL_LIB_CTX *libctx, const char *propq)
+                                          OSSL_LIB_CTX *libctx,
+                                          const char *propq)
 {
     CMS_ContentInfo *ret, *ci;
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -28,7 +28,7 @@ static int cms_cb(int ok, X509_STORE_CTX *ctx);
 static void receipt_request_print(CMS_ContentInfo *cms);
 static CMS_ReceiptRequest *make_receipt_request(
     STACK_OF(OPENSSL_STRING) *rr_to, int rr_allorfirst,
-    STACK_OF(OPENSSL_STRING) *rr_from, OPENSSL_CTX *libctx, const char *propq);
+    STACK_OF(OPENSSL_STRING) *rr_from, OSSL_LIB_CTX *libctx, const char *propq);
 static int cms_set_pkey_param(EVP_PKEY_CTX *pctx,
                               STACK_OF(OPENSSL_STRING) *param);
 
@@ -233,7 +233,7 @@ const OPTIONS cms_options[] = {
 
 static CMS_ContentInfo *load_content_info(int informat, BIO *in, BIO **indata,
                                           const char *name,
-                                          OPENSSL_CTX *libctx, const char *propq)
+                                          OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ContentInfo *ret, *ci;
 
@@ -301,7 +301,7 @@ int cms_main(int argc, char **argv)
     long ltmp;
     const char *mime_eol = "\n";
     OPTION_CHOICE o;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     if ((vpm = X509_VERIFY_PARAM_new()) == NULL)
@@ -1389,7 +1389,7 @@ static STACK_OF(GENERAL_NAMES) *make_names_stack(STACK_OF(OPENSSL_STRING) *ns)
 static CMS_ReceiptRequest *make_receipt_request(
    STACK_OF(OPENSSL_STRING) *rr_to, int rr_allorfirst,
    STACK_OF(OPENSSL_STRING) *rr_from,
-   OPENSSL_CTX *libctx, const char *propq)
+   OSSL_LIB_CTX *libctx, const char *propq)
 {
     STACK_OF(GENERAL_NAMES) *rct_to = NULL, *rct_from = NULL;
     CMS_ReceiptRequest *rr;

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -220,7 +220,7 @@ static void free_config_and_unload(CONF *conf)
 
 static int verify_module_load(const char *parent_config_file)
 {
-    return OPENSSL_CTX_load_config(NULL, parent_config_file);
+    return OSSL_LIB_CTX_load_config(NULL, parent_config_file);
 }
 
 /*

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -22,7 +22,7 @@
 #endif
 
 static int init_keygen_file(EVP_PKEY_CTX **pctx, const char *file, ENGINE *e,
-                            OPENSSL_CTX *libctx, const char *propq);
+                            OSSL_LIB_CTX *libctx, const char *propq);
 static int genpkey_cb(EVP_PKEY_CTX *ctx);
 
 typedef enum OPTION_choice {
@@ -73,7 +73,7 @@ int genpkey_main(int argc, char **argv)
     OPTION_CHOICE o;
     int outformat = FORMAT_PEM, text = 0, ret = 1, rv, do_param = 0;
     int private = 0;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     prog = opt_init(argc, argv, genpkey_options);
@@ -240,7 +240,7 @@ int genpkey_main(int argc, char **argv)
 }
 
 static int init_keygen_file(EVP_PKEY_CTX **pctx, const char *file, ENGINE *e,
-                            OPENSSL_CTX *libctx, const char *propq)
+                            OSSL_LIB_CTX *libctx, const char *propq)
 {
     BIO *pbio;
     EVP_PKEY *pkey = NULL;
@@ -287,7 +287,7 @@ static int init_keygen_file(EVP_PKEY_CTX **pctx, const char *file, ENGINE *e,
 
 int init_gen_str(EVP_PKEY_CTX **pctx,
                  const char *algname, ENGINE *e, int do_param,
-                 OPENSSL_CTX *libctx, const char *propq)
+                 OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY_CTX *ctx = NULL;
     const EVP_PKEY_ASN1_METHOD *ameth;

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -225,7 +225,7 @@ int x509_ctrl_string(X509 *x, const char *value);
 int x509_req_ctrl_string(X509_REQ *x, const char *value);
 int init_gen_str(EVP_PKEY_CTX **pctx,
                  const char *algname, ENGINE *e, int do_param,
-                 OPENSSL_CTX *libctx, const char *propq);
+                 OSSL_LIB_CTX *libctx, const char *propq);
 int do_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md,
                  STACK_OF(OPENSSL_STRING) *sigopts);
 int do_X509_verify(X509 *x, EVP_PKEY *pkey, STACK_OF(OPENSSL_STRING) *vfyopts);
@@ -308,15 +308,15 @@ typedef struct verify_options_st {
 
 extern VERIFY_CB_ARGS verify_args;
 
-OPENSSL_CTX *app_create_libctx(void);
-OPENSSL_CTX *app_get0_libctx(void);
+OSSL_LIB_CTX *app_create_libctx(void);
+OSSL_LIB_CTX *app_get0_libctx(void);
 OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
                                      const OSSL_PARAM *paramdefs);
 void app_params_free(OSSL_PARAM *params);
-int app_provider_load(OPENSSL_CTX *libctx, const char *provider_name);
+int app_provider_load(OSSL_LIB_CTX *libctx, const char *provider_name);
 void app_providers_cleanup(void);
 
-OPENSSL_CTX *app_get0_libctx(void);
+OSSL_LIB_CTX *app_get0_libctx(void);
 const char *app_get0_propq(void);
 
 #endif

--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -27,7 +27,7 @@ static void provider_free(OSSL_PROVIDER *prov)
     OSSL_PROVIDER_unload(prov);
 }
 
-int app_provider_load(OPENSSL_CTX *libctx, const char *provider_name)
+int app_provider_load(OSSL_LIB_CTX *libctx, const char *provider_name)
 {
     OSSL_PROVIDER *prov;
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -63,7 +63,7 @@ typedef struct {
     unsigned long mask;
 } NAME_EX_TBL;
 
-static OPENSSL_CTX *app_libctx = NULL;
+static OSSL_LIB_CTX *app_libctx = NULL;
 
 static int set_table_opts(unsigned long *flags, const char *arg,
                           const NAME_EX_TBL * in_tbl);
@@ -322,7 +322,7 @@ static char *app_get_pass(const char *arg, int keepbio)
     return OPENSSL_strdup(tpass);
 }
 
-OPENSSL_CTX *app_get0_libctx(void)
+OSSL_LIB_CTX *app_get0_libctx(void)
 {
     return app_libctx;
 }
@@ -333,7 +333,7 @@ const char *app_get0_propq(void)
     return NULL;
 }
 
-OPENSSL_CTX *app_create_libctx(void)
+OSSL_LIB_CTX *app_create_libctx(void)
 {
     /*
      * Load the NULL provider into the default library context and create a
@@ -345,7 +345,7 @@ OPENSSL_CTX *app_create_libctx(void)
             BIO_puts(bio_err, "Failed to create null provider\n");
             return NULL;
         }
-        app_libctx = OPENSSL_CTX_new();
+        app_libctx = OSSL_LIB_CTX_new();
     }
     if (app_libctx == NULL)
         BIO_puts(bio_err, "Failed to create library context\n");
@@ -676,7 +676,7 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
 {
     PW_CB_DATA uidata;
     OSSL_STORE_CTX *ctx = NULL;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
     int ncerts = 0;
     int ncrls = 0;
@@ -1077,7 +1077,7 @@ X509_STORE *setup_verify(const char *CAfile, int noCAfile,
 {
     X509_STORE *store = X509_STORE_new();
     X509_LOOKUP *lookup;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     if (store == NULL)

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -88,7 +88,7 @@ static int apps_startup(void)
 static void apps_shutdown(void)
 {
     app_providers_cleanup();
-    OPENSSL_CTX_free(app_get0_libctx());
+    OSSL_LIB_CTX_free(app_get0_libctx());
     destroy_ui_method();
 }
 

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -60,7 +60,7 @@ int pkcs7_main(int argc, char **argv)
     char *infile = NULL, *outfile = NULL, *prog;
     int i, print_certs = 0, text = 0, noout = 0, p7_print = 0, ret = 1;
     OPTION_CHOICE o;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     prog = opt_init(argc, argv, pkcs7_options);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -24,7 +24,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
                               const char *keyfile, int keyform, int key_type,
                               char *passinarg, int pkey_op, ENGINE *e,
                               const int impl, int rawin, EVP_PKEY **ppkey,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
 
 static int setup_peer(EVP_PKEY_CTX *ctx, int peerform, const char *file,
                       ENGINE *e);
@@ -124,7 +124,7 @@ int pkeyutl_main(int argc, char **argv)
     int rawin = 0;
     const EVP_MD *md = NULL;
     int filesize = -1;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = NULL;
 
     prog = opt_init(argc, argv, pkeyutl_options);
@@ -512,7 +512,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
                               char *passinarg, int pkey_op, ENGINE *e,
                               const int engine_impl, int rawin,
                               EVP_PKEY **ppkey,
-                              OPENSSL_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -154,7 +154,7 @@ int smime_main(int argc, char **argv)
     int vpmtouched = 0, rv = 0;
     ENGINE *e = NULL;
     const char *mime_eol = "\n";
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     if ((vpm = X509_VERIFY_PARAM_new()) == NULL)

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -19,7 +19,7 @@
 static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,
                    int expected, int criterion, OSSL_STORE_SEARCH *search,
                    int text, int noout, int recursive, int indent, BIO *out,
-                   const char *prog, OPENSSL_CTX *libctx, const char *propq);
+                   const char *prog, OSSL_LIB_CTX *libctx, const char *propq);
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP, OPT_ENGINE, OPT_OUT, OPT_PASSIN,
@@ -84,7 +84,7 @@ int storeutl_main(int argc, char *argv[])
     char *alias = NULL;
     OSSL_STORE_SEARCH *search = NULL;
     const EVP_MD *digest = NULL;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     while ((o = opt_next()) != OPT_EOF) {
@@ -351,7 +351,7 @@ static int indent_printf(int indent, BIO *bio, const char *format, ...)
 static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,
                    int expected, int criterion, OSSL_STORE_SEARCH *search,
                    int text, int noout, int recursive, int indent, BIO *out,
-                   const char *prog, OPENSSL_CTX *libctx, const char *propq)
+                   const char *prog, OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_STORE_CTX *store_ctx = NULL;
     int ret = 1, items = 0;

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -957,7 +957,7 @@ static X509_STORE *create_cert_store(const char *CApath, const char *CAfile,
 {
     X509_STORE *cert_ctx = NULL;
     X509_LOOKUP *lookup = NULL;
-    OPENSSL_CTX *libctx = app_get0_libctx();
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
     const char *propq = app_get0_propq();
 
     cert_ctx = X509_STORE_new();

--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -55,7 +55,7 @@ int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type, char *data,
 
 int asn1_item_digest_ex(const ASN1_ITEM *it, const EVP_MD *md, void *asn,
                         unsigned char *data, unsigned int *len,
-                        OPENSSL_CTX *libctx, const char *propq)
+                        OSSL_LIB_CTX *libctx, const char *propq)
 {
     int i, ret = 0;
     unsigned char *str = NULL;

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -126,7 +126,7 @@ int ASN1_item_sign(const ASN1_ITEM *it, X509_ALGOR *algor1, X509_ALGOR *algor2,
 int ASN1_item_sign_ex(const ASN1_ITEM *it, X509_ALGOR *algor1,
                       X509_ALGOR *algor2, ASN1_BIT_STRING *signature,
                       const void *data, const ASN1_OCTET_STRING *id,
-                      EVP_PKEY *pkey, const EVP_MD *md, OPENSSL_CTX *libctx,
+                      EVP_PKEY *pkey, const EVP_MD *md, OSSL_LIB_CTX *libctx,
                       const char *propq)
 {
     int rv = 0;

--- a/crypto/asn1/a_verify.c
+++ b/crypto/asn1/a_verify.c
@@ -95,7 +95,7 @@ int ASN1_item_verify(const ASN1_ITEM *it, const X509_ALGOR *alg,
 int ASN1_item_verify_ex(const ASN1_ITEM *it, const X509_ALGOR *alg,
                         const ASN1_BIT_STRING *signature, const void *data,
                         const ASN1_OCTET_STRING *id, EVP_PKEY *pkey,
-                        OPENSSL_CTX *libctx, const char *propq)
+                        OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_MD_CTX *ctx;
     int rv = -1;

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -232,7 +232,7 @@ static int asn1_write_micalg(BIO *out, STACK_OF(X509_ALGOR) *mdalgs)
 int SMIME_write_ASN1_ex(BIO *bio, ASN1_VALUE *val, BIO *data, int flags,
                         int ctype_nid, int econt_nid,
                         STACK_OF(X509_ALGOR) *mdalgs, const ASN1_ITEM *it,
-                        OPENSSL_CTX *libctx, const char *propq)
+                        OSSL_LIB_CTX *libctx, const char *propq)
 {
     char bound[33], c;
     int i;

--- a/crypto/asn1/d2i_pr.c
+++ b/crypto/asn1/d2i_pr.c
@@ -22,7 +22,8 @@
 #include "crypto/evp.h"
 
 EVP_PKEY *d2i_PrivateKey_ex(int type, EVP_PKEY **a, const unsigned char **pp,
-                            long length, OSSL_LIB_CTX *libctx, const char *propq)
+                            long length, OSSL_LIB_CTX *libctx,
+                            const char *propq)
 {
     EVP_PKEY *ret;
     const unsigned char *p = *pp;

--- a/crypto/asn1/d2i_pr.c
+++ b/crypto/asn1/d2i_pr.c
@@ -22,7 +22,7 @@
 #include "crypto/evp.h"
 
 EVP_PKEY *d2i_PrivateKey_ex(int type, EVP_PKEY **a, const unsigned char **pp,
-                            long length, OPENSSL_CTX *libctx, const char *propq)
+                            long length, OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY *ret;
     const unsigned char *p = *pp;
@@ -98,7 +98,7 @@ EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
  */
 
 EVP_PKEY *d2i_AutoPrivateKey_ex(EVP_PKEY **a, const unsigned char **pp,
-                                long length, OPENSSL_CTX *libctx,
+                                long length, OSSL_LIB_CTX *libctx,
                                 const char *propq)
 {
     STACK_OF(ASN1_TYPE) *inkey;

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -170,7 +170,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
                     int (*func)(void *), void *args, size_t size)
 {
     async_ctx *ctx;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
     if (!OPENSSL_init_crypto(OPENSSL_INIT_ASYNC, NULL))
         return ASYNC_ERR;
@@ -208,7 +208,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
                  * Restore the default libctx to what it was the last time the
                  * fibre ran
                  */
-                libctx = OPENSSL_CTX_set0_default(ctx->currjob->libctx);
+                libctx = OSSL_LIB_CTX_set0_default(ctx->currjob->libctx);
                 /* Resume previous job */
                 if (!async_fibre_swapcontext(&ctx->dispatcher,
                         &ctx->currjob->fibrectx, 1)) {
@@ -221,7 +221,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
                  * again to what it was originally, and remember what it had
                  * been changed to.
                  */
-                ctx->currjob->libctx = OPENSSL_CTX_set0_default(libctx);
+                ctx->currjob->libctx = OSSL_LIB_CTX_set0_default(libctx);
                 continue;
             }
 
@@ -252,7 +252,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
 
         ctx->currjob->func = func;
         ctx->currjob->waitctx = wctx;
-        libctx = openssl_ctx_get_concrete(NULL);
+        libctx = ossl_lib_ctx_get_concrete(NULL);
         if (!async_fibre_swapcontext(&ctx->dispatcher,
                 &ctx->currjob->fibrectx, 1)) {
             ASYNCerr(ASYNC_F_ASYNC_START_JOB, ASYNC_R_FAILED_TO_SWAP_CONTEXT);
@@ -262,7 +262,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
          * In case the fibre changed the default libctx we set it back again
          * to what it was, and remember what it had been changed to.
          */
-        ctx->currjob->libctx = OPENSSL_CTX_set0_default(libctx);
+        ctx->currjob->libctx = OSSL_LIB_CTX_set0_default(libctx);
     }
 
 err:

--- a/crypto/async/async_local.h
+++ b/crypto/async/async_local.h
@@ -43,7 +43,7 @@ struct async_job_st {
     int ret;
     int status;
     ASYNC_WAIT_CTX *waitctx;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 };
 
 struct fd_lookup_st {

--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -87,7 +87,7 @@ struct bignum_ctx {
     /* Flags. */
     int flags;
     /* The library context */
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 };
 
 #ifndef FIPS_MODULE
@@ -128,7 +128,7 @@ static void ctxdbg(BIO *channel, const char *text, BN_CTX *ctx)
 # define CTXDBG(str, ctx) do {} while(0)
 #endif /* FIPS_MODULE */
 
-BN_CTX *BN_CTX_new_ex(OPENSSL_CTX *ctx)
+BN_CTX *BN_CTX_new_ex(OSSL_LIB_CTX *ctx)
 {
     BN_CTX *ret;
 
@@ -150,7 +150,7 @@ BN_CTX *BN_CTX_new(void)
 }
 #endif
 
-BN_CTX *BN_CTX_secure_new_ex(OPENSSL_CTX *ctx)
+BN_CTX *BN_CTX_secure_new_ex(OSSL_LIB_CTX *ctx)
 {
     BN_CTX *ret = BN_CTX_new_ex(ctx);
 
@@ -249,7 +249,7 @@ BIGNUM *BN_CTX_get(BN_CTX *ctx)
     return ret;
 }
 
-OPENSSL_CTX *bn_get_lib_ctx(BN_CTX *ctx)
+OSSL_LIB_CTX *bn_get_lib_ctx(BN_CTX *ctx)
 {
     if (ctx == NULL)
         return NULL;

--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -249,7 +249,7 @@ BIGNUM *BN_CTX_get(BN_CTX *ctx)
     return ret;
 }
 
-OSSL_LIB_CTX *bn_get_lib_ctx(BN_CTX *ctx)
+OSSL_LIB_CTX *bn_get_libctx(BN_CTX *ctx)
 {
     if (ctx == NULL)
         return NULL;

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -25,7 +25,7 @@ static int bnrand(BNRAND_FLAG flag, BIGNUM *rnd, int bits, int top, int bottom,
 {
     unsigned char *buf = NULL;
     int b, ret = 0, bit, bytes, mask;
-    OPENSSL_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
 
     if (bits == 0) {
         if (top != BN_RAND_TOP_ANY || bottom != BN_RAND_BOTTOM_ANY)
@@ -254,7 +254,7 @@ int BN_generate_dsa_nonce(BIGNUM *out, const BIGNUM *range,
     unsigned char *k_bytes = NULL;
     int ret = 0;
     EVP_MD *md = NULL;
-    OPENSSL_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
 
     if (mdctx == NULL)
         goto err;

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -25,7 +25,7 @@ static int bnrand(BNRAND_FLAG flag, BIGNUM *rnd, int bits, int top, int bottom,
 {
     unsigned char *buf = NULL;
     int b, ret = 0, bit, bytes, mask;
-    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_libctx(ctx);
 
     if (bits == 0) {
         if (top != BN_RAND_TOP_ANY || bottom != BN_RAND_BOTTOM_ANY)
@@ -254,7 +254,7 @@ int BN_generate_dsa_nonce(BIGNUM *out, const BIGNUM *range,
     unsigned char *k_bytes = NULL;
     int ret = 0;
     EVP_MD *md = NULL;
-    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_libctx(ctx);
 
     if (mdctx == NULL)
         goto err;

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -101,7 +101,7 @@ static int cmp_ctx_set_md(OSSL_CMP_CTX *ctx, EVP_MD **pmd, int nid)
  * Allocates and initializes OSSL_CMP_CTX context structure with default values.
  * Returns new context on success, NULL on error
  */
-OSSL_CMP_CTX *OSSL_CMP_CTX_new(OPENSSL_CTX *libctx, const char *propq)
+OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_CMP_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -28,7 +28,7 @@
  * this structure is used to store the context for CMP sessions
  */
 struct ossl_cmp_ctx_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propq;
     OSSL_CMP_log_cb_t log_cb; /* log callback for error/debug/etc. output */
     OSSL_CMP_severity log_verbosity; /* level of verbosity of log output */
@@ -747,7 +747,7 @@ int ossl_cmp_asn1_octet_string_set1(ASN1_OCTET_STRING **tgt,
 int ossl_cmp_asn1_octet_string_set1_bytes(ASN1_OCTET_STRING **tgt,
                                           const unsigned char *bytes, int len);
 STACK_OF(X509)
-    *ossl_cmp_build_cert_chain(OPENSSL_CTX *libctx, const char *propq,
+    *ossl_cmp_build_cert_chain(OSSL_LIB_CTX *libctx, const char *propq,
                                X509_STORE *store,
                                STACK_OF(X509) *certs, X509 *cert);
 

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -48,7 +48,7 @@ void OSSL_CMP_SRV_CTX_free(OSSL_CMP_SRV_CTX *srv_ctx)
     OPENSSL_free(srv_ctx);
 }
 
-OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OPENSSL_CTX *libctx, const char *propq)
+OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_CMP_SRV_CTX *ctx = OPENSSL_zalloc(sizeof(OSSL_CMP_SRV_CTX));
 

--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -217,7 +217,7 @@ int ossl_cmp_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
  */
 /* TODO this should be of more general interest and thus be exported. */
 STACK_OF(X509)
-    *ossl_cmp_build_cert_chain(OPENSSL_CTX *libctx, const char *propq,
+    *ossl_cmp_build_cert_chain(OSSL_LIB_CTX *libctx, const char *propq,
                                X509_STORE *store,
                                STACK_OF(X509) *certs, X509 *cert)
 {

--- a/crypto/cms/cms_cd.c
+++ b/crypto/cms/cms_cd.c
@@ -21,7 +21,7 @@
 
 /* CMS CompressedData Utilities */
 
-CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OPENSSL_CTX *libctx,
+CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OSSL_LIB_CTX *libctx,
                                            const char *propq)
 {
     CMS_ContentInfo *cms;

--- a/crypto/cms/cms_dd.c
+++ b/crypto/cms/cms_dd.c
@@ -18,7 +18,7 @@
 /* CMS DigestedData Utilities */
 
 CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
-                                         OPENSSL_CTX *libctx, const char *propq)
+                                         OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ContentInfo *cms;
     CMS_DigestedData *dd;

--- a/crypto/cms/cms_dd.c
+++ b/crypto/cms/cms_dd.c
@@ -18,7 +18,8 @@
 /* CMS DigestedData Utilities */
 
 CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
-                                         OSSL_LIB_CTX *libctx, const char *propq)
+                                         OSSL_LIB_CTX *libctx,
+                                         const char *propq)
 {
     CMS_ContentInfo *cms;
     CMS_DigestedData *dd;

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -16,7 +16,7 @@
 
 #ifndef OPENSSL_NO_EC
 static EVP_PKEY *pkey_type2param(int ptype, const void *pval,
-                                 OPENSSL_CTX *libctx, const char *propq)
+                                 OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *pctx = NULL;

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -219,7 +219,7 @@ EVP_PKEY_CTX *CMS_RecipientInfo_get0_pkey_ctx(CMS_RecipientInfo *ri)
 }
 
 CMS_ContentInfo *CMS_EnvelopedData_create_ex(const EVP_CIPHER *cipher,
-                                             OPENSSL_CTX *libctx,
+                                             OSSL_LIB_CTX *libctx,
                                              const char *propq)
 {
     CMS_ContentInfo *cms;
@@ -248,7 +248,7 @@ CMS_ContentInfo *CMS_EnvelopedData_create(const EVP_CIPHER *cipher)
 }
 
 CMS_ContentInfo *
-CMS_AuthEnvelopedData_create_ex(const EVP_CIPHER *cipher, OPENSSL_CTX *libctx,
+CMS_AuthEnvelopedData_create_ex(const EVP_CIPHER *cipher, OSSL_LIB_CTX *libctx,
                                 const char *propq)
 {
     CMS_ContentInfo *cms;

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -117,7 +117,7 @@ int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
 CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OPENSSL_CTX *libctx, const char *propq)
+    OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ReceiptRequest *rr;
 

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -40,7 +40,7 @@ int i2d_CMS_ContentInfo(const CMS_ContentInfo *a, unsigned char **out)
     return ASN1_item_i2d((const ASN1_VALUE *)a, out, (CMS_ContentInfo_it()));
 }
 
-CMS_ContentInfo *CMS_ContentInfo_new_ex(OPENSSL_CTX *libctx, const char *propq)
+CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ContentInfo *ci;
 
@@ -78,7 +78,7 @@ const CMS_CTX *cms_get0_cmsctx(const CMS_ContentInfo *cms)
     return cms != NULL ? &cms->ctx : NULL;
 }
 
-OPENSSL_CTX *cms_ctx_get0_libctx(const CMS_CTX *ctx)
+OSSL_LIB_CTX *cms_ctx_get0_libctx(const CMS_CTX *ctx)
 {
     return ctx->libctx;
 }
@@ -117,7 +117,7 @@ const ASN1_OBJECT *CMS_get0_type(const CMS_ContentInfo *cms)
     return cms->contentType;
 }
 
-CMS_ContentInfo *cms_Data_create(OPENSSL_CTX *libctx, const char *propq)
+CMS_ContentInfo *cms_Data_create(OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ContentInfo *cms = CMS_ContentInfo_new_ex(libctx, propq);
 

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -47,7 +47,7 @@ typedef struct CMS_ReceiptsFrom_st CMS_ReceiptsFrom;
 typedef struct CMS_CTX_st CMS_CTX;
 
 struct CMS_CTX_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 };
 
@@ -390,14 +390,14 @@ DECLARE_ASN1_ALLOC_FUNCTIONS(CMS_IssuerAndSerialNumber)
 
 BIO *cms_content_bio(CMS_ContentInfo *cms);
 const CMS_CTX *cms_get0_cmsctx(const CMS_ContentInfo *cms);
-OPENSSL_CTX *cms_ctx_get0_libctx(const CMS_CTX *ctx);
+OSSL_LIB_CTX *cms_ctx_get0_libctx(const CMS_CTX *ctx);
 const char *cms_ctx_get0_propq(const CMS_CTX *ctx);
 void cms_resolve_libctx(CMS_ContentInfo *ci);
 
-CMS_ContentInfo *cms_Data_create(OPENSSL_CTX *ctx, const char *propq);
+CMS_ContentInfo *cms_Data_create(OSSL_LIB_CTX *ctx, const char *propq);
 
 CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
-                                         OPENSSL_CTX *libctx, const char *propq);
+                                         OSSL_LIB_CTX *libctx, const char *propq);
 BIO *cms_DigestedData_init_bio(const CMS_ContentInfo *cms);
 int cms_DigestedData_do_final(const CMS_ContentInfo *cms, BIO *chain, int verify);
 
@@ -411,7 +411,7 @@ int cms_SignerIdentifier_get0_signer_id(CMS_SignerIdentifier *sid,
                                         ASN1_INTEGER **sno);
 int cms_SignerIdentifier_cert_cmp(CMS_SignerIdentifier *sid, X509 *cert);
 
-CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OPENSSL_CTX *libctx,
+CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OSSL_LIB_CTX *libctx,
                                            const char *propq);
 BIO *cms_CompressedData_init_bio(const CMS_ContentInfo *cms);
 

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -397,9 +397,11 @@ void cms_resolve_libctx(CMS_ContentInfo *ci);
 CMS_ContentInfo *cms_Data_create(OSSL_LIB_CTX *ctx, const char *propq);
 
 CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
-                                         OSSL_LIB_CTX *libctx, const char *propq);
+                                         OSSL_LIB_CTX *libctx,
+                                         const char *propq);
 BIO *cms_DigestedData_init_bio(const CMS_ContentInfo *cms);
-int cms_DigestedData_do_final(const CMS_ContentInfo *cms, BIO *chain, int verify);
+int cms_DigestedData_do_final(const CMS_ContentInfo *cms,
+                              BIO *chain, int verify);
 
 BIO *cms_SignedData_init_bio(CMS_ContentInfo *cms);
 int cms_SignedData_final(CMS_ContentInfo *cms, BIO *chain);

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -119,7 +119,7 @@ int CMS_data(CMS_ContentInfo *cms, BIO *out, unsigned int flags)
 }
 
 CMS_ContentInfo *CMS_data_create_ex(BIO *in, unsigned int flags,
-                                    OPENSSL_CTX *libctx, const char *propq)
+                                    OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ContentInfo *cms = cms_Data_create(libctx, propq);
 
@@ -164,7 +164,7 @@ int CMS_digest_verify(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
 }
 
 CMS_ContentInfo *CMS_digest_create_ex(BIO *in, const EVP_MD *md,
-                                      unsigned int flags, OPENSSL_CTX *ctx,
+                                      unsigned int flags, OSSL_LIB_CTX *ctx,
                                       const char *propq)
 {
     CMS_ContentInfo *cms;
@@ -220,7 +220,7 @@ int CMS_EncryptedData_decrypt(CMS_ContentInfo *cms,
 CMS_ContentInfo *CMS_EncryptedData_encrypt_ex(BIO *in, const EVP_CIPHER *cipher,
                                               const unsigned char *key,
                                               size_t keylen, unsigned int flags,
-                                              OPENSSL_CTX *libctx,
+                                              OSSL_LIB_CTX *libctx,
                                               const char *propq)
 {
     CMS_ContentInfo *cms;
@@ -500,7 +500,7 @@ int CMS_verify_receipt(CMS_ContentInfo *rcms, CMS_ContentInfo *ocms,
 
 CMS_ContentInfo *CMS_sign_ex(X509 *signcert, EVP_PKEY *pkey,
                              STACK_OF(X509) *certs, BIO *data,
-                             unsigned int flags, OPENSSL_CTX *libctx,
+                             unsigned int flags, OSSL_LIB_CTX *libctx,
                              const char *propq)
 {
     CMS_ContentInfo *cms;
@@ -619,7 +619,7 @@ CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
 
 CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *data,
                                 const EVP_CIPHER *cipher, unsigned int flags,
-                                OPENSSL_CTX *libctx, const char *propq)
+                                OSSL_LIB_CTX *libctx, const char *propq)
 {
     CMS_ContentInfo *cms;
     int i;

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -178,7 +178,7 @@ int CONF_dump_bio(LHASH_OF(CONF_VALUE) *conf, BIO *out)
  * the "CONF classic" functions, for consistency.
  */
 
-CONF *NCONF_new_ex(OPENSSL_CTX *libctx, CONF_METHOD *meth)
+CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth)
 {
     CONF *ret;
 

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -148,7 +148,7 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
 
 }
 
-int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
+int CONF_modules_load_file_ex(OSSL_LIB_CTX *libctx, const char *filename,
                               const char *appname, unsigned long flags)
 {
     char *file = NULL;

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -224,8 +224,8 @@ int ossl_lib_ctx_is_global_default(OSSL_LIB_CTX *ctx)
 }
 
 static void ossl_lib_ctx_generic_new(void *parent_ign, void *ptr_ign,
-                                    CRYPTO_EX_DATA *ad, int index,
-                                    long argl_ign, void *argp)
+                                     CRYPTO_EX_DATA *ad, int index,
+                                     long argl_ign, void *argp)
 {
     const OSSL_LIB_CTX_METHOD *meth = argp;
     void *ptr = meth->new_func(crypto_ex_data_get_ossl_lib_ctx(ad));
@@ -234,8 +234,8 @@ static void ossl_lib_ctx_generic_new(void *parent_ign, void *ptr_ign,
         CRYPTO_set_ex_data(ad, index, ptr);
 }
 static void ossl_lib_ctx_generic_free(void *parent_ign, void *ptr,
-                                     CRYPTO_EX_DATA *ad, int index,
-                                     long argl_ign, void *argp)
+                                      CRYPTO_EX_DATA *ad, int index,
+                                      long argl_ign, void *argp)
 {
     const OSSL_LIB_CTX_METHOD *meth = argp;
 
@@ -244,7 +244,7 @@ static void ossl_lib_ctx_generic_free(void *parent_ign, void *ptr,
 
 /* Non-static so we can use it in context_internal_test */
 static int ossl_lib_ctx_init_index(OSSL_LIB_CTX *ctx, int static_index,
-                                  const OSSL_LIB_CTX_METHOD *meth)
+                                   const OSSL_LIB_CTX_METHOD *meth)
 {
     int idx;
 
@@ -264,7 +264,7 @@ static int ossl_lib_ctx_init_index(OSSL_LIB_CTX *ctx, int static_index,
 }
 
 void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index,
-                           const OSSL_LIB_CTX_METHOD *meth)
+                            const OSSL_LIB_CTX_METHOD *meth)
 {
     void *data = NULL;
     int dynidx;
@@ -322,7 +322,7 @@ OSSL_EX_DATA_GLOBAL *ossl_lib_ctx_get_ex_data_global(OSSL_LIB_CTX *ctx)
 }
 
 int ossl_lib_ctx_run_once(OSSL_LIB_CTX *ctx, unsigned int idx,
-                         ossl_lib_ctx_run_once_fn run_once_fn)
+                          ossl_lib_ctx_run_once_fn run_once_fn)
 {
     int done = 0, ret = 0;
 

--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -14,7 +14,7 @@
 #include "internal/provider.h"
 
 struct algorithm_data_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     int operation_id;            /* May be zero for finding them all */
     int (*pre)(OSSL_PROVIDER *, int operation_id, void *data, int *result);
     void (*fn)(OSSL_PROVIDER *, const OSSL_ALGORITHM *, int no_store,
@@ -85,7 +85,7 @@ static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
     return ok;
 }
 
-void ossl_algorithm_do_all(OPENSSL_CTX *libctx, int operation_id,
+void ossl_algorithm_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                            OSSL_PROVIDER *provider,
                            int (*pre)(OSSL_PROVIDER *, int operation_id,
                                       void *data, int *result),

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -16,7 +16,7 @@
 #include "internal/provider.h"
 
 struct construct_data_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     OSSL_METHOD_STORE *store;
     int operation_id;
     int force_store;
@@ -100,7 +100,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
     data->mcm->destruct(method, data->mcm_data);
 }
 
-void *ossl_method_construct(OPENSSL_CTX *libctx, int operation_id,
+void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
                             int force_store,
                             OSSL_METHOD_CONSTRUCT_METHOD *mcm, void *mcm_data)
 {

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -394,7 +394,7 @@ OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
 {
     OSSL_NAMEMAP *namemap =
         ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_NAMEMAP_INDEX,
-                             &stored_namemap_method);
+                              &stored_namemap_method);
 
 #ifndef FIPS_MODULE
     if (namemap != NULL && ossl_namemap_empty(namemap)) {

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -62,9 +62,9 @@ static void namenum_free(NAMENUM_ENTRY *n)
     OPENSSL_free(n);
 }
 
-/* OPENSSL_CTX_METHOD functions for a namemap stored in a library context */
+/* OSSL_LIB_CTX_METHOD functions for a namemap stored in a library context */
 
-static void *stored_namemap_new(OPENSSL_CTX *libctx)
+static void *stored_namemap_new(OSSL_LIB_CTX *libctx)
 {
     OSSL_NAMEMAP *namemap = ossl_namemap_new();
 
@@ -85,7 +85,7 @@ static void stored_namemap_free(void *vnamemap)
     }
 }
 
-static const OPENSSL_CTX_METHOD stored_namemap_method = {
+static const OSSL_LIB_CTX_METHOD stored_namemap_method = {
     stored_namemap_new,
     stored_namemap_free,
 };
@@ -390,10 +390,10 @@ static void get_legacy_md_names(const OBJ_NAME *on, void *arg)
  * ==========================
  */
 
-OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx)
+OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
 {
     OSSL_NAMEMAP *namemap =
-        openssl_ctx_get_data(libctx, OPENSSL_CTX_NAMEMAP_INDEX,
+        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_NAMEMAP_INDEX,
                              &stored_namemap_method);
 
 #ifndef FIPS_MODULE

--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -353,7 +353,7 @@ int OSSL_CRMF_MSG_push0_extension(OSSL_CRMF_MSG *crm,
 static int create_popo_signature(OSSL_CRMF_POPOSIGNINGKEY *ps,
                                  const OSSL_CRMF_CERTREQUEST *cr,
                                  EVP_PKEY *pkey, const EVP_MD *digest,
-                                 OPENSSL_CTX *libctx, const char *propq)
+                                 OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (ps == NULL || cr == NULL || pkey == NULL) {
         CRMFerr(0, CRMF_R_NULL_ARGUMENT);
@@ -373,7 +373,7 @@ static int create_popo_signature(OSSL_CRMF_POPOSIGNINGKEY *ps,
 
 int OSSL_CRMF_MSG_create_popo(int meth, OSSL_CRMF_MSG *crm,
                               EVP_PKEY *pkey, const EVP_MD *digest,
-                              OPENSSL_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_CRMF_POPO *pp = NULL;
     ASN1_INTEGER *tag = NULL;
@@ -441,7 +441,7 @@ int OSSL_CRMF_MSG_create_popo(int meth, OSSL_CRMF_MSG *crm,
 /* verifies the Proof-of-Possession of the request with the given rid in reqs */
 int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
                                int rid, int acceptRAVerified,
-                               OPENSSL_CTX *libctx, const char *propq)
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_CRMF_MSG *req = NULL;
     X509_PUBKEY *pubkey = NULL;
@@ -587,7 +587,7 @@ int OSSL_CRMF_CERTTEMPLATE_fill(OSSL_CRMF_CERTTEMPLATE *tmpl,
  */
 X509
 *OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert(const OSSL_CRMF_ENCRYPTEDVALUE *ecert,
-                                       OPENSSL_CTX *libctx, const char *propq,
+                                       OSSL_LIB_CTX *libctx, const char *propq,
                                        EVP_PKEY *pkey)
 {
     X509 *cert = NULL; /* decrypted certificate */

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -35,7 +35,7 @@
  * |macnid| e.g., NID_hmac_sha1
  * returns pointer to OSSL_CRMF_PBMPARAMETER on success, NULL on error
  */
-OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OPENSSL_CTX *libctx, size_t slen,
+OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t slen,
                                            int owfnid, size_t itercnt,
                                            int macnid)
 {
@@ -123,7 +123,7 @@ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OPENSSL_CTX *libctx, size_t slen,
  * returns 1 on success, 0 on error
  */
 /* TODO try to combine with other MAC calculations in the libray */
-int OSSL_CRMF_pbm_new(OPENSSL_CTX *libctx, const char *propq,
+int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
                       const OSSL_CRMF_PBMPARAMETER *pbmp,
                       const unsigned char *msg, size_t msglen,
                       const unsigned char *sec, size_t seclen,

--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -133,7 +133,7 @@ SCT *SCT_new_from_base64(unsigned char version, const char *logid_base64,
  * -1 on internal (malloc) failure
  */
 int CTLOG_new_from_base64_ex(CTLOG **ct_log, const char *pkey_base64,
-                             const char *name, OPENSSL_CTX *libctx,
+                             const char *name, OSSL_LIB_CTX *libctx,
                              const char *propq)
 {
     unsigned char *pkey_der = NULL;

--- a/crypto/ct/ct_local.h
+++ b/crypto/ct/ct_local.h
@@ -101,7 +101,7 @@ struct sct_ctx_st {
     /* milliseconds since epoch (to check that the SCT isn't from the future) */
     uint64_t epoch_time_in_ms;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 };
 
@@ -113,14 +113,14 @@ struct ct_policy_eval_ctx_st {
     /* milliseconds since epoch (to check that SCTs aren't from the future) */
     uint64_t epoch_time_in_ms;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 };
 
 /*
  * Creates a new context for verifying an SCT.
  */
-SCT_CTX *SCT_CTX_new(OPENSSL_CTX *ctx, const char *propq);
+SCT_CTX *SCT_CTX_new(OSSL_LIB_CTX *ctx, const char *propq);
 /*
  * Deletes an SCT verification context.
  */

--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -22,7 +22,7 @@
  * Information about a CT log server.
  */
 struct ctlog_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     char *name;
     uint8_t log_id[CT_V1_HASHLEN];
@@ -34,7 +34,7 @@ struct ctlog_st {
  * It takes ownership of any CTLOG instances added to it.
  */
 struct ctlog_store_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     STACK_OF(CTLOG) *logs;
 };
@@ -100,7 +100,7 @@ err:
     return ret;
 }
 
-CTLOG_STORE *CTLOG_STORE_new_ex(OPENSSL_CTX *libctx, const char *propq)
+CTLOG_STORE *CTLOG_STORE_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     CTLOG_STORE *ret = OPENSSL_zalloc(sizeof(*ret));
 
@@ -264,7 +264,7 @@ end:
  * Takes ownership of the public key.
  * Copies the name.
  */
-CTLOG *CTLOG_new_ex(EVP_PKEY *public_key, const char *name, OPENSSL_CTX *libctx,
+CTLOG *CTLOG_new_ex(EVP_PKEY *public_key, const char *name, OSSL_LIB_CTX *libctx,
                     const char *propq)
 {
     CTLOG *ret = OPENSSL_zalloc(sizeof(*ret));

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -25,7 +25,7 @@
  */
 static const time_t SCT_CLOCK_DRIFT_TOLERANCE = 300;
 
-CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OPENSSL_CTX *libctx,
+CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OSSL_LIB_CTX *libctx,
                                               const char *propq)
 {
     CT_POLICY_EVAL_CTX *ctx = OPENSSL_zalloc(sizeof(CT_POLICY_EVAL_CTX));

--- a/crypto/ct/ct_sct_ctx.c
+++ b/crypto/ct/ct_sct_ctx.c
@@ -20,7 +20,7 @@
 
 #include "ct_local.h"
 
-SCT_CTX *SCT_CTX_new(OPENSSL_CTX *libctx, const char *propq)
+SCT_CTX *SCT_CTX_new(OSSL_LIB_CTX *libctx, const char *propq)
 {
     SCT_CTX *sctx = OPENSSL_zalloc(sizeof(*sctx));
 

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -479,7 +479,7 @@ static size_t dh_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static int dh_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                             EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                             EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                              const char *propq)
 {
     DH *dh = from->pkey.dh;

--- a/crypto/dh/dh_gen.c
+++ b/crypto/dh/dh_gen.c
@@ -91,7 +91,7 @@ int dh_get_named_group_uid_from_size(int pbits)
 
 #ifdef FIPS_MODULE
 
-static int dh_gen_named_group(OPENSSL_CTX *libctx, DH *ret, int prime_len)
+static int dh_gen_named_group(OSSL_LIB_CTX *libctx, DH *ret, int prime_len)
 {
     DH *dh;
     int ok = 0;

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -100,7 +100,7 @@ const char *ossl_ffc_named_group_from_uid(int uid)
     return NULL;
 }
 
-static DH *dh_param_init(OPENSSL_CTX *libctx, int uid, const BIGNUM *p,
+static DH *dh_param_init(OSSL_LIB_CTX *libctx, int uid, const BIGNUM *p,
                          const BIGNUM *q, const BIGNUM *g)
 {
     DH *dh = dh_new_ex(libctx);
@@ -117,7 +117,7 @@ static DH *dh_param_init(OPENSSL_CTX *libctx, int uid, const BIGNUM *p,
     return dh;
 }
 
-static DH *dh_new_by_group_name(OPENSSL_CTX *libctx, const char *name)
+static DH *dh_new_by_group_name(OSSL_LIB_CTX *libctx, const char *name)
 {
     int i;
 
@@ -136,7 +136,7 @@ static DH *dh_new_by_group_name(OPENSSL_CTX *libctx, const char *name)
     return NULL;
 }
 
-DH *dh_new_by_nid_ex(OPENSSL_CTX *libctx, int nid)
+DH *dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid)
 {
     const char *name = ossl_ffc_named_group_from_uid(nid);
 

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -29,7 +29,7 @@ int dh_KDF_X9_42_asn1(unsigned char *out, size_t outlen,
                       const unsigned char *Z, size_t Zlen,
                       const char *cek_alg,
                       const unsigned char *ukm, size_t ukmlen, const EVP_MD *md,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ret = 0;
     EVP_KDF_CTX *kctx = NULL;
@@ -69,7 +69,7 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
     int nid;
     const char *key_alg = NULL;
     const OSSL_PROVIDER *prov = EVP_MD_provider(md);
-    OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
 
     nid = OBJ_obj2nid(key_oid);
     if (nid == NID_undef)

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -69,7 +69,7 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
     int nid;
     const char *key_alg = NULL;
     const OSSL_PROVIDER *prov = EVP_MD_provider(md);
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
 
     nid = OBJ_obj2nid(key_oid);
     if (nid == NID_undef)

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -24,7 +24,7 @@
 #include "crypto/dh.h"
 #include "dh_local.h"
 
-static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx);
+static DH *dh_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx);
 
 #ifndef FIPS_MODULE
 int DH_set_method(DH *dh, const DH_METHOD *meth)
@@ -63,12 +63,12 @@ DH *DH_new_method(ENGINE *engine)
 }
 #endif /* !FIPS_MODULE */
 
-DH *dh_new_ex(OPENSSL_CTX *libctx)
+DH *dh_new_ex(OSSL_LIB_CTX *libctx)
 {
     return dh_new_intern(NULL, libctx);
 }
 
-static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
+static DH *dh_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx)
 {
     DH *ret = OPENSSL_zalloc(sizeof(*ret));
 

--- a/crypto/dh/dh_local.h
+++ b/crypto/dh/dh_local.h
@@ -32,7 +32,7 @@ struct dh_st {
     CRYPTO_EX_DATA ex_data;
     ENGINE *engine;
 #endif
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const DH_METHOD *meth;
     CRYPTO_RWLOCK *lock;
 

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -274,7 +274,7 @@ static int pkey_dh_ctrl_str(EVP_PKEY_CTX *ctx,
     return -2;
 }
 
-static DH *ffc_params_generate(OPENSSL_CTX *libctx, DH_PKEY_CTX *dctx,
+static DH *ffc_params_generate(OSSL_LIB_CTX *libctx, DH_PKEY_CTX *dctx,
                                BN_GENCB *pcb)
 {
     DH *ret;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -498,7 +498,7 @@ static size_t dsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static int dsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                              EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                              EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                               const char *propq)
 {
     DSA *dsa = from->pkey.dsa;

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -25,7 +25,7 @@
 #include "crypto/dsa.h"
 #include "crypto/dh.h" /* required by DSA_dup_DH() */
 
-static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx);
+static DSA *dsa_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx);
 
 #ifndef FIPS_MODULE
 
@@ -132,7 +132,7 @@ const DSA_METHOD *DSA_get_method(DSA *d)
     return d->meth;
 }
 
-static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
+static DSA *dsa_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx)
 {
     DSA *ret = OPENSSL_zalloc(sizeof(*ret));
 
@@ -194,7 +194,7 @@ DSA *DSA_new_method(ENGINE *engine)
     return dsa_new_intern(engine, NULL);
 }
 
-DSA *dsa_new_with_ctx(OPENSSL_CTX *libctx)
+DSA *dsa_new_with_ctx(OSSL_LIB_CTX *libctx)
 {
     return dsa_new_intern(NULL, libctx);
 }

--- a/crypto/dsa/dsa_local.h
+++ b/crypto/dsa/dsa_local.h
@@ -32,7 +32,7 @@ struct dsa_st {
     /* functional reference if 'meth' is ENGINE-provided */
     ENGINE *engine;
     CRYPTO_RWLOCK *lock;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
     /* Provider data */
     size_t dirty_cnt; /* If any key material changes, increment this */

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -5439,7 +5439,7 @@ static void sc_muladd(uint8_t *s, const uint8_t *a, const uint8_t *b,
 
 int ED25519_sign(uint8_t *out_sig, const uint8_t *message, size_t message_len,
                  const uint8_t public_key[32], const uint8_t private_key[32],
-                 OPENSSL_CTX *libctx, const char *propq)
+                 OSSL_LIB_CTX *libctx, const char *propq)
 {
     uint8_t az[SHA512_DIGEST_LENGTH];
     uint8_t nonce[SHA512_DIGEST_LENGTH];
@@ -5495,7 +5495,7 @@ static const char allzeroes[15];
 
 int ED25519_verify(const uint8_t *message, size_t message_len,
                    const uint8_t signature[64], const uint8_t public_key[32],
-                   OPENSSL_CTX *libctx, const char *propq)
+                   OSSL_LIB_CTX *libctx, const char *propq)
 {
     int i;
     ge_p3 A;
@@ -5577,7 +5577,7 @@ err:
     return res;
 }
 
-int ED25519_public_from_private(OPENSSL_CTX *ctx, uint8_t out_public_key[32],
+int ED25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[32],
                                 const uint8_t private_key[32], const char *propq)
 {
     uint8_t az[SHA512_DIGEST_LENGTH];

--- a/crypto/ec/curve448/curve448_local.h
+++ b/crypto/ec/curve448/curve448_local.h
@@ -10,11 +10,11 @@
 # define OSSL_CRYPTO_EC_CURVE448_LOCAL_H
 # include "curve448utils.h"
 
-int ED448ph_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t hash[64],
+int ED448ph_sign(OSSL_LIB_CTX *ctx, uint8_t *out_sig, const uint8_t hash[64],
                  const uint8_t public_key[57], const uint8_t private_key[57],
                  const uint8_t *context, size_t context_len, const char *propq);
 
-int ED448ph_verify(OPENSSL_CTX *ctx, const uint8_t hash[64],
+int ED448ph_verify(OSSL_LIB_CTX *ctx, const uint8_t hash[64],
                    const uint8_t signature[114], const uint8_t public_key[57],
                    const uint8_t *context, size_t context_len, const char *propq);
 

--- a/crypto/ec/curve448/ed448.h
+++ b/crypto/ec/curve448/ed448.h
@@ -38,7 +38,7 @@
  * privkey (in): The private key.
  */
 c448_error_t c448_ed448_derive_public_key(
-                        OPENSSL_CTX *ctx,
+                        OSSL_LIB_CTX *ctx,
                         uint8_t pubkey [EDDSA_448_PUBLIC_BYTES],
                         const uint8_t privkey [EDDSA_448_PRIVATE_BYTES],
                         const char *propq);
@@ -61,7 +61,7 @@ c448_error_t c448_ed448_derive_public_key(
  * disambiguation.  For Ed448 it is safe.
  */
 c448_error_t c448_ed448_sign(
-                        OPENSSL_CTX *ctx,
+                        OSSL_LIB_CTX *ctx,
                         uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                         const uint8_t privkey[EDDSA_448_PRIVATE_BYTES],
                         const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
@@ -87,7 +87,7 @@ c448_error_t c448_ed448_sign(
  * disambiguation.  For Ed448 it is safe.
  */
 c448_error_t c448_ed448_sign_prehash(
-                        OPENSSL_CTX *ctx,
+                        OSSL_LIB_CTX *ctx,
                         uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                         const uint8_t privkey[EDDSA_448_PRIVATE_BYTES],
                         const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
@@ -114,7 +114,7 @@ c448_error_t c448_ed448_sign_prehash(
  * non-prehashed messages, at least without some very careful protocol-level
  * disambiguation.  For Ed448 it is safe.
  */
-c448_error_t c448_ed448_verify(OPENSSL_CTX *ctx,
+c448_error_t c448_ed448_verify(OSSL_LIB_CTX *ctx,
                                const uint8_t
                                signature[EDDSA_448_SIGNATURE_BYTES],
                                const uint8_t
@@ -142,7 +142,7 @@ c448_error_t c448_ed448_verify(OPENSSL_CTX *ctx,
  * disambiguation.  For Ed448 it is safe.
  */
 c448_error_t c448_ed448_verify_prehash(
-                    OPENSSL_CTX *ctx,
+                    OSSL_LIB_CTX *ctx,
                     const uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                     const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
                     const uint8_t hash[64],
@@ -199,7 +199,7 @@ c448_error_t curve448_point_decode_like_eddsa_and_mul_by_ratio(
  * ed (in): The EdDSA private key
  */
 c448_error_t c448_ed448_convert_private_key_to_x448(
-                            OPENSSL_CTX *ctx,
+                            OSSL_LIB_CTX *ctx,
                             uint8_t x[X448_PRIVATE_BYTES],
                             const uint8_t ed[EDDSA_448_PRIVATE_BYTES],
                             const char *propq);

--- a/crypto/ec/curve448/eddsa.c
+++ b/crypto/ec/curve448/eddsa.c
@@ -20,7 +20,7 @@
 
 #define COFACTOR 4
 
-static c448_error_t oneshot_hash(OPENSSL_CTX *ctx, uint8_t *out, size_t outlen,
+static c448_error_t oneshot_hash(OSSL_LIB_CTX *ctx, uint8_t *out, size_t outlen,
                                  const uint8_t *in, size_t inlen,
                                  const char *propq)
 {
@@ -54,7 +54,7 @@ static void clamp(uint8_t secret_scalar_ser[EDDSA_448_PRIVATE_BYTES])
     secret_scalar_ser[EDDSA_448_PRIVATE_BYTES - 2] |= 0x80;
 }
 
-static c448_error_t hash_init_with_dom(OPENSSL_CTX *ctx, EVP_MD_CTX *hashctx,
+static c448_error_t hash_init_with_dom(OSSL_LIB_CTX *ctx, EVP_MD_CTX *hashctx,
                                        uint8_t prehashed,
                                        uint8_t for_prehash,
                                        const uint8_t *context,
@@ -95,7 +95,7 @@ static c448_error_t hash_init_with_dom(OPENSSL_CTX *ctx, EVP_MD_CTX *hashctx,
 
 /* In this file because it uses the hash */
 c448_error_t c448_ed448_convert_private_key_to_x448(
-                            OPENSSL_CTX *ctx,
+                            OSSL_LIB_CTX *ctx,
                             uint8_t x[X448_PRIVATE_BYTES],
                             const uint8_t ed [EDDSA_448_PRIVATE_BYTES],
                             const char *propq)
@@ -107,7 +107,7 @@ c448_error_t c448_ed448_convert_private_key_to_x448(
 }
 
 c448_error_t c448_ed448_derive_public_key(
-                        OPENSSL_CTX *ctx,
+                        OSSL_LIB_CTX *ctx,
                         uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
                         const uint8_t privkey[EDDSA_448_PRIVATE_BYTES],
                         const char *propq)
@@ -153,7 +153,7 @@ c448_error_t c448_ed448_derive_public_key(
 }
 
 c448_error_t c448_ed448_sign(
-                        OPENSSL_CTX *ctx,
+                        OSSL_LIB_CTX *ctx,
                         uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                         const uint8_t privkey[EDDSA_448_PRIVATE_BYTES],
                         const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
@@ -261,7 +261,7 @@ c448_error_t c448_ed448_sign(
 }
 
 c448_error_t c448_ed448_sign_prehash(
-                        OPENSSL_CTX *ctx,
+                        OSSL_LIB_CTX *ctx,
                         uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                         const uint8_t privkey[EDDSA_448_PRIVATE_BYTES],
                         const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
@@ -273,7 +273,7 @@ c448_error_t c448_ed448_sign_prehash(
 }
 
 c448_error_t c448_ed448_verify(
-                    OPENSSL_CTX *ctx,
+                    OSSL_LIB_CTX *ctx,
                     const uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                     const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
                     const uint8_t *message, size_t message_len,
@@ -356,7 +356,7 @@ c448_error_t c448_ed448_verify(
 }
 
 c448_error_t c448_ed448_verify_prehash(
-                    OPENSSL_CTX *ctx,
+                    OSSL_LIB_CTX *ctx,
                     const uint8_t signature[EDDSA_448_SIGNATURE_BYTES],
                     const uint8_t pubkey[EDDSA_448_PUBLIC_BYTES],
                     const uint8_t hash[64], const uint8_t *context,
@@ -366,7 +366,7 @@ c448_error_t c448_ed448_verify_prehash(
                              context_len, propq);
 }
 
-int ED448_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t *message,
+int ED448_sign(OSSL_LIB_CTX *ctx, uint8_t *out_sig, const uint8_t *message,
                size_t message_len, const uint8_t public_key[57],
                const uint8_t private_key[57], const uint8_t *context,
                size_t context_len, const char *propq)
@@ -376,7 +376,7 @@ int ED448_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t *message,
         == C448_SUCCESS;
 }
 
-int ED448_verify(OPENSSL_CTX *ctx, const uint8_t *message, size_t message_len,
+int ED448_verify(OSSL_LIB_CTX *ctx, const uint8_t *message, size_t message_len,
                  const uint8_t signature[114], const uint8_t public_key[57],
                  const uint8_t *context, size_t context_len, const char *propq)
 {
@@ -385,7 +385,7 @@ int ED448_verify(OPENSSL_CTX *ctx, const uint8_t *message, size_t message_len,
                              propq) == C448_SUCCESS;
 }
 
-int ED448ph_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t hash[64],
+int ED448ph_sign(OSSL_LIB_CTX *ctx, uint8_t *out_sig, const uint8_t hash[64],
                  const uint8_t public_key[57], const uint8_t private_key[57],
                  const uint8_t *context, size_t context_len, const char *propq)
 {
@@ -394,7 +394,7 @@ int ED448ph_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t hash[64],
 
 }
 
-int ED448ph_verify(OPENSSL_CTX *ctx, const uint8_t hash[64],
+int ED448ph_verify(OSSL_LIB_CTX *ctx, const uint8_t hash[64],
                    const uint8_t signature[114], const uint8_t public_key[57],
                    const uint8_t *context, size_t context_len, const char *propq)
 {
@@ -402,7 +402,7 @@ int ED448ph_verify(OPENSSL_CTX *ctx, const uint8_t hash[64],
                                      (uint8_t)context_len, propq) == C448_SUCCESS;
 }
 
-int ED448_public_from_private(OPENSSL_CTX *ctx, uint8_t out_public_key[57],
+int ED448_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[57],
                               const uint8_t private_key[57], const char *propq)
 {
     return c448_ed448_derive_public_key(ctx, out_public_key, private_key, propq)

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -101,7 +101,7 @@ static int eckey_pub_encode(X509_PUBKEY *pk, const EVP_PKEY *pkey)
 }
 
 static EC_KEY *eckey_type2param(int ptype, const void *pval,
-                                OPENSSL_CTX *libctx, const char *propq)
+                                OSSL_LIB_CTX *libctx, const char *propq)
 {
     EC_KEY *eckey = NULL;
     EC_GROUP *group = NULL;
@@ -155,7 +155,7 @@ static int eckey_pub_decode(EVP_PKEY *pkey, const X509_PUBKEY *pubkey)
     int ptype, pklen;
     EC_KEY *eckey = NULL;
     X509_ALGOR *palg;
-    OPENSSL_CTX *libctx = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
 
     if (!X509_PUBKEY_get0_libctx(&libctx, &propq, pubkey)
@@ -200,7 +200,7 @@ static int eckey_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 }
 
 static int eckey_priv_decode_ex(EVP_PKEY *pkey, const PKCS8_PRIV_KEY_INFO *p8,
-                                OPENSSL_CTX *libctx, const char *propq)
+                                OSSL_LIB_CTX *libctx, const char *propq)
 {
     const unsigned char *p = NULL;
     const void *pval;
@@ -562,7 +562,7 @@ size_t ec_pkey_dirty_cnt(const EVP_PKEY *pkey)
 
 static
 int ec_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                      EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                      EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                       const char *propq)
 {
     const EC_KEY *eckey = NULL;

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -50,7 +50,8 @@ static char *ec_param_encoding_id2name(int id)
 }
 
 int ec_group_todata(const EC_GROUP *group, OSSL_PARAM_BLD *tmpl,
-                    OSSL_PARAM params[], OSSL_LIB_CTX *libctx, const char *propq,
+                    OSSL_PARAM params[], OSSL_LIB_CTX *libctx,
+                    const char *propq,
                     BN_CTX *bnctx, unsigned char **genbuf)
 {
     int ret = 0, curve_nid, encoding_flag;

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -50,7 +50,7 @@ static char *ec_param_encoding_id2name(int id)
 }
 
 int ec_group_todata(const EC_GROUP *group, OSSL_PARAM_BLD *tmpl,
-                    OSSL_PARAM params[], OPENSSL_CTX *libctx, const char *propq,
+                    OSSL_PARAM params[], OSSL_LIB_CTX *libctx, const char *propq,
                     BN_CTX *bnctx, unsigned char **genbuf)
 {
     int ret = 0, curve_nid, encoding_flag;

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3180,7 +3180,7 @@ int ec_curve_name2nid(const char *name)
     return NID_undef;
 }
 
-static EC_GROUP *ec_group_new_from_data(OPENSSL_CTX *libctx,
+static EC_GROUP *ec_group_new_from_data(OSSL_LIB_CTX *libctx,
                                         const char *propq,
                                         const ec_list_element curve)
 {
@@ -3290,7 +3290,7 @@ static EC_GROUP *ec_group_new_from_data(OPENSSL_CTX *libctx,
     return group;
 }
 
-EC_GROUP *EC_GROUP_new_by_curve_name_ex(OPENSSL_CTX *libctx, const char *propq,
+EC_GROUP *EC_GROUP_new_by_curve_name_ex(OSSL_LIB_CTX *libctx, const char *propq,
                                         int nid)
 {
     EC_GROUP *ret = NULL;

--- a/crypto/ec/ec_cvt.c
+++ b/crypto/ec/ec_cvt.c
@@ -54,7 +54,7 @@ EC_GROUP *EC_GROUP_new_curve_GFp(const BIGNUM *p, const BIGNUM *a,
         meth = EC_GFp_mont_method();
 #endif
 
-    ret = ec_group_new_ex(bn_get_lib_ctx(ctx), NULL, meth);
+    ret = ec_group_new_ex(bn_get_libctx(ctx), NULL, meth);
     if (ret == NULL)
         return NULL;
 
@@ -75,7 +75,7 @@ EC_GROUP *EC_GROUP_new_curve_GF2m(const BIGNUM *p, const BIGNUM *a,
 
     meth = EC_GF2m_simple_method();
 
-    ret = ec_group_new_ex(bn_get_lib_ctx(ctx), NULL, meth);
+    ret = ec_group_new_ex(bn_get_libctx(ctx), NULL, meth);
     if (ret == NULL)
         return NULL;
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -34,12 +34,12 @@ EC_KEY *EC_KEY_new(void)
 }
 #endif
 
-EC_KEY *EC_KEY_new_ex(OPENSSL_CTX *ctx, const char *propq)
+EC_KEY *EC_KEY_new_ex(OSSL_LIB_CTX *ctx, const char *propq)
 {
     return ec_key_new_method_int(ctx, propq, NULL);
 }
 
-EC_KEY *EC_KEY_new_by_curve_name_ex(OPENSSL_CTX *ctx, const char *propq,
+EC_KEY *EC_KEY_new_by_curve_name_ex(OSSL_LIB_CTX *ctx, const char *propq,
                                     int nid)
 {
     EC_KEY *ret = EC_KEY_new_ex(ctx, propq);
@@ -651,7 +651,7 @@ int EC_KEY_set_public_key_affine_coordinates(EC_KEY *key, BIGNUM *x,
 
 }
 
-OPENSSL_CTX *ec_key_get_libctx(const EC_KEY *key)
+OSSL_LIB_CTX *ec_key_get_libctx(const EC_KEY *key)
 {
     return key->libctx;
 }

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -76,7 +76,7 @@ int EC_KEY_set_method(EC_KEY *key, const EC_KEY_METHOD *meth)
     return 1;
 }
 
-EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, const char *propq,
+EC_KEY *ec_key_new_method_int(OSSL_LIB_CTX *libctx, const char *propq,
                               ENGINE *engine)
 {
     EC_KEY *ret = OPENSSL_zalloc(sizeof(*ret));

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -26,7 +26,7 @@
 
 /* functions for EC_GROUP objects */
 
-EC_GROUP *ec_group_new_ex(OPENSSL_CTX *libctx, const char *propq,
+EC_GROUP *ec_group_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
                           const EC_METHOD *meth)
 {
     EC_GROUP *ret;
@@ -1403,7 +1403,7 @@ int EC_GROUP_get_pentanomial_basis(const EC_GROUP *group, unsigned int *k1,
  * mathematically wrong anyway and should not be used.
  */
 static EC_GROUP *ec_group_explicit_to_named(const EC_GROUP *group,
-                                            OPENSSL_CTX *libctx,
+                                            OSSL_LIB_CTX *libctx,
                                             const char *propq,
                                             BN_CTX *ctx)
 {
@@ -1499,7 +1499,7 @@ static int ec_encoding_param2id(const OSSL_PARAM *p, int *id)
 }
 
 static EC_GROUP *group_new_from_name(const OSSL_PARAM *p,
-                                     OPENSSL_CTX *libctx, const char *propq)
+                                     OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ok = 0, nid;
     const char *curve_name = NULL;
@@ -1528,7 +1528,7 @@ static EC_GROUP *group_new_from_name(const OSSL_PARAM *p,
 }
 
 EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
-                                   OPENSSL_CTX *libctx, const char *propq)
+                                   OSSL_LIB_CTX *libctx, const char *propq)
 {
     const OSSL_PARAM *ptmp, *pa, *pb;
     int ok = 0;

--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -275,7 +275,7 @@ struct ec_group_st {
         EC_PRE_COMP *ec;
     } pre_comp;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 };
 
@@ -299,7 +299,7 @@ struct ec_key_st {
     CRYPTO_EX_DATA ex_data;
 #endif
     CRYPTO_RWLOCK *lock;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 
     /* Provider data */
@@ -601,7 +601,7 @@ int ec_group_simple_order_bits(const EC_GROUP *group);
  *  \param   meth   EC_METHOD to use
  *  \return  newly created EC_GROUP object or NULL in case of an error.
  */
-EC_GROUP *ec_group_new_ex(OPENSSL_CTX *libctx, const char *propq,
+EC_GROUP *ec_group_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
                           const EC_METHOD *meth);
 
 #ifdef ECP_NISTZ256_ASM
@@ -657,7 +657,7 @@ struct ec_key_method_st {
 
 #define EC_KEY_METHOD_DYNAMIC   1
 
-EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, const char *propq,
+EC_KEY *ec_key_new_method_int(OSSL_LIB_CTX *libctx, const char *propq,
                               ENGINE *engine);
 
 int ossl_ec_key_gen(EC_KEY *eckey);

--- a/crypto/ec/ecdh_kdf.c
+++ b/crypto/ec/ecdh_kdf.c
@@ -25,7 +25,7 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
                    const unsigned char *Z, size_t Zlen,
                    const unsigned char *sinfo, size_t sinfolen,
                    const EVP_MD *md,
-                   OPENSSL_CTX *libctx, const char *propq)
+                   OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ret = 0;
     EVP_KDF_CTX *kctx = NULL;

--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -10,7 +10,7 @@
 #include <openssl/err.h>
 #include "crypto/ecx.h"
 
-ECX_KEY *ecx_key_new(OPENSSL_CTX *libctx, ECX_KEY_TYPE type, int haspubkey,
+ECX_KEY *ecx_key_new(OSSL_LIB_CTX *libctx, ECX_KEY_TYPE type, int haspubkey,
                      const char *propq)
 {
     ECX_KEY *ret = OPENSSL_zalloc(sizeof(*ret));

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -36,7 +36,7 @@ typedef enum {
 /* Setup EVP_PKEY using public, private or generation */
 static int ecx_key_op(EVP_PKEY *pkey, int id, const X509_ALGOR *palg,
                       const unsigned char *p, int plen, ecx_key_op_t op,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     ECX_KEY *key = NULL;
     unsigned char *privkey, *pubkey;
@@ -150,7 +150,7 @@ static int ecx_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 }
 
 static int ecx_priv_decode_ex(EVP_PKEY *pkey, const PKCS8_PRIV_KEY_INFO *p8,
-                              OPENSSL_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx, const char *propq)
 {
     const unsigned char *p;
     int plen;
@@ -396,7 +396,7 @@ static size_t ecx_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static int ecx_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                              EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                              EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                               const char *propq)
 {
     const ECX_KEY *key = from->pkey.ecx;

--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -217,7 +217,7 @@ int OSSL_DECODER_CTX_add_decoder(OSSL_DECODER_CTX *ctx, OSSL_DECODER *decoder)
 }
 
 int OSSL_DECODER_CTX_add_extra(OSSL_DECODER_CTX *ctx,
-                               OPENSSL_CTX *libctx, const char *propq)
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     /*
      * This function goes through existing decoder methods in

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -245,7 +245,7 @@ static void *construct_decoder(const OSSL_ALGORITHM *algodef,
      * namemap entry, this is it.  Should the name already exist there, we
      * know that ossl_namemap_add() will return its corresponding number.
      */
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
@@ -380,7 +380,7 @@ int OSSL_DECODER_number(const OSSL_DECODER *decoder)
 int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name)
 {
     if (decoder->base.prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(decoder->base.prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(decoder->base.prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
         return ossl_namemap_name2num(namemap, name) == decoder->base.id;
@@ -398,7 +398,7 @@ static void decoder_do_one(OSSL_PROVIDER *provider,
                            int no_store, void *vdata)
 {
     struct decoder_do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
@@ -434,7 +434,7 @@ void OSSL_DECODER_names_do_all(const OSSL_DECODER *decoder,
         return;
 
     if (decoder->base.prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(decoder->base.prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(decoder->base.prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
         ossl_namemap_doall_names(namemap, decoder->base.id, fn, data);

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -110,7 +110,7 @@ static void dealloc_tmp_decoder_store(void *store)
 static OSSL_METHOD_STORE *get_decoder_store(OSSL_LIB_CTX *libctx)
 {
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DECODER_STORE_INDEX,
-                                &decoder_store_method);
+                                 &decoder_store_method);
 }
 
 /* Get decoder methods from a store, or put one in */

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -257,7 +257,7 @@ static void collect_decoder(OSSL_DECODER *decoder, void *arg)
 
 int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
                                         EVP_PKEY **pkey, const char *keytype,
-                                        OPENSSL_CTX *libctx,
+                                        OSSL_LIB_CTX *libctx,
                                         const char *propquery)
 {
     struct collected_data_st *data = NULL;
@@ -326,7 +326,7 @@ int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
 OSSL_DECODER_CTX *
 OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
                                  const char *input_type, const char *keytype,
-                                 OPENSSL_CTX *libctx, const char *propquery)
+                                 OSSL_LIB_CTX *libctx, const char *propquery)
 {
     OSSL_DECODER_CTX *ctx = NULL;
 

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -235,7 +235,7 @@ int OSSL_ENCODER_CTX_add_encoder(OSSL_ENCODER_CTX *ctx, OSSL_ENCODER *encoder)
 }
 
 int OSSL_ENCODER_CTX_add_extra(OSSL_ENCODER_CTX *ctx,
-                               OPENSSL_CTX *libctx, const char *propq)
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     return 1;
 }

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -257,7 +257,7 @@ static void *construct_encoder(const OSSL_ALGORITHM *algodef,
      * namemap entry, this is it.  Should the name already exist there, we
      * know that ossl_namemap_add() will return its corresponding number.
      */
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
@@ -392,7 +392,7 @@ int OSSL_ENCODER_number(const OSSL_ENCODER *encoder)
 int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name)
 {
     if (encoder->base.prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(encoder->base.prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(encoder->base.prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
         return ossl_namemap_name2num(namemap, name) == encoder->base.id;
@@ -410,7 +410,7 @@ static void encoder_do_one(OSSL_PROVIDER *provider,
                            int no_store, void *vdata)
 {
     struct encoder_do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
@@ -451,7 +451,7 @@ void OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
         return;
 
     if (encoder->base.prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(encoder->base.prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(encoder->base.prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
         ossl_namemap_doall_names(namemap, encoder->base.id, fn, data);

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -110,7 +110,7 @@ static void dealloc_tmp_encoder_store(void *store)
 static OSSL_METHOD_STORE *get_encoder_store(OSSL_LIB_CTX *libctx)
 {
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_ENCODER_STORE_INDEX,
-                                &encoder_store_method);
+                                 &encoder_store_method);
 }
 
 /* Get encoder methods from a store, or put one in */

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -206,7 +206,7 @@ static void encoder_destruct_EVP_PKEY(void *arg)
 static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
                                                const EVP_PKEY *pkey,
                                                int selection,
-                                               OPENSSL_CTX *libctx,
+                                               OSSL_LIB_CTX *libctx,
                                                const char *propquery)
 {
     struct construct_data_st *data = NULL;
@@ -337,7 +337,7 @@ static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
 OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                                    const char *output_type,
                                                    int selection,
-                                                   OPENSSL_CTX *libctx,
+                                                   OSSL_LIB_CTX *libctx,
                                                    const char *propquery)
 {
     OSSL_ENCODER_CTX *ctx = NULL;

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -405,7 +405,7 @@ OSSL_PROVIDER *EVP_ASYM_CIPHER_provider(const EVP_ASYM_CIPHER *cipher)
     return cipher->prov;
 }
 
-EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                        const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_ASYM_CIPHER, algorithm, properties,
@@ -424,7 +424,7 @@ int EVP_ASYM_CIPHER_number(const EVP_ASYM_CIPHER *cipher)
     return cipher->name_id;
 }
 
-void EVP_ASYM_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                      void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                 void *arg),
                                      void *arg)

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -83,7 +83,7 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
 
 #ifndef FIPS_MODULE
 EVP_MD_CTX *evp_md_ctx_new_ex(EVP_PKEY *pkey, const ASN1_OCTET_STRING *id,
-                              OPENSSL_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_MD_CTX *ctx;
     EVP_PKEY_CTX *pctx = NULL;
@@ -954,7 +954,7 @@ static void evp_md_free(void *md)
     EVP_MD_free(md);
 }
 
-EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                      const char *properties)
 {
     EVP_MD *md =
@@ -987,7 +987,7 @@ void EVP_MD_free(EVP_MD *md)
     OPENSSL_free(md);
 }
 
-void EVP_MD_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
                             void (*fn)(EVP_MD *mac, void *arg),
                             void *arg)
 {

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1183,7 +1183,7 @@ static OSSL_LIB_CTX *EVP_CIPHER_CTX_get_libctx(EVP_CIPHER_CTX *ctx)
         return NULL;
 
     prov = EVP_CIPHER_provider(cipher);
-    return ossl_provider_library_context(prov);
+    return ossl_provider_libctx(prov);
 }
 #endif
 

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1174,7 +1174,7 @@ const OSSL_PARAM *EVP_CIPHER_gettable_ctx_params(const EVP_CIPHER *cipher)
 }
 
 #ifndef FIPS_MODULE
-static OPENSSL_CTX *EVP_CIPHER_CTX_get_libctx(EVP_CIPHER_CTX *ctx)
+static OSSL_LIB_CTX *EVP_CIPHER_CTX_get_libctx(EVP_CIPHER_CTX *ctx)
 {
     const EVP_CIPHER *cipher = ctx->cipher;
     const OSSL_PROVIDER *prov;
@@ -1197,7 +1197,7 @@ int EVP_CIPHER_CTX_rand_key(EVP_CIPHER_CTX *ctx, unsigned char *key)
 #else
     {
         int kl;
-        OPENSSL_CTX *libctx = EVP_CIPHER_CTX_get_libctx(ctx);
+        OSSL_LIB_CTX *libctx = EVP_CIPHER_CTX_get_libctx(ctx);
 
         kl = EVP_CIPHER_CTX_key_length(ctx);
         if (kl <= 0 || RAND_priv_bytes_ex(libctx, key, kl) <= 0)
@@ -1456,7 +1456,7 @@ static void evp_cipher_free(void *cipher)
     EVP_CIPHER_free(cipher);
 }
 
-EVP_CIPHER *EVP_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_CIPHER *EVP_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                              const char *properties)
 {
     EVP_CIPHER *cipher =
@@ -1494,7 +1494,7 @@ void EVP_CIPHER_free(EVP_CIPHER *cipher)
     OPENSSL_free(cipher);
 }
 
-void EVP_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                 void (*fn)(EVP_CIPHER *mac, void *arg),
                                 void *arg)
 {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -28,20 +28,20 @@ static void evp_method_store_free(void *vstore)
     ossl_method_store_free(vstore);
 }
 
-static void *evp_method_store_new(OPENSSL_CTX *ctx)
+static void *evp_method_store_new(OSSL_LIB_CTX *ctx)
 {
     return ossl_method_store_new(ctx);
 }
 
 
-static const OPENSSL_CTX_METHOD evp_method_store_method = {
+static const OSSL_LIB_CTX_METHOD evp_method_store_method = {
     evp_method_store_new,
     evp_method_store_free,
 };
 
 /* Data to be passed through ossl_method_construct() */
 struct evp_method_data_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     OSSL_METHOD_CONSTRUCT_METHOD *mcm;
     int operation_id;            /* For get_evp_method_from_store() */
     int name_id;                 /* For get_evp_method_from_store() */
@@ -59,7 +59,7 @@ struct evp_method_data_st {
 /*
  * Generic routines to fetch / create EVP methods with ossl_method_construct()
  */
-static void *alloc_tmp_evp_method_store(OPENSSL_CTX *ctx)
+static void *alloc_tmp_evp_method_store(OSSL_LIB_CTX *ctx)
 {
     return ossl_method_store_new(ctx);
 }
@@ -70,9 +70,9 @@ static void *alloc_tmp_evp_method_store(OPENSSL_CTX *ctx)
         ossl_method_store_free(store);
 }
 
-static OSSL_METHOD_STORE *get_evp_method_store(OPENSSL_CTX *libctx)
+static OSSL_METHOD_STORE *get_evp_method_store(OSSL_LIB_CTX *libctx)
 {
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_EVP_METHOD_STORE_INDEX,
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_EVP_METHOD_STORE_INDEX,
                                 &evp_method_store_method);
 }
 
@@ -95,7 +95,7 @@ static uint32_t evp_method_id(int name_id, unsigned int operation_id)
     return ((name_id << 8) & 0xFFFFFF00) | (operation_id & 0x000000FF);
 }
 
-static void *get_evp_method_from_store(OPENSSL_CTX *libctx, void *store,
+static void *get_evp_method_from_store(OSSL_LIB_CTX *libctx, void *store,
                                        void *data)
 {
     struct evp_method_data_st *methdata = data;
@@ -133,7 +133,7 @@ static void *get_evp_method_from_store(OPENSSL_CTX *libctx, void *store,
     return method;
 }
 
-static int put_evp_method_in_store(OPENSSL_CTX *libctx, void *store,
+static int put_evp_method_in_store(OSSL_LIB_CTX *libctx, void *store,
                                    void *method, const OSSL_PROVIDER *prov,
                                    int operation_id, const char *names,
                                    const char *propdef, void *data)
@@ -185,7 +185,7 @@ static void *construct_evp_method(const OSSL_ALGORITHM *algodef,
      * number.
      */
     struct evp_method_data_st *methdata = data;
-    OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
     int name_id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
@@ -215,21 +215,21 @@ static void destruct_evp_method(void *method, void *data)
     methdata->destruct_method(method);
 }
 
-static const char *libctx_descriptor(OPENSSL_CTX *libctx)
+static const char *libctx_descriptor(OSSL_LIB_CTX *libctx)
 {
 #ifdef FIPS_MODULE
     return "FIPS internal library context";
 #else
-    if (openssl_ctx_is_global_default(libctx))
+    if (ossl_lib_ctx_is_global_default(libctx))
         return "Global default library context";
-    if (openssl_ctx_is_default(libctx))
+    if (ossl_lib_ctx_is_default(libctx))
         return "Thread-local default library context";
     return "Non-default library context";
 #endif
 }
 
 static void *
-inner_evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
+inner_evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
                         int name_id, const char *name,
                         const char *properties,
                         void *(*new_method)(int name_id,
@@ -352,7 +352,7 @@ inner_evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
     return method;
 }
 
-void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
+void *evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
                         const char *name, const char *properties,
                         void *(*new_method)(int name_id,
                                             const OSSL_DISPATCH *fns,
@@ -372,7 +372,7 @@ void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
  * This is meant to be used when one method needs to fetch an associated
  * other method.
  */
-void *evp_generic_fetch_by_number(OPENSSL_CTX *libctx, int operation_id,
+void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
                                   int name_id, const char *properties,
                                   void *(*new_method)(int name_id,
                                                       const OSSL_DISPATCH *fns,
@@ -386,7 +386,7 @@ void *evp_generic_fetch_by_number(OPENSSL_CTX *libctx, int operation_id,
                                    free_method);
 }
 
-void evp_method_store_flush(OPENSSL_CTX *libctx)
+void evp_method_store_flush(OSSL_LIB_CTX *libctx)
 {
     OSSL_METHOD_STORE *store = get_evp_method_store(libctx);
 
@@ -394,7 +394,7 @@ void evp_method_store_flush(OPENSSL_CTX *libctx)
         ossl_method_store_flush_cache(store, 1);
 }
 
-static int evp_set_parsed_default_properties(OPENSSL_CTX *libctx,
+static int evp_set_parsed_default_properties(OSSL_LIB_CTX *libctx,
                                              OSSL_PROPERTY_LIST *def_prop,
                                              int loadconfig)
 {
@@ -412,7 +412,7 @@ static int evp_set_parsed_default_properties(OPENSSL_CTX *libctx,
     return 0;
 }
 
-int evp_set_default_properties_int(OPENSSL_CTX *libctx, const char *propq,
+int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig)
 {
     OSSL_PROPERTY_LIST *pl = NULL;
@@ -424,12 +424,12 @@ int evp_set_default_properties_int(OPENSSL_CTX *libctx, const char *propq,
     return evp_set_parsed_default_properties(libctx, pl, loadconfig);
 }
 
-int EVP_set_default_properties(OPENSSL_CTX *libctx, const char *propq)
+int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq)
 {
     return evp_set_default_properties_int(libctx, propq, 1);
 }
 
-static int evp_default_properties_merge(OPENSSL_CTX *libctx, const char *propq)
+static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, 1);
     OSSL_PROPERTY_LIST *pl1, *pl2;
@@ -451,7 +451,7 @@ static int evp_default_properties_merge(OPENSSL_CTX *libctx, const char *propq)
     return evp_set_parsed_default_properties(libctx, pl2, 0);
 }
 
-static int evp_default_property_is_enabled(OPENSSL_CTX *libctx,
+static int evp_default_property_is_enabled(OSSL_LIB_CTX *libctx,
                                            const char *prop_name)
 {
     OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, 1);
@@ -459,12 +459,12 @@ static int evp_default_property_is_enabled(OPENSSL_CTX *libctx,
     return plp != NULL && ossl_property_is_enabled(libctx, prop_name, *plp);
 }
 
-int EVP_default_properties_is_fips_enabled(OPENSSL_CTX *libctx)
+int EVP_default_properties_is_fips_enabled(OSSL_LIB_CTX *libctx)
 {
     return evp_default_property_is_enabled(libctx, "fips");
 }
 
-int EVP_default_properties_enable_fips(OPENSSL_CTX *libctx, int enable)
+int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable)
 {
     const char *query = (enable != 0) ? "fips=yes" : "-fips";
 
@@ -484,7 +484,7 @@ static void do_one(OSSL_PROVIDER *provider, const OSSL_ALGORITHM *algo,
                    int no_store, void *vdata)
 {
     struct do_all_data_st *data = vdata;
-    OPENSSL_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     int name_id = ossl_namemap_add_names(namemap, 0, algo->algorithm_names,
                                          NAME_SEPARATOR);
@@ -499,7 +499,7 @@ static void do_one(OSSL_PROVIDER *provider, const OSSL_ALGORITHM *algo,
     }
 }
 
-void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
+void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                         void (*user_fn)(void *method, void *arg),
                         void *user_arg,
                         void *(*new_method)(int name_id,
@@ -524,7 +524,7 @@ void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
 
 const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id)
 {
-    OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
     return ossl_namemap_num2name(namemap, name_id, 0);
@@ -536,7 +536,7 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
     /*
      * For a |prov| that is NULL, the library context will be NULL
      */
-    OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
     if (prov == NULL)
@@ -548,7 +548,7 @@ void evp_names_do_all(OSSL_PROVIDER *prov, int number,
                       void (*fn)(const char *name, void *data),
                       void *data)
 {
-    OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
     ossl_namemap_doall_names(namemap, number, fn, data);

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -73,7 +73,7 @@ static void *alloc_tmp_evp_method_store(OSSL_LIB_CTX *ctx)
 static OSSL_METHOD_STORE *get_evp_method_store(OSSL_LIB_CTX *libctx)
 {
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_EVP_METHOD_STORE_INDEX,
-                                &evp_method_store_method);
+                                 &evp_method_store_method);
 }
 
 /*

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -185,7 +185,7 @@ static void *construct_evp_method(const OSSL_ALGORITHM *algodef,
      * number.
      */
     struct evp_method_data_st *methdata = data;
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
     int name_id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
@@ -484,7 +484,7 @@ static void do_one(OSSL_PROVIDER *provider, const OSSL_ALGORITHM *algo,
                    int no_store, void *vdata)
 {
     struct do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     int name_id = ossl_namemap_add_names(namemap, 0, algo->algorithm_names,
                                          NAME_SEPARATOR);
@@ -524,7 +524,7 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
 
 const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id)
 {
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
     return ossl_namemap_num2name(namemap, name_id, 0);
@@ -536,7 +536,7 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
     /*
      * For a |prov| that is NULL, the library context will be NULL
      */
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
     if (prov == NULL)
@@ -548,7 +548,7 @@ void evp_names_do_all(OSSL_PROVIDER *prov, int number,
                       void (*fn)(const char *name, void *data),
                       void *data)
 {
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
     ossl_namemap_doall_names(namemap, number, fn, data);

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -232,21 +232,21 @@ int is_partially_overlapping(const void *ptr1, const void *ptr2, int len);
 #include <openssl/types.h>
 #include <openssl/core.h>
 
-void *evp_generic_fetch(OPENSSL_CTX *ctx, int operation_id,
+void *evp_generic_fetch(OSSL_LIB_CTX *ctx, int operation_id,
                         const char *name, const char *properties,
                         void *(*new_method)(int name_id,
                                             const OSSL_DISPATCH *fns,
                                             OSSL_PROVIDER *prov),
                         int (*up_ref_method)(void *),
                         void (*free_method)(void *));
-void *evp_generic_fetch_by_number(OPENSSL_CTX *ctx, int operation_id,
+void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
                                   int name_id, const char *properties,
                                   void *(*new_method)(int name_id,
                                                       const OSSL_DISPATCH *fns,
                                                       OSSL_PROVIDER *prov),
                                   int (*up_ref_method)(void *),
                                   void (*free_method)(void *));
-void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
+void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                         void (*user_fn)(void *method, void *arg),
                         void *user_arg,
                         void *(*new_method)(int name_id,
@@ -255,7 +255,7 @@ void evp_generic_do_all(OPENSSL_CTX *libctx, int operation_id,
                         void (*free_method)(void *));
 
 /* Internal fetchers for method types that are to be combined with others */
-EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OPENSSL_CTX *ctx, int name_id,
+EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OSSL_LIB_CTX *ctx, int name_id,
                                          const char *properties);
 
 /* Internal structure constructors for fetched methods */

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -18,7 +18,7 @@
 
 /* Extract a private key from a PKCS8 structure */
 
-EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OPENSSL_CTX *libctx,
+EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
                             const char *propq)
 {
     EVP_PKEY *pkey = NULL;

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -263,7 +263,7 @@ static void *evp_rand_from_dispatch(int name_id,
     return rand;
 }
 
-EVP_RAND *EVP_RAND_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+EVP_RAND *EVP_RAND_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                          const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_RAND, algorithm, properties,
@@ -447,7 +447,7 @@ const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand)
                ossl_provider_ctx(EVP_RAND_provider(rand)));
 }
 
-void EVP_RAND_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_RAND *rand, void *arg),
                               void *arg)
 {

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -166,7 +166,7 @@ OSSL_PROVIDER *EVP_KEYEXCH_provider(const EVP_KEYEXCH *exchange)
     return exchange->prov;
 }
 
-EVP_KEYEXCH *EVP_KEYEXCH_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_KEYEXCH *EVP_KEYEXCH_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYEXCH, algorithm, properties,
@@ -457,7 +457,7 @@ int EVP_KEYEXCH_is_a(const EVP_KEYEXCH *keyexch, const char *name)
     return evp_is_a(keyexch->prov, keyexch->name_id, NULL, name);
 }
 
-void EVP_KEYEXCH_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYEXCH *keyexch, void *arg),
                                  void *arg)
 {

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -147,7 +147,7 @@ static void *evp_kdf_from_dispatch(int name_id,
     return kdf;
 }
 
-EVP_KDF *EVP_KDF_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+EVP_KDF *EVP_KDF_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_KDF, algorithm, properties,
@@ -186,7 +186,7 @@ const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf)
     return kdf->settable_ctx_params(ossl_provider_ctx(EVP_KDF_provider(kdf)));
 }
 
-void EVP_KDF_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KDF *kdf, void *arg),
                              void *arg)
 {

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -321,7 +321,7 @@ OSSL_PROVIDER *EVP_KEM_provider(const EVP_KEM *kem)
     return kem->prov;
 }
 
-EVP_KEM *EVP_KEM_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_KEM *EVP_KEM_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEM, algorithm, properties,
@@ -340,7 +340,7 @@ int EVP_KEM_number(const EVP_KEM *kem)
     return kem->name_id;
 }
 
-void EVP_KEM_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KEM *kem, void *arg),
                              void *arg)
 {

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -197,7 +197,7 @@ static void *keymgmt_from_dispatch(int name_id,
     return keymgmt;
 }
 
-EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OPENSSL_CTX *ctx, int name_id,
+EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OSSL_LIB_CTX *ctx, int name_id,
                                          const char *properties)
 {
     return evp_generic_fetch_by_number(ctx,
@@ -207,7 +207,7 @@ EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OPENSSL_CTX *ctx, int name_id,
                                        (void (*)(void *))EVP_KEYMGMT_free);
 }
 
-EVP_KEYMGMT *EVP_KEYMGMT_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYMGMT, algorithm, properties,
@@ -259,7 +259,7 @@ int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name)
     return evp_is_a(keymgmt->prov, keymgmt->name_id, NULL, name);
 }
 
-void EVP_KEYMGMT_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
                                  void *arg)
 {

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -38,7 +38,7 @@ static const char *canon_mdname(const char *mdname)
 
 static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const EVP_MD *type, const char *mdname,
-                          OPENSSL_CTX *libctx, const char *props,
+                          OSSL_LIB_CTX *libctx, const char *props,
                           ENGINE *e, EVP_PKEY *pkey, int ver)
 {
     EVP_PKEY_CTX *locpctx = NULL;
@@ -311,7 +311,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
 }
 
 int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                          const char *mdname, OPENSSL_CTX *libctx,
+                          const char *mdname, OSSL_LIB_CTX *libctx,
                           const char *props, EVP_PKEY *pkey)
 {
     return do_sigver_init(ctx, pctx, NULL, mdname, libctx, props, NULL, pkey, 0);
@@ -324,7 +324,7 @@ int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
 }
 
 int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                            const char *mdname, OPENSSL_CTX *libctx,
+                            const char *mdname, OSSL_LIB_CTX *libctx,
                             const char *props, EVP_PKEY *pkey)
 {
     return do_sigver_init(ctx, pctx, NULL, mdname, libctx, props, NULL, pkey, 1);

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -149,7 +149,7 @@ static void *evp_mac_from_dispatch(int name_id,
     return mac;
 }
 
-EVP_MAC *EVP_MAC_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+EVP_MAC *EVP_MAC_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_MAC, algorithm, properties,
@@ -193,7 +193,7 @@ const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac)
     return mac->settable_ctx_params(ossl_provider_ctx(EVP_MAC_provider(mac)));
 }
 
-void EVP_MAC_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_MAC *mac, void *arg),
                              void *arg)
 {

--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -72,7 +72,7 @@ const EVP_CIPHER *EVP_get_cipherbyname(const char *name)
     return evp_get_cipherbyname_ex(NULL, name);
 }
 
-const EVP_CIPHER *evp_get_cipherbyname_ex(OPENSSL_CTX *libctx, const char *name)
+const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx, const char *name)
 {
     const EVP_CIPHER *cp;
     OSSL_NAMEMAP *namemap;
@@ -117,7 +117,7 @@ const EVP_MD *EVP_get_digestbyname(const char *name)
     return evp_get_digestbyname_ex(NULL, name);
 }
 
-const EVP_MD *evp_get_digestbyname_ex(OPENSSL_CTX *libctx, const char *name)
+const EVP_MD *evp_get_digestbyname_ex(OSSL_LIB_CTX *libctx, const char *name)
 {
     const EVP_MD *dp;
     OSSL_NAMEMAP *namemap;

--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -72,7 +72,8 @@ const EVP_CIPHER *EVP_get_cipherbyname(const char *name)
     return evp_get_cipherbyname_ex(NULL, name);
 }
 
-const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx, const char *name)
+const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx,
+                                          const char *name)
 {
     const EVP_CIPHER *cp;
     OSSL_NAMEMAP *namemap;

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -22,7 +22,7 @@
 int pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
                          const unsigned char *salt, int saltlen, int iter,
                          const EVP_MD *digest, int keylen, unsigned char *out,
-                         OPENSSL_CTX *libctx, const char *propq)
+                         OSSL_LIB_CTX *libctx, const char *propq)
 {
     const char *empty = "";
     int rv = 1, mode = 1;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -576,7 +576,8 @@ int EVP_PKEY_get_raw_public_key(const EVP_PKEY *pkey, unsigned char *pub,
 
 static EVP_PKEY *new_cmac_key_int(const unsigned char *priv, size_t len,
                                   const char *cipher_name,
-                                  const EVP_CIPHER *cipher, OSSL_LIB_CTX *libctx,
+                                  const EVP_CIPHER *cipher,
+                                  OSSL_LIB_CTX *libctx,
                                   const char *propq, ENGINE *e)
 {
 # ifndef OPENSSL_NO_CMAC

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1069,7 +1069,7 @@ int EVP_PKEY_can_sign(const EVP_PKEY *pkey)
         }
     } else {
         const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
         const char *supported_sig =
             pkey->keymgmt->query_operation_name != NULL
             ? pkey->keymgmt->query_operation_name(OSSL_OP_SIGNATURE)
@@ -1885,7 +1885,7 @@ int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src)
                  * that we are using.
                  */
                 OSSL_LIB_CTX *libctx =
-                    ossl_provider_library_context(keymgmt->prov);
+                    ossl_provider_libctx(keymgmt->prov);
                 EVP_PKEY_CTX *pctx =
                     EVP_PKEY_CTX_new_from_pkey(libctx, *dest, NULL);
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -335,7 +335,7 @@ int EVP_PKEY_eq(const EVP_PKEY *a, const EVP_PKEY *b)
 }
 
 
-static EVP_PKEY *new_raw_key_int(OPENSSL_CTX *libctx,
+static EVP_PKEY *new_raw_key_int(OSSL_LIB_CTX *libctx,
                                  const char *strtype,
                                  const char *propq,
                                  int nidtype,
@@ -450,7 +450,7 @@ static EVP_PKEY *new_raw_key_int(OPENSSL_CTX *libctx,
     return pkey;
 }
 
-EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OPENSSL_CTX *libctx,
+EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OSSL_LIB_CTX *libctx,
                                           const char *keytype,
                                           const char *propq,
                                           const unsigned char *priv, size_t len)
@@ -466,7 +466,7 @@ EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *e,
     return new_raw_key_int(NULL, NULL, NULL, type, e, priv, len, 1);
 }
 
-EVP_PKEY *EVP_PKEY_new_raw_public_key_ex(OPENSSL_CTX *libctx,
+EVP_PKEY *EVP_PKEY_new_raw_public_key_ex(OSSL_LIB_CTX *libctx,
                                          const char *keytype, const char *propq,
                                          const unsigned char *pub, size_t len)
 {
@@ -576,7 +576,7 @@ int EVP_PKEY_get_raw_public_key(const EVP_PKEY *pkey, unsigned char *pub,
 
 static EVP_PKEY *new_cmac_key_int(const unsigned char *priv, size_t len,
                                   const char *cipher_name,
-                                  const EVP_CIPHER *cipher, OPENSSL_CTX *libctx,
+                                  const EVP_CIPHER *cipher, OSSL_LIB_CTX *libctx,
                                   const char *propq, ENGINE *e)
 {
 # ifndef OPENSSL_NO_CMAC
@@ -634,7 +634,7 @@ static EVP_PKEY *new_cmac_key_int(const unsigned char *priv, size_t len,
 }
 
 EVP_PKEY *EVP_PKEY_new_CMAC_key_ex(const unsigned char *priv, size_t len,
-                                   const char *cipher_name, OPENSSL_CTX *libctx,
+                                   const char *cipher_name, OSSL_LIB_CTX *libctx,
                                    const char *propq)
 {
     return new_cmac_key_int(priv, len, cipher_name, NULL, libctx, propq, NULL);
@@ -1069,7 +1069,7 @@ int EVP_PKEY_can_sign(const EVP_PKEY *pkey)
         }
     } else {
         const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
-        OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
         const char *supported_sig =
             pkey->keymgmt->query_operation_name != NULL
             ? pkey->keymgmt->query_operation_name(OSSL_OP_SIGNATURE)
@@ -1171,7 +1171,7 @@ static int unsup_alg(BIO *out, const EVP_PKEY *pkey, int indent,
 
 static int print_pkey(const EVP_PKEY *pkey, BIO *out, int indent,
                       int selection /* For provided encoding */,
-                      OPENSSL_CTX *libctx /* For provided encoding */,
+                      OSSL_LIB_CTX *libctx /* For provided encoding */,
                       const char *propquery /* For provided encoding */,
                       int (*legacy_print)(BIO *out, const EVP_PKEY *pkey,
                                           int indent, ASN1_PCTX *pctx),
@@ -1687,7 +1687,7 @@ int EVP_PKEY_size(const EVP_PKEY *pkey)
     return size;
 }
 
-void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
+void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
                                   EVP_KEYMGMT **keymgmt,
                                   const char *propquery)
 {
@@ -1884,7 +1884,7 @@ int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src)
                  * We perform the export in the same libctx as the keymgmt
                  * that we are using.
                  */
-                OPENSSL_CTX *libctx =
+                OSSL_LIB_CTX *libctx =
                     ossl_provider_library_context(keymgmt->prov);
                 EVP_PKEY_CTX *pctx =
                     EVP_PKEY_CTX_new_from_pkey(libctx, *dest, NULL);

--- a/crypto/evp/p_sign.c
+++ b/crypto/evp/p_sign.c
@@ -15,7 +15,7 @@
 #include "crypto/evp.h"
 
 int EVP_SignFinal_ex(EVP_MD_CTX *ctx, unsigned char *sigret,
-                     unsigned int *siglen, EVP_PKEY *pkey, OPENSSL_CTX *libctx,
+                     unsigned int *siglen, EVP_PKEY *pkey, OSSL_LIB_CTX *libctx,
                      const char *propq)
 {
     unsigned char m[EVP_MAX_MD_SIZE];

--- a/crypto/evp/p_verify.c
+++ b/crypto/evp/p_verify.c
@@ -15,7 +15,7 @@
 #include "crypto/evp.h"
 
 int EVP_VerifyFinal_ex(EVP_MD_CTX *ctx, const unsigned char *sigbuf,
-                       unsigned int siglen, EVP_PKEY *pkey, OPENSSL_CTX *libctx,
+                       unsigned int siglen, EVP_PKEY *pkey, OSSL_LIB_CTX *libctx,
                        const char *propq)
 {
     unsigned char m[EVP_MAX_MD_SIZE];

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -62,7 +62,7 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     if (maxmem == 0)
         maxmem = SCRYPT_MAX_MEM;
 
-    /* Use OPENSSL_CTX_set0_default() if you need a library context */
+    /* Use OSSL_LIB_CTX_set0_default() if you need a library context */
     kdf = EVP_KDF_fetch(NULL, OSSL_KDF_NAME_SCRYPT, NULL);
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -172,7 +172,7 @@ static int get_legacy_alg_type_from_keymgmt(const EVP_KEYMGMT *keymgmt)
 }
 #endif /* FIPS_MODULE */
 
-static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
+static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
                                  EVP_PKEY *pkey, ENGINE *e,
                                  const char *keytype, const char *propquery,
                                  int id)
@@ -338,14 +338,14 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
 
 /*- All methods below can also be used in FIPS_MODULE */
 
-EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OPENSSL_CTX *libctx,
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OSSL_LIB_CTX *libctx,
                                          const char *name,
                                          const char *propquery)
 {
     return int_ctx_new(libctx, NULL, NULL, name, propquery, -1);
 }
 
-EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OPENSSL_CTX *libctx, EVP_PKEY *pkey,
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OSSL_LIB_CTX *libctx, EVP_PKEY *pkey,
                                          const char *propquery)
 {
     return int_ctx_new(libctx, pkey, NULL, NULL, propquery, -1);
@@ -1762,7 +1762,7 @@ int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx)
     return ret;
 }
 
-OPENSSL_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx)
+OSSL_LIB_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx)
 {
     return ctx->libctx;
 }

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -298,7 +298,7 @@ OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature)
     return signature->prov;
 }
 
-EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                    const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
@@ -317,7 +317,7 @@ int EVP_SIGNATURE_number(const EVP_SIGNATURE *signature)
     return signature->name_id;
 }
 
-void EVP_SIGNATURE_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(EVP_SIGNATURE *signature,
                                               void *arg),
                                    void *arg)

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -10,9 +10,9 @@
 #include "crypto/cryptlib.h"
 #include "internal/thread_once.h"
 
-int do_ex_data_init(OPENSSL_CTX *ctx)
+int do_ex_data_init(OSSL_LIB_CTX *ctx)
 {
-    OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ctx);
+    OSSL_EX_DATA_GLOBAL *global = ossl_lib_ctx_get_ex_data_global(ctx);
 
     if (global == NULL)
         return 0;
@@ -59,10 +59,10 @@ static void cleanup_cb(EX_CALLBACK *funcs)
  * called under potential race-conditions anyway (it's for program shutdown
  * after all).
  */
-void crypto_cleanup_all_ex_data_int(OPENSSL_CTX *ctx)
+void crypto_cleanup_all_ex_data_int(OSSL_LIB_CTX *ctx)
 {
     int i;
-    OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ctx);
+    OSSL_EX_DATA_GLOBAL *global = ossl_lib_ctx_get_ex_data_global(ctx);
 
     if (global == NULL)
         return;
@@ -100,12 +100,12 @@ static int dummy_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
     return 1;
 }
 
-int crypto_free_ex_index_ex(OPENSSL_CTX *ctx, int class_index, int idx)
+int crypto_free_ex_index_ex(OSSL_LIB_CTX *ctx, int class_index, int idx)
 {
     EX_CALLBACKS *ip;
     EX_CALLBACK *a;
     int toret = 0;
-    OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ctx);
+    OSSL_EX_DATA_GLOBAL *global = ossl_lib_ctx_get_ex_data_global(ctx);
 
     if (global == NULL)
         return 0;
@@ -136,7 +136,7 @@ int CRYPTO_free_ex_index(int class_index, int idx)
 /*
  * Register a new index.
  */
-int crypto_get_ex_new_index_ex(OPENSSL_CTX *ctx, int class_index, long argl,
+int crypto_get_ex_new_index_ex(OSSL_LIB_CTX *ctx, int class_index, long argl,
                                void *argp, CRYPTO_EX_new *new_func,
                                CRYPTO_EX_dup *dup_func,
                                CRYPTO_EX_free *free_func)
@@ -144,7 +144,7 @@ int crypto_get_ex_new_index_ex(OPENSSL_CTX *ctx, int class_index, long argl,
     int toret = -1;
     EX_CALLBACK *a;
     EX_CALLBACKS *ip;
-    OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ctx);
+    OSSL_EX_DATA_GLOBAL *global = ossl_lib_ctx_get_ex_data_global(ctx);
 
     if (global == NULL)
         return -1;
@@ -203,7 +203,7 @@ int CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
  * in the lock, then using them outside the lock. Note this only applies
  * to the global "ex_data" state (ie. class definitions), not 'ad' itself.
  */
-int crypto_new_ex_data_ex(OPENSSL_CTX *ctx, int class_index, void *obj,
+int crypto_new_ex_data_ex(OSSL_LIB_CTX *ctx, int class_index, void *obj,
                           CRYPTO_EX_DATA *ad)
 {
     int mx, i;
@@ -211,7 +211,7 @@ int crypto_new_ex_data_ex(OPENSSL_CTX *ctx, int class_index, void *obj,
     EX_CALLBACK **storage = NULL;
     EX_CALLBACK *stack[10];
     EX_CALLBACKS *ip;
-    OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ctx);
+    OSSL_EX_DATA_GLOBAL *global = ossl_lib_ctx_get_ex_data_global(ctx);
 
     if (global == NULL)
         return 0;
@@ -275,7 +275,7 @@ int CRYPTO_dup_ex_data(int class_index, CRYPTO_EX_DATA *to,
         /* Nothing to copy over */
         return 1;
 
-    global = openssl_ctx_get_ex_data_global(from->ctx);
+    global = ossl_lib_ctx_get_ex_data_global(from->ctx);
     if (global == NULL)
         return 0;
 
@@ -342,7 +342,7 @@ void CRYPTO_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
     EX_CALLBACK *f;
     EX_CALLBACK *stack[10];
     EX_CALLBACK **storage = NULL;
-    OSSL_EX_DATA_GLOBAL *global = openssl_ctx_get_ex_data_global(ad->ctx);
+    OSSL_EX_DATA_GLOBAL *global = ossl_lib_ctx_get_ex_data_global(ad->ctx);
 
     if (global == NULL)
         goto err;
@@ -402,7 +402,7 @@ int CRYPTO_alloc_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad,
     if (curval != NULL)
         return 1;
 
-    global = openssl_ctx_get_ex_data_global(ad->ctx);
+    global = ossl_lib_ctx_get_ex_data_global(ad->ctx);
     if (global == NULL)
         return 0;
 
@@ -464,7 +464,7 @@ void *CRYPTO_get_ex_data(const CRYPTO_EX_DATA *ad, int idx)
     return sk_void_value(ad->sk, idx);
 }
 
-OPENSSL_CTX *crypto_ex_data_get_openssl_ctx(const CRYPTO_EX_DATA *ad)
+OSSL_LIB_CTX *crypto_ex_data_get_ossl_lib_ctx(const CRYPTO_EX_DATA *ad)
 {
     return ad->ctx;
 }

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -320,7 +320,7 @@ static int generate_q_fips186_4(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
     unsigned char md[EVP_MAX_MD_SIZE];
     int mdsize = EVP_MD_size(evpmd);
     unsigned char *pmd;
-    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_libctx(ctx);
 
     /* find q */
     for (;;) {
@@ -391,7 +391,7 @@ static int generate_q_fips186_2(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
     unsigned char buf2[EVP_MAX_MD_SIZE];
     unsigned char md[EVP_MAX_MD_SIZE];
     int i, r, ret = 0, m = *retm;
-    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_libctx(ctx);
 
     /* find q */
     for (;;) {

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -320,7 +320,7 @@ static int generate_q_fips186_4(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
     unsigned char md[EVP_MAX_MD_SIZE];
     int mdsize = EVP_MD_size(evpmd);
     unsigned char *pmd;
-    OPENSSL_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
 
     /* find q */
     for (;;) {
@@ -391,7 +391,7 @@ static int generate_q_fips186_2(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
     unsigned char buf2[EVP_MAX_MD_SIZE];
     unsigned char md[EVP_MAX_MD_SIZE];
     int i, r, ret = 0, m = *retm;
-    OPENSSL_CTX *libctx = bn_get_lib_ctx(ctx);
+    OSSL_LIB_CTX *libctx = bn_get_lib_ctx(ctx);
 
     /* find q */
     for (;;) {
@@ -510,7 +510,7 @@ static const char *default_mdname(size_t N)
  *   - FFC_PARAM_RET_STATUS_UNVERIFIABLE_G if the validation of G succeeded,
  *     but G is unverifiable.
  */
-int ossl_ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_4_gen_verify(OSSL_LIB_CTX *libctx,
                                          FFC_PARAMS *params, int mode, int type,
                                          size_t L, size_t N, int *res,
                                          BN_GENCB *cb)
@@ -803,7 +803,7 @@ err:
 }
 
 /* Note this function is only used for verification in fips mode */
-int ossl_ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_2_gen_verify(OSSL_LIB_CTX *libctx,
                                          FFC_PARAMS *params, int mode, int type,
                                          size_t L, size_t N, int *res,
                                          BN_GENCB *cb)
@@ -1033,7 +1033,7 @@ err:
     return ok;
 }
 
-int ossl_ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+int ossl_ffc_params_FIPS186_4_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
                                        int *res, BN_GENCB *cb)
 {
@@ -1043,7 +1043,7 @@ int ossl_ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
 }
 
 /* This should no longer be used in FIPS mode */
-int ossl_ffc_params_FIPS186_2_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+int ossl_ffc_params_FIPS186_2_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
                                        int *res, BN_GENCB *cb)
 {

--- a/crypto/ffc/ffc_params_validate.c
+++ b/crypto/ffc/ffc_params_validate.c
@@ -45,7 +45,7 @@ int ossl_ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
     return 1;
 }
 
-int ossl_ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_4_validate(OSSL_LIB_CTX *libctx,
                                        const FFC_PARAMS *params, int type,
                                        int *res, BN_GENCB *cb)
 {
@@ -63,7 +63,7 @@ int ossl_ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx,
 }
 
 /* This may be used in FIPS mode to validate deprecated FIPS-186-2 Params */
-int ossl_ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_2_validate(OSSL_LIB_CTX *libctx,
                                        const FFC_PARAMS *params, int type,
                                        int *res, BN_GENCB *cb)
 {
@@ -88,7 +88,7 @@ int ossl_ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx,
  * extra parameters such as the digest and seed, which may not be available for
  * this test.
  */
-int ossl_ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+int ossl_ffc_params_simple_validate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                     int type)
 {
     int ret, res = 0;

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -339,7 +339,7 @@ void OPENSSL_cleanup(void)
 
     /*
      * TODO(3.0): This function needs looking at with a view to moving most/all
-     * of this into onfree handlers in OPENSSL_CTX.
+     * of this into onfree handlers in OSSL_LIB_CTX.
      */
 
     /* If we've not been inited then no need to deinit */
@@ -396,7 +396,7 @@ void OPENSSL_cleanup(void)
      * - rand_cleanup_int could call an ENGINE's RAND cleanup function so
      * must be called before engine_cleanup_int()
      * - ENGINEs use CRYPTO_EX_DATA and therefore, must be cleaned up
-     * before the ex data handlers are wiped during default openssl_ctx deinit.
+     * before the ex data handlers are wiped during default ossl_lib_ctx deinit.
      * - conf_modules_free_int() can end up in ENGINE code so must be called
      * before engine_cleanup_int()
      * - ENGINEs and additional EVP algorithms might use added OIDs names so
@@ -418,8 +418,8 @@ void OPENSSL_cleanup(void)
     ossl_store_cleanup_int();
 #endif
 
-    OSSL_TRACE(INIT, "OPENSSL_cleanup: openssl_ctx_default_deinit()\n");
-    openssl_ctx_default_deinit();
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: ossl_lib_ctx_default_deinit()\n");
+    ossl_lib_ctx_default_deinit();
 
     ossl_cleanup_thread();
 
@@ -458,7 +458,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
 {
     /*
      * TODO(3.0): This function needs looking at with a view to moving most/all
-     * of this into OPENSSL_CTX.
+     * of this into OSSL_LIB_CTX.
      */
 
     if (stopped) {

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -213,7 +213,7 @@ void OPENSSL_thread_stop_ex(OSSL_LIB_CTX *ctx)
     ctx = ossl_lib_ctx_get_concrete(ctx);
     /*
      * TODO(3.0). It would be nice if we could figure out a way to do this on
-     * all threads that have used the OSSL_LIB_CTX when the OSSL_LIB_CTX is freed.
+     * all threads that have used the OSSL_LIB_CTX when the context is freed.
      * This is currently not possible due to the use of thread local variables.
      */
     ossl_ctx_thread_stop(ctx);
@@ -284,7 +284,7 @@ void ossl_ctx_thread_stop(void *arg)
     OSSL_LIB_CTX *ctx = arg;
     CRYPTO_THREAD_LOCAL *local
         = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_THREAD_EVENT_HANDLER_INDEX,
-                               &thread_event_ossl_ctx_method);
+                                &thread_event_ossl_ctx_method);
 
     if (local == NULL)
         return;
@@ -333,12 +333,12 @@ int ossl_init_thread_start(const void *index, void *arg,
 
     /*
      * In FIPS mode the list of THREAD_EVENT_HANDLERs is unique per combination
-     * of OSSL_LIB_CTX and thread. This is because in FIPS mode each OSSL_LIB_CTX
-     * gets informed about thread stop events individually.
+     * of OSSL_LIB_CTX and thread. This is because in FIPS mode each
+     * OSSL_LIB_CTX gets informed about thread stop events individually.
      */
     CRYPTO_THREAD_LOCAL *local
         = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_THREAD_EVENT_HANDLER_INDEX,
-                               &thread_event_ossl_ctx_method);
+                                &thread_event_ossl_ctx_method);
 #else
     /*
      * Outside of FIPS mode the list of THREAD_EVENT_HANDLERs is unique per

--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -142,7 +142,7 @@ __owur static ossl_inline int siv128_do_encrypt(EVP_CIPHER_CTX *ctx, unsigned ch
  */
 SIV128_CONTEXT *CRYPTO_siv128_new(const unsigned char *key, int klen,
                                   EVP_CIPHER *cbc, EVP_CIPHER *ctr,
-                                  OPENSSL_CTX *libctx, const char *propq)
+                                  OSSL_LIB_CTX *libctx, const char *propq)
 {
     SIV128_CONTEXT *ctx;
     int ret;
@@ -162,7 +162,7 @@ SIV128_CONTEXT *CRYPTO_siv128_new(const unsigned char *key, int klen,
  */
 int CRYPTO_siv128_init(SIV128_CONTEXT *ctx, const unsigned char *key, int klen,
                        const EVP_CIPHER *cbc, const EVP_CIPHER *ctr,
-                       OPENSSL_CTX *libctx, const char *propq)
+                       OSSL_LIB_CTX *libctx, const char *propq)
 {
     static const unsigned char zero[SIV_LEN] = { 0 };
     size_t out_len = SIV_LEN;

--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -253,7 +253,7 @@ int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert)
 }
 
 int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
-                              OPENSSL_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx, const char *propq)
 {
     ASN1_OCTET_STRING *byKey = NULL;
     unsigned char md[SHA_DIGEST_LENGTH];
@@ -290,7 +290,7 @@ int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert)
     return OCSP_RESPID_set_by_key_ex(respid, cert, NULL, NULL);
 }
 
-int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OPENSSL_CTX *libctx,
+int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
                          const char *propq)
 {
     EVP_MD *sha1 = NULL;

--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -26,7 +26,7 @@
 #ifndef OPENSSL_NO_STDIO
 STACK_OF(X509_INFO)
 *PEM_X509_INFO_read_ex(FILE *fp, STACK_OF(X509_INFO) *sk, pem_password_cb *cb,
-                       void *u, OPENSSL_CTX *libctx, const char *propq)
+                       void *u, OSSL_LIB_CTX *libctx, const char *propq)
 {
     BIO *b;
     STACK_OF(X509_INFO) *ret;
@@ -50,7 +50,7 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read(FILE *fp, STACK_OF(X509_INFO) *sk,
 
 STACK_OF(X509_INFO)
 *PEM_X509_INFO_read_bio_ex(BIO *bp, STACK_OF(X509_INFO) *sk,
-                           pem_password_cb *cb, void *u, OPENSSL_CTX *libctx,
+                           pem_password_cb *cb, void *u, OSSL_LIB_CTX *libctx,
                            const char *propq)
 {
     X509_INFO *xi = NULL;

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -22,14 +22,14 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder,
                       int nid, const EVP_CIPHER *enc,
                       const char *kstr, int klen,
                       pem_password_cb *cb, void *u,
-                      OPENSSL_CTX *libctx, const char *propq);
+                      OSSL_LIB_CTX *libctx, const char *propq);
 
 #ifndef OPENSSL_NO_STDIO
 static int do_pk8pkey_fp(FILE *bp, const EVP_PKEY *x, int isder,
                          int nid, const EVP_CIPHER *enc,
                          const char *kstr, int klen,
                          pem_password_cb *cb, void *u,
-                         OPENSSL_CTX *libctx, const char *propq);
+                         OSSL_LIB_CTX *libctx, const char *propq);
 #endif
 /*
  * These functions write a private key in PKCS#8 format: it is a "drop in"
@@ -69,7 +69,7 @@ int i2d_PKCS8PrivateKey_nid_bio(BIO *bp, const EVP_PKEY *x, int nid,
 static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                       const EVP_CIPHER *enc, const char *kstr, int klen,
                       pem_password_cb *cb, void *u,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ret = 0;
     const char *outtype = isder ? "DER" : "PEM";
@@ -230,7 +230,7 @@ int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc
 static int do_pk8pkey_fp(FILE *fp, const EVP_PKEY *x, int isder, int nid,
                          const EVP_CIPHER *enc, const char *kstr, int klen,
                          pem_password_cb *cb, void *u,
-                         OPENSSL_CTX *libctx, const char *propq)
+                         OSSL_LIB_CTX *libctx, const char *propq)
 {
     BIO *bp;
     int ret;

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -31,7 +31,7 @@ int pem_check_suffix(const char *pem_str, const char *suffix);
 
 static EVP_PKEY *pem_read_bio_key(BIO *bp, EVP_PKEY **x,
                                   pem_password_cb *cb, void *u,
-                                  OPENSSL_CTX *libctx, const char *propq,
+                                  OSSL_LIB_CTX *libctx, const char *propq,
                                   int expected_store_info_type,
                                   int try_secure)
 {
@@ -101,7 +101,7 @@ static EVP_PKEY *pem_read_bio_key(BIO *bp, EVP_PKEY **x,
 
 EVP_PKEY *PEM_read_bio_PUBKEY_ex(BIO *bp, EVP_PKEY **x,
                                  pem_password_cb *cb, void *u,
-                                 OPENSSL_CTX *libctx, const char *propq)
+                                 OSSL_LIB_CTX *libctx, const char *propq)
 {
     return pem_read_bio_key(bp, x, cb, u, libctx, propq,
                             OSSL_STORE_INFO_PUBKEY, 0);
@@ -116,7 +116,7 @@ EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
 #ifndef OPENSSL_NO_STDIO
 EVP_PKEY *PEM_read_PUBKEY_ex(FILE *fp, EVP_PKEY **x,
                              pem_password_cb *cb, void *u,
-                             OPENSSL_CTX *libctx, const char *propq)
+                             OSSL_LIB_CTX *libctx, const char *propq)
 {
     BIO *b;
     EVP_PKEY *ret;
@@ -139,7 +139,7 @@ EVP_PKEY *PEM_read_PUBKEY(FILE *fp, EVP_PKEY **x, pem_password_cb *cb, void *u)
 
 EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x,
                                      pem_password_cb *cb, void *u,
-                                     OPENSSL_CTX *libctx, const char *propq)
+                                     OSSL_LIB_CTX *libctx, const char *propq)
 {
     return pem_read_bio_key(bp, x, cb, u, libctx, propq,
                             OSSL_STORE_INFO_PKEY, 1);
@@ -198,7 +198,7 @@ int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
 }
 
 EVP_PKEY *PEM_read_bio_Parameters_ex(BIO *bp, EVP_PKEY **x,
-                                     OPENSSL_CTX *libctx, const char *propq)
+                                     OSSL_LIB_CTX *libctx, const char *propq)
 {
     return pem_read_bio_key(bp, x, NULL, NULL, libctx, propq,
                             OSSL_STORE_INFO_PARAMS, 0);
@@ -227,7 +227,7 @@ PEM_write_fnsig(Parameters, EVP_PKEY, BIO, write_bio)
 
 #ifndef OPENSSL_NO_STDIO
 EVP_PKEY *PEM_read_PrivateKey_ex(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
-                                 void *u, OPENSSL_CTX *libctx,
+                                 void *u, OSSL_LIB_CTX *libctx,
                                  const char *propq)
 {
     BIO *b;

--- a/crypto/pkcs12/p12_key.c
+++ b/crypto/pkcs12/p12_key.c
@@ -74,7 +74,7 @@ int PKCS12_key_gen_uni(unsigned char *pass, int passlen, unsigned char *salt,
      * The parameter query isn't available but the library context can be
      * extracted from the passed digest.
      */
-    kdf = EVP_KDF_fetch(ossl_provider_library_context(EVP_MD_provider(md_type)),
+    kdf = EVP_KDF_fetch(ossl_provider_libctx(EVP_MD_provider(md_type)),
                         "PKCS12KDF", NULL);
     if (kdf == NULL)
         return 0;

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -83,7 +83,7 @@ PKCS7 *PKCS7_new(void)
     return (PKCS7 *)ASN1_item_new(ASN1_ITEM_rptr(PKCS7));
 }
 
-PKCS7 *PKCS7_new_ex(OPENSSL_CTX *libctx, const char *propq)
+PKCS7 *PKCS7_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     PKCS7 *pkcs7 = PKCS7_new();
 

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -432,7 +432,7 @@ const PKCS7_CTX *pkcs7_get0_ctx(const PKCS7 *p7)
     return p7 != NULL ? &p7->ctx : NULL;
 }
 
-OPENSSL_CTX *pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx)
+OSSL_LIB_CTX *pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx)
 {
     return ctx != NULL ? ctx->libctx : NULL;
 }

--- a/crypto/pkcs7/pk7_local.h
+++ b/crypto/pkcs7/pk7_local.h
@@ -10,5 +10,5 @@
 #include "crypto/pkcs7.h"
 
 const PKCS7_CTX *pkcs7_get0_ctx(const PKCS7 *p7);
-OPENSSL_CTX *pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx);
+OSSL_LIB_CTX *pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx);
 const char *pkcs7_ctx_get0_propq(const PKCS7_CTX *ctx);

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -21,7 +21,7 @@
 static int pkcs7_copy_existing_digest(PKCS7 *p7, PKCS7_SIGNER_INFO *si);
 
 PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
-                     BIO *data, int flags, OPENSSL_CTX *libctx,
+                     BIO *data, int flags, OSSL_LIB_CTX *libctx,
                      const char *propq)
 {
     PKCS7 *p7;
@@ -445,7 +445,7 @@ STACK_OF(X509) *PKCS7_get0_signers(PKCS7 *p7, STACK_OF(X509) *certs,
 
 PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
                         const EVP_CIPHER *cipher, int flags,
-                        OPENSSL_CTX *libctx, const char *propq)
+                        OSSL_LIB_CTX *libctx, const char *propq)
 {
     PKCS7 *p7;
     BIO *p7bio = NULL;

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -71,8 +71,9 @@ OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop)
     PROPERTY_DEFN_ELEM elem, *r;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
-    property_defns = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
-                                          &property_defns_method);
+    property_defns = ossl_lib_ctx_get_data(ctx,
+                                           OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
+                                           &property_defns_method);
     if (property_defns == NULL)
         return NULL;
 
@@ -88,8 +89,9 @@ int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
     size_t len;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
-    property_defns = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
-                                          &property_defns_method);
+    property_defns = ossl_lib_ctx_get_data(ctx,
+                                           OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
+                                           &property_defns_method);
     if (property_defns == NULL)
         return 0;
 

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -57,21 +57,21 @@ static void property_defns_free(void *vproperty_defns)
     }
 }
 
-static void *property_defns_new(OPENSSL_CTX *ctx) {
+static void *property_defns_new(OSSL_LIB_CTX *ctx) {
     return lh_PROPERTY_DEFN_ELEM_new(&property_defn_hash, &property_defn_cmp);
 }
 
-static const OPENSSL_CTX_METHOD property_defns_method = {
+static const OSSL_LIB_CTX_METHOD property_defns_method = {
     property_defns_new,
     property_defns_free,
 };
 
-OSSL_PROPERTY_LIST *ossl_prop_defn_get(OPENSSL_CTX *ctx, const char *prop)
+OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop)
 {
     PROPERTY_DEFN_ELEM elem, *r;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
-    property_defns = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_DEFN_INDEX,
+    property_defns = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
                                           &property_defns_method);
     if (property_defns == NULL)
         return NULL;
@@ -81,14 +81,14 @@ OSSL_PROPERTY_LIST *ossl_prop_defn_get(OPENSSL_CTX *ctx, const char *prop)
     return r != NULL ? r->defn : NULL;
 }
 
-int ossl_prop_defn_set(OPENSSL_CTX *ctx, const char *prop,
+int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
                        OSSL_PROPERTY_LIST *pl)
 {
     PROPERTY_DEFN_ELEM elem, *old, *p = NULL;
     size_t len;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
-    property_defns = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_DEFN_INDEX,
+    property_defns = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
                                           &property_defns_method);
     if (property_defns == NULL)
         return 0;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -57,7 +57,7 @@ typedef struct {
 } ALGORITHM;
 
 struct ossl_method_store_st {
-    OPENSSL_CTX *ctx;
+    OSSL_LIB_CTX *ctx;
     size_t nelem;
     SPARSE_ARRAY_OF(ALGORITHM) *algs;
     int need_flush;
@@ -85,25 +85,25 @@ static void ossl_ctx_global_properties_free(void *vstore)
     }
 }
 
-static void *ossl_ctx_global_properties_new(OPENSSL_CTX *ctx)
+static void *ossl_ctx_global_properties_new(OSSL_LIB_CTX *ctx)
 {
     return OPENSSL_zalloc(sizeof(OSSL_PROPERTY_LIST **));
 }
 
 
-static const OPENSSL_CTX_METHOD ossl_ctx_global_properties_method = {
+static const OSSL_LIB_CTX_METHOD ossl_ctx_global_properties_method = {
     ossl_ctx_global_properties_new,
     ossl_ctx_global_properties_free,
 };
 
-OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OPENSSL_CTX *libctx,
+OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
                                                 int loadconfig)
 {
 #ifndef FIPS_MODULE
     if (loadconfig && !OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
         return NULL;
 #endif
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_GLOBAL_PROPERTIES,
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
                                 &ossl_ctx_global_properties_method);
 }
 
@@ -169,10 +169,10 @@ static void alg_cleanup(ossl_uintmax_t idx, ALGORITHM *a)
 }
 
 /*
- * The OPENSSL_CTX param here allows access to underlying property data needed
+ * The OSSL_LIB_CTX param here allows access to underlying property data needed
  * for computation
  */
-OSSL_METHOD_STORE *ossl_method_store_new(OPENSSL_CTX *ctx)
+OSSL_METHOD_STORE *ossl_method_store_new(OSSL_LIB_CTX *ctx)
 {
     OSSL_METHOD_STORE *res;
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -104,7 +104,7 @@ OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
         return NULL;
 #endif
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
-                                &ossl_ctx_global_properties_method);
+                                 &ossl_ctx_global_properties_method);
 }
 
 static int ossl_method_up_ref(METHOD *method)

--- a/crypto/property/property_local.h
+++ b/crypto/property/property_local.h
@@ -14,9 +14,9 @@
 typedef int OSSL_PROPERTY_IDX;
 
 /* Property string functions */
-OSSL_PROPERTY_IDX ossl_property_name(OPENSSL_CTX *ctx, const char *s,
+OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
                                      int create);
-OSSL_PROPERTY_IDX ossl_property_value(OPENSSL_CTX *ctx, const char *s,
+OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
                                       int create);
 
 /* Property list functions */
@@ -24,8 +24,8 @@ void ossl_property_free(OSSL_PROPERTY_LIST *p);
 int ossl_property_has_optional(const OSSL_PROPERTY_LIST *query);
 
 /* Property definition cache functions */
-OSSL_PROPERTY_LIST *ossl_prop_defn_get(OPENSSL_CTX *ctx, const char *prop);
-int ossl_prop_defn_set(OPENSSL_CTX *ctx, const char *prop,
+OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop);
+int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
                        OSSL_PROPERTY_LIST *pl);
 
 /* Property cache lock / unlock */

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -80,7 +80,7 @@ static int match(const char *t[], const char m[], size_t m_len)
     return 0;
 }
 
-static int parse_name(OPENSSL_CTX *ctx, const char *t[], int create,
+static int parse_name(OSSL_LIB_CTX *ctx, const char *t[], int create,
                       OSSL_PROPERTY_IDX *idx)
 {
     char name[100];
@@ -187,7 +187,7 @@ static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
     return 1;
 }
 
-static int parse_string(OPENSSL_CTX *ctx, const char *t[], char delim,
+static int parse_string(OSSL_LIB_CTX *ctx, const char *t[], char delim,
                         PROPERTY_DEFINITION *res, const int create)
 {
     char v[1000];
@@ -218,7 +218,7 @@ static int parse_string(OPENSSL_CTX *ctx, const char *t[], char delim,
     return !err;
 }
 
-static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
+static int parse_unquoted(OSSL_LIB_CTX *ctx, const char *t[],
                           PROPERTY_DEFINITION *res, const int create)
 {
     char v[1000];
@@ -251,7 +251,7 @@ static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
     return !err;
 }
 
-static int parse_value(OPENSSL_CTX *ctx, const char *t[],
+static int parse_value(OSSL_LIB_CTX *ctx, const char *t[],
                        PROPERTY_DEFINITION *res, int create)
 {
     const char *s = *t;
@@ -326,7 +326,7 @@ static OSSL_PROPERTY_LIST *stack_to_property_list(STACK_OF(PROPERTY_DEFINITION)
     return r;
 }
 
-OSSL_PROPERTY_LIST *ossl_parse_property(OPENSSL_CTX *ctx, const char *defn)
+OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn)
 {
     PROPERTY_DEFINITION *prop = NULL;
     OSSL_PROPERTY_LIST *res = NULL;
@@ -385,7 +385,7 @@ err:
     return res;
 }
 
-OSSL_PROPERTY_LIST *ossl_parse_query(OPENSSL_CTX *ctx, const char *s)
+OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s)
 {
     STACK_OF(PROPERTY_DEFINITION) *sk;
     OSSL_PROPERTY_LIST *res = NULL;
@@ -453,7 +453,7 @@ int ossl_property_has_optional(const OSSL_PROPERTY_LIST *query)
     return query->has_optional ? 1 : 0;
 }
 
-int ossl_property_is_enabled(OPENSSL_CTX *ctx,  const char *property_name,
+int ossl_property_is_enabled(OSSL_LIB_CTX *ctx,  const char *property_name,
                              const OSSL_PROPERTY_LIST *prop_list)
 {
     int i;
@@ -590,7 +590,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
     return r;
 }
 
-int ossl_property_parse_init(OPENSSL_CTX *ctx)
+int ossl_property_parse_init(OSSL_LIB_CTX *ctx)
 {
     static const char *const predefined_names[] = {
         "provider",     /* Name of provider (default, legacy, fips) */

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -81,7 +81,7 @@ static void property_string_data_free(void *vpropdata)
     OPENSSL_free(propdata);
 }
 
-static void *property_string_data_new(OPENSSL_CTX *ctx) {
+static void *property_string_data_new(OSSL_LIB_CTX *ctx) {
     PROPERTY_STRING_DATA *propdata = OPENSSL_zalloc(sizeof(*propdata));
 
     if (propdata == NULL)
@@ -104,7 +104,7 @@ err:
     return NULL;
 }
 
-static const OPENSSL_CTX_METHOD property_string_data_method = {
+static const OSSL_LIB_CTX_METHOD property_string_data_method = {
     property_string_data_new,
     property_string_data_free,
 };
@@ -147,11 +147,11 @@ static OSSL_PROPERTY_IDX ossl_property_string(PROP_TABLE *t,
     return ps != NULL ? ps->idx : 0;
 }
 
-OSSL_PROPERTY_IDX ossl_property_name(OPENSSL_CTX *ctx, const char *s,
+OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
                                      int create)
 {
     PROPERTY_STRING_DATA *propdata
-        = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_STRING_INDEX,
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
                                &property_string_data_method);
 
     if (propdata == NULL)
@@ -161,11 +161,11 @@ OSSL_PROPERTY_IDX ossl_property_name(OPENSSL_CTX *ctx, const char *s,
                                 s);
 }
 
-OSSL_PROPERTY_IDX ossl_property_value(OPENSSL_CTX *ctx, const char *s,
+OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
                                       int create)
 {
     PROPERTY_STRING_DATA *propdata
-        = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_STRING_INDEX,
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
                                &property_string_data_method);
 
     if (propdata == NULL)

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -152,7 +152,7 @@ OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
 {
     PROPERTY_STRING_DATA *propdata
         = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
-                               &property_string_data_method);
+                                &property_string_data_method);
 
     if (propdata == NULL)
         return 0;
@@ -166,7 +166,7 @@ OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
 {
     PROPERTY_STRING_DATA *propdata
         = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
-                               &property_string_data_method);
+                                &property_string_data_method);
 
     if (propdata == NULL)
         return 0;

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -13,7 +13,7 @@
 #include <openssl/core_names.h>
 #include "internal/provider.h"
 
-OSSL_PROVIDER *OSSL_PROVIDER_try_load(OPENSSL_CTX *libctx, const char *name)
+OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name)
 {
     OSSL_PROVIDER *prov = NULL;
 
@@ -30,7 +30,7 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OPENSSL_CTX *libctx, const char *name)
     return prov;
 }
 
-OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *libctx, const char *name)
+OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name)
 {
     /* Any attempt to load a provider disables auto-loading of defaults */
     if (ossl_provider_disable_fallback_loading(libctx))
@@ -44,7 +44,7 @@ int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
     return 1;
 }
 
-int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name)
+int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name)
 {
     OSSL_PROVIDER *prov = NULL;
     int available = 0;
@@ -91,7 +91,7 @@ int OSSL_PROVIDER_get_capabilities(const OSSL_PROVIDER *prov,
     return ossl_provider_get_capabilities(prov, capability, cb, arg);
 }
 
-int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *libctx, const char *name,
+int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
                               OSSL_provider_init_fn *init_fn)
 {
     OSSL_PROVIDER *prov = NULL;
@@ -120,7 +120,7 @@ const char *OSSL_PROVIDER_name(const OSSL_PROVIDER *prov)
     return ossl_provider_name(prov);
 }
 
-int OSSL_PROVIDER_do_all(OPENSSL_CTX *ctx,
+int OSSL_PROVIDER_do_all(OSSL_LIB_CTX *ctx,
                          int (*cb)(OSSL_PROVIDER *provider,
                                    void *cbdata),
                          void *cbdata)

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -70,7 +70,7 @@ static int provider_conf_params(OSSL_PROVIDER *prov,
     return ok;
 }
 
-static int provider_conf_load(OPENSSL_CTX *libctx, const char *name,
+static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
                               const char *value, const CONF *cnf)
 {
     int i;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -54,7 +54,7 @@ struct ossl_provider_st {
     DSO *module;
     OSSL_provider_init_fn *init_function;
     STACK_OF(INFOPAIR) *parameters;
-    OPENSSL_CTX *libctx; /* The library context this instance is in */
+    OSSL_LIB_CTX *libctx; /* The library context this instance is in */
     struct provider_store_st *store; /* The store this instance belongs to */
 #ifndef FIPS_MODULE
     /*
@@ -138,7 +138,7 @@ static void provider_store_free(void *vstore)
     OPENSSL_free(store);
 }
 
-static void *provider_store_new(OPENSSL_CTX *ctx)
+static void *provider_store_new(OSSL_LIB_CTX *ctx)
 {
     struct provider_store_st *store = OPENSSL_zalloc(sizeof(*store));
     const struct predefined_providers_st *p = NULL;
@@ -179,23 +179,23 @@ static void *provider_store_new(OPENSSL_CTX *ctx)
     return store;
 }
 
-static const OPENSSL_CTX_METHOD provider_store_method = {
+static const OSSL_LIB_CTX_METHOD provider_store_method = {
     provider_store_new,
     provider_store_free,
 };
 
-static struct provider_store_st *get_provider_store(OPENSSL_CTX *libctx)
+static struct provider_store_st *get_provider_store(OSSL_LIB_CTX *libctx)
 {
     struct provider_store_st *store = NULL;
 
-    store = openssl_ctx_get_data(libctx, OPENSSL_CTX_PROVIDER_STORE_INDEX,
+    store = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_STORE_INDEX,
                                  &provider_store_method);
     if (store == NULL)
         CRYPTOerr(CRYPTO_F_GET_PROVIDER_STORE, ERR_R_INTERNAL_ERROR);
     return store;
 }
 
-int ossl_provider_disable_fallback_loading(OPENSSL_CTX *libctx)
+int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx)
 {
     struct provider_store_st *store;
 
@@ -206,7 +206,7 @@ int ossl_provider_disable_fallback_loading(OPENSSL_CTX *libctx)
     return 0;
 }
 
-OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name,
+OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
                                   int noconfig)
 {
     struct provider_store_st *store = NULL;
@@ -271,7 +271,7 @@ int ossl_provider_up_ref(OSSL_PROVIDER *prov)
     return ref;
 }
 
-OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
+OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
                                  OSSL_provider_init_fn *init_function,
                                  int noconfig)
 {
@@ -430,7 +430,7 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov,
  */
 static const OSSL_DISPATCH *core_dispatch; /* Define further down */
 
-int OSSL_PROVIDER_set_default_search_path(OPENSSL_CTX *libctx, const char *path)
+int OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *libctx, const char *path)
 {
     struct provider_store_st *store;
     char *p = NULL;
@@ -724,7 +724,7 @@ static void provider_activate_fallbacks(struct provider_store_st *store)
     }
 }
 
-int ossl_provider_forall_loaded(OPENSSL_CTX *ctx,
+int ossl_provider_forall_loaded(OSSL_LIB_CTX *ctx,
                                 int (*cb)(OSSL_PROVIDER *provider,
                                           void *cbdata),
                                 void *cbdata)
@@ -816,7 +816,7 @@ void *ossl_provider_prov_ctx(const OSSL_PROVIDER *prov)
     return NULL;
 }
 
-OPENSSL_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov)
+OSSL_LIB_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov)
 {
     /* TODO(3.0) just: return prov->libctx; */
     return prov != NULL ? prov->libctx : NULL;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -189,7 +189,7 @@ static struct provider_store_st *get_provider_store(OSSL_LIB_CTX *libctx)
     struct provider_store_st *store = NULL;
 
     store = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_STORE_INDEX,
-                                 &provider_store_method);
+                                  &provider_store_method);
     if (store == NULL)
         CRYPTOerr(CRYPTO_F_GET_PROVIDER_STORE, ERR_R_INTERNAL_ERROR);
     return store;
@@ -430,7 +430,8 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov,
  */
 static const OSSL_DISPATCH *core_dispatch; /* Define further down */
 
-int OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *libctx, const char *path)
+int OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *libctx,
+                                          const char *path)
 {
     struct provider_store_st *store;
     char *p = NULL;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -816,7 +816,7 @@ void *ossl_provider_prov_ctx(const OSSL_PROVIDER *prov)
     return NULL;
 }
 
-OSSL_LIB_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov)
+OSSL_LIB_CTX *ossl_provider_libctx(const OSSL_PROVIDER *prov)
 {
     /* TODO(3.0) just: return prov->libctx; */
     return prov != NULL ? prov->libctx : NULL;
@@ -849,7 +849,7 @@ int ossl_provider_self_test(const OSSL_PROVIDER *prov)
         return 1;
     ret = prov->self_test(prov->provctx);
     if (ret == 0)
-        evp_method_store_flush(ossl_provider_library_context(prov));
+        evp_method_store_flush(ossl_provider_libctx(prov));
     return ret;
 }
 
@@ -940,7 +940,7 @@ static const OSSL_PARAM param_types[] = {
 static OSSL_FUNC_core_gettable_params_fn core_gettable_params;
 static OSSL_FUNC_core_get_params_fn core_get_params;
 static OSSL_FUNC_core_thread_start_fn core_thread_start;
-static OSSL_FUNC_core_get_library_context_fn core_get_libctx;
+static OSSL_FUNC_core_get_libctx_fn core_get_libctx;
 #ifndef FIPS_MODULE
 static OSSL_FUNC_core_new_error_fn core_new_error;
 static OSSL_FUNC_core_set_error_debug_fn core_set_error_debug;
@@ -996,7 +996,7 @@ static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
      */
     OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
-    return (OPENSSL_CORE_CTX *)ossl_provider_library_context(prov);
+    return (OPENSSL_CORE_CTX *)ossl_provider_libctx(prov);
 }
 
 static int core_thread_start(const OSSL_CORE_HANDLE *handle,
@@ -1079,7 +1079,7 @@ static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
 static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_GETTABLE_PARAMS, (void (*)(void))core_gettable_params },
     { OSSL_FUNC_CORE_GET_PARAMS, (void (*)(void))core_get_params },
-    { OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT, (void (*)(void))core_get_libctx },
+    { OSSL_FUNC_CORE_GET_LIBCTX, (void (*)(void))core_get_libctx },
     { OSSL_FUNC_CORE_THREAD_START, (void (*)(void))core_thread_start },
 #ifndef FIPS_MODULE
     { OSSL_FUNC_CORE_NEW_ERROR, (void (*)(void))core_new_error },

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -266,7 +266,7 @@ const RAND_METHOD *RAND_get_rand_method(void)
  * the default method, then just call RAND_bytes().  Otherwise make
  * sure we're instantiated and use the private DRBG.
  */
-int RAND_priv_bytes_ex(OPENSSL_CTX *ctx, unsigned char *buf, int num)
+int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num)
 {
     EVP_RAND_CTX *rand;
     const RAND_METHOD *meth = RAND_get_rand_method();
@@ -290,7 +290,7 @@ int RAND_priv_bytes(unsigned char *buf, int num)
     return RAND_priv_bytes_ex(NULL, buf, num);
 }
 
-int RAND_bytes_ex(OPENSSL_CTX *ctx, unsigned char *buf, int num)
+int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num)
 {
     EVP_RAND_CTX *rand;
     const RAND_METHOD *meth = RAND_get_rand_method();
@@ -366,10 +366,10 @@ typedef struct rand_global_st {
 } RAND_GLOBAL;
 
 /*
- * Initialize the OPENSSL_CTX global DRBGs on first use.
+ * Initialize the OSSL_LIB_CTX global DRBGs on first use.
  * Returns the allocated global data on success or NULL on failure.
  */
-static void *rand_ossl_ctx_new(OPENSSL_CTX *libctx)
+static void *rand_ossl_ctx_new(OSSL_LIB_CTX *libctx)
 {
     RAND_GLOBAL *dgbl = OPENSSL_zalloc(sizeof(*dgbl));
 
@@ -423,20 +423,20 @@ static void rand_ossl_ctx_free(void *vdgbl)
     OPENSSL_free(dgbl);
 }
 
-static const OPENSSL_CTX_METHOD rand_drbg_ossl_ctx_method = {
+static const OSSL_LIB_CTX_METHOD rand_drbg_ossl_ctx_method = {
     rand_ossl_ctx_new,
     rand_ossl_ctx_free,
 };
 
-static RAND_GLOBAL *rand_get_global(OPENSSL_CTX *libctx)
+static RAND_GLOBAL *rand_get_global(OSSL_LIB_CTX *libctx)
 {
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_DRBG_INDEX,
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_INDEX,
                                 &rand_drbg_ossl_ctx_method);
 }
 
 static void rand_delete_thread_state(void *arg)
 {
-    OPENSSL_CTX *ctx = arg;
+    OSSL_LIB_CTX *ctx = arg;
     RAND_GLOBAL *dgbl = rand_get_global(ctx);
     EVP_RAND_CTX *rand;
 
@@ -452,7 +452,7 @@ static void rand_delete_thread_state(void *arg)
     EVP_RAND_CTX_free(rand);
 }
 
-static EVP_RAND_CTX *rand_new_drbg(OPENSSL_CTX *libctx, EVP_RAND_CTX *parent,
+static EVP_RAND_CTX *rand_new_drbg(OSSL_LIB_CTX *libctx, EVP_RAND_CTX *parent,
                                    unsigned int reseed_interval,
                                    time_t reseed_time_interval)
 {
@@ -512,7 +512,7 @@ static EVP_RAND_CTX *rand_new_drbg(OPENSSL_CTX *libctx, EVP_RAND_CTX *parent,
  * Returns pointer to its EVP_RAND_CTX on success, NULL on failure.
  *
  */
-EVP_RAND_CTX *RAND_get0_primary(OPENSSL_CTX *ctx)
+EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx)
 {
     RAND_GLOBAL *dgbl = rand_get_global(ctx);
 
@@ -534,7 +534,7 @@ EVP_RAND_CTX *RAND_get0_primary(OPENSSL_CTX *ctx)
  * Get the public random generator.
  * Returns pointer to its EVP_RAND_CTX on success, NULL on failure.
  */
-EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx)
+EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx)
 {
     RAND_GLOBAL *dgbl = rand_get_global(ctx);
     EVP_RAND_CTX *rand, *primary;
@@ -548,7 +548,7 @@ EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx)
         if (primary == NULL)
             return NULL;
 
-        ctx = openssl_ctx_get_concrete(ctx);
+        ctx = ossl_lib_ctx_get_concrete(ctx);
         /*
          * If the private is also NULL then this is the first time we've
          * used this thread.
@@ -567,7 +567,7 @@ EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx)
  * Get the private random generator.
  * Returns pointer to its EVP_RAND_CTX on success, NULL on failure.
  */
-EVP_RAND_CTX *RAND_get0_private(OPENSSL_CTX *ctx)
+EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx)
 {
     RAND_GLOBAL *dgbl = rand_get_global(ctx);
     EVP_RAND_CTX *rand, *primary;
@@ -581,7 +581,7 @@ EVP_RAND_CTX *RAND_get0_private(OPENSSL_CTX *ctx)
         if (primary == NULL)
             return NULL;
 
-        ctx = openssl_ctx_get_concrete(ctx);
+        ctx = ossl_lib_ctx_get_concrete(ctx);
         /*
          * If the public is also NULL then this is the first time we've
          * used this thread.

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -431,7 +431,7 @@ static const OSSL_LIB_CTX_METHOD rand_drbg_ossl_ctx_method = {
 static RAND_GLOBAL *rand_get_global(OSSL_LIB_CTX *libctx)
 {
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_INDEX,
-                                &rand_drbg_ossl_ctx_method);
+                                 &rand_drbg_ossl_ctx_method);
 }
 
 static void rand_delete_thread_state(void *arg)

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -889,7 +889,7 @@ static size_t rsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
  */
 static int rsa_int_export_to(const EVP_PKEY *from, int rsa_type,
                              void *to_keydata, EVP_KEYMGMT *to_keymgmt,
-                             OPENSSL_CTX *libctx, const char *propq)
+                             OSSL_LIB_CTX *libctx, const char *propq)
 {
     RSA *rsa = from->pkey.rsa;
     OSSL_PARAM_BLD *tmpl = OSSL_PARAM_BLD_new();
@@ -1019,7 +1019,7 @@ static int rsa_int_import_from(const OSSL_PARAM params[], void *vpctx,
 }
 
 static int rsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                              EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                              EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                               const char *propq)
 {
     return rsa_int_export_to(from, RSA_FLAG_TYPE_RSA, to_keydata,
@@ -1027,7 +1027,7 @@ static int rsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
 }
 
 static int rsa_pss_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                                  EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                                  EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                                   const char *propq)
 {
     return rsa_int_export_to(from, RSA_FLAG_TYPE_RSASSAPSS, to_keydata,

--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -212,7 +212,7 @@ int ossl_rsa_pss_params_30_todata(const RSA_PSS_PARAMS_30 *pss,
 
 int ossl_rsa_pss_params_30_fromdata(RSA_PSS_PARAMS_30 *pss_params,
                                     const OSSL_PARAM params[],
-                                    OPENSSL_CTX *libctx)
+                                    OSSL_LIB_CTX *libctx)
 {
     const OSSL_PARAM *param_md, *param_mgf, *param_mgf1md,  *param_saltlen;
     const OSSL_PARAM *param_propq;

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -28,7 +28,7 @@
 #include "rsa_local.h"
 
 static int rsa_keygen_pairwise_test(RSA *rsa, OSSL_CALLBACK *cb, void *cbarg);
-static int rsa_keygen(OPENSSL_CTX *libctx, RSA *rsa, int bits, int primes,
+static int rsa_keygen(OSSL_LIB_CTX *libctx, RSA *rsa, int bits, int primes,
                       BIGNUM *e_value, BN_GENCB *cb, int pairwise_test);
 
 /*
@@ -419,7 +419,7 @@ static int rsa_multiprime_keygen(RSA *rsa, int bits, int primes,
 }
 #endif /* FIPS_MODULE */
 
-static int rsa_keygen(OPENSSL_CTX *libctx, RSA *rsa, int bits, int primes,
+static int rsa_keygen(OSSL_LIB_CTX *libctx, RSA *rsa, int bits, int primes,
                       BIGNUM *e_value, BN_GENCB *cb, int pairwise_test)
 {
     int ok = 0;

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -27,7 +27,7 @@
 #include "crypto/security_bits.h"
 #include "rsa_local.h"
 
-static RSA *rsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx);
+static RSA *rsa_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx);
 
 #ifndef FIPS_MODULE
 RSA *RSA_new(void)
@@ -66,12 +66,12 @@ RSA *RSA_new_method(ENGINE *engine)
 }
 #endif
 
-RSA *ossl_rsa_new_with_ctx(OPENSSL_CTX *libctx)
+RSA *ossl_rsa_new_with_ctx(OSSL_LIB_CTX *libctx)
 {
     return rsa_new_intern(NULL, libctx);
 }
 
-static RSA *rsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
+static RSA *rsa_new_intern(ENGINE *engine, OSSL_LIB_CTX *libctx)
 {
     RSA *ret = OPENSSL_zalloc(sizeof(*ret));
 
@@ -189,7 +189,7 @@ int RSA_up_ref(RSA *r)
     return i > 1 ? 1 : 0;
 }
 
-OPENSSL_CTX *ossl_rsa_get0_libctx(RSA *r)
+OSSL_LIB_CTX *ossl_rsa_get0_libctx(RSA *r)
 {
     return r->libctx;
 }

--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -56,7 +56,7 @@ struct rsa_st {
      */
     int dummy_zero;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     int32_t version;
     const RSA_METHOD *meth;
     /* functional reference if 'meth' is ENGINE-provided */
@@ -196,10 +196,10 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
                                        int nbits, const BIGNUM *e, BN_CTX *ctx,
                                        BN_GENCB *cb);
 
-int ossl_rsa_padding_add_SSLv23_ex(OPENSSL_CTX *libctx, unsigned char *to,
+int ossl_rsa_padding_add_SSLv23_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                    int tlen, const unsigned char *from,
                                    int flen);
-int ossl_rsa_padding_add_PKCS1_type_2_ex(OPENSSL_CTX *libctx, unsigned char *to,
+int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                          int tlen, const unsigned char *from,
                                          int flen);
 

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -51,7 +51,7 @@ int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
  * Step numbers are included here but not in the constant time inverse below
  * to avoid complicating an already difficult enough function.
  */
-int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OPENSSL_CTX *libctx,
+int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OSSL_LIB_CTX *libctx,
                                             unsigned char *to, int tlen,
                                             const unsigned char *from, int flen,
                                             const unsigned char *param,

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -124,7 +124,7 @@ int RSA_padding_check_PKCS1_type_1(unsigned char *to, int tlen,
     return j;
 }
 
-int ossl_rsa_padding_add_PKCS1_type_2_ex(OPENSSL_CTX *libctx, unsigned char *to,
+int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                          int tlen, const unsigned char *from,
                                          int flen)
 {
@@ -298,7 +298,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
  * decrypted data will be randomly generated (as per
  * https://tools.ietf.org/html/rfc5246#section-7.4.7.1).
  */
-int ossl_rsa_padding_check_PKCS1_type_2_TLS(OPENSSL_CTX *libctx,
+int ossl_rsa_padding_check_PKCS1_type_2_TLS(OSSL_LIB_CTX *libctx,
                                             unsigned char *to, size_t tlen,
                                             const unsigned char *from,
                                             size_t flen, int client_version,

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -21,7 +21,7 @@
 #include "internal/constant_time.h"
 #include "rsa_local.h"
 
-int ossl_rsa_padding_add_SSLv23_ex(OPENSSL_CTX *libctx, unsigned char *to,
+int ossl_rsa_padding_add_SSLv23_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                    int tlen, const unsigned char *from,
                                    int flen)
 {

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -32,7 +32,7 @@ struct ossl_self_test_st
 };
 
 #ifndef FIPS_MODULE
-static void *self_test_set_callback_new(OPENSSL_CTX *ctx)
+static void *self_test_set_callback_new(OSSL_LIB_CTX *ctx)
 {
     SELF_TEST_CB *stcb;
 
@@ -45,18 +45,18 @@ static void self_test_set_callback_free(void *stcb)
     OPENSSL_free(stcb);
 }
 
-static const OPENSSL_CTX_METHOD self_test_set_callback_method = {
+static const OSSL_LIB_CTX_METHOD self_test_set_callback_method = {
     self_test_set_callback_new,
     self_test_set_callback_free,
 };
 
-static SELF_TEST_CB *get_self_test_callback(OPENSSL_CTX *libctx)
+static SELF_TEST_CB *get_self_test_callback(OSSL_LIB_CTX *libctx)
 {
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_SELF_TEST_CB_INDEX,
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_SELF_TEST_CB_INDEX,
                                 &self_test_set_callback_method);
 }
 
-void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
+void OSSL_SELF_TEST_set_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK *cb,
                                  void *cbarg)
 {
     SELF_TEST_CB *stcb = get_self_test_callback(libctx);
@@ -67,7 +67,7 @@ void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
     }
 }
 
-void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK **cb,
+void OSSL_SELF_TEST_get_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK **cb,
                                  void **cbarg)
 {
     SELF_TEST_CB *stcb = get_self_test_callback(libctx);

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -53,7 +53,7 @@ static const OSSL_LIB_CTX_METHOD self_test_set_callback_method = {
 static SELF_TEST_CB *get_self_test_callback(OSSL_LIB_CTX *libctx)
 {
     return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_SELF_TEST_CB_INDEX,
-                                &self_test_set_callback_method);
+                                 &self_test_set_callback_method);
 }
 
 void OSSL_SELF_TEST_set_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK *cb,

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -139,7 +139,7 @@ int sm2_encrypt(const EC_KEY *key,
     size_t field_size;
     const int C3_size = EVP_MD_size(digest);
     EVP_MD *fetched_digest = NULL;
-    OPENSSL_CTX *libctx = ec_key_get_libctx(key);
+    OSSL_LIB_CTX *libctx = ec_key_get_libctx(key);
     const char *propq = ec_key_get0_propq(key);
 
     /* NULL these before any "goto done" */
@@ -297,7 +297,7 @@ int sm2_decrypt(const EC_KEY *key,
     const uint8_t *C3 = NULL;
     int msg_len = 0;
     EVP_MD_CTX *hash = NULL;
-    OPENSSL_CTX *libctx = ec_key_get_libctx(key);
+    OSSL_LIB_CTX *libctx = ec_key_get_libctx(key);
     const char *propq = ec_key_get0_propq(key);
 
     if (field_size == 0 || hash_size <= 0)

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -147,7 +147,7 @@ static BIGNUM *sm2_compute_msg_hash(const EVP_MD *digest,
     uint8_t *z = NULL;
     BIGNUM *e = NULL;
     EVP_MD *fetched_digest = NULL;
-    OPENSSL_CTX *libctx = ec_key_get_libctx(key);
+    OSSL_LIB_CTX *libctx = ec_key_get_libctx(key);
     const char *propq = ec_key_get0_propq(key);
 
     if (md_size < 0) {
@@ -206,7 +206,7 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
     BIGNUM *s = NULL;
     BIGNUM *x1 = NULL;
     BIGNUM *tmp = NULL;
-    OPENSSL_CTX *libctx = ec_key_get_libctx(key);
+    OSSL_LIB_CTX *libctx = ec_key_get_libctx(key);
 
     kG = EC_POINT_new(group);
     ctx = BN_CTX_new_ex(libctx);
@@ -306,7 +306,7 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
     BIGNUM *x1 = NULL;
     const BIGNUM *r = NULL;
     const BIGNUM *s = NULL;
-    OPENSSL_CTX *libctx = ec_key_get_libctx(key);
+    OSSL_LIB_CTX *libctx = ec_key_get_libctx(key);
 
     ctx = BN_CTX_new_ex(libctx);
     pt = EC_POINT_new(group);

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -21,7 +21,7 @@
 /* calculate = SHA1(PAD(x) || PAD(y)) */
 
 static BIGNUM *srp_Calc_xy(const BIGNUM *x, const BIGNUM *y, const BIGNUM *N,
-                           OPENSSL_CTX *libctx, const char *propq)
+                           OSSL_LIB_CTX *libctx, const char *propq)
 {
     unsigned char digest[SHA_DIGEST_LENGTH];
     unsigned char *tmp = NULL;
@@ -49,7 +49,7 @@ static BIGNUM *srp_Calc_xy(const BIGNUM *x, const BIGNUM *y, const BIGNUM *N,
     return res;
 }
 
-static BIGNUM *srp_Calc_k(const BIGNUM *N, const BIGNUM *g, OPENSSL_CTX *libctx,
+static BIGNUM *srp_Calc_k(const BIGNUM *N, const BIGNUM *g, OSSL_LIB_CTX *libctx,
                           const char *propq)
 {
     /* k = SHA1(N | PAD(g)) -- tls-srp RFC 5054 */
@@ -57,7 +57,7 @@ static BIGNUM *srp_Calc_k(const BIGNUM *N, const BIGNUM *g, OPENSSL_CTX *libctx,
 }
 
 BIGNUM *SRP_Calc_u_ex(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     /* u = SHA1(PAD(A) || PAD(B) ) -- tls-srp RFC 5054 */
     return srp_Calc_xy(A, B, N, libctx, propq);
@@ -100,7 +100,7 @@ BIGNUM *SRP_Calc_server_key(const BIGNUM *A, const BIGNUM *v, const BIGNUM *u,
 }
 
 BIGNUM *SRP_Calc_B_ex(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
-                      const BIGNUM *v, OPENSSL_CTX *libctx, const char *propq)
+                      const BIGNUM *v, OSSL_LIB_CTX *libctx, const char *propq)
 {
     BIGNUM *kv = NULL, *gb = NULL;
     BIGNUM *B = NULL, *k = NULL;
@@ -138,7 +138,7 @@ BIGNUM *SRP_Calc_B(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
 }
 
 BIGNUM *SRP_Calc_x_ex(const BIGNUM *s, const char *user, const char *pass,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     unsigned char dig[SHA_DIGEST_LENGTH];
     EVP_MD_CTX *ctxt;
@@ -207,7 +207,7 @@ BIGNUM *SRP_Calc_A(const BIGNUM *a, const BIGNUM *N, const BIGNUM *g)
 
 BIGNUM *SRP_Calc_client_key_ex(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                             const BIGNUM *x, const BIGNUM *a, const BIGNUM *u,
-                            OPENSSL_CTX *libctx, const char *propq)
+                            OSSL_LIB_CTX *libctx, const char *propq)
 {
     BIGNUM *tmp = NULL, *tmp2 = NULL, *tmp3 = NULL, *k = NULL, *K = NULL;
     BN_CTX *bn_ctx;

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -49,7 +49,8 @@ static BIGNUM *srp_Calc_xy(const BIGNUM *x, const BIGNUM *y, const BIGNUM *N,
     return res;
 }
 
-static BIGNUM *srp_Calc_k(const BIGNUM *N, const BIGNUM *g, OSSL_LIB_CTX *libctx,
+static BIGNUM *srp_Calc_k(const BIGNUM *N, const BIGNUM *g,
+                          OSSL_LIB_CTX *libctx,
                           const char *propq)
 {
     /* k = SHA1(N | PAD(g)) -- tls-srp RFC 5054 */

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -596,7 +596,7 @@ SRP_user_pwd *SRP_VBASE_get1_by_user(SRP_VBASE *vb, char *username)
  */
 char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
                              char **verifier, const char *N, const char *g,
-                             OPENSSL_CTX *libctx, const char *propq)
+                             OSSL_LIB_CTX *libctx, const char *propq)
 {
     int len;
     char *result = NULL, *vf = NULL;
@@ -702,7 +702,7 @@ char *SRP_create_verifier(const char *user, const char *pass, char **salt,
  */
 int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
                               BIGNUM **verifier, const BIGNUM *N,
-                              const BIGNUM *g, OPENSSL_CTX *libctx,
+                              const BIGNUM *g, OSSL_LIB_CTX *libctx,
                               const char *propq)
 {
     int result = 0;

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -32,7 +32,7 @@
 static int ossl_store_close_it(OSSL_STORE_CTX *ctx);
 
 OSSL_STORE_CTX *
-OSSL_STORE_open_ex(const char *uri, OPENSSL_CTX *libctx, const char *propq,
+OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
                    const UI_METHOD *ui_method, void *ui_data,
                    OSSL_STORE_post_process_info_fn post_process,
                    void *post_process_data)
@@ -916,7 +916,7 @@ const EVP_MD *OSSL_STORE_SEARCH_get0_digest(const OSSL_STORE_SEARCH *criterion)
 }
 
 OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
-                                  OPENSSL_CTX *libctx, const char *propq,
+                                  OSSL_LIB_CTX *libctx, const char *propq,
                                   const UI_METHOD *ui_method, void *ui_data,
                                   OSSL_STORE_post_process_info_fn post_process,
                                   void *post_process_data)

--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -171,10 +171,10 @@ int ossl_store_file_detach_pem_bio_int(OSSL_STORE_LOADER_CTX *ctx);
  * Provider stuff
  * -------------------
  */
-OSSL_STORE_LOADER *ossl_store_loader_fetch(OPENSSL_CTX *libctx,
+OSSL_STORE_LOADER *ossl_store_loader_fetch(OSSL_LIB_CTX *libctx,
                                            const char *scheme,
                                            const char *properties);
-OSSL_STORE_LOADER *ossl_store_loader_fetch_by_number(OPENSSL_CTX *libctx,
+OSSL_STORE_LOADER *ossl_store_loader_fetch_by_number(OSSL_LIB_CTX *libctx,
                                                      int scheme_id,
                                                      const char *properties);
 

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -235,7 +235,7 @@ static void *construct_loader(const OSSL_ALGORITHM *algodef,
      * namemap entry, this is it.  Should the scheme already exist there, we
      * know that ossl_namemap_add() will return its corresponding number.
      */
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(prov);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *scheme = algodef->algorithm_names;
     int id = ossl_namemap_add_name(namemap, 0, scheme);
@@ -361,7 +361,7 @@ int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader)
 int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader, const char *name)
 {
     if (loader->prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(loader->prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(loader->prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
         return ossl_namemap_name2num(namemap, name) == loader->scheme_id;
@@ -379,7 +379,7 @@ static void loader_do_one(OSSL_PROVIDER *provider,
                           int no_store, void *vdata)
 {
     struct loader_do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *name = algodef->algorithm_names;
     int id = ossl_namemap_add_name(namemap, 0, name);
@@ -417,7 +417,7 @@ void OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
         return;
 
     if (loader->prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(loader->prov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(loader->prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
         ossl_namemap_doall_names(namemap, loader->scheme_id, fn, data);

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -107,7 +107,7 @@ int ossl_store_handle_load_result(const OSSL_PARAM params[], void *arg)
     OSSL_STORE_CTX *ctx = cbdata->ctx;
     const OSSL_PROVIDER *provider =
         OSSL_STORE_LOADER_provider(ctx->fetched_loader);
-    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
     const char *propq = ctx->properties;
     const OSSL_PARAM *p;
     struct extracted_param_data_st helper_data;

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -73,13 +73,13 @@ struct extracted_param_data_st {
 static int try_name(struct extracted_param_data_st *, OSSL_STORE_INFO **);
 static int try_key(struct extracted_param_data_st *, OSSL_STORE_INFO **,
                    OSSL_STORE_CTX *, const OSSL_PROVIDER *,
-                   OPENSSL_CTX *, const char *);
+                   OSSL_LIB_CTX *, const char *);
 static int try_cert(struct extracted_param_data_st *, OSSL_STORE_INFO **,
-                    OPENSSL_CTX *, const char *);
+                    OSSL_LIB_CTX *, const char *);
 static int try_crl(struct extracted_param_data_st *, OSSL_STORE_INFO **,
-                   OPENSSL_CTX *, const char *);
+                   OSSL_LIB_CTX *, const char *);
 static int try_pkcs12(struct extracted_param_data_st *, OSSL_STORE_INFO **,
-                      OSSL_STORE_CTX *, OPENSSL_CTX *, const char *);
+                      OSSL_STORE_CTX *, OSSL_LIB_CTX *, const char *);
 
 #define SET_ERR_MARK() ERR_set_mark()
 #define CLEAR_ERR_MARK()                                                \
@@ -107,7 +107,7 @@ int ossl_store_handle_load_result(const OSSL_PARAM params[], void *arg)
     OSSL_STORE_CTX *ctx = cbdata->ctx;
     const OSSL_PROVIDER *provider =
         OSSL_STORE_LOADER_provider(ctx->fetched_loader);
-    OPENSSL_CTX *libctx = ossl_provider_library_context(provider);
+    OSSL_LIB_CTX *libctx = ossl_provider_library_context(provider);
     const char *propq = ctx->properties;
     const OSSL_PARAM *p;
     struct extracted_param_data_st helper_data;
@@ -192,7 +192,7 @@ static int try_name(struct extracted_param_data_st *data, OSSL_STORE_INFO **v)
 static EVP_PKEY *try_key_ref(struct extracted_param_data_st *data,
                              OSSL_STORE_CTX *ctx,
                              const OSSL_PROVIDER *provider,
-                             OPENSSL_CTX *libctx, const char *propq)
+                             OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY *pk = NULL;
     EVP_KEYMGMT *keymgmt = NULL;
@@ -247,7 +247,7 @@ static EVP_PKEY *try_key_ref(struct extracted_param_data_st *data,
 static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
                                OSSL_STORE_CTX *ctx,
                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg,
-                               OPENSSL_CTX *libctx, const char *propq)
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY *pk = NULL;
     OSSL_DECODER_CTX *decoderctx = NULL;
@@ -272,7 +272,7 @@ static EVP_PKEY *try_key_value_legacy(struct extracted_param_data_st *data,
                                       store_info_new_fn **store_info_new,
                                       OSSL_STORE_CTX *ctx,
                                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg,
-                                      OPENSSL_CTX *libctx, const char *propq)
+                                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     EVP_PKEY *pk = NULL;
     const unsigned char *der = data->octet_data, *derp;
@@ -351,7 +351,7 @@ static EVP_PKEY *try_key_value_legacy(struct extracted_param_data_st *data,
 
 static int try_key(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
                    OSSL_STORE_CTX *ctx, const OSSL_PROVIDER *provider,
-                   OPENSSL_CTX *libctx, const char *propq)
+                   OSSL_LIB_CTX *libctx, const char *propq)
 {
     store_info_new_fn *store_info_new = NULL;
 
@@ -422,7 +422,7 @@ static int try_key(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
 }
 
 static int try_cert(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
-                    OPENSSL_CTX *libctx, const char *propq)
+                    OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (data->object_type == OSSL_OBJECT_UNKNOWN
         || data->object_type == OSSL_OBJECT_CERT) {
@@ -469,7 +469,7 @@ static int try_cert(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
 }
 
 static int try_crl(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
-                   OPENSSL_CTX *libctx, const char *propq)
+                   OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (data->object_type == OSSL_OBJECT_UNKNOWN
         || data->object_type == OSSL_OBJECT_CRL) {
@@ -497,7 +497,7 @@ static int try_crl(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
 
 static int try_pkcs12(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
                       OSSL_STORE_CTX *ctx,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     /* There is no specific object type for PKCS12 */
     if (data->object_type == OSSL_OBJECT_UNKNOWN) {

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -49,7 +49,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
                                const X509_NAME *name, X509_OBJECT *ret);
 static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
                                   const X509_NAME *name, X509_OBJECT *ret,
-                                  OPENSSL_CTX *libctx, const char *propq);
+                                  OSSL_LIB_CTX *libctx, const char *propq);
 static X509_LOOKUP_METHOD x509_dir_lookup = {
     "Load certs from files in a directory",
     new_dir,                         /* new_item */
@@ -216,7 +216,7 @@ static int add_cert_dir(BY_DIR *ctx, const char *dir, int type)
 
 static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
                                   const X509_NAME *name, X509_OBJECT *ret,
-                                  OPENSSL_CTX *libctx, const char *propq)
+                                  OSSL_LIB_CTX *libctx, const char *propq)
 {
     BY_DIR *ctx;
     union {

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -20,7 +20,7 @@
 static int by_file_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc,
                         long argl, char **ret);
 static int by_file_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argc,
-                           long argl, char **ret, OPENSSL_CTX *libctx,
+                           long argl, char **ret, OSSL_LIB_CTX *libctx,
                            const char *propq);
 
 
@@ -45,7 +45,7 @@ X509_LOOKUP_METHOD *X509_LOOKUP_file(void)
 }
 
 static int by_file_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
-                           long argl, char **ret, OPENSSL_CTX *libctx,
+                           long argl, char **ret, OSSL_LIB_CTX *libctx,
                            const char *propq)
 {
     int ok = 0;
@@ -87,7 +87,7 @@ static int by_file_ctrl(X509_LOOKUP *ctx, int cmd,
 }
 
 int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
-                           OPENSSL_CTX *libctx, const char *propq)
+                           OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ret = 0;
     BIO *in = NULL;
@@ -212,7 +212,7 @@ int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type)
 }
 
 int X509_load_cert_crl_file_ex(X509_LOOKUP *ctx, const char *file, int type,
-                               OPENSSL_CTX *libctx, const char *propq)
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     STACK_OF(X509_INFO) *inf;
     X509_INFO *itmp;

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -15,7 +15,7 @@
 /* Generic object loader, given expected type and criterion */
 static int cache_objects(X509_LOOKUP *lctx, const char *uri,
                          const OSSL_STORE_SEARCH *criterion,
-                         int depth, OPENSSL_CTX *libctx, const char *propq)
+                         int depth, OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ok = 0;
     OSSL_STORE_CTX *ctx = NULL;
@@ -105,7 +105,7 @@ static void by_store_free(X509_LOOKUP *ctx)
 }
 
 static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
-                            long argl, char **retp, OPENSSL_CTX *libctx,
+                            long argl, char **retp, OSSL_LIB_CTX *libctx,
                             const char *propq)
 {
     switch (cmd) {
@@ -141,7 +141,7 @@ static int by_store_ctrl(X509_LOOKUP *ctx, int cmd,
 
 static int by_store(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                     const OSSL_STORE_SEARCH *criterion, X509_OBJECT *ret,
-                    OPENSSL_CTX *libctx, const char *propq)
+                    OSSL_LIB_CTX *libctx, const char *propq)
 {
     STACK_OF(OPENSSL_STRING) *uris = X509_LOOKUP_get_method_data(ctx);
     int i;
@@ -159,7 +159,7 @@ static int by_store(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
 
 static int by_store_subject_ex(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                                const X509_NAME *name, X509_OBJECT *ret,
-                               OPENSSL_CTX *libctx, const char *propq)
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_STORE_SEARCH *criterion =
         OSSL_STORE_SEARCH_by_name((X509_NAME *)name); /* won't modify it */

--- a/crypto/x509/x509_d2.c
+++ b/crypto/x509/x509_d2.c
@@ -12,7 +12,7 @@
 #include <openssl/crypto.h>
 #include <openssl/x509.h>
 
-int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OPENSSL_CTX *libctx,
+int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OSSL_LIB_CTX *libctx,
                                     const char *propq)
 {
     X509_LOOKUP *lookup;
@@ -43,7 +43,7 @@ int X509_STORE_set_default_paths(X509_STORE *ctx)
 }
 
 int X509_STORE_load_file_ex(X509_STORE *ctx, const char *file,
-                            OPENSSL_CTX *libctx, const char *propq)
+                            OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_LOOKUP *lookup;
 
@@ -74,7 +74,7 @@ int X509_STORE_load_path(X509_STORE *ctx, const char *path)
 }
 
 int X509_STORE_load_store_ex(X509_STORE *ctx, const char *uri,
-                             OPENSSL_CTX *libctx, const char *propq)
+                             OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_LOOKUP *lookup;
 
@@ -92,7 +92,7 @@ int X509_STORE_load_store(X509_STORE *ctx, const char *uri)
 }
 
 int X509_STORE_load_locations_ex(X509_STORE *ctx, const char *file,
-                                 const char *path, OPENSSL_CTX *libctx,
+                                 const char *path, OSSL_LIB_CTX *libctx,
                                  const char *propq)
 {
     if (file == NULL && path == NULL)

--- a/crypto/x509/x509_local.h
+++ b/crypto/x509/x509_local.h
@@ -92,9 +92,9 @@ struct x509_lookup_method_st {
                          const char *str, int len, X509_OBJECT *ret);
     int (*get_by_subject_ex) (X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                               const X509_NAME *name, X509_OBJECT *ret,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
     int (*ctrl_ex) (X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
-                    char **ret, OPENSSL_CTX *libctx, const char *propq);
+                    char **ret, OSSL_LIB_CTX *libctx, const char *propq);
 };
 
 /* This is the functions plus an instance of the local variables. */

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -72,7 +72,7 @@ int X509_LOOKUP_shutdown(X509_LOOKUP *ctx)
 }
 
 int X509_LOOKUP_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
-                        char **ret, OPENSSL_CTX *libctx, const char *propq)
+                        char **ret, OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (ctx->method == NULL)
         return -1;
@@ -91,7 +91,7 @@ int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
 
 int X509_LOOKUP_by_subject_ex(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                               const X509_NAME *name, X509_OBJECT *ret,
-                              OPENSSL_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (ctx->skip
         || ctx->method == NULL

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2322,7 +2322,7 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
     return 1;
 }
 
-X509_STORE_CTX *X509_STORE_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq)
+X509_STORE_CTX *X509_STORE_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_STORE_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -37,7 +37,7 @@ int X509_verify(X509 *a, EVP_PKEY *r)
                                a->distinguishing_id, r, a->libctx, a->propq);
 }
 
-int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OPENSSL_CTX *libctx,
+int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
                        const char *propq)
 {
     return ASN1_item_verify_ex(ASN1_ITEM_rptr(X509_REQ_INFO), &a->sig_alg,
@@ -555,7 +555,7 @@ EVP_PKEY *d2i_PrivateKey_fp(FILE *fp, EVP_PKEY **a)
     return ASN1_d2i_fp_of(EVP_PKEY, EVP_PKEY_new, d2i_AutoPrivateKey, fp, a);
 }
 
-EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OPENSSL_CTX *libctx,
+EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                const char *propq)
 {
     BIO *b;
@@ -619,7 +619,7 @@ EVP_PKEY *d2i_PrivateKey_bio(BIO *bp, EVP_PKEY **a)
     return ASN1_d2i_bio_of(EVP_PKEY, EVP_PKEY_new, d2i_AutoPrivateKey, bp, a);
 }
 
-EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OPENSSL_CTX *libctx,
+EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                 const char *propq)
 {
     BUF_MEM *b = NULL;

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -490,7 +490,7 @@ void *X509_CRL_get_meth_data(X509_CRL *crl)
     return crl->meth_data;
 }
 
-int x509_crl_set0_libctx(X509_CRL *x, OPENSSL_CTX *libctx, const char *propq)
+int x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (x != NULL) {
         x->libctx = libctx;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -31,7 +31,7 @@ struct X509_pubkey_st {
     EVP_PKEY *pkey;
 
     /* extra data for the callback, used by d2i_PUBKEY_ex */
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propq;
 };
 
@@ -100,7 +100,7 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
         }
     } else if (evp_pkey_is_provided(pkey)) {
         const OSSL_PROVIDER *pkprov = EVP_KEYMGMT_provider(pkey->keymgmt);
-        OPENSSL_CTX *libctx = ossl_provider_library_context(pkprov);
+        OSSL_LIB_CTX *libctx = ossl_provider_library_context(pkprov);
         unsigned char *der = NULL;
         size_t derlen = 0;
         int selection = (OSSL_KEYMGMT_SELECT_PUBLIC_KEY
@@ -242,7 +242,7 @@ EVP_PKEY *X509_PUBKEY_get(const X509_PUBKEY *key)
  */
 
 EVP_PKEY *d2i_PUBKEY_ex(EVP_PKEY **a, const unsigned char **pp, long length,
-                        OPENSSL_CTX *libctx, const char *propq)
+                        OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509_PUBKEY *xpk, *xpk2 = NULL, **pxpk = NULL;
     EVP_PKEY *pktmp = NULL;
@@ -309,7 +309,7 @@ int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp)
         X509_PUBKEY_free(xpk);
     } else if (a->keymgmt != NULL) {
         const OSSL_PROVIDER *pkprov = EVP_KEYMGMT_provider(a->keymgmt);
-        OPENSSL_CTX *libctx = ossl_provider_library_context(pkprov);
+        OSSL_LIB_CTX *libctx = ossl_provider_library_context(pkprov);
         int selection = (OSSL_KEYMGMT_SELECT_PUBLIC_KEY
                          | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS);
         OSSL_ENCODER_CTX *ctx =
@@ -530,7 +530,7 @@ int X509_PUBKEY_eq(const X509_PUBKEY *a, const X509_PUBKEY *b)
     return EVP_PKEY_eq(pA, pB);
 }
 
-int X509_PUBKEY_get0_libctx(OPENSSL_CTX **plibctx, const char **ppropq,
+int X509_PUBKEY_get0_libctx(OSSL_LIB_CTX **plibctx, const char **ppropq,
                             const X509_PUBKEY *key)
 {
     if (plibctx)

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -100,7 +100,7 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
         }
     } else if (evp_pkey_is_provided(pkey)) {
         const OSSL_PROVIDER *pkprov = EVP_KEYMGMT_provider(pkey->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(pkprov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(pkprov);
         unsigned char *der = NULL;
         size_t derlen = 0;
         int selection = (OSSL_KEYMGMT_SELECT_PUBLIC_KEY
@@ -309,7 +309,7 @@ int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp)
         X509_PUBKEY_free(xpk);
     } else if (a->keymgmt != NULL) {
         const OSSL_PROVIDER *pkprov = EVP_KEYMGMT_provider(a->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_library_context(pkprov);
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(pkprov);
         int selection = (OSSL_KEYMGMT_SELECT_PUBLIC_KEY
                          | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS);
         OSSL_ENCODER_CTX *ctx =

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -134,7 +134,7 @@ int i2d_X509(const X509 *a, unsigned char **out)
  * asn1 object and it needs a libctx to operate.
  * Use X509_new_ex() instead if possible.
  */
-int x509_set0_libctx(X509 *x, OPENSSL_CTX *libctx, const char *propq)
+int x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (x != NULL) {
         x->libctx = libctx;
@@ -143,7 +143,7 @@ int x509_set0_libctx(X509 *x, OPENSSL_CTX *libctx, const char *propq)
     return 1;
 }
 
-X509 *X509_new_ex(OPENSSL_CTX *libctx, const char *propq)
+X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 {
     X509 *cert = NULL;
 

--- a/doc/internal/man3/OSSL_METHOD_STORE.pod
+++ b/doc/internal/man3/OSSL_METHOD_STORE.pod
@@ -15,10 +15,10 @@ ossl_method_store_flush_cache
 
  typedef struct ossl_method_store_st OSSL_METHOD_STORE;
 
- OSSL_METHOD_STORE *ossl_method_store_new(OPENSSL_CTX *ctx);
+ OSSL_METHOD_STORE *ossl_method_store_new(OSSL_LIB_CTX *ctx);
  void ossl_method_store_free(OSSL_METHOD_STORE *store);
- int ossl_method_store_init(OPENSSL_CTX *ctx);
- void ossl_method_store_cleanup(OPENSSL_CTX *ctx);
+ int ossl_method_store_init(OSSL_LIB_CTX *ctx);
+ void ossl_method_store_cleanup(OSSL_LIB_CTX *ctx);
  int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
                            int nid, const char *properties, void *method,
                            int (*method_up_ref)(void *),

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -10,7 +10,7 @@ evp_generic_fetch, evp_generic_fetch_by_number
  /* Only for EVP source */
  #include "evp_local.h"
 
- void *evp_generic_fetch(OPENSSL_CTX *libctx, int operation_id,
+ void *evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
                          const char *name, const char *properties,
                          void *(*new_method)(int name_id,
                                              const OSSL_DISPATCH *fns,
@@ -20,7 +20,7 @@ evp_generic_fetch, evp_generic_fetch_by_number
                          int (*up_ref_method)(void *),
                          void (*free_method)(void *));
 
- void *evp_generic_fetch_by_number(OPENSSL_CTX *ctx, int operation_id,
+ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
                                    int name_id, const char *properties,
                                    void *(*new_method)(int name_id,
                                                        const OSSL_DISPATCH *fns,
@@ -182,7 +182,7 @@ And here's the implementation of the FOO method fetcher:
         EVP_FOO_meth_free(vfoo);
     }
 
-    EVP_FOO *EVP_FOO_fetch(OPENSSL_CTX *ctx,
+    EVP_FOO *EVP_FOO_fetch(OSSL_LIB_CTX *ctx,
                            const char *name,
                            const char *properties)
     {

--- a/doc/internal/man3/evp_pkey_export_to_provider.pod
+++ b/doc/internal/man3/evp_pkey_export_to_provider.pod
@@ -10,7 +10,7 @@ evp_pkey_export_to_provider, evp_pkey_copy_downgraded, evp_pkey_downgrade
  /* Only for EVP source */
  #include "evp_local.h"
 
- void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
+ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
                                    EVP_KEYMGMT **keymgmt,
                                    const char *propquery);
  int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
@@ -60,7 +60,7 @@ allocated, this is OK.
 
 =head1 SEE ALSO
 
-L<OPENSSL_CTX(3)>, L<EVP_KEYMGMT(3)>
+L<OSSL_LIB_CTX(3)>, L<EVP_KEYMGMT(3)>
 
 =head1 HISTORY
 

--- a/doc/internal/man3/ossl_algorithm_do_all.pod
+++ b/doc/internal/man3/ossl_algorithm_do_all.pod
@@ -6,7 +6,7 @@ ossl_algorithm_do_all - generic algorithm implementation iterator
 
 =head1 SYNOPSIS
 
- void ossl_algorithm_do_all(OPENSSL_CTX *libctx, int operation_id,
+ void ossl_algorithm_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                             OSSL_PROVIDER *provider,
                             void (*fn)(OSSL_PROVIDER *provider,
                                        const OSSL_ALGORITHM *algo,

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -17,7 +17,7 @@ ossl_cmp_mock_srv_set_checkAfterTime
 
  #include "apps/cmp_mock_srv.h"
 
- OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OPENSSL_CTX *libctx, const char *propq);
+ OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx, const char *propq);
  void ossl_cmp_mock_srv_free(OSSL_CMP_SRV_CTX *srv_ctx);
 
  int ossl_cmp_mock_srv_set1_certOut(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);

--- a/doc/internal/man3/ossl_cmp_msg_protect.pod
+++ b/doc/internal/man3/ossl_cmp_msg_protect.pod
@@ -13,7 +13,7 @@ ossl_cmp_msg_add_extraCerts
  #include "cmp_local.h"
 
  STACK_OF(X509)
-     *ossl_cmp_build_cert_chain(OPENSSL_CTX *libctx, const char *propq,
+     *ossl_cmp_build_cert_chain(OSSL_LIB_CTX *libctx, const char *propq,
                                 X509_STORE *store,
                                 STACK_OF(X509) *certs, X509 *cert);
  ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,

--- a/doc/internal/man3/ossl_lib_ctx_get_data.pod
+++ b/doc/internal/man3/ossl_lib_ctx_get_data.pod
@@ -16,10 +16,10 @@ ossl_lib_ctx_get_data, ossl_lib_ctx_run_once, ossl_lib_ctx_onfree
  } OSSL_LIB_CTX_METHOD;
 
  void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index,
-                            const OSSL_LIB_CTX_METHOD *meth);
+                             const OSSL_LIB_CTX_METHOD *meth);
 
  int ossl_lib_ctx_run_once(OSSL_LIB_CTX *ctx, unsigned int idx,
-                          ossl_lib_ctx_run_once_fn run_once_fn);
+                           ossl_lib_ctx_run_once_fn run_once_fn);
  int ossl_lib_ctx_onfree(OSSL_LIB_CTX *ctx, ossl_lib_ctx_onfree_fn onfreefn);
 
 =head1 DESCRIPTION
@@ -118,8 +118,8 @@ To get and use the data stored in the library context, simply do this:
  int foo_some_function(OSSL_LIB_CTX *ctx)
  {
     if (!ossl_lib_ctx_run_once(ctx,
-                              OSSL_LIB_CTX_FOO_RUN_ONCE_INDEX,
-                              do_foo_init))
+                               OSSL_LIB_CTX_FOO_RUN_ONCE_INDEX,
+                               do_foo_init))
         return 0;
 
     /* Do some work using foo resources in ctx */

--- a/doc/internal/man3/ossl_lib_ctx_get_data.pod
+++ b/doc/internal/man3/ossl_lib_ctx_get_data.pod
@@ -2,29 +2,29 @@
 
 =head1 NAME
 
-openssl_ctx_get_data, openssl_ctx_run_once, openssl_ctx_onfree
-- internal OPENSSL_CTX routines
+ossl_lib_ctx_get_data, ossl_lib_ctx_run_once, ossl_lib_ctx_onfree
+- internal OSSL_LIB_CTX routines
 
 =head1 SYNOPSIS
 
  #include <openssl/types.h>
  #include "internal/cryptlib.h"
 
- typedef struct openssl_ctx_method {
-     void *(*new_func)(OPENSSL_CTX *ctx);
+ typedef struct ossl_lib_ctx_method {
+     void *(*new_func)(OSSL_LIB_CTX *ctx);
      void (*free_func)(void *);
- } OPENSSL_CTX_METHOD;
+ } OSSL_LIB_CTX_METHOD;
 
- void *openssl_ctx_get_data(OPENSSL_CTX *ctx, int index,
-                            const OPENSSL_CTX_METHOD *meth);
+ void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index,
+                            const OSSL_LIB_CTX_METHOD *meth);
 
- int openssl_ctx_run_once(OPENSSL_CTX *ctx, unsigned int idx,
-                          openssl_ctx_run_once_fn run_once_fn);
- int openssl_ctx_onfree(OPENSSL_CTX *ctx, openssl_ctx_onfree_fn onfreefn);
+ int ossl_lib_ctx_run_once(OSSL_LIB_CTX *ctx, unsigned int idx,
+                          ossl_lib_ctx_run_once_fn run_once_fn);
+ int ossl_lib_ctx_onfree(OSSL_LIB_CTX *ctx, ossl_lib_ctx_onfree_fn onfreefn);
 
 =head1 DESCRIPTION
 
-Internally, the OpenSSL library context B<OPENSSL_CTX> is implemented
+Internally, the OpenSSL library context B<OSSL_LIB_CTX> is implemented
 as a B<CRYPTO_EX_DATA>, which allows data from diverse parts of the
 library to be added and removed dynamically.
 Each such data item must have a corresponding CRYPTO_EX_DATA index
@@ -33,9 +33,9 @@ to identify data items. These are mapped transparently to CRYPTO_EX_DATA dynamic
 indexes internally to the implementation.
 See the example further down to see how that's done.
 
-openssl_ctx_get_data() is used to retrieve a pointer to the data in
+ossl_lib_ctx_get_data() is used to retrieve a pointer to the data in
 the library context I<ctx> associated with the given I<index>. An
-OPENSSL_CTX_METHOD must be defined and given in the I<meth> parameter. The index
+OSSL_LIB_CTX_METHOD must be defined and given in the I<meth> parameter. The index
 for it should be defined in cryptlib.h. The functions through the method are
 used to create or free items that are stored at that index whenever a library
 context is created or freed, meaning that the code that use a data item of that
@@ -44,18 +44,18 @@ index doesn't have to worry about that, just use the data available.
 Deallocation of an index happens automatically when the library
 context is freed.
 
-openssl_ctx_run_once is used to run some initialisation routine I<run_once_fn>
+ossl_lib_ctx_run_once is used to run some initialisation routine I<run_once_fn>
 exactly once per library context I<ctx> object. Each initialisation routine
 should be allocate a unique run once index in cryptlib.h.
 
 Any resources allocated via a run once initialisation routine can be cleaned up
-using openssl_ctx_onfree. This associates an "on free" routine I<onfreefn> with
+using ossl_lib_ctx_onfree. This associates an "on free" routine I<onfreefn> with
 the library context I<ctx>. When I<ctx> is freed all associated "on free"
 routines are called.
 
 =head1 RETURN VALUES
 
-openssl_ctx_get_data() returns a pointer on success, or NULL on
+ossl_lib_ctx_get_data() returns a pointer on success, or NULL on
 failure.
 
 =head1 EXAMPLES
@@ -71,7 +71,7 @@ and a destructor to an index.
      void *data;
  } FOO;
 
- static void *foo_new(OPENSSL_CTX *ctx)
+ static void *foo_new(OSSL_LIB_CTX *ctx)
  {
      FOO *ptr = OPENSSL_zalloc(sizeof(*foo));
      if (ptr != NULL)
@@ -85,9 +85,9 @@ and a destructor to an index.
 
  /*
   * Include a reference to this in the methods table in context.c 
-  * OPENSSL_CTX_FOO_INDEX should be added to internal/cryptlib.h
+  * OSSL_LIB_CTX_FOO_INDEX should be added to internal/cryptlib.h
   */
- const OPENSSL_CTX_METHOD foo_method = {
+ const OSSL_LIB_CTX_METHOD foo_method = {
      foo_new,
      foo_free
  };
@@ -99,26 +99,26 @@ To get and use the data stored in the library context, simply do this:
  /*
   * ctx is received from a caller,
   */
- FOO *data = openssl_ctx_get_data(ctx, OPENSSL_CTX_FOO_INDEX, &foo_method);
+ FOO *data = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_FOO_INDEX, &foo_method);
 
 =head2 Run Once
 
- void foo_cleanup(OPENSSL_CTX *ctx)
+ void foo_cleanup(OSSL_LIB_CTX *ctx)
  {
      /* Free foo resources associated with ctx */
  }
 
- static openssl_ctx_run_once_fn do_foo_init;
- static int do_foo_init(OPENSSL_CTX *ctx)
+ static ossl_lib_ctx_run_once_fn do_foo_init;
+ static int do_foo_init(OSSL_LIB_CTX *ctx)
  {
      /* Allocate and initialise some foo resources and associated with ctx */
-     return openssl_ctx_onfree(ctx, &foo_cleanup)
+     return ossl_lib_ctx_onfree(ctx, &foo_cleanup)
  }
 
- int foo_some_function(OPENSSL_CTX *ctx)
+ int foo_some_function(OSSL_LIB_CTX *ctx)
  {
-    if (!openssl_ctx_run_once(ctx,
-                              OPENSSL_CTX_FOO_RUN_ONCE_INDEX,
+    if (!ossl_lib_ctx_run_once(ctx,
+                              OSSL_LIB_CTX_FOO_RUN_ONCE_INDEX,
                               do_foo_init))
         return 0;
 
@@ -128,7 +128,7 @@ To get and use the data stored in the library context, simply do this:
 
 =head1 SEE ALSO
 
-L<OPENSSL_CTX(3)>
+L<OSSL_LIB_CTX(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -11,13 +11,13 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
 
  struct ossl_method_construct_method_st {
      /* Create store */
-     void *(*alloc_tmp_store)(OPENSSL_CTX *ctx);
+     void *(*alloc_tmp_store)(OSSL_LIB_CTX *ctx);
      /* Remove a store */
      void (*dealloc_tmp_store)(void *store);
      /* Get an already existing method from a store */
-     void *(*get)(OPENSSL_CTX *libctx, void *store, void *data);
+     void *(*get)(OSSL_LIB_CTX *libctx, void *store, void *data);
      /* Store a method in a store */
-     int (*put)(OPENSSL_CTX *libctx, void *store, void *method,
+     int (*put)(OSSL_LIB_CTX *libctx, void *store, void *method,
                 const OSSL_PROVIDER *prov, int operation_id, const char *name,
                 const char *propdef, void *data);
      /* Construct a new method */
@@ -28,7 +28,7 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
  };
  typedef struct ossl_method_construct_method OSSL_METHOD_CONSTRUCT_METHOD;
 
- void *ossl_method_construct(OPENSSL_CTX *ctx, int operation_id,
+ void *ossl_method_construct(OSSL_LIB_CTX *ctx, int operation_id,
                              int force_cache,
                              OSSL_METHOD_CONSTRUCT_METHOD *mcm, void *mcm_data);
 

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -12,7 +12,7 @@ ossl_namemap_doall_names
 
  #include "internal/cryptlib.h"
 
- OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx);
+ OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx);
 
  OSSL_NAMEMAP *ossl_namemap_new(void);
  void ossl_namemap_free(OSSL_NAMEMAP *namemap);

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -22,9 +22,9 @@ ossl_provider_get_capabilities
 
  #include "internal/provider.h"
 
- OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name,
+ OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
                                    int noconfig);
- OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
+ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
                                   ossl_provider_init_fn *init_function
                                   int noconfig);
  int ossl_provider_up_ref(OSSL_PROVIDER *prov);
@@ -45,7 +45,7 @@ ossl_provider_get_capabilities
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
 
  /* Iterate over all loaded providers */
- int ossl_provider_forall_loaded(OPENSSL_CTX *,
+ int ossl_provider_forall_loaded(OSSL_LIB_CTX *,
                                  int (*cb)(OSSL_PROVIDER *provider,
                                            void *cbdata),
                                  void *cbdata);
@@ -55,7 +55,7 @@ ossl_provider_get_capabilities
  const DSO *ossl_provider_dso(OSSL_PROVIDER *prov);
  const char *ossl_provider_module_name(OSSL_PROVIDER *prov);
  const char *ossl_provider_module_path(OSSL_PROVIDER *prov);
- OPENSSL_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov);
+ OSSL_LIB_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov);
 
  /* Thin wrappers around calls to the provider */
  void ossl_provider_teardown(const OSSL_PROVIDER *prov);

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -11,7 +11,7 @@ ossl_provider_ctx,
 ossl_provider_forall_loaded,
 ossl_provider_name, ossl_provider_dso,
 ossl_provider_module_name, ossl_provider_module_path,
-ossl_provider_library_context,
+ossl_provider_libctx,
 ossl_provider_teardown, ossl_provider_gettable_params,
 ossl_provider_get_params, ossl_provider_query_operation,
 ossl_provider_set_operation_bit, ossl_provider_test_operation_bit,
@@ -55,7 +55,7 @@ ossl_provider_get_capabilities
  const DSO *ossl_provider_dso(OSSL_PROVIDER *prov);
  const char *ossl_provider_module_name(OSSL_PROVIDER *prov);
  const char *ossl_provider_module_path(OSSL_PROVIDER *prov);
- OSSL_LIB_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov);
+ OSSL_LIB_CTX *ossl_provider_libctx(const OSSL_PROVIDER *prov);
 
  /* Thin wrappers around calls to the provider */
  void ossl_provider_teardown(const OSSL_PROVIDER *prov);
@@ -144,7 +144,7 @@ This will be used in preference to automatically trying to figure out
 the path from the provider name and the default module directory (more
 on this in L</NOTES>).
 
-ossl_provider_library_context() returns the library context the given
+ossl_provider_libctx() returns the library context the given
 provider I<prov> is registered in.
 
 ossl_provider_add_parameter() adds a global parameter for the provider
@@ -280,7 +280,7 @@ ossl_provider_module_name(), and ossl_provider_module_path() return a
 pointer to their respective data if it's available, otherwise NULL
 is returned.
 
-ossl_provider_library_context() return a pointer to the library context.
+ossl_provider_libctx() return a pointer to the library context.
 This may be NULL, and is perfectly valid, as it denotes the default
 global library context.
 

--- a/doc/internal/man3/x509v3_cache_extensions.pod
+++ b/doc/internal/man3/x509v3_cache_extensions.pod
@@ -9,7 +9,7 @@ x509v3_cache_extensions
 
  #include <openssl/x509v3.h>
 
- int x509v3_cache_extensions(X509 *x, OPENSSL_CTX *libctx, const char *propq);
+ int x509v3_cache_extensions(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/BN_CTX_new.pod
+++ b/doc/man3/BN_CTX_new.pod
@@ -9,10 +9,10 @@ BN_CTX_new_ex, BN_CTX_new, BN_CTX_secure_new_ex, BN_CTX_secure_new, BN_CTX_free
 
  #include <openssl/bn.h>
 
- BN_CTX *BN_CTX_new_ex(OPENSSL_CTX *ctx);
+ BN_CTX *BN_CTX_new_ex(OSSL_LIB_CTX *ctx);
  BN_CTX *BN_CTX_new(void);
 
- BN_CTX *BN_CTX_secure_new_ex(OPENSSL_CTX *ctx);
+ BN_CTX *BN_CTX_secure_new_ex(OSSL_LIB_CTX *ctx);
  BN_CTX *BN_CTX_secure_new(void);
 
  void BN_CTX_free(BN_CTX *c);

--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -113,12 +113,12 @@ It is recommended that B<add> is a multiple of 4.
 The random generator must be seeded prior to calling BN_generate_prime_ex().
 If the automatic seeding or reseeding of the OpenSSL CSPRNG fails due to
 external circumstances (see L<RAND(7)>), the operation will fail.
-The random number generator configured for the OPENSSL_CTX associated with
+The random number generator configured for the OSSL_LIB_CTX associated with
 B<ctx> will be used.
 
 BN_generate_prime_ex() is the same as BN_generate_prime_ex2() except that no
 B<ctx> parameter is passed.
-In this case the random number generator associated with the default OPENSSL_CTX
+In this case the random number generator associated with the default OSSL_LIB_CTX
 will be used.
 
 BN_check_prime(), BN_is_prime_ex(), BN_is_prime_fasttest_ex(), BN_is_prime()

--- a/doc/man3/CMS_EncryptedData_encrypt.pod
+++ b/doc/man3/CMS_EncryptedData_encrypt.pod
@@ -14,7 +14,7 @@ CMS_EncryptedData_encrypt_ex, CMS_EncryptedData_encrypt
                                                const unsigned char *key,
                                                size_t keylen,
                                                unsigned int flags,
-                                               OPENSSL_CTX *ctx,
+                                               OSSL_LIB_CTX *ctx,
                                                const char *propq);
 
  CMS_ContentInfo *CMS_EncryptedData_encrypt(BIO *in,

--- a/doc/man3/CMS_EnvelopedData_create.pod
+++ b/doc/man3/CMS_EnvelopedData_create.pod
@@ -11,12 +11,12 @@ CMS_AuthEnvelopedData_create, CMS_AuthEnvelopedData_create_ex
  #include <openssl/cms.h>
 
  CMS_ContentInfo *
- CMS_EnvelopedData_create_ex(const EVP_CIPHER *cipher, OPENSSL_CTX *libctx,
+ CMS_EnvelopedData_create_ex(const EVP_CIPHER *cipher, OSSL_LIB_CTX *libctx,
                              const char *propq);
  CMS_ContentInfo *CMS_EnvelopedData_create(const EVP_CIPHER *cipher);
 
  CMS_ContentInfo *
- CMS_AuthEnvelopedData_create_ex(const EVP_CIPHER *cipher, OPENSSL_CTX *libctx,
+ CMS_AuthEnvelopedData_create_ex(const EVP_CIPHER *cipher, OSSL_LIB_CTX *libctx,
                                  const char *propq);
  CMS_ContentInfo *CMS_AuthEnvelopedData_create(const EVP_CIPHER *cipher);
 

--- a/doc/man3/CMS_data_create.pod
+++ b/doc/man3/CMS_data_create.pod
@@ -10,7 +10,7 @@ CMS_data_create_ex, CMS_data_create
  #include <openssl/cms.h>
 
  CMS_ContentInfo *CMS_data_create_ex(BIO *in, unsigned int flags,
-                                     OPENSSL_CTX *libctx, const char *propq);
+                                     OSSL_LIB_CTX *libctx, const char *propq);
  CMS_ContentInfo *CMS_data_create(BIO *in, unsigned int flags);
 
 =head1 DESCRIPTION

--- a/doc/man3/CMS_digest_create.pod
+++ b/doc/man3/CMS_digest_create.pod
@@ -10,7 +10,7 @@ CMS_digest_create_ex, CMS_digest_create
  #include <openssl/cms.h>
 
  CMS_ContentInfo *CMS_digest_create_ex(BIO *in, const EVP_MD *md,
-                                       unsigned int flags, OPENSSL_CTX *ctx,
+                                       unsigned int flags, OSSL_LIB_CTX *ctx,
                                        const char *propq);
 
  CMS_ContentInfo *CMS_digest_create(BIO *in, const EVP_MD *md,

--- a/doc/man3/CMS_encrypt.pod
+++ b/doc/man3/CMS_encrypt.pod
@@ -10,7 +10,7 @@ CMS_encrypt_ex, CMS_encrypt - create a CMS envelopedData structure
 
  CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
                                  const EVP_CIPHER *cipher, unsigned int flags,
-                                 OPENSSL_CTX *libctx, const char *propq);
+                                 OSSL_LIB_CTX *libctx, const char *propq);
  CMS_ContentInfo *CMS_encrypt(STACK_OF(X509) *certs, BIO *in,
                               const EVP_CIPHER *cipher, unsigned int flags);
 

--- a/doc/man3/CMS_get1_ReceiptRequest.pod
+++ b/doc/man3/CMS_get1_ReceiptRequest.pod
@@ -13,7 +13,7 @@ CMS_add1_ReceiptRequest, CMS_get1_ReceiptRequest, CMS_ReceiptRequest_get0_values
  CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
      unsigned char *id, int idlen, int allorfirst,
      STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo,
-     OPENSSL_CTX *libctx, const char *propq);
+     OSSL_LIB_CTX *libctx, const char *propq);
  CMS_ReceiptRequest *CMS_ReceiptRequest_create0(
      unsigned char *id, int idlen, int allorfirst,
      STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo);

--- a/doc/man3/CMS_sign.pod
+++ b/doc/man3/CMS_sign.pod
@@ -10,7 +10,7 @@ CMS_sign, CMS_sign_ex - create a CMS SignedData structure
 
  CMS_ContentInfo *CMS_sign_ex(X509 *signcert, EVP_PKEY *pkey,
                               STACK_OF(X509) *certs, BIO *data,
-                              unsigned int flags, OPENSSL_CTX *ctx,
+                              unsigned int flags, OSSL_LIB_CTX *ctx,
                               const char *propq);
  CMS_ContentInfo *CMS_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
                            BIO *data, unsigned int flags);

--- a/doc/man3/CONF_modules_load_file.pod
+++ b/doc/man3/CONF_modules_load_file.pod
@@ -9,7 +9,7 @@ CONF_modules_load_file_ex, CONF_modules_load_file, CONF_modules_load
 
  #include <openssl/conf.h>
 
- int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
+ int CONF_modules_load_file_ex(OSSL_LIB_CTX *libctx, const char *filename,
                                const char *appname, unsigned long flags);
  int CONF_modules_load_file(const char *filename, const char *appname,
                             unsigned long flags);

--- a/doc/man3/CTLOG_STORE_new.pod
+++ b/doc/man3/CTLOG_STORE_new.pod
@@ -11,7 +11,7 @@ Create and populate a Certificate Transparency log list
 
  #include <openssl/ct.h>
 
- CTLOG_STORE *CTLOG_STORE_new_ex(OPENSSL_CTX *libctx, const char *propq);
+ CTLOG_STORE *CTLOG_STORE_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  CTLOG_STORE *CTLOG_STORE_new(void);
  void CTLOG_STORE_free(CTLOG_STORE *store);
 

--- a/doc/man3/CTLOG_new.pod
+++ b/doc/man3/CTLOG_new.pod
@@ -12,11 +12,11 @@ encapsulates information about a Certificate Transparency log
  #include <openssl/ct.h>
 
  CTLOG *CTLOG_new_ex(EVP_PKEY *public_key, const char *name,
-                     OPENSSL_CTX *libctx, const char *propq);
+                     OSSL_LIB_CTX *libctx, const char *propq);
  CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
 
  int CTLOG_new_from_base64_ex(CTLOG **ct_log, const char *pkey_base64,
-                              const char *name, OPENSSL_CTX *libctx,
+                              const char *name, OSSL_LIB_CTX *libctx,
                               const char *propq);
  int CTLOG_new_from_base64(CTLOG ** ct_log,
                            const char *pkey_base64, const char *name);

--- a/doc/man3/CT_POLICY_EVAL_CTX_new.pod
+++ b/doc/man3/CT_POLICY_EVAL_CTX_new.pod
@@ -14,7 +14,7 @@ Encapsulates the data required to evaluate whether SCTs meet a Certificate Trans
 
  #include <openssl/ct.h>
 
- CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OPENSSL_CTX *libctx,
+ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OSSL_LIB_CTX *libctx,
                                                const char *propq);
  CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new(void);
  void CT_POLICY_EVAL_CTX_free(CT_POLICY_EVAL_CTX *ctx);

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -28,7 +28,7 @@ objects
  #include <openssl/ec.h>
 
  EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
-                                    OPENSSL_CTX *libctx, const char *propq);
+                                    OSSL_LIB_CTX *libctx, const char *propq);
  EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params);
  EC_GROUP *EC_GROUP_new_from_ecpkparameters(const ECPKPARAMETERS *params);
  void EC_GROUP_free(EC_GROUP *group);
@@ -37,7 +37,7 @@ objects
                                   const BIGNUM *b, BN_CTX *ctx);
  EC_GROUP *EC_GROUP_new_curve_GF2m(const BIGNUM *p, const BIGNUM *a,
                                    const BIGNUM *b, BN_CTX *ctx);
- EC_GROUP *EC_GROUP_new_by_curve_name_ex(OPENSSL_CTX *libctx, const char *propq,
+ EC_GROUP *EC_GROUP_new_by_curve_name_ex(OSSL_LIB_CTX *libctx, const char *propq,
                                          int nid);
  EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
 
@@ -90,14 +90,14 @@ pentanomial for this parameter.
 Although deprecated since OpenSSL 3.0 and should no longer be used,
 a new curve can be constructed by calling EC_GROUP_new(), using the
 implementation provided by I<meth> (see L<EC_GFp_simple_method(3)>) and
-associated with the library context I<ctx> (see L<OPENSSL_CTX(3)>).
+associated with the library context I<ctx> (see L<OSSL_LIB_CTX(3)>).
 The I<ctx> parameter may be NULL in which case the default library context is
 used.
 It is then necessary to call EC_GROUP_set_curve() to set the curve parameters.
 Applications should instead use one of the other EC_GROUP_new_* constructors.
 
 EC_GROUP_new_from_params() creates a group with parameters specified by I<params>.
-The library context I<libctx> (see L<OPENSSL_CTX(3)>) and property query string
+The library context I<libctx> (see L<OSSL_LIB_CTX(3)>) and property query string
 I<propq> are used to fetch algorithms from providers.
 I<params> may be either a list of explicit params or a named group,
 The values for I<ctx> and I<propq> may be NULL.
@@ -155,7 +155,7 @@ readable comment string describing the curve.
 In order to construct a built-in curve use the function
 EC_GROUP_new_by_curve_name_ex() and provide the I<nid> of the curve to
 be constructed, the associated library context to be used in I<ctx> (see
-L<OPENSSL_CTX(3)>) and any property query string in I<propq>. The I<ctx> value
+L<OSSL_LIB_CTX(3)>) and any property query string in I<propq>. The I<ctx> value
 may be NULL in which case the default library context is used. The I<propq>
 value may also be NULL.
 
@@ -188,7 +188,7 @@ EC_GROUP_get_curve_GF2m() return 1 on success or 0 on error.
 L<crypto(7)>, L<EC_GROUP_copy(3)>,
 L<EC_POINT_new(3)>, L<EC_POINT_add(3)>, L<EC_KEY_new(3)>,
 L<EC_GFp_simple_method(3)>, L<d2i_ECPKParameters(3)>,
-L<OPENSSL_CTX(3)>, L<EVP_PKEY-EC(7)>
+L<OSSL_LIB_CTX(3)>, L<EVP_PKEY-EC(7)>
 
 =head1 HISTORY
 

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -20,12 +20,12 @@ EC_KEY objects
 
  #include <openssl/ec.h>
 
- EC_KEY *EC_KEY_new_ex(OPENSSL_CTX *ctx, const char *propq);
+ EC_KEY *EC_KEY_new_ex(OSSL_LIB_CTX *ctx, const char *propq);
  EC_KEY *EC_KEY_new(void);
  int EC_KEY_get_flags(const EC_KEY *key);
  void EC_KEY_set_flags(EC_KEY *key, int flags);
  void EC_KEY_clear_flags(EC_KEY *key, int flags);
- EC_KEY *EC_KEY_new_by_curve_name_ex(OPENSSL_CTX *ctx, const char *propq,
+ EC_KEY *EC_KEY_new_by_curve_name_ex(OSSL_LIB_CTX *ctx, const char *propq,
                                      int nid);
  EC_KEY *EC_KEY_new_by_curve_name(int nid);
  void EC_KEY_free(EC_KEY *key);
@@ -68,7 +68,7 @@ An EC_KEY represents a public key and, optionally, the associated private
 key.
 A new EC_KEY with no associated curve can be constructed by calling
 EC_KEY_new_ex() and specifying the associated library context in I<ctx>
-(see L<OPENSSL_CTX(3)>) and property query string I<propq>.
+(see L<OSSL_LIB_CTX(3)>) and property query string I<propq>.
 The I<ctx> parameter may be NULL in which case the default library context is
 used.
 The reference count for the newly created EC_KEY is initially
@@ -81,7 +81,7 @@ context is always used.
 
 Alternatively a new EC_KEY can be constructed by calling
 EC_KEY_new_by_curve_name_ex() and supplying the nid of the associated
-curve, the library context to be used I<ctx> (see L<OPENSSL_CTX(3)>) and any
+curve, the library context to be used I<ctx> (see L<OSSL_LIB_CTX(3)>) and any
 property query string I<propq>.
 The I<ctx> parameter may be NULL in which case the default library context is
 used. The I<propq> value may also be NULL.
@@ -209,7 +209,7 @@ L<EC_GROUP_copy(3)>, L<EC_POINT_new(3)>,
 L<EC_POINT_add(3)>,
 L<EC_GFp_simple_method(3)>,
 L<d2i_ECPKParameters(3)>,
-L<OPENSSL_CTX(3)>
+L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/EVP_ASYM_CIPHER_free.pod
+++ b/doc/man3/EVP_ASYM_CIPHER_free.pod
@@ -12,14 +12,14 @@ EVP_ASYM_CIPHER_gettable_ctx_params, EVP_ASYM_CIPHER_settable_ctx_params
 
  #include <openssl/evp.h>
 
- EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                         const char *properties);
  void EVP_ASYM_CIPHER_free(EVP_ASYM_CIPHER *cipher);
  int EVP_ASYM_CIPHER_up_ref(EVP_ASYM_CIPHER *cipher);
  int EVP_ASYM_CIPHER_number(const EVP_ASYM_CIPHER *cipher);
  int EVP_ASYM_CIPHER_is_a(const EVP_ASYM_CIPHER *cipher, const char *name);
  OSSL_PROVIDER *EVP_ASYM_CIPHER_provider(const EVP_ASYM_CIPHER *cipher);
- void EVP_ASYM_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                       void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                  void *arg),
                                       void *arg);
@@ -34,7 +34,7 @@ EVP_ASYM_CIPHER_gettable_ctx_params, EVP_ASYM_CIPHER_settable_ctx_params
 EVP_ASYM_CIPHER_fetch() fetches the implementation for the given
 B<algorithm> from any provider offering it, within the criteria given
 by the B<properties> and in the scope of the given library context B<ctx> (see
-L<OPENSSL_CTX(3)>). The algorithm will be one offering functions for performing
+L<OSSL_LIB_CTX(3)>). The algorithm will be one offering functions for performing
 asymmetric cipher related tasks such as asymmetric encryption and decryption.
 See L<provider(7)/Fetching algorithms> for further information.
 

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -27,7 +27,7 @@ EVP_MD_do_all_provided
 
  #include <openssl/evp.h>
 
- EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                       const char *properties);
  int EVP_MD_up_ref(EVP_MD *md);
  void EVP_MD_free(EVP_MD *md);
@@ -95,7 +95,7 @@ EVP_MD_do_all_provided
  EVP_PKEY_CTX *EVP_MD_CTX_pkey_ctx(const EVP_MD_CTX *ctx);
  void EVP_MD_CTX_set_pkey_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pctx);
 
- void EVP_MD_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_MD *mac, void *arg),
                              void *arg);
 
@@ -259,7 +259,7 @@ identifiable with I<name>, otherwise 0.
 If I<md> is a legacy digest (it's the return value from the likes of
 EVP_sha256() rather than the result of an EVP_MD_fetch()), only cipher
 names registered with the default library context (see
-L<OPENSSL_CTX(3)>) will be considered.
+L<OSSL_LIB_CTX(3)>) will be considered.
 
 =item EVP_MD_number()
 

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -10,7 +10,7 @@ EVP_DigestSignFinal, EVP_DigestSign - EVP signing functions
  #include <openssl/evp.h>
 
  int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                           const char *mdname, OPENSSL_CTX *libctx,
+                           const char *mdname, OSSL_LIB_CTX *libctx,
                            const char *props, EVP_PKEY *pkey);
  int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                         const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
@@ -53,7 +53,7 @@ EVP_PKEY_CTX value before being passed to EVP_DigestSignInit_ex()
 (which means the EVP_PKEY_CTX is created inside EVP_DigestSignInit_ex()
 and it will be freed automatically when the EVP_MD_CTX is freed). If the
 EVP_PKEY_CTX to be used is created by EVP_DigestSignInit_ex then it
-will use the B<OPENSSL_CTX> specified in I<libctx> and the property query string
+will use the B<OSSL_LIB_CTX> specified in I<libctx> and the property query string
 specified in I<props>.
 
 The digest I<mdname> may be NULL if the signing algorithm supports it. The

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -10,7 +10,7 @@ EVP_DigestVerifyFinal, EVP_DigestVerify - EVP signature verification functions
  #include <openssl/evp.h>
 
  int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                             const char *mdname, OPENSSL_CTX *libctx,
+                             const char *mdname, OSSL_LIB_CTX *libctx,
                              const char *props, EVP_PKEY *pkey);
  int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
@@ -52,7 +52,7 @@ an EVP_PKEY_CTX value before being passed to EVP_DigestVerifyInit_ex()
 (which means the EVP_PKEY_CTX is created inside
 EVP_DigestVerifyInit_ex() and it will be freed automatically when the
 EVP_MD_CTX is freed). If the EVP_PKEY_CTX to be used is created by
-EVP_DigestVerifyInit_ex then it will use the B<OPENSSL_CTX> specified
+EVP_DigestVerifyInit_ex then it will use the B<OSSL_LIB_CTX> specified
 in I<libctx> and the property query string specified in I<props>.
 
 No B<EVP_PKEY_CTX> will be created by EVP_DigestSignInit_ex() if the

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -72,7 +72,7 @@ EVP_CIPHER_do_all_provided
 
  #include <openssl/evp.h>
 
- EVP_CIPHER *EVP_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_CIPHER *EVP_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                               const char *properties);
  int EVP_CIPHER_up_ref(EVP_CIPHER *cipher);
  void EVP_CIPHER_free(EVP_CIPHER *cipher);
@@ -159,7 +159,7 @@ EVP_CIPHER_do_all_provided
  int EVP_CIPHER_param_to_asn1(EVP_CIPHER_CTX *c, ASN1_TYPE *type);
  int EVP_CIPHER_asn1_to_param(EVP_CIPHER_CTX *c, ASN1_TYPE *type);
 
- void EVP_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_CIPHER *cipher, void *arg),
                                  void *arg);
 
@@ -346,7 +346,7 @@ algorithm that's identifiable with I<name>, otherwise 0.
 If I<cipher> is a legacy cipher (it's the return value from the likes
 of EVP_aes128() rather than the result of an EVP_CIPHER_fetch()), only
 cipher names registered with the default library context (see
-L<OPENSSL_CTX(3)>) will be considered.
+L<OSSL_LIB_CTX(3)>) will be considered.
 
 EVP_CIPHER_number() returns the internal dynamic number assigned to
 the I<cipher>.  This is only useful with fetched B<EVP_CIPHER>s.

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -27,13 +27,13 @@ EVP_KDF_gettable_params - EVP KDF routines
  int EVP_KDF_derive(EVP_KDF_CTX *ctx, unsigned char *key, size_t keylen);
  int EVP_KDF_up_ref(EVP_KDF *kdf);
  void EVP_KDF_free(EVP_KDF *kdf);
- EVP_KDF *EVP_KDF_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+ EVP_KDF *EVP_KDF_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                         const char *properties);
  int EVP_KDF_number(const EVP_KDF *kdf);
  int EVP_KDF_is_a(const EVP_KDF *kdf, const char *name);
  const char *EVP_KDF_name(const EVP_KDF *kdf);
  const OSSL_PROVIDER *EVP_KDF_provider(const EVP_KDF *kdf);
- void EVP_KDF_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_KDF *kdf, void *arg),
                               void *arg);
  void EVP_KDF_names_do_all(const EVP_KDF *kdf,

--- a/doc/man3/EVP_KEM_free.pod
+++ b/doc/man3/EVP_KEM_free.pod
@@ -12,14 +12,14 @@ EVP_KEM_gettable_ctx_params, EVP_KEM_settable_ctx_params
 
  #include <openssl/evp.h>
 
- EVP_KEM *EVP_KEM_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_KEM *EVP_KEM_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                         const char *properties);
  void EVP_KEM_free(EVP_KEM *kem);
  int EVP_KEM_up_ref(EVP_KEM *kem);
  int EVP_KEM_number(const EVP_KEM *kem);
  int EVP_KEM_is_a(const EVP_KEM *kem, const char *name);
  OSSL_PROVIDER *EVP_KEM_provider(const EVP_KEM *kem);
- void EVP_KEM_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_KEM *kem, void *arg), void *arg);
  void EVP_KEM_names_do_all(const EVP_KEM *kem,
                            void (*fn)(const char *name, void *data), void *data);
@@ -30,7 +30,7 @@ EVP_KEM_gettable_ctx_params, EVP_KEM_settable_ctx_params
 
 EVP_KEM_fetch() fetches the implementation for the given B<algorithm> from any
 provider offering it, within the criteria given by the B<properties> and in the
-scope of the given library context B<ctx> (see L<OPENSSL_CTX(3)>). The algorithm
+scope of the given library context B<ctx> (see L<OSSL_LIB_CTX(3)>). The algorithm
 will be one offering functions for performing asymmetric kem related tasks such
 as key encapsulation and decapsulation.
 See L<provider(7)/Fetching algorithms> for further information.

--- a/doc/man3/EVP_KEYEXCH_free.pod
+++ b/doc/man3/EVP_KEYEXCH_free.pod
@@ -12,14 +12,14 @@ EVP_KEYEXCH_gettable_ctx_params, EVP_KEYEXCH_settable_ctx_params
 
  #include <openssl/evp.h>
 
- EVP_KEYEXCH *EVP_KEYEXCH_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_KEYEXCH *EVP_KEYEXCH_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                 const char *properties);
  void EVP_KEYEXCH_free(EVP_KEYEXCH *exchange);
  int EVP_KEYEXCH_up_ref(EVP_KEYEXCH *exchange);
  OSSL_PROVIDER *EVP_KEYEXCH_provider(const EVP_KEYEXCH *exchange);
  int EVP_KEYEXCH_is_a(const EVP_KEYEXCH *exchange, const char *name);
  int EVP_KEYEXCH_number(const EVP_KEYEXCH *exchange);
- void EVP_KEYEXCH_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(EVP_KEYEXCH *exchange, void *arg),
                                   void *arg);
  void EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *exchange,

--- a/doc/man3/EVP_KEYMGMT.pod
+++ b/doc/man3/EVP_KEYMGMT.pod
@@ -23,7 +23,7 @@ EVP_KEYMGMT_gen_settable_params
 
  typedef struct evp_keymgmt_st EVP_KEYMGMT;
 
- EVP_KEYMGMT *EVP_KEYMGMT_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                 const char *properties);
  int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt);
  void EVP_KEYMGMT_free(EVP_KEYMGMT *keymgmt);
@@ -32,7 +32,7 @@ EVP_KEYMGMT_gen_settable_params
  int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt);
  const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt);
 
- void EVP_KEYMGMT_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
                                   void *arg);
  void EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
@@ -54,7 +54,7 @@ public interface, this object is simply passed into other functions
 when needed.
 
 EVP_KEYMGMT_fetch() looks for an algorithm within the provider that
-has been loaded into the B<OPENSSL_CTX> given by I<ctx>, having the
+has been loaded into the B<OSSL_LIB_CTX> given by I<ctx>, having the
 name given by I<algorithm> and the properties given by I<properties>.
 
 EVP_KEYMGMT_up_ref() increments the reference count for the given
@@ -128,7 +128,7 @@ NULL on error.
 
 =head1 SEE ALSO
 
-L<EVP_MD_fetch(3)>, L<OPENSSL_CTX(3)>
+L<EVP_MD_fetch(3)>, L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -18,7 +18,7 @@ EVP_MAC_do_all_provided - EVP MAC routines
  typedef struct evp_mac_st EVP_MAC;
  typedef struct evp_mac_ctx_st EVP_MAC_CTX;
 
- EVP_MAC *EVP_MAC_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+ EVP_MAC *EVP_MAC_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                         const char *properties);
  int EVP_MAC_up_ref(EVP_MAC *mac);
  void EVP_MAC_free(EVP_MAC *mac);
@@ -48,7 +48,7 @@ EVP_MAC_do_all_provided - EVP MAC routines
  const OSSL_PARAM *EVP_MAC_gettable_ctx_params(const EVP_MAC *mac);
  const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac);
 
- void EVP_MAC_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_MAC *mac, void *arg),
                               void *arg);
 

--- a/doc/man3/EVP_PKEY_CTX_get0_libctx.pod
+++ b/doc/man3/EVP_PKEY_CTX_get0_libctx.pod
@@ -4,25 +4,25 @@
 
 EVP_PKEY_CTX_get0_libctx,
 EVP_PKEY_CTX_get0_propq
-- functions for getting OPENSSL_CTX and property query data from an EVP_PKEY_CTX
+- functions for getting OSSL_LIB_CTX and property query data from an EVP_PKEY_CTX
 
 =head1 SYNOPSIS
 
  #include <openssl/evp.h>
 
- OPENSSL_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx);
+ OSSL_LIB_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx);
  const char *EVP_PKEY_CTX_get0_propq(EVP_PKEY_CTX *ctx);
 
 =head1 DESCRIPTION
 
 The EVP_PKEY_CTX_get0_libctx() and EVP_PKEY_CTX_get0_propq() functions obtain
-the OPENSSL_CTX and property query string values respectively that were
+the OSSL_LIB_CTX and property query string values respectively that were
 associated with the EVP_PKEY_CTX when it was constructed.
 
 =head1 RETURN VALUES
 
 EVP_PKEY_CTX_get0_libctx() and EVP_PKEY_CTX_get0_propq() functions return the
-OPENSSL_CTX and property query string associated with the EVP_PKEY_CTX or NULL
+OSSL_LIB_CTX and property query string associated with the EVP_PKEY_CTX or NULL
 if they are not set. The returned values should not be freed by the caller.
 
 =head1 SEE ALSO

--- a/doc/man3/EVP_PKEY_CTX_new.pod
+++ b/doc/man3/EVP_PKEY_CTX_new.pod
@@ -12,10 +12,10 @@ EVP_PKEY_CTX_new_from_pkey, EVP_PKEY_CTX_dup, EVP_PKEY_CTX_free
 
  EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
  EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
- EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OPENSSL_CTX *libctx,
+ EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OSSL_LIB_CTX *libctx,
                                           const char *name,
                                           const char *propquery);
- EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OPENSSL_CTX *libctx,
+ EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OSSL_LIB_CTX *libctx,
                                           EVP_PKEY *pkey,
                                           const char *propquery);
  EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *ctx);
@@ -30,14 +30,14 @@ The EVP_PKEY_CTX_new_id() function allocates public key algorithm context
 using the key type specified by I<id> and ENGINE I<e>.
 
 The EVP_PKEY_CTX_new_from_name() function allocates a public key algorithm
-context using the library context I<libctx> (see L<OPENSSL_CTX(3)>), the
+context using the library context I<libctx> (see L<OSSL_LIB_CTX(3)>), the
 key type specified by I<name> and the property query I<propquery>.  None
 of the arguments are duplicated, so they  must remain unchanged for the
 lifetime of the returned B<EVP_PKEY_CTX> or of any of its duplicates.  Read
 further about the possible names in L</NOTES> below.
 
 The EVP_PKEY_CTX_new_from_pkey() function allocates a public key algorithm
-context using the library context I<libctx> (see L<OPENSSL_CTX(3)>) and the
+context using the library context I<libctx> (see L<OSSL_LIB_CTX(3)>) and the
 algorithm specified by I<pkey> and the property query I<propquery>. None of the
 arguments are duplicated, so they must remain unchanged for the lifetime of the
 returned B<EVP_PKEY_CTX> or any of its duplicates.

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -24,14 +24,14 @@ EVP_PKEY_get_raw_public_key
  int EVP_PKEY_up_ref(EVP_PKEY *key);
  void EVP_PKEY_free(EVP_PKEY *key);
 
- EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OPENSSL_CTX *libctx,
+ EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OSSL_LIB_CTX *libctx,
                                            const char *keytype,
                                            const char *propq,
                                            const unsigned char *key,
                                            size_t keylen);
  EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *e,
                                         const unsigned char *key, size_t keylen);
- EVP_PKEY *EVP_PKEY_new_raw_public_key_ex(OPENSSL_CTX *libctx,
+ EVP_PKEY *EVP_PKEY_new_raw_public_key_ex(OSSL_LIB_CTX *libctx,
                                           const char *keytype,
                                           const char *propq,
                                           const unsigned char *key,
@@ -40,7 +40,7 @@ EVP_PKEY_get_raw_public_key
                                        const unsigned char *key, size_t keylen);
  EVP_PKEY *EVP_PKEY_new_CMAC_key_ex(const unsigned char *priv, size_t len,
                                     const char *cipher_name,
-                                    OPENSSL_CTX *libctx, const char *propq);
+                                    OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
                                  size_t len, const EVP_CIPHER *cipher);
  EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *e, const unsigned char *key,

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -21,7 +21,7 @@ EVP_RAND_STATE_ERROR - EVP RAND routines
  typedef struct evp_rand_st EVP_RAND;
  typedef struct evp_rand_ctx_st EVP_RAND_CTX;
 
- EVP_RAND *EVP_RAND_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+ EVP_RAND *EVP_RAND_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                         const char *properties);
  int EVP_RAND_up_ref(EVP_RAND *rand);
  void EVP_RAND_free(EVP_RAND *rand);
@@ -38,7 +38,7 @@ EVP_RAND_STATE_ERROR - EVP RAND routines
  const char *EVP_RAND_name(const EVP_RAND *rand);
  int EVP_RAND_is_a(const EVP_RAND *rand, const char *name);
  const OSSL_PROVIDER *EVP_RAND_provider(const EVP_RAND *rand);
- void EVP_RAND_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                                void (*fn)(EVP_RAND *rand, void *arg),
                                void *arg);
  void EVP_RAND_names_do_all(const EVP_RAND *rand,

--- a/doc/man3/EVP_SIGNATURE_free.pod
+++ b/doc/man3/EVP_SIGNATURE_free.pod
@@ -12,14 +12,14 @@ EVP_SIGNATURE_gettable_ctx_params, EVP_SIGNATURE_settable_ctx_params
 
  #include <openssl/evp.h>
 
- EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                     const char *properties);
  void EVP_SIGNATURE_free(EVP_SIGNATURE *signature);
  int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature);
  int EVP_SIGNATURE_number(const EVP_SIGNATURE *signature);
  int EVP_SIGNATURE_is_a(const EVP_SIGNATURE *signature, const char *name);
  OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature);
- void EVP_SIGNATURE_do_all_provided(OPENSSL_CTX *libctx,
+ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
                                     void (*fn)(EVP_SIGNATURE *signature,
                                                void *arg),
                                     void *arg);

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -13,7 +13,7 @@ EVP_SignFinal_ex, EVP_SignFinal
  int EVP_SignInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
  int EVP_SignUpdate(EVP_MD_CTX *ctx, const void *d, unsigned int cnt);
  int EVP_SignFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s,
-                      EVP_PKEY *pkey, OPENSSL_CTX *libctx, const char *propq);
+                      EVP_PKEY *pkey, OSSL_LIB_CTX *libctx, const char *propq);
  int EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *sig, unsigned int *s,
                    EVP_PKEY *pkey);
 

--- a/doc/man3/EVP_VerifyInit.pod
+++ b/doc/man3/EVP_VerifyInit.pod
@@ -14,7 +14,7 @@ EVP_VerifyInit, EVP_VerifyUpdate, EVP_VerifyFinal_ex, EVP_VerifyFinal
  int EVP_VerifyUpdate(EVP_MD_CTX *ctx, const void *d, unsigned int cnt);
  int EVP_VerifyFinal_ex(EVP_MD_CTX *ctx, const unsigned char *sigbuf,
                         unsigned int siglen, EVP_PKEY *pkey,
-                        OPENSSL_CTX *libctx, const char *propq);
+                        OSSL_LIB_CTX *libctx, const char *propq);
  int EVP_VerifyFinal(EVP_MD_CTX *ctx, unsigned char *sigbuf, unsigned int siglen,
                      EVP_PKEY *pkey);
 

--- a/doc/man3/EVP_set_default_properties.pod
+++ b/doc/man3/EVP_set_default_properties.pod
@@ -10,9 +10,9 @@ EVP_default_properties_is_fips_enabled
 
  #include <openssl/evp.h>
 
- int EVP_set_default_properties(OPENSSL_CTX *libctx, const char *propq);
- int EVP_default_properties_enable_fips(OPENSSL_CTX *libctx, int enable);
- int EVP_default_properties_is_fips_enabled(OPENSSL_CTX *libctx);
+ int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq);
+ int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable);
+ int EVP_default_properties_is_fips_enabled(OSSL_LIB_CTX *libctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/NCONF_new_ex.pod
+++ b/doc/man3/NCONF_new_ex.pod
@@ -9,7 +9,7 @@ NCONF_new_ex, NCONF_new, NCONF_free, NCONF_default, NCONF_load
 
  #include <openssl/conf.h>
 
- CONF *NCONF_new_ex(OPENSSL_CTX *libctx, CONF_METHOD *meth);
+ CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth);
  CONF *NCONF_new(CONF_METHOD *meth);
  void NCONF_free(CONF *conf);
  CONF_METHOD *NCONF_default(void);

--- a/doc/man3/OCSP_response_status.pod
+++ b/doc/man3/OCSP_response_status.pod
@@ -19,9 +19,9 @@ OCSP_RESPID_match, OCSP_basic_sign, OCSP_basic_sign_ctx
 
  int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert);
  int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
  int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert);
- int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OPENSSL_CTX *libctx,
+ int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
                           const char *propq);
  int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert);
 

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -15,7 +15,7 @@ and deinitialisation functions
  void OPENSSL_cleanup(void);
  int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
  int OPENSSL_atexit(void (*handler)(void));
- void OPENSSL_thread_stop_ex(OPENSSL_CTX *ctx);
+ void OPENSSL_thread_stop_ex(OSSL_LIB_CTX *ctx);
  void OPENSSL_thread_stop(void);
 
  OPENSSL_INIT_SETTINGS *OPENSSL_INIT_new(void);
@@ -214,24 +214,24 @@ process wide resources are freed. In the event that multiple stop handlers are
 registered, no guarantees are made about the order of execution.
 
 The OPENSSL_thread_stop_ex() function deallocates resources associated
-with the current thread for the given OPENSSL_CTX B<ctx>. The B<ctx> parameter
-can be NULL in which case the default OPENSSL_CTX is used.
+with the current thread for the given OSSL_LIB_CTX B<ctx>. The B<ctx> parameter
+can be NULL in which case the default OSSL_LIB_CTX is used.
 
 Typically, this function will be called automatically by the library when
-the thread exits as long as the OPENSSL_CTX has not been freed before the thread
-exits. If OPENSSL_CTX_free() is called OPENSSL_thread_stop_ex will be called
+the thread exits as long as the OSSL_LIB_CTX has not been freed before the thread
+exits. If OSSL_LIB_CTX_free() is called OPENSSL_thread_stop_ex will be called
 automatically for the current thread (but not any other threads that may have
-used this OPENSSL_CTX).
+used this OSSL_LIB_CTX).
 
 OPENSSL_thread_stop_ex should be called on all threads that will exit after the
-OPENSSL_CTX is freed.
-Typically this is not necessary for the default OPENSSL_CTX (because all
+OSSL_LIB_CTX is freed.
+Typically this is not necessary for the default OSSL_LIB_CTX (because all
 resources are cleaned up on library exit) except if thread local resources
 should be freed before library exit, or under the circumstances described in
 the NOTES section below.
 
 OPENSSL_thread_stop() is the same as OPENSSL_thread_stop_ex() except that the
-default OPENSSL_CTX is always used.
+default OSSL_LIB_CTX is always used.
 
 The B<OPENSSL_INIT_LOAD_CONFIG> flag will load a configuration file, as with
 L<CONF_modules_load_file(3)> with NULL filename and application name and the

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -67,7 +67,7 @@ OSSL_CMP_CTX_set1_senderNonce
 
  #include <openssl/cmp.h>
 
- OSSL_CMP_CTX *OSSL_CMP_CTX_new(OPENSSL_CTX *libctx, const char *propq);
+ OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq);
  void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val);

--- a/doc/man3/OSSL_CMP_SRV_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_SRV_CTX_new.pod
@@ -29,7 +29,7 @@ OSSL_CMP_SRV_CTX_set_grant_implicit_confirm
                                             const OSSL_CMP_MSG *req);
  OSSL_CMP_MSG *OSSL_CMP_CTX_server_perform(OSSL_CMP_CTX *client_ctx,
                                            const OSSL_CMP_MSG *req);
- OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OPENSSL_CTX *libctx, const char *propq);
+ OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OSSL_LIB_CTX *libctx, const char *propq);
  void OSSL_CMP_SRV_CTX_free(OSSL_CMP_SRV_CTX *srv_ctx);
 
  typedef OSSL_CMP_PKISI *(*OSSL_CMP_SRV_cert_request_cb_t)(

--- a/doc/man3/OSSL_CRMF_MSG_get0_tmpl.pod
+++ b/doc/man3/OSSL_CRMF_MSG_get0_tmpl.pod
@@ -26,7 +26,7 @@ OSSL_CRMF_MSG_get_certReqId
 
  X509
  *OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert(const OSSL_CRMF_ENCRYPTEDVALUE *ecert,
-                                        OPENSSL_CTX *libctx, const char *propq,
+                                        OSSL_LIB_CTX *libctx, const char *propq,
                                         EVP_PKEY *pkey);
 
  int OSSL_CRMF_MSG_get_certReqId(const OSSL_CRMF_MSG *crm);
@@ -50,7 +50,7 @@ of the given CertId I<cid>, which must be of ASN.1 type GEN_DIRNAME.
 
 OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert() decrypts the certificate in the given
 encryptedValue I<ecert>, using the private key I<pkey>, library context
-I<libctx> and property query string I<propq> (see L<OPENSSL_CTX(3)>).
+I<libctx> and property query string I<propq> (see L<OSSL_LIB_CTX(3)>).
 This is needed for the indirect POPO method as in RFC 4210 section 5.2.8.2.
 The function returns the decrypted certificate as a copy, leaving its ownership
 with the caller, who is responsible for freeing it.

--- a/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
+++ b/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
@@ -32,11 +32,11 @@ OSSL_CRMF_MSGS_verify_popo
 
  int OSSL_CRMF_MSG_create_popo(int meth, OSSL_CRMF_MSG *crm,
                                EVP_PKEY *pkey, const EVP_MD *digest,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
 
  int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
                                 int rid, int acceptRAVerified,
-                                OPENSSL_CTX *libctx, const char *propq);
+                                OSSL_LIB_CTX *libctx, const char *propq);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OSSL_CRMF_pbmp_new.pod
+++ b/doc/man3/OSSL_CRMF_pbmp_new.pod
@@ -10,13 +10,13 @@ OSSL_CRMF_pbmp_new
 
  #include <openssl/crmf.h>
 
- int OSSL_CRMF_pbm_new(OPENSSL_CTX *libctx, const char *propq,
+ int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
                        const OSSL_CRMF_PBMPARAMETER *pbmp,
                        const unsigned char *msg, size_t msglen,
                        const unsigned char *sec, size_t seclen,
                        unsigned char **mac, size_t *maclen);
 
- OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OPENSSL_CTX *libctx, size_t saltlen,
+ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t saltlen,
                                             int owfnid, size_t itercnt,
                                             int macnid);
 

--- a/doc/man3/OSSL_DECODER.pod
+++ b/doc/man3/OSSL_DECODER.pod
@@ -22,7 +22,7 @@ OSSL_DECODER_get_params
 
  typedef struct ossl_decoder_st OSSL_DECODER;
 
- OSSL_DECODER *OSSL_DECODER_fetch(OPENSSL_CTX *ctx, const char *name,
+ OSSL_DECODER *OSSL_DECODER_fetch(OSSL_LIB_CTX *ctx, const char *name,
                                   const char *properties);
  int OSSL_DECODER_up_ref(OSSL_DECODER *decoder);
  void OSSL_DECODER_free(OSSL_DECODER *decoder);
@@ -30,7 +30,7 @@ OSSL_DECODER_get_params
  const char *OSSL_DECODER_properties(const OSSL_DECODER *decoder);
  int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name);
  int OSSL_DECODER_number(const OSSL_DECODER *decoder);
- void OSSL_DECODER_do_all_provided(OPENSSL_CTX *libctx,
+ void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(OSSL_DECODER *decoder, void *arg),
                                    void *arg);
  void OSSL_DECODER_names_do_all(const OSSL_DECODER *decoder,
@@ -46,7 +46,7 @@ decode encoded data into an object of some type that the rest
 of OpenSSL knows how to handle.
 
 OSSL_DECODER_fetch() looks for an algorithm within the provider that
-has been loaded into the B<OPENSSL_CTX> given by I<ctx>, having the
+has been loaded into the B<OSSL_LIB_CTX> given by I<ctx>, having the
 name given by I<name> and the properties given by I<properties>.
 The I<name> determines what type of object the fetched decoder
 method is expected to be able to decode, and the properties are
@@ -124,7 +124,7 @@ Text, because pod2xxx doesn't like empty sections
 =head1 SEE ALSO
 
 L<provider(7)>, L<OSSL_DECODER_CTX(3)>, L<OSSL_DECODER_from_bio(3)>,
-L<OSSL_DECODER_CTX_new_by_EVP_PKEY(3)>, L<OPENSSL_CTX(3)>
+L<OSSL_DECODER_CTX_new_by_EVP_PKEY(3)>, L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_DECODER_CTX_new_by_EVP_PKEY.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_by_EVP_PKEY.pod
@@ -16,7 +16,7 @@ OSSL_DECODER_CTX_set_passphrase_cb
  OSSL_DECODER_CTX *
  OSSL_DECODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                   const char *input_type, const char *keytype,
-                                  OPENSSL_CTX *libctx, const char *propquery);
+                                  OSSL_LIB_CTX *libctx, const char *propquery);
 
  int OSSL_DECODER_CTX_set_passphrase(OSSL_DECODER_CTX *ctx,
                                      const unsigned char *kstr,

--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -22,7 +22,7 @@ OSSL_ENCODER_get_params
 
  typedef struct ossl_encoder_st OSSL_ENCODER;
 
- OSSL_ENCODER *OSSL_ENCODER_fetch(OPENSSL_CTX *ctx, const char *name,
+ OSSL_ENCODER *OSSL_ENCODER_fetch(OSSL_LIB_CTX *ctx, const char *name,
                                   const char *properties);
  int OSSL_ENCODER_up_ref(OSSL_ENCODER *encoder);
  void OSSL_ENCODER_free(OSSL_ENCODER *encoder);
@@ -30,7 +30,7 @@ OSSL_ENCODER_get_params
  const char *OSSL_ENCODER_properties(const OSSL_ENCODER *encoder);
  int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name);
  int OSSL_ENCODER_number(const OSSL_ENCODER *encoder);
- void OSSL_ENCODER_do_all_provided(OPENSSL_CTX *libctx,
+ void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(OSSL_ENCODER *encoder, void *arg),
                                    void *arg);
  void OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
@@ -46,7 +46,7 @@ encode an object of some kind to a encoded form, such as PEM,
 DER, or even human readable text.
 
 OSSL_ENCODER_fetch() looks for an algorithm within the provider that
-has been loaded into the B<OPENSSL_CTX> given by I<ctx>, having the
+has been loaded into the B<OSSL_LIB_CTX> given by I<ctx>, having the
 name given by I<name> and the properties given by I<properties>.
 The I<name> determines what type of object the fetched encoder
 method is expected to be able to encode, and the properties are
@@ -117,7 +117,7 @@ OSSL_ENCODER_number() returns an integer.
 =head1 SEE ALSO
 
 L<provider(7)>, L<OSSL_ENCODER_CTX(3)>, L<OSSL_ENCODER_to_bio(3)>,
-L<OSSL_ENCODER_CTX_new_by_EVP_PKEY(3)>, L<OPENSSL_CTX(3)>
+L<OSSL_ENCODER_CTX_new_by_EVP_PKEY(3)>, L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_ENCODER_CTX.pod
+++ b/doc/man3/OSSL_ENCODER_CTX.pod
@@ -42,7 +42,7 @@ OSSL_ENCODER_CTX_set_cleanup
 
  int OSSL_ENCODER_CTX_add_encoder(OSSL_ENCODER_CTX *ctx, OSSL_ENCODER *encoder);
  int OSSL_ENCODER_CTX_add_extra(OSSL_ENCODER_CTX *ctx,
-                                OPENSSL_CTX *libctx, const char *propq);
+                                OSSL_LIB_CTX *libctx, const char *propq);
  int OSSL_ENCODER_CTX_get_num_encoders(OSSL_ENCODER_CTX *ctx);
 
  typedef struct ossl_encoder_instance_st OSSL_ENCODER_INSTANCE;

--- a/doc/man3/OSSL_ENCODER_CTX_new_by_EVP_PKEY.pod
+++ b/doc/man3/OSSL_ENCODER_CTX_new_by_EVP_PKEY.pod
@@ -17,7 +17,7 @@ OSSL_ENCODER_CTX_set_passphrase_ui
  OSSL_ENCODER_CTX *
  OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                   const char *output_type, int selection,
-                                  OPENSSL_CTX *libctx, const char *propquery);
+                                  OSSL_LIB_CTX *libctx, const char *propquery);
 
  int OSSL_ENCODER_CTX_set_cipher(OSSL_ENCODER_CTX *ctx,
                                  const char *cipher_name,

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -2,43 +2,43 @@
 
 =head1 NAME
 
-OPENSSL_CTX, OPENSSL_CTX_new, OPENSSL_CTX_free, OPENSSL_CTX_load_config,
-OPENSSL_CTX_set0_default
+OSSL_LIB_CTX, OSSL_LIB_CTX_new, OSSL_LIB_CTX_free, OSSL_LIB_CTX_load_config,
+OSSL_LIB_CTX_set0_default
 - OpenSSL library context
 
 =head1 SYNOPSIS
 
  #include <openssl/crypto.h>
 
- typedef struct openssl_ctx_st OPENSSL_CTX;
+ typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
 
- OPENSSL_CTX *OPENSSL_CTX_new(void);
- int OPENSSL_CTX_load_config(OPENSSL_CTX *ctx, const char *config_file);
- void OPENSSL_CTX_free(OPENSSL_CTX *ctx);
- OPENSSL_CTX *OPENSSL_CTX_set0_default(OPENSSL_CTX *ctx);
+ OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
+ int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
+ void OSSL_LIB_CTX_free(OSSL_LIB_CTX *ctx);
+ OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *ctx);
 
 =head1 DESCRIPTION
 
-B<OPENSSL_CTX> is an internal OpenSSL library context type.
+B<OSSL_LIB_CTX> is an internal OpenSSL library context type.
 Applications may allocate their own, but may also use NULL to use
-a default context with functions that take an B<OPENSSL_CTX>
+a default context with functions that take an B<OSSL_LIB_CTX>
 argument.
 
 When a non default library context is in use care should be taken with
 multi-threaded applications to properly clean up thread local resources before
-the OPENSSL_CTX is freed.
+the OSSL_LIB_CTX is freed.
 See L<OPENSSL_thread_stop_ex(3)> for more information.
 
-OPENSSL_CTX_new() creates a new OpenSSL library context.
+OSSL_LIB_CTX_new() creates a new OpenSSL library context.
 
-OPENSSL_CTX_load_config() loads a configuration file using the given C<ctx>.
+OSSL_LIB_CTX_load_config() loads a configuration file using the given C<ctx>.
 This can be used to associate a library context with providers that are loaded
 from a configuration.
 
-OPENSSL_CTX_free() frees the given I<ctx>, unless it happens to be the
+OSSL_LIB_CTX_free() frees the given I<ctx>, unless it happens to be the
 default OpenSSL library context.
 
-OPENSSL_CTX_set0_default() sets the default OpenSSL library context to be
+OSSL_LIB_CTX_set0_default() sets the default OpenSSL library context to be
 I<ctx> in the current thread.  The previous default library context is
 returned.  Care should be taken by the caller to restore the previous
 default library context with a subsequent call of this function.
@@ -53,15 +53,15 @@ that job has finished.
 
 =head1 RETURN VALUES
 
-OPENSSL_CTX_new() and OPENSSL_CTX_set0_default() return a library context
+OSSL_LIB_CTX_new() and OSSL_LIB_CTX_set0_default() return a library context
 pointer on success, or NULL on error.
 
-OPENSSL_CTX_free() doesn't return any value.
+OSSL_LIB_CTX_free() doesn't return any value.
 
 =head1 HISTORY
 
-OPENSSL_CTX, OPENSSL_CTX_new(), OPENSSL_CTX_load_config(), OPENSSL_CTX_free()
-and OPENSSL_CTX_set0_default() were added in OpenSSL 3.0.
+OSSL_LIB_CTX, OSSL_LIB_CTX_new(), OSSL_LIB_CTX_load_config(), OSSL_LIB_CTX_free()
+and OSSL_LIB_CTX_set0_default() were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -17,14 +17,14 @@ OSSL_PROVIDER_get_capabilities, OSSL_PROVIDER_self_test
 
  typedef struct ossl_provider_st OSSL_PROVIDER;
 
- void OSSL_PROVIDER_set_default_search_path(OPENSSL_CTX *libctx,
+ void OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *libctx,
                                             const char *path);
 
- OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *libctx, const char *name);
- OSSL_PROVIDER *OSSL_PROVIDER_try_load(OPENSSL_CTX *libctx, const char *name);
+ OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name);
+ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name);
  int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
- int OSSL_PROVIDER_available(OPENSSL_CTX *libctx, const char *name);
- int OSSL_PROVIDER_do_all(OPENSSL_CTX *ctx,
+ int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name);
+ int OSSL_PROVIDER_do_all(OSSL_LIB_CTX *ctx,
                           int (*cb)(OSSL_PROVIDER *provider, void *cbdata),
                           void *cbdata);
 
@@ -36,7 +36,7 @@ OSSL_PROVIDER_get_capabilities, OSSL_PROVIDER_self_test
                                                      int *no_cache);
  void *OSSL_PROVIDER_get0_provider_ctx(const OSSL_PROVIDER *prov);
 
- int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *libctx, const char *name,
+ int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
                                ossl_provider_init_fn *init_fn);
 
  const char *OSSL_PROVIDER_name(const OSSL_PROVIDER *prov);
@@ -57,7 +57,7 @@ libraries, or can be a loadable module.
 The functions described here handle both forms.
 
 Some of these functions operate within a library context, please see
-L<OPENSSL_CTX(3)> for further details.
+L<OSSL_LIB_CTX(3)> for further details.
 
 =head2 Functions
 
@@ -174,7 +174,7 @@ its build number.
 
 =head1 SEE ALSO
 
-L<openssl-core.h(7)>, L<OPENSSL_CTX(3)>, L<provider(7)>
+L<openssl-core.h(7)>, L<OSSL_LIB_CTX(3)>, L<provider(7)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_SELF_TEST_set_callback.pod
+++ b/doc/man3/OSSL_SELF_TEST_set_callback.pod
@@ -9,14 +9,14 @@ OSSL_SELF_TEST_get_callback - specify a callback for processing self tests
 
  #include <openssl/self_test.h>
 
- void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *ctx, OSSL_CALLBACK *cb, void *cbarg);
- void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *ctx, OSSL_CALLBACK **cb, void **cbarg);
+ void OSSL_SELF_TEST_set_callback(OSSL_LIB_CTX *ctx, OSSL_CALLBACK *cb, void *cbarg);
+ void OSSL_SELF_TEST_get_callback(OSSL_LIB_CTX *ctx, OSSL_CALLBACK **cb, void **cbarg);
 
 =head1 DESCRIPTION
 
 Set or gets the optional application callback (and the callback argument) that
 is called during self testing.
-The application callback B<OSSL_CALLBACK> is associated with a B<OPENSSL_CTX>.
+The application callback B<OSSL_CALLBACK> is associated with a B<OSSL_LIB_CTX>.
 The application callback function receives information about a running self test,
 and may return a result to the calling self test.
 See L<openssl-core.h(7)> for further information on the callback.
@@ -33,7 +33,7 @@ not been called.
 L<openssl-core.h(7)>,
 L<OSSL_PROVIDER-FIPS(7)>
 L<OSSL_SELF_TEST_new(3)>
-L<OPENSSL_CTX(3)>
+L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -34,7 +34,7 @@ unregister STORE loaders for different URI schemes
  typedef struct ossl_store_loader_st OSSL_STORE_LOADER;
 
  OSSL_STORE_LOADER *OSSL_STORE_LOADER_fetch(const char *scheme,
-                                            OPENSSL_CTX *libctx,
+                                            OSSL_LIB_CTX *libctx,
                                             const char *properties);
  int OSSL_STORE_LOADER_up_ref(OSSL_STORE_LOADER *loader);
  void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *loader);
@@ -44,7 +44,7 @@ unregister STORE loaders for different URI schemes
  int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader);
  int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader,
                             const char *scheme);
- void OSSL_STORE_LOADER_do_all_provided(OPENSSL_CTX *libctx,
+ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
                                         void (*fn)(OSSL_STORE_LOADER *loader,
                                                    void *arg),
                                         void *arg);
@@ -76,7 +76,7 @@ L<openssl_user_macros(7)>:
       OSSL_STORE_open_ex_fn store_open_ex_function);
  typedef OSSL_STORE_LOADER_CTX *(*OSSL_STORE_attach_fn)
      (const OSSL_STORE_LOADER *loader, BIO *bio,
-      OPENSSL_CTX *libctx, const char *propq,
+      OSSL_LIB_CTX *libctx, const char *propq,
       const UI_METHOD *ui_method, void *ui_data);
  int OSSL_STORE_LOADER_set_attach(OSSL_STORE_LOADER *loader,
                                   OSSL_STORE_attach_fn attach_function);
@@ -118,7 +118,7 @@ OSSL_STORE_eof(), OSSL_STORE_error() and OSSL_STORE_close() for specific
 storage schemes.
 
 OSSL_STORE_LOADER_fetch() looks for an implementation for a storage
-I<scheme> within the providers that has been loaded into the B<OPENSSL_CTX>
+I<scheme> within the providers that has been loaded into the B<OSSL_LIB_CTX>
 given by I<ctx>, and with the properties given by I<properties>.
 
 OSSL_STORE_LOADER_up_ref() increments the reference count for the given
@@ -347,7 +347,7 @@ or NULL on failure.
 
 =head1 SEE ALSO
 
-L<ossl_store(7)>, L<OSSL_STORE_open(3)>, L<OPENSSL_CTX(3)>,
+L<ossl_store(7)>, L<OSSL_STORE_open(3)>, L<OSSL_LIB_CTX(3)>,
 L<provider-storemgmt(7)>
 
 =head1 HISTORY

--- a/doc/man3/OSSL_STORE_attach.pod
+++ b/doc/man3/OSSL_STORE_attach.pod
@@ -9,7 +9,7 @@ OSSL_STORE_attach - Functions to read objects from a BIO
  #include <openssl/store.h>
 
  OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bio, const char *scheme,
-                                   OPENSSL_CTX *libctx, const char *propq,
+                                   OSSL_LIB_CTX *libctx, const char *propq,
                                    const UI_METHOD *ui_method, void *ui_data,
                                    OSSL_STORE_post_process_info_fn post_process,
                                    void *post_process_data);

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -22,7 +22,7 @@ OSSL_STORE_error, OSSL_STORE_close
                                  OSSL_STORE_post_process_info_fn post_process,
                                  void *post_process_data);
  OSSL_STORE_CTX *
- OSSL_STORE_open_ex(const char *uri, OPENSSL_CTX *libctx, const char *propq,
+ OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
                     const UI_METHOD *ui_method, void *ui_data,
                     OSSL_STORE_post_process_info_fn post_process,
                     void *post_process_data);

--- a/doc/man3/PEM_X509_INFO_read_bio_ex.pod
+++ b/doc/man3/PEM_X509_INFO_read_bio_ex.pod
@@ -12,13 +12,13 @@ object's
 
  STACK_OF(X509_INFO) *PEM_X509_INFO_read_ex(FILE *fp, STACK_OF(X509_INFO) *sk,
                                             pem_password_cb *cb, void *u,
-                                            OPENSSL_CTX *libctx,
+                                            OSSL_LIB_CTX *libctx,
                                             const char *propq);
 
  STACK_OF(X509_INFO) *PEM_X509_INFO_read_bio_ex(BIO *bio,
                                                 STACK_OF(X509_INFO) *sk,
                                                 pem_password_cb *cb, void *u,
-                                                OPENSSL_CTX *libctx,
+                                                OSSL_LIB_CTX *libctx,
                                                 const char *propq);
 
 =head1 DESCRIPTION

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -36,12 +36,12 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
  typedef int pem_password_cb(char *buf, int size, int rwflag, void *u);
 
  EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
-                                      void *u, OPENSSL_CTX *libctx,
+                                      void *u, OSSL_LIB_CTX *libctx,
                                       const char *propq);
  EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
                                    pem_password_cb *cb, void *u);
  EVP_PKEY *PEM_read_PrivateKey_ex(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
-                                  void *u, OPENSSL_CTX *libctx,
+                                  void *u, OSSL_LIB_CTX *libctx,
                                   const char *propq);
  EVP_PKEY *PEM_read_PrivateKey(FILE *fp, EVP_PKEY **x,
                                pem_password_cb *cb, void *u);
@@ -70,12 +70,12 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
 
  EVP_PKEY *PEM_read_bio_PUBKEY_ex(BIO *bp, EVP_PKEY **x,
                                   pem_password_cb *cb, void *u,
-                                  OPENSSL_CTX *libctx, const char *propq);
+                                  OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
                                pem_password_cb *cb, void *u);
  EVP_PKEY *PEM_read_PUBKEY_ex(FILE *fp, EVP_PKEY **x,
                               pem_password_cb *cb, void *u,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *PEM_read_PUBKEY(FILE *fp, EVP_PKEY **x,
                            pem_password_cb *cb, void *u);
  int PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x);
@@ -125,7 +125,7 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
  int PEM_write_DSA_PUBKEY(FILE *fp, DSA *x);
 
  EVP_PKEY *PEM_read_bio_Parameters_ex(BIO *bp, EVP_PKEY **x,
-                                      OPENSSL_CTX *libctx, const char *propq);
+                                      OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x);
  int PEM_write_bio_Parameters(BIO *bp, const EVP_PKEY *x);
 

--- a/doc/man3/PKCS7_encrypt.pod
+++ b/doc/man3/PKCS7_encrypt.pod
@@ -11,7 +11,7 @@ PKCS7_encrypt_ex, PKCS7_encrypt
 
  PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
                          const EVP_CIPHER *cipher, int flags,
-                         OPENSSL_CTX *libctx, const char *propq);
+                         OSSL_LIB_CTX *libctx, const char *propq);
  PKCS7 *PKCS7_encrypt(STACK_OF(X509) *certs, BIO *in, const EVP_CIPHER *cipher,
                       int flags);
 

--- a/doc/man3/PKCS7_sign.pod
+++ b/doc/man3/PKCS7_sign.pod
@@ -10,7 +10,7 @@ PKCS7_sign_ex, PKCS7_sign
  #include <openssl/pkcs7.h>
 
  PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
-                      BIO *data, int flags, OPENSSL_CTX *libctx,
+                      BIO *data, int flags, OSSL_LIB_CTX *libctx,
                       const char *propq);
  PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
                    BIO *data, int flags);

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -12,8 +12,8 @@ RAND_pseudo_bytes - generate random data
  int RAND_bytes(unsigned char *buf, int num);
  int RAND_priv_bytes(unsigned char *buf, int num);
 
- int RAND_bytes_ex(OPENSSL_CTX *ctx, unsigned char *buf, int num);
- int RAND_priv_bytes_ex(OPENSSL_CTX *ctx, unsigned char *buf, int num);
+ int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
+ int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
@@ -37,7 +37,7 @@ RAND_bytes_ex() and RAND_priv_bytes_ex() are the same as RAND_bytes() and
 RAND_priv_bytes() except that they both take an additional I<ctx> parameter.
 The DRBG used for the operation is the public or private DRBG associated with
 the specified I<ctx>. The parameter can be NULL, in which case
-the default library context is used (see L<OPENSSL_CTX(3)>.
+the default library context is used (see L<OSSL_LIB_CTX(3)>.
 If the default RAND_METHOD has been changed then for compatibility reasons the
 RAND_METHOD will be used in preference and the DRBG of the library context
 ignored.

--- a/doc/man3/RAND_get0_primary.pod
+++ b/doc/man3/RAND_get0_primary.pod
@@ -11,9 +11,9 @@ RAND_get0_private
 
  #include <openssl/rand.h>
 
- EVP_RAND_CTX *RAND_get0_primary(OPENSSL_CTX *ctx);
- EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx);
- EVP_RAND_CTX *RAND_get0_private(OPENSSL_CTX *ctx);
+ EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx);
+ EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx);
+ EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx);
 
 
 =head1 DESCRIPTION
@@ -31,16 +31,16 @@ These functions here provide access to the shared DRBG instances.
 =head1 RETURN VALUES
 
 RAND_get0_primary() returns a pointer to the I<primary> DRBG instance
-for the given OPENSSL_CTX B<ctx>.
+for the given OSSL_LIB_CTX B<ctx>.
 
 RAND_get0_public() returns a pointer to the I<public> DRBG instance
-for the given OPENSSL_CTX B<ctx>.
+for the given OSSL_LIB_CTX B<ctx>.
 
 RAND_get0_private() returns a pointer to the I<private> DRBG instance
-for the given OPENSSL_CTX B<ctx>.
+for the given OSSL_LIB_CTX B<ctx>.
 
 In all the above cases the B<ctx> parameter can
-be NULL in which case the default OPENSSL_CTX is used.
+be NULL in which case the default OSSL_LIB_CTX is used.
 
 =head1 NOTES
 

--- a/doc/man3/SMIME_write_ASN1.pod
+++ b/doc/man3/SMIME_write_ASN1.pod
@@ -12,7 +12,7 @@ SMIME_write_ASN1_ex, SMIME_write_ASN1
  int SMIME_write_ASN1_ex(BIO *out, ASN1_VALUE *val, BIO *data, int flags,
                          int ctype_nid, int econt_nid,
                          STACK_OF(X509_ALGOR) *mdalgs, const ASN1_ITEM *it,
-                         OPENSSL_CTX *libctx, const char *propq);
+                         OSSL_LIB_CTX *libctx, const char *propq);
 
  int SMIME_write_ASN1(BIO *out,
      ASN1_VALUE *val, BIO *data, int flags, int ctype_nid, int econt_nid,

--- a/doc/man3/SRP_Calc_B.pod
+++ b/doc/man3/SRP_Calc_B.pod
@@ -22,22 +22,22 @@ SRP_Calc_client_key
  BIGNUM *SRP_Calc_server_key(const BIGNUM *A, const BIGNUM *v, const BIGNUM *u,
                              const BIGNUM *b, const BIGNUM *N);
  BIGNUM *SRP_Calc_B_ex(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
-                       const BIGNUM *v, OPENSSL_CTX *libctx, const char *propq);
+                       const BIGNUM *v, OSSL_LIB_CTX *libctx, const char *propq);
  BIGNUM *SRP_Calc_B(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
                    const BIGNUM *v);
 
  BIGNUM *SRP_Calc_u_ex(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N,
-                       OPENSSL_CTX *libctx, const char *propq);
+                       OSSL_LIB_CTX *libctx, const char *propq);
  BIGNUM *SRP_Calc_u(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N);
 
  /* client side .... */
  BIGNUM *SRP_Calc_client_key_ex(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                              const BIGNUM *x, const BIGNUM *a, const BIGNUM *u,
-                             OPENSSL_CTX *libctx, const char *propq);
+                             OSSL_LIB_CTX *libctx, const char *propq);
  BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                              const BIGNUM *x, const BIGNUM *a, const BIGNUM *u);
  BIGNUM *SRP_Calc_x_ex(const BIGNUM *s, const char *user, const char *pass,
-                       OPENSSL_CTX *libctx, const char *propq);
+                       OSSL_LIB_CTX *libctx, const char *propq);
  BIGNUM *SRP_Calc_x(const BIGNUM *s, const char *user, const char *pass);
  BIGNUM *SRP_Calc_A(const BIGNUM *a, const BIGNUM *N, const BIGNUM *g);
 

--- a/doc/man3/SRP_create_verifier.pod
+++ b/doc/man3/SRP_create_verifier.pod
@@ -16,13 +16,13 @@ SRP_get_default_gN
 
  int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
                                BIGNUM **verifier, const BIGNUM *N,
-                               const BIGNUM *g, OPENSSL_CTX *libctx,
+                               const BIGNUM *g, OSSL_LIB_CTX *libctx,
                                const char *propq);
  char *SRP_create_verifier_BN(const char *user, const char *pass, BIGNUM **salt,
                               BIGNUM **verifier, const BIGNUM *N, const BIGNUM *g);
  char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
                               char **verifier, const char *N, const char *g,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
  char *SRP_create_verifier(const char *user, const char *pass, char **salt,
                            char **verifier, const char *N, const char *g);
 

--- a/doc/man3/SSL_CTX_new.pod
+++ b/doc/man3/SSL_CTX_new.pod
@@ -18,7 +18,7 @@ functions
 
  #include <openssl/ssl.h>
 
- SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
+ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
                          const SSL_METHOD *method);
  SSL_CTX *SSL_CTX_new(const SSL_METHOD *method);
  int SSL_CTX_up_ref(SSL_CTX *ctx);
@@ -75,7 +75,7 @@ functions
 
 SSL_CTX_new_ex() creates a new B<SSL_CTX> object as a framework to
 establish TLS/SSL or DTLS enabled connections using the library context
-I<libctx> (see L<OPENSSL_CTX(3)>). Any cryptographic algorithms that are used
+I<libctx> (see L<OSSL_LIB_CTX(3)>). Any cryptographic algorithms that are used
 by any B<SSL> objects created from this B<SSL_CTX> will be fetched from the
 I<libctx> using the property query string I<propq> (see
 L<provider(7)/Fetching algorithms>. Either or both the I<libctx> or I<propq>

--- a/doc/man3/SSL_load_client_CA_file.pod
+++ b/doc/man3/SSL_load_client_CA_file.pod
@@ -13,7 +13,7 @@ SSL_add_store_cert_subjects_to_stack
  #include <openssl/ssl.h>
 
  STACK_OF(X509_NAME) *SSL_load_client_CA_file_ex(const char *file,
-                                                 OPENSSL_CTX *libctx,
+                                                 OSSL_LIB_CTX *libctx,
                                                  const char *propq);
  STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file);
 

--- a/doc/man3/X509_LOOKUP.pod
+++ b/doc/man3/X509_LOOKUP.pod
@@ -34,19 +34,19 @@ X509_LOOKUP_by_alias
  void *X509_LOOKUP_get_method_data(const X509_LOOKUP *ctx);
 
  int X509_LOOKUP_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
-                         char **ret, OPENSSL_CTX *libctx, const char *propq);
+                         char **ret, OSSL_LIB_CTX *libctx, const char *propq);
  int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc,
                       long argl, char **ret);
  int X509_LOOKUP_load_file_ex(X509_LOOKUP *ctx, char *name, long type,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
  int X509_LOOKUP_load_file(X509_LOOKUP *ctx, char *name, long type);
  int X509_LOOKUP_load_file_ex(X509_LOOKUP *ctx, char *name, long type,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
  int X509_LOOKUP_add_dir(X509_LOOKUP *ctx, char *name, long type);
- int X509_LOOKUP_add_store_ex(X509_LOOKUP *ctx, char *uri, OPENSSL_CTX *libctx,
+ int X509_LOOKUP_add_store_ex(X509_LOOKUP *ctx, char *uri, OSSL_LIB_CTX *libctx,
                               const char *propq);
  int X509_LOOKUP_add_store(X509_LOOKUP *ctx, char *uri);
- int X509_LOOKUP_load_store_ex(X509_LOOKUP *ctx, char *uri, OPENSSL_CTX *libctx,
+ int X509_LOOKUP_load_store_ex(X509_LOOKUP *ctx, char *uri, OSSL_LIB_CTX *libctx,
                                const char *propq);
  int X509_LOOKUP_load_store(X509_LOOKUP *ctx, char *uri);
 
@@ -54,7 +54,7 @@ X509_LOOKUP_by_alias
 
  int X509_LOOKUP_by_subject_ex(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                                const X509_NAME *name, X509_OBJECT *ret,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
  int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                             const X509_NAME *name, X509_OBJECT *ret);
  int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,

--- a/doc/man3/X509_LOOKUP_hash_dir.pod
+++ b/doc/man3/X509_LOOKUP_hash_dir.pod
@@ -17,11 +17,11 @@ X509_load_cert_crl_file_ex, X509_load_cert_crl_file
  X509_LOOKUP_METHOD *X509_LOOKUP_store(void);
 
  int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
-                            OPENSSL_CTX *libctx, const char *propq);
+                            OSSL_LIB_CTX *libctx, const char *propq);
  int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type);
  int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type);
  int X509_load_cert_crl_file_ex(X509_LOOKUP *ctx, const char *file, int type,
-                                OPENSSL_CTX *libctx, const char *propq);
+                                OSSL_LIB_CTX *libctx, const char *propq);
  int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type);
 
 =head1 DESCRIPTION

--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -21,7 +21,7 @@ X509_PUBKEY_eq - SubjectPublicKeyInfo public key functions
  EVP_PKEY *X509_PUBKEY_get(const X509_PUBKEY *key);
 
  EVP_PKEY *d2i_PUBKEY_ex(EVP_PKEY **a, const unsigned char **pp, long length,
-                         OPENSSL_CTX *libctx, const char *propq);
+                         OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *d2i_PUBKEY(EVP_PKEY **a, const unsigned char **pp, long length);
  int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp);
 

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -18,7 +18,7 @@ X509_STORE_CTX_verify_fn
 
  #include <openssl/x509_vfy.h>
 
- X509_STORE_CTX *X509_STORE_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq);
+ X509_STORE_CTX *X509_STORE_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  X509_STORE_CTX *X509_STORE_CTX_new(void);
  void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
  void X509_STORE_CTX_free(X509_STORE_CTX *ctx);

--- a/doc/man3/X509_STORE_add_cert.pod
+++ b/doc/man3/X509_STORE_add_cert.pod
@@ -28,18 +28,18 @@ X509_STORE_load_locations_ex, X509_STORE_load_locations
  X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *store,
                                     X509_LOOKUP_METHOD *meth);
 
- int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OPENSSL_CTX *libctx,
+ int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OSSL_LIB_CTX *libctx,
                                      const char *propq);
  int X509_STORE_set_default_paths(X509_STORE *ctx);
  int X509_STORE_load_file_ex(X509_STORE *ctx, const char *file,
-                             OPENSSL_CTX *libctx, const char *propq);
+                             OSSL_LIB_CTX *libctx, const char *propq);
  int X509_STORE_load_file(X509_STORE *ctx, const char *file);
  int X509_STORE_load_path(X509_STORE *ctx, const char *dir);
  int X509_STORE_load_store_ex(X509_STORE *ctx, const char *uri,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
  int X509_STORE_load_store(X509_STORE *ctx, const char *uri);
  int X509_STORE_load_locations_ex(X509_STORE *ctx, const char *file,
-                                  const char *dir, OPENSSL_CTX *libctx,
+                                  const char *dir, OSSL_LIB_CTX *libctx,
                                   const char *propq);
  int X509_STORE_load_locations(X509_STORE *ctx,
                                const char *file, const char *dir);

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -11,7 +11,7 @@ X509_free, X509_up_ref - X509 certificate ASN1 allocation functions
  #include <openssl/x509.h>
 
  X509 *X509_new(void);
- X509 *X509_new_ex(OPENSSL_CTX *libctx, const char *propq);
+ X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
  void X509_free(X509 *a);
  int X509_up_ref(X509 *a);
  STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *x);

--- a/doc/man3/X509_verify.pod
+++ b/doc/man3/X509_verify.pod
@@ -14,7 +14,7 @@ verify certificate, certificate request, or CRL signature
  int X509_verify(X509 *x, EVP_PKEY *pkey);
  int X509_self_signed(X509 *cert, int verify_signature);
 
- int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey, OPENSSL_CTX *libctx,
+ int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *pkey, OSSL_LIB_CTX *libctx,
                         const char *propq);
  int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r);
  int X509_CRL_verify(X509_CRL *a, EVP_PKEY *r);
@@ -61,7 +61,7 @@ L<X509_NAME_get_index_by_NID(3)>,
 L<X509_NAME_print_ex(3)>,
 L<X509V3_get_d2i(3)>,
 L<X509_verify_cert(3)>,
-L<OPENSSL_CTX(3)>
+L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -14,7 +14,7 @@ i2d_PrivateKey_fp
  #include <openssl/evp.h>
 
  EVP_PKEY *d2i_PrivateKey_ex(int type, EVP_PKEY **a, const unsigned char **pp,
-                             long length, OPENSSL_CTX *libctx,
+                             long length, OSSL_LIB_CTX *libctx,
                              const char *propq);
  EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
                           long length);
@@ -23,7 +23,7 @@ i2d_PrivateKey_fp
  EVP_PKEY *d2i_KeyParams(int type, EVP_PKEY **a, const unsigned char **pp,
                          long length);
  EVP_PKEY *d2i_AutoPrivateKey_ex(EVP_PKEY **a, const unsigned char **pp,
-                                 long length, OPENSSL_CTX *libctx,
+                                 long length, OSSL_LIB_CTX *libctx,
                                  const char *propq);
  EVP_PKEY *d2i_AutoPrivateKey(EVP_PKEY **a, const unsigned char **pp,
                               long length);
@@ -37,10 +37,10 @@ i2d_PrivateKey_fp
 
  #include <openssl/x509.h>
 
- EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OPENSSL_CTX *libctx,
+ EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                  const char *propq);
  EVP_PKEY *d2i_PrivateKey_bio(BIO *bp, EVP_PKEY **a);
- EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OPENSSL_CTX *libctx,
+ EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                 const char *propq);
  EVP_PKEY *d2i_PrivateKey_fp(FILE *fp, EVP_PKEY **a);
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -104,7 +104,7 @@ provider):
  core_gettable_params           OSSL_FUNC_CORE_GETTABLE_PARAMS
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
- core_get_libctx       OSSL_FUNC_CORE_GET_LIBCTX
+ core_get_libctx                OSSL_FUNC_CORE_GET_LIBCTX
  core_new_error                 OSSL_FUNC_CORE_NEW_ERROR
  core_set_error_debug           OSSL_FUNC_CORE_SET_ERROR_DEBUG
  core_set_error                 OSSL_FUNC_CORE_SET_ERROR

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -20,7 +20,7 @@ provider-base
  int core_get_params(const OSSL_CORE_HANDLE *handle, OSSL_PARAM params[]);
  int core_thread_start(const OSSL_CORE_HANDLE *handle,
                        OSSL_thread_stop_handler_fn handfn);
- OPENSSL_CORE_CTX *core_get_library_context(const OSSL_CORE_HANDLE *handle);
+ OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle);
  void core_new_error(const OSSL_CORE_HANDLE *handle);
  void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
                            const char *file, int line, const char *func);
@@ -104,7 +104,7 @@ provider):
  core_gettable_params           OSSL_FUNC_CORE_GETTABLE_PARAMS
  core_get_params                OSSL_FUNC_CORE_GET_PARAMS
  core_thread_start              OSSL_FUNC_CORE_THREAD_START
- core_get_library_context       OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT
+ core_get_libctx       OSSL_FUNC_CORE_GET_LIBCTX
  core_new_error                 OSSL_FUNC_CORE_NEW_ERROR
  core_set_error_debug           OSSL_FUNC_CORE_SET_ERROR_DEBUG
  core_set_error                 OSSL_FUNC_CORE_SET_ERROR
@@ -152,7 +152,7 @@ parameters.
 
 =for comment core_thread_start() TBA
 
-core_get_library_context() retrieves the library context in which the library
+core_get_libctx() retrieves the library context in which the library
 object for the current provider is stored, accessible through the I<handle>.
 This may sometimes be useful if the provider wishes to store a
 reference to its context in the same library context.

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -191,7 +191,7 @@ arguments are passed:
 
 =item The library context
 
-See L<OPENSSL_CTX(3)> for a more detailed description.
+See L<OSSL_LIB_CTX(3)> for a more detailed description.
 This may be NULL to signify the default (global) library context, or a
 context created by the user.
 Only providers loaded in this library context (see
@@ -383,7 +383,7 @@ other providers:
 =head1 SEE ALSO
 
 L<EVP_DigestInit_ex(3)>, L<EVP_EncryptInit_ex(3)>,
-L<OPENSSL_CTX(3)>,
+L<OSSL_LIB_CTX(3)>,
 L<EVP_set_default_properties(3)>,
 L<EVP_MD_fetch(3)>,
 L<EVP_CIPHER_fetch(3)>,

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -262,7 +262,7 @@ typedef OSSL_STORE_INFO *(*file_try_decode_fn)(const char *pem_name,
                                                int *matchcount,
                                                const UI_METHOD *ui_method,
                                                void *ui_data, const char *uri,
-                                               OPENSSL_CTX *libctx,
+                                               OSSL_LIB_CTX *libctx,
                                                const char *propq);
 /*
  * The eof function should return 1 if there's no more data to be found
@@ -299,7 +299,7 @@ static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
                                           int *matchcount,
                                           const UI_METHOD *ui_method,
                                           void *ui_data, const char *uri,
-                                          OPENSSL_CTX *libctx,
+                                          OSSL_LIB_CTX *libctx,
                                           const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
@@ -434,7 +434,7 @@ static OSSL_STORE_INFO *try_decode_PKCS8Encrypted(const char *pem_name,
                                                   const UI_METHOD *ui_method,
                                                   void *ui_data,
                                                   const char *uri,
-                                                  OPENSSL_CTX *libctx,
+                                                  OSSL_LIB_CTX *libctx,
                                                   const char *propq)
 {
     X509_SIG *p8 = NULL;
@@ -509,7 +509,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
                                               int *matchcount,
                                               const UI_METHOD *ui_method,
                                               void *ui_data, const char *uri,
-                                              OPENSSL_CTX *libctx,
+                                              OSSL_LIB_CTX *libctx,
                                               const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
@@ -638,7 +638,7 @@ static OSSL_STORE_INFO *try_decode_PUBKEY(const char *pem_name,
                                           int *matchcount,
                                           const UI_METHOD *ui_method,
                                           void *ui_data, const char *uri,
-                                          OPENSSL_CTX *libctx,
+                                          OSSL_LIB_CTX *libctx,
                                           const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
@@ -674,7 +674,7 @@ static OSSL_STORE_INFO *try_decode_params(const char *pem_name,
                                           int *matchcount,
                                           const UI_METHOD *ui_method,
                                           void *ui_data, const char *uri,
-                                          OPENSSL_CTX *libctx,
+                                          OSSL_LIB_CTX *libctx,
                                           const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
@@ -752,7 +752,7 @@ static OSSL_STORE_INFO *try_decode_X509Certificate(const char *pem_name,
                                                    const UI_METHOD *ui_method,
                                                    void *ui_data,
                                                    const char *uri,
-                                                   OPENSSL_CTX *libctx,
+                                                   OSSL_LIB_CTX *libctx,
                                                    const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
@@ -808,7 +808,7 @@ static OSSL_STORE_INFO *try_decode_X509CRL(const char *pem_name,
                                            int *matchcount,
                                            const UI_METHOD *ui_method,
                                            void *ui_data, const char *uri,
-                                           OPENSSL_CTX *libctx,
+                                           OSSL_LIB_CTX *libctx,
                                            const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
@@ -902,7 +902,7 @@ struct ossl_store_loader_ctx_st {
     /* Expected object type.  May be unspecified */
     int expected_type;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 };
 
@@ -942,7 +942,7 @@ static int file_find_type(OSSL_STORE_LOADER_CTX *ctx)
 
 static OSSL_STORE_LOADER_CTX *file_open_ex
     (const OSSL_STORE_LOADER *loader, const char *uri,
-     OPENSSL_CTX *libctx, const char *propq,
+     OSSL_LIB_CTX *libctx, const char *propq,
      const UI_METHOD *ui_method, void *ui_data)
 {
     OSSL_STORE_LOADER_CTX *ctx = NULL;
@@ -1074,7 +1074,7 @@ static OSSL_STORE_LOADER_CTX *file_open
 
 static OSSL_STORE_LOADER_CTX *file_attach
     (const OSSL_STORE_LOADER *loader, BIO *bp,
-     OPENSSL_CTX *libctx, const char *propq,
+     OSSL_LIB_CTX *libctx, const char *propq,
      const UI_METHOD *ui_method, void *ui_data)
 {
     OSSL_STORE_LOADER_CTX *ctx = NULL;

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -76,13 +76,13 @@ struct evp_pkey_asn1_method_st {
     /* Exports and imports to / from providers */
     size_t (*dirty_cnt) (const EVP_PKEY *pk);
     int (*export_to) (const EVP_PKEY *pk, void *to_keydata,
-                      EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
+                      EVP_KEYMGMT *to_keymgmt, OSSL_LIB_CTX *libctx,
                       const char *propq);
     OSSL_CALLBACK *import_from;
 
     int (*priv_decode_ex) (EVP_PKEY *pk,
                                     const PKCS8_PRIV_KEY_INFO *p8inf,
-                                    OPENSSL_CTX *libctx,
+                                    OSSL_LIB_CTX *libctx,
                                     const char *propq);
 } /* EVP_PKEY_ASN1_METHOD */ ;
 

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -110,7 +110,7 @@ int bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
                                   const BIGNUM *r1, const BIGNUM *r2, int nlen,
                                   const BIGNUM *e, BN_CTX *ctx, BN_GENCB *cb);
 
-OSSL_LIB_CTX *bn_get_lib_ctx(BN_CTX *ctx);
+OSSL_LIB_CTX *bn_get_libctx(BN_CTX *ctx);
 
 extern const BIGNUM bn_inv_sqrt_2;
 

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -110,7 +110,7 @@ int bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
                                   const BIGNUM *r1, const BIGNUM *r2, int nlen,
                                   const BIGNUM *e, BN_CTX *ctx, BN_GENCB *cb);
 
-OPENSSL_CTX *bn_get_lib_ctx(BN_CTX *ctx);
+OSSL_LIB_CTX *bn_get_lib_ctx(BN_CTX *ctx);
 
 extern const BIGNUM bn_inv_sqrt_2;
 

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -12,7 +12,7 @@
 
 # include <openssl/decoder.h>
 
-OSSL_DECODER *ossl_decoder_fetch_by_number(OPENSSL_CTX *libctx,
+OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx,
                                                      int id,
                                                      const char *properties);
 
@@ -33,7 +33,7 @@ int ossl_decoder_ctx_add_decoder_inst(OSSL_DECODER_CTX *ctx,
 
 int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
                                         EVP_PKEY **pkey, const char *keytype,
-                                        OPENSSL_CTX *libctx,
+                                        OSSL_LIB_CTX *libctx,
                                         const char *propquery);
 
 #endif

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -11,8 +11,8 @@
 #include <openssl/dh.h>
 #include "internal/ffc.h"
 
-DH *dh_new_by_nid_ex(OPENSSL_CTX *libctx, int nid);
-DH *dh_new_ex(OPENSSL_CTX *libctx);
+DH *dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid);
+DH *dh_new_ex(OSSL_LIB_CTX *libctx);
 
 int dh_generate_ffc_parameters(DH *dh, int type, int pbits, int qbits,
                                BN_GENCB *cb);
@@ -40,4 +40,4 @@ int dh_KDF_X9_42_asn1(unsigned char *out, size_t outlen,
                       const unsigned char *Z, size_t Zlen,
                       const char *cek_alg,
                       const unsigned char *ukm, size_t ukmlen, const EVP_MD *md,
-                      OPENSSL_CTX *libctx, const char *propq);
+                      OSSL_LIB_CTX *libctx, const char *propq);

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -14,7 +14,7 @@
 #define DSA_PARAMGEN_TYPE_FIPS_186_4   0   /* Use FIPS186-4 standard */
 #define DSA_PARAMGEN_TYPE_FIPS_186_2   1   /* Use legacy FIPS186-2 standard */
 
-DSA *dsa_new_with_ctx(OPENSSL_CTX *libctx);
+DSA *dsa_new_with_ctx(OSSL_LIB_CTX *libctx);
 
 int dsa_generate_ffc_parameters(DSA *dsa, int type, int pbits, int qbits,
                                 BN_GENCB *cb);

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -47,19 +47,19 @@ __owur int ec_group_do_inverse_ord(const EC_GROUP *group, BIGNUM *res,
 int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
                    const unsigned char *Z, size_t Zlen,
                    const unsigned char *sinfo, size_t sinfolen,
-                   const EVP_MD *md, OPENSSL_CTX *libctx, const char *propq);
+                   const EVP_MD *md, OSSL_LIB_CTX *libctx, const char *propq);
 
 int ec_key_public_check(const EC_KEY *eckey, BN_CTX *ctx);
 int ec_key_private_check(const EC_KEY *eckey);
 int ec_key_pairwise_check(const EC_KEY *eckey, BN_CTX *ctx);
-OPENSSL_CTX *ec_key_get_libctx(const EC_KEY *eckey);
+OSSL_LIB_CTX *ec_key_get_libctx(const EC_KEY *eckey);
 const char *ec_key_get0_propq(const EC_KEY *eckey);
 const char *ec_curve_nid2name(int nid);
 int ec_curve_name2nid(const char *name);
 
 /* Backend support */
 int ec_group_todata(const EC_GROUP *group, OSSL_PARAM_BLD *tmpl,
-                    OSSL_PARAM params[], OPENSSL_CTX *libctx, const char *propq,
+                    OSSL_PARAM params[], OSSL_LIB_CTX *libctx, const char *propq,
                     BN_CTX *bnctx, unsigned char **genbuf);
 int ec_group_fromdata(EC_KEY *ec, const OSSL_PARAM params[]);
 int ec_key_fromdata(EC_KEY *ecx, const OSSL_PARAM params[], int include_private);

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -59,7 +59,8 @@ int ec_curve_name2nid(const char *name);
 
 /* Backend support */
 int ec_group_todata(const EC_GROUP *group, OSSL_PARAM_BLD *tmpl,
-                    OSSL_PARAM params[], OSSL_LIB_CTX *libctx, const char *propq,
+                    OSSL_PARAM params[], OSSL_LIB_CTX *libctx,
+                    const char *propq,
                     BN_CTX *bnctx, unsigned char **genbuf);
 int ec_group_fromdata(EC_KEY *ec, const OSSL_PARAM params[]);
 int ec_key_fromdata(EC_KEY *ecx, const OSSL_PARAM params[], int include_private);

--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -61,7 +61,7 @@ typedef enum {
            : EVP_PKEY_ED448)))
 
 struct ecx_key_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     unsigned int haspubkey:1;
     unsigned char pubkey[MAX_KEYLEN];
@@ -75,7 +75,7 @@ struct ecx_key_st {
 typedef struct ecx_key_st ECX_KEY;
 
 size_t ecx_key_length(ECX_KEY_TYPE type);
-ECX_KEY *ecx_key_new(OPENSSL_CTX *libctx, ECX_KEY_TYPE type, int haspubkey,
+ECX_KEY *ecx_key_new(OSSL_LIB_CTX *libctx, ECX_KEY_TYPE type, int haspubkey,
                      const char *propq);
 unsigned char *ecx_key_allocate_privkey(ECX_KEY *key);
 void ecx_key_free(ECX_KEY *key);
@@ -86,23 +86,23 @@ int X25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
 void X25519_public_from_private(uint8_t out_public_value[32],
                                 const uint8_t private_key[32]);
 
-int ED25519_public_from_private(OPENSSL_CTX *ctx, uint8_t out_public_key[32],
+int ED25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[32],
                                 const uint8_t private_key[32], const char *propq);
 int ED25519_sign(uint8_t *out_sig, const uint8_t *message, size_t message_len,
                  const uint8_t public_key[32], const uint8_t private_key[32],
-                 OPENSSL_CTX *libctx, const char *propq);
+                 OSSL_LIB_CTX *libctx, const char *propq);
 int ED25519_verify(const uint8_t *message, size_t message_len,
                    const uint8_t signature[64], const uint8_t public_key[32],
-                   OPENSSL_CTX *libctx, const char *propq);
+                   OSSL_LIB_CTX *libctx, const char *propq);
 
-int ED448_public_from_private(OPENSSL_CTX *ctx, uint8_t out_public_key[57],
+int ED448_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[57],
                               const uint8_t private_key[57], const char *propq);
-int ED448_sign(OPENSSL_CTX *ctx, uint8_t *out_sig, const uint8_t *message,
+int ED448_sign(OSSL_LIB_CTX *ctx, uint8_t *out_sig, const uint8_t *message,
                size_t message_len, const uint8_t public_key[57],
                const uint8_t private_key[57], const uint8_t *context,
                size_t context_len, const char *propq);
 
-int ED448_verify(OPENSSL_CTX *ctx, const uint8_t *message, size_t message_len,
+int ED448_verify(OSSL_LIB_CTX *ctx, const uint8_t *message, size_t message_len,
                  const uint8_t signature[114], const uint8_t public_key[57],
                  const uint8_t *context, size_t context_len, const char *propq);
 

--- a/include/crypto/encoder.h
+++ b/include/crypto/encoder.h
@@ -9,5 +9,5 @@
 
 #include <openssl/types.h>
 
-OSSL_ENCODER *ossl_encoder_fetch_by_number(OPENSSL_CTX *libctx, int id,
+OSSL_ENCODER *ossl_encoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
                                            const char *properties);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -801,8 +801,10 @@ void evp_encode_ctx_set_flags(EVP_ENCODE_CTX *ctx, unsigned int flags);
 /* Use the SRP base64 alphabet instead of the standard one */
 #define EVP_ENCODE_CTX_USE_SRP_ALPHABET     2
 
-const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx, const char *name);
-const EVP_MD *evp_get_digestbyname_ex(OSSL_LIB_CTX *libctx, const char *name);
+const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx,
+                                          const char *name);
+const EVP_MD *evp_get_digestbyname_ex(OSSL_LIB_CTX *libctx,
+                                      const char *name);
 
 int pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
                          const unsigned char *salt, int saltlen, int iter,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -42,7 +42,7 @@ struct evp_pkey_ctx_st {
      * Library context, property query, keytype and keymgmt associated with
      * this context
      */
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propquery;
     const char *keytype;
     EVP_KEYMGMT *keymgmt;
@@ -699,7 +699,7 @@ void openssl_add_all_ciphers_int(void);
 void openssl_add_all_digests_int(void);
 void evp_cleanup_int(void);
 void evp_app_cleanup_int(void);
-void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
+void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
                                   EVP_KEYMGMT **keymgmt,
                                   const char *propquery);
 #ifndef FIPS_MODULE
@@ -801,13 +801,13 @@ void evp_encode_ctx_set_flags(EVP_ENCODE_CTX *ctx, unsigned int flags);
 /* Use the SRP base64 alphabet instead of the standard one */
 #define EVP_ENCODE_CTX_USE_SRP_ALPHABET     2
 
-const EVP_CIPHER *evp_get_cipherbyname_ex(OPENSSL_CTX *libctx, const char *name);
-const EVP_MD *evp_get_digestbyname_ex(OPENSSL_CTX *libctx, const char *name);
+const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx, const char *name);
+const EVP_MD *evp_get_digestbyname_ex(OSSL_LIB_CTX *libctx, const char *name);
 
 int pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
                          const unsigned char *salt, int saltlen, int iter,
                          const EVP_MD *digest, int keylen, unsigned char *out,
-                         OPENSSL_CTX *libctx, const char *propq);
+                         OSSL_LIB_CTX *libctx, const char *propq);
 
 #ifndef FIPS_MODULE
 /*
@@ -826,7 +826,7 @@ int evp_pkey_ctx_set_params_strict(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 int evp_pkey_ctx_get_params_strict(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 
 EVP_MD_CTX *evp_md_ctx_new_ex(EVP_PKEY *pkey, const ASN1_OCTET_STRING *id,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
 int evp_pkey_name2type(const char *name);
 
 int evp_pkey_ctx_set1_id_prov(EVP_PKEY_CTX *ctx, const void *id, int len);
@@ -835,8 +835,8 @@ int evp_pkey_ctx_get1_id_len_prov(EVP_PKEY_CTX *ctx, size_t *id_len);
 
 int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 #endif /* !defined(FIPS_MODULE) */
-void evp_method_store_flush(OPENSSL_CTX *libctx);
-int evp_set_default_properties_int(OPENSSL_CTX *libctx, const char *propq,
+void evp_method_store_flush(OSSL_LIB_CTX *libctx);
+int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig);
 
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -48,8 +48,8 @@ const char *ossl_rsa_mgf_nid2name(int mgf);
 int ossl_rsa_oaeppss_md2nid(const EVP_MD *md);
 const char *ossl_rsa_oaeppss_nid2name(int md);
 
-RSA *ossl_rsa_new_with_ctx(OPENSSL_CTX *libctx);
-OPENSSL_CTX *ossl_rsa_get0_libctx(RSA *r);
+RSA *ossl_rsa_new_with_ctx(OSSL_LIB_CTX *libctx);
+OSSL_LIB_CTX *ossl_rsa_get0_libctx(RSA *r);
 
 int ossl_rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
                              const STACK_OF(BIGNUM) *exps,
@@ -64,14 +64,14 @@ int ossl_rsa_pss_params_30_todata(const RSA_PSS_PARAMS_30 *pss,
                                   OSSL_PARAM_BLD *bld, OSSL_PARAM params[]);
 int ossl_rsa_pss_params_30_fromdata(RSA_PSS_PARAMS_30 *pss_params,
                                     const OSSL_PARAM params[],
-                                    OPENSSL_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx);
 
-int ossl_rsa_padding_check_PKCS1_type_2_TLS(OPENSSL_CTX *ctx, unsigned char *to,
+int ossl_rsa_padding_check_PKCS1_type_2_TLS(OSSL_LIB_CTX *ctx, unsigned char *to,
                                             size_t tlen,
                                             const unsigned char *from,
                                             size_t flen, int client_version,
                                             int alt_version);
-int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OPENSSL_CTX *libctx,
+int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OSSL_LIB_CTX *libctx,
                                             unsigned char *to, int tlen,
                                             const unsigned char *from, int flen,
                                             const unsigned char *param,

--- a/include/crypto/siv.h
+++ b/include/crypto/siv.h
@@ -13,10 +13,10 @@ typedef struct siv128_context SIV128_CONTEXT;
 
 SIV128_CONTEXT *CRYPTO_siv128_new(const unsigned char *key, int klen,
                                   EVP_CIPHER *cbc, EVP_CIPHER *ctr,
-                                  OPENSSL_CTX *libctx, const char *propq);
+                                  OSSL_LIB_CTX *libctx, const char *propq);
 int CRYPTO_siv128_init(SIV128_CONTEXT *ctx, const unsigned char *key, int klen,
                        const EVP_CIPHER *cbc, const EVP_CIPHER *ctr,
-                       OPENSSL_CTX *libctx, const char *propq);
+                       OSSL_LIB_CTX *libctx, const char *propq);
 int CRYPTO_siv128_copy_ctx(SIV128_CONTEXT *dest, SIV128_CONTEXT *src);
 int CRYPTO_siv128_aad(SIV128_CONTEXT *ctx, const unsigned char *aad,
                       size_t len);

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -115,7 +115,7 @@ struct X509_crl_st {
     void *meth_data;
     CRYPTO_RWLOCK *lock;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propq;
 };
 
@@ -195,7 +195,7 @@ struct x509_st {
     /* Set on live certificates for authentication purposes */
     ASN1_OCTET_STRING *distinguishing_id;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propq;
 } /* X509 */ ;
 
@@ -271,7 +271,7 @@ struct x509_store_ctx_st {      /* X509_STORE_CTX */
     /* signed via bare TA public key, rather than CA certificate */
     int bare_ta_signed;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 };
 
@@ -305,16 +305,16 @@ int x509_set1_time(ASN1_TIME **ptm, const ASN1_TIME *tm);
 int x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags);
 int x509v3_cache_extensions(X509 *x);
 int x509_init_sig_info(X509 *x);
-int x509_check_issued_int(X509 *issuer, X509 *subject, OPENSSL_CTX *libctx,
+int x509_check_issued_int(X509 *issuer, X509 *subject, OSSL_LIB_CTX *libctx,
                           const char *propq);
 
-int x509_set0_libctx(X509 *x, OPENSSL_CTX *libctx, const char *propq);
-int x509_crl_set0_libctx(X509_CRL *x, OPENSSL_CTX *libctx, const char *propq);
+int x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);
+int x509_crl_set0_libctx(X509_CRL *x, OSSL_LIB_CTX *libctx, const char *propq);
 int x509_init_sig_info(X509 *x);
 int asn1_item_digest_ex(const ASN1_ITEM *it, const EVP_MD *type, void *data,
                         unsigned char *md, unsigned int *len,
-                        OPENSSL_CTX *libctx, const char *propq);
+                        OSSL_LIB_CTX *libctx, const char *propq);
 int X509_add_cert_new(STACK_OF(X509) **sk, X509 *cert, int flags);
 
-int X509_PUBKEY_get0_libctx(OPENSSL_CTX **plibctx, const char **ppropq,
+int X509_PUBKEY_get0_libctx(OSSL_LIB_CTX **plibctx, const char **ppropq,
                             const X509_PUBKEY *key);

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -28,13 +28,13 @@
  */
 typedef struct ossl_method_construct_method_st {
     /* Create store */
-    void *(*alloc_tmp_store)(OPENSSL_CTX *ctx);
+    void *(*alloc_tmp_store)(OSSL_LIB_CTX *ctx);
     /* Remove a store */
     void (*dealloc_tmp_store)(void *store);
     /* Get an already existing method from a store */
-    void *(*get)(OPENSSL_CTX *libctx, void *store, void *data);
+    void *(*get)(OSSL_LIB_CTX *libctx, void *store, void *data);
     /* Store a method in a store */
-    int (*put)(OPENSSL_CTX *libctx, void *store, void *method,
+    int (*put)(OSSL_LIB_CTX *libctx, void *store, void *method,
                const OSSL_PROVIDER *prov, int operation_id, const char *name,
                const char *propdef, void *data);
     /* Construct a new method */
@@ -44,11 +44,11 @@ typedef struct ossl_method_construct_method_st {
     void (*destruct)(void *method, void *data);
 } OSSL_METHOD_CONSTRUCT_METHOD;
 
-void *ossl_method_construct(OPENSSL_CTX *ctx, int operation_id,
+void *ossl_method_construct(OSSL_LIB_CTX *ctx, int operation_id,
                             int force_cache,
                             OSSL_METHOD_CONSTRUCT_METHOD *mcm, void *mcm_data);
 
-void ossl_algorithm_do_all(OPENSSL_CTX *libctx, int operation_id,
+void ossl_algorithm_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                            OSSL_PROVIDER *provider,
                            int (*pre)(OSSL_PROVIDER *, int operation_id,
                                       void *data, int *result),

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -174,7 +174,7 @@ int ossl_lib_ctx_is_global_default(OSSL_LIB_CTX *ctx);
 
 /* Functions to retrieve pointers to data by index */
 void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *, int /* index */,
-                           const OSSL_LIB_CTX_METHOD * ctx);
+                            const OSSL_LIB_CTX_METHOD * ctx);
 
 void ossl_lib_ctx_default_deinit(void);
 OSSL_EX_DATA_GLOBAL *ossl_lib_ctx_get_ex_data_global(OSSL_LIB_CTX *ctx);
@@ -182,7 +182,7 @@ typedef int (ossl_lib_ctx_run_once_fn)(OSSL_LIB_CTX *ctx);
 typedef void (ossl_lib_ctx_onfree_fn)(OSSL_LIB_CTX *ctx);
 
 int ossl_lib_ctx_run_once(OSSL_LIB_CTX *ctx, unsigned int idx,
-                         ossl_lib_ctx_run_once_fn run_once_fn);
+                          ossl_lib_ctx_run_once_fn run_once_fn);
 int ossl_lib_ctx_onfree(OSSL_LIB_CTX *ctx, ossl_lib_ctx_onfree_fn onfreefn);
 
 OSSL_LIB_CTX *crypto_ex_data_get_ossl_lib_ctx(const CRYPTO_EX_DATA *ad);

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -91,8 +91,8 @@ void OPENSSL_cpuid_setup(void);
 extern unsigned int OPENSSL_ia32cap_P[];
 #endif
 void OPENSSL_showfatal(const char *fmta, ...);
-int do_ex_data_init(OPENSSL_CTX *ctx);
-void crypto_cleanup_all_ex_data_int(OPENSSL_CTX *ctx);
+int do_ex_data_init(OSSL_LIB_CTX *ctx);
+void crypto_cleanup_all_ex_data_int(OSSL_LIB_CTX *ctx);
 int openssl_init_fork_handlers(void);
 int openssl_get_fork_id(void);
 
@@ -138,62 +138,62 @@ typedef struct ossl_ex_data_global_st {
 } OSSL_EX_DATA_GLOBAL;
 
 
-/* OPENSSL_CTX */
+/* OSSL_LIB_CTX */
 
-# define OPENSSL_CTX_PROVIDER_STORE_RUN_ONCE_INDEX          0
-# define OPENSSL_CTX_DEFAULT_METHOD_STORE_RUN_ONCE_INDEX    1
-# define OPENSSL_CTX_METHOD_STORE_RUN_ONCE_INDEX            2
-# define OPENSSL_CTX_MAX_RUN_ONCE                           3
+# define OSSL_LIB_CTX_PROVIDER_STORE_RUN_ONCE_INDEX          0
+# define OSSL_LIB_CTX_DEFAULT_METHOD_STORE_RUN_ONCE_INDEX    1
+# define OSSL_LIB_CTX_METHOD_STORE_RUN_ONCE_INDEX            2
+# define OSSL_LIB_CTX_MAX_RUN_ONCE                           3
 
-# define OPENSSL_CTX_EVP_METHOD_STORE_INDEX         0
-# define OPENSSL_CTX_PROVIDER_STORE_INDEX           1
-# define OPENSSL_CTX_PROPERTY_DEFN_INDEX            2
-# define OPENSSL_CTX_PROPERTY_STRING_INDEX          3
-# define OPENSSL_CTX_NAMEMAP_INDEX                  4
-# define OPENSSL_CTX_DRBG_INDEX                     5
-# define OPENSSL_CTX_DRBG_NONCE_INDEX               6
-# define OPENSSL_CTX_RAND_CRNGT_INDEX               7
-# define OPENSSL_CTX_THREAD_EVENT_HANDLER_INDEX     8
-# define OPENSSL_CTX_FIPS_PROV_INDEX                9
-# define OPENSSL_CTX_ENCODER_STORE_INDEX        10
-# define OPENSSL_CTX_DECODER_STORE_INDEX      11
-# define OPENSSL_CTX_SELF_TEST_CB_INDEX            12
-# define OPENSSL_CTX_BIO_PROV_INDEX                13
-# define OPENSSL_CTX_GLOBAL_PROPERTIES             14
-# define OPENSSL_CTX_STORE_LOADER_STORE_INDEX      15
-# define OPENSSL_CTX_MAX_INDEXES                   16
+# define OSSL_LIB_CTX_EVP_METHOD_STORE_INDEX         0
+# define OSSL_LIB_CTX_PROVIDER_STORE_INDEX           1
+# define OSSL_LIB_CTX_PROPERTY_DEFN_INDEX            2
+# define OSSL_LIB_CTX_PROPERTY_STRING_INDEX          3
+# define OSSL_LIB_CTX_NAMEMAP_INDEX                  4
+# define OSSL_LIB_CTX_DRBG_INDEX                     5
+# define OSSL_LIB_CTX_DRBG_NONCE_INDEX               6
+# define OSSL_LIB_CTX_RAND_CRNGT_INDEX               7
+# define OSSL_LIB_CTX_THREAD_EVENT_HANDLER_INDEX     8
+# define OSSL_LIB_CTX_FIPS_PROV_INDEX                9
+# define OSSL_LIB_CTX_ENCODER_STORE_INDEX        10
+# define OSSL_LIB_CTX_DECODER_STORE_INDEX      11
+# define OSSL_LIB_CTX_SELF_TEST_CB_INDEX            12
+# define OSSL_LIB_CTX_BIO_PROV_INDEX                13
+# define OSSL_LIB_CTX_GLOBAL_PROPERTIES             14
+# define OSSL_LIB_CTX_STORE_LOADER_STORE_INDEX      15
+# define OSSL_LIB_CTX_MAX_INDEXES                   16
 
-typedef struct openssl_ctx_method {
-    void *(*new_func)(OPENSSL_CTX *ctx);
+typedef struct ossl_lib_ctx_method {
+    void *(*new_func)(OSSL_LIB_CTX *ctx);
     void (*free_func)(void *);
-} OPENSSL_CTX_METHOD;
+} OSSL_LIB_CTX_METHOD;
 
-OPENSSL_CTX *openssl_ctx_get_concrete(OPENSSL_CTX *ctx);
-int openssl_ctx_is_default(OPENSSL_CTX *ctx);
-int openssl_ctx_is_global_default(OPENSSL_CTX *ctx);
+OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
+int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);
+int ossl_lib_ctx_is_global_default(OSSL_LIB_CTX *ctx);
 
 /* Functions to retrieve pointers to data by index */
-void *openssl_ctx_get_data(OPENSSL_CTX *, int /* index */,
-                           const OPENSSL_CTX_METHOD * ctx);
+void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *, int /* index */,
+                           const OSSL_LIB_CTX_METHOD * ctx);
 
-void openssl_ctx_default_deinit(void);
-OSSL_EX_DATA_GLOBAL *openssl_ctx_get_ex_data_global(OPENSSL_CTX *ctx);
-typedef int (openssl_ctx_run_once_fn)(OPENSSL_CTX *ctx);
-typedef void (openssl_ctx_onfree_fn)(OPENSSL_CTX *ctx);
+void ossl_lib_ctx_default_deinit(void);
+OSSL_EX_DATA_GLOBAL *ossl_lib_ctx_get_ex_data_global(OSSL_LIB_CTX *ctx);
+typedef int (ossl_lib_ctx_run_once_fn)(OSSL_LIB_CTX *ctx);
+typedef void (ossl_lib_ctx_onfree_fn)(OSSL_LIB_CTX *ctx);
 
-int openssl_ctx_run_once(OPENSSL_CTX *ctx, unsigned int idx,
-                         openssl_ctx_run_once_fn run_once_fn);
-int openssl_ctx_onfree(OPENSSL_CTX *ctx, openssl_ctx_onfree_fn onfreefn);
+int ossl_lib_ctx_run_once(OSSL_LIB_CTX *ctx, unsigned int idx,
+                         ossl_lib_ctx_run_once_fn run_once_fn);
+int ossl_lib_ctx_onfree(OSSL_LIB_CTX *ctx, ossl_lib_ctx_onfree_fn onfreefn);
 
-OPENSSL_CTX *crypto_ex_data_get_openssl_ctx(const CRYPTO_EX_DATA *ad);
-int crypto_new_ex_data_ex(OPENSSL_CTX *ctx, int class_index, void *obj,
+OSSL_LIB_CTX *crypto_ex_data_get_ossl_lib_ctx(const CRYPTO_EX_DATA *ad);
+int crypto_new_ex_data_ex(OSSL_LIB_CTX *ctx, int class_index, void *obj,
                           CRYPTO_EX_DATA *ad);
-int crypto_get_ex_new_index_ex(OPENSSL_CTX *ctx, int class_index,
+int crypto_get_ex_new_index_ex(OSSL_LIB_CTX *ctx, int class_index,
                                long argl, void *argp,
                                CRYPTO_EX_new *new_func,
                                CRYPTO_EX_dup *dup_func,
                                CRYPTO_EX_free *free_func);
-int crypto_free_ex_index_ex(OPENSSL_CTX *ctx, int class_index, int idx);
+int crypto_free_ex_index_ex(OSSL_LIB_CTX *ctx, int class_index, int idx);
 
 /* Function for simple binary search */
 

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -145,28 +145,28 @@ int ossl_ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent);
 #endif /* FIPS_MODULE */
 
 
-int ossl_ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+int ossl_ffc_params_FIPS186_4_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
                                        int *res, BN_GENCB *cb);
-int ossl_ffc_params_FIPS186_2_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+int ossl_ffc_params_FIPS186_2_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
                                        int *res, BN_GENCB *cb);
 
-int ossl_ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_4_gen_verify(OSSL_LIB_CTX *libctx,
                                          FFC_PARAMS *params, int mode, int type,
                                          size_t L, size_t N, int *res,
                                          BN_GENCB *cb);
-int ossl_ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_2_gen_verify(OSSL_LIB_CTX *libctx,
                                          FFC_PARAMS *params, int mode, int type,
                                          size_t L, size_t N, int *res,
                                          BN_GENCB *cb);
 
-int ossl_ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+int ossl_ffc_params_simple_validate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                     int type);
-int ossl_ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_4_validate(OSSL_LIB_CTX *libctx,
                                        const FFC_PARAMS *params,
                                        int type, int *res, BN_GENCB *cb);
-int ossl_ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx,
+int ossl_ffc_params_FIPS186_2_validate(OSSL_LIB_CTX *libctx,
                                        const FFC_PARAMS *params,
                                        int type, int *res, BN_GENCB *cb);
 

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -11,7 +11,7 @@
 
 typedef struct ossl_namemap_st OSSL_NAMEMAP;
 
-OSSL_NAMEMAP *ossl_namemap_stored(OPENSSL_CTX *libctx);
+OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx);
 
 OSSL_NAMEMAP *ossl_namemap_new(void);
 void ossl_namemap_free(OSSL_NAMEMAP *namemap);

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -45,7 +45,8 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
                             const char *prop_query, void **method);
 
 /* Get the global properties associate with the specified library context */
-OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *ctx, int loadconfig);
+OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *ctx,
+                                                int loadconfig);
 
 /* property query cache functions */
 int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, int nid,

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -17,23 +17,23 @@ typedef struct ossl_method_store_st OSSL_METHOD_STORE;
 typedef struct ossl_property_list_st OSSL_PROPERTY_LIST;
 
 /* Initialisation */
-int ossl_property_parse_init(OPENSSL_CTX *ctx);
+int ossl_property_parse_init(OSSL_LIB_CTX *ctx);
 
 /* Property definition parser */
-OSSL_PROPERTY_LIST *ossl_parse_property(OPENSSL_CTX *ctx, const char *defn);
+OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn);
 /* Property query parser */
-OSSL_PROPERTY_LIST *ossl_parse_query(OPENSSL_CTX *ctx, const char *s);
+OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s);
 /* Property checker of query vs definition */
 int ossl_property_match_count(const OSSL_PROPERTY_LIST *query,
                               const OSSL_PROPERTY_LIST *defn);
-int ossl_property_is_enabled(OPENSSL_CTX *ctx,  const char *property_name,
+int ossl_property_is_enabled(OSSL_LIB_CTX *ctx,  const char *property_name,
                              const OSSL_PROPERTY_LIST *prop_list);
 /* Free a parsed property list */
 void ossl_property_free(OSSL_PROPERTY_LIST *p);
 
 
 /* Implementation store functions */
-OSSL_METHOD_STORE *ossl_method_store_new(OPENSSL_CTX *ctx);
+OSSL_METHOD_STORE *ossl_method_store_new(OSSL_LIB_CTX *ctx);
 void ossl_method_store_free(OSSL_METHOD_STORE *store);
 int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
                           int nid, const char *properties, void *method,
@@ -45,7 +45,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
                             const char *prop_query, void **method);
 
 /* Get the global properties associate with the specified library context */
-OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OPENSSL_CTX *ctx, int loadconfig);
+OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *ctx, int loadconfig);
 
 /* property query cache functions */
 int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, int nid,

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -27,9 +27,9 @@ extern "C" {
  */
 
 /* Provider Object finder, constructor and destructor */
-OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name,
+OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
                                   int noconfig);
-OSSL_PROVIDER *ossl_provider_new(OPENSSL_CTX *libctx, const char *name,
+OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
                                  OSSL_provider_init_fn *init_function,
                                  int noconfig);
 int ossl_provider_up_ref(OSSL_PROVIDER *prov);
@@ -42,7 +42,7 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
                                 const char *value);
 
 /* Disable fallback loading */
-int ossl_provider_disable_fallback_loading(OPENSSL_CTX *libctx);
+int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
 
 /*
  * Activate the Provider
@@ -57,7 +57,7 @@ int ossl_provider_available(OSSL_PROVIDER *prov);
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
 
 /* Iterate over all loaded providers */
-int ossl_provider_forall_loaded(OPENSSL_CTX *,
+int ossl_provider_forall_loaded(OSSL_LIB_CTX *,
                                 int (*cb)(OSSL_PROVIDER *provider,
                                           void *cbdata),
                                 void *cbdata);
@@ -68,7 +68,7 @@ const DSO *ossl_provider_dso(const OSSL_PROVIDER *prov);
 const char *ossl_provider_module_name(const OSSL_PROVIDER *prov);
 const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 void *ossl_provider_prov_ctx(const OSSL_PROVIDER *prov);
-OPENSSL_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov);
+OSSL_LIB_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -68,7 +68,7 @@ const DSO *ossl_provider_dso(const OSSL_PROVIDER *prov);
 const char *ossl_provider_module_name(const OSSL_PROVIDER *prov);
 const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 void *ossl_provider_prov_ctx(const OSSL_PROVIDER *prov);
-OSSL_LIB_CTX *ossl_provider_library_context(const OSSL_PROVIDER *prov);
+OSSL_LIB_CTX *ossl_provider_libctx(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);

--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -12,7 +12,7 @@
 /*
  * Initialisation of global data should never happen via "RUN_ONCE" inside the
  * FIPS module. Global data should instead always be associated with a specific
- * OPENSSL_CTX object. In this way data will get cleaned up correctly when the
+ * OSSL_LIB_CTX object. In this way data will get cleaned up correctly when the
  * module gets unloaded.
  */
 #if !defined(FIPS_MODULE) || defined(ALLOW_RUN_ONCE_IN_FIPS)

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -736,12 +736,12 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x);
 int ASN1_item_sign_ex(const ASN1_ITEM *it, X509_ALGOR *algor1,
                       X509_ALGOR *algor2, ASN1_BIT_STRING *signature,
                       const void *data, const ASN1_OCTET_STRING *id,
-                      EVP_PKEY *pkey, const EVP_MD *md, OPENSSL_CTX *libctx,
+                      EVP_PKEY *pkey, const EVP_MD *md, OSSL_LIB_CTX *libctx,
                       const char *propq);
 int ASN1_item_verify_ex(const ASN1_ITEM *it, const X509_ALGOR *alg,
                         const ASN1_BIT_STRING *signature, const void *data,
                         const ASN1_OCTET_STRING *id, EVP_PKEY *pkey,
-                        OPENSSL_CTX *libctx, const char *propq);
+                        OSSL_LIB_CTX *libctx, const char *propq);
 
 /* ASN1 alloc/free macros for when a type is only used internally */
 
@@ -912,7 +912,7 @@ int SMIME_write_ASN1(BIO *bio, ASN1_VALUE *val, BIO *data, int flags,
 int SMIME_write_ASN1_ex(BIO *bio, ASN1_VALUE *val, BIO *data, int flags,
                         int ctype_nid, int econt_nid,
                         STACK_OF(X509_ALGOR) *mdalgs, const ASN1_ITEM *it,
-                        OPENSSL_CTX *libctx, const char *propq);
+                        OSSL_LIB_CTX *libctx, const char *propq);
 ASN1_VALUE *SMIME_read_ASN1(BIO *bio, BIO **bcont, const ASN1_ITEM *it);
 ASN1_VALUE *SMIME_read_ASN1_ex(BIO *bio, BIO **bcont, const ASN1_ITEM *it,
                                ASN1_VALUE **x);

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -206,9 +206,9 @@ void BN_zero_ex(BIGNUM *a);
 
 const BIGNUM *BN_value_one(void);
 char *BN_options(void);
-BN_CTX *BN_CTX_new_ex(OPENSSL_CTX *ctx);
+BN_CTX *BN_CTX_new_ex(OSSL_LIB_CTX *ctx);
 BN_CTX *BN_CTX_new(void);
-BN_CTX *BN_CTX_secure_new_ex(OPENSSL_CTX *ctx);
+BN_CTX *BN_CTX_secure_new_ex(OSSL_LIB_CTX *ctx);
 BN_CTX *BN_CTX_secure_new(void);
 void BN_CTX_free(BN_CTX *c);
 void BN_CTX_start(BN_CTX *ctx);

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -259,7 +259,7 @@ void OSSL_CMP_ITAV_free(OSSL_CMP_ITAV *itav);
 void OSSL_CMP_MSG_free(OSSL_CMP_MSG *msg);
 
 /* from cmp_ctx.c */
-OSSL_CMP_CTX *OSSL_CMP_CTX_new(OPENSSL_CTX *libctx, const char *propq);
+OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq);
 void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx);
 int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx);
 /* various CMP options: */
@@ -396,7 +396,7 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
                                            const OSSL_CMP_MSG *req);
 OSSL_CMP_MSG * OSSL_CMP_CTX_server_perform(OSSL_CMP_CTX *client_ctx,
                                            const OSSL_CMP_MSG *req);
-OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OPENSSL_CTX *libctx, const char *propq);
+OSSL_CMP_SRV_CTX *OSSL_CMP_SRV_CTX_new(OSSL_LIB_CTX *libctx, const char *propq);
 void OSSL_CMP_SRV_CTX_free(OSSL_CMP_SRV_CTX *srv_ctx);
 typedef OSSL_CMP_PKISI *(*OSSL_CMP_SRV_cert_request_cb_t)
     (OSSL_CMP_SRV_CTX *srv_ctx, const OSSL_CMP_MSG *req, int certReqId,

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -53,7 +53,7 @@ DECLARE_ASN1_FUNCTIONS(CMS_ContentInfo)
 DECLARE_ASN1_FUNCTIONS(CMS_ReceiptRequest)
 DECLARE_ASN1_PRINT_FUNCTION(CMS_ContentInfo)
 
-CMS_ContentInfo *CMS_ContentInfo_new_ex(OPENSSL_CTX *libctx, const char *propq);
+CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 
 # define CMS_SIGNERINFO_ISSUER_SERIAL    0
 # define CMS_SIGNERINFO_KEYIDENTIFIER    1
@@ -125,7 +125,7 @@ CMS_ContentInfo *CMS_sign(X509 *signcert, EVP_PKEY *pkey,
                           unsigned int flags);
 CMS_ContentInfo *CMS_sign_ex(X509 *signcert, EVP_PKEY *pkey,
                              STACK_OF(X509) *certs, BIO *data,
-                             unsigned int flags, OPENSSL_CTX *ctx,
+                             unsigned int flags, OSSL_LIB_CTX *ctx,
                              const char *propq);
 
 CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
@@ -135,14 +135,14 @@ CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
 int CMS_data(CMS_ContentInfo *cms, BIO *out, unsigned int flags);
 CMS_ContentInfo *CMS_data_create(BIO *in, unsigned int flags);
 CMS_ContentInfo *CMS_data_create_ex(BIO *in, unsigned int flags,
-                                    OPENSSL_CTX *ctx, const char *propq);
+                                    OSSL_LIB_CTX *ctx, const char *propq);
 
 int CMS_digest_verify(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
                       unsigned int flags);
 CMS_ContentInfo *CMS_digest_create(BIO *in, const EVP_MD *md,
                                    unsigned int flags);
 CMS_ContentInfo *CMS_digest_create_ex(BIO *in, const EVP_MD *md,
-                                      unsigned int flags, OPENSSL_CTX *ctx,
+                                      unsigned int flags, OSSL_LIB_CTX *ctx,
                                       const char *propq);
 
 int CMS_EncryptedData_decrypt(CMS_ContentInfo *cms,
@@ -155,7 +155,7 @@ CMS_ContentInfo *CMS_EncryptedData_encrypt(BIO *in, const EVP_CIPHER *cipher,
 CMS_ContentInfo *CMS_EncryptedData_encrypt_ex(BIO *in, const EVP_CIPHER *cipher,
                                               const unsigned char *key,
                                               size_t keylen, unsigned int flags,
-                                              OPENSSL_CTX *ctx,
+                                              OSSL_LIB_CTX *ctx,
                                               const char *propq);
 
 int CMS_EncryptedData_set1_key(CMS_ContentInfo *cms, const EVP_CIPHER *ciph,
@@ -174,7 +174,7 @@ CMS_ContentInfo *CMS_encrypt(STACK_OF(X509) *certs, BIO *in,
                              const EVP_CIPHER *cipher, unsigned int flags);
 CMS_ContentInfo *CMS_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
                                 const EVP_CIPHER *cipher, unsigned int flags,
-                                OPENSSL_CTX *ctx, const char *propq);
+                                OSSL_LIB_CTX *ctx, const char *propq);
 
 int CMS_decrypt(CMS_ContentInfo *cms, EVP_PKEY *pkey, X509 *cert,
                 BIO *dcont, BIO *out, unsigned int flags);
@@ -193,11 +193,11 @@ int CMS_RecipientInfo_type(CMS_RecipientInfo *ri);
 EVP_PKEY_CTX *CMS_RecipientInfo_get0_pkey_ctx(CMS_RecipientInfo *ri);
 CMS_ContentInfo *CMS_AuthEnvelopedData_create(const EVP_CIPHER *cipher);
 CMS_ContentInfo *
-CMS_AuthEnvelopedData_create_ex(const EVP_CIPHER *cipher, OPENSSL_CTX *ctx,
+CMS_AuthEnvelopedData_create_ex(const EVP_CIPHER *cipher, OSSL_LIB_CTX *ctx,
                                 const char *propq);
 CMS_ContentInfo *CMS_EnvelopedData_create(const EVP_CIPHER *cipher);
 CMS_ContentInfo *CMS_EnvelopedData_create_ex(const EVP_CIPHER *cipher,
-                                             OPENSSL_CTX *ctx,
+                                             OSSL_LIB_CTX *ctx,
                                              const char *propq);
 
 CMS_RecipientInfo *CMS_add1_recipient_cert(CMS_ContentInfo *cms,
@@ -342,7 +342,7 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList,
     STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OPENSSL_CTX *ctx, const char *propq);
+    OSSL_LIB_CTX *ctx, const char *propq);
 
 int CMS_add1_ReceiptRequest(CMS_SignerInfo *si, CMS_ReceiptRequest *rr);
 void CMS_ReceiptRequest_get0_values(CMS_ReceiptRequest *rr,

--- a/include/openssl/conf.h.in
+++ b/include/openssl/conf.h.in
@@ -119,10 +119,10 @@ struct conf_st {
     void *meth_data;
     LHASH_OF(CONF_VALUE) *data;
     unsigned int flag_dollarid:1;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 };
 
-CONF *NCONF_new_ex(OPENSSL_CTX *libctx, CONF_METHOD *meth);
+CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth);
 CONF *NCONF_new(CONF_METHOD *meth);
 CONF_METHOD *NCONF_default(void);
 DEPRECATEDIN_3_0(CONF_METHOD *NCONF_WIN32(void))
@@ -150,7 +150,7 @@ int NCONF_dump_bio(const CONF *conf, BIO *out);
 
 int CONF_modules_load(const CONF *cnf, const char *appname,
                       unsigned long flags);
-int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
+int CONF_modules_load_file_ex(OSSL_LIB_CTX *libctx, const char *filename,
                               const char *appname, unsigned long flags);
 int CONF_modules_load_file(const char *filename, const char *appname,
                            unsigned long flags);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -66,7 +66,7 @@ OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_CORE_HANDLE *prov,
 # define OSSL_FUNC_CORE_THREAD_START           3
 OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_CORE_HANDLE *prov,
                                            OSSL_thread_stop_handler_fn handfn))
-# define OSSL_FUNC_CORE_GET_LIBCTX    4
+# define OSSL_FUNC_CORE_GET_LIBCTX             4
 OSSL_CORE_MAKE_FUNC(OPENSSL_CORE_CTX *,core_get_libctx,
                     (const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_NEW_ERROR              5

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -66,8 +66,8 @@ OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_CORE_HANDLE *prov,
 # define OSSL_FUNC_CORE_THREAD_START           3
 OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_CORE_HANDLE *prov,
                                            OSSL_thread_stop_handler_fn handfn))
-# define OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT    4
-OSSL_CORE_MAKE_FUNC(OPENSSL_CORE_CTX *,core_get_library_context,
+# define OSSL_FUNC_CORE_GET_LIBCTX    4
+OSSL_CORE_MAKE_FUNC(OPENSSL_CORE_CTX *,core_get_libctx,
                     (const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_NEW_ERROR              5
 OSSL_CORE_MAKE_FUNC(void,core_new_error,(const OSSL_CORE_HANDLE *prov))

--- a/include/openssl/crmf.h.in
+++ b/include/openssl/crmf.h.in
@@ -77,10 +77,10 @@ DECLARE_ASN1_FUNCTIONS(OSSL_CRMF_MSGS)
 typedef struct ossl_crmf_optionalvalidity_st OSSL_CRMF_OPTIONALVALIDITY;
 
 /* crmf_pbm.c */
-OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OPENSSL_CTX *libctx, size_t slen,
+OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t slen,
                                            int owfnid, size_t itercnt,
                                            int macnid);
-int OSSL_CRMF_pbm_new(OPENSSL_CTX *libctx, const char *propq,
+int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
                       const OSSL_CRMF_PBMPARAMETER *pbmp,
                       const unsigned char *msg, size_t msglen,
                       const unsigned char *sec, size_t seclen,
@@ -132,10 +132,10 @@ int OSSL_CRMF_MSG_push0_extension(OSSL_CRMF_MSG *crm, X509_EXTENSION *ext);
 #  define OSSL_CRMF_POPO_KEYAGREE   3
 int OSSL_CRMF_MSG_create_popo(int meth, OSSL_CRMF_MSG *crm,
                               EVP_PKEY *pkey, const EVP_MD *digest,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
 int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
                                int rid, int acceptRAVerified,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
 OSSL_CRMF_CERTTEMPLATE *OSSL_CRMF_MSG_get0_tmpl(const OSSL_CRMF_MSG *crm);
 ASN1_INTEGER
 *OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl);
@@ -151,7 +151,7 @@ int OSSL_CRMF_CERTTEMPLATE_fill(OSSL_CRMF_CERTTEMPLATE *tmpl,
                                 const ASN1_INTEGER *serial);
 X509
 *OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert(const OSSL_CRMF_ENCRYPTEDVALUE *ecert,
-                                       OPENSSL_CTX *libctx, const char *propq,
+                                       OSSL_LIB_CTX *libctx, const char *propq,
                                        EVP_PKEY *pkey);
 
 #  ifdef __cplusplus

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -173,7 +173,7 @@ const char *OPENSSL_info(int type);
 int OPENSSL_issetugid(void);
 
 struct crypto_ex_data_st {
-    OPENSSL_CTX *ctx;
+    OSSL_LIB_CTX *ctx;
     STACK_OF(void) *sk;
 };
 
@@ -202,7 +202,7 @@ struct crypto_ex_data_st {
 # define CRYPTO_EX_INDEX_UI_METHOD       14
 # define CRYPTO_EX_INDEX_RAND_DRBG       15
 # define CRYPTO_EX_INDEX_DRBG            CRYPTO_EX_INDEX_RAND_DRBG
-# define CRYPTO_EX_INDEX_OPENSSL_CTX     16
+# define CRYPTO_EX_INDEX_OSSL_LIB_CTX     16
 # define CRYPTO_EX_INDEX_EVP_PKEY        17
 # define CRYPTO_EX_INDEX__COUNT          18
 
@@ -449,7 +449,7 @@ void OPENSSL_cleanup(void);
 int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
 int OPENSSL_atexit(void (*handler)(void));
 void OPENSSL_thread_stop(void);
-void OPENSSL_thread_stop_ex(OPENSSL_CTX *ctx);
+void OPENSSL_thread_stop_ex(OSSL_LIB_CTX *ctx);
 
 /* Low-level control of initialization */
 OPENSSL_INIT_SETTINGS *OPENSSL_INIT_new(void);
@@ -506,10 +506,10 @@ int CRYPTO_THREAD_cleanup_local(CRYPTO_THREAD_LOCAL *key);
 CRYPTO_THREAD_ID CRYPTO_THREAD_get_current_id(void);
 int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b);
 
-OPENSSL_CTX *OPENSSL_CTX_new(void);
-int OPENSSL_CTX_load_config(OPENSSL_CTX *ctx, const char *config_file);
-void OPENSSL_CTX_free(OPENSSL_CTX *);
-OPENSSL_CTX *OPENSSL_CTX_set0_default(OPENSSL_CTX *libctx);
+OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
+int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
+void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
+OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx);
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -202,7 +202,7 @@ struct crypto_ex_data_st {
 # define CRYPTO_EX_INDEX_UI_METHOD       14
 # define CRYPTO_EX_INDEX_RAND_DRBG       15
 # define CRYPTO_EX_INDEX_DRBG            CRYPTO_EX_INDEX_RAND_DRBG
-# define CRYPTO_EX_INDEX_OSSL_LIB_CTX     16
+# define CRYPTO_EX_INDEX_OSSL_LIB_CTX    16
 # define CRYPTO_EX_INDEX_EVP_PKEY        17
 # define CRYPTO_EX_INDEX__COUNT          18
 

--- a/include/openssl/ct.h.in
+++ b/include/openssl/ct.h.in
@@ -83,7 +83,7 @@ typedef enum {
  * The caller is responsible for calling CT_POLICY_EVAL_CTX_free when finished
  * with the CT_POLICY_EVAL_CTX.
  */
-CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OPENSSL_CTX *libctx,
+CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OSSL_LIB_CTX *libctx,
                                               const char *propq);
                                                        
 /*
@@ -433,7 +433,7 @@ SCT *o2i_SCT(SCT **psct, const unsigned char **in, size_t len);
  * Returns NULL if malloc fails or if |public_key| cannot be converted to DER.
  * Should be deleted by the caller using CTLOG_free when no longer needed.
  */
-CTLOG *CTLOG_new_ex(EVP_PKEY *public_key, const char *name, OPENSSL_CTX *libctx,
+CTLOG *CTLOG_new_ex(EVP_PKEY *public_key, const char *name, OSSL_LIB_CTX *libctx,
                     const char *propq);
 
 /*
@@ -451,7 +451,7 @@ CTLOG *CTLOG_new(EVP_PKEY *public_key, const char *name);
  * Should be deleted by the caller using CTLOG_free when no longer needed.
  */
 int CTLOG_new_from_base64_ex(CTLOG **ct_log, const char *pkey_base64,
-                             const char *name, OPENSSL_CTX *libctx,
+                             const char *name, OSSL_LIB_CTX *libctx,
                              const char *propq);
 
 /*
@@ -484,7 +484,7 @@ EVP_PKEY *CTLOG_get0_public_key(const CTLOG *log);
  * property query string.
  * Should be deleted by the caller using CTLOG_STORE_free when no longer needed.
  */
-CTLOG_STORE *CTLOG_STORE_new_ex(OPENSSL_CTX *libctx, const char *propq);
+CTLOG_STORE *CTLOG_STORE_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 
 /*
  * Same as CTLOG_STORE_new_ex except that the default libctx and

--- a/include/openssl/decoder.h
+++ b/include/openssl/decoder.h
@@ -26,7 +26,7 @@
 extern "C" {
 # endif
 
-OSSL_DECODER *OSSL_DECODER_fetch(OPENSSL_CTX *libctx, const char *name,
+OSSL_DECODER *OSSL_DECODER_fetch(OSSL_LIB_CTX *libctx, const char *name,
                                  const char *properties);
 int OSSL_DECODER_up_ref(OSSL_DECODER *encoder);
 void OSSL_DECODER_free(OSSL_DECODER *encoder);
@@ -36,7 +36,7 @@ const char *OSSL_DECODER_properties(const OSSL_DECODER *encoder);
 int OSSL_DECODER_number(const OSSL_DECODER *encoder);
 int OSSL_DECODER_is_a(const OSSL_DECODER *encoder, const char *name);
 
-void OSSL_DECODER_do_all_provided(OPENSSL_CTX *libctx,
+void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(OSSL_DECODER *encoder, void *arg),
                                   void *arg);
 void OSSL_DECODER_names_do_all(const OSSL_DECODER *encoder,
@@ -72,7 +72,7 @@ int OSSL_DECODER_CTX_set_input_type(OSSL_DECODER_CTX *ctx,
                                     const char *input_type);
 int OSSL_DECODER_CTX_add_decoder(OSSL_DECODER_CTX *ctx, OSSL_DECODER *decoder);
 int OSSL_DECODER_CTX_add_extra(OSSL_DECODER_CTX *ctx,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
 int OSSL_DECODER_CTX_get_num_decoders(OSSL_DECODER_CTX *ctx);
 
 typedef struct ossl_decoder_instance_st OSSL_DECODER_INSTANCE;
@@ -116,7 +116,7 @@ int OSSL_DECODER_from_data(OSSL_DECODER_CTX *ctx, const unsigned char **pdata,
 OSSL_DECODER_CTX *
 OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
                                  const char *input_type, const char *keytype,
-                                 OPENSSL_CTX *libctx, const char *propquery);
+                                 OSSL_LIB_CTX *libctx, const char *propquery);
 
 # ifdef __cplusplus
 }

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -391,7 +391,7 @@ EC_GROUP *EC_GROUP_new_curve_GF2m(const BIGNUM *p, const BIGNUM *a,
  *          if an error occurred
  */
 EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
-                                   OPENSSL_CTX *libctx, const char *propq);
+                                   OSSL_LIB_CTX *libctx, const char *propq);
 
 /**
  * Creates a EC_GROUP object with a curve specified by a NID
@@ -402,7 +402,7 @@ EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
  *  \return newly created EC_GROUP object with specified curve or NULL
  *          if an error occurred
  */
-EC_GROUP *EC_GROUP_new_by_curve_name_ex(OPENSSL_CTX *libctx, const char *propq,
+EC_GROUP *EC_GROUP_new_by_curve_name_ex(OSSL_LIB_CTX *libctx, const char *propq,
                                         int nid);
 
 /**
@@ -882,7 +882,7 @@ int ECPKParameters_print_fp(FILE *fp, const EC_GROUP *x, int off);
  *               which case the default library context is used.
  *  \return EC_KEY object or NULL if an error occurred.
  */
-EC_KEY *EC_KEY_new_ex(OPENSSL_CTX *ctx, const char *propq);
+EC_KEY *EC_KEY_new_ex(OSSL_LIB_CTX *ctx, const char *propq);
 
 /**
  *  Creates a new EC_KEY object. Same as calling EC_KEY_new_ex with a
@@ -908,7 +908,7 @@ int EC_KEY_decoded_from_explicit_params(const EC_KEY *key);
  *  \param  nid   NID of the named curve.
  *  \return EC_KEY object or NULL if an error occurred.
  */
-EC_KEY *EC_KEY_new_by_curve_name_ex(OPENSSL_CTX *ctx, const char *propq,
+EC_KEY *EC_KEY_new_by_curve_name_ex(OSSL_LIB_CTX *ctx, const char *propq,
                                     int nid);
 
 /**

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -26,7 +26,7 @@
 extern "C" {
 # endif
 
-OSSL_ENCODER *OSSL_ENCODER_fetch(OPENSSL_CTX *libctx, const char *name,
+OSSL_ENCODER *OSSL_ENCODER_fetch(OSSL_LIB_CTX *libctx, const char *name,
                                  const char *properties);
 int OSSL_ENCODER_up_ref(OSSL_ENCODER *encoder);
 void OSSL_ENCODER_free(OSSL_ENCODER *encoder);
@@ -36,7 +36,7 @@ const char *OSSL_ENCODER_properties(const OSSL_ENCODER *encoder);
 int OSSL_ENCODER_number(const OSSL_ENCODER *encoder);
 int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name);
 
-void OSSL_ENCODER_do_all_provided(OPENSSL_CTX *libctx,
+void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(OSSL_ENCODER *encoder, void *arg),
                                   void *arg);
 void OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
@@ -72,7 +72,7 @@ int OSSL_ENCODER_CTX_set_selection(OSSL_ENCODER_CTX *ctx, int selection);
 /* Utilities to add encoders */
 int OSSL_ENCODER_CTX_add_encoder(OSSL_ENCODER_CTX *ctx, OSSL_ENCODER *encoder);
 int OSSL_ENCODER_CTX_add_extra(OSSL_ENCODER_CTX *ctx,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
 int OSSL_ENCODER_CTX_get_num_encoders(OSSL_ENCODER_CTX *ctx);
 
 typedef struct ossl_encoder_instance_st OSSL_ENCODER_INSTANCE;
@@ -112,7 +112,7 @@ int OSSL_ENCODER_to_data(OSSL_ENCODER_CTX *ctx, unsigned char **pdata,
 OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                                    const char *output_type,
                                                    int selection,
-                                                   OPENSSL_CTX *libctx,
+                                                   OSSL_LIB_CTX *libctx,
                                                    const char *propquery);
 
 # ifdef __cplusplus

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1242,7 +1242,8 @@ int i2d_PublicKey(const EVP_PKEY *a, unsigned char **pp);
 
 
 EVP_PKEY *d2i_PrivateKey_ex(int type, EVP_PKEY **a, const unsigned char **pp,
-                            long length, OSSL_LIB_CTX *libctx, const char *propq);
+                            long length, OSSL_LIB_CTX *libctx,
+                            const char *propq);
 EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
                          long length);
 EVP_PKEY *d2i_AutoPrivateKey_ex(EVP_PKEY **a, const unsigned char **pp,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -79,9 +79,9 @@
 extern "C" {
 #endif
 
-int EVP_set_default_properties(OPENSSL_CTX *libctx, const char *propq);
-int EVP_default_properties_is_fips_enabled(OPENSSL_CTX *libctx);
-int EVP_default_properties_enable_fips(OPENSSL_CTX *libctx, int enable);
+int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq);
+int EVP_default_properties_is_fips_enabled(OSSL_LIB_CTX *libctx);
+int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable);
 
 # define EVP_PKEY_MO_SIGN        0x0001
 # define EVP_PKEY_MO_VERIFY      0x0002
@@ -524,7 +524,7 @@ int EVP_CIPHER_key_length(const EVP_CIPHER *cipher);
 int EVP_CIPHER_iv_length(const EVP_CIPHER *cipher);
 unsigned long EVP_CIPHER_flags(const EVP_CIPHER *cipher);
 int EVP_CIPHER_mode(const EVP_CIPHER *cipher);
-EVP_CIPHER *EVP_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_CIPHER *EVP_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                              const char *properties);
 int EVP_CIPHER_up_ref(EVP_CIPHER *cipher);
 void EVP_CIPHER_free(EVP_CIPHER *cipher);
@@ -628,7 +628,7 @@ __owur int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md,
 __owur int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md,
                               size_t len);
 
-__owur EVP_MD *EVP_MD_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+__owur EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                             const char *properties);
 
 int EVP_MD_up_ref(EVP_MD *md);
@@ -692,7 +692,7 @@ __owur int EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm,
 __owur int EVP_SignFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s,
                          EVP_PKEY *pkey);
 __owur int EVP_SignFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s,
-                            EVP_PKEY *pkey, OPENSSL_CTX *libctx,
+                            EVP_PKEY *pkey, OSSL_LIB_CTX *libctx,
                             const char *propq);
 
 __owur int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret,
@@ -703,14 +703,14 @@ __owur int EVP_VerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sigbuf,
                            unsigned int siglen, EVP_PKEY *pkey);
 __owur int EVP_VerifyFinal_ex(EVP_MD_CTX *ctx, const unsigned char *sigbuf,
                               unsigned int siglen, EVP_PKEY *pkey,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
 
 __owur int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
                             size_t siglen, const unsigned char *tbs,
                             size_t tbslen);
 
 int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                          const char *mdname, OPENSSL_CTX *libctx,
+                          const char *mdname, OSSL_LIB_CTX *libctx,
                           const char *props, EVP_PKEY *pkey);
 /*__owur*/ int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                   const EVP_MD *type, ENGINE *e,
@@ -720,7 +720,7 @@ __owur int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
                                size_t *siglen);
 
 int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-                            const char *mdname, OPENSSL_CTX *libctx,
+                            const char *mdname, OSSL_LIB_CTX *libctx,
                             const char *props, EVP_PKEY *pkey);
 __owur int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                 const EVP_MD *type, ENGINE *e,
@@ -1072,7 +1072,7 @@ void EVP_CIPHER_do_all(void (*fn) (const EVP_CIPHER *ciph,
 void EVP_CIPHER_do_all_sorted(void (*fn)
                                (const EVP_CIPHER *ciph, const char *from,
                                 const char *to, void *x), void *arg);
-void EVP_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                 void (*fn)(EVP_CIPHER *cipher, void *arg),
                                 void *arg);
 
@@ -1082,13 +1082,13 @@ void EVP_MD_do_all(void (*fn) (const EVP_MD *ciph,
 void EVP_MD_do_all_sorted(void (*fn)
                            (const EVP_MD *ciph, const char *from,
                             const char *to, void *x), void *arg);
-void EVP_MD_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
                             void (*fn)(EVP_MD *md, void *arg),
                             void *arg);
 
 /* MAC stuff */
 
-EVP_MAC *EVP_MAC_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+EVP_MAC *EVP_MAC_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                        const char *properties);
 int EVP_MAC_up_ref(EVP_MAC *mac);
 void EVP_MAC_free(EVP_MAC *mac);
@@ -1114,7 +1114,7 @@ const OSSL_PARAM *EVP_MAC_gettable_params(const EVP_MAC *mac);
 const OSSL_PARAM *EVP_MAC_gettable_ctx_params(const EVP_MAC *mac);
 const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac);
 
-void EVP_MAC_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_MAC *mac, void *arg),
                              void *arg);
 void EVP_MAC_names_do_all(const EVP_MAC *mac,
@@ -1122,7 +1122,7 @@ void EVP_MAC_names_do_all(const EVP_MAC *mac,
                           void *data);
 
 /* RAND stuff */
-EVP_RAND *EVP_RAND_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+EVP_RAND *EVP_RAND_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                          const char *properties);
 int EVP_RAND_up_ref(EVP_RAND *rand);
 void EVP_RAND_free(EVP_RAND *rand);
@@ -1141,7 +1141,7 @@ const OSSL_PARAM *EVP_RAND_gettable_params(const EVP_RAND *rand);
 const OSSL_PARAM *EVP_RAND_gettable_ctx_params(const EVP_RAND *rand);
 const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand);
 
-void EVP_RAND_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_RAND *rand, void *arg),
                               void *arg);
 void EVP_RAND_names_do_all(const EVP_RAND *rand,
@@ -1242,11 +1242,11 @@ int i2d_PublicKey(const EVP_PKEY *a, unsigned char **pp);
 
 
 EVP_PKEY *d2i_PrivateKey_ex(int type, EVP_PKEY **a, const unsigned char **pp,
-                            long length, OPENSSL_CTX *libctx, const char *propq);
+                            long length, OSSL_LIB_CTX *libctx, const char *propq);
 EVP_PKEY *d2i_PrivateKey(int type, EVP_PKEY **a, const unsigned char **pp,
                          long length);
 EVP_PKEY *d2i_AutoPrivateKey_ex(EVP_PKEY **a, const unsigned char **pp,
-                                long length, OPENSSL_CTX *libctx,
+                                long length, OSSL_LIB_CTX *libctx,
                                 const char *propq);
 EVP_PKEY *d2i_AutoPrivateKey(EVP_PKEY **a, const unsigned char **pp,
                              long length);
@@ -1554,7 +1554,7 @@ DEPRECATEDIN_3_0(int EVP_PKEY_meth_remove(const EVP_PKEY_METHOD *pmeth))
 DEPRECATEDIN_3_0(size_t EVP_PKEY_meth_get_count(void))
 DEPRECATEDIN_3_0(const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx))
 
-EVP_KEYMGMT *EVP_KEYMGMT_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                const char *properties);
 int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt);
 void EVP_KEYMGMT_free(EVP_KEYMGMT *keymgmt);
@@ -1562,7 +1562,7 @@ const OSSL_PROVIDER *EVP_KEYMGMT_provider(const EVP_KEYMGMT *keymgmt);
 const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt);
 int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt);
 int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name);
-void EVP_KEYMGMT_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
                                  void *arg);
 void EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
@@ -1574,10 +1574,10 @@ const OSSL_PARAM *EVP_KEYMGMT_gen_settable_params(const EVP_KEYMGMT *keymgmt);
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
-EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OPENSSL_CTX *libctx,
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_name(OSSL_LIB_CTX *libctx,
                                          const char *name,
                                          const char *propquery);
-EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OPENSSL_CTX *libctx,
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OSSL_LIB_CTX *libctx,
                                          EVP_PKEY *pkey, const char *propquery);
 EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *ctx);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
@@ -1603,14 +1603,14 @@ void EVP_PKEY_CTX_set0_keygen_info(EVP_PKEY_CTX *ctx, int *dat, int datlen);
 
 EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *e,
                                const unsigned char *key, int keylen);
-EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OPENSSL_CTX *libctx,
+EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OSSL_LIB_CTX *libctx,
                                           const char *keytype,
                                           const char *propq,
                                           const unsigned char *priv, size_t len);
 EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *e,
                                        const unsigned char *priv,
                                        size_t len);
-EVP_PKEY *EVP_PKEY_new_raw_public_key_ex(OPENSSL_CTX *libctx,
+EVP_PKEY *EVP_PKEY_new_raw_public_key_ex(OSSL_LIB_CTX *libctx,
                                          const char *keytype, const char *propq,
                                          const unsigned char *pub, size_t len);
 EVP_PKEY *EVP_PKEY_new_raw_public_key(int type, ENGINE *e,
@@ -1622,7 +1622,7 @@ int EVP_PKEY_get_raw_public_key(const EVP_PKEY *pkey, unsigned char *pub,
                                 size_t *len);
 
 EVP_PKEY *EVP_PKEY_new_CMAC_key_ex(const unsigned char *priv, size_t len,
-                                   const char *cipher_name, OPENSSL_CTX *libctx,
+                                   const char *cipher_name, OSSL_LIB_CTX *libctx,
                                    const char *propq);
 EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
                                 size_t len, const EVP_CIPHER *cipher);
@@ -1639,11 +1639,11 @@ void *EVP_PKEY_CTX_get_app_data(EVP_PKEY_CTX *ctx);
 void EVP_SIGNATURE_free(EVP_SIGNATURE *signature);
 int EVP_SIGNATURE_up_ref(EVP_SIGNATURE *signature);
 OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature);
-EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                    const char *properties);
 int EVP_SIGNATURE_is_a(const EVP_SIGNATURE *signature, const char *name);
 int EVP_SIGNATURE_number(const EVP_SIGNATURE *signature);
-void EVP_SIGNATURE_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(EVP_SIGNATURE *signature,
                                               void *data),
                                    void *data);
@@ -1656,11 +1656,11 @@ const OSSL_PARAM *EVP_SIGNATURE_settable_ctx_params(const EVP_SIGNATURE *sig);
 void EVP_ASYM_CIPHER_free(EVP_ASYM_CIPHER *cipher);
 int EVP_ASYM_CIPHER_up_ref(EVP_ASYM_CIPHER *cipher);
 OSSL_PROVIDER *EVP_ASYM_CIPHER_provider(const EVP_ASYM_CIPHER *cipher);
-EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                        const char *properties);
 int EVP_ASYM_CIPHER_is_a(const EVP_ASYM_CIPHER *cipher, const char *name);
 int EVP_ASYM_CIPHER_number(const EVP_ASYM_CIPHER *cipher);
-void EVP_ASYM_CIPHER_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                      void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                 void *arg),
                                      void *arg);
@@ -1673,11 +1673,11 @@ const OSSL_PARAM *EVP_ASYM_CIPHER_settable_ctx_params(const EVP_ASYM_CIPHER *cip
 void EVP_KEM_free(EVP_KEM *wrap);
 int EVP_KEM_up_ref(EVP_KEM *wrap);
 OSSL_PROVIDER *EVP_KEM_provider(const EVP_KEM *wrap);
-EVP_KEM *EVP_KEM_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_KEM *EVP_KEM_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                        const char *properties);
 int EVP_KEM_is_a(const EVP_KEM *wrap, const char *name);
 int EVP_KEM_number(const EVP_KEM *wrap);
-void EVP_KEM_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KEM *wrap, void *arg), void *arg);
 void EVP_KEM_names_do_all(const EVP_KEM *wrap,
                           void (*fn)(const char *name, void *data), void *data);
@@ -1938,12 +1938,12 @@ DEPRECATEDIN_3_0(void EVP_PKEY_meth_get_digest_custom
 
 void EVP_KEYEXCH_free(EVP_KEYEXCH *exchange);
 int EVP_KEYEXCH_up_ref(EVP_KEYEXCH *exchange);
-EVP_KEYEXCH *EVP_KEYEXCH_fetch(OPENSSL_CTX *ctx, const char *algorithm,
+EVP_KEYEXCH *EVP_KEYEXCH_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                const char *properties);
 OSSL_PROVIDER *EVP_KEYEXCH_provider(const EVP_KEYEXCH *exchange);
 int EVP_KEYEXCH_is_a(const EVP_KEYEXCH *keyexch, const char *name);
 int EVP_KEYEXCH_number(const EVP_KEYEXCH *keyexch);
-void EVP_KEYEXCH_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYEXCH *keyexch, void *data),
                                  void *data);
 void EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,
@@ -1966,7 +1966,7 @@ int EVP_hex2ctrl(int (*cb)(void *ctx, int cmd, void *buf, size_t buflen),
 int EVP_PKEY_CTX_set_group_name(EVP_PKEY_CTX *ctx, const char *name);
 int EVP_PKEY_CTX_get_group_name(EVP_PKEY_CTX *ctx, char *name, size_t namelen);
 
-OPENSSL_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx);
+OSSL_LIB_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx);
 const char *EVP_PKEY_CTX_get0_propq(EVP_PKEY_CTX *ctx);
 
 # ifdef  __cplusplus

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -27,7 +27,7 @@ extern "C" {
 
 int EVP_KDF_up_ref(EVP_KDF *kdf);
 void EVP_KDF_free(EVP_KDF *kdf);
-EVP_KDF *EVP_KDF_fetch(OPENSSL_CTX *libctx, const char *algorithm,
+EVP_KDF *EVP_KDF_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                        const char *properties);
 
 EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf);
@@ -49,7 +49,7 @@ const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf);
 const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf);
 const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf);
 
-void EVP_KDF_do_all_provided(OPENSSL_CTX *libctx,
+void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KDF *kdf, void *arg),
                              void *arg);
 void EVP_KDF_names_do_all(const EVP_KDF *kdf,

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -290,9 +290,9 @@ int OCSP_basic_sign_ctx(OCSP_BASICRESP *brsp,
                         STACK_OF(X509) *certs, unsigned long flags);
 int OCSP_RESPID_set_by_name(OCSP_RESPID *respid, X509 *cert);
 int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
 int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert);
-int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OPENSSL_CTX *libctx,
+int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
                          const char *propq);
 int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert);
 

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -326,7 +326,7 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read_bio(BIO *bp, STACK_OF(X509_INFO) *sk,
                                             pem_password_cb *cb, void *u);
 STACK_OF(X509_INFO)
 *PEM_X509_INFO_read_bio_ex(BIO *bp, STACK_OF(X509_INFO) *sk,
-                           pem_password_cb *cb, void *u, OPENSSL_CTX *libctx,
+                           pem_password_cb *cb, void *u, OSSL_LIB_CTX *libctx,
                            const char *propq);
 
 int PEM_X509_INFO_write_bio(BIO *bp, const X509_INFO *xi, EVP_CIPHER *enc,
@@ -348,7 +348,7 @@ STACK_OF(X509_INFO) *PEM_X509_INFO_read(FILE *fp, STACK_OF(X509_INFO) *sk,
                                         pem_password_cb *cb, void *u);
 STACK_OF(X509_INFO)
 *PEM_X509_INFO_read_ex(FILE *fp, STACK_OF(X509_INFO) *sk, pem_password_cb *cb,
-                       void *u, OPENSSL_CTX *libctx, const char *propq);
+                       void *u, OSSL_LIB_CTX *libctx, const char *propq);
 #endif
 
 int PEM_SignInit(EVP_MD_CTX *ctx, EVP_MD *type);
@@ -395,20 +395,20 @@ DECLARE_PEM_write(DHxparams, DH)
 DECLARE_PEM_rw_cb(PrivateKey, EVP_PKEY)
 EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x,
                                      pem_password_cb *cb, void *u,
-                                     OPENSSL_CTX *libctx, const char *propq);
+                                     OSSL_LIB_CTX *libctx, const char *propq);
 # ifndef OPENSSL_NO_STDIO
 EVP_PKEY *PEM_read_PrivateKey_ex(FILE *fp, EVP_PKEY **x,
                                  pem_password_cb *cb, void *u,
-                                 OPENSSL_CTX *libctx, const char *propq);
+                                 OSSL_LIB_CTX *libctx, const char *propq);
 # endif
 DECLARE_PEM_rw(PUBKEY, EVP_PKEY)
 EVP_PKEY *PEM_read_bio_PUBKEY_ex(BIO *bp, EVP_PKEY **x,
                                  pem_password_cb *cb, void *u,
-                                 OPENSSL_CTX *libctx, const char *propq);
+                                 OSSL_LIB_CTX *libctx, const char *propq);
 # ifndef OPENSSL_NO_STDIO
 EVP_PKEY *PEM_read_PUBKEY_ex(FILE *fp, EVP_PKEY **x,
                              pem_password_cb *cb, void *u,
-                             OPENSSL_CTX *libctx, const char *propq);
+                             OSSL_LIB_CTX *libctx, const char *propq);
 # endif
 
 int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
@@ -451,7 +451,7 @@ int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc
                               pem_password_cb *cd, void *u);
 # endif
 EVP_PKEY *PEM_read_bio_Parameters_ex(BIO *bp, EVP_PKEY **x,
-                                     OPENSSL_CTX *libctx, const char *propq);
+                                     OSSL_LIB_CTX *libctx, const char *propq);
 EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x);
 int PEM_write_bio_Parameters(BIO *bp, const EVP_PKEY *x);
 

--- a/include/openssl/pkcs7.h.in
+++ b/include/openssl/pkcs7.h.in
@@ -43,7 +43,7 @@ Key_Encryption_ID       rsaEncryption
 */
 
 typedef struct PKCS7_CTX_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
 } PKCS7_CTX;
 
@@ -252,7 +252,7 @@ DECLARE_ASN1_FUNCTIONS(PKCS7_SIGN_ENVELOPE)
 DECLARE_ASN1_FUNCTIONS(PKCS7_DIGEST)
 DECLARE_ASN1_FUNCTIONS(PKCS7_ENCRYPT)
 DECLARE_ASN1_FUNCTIONS(PKCS7)
-PKCS7 *PKCS7_new_ex(OPENSSL_CTX *libctx, const char *propq);
+PKCS7 *PKCS7_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 
 DECLARE_ASN1_ITEM(PKCS7_ATTR_SIGN)
 DECLARE_ASN1_ITEM(PKCS7_ATTR_VERIFY)
@@ -314,7 +314,7 @@ int PKCS7_set_attributes(PKCS7_SIGNER_INFO *p7si,
 PKCS7 *PKCS7_sign(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
                   BIO *data, int flags);
 PKCS7 *PKCS7_sign_ex(X509 *signcert, EVP_PKEY *pkey, STACK_OF(X509) *certs,
-                     BIO *data, int flags, OPENSSL_CTX *libctx,
+                     BIO *data, int flags, OSSL_LIB_CTX *libctx,
                      const char *propq);
 
 PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *p7,
@@ -330,7 +330,7 @@ PKCS7 *PKCS7_encrypt(STACK_OF(X509) *certs, BIO *in, const EVP_CIPHER *cipher,
                      int flags);
 PKCS7 *PKCS7_encrypt_ex(STACK_OF(X509) *certs, BIO *in,
                         const EVP_CIPHER *cipher, int flags,
-                        OPENSSL_CTX *libctx, const char *propq);
+                        OSSL_LIB_CTX *libctx, const char *propq);
 int PKCS7_decrypt(PKCS7 *p7, EVP_PKEY *pkey, X509 *cert, BIO *data,
                   int flags);
 

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -17,14 +17,14 @@ extern "C" {
 # endif
 
 /* Set the default provider search path */
-int OSSL_PROVIDER_set_default_search_path(OPENSSL_CTX *, const char *path);
+int OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *, const char *path);
 
 /* Load and unload a provider */
-OSSL_PROVIDER *OSSL_PROVIDER_load(OPENSSL_CTX *, const char *name);
-OSSL_PROVIDER *OSSL_PROVIDER_try_load(OPENSSL_CTX *, const char *name);
+OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *, const char *name);
+OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *, const char *name);
 int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov);
-int OSSL_PROVIDER_available(OPENSSL_CTX *, const char *name);
-int OSSL_PROVIDER_do_all(OPENSSL_CTX *ctx,
+int OSSL_PROVIDER_available(OSSL_LIB_CTX *, const char *name);
+int OSSL_PROVIDER_do_all(OSSL_LIB_CTX *ctx,
                          int (*cb)(OSSL_PROVIDER *provider, void *cbdata),
                          void *cbdata);
 
@@ -42,7 +42,7 @@ const OSSL_ALGORITHM *OSSL_PROVIDER_query_operation(const OSSL_PROVIDER *prov,
 void *OSSL_PROVIDER_get0_provider_ctx(const OSSL_PROVIDER *prov);
 
 /* Add a built in providers */
-int OSSL_PROVIDER_add_builtin(OPENSSL_CTX *, const char *name,
+int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *, const char *name,
                               OSSL_provider_init_fn *init_fn);
 
 /* Information */

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -59,17 +59,17 @@ RAND_METHOD *RAND_OpenSSL(void);
 int RAND_bytes(unsigned char *buf, int num);
 int RAND_priv_bytes(unsigned char *buf, int num);
 
-/* Equivalent of RAND_priv_bytes() but additionally taking an OPENSSL_CTX */
-int RAND_priv_bytes_ex(OPENSSL_CTX *ctx, unsigned char *buf, int num);
+/* Equivalent of RAND_priv_bytes() but additionally taking an OSSL_LIB_CTX */
+int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
 
-/* Equivalent of RAND_bytes() but additionally taking an OPENSSL_CTX */
-int RAND_bytes_ex(OPENSSL_CTX *ctx, unsigned char *buf, int num);
+/* Equivalent of RAND_bytes() but additionally taking an OSSL_LIB_CTX */
+int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
 
 DEPRECATEDIN_1_1_0(int RAND_pseudo_bytes(unsigned char *buf, int num))
 
-EVP_RAND_CTX *RAND_get0_primary(OPENSSL_CTX *ctx);
-EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx);
-EVP_RAND_CTX *RAND_get0_private(OPENSSL_CTX *ctx);
+EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx);
+EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx);
+EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx);
 
 void RAND_seed(const void *buf, int num);
 void RAND_keep_random_devices_open(int keep);

--- a/include/openssl/self_test.h
+++ b/include/openssl/self_test.h
@@ -66,9 +66,9 @@ extern "C" {
 }
 # endif
 
-void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
+void OSSL_SELF_TEST_set_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK *cb,
                                  void *cbarg);
-void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK **cb,
+void OSSL_SELF_TEST_get_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK **cb,
                                  void **cbarg);
 
 OSSL_SELF_TEST *OSSL_SELF_TEST_new(OSSL_CALLBACK *cb, void *cbarg);

--- a/include/openssl/srp.h.in
+++ b/include/openssl/srp.h.in
@@ -104,12 +104,12 @@ SRP_user_pwd *SRP_VBASE_get1_by_user(SRP_VBASE *vb, char *username);
 
 char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
                              char **verifier, const char *N, const char *g,
-                             OPENSSL_CTX *libctx, const char *propq);
+                             OSSL_LIB_CTX *libctx, const char *propq);
 char *SRP_create_verifier(const char *user, const char *pass, char **salt,
                           char **verifier, const char *N, const char *g);
 int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
                               BIGNUM **verifier, const BIGNUM *N,
-                              const BIGNUM *g, OPENSSL_CTX *libctx,
+                              const BIGNUM *g, OSSL_LIB_CTX *libctx,
                               const char *propq);
 int SRP_create_verifier_BN(const char *user, const char *pass, BIGNUM **salt,
                            BIGNUM **verifier, const BIGNUM *N,
@@ -143,22 +143,22 @@ SRP_gN *SRP_get_default_gN(const char *id);
 BIGNUM *SRP_Calc_server_key(const BIGNUM *A, const BIGNUM *v, const BIGNUM *u,
                             const BIGNUM *b, const BIGNUM *N);
 BIGNUM *SRP_Calc_B_ex(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
-                      const BIGNUM *v, OPENSSL_CTX *libctx, const char *propq);
+                      const BIGNUM *v, OSSL_LIB_CTX *libctx, const char *propq);
 BIGNUM *SRP_Calc_B(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
                    const BIGNUM *v);
 int SRP_Verify_A_mod_N(const BIGNUM *A, const BIGNUM *N);
 BIGNUM *SRP_Calc_u_ex(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N,
-                      OPENSSL_CTX *libctx, const char *propq);
+                      OSSL_LIB_CTX *libctx, const char *propq);
 BIGNUM *SRP_Calc_u(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N);
 
 /* client side .... */
 BIGNUM *SRP_Calc_x_ex(const BIGNUM *s, const char *user, const char *pass,
-                      OPENSSL_CTX *libctx, const char *propq);
+                      OSSL_LIB_CTX *libctx, const char *propq);
 BIGNUM *SRP_Calc_x(const BIGNUM *s, const char *user, const char *pass);
 BIGNUM *SRP_Calc_A(const BIGNUM *a, const BIGNUM *N, const BIGNUM *g);
 BIGNUM *SRP_Calc_client_key_ex(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                             const BIGNUM *x, const BIGNUM *a, const BIGNUM *u,
-                            OPENSSL_CTX *libctx, const char *propq);
+                            OSSL_LIB_CTX *libctx, const char *propq);
 BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                             const BIGNUM *x, const BIGNUM *a, const BIGNUM *u);
 int SRP_Verify_B_mod_N(const BIGNUM *B, const BIGNUM *N);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1538,7 +1538,7 @@ void BIO_ssl_shutdown(BIO *ssl_bio);
 
 __owur int SSL_CTX_set_cipher_list(SSL_CTX *, const char *str);
 __owur SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);
-__owur SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
+__owur SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
                                const SSL_METHOD *meth);
 int SSL_CTX_up_ref(SSL_CTX *ctx);
 void SSL_CTX_free(SSL_CTX *);
@@ -1640,7 +1640,7 @@ __owur int SSL_CTX_use_certificate_chain_file(SSL_CTX *ctx, const char *file);
 __owur int SSL_use_certificate_chain_file(SSL *ssl, const char *file);
 __owur STACK_OF(X509_NAME) *SSL_load_client_CA_file(const char *file);
 __owur STACK_OF(X509_NAME)
-*SSL_load_client_CA_file_ex(const char *file, OPENSSL_CTX *libctx,
+*SSL_load_client_CA_file_ex(const char *file, OSSL_LIB_CTX *libctx,
                             const char *propq);
 __owur int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stackCAs,
                                                const char *file);

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -57,7 +57,7 @@ OSSL_STORE_open(const char *uri, const UI_METHOD *ui_method, void *ui_data,
                 OSSL_STORE_post_process_info_fn post_process,
                 void *post_process_data);
 OSSL_STORE_CTX *
-OSSL_STORE_open_ex(const char *uri, OPENSSL_CTX *libctx, const char *propq,
+OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
                    const UI_METHOD *ui_method, void *ui_data,
                    OSSL_STORE_post_process_info_fn post_process,
                    void *post_process_data);
@@ -127,7 +127,7 @@ int OSSL_STORE_close(OSSL_STORE_CTX *ctx);
  * BIO actually reads.
  */
 OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bio, const char *scheme,
-                                  OPENSSL_CTX *libctx, const char *propq,
+                                  OSSL_LIB_CTX *libctx, const char *propq,
                                   const UI_METHOD *ui_method, void *ui_data,
                                   OSSL_STORE_post_process_info_fn post_process,
                                   void *post_process_data);
@@ -250,7 +250,7 @@ int OSSL_STORE_find(OSSL_STORE_CTX *ctx, const OSSL_STORE_SEARCH *search);
 typedef struct ossl_store_loader_st OSSL_STORE_LOADER;
 
 OSSL_STORE_LOADER *OSSL_STORE_LOADER_fetch(const char *scheme,
-                                           OPENSSL_CTX *libctx,
+                                           OSSL_LIB_CTX *libctx,
                                            const char *properties);
 int OSSL_STORE_LOADER_up_ref(OSSL_STORE_LOADER *loader);
 void OSSL_STORE_LOADER_free(OSSL_STORE_LOADER *loader);
@@ -260,7 +260,7 @@ const char *OSSL_STORE_LOADER_properties(const OSSL_STORE_LOADER *loader);
 int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader);
 int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader,
                            const char *scheme);
-void OSSL_STORE_LOADER_do_all_provided(OPENSSL_CTX *libctx,
+void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
                                        void (*fn)(OSSL_STORE_LOADER *loader,
                                                   void *arg),
                                        void *arg);
@@ -285,12 +285,12 @@ typedef OSSL_STORE_LOADER_CTX *(*OSSL_STORE_open_fn)
      const UI_METHOD *ui_method, void *ui_data);
 typedef OSSL_STORE_LOADER_CTX *(*OSSL_STORE_open_ex_fn)
     (const OSSL_STORE_LOADER *loader,
-     const char *uri, OPENSSL_CTX *libctx, const char *propq,
+     const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
      const UI_METHOD *ui_method, void *ui_data);
 
 typedef OSSL_STORE_LOADER_CTX *(*OSSL_STORE_attach_fn)
     (const OSSL_STORE_LOADER *loader, BIO *bio,
-     OPENSSL_CTX *libctx, const char *propq,
+     OSSL_LIB_CTX *libctx, const char *propq,
      const UI_METHOD *ui_method, void *ui_data);
 typedef int (*OSSL_STORE_ctrl_fn)
     (OSSL_STORE_LOADER_CTX *ctx, int cmd, va_list args);

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -204,7 +204,7 @@ typedef struct ct_policy_eval_ctx_st CT_POLICY_EVAL_CTX;
 typedef struct ossl_store_info_st OSSL_STORE_INFO;
 typedef struct ossl_store_search_st OSSL_STORE_SEARCH;
 
-typedef struct openssl_ctx_st OPENSSL_CTX;
+typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
 
 typedef struct ossl_dispatch_st OSSL_DISPATCH;
 typedef struct ossl_item_st OSSL_ITEM;

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -365,7 +365,7 @@ const char *X509_verify_cert_error_string(long n);
 int X509_verify(X509 *a, EVP_PKEY *r);
 int X509_self_signed(X509 *cert, int verify_signature);
 
-int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OPENSSL_CTX *libctx,
+int X509_REQ_verify_ex(X509_REQ *a, EVP_PKEY *r, OSSL_LIB_CTX *libctx,
                        const char *propq);
 int X509_REQ_verify(X509_REQ *a, EVP_PKEY *r);
 int X509_CRL_verify(X509_CRL *a, EVP_PKEY *r);
@@ -443,7 +443,7 @@ PKCS8_PRIV_KEY_INFO *d2i_PKCS8_PRIV_KEY_INFO_fp(FILE *fp,
 int i2d_PKCS8_PRIV_KEY_INFO_fp(FILE *fp, const PKCS8_PRIV_KEY_INFO *p8inf);
 int i2d_PKCS8PrivateKeyInfo_fp(FILE *fp, const EVP_PKEY *key);
 int i2d_PrivateKey_fp(FILE *fp, const EVP_PKEY *pkey);
-EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OPENSSL_CTX *libctx,
+EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                const char *propq);
 EVP_PKEY *d2i_PrivateKey_fp(FILE *fp, EVP_PKEY **a);
 int i2d_PUBKEY_fp(FILE *fp, const EVP_PKEY *pkey);
@@ -485,7 +485,7 @@ PKCS8_PRIV_KEY_INFO *d2i_PKCS8_PRIV_KEY_INFO_bio(BIO *bp,
 int i2d_PKCS8_PRIV_KEY_INFO_bio(BIO *bp, const PKCS8_PRIV_KEY_INFO *p8inf);
 int i2d_PKCS8PrivateKeyInfo_bio(BIO *bp, const EVP_PKEY *key);
 int i2d_PrivateKey_bio(BIO *bp, const EVP_PKEY *pkey);
-EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OPENSSL_CTX *libctx,
+EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                 const char *propq);
 EVP_PKEY *d2i_PrivateKey_bio(BIO *bp, EVP_PKEY **a);
 int i2d_PUBKEY_bio(BIO *bp, const EVP_PKEY *pkey);
@@ -542,7 +542,7 @@ int X509_get_pubkey_parameters(EVP_PKEY *pkey, STACK_OF(X509) *chain);
 long X509_get_pathlen(X509 *x);
 DECLARE_ASN1_ENCODE_FUNCTIONS_only(EVP_PKEY, PUBKEY)
 EVP_PKEY *d2i_PUBKEY_ex(EVP_PKEY **a, const unsigned char **pp, long length,
-                        OPENSSL_CTX *libctx, const char *propq);
+                        OSSL_LIB_CTX *libctx, const char *propq);
 # ifndef OPENSSL_NO_RSA
 DECLARE_ASN1_ENCODE_FUNCTIONS_only(RSA, RSA_PUBKEY)
 # endif
@@ -576,7 +576,7 @@ int X509_NAME_set(X509_NAME **xn, const X509_NAME *name);
 
 DECLARE_ASN1_FUNCTIONS(X509_CINF)
 DECLARE_ASN1_FUNCTIONS(X509)
-X509 *X509_new_ex(OPENSSL_CTX *libctx, const char *propq);
+X509 *X509_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 DECLARE_ASN1_FUNCTIONS(X509_CERT_AUX)
 
 #define X509_get_ex_new_index(l, p, newf, dupf, freef) \
@@ -1054,7 +1054,7 @@ X509_ALGOR *PKCS5_pbkdf2_set(int iter, unsigned char *salt, int saltlen,
 DECLARE_ASN1_FUNCTIONS(PKCS8_PRIV_KEY_INFO)
 
 EVP_PKEY *EVP_PKCS82PKEY(const PKCS8_PRIV_KEY_INFO *p8);
-EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OPENSSL_CTX *libctx,
+EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
                             const char *propq);
 PKCS8_PRIV_KEY_INFO *EVP_PKEY2PKCS8(const EVP_PKEY *pkey);
 

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -389,7 +389,7 @@ X509_STORE_CTX_cleanup_fn X509_STORE_get_cleanup(const X509_STORE *ctx);
 int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data);
 void *X509_STORE_get_ex_data(const X509_STORE *ctx, int idx);
 
-X509_STORE_CTX *X509_STORE_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq);
+X509_STORE_CTX *X509_STORE_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 X509_STORE_CTX *X509_STORE_CTX_new(void);
 
 int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x);
@@ -441,7 +441,7 @@ typedef int (*X509_LOOKUP_ctrl_fn)(X509_LOOKUP *ctx, int cmd, const char *argc,
                                    long argl, char **ret);
 typedef int (*X509_LOOKUP_ctrl_ex_fn)(
     X509_LOOKUP *ctx, int cmd, const char *argc, long argl, char **ret,
-    OPENSSL_CTX *libctx, const char *propq);
+    OSSL_LIB_CTX *libctx, const char *propq);
 
 typedef int (*X509_LOOKUP_get_by_subject_fn)(X509_LOOKUP *ctx,
                                              X509_LOOKUP_TYPE type,
@@ -451,7 +451,7 @@ typedef int (*X509_LOOKUP_get_by_subject_ex_fn)(X509_LOOKUP *ctx,
                                                          X509_LOOKUP_TYPE type,
                                                          const X509_NAME *name,
                                                          X509_OBJECT *ret,
-                                                         OPENSSL_CTX *libctx,
+                                                         OSSL_LIB_CTX *libctx,
                                                          const char *propq);
 typedef int (*X509_LOOKUP_get_by_issuer_serial_fn)(X509_LOOKUP *ctx,
                                                    X509_LOOKUP_TYPE type,
@@ -530,15 +530,15 @@ X509_OBJECT *X509_STORE_CTX_get_obj_by_subject(X509_STORE_CTX *vs,
 int X509_LOOKUP_ctrl(X509_LOOKUP *ctx, int cmd, const char *argc,
                      long argl, char **ret);
 int X509_LOOKUP_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argc, long argl,
-                        char **ret, OPENSSL_CTX *libctx, const char *propq);
+                        char **ret, OSSL_LIB_CTX *libctx, const char *propq);
 
 int X509_load_cert_file(X509_LOOKUP *ctx, const char *file, int type);
 int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
-                           OPENSSL_CTX *libctx, const char *propq);
+                           OSSL_LIB_CTX *libctx, const char *propq);
 int X509_load_crl_file(X509_LOOKUP *ctx, const char *file, int type);
 int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type);
 int X509_load_cert_crl_file_ex(X509_LOOKUP *ctx, const char *file, int type,
-                               OPENSSL_CTX *libctx, const char *propq);
+                               OSSL_LIB_CTX *libctx, const char *propq);
 
 X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method);
 void X509_LOOKUP_free(X509_LOOKUP *ctx);
@@ -547,7 +547,7 @@ int X509_LOOKUP_by_subject(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                            const X509_NAME *name, X509_OBJECT *ret);
 int X509_LOOKUP_by_subject_ex(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                               const X509_NAME *name, X509_OBJECT *ret,
-                              OPENSSL_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx, const char *propq);
 int X509_LOOKUP_by_issuer_serial(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
                                  const X509_NAME *name,
                                  const ASN1_INTEGER *serial,
@@ -571,13 +571,13 @@ int X509_STORE_load_locations(X509_STORE *ctx,
 int X509_STORE_set_default_paths(X509_STORE *ctx);
 
 int X509_STORE_load_file_ex(X509_STORE *ctx, const char *file,
-                            OPENSSL_CTX *libctx, const char *propq);
+                            OSSL_LIB_CTX *libctx, const char *propq);
 int X509_STORE_load_store_ex(X509_STORE *ctx, const char *store,
-                             OPENSSL_CTX *libctx, const char *propq);
+                             OSSL_LIB_CTX *libctx, const char *propq);
 int X509_STORE_load_locations_ex(X509_STORE *ctx, const char *file,
-                                 const char *dir, OPENSSL_CTX *libctx,
+                                 const char *dir, OSSL_LIB_CTX *libctx,
                                  const char *propq);
-int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OPENSSL_CTX *libctx,
+int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OSSL_LIB_CTX *libctx,
                                     const char *propq);
 
 #define X509_STORE_CTX_get_ex_new_index(l, p, newf, dupf, freef) \

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -136,7 +136,7 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
                             const OSSL_DISPATCH *in, const OSSL_DISPATCH **out,
                             void **provctx)
 {
-    OSSL_FUNC_core_get_library_context_fn *c_get_libctx = NULL;
+    OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
     BIO_METHOD *corebiometh;
 
     if (!ossl_prov_bio_from_dispatch(in))
@@ -149,8 +149,8 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;
-        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
-            c_get_libctx = OSSL_FUNC_core_get_library_context(in);
+        case OSSL_FUNC_CORE_GET_LIBCTX:
+            c_get_libctx = OSSL_FUNC_core_get_libctx(in);
             break;
         default:
             /* Just ignore anything we don't understand */
@@ -175,7 +175,7 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
         *provctx = NULL;
         return 0;
     }
-    ossl_prov_ctx_set0_library_context(*provctx,
+    ossl_prov_ctx_set0_libctx(*provctx,
                                        (OSSL_LIB_CTX *)c_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
     ossl_prov_ctx_set0_core_bio_method(*provctx, corebiometh);

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -176,7 +176,7 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
         return 0;
     }
     ossl_prov_ctx_set0_library_context(*provctx,
-                                       (OPENSSL_CTX *)c_get_libctx(handle));
+                                       (OSSL_LIB_CTX *)c_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
     ossl_prov_ctx_set0_core_bio_method(*provctx, corebiometh);
 

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -25,15 +25,15 @@ typedef struct prov_ctx_st {
  * To be used anywhere the library context needs to be passed, such as to
  * fetching functions.
  */
-# define PROV_LIBRARY_CONTEXT_OF(provctx)        \
-    ossl_prov_ctx_get0_library_context((provctx))
+# define PROV_LIBCTX_OF(provctx)        \
+    ossl_prov_ctx_get0_libctx((provctx))
 
 PROV_CTX *ossl_prov_ctx_new(void);
 void ossl_prov_ctx_free(PROV_CTX *ctx);
-void ossl_prov_ctx_set0_library_context(PROV_CTX *ctx, OSSL_LIB_CTX *libctx);
+void ossl_prov_ctx_set0_libctx(PROV_CTX *ctx, OSSL_LIB_CTX *libctx);
 void ossl_prov_ctx_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle);
 void ossl_prov_ctx_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh);
-OSSL_LIB_CTX *ossl_prov_ctx_get0_library_context(PROV_CTX *ctx);
+OSSL_LIB_CTX *ossl_prov_ctx_get0_libctx(PROV_CTX *ctx);
 const OSSL_CORE_HANDLE *ossl_prov_ctx_get0_handle(PROV_CTX *ctx);
 BIO_METHOD *ossl_prov_ctx_get0_core_bio_method(PROV_CTX *ctx);
 

--- a/providers/common/include/prov/provider_ctx.h
+++ b/providers/common/include/prov/provider_ctx.h
@@ -17,7 +17,7 @@
 
 typedef struct prov_ctx_st {
     const OSSL_CORE_HANDLE *handle;
-    OPENSSL_CTX *libctx;         /* For all provider modules */
+    OSSL_LIB_CTX *libctx;         /* For all provider modules */
     BIO_METHOD *corebiometh;
 } PROV_CTX;
 
@@ -30,10 +30,10 @@ typedef struct prov_ctx_st {
 
 PROV_CTX *ossl_prov_ctx_new(void);
 void ossl_prov_ctx_free(PROV_CTX *ctx);
-void ossl_prov_ctx_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx);
+void ossl_prov_ctx_set0_library_context(PROV_CTX *ctx, OSSL_LIB_CTX *libctx);
 void ossl_prov_ctx_set0_handle(PROV_CTX *ctx, const OSSL_CORE_HANDLE *handle);
 void ossl_prov_ctx_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh);
-OPENSSL_CTX *ossl_prov_ctx_get0_library_context(PROV_CTX *ctx);
+OSSL_LIB_CTX *ossl_prov_ctx_get0_library_context(PROV_CTX *ctx);
 const OSSL_CORE_HANDLE *ossl_prov_ctx_get0_handle(PROV_CTX *ctx);
 BIO_METHOD *ossl_prov_ctx_get0_core_bio_method(PROV_CTX *ctx);
 

--- a/providers/common/include/prov/provider_util.h
+++ b/providers/common/include/prov/provider_util.h
@@ -45,7 +45,7 @@ typedef struct {
  */
 int ossl_prov_cipher_load_from_params(PROV_CIPHER *pc,
                                       const OSSL_PARAM params[],
-                                      OPENSSL_CTX *ctx);
+                                      OSSL_LIB_CTX *ctx);
 
 /* Reset the PROV_CIPHER fields and free any allocated cipher reference */
 void ossl_prov_cipher_reset(PROV_CIPHER *pc);
@@ -63,7 +63,7 @@ ENGINE *ossl_prov_cipher_engine(const PROV_CIPHER *pc);
  * Fetch a digest from the specified libctx using the provided mdname and
  * propquery. Store the result in the PROV_DIGEST and return the fetched md.
  */
-const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OPENSSL_CTX *libctx,
+const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OSSL_LIB_CTX *libctx,
                                      const char *mdname, const char *propquery);
 
 /*
@@ -74,7 +74,7 @@ const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OPENSSL_CTX *libctx,
  */
 int ossl_prov_digest_load_from_params(PROV_DIGEST *pd,
                                       const OSSL_PARAM params[],
-                                      OPENSSL_CTX *ctx);
+                                      OSSL_LIB_CTX *ctx);
 
 /* Reset the PROV_DIGEST fields and free any allocated digest reference */
 void ossl_prov_digest_reset(PROV_DIGEST *pd);
@@ -123,7 +123,7 @@ int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
                                       const char *macname,
                                       const char *ciphername,
                                       const char *mdname,
-                                      OPENSSL_CTX *ctx);
+                                      OSSL_LIB_CTX *ctx);
 
 typedef struct ag_capable_st {
     OSSL_ALGORITHM alg;

--- a/providers/common/include/prov/providercommon.h
+++ b/providers/common/include/prov/providercommon.h
@@ -10,7 +10,7 @@
 #include <openssl/provider.h>
 #include <openssl/core_dispatch.h>
 
-const OSSL_CORE_HANDLE *FIPS_get_core_handle(OPENSSL_CTX *ctx);
+const OSSL_CORE_HANDLE *FIPS_get_core_handle(OSSL_LIB_CTX *ctx);
 
 const char *ossl_prov_util_nid_to_name(int nid);
 

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -21,7 +21,7 @@ void ossl_prov_ctx_free(PROV_CTX *ctx)
     OPENSSL_free(ctx);
 }
 
-void ossl_prov_ctx_set0_library_context(PROV_CTX *ctx, OSSL_LIB_CTX *libctx)
+void ossl_prov_ctx_set0_libctx(PROV_CTX *ctx, OSSL_LIB_CTX *libctx)
 {
     if (ctx != NULL)
         ctx->libctx = libctx;
@@ -39,7 +39,7 @@ void ossl_prov_ctx_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh)
         ctx->corebiometh = corebiometh;
 }
 
-OSSL_LIB_CTX *ossl_prov_ctx_get0_library_context(PROV_CTX *ctx)
+OSSL_LIB_CTX *ossl_prov_ctx_get0_libctx(PROV_CTX *ctx)
 {
     if (ctx == NULL)
         return NULL;

--- a/providers/common/provider_ctx.c
+++ b/providers/common/provider_ctx.c
@@ -21,7 +21,7 @@ void ossl_prov_ctx_free(PROV_CTX *ctx)
     OPENSSL_free(ctx);
 }
 
-void ossl_prov_ctx_set0_library_context(PROV_CTX *ctx, OPENSSL_CTX *libctx)
+void ossl_prov_ctx_set0_library_context(PROV_CTX *ctx, OSSL_LIB_CTX *libctx)
 {
     if (ctx != NULL)
         ctx->libctx = libctx;
@@ -39,7 +39,7 @@ void ossl_prov_ctx_set0_core_bio_method(PROV_CTX *ctx, BIO_METHOD *corebiometh)
         ctx->corebiometh = corebiometh;
 }
 
-OPENSSL_CTX *ossl_prov_ctx_get0_library_context(PROV_CTX *ctx)
+OSSL_LIB_CTX *ossl_prov_ctx_get0_library_context(PROV_CTX *ctx)
 {
     if (ctx == NULL)
         return NULL;

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -67,7 +67,7 @@ static int load_common(const OSSL_PARAM params[], const char **propquery,
 
 int ossl_prov_cipher_load_from_params(PROV_CIPHER *pc,
                                       const OSSL_PARAM params[],
-                                      OPENSSL_CTX *ctx)
+                                      OSSL_LIB_CTX *ctx)
 {
     const OSSL_PARAM *p;
     const char *propquery;
@@ -124,7 +124,7 @@ int ossl_prov_digest_copy(PROV_DIGEST *dst, const PROV_DIGEST *src)
     return 1;
 }
 
-const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OPENSSL_CTX *libctx,
+const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OSSL_LIB_CTX *libctx,
                            const char *mdname, const char *propquery)
 {
     EVP_MD_free(pd->alloc_md);
@@ -135,7 +135,7 @@ const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OPENSSL_CTX *libctx,
 
 int ossl_prov_digest_load_from_params(PROV_DIGEST *pd,
                                       const OSSL_PARAM params[],
-                                      OPENSSL_CTX *ctx)
+                                      OSSL_LIB_CTX *ctx)
 {
     const OSSL_PARAM *p;
     const char *propquery;
@@ -245,7 +245,7 @@ int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
                                       const char *macname,
                                       const char *ciphername,
                                       const char *mdname,
-                                      OPENSSL_CTX *libctx)
+                                      OSSL_LIB_CTX *libctx)
 {
     const OSSL_PARAM *p;
     const char *properties = NULL;

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -563,7 +563,7 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
         return 0;
     }
     ossl_prov_ctx_set0_library_context(*provctx,
-                                       (OPENSSL_CTX *)c_get_libctx(handle));
+                                       (OSSL_LIB_CTX *)c_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
     ossl_prov_ctx_set0_core_bio_method(*provctx, corebiometh);
 

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -523,7 +523,7 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
                                const OSSL_DISPATCH **out,
                                void **provctx)
 {
-    OSSL_FUNC_core_get_library_context_fn *c_get_libctx = NULL;
+    OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
     BIO_METHOD *corebiometh;
 
     if (!ossl_prov_bio_from_dispatch(in))
@@ -536,8 +536,8 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;
-        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
-            c_get_libctx = OSSL_FUNC_core_get_library_context(in);
+        case OSSL_FUNC_CORE_GET_LIBCTX:
+            c_get_libctx = OSSL_FUNC_core_get_libctx(in);
             break;
         default:
             /* Just ignore anything we don't understand */
@@ -562,7 +562,7 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
         *provctx = NULL;
         return 0;
     }
-    ossl_prov_ctx_set0_library_context(*provctx,
+    ossl_prov_ctx_set0_libctx(*provctx,
                                        (OSSL_LIB_CTX *)c_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
     ossl_prov_ctx_set0_core_bio_method(*provctx, corebiometh);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -705,7 +705,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
     ossl_prov_ctx_set0_handle(*provctx, handle);
 
     if ((fgbl = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_FIPS_PROV_INDEX,
-                                     &fips_prov_ossl_ctx_method)) == NULL)
+                                      &fips_prov_ossl_ctx_method)) == NULL)
         goto err;
 
     fgbl->handle = handle;
@@ -821,8 +821,8 @@ int ERR_pop_to_mark(void)
 const OSSL_CORE_HANDLE *FIPS_get_core_handle(OSSL_LIB_CTX *libctx)
 {
     FIPS_GLOBAL *fgbl = ossl_lib_ctx_get_data(libctx,
-                                             OSSL_LIB_CTX_FIPS_PROV_INDEX,
-                                             &fips_prov_ossl_ctx_method);
+                                              OSSL_LIB_CTX_FIPS_PROV_INDEX,
+                                              &fips_prov_ossl_ctx_method);
 
     if (fgbl == NULL)
         return NULL;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -73,7 +73,7 @@ static OSSL_FUNC_CRYPTO_secure_clear_free_fn *c_CRYPTO_secure_clear_free;
 static OSSL_FUNC_CRYPTO_secure_allocated_fn *c_CRYPTO_secure_allocated;
 static OSSL_FUNC_BIO_vsnprintf_fn *c_BIO_vsnprintf;
 static OSSL_FUNC_self_test_cb_fn *c_stcbfn = NULL;
-static OSSL_FUNC_core_get_library_context_fn *c_get_libctx = NULL;
+static OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
 
 typedef struct fips_global_st {
     const OSSL_CORE_HANDLE *handle;
@@ -544,7 +544,7 @@ static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
 
 static void fips_teardown(void *provctx)
 {
-    OSSL_LIB_CTX_free(PROV_LIBRARY_CONTEXT_OF(provctx));
+    OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
     ossl_prov_ctx_free(provctx);
 }
 
@@ -586,8 +586,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
-            c_get_libctx = OSSL_FUNC_core_get_library_context(in);
+        case OSSL_FUNC_CORE_GET_LIBCTX:
+            c_get_libctx = OSSL_FUNC_core_get_libctx(in);
             break;
         case OSSL_FUNC_CORE_GETTABLE_PARAMS:
             c_gettable_params = OSSL_FUNC_core_gettable_params(in);
@@ -701,7 +701,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         OSSL_LIB_CTX_free(libctx);
         goto err;
     }
-    ossl_prov_ctx_set0_library_context(*provctx, libctx);
+    ossl_prov_ctx_set0_libctx(*provctx, libctx);
     ossl_prov_ctx_set0_handle(*provctx, handle);
 
     if ((fgbl = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_FIPS_PROV_INDEX,
@@ -740,12 +740,12 @@ int fips_intern_provider_init(const OSSL_CORE_HANDLE *handle,
                               const OSSL_DISPATCH **out,
                               void **provctx)
 {
-    OSSL_FUNC_core_get_library_context_fn *c_internal_get_libctx = NULL;
+    OSSL_FUNC_core_get_libctx_fn *c_internal_get_libctx = NULL;
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
-        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
-            c_internal_get_libctx = OSSL_FUNC_core_get_library_context(in);
+        case OSSL_FUNC_CORE_GET_LIBCTX:
+            c_internal_get_libctx = OSSL_FUNC_core_get_libctx(in);
             break;
         default:
             break;
@@ -763,7 +763,7 @@ int fips_intern_provider_init(const OSSL_CORE_HANDLE *handle,
      * internal provider. This is not something that most providers would be
      * able to do.
      */
-    ossl_prov_ctx_set0_library_context(
+    ossl_prov_ctx_set0_libctx(
         *provctx, (OSSL_LIB_CTX *)c_internal_get_libctx(handle)
     );
     ossl_prov_ctx_set0_handle(*provctx, handle);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -763,9 +763,8 @@ int fips_intern_provider_init(const OSSL_CORE_HANDLE *handle,
      * internal provider. This is not something that most providers would be
      * able to do.
      */
-    ossl_prov_ctx_set0_libctx(
-        *provctx, (OSSL_LIB_CTX *)c_internal_get_libctx(handle)
-    );
+    ossl_prov_ctx_set0_libctx(*provctx,
+                              (OSSL_LIB_CTX *)c_internal_get_libctx(handle));
     ossl_prov_ctx_set0_handle(*provctx, handle);
 
     *out = intern_dispatch_table;

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -20,8 +20,8 @@
 /*
  * We're cheating here. Normally we don't allow RUN_ONCE usage inside the FIPS
  * module because all such initialisation should be associated with an
- * individual OPENSSL_CTX. That doesn't work with the self test though because
- * it should be run once regardless of the number of OPENSSL_CTXs we have.
+ * individual OSSL_LIB_CTX. That doesn't work with the self test though because
+ * it should be run once regardless of the number of OSSL_LIB_CTXs we have.
  */
 #define ALLOW_RUN_ONCE_IN_FIPS
 #include <internal/thread_once.h>
@@ -160,7 +160,7 @@ DEP_FINI_ATTRIBUTE void cleanup(void)
  */
 static int verify_integrity(OSSL_CORE_BIO *bio, OSSL_FUNC_BIO_read_ex_fn read_ex_cb,
                             unsigned char *expected, size_t expected_len,
-                            OPENSSL_CTX *libctx, OSSL_SELF_TEST *ev,
+                            OSSL_LIB_CTX *libctx, OSSL_SELF_TEST *ev,
                             const char *event_type)
 {
     int ret = 0, status;

--- a/providers/fips/self_test.h
+++ b/providers/fips/self_test.h
@@ -31,11 +31,11 @@ typedef struct self_test_post_params_st {
     OSSL_FUNC_BIO_free_fn *bio_free_cb;
     OSSL_CALLBACK *cb;
     void *cb_arg;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
 } SELF_TEST_POST_PARAMS;
 
 int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test);
-int SELF_TEST_kats(OSSL_SELF_TEST *event, OPENSSL_CTX *libctx);
+int SELF_TEST_kats(OSSL_SELF_TEST *event, OSSL_LIB_CTX *libctx);
 
 void SELF_TEST_disable_conditional_error_state(void);

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -18,7 +18,7 @@
 #include "self_test_data.inc"
 
 static int self_test_digest(const ST_KAT_DIGEST *t, OSSL_SELF_TEST *st,
-                            OPENSSL_CTX *libctx)
+                            OSSL_LIB_CTX *libctx)
 {
     int ok = 0;
     unsigned char out[EVP_MAX_MD_SIZE];
@@ -83,7 +83,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
 
 /* Test a single KAT for encrypt/decrypt */
 static int self_test_cipher(const ST_KAT_CIPHER *t, OSSL_SELF_TEST *st,
-                            OPENSSL_CTX *libctx)
+                            OSSL_LIB_CTX *libctx)
 {
     int ret = 0, encrypt = 1, len, ct_len = 0, pt_len = 0;
     EVP_CIPHER_CTX *ctx = NULL;
@@ -179,7 +179,7 @@ err:
 }
 
 static int self_test_kdf(const ST_KAT_KDF *t, OSSL_SELF_TEST *st,
-                         OPENSSL_CTX *libctx)
+                         OSSL_LIB_CTX *libctx)
 {
     int ret = 0;
     unsigned char out[64];
@@ -236,7 +236,7 @@ err:
 }
 
 static int self_test_drbg(const ST_KAT_DRBG *t, OSSL_SELF_TEST *st,
-                          OPENSSL_CTX *libctx)
+                          OSSL_LIB_CTX *libctx)
 {
     int ret = 0;
     unsigned char out[256];
@@ -347,7 +347,7 @@ err:
 }
 
 static int self_test_ka(const ST_KAT_KAS *t,
-                        OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+                        OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int ret = 0;
     EVP_PKEY_CTX *kactx = NULL, *dctx = NULL;
@@ -423,7 +423,7 @@ err:
 }
 
 static int self_test_sign(const ST_KAT_SIGN *t,
-                         OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+                         OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int ret = 0;
     OSSL_PARAM *params = NULL, *params_sig = NULL;
@@ -513,7 +513,7 @@ err:
  * and decrypt..
  */
 static int self_test_asym_cipher(const ST_KAT_ASYM_CIPHER *t, OSSL_SELF_TEST *st,
-                                 OPENSSL_CTX *libctx)
+                                 OSSL_LIB_CTX *libctx)
 {
     int ret = 0;
     OSSL_PARAM *keyparams = NULL, *initparams = NULL;
@@ -598,7 +598,7 @@ err:
  * All tests are run regardless of if they fail or not.
  * Return 0 if any test fails.
  */
-static int self_test_digests(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_digests(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -609,7 +609,7 @@ static int self_test_digests(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
     return ret;
 }
 
-static int self_test_ciphers(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_ciphers(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -620,7 +620,7 @@ static int self_test_ciphers(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
     return ret;
 }
 
-static int self_test_asym_ciphers(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_asym_ciphers(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -631,7 +631,7 @@ static int self_test_asym_ciphers(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
     return ret;
 }
 
-static int self_test_kdfs(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_kdfs(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -642,7 +642,7 @@ static int self_test_kdfs(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
     return ret;
 }
 
-static int self_test_drbgs(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_drbgs(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -653,7 +653,7 @@ static int self_test_drbgs(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
     return ret;
 }
 
-static int self_test_kas(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_kas(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -664,7 +664,7 @@ static int self_test_kas(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
     return ret;
 }
 
-static int self_test_signatures(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+static int self_test_signatures(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int i, ret = 1;
 
@@ -680,7 +680,7 @@ static int self_test_signatures(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
  * Return 1 is successful, otherwise return 0.
  * This runs all the tests regardless of if any fail.
  */
-int SELF_TEST_kats(OSSL_SELF_TEST *st, OPENSSL_CTX *libctx)
+int SELF_TEST_kats(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
     int ret = 1;
 

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -62,7 +62,7 @@ static OSSL_ITEM padding_item[] = {
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     RSA *rsa;
     int pad_mode;
     int operation;

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -87,7 +87,7 @@ static void *rsa_newctx(void *provctx)
     prsactx = OPENSSL_zalloc(sizeof(PROV_RSA_CTX));
     if (prsactx == NULL)
         return NULL;
-    prsactx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    prsactx->libctx = PROV_LIBCTX_OF(provctx);
 
     return prsactx;
 }

--- a/providers/implementations/asymciphers/sm2_enc.c
+++ b/providers/implementations/asymciphers/sm2_enc.c
@@ -38,7 +38,7 @@ static OSSL_FUNC_asym_cipher_settable_ctx_params_fn sm2_settable_ctx_params;
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     EC_KEY *key;
     PROV_DIGEST md;
 } PROV_SM2_CTX;

--- a/providers/implementations/asymciphers/sm2_enc.c
+++ b/providers/implementations/asymciphers/sm2_enc.c
@@ -49,7 +49,7 @@ static void *sm2_newctx(void *provctx)
 
     if (psm2ctx == NULL)
         return NULL;
-    psm2ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    psm2ctx->libctx = PROV_LIBCTX_OF(provctx);
 
     return psm2ctx;
 }

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -40,7 +40,7 @@ static void *aes_siv_newctx(void *provctx, size_t keybits, unsigned int mode,
         ctx->flags = flags;
         ctx->keylen = keybits / 8;
         ctx->hw = ossl_prov_cipher_hw_aes_siv(keybits);
-        ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+        ctx->libctx = PROV_LIBCTX_OF(provctx);
     }
     return ctx;
 }

--- a/providers/implementations/ciphers/cipher_aes_siv.h
+++ b/providers/implementations/ciphers/cipher_aes_siv.h
@@ -31,7 +31,7 @@ typedef struct prov_siv_ctx_st {
     EVP_CIPHER *ctr;        /* These are fetched - so we need to free them */
     EVP_CIPHER *cbc;
     const PROV_CIPHER_HW_AES_SIV *hw;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 } PROV_AES_SIV_CTX;
 
 const PROV_CIPHER_HW_AES_SIV *ossl_prov_cipher_hw_aes_siv(size_t keybits);

--- a/providers/implementations/ciphers/cipher_aes_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_siv_hw.c
@@ -22,7 +22,7 @@ static int aes_siv_initkey(void *vctx, const unsigned char *key, size_t keylen)
     PROV_AES_SIV_CTX *ctx = (PROV_AES_SIV_CTX *)vctx;
     SIV128_CONTEXT *sctx = &ctx->siv;
     size_t klen  = keylen / 2;
-    OPENSSL_CTX *libctx = ctx->libctx;
+    OSSL_LIB_CTX *libctx = ctx->libctx;
     const char *propq = NULL;
 
     EVP_CIPHER_free(ctx->cbc);

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -595,5 +595,5 @@ void ossl_cipher_generic_initkey(void *vctx, size_t kbits, size_t blkbits,
     ctx->mode = mode;
     ctx->blocksize = blkbits / 8;
     if (provctx != NULL)
-        ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx); /* used for rand */
+        ctx->libctx = PROV_LIBCTX_OF(provctx); /* used for rand */
 }

--- a/providers/implementations/ciphers/ciphercommon_block.c
+++ b/providers/implementations/ciphers/ciphercommon_block.c
@@ -22,7 +22,7 @@ int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     unsigned char **mac,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
-                                    OPENSSL_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx);
 
 int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     size_t origreclen,
@@ -31,7 +31,7 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
                                     int aead,
-                                    OPENSSL_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx);
 
 /*
  * Fills a single block of buffered data from the input, and returns the amount
@@ -154,7 +154,7 @@ int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
  *   1: (in constant time) Record is publicly valid. If padding is invalid then
  *      the mac is random
  */
-int tlsunpadblock(OPENSSL_CTX *libctx, unsigned int tlsversion,
+int tlsunpadblock(OSSL_LIB_CTX *libctx, unsigned int tlsversion,
                   unsigned char *buf, size_t *buflen, size_t blocksize,
                   unsigned char **mac, int *alloced, size_t macsize, int aead)
 {

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -36,7 +36,7 @@ void gcm_initctx(void *provctx, PROV_GCM_CTX *ctx, size_t keybits,
     ctx->ivlen = (EVP_GCM_TLS_FIXED_IV_LEN + EVP_GCM_TLS_EXPLICIT_IV_LEN);
     ctx->keylen = keybits / 8;
     ctx->hw = hw;
-    ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    ctx->libctx = PROV_LIBCTX_OF(provctx);
 }
 
 static int gcm_init(void *vctx, const unsigned char *key, size_t keylen,

--- a/providers/implementations/ciphers/ciphercommon_local.h
+++ b/providers/implementations/ciphers/ciphercommon_local.h
@@ -11,6 +11,6 @@
 
 void padblock(unsigned char *buf, size_t *buflen, size_t blocksize);
 int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize);
-int tlsunpadblock(OPENSSL_CTX *libctx, unsigned int tlsversion,
+int tlsunpadblock(OSSL_LIB_CTX *libctx, unsigned int tlsversion,
                   unsigned char *buf, size_t *buflen, size_t blocksize,
                   unsigned char **mac, int *alloced, size_t macsize, int aead);

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -176,7 +176,7 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
     struct der2key_ctx_st *ctx = vctx;
-    void *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    void *libctx = PROV_LIBCTX_OF(ctx->provctx);
     unsigned char *der = NULL;
     const unsigned char *derp;
     long der_len = 0;

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -789,7 +789,7 @@ static const OSSL_PARAM *key2any_settable_ctx_params(ossl_unused void *provctx)
 static int key2any_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     struct key2any_ctx_st *ctx = vctx;
-    OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_library_context(ctx->provctx);
+    OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_libctx(ctx->provctx);
     const OSSL_PARAM *cipherp =
         OSSL_PARAM_locate_const(params, OSSL_ENCODER_PARAM_CIPHER);
     const OSSL_PARAM *propsp =

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -789,7 +789,7 @@ static const OSSL_PARAM *key2any_settable_ctx_params(ossl_unused void *provctx)
 static int key2any_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     struct key2any_ctx_st *ctx = vctx;
-    OPENSSL_CTX *libctx = ossl_prov_ctx_get0_library_context(ctx->provctx);
+    OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_library_context(ctx->provctx);
     const OSSL_PARAM *cipherp =
         OSSL_PARAM_locate_const(params, OSSL_ENCODER_PARAM_CIPHER);
     const OSSL_PARAM *propsp =

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -408,7 +408,7 @@ static int ec_param_explicit_gen_to_text(BIO *out, const EC_GROUP *group,
 
 /* Print explicit parameters */
 static int ec_param_explicit_to_text(BIO *out, const EC_GROUP *group,
-                                     OPENSSL_CTX *libctx)
+                                     OSSL_LIB_CTX *libctx)
 {
     int ret = 0, tmp_nid;
     BN_CTX *ctx = NULL;
@@ -449,7 +449,7 @@ err:
 }
 
 static int ec_param_to_text(BIO *out, const EC_GROUP *group,
-                            OPENSSL_CTX *libctx)
+                            OSSL_LIB_CTX *libctx)
 {
     if (EC_GROUP_get_asn1_flag(group) & OPENSSL_EC_NAMED_CURVE) {
         const char *curve_name;

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -87,7 +87,7 @@ static void *dh_newctx(void *provctx)
     pdhctx = OPENSSL_zalloc(sizeof(PROV_DH_CTX));
     if (pdhctx == NULL)
         return NULL;
-    pdhctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    pdhctx->libctx = PROV_LIBCTX_OF(provctx);
     pdhctx->kdf_type = PROV_DH_KDF_NONE;
     return pdhctx;
 }

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -59,7 +59,7 @@ enum kdf_type {
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     DH *dh;
     DH *dhpeer;
     unsigned int pad : 1;

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -90,7 +90,7 @@ void *ecdh_newctx(void *provctx)
     if (pectx == NULL)
         return NULL;
 
-    pectx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    pectx->libctx = PROV_LIBCTX_OF(provctx);
     pectx->cofactor_mode = -1;
     pectx->kdf_type = PROV_ECDH_KDF_NONE;
 

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -50,7 +50,7 @@ enum kdf_type {
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
     EC_KEY *k;
     EC_KEY *peerk;

--- a/providers/implementations/exchange/kdf_exch.c
+++ b/providers/implementations/exchange/kdf_exch.c
@@ -49,7 +49,7 @@ static void *kdf_newctx(const char *kdfname, void *provctx)
 
     kdfctx->provctx = provctx;
 
-    kdf = EVP_KDF_fetch(PROV_LIBRARY_CONTEXT_OF(provctx), kdfname, NULL);
+    kdf = EVP_KDF_fetch(PROV_LIBCTX_OF(provctx), kdfname, NULL);
     if (kdf == NULL)
         goto err;
     kdfctx->kdfctx = EVP_KDF_CTX_new(kdf);
@@ -146,7 +146,7 @@ static int kdf_set_ctx_params(void *vpkdfctx, const OSSL_PARAM params[])
 static const OSSL_PARAM *kdf_settable_ctx_params(void *provctx,
                                                  const char *kdfname)
 {
-    EVP_KDF *kdf = EVP_KDF_fetch(PROV_LIBRARY_CONTEXT_OF(provctx), kdfname,
+    EVP_KDF *kdf = EVP_KDF_fetch(PROV_LIBCTX_OF(provctx), kdfname,
                                  NULL);
     const OSSL_PARAM *params;
 

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -81,7 +81,7 @@ struct prov_cipher_ctx_st {
     unsigned char iv[GENERIC_BLOCK_SIZE];
     const PROV_CIPHER_HW *hw; /* hardware specific functions */
     const void *ks; /* Pointer to algorithm specific key data */
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 };
 
 struct prov_cipher_hw_st {

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -72,7 +72,7 @@ typedef struct prov_gcm_ctx_st {
     unsigned char iv[GCM_IV_MAX_SIZE]; /* Buffer to use for IV's */
     unsigned char buf[AES_BLOCK_SIZE]; /* Buffer of partial blocks processed via update calls */
 
-    OPENSSL_CTX *libctx;    /* needed for rand calls */
+    OSSL_LIB_CTX *libctx;    /* needed for rand calls */
     const PROV_GCM_HW *hw;  /* hardware specific methods */
     GCM128_CONTEXT gcm;
     ctr128_f ctr;

--- a/providers/implementations/include/prov/kdfexchange.h
+++ b/providers/implementations/include/prov/kdfexchange.h
@@ -12,7 +12,7 @@
 #include "internal/refcount.h"
 
 struct kdf_data_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
 };

--- a/providers/implementations/include/prov/macsignature.h
+++ b/providers/implementations/include/prov/macsignature.h
@@ -14,7 +14,7 @@
 
 struct mac_key_st {
     CRYPTO_RWLOCK *lock;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     CRYPTO_REF_COUNT refcnt;
     unsigned char *priv_key;
     size_t priv_key_len;
@@ -25,6 +25,6 @@ struct mac_key_st {
 
 typedef struct mac_key_st MAC_KEY;
 
-MAC_KEY *mac_key_new(OPENSSL_CTX *libctx, int cmac);
+MAC_KEY *mac_key_new(OSSL_LIB_CTX *libctx, int cmac);
 void mac_key_free(MAC_KEY *mackey);
 int mac_key_up_ref(MAC_KEY *mackey);

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -168,7 +168,7 @@ static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_HKDF *ctx = vctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
     int n;
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, provctx))

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -168,7 +168,7 @@ static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_HKDF *ctx = vctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     int n;
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, provctx))

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -254,7 +254,7 @@ static int kbkdf_set_buffer(unsigned char **out, size_t *out_len,
 static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     KBKDF *ctx = (KBKDF *)vctx;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     const OSSL_PARAM *p;
     OSSL_PARAM mparams[2];
 

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -254,7 +254,7 @@ static int kbkdf_set_buffer(unsigned char **out, size_t *out_len,
 static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     KBKDF *ctx = (KBKDF *)vctx;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
     const OSSL_PARAM *p;
     OSSL_PARAM mparams[2];
 

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -132,7 +132,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KRB5KDF_CTX *ctx = vctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
 
     if (!ossl_prov_cipher_load_from_params(&ctx->cipher, params, provctx))
         return 0;

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -132,7 +132,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KRB5KDF_CTX *ctx = vctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
 
     if (!ossl_prov_cipher_load_from_params(&ctx->cipher, params, provctx))
         return 0;

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -111,7 +111,7 @@ static void kdf_pbkdf2_reset(void *vctx)
 static void kdf_pbkdf2_init(KDF_PBKDF2 *ctx)
 {
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
                                                  SN_sha1, 0);
@@ -168,7 +168,7 @@ static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_PBKDF2 *ctx = vctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
     int pkcs5;
     uint64_t iter, min_iter;
 

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -111,7 +111,7 @@ static void kdf_pbkdf2_reset(void *vctx)
 static void kdf_pbkdf2_init(KDF_PBKDF2 *ctx)
 {
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
 
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
                                                  SN_sha1, 0);
@@ -168,7 +168,7 @@ static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_PBKDF2 *ctx = vctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     int pkcs5;
     uint64_t iter, min_iter;
 

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -223,7 +223,7 @@ static int kdf_pkcs12_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_PKCS12 *ctx = vctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, provctx))
         return 0;

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -223,7 +223,7 @@ static int kdf_pkcs12_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_PKCS12 *ctx = vctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, provctx))
         return 0;

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -66,7 +66,7 @@ static void *kdf_scrypt_new(void *provctx)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    ctx->libctx = PROV_LIBCTX_OF(provctx);
     kdf_scrypt_init(ctx);
     return ctx;
 }

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -37,10 +37,10 @@ static int scrypt_alg(const char *pass, size_t passlen,
                       const unsigned char *salt, size_t saltlen,
                       uint64_t N, uint64_t r, uint64_t p, uint64_t maxmem,
                       unsigned char *key, size_t keylen, EVP_MD *sha256,
-                      OPENSSL_CTX *libctx, const char *propq);
+                      OSSL_LIB_CTX *libctx, const char *propq);
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     unsigned char *pass;
     size_t pass_len;
@@ -404,7 +404,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
                       const unsigned char *salt, size_t saltlen,
                       uint64_t N, uint64_t r, uint64_t p, uint64_t maxmem,
                       unsigned char *key, size_t keylen, EVP_MD *sha256,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     int rv = 0;
     unsigned char *B;

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -134,7 +134,7 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_SSHKDF *ctx = vctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
     int t;
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, provctx))

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -134,7 +134,7 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_SSHKDF *ctx = vctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     int t;
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, provctx))

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -452,7 +452,7 @@ static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_SSKDF *ctx = vctx;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
     size_t sz;
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, libctx))

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -452,7 +452,7 @@ static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     KDF_SSKDF *ctx = vctx;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     size_t sz;
 
     if (!ossl_prov_digest_load_from_params(&ctx->digest, params, libctx))

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -166,7 +166,7 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     TLS1_PRF *ctx = vctx;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL) {
         if (strcasecmp(p->data, SN_md5_sha1) == 0) {

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -166,7 +166,7 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     TLS1_PRF *ctx = vctx;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL) {
         if (strcasecmp(p->data, SN_md5_sha1) == 0) {

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -70,7 +70,7 @@ static const struct {
 #endif
 };
 
-static int find_alg_id(OPENSSL_CTX *libctx, const char *algname,
+static int find_alg_id(OSSL_LIB_CTX *libctx, const char *algname,
                        const char *propq, size_t *id)
 {
     int ret = 1;
@@ -387,7 +387,7 @@ static int x942kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p, *pq;
     KDF_X942 *ctx = vctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     const char *propq = NULL;
     size_t id;
 

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -387,7 +387,7 @@ static int x942kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p, *pq;
     KDF_X942 *ctx = vctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(ctx->provctx);
     const char *propq = NULL;
     size_t id;
 

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -52,7 +52,7 @@ static OSSL_FUNC_kem_settable_ctx_params_fn rsakem_settable_ctx_params;
  * we use that here too.
  */
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     RSA *rsa;
     int op;
 } PROV_RSA_CTX;

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -86,7 +86,7 @@ static void *rsakem_newctx(void *provctx)
 
     if (prsactx == NULL)
         return NULL;
-    prsactx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    prsactx->libctx = PROV_LIBCTX_OF(provctx);
     prsactx->op = KEM_OP_UNDEFINED;
 
     return prsactx;

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -136,7 +136,7 @@ static void *dh_newdata(void *provctx)
     DH *dh = NULL;
 
     if (ossl_prov_is_running()) {
-        dh = dh_new_ex(PROV_LIBRARY_CONTEXT_OF(provctx));
+        dh = dh_new_ex(PROV_LIBCTX_OF(provctx));
         if (dh != NULL) {
             DH_clear_flags(dh, DH_FLAG_TYPE_MASK);
             DH_set_flags(dh, DH_FLAG_TYPE_DH);
@@ -149,7 +149,7 @@ static void *dhx_newdata(void *provctx)
 {
     DH *dh = NULL;
 
-    dh = dh_new_ex(PROV_LIBRARY_CONTEXT_OF(provctx));
+    dh = dh_new_ex(PROV_LIBCTX_OF(provctx));
     if (dh != NULL) {
         DH_clear_flags(dh, DH_FLAG_TYPE_MASK);
         DH_set_flags(dh, DH_FLAG_TYPE_DHX);
@@ -430,7 +430,7 @@ static int dh_validate(void *keydata, int selection)
 
 static void *dh_gen_init_base(void *provctx, int selection, int type)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     struct dh_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -52,7 +52,7 @@ static OSSL_FUNC_keymgmt_export_types_fn dh_export_types;
     (OSSL_KEYMGMT_SELECT_KEYPAIR | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)
 
 struct dh_gen_ctx {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
     FFC_PARAMS *ffc_params;
     int selection;
@@ -430,7 +430,7 @@ static int dh_validate(void *keydata, int selection)
 
 static void *dh_gen_init_base(void *provctx, int selection, int type)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     struct dh_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -50,7 +50,7 @@ static OSSL_FUNC_keymgmt_export_types_fn dsa_export_types;
     (OSSL_KEYMGMT_SELECT_KEYPAIR | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)
 
 struct dsa_gen_ctx {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
     FFC_PARAMS *ffc_params;
     int selection;
@@ -363,7 +363,7 @@ static int dsa_validate(void *keydata, int selection)
 
 static void *dsa_gen_init(void *provctx, int selection)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     struct dsa_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running() || (selection & DSA_POSSIBLE_SELECTIONS) == 0)

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -113,7 +113,7 @@ static void *dsa_newdata(void *provctx)
 {
     if (!ossl_prov_is_running())
         return NULL;
-    return dsa_new_with_ctx(PROV_LIBRARY_CONTEXT_OF(provctx));
+    return dsa_new_with_ctx(PROV_LIBCTX_OF(provctx));
 }
 
 static void dsa_freedata(void *keydata)
@@ -363,7 +363,7 @@ static int dsa_validate(void *keydata, int selection)
 
 static void *dsa_gen_init(void *provctx, int selection)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     struct dsa_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running() || (selection & DSA_POSSIBLE_SELECTIONS) == 0)

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -236,7 +236,7 @@ void *ec_newdata(void *provctx)
 {
     if (!ossl_prov_is_running())
         return NULL;
-    return EC_KEY_new_ex(PROV_LIBRARY_CONTEXT_OF(provctx), NULL);
+    return EC_KEY_new_ex(PROV_LIBCTX_OF(provctx), NULL);
 }
 
 static
@@ -831,7 +831,7 @@ struct ec_gen_ctx {
 
 static void *ec_gen_init(void *provctx, int selection)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     struct ec_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running() || (selection & (EC_POSSIBLE_SELECTIONS)) == 0)

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -567,7 +567,7 @@ int common_get_params(void *key, OSSL_PARAM params[], int sm2)
     const EC_GROUP *ecg = NULL;
     OSSL_PARAM *p;
     unsigned char *pub_key = NULL, *genbuf = NULL;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propq;
     BN_CTX *bnctx = NULL;
 
@@ -817,7 +817,7 @@ int ec_validate(void *keydata, int selection)
 }
 
 struct ec_gen_ctx {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *group_name;
     char *encoding;
     char *field_type;
@@ -831,7 +831,7 @@ struct ec_gen_ctx {
 
 static void *ec_gen_init(void *provctx, int selection)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     struct ec_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running() || (selection & (EC_POSSIBLE_SELECTIONS)) == 0)

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -68,7 +68,7 @@ static OSSL_FUNC_keymgmt_export_types_fn ecx_imexport_types;
 #define ECX_POSSIBLE_SELECTIONS (OSSL_KEYMGMT_SELECT_KEYPAIR)
 
 struct ecx_gen_ctx {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     ECX_KEY_TYPE type;
     int selection;
@@ -443,7 +443,7 @@ static const OSSL_PARAM *ed448_settable_params(void *provctx)
 
 static void *ecx_gen_init(void *provctx, int selection, ECX_KEY_TYPE type)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     struct ecx_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -85,7 +85,7 @@ static void *x25519_new_key(void *provctx)
 {
     if (!ossl_prov_is_running())
         return 0;
-    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_X25519, 0,
+    return ecx_key_new(PROV_LIBCTX_OF(provctx), ECX_KEY_TYPE_X25519, 0,
                        NULL);
 }
 
@@ -93,7 +93,7 @@ static void *x448_new_key(void *provctx)
 {
     if (!ossl_prov_is_running())
         return 0;
-    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_X448, 0,
+    return ecx_key_new(PROV_LIBCTX_OF(provctx), ECX_KEY_TYPE_X448, 0,
                        NULL);
 }
 
@@ -101,7 +101,7 @@ static void *ed25519_new_key(void *provctx)
 {
     if (!ossl_prov_is_running())
         return 0;
-    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_ED25519, 0,
+    return ecx_key_new(PROV_LIBCTX_OF(provctx), ECX_KEY_TYPE_ED25519, 0,
                        NULL);
 }
 
@@ -109,7 +109,7 @@ static void *ed448_new_key(void *provctx)
 {
     if (!ossl_prov_is_running())
         return 0;
-    return ecx_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), ECX_KEY_TYPE_ED448, 0,
+    return ecx_key_new(PROV_LIBCTX_OF(provctx), ECX_KEY_TYPE_ED448, 0,
                        NULL);
 }
 
@@ -443,7 +443,7 @@ static const OSSL_PARAM *ed448_settable_params(void *provctx)
 
 static void *ecx_gen_init(void *provctx, int selection, ECX_KEY_TYPE type)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     struct ecx_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
@@ -42,7 +42,7 @@ KDF_DATA *kdf_data_new(void *provctx)
         OPENSSL_free(kdfdata);
         return NULL;
     }
-    kdfdata->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    kdfdata->libctx = PROV_LIBCTX_OF(provctx);
     kdfdata->refcnt = 1;
 
     return kdfdata;

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -50,14 +50,14 @@ static OSSL_FUNC_keymgmt_gen_set_params_fn cmac_gen_set_params;
 static OSSL_FUNC_keymgmt_gen_settable_params_fn cmac_gen_settable_params;
 
 struct mac_gen_ctx {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     int selection;
     unsigned char *priv_key;
     size_t priv_key_len;
     PROV_CIPHER cipher;
 };
 
-MAC_KEY *mac_key_new(OPENSSL_CTX *libctx, int cmac)
+MAC_KEY *mac_key_new(OSSL_LIB_CTX *libctx, int cmac)
 {
     MAC_KEY *mackey;
 
@@ -372,7 +372,7 @@ static const OSSL_PARAM *mac_settable_params(void *provctx)
 
 static void *mac_gen_init(void *provctx, int selection)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     struct mac_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -118,12 +118,12 @@ int mac_key_up_ref(MAC_KEY *mackey)
 
 static void *mac_new(void *provctx)
 {
-    return mac_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), 0);
+    return mac_key_new(PROV_LIBCTX_OF(provctx), 0);
 }
 
 static void *mac_new_cmac(void *provctx)
 {
-    return mac_key_new(PROV_LIBRARY_CONTEXT_OF(provctx), 1);
+    return mac_key_new(PROV_LIBCTX_OF(provctx), 1);
 }
 
 static void mac_free(void *mackey)
@@ -372,7 +372,7 @@ static const OSSL_PARAM *mac_settable_params(void *provctx)
 
 static void *mac_gen_init(void *provctx, int selection)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     struct mac_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -58,7 +58,7 @@ DEFINE_SPECIAL_STACK_OF_CONST(BIGNUM_const, BIGNUM)
 
 static int pss_params_fromdata(RSA_PSS_PARAMS_30 *pss_params,
                                const OSSL_PARAM params[], int rsa_type,
-                               OPENSSL_CTX *libctx)
+                               OSSL_LIB_CTX *libctx)
 {
     if (!ossl_rsa_pss_params_30_fromdata(pss_params, params, libctx))
         return 0;
@@ -73,7 +73,7 @@ static int pss_params_fromdata(RSA_PSS_PARAMS_30 *pss_params,
 
 static void *rsa_newdata(void *provctx)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     RSA *rsa;
 
     if (!ossl_prov_is_running())
@@ -89,7 +89,7 @@ static void *rsa_newdata(void *provctx)
 
 static void *rsapss_newdata(void *provctx)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     RSA *rsa;
 
     if (!ossl_prov_is_running())
@@ -382,7 +382,7 @@ static int rsa_validate(void *keydata, int selection)
 }
 
 struct rsa_gen_ctx {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     const char *propq;
 
     int rsa_type;
@@ -416,7 +416,7 @@ static int rsa_gencb(int p, int n, BN_GENCB *cb)
 
 static void *gen_init(void *provctx, int selection, int rsa_type)
 {
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
     struct rsa_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -73,7 +73,7 @@ static int pss_params_fromdata(RSA_PSS_PARAMS_30 *pss_params,
 
 static void *rsa_newdata(void *provctx)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     RSA *rsa;
 
     if (!ossl_prov_is_running())
@@ -89,7 +89,7 @@ static void *rsa_newdata(void *provctx)
 
 static void *rsapss_newdata(void *provctx)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     RSA *rsa;
 
     if (!ossl_prov_is_running())
@@ -416,7 +416,7 @@ static int rsa_gencb(int p, int n, BN_GENCB *cb)
 
 static void *gen_init(void *provctx, int selection, int rsa_type)
 {
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(provctx);
     struct rsa_gen_ctx *gctx = NULL;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -173,7 +173,7 @@ static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *provctx)
 static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct cmac_data_st *macctx = vmacctx;
-    OSSL_LIB_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
+    OSSL_LIB_CTX *ctx = PROV_LIBCTX_OF(macctx->provctx);
     const OSSL_PARAM *p;
 
     if (!ossl_prov_cipher_load_from_params(&macctx->cipher, params, ctx))

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -173,7 +173,7 @@ static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *provctx)
 static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct cmac_data_st *macctx = vmacctx;
-    OPENSSL_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
+    OSSL_LIB_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
     const OSSL_PARAM *p;
 
     if (!ossl_prov_cipher_load_from_params(&macctx->cipher, params, ctx))

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -184,7 +184,7 @@ static int gmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct gmac_data_st *macctx = vmacctx;
     EVP_CIPHER_CTX *ctx = macctx->ctx;
-    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBCTX_OF(macctx->provctx);
     const OSSL_PARAM *p;
 
    if (ctx == NULL

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -184,7 +184,7 @@ static int gmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct gmac_data_st *macctx = vmacctx;
     EVP_CIPHER_CTX *ctx = macctx->ctx;
-    OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
+    OSSL_LIB_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
     const OSSL_PARAM *p;
 
    if (ctx == NULL

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -256,7 +256,7 @@ static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *provctx)
 static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct hmac_data_st *macctx = vmacctx;
-    OPENSSL_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
+    OSSL_LIB_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
     const OSSL_PARAM *p;
 
     if (!ossl_prov_digest_load_from_params(&macctx->digest, params, ctx))

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -256,7 +256,7 @@ static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *provctx)
 static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
     struct hmac_data_st *macctx = vmacctx;
-    OSSL_LIB_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
+    OSSL_LIB_CTX *ctx = PROV_LIBCTX_OF(macctx->provctx);
     const OSSL_PARAM *p;
 
     if (!ossl_prov_digest_load_from_params(&macctx->digest, params, ctx))

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -178,7 +178,7 @@ static void *kmac_fetch_new(void *provctx, const OSSL_PARAM *params)
     if (kctx == NULL)
         return 0;
     if (!ossl_prov_digest_load_from_params(&kctx->digest, params,
-                                      PROV_LIBRARY_CONTEXT_OF(provctx))) {
+                                      PROV_LIBCTX_OF(provctx))) {
         kmac_free(kctx);
         return 0;
     }

--- a/providers/implementations/rands/crngt.c
+++ b/providers/implementations/rands/crngt.c
@@ -117,7 +117,7 @@ size_t prov_crngt_get_entropy(PROV_DRBG *drbg,
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(drbg->provctx);
     CRNG_TEST_GLOBAL *crngt_glob
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_RAND_CRNGT_INDEX,
-                               &rand_crng_ossl_ctx_method);
+                                &rand_crng_ossl_ctx_method);
     OSSL_CALLBACK *stcb = NULL;
     void *stcbarg = NULL;
     OSSL_SELF_TEST *st = NULL;

--- a/providers/implementations/rands/crngt.c
+++ b/providers/implementations/rands/crngt.c
@@ -29,7 +29,7 @@ typedef struct crng_test_global_st {
     RAND_POOL *crngt_pool;
 } CRNG_TEST_GLOBAL;
 
-static int crngt_get_entropy(OPENSSL_CTX *ctx, RAND_POOL *pool,
+static int crngt_get_entropy(OSSL_LIB_CTX *ctx, RAND_POOL *pool,
                              unsigned char *buf, unsigned char *md,
                              unsigned int *md_size)
 {
@@ -65,7 +65,7 @@ static void rand_crng_ossl_ctx_free(void *vcrngt_glob)
     OPENSSL_free(crngt_glob);
 }
 
-static void *rand_crng_ossl_ctx_new(OPENSSL_CTX *ctx)
+static void *rand_crng_ossl_ctx_new(OSSL_LIB_CTX *ctx)
 {
     unsigned char buf[CRNGT_BUFSIZ];
     CRNG_TEST_GLOBAL *crngt_glob = OPENSSL_zalloc(sizeof(*crngt_glob));
@@ -88,7 +88,7 @@ static void *rand_crng_ossl_ctx_new(OPENSSL_CTX *ctx)
     return NULL;
 }
 
-static const OPENSSL_CTX_METHOD rand_crng_ossl_ctx_method = {
+static const OSSL_LIB_CTX_METHOD rand_crng_ossl_ctx_method = {
     rand_crng_ossl_ctx_new,
     rand_crng_ossl_ctx_free,
 };
@@ -114,9 +114,9 @@ size_t prov_crngt_get_entropy(PROV_DRBG *drbg,
     RAND_POOL *pool;
     size_t q, r = 0, s, t = 0;
     int attempts = 3, crng_test_pass = 1;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(drbg->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(drbg->provctx);
     CRNG_TEST_GLOBAL *crngt_glob
-        = openssl_ctx_get_data(libctx, OPENSSL_CTX_RAND_CRNGT_INDEX,
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_RAND_CRNGT_INDEX,
                                &rand_crng_ossl_ctx_method);
     OSSL_CALLBACK *stcb = NULL;
     void *stcbarg = NULL;

--- a/providers/implementations/rands/crngt.c
+++ b/providers/implementations/rands/crngt.c
@@ -114,7 +114,7 @@ size_t prov_crngt_get_entropy(PROV_DRBG *drbg,
     RAND_POOL *pool;
     size_t q, r = 0, s, t = 0;
     int attempts = 3, crng_test_pass = 1;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(drbg->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(drbg->provctx);
     CRNG_TEST_GLOBAL *crngt_glob
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_RAND_CRNGT_INDEX,
                                &rand_crng_ossl_ctx_method);

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -318,7 +318,7 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
     size_t ret = 0, n;
     RAND_POOL *pool;
     unsigned char *buf = NULL;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(drbg->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(drbg->provctx);
     PROV_DRBG_NONCE_GLOBAL *dngbl
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_NONCE_INDEX,
                                &drbg_nonce_ossl_ctx_method);

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -272,12 +272,12 @@ typedef struct prov_drbg_nonce_global_st {
 
 /*
  * drbg_ossl_ctx_new() calls drgb_setup() which calls rand_drbg_get_nonce()
- * which needs to get the rand_nonce_lock out of the OPENSSL_CTX...but since
+ * which needs to get the rand_nonce_lock out of the OSSL_LIB_CTX...but since
  * drbg_ossl_ctx_new() hasn't finished running yet we need the rand_nonce_lock
  * to be in a different global data object. Otherwise we will go into an
  * infinite recursion loop.
  */
-static void *prov_drbg_nonce_ossl_ctx_new(OPENSSL_CTX *libctx)
+static void *prov_drbg_nonce_ossl_ctx_new(OSSL_LIB_CTX *libctx)
 {
     PROV_DRBG_NONCE_GLOBAL *dngbl = OPENSSL_zalloc(sizeof(*dngbl));
 
@@ -305,7 +305,7 @@ static void prov_drbg_nonce_ossl_ctx_free(void *vdngbl)
     OPENSSL_free(dngbl);
 }
 
-static const OPENSSL_CTX_METHOD drbg_nonce_ossl_ctx_method = {
+static const OSSL_LIB_CTX_METHOD drbg_nonce_ossl_ctx_method = {
     prov_drbg_nonce_ossl_ctx_new,
     prov_drbg_nonce_ossl_ctx_free,
 };
@@ -318,9 +318,9 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
     size_t ret = 0, n;
     RAND_POOL *pool;
     unsigned char *buf = NULL;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(drbg->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(drbg->provctx);
     PROV_DRBG_NONCE_GLOBAL *dngbl
-        = openssl_ctx_get_data(libctx, OPENSSL_CTX_DRBG_NONCE_INDEX,
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_NONCE_INDEX,
                                &drbg_nonce_ossl_ctx_method);
     struct {
         void *instance;

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -321,7 +321,7 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(drbg->provctx);
     PROV_DRBG_NONCE_GLOBAL *dngbl
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_NONCE_INDEX,
-                               &drbg_nonce_ossl_ctx_method);
+                                &drbg_nonce_ossl_ctx_method);
     struct {
         void *instance;
         int count;

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -663,7 +663,7 @@ static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_CTR *ctr = (PROV_DRBG_CTR *)ctx->data;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
     const OSSL_PARAM *p;
     char *ecb;
     const char *propquery = NULL;

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -663,7 +663,7 @@ static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_CTR *ctr = (PROV_DRBG_CTR *)ctx->data;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     const OSSL_PARAM *p;
     char *ecb;
     const char *propquery = NULL;

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -456,7 +456,7 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_HASH *hash = (PROV_DRBG_HASH *)ctx->data;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
     const EVP_MD *md;
 
     if (!ossl_prov_digest_load_from_params(&hash->digest, params, libctx))

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -456,7 +456,7 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_HASH *hash = (PROV_DRBG_HASH *)ctx->data;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     const EVP_MD *md;
 
     if (!ossl_prov_digest_load_from_params(&hash->digest, params, libctx))

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -364,7 +364,7 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_HMAC *hmac = (PROV_DRBG_HMAC *)ctx->data;
-    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
     const EVP_MD *md;
 
     if (!ossl_prov_digest_load_from_params(&hmac->digest, params, libctx))

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -364,7 +364,7 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_DRBG *ctx = (PROV_DRBG *)vctx;
     PROV_DRBG_HMAC *hmac = (PROV_DRBG_HMAC *)ctx->data;
-    OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
+    OSSL_LIB_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     const EVP_MD *md;
 
     if (!ossl_prov_digest_load_from_params(&hmac->digest, params, libctx))

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -63,7 +63,7 @@ static OSSL_FUNC_signature_settable_ctx_md_params_fn dsa_settable_ctx_md_params;
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     DSA *dsa;
 

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -108,7 +108,7 @@ static void *dsa_newctx(void *provctx, const char *propq)
     if (pdsactx == NULL)
         return NULL;
 
-    pdsactx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    pdsactx->libctx = PROV_LIBCTX_OF(provctx);
     pdsactx->flag_allow_md = 1;
     if (propq != NULL && (pdsactx->propq = OPENSSL_strdup(propq)) == NULL) {
         OPENSSL_free(pdsactx);

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -107,7 +107,7 @@ static void *ecdsa_newctx(void *provctx, const char *propq)
     if (ctx == NULL)
         return NULL;
 
-    ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    ctx->libctx = PROV_LIBCTX_OF(provctx);
     if (propq != NULL && (ctx->propq = OPENSSL_strdup(propq)) == NULL) {
         OPENSSL_free(ctx);
         ctx = NULL;

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -61,7 +61,7 @@ static OSSL_FUNC_signature_settable_ctx_md_params_fn ecdsa_settable_ctx_md_param
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     EC_KEY *ec;
     char mdname[OSSL_MAX_NAME_SIZE];

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -35,7 +35,7 @@ static OSSL_FUNC_signature_get_ctx_params_fn eddsa_get_ctx_params;
 static OSSL_FUNC_signature_gettable_ctx_params_fn eddsa_gettable_ctx_params;
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     ECX_KEY *key;
 
     /* The Algorithm Identifier of the signature algorithm */

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -57,7 +57,7 @@ static void *eddsa_newctx(void *provctx, const char *propq_unused)
         return NULL;
     }
 
-    peddsactx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    peddsactx->libctx = PROV_LIBCTX_OF(provctx);
 
     return peddsactx;
 }

--- a/providers/implementations/signature/mac_legacy.c
+++ b/providers/implementations/signature/mac_legacy.c
@@ -55,7 +55,7 @@ static void *mac_newctx(void *provctx, const char *propq, const char *macname)
     if (pmacctx == NULL)
         return NULL;
 
-    pmacctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    pmacctx->libctx = PROV_LIBCTX_OF(provctx);
     if (propq != NULL && (pmacctx->propq = OPENSSL_strdup(propq)) == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -200,7 +200,7 @@ static int mac_set_ctx_params(void *vpmacctx, const OSSL_PARAM params[])
 static const OSSL_PARAM *mac_settable_ctx_params(void *provctx,
                                                  const char *macname)
 {
-    EVP_MAC *mac = EVP_MAC_fetch(PROV_LIBRARY_CONTEXT_OF(provctx), macname,
+    EVP_MAC *mac = EVP_MAC_fetch(PROV_LIBCTX_OF(provctx), macname,
                                  NULL);
     const OSSL_PARAM *params;
 

--- a/providers/implementations/signature/mac_legacy.c
+++ b/providers/implementations/signature/mac_legacy.c
@@ -37,7 +37,7 @@ static OSSL_FUNC_signature_settable_ctx_params_fn mac_poly1305_settable_ctx_para
 static OSSL_FUNC_signature_settable_ctx_params_fn mac_cmac_settable_ctx_params;
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     MAC_KEY *key;
     EVP_MAC_CTX *macctx;

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -74,7 +74,7 @@ static OSSL_ITEM padding_item[] = {
  */
 
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     RSA *rsa;
     int operation;

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -170,7 +170,7 @@ static void *rsa_newctx(void *provctx, const char *propq)
         return NULL;
     }
 
-    prsactx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    prsactx->libctx = PROV_LIBCTX_OF(provctx);
     prsactx->flag_allow_md = 1;
     prsactx->propq = propq_copy;
     return prsactx;

--- a/providers/implementations/signature/sm2sig.c
+++ b/providers/implementations/signature/sm2sig.c
@@ -102,7 +102,7 @@ static void *sm2sig_newctx(void *provctx, const char *propq)
     if (ctx == NULL)
         return NULL;
 
-    ctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
+    ctx->libctx = PROV_LIBCTX_OF(provctx);
     if (propq != NULL && (ctx->propq = OPENSSL_strdup(propq)) == NULL) {
         OPENSSL_free(ctx);
         ctx = NULL;

--- a/providers/implementations/signature/sm2sig.c
+++ b/providers/implementations/signature/sm2sig.c
@@ -59,7 +59,7 @@ static OSSL_FUNC_signature_settable_ctx_md_params_fn sm2sig_settable_ctx_md_para
  * we use that here too.
  */
 typedef struct {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     char *propq;
     EC_KEY *ec;
 

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -530,7 +530,7 @@ void file_load_cleanup(void *construct_data)
 static int file_setup_decoders(struct file_ctx_st *ctx)
 {
     EVP_PKEY *dummy; /* for OSSL_DECODER_CTX_new_by_EVP_PKEY() */
-    OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_library_context(ctx->provctx);
+    OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_libctx(ctx->provctx);
     OSSL_DECODER *to_obj = NULL; /* Last resort decoder */
     OSSL_DECODER_INSTANCE *to_obj_inst = NULL;
     OSSL_DECODER_CLEANUP *old_cleanup = NULL;

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -530,7 +530,7 @@ void file_load_cleanup(void *construct_data)
 static int file_setup_decoders(struct file_ctx_st *ctx)
 {
     EVP_PKEY *dummy; /* for OSSL_DECODER_CTX_new_by_EVP_PKEY() */
-    OPENSSL_CTX *libctx = ossl_prov_ctx_get0_library_context(ctx->provctx);
+    OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_library_context(ctx->provctx);
     OSSL_DECODER *to_obj = NULL; /* Last resort decoder */
     OSSL_DECODER_INSTANCE *to_obj_inst = NULL;
     OSSL_DECODER_CLEANUP *old_cleanup = NULL;

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -161,7 +161,7 @@ static const OSSL_ALGORITHM *legacy_query(void *provctx, int operation_id,
 
 static void legacy_teardown(void *provctx)
 {
-    OSSL_LIB_CTX_free(PROV_LIBRARY_CONTEXT_OF(provctx));
+    OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
     ossl_prov_ctx_free(provctx);
 }
 
@@ -179,7 +179,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        const OSSL_DISPATCH **out,
                        void **provctx)
 {
-    OSSL_FUNC_core_get_library_context_fn *c_get_libctx = NULL;
+    OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
     OSSL_LIB_CTX *libctx = NULL;
 
     for (; in->function_id != 0; in++) {
@@ -190,8 +190,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;
-        case OSSL_FUNC_CORE_GET_LIBRARY_CONTEXT:
-            c_get_libctx = OSSL_FUNC_core_get_library_context(in);
+        case OSSL_FUNC_CORE_GET_LIBCTX:
+            c_get_libctx = OSSL_FUNC_core_get_libctx(in);
             break;
         /* Just ignore anything we don't understand */
         default:
@@ -209,7 +209,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         *provctx = NULL;
         return 0;
     }
-    ossl_prov_ctx_set0_library_context(*provctx, libctx);
+    ossl_prov_ctx_set0_libctx(*provctx, libctx);
     ossl_prov_ctx_set0_handle(*provctx, handle);
 
     *out = legacy_dispatch_table;

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -161,7 +161,7 @@ static const OSSL_ALGORITHM *legacy_query(void *provctx, int operation_id,
 
 static void legacy_teardown(void *provctx)
 {
-    OPENSSL_CTX_free(PROV_LIBRARY_CONTEXT_OF(provctx));
+    OSSL_LIB_CTX_free(PROV_LIBRARY_CONTEXT_OF(provctx));
     ossl_prov_ctx_free(provctx);
 }
 
@@ -180,7 +180,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        void **provctx)
 {
     OSSL_FUNC_core_get_library_context_fn *c_get_libctx = NULL;
-    OPENSSL_CTX *libctx = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
 
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
@@ -203,8 +203,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         return 0;
 
     if ((*provctx = ossl_prov_ctx_new()) == NULL
-        || (libctx = OPENSSL_CTX_new()) == NULL) {
-        OPENSSL_CTX_free(libctx);
+        || (libctx = OSSL_LIB_CTX_new()) == NULL) {
+        OSSL_LIB_CTX_free(libctx);
         legacy_teardown(*provctx);
         *provctx = NULL;
         return 0;

--- a/ssl/record/record_local.h
+++ b/ssl/record/record_local.h
@@ -113,7 +113,7 @@ __owur int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                            unsigned char **mac,
                                            int *alloced,
                                            size_t block_size, size_t mac_size,
-                                           OPENSSL_CTX *libctx);
+                                           OSSL_LIB_CTX *libctx);
 __owur int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                            size_t origreclen,
                                            unsigned char *recdata,
@@ -121,7 +121,7 @@ __owur int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                            int *alloced,
                                            size_t block_size, size_t mac_size,
                                            int aead,
-                                           OPENSSL_CTX *libctx);
+                                           OSSL_LIB_CTX *libctx);
 int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap);
 __owur int dtls1_get_record(SSL *s);
 int early_data_count_ok(SSL *s, size_t length, size_t overhead, int send);

--- a/ssl/record/tls_pad.c
+++ b/ssl/record/tls_pad.c
@@ -29,7 +29,7 @@ static int ssl3_cbc_copy_mac(size_t *reclen,
                              size_t block_size,
                              size_t mac_size,
                              size_t good,
-                             OPENSSL_CTX *libctx);
+                             OSSL_LIB_CTX *libctx);
 
 int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     size_t origreclen,
@@ -37,7 +37,7 @@ int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     unsigned char **mac,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
-                                    OPENSSL_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx);
 
 int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     size_t origreclen,
@@ -46,7 +46,7 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
                                     int aead,
-                                    OPENSSL_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx);
 
 /*-
  * ssl3_cbc_remove_padding removes padding from the decrypted, SSLv3, CBC
@@ -71,7 +71,7 @@ int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     unsigned char **mac,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
-                                    OPENSSL_CTX *libctx)
+                                    OSSL_LIB_CTX *libctx)
 {
     size_t padding_length;
     size_t good;
@@ -117,7 +117,7 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
                                     int aead,
-                                    OPENSSL_CTX *libctx)
+                                    OSSL_LIB_CTX *libctx)
 {
     size_t good = -1;
     size_t padding_length, to_check, i;
@@ -204,7 +204,7 @@ static int ssl3_cbc_copy_mac(size_t *reclen,
                              size_t block_size,
                              size_t mac_size,
                              size_t good,
-                             OPENSSL_CTX *libctx)
+                             OSSL_LIB_CTX *libctx)
 {
 #if defined(CBC_MAC_ROTATE_IN_PLACE)
     unsigned char rotated_mac_buf[64 + EVP_MAX_MD_SIZE];

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -606,7 +606,7 @@ static unsigned long xname_hash(const X509_NAME *a)
 }
 
 STACK_OF(X509_NAME) *SSL_load_client_CA_file_ex(const char *file,
-                                                OPENSSL_CTX *libctx,
+                                                OSSL_LIB_CTX *libctx,
                                                 const char *propq)
 {
     BIO *in = BIO_new(BIO_s_file());
@@ -614,7 +614,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file_ex(const char *file,
     X509_NAME *xn = NULL;
     STACK_OF(X509_NAME) *ret = NULL;
     LHASH_OF(X509_NAME) *name_hash = lh_X509_NAME_new(xname_hash, xname_cmp);
-    OPENSSL_CTX *prev_libctx = NULL;
+    OSSL_LIB_CTX *prev_libctx = NULL;
 
     if ((name_hash == NULL) || (in == NULL)) {
         SSLerr(0, ERR_R_MALLOC_FAILURE);
@@ -630,7 +630,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file_ex(const char *file,
         goto err;
 
     /* Internally lh_X509_NAME_retrieve() needs the libctx to retrieve SHA1 */
-    prev_libctx = OPENSSL_CTX_set0_default(libctx);
+    prev_libctx = OSSL_LIB_CTX_set0_default(libctx);
     for (;;) {
         if (PEM_read_bio_X509(in, &x, NULL, NULL) == NULL)
             break;
@@ -665,7 +665,7 @@ STACK_OF(X509_NAME) *SSL_load_client_CA_file_ex(const char *file,
     ret = NULL;
  done:
     /* restore the old libctx */
-    OPENSSL_CTX_set0_default(prev_libctx);
+    OSSL_LIB_CTX_set0_default(prev_libctx);
     BIO_free(in);
     X509_free(x);
     lh_X509_NAME_free(name_hash);

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -469,7 +469,7 @@ static int do_store(SSL_CONF_CTX *cctx,
     CERT *cert;
     X509_STORE **st;
     SSL_CTX *ctx;
-    OPENSSL_CTX *libctx = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
     const char *propq = NULL;
 
     if (cctx->ctx != NULL) {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3123,7 +3123,7 @@ static int ssl_session_cmp(const SSL_SESSION *a, const SSL_SESSION *b)
  * via ssl.h.
  */
 
-SSL_CTX *SSL_CTX_new_ex(OPENSSL_CTX *libctx, const char *propq,
+SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
                         const SSL_METHOD *meth)
 {
     SSL_CTX *ret = NULL;
@@ -5893,7 +5893,7 @@ void SSL_set_allow_early_data_cb(SSL *s,
     s->allow_early_data_cb_data = arg;
 }
 
-const EVP_CIPHER *ssl_evp_cipher_fetch(OPENSSL_CTX *libctx,
+const EVP_CIPHER *ssl_evp_cipher_fetch(OSSL_LIB_CTX *libctx,
                                        int nid,
                                        const char *properties)
 {
@@ -5948,7 +5948,7 @@ void ssl_evp_cipher_free(const EVP_CIPHER *cipher)
     }
 }
 
-const EVP_MD *ssl_evp_md_fetch(OPENSSL_CTX *libctx,
+const EVP_MD *ssl_evp_md_fetch(OSSL_LIB_CTX *libctx,
                                int nid,
                                const char *properties)
 {

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -832,7 +832,7 @@ typedef struct tls_group_info_st {
 # define TLS_GROUP_FFDHE_FOR_TLS1_3 (TLS_GROUP_FFDHE|TLS_GROUP_ONLY_FOR_TLS1_3)
 
 struct ssl_ctx_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 
     const SSL_METHOD *method;
     STACK_OF(SSL_CIPHER) *cipher_list;
@@ -2812,12 +2812,12 @@ void ssl_comp_free_compression_methods_int(void);
 /* ssl_mcnf.c */
 void ssl_ctx_system_config(SSL_CTX *ctx);
 
-const EVP_CIPHER *ssl_evp_cipher_fetch(OPENSSL_CTX *libctx,
+const EVP_CIPHER *ssl_evp_cipher_fetch(OSSL_LIB_CTX *libctx,
                                        int nid,
                                        const char *properties);
 int ssl_evp_cipher_up_ref(const EVP_CIPHER *cipher);
 void ssl_evp_cipher_free(const EVP_CIPHER *cipher);
-const EVP_MD *ssl_evp_md_fetch(OPENSSL_CTX *libctx,
+const EVP_MD *ssl_evp_md_fetch(OSSL_LIB_CTX *libctx,
                                int nid,
                                const char *properties);
 int ssl_evp_md_up_ref(const EVP_MD *md);

--- a/ssl/ssl_mcnf.c
+++ b/ssl/ssl_mcnf.c
@@ -28,8 +28,8 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
     unsigned int flags;
     const SSL_METHOD *meth;
     const SSL_CONF_CMD *cmds;
-    OPENSSL_CTX *prev_libctx = NULL;
-    OPENSSL_CTX *libctx = NULL;
+    OSSL_LIB_CTX *prev_libctx = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
 
     if (s == NULL && ctx == NULL) {
         SSLerr(SSL_F_SSL_DO_CONFIG, ERR_R_PASSED_NULL_PARAMETER);
@@ -66,7 +66,7 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
     if (meth->ssl_connect != ssl_undefined_function)
         flags |= SSL_CONF_FLAG_CLIENT;
     SSL_CONF_CTX_set_flags(cctx, flags);
-    prev_libctx = OPENSSL_CTX_set0_default(libctx);
+    prev_libctx = OSSL_LIB_CTX_set0_default(libctx);
     for (i = 0; i < cmd_count; i++) {
         char *cmdstr, *arg;
 
@@ -84,7 +84,7 @@ static int ssl_do_config(SSL *s, SSL_CTX *ctx, const char *name, int system)
     }
     rv = SSL_CONF_CTX_finish(cctx);
  err:
-    OPENSSL_CTX_set0_default(prev_libctx);
+    OSSL_LIB_CTX_set0_default(prev_libctx);
     SSL_CONF_CTX_free(cctx);
     return rv <= 0 ? 0 : 1;
 }

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -43,7 +43,7 @@ typedef struct st_args {
 } SELF_TEST_ARGS;
 
 static OSSL_PROVIDER *prov_null = NULL;
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static SELF_TEST_ARGS self_test_args = { 0 };
 static OSSL_CALLBACK self_test_events;
 
@@ -1440,9 +1440,9 @@ int setup_tests(void)
         return 0;
     }
 
-    libctx = OPENSSL_CTX_new();
+    libctx = OSSL_LIB_CTX_new();
     if (libctx == NULL
-        || !OPENSSL_CTX_load_config(libctx, config_file)) {
+        || !OSSL_LIB_CTX_load_config(libctx, config_file)) {
         opt_printf_stderr("Failed to load config\n");
         return 0;
     }
@@ -1489,5 +1489,5 @@ int setup_tests(void)
 void cleanup_tests(void)
 {
     OSSL_PROVIDER_unload(prov_null);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 }

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -45,33 +45,33 @@ static int save_current(void *args)
 
 static int change_deflt_libctx(void *args)
 {
-    OPENSSL_CTX *libctx = OPENSSL_CTX_new();
-    OPENSSL_CTX *oldctx, *tmpctx;
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_LIB_CTX *oldctx, *tmpctx;
     int ret = 0;
 
     if (libctx == NULL)
         return 0;
 
-    oldctx = OPENSSL_CTX_set0_default(libctx);
+    oldctx = OSSL_LIB_CTX_set0_default(libctx);
     ASYNC_pause_job();
 
     /* Check the libctx is set up as we expect */
-    tmpctx = OPENSSL_CTX_set0_default(oldctx);
+    tmpctx = OSSL_LIB_CTX_set0_default(oldctx);
     if (tmpctx != libctx)
         goto err;
 
     /* Set it back again to continue to use our own libctx */
-    oldctx = OPENSSL_CTX_set0_default(libctx);
+    oldctx = OSSL_LIB_CTX_set0_default(libctx);
     ASYNC_pause_job();
 
     /* Check the libctx is set up as we expect */
-    tmpctx = OPENSSL_CTX_set0_default(oldctx);
+    tmpctx = OSSL_LIB_CTX_set0_default(oldctx);
     if (tmpctx != libctx)
         goto err;
 
     ret = 1;
  err:
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     return ret;
 }
 
@@ -344,8 +344,8 @@ static int test_ASYNC_start_job_ex(void)
     ASYNC_JOB *job = NULL;
     int funcret;
     ASYNC_WAIT_CTX *waitctx = NULL;
-    OPENSSL_CTX *libctx = OPENSSL_CTX_new();
-    OPENSSL_CTX *oldctx, *tmpctx, *globalctx;
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_LIB_CTX *oldctx, *tmpctx, *globalctx;
     int ret = 0;
 
     if (libctx == NULL) {
@@ -354,7 +354,7 @@ static int test_ASYNC_start_job_ex(void)
         goto err;
     }
 
-    globalctx = oldctx = OPENSSL_CTX_set0_default(libctx);
+    globalctx = oldctx = OSSL_LIB_CTX_set0_default(libctx);
 
     if ((waitctx = ASYNC_WAIT_CTX_new()) == NULL
             || ASYNC_start_job(&job, waitctx, &funcret, change_deflt_libctx,
@@ -366,8 +366,8 @@ static int test_ASYNC_start_job_ex(void)
     }
 
     /* Reset the libctx temporarily to find out what it is*/
-    tmpctx = OPENSSL_CTX_set0_default(oldctx);
-    oldctx = OPENSSL_CTX_set0_default(tmpctx);
+    tmpctx = OSSL_LIB_CTX_set0_default(oldctx);
+    oldctx = OSSL_LIB_CTX_set0_default(tmpctx);
     if (tmpctx != libctx) {
         fprintf(stderr,
                 "test_ASYNC_start_job_ex() failed - unexpected libctx\n");
@@ -382,7 +382,7 @@ static int test_ASYNC_start_job_ex(void)
     }
 
     /* Reset the libctx and continue with the global default libctx */
-    tmpctx = OPENSSL_CTX_set0_default(oldctx);
+    tmpctx = OSSL_LIB_CTX_set0_default(oldctx);
     if (tmpctx != libctx) {
         fprintf(stderr,
                 "test_ASYNC_start_job_ex() failed - unexpected libctx\n");
@@ -398,8 +398,8 @@ static int test_ASYNC_start_job_ex(void)
     }
 
     /* Reset the libctx temporarily to find out what it is*/
-    tmpctx = OPENSSL_CTX_set0_default(libctx);
-    OPENSSL_CTX_set0_default(tmpctx);
+    tmpctx = OSSL_LIB_CTX_set0_default(libctx);
+    OSSL_LIB_CTX_set0_default(tmpctx);
     if (tmpctx != globalctx) {
         fprintf(stderr,
                 "test_ASYNC_start_job_ex() failed - global libctx check failed\n");
@@ -409,7 +409,7 @@ static int test_ASYNC_start_job_ex(void)
     ret = 1;
  err:
     ASYNC_WAIT_CTX_free(waitctx);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     return ret;
 }
 

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -30,7 +30,7 @@ typedef struct test_fixture {
     STACK_OF(X509) *caPubs;
 } CMP_SES_TEST_FIXTURE;
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *default_null_provider = NULL, *provider = NULL;
 
 static EVP_PKEY *server_key = NULL;
@@ -343,7 +343,7 @@ void cleanup_tests(void)
     EVP_PKEY_free(server_key);
     X509_free(client_cert);
     EVP_PKEY_free(client_key);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     return;
 }
 

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -30,7 +30,7 @@ typedef struct test_fixture {
     OSSL_CMP_PKISI *si;
 } CMP_MSG_TEST_FIXTURE;
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *default_null_provider = NULL, *provider = NULL;
 
 /* TODO(3.0) Clean this up - See issue #12680 */
@@ -551,7 +551,7 @@ void cleanup_tests(void)
 {
     EVP_PKEY_free(newkey);
     X509_free(cert);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 }
 
 #define USAGE "new.key server.crt pkcs10.der module_name [module_conf_file]\n"

--- a/test/cmp_protect_test.c
+++ b/test/cmp_protect_test.c
@@ -31,7 +31,7 @@ typedef struct test_fixture {
     int expected;
 } CMP_PROTECT_TEST_FIXTURE;
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *default_null_provider = NULL, *provider = NULL;
 
 static void tear_down(CMP_PROTECT_TEST_FIXTURE *fixture)
@@ -500,7 +500,7 @@ void cleanup_tests(void)
     X509_free(intermediate);
     OSSL_CMP_MSG_free(ir_protected);
     OSSL_CMP_MSG_free(ir_unprotected);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 }
 
 #define USAGE "server.pem IR_protected.der IR_unprotected.der IP_PBM.der " \

--- a/test/cmp_server_test.c
+++ b/test/cmp_server_test.c
@@ -18,7 +18,7 @@ typedef struct test_fixture {
     OSSL_CMP_MSG *req;
 } CMP_SRV_TEST_FIXTURE;
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *default_null_provider = NULL, *provider = NULL;
 static OSSL_CMP_MSG *request = NULL;
 
@@ -123,7 +123,7 @@ void cleanup_tests(void)
     OSSL_CMP_MSG_free(request);
     OSSL_PROVIDER_unload(default_null_provider);
     OSSL_PROVIDER_unload(provider);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     return;
 }
 

--- a/test/cmp_testlib.c
+++ b/test/cmp_testlib.c
@@ -12,7 +12,7 @@
 #include "cmp_testlib.h"
 #include <openssl/rsa.h> /* needed in case config no-deprecated */
 
-EVP_PKEY *load_pem_key(const char *file, OPENSSL_CTX *libctx)
+EVP_PKEY *load_pem_key(const char *file, OSSL_LIB_CTX *libctx)
 {
     EVP_PKEY *key = NULL;
     BIO *bio = NULL;
@@ -27,7 +27,7 @@ EVP_PKEY *load_pem_key(const char *file, OPENSSL_CTX *libctx)
     return key;
 }
 
-X509 *load_pem_cert(const char *file, OPENSSL_CTX *libctx)
+X509 *load_pem_cert(const char *file, OSSL_LIB_CTX *libctx)
 {
     X509 *cert = NULL;
     BIO *bio = NULL;

--- a/test/cmp_testlib.h
+++ b/test/cmp_testlib.h
@@ -23,8 +23,8 @@
 
 # ifndef OPENSSL_NO_CMP
 #  define CMP_TEST_REFVALUE_LENGTH 15 /* arbitrary value */
-EVP_PKEY *load_pem_key(const char *file, OPENSSL_CTX *libctx);
-X509 *load_pem_cert(const char *file, OPENSSL_CTX *libctx);
+EVP_PKEY *load_pem_key(const char *file, OSSL_LIB_CTX *libctx);
+X509 *load_pem_cert(const char *file, OSSL_LIB_CTX *libctx);
 X509_REQ *load_csr(const char *file);
 OSSL_CMP_MSG *load_pkimsg(const char *file);
 int valid_asn1_encoding(const OSSL_CMP_MSG *msg);

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -37,7 +37,7 @@ typedef struct test_fixture {
     int additional_arg;
 } CMP_VFY_TEST_FIXTURE;
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *default_null_provider = NULL, *provider = NULL;
 
 static void tear_down(CMP_VFY_TEST_FIXTURE *fixture)
@@ -549,7 +549,7 @@ void cleanup_tests(void)
     X509_free(instaca_cert);
     OSSL_CMP_MSG_free(ir_unprotected);
     OSSL_CMP_MSG_free(ir_rmprotection);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     return;
 }
 

--- a/test/context_internal_test.c
+++ b/test/context_internal_test.c
@@ -14,7 +14,7 @@
 
 /*
  * Everything between BEGIN EXAMPLE and END EXAMPLE is copied from
- * doc/internal/man3/openssl_ctx_get_data.pod
+ * doc/internal/man3/ossl_lib_ctx_get_data.pod
  */
 
 /*
@@ -27,7 +27,7 @@ typedef struct foo_st {
     void *data;
 } FOO;
 
-static void *foo_new(OPENSSL_CTX *ctx)
+static void *foo_new(OSSL_LIB_CTX *ctx)
 {
     FOO *ptr = OPENSSL_zalloc(sizeof(*ptr));
     if (ptr != NULL)
@@ -38,7 +38,7 @@ static void foo_free(void *ptr)
 {
     OPENSSL_free(ptr);
 }
-static const OPENSSL_CTX_METHOD foo_method = {
+static const OSSL_LIB_CTX_METHOD foo_method = {
     foo_new,
     foo_free
 };
@@ -48,23 +48,23 @@ static const OPENSSL_CTX_METHOD foo_method = {
  * ======================================================================
  */
 
-static int test_context(OPENSSL_CTX *ctx)
+static int test_context(OSSL_LIB_CTX *ctx)
 {
     FOO *data = NULL;
 
-    return TEST_ptr(data = openssl_ctx_get_data(ctx, 0, &foo_method))
+    return TEST_ptr(data = ossl_lib_ctx_get_data(ctx, 0, &foo_method))
         /* OPENSSL_zalloc in foo_new() initialized it to zero */
         && TEST_int_eq(data->i, 42);
 }
 
 static int test_app_context(void)
 {
-    OPENSSL_CTX *ctx = NULL;
+    OSSL_LIB_CTX *ctx = NULL;
     int result =
-        TEST_ptr(ctx = OPENSSL_CTX_new())
+        TEST_ptr(ctx = OSSL_LIB_CTX_new())
         && test_context(ctx);
 
-    OPENSSL_CTX_free(ctx);
+    OSSL_LIB_CTX_free(ctx);
     return result;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -34,7 +34,7 @@
 #include "crypto/evp.h"
 #include "../e_os.h" /* strcasecmp */
 
-static OPENSSL_CTX *testctx = NULL;
+static OSSL_LIB_CTX *testctx = NULL;
 
 /*
  * kExampleRSAKeyDER is an RSA private key in ASN.1, DER format. Of course, you
@@ -478,11 +478,11 @@ static EVP_PKEY *load_example_hmac_key(void)
 
 static int test_EVP_set_default_properties(void)
 {
-    OPENSSL_CTX *ctx;
+    OSSL_LIB_CTX *ctx;
     EVP_MD *md = NULL;
     int res = 0;
 
-    if (!TEST_ptr(ctx = OPENSSL_CTX_new())
+    if (!TEST_ptr(ctx = OSSL_LIB_CTX_new())
             || !TEST_ptr(md = EVP_MD_fetch(ctx, "sha256", NULL)))
         goto err;
     EVP_MD_free(md);
@@ -501,7 +501,7 @@ static int test_EVP_set_default_properties(void)
     res = 1;
 err:
     EVP_MD_free(md);
-    OPENSSL_CTX_free(ctx);
+    OSSL_LIB_CTX_free(ctx);
     return res;
 }
 
@@ -1894,7 +1894,7 @@ static int test_keygen_with_empty_template(int n)
  */
 static int test_pkey_ctx_fail_without_provider(int tst)
 {
-    OPENSSL_CTX *tmpctx = OPENSSL_CTX_new();
+    OSSL_LIB_CTX *tmpctx = OSSL_LIB_CTX_new();
     OSSL_PROVIDER *nullprov = NULL;
     EVP_PKEY_CTX *pctx = NULL;
     const char *keytype = NULL;
@@ -1949,7 +1949,7 @@ static int test_pkey_ctx_fail_without_provider(int tst)
  err:
     EVP_PKEY_CTX_free(pctx);
     OSSL_PROVIDER_unload(nullprov);
-    OPENSSL_CTX_free(tmpctx);
+    OSSL_LIB_CTX_free(tmpctx);
     return ret;
 }
 
@@ -2098,7 +2098,7 @@ err:
 
 int setup_tests(void)
 {
-    testctx = OPENSSL_CTX_new();
+    testctx = OSSL_LIB_CTX_new();
 
     if (!TEST_ptr(testctx))
         return 0;
@@ -2162,5 +2162,5 @@ int setup_tests(void)
 
 void cleanup_tests(void)
 {
-    OPENSSL_CTX_free(testctx);
+    OSSL_LIB_CTX_free(testctx);
 }

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -20,7 +20,7 @@
 #include "testutil.h"
 #include "internal/nelem.h"
 
-static OPENSSL_CTX *mainctx = NULL;
+static OSSL_LIB_CTX *mainctx = NULL;
 static OSSL_PROVIDER *nullprov = NULL;
 
 /*
@@ -214,7 +214,7 @@ static int test_d2i_AutoPrivateKey_ex(int i)
 
 static int test_alternative_default(void)
 {
-    OPENSSL_CTX *oldctx;
+    OSSL_LIB_CTX *oldctx;
     EVP_MD *sha256;
     int ok = 0;
 
@@ -229,7 +229,7 @@ static int test_alternative_default(void)
      * Now we switch to our main library context, and try again.  Since no
      * providers are loaded in this one, it should fall back to the default.
      */
-    if (!TEST_ptr(oldctx = OPENSSL_CTX_set0_default(mainctx))
+    if (!TEST_ptr(oldctx = OSSL_LIB_CTX_set0_default(mainctx))
         || !TEST_ptr(sha256 = EVP_MD_fetch(NULL, "SHA2-256", NULL)))
         goto err;
     EVP_MD_free(sha256);
@@ -239,7 +239,7 @@ static int test_alternative_default(void)
      * Switching back should give us our main library context back, and
      * fetching SHA2-256 should fail again.
      */
-    if (!TEST_ptr_eq(OPENSSL_CTX_set0_default(oldctx), mainctx)
+    if (!TEST_ptr_eq(OSSL_LIB_CTX_set0_default(oldctx), mainctx)
         || !TEST_ptr_null(sha256 = EVP_MD_fetch(NULL, "SHA2-256", NULL)))
         goto err;
 
@@ -272,14 +272,14 @@ static int test_d2i_PrivateKey_ex(void) {
 
 int setup_tests(void)
 {
-    mainctx = OPENSSL_CTX_new();
+    mainctx = OSSL_LIB_CTX_new();
 
     if (!TEST_ptr(mainctx))
         return 0;
 
     nullprov = OSSL_PROVIDER_load(NULL, "null");
     if (!TEST_ptr(nullprov)) {
-        OPENSSL_CTX_free(mainctx);
+        OSSL_LIB_CTX_free(mainctx);
         mainctx = NULL;
         return 0;
     }
@@ -293,6 +293,6 @@ int setup_tests(void)
 
 void cleanup_tests(void)
 {
-    OPENSSL_CTX_free(mainctx);
+    OSSL_LIB_CTX_free(mainctx);
     OSSL_PROVIDER_unload(nullprov);
 }

--- a/test/evp_fetch_prov_test.c
+++ b/test/evp_fetch_prov_test.c
@@ -76,17 +76,17 @@ static int calculate_digest(const EVP_MD *md, const char *msg, size_t len,
     return ret;
 }
 
-static int load_providers(OPENSSL_CTX **libctx, OSSL_PROVIDER *prov[])
+static int load_providers(OSSL_LIB_CTX **libctx, OSSL_PROVIDER *prov[])
 {
-    OPENSSL_CTX *ctx = NULL;
+    OSSL_LIB_CTX *ctx = NULL;
     int ret = 0;
     size_t i;
 
-    ctx = OPENSSL_CTX_new();
+    ctx = OSSL_LIB_CTX_new();
     if (!TEST_ptr(ctx))
         goto err;
 
-    if (!TEST_true(OPENSSL_CTX_load_config(ctx, config_file)))
+    if (!TEST_true(OSSL_LIB_CTX_load_config(ctx, config_file)))
         goto err;
     if (test_get_argument_count() > 2)
         goto err;
@@ -102,7 +102,7 @@ static int load_providers(OPENSSL_CTX **libctx, OSSL_PROVIDER *prov[])
     *libctx = ctx;
 err:
     if (ret == 0)
-        OPENSSL_CTX_free(ctx);
+        OSSL_LIB_CTX_free(ctx);
     return ret;
 }
 
@@ -111,7 +111,7 @@ err:
  */
 static int test_EVP_MD_fetch(void)
 {
-    OPENSSL_CTX *ctx = NULL;
+    OSSL_LIB_CTX *ctx = NULL;
     EVP_MD *md = NULL;
     OSSL_PROVIDER *prov[2] = {NULL, NULL};
     int ret = 0;
@@ -162,7 +162,7 @@ err:
      */
     if (ctx != NULL) {
         OPENSSL_thread_stop_ex(ctx);
-        OPENSSL_CTX_free(ctx);
+        OSSL_LIB_CTX_free(ctx);
     }
     return ret;
 }
@@ -197,7 +197,7 @@ err:
  */
 static int test_EVP_CIPHER_fetch(void)
 {
-    OPENSSL_CTX *ctx = NULL;
+    OSSL_LIB_CTX *ctx = NULL;
     EVP_CIPHER *cipher = NULL;
     OSSL_PROVIDER *prov[2] = {NULL, NULL};
     int ret = 0;
@@ -229,7 +229,7 @@ err:
     EVP_CIPHER_free(cipher);
     OSSL_PROVIDER_unload(prov[0]);
     OSSL_PROVIDER_unload(prov[1]);
-    OPENSSL_CTX_free(ctx);
+    OSSL_LIB_CTX_free(ctx);
     return ret;
 }
 

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -32,7 +32,7 @@
 #include "crypto/bn_dh.h"   /* _bignum_ffdhe2048_p */
 #include "../e_os.h"        /* strcasecmp */
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *nullprov = NULL;
 static OSSL_PROVIDER *libprov = NULL;
 static STACK_OF(OPENSSL_CSTRING) *cipher_names = NULL;
@@ -643,11 +643,11 @@ int setup_tests(void)
     if (!TEST_ptr(nullprov))
         return 0;
 
-    libctx = OPENSSL_CTX_new();
+    libctx = OSSL_LIB_CTX_new();
     if (!TEST_ptr(libctx))
         return 0;
     if (config_file != NULL
-        && !TEST_true(OPENSSL_CTX_load_config(libctx, config_file)))
+        && !TEST_true(OSSL_LIB_CTX_load_config(libctx, config_file)))
         return 0;
 
     libprov = OSSL_PROVIDER_load(libctx, prov_name);
@@ -681,6 +681,6 @@ void cleanup_tests(void)
 {
     sk_OPENSSL_CSTRING_free(cipher_names);
     OSSL_PROVIDER_unload(libprov);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     OSSL_PROVIDER_unload(nullprov);
 }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -73,7 +73,7 @@ typedef enum OPTION_choice {
 } OPTION_CHOICE;
 
 static OSSL_PROVIDER *prov_null = NULL;
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 
 /* List of public and private keys */
 static KEY_LIST *private_keys;
@@ -1842,9 +1842,9 @@ static int pbe_test_run(EVP_TEST *t)
     PBE_DATA *expected = t->data;
     unsigned char *key;
     EVP_MD *fetched_digest = NULL;
-    OPENSSL_CTX *save_libctx;
+    OSSL_LIB_CTX *save_libctx;
 
-    save_libctx = OPENSSL_CTX_set0_default(libctx);
+    save_libctx = OSSL_LIB_CTX_set0_default(libctx);
 
     if (!TEST_ptr(key = OPENSSL_malloc(expected->key_len))) {
         t->err = "INTERNAL_ERROR";
@@ -1890,7 +1890,7 @@ static int pbe_test_run(EVP_TEST *t)
 err:
     EVP_MD_free(fetched_digest);
     OPENSSL_free(key);
-    OPENSSL_CTX_set0_default(save_libctx);
+    OSSL_LIB_CTX_set0_default(save_libctx);
     return 1;
 }
 
@@ -3595,9 +3595,9 @@ int setup_tests(void)
     }
 
     /* load the provider via configuration into the created library context */
-    libctx = OPENSSL_CTX_new();
+    libctx = OSSL_LIB_CTX_new();
     if (libctx == NULL
-        || !OPENSSL_CTX_load_config(libctx, config_file)) {
+        || !OSSL_LIB_CTX_load_config(libctx, config_file)) {
         TEST_error("Failed to load config %s\n", config_file);
         return 0;
     }
@@ -3613,7 +3613,7 @@ int setup_tests(void)
 void cleanup_tests(void)
 {
     OSSL_PROVIDER_unload(prov_null);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 }
 
 #define STR_STARTS_WITH(str, pre) strncasecmp(pre, str, strlen(pre)) == 0

--- a/test/filterprov.c
+++ b/test/filterprov.c
@@ -26,7 +26,7 @@ int filter_provider_set_filter(int operation, const char *name);
 #define MAX_ALG_FILTERS 5
 
 struct filter_prov_globals_st {
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     OSSL_PROVIDER *deflt;
     struct {
         int operation;
@@ -40,7 +40,7 @@ static struct filter_prov_globals_st ourglobals;
 static struct filter_prov_globals_st *get_globals(void)
 {
     /*
-     * Ideally we'd like to store this in the OPENSSL_CTX so that we can have
+     * Ideally we'd like to store this in the OSSL_LIB_CTX so that we can have
      * more than one instance of the filter provider at a time. But for now we
      * just make it simple.
      */
@@ -97,7 +97,7 @@ static void filter_teardown(void *provctx)
     struct filter_prov_globals_st *globs = get_globals();
 
     OSSL_PROVIDER_unload(globs->deflt);
-    OPENSSL_CTX_free(globs->libctx);
+    OSSL_LIB_CTX_free(globs->libctx);
 }
 
 /* Functions we provide to the core */
@@ -116,7 +116,7 @@ int filter_provider_init(const OSSL_CORE_HANDLE *handle,
                          void **provctx)
 {
     memset(&ourglobals, 0, sizeof(ourglobals));
-    ourglobals.libctx = OPENSSL_CTX_new();
+    ourglobals.libctx = OSSL_LIB_CTX_new();
     if (ourglobals.libctx == NULL)
         goto err;
 
@@ -130,7 +130,7 @@ int filter_provider_init(const OSSL_CORE_HANDLE *handle,
 
  err:
     OSSL_PROVIDER_unload(ourglobals.deflt);
-    OPENSSL_CTX_free(ourglobals.libctx);
+    OSSL_LIB_CTX_free(ourglobals.libctx);
     return 0;
 }
 

--- a/test/keymgmt_internal_test.c
+++ b/test/keymgmt_internal_test.c
@@ -21,9 +21,9 @@
 #include "testutil.h"
 
 typedef struct {
-    OPENSSL_CTX *ctx1;
+    OSSL_LIB_CTX *ctx1;
     OSSL_PROVIDER *prov1;
-    OPENSSL_CTX *ctx2;
+    OSSL_LIB_CTX *ctx2;
     OSSL_PROVIDER *prov2;
 } FIXTURE;
 
@@ -32,8 +32,8 @@ static void tear_down(FIXTURE *fixture)
     if (fixture != NULL) {
         OSSL_PROVIDER_unload(fixture->prov1);
         OSSL_PROVIDER_unload(fixture->prov2);
-        OPENSSL_CTX_free(fixture->ctx1);
-        OPENSSL_CTX_free(fixture->ctx2);
+        OSSL_LIB_CTX_free(fixture->ctx1);
+        OSSL_LIB_CTX_free(fixture->ctx2);
         OPENSSL_free(fixture);
     }
 }
@@ -43,10 +43,10 @@ static FIXTURE *set_up(const char *testcase_name)
     FIXTURE *fixture;
 
     if (!TEST_ptr(fixture = OPENSSL_zalloc(sizeof(*fixture)))
-        || !TEST_ptr(fixture->ctx1 = OPENSSL_CTX_new())
+        || !TEST_ptr(fixture->ctx1 = OSSL_LIB_CTX_new())
         || !TEST_ptr(fixture->prov1 = OSSL_PROVIDER_load(fixture->ctx1,
                                                          "default"))
-        || !TEST_ptr(fixture->ctx2 = OPENSSL_CTX_new())
+        || !TEST_ptr(fixture->ctx2 = OSSL_LIB_CTX_new())
         || !TEST_ptr(fixture->prov2 = OSSL_PROVIDER_load(fixture->ctx2,
                                                          "default"))) {
         tear_down(fixture);

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -387,9 +387,9 @@ err:
 static int test_fips_mode(void)
 {
     int ret = 0;
-    OPENSSL_CTX *ctx = NULL;
+    OSSL_LIB_CTX *ctx = NULL;
 
-    if (!TEST_ptr(ctx = OPENSSL_CTX_new()))
+    if (!TEST_ptr(ctx = OSSL_LIB_CTX_new()))
         goto err;
 
     ret = TEST_true(EVP_set_default_properties(ctx, "default=yes,fips=yes"))
@@ -408,7 +408,7 @@ static int test_fips_mode(void)
           && TEST_true(EVP_default_properties_enable_fips(ctx, 0))
           && TEST_false(EVP_default_properties_is_fips_enabled(ctx));
 err:
-    OPENSSL_CTX_free(ctx);
+    OSSL_LIB_CTX_free(ctx);
     return ret;
 }
 

--- a/test/provider_fallback_test.c
+++ b/test/provider_fallback_test.c
@@ -12,7 +12,7 @@
 #include <openssl/evp.h>
 #include "testutil.h"
 
-static int test_provider(OPENSSL_CTX *ctx)
+static int test_provider(OSSL_LIB_CTX *ctx)
 {
     EVP_KEYMGMT *rsameth = NULL;
     const OSSL_PROVIDER *prov = NULL;
@@ -34,16 +34,16 @@ static int test_fallback_provider(void)
 
 static int test_explicit_provider(void)
 {
-    OPENSSL_CTX *ctx = NULL;
+    OSSL_LIB_CTX *ctx = NULL;
     OSSL_PROVIDER *prov = NULL;
     int ok;
 
-    ok = TEST_ptr(ctx = OPENSSL_CTX_new())
+    ok = TEST_ptr(ctx = OSSL_LIB_CTX_new())
         && TEST_ptr(prov = OSSL_PROVIDER_load(ctx, "default"))
         && test_provider(ctx)
         && TEST_true(OSSL_PROVIDER_unload(prov));
 
-    OPENSSL_CTX_free(ctx);
+    OSSL_LIB_CTX_free(ctx);
     return ok;
 }
 

--- a/test/provider_status_test.c
+++ b/test/provider_status_test.c
@@ -28,7 +28,7 @@ struct self_test_arg {
     int count;
 };
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static char *provider_name = NULL;
 static struct self_test_arg self_test_args = { 0 };
 
@@ -170,13 +170,13 @@ int setup_tests(void)
         }
     }
 
-    libctx = OPENSSL_CTX_new();
+    libctx = OSSL_LIB_CTX_new();
     if (libctx == NULL)
         return 0;
     self_test_args.count = 0;
     OSSL_SELF_TEST_set_callback(libctx, self_test_on_load, &self_test_args);
 
-    if (!OPENSSL_CTX_load_config(libctx, config_file)) {
+    if (!OSSL_LIB_CTX_load_config(libctx, config_file)) {
         opt_printf_stderr("Failed to load config\n");
         return 0;
     }

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -21,7 +21,7 @@
 
 static CONF *conf = NULL;
 static OSSL_PROVIDER *defctxnull = NULL, *thisprov = NULL;
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 
 /* Currently the section names are of the form test-<number>, e.g. test-15. */
 #define MAX_TESTCASE_NAME_LENGTH 100
@@ -542,5 +542,5 @@ void cleanup_tests(void)
     NCONF_free(conf);
     OSSL_PROVIDER_unload(defctxnull);
     OSSL_PROVIDER_unload(thisprov);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 }

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -606,7 +606,7 @@ __owur static int parse_expected_client_sign_hash(SSL_TEST_CTX *test_ctx,
 }
 
 __owur static int parse_expected_ca_names(STACK_OF(X509_NAME) **pnames,
-                                          const char *value, OPENSSL_CTX *libctx)
+                                          const char *value, OSSL_LIB_CTX *libctx)
 {
     if (value == NULL)
         return 0;
@@ -718,7 +718,7 @@ static const ssl_test_server_option ssl_test_server_options[] = {
     { "SessionTicketAppData", &parse_server_session_ticket_app_data },
 };
 
-SSL_TEST_CTX *SSL_TEST_CTX_new(OPENSSL_CTX *libctx)
+SSL_TEST_CTX *SSL_TEST_CTX_new(OSSL_LIB_CTX *libctx)
 {
     SSL_TEST_CTX *ret;
 
@@ -837,7 +837,7 @@ static int parse_server_options(SSL_TEST_SERVER_CONF *server, const CONF *conf,
 }
 
 SSL_TEST_CTX *SSL_TEST_CTX_create(const CONF *conf, const char *test_section,
-                                  OPENSSL_CTX *libctx)
+                                  OSSL_LIB_CTX *libctx)
 {
     STACK_OF(CONF_VALUE) *sk_conf = NULL;
     SSL_TEST_CTX *ctx = NULL;

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -606,7 +606,8 @@ __owur static int parse_expected_client_sign_hash(SSL_TEST_CTX *test_ctx,
 }
 
 __owur static int parse_expected_ca_names(STACK_OF(X509_NAME) **pnames,
-                                          const char *value, OSSL_LIB_CTX *libctx)
+                                          const char *value,
+                                          OSSL_LIB_CTX *libctx)
 {
     if (value == NULL)
         return 0;

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -226,7 +226,7 @@ typedef struct {
     /* Expected Session Ticket Application Data */
     char *expected_session_ticket_app_data;
 
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);
@@ -249,9 +249,9 @@ const char *ssl_max_fragment_len_name(int MFL_mode);
  * See test/README.ssltest.md for details on the conf file format.
  */
 SSL_TEST_CTX *SSL_TEST_CTX_create(const CONF *conf, const char *test_section,
-                                  OPENSSL_CTX *libctx);
+                                  OSSL_LIB_CTX *libctx);
 
-SSL_TEST_CTX *SSL_TEST_CTX_new(OPENSSL_CTX *libctx);
+SSL_TEST_CTX *SSL_TEST_CTX_new(OSSL_LIB_CTX *libctx);
 
 void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx);
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -48,7 +48,7 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
                       const OSSL_DISPATCH **out,
                       void **provctx);
 
-static OPENSSL_CTX *libctx = NULL;
+static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *defctxnull = NULL;
 
 #ifndef OPENSSL_NO_TLS1_3
@@ -6565,7 +6565,7 @@ static int int_test_ssl_get_shared_ciphers(int tst, int clnt)
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
     char buf[1024];
-    OPENSSL_CTX *tmplibctx = OPENSSL_CTX_new();
+    OSSL_LIB_CTX *tmplibctx = OSSL_LIB_CTX_new();
 
     if (!TEST_ptr(tmplibctx))
         goto end;
@@ -6630,7 +6630,7 @@ static int int_test_ssl_get_shared_ciphers(int tst, int clnt)
     SSL_free(clientssl);
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
-    OPENSSL_CTX_free(tmplibctx);
+    OSSL_LIB_CTX_free(tmplibctx);
 
     return testresult;
 }
@@ -7824,8 +7824,8 @@ static int test_sigalgs_available(int idx)
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
-    OPENSSL_CTX *tmpctx = OPENSSL_CTX_new();
-    OPENSSL_CTX *clientctx = libctx, *serverctx = libctx;
+    OSSL_LIB_CTX *tmpctx = OSSL_LIB_CTX_new();
+    OSSL_LIB_CTX *clientctx = libctx, *serverctx = libctx;
     OSSL_PROVIDER *filterprov = NULL;
     int sig, hash;
 
@@ -7928,7 +7928,7 @@ static int test_sigalgs_available(int idx)
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     OSSL_PROVIDER_unload(filterprov);
-    OPENSSL_CTX_free(tmpctx);
+    OSSL_LIB_CTX_free(tmpctx);
 
     return testresult;
 }
@@ -8054,7 +8054,7 @@ int setup_tests(void)
     char *modulename;
     char *configfile;
 
-    libctx = OPENSSL_CTX_new();
+    libctx = OSSL_LIB_CTX_new();
     if (!TEST_ptr(libctx))
         return 0;
 
@@ -8080,7 +8080,7 @@ int setup_tests(void)
             || !TEST_ptr(configfile = test_get_argument(4)))
         return 0;
 
-    if (!TEST_true(OPENSSL_CTX_load_config(libctx, configfile)))
+    if (!TEST_true(OSSL_LIB_CTX_load_config(libctx, configfile)))
         return 0;
 
     /* Check we have the expected provider available */
@@ -8272,5 +8272,5 @@ void cleanup_tests(void)
     bio_s_mempacket_test_free();
     bio_s_always_retry_free();
     OSSL_PROVIDER_unload(defctxnull);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 }

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -926,7 +926,7 @@ int main(int argc, char *argv[])
     char *arg = NULL, *argn = NULL;
     const char *provider = NULL, *config = NULL;
     OSSL_PROVIDER *thisprov = NULL, *defctxnull = NULL;
-    OPENSSL_CTX *libctx = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
 
     verbose = 0;
     debug = 0;
@@ -1367,12 +1367,12 @@ int main(int argc, char *argv[])
         defctxnull = OSSL_PROVIDER_load(NULL, "null");
         if (defctxnull == NULL)
             goto end;
-        libctx = OPENSSL_CTX_new();
+        libctx = OSSL_LIB_CTX_new();
         if (libctx == NULL)
             goto end;
 
         if (config != NULL
-                && !OPENSSL_CTX_load_config(libctx, config))
+                && !OSSL_LIB_CTX_load_config(libctx, config))
             goto end;
 
         thisprov = OSSL_PROVIDER_load(libctx, provider);
@@ -1891,7 +1891,7 @@ int main(int argc, char *argv[])
 
     OSSL_PROVIDER_unload(defctxnull);
     OSSL_PROVIDER_unload(thisprov);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
 
     BIO_free(bio_err);
     EXIT(ret);

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -684,7 +684,7 @@ static int always_retry_puts(BIO *bio, const char *str)
     return -1;
 }
 
-int create_ssl_ctx_pair(OPENSSL_CTX *libctx, const SSL_METHOD *sm,
+int create_ssl_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
 const SSL_METHOD *cm,
                         int min_proto_version, int max_proto_version,
                         SSL_CTX **sctx, SSL_CTX **cctx, char *certfile,

--- a/test/ssltestlib.h
+++ b/test/ssltestlib.h
@@ -12,7 +12,7 @@
 
 # include <openssl/ssl.h>
 
-int create_ssl_ctx_pair(OPENSSL_CTX *libctx, const SSL_METHOD *sm,
+int create_ssl_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
                         const SSL_METHOD *cm, int min_proto_version,
                         int max_proto_version, SSL_CTX **sctx, SSL_CTX **cctx,
                         char *certfile, char *privkeyfile);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -205,7 +205,7 @@ size_t test_get_argument_count(void);
  */
 int test_skip_common_options(void);
 
-int test_get_libctx(OPENSSL_CTX **libctx,
+int test_get_libctx(OSSL_LIB_CTX **libctx,
                     OSSL_PROVIDER **default_null_provider,
                     OSSL_PROVIDER **provider, int argn, const char *usage);
 

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -32,7 +32,7 @@ int test_get_libctx(OSSL_LIB_CTX **libctx,
         }
 
         if (config_fname != NULL
-                && !TEST_true(OSSL_LIB_CTX_load_config(*libctx, config_fname))) {
+            && !TEST_true(OSSL_LIB_CTX_load_config(*libctx, config_fname))) {
             TEST_error("Error loading config file %s\n", config_fname);
             goto err;
         }

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -11,7 +11,7 @@
 #include <openssl/provider.h>
 #include <string.h>
 
-int test_get_libctx(OPENSSL_CTX **libctx,
+int test_get_libctx(OSSL_LIB_CTX **libctx,
                     OSSL_PROVIDER **default_null_provider,
                     OSSL_PROVIDER **provider, int argn, const char *usage)
 {
@@ -25,14 +25,14 @@ int test_get_libctx(OPENSSL_CTX **libctx,
         const char *config_fname = test_get_argument(argn + 1);
 
         *default_null_provider = OSSL_PROVIDER_load(NULL, "null");
-        *libctx = OPENSSL_CTX_new();
+        *libctx = OSSL_LIB_CTX_new();
         if (!TEST_ptr(*libctx)) {
             TEST_error("Failed to create libctx\n");
             goto err;
         }
 
         if (config_fname != NULL
-                && !TEST_true(OPENSSL_CTX_load_config(*libctx, config_fname))) {
+                && !TEST_true(OSSL_LIB_CTX_load_config(*libctx, config_fname))) {
             TEST_error("Error loading config file %s\n", config_fname);
             goto err;
         }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -528,7 +528,7 @@ static const OSSL_PARAM *xor_settable_params(void *provctx)
 
 struct xor_gen_ctx {
     int selection;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
 };
 
 static void *xor_gen_init(void *provctx, int selection)
@@ -542,8 +542,8 @@ static void *xor_gen_init(void *provctx, int selection)
     if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL)
         gctx->selection = selection;
 
-    /* Our provctx is really just an OPENSSL_CTX */
-    gctx->libctx = (OPENSSL_CTX *)provctx;
+    /* Our provctx is really just an OSSL_LIB_CTX */
+    gctx->libctx = (OSSL_LIB_CTX *)provctx;
 
     return gctx;
 }
@@ -648,14 +648,14 @@ static const OSSL_ALGORITHM *tls_prov_query(void *provctx, int operation_id,
 
 /* Functions we provide to the core */
 static const OSSL_DISPATCH tls_prov_dispatch_table[] = {
-    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OPENSSL_CTX_free },
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))tls_prov_query },
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES, (void (*)(void))tls_prov_get_capabilities },
     { 0, NULL }
 };
 
 static
-unsigned int randomize_tls_group_id(OPENSSL_CTX *libctx)
+unsigned int randomize_tls_group_id(OSSL_LIB_CTX *libctx)
 {
     /*
      * Randomise the group_id we're going to use to ensure we don't interoperate
@@ -692,7 +692,7 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
                       const OSSL_DISPATCH **out,
                       void **provctx)
 {
-    OPENSSL_CTX *libctx = OPENSSL_CTX_new();
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
 
     *provctx = libctx;
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4444,8 +4444,8 @@ EVP_KDF_derive                          ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_name                            ?	3_0_0	EXIST::FUNCTION:
 EC_GROUP_get0_field                     ?	3_0_0	EXIST::FUNCTION:EC
 CRYPTO_alloc_ex_data                    ?	3_0_0	EXIST::FUNCTION:
-OPENSSL_CTX_new                         ?	3_0_0	EXIST::FUNCTION:
-OPENSSL_CTX_free                        ?	3_0_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_new                        ?	3_0_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_free                       ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_LH_flush                        ?	3_0_0	EXIST::FUNCTION:
 BN_native2bn                            ?	3_0_0	EXIST::FUNCTION:
 BN_bn2nativepad                         ?	3_0_0	EXIST::FUNCTION:
@@ -4970,7 +4970,7 @@ EVP_PKEY_CTX_set1_rsa_keygen_pubexp     ?	3_0_0	EXIST::FUNCTION:RSA
 EVP_PKEY_CTX_set_rsa_keygen_primes      ?	3_0_0	EXIST::FUNCTION:RSA
 NCONF_new_ex                            ?	3_0_0	EXIST::FUNCTION:
 CONF_modules_load_file_ex               ?	3_0_0	EXIST::FUNCTION:
-OPENSSL_CTX_load_config                 ?	3_0_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_load_config                ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_to_param                 ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_free_params              ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_int                 ?	3_0_0	EXIST::FUNCTION:
@@ -5100,7 +5100,7 @@ OSSL_PROVIDER_get_capabilities          ?	3_0_0	EXIST::FUNCTION:
 EC_GROUP_new_by_curve_name_ex           ?	3_0_0	EXIST::FUNCTION:EC
 EC_KEY_new_ex                           ?	3_0_0	EXIST::FUNCTION:EC
 EC_KEY_new_by_curve_name_ex             ?	3_0_0	EXIST::FUNCTION:EC
-OPENSSL_CTX_set0_default                ?	3_0_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_set0_default               ?	3_0_0	EXIST::FUNCTION:
 PEM_X509_INFO_read_bio_ex               ?	3_0_0	EXIST::FUNCTION:
 PEM_X509_INFO_read_ex                   ?	3_0_0	EXIST::FUNCTION:STDIO
 X509_REQ_verify_ex                      ?	3_0_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -39,7 +39,7 @@ EVP_RAND                                datatype
 EVP_RAND_CTX                            datatype
 GEN_SESSION_CB                          datatype
 OPENSSL_Applink                         external
-OPENSSL_CTX                             datatype
+OSSL_LIB_CTX                            datatype
 NAMING_AUTHORITY                        datatype
 OSSL_DECODER                            datatype
 OSSL_DECODER_CTX                        datatype


### PR DESCRIPTION
OpenSSL 3.0 introduces a lot of new type names starting with the OSSL_ prefix, e.g.

    OSSL_CALLBACK, OSSL_PARAM, OSSL_ALGORITHM, OSSL_SERIALIZER, OSSL_DESERIALIZER, ...

In my opinion, the OPENSSL_CTX type deviates from this nice consistent naming scheme and should be renamed to OSSL_CONTEXT. (If you prefer brevity, an alternative name would be to rename it to OSSL_CTX, but that's only my second best choice.)


Changing the OPENSSL_CTX prefix affects many locations, but except for util/libcrypto.num and util/other.syms (which are treated specially), the change does not break indentation. You might also fear a lot of merge conflicts and think this might be a problem shortly before the beta1 release.

For that reason this change is fully automated by a script which is rerunnable. In fact, the bulk changes are four lines of bash code (see end of script). The idea is to run the script and merge the pull request as last commit, _after_ all other commits for beta1 have been merged, and before the usual release commits.

~~I opened two draft pull requests as proof-of-concept, this one here renames the prefix to OSSL_CONTEXT, the other one (#12622) renames it to OSSL_CTX.~~

~~@openssl/otc, please let me know if you would accept such a renaming and which prefix you would prefer. In that case I would amend this PoC script with a more detailed commit message and NEWS and CHANGES entries, all fully automated.~~



