### PR TITLE
Improve support and documentation of multi-valued RDNs (containing sets of AVAs) for X509 Distinguished Names

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -200,7 +200,7 @@ const OPTIONS ca_options[] = {
     {"rand_serial", OPT_RAND_SERIAL, '-',
      "Always create a random serial; do not store it"},
     {"multivalue-rdn", OPT_MULTIVALUE_RDN, '-',
-     "Enable support for multivalued RDNs"},
+     "Deprecated; multi-valued RDNs support is always on."},
     {"startdate", OPT_STARTDATE, 's', "Cert notBefore, YYMMDDHHMMSSZ"},
     {"enddate", OPT_ENDDATE, 's',
      "YYMMDDHHMMSSZ cert notAfter (overrides -days)"},
@@ -288,7 +288,7 @@ int ca_main(int argc, char **argv)
     size_t outdirlen = 0;
     int create_ser = 0, free_passin = 0, total = 0, total_done = 0;
     int batch = 0, default_op = 1, doupdatedb = 0, ext_copy = EXT_COPY_NONE;
-    int keyformat = FORMAT_PEM, multirdn = 0, notext = 0, output_der = 0;
+    int keyformat = FORMAT_PEM, multirdn = 1, notext = 0, output_der = 0;
     int ret = 1, email_dn = 1, req = 0, verbose = 0, gencrl = 0, dorevoke = 0;
     int rand_ser = 0, i, j, selfsign = 0, def_nid, def_ret;
     long crldays = 0, crlhours = 0, crlsec = 0, days = 0;
@@ -344,7 +344,7 @@ opthelp:
             create_ser = 1;
             break;
         case OPT_MULTIVALUE_RDN:
-            multirdn = 1;
+            /* obsolete */
             break;
         case OPT_STARTDATE:
             startdate = opt_arg();

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -910,7 +910,7 @@ static int set_name(const char *str,
                     OSSL_CMP_CTX *ctx, const char *desc)
 {
     if (str != NULL) {
-        X509_NAME *n = parse_name(str, MBSTRING_ASC, 0, desc);
+        X509_NAME *n = parse_name(str, MBSTRING_ASC, 1, desc);
 
         if (n == NULL)
             return 0;

--- a/apps/req.c
+++ b/apps/req.c
@@ -127,7 +127,7 @@ const OPTIONS req_options[] = {
     {"subj", OPT_SUBJ, 's', "Set or modify request subject"},
     {"subject", OPT_SUBJECT, '-', "Output the request's subject"},
     {"multivalue-rdn", OPT_MULTIVALUE_RDN, '-',
-     "Enable support for multivalued RDNs"},
+     "Deprecated; multi-valued RDNs support is always on."},
     {"days", OPT_DAYS, 'p', "Number of days cert is valid for"},
     {"set_serial", OPT_SET_SERIAL, 's', "Serial number to use"},
     {"addext", OPT_ADDEXT, 's',
@@ -257,7 +257,7 @@ int req_main(int argc, char **argv)
     int ret = 1, x509 = 0, days = 0, i = 0, newreq = 0, verbose = 0;
     int pkey_type = -1, private = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, keyform = FORMAT_PEM;
-    int modulus = 0, multirdn = 0, verify = 0, noout = 0, text = 0;
+    int modulus = 0, multirdn = 1, verify = 0, noout = 0, text = 0;
     int noenc = 0, newhdr = 0, subject = 0, pubkey = 0, precert = 0;
     long newkey = -1;
     unsigned long chtype = MBSTRING_ASC, reqflag = 0;
@@ -421,7 +421,7 @@ int req_main(int argc, char **argv)
             subj = opt_arg();
             break;
         case OPT_MULTIVALUE_RDN:
-            multirdn = 1;
+            /* obsolete */
             break;
         case OPT_ADDEXT:
             p = opt_arg();

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -179,7 +179,7 @@ int x509_main(int argc, char **argv)
     char *subj = NULL;
     X509_NAME *fsubj = NULL;
     const unsigned long chtype = MBSTRING_ASC;
-    const int multirdn = 0;
+    const int multirdn = 1;
     STACK_OF(ASN1_OBJECT) *trust = NULL, *reject = NULL;
     STACK_OF(OPENSSL_STRING) *sigopts = NULL, *vfyopts = NULL;
     X509 *x = NULL, *xca = NULL;

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -13,6 +13,7 @@
 #include <openssl/x509.h>
 #include <openssl/buffer.h>
 #include "crypto/x509.h"
+#include "crypto/ctype.h"
 
 DEFINE_STACK_OF(X509_NAME_ENTRY)
 
@@ -28,6 +29,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
     const X509_NAME_ENTRY *ne;
     int i;
     int n, lold, l, l1, l2, num, j, type;
+    int prev_set = -1;
     const char *s;
     char *p;
     unsigned char *q;
@@ -109,14 +111,11 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             if (!gs_doit[j & 3])
                 continue;
             l2++;
-#ifndef CHARSET_EBCDIC
-            if ((q[j] < ' ') || (q[j] > '~'))
+            if (q[j] == '/' || q[j] == '+')
+                l2++; /* char needs to be escaped */
+            else if ((ossl_toascii(q[j]) < ossl_toascii(' ')) ||
+                     (ossl_toascii(q[j]) > ossl_toascii('~')))
                 l2 += 3;
-#else
-            if ((os_toascii[q[j]] < os_toascii[' ']) ||
-                (os_toascii[q[j]] > os_toascii['~']))
-                l2 += 3;
-#endif
         }
 
         lold = l;
@@ -133,7 +132,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             break;
         } else
             p = &(buf[lold]);
-        *(p++) = '/';
+        *(p++) = prev_set == ne->set ? '+' : '/';
         memcpy(p, s, (unsigned int)l1);
         p += l1;
         *(p++) = '=';
@@ -152,8 +151,11 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 *(p++) = 'x';
                 *(p++) = hex[(n >> 4) & 0x0f];
                 *(p++) = hex[n & 0x0f];
-            } else
+            } else {
+                if (n == '/' || n == '+')
+                    *(p++) = '\\';
                 *(p++) = n;
+            }
 #else
             n = os_toascii[q[j]];
             if ((n < os_toascii[' ']) || (n > os_toascii['~'])) {
@@ -161,11 +163,15 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
                 *(p++) = 'x';
                 *(p++) = hex[(n >> 4) & 0x0f];
                 *(p++) = hex[n & 0x0f];
-            } else
+            } else {
+                if (n == os_toascii['/'] || n == os_toascii['+'])
+                    *(p++) = '\\';
                 *(p++) = q[j];
+            }
 #endif
         }
         *p = '\0';
+        prev_set = ne->set;
     }
     if (b != NULL) {
         p = b->data;

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -285,11 +285,17 @@ used).
 =item B<-subj> I<arg>
 
 Supersedes subject name given in the request.
+
 The arg must be formatted as C</type0=value0/type1=value1/type2=...>.
-Keyword characters may be escaped by C<\> (backslash), and whitespace is
-retained.
+Special characters may be escaped by C<\> (backslash), whitespace is retained.
 Empty values are permitted, but the corresponding type will not be included
 in the resulting certificate.
+Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
+Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
+between the AttributeValueAssertions (AVAs) that specify the members of the set.
+Example:
+
+C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 =item B<-utf8>
 
@@ -313,12 +319,7 @@ This overrides any option or configuration to use a serial number file.
 
 =item B<-multivalue-rdn>
 
-This option causes the -subj argument to be interpreted with full
-support for multivalued RDNs. Example:
-
-C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
-
-If B<-multi-rdn> is not used then the UID value is C<123456+CN=John Doe>.
+This option has been deprecated and has no effect.
 
 {- $OpenSSL::safe::opt_r_item -}
 
@@ -791,7 +792,8 @@ retained mainly for compatibility reasons.
 
 The B<-section> option was added in OpenSSL 3.0.0.
 
-The B<-certform> option has become obsolete in OpenSSL 3.0.0 and has no effect.
+The B<-certform> and B<-multivalue-rdn> options
+have become obsolete in OpenSSL 3.0.0 and have no effect.
 
 All B<-keyform> values except B<ENGINE> have become obsolete in OpenSSL 3.0.0
 and have no effect.

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -268,19 +268,23 @@ For KUR, it defaults to the subject DN of the reference certificate
 (see B<-oldcert>).
 This default is used for IR and CR only if no SANs are set.
 
-The argument must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by C<\>E<nbsp>(backslash), no spaces are skipped.
-
 The subject DN is also used as fallback sender of outgoing CMP messages
 if no B<-cert> and no B<-oldcert> are given.
+
+The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
+Special characters may be escaped by C<\> (backslash), whitespace is retained.
+Empty values are permitted, but the corresponding type will not be included.
+Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
+Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
+between the AttributeValueAssertions (AVAs) that specify the members of the set.
+Example:
+
+C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 =item B<-issuer> I<name>
 
 X509 issuer Distinguished Name (DN) of the CA server
 to place in the requested certificate template in IR/CR/KUR.
-
-The argument must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by C<\>E<nbsp>(backslash), no spaces are skipped.
 
 If neither B<-srvcert> nor B<-recipient> is available,
 the name given in this option is also set as the recipient of the CMP message.
@@ -519,10 +523,6 @@ and as default value for the expected sender of incoming CMP messages.
 Distinguished Name (DN) to use in the recipient field of CMP request messages,
 i.e., the CMP server (usually the addressed CA).
 
-The argument must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by C<\>E<nbsp>(backslash), no spaces are skipped.
-The empty name (NULL-DN) can be given explicitly as a single slash: 'I</>'.
-
 The recipient field in the header of a CMP message is mandatory.
 If not given explicitly the recipient is determined in the following order:
 the subject of the CMP server certificate given with the B<-srvcert> option,
@@ -535,9 +535,6 @@ as far as any of those is present, else the NULL-DN as last resort.
 
 Distinguished Name (DN) expected in the sender field of incoming CMP messages.
 Defaults to the subject DN of the pinned B<-srvcert>, if any.
-
-The argument must be formatted as I</type0=value0/type1=value1/type2=...>,
-characters may be escaped by C<\>E<nbsp>(backslash), no spaces are skipped.
 
 This can be used to make sure that only a particular entity is accepted as
 CMP message signer, and attackers are not able to use arbitrary certificates

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -32,7 +32,6 @@ B<openssl> B<req>
 [B<-I<digest>>]
 [B<-config> I<filename>]
 [B<-section> I<name>]
-[B<-multivalue-rdn>]
 [B<-x509>]
 [B<-days> I<n>]
 [B<-set_serial> I<n>]
@@ -45,6 +44,7 @@ B<openssl> B<req>
 [B<-reqopt>]
 [B<-subject>]
 [B<-subj> I<arg>]
+[B<-multivalue-rdn>]
 [B<-sigopt> I<nm>:I<v>]
 [B<-vfyopt> I<nm>:I<v>]
 [B<-batch>]
@@ -233,19 +233,21 @@ Specifies the name of the section to use; the default is B<req>.
 
 Sets subject name for new request or supersedes the subject name
 when processing a request.
+
 The arg must be formatted as C</type0=value0/type1=value1/type2=...>.
-Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Special characters may be escaped by C<\> (backslash), whitespace is retained.
 Empty values are permitted, but the corresponding type will not be included
 in the request.
-
-=item B<-multivalue-rdn>
-
-This option causes the -subj argument to be interpreted with full
-support for multivalued RDNs. Example:
+Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
+Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
+between the AttributeValueAssertions (AVAs) that specify the members of the set.
+Example:
 
 C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
-If -multi-rdn is not used then the UID value is C<123456+CN=John Doe>.
+=item B<-multivalue-rdn>
+
+This option has been deprecated and has no effect.
 
 =item B<-x509>
 
@@ -697,8 +699,8 @@ L<x509v3_config(5)>
 
 The B<-section> option was added in OpenSSL 3.0.0.
 
-All B<-keyform> values except B<ENGINE> have become obsolete in OpenSSL 3.0.0
-and have no effect.
+All B<-keyform> values except B<ENGINE> and the B<-multivalue-rdn> option
+have become obsolete in OpenSSL 3.0.0 and have no effect.
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
 The <-nodes> option was deprecated in OpenSSL 3.0, too; use B<-noenc> instead.

--- a/doc/man1/openssl-storeutl.pod.in
+++ b/doc/man1/openssl-storeutl.pod.in
@@ -80,11 +80,19 @@ returned.
 =item B<-subject> I<arg>
 
 Search for an object having the subject name I<arg>.
+
 The arg must be formatted as C</type0=value0/type1=value1/type2=...>.
-Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Special characters may be escaped by C<\> (backslash), whitespace is retained.
 Empty values are permitted but are ignored for the search.  That is,
 a search with an empty value will have the same effect as not specifying
 the type at all.
+Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
+Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
+between the AttributeValueAssertions (AVAs) that specify the members of the set.
+
+Example:
+
+C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 =item B<-issuer> I<arg>
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -517,11 +517,17 @@ generate a certificate containing any desired public key.
 =item B<-subj> I<arg>
 
 When a certificate is created set its subject name to the given value.
+
 The arg must be formatted as C</type0=value0/type1=value1/type2=...>.
-Keyword characters may be escaped by \ (backslash), and whitespace is retained.
+Special characters may be escaped by C<\> (backslash), whitespace is retained.
 Empty values are permitted, but the corresponding type will not be included
-in the certificate. Giving a single C</> will lead to an empty sequence of RDNs
-(a NULL subject DN).
+in the certificate.
+Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
+Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
+between the AttributeValueAssertions (AVAs) that specify the members of the set.
+Example:
+
+C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 Unless the B<-CA> option is given the issuer is set to the same value.
 

--- a/doc/man3/X509_NAME_add_entry_by_txt.pod
+++ b/doc/man3/X509_NAME_add_entry_by_txt.pod
@@ -66,13 +66,13 @@ RelativeDistinguishedName (RDN).
 B<loc> actually determines the index where the new entry is inserted:
 if it is -1 it is appended.
 
-B<set> determines how the new type is added. If it is zero a
-new RDN is created.
+B<set> determines how the new type is added.
+If it is zero a new RDN is created.
 
-If B<set> is -1 or 1 it is added to the previous or next RDN
-structure respectively. This will then be a multivalued RDN:
-since multivalues RDNs are very seldom used B<set> is almost
-always set to zero.
+If B<set> is -1 or 1 it is added as a new set member
+to the previous or next RDN structure, respectively.
+This will then become part of a multi-valued RDN (containing a set of AVAs).
+Since multi-valued RDNs are very rarely used B<set> typically will be zero.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -9,19 +9,21 @@ X509_NAME_oneline - X509_NAME printing routines
 
  #include <openssl/x509.h>
 
- int X509_NAME_print_ex(BIO *out, const X509_NAME *nm, int indent, unsigned long flags);
- int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm, int indent, unsigned long flags);
+ int X509_NAME_print_ex(BIO *out, const X509_NAME *nm,
+                        int indent, unsigned long flags);
+ int X509_NAME_print_ex_fp(FILE *fp, const X509_NAME *nm,
+                           int indent, unsigned long flags);
  char *X509_NAME_oneline(const X509_NAME *a, char *buf, int size);
  int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase);
 
 =head1 DESCRIPTION
 
-X509_NAME_print_ex() prints a human readable version of B<nm> to BIO B<out>. Each
-line (for multiline formats) is indented by B<indent> spaces. The output format
-can be extensively customised by use of the B<flags> parameter.
+X509_NAME_print_ex() prints a human readable version of B<nm> to BIO B<out>.
+Each line (for multiline formats) is indented by B<indent> spaces. The
+output format can be extensively customised by use of the B<flags> parameter.
 
-X509_NAME_print_ex_fp() is identical to X509_NAME_print_ex() except the output is
-written to FILE pointer B<fp>.
+X509_NAME_print_ex_fp() is identical to X509_NAME_print_ex()
+except the output is written to FILE pointer B<fp>.
 
 X509_NAME_oneline() prints an ASCII version of B<a> to B<buf>.
 If B<buf> is B<NULL> then a buffer is dynamically allocated and returned, and
@@ -52,15 +54,18 @@ The complete set of the flags supported by X509_NAME_print_ex() is listed below.
 Several options can be ored together.
 
 The options B<XN_FLAG_SEP_COMMA_PLUS>, B<XN_FLAG_SEP_CPLUS_SPC>,
-B<XN_FLAG_SEP_SPLUS_SPC> and B<XN_FLAG_SEP_MULTILINE> determine the field separators
-to use. Two distinct separators are used between distinct RelativeDistinguishedName
-components and separate values in the same RDN for a multi-valued RDN. Multi-valued
-RDNs are currently very rare so the second separator will hardly ever be used.
+B<XN_FLAG_SEP_SPLUS_SPC> and B<XN_FLAG_SEP_MULTILINE>
+determine the field separators to use.
+Two distinct separators are used between distinct RelativeDistinguishedName
+components and separate values in the same RDN for a multi-valued RDN.
+Multi-valued RDNs are currently very rare
+so the second separator will hardly ever be used.
 
-B<XN_FLAG_SEP_COMMA_PLUS> uses comma and plus as separators. B<XN_FLAG_SEP_CPLUS_SPC>
-uses comma and plus with spaces: this is more readable that plain comma and plus.
-B<XN_FLAG_SEP_SPLUS_SPC> uses spaced semicolon and plus. B<XN_FLAG_SEP_MULTILINE> uses
-spaced newline and plus respectively.
+B<XN_FLAG_SEP_COMMA_PLUS> uses comma and plus as separators.
+B<XN_FLAG_SEP_CPLUS_SPC> uses comma and plus with spaces:
+this is more readable that plain comma and plus.
+B<XN_FLAG_SEP_SPLUS_SPC> uses spaced semicolon and plus.
+B<XN_FLAG_SEP_MULTILINE> uses spaced newline and plus respectively.
 
 If B<XN_FLAG_DN_REV> is set the whole DN is printed in reversed order.
 
@@ -84,18 +89,21 @@ control how each field value is displayed.
 
 In addition a number options can be set for commonly used formats.
 
-B<XN_FLAG_RFC2253> sets options which produce an output compatible with RFC2253 it
-is equivalent to:
- C<ASN1_STRFLGS_RFC2253 | XN_FLAG_SEP_COMMA_PLUS | XN_FLAG_DN_REV | XN_FLAG_FN_SN | XN_FLAG_DUMP_UNKNOWN_FIELDS>
-
+B<XN_FLAG_RFC2253> sets options which produce an output compatible with RFC2253.
+It is equivalent to:
+ C<ASN1_STRFLGS_RFC2253 | XN_FLAG_SEP_COMMA_PLUS | XN_FLAG_DN_REV
+   | XN_FLAG_FN_SN | XN_FLAG_DUMP_UNKNOWN_FIELDS>
 
 B<XN_FLAG_ONELINE> is a more readable one line format which is the same as:
- C<ASN1_STRFLGS_RFC2253 | ASN1_STRFLGS_ESC_QUOTE | XN_FLAG_SEP_CPLUS_SPC | XN_FLAG_SPC_EQ | XN_FLAG_FN_SN>
+ C<ASN1_STRFLGS_RFC2253 | ASN1_STRFLGS_ESC_QUOTE | XN_FLAG_SEP_CPLUS_SPC
+   | XN_FLAG_SPC_EQ | XN_FLAG_FN_SN>
 
 B<XN_FLAG_MULTILINE> is a multiline format which is the same as:
- C<ASN1_STRFLGS_ESC_CTRL | ASN1_STRFLGS_ESC_MSB | XN_FLAG_SEP_MULTILINE | XN_FLAG_SPC_EQ | XN_FLAG_FN_LN | XN_FLAG_FN_ALIGN>
+ C<ASN1_STRFLGS_ESC_CTRL | ASN1_STRFLGS_ESC_MSB | XN_FLAG_SEP_MULTILINE
+   | XN_FLAG_SPC_EQ | XN_FLAG_FN_LN | XN_FLAG_FN_ALIGN>
 
-B<XN_FLAG_COMPAT> uses a format identical to X509_NAME_print(): in fact it calls X509_NAME_print() internally.
+B<XN_FLAG_COMPAT> uses a format identical to X509_NAME_print():
+in fact it calls X509_NAME_print() internally.
 
 =head1 RETURN VALUES
 
@@ -103,9 +111,9 @@ X509_NAME_oneline() returns a valid string on success or NULL on error.
 
 X509_NAME_print() returns 1 on success or 0 on error.
 
-X509_NAME_print_ex() and X509_NAME_print_ex_fp() return 1 on success or 0 on error
-if the B<XN_FLAG_COMPAT> is set, which is the same as X509_NAME_print(). Otherwise,
-it returns -1 on error or other values on success.
+X509_NAME_print_ex() and X509_NAME_print_ex_fp() return 1 on success or 0 on
+error if the B<XN_FLAG_COMPAT> is set, which is the same as X509_NAME_print().
+Otherwise, it returns -1 on error or other values on success.
 
 =head1 SEE ALSO
 

--- a/doc/man3/X509_NAME_print_ex.pod
+++ b/doc/man3/X509_NAME_print_ex.pod
@@ -18,27 +18,28 @@ X509_NAME_oneline - X509_NAME printing routines
 
 =head1 DESCRIPTION
 
-X509_NAME_print_ex() prints a human readable version of B<nm> to BIO B<out>.
-Each line (for multiline formats) is indented by B<indent> spaces. The
-output format can be extensively customised by use of the B<flags> parameter.
+X509_NAME_print_ex() prints a human readable version of I<nm> to BIO I<out>.
+Each line (for multiline formats) is indented by I<indent> spaces. The
+output format can be extensively customised by use of the I<flags> parameter.
 
 X509_NAME_print_ex_fp() is identical to X509_NAME_print_ex()
-except the output is written to FILE pointer B<fp>.
+except the output is written to FILE pointer I<fp>.
 
-X509_NAME_oneline() prints an ASCII version of B<a> to B<buf>.
-If B<buf> is B<NULL> then a buffer is dynamically allocated and returned, and
-B<size> is ignored.
-Otherwise, at most B<size> bytes will be written, including the ending '\0',
-and B<buf> is returned.
+X509_NAME_oneline() prints an ASCII version of I<a> to I<buf>.
+This supports multi-valued RDNs and escapes B</> and B<+> characters in values.
+If I<buf> is B<NULL> then a buffer is dynamically allocated and returned, and
+I<size> is ignored.
+Otherwise, at most I<size> bytes will be written, including the ending '\0',
+and I<buf> is returned.
 
-X509_NAME_print() prints out B<name> to B<bp> indenting each line by B<obase>
+X509_NAME_print() prints out I<name> to I<bp> indenting each line by I<obase>
 characters. Multiple lines are used if the output (including indent) exceeds
 80 characters.
 
 =head1 NOTES
 
 The functions X509_NAME_oneline() and X509_NAME_print()
-produce a non standard output form, they don't handle multi character fields and
+produce a non standard output form, they don't handle multi-character fields and
 have various quirks and inconsistencies.
 Their use is strongly discouraged in new applications and they could
 be deprecated in a future release.

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -25,16 +25,20 @@ This set of functions are used to compare X509 objects, including X509
 certificates, X509 CRL objects and various values in an X509 certificate.
 
 The X509_cmp() function compares two B<X509> objects indicated by parameters
-B<a> and B<b>. The comparison is based on the B<memcmp> result of the hash
+I<a> and I<b>. The comparison is based on the B<memcmp> result of the hash
 values of two B<X509> objects and the canonical (DER) encoding values.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
-parameters B<a> and B<b>. The comparison is based on the B<memcmp> result of
-the canonical (DER) encoding values of the two objects. L<i2d_X509_NAME(3)>
-has a more detailed description of the DER encoding of the B<X509_NAME> structure.
+parameters I<a> and I<b>. The comparison is based on the B<memcmp> result of the
+canonical (DER) encoding values of the two objects using L<i2d_X509_NAME(3)>.
+This procedure adheres to the matching rules for Distinguished Names (DN)
+given in RFC 4517 section 4.2.15 and RFC 5280 section 7.1.
+In particular, the order of Relative Distinguished Names (RDNs) is relevant.
+On the other hand, if an RDN is multi-valued, i.e., it contains a set of
+AttributeValueAssertions (AVAs), its members are effectively not ordered.
 
 The X509_issuer_and_serial_cmp() function compares the serial number and issuer
-values in the given B<X509> objects B<a> and B<b>.
+values in the given B<X509> objects I<a> and I<b>.
 
 The X509_issuer_name_cmp(), X509_subject_name_cmp() and X509_CRL_cmp() functions
 are effectively wrappers of the X509_NAME_cmp() function. These functions compare
@@ -47,8 +51,8 @@ of just the issuer name.
 
 =head1 RETURN VALUES
 
-The B<X509> comparison functions return B<-1>, B<0>, or B<1> if object B<a> is
-found to be less than, to match, or be greater than object B<b>, respectively.
+The B<X509> comparison functions return B<-1>, B<0>, or B<1> if object I<a> is
+found to be less than, to match, or be greater than object I<b>, respectively.
 
 X509_NAME_cmp(), X509_issuer_and_serial_cmp(), X509_issuer_name_cmp(),
 X509_subject_name_cmp() and X509_CRL_cmp() may return B<-2> to indicate an error.

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -47,9 +47,8 @@ of just the issuer name.
 
 =head1 RETURN VALUES
 
-Like common memory comparison functions, the B<X509> comparison functions return
-an integer less than, equal to, or greater than zero if object B<a> is found to
-be less than, to match, or be greater than object B<b>, respectively.
+The B<X509> comparison functions return B<-1>, B<0>, or B<1> if object B<a> is
+found to be less than, to match, or be greater than object B<b>, respectively.
 
 X509_NAME_cmp(), X509_issuer_and_serial_cmp(), X509_issuer_name_cmp(),
 X509_subject_name_cmp() and X509_CRL_cmp() may return B<-2> to indicate an error.


### PR DESCRIPTION
* Add/harmonize multi-valued RDN support and respective documentation for the `ca`, `cmp`, `req`, `storeutl`, and `x509` apps
* Fix #12765 by clearly documenting the semantics of `X509_NAME_cmp()`, referencing relevant RFCs
* Restrict normal return values of `X509_NAME_cmp()` to {-1,0,1} to avoid confusion with `-2` used for indicating errors
* Fix output of `X509_NAME_oneline()` for multi-valued RDNs, escaping '`/`' and '`+`' in values
* Re-format long lines in `X509_NAME_print_ex.pod` to fit within the 80 chars limit

