### PR TITLE
Handle unused parameters in a systematic way

### DIFF
--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -77,16 +77,18 @@ const OPTIONS ciphers_options[] = {
 };
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int dummy_psk(SSL *ssl, const char *hint, char *identity,
-                              unsigned int max_identity_len,
-                              unsigned char *psk,
-                              unsigned int max_psk_len)
+static unsigned int dummy_psk(ossl_unused SSL *unused__ssl,
+                              ossl_unused const char *unused__hint,
+                              ossl_unused char *unused__identity,
+                              ossl_unused unsigned int unused__max_identity_len,
+                              ossl_unused unsigned char *unused__psk,
+                              ossl_unused unsigned int unused__max_psk_len)
 {
     return 0;
 }
 #endif
 #ifndef OPENSSL_NO_SRP
-static char *dummy_srp(SSL *ssl, void *arg)
+static char *dummy_srp(ossl_unused SSL *unused__ssl, ossl_unused void *unused__arg)
 {
     return "";
 }

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2096,7 +2096,7 @@ static int write_cert(BIO *bio, X509 *cert)
  * where DER does not make much sense for writing more than one cert!
  * Returns number of written certificates on success, 0 on error.
  */
-static int save_certs(OSSL_CMP_CTX *ctx,
+static int save_certs(ossl_unused OSSL_CMP_CTX *unused__ctx,
                       STACK_OF(X509) *certs, char *destFile, char *desc)
 {
     BIO *bio = NULL;

--- a/apps/cmp_mock_srv.c
+++ b/apps/cmp_mock_srv.c
@@ -18,7 +18,7 @@
 DEFINE_STACK_OF(X509)
 DEFINE_STACK_OF(OSSL_CMP_ITAV)
 DEFINE_STACK_OF(ASN1_UTF8STRING)
- 
+
 /* the context for the CMP mock server */
 typedef struct
 {
@@ -176,8 +176,8 @@ int ossl_cmp_mock_srv_set_checkAfterTime(OSSL_CMP_SRV_CTX *srv_ctx, int sec)
 static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
                                             const OSSL_CMP_MSG *cert_req,
                                             int certReqId,
-                                            const OSSL_CRMF_MSG *crm,
-                                            const X509_REQ *p10cr,
+                                            ossl_unused const OSSL_CRMF_MSG *unused__crm,
+                                            ossl_unused const X509_REQ *unused__p10cr,
                                             X509 **certOut,
                                             STACK_OF(X509) **chainOut,
                                             STACK_OF(X509) **caPubs)
@@ -328,7 +328,7 @@ static void process_error(OSSL_CMP_SRV_CTX *srv_ctx, const OSSL_CMP_MSG *error,
 static int process_certConf(OSSL_CMP_SRV_CTX *srv_ctx,
                             const OSSL_CMP_MSG *certConf, int certReqId,
                             const ASN1_OCTET_STRING *certHash,
-                            const OSSL_CMP_PKISI *si)
+                            ossl_unused const OSSL_CMP_PKISI *unused__si)
 {
     mock_srv_ctx *ctx = OSSL_CMP_SRV_CTX_get0_custom_ctx(srv_ctx);
     ASN1_OCTET_STRING *digest;
@@ -360,8 +360,10 @@ static int process_certConf(OSSL_CMP_SRV_CTX *srv_ctx,
 }
 
 static int process_pollReq(OSSL_CMP_SRV_CTX *srv_ctx,
-                           const OSSL_CMP_MSG *pollReq, int certReqId,
-                           OSSL_CMP_MSG **certReq, int64_t *check_after)
+                           const OSSL_CMP_MSG *pollReq,
+                           ossl_unused int unused__certReqId,
+                           OSSL_CMP_MSG **certReq,
+                           int64_t *check_after)
 {
     mock_srv_ctx *ctx = OSSL_CMP_SRV_CTX_get0_custom_ctx(srv_ctx);
 

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -398,7 +398,7 @@ static int common_dh_cb(int p, BIO *b)
 }
 
 #if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-static int dh_cb(int p, int n, BN_GENCB *cb)
+static int dh_cb(int p, ossl_unused int unused__n, BN_GENCB *cb)
 {
     return common_dh_cb(p, BN_GENCB_get_arg(cb));
 }

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -240,7 +240,7 @@ static int util_verbose(ENGINE *e, int verbose, BIO *out, const char *indent)
 }
 
 static void util_do_cmds(ENGINE *e, STACK_OF(OPENSSL_STRING) *cmds,
-                         BIO *out, const char *indent)
+                         BIO *out, ossl_unused const char *unused__indent)
 {
     int loop, res, num = sk_OPENSSL_STRING_num(cmds);
 

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -486,7 +486,7 @@ cleanup:
     return ret;
 }
 
-static int self_test_events(const OSSL_PARAM params[], void *arg)
+static int self_test_events(const OSSL_PARAM params[], ossl_unused void *unused__arg)
 {
     const OSSL_PARAM *p = NULL;
     const char *phase = NULL, *type = NULL, *desc = NULL;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -136,7 +136,7 @@ int chopup_args(ARGS *arg, char *buf)
 }
 
 #ifndef APP_INIT
-int app_init(long mesgwin)
+int app_init(ossl_unused long unused__mesgwin)
 {
     return 1;
 }
@@ -501,7 +501,7 @@ X509 *load_cert_pass(const char *uri, int maybe_stdin,
 }
 
 /* the format parameter is meanwhile not needed anymore and thus ignored */
-X509_CRL *load_crl(const char *uri, int format, const char *desc)
+X509_CRL *load_crl(const char *uri, ossl_unused int unused__format, const char *desc)
 {
     X509_CRL *crl = NULL;
 
@@ -1951,7 +1951,7 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
  */
 
 static STACK_OF(X509_CRL) *crls_http_cb(const X509_STORE_CTX *ctx,
-                                        const X509_NAME *nm)
+                                        ossl_unused const X509_NAME *unused__nm)
 {
     X509 *x;
     STACK_OF(X509_CRL) *crls = NULL;

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -66,7 +66,7 @@ void log_message(const char *prog, int level, const char *fmt, ...)
 }
 
 #ifdef HTTP_DAEMON
-void socket_timeout(int signum)
+void socket_timeout(ossl_unused int unused__signum)
 {
     if (acfd != (int)INVALID_SOCKET)
         (void)shutdown(acfd, SHUT_RD);

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -438,7 +438,7 @@ int ssl_print_tmp_key(BIO *out, SSL *s)
 }
 
 long bio_dump_callback(BIO *bio, int cmd, const char *argp,
-                       int argi, long argl, long ret)
+                       int argi, ossl_unused long unused__argl, long ret)
 {
     BIO *out;
 
@@ -566,7 +566,7 @@ static STRINT_PAIR handshakes[] = {
 };
 
 void msg_cb(int write_p, int version, int content_type, const void *buf,
-            size_t len, SSL *ssl, void *arg)
+            size_t len, ossl_unused SSL *unused__ssl, void *arg)
 {
     BIO *bio = arg;
     const char *str_write_p = write_p ? ">>>" : "<<<";
@@ -721,7 +721,7 @@ static STRINT_PAIR signature_tls12_hash_list[] = {
     {NULL}
 };
 
-void tlsext_cb(SSL *s, int client_server, int type,
+void tlsext_cb(ossl_unused SSL *unused__ssl, int client_server, int type,
                const unsigned char *data, int len, void *arg)
 {
     BIO *bio = arg;
@@ -1519,7 +1519,7 @@ void ssl_ctx_security_debug(SSL_CTX *ctx, int verbose)
     SSL_CTX_set0_security_ex_data(ctx, &sdb);
 }
 
-static void keylog_callback(const SSL *ssl, const char *line)
+static void keylog_callback(ossl_unused const SSL *unused__ssl, const char *line)
 {
     if (bio_keylog == NULL) {
         BIO_printf(bio_err, "Keylog callback is invoked without valid file!\n");

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -105,7 +105,8 @@ static int restore_errno(void)
 static char *psk_identity = "Client_identity";
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
+static unsigned int psk_client_cb(ossl_unused SSL *unused__ssl,
+                                  const char *hint, char *identity,
                                   unsigned int max_identity_len,
                                   unsigned char *psk,
                                   unsigned int max_psk_len)
@@ -235,7 +236,7 @@ typedef struct tlsextctx_st {
     int ack;
 } tlsextctx;
 
-static int ssl_servername_cb(SSL *s, int *ad, void *arg)
+static int ssl_servername_cb(SSL *s, ossl_unused int *unused__ad, void *arg)
 {
     tlsextctx *p = (tlsextctx *) arg;
     const char *hn = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
@@ -335,7 +336,7 @@ static int ssl_srp_verify_param_cb(SSL *s, void *arg)
 
 # define PWD_STRLEN 1024
 
-static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
+static char *ssl_give_srp_client_pwd_cb(ossl_unused SSL *unused__ssl, void *arg)
 {
     SRP_ARG *srp_arg = (SRP_ARG *)arg;
     char *pass = app_malloc(PWD_STRLEN + 1, "SRP password buffer");
@@ -366,7 +367,8 @@ typedef struct tlsextnextprotoctx_st {
 
 static tlsextnextprotoctx next_proto;
 
-static int next_proto_cb(SSL *s, unsigned char **out, unsigned char *outlen,
+static int next_proto_cb(ossl_unused SSL *unused__ssl,
+                         unsigned char **out, unsigned char *outlen,
                          const unsigned char *in, unsigned int inlen,
                          void *arg)
 {
@@ -391,9 +393,10 @@ static int next_proto_cb(SSL *s, unsigned char **out, unsigned char *outlen,
 }
 #endif                         /* ndef OPENSSL_NO_NEXTPROTONEG */
 
-static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
+static int serverinfo_cli_parse_cb(ossl_unused SSL *unused__ssl,
+                                   unsigned int ext_type,
                                    const unsigned char *in, size_t inlen,
-                                   int *al, void *arg)
+                                   ossl_unused int *unused__al, ossl_unused void *unused__arg)
 {
     char pem_name[100];
     unsigned char ext_buf[4 + 65536];

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -134,7 +134,8 @@ char *psk_key = NULL;           /* by default PSK is not used */
 static char http_server_binmode = 0; /* for now: 0/1 = default/binary */
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int psk_server_cb(SSL *ssl, const char *identity,
+static unsigned int psk_server_cb(ossl_unused SSL *unused__ssl,
+                                  const char *identity,
                                   unsigned char *psk,
                                   unsigned int max_psk_len)
 {
@@ -463,7 +464,7 @@ typedef struct tlsextctx_st {
     int extension_error;
 } tlsextctx;
 
-static int ssl_servername_cb(SSL *s, int *ad, void *arg)
+static int ssl_servername_cb(SSL *s, ossl_unused int *unused__ad, void *arg)
 {
     tlsextctx *p = (tlsextctx *) arg;
     const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
@@ -676,7 +677,7 @@ typedef struct tlsextnextprotoctx_st {
     size_t len;
 } tlsextnextprotoctx;
 
-static int next_proto_cb(SSL *s, const unsigned char **data,
+static int next_proto_cb(ossl_unused SSL *unused__ssl, const unsigned char **data,
                          unsigned int *len, void *arg)
 {
     tlsextnextprotoctx *next_proto = arg;
@@ -694,7 +695,8 @@ typedef struct tlsextalpnctx_st {
     size_t len;
 } tlsextalpnctx;
 
-static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
+static int alpn_cb(ossl_unused SSL *unused__ssl,
+                   const unsigned char **out, unsigned char *outlen,
                    const unsigned char *in, unsigned int inlen, void *arg)
 {
     tlsextalpnctx *alpn_ctx = arg;
@@ -727,7 +729,7 @@ static int alpn_cb(SSL *s, const unsigned char **out, unsigned char *outlen,
     return SSL_TLSEXT_ERR_OK;
 }
 
-static int not_resumable_sess_cb(SSL *s, int is_forward_secure)
+static int not_resumable_sess_cb(ossl_unused SSL *unused__ssl, int is_forward_secure)
 {
     /* disable resumption for sessions with forward secure ciphers */
     return is_forward_secure;
@@ -2311,7 +2313,7 @@ static void print_stats(BIO *bio, SSL_CTX *ssl_ctx)
                SSL_CTX_sess_get_cache_size(ssl_ctx));
 }
 
-static int sv_body(int s, int stype, int prot, unsigned char *context)
+static int sv_body(int s, int stype, ossl_unused int unused__prot, unsigned char *context)
 {
     char *buf = NULL;
     fd_set readfds;
@@ -3025,7 +3027,8 @@ static DH *load_dh_param(const char *dhfile)
 }
 #endif
 
-static int www_body(int s, int stype, int prot, unsigned char *context)
+static int www_body(int s, ossl_unused int unused__stype, ossl_unused int unused__prot,
+                    unsigned char *context)
 {
     char *buf = NULL;
     int ret = 1;
@@ -3460,7 +3463,8 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     return ret;
 }
 
-static int rev_body(int s, int stype, int prot, unsigned char *context)
+static int rev_body(int s, ossl_unused int unused__stype, ossl_unused int unused__prot,
+                    unsigned char *context)
 {
     char *buf = NULL;
     int i;
@@ -3660,7 +3664,7 @@ typedef struct simple_ssl_session_st {
 
 static simple_ssl_session *first = NULL;
 
-static int add_session(SSL *ssl, SSL_SESSION *session)
+static int add_session(ossl_unused SSL *unused__ssl, SSL_SESSION *session)
 {
     simple_ssl_session *sess = app_malloc(sizeof(*sess), "get session");
     unsigned char *p;
@@ -3699,7 +3703,7 @@ static int add_session(SSL *ssl, SSL_SESSION *session)
     return 0;
 }
 
-static SSL_SESSION *get_session(SSL *ssl, const unsigned char *id, int idlen,
+static SSL_SESSION *get_session(ossl_unused SSL *unused__ssl, const unsigned char *id, int idlen,
                                 int *do_copy)
 {
     simple_ssl_session *sess;
@@ -3715,7 +3719,7 @@ static SSL_SESSION *get_session(SSL *ssl, const unsigned char *id, int idlen,
     return NULL;
 }
 
-static void del_session(SSL_CTX *sctx, SSL_SESSION *session)
+static void del_session(ossl_unused SSL_CTX *unused__sctx, SSL_SESSION *session)
 {
     simple_ssl_session *sess, *prev = NULL;
     const unsigned char *id;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -171,7 +171,7 @@ static const int aead_lengths_list[] = {
 
 #ifdef SIGALRM
 
-static void alarmed(int sig)
+static void alarmed(ossl_unused int unused__sig)
 {
     signal(SIGALRM, alarmed);
     run = 0;
@@ -322,7 +322,7 @@ enum {
     D_CBC_128_CML, D_CBC_192_CML, D_CBC_256_CML,
     D_EVP, D_SHA256, D_SHA512, D_WHIRLPOOL,
     D_IGE_128_AES, D_IGE_192_AES, D_IGE_256_AES,
-    D_GHASH, D_RAND, D_EVP_HMAC, D_EVP_CMAC, ALGOR_NUM 
+    D_GHASH, D_RAND, D_EVP_HMAC, D_EVP_CMAC, ALGOR_NUM
 };
 /* name of algorithms to test. MUST BE KEEP IN SYNC with above enum ! */
 static const char *names[ALGOR_NUM] = {
@@ -1997,13 +1997,13 @@ int speed_main(int argc, char **argv)
         memset(doit, 1, sizeof(doit));
         doit[D_EVP] = doit[D_EVP_HMAC] = doit[D_EVP_CMAC] = 0;
 #if !defined(OPENSSL_NO_MDC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-	doit[D_MDC2] = 0;
+        doit[D_MDC2] = 0;
 #endif
 #if !defined(OPENSSL_NO_MD4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-	doit[D_MD4] = 0;
+        doit[D_MD4] = 0;
 #endif
 #if !defined(OPENSSL_NO_RMD160) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-	doit[D_RMD160] = 0;
+        doit[D_RMD160] = 0;
 #endif
 #if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         memset(rsa_doit, 1, sizeof(rsa_doit));
@@ -2110,7 +2110,7 @@ int speed_main(int argc, char **argv)
         BF_set_key(&bf_ks, 16, key16);
 #endif
 #if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_CAST]) 
+    if (doit[D_CBC_CAST])
         CAST_set_key(&cast_ks, 16, key16);
 #endif
 #ifndef SIGALRM
@@ -4036,7 +4036,7 @@ int speed_main(int argc, char **argv)
         for (k = 0; k < EdDSA_NUM; k++) {
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx[k]);
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx2[k]);
-	}
+        }
 # ifndef OPENSSL_NO_SM2
         for (k = 0; k < SM2_NUM; k++) {
             EVP_PKEY_CTX *pctx = NULL;
@@ -4088,11 +4088,13 @@ static void print_message(const char *s, long num, int length, int tm)
     (void)BIO_flush(bio_err);
     run = 1;
     alarm(tm);
+    (void)num; /* silence -Wunused-parameter */
 #else
     BIO_printf(bio_err,
                mr ? "+DN:%s:%ld:%d\n"
                : "Doing %s %ld times on %d size blocks: ", s, num, length);
     (void)BIO_flush(bio_err);
+    (void)tm; /* silence -Wunused-parameter */
 #endif
 }
 
@@ -4106,11 +4108,13 @@ static void pkey_print_message(const char *str, const char *str2, long num,
     (void)BIO_flush(bio_err);
     run = 1;
     alarm(tm);
+    (void)num; /* silence -Wunused-parameter */
 #else
     BIO_printf(bio_err,
                mr ? "+DNP:%ld:%d:%s:%s\n"
                : "Doing %ld %u bits %s %s's: ", num, bits, str, str2);
     (void)BIO_flush(bio_err);
+    (void)tm; /* silence -Wunused-parameter */
 #endif
 }
 

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -1010,7 +1010,7 @@ static X509_STORE *create_cert_store(const char *CApath, const char *CAfile,
     return NULL;
 }
 
-static int verify_cb(int ok, X509_STORE_CTX *ctx)
+static int verify_cb(int ok, ossl_unused X509_STORE_CTX *unused__ctx)
 {
     return ok;
 }

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -187,7 +187,7 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
 
 void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
-                        const AES_KEY *key2, const unsigned char *ivec,
+                        ossl_unused const AES_KEY *unused__key2, const unsigned char *ivec,
                         const int enc)
 {
     size_t n;

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -34,7 +34,7 @@ void *ASN1_d2i_fp(void *(*xnew) (void), d2i_of_void *d2i, FILE *in, void **x)
 }
 # endif
 
-void *ASN1_d2i_bio(void *(*xnew) (void), d2i_of_void *d2i, BIO *in, void **x)
+void *ASN1_d2i_bio(ossl_unused void *(*xnew) (void), d2i_of_void *d2i, BIO *in, void **x)
 {
     BUF_MEM *b = NULL;
     const unsigned char *p;

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -244,7 +244,7 @@ static int traverse_string(const unsigned char *p, int len, int inform,
 
 /* Just count number of characters */
 
-static int in_utf8(unsigned long value, void *arg)
+static int in_utf8(ossl_unused unsigned long unused__value, void *arg)
 {
     int *nchar;
     nchar = arg;

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -236,7 +236,7 @@ int SMIME_write_ASN1_with_libctx(BIO *bio, ASN1_VALUE *val, BIO *data, int flags
                                  int ctype_nid, int econt_nid,
                                  STACK_OF(X509_ALGOR) *mdalgs,
                                  const ASN1_ITEM *it,
-                                 OPENSSL_CTX *libctx, const char *propq)
+                                 OPENSSL_CTX *libctx, ossl_unused const char *unused__propq)
 {
     char bound[33], c;
     int i;

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -44,7 +44,7 @@ static int oid_module_init(CONF_IMODULE *md, const CONF *cnf)
     return 1;
 }
 
-static void oid_module_finish(CONF_IMODULE *md)
+static void oid_module_finish(ossl_unused CONF_IMODULE *unused__md)
 {
 }
 

--- a/crypto/asn1/asn_mstbl.c
+++ b/crypto/asn1/asn_mstbl.c
@@ -40,7 +40,7 @@ static int stbl_module_init(CONF_IMODULE *md, const CONF *cnf)
     return 1;
 }
 
-static void stbl_module_finish(CONF_IMODULE *md)
+static void stbl_module_finish(ossl_unused CONF_IMODULE *unused__md)
 {
     ASN1_STRING_TABLE_cleanup();
 }

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -102,7 +102,7 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
     return NULL;
 }
 
-static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
+static int ndef_prefix(ossl_unused BIO *unused__b, unsigned char **pbuf, int *plen, void *parg)
 {
     NDEF_SUPPORT *ndef_aux;
     unsigned char *p;
@@ -131,7 +131,7 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     return 1;
 }
 
-static int ndef_prefix_free(BIO *b, unsigned char **pbuf, int *plen,
+static int ndef_prefix_free(ossl_unused BIO *unused__b, unsigned char **pbuf, int *plen,
                             void *parg)
 {
     NDEF_SUPPORT *ndef_aux;
@@ -160,7 +160,7 @@ static int ndef_suffix_free(BIO *b, unsigned char **pbuf, int *plen,
     return 1;
 }
 
-static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
+static int ndef_suffix(ossl_unused BIO *unused__b, unsigned char **pbuf, int *plen, void *parg)
 {
     NDEF_SUPPORT *ndef_aux;
     unsigned char *p;

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -13,7 +13,7 @@
 #include <openssl/buffer.h>
 #include <openssl/asn1.h>
 
-int i2a_ASN1_STRING(BIO *bp, const ASN1_STRING *a, int type)
+int i2a_ASN1_STRING(BIO *bp, const ASN1_STRING *a, ossl_unused int unused__type)
 {
     int i, n = 0;
     static const char *h = "0123456789ABCDEF";

--- a/crypto/asn1/nsseq.c
+++ b/crypto/asn1/nsseq.c
@@ -13,8 +13,8 @@
 #include <openssl/x509.h>
 #include <openssl/objects.h>
 
-static int nsseq_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                    void *exarg)
+static int nsseq_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                    ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_NEW_POST) {
         NETSCAPE_CERT_SEQUENCE *nsseq;

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -211,7 +211,9 @@ static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, size_t saltlen,
 
 int PKCS5_v2_scrypt_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int passlen, ASN1_TYPE *param,
-                             const EVP_CIPHER *c, const EVP_MD *md, int en_de)
+                             ossl_unused const EVP_CIPHER *unused__c,
+                             ossl_unused const EVP_MD *unused__md,
+                             int en_de)
 {
     unsigned char *salt, key[EVP_MAX_KEY_LENGTH];
     uint64_t p, r, N;

--- a/crypto/asn1/p8_pkey.c
+++ b/crypto/asn1/p8_pkey.c
@@ -14,8 +14,8 @@
 #include "crypto/x509.h"
 
 /* Minor tweak to operation: zero private key data */
-static int pkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                   void *exarg)
+static int pkey_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                   ossl_unused void *unused__exarg)
 {
     /* Since the structure must still be valid use ASN1_OP_FREE_PRE */
     if (operation == ASN1_OP_FREE_PRE) {

--- a/crypto/asn1/t_pkey.c
+++ b/crypto/asn1/t_pkey.c
@@ -43,7 +43,7 @@ int ASN1_buf_print(BIO *bp, const unsigned char *buf, size_t buflen, int indent)
 }
 
 int ASN1_bn_print(BIO *bp, const char *number, const BIGNUM *num,
-                  unsigned char *ign, int indent)
+                  ossl_unused unsigned char *unused__ign, int indent)
 {
     int n, rv = 0;
     const char *neg;

--- a/crypto/asn1/x_bignum.c
+++ b/crypto/asn1/x_bignum.c
@@ -62,7 +62,7 @@ ASN1_ITEM_start(CBIGNUM)
         ASN1_ITYPE_PRIMITIVE, V_ASN1_INTEGER, NULL, 0, &cbignum_pf, BN_SENSITIVE, "CBIGNUM"
 ASN1_ITEM_end(CBIGNUM)
 
-static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static int bn_new(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     *pval = (ASN1_VALUE *)BN_new();
     if (*pval != NULL)
@@ -71,7 +71,7 @@ static int bn_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
         return 0;
 }
 
-static int bn_secure_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static int bn_secure_new(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     *pval = (ASN1_VALUE *)BN_secure_new();
     if (*pval != NULL)
@@ -91,8 +91,9 @@ static void bn_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
     *pval = NULL;
 }
 
-static int bn_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
-                  const ASN1_ITEM *it)
+static int bn_i2c(const ASN1_VALUE **pval, unsigned char *cont,
+                  ossl_unused int *unused__putype,
+                  ossl_unused const ASN1_ITEM *unused__it)
 {
     BIGNUM *bn;
     int pad;
@@ -113,7 +114,8 @@ static int bn_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
 }
 
 static int bn_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
-                  int utype, char *free_cont, const ASN1_ITEM *it)
+                  ossl_unused int unused__utype, ossl_unused char *unused__free_cont,
+                  const ASN1_ITEM *it)
 {
     BIGNUM *bn;
 
@@ -146,8 +148,10 @@ static int bn_secure_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     return ret;
 }
 
-static int bn_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
-                    int indent, const ASN1_PCTX *pctx)
+static int bn_print(BIO *out, const ASN1_VALUE **pval,
+                    ossl_unused const ASN1_ITEM *unused__it,
+                    ossl_unused int unused__indent,
+                    ossl_unused const ASN1_PCTX *unused__pctx)
 {
     if (!BN_print(out, *(BIGNUM **)pval))
         return 0;

--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -26,7 +26,7 @@
 #define INTxx_FLAG_ZERO_DEFAULT (1<<0)
 #define INTxx_FLAG_SIGNED       (1<<1)
 
-static int uint64_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static int uint64_new(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     if ((*pval = (ASN1_VALUE *)OPENSSL_zalloc(sizeof(uint64_t))) == NULL) {
         ASN1err(ASN1_F_UINT64_NEW, ERR_R_MALLOC_FAILURE);
@@ -35,18 +35,18 @@ static int uint64_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
     return 1;
 }
 
-static void uint64_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static void uint64_free(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     OPENSSL_free(*pval);
     *pval = NULL;
 }
 
-static void uint64_clear(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static void uint64_clear(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     **(uint64_t **)pval = 0;
 }
 
-static int uint64_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
+static int uint64_i2c(const ASN1_VALUE **pval, unsigned char *cont, ossl_unused int *unused__putype,
                       const ASN1_ITEM *it)
 {
     uint64_t utmp;
@@ -71,7 +71,7 @@ static int uint64_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
 }
 
 static int uint64_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
-                      int utype, char *free_cont, const ASN1_ITEM *it)
+                      ossl_unused int unused__utype, ossl_unused char *unused__free_cont, const ASN1_ITEM *it)
 {
     uint64_t utmp = 0;
     char *cp;
@@ -112,7 +112,7 @@ static int uint64_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 }
 
 static int uint64_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
-                        int indent, const ASN1_PCTX *pctx)
+                        ossl_unused int unused__indent, ossl_unused const ASN1_PCTX *unused__pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
         return BIO_printf(out, "%jd\n", **(int64_t **)pval);
@@ -121,7 +121,7 @@ static int uint64_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
 
 /* 32-bit variants */
 
-static int uint32_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static int uint32_new(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     if ((*pval = (ASN1_VALUE *)OPENSSL_zalloc(sizeof(uint32_t))) == NULL) {
         ASN1err(ASN1_F_UINT32_NEW, ERR_R_MALLOC_FAILURE);
@@ -130,18 +130,18 @@ static int uint32_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
     return 1;
 }
 
-static void uint32_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static void uint32_free(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     OPENSSL_free(*pval);
     *pval = NULL;
 }
 
-static void uint32_clear(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static void uint32_clear(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     **(uint32_t **)pval = 0;
 }
 
-static int uint32_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
+static int uint32_i2c(const ASN1_VALUE **pval, unsigned char *cont, ossl_unused int *unused__putype,
                       const ASN1_ITEM *it)
 {
     uint32_t utmp;
@@ -173,7 +173,7 @@ static int uint32_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
 #define ABS_INT32_MIN ((uint32_t)INT32_MAX + 1)
 
 static int uint32_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
-                      int utype, char *free_cont, const ASN1_ITEM *it)
+                      ossl_unused int unused__utype, ossl_unused char *unused__free_cont, const ASN1_ITEM *it)
 {
     uint64_t utmp = 0;
     uint32_t utmp2 = 0;
@@ -221,7 +221,7 @@ static int uint32_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
 }
 
 static int uint32_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
-                        int indent, const ASN1_PCTX *pctx)
+                        ossl_unused int unused__indent, ossl_unused const ASN1_PCTX *unused__pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
         return BIO_printf(out, "%d\n", **(int32_t **)pval);

--- a/crypto/asn1/x_long.c
+++ b/crypto/asn1/x_long.c
@@ -82,7 +82,8 @@ static int num_bits_ulong(unsigned long value)
     return (int)ret;
 }
 
-static int long_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
+static int long_i2c(const ASN1_VALUE **pval, unsigned char *cont,
+                    ossl_unused int *unused__putype,
                     const ASN1_ITEM *it)
 {
     long ltmp;
@@ -126,7 +127,8 @@ static int long_i2c(const ASN1_VALUE **pval, unsigned char *cont, int *putype,
 }
 
 static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
-                    int utype, char *free_cont, const ASN1_ITEM *it)
+                    ossl_unused int unused__utype, ossl_unused char *unused__free_cont,
+                    const ASN1_ITEM *it)
 {
     int i;
     long ltmp;
@@ -186,8 +188,10 @@ static int long_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
     return 1;
 }
 
-static int long_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      int indent, const ASN1_PCTX *pctx)
+static int long_print(BIO *out, const ASN1_VALUE **pval,
+                      ossl_unused const ASN1_ITEM *unused__it,
+                      ossl_unused int unused__indent,
+                      ossl_unused const ASN1_PCTX *unused__pctx)
 {
     long l;
 

--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -47,7 +47,7 @@ int async_fibre_init_dispatcher(async_fibre *fibre)
     return 1;
 }
 
-VOID CALLBACK async_start_func_win(PVOID unused)
+VOID CALLBACK async_start_func_win(ossl_unused PVOID unused__arg)
 {
     async_start_func();
 }

--- a/crypto/async/arch/async_win.h
+++ b/crypto/async/arch/async_win.h
@@ -31,6 +31,6 @@ typedef struct async_fibre_st {
 # define async_fibre_free(f)             (DeleteFiber((f)->fibre))
 
 int async_fibre_init_dispatcher(async_fibre *fibre);
-VOID CALLBACK async_start_func_win(PVOID unused);
+VOID CALLBACK async_start_func_win(PVOID unused__arg);
 
 #endif

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -395,7 +395,7 @@ err:
 }
 
 /* TODO(3.0): arg ignored for now */
-static void async_delete_thread_state(void *arg)
+static void async_delete_thread_state(ossl_unused void *unused__arg)
 {
     async_pool *pool = (async_pool *)CRYPTO_THREAD_get_local(&poolkey);
 

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -38,7 +38,7 @@
  * Returns the file descriptor on success or INVALID_SOCKET on failure.  On
  * failure errno is set, and a status is added to the OpenSSL error stack.
  */
-int BIO_socket(int domain, int socktype, int protocol, int options)
+int BIO_socket(int domain, int socktype, int protocol, ossl_unused int unused__options)
 {
     int sock = -1;
 

--- a/crypto/bio/bio_cb.c
+++ b/crypto/bio/bio_cb.c
@@ -14,8 +14,8 @@
 #include "internal/cryptlib.h"
 #include <openssl/err.h>
 
-long BIO_debug_callback(BIO *bio, int cmd, const char *argp,
-                        int argi, long argl, long ret)
+long BIO_debug_callback(BIO *bio, int cmd, ossl_unused const char *unused__argp,
+                        int argi, ossl_unused long unused__argl, long ret)
 {
     BIO *b;
     char buf[256];

--- a/crypto/bio/bss_log.c
+++ b/crypto/bio/bss_log.c
@@ -387,7 +387,7 @@ static void xcloselog(BIO *bp)
 
 # else                          /* Unix/Watt32 */
 
-static void xopenlog(BIO *bp, char *name, int level)
+static void xopenlog(ossl_unused BIO *unused__bp, char *name, int level)
 {
 #  ifdef WATT32                 /* djgpp/DOS */
     openlog(name, LOG_PID | LOG_CONS | LOG_NDELAY, level);
@@ -396,12 +396,12 @@ static void xopenlog(BIO *bp, char *name, int level)
 #  endif
 }
 
-static void xsyslog(BIO *bp, int priority, const char *string)
+static void xsyslog(ossl_unused BIO *unused__bp, int priority, const char *string)
 {
     syslog(priority, "%s", string);
 }
 
-static void xcloselog(BIO *bp)
+static void xcloselog(ossl_unused BIO *unused__bp)
 {
     closelog();
 }

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -39,17 +39,17 @@ const BIO_METHOD *BIO_s_null(void)
     return &null_method;
 }
 
-static int null_read(BIO *b, char *out, int outl)
+static int null_read(ossl_unused BIO *unused__b, ossl_unused char *unused__out, ossl_unused int unused__outl)
 {
     return 0;
 }
 
-static int null_write(BIO *b, const char *in, int inl)
+static int null_write(ossl_unused BIO *unused__b, ossl_unused const char *unused__in, int inl)
 {
     return inl;
 }
 
-static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
+static long null_ctrl(ossl_unused BIO *unused__b, int cmd, ossl_unused long unused__num, ossl_unused void *unused__ptr)
 {
     long ret = 1;
 
@@ -74,12 +74,12 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int null_gets(BIO *bp, char *buf, int size)
+static int null_gets(ossl_unused BIO *unused__bp, ossl_unused char *unused__buf, ossl_unused int unused__size)
 {
     return 0;
 }
 
-static int null_puts(BIO *bp, const char *str)
+static int null_puts(ossl_unused BIO *unused__bp, const char *str)
 {
     if (str == NULL)
         return 0;

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -42,7 +42,7 @@ void BN_RECP_CTX_free(BN_RECP_CTX *recp)
         OPENSSL_free(recp);
 }
 
-int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *ctx)
+int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, ossl_unused BN_CTX *unused__ctx)
 {
     if (!BN_copy(&(recp->N), d))
         return 0;

--- a/crypto/cmac/cm_ameth.c
+++ b/crypto/cmac/cm_ameth.c
@@ -23,7 +23,7 @@
  * length and to free up a CMAC key.
  */
 
-static int cmac_size(const EVP_PKEY *pkey)
+static int cmac_size(ossl_unused const EVP_PKEY *unused__pkey)
 {
     return EVP_MAX_BLOCK_LENGTH;
 }

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -38,7 +38,7 @@ DEFINE_STACK_OF(OSSL_CRMF_CERTID)
 static int unprotected_exception(const OSSL_CMP_CTX *ctx,
                                  const OSSL_CMP_MSG *rep,
                                  int invalid_protection,
-                                 int expected_type /* ignored here */)
+                                 ossl_unused int expected_type /* ignored here */)
 {
     int rcvd_type = ossl_cmp_msg_get_bodytype(rep /* may be NULL */);
     const char *msg_type = NULL;
@@ -484,10 +484,9 @@ static X509 *get1_cert_status(OSSL_CMP_CTX *ctx, int bodytype,
  * an EE must be able to validate the certificates it gets enrolled.
  */
 int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
-                         const char **text)
+                         ossl_unused const char **unused__text)
 {
     X509_STORE *out_trusted = OSSL_CMP_CTX_get_certConf_cb_arg(ctx);
-    (void)text; /* make (artificial) use of var to prevent compiler warning */
 
     if (fail_info != 0) /* accept any error flagged by CMP core library */
         return fail_info;
@@ -508,7 +507,7 @@ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
  */
 static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
                          OSSL_CMP_MSG **resp, int *checkAfter,
-                         int req_type, int expected_type)
+                         ossl_unused int unused__req_type, ossl_unused int unused__expected_type)
 {
     EVP_PKEY *rkey = OSSL_CMP_CTX_get0_newPkey(ctx /* may be NULL */, 0);
     int fail_info = 0; /* no failure */

--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -142,6 +142,10 @@ int OSSL_CMP_print_to_bio(BIO *bio, const char *component, const char *file,
     if (BIO_printf(bio, "%s:%s:%d:", improve_location_name(component, "CMP"),
                    file, line) < 0)
         return 0;
+#else
+    (void)component; /* silence -Wunused-parameter */
+    (void)file;      /* silence -Wunused-parameter */
+    (void)line;      /* silence -Wunused-parameter */
 #endif
     return BIO_printf(bio, OSSL_CMP_LOG_PREFIX"%s: %s\n",
                       level_string, msg) >= 0;

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -437,8 +437,9 @@ static int check_msg_all_certs(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
     return ret;
 }
 
-static int no_log_cb(const char *func, const char *file, int line,
-                     OSSL_CMP_severity level, const char *msg)
+static int no_log_cb(ossl_unused const char *unused__func, ossl_unused const char *unused__file,
+                     ossl_unused int unused__line, ossl_unused OSSL_CMP_severity unused__level,
+                     ossl_unused const char *unused__msg)
 {
     return 1;
 }

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -43,8 +43,9 @@ ASN1_NDEF_SEQUENCE(CMS_EncapsulatedContentInfo) = {
 } static_ASN1_NDEF_SEQUENCE_END(CMS_EncapsulatedContentInfo)
 
 /* Minor tweak to operation: free up signer key, cert */
-static int cms_si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                     void *exarg)
+static int cms_si_cb(int operation, ASN1_VALUE **pval,
+                     ossl_unused const ASN1_ITEM *unused__it,
+                     ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_POST) {
         CMS_SignerInfo *si = (CMS_SignerInfo *)*pval;
@@ -118,8 +119,8 @@ ASN1_CHOICE(CMS_KeyAgreeRecipientIdentifier) = {
   ASN1_IMP(CMS_KeyAgreeRecipientIdentifier, d.rKeyId, CMS_RecipientKeyIdentifier, 0)
 } static_ASN1_CHOICE_END(CMS_KeyAgreeRecipientIdentifier)
 
-static int cms_rek_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int cms_rek_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                      ossl_unused void *unused__exarg)
 {
     CMS_RecipientEncryptedKey *rek = (CMS_RecipientEncryptedKey *)*pval;
     if (operation == ASN1_OP_FREE_POST) {
@@ -144,8 +145,8 @@ ASN1_CHOICE(CMS_OriginatorIdentifierOrKey) = {
   ASN1_IMP(CMS_OriginatorIdentifierOrKey, d.originatorKey, CMS_OriginatorPublicKey, 1)
 } static_ASN1_CHOICE_END(CMS_OriginatorIdentifierOrKey)
 
-static int cms_kari_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                       void *exarg)
+static int cms_kari_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                       ossl_unused void *unused__exarg)
 {
     CMS_KeyAgreeRecipientInfo *kari = (CMS_KeyAgreeRecipientInfo *)*pval;
     if (operation == ASN1_OP_NEW_POST) {
@@ -195,8 +196,8 @@ ASN1_SEQUENCE(CMS_OtherRecipientInfo) = {
 } static_ASN1_SEQUENCE_END(CMS_OtherRecipientInfo)
 
 /* Free up RecipientInfo additional data */
-static int cms_ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                     void *exarg)
+static int cms_ri_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                     ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_PRE) {
         CMS_RecipientInfo *ri = (CMS_RecipientInfo *)*pval;
@@ -278,7 +279,7 @@ ASN1_ADB(CMS_ContentInfo) = {
 } ASN1_ADB_END(CMS_ContentInfo, 0, contentType, 0, &cms_default_tt, NULL);
 
 /* CMS streaming support */
-static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
+static int cms_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
                   void *exarg)
 {
     ASN1_STREAM_ARG *sarg = exarg;

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -179,7 +179,7 @@ BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
 int cms_EncryptedContent_init(CMS_EncryptedContentInfo *ec,
                               const EVP_CIPHER *cipher,
                               const unsigned char *key, size_t keylen,
-                              const CMS_CTX *cms_ctx)
+                              ossl_unused const CMS_CTX *unused__cms_ctx)
 {
     ec->cipher = cipher;
     if (key) {

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -123,7 +123,7 @@ int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
 CMS_ReceiptRequest *CMS_ReceiptRequest_create0_with_libctx(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OPENSSL_CTX *libctx, const char *propq)
+    OPENSSL_CTX *libctx, ossl_unused const char *unused__propq)
 {
     CMS_ReceiptRequest *rr;
 

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -183,7 +183,7 @@ static int cms_copy_messageDigest(CMS_ContentInfo *cms, CMS_SignerInfo *si)
 }
 
 int cms_set1_SignerIdentifier(CMS_SignerIdentifier *sid, X509 *cert, int type,
-                              const CMS_CTX *ctx)
+                              ossl_unused const CMS_CTX *unused__ctx)
 {
     switch (type) {
     case CMS_SIGNERINFO_ISSUER_SERIAL:

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -945,14 +945,16 @@ CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
 
 #else
 
-int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
-                   unsigned int flags)
+int CMS_uncompress(ossl_unused CMS_ContentInfo *unused__cms, ossl_unused BIO *unused__dcont,
+                   ossl_unused BIO *unused__out,
+                   ossl_unused unsigned int unused__flags)
 {
     CMSerr(CMS_F_CMS_UNCOMPRESS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
     return 0;
 }
 
-CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
+CMS_ContentInfo *CMS_compress(ossl_unused BIO *unused__in, ossl_unused int unused__comp_nid,
+                              ossl_unused unsigned int unused__flags)
 {
     CMSerr(CMS_F_CMS_COMPRESS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
     return NULL;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -945,7 +945,7 @@ static int def_is_number(const CONF *conf, char c)
     return IS_NUMBER(conf, c);
 }
 
-static int def_to_int(const CONF *conf, char c)
+static int def_to_int(ossl_unused const CONF *unused__conf, char c)
 {
     return c - '0';
 }

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -281,12 +281,12 @@ char *NCONF_get_string(const CONF *conf, const char *group, const char *name)
     return NULL;
 }
 
-static int default_is_number(const CONF *conf, char c)
+static int default_is_number(ossl_unused const CONF *unused__conf, char c)
 {
     return ossl_isdigit(c);
 }
 
-static int default_to_int(const CONF *conf, char c)
+static int default_to_int(ossl_unused const CONF *unused__conf, char c)
 {
     return (int)(c - '0');
 }

--- a/crypto/conf/conf_ssl.c
+++ b/crypto/conf/conf_ssl.c
@@ -40,7 +40,7 @@ struct ssl_conf_cmd_st {
 static struct ssl_conf_name_st *ssl_names;
 static size_t ssl_names_count;
 
-static void ssl_module_free(CONF_IMODULE *md)
+static void ssl_module_free(ossl_unused CONF_IMODULE *unused__md)
 {
     size_t i, j;
     if (ssl_names == NULL)

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -191,6 +191,8 @@ OPENSSL_CTX *OPENSSL_CTX_set0_default(OPENSSL_CTX *libctx)
     if ((current_defctx = get_default_context()) != NULL
         && set_default_context(libctx))
         return current_defctx;
+#else
+    (void)libctx; /* silence -Wunused-parameter */
 #endif
 
     return NULL;
@@ -201,6 +203,8 @@ OPENSSL_CTX *openssl_ctx_get_concrete(OPENSSL_CTX *ctx)
 #ifndef FIPS_MODULE
     if (ctx == NULL)
         return get_default_context();
+#else
+    (void)ctx; /* silence -Wunused-parameter */
 #endif
     return ctx;
 }
@@ -210,6 +214,8 @@ int openssl_ctx_is_default(OPENSSL_CTX *ctx)
 #ifndef FIPS_MODULE
     if (ctx == NULL || ctx == get_default_context())
         return 1;
+#else
+    (void)ctx; /* silence -Wunused-parameter */
 #endif
     return 0;
 }
@@ -219,13 +225,18 @@ int openssl_ctx_is_global_default(OPENSSL_CTX *ctx)
 #ifndef FIPS_MODULE
     if (openssl_ctx_get_concrete(ctx) == &default_context_int)
         return 1;
+#else
+    (void)ctx; /* silence -Wunused-parameter */
 #endif
     return 0;
 }
 
-static void openssl_ctx_generic_new(void *parent_ign, void *ptr_ign,
-                                    CRYPTO_EX_DATA *ad, int index,
-                                    long argl_ign, void *argp)
+static void openssl_ctx_generic_new(ossl_unused void *unused__parent_ign,
+                                    ossl_unused void *unused__ptr_ign,
+                                    CRYPTO_EX_DATA *ad,
+                                    int index,
+                                    ossl_unused long unused__argl_ign,
+                                    void *argp)
 {
     const OPENSSL_CTX_METHOD *meth = argp;
     void *ptr = meth->new_func(crypto_ex_data_get_openssl_ctx(ad));
@@ -233,9 +244,12 @@ static void openssl_ctx_generic_new(void *parent_ign, void *ptr_ign,
     if (ptr != NULL)
         CRYPTO_set_ex_data(ad, index, ptr);
 }
-static void openssl_ctx_generic_free(void *parent_ign, void *ptr,
-                                     CRYPTO_EX_DATA *ad, int index,
-                                     long argl_ign, void *argp)
+static void openssl_ctx_generic_free(ossl_unused void *unused__parent_ign,
+                                     void *ptr,
+                                     ossl_unused CRYPTO_EX_DATA *unused__ad,
+                                     ossl_unused int unused__index,
+                                     ossl_unused long unused__argl_ign,
+                                     void *argp)
 {
     const OPENSSL_CTX_METHOD *meth = argp;
 

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -25,7 +25,8 @@ struct construct_data_st {
 };
 
 static int ossl_method_construct_precondition(OSSL_PROVIDER *provider,
-                                              int operation_id, void *cbdata,
+                                              int operation_id,
+                                              ossl_unused void *unused__cbdata,
                                               int *result)
 {
     if (!ossl_assert(result != NULL)) {
@@ -48,7 +49,7 @@ static int ossl_method_construct_precondition(OSSL_PROVIDER *provider,
 
 static int ossl_method_construct_postcondition(OSSL_PROVIDER *provider,
                                                int operation_id, int no_store,
-                                               void *cbdata, int *result)
+                                               ossl_unused void *unused__cbdata, int *result)
 {
     if (!ossl_assert(result != NULL)) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -64,7 +64,7 @@ static void namenum_free(NAMENUM_ENTRY *n)
 
 /* OPENSSL_CTX_METHOD functions for a namemap stored in a library context */
 
-static void *stored_namemap_new(OPENSSL_CTX *libctx)
+static void *stored_namemap_new(ossl_unused OPENSSL_CTX *unused__libctx)
 {
     OSSL_NAMEMAP *namemap = ossl_namemap_new();
 

--- a/crypto/ct/ct_x509v3.c
+++ b/crypto/ct/ct_x509v3.c
@@ -15,17 +15,19 @@
 
 DEFINE_STACK_OF(SCT)
 
-static char *i2s_poison(const X509V3_EXT_METHOD *method, void *val)
+static char *i2s_poison(ossl_unused const X509V3_EXT_METHOD *unused__method, ossl_unused void *unused__val)
 {
     return OPENSSL_strdup("NULL");
 }
 
-static void *s2i_poison(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx, const char *str)
+static void *s2i_poison(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                        ossl_unused X509V3_CTX *unused__ctx,
+                        ossl_unused const char *unused__str)
 {
    return ASN1_NULL_new();
 }
 
-static int i2r_SCT_LIST(X509V3_EXT_METHOD *method, STACK_OF(SCT) *sct_list,
+static int i2r_SCT_LIST(ossl_unused X509V3_EXT_METHOD *unused__method, STACK_OF(SCT) *sct_list,
                  BIO *out, int indent)
 {
     SCT_LIST_print(sct_list, out, indent, "\n", NULL);

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -354,7 +354,7 @@ static int dh_security_bits(const EVP_PKEY *pkey)
     return DH_security_bits(pkey->pkey.dh);
 }
 
-static int dh_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
+static int dh_cmp_parameters(const EVP_PKEY *a, ossl_unused const EVP_PKEY *unused__b)
 {
     return ffc_params_cmp(&a->pkey.dh->params, &a->pkey.dh->params,
                           a->ameth != &dhx_asn1_meth);
@@ -414,19 +414,19 @@ static int dh_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 }
 
 static int dh_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                          ASN1_PCTX *ctx)
+                          ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_dh_print(bp, pkey->pkey.dh, indent, 0);
 }
 
 static int dh_public_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                           ASN1_PCTX *ctx)
+                           ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_dh_print(bp, pkey->pkey.dh, indent, 1);
 }
 
 static int dh_private_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                            ASN1_PCTX *ctx)
+                            ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_dh_print(bp, pkey->pkey.dh, indent, 2);
 }
@@ -453,7 +453,7 @@ static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
     }
 }
 
-static int dhx_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int dhx_pkey_ctrl(ossl_unused EVP_PKEY *unused__pkey, int op, long arg1, void *arg2)
 {
     switch (op) {
 #ifndef OPENSSL_NO_CMS
@@ -500,8 +500,9 @@ static size_t dh_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static int dh_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                             EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
-                             const char *propq)
+                             EVP_KEYMGMT *to_keymgmt,
+                             ossl_unused OPENSSL_CTX *unused__libctx,
+                             ossl_unused const char *unused__propq)
 {
     DH *dh = from->pkey.dh;
     OSSL_PARAM_BLD *tmpl;

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -21,8 +21,9 @@
 #include <openssl/asn1t.h>
 
 /* Override the default free and new methods */
-static int dh_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
+static int dh_cb(int operation, ASN1_VALUE **pval,
+                 ossl_unused const ASN1_ITEM *unused__it,
+                 ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)DH_new();

--- a/crypto/dh/dh_gen.c
+++ b/crypto/dh/dh_gen.c
@@ -40,6 +40,7 @@ int dh_generate_ffc_parameters(DH *dh, int type, int pbits, int qbits,
 {
     int ret, res;
 
+    (void)type; /* silence -Wunused-parameter */
 #ifndef FIPS_MODULE
     if (type == DH_PARAMGEN_TYPE_FIPS_186_2)
         ret = ffc_params_FIPS186_2_generate(dh->libctx, &dh->params,
@@ -115,6 +116,7 @@ int DH_generate_parameters_ex(DH *ret, int prime_len, int generator,
                               BN_GENCB *cb)
 {
 #ifdef FIPS_MODULE
+    (void)cb; /* silence -Wunused-parameter */
     if (generator != 2)
         return 0;
     return dh_gen_named_group(ret->libctx, ret, prime_len);

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -145,7 +145,7 @@ const DH_METHOD *DH_get_default_method(void)
     return default_DH_method;
 }
 
-static int dh_bn_mod_exp(const DH *dh, BIGNUM *r,
+static int dh_bn_mod_exp(ossl_unused const DH *unused__dh, BIGNUM *r,
                          const BIGNUM *a, const BIGNUM *p,
                          const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *m_ctx)
 {

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -104,6 +104,8 @@ static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
             goto err;
         }
     }
+#else
+    (void)engine; /* silence -Wunused-parameter */
 #endif
 
     ret->flags = ret->meth->flags;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -390,19 +390,19 @@ static int dsa_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
 }
 
 static int dsa_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                           ASN1_PCTX *ctx)
+                           ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 0);
 }
 
 static int dsa_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                         ASN1_PCTX *ctx)
+                         ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 1);
 }
 
 static int dsa_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                          ASN1_PCTX *ctx)
+                          ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_dsa_print(bp, pkey->pkey.dsa, indent, 2);
 }
@@ -426,8 +426,9 @@ static int old_dsa_priv_encode(const EVP_PKEY *pkey, unsigned char **pder)
     return i2d_DSAPrivateKey(pkey->pkey.dsa, pder);
 }
 
-static int dsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
-                         const ASN1_STRING *sig, int indent, ASN1_PCTX *pctx)
+static int dsa_sig_print(BIO *bp, ossl_unused const X509_ALGOR *unused__sigalg,
+                         const ASN1_STRING *sig, int indent,
+                         ossl_unused ASN1_PCTX *unused__pctx)
 {
     DSA_SIG *dsa_sig;
     const unsigned char *p;
@@ -520,8 +521,9 @@ static size_t dsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static int dsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                              EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
-                              const char *propq)
+                              EVP_KEYMGMT *to_keymgmt,
+                              ossl_unused OPENSSL_CTX *unused__libctx,
+                              ossl_unused const char *unused__propq)
 {
     DSA *dsa = from->pkey.dsa;
     OSSL_PARAM_BLD *tmpl;

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -22,8 +22,9 @@
 #include "crypto/asn1_dsa.h"
 
 /* Override the default free and new methods */
-static int dsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int dsa_cb(int operation, ASN1_VALUE **pval,
+                  ossl_unused const ASN1_ITEM *unused__it,
+                  ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)DSA_new();

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -27,7 +27,7 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type, int pbits, int qbits,
                                 BN_GENCB *cb)
 {
     int ret = 0, res;
-
+    (void)type; /* silence -Wunused-parameter */
 #ifndef FIPS_MODULE
     if (type == DSA_PARAMGEN_TYPE_FIPS_186_2)
         ret = ffc_params_FIPS186_2_generate(dsa->libctx, &dsa->params,

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -168,6 +168,8 @@ static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
             goto err;
         }
     }
+#else
+    (void)engine; /* silence -Wunused-parameter */
 #endif
 
     ret->flags = ret->meth->flags & ~DSA_FLAG_NON_FIPS_ALLOW;

--- a/crypto/dsa/dsa_sign.c
+++ b/crypto/dsa/dsa_sign.c
@@ -148,7 +148,7 @@ int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s)
     return 1;
 }
 
-int dsa_sign_int(int type, const unsigned char *dgst,
+int dsa_sign_int(ossl_unused int unused__type, const unsigned char *dgst,
                  int dlen, unsigned char *sig, unsigned int *siglen, DSA *dsa)
 {
     DSA_SIG *s;
@@ -180,7 +180,7 @@ int DSA_sign(int type, const unsigned char *dgst, int dlen,
  *      0: incorrect signature
  *     -1: error
  */
-int DSA_verify(int type, const unsigned char *dgst, int dgst_len,
+int DSA_verify(ossl_unused int unused__type, const unsigned char *dgst, int dgst_len,
                const unsigned char *sigbuf, int siglen, DSA *dsa)
 {
     DSA_SIG *s;

--- a/crypto/dso/dso_dlfcn.c
+++ b/crypto/dso/dso_dlfcn.c
@@ -194,7 +194,7 @@ static DSO_FUNC_TYPE dlfcn_bind_func(DSO *dso, const char *symname)
     return u.sym;
 }
 
-static char *dlfcn_merger(DSO *dso, const char *filespec1,
+static char *dlfcn_merger(ossl_unused DSO *unused__dso, const char *filespec1,
                           const char *filespec2)
 {
     char *merged;

--- a/crypto/dso/dso_lib.c
+++ b/crypto/dso/dso_lib.c
@@ -14,7 +14,7 @@ DEFINE_STACK_OF(void)
 
 static DSO_METHOD *default_DSO_meth = NULL;
 
-static DSO *DSO_new_method(DSO_METHOD *meth)
+static DSO *DSO_new_method(ossl_unused DSO_METHOD *unused__meth)
 {
     DSO *ret;
 

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -100,7 +100,7 @@ int ec_GF2m_simple_group_copy(EC_GROUP *dest, const EC_GROUP *src)
 /* Set the curve parameters of an EC_GROUP structure. */
 int ec_GF2m_simple_group_set_curve(EC_GROUP *group,
                                    const BIGNUM *p, const BIGNUM *a,
-                                   const BIGNUM *b, BN_CTX *ctx)
+                                   const BIGNUM *b, ossl_unused BN_CTX *unused__ctx)
 {
     int ret = 0, i;
 
@@ -139,7 +139,7 @@ int ec_GF2m_simple_group_set_curve(EC_GROUP *group,
  * then there values will not be set but the method will return with success.
  */
 int ec_GF2m_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
-                                   BIGNUM *a, BIGNUM *b, BN_CTX *ctx)
+                                   BIGNUM *a, BIGNUM *b, ossl_unused BN_CTX *unused__ctx)
 {
     int ret = 0;
 
@@ -274,7 +274,7 @@ int ec_GF2m_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
  * Set an EC_POINT to the point at infinity. A point at infinity is
  * represented by having Z=0.
  */
-int ec_GF2m_simple_point_set_to_infinity(const EC_GROUP *group,
+int ec_GF2m_simple_point_set_to_infinity(ossl_unused const EC_GROUP *unused__group,
                                          EC_POINT *point)
 {
     point->Z_is_one = 0;
@@ -286,10 +286,11 @@ int ec_GF2m_simple_point_set_to_infinity(const EC_GROUP *group,
  * Set the coordinates of an EC_POINT using affine coordinates. Note that
  * the simple implementation only uses affine coordinates.
  */
-int ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *group,
+int ec_GF2m_simple_point_set_affine_coordinates(ossl_unused const EC_GROUP *unused__group,
                                                 EC_POINT *point,
                                                 const BIGNUM *x,
-                                                const BIGNUM *y, BN_CTX *ctx)
+                                                const BIGNUM *y,
+                                                ossl_unused BN_CTX *unused__ctx)
 {
     int ret = 0;
     if (x == NULL || y == NULL) {
@@ -321,7 +322,7 @@ int ec_GF2m_simple_point_set_affine_coordinates(const EC_GROUP *group,
 int ec_GF2m_simple_point_get_affine_coordinates(const EC_GROUP *group,
                                                 const EC_POINT *point,
                                                 BIGNUM *x, BIGNUM *y,
-                                                BN_CTX *ctx)
+                                                ossl_unused BN_CTX *unused__ctx)
 {
     int ret = 0;
 
@@ -496,7 +497,7 @@ int ec_GF2m_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
 }
 
 /* Indicates whether the given point is the point at infinity. */
-int ec_GF2m_simple_is_at_infinity(const EC_GROUP *group,
+int ec_GF2m_simple_is_at_infinity(ossl_unused const EC_GROUP *unused__group,
                                   const EC_POINT *point)
 {
     return BN_is_zero(point->Z);

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -452,19 +452,19 @@ static int eckey_param_encode(const EVP_PKEY *pkey, unsigned char **pder)
 }
 
 static int eckey_param_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                             ASN1_PCTX *ctx)
+                             ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PARAM);
 }
 
 static int eckey_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                           ASN1_PCTX *ctx)
+                           ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PUBLIC);
 }
 
 static int eckey_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                            ASN1_PCTX *ctx)
+                            ossl_unused ASN1_PCTX *unused__ctx)
 {
     return do_EC_KEY_print(bp, pkey->pkey.ec, indent, EC_KEY_PRINT_PRIVATE);
 }

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -50,7 +50,9 @@ static char *ec_param_encoding_id2name(int id)
 }
 
 int ec_group_todata(const EC_GROUP *group, OSSL_PARAM_BLD *tmpl,
-                    OSSL_PARAM params[], OPENSSL_CTX *libctx, const char *propq,
+                    OSSL_PARAM params[],
+                    ossl_unused OPENSSL_CTX *unused__libctx,
+                    ossl_unused const char *unused__propq,
                     BN_CTX *bnctx, unsigned char **genbuf)
 {
     int ret = 0, curve_nid, encoding_flag;

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -119,6 +119,8 @@ EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, const char *propq,
             goto err;
         }
     }
+#else
+    (void)engine; /* silence -Wunused-parameter */
 #endif
 
     ret->version = 1;

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -440,7 +440,7 @@ BN_MONT_CTX *EC_GROUP_get_mont_data(const EC_GROUP *group)
     return group->mont_data;
 }
 
-int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, BN_CTX *ctx)
+int EC_GROUP_get_order(const EC_GROUP *group, BIGNUM *order, ossl_unused BN_CTX *unused__ctx)
 {
     if (group->order == NULL)
         return 0;
@@ -461,7 +461,7 @@ int EC_GROUP_order_bits(const EC_GROUP *group)
 }
 
 int EC_GROUP_get_cofactor(const EC_GROUP *group, BIGNUM *cofactor,
-                          BN_CTX *ctx)
+                          ossl_unused BN_CTX *unused__ctx)
 {
 
     if (group->cofactor == NULL)

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -55,7 +55,7 @@ int ossl_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
     return eckey->group->meth->ecdsa_verify_sig(dgst, dgst_len, sig, eckey);
 }
 
-int ossl_ecdsa_sign(int type, const unsigned char *dgst, int dlen,
+int ossl_ecdsa_sign(ossl_unused int unused__type, const unsigned char *dgst, int dlen,
                     unsigned char *sig, unsigned int *siglen,
                     const BIGNUM *kinv, const BIGNUM *r, EC_KEY *eckey)
 {
@@ -330,7 +330,7 @@ ECDSA_SIG *ecdsa_simple_sign_sig(const unsigned char *dgst, int dgst_len,
  *      0: incorrect signature
  *     -1: error
  */
-int ossl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
+int ossl_ecdsa_verify(ossl_unused int unused__type, const unsigned char *dgst, int dgst_len,
                       const unsigned char *sigbuf, int sig_len, EC_KEY *eckey)
 {
     ECDSA_SIG *s;

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -286,7 +286,7 @@ int ec_GFp_mont_field_decode(const EC_GROUP *group, BIGNUM *r,
 }
 
 int ec_GFp_mont_field_set_to_one(const EC_GROUP *group, BIGNUM *r,
-                                 BN_CTX *ctx)
+                                 ossl_unused BN_CTX *unused__ctx)
 {
     if (group->field_data2 == NULL) {
         ECerr(EC_F_EC_GFP_MONT_FIELD_SET_TO_ONE, EC_R_NOT_INITIALIZED);

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -936,9 +936,10 @@ __owur static int ecp_nistz256_mult_precompute(EC_GROUP *group, BN_CTX *ctx)
     return ret;
 }
 
-__owur static int ecp_nistz256_set_from_affine(EC_POINT *out, const EC_GROUP *group,
+__owur static int ecp_nistz256_set_from_affine(EC_POINT *out,
+                                               ossl_unused const EC_GROUP *unused__group,
                                                const P256_POINT_AFFINE *in,
-                                               BN_CTX *ctx)
+                                               ossl_unused BN_CTX *unused__ctx)
 {
     int ret = 0;
 
@@ -1176,7 +1177,8 @@ err:
 
 __owur static int ecp_nistz256_get_affine(const EC_GROUP *group,
                                           const EC_POINT *point,
-                                          BIGNUM *x, BIGNUM *y, BN_CTX *ctx)
+                                          BIGNUM *x, BIGNUM *y,
+                                          ossl_unused BN_CTX *unused__ctx)
 {
     BN_ULONG z_inv2[P256_LIMBS];
     BN_ULONG z_inv3[P256_LIMBS];

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -364,7 +364,7 @@ int ec_GFp_simple_point_copy(EC_POINT *dest, const EC_POINT *src)
     return 1;
 }
 
-int ec_GFp_simple_point_set_to_infinity(const EC_GROUP *group,
+int ec_GFp_simple_point_set_to_infinity(ossl_unused const EC_GROUP *unused__group,
                                         EC_POINT *point)
 {
     point->Z_is_one = 0;
@@ -940,7 +940,8 @@ int ec_GFp_simple_dbl(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a,
     return ret;
 }
 
-int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
+int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point,
+                         ossl_unused BN_CTX *unused__ctx)
 {
     if (EC_POINT_is_at_infinity(group, point) || BN_is_zero(point->Y))
         /* point is its own inverse */
@@ -949,7 +950,7 @@ int ec_GFp_simple_invert(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx)
     return BN_usub(point->Y, group->field, point->Y);
 }
 
-int ec_GFp_simple_is_at_infinity(const EC_GROUP *group, const EC_POINT *point)
+int ec_GFp_simple_is_at_infinity(ossl_unused const EC_GROUP *unused__group, const EC_POINT *point)
 {
     return BN_is_zero(point->Z);
 }

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -36,7 +36,7 @@ typedef enum {
 /* Setup EVP_PKEY using public, private or generation */
 static int ecx_key_op(EVP_PKEY *pkey, int id, const X509_ALGOR *palg,
                       const unsigned char *p, int plen, ecx_key_op_t op,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OPENSSL_CTX *libctx, ossl_unused const char *unused__propq)
 {
     ECX_KEY *key = NULL;
     unsigned char *privkey, *pubkey;
@@ -240,13 +240,14 @@ static void ecx_free(EVP_PKEY *pkey)
 }
 
 /* "parameters" are always equal */
-static int ecx_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
+static int ecx_cmp_parameters(ossl_unused const EVP_PKEY *unused__a,
+                              ossl_unused const EVP_PKEY *unused__b)
 {
     return 1;
 }
 
 static int ecx_key_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                         ASN1_PCTX *ctx, ecx_key_op_t op)
+                         ossl_unused ASN1_PCTX *unused__ctx, ecx_key_op_t op)
 {
     const ECX_KEY *ecxkey = pkey->pkey.ecx;
     const char *nm = OBJ_nid2ln(pkey->ameth->pkey_id);
@@ -318,7 +319,7 @@ static int ecx_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
     }
 }
 
-static int ecd_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int ecd_ctrl(ossl_unused EVP_PKEY *unused__pkey, int op, ossl_unused long unused__arg1, void *arg2)
 {
     switch (op) {
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:
@@ -387,7 +388,7 @@ static int ecx_get_pub_key(const EVP_PKEY *pkey, unsigned char *pub,
     return 1;
 }
 
-static size_t ecx_pkey_dirty_cnt(const EVP_PKEY *pkey)
+static size_t ecx_pkey_dirty_cnt(ossl_unused const EVP_PKEY *unused__pkey)
 {
     /*
      * We provide no mechanism to "update" an ECX key once it has been set,
@@ -397,8 +398,9 @@ static size_t ecx_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 static int ecx_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
-                              EVP_KEYMGMT *to_keymgmt, OPENSSL_CTX *libctx,
-                              const char *propq)
+                              EVP_KEYMGMT *to_keymgmt,
+                              ossl_unused OPENSSL_CTX *unused__libctx,
+                              ossl_unused const char *unused__propq)
 {
     const ECX_KEY *key = from->pkey.ecx;
     OSSL_PARAM_BLD *tmpl = OSSL_PARAM_BLD_new();
@@ -560,19 +562,22 @@ const EVP_PKEY_ASN1_METHOD ecx448_asn1_meth = {
     ecx_priv_decode_with_libctx
 };
 
-static int ecd_size25519(const EVP_PKEY *pkey)
+static int ecd_size25519(ossl_unused const EVP_PKEY *unused__pkey)
 {
     return ED25519_SIGSIZE;
 }
 
-static int ecd_size448(const EVP_PKEY *pkey)
+static int ecd_size448(ossl_unused const EVP_PKEY *unused__pkey)
 {
     return ED448_SIGSIZE;
 }
 
-static int ecd_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
-                           const void *asn, const X509_ALGOR *sigalg,
-                           const ASN1_BIT_STRING *str, EVP_PKEY *pkey)
+static int ecd_item_verify(EVP_MD_CTX *ctx,
+                           ossl_unused const ASN1_ITEM *unused__it,
+                           ossl_unused const void *unused__data,
+                           const X509_ALGOR *sigalg,
+                           ossl_unused const ASN1_BIT_STRING *unused__sig,
+                           EVP_PKEY *pkey)
 {
     const ASN1_OBJECT *obj;
     int ptype;
@@ -592,10 +597,11 @@ static int ecd_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
     return 2;
 }
 
-static int ecd_item_sign25519(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
-                              const void *asn,
+static int ecd_item_sign25519(ossl_unused EVP_MD_CTX *unused__ctx,
+                              ossl_unused const ASN1_ITEM *unused__it,
+                              ossl_unused const void *unused__data,
                               X509_ALGOR *alg1, X509_ALGOR *alg2,
-                              ASN1_BIT_STRING *str)
+                              ossl_unused ASN1_BIT_STRING *unused__str)
 {
     /* Set algorithms identifiers */
     X509_ALGOR_set0(alg1, OBJ_nid2obj(NID_ED25519), V_ASN1_UNDEF, NULL);
@@ -605,18 +611,20 @@ static int ecd_item_sign25519(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
     return 3;
 }
 
-static int ecd_sig_info_set25519(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
-                                 const ASN1_STRING *sig)
+static int ecd_sig_info_set25519(X509_SIG_INFO *siginf,
+                                 ossl_unused const X509_ALGOR *unused__alg,
+                                 ossl_unused const ASN1_STRING *unused__sig)
 {
     X509_SIG_INFO_set(siginf, NID_undef, NID_ED25519, X25519_SECURITY_BITS,
                       X509_SIG_INFO_TLS);
     return 1;
 }
 
-static int ecd_item_sign448(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
-                            const void *asn,
+static int ecd_item_sign448(ossl_unused EVP_MD_CTX *unused__ctx,
+                            ossl_unused const ASN1_ITEM *unused__it,
+                            ossl_unused const void *unused__data,
                             X509_ALGOR *alg1, X509_ALGOR *alg2,
-                            ASN1_BIT_STRING *str)
+                            ossl_unused ASN1_BIT_STRING *unused__str)
 {
     /* Set algorithm identifier */
     X509_ALGOR_set0(alg1, OBJ_nid2obj(NID_ED448), V_ASN1_UNDEF, NULL);
@@ -626,8 +634,9 @@ static int ecd_item_sign448(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
     return 3;
 }
 
-static int ecd_sig_info_set448(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
-                               const ASN1_STRING *sig)
+static int ecd_sig_info_set448(X509_SIG_INFO *siginf,
+                               ossl_unused const X509_ALGOR *unused__alg,
+                               ossl_unused const ASN1_STRING *unused__sig)
 {
     X509_SIG_INFO_set(siginf, NID_undef, NID_ED448, X448_SECURITY_BITS,
                       X509_SIG_INFO_TLS);
@@ -744,10 +753,11 @@ static int pkey_ecx_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
                       NULL, NULL);
 }
 
-static int validate_ecx_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
-                                          size_t *keylen,
-                                          const unsigned char **privkey,
-                                          const unsigned char **pubkey)
+static int validate_ecx_derive(EVP_PKEY_CTX *ctx,
+                               ossl_unused unsigned char *unused__key,
+                               ossl_unused size_t *unused__keylen,
+                               const unsigned char **privkey,
+                               const unsigned char **pubkey)
 {
     const ECX_KEY *ecxkey, *peerkey;
 
@@ -797,7 +807,8 @@ static int pkey_ecx_derive448(EVP_PKEY_CTX *ctx, unsigned char *key,
     return 1;
 }
 
-static int pkey_ecx_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
+static int pkey_ecx_ctrl(ossl_unused EVP_PKEY_CTX *unused__ctx, int type,
+                         ossl_unused int unused__p1, ossl_unused void *unused__p2)
 {
     /* Only need to handle peer key for derivation */
     if (type == EVP_PKEY_CTRL_PEER_KEY)
@@ -901,7 +912,8 @@ static int pkey_ecd_digestverify448(EVP_MD_CTX *ctx, const unsigned char *sig,
     return ED448_verify(NULL, tbs, tbslen, sig, edkey->pubkey, NULL, 0);
 }
 
-static int pkey_ecd_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
+static int pkey_ecd_ctrl(ossl_unused EVP_PKEY_CTX *unused__ctx, int type,
+                         ossl_unused int unused__p1, void *p2)
 {
     switch (type) {
     case EVP_PKEY_CTRL_MD:

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -140,8 +140,10 @@ static void *get_decoder_from_store(OPENSSL_CTX *libctx, void *store,
 
 static int put_decoder_in_store(OPENSSL_CTX *libctx, void *store,
                                 void *method, const OSSL_PROVIDER *prov,
-                                int operation_id, const char *names,
-                                const char *propdef, void *unused)
+                                ossl_unused int unused__operation_id,
+                                const char *names,
+                                const char *propdef,
+                                ossl_unused void *unused__data)
 {
     OSSL_NAMEMAP *namemap;
     int id;
@@ -239,7 +241,8 @@ static void *decoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
  * then call decoder_from_dispatch() with that identity number.
  */
 static void *construct_decoder(const OSSL_ALGORITHM *algodef,
-                               OSSL_PROVIDER *prov, void *unused)
+                               OSSL_PROVIDER *prov,
+                               ossl_unused void *unused__data)
 {
     /*
      * This function is only called if get_decoder_from_store() returned
@@ -260,7 +263,7 @@ static void *construct_decoder(const OSSL_ALGORITHM *algodef,
 }
 
 /* Intermediary function to avoid ugly casts, used below */
-static void destruct_decoder(void *method, void *data)
+static void destruct_decoder(void *method, ossl_unused void *unused__data)
 {
     OSSL_DECODER_free(method);
 }
@@ -397,7 +400,8 @@ struct decoder_do_all_data_st {
 
 static void decoder_do_one(OSSL_PROVIDER *provider,
                            const OSSL_ALGORITHM *algodef,
-                           int no_store, void *vdata)
+                           ossl_unused int unused__no_store,
+                           void *vdata)
 {
     struct decoder_do_all_data_st *data = vdata;
     OPENSSL_CTX *libctx = ossl_provider_library_context(provider);

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -138,8 +138,10 @@ static void *get_encoder_from_store(OPENSSL_CTX *libctx, void *store,
 
 static int put_encoder_in_store(OPENSSL_CTX *libctx, void *store,
                                 void *method, const OSSL_PROVIDER *prov,
-                                int operation_id, const char *names,
-                                const char *propdef, void *unused)
+                                ossl_unused int unused__operation_id,
+                                const char *names,
+                                const char *propdef,
+                                ossl_unused void *unused__data)
 {
     OSSL_NAMEMAP *namemap;
     int id;
@@ -231,7 +233,8 @@ static void *encoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
  * then call encoder_from_dispatch() with that identity number.
  */
 static void *construct_encoder(const OSSL_ALGORITHM *algodef,
-                               OSSL_PROVIDER *prov, void *unused)
+                               OSSL_PROVIDER *prov,
+                               ossl_unused void *unused__data)
 {
     /*
      * This function is only called if get_encoder_from_store() returned
@@ -252,7 +255,7 @@ static void *construct_encoder(const OSSL_ALGORITHM *algodef,
 }
 
 /* Intermediary function to avoid ugly casts, used below */
-static void destruct_encoder(void *method, void *data)
+static void destruct_encoder(void *method, ossl_unused void *unused__data)
 {
     OSSL_ENCODER_free(method);
 }
@@ -389,7 +392,8 @@ struct encoder_do_all_data_st {
 
 static void encoder_do_one(OSSL_PROVIDER *provider,
                            const OSSL_ALGORITHM *algodef,
-                           int no_store, void *vdata)
+                           ossl_unused int unused__no_store,
+                           void *vdata)
 {
     struct encoder_do_all_data_st *data = vdata;
     OPENSSL_CTX *libctx = ossl_provider_library_context(provider);

--- a/crypto/encode_decode/endecode_pass.c
+++ b/crypto/encode_decode/endecode_pass.c
@@ -21,7 +21,9 @@
  * verify) passphrase reading.
  */
 static int do_passphrase(char *pass, size_t pass_size, size_t *pass_len,
-                         const OSSL_PARAM params[], void *arg, int verify,
+                         const OSSL_PARAM params[],
+                         ossl_unused void *unused__arg,
+                         int verify,
                          const UI_METHOD *ui_method, void *ui_data, int errlib)
 {
     const OSSL_PARAM *p;

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -173,7 +173,7 @@ static int int_engine_module_init(CONF_IMODULE *md, const CONF *cnf)
     return 1;
 }
 
-static void int_engine_module_finish(CONF_IMODULE *md)
+static void int_engine_module_finish(ossl_unused CONF_IMODULE *unused__md)
 {
     ENGINE *e;
 

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -62,7 +62,7 @@ static int int_ctrl_cmd_by_num(const ENGINE_CMD_DEFN *defn, unsigned int num)
 }
 
 static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
-                           void (*f) (void))
+                           ossl_unused void (*f) (void))
 {
     int idx;
     char *s = (char *)p;

--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -136,9 +136,12 @@ static void int_free_str(char *s)
  * a "free" handler and that will get called if an ENGINE is being destroyed
  * and there was an ex_data element corresponding to our context type.
  */
-static void dynamic_data_ctx_free_func(void *parent, void *ptr,
-                                       CRYPTO_EX_DATA *ad, int idx, long argl,
-                                       void *argp)
+static void dynamic_data_ctx_free_func(ossl_unused void *unused__parent,
+                                       void *ptr,
+                                       ossl_unused CRYPTO_EX_DATA *unused__ad,
+                                       ossl_unused int unused__idx,
+                                       ossl_unused long unused__argl,
+                                       ossl_unused void *unused__argp)
 {
     if (ptr) {
         dynamic_data_ctx *ctx = (dynamic_data_ctx *)ptr;
@@ -273,7 +276,7 @@ void engine_load_dynamic_int(void)
     ERR_clear_error();
 }
 
-static int dynamic_init(ENGINE *e)
+static int dynamic_init(ossl_unused ENGINE *unused__e)
 {
     /*
      * We always return failure - the "dynamic" engine itself can't be used
@@ -282,7 +285,7 @@ static int dynamic_init(ENGINE *e)
     return 0;
 }
 
-static int dynamic_finish(ENGINE *e)
+static int dynamic_finish(ossl_unused ENGINE *unused__e)
 {
     /*
      * This should never be called on account of "dynamic_init" always
@@ -291,7 +294,7 @@ static int dynamic_finish(ENGINE *e)
     return 0;
 }
 
-static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, ossl_unused void (*f) (void))
 {
     dynamic_data_ctx *ctx = dynamic_get_data_ctx(e);
     int initialised;

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -198,7 +198,8 @@ typedef struct {
 } TEST_RC4_KEY;
 # define test(ctx) ((TEST_RC4_KEY *)EVP_CIPHER_CTX_get_cipher_data(ctx))
 static int test_rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             ossl_unused const unsigned char *unused__iv,
+                             ossl_unused int unused__enc)
 {
     const int n = EVP_CIPHER_CTX_key_length(ctx);
 
@@ -290,7 +291,7 @@ static int test_cipher_nids(const int **nids)
     return pos;
 }
 
-static int openssl_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
+static int openssl_ciphers(ossl_unused ENGINE *unused__e, const EVP_CIPHER **cipher,
                            const int **nids, int nid)
 {
     if (!cipher) {
@@ -386,7 +387,7 @@ static int test_digest_nids(const int **nids)
     return pos;
 }
 
-static int openssl_digests(ENGINE *e, const EVP_MD **digest,
+static int openssl_digests(ossl_unused ENGINE *unused__e, const EVP_MD **digest,
                            const int **nids, int nid)
 {
     if (!digest) {
@@ -409,9 +410,10 @@ static int openssl_digests(ENGINE *e, const EVP_MD **digest,
 #endif
 
 #ifdef TEST_ENG_OPENSSL_PKEY
-static EVP_PKEY *openssl_load_privkey(ENGINE *eng, const char *key_id,
-                                      UI_METHOD *ui_method,
-                                      void *callback_data)
+static EVP_PKEY *openssl_load_privkey(ossl_unused ENGINE *unused__eng,
+                                      const char *key_id,
+                                      ossl_unused UI_METHOD *unused__ui_method,
+                                      ossl_unused void *unused__callback_data)
 {
     BIO *in;
     EVP_PKEY *key;
@@ -651,7 +653,7 @@ static int ossl_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 
 #endif
 
-int openssl_destroy(ENGINE *e)
+int openssl_destroy(ossl_unused ENGINE *unused__e)
 {
     test_sha_md_destroy();
 #ifdef TEST_ENG_OPENSSL_RC4
@@ -660,4 +662,3 @@ int openssl_destroy(ENGINE *e)
 #endif
     return 1;
 }
-

--- a/crypto/engine/eng_rdrand.c
+++ b/crypto/engine/eng_rdrand.c
@@ -49,7 +49,7 @@ static RAND_METHOD rdrand_meth = {
     random_status,
 };
 
-static int rdrand_init(ENGINE *e)
+static int rdrand_init(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -165,7 +165,9 @@ typedef struct {
     int len;
 } ENGINE_FIND_STR;
 
-static void look_str_cb(int nid, STACK_OF(ENGINE) *sk, ENGINE *def, void *arg)
+static void look_str_cb(int nid, STACK_OF(ENGINE) *sk,
+                        ossl_unused ENGINE *unused__def,
+                        void *arg)
 {
     ENGINE_FIND_STR *lk = arg;
     int i;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -267,7 +267,7 @@ int ERR_load_strings_const(const ERR_STRING_DATA *str)
     return 1;
 }
 
-int ERR_unload_strings(int lib, ERR_STRING_DATA *str)
+int ERR_unload_strings(ossl_unused int unused__lib, ERR_STRING_DATA *str)
 {
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
         return 0;
@@ -560,7 +560,7 @@ const char *ERR_lib_error_string(unsigned long e)
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
-const char *ERR_func_error_string(unsigned long e)
+const char *ERR_func_error_string(ossl_unused unsigned long unused__e)
 {
     return NULL;
 }
@@ -595,7 +595,7 @@ const char *ERR_reason_error_string(unsigned long e)
 }
 
 /* TODO(3.0): arg ignored for now */
-static void err_delete_thread_state(void *arg)
+static void err_delete_thread_state(ossl_unused void *unused__arg)
 {
     ERR_STATE *state = CRYPTO_THREAD_get_local(&err_thread_local);
     if (state == NULL)
@@ -606,13 +606,13 @@ static void err_delete_thread_state(void *arg)
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_1_1_0
-void ERR_remove_thread_state(void *dummy)
+void ERR_remove_thread_state(ossl_unused void *unused__dummy)
 {
 }
 #endif
 
 #ifndef OPENSSL_NO_DEPRECATED_1_0_0
-void ERR_remove_state(unsigned long pid)
+void ERR_remove_state(ossl_unused unsigned long unused__pid)
 {
 }
 #endif

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -142,7 +142,8 @@ static void ctr64_inc(unsigned char *counter)
 # endif
 
 static int aesni_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                          const unsigned char *iv, int enc)
+                          ossl_unused const unsigned char *unused__iv,
+                          int enc)
 {
     int ret, mode;
     EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
@@ -219,7 +220,7 @@ static int aesni_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                             const unsigned char *in, size_t len);
 
 static int aesni_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                              const unsigned char *iv, int enc)
+                              const unsigned char *iv, ossl_unused int unused__enc)
 {
     EVP_AES_GCM_CTX *gctx = EVP_C_DATA(EVP_AES_GCM_CTX,ctx);
     if (!iv && !key)
@@ -2283,7 +2284,7 @@ const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
         BLOCK_CIPHER_generic(nid,keylen,1,16,ctr,ctr,CTR,flags)
 
 static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        ossl_unused const unsigned char *unused__iv, int enc)
 {
     int ret, mode;
     EVP_AES_KEY *dat = EVP_C_DATA(EVP_AES_KEY,ctx);
@@ -2672,7 +2673,7 @@ static int aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 }
 
 static int aes_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            const unsigned char *iv, ossl_unused int unused__enc)
 {
     EVP_AES_GCM_CTX *gctx = EVP_C_DATA(EVP_AES_GCM_CTX,ctx);
     if (!iv && !key)
@@ -3060,7 +3061,7 @@ BLOCK_CIPHER_custom(NID_aes, 128, 1, 12, gcm, GCM,
     BLOCK_CIPHER_custom(NID_aes, 256, 1, 12, gcm, GCM,
                     EVP_CIPH_FLAG_AEAD_CIPHER | CUSTOM_FLAGS)
 
-static int aes_xts_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
+static int aes_xts_ctrl(EVP_CIPHER_CTX *c, int type, ossl_unused int unused__arg, void *ptr)
 {
     EVP_AES_XTS_CTX *xctx = EVP_C_DATA(EVP_AES_XTS_CTX, c);
 
@@ -3343,7 +3344,7 @@ static int aes_ccm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 }
 
 static int aes_ccm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            const unsigned char *iv, ossl_unused int unused__enc)
 {
     EVP_AES_CCM_CTX *cctx = EVP_C_DATA(EVP_AES_CCM_CTX,ctx);
     if (!iv && !key)
@@ -3526,7 +3527,7 @@ typedef struct {
 } EVP_AES_WRAP_CTX;
 
 static int aes_wrap_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             const unsigned char *iv, ossl_unused int unused__enc)
 {
     EVP_AES_WRAP_CTX *wctx = EVP_C_DATA(EVP_AES_WRAP_CTX,ctx);
     if (!iv && !key)
@@ -3787,6 +3788,8 @@ static int aes_ocb_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                     return 0;
                 break;
             }
+# else
+            (void)enc; /* silence -Wunused-parameter */
 # endif
 # ifdef VPAES_CAPABLE
             if (VPAES_CAPABLE) {
@@ -4010,7 +4013,7 @@ typedef SIV128_CONTEXT EVP_AES_SIV_CTX;
 
 #define aesni_siv_init_key aes_siv_init_key
 static int aes_siv_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            ossl_unused const unsigned char *unused__iv, ossl_unused int unused__enc)
 {
     const EVP_CIPHER *ctr;
     const EVP_CIPHER *cbc;

--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
@@ -68,7 +68,8 @@ void aesni256_cbc_sha1_dec(const void *inp, void *out, size_t blocks,
 
 static int aesni_cbc_hmac_sha1_init_key(EVP_CIPHER_CTX *ctx,
                                         const unsigned char *inkey,
-                                        const unsigned char *iv, int enc)
+                                        ossl_unused const unsigned char *unused__iv,
+                                        int enc)
 {
     EVP_AES_HMAC_SHA1 *key = data(ctx);
     int ret;

--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
@@ -64,7 +64,8 @@ int aesni_cbc_sha256_enc(const void *inp, void *out, size_t blocks,
 
 static int aesni_cbc_hmac_sha256_init_key(EVP_CIPHER_CTX *ctx,
                                           const unsigned char *inkey,
-                                          const unsigned char *iv, int enc)
+                                          ossl_unused const unsigned char *unused__iv,
+                                          int enc)
 {
     EVP_AES_HMAC_SHA256 *key = data(ctx);
     int ret;

--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -57,7 +57,8 @@ typedef struct {
 
 /* The subkey for ARIA is generated. */
 static int aria_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                         ossl_unused const unsigned char *unused__iv,
+                         int enc)
 {
     int ret;
     int mode = EVP_CIPHER_CTX_mode(ctx);
@@ -114,7 +115,7 @@ static void aria_cfb8_encrypt(const unsigned char *in, unsigned char *out,
 }
 
 static void aria_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                             const ARIA_KEY *key, const int enc)
+                             const ARIA_KEY *key, ossl_unused const int unused__enc)
 {
     aria_encrypt(in, out, key);
 }
@@ -203,7 +204,7 @@ static void ctr64_inc(unsigned char *counter)
 }
 
 static int aria_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                                 const unsigned char *iv, int enc)
+                             const unsigned char *iv, ossl_unused int unused__enc)
 {
     int ret;
     EVP_ARIA_GCM_CTX *gctx = EVP_C_DATA(EVP_ARIA_GCM_CTX,ctx);
@@ -499,7 +500,7 @@ static int aria_gcm_cleanup(EVP_CIPHER_CTX *ctx)
 }
 
 static int aria_ccm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                             const unsigned char *iv, ossl_unused int unused__enc)
 {
     int ret;
     EVP_ARIA_CCM_CTX *cctx = EVP_C_DATA(EVP_ARIA_CCM_CTX,ctx);

--- a/crypto/evp/e_bf.c
+++ b/crypto/evp/e_bf.c
@@ -36,7 +36,7 @@ IMPLEMENT_BLOCK_CIPHER(bf, ks, BF, EVP_BF_KEY, NID_bf, 8, 16, 8, 64,
                        EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 
 static int bf_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                       const unsigned char *iv, int enc)
+                       ossl_unused const unsigned char *unused__iv, ossl_unused int unused__enc)
 {
     BF_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -188,7 +188,7 @@ const EVP_CIPHER *EVP_camellia_##keylen##_##mode(void) \
 
 /* The subkey for Camellia is generated. */
 static int camellia_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             ossl_unused const unsigned char *unused__iv, int enc)
 {
     int ret, mode;
     EVP_CAMELLIA_KEY *dat = EVP_C_DATA(EVP_CAMELLIA_KEY,ctx);

--- a/crypto/evp/e_cast.c
+++ b/crypto/evp/e_cast.c
@@ -38,7 +38,8 @@ IMPLEMENT_BLOCK_CIPHER(cast5, ks, CAST, EVP_CAST_KEY,
                        EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 
 static int cast_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+                         ossl_unused const unsigned char *unused__iv,
+                         ossl_unused int unused__enc)
 {
     CAST_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -35,7 +35,8 @@ typedef struct {
 
 static int chacha_init_key(EVP_CIPHER_CTX *ctx,
                            const unsigned char user_key[CHACHA_KEY_SIZE],
-                           const unsigned char iv[CHACHA_CTR_SIZE], int enc)
+                           const unsigned char iv[CHACHA_CTR_SIZE],
+                           ossl_unused int unused__enc)
 {
     EVP_CHACHA_KEY *key = data(ctx);
     unsigned int i;

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -209,7 +209,8 @@ BLOCK_CIPHER_defs(des, EVP_DES_KEY, NID_des, 8, 8, 8, 64,
                      EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, des_ctrl)
 
 static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        ossl_unused const unsigned char *unused__iv,
+                        int enc)
 {
     DES_cblock *deskey = (DES_cblock *)key;
     EVP_DES_KEY *dat = (EVP_DES_KEY *) EVP_CIPHER_CTX_get_cipher_data(ctx);
@@ -225,12 +226,17 @@ static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             return 1;
         }
     }
+# else
+    (void)enc; /* silence -Wunused-parameter */
 # endif
     DES_set_key_unchecked(deskey, EVP_CIPHER_CTX_get_cipher_data(ctx));
     return 1;
 }
 
-static int des_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
+static int des_ctrl(ossl_unused EVP_CIPHER_CTX *unused__c,
+                    int type,
+                    ossl_unused int unused__arg,
+                    void *ptr)
 {
 
     switch (type) {

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -224,7 +224,7 @@ BLOCK_CIPHER_defs(des_ede, DES_EDE_KEY, NID_des_ede, 8, 16, 8, 64,
                      des_ede3_init_key, NULL, NULL, NULL, des3_ctrl)
 
 static int des_ede_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                            const unsigned char *iv, int enc)
+                            ossl_unused const unsigned char *unused__iv, int enc)
 {
     DES_cblock *deskey = (DES_cblock *)key;
     DES_EDE_KEY *dat = data(ctx);
@@ -243,6 +243,8 @@ static int des_ede_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             return 1;
         }
     }
+#else
+    (void)enc; /* silence -Wunused-parameter */
 # endif
     DES_set_key_unchecked(&deskey[0], &dat->ks1);
     DES_set_key_unchecked(&deskey[1], &dat->ks2);
@@ -251,7 +253,8 @@ static int des_ede_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 }
 
 static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             ossl_unused const unsigned char *unused__iv,
+                             int enc)
 {
     DES_cblock *deskey = (DES_cblock *)key;
     DES_EDE_KEY *dat = data(ctx);
@@ -270,6 +273,8 @@ static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             return 1;
         }
     }
+#else
+    (void)enc; /* silence -Wunused-parameter */
 # endif
     DES_set_key_unchecked(&deskey[0], &dat->ks1);
     DES_set_key_unchecked(&deskey[1], &dat->ks2);
@@ -277,7 +282,7 @@ static int des_ede3_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     return 1;
 }
 
-static int des3_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
+static int des3_ctrl(EVP_CIPHER_CTX *ctx, int type, ossl_unused int unused__arg, void *ptr)
 {
 
     DES_cblock *deskey = ptr;

--- a/crypto/evp/e_idea.c
+++ b/crypto/evp/e_idea.c
@@ -55,7 +55,8 @@ BLOCK_CIPHER_defs(idea, IDEA_KEY_SCHEDULE, NID_idea, 8, 16, 8, 64,
                   EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv, NULL)
 
 static int idea_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+                         ossl_unused const unsigned char *unused__iv,
+                         int enc)
 {
     if (!enc) {
         if (EVP_CIPHER_CTX_mode(ctx) == EVP_CIPH_OFB_MODE)

--- a/crypto/evp/e_null.c
+++ b/crypto/evp/e_null.c
@@ -35,13 +35,16 @@ const EVP_CIPHER *EVP_enc_null(void)
     return &n_cipher;
 }
 
-static int null_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+static int null_init_key(ossl_unused EVP_CIPHER_CTX *unused__ctx,
+                         ossl_unused const unsigned char *unused__key,
+                         ossl_unused const unsigned char *unused__iv,
+                         ossl_unused int unused__enc)
 {
     return 1;
 }
 
-static int null_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+static int null_cipher(ossl_unused EVP_CIPHER_CTX *unused__ctx,
+                       unsigned char *out,
                        const unsigned char *in, size_t inl)
 {
     if (in != out)

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -88,7 +88,8 @@ const EVP_CIPHER *EVP_rc2_40_cbc(void)
 }
 
 static int rc2_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        ossl_unused const unsigned char *unused__iv,
+                        ossl_unused int unused__enc)
 {
     RC2_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx),
                 key, data(ctx)->key_bits);

--- a/crypto/evp/e_rc4.c
+++ b/crypto/evp/e_rc4.c
@@ -73,7 +73,8 @@ const EVP_CIPHER *EVP_rc4_40(void)
 }
 
 static int rc4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        ossl_unused const unsigned char *unused__iv,
+                        ossl_unused int unused__enc)
 {
     RC4_set_key(&data(ctx)->ks, EVP_CIPHER_CTX_key_length(ctx), key);
     return 1;

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -43,7 +43,8 @@ void rc4_md5_enc(RC4_KEY *key, const void *in0, void *out,
 
 static int rc4_hmac_md5_init_key(EVP_CIPHER_CTX *ctx,
                                  const unsigned char *inkey,
-                                 const unsigned char *iv, int enc)
+                                 ossl_unused const unsigned char *unused__iv,
+                                 ossl_unused int unused__enc)
 {
     EVP_RC4_HMAC_MD5 *key = data(ctx);
 

--- a/crypto/evp/e_seed.c
+++ b/crypto/evp/e_seed.c
@@ -34,7 +34,8 @@ IMPLEMENT_BLOCK_CIPHER(seed, ks, SEED, EVP_SEED_KEY, NID_seed,
                        seed_init_key, 0, 0, 0, 0)
 
 static int seed_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                         const unsigned char *iv, int enc)
+                         ossl_unused const unsigned char *unused__iv,
+                         ossl_unused int unused__enc)
 {
     SEED_set_key(key, &EVP_C_DATA(EVP_SEED_KEY,ctx)->ks);
     return 1;

--- a/crypto/evp/e_sm4.c
+++ b/crypto/evp/e_sm4.c
@@ -22,7 +22,8 @@ typedef struct {
 } EVP_SM4_KEY;
 
 static int sm4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                        const unsigned char *iv, int enc)
+                        ossl_unused const unsigned char *unused__iv,
+                        ossl_unused int unused__enc)
 {
     SM4_set_key(key, EVP_CIPHER_CTX_get_cipher_data(ctx));
     return 1;

--- a/crypto/evp/e_xcbc_d.c
+++ b/crypto/evp/e_xcbc_d.c
@@ -57,7 +57,8 @@ const EVP_CIPHER *EVP_desx_cbc(void)
 }
 
 static int desx_cbc_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             ossl_unused const unsigned char *unused__iv,
+                             ossl_unused int unused__enc)
 {
     DES_cblock *deskey = (DES_cblock *)key;
 

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -464,7 +464,7 @@ struct do_all_data_st {
 };
 
 static void do_one(OSSL_PROVIDER *provider, const OSSL_ALGORITHM *algo,
-                   int no_store, void *vdata)
+                   ossl_unused int unused__no_store, void *vdata)
 {
     struct do_all_data_st *data = vdata;
     OPENSSL_CTX *libctx = ossl_provider_library_context(provider);

--- a/crypto/evp/legacy_sha.c
+++ b/crypto/evp/legacy_sha.c
@@ -68,7 +68,7 @@ static int sha1_int_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
     return sha1_ctrl(ctx != NULL ? EVP_MD_CTX_md_data(ctx) : NULL, cmd, p1, p2);
 }
 
-static int shake_ctrl(EVP_MD_CTX *evp_ctx, int cmd, int p1, void *p2)
+static int shake_ctrl(EVP_MD_CTX *evp_ctx, int cmd, int p1, ossl_unused void *unused__p2)
 {
     KECCAK1600_CTX *ctx = evp_ctx->md_data;
 

--- a/crypto/evp/m_null.c
+++ b/crypto/evp/m_null.c
@@ -14,17 +14,19 @@
 #include <openssl/x509.h>
 #include "crypto/evp.h"
 
-static int init(EVP_MD_CTX *ctx)
+static int init(ossl_unused EVP_MD_CTX *unused__ctx)
 {
     return 1;
 }
 
-static int update(EVP_MD_CTX *ctx, const void *data, size_t count)
+static int update(ossl_unused EVP_MD_CTX *unused__ctx, ossl_unused const void *unused__data,
+                  ossl_unused size_t unused__count)
 {
     return 1;
 }
 
-static int final(EVP_MD_CTX *ctx, unsigned char *md)
+static int final(ossl_unused EVP_MD_CTX *unused__ctx,
+                 ossl_unused unsigned char *unused__md)
 {
     return 1;
 }

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -18,7 +18,9 @@
 
 #ifndef FIPS_MODULE
 
-static int update(EVP_MD_CTX *ctx, const void *data, size_t datalen)
+static int update(ossl_unused EVP_MD_CTX *unused__ctx,
+                  ossl_unused const void *unused__data,
+                  ossl_unused size_t unused__datalen)
 {
     EVPerr(EVP_F_UPDATE, EVP_R_ONLY_ONESHOT_SUPPORTED);
     return 0;

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -104,8 +104,8 @@ int PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
  */
 
 int PKCS5_v2_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
-                          ASN1_TYPE *param, const EVP_CIPHER *c,
-                          const EVP_MD *md, int en_de)
+                          ASN1_TYPE *param, ossl_unused const EVP_CIPHER *unused__c,
+                          ossl_unused const EVP_MD *unused__md, int en_de)
 {
     PBE2PARAM *pbe2 = NULL;
     const EVP_CIPHER *cipher;
@@ -153,7 +153,9 @@ int PKCS5_v2_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
 
 int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              int passlen, ASN1_TYPE *param,
-                             const EVP_CIPHER *c, const EVP_MD *md, int en_de)
+                             ossl_unused const EVP_CIPHER *unused__c,
+                             ossl_unused const EVP_MD *unused__md,
+                             int en_de)
 {
     unsigned char *salt, key[EVP_MAX_KEY_LENGTH];
     int saltlen, iter, t;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1200,7 +1200,7 @@ int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
 }
 
 static int legacy_asn1_ctrl_to_param(EVP_PKEY *pkey, int op,
-                                     int arg1, void *arg2)
+                                     ossl_unused int unused__arg1, void *arg2)
 {
     if (pkey->keymgmt == NULL)
         return 0;
@@ -1440,8 +1440,10 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
     if (pkey == NULL && eptr != NULL)
         ENGINE_finish(e);
 # endif
+#else
+    (void)str; /* silence -Wunused-parameter */
+    (void)len; /* silence -Wunused-parameter */
 #endif
-
 
     {
         int check = 1;

--- a/crypto/evp/pkey_mac.c
+++ b/crypto/evp/pkey_mac.c
@@ -289,7 +289,7 @@ static int pkey_mac_signctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
 }
 
 static int pkey_mac_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig,
-                             size_t *siglen, EVP_MD_CTX *mctx)
+                            size_t *siglen, ossl_unused EVP_MD_CTX *unused__mctx)
 {
     MAC_PKEY_CTX *hctx = EVP_PKEY_CTX_get_data(ctx);
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -159,6 +159,8 @@ static int is_legacy_alg(int id, const char *keytype)
         return 0;
     }
 #else
+    (void)id;      /* silence -Wunused-parameter */
+    (void)keytype; /* silence -Wunused-parameter */
     return 0;
 #endif
 }

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -85,19 +85,22 @@ void crypto_cleanup_all_ex_data_int(OPENSSL_CTX *ctx)
  * Unregister a new index by replacing the callbacks with no-ops.
  * Any in-use instances are leaked.
  */
-static void dummy_new(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
-                     long argl, void *argp)
+static void dummy_new(ossl_unused void *unused__parent,ossl_unused void *unused__ptr,
+                      ossl_unused CRYPTO_EX_DATA *unused__ad, ossl_unused int unused__idx,
+                      ossl_unused long unused__argl, ossl_unused void *unused__argp)
 {
 }
 
-static void dummy_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad, int idx,
-                       long argl, void *argp)
+static void dummy_free(ossl_unused void *unused__parent, ossl_unused void *unused__ptr,
+                       ossl_unused CRYPTO_EX_DATA *unused__ad, ossl_unused int unused__idx,
+                       ossl_unused long unused__argl, ossl_unused void *unused__argp)
 {
 }
 
-static int dummy_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                     void **from_d, int idx,
-                     long argl, void *argp)
+static int dummy_dup(ossl_unused CRYPTO_EX_DATA *unused__to,
+                     ossl_unused const CRYPTO_EX_DATA *unused__from,
+                     ossl_unused void **unused__from_d, ossl_unused int unused__idx,
+                     ossl_unused long unused__argl, ossl_unused void *unused__argp)
 {
     return 1;
 }

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -361,7 +361,7 @@ err:
 static int generate_q_fips186_2(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
                                 unsigned char *buf, unsigned char *seed,
                                 size_t qsize, int generate_seed, int *retm,
-                                int *res, BN_GENCB *cb)
+                                ossl_unused int *unused__res, BN_GENCB *cb)
 {
     unsigned char buf2[EVP_MAX_MD_SIZE];
     unsigned char md[EVP_MAX_MD_SIZE];
@@ -774,7 +774,8 @@ err:
 }
 
 int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                    int mode, int type, size_t L, size_t N,
+                                    int mode, ossl_unused int unused__type,
+                                    size_t L, size_t N,
                                     int *res, BN_GENCB *cb)
 {
     int ok = FFC_PARAM_RET_STATUS_FAILED;

--- a/crypto/hmac/hm_ameth.c
+++ b/crypto/hmac/hm_ameth.c
@@ -24,7 +24,7 @@
  * length and to free up an HMAC key.
  */
 
-static int hmac_size(const EVP_PKEY *pkey)
+static int hmac_size(ossl_unused const EVP_PKEY *unused__pkey)
 {
     return EVP_MAX_MD_SIZE;
 }
@@ -39,7 +39,7 @@ static void hmac_key_free(EVP_PKEY *pkey)
     }
 }
 
-static int hmac_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int hmac_pkey_ctrl(ossl_unused EVP_PKEY *unused__pkey, int op, ossl_unused long unused__arg1, void *arg2)
 {
     switch (op) {
     case ASN1_PKEY_CTRL_DEFAULT_MD_NID:

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -242,7 +242,7 @@ void ossl_ctx_thread_stop(void *arg)
 
 #else
 
-static void *thread_event_ossl_ctx_new(OPENSSL_CTX *libctx)
+static void *thread_event_ossl_ctx_new(ossl_unused OPENSSL_CTX *unused__libctx)
 {
     THREAD_EVENT_HANDLER **hands = NULL;
     CRYPTO_THREAD_LOCAL *tlocal = OPENSSL_zalloc(sizeof(*tlocal));

--- a/crypto/mem.c
+++ b/crypto/mem.c
@@ -264,21 +264,20 @@ void CRYPTO_clear_free(void *str, size_t num, const char *file, int line)
 #if !defined(OPENSSL_NO_CRYPTO_MDEBUG)
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
-int CRYPTO_mem_ctrl(int mode)
+int CRYPTO_mem_ctrl(ossl_unused int unused__mode)
 {
-    (void)mode;
     return -1;
 }
 
-int CRYPTO_set_mem_debug(int flag)
+int CRYPTO_set_mem_debug(ossl_unused int unused__flag)
 {
-    (void)flag;
     return -1;
 }
 
-int CRYPTO_mem_debug_push(const char *info, const char *file, int line)
+int CRYPTO_mem_debug_push(ossl_unused const char *unused__info,
+                          ossl_unused const char *unused__file,
+                          ossl_unused int unused__line)
 {
-    (void)info; (void)file; (void)line;
     return -1;
 }
 
@@ -287,42 +286,45 @@ int CRYPTO_mem_debug_pop(void)
     return -1;
 }
 
-void CRYPTO_mem_debug_malloc(void *addr, size_t num, int flag,
-                             const char *file, int line)
+void CRYPTO_mem_debug_malloc(ossl_unused void *unused__addr,
+                             ossl_unused size_t unused__num,
+                             ossl_unused int unused__flag,
+                             ossl_unused const char *unused__file,
+                             ossl_unused int unused__line)
 {
-    (void)addr; (void)num; (void)flag; (void)file; (void)line;
 }
 
-void CRYPTO_mem_debug_realloc(void *addr1, void *addr2, size_t num, int flag,
-                              const char *file, int line)
+void CRYPTO_mem_debug_realloc(ossl_unused void *unused__addr1,
+                              ossl_unused void *unused__addr2,
+                              ossl_unused size_t unused__num,
+                              ossl_unused int unused__flag,
+                              ossl_unused const char *unused__file,
+                              ossl_unused int unused__line)
 {
-    (void)addr1; (void)addr2; (void)num; (void)flag; (void)file; (void)line;
 }
 
-void CRYPTO_mem_debug_free(void *addr, int flag,
-                           const char *file, int line)
+void CRYPTO_mem_debug_free(ossl_unused void *unused__addr,
+                           ossl_unused int unused__flag,
+                           ossl_unused const char *unused__file,
+                           ossl_unused int unused__line)
 {
-    (void)addr; (void)flag; (void)file; (void)line;
 }
 
-int CRYPTO_mem_leaks(BIO *b)
+int CRYPTO_mem_leaks(ossl_unused BIO *unused__b)
 {
-    (void)b;
     return -1;
 }
 
 #  ifndef OPENSSL_NO_STDIO
-int CRYPTO_mem_leaks_fp(FILE *fp)
+int CRYPTO_mem_leaks_fp(ossl_unused FILE *unused__fp)
 {
-    (void)fp;
     return -1;
 }
 #  endif
 
-int CRYPTO_mem_leaks_cb(int (*cb)(const char *str, size_t len, void *u),
-                        void *u)
+int CRYPTO_mem_leaks_cb(ossl_unused int (*unused__cb)(const char *str, size_t len, void *u),
+                        ossl_unused void *unused__u)
 {
-    (void)cb; (void)u;
     return -1;
 }
 

--- a/crypto/modes/cfb128.c
+++ b/crypto/modes/cfb128.c
@@ -180,7 +180,7 @@ static void cfbr_encrypt_block(const unsigned char *in, unsigned char *out,
 /* N.B. This expects the input to be packed, MS bit first */
 void CRYPTO_cfb128_1_encrypt(const unsigned char *in, unsigned char *out,
                              size_t bits, const void *key,
-                             unsigned char ivec[16], int *num,
+                             unsigned char ivec[16], ossl_unused int *unused__num,
                              int enc, block128_f block)
 {
     size_t n;
@@ -196,7 +196,7 @@ void CRYPTO_cfb128_1_encrypt(const unsigned char *in, unsigned char *out,
 
 void CRYPTO_cfb128_8_encrypt(const unsigned char *in, unsigned char *out,
                              size_t length, const void *key,
-                             unsigned char ivec[16], int *num,
+                             unsigned char ivec[16], ossl_unused int *unused__num,
                              int enc, block128_f block)
 {
     size_t n;

--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -109,8 +109,8 @@ const X509V3_EXT_METHOD v3_ocsp_serviceloc = {
     NULL
 };
 
-static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
-                          int ind)
+static int i2r_ocsp_crlid(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                          void *in, BIO *bp, int ind)
 {
     OCSP_CRLID *a = in;
     if (a->crlUrl) {
@@ -142,8 +142,8 @@ static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
     return 0;
 }
 
-static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
-                            BIO *bp, int ind)
+static int i2r_ocsp_acutoff(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                            void *cutoff, BIO *bp, int ind)
 {
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
@@ -152,8 +152,8 @@ static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
     return 1;
 }
 
-static int i2r_object(const X509V3_EXT_METHOD *method, void *oid, BIO *bp,
-                      int ind)
+static int i2r_object(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                      void *oid, BIO *bp, int ind)
 {
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
@@ -214,8 +214,8 @@ static void ocsp_nonce_free(void *a)
     ASN1_OCTET_STRING_free(a);
 }
 
-static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
-                          BIO *out, int indent)
+static int i2r_ocsp_nonce(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                          void *nonce, BIO *out, int indent)
 {
     if (BIO_printf(out, "%*s", indent, "") <= 0)
         return 0;
@@ -226,20 +226,21 @@ static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
 
 /* Nocheck is just a single NULL. Don't print anything and always set it */
 
-static int i2r_ocsp_nocheck(const X509V3_EXT_METHOD *method, void *nocheck,
-                            BIO *out, int indent)
+static int i2r_ocsp_nocheck(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                            ossl_unused void *unused__nocheck, ossl_unused BIO *unused__out,
+                            ossl_unused int unused__indent)
 {
     return 1;
 }
 
-static void *s2i_ocsp_nocheck(const X509V3_EXT_METHOD *method,
-                              X509V3_CTX *ctx, const char *str)
+static void *s2i_ocsp_nocheck(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                              ossl_unused X509V3_CTX *unused__ctx, ossl_unused const char *unused__str)
 {
     return ASN1_NULL_new();
 }
 
-static int i2r_ocsp_serviceloc(const X509V3_EXT_METHOD *method, void *in,
-                               BIO *bp, int ind)
+static int i2r_ocsp_serviceloc(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                               void *in, BIO *bp, int ind)
 {
     int i;
     OCSP_SERVICELOC *a = in;

--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -62,8 +62,7 @@ static size_t bytes_to_blocks(size_t bytes)
 }
 
 static OSSL_PARAM_BLD_DEF *param_push(OSSL_PARAM_BLD *bld, const char *key,
-                                      int size, size_t alloc, int type,
-                                      int secure)
+                                      int size, int type, int secure)
 {
     OSSL_PARAM_BLD_DEF *pd = OPENSSL_zalloc(sizeof(*pd));
 
@@ -89,7 +88,7 @@ static OSSL_PARAM_BLD_DEF *param_push(OSSL_PARAM_BLD *bld, const char *key,
 static int param_push_num(OSSL_PARAM_BLD *bld, const char *key,
                           void *num, size_t size, int type)
 {
-    OSSL_PARAM_BLD_DEF *pd = param_push(bld, key, size, size, type, 0);
+    OSSL_PARAM_BLD_DEF *pd = param_push(bld, key, size, type, 0);
 
     if (pd == NULL)
         return 0;
@@ -229,7 +228,7 @@ int OSSL_PARAM_BLD_push_BN_pad(OSSL_PARAM_BLD *bld, const char *key,
         if (BN_get_flags(bn, BN_FLG_SECURE) == BN_FLG_SECURE)
             secure = 1;
     }
-    pd = param_push(bld, key, sz, sz, OSSL_PARAM_UNSIGNED_INTEGER, secure);
+    pd = param_push(bld, key, sz, OSSL_PARAM_UNSIGNED_INTEGER, secure);
     if (pd == NULL)
         return 0;
     pd->bn = bn;
@@ -248,7 +247,7 @@ int OSSL_PARAM_BLD_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_UTF8_STRING, 0);
+    pd = param_push(bld, key, bsize, OSSL_PARAM_UTF8_STRING, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -267,7 +266,7 @@ int OSSL_PARAM_BLD_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, sizeof(buf), OSSL_PARAM_UTF8_PTR, 0);
+    pd = param_push(bld, key, bsize, OSSL_PARAM_UTF8_PTR, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -284,7 +283,7 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_OCTET_STRING, 0);
+    pd = param_push(bld, key, bsize, OSSL_PARAM_OCTET_STRING, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -301,7 +300,7 @@ int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, sizeof(buf), OSSL_PARAM_OCTET_PTR, 0);
+    pd = param_push(bld, key, bsize, OSSL_PARAM_OCTET_PTR, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -103,7 +103,7 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
 }
 
 static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
-                               const char *value, size_t value_n, int ishex,
+                               const char *value, ossl_unused size_t unused__value_n, int ishex,
                                void *buf, size_t buf_n, BIGNUM *tmpbn)
 {
     if (buf == NULL)

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -30,7 +30,7 @@ ASN1_ADB(PKCS7) = {
 } ASN1_ADB_END(PKCS7, 0, type, 0, &p7default_tt, NULL);
 
 /* PKCS#7 streaming support */
-static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
+static int pk7_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
                   void *exarg)
 {
     ASN1_STREAM_ARG *sarg = exarg;
@@ -126,8 +126,8 @@ ASN1_NDEF_SEQUENCE(PKCS7_SIGNED) = {
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_SIGNED)
 
 /* Minor tweak to operation: free up EVP_PKEY */
-static int si_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
+static int si_cb(int operation, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                 ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_POST) {
         PKCS7_SIGNER_INFO *si = (PKCS7_SIGNER_INFO *)*pval;
@@ -169,8 +169,9 @@ ASN1_NDEF_SEQUENCE(PKCS7_ENVELOPE) = {
 IMPLEMENT_ASN1_FUNCTIONS(PKCS7_ENVELOPE)
 
 /* Minor tweak to operation: free up X509 */
-static int ri_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                 void *exarg)
+static int ri_cb(int operation, ASN1_VALUE **pval,
+                 ossl_unused const ASN1_ITEM *unused__it,
+                 ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_POST) {
         PKCS7_RECIP_INFO *ri = (PKCS7_RECIP_INFO *)*pval;

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -22,7 +22,7 @@ DEFINE_STACK_OF(X509_ALGOR)
 DEFINE_STACK_OF(PKCS7_RECIP_INFO)
 DEFINE_STACK_OF(PKCS7_SIGNER_INFO)
 
-long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg)
+long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, ossl_unused char *unused__parg)
 {
     int nid;
     long ret;

--- a/crypto/poly1305/poly1305_ameth.c
+++ b/crypto/poly1305/poly1305_ameth.c
@@ -19,7 +19,7 @@
  * POLY1305 output length and to free up a POLY1305 key.
  */
 
-static int poly1305_size(const EVP_PKEY *pkey)
+static int poly1305_size(ossl_unused const EVP_PKEY *unused__pkey)
 {
     return POLY1305_DIGEST_SIZE;
 }
@@ -34,7 +34,8 @@ static void poly1305_key_free(EVP_PKEY *pkey)
     }
 }
 
-static int poly1305_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int poly1305_pkey_ctrl(ossl_unused EVP_PKEY *unused__pkey, ossl_unused int unused__op,
+                              ossl_unused long unused__arg1, ossl_unused void *unused__arg2)
 {
     /* nothing, (including ASN1_PKEY_CTRL_DEFAULT_MD_NID), is supported */
     return -2;

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -57,7 +57,7 @@ static void property_defns_free(void *vproperty_defns)
     }
 }
 
-static void *property_defns_new(OPENSSL_CTX *ctx) {
+static void *property_defns_new(ossl_unused OPENSSL_CTX *unused__ctx) {
     return lh_PROPERTY_DEFN_ELEM_new(&property_defn_hash, &property_defn_cmp);
 }
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -85,7 +85,7 @@ static void ossl_ctx_global_properties_free(void *vstore)
     }
 }
 
-static void *ossl_ctx_global_properties_new(OPENSSL_CTX *ctx)
+static void *ossl_ctx_global_properties_new(ossl_unused OPENSSL_CTX *unused__ctx)
 {
     return OPENSSL_zalloc(sizeof(OSSL_PROPERTY_LIST **));
 }
@@ -102,6 +102,8 @@ OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OPENSSL_CTX *libctx,
 #ifndef FIPS_MODULE
     if (loadconfig && !OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
         return NULL;
+#else
+    (void)loadconfig;
 #endif
     return openssl_ctx_get_data(libctx, OPENSSL_CTX_GLOBAL_PROPERTIES,
                                 &ossl_ctx_global_properties_method);
@@ -158,7 +160,7 @@ static void impl_cache_free(QUERY *elem)
     }
 }
 
-static void alg_cleanup(ossl_uintmax_t idx, ALGORITHM *a)
+static void alg_cleanup(ossl_unused ossl_uintmax_t unused__idx, ALGORITHM *a)
 {
     if (a != NULL) {
         sk_IMPLEMENTATION_pop_free(a->impls, &impl_free);
@@ -475,7 +477,7 @@ static void impl_cache_flush_cache(QUERY *c, IMPL_CACHE_FLUSH *state)
         state->nelem++;
 }
 
-static void impl_cache_flush_one_alg(ossl_uintmax_t idx, ALGORITHM *alg,
+static void impl_cache_flush_one_alg(ossl_unused ossl_uintmax_t unused__idx, ALGORITHM *alg,
                                      void *v)
 {
     IMPL_CACHE_FLUSH *state = (IMPL_CACHE_FLUSH *)v;

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -81,7 +81,7 @@ static void property_string_data_free(void *vpropdata)
     OPENSSL_free(propdata);
 }
 
-static void *property_string_data_new(OPENSSL_CTX *ctx) {
+static void *property_string_data_new(ossl_unused OPENSSL_CTX *unused__ctx) {
     PROPERTY_STRING_DATA *propdata = OPENSSL_zalloc(sizeof(*propdata));
 
     if (propdata == NULL)

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -174,7 +174,7 @@ static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)
 }
 
 
-static void provider_conf_deinit(CONF_IMODULE *md)
+static void provider_conf_deinit(ossl_unused CONF_IMODULE *unused__md)
 {
     sk_OSSL_PROVIDER_pop_free(activated_providers, ossl_provider_free);
     activated_providers = NULL;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -223,6 +223,8 @@ OSSL_PROVIDER *ossl_provider_find(OPENSSL_CTX *libctx, const char *name,
          */
         if (!noconfig)
             OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#else
+        (void)noconfig; /* silence -Wunused-parameter */
 #endif
 
         tmpl.name = (char *)name;
@@ -792,6 +794,7 @@ const DSO *ossl_provider_dso(const OSSL_PROVIDER *prov)
 const char *ossl_provider_module_name(const OSSL_PROVIDER *prov)
 {
 #ifdef FIPS_MODULE
+    (void)prov; /* silence -Wunused-parameter */
     return NULL;
 #else
     return DSO_get_filename(prov->module);
@@ -801,6 +804,7 @@ const char *ossl_provider_module_name(const OSSL_PROVIDER *prov)
 const char *ossl_provider_module_path(const OSSL_PROVIDER *prov)
 {
 #ifdef FIPS_MODULE
+    (void)prov; /* silence -Wunused-parameter */
     return NULL;
 #else
     /* FIXME: Ensure it's a full path */
@@ -946,7 +950,7 @@ static OSSL_FUNC_core_clear_last_error_mark_fn core_clear_last_error_mark;
 static OSSL_FUNC_core_pop_error_to_mark_fn core_pop_error_to_mark;
 #endif
 
-static const OSSL_PARAM *core_gettable_params(const OSSL_CORE_HANDLE *handle)
+static const OSSL_PARAM *core_gettable_params(ossl_unused const OSSL_CORE_HANDLE *unused__handle)
 {
     return param_types;
 }
@@ -1020,12 +1024,12 @@ static int core_thread_start(const OSSL_CORE_HANDLE *handle,
  * We cannot currently do that since there's no support for it in the
  * ERR subsystem.
  */
-static void core_new_error(const OSSL_CORE_HANDLE *handle)
+static void core_new_error(ossl_unused const OSSL_CORE_HANDLE *unused__handle)
 {
     ERR_new();
 }
 
-static void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
+static void core_set_error_debug(ossl_unused const OSSL_CORE_HANDLE *unused__handle,
                                  const char *file, int line, const char *func)
 {
     ERR_set_debug(file, line, func);
@@ -1052,17 +1056,17 @@ static void core_vset_error(const OSSL_CORE_HANDLE *handle,
     }
 }
 
-static int core_set_error_mark(const OSSL_CORE_HANDLE *handle)
+static int core_set_error_mark(ossl_unused const OSSL_CORE_HANDLE *unused__handle)
 {
     return ERR_set_mark();
 }
 
-static int core_clear_last_error_mark(const OSSL_CORE_HANDLE *handle)
+static int core_clear_last_error_mark(ossl_unused const OSSL_CORE_HANDLE *unused__handle)
 {
     return ERR_clear_last_mark();
 }
 
-static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
+static int core_pop_error_to_mark(ossl_unused const OSSL_CORE_HANDLE *unused__handle)
 {
     return ERR_pop_to_mark();
 }

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -359,7 +359,7 @@ typedef struct rand_global_st {
  * Initialize the OPENSSL_CTX global DRBGs on first use.
  * Returns the allocated global data on success or NULL on failure.
  */
-static void *rand_ossl_ctx_new(OPENSSL_CTX *libctx)
+static void *rand_ossl_ctx_new(ossl_unused OPENSSL_CTX *unused__libctx)
 {
     RAND_GLOBAL *dgbl = OPENSSL_zalloc(sizeof(*dgbl));
 

--- a/crypto/rand/rand_meth.c
+++ b/crypto/rand/rand_meth.c
@@ -12,7 +12,7 @@
 #include "rand_local.h"
 
 /* Implements the default OpenSSL RAND_add() method */
-static int drbg_add(const void *buf, int num, double randomness)
+static int drbg_add(const void *buf, int num, ossl_unused double unused__randomness)
 {
     EVP_RAND_CTX *drbg = RAND_get0_primary(NULL);
 

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -444,13 +444,13 @@ static int pkey_rsa_print(BIO *bp, const EVP_PKEY *pkey, int off, int priv)
 }
 
 static int rsa_pub_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                         ASN1_PCTX *ctx)
+                         ossl_unused ASN1_PCTX *unused__ctx)
 {
     return pkey_rsa_print(bp, pkey, indent, 0);
 }
 
 static int rsa_priv_print(BIO *bp, const EVP_PKEY *pkey, int indent,
-                          ASN1_PCTX *ctx)
+                          ossl_unused ASN1_PCTX *unused__ctx)
 {
     return pkey_rsa_print(bp, pkey, indent, 1);
 }
@@ -477,7 +477,8 @@ static RSA_PSS_PARAMS *rsa_pss_decode(const X509_ALGOR *alg)
 }
 
 static int rsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
-                         const ASN1_STRING *sig, int indent, ASN1_PCTX *pctx)
+                         const ASN1_STRING *sig, int indent,
+                         ossl_unused ASN1_PCTX *unused__pctx)
 {
     if (OBJ_obj2nid(sigalg->algorithm) == EVP_PKEY_RSA_PSS) {
         int rv;
@@ -746,7 +747,8 @@ static int rsa_pss_to_ctx(EVP_MD_CTX *ctx, EVP_PKEY_CTX *pkctx,
     return rv;
 }
 
-static int rsa_pss_verify_param(const EVP_MD **pmd, const EVP_MD **pmgf1md,
+static int rsa_pss_verify_param(ossl_unused const EVP_MD **unused__pmd,
+                                ossl_unused const EVP_MD **unused__pmgf1md,
                                 int *psaltlen, int *ptrailerField)
 {
     if (psaltlen != NULL && *psaltlen < 0) {
@@ -876,9 +878,12 @@ static int rsa_cms_verify(CMS_SignerInfo *si)
  * is encountered requiring special handling. We currently only handle PSS.
  */
 
-static int rsa_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
-                           const void *asn, const X509_ALGOR *sigalg,
-                           const ASN1_BIT_STRING *sig, EVP_PKEY *pkey)
+static int rsa_item_verify(EVP_MD_CTX *ctx,
+                           ossl_unused const ASN1_ITEM *unused__it,
+                           ossl_unused const void *unused__data,
+                           const X509_ALGOR *sigalg,
+                           ossl_unused const ASN1_BIT_STRING *unused__sig,
+                           EVP_PKEY *pkey)
 {
     /* Sanity check: make sure it is PSS */
     if (OBJ_obj2nid(sigalg->algorithm) != EVP_PKEY_RSA_PSS) {
@@ -920,9 +925,11 @@ static int rsa_cms_sign(CMS_SignerInfo *si)
 }
 #endif
 
-static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, const void *asn,
+static int rsa_item_sign(EVP_MD_CTX *ctx,
+                         ossl_unused const ASN1_ITEM *unused__it,
+                         ossl_unused const void *unused__data,
                          X509_ALGOR *alg1, X509_ALGOR *alg2,
-                         ASN1_BIT_STRING *sig)
+                         ossl_unused ASN1_BIT_STRING *unused__sig)
 {
     int pad_mode;
     EVP_PKEY_CTX *pkctx = EVP_MD_CTX_pkey_ctx(ctx);
@@ -954,7 +961,7 @@ static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, const void *asn,
 }
 
 static int rsa_sig_info_set(X509_SIG_INFO *siginf, const X509_ALGOR *sigalg,
-                            const ASN1_STRING *sig)
+                            ossl_unused const ASN1_STRING *unused__sig)
 {
     int rv = 0;
     int mdnid, saltlen;
@@ -1186,9 +1193,9 @@ static size_t rsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
  * that the type flag for the RSA key is properly set by other functions
  * in this file.
  */
-static int rsa_int_export_to(const EVP_PKEY *from, int rsa_type,
+static int rsa_int_export_to(const EVP_PKEY *from, ossl_unused int unused__rsa_type,
                              void *to_keydata, EVP_KEYMGMT *to_keymgmt,
-                             OPENSSL_CTX *libctx, const char *propq)
+                             ossl_unused OPENSSL_CTX *unused__libctx, const char *propq)
 {
     RSA *rsa = from->pkey.rsa;
     OSSL_PARAM_BLD *tmpl = OSSL_PARAM_BLD_new();

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -25,8 +25,9 @@
  * and calculate helper products for multi-prime
  * RSA keys.
  */
-static int rsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int rsa_cb(int operation, ASN1_VALUE **pval,
+                  ossl_unused const ASN1_ITEM *unused__it,
+                  ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_NEW_PRE) {
         *pval = (ASN1_VALUE *)RSA_new();
@@ -74,8 +75,9 @@ ASN1_SEQUENCE_cb(RSAPublicKey, rsa_cb) = {
 } ASN1_SEQUENCE_END_cb(RSA, RSAPublicKey)
 
 /* Free up maskHash */
-static int rsa_pss_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int rsa_pss_cb(int operation, ASN1_VALUE **pval,
+                      ossl_unused const ASN1_ITEM *unused__it,
+                      ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_PRE) {
         RSA_PSS_PARAMS *pss = (RSA_PSS_PARAMS *)*pval;
@@ -94,8 +96,9 @@ ASN1_SEQUENCE_cb(RSA_PSS_PARAMS, rsa_pss_cb) = {
 IMPLEMENT_ASN1_FUNCTIONS(RSA_PSS_PARAMS)
 
 /* Free up maskHash */
-static int rsa_oaep_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                       void *exarg)
+static int rsa_oaep_cb(int operation, ASN1_VALUE **pval,
+                       ossl_unused const ASN1_ITEM *unused__it,
+                       ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_PRE) {
         RSA_OAEP_PARAMS *oaep = (RSA_OAEP_PARAMS *)*pval;

--- a/crypto/rsa/rsa_backend.c
+++ b/crypto/rsa/rsa_backend.c
@@ -163,7 +163,8 @@ int rsa_todata(RSA *rsa, OSSL_PARAM_BLD *bld, OSSL_PARAM params[])
     return ret;
 }
 
-int rsa_pss_params_30_todata(const RSA_PSS_PARAMS_30 *pss, const char *propq,
+int rsa_pss_params_30_todata(const RSA_PSS_PARAMS_30 *pss,
+                             ossl_unused const char *unused__propq,
                              OSSL_PARAM_BLD *bld, OSSL_PARAM params[])
 {
     if (!rsa_pss_params_30_is_unrestricted(pss)) {

--- a/crypto/rsa/rsa_chk.c
+++ b/crypto/rsa/rsa_chk.c
@@ -257,6 +257,7 @@ int RSA_check_key(const RSA *key)
 int RSA_check_key_ex(const RSA *key, BN_GENCB *cb)
 {
 #ifdef FIPS_MODULE
+    (void)cb; /* silence -Wunused-parameter */
     return rsa_validate_public(key)
            && rsa_validate_private(key)
            && rsa_validate_pairwise(key);

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -108,6 +108,8 @@ static RSA *rsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
             goto err;
         }
     }
+#else
+    (void)engine; /* silence -Wunused-parameter */
 #endif
 
     ret->flags = ret->meth->flags & ~RSA_FLAG_NON_FIPS_ALLOW;
@@ -647,6 +649,7 @@ const BIGNUM *RSA_get0_iqmp(const RSA *r)
 const RSA_PSS_PARAMS *RSA_get0_pss_params(const RSA *r)
 {
 #ifdef FIPS_MODULE
+    (void)r; /* silence -Wunused-parameter */
     return NULL;
 #else
     return r->pss;

--- a/crypto/rsa/rsa_none.c
+++ b/crypto/rsa/rsa_none.c
@@ -35,7 +35,8 @@ int RSA_padding_add_none(unsigned char *to, int tlen,
 }
 
 int RSA_padding_check_none(unsigned char *to, int tlen,
-                           const unsigned char *from, int flen, int num)
+                           const unsigned char *from, int flen,
+                           ossl_unused int unused__num)
 {
 
     if (flen > tlen) {

--- a/crypto/rsa/rsa_saos.c
+++ b/crypto/rsa/rsa_saos.c
@@ -20,7 +20,7 @@
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 
-int RSA_sign_ASN1_OCTET_STRING(int type,
+int RSA_sign_ASN1_OCTET_STRING(ossl_unused int unused__type,
                                const unsigned char *m, unsigned int m_len,
                                unsigned char *sigret, unsigned int *siglen,
                                RSA *rsa)
@@ -57,7 +57,7 @@ int RSA_sign_ASN1_OCTET_STRING(int type,
     return ret;
 }
 
-int RSA_verify_ASN1_OCTET_STRING(int dtype,
+int RSA_verify_ASN1_OCTET_STRING(ossl_unused int unused__dtype,
                                  const unsigned char *m,
                                  unsigned int m_len, unsigned char *sigbuf,
                                  unsigned int siglen, RSA *rsa)

--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -80,6 +80,8 @@ int rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test, int nbits,
         q1 = test->q1;
         q2 = test->q2;
     }
+#else
+    (void)test; /* silence -Wunused-parameter */
 #endif
 
     /* (Step 1) Check key length

--- a/crypto/rsa/rsa_x931.c
+++ b/crypto/rsa/rsa_x931.c
@@ -56,7 +56,7 @@ int RSA_padding_add_X931(unsigned char *to, int tlen,
     return 1;
 }
 
-int RSA_padding_check_X931(unsigned char *to, int tlen,
+int RSA_padding_check_X931(unsigned char *to, ossl_unused int unused__tlen,
                            const unsigned char *from, int flen, int num)
 {
     int i = 0, j;

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -31,7 +31,7 @@ struct ossl_self_test_st
     void *cb_arg;
 };
 
-static void *self_test_set_callback_new(OPENSSL_CTX *ctx)
+static void *self_test_set_callback_new(ossl_unused OPENSSL_CTX *unused__ctx)
 {
     SELF_TEST_CB *stcb;
 

--- a/crypto/siphash/siphash_ameth.c
+++ b/crypto/siphash/siphash_ameth.c
@@ -20,7 +20,7 @@
  * SIPHASH output length and to free up a SIPHASH key.
  */
 
-static int siphash_size(const EVP_PKEY *pkey)
+static int siphash_size(ossl_unused const EVP_PKEY *unused__pkey)
 {
     return SIPHASH_MAX_DIGEST_SIZE;
 }
@@ -36,7 +36,8 @@ static void siphash_key_free(EVP_PKEY *pkey)
     }
 }
 
-static int siphash_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
+static int siphash_pkey_ctrl(ossl_unused EVP_PKEY *unused__pkey, ossl_unused int unused__op,
+                             ossl_unused long unused__arg1, ossl_unused void *unused__arg2)
 {
     /* nothing (including ASN1_PKEY_CTRL_DEFAULT_MD_NID), is supported */
     return -2;

--- a/crypto/sm2/sm2_pmeth.c
+++ b/crypto/sm2/sm2_pmeth.c
@@ -312,7 +312,7 @@ static int pkey_sm2_digest_custom(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx)
     return EVP_DigestUpdate(mctx, z, (size_t)mdlen);
 }
 
-static int pkey_sm2_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
+static int pkey_sm2_paramgen(ossl_unused EVP_PKEY_CTX *unused__ctx, EVP_PKEY *pkey)
 {
     EC_KEY *ec = NULL;
     int ret;

--- a/crypto/sparse_array.c
+++ b/crypto/sparse_array.c
@@ -107,7 +107,7 @@ static void sa_free_node(void **p)
     OPENSSL_free(p);
 }
 
-static void sa_free_leaf(ossl_uintmax_t n, void *p, void *arg)
+static void sa_free_leaf(ossl_unused ossl_uintmax_t unused__n, void *p, ossl_unused void *unused__arg)
 {
     OPENSSL_free(p);
 }

--- a/crypto/store/loader_file.c
+++ b/crypto/store/loader_file.c
@@ -116,7 +116,7 @@ static int file_fill_pem_pass_data(struct pem_pass_data *pass_data,
 }
 
 /* This is used anywhere a pem_password_cb is needed */
-static int file_get_pem_pass(char *buf, int num, int w, void *data)
+static int file_get_pem_pass(char *buf, int num, ossl_unused int unused__w, void *data)
 {
     struct pem_pass_data *pass_data = data;
     char *pass = file_get_pass(pass_data->ui_method, buf, num,
@@ -207,14 +207,14 @@ typedef struct file_handler_st {
  * then serving them one piece at a time.
  */
 static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
-                                          const char *pem_header,
+                                          ossl_unused const char *unused__pem_header,
                                           const unsigned char *blob,
                                           size_t len, void **pctx,
                                           int *matchcount,
                                           const UI_METHOD *ui_method,
                                           void *ui_data, const char *uri,
-                                          OPENSSL_CTX *libctx,
-                                          const char *propq)
+                                          ossl_unused OPENSSL_CTX *unused__libctx,
+                                          ossl_unused const char *unused__propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
     STACK_OF(OSSL_STORE_INFO) *ctx = *pctx;
@@ -343,15 +343,16 @@ static FILE_HANDLER PKCS12_handler = {
  * decoding process will then start over with the new blob.
  */
 static OSSL_STORE_INFO *try_decode_PKCS8Encrypted(const char *pem_name,
-                                                  const char *pem_header,
+                                                  ossl_unused const char *unused__pem_header,
                                                   const unsigned char *blob,
-                                                  size_t len, void **pctx,
+                                                  size_t len,
+                                                  ossl_unused void **unused__pctx,
                                                   int *matchcount,
                                                   const UI_METHOD *ui_method,
                                                   void *ui_data,
                                                   const char *uri,
-                                                  OPENSSL_CTX *libctx,
-                                                  const char *propq)
+                                                  ossl_unused OPENSSL_CTX *unused__libctx,
+                                                  ossl_unused const char *unused__propq)
 {
     X509_SIG *p8 = NULL;
     char kbuf[PEM_BUFSIZE];
@@ -423,12 +424,14 @@ static FILE_HANDLER PKCS8Encrypted_handler = {
  */
 int pem_check_suffix(const char *pem_str, const char *suffix);
 static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
-                                              const char *pem_header,
+                                              ossl_unused const char *unused__pem_header,
                                               const unsigned char *blob,
-                                              size_t len, void **pctx,
+                                              size_t len,
+                                              ossl_unused void **unused__pctx,
                                               int *matchcount,
-                                              const UI_METHOD *ui_method,
-                                              void *ui_data, const char *uri,
+                                              ossl_unused const UI_METHOD *unused__ui_method,
+                                              ossl_unused void *unused__ui_data,
+                                              ossl_unused const char *unused__uri,
                                               OPENSSL_CTX *libctx,
                                               const char *propq)
 {
@@ -544,14 +547,16 @@ static FILE_HANDLER PrivateKey_handler = {
  * Public key decoder.  Only supports SubjectPublicKeyInfo formatted keys.
  */
 static OSSL_STORE_INFO *try_decode_PUBKEY(const char *pem_name,
-                                          const char *pem_header,
+                                          ossl_unused const char *unused__pem_header,
                                           const unsigned char *blob,
-                                          size_t len, void **pctx,
+                                          size_t len,
+                                          ossl_unused void **unused__pctx,
                                           int *matchcount,
-                                          const UI_METHOD *ui_method,
-                                          void *ui_data, const char *uri,
-                                          OPENSSL_CTX *libctx,
-                                          const char *propq)
+                                          ossl_unused const UI_METHOD *unused__ui_method,
+                                          ossl_unused void *unused__ui_data,
+                                          ossl_unused const char *unused__uri,
+                                          ossl_unused OPENSSL_CTX *unused__libctx,
+                                          ossl_unused const char *unused__propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
     EVP_PKEY *pkey = NULL;
@@ -580,14 +585,16 @@ static FILE_HANDLER PUBKEY_handler = {
  * Key parameter decoder.
  */
 static OSSL_STORE_INFO *try_decode_params(const char *pem_name,
-                                          const char *pem_header,
+                                          ossl_unused const char *unused__pem_header,
                                           const unsigned char *blob,
-                                          size_t len, void **pctx,
+                                          size_t len,
+                                          ossl_unused void **unused__pctx,
                                           int *matchcount,
-                                          const UI_METHOD *ui_method,
-                                          void *ui_data, const char *uri,
-                                          OPENSSL_CTX *libctx,
-                                          const char *propq)
+                                          ossl_unused const UI_METHOD *unused__ui_method,
+                                          ossl_unused void *unused__ui_data,
+                                          ossl_unused const char *unused__uri,
+                                          ossl_unused OPENSSL_CTX *unused__libctx,
+                                          ossl_unused const char *unused__propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
     int slen = 0;
@@ -668,13 +675,14 @@ static FILE_HANDLER params_handler = {
  * X.509 certificate decoder.
  */
 static OSSL_STORE_INFO *try_decode_X509Certificate(const char *pem_name,
-                                                   const char *pem_header,
+                                                   ossl_unused const char *unused__pem_header,
                                                    const unsigned char *blob,
-                                                   size_t len, void **pctx,
+                                                   size_t len,
+                                                   ossl_unused void **unused__pctx,
                                                    int *matchcount,
-                                                   const UI_METHOD *ui_method,
-                                                   void *ui_data,
-                                                   const char *uri,
+                                                   ossl_unused const UI_METHOD *unused__ui_method,
+                                                   ossl_unused void *unused__ui_data,
+                                                   ossl_unused const char *unused__uri,
                                                    OPENSSL_CTX *libctx,
                                                    const char *propq)
 {
@@ -725,14 +733,16 @@ static FILE_HANDLER X509Certificate_handler = {
  * X.509 CRL decoder.
  */
 static OSSL_STORE_INFO *try_decode_X509CRL(const char *pem_name,
-                                           const char *pem_header,
+                                           ossl_unused const char *unused__pem_header,
                                            const unsigned char *blob,
-                                           size_t len, void **pctx,
+                                           size_t len,
+                                           ossl_unused void **unused__pctx,
                                            int *matchcount,
-                                           const UI_METHOD *ui_method,
-                                           void *ui_data, const char *uri,
-                                           OPENSSL_CTX *libctx,
-                                           const char *propq)
+                                           ossl_unused const UI_METHOD *unused__ui_method,
+                                           ossl_unused void *unused__ui_data,
+                                           ossl_unused const char *unused__uri,
+                                           ossl_unused OPENSSL_CTX *unused__libctx,
+                                           ossl_unused const char *unused__propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
     X509_CRL *crl = NULL;
@@ -862,10 +872,12 @@ static int file_find_type(OSSL_STORE_LOADER_CTX *ctx)
     return 1;
 }
 
-static OSSL_STORE_LOADER_CTX *file_open_with_libctx
-    (const OSSL_STORE_LOADER *loader, const char *uri,
-     OPENSSL_CTX *libctx, const char *propq,
-     const UI_METHOD *ui_method, void *ui_data)
+static OSSL_STORE_LOADER_CTX *file_open_with_libctx (ossl_unused const OSSL_STORE_LOADER *unused__loader,
+                                                     const char *uri,
+                                                     OPENSSL_CTX *libctx,
+                                                     const char *propq,
+                                                     ossl_unused const UI_METHOD *unused__ui_method,
+                                                     ossl_unused void *unused__ui_data)
 {
     OSSL_STORE_LOADER_CTX *ctx = NULL;
     struct stat st;
@@ -991,17 +1003,20 @@ static OSSL_STORE_LOADER_CTX *file_open_with_libctx
     return NULL;
 }
 
-static OSSL_STORE_LOADER_CTX *file_open
-    (const OSSL_STORE_LOADER *loader, const char *uri,
-     const UI_METHOD *ui_method, void *ui_data)
+static OSSL_STORE_LOADER_CTX *file_open(const OSSL_STORE_LOADER *loader,
+                                        const char *uri,
+                                        const UI_METHOD *ui_method,
+                                        void *ui_data)
 {
     return file_open_with_libctx(loader, uri, NULL, NULL, ui_method, ui_data);
 }
 
-static OSSL_STORE_LOADER_CTX *file_attach
-    (const OSSL_STORE_LOADER *loader, BIO *bp,
-     OPENSSL_CTX *libctx, const char *propq,
-     const UI_METHOD *ui_method, void *ui_data)
+static OSSL_STORE_LOADER_CTX *file_attach(ossl_unused const OSSL_STORE_LOADER *unused__loader,
+                                          BIO *bp,
+                                          OPENSSL_CTX *libctx,
+                                          const char *propq,
+                                          ossl_unused const UI_METHOD *unused__ui_method,
+                                          ossl_unused void *unused__ui_data)
 {
     OSSL_STORE_LOADER_CTX *ctx = NULL;
 

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -346,6 +346,9 @@ int OSSL_trace_set_channel(int category, BIO *channel)
     if (category >= 0 && category < OSSL_TRACE_CATEGORY_NUM)
         return set_trace_data(category, SIMPLE_CHANNEL, &channel, NULL, NULL,
                               trace_attach_cb, trace_detach_cb);
+#else
+    (void) category; /* silence -Wunused-parameter */
+    (void) channel;  /* silence -Wunused-parameter */
 #endif
     return 0;
 }
@@ -405,6 +408,10 @@ int OSSL_trace_set_callback(int category, OSSL_trace_cb callback, void *data)
  err:
     BIO_free(channel);
     OPENSSL_free(trace_data);
+#else
+    (void) category; /* silence -Wunused-parameter */
+    (void) callback; /* silence -Wunused-parameter */
+    (void) data;     /* silence -Wunused-parameter */
 #endif
 
     return 0;
@@ -416,6 +423,9 @@ int OSSL_trace_set_prefix(int category, const char *prefix)
     if (category >= 0 && category < OSSL_TRACE_CATEGORY_NUM)
         return set_trace_data(category, 0, NULL, &prefix, NULL,
                               trace_attach_cb, trace_detach_cb);
+#else
+    (void) category; /* silence -Wunused-parameter */
+    (void) prefix;   /* silence -Wunused-parameter */
 #endif
     return 0;
 }
@@ -426,6 +436,9 @@ int OSSL_trace_set_suffix(int category, const char *suffix)
     if (category >= 0 && category < OSSL_TRACE_CATEGORY_NUM)
         return set_trace_data(category, 0, NULL, NULL, &suffix,
                               trace_attach_cb, trace_detach_cb);
+#else
+    (void) category; /* silence -Wunused-parameter */
+    (void) suffix;   /* silence -Wunused-parameter */
 #endif
     return 0;
 }
@@ -448,6 +461,8 @@ int OSSL_trace_enabled(int category)
     category = ossl_trace_get_category(category);
     if (category >= 0)
         ret = trace_channels[category].bio != NULL;
+#else
+    (void) category; /* silence -Wunused-parameter */
 #endif
     return ret;
 }
@@ -481,6 +496,8 @@ BIO *OSSL_trace_begin(int category)
             break;
         }
     }
+#else
+    (void) category; /* silence -Wunused-parameter */
 #endif
     return channel;
 }
@@ -510,5 +527,8 @@ void OSSL_trace_end(int category, BIO * channel)
         current_channel = NULL;
         CRYPTO_THREAD_unlock(trace_lock);
     }
+#else
+    (void) category; /* silence -Wunused-parameter */
+    (void) channel;  /* silence -Wunused-parameter */
 #endif
 }

--- a/crypto/ts/ts_asn1.c
+++ b/crypto/ts/ts_asn1.c
@@ -156,8 +156,8 @@ static int ts_resp_set_tst_info(TS_RESP *a)
     return 1;
 }
 
-static int ts_resp_cb(int op, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int ts_resp_cb(int op, ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it,
+                      ossl_unused void *unused__exarg)
 {
     TS_RESP *ts_resp = (TS_RESP *)*pval;
     if (op == ASN1_OP_NEW_POST) {

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -43,7 +43,7 @@ static ASN1_GENERALIZEDTIME
                                     unsigned);
 
 /* Default callback for response generation. */
-static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, void *data)
+static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, ossl_unused void *unused__data)
 {
     ASN1_INTEGER *serial = ASN1_INTEGER_new();
 
@@ -63,7 +63,7 @@ static ASN1_INTEGER *def_serial_cb(struct TS_resp_ctx *ctx, void *data)
 
 #if defined(OPENSSL_SYS_UNIX)
 
-static int def_time_cb(struct TS_resp_ctx *ctx, void *data,
+static int def_time_cb(struct TS_resp_ctx *ctx, ossl_unused void *unused__data,
                        long *sec, long *usec)
 {
     struct timeval tv;
@@ -101,8 +101,9 @@ static int def_time_cb(struct TS_resp_ctx *ctx, void *data,
 
 #endif
 
-static int def_extension_cb(struct TS_resp_ctx *ctx, X509_EXTENSION *ext,
-                            void *data)
+static int def_extension_cb(struct TS_resp_ctx *ctx,
+                            ossl_unused X509_EXTENSION *unused__ext,
+                            ossl_unused void *unused__data)
 {
     TS_RESP_CTX_set_status_info(ctx, TS_STATUS_REJECTION,
                                 "Unsupported extension.");

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -96,7 +96,7 @@ static int allocate_string_stack(UI *ui)
     return 0;
 }
 
-static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
+static UI_STRING *general_allocate_prompt(ossl_unused UI *unused__ui, const char *prompt,
                                           int prompt_freeable,
                                           enum UI_string_types type,
                                           int input_flags, char *result_buf)
@@ -457,7 +457,7 @@ int UI_get_result_length(UI *ui, int i)
     return UI_get_result_string_length(sk_UI_STRING_value(ui->strings, i));
 }
 
-static int print_error(const char *str, size_t len, UI *ui)
+static int print_error(const char *str, ossl_unused size_t unused__len, UI *ui)
 {
     UI_STRING uis;
 
@@ -550,7 +550,7 @@ int UI_process(UI *ui)
     return ok;
 }
 
-int UI_ctrl(UI *ui, int cmd, long i, void *p, void (*f) (void))
+int UI_ctrl(UI *ui, int cmd, long i, ossl_unused void *unused__p, ossl_unused void (*f) (void))
 {
     if (ui == NULL) {
         UIerr(UI_F_UI_CTRL, ERR_R_PASSED_NULL_PARAMETER);

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -200,7 +200,7 @@ static int close_console(UI *ui);
  * The following function makes sure that info and error strings are printed
  * before any prompt.
  */
-static int write_string(UI *ui, UI_STRING *uis)
+static int write_string(ossl_unused UI *unused__ui, UI_STRING *uis)
 {
     switch (UI_get_string_type(uis)) {
     case UIT_ERROR:
@@ -487,7 +487,7 @@ static int open_console(UI *ui)
     return 1;
 }
 
-static int noecho_console(UI *ui)
+static int noecho_console(ossl_unused UI *unused__ui)
 {
 # ifdef TTY_FLAGS
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));
@@ -529,7 +529,7 @@ static int noecho_console(UI *ui)
     return 1;
 }
 
-static int echo_console(UI *ui)
+static int echo_console(ossl_unused UI *unused__ui)
 {
 # if defined(TTY_set) && !defined(OPENSSL_SYS_VMS)
     memcpy(&(tty_new), &(tty_orig), sizeof(tty_orig));

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -61,8 +61,10 @@ struct pem_password_cb_data {
     int rwflag;
 };
 
-static void ui_new_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-                               int idx, long argl, void *argp)
+static void ui_new_method_data(ossl_unused void *unused__parent, ossl_unused void *unused__ptr,
+                               ossl_unused CRYPTO_EX_DATA *unused__ad,
+                               ossl_unused int unused__idx, ossl_unused long unused__argl,
+                               ossl_unused void *unused__argp)
 {
     /*
      * Do nothing, the data is allocated externally and assigned later with
@@ -70,16 +72,19 @@ static void ui_new_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
      */
 }
 
-static int ui_dup_method_data(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                              void **pptr, int idx, long argl, void *argp)
+static int ui_dup_method_data(ossl_unused CRYPTO_EX_DATA *unused__to,
+                              ossl_unused const CRYPTO_EX_DATA *unused__from,
+                              void **pptr, ossl_unused int unused__idx,
+                              ossl_unused long unused__argl, ossl_unused void *unused__argp)
 {
     if (*pptr != NULL)
         *pptr = OPENSSL_memdup(*pptr, sizeof(struct pem_password_cb_data));
     return 1;
 }
 
-static void ui_free_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-                                int idx, long argl, void *argp)
+static void ui_free_method_data(ossl_unused void *unused__parent, void *ptr,
+                                ossl_unused CRYPTO_EX_DATA *unused__ad, ossl_unused int unused__idx,
+                                ossl_unused long unused__argl, ossl_unused void *unused__argp)
 {
     OPENSSL_free(ptr);
 }
@@ -95,7 +100,7 @@ DEFINE_RUN_ONCE_STATIC(ui_method_data_index_init)
     return 1;
 }
 
-static int ui_open(UI *ui)
+static int ui_open(ossl_unused UI *unused__ui)
 {
     return 1;
 }
@@ -129,11 +134,11 @@ static int ui_read(UI *ui, UI_STRING *uis)
     }
     return 1;
 }
-static int ui_write(UI *ui, UI_STRING *uis)
+static int ui_write(ossl_unused UI *unused__ui, ossl_unused UI_STRING *unused__uis)
 {
     return 1;
 }
-static int ui_close(UI *ui)
+static int ui_close(ossl_unused UI *unused__ui)
 {
     return 1;
 }

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -76,7 +76,7 @@ X509_LOOKUP_METHOD *X509_LOOKUP_hash_dir(void)
 }
 
 static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
-                    char **retp)
+                    ossl_unused char **unused__retp)
 {
     int ret = 0;
     BY_DIR *ld = (BY_DIR *)ctx->method_data;

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -47,7 +47,8 @@ X509_LOOKUP_METHOD *X509_LOOKUP_file(void)
 }
 
 static int by_file_ctrl_with_libctx(X509_LOOKUP *ctx, int cmd,
-                                    const char *argp, long argl, char **ret,
+                                    const char *argp, long argl,
+                                    ossl_unused char **unused__ret,
                                     OPENSSL_CTX *libctx, const char *propq)
 {
     int ok = 0;
@@ -261,4 +262,3 @@ int X509_load_cert_crl_file(X509_LOOKUP *ctx, const char *file, int type)
 {
     return X509_load_cert_crl_file_with_libctx(ctx, file, type, NULL, NULL);
 }
-

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -108,8 +108,8 @@ static void by_store_free(X509_LOOKUP *ctx)
 }
 
 static int by_store_ctrl_with_libctx(X509_LOOKUP *ctx, int cmd,
-                                     const char *argp, long argl,
-                                     char **retp,
+                                     const char *argp, ossl_unused long unused__argl,
+                                     ossl_unused char **unused__retp,
                                      OPENSSL_CTX *libctx, const char *propq)
 {
     switch (cmd) {
@@ -143,8 +143,9 @@ static int by_store_ctrl(X509_LOOKUP *ctx, int cmd,
     return by_store_ctrl_with_libctx(ctx, cmd, argp, argl, retp, NULL, NULL);
 }
 
-static int by_store(X509_LOOKUP *ctx, X509_LOOKUP_TYPE type,
-                    const OSSL_STORE_SEARCH *criterion, X509_OBJECT *ret,
+static int by_store(X509_LOOKUP *ctx, ossl_unused X509_LOOKUP_TYPE unused__type,
+                    const OSSL_STORE_SEARCH *criterion,
+                    ossl_unused X509_OBJECT *unused__ret,
                     OPENSSL_CTX *libctx, const char *propq)
 {
     STACK_OF(OPENSSL_STRING) *uris = X509_LOOKUP_get_method_data(ctx);

--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -20,7 +20,7 @@ DEFINE_STACK_OF(X509_POLICY_NODE)
 
 static void expected_print(BIO *channel,
                            X509_POLICY_LEVEL *lev, X509_POLICY_NODE *node,
-                           int indent)
+                           ossl_unused int unused__indent)
 {
     if ((lev->flags & X509_V_FLAG_INHIBIT_MAP)
         || !(node->data->flags & POLICY_DATA_FLAG_MAP_MASK))

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -202,7 +202,7 @@ static int i2r_IPAddressOrRanges(BIO *out,
 /*
  * i2r handler for an IPAddrBlocks extension.
  */
-static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *method,
+static int i2r_IPAddrBlocks(ossl_unused const X509V3_EXT_METHOD *unused__method,
                             void *ext, BIO *out, int indent)
 {
     const IPAddrBlocks *addr = ext;
@@ -891,8 +891,8 @@ int X509v3_addr_canonize(IPAddrBlocks *addr)
 /*
  * v2i handler for the IPAddrBlocks extension.
  */
-static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
-                              struct v3_ext_ctx *ctx,
+static void *v2i_IPAddrBlocks(ossl_unused const struct v3_ext_method *unused__method,
+                              ossl_unused struct v3_ext_ctx *unused__ctx,
                               STACK_OF(CONF_VALUE) *values)
 {
     static const char v4addr_chars[] = "0123456789.";

--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -73,8 +73,8 @@ const X509V3_EXT_METHOD v3_ext_admission = {
 };
 
 
-static int i2r_NAMING_AUTHORITY(const struct v3_ext_method *method, void *in,
-                                BIO *bp, int ind)
+static int i2r_NAMING_AUTHORITY(ossl_unused const struct v3_ext_method *unused__method,
+                                void *in, BIO *bp, int ind)
 {
     NAMING_AUTHORITY * namingAuthority = (NAMING_AUTHORITY*) in;
 

--- a/crypto/x509/v3_akey.c
+++ b/crypto/x509/v3_akey.c
@@ -37,7 +37,7 @@ const X509V3_EXT_METHOD v3_akey_id = {
     NULL
 };
 
-static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(ossl_unused X509V3_EXT_METHOD *unused__method,
                                                  AUTHORITY_KEYID *akeyid,
                                                  STACK_OF(CONF_VALUE)
                                                  *extlist)
@@ -76,7 +76,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
  * this is always included.
  */
 
-static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
+static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(ossl_unused X509V3_EXT_METHOD *unused__method,
                                             X509V3_CTX *ctx,
                                             STACK_OF(CONF_VALUE) *values)
 {

--- a/crypto/x509/v3_alt.c
+++ b/crypto/x509/v3_alt.c
@@ -78,7 +78,7 @@ STACK_OF(CONF_VALUE) *i2v_GENERAL_NAMES(X509V3_EXT_METHOD *method,
     return ret;
 }
 
-STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(X509V3_EXT_METHOD *method,
+STACK_OF(CONF_VALUE) *i2v_GENERAL_NAME(ossl_unused X509V3_EXT_METHOD *unused__method,
                                        GENERAL_NAME *gen,
                                        STACK_OF(CONF_VALUE) *ret)
 {
@@ -494,7 +494,7 @@ GENERAL_NAME *v2i_GENERAL_NAME(const X509V3_EXT_METHOD *method,
 }
 
 GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
-                               const X509V3_EXT_METHOD *method,
+                               ossl_unused const X509V3_EXT_METHOD *unused__method,
                                X509V3_CTX *ctx, int gen_type, const char *value,
                                int is_nc)
 {

--- a/crypto/x509/v3_asid.c
+++ b/crypto/x509/v3_asid.c
@@ -111,7 +111,7 @@ static int i2r_ASIdentifierChoice(BIO *out,
 /*
  * i2r method for an ASIdentifier extension.
  */
-static int i2r_ASIdentifiers(const X509V3_EXT_METHOD *method,
+static int i2r_ASIdentifiers(ossl_unused const X509V3_EXT_METHOD *unused__method,
                              void *ext, BIO *out, int indent)
 {
     ASIdentifiers *asid = ext;
@@ -519,8 +519,8 @@ int X509v3_asid_canonize(ASIdentifiers *asid)
 /*
  * v2i method for an ASIdentifier extension.
  */
-static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
-                               struct v3_ext_ctx *ctx,
+static void *v2i_ASIdentifiers(ossl_unused const struct v3_ext_method *unused__method,
+                               ossl_unused struct v3_ext_ctx *unused__ctx,
                                STACK_OF(CONF_VALUE) *values)
 {
     ASN1_INTEGER *min = NULL, *max = NULL;

--- a/crypto/x509/v3_bcons.c
+++ b/crypto/x509/v3_bcons.c
@@ -44,7 +44,7 @@ ASN1_SEQUENCE(BASIC_CONSTRAINTS) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(BASIC_CONSTRAINTS)
 
-static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
+static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(ossl_unused X509V3_EXT_METHOD *unused__method,
                                                    BASIC_CONSTRAINTS *bcons,
                                                    STACK_OF(CONF_VALUE)
                                                    *extlist)
@@ -54,8 +54,8 @@ static STACK_OF(CONF_VALUE) *i2v_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
     return extlist;
 }
 
-static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(X509V3_EXT_METHOD *method,
-                                                X509V3_CTX *ctx,
+static BASIC_CONSTRAINTS *v2i_BASIC_CONSTRAINTS(ossl_unused X509V3_EXT_METHOD *unused__method,
+                                                ossl_unused X509V3_CTX *unused__ctx,
                                                 STACK_OF(CONF_VALUE) *values)
 {
     BASIC_CONSTRAINTS *bcons = NULL;

--- a/crypto/x509/v3_bitst.c
+++ b/crypto/x509/v3_bitst.c
@@ -58,7 +58,7 @@ STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
 }
 
 ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
-                                     X509V3_CTX *ctx,
+                                     ossl_unused X509V3_CTX *unused__ctx,
                                      STACK_OF(CONF_VALUE) *nval)
 {
     CONF_VALUE *val;

--- a/crypto/x509/v3_cpols.c
+++ b/crypto/x509/v3_cpols.c
@@ -91,7 +91,7 @@ ASN1_SEQUENCE(NOTICEREF) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(NOTICEREF)
 
-static STACK_OF(POLICYINFO) *r2i_certpol(X509V3_EXT_METHOD *method,
+static STACK_OF(POLICYINFO) *r2i_certpol(ossl_unused X509V3_EXT_METHOD *unused__method,
                                          X509V3_CTX *ctx, const char *value)
 {
     STACK_OF(POLICYINFO) *pols;
@@ -285,7 +285,7 @@ static int displaytext_str2tag(const char *tagstr, unsigned int *tag_len)
     return V_ASN1_VISIBLESTRING;
 }
 
-static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
+static POLICYQUALINFO *notice_section(ossl_unused X509V3_CTX *unused__ctx,
                                       STACK_OF(CONF_VALUE) *unot, int ia5org)
 {
     int i, ret, len, tag;
@@ -404,7 +404,8 @@ static int nref_nos(STACK_OF(ASN1_INTEGER) *nnums, STACK_OF(CONF_VALUE) *nos)
     return 0;
 }
 
-static int i2r_certpol(X509V3_EXT_METHOD *method, STACK_OF(POLICYINFO) *pol,
+static int i2r_certpol(ossl_unused X509V3_EXT_METHOD *unused__method,
+                       STACK_OF(POLICYINFO) *pol,
                        BIO *out, int indent)
 {
     int i;

--- a/crypto/x509/v3_crld.c
+++ b/crypto/x509/v3_crld.c
@@ -296,8 +296,9 @@ static void *v2i_crld(const X509V3_EXT_METHOD *method,
     return NULL;
 }
 
-static int dpn_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int dpn_cb(int operation, ASN1_VALUE **pval,
+                  ossl_unused const ASN1_ITEM *unused__it,
+                  ossl_unused void *unused__exarg)
 {
     DIST_POINT_NAME *dpn = (DIST_POINT_NAME *)*pval;
 
@@ -363,7 +364,8 @@ const X509V3_EXT_METHOD v3_idp = {
     NULL
 };
 
-static void *v2i_idp(const X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
+static void *v2i_idp(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                     X509V3_CTX *ctx,
                      STACK_OF(CONF_VALUE) *nval)
 {
     ISSUING_DIST_POINT *idp = NULL;
@@ -439,8 +441,8 @@ static int print_distpoint(BIO *out, DIST_POINT_NAME *dpn, int indent)
     return 1;
 }
 
-static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
-                   int indent)
+static int i2r_idp(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                   void *pidp, BIO *out, int indent)
 {
     ISSUING_DIST_POINT *idp = pidp;
     if (idp->distpoint)
@@ -463,8 +465,8 @@ static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
     return 1;
 }
 
-static int i2r_crldp(const X509V3_EXT_METHOD *method, void *pcrldp, BIO *out,
-                     int indent)
+static int i2r_crldp(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                     void *pcrldp, BIO *out, int indent)
 {
     STACK_OF(DIST_POINT) *crld = pcrldp;
     DIST_POINT *point;

--- a/crypto/x509/v3_extku.c
+++ b/crypto/x509/v3_extku.c
@@ -53,8 +53,8 @@ ASN1_ITEM_TEMPLATE_END(EXTENDED_KEY_USAGE)
 
 IMPLEMENT_ASN1_FUNCTIONS(EXTENDED_KEY_USAGE)
 
-static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD
-                                                    *method, void *a, STACK_OF(CONF_VALUE)
+static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                                    void *a, STACK_OF(CONF_VALUE)
                                                     *ext_list)
 {
     EXTENDED_KEY_USAGE *eku = a;
@@ -69,8 +69,8 @@ static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD
     return ext_list;
 }
 
-static void *v2i_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD *method,
-                                    X509V3_CTX *ctx,
+static void *v2i_EXTENDED_KEY_USAGE(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                    ossl_unused X509V3_CTX *unused__ctx,
                                     STACK_OF(CONF_VALUE) *nval)
 {
     EXTENDED_KEY_USAGE *extku;

--- a/crypto/x509/v3_ia5.c
+++ b/crypto/x509/v3_ia5.c
@@ -25,7 +25,7 @@ const X509V3_EXT_METHOD v3_ns_ia5_list[8] = {
     EXT_END
 };
 
-char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
+char *i2s_ASN1_IA5STRING(ossl_unused X509V3_EXT_METHOD *unused__method, ASN1_IA5STRING *ia5)
 {
     char *tmp;
 
@@ -40,8 +40,9 @@ char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
     return tmp;
 }
 
-ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
-                                   X509V3_CTX *ctx, const char *str)
+ASN1_IA5STRING *s2i_ASN1_IA5STRING(ossl_unused X509V3_EXT_METHOD *unused__method,
+                                   ossl_unused X509V3_CTX *unused__ctx,
+                                   const char *str)
 {
     ASN1_IA5STRING *ia5;
     if (str == NULL) {

--- a/crypto/x509/v3_int.c
+++ b/crypto/x509/v3_int.c
@@ -28,10 +28,10 @@ const X509V3_EXT_METHOD v3_delta_crl = {
     0, 0, 0, 0, NULL
 };
 
-static void *s2i_asn1_int(X509V3_EXT_METHOD *meth, X509V3_CTX *ctx,
+static void *s2i_asn1_int(X509V3_EXT_METHOD *method, ossl_unused X509V3_CTX *unused__ctx,
                           const char *value)
 {
-    return s2i_ASN1_INTEGER(meth, value);
+    return s2i_ASN1_INTEGER(method, value);
 }
 
 const X509V3_EXT_METHOD v3_inhibit_anyp = {

--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -34,8 +34,9 @@ ASN1_SEQUENCE(ISSUER_SIGN_TOOL) = {
 IMPLEMENT_ASN1_FUNCTIONS(ISSUER_SIGN_TOOL)
 
 
-static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
-                        STACK_OF(CONF_VALUE) *nval)
+static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(ossl_unused X509V3_EXT_METHOD *unused__method,
+                                              ossl_unused X509V3_CTX *unused__ctx,
+                                              STACK_OF(CONF_VALUE) *nval)
 {
     ISSUER_SIGN_TOOL *ist = ISSUER_SIGN_TOOL_new();
     int i;
@@ -91,9 +92,9 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
     return ist;
 }
 
-static int i2r_issuer_sign_tool(X509V3_EXT_METHOD *method,
-                                 ISSUER_SIGN_TOOL *ist, BIO *out,
-                                 int indent)
+static int i2r_issuer_sign_tool(ossl_unused X509V3_EXT_METHOD *unused__method,
+                                ISSUER_SIGN_TOOL *ist, BIO *out,
+                                int indent)
 {
     int new_line = 0;
 

--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -169,7 +169,7 @@ static int i2r_NAME_CONSTRAINTS(const X509V3_EXT_METHOD *method, void *a,
     return 1;
 }
 
-static int do_i2r_name_constraints(const X509V3_EXT_METHOD *method,
+static int do_i2r_name_constraints(ossl_unused const X509V3_EXT_METHOD *unused__method,
                                    STACK_OF(GENERAL_SUBTREE) *trees,
                                    BIO *bp, int ind, const char *name)
 {

--- a/crypto/x509/v3_pci.c
+++ b/crypto/x509/v3_pci.c
@@ -66,7 +66,8 @@ const X509V3_EXT_METHOD v3_pci =
     NULL,
 };
 
-static int i2r_pci(X509V3_EXT_METHOD *method, PROXY_CERT_INFO_EXTENSION *pci,
+static int i2r_pci(ossl_unused X509V3_EXT_METHOD *unused__method,
+                   PROXY_CERT_INFO_EXTENSION *pci,
                    BIO *out, int indent)
 {
     BIO_printf(out, "%*sPath Length Constraint: ", indent, "");
@@ -242,7 +243,7 @@ static int process_pci_value(CONF_VALUE *val,
     return 0;
 }
 
-static PROXY_CERT_INFO_EXTENSION *r2i_pci(X509V3_EXT_METHOD *method,
+static PROXY_CERT_INFO_EXTENSION *r2i_pci(ossl_unused X509V3_EXT_METHOD *unused__method,
                                           X509V3_CTX *ctx, char *value)
 {
     PROXY_CERT_INFO_EXTENSION *pci = NULL;

--- a/crypto/x509/v3_pcons.c
+++ b/crypto/x509/v3_pcons.c
@@ -42,8 +42,8 @@ ASN1_SEQUENCE(POLICY_CONSTRAINTS) = {
 
 IMPLEMENT_ASN1_ALLOC_FUNCTIONS(POLICY_CONSTRAINTS)
 
-static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD
-                                                    *method, void *a, STACK_OF(CONF_VALUE)
+static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                                    void *a, STACK_OF(CONF_VALUE)
                                                     *extlist)
 {
     POLICY_CONSTRAINTS *pcons = a;
@@ -54,8 +54,8 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD
     return extlist;
 }
 
-static void *v2i_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD *method,
-                                    X509V3_CTX *ctx,
+static void *v2i_POLICY_CONSTRAINTS(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                    ossl_unused X509V3_CTX *unused__ctx,
                                     STACK_OF(CONF_VALUE) *values)
 {
     POLICY_CONSTRAINTS *pcons = NULL;

--- a/crypto/x509/v3_pku.c
+++ b/crypto/x509/v3_pku.c
@@ -33,7 +33,7 @@ ASN1_SEQUENCE(PKEY_USAGE_PERIOD) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(PKEY_USAGE_PERIOD)
 
-static int i2r_PKEY_USAGE_PERIOD(X509V3_EXT_METHOD *method,
+static int i2r_PKEY_USAGE_PERIOD(ossl_unused X509V3_EXT_METHOD *unused__method,
                                  PKEY_USAGE_PERIOD *usage, BIO *out,
                                  int indent)
 {

--- a/crypto/x509/v3_pmaps.c
+++ b/crypto/x509/v3_pmaps.c
@@ -46,9 +46,8 @@ ASN1_ITEM_TEMPLATE_END(POLICY_MAPPINGS)
 
 IMPLEMENT_ASN1_ALLOC_FUNCTIONS(POLICY_MAPPING)
 
-static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD
-                                                 *method, void *a, STACK_OF(CONF_VALUE)
-                                                 *ext_list)
+static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                                 void *a, STACK_OF(CONF_VALUE) *ext_list)
 {
     POLICY_MAPPINGS *pmaps = a;
     POLICY_MAPPING *pmap;
@@ -65,8 +64,9 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD
     return ext_list;
 }
 
-static void *v2i_POLICY_MAPPINGS(const X509V3_EXT_METHOD *method,
-                                 X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *nval)
+static void *v2i_POLICY_MAPPINGS(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                 ossl_unused X509V3_CTX *unused__ctx,
+                                 STACK_OF(CONF_VALUE) *nval)
 {
     POLICY_MAPPING *pmap = NULL;
     ASN1_OBJECT *obj1 = NULL, *obj2 = NULL;

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -652,7 +652,8 @@ static int check_ssl_ca(const X509 *x)
         return 0;
 }
 
-static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_ssl_client(ossl_unused const X509_PURPOSE *unused__xp,
+                                    const X509 *x,
                                     int ca)
 {
     if (xku_reject(x, XKU_SSL_CLIENT))
@@ -676,7 +677,8 @@ static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
 #define KU_TLS \
         KU_DIGITAL_SIGNATURE|KU_KEY_ENCIPHERMENT|KU_KEY_AGREEMENT
 
-static int check_purpose_ssl_server(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_ssl_server(ossl_unused const X509_PURPOSE *unused__xp,
+                                    const X509 *x,
                                     int ca)
 {
     if (xku_reject(x, XKU_SSL_SERVER | XKU_SGC))
@@ -733,7 +735,8 @@ static int purpose_smime(const X509 *x, int ca)
     return 1;
 }
 
-static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_smime_sign(ossl_unused const X509_PURPOSE *unused__xp,
+                                    const X509 *x,
                                     int ca)
 {
     int ret;
@@ -745,7 +748,8 @@ static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
     return ret;
 }
 
-static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_smime_encrypt(ossl_unused const X509_PURPOSE *unused__xp,
+                                       const X509 *x,
                                        int ca)
 {
     int ret;
@@ -757,7 +761,8 @@ static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
     return ret;
 }
 
-static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_crl_sign(ossl_unused const X509_PURPOSE *unused__xp,
+                                  const X509 *x,
                                   int ca)
 {
     if (ca) {
@@ -777,7 +782,7 @@ static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
  * is valid. Additional checks must be made on the chain.
  */
 
-static int ocsp_helper(const X509_PURPOSE *xp, const X509 *x, int ca)
+static int ocsp_helper(ossl_unused const X509_PURPOSE *unused__xp, const X509 *x, int ca)
 {
     /*
      * Must be a valid CA.  Should we really support the "I don't know" value
@@ -789,7 +794,8 @@ static int ocsp_helper(const X509_PURPOSE *xp, const X509 *x, int ca)
     return 1;
 }
 
-static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
+static int check_purpose_timestamp_sign(ossl_unused const X509_PURPOSE *unused__xp,
+                                        const X509 *x,
                                         int ca)
 {
     int i_ext;
@@ -824,7 +830,9 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
     return 1;
 }
 
-static int no_check(const X509_PURPOSE *xp, const X509 *x, int ca)
+static int no_check(ossl_unused const X509_PURPOSE *unused__xp,
+                    ossl_unused const X509 *unused__x,
+                    ossl_unused int unused__ca)
 {
     return 1;
 }

--- a/crypto/x509/v3_skey.c
+++ b/crypto/x509/v3_skey.c
@@ -24,14 +24,15 @@ const X509V3_EXT_METHOD v3_skey_id = {
     NULL
 };
 
-char *i2s_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
+char *i2s_ASN1_OCTET_STRING(ossl_unused X509V3_EXT_METHOD *unused__method,
                             const ASN1_OCTET_STRING *oct)
 {
     return OPENSSL_buf2hexstr(oct->data, oct->length);
 }
 
-ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
-                                         X509V3_CTX *ctx, const char *str)
+ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(ossl_unused X509V3_EXT_METHOD *unused__method,
+                                         ossl_unused X509V3_CTX *unused__ctx,
+                                         const char *str)
 {
     ASN1_OCTET_STRING *oct;
     long length;

--- a/crypto/x509/v3_sxnet.c
+++ b/crypto/x509/v3_sxnet.c
@@ -57,7 +57,8 @@ ASN1_SEQUENCE(SXNET) = {
 
 IMPLEMENT_ASN1_FUNCTIONS(SXNET)
 
-static int sxnet_i2r(X509V3_EXT_METHOD *method, SXNET *sx, BIO *out,
+static int sxnet_i2r(ossl_unused X509V3_EXT_METHOD *unused__method,
+                     SXNET *sx, BIO *out,
                      int indent)
 {
     long v;
@@ -84,7 +85,8 @@ static int sxnet_i2r(X509V3_EXT_METHOD *method, SXNET *sx, BIO *out,
  * they should really be separate values for each user.
  */
 
-static SXNET *sxnet_v2i(X509V3_EXT_METHOD *method, X509V3_CTX *ctx,
+static SXNET *sxnet_v2i(ossl_unused X509V3_EXT_METHOD *unused__method,
+                        ossl_unused X509V3_CTX *unused__ctx,
                         STACK_OF(CONF_VALUE) *nval)
 {
     CONF_VALUE *cnf;

--- a/crypto/x509/v3_tlsf.c
+++ b/crypto/x509/v3_tlsf.c
@@ -60,7 +60,7 @@ static TLS_FEATURE_NAME tls_feature_tbl[] = {
  * used by the CONF library to represent a multi-valued extension.  ext_list is
  * returned.
  */
-static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *method,
+static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(ossl_unused const X509V3_EXT_METHOD *unused__method,
                                              TLS_FEATURE *tls_feature,
                                              STACK_OF(CONF_VALUE) *ext_list)
 {
@@ -87,8 +87,9 @@ static STACK_OF(CONF_VALUE) *i2v_TLS_FEATURE(const X509V3_EXT_METHOD *method,
  * structure, which is returned if the conversion is successful.  In case of
  * error, NULL is returned.
  */
-static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *method,
-                                    X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *nval)
+static TLS_FEATURE *v2i_TLS_FEATURE(ossl_unused const X509V3_EXT_METHOD *unused__method,
+                                    ossl_unused X509V3_CTX *unused__ctx,
+                                    STACK_OF(CONF_VALUE) *nval)
 {
     TLS_FEATURE *tlsf;
     char *extval, *endptr;

--- a/crypto/x509/v3_utf8.c
+++ b/crypto/x509/v3_utf8.c
@@ -27,7 +27,7 @@ const X509V3_EXT_METHOD v3_utf8_list[1] = {
     EXT_UTF8STRING(NID_subjectSignTool),
 };
 
-char *i2s_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
+char *i2s_ASN1_UTF8STRING(ossl_unused X509V3_EXT_METHOD *unused__method,
                           ASN1_UTF8STRING *utf8)
 {
     char *tmp;
@@ -45,8 +45,9 @@ char *i2s_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
     return tmp;
 }
 
-ASN1_UTF8STRING *s2i_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
-                                     X509V3_CTX *ctx, const char *str)
+ASN1_UTF8STRING *s2i_ASN1_UTF8STRING(ossl_unused X509V3_EXT_METHOD *unused__method,
+                                     ossl_unused X509V3_CTX *unused__ctx,
+                                     const char *str)
 {
     ASN1_UTF8STRING *utf8;
     if (str == NULL) {

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -146,7 +146,7 @@ static char *bignum_to_string(const BIGNUM *bn)
     return ret;
 }
 
-char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, const ASN1_ENUMERATED *a)
+char *i2s_ASN1_ENUMERATED(ossl_unused X509V3_EXT_METHOD *unused__method, const ASN1_ENUMERATED *a)
 {
     BIGNUM *bntmp = NULL;
     char *strtmp = NULL;
@@ -160,7 +160,7 @@ char *i2s_ASN1_ENUMERATED(X509V3_EXT_METHOD *method, const ASN1_ENUMERATED *a)
     return strtmp;
 }
 
-char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, const ASN1_INTEGER *a)
+char *i2s_ASN1_INTEGER(ossl_unused X509V3_EXT_METHOD *unused__method, const ASN1_INTEGER *a)
 {
     BIGNUM *bntmp = NULL;
     char *strtmp = NULL;
@@ -174,7 +174,7 @@ char *i2s_ASN1_INTEGER(X509V3_EXT_METHOD *method, const ASN1_INTEGER *a)
     return strtmp;
 }
 
-ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *method, const char *value)
+ASN1_INTEGER *s2i_ASN1_INTEGER(ossl_unused X509V3_EXT_METHOD *unused__method, const char *value)
 {
     BIGNUM *bn = NULL;
     ASN1_INTEGER *aint;
@@ -625,7 +625,7 @@ static int equal_case(const unsigned char *pattern, size_t pattern_len,
  */
 static int equal_email(const unsigned char *a, size_t a_len,
                        const unsigned char *b, size_t b_len,
-                       unsigned int unused_flags)
+                       ossl_unused unsigned int unused__flags)
 {
     size_t i = a_len;
 

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -311,7 +311,7 @@ ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)
 }
 
 void *X509_ATTRIBUTE_get0_data(X509_ATTRIBUTE *attr, int idx,
-                               int atrtype, void *data)
+                               int atrtype, ossl_unused void *unused__data)
 {
     ASN1_TYPE *ttmp;
     ttmp = X509_ATTRIBUTE_get0_type(attr, idx);

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -240,7 +240,7 @@ static int trust_1oid(X509_TRUST *trust, X509 *x, int flags)
     return obj_trust(trust->arg1, x, flags);
 }
 
-static int trust_compat(X509_TRUST *trust, X509 *x, int flags)
+static int trust_compat(ossl_unused X509_TRUST *unused__trust, X509 *x, int flags)
 {
     /* Call for side-effect of computing hash and caching extensions */
     if (X509_check_purpose(x, -1, 0) != 1)

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -106,7 +106,7 @@ static int check_crl_chain(X509_STORE_CTX *ctx,
 
 static int internal_verify(X509_STORE_CTX *ctx);
 
-static int null_callback(int ok, X509_STORE_CTX *e)
+static int null_callback(int ok, ossl_unused X509_STORE_CTX *unused__e)
 {
     return ok;
 }
@@ -1320,7 +1320,7 @@ static int check_crl_path(X509_STORE_CTX *ctx, X509 *x)
  * RFC5280 version
  */
 
-static int check_crl_chain(X509_STORE_CTX *ctx,
+static int check_crl_chain(ossl_unused X509_STORE_CTX *unused__ctx,
                            STACK_OF(X509) *cert_path,
                            STACK_OF(X509) *crl_path)
 {
@@ -1985,7 +1985,8 @@ int X509_get_pubkey_parameters(EVP_PKEY *pkey, STACK_OF(X509) *chain)
 /* Make a delta CRL as the diff between two full CRLs */
 
 X509_CRL *X509_CRL_diff(X509_CRL *base, X509_CRL *newer,
-                        EVP_PKEY *skey, const EVP_MD *md, unsigned int flags)
+                        EVP_PKEY *skey, const EVP_MD *md,
+                        ossl_unused unsigned int unused__flags)
 {
     X509_CRL *crl = NULL;
     int i;
@@ -2474,7 +2475,8 @@ void X509_STORE_CTX_set_flags(X509_STORE_CTX *ctx, unsigned long flags)
     X509_VERIFY_PARAM_set_flags(ctx->param, flags);
 }
 
-void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, unsigned long flags,
+void X509_STORE_CTX_set_time(X509_STORE_CTX *ctx,
+                             ossl_unused unsigned long unused__flags,
                              time_t t)
 {
     X509_VERIFY_PARAM_set_time(ctx->param, t);

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -49,8 +49,9 @@ static const X509_CRL_METHOD *default_crl_method = &int_crl_meth;
  * the original encoding the signature won't be affected by reordering of the
  * revoked field.
  */
-static int crl_inf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                      void *exarg)
+static int crl_inf_cb(int operation, ASN1_VALUE **pval,
+                      ossl_unused const ASN1_ITEM *unused__it,
+                      ossl_unused void *unused__exarg)
 {
     X509_CRL_INFO *a = (X509_CRL_INFO *)*pval;
 
@@ -154,8 +155,9 @@ static int crl_set_issuers(X509_CRL *crl)
  * The X509_CRL structure needs a bit of customisation. Cache some extensions
  * and hash of the whole CRL.
  */
-static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int crl_cb(int operation, ASN1_VALUE **pval,
+                  ossl_unused const ASN1_ITEM *unused__it,
+                  ossl_unused void *unused__exarg)
 {
     X509_CRL *crl = (X509_CRL *)*pval;
     STACK_OF(X509_EXTENSION) *exts;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -90,7 +90,7 @@ IMPLEMENT_ASN1_FUNCTIONS(X509_NAME)
 
 IMPLEMENT_ASN1_DUP_FUNCTION(X509_NAME)
 
-static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *it)
+static int x509_name_ex_new(ASN1_VALUE **val, ossl_unused const ASN1_ITEM *unused__it)
 {
     X509_NAME *ret = OPENSSL_zalloc(sizeof(*ret));
 
@@ -113,7 +113,7 @@ static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *it)
     return 0;
 }
 
-static void x509_name_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
+static void x509_name_ex_free(ASN1_VALUE **pval, ossl_unused const ASN1_ITEM *unused__it)
 {
     X509_NAME *a;
 
@@ -140,7 +140,8 @@ static void local_sk_X509_NAME_ENTRY_pop_free(STACK_OF(X509_NAME_ENTRY) *ne)
 
 static int x509_name_ex_d2i(ASN1_VALUE **val,
                             const unsigned char **in, long len,
-                            const ASN1_ITEM *it, int tag, int aclass,
+                            ossl_unused const ASN1_ITEM *unused__it,
+                            int tag, int aclass,
                             char opt, ASN1_TLC *ctx)
 {
     const unsigned char *p = *in, *q;
@@ -212,7 +213,9 @@ static int x509_name_ex_d2i(ASN1_VALUE **val,
 }
 
 static int x509_name_ex_i2d(const ASN1_VALUE **val, unsigned char **out,
-                            const ASN1_ITEM *it, int tag, int aclass)
+                            ossl_unused const ASN1_ITEM *unused__it,
+                            ossl_unused int unused__tag,
+                            ossl_unused int unused__aclass)
 {
     int ret;
     X509_NAME *a = (X509_NAME *)*val;
@@ -285,7 +288,7 @@ static int x509_name_encode(X509_NAME *a)
 
 static int x509_name_ex_print(BIO *out, const ASN1_VALUE **pval,
                               int indent,
-                              const char *fname, const ASN1_PCTX *pctx)
+                              ossl_unused const char *unused__fname, const ASN1_PCTX *pctx)
 {
     if (X509_NAME_print_ex(out, (const X509_NAME *)*pval,
                            indent, pctx->nm_flags) <= 0)

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -37,8 +37,9 @@ struct X509_pubkey_st {
 static int x509_pubkey_decode(EVP_PKEY **pk, const X509_PUBKEY *key);
 
 /* Minor tweak to operation: free up EVP_PKEY */
-static int pubkey_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                     void *exarg)
+static int pubkey_cb(int operation, ASN1_VALUE **pval,
+                     ossl_unused const ASN1_ITEM *unused__it,
+                     ossl_unused void *unused__exarg)
 {
     if (operation == ASN1_OP_FREE_POST) {
         X509_PUBKEY *pubkey = (X509_PUBKEY *)*pval;

--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -34,8 +34,9 @@ DEFINE_STACK_OF(X509_ATTRIBUTE)
  *
  */
 
-static int rinf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                   void *exarg)
+static int rinf_cb(int operation, ASN1_VALUE **pval,
+                   ossl_unused const ASN1_ITEM *unused__it,
+                   ossl_unused void *unused__exarg)
 {
     X509_REQ_INFO *rinf = (X509_REQ_INFO *)*pval;
 
@@ -47,8 +48,9 @@ static int rinf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     return 1;
 }
 
-static int req_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                  void *exarg)
+static int req_cb(int operation, ASN1_VALUE **pval,
+                  ossl_unused const ASN1_ITEM *unused__it,
+                  ossl_unused void *unused__exarg)
 {
 #ifndef OPENSSL_NO_SM2
     X509_REQ *ret = (X509_REQ *)*pval;

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -37,8 +37,9 @@ IMPLEMENT_ASN1_FUNCTIONS(X509_CINF)
 
 extern void policy_cache_free(X509_POLICY_CACHE *cache);
 
-static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
-                   void *exarg)
+static int x509_cb(int operation, ASN1_VALUE **pval,
+                   ossl_unused const ASN1_ITEM *unused__it,
+                   ossl_unused void *unused__exarg)
 {
     X509 *ret = (X509 *)*pval;
 

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -147,8 +147,10 @@ static ossl_inline int io_getevents(aio_context_t ctx, long min, long max,
 #endif
 }
 
-static void afalg_waitfd_cleanup(ASYNC_WAIT_CTX *ctx, const void *key,
-                                 OSSL_ASYNC_FD waitfd, void *custom)
+static void afalg_waitfd_cleanup(ossl_unused ASYNC_WAIT_CTX *unused__ctx,
+                                 ossl_unused const void *unused__key,
+                                 OSSL_ASYNC_FD waitfd,
+                                 ossl_unused void *unused__custom)
 {
     close(waitfd);
 }
@@ -512,7 +514,8 @@ static int afalg_start_cipher_sk(afalg_ctx *actx, const unsigned char *in,
 }
 
 static int afalg_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                             const unsigned char *iv, int enc)
+                             ossl_unused const unsigned char *unused__iv,
+                             ossl_unused int unused__enc)
 {
     int ciphertype;
     int ret;
@@ -705,7 +708,8 @@ static const EVP_CIPHER *afalg_aes_cbc(int nid)
     return cipher_handle->_hidden;
 }
 
-static int afalg_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
+static int afalg_ciphers(ossl_unused ENGINE *unused__e,
+                         const EVP_CIPHER **cipher,
                          const int **nids, int nid)
 {
     int r = 1;
@@ -854,12 +858,12 @@ void engine_load_afalg_int(void)
 }
 # endif
 
-static int afalg_init(ENGINE *e)
+static int afalg_init(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }
 
-static int afalg_finish(ENGINE *e)
+static int afalg_finish(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }
@@ -874,7 +878,7 @@ static int free_cbc(void)
     return 1;
 }
 
-static int afalg_destroy(ENGINE *e)
+static int afalg_destroy(ossl_unused ENGINE *unused__e)
 {
     ERR_unload_AFALG_strings();
     free_cbc();

--- a/engines/e_afalg_err.c
+++ b/engines/e_afalg_err.c
@@ -62,7 +62,7 @@ static void ERR_unload_AFALG_strings(void)
     }
 }
 
-static void ERR_AFALG_error(int function, int reason, char *file, int line)
+static void ERR_AFALG_error(ossl_unused int unused__function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();

--- a/engines/e_capi.c
+++ b/engines/e_capi.c
@@ -1896,7 +1896,7 @@ static int cert_select_dialog(ENGINE *e, SSL *ssl, STACK_OF(X509) *certs)
 OPENSSL_EXPORT
     int bind_engine(ENGINE *e, const char *id, const dynamic_fns *fns);
 OPENSSL_EXPORT
-    int bind_engine(ENGINE *e, const char *id, const dynamic_fns *fns)
+    int bind_engine(ossl_unused ENGINE *unused__e, ossl_unused const char *unused__id, ossl_unused const dynamic_fns *unused__fns)
 {
     return 0;
 }

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -353,19 +353,19 @@ void engine_load_dasync_int(void)
     ERR_clear_error();
 }
 
-static int dasync_init(ENGINE *e)
+static int dasync_init(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }
 
 
-static int dasync_finish(ENGINE *e)
+static int dasync_finish(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }
 
 
-static int dasync_destroy(ENGINE *e)
+static int dasync_destroy(ossl_unused ENGINE *unused__e)
 {
     destroy_digests();
     destroy_ciphers();
@@ -374,7 +374,8 @@ static int dasync_destroy(ENGINE *e)
     return 1;
 }
 
-static int dasync_pkey(ENGINE *e, EVP_PKEY_METHOD **pmeth,
+static int dasync_pkey(ossl_unused ENGINE *unused__e,
+                       EVP_PKEY_METHOD **pmeth,
                        const int **pnids, int nid)
 {
     static const int rnid = EVP_PKEY_RSA;
@@ -393,7 +394,8 @@ static int dasync_pkey(ENGINE *e, EVP_PKEY_METHOD **pmeth,
     return 0;
 }
 
-static int dasync_digests(ENGINE *e, const EVP_MD **digest,
+static int dasync_digests(ossl_unused ENGINE *unused__e,
+                          const EVP_MD **digest,
                           const int **nids, int nid)
 {
     int ok = 1;
@@ -414,8 +416,9 @@ static int dasync_digests(ENGINE *e, const EVP_MD **digest,
     return ok;
 }
 
-static int dasync_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
-                                   const int **nids, int nid)
+static int dasync_ciphers(ossl_unused ENGINE *unused__e,
+                          const EVP_CIPHER **cipher,
+                          const int **nids, int nid)
 {
     int ok = 1;
     if (cipher == NULL) {
@@ -440,7 +443,8 @@ static int dasync_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
     return ok;
 }
 
-static void wait_cleanup(ASYNC_WAIT_CTX *ctx, const void *key,
+static void wait_cleanup(ossl_unused ASYNC_WAIT_CTX *unused__ctx,
+                         ossl_unused const void *unused__key,
                          OSSL_ASYNC_FD readfd, void *pvwritefd)
 {
     OSSL_ASYNC_FD *pwritefd = (OSSL_ASYNC_FD *)pvwritefd;

--- a/engines/e_dasync_err.c
+++ b/engines/e_dasync_err.c
@@ -47,7 +47,7 @@ static void ERR_unload_DASYNC_strings(void)
     }
 }
 
-static void ERR_DASYNC_error(int function, int reason, char *file, int line)
+static void ERR_DASYNC_error(ossl_unused int unused__function, int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();

--- a/engines/e_ossltest.c
+++ b/engines/e_ossltest.c
@@ -375,19 +375,19 @@ void ENGINE_load_ossltest(void)
 }
 
 
-static int ossltest_init(ENGINE *e)
+static int ossltest_init(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }
 
 
-static int ossltest_finish(ENGINE *e)
+static int ossltest_finish(ossl_unused ENGINE *unused__e)
 {
     return 1;
 }
 
 
-static int ossltest_destroy(ENGINE *e)
+static int ossltest_destroy(ossl_unused ENGINE *unused__e)
 {
     destroy_digests();
     destroy_ciphers();
@@ -395,8 +395,9 @@ static int ossltest_destroy(ENGINE *e)
     return 1;
 }
 
-static int ossltest_digests(ENGINE *e, const EVP_MD **digest,
-                          const int **nids, int nid)
+static int ossltest_digests(ossl_unused ENGINE *unused__e,
+                            const EVP_MD **digest,
+                            const int **nids, int nid)
 {
     int ok = 1;
     if (!digest) {
@@ -428,8 +429,9 @@ static int ossltest_digests(ENGINE *e, const EVP_MD **digest,
     return ok;
 }
 
-static int ossltest_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
-                          const int **nids, int nid)
+static int ossltest_ciphers(ossl_unused ENGINE *unused__e,
+                            const EVP_CIPHER **cipher,
+                            const int **nids, int nid)
 {
     int ok = 1;
     if (!cipher) {

--- a/engines/e_ossltest_err.c
+++ b/engines/e_ossltest_err.c
@@ -47,7 +47,8 @@ static void ERR_unload_OSSLTEST_strings(void)
     }
 }
 
-static void ERR_OSSLTEST_error(int function, int reason, char *file, int line)
+static void ERR_OSSLTEST_error(ossl_unused int unused__function,
+                               int reason, char *file, int line)
 {
     if (lib_code == 0)
         lib_code = ERR_get_next_error_library();

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -131,7 +131,7 @@ static ENGINE *ENGINE_padlock(void)
 #  endif
 
 /* Check availability of the engine */
-static int padlock_init(ENGINE *e)
+static int padlock_init(ossl_unused ENGINE *unused__e)
 {
     return (padlock_use_rng || padlock_use_ace);
 }
@@ -516,7 +516,7 @@ DECLARE_AES_EVP(256, ofb, OFB)
 DECLARE_AES_EVP(256, ctr, CTR)
 
 static int
-padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
+padlock_ciphers(ossl_unused ENGINE *unused__e, const EVP_CIPHER **cipher, const int **nids,
                 int nid)
 {
     /* No specific cipher => return a list of supported nids ... */
@@ -587,7 +587,7 @@ padlock_ciphers(ENGINE *e, const EVP_CIPHER **cipher, const int **nids,
 /* Prepare the encryption key for PadLock usage */
 static int
 padlock_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
-                     const unsigned char *iv, int enc)
+                     ossl_unused const unsigned char *unused__iv, int enc)
 {
     struct padlock_cipher_data *cdata;
     int key_len = EVP_CIPHER_CTX_key_length(ctx) * 8;

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -276,7 +276,7 @@ static ASN1_PCTX *pctx;
 }
 
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     pctx = ASN1_PCTX_new();
     ASN1_PCTX_set_flags(pctx, ASN1_PCTX_FLAGS_SHOW_ABSENT |

--- a/fuzz/asn1parse.c
+++ b/fuzz/asn1parse.c
@@ -21,7 +21,7 @@
 
 static BIO *bio_out;
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     bio_out = BIO_new_file("/dev/null", "w");
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);

--- a/fuzz/bignum.c
+++ b/fuzz/bignum.c
@@ -19,7 +19,7 @@
 #include "fuzzer.h"
 
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();

--- a/fuzz/bndiv.c
+++ b/fuzz/bndiv.c
@@ -28,7 +28,7 @@ static BIGNUM *b3;
 static BIGNUM *b4;
 static BIGNUM *b5;
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     b1 = BN_new();
     b2 = BN_new();

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -40,7 +40,7 @@ static int idx;
 time_t time(time_t *t) TIME_IMPL(t)
 #endif
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     STACK_OF(SSL_COMP) *comp_methods;
 

--- a/fuzz/cmp.c
+++ b/fuzz/cmp.c
@@ -20,7 +20,7 @@
 
 DEFINE_STACK_OF(OSSL_CMP_ITAV)
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();
@@ -31,7 +31,7 @@ int FuzzerInitialize(int *argc, char ***argv)
 
 static int num_responses;
 
-static OSSL_CMP_MSG *transfer_cb(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req)
+static OSSL_CMP_MSG *transfer_cb(OSSL_CMP_CTX *ctx, ossl_unused const OSSL_CMP_MSG *unused__req)
 {
     if (num_responses++ > 2)
         return NULL; /* prevent loops due to repeated pollRep */
@@ -39,14 +39,19 @@ static OSSL_CMP_MSG *transfer_cb(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req)
                             OSSL_CMP_CTX_get_transfer_cb_arg(ctx));
 }
 
-static int print_noop(const char *func, const char *file, int line,
-                      OSSL_CMP_severity level, const char *msg)
+static int print_noop(ossl_unused const char *unused__func,
+                      ossl_unused const char *unused__file,
+                      ossl_unused int unused__line,
+                      ossl_unused OSSL_CMP_severity unused__level,
+                      ossl_unused const char *unused__msg)
 {
     return 1;
 }
 
-static int allow_unprotected(const OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *rep,
-                             int invalid_protection, int expected_type)
+static int allow_unprotected(ossl_unused const OSSL_CMP_CTX *unused__ctx,
+                             ossl_unused const OSSL_CMP_MSG *unused__rep,
+                             ossl_unused int unused__invalid_protection,
+                             ossl_unused int unused__expected_type)
 {
     return 1;
 }
@@ -102,57 +107,61 @@ static void cmp_client_process_response(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
     ASN1_INTEGER_free(serial);
 }
 
-static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
-                                            const OSSL_CMP_MSG *cert_req,
-                                            int certReqId,
-                                            const OSSL_CRMF_MSG *crm,
-                                            const X509_REQ *p10cr,
-                                            X509 **certOut,
-                                            STACK_OF(X509) **chainOut,
-                                            STACK_OF(X509) **caPubs)
+static OSSL_CMP_PKISI *process_cert_request(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                                            ossl_unused const OSSL_CMP_MSG *unused__cert_req,
+                                            ossl_unused int unused__certReqId,
+                                            ossl_unused const OSSL_CRMF_MSG *unused__crm,
+                                            ossl_unused const X509_REQ *unused__p10cr,
+                                            ossl_unused X509 **unused__certOut,
+                                            ossl_unused STACK_OF(X509) **chainOut,
+                                            ossl_unused STACK_OF(X509) **caPubs)
 {
     CMPerr(0, CMP_R_ERROR_PROCESSING_MESSAGE);
     return NULL;
 }
 
-static OSSL_CMP_PKISI *process_rr(OSSL_CMP_SRV_CTX *srv_ctx,
-                                  const OSSL_CMP_MSG *rr,
-                                  const X509_NAME *issuer,
-                                  const ASN1_INTEGER *serial)
+static OSSL_CMP_PKISI *process_rr(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                                  ossl_unused const OSSL_CMP_MSG *unused__rr,
+                                  ossl_unused const X509_NAME *unused__issuer,
+                                  ossl_unused const ASN1_INTEGER *unused__serial)
 {
     CMPerr(0, CMP_R_ERROR_PROCESSING_MESSAGE);
     return NULL;
 }
 
-static int process_genm(OSSL_CMP_SRV_CTX *srv_ctx,
-                        const OSSL_CMP_MSG *genm,
-                        const STACK_OF(OSSL_CMP_ITAV) *in,
-                        STACK_OF(OSSL_CMP_ITAV) **out)
+static int process_genm(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                        ossl_unused const OSSL_CMP_MSG *unused__genm,
+                        ossl_unused const STACK_OF(OSSL_CMP_ITAV) *in,
+                        ossl_unused STACK_OF(OSSL_CMP_ITAV) **out)
 {
     CMPerr(0, CMP_R_ERROR_PROCESSING_MESSAGE);
     return 0;
 }
 
-static void process_error(OSSL_CMP_SRV_CTX *srv_ctx, const OSSL_CMP_MSG *error,
-                          const OSSL_CMP_PKISI *statusInfo,
-                          const ASN1_INTEGER *errorCode,
-                          const OSSL_CMP_PKIFREETEXT *errorDetails)
+static void process_error(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                          ossl_unused const OSSL_CMP_MSG *unused__error,
+                          ossl_unused const OSSL_CMP_PKISI *unused__statusInfo,
+                          ossl_unused const ASN1_INTEGER *unused__errorCode,
+                          ossl_unused const OSSL_CMP_PKIFREETEXT *unused__errorDetails)
 {
     CMPerr(0, CMP_R_ERROR_PROCESSING_MESSAGE);
 }
 
-static int process_certConf(OSSL_CMP_SRV_CTX *srv_ctx,
-                            const OSSL_CMP_MSG *certConf, int certReqId,
-                            const ASN1_OCTET_STRING *certHash,
-                            const OSSL_CMP_PKISI *si)
+static int process_certConf(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                            ossl_unused const OSSL_CMP_MSG *unused__certConf,
+                            ossl_unused int unused__certReqId,
+                            ossl_unused const ASN1_OCTET_STRING *unused__certHash,
+                            ossl_unused const OSSL_CMP_PKISI *unused__si)
 {
     CMPerr(0, CMP_R_ERROR_PROCESSING_MESSAGE);
     return 0;
 }
 
-static int process_pollReq(OSSL_CMP_SRV_CTX *srv_ctx,
-                           const OSSL_CMP_MSG *pollReq, int certReqId,
-                           OSSL_CMP_MSG **certReq, int64_t *check_after)
+static int process_pollReq(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                           ossl_unused const OSSL_CMP_MSG *unused__pollReq,
+                           ossl_unused int unused__certReqId,
+                           ossl_unused OSSL_CMP_MSG **unused__certReq,
+                           ossl_unused int64_t *unused__check_after)
 {
     CMPerr(0, CMP_R_ERROR_PROCESSING_MESSAGE);
     return 0;

--- a/fuzz/cms.c
+++ b/fuzz/cms.c
@@ -17,7 +17,7 @@
 #include <openssl/err.h>
 #include "fuzzer.h"
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();

--- a/fuzz/conf.c
+++ b/fuzz/conf.c
@@ -16,7 +16,7 @@
 #include <openssl/err.h>
 #include "fuzzer.h"
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();

--- a/fuzz/crl.c
+++ b/fuzz/crl.c
@@ -13,7 +13,7 @@
 #include <openssl/err.h>
 #include "fuzzer.h"
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();

--- a/fuzz/ct.c
+++ b/fuzz/ct.c
@@ -17,7 +17,7 @@
 #include <openssl/err.h>
 #include "fuzzer.h"
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     CRYPTO_free_ex_index(0, -1);

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -487,7 +487,7 @@ static int idx;
 time_t time(time_t *t) TIME_IMPL(t)
 #endif
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     STACK_OF(SSL_COMP) *comp_methods;
 

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -16,7 +16,7 @@
 
 #include "rand.inc"
 
-int FuzzerInitialize(int *argc, char ***argv)
+int FuzzerInitialize(ossl_unused int *unused__argc, ossl_unused char ***unused__argv)
 {
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -411,29 +411,34 @@ static ossl_inline int ktls_configure_crypto(const EVP_CIPHER *c, int tls_versio
 # endif /* HEADER_INTERNAL_KTLS */
 #else /* defined(OPENSSL_NO_KTLS) */
 /* Dummy functions here */
-static ossl_inline int ktls_enable(int fd)
+static ossl_inline int ktls_enable(ossl_unused int fd)
 {
     return 0;
 }
 
-static ossl_inline int ktls_start(int fd, void *crypto_info,
-                                  size_t len, int is_tx)
+static ossl_inline int ktls_start(ossl_unused int fd, ossl_unused void *crypto_info,
+                                  ossl_unused size_t len, ossl_unused int is_tx)
 {
     return 0;
 }
 
-static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
-                                              const void *data, size_t length)
+static ossl_inline int ktls_send_ctrl_message(ossl_unused int fd,
+					      ossl_unused unsigned char record_type,
+                                              ossl_unused const void *data,
+					      ossl_unused size_t length)
 {
     return -1;
 }
 
-static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
+static ossl_inline int ktls_read_record(ossl_unused int fd, ossl_unused void *data,
+					ossl_unused size_t length)
 {
     return -1;
 }
 
-static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off, size_t size, int flags)
+static ossl_inline ossl_ssize_t ktls_sendfile(ossl_unused int s, ossl_unused int fd,
+					      ossl_unused off_t off, ossl_unused size_t size,
+					      ossl_unused int flags)
 {
     return -1;
 }

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -30,7 +30,7 @@
 
 typedef _Atomic int CRYPTO_REF_COUNT;
 
-static inline int CRYPTO_UP_REF(_Atomic int *val, int *ret, void *lock)
+static inline int CRYPTO_UP_REF(_Atomic int *val, int *ret, ossl_unused void *lock)
 {
     *ret = atomic_fetch_add_explicit(val, 1, memory_order_relaxed) + 1;
     return 1;
@@ -46,7 +46,7 @@ static inline int CRYPTO_UP_REF(_Atomic int *val, int *ret, void *lock)
  * to mutable members doesn't have to be serialized anymore, which would
  * otherwise imply an acquire fence. Hence conditional acquire fence...
  */
-static inline int CRYPTO_DOWN_REF(_Atomic int *val, int *ret, void *lock)
+static inline int CRYPTO_DOWN_REF(_Atomic int *val, int *ret, ossl_unused void *lock)
 {
     *ret = atomic_fetch_sub_explicit(val, 1, memory_order_relaxed) - 1;
     if (*ret == 0)

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -41,12 +41,12 @@ static const OSSL_PARAM base_param_types[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *base_gettable_params(void *provctx)
+static const OSSL_PARAM *base_gettable_params(ossl_unused void *unused__provctx)
 {
     return base_param_types;
 }
 
-static int base_get_params(void *provctx, OSSL_PARAM params[])
+static int base_get_params(ossl_unused void *unused__provctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -76,7 +76,7 @@ static const OSSL_ALGORITHM base_encoder[] = {
 #undef ENCODER
 
 static const OSSL_ALGORITHM base_decoder[] = {
-#define DECODER(name, fips, input, func_table)                                \
+#define DECODER(name, fips, input, func_table)                              \
     { name,                                                                 \
       "provider=base,fips=" fips ",input=" input,                           \
       (func_table) }
@@ -86,8 +86,9 @@ static const OSSL_ALGORITHM base_decoder[] = {
 };
 #undef DECODER
 
-static const OSSL_ALGORITHM *base_query(void *provctx, int operation_id,
-                                         int *no_cache)
+static const OSSL_ALGORITHM *base_query(ossl_unused void *unused__provctx,
+                                        int operation_id,
+                                        int *no_cache)
 {
     *no_cache = 0;
     switch (operation_id) {

--- a/providers/common/bio_prov.c
+++ b/providers/common/bio_prov.c
@@ -149,7 +149,7 @@ static int bio_core_write_ex(BIO *bio, const char *data, size_t data_len,
     return ossl_prov_bio_write_ex(BIO_get_data(bio), data, data_len, written);
 }
 
-static long bio_core_ctrl(BIO *bio, int cmd, long num, void *ptr)
+static long bio_core_ctrl(ossl_unused BIO *unused__bio, ossl_unused int unused__cmd, ossl_unused long unused__num, ossl_unused void *unused__ptr)
 {
     /* We don't support this */
     assert(0);

--- a/providers/common/capabilities.c
+++ b/providers/common/capabilities.c
@@ -178,7 +178,8 @@ static int tls_group_capability(OSSL_CALLBACK *cb, void *arg)
     return 1;
 }
 
-int provider_get_capabilities(void *provctx, const char *capability,
+int provider_get_capabilities(ossl_unused void *unused__provctx,
+                              const char *capability,
                               OSSL_CALLBACK *cb, void *arg)
 {
     if (strcasecmp(capability, "TLS-GROUP") == 0)

--- a/providers/common/der/der_dsa_key.c
+++ b/providers/common/der/der_dsa_key.c
@@ -11,7 +11,7 @@
 #include "internal/packet.h"
 #include "prov/der_dsa.h"
 
-int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa)
+int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, ossl_unused DSA *unused__dsa)
 {
     return DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */

--- a/providers/common/der/der_dsa_sig.c
+++ b/providers/common/der/der_dsa_sig.c
@@ -18,7 +18,7 @@
         break;
 
 int DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,
-                                          DSA *dsa, int mdnid)
+                                          ossl_unused DSA *unused__dsa, int mdnid)
 {
     const unsigned char *precompiled = NULL;
     size_t precompiled_sz = 0;

--- a/providers/common/der/der_ec_key.c
+++ b/providers/common/der/der_ec_key.c
@@ -11,7 +11,7 @@
 #include "internal/packet.h"
 #include "prov/der_ec.h"
 
-int DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, EC_KEY *ec)
+int DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, ossl_unused EC_KEY *unused__ec)
 {
     return DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */

--- a/providers/common/der/der_ec_sig.c
+++ b/providers/common/der/der_ec_sig.c
@@ -25,7 +25,7 @@
         break;
 
 int DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,
-                                            EC_KEY *ec, int mdnid)
+                                            ossl_unused EC_KEY *unused__ec, int mdnid)
 {
     const unsigned char *precompiled = NULL;
     size_t precompiled_sz = 0;

--- a/providers/common/der/der_rsa_sig.c
+++ b/providers/common/der/der_rsa_sig.c
@@ -29,7 +29,7 @@
         break;
 
 int DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
-                                                  RSA *rsa, int mdnid)
+                                                  ossl_unused RSA *unused__rsa, int mdnid)
 {
     const unsigned char *precompiled = NULL;
     size_t precompiled_sz = 0;

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -44,12 +44,12 @@ static const OSSL_PARAM deflt_param_types[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *deflt_gettable_params(void *provctx)
+static const OSSL_PARAM *deflt_gettable_params(ossl_unused void *unused__provctx)
 {
     return deflt_param_types;
 }
 
-static int deflt_get_params(void *provctx, OSSL_PARAM params[])
+static int deflt_get_params(ossl_unused void *unused__provctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -407,7 +407,7 @@ static const OSSL_ALGORITHM deflt_encoder[] = {
 #undef ENCODER
 
 static const OSSL_ALGORITHM deflt_decoder[] = {
-#define DECODER(name, fips, input, func_table)                                \
+#define DECODER(name, fips, input, func_table)                              \
     { name,                                                                 \
       "provider=default,fips=" fips ",input=" input,                        \
       (func_table) }
@@ -417,7 +417,8 @@ static const OSSL_ALGORITHM deflt_decoder[] = {
 };
 #undef DECODER
 
-static const OSSL_ALGORITHM *deflt_query(void *provctx, int operation_id,
+static const OSSL_ALGORITHM *deflt_query(ossl_unused void *unused__provctx,
+                                         int operation_id,
                                          int *no_cache)
 {
     *no_cache = 0;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -76,7 +76,7 @@ typedef struct fips_global_st {
     const OSSL_CORE_HANDLE *handle;
 } FIPS_GLOBAL;
 
-static void *fips_prov_ossl_ctx_new(OPENSSL_CTX *libctx)
+static void *fips_prov_ossl_ctx_new(ossl_unused OPENSSL_CTX *unused__libctx)
 {
     FIPS_GLOBAL *fgbl = OPENSSL_zalloc(sizeof(*fgbl));
 
@@ -129,12 +129,12 @@ static OSSL_PARAM core_params[] =
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *fips_gettable_params(void *provctx)
+static const OSSL_PARAM *fips_gettable_params(ossl_unused void *unused__provctx)
 {
     return fips_param_types;
 }
 
-static int fips_get_params(void *provctx, OSSL_PARAM params[])
+static int fips_get_params(ossl_unused void *unused__provctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -164,7 +164,7 @@ static void set_self_test_cb(const OSSL_CORE_HANDLE *handle)
     }
 }
 
-static int fips_self_test(void *provctx)
+static int fips_self_test(ossl_unused void *unused__provctx)
 {
     set_self_test_cb(FIPS_get_core_handle(selftest_params.libctx));
     return SELF_TEST_post(&selftest_params, 1) ? 1 : 0;
@@ -467,7 +467,8 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
     { NULL, NULL, NULL }
 };
 
-static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
+static const OSSL_ALGORITHM *fips_query(ossl_unused void *unused__provctx,
+                                        int operation_id,
                                         int *no_cache)
 {
     *no_cache = 0;

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -108,7 +108,8 @@ static int rsa_init(void *vprsactx, void *vrsa)
 }
 
 static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
-                       size_t outsize, const unsigned char *in, size_t inlen)
+                       ossl_unused size_t unused__outsize,
+                       const unsigned char *in, size_t inlen)
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
     int ret;
@@ -382,7 +383,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -526,7 +527,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -61,7 +61,7 @@ static const OSSL_PARAM cipher_aes_known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_KEYLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *aes_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *aes_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return cipher_aes_known_settable_ctx_params;
 }
@@ -279,7 +279,7 @@ static const OSSL_PARAM cipher_aes_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_IV_STATE, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *aes_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *aes_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return cipher_aes_known_gettable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
@@ -45,7 +45,7 @@ int cipher_capable_aes_cbc_hmac_sha256(void)
 
 static int aesni_cbc_hmac_sha256_init_key(PROV_CIPHER_CTX *vctx,
                                           const unsigned char *key,
-                                          size_t keylen)
+                                          ossl_unused size_t unused__keylen)
 {
     int ret;
     PROV_AES_HMAC_SHA_CTX *ctx = (PROV_AES_HMAC_SHA_CTX *)vctx;

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -19,7 +19,7 @@
 #include "cipher_aes_ccm.h"
 #include "prov/implementations.h"
 
-static void *aes_ccm_newctx(void *provctx, size_t keybits)
+static void *aes_ccm_newctx(ossl_unused void *unused__provctx, size_t keybits)
 {
     PROV_AES_CCM_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_aesni.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_aesni.inc
@@ -32,7 +32,7 @@ static const PROV_CCM_HW aesni_ccm = {
     ccm_generic_gettag
 };
 
-const PROV_CCM_HW *PROV_AES_HW_ccm(size_t keybits)
+const PROV_CCM_HW *PROV_AES_HW_ccm(ossl_unused size_t keybits)
 {
     return AESNI_CAPABLE ? &aesni_ccm : &aes_ccm;
 }

--- a/providers/implementations/ciphers/cipher_aes_cts_fips.c
+++ b/providers/implementations/ciphers/cipher_aes_cts_fips.c
@@ -360,8 +360,10 @@ int aes_cbc_cts_block_update(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-int aes_cbc_cts_block_final(void *vctx, unsigned char *out, size_t *outl,
-                            size_t outsize)
+int aes_cbc_cts_block_final(ossl_unused void *unused__vctx,
+                            ossl_unused unsigned char *unused__out,
+                            size_t *outl,
+                            ossl_unused size_t unused__outsize)
 {
     *outl = 0;
     return 1;

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_aesni.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_aesni.inc
@@ -31,7 +31,7 @@ static const PROV_GCM_HW aesni_gcm = {
     gcm_one_shot
 };
 
-const PROV_GCM_HW *PROV_AES_HW_gcm(size_t keybits)
+const PROV_GCM_HW *PROV_AES_HW_gcm(ossl_unused size_t keybits)
 {
     return AESNI_CAPABLE ? &aesni_gcm : &aes_gcm;
 }

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -132,6 +132,7 @@ static const PROV_CIPHER_HW aes_##mode = {                                     \
 PROV_CIPHER_HW_declare(mode)                                                   \
 const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_##mode(size_t keybits)                \
 {                                                                              \
+    (void)keybits; /* silence -Wunused-parameter */                            \
     PROV_CIPHER_HW_select(mode)                                                \
     return &aes_##mode;                                                        \
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -199,7 +199,7 @@ static int aes_ocb_block_update_internal(PROV_AES_OCB_CTX *ctx,
 
 /* A wrapper function that has the same signature as cipher */
 static int cipher_updateaad(PROV_AES_OCB_CTX *ctx, const unsigned char *in,
-                            unsigned char *out, size_t len)
+                            ossl_unused unsigned char *unused__out, size_t len)
 {
     return aes_generic_ocb_setaad(ctx, in, len);
 }
@@ -250,7 +250,7 @@ static int aes_ocb_block_update(void *vctx, unsigned char *out, size_t *outl,
 }
 
 static int aes_ocb_block_final(void *vctx, unsigned char *out, size_t *outl,
-                               size_t outsize)
+                               ossl_unused size_t unused__outsize)
 {
     PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
 
@@ -290,7 +290,7 @@ static int aes_ocb_block_final(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-static void *aes_ocb_newctx(void *provctx, size_t kbits, size_t blkbits,
+static void *aes_ocb_newctx(ossl_unused void *unused__provctx, size_t kbits, size_t blkbits,
                             size_t ivbits, unsigned int mode, uint64_t flags)
 {
     PROV_AES_OCB_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
@@ -452,7 +452,7 @@ static const OSSL_PARAM cipher_ocb_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cipher_ocb_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *cipher_ocb_gettable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     return cipher_ocb_known_gettable_ctx_params;
 }
@@ -463,7 +463,7 @@ static const OSSL_PARAM cipher_ocb_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cipher_ocb_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *cipher_ocb_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     return cipher_ocb_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb_hw.c
@@ -113,7 +113,7 @@ static const PROV_CIPHER_HW aes_generic_ocb = {
     NULL
 };
 PROV_CIPHER_HW_declare()
-const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_ocb(size_t keybits)
+const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_ocb(ossl_unused size_t unused__keybits)
 {
     PROV_CIPHER_HW_select()
     return &aes_generic_ocb;

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -67,7 +67,9 @@ static void *siv_dupctx(void *vctx)
 }
 
 static int siv_init(void *vctx, const unsigned char *key, size_t keylen,
-                    const unsigned char *iv, size_t ivlen, int enc)
+                    ossl_unused const unsigned char *unused__iv,
+                    ossl_unused size_t unused__ivlen,
+                    int enc)
 {
     PROV_AES_SIV_CTX *ctx = (PROV_AES_SIV_CTX *)vctx;
 
@@ -119,7 +121,7 @@ static int siv_cipher(void *vctx, unsigned char *out, size_t *outl,
 }
 
 static int siv_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                            size_t outsize)
+                            ossl_unused size_t unused__outsize)
 {
     PROV_AES_SIV_CTX *ctx = (PROV_AES_SIV_CTX *)vctx;
 
@@ -166,7 +168,7 @@ static const OSSL_PARAM aes_siv_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *aes_siv_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *aes_siv_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return aes_siv_known_gettable_ctx_params;
 }
@@ -216,7 +218,7 @@ static const OSSL_PARAM aes_siv_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *aes_siv_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *aes_siv_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return aes_siv_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_siv_hw.c
@@ -130,7 +130,7 @@ static const PROV_CIPHER_HW_AES_SIV aes_siv_hw =
     aes_siv_dupctx,
 };
 
-const PROV_CIPHER_HW_AES_SIV *PROV_CIPHER_HW_aes_siv(size_t keybits)
+const PROV_CIPHER_HW_AES_SIV *PROV_CIPHER_HW_aes_siv(ossl_unused size_t unused__keybits)
 {
     return &aes_siv_hw;
 }

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -157,8 +157,10 @@ static int aes_wrap_cipher_internal(void *vctx, unsigned char *out,
     return rv ? (int)rv : -1;
 }
 
-static int aes_wrap_final(void *vctx, unsigned char *out, size_t *outl,
-                          size_t outsize)
+static int aes_wrap_final(ossl_unused void *unused__vctx,
+                          ossl_unused unsigned char *unused__out,
+                          size_t *outl,
+                          ossl_unused size_t unused__outsize)
 {
     *outl = 0;
     return 1;
@@ -217,7 +219,7 @@ static int aes_wrap_set_ctx_params(void *vctx, const OSSL_PARAM params[])
                                          flags, kbits, blkbits, ivbits);       \
     }                                                                          \
     static OSSL_FUNC_cipher_newctx_fn aes_##kbits##fname##_newctx;             \
-    static void *aes_##kbits##fname##_newctx(void *provctx)                    \
+    static void *aes_##kbits##fname##_newctx(ossl_unused void *unused__provctx)        \
     {                                                                          \
         return aes_##mode##_newctx(kbits, blkbits, ivbits,                     \
                                    EVP_CIPH_##UCMODE##_MODE, flags);           \

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -104,7 +104,7 @@ static int aes_xts_dinit(void *vctx, const unsigned char *key, size_t keylen,
     return aes_xts_init(vctx, key, keylen, iv, ivlen, 0);
 }
 
-static void *aes_xts_newctx(void *provctx, unsigned int mode, uint64_t flags,
+static void *aes_xts_newctx(ossl_unused void *unused__provctx, unsigned int mode, uint64_t flags,
                             size_t kbits, size_t blkbits, size_t ivbits)
 {
     PROV_AES_XTS_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
@@ -147,7 +147,7 @@ static void *aes_xts_dupctx(void *vctx)
 }
 
 static int aes_xts_cipher(void *vctx, unsigned char *out, size_t *outl,
-                          size_t outsize, const unsigned char *in, size_t inl)
+                          ossl_unused size_t unused__outsize, const unsigned char *in, size_t inl)
 {
     PROV_AES_XTS_CTX *ctx = (PROV_AES_XTS_CTX *)vctx;
 
@@ -199,8 +199,9 @@ static int aes_xts_stream_update(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-static int aes_xts_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                                size_t outsize)
+static int aes_xts_stream_final(ossl_unused void *unused__vctx, ossl_unused unsigned char *unused__out,
+                                size_t *outl,
+                                ossl_unused size_t unused__outsize)
 {
     *outl = 0;
     return 1;
@@ -211,7 +212,7 @@ static const OSSL_PARAM aes_xts_known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *aes_xts_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *aes_xts_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return aes_xts_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -166,7 +166,7 @@ static const PROV_CIPHER_HW aes_generic_xts = {
     cipher_hw_aes_xts_copyctx
 };
 PROV_CIPHER_HW_declare_xts()
-const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_xts(size_t keybits)
+const PROV_CIPHER_HW *PROV_CIPHER_HW_aes_xts(ossl_unused size_t unused__keybits)
 {
     PROV_CIPHER_HW_select_xts()
     return &aes_generic_xts;

--- a/providers/implementations/ciphers/cipher_aria_ccm.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm.c
@@ -14,7 +14,7 @@
 
 static OSSL_FUNC_cipher_freectx_fn aria_ccm_freectx;
 
-static void *aria_ccm_newctx(void *provctx, size_t keybits)
+static void *aria_ccm_newctx(ossl_unused void *unused__provctx, size_t keybits)
 {
     PROV_ARIA_CCM_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 

--- a/providers/implementations/ciphers/cipher_aria_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm_hw.c
@@ -34,7 +34,7 @@ static const PROV_CCM_HW ccm_aria = {
     ccm_generic_auth_decrypt,
     ccm_generic_gettag
 };
-const PROV_CCM_HW *PROV_ARIA_HW_ccm(size_t keybits)
+const PROV_CCM_HW *PROV_ARIA_HW_ccm(ossl_unused size_t unused__keybits)
 {
     return &ccm_aria;
 }

--- a/providers/implementations/ciphers/cipher_aria_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm_hw.c
@@ -31,7 +31,7 @@ static const PROV_GCM_HW aria_gcm = {
     gcm_cipher_final,
     gcm_one_shot
 };
-const PROV_GCM_HW *PROV_ARIA_HW_gcm(size_t keybits)
+const PROV_GCM_HW *PROV_ARIA_HW_gcm(ossl_unused size_t unused__keybits)
 {
     return &aria_gcm;
 }

--- a/providers/implementations/ciphers/cipher_aria_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_hw.c
@@ -37,7 +37,7 @@ static const PROV_CIPHER_HW aria_##mode = {                                    \
     cipher_hw_chunked_##mode,                                                  \
     cipher_hw_aria_copyctx                                                     \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_aria_##mode(size_t keybits)               \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_aria_##mode(ossl_unused size_t unused__keybits)   \
 {                                                                              \
     return &aria_##mode;                                                       \
 }

--- a/providers/implementations/ciphers/cipher_blowfish_hw.c
+++ b/providers/implementations/ciphers/cipher_blowfish_hw.c
@@ -24,16 +24,16 @@ static int cipher_hw_blowfish_initkey(PROV_CIPHER_CTX *ctx,
     return 1;
 }
 
-# define PROV_CIPHER_HW_blowfish_mode(mode, UCMODE)                            \
-IMPLEMENT_CIPHER_HW_##UCMODE(mode, blowfish, PROV_BLOWFISH_CTX, BF_KEY,        \
-                             BF_##mode)                                        \
-static const PROV_CIPHER_HW bf_##mode = {                                      \
-    cipher_hw_blowfish_initkey,                                                \
-    cipher_hw_blowfish_##mode##_cipher                                         \
-};                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_blowfish_##mode(size_t keybits)           \
-{                                                                              \
-    return &bf_##mode;                                                         \
+# define PROV_CIPHER_HW_blowfish_mode(mode, UCMODE)                              \
+IMPLEMENT_CIPHER_HW_##UCMODE(mode, blowfish, PROV_BLOWFISH_CTX, BF_KEY,          \
+                             BF_##mode)                                          \
+static const PROV_CIPHER_HW bf_##mode = {                                        \
+    cipher_hw_blowfish_initkey,                                                  \
+    cipher_hw_blowfish_##mode##_cipher                                           \
+};                                                                               \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_blowfish_##mode(ossl_unused size_t unused__keybits) \
+{                                                                                \
+    return &bf_##mode;                                                           \
 }
 
 PROV_CIPHER_HW_blowfish_mode(cbc, CBC)

--- a/providers/implementations/ciphers/cipher_camellia_hw.c
+++ b/providers/implementations/ciphers/cipher_camellia_hw.c
@@ -58,7 +58,7 @@ static const PROV_CIPHER_HW camellia_##mode = {                                \
     cipher_hw_camellia_copyctx                                                 \
 };                                                                             \
 PROV_CIPHER_HW_declare(mode)                                                   \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_camellia_##mode(size_t keybits)           \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_camellia_##mode(ossl_unused size_t unused__keybits) \
 {                                                                              \
     PROV_CIPHER_HW_select(mode)                                                \
     return &camellia_##mode;                                                   \

--- a/providers/implementations/ciphers/cipher_cast5_hw.c
+++ b/providers/implementations/ciphers/cipher_cast5_hw.c
@@ -31,7 +31,7 @@ static const PROV_CIPHER_HW cast5_##mode = {                                   \
     cipher_hw_cast5_initkey,                                                   \
     cipher_hw_cast5_##mode##_cipher                                            \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_cast5_##mode(size_t keybits)              \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_cast5_##mode(ossl_unused size_t unused__keybits)  \
 {                                                                              \
     return &cast5_##mode;                                                      \
 }

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -41,7 +41,7 @@ void chacha20_initctx(PROV_CHACHA20_CTX *ctx)
                            NULL);
 }
 
-static void *chacha20_newctx(void *provctx)
+static void *chacha20_newctx(ossl_unused void *unused__provctx)
 {
      PROV_CHACHA20_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 
@@ -68,7 +68,7 @@ static int chacha20_get_params(OSSL_PARAM params[])
                                      CHACHA20_IVLEN * 8);
 }
 
-static int chacha20_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int chacha20_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -91,12 +91,12 @@ static const OSSL_PARAM chacha20_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *chacha20_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *chacha20_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return chacha20_known_gettable_ctx_params;
 }
 
-static int chacha20_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+static int chacha20_set_ctx_params(ossl_unused void *unused__vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
     size_t len;
@@ -131,7 +131,7 @@ static const OSSL_PARAM chacha20_known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *chacha20_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *chacha20_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return chacha20_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_hw.c
@@ -12,7 +12,7 @@
 #include "cipher_chacha20.h"
 
 static int chacha20_initkey(PROV_CIPHER_CTX *bctx, const uint8_t *key,
-                            size_t keylen)
+                            ossl_unused size_t unused__keylen)
 {
     PROV_CHACHA20_CTX *ctx = (PROV_CHACHA20_CTX *)bctx;
     unsigned int i;
@@ -114,7 +114,7 @@ static const PROV_CIPHER_HW_CHACHA20 chacha20_hw = {
     chacha20_initiv
 };
 
-const PROV_CIPHER_HW *PROV_CIPHER_HW_chacha20(size_t keybits)
+const PROV_CIPHER_HW *PROV_CIPHER_HW_chacha20(ossl_unused size_t unused__keybits)
 {
     return (PROV_CIPHER_HW *)&chacha20_hw;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -41,7 +41,7 @@ static OSSL_FUNC_cipher_gettable_ctx_params_fn chacha20_poly1305_gettable_ctx_pa
 #define chacha20_poly1305_gettable_params cipher_generic_gettable_params
 #define chacha20_poly1305_update chacha20_poly1305_cipher
 
-static void *chacha20_poly1305_newctx(void *provctx)
+static void *chacha20_poly1305_newctx(ossl_unused void *unused__provctx)
 {
     PROV_CHACHA20_POLY1305_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 
@@ -136,7 +136,7 @@ static const OSSL_PARAM chacha20_poly1305_known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 static const OSSL_PARAM *chacha20_poly1305_gettable_ctx_params
-    (ossl_unused void *provctx)
+    (ossl_unused void *unused__provctx)
 {
     return chacha20_poly1305_known_gettable_ctx_params;
 }
@@ -282,7 +282,7 @@ static int chacha20_poly1305_cipher(void *vctx, unsigned char *out,
 }
 
 static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
-                                   size_t outsize)
+                                   ossl_unused size_t unused__outsize)
 {
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
     PROV_CIPHER_HW_CHACHA20_POLY1305 *hw =

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -399,7 +399,7 @@ static const PROV_CIPHER_HW_CHACHA20_POLY1305 chacha20poly1305_hw =
     chacha_poly1305_tls_iv_set_fixed
 };
 
-const PROV_CIPHER_HW *PROV_CIPHER_HW_chacha20_poly1305(size_t keybits)
+const PROV_CIPHER_HW *PROV_CIPHER_HW_chacha20_poly1305(ossl_unused size_t unused__keybits)
 {
     return (PROV_CIPHER_HW *)&chacha20poly1305_hw;
 }

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -17,7 +17,8 @@
 #include "cipher_des.h"
 
 static int cipher_hw_des_initkey(PROV_CIPHER_CTX *ctx,
-                                 const unsigned char *key, size_t keylen)
+                                 const unsigned char *key,
+                                 ossl_unused size_t unused__keylen)
 {
     PROV_DES_CTX *dctx = (PROV_DES_CTX *)ctx;
     DES_cblock *deskey = (DES_cblock *)key;

--- a/providers/implementations/ciphers/cipher_desx_hw.c
+++ b/providers/implementations/ciphers/cipher_desx_hw.c
@@ -25,7 +25,8 @@
 #define ks3 tks.ks[2].ks[0].cblock
 
 static int cipher_hw_desx_cbc_initkey(PROV_CIPHER_CTX *ctx,
-                                      const unsigned char *key, size_t keylen)
+                                      const unsigned char *key,
+                                      ossl_unused size_t unused__keylen)
 {
     PROV_TDES_CTX *tctx = (PROV_TDES_CTX *)ctx;
     DES_cblock *deskey = (DES_cblock *)key;

--- a/providers/implementations/ciphers/cipher_idea_hw.c
+++ b/providers/implementations/ciphers/cipher_idea_hw.c
@@ -17,7 +17,8 @@
 #include "cipher_idea.h"
 
 static int cipher_hw_idea_initkey(PROV_CIPHER_CTX *ctx,
-                                  const unsigned char *key, size_t keylen)
+                                  const unsigned char *key,
+                                  ossl_unused size_t unused__keylen)
 {
     PROV_IDEA_CTX *ictx =  (PROV_IDEA_CTX *)ctx;
     IDEA_KEY_SCHEDULE *ks = &(ictx->ks.ks);
@@ -43,7 +44,7 @@ static const PROV_CIPHER_HW idea_##mode = {                                    \
     cipher_hw_idea_initkey,                                                    \
     cipher_hw_idea_##mode##_cipher                                             \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_idea_##mode(size_t keybits)               \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_idea_##mode(ossl_unused size_t unused__keybits)   \
 {                                                                              \
     return &idea_##mode;                                                       \
 }

--- a/providers/implementations/ciphers/cipher_null.c
+++ b/providers/implementations/ciphers/cipher_null.c
@@ -21,7 +21,7 @@ typedef struct prov_cipher_null_ctx_st {
 } PROV_CIPHER_NULL_CTX;
 
 static OSSL_FUNC_cipher_newctx_fn null_newctx;
-static void *null_newctx(void *provctx)
+static void *null_newctx(ossl_unused void *unused__provctx)
 {
     return OPENSSL_zalloc(sizeof(PROV_CIPHER_NULL_CTX));
 }
@@ -33,8 +33,11 @@ static void null_freectx(void *vctx)
 }
 
 static OSSL_FUNC_cipher_encrypt_init_fn null_einit;
-static int null_einit(void *vctx, const unsigned char *key, size_t keylen,
-                      const unsigned char *iv, size_t ivlen)
+static int null_einit(void *vctx,
+                      ossl_unused const unsigned char *unused__key,
+                      ossl_unused size_t unused__keylen,
+                      ossl_unused const unsigned char *unused__iv,
+                      ossl_unused size_t unused__ivlen)
 {
     PROV_CIPHER_NULL_CTX *ctx = (PROV_CIPHER_NULL_CTX *)vctx;
 
@@ -43,8 +46,11 @@ static int null_einit(void *vctx, const unsigned char *key, size_t keylen,
 }
 
 static OSSL_FUNC_cipher_decrypt_init_fn null_dinit;
-static int null_dinit(void *vctx, const unsigned char *key, size_t keylen,
-                      const unsigned char *iv, size_t ivlen)
+static int null_dinit(ossl_unused void *unused__vctx,
+                      ossl_unused const unsigned char *unused__key,
+                      ossl_unused size_t unused__keylen,
+                      ossl_unused const unsigned char *unused__iv,
+                      ossl_unused size_t unused__ivlen)
 {
     return 1;
 }
@@ -74,8 +80,10 @@ static int null_cipher(void *vctx, unsigned char *out, size_t *outl,
 }
 
 static OSSL_FUNC_cipher_final_fn null_final;
-static int null_final(void *vctx, unsigned char *out, size_t *outl,
-                      size_t outsize)
+static int null_final(ossl_unused void *unused__vctx,
+                      ossl_unused unsigned char *unused__out,
+                      size_t *outl,
+                      ossl_unused size_t unused__outsize)
 {
     *outl = 0;
     return 1;
@@ -95,7 +103,7 @@ static const OSSL_PARAM null_known_gettable_ctx_params[] = {
 };
 
 static OSSL_FUNC_cipher_gettable_ctx_params_fn null_gettable_ctx_params;
-static const OSSL_PARAM *null_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *null_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return null_known_gettable_ctx_params;
 }
@@ -131,7 +139,7 @@ static const OSSL_PARAM null_known_settable_ctx_params[] = {
 };
 
 static OSSL_FUNC_cipher_settable_ctx_params_fn null_settable_ctx_params;
-static const OSSL_PARAM *null_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *null_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return null_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -196,7 +196,7 @@ static int alg##_##kbits##_##lcmode##_get_params(OSSL_PARAM params[])          \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
 static OSSL_FUNC_cipher_newctx_fn alg##_##kbits##_##lcmode##_newctx;           \
-static void * alg##_##kbits##_##lcmode##_newctx(void *provctx)                 \
+static void * alg##_##kbits##_##lcmode##_newctx(ossl_unused void *unused__provctx)     \
 {                                                                              \
      PROV_##UCALG##_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));                   \
      if (ctx != NULL) {                                                        \

--- a/providers/implementations/ciphers/cipher_rc2_hw.c
+++ b/providers/implementations/ciphers/cipher_rc2_hw.c
@@ -16,7 +16,8 @@
 #include "cipher_rc2.h"
 
 static int cipher_hw_rc2_initkey(PROV_CIPHER_CTX *ctx,
-                                 const unsigned char *key, size_t keylen)
+                                 const unsigned char *key,
+                                 ossl_unused size_t unused__keylen)
 {
     PROV_RC2_CTX *rctx =  (PROV_RC2_CTX *)ctx;
     RC2_KEY *ks = &(rctx->ks.ks);
@@ -32,7 +33,7 @@ static const PROV_CIPHER_HW rc2_##mode = {                                     \
     cipher_hw_rc2_initkey,                                                     \
     cipher_hw_rc2_##mode##_cipher                                              \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_rc2_##mode(size_t keybits)                \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_rc2_##mode(ossl_unused size_t unused__keybits)    \
 {                                                                              \
     return &rc2_##mode;                                                        \
 }

--- a/providers/implementations/ciphers/cipher_rc4.c
+++ b/providers/implementations/ciphers/cipher_rc4.c
@@ -54,7 +54,7 @@ static int alg##_##kbits##_get_params(OSSL_PARAM params[])                     \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
 static OSSL_FUNC_cipher_newctx_fn alg##_##kbits##_newctx;                      \
-static void * alg##_##kbits##_newctx(void *provctx)                            \
+static void * alg##_##kbits##_newctx(ossl_unused void *unused__provctx)                \
 {                                                                              \
      PROV_##UCALG##_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));                   \
      if (ctx != NULL) {                                                        \

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -44,7 +44,7 @@ static OSSL_FUNC_cipher_get_params_fn rc4_hmac_md5_get_params;
 #define rc4_hmac_md5_final cipher_generic_stream_final
 #define rc4_hmac_md5_cipher cipher_generic_cipher
 
-static void *rc4_hmac_md5_newctx(void *provctx)
+static void *rc4_hmac_md5_newctx(ossl_unused void *unused__provctx)
 {
     PROV_RC4_HMAC_MD5_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
 
@@ -72,7 +72,7 @@ static const OSSL_PARAM rc4_hmac_md5_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *rc4_hmac_md5_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *rc4_hmac_md5_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return rc4_hmac_md5_known_gettable_ctx_params;
 }
@@ -107,7 +107,7 @@ static const OSSL_PARAM rc4_hmac_md5_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *rc4_hmac_md5_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *rc4_hmac_md5_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return rc4_hmac_md5_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5_hw.c
@@ -225,7 +225,7 @@ static const PROV_CIPHER_HW_RC4_HMAC_MD5 rc4_hmac_md5_hw = {
     cipher_hw_rc4_hmac_md5_tls_init,
     cipher_hw_rc4_hmac_md5_init_mackey
 };
-const PROV_CIPHER_HW *PROV_CIPHER_HW_rc4_hmac_md5(size_t keybits)
+const PROV_CIPHER_HW *PROV_CIPHER_HW_rc4_hmac_md5(ossl_unused size_t unused__keybits)
 {
     return (PROV_CIPHER_HW *)&rc4_hmac_md5_hw;
 }

--- a/providers/implementations/ciphers/cipher_rc4_hw.c
+++ b/providers/implementations/ciphers/cipher_rc4_hw.c
@@ -37,7 +37,7 @@ static const PROV_CIPHER_HW rc4_hw = {
     cipher_hw_rc4_initkey,
     cipher_hw_rc4_cipher
 };
-const PROV_CIPHER_HW *PROV_CIPHER_HW_rc4(size_t keybits)
+const PROV_CIPHER_HW *PROV_CIPHER_HW_rc4(ossl_unused size_t unused__keybits)
 {
     return &rc4_hw;
 }

--- a/providers/implementations/ciphers/cipher_seed_hw.c
+++ b/providers/implementations/ciphers/cipher_seed_hw.c
@@ -16,7 +16,8 @@
 #include "cipher_seed.h"
 
 static int cipher_hw_seed_initkey(PROV_CIPHER_CTX *ctx,
-                                  const unsigned char *key, size_t keylen)
+                                  const unsigned char *key,
+                                  ossl_unused size_t unused__keylen)
 {
     PROV_SEED_CTX *sctx =  (PROV_SEED_CTX *)ctx;
 
@@ -31,7 +32,7 @@ static const PROV_CIPHER_HW seed_##mode = {                                    \
     cipher_hw_seed_initkey,                                                    \
     cipher_hw_seed_##mode##_cipher                                             \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_seed_##mode(size_t keybits)               \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_seed_##mode(ossl_unused size_t unused__keybits)   \
 {                                                                              \
     return &seed_##mode;                                                       \
 }

--- a/providers/implementations/ciphers/cipher_sm4_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_hw.c
@@ -10,7 +10,8 @@
 #include "cipher_sm4.h"
 
 static int cipher_hw_sm4_initkey(PROV_CIPHER_CTX *ctx,
-                                 const unsigned char *key, size_t keylen)
+                                 const unsigned char *key,
+                                 ossl_unused size_t unused__keylen)
 {
     PROV_SM4_CTX *sctx =  (PROV_SM4_CTX *)ctx;
     SM4_KEY *ks = &sctx->ks.ks;
@@ -34,7 +35,7 @@ static const PROV_CIPHER_HW sm4_##mode = {                                     \
     cipher_hw_chunked_##mode,                                                  \
     cipher_hw_sm4_copyctx                                                      \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_sm4_##mode(size_t keybits)                \
+const PROV_CIPHER_HW *PROV_CIPHER_HW_sm4_##mode(ossl_unused size_t unused__keybits)    \
 {                                                                              \
     return &sm4_##mode;                                                        \
 }

--- a/providers/implementations/ciphers/cipher_tdes_default_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_default_hw.c
@@ -20,7 +20,8 @@
 #define ks3 tks.ks[2]
 
 static int cipher_hw_tdes_ede2_initkey(PROV_CIPHER_CTX *ctx,
-                                       const unsigned char *key, size_t keylen)
+                                       const unsigned char *key,
+                                       ossl_unused size_t unused__keylen)
 {
     PROV_TDES_CTX *tctx = (PROV_TDES_CTX *)ctx;
     DES_cblock *deskey = (DES_cblock *)key;
@@ -143,4 +144,3 @@ PROV_CIPHER_HW_tdes_mode(ede2, ecb)
 PROV_CIPHER_HW_tdes_mode(ede2, cbc)
 PROV_CIPHER_HW_tdes_mode(ede2, ofb)
 PROV_CIPHER_HW_tdes_mode(ede2, cfb)
-

--- a/providers/implementations/ciphers/cipher_tdes_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_hw.c
@@ -21,7 +21,7 @@
 #define ks3 tks.ks[2]
 
 int cipher_hw_tdes_ede3_initkey(PROV_CIPHER_CTX *ctx, const unsigned char *key,
-                                size_t keylen)
+                                ossl_unused size_t unused__keylen)
 {
     PROV_TDES_CTX *tctx = (PROV_TDES_CTX *)ctx;
     DES_cblock *deskey = (DES_cblock *)key;

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -29,7 +29,7 @@ static const OSSL_PARAM cipher_known_gettable_params[] = {
     { OSSL_CIPHER_PARAM_TLS_MAC, OSSL_PARAM_OCTET_PTR, NULL, 0, OSSL_PARAM_UNMODIFIED },
     OSSL_PARAM_END
 };
-const OSSL_PARAM *cipher_generic_gettable_params(void *provctx)
+const OSSL_PARAM *cipher_generic_gettable_params(ossl_unused void *unused__provctx)
 {
     return cipher_known_gettable_params;
 }
@@ -118,7 +118,7 @@ static const OSSL_PARAM cipher_aead_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_GET_IV_GEN, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *cipher_aead_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *cipher_aead_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return cipher_aead_known_gettable_ctx_params;
 }
@@ -131,7 +131,7 @@ static const OSSL_PARAM cipher_aead_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_SET_IV_INV, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *cipher_aead_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *cipher_aead_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return cipher_aead_known_settable_ctx_params;
 }
@@ -430,8 +430,10 @@ int cipher_generic_stream_update(void *vctx, unsigned char *out, size_t *outl,
 
     return 1;
 }
-int cipher_generic_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                                size_t outsize)
+int cipher_generic_stream_final(ossl_unused void *unused__vctx,
+                                ossl_unused unsigned char *unused__out,
+                                size_t *outl,
+                                ossl_unused size_t unused__outsize)
 {
     *outl = 0;
     return 1;

--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -271,7 +271,7 @@ int ccm_stream_update(void *vctx, unsigned char *out, size_t *outl,
 }
 
 int ccm_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                            size_t outsize)
+                     ossl_unused size_t unused__outsize)
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
     int i;
@@ -432,4 +432,3 @@ void ccm_initctx(PROV_CCM_CTX *ctx, size_t keybits, const PROV_CCM_HW *hw)
     ctx->tls_aad_len = UNINITIALISED_SIZET;
     ctx->hw = hw;
 }
-

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -306,7 +306,7 @@ int gcm_stream_update(void *vctx, unsigned char *out, size_t *outl,
 }
 
 int gcm_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                     size_t outsize)
+                     ossl_unused size_t unused__outsize)
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     int i;

--- a/providers/implementations/ciphers/ciphercommon_gcm_hw.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm_hw.c
@@ -49,7 +49,8 @@ int gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
 
 int gcm_one_shot(PROV_GCM_CTX *ctx, unsigned char *aad, size_t aad_len,
                  const unsigned char *in, size_t in_len,
-                 unsigned char *out, unsigned char *tag, size_t tag_len)
+                 unsigned char *out, unsigned char *tag,
+                 ossl_unused size_t unused__tag_len)
 {
     int ret = 0;
 

--- a/providers/implementations/digests/digestcommon.c
+++ b/providers/implementations/digests/digestcommon.c
@@ -40,7 +40,7 @@ static const OSSL_PARAM digest_default_known_gettable_params[] = {
     OSSL_PARAM_ulong(OSSL_DIGEST_PARAM_FLAGS, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *digest_default_gettable_params(void *provctx)
+const OSSL_PARAM *digest_default_gettable_params(ossl_unused void *unused__provctx)
 {
     return digest_default_known_gettable_params;
 }

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -30,7 +30,7 @@ static const OSSL_PARAM known_md5_sha1_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *md5_sha1_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *md5_sha1_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_md5_sha1_settable_ctx_params;
 }

--- a/providers/implementations/digests/mdc2_prov.c
+++ b/providers/implementations/digests/mdc2_prov.c
@@ -30,7 +30,7 @@ static const OSSL_PARAM known_mdc2_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *mdc2_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *mdc2_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_mdc2_settable_ctx_params;
 }

--- a/providers/implementations/digests/sha2_prov.c
+++ b/providers/implementations/digests/sha2_prov.c
@@ -31,7 +31,7 @@ static const OSSL_PARAM known_sha1_settable_ctx_params[] = {
     {OSSL_DIGEST_PARAM_SSL3_MS, OSSL_PARAM_OCTET_STRING, NULL, 0, 0},
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *sha1_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sha1_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_sha1_settable_ctx_params;
 }

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -183,7 +183,7 @@ static PROV_SHA3_METHOD shake_s390x_md =
 
 #define SHA3_newctx(typ, uname, name, bitlen, pad)                             \
 static OSSL_FUNC_digest_newctx_fn name##_newctx;                               \
-static void *name##_newctx(void *provctx)                                      \
+static void *name##_newctx(ossl_unused void *unused__provctx)                          \
 {                                                                              \
     KECCAK1600_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));                        \
                                                                                \
@@ -196,7 +196,7 @@ static void *name##_newctx(void *provctx)                                      \
 
 #define KMAC_newctx(uname, bitlen, pad)                                        \
 static OSSL_FUNC_digest_newctx_fn uname##_newctx;                              \
-static void *uname##_newctx(void *provctx)                                     \
+static void *uname##_newctx(ossl_unused void *unused__provctx)                         \
 {                                                                              \
     KECCAK1600_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));                        \
                                                                                \
@@ -250,7 +250,7 @@ static const OSSL_PARAM known_shake_settable_ctx_params[] = {
     {OSSL_DIGEST_PARAM_XOFLEN, OSSL_PARAM_UNSIGNED_INTEGER, NULL, 0, 0},
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *shake_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *shake_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_shake_settable_ctx_params;
 }

--- a/providers/implementations/encode_decode/decode_common.c
+++ b/providers/implementations/encode_decode/decode_common.c
@@ -64,7 +64,8 @@ struct pwdata_st {
 };
 
 pem_password_cb pw_pem_password_to_ossl_passhrase;
-int pw_pem_password_to_ossl_passhrase(char *buf, int size, int rwflag,
+int pw_pem_password_to_ossl_passhrase(char *buf, int size,
+                                      ossl_unused int unused__rwflag,
                                       void *userdata)
 {
     struct pwdata_st *data = userdata;

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -72,7 +72,7 @@ static void der2key_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *der2key_gettable_params(void *provctx)
+static const OSSL_PARAM *der2key_gettable_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM gettables[] = {
         { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },

--- a/providers/implementations/encode_decode/decode_ms2key.c
+++ b/providers/implementations/encode_decode/decode_ms2key.c
@@ -151,7 +151,8 @@ static int ms2key_post(struct ms2key_ctx_st *ctx, EVP_PKEY *pkey,
 
 static int msblob2key_decode(void *vctx, OSSL_CORE_BIO *cin,
                              OSSL_CALLBACK *data_cb, void *data_cbarg,
-                             OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+                             ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__pw_cb,
+                             ossl_unused void *unused__pw_cbarg)
 {
     struct ms2key_ctx_st *ctx = vctx;
     int ispub = -1;

--- a/providers/implementations/encode_decode/decode_pem2der.c
+++ b/providers/implementations/encode_decode/decode_pem2der.c
@@ -55,7 +55,7 @@ static void pem2der_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *pem2der_gettable_params(void *provctx)
+static const OSSL_PARAM *pem2der_gettable_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM gettables[] = {
         { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
@@ -82,7 +82,7 @@ struct pem2der_pass_data_st {
     void *cbarg;
 };
 
-static int pem2der_pass_helper(char *buf, int num, int w, void *data)
+static int pem2der_pass_helper(char *buf, int num, ossl_unused int unused__w, void *data)
 {
     struct pem2der_pass_data_st *pass_data = data;
     size_t plen;

--- a/providers/implementations/encode_decode/encoder_dh_param.c
+++ b/providers/implementations/encode_decode/encoder_dh_param.c
@@ -44,7 +44,7 @@ static void *dh_param_newctx(void *provctx)
     return provctx;
 }
 
-static void dh_param_freectx(void *ctx)
+static void dh_param_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -72,7 +72,8 @@ static int dh_param_der_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dh_param_der(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                        ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                        ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -109,7 +110,8 @@ static int dh_param_pem_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dh_param_pem(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                        ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                        ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -146,7 +148,8 @@ static int dh_param_print_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dh_param_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                          ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                          ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_dh_priv.c
+++ b/providers/implementations/encode_decode/encoder_dh_priv.c
@@ -217,7 +217,7 @@ static void *dh_print_newctx(void *provctx)
     return provctx;
 }
 
-static void dh_print_freectx(void *ctx)
+static void dh_print_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -244,7 +244,8 @@ static int dh_priv_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int dh_priv_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_dh_pub.c
+++ b/providers/implementations/encode_decode/encoder_dh_pub.c
@@ -44,7 +44,7 @@ static void *dh_pub_newctx(void *provctx)
     return provctx;
 }
 
-static void dh_pub_freectx(void *ctx)
+static void dh_pub_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -72,7 +72,8 @@ static int dh_pub_der_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dh_pub_der(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                      OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                      ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                      ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -113,7 +114,8 @@ static int dh_pub_pem_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dh_pub_pem(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                      OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                      ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                      ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -153,7 +155,8 @@ static int dh_pub_print_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dh_pub_print(void *ctx, void *dh, OSSL_CORE_BIO *cout,
-                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                        ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                        ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_dsa.c
+++ b/providers/implementations/encode_decode/encoder_dsa.c
@@ -92,7 +92,8 @@ int ossl_prov_print_dsa(BIO *out, DSA *dsa, enum dsa_print_type type)
     goto err;
 }
 
-int ossl_prov_prepare_dsa_params(const void *dsa, int nid,
+int ossl_prov_prepare_dsa_params(const void *dsa,
+                                 ossl_unused int unused__nid,
                                  void **pstr, int *pstrtype)
 {
     ASN1_STRING *params = ASN1_STRING_new();

--- a/providers/implementations/encode_decode/encoder_dsa_param.c
+++ b/providers/implementations/encode_decode/encoder_dsa_param.c
@@ -44,7 +44,7 @@ static void *dsa_param_newctx(void *provctx)
     return provctx;
 }
 
-static void dsa_param_freectx(void *ctx)
+static void dsa_param_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -72,7 +72,8 @@ static int dsa_param_der_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dsa_param_der(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -110,7 +111,8 @@ static int dsa_param_pem_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dsa_param_pem(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -147,7 +149,8 @@ static int dsa_param_print_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dsa_param_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                           OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                           ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                           ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_dsa_priv.c
+++ b/providers/implementations/encode_decode/encoder_dsa_priv.c
@@ -215,7 +215,7 @@ static void *dsa_print_newctx(void *provctx)
     return provctx;
 }
 
-static void dsa_print_freectx(void *ctx)
+static void dsa_print_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -242,7 +242,8 @@ static int dsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int dsa_priv_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                          ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                          ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_dsa_pub.c
+++ b/providers/implementations/encode_decode/encoder_dsa_pub.c
@@ -44,7 +44,7 @@ static void *dsa_pub_newctx(void *provctx)
     return provctx;
 }
 
-static void dsa_pub_freectx(void *ctx)
+static void dsa_pub_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -72,7 +72,8 @@ static int dsa_pub_der_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dsa_pub_der(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                       ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                       ossl_unused void *unused__cbarg)
 {
     /*
      * TODO(v3.0) implement setting save_parameters, see dsa_pub_encode()
@@ -123,7 +124,8 @@ static int dsa_pub_pem_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dsa_pub_pem(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                       ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                       ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -163,7 +165,8 @@ static int dsa_pub_print_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int dsa_pub_print(void *ctx, void *dsa, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_ec.c
+++ b/providers/implementations/encode_decode/encoder_ec.c
@@ -238,7 +238,8 @@ static int ossl_prov_prepare_ec_explicit_params(const void *eckey,
     return 1;
 }
 
-int ossl_prov_prepare_ec_params(const void *eckey, int nid,
+int ossl_prov_prepare_ec_params(const void *eckey,
+                                ossl_unused int unused__nid,
                                 void **pstr, int *pstrtype)
 {
     int curve_nid;

--- a/providers/implementations/encode_decode/encoder_ec_param.c
+++ b/providers/implementations/encode_decode/encoder_ec_param.c
@@ -35,7 +35,7 @@ static void *ec_param_newctx(void *provctx)
     return provctx;
 }
 
-static void ec_param_freectx(void *vctx)
+static void ec_param_freectx(ossl_unused void *unused__vctx)
 {
 }
 
@@ -65,7 +65,8 @@ static int ec_param_der_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_param_der(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
-                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                        ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                        ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
@@ -105,7 +106,8 @@ static int ec_param_pem_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_param_pem(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
-                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                        ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                        ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
@@ -144,7 +146,8 @@ static int ec_param_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_param_print(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
-                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                          ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                          ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_ec_priv.c
+++ b/providers/implementations/encode_decode/encoder_ec_priv.c
@@ -213,7 +213,7 @@ static void *ec_print_newctx(void *provctx)
     return provctx;
 }
 
-static void ec_print_freectx(void *ctx)
+static void ec_print_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -242,7 +242,8 @@ static int ec_priv_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_priv_print(void *ctx, void *eckey, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_ec_pub.c
+++ b/providers/implementations/encode_decode/encoder_ec_pub.c
@@ -39,7 +39,7 @@ static void *ec_pub_newctx(void *provctx)
     return provctx;
 }
 
-static void ec_pub_freectx(void *ctx)
+static void ec_pub_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -69,7 +69,8 @@ static int ec_pub_der_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_pub_der(void *ctx, void *eckey, OSSL_CORE_BIO *cout,
-                      OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                      ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                      ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -111,7 +112,8 @@ static int ec_pub_pem_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_pub_pem(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
-                      OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                      ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                      ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;
@@ -152,7 +154,8 @@ static int ec_pub_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ec_pub_print(void *vctx, void *eckey, OSSL_CORE_BIO *cout,
-                        OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                        ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                        ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(vctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_ecx_priv.c
+++ b/providers/implementations/encode_decode/encoder_ecx_priv.c
@@ -258,7 +258,8 @@ static int ecx_priv_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ecx_priv_print(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
-                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                          ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                          ossl_unused void *unused__cbarg)
 {
     struct ecx_priv_ctx_st *ctx = vctx;
     BIO *out = bio_new_from_core_bio(ctx->provctx, cout);

--- a/providers/implementations/encode_decode/encoder_ecx_pub.c
+++ b/providers/implementations/encode_decode/encoder_ecx_pub.c
@@ -102,7 +102,8 @@ static int ecx_pub_der_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ecx_pub_der(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
-                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                       ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                       ossl_unused void *unused__cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
     BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
@@ -146,7 +147,8 @@ static int ecx_pub_pem_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ecx_pub_pem(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
-                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                       ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                       ossl_unused void *unused__cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
     BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
@@ -189,7 +191,8 @@ static int ecx_pub_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int ecx_pub_print(void *vctx, void *ecxkey, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     struct ecx_pub_ctx_st *ctx = vctx;
     BIO *out = bio_new_from_core_bio(ctx->provctx, cout);

--- a/providers/implementations/encode_decode/encoder_rsa.c
+++ b/providers/implementations/encode_decode/encoder_rsa.c
@@ -194,7 +194,8 @@ int ossl_prov_print_rsa(BIO *out, RSA *rsa, int priv)
  * functionality doesn't allow that.
  */
 
-int ossl_prov_prepare_rsa_params(const void *rsa, int nid,
+int ossl_prov_prepare_rsa_params(const void *rsa,
+                                 ossl_unused int unused__nid,
                                  void **pstr, int *pstrtype)
 {
     const RSA_PSS_PARAMS_30 *pss = rsa_get0_pss_params_30((RSA *)rsa);

--- a/providers/implementations/encode_decode/encoder_rsa_priv.c
+++ b/providers/implementations/encode_decode/encoder_rsa_priv.c
@@ -219,7 +219,7 @@ static void *rsa_print_newctx(void *provctx)
     return provctx;
 }
 
-static void rsa_print_freectx(void *ctx)
+static void rsa_print_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -246,7 +246,8 @@ static int rsa_priv_print_data(void *vctx, const OSSL_PARAM params[],
 }
 
 static int rsa_priv_print(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
-                          OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                          ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                          ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/encode_decode/encoder_rsa_pub.c
+++ b/providers/implementations/encode_decode/encoder_rsa_pub.c
@@ -44,7 +44,7 @@ static void *rsa_pub_newctx(void *provctx)
     return provctx;
 }
 
-static void rsa_pub_freectx(void *ctx)
+static void rsa_pub_freectx(ossl_unused void *unused__ctx)
 {
 }
 
@@ -72,7 +72,8 @@ static int rsa_pub_der_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int rsa_pub_der(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
-                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                       ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                       ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -113,7 +114,8 @@ static int rsa_pub_pem_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int rsa_pub_pem(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
-                       OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                       ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                       ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;
@@ -153,7 +155,8 @@ static int rsa_pub_print_data(void *ctx, const OSSL_PARAM params[],
 }
 
 static int rsa_pub_print(void *ctx, void *rsa, OSSL_CORE_BIO *cout,
-                         OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                         ossl_unused OSSL_PASSPHRASE_CALLBACK *unused__cb,
+                         ossl_unused void *unused__cbarg)
 {
     BIO *out = bio_new_from_core_bio(ctx, cout);
     int ret;

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -362,7 +362,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dh_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }
@@ -378,7 +378,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dh_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -279,7 +279,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
 };
 
 static
-const OSSL_PARAM *ecdh_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *ecdh_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }
@@ -360,7 +360,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
 };
 
 static
-const OSSL_PARAM *ecdh_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *ecdh_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }

--- a/providers/implementations/exchange/ecx_exch.c
+++ b/providers/implementations/exchange/ecx_exch.c
@@ -40,7 +40,7 @@ typedef struct {
     ECX_KEY *peerkey;
 } PROV_ECX_CTX;
 
-static void *ecx_newctx(void *provctx, size_t keylen)
+static void *ecx_newctx(ossl_unused void *unused__provctx, size_t keylen)
 {
     PROV_ECX_CTX *ctx = OPENSSL_zalloc(sizeof(PROV_ECX_CTX));
 

--- a/providers/implementations/exchange/kdf_exch.c
+++ b/providers/implementations/exchange/kdf_exch.c
@@ -81,7 +81,7 @@ static int kdf_init(void *vpkdfctx, void *vkdf)
 }
 
 static int kdf_derive(void *vpkdfctx, unsigned char *secret, size_t *secretlen,
-                      size_t outlen)
+                      ossl_unused size_t unused__outlen)
 {
     PROV_KDF_CTX *pkdfctx = (PROV_KDF_CTX *)vpkdfctx;
 

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -322,6 +322,7 @@ static const OSSL_PARAM name##_known_gettable_ctx_params[] = {                 \
 };                                                                             \
 const OSSL_PARAM * name##_gettable_ctx_params(void *provctx)                   \
 {                                                                              \
+    (void)provctx;                                                             \
     return name##_known_gettable_ctx_params;                                   \
 }
 
@@ -334,7 +335,8 @@ static const OSSL_PARAM name##_known_settable_ctx_params[] = {                 \
 };                                                                             \
 const OSSL_PARAM * name##_settable_ctx_params(void *provctx)                   \
 {                                                                              \
-    return name##_known_settable_ctx_params;                                   \
+    (void)provctx;                                                             \
+    return name##_known_settable_ctx_params;	                               \
 }
 
 int cipher_generic_initiv(PROV_CIPHER_CTX *ctx, const unsigned char *iv,

--- a/providers/implementations/include/prov/digestcommon.h
+++ b/providers/implementations/include/prov/digestcommon.h
@@ -19,7 +19,7 @@ extern "C" {
 # endif
 
 #define PROV_FUNC_DIGEST_GET_PARAM(name, blksize, dgstsize, flags)             \
-static OSSL_FUNC_digest_get_params_fn name##_get_params;                         \
+static OSSL_FUNC_digest_get_params_fn name##_get_params;                       \
 static int name##_get_params(OSSL_PARAM params[])                              \
 {                                                                              \
     return digest_default_get_params(params, blksize, dgstsize, flags);        \
@@ -32,10 +32,10 @@ static int name##_get_params(OSSL_PARAM params[])                              \
 
 # define PROV_DISPATCH_FUNC_DIGEST_CONSTRUCT_START(                            \
     name, CTX, blksize, dgstsize, flags, init, upd, fin)                       \
-static OSSL_FUNC_digest_newctx_fn name##_newctx;                                 \
-static OSSL_FUNC_digest_freectx_fn name##_freectx;                               \
-static OSSL_FUNC_digest_dupctx_fn name##_dupctx;                                 \
-static void *name##_newctx(void *prov_ctx)                                     \
+static OSSL_FUNC_digest_newctx_fn name##_newctx;                               \
+static OSSL_FUNC_digest_freectx_fn name##_freectx;                             \
+static OSSL_FUNC_digest_dupctx_fn name##_dupctx;                               \
+static void *name##_newctx(ossl_unused void *prov_ctx)                         \
 {                                                                              \
     CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));                                   \
     return ctx;                                                                \
@@ -53,7 +53,7 @@ static void *name##_dupctx(void *ctx)                                          \
         *ret = *in;                                                            \
     return ret;                                                                \
 }                                                                              \
-static OSSL_FUNC_digest_final_fn name##_internal_final;                          \
+static OSSL_FUNC_digest_final_fn name##_internal_final;                        \
 static int name##_internal_final(void *ctx, unsigned char *out, size_t *outl,  \
                                  size_t outsz)                                 \
 {                                                                              \

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -225,7 +225,7 @@ static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_hkdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kdf_hkdf_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MODE, NULL, 0),
@@ -250,7 +250,7 @@ static int kdf_hkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -298,7 +298,7 @@ static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kbkdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kbkdf_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
@@ -316,7 +316,7 @@ static const OSSL_PARAM *kbkdf_settable_ctx_params(ossl_unused void *provctx)
     return known_settable_ctx_params;
 }
 
-static int kbkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int kbkdf_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -328,7 +328,7 @@ static int kbkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return OSSL_PARAM_set_size_t(p, SIZE_MAX);
 }
 
-static const OSSL_PARAM *kbkdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kbkdf_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] =
         { OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL), OSSL_PARAM_END };

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -140,7 +140,7 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *krb5kdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *krb5kdf_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -170,7 +170,7 @@ static int krb5kdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *krb5kdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *krb5kdf_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -200,7 +200,7 @@ static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -214,7 +214,7 @@ static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(ossl_unused void *p_ctx)
     return known_settable_ctx_params;
 }
 
-static int kdf_pbkdf2_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int kdf_pbkdf2_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -223,7 +223,7 @@ static int kdf_pbkdf2_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -238,7 +238,7 @@ static int kdf_pkcs12_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_pkcs12_settable_ctx_params(void *provctx)
+static const OSSL_PARAM *kdf_pkcs12_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -252,7 +252,7 @@ static const OSSL_PARAM *kdf_pkcs12_settable_ctx_params(void *provctx)
     return known_settable_ctx_params;
 }
 
-static int kdf_pkcs12_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int kdf_pkcs12_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -261,7 +261,7 @@ static int kdf_pkcs12_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_pkcs12_gettable_ctx_params(void *provctx)
+static const OSSL_PARAM *kdf_pkcs12_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -194,7 +194,7 @@ static int kdf_scrypt_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_PASSWORD, NULL, 0),
@@ -208,7 +208,7 @@ static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(ossl_unused void *p_ctx)
     return known_settable_ctx_params;
 }
 
-static int kdf_scrypt_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int kdf_scrypt_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -217,7 +217,7 @@ static int kdf_scrypt_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -160,7 +160,7 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -174,7 +174,7 @@ static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(ossl_unused void *p_ctx)
     return known_settable_ctx_params;
 }
 
-static int kdf_sshkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int kdf_sshkdf_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -183,7 +183,7 @@ static int kdf_sshkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -478,7 +478,7 @@ static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *sskdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sskdf_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SECRET, NULL, 0),
@@ -504,7 +504,7 @@ static int sskdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *sskdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sskdf_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -200,7 +200,7 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(ossl_unused void *ctx)
+static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(ossl_unused void *unused__ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -212,7 +212,7 @@ static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(ossl_unused void *ctx)
     return known_settable_ctx_params;
 }
 
-static int kdf_tls1_prf_get_ctx_params(void *vctx, OSSL_PARAM params[])
+static int kdf_tls1_prf_get_ctx_params(ossl_unused void *unused__vctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -221,7 +221,7 @@ static int kdf_tls1_prf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(ossl_unused void *ctx)
+static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(ossl_unused void *unused__ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -402,7 +402,7 @@ static int x942kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *x942kdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *x942kdf_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -426,7 +426,7 @@ static int x942kdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *x942kdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *x942kdf_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -347,7 +347,7 @@ static const OSSL_PARAM dh_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_gettable_params(void *provctx)
+static const OSSL_PARAM *dh_gettable_params(ossl_unused void *unused__provctx)
 {
     return dh_params;
 }
@@ -357,7 +357,7 @@ static const OSSL_PARAM dh_known_settable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_settable_params(void *provctx)
+static const OSSL_PARAM *dh_settable_params(ossl_unused void *unused__provctx)
 {
     return dh_known_settable_params;
 }
@@ -548,7 +548,7 @@ static int dh_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *dh_gen_settable_params(void *provctx)
+static const OSSL_PARAM *dh_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
@@ -722,7 +722,7 @@ const OSSL_DISPATCH dh_keymgmt_functions[] = {
 };
 
 /* For any DH key, we use the "DH" algorithms regardless of sub-type. */
-static const char *dhx_query_operation_name(int operation_id)
+static const char *dhx_query_operation_name(ossl_unused int unused__operation_id)
 {
     return "DH";
 }

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -295,7 +295,7 @@ static const OSSL_PARAM dsa_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_gettable_params(void *provctx)
+static const OSSL_PARAM *dsa_gettable_params(ossl_unused void *unused__provctx)
 {
     return dsa_params;
 }
@@ -454,7 +454,7 @@ static int dsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *dsa_gen_settable_params(void *provctx)
+static const OSSL_PARAM *dsa_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_FFC_TYPE, NULL, 0),

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -631,7 +631,7 @@ static const OSSL_PARAM ec_known_gettable_params[] = {
 };
 
 static
-const OSSL_PARAM *ec_gettable_params(void *provctx)
+const OSSL_PARAM *ec_gettable_params(ossl_unused void *unused__provctx)
 {
     return ec_known_gettable_params;
 }
@@ -643,7 +643,7 @@ static const OSSL_PARAM ec_known_settable_params[] = {
 };
 
 static
-const OSSL_PARAM *ec_settable_params(void *provctx)
+const OSSL_PARAM *ec_settable_params(ossl_unused void *unused__provctx)
 {
     return ec_known_settable_params;
 }
@@ -894,7 +894,7 @@ err:
     return ret;
 }
 
-static const OSSL_PARAM *ec_gen_settable_params(void *provctx)
+static const OSSL_PARAM *ec_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
@@ -926,7 +926,7 @@ static int ec_gen_assign_group(EC_KEY *ec, EC_GROUP *group)
 /*
  * The callback arguments (osslcb & cbarg) are not used by EC_KEY generation
  */
-static void *ec_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+static void *ec_gen(void *genctx, ossl_unused OSSL_CALLBACK *unused__osslcb, ossl_unused void *unused__cbarg)
 {
     struct ec_gen_ctx *gctx = genctx;
     EC_KEY *ec = NULL;

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -259,7 +259,7 @@ static int ecx_get_params(void *key, OSSL_PARAM params[], int bits, int secbits,
     return key_to_params(ecx, NULL, params);
 }
 
-static int ed_get_params(void *key, OSSL_PARAM params[])
+static int ed_get_params(ossl_unused void *unused__key, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -314,22 +314,22 @@ static const OSSL_PARAM ed_gettable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *x25519_gettable_params(void *provctx)
+static const OSSL_PARAM *x25519_gettable_params(ossl_unused void *unused__provctx)
 {
     return ecx_gettable_params;
 }
 
-static const OSSL_PARAM *x448_gettable_params(void *provctx)
+static const OSSL_PARAM *x448_gettable_params(ossl_unused void *unused__provctx)
 {
     return ecx_gettable_params;
 }
 
-static const OSSL_PARAM *ed25519_gettable_params(void *provctx)
+static const OSSL_PARAM *ed25519_gettable_params(ossl_unused void *unused__provctx)
 {
     return ed_gettable_params;
 }
 
-static const OSSL_PARAM *ed448_gettable_params(void *provctx)
+static const OSSL_PARAM *ed448_gettable_params(ossl_unused void *unused__provctx)
 {
     return ed_gettable_params;
 }
@@ -365,12 +365,12 @@ static int x448_set_params(void *key, const OSSL_PARAM params[])
     return ecx_set_params(key, params);
 }
 
-static int ed25519_set_params(void *key, const OSSL_PARAM params[])
+static int ed25519_set_params(ossl_unused void *unused__key, ossl_unused const OSSL_PARAM params[])
 {
     return 1;
 }
 
-static int ed448_set_params(void *key, const OSSL_PARAM params[])
+static int ed448_set_params(ossl_unused void *unused__key, ossl_unused const OSSL_PARAM params[])
 {
     return 1;
 }
@@ -384,22 +384,22 @@ static const OSSL_PARAM ed_settable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *x25519_settable_params(void *provctx)
+static const OSSL_PARAM *x25519_settable_params(ossl_unused void *unused__provctx)
 {
     return ecx_settable_params;
 }
 
-static const OSSL_PARAM *x448_settable_params(void *provctx)
+static const OSSL_PARAM *x448_settable_params(ossl_unused void *unused__provctx)
 {
     return ecx_settable_params;
 }
 
-static const OSSL_PARAM *ed25519_settable_params(void *provctx)
+static const OSSL_PARAM *ed25519_settable_params(ossl_unused void *unused__provctx)
 {
     return ed_settable_params;
 }
 
-static const OSSL_PARAM *ed448_settable_params(void *provctx)
+static const OSSL_PARAM *ed448_settable_params(ossl_unused void *unused__provctx)
 {
     return ed_settable_params;
 }
@@ -476,7 +476,7 @@ static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *ecx_gen_settable_params(void *provctx)
+static const OSSL_PARAM *ecx_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
@@ -535,7 +535,7 @@ err:
     return NULL;
 }
 
-static void *x25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+static void *x25519_gen(void *genctx, ossl_unused OSSL_CALLBACK *unused__osslcb, ossl_unused void *unused__cbarg)
 {
     struct ecx_gen_ctx *gctx = genctx;
 
@@ -546,7 +546,7 @@ static void *x25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
     return ecx_gen(gctx);
 }
 
-static void *x448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+static void *x448_gen(void *genctx, ossl_unused OSSL_CALLBACK *unused__osslcb, ossl_unused void *unused__cbarg)
 {
     struct ecx_gen_ctx *gctx = genctx;
 
@@ -557,7 +557,7 @@ static void *x448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
     return ecx_gen(gctx);
 }
 
-static void *ed25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+static void *ed25519_gen(void *genctx, ossl_unused OSSL_CALLBACK *unused__osslcb, ossl_unused void *unused__cbarg)
 {
     struct ecx_gen_ctx *gctx = genctx;
 #ifdef S390X_EC_ASM
@@ -570,7 +570,7 @@ static void *ed25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
     return ecx_gen(gctx);
 }
 
-static void *ed448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+static void *ed448_gen(void *genctx, ossl_unused OSSL_CALLBACK *unused__osslcb, ossl_unused void *unused__cbarg)
 {
     struct ecx_gen_ctx *gctx = genctx;
 

--- a/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
@@ -77,7 +77,7 @@ static void kdf_freedata(void *kdfdata)
     kdf_data_free(kdfdata);
 }
 
-static int kdf_has(void *keydata, int selection)
+static int kdf_has(ossl_unused void *unused__keydata, ossl_unused int unused__selection)
 {
     return 0;
 }

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -341,7 +341,7 @@ static const OSSL_PARAM rsa_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_params(void *provctx)
+static const OSSL_PARAM *rsa_gettable_params(ossl_unused void *unused__provctx)
 {
     return rsa_params;
 }
@@ -480,7 +480,7 @@ static int rsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
     OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_RSA_MGF1_DIGEST, NULL, 0),   \
     OSSL_PARAM_int(OSSL_PKEY_PARAM_RSA_PSS_SALTLEN, NULL)
 
-static const OSSL_PARAM *rsa_gen_settable_params(void *provctx)
+static const OSSL_PARAM *rsa_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         rsa_gen_basic,
@@ -490,7 +490,7 @@ static const OSSL_PARAM *rsa_gen_settable_params(void *provctx)
     return settable;
 }
 
-static const OSSL_PARAM *rsapss_gen_settable_params(void *provctx)
+static const OSSL_PARAM *rsapss_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         rsa_gen_basic,
@@ -592,7 +592,7 @@ void *rsa_load(const void *reference, size_t reference_sz)
 }
 
 /* For any RSA key, we use the "RSA" algorithms regardless of sub-type. */
-static const char *rsapss_query_operation_name(int operation_id)
+static const char *rsapss_query_operation_name(ossl_unused int unused__operation_id)
 {
     return "RSA";
 }

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -40,7 +40,7 @@ struct blake2_mac_data_st {
 
 static size_t blake2_mac_size(void *vmacctx);
 
-static void *blake2_mac_new(void *unused_provctx)
+static void *blake2_mac_new(ossl_unused void *unused__provctx)
 {
     struct blake2_mac_data_st *macctx = OPENSSL_zalloc(sizeof(*macctx));
 
@@ -97,7 +97,7 @@ static int blake2_mac_update(void *vmacctx,
 
 static int blake2_mac_final(void *vmacctx,
                             unsigned char *out, size_t *outl,
-                            size_t outsize)
+                            ossl_unused size_t unused__outsize)
 {
     struct blake2_mac_data_st *macctx = vmacctx;
 
@@ -109,7 +109,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *blake2_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *blake2_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -131,7 +131,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_SALT, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *blake2_mac_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *blake2_mac_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -114,7 +114,7 @@ static int cmac_update(void *vmacctx, const unsigned char *data,
 }
 
 static int cmac_final(void *vmacctx, unsigned char *out, size_t *outl,
-                      size_t outsize)
+                      ossl_unused size_t unused__outsize)
 {
     struct cmac_data_st *macctx = vmacctx;
 
@@ -125,7 +125,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cmac_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *cmac_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -146,7 +146,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -87,7 +87,7 @@ static void *gmac_dup(void *vsrc)
     return dst;
 }
 
-static int gmac_init(void *vmacctx)
+static int gmac_init(ossl_unused void *unused__vmacctx)
 {
     return 1;
 }
@@ -109,7 +109,7 @@ static int gmac_update(void *vmacctx, const unsigned char *data,
 }
 
 static int gmac_final(void *vmacctx, unsigned char *out, size_t *outl,
-                      size_t outsize)
+                      ossl_unused size_t unused__outsize)
 {
     struct gmac_data_st *macctx = vmacctx;
     int hlen = 0;
@@ -136,7 +136,7 @@ static const OSSL_PARAM known_gettable_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *gmac_gettable_params(void *provctx)
+static const OSSL_PARAM *gmac_gettable_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_params;
 }
@@ -158,7 +158,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_IV, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *gmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *gmac_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -123,7 +123,7 @@ static int hmac_update(void *vmacctx, const unsigned char *data,
 }
 
 static int hmac_final(void *vmacctx, unsigned char *out, size_t *outl,
-                      size_t outsize)
+                      ossl_unused size_t unused__outsize)
 {
     unsigned int hlen;
     struct hmac_data_st *macctx = vmacctx;
@@ -138,7 +138,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *hmac_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *hmac_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -160,7 +160,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_int(OSSL_MAC_PARAM_FLAGS, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -284,7 +284,7 @@ static int kmac_update(void *vmacctx, const unsigned char *data,
 }
 
 static int kmac_final(void *vmacctx, unsigned char *out, size_t *outl,
-                      size_t outsize)
+                      ossl_unused size_t unused__outsize)
 {
     struct kmac_data_st *kctx = vmacctx;
     EVP_MD_CTX *ctx = kctx->ctx;
@@ -306,7 +306,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *kmac_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kmac_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -328,7 +328,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_CUSTOM, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *kmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kmac_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -72,7 +72,7 @@ static size_t poly1305_size(void)
     return POLY1305_DIGEST_SIZE;
 }
 
-static int poly1305_init(void *vmacctx)
+static int poly1305_init(ossl_unused void *unused__vmacctx)
 {
     /* initialize the context in MAC_ctrl function */
     return 1;
@@ -89,7 +89,7 @@ static int poly1305_update(void *vmacctx, const unsigned char *data,
 }
 
 static int poly1305_final(void *vmacctx, unsigned char *out, size_t *outl,
-                          size_t outsize)
+                          ossl_unused size_t unused__outsize)
 {
     struct poly1305_data_st *ctx = vmacctx;
 
@@ -102,7 +102,7 @@ static const OSSL_PARAM known_gettable_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *poly1305_gettable_params(void *provctx)
+static const OSSL_PARAM *poly1305_gettable_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_params;
 }
@@ -121,7 +121,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *poly1305_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *poly1305_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -80,7 +80,7 @@ static size_t siphash_size(void *vmacctx)
     return SipHash_hash_size(&ctx->siphash);
 }
 
-static int siphash_init(void *vmacctx)
+static int siphash_init(ossl_unused void *unused__vmacctx)
 {
     /* Not much to do here, actual initialization happens through controls */
     return 1;
@@ -112,7 +112,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *siphash_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *siphash_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -132,7 +132,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *siphash_settable_params(void *provctx)
+static const OSSL_PARAM *siphash_settable_params(ossl_unused void *unused__provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/rands/crngt.c
+++ b/providers/implementations/rands/crngt.c
@@ -95,7 +95,7 @@ static const OPENSSL_CTX_METHOD rand_crng_ossl_ctx_method = {
 size_t prov_crngt_get_entropy(PROV_DRBG *drbg,
                               unsigned char **pout,
                               int entropy, size_t min_len, size_t max_len,
-                              int prediction_resistance)
+                              ossl_unused int unused__prediction_resistance)
 {
     unsigned char buf[CRNGT_BUFSIZ], md[EVP_MAX_MD_SIZE];
     unsigned int sz;
@@ -132,7 +132,7 @@ err:
     return r;
 }
 
-void prov_crngt_cleanup_entropy(PROV_DRBG *drbg,
+void prov_crngt_cleanup_entropy(ossl_unused PROV_DRBG *unused__drbg,
                                 unsigned char *out, size_t outlen)
 {
     OPENSSL_secure_clear_free(out, outlen);

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -270,7 +270,7 @@ typedef struct prov_drbg_nonce_global_st {
  * to be in a different global data object. Otherwise we will go into an
  * infinite recursion loop.
  */
-static void *prov_drbg_nonce_ossl_ctx_new(OPENSSL_CTX *libctx)
+static void *prov_drbg_nonce_ossl_ctx_new(ossl_unused OPENSSL_CTX *unused__libctx)
 {
     PROV_DRBG_NONCE_GLOBAL *dngbl = OPENSSL_zalloc(sizeof(*dngbl));
 
@@ -306,7 +306,8 @@ static const OPENSSL_CTX_METHOD drbg_nonce_ossl_ctx_method = {
 /* Get a nonce from the operating system */
 static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
                                   unsigned char **pout,
-                                  int entropy, size_t min_len, size_t max_len)
+                                  ossl_unused int unused__entropy,
+                                  size_t min_len, size_t max_len)
 {
     size_t ret = 0, n;
     RAND_POOL *pool;
@@ -319,7 +320,7 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
         void *instance;
         int count;
     } data;
-    
+
     if (dngbl == NULL)
         return 0;
 
@@ -365,7 +366,8 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
     return ret;
 }
 
-static void prov_drbg_clear_nonce(PROV_DRBG *drbg, unsigned char *nonce,
+static void prov_drbg_clear_nonce(ossl_unused PROV_DRBG *unused__drbg,
+                                  unsigned char *nonce,
                                   size_t noncelen)
 {
     OPENSSL_clear_free(nonce, noncelen);
@@ -456,7 +458,7 @@ int PROV_DRBG_instantiate(PROV_DRBG *drbg, unsigned int strength,
 #ifndef PROV_RAND_GET_RANDOM_NONCE
         else { /* parent == NULL */
             noncelen = prov_drbg_get_nonce(drbg, &nonce, drbg->strength / 2,
-                                           drbg->min_noncelen, 
+                                           drbg->min_noncelen,
                                            drbg->max_noncelen);
             if (noncelen < drbg->min_noncelen
                     || noncelen > drbg->max_noncelen) {

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -635,7 +635,7 @@ static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETTABLE_CTX_COMMON,
@@ -701,7 +701,7 @@ static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -432,7 +432,7 @@ static int drbg_hash_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETTABLE_CTX_COMMON,
@@ -476,7 +476,7 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_hash_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hash_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -329,7 +329,7 @@ static int drbg_hmac_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETTABLE_CTX_COMMON,
@@ -378,7 +378,7 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_hmac_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hmac_settable_ctx_params(ossl_unused void *unused__p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -398,6 +398,8 @@ static ssize_t syscall_random(void *buf, size_t buflen)
     if (p_getentropy.p != NULL)
         return p_getentropy.f(buf, buflen) == 0 ? (ssize_t)buflen : -1;
 #  endif
+   (void)buf;    /* silence -Wunused-parameter */
+   (void)buflen; /* silence -Wunused-parameter */
 
     /* Linux supports this since version 3.17 */
 #  if defined(__linux) && defined(__NR_getrandom)

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -129,10 +129,10 @@ static int test_rng_generate(PROV_DRBG *drbg,
     return 1;
 }
 
-static int test_rng_generate_wrapper
-    (void *vdrbg, unsigned char *out, size_t outlen,
-      unsigned int strength, int prediction_resistance,
-      const unsigned char *adin, size_t adin_len)
+static int test_rng_generate_wrapper(void *vdrbg, unsigned char *out, size_t outlen,
+                                     unsigned int strength,
+                                     ossl_unused int unused__prediction_resistance,
+                                     const unsigned char *adin, size_t adin_len)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
 
@@ -154,7 +154,7 @@ static int test_rng_reseed(PROV_DRBG *drbg,
     return 1;
 }
 
-static int test_rng_reseed_wrapper(void *vdrbg, int prediction_resistance,
+static int test_rng_reseed_wrapper(void *vdrbg, int ossl_unused prediction_resistance,
                                    const unsigned char *ent, size_t ent_len,
                                    const unsigned char *adin, size_t adin_len)
 {
@@ -186,7 +186,7 @@ static int test_rng_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *test_rng_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *test_rng_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_DRBG_GETTABLE_CTX_COMMON,
@@ -264,7 +264,7 @@ static int test_rng_set_ctx_params(void *vdrbg, const OSSL_PARAM params[])
     return drbg_set_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, NULL, 0),
@@ -285,7 +285,7 @@ static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *provctx)
     return known_settable_ctx_params;
 }
 
-static int test_rng_verify_zeroization(void *vdrbg)
+static int test_rng_verify_zeroization(ossl_unused void *unused__vdrbg)
 {
     return 1;
 }

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -412,7 +412,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dsa_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -454,7 +454,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dsa_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -399,7 +399,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *ecdsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *ecdsa_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -451,7 +451,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *ecdsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *ecdsa_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -36,7 +36,7 @@ typedef struct {
     ECX_KEY *key;
 } PROV_EDDSA_CTX;
 
-static void *eddsa_newctx(void *provctx, const char *propq_unused)
+static void *eddsa_newctx(void *provctx, ossl_unused const char *unused__propq)
 {
     PROV_EDDSA_CTX *peddsactx = OPENSSL_zalloc(sizeof(PROV_EDDSA_CTX));
 

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -983,7 +983,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *unused__provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -1233,7 +1233,7 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *unused__provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -43,12 +43,12 @@ static const OSSL_PARAM legacy_param_types[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *legacy_gettable_params(void *provctx)
+static const OSSL_PARAM *legacy_gettable_params(ossl_unused void *unused__provctx)
 {
     return legacy_param_types;
 }
 
-static int legacy_get_params(void *provctx, OSSL_PARAM params[])
+static int legacy_get_params(ossl_unused void *unused__provctx, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -144,7 +144,7 @@ static const OSSL_ALGORITHM legacy_ciphers[] = {
     { NULL, NULL, NULL }
 };
 
-static const OSSL_ALGORITHM *legacy_query(void *provctx, int operation_id,
+static const OSSL_ALGORITHM *legacy_query(ossl_unused void *unused__provctx, int operation_id,
                                           int *no_cache)
 {
     *no_cache = 0;

--- a/providers/nullprov.c
+++ b/providers/nullprov.c
@@ -25,12 +25,12 @@ static const OSSL_ITEM null_param_types[] = {
     { 0, NULL }
 };
 
-static const OSSL_ITEM *null_gettable_params(const OSSL_PROVIDER *prov)
+static const OSSL_ITEM *null_gettable_params(ossl_unused const OSSL_PROVIDER *unused__prov)
 {
     return null_param_types;
 }
 
-static int null_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
+static int null_get_params(ossl_unused const OSSL_PROVIDER *unused__prov, OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
 
@@ -47,9 +47,9 @@ static int null_get_params(const OSSL_PROVIDER *prov, OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_ALGORITHM *null_query(OSSL_PROVIDER *prov,
-                                          int operation_id,
-                                          int *no_cache)
+static const OSSL_ALGORITHM *null_query(ossl_unused OSSL_PROVIDER *unused__prov,
+                                        ossl_unused int unused__operation_id,
+                                        int *no_cache)
 {
     *no_cache = 0;
     return NULL;
@@ -64,7 +64,7 @@ static const OSSL_DISPATCH null_dispatch_table[] = {
 };
 
 int ossl_null_provider_init(const OSSL_CORE_HANDLE *handle,
-                            const OSSL_DISPATCH *in,
+                            ossl_unused const OSSL_DISPATCH *unused__in,
                             const OSSL_DISPATCH **out,
                             void **provctx)
 {

--- a/ssl/record/ssl3_record_tls13.c
+++ b/ssl/record/ssl3_record_tls13.c
@@ -21,7 +21,8 @@
  *    1: if the record encryption/decryption was successful.
  */
 int tls13_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
-              SSL_MAC_BUF *mac, size_t macsize)
+              ossl_unused SSL_MAC_BUF *unused__mac,
+              ossl_unused size_t unused__macsize)
 {
     EVP_CIPHER_CTX *ctx;
     unsigned char iv[EVP_MAX_IV_LENGTH], recheader[SSL3_RT_HEADER_LENGTH];

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3271,17 +3271,15 @@ void ssl_sort_cipher_list(void)
     qsort(ssl3_scsvs, SSL3_NUM_SCSVS, sizeof(ssl3_scsvs[0]), cipher_compare);
 }
 
-static int ssl_undefined_function_1(SSL *ssl, unsigned char *r, size_t s,
-                                    const char * t, size_t u,
-                                    const unsigned char * v, size_t w, int x)
+static int ssl_undefined_function_1(SSL *ssl,
+                                    ossl_unused unsigned char *unused__r,
+                                    ossl_unused size_t unused__s,
+                                    ossl_unused const char *unused__t,
+                                    ossl_unused size_t unused__u,
+                                    ossl_unused const unsigned char *unused__v,
+                                    ossl_unused size_t unused__w,
+                                    ossl_unused int unused__x)
 {
-    (void)r;
-    (void)s;
-    (void)t;
-    (void)u;
-    (void)v;
-    (void)w;
-    (void)x;
     return ssl_undefined_function(ssl);
 }
 
@@ -3324,7 +3322,7 @@ const SSL_CIPHER *ssl3_get_cipher(unsigned int u)
         return NULL;
 }
 
-int ssl3_set_handshake_header(SSL *s, WPACKET *pkt, int htype)
+int ssl3_set_handshake_header(ossl_unused SSL *unused__ssl, WPACKET *pkt, int htype)
 {
     /* No header in the event of a CCS */
     if (htype == SSL3_MT_CHANGE_CIPHER_SPEC)
@@ -3427,7 +3425,7 @@ int ssl3_clear(SSL *s)
 }
 
 #ifndef OPENSSL_NO_SRP
-static char *srp_password_from_info_cb(SSL *s, void *arg)
+static char *srp_password_from_info_cb(SSL *s, ossl_unused void *unused__arg)
 {
     return OPENSSL_strdup(s->srp_ctx.info);
 }

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -969,7 +969,7 @@ int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain, int ref)
 
 static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
                                          int op, int bits, int nid, void *other,
-                                         void *ex)
+                                         ossl_unused void *unused__ex)
 {
     int level, minbits;
     static const int minbits_table[5] = { 80, 112, 128, 192, 256 };

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -36,43 +36,51 @@ DEFINE_STACK_OF(OCSP_RESPID)
 DEFINE_STACK_OF(SRTP_PROTECTION_PROFILE)
 DEFINE_STACK_OF(SCT)
 
-static int ssl_undefined_function_1(SSL *ssl, SSL3_RECORD *r, size_t s, int t,
-                                    SSL_MAC_BUF *mac, size_t macsize)
+static int ssl_undefined_function_1(SSL *ssl, ossl_unused SSL3_RECORD *unused__r,
+                                    ossl_unused size_t unused__s, ossl_unused int unused__t,
+                                    ossl_unused SSL_MAC_BUF *unused__mac,
+                                    ossl_unused size_t unused__macsize)
 {
     return ssl_undefined_function(ssl);
 }
 
-static int ssl_undefined_function_2(SSL *ssl, SSL3_RECORD *r, unsigned char *s,
-                                    int t)
+static int ssl_undefined_function_2(SSL *ssl, ossl_unused SSL3_RECORD *unused__r,
+                                    ossl_unused unsigned char *unused__s,
+                                    ossl_unused int unused__t)
 {
     return ssl_undefined_function(ssl);
 }
 
-static int ssl_undefined_function_3(SSL *ssl, unsigned char *r,
-                                    unsigned char *s, size_t t, size_t *u)
+static int ssl_undefined_function_3(SSL *ssl, ossl_unused unsigned char *unused__r,
+                                    ossl_unused unsigned char *unused__s,
+                                    ossl_unused size_t unused__t,
+                                    ossl_unused size_t *unused__u)
 {
     return ssl_undefined_function(ssl);
 }
 
-static int ssl_undefined_function_4(SSL *ssl, int r)
+static int ssl_undefined_function_4(SSL *ssl, ossl_unused int unused__r)
 {
     return ssl_undefined_function(ssl);
 }
 
-static size_t ssl_undefined_function_5(SSL *ssl, const char *r, size_t s,
-                                       unsigned char *t)
+static size_t ssl_undefined_function_5(SSL *ssl, ossl_unused const char *unused__r,
+                                       ossl_unused size_t unused__s,
+                                       ossl_unused unsigned char *unused__t)
 {
     return ssl_undefined_function(ssl);
 }
 
-static int ssl_undefined_function_6(int r)
+static int ssl_undefined_function_6(ossl_unused int unused__r)
 {
     return ssl_undefined_function(NULL);
 }
 
-static int ssl_undefined_function_7(SSL *ssl, unsigned char *r, size_t s,
-                                    const char *t, size_t u,
-                                    const unsigned char *v, size_t w, int x)
+static int ssl_undefined_function_7(SSL *ssl, ossl_unused unsigned char *unused__r,
+                                    ossl_unused size_t unused__s,
+                                    ossl_unused const char *unused__t, ossl_unused size_t unused__u,
+                                    ossl_unused const unsigned char *unused__v,
+                                    ossl_unused size_t unused__w, ossl_unused int unused__x)
 {
     return ssl_undefined_function(ssl);
 }
@@ -2085,6 +2093,10 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
     }
 
 #ifdef OPENSSL_NO_KTLS
+    (void)fd;     /* silence -Wunused-parameter */
+    (void)offset; /* silence -Wunused-parameter */
+    (void)size;   /* silence -Wunused-parameter */
+    (void)flags;  /* silence -Wunused-parameter */
     ERR_raise_data(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR,
                    "can't call ktls_sendfile(), ktls disabled");
     return -1;
@@ -2791,7 +2803,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
  * - if we are before or during/after the handshake,
  * - if a resumption or normal handshake is being attempted/has occurred
  * - whether we have negotiated TLSv1.2 (or below) or TLSv1.3
- * 
+ *
  * Note that only the host_name type is defined (RFC 3546).
  */
 const char *SSL_get_servername(const SSL *s, const int type)
@@ -3881,7 +3893,7 @@ void SSL_set_connect_state(SSL *s)
     clear_ciphers(s);
 }
 
-int ssl_undefined_function(SSL *s)
+int ssl_undefined_function(ossl_unused SSL *unused__ssl)
 {
     SSLerr(SSL_F_SSL_UNDEFINED_FUNCTION, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return 0;
@@ -3894,12 +3906,12 @@ int ssl_undefined_void_function(void)
     return 0;
 }
 
-int ssl_undefined_const_function(const SSL *s)
+int ssl_undefined_const_function(ossl_unused const SSL *unused__s)
 {
     return 0;
 }
 
-const SSL_METHOD *ssl_bad_method(int ver)
+const SSL_METHOD *ssl_bad_method(ossl_unused int unused__ver)
 {
     SSLerr(SSL_F_SSL_BAD_METHOD, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
     return NULL;
@@ -4792,11 +4804,9 @@ int SSL_is_server(const SSL *s)
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_1_1_0
-void SSL_set_debug(SSL *s, int debug)
+void SSL_set_debug(ossl_unused SSL *unused__s, ossl_unused int unused__debug)
 {
     /* Old function was do-nothing anyway... */
-    (void)s;
-    (void)debug;
 }
 #endif
 
@@ -5070,14 +5080,15 @@ const STACK_OF(SCT) *SSL_get0_peer_scts(SSL *s)
     return NULL;
 }
 
-static int ct_permissive(const CT_POLICY_EVAL_CTX * ctx,
-                         const STACK_OF(SCT) *scts, void *unused_arg)
+static int ct_permissive(ossl_unused const CT_POLICY_EVAL_CTX * unused__ctx,
+                         ossl_unused const STACK_OF(SCT) *scts,
+                         ossl_unused void *unused__arg)
 {
     return 1;
 }
 
-static int ct_strict(const CT_POLICY_EVAL_CTX * ctx,
-                     const STACK_OF(SCT) *scts, void *unused_arg)
+static int ct_strict(ossl_unused const CT_POLICY_EVAL_CTX * unused__ctx,
+                     const STACK_OF(SCT) *scts, ossl_unused void *unused__arg)
 {
     int count = scts != NULL ? sk_SCT_num(scts) : 0;
     int i;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -783,11 +783,15 @@ static int serverinfo_find_extension(const unsigned char *serverinfo,
     /* Unreachable */
 }
 
-static int serverinfoex_srv_parse_cb(SSL *s, unsigned int ext_type,
-                                     unsigned int context,
-                                     const unsigned char *in,
-                                     size_t inlen, X509 *x, size_t chainidx,
-                                     int *al, void *arg)
+static int serverinfoex_srv_parse_cb(ossl_unused SSL *unused__ssl,
+                                     ossl_unused unsigned int unused__ext_type,
+                                     ossl_unused unsigned int unused__context,
+                                     ossl_unused const unsigned char *unused__in,
+                                     size_t inlen,
+                                     ossl_unused X509 *unused__x,
+                                     ossl_unused size_t unused__chainidx,
+                                     int *al,
+                                     ossl_unused void *unused__arg)
 {
 
     if (inlen != 0) {
@@ -809,8 +813,11 @@ static int serverinfo_srv_parse_cb(SSL *s, unsigned int ext_type,
 static int serverinfoex_srv_add_cb(SSL *s, unsigned int ext_type,
                                    unsigned int context,
                                    const unsigned char **out,
-                                   size_t *outlen, X509 *x, size_t chainidx,
-                                   int *al, void *arg)
+                                   size_t *outlen,
+                                   ossl_unused X509 *unused__x,
+                                   size_t chainidx,
+                                   int *al,
+                                   ossl_unused void *unused__arg)
 {
     const unsigned char *serverinfo = NULL;
     size_t serverinfo_length = 0;

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -879,7 +879,7 @@ int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
  * otherwise. These functions return 1 on success or 0 on failure.
  */
 
-static int final_renegotiate(SSL *s, unsigned int context, int sent)
+static int final_renegotiate(SSL *s, ossl_unused unsigned int unused__context, int sent)
 {
     if (!s->server) {
         /*
@@ -910,7 +910,7 @@ static int final_renegotiate(SSL *s, unsigned int context, int sent)
     return 1;
 }
 
-static int init_server_name(SSL *s, unsigned int context)
+static int init_server_name(SSL *s, ossl_unused unsigned int unused__context)
 {
     if (s->server) {
         s->servername_done = 0;
@@ -922,7 +922,7 @@ static int init_server_name(SSL *s, unsigned int context)
     return 1;
 }
 
-static int final_server_name(SSL *s, unsigned int context, int sent)
+static int final_server_name(SSL *s, ossl_unused unsigned int unused__context, int sent)
 {
     int ret = SSL_TLSEXT_ERR_NOACK;
     int altmp = SSL_AD_UNRECOGNIZED_NAME;
@@ -1024,7 +1024,7 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
 }
 
 #ifndef OPENSSL_NO_EC
-static int final_ec_pt_formats(SSL *s, unsigned int context, int sent)
+static int final_ec_pt_formats(SSL *s, ossl_unused unsigned int unused__context, ossl_unused int unused__sent)
 {
     unsigned long alg_k, alg_a;
 
@@ -1063,7 +1063,7 @@ static int final_ec_pt_formats(SSL *s, unsigned int context, int sent)
 }
 #endif
 
-static int init_session_ticket(SSL *s, unsigned int context)
+static int init_session_ticket(SSL *s, ossl_unused unsigned int unused__context)
 {
     if (!s->server)
         s->ext.ticket_expected = 0;
@@ -1072,7 +1072,7 @@ static int init_session_ticket(SSL *s, unsigned int context)
 }
 
 #ifndef OPENSSL_NO_OCSP
-static int init_status_request(SSL *s, unsigned int context)
+static int init_status_request(SSL *s, ossl_unused unsigned int unused__context)
 {
     if (s->server) {
         s->ext.status_type = TLSEXT_STATUSTYPE_nothing;
@@ -1091,7 +1091,7 @@ static int init_status_request(SSL *s, unsigned int context)
 #endif
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
-static int init_npn(SSL *s, unsigned int context)
+static int init_npn(SSL *s, ossl_unused unsigned int unused__context)
 {
     s->s3.npn_seen = 0;
 
@@ -1099,7 +1099,7 @@ static int init_npn(SSL *s, unsigned int context)
 }
 #endif
 
-static int init_alpn(SSL *s, unsigned int context)
+static int init_alpn(SSL *s, ossl_unused unsigned int unused__context)
 {
     OPENSSL_free(s->s3.alpn_selected);
     s->s3.alpn_selected = NULL;
@@ -1112,7 +1112,7 @@ static int init_alpn(SSL *s, unsigned int context)
     return 1;
 }
 
-static int final_alpn(SSL *s, unsigned int context, int sent)
+static int final_alpn(SSL *s, ossl_unused unsigned int unused__context, int sent)
 {
     if (!s->server && !sent && s->session->ext.alpn_selected != NULL)
             s->ext.early_data_ok = 0;
@@ -1132,7 +1132,7 @@ static int final_alpn(SSL *s, unsigned int context, int sent)
     return tls_handle_alpn(s);
 }
 
-static int init_sig_algs(SSL *s, unsigned int context)
+static int init_sig_algs(SSL *s, ossl_unused unsigned int unused__context)
 {
     /* Clear any signature algorithms extension received */
     OPENSSL_free(s->s3.tmp.peer_sigalgs);
@@ -1141,7 +1141,7 @@ static int init_sig_algs(SSL *s, unsigned int context)
     return 1;
 }
 
-static int init_sig_algs_cert(SSL *s, unsigned int context)
+static int init_sig_algs_cert(SSL *s, ossl_unused unsigned int unused__context)
 {
     /* Clear any signature algorithms extension received */
     OPENSSL_free(s->s3.tmp.peer_cert_sigalgs);
@@ -1151,7 +1151,7 @@ static int init_sig_algs_cert(SSL *s, unsigned int context)
 }
 
 #ifndef OPENSSL_NO_SRP
-static int init_srp(SSL *s, unsigned int context)
+static int init_srp(SSL *s, ossl_unused unsigned int unused__context)
 {
     OPENSSL_free(s->srp_ctx.login);
     s->srp_ctx.login = NULL;
@@ -1160,14 +1160,14 @@ static int init_srp(SSL *s, unsigned int context)
 }
 #endif
 
-static int init_etm(SSL *s, unsigned int context)
+static int init_etm(SSL *s, ossl_unused unsigned int unused__context)
 {
     s->ext.use_etm = 0;
 
     return 1;
 }
 
-static int init_ems(SSL *s, unsigned int context)
+static int init_ems(SSL *s, ossl_unused unsigned int unused__context)
 {
     if (s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS) {
         s->s3.flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
@@ -1177,7 +1177,7 @@ static int init_ems(SSL *s, unsigned int context)
     return 1;
 }
 
-static int final_ems(SSL *s, unsigned int context, int sent)
+static int final_ems(SSL *s, ossl_unused unsigned int unused__context, ossl_unused int unused__sent)
 {
     /*
      * Check extended master secret extension is not dropped on
@@ -1205,7 +1205,7 @@ static int final_ems(SSL *s, unsigned int context, int sent)
     return 1;
 }
 
-static int init_certificate_authorities(SSL *s, unsigned int context)
+static int init_certificate_authorities(SSL *s, ossl_unused unsigned int unused__context)
 {
     sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
     s->s3.tmp.peer_ca_names = NULL;
@@ -1213,9 +1213,9 @@ static int init_certificate_authorities(SSL *s, unsigned int context)
 }
 
 static EXT_RETURN tls_construct_certificate_authorities(SSL *s, WPACKET *pkt,
-                                                        unsigned int context,
-                                                        X509 *x,
-                                                        size_t chainidx)
+                                                        ossl_unused unsigned int unused__context,
+                                                        ossl_unused X509 *unused__x,
+                                                        ossl_unused size_t unused__chainidx)
 {
     const STACK_OF(X509_NAME) *ca_sk = get_ca_names(s);
 
@@ -1246,8 +1246,9 @@ static EXT_RETURN tls_construct_certificate_authorities(SSL *s, WPACKET *pkt,
 }
 
 static int tls_parse_certificate_authorities(SSL *s, PACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             ossl_unused X509 *unused__x,
+                                             ossl_unused size_t unused__chainidx)
 {
     if (!parse_ca_names(s, pkt))
         return 0;
@@ -1260,7 +1261,7 @@ static int tls_parse_certificate_authorities(SSL *s, PACKET *pkt,
 }
 
 #ifndef OPENSSL_NO_SRTP
-static int init_srtp(SSL *s, unsigned int context)
+static int init_srtp(SSL *s, ossl_unused unsigned int unused__context)
 {
     if (s->server)
         s->srtp_profile = NULL;
@@ -1269,7 +1270,7 @@ static int init_srtp(SSL *s, unsigned int context)
 }
 #endif
 
-static int final_sig_algs(SSL *s, unsigned int context, int sent)
+static int final_sig_algs(SSL *s, ossl_unused unsigned int unused__context, int sent)
 {
     if (!sent && SSL_IS_TLS13(s) && !s->hit) {
         SSLfatal(s, TLS13_AD_MISSING_EXTENSION, SSL_F_FINAL_SIG_ALGS,
@@ -1444,7 +1445,7 @@ static int final_key_share(SSL *s, unsigned int context, int sent)
     return 1;
 }
 
-static int init_psk_kex_modes(SSL *s, unsigned int context)
+static int init_psk_kex_modes(SSL *s, ossl_unused unsigned int unused__context)
 {
     s->ext.psk_kex_mode = TLSEXT_KEX_MODE_FLAG_NONE;
     return 1;
@@ -1684,7 +1685,7 @@ static int final_early_data(SSL *s, unsigned int context, int sent)
     return 1;
 }
 
-static int final_maxfragmentlen(SSL *s, unsigned int context, int sent)
+static int final_maxfragmentlen(SSL *s, ossl_unused unsigned int unused__context, int sent)
 {
     /*
      * Session resumption on server-side with MFL extension active
@@ -1709,7 +1710,7 @@ static int final_maxfragmentlen(SSL *s, unsigned int context, int sent)
     return 1;
 }
 
-static int init_post_handshake_auth(SSL *s, unsigned int context)
+static int init_post_handshake_auth(SSL *s, ossl_unused unsigned int unused__context)
 {
     s->post_handshake_auth = SSL_PHA_NONE;
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -17,8 +17,9 @@ DEFINE_STACK_OF_CONST(SSL_CIPHER)
 DEFINE_STACK_OF(OCSP_RESPID)
 
 EXT_RETURN tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt,
-                                          unsigned int context, X509 *x,
-                                          size_t chainidx)
+                                          ossl_unused unsigned int unused__context,
+                                          ossl_unused X509 *unused__x,
+                                          ossl_unused size_t unused__chainidx)
 {
     /* Add RI if renegotiating */
     if (!s->renegotiate)
@@ -38,8 +39,9 @@ EXT_RETURN tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt,
 }
 
 EXT_RETURN tls_construct_ctos_server_name(SSL *s, WPACKET *pkt,
-                                          unsigned int context, X509 *x,
-                                          size_t chainidx)
+                                          ossl_unused unsigned int unused__context,
+                                          ossl_unused X509 *unused__x,
+                                          ossl_unused size_t unused__chainidx)
 {
     if (s->ext.hostname == NULL)
         return EXT_RETURN_NOT_SENT;
@@ -65,8 +67,9 @@ EXT_RETURN tls_construct_ctos_server_name(SSL *s, WPACKET *pkt,
 
 /* Push a Max Fragment Len extension into ClientHello */
 EXT_RETURN tls_construct_ctos_maxfragmentlen(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             ossl_unused X509 *unused__x,
+                                             ossl_unused size_t unused__chainidx)
 {
     if (s->ext.max_fragment_len_mode == TLSEXT_max_fragment_length_DISABLED)
         return EXT_RETURN_NOT_SENT;
@@ -90,8 +93,10 @@ EXT_RETURN tls_construct_ctos_maxfragmentlen(SSL *s, WPACKET *pkt,
 }
 
 #ifndef OPENSSL_NO_SRP
-EXT_RETURN tls_construct_ctos_srp(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_srp(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     /* Add SRP username if there is one */
     if (s->srp_ctx.login == NULL)
@@ -161,8 +166,9 @@ static int use_ecc(SSL *s, int min_version, int max_version)
 }
 
 EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
-                                            unsigned int context, X509 *x,
-                                            size_t chainidx)
+                                            ossl_unused unsigned int unused__context,
+                                            ossl_unused X509 *unused__x,
+                                            ossl_unused size_t unused__chainidx)
 {
     const unsigned char *pformats;
     size_t num_formats;
@@ -196,8 +202,9 @@ EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
 
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
-                                               unsigned int context, X509 *x,
-                                               size_t chainidx)
+                                               ossl_unused unsigned int unused__context,
+                                               ossl_unused X509 *unused__x,
+                                               ossl_unused size_t unused__chainidx)
 {
     const uint16_t *pgroups = NULL;
     size_t num_groups = 0, i;
@@ -259,8 +266,9 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
 #endif
 
 EXT_RETURN tls_construct_ctos_session_ticket(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             ossl_unused X509 *unused__x,
+                                             ossl_unused size_t unused__chainidx)
 {
     size_t ticklen;
 
@@ -303,8 +311,9 @@ EXT_RETURN tls_construct_ctos_session_ticket(SSL *s, WPACKET *pkt,
 }
 
 EXT_RETURN tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt,
-                                       unsigned int context, X509 *x,
-                                       size_t chainidx)
+                                       ossl_unused unsigned int unused__context,
+                                       ossl_unused X509 *unused__x,
+                                       ossl_unused size_t unused__chainidx)
 {
     size_t salglen;
     const uint16_t *salg;
@@ -331,8 +340,9 @@ EXT_RETURN tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_OCSP
 EXT_RETURN tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             X509 *x,
+                                             ossl_unused size_t unused__chainidx)
 {
     int i;
 
@@ -404,8 +414,10 @@ EXT_RETURN tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
 #endif
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
-EXT_RETURN tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_npn(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (s->ctx->ext.npn_select_cb == NULL || !SSL_IS_FIRST_HANDSHAKE(s))
         return EXT_RETURN_NOT_SENT;
@@ -425,8 +437,10 @@ EXT_RETURN tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context,
 }
 #endif
 
-EXT_RETURN tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context,
-                                   X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_alpn(SSL *s, WPACKET *pkt,
+                                   ossl_unused unsigned int unused__context,
+                                   ossl_unused X509 *unused__x,
+                                   ossl_unused size_t unused__chainidx)
 {
     s->s3.alpn_sent = 0;
 
@@ -451,8 +465,9 @@ EXT_RETURN tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context,
 
 #ifndef OPENSSL_NO_SRTP
 EXT_RETURN tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt,
-                                       unsigned int context, X509 *x,
-                                       size_t chainidx)
+                                       ossl_unused unsigned int unused__context,
+                                       ossl_unused X509 *unused__x,
+                                       ossl_unused size_t unused__chainidx)
 {
     STACK_OF(SRTP_PROTECTION_PROFILE) *clnt = SSL_get_srtp_profiles(s);
     int i, end;
@@ -494,8 +509,10 @@ EXT_RETURN tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt,
 }
 #endif
 
-EXT_RETURN tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_etm(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)
         return EXT_RETURN_NOT_SENT;
@@ -511,8 +528,10 @@ EXT_RETURN tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context,
 }
 
 #ifndef OPENSSL_NO_CT
-EXT_RETURN tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_sct(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  X509 *x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (s->ct_validation_callback == NULL)
         return EXT_RETURN_NOT_SENT;
@@ -532,8 +551,10 @@ EXT_RETURN tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context,
 }
 #endif
 
-EXT_RETURN tls_construct_ctos_ems(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_ems(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (s->options & SSL_OP_NO_EXTENDED_MASTER_SECRET)
         return EXT_RETURN_NOT_SENT;
@@ -549,8 +570,9 @@ EXT_RETURN tls_construct_ctos_ems(SSL *s, WPACKET *pkt, unsigned int context,
 }
 
 EXT_RETURN tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
-                                                 unsigned int context, X509 *x,
-                                                 size_t chainidx)
+                                                 ossl_unused unsigned int unused__context,
+                                                 ossl_unused X509 *unused__x,
+                                                 ossl_unused size_t unused__chainidx)
 {
     int currv, min_version, max_version, reason;
 
@@ -599,8 +621,9 @@ EXT_RETURN tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
  * Construct a psk_kex_modes extension.
  */
 EXT_RETURN tls_construct_ctos_psk_kex_modes(SSL *s, WPACKET *pkt,
-                                            unsigned int context, X509 *x,
-                                            size_t chainidx)
+                                            ossl_unused unsigned int unused__context,
+                                            ossl_unused X509 *unused__x,
+                                            ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     int nodhe = s->options & SSL_OP_ALLOW_NO_DHE_KEX;
@@ -685,8 +708,9 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
 #endif
 
 EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
-                                        unsigned int context, X509 *x,
-                                        size_t chainidx)
+                                        ossl_unused unsigned int unused__context,
+                                        ossl_unused X509 *unused__x,
+                                        ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     size_t i, num_groups = 0;
@@ -745,8 +769,10 @@ EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
 #endif
 }
 
-EXT_RETURN tls_construct_ctos_cookie(SSL *s, WPACKET *pkt, unsigned int context,
-                                     X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_cookie(SSL *s, WPACKET *pkt,
+                                     ossl_unused unsigned int unused__context,
+                                     ossl_unused X509 *unused__x,
+                                     ossl_unused size_t unused__chainidx)
 {
     EXT_RETURN ret = EXT_RETURN_FAIL;
 
@@ -775,8 +801,9 @@ EXT_RETURN tls_construct_ctos_cookie(SSL *s, WPACKET *pkt, unsigned int context,
 }
 
 EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
-                                         unsigned int context, X509 *x,
-                                         size_t chainidx)
+                                         ossl_unused unsigned int unused__context,
+                                         ossl_unused X509 *unused__x,
+                                         ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_PSK
     char identity[PSK_MAX_IDENTITY_LEN + 1];
@@ -957,8 +984,9 @@ EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
 #define PSK_PRE_BINDER_OVERHEAD (2 + 2 + 2 + 2 + 4 + 2 + 1)
 
 EXT_RETURN tls_construct_ctos_padding(SSL *s, WPACKET *pkt,
-                                      unsigned int context, X509 *x,
-                                      size_t chainidx)
+                                      ossl_unused unsigned int unused__context,
+                                      ossl_unused X509 *unused__x,
+                                      ossl_unused size_t unused__chainidx)
 {
     unsigned char *padbytes;
     size_t hlen;
@@ -1027,8 +1055,10 @@ EXT_RETURN tls_construct_ctos_padding(SSL *s, WPACKET *pkt,
 /*
  * Construct the pre_shared_key extension
  */
-EXT_RETURN tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_ctos_psk(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     uint32_t now, agesec, agems = 0;
@@ -1233,8 +1263,9 @@ EXT_RETURN tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context,
 }
 
 EXT_RETURN tls_construct_ctos_post_handshake_auth(SSL *s, WPACKET *pkt,
-                                                  unsigned int context,
-                                                  X509 *x, size_t chainidx)
+                                                  ossl_unused unsigned int unused__context,
+                                                  ossl_unused X509 *unused__x,
+                                                  ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     if (!s->pha_enabled)
@@ -1262,8 +1293,10 @@ EXT_RETURN tls_construct_ctos_post_handshake_auth(SSL *s, WPACKET *pkt,
 /*
  * Parse the server's renegotiation binding and abort if it's not right
  */
-int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
-                               X509 *x, size_t chainidx)
+int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt,
+                               ossl_unused unsigned int unused__context,
+                               ossl_unused X509 *unused__x,
+                               ossl_unused size_t unused__chainidx)
 {
     size_t expected_len = s->s3.previous_client_finished_len
         + s->s3.previous_server_finished_len;
@@ -1322,8 +1355,10 @@ int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
 }
 
 /* Parse the server's max fragment len extension packet */
-int tls_parse_stoc_maxfragmentlen(SSL *s, PACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+int tls_parse_stoc_maxfragmentlen(SSL *s, PACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     unsigned int value;
 
@@ -1363,8 +1398,10 @@ int tls_parse_stoc_maxfragmentlen(SSL *s, PACKET *pkt, unsigned int context,
     return 1;
 }
 
-int tls_parse_stoc_server_name(SSL *s, PACKET *pkt, unsigned int context,
-                               X509 *x, size_t chainidx)
+int tls_parse_stoc_server_name(SSL *s, PACKET *pkt,
+                               ossl_unused unsigned int unused__context,
+                               ossl_unused X509 *unused__x,
+                               ossl_unused size_t unused__chainidx)
 {
     if (s->ext.hostname == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_SERVER_NAME,
@@ -1396,8 +1433,10 @@ int tls_parse_stoc_server_name(SSL *s, PACKET *pkt, unsigned int context,
 }
 
 #ifndef OPENSSL_NO_EC
-int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
-                                 X509 *x, size_t chainidx)
+int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt,
+                                 ossl_unused unsigned int unused__context,
+                                 ossl_unused X509 *unused__x,
+                                 ossl_unused size_t unused__chainidx)
 {
     size_t ecpointformats_len;
     PACKET ecptformatlist;
@@ -1439,8 +1478,10 @@ int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 }
 #endif
 
-int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (s->ext.session_ticket_cb != NULL &&
         !s->ext.session_ticket_cb(s, PACKET_data(pkt),
@@ -1468,8 +1509,10 @@ int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
 }
 
 #ifndef OPENSSL_NO_OCSP
-int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+int tls_parse_stoc_status_request(SSL *s, PACKET *pkt,
+                                  unsigned int context,
+                                  ossl_unused X509 *unused__x,
+                                  size_t chainidx)
 {
     if (context == SSL_EXT_TLS1_3_CERTIFICATE_REQUEST) {
         /* We ignore this if the server sends a CertificateRequest */
@@ -1512,8 +1555,8 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
 
 
 #ifndef OPENSSL_NO_CT
-int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx)
 {
     if (context == SSL_EXT_TLS1_3_CERTIFICATE_REQUEST) {
         /* We ignore this if the server sends it in a CertificateRequest */
@@ -1595,8 +1638,10 @@ static int ssl_next_proto_validate(SSL *s, PACKET *pkt)
     return 1;
 }
 
-int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_stoc_npn(SSL *s, PACKET *pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     unsigned char *selected;
     unsigned char selected_len;
@@ -1649,8 +1694,10 @@ int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 #endif
 
-int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                        size_t chainidx)
+int tls_parse_stoc_alpn(SSL *s, PACKET *pkt,
+                        ossl_unused unsigned int unused__context,
+                        ossl_unused X509 *unused__x,
+                        ossl_unused size_t unused__chainidx)
 {
     size_t len;
 
@@ -1718,8 +1765,10 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 #ifndef OPENSSL_NO_SRTP
-int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                            size_t chainidx)
+int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt,
+                            ossl_unused unsigned int unused__context,
+                            ossl_unused X509 *unused__x,
+                            ossl_unused size_t unused__chainidx)
 {
     unsigned int id, ct, mki;
     int i;
@@ -1769,8 +1818,10 @@ int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 #endif
 
-int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_stoc_etm(SSL *s, ossl_unused PACKET *unused__pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     /* Ignore if inappropriate ciphersuite */
     if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)
@@ -1781,8 +1832,10 @@ int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     return 1;
 }
 
-int tls_parse_stoc_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_stoc_ems(SSL *s, ossl_unused PACKET *unused__pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     if (s->options & SSL_OP_NO_EXTENDED_MASTER_SECRET)
         return 1;
@@ -1794,7 +1847,7 @@ int tls_parse_stoc_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 int tls_parse_stoc_supported_versions(SSL *s, PACKET *pkt, unsigned int context,
-                                      X509 *x, size_t chainidx)
+                                      ossl_unused X509 *unused__x, ossl_unused size_t unused__chainidx)
 {
     unsigned int version;
 
@@ -1827,8 +1880,9 @@ int tls_parse_stoc_supported_versions(SSL *s, PACKET *pkt, unsigned int context,
     return 1;
 }
 
-int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                             size_t chainidx)
+int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context,
+                             ossl_unused X509 *unused__x,
+                             ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     unsigned int group_id;
@@ -1930,8 +1984,10 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     return 1;
 }
 
-int tls_parse_stoc_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_stoc_cookie(SSL *s, PACKET *pkt,
+                          ossl_unused unsigned int unused__context,
+                          ossl_unused X509 *unused__x,
+                          ossl_unused size_t unused__chainidx)
 {
     PACKET cookie;
 
@@ -1947,7 +2003,7 @@ int tls_parse_stoc_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 int tls_parse_stoc_early_data(SSL *s, PACKET *pkt, unsigned int context,
-                              X509 *x, size_t chainidx)
+                              ossl_unused X509 *unused__x, ossl_unused size_t unused__chainidx)
 {
     if (context == SSL_EXT_TLS1_3_NEW_SESSION_TICKET) {
         unsigned long max_early_data;
@@ -1987,8 +2043,10 @@ int tls_parse_stoc_early_data(SSL *s, PACKET *pkt, unsigned int context,
     return 1;
 }
 
-int tls_parse_stoc_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_stoc_psk(SSL *s, PACKET *pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     unsigned int identity;

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -29,10 +29,13 @@ typedef struct {
  * Provide thin wrapper callbacks which convert new style arguments to old style
  */
 static int custom_ext_add_old_cb_wrap(SSL *s, unsigned int ext_type,
-                                      unsigned int context,
+                                      ossl_unused unsigned int unused__context,
                                       const unsigned char **out,
-                                      size_t *outlen, X509 *x, size_t chainidx,
-                                      int *al, void *add_arg)
+                                      size_t *outlen,
+                                      ossl_unused X509 *unused__x,
+                                      ossl_unused size_t unused__chainidx,
+                                      int *al,
+                                      void *add_arg)
 {
     custom_ext_add_cb_wrap *add_cb_wrap = (custom_ext_add_cb_wrap *)add_arg;
 
@@ -44,7 +47,7 @@ static int custom_ext_add_old_cb_wrap(SSL *s, unsigned int ext_type,
 }
 
 static void custom_ext_free_old_cb_wrap(SSL *s, unsigned int ext_type,
-                                        unsigned int context,
+                                        ossl_unused unsigned int unused__context,
                                         const unsigned char *out, void *add_arg)
 {
     custom_ext_add_cb_wrap *add_cb_wrap = (custom_ext_add_cb_wrap *)add_arg;
@@ -56,10 +59,13 @@ static void custom_ext_free_old_cb_wrap(SSL *s, unsigned int ext_type,
 }
 
 static int custom_ext_parse_old_cb_wrap(SSL *s, unsigned int ext_type,
-                                        unsigned int context,
+                                        ossl_unused unsigned int unused__context,
                                         const unsigned char *in,
-                                        size_t inlen, X509 *x, size_t chainidx,
-                                        int *al, void *parse_arg)
+                                        size_t inlen,
+                                        ossl_unused X509 *unused__x,
+                                        ossl_unused size_t unused__chainidx,
+                                        int *al,
+                                        void *parse_arg)
 {
     custom_ext_parse_cb_wrap *parse_cb_wrap =
         (custom_ext_parse_cb_wrap *)parse_arg;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -42,8 +42,10 @@ DEFINE_STACK_OF(X509_EXTENSION)
 /*
  * Parse the client's renegotiation binding and abort if it's not right
  */
-int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
-                               X509 *x, size_t chainidx)
+int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt,
+                               ossl_unused unsigned int unused__context,
+                               ossl_unused X509 *unused__x,
+                               ossl_unused size_t unused__chainidx)
 {
     unsigned int ilen;
     const unsigned char *data;
@@ -98,8 +100,10 @@ int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
  *   extension.
  * - On session reconnect, the servername extension may be absent.
  */
-int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
-                               X509 *x, size_t chainidx)
+int tls_parse_ctos_server_name(SSL *s, PACKET *pkt,
+                               ossl_unused unsigned int unused__context,
+                               ossl_unused X509 *unused__x,
+                               ossl_unused size_t unused__chainidx)
 {
     unsigned int servname_type;
     PACKET sni, hostname;
@@ -181,8 +185,10 @@ int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
     return 1;
 }
 
-int tls_parse_ctos_maxfragmentlen(SSL *s, PACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+int tls_parse_ctos_maxfragmentlen(SSL *s, PACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     unsigned int value;
 
@@ -221,8 +227,10 @@ int tls_parse_ctos_maxfragmentlen(SSL *s, PACKET *pkt, unsigned int context,
 }
 
 #ifndef OPENSSL_NO_SRP
-int tls_parse_ctos_srp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_ctos_srp(SSL *s, PACKET *pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     PACKET srp_I;
 
@@ -249,8 +257,10 @@ int tls_parse_ctos_srp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 #endif
 
 #ifndef OPENSSL_NO_EC
-int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
-                                 X509 *x, size_t chainidx)
+int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt,
+                                 ossl_unused unsigned int unused__context,
+                                 ossl_unused X509 *unused__x,
+                                 ossl_unused size_t unused__chainidx)
 {
     PACKET ec_point_format_list;
 
@@ -275,8 +285,10 @@ int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
 }
 #endif                          /* OPENSSL_NO_EC */
 
-int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (s->ext.session_ticket_cb &&
             !s->ext.session_ticket_cb(s, PACKET_data(pkt),
@@ -290,8 +302,10 @@ int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
     return 1;
 }
 
-int tls_parse_ctos_sig_algs_cert(SSL *s, PACKET *pkt, unsigned int context,
-                                 X509 *x, size_t chainidx)
+int tls_parse_ctos_sig_algs_cert(SSL *s, PACKET *pkt,
+                                 ossl_unused unsigned int unused__context,
+                                 ossl_unused X509 *unused__x,
+                                 ossl_unused size_t unused__chainidx)
 {
     PACKET supported_sig_algs;
 
@@ -311,8 +325,10 @@ int tls_parse_ctos_sig_algs_cert(SSL *s, PACKET *pkt, unsigned int context,
     return 1;
 }
 
-int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                            size_t chainidx)
+int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt,
+                            ossl_unused unsigned int unused__context,
+                            ossl_unused X509 *unused__x,
+                            ossl_unused size_t unused__chainidx)
 {
     PACKET supported_sig_algs;
 
@@ -333,8 +349,10 @@ int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 #ifndef OPENSSL_NO_OCSP
-int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+int tls_parse_ctos_status_request(SSL *s, PACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  X509 *x,
+                                  ossl_unused size_t unused__chainidx)
 {
     PACKET responder_id_list, exts;
 
@@ -447,8 +465,10 @@ int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
 #endif
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
-int tls_parse_ctos_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_ctos_npn(SSL *s, ossl_unused PACKET *unused__pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     /*
      * We shouldn't accept this extension on a
@@ -465,8 +485,10 @@ int tls_parse_ctos_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
  * Save the ALPN extension in a ClientHello.|pkt| holds the contents of the ALPN
  * extension, not including type and length. Returns: 1 on success, 0 on error.
  */
-int tls_parse_ctos_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                        size_t chainidx)
+int tls_parse_ctos_alpn(SSL *s, PACKET *pkt,
+                        ossl_unused unsigned int unused__context,
+                        ossl_unused X509 *unused__x,
+                        ossl_unused size_t unused__chainidx)
 {
     PACKET protocol_list, save_protocol_list, protocol;
 
@@ -505,8 +527,10 @@ int tls_parse_ctos_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 #ifndef OPENSSL_NO_SRTP
-int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                            size_t chainidx)
+int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt,
+                            ossl_unused unsigned int unused__context,
+                            ossl_unused X509 *unused__x,
+                            ossl_unused size_t unused__chainidx)
 {
     STACK_OF(SRTP_PROTECTION_PROFILE) *srvr;
     unsigned int ct, mki_len, id;
@@ -573,8 +597,10 @@ int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 #endif
 
-int tls_parse_ctos_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_ctos_etm(SSL *s, ossl_unused PACKET *unused__pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC))
         s->ext.use_etm = 1;
@@ -586,8 +612,10 @@ int tls_parse_ctos_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
  * Process a psk_kex_modes extension received in the ClientHello. |pkt| contains
  * the raw PACKET data for the extension. Returns 1 on success or 0 on failure.
  */
-int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
-                                 X509 *x, size_t chainidx)
+int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt,
+                                 ossl_unused unsigned int unused__context,
+                                 ossl_unused X509 *unused__x,
+                                 ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     PACKET psk_kex_modes;
@@ -616,8 +644,10 @@ int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
  * Process a key_share extension received in the ClientHello. |pkt| contains
  * the raw PACKET data for the extension. Returns 1 on success or 0 on failure.
  */
-int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                             size_t chainidx)
+int tls_parse_ctos_key_share(SSL *s, PACKET *pkt,
+                             ossl_unused unsigned int unused__context,
+                             ossl_unused X509 *unused__x,
+                             ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     unsigned int group_id;
@@ -732,8 +762,10 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     return 1;
 }
 
-int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                          size_t chainidx)
+int tls_parse_ctos_cookie(SSL *s, PACKET *pkt,
+                          ossl_unused unsigned int unused__context,
+                          ossl_unused X509 *unused__x,
+                          ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     unsigned int format, version, key_share, group_id;
@@ -957,8 +989,10 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
-                                    X509 *x, size_t chainidx)
+int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt,
+                                    ossl_unused unsigned int unused__context,
+                                    ossl_unused X509 *unused__x,
+                                    ossl_unused size_t unused__chainidx)
 {
     PACKET supported_groups_list;
 
@@ -989,8 +1023,10 @@ int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
 }
 #endif
 
-int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_ctos_ems(SSL *s, PACKET *pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     /* The extension must always be empty */
     if (PACKET_remaining(pkt) != 0) {
@@ -1008,8 +1044,10 @@ int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 }
 
 
-int tls_parse_ctos_early_data(SSL *s, PACKET *pkt, unsigned int context,
-                              X509 *x, size_t chainidx)
+int tls_parse_ctos_early_data(SSL *s, PACKET *pkt,
+                              ossl_unused unsigned int unused__context,
+                              ossl_unused X509 *unused__x,
+                              ossl_unused size_t unused__chainidx)
 {
     if (PACKET_remaining(pkt) != 0) {
         SSLfatal(s, SSL_AD_DECODE_ERROR,
@@ -1054,8 +1092,10 @@ static SSL_TICKET_STATUS tls_get_stateful_ticket(SSL *s, PACKET *tick,
     return SSL_TICKET_SUCCESS;
 }
 
-int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx)
+int tls_parse_ctos_psk(SSL *s, PACKET *pkt,
+                       ossl_unused unsigned int unused__context,
+                       ossl_unused X509 *unused__x,
+                       ossl_unused size_t unused__chainidx)
 {
     PACKET identities, binders, binder;
     size_t binderoffset, hashsize;
@@ -1298,8 +1338,10 @@ err:
     return 0;
 }
 
-int tls_parse_ctos_post_handshake_auth(SSL *s, PACKET *pkt, unsigned int context,
-                                       X509 *x, size_t chainidx)
+int tls_parse_ctos_post_handshake_auth(SSL *s, PACKET *pkt,
+                                       ossl_unused unsigned int unused__context,
+                                       ossl_unused X509 *unused__x,
+                                       ossl_unused size_t unused__chainidx)
 {
     if (PACKET_remaining(pkt) != 0) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_F_TLS_PARSE_CTOS_POST_HANDSHAKE_AUTH,
@@ -1316,8 +1358,9 @@ int tls_parse_ctos_post_handshake_auth(SSL *s, PACKET *pkt, unsigned int context
  * Add the server's renegotiation binding
  */
 EXT_RETURN tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt,
-                                          unsigned int context, X509 *x,
-                                          size_t chainidx)
+                                          ossl_unused unsigned int unused__context,
+                                          ossl_unused X509 *unused__x,
+                                          ossl_unused size_t unused__chainidx)
 {
     if (!s->s3.send_connection_binding)
         return EXT_RETURN_NOT_SENT;
@@ -1341,8 +1384,9 @@ EXT_RETURN tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt,
 }
 
 EXT_RETURN tls_construct_stoc_server_name(SSL *s, WPACKET *pkt,
-                                          unsigned int context, X509 *x,
-                                          size_t chainidx)
+                                          ossl_unused unsigned int unused__context,
+                                          ossl_unused X509 *unused__x,
+                                          ossl_unused size_t unused__chainidx)
 {
     if (s->servername_done != 1)
         return EXT_RETURN_NOT_SENT;
@@ -1366,8 +1410,9 @@ EXT_RETURN tls_construct_stoc_server_name(SSL *s, WPACKET *pkt,
 
 /* Add/include the server's max fragment len extension into ServerHello */
 EXT_RETURN tls_construct_stoc_maxfragmentlen(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             ossl_unused X509 *unused__x,
+                                             ossl_unused size_t unused__chainidx)
 {
     if (!USE_MAX_FRAGMENT_LENGTH_EXT(s->session))
         return EXT_RETURN_NOT_SENT;
@@ -1390,8 +1435,9 @@ EXT_RETURN tls_construct_stoc_maxfragmentlen(SSL *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_EC
 EXT_RETURN tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt,
-                                            unsigned int context, X509 *x,
-                                            size_t chainidx)
+                                            ossl_unused unsigned int unused__context,
+                                            ossl_unused X509 *unused__x,
+                                            ossl_unused size_t unused__chainidx)
 {
     unsigned long alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
     unsigned long alg_a = s->s3.tmp.new_cipher->algorithm_auth;
@@ -1419,8 +1465,9 @@ EXT_RETURN tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt,
 
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
 EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
-                                               unsigned int context, X509 *x,
-                                               size_t chainidx)
+                                               ossl_unused unsigned int unused__context,
+                                               ossl_unused X509 *unused__x,
+                                               ossl_unused size_t unused__chainidx)
 {
     const uint16_t *groups;
     size_t numgroups, i, first = 1;
@@ -1487,8 +1534,9 @@ EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
 #endif
 
 EXT_RETURN tls_construct_stoc_session_ticket(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             ossl_unused X509 *unused__x,
+                                             ossl_unused size_t unused__chainidx)
 {
     if (!s->ext.ticket_expected || !tls_use_ticket(s)) {
         s->ext.ticket_expected = 0;
@@ -1507,7 +1555,8 @@ EXT_RETURN tls_construct_stoc_session_ticket(SSL *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_OCSP
 EXT_RETURN tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
+                                             unsigned int context,
+                                             ossl_unused X509 *unused__x,
                                              size_t chainidx)
 {
     /* We don't currently support this extension inside a CertificateRequest */
@@ -1548,8 +1597,9 @@ EXT_RETURN tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
 EXT_RETURN tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
-                                             unsigned int context, X509 *x,
-                                             size_t chainidx)
+                                             ossl_unused unsigned int unused__context,
+                                             ossl_unused X509 *unused__x,
+                                             ossl_unused size_t unused__chainidx)
 {
     const unsigned char *npa;
     unsigned int npalen;
@@ -1577,8 +1627,10 @@ EXT_RETURN tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
 }
 #endif
 
-EXT_RETURN tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context,
-                                   X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_stoc_alpn(SSL *s, WPACKET *pkt,
+                                   ossl_unused unsigned int unused__context,
+                                   ossl_unused X509 *unused__x,
+                                   ossl_unused size_t unused__chainidx)
 {
     if (s->s3.alpn_selected == NULL)
         return EXT_RETURN_NOT_SENT;
@@ -1601,8 +1653,9 @@ EXT_RETURN tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context,
 
 #ifndef OPENSSL_NO_SRTP
 EXT_RETURN tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt,
-                                       unsigned int context, X509 *x,
-                                       size_t chainidx)
+                                       ossl_unused unsigned int unused__context,
+                                       ossl_unused X509 *unused__x,
+                                       ossl_unused size_t unused__chainidx)
 {
     if (s->srtp_profile == NULL)
         return EXT_RETURN_NOT_SENT;
@@ -1622,8 +1675,10 @@ EXT_RETURN tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt,
 }
 #endif
 
-EXT_RETURN tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_stoc_etm(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (!s->ext.use_etm)
         return EXT_RETURN_NOT_SENT;
@@ -1652,8 +1707,10 @@ EXT_RETURN tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context,
     return EXT_RETURN_SENT;
 }
 
-EXT_RETURN tls_construct_stoc_ems(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_stoc_ems(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if ((s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS) == 0)
         return EXT_RETURN_NOT_SENT;
@@ -1669,8 +1726,9 @@ EXT_RETURN tls_construct_stoc_ems(SSL *s, WPACKET *pkt, unsigned int context,
 }
 
 EXT_RETURN tls_construct_stoc_supported_versions(SSL *s, WPACKET *pkt,
-                                                 unsigned int context, X509 *x,
-                                                 size_t chainidx)
+                                                 ossl_unused unsigned int unused__context,
+                                                 ossl_unused X509 *unused__x,
+                                                 ossl_unused size_t unused__chainidx)
 {
     if (!ossl_assert(SSL_IS_TLS13(s))) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
@@ -1693,8 +1751,9 @@ EXT_RETURN tls_construct_stoc_supported_versions(SSL *s, WPACKET *pkt,
 }
 
 EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
-                                        unsigned int context, X509 *x,
-                                        size_t chainidx)
+                                        ossl_unused unsigned int unused__context,
+                                        ossl_unused X509 *unused__x,
+                                        ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     unsigned char *encodedPoint;
@@ -1775,8 +1834,10 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
 #endif
 }
 
-EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
-                                     X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt,
+                                     ossl_unused unsigned int unused__context,
+                                     ossl_unused X509 *unused__x,
+                                     ossl_unused size_t unused__chainidx)
 {
 #ifndef OPENSSL_NO_TLS1_3
     unsigned char *hashval1, *hashval2, *appcookie1, *appcookie2, *cookie;
@@ -1911,8 +1972,9 @@ EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
 }
 
 EXT_RETURN tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt,
-                                            unsigned int context, X509 *x,
-                                            size_t chainidx)
+                                            ossl_unused unsigned int unused__context,
+                                            ossl_unused X509 *unused__x,
+                                            ossl_unused size_t unused__chainidx)
 {
     const unsigned char cryptopro_ext[36] = {
         0xfd, 0xe8,         /* 65000 */
@@ -1938,8 +2000,9 @@ EXT_RETURN tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt,
 }
 
 EXT_RETURN tls_construct_stoc_early_data(SSL *s, WPACKET *pkt,
-                                         unsigned int context, X509 *x,
-                                         size_t chainidx)
+                                         unsigned int context,
+                                         ossl_unused X509 *unused__x,
+                                         ossl_unused size_t unused__chainidx)
 {
     if (context == SSL_EXT_TLS1_3_NEW_SESSION_TICKET) {
         if (s->max_early_data == 0)
@@ -1971,8 +2034,10 @@ EXT_RETURN tls_construct_stoc_early_data(SSL *s, WPACKET *pkt,
     return EXT_RETURN_SENT;
 }
 
-EXT_RETURN tls_construct_stoc_psk(SSL *s, WPACKET *pkt, unsigned int context,
-                                  X509 *x, size_t chainidx)
+EXT_RETURN tls_construct_stoc_psk(SSL *s, WPACKET *pkt,
+                                  ossl_unused unsigned int unused__context,
+                                  ossl_unused X509 *unused__x,
+                                  ossl_unused size_t unused__chainidx)
 {
     if (!s->hit)
         return EXT_RETURN_NOT_SENT;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -115,7 +115,7 @@ void ossl_statem_set_renegotiate(SSL *s)
  * Put the state machine into an error state and send an alert if appropriate.
  * This is a permanent error for the current connection.
  */
-void ossl_statem_fatal(SSL *s, int al, int func, int reason, const char *file,
+void ossl_statem_fatal(SSL *s, int al, ossl_unused int unused__func, int reason, const char *file,
                        int line)
 {
     ERR_raise(ERR_LIB_SSL, reason);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -736,7 +736,7 @@ WORK_STATE ossl_statem_client_pre_work(SSL *s, WORK_STATE wst)
  * Perform any work that needs to be done after sending a message from the
  * client to the server.
  */
-WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst)
+WORK_STATE ossl_statem_client_post_work(SSL *s, ossl_unused WORK_STATE unused__wst)
 {
     OSSL_STATEM *st = &s->statem;
 
@@ -890,7 +890,7 @@ WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst)
  *   1: Success
  *   0: Error
  */
-int ossl_statem_client_construct_message(SSL *s, WPACKET *pkt,
+int ossl_statem_client_construct_message(SSL *s, ossl_unused WPACKET *unused__pkt,
                                          confunc_f *confunc, int *mt)
 {
     OSSL_STATEM *st = &s->statem;
@@ -3986,7 +3986,7 @@ int ssl_cipher_list_to_bytes(SSL *s, STACK_OF(SSL_CIPHER) *sk, WPACKET *pkt)
     return 1;
 }
 
-int tls_construct_end_of_early_data(SSL *s, WPACKET *pkt)
+int tls_construct_end_of_early_data(SSL *s, ossl_unused WPACKET *unused__pkt)
 {
     if (s->early_data_state != SSL_EARLY_DATA_WRITE_RETRY
             && s->early_data_state != SSL_EARLY_DATA_FINISHED_WRITING) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1057,7 +1057,7 @@ unsigned long ssl3_output_cert_chain(SSL *s, WPACKET *pkt, CERT_PKEY *cpk)
  * in NBIO events. If |clearbufs| is set then init_buf and the wbio buffer is
  * freed up as well.
  */
-WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs, int stop)
+WORK_STATE tls_finish_handshake(SSL *s, ossl_unused WORK_STATE unused__wst, int clearbufs, int stop)
 {
     void (*cb) (const SSL *ssl, int type, int val) = NULL;
     int cleanuphand = s->statem.cleanuphand;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -818,7 +818,7 @@ static ossl_inline int conn_is_closed(void)
  * Perform any work that needs to be done after sending a message from the
  * server to the client.
  */
-WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
+WORK_STATE ossl_statem_server_post_work(SSL *s, ossl_unused WORK_STATE unused__wst)
 {
     OSSL_STATEM *st = &s->statem;
 
@@ -1028,7 +1028,7 @@ WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst)
  *   1: Success
  *   0: Error
  */
-int ossl_statem_server_construct_message(SSL *s, WPACKET *pkt,
+int ossl_statem_server_construct_message(SSL *s, ossl_unused WPACKET *unused__pkt,
                                          confunc_f *confunc, int *mt)
 {
     OSSL_STATEM *st = &s->statem;
@@ -2488,7 +2488,7 @@ int tls_construct_server_hello(SSL *s, WPACKET *pkt)
     return 1;
 }
 
-int tls_construct_server_done(SSL *s, WPACKET *pkt)
+int tls_construct_server_done(SSL *s, ossl_unused WPACKET *unused__pkt)
 {
     if (!s->s3.tmp.cert_request) {
         if (!ssl3_digest_cached_records(s, 0)) {
@@ -3594,6 +3594,8 @@ WORK_STATE tls_post_process_client_key_exchange(SSL *s, WORK_STATE wst)
                      sizeof(sctpauthkey), sctpauthkey);
         }
     }
+#else
+    (void)wst; /* silence -Wunused-parameter */
 #endif
 
     if (s->statem.no_cert_verify || !s->session->peer) {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1426,7 +1426,7 @@ static int sigalg_security_bits(SSL_CTX *ctx, const SIGALG_LOOKUP *lu)
          * SHA1 at 2^63.4 and MD5+SHA1 at 2^67.2
          * https://documents.epfl.ch/users/l/le/lenstra/public/papers/lat.pdf
          * puts a chosen-prefix attack for MD5 at 2^39.
-	 */
+         */
         if (md_type == NID_sha1)
             secbits = 64;
         else if (md_type == NID_md5_sha1)
@@ -3483,4 +3483,3 @@ size_t ssl_hmac_size(const SSL_HMAC *ctx)
 #endif
     return 0;
 }
-

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -297,7 +297,7 @@ int tls13_generate_handshake_secret(SSL *s, const unsigned char *insecret,
  * failure.
  */
 int tls13_generate_master_secret(SSL *s, unsigned char *out,
-                                 unsigned char *prev, size_t prevlen,
+                                 unsigned char *prev, ossl_unused size_t unused__prevlen,
                                  size_t *secret_size)
 {
     const EVP_MD *md = ssl_handshake_md(s);
@@ -311,7 +311,7 @@ int tls13_generate_master_secret(SSL *s, unsigned char *out,
  * Generates the mac for the Finished message. Returns the length of the MAC or
  * 0 on error.
  */
-size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
+size_t tls13_final_finish_mac(SSL *s, const char *str, ossl_unused size_t unused__slen,
                              unsigned char *out)
 {
     const char *mdname = EVP_MD_name(ssl_handshake_md(s));

--- a/test/aborttest.c
+++ b/test/aborttest.c
@@ -9,7 +9,7 @@
 
 #include <openssl/crypto.h>
 
-int main(int argc, char **argv)
+int main(ossl_unused int unused__argc, ossl_unused char **unused__argv)
 {
     OPENSSL_die("Voluntary abort", __FILE__, __LINE__);
     return 0;

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -80,7 +80,9 @@ err:
 
 #if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DSA)                        \
     || !defined(OPENSSL_NO_RSA)
-static int sig_gen(EVP_PKEY *pkey, OSSL_PARAM *params, const char *digest_name,
+static int sig_gen(EVP_PKEY *pkey,
+                   ossl_unused OSSL_PARAM *unused__params,
+                   const char *digest_name,
                    const unsigned char *msg, size_t msg_len,
                    unsigned char **sig_out, size_t *sig_out_len)
 {
@@ -669,8 +671,8 @@ err:
 /* cipher encrypt/decrypt */
 static int cipher_enc(const char *alg,
                       const unsigned char *pt, size_t pt_len,
-                      const unsigned char *key, size_t key_len,
-                      const unsigned char *iv, size_t iv_len,
+                      const unsigned char *key, ossl_unused size_t unused__key_len,
+                      const unsigned char *iv, ossl_unused size_t unused__iv_len,
                       const unsigned char *ct, size_t ct_len,
                       int enc)
 {
@@ -714,7 +716,7 @@ static int cipher_enc_dec_test(int id)
 
 static int aes_ccm_enc_dec(const char *alg,
                            const unsigned char *pt, size_t pt_len,
-                           const unsigned char *key, size_t key_len,
+                           const unsigned char *key, ossl_unused size_t unused__key_len,
                            const unsigned char *iv, size_t iv_len,
                            const unsigned char *aad, size_t aad_len,
                            const unsigned char *ct, size_t ct_len,
@@ -801,7 +803,7 @@ static int aes_ccm_enc_dec_test(int id)
 
 static int aes_gcm_enc_dec(const char *alg,
                            const unsigned char *pt, size_t pt_len,
-                           const unsigned char *key, size_t key_len,
+                           const unsigned char *key, ossl_unused size_t unused__key_len,
                            const unsigned char *iv, size_t iv_len,
                            const unsigned char *aad, size_t aad_len,
                            const unsigned char *ct, size_t ct_len,

--- a/test/asynciotest.c
+++ b/test/asynciotest.c
@@ -273,7 +273,7 @@ static long async_ctrl(BIO *bio, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int async_gets(BIO *bio, char *buf, int size)
+static int async_gets(ossl_unused BIO *unused__bio, ossl_unused char *unused__buf, ossl_unused int unused__size)
 {
     /* We don't support this - not needed anyway */
     return -1;

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -19,14 +19,14 @@
 static int ctr = 0;
 static ASYNC_JOB *currjob = NULL;
 
-static int only_pause(void *args)
+static int only_pause(ossl_unused void *unused__args)
 {
     ASYNC_pause_job();
 
     return 1;
 }
 
-static int add_two(void *args)
+static int add_two(ossl_unused void *unused__args)
 {
     ctr++;
     ASYNC_pause_job();
@@ -35,7 +35,7 @@ static int add_two(void *args)
     return 2;
 }
 
-static int save_current(void *args)
+static int save_current(ossl_unused void *unused__args)
 {
     currjob = ASYNC_get_current_job();
     ASYNC_pause_job();
@@ -43,7 +43,7 @@ static int save_current(void *args)
     return 1;
 }
 
-static int change_deflt_libctx(void *args)
+static int change_deflt_libctx(ossl_unused void *unused__args)
 {
     OPENSSL_CTX *libctx = OPENSSL_CTX_new();
     OPENSSL_CTX *oldctx, *tmpctx;
@@ -77,7 +77,7 @@ static int change_deflt_libctx(void *args)
 
 
 #define MAGIC_WAIT_FD   ((OSSL_ASYNC_FD)99)
-static int waitfd(void *args)
+static int waitfd(ossl_unused void *unused__args)
 {
     ASYNC_JOB *job;
     ASYNC_WAIT_CTX *waitctx;
@@ -110,7 +110,7 @@ static int waitfd(void *args)
     return 1;
 }
 
-static int blockpause(void *args)
+static int blockpause(ossl_unused void *unused__args)
 {
     ASYNC_block_pause();
     ASYNC_pause_job();
@@ -156,7 +156,7 @@ static int test_ASYNC_init_thread(void)
     return 1;
 }
 
-static int test_callback(void *arg)
+static int test_callback(ossl_unused void *unused__arg)
 {
     printf("callback test pass\n");
     return 1;
@@ -413,7 +413,7 @@ static int test_ASYNC_start_job_with_libctx(void)
     return ret;
 }
 
-int main(int argc, char **argv)
+int main(ossl_unused int unused__argc, ossl_unused char **unused__argv)
 {
     if (!ASYNC_is_capable()) {
         fprintf(stderr,

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -354,7 +354,7 @@ static int send_record(BIO *rbio, unsigned char type, uint64_t seqnr,
     return 1;
 }
 
-static int send_finished(SSL *s, BIO *rbio)
+static int send_finished(ossl_unused SSL *unused__ssl, BIO *rbio)
 {
     static unsigned char finished_msg[DTLS1_HM_HEADER_LENGTH +
                                       TLS1_FINISH_MAC_LENGTH] = {

--- a/test/bio_prefix_text.c
+++ b/test/bio_prefix_text.c
@@ -91,7 +91,7 @@ static int run_pipe(void)
     return 1;
 }
 
-static int setup_bio_chain(const char *progname)
+static int setup_bio_chain(ossl_unused const char *unused__progname)
 {
     BIO *next = NULL;
     size_t n = amount;

--- a/test/cmp_asn_test.c
+++ b/test/cmp_asn_test.c
@@ -40,7 +40,7 @@ static void tear_down(CMP_ASN_TEST_FIXTURE *fixture)
     OPENSSL_free(fixture);
 }
 
-static int execute_cmp_asn1_get_int_test(CMP_ASN_TEST_FIXTURE *fixture)
+static int execute_cmp_asn1_get_int_test(ossl_unused CMP_ASN_TEST_FIXTURE *unused__fixture)
 {
     ASN1_INTEGER *asn1integer = ASN1_INTEGER_new();
     ASN1_INTEGER_set(asn1integer, 77);

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -120,8 +120,11 @@ static int test_CTX_reinit(void)
 #if !defined(OPENSSL_NO_ERR) && !defined(OPENSSL_NO_AUTOERRINIT)
 
 static int msg_total_size = 0;
-static int msg_total_size_log_cb(const char *func, const char *file, int line,
-                                 OSSL_CMP_severity level, const char *msg)
+static int msg_total_size_log_cb(ossl_unused const char *unused__func,
+                                 ossl_unused const char *unused__file,
+                                 ossl_unused int unused__line,
+                                 ossl_unused OSSL_CMP_severity unused__level,
+                                 const char *msg)
 {
     msg_total_size += strlen(msg);
     TEST_note("total=%d len=%zu msg='%s'\n", msg_total_size, strlen(msg), msg);
@@ -305,19 +308,22 @@ static int test_cmp_ctx_log_cb(void)
     return result;
 }
 
-static BIO *test_http_cb(BIO *bio, void *arg, int use_ssl, int detail)
+static BIO *test_http_cb(ossl_unused BIO *unused__bio, ossl_unused void *unused__arg,
+                         ossl_unused int unused__use_ssl, ossl_unused int unused__detail)
 {
     return NULL;
 }
 
-static OSSL_CMP_MSG *test_transfer_cb(OSSL_CMP_CTX *ctx,
-                                      const OSSL_CMP_MSG *req)
+static OSSL_CMP_MSG *test_transfer_cb(ossl_unused OSSL_CMP_CTX *unused__ctx,
+                                      ossl_unused const OSSL_CMP_MSG *unused__req)
 {
     return NULL;
 }
 
-static int test_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
-                            const char **txt)
+static int test_certConf_cb(ossl_unused OSSL_CMP_CTX *unused__ctx,
+                            ossl_unused X509 *unused__cert,
+                            ossl_unused int unused__fail_info,
+                            ossl_unused const char **unused__txt)
 {
     return 0;
 }

--- a/test/cmp_server_test.c
+++ b/test/cmp_server_test.c
@@ -46,14 +46,14 @@ static CMP_SRV_TEST_FIXTURE *set_up(const char *const test_case_name)
 
 static int dummy_errorCode = CMP_R_MULTIPLE_SAN_SOURCES; /* any reason code */
 
-static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
-                                            const OSSL_CMP_MSG *cert_req,
-                                            int certReqId,
-                                            const OSSL_CRMF_MSG *crm,
-                                            const X509_REQ *p10cr,
-                                            X509 **certOut,
-                                            STACK_OF(X509) **chainOut,
-                                            STACK_OF(X509) **caPubs)
+static OSSL_CMP_PKISI *process_cert_request(ossl_unused OSSL_CMP_SRV_CTX *unused__srv_ctx,
+                                            ossl_unused const OSSL_CMP_MSG *unused__cert_req,
+                                            ossl_unused int unused__certReqId,
+                                            ossl_unused const OSSL_CRMF_MSG *unused__crm,
+                                            ossl_unused const X509_REQ *unused__p10cr,
+                                            ossl_unused X509 **unused__certOut,
+                                            ossl_unused STACK_OF(X509) **chainOut,
+                                            ossl_unused STACK_OF(X509) **caPubs)
 {
     CMPerr(0, dummy_errorCode);
     return NULL;

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -427,8 +427,10 @@ static int execute_msg_check_test(CMP_VFY_TEST_FIXTURE *fixture)
                                              fixture->cmp_ctx->transactionID));
 }
 
-static int allow_unprotected(const OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
-                             int invalid_protection, int allow)
+static int allow_unprotected(ossl_unused const OSSL_CMP_CTX *unused__ctx,
+                             ossl_unused const OSSL_CMP_MSG *unused__msg,
+                             ossl_unused int unused__invalid_protection,
+                             int allow)
 {
     return allow;
 }

--- a/test/confdump.c
+++ b/test/confdump.c
@@ -51,7 +51,7 @@ static void dump_section(const char *name, const CONF *cnf)
     }
 }
 
-int main(int argc, char **argv)
+int main(ossl_unused int unused__argc, char **argv)
 {
     long eline;
     CONF *conf = NCONF_new(NCONF_default());

--- a/test/constant_time_test.c
+++ b/test/constant_time_test.c
@@ -59,7 +59,8 @@ static uint64_t test_values_64[] = {
 };
 
 static int test_binary_op(unsigned int (*op) (unsigned int a, unsigned int b),
-                          const char *op_name, unsigned int a, unsigned int b,
+                          ossl_unused const char *unused__op_name,
+                          unsigned int a, unsigned int b,
                           int is_true)
 {
     if (is_true && !TEST_uint_eq(op(a, b), CONSTTIME_TRUE))
@@ -71,7 +72,8 @@ static int test_binary_op(unsigned int (*op) (unsigned int a, unsigned int b),
 
 static int test_binary_op_8(unsigned
                             char (*op) (unsigned int a, unsigned int b),
-                            const char *op_name, unsigned int a,
+                            ossl_unused const char *unused__op_name,
+                            unsigned int a,
                             unsigned int b, int is_true)
 {
     if (is_true && !TEST_uint_eq(op(a, b), CONSTTIME_TRUE_8))
@@ -82,7 +84,8 @@ static int test_binary_op_8(unsigned
 }
 
 static int test_binary_op_s(size_t (*op) (size_t a, size_t b),
-                            const char *op_name, size_t a, size_t b,
+                            ossl_unused const char *unused__op_name,
+                            size_t a, size_t b,
                             int is_true)
 {
     if (is_true && !TEST_size_t_eq(op(a,b), CONSTTIME_TRUE_S))

--- a/test/context_internal_test.c
+++ b/test/context_internal_test.c
@@ -27,7 +27,7 @@ typedef struct foo_st {
     void *data;
 } FOO;
 
-static void *foo_new(OPENSSL_CTX *ctx)
+static void *foo_new(ossl_unused OPENSSL_CTX *unused__ctx)
 {
     FOO *ptr = OPENSSL_zalloc(sizeof(*ptr));
     if (ptr != NULL)

--- a/test/danetest.c
+++ b/test/danetest.c
@@ -293,7 +293,7 @@ static int allws(const char *cp)
 }
 
 static int test_tlsafile(SSL_CTX *ctx, const char *base_name,
-                         BIO *f, const char *path)
+                         BIO *f, ossl_unused const char *unused__path)
 {
     char *line;
     int testno = 0;

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -228,7 +228,7 @@ static int dh_test(void)
     return ret;
 }
 
-static int cb(int p, int n, BN_GENCB *arg)
+static int cb(ossl_unused int unused__p, ossl_unused int unused__n, ossl_unused BN_GENCB *unused__arg)
 {
     return 1;
 }

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -141,7 +141,7 @@ static int crngt_skip(void)
  * Once the RNG infrastructure is able to disable these tests, it should be
  * reconstituted.
  */
-static int disable_crngt(EVP_RAND_CTX *drbg)
+static int disable_crngt(ossl_unused EVP_RAND_CTX *unused__drbg)
 {
     return 1;
 }
@@ -469,7 +469,7 @@ static int wait_for_thread(thread_t thread)
 
 typedef pthread_t thread_t;
 
-static void *thread_run(void *arg)
+static void *thread_run(ossl_unused void *unused__arg)
 {
     run_multi_thread_test();
     /*

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -119,7 +119,7 @@ static int dsa_test(void)
     return ret;
 }
 
-static int dsa_cb(int p, int n, BN_GENCB *arg)
+static int dsa_cb(int p, ossl_unused int unused__n, ossl_unused BN_GENCB *unused__arg)
 {
     static int ok = 0, num = 0;
 

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -24,7 +24,8 @@ DEFINE_STACK_OF(SSL_CIPHER)
 
 static int debug = 0;
 
-static unsigned int clnt_psk_callback(SSL *ssl, const char *hint,
+static unsigned int clnt_psk_callback(ossl_unused SSL *unused__ssl,
+                                      ossl_unused const char *unused__hint,
                                       char *ident, unsigned int max_ident_len,
                                       unsigned char *psk,
                                       unsigned int max_psk_len)
@@ -38,7 +39,8 @@ static unsigned int clnt_psk_callback(SSL *ssl, const char *hint,
     return max_psk_len;
 }
 
-static unsigned int srvr_psk_callback(SSL *ssl, const char *identity,
+static unsigned int srvr_psk_callback(ossl_unused SSL *unused__ssl,
+                                      ossl_unused const char *unused__identity,
                                       unsigned char *psk,
                                       unsigned int max_psk_len)
 {

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -42,7 +42,7 @@ static unsigned char certstatus[] = {
 
 #define RECORD_SEQUENCE 10
 
-static unsigned int timer_cb(SSL *s, unsigned int timer_us)
+static unsigned int timer_cb(ossl_unused SSL *unused__ssl, unsigned int timer_us)
 {
     ++timer_cb_count;
 
@@ -247,7 +247,7 @@ static int test_dtls_drop_records(int idx)
 
 static const char dummy_cookie[] = "0123456";
 
-static int generate_cookie_cb(SSL *ssl, unsigned char *cookie,
+static int generate_cookie_cb(ossl_unused SSL *unused__ssl, unsigned char *cookie,
                               unsigned int *cookie_len)
 {
     memcpy(cookie, dummy_cookie, sizeof(dummy_cookie));
@@ -255,7 +255,7 @@ static int generate_cookie_cb(SSL *ssl, unsigned char *cookie,
     return 1;
 }
 
-static int verify_cookie_cb(SSL *ssl, const unsigned char *cookie,
+static int verify_cookie_cb(ossl_unused SSL *unused__ssl, const unsigned char *cookie,
                             unsigned int cookie_len)
 {
     return TEST_mem_eq(cookie, cookie_len, dummy_cookie, sizeof(dummy_cookie));

--- a/test/dtlsv1listentest.c
+++ b/test/dtlsv1listentest.c
@@ -259,7 +259,7 @@ static tests testpackets[9] = {
 
 # define COOKIE_LEN  20
 
-static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
+static int cookie_gen(ossl_unused SSL *unused__ssl, unsigned char *cookie, unsigned int *cookie_len)
 {
     unsigned int i;
 
@@ -270,7 +270,7 @@ static int cookie_gen(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
     return 1;
 }
 
-static int cookie_verify(SSL *ssl, const unsigned char *cookie,
+static int cookie_verify(ossl_unused SSL *unused__ssl, const unsigned char *cookie,
                          unsigned int cookie_len)
 {
     unsigned int i;

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -206,7 +206,7 @@ static int x9_62_tests(int n)
  * - reject that signature after modifying the signature
  * - accept that signature after un-modifying the signature
  */
-static int set_sm2_id(EVP_MD_CTX *mctx, EVP_PKEY *pkey)
+static int set_sm2_id(EVP_MD_CTX *mctx, ossl_unused EVP_PKEY *unused__pkey)
 {
     /* With the SM2 key type, the SM2 ID is mandatory */
     static const char sm2_id[] = { 1, 2, 3, 4, 'l', 'e', 't', 't', 'e', 'r' };

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -331,17 +331,19 @@ static int encode_public_EVP_PKEY_MSBLOB(void **encoded,
 
 # ifndef OPENSSL_NO_RC4
 static pem_password_cb pass_pw;
-static int pass_pw(char *buf, int size, int rwflag, void *userdata)
+static int pass_pw(char *buf, int size,
+                   ossl_unused int unused__rwflag,
+                   void *userdata)
 {
     OPENSSL_strlcpy(buf, userdata, size);
     return strlen(userdata);
 }
 
 static int encode_EVP_PKEY_PVK(void **encoded, long *encoded_len,
-                                  void *object,
-                                  const char *pass,
-                                  ossl_unused const char *pcipher,
-                                  ossl_unused const char *encoder_propq)
+                               void *object,
+                               const char *pass,
+                               ossl_unused const char *pcipher,
+                               ossl_unused const char *encoder_propq)
 {
     EVP_PKEY *pkey = object;
     BIO *mem_ser = NULL;
@@ -421,8 +423,9 @@ static int test_unprotected_via_DER(const char *type, EVP_PKEY *key)
                                       0);
 }
 
-static int check_unprotected_PKCS8_PEM(const char *type,
-                                       const void *data, size_t data_len)
+static int check_unprotected_PKCS8_PEM(ossl_unused const char *unused__type,
+                                       const void *data,
+                                       ossl_unused size_t unused__data_len)
 {
     static const char pem_header[] = "-----BEGIN " PEM_STRING_PKCS8INF "-----";
 
@@ -441,7 +444,8 @@ static int test_unprotected_via_PEM(const char *type, EVP_PKEY *key)
 }
 
 static int check_unprotected_legacy_PEM(const char *type,
-                                        const void *data, size_t data_len)
+                                        const void *data,
+                                        ossl_unused size_t unused__data_len)
 {
     static char pem_header[80];
 
@@ -454,15 +458,16 @@ static int check_unprotected_legacy_PEM(const char *type,
 static int test_unprotected_via_legacy_PEM(const char *type, EVP_PKEY *key)
 {
     return test_encode_decode(type, key, NULL, NULL,
-                                      encode_EVP_PKEY_legacy_PEM,
-                                      decode_EVP_PKEY_prov,
-                                      test_text,
-                                      check_unprotected_legacy_PEM, dump_pem,
-                                      NULL, 1);
+                              encode_EVP_PKEY_legacy_PEM,
+                              decode_EVP_PKEY_prov,
+                              test_text,
+                              check_unprotected_legacy_PEM, dump_pem,
+                              NULL, 1);
 }
 
 #ifndef OPENSSL_NO_DSA
-static int check_MSBLOB(const char *type, const void *data, size_t data_len)
+static int check_MSBLOB(ossl_unused const char *unused__type,
+                        const void *data, size_t data_len)
 {
     const unsigned char *datap = data;
     EVP_PKEY *pkey = b2i_PrivateKey(&datap, data_len);
@@ -483,7 +488,8 @@ static int test_unprotected_via_MSBLOB(const char *type, EVP_PKEY *key)
 }
 
 # ifndef OPENSSL_NO_RC4
-static int check_PVK(const char *type, const void *data, size_t data_len)
+static int check_PVK(ossl_unused const char *unused__type,
+                     const void *data, size_t data_len)
 {
     const unsigned char *in = data;
     unsigned int saltlen = 0, keylen = 0;
@@ -507,7 +513,7 @@ static int test_unprotected_via_PVK(const char *type, EVP_PKEY *key)
 static const char *pass_cipher = "AES-256-CBC";
 static const char *pass = "the holy handgrenade of antioch";
 
-static int check_protected_PKCS8_DER(const char *type,
+static int check_protected_PKCS8_DER(ossl_unused const char *unused__type,
                                      const void *data, size_t data_len)
 {
     const unsigned char *datap = data;
@@ -529,8 +535,9 @@ static int test_protected_via_DER(const char *type, EVP_PKEY *key)
                                       0);
 }
 
-static int check_protected_PKCS8_PEM(const char *type,
-                                     const void *data, size_t data_len)
+static int check_protected_PKCS8_PEM(ossl_unused const char *unused__type,
+                                     const void *data,
+                                     ossl_unused size_t unused__data_len)
 {
     static const char pem_header[] = "-----BEGIN " PEM_STRING_PKCS8 "-----";
 
@@ -549,7 +556,8 @@ static int test_protected_via_PEM(const char *type, EVP_PKEY *key)
 }
 
 static int check_protected_legacy_PEM(const char *type,
-                                      const void *data, size_t data_len)
+                                      const void *data,
+                                      ossl_unused size_t unused__data_len)
 {
     static char pem_header[80];
 
@@ -603,7 +611,9 @@ static int test_public_via_DER(const char *type, EVP_PKEY *key)
                                       0);
 }
 
-static int check_public_PEM(const char *type, const void *data, size_t data_len)
+static int check_public_PEM(ossl_unused const char *unused__type,
+                            const void *data,
+                            ossl_unused size_t unused__data_len)
 {
     static const char pem_header[] = "-----BEGIN " PEM_STRING_PUBLIC "-----";
 
@@ -623,7 +633,7 @@ static int test_public_via_PEM(const char *type, EVP_PKEY *key)
 }
 
 #ifndef OPENSSL_NO_DSA
-static int check_public_MSBLOB(const char *type,
+static int check_public_MSBLOB(ossl_unused const char *unused__type,
                                const void *data, size_t data_len)
 {
     const unsigned char *datap = data;

--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -191,15 +191,19 @@ static EVP_PKEY_METHOD *test_rsa = NULL;
 static int called_encrypt = 0;
 
 /* Test function to check operation has been redirected */
-static int test_encrypt(EVP_PKEY_CTX *ctx, unsigned char *sig,
-                        size_t *siglen, const unsigned char *tbs, size_t tbslen)
+static int test_encrypt(ossl_unused EVP_PKEY_CTX *unused__ctx,
+                        ossl_unused unsigned char *unused__sig,
+                        ossl_unused size_t *unused__siglen,
+                        ossl_unused const unsigned char *unused__tbs,
+                        ossl_unused size_t unused__tbslen)
 {
     called_encrypt = 1;
     return 1;
 }
 
-static int test_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
-                           const int **pnids, int nid)
+static int test_pkey_meths (ossl_unused ENGINE *unused__e,
+                            EVP_PKEY_METHOD **pmeth,
+                            const int **pnids, int nid)
 {
     static const int rnid = EVP_PKEY_RSA;
     if (pmeth == NULL) {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1144,17 +1144,17 @@ static int test_set_get_raw_keys(int tst)
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
-static int pkey_custom_check(EVP_PKEY *pkey)
+static int pkey_custom_check(ossl_unused EVP_PKEY *unused__pkey)
 {
     return 0xbeef;
 }
 
-static int pkey_custom_pub_check(EVP_PKEY *pkey)
+static int pkey_custom_pub_check(ossl_unused EVP_PKEY *unused__pkey)
 {
     return 0xbeef;
 }
 
-static int pkey_custom_param_check(EVP_PKEY *pkey)
+static int pkey_custom_param_check(ossl_unused EVP_PKEY *unused__pkey)
 {
     return 0xbeef;
 }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2640,7 +2640,8 @@ static void keypair_test_cleanup(EVP_TEST *t)
 /*
  * For tests that do not accept any custom keywords.
  */
-static int void_test_parse(EVP_TEST *t, const char *keyword, const char *value)
+static int void_test_parse(ossl_unused EVP_TEST *unused__t, ossl_unused const char *unused__keyword,
+                           ossl_unused const char *unused__value)
 {
     return 0;
 }
@@ -3623,6 +3624,8 @@ static int is_pkey_disabled(const char *name)
 #ifdef OPENSSL_NO_RSA
     if (STR_STARTS_WITH(name, "RSA"))
         return 1;
+#else
+    (void)name; /* silence -Wunused-parameter */
 #endif
 #ifdef OPENSSL_NO_EC
     if (STR_STARTS_WITH(name, "EC"))
@@ -3645,6 +3648,8 @@ static int is_mac_disabled(const char *name)
     if (STR_STARTS_WITH(name, "BLAKE2BMAC")
         || STR_STARTS_WITH(name, "BLAKE2SMAC"))
         return 1;
+#else
+    (void)name; /* silence -Wunused-parameter */
 #endif
 #ifdef OPENSSL_NO_CMAC
     if (STR_STARTS_WITH(name, "CMAC"))
@@ -3665,6 +3670,8 @@ static int is_kdf_disabled(const char *name)
 #ifdef OPENSSL_NO_SCRYPT
     if (STR_ENDS_WITH(name, "SCRYPT"))
         return 1;
+#else
+    (void)name; /* silence -Wunused-parameter */
 #endif
 #ifdef OPENSSL_NO_CMS
     if (strcasecmp(name, "X942KDF") == 0)

--- a/test/exdatatest.c
+++ b/test/exdatatest.c
@@ -26,8 +26,10 @@ static int gbl_result;
  * Apps explicitly set/get ex_data as needed
  */
 
-static void exnew(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-          int idx, long argl, void *argp)
+static void exnew(ossl_unused void *unused__parent,
+                  void *ptr,
+                  ossl_unused CRYPTO_EX_DATA *unused__ad,
+                  int idx, long argl, void *argp)
 {
     if (!TEST_int_eq(idx, saved_idx)
         || !TEST_long_eq(argl, saved_argl)
@@ -36,8 +38,9 @@ static void exnew(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
         gbl_result = 0;
 }
 
-static int exdup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-          void **from_d, int idx, long argl, void *argp)
+static int exdup(ossl_unused CRYPTO_EX_DATA *unused__to,
+                 ossl_unused const CRYPTO_EX_DATA *unused__from,
+                 void **from_d, int idx, long argl, void *argp)
 {
     if (!TEST_int_eq(idx, saved_idx)
         || !TEST_long_eq(argl, saved_argl)
@@ -47,8 +50,10 @@ static int exdup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
     return 1;
 }
 
-static void exfree(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-            int idx, long argl, void *argp)
+static void exfree(ossl_unused void *unused__parent,
+                   ossl_unused void *unused__ptr,
+                   ossl_unused CRYPTO_EX_DATA *unused__ad,
+                   int idx, long argl, void *argp)
 {
     if (!TEST_int_eq(idx, saved_idx)
         || !TEST_long_eq(argl, saved_argl)
@@ -68,8 +73,9 @@ typedef struct myobj_ex_data_st {
     int dup;
 } MYOBJ_EX_DATA;
 
-static void exnew2(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-          int idx, long argl, void *argp)
+static void exnew2(ossl_unused void *unused__parent,
+                   void *ptr, CRYPTO_EX_DATA *ad,
+                   int idx, long argl, void *argp)
 {
     MYOBJ_EX_DATA *ex_data = OPENSSL_zalloc(sizeof(*ex_data));
 
@@ -86,8 +92,9 @@ static void exnew2(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     }
 }
 
-static int exdup2(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-          void **from_d, int idx, long argl, void *argp)
+static int exdup2(CRYPTO_EX_DATA *to,
+                  ossl_unused const CRYPTO_EX_DATA *unused__from,
+                  void **from_d, int idx, long argl, void *argp)
 {
     MYOBJ_EX_DATA **update_ex_data = (MYOBJ_EX_DATA**)from_d;
     MYOBJ_EX_DATA *ex_data = NULL;
@@ -111,8 +118,10 @@ static int exdup2(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
     return 1;
 }
 
-static void exfree2(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
-            int idx, long argl, void *argp)
+static void exfree2(ossl_unused void *unused__parent,
+                    ossl_unused void *unused__ptr,
+                    CRYPTO_EX_DATA *ad,
+                    int idx, long argl, void *argp)
 {
     MYOBJ_EX_DATA *ex_data = CRYPTO_get_ex_data(ad, idx);
 

--- a/test/exptest.c
+++ b/test/exptest.c
@@ -119,7 +119,7 @@ static int test_mod_exp_zero(void)
     return ret;
 }
 
-static int test_mod_exp(int round)
+static int test_mod_exp(ossl_unused int unused__round)
 {
     BN_CTX *ctx;
     unsigned char c;

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -566,7 +566,7 @@ err:
     return ret;
 }
 
-static int ffc_private_gen_test(int index)
+static int ffc_private_gen_test(ossl_unused int unused__index)
 {
     int ret = 0, res = -1, N;
     FFC_PARAMS *params;

--- a/test/filterprov.c
+++ b/test/filterprov.c
@@ -52,21 +52,21 @@ static OSSL_FUNC_provider_get_params_fn filter_get_params;
 static OSSL_FUNC_provider_query_operation_fn filter_query;
 static OSSL_FUNC_provider_teardown_fn filter_teardown;
 
-static const OSSL_PARAM *filter_gettable_params(void *provctx)
+static const OSSL_PARAM *filter_gettable_params(ossl_unused void *unused__provctx)
 {
     struct filter_prov_globals_st *globs = get_globals();
 
     return OSSL_PROVIDER_gettable_params(globs->deflt);
 }
 
-static int filter_get_params(void *provctx, OSSL_PARAM params[])
+static int filter_get_params(ossl_unused void *unused__provctx, OSSL_PARAM params[])
 {
     struct filter_prov_globals_st *globs = get_globals();
 
     return OSSL_PROVIDER_get_params(globs->deflt, params);
 }
 
-static int filter_get_capabilities(void *provctx, const char *capability,
+static int filter_get_capabilities(ossl_unused void *unused__provctx, const char *capability,
                                    OSSL_CALLBACK *cb, void *arg)
 {
     struct filter_prov_globals_st *globs = get_globals();
@@ -74,7 +74,7 @@ static int filter_get_capabilities(void *provctx, const char *capability,
     return OSSL_PROVIDER_get_capabilities(globs->deflt, capability, cb, arg);
 }
 
-static const OSSL_ALGORITHM *filter_query(void *provctx,
+static const OSSL_ALGORITHM *filter_query(ossl_unused void *unused__provctx,
                                           int operation_id,
                                           int *no_cache)
 {
@@ -92,7 +92,7 @@ static const OSSL_ALGORITHM *filter_query(void *provctx,
     return OSSL_PROVIDER_query_operation(globs->deflt, operation_id, no_cache);
 }
 
-static void filter_teardown(void *provctx)
+static void filter_teardown(ossl_unused void *unused__provctx)
 {
     struct filter_prov_globals_st *globs = get_globals();
 
@@ -110,8 +110,8 @@ static const OSSL_DISPATCH filter_dispatch_table[] = {
     { 0, NULL }
 };
 
-int filter_provider_init(const OSSL_CORE_HANDLE *handle,
-                         const OSSL_DISPATCH *in,
+int filter_provider_init(ossl_unused const OSSL_CORE_HANDLE *unused__handle,
+                         ossl_unused const OSSL_DISPATCH *unused__in,
                          const OSSL_DISPATCH **out,
                          void **provctx)
 {

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -222,12 +222,12 @@ static int client_hello_select_server_ctx(SSL *s, void *arg, int ignore)
  * configurations to ensure the state machine propagates the result
  * correctly.
  */
-static int servername_ignore_cb(SSL *s, int *ad, void *arg)
+static int servername_ignore_cb(SSL *s, ossl_unused int *unused__ad, void *arg)
 {
     return select_server_ctx(s, arg, 1);
 }
 
-static int servername_reject_cb(SSL *s, int *ad, void *arg)
+static int servername_reject_cb(SSL *s, ossl_unused int *unused__ad, void *arg)
 {
     return select_server_ctx(s, arg, 0);
 }
@@ -298,7 +298,7 @@ static int server_ocsp_cb(SSL *s, void *arg)
     return SSL_TLSEXT_ERR_OK;
 }
 
-static int client_ocsp_cb(SSL *s, void *arg)
+static int client_ocsp_cb(SSL *s, ossl_unused void *unused__arg)
 {
     const unsigned char *resp;
     int len;
@@ -310,26 +310,31 @@ static int client_ocsp_cb(SSL *s, void *arg)
     return 1;
 }
 
-static int verify_reject_cb(X509_STORE_CTX *ctx, void *arg) {
+static int verify_reject_cb(X509_STORE_CTX *ctx, ossl_unused void *unused__arg) {
     X509_STORE_CTX_set_error(ctx, X509_V_ERR_APPLICATION_VERIFICATION);
     return 0;
 }
 
-static int verify_accept_cb(X509_STORE_CTX *ctx, void *arg) {
+static int verify_accept_cb(ossl_unused X509_STORE_CTX *unused__ctx, ossl_unused void *unused__arg) {
     return 1;
 }
 
-static int broken_session_ticket_cb(SSL *s, unsigned char *key_name,
-                                    unsigned char *iv, EVP_CIPHER_CTX *ctx,
-                                    EVP_MAC_CTX *hctx, int enc)
+static int broken_session_ticket_cb(ossl_unused SSL *unused__ssl,
+                                    ossl_unused unsigned char *unused__key_name,
+                                    ossl_unused unsigned char *unused__iv,
+                                    ossl_unused EVP_CIPHER_CTX *unused__ctx,
+                                    ossl_unused EVP_MAC_CTX *unused__hctx,
+                                    ossl_unused int unused__enc)
 {
     return 0;
 }
 
-static int do_not_call_session_ticket_cb(SSL *s, unsigned char *key_name,
-                                         unsigned char *iv,
-                                         EVP_CIPHER_CTX *ctx,
-                                         EVP_MAC_CTX *hctx, int enc)
+static int do_not_call_session_ticket_cb(SSL *s,
+                                         ossl_unused unsigned char *unused__key_name,
+                                         ossl_unused unsigned char *unused__iv,
+                                         ossl_unused EVP_CIPHER_CTX *unused__ctx,
+                                         ossl_unused EVP_MAC_CTX *unused__hctx,
+                                         ossl_unused int unused__enc)
 {
     HANDSHAKE_EX_DATA *ex_data =
         (HANDSHAKE_EX_DATA*)(SSL_get_ex_data(s, ex_data_idx));
@@ -386,7 +391,8 @@ err:
  * protocols, or the server doesn't advertise any, it SHOULD select the first
  * protocol that it supports.
  */
-static int client_npn_cb(SSL *s, unsigned char **out, unsigned char *outlen,
+static int client_npn_cb(ossl_unused SSL *unused__ssl,
+                         unsigned char **out, unsigned char *outlen,
                          const unsigned char *in, unsigned int inlen,
                          void *arg)
 {
@@ -401,7 +407,8 @@ static int client_npn_cb(SSL *s, unsigned char **out, unsigned char *outlen,
         ? SSL_TLSEXT_ERR_OK : SSL_TLSEXT_ERR_ALERT_FATAL;
 }
 
-static int server_npn_cb(SSL *s, const unsigned char **data,
+static int server_npn_cb(ossl_unused SSL *unused__ssl,
+                         const unsigned char **data,
                          unsigned int *len, void *arg)
 {
     CTX_DATA *ctx_data = (CTX_DATA*)(arg);
@@ -417,7 +424,8 @@ static int server_npn_cb(SSL *s, const unsigned char **data,
  * supports no protocols that the client advertises, then the server SHALL
  * respond with a fatal "no_application_protocol" alert.
  */
-static int server_alpn_cb(SSL *s, const unsigned char **out,
+static int server_alpn_cb(ossl_unused SSL *unused__ssl,
+                          const unsigned char **out,
                           unsigned char *outlen, const unsigned char *in,
                           unsigned int inlen, void *arg)
 {
@@ -443,7 +451,7 @@ static int server_alpn_cb(SSL *s, const unsigned char **out,
 }
 
 #ifndef OPENSSL_NO_SRP
-static char *client_srp_cb(SSL *s, void *arg)
+static char *client_srp_cb(ossl_unused SSL *unused__ssl, void *arg)
 {
     CTX_DATA *ctx_data = (CTX_DATA*)(arg);
     return OPENSSL_strdup(ctx_data->srp_password);
@@ -476,11 +484,12 @@ static int generate_session_ticket_cb(SSL *s, void *arg)
     return SSL_SESSION_set1_ticket_appdata(ss, app_data, strlen(app_data));
 }
 
-static int decrypt_session_ticket_cb(SSL *s, SSL_SESSION *ss,
-                                     const unsigned char *keyname,
-                                     size_t keyname_len,
+static int decrypt_session_ticket_cb(ossl_unused SSL *unused__ssl,
+                                     ossl_unused SSL_SESSION *unused__ss,
+                                     ossl_unused const unsigned char *unused__keyname,
+                                     ossl_unused size_t unused__keyname_len,
                                      SSL_TICKET_STATUS status,
-                                     void *arg)
+                                     ossl_unused void *unused__arg)
 {
     switch (status) {
     case SSL_TICKET_EMPTY:
@@ -729,7 +738,8 @@ err:
 }
 
 /* Configure per-SSL callbacks and other properties. */
-static void configure_handshake_ssl(SSL *server, SSL *client,
+static void configure_handshake_ssl(ossl_unused SSL *unused__server,
+                                    SSL *client,
                                     const SSL_TEST_EXTRA_CONF *extra)
 {
     if (extra->client.servername != SSL_TEST_SERVERNAME_NONE)

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -100,8 +100,13 @@ static int mock_http_server(BIO *in, BIO *out,
     }
 }
 
-static long http_bio_cb_ex(BIO *bio, int oper, const char *argp, size_t len,
-                           int cmd, long argl, int ret, size_t *processed)
+static long http_bio_cb_ex(BIO *bio, int oper,
+                           ossl_unused const char *unused__argp,
+                           ossl_unused size_t unused__len,
+                           int cmd,
+                           ossl_unused long unused__argl,
+                           int ret,
+                           ossl_unused size_t *unused__processed)
 {
 
     if (oper == (BIO_CB_CTRL | BIO_CB_RETURN) && cmd == BIO_CTRL_FLUSH)

--- a/test/keymgmt_internal_test.c
+++ b/test/keymgmt_internal_test.c
@@ -38,7 +38,7 @@ static void tear_down(FIXTURE *fixture)
     }
 }
 
-static FIXTURE *set_up(const char *testcase_name)
+static FIXTURE *set_up(ossl_unused const char *unused__testcase_name)
 {
     FIXTURE *fixture;
 

--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -29,7 +29,7 @@
  * test framework to avoid CRYPTO_mem_leaks stuff.
  */
 
-int main(int argc, char *argv[])
+int main(ossl_unused int unused__argc, char *argv[])
 {
 #if __SANITIZE_ADDRESS__
     int exitcode = EXIT_SUCCESS;

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -43,7 +43,7 @@ static OSSL_FUNC_provider_gettable_params_fn p_gettable_params;
 static OSSL_FUNC_provider_get_params_fn p_get_params;
 static OSSL_FUNC_provider_get_reason_strings_fn p_get_reason_strings;
 
-static const OSSL_PARAM *p_gettable_params(void *_)
+static const OSSL_PARAM *p_gettable_params(ossl_unused void *unused___)
 {
     return p_param_types;
 }
@@ -101,7 +101,7 @@ static int p_get_params(void *vhand, OSSL_PARAM params[])
     return ok;
 }
 
-static const OSSL_ITEM *p_get_reason_strings(void *_)
+static const OSSL_ITEM *p_get_reason_strings(ossl_unused void *unused___)
 {
     static const OSSL_ITEM reason_strings[] = {
         {1, "dummy reason string"},

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -29,12 +29,12 @@ static int add_property_names(const char *n, ...)
     return res;
 }
 
-static int up_ref(void *p)
+static int up_ref(ossl_unused void *unused__p)
 {
     return 1;
 }
 
-static void down_ref(void *p)
+static void down_ref(ossl_unused void *unused__p)
 {
 }
 

--- a/test/rsa_complex.c
+++ b/test/rsa_complex.c
@@ -20,7 +20,7 @@
 #include <openssl/rsa.h>
 #include <stdlib.h>
 
-int main(int argc, char *argv[])
+int main(ossl_unused int unused__argc, ossl_unused char *argv[])
 {
     /* There are explicitly no run time checks for this one */
     return EXIT_SUCCESS;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -132,7 +132,7 @@ static unsigned char serverinfov2[] = {
     0xff        /* Dummy extension data */
 };
 
-static int hostname_cb(SSL *s, int *al, void *arg)
+static int hostname_cb(SSL *s, ossl_unused int *unused__al, ossl_unused void *unused__arg)
 {
     const char *hostname = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
 
@@ -143,7 +143,7 @@ static int hostname_cb(SSL *s, int *al, void *arg)
     return SSL_TLSEXT_ERR_NOACK;
 }
 
-static void client_keylog_callback(const SSL *ssl, const char *line)
+static void client_keylog_callback(ossl_unused const SSL *unused__ssl, const char *line)
 {
     int line_length = strlen(line);
 
@@ -159,7 +159,7 @@ static void client_keylog_callback(const SSL *ssl, const char *line)
     client_log_buffer[client_log_buffer_index++] = '\n';
 }
 
-static void server_keylog_callback(const SSL *ssl, const char *line)
+static void server_keylog_callback(ossl_unused const SSL *unused__ssl, const char *line)
 {
     int line_length = strlen(line);
 
@@ -544,7 +544,7 @@ end:
 #endif
 
 #ifndef OPENSSL_NO_TLS1_2
-static int full_client_hello_callback(SSL *s, int *al, void *arg)
+static int full_client_hello_callback(SSL *s, ossl_unused int *unused__al, void *arg)
 {
     int *ctr = arg;
     const unsigned char *p;
@@ -1054,7 +1054,7 @@ static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
     }
 
     if (!TEST_true(ping_pong_query(clientssl, serverssl, cfd, sfd,
-				   rec_seq_size)))
+                                   rec_seq_size)))
         goto end;
 
     testresult = 1;
@@ -1892,7 +1892,7 @@ static int test_tlsext_status_type(void)
 #if !defined(OPENSSL_NO_TLS1_3) || !defined(OPENSSL_NO_TLS1_2)
 static int new_called, remove_called, get_called;
 
-static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
+static int new_session_cb(ossl_unused SSL *unused__ssl, SSL_SESSION *sess)
 {
     new_called++;
     /*
@@ -1903,14 +1903,16 @@ static int new_session_cb(SSL *ssl, SSL_SESSION *sess)
     return 1;
 }
 
-static void remove_session_cb(SSL_CTX *ctx, SSL_SESSION *sess)
+static void remove_session_cb(ossl_unused SSL_CTX *unused__ctx, ossl_unused SSL_SESSION *unused__sess)
 {
     remove_called++;
 }
 
 static SSL_SESSION *get_sess_val = NULL;
 
-static SSL_SESSION *get_session_cb(SSL *ssl, const unsigned char *id, int len,
+static SSL_SESSION *get_session_cb(ossl_unused SSL *unused__ssl,
+                                   ossl_unused const unsigned char *unused__id,
+                                   ossl_unused int unused__len,
                                    int *copy)
 {
     get_called++;
@@ -2268,7 +2270,7 @@ static int test_session_wo_ca_names(void)
 static SSL_SESSION *sesscache[6];
 static int do_cache;
 
-static int new_cachesession_cb(SSL *ssl, SSL_SESSION *sess)
+static int new_cachesession_cb(ossl_unused SSL *unused__ssl, SSL_SESSION *sess)
 {
     if (do_cache) {
         sesscache[new_called] = sess;
@@ -3069,7 +3071,7 @@ static int test_set_sigalgs(int idx)
 static int psk_client_cb_cnt = 0;
 static int psk_server_cb_cnt = 0;
 
-static int use_session_cb(SSL *ssl, const EVP_MD *md, const unsigned char **id,
+static int use_session_cb(ossl_unused SSL *unused__ssl, const EVP_MD *md, const unsigned char **id,
                           size_t *idlen, SSL_SESSION **sess)
 {
     switch (++use_session_cb_cnt) {
@@ -3101,7 +3103,9 @@ static int use_session_cb(SSL *ssl, const EVP_MD *md, const unsigned char **id,
 }
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *id,
+static unsigned int psk_client_cb(ossl_unused SSL *unused__ssl,
+                                  ossl_unused const char *unused__hint,
+                                  char *id,
                                   unsigned int max_id_len,
                                   unsigned char *psk,
                                   unsigned int max_psk_len)
@@ -3130,7 +3134,8 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *id,
 }
 #endif /* OPENSSL_NO_PSK */
 
-static int find_session_cb(SSL *ssl, const unsigned char *identity,
+static int find_session_cb(ossl_unused SSL *unused__ssl,
+                           const unsigned char *identity,
                            size_t identity_len, SSL_SESSION **sess)
 {
     find_session_cb_cnt++;
@@ -3157,7 +3162,8 @@ static int find_session_cb(SSL *ssl, const unsigned char *identity,
 }
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int psk_server_cb(SSL *ssl, const char *identity,
+static unsigned int psk_server_cb(ossl_unused SSL *unused__ssl,
+                                  const char *identity,
                                   unsigned char *psk, unsigned int max_psk_len)
 {
     unsigned int psklen = 0;
@@ -3531,7 +3537,7 @@ static int test_early_data_read_write(int idx)
 
 static int allow_ed_cb_called = 0;
 
-static int allow_early_data_cb(SSL *s, void *arg)
+static int allow_early_data_cb(ossl_unused SSL *unused__ssl, void *arg)
 {
     int *usecb = (int *)arg;
 
@@ -3933,9 +3939,12 @@ static int test_early_data_not_sent(int idx)
 
 static const char *servalpn;
 
-static int alpn_select_cb(SSL *ssl, const unsigned char **out,
-                          unsigned char *outlen, const unsigned char *in,
-                          unsigned int inlen, void *arg)
+static int alpn_select_cb(ossl_unused SSL *unused__ssl,
+                          const unsigned char **out,
+                          unsigned char *outlen,
+                          const unsigned char *in,
+                          unsigned int inlen,
+                          ossl_unused void *unused__arg)
 {
     unsigned int protlen = 0;
     const unsigned char *prot;
@@ -5120,7 +5129,8 @@ static int test_tls13_psk(int idx)
 
 static unsigned char cookie_magic_value[] = "cookie magic";
 
-static int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
+static int generate_cookie_callback(ossl_unused SSL *unused__ssl,
+                                    unsigned char *cookie,
                                     unsigned int *cookie_len)
 {
     /*
@@ -5133,7 +5143,8 @@ static int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
     return 1;
 }
 
-static int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
+static int verify_cookie_callback(ossl_unused SSL *unused__ssl,
+                                  const unsigned char *cookie,
                                   unsigned int cookie_len)
 {
     if (cookie_len == sizeof(cookie_magic_value) - 1
@@ -5256,8 +5267,11 @@ static int snicb = 0;
 
 #define TEST_EXT_TYPE1  0xff00
 
-static int old_add_cb(SSL *s, unsigned int ext_type, const unsigned char **out,
-                      size_t *outlen, int *al, void *add_arg)
+static int old_add_cb(SSL *s,
+                      ossl_unused unsigned int unused__ext_type,
+                      const unsigned char **out,
+                      size_t *outlen,
+                      ossl_unused int *unused__al, void *add_arg)
 {
     int *server = (int *)add_arg;
     unsigned char *data;
@@ -5277,14 +5291,20 @@ static int old_add_cb(SSL *s, unsigned int ext_type, const unsigned char **out,
     return 1;
 }
 
-static void old_free_cb(SSL *s, unsigned int ext_type, const unsigned char *out,
-                        void *add_arg)
+static void old_free_cb(ossl_unused SSL *unused__ssl,
+                        ossl_unused unsigned int unused__ext_type,
+                        const unsigned char *out,
+                        ossl_unused void *unused__add_arg)
 {
     OPENSSL_free((unsigned char *)out);
 }
 
-static int old_parse_cb(SSL *s, unsigned int ext_type, const unsigned char *in,
-                        size_t inlen, int *al, void *parse_arg)
+static int old_parse_cb(SSL *s,
+                        ossl_unused unsigned int unused__ext_type,
+                        const unsigned char *in,
+                        size_t inlen,
+                        ossl_unused int *unused__al,
+                        void *parse_arg)
 {
     int *server = (int *)parse_arg;
 
@@ -5301,9 +5321,15 @@ static int old_parse_cb(SSL *s, unsigned int ext_type, const unsigned char *in,
     return 1;
 }
 
-static int new_add_cb(SSL *s, unsigned int ext_type, unsigned int context,
-                      const unsigned char **out, size_t *outlen, X509 *x,
-                      size_t chainidx, int *al, void *add_arg)
+static int new_add_cb(SSL *s,
+                      ossl_unused unsigned int unused__ext_type,
+                      ossl_unused unsigned int unused__context,
+                      const unsigned char **out,
+                      size_t *outlen,
+                      ossl_unused X509 *unused__x,
+                      ossl_unused size_t unused__chainidx,
+                      ossl_unused int *unused__al,
+                      void *add_arg)
 {
     int *server = (int *)add_arg;
     unsigned char *data;
@@ -5323,15 +5349,24 @@ static int new_add_cb(SSL *s, unsigned int ext_type, unsigned int context,
     return 1;
 }
 
-static void new_free_cb(SSL *s, unsigned int ext_type, unsigned int context,
-                        const unsigned char *out, void *add_arg)
+static void new_free_cb(ossl_unused SSL *unused__ssl,
+                        ossl_unused unsigned int unused__ext_type,
+                        ossl_unused unsigned int unused__context,
+                        const unsigned char *out,
+                        ossl_unused void *unused__add_arg)
 {
     OPENSSL_free((unsigned char *)out);
 }
 
-static int new_parse_cb(SSL *s, unsigned int ext_type, unsigned int context,
-                        const unsigned char *in, size_t inlen, X509 *x,
-                        size_t chainidx, int *al, void *parse_arg)
+static int new_parse_cb(SSL *s,
+                        ossl_unused unsigned int unused__ext_type,
+                        ossl_unused unsigned int unused__context,
+                        const unsigned char *in,
+                        size_t inlen,
+                        ossl_unused X509 *unused__x,
+                        ossl_unused size_t unused__chainidx,
+                        ossl_unused int *unused__al,
+                        void *parse_arg)
 {
     int *server = (int *)parse_arg;
 
@@ -6248,7 +6283,7 @@ static SRP_VBASE *vbase = NULL;
 
 DEFINE_STACK_OF(SRP_user_pwd)
 
-static int ssl_srp_cb(SSL *s, int *ad, void *arg)
+static int ssl_srp_cb(SSL *s, int *ad, ossl_unused void *unused__arg)
 {
     int ret = SSL3_AL_FATAL;
     char *username;
@@ -6956,7 +6991,7 @@ static int gen_tick_called, dec_tick_called, tick_key_cb_called;
 static int tick_key_renew = 0;
 static SSL_TICKET_RETURN tick_dec_ret = SSL_TICKET_RETURN_ABORT;
 
-static int gen_tick_cb(SSL *s, void *arg)
+static int gen_tick_cb(SSL *s, ossl_unused void *unused__arg)
 {
     gen_tick_called = 1;
 
@@ -6964,11 +6999,12 @@ static int gen_tick_cb(SSL *s, void *arg)
                                            strlen(appdata));
 }
 
-static SSL_TICKET_RETURN dec_tick_cb(SSL *s, SSL_SESSION *ss,
-                                     const unsigned char *keyname,
-                                     size_t keyname_length,
+static SSL_TICKET_RETURN dec_tick_cb(ossl_unused SSL *unused__ssl,
+                                     SSL_SESSION *ss,
+                                     ossl_unused const unsigned char *unused__keyname,
+                                     ossl_unused size_t unused__keyname_length,
                                      SSL_TICKET_STATUS status,
-                                     void *arg)
+                                     ossl_unused void *unused__arg)
 {
     void *tickdata;
     size_t tickdlen;
@@ -7009,7 +7045,8 @@ static SSL_TICKET_RETURN dec_tick_cb(SSL *s, SSL_SESSION *ss,
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
-static int tick_key_cb(SSL *s, unsigned char key_name[16],
+static int tick_key_cb(ossl_unused SSL *unused__ssl,
+                       unsigned char key_name[16],
                        unsigned char iv[EVP_MAX_IV_LENGTH], EVP_CIPHER_CTX *ctx,
                        HMAC_CTX *hctx, int enc)
 {
@@ -7038,7 +7075,8 @@ static int tick_key_cb(SSL *s, unsigned char key_name[16],
 }
 #endif
 
-static int tick_key_evp_cb(SSL *s, unsigned char key_name[16],
+static int tick_key_evp_cb(ossl_unused SSL *unused__ssl,
+                           unsigned char key_name[16],
                            unsigned char iv[EVP_MAX_IV_LENGTH],
                            EVP_CIPHER_CTX *ctx, EVP_MAC_CTX *hctx, int enc)
 {
@@ -7676,7 +7714,8 @@ err:
     return 0;
 }
 
-static int verify_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
+static int verify_cb(ossl_unused int unused__preverify_ok,
+                     ossl_unused X509_STORE_CTX *unused__x509_ctx)
 {
     return 1;
 }

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -76,13 +76,15 @@ static long tls_corrupt_ctrl(BIO *bio, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int tls_corrupt_gets(BIO *bio, char *buf, int size)
+static int tls_corrupt_gets(ossl_unused BIO *unused__bio,
+                            ossl_unused char *unused__buf,
+                            ossl_unused int unused__size)
 {
     /* We don't support this - not needed anyway */
     return -1;
 }
 
-static int tls_corrupt_puts(BIO *bio, const char *str)
+static int tls_corrupt_puts(ossl_unused BIO *unused__bio, ossl_unused const char *unused__str)
 {
     /* We don't support this - not needed anyway */
     return -1;

--- a/test/ssltest_old.c
+++ b/test/ssltest_old.c
@@ -129,9 +129,10 @@ static int npn_client = 0;
 static int npn_server = 0;
 static int npn_server_reject = 0;
 
-static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
-                         const unsigned char *in, unsigned int inlen,
-                         void *arg)
+static int cb_client_npn(ossl_unused SSL *unused__ssl,
+                         unsigned char **out, unsigned char *outlen,
+                         ossl_unused const unsigned char *unused__in, ossl_unused unsigned int unused__inlen,
+                         ossl_unused void *unused__arg)
 {
     /*
      * This callback only returns the protocol string, rather than a length
@@ -143,16 +144,20 @@ static int cb_client_npn(SSL *s, unsigned char **out, unsigned char *outlen,
     return SSL_TLSEXT_ERR_OK;
 }
 
-static int cb_server_npn(SSL *s, const unsigned char **data,
-                         unsigned int *len, void *arg)
+static int cb_server_npn(ossl_unused SSL *unused__ssl,
+                         const unsigned char **data,
+                         unsigned int *len,
+                         ossl_unused void *unused__arg)
 {
     *data = (const unsigned char *)NEXT_PROTO_STRING;
     *len = sizeof(NEXT_PROTO_STRING) - 1;
     return SSL_TLSEXT_ERR_OK;
 }
 
-static int cb_server_rejects_npn(SSL *s, const unsigned char **data,
-                                 unsigned int *len, void *arg)
+static int cb_server_rejects_npn(ossl_unused SSL *unused__ssl,
+                                 ossl_unused const unsigned char **unused__data,
+                                 ossl_unused unsigned int *unused__len,
+                                 ossl_unused void *unused__arg)
 {
     return SSL_TLSEXT_ERR_NOACK;
 }
@@ -224,7 +229,7 @@ static const char *client_sess_in;
 static SSL_SESSION *server_sess;
 static SSL_SESSION *client_sess;
 
-static int servername_cb(SSL *s, int *ad, void *arg)
+static int servername_cb(SSL *s, ossl_unused int *unused__ad, ossl_unused void *unused__arg)
 {
     const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
     if (sn_server2 == NULL) {
@@ -241,7 +246,7 @@ static int servername_cb(SSL *s, int *ad, void *arg)
     }
     return SSL_TLSEXT_ERR_OK;
 }
-static int verify_servername(SSL *client, SSL *server)
+static int verify_servername(ossl_unused SSL *unused__client, SSL *server)
 {
     /* just need to see if sn_context is what we expect */
     SSL_CTX* ctx = SSL_get_SSL_CTX(server);
@@ -301,7 +306,7 @@ static unsigned char *next_protos_parse(size_t *outlen,
     return out;
 }
 
-static int cb_server_alpn(SSL *s, const unsigned char **out,
+static int cb_server_alpn(ossl_unused SSL *unused__ssl, const unsigned char **out,
                           unsigned char *outlen, const unsigned char *in,
                           unsigned int inlen, void *arg)
 {
@@ -420,9 +425,12 @@ static int custom_ext = 0;
 /* This set based on extension callbacks */
 static int custom_ext_error = 0;
 
-static int serverinfo_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char *in, size_t inlen,
-                                   int *al, void *arg)
+static int serverinfo_cli_parse_cb(ossl_unused SSL *unused__ssl,
+                                   unsigned int ext_type,
+                                   ossl_unused const unsigned char *unused__in,
+                                   ossl_unused size_t unused__inlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     if (ext_type == TLSEXT_TYPE_signed_certificate_timestamp)
         serverinfo_sct_seen++;
@@ -452,25 +460,34 @@ static int verify_serverinfo(void)
  * 3 - ClientHello with "abc", "defg" response
  */
 
-static int custom_ext_0_cli_add_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+static int custom_ext_0_cli_add_cb(ossl_unused SSL *unused__ssl,
+                                   unsigned int ext_type,
+                                   ossl_unused const unsigned char **unused__out,
+                                   ossl_unused size_t *unused__outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_0)
         custom_ext_error = 1;
     return 0;                   /* Don't send an extension */
 }
 
-static int custom_ext_0_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_0_cli_parse_cb(ossl_unused SSL *unused__ssl,
+                                     ossl_unused unsigned int unused__ext_type,
+                                     ossl_unused const unsigned char *unused__in,
+                                     ossl_unused size_t unused__inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     return 1;
 }
 
-static int custom_ext_1_cli_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_1_cli_add_cb(ossl_unused SSL *unused__ssl,
+                                   unsigned int ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_1)
         custom_ext_error = 1;
@@ -479,16 +496,22 @@ static int custom_ext_1_cli_add_cb(SSL *s, unsigned int ext_type,
     return 1;                   /* Send "abc" */
 }
 
-static int custom_ext_1_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_1_cli_parse_cb(ossl_unused SSL *unused__ssl,
+                                     ossl_unused unsigned int unused__ext_type,
+                                     ossl_unused const unsigned char *unused__in,
+                                     ossl_unused size_t unused__inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     return 1;
 }
 
-static int custom_ext_2_cli_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_2_cli_add_cb(ossl_unused SSL *unused__ssl,
+                                   unsigned int ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
@@ -497,9 +520,12 @@ static int custom_ext_2_cli_add_cb(SSL *s, unsigned int ext_type,
     return 1;                   /* Send "abc" */
 }
 
-static int custom_ext_2_cli_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_2_cli_parse_cb(ossl_unused SSL *unused__ssl,
+                                     unsigned int ext_type,
+                                     ossl_unused const unsigned char *unused__in,
+                                     size_t inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
@@ -508,9 +534,12 @@ static int custom_ext_2_cli_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_3_cli_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_cli_add_cb(ossl_unused SSL *unused__ssl,
+                                   unsigned int ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
@@ -519,9 +548,12 @@ static int custom_ext_3_cli_add_cb(SSL *s, unsigned int ext_type,
     return 1;                   /* Send "abc" */
 }
 
-static int custom_ext_3_cli_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_cli_parse_cb(ossl_unused SSL *unused__ssl,
+                                     unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
@@ -536,27 +568,36 @@ static int custom_ext_3_cli_parse_cb(SSL *s, unsigned int ext_type,
  * custom_ext_0_cli_add_cb returns 0 - the server won't receive a callback
  * for this extension
  */
-static int custom_ext_0_srv_parse_cb(SSL *s, unsigned int ext_type,
-                                     const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+static int custom_ext_0_srv_parse_cb(ossl_unused SSL *unused__ssl,
+                                     ossl_unused unsigned int unused__ext_type,
+                                     ossl_unused const unsigned char *unused__in,
+                                     ossl_unused size_t unused__inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     custom_ext_error = 1;
     return 1;
 }
 
 /* 'add' callbacks are only called if the 'parse' callback is called */
-static int custom_ext_0_srv_add_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+static int custom_ext_0_srv_add_cb(ossl_unused SSL *unused__ssl,
+                                   ossl_unused unsigned int unused__ext_type,
+                                   ossl_unused const unsigned char **unused__out,
+                                   ossl_unused size_t *unused__outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     /* Error: should not have been called */
     custom_ext_error = 1;
     return 0;                   /* Don't send an extension */
 }
 
-static int custom_ext_1_srv_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_1_srv_parse_cb(ossl_unused SSL *unused__ssl,
+                                     unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_1)
         custom_ext_error = 1;
@@ -568,16 +609,22 @@ static int custom_ext_1_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_1_srv_add_cb(SSL *s, unsigned int ext_type,
-                                   const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+static int custom_ext_1_srv_add_cb(ossl_unused SSL *unused__ssl,
+                                   ossl_unused unsigned int unused__ext_type,
+                                   ossl_unused const unsigned char **unused__out,
+                                   ossl_unused size_t *unused__outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     return 0;                   /* Don't send an extension */
 }
 
-static int custom_ext_2_srv_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_2_srv_parse_cb(ossl_unused SSL *unused__ssl,
+                                     unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_2)
         custom_ext_error = 1;
@@ -589,18 +636,24 @@ static int custom_ext_2_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_2_srv_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_2_srv_add_cb(ossl_unused SSL *unused__ssl,
+                                   ossl_unused unsigned int unused__ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     *out = NULL;
     *outlen = 0;
     return 1;                   /* Send empty extension */
 }
 
-static int custom_ext_3_srv_parse_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_srv_parse_cb(ossl_unused SSL *unused__ssl,
+                                     unsigned int ext_type,
                                      const unsigned char *in,
-                                     size_t inlen, int *al, void *arg)
+                                     size_t inlen,
+                                     ossl_unused int *unused__al,
+                                     ossl_unused void *unused__arg)
 {
     if (ext_type != CUSTOM_EXT_TYPE_3)
         custom_ext_error = 1;
@@ -612,9 +665,12 @@ static int custom_ext_3_srv_parse_cb(SSL *s, unsigned int ext_type,
     return 1;
 }
 
-static int custom_ext_3_srv_add_cb(SSL *s, unsigned int ext_type,
+static int custom_ext_3_srv_add_cb(ossl_unused SSL *unused__ssl,
+                                   ossl_unused unsigned int unused__ext_type,
                                    const unsigned char **out,
-                                   size_t *outlen, int *al, void *arg)
+                                   size_t *outlen,
+                                   ossl_unused int *unused__al,
+                                   ossl_unused void *unused__arg)
 {
     *out = (const unsigned char *)custom_ext_srv_string;
     *outlen = strlen(custom_ext_srv_string);
@@ -3083,7 +3139,8 @@ static int psk_key2bn(const char *pskkey, unsigned char *psk,
     return ret;
 }
 
-static unsigned int psk_client_callback(SSL *ssl, const char *hint,
+static unsigned int psk_client_callback(ossl_unused SSL *unused__ssl,
+                                        ossl_unused const char *unused__hint,
                                         char *identity,
                                         unsigned int max_identity_len,
                                         unsigned char *psk,
@@ -3106,7 +3163,8 @@ static unsigned int psk_client_callback(SSL *ssl, const char *hint,
     return psk_len;
 }
 
-static unsigned int psk_server_callback(SSL *ssl, const char *identity,
+static unsigned int psk_server_callback(ossl_unused SSL *unused__ssl,
+                                        const char *identity,
                                         unsigned char *psk,
                                         unsigned int max_psk_len)
 {

--- a/test/ssltestlib.c
+++ b/test/ssltestlib.c
@@ -236,7 +236,7 @@ static long tls_dump_ctrl(BIO *bio, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int tls_dump_gets(BIO *bio, char *buf, int size)
+static int tls_dump_gets(ossl_unused BIO *unused__bio, ossl_unused char *unused__buf, ossl_unused int unused__size)
 {
     /* We don't support this - not needed anyway */
     return -1;
@@ -527,7 +527,7 @@ static int mempacket_test_write(BIO *bio, const char *in, int inl)
     return mempacket_test_inject(bio, in, inl, -1, STANDARD_PACKET);
 }
 
-static long mempacket_test_ctrl(BIO *bio, int cmd, long num, void *ptr)
+static long mempacket_test_ctrl(BIO *bio, int cmd, long num, ossl_unused void *unused__ptr)
 {
     long ret = 1;
     MEMPACKET_TEST_CTX *ctx = BIO_get_data(bio);
@@ -579,7 +579,7 @@ static long mempacket_test_ctrl(BIO *bio, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int mempacket_test_gets(BIO *bio, char *buf, int size)
+static int mempacket_test_gets(ossl_unused BIO *unused__bio, ossl_unused char *unused__buf, ossl_unused int unused__size)
 {
     /* We don't support this - not needed anyway */
     return -1;
@@ -640,19 +640,19 @@ static int always_retry_free(BIO *bio)
     return 1;
 }
 
-static int always_retry_read(BIO *bio, char *out, int outl)
+static int always_retry_read(BIO *bio, ossl_unused char *unused__out, ossl_unused int unused__outl)
 {
     BIO_set_retry_read(bio);
     return -1;
 }
 
-static int always_retry_write(BIO *bio, const char *in, int inl)
+static int always_retry_write(BIO *bio, ossl_unused const char *unused__in, ossl_unused int unused__inl)
 {
     BIO_set_retry_write(bio);
     return -1;
 }
 
-static long always_retry_ctrl(BIO *bio, int cmd, long num, void *ptr)
+static long always_retry_ctrl(BIO *bio, int cmd, ossl_unused long unused__num, ossl_unused void *unused__ptr)
 {
     long ret = 1;
 
@@ -672,13 +672,13 @@ static long always_retry_ctrl(BIO *bio, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int always_retry_gets(BIO *bio, char *buf, int size)
+static int always_retry_gets(BIO *bio, ossl_unused char *unused__buf, ossl_unused int unused__size)
 {
     BIO_set_retry_read(bio);
     return -1;
 }
 
-static int always_retry_puts(BIO *bio, const char *str)
+static int always_retry_puts(BIO *bio, ossl_unused const char *unused__str)
 {
     BIO_set_retry_write(bio);
     return -1;

--- a/test/testutil/apps_mem.c
+++ b/test/testutil/apps_mem.c
@@ -11,7 +11,7 @@
 
 /* shim that avoids sucking in too much from apps/apps.c */
 
-void* app_malloc(int sz, const char *what)
+void* app_malloc(int sz, const ossl_unused char *unused__what)
 {
     void *vp = OPENSSL_malloc(sz);
 

--- a/test/testutil/cb.c
+++ b/test/testutil/cb.c
@@ -10,7 +10,7 @@
 #include "output.h"
 #include "tu_local.h"
 
-int openssl_error_cb(const char *str, size_t len, void *u)
+int openssl_error_cb(const char *str, ossl_unused size_t unused__len, ossl_unused void *unused__u)
 {
     return test_printf_stderr("%s", str);
 }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -25,7 +25,7 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
 /*
  * Top secret. This algorithm only works if no one knows what this number is.
  * Please don't tell anyone what it is.
- * 
+ *
  * This algorithm is for testing only - don't really use it!
  */
 static const unsigned char private_constant[XOR_KEY_SIZE] = {
@@ -70,7 +70,8 @@ static const OSSL_PARAM xor_group_params[] = {
     OSSL_PARAM_END
 };
 
-static int tls_prov_get_capabilities(void *provctx, const char *capability,
+static int tls_prov_get_capabilities(ossl_unused void *unused__provctx,
+                                     const char *capability,
                                      OSSL_CALLBACK *cb, void *arg)
 {
     /* We're only adding one group so we only call the callback once */
@@ -98,7 +99,7 @@ typedef struct {
     XORKEY *peerkey;
 } PROV_XOR_CTX;
 
-static void *xor_newctx(void *provctx)
+static void *xor_newctx(ossl_unused void *unused__provctx)
 {
     PROV_XOR_CTX *pxorctx = OPENSSL_zalloc(sizeof(PROV_XOR_CTX));
 
@@ -204,7 +205,7 @@ static OSSL_FUNC_keymgmt_gettable_params_fn xor_gettable_params;
 static OSSL_FUNC_keymgmt_set_params_fn xor_set_params;
 static OSSL_FUNC_keymgmt_settable_params_fn xor_settable_params;
 
-static void *xor_newdata(void *provctx)
+static void *xor_newdata(ossl_unused void *unused__provctx)
 {
     return OPENSSL_zalloc(sizeof(XORKEY));
 }
@@ -290,7 +291,7 @@ static const OSSL_PARAM xor_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *xor_gettable_params(void *provctx)
+static const OSSL_PARAM *xor_gettable_params(ossl_unused void *unused__provctx)
 {
     return xor_params;
 }
@@ -317,7 +318,7 @@ static const OSSL_PARAM xor_known_settable_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *xor_settable_params(void *provctx)
+static const OSSL_PARAM *xor_settable_params(ossl_unused void *unused__provctx)
 {
     return xor_known_settable_params;
 }
@@ -362,7 +363,7 @@ static int xor_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *xor_gen_settable_params(void *provctx)
+static const OSSL_PARAM *xor_gen_settable_params(ossl_unused void *unused__provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),
@@ -371,7 +372,9 @@ static const OSSL_PARAM *xor_gen_settable_params(void *provctx)
     return settable;
 }
 
-static void *xor_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+static void *xor_gen(void *genctx,
+                     ossl_unused OSSL_CALLBACK *unused__osslcb,
+                     ossl_unused void *unused__cbarg)
 {
     struct xor_gen_ctx *gctx = genctx;
     XORKEY *key = OPENSSL_zalloc(sizeof(*key));
@@ -426,7 +429,8 @@ static const OSSL_ALGORITHM tls_prov_keymgmt[] = {
     { NULL, NULL, NULL }
 };
 
-static const OSSL_ALGORITHM *tls_prov_query(void *provctx, int operation_id,
+static const OSSL_ALGORITHM *tls_prov_query(ossl_unused void *unused__provctx,
+                                            int operation_id,
                                             int *no_cache)
 {
     *no_cache = 0;
@@ -447,8 +451,8 @@ static const OSSL_DISPATCH tls_prov_dispatch_table[] = {
     { 0, NULL }
 };
 
-int tls_provider_init(const OSSL_CORE_HANDLE *handle,
-                      const OSSL_DISPATCH *in,
+int tls_provider_init(ossl_unused const OSSL_CORE_HANDLE *unused__handle,
+                      ossl_unused const OSSL_DISPATCH *unused__in,
                       const OSSL_DISPATCH **out,
                       void **provctx)
 {

--- a/test/tls13ccstest.c
+++ b/test/tls13ccstest.c
@@ -229,7 +229,7 @@ static long watchccs_ctrl(BIO *bio, int cmd, long num, void *ptr)
     return ret;
 }
 
-static int watchccs_gets(BIO *bio, char *buf, int size)
+static int watchccs_gets(ossl_unused BIO *unused__bio, ossl_unused char *unused__buf, ossl_unused int unused__size)
 {
     /* We don't support this - not needed anyway */
     return -1;

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -126,7 +126,7 @@ static unsigned char server_ats_iv[] = {
 };
 
 /* Mocked out implementations of various functions */
-int ssl3_digest_cached_records(SSL *s, int keep)
+int ssl3_digest_cached_records(ossl_unused SSL *unused__ssl, ossl_unused int unused__keep)
 {
     return 1;
 }
@@ -134,7 +134,8 @@ int ssl3_digest_cached_records(SSL *s, int keep)
 static int full_hash = 0;
 
 /* Give a hash of the currently set handshake */
-int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
+int ssl_handshake_hash(ossl_unused SSL *unused__ssl,
+                       unsigned char *out, size_t outlen,
                        size_t *hashlen)
 {
     if (sizeof(hs_start_hash) > outlen
@@ -152,29 +153,34 @@ int ssl_handshake_hash(SSL *s, unsigned char *out, size_t outlen,
     return 1;
 }
 
-const EVP_MD *ssl_handshake_md(SSL *s)
+const EVP_MD *ssl_handshake_md(ossl_unused SSL *unused__ssl)
 {
     return EVP_sha256();
 }
 
-void RECORD_LAYER_reset_read_sequence(RECORD_LAYER *rl)
+void RECORD_LAYER_reset_read_sequence(ossl_unused RECORD_LAYER *unused__rl)
 {
 }
 
-void RECORD_LAYER_reset_write_sequence(RECORD_LAYER *rl)
+void RECORD_LAYER_reset_write_sequence(ossl_unused RECORD_LAYER *unused__rl)
 {
 }
 
-int ssl_cipher_get_evp_cipher(SSL_CTX *ctx, const SSL_CIPHER *sslc,
-                                     const EVP_CIPHER **enc)
+int ssl_cipher_get_evp_cipher(ossl_unused SSL_CTX *unused__ctx,
+                              ossl_unused const SSL_CIPHER *unused__sslc,
+                              ossl_unused const EVP_CIPHER **unused__enc)
 {
     return 0;
 }
 
-int ssl_cipher_get_evp(SSL_CTX *ctx, const SSL_SESSION *s,
-                       const EVP_CIPHER **enc, const EVP_MD **md,
-                       int *mac_pkey_type, size_t *mac_secret_size,
-                       SSL_COMP **comp, int use_etm)
+int ssl_cipher_get_evp(ossl_unused SSL_CTX *unused__ctx,
+                       ossl_unused const SSL_SESSION *unused__s,
+                       ossl_unused const EVP_CIPHER **unused__enc,
+                       ossl_unused const EVP_MD **unused__md,
+                       ossl_unused int *unused__mac_pkey_type,
+                       ossl_unused size_t *unused__mac_secret_size,
+                       ossl_unused SSL_COMP **unused__comp,
+                       ossl_unused int unused__use_etm)
 
 {
     return 0;
@@ -185,39 +191,43 @@ int tls1_alert_code(int code)
     return code;
 }
 
-int ssl_log_secret(SSL *ssl,
-                   const char *label,
-                   const uint8_t *secret,
-                   size_t secret_len)
+int ssl_log_secret(ossl_unused SSL *unused__ssl,
+                   ossl_unused const char *unused__label,
+                   ossl_unused const uint8_t *unused__secret,
+                   ossl_unused size_t unused__secret_len)
 {
     return 1;
 }
 
-const EVP_MD *ssl_md(SSL_CTX *ctx, int idx)
+const EVP_MD *ssl_md(ossl_unused SSL_CTX *unused__ctx, ossl_unused int unused__idx)
 {
     return EVP_sha256();
 }
 
-void ossl_statem_fatal(SSL *s, int al, int func, int reason, const char *file,
-                           int line)
+void ossl_statem_fatal(ossl_unused SSL *unused__ssl,
+                       ossl_unused int unused__al,
+                       ossl_unused int unused__func,
+                       ossl_unused int unused__reason,
+                       ossl_unused const char *unused__file,
+                       ossl_unused int unused__line)
 {
 }
 
-int ossl_statem_export_allowed(SSL *s)
+int ossl_statem_export_allowed(ossl_unused SSL *unused__ssl)
 {
     return 1;
 }
 
-int ossl_statem_export_early_allowed(SSL *s)
+int ossl_statem_export_early_allowed(ossl_unused SSL *unused__ssl)
 {
     return 1;
 }
 
-void ssl_evp_cipher_free(const EVP_CIPHER *cipher)
+void ssl_evp_cipher_free(ossl_unused const EVP_CIPHER *unused__cipher)
 {
 }
 
-void ssl_evp_md_free(const EVP_MD *md)
+void ssl_evp_md_free(ossl_unused const EVP_MD *unused__md)
 {
 }
 

--- a/test/uitest.c
+++ b/test/uitest.c
@@ -18,7 +18,7 @@
 #include <openssl/ui.h>
 
 /* Old style PEM password callback */
-static int test_pem_password_cb(char *buf, int size, int rwflag, void *userdata)
+static int test_pem_password_cb(char *buf, int size, ossl_unused int unused__rwflag, void *userdata)
 {
     OPENSSL_strlcpy(buf, (char *)userdata, (size_t)size);
     return strlen(buf);


### PR DESCRIPTION
This change makes it possible to compile OpenSSL with "-Wunused-parameters" without a warning and make intentionally unused parameters explicit. The changes brings the code-base closer to a silent compilation with "-Wextra". For more details, see the commit message.

The change is similar to the recent change https://github.com/openssl/openssl/commit/1017ab21e478b18dd2d9266955dee7e418932a3c but is applied to the full code-base.

One other approach - with less typographic overhead - would to define a macro like the following

```
   #if defined(__GNUC__)
   # define OSSL_UNUSED(x) UNUSED_ ## (x) __attribute__((unused))
   #else
   # define OSSL_UNUSED(x) (x)
   #endif
```

such that instead of 

```
  static OSSL_STORE_INFO *
  try_decode_X509Certificate(const char *pem_name,
			     ossl_unused const char *UNUSED_pem_header,
			     const unsigned char *blob,
			     size_t len,
			     ossl_unused void **UNUSED_pctx,
			     int *matchcount,
			     ossl_unused const UI_METHOD *UNUSED_ui_method,
			     ossl_unused void *UNUSED_ui_data,
			     ossl_unused const char *UNUSED_uri,
			     OPENSSL_CTX *libctx,
			     const char *propq)
```

 
 the following could be used 

```
   static OSSL_STORE_INFO *
   try_decode_X509Certificate(const char *pem_name,
			      const char *OSSL_UNUSED(pem_header),
			      const unsigned char *blob,
			      size_t len,
			      void **OSSL_UNUSED(pctx),
			      int *matchcount,
			      const UI_METHOD *OSSL_UNUSED(ui_method),
			      void *OSSL_UNUSED(ui_data),
			      const char *OSSL_UNUSED(uri),
			      OPENSSL_CTX *libctx,
			      const char *propq)
```


The latter one would be easier for the developer, since flagging of the parameter is sufficient (no naming conventions to follow). This transition could be made with little effort if wanted.
