### PR TITLE
Change the comparison method of EC_METHOD

### DIFF
--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -323,7 +323,7 @@ struct ec_point_st {
 static ossl_inline int ec_point_is_compat(const EC_POINT *point,
                                           const EC_GROUP *group)
 {
-    return group->meth == point->meth
+    return group->meth->field_type == point->meth->field_type
            && (group->curve_name == 0
                || point->curve_name == 0
                || group->curve_name == point->curve_name);


### PR DESCRIPTION
CLA: trivial

I want to write an ssl server. Now i’ve already complie the openssl to static lib called libcrypto.a,
I also have an engine called sm2_engine compiled to tasshsm_sm2.so, use this engine load the private key by ENGINE_load_private_key(),like this:
if (SSL_CTX_use_certificate_file(ctx, SERVER_SIGN_CERT_HSM, SSL_FILETYPE_PEM) != 1) {
exit(0);
}
EVP_PKEY *pkey = ENGINE_load_private_key(tasshsmsm2_e, sign_key_index, NULL, NULL);
if (SSL_CTX_use_PrivateKey(ctx, pkey) != 1) {
exit(0);
}
But it doesn’t work, display an error: X509_check_private_key:key values mismatch. I can be sure that my private and public keys match. After a period of investigation, i found the root cause is group->meth != point->meth in ec_point_is_compat(). But in fact, the content of group->meth and point->meth is the same, but they’re in the different of memory address caused by the staitc libcrypto.a and tasshsm_sm2.so. My engine lib will copy a mirror image of “static const EC_METHOD ret” defined in EC_GFp_mont_method() when calling the EC_GFp_mont_method() in my engine lib, and the address is located in tasshsm_sm2.so’s memery maps. So, if you call the EC_GFp_mont_method() in your main function, you’ll get the meth’s address is in main’s address maps like “(const EC_METHOD *) 0x907360 <ret.9094>”; If you call the EC_GFp_mont_method() in your engine’s function like tasshsm_sm2.so, you’ll get the meth’s address is in tasshsm_sm2.so’s address maps like “(const EC_METHOD *) 0x7ffff6a4a1e0 <ret.9094>”. Obviously, they’re different address. So, i change this comparison to memcmp(group->meth, point->meth, sizeof(EC_METHOD)), it still not work, because this struct have the fucntion pointer’s address like ec_GFp_mont_group_init(), they also have the different address although they point to the same conntent(the ec_GFp_mont_group_init() function). Because this struct have to many function address, So I'm not going to compare all of them, i just compare the field_type of EC_METHOD. 
In a word, if openssl allowed the static libcrypto.a supported the engine, this comparision should be changed.