### PR TITLE
OSSL_STORE file_load_try_decode(): Avoid flooding error queue by failed parsing attempts

### DIFF
--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -480,6 +480,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
                         || ameth2->pkey_flags & ASN1_PKEY_ALIAS)
                         continue;
 
+                    ERR_set_mark(); /* prevent flooding error queue */
                     tmp_pkey =
                         d2i_PrivateKey_ex(ameth2->pkey_id, NULL,
                                           &tmp_blob, len, libctx, propq);
@@ -490,6 +491,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
                             pkey = tmp_pkey;
                         (*matchcount)++;
                     }
+                    ERR_pop_to_mark();
                 }
             }
             curengine = ENGINE_get_next(curengine);
@@ -504,6 +506,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
             if (ameth->pkey_flags & ASN1_PKEY_ALIAS)
                 continue;
 
+            ERR_set_mark(); /* prevent flooding error queue */
             tmp_pkey = d2i_PrivateKey_ex(ameth->pkey_id, NULL, &tmp_blob, len,
                                          libctx, propq);
             if (tmp_pkey != NULL) {
@@ -513,6 +516,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
                     pkey = tmp_pkey;
                 (*matchcount)++;
             }
+            ERR_pop_to_mark();
         }
 
         if (*matchcount > 1) {
@@ -625,6 +629,8 @@ static OSSL_STORE_INFO *try_decode_params(const char *pem_name,
             if (ameth->pkey_flags & ASN1_PKEY_ALIAS)
                 continue;
 
+            ERR_set_mark(); /* prevent flooding error queue */
+
             if (EVP_PKEY_set_type(tmp_pkey, ameth->pkey_id)
                 && (ameth = EVP_PKEY_get0_asn1(tmp_pkey)) != NULL
                 && ameth->param_decode != NULL
@@ -636,6 +642,7 @@ static OSSL_STORE_INFO *try_decode_params(const char *pem_name,
                 tmp_pkey = NULL;
                 (*matchcount)++;
             }
+            ERR_pop_to_mark();
         }
 
         EVP_PKEY_free(tmp_pkey);
@@ -936,8 +943,7 @@ static OSSL_STORE_LOADER_CTX *file_open_with_libctx
         return NULL;
     }
 
-    /* Successfully found a working path, clear possible collected errors */
-    ERR_clear_error();
+    /* Successfully found a working path */
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx == NULL) {
@@ -1124,11 +1130,22 @@ static OSSL_STORE_INFO *file_load_try_decode(OSSL_STORE_LOADER_CTX *ctx,
             const FILE_HANDLER *handler = file_handlers[i];
             int try_matchcount = 0;
             void *tmp_handler_ctx = NULL;
-            OSSL_STORE_INFO *tmp_result =
+            OSSL_STORE_INFO *tmp_result;
+            unsigned long err;
+
+            ERR_set_mark();
+            tmp_result =
                 handler->try_decode(pem_name, pem_header, data, len,
                                     &tmp_handler_ctx, &try_matchcount,
                                     ui_method, ui_data, ctx->uri,
                                     ctx->libctx, ctx->propq);
+            /* avoid flooding error queue with low-level ASN.1 parse errors */
+            err = ERR_peek_last_error();
+            if (ERR_GET_LIB(err) == ERR_LIB_ASN1
+                    && ERR_GET_REASON(err) == ERR_R_NESTED_ASN1_ERROR)
+                ERR_pop_to_mark();
+            else
+                ERR_clear_last_mark();
 
             if (try_matchcount > 0) {
 
@@ -1176,9 +1193,6 @@ static OSSL_STORE_INFO *file_load_try_decode(OSSL_STORE_LOADER_CTX *ctx,
         result = NULL;
         goto again;
     }
-
-    if (result != NULL)
-        ERR_clear_error();
 
     return result;
 }
@@ -1448,7 +1462,6 @@ static OSSL_STORE_INFO *file_load(OSSL_STORE_LOADER_CTX *ctx,
     OSSL_STORE_INFO *result = NULL;
 
     ctx->errcnt = 0;
-    ERR_clear_error();
 
     if (ctx->type == is_dir) {
         do {


### PR DESCRIPTION
When loading credentials form a file, the OSSL_STORE implementation sequentially tries a large (nested) list of possible types and formats.
This typically leads to overflow of the error queue due many failed attempts parsing the input.
Moreover, those spurious errors tend to hide the real cause of a load failure.

For instance, when loading an encrypted key from a PKCS#12 file using a wrong password, the queue output will look like this:
```
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:630:Field=pkey, Type=PKCS8_PRIV_KEY_INFO
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):wrong tag:crypto/asn1/tasn_dec.c:1135:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:698:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:630:Field=pkey, Type=PKCS8_PRIV_KEY_INFO
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):wrong tag:crypto/asn1/tasn_dec.c:1135:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:698:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:630:Field=pkey, Type=PKCS8_PRIV_KEY_INFO
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):ASN1 lib:crypto/asn1/d2i_pr.c:67:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):ASN1 lib:crypto/asn1/d2i_pr.c:67:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):wrong tag:crypto/asn1/tasn_dec.c:1135:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:698:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:630:Field=pkey, Type=PKCS8_PRIV_KEY_INFO
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):wrong tag:crypto/asn1/tasn_dec.c:1135:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:698:
C0F751C4AD7F0000:error::asn1 encoding routines:(unknown function):nested asn1 error:crypto/asn1/tasn_dec.c:630:Field=pkey, Type=PKCS8_PRIV_KEY_INFO
```
which is useless.

It took me a while to trace down why this happens, but meanwhile I've found a good way of fixing it:
for all (even nested) retry loops, mark the current state of the error queue and after a failed attempt restore the previous state of the queue if the error was a parse error (likely because an unsuitable type/format has been tried).

With this fix, the queue output when loading an encrypted key from a PKCS#12 file using a wrong password becomes
```
C0B7C909767F0000:error::STORE routines:(unknown function):error verifying pkcs12 mac:crypto/store/loader_file.c:251:
```
which contains relevant information only.