### PR TITLE
Test case for a2i_IPADDRESS

### DIFF
--- a/test/x509_internal_test.c
+++ b/test/x509_internal_test.c
@@ -48,8 +48,62 @@ static int test_standard_exts(void)
     return good;
 }
 
+typedef struct {
+    const char *ipasc;
+    const char *data;
+    int length;
+    ASN1_OCTET_STRING ip;
+} IP_TESTDATA;
+
+static IP_TESTDATA a2i_ipaddress_tests[] = {
+    {"127.0.0.1", "\x7f\x00\x00\x01", 4},
+    {"1.2.3.4", "\x01\x02\x03\x04", 4},
+    {"1.2.3.255", "\x01\x02\x03\xff", 4},
+    {"1.2.3", NULL, 0},
+    {"1.2.3 .4", NULL, 0},
+
+    {"::1", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", 16},
+    {"1:1:1:1:1:1:1:1", "\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01\x00\x01", 16},
+    {"2001:db8::ff00:42:8329", "\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\xff\x00\x00\x42\x83\x29", 16},
+    {"1:1:1:1:1:1:1:1.test", NULL, 0},
+    {":::1", NULL, 0},
+    {"2001::123g", NULL, 0},
+
+    {"example.test", NULL, 0},
+    {"", NULL, 0},
+
+    {"1.2.3.4.example.test", NULL, 0},
+    {"1.2.3.4 ", NULL, 0},
+};
+
+
+static int test_a2i_ipaddress(int idx)
+{
+    int good = 1;
+    ASN1_OCTET_STRING *ip;
+    int len = a2i_ipaddress_tests[idx].length;
+
+    ip = a2i_IPADDRESS(a2i_ipaddress_tests[idx].ipasc);
+    if (len == 0) {
+        if (!TEST_ptr_null(ip)) {
+            good = 0;
+            TEST_note("'%s' should not be parsed as IP address", a2i_ipaddress_tests[idx].ipasc);
+        }
+    } else {
+        if (!TEST_ptr(ip)
+            || !TEST_int_eq(ASN1_STRING_length(ip), len)
+            || !TEST_mem_eq(ASN1_STRING_get0_data(ip), len,
+                            a2i_ipaddress_tests[idx].data, len)) {
+            good = 0;
+        }
+    }
+    ASN1_OCTET_STRING_free(ip);
+    return good;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_standard_exts);
+    ADD_ALL_TESTS(test_a2i_ipaddress, OSSL_NELEM(a2i_ipaddress_tests));
     return 1;
 }


### PR DESCRIPTION
Unit test to show that a2i_IPADDRESS("1.2.3.4.test.example") ignores
trailing data.

See: https://github.com/openssl/openssl/issues/12649
See: https://bugs.python.org/issue41556
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
