### PR TITLE
run_tests.pl: Add warning that HARNESS_JOBS > 1 overrides HARNESS_VERBOSE

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -56,6 +56,8 @@ my %openssl_args = ();
 $openssl_args{'failure_verbosity'} = $ENV{HARNESS_VERBOSE} ? 0 :
     $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} ? 2 :
     1; # $ENV{HARNESS_VERBOSE_FAILURE}
+print "Warning: HARNESS_JOBS > 1 overrides HARNESS_VERBOSE\n"
+    if $ENV{HARNESS_JOBS} > 1;
 print "Warning: HARNESS_VERBOSE overrides HARNESS_VERBOSE_FAILURE*\n"
     if ($ENV{HARNESS_VERBOSE} && ($ENV{HARNESS_VERBOSE_FAILURE}
                                   || $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS}));


### PR DESCRIPTION
It turns out that `V=1` gets ignored if `HARNESS_JOBS` > 1.