### PR TITLE
Fix broken windows builds.

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -406,7 +406,7 @@ test: tests
 	set SRCTOP=$(SRCDIR)
 	set BLDTOP=$(BLDDIR)
 	set PERL=$(PERL)
-	set FIPSKEY=$(FIPSKEY) \
+	set FIPSKEY=$(FIPSKEY)
 	"$(PERL)" "$(SRCDIR)\test\run_tests.pl" $(TESTS)
 	@{- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}
 	@$(ECHO) "Tests are not supported with your chosen Configure options"


### PR DESCRIPTION
A miscellaneous ```\``` was accidently added to set FIPSKEY=$(FIPSKEY) which was causing some
external CI build loops to not produce test results.
It looks like it was accidently copied from the unix variant which requires the slash.
Thanks to Wolfgang Beck for tracking down the issue.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
