### PR TITLE
PEM: Make PEM_write_bio_PrivateKey_traditional() handle provider-native keys

### DIFF
--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -160,20 +160,36 @@ PEM_write_cb_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
     return PEM_write_bio_PrivateKey_traditional(out, x, enc, kstr, klen, cb, u);
 }
 
+/*
+ * Note: there is no way to tell a provided pkey encoder to use "traditional"
+ * encoding.  Therefore, if the pkey is provided, we try to take a copy 
+ * TODO: when #legacy keys are gone, this function will not be possible any
+ * more and should be removed.
+ */
 int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
                                          const EVP_CIPHER *enc,
                                          const unsigned char *kstr, int klen,
                                          pem_password_cb *cb, void *u)
 {
     char pem_str[80];
+    EVP_PKEY *copy = NULL;
+    int ret;
+
+    if (evp_pkey_is_assigned(x)
+        && evp_pkey_is_provided(x)
+        && evp_pkey_copy_downgraded(&copy, x))
+        x = copy;
 
     if (x->ameth == NULL || x->ameth->old_priv_encode == NULL) {
         ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_PUBLIC_KEY_TYPE);
         return 0;
     }
     BIO_snprintf(pem_str, 80, "%s PRIVATE KEY", x->ameth->pem_str);
-    return PEM_ASN1_write_bio((i2d_of_void *)i2d_PrivateKey,
-                              pem_str, bp, x, enc, kstr, klen, cb, u);
+    ret = PEM_ASN1_write_bio((i2d_of_void *)i2d_PrivateKey,
+                             pem_str, bp, x, enc, kstr, klen, cb, u);
+
+    EVP_PKEY_free(copy);
+    return ret;
 }
 
 EVP_PKEY *PEM_read_bio_Parameters_ex(BIO *bp, EVP_PKEY **x,

--- a/doc/internal/man3/evp_pkey_export_to_provider.pod
+++ b/doc/internal/man3/evp_pkey_export_to_provider.pod
@@ -32,7 +32,7 @@ exported, then I<*keymgmt> is assigned the implicitly fetched B<EVP_KEYMGMT>.
 
 evp_pkey_copy_downgraded() makes a copy of I<src> in legacy form into I<*dest>,
 if there's a corresponding legacy implementation.  This should be used if the
-use of downgraded key is temporary.
+use of a downgraded key is temporary.
 For example, L<PEM_write_bio_PrivateKey_traditional(3)> uses this to try its
 best to get "traditional" PEM output even if the input B<EVP_PKEY> has a
 provider-native internal key.

--- a/doc/internal/man3/evp_pkey_export_to_provider.pod
+++ b/doc/internal/man3/evp_pkey_export_to_provider.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-evp_pkey_export_to_provider, evp_pkey_downgrade
+evp_pkey_export_to_provider, evp_pkey_copy_downgraded, evp_pkey_downgrade
 - internal EVP_PKEY support functions for providers
 
 =head1 SYNOPSIS
@@ -13,6 +13,7 @@ evp_pkey_export_to_provider, evp_pkey_downgrade
  void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
                                    EVP_KEYMGMT **keymgmt,
                                    const char *propquery);
+ int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
  int evp_pkey_downgrade(EVP_PKEY *pk);
 
 =head1 DESCRIPTION
@@ -28,6 +29,13 @@ default context), the name of the legacy type of I<pk>, and the I<propquery>
 
 If I<keymgmt> isn't NULL but I<*keymgmt> is, and the "origin" was successfully
 exported, then I<*keymgmt> is assigned the implicitly fetched B<EVP_KEYMGMT>.
+
+evp_pkey_copy_downgraded() makes a copy of I<src> in legacy form into I<*dest>,
+if there's a corresponding legacy implementation.  This should be used if the
+use of downgraded key is temporary.
+For example, L<PEM_write_bio_PrivateKey_traditional(3)> uses this to try its
+best to get "traditional" PEM output even if the input B<EVP_PKEY> has a
+provider-native internal key.
 
 evp_pkey_downgrade() converts an B<EVP_PKEY> with a provider side "origin" key
 to one with a legacy "origin", if there's a corresponding legacy implementation.

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -566,6 +566,7 @@ struct evp_pkey_st {
 # endif
 
     /* == Common attributes == */
+    /* If these are modified, so must evp_pkey_downgrade() */
     CRYPTO_REF_COUNT references;
     CRYPTO_RWLOCK *lock;
     STACK_OF(X509_ATTRIBUTE) *attributes; /* [ 0 ] */
@@ -647,6 +648,7 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OPENSSL_CTX *libctx,
                                   EVP_KEYMGMT **keymgmt,
                                   const char *propquery);
 #ifndef FIPS_MODULE
+int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
 int evp_pkey_downgrade(EVP_PKEY *pk);
 void evp_pkey_free_legacy(EVP_PKEY *x);
 #endif


### PR DESCRIPTION
PEM_write_bio_PrivateKey_traditional() didn't handle provider-native
keys very well.  Originally, it would simply use the corresponding
encoder, which is likely to output modern PEM (not "traditional").

PEM_write_bio_PrivateKey_traditional() is now changed to try and get a
legacy copy of the input EVP_PKEY, and use that copy for traditional
output, if it has such support.

Internally, evp_pkey_copy_downgraded() is added, to be used when
evp_pkey_downgrade() is too intrusive for what it's needed for.

-----

This is a follow-up on #12728, and currently includes its commits.  Only the last commit belongs here.