### PR TITLE
Cleanup deprecation of ENGINE_setup_bsd_cryptodev

### DIFF
--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -763,7 +763,7 @@ typedef int (*dynamic_bind_engine) (ENGINE *e, const char *id,
 void *ENGINE_get_static_state(void);
 
 #  if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
-DEPRECATEDIN_3_0(DEPRECATEDIN_1_1_0(void ENGINE_setup_bsd_cryptodev(void)))
+DEPRECATEDIN_1_1_0(void ENGINE_setup_bsd_cryptodev(void))
 #  endif
 
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3189,7 +3189,7 @@ EVP_read_pw_string_min                  3254	3_0_0	EXIST::FUNCTION:
 X509_set1_notBefore                     3255	3_0_0	EXIST::FUNCTION:
 MD4                                     3256	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 EVP_PKEY_CTX_dup                        3257	3_0_0	EXIST::FUNCTION:
-ENGINE_setup_bsd_cryptodev              3258	3_0_0	EXIST:__FreeBSD__:FUNCTION:DEPRECATEDIN_1_1_0,ENGINE
+ENGINE_setup_bsd_cryptodev              3258	3_0_0	EXIST:__FreeBSD__:FUNCTION:DEPRECATEDIN_1_1_0,DEPRECATEDIN_3_0,ENGINE
 PEM_read_bio_DHparams                   3259	3_0_0	EXIST::FUNCTION:DH
 CMS_SharedInfo_encode                   3260	3_0_0	EXIST::FUNCTION:CMS
 ASN1_OBJECT_create                      3261	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3189,7 +3189,7 @@ EVP_read_pw_string_min                  3254	3_0_0	EXIST::FUNCTION:
 X509_set1_notBefore                     3255	3_0_0	EXIST::FUNCTION:
 MD4                                     3256	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD4
 EVP_PKEY_CTX_dup                        3257	3_0_0	EXIST::FUNCTION:
-ENGINE_setup_bsd_cryptodev              3258	3_0_0	EXIST:__FreeBSD__:FUNCTION:DEPRECATEDIN_1_1_0,DEPRECATEDIN_3_0,ENGINE
+ENGINE_setup_bsd_cryptodev              3258	3_0_0	EXIST:__FreeBSD__:FUNCTION:DEPRECATEDIN_1_1_0,ENGINE
 PEM_read_bio_DHparams                   3259	3_0_0	EXIST::FUNCTION:DH
 CMS_SharedInfo_encode                   3260	3_0_0	EXIST::FUNCTION:CMS
 ASN1_OBJECT_create                      3261	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
It was already deprecated in 1.1.0, no need to deprecate it harder in 3.0.