### PR TITLE
Fix incorrect selection flags for ec serializer.

### DIFF
--- a/providers/implementations/serializers/serializer_ec_priv.c
+++ b/providers/implementations/serializers/serializer_ec_priv.c
@@ -128,7 +128,7 @@ static int ec_priv_der_data(void *vctx, const OSSL_PARAM params[],
         EC_KEY *eckey;
 
         if ((eckey = ec_new(ctx->provctx)) != NULL
-            && ec_import(eckey, OSSL_KEYMGMT_SELECT_KEYPAIR, params)
+            && ec_import(eckey, OSSL_KEYMGMT_SELECT_ALL, params)
             && ec_priv_der(ctx, eckey, out, cb, cbarg))
             ok = 1;
         ec_free(eckey);
@@ -175,7 +175,7 @@ static int ec_pem_priv_data(void *vctx, const OSSL_PARAM params[],
         EC_KEY *eckey;
 
         if ((eckey = ec_new(ctx->provctx)) != NULL
-            && ec_import(eckey, OSSL_KEYMGMT_SELECT_KEYPAIR, params)
+            && ec_import(eckey, OSSL_KEYMGMT_SELECT_ALL, params)
             && ec_pem_priv(ctx, eckey, out, cb, cbarg))
             ok = 1;
         ec_free(eckey);
@@ -233,7 +233,7 @@ static int ec_priv_print_data(void *vctx, const OSSL_PARAM params[],
         EC_KEY *eckey;
 
         if ((eckey = ec_new(ctx->provctx)) != NULL
-            && ec_import(eckey, OSSL_KEYMGMT_SELECT_KEYPAIR, params)
+            && ec_import(eckey, OSSL_KEYMGMT_SELECT_ALL, params)
             && ec_priv_print(ctx, eckey, out, cb, cbarg))
             ok = 1;
         ec_free(eckey);

--- a/providers/implementations/serializers/serializer_ec_pub.c
+++ b/providers/implementations/serializers/serializer_ec_pub.c
@@ -17,6 +17,9 @@
 #include "prov/provider_ctx.h"
 #include "serializer_local.h"
 
+#define EC_SELECT_PUBLIC_IMPORTABLE                                            \
+    OSSL_KEYMGMT_SELECT_PUBLIC_KEY | OSSL_KEYMGMT_SELECT_ALL_PARAMETERS
+
 static OSSL_FUNC_serializer_newctx_fn ec_pub_newctx;
 static OSSL_FUNC_serializer_freectx_fn ec_pub_freectx;
 static OSSL_FUNC_serializer_serialize_data_fn ec_pub_der_data;
@@ -58,7 +61,7 @@ static int ec_pub_der_data(void *vctx, const OSSL_PARAM params[],
 
         /* vctx == provctx */
         if ((eckey = ec_new(vctx)) != NULL
-            && ec_import(eckey, OSSL_KEYMGMT_SELECT_KEYPAIR, params)
+            && ec_import(eckey, EC_SELECT_PUBLIC_IMPORTABLE, params)
             && ec_pub_der(vctx, eckey, out, cb, cbarg))
             ok = 1;
         ec_free(eckey);
@@ -100,7 +103,7 @@ static int ec_pub_pem_data(void *vctx, const OSSL_PARAM params[],
 
         /* ctx == provctx */
         if ((eckey = ec_new(vctx)) != NULL
-            && ec_import(eckey, OSSL_KEYMGMT_SELECT_KEYPAIR, params)
+            && ec_import(eckey, EC_SELECT_PUBLIC_IMPORTABLE, params)
             && ec_pub_pem(vctx, eckey, out, cb, cbarg))
             ok = 1;
         ec_free(eckey);
@@ -141,7 +144,7 @@ static int ec_pub_print_data(void *vctx, const OSSL_PARAM params[],
 
         /* ctx == provctx */
         if ((eckey = ec_new(vctx)) != NULL
-            && ec_import(eckey, OSSL_KEYMGMT_SELECT_KEYPAIR, params)
+            && ec_import(eckey, EC_SELECT_PUBLIC_IMPORTABLE, params)
             && ec_pub_print(vctx, eckey, out, cb, cbarg))
             ok = 1;
         ec_free(eckey);

--- a/test/recipes/15-test_genec.t
+++ b/test/recipes/15-test_genec.t
@@ -194,6 +194,7 @@ plan tests => scalar(@curve_list) * scalar(keys %params_encodings)
     + 1                             # Checking that with no curve it fails
     + 1                             # Checking that with unknown curve it fails
     + 1                             # Subtest for explicit only curves
+    + 1                             # base serializer test
     ;
 
 ok(!run(app([ 'openssl', 'genpkey',
@@ -204,6 +205,15 @@ ok(!run(app([ 'openssl', 'genpkey',
               '-algorithm', 'EC',
               '-pkeyopt', 'ec_paramgen_curve:bogus_foobar_curve'])),
    "genpkey EC with unknown curve name should fail");
+
+ok(run(app([ 'openssl', 'genpkey',
+             '-provider-path', 'providers',
+             '-provider', 'base',
+             '-config', srctop_file("test", "default.cnf"),
+             '-algorithm', 'EC',
+             '-pkeyopt', 'ec_paramgen_curve:prime256v1',
+             '-text'])),
+    "generate a private key and serialize it using the base provider");
 
 foreach my $curvename (@curve_list) {
     foreach my $paramenc (sort keys %params_encodings) {


### PR DESCRIPTION
Fixes #12630

ec_import requires domain parameters to be part of the selection.
The public and private serialisers were not selecting the correct flags so the import was failing.
Added a test that uses the base provider so that a export/import happens for serialization.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
