### PR TITLE
OCSP: Add return value checks.

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2678,6 +2678,8 @@ OBJ_R_UNKNOWN_NID:101:unknown nid
 OBJ_R_UNKNOWN_OBJECT_NAME:103:unknown object name
 OCSP_R_CERTIFICATE_VERIFY_ERROR:101:certificate verify error
 OCSP_R_DIGEST_ERR:102:digest err
+OCSP_R_DIGEST_NAME_ERR:106:digest name err
+OCSP_R_DIGEST_SIZE_ERR:107:digest size err
 OCSP_R_ERROR_IN_NEXTUPDATE_FIELD:122:error in nextupdate field
 OCSP_R_ERROR_IN_THISUPDATE_FIELD:123:error in thisupdate field
 OCSP_R_MISSING_OCSPSIGNING_USAGE:103:missing ocspsigning usage

--- a/crypto/ocsp/ocsp_err.c
+++ b/crypto/ocsp/ocsp_err.c
@@ -17,6 +17,8 @@ static const ERR_STRING_DATA OCSP_str_reasons[] = {
     {ERR_PACK(ERR_LIB_OCSP, 0, OCSP_R_CERTIFICATE_VERIFY_ERROR),
     "certificate verify error"},
     {ERR_PACK(ERR_LIB_OCSP, 0, OCSP_R_DIGEST_ERR), "digest err"},
+    {ERR_PACK(ERR_LIB_OCSP, 0, OCSP_R_DIGEST_NAME_ERR), "digest name err"},
+    {ERR_PACK(ERR_LIB_OCSP, 0, OCSP_R_DIGEST_SIZE_ERR), "digest size err"},
     {ERR_PACK(ERR_LIB_OCSP, 0, OCSP_R_ERROR_IN_NEXTUPDATE_FIELD),
     "error in nextupdate field"},
     {ERR_PACK(ERR_LIB_OCSP, 0, OCSP_R_ERROR_IN_THISUPDATE_FIELD),

--- a/include/openssl/ocsperr.h
+++ b/include/openssl/ocsperr.h
@@ -50,6 +50,8 @@ int ERR_load_OCSP_strings(void);
  */
 #  define OCSP_R_CERTIFICATE_VERIFY_ERROR                  101
 #  define OCSP_R_DIGEST_ERR                                102
+#  define OCSP_R_DIGEST_NAME_ERR                           106
+#  define OCSP_R_DIGEST_SIZE_ERR                           107
 #  define OCSP_R_ERROR_IN_NEXTUPDATE_FIELD                 122
 #  define OCSP_R_ERROR_IN_THISUPDATE_FIELD                 123
 #  define OCSP_R_MISSING_OCSPSIGNING_USAGE                 103


### PR DESCRIPTION
The calls are unlikely to fail but better checking their return than not.

Also added some blank lines to separate declarations from code.
