### PR TITLE
RAND: allow the primary, public and private of DRBGs to be overriden and replaced.

### DIFF
--- a/doc/man3/RAND_get0_primary.pod
+++ b/doc/man3/RAND_get0_primary.pod
@@ -4,7 +4,10 @@
 
 RAND_get0_primary,
 RAND_get0_public,
-RAND_get0_private
+RAND_get0_private,
+RAND_set0_primary,
+RAND_set0_public,
+RAND_set0_private
 - get access to the global EVP_RAND_CTX instances
 
 =head1 SYNOPSIS
@@ -14,6 +17,9 @@ RAND_get0_private
  EVP_RAND_CTX *RAND_get0_primary(OPENSSL_CTX *ctx);
  EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx);
  EVP_RAND_CTX *RAND_get0_private(OPENSSL_CTX *ctx);
+ int RAND_set0_primary(OPENSSL_CTX *ctx, EVP_RAND_CTX *rand);
+ int RAND_set0_public(OPENSSL_CTX *ctx, EVP_RAND_CTX *rand);
+ int RAND_set0_private(OPENSSL_CTX *ctx, EVP_RAND_CTX *rand);
 
 
 =head1 DESCRIPTION
@@ -28,6 +34,13 @@ directly, but is used internally to reseed the other two instances.
 
 These functions here provide access to the shared DRBG instances.
 
+The three functions: RAND_set0_primary(),  RAND_set0_public() and
+RAND_set0_private() alter the default DRBGs to better suite an application's
+requirements.  In each case the specified EVP_RAND_CTX replaces any
+existing one and control is retained by the RAND subsystem.  Note that,
+the parentage of the replacement DRBG instances is arbitrary and need not be
+related to the default arrangement.
+
 =head1 RETURN VALUES
 
 RAND_get0_primary() returns a pointer to the I<primary> DRBG instance
@@ -38,6 +51,9 @@ for the given OPENSSL_CTX B<ctx>.
 
 RAND_get0_private() returns a pointer to the I<private> DRBG instance
 for the given OPENSSL_CTX B<ctx>.
+
+RAND_set0_primary(), RAND_set0_public() and RAND_set0_private() return 1 on
+success and 0 on error.
 
 In all the above cases the B<ctx> parameter can
 be NULL in which case the default OPENSSL_CTX is used.

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -70,6 +70,9 @@ DEPRECATEDIN_1_1_0(int RAND_pseudo_bytes(unsigned char *buf, int num))
 EVP_RAND_CTX *RAND_get0_primary(OPENSSL_CTX *ctx);
 EVP_RAND_CTX *RAND_get0_public(OPENSSL_CTX *ctx);
 EVP_RAND_CTX *RAND_get0_private(OPENSSL_CTX *ctx);
+int RAND_set0_primary(OPENSSL_CTX *ctx, EVP_RAND_CTX *rand);
+int RAND_set0_public(OPENSSL_CTX *ctx, EVP_RAND_CTX *rand);
+int RAND_set0_private(OPENSSL_CTX *ctx, EVP_RAND_CTX *rand);
 
 void RAND_seed(const void *buf, int num);
 void RAND_keep_random_devices_open(int keep);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5286,3 +5286,6 @@ OSSL_PARAM_get_octet_string_ptr         ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_CTX_set_passphrase_cb      ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_mac_key                ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_new_CMAC_key_with_libctx       ?	3_0_0	EXIST::FUNCTION:
+RAND_set0_primary                       ?	3_0_0	EXIST::FUNCTION:
+RAND_set0_public                        ?	3_0_0	EXIST::FUNCTION:
+RAND_set0_private                       ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Allow the default DRBG set up to be modified in an application manner.

- [x] documentation is added or updated
- [x] tests are added or updated
