### PR TITLE
Clean up and extend CMP chain building for the CMP signer, TLS client, and newly enrolled certs

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -888,23 +888,6 @@ static OSSL_CMP_MSG *read_write_req_resp(OSSL_CMP_CTX *ctx,
     return res;
 }
 
-static int set1_store_parameters(X509_STORE *ts)
-{
-    if (ts == NULL)
-        return 0;
-
-    /* copy vpm to store */
-    if (!X509_STORE_set1_param(ts, vpm /* may be NULL */)) {
-        BIO_printf(bio_err, "error setting verification parameters\n");
-        OSSL_CMP_CTX_print_errors(cmp_ctx);
-        return 0;
-    }
-
-    X509_STORE_set_verify_cb(ts, X509_STORE_CTX_print_verify_cb);
-
-    return 1;
-}
-
 static int set_name(const char *str,
                     int (*set_fn) (OSSL_CMP_CTX *ctx, const X509_NAME *name),
                     OSSL_CMP_CTX *ctx, const char *desc)
@@ -990,6 +973,24 @@ static X509_STORE *load_certstore(char *input, const char *desc)
     return store;
 }
 
+static X509_STORE *load_trusted(char *input, int for_new_cert, const char *desc)
+{
+    X509_STORE *ts = load_certstore(input, desc);
+
+    if (ts == NULL)
+        return NULL;
+    X509_STORE_set_verify_cb(ts, X509_STORE_CTX_print_verify_cb);
+
+    /* copy vpm to store */
+    if (X509_STORE_set1_param(ts, vpm /* may be NULL */)
+            && (for_new_cert || truststore_set_host_etc(ts, NULL)))
+        return ts;
+    BIO_printf(bio_err, "error setting verification parameters\n");
+    OSSL_CMP_CTX_print_errors(cmp_ctx);
+    X509_STORE_free(ts);
+    return NULL;
+}
+
 /* TODO potentially move to apps/lib/apps.c */
 static STACK_OF(X509) *load_certs_multifile(char *files,
                                             const char *pass, const char *desc)
@@ -1025,31 +1026,20 @@ static STACK_OF(X509) *load_certs_multifile(char *files,
 }
 
 typedef int (*add_X509_stack_fn_t)(void *ctx, const STACK_OF(X509) *certs);
-typedef int (*add_X509_fn_t)(void *ctx, const X509 *cert);
 
 static int setup_certs(char *files, const char *desc, void *ctx,
-                       add_X509_stack_fn_t addn_fn, add_X509_fn_t add1_fn)
+                       add_X509_stack_fn_t set1_fn)
 {
-    int ret = 1;
+    STACK_OF(X509) *certs;
+    int ok;
 
-    if (files != NULL) {
-        STACK_OF(X509) *certs = load_certs_multifile(files, opt_otherpass,
-                                                     desc);
-        if (certs == NULL) {
-            ret = 0;
-        } else {
-            if (addn_fn != NULL) {
-                ret = (*addn_fn)(ctx, certs);
-            } else {
-                int i;
-
-                for (i = 0; i < sk_X509_num(certs /* may be NULL */); i++)
-                    ret &= (*add1_fn)(ctx, sk_X509_value(certs, i));
-            }
-            sk_X509_pop_free(certs, X509_free);
-        }
-    }
-    return ret;
+    if (files == NULL)
+        return 1;
+    if ((certs = load_certs_multifile(files, opt_otherpass, desc)) == NULL)
+        return 0;
+    ok = (*set1_fn)(ctx, certs);
+    sk_X509_pop_free(certs, X509_free);
+    return ok;
 }
 
 
@@ -1175,13 +1165,9 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
 
     if (opt_srv_trusted != NULL) {
         X509_STORE *ts =
-            load_certstore(opt_srv_trusted, "certificates trusted by server");
+            load_trusted(opt_srv_trusted, 0, "certs trusted by server");
 
-        if (ts == NULL)
-            goto err;
-        if (!set1_store_parameters(ts)
-                || !truststore_set_host_etc(ts, NULL)
-                || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
+        if (ts == NULL || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
             X509_STORE_free(ts);
             goto err;
         }
@@ -1190,7 +1176,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
     }
     if (!setup_certs(opt_srv_untrusted,
                      "untrusted certificates for mock server", ctx,
-                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted, NULL))
+                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted))
         goto err;
 
     if (opt_rsp_cert == NULL) {
@@ -1212,12 +1198,10 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
     /* TODO find a cleaner solution not requiring type casts */
     if (!setup_certs(opt_rsp_extracerts,
                      "CMP extra certificates for mock server", srv_ctx,
-                     (add_X509_stack_fn_t)ossl_cmp_mock_srv_set1_chainOut,
-                     NULL))
+                     (add_X509_stack_fn_t)ossl_cmp_mock_srv_set1_chainOut))
         goto err;
     if (!setup_certs(opt_rsp_capubs, "caPubs for mock server", srv_ctx,
-                     (add_X509_stack_fn_t)ossl_cmp_mock_srv_set1_caPubsOut,
-                     NULL))
+                     (add_X509_stack_fn_t)ossl_cmp_mock_srv_set1_caPubsOut))
         goto err;
     (void)ossl_cmp_mock_srv_set_pollCount(srv_ctx, opt_poll_count);
     (void)ossl_cmp_mock_srv_set_checkAfterTime(srv_ctx, opt_check_after);
@@ -1271,16 +1255,15 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
 static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
 {
     if (!setup_certs(opt_untrusted, "untrusted certificates", ctx,
-                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted,
-                     NULL))
-        goto err;
+                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted))
+        return 0;
 
     if (opt_srvcert != NULL || opt_trusted != NULL) {
-        X509_STORE *ts = NULL;
+        X509 *srvcert;
+        X509_STORE *ts;
+        int ok;
 
         if (opt_srvcert != NULL) {
-            X509 *srvcert;
-
             if (opt_trusted != NULL) {
                 CMP_warn("-trusted option is ignored since -srvcert option is present");
                 opt_trusted = NULL;
@@ -1291,33 +1274,22 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
             }
             srvcert = load_cert_pwd(opt_srvcert, opt_otherpass,
                                     "directly trusted CMP server certificate");
-            if (srvcert == NULL)
-                /*
-                 * opt_otherpass is needed in case
-                 * opt_srvcert is an encrypted PKCS#12 file
-                 */
-                goto err;
-            if (!OSSL_CMP_CTX_set1_srvCert(ctx, srvcert)) {
-                X509_free(srvcert);
-                goto oom;
-            }
+            ok = srvcert != NULL && OSSL_CMP_CTX_set1_srvCert(ctx, srvcert);
             X509_free(srvcert);
-            if ((ts = X509_STORE_new()) == NULL)
-                goto oom;
+            if (!ok)
+                return 0;
         }
-        if (opt_trusted != NULL
-                && (ts = load_certstore(opt_trusted, "trusted certificates"))
-            == NULL)
-            goto err;
-        if (!set1_store_parameters(ts) /* also copies vpm */
-                /*
-                 * clear any expected host/ip/email address;
-                 * opt_expect_sender is used instead
-                 */
-                || !truststore_set_host_etc(ts, NULL)
-                || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
-            X509_STORE_free(ts);
-            goto oom;
+        if (opt_trusted != NULL) {
+            /*
+             * the 0 arg below clears any expected host/ip/email address;
+             * opt_expect_sender is used instead
+             */
+            ts = load_trusted(opt_trusted, 0, "certs trusted by client");
+
+            if (ts == NULL || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
+                X509_STORE_free(ts);
+                return 0;
+            }
         }
     }
 
@@ -1330,14 +1302,11 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
     if (opt_out_trusted != NULL) { /* for use in OSSL_CMP_certConf_cb() */
         X509_VERIFY_PARAM *out_vpm = NULL;
         X509_STORE *out_trusted =
-            load_certstore(opt_out_trusted,
-                           "trusted certs for verifying newly enrolled cert");
+            load_trusted(opt_out_trusted, 1,
+                         "trusted certs for verifying newly enrolled cert");
 
         if (out_trusted == NULL)
-            goto err;
-        /* any -verify_hostname, -verify_ip, and -verify_email apply here */
-        if (!set1_store_parameters(out_trusted))
-            goto oom;
+            return 0;
         /* ignore any -attime here, new certs are current anyway */
         out_vpm = X509_STORE_get0_param(out_trusted);
         X509_VERIFY_PARAM_clear_flags(out_vpm, X509_V_FLAG_USE_CHECK_TIME);
@@ -1351,14 +1320,7 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
     if (opt_implicit_confirm)
         (void)OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_IMPLICIT_CONFIRM, 1);
 
-    (void)OSSL_CMP_CTX_set_certConf_cb(ctx, OSSL_CMP_certConf_cb);
-
     return 1;
-
- oom:
-    CMP_err("out of memory");
- err:
-    return 0;
 }
 
 #ifndef OPENSSL_NO_SOCK
@@ -1368,7 +1330,7 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
  */
 static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 {
-    STACK_OF(X509) *untrusted_certs = OSSL_CMP_CTX_get0_untrusted(ctx);
+    STACK_OF(X509) *untrusted = OSSL_CMP_CTX_get0_untrusted(ctx);
     EVP_PKEY *pkey = NULL;
     X509_STORE *trust_store = NULL;
     SSL_CTX *ssl_ctx;
@@ -1412,21 +1374,37 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             sk_X509_pop_free(certs, X509_free);
             goto err;
         }
-        for (i = 0; i < sk_X509_num(untrusted_certs); i++) {
-            cert = sk_X509_value(untrusted_certs, i);
+        for (i = 0; i < sk_X509_num(untrusted); i++) {
+            cert = sk_X509_value(untrusted, i);
             if (!SSL_CTX_add1_chain_cert(ssl_ctx, cert)) {
                 CMP_err("could not add untrusted cert to TLS client cert chain");
                 goto err;
             }
         }
-        CMP_debug("trying to build cert chain for own TLS cert");
-        if (SSL_CTX_build_cert_chain(ssl_ctx,
-                                     SSL_BUILD_CHAIN_FLAG_UNTRUSTED |
-                                     SSL_BUILD_CHAIN_FLAG_NO_ROOT)) {
-            CMP_debug("succeeded building cert chain for own TLS cert");
-        } else {
-            OSSL_CMP_CTX_print_errors(ctx);
-            CMP_warn("could not build cert chain for own TLS cert");
+
+        {
+            X509_VERIFY_PARAM *tls_vpm = NULL;
+            unsigned long bak_flags = 0; /* compiler warns without init */
+
+            if (trust_store != NULL) {
+                tls_vpm = X509_STORE_get0_param(trust_store);
+                bak_flags = X509_VERIFY_PARAM_get_flags(tls_vpm);
+                /* disable any cert status/revocation checking etc. */
+                X509_VERIFY_PARAM_clear_flags(tls_vpm,
+                                              ~(X509_V_FLAG_USE_CHECK_TIME
+                                                | X509_V_FLAG_NO_CHECK_TIME));
+            }
+            CMP_debug("trying to build cert chain for own TLS cert");
+            if (SSL_CTX_build_cert_chain(ssl_ctx,
+                                         SSL_BUILD_CHAIN_FLAG_UNTRUSTED |
+                                         SSL_BUILD_CHAIN_FLAG_NO_ROOT)) {
+                CMP_debug("success building cert chain for own TLS cert");
+            } else {
+                OSSL_CMP_CTX_print_errors(ctx);
+                CMP_warn("could not build cert chain for own TLS cert");
+            }
+            if (trust_store != NULL)
+                X509_VERIFY_PARAM_set_flags(tls_vpm, bak_flags);
         }
 
         /* If present we append to the list also the certs from opt_tls_extra */
@@ -1503,17 +1481,17 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 {
     if (!opt_unprotected_requests && opt_secret == NULL && opt_cert == NULL) {
         CMP_err("must give client credentials unless -unprotected_requests is set");
-        goto err;
+        return 0;
     }
 
     if (opt_ref == NULL && opt_cert == NULL && opt_subject == NULL) {
         /* cert or subject should determine the sender */
         CMP_err("must give -ref if no -cert and no -subject given");
-        goto err;
+        return 0;
     }
     if (!opt_secret && ((opt_cert == NULL) != (opt_key == NULL))) {
         CMP_err("must give both -cert and -key options or neither");
-        goto err;
+        return 0;
     }
     if (opt_secret != NULL) {
         char *pass_string = get_passwd(opt_secret, "PBMAC");
@@ -1526,7 +1504,7 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
                                                 strlen(pass_string));
             clear_free(pass_string);
             if (res == 0)
-                goto err;
+                return 0;
         }
         if (opt_cert != NULL || opt_key != NULL)
             CMP_warn("no signature-based protection used since -secret is given");
@@ -1534,7 +1512,7 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
     if (opt_ref != NULL
             && !OSSL_CMP_CTX_set1_referenceValue(ctx, (unsigned char *)opt_ref,
                                                  strlen(opt_ref)))
-        goto err;
+        return 0;
 
     if (opt_key != NULL) {
         EVP_PKEY *pkey = load_key_pwd(opt_key, opt_keyform, opt_keypass, engine,
@@ -1542,7 +1520,7 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
         if (pkey == NULL || !OSSL_CMP_CTX_set1_pkey(ctx, pkey)) {
             EVP_PKEY_free(pkey);
-            goto err;
+            return 0;
         }
         EVP_PKEY_free(pkey);
     }
@@ -1553,38 +1531,35 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         X509 *cert;
         STACK_OF(X509) *certs = NULL;
         X509_STORE *own_trusted = NULL;
-        int ok = 0;
+        int ok;
 
         if (!load_cert_certs(opt_cert, &cert, &certs, 0, opt_keypass,
                              "CMP client certificate (optionally with chain)"))
             /* opt_keypass is needed if opt_cert is an encrypted PKCS#12 file */
-            goto err;
+            return 0;
         ok = OSSL_CMP_CTX_set1_cert(ctx, cert);
         X509_free(cert);
         if (!ok) {
             CMP_err("out of memory");
         } else {
             if (opt_own_trusted != NULL) {
-                own_trusted = load_certstore(opt_own_trusted,
-                                             "trusted certs for verifying own CMP signer cert");
-                ok = own_trusted != NULL
-                    && set1_store_parameters(own_trusted)
-                    && truststore_set_host_etc(own_trusted, NULL);
+                own_trusted = load_trusted(opt_own_trusted, 0,
+                                           "trusted certs for verifying own CMP signer cert");
+                ok = own_trusted != NULL;
             }
             ok = ok && OSSL_CMP_CTX_build_cert_chain(ctx, own_trusted, certs);
         }
         X509_STORE_free(own_trusted);
         sk_X509_pop_free(certs, X509_free);
         if (!ok)
-            goto err;
+            return 0;
     } else if (opt_own_trusted != NULL) {
         CMP_warn("-own_trusted option is ignored without -cert");
     }
 
     if (!setup_certs(opt_extracerts, "extra certificates for CMP", ctx,
-                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_extraCertsOut,
-                     NULL))
-        goto err;
+                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_extraCertsOut))
+        return 0;
     cleanse(opt_otherpass);
 
     if (opt_unprotected_requests)
@@ -1595,12 +1570,12 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
         if (digest == NID_undef) {
             CMP_err1("digest algorithm name not recognized: '%s'", opt_digest);
-            goto err;
+            return 0;
         }
         if (!OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_DIGEST_ALGNID, digest)
             || !OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_OWF_ALGNID, digest)) {
             CMP_err1("digest algorithm name not supported: '%s'", opt_digest);
-            goto err;
+            return 0;
         }
     }
 
@@ -1608,14 +1583,11 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         int mac = OBJ_ln2nid(opt_mac);
         if (mac == NID_undef) {
             CMP_err1("MAC algorithm name not recognized: '%s'", opt_mac);
-            goto err;
+            return 0;
         }
         (void)OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_MAC_ALGNID, mac);
     }
     return 1;
-
- err:
-    return 0;
 }
 
 /*
@@ -1629,7 +1601,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         CMP_warn("no -subject given, neither -oldcert nor -cert available as default");
     if (!set_name(opt_subject, OSSL_CMP_CTX_set1_subjectName, ctx, "subject")
             || !set_name(opt_issuer, OSSL_CMP_CTX_set1_issuer, ctx, "issuer"))
-        goto err;
+        return 0;
 
     if (opt_newkey != NULL) {
         const char *file = opt_newkey;
@@ -1647,7 +1619,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         cleanse(opt_newkeypass);
         if (pkey == NULL || !OSSL_CMP_CTX_set0_newPkey(ctx, priv, pkey)) {
             EVP_PKEY_free(pkey);
-            goto err;
+            return 0;
         }
     }
 
@@ -1655,12 +1627,12 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             && !OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_VALIDITY_DAYS,
                                         opt_days)) {
         CMP_err("could not set requested cert validity period");
-        goto err;
+        return 0;
     }
 
     if (opt_policies != NULL && opt_policy_oids != NULL) {
         CMP_err("cannot have policies both via -policies and via -policy_oids");
-        goto err;
+        return 0;
     }
 
     if (opt_reqexts != NULL || opt_policies != NULL) {
@@ -1668,7 +1640,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         X509_EXTENSIONS *exts = sk_X509_EXTENSION_new_null();
 
         if (exts == NULL)
-            goto err;
+            return 0;
         X509V3_set_ctx(&ext_ctx, NULL, NULL, NULL, NULL, 0);
         X509V3_set_nconf(&ext_ctx, conf);
         if (opt_reqexts != NULL
@@ -1676,24 +1648,24 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             CMP_err1("cannot load certificate request extension section '%s'",
                      opt_reqexts);
             sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-            goto err;
+            return 0;
         }
         if (opt_policies != NULL
             && !X509V3_EXT_add_nconf_sk(conf, &ext_ctx, opt_policies, &exts)) {
             CMP_err1("cannot load policy cert request extension section '%s'",
                      opt_policies);
             sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
-            goto err;
+            return 0;
         }
         OSSL_CMP_CTX_set0_reqExtensions(ctx, exts);
     }
     if (OSSL_CMP_CTX_reqExtensions_have_SAN(ctx) && opt_sans != NULL) {
         CMP_err("cannot have Subject Alternative Names both via -reqexts and via -sans");
-        goto err;
+        return 0;
     }
 
     if (!set_gennames(ctx, opt_sans, "Subject Alternative Name"))
-        goto err;
+        return 0;
 
     if (opt_san_nodefault) {
         if (opt_sans != NULL)
@@ -1715,19 +1687,19 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
         if ((policy = OBJ_txt2obj(opt_policy_oids, 1)) == 0) {
             CMP_err1("unknown policy OID '%s'", opt_policy_oids);
-            goto err;
+            return 0;
         }
 
         if ((pinfo = POLICYINFO_new()) == NULL) {
             ASN1_OBJECT_free(policy);
-            goto err;
+            return 0;
         }
         pinfo->policyid = policy;
 
         if (!OSSL_CMP_CTX_push0_policy(ctx, pinfo)) {
             CMP_err1("cannot add policy with OID '%s'", opt_policy_oids);
             POLICYINFO_free(pinfo);
-            goto err;
+            return 0;
         }
         opt_policy_oids = next;
     }
@@ -1743,7 +1715,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
                 load_csr_autofmt(opt_csr, "PKCS#10 CSR for p10cr");
 
             if (csr == NULL)
-                goto err;
+                return 0;
             if (!OSSL_CMP_CTX_set1_p10CSR(ctx, csr)) {
                 X509_REQ_free(csr);
                 goto oom;
@@ -1758,7 +1730,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         /* opt_keypass is needed if opt_oldcert is an encrypted PKCS#12 file */
 
         if (oldcert == NULL)
-            goto err;
+            return 0;
         if (!OSSL_CMP_CTX_set1_oldCert(ctx, oldcert)) {
             X509_free(oldcert);
             goto oom;
@@ -1774,7 +1746,6 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
  oom:
     CMP_err("out of memory");
- err:
     return 0;
 }
 

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -22,6 +22,7 @@
 #include "openssl/cmp_util.h"
 
 DEFINE_STACK_OF(ASN1_UTF8STRING)
+DEFINE_STACK_OF(X509)
 DEFINE_STACK_OF(X509_CRL)
 DEFINE_STACK_OF(OSSL_CMP_CERTRESPONSE)
 DEFINE_STACK_OF(OSSL_CMP_PKISI)
@@ -487,14 +488,35 @@ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
                          const char **text)
 {
     X509_STORE *out_trusted = OSSL_CMP_CTX_get_certConf_cb_arg(ctx);
+    STACK_OF(X509) *chain = NULL;
     (void)text; /* make (artificial) use of var to prevent compiler warning */
 
     if (fail_info != 0) /* accept any error flagged by CMP core library */
         return fail_info;
 
-    if (out_trusted != NULL
-            && !OSSL_CMP_validate_cert_path(ctx, out_trusted, cert))
-        fail_info = 1 << OSSL_CMP_PKIFAILUREINFO_incorrectData;
+    ossl_cmp_debug(ctx, "trying to build chain for newly enrolled cert");
+    chain = ossl_cmp_build_cert_chain(ctx->libctx, ctx->propq,
+                                      out_trusted /* may be NULL */,
+                                      ctx->untrusted, cert);
+    if (sk_X509_num(chain) > 0)
+        X509_free(sk_X509_shift(chain)); /* remove leaf (EE) cert */
+    if (out_trusted != NULL) {
+        if (chain == NULL) {
+            ossl_cmp_err(ctx, "failed building chain for newly enrolled cert");
+            fail_info = 1 << OSSL_CMP_PKIFAILUREINFO_incorrectData;
+        } else {
+            ossl_cmp_debug(ctx,
+                           "succeeded building proper chain for newly enrolled cert");
+        }
+    } else if (chain == NULL) {
+        ossl_cmp_warn(ctx, "could not build approximate chain for newly enrolled cert, resorting to received extraCerts");
+        chain = OSSL_CMP_CTX_get1_extraCertsIn(ctx);
+    } else {
+        ossl_cmp_debug(ctx,
+                       "success building approximate chain for newly enrolled cert");
+    }
+    (void)ossl_cmp_ctx_set1_newChain(ctx, chain);
+    sk_X509_pop_free(chain, X509_free);
 
     return fail_info;
 }
@@ -515,9 +537,13 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
     const char *txt = NULL;
     OSSL_CMP_CERTREPMESSAGE *crepmsg;
     OSSL_CMP_CERTRESPONSE *crep;
+    OSSL_CMP_certConf_cb_t cb;
     X509 *cert;
     char *subj = NULL;
     int ret = 1;
+
+    if (!ossl_assert(ctx != NULL))
+        return 0;
 
  retry:
     crepmsg = (*resp)->body->value.ip; /* same for cp and kup */
@@ -584,21 +610,19 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
          *                    OSSL_CMP_PKISTATUS_rejection, fail_info, txt)
          * not throwing CMP_R_CERTIFICATE_NOT_ACCEPTED with txt
          * not returning 0
-         * since we better leave this for any ctx->certConf_cb to decide
+         * since we better leave this for the certConf_cb to decide
          */
     }
 
     /*
-     * Execute the certification checking callback function possibly set in ctx,
+     * Execute the certification checking callback function,
      * which can determine whether to accept a newly enrolled certificate.
      * It may overrule the pre-decision reflected in 'fail_info' and '*txt'.
      */
-    if (ctx->certConf_cb
-            && (fail_info = ctx->certConf_cb(ctx, ctx->newCert,
-                                             fail_info, &txt)) != 0) {
-        if (txt == NULL)
-            txt = "CMP client application did not accept it";
-    }
+    cb = ctx->certConf_cb != NULL ? ctx->certConf_cb : OSSL_CMP_certConf_cb;
+    if ((fail_info = cb(ctx, ctx->newCert, fail_info, &txt)) != 0
+            && txt == NULL)
+        txt = "CMP client did not accept it";
     if (fail_info != 0) /* immediately log error before any certConf exchange */
         ossl_cmp_log1(ERROR, ctx,
                       "rejecting newly enrolled cert with subject: %s", subj);

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -71,6 +71,7 @@ struct ossl_cmp_ctx_st {
     /* client authentication */
     int unprotectedSend; /* send unprotected PKI messages */
     X509 *cert; /* protection cert used to identify and sign for MSG_SIG_ALG */
+    STACK_OF(X509) *chain; /* (cached) chain of protection cert including it */
     EVP_PKEY *pkey; /* the key pair corresponding to cert */
     ASN1_OCTET_STRING *referenceValue; /* optional user name for MSG_MAC_ALG */
     ASN1_OCTET_STRING *secretValue; /* password/shared secret for MSG_MAC_ALG */

--- a/doc/internal/man3/ossl_cmp_msg_protect.pod
+++ b/doc/internal/man3/ossl_cmp_msg_protect.pod
@@ -46,7 +46,7 @@ It also sets the protectionAlg field in the message header accordingly.
 ossl_cmp_msg_add_extraCerts() adds elements to the extraCerts field in I<msg>.
 If signature-based message protection is used it adds first the CMP signer cert
 ctx->cert and then its chain ctx->chain. If this chain is not present in I<ctx>
-tries to build it using ctx->untrusted_certs and caches the result in ctx->chain.
+tries to build it using ctx->untrusted and caches the result in ctx->chain.
 In any case all the certificates explicitly specified to be sent out (i.e.,
 I<ctx->extraCertsOut>) are added. Note that it will NOT add the root certificate
 of the chain, i.e, the trust anchor (unless it is part of extraCertsOut).

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -681,6 +681,7 @@ Defaults to C<hmac-sha1> as per RFC 4210.
 =item B<-extracerts> I<sources>
 
 Certificates to append in the extraCerts field when sending messages.
+They can be used as the default CMP signer certificate chain to include.
 
 Multiple filenames or URLs may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -175,7 +175,7 @@ and the proof-of-possession method is set to OSSL_CRMF_POPO_SIGNATURE.
 
 OSSL_CMP_CTX_free() deallocates an OSSL_CMP_CTX structure.
 
-OSSL_CMP_CTX_reinit() prepares the given B<ctx> for a further transaction by
+OSSL_CMP_CTX_reinit() prepares the given I<ctx> for a further transaction by
 clearing the internal CMP transaction (aka session) status, PKIStatusInfo,
 and any previous results (newCert, newChain, caPubs, and extraCertsIn)
 from the last executed transaction.
@@ -288,7 +288,7 @@ RFC 4210.
 
 =item B<OSSL_CMP_OPT_IGNORE_KEYUSAGE>
 
-        Ignore key usage restrictions in signer certificate when
+        Ignore key usage restrictions in the signer's certificate when
         validating signature-based protection in received CMP messages.
         Else, 'digitalSignature' must be allowed by CMP signer certificates.
 
@@ -302,57 +302,57 @@ RFC 4210.
 OSSL_CMP_CTX_get_option() reads the current value of the given option
 (e.g., OSSL_CMP_OPT_IMPLICIT_CONFIRM) from the given OSSL_CMP_CTX structure.
 
-OSSL_CMP_CTX_set_log_cb() sets in B<ctx> the callback function C<cb>
+OSSL_CMP_CTX_set_log_cb() sets in I<ctx> the callback function I<cb>
 for handling error queue entries and logging messages.
-When C<cb> is NULL errors are printed to STDERR (if available, else ignored)
+When I<cb> is NULL errors are printed to STDERR (if available, else ignored)
 any log messages are ignored.
 Alternatively, L<OSSL_CMP_log_open(3)> may be used to direct logging to STDOUT.
 
 OSSL_CMP_CTX_set_log_verbosity() is a macro setting the
 OSSL_CMP_OPT_LOG_VERBOSITY context option to the given level.
 
-OSSL_CMP_CTX_print_errors() outputs any entries in the OpenSSL error queue.
-It is similar to B<ERR_print_errors_cb()> but uses the CMP log callback function
+OSSL_CMP_CTX_print_errors() outputs any entries in the OpenSSL error queue. It
+is similar to L<ERR_print_errors_cb(3)> but uses the CMP log callback function
 if set in the C<ctx> for uniformity with CMP logging if given. Otherwise it uses
-B<ERR_print_errors(3)> to print to STDERR (unless OPENSSL_NO_STDIO is defined).
+L<ERR_print_errors(3)> to print to STDERR (unless OPENSSL_NO_STDIO is defined).
 
 OSSL_CMP_CTX_set1_serverPath() sets the HTTP path of the CMP server on the host,
 also known as "CMP alias".
-The default is I</>.
+The default is C</>.
 
-OSSL_CMP_CTX_set1_server() sets the given server B<address>
-(which may be a hostname or IP address or NULL) in the given B<ctx>.
+OSSL_CMP_CTX_set1_server() sets the given server I<address>
+(which may be a hostname or IP address or NULL) in the given I<ctx>.
 
 OSSL_CMP_CTX_set_serverPort() sets the port of the CMP server to connect to.
-If not used or the B<port> argument is 0
+If not used or the I<port> argument is 0
 the default port applies, which is 80 for HTTP and 443 for HTTPS.
 
 OSSL_CMP_CTX_set1_proxy() sets the HTTP proxy to be used for connecting to
 the given CMP server unless overruled by any "no_proxy" settings (see below).
 If TLS is not used this defaults to the value of
-the environment variable B<http_proxy> if set, else B<HTTP_PROXY>.
-Otherwise defaults to the value of B<https_proxy> if set, else B<HTTPS_PROXY>.
+the environment variable C<http_proxy> if set, else C<HTTP_PROXY>.
+Otherwise defaults to the value of C<https_proxy> if set, else C<HTTPS_PROXY>.
 An empty proxy string specifies not to use a proxy.
-Else the format is I<[http[s]://]address[:port][/path]>,
+Else the format is C<[http[s]://]address[:port][/path]>,
 where any path given is ignored.
-The default port number is 80, or 443 in case I<https:> is given.
+The default port number is 80, or 443 in case C<https:> is given.
 
 OSSL_CMP_CTX_set1_no_proxy() sets the list of server hostnames not to use
 an HTTP proxy for. The names may be separated by commas and/or whitespace.
-Defaults to the environment variable B<no_proxy> if set, else B<NO_PROXY>.
+Defaults to the environment variable C<no_proxy> if set, else C<NO_PROXY>.
 
 OSSL_CMP_CTX_set_http_cb() sets the optional BIO connect/disconnect callback
 function, which has the prototype
 
  typedef BIO *(*HTTP_bio_cb_t) (BIO *bio, void *ctx, int connect, int detail);
 
-The callback may modify the BIO B<bio> provided by OSSL_CMP_MSG_http_perform(),
-whereby it may make use of a custom defined argument B<ctx>
+The callback may modify the I<bio> provided by L<OSSL_CMP_MSG_http_perform(3)>,
+whereby it may make use of a custom defined argument I<ctx>
 stored in the OSSL_CMP_CTX by means of OSSL_CMP_CTX_set_http_cb_arg().
 During connection establishment, just after calling BIO_do_connect_retry(),
-the function is invoked with the B<connect> argument being 1 and the B<detail>
+the function is invoked with the I<connect> argument being 1 and the I<detail>
 argument being 1 if HTTPS is requested, i.e., SSL/TLS should be enabled. On
-disconnect B<connect> is 0 and B<detail> is 1 in case no error occurred, else 0.
+disconnect I<connect> is 0 and I<detail> is 1 in case no error occurred, else 0.
 For instance, on connect the function may prepend a TLS BIO to implement HTTPS;
 after disconnect it may do some diagnostic output and/or specific cleanup.
 The function should return NULL to indicate failure.
@@ -361,8 +361,8 @@ After disconnect the modified BIO will be deallocated using BIO_free_all().
 OSSL_CMP_CTX_set_http_cb_arg() sets an argument, respectively a pointer to
 a structure containing arguments,
 optionally to be used by the http connect/disconnect callback function.
-B<arg> is not consumed, and it must therefore explicitly be freed when not
-needed any more. B<arg> may be NULL to clear the entry.
+I<arg> is not consumed, and it must therefore explicitly be freed when not
+needed any more. I<arg> may be NULL to clear the entry.
 
 OSSL_CMP_CTX_get_http_cb_arg() gets the argument, respectively the pointer to a
 structure containing arguments, previously set by
@@ -377,7 +377,7 @@ which has the type
 Returns 1 on success, 0 on error.
 
 Default is NULL, which implies the use of L<OSSL_CMP_MSG_http_perform(3)>.
-The callback should send the CMP request message it obtains via the B<req>
+The callback should send the CMP request message it obtains via the I<req>
 parameter and on success return the response, else it must return NULL.
 The transfer callback may make use of a custom defined argument stored in
 the ctx by means of OSSL_CMP_CTX_set_transfer_cb_arg(), which may be retrieved
@@ -385,26 +385,26 @@ again through OSSL_CMP_CTX_get_transfer_cb_arg().
 
 OSSL_CMP_CTX_set_transfer_cb_arg() sets an argument, respectively a pointer to a
 structure containing arguments, optionally to be used by the transfer callback.
-B<arg> is not consumed, and it must therefore explicitly be freed when not
-needed any more. B<arg> may be NULL to clear the entry.
+I<arg> is not consumed, and it must therefore explicitly be freed when not
+needed any more. I<arg> may be NULL to clear the entry.
 
 OSSL_CMP_CTX_get_transfer_cb_arg() gets the argument, respectively the pointer
 to a structure containing arguments, previously set by
 OSSL_CMP_CTX_set_transfer_cb_arg() or NULL if unset.
 
-OSSL_CMP_CTX_set1_srvCert() sets the expected server cert B<srvCert> and trusts
+OSSL_CMP_CTX_set1_srvCert() sets the expected server cert in I<ctx> and trusts
 it directly (even if it is expired) when verifying signed response messages.
 May be used alternatively to OSSL_CMP_CTX_set0_trustedStore()
 to pin the accepted server.
 Any previously set value is freed.
-The B<cert> argument may be NULL to clear the entry.
+The I<cert> argument may be NULL to clear the entry.
 If set, the subject of the certificate is also used
 as default value for the recipient of CMP requests
 and as default value for the expected sender of CMP responses.
 
 OSSL_CMP_CTX_set1_expected_sender() sets the Distinguished Name (DN)
 expected in the sender field of CMP response messages.
-Defaults to the subject of the pinned server certificate B<-srvcert>, if any.
+Defaults to the subject of the pinned server certificate, if any.
 This can be used to make sure that only a particular entity is accepted as
 CMP message signer, and attackers are not able to use arbitrary certificates
 of a trusted PKI hierarchy to fraudulently pose as CMP server.
@@ -431,54 +431,56 @@ The reference counts of those certificates handled successfully are increased.
 OSSL_CMP_CTX_get0_untrusted(OSSL_CMP_CTX *ctx) returns a pointer to the
 list of untrusted certs, which may be empty if unset.
 
-OSSL_CMP_CTX_set1_cert() sets the certificate used for CMP message protection.
-The public key of this B<cert> must correspond to
-the private key set before or thereafter via B<OSSL_CMP_CTX_set1_pkey()>.
+OSSL_CMP_CTX_set1_cert() sets the certificate related to the private key
+used for CMP message protection.
+Therefore the public key of this I<cert> must correspond to
+the private key set before or thereafter via OSSL_CMP_CTX_set1_pkey().
 When using signature-based protection of CMP request messages
-this "protection certificate" will be included first in the extraCerts field.
-The subject of this B<cert> will be used as the sender field of outgoing
-messages, while the subject of any cert set via B<OSSL_CMP_CTX_set1_oldCert()>
-and any value set via B<OSSL_CMP_CTX_set1_subjectName()> are used as fallback.
-The B<cert> argument may be NULL to clear the entry.
+this CMP signer certificate will be included first in the extraCerts field.
+The subject of this I<cert> will be used as the sender field of outgoing
+messages, while the subject of any cert set via OSSL_CMP_CTX_set1_oldCert()
+and any value set via OSSL_CMP_CTX_set1_subjectName() are used as fallback.
+The I<cert> argument may be NULL to clear the entry.
 
 OSSL_CMP_CTX_build_cert_chain() builds a certificate chain for the CMP signer
-certificate previously set in the B<ctx>. It adds the optional B<candidates>,
+certificate previously set in the I<ctx>. It adds the optional I<candidates>,
 a list of intermediate CA certs that may already constitute the targeted chain,
-to the untrusted certs that may already exist in the B<ctx>.
+to the untrusted certs that may already exist in the I<ctx>.
 Then the function uses this augumented set of certs for chain construction.
 If I<own_trusted> is NULL it builds the chain as far down as possible and
 ignores any verification errors. Else the CMP signer certificate must be
 verifiable where the chain reaches a trust anchor contained in I<own_trusted>.
-On success the function stores the resulting chain in B<ctx>
+On success the function stores the resulting chain in I<ctx>
 for inclusion in the extraCerts field of signature-protected messages.
 Calling this function is optional; by default a chain construction
 is performed on demand that is equivalent to calling this function
-with the B<candidates> and I<own_trusted> arguments being NULL.
+with the I<candidates> and I<own_trusted> arguments being NULL.
 
 OSSL_CMP_CTX_set1_pkey() sets the private key corresponding to the
-protection certificate B<cert> set via B<OSSL_CMP_CTX_set1_cert()>.
+CMP signer certificate set via OSSL_CMP_CTX_set1_cert().
 This key is used create signature-based protection (protectionAlg = MSG_SIG_ALG)
 of outgoing messages
-unless a PBM secret has been set via  B<OSSL_CMP_CTX_set1_secretValue()>.
-The B<pkey> argument may be NULL to clear the entry.
+unless a PBM secret has been set via OSSL_CMP_CTX_set1_secretValue().
+The I<pkey> argument may be NULL to clear the entry.
 
-OSSL_CMP_CTX_set1_secretValue() sets the byte string B<sec> with length B<len>
-as PBM secret in the given B<ctx> or clears it if the B<sec> argument is NULL.
+OSSL_CMP_CTX_set1_secretValue() sets the byte string I<sec> with length I<len>
+as PBM secret in the given I<ctx> or clears it if the I<sec> argument is NULL.
 If present, this secret is used to create PBM-based protection of outgoing
 messages and to verify any PBM-based protection of incoming messages
 (protectionAlg = MSG_MAC_ALG). PBM stands for Password-Based MAC.
 PBM-based protection takes precedence over signature-based protection.
 
-OSSL_CMP_CTX_set1_referenceValue() sets the given referenceValue B<ref> with
-length B<len> in the given B<ctx> or clears it if the B<ref> argument is NULL.
+OSSL_CMP_CTX_set1_referenceValue() sets the given referenceValue I<ref> with
+length I<len> in the given I<ctx> or clears it if the I<ref> argument is NULL.
 According to RFC 4210 section 5.1.1, if no value for the sender field in
-CMP message headers can be determined (i.e., no protection certificate B<cert>
-and no B<subjectName> is given) then the sender field will contain the NULL-DN
+CMP message headers can be determined (i.e., no CMP signer certificate
+and no subject DN is set via OSSL_CMP_CTX_set1_subjectName()
+then the sender field will contain the NULL-DN
 and the senderKID field of the CMP message header must be set.
 When signature-based protection is used the senderKID will be set to
-the subjectKeyIdentifier of the protection B<cert> as far as present.
+the subjectKeyIdentifier of the CMP signer certificate as far as present.
 If not present or when PBM-based protection is used
-the B<ref> value is taken as the fallback value for the senderKID.
+the I<ref> value is taken as the fallback value for the senderKID.
 
 OSSL_CMP_CTX_set1_recipient() sets the recipient name that will be used in the
 PKIHeader of CMP request messages, i.e. the X509 name of the (CA) server.
@@ -488,10 +490,10 @@ If not given explicitly the recipient is determined in the following order:
 the subject of the CMP server certificate set using OSSL_CMP_CTX_set1_srvCert(),
 the value set using OSSL_CMP_CTX_set1_issuer(),
 the issuer of the certificate set using OSSL_CMP_CTX_set1_oldCert(),
-the issuer of the protection certificate (B<cert>),
+the issuer of the CMP signer certificate,
 as far as any of those is present, else the NULL-DN as last resort.
 
-OSSL_CMP_CTX_push0_geninfo_ITAV() adds B<itav> to the stack in the B<ctx> to be
+OSSL_CMP_CTX_push0_geninfo_ITAV() adds I<itav> to the stack in the I<ctx> to be
 added to the GeneralInfo field of the CMP PKIMessage header of a request
 message sent with this context.
 
@@ -500,13 +502,13 @@ sent to remote.
 
 OSSL_CMP_CTX_set0_newPkey() can be used to explicitly set the given EVP_PKEY
 structure as the private or public key to be certified in the CMP context.
-The B<priv> parameter must be 0 if and only if the given key is a public key.
+The I<priv> parameter must be 0 if and only if the given key is a public key.
 
 OSSL_CMP_CTX_get0_newPkey() gives the key to use for certificate enrollment
 dependent on fields of the CMP context structure:
 the newPkey (which may be a private or public key) if present,
 else the public key in the p10CSR if present, else the client private key.
-If the B<priv> parameter is not 0 and the selected key does not have a
+If the I<priv> parameter is not 0 and the selected key does not have a
 private component then NULL is returned.
 
 OSSL_CMP_CTX_set1_issuer() sets the name of the intended issuer that
@@ -514,22 +516,22 @@ will be set in the CertTemplate, i.e., the X509 name of the CA server.
 
 OSSL_CMP_CTX_set1_subjectName() sets the subject DN that will be used in
 the CertTemplate structure when requesting a new cert. For Key Update Requests
-(KUR), it defaults to the subject DN of the B<reference certificate>,
-see B<OSSL_CMP_CTX_set1_oldCert()>. This default is used for Initialization
+(KUR), it defaults to the subject DN of the reference certificate,
+see OSSL_CMP_CTX_set1_oldCert(). This default is used for Initialization
 Requests (IR) and Certification Requests (CR) only if no SANs are set.
-The B<subjectName> is also used as fallback for the sender field
-of outgoing CMP messages if no B<cert> and no B<oldcert> are available.
+The I<subjectName> is also used as fallback for the sender field
+of outgoing CMP messages if no reference certificate is available.
 
 OSSL_CMP_CTX_push1_subjectAltName() adds the given X509 name to the list of
 alternate names on the certificate template request. This cannot be used if
 any Subject Alternative Name extension is set via
 OSSL_CMP_CTX_set0_reqExtensions().
 By default, unless OSSL_CMP_OPT_SUBJECTALTNAME_NODEFAULT has been set,
-the Subject Alternative Names are copied from the B<reference certificate>,
-see B<OSSL_CMP_CTX_set1_oldCert()>.
-If set and the subject DN is not set with OSSL_CMP_CTX_set1_subjectName(), then
+the Subject Alternative Names are copied from the reference certificate,
+see OSSL_CMP_CTX_set1_oldCert().
+If set and the subject DN is not set with OSSL_CMP_CTX_set1_subjectName() then
 the certificate template of an IR and CR will not be filled with the default
-subject DN from the B<reference certificate>.
+subject DN from the reference certificate.
 If a subject DN is desired it needs to be set explicitly with
 OSSL_CMP_CTX_set1_subjectName().
 
@@ -544,24 +546,25 @@ to the X509_EXTENSIONS of the requested certificate template.
 
 OSSL_CMP_CTX_set1_oldCert() sets the old certificate to be updated in
 Key Update Requests (KUR) or to be revoked in Revocation Requests (RR).
-It must be given for RR, else it defaults to the protection B<cert>.
-The B<reference certificate> determined in this way, if any, is also used for
+It must be given for RR, else it defaults to the CMP signer certificate.
+The reference certificate determined in this way, if any, is also used for
 deriving default subject DN and Subject Alternative Names for IR, CR, and KUR.
-Its subject is used as sender in CMP message headers if no protection cert is given.
+The subject of the reference certificate is used as the sender field value
+in CMP message headers.
 Its issuer is used as default recipient in CMP message headers.
 
 OSSL_CMP_CTX_set1_p10CSR() sets the PKCS#10 CSR to be used in P10CR.
 
-OSSL_CMP_CTX_push0_genm_ITAV() adds B<itav> to the stack in the B<ctx> which
+OSSL_CMP_CTX_push0_genm_ITAV() adds I<itav> to the stack in the I<ctx> which
 will be the body of a General Message sent with this context.
 
 OSSL_CMP_certConf_cb() is the default certificate confirmation callback function.
 If the callback argument is not NULL it must point to a trust store.
 In this case the function checks that the newly enrolled certificate can be
-verified using this trust store and untrusted certificates from the B<ctx>,
+verified using this trust store and untrusted certificates from the I<ctx>,
 which have been augmented by the list of extraCerts received.
 If the callback argument is NULL the function tries building an approximate
-chain as far as possible using the same untrusted certificates from the B<ctx>,
+chain as far as possible using the same untrusted certificates from the I<ctx>,
 and if this fails it takes the received extraCerts as fallback.
 The resulting cert chain can be retrieved using OSSL_CMP_CTX_get1_newChain().
 
@@ -572,13 +575,13 @@ a positive or negative certConf message to the server. The callback has type
  typedef int (*OSSL_CMP_certConf_cb_t) (OSSL_CMP_CTX *ctx, X509 *cert,
                                         int fail_info, const char **txt);
 
-and should inspect the certificate it obtains via the B<cert> parameter and may
-overrule the pre-decision given in the B<fail_info> and B<*txt> parameters.
+and should inspect the certificate it obtains via the I<cert> parameter and may
+overrule the pre-decision given in the I<fail_info> and I<*txt> parameters.
 If it accepts the certificate it must return 0, indicating success. Else it must
 return a bit field reflecting PKIFailureInfo with at least one failure bit and
-may set the B<*txt> output parameter to point to a string constant with more
+may set the I<*txt> output parameter to point to a string constant with more
 detail.  The transfer callback may make use of a custom defined argument stored
-in the B<ctx> by means of OSSL_CMP_CTX_set_certConf_cb_arg(), which may be
+in the I<ctx> by means of OSSL_CMP_CTX_set_certConf_cb_arg(), which may be
 retrieved again through OSSL_CMP_CTX_get_certConf_cb_arg().
 Typically, the callback will check at least that the certificate can be verified
 using a set of trusted certificates.
@@ -587,8 +590,8 @@ enrolled certificate with the certificate template of the request.
 
 OSSL_CMP_CTX_set_certConf_cb_arg() sets an argument, respectively a pointer to a
 structure containing arguments, optionally to be used by the certConf callback.
-B<arg> is not consumed, and it must therefore explicitly be freed when not
-needed any more. B<arg> may be NULL to clear the entry.
+I<arg> is not consumed, and it must therefore explicitly be freed when not
+needed any more. I<arg> may be NULL to clear the entry.
 
 OSSL_CMP_CTX_get_certConf_cb_arg() gets the argument, respectively the pointer
 to a structure containing arguments, previously set by
@@ -626,8 +629,8 @@ transaction.
 OSSL_CMP_CTX_set1_transactionID() sets the given transaction ID in the given
 OSSL_CMP_CTX structure.
 
-OSSL_CMP_CTX_set1_senderNonce() stores the last sent sender B<nonce> in
-the B<ctx>. This will be used to validate the recipNonce in incoming messages.
+OSSL_CMP_CTX_set1_senderNonce() stores the last sent sender I<nonce> in
+the I<ctx>. This will be used to validate the recipNonce in incoming messages.
 
 =head1 NOTES
 
@@ -657,8 +660,8 @@ OSSL_CMP_CTX_get_status(), and
 OSSL_CMP_CTX_get_failInfoCode()
 return the intended value as described above or -1 on error.
 
-OSSL_CMP_certConf_cb() returns B<fail_info> if it is not equal to B<0>,
-else B<0> on successful validation,
+OSSL_CMP_certConf_cb() returns I<fail_info> if it is not equal to 0,
+else 0 on successful validation,
 or else a bit field with the B<OSSL_CMP_PKIFAILUREINFO_incorrectData> bit set.
 
 All other functions return 1 on success, 0 on error.
@@ -729,7 +732,8 @@ the id-it-signKeyPairTypes OID and prints info on the General Response contents:
 
 L<OSSL_CMP_exec_IR_ses(3)>, L<OSSL_CMP_exec_CR_ses(3)>,
 L<OSSL_CMP_exec_KUR_ses(3)>, L<OSSL_CMP_exec_GENM_ses(3)>,
-L<OSSL_CMP_exec_certreq(3)>
+L<OSSL_CMP_exec_certreq(3)>, L<OSSL_CMP_MSG_http_perform(3)>,
+L<ERR_print_errors_cb(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -48,6 +48,7 @@ OSSL_CMP_CTX_set1_oldCert,
 OSSL_CMP_CTX_set1_p10CSR,
 OSSL_CMP_CTX_push0_genm_ITAV,
 OSSL_CMP_certConf_cb_t,
+OSSL_CMP_certConf_cb,
 OSSL_CMP_CTX_set_certConf_cb,
 OSSL_CMP_CTX_set_certConf_cb_arg,
 OSSL_CMP_CTX_get_certConf_cb_arg,
@@ -137,6 +138,8 @@ OSSL_CMP_CTX_set1_senderNonce
  /* certificate confirmation: */
  typedef int (*OSSL_CMP_certConf_cb_t)(OSSL_CMP_CTX *ctx, X509 *cert,
                                        int fail_info, const char **txt);
+ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
+                          const char **text);
  int OSSL_CMP_CTX_set_certConf_cb(OSSL_CMP_CTX *ctx, OSSL_CMP_certConf_cb_t cb);
  int OSSL_CMP_CTX_set_certConf_cb_arg(OSSL_CMP_CTX *ctx, void *arg);
  void *OSSL_CMP_CTX_get_certConf_cb_arg(const OSSL_CMP_CTX *ctx);
@@ -430,7 +433,7 @@ list of untrusted certs, which may be empty if unset.
 
 OSSL_CMP_CTX_set1_cert() sets the certificate used for CMP message protection.
 The public key of this B<cert> must correspond to
-the private key set via B<OSSL_CMP_CTX_set1_pkey()>.
+the private key set before or thereafter via B<OSSL_CMP_CTX_set1_pkey()>.
 When using signature-based protection of CMP request messages
 this "protection certificate" will be included first in the extraCerts field.
 The subject of this B<cert> will be used as the sender field of outgoing
@@ -552,6 +555,16 @@ OSSL_CMP_CTX_set1_p10CSR() sets the PKCS#10 CSR to be used in P10CR.
 OSSL_CMP_CTX_push0_genm_ITAV() adds B<itav> to the stack in the B<ctx> which
 will be the body of a General Message sent with this context.
 
+OSSL_CMP_certConf_cb() is the default certificate confirmation callback function.
+If the callback argument is not NULL it must point to a trust store.
+In this case the function checks that the newly enrolled certificate can be
+verified using this trust store and untrusted certificates from the B<ctx>,
+which have been augmented by the list of extraCerts received.
+If the callback argument is NULL the function tries building an approximate
+chain as far as possible using the same untrusted certificates from the B<ctx>,
+and if this fails it takes the received extraCerts as fallback.
+The resulting cert chain can be retrieved using OSSL_CMP_CTX_get1_newChain().
+
 OSSL_CMP_CTX_set_certConf_cb() sets the callback used for evaluating the newly
 enrolled certificate before the library sends, depending on its result,
 a positive or negative certConf message to the server. The callback has type
@@ -643,6 +656,10 @@ OSSL_CMP_CTX_reqExtensions_have_SAN(),
 OSSL_CMP_CTX_get_status(), and
 OSSL_CMP_CTX_get_failInfoCode()
 return the intended value as described above or -1 on error.
+
+OSSL_CMP_certConf_cb() returns B<fail_info> if it is not equal to B<0>,
+else B<0> on successful validation,
+or else a bit field with the B<OSSL_CMP_PKIFAILUREINFO_incorrectData> bit set.
 
 All other functions return 1 on success, 0 on error.
 

--- a/doc/man3/OSSL_CMP_exec_certreq.pod
+++ b/doc/man3/OSSL_CMP_exec_certreq.pod
@@ -13,8 +13,7 @@ OSSL_CMP_P10CR,
 OSSL_CMP_KUR,
 OSSL_CMP_try_certreq,
 OSSL_CMP_exec_RR_ses,
-OSSL_CMP_exec_GENM_ses,
-OSSL_CMP_certConf_cb
+OSSL_CMP_exec_GENM_ses
 - functions implementing CMP client transactions
 
 =head1 SYNOPSIS
@@ -33,8 +32,6 @@ OSSL_CMP_certConf_cb
  #define OSSL_CMP_KUR
  int OSSL_CMP_try_certreq(OSSL_CMP_CTX *ctx, int req_type,
                           const OSSL_CRMF_MSG *crm, int *checkAfter);
- int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
-                          const char **text);
  X509 *OSSL_CMP_exec_RR_ses(OSSL_CMP_CTX *ctx);
  STACK_OF(OSSL_CMP_ITAV) *OSSL_CMP_exec_GENM_ses(OSSL_CMP_CTX *ctx);
 
@@ -101,12 +98,6 @@ If the caller decides to abort the pending certificate request and provides
 a negative value as the B<req_type> argument then OSSL_CMP_try_certreq()
 aborts the CMP transaction by sending an error message to the server.
 
-OSSL_CMP_certConf_cb() is a basic certificate confirmation callback validating
-that the new certificate can be verified with the trusted/untrusted certificates
-in B<ctx>.
-As there is no requirement in RFC 4210 that the certificate can be
-validated by the client, this callback is not set by default in the context.
-
 OSSL_CMP_exec_RR_ses() requests the revocation of the certificate
 specified in the B<ctx> using L<OSSL_CMP_CTX_set1_oldCert(3)>.
 RFC 4210 is vague in which PKIStatus should be returned by the server.
@@ -145,10 +136,6 @@ in case a 'waiting' status has been received and checkAfter value is available.
 In the latter case L<OSSL_CMP_CTX_get0_newCert(3)> yields NULL
 and the output parameter B<checkAfter> has been used to
 assign the received value unless B<checkAfter> is NULL.
-
-OSSL_CMP_certConf_cb() returns B<fail_info> if it is not equal to B<0>,
-else B<0> on successful validation,
-or else a bit field with the B<OSSL_CMP_PKIFAILUREINFO_incorrectData> bit set.
 
 OSSL_CMP_exec_RR_ses() returns the
 pointer to the revoked certificate on success, B<NULL> on error.


### PR DESCRIPTION
It turned out that so far the chain building of the CMP implementation had some conceptual defects, fixed in this PR.
Doing so I also corrected a minor bug. The strengthened `OSSL_CMP_certConf_cb()` is now used by default.

UPDATE: all API changes have been carved out to #12790 and #12791, removing part of the items listed here:

* ~~Add the CLI options `-own_trusted` and `-chainout`.~~
* Use strengthened cert chain building, optionally verifying it using a trust store
  while making sure that no certificate status (e.g., CRL) checks are done.
* ~~Extend the tests in `cmp_protect_test.c` and the documentation accordingly.~~
* Use `OSSL_CMP_certConf_cb()` the default and move its doc to OSSL_CMP_CTX_new.pod.
* ~~Fix bug: set senderKID and extend extraCerts also for unprotected CMP requests.~~
* ~~Simplify certificate saving in `apps/cmp.c`.~~
* Simplify certificate and cert store loading in `apps/cmp.c`



<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
