### PR TITLE
Teach EdDSA signature algorithms about AlgorithmIdentifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,12 @@ doc/man1/openssl-*.pod
 providers/common/der/der_digests_gen.c
 providers/common/der/der_dsa_gen.c
 providers/common/der/der_ec_gen.c
+providers/common/der/der_ecx_gen.c
 providers/common/der/der_rsa_gen.c
 providers/common/der/der_wrap_gen.c
 providers/common/include/prov/der_dsa.h
 providers/common/include/prov/der_ec.h
+providers/common/include/prov/der_ecx.h
 providers/common/include/prov/der_rsa.h
 providers/common/include/prov/der_digests.h
 providers/common/include/prov/der_wrap.h

--- a/doc/man7/EVP_SIGNATURE-ED25519.pod
+++ b/doc/man7/EVP_SIGNATURE-ED25519.pod
@@ -15,10 +15,23 @@ one-shot digest sign and digest verify using PureEdDSA and B<Ed25519> or B<Ed448
 (see RFC8032). It has associated private and public key formats compatible with
 RFC 8410.
 
+=head2 ED25591 and ED448 Signature Parameters
+
 No additional parameters can be set during one-shot signing or verification.
 In particular, because PureEdDSA is used, a digest must B<NOT> be specified when
 signing or verifying.
 See L<EVP_PKEY-X25519(7)> for information related to B<X25519> and B<X448> keys.
+
+The following signature parameters can be retrieved using
+EVP_PKEY_CTX_get_params().
+
+=over 4
+
+=item "algorithm-id" (B<OSSL_SIGNATURE_PARAM_ALGORITHM_ID>) <octet string>
+
+The parameters are described in L<provider-signature(7)>.
+
+=back
 
 =head1 NOTES
 

--- a/providers/common/der/ECX.asn1
+++ b/providers/common/der/ECX.asn1
@@ -1,0 +1,11 @@
+
+-- -------------------------------------------------------------------
+-- Taken from RFC 8410, 9  ASN.1 Module
+-- (https://tools.ietf.org/html/rfc8410#section-9)
+
+id-edwards-curve-algs OBJECT IDENTIFIER ::= { 1 3 101 }
+
+id-X25519        OBJECT IDENTIFIER ::= { id-edwards-curve-algs 110 }
+id-X448          OBJECT IDENTIFIER ::= { id-edwards-curve-algs 111 }
+id-Ed25519       OBJECT IDENTIFIER ::= { id-edwards-curve-algs 112 }
+id-Ed448         OBJECT IDENTIFIER ::= { id-edwards-curve-algs 113 }

--- a/providers/common/der/build.info
+++ b/providers/common/der/build.info
@@ -83,9 +83,12 @@ $COMMON=\
         $DER_RSA_COMMON \
         $DER_DSA_GEN $DER_DSA_AUX \
         $DER_EC_GEN $DER_EC_AUX \
-        $DER_ECX_GEN $DER_ECX_AUX \
         $DER_DIGESTS_GEN \
         $DER_WRAP_GEN
+
+IF[{- !$disabled{ec} -}]
+  $COMMON = $COMMON $DER_ECX_GEN $DER_ECX_AUX
+ENDIF
 
 SOURCE[../../libfips.a]=$COMMON $DER_RSA_FIPSABLE
 SOURCE[../../libnonfips.a]=$COMMON $DER_RSA_FIPSABLE

--- a/providers/common/der/build.info
+++ b/providers/common/der/build.info
@@ -50,6 +50,19 @@ DEPEND[${DER_EC_GEN/.c/.o}]=$DER_EC_H
 GENERATE[$DER_EC_H]=der_ec.h.in
 DEPEND[$DER_EC_H]=oids_to_c.pm
 
+#----- ECX
+$DER_ECX_H=../include/prov/der_ecx.h
+$DER_ECX_GEN=der_ecx_gen.c
+$DER_ECX_AUX=der_ecx_key.c
+
+GENERATE[$DER_ECX_GEN]=der_ecx_gen.c.in
+DEPEND[$DER_ECX_GEN]=oids_to_c.pm
+
+DEPEND[${DER_ECX_AUX/.c/.o}]=$DER_ECX_H
+DEPEND[${DER_ECX_GEN/.c/.o}]=$DER_ECX_H
+GENERATE[$DER_ECX_H]=der_ecx.h.in
+DEPEND[$DER_ECX_H]=oids_to_c.pm
+
 #----- KEY WRAP
 $DER_WRAP_H=../include/prov/der_wrap.h
 $DER_WRAP_GEN=der_wrap_gen.c
@@ -70,6 +83,7 @@ $COMMON=\
         $DER_RSA_COMMON \
         $DER_DSA_GEN $DER_DSA_AUX \
         $DER_EC_GEN $DER_EC_AUX \
+        $DER_ECX_GEN $DER_ECX_AUX \
         $DER_DIGESTS_GEN \
         $DER_WRAP_GEN
 

--- a/providers/common/der/der_ecx.h.in
+++ b/providers/common/der/der_ecx.h.in
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/der.h"
+#include "crypto/ecx.h"
+
+/* Well known OIDs precompiled */
+{-
+    $OUT = oids_to_c::process_leaves('providers/common/der/ECX.asn1',
+                                     { dir => $config{sourcedir},
+                                       filter => \&oids_to_c::filter_to_H });
+-}
+
+int DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec);
+int DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec);
+int DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec);
+int DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec);

--- a/providers/common/der/der_ecx_gen.c.in
+++ b/providers/common/der/der_ecx_gen.c.in
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "prov/der_ecx.h"
+
+/* Well known OIDs precompiled */
+{-
+    $OUT = oids_to_c::process_leaves('providers/common/der/ECX.asn1',
+                                     { dir => $config{sourcedir},
+                                       filter => \&oids_to_c::filter_to_C });
+-}

--- a/providers/common/der/der_ecx_key.c
+++ b/providers/common/der/der_ecx_key.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/obj_mac.h>
+#include "internal/packet.h"
+#include "prov/der_ecx.h"
+
+int DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec)
+{
+    return DER_w_begin_sequence(pkt, cont)
+        /* No parameters (yet?) */
+        && DER_w_precompiled(pkt, -1, der_oid_id_X25519,
+                             sizeof(der_oid_id_X25519))
+        && DER_w_end_sequence(pkt, cont);
+}
+
+int DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec)
+{
+    return DER_w_begin_sequence(pkt, cont)
+        /* No parameters (yet?) */
+        && DER_w_precompiled(pkt, -1, der_oid_id_X448,
+                             sizeof(der_oid_id_X448))
+        && DER_w_end_sequence(pkt, cont);
+}
+
+int DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec)
+{
+    return DER_w_begin_sequence(pkt, cont)
+        /* No parameters (yet?) */
+        && DER_w_precompiled(pkt, -1, der_oid_id_Ed25519,
+                             sizeof(der_oid_id_Ed25519))
+        && DER_w_end_sequence(pkt, cont);
+}
+
+int DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec)
+{
+    return DER_w_begin_sequence(pkt, cont)
+        /* No parameters (yet?) */
+        && DER_w_precompiled(pkt, -1, der_oid_id_Ed448,
+                             sizeof(der_oid_id_Ed448))
+        && DER_w_end_sequence(pkt, cont);
+}

--- a/providers/implementations/signature/build.info
+++ b/providers/implementations/signature/build.info
@@ -20,6 +20,7 @@ SOURCE[../../libnonfips.a]=rsa.c
 DEPEND[rsa.o]=../../common/include/prov/der_rsa.h
 DEPEND[dsa.o]=../../common/include/prov/der_dsa.h
 DEPEND[ecdsa.o]=../../common/include/prov/der_ec.h
+DEPEND[eddsa.o]=../../common/include/prov/der_ecx.h
 
 SOURCE[../../libfips.a]=mac_legacy.c
 SOURCE[../../libnonfips.a]=mac_legacy.c

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -143,15 +143,15 @@ subtest "generating certificate requests with Ed25519" => sub {
 
     SKIP: {
         skip "Ed25519 is not supported by this OpenSSL build", 2
-            if disabled("ec") || !@tmp_loader_hack;
+            if disabled("ec");
 
-        ok(run(app(["openssl", "req", @tmp_loader_hack,
+        ok(run(app(["openssl", "req",
                     "-config", srctop_file("test", "test.cnf"),
                     "-new", "-out", "testreq-ed25519.pem", "-utf8",
                     "-key", srctop_file("test", "tested25519.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", @tmp_loader_hack,
+        ok(run(app(["openssl", "req",
                     "-config", srctop_file("test", "test.cnf"),
                     "-verify", "-in", "testreq-ed25519.pem", "-noout"])),
            "Verifying signature on request");
@@ -163,15 +163,15 @@ subtest "generating certificate requests with Ed448" => sub {
 
     SKIP: {
         skip "Ed448 is not supported by this OpenSSL build", 2
-            if disabled("ec") || !@tmp_loader_hack;
+            if disabled("ec");
 
-        ok(run(app(["openssl", "req", @tmp_loader_hack,
+        ok(run(app(["openssl", "req",
                     "-config", srctop_file("test", "test.cnf"),
                     "-new", "-out", "testreq-ed448.pem", "-utf8",
                     "-key", srctop_file("test", "tested448.pem")])),
            "Generating request");
 
-        ok(run(app(["openssl", "req", @tmp_loader_hack,
+        ok(run(app(["openssl", "req",
                     "-config", srctop_file("test", "test.cnf"),
                     "-verify", "-in", "testreq-ed448.pem", "-noout"])),
            "Verifying signature on request");


### PR DESCRIPTION
The other signature algorithms know how to create their own
AlgorithmIdentifiers, but the EdDSA algorithms missed this.

Fixes #11875