### PR TITLE
[WIP, Parked] EVP: Adapt EVP_PKEY_set_alias_type() for provider-native EVP_PKEYs

### DIFF
--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -434,7 +434,7 @@ int evp_keymgmt_util_convert(EVP_PKEY *target, const char *keytype,
                              OPENSSL_CTX *libctx, const char *propq)
 {
     EVP_KEYMGMT *new_keymgmt;
-    EVP_PKEY tmp = { 0, };
+    EVP_PKEY tmp;
     struct evp_keymgmt_util_try_import_data_st import_data;
     int selection = OSSL_KEYMGMT_SELECT_ALL;
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -681,6 +681,8 @@ void *evp_keymgmt_util_fromdata(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
 int evp_keymgmt_util_has(EVP_PKEY *pk, int selection);
 int evp_keymgmt_util_match(EVP_PKEY *pk1, EVP_PKEY *pk2, int selection);
 int evp_keymgmt_util_copy(EVP_PKEY *to, EVP_PKEY *from, int selection);
+int evp_keymgmt_util_convert(EVP_PKEY *target, const char *keytype,
+                             OPENSSL_CTX *libctx, const char *propq);
 void *evp_keymgmt_util_gen(EVP_PKEY *target, EVP_KEYMGMT *keymgmt,
                            void *genctx, OSSL_CALLBACK *cb, void *cbarg);
 int evp_keymgmt_util_get_deflt_digest_name(EVP_KEYMGMT *keymgmt,


### PR DESCRIPTION
For provider-native keys, this is a bit more complex than flipping a
key identity.  We solve this by performing an export/import between
the current and the target EVP_KEYMGMT.
