### PR TITLE
TEST: skip POSIX errcode zero in tesst/recipes/02-test_errstr.t

### DIFF
--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -57,7 +57,18 @@ plan tests => scalar @Errno::EXPORT_OK
 foreach my $errname (@Errno::EXPORT_OK) {
     # The error names are perl constants, which are implemented as functions
     # returning the numeric value of that name.
-    &ok(match_syserr_reason("Errno::$errname"->()))
+    my $errcode = "Errno::$errname"->();
+
+    # On most systems, there is no E macro for errcode zero in <errno.h>,
+    # which means that it seldom comes up here.  However, reports indicate
+    # that some platforms do have an E macro for errcode zero.
+    # With perl, errcode zero is a bit special.  Perl consistently gives
+    # the empty string for that one, while the C strerror() may give back
+    # something else.  The easiest way to deal with that possible mismatch
+    # is to skip this errcode.
+    continue if $errcode == 0;
+
+    &ok(match_syserr_reason($errcode))
 }
 
 # OpenSSL library 1 is the "unknown" library

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -59,16 +59,19 @@ foreach my $errname (@Errno::EXPORT_OK) {
     # returning the numeric value of that name.
     my $errcode = "Errno::$errname"->();
 
-    # On most systems, there is no E macro for errcode zero in <errno.h>,
-    # which means that it seldom comes up here.  However, reports indicate
-    # that some platforms do have an E macro for errcode zero.
-    # With perl, errcode zero is a bit special.  Perl consistently gives
-    # the empty string for that one, while the C strerror() may give back
-    # something else.  The easiest way to deal with that possible mismatch
-    # is to skip this errcode.
-    continue if $errcode == 0;
+  SKIP: {
+      # On most systems, there is no E macro for errcode zero in <errno.h>,
+      # which means that it seldom comes up here.  However, reports indicate
+      # that some platforms do have an E macro for errcode zero.
+      # With perl, errcode zero is a bit special.  Perl consistently gives
+      # the empty string for that one, while the C strerror() may give back
+      # something else.  The easiest way to deal with that possible mismatch
+      # is to skip this errcode.
+      skip "perl error strings and ssystem error strings for errcode 0 differ", 1
+          if $errcode == 0;
 
-    &ok(match_syserr_reason($errcode))
+      &ok(match_syserr_reason($errcode));
+    }
 }
 
 # OpenSSL library 1 is the "unknown" library


### PR DESCRIPTION
On most systems, there is no E macro for errcode zero in <errno.h>,
which means that it seldom comes up here.  However, reports indicate
that some platforms do have an E macro for errcode zero.
With perl, errcode zero is a bit special.  Perl consistently gives
the empty string for that one, while the C strerror() may give back
something else.  The easiest way to deal with that possible mismatch
is to skip this errcode.

Fixes #12798
