### PR TITLE
Avoid uninitialised variable warning when running tests with 'TESTS=xxx'

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -31,7 +31,7 @@ my $srctop = $ENV{SRCTOP} || $ENV{TOP};
 my $bldtop = $ENV{BLDTOP} || $ENV{TOP};
 my $recipesdir = catdir($srctop, "test", "recipes");
 my $libdir = rel2abs(catdir($srctop, "util", "perl"));
-my $jobs = $ENV{HARNESS_JOBS};
+my $jobs = $ENV{HARNESS_JOBS} // 1;
 
 $ENV{OPENSSL_CONF} = rel2abs(catdir($srctop, "apps", "openssl.cnf"));
 $ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "providers"));
@@ -46,7 +46,7 @@ my %tapargs =
       merge             => 1,
     );
 
-$tapargs{jobs} = $jobs if defined $jobs;
+$tapargs{jobs} = $jobs if $jobs > 1;
 
 # Additional OpenSSL special TAP arguments.  Because we can't pass them via
 # TAP::Harness->new(), they will be accessed directly, see the
@@ -57,7 +57,7 @@ $openssl_args{'failure_verbosity'} = $ENV{HARNESS_VERBOSE} ? 0 :
     $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} ? 2 :
     1; # $ENV{HARNESS_VERBOSE_FAILURE}
 print "Warning: HARNESS_JOBS > 1 overrides HARNESS_VERBOSE\n"
-    if $ENV{HARNESS_JOBS} > 1;
+    if $jobs > 1;
 print "Warning: HARNESS_VERBOSE overrides HARNESS_VERBOSE_FAILURE*\n"
     if ($ENV{HARNESS_VERBOSE} && ($ENV{HARNESS_VERBOSE_FAILURE}
                                   || $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS}));


### PR DESCRIPTION
When running tests locally using 'TESTS=xxx' I get a warning for every run:

```
$ make TESTS=test_genrsa test
make depend && make _tests
make[1]: Entering directory '/home/jon/work/jaffa/openssl/openssl-aix-fix'
make[1]: Leaving directory '/home/jon/work/jaffa/openssl/openssl-aix-fix'
make[1]: Entering directory '/home/jon/work/jaffa/openssl/openssl-aix-fix'
( SRCTOP=. \
  BLDTOP=. \
  PERL="/usr/bin/perl" \
  FIPSKEY="f4556650ac31d35461610bac4ed81b1a181b2d8a43ea2854cbae22ca74560813" \
  EXE_EXT= \
  /usr/bin/perl ./test/run_tests.pl test_genrsa )
Use of uninitialized value $ENV{"HARNESS_JOBS"} in numeric gt (>) at ./test/run_tests.pl line 60.
15-test_genrsa.t .. ok    
All tests successful.
Files=1, Tests=14,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.85 cusr  0.14 csys =  1.02 CPU)
Result: PASS
make[1]: Leaving directory '/home/jon/work/jaffa/openssl/openssl-aix-fix'
```

This seems to be related to the recent PR:

https://github.com/openssl/openssl/pull/12326
