### PR TITLE
Appease -Werror=stringop-overflow=

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -22,7 +22,7 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
     EVP_MD_CTX *s1;
     unsigned char buf[16], smd[SHA_DIGEST_LENGTH];
     unsigned char c = 'A';
-    unsigned int i, j, k;
+    unsigned int i, k;
     int ret = 0;
 
 #ifdef CHARSET_EBCDIC
@@ -47,8 +47,7 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
             goto err;
         }
 
-        for (j = 0; j < k; j++)
-            buf[j] = c;
+        memset(buf, c, k);
         c++;
         if (!EVP_DigestInit_ex(s1, sha1, NULL)
             || !EVP_DigestUpdate(s1, buf, k)


### PR DESCRIPTION
gcc 10 seems to think of assigning to an (unsigned) char array
as a stringop and demands additional space for a
terminating '\0':

```
In function 'ssl3_generate_key_block',
    inlined from 'ssl3_setup_key_block' at ssl/s3_enc.c:304:11:
ssl/s3_enc.c:51:20: error: writing 1 byte into a region of size 0
[-Werror=stringop-overflow=]
   51 |             buf[j] = c;
      |             ~~~~~~~^~~
ssl/s3_enc.c: In function 'ssl3_setup_key_block':
ssl/s3_enc.c:23:19: note: at offset 16 to object 'buf' with size 16
declared here
   23 |     unsigned char buf[16], smd[SHA_DIGEST_LENGTH];
      |                   ^~~
```
