### PR TITLE
Only support asm AES-GCM for armv8 with aes+pmull

### DIFF
--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -93,8 +93,8 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
 #    define HWAES_ctr32_encrypt_blocks aes_v8_ctr32_encrypt_blocks
 #    define AES_PMULL_CAPABLE ((OPENSSL_armcap_P & ARMV8_PMULL) && (OPENSSL_armcap_P & ARMV8_AES))
 
-/* Currently only support armv8 AES-GCM asm for AES_PMULL_CAPABLE target */
-#    if __ARM_MAX_ARCH__>=8 && AES_PMULL_CAPABLE
+/* Currently only support armv8 AES-GCM asm for target with crypto extension */
+#    if __ARM_MAX_ARCH__>=8 && defined(__ARM_FEATURE_CRYPTO)
 #     define AES_GCM_ENC_BYTES 512
 #     define AES_GCM_DEC_BYTES 512
 #     define AES_gcm_encrypt armv8_aes_gcm_encrypt

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -92,9 +92,11 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
 #    define HWAES_ecb_encrypt aes_v8_ecb_encrypt
 #    define HWAES_ctr32_encrypt_blocks aes_v8_ctr32_encrypt_blocks
 #    define AES_PMULL_CAPABLE ((OPENSSL_armcap_P & ARMV8_PMULL) && (OPENSSL_armcap_P & ARMV8_AES))
-#    define AES_GCM_ENC_BYTES 512
-#    define AES_GCM_DEC_BYTES 512
-#    if __ARM_MAX_ARCH__>=8
+
+/* Currently only support armv8 AES-GCM asm for AES_PMULL_CAPABLE target */
+#    if __ARM_MAX_ARCH__>=8 && AES_PMULL_CAPABLE
+#     define AES_GCM_ENC_BYTES 512
+#     define AES_GCM_DEC_BYTES 512
 #     define AES_gcm_encrypt armv8_aes_gcm_encrypt
 #     define AES_gcm_decrypt armv8_aes_gcm_decrypt
 #     define AES_GCM_ASM(gctx) ((gctx)->ctr==aes_v8_ctr32_encrypt_blocks && \


### PR DESCRIPTION
Fixes #11910
+ I haven't actually done compiles to test this fix, but I think it's the right shape. Requesting confirmation from @zorrorffm
+ If compiling for an armv8 target without aes/pmull support, do not introduce declarations of gcm functions that will never be defined or used