### PR TITLE
app_load_config_bio(): fix crash on error

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -389,7 +389,6 @@ CONF *app_load_config_bio(BIO *in, const char *filename)
     else
         BIO_printf(bio_err, "config input");
 
-    CONF_modules_load(conf, NULL, 0);
     NCONF_free(conf);
     return NULL;
 }


### PR DESCRIPTION
When a config file contains an error, `app_load_config_bio()` crashes because
```
    CONF_modules_load(conf, NULL, 0);
````
is still called.

I do not know why this call was added in commit ae89578be2930c726d6ef56451233757a89f224f but at least it needs to be guarded by
```
    if (conf->data != NULL)
```
which is done in this PR.

Else one gets crashes like
```
CMP:apps/cmp.c:2835:CMP info: using OpenSSL configuration file 'openssl.cnf'
openssl: Error on line 482 of config file "openssl.cnf"
AddressSanitizer:DEADLYSIGNAL
=================================================================
==19020==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000000a8 (pc 0x7effc401b74c bp 0x7ffeee006bf0 sp 0x7ffeee006b70 T0)
==19020==The signal is caused by a WRITE memory access.
==19020==Hint: address points to the zero page.
    #0 0x7effc401b74c in OPENSSL_LH_retrieve crypto/lhash/lhash.c:171
    #1 0x7effc3e77c2e in lh_CONF_VALUE_retrieve include/openssl/conf.h:38
    #2 0x7effc3e783a4 in _CONF_get_string crypto/conf/conf_api.c:91
    #3 0x7effc3e7e4a6 in NCONF_get_string crypto/conf/conf_lib.c:265
    #4 0x7effc3e7ef0f in CONF_modules_load crypto/conf/conf_mod.c:100
    #5 0x4c5af4 in app_load_config_bio apps/lib/apps.c:393
    #6 0x4c5b83 in app_load_config apps/lib/apps.c:407
    #7 0x43d3a2 in cmp_main apps/cmp.c:2836
    #8 0x464655 in do_cmd apps/openssl.c:406
    #9 0x463d40 in main apps/openssl.c:288
    #10 0x7effc39f909a in __libc_start_main ../csu/libc-start.c:308
    #11 0x422de9 in _start (apps/openssl+0x422de9)
```