### PR TITLE
Add OCSP_PARTIAL_CHAIN to OCSP_basic_verify()

### DIFF
--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -38,6 +38,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
     STACK_OF(X509) *chain = NULL;
     STACK_OF(X509) *untrusted = NULL;
     X509_STORE_CTX *ctx = NULL;
+    X509_VERIFY_PARAM *vp;
     int i, ret = ocsp_find_signer(&signer, bs, certs, flags);
 
     if (!ret) {
@@ -85,6 +86,9 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
             OCSPerr(OCSP_F_OCSP_BASIC_VERIFY, ERR_R_X509_LIB);
             goto f_err;
         }
+        if ((flags & OCSP_PARTIAL_CHAIN) != 0
+                && (vp = X509_STORE_CTX_get0_param(ctx)) != NULL)
+            X509_VERIFY_PARAM_set_flags(vp, X509_V_FLAG_PARTIAL_CHAIN);
 
         X509_STORE_CTX_set_purpose(ctx, X509_PURPOSE_OCSP_HELPER);
         ret = X509_verify_cert(ctx);

--- a/doc/man3/OCSP_resp_find_status.pod
+++ b/doc/man3/OCSP_resp_find_status.pod
@@ -120,7 +120,7 @@ OCSP_basic_verify() checks that the basic response message B<bs> is correctly
 signed and that the signer certificate can be validated. It takes B<st> as
 the trusted store and B<certs> as a set of untrusted intermediate certificates.
 The function first tries to find the signer certificate of the response
-in <certs>. It also searches the certificates the responder may have included
+in B<certs>. It also searches the certificates the responder may have included
 in B<bs> unless the B<flags> contain B<OCSP_NOINTERN>.
 It fails if the signer certificate cannot be found.
 Next, the function checks the signature of B<bs> and fails on error
@@ -128,6 +128,10 @@ unless the B<flags> contain B<OCSP_NOSIGS>. Then the function already returns
 success if the B<flags> contain B<OCSP_NOVERIFY> or if the signer certificate
 was found in B<certs> and the B<flags> contain B<OCSP_TRUSTOTHER>.
 Otherwise the function continues by validating the signer certificate.
+If B<flags> contains B<OCSP_PARTIAL_CHAIN>, intermediate CA certificates
+in B<st> are trust-anchors.
+For more details, see the description of B<X509_V_FLAG_PARTIAL_CHAIN>
+in L<X509_VERIFY_PARAM_set_flags(3)/VERIFICATION FLAGS>.
 To this end, all certificates in B<cert> and in B<bs> are considered as
 untrusted certificates for the construction of the validation path for the
 signer certificate unless the B<OCSP_NOCHAIN> flag is set. After successful path
@@ -185,7 +189,8 @@ L<OCSP_cert_to_id(3)>,
 L<OCSP_request_add1_nonce(3)>,
 L<OCSP_REQUEST_new(3)>,
 L<OCSP_response_status(3)>,
-L<OCSP_sendreq_new(3)>
+L<OCSP_sendreq_new(3)>,
+L<X509_VERIFY_PARAM_set_flags(3)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -75,7 +75,7 @@ These functions manipulate the B<X509_VERIFY_PARAM> structure associated with
 a certificate verification operation.
 
 The X509_VERIFY_PARAM_set_flags() function sets the flags in B<param> by oring
-it with B<flags>. See the B<VERIFICATION FLAGS> section for a complete
+it with B<flags>. See L</VERIFICATION FLAGS> for a complete
 description of values the B<flags> parameter can take.
 
 X509_VERIFY_PARAM_get_flags() returns the flags in B<param>.

--- a/include/openssl/ocsp.h
+++ b/include/openssl/ocsp.h
@@ -102,6 +102,7 @@ extern "C" {
 #  define OCSP_TRUSTOTHER                 0x200
 #  define OCSP_RESPID_KEY                 0x400
 #  define OCSP_NOTIME                     0x800
+#  define OCSP_PARTIAL_CHAIN              0x1000
 
 typedef struct ocsp_cert_id_st OCSP_CERTID;
 typedef struct ocsp_one_request_st OCSP_ONEREQ;


### PR DESCRIPTION
This adds a flag, OCSP_PARTIAL_CHAIN, to the OCSP_basic_verify()
function.  This is equivalent to X509_V_FLAG_PARTIAL_CHAIN, in that
if any certificate in the OCSP response is in the trust store, then
trust it. The new flag is documented for OCSP.

A new function X509_STORE_CTX_get_flags() was added.  That function is
not documented, since doc/man3/X509_VERIFY_PARAM_set_flags.pod calls
this family out as likely to be deprecated.

-----------

Akamai needs this.  I hope it will get reviewed before the BETA as I think that adding a new flag is a considered to be an API change.