### PR TITLE
Fix API to allow zero-length secret for EVP_KDF

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -132,6 +132,10 @@ static int kdf_hkdf_derive(void *vctx, unsigned char *key, size_t keylen)
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_KEY);
         return 0;
     }
+    if (keylen == 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        return 0;
+    }
 
     switch (ctx->mode) {
     case EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND:

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -205,6 +205,12 @@ static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen)
         return 0;
     }
 
+    /* Fail if the output length is zero */
+    if (keylen == 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        return 0;
+    }
+
     h = EVP_MAC_size(ctx->ctx_init);
     if (h == 0)
         goto done;

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -144,6 +144,10 @@ static int kdf_tls1_prf_derive(void *vctx, unsigned char *key,
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_SEED);
         return 0;
     }
+    if (keylen == 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+        return 0;
+    }
 
     return tls1_prf_alg(ctx->P_hash, ctx->P_sha1,
                         ctx->sec, ctx->seclen,

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -120,7 +120,7 @@ static void *hmac_dup(void *vsrc)
     }
     if (src->key != NULL) {
         /* There is no "secure" OPENSSL_memdup */
-        dst->key = OPENSSL_secure_malloc(src->keylen);
+        dst->key = OPENSSL_secure_malloc(src->keylen > 0 ? src->keylen : 1);
         if (dst->key == NULL) {
             hmac_free(dst);
             return 0;
@@ -265,7 +265,7 @@ static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
         if (macctx->keylen > 0)
             OPENSSL_secure_clear_free(macctx->key, macctx->keylen);
         /* Keep a copy of the key if we need it for TLS HMAC */
-        macctx->key = OPENSSL_secure_malloc(p->data_size);
+        macctx->key = OPENSSL_secure_malloc(p->data_size > 0 ? p->data_size : 1);
         if (macctx->key == NULL)
             return 0;
         memcpy(macctx->key, p->data, p->data_size);

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -34,12 +34,12 @@ static OSSL_PARAM *construct_tls1_prf_params(const char *digest, const char *sec
     OSSL_PARAM *p = params;
 
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char*)digest, strlen(digest));
+                                            (char *)digest, strlen(digest));
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET,
-                                             (unsigned char*)secret,
+                                             (unsigned char *)secret,
                                              strlen(secret));
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
-                                             (unsigned char*)seed,
+                                             (unsigned char *)seed,
                                              strlen(seed));
     *p = OSSL_PARAM_construct_end();
 
@@ -195,7 +195,7 @@ static OSSL_PARAM *construct_hkdf_params(char *digest, char *key,
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                              salt, strlen(salt));
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
-                                             (unsigned char*)key, keylen);
+                                             (unsigned char *)key, keylen);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
                                              info, strlen(info));
     *p = OSSL_PARAM_construct_end();
@@ -904,7 +904,7 @@ static int test_kdf_kbkdf_empty_key(void)
     EVP_KDF_CTX *kctx;
     OSSL_PARAM *params;
 
-    static unsigned char key[] = {};
+    static unsigned char key[] = {0x01};
     unsigned char result[32] = { 0 };
 
     params = construct_kbkdf_params("sha256", "HMAC", key, 0, "prf", "test");

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -27,26 +27,37 @@ static EVP_KDF_CTX *get_kdfbyname(const char *name)
     return kctx;
 }
 
+static OSSL_PARAM *construct_tls1_prf_params(const char *digest, const char *secret,
+    const char *seed)
+{
+    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 4);
+    OSSL_PARAM *p = params;
+
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+                                            (char*)digest, strlen(digest));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET,
+                                             (unsigned char*)secret,
+                                             strlen(secret));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
+                                             (unsigned char*)seed,
+                                             strlen(seed));
+    *p = OSSL_PARAM_construct_end();
+
+    return params;
+}
+
 static int test_kdf_tls1_prf(void)
 {
     int ret;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[16];
-    OSSL_PARAM params[4], *p = params;
+    OSSL_PARAM *params;
     static const unsigned char expected[sizeof(out)] = {
         0x8e, 0x4d, 0x93, 0x25, 0x30, 0xd7, 0x65, 0xa0,
         0xaa, 0xe9, 0x74, 0xc3, 0x04, 0x73, 0x5e, 0xcc
     };
 
-    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)"sha256", sizeof("sha256"));
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET,
-                                             (unsigned char *)"secret",
-                                             (size_t)6);
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED,
-                                             (unsigned char *)"seed",
-                                             (size_t)4);
-    *p = OSSL_PARAM_construct_end();
+    params = construct_tls1_prf_params("sha256", "secret", "seed");
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
@@ -55,7 +66,141 @@ static int test_kdf_tls1_prf(void)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
     EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
     return ret;
+}
+
+static int test_kdf_tls1_prf_invalid_digest(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx = NULL;
+    OSSL_PARAM *params;
+
+    params = construct_tls1_prf_params("blah", "secret", "seed");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
+        && TEST_false(EVP_KDF_CTX_set_params(kctx, params));
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_tls1_prf_zero_output_size(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx = NULL;
+    unsigned char out[16];
+    OSSL_PARAM *params;
+
+    params = construct_tls1_prf_params("sha256", "secret", "seed");
+
+    /* Negative test - derive should fail */
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_eq(EVP_KDF_derive(kctx, out, 0), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_tls1_prf_empty_secret(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx = NULL;
+    unsigned char out[16];
+    OSSL_PARAM *params;
+
+    params = construct_tls1_prf_params("sha256", "", "seed");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_tls1_prf_1byte_secret(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx = NULL;
+    unsigned char out[16];
+    OSSL_PARAM *params;
+
+    params = construct_tls1_prf_params("sha256", "1", "seed");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_tls1_prf_empty_seed(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx = NULL;
+    unsigned char out[16];
+    OSSL_PARAM *params;
+
+    params = construct_tls1_prf_params("sha256", "secret", "");
+
+    /* Negative test - derive should fail */
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_tls1_prf_1byte_seed(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx = NULL;
+    unsigned char out[16];
+    OSSL_PARAM *params;
+
+    params = construct_tls1_prf_params("sha256", "secret", "1");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_TLS1_PRF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static OSSL_PARAM *construct_hkdf_params(char *digest, char *key,
+    size_t keylen, char *salt, char *info)
+{
+    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 5);
+    OSSL_PARAM *p = params;
+
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+                                            digest, strlen(digest));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
+                                             salt, strlen(salt));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
+                                             (unsigned char*)key, keylen);
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
+                                             info, strlen(info));
+    *p = OSSL_PARAM_construct_end();
+
+    return params;
 }
 
 static int test_kdf_hkdf(void)
@@ -63,20 +208,12 @@ static int test_kdf_hkdf(void)
     int ret;
     EVP_KDF_CTX *kctx;
     unsigned char out[10];
-    OSSL_PARAM params[5], *p = params;
+    OSSL_PARAM *params;
     static const unsigned char expected[sizeof(out)] = {
         0x2a, 0xc4, 0x36, 0x9f, 0x52, 0x59, 0x96, 0xf8, 0xde, 0x13
     };
 
-    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)"sha256", sizeof("sha256"));
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
-                                             (unsigned char *)"salt", 4);
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
-                                             (unsigned char *)"secret", 6);
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,
-                                             (unsigned char *)"label", 5);
-    *p = OSSL_PARAM_construct_end();
+    params = construct_hkdf_params("sha256", "secret", 6, "salt", "label");
 
     ret =
         TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
@@ -85,7 +222,121 @@ static int test_kdf_hkdf(void)
         && TEST_mem_eq(out, sizeof(out), expected, sizeof(expected));
 
     EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
     return ret;
+}
+
+static int test_kdf_hkdf_invalid_digest(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM *params;
+
+    params = construct_hkdf_params("blah", "secret", 6, "salt", "label");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
+        && TEST_false(EVP_KDF_CTX_set_params(kctx, params));
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_hkdf_zero_output_size(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[10];
+    OSSL_PARAM *params;
+
+    params = construct_hkdf_params("sha256", "secret", 6, "salt", "label");
+
+    /* Negative test - derive should fail */
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_eq(EVP_KDF_derive(kctx, out, 0), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_hkdf_empty_key(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[10];
+    OSSL_PARAM *params;
+
+    params = construct_hkdf_params("sha256", "", 0, "salt", "label");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_hkdf_1byte_key(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[10];
+    OSSL_PARAM *params;
+
+    params = construct_hkdf_params("sha256", "1", 1, "salt", "label");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_hkdf_empty_salt(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[10];
+    OSSL_PARAM *params;
+
+    params = construct_hkdf_params("sha256", "secret", 6, "", "label");
+
+    ret =
+        TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_HKDF))
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static OSSL_PARAM *construct_pbkdf2_params(char *pass, char *digest, char *salt,
+    unsigned int *iter, int *mode)
+{
+    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 6);
+    OSSL_PARAM *p = params;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
+                                             (unsigned char *)pass, strlen(pass));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
+                                             (unsigned char *)salt, strlen(salt));
+    *p++ = OSSL_PARAM_construct_uint(OSSL_KDF_PARAM_ITER, iter);
+    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
+                                             digest, strlen(digest));
+    *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, mode);
+    *p = OSSL_PARAM_construct_end();
+
+    return params;
 }
 
 static int test_kdf_pbkdf2(void)
@@ -93,10 +344,9 @@ static int test_kdf_pbkdf2(void)
     int ret = 0;
     EVP_KDF_CTX *kctx;
     unsigned char out[25];
-    size_t len = 0;
     unsigned int iterations = 4096;
     int mode = 0;
-    OSSL_PARAM params[6], *p = params;
+    OSSL_PARAM *params;
     const unsigned char expected[sizeof(out)] = {
         0x34, 0x8c, 0x89, 0xdb, 0xcb, 0xd3, 0x2b, 0x2f,
         0x32, 0xd8, 0x14, 0xb8, 0x11, 0x6e, 0x84, 0xcf,
@@ -104,59 +354,220 @@ static int test_kdf_pbkdf2(void)
         0x1c
     };
 
-    if (sizeof(len) > 32)
-        len = SIZE_MAX;
-
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD,
-                                             (unsigned char *)
-                                                "passwordPASSWORDpassword", 24);
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
-                                             (unsigned char *)
-                                                "saltSALTsaltSALTsaltSALTsaltSALTsalt",
-                                                36);
-    *p++ = OSSL_PARAM_construct_uint(OSSL_KDF_PARAM_ITER, &iterations);
-    *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                             (char *)"sha256", 7);
-    *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &mode);
-    *p = OSSL_PARAM_construct_end();
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+                                     &iterations, &mode);
 
     if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
         || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
         || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0)
-        || !TEST_mem_eq(out, sizeof(out), expected, sizeof(expected))
-        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
-        /* A key length that is too small should fail */
-        || !TEST_int_eq(EVP_KDF_derive(kctx, out, 112 / 8 - 1), 0)
-        /* A key length that is too large should fail */
-        || (len != 0 && !TEST_int_eq(EVP_KDF_derive(kctx, out, len), 0)))
+        || !TEST_mem_eq(out, sizeof(out), expected, sizeof(expected)))
         goto err;
-#if 0
-/* TODO */
-          /* Salt length less than 128 bits should fail */
-          || TEST_int_eq(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_SALT,
-                                      "123456781234567",
-                                      (size_t)15), 0)
-          /* A small iteration count should fail */
-          || TEST_int_eq(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_ITER, 1), 0)
-          || TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_PBKDF2_PKCS5_MODE,
-                                      1), 0)
-          /* Small salts will pass if the "pkcs5" mode is enabled */
-          || TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_SALT,
-                                      "123456781234567",
-                                      (size_t)15), 0)
-          /* A small iteration count will pass if "pkcs5" mode is enabled */
-          || TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_ITER, 1), 0)
-          /*
-           * If the "pkcs5" mode is disabled then the small salt and iter will
-           * fail when the derive gets called.
-           */
-          || TEST_int_gt(EVP_KDF_ctrl(kctx, EVP_KDF_CTRL_SET_PBKDF2_PKCS5_MODE,
-                                      0), 0)
-          || TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out)), 0);
-#endif
+
     ret = 1;
 err:
     EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_small_output(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[25];
+    unsigned int iterations = 4096;
+    int mode = 0;
+    OSSL_PARAM *params;
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        /* A key length that is too small should fail */
+        || !TEST_int_eq(EVP_KDF_derive(kctx, out, 112 / 8 - 1), 0))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_large_output(void)
+{   
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[25];
+    size_t len = 0;
+    unsigned int iterations = 4096;
+    int mode = 0;
+    OSSL_PARAM *params;
+
+    if (sizeof(len) > 32)
+        len = SIZE_MAX;
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params)) 
+        /* A key length that is too large should fail */
+        || (len != 0 && !TEST_int_eq(EVP_KDF_derive(kctx, out, len), 0)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_small_salt(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned int iterations = 4096;
+    int mode = 0;
+    OSSL_PARAM *params;
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALT",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        /* A salt that is too small should fail */
+        || !TEST_false(EVP_KDF_CTX_set_params(kctx, params)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_small_iterations(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned int iterations = 1;
+    int mode = 0;
+    OSSL_PARAM *params;
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        /* An iteration count that is too small should fail */
+        || !TEST_false(EVP_KDF_CTX_set_params(kctx, params)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_small_salt_pkcs5(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[25];
+    unsigned int iterations = 4096;
+    int mode = 1;
+    OSSL_PARAM *params;
+    OSSL_PARAM mode_params[2];
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALT",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        /* A salt that is too small should pass in pkcs5 mode */
+        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0))
+        goto err;
+
+    mode = 0;
+    mode_params[0] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &mode);
+    mode_params[1] = OSSL_PARAM_construct_end();
+    
+    /* If the "pkcs5" mode is disabled then the derive will now fail */
+    if (!TEST_true(EVP_KDF_CTX_set_params(kctx, mode_params))
+        || !TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out)), 0))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_small_iterations_pkcs5(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned char out[25];
+    unsigned int iterations = 1;
+    int mode = 1;
+    OSSL_PARAM *params;
+    OSSL_PARAM mode_params[2];
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "sha256",
+                                     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        /* An iteration count that is too small will pass in pkcs5 mode */
+        || !TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        || !TEST_int_gt(EVP_KDF_derive(kctx, out, sizeof(out)), 0))
+        goto err;
+
+    mode = 0;
+    mode_params[0] = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, &mode);
+    mode_params[1] = OSSL_PARAM_construct_end();
+
+    /* If the "pkcs5" mode is disabled then the derive will now fail */
+    if (!TEST_true(EVP_KDF_CTX_set_params(kctx, mode_params))
+        || !TEST_int_eq(EVP_KDF_derive(kctx, out, sizeof(out)), 0))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_pbkdf2_invalid_digest(void)
+{
+    int ret = 0;
+    EVP_KDF_CTX *kctx;
+    unsigned int iterations = 4096;
+    int mode = 0;
+    OSSL_PARAM *params;
+
+    params = construct_pbkdf2_params("passwordPASSWORDpassword", "blah",
+                                     "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+                                     &iterations, &mode);
+
+    if (!TEST_ptr(kctx = get_kdfbyname(OSSL_KDF_NAME_PBKDF2))
+        /* Unknown digest should fail */
+        || !TEST_false(EVP_KDF_CTX_set_params(kctx, params)))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
     return ret;
 }
 
@@ -423,6 +834,134 @@ static int test_kdf_kbkdf_6803_256(void)
     return ret;
 }
 #endif
+
+static OSSL_PARAM *construct_kbkdf_params(char *digest, char *mac, unsigned char *key,
+    size_t keylen, char *salt, char *info)
+{
+    OSSL_PARAM *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 7);
+    OSSL_PARAM *p = params;
+
+    *p++ = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_DIGEST, digest, strlen(digest));
+    *p++ = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_MAC, mac, strlen(mac));
+    *p++ = OSSL_PARAM_construct_utf8_string(
+        OSSL_KDF_PARAM_MODE, "COUNTER", 0);
+    *p++ = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_KEY, key, keylen);
+    *p++ = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_SALT, salt, strlen(salt));
+    *p++ = OSSL_PARAM_construct_octet_string(
+        OSSL_KDF_PARAM_INFO, info, strlen(info));
+    *p = OSSL_PARAM_construct_end();
+
+    return params;
+}
+
+static int test_kdf_kbkdf_invalid_digest(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM *params;
+
+    static unsigned char key[] = {0x01};
+
+    params = construct_kbkdf_params("blah", "HMAC", key, 1, "prf", "test");
+
+    /* Negative test case - set_params should fail */
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_false(EVP_KDF_CTX_set_params(kctx, params));
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_kbkdf_invalid_mac(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM *params;
+
+    static unsigned char key[] = {0x01};
+
+    params = construct_kbkdf_params("sha256", "blah", key, 1, "prf", "test");
+
+    /* Negative test case - set_params should fail */
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_false(EVP_KDF_CTX_set_params(kctx, params));
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_kbkdf_empty_key(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM *params;
+
+    static unsigned char key[] = {};
+    unsigned char result[32] = { 0 };
+
+    params = construct_kbkdf_params("sha256", "HMAC", key, 0, "prf", "test");
+
+    /* Negative test case - derive should fail */
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_eq(EVP_KDF_derive(kctx, result, sizeof(result)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_kbkdf_1byte_key(void)
+{   
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM *params;
+    
+    static unsigned char key[] = {0x01};
+    unsigned char result[32] = { 0 };
+
+    params = construct_kbkdf_params("sha256", "HMAC", key, 1, "prf", "test");
+
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_gt(EVP_KDF_derive(kctx, result, sizeof(result)), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
+
+static int test_kdf_kbkdf_zero_output_size(void)
+{
+    int ret;
+    EVP_KDF_CTX *kctx;
+    OSSL_PARAM *params;
+
+    static unsigned char key[] = {0x01};
+    unsigned char result[32] = { 0 };
+
+    params = construct_kbkdf_params("sha256", "HMAC", key, 1, "prf", "test");
+
+    /* Negative test case - derive should fail */
+    kctx = get_kdfbyname("KBKDF");
+    ret = TEST_ptr(kctx)
+        && TEST_true(EVP_KDF_CTX_set_params(kctx, params))
+        && TEST_int_eq(EVP_KDF_derive(kctx, result, 0), 0);
+
+    EVP_KDF_CTX_free(kctx);
+    OPENSSL_free(params);
+    return ret;
+}
 
 /* Two test vectors from RFC 8009 (AES Encryption with HMAC-SHA2 for Kerberos
  * 5) appendix A. */
@@ -777,12 +1316,35 @@ int setup_tests(void)
     ADD_TEST(test_kdf_kbkdf_6803_128);
     ADD_TEST(test_kdf_kbkdf_6803_256);
 #endif
+    ADD_TEST(test_kdf_kbkdf_invalid_digest);
+    ADD_TEST(test_kdf_kbkdf_invalid_mac);
+    ADD_TEST(test_kdf_kbkdf_zero_output_size);
+    ADD_TEST(test_kdf_kbkdf_empty_key);
+    ADD_TEST(test_kdf_kbkdf_1byte_key);
     ADD_TEST(test_kdf_kbkdf_8009_prf1);
     ADD_TEST(test_kdf_kbkdf_8009_prf2);
     ADD_TEST(test_kdf_get_kdf);
     ADD_TEST(test_kdf_tls1_prf);
+    ADD_TEST(test_kdf_tls1_prf_invalid_digest);
+    ADD_TEST(test_kdf_tls1_prf_zero_output_size);
+    ADD_TEST(test_kdf_tls1_prf_empty_secret);
+    ADD_TEST(test_kdf_tls1_prf_1byte_secret);
+    ADD_TEST(test_kdf_tls1_prf_empty_seed);
+    ADD_TEST(test_kdf_tls1_prf_1byte_seed);
     ADD_TEST(test_kdf_hkdf);
+    ADD_TEST(test_kdf_hkdf_invalid_digest);
+    ADD_TEST(test_kdf_hkdf_zero_output_size);
+    ADD_TEST(test_kdf_hkdf_empty_key);
+    ADD_TEST(test_kdf_hkdf_1byte_key);
+    ADD_TEST(test_kdf_hkdf_empty_salt);
     ADD_TEST(test_kdf_pbkdf2);
+    ADD_TEST(test_kdf_pbkdf2_small_output);
+    ADD_TEST(test_kdf_pbkdf2_large_output);
+    ADD_TEST(test_kdf_pbkdf2_small_salt);
+    ADD_TEST(test_kdf_pbkdf2_small_iterations);
+    ADD_TEST(test_kdf_pbkdf2_small_salt_pkcs5);
+    ADD_TEST(test_kdf_pbkdf2_small_iterations_pkcs5);
+    ADD_TEST(test_kdf_pbkdf2_invalid_digest);
 #ifndef OPENSSL_NO_SCRYPT
     ADD_TEST(test_kdf_scrypt);
 #endif

--- a/test/evp_kdf_test.c
+++ b/test/evp_kdf_test.c
@@ -34,7 +34,7 @@ static OSSL_PARAM *construct_tls1_prf_params(const char *digest, const char *sec
     OSSL_PARAM *p = params;
 
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)digest, strlen(digest));
+                                            (char *)digest, 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET,
                                              (unsigned char *)secret,
                                              strlen(secret));
@@ -191,7 +191,7 @@ static OSSL_PARAM *construct_hkdf_params(char *digest, char *key,
     OSSL_PARAM *p = params;
 
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            digest, strlen(digest));
+                                            digest, 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                              salt, strlen(salt));
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
@@ -332,7 +332,7 @@ static OSSL_PARAM *construct_pbkdf2_params(char *pass, char *digest, char *salt,
                                              (unsigned char *)salt, strlen(salt));
     *p++ = OSSL_PARAM_construct_uint(OSSL_KDF_PARAM_ITER, iter);
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                             digest, strlen(digest));
+                                             digest, 0);
     *p++ = OSSL_PARAM_construct_int(OSSL_KDF_PARAM_PKCS5, mode);
     *p = OSSL_PARAM_construct_end();
 
@@ -842,9 +842,9 @@ static OSSL_PARAM *construct_kbkdf_params(char *digest, char *mac, unsigned char
     OSSL_PARAM *p = params;
 
     *p++ = OSSL_PARAM_construct_utf8_string(
-        OSSL_KDF_PARAM_DIGEST, digest, strlen(digest));
+        OSSL_KDF_PARAM_DIGEST, digest, 0);
     *p++ = OSSL_PARAM_construct_utf8_string(
-        OSSL_KDF_PARAM_MAC, mac, strlen(mac));
+        OSSL_KDF_PARAM_MAC, mac, 0);
     *p++ = OSSL_PARAM_construct_utf8_string(
         OSSL_KDF_PARAM_MODE, "COUNTER", 0);
     *p++ = OSSL_PARAM_construct_octet_string(
@@ -985,9 +985,9 @@ static int test_kdf_kbkdf_8009_prf1(void)
     unsigned char result[sizeof(output)] = { 0 };
 
     params[i++] = OSSL_PARAM_construct_utf8_string(
-        OSSL_KDF_PARAM_DIGEST, digest, strlen(digest) + 1);
+        OSSL_KDF_PARAM_DIGEST, digest, 0);
     params[i++] = OSSL_PARAM_construct_utf8_string(
-        OSSL_KDF_PARAM_MAC, mac, strlen(mac) + 1);
+        OSSL_KDF_PARAM_MAC, mac, 0);
     params[i++] = OSSL_PARAM_construct_octet_string(
         OSSL_KDF_PARAM_KEY, input_key, sizeof(input_key));
     params[i++] = OSSL_PARAM_construct_octet_string(
@@ -1030,9 +1030,9 @@ static int test_kdf_kbkdf_8009_prf2(void)
     unsigned char result[sizeof(output)] = { 0 };
 
     params[i++] = OSSL_PARAM_construct_utf8_string(
-        OSSL_KDF_PARAM_DIGEST, digest, strlen(digest) + 1);
+        OSSL_KDF_PARAM_DIGEST, digest, 0);
     params[i++] = OSSL_PARAM_construct_utf8_string(
-        OSSL_KDF_PARAM_MAC, mac, strlen(mac) + 1);
+        OSSL_KDF_PARAM_MAC, mac, 0);
     params[i++] = OSSL_PARAM_construct_octet_string(
         OSSL_KDF_PARAM_KEY, input_key, sizeof(input_key));
     params[i++] = OSSL_PARAM_construct_octet_string(
@@ -1254,12 +1254,11 @@ static int test_kdf_x942_asn1(void)
     };
 
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST,
-                                            (char *)"sha1", sizeof("sha1"));
+                                            (char *)"sha1", 0);
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY, z,
                                              sizeof(z));
     *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CEK_ALG,
-                                            (char *)cek_alg,
-                                            strlen(cek_alg) + 1);
+                                            (char *)cek_alg, 0);
     *p = OSSL_PARAM_construct_end();
 
     ret =


### PR DESCRIPTION
The behaviour of EVP_KDF_CTX_set_params changed between alpha4 and current, so that one of our tests started to fail. The test results in this API call:

    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, (char *) mdname, 0);
    params[1] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SECRET, secret, secretlen);
    params[2] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SEED, seed, seedlen);
    params[3] = OSSL_PARAM_construct_end();

    ret = EVP_KDF_CTX_set_params(ctx, params);

Where:
  secret = pointer to blank buffer
  secretlen = 0

The KDF is OSSL_KDF_NAME_TLS1_PRF.

This started to fail recently with a change to the HMAC code (which is used internally in the KDF):

https://github.com/openssl/openssl/commit/3fddbb264e87a8cef2903cbd7b02b8e1a39a2a99

The code added to allocate a copy of the HMAC key is not zero-length aware so the OPENSSL_secure_malloc fails. The KDF code to store the secret is already zero-length aware.

This PR also goes some way to fixing #8531 although the secret buffer is still checked for NULL so the user would have to provide a non-null buffer even with a length of zero.
