### PR TITLE
rand: instantiate the DRBGs upon first use.

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -246,7 +246,7 @@ int RAND_status(void)
         return meth->status != NULL ? meth->status() : 0;
 
     if ((rand = RAND_get0_primary(NULL)) == NULL)
-        return EVP_RAND_STATE_UNINITIALISED;
+        return 0;
     return EVP_RAND_state(rand) == EVP_RAND_STATE_READY;
 }
 #else  /* !FIPS_MODULE */
@@ -467,7 +467,12 @@ static EVP_RAND_CTX *rand_new_drbg(OPENSSL_CTX *libctx, EVP_RAND_CTX *parent,
     if (!EVP_RAND_set_ctx_params(ctx, params)) {
         RANDerr(0, RAND_R_ERROR_INITIALISING_DRBG);
         EVP_RAND_CTX_free(ctx);
-        ctx = NULL;
+        return NULL;
+    }
+    if (!EVP_RAND_instantiate(ctx, 0, 0, NULL, 0)) {
+        RANDerr(0, RAND_R_ERROR_INSTANTIATING_DRBG);
+        EVP_RAND_CTX_free(ctx);
+        return NULL;
     }
     return ctx;
 }

--- a/test/build.info
+++ b/test/build.info
@@ -52,7 +52,7 @@ IF[{- !$disabled{tests} -}]
           cipherbytes_test \
           asn1_encode_test asn1_decode_test asn1_string_table_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
-          recordlentest drbgtest sslbuffertest \
+          recordlentest drbgtest rand_status_test sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           http_test servername_test ocspapitest fatalerrtest tls13ccstest \
           sysdefaulttest errtest ssl_ctx_test gosttest \
@@ -379,6 +379,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[drbgtest]=drbgtest.c
   INCLUDE[drbgtest]=../include ../apps/include
   DEPEND[drbgtest]=../libcrypto.a libtestutil.a
+
+  SOURCE[rand_status_test]=rand_status_test.c
+  INCLUDE[rand_status_test]=../include ../apps/include
+  DEPEND[rand_status_test]=../libcrypto libtestutil.a
 
   SOURCE[x509_dup_cert_test]=x509_dup_cert_test.c
   INCLUDE[x509_dup_cert_test]=../include ../apps/include

--- a/test/rand_status_test.c
+++ b/test/rand_status_test.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/rand.h>
+#include "testutil.h"
+
+/*
+ * This needs to be in a test executable all by itself so that it can be
+ * guaranteed to run before any generate calls have been made.
+ */
+
+static int test_rand_status(void)
+{
+    return TEST_true(RAND_status());
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_rand_status);
+    return 1;
+}

--- a/test/recipes/05-test_rand.t
+++ b/test/recipes/05-test_rand.t
@@ -11,7 +11,8 @@ use warnings;
 use OpenSSL::Test;
 use OpenSSL::Test::Utils;
 
-plan tests => 1;
+plan tests => 2;
 setup("test_rand");
 
 ok(run(test(["drbgtest"])));
+ok(run(test(["rand_status_test"])));


### PR DESCRIPTION
For backwards compatibility, calling `RAND_status(3)` before generating any bytes needs to instantiate the primary DRBG.  This change instantiates the three DRBGs earlier, not relying on the automatic restart mechanism.

- [x] tests are added or updated

Fixes #12714
