### PR TITLE
Fix dgst output for HMAC

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -406,13 +406,8 @@ int dgst_main(int argc, char **argv)
     } else {
         const char *sig_name = NULL;
         if (!out_bin) {
-            if (sigkey != NULL) {
-                const EVP_PKEY_ASN1_METHOD *ameth;
-                ameth = EVP_PKEY_get0_asn1(sigkey);
-                if (ameth)
-                    EVP_PKEY_asn1_get0_info(NULL, NULL,
-                                            NULL, NULL, &sig_name, ameth);
-            }
+            if (sigkey != NULL)
+                sig_name = EVP_PKEY_get0_first_alg_name(sigkey);
         }
         ret = 0;
         for (i = 0; i < argc; i++) {

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -319,7 +319,8 @@ int dgst_main(int argc, char **argv)
 
     if (hmac_key != NULL) {
         sigkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, impl,
-                                              (unsigned char *)hmac_key, -1);
+                                              (unsigned char *)hmac_key,
+                                              strlen(hmac_key));
         if (sigkey == NULL)
             goto end;
     }

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -163,3 +163,20 @@ int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *key,
         return 1;
     return 0;
 }
+
+const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key)
+{
+    const EVP_PKEY_ASN1_METHOD *ameth;
+    const char *name = NULL;
+
+    if (key->keymgmt != NULL)
+        return EVP_KEYMGMT_get0_first_name(key->keymgmt);
+
+    /* Otherwise fallback to legacy */
+    ameth = EVP_PKEY_get0_asn1(key);
+    if (ameth != NULL)
+        EVP_PKEY_asn1_get0_info(NULL, NULL,
+                                NULL, NULL, &name, ameth);
+
+    return name;
+}

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -249,6 +249,11 @@ int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt)
     return keymgmt->name_id;
 }
 
+const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt)
+{
+    return evp_first_name(keymgmt->prov, keymgmt->name_id);
+}
+
 int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name)
 {
     return evp_is_a(keymgmt->prov, keymgmt->name_id, NULL, name);

--- a/doc/man3/EVP_KEYMGMT.pod
+++ b/doc/man3/EVP_KEYMGMT.pod
@@ -9,6 +9,7 @@ EVP_KEYMGMT_free,
 EVP_KEYMGMT_provider,
 EVP_KEYMGMT_is_a,
 EVP_KEYMGMT_number,
+EVP_KEYMGMT_get0_first_name,
 EVP_KEYMGMT_do_all_provided,
 EVP_KEYMGMT_names_do_all,
 EVP_KEYMGMT_gettable_params,
@@ -29,6 +30,8 @@ EVP_KEYMGMT_gen_settable_params
  const OSSL_PROVIDER *EVP_KEYMGMT_provider(const EVP_KEYMGMT *keymgmt);
  int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name);
  int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt);
+ const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt);
+
  void EVP_KEYMGMT_do_all_provided(OPENSSL_CTX *libctx,
                                   void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
                                   void *arg);
@@ -68,6 +71,12 @@ algorithm that's identifiable with I<name>.
 
 EVP_KEYMGMT_number() returns the internal dynamic number assigned to
 the I<keymgmt>.
+
+EVP_KEYMGMT_get0_first_name() returns the first algorithm name that is found for
+the given I<keymgmt>. Note that the I<keymgmt> may have multiple synonyms
+associated with it. In this case it is undefined which one will be returned.
+Ownership of the returned string is retained by the I<keymgmt> object and should
+not be freed by the caller.
 
 EVP_KEYMGMT_names_do_all() traverses all names for the I<keymgmt>, and
 calls I<fn> with each name and I<data>.
@@ -110,6 +119,8 @@ EVP_KEYMGMT_is_a() returns 1 of I<keymgmt> was identifiable,
 otherwise 0.
 
 EVP_KEYMGMT_number() returns an integer.
+
+EVP_KEYMGMT_get0_first_name() returns the name that is found or NULL on error.
 
 EVP_KEYMGMT_gettable_params(), EVP_KEYMGMT_settable_params() and
 EVP_KEYMGMT_gen_settable_params() return a constant B<OSSL_PARAM> array or

--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-EVP_PKEY_is_a, EVP_PKEY_can_sign
+EVP_PKEY_is_a, EVP_PKEY_can_sign, EVP_PKEY_get0_first_alg_name
 - key type and capabilities functions
 
 =head1 SYNOPSIS
@@ -11,6 +11,8 @@ EVP_PKEY_is_a, EVP_PKEY_can_sign
 
  int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
  int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
+ const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key);
+
 
 =head1 DESCRIPTION
 
@@ -20,6 +22,12 @@ EVP_PKEY_can_sign() checks if the functionality for the key type of
 I<pkey> supports signing.  No other check is done, such as whether
 I<pkey> contains a private key.
 
+EVP_PKEY_get0_first_alg_name() returns the first algorithm name that is found
+for the given I<pkey>. Note that the I<pkey> may have multiple synonyms
+associated with it. In this case it is undefined which one will be returned.
+Ownership of the returned string is retained by the I<pkey> object and should
+not be freed by the caller.
+
 =head1 RETURN VALUES
 
 EVP_PKEY_is_a() returns 1 if I<pkey> has the key type I<name>,
@@ -27,6 +35,8 @@ otherwise 0.
 
 EVP_PKEY_can_sign() returns 1 if the I<pkey> key type functionality
 supports signing, otherwise 0.
+
+EVP_KEYMGMT_get0_first_name() returns the name that is found or NULL on error.
 
 =head1 EXAMPLES
 
@@ -59,6 +69,10 @@ this as an crude example:
          exit(1);
      }
      /* Sign something... */
+
+=head1 HISTORY
+
+The functions described here were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1500,6 +1500,8 @@ int EVP_PKEY_CTX_set1_id(EVP_PKEY_CTX *ctx, const void *id, int len);
 int EVP_PKEY_CTX_get1_id(EVP_PKEY_CTX *ctx, void *id);
 int EVP_PKEY_CTX_get1_id_len(EVP_PKEY_CTX *ctx, size_t *id_len);
 
+const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key);
+
 # define EVP_PKEY_OP_UNDEFINED           0
 # define EVP_PKEY_OP_PARAMGEN            (1<<1)
 # define EVP_PKEY_OP_KEYGEN              (1<<2)
@@ -1577,6 +1579,7 @@ EVP_KEYMGMT *EVP_KEYMGMT_fetch(OPENSSL_CTX *ctx, const char *algorithm,
 int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt);
 void EVP_KEYMGMT_free(EVP_KEYMGMT *keymgmt);
 const OSSL_PROVIDER *EVP_KEYMGMT_provider(const EVP_KEYMGMT *keymgmt);
+const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt);
 int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt);
 int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name);
 void EVP_KEYMGMT_do_all_provided(OPENSSL_CTX *libctx,

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -111,9 +111,8 @@ subtest "HMAC generation with `dgst` CLI" => sub {
     my @hmacdata = run(app(['openssl', 'dgst', '-sha256', '-hmac', '123456',
                             $testdata, $testdata]), capture => 1);
     chomp(@hmacdata);
-    my $expected = "HMAC-SHA256(../../test/data.txt)= "
-                   ."6f12484129c4a761747f13d8234a1ff0e074adb34e9e9bf3a155c391b97b9a7c";
-    ok($hmacdata[0] eq $expected, "HMAC: Check HMAC value is as expected");
-    ok($hmacdata[1] eq $expected,
-       "HMAC: Check second HMAC value is consistent with the first");
+    my $expected = qr/HMAC-SHA256\([^\)]*data.txt\)= 6f12484129c4a761747f13d8234a1ff0e074adb34e9e9bf3a155c391b97b9a7c/;
+    ok($hmacdata[0] =~ $expected, "HMAC: Check HMAC value is as expected ($hmacdata[0]) vs ($expected)");
+    ok($hmacdata[1] =~ $expected,
+       "HMAC: Check second HMAC value is consistent with the first ($hmacdata[1]) vs ($expected)");
 };

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_dgst");
 
-plan tests => 5;
+plan tests => 6;
 
 sub tsignverify {
     my $testtext = shift;
@@ -102,3 +102,18 @@ SKIP: {
                     srctop_file("test","tested448pub.pem"));
     };
 }
+
+subtest "HMAC generation with `dgst` CLI" => sub {
+    plan tests => 2;
+
+    my $testdata = srctop_file('test', 'data.txt');
+    #HMAC the data twice to check consistency
+    my @hmacdata = run(app(['openssl', 'dgst', '-sha256', '-hmac', '123456',
+                            $testdata, $testdata]), capture => 1);
+    chomp(@hmacdata);
+    my $expected = "HMAC-SHA256(../../test/data.txt)= "
+                   ."6f12484129c4a761747f13d8234a1ff0e074adb34e9e9bf3a155c391b97b9a7c";
+    ok($hmacdata[0] eq $expected, "HMAC: Check HMAC value is as expected");
+    ok($hmacdata[1] eq $expected,
+       "HMAC: Check second HMAC value is consistent with the first");
+};

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5280,3 +5280,5 @@ EVP_PKEY_CTX_get1_id_len                ?	3_0_0	EXIST::FUNCTION:
 CMS_AuthEnvelopedData_create            ?	3_0_0	EXIST::FUNCTION:CMS
 CMS_AuthEnvelopedData_create_with_libctx ?	3_0_0	EXIST::FUNCTION:CMS
 EVP_PKEY_CTX_set_ec_param_enc           ?	3_0_0	EXIST::FUNCTION:EC
+EVP_PKEY_get0_first_alg_name            ?	3_0_0	EXIST::FUNCTION:
+EVP_KEYMGMT_get0_first_name             ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The dgst app was using an undocumented behaviour in the
EVP_PKEY_new_raw_private_key() function when setting a key length for
a MAC. The old EVP_PKEY to MAC bridge, probably by accident, converts a
-1 length to a strlen() call, by virtue of the fact that it eventually
calls ASN1_STRING_set() which has this feature.

As noted above this is undocumented, and unexpected since the len
parameter to EVP_PKEY_new_raw_private_key() is an unsigned value (size_t).
In the old bridge it was later (silently) cast to an int, and therefore
the original -1 value was restored. This only works because sizeof(int) <=
sizeof(size_t). If we ever run on a platform where sizeof(int) >
sizeof(size_t) then it would have failed. The behaviour also doesn't hold
for EVP_PKEY_new_raw_private_key() in general - only when the old MAC
bridge was in use.

Rather than restore the original behaviour I think it is best to simply
fix the dgst app to not assume it exists. We should not bake in this
backwards and inconsistent behaviour.

Fixes #12837
