### PR TITLE
OSSL_CMP_CTX: rename field and its getter/setter from 'untrusted_certs' to 'untrusted'

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1234,8 +1234,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
     }
     if (!setup_certs(opt_srv_untrusted,
                      "untrusted certificates for mock server", ctx,
-                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted_certs,
-                     NULL))
+                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted, NULL))
         goto err;
 
     if (opt_rsp_cert == NULL) {
@@ -1316,7 +1315,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
 static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
 {
     if (!setup_certs(opt_untrusted, "untrusted certificates", ctx,
-                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted_certs,
+                     (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted,
                      NULL))
         goto err;
 
@@ -1413,7 +1412,7 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
  */
 static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 {
-    STACK_OF(X509) *untrusted_certs = OSSL_CMP_CTX_get0_untrusted_certs(ctx);
+    STACK_OF(X509) *untrusted_certs = OSSL_CMP_CTX_get0_untrusted(ctx);
     EVP_PKEY *pkey = NULL;
     X509_STORE *trust_store = NULL;
     SSL_CTX *ssl_ctx;

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -469,7 +469,7 @@ static X509 *get1_cert_status(OSSL_CMP_CTX *ctx, int bodytype,
 /*-
  * Callback fn validating that the new certificate can be verified, using
  * ctx->certConf_cb_arg, which has been initialized using opt_out_trusted, and
- * ctx->untrusted_certs, which at this point already contains ctx->extraCertsIn.
+ * ctx->untrusted, which at this point already contains ctx->extraCertsIn.
  * Returns 0 on acceptance, else a bit field reflecting PKIFailureInfo.
  * Quoting from RFC 4210 section 5.1. Overall PKI Message:
  *     The extraCerts field can contain certificates that may be useful to

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -60,7 +60,7 @@ struct ossl_cmp_ctx_st {
     X509 *validatedSrvCert; /* caches any already validated server cert */
     X509_NAME *expected_sender; /* expected sender in header of response */
     X509_STORE *trusted; /* trust store maybe w CRLs and cert verify callback */
-    STACK_OF(X509) *untrusted_certs; /* untrusted (intermediate) certs */
+    STACK_OF(X509) *untrusted; /* untrusted (intermediate CA) certs */
     int ignore_keyusage; /* ignore key usage entry when validating certs */
     /*
      * permitTAInExtraCertsForIR allows use of root certs in extracerts

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -146,14 +146,14 @@ int ossl_cmp_msg_add_extraCerts(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
                            | X509_ADD_FLAG_PREPEND))
             return 0;
         /* if we have untrusted certs, try to add intermediate certs */
-        if (ctx->untrusted_certs != NULL) {
+        if (ctx->untrusted != NULL) {
             STACK_OF(X509) *chain;
             int res;
 
             ossl_cmp_debug(ctx,
                            "trying to build chain for own CMP signer cert");
             chain = ossl_cmp_build_cert_chain(ctx->libctx, ctx->propq, NULL,
-                                              ctx->untrusted_certs, ctx->cert);
+                                              ctx->untrusted, ctx->cert);
             res = X509_add_certs(msg->extraCerts, chain,
                                  X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP
                                  | X509_ADD_FLAG_NO_SS);
@@ -298,7 +298,7 @@ int ossl_cmp_msg_protect(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
 
         /*
          * will add ctx->cert followed, if possible, by its chain built
-         * from ctx->untrusted_certs, and then ctx->extraCertsOut
+         * from ctx->untrusted, and then ctx->extraCertsOut
          */
     } else {
         CMPerr(0, CMP_R_MISSING_KEY_INPUT_FOR_CREATING_PROTECTION);

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -26,8 +26,8 @@ OSSL_CMP_CTX_set1_srvCert,
 OSSL_CMP_CTX_set1_expected_sender,
 OSSL_CMP_CTX_set0_trustedStore,
 OSSL_CMP_CTX_get0_trustedStore,
-OSSL_CMP_CTX_set1_untrusted_certs,
-OSSL_CMP_CTX_get0_untrusted_certs,
+OSSL_CMP_CTX_set1_untrusted,
+OSSL_CMP_CTX_get0_untrusted,
 OSSL_CMP_CTX_set1_cert,
 OSSL_CMP_CTX_build_cert_chain,
 OSSL_CMP_CTX_set1_pkey,
@@ -99,9 +99,8 @@ OSSL_CMP_CTX_set1_senderNonce
                                       const X509_NAME *name);
  int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
  X509_STORE *OSSL_CMP_CTX_get0_trustedStore(const OSSL_CMP_CTX *ctx);
- int OSSL_CMP_CTX_set1_untrusted_certs(OSSL_CMP_CTX *ctx,
-                                       STACK_OF(X509) *certs);
- STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted_certs(const OSSL_CMP_CTX *ctx);
+ int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
+ STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted(const OSSL_CMP_CTX *ctx);
 
  /* client authentication: */
  int OSSL_CMP_CTX_set1_cert(OSSL_CMP_CTX *ctx, X509 *cert);
@@ -420,13 +419,13 @@ When given a NULL parameter the entry is cleared.
 OSSL_CMP_CTX_get0_trustedStore() returns a pointer to the currently set
 certificate store containing trusted cert etc., or an empty store if unset.
 
-OSSL_CMP_CTX_set1_untrusted_certs() sets up a list of non-trusted certificates
+OSSL_CMP_CTX_set1_untrusted() sets up a list of non-trusted certificates
 of intermediate CAs that may be useful for path construction for the CMP client
 certificate, for the TLS client certificate (if any), when verifying
 the CMP server certificate, and when verifying newly enrolled certificates.
 The reference counts of those certificates handled successfully are increased.
 
-OSSL_CMP_CTX_get0_untrusted_certs(OSSL_CMP_CTX *ctx) returns a pointer to the
+OSSL_CMP_CTX_get0_untrusted(OSSL_CMP_CTX *ctx) returns a pointer to the
 list of untrusted certs, which may be empty if unset.
 
 OSSL_CMP_CTX_set1_cert() sets the certificate used for CMP message protection.
@@ -629,7 +628,7 @@ OSSL_CMP_CTX_new(),
 OSSL_CMP_CTX_get_http_cb_arg(),
 OSSL_CMP_CTX_get_transfer_cb_arg(),
 OSSL_CMP_CTX_get0_trustedStore(),
-OSSL_CMP_CTX_get0_untrusted_certs(),
+OSSL_CMP_CTX_get0_untrusted(),
 OSSL_CMP_CTX_get0_newPkey(),
 OSSL_CMP_CTX_get_certConf_cb_arg(),
 OSSL_CMP_CTX_get0_statusString(),

--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -26,7 +26,7 @@ In case of signature algorithm, the certificate to use for the signature check
 is preferably the one provided by a call to L<OSSL_CMP_CTX_set1_srvCert(3)>.
 If no such sender cert has been pinned then candidate sender certificates are
 taken from the list of certificates received in the C<msg> extraCerts, then any
-certificates provided before via L<OSSL_CMP_CTX_set1_untrusted_certs(3)>, and
+certificates provided before via L<OSSL_CMP_CTX_set1_untrusted(3)>, and
 then all trusted certificates provided via L<OSSL_CMP_CTX_set0_trustedStore(3)>,
 where a candidate is acceptable only if has not expired, its subject DN matches
 the C<msg> sender DN (as far as present), and its subject key identifier

--- a/include/openssl/cmp.h
+++ b/include/openssl/cmp.h
@@ -291,8 +291,8 @@ int OSSL_CMP_CTX_set1_srvCert(OSSL_CMP_CTX *ctx, X509 *cert);
 int OSSL_CMP_CTX_set1_expected_sender(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
 X509_STORE *OSSL_CMP_CTX_get0_trustedStore(const OSSL_CMP_CTX *ctx);
-int OSSL_CMP_CTX_set1_untrusted_certs(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
-STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted_certs(const OSSL_CMP_CTX *ctx);
+int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
+STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted(const OSSL_CMP_CTX *ctx);
 /* client authentication: */
 int OSSL_CMP_CTX_set1_cert(OSSL_CMP_CTX *ctx, X509 *cert);
 int OSSL_CMP_CTX_build_cert_chain(OSSL_CMP_CTX *ctx, X509_STORE *own_trusted,

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -746,7 +746,7 @@ DEFINE_SET_TEST(OSSL_CMP, CTX, 1, 1, expected_sender, X509_NAME)
 DEFINE_SET_GET_BASE_TEST(OSSL_CMP_CTX, set0, get0, 0, trustedStore,
                          X509_STORE *, NULL,
                          DEFAULT_STORE, X509_STORE_new_1(), X509_STORE_free)
-DEFINE_SET_GET_SK_X509_TEST(OSSL_CMP, CTX, 1, 0, untrusted_certs)
+DEFINE_SET_GET_SK_X509_TEST(OSSL_CMP, CTX, 1, 0, untrusted)
 
 DEFINE_SET_TEST(OSSL_CMP, CTX, 1, 0, cert, X509)
 DEFINE_SET_TEST(OSSL_CMP, CTX, 1, 0, pkey, EVP_PKEY)
@@ -830,7 +830,7 @@ int setup_tests(void)
     ADD_TEST(test_CTX_set0_get0_validatedSrvCert);
     ADD_TEST(test_CTX_set1_get0_expected_sender);
     ADD_TEST(test_CTX_set0_get0_trustedStore);
-    ADD_TEST(test_CTX_set1_get0_untrusted_certs);
+    ADD_TEST(test_CTX_set1_get0_untrusted);
     /* client authentication: */
     ADD_TEST(test_CTX_set1_get0_cert);
     ADD_TEST(test_CTX_set1_get0_pkey);

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -191,7 +191,7 @@ static int add_trusted(OSSL_CMP_CTX *ctx, X509 *cert)
 
 static int add_untrusted(OSSL_CMP_CTX *ctx, X509 *cert)
 {
-    return X509_add_cert(OSSL_CMP_CTX_get0_untrusted_certs(ctx), cert,
+    return X509_add_cert(OSSL_CMP_CTX_get0_untrusted(ctx), cert,
                          X509_ADD_FLAG_UP_REF);
 }
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4770,8 +4770,8 @@ OSSL_CMP_CTX_set1_srvCert               ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_expected_sender       ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set0_trustedStore          ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_trustedStore          ?	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_CTX_set1_untrusted_certs       ?	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_CTX_get0_untrusted_certs       ?	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_set1_untrusted             ?	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_get0_untrusted             ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_cert                  ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_pkey                  ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_build_cert_chain           ?	3_0_0	EXIST::FUNCTION:CMP


### PR DESCRIPTION
This just does some renaming for API consistency and name brevity.