### PR TITLE
conf: add diagnostic option.

### DIFF
--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -89,6 +89,7 @@ static int provider_conf_load(OPENSSL_CTX *libctx, const char *name,
 
     if (!ecmds) {
         CRYPTOerr(CRYPTO_F_PROVIDER_CONF_LOAD, CRYPTO_R_PROVIDER_SECTION_ERROR);
+        ERR_add_error_data(3, "section=", value, " not found");
         return 0;
     }
 

--- a/doc/man3/CONF_modules_load_file.pod
+++ b/doc/man3/CONF_modules_load_file.pod
@@ -24,7 +24,8 @@ library context B<libctx> file B<filename> and application name B<appname>.
 If B<filename> is NULL the standard OpenSSL configuration file is used.
 If B<appname> is NULL the standard OpenSSL application name B<openssl_conf> is
 used.
-The behaviour can be customized using B<flags>.
+The behaviour can be customized using B<flags>. Note that, the error suppressing
+can be overriden by B<config_diagnostics> as described in L<config(5)>.
 
 CONF_modules_load_file() is the same as CONF_modules_load_file_with_libctx() but
 has a NULL library context.

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -160,6 +160,12 @@ how to configure any modules in the library. It is not an error to leave
 any module in its default configuration. An application can specify a
 different name by calling CONF_modules_load_file(), for example, directly.
 
+OpenSSL also looks up the value of B<config_diagnostics>.
+If this exists and has a nonzero numeric value, any error suppressing flags
+passed to CONF_modules_load() will be ignored.
+This is useful for diagnosing misconfigurations and should not be used in
+production.
+
  # This must be in the default section
  openssl_conf = openssl_init
 
@@ -482,6 +488,7 @@ L<openssl-x509(1)>, L<openssl-req(1)>, L<openssl-ca(1)>,
 L<openssl-fipsinstall(1)>,
 L<ASN1_generate_nconf(3)>,
 L<EVP_set_default_properties(3)>,
+L<CONF_modules_load(3)>,
 L<CONF_modules_load_file(3)>,
 L<fips_config(5)>, and
 L<x509v3_config(5)>.


### PR DESCRIPTION
This is intended to assist with debugging configurations.

- [x] documentation is added or updated
- [ ] tests are added or updated
