### PR TITLE
Fix CMP server app verbosity

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2649,6 +2649,7 @@ int cmp_main(int argc, char **argv)
     char mock_server[] = "mock server:1";
     int ret = 0; /* default: failure */
 
+    ERR_clear_error(); /* clear leftover errors on loading libengines.so etc. */
     if (argc <= 1) {
         opt_help(cmp_options);
         goto err;


### PR DESCRIPTION
* apps/cmp.c: fix use of -verbosity option for server side
* apps/cmp.c: clear leftover errors on loading libengines.so etc.
