### PR TITLE
Improve robustness and performance of building Unix static libraries

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -27,8 +27,8 @@ my %targets=(
 	build_scheme	=> [ "unified", "unix" ],
 	build_file	=> "Makefile",
 
-	AR		=> "ar",
-	ARFLAGS		=> "r",
+	AR		=> "(unused)",
+	ARFLAGS		=> "(unused)",
 	CC		=> "cc",
 	HASHBANGPERL	=> "/usr/bin/env perl",
 	RANLIB		=> sub { which("$config{cross_compile_prefix}ranlib")

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1510,13 +1510,14 @@ EOF
       my @objs = map { platform->obj($_) } @{$args{objs}};
       my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
                       fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
-      my $max_per_call = 250;
+      my $max_per_call = 500;
       my @objs_grouped;
       push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
       my $fill_lib =
           join("\n\t", (map { "\$(AR) \$(ARFLAGS) $lib $_" } @objs_grouped));
       return <<"EOF";
 $lib: $deps
+	\$(RM) $lib
 	$fill_lib
 	\$(RANLIB) \$\@ || echo Never mind.
 EOF


### PR DESCRIPTION
This is a fixup of commit 385deae79f26dd685339d3141a06d04d6bd753cd, which solved #12116.

It turned out that MinGW builds work fine if 500 (instead of 250) object file names are passed per `ar` call,
which make generation of `libcrypto.a` a little more efficient again.

Moreover, I found that if anything goes wrong while producing `libcrypto.a` further `make` calls typically fail due to duplicate entries in that archive file, such that the `libcrypto.a` file needs to be removed (e.g., using `make libclean`). 
Changing the `ar` flags to `cru` hopefully cures this.