### PR TITLE
Free allocated data on error paths

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -786,6 +786,7 @@ int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
     /* Create buffer with peer's address and port */
     if (!BIO_ADDR_rawaddress(peer, NULL, &length)) {
         BIO_printf(bio_err, "Failed getting peer address\n");
+        BIO_ADDR_free(lpeer);
         return 0;
     }
     OPENSSL_assert(length != 0);

--- a/crypto/evp/p5_crpt.c
+++ b/crypto/evp/p5_crpt.c
@@ -91,7 +91,7 @@ int PKCS5_PBE_keyivgen(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
         goto err;
     mdsize = EVP_MD_size(md);
     if (mdsize < 0)
-        return 0;
+        goto err;
     for (i = 1; i < iter; i++) {
         if (!EVP_DigestInit_ex(ctx, md, NULL))
             goto err;

--- a/crypto/pkcs12/p12_npas.c
+++ b/crypto/pkcs12/p12_npas.c
@@ -157,8 +157,10 @@ static int newpass_bag(PKCS12_SAFEBAG *bag, const char *oldpass,
     if ((p8 = PKCS8_decrypt(bag->value.shkeybag, oldpass, -1)) == NULL)
         return 0;
     X509_SIG_get0(bag->value.shkeybag, &shalg, NULL);
-    if (!alg_get(shalg, &p8_nid, &p8_iter, &p8_saltlen))
+    if (!alg_get(shalg, &p8_nid, &p8_iter, &p8_saltlen)) {
+        PKCS8_PRIV_KEY_INFO_free(p8);
         return 0;
+    }
     p8new = PKCS8_encrypt(p8_nid, NULL, newpass, -1, NULL, p8_saltlen,
                           p8_iter, p8);
     PKCS8_PRIV_KEY_INFO_free(p8);

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3214,6 +3214,7 @@ static int build_chain(X509_STORE_CTX *ctx)
                     }
                     self_signed = X509_self_signed(x, 0);
                     if (self_signed < 0) {
+                        sk_X509_free(sktmp);
                         ctx->error = X509_V_ERR_UNSPECIFIED;
                         return 0;
                     }

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1051,12 +1051,16 @@ int dtls1_buffer_message(SSL *s, int is_ccs)
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len +
                          ((s->version ==
                            DTLS1_BAD_VER) ? 3 : DTLS1_CCS_HEADER_LENGTH)
-                         == (unsigned int)s->init_num))
+                         == (unsigned int)s->init_num)) {
+            dtls1_hm_fragment_free(frag);
             return 0;
+        }
     } else {
         if (!ossl_assert(s->d1->w_msg_hdr.msg_len +
-                         DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num))
+                         DTLS1_HM_HEADER_LENGTH == (unsigned int)s->init_num)) {
+            dtls1_hm_fragment_free(frag);
             return 0;
+        }
     }
 
     frag->msg_header.msg_len = s->d1->w_msg_hdr.msg_len;


### PR DESCRIPTION
A number of cases where data was accidentally not freed on error paths have been isolated and fixed.

Report from Dinghao Liu.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
