### PR TITLE
Fix fipsinstall module path

### DIFF
--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -339,6 +339,7 @@ typedef struct string_int_pair_st {
 #define OPT_SECTION(sec) { OPT_SECTION_STR, 1, '-', sec " options:\n" }
 #define OPT_PARAMETERS() { OPT_PARAM_STR, 1, '-', "Parameters:\n" }
 
+const char *opt_path_end(const char *filename);
 char *opt_progname(const char *argv0);
 char *opt_getprog(void);
 char *opt_init(int ac, char **av, const OPTIONS * o);

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -58,6 +58,8 @@ Print a usage message.
 =item B<-module> I<filename>
 
 Filename of the FIPS module to perform an integrity check on.
+The path provided in the filename is used to load the module when it is
+activated, and this overrides the environment variable B<OPENSSL_MODULES>.
 
 =item B<-out> I<configfilename>
 


### PR DESCRIPTION
If a path is specified with the -module option it will use this path to load the library when the provider is activated,
instead of also having to set the environment variable OPENSSL_MODULES.

Added a platform specific opt_path_end() function that uses existing functionality used by opt_progname().

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
