### PR TITLE
 EVP: Preserve the EVP_PKEY id in a few more spots 

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -606,10 +606,8 @@ static EVP_PKEY *new_cmac_key_int(const unsigned char *priv, size_t len,
     }
 
     ctx = EVP_PKEY_CTX_new_from_name(libctx, "CMAC", propq);
-    if (ctx == NULL) {
-        EVPerr(0, ERR_R_MALLOC_FAILURE);
+    if (ctx == NULL)
         goto err;
-    }
 
     if (!EVP_PKEY_key_fromdata_init(ctx)) {
         EVPerr(0, EVP_R_KEY_SETUP_FAILED);

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -986,51 +986,62 @@ int EVP_PKEY_base_id(const EVP_PKEY *pkey)
     return EVP_PKEY_type(pkey->type);
 }
 
+#ifndef FIPS_MODULE
+int evp_pkey_name2type(const char *name)
+{
+    /*
+     * These hard coded cases are pure hackery to get around the fact
+     * that names in crypto/objects/objects.txt are a mess.  There is
+     * no "EC", and "RSA" leads to the NID for 2.5.8.1.1, an OID that's
+     * fallen out in favor of { pkcs-1 1 }, i.e. 1.2.840.113549.1.1.1,
+     * the NID of which is used for EVP_PKEY_RSA.  Strangely enough,
+     * "DSA" is accurate...  but still, better be safe and hard-code
+     * names that we know.
+     * On a similar topic, EVP_PKEY_type(EVP_PKEY_SM2) will result in
+     * EVP_PKEY_EC, because of aliasing.
+     * TODO Clean this away along with all other #legacy support.
+     */
+    int type = NID_undef;
+
+    if (strcasecmp(name, "RSA") == 0)
+        type = EVP_PKEY_RSA;
+    else if (strcasecmp(name, "RSA-PSS") == 0)
+        type = EVP_PKEY_RSA_PSS;
+    else if (strcasecmp(name, "EC") == 0)
+        type = EVP_PKEY_EC;
+    else if (strcasecmp(name, "ED25519") == 0)
+        type = EVP_PKEY_ED25519;
+    else if (strcasecmp(name, "ED448") == 0)
+        type = EVP_PKEY_ED448;
+    else if (strcasecmp(name, "X25519") == 0)
+        type = EVP_PKEY_X25519;
+    else if (strcasecmp(name, "X448") == 0)
+        type = EVP_PKEY_X448;
+    else if (strcasecmp(name, "SM2") == 0)
+        type = EVP_PKEY_SM2;
+    else if (strcasecmp(name, "DH") == 0)
+        type = EVP_PKEY_DH;
+    else if (strcasecmp(name, "X9.42 DH") == 0)
+        type = EVP_PKEY_DHX;
+    else if (strcasecmp(name, "DSA") == 0)
+        type = EVP_PKEY_DSA;
+
+    if (type == NID_undef)
+        type = EVP_PKEY_type(OBJ_sn2nid(name));
+    if (type == NID_undef)
+        type = EVP_PKEY_type(OBJ_ln2nid(name));
+
+    return type;
+}
+#endif
+
 int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name)
 {
 #ifndef FIPS_MODULE
     if (pkey->keymgmt == NULL) {
-        /*
-         * These hard coded cases are pure hackery to get around the fact
-         * that names in crypto/objects/objects.txt are a mess.  There is
-         * no "EC", and "RSA" leads to the NID for 2.5.8.1.1, an OID that's
-         * fallen out in favor of { pkcs-1 1 }, i.e. 1.2.840.113549.1.1.1,
-         * the NID of which is used for EVP_PKEY_RSA.  Strangely enough,
-         * "DSA" is accurate...  but still, better be safe and hard-code
-         * names that we know.
-         * TODO Clean this away along with all other #legacy support.
-         */
-        int type;
+        int type = evp_pkey_name2type(name);
 
-        if (strcasecmp(name, "RSA") == 0)
-            type = EVP_PKEY_RSA;
-        else if (strcasecmp(name, "RSA-PSS") == 0)
-            type = EVP_PKEY_RSA_PSS;
-#ifndef OPENSSL_NO_EC
-        else if (strcasecmp(name, "EC") == 0)
-            type = EVP_PKEY_EC;
-        else if (strcasecmp(name, "ED25519") == 0)
-            type = EVP_PKEY_ED25519;
-        else if (strcasecmp(name, "ED448") == 0)
-            type = EVP_PKEY_ED448;
-        else if (strcasecmp(name, "X25519") == 0)
-            type = EVP_PKEY_X25519;
-        else if (strcasecmp(name, "X448") == 0)
-            type = EVP_PKEY_X448;
-#endif
-#ifndef OPENSSL_NO_DH
-        else if (strcasecmp(name, "DH") == 0)
-            type = EVP_PKEY_DH;
-        else if (strcasecmp(name, "X9.42 DH") == 0)
-            type = EVP_PKEY_DHX;
-#endif
-#ifndef OPENSSL_NO_DSA
-        else if (strcasecmp(name, "DSA") == 0)
-            type = EVP_PKEY_DSA;
-#endif
-        else
-            type = EVP_PKEY_type(OBJ_sn2nid(name));
-        return EVP_PKEY_type(pkey->type) == type;
+        return pkey->type == type;
     }
 #endif
     return EVP_KEYMGMT_is_a(pkey->keymgmt, name);

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -212,6 +212,12 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
         evp_pkey_free_legacy(*ppkey);
 #endif
 
+    /*
+     * Because we still have legacy keys, and evp_pkey_downgrade()
+     * TODO remove this #legacy internal keys are gone
+     */
+    (*ppkey)->type = ctx->legacy_keytype;
+
 /* TODO remove when SM2 key have been cleanly separated from EC keys */
 #ifdef TMP_SM2_HACK
     /*

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -185,15 +185,6 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
     const EVP_PKEY_METHOD *pmeth = NULL;
     EVP_KEYMGMT *keymgmt = NULL;
 
-#if 0
-    /*
-     * When using providers, the context is bound to the algo implementation
-     * later.
-     */
-    if (pkey == NULL && e == NULL && id == -1)
-        goto common;
-#endif
-
     /*
      * If the given |pkey| is provided, we extract the keytype from its
      * keymgmt and skip over the legacy code.

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -128,9 +128,9 @@ static int get_legacy_alg_type_from_name(const char *keytype)
     int id = NID_undef;
 
 #ifndef FIPS_MODULE
-    id = OBJ_sn2nid(keytype);
+    id = EVP_PKEY_type(OBJ_sn2nid(keytype));
     if (id == NID_undef)
-        id = OBJ_ln2nid(keytype);
+        id = EVP_PKEY_type(OBJ_ln2nid(keytype));
 #endif
     return id;
 }

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -283,8 +283,23 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
          * directly.
          * TODO: Remove this when #legacy keys are gone.
          */
-        if (keymgmt != NULL)
-            id = get_legacy_alg_type_from_keymgmt(keymgmt);
+        if (keymgmt != NULL) {
+            int tmp_id = get_legacy_alg_type_from_keymgmt(keymgmt);
+
+            if (id == -1) {
+                id = tmp_id;
+            } else {
+                /*
+                 * It really really shouldn't differ.  If it still does,
+                 * something is very wrong.
+                 */
+                if (!ossl_assert(id == tmp_id)) {
+                    EVPerr(EVP_F_INT_CTX_NEW, ERR_R_INTERNAL_ERROR);
+                    EVP_KEYMGMT_free(keymgmt);
+                    return NULL;
+                }
+            }
+        }
     }
 
     if (pmeth == NULL && keymgmt == NULL) {

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -271,17 +271,11 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
         if (legacy)
             ERR_set_mark();
 
-        /*
-         * If we know that we should have everything covered by a provider
-         * backend, at least in the default provider, then we can drop the
-         * corresponding EVP_PKEY_METHOD.
-         */
-        if (!legacy)
-            pmeth = NULL;
-
         keymgmt = EVP_KEYMGMT_fetch(libctx, keytype, propquery);
         if (legacy)
             ERR_pop_to_mark();
+        else if (keymgmt == NULL)
+            return NULL;   /* EVP_KEYMGMT_fetch() recorded an error */
 
         /*
          * Chase down the legacy NID, as that might be needed for diverse

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -286,17 +286,19 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
         if (keymgmt != NULL) {
             int tmp_id = get_legacy_alg_type_from_keymgmt(keymgmt);
 
-            if (id == -1) {
-                id = tmp_id;
-            } else {
-                /*
-                 * It really really shouldn't differ.  If it still does,
-                 * something is very wrong.
-                 */
-                if (!ossl_assert(id == tmp_id)) {
-                    EVPerr(EVP_F_INT_CTX_NEW, ERR_R_INTERNAL_ERROR);
-                    EVP_KEYMGMT_free(keymgmt);
-                    return NULL;
+            if (tmp_id != NID_undef) {
+                if (id == -1) {
+                    id = tmp_id;
+                } else {
+                    /*
+                     * It really really shouldn't differ.  If it still does,
+                     * something is very wrong.
+                     */
+                    if (!ossl_assert(id == tmp_id)) {
+                        EVPerr(EVP_F_INT_CTX_NEW, ERR_R_INTERNAL_ERROR);
+                        EVP_KEYMGMT_free(keymgmt);
+                        return NULL;
+                    }
                 }
             }
         }

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -768,6 +768,7 @@ int evp_pkey_ctx_get_params_strict(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 EVP_MD_CTX *evp_md_ctx_new_with_libctx(EVP_PKEY *pkey,
                                        const ASN1_OCTET_STRING *id,
                                        OPENSSL_CTX *libctx, const char *propq);
+int evp_pkey_name2type(const char *name);
 #endif /* !defined(FIPS_MODULE) */
 void evp_method_store_flush(OPENSSL_CTX *libctx);
 int evp_set_default_properties_int(OPENSSL_CTX *libctx, const char *propq,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -62,6 +62,8 @@ struct evp_pkey_ctx_st {
 
     /* Legacy fields below */
 
+    /* EVP_PKEY identity */
+    int legacy_keytype;
     /* Method associated with this operation */
     const EVP_PKEY_METHOD *pmeth;
     /* Engine that implements this method or NULL if builtin */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1814,8 +1814,8 @@ static int test_pkey_ctx_fail_without_provider(int tst)
     OPENSSL_CTX *tmpctx = OPENSSL_CTX_new();
     OSSL_PROVIDER *nullprov = NULL;
     EVP_PKEY_CTX *pctx = NULL;
-    const char *keytype;
-    int expect_null;
+    const char *keytype = NULL;
+    int expect_null = 0;
     int ret = 0;
 
     if (!TEST_ptr(tmpctx))
@@ -1845,6 +1845,9 @@ static int test_pkey_ctx_fail_without_provider(int tst)
         goto end;
 #endif
         break;
+    default:
+        TEST_error("No test for case %d", tst);
+        goto err;
     }
 
     pctx = EVP_PKEY_CTX_new_from_name(tmpctx, keytype, "");

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1844,6 +1844,10 @@ static int test_pkey_ctx_fail_without_provider(int tst)
         TEST_info("EC disable, skipping SM2 check...");
         goto end;
 #endif
+#ifdef OPENSSL_NO_SM2
+        TEST_info("SM2 disable, skipping SM2 check...");
+        goto end;
+#endif
         break;
     default:
         TEST_error("No test for case %d", tst);
@@ -1854,7 +1858,7 @@ static int test_pkey_ctx_fail_without_provider(int tst)
     if (expect_null ? !TEST_ptr_null(pctx) : !TEST_ptr(pctx))
         goto err;
 
-#ifdef OPENSSL_NO_EC
+#if defined(OPENSSL_NO_EC) || defined(OPENSSL_NO_SM2)
  end:
 #endif
     ret = 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1840,10 +1840,10 @@ static int test_pkey_ctx_fail_without_provider(int tst)
     case 1:
         keytype = "SM2";
         expect_null = 0; /* TODO: change to 1 when we have a SM2 keymgmt */
-# ifdef OPENSSL_NO_EC
+#ifdef OPENSSL_NO_EC
         TEST_info("EC disable, skipping SM2 check...");
         goto end;
-# endif
+#endif
         break;
     }
 
@@ -1851,7 +1851,9 @@ static int test_pkey_ctx_fail_without_provider(int tst)
     if (expect_null ? !TEST_ptr_null(pctx) : !TEST_ptr(pctx))
         goto err;
 
+#ifdef OPENSSL_NO_EC
  end:
+#endif
     ret = 1;
 
  err:

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1803,14 +1803,19 @@ static int test_keygen_with_empty_template(int n)
 
 /*
  * Test that we fail if we attempt to use an algorithm that is not available
- * in the current library context (unless we are using an algorithm that should
- * be made available via legacy codepaths).
+ * in the current library context (unless we are using an algorithm that
+ * should be made available via legacy codepaths).
+ *
+ * 0:   RSA
+ * 1:   SM2
  */
 static int test_pkey_ctx_fail_without_provider(int tst)
 {
     OPENSSL_CTX *tmpctx = OPENSSL_CTX_new();
     OSSL_PROVIDER *nullprov = NULL;
     EVP_PKEY_CTX *pctx = NULL;
+    const char *keytype;
+    int expect_null;
     int ret = 0;
 
     if (!TEST_ptr(tmpctx))
@@ -1820,21 +1825,33 @@ static int test_pkey_ctx_fail_without_provider(int tst)
     if (!TEST_ptr(nullprov))
         goto err;
 
-    pctx = EVP_PKEY_CTX_new_from_name(tmpctx, tst == 0 ? "RSA" : "SM2", "");
-
-    /* RSA is not available via any provider so we expect this to fail */
-    if (tst == 0 && !TEST_ptr_null(pctx))
-        goto err;
-
     /*
-     * SM2 is always available because it is implemented via legacy codepaths
-     * and not in a provider at all. We expect this to pass.
-     * TODO(3.0): This can be removed once there are no more algorithms
-     * available via legacy codepaths
+     * We check for certain algos in the null provider.
+     * If an algo I expected to have a provider keymgmt, contructing an
+     * EVP_PKEY_CTX is expected to fail (return NULL).
+     * Otherwise, if it's expected to have legacy support, contructing an
+     * EVP_PKEY_CTX is expected to succeed (return non-NULL).
      */
-    if (tst == 1 && !TEST_ptr(pctx))
+    switch (tst) {
+    case 0:
+        keytype = "RSA";
+        expect_null = 1;
+        break;
+    case 1:
+        keytype = "SM2";
+        expect_null = 0; /* TODO: change to 1 when we have a SM2 keymgmt */
+# ifdef OPENSSL_NO_EC
+        TEST_info("EC disable, skipping SM2 check...");
+        goto end;
+# endif
+        break;
+    }
+
+    pctx = EVP_PKEY_CTX_new_from_name(tmpctx, keytype, "");
+    if (expect_null ? !TEST_ptr_null(pctx) : !TEST_ptr(pctx))
         goto err;
 
+ end:
     ret = 1;
 
  err:

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1827,7 +1827,7 @@ static int test_pkey_ctx_fail_without_provider(int tst)
 
     /*
      * We check for certain algos in the null provider.
-     * If an algo I expected to have a provider keymgmt, contructing an
+     * If an algo is expected to have a provider keymgmt, contructing an
      * EVP_PKEY_CTX is expected to fail (return NULL).
      * Otherwise, if it's expected to have legacy support, contructing an
      * EVP_PKEY_CTX is expected to succeed (return non-NULL).


### PR DESCRIPTION
When working with #12536 and `test/evp_extra_test.c`, I noticed that SM2 keys weren't possible to "downgrade", because `pkey->type` was -1...  which is odd, because we know for a fact that there *is* a corresponding `EVP_PKEY_METHOD` implementation.

It turned out that, depending on which variant of `EVP_PKEY_CTX_new*` is used, you might or might not get a proper `pkey->type`, so for the sake of consistency, I made the code try a little harder.

Also, when `EVP_PKEY_CTX_new_from_name()` was called, you could end up with an `EVP_PKEY_CTX` with both `ctx->keymgmt` and `ctx->pmeth` being NULL, rendering `ctx` practically useless.   This is the case for SM2, in the following line:

https://github.com/openssl/openssl/blob/d55d0935deb1a8af9cb9a76bf4ca21da47ba8184/test/evp_extra_test.c#L1823

(that goes undetected by this test)