### PR TITLE
Fix VS2019 compile error C4703: potentially uninitialized local point…

### DIFF
--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -633,8 +633,8 @@ static int rsa_to_text(BIO *out, const void *key, int selection)
 {
     const RSA *rsa = key;
     const char *type_label = "RSA key";
-    const char *modulus_label;
-    const char *exponent_label;
+    const char *modulus_label = NULL;
+    const char *exponent_label = NULL;
     const BIGNUM *rsa_d = NULL, *rsa_n = NULL, *rsa_e = NULL;
     STACK_OF(BIGNUM_const) *factors = NULL;
     STACK_OF(BIGNUM_const) *exps = NULL;


### PR DESCRIPTION
Fix VS2019 compile error C4703: potentially uninitialized local pointer variable used.

encode_key2text.c(689): error C4703: potentially uninitialized local pointer variable 'modulus_label' used
encode_key2text.c(691): error C4703: potentially uninitialized local pointer variable 'exponent_label' used

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
