### PR TITLE
Fix: ecp_nistz256-armv4.S bad arguments

### DIFF
--- a/crypto/ec/asm/ecp_nistz256-armv4.pl
+++ b/crypto/ec/asm/ecp_nistz256-armv4.pl
@@ -1521,9 +1521,9 @@ ecp_nistz256_point_add:
 	ldr	$t2,[sp,#32*18+12]	@ ~is_equal(S1,S2)
 	mvn	$t0,$t0			@ -1/0 -> 0/-1
 	mvn	$t1,$t1			@ -1/0 -> 0/-1
-	orr	$a0,$t0
-	orr	$a0,$t1
-	orrs	$a0,$t2			@ set flags
+	orr	$a0,$a0,$t0
+	orr	$a0,$a0,$t1
+	orrs	$a0,$a0,$t2		@ set flags
 
 	@ if(~is_equal(U1,U2) | in1infty | in2infty | ~is_equal(S1,S2))
 	bne	.Ladd_proceed


### PR DESCRIPTION
Fix this error:

crypto/ec/ecp_nistz256-armv4.S:3853: Error: bad arguments to instruction -- orr r11,r10
crypto/ec/ecp_nistz256-armv4.S:3854: Error: bad arguments to instruction -- orr r11,r12
crypto/ec/ecp_nistz256-armv4.S:3855: Error: bad arguments to instruction -- orrs r11,r14

Always use 3-operand form instructions

CLA: trivial

Fixes #12848
