### PR TITLE
Fix mem leaks on PKCS#12 read error in PKCS12_key_gen_{asc,utf8}

### DIFF
--- a/crypto/pkcs12/p12_key.c
+++ b/crypto/pkcs12/p12_key.c
@@ -33,10 +33,8 @@ int PKCS12_key_gen_asc(const char *pass, int passlen, unsigned char *salt,
     }
     ret = PKCS12_key_gen_uni(unipass, uniplen, salt, saltlen,
                              id, iter, n, out, md_type);
-    if (ret <= 0)
-        return 0;
     OPENSSL_clear_free(unipass, uniplen);
-    return ret;
+    return ret > 0;
 }
 
 int PKCS12_key_gen_utf8(const char *pass, int passlen, unsigned char *salt,
@@ -56,10 +54,8 @@ int PKCS12_key_gen_utf8(const char *pass, int passlen, unsigned char *salt,
     }
     ret = PKCS12_key_gen_uni(unipass, uniplen, salt, saltlen,
                              id, iter, n, out, md_type);
-    if (ret <= 0)
-        return 0;
     OPENSSL_clear_free(unipass, uniplen);
-    return ret;
+    return ret > 0;
 }
 
 int PKCS12_key_gen_uni(unsigned char *pass, int passlen, unsigned char *salt,


### PR DESCRIPTION
Fixes a leak in each of `PKCS12_key_gen_{asc,utf8}`
~~and a potential leak on multiple iterations within `file_load()` of `loader_file.c`~~.