### PR TITLE
Building: Build Unix static libraries a limited number of object files at a time

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -66,7 +66,7 @@ my %targets=(
         template        => 1,
 
         AR              => "ar",
-        ARFLAGS         => "r",
+        ARFLAGS         => "qc",
         CC              => "cc",
         lflags          =>
             sub { $withargs{zlib_lib} ? "-L".$withargs{zlib_lib} : () },

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1506,11 +1506,12 @@ EOF
       my %args = @_;
       my $lib = platform->staticlib($args{lib});
       my @objs = map { platform->obj($_) } @{$args{objs}};
-      my $objs = join(" \\\n" . ' ' x (length($lib) + 2),
+      my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
                       fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
+      my $fill_lib = join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs));
       return <<"EOF";
-$lib: $objs
-	\$(AR) \$(ARFLAGS) \$\@ \$\?
+$lib: $deps
+	$fill_lib
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF
   }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1508,7 +1508,11 @@ EOF
       my @objs = map { platform->obj($_) } @{$args{objs}};
       my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
                       fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
-      my $fill_lib = join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs));
+      my $max_per_call = 250;
+      my @objs_grouped;
+      push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
+      my $fill_lib =
+          join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs_grouped));
       return <<"EOF";
 $lib: $deps
 	$fill_lib


### PR DESCRIPTION
We're hitting problems that the 'ar' command line becomes too long for
some 'make' versions, or the shell it uses.

We therefore change the way we create a static library by doing so one
object file at a time.  This is slower, but has better guarantees to
work properly on limited systems.

Fixes #12116
