### PR TITLE
Ec keygen self test fix

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -256,7 +256,7 @@ int ossl_ec_key_gen(EC_KEY *eckey)
  *                   fails then the keypair is not generated,
  * Returns 1 if the keypair was generated or 0 otherwise.
  */
-int ec_generate_key(OPENSSL_CTX *libctx, EC_KEY *eckey, int pairwise_test)
+static int ec_generate_key(EC_KEY *eckey, int pairwise_test)
 {
     int ok = 0;
     BIGNUM *priv_key = NULL;
@@ -325,7 +325,7 @@ int ec_generate_key(OPENSSL_CTX *libctx, EC_KEY *eckey, int pairwise_test)
         OSSL_CALLBACK *cb = NULL;
         void *cbarg = NULL;
 
-        OSSL_SELF_TEST_get_callback(libctx, &cb, &cbarg);
+        OSSL_SELF_TEST_get_callback(eckey->libctx, &cb, &cbarg);
         ok = ecdsa_keygen_pairwise_test(eckey, cb, cbarg);
     }
 err:
@@ -345,7 +345,7 @@ err:
 
 int ec_key_simple_generate_key(EC_KEY *eckey)
 {
-    return ec_generate_key(NULL, eckey, 0);
+    return ec_generate_key(eckey, 0);
 }
 
 int ec_key_simple_generate_public_key(EC_KEY *eckey)

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -31,6 +31,7 @@ struct ossl_self_test_st
     void *cb_arg;
 };
 
+#ifndef FIPS_MODULE
 static void *self_test_set_callback_new(OPENSSL_CTX *ctx)
 {
     SELF_TEST_CB *stcb;
@@ -55,7 +56,6 @@ static SELF_TEST_CB *get_self_test_callback(OPENSSL_CTX *libctx)
                                 &self_test_set_callback_method);
 }
 
-#ifndef FIPS_MODULE
 void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
                                  void *cbarg)
 {
@@ -66,7 +66,6 @@ void OSSL_SELF_TEST_set_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK *cb,
         stcb->cbarg = cbarg;
     }
 }
-#endif /* FIPS_MODULE */
 
 void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK **cb,
                                  void **cbarg)
@@ -78,6 +77,7 @@ void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK **cb,
     if (cbarg != NULL)
         *cbarg = (stcb != NULL ? stcb->cbarg : NULL);
 }
+#endif /* FIPS_MODULE */
 
 static void self_test_setparams(OSSL_SELF_TEST *st)
 {

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -49,7 +49,6 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
                    const unsigned char *sinfo, size_t sinfolen,
                    const EVP_MD *md, OPENSSL_CTX *libctx, const char *propq);
 
-int ec_generate_key(OPENSSL_CTX *libctx, EC_KEY *eckey, int pairwise_test);
 int ec_key_public_check(const EC_KEY *eckey, BN_CTX *ctx);
 int ec_key_private_check(const EC_KEY *eckey);
 int ec_key_pairwise_check(const EC_KEY *eckey, BN_CTX *ctx);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -886,3 +886,20 @@ int FIPS_security_check_enabled(void)
 {
     return fips_security_checks;
 }
+
+void OSSL_SELF_TEST_get_callback(OPENSSL_CTX *libctx, OSSL_CALLBACK **cb,
+                                 void **cbarg)
+{
+    if (libctx == NULL)
+        libctx = selftest_params.libctx;
+
+    if (c_stcbfn != NULL && c_get_libctx != NULL) {
+        /* Get the parent libctx */
+        c_stcbfn(c_get_libctx(FIPS_get_core_handle(libctx)), cb, cbarg);
+    } else {
+        if (cb != NULL)
+            *cb = NULL;
+        if (cbarg != NULL)
+            *cbarg = NULL;
+    }
+}

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -644,14 +644,11 @@ int setup_tests(void)
         return 0;
 
     libctx = OPENSSL_CTX_new();
-
     if (!TEST_ptr(libctx))
         return 0;
-
-    if (config_file != NULL) {
-        if (!TEST_true(OPENSSL_CTX_load_config(libctx, config_file)))
-            return 0;
-    }
+    if (config_file != NULL
+        && !TEST_true(OPENSSL_CTX_load_config(libctx, config_file)))
+        return 0;
 
     libprov = OSSL_PROVIDER_load(libctx, prov_name);
     if (!TEST_ptr(libprov))


### PR DESCRIPTION
Issue reported by Mark Powers from Acumen..

OSSL_SELF_TEST_get_callback() was not working inside the conditional tests since it was using the wrong library context.
It turns out this is a bit complicated to fix since the library context we want was the core library context NOT the internal fips library context that we have.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
