### PR TITLE
Add AKID and SKID output to X509_STORE_CTX_print_verify_cb()

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -200,9 +200,11 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
         }
     }
 
-    if (!(cflag & X509_FLAG_NO_EXTENSIONS))
-        X509V3_extensions_print(bp, "X509v3 extensions",
-                                X509_get0_extensions(x), cflag, 8);
+    if (!(cflag & X509_FLAG_NO_EXTENSIONS)
+        && !X509V3_extensions_print(bp, "X509v3 extensions",
+                                    X509_get0_extensions(x),
+                                    cflag & ~X509_FLAG_EXTENSIONS_ONLY_KID, 8))
+        goto err;
 
     if (!(cflag & X509_FLAG_NO_SIGDUMP)) {
         const X509_ALGOR *sig_alg;
@@ -427,8 +429,15 @@ static int print_certs(BIO *bio, const STACK_OF(X509) *certs)
 
     for (i = 0; i < sk_X509_num(certs); i++) {
         X509 *cert = sk_X509_value(certs, i);
-        if (cert != NULL && !x509_print_ex_brief(bio, cert, 0))
-            return 0;
+
+        if (cert != NULL) {
+            if (!x509_print_ex_brief(bio, cert, 0))
+                return 0;
+            if (!X509V3_extensions_print(bio, NULL,
+                                         X509_get0_extensions(cert),
+                                         X509_FLAG_EXTENSIONS_ONLY_KID, 8))
+                return 0;
+            }
     }
     return 1;
 }

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -202,8 +202,7 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
 
     if (!(cflag & X509_FLAG_NO_EXTENSIONS)
         && !X509V3_extensions_print(bp, "X509v3 extensions",
-                                    X509_get0_extensions(x),
-                                    cflag & ~X509_FLAG_EXTENSIONS_ONLY_KID, 8))
+                                    X509_get0_extensions(x), cflag, 8))
         goto err;
 
     if (!(cflag & X509_FLAG_NO_SIGDUMP)) {
@@ -417,7 +416,8 @@ int x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags)
     if (X509_cmp_current_time(X509_get0_notAfter(cert)) < 0)
         if (BIO_printf(bio, "        no more valid\n") <= 0)
             return 0;
-    return X509_print_ex(bio, cert, flags, ~(neg_cflags));
+    return X509_print_ex(bio, cert, flags,
+                         ~neg_cflags & ~X509_FLAG_EXTENSIONS_ONLY_KID);
 }
 
 static int print_certs(BIO *bio, const STACK_OF(X509) *certs)

--- a/crypto/x509/v3_prn.c
+++ b/crypto/x509/v3_prn.c
@@ -156,10 +156,15 @@ int X509V3_extensions_print(BIO *bp, const char *title,
     for (i = 0; i < sk_X509_EXTENSION_num(exts); i++) {
         ASN1_OBJECT *obj;
         X509_EXTENSION *ex;
+
         ex = sk_X509_EXTENSION_value(exts, i);
+        obj = X509_EXTENSION_get_object(ex);
+        if ((flag & X509_FLAG_EXTENSIONS_ONLY_KID) != 0
+                && OBJ_obj2nid(obj) != NID_subject_key_identifier
+                && OBJ_obj2nid(obj) != NID_authority_key_identifier)
+            continue;
         if (indent && BIO_printf(bp, "%*s", indent, "") <= 0)
             return 0;
-        obj = X509_EXTENSION_get_object(ex);
         i2a_ASN1_OBJECT(bp, obj);
         j = X509_EXTENSION_get_critical(ex);
         if (BIO_printf(bp, ": %s\n", j ? "critical" : "") <= 0)

--- a/include/openssl/x509.h
+++ b/include/openssl/x509.h
@@ -159,6 +159,7 @@ DEFINE_OR_DECLARE_STACK_OF(X509_TRUST)
 # define X509_FLAG_NO_AUX                (1L << 10)
 # define X509_FLAG_NO_ATTRIBUTES         (1L << 11)
 # define X509_FLAG_NO_IDS                (1L << 12)
+# define X509_FLAG_EXTENSIONS_ONLY_KID   (1L << 13)
 
 /* Flags specific to X509_NAME_print_ex() */
 


### PR DESCRIPTION
In case a certificate (path) validation fails the verification callback function `X509_STORE_CTX_print_verify_cb()` provides valuable diagnostic information including the most relevant fields of the target certificate that failed to verify and, if appropriate, of the available untrusted and trusted certificates.

It turned out that in order to be able to find out using the given diagnostic output why certificate chain building failed it can be important to compare the authority key identifiers (AKID) of certificates with the subject key identifiers (SKID) of all candidate issuer certificates, but so far the list of available untrusted and trusted certificates was printed without those AKIDs and SKIDs.

This PR makes sure this piece of information is provided.
To this end a new flag `X509_FLAG_EXTENSIONS_ONLY_KID` is added to `include/openssl/x509.h`.