### PR TITLE
Simplify the tarball generating scripts

### DIFF
--- a/util/mktar.sh
+++ b/util/mktar.sh
@@ -31,8 +31,7 @@ done
 if [ -z "$TARFILE" ]; then TARFILE="$NAME.tar"; fi
 
 # This counts on .gitattributes to specify what files should be ignored
-git archive --worktree-attributes --format=tar --prefix="$NAME/" -v HEAD \
-    | gzip -9 > "$TARFILE.gz"
+git archive --worktree-attributes -9 --prefix="$NAME/" -o $TARFILE.gz -v HEAD
 
 # Good old way to ensure we display an absolute path
 td=`dirname $TARFILE`


### PR DESCRIPTION
As per disscussed in issue 12364[1], since the format of git archive will
inferred from the output file and attributes are by default taken from the
.gitattributes files in the tree that is being archived, we can make the
release scripts simper by:
- remove the pipe for gzip
- remove the option "--worktree-attributes"

[1] https://github.com/openssl/openssl/issues/12364

Signed-off-by: Hu Keping <hukeping@huawei.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
