### PR TITLE
Fix CMS so that it still works with non fetchable algorithms.

### DIFF
--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -394,12 +394,17 @@ BIO *cms_DigestAlgorithm_init_bio(X509_ALGOR *digestAlgorithm,
 {
     BIO *mdbio = NULL;
     const ASN1_OBJECT *digestoid;
-    EVP_MD *digest = NULL;
+    const EVP_MD *digest = NULL;
+    EVP_MD *fetched_digest = NULL;
     const char *alg;
 
     X509_ALGOR_get0(&digestoid, NULL, NULL, digestAlgorithm);
     alg = OBJ_nid2sn(OBJ_obj2nid(digestoid));
-    digest = EVP_MD_fetch(ctx->libctx, alg, ctx->propq);
+    fetched_digest = EVP_MD_fetch(ctx->libctx, alg, ctx->propq);
+    if (fetched_digest != NULL)
+        digest = fetched_digest;
+    else
+        digest = EVP_get_digestbyobj(digestoid);
     if (digest == NULL) {
         CMSerr(CMS_F_CMS_DIGESTALGORITHM_INIT_BIO,
                CMS_R_UNKNOWN_DIGEST_ALGORITHM);
@@ -410,10 +415,10 @@ BIO *cms_DigestAlgorithm_init_bio(X509_ALGOR *digestAlgorithm,
         CMSerr(CMS_F_CMS_DIGESTALGORITHM_INIT_BIO, CMS_R_MD_BIO_INIT_ERROR);
         goto err;
     }
-    EVP_MD_free(digest);
+    EVP_MD_free(fetched_digest);
     return mdbio;
  err:
-    EVP_MD_free(digest);
+    EVP_MD_free(fetched_digest);
     BIO_free(mdbio);
     return NULL;
 }

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -817,7 +817,8 @@ int CMS_SignerInfo_verify(CMS_SignerInfo *si)
     unsigned char *abuf = NULL;
     int alen, r = -1;
     const char *name;
-    EVP_MD *md = NULL;
+    const EVP_MD *md;
+    EVP_MD *fetched_md = NULL;
     const CMS_CTX *ctx = si->cms_ctx;
 
     if (si->pkey == NULL) {
@@ -829,7 +830,11 @@ int CMS_SignerInfo_verify(CMS_SignerInfo *si)
         return -1;
 
     name = OBJ_nid2sn(OBJ_obj2nid(si->digestAlgorithm->algorithm));
-    md = EVP_MD_fetch(ctx->libctx, name, ctx->propq);
+    fetched_md = EVP_MD_fetch(ctx->libctx, name, ctx->propq);
+    if (fetched_md != NULL)
+        md = fetched_md;
+    else
+        md = EVP_get_digestbyobj(si->digestAlgorithm->algorithm);
     if (md == NULL)
         return -1;
     if (si->mctx == NULL && (si->mctx = EVP_MD_CTX_new()) == NULL) {
@@ -860,7 +865,7 @@ int CMS_SignerInfo_verify(CMS_SignerInfo *si)
     if (r <= 0)
         CMSerr(CMS_F_CMS_SIGNERINFO_VERIFY, CMS_R_VERIFICATION_FAILURE);
  err:
-    EVP_MD_free(md);
+    EVP_MD_free(fetched_md);
     EVP_MD_CTX_reset(mctx);
     return r;
 }


### PR DESCRIPTION
Fixes #12633

For CMS the Gost engine still requires calls to EVP_get_digestbyname() and EVP_get_cipherbyname() when
EVP_MD_fetch() and EVP_CIPHER_fetch() return NULL.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
