### PR TITLE
Fix DSA/DH so that legacy keys can still be generated by the default provider

### DIFF
--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -117,6 +117,14 @@ void ffc_params_set_flags(FFC_PARAMS *params, unsigned int flags)
     params->flags = flags;
 }
 
+void ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags, int enable)
+{
+    if (enable)
+        params->flags |= flags;
+    else
+        params->flags &= ~flags;
+}
+
 int ffc_set_digest(FFC_PARAMS *params, const char *alg, const char *props)
 {
     params->mdname = alg;

--- a/crypto/ffc/ffc_params_validate.c
+++ b/crypto/ffc/ffc_params_validate.c
@@ -66,7 +66,7 @@ int ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
 {
     size_t L, N;
 
-    if (params->p == NULL || params->q == NULL) {
+    if (params == NULL || params->p == NULL || params->q == NULL) {
         *res = FFC_CHECK_INVALID_PQ;
         return FFC_PARAM_RET_STATUS_FAILED;
     }
@@ -99,7 +99,12 @@ int ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params, int type
     params->flags = FFC_PARAM_FLAG_VALIDATE_G;
     params->gindex = FFC_UNVERIFIABLE_GINDEX;
 
-    ret = ffc_params_FIPS186_4_validate(libctx, params, type, &res, NULL);
+#ifndef FIPS_MODULE
+    if (save_flags & FFC_PARAM_FLAG_VALIDATE_LEGACY)
+        ret = ffc_params_FIPS186_2_validate(libctx, params, type, &res, NULL);
+    else
+#endif
+        ret = ffc_params_FIPS186_4_validate(libctx, params, type, &res, NULL);
     params->flags = save_flags;
     params->gindex = save_gindex;
     return ret != FFC_PARAM_RET_STATUS_FAILED;

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -39,10 +39,11 @@
 #define FFC_PARAM_RET_STATUS_UNVERIFIABLE_G 2
 
 /* Validation flags */
-# define FFC_PARAM_FLAG_VALIDATE_PQ  0x01
-# define FFC_PARAM_FLAG_VALIDATE_G   0x02
+# define FFC_PARAM_FLAG_VALIDATE_PQ    0x01
+# define FFC_PARAM_FLAG_VALIDATE_G     0x02
 # define FFC_PARAM_FLAG_VALIDATE_ALL                                           \
     (FFC_PARAM_FLAG_VALIDATE_PQ | FFC_PARAM_FLAG_VALIDATE_G)
+#define FFC_PARAM_FLAG_VALIDATE_LEGACY 0x04
 
 /*
  * NB: These values must align with the equivalently named macros in
@@ -124,6 +125,7 @@ void ffc_params_set_gindex(FFC_PARAMS *params, int index);
 void ffc_params_set_pcounter(FFC_PARAMS *params, int index);
 void ffc_params_set_h(FFC_PARAMS *params, int index);
 void ffc_params_set_flags(FFC_PARAMS *params, unsigned int flags);
+void ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags, int enable);
 int ffc_set_digest(FFC_PARAMS *params, const char *alg, const char *props);
 
 int ffc_params_set_validate_params(FFC_PARAMS *params,

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -621,6 +621,8 @@ static void *dh_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
             goto end;
         if (gctx->priv_len > 0)
             DH_set_length(dh, (long)gctx->priv_len);
+        ffc_params_enable_flags(ffc, FFC_PARAM_FLAG_VALIDATE_LEGACY,
+                                gctx->gen_type == DH_PARAMGEN_TYPE_FIPS_186_2);
         if (DH_generate_key(dh) <= 0)
             goto end;
     }

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -529,6 +529,8 @@ static void *dsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
                                          gencb) <= 0)
              goto end;
     }
+    ffc_params_enable_flags(ffc, FFC_PARAM_FLAG_VALIDATE_LEGACY,
+                            gctx->gen_type == DSA_PARAMGEN_TYPE_FIPS_186_2);
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
         if (ffc->p == NULL
             || ffc->q == NULL

--- a/test/recipes/15-test_gendsa.t
+++ b/test/recipes/15-test_gendsa.t
@@ -19,7 +19,7 @@ setup("test_gendsa");
 plan skip_all => "This test is unsupported in a no-dsa build"
     if disabled("dsa");
 
-plan tests => 8;
+plan tests => 10;
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DSA',
@@ -39,6 +39,13 @@ ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-pkeyopt', 'type:fips186_2',
              '-text'])),
    "genpkey DSA params fips186_2");
+
+ok(run(app([ 'openssl', 'genpkey', '-genparam',
+             '-algorithm', 'DSA',
+             '-pkeyopt', 'type:fips186_2',
+             '-pkeyopt', 'dsa_paramgen_bits:1024',
+             '-out', 'dsagen.legacy.pem'])),
+   "genpkey DSA params fips186_2 PEM");
 
 ok(!run(app([ 'openssl', 'genpkey', '-algorithm', 'DSA',
              '-pkeyopt', 'type:group',
@@ -61,6 +68,12 @@ ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-outform', 'DER',
              '-out', 'dsagen.der'])),
    "genpkey DSA params fips186_4 DER");
+
+ok(run(app([ 'openssl', 'genpkey',
+             '-paramfile', 'dsagen.legacy.pem',
+             '-pkeyopt', 'type:fips186_2',
+             '-text'])),
+   "genpkey DSA fips186_2 with PEM params");
 
 # The seed and counter should be the ones generated from the param generation
 # Just put some dummy ones in to show it works.


### PR DESCRIPTION
Fixes #12589

The 'type' parameter needed to be propagated to the ffc params during keygen,
so that the simple validation of params done during keygen can handle legacy keys for the default provider.
The fips provider ignores this change and only allows fips186-4 approved sizes.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
