### PR TITLE
Fix use of OPENSSL_realloc in provider

### DIFF
--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -31,7 +31,7 @@ static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
     int first_operation = 1;
     int last_operation = OSSL_OP__HIGHEST;
     int cur_operation;
-    int ok = 0;
+    int ok = 1;
 
     if (data->operation_id != 0)
         first_operation = last_operation = data->operation_id;
@@ -77,9 +77,9 @@ static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
                 return 0;
         }
 
-        /* If post-condition fulfilled, set general success */
-        if (ret)
-            ok = 1;
+        /* If post-condition not fulfilled, set general failure */
+        if (!ret)
+            ok = 0;
     }
 
     return ok;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -875,14 +875,17 @@ int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum)
     unsigned char bit = (1 << (bitnum % 8)) & 0xFF;
 
     if (provider->operation_bits_sz <= byte) {
-        provider->operation_bits = OPENSSL_realloc(provider->operation_bits,
-                                                   byte + 1);
-        if (provider->operation_bits == NULL) {
+        unsigned char *tmp = OPENSSL_realloc(provider->operation_bits,
+                                             byte + 1);
+
+        if (tmp == NULL) {
             ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
             return 0;
         }
+        provider->operation_bits = tmp;
         memset(provider->operation_bits + provider->operation_bits_sz,
                '\0', byte + 1 - provider->operation_bits_sz);
+        provider->operation_bits_sz = byte + 1;
     }
     provider->operation_bits[byte] |= bit;
     return 1;


### PR DESCRIPTION
Fix OPENSSL_realloc failure case; `provider->operation_bits` memory
is lost when `OPENSSL_realloc()` returns NULL.

`operation_bits_sz` is never set to the length of the allocated array.
This means that operation_bits is always reallocated in
`ossl_provider_set_operation_bit()`, possibly shrinking the array.
In addition, it means that the `memset()` always zeros out the
whole reallocated array, not just the new part. Also, because
`operation_bits_sz` is always zero, the value of `*result` in
`ossl_provider_test_operation_bit()` will always be zero.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
