### PR TITLE
Updated fix for test hang in 81-test_cmp_cli.t 

### DIFF
--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -37,9 +37,9 @@ plan skip_all => "Tests involving CMP server not available on Windows or VMS"
 plan skip_all => "Tests involving CMP server not available in cross-compile builds"
     if defined $ENV{EXE_SHELL};
 plan skip_all => "Tests involving CMP server require 'kill' command"
-    unless `which kill`;
+    if system("which kill");
 plan skip_all => "Tests involving CMP server require 'lsof' command"
-    unless `which lsof`; # this typically excludes Solaris
+    if system("which lsof"); # this typically excludes Solaris
 
 sub chop_dblquot { # chop any leading & trailing '"' (needed for Windows)
     my $str = shift;


### PR DESCRIPTION
An updated fix for the Solaris cmp test hang.

The current 'skip_all' check is looking at the command output instead of the return code and so will always fail.

Fixes #12422

