### PR TITLE
Fix new issue on AIX caused by broken compiler handling of macro expansion

### DIFF
--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -87,8 +87,8 @@ static const OSSL_ALGORITHM base_decoder[] = {
 #undef DECODER
 
 static const OSSL_ALGORITHM base_store[] = {
-#define STORE(name, fips, func_table)                           \
-    { name, "provider=base,fips=" fips, (func_table) },
+#define STORE(name, _fips, func_table)                           \
+    { name, "provider=base,fips=" _fips, (func_table) },
 
 #include "stores.inc"
     { NULL, NULL, NULL }

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -434,8 +434,8 @@ static const OSSL_ALGORITHM deflt_decoder[] = {
 #undef DECODER
 
 static const OSSL_ALGORITHM deflt_store[] = {
-#define STORE(name, fips, func_table)                           \
-    { name, "provider=default,fips=" fips, (func_table) },
+#define STORE(name, _fips, func_table)                           \
+    { name, "provider=default,fips=" _fips, (func_table) },
 
 #include "stores.inc"
     { NULL, NULL, NULL }


### PR DESCRIPTION
Some code was added while the original PR (https://github.com/openssl/openssl/pull/12767) was in progress. This code also needs to be tweaked to work on AIX.
