### PR TITLE
Clean away some declarations

### DIFF
--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -21,7 +21,6 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type, int pbits, int qbits,
 
 int dsa_sign_int(int type, const unsigned char *dgst,
                  int dlen, unsigned char *sig, unsigned int *siglen, DSA *dsa);
-const unsigned char *dsa_algorithmidentifier_encoding(int md_nid, size_t *len);
 
 FFC_PARAMS *dsa_get0_params(DSA *dsa);
 int dsa_ffc_params_fromdata(DSA *dsa, const OSSL_PARAM params[]);

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -57,7 +57,6 @@ OPENSSL_CTX *ec_key_get_libctx(const EC_KEY *eckey);
 const char *ec_key_get0_propq(const EC_KEY *eckey);
 const char *ec_curve_nid2name(int nid);
 int ec_curve_name2nid(const char *name);
-const unsigned char *ecdsa_algorithmidentifier_encoding(int md_nid, size_t *len);
 
 /* Backend support */
 int ec_key_fromdata(EC_KEY *ecx, const OSSL_PARAM params[], int include_private);

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -87,7 +87,6 @@ int int_rsa_verify(int dtype, const unsigned char *m,
                    size_t siglen, RSA *rsa);
 
 const unsigned char *rsa_digestinfo_encoding(int md_nid, size_t *len);
-const unsigned char *rsa_algorithmidentifier_encoding(int md_nid, size_t *len);
 
 extern const char *rsa_mp_factor_names[];
 extern const char *rsa_mp_exp_names[];


### PR DESCRIPTION
dsa_algorithmidentifier_encoding(), ecdsa_algorithmidentifier_encoding(),
rsa_algorithmidentifier_encoding() have been replaced with DER writer
functions, so they aren't useful any more.
