### PR TITLE
Update AES GCM IV max length to be 1024 bits (was 512)

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -20,6 +20,9 @@
 #include "prov/implementations.h"
 #include "prov/providercommon.h"
 
+#define AES_GCM_IV_MIN_SIZE     (64 / 8) /* size in bytes */
+/* Note: GCM_IV_MAX_SIZE is listed in ciphercommon_gcm.h */
+
 static void *aes_gcm_newctx(void *provctx, size_t keybits)
 {
     PROV_AES_GCM_CTX *ctx;
@@ -29,7 +32,8 @@ static void *aes_gcm_newctx(void *provctx, size_t keybits)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        gcm_initctx(provctx, &ctx->base, keybits, PROV_AES_HW_gcm(keybits), 8);
+        gcm_initctx(provctx, &ctx->base, keybits, PROV_AES_HW_gcm(keybits),
+                    AES_GCM_IV_MIN_SIZE);
     return ctx;
 }
 

--- a/providers/implementations/ciphers/cipher_aria_gcm.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm.c
@@ -13,6 +13,8 @@
 #include "prov/implementations.h"
 #include "prov/providercommon.h"
 
+#define ARIA_GCM_IV_MIN_SIZE     (32 / 8) /* size in bytes */
+
 static void *aria_gcm_newctx(void *provctx, size_t keybits)
 {
     PROV_ARIA_GCM_CTX *ctx;
@@ -22,7 +24,8 @@ static void *aria_gcm_newctx(void *provctx, size_t keybits)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        gcm_initctx(provctx, &ctx->base, keybits, PROV_ARIA_HW_gcm(keybits), 4);
+        gcm_initctx(provctx, &ctx->base, keybits, PROV_ARIA_HW_gcm(keybits),
+                    ARIA_GCM_IV_MIN_SIZE);
     return ctx;
 }
 

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -14,7 +14,7 @@
 typedef struct prov_gcm_hw_st PROV_GCM_HW;
 
 #define GCM_IV_DEFAULT_SIZE 12 /* IV's for AES_GCM should normally be 12 bytes */
-#define GCM_IV_MAX_SIZE     64
+#define GCM_IV_MAX_SIZE     (1024 / 8)
 #define GCM_TAG_MAX_SIZE    16
 
 #if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

See query in PR #11843