### PR TITLE
OSSL_DECODER 'decode' function must never be NULL.

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -215,7 +215,7 @@ void *ossl_decoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
      */
     if (!((decoder->newctx == NULL && decoder->freectx == NULL)
           || (decoder->newctx != NULL && decoder->freectx != NULL))
-        || (decoder->decode == NULL && decoder->export_object == NULL)) {
+        || decoder->decode == NULL) {
         OSSL_DECODER_free(decoder);
         ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_INVALID_PROVIDER_FUNCTIONS);
         return NULL;


### PR DESCRIPTION
The conditions for a valid implementation allowed the 'decode'
function to be NULL or the 'export_object' was NULL.  That condition
is changed so that 'decode' is checked to be non-NULL by itself.

Fixes #12819
