### PR TITLE
apps/pkcs12.c: Add -untrusted option and improve option documentation

### DIFF
--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -13,6 +13,7 @@ B<openssl> B<pkcs12>
 [B<-chain>]
 [B<-inkey> I<file_or_id>]
 [B<-certfile> I<filename>]
+[B<-untrusted> I<filename>]
 [B<-passcerts> I<arg>]
 [B<-name> I<name>]
 [B<-caname> I<name>]
@@ -73,8 +74,9 @@ programs including Netscape, MSIE and MS Outlook.
 =head1 OPTIONS
 
 There are a lot of options the meaning of some depends of whether a PKCS#12 file
-is being created or parsed. By default a PKCS#12 file is parsed. A PKCS#12
-file can be created by using the B<-export> option (see below).
+is being created or parsed. By default a PKCS#12 file is parsed.
+A PKCS#12 file can be created by using the B<-export> option (see below).
+Many further options such as B<-chain> make sense only with B<-export>.
 
 =head1 PARSING OPTIONS
 
@@ -86,10 +88,10 @@ Print out a usage message.
 
 =item B<-in> I<filename>
 
-This specifies filename or URI of the PKCS#12 file to be parsed.
-With B<-export>, this refers to the the certificate and/or key input,
-which can be in PEM, DER, or PKCS#12 format.
+This specifies the input filename or URI.
 Standard input is used by default.
+Without the B<-export> option this is a PKCS#12 file to be parsed.
+With the B<-export> option this is a file with certificates and possibly a key.
 
 =item B<-out> I<filename>
 
@@ -103,8 +105,8 @@ otherwise it is equivalent to B<-passin>.
 
 =item B<-noout>
 
-This option inhibits output of the keys and certificates to the output file
-version of the PKCS#12 file.
+This option inhibits credentials output,
+and so the PKCS#12 input is just verified.
 
 =item B<-clcerts>
 
@@ -206,8 +208,8 @@ certificates are present they will also be included in the PKCS#12 file.
 
 =item B<-inkey> I<file_or_id>
 
-File to read private key from. If not present then a private key must be present
-in the input file.
+File to read private key from for PKCS12 output.
+If not present then the input file (B<-in> argument) must contain a private key.
 If no engine is used, the argument is taken as a file; if an engine is
 specified, the argument is given to the engine as a key identifier.
 
@@ -218,8 +220,15 @@ name is typically displayed in list boxes by software importing the file.
 
 =item B<-certfile> I<filename>
 
-A filename or URI to read additional certificates from.
-The file can be in PEM, DER, or PKCS#12 format.
+An input file with extra certificates to be added to the PKCS12 output
+if the B<-export> option is given.
+
+=item B<-untrusted> I<filename>
+
+An input file of untrusted certificates that may be used
+for chain building, which is relevant only when a PKCS#12 file is created
+with the B<-export> option and the B<-chain> option is given as well.
+Any certificates that are actually part of the chain are added to the output.
 
 =item B<-passcerts> I<arg>
 
@@ -243,9 +252,12 @@ see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-chain>
 
-If this option is present then an attempt is made to include the entire
-certificate chain of the user certificate. The standard CA store is used
-for this search. If the search fails it is considered a fatal error.
+If this option is present then the certificate chain of the end entity
+certificate is built and included in the PKCS#12 output file.
+The end entity certificate is the first one read from the B<-in> file
+if no key is given, else the first certificate matching the given key.
+The standard CA trust store is used for chain building,
+as well as any untrusted CA certificates given with the B<-untrusted> option.
 
 =item B<-descert>
 
@@ -404,7 +416,7 @@ L<ossl_store-file(7)>
 =head1 HISTORY
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
-The <-nodes> option was deprecated in OpenSSL 3.0, too; use B<-noenc> instead.
+The B<-nodes> option was deprecated in OpenSSL 3.0, too; use B<-noenc> instead.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_add_cert.pod
+++ b/doc/man3/X509_add_cert.pod
@@ -19,6 +19,9 @@ X509_add_cert() adds a certificate I<cert> to the given list I<sk>.
 
 X509_add_certs() adds a list of certificate I<certs> to the given list I<sk>.
 The I<certs> argument may be NULL, which implies no effect.
+It does not modify the list I<certs> but
+in case the B<X509_ADD_FLAG_UP_REF> flag (described below) is set
+the reference counters of those of its members added to I<sk> are increased.
 
 Both these functions have a I<flags> parameter,
 which is used to control details of the operation.
@@ -41,6 +44,15 @@ which is determined using L<X509_self_signed(3)>, are ignored.
 =head1 RETURN VALUES
 
 Both functions return 1 for success and 0 for failure.
+
+=head1 NOTES
+
+If X509_add_certs() is used with the flags B<X509_ADD_FLAG_NO_DUP> or
+B<X509_ADD_FLAG_NO_SS> it is advisable to use also B<X509_ADD_FLAG_UP_REF>
+because otherwise likely not for all members of the I<certs> list
+the ownership is transferred to the list of certificates I<sk>.
+
+Care should also be taken in case the I<certs> argument equals I<sk>.
 
 =head1 SEE ALSO
 

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -57,7 +57,7 @@ if (eval { require Win32::API; 1; }) {
 }
 $ENV{OPENSSL_WIN32_UTF8}=1;
 
-plan tests => 4;
+plan tests => 5;
 
 # Test different PKCS#12 formats
 ok(run(test(["pkcs12_format_test"])), "test pkcs12 formats");
@@ -70,6 +70,14 @@ ok(run(app(["openssl", "pkcs12", "-noout",
 
 my @path = qw(test certs);
 my $tmpfile = "tmp.p12";
+
+# Test the -chain option with -untrusted
+ok(run(app(["openssl", "pkcs12", "-export", "-chain",
+            "-CAfile",  srctop_file(@path,  "sroot-cert.pem"),
+            "-untrusted", srctop_file(@path, "ca-cert.pem"),
+            "-in", srctop_file(@path, "ee-cert.pem"),
+            "-nokeys", "-passout", "pass:", "-out", $tmpfile])),
+   "test_pkcs12_chain_untrusted");
 
 # Test the -passcerts option
 ok(run(app(["openssl", "pkcs12", "-export",


### PR DESCRIPTION
This PR adds the option `-untrusted` to the PKCS#12 app and 
improves the user guidance for various options both in the app and the man page.

So far, lists of certificates to be used for chain building (with the  `-chain` option)
could be done only by adding them along with trusted certs (via, e.g., the `-CAfile` option).
This is not only inconvenient but also inadequate: they should not be trusted
but used only as candidates for intermediate CA certs as far as needed for building the chain.

In analogy of the `-untrusted` option of the verify app,
the new `-untrusted` option offers the possibility to provide intermediate CA certs in a separate file
and passes them (rather than NULL) to `X509_STORE_CTX_init()`.

I also improved the handling of end entity certs (in particular with the `-nokeys` option),
made some error messages more informative, added many warnings on inconsistent option use,
and clarified the use of various options in the app help output and documentation.

- [x] documentation is added or updated
- [x] tests are added or updated