### PR TITLE
Fix 3 minor bugs in CMP client

### DIFF
--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -179,7 +179,7 @@ int ossl_cmp_msg_add_extraCerts(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
                         X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP))
         return 0;
 
-    /* if none was found avoid empty ASN.1 sequence */
+    /* in case extraCerts are empty list avoid empty ASN.1 sequence */
     if (sk_X509_num(msg->extraCerts) == 0) {
         sk_X509_free(msg->extraCerts);
         msg->extraCerts = NULL;
@@ -272,11 +272,11 @@ int ossl_cmp_msg_protect(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
     ASN1_BIT_STRING_free(msg->protection);
     msg->protection = NULL;
 
-    if (ctx->unprotectedSend)
-        return 1;
-
-    /* use PasswordBasedMac according to 5.1.3.1 if secretValue is given */
-    if (ctx->secretValue != NULL) {
+    if (ctx->unprotectedSend) {
+        if (!set_senderKID(ctx, msg, NULL))
+            goto err;
+    } else if (ctx->secretValue != NULL) {
+        /* use PasswordBasedMac according to 5.1.3.1 if secretValue is given */
         if (!set_pbmac_algor(ctx, &msg->header->protectionAlg))
             goto err;
         if (!set_senderKID(ctx, msg, NULL))
@@ -310,11 +310,12 @@ int ossl_cmp_msg_protect(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
         CMPerr(0, CMP_R_MISSING_KEY_INPUT_FOR_CREATING_PROTECTION);
         goto err;
     }
-    if ((msg->protection = ossl_cmp_calc_protection(ctx, msg)) == NULL)
+    if (!ctx->unprotectedSend
+            && ((msg->protection = ossl_cmp_calc_protection(ctx, msg)) == NULL))
         goto err;
 
     /*
-     * If present, add ctx->cert followed by its chain as far as possible.
+     * For signature-based protection add ctx->cert followed by its chain.
      * Finally add any additional certificates from ctx->extraCertsOut;
      * even if not needed to validate the protection
      * the option to do this might be handy for certain use cases.
@@ -327,11 +328,10 @@ int ossl_cmp_msg_protect(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
      * to the client it set to NULL-DN. In this case for identification at least
      * the senderKID must be set, where we took the referenceValue as fallback.
      */
-    if (ossl_cmp_general_name_is_NULL_DN(msg->header->sender)
-            && msg->header->senderKID == NULL)
-        CMPerr(0, CMP_R_MISSING_SENDER_IDENTIFICATION);
-    else
+    if (!(ossl_cmp_general_name_is_NULL_DN(msg->header->sender)
+          && msg->header->senderKID == NULL))
         return 1;
+    CMPerr(0, CMP_R_MISSING_SENDER_IDENTIFICATION);
 
  err:
     CMPerr(0, CMP_R_ERROR_PROTECTING_MESSAGE);

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -140,7 +140,8 @@ int ossl_cmp_msg_add_extraCerts(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
         return 0;
 
     /* Add first ctx->cert and its chain if using signature-based protection */
-    if (!ctx->unprotectedSend && ctx->secretValue == NULL) {
+    if (!ctx->unprotectedSend && ctx->secretValue == NULL
+            && ctx->cert != NULL && ctx->pkey != NULL) {
         int flags_prepend = X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP
             | X509_ADD_FLAG_PREPEND | X509_ADD_FLAG_NO_SS;
 

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -590,13 +590,13 @@ with a signature key."
 
 =item B<-extracertsout> I<filename>
 
-The file where to save any extra certificates received in the extraCerts field
-of response messages.
+The file where to save all certificates contained in the extraCerts field
+of the last received response message (except for pollRep and PKIConf).
 
 =item B<-cacertsout> I<filename>
 
-The file where to save any CA certificates received in the caPubs field of
-Initialization Response (IP) messages.
+The file where to save any CA certificates contained in the caPubs field of
+the last received certificate response (i.e., IP, CP, or KUP) message.
 
 =back
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -617,14 +617,14 @@ OSSL_CMP_CTX_get1_newChain() returns a pointer to a duplicate of the stack of
 X.509 certificates computed by OSSL_CMP_certConf_cb() (if this function has
 been called) on the last received certificate response message IP/CP/KUP.
 
-OSSL_CMP_CTX_get1_caPubs() returns a pointer to a duplicate of the stack of
+OSSL_CMP_CTX_get1_caPubs() returns a pointer to a duplicate of the list of
 X.509 certificates received in the caPubs field of last received certificate
 response message IP/CP/KUP.
 
-OSSL_CMP_CTX_get1_extraCertsIn() returns a pointer to a duplicate of the stack
-of X.509 certificates received in the last received nonempty extraCerts field.
-Returns an empty stack if no extraCerts have been received in the current
-transaction.
+OSSL_CMP_CTX_get1_extraCertsIn() returns a pointer to a duplicate of the list
+of X.509 certificates contained in the extraCerts field of the last received
+response message (except for pollRep and PKIConf), or
+an empty stack if no extraCerts have been received in the current transaction.
 
 OSSL_CMP_CTX_set1_transactionID() sets the given transaction ID in the given
 OSSL_CMP_CTX structure.


### PR DESCRIPTION
These three commits have been carved out from #12655 for more convenient review:
* bugfix in ossl_cmp_msg_add_extraCerts(): should include cert chain when using PBM
* bugfix in ossl_cmp_msg_protect(): set senderKID and extend extraCerts also for unprotected CMP requests
* bugfix in cmp_client.c: inconsistencies on retrieving extraCerts in code and documentation