### PR TITLE
Fix an EVP_MD_CTX leak

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -22,24 +22,9 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-/* This call frees resources associated with the context */
-int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
+
+void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force)
 {
-    if (ctx == NULL)
-        return 1;
-
-#ifndef FIPS_MODULE
-    /* TODO(3.0): Temporarily no support for EVP_DigestSign* in FIPS module */
-    /*
-     * pctx should be freed by the user of EVP_MD_CTX
-     * if EVP_MD_CTX_FLAG_KEEP_PKEY_CTX is set
-     */
-    if (!EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_KEEP_PKEY_CTX)) {
-        EVP_PKEY_CTX_free(ctx->pctx);
-        ctx->pctx = NULL;
-    }
-#endif
-
     EVP_MD_free(ctx->fetched_digest);
     ctx->fetched_digest = NULL;
     ctx->reqdigest = NULL;
@@ -61,13 +46,36 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
         && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_CLEANED))
         ctx->digest->cleanup(ctx);
     if (ctx->digest && ctx->digest->ctx_size && ctx->md_data
-        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_REUSE)) {
+            && (!EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_REUSE) || force))
         OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
-    }
+    if (force)
+        ctx->digest = NULL;
 
 #if !defined(FIPS_MODULE) && !defined(OPENSSL_NO_ENGINE)
     ENGINE_finish(ctx->engine);
+    ctx->engine = NULL;
 #endif
+}
+
+/* This call frees resources associated with the context */
+int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
+{
+    if (ctx == NULL)
+        return 1;
+
+#ifndef FIPS_MODULE
+    /* TODO(3.0): Temporarily no support for EVP_DigestSign* in FIPS module */
+    /*
+     * pctx should be freed by the user of EVP_MD_CTX
+     * if EVP_MD_CTX_FLAG_KEEP_PKEY_CTX is set
+     */
+    if (!EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_KEEP_PKEY_CTX)) {
+        EVP_PKEY_CTX_free(ctx->pctx);
+        ctx->pctx = NULL;
+    }
+#endif
+
+    evp_md_ctx_clear_digest(ctx, 0);
 
     /* TODO(3.0): End of legacy code */
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -76,9 +76,6 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
 #endif
 
     evp_md_ctx_clear_digest(ctx, 0);
-
-    /* TODO(3.0): End of legacy code */
-
     OPENSSL_cleanse(ctx, sizeof(*ctx));
 
     return 1;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -176,6 +176,9 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         }
 
         if (mdname != NULL) {
+            if (ctx->digest != NULL && ctx->digest->ctx_size > 0)
+                OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
+            ctx->md_data = NULL;
             /*
              * This might be requested by a later call to EVP_MD_CTX_md().
              * In that case the "explicit fetch" rules apply for that

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -176,6 +176,10 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
         }
 
         if (mdname != NULL) {
+            /*
+             * If the old digest was a legacy one then we should ensure we free
+             * any md_data. This can be removed once no more legacy.
+             */
             if (ctx->digest != NULL && ctx->digest->ctx_size > 0)
                 OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
             ctx->md_data = NULL;
@@ -188,6 +192,10 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
              */
             ctx->digest = ctx->reqdigest = ctx->fetched_digest =
                 EVP_MD_fetch(locpctx->libctx, mdname, props);
+            if (ctx->digest == NULL) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
+                goto err;
+            }
         }
     }
 

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -177,17 +177,11 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
 
         if (mdname != NULL) {
             /*
-             * If the old digest was a legacy one then we should ensure we free
-             * any md_data. This can be removed once no more legacy.
+             * We're about to get a new digest so clear anything associated with
+             * an old digest.
              */
-            if (ctx->digest != NULL) {
-                if (ctx->digest->cleanup != NULL
-                        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_CLEANED))
-                    ctx->digest->cleanup(ctx);
-                if (ctx->digest->ctx_size > 0)
-                    OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
-                ctx->md_data = NULL;
-            }
+            evp_md_ctx_clear_digest(ctx, 1);
+
             /*
              * This might be requested by a later call to EVP_MD_CTX_md().
              * In that case the "explicit fetch" rules apply for that

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -772,3 +772,5 @@ EVP_MD_CTX *evp_md_ctx_new_with_libctx(EVP_PKEY *pkey,
 void evp_method_store_flush(OPENSSL_CTX *libctx);
 int evp_set_default_properties_int(OPENSSL_CTX *libctx, const char *propq,
                                    int loadconfig);
+
+void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);


### PR DESCRIPTION
If we initialise an EVP_MD_CTX with a legacy MD, and then reuse the same
EVP_MD_CTX with a provided MD then we end up leaking the md_data.

We need to ensure we free the md_data if we change to a provided MD.

I've marked this as urgent because this is causing test failures on master for those with asan switched on.