### PR TITLE
Remove needless #ifndef OPENSSL_NO_SOCK for X509_{CRL_}load_http

### DIFF
--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -126,7 +126,6 @@ int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx)
                               &x->sig_alg, &x->signature, &x->cert_info, ctx);
 }
 
-#if !defined(OPENSSL_NO_SOCK)
 static ASN1_VALUE *simple_get_asn1(const char *url, BIO *bio, BIO *rbio,
                                    int timeout, const ASN1_ITEM *it)
 {
@@ -142,7 +141,6 @@ X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout)
     return (X509 *)simple_get_asn1(url, bio, rbio, timeout,
                                    ASN1_ITEM_rptr(X509));
 }
-#endif
 
 int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
@@ -172,13 +170,11 @@ int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx)
                               &x->crl, ctx);
 }
 
-#if !defined(OPENSSL_NO_SOCK)
 X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout)
 {
     return (X509_CRL *)simple_get_asn1(url, bio, rbio, timeout,
                                        ASN1_ITEM_rptr(X509_CRL));
 }
-#endif
 
 int NETSCAPE_SPKI_sign(NETSCAPE_SPKI *x, EVP_PKEY *pkey, const EVP_MD *md)
 {

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -383,12 +383,10 @@ int X509_REQ_digest(const X509_REQ *data, const EVP_MD *type,
 int X509_NAME_digest(const X509_NAME *data, const EVP_MD *type,
                      unsigned char *md, unsigned int *len);
 
-# if !defined(OPENSSL_NO_SOCK)
 X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
-#  define X509_http_nbio(url) X509_load_http(url, NULL, NULL, 0)
+# define X509_http_nbio(url) X509_load_http(url, NULL, NULL, 0)
 X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
-#  define X509_CRL_http_nbio(url) X509_CRL_load_http(url, NULL,  NULL, 0)
-# endif
+# define X509_CRL_http_nbio(url) X509_CRL_load_http(url, NULL,  NULL, 0)
 
 # ifndef OPENSSL_NO_STDIO
 X509 *d2i_X509_fp(FILE *fp, X509 **x509);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -245,7 +245,7 @@ RSA_get_ex_data                         249	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 EVP_PKEY_meth_get_decrypt               250	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 DES_cfb_encrypt                         251	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 CMS_SignerInfo_set1_signer_cert         252	3_0_0	EXIST::FUNCTION:CMS
-X509_CRL_load_http                      253	3_0_0	EXIST::FUNCTION:SOCK
+X509_CRL_load_http                      253	3_0_0	EXIST::FUNCTION:
 ENGINE_register_all_ciphers             254	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 SXNET_new                               255	3_0_0	EXIST::FUNCTION:
 EVP_camellia_256_ctr                    256	3_0_0	EXIST::FUNCTION:CAMELLIA
@@ -1243,7 +1243,7 @@ TS_REQ_set_cert_req                     1271	3_0_0	EXIST::FUNCTION:TS
 TXT_DB_get_by_index                     1272	3_0_0	EXIST::FUNCTION:
 X509_check_ca                           1273	3_0_0	EXIST::FUNCTION:
 DH_get_2048_224                         1274	3_0_0	EXIST::FUNCTION:DH
-X509_load_http                          1275	3_0_0	EXIST::FUNCTION:SOCK
+X509_load_http                          1275	3_0_0	EXIST::FUNCTION:
 i2d_AUTHORITY_INFO_ACCESS               1276	3_0_0	EXIST::FUNCTION:
 EVP_get_cipherbyname                    1277	3_0_0	EXIST::FUNCTION:
 CONF_dump_fp                            1278	3_0_0	EXIST::FUNCTION:STDIO


### PR DESCRIPTION
It turned out that `#ifndef OPENSSL_NO_SOCK` is no more needed for `X509_{CRL_}load_http()`.