### PR TITLE
Further KTLS cleanups in libcrypto

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -377,7 +377,6 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret = 1;
     BIO_CONNECT *data;
 # ifndef OPENSSL_NO_KTLS
-    size_t crypto_info_len;
     ktls_crypto_info_t *crypto_info;
 # endif
 
@@ -542,12 +541,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
 # ifndef OPENSSL_NO_KTLS
     case BIO_CTRL_SET_KTLS:
         crypto_info = (ktls_crypto_info_t *)ptr;
-#  ifdef __FreeBSD__
-        crypto_info_len = sizeof(*crypto_info);
-#  else
-        crypto_info_len = crypto_info->tls_crypto_info_len;
-#  endif
-        ret = ktls_start(b->num, crypto_info, crypto_info_len, num);
+        ret = ktls_start(b->num, crypto_info, num);
         if (ret)
             BIO_set_ktls_flag(b, num);
         break;

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -377,11 +377,8 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret = 1;
     BIO_CONNECT *data;
 # ifndef OPENSSL_NO_KTLS
-#  ifdef __FreeBSD__
-    struct tls_enable *crypto_info;
-#  else
-    struct tls12_crypto_info_aes_gcm_128 *crypto_info;
-#  endif
+    size_t crypto_info_len;
+    ktls_crypto_info_t *crypto_info;
 # endif
 
     data = (BIO_CONNECT *)b->ptr;
@@ -544,12 +541,13 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 # ifndef OPENSSL_NO_KTLS
     case BIO_CTRL_SET_KTLS:
+        crypto_info = (ktls_crypto_info_t *)ptr;
 #  ifdef __FreeBSD__
-        crypto_info = (struct tls_enable *)ptr;
+        crypto_info_len = sizeof(*crypto_info);
 #  else
-        crypto_info = (struct tls12_crypto_info_aes_gcm_128 *)ptr;
+        crypto_info_len = crypto_info->tls_crypto_info_len;
 #  endif
-        ret = ktls_start(b->num, crypto_info, sizeof(*crypto_info), num);
+        ret = ktls_start(b->num, crypto_info, crypto_info_len, num);
         if (ret)
             BIO_set_ktls_flag(b, num);
         break;

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -155,11 +155,7 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
     int *ip;
 # ifndef OPENSSL_NO_KTLS
     size_t crypto_info_len;
-#  ifdef __FreeBSD__
-    struct tls_enable *crypto_info;
-#  else
-    struct tls_crypto_info_all *crypto_info;
-#  endif
+    ktls_crypto_info_t *crypto_info;
 # endif
 
     switch (cmd) {
@@ -190,11 +186,10 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 # ifndef OPENSSL_NO_KTLS
     case BIO_CTRL_SET_KTLS:
+        crypto_info = (ktls_crypto_info_t *)ptr;
 #  ifdef __FreeBSD__
-        crypto_info = (struct tls_enable *)ptr;
         crypto_info_len = sizeof(*crypto_info);
 #  else
-        crypto_info = (struct tls_crypto_info_all *)ptr;
         crypto_info_len = crypto_info->tls_crypto_info_len;
 #  endif
         ret = ktls_start(b->num, crypto_info, crypto_info_len, num);

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -154,7 +154,6 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret = 1;
     int *ip;
 # ifndef OPENSSL_NO_KTLS
-    size_t crypto_info_len;
     ktls_crypto_info_t *crypto_info;
 # endif
 
@@ -187,12 +186,7 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
 # ifndef OPENSSL_NO_KTLS
     case BIO_CTRL_SET_KTLS:
         crypto_info = (ktls_crypto_info_t *)ptr;
-#  ifdef __FreeBSD__
-        crypto_info_len = sizeof(*crypto_info);
-#  else
-        crypto_info_len = crypto_info->tls_crypto_info_len;
-#  endif
-        ret = ktls_start(b->num, crypto_info, crypto_info_len, num);
+        ret = ktls_start(b->num, crypto_info, num);
         if (ret)
             BIO_set_ktls_flag(b, num);
         break;

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -66,15 +66,14 @@ static ossl_inline int ktls_enable(int fd)
  * as using TLS.  If successful, then data received for this socket will
  * be authenticated and decrypted using the tls_en provided here.
  */
-static ossl_inline int ktls_start(int fd,
-                                  void *tls_en,
-                                  size_t len, int is_tx)
+static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *tls_en, int is_tx)
 {
     if (is_tx)
         return setsockopt(fd, IPPROTO_TCP, TCP_TXTLS_ENABLE,
-                          tls_en, len) ? 0 : 1;
+                          tls_en, sizeof(*tls_en)) ? 0 : 1;
 #   ifndef OPENSSL_NO_KTLS_RX
-    return setsockopt(fd, IPPROTO_TCP, TCP_RXTLS_ENABLE, tls_en, len) ? 0 : 1;
+    return setsockopt(fd, IPPROTO_TCP, TCP_RXTLS_ENABLE, tls_en,
+                      sizeof(*tls_en)) ? 0 : 1;
 #   else
     return 0;
 #   endif
@@ -281,11 +280,11 @@ static ossl_inline int ktls_enable(int fd)
  * If successful, then data received using this socket will be decrypted,
  * authenticated and decapsulated using the crypto_info provided here.
  */
-static ossl_inline int ktls_start(int fd, void *crypto_info,
-                                  size_t len, int is_tx)
+static ossl_inline int ktls_start(int fd, ktls_crypto_info_t *crypto_info,
+                                  int is_tx)
 {
     return setsockopt(fd, SOL_TLS, is_tx ? TLS_TX : TLS_RX,
-                      crypto_info, len) ? 0 : 1;
+                      crypto_info, crypto_info->tls_crypto_info_len) ? 0 : 1;
 }
 
 /*

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -400,33 +400,5 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
 #   endif /* OPENSSL_NO_KTLS_RX */
 
 #  endif /* OPENSSL_SYS_LINUX */
-# else /* OPENSSL_NO_KTLS */
-/* Dummy functions here */
-static ossl_inline int ktls_enable(int fd)
-{
-    return 0;
-}
-
-static ossl_inline int ktls_start(int fd, void *crypto_info,
-                                  size_t len, int is_tx)
-{
-    return 0;
-}
-
-static ossl_inline int ktls_send_ctrl_message(int fd, unsigned char record_type,
-                                              const void *data, size_t length)
-{
-    return -1;
-}
-
-static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
-{
-    return -1;
-}
-
-static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off, size_t size, int flags)
-{
-    return -1;
-}
 # endif /* OPENSSL_NO_KTLS */
 #endif /* HEADER_INTERNAL_KTLS */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

I know that I previously promised that I had no more KTLS changes, but I noticed while backporting the last set of changes to a private 1.1.1 branch that I had missed applying some of the cleanups in the last changes to the socket BIOs in libcrypto.  These changes are small cleanups that should not be a functional change and are not urgent.  It does fix one possible bug on Linux for sockets created via bss_conn.c.