### PR TITLE
Increase PSK_MAX_IDENTITY_LEN from 128 to 256

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -849,7 +849,7 @@ void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
  * the maximum length of the buffer given to callbacks containing the
  * resulting identity/psk
  */
-#  define PSK_MAX_IDENTITY_LEN 128
+#  define PSK_MAX_IDENTITY_LEN 256
 #  define PSK_MAX_PSK_LEN 256
 typedef unsigned int (*SSL_psk_client_cb_func)(SSL *ssl,
                                                const char *hint,


### PR DESCRIPTION
We are considering using the format "host-nqn controller-nqn" for
psk-id in the NVMe-oF/TCP over TLS spec, it's in the current version,
but openssl's limit was 128 upto now, we need a little longer than that.
