### PR TITLE
Increase PSK_MAX_PSK_LEN from 256 to 512

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -850,7 +850,7 @@ void SSL_get0_alpn_selected(const SSL *ssl, const unsigned char **data,
  * resulting identity/psk
  */
 #  define PSK_MAX_IDENTITY_LEN 128
-#  define PSK_MAX_PSK_LEN 256
+#  define PSK_MAX_PSK_LEN 512
 typedef unsigned int (*SSL_psk_client_cb_func)(SSL *ssl,
                                                const char *hint,
                                                char *identity,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -524,7 +524,7 @@ struct ssl_method_st {
  * Matches the length of PSK_MAX_PSK_LEN. We keep it the same value for
  * consistency, even in the event of OPENSSL_NO_PSK being defined.
  */
-# define TLS13_MAX_RESUMPTION_PSK_LENGTH      256
+# define TLS13_MAX_RESUMPTION_PSK_LENGTH      512
 
 /*-
  * Lets make this into an ASN.1 type structure as follows


### PR DESCRIPTION
Increase PSK_MAX_PSK_LEN from 256 to 512, so OpenSSL can connect to a device that only accepts 512 byte psk's
