### PR TITLE
Allow unauthenticated CMP server if missing -trusted, -srvcert, and -secret options

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1590,10 +1590,8 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         }
         EVP_PKEY_free(pkey);
     }
-    if (opt_secret == NULL && opt_srvcert == NULL && opt_trusted == NULL) {
-        CMP_err("missing -secret or -srvcert or -trusted");
-        goto err;
-    }
+    if (opt_secret == NULL && opt_srvcert == NULL && opt_trusted == NULL)
+        CMP_warn("will not authenticate server due to missing -secret, -trusted, or -srvcert");
 
     if (opt_cert != NULL) {
         X509 *cert;

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -568,6 +568,10 @@ int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg)
     switch (ossl_cmp_hdr_get_protection_nid(msg->header)) {
         /* 5.1.3.1.  Shared Secret Information */
     case NID_id_PasswordBasedMAC:
+        if (ctx->secretValue == NULL) {
+            ossl_cmp_warn(ctx, "no secret available for verifying PBM-based CMP message protection");
+            return 1;
+        }
         if (verify_PBMAC(ctx, msg)) {
             /*
              * RFC 4210, 5.3.2: 'Note that if the PKI Message Protection is
@@ -615,6 +619,10 @@ int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg)
     default:
         scrt = ctx->srvCert;
         if (scrt == NULL) {
+            if (ctx->trusted == NULL) {
+                ossl_cmp_warn(ctx, "no trust store nor pinned server cert available for verifying signature-based CMP message protection");
+                return 1;
+            }
             if (check_msg_find_cert(ctx, msg))
                 return 1;
         } else { /* use pinned sender cert */

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -174,6 +174,7 @@ Default filename is from the environment variable C<OPENSSL_CONF>.
 Section(s) to use within config file defining CMP options.
 An empty string C<""> means no specific section.
 Default is C<cmp>.
+
 Multiple section names may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Contents of sections named later may override contents of sections named before.
@@ -483,6 +484,9 @@ during CMP server authentication.
 This option gives more flexibility than the B<-srvcert> option because the
 protection certificate is not pinned but may be any certificate
 for which a chain to one of the given trusted certificates can be constructed.
+
+If no B<-trusted>, B<-srvcert>, and B<-secret> option is given
+then protected response messages from the server are not authenticated.
 
 Multiple filenames may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
@@ -808,6 +812,7 @@ Default is one invocation.
 =item B<-reqin> I<filenames>
 
 Take sequence of CMP requests from file(s).
+
 Multiple filenames may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 As many files are read as needed for a complete transaction.
@@ -822,18 +827,21 @@ and the CMP server complains that the transaction ID has already been used.
 =item B<-reqout> I<filenames>
 
 Save sequence of CMP requests to file(s).
+
 Multiple filenames may be given, separated by commas and/or whitespace.
 As many files are written as needed to store the complete transaction.
 
 =item B<-rspin> I<filenames>
 
 Process sequence of CMP responses provided in file(s), skipping server.
+
 Multiple filenames may be given, separated by commas and/or whitespace.
 As many files are read as needed for the complete transaction.
 
 =item B<-rspout> I<filenames>
 
 Save sequence of CMP responses to file(s).
+
 Multiple filenames may be given, separated by commas and/or whitespace.
 As many files are written as needed to store the complete transaction.
 


### PR DESCRIPTION
If the user did not provide means to authenticate a CMP server
this is no more an error but just means that server authentication is skipped (with a warning given).