### PR TITLE
Improve CMP user guidance and documentation

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -269,7 +269,7 @@ const OPTIONS cmp_options[] = {
     {"geninfo", OPT_GENINFO, 's',
      "generalInfo integer values to place in request PKIHeader with given OID"},
     {OPT_MORE_STR, 0, 0,
-     "specified in the form <OID>:int:<n>, e.g. \"1.2.3:int:987\""},
+     "specified in the form <OID>:int:<n>, e.g. \"1.2.3.4:int:56789\""},
 
     OPT_SECTION("Certificate enrollment"),
     {"newkey", OPT_NEWKEY, 's',

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -395,7 +395,9 @@ const OPTIONS cmp_options[] = {
     {"mac", OPT_MAC, 's',
      "MAC algorithm to use in PBM-based message protection. Default \"hmac-sha1\""},
     {"extracerts", OPT_EXTRACERTS, 's',
-     "Certificates to append in extraCerts field of outgoing messages"},
+     "Certificates to append in extraCerts field of outgoing messages."},
+    {OPT_MORE_STR, 0, 0,
+     "This can be used as the default CMP signer cert chain to include"},
     {"unprotected_requests", OPT_UNPROTECTED_REQUESTS, '-',
      "Send messages without CMP-level protection"},
 

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1601,7 +1601,8 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
  */
 static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 {
-    if (opt_subject == NULL && opt_oldcert == NULL && opt_cert == NULL)
+    if (opt_subject == NULL && opt_oldcert == NULL && opt_cert == NULL
+            && opt_cmd != CMP_RR && opt_cmd != CMP_GENM)
         CMP_warn("no -subject given, neither -oldcert nor -cert available as default");
     if (!set_name(opt_subject, OSSL_CMP_CTX_set1_subjectName, ctx, "subject")
             || !set_name(opt_issuer, OSSL_CMP_CTX_set1_issuer, ctx, "issuer"))
@@ -2949,5 +2950,5 @@ int cmp_main(int argc, char **argv)
     NCONF_free(conf); /* must not do as long as opt_... variables are used */
     OSSL_CMP_log_close();
 
-    return ret == 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+    return ret == 0 ? EXIT_FAILURE : EXIT_SUCCESS; /* ret == -1 for -help */
 }

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -495,11 +495,14 @@ Each source may contain multiple certificates.
 
 =item B<-untrusted> I<sources>
 
-Non-trusted intermediate CA certificate(s) that may be useful for cert path
-construction for the CMP client certificate (to include in the extraCerts field
-of outgoing messages), for the TLS client certificate (if TLS is enabled),
+Non-trusted intermediate CA certificate(s).
+Any extra certificates given with the B<-cert> option are appended to it.
+All these certificates may be useful for cert path construction
+for the CMP client certificate (to include in the extraCerts field of outgoing
+messages) and for the TLS client certificate (if TLS is enabled)
+as well as for chain building
 when verifying the CMP server certificate (checking signature-based
-CMP message protection), and when verifying newly enrolled certificates.
+CMP message protection) and when verifying newly enrolled certificates.
 
 Multiple filenames may be given, separated by commas and/or whitespace.
 Each file may contain multiple certificates.
@@ -716,8 +719,9 @@ The only value with effect is B<ENGINE>.
 =item B<-otherpass> I<arg>
 
 Pass phrase source for certificate given with the B<-trusted>, B<-untrusted>,
-B<-own_trusted>,
-B<-out_trusted>, B<-extracerts>, B<-tls_extra>, or B<-tls_trusted> options.
+B<-own_trusted>, B<-srvcert>, B<-out_trusted>, B<-extracerts>,
+B<-srv_trusted>, B<-srv_untrusted>, B<-rsp_extracerts>, B<-rsp_capubs>,
+B<-tls_extra>, and B<-tls_trusted> options.
 If not given here, the password will be prompted for if needed.
 
 For more information about the format of B<arg> see the

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -1030,7 +1030,7 @@ to issue the following shell commands.
   cd /path/to/openssl
   export OPENSSL_CONF=openssl.cnf
 =begin comment
-  wget 'http://pki.certificate.fi:8080/install-ca-cert.html/ca-certificate.crt\
+  wget 'http://pki.certificate.fi:8081/install-ca-cert.html/ca-certificate.crt\
         ?ca-id=632&download-certificate=1' -O insta.ca.crt
 =end comment
   openssl genrsa -out insta.priv.pem

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -613,10 +613,11 @@ is typically used when authenticating with pre-shared key (password-based MAC).
 
 =item B<-secret> I<arg>
 
-Source of secret value to use for creating PBM-based protection of outgoing
-messages and for verifying any PBM-based protection of incoming messages.
+Prefer PBM-based message protection with given source of a secret value.
+The secret is used for creating PBM-based protection of outgoing messages
+and (as far as needed) for verifying PBM-based protection of incoming messages.
 PBM stands for Password-Based Message Authentication Code.
-This takes precedence over the B<-cert> option.
+This takes precedence over the B<-cert> and B<-key> options.
 
 For more information about the format of B<arg> see the
 B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
@@ -627,13 +628,17 @@ The client's current CMP signer certificate.
 Requires the corresponding key to be given with B<-key>.
 The subject of this certificate will be used as sender of outgoing CMP messages,
 while the subject of B<-oldcert> or B<-subjectName> may provide fallback values.
+The issuer of this certificate is used as one of the recipient fallback values.
 When using signature-based message protection, this "protection certificate"
-will be included first in the extraCerts field of outgoing messages.
+will be included first in the extraCerts field of outgoing messages
+and the signature is done with the corresponding key.
 In Initialization Request (IR) messages this can be used for authenticating
 using an external entity certificate as defined in appendix E.7 of RFC 4210.
 For Key Update Request (KUR) messages this is also used as
 the certificate to be updated if the B<-oldcert> option is not given.
-If the file includes further certs, they are appended to the untrusted certs.
+If the file includes further certs, they are appended to the untrusted certs
+because they typically constitute the chain of the client certificate, which
+is included in the extraCerts field in signature-protected request messages.
 
 =item B<-own_trusted> I<filenames>
 

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -235,7 +235,7 @@ e.g., C<signKeyPairTypes>.
 =item B<-geninfo> I<OID:int:N>
 
 generalInfo integer values to place in request PKIHeader with given OID,
-e.g., C<1.2.3:int:987>.
+e.g., C<1.2.3.4:int:56789>.
 
 =back
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -618,8 +618,9 @@ X.509 certificates computed by OSSL_CMP_certConf_cb() (if this function has
 been called) on the last received certificate response message IP/CP/KUP.
 
 OSSL_CMP_CTX_get1_caPubs() returns a pointer to a duplicate of the list of
-X.509 certificates received in the caPubs field of last received certificate
-response message IP/CP/KUP.
+X.509 certificates in the caPubs field of the last received certificate
+response message (of type IP, CP, or KUP),
+or an empty stack if no caPubs have been received in the current transaction.
 
 OSSL_CMP_CTX_get1_extraCertsIn() returns a pointer to a duplicate of the list
 of X.509 certificates contained in the extraCerts field of the last received


### PR DESCRIPTION
* apps/cmp.c: Improve documentation of -secret, -cert, and -key options
* apps/cmp.c: Improve documentation of -extracerts, -untrusted, and -otherpass
* apps/cmp.c: Improve user guidance on -missing -subject etc. options
* apps/cmp.c: Improve example given for -geninfo option (also in man page)
* openssl-cmp.pod.in: Update Insta Demo CA port number in case needed,
  which is a fixup of commit 6b0da38d1cc6731cf3b863eb02d8c8ae47f49d40 regarding `openssl-cmp.pod.in`
* OSSL_CMP_CTX_new.pod: improve doc of `OSSL_CMP_CTX_get1_caPubs()` and `OSSL_CMP_CTX_get1_extraCertsIn()`
