### PR TITLE
Fix no-cms build errors.

### DIFF
--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -60,7 +60,7 @@ err:
     return ret;
 }
 
-#if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_CMS)
+#if !defined(FIPS_MODULE)
 int DH_KDF_X9_42(unsigned char *out, size_t outlen,
                  const unsigned char *Z, size_t Zlen,
                  ASN1_OBJECT *key_oid,
@@ -81,4 +81,4 @@ int DH_KDF_X9_42(unsigned char *out, size_t outlen,
     return dh_KDF_X9_42_asn1(out, outlen, Z, Zlen, key_alg,
                              ukm, ukmlen, md, libctx, NULL);
 }
-#endif /* !defined(FIPS_MODULE) && !defined(OPENSSL_NO_CMS) */
+#endif /* !defined(FIPS_MODULE) */

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -172,11 +172,7 @@ static int pkey_dh_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     case EVP_PKEY_CTRL_DH_KDF_TYPE:
         if (p1 == -2)
             return dctx->kdf_type;
-#ifdef OPENSSL_NO_CMS
-        if (p1 != EVP_PKEY_DH_KDF_NONE)
-#else
         if (p1 != EVP_PKEY_DH_KDF_NONE && p1 != EVP_PKEY_DH_KDF_X9_42)
-#endif
             return -2;
         dctx->kdf_type = p1;
         return 1;
@@ -445,7 +441,6 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
         *keylen = ret;
         return 1;
     }
-#ifndef OPENSSL_NO_CMS
     else if (dctx->kdf_type == EVP_PKEY_DH_KDF_X9_42) {
 
         unsigned char *Z = NULL;
@@ -475,7 +470,6 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
         OPENSSL_clear_free(Z, Zlen);
         return ret;
     }
-#endif
     return 0;
 }
 

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -202,14 +202,12 @@ DH *DH_get_2048_256(void);
 DH *DH_new_by_nid(int nid);
 DEPRECATEDIN_3_0(int DH_get_nid(const DH *dh))
 
-#  ifndef OPENSSL_NO_CMS
 /* RFC2631 KDF */
 DEPRECATEDIN_3_0(int DH_KDF_X9_42(unsigned char *out, size_t outlen,
                                   const unsigned char *Z, size_t Zlen,
                                   ASN1_OBJECT *key_oid,
                                   const unsigned char *ukm,
                                   size_t ukmlen, const EVP_MD *md))
-#  endif
 
 void DH_get0_pqg(const DH *dh,
                  const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);
@@ -316,9 +314,7 @@ int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 
 /* KDF types */
 #  define EVP_PKEY_DH_KDF_NONE                            1
-#  ifndef OPENSSL_NO_CMS
-#   define EVP_PKEY_DH_KDF_X9_42                          2
-#  endif
+#  define EVP_PKEY_DH_KDF_X9_42                           2
 
 #  ifdef  __cplusplus
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2939,7 +2939,7 @@ TS_RESP_CTX_set_status_info             3001	3_0_0	EXIST::FUNCTION:TS
 BIO_f_nbio_test                         3002	3_0_0	EXIST::FUNCTION:
 SEED_ofb128_encrypt                     3003	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 d2i_RSAPrivateKey_bio                   3004	3_0_0	EXIST::FUNCTION:RSA
-DH_KDF_X9_42                            3005	3_0_0	EXIST::FUNCTION:CMS,DEPRECATEDIN_3_0,DH
+DH_KDF_X9_42                            3005	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DH
 EVP_PKEY_meth_set_signctx               3006	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_CRL_get_version                    3007	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_get0_info                 3008	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0


### PR DESCRIPTION
The X942-KDF is now indepedent of the CMS code (since it no longer uses CMS_SharedInfo_encode).
Any code related to EVP_PKEY_DH_KDF_X9_42 needs to not be wrapped by !defined(OPENSSL_NO_CMS).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
