### PR TITLE
X509_dup: fix copying of libctx and propq using new ASN1_OP_DUP_POST cb operation

### DIFF
--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -48,8 +48,7 @@ void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, const void *x)
 
 void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
 {
-    const ASN1_AUX *aux = it->funcs;
-    ASN1_aux_cb *asn1_cb = aux != NULL ? aux->asn1_cb : NULL;
+    ASN1_aux_cb *asn1_cb = NULL;
     unsigned char *b = NULL;
     const unsigned char *p;
     long i;
@@ -57,6 +56,13 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
 
     if (x == NULL)
         return NULL;
+
+    if (it->itype == ASN1_ITYPE_SEQUENCE || it->itype == ASN1_ITYPE_CHOICE
+        || it->itype == ASN1_ITYPE_NDEF_SEQUENCE) {
+        const ASN1_AUX *aux = it->funcs;
+
+        asn1_cb = aux != NULL ? aux->asn1_cb : NULL;
+    }
 
     if (asn1_cb != NULL
         && !asn1_cb(ASN1_OP_DUP_PRE, (ASN1_VALUE **)&x, it, NULL))

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -97,6 +97,17 @@ static int x509_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         ASN1_OCTET_STRING_free(ret->distinguishing_id);
         break;
 
+    case ASN1_OP_DUP_POST:
+        {
+            X509 *old = exarg;
+
+            ret->libctx = old->libctx;
+            ret->propq = old->propq;
+        }
+        break;
+
+    default:
+        break;
     }
 
     return 1;

--- a/include/openssl/asn1t.h.in
+++ b/include/openssl/asn1t.h.in
@@ -746,6 +746,8 @@ typedef struct ASN1_STREAM_ARG_st {
 # define ASN1_OP_STREAM_POST     11
 # define ASN1_OP_DETACHED_PRE    12
 # define ASN1_OP_DETACHED_POST   13
+# define ASN1_OP_DUP_PRE         14
+# define ASN1_OP_DUP_POST        15
 
 /* Macro to implement a primitive type */
 # define IMPLEMENT_ASN1_TYPE(stname) IMPLEMENT_ASN1_TYPE_ex(stname, stname, 0)

--- a/include/openssl/asn1t.h.in
+++ b/include/openssl/asn1t.h.in
@@ -37,6 +37,55 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 extern "C" {
 #endif
 
+/*-
+ * These are the possible values for the itype field of the
+ * ASN1_ITEM structure and determine how it is interpreted.
+ *
+ * For PRIMITIVE types the underlying type
+ * determines the behaviour if items is NULL.
+ *
+ * Otherwise templates must contain a single
+ * template and the type is treated in the
+ * same way as the type specified in the template.
+ *
+ * For SEQUENCE types the templates field points
+ * to the members, the size field is the
+ * structure size.
+ *
+ * For CHOICE types the templates field points
+ * to each possible member (typically a union)
+ * and the 'size' field is the offset of the
+ * selector.
+ *
+ * The 'funcs' field is used for application-specific
+ * data and functions.
+ *
+ * The EXTERN type uses a new style d2i/i2d.
+ * The new style should be used where possible
+ * because it avoids things like the d2i IMPLICIT
+ * hack.
+ *
+ * MSTRING is a multiple string type, it is used
+ * for a CHOICE of character strings where the
+ * actual strings all occupy an ASN1_STRING
+ * structure. In this case the 'utype' field
+ * has a special meaning, it is used as a mask
+ * of acceptable types using the B_ASN1 constants.
+ *
+ * NDEF_SEQUENCE is the same as SEQUENCE except
+ * that it will use indefinite length constructed
+ * encoding if requested.
+ *
+ */
+
+# define ASN1_ITYPE_PRIMITIVE            0x0
+# define ASN1_ITYPE_SEQUENCE             0x1
+# define ASN1_ITYPE_CHOICE               0x2
+/* unused value                          0x3 */
+# define ASN1_ITYPE_EXTERN               0x4
+# define ASN1_ITYPE_MSTRING              0x5
+# define ASN1_ITYPE_NDEF_SEQUENCE        0x6
+
 /* Macro to obtain ASN1_ADB pointer from a type (only used internally) */
 # define ASN1_ADB_ptr(iptr) ((const ASN1_ADB *)((iptr)()))
 
@@ -557,63 +606,11 @@ struct ASN1_ITEM_st {
     const ASN1_TEMPLATE *templates; /* If SEQUENCE or CHOICE this contains
                                      * the contents */
     long tcount;                /* Number of templates if SEQUENCE or CHOICE */
-    const void *funcs;          /* functions that handle this type */
+    const void *funcs;          /* further data and type-specific functions */
+    /* funcs can be ASN1_PRIMITIVE_FUNCS*, ASN1_EXTERN_FUNCS*, or ASN1_AUX* */
     long size;                  /* Structure size (usually) */
     const char *sname;          /* Structure name */
 };
-
-/*-
- * These are values for the itype field and
- * determine how the type is interpreted.
- *
- * For PRIMITIVE types the underlying type
- * determines the behaviour if items is NULL.
- *
- * Otherwise templates must contain a single
- * template and the type is treated in the
- * same way as the type specified in the template.
- *
- * For SEQUENCE types the templates field points
- * to the members, the size field is the
- * structure size.
- *
- * For CHOICE types the templates field points
- * to each possible member (typically a union)
- * and the 'size' field is the offset of the
- * selector.
- *
- * The 'funcs' field is used for application
- * specific functions.
- *
- * The EXTERN type uses a new style d2i/i2d.
- * The new style should be used where possible
- * because it avoids things like the d2i IMPLICIT
- * hack.
- *
- * MSTRING is a multiple string type, it is used
- * for a CHOICE of character strings where the
- * actual strings all occupy an ASN1_STRING
- * structure. In this case the 'utype' field
- * has a special meaning, it is used as a mask
- * of acceptable types using the B_ASN1 constants.
- *
- * NDEF_SEQUENCE is the same as SEQUENCE except
- * that it will use indefinite length constructed
- * encoding if requested.
- *
- */
-
-# define ASN1_ITYPE_PRIMITIVE            0x0
-
-# define ASN1_ITYPE_SEQUENCE             0x1
-
-# define ASN1_ITYPE_CHOICE               0x2
-
-# define ASN1_ITYPE_EXTERN               0x4
-
-# define ASN1_ITYPE_MSTRING              0x5
-
-# define ASN1_ITYPE_NDEF_SEQUENCE        0x6
 
 /*
  * Cache for ASN1 tag and length, so we don't keep re-reading it for things

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -33,16 +33,6 @@ typedef struct test_fixture {
 static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *default_null_provider = NULL, *provider = NULL;
 
-/* TODO(3.0) Clean this up - See issue #12680 */
-static X509 *X509_dup_ex(const X509 *cert)
-{
-    X509 *dup = X509_dup(cert);
-
-    if (dup != NULL)
-        x509_set0_libctx(dup, libctx, NULL);
-    return dup;
-}
-
 static unsigned char ref[CMP_TEST_REFVALUE_LENGTH];
 
 static void tear_down(CMP_MSG_TEST_FIXTURE *fixture)
@@ -296,7 +286,7 @@ static int test_cmp_create_certconf(void)
     fixture->fail_info = 0;
     fixture->expected = 1;
     if (!TEST_true(ossl_cmp_ctx_set0_newCert(fixture->cmp_ctx,
-                                             X509_dup_ex(cert)))) {
+                                             X509_dup(cert)))) {
         tear_down(fixture);
         fixture = NULL;
     }
@@ -310,7 +300,7 @@ static int test_cmp_create_certconf_badAlg(void)
     fixture->fail_info = 1 << OSSL_CMP_PKIFAILUREINFO_badAlg;
     fixture->expected = 1;
     if (!TEST_true(ossl_cmp_ctx_set0_newCert(fixture->cmp_ctx,
-                                             X509_dup_ex(cert)))) {
+                                             X509_dup(cert)))) {
         tear_down(fixture);
         fixture = NULL;
     }
@@ -324,7 +314,7 @@ static int test_cmp_create_certconf_fail_info_max(void)
     fixture->fail_info = 1 << OSSL_CMP_PKIFAILUREINFO_MAX;
     fixture->expected = 1;
     if (!TEST_true(ossl_cmp_ctx_set0_newCert(fixture->cmp_ctx,
-                                             X509_dup_ex(cert)))) {
+                                             X509_dup(cert)))) {
         tear_down(fixture);
         fixture = NULL;
     }
@@ -405,7 +395,7 @@ static int execute_certrep_create(CMP_MSG_TEST_FIXTURE *fixture)
     cresp->certifiedKeyPair->certOrEncCert->type =
         OSSL_CMP_CERTORENCCERT_CERTIFICATE;
     if ((cresp->certifiedKeyPair->certOrEncCert->value.certificate =
-         X509_dup_ex(cert)) == NULL
+         X509_dup(cert)) == NULL
             || !sk_OSSL_CMP_CERTRESPONSE_push(crepmsg->response, cresp))
         goto err;
     cresp = NULL;


### PR DESCRIPTION
This fixes #12680.

Unfortunately the arg types of the generic ASN.1 callback function:
```
typedef int ASN1_aux_cb(int operation, ASN1_VALUE **in, const ASN1_ITEM *it,
                        void *exarg);
```
are not really adequate here, so I had to use pretty ugly casts, but it works.
