### PR TITLE
Avoid AIX compiler issue with macro argument name change

### DIFF
--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -65,9 +65,9 @@ static int base_get_params(void *provctx, OSSL_PARAM params[])
 }
 
 static const OSSL_ALGORITHM base_encoder[] = {
-#define ENCODER(name, fips, format, type, func_table)                           \
+#define ENCODER(name, _fips, _format, _type, func_table)                    \
     { name,                                                                 \
-      "provider=base,fips=" fips ",format=" format ",type=" type,           \
+      "provider=base,fips=" _fips ",format=" _format ",type=" _type,        \
       (func_table) }
 
 #include "encoders.inc"
@@ -76,9 +76,9 @@ static const OSSL_ALGORITHM base_encoder[] = {
 #undef ENCODER
 
 static const OSSL_ALGORITHM base_decoder[] = {
-#define DECODER(name, fips, input, func_table)                                \
+#define DECODER(name, _fips, _input, func_table)                            \
     { name,                                                                 \
-      "provider=base,fips=" fips ",input=" input,                           \
+      "provider=base,fips=" _fips ",input=" _input,                         \
       (func_table) }
 
 #include "decoders.inc"

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -412,9 +412,9 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
 };
 
 static const OSSL_ALGORITHM deflt_encoder[] = {
-#define ENCODER(name, fips, format, type, func_table)                           \
+#define ENCODER(name, _fips, _format, _type, func_table)                    \
     { name,                                                                 \
-      "provider=default,fips=" fips ",format=" format ",type=" type,        \
+      "provider=default,fips=" _fips ",format=" _format ",type=" _type,     \
       (func_table) }
 
 #include "encoders.inc"
@@ -423,9 +423,9 @@ static const OSSL_ALGORITHM deflt_encoder[] = {
 #undef ENCODER
 
 static const OSSL_ALGORITHM deflt_decoder[] = {
-#define DECODER(name, fips, input, func_table)                                \
+#define DECODER(name, _fips, _input, func_table)                            \
     { name,                                                                 \
-      "provider=default,fips=" fips ",input=" input,                        \
+      "provider=default,fips=" _fips ",input=" _input,                      \
       (func_table) }
 
 #include "decoders.inc"


### PR DESCRIPTION
Fixes #12756

The IBM XLC compiler on AIX has problems handling macro substitution when argument names appear in strings. Renaming the arguments so they don't match any substring fixes this.

Tested on AIX 7.2 using IBM XLC v13.