### PR TITLE
Fix the DRBG reseed propagation [1.1.1]

### DIFF
--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -620,7 +620,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
             || now - drbg->reseed_time >= drbg->reseed_time_interval)
             reseed_required = 1;
     }
-    if (drbg->reseed_counter > 0 && drbg->parent != NULL) {
+    if (rbg->enable_reseed_propagation && drbg->parent != NULL) {
         if (drbg->reseed_counter != tsan_load(&drbg->parent->reseed_counter))
             reseed_required = 1;
     }

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -327,13 +327,6 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
         max_entropylen += drbg->max_noncelen;
     }
 
-    drbg->reseed_next_counter = tsan_load(&drbg->reseed_prop_counter);
-    if (drbg->reseed_next_counter) {
-        drbg->reseed_next_counter++;
-        if (!drbg->reseed_next_counter)
-            drbg->reseed_next_counter = 1;
-    }
-
     if (drbg->get_entropy != NULL)
         entropylen = drbg->get_entropy(drbg, &entropy, min_entropy,
                                        min_entropylen, max_entropylen, 0);
@@ -361,7 +354,12 @@ int RAND_DRBG_instantiate(RAND_DRBG *drbg,
     drbg->state = DRBG_READY;
     drbg->reseed_gen_counter = 1;
     drbg->reseed_time = time(NULL);
-    tsan_store(&drbg->reseed_prop_counter, drbg->reseed_next_counter);
+    if (drbg->reseed_prop_counter > 0) {
+        if (drbg->parent == NULL)
+            drbg->reseed_prop_counter++;
+        else
+            drbg->reseed_prop_counter = drbg->parent->reseed_prop_counter;
+    }
 
  end:
     if (entropy != NULL && drbg->cleanup_entropy != NULL)
@@ -428,14 +426,6 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
     }
 
     drbg->state = DRBG_ERROR;
-
-    drbg->reseed_next_counter = tsan_load(&drbg->reseed_prop_counter);
-    if (drbg->reseed_next_counter) {
-        drbg->reseed_next_counter++;
-        if (!drbg->reseed_next_counter)
-            drbg->reseed_next_counter = 1;
-    }
-
     if (drbg->get_entropy != NULL)
         entropylen = drbg->get_entropy(drbg, &entropy, drbg->strength,
                                        drbg->min_entropylen,
@@ -453,7 +443,12 @@ int RAND_DRBG_reseed(RAND_DRBG *drbg,
     drbg->state = DRBG_READY;
     drbg->reseed_gen_counter = 1;
     drbg->reseed_time = time(NULL);
-    tsan_store(&drbg->reseed_prop_counter, drbg->reseed_next_counter);
+    if (drbg->reseed_prop_counter > 0) {
+        if (drbg->parent == NULL)
+            drbg->reseed_prop_counter++;
+        else
+            drbg->reseed_prop_counter = drbg->parent->reseed_prop_counter;
+    }
 
  end:
     if (entropy != NULL && drbg->cleanup_entropy != NULL)
@@ -623,11 +618,8 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
             || now - drbg->reseed_time >= drbg->reseed_time_interval)
             reseed_required = 1;
     }
-    if (drbg->parent != NULL) {
-        unsigned int reseed_counter = tsan_load(&drbg->reseed_prop_counter);
-        if (reseed_counter > 0
-                && tsan_load(&drbg->parent->reseed_prop_counter)
-                   != reseed_counter)
+    if (drbg->reseed_prop_counter > 0 && drbg->parent != NULL) {
+        if (drbg->reseed_prop_counter != drbg->parent->reseed_prop_counter)
             reseed_required = 1;
     }
 
@@ -708,8 +700,7 @@ int RAND_DRBG_set_callbacks(RAND_DRBG *drbg,
                             RAND_DRBG_get_nonce_fn get_nonce,
                             RAND_DRBG_cleanup_nonce_fn cleanup_nonce)
 {
-    if (drbg->state != DRBG_UNINITIALISED
-            || drbg->parent != NULL)
+    if (drbg->state != DRBG_UNINITIALISED)
         return 0;
     drbg->get_entropy = get_entropy;
     drbg->cleanup_entropy = cleanup_entropy;
@@ -886,7 +877,7 @@ static RAND_DRBG *drbg_setup(RAND_DRBG *parent)
         goto err;
 
     /* enable seed propagation */
-    tsan_store(&drbg->reseed_prop_counter, 1);
+    drbg->reseed_prop_counter = 1;
 
     /*
      * Ignore instantiation error to support just-in-time instantiation.

--- a/crypto/rand/drbg_lib.c
+++ b/crypto/rand/drbg_lib.c
@@ -621,7 +621,7 @@ int RAND_DRBG_generate(RAND_DRBG *drbg, unsigned char *out, size_t outlen,
             reseed_required = 1;
     }
     if (drbg->reseed_prop_counter > 0 && drbg->parent != NULL) {
-        if (drbg->reseed_prop_counter != drbg->parent->reseed_prop_counter)
+        if (drbg->reseed_prop_counter != tsan_load(&drbg->parent->reseed_prop_counter))
             reseed_required = 1;
     }
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -174,8 +174,6 @@ size_t rand_drbg_get_entropy(RAND_DRBG *drbg,
                                    prediction_resistance,
                                    (unsigned char *)&drbg, sizeof(drbg)) != 0)
                 bytes = bytes_needed;
-            drbg->reseed_next_counter
-                = tsan_load(&drbg->parent->reseed_prop_counter);
             rand_drbg_unlock(drbg->parent);
 
             rand_pool_add_end(pool, bytes, 8 * bytes);

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -16,7 +16,6 @@
 # include <openssl/hmac.h>
 # include <openssl/ec.h>
 # include <openssl/rand_drbg.h>
-# include "internal/tsan_assist.h"
 
 # include "internal/numbers.h"
 
@@ -258,8 +257,7 @@ struct rand_drbg_st {
      * is added by RAND_add() or RAND_seed() will have an immediate effect on
      * the output of RAND_bytes() resp. RAND_priv_bytes().
      */
-    TSAN_QUALIFIER unsigned int reseed_prop_counter;
-    unsigned int reseed_next_counter;
+    unsigned int reseed_prop_counter;
 
     size_t seedlen;
     DRBG_STATUS state;

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -16,6 +16,7 @@
 # include <openssl/hmac.h>
 # include <openssl/ec.h>
 # include <openssl/rand_drbg.h>
+# include "internal/tsan_assist.h"
 
 # include "internal/numbers.h"
 
@@ -247,9 +248,15 @@ struct rand_drbg_st {
      * This value is ignored if it is zero.
      */
     time_t reseed_time_interval;
+
+    /*
+     * Enables reseed propagation (see following comment)
+     */
+    unsigned int enable_reseed_propagation;
+
     /*
      * Counts the number of reseeds since instantiation.
-     * This value is ignored if it is zero.
+     * This value is ignored if enable_reseed_propagation is zero.
      *
      * This counter is used only for seed propagation from the <master> DRBG
      * to its two children, the <public> and <private> DRBG. This feature is
@@ -257,7 +264,7 @@ struct rand_drbg_st {
      * is added by RAND_add() or RAND_seed() will have an immediate effect on
      * the output of RAND_bytes() resp. RAND_priv_bytes().
      */
-    unsigned int reseed_prop_counter;
+    TSAN_QUALIFIER unsigned int reseed_prop_counter;
 
     size_t seedlen;
     DRBG_STATUS state;

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -235,7 +235,7 @@ struct rand_drbg_st {
     size_t max_perslen, max_adinlen;
 
     /* Counts the number of generate requests since the last reseed. */
-    unsigned int reseed_gen_counter;
+    unsigned int generate_counter;
     /*
      * Maximum number of generate requests until a reseed is required.
      * This value is ignored if it is zero.
@@ -264,7 +264,7 @@ struct rand_drbg_st {
      * is added by RAND_add() or RAND_seed() will have an immediate effect on
      * the output of RAND_bytes() resp. RAND_priv_bytes().
      */
-    TSAN_QUALIFIER unsigned int reseed_prop_counter;
+    TSAN_QUALIFIER unsigned int reseed_counter;
 
     size_t seedlen;
     DRBG_STATUS state;


### PR DESCRIPTION
Before explaining the issue and the fix, let me recap briefly what reseed propagation is all about. In a nutshell, it is a compatibility feature to support the traditional way of (re-)seeding manually by calling 'RAND_add()' before 'RAND_bytes(). I'll explain it for the 'public' DRBG, the situation for the 'private' DRBG is analogous.

## Reseed Propagation

For performance reasons, every thread has its own 'public' DRBG instance, and all public DRBGs are chained to a common 'primary' DRBG, which seeds from the operating system. The primary DRBG is shared by all threads and guarded by a mutex. Every DRBG reseeds independently when its number of generate requests or its elapsed time interval since the last (re-)seeding exceeds a certain threshold. This is the 'normal' way to reseed according to the NIST standard.

When a thread of the application calls RAND_add() to seed the CSPRNG, it expects an immediate effect on the output of a subsequent RAND_bytes() call within the same thread. However, the former triggers a reseeding of the primary DRBG, whereas the latter generates the output using the thread-local 'public' DRBG. In this specific situation, OpenSSL needs to guarantee an immediate propagation of the reseeding to the 'public' DRBG within the same thread.


### The original implementation

Again for performance reasons, the seed propagation was implemented in a non-blocking fashion, i.e. without taking the look of the primary DRBG: The primary DRBG maintains a reseed_counter (not to be confused with the generate_counter which counts the generate requests), which is incremented automatically when it reseeds.

https://github.com/openssl/openssl/blob/1708e3e85b4a86bae26860aa5d2913fc8eff6086/crypto/rand/drbg_lib.c#L612-L615

The secondary DRBG has a copy of the reseed_counter, and whenever the two counters are out of sync, the secondary DRBG will reseed automatically.

https://github.com/openssl/openssl/blob/1708e3e85b4a86bae26860aa5d2913fc8eff6086/crypto/rand/drbg_lib.c#L439-L444

In other words, the reseed_counter was used like a revision counter to detect and propagate the reseeding. Note that eventually the reseeding will propagate to the public DRBGs of all threads, but it is not guaranteed that it will happen immediately.


## The issue

### Part 1: the thread sanitizer warning

The original implementation did not use atomics, because I assumed that integer read and write operations where atomic with relaxed semantic, which would be sufficient for synchronization within the same thread. (In fact, I did not know much about memory ordering and aqcuire/release/relaxed semantics at that time.) This assumption turned out to be naive when @bernd-edlinger reported a thread sanitizer (TSAN) warning about a data race in RAND_DRBG_generate() in issue #7394:

> This was reported by thread sanitizer once (using openssl 1.1.1 release tar ball):
> 
> ```
> ==================
> WARNING: ThreadSanitizer: data race (pid=17059)
>   Read of size 4 at 0x7b480001e980 by thread T8 (mutexes: write M145, write M33):
>     #0 RAND_DRBG_generate crypto/rand/drbg_lib.c:613 (CPPTestServer+0x11295f0)
>     #1 RAND_DRBG_bytes crypto/rand/drbg_lib.c:658 (CPPTestServer+0x11295f0)
>     #2 drbg_bytes crypto/rand/drbg_lib.c:946 (CPPTestServer+0x11295f0)
>     #3 RAND_bytes crypto/rand/rand_lib.c:776 (CPPTestServer+0x112c1f8)
>     ...
> 
>   Previous write of size 4 at 0x7b480001e980 by thread T27 (mutexes: write M494, write M152, write M158):
>     #0 RAND_DRBG_reseed crypto/rand/drbg_lib.c:441 (CPPTestServer+0x1127f1b)
>     #1 rand_drbg_restart crypto/rand/drbg_lib.c:542 (CPPTestServer+0x11281c2)
>     #2 drbg_add crypto/rand/drbg_lib.c:974 (CPPTestServer+0x11284a7)
>     #3 drbg_seed crypto/rand/drbg_lib.c:985 (CPPTestServer+0x11284a7)
>     #4 RAND_seed crypto/rand/rand_lib.c:738 (CPPTestServer+0x112bee2)
>     ...
> 
>   Location is heap block of size 352 at 0x7b480001e900 allocated by main thread:
>     ...
>     #5 CRYPTO_secure_zalloc crypto/mem_sec.c:145 (CPPTestServer+0x11013d8)
>     #6 rand_drbg_new crypto/rand/drbg_lib.c:175 (CPPTestServer+0x11266eb)
>     #7 RAND_DRBG_secure_new crypto/rand/drbg_lib.c:243 (CPPTestServer+0x1129bdd)
>     #8 drbg_setup crypto/rand/drbg_lib.c:853 (CPPTestServer+0x1129bdd)
>     ...
> 
> 
>   Mutex M158 (0x7b1000050e80) created at:
>     #0 pthread_rwlock_init ../../../../gcc-9-20181007/libsanitizer/tsan/tsan_interceptors.cc:1224 (libtsan.so.0+0x2fd7e)
>     #1 CRYPTO_THREAD_lock_new crypto/threads_pthread.c:29 (CPPTestServer+0x1166030)
>     #2 rand_drbg_enable_locking crypto/rand/drbg_lib.c:813 (CPPTestServer+0x11290c5)
>     #3 drbg_setup crypto/rand/drbg_lib.c:858 (CPPTestServer+0x1129bf1)
>     ...
> 
> 
> SUMMARY: ThreadSanitizer: data race crypto/rand/drbg_lib.c:613 in RAND_DRBG_generate
> ==================
> ```

The data race affects the aforementioned operations happening in different threads:

**thread 8, frame 0**

https://github.com/openssl/openssl/blob/1708e3e85b4a86bae26860aa5d2913fc8eff6086/crypto/rand/drbg_lib.c#L612-L615


**thread 27, frame 0**

https://github.com/openssl/openssl/blob/1708e3e85b4a86bae26860aa5d2913fc8eff6086/crypto/rand/drbg_lib.c#L439-L444



It was considered that the data race might be harmless but nevertheless it would be better to fix the warning (see https://github.com/openssl/openssl/issues/7394#issuecomment-429529259 and ff.).

### Part 2: another data race

During the analysis of the issue, @bernd-edlinger noticed another potential race

> The problem is that parent->reseed_prop_counter is read twice,
> once before get_entropy from parent, and once after get_entropy.
> So what can happen is, and it will not be fixed by acquire/release semantics:
> When we are interrupted after the get_entropy call, when the
> parent's mutex is already released, but before parent->reseed_prop_counter
> is read for the second time, the dependent DRBG will not have a reason
> to call get_entropy again, and that state is persistent.

> To fix that, we need to get the parent's reseed_prop_counter before
> getting the entropy from the parent. Atomic with relaxed semantic
> should be sufficient, because the parent's mutex has the necessary
> acquire/release barriers.


## The fix

Bernds pull request #7399 fixed the data races, but at the price that the original simplicity of the implementation got lost, in particular by the introduction of the new 'reseed_next_counter' member. Unfortunately, https://github.com/openssl/openssl/pull/7399/files#diff-9181ac017a6177a5f2619f65c9b7a346R411 also introduced a breaking change of the original semantics  of the seed propagation: instead of copying the value from the parent, the secondary DRBGs now increment their counter by themselves. IIUC, a secondary DRBG which is behind the primary DRBG by three counts will reseed three times until it considers itself in-sync with the primary DRBG.


### Alternative fix

My alternative proposal intends to fix the data race while retaining the original simplicity.


Note that in the meantime, `seed_counter` has been renamed to `seed_prop_counter` and `generate_counter` to `seed_gen_counter` (which is another issue to be fixed).


#### Atomics with relaxed semantics should be sufficient

Since the incrementing of the reseed_counter of the principal DRBG is protected by the lock, my understanding is that it should be sufficient to read the value using an atomic operation with relaxed semantics, see also the comments by @kroeckx and @bernd-edlinger.

https://github.com/openssl/openssl/issues/7394#issuecomment-429540196
https://github.com/openssl/openssl/issues/7394#issuecomment-429546542
https://github.com/openssl/openssl/issues/7394#issuecomment-429547343

See also this discussion between @dot-asm and @bernd-edlinger:

https://github.com/openssl/openssl/pull/7399#issuecomment-430005076 and ff.

#### Simplify the counter wrap

The counter wrap was complicated unnecessarily by the fact that `seed_counter == 0` had the special meaning of turning seed propagation off. I removed that extra complexity by adding a separate `enable_reseed_propagation` member.

#### Remove the 'reseed_next_counter'

The 'reseed_next_counter' was introduced to fix a race between two different threads. But it is not the intention of the seed propagation to enforce reseed propagation across threads.


#### Restore the original names

A lot of additional confusion between the two counters `generate_counter` and `reseed_counter` has been created by the renaming to `reseed_gen_counter` and `reseed_prop_counter` on master, which subsequently has partially been reverted. This turned out to be a footgun during the provider replumbing (I hope you remember that, @paulidale.) For that reason, I am restoring the original names here on 1.1.1 and I will do the same on master.



### What about the master branch?

On the master branch, the implementation has deviated even more from the simple original idea.

https://github.com/openssl/openssl/blob/714a1bb380ddb2bf7538f6a61f47ac87200e3e06/providers/implementations/rands/drbg_local.h#L181-L192

It seems that 'get_parent_reseed_count()' nowadays takes the parent's lock before reading the reseed count, which completely thwarts the original intent of having a lock-free implementation.

https://github.com/openssl/openssl/blob/714a1bb380ddb2bf7538f6a61f47ac87200e3e06/providers/implementations/rands/drbg.c#L137-L146


I am working on a fix for master which will hopefully be in time for the beta1 freeze. I chose to raise the pull request for 1.1.1. first, because that's the root cause of the problem and it was easier to start with.


I'd be happy to get some feedback not only from @paulidale, but also from @bernd-edlinger and @kroeckx.
