### PR TITLE
OpenSSL::ParseC: recognise inline function bodies

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1083,8 +1083,8 @@ errors:
            include/openssl/ebcdic.h
            include/openssl/opensslconf.h
            include/openssl/symhacks.h ) );
-   our @cryptoheaders = ();
-   our @sslheaders = ();
+   our %cryptoheaders = ();
+   our %sslheaders = ();
    foreach my $d ( qw( include/openssl include/internal ) ) {
        my @header_patterns =
            map { catfile($config{sourcedir}, $d, $_) } ( '*.h', '*.h.in' );
@@ -1104,20 +1104,20 @@ errors:
            # file to be added must be either in the public header directory
            # or one of the pre-declared internal headers, and must under no
            # circumstances be one of those that must be skipped.
-           push @cryptoheaders, $new_f
+           $cryptoheaders{$new_f} = 1
                if (($d eq 'include/openssl'
                     || ( grep { $_ eq $fn } @cryptoheaders_tmpl ))
                    && !( grep { $_ eq $fn } @cryptoskipheaders ));
            # The logic to add files to @sslheaders is much simpler...
-           push @sslheaders, $new_f if grep { $_ eq $fn } @sslheaders_tmpl;
+           $sslheaders{$new_f} = 1 if grep { $_ eq $fn } @sslheaders_tmpl;
        }
    }
    "";
 -}
 CRYPTOHEADERS={- join(" \\\n" . ' ' x 14,
-                      fill_lines(" ", $COLUMNS - 14, sort @cryptoheaders)) -}
+                      fill_lines(" ", $COLUMNS - 14, sort keys %cryptoheaders)) -}
 SSLHEADERS={- join(" \\\n" . ' ' x 11,
-                   fill_lines(" ", $COLUMNS - 11, sort @sslheaders)) -}
+                   fill_lines(" ", $COLUMNS - 11, sort keys %sslheaders)) -}
 ordinals: build_generated
 	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
                 --ordinals $(SRCDIR)/util/libcrypto.num \

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -601,6 +601,7 @@ my @chandlers = (
       massager => sub { return (); }
     },
     # Function returning function pointer declaration
+    # This sort of declaration may have a body (inline functions, for example)
     { regexp   => qr/(?:(typedef)\s?)?          # Possible typedef      ($1)
                      ((?:\w|\*|\s)*?)           # Return type           ($2)
                      \s?                        # Possible space
@@ -609,14 +610,15 @@ my @chandlers = (
                      (\(.*\))                   # Parameters            ($4)
                      \)>>>
                      <<<(\(.*\))>>>             # F.p. parameters       ($5)
-                     ;
+                     (?:<<<\{.*\}>>>|;)         # Body or semicolon
                     /x,
       massager => sub {
-          return ("", $3, 'F', "", "$2(*$4)$5", all_conds())
+          return ("", $3, 'T', "", "$2(*$4)$5", all_conds())
               if defined $1;
           return ("", $3, 'F', "$2(*)$5", "$2(*$4)$5", all_conds()); }
     },
     # Function pointer declaration, or typedef thereof
+    # This sort of declaration never has a function body
     { regexp   => qr/(?:(typedef)\s?)?          # Possible typedef      ($1)
                      ((?:\w|\*|\s)*?)           # Return type           ($2)
                      <<<\(\*([[:alpha:]_]\w*)\)>>> # T.d. or var name   ($3)
@@ -630,12 +632,13 @@ my @chandlers = (
       },
     },
     # Function declaration, or typedef thereof
+    # This sort of declaration may have a body (inline functions, for example)
     { regexp   => qr/(?:(typedef)\s?)?          # Possible typedef      ($1)
                      ((?:\w|\*|\s)*?)           # Return type           ($2)
                      \s?                        # Possible space
                      ([[:alpha:]_]\w*)          # Function name         ($3)
                      <<<(\(.*\))>>>             # Parameters            ($4)
-                     ;
+                     (?:<<<\{.*\}>>>|;)         # Body or semicolon
                     /x,
       massager => sub {
           return ("", $3, 'T', "", "$2$4", all_conds())


### PR DESCRIPTION
Function bodies in headers weren't a thing when OpenSSL::ParseC was
created, at least not as clearly as they are nowadays.  This module
must evolve to recognise them (and promptly ignore them).
