### PR TITLE
Reduce compilation issues with VS2019 at high warning level

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -114,7 +114,7 @@ ASN1_BIT_STRING *c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
     ret->flags |= (ASN1_STRING_FLAG_BITS_LEFT | i); /* set */
 
     if (len-- > 1) {            /* using one because of the bits left byte */
-        s = OPENSSL_malloc((int)len);
+        s = (unsigned char *)OPENSSL_malloc((int)len);
         if (s == NULL) {
             i = ERR_R_MALLOC_FAILURE;
             goto err;
@@ -162,7 +162,7 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value)
     if ((a->length < (w + 1)) || (a->data == NULL)) {
         if (!value)
             return 1;         /* Don't need to set */
-        c = OPENSSL_clear_realloc(a->data, a->length, w + 1);
+        c = (unsigned char *)OPENSSL_clear_realloc(a->data, a->length, w + 1);
         if (c == NULL) {
             ASN1err(ASN1_F_ASN1_BIT_STRING_SET_BIT, ERR_R_MALLOC_FAILURE);
             return 0;
@@ -172,7 +172,7 @@ int ASN1_BIT_STRING_set_bit(ASN1_BIT_STRING *a, int n, int value)
         a->data = c;
         a->length = w + 1;
     }
-    a->data[w] = ((a->data[w]) & iv) | v;
+    a->data[w] = (unsigned char)(((a->data[w]) & iv) | v);
     while ((a->length > 0) && (a->data[a->length - 1] == 0))
         a->length--;
     return 1;

--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -67,7 +67,7 @@ void *ASN1_item_d2i_bio(const ASN1_ITEM *it, BIO *in, void *x)
         goto err;
 
     p = (const unsigned char *)b->data;
-    ret = ASN1_item_d2i(x, &p, len, it);
+    ret = ASN1_item_d2i((ASN1_VALUE **)x, &p, len, it);
  err:
     BUF_MEM_free(b);
     return ret;
@@ -84,7 +84,7 @@ void *ASN1_item_d2i_fp(const ASN1_ITEM *it, FILE *in, void *x)
         return NULL;
     }
     BIO_set_fp(b, in, BIO_NOCLOSE);
-    ret = ASN1_item_d2i_bio(it, b, x);
+    ret = (char *)ASN1_item_d2i_bio(it, b, x);
     BIO_free(b);
     return ret;
 }
@@ -121,7 +121,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
                 ASN1err(ASN1_F_ASN1_D2I_READ_BIO, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
-            i = BIO_read(in, &(b->data[len]), want);
+            i = BIO_read(in, &(b->data[len]), (int)want);
             if ((i < 0) && ((len - off) == 0)) {
                 ASN1err(ASN1_F_ASN1_D2I_READ_BIO, ASN1_R_NOT_ENOUGH_DATA);
                 goto err;
@@ -138,7 +138,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
 
         p = (unsigned char *)&(b->data[off]);
         q = p;
-        inf = ASN1_get_object(&q, &slen, &tag, &xclass, len - off);
+        inf = ASN1_get_object(&q, &slen, &tag, &xclass, (long)(len - off));
         if (inf & 0x80) {
             unsigned long e;
 
@@ -148,7 +148,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
             else
                 ERR_clear_error(); /* clear error */
         }
-        i = q - p;            /* header length */
+        i = (int)(q - p);       /* header length */
         off += i;               /* end of data */
 
         if (inf & 1) {
@@ -193,7 +193,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
                     }
                     want -= chunk;
                     while (chunk > 0) {
-                        i = BIO_read(in, &(b->data[len]), chunk);
+                        i = BIO_read(in, &(b->data[len]), (int)chunk);
                         if (i <= 0) {
                             ASN1err(ASN1_F_ASN1_D2I_READ_BIO,
                                     ASN1_R_NOT_ENOUGH_DATA);
@@ -228,7 +228,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
     }
 
     *pb = b;
-    return off;
+    return (int)off;
  err:
     BUF_MEM_free(b);
     return -1;

--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -36,7 +36,7 @@ int ASN1_digest(i2d_of_void *i2d, const EVP_MD *type, char *data,
         ASN1err(ASN1_F_ASN1_DIGEST, ERR_R_INTERNAL_ERROR);
         return 0;
     }
-    if ((str = OPENSSL_malloc(inl)) == NULL) {
+    if ((str = (unsigned char *)OPENSSL_malloc(inl)) == NULL) {
         ASN1err(ASN1_F_ASN1_DIGEST, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -79,7 +79,7 @@ int asn1_item_digest_with_libctx(const ASN1_ITEM *it, const EVP_MD *md,
      if (fetched_md == NULL)
          goto err;
 
-    ret = EVP_Digest(str, i, data, len, fetched_md, NULL);
+    ret = EVP_Digest(str, (size_t)i, data, len, fetched_md, NULL);
 err:
     OPENSSL_free(str);
     if (fetched_md != md)

--- a/crypto/asn1/a_dup.c
+++ b/crypto/asn1/a_dup.c
@@ -18,13 +18,13 @@ void *ASN1_dup(i2d_of_void *i2d, d2i_of_void *d2i, const void *x)
     unsigned char *b, *p;
     const unsigned char *p2;
     int i;
-    char *ret;
+    void *ret;
 
     if (x == NULL)
         return NULL;
 
     i = i2d(x, NULL);
-    b = OPENSSL_malloc(i + 10);
+    b = (unsigned char *)OPENSSL_malloc(i + 10);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_DUP, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -56,7 +56,7 @@ void *ASN1_item_dup(const ASN1_ITEM *it, const void *x)
     if (x == NULL)
         return NULL;
 
-    i = ASN1_item_i2d(x, &b, it);
+    i = ASN1_item_i2d((const ASN1_VALUE *)x, &b, it);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_DUP, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/asn1/a_gentm.c
+++ b/crypto/asn1/a_gentm.c
@@ -39,7 +39,7 @@ int ASN1_GENERALIZEDTIME_set_string(ASN1_GENERALIZEDTIME *s, const char *str)
     ASN1_GENERALIZEDTIME t;
 
     t.type = V_ASN1_GENERALIZEDTIME;
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = 0;
 

--- a/crypto/asn1/a_i2d_fp.c
+++ b/crypto/asn1/a_i2d_fp.c
@@ -41,7 +41,7 @@ int ASN1_i2d_bio(i2d_of_void *i2d, BIO *out, const void *x)
     if (n <= 0)
         return 0;
 
-    b = OPENSSL_malloc(n);
+    b = (char *)OPENSSL_malloc(n);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_I2D_BIO, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -89,7 +89,7 @@ int ASN1_item_i2d_bio(const ASN1_ITEM *it, BIO *out, const void *x)
     unsigned char *b = NULL;
     int i, j = 0, n, ret = 1;
 
-    n = ASN1_item_i2d(x, &b, it);
+    n = ASN1_item_i2d((const ASN1_VALUE *)x, &b, it);
     if (b == NULL) {
         ASN1err(ASN1_F_ASN1_ITEM_I2D_BIO, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -200,7 +200,7 @@ static size_t c2i_ibuf(unsigned char *b, int *pneg,
 
 int i2c_ASN1_INTEGER(ASN1_INTEGER *a, unsigned char **pp)
 {
-    return i2c_ibuf(a->data, a->length, a->type & V_ASN1_NEG, pp);
+    return (int)i2c_ibuf(a->data, a->length, a->type & V_ASN1_NEG, pp);
 }
 
 /* Convert big endian buffer into uint64_t, return 0 on error */
@@ -297,7 +297,7 @@ ASN1_INTEGER *c2i_ASN1_INTEGER(ASN1_INTEGER **a, const unsigned char **pp,
     } else
         ret = *a;
 
-    if (ASN1_STRING_set(ret, NULL, r) == 0)
+    if (ASN1_STRING_set(ret, NULL, (int)r) == 0)
         goto err;
 
     c2i_ibuf(ret->data, &neg, *pp, len);
@@ -347,7 +347,7 @@ static int asn1_string_set_int64(ASN1_STRING *a, int64_t r, int itype)
         off = asn1_put_uint64(tbuf, r);
         a->type &= ~V_ASN1_NEG;
     }
-    return ASN1_STRING_set(a, tbuf + off, sizeof(tbuf) - off);
+    return ASN1_STRING_set(a, tbuf + off, (int)(sizeof(tbuf) - off));
 }
 
 static int asn1_string_get_uint64(uint64_t *pr, const ASN1_STRING *a,
@@ -375,7 +375,7 @@ static int asn1_string_set_uint64(ASN1_STRING *a, uint64_t r, int itype)
 
     a->type = itype;
     off = asn1_put_uint64(tbuf, r);
-    return ASN1_STRING_set(a, tbuf + off, sizeof(tbuf) - off);
+    return ASN1_STRING_set(a, tbuf + off, (int)(sizeof(tbuf) - off));
 }
 
 /*
@@ -417,7 +417,7 @@ ASN1_INTEGER *d2i_ASN1_UINTEGER(ASN1_INTEGER **a, const unsigned char **pp,
      * We must OPENSSL_malloc stuff, even for 0 bytes otherwise it signifies
      * a missing NULL parameter.
      */
-    s = OPENSSL_malloc((int)len + 1);
+    s = (unsigned char *)OPENSSL_malloc((int)len + 1);
     if (s == NULL) {
         i = ERR_R_MALLOC_FAILURE;
         goto err;
@@ -625,6 +625,6 @@ int i2c_uint64_int(unsigned char *p, uint64_t r, int neg)
     size_t off;
 
     off = asn1_put_uint64(buf, r);
-    return i2c_ibuf(buf + off, sizeof(buf) - off, neg, &p);
+    return (int)i2c_ibuf(buf + off, sizeof(buf) - off, neg, &p);
 }
 

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -52,7 +52,7 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
     char strbuf[32];
     int (*cpyfunc) (unsigned long, void *) = NULL;
     if (len == -1)
-        len = strlen((const char *)in);
+        len = (int)strlen((const char *)in);
     if (!mask)
         mask = DIRSTRING_TYPE;
 
@@ -186,7 +186,7 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
         cpyfunc = cpy_utf8;
         break;
     }
-    if ((p = OPENSSL_malloc(outlen + 1)) == NULL) {
+    if ((p = (unsigned char *)OPENSSL_malloc(outlen + 1)) == NULL) {
         if (free_out)
             ASN1_STRING_free(dest);
         ASN1err(ASN1_F_ASN1_MBSTRING_NCOPY, ERR_R_MALLOC_FAILURE);
@@ -247,7 +247,7 @@ static int traverse_string(const unsigned char *p, int len, int inform,
 static int in_utf8(unsigned long value, void *arg)
 {
     int *nchar;
-    nchar = arg;
+    nchar = (int *)arg;
     (*nchar)++;
     return 1;
 }
@@ -257,7 +257,7 @@ static int in_utf8(unsigned long value, void *arg)
 static int out_utf8(unsigned long value, void *arg)
 {
     int *outlen;
-    outlen = arg;
+    outlen = (int *)arg;
     *outlen += UTF8_putc(NULL, -1, value);
     return 1;
 }
@@ -294,7 +294,7 @@ static int type_str(unsigned long value, void *arg)
 static int cpy_asc(unsigned long value, void *arg)
 {
     unsigned char **p, *q;
-    p = arg;
+    p = (unsigned char **)arg;
     q = *p;
     *q = (unsigned char)value;
     (*p)++;
@@ -306,7 +306,7 @@ static int cpy_asc(unsigned long value, void *arg)
 static int cpy_bmp(unsigned long value, void *arg)
 {
     unsigned char **p, *q;
-    p = arg;
+    p = (unsigned char **)arg;
     q = *p;
     *q++ = (unsigned char)((value >> 8) & 0xff);
     *q = (unsigned char)(value & 0xff);
@@ -319,7 +319,7 @@ static int cpy_bmp(unsigned long value, void *arg)
 static int cpy_univ(unsigned long value, void *arg)
 {
     unsigned char **p, *q;
-    p = arg;
+    p = (unsigned char **)arg;
     q = *p;
     *q++ = (unsigned char)((value >> 24) & 0xff);
     *q++ = (unsigned char)((value >> 16) & 0xff);
@@ -335,7 +335,7 @@ static int cpy_utf8(unsigned long value, void *arg)
 {
     unsigned char **p;
     int ret;
-    p = arg;
+    p = (unsigned char **)arg;
     /* We already know there is enough room so pass 0xff as the length */
     ret = UTF8_putc(*p, 0xff, value);
     *p += ret;

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -31,7 +31,7 @@ int i2d_ASN1_OBJECT(const ASN1_OBJECT *a, unsigned char **pp)
         return objsize;
 
     if (*pp == NULL) {
-        if ((p = allocated = OPENSSL_malloc(objsize)) == NULL) {
+        if ((p = allocated = (unsigned char *)OPENSSL_malloc(objsize)) == NULL) {
             ASN1err(ASN1_F_I2D_ASN1_OBJECT, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -62,7 +62,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
     if (num == 0)
         return 0;
     else if (num == -1)
-        num = strlen(buf);
+        num = (int)strlen(buf);
 
     p = buf;
     c = *(p++);
@@ -135,7 +135,7 @@ int a2d_ASN1_OBJECT(unsigned char *out, int olen, const char *buf, int num)
                 if (tmp != ftmp)
                     OPENSSL_free(tmp);
                 tmpsize = blsize + 32;
-                tmp = OPENSSL_malloc(tmpsize);
+                tmp = (char *)OPENSSL_malloc(tmpsize);
                 if (tmp == NULL)
                     goto err;
             }
@@ -191,7 +191,7 @@ int i2a_ASN1_OBJECT(BIO *bp, const ASN1_OBJECT *a)
         return BIO_write(bp, "NULL", 4);
     i = i2t_ASN1_OBJECT(buf, sizeof(buf), a);
     if (i > (int)(sizeof(buf) - 1)) {
-        if ((p = OPENSSL_malloc(i + 1)) == NULL) {
+        if ((p = (char *)OPENSSL_malloc(i + 1)) == NULL) {
             ASN1err(ASN1_F_I2A_ASN1_OBJECT, ERR_R_MALLOC_FAILURE);
             return -1;
         }
@@ -305,7 +305,7 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
     if ((data == NULL) || (ret->length < length)) {
         ret->length = 0;
         OPENSSL_free(data);
-        data = OPENSSL_malloc(length);
+        data = (unsigned char *)OPENSSL_malloc(length);
         if (data == NULL) {
             i = ERR_R_MALLOC_FAILURE;
             goto err;
@@ -336,7 +336,7 @@ ASN1_OBJECT *ASN1_OBJECT_new(void)
 {
     ASN1_OBJECT *ret;
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (ASN1_OBJECT *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1err(ASN1_F_ASN1_OBJECT_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -77,9 +77,9 @@ int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
         goto err;
     }
     inll = (size_t)inl;
-    buf_in = OPENSSL_malloc(inll);
+    buf_in = (unsigned char *)OPENSSL_malloc(inll);
     outll = outl = EVP_PKEY_size(pkey);
-    buf_out = OPENSSL_malloc(outll);
+    buf_out = (unsigned char *)OPENSSL_malloc(outll);
     if (buf_in == NULL || buf_out == NULL) {
         outl = 0;
         ASN1err(ASN1_F_ASN1_SIGN, ERR_R_MALLOC_FAILURE);
@@ -195,7 +195,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
         if (algor1 != NULL) {
             const unsigned char *pp = aid;
 
-            if (d2i_X509_ALGOR(&algor1, &pp, aid_len) == NULL) {
+            if (d2i_X509_ALGOR(&algor1, &pp, (int)aid_len) == NULL) {
                 ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
@@ -204,7 +204,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
         if (algor2 != NULL) {
             const unsigned char *pp = aid;
 
-            if (d2i_X509_ALGOR(&algor2, &pp, aid_len) == NULL) {
+            if (d2i_X509_ALGOR(&algor2, &pp, (int)aid_len) == NULL) {
                 ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ERR_R_INTERNAL_ERROR);
                 goto err;
             }
@@ -273,7 +273,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
         goto err;
     }
     outl = outll;
-    buf_out = OPENSSL_malloc(outll);
+    buf_out = (unsigned char *)OPENSSL_malloc(outll);
     if (buf_in == NULL || buf_out == NULL) {
         outl = 0;
         ASN1err(ASN1_F_ASN1_ITEM_SIGN_CTX, ERR_R_MALLOC_FAILURE);
@@ -288,7 +288,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
     OPENSSL_free(signature->data);
     signature->data = buf_out;
     buf_out = NULL;
-    signature->length = outl;
+    signature->length = (int)outl;
     /*
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
@@ -298,5 +298,5 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
  err:
     OPENSSL_clear_free((char *)buf_in, inl);
     OPENSSL_clear_free((char *)buf_out, outll);
-    return outl;
+    return (int)outl;
 }

--- a/crypto/asn1/a_strex.c
+++ b/crypto/asn1/a_strex.c
@@ -39,7 +39,7 @@ static int send_bio_chars(void *arg, const void *buf, int len)
 {
     if (!arg)
         return 1;
-    if (BIO_write(arg, buf, len) != len)
+    if (BIO_write((BIO *)arg, buf, len) != len)
         return 0;
     return 1;
 }
@@ -280,7 +280,7 @@ static int do_dump(unsigned long lflags, char_io *io_ch, void *arg,
     t.type = str->type;
     t.value.ptr = (char *)str;
     der_len = i2d_ASN1_TYPE(&t, NULL);
-    if ((der_buf = OPENSSL_malloc(der_len)) == NULL) {
+    if ((der_buf = (unsigned char *)OPENSSL_malloc(der_len)) == NULL) {
         ASN1err(ASN1_F_DO_DUMP, ERR_R_MALLOC_FAILURE);
         return -1;
     }
@@ -344,7 +344,7 @@ static int do_print_ex(char_io *io_ch, void *arg, unsigned long lflags,
     if (lflags & ASN1_STRFLGS_SHOW_TYPE) {
         const char *tagname;
         tagname = ASN1_tag2str(type);
-        outlen += strlen(tagname);
+        outlen += (int)strlen(tagname);
         if (!io_ch(arg, tagname, outlen) || !io_ch(arg, ":", 1))
             return -1;
         outlen++;
@@ -525,7 +525,7 @@ static int do_name_ex(char_io *io_ch, void *arg, const X509_NAME *n,
                     objbuf = "";
                 }
             }
-            objlen = strlen(objbuf);
+            objlen = (int)strlen(objbuf);
             if (!io_ch(arg, objbuf, objlen))
                 return -1;
             if ((objlen < fld_len) && (flags & XN_FLAG_FN_ALIGN)) {

--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -159,7 +159,7 @@ static ASN1_STRING_TABLE *stable_get(int nid)
     tmp = ASN1_STRING_TABLE_get(nid);
     if (tmp != NULL && tmp->flags & STABLE_FLAGS_MALLOC)
         return tmp;
-    if ((rv = OPENSSL_zalloc(sizeof(*rv))) == NULL) {
+    if ((rv = (ASN1_STRING_TABLE *)OPENSSL_zalloc(sizeof(*rv))) == NULL) {
         ASN1err(ASN1_F_STABLE_GET, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -288,7 +288,7 @@ ASN1_TIME *asn1_time_from_tm(ASN1_TIME *s, struct tm *ts, int type)
     if (tmps == NULL)
         return NULL;
 
-    if (!ASN1_STRING_set(tmps, NULL, len))
+    if (!ASN1_STRING_set(tmps, NULL, (int)len))
         goto err;
 
     tmps->type = type;
@@ -382,7 +382,7 @@ int ASN1_TIME_set_string_X509(ASN1_TIME *s, const char *str)
     struct tm tm;
     int rv = 0;
 
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = ASN1_STRING_FLAG_X509_TIME;
 
@@ -418,7 +418,7 @@ int ASN1_TIME_set_string_X509(ASN1_TIME *s, const char *str)
              * to a piece of memory allocated outside of this function.
              * new t.data would be freed after ASN1_STRING_copy is done.
              */
-            t.data = OPENSSL_zalloc(t.length + 1);
+            t.data = (unsigned char *)OPENSSL_zalloc(t.length + 1);
             if (t.data == NULL)
                 goto out;
             memcpy(t.data, str + 2, t.length);

--- a/crypto/asn1/a_type.c
+++ b/crypto/asn1/a_type.c
@@ -35,7 +35,7 @@ void ASN1_TYPE_set(ASN1_TYPE *a, int type, void *value)
     if (type == V_ASN1_BOOLEAN)
         a->value.boolean = value ? 0xff : 0;
     else
-        a->value.ptr = value;
+        a->value.ptr = (char *)value;
 }
 
 int ASN1_TYPE_set1(ASN1_TYPE *a, int type, const void *value)
@@ -45,13 +45,13 @@ int ASN1_TYPE_set1(ASN1_TYPE *a, int type, const void *value)
         ASN1_TYPE_set(a, type, p);
     } else if (type == V_ASN1_OBJECT) {
         ASN1_OBJECT *odup;
-        odup = OBJ_dup(value);
+        odup = OBJ_dup((const ASN1_OBJECT *)value);
         if (!odup)
             return 0;
         ASN1_TYPE_set(a, type, odup);
     } else {
         ASN1_STRING *sdup;
-        sdup = ASN1_STRING_dup(value);
+        sdup = ASN1_STRING_dup((const ASN1_STRING *)value);
         if (!sdup)
             return 0;
         ASN1_TYPE_set(a, type, sdup);

--- a/crypto/asn1/a_utctm.c
+++ b/crypto/asn1/a_utctm.c
@@ -36,7 +36,7 @@ int ASN1_UTCTIME_set_string(ASN1_UTCTIME *s, const char *str)
     ASN1_UTCTIME t;
 
     t.type = V_ASN1_UTCTIME;
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = 0;
 

--- a/crypto/asn1/a_verify.c
+++ b/crypto/asn1/a_verify.c
@@ -52,7 +52,7 @@ int ASN1_verify(i2d_of_void *i2d, X509_ALGOR *a, ASN1_BIT_STRING *signature,
         ASN1err(ASN1_F_ASN1_VERIFY, ERR_R_INTERNAL_ERROR);
         goto err;
     }
-    buf_in = OPENSSL_malloc((unsigned int)inl);
+    buf_in = (unsigned char *)OPENSSL_malloc((unsigned int)inl);
     if (buf_in == NULL) {
         ASN1err(ASN1_F_ASN1_VERIFY, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -221,7 +221,7 @@ const EVP_PKEY_ASN1_METHOD *EVP_PKEY_get0_asn1(const EVP_PKEY *pkey)
 EVP_PKEY_ASN1_METHOD *EVP_PKEY_asn1_new(int id, int flags,
                                         const char *pem_str, const char *info)
 {
-    EVP_PKEY_ASN1_METHOD *ameth = OPENSSL_zalloc(sizeof(*ameth));
+    EVP_PKEY_ASN1_METHOD *ameth = (EVP_PKEY_ASN1_METHOD *)OPENSSL_zalloc(sizeof(*ameth));
 
     if (ameth == NULL)
         return NULL;

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -159,7 +159,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
         if (r & 0x80)
             goto err;
         /* Update copy length */
-        cpy_len -= cpy_start - orig_der;
+        cpy_len -= (int)(cpy_start - orig_der);
         /*
          * For IMPLICIT tagging the length should match the original length
          * and constructed flag should be consistent.
@@ -192,7 +192,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
 
     /* Allocate buffer for new encoding */
 
-    new_der = OPENSSL_malloc(len);
+    new_der = (unsigned char *)OPENSSL_malloc(len);
     if (new_der == NULL)
         goto err;
 
@@ -239,7 +239,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
 
 static int asn1_cb(const char *elem, int len, void *bitstr)
 {
-    tag_exp_arg *arg = bitstr;
+    tag_exp_arg *arg = (tag_exp_arg *)bitstr;
     int i;
     int utype;
     int vlen = 0;
@@ -254,8 +254,8 @@ static int asn1_cb(const char *elem, int len, void *bitstr)
         /* Look for the ':' in name value pairs */
         if (*p == ':') {
             vstart = p + 1;
-            vlen = len - (vstart - elem);
-            len = p - elem;
+            vlen = (int)(len - (vstart - elem));
+            len = (int)(p - elem);
             break;
         }
     }
@@ -363,7 +363,7 @@ static int parse_tagging(const char *vstart, int vlen, int *ptag, int *pclass)
     *ptag = tag_num;
     /* If we have non numeric characters, parse them */
     if (eptr)
-        vlen -= eptr - vstart;
+        vlen -= (int)(eptr - vstart);
     else
         vlen = 0;
     if (vlen) {
@@ -564,7 +564,7 @@ static int asn1_str2tag(const char *tagstr, int len)
     };
 
     if (len == -1)
-        len = strlen(tagstr);
+        len = (int)strlen(tagstr);
 
     tntmp = tnst;
     for (i = 0; i < OSSL_NELEM(tnst); i++, tntmp++) {
@@ -755,7 +755,7 @@ static int bitstr_cb(const char *elem, int len, void *bitstr)
         ASN1err(ASN1_F_BITSTR_CB, ASN1_R_INVALID_NUMBER);
         return 0;
     }
-    if (!ASN1_BIT_STRING_set_bit(bitstr, bitnum, 1)) {
+    if (!ASN1_BIT_STRING_set_bit((ASN1_BIT_STRING *)bitstr, bitnum, 1)) {
         ASN1err(ASN1_F_BITSTR_CB, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -764,7 +764,7 @@ static int bitstr_cb(const char *elem, int len, void *bitstr)
 
 static int mask_cb(const char *elem, int len, void *arg)
 {
-    unsigned long *pmask = arg, tmpmask;
+    unsigned long *pmask = (unsigned long *)arg, tmpmask;
     int tag;
     if (elem == NULL)
         return 0;

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -164,9 +164,9 @@ void ASN1_put_object(unsigned char **pp, int constructed, int length, int tag,
     i = (constructed) ? V_ASN1_CONSTRUCTED : 0;
     i |= (xclass & V_ASN1_PRIVATE);
     if (tag < 31) {
-        *(p++) = i | (tag & V_ASN1_PRIMITIVE_TAG);
+        *(p++) = (unsigned char)(i | (tag & V_ASN1_PRIMITIVE_TAG));
     } else {
-        *(p++) = i | V_ASN1_PRIMITIVE_TAG;
+        *(p++) = (unsigned char)(i | V_ASN1_PRIMITIVE_TAG);
         for (i = 0, ttag = tag; ttag > 0; i++)
             ttag >>= 7;
         ttag = i;
@@ -206,7 +206,7 @@ static void asn1_put_length(unsigned char **pp, int length)
         len = length;
         for (i = 0; len > 0; i++)
             len >>= 8;
-        *(p++) = i | 0x80;
+        *(p++) = (unsigned char)(i | 0x80);
         len = i;
         while (i-- > 0) {
             p[i] = length & 0xff;
@@ -278,7 +278,7 @@ ASN1_STRING *ASN1_STRING_dup(const ASN1_STRING *str)
 int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len_in)
 {
     unsigned char *c;
-    const char *data = _data;
+    const char *data = (const char *)_data;
     size_t len;
 
     if (len_in < 0) {
@@ -299,7 +299,7 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len_in)
     }
     if ((size_t)str->length <= len || str->data == NULL) {
         c = str->data;
-        str->data = OPENSSL_realloc(c, len + 1);
+        str->data = (unsigned char *)OPENSSL_realloc(c, len + 1);
         if (str->data == NULL) {
             ASN1err(ASN1_F_ASN1_STRING_SET, ERR_R_MALLOC_FAILURE);
             str->data = c;
@@ -318,7 +318,7 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len_in)
 void ASN1_STRING_set0(ASN1_STRING *str, void *data, int len)
 {
     OPENSSL_free(str->data);
-    str->data = data;
+    str->data = (unsigned char *)data;
     str->length = len;
 }
 
@@ -331,7 +331,7 @@ ASN1_STRING *ASN1_STRING_type_new(int type)
 {
     ASN1_STRING *ret;
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (ASN1_STRING *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1err(ASN1_F_ASN1_STRING_TYPE_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -430,7 +430,7 @@ char *sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text, const char *sep,
         if (length > max_len)
             return NULL;
     }
-    if ((result = OPENSSL_malloc(length + 1)) == NULL)
+    if ((result = (char *)OPENSSL_malloc(length + 1)) == NULL)
         return NULL;
 
     for (i = 0, p = result; i < sk_ASN1_UTF8STRING_num(text); ++i) {

--- a/crypto/asn1/asn1_par.c
+++ b/crypto/asn1/asn1_par.c
@@ -122,7 +122,7 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
             ret = 0;
             goto end;
         }
-        hl = (p - op);
+        hl = (int)(p - op);
         length -= hl;
         /*
          * if j == 0x21 it is a constructed indefinite length object
@@ -144,14 +144,14 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
             if ((j == 0x21) && (len == 0)) {
                 for (;;) {
                     r = asn1_parse2(bp, &p, (long)(tot - p),
-                                    offset + (p - *pp), depth + 1,
+                                    (int)(offset + (p - *pp)), depth + 1,
                                     indent, dump);
                     if (r == 0) {
                         ret = 0;
                         goto end;
                     }
                     if ((r == 2) || (p >= tot)) {
-                        len = p - sp;
+                        len = (long)(p - sp);
                         break;
                     }
                 }
@@ -161,13 +161,13 @@ static int asn1_parse2(BIO *bp, const unsigned char **pp, long length,
                 while (p < ep) {
                     sp = p;
                     r = asn1_parse2(bp, &p, tmp,
-                                    offset + (p - *pp), depth + 1,
+                                    (int)(offset + (p - *pp)), depth + 1,
                                     indent, dump);
                     if (r == 0) {
                         ret = 0;
                         goto end;
                     }
-                    tmp -= p - sp;
+                    tmp -= (long)(p - sp);
                 }
             }
         } else if (xclass != 0) {

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -337,7 +337,7 @@ static int asn1_output_data(BIO *out, BIO *data, ASN1_VALUE *val, int flags,
                             const ASN1_ITEM *it)
 {
     BIO *tmpbio;
-    const ASN1_AUX *aux = it->funcs;
+    const ASN1_AUX *aux = (const ASN1_AUX *)it->funcs;
     ASN1_STREAM_ARG sarg;
     int rv = 1;
 
@@ -524,7 +524,7 @@ int SMIME_crlf_copy(BIO *in, BIO *out, int flags)
         if (flags & SMIME_TEXT)
             BIO_printf(out, "Content-Type: text/plain\r\n\r\n");
         while ((len = BIO_gets(in, linebuf, MAX_SMLEN)) > 0) {
-            eol = strip_eol(linebuf, &len, flags);
+            eol = (char)strip_eol(linebuf, &len, flags);
             if (len) {
                 /* Not EOF: write out all CRLF */
                 if (flags & SMIME_ASCIICRLF) {
@@ -594,7 +594,7 @@ static int multi_split(BIO *bio, const char *bound, STACK_OF(BIO) **ret)
     STACK_OF(BIO) *parts;
     char state, part, first;
 
-    blen = strlen(bound);
+    blen = (int)strlen(bound);
     part = 0;
     state = 0;
     first = 1;
@@ -603,7 +603,7 @@ static int multi_split(BIO *bio, const char *bound, STACK_OF(BIO) **ret)
     if (*ret == NULL)
         return 0;
     while ((len = BIO_gets(bio, linebuf, MAX_SMLEN)) > 0) {
-        state = mime_bound_check(linebuf, len, bound, blen);
+        state = (char)mime_bound_check(linebuf, len, bound, blen);
         if (state == 1) {
             first = 1;
             part++;
@@ -824,15 +824,15 @@ static MIME_HEADER *mime_hdr_new(const char *name, const char *value)
         if ((tmpname = OPENSSL_strdup(name)) == NULL)
             return NULL;
         for (p = tmpname; *p; p++)
-            *p = ossl_tolower(*p);
+            *p = (char)ossl_tolower(*p);
     }
     if (value) {
         if ((tmpval = OPENSSL_strdup(value)) == NULL)
             goto err;
         for (p = tmpval; *p; p++)
-            *p = ossl_tolower(*p);
+            *p = (char)ossl_tolower(*p);
     }
-    mhdr = OPENSSL_malloc(sizeof(*mhdr));
+    mhdr = (MIME_HEADER *)OPENSSL_malloc(sizeof(*mhdr));
     if (mhdr == NULL)
         goto err;
     mhdr->name = tmpname;
@@ -858,7 +858,7 @@ static int mime_hdr_addparam(MIME_HEADER *mhdr, const char *name, const char *va
         if (!tmpname)
             goto err;
         for (p = tmpname; *p; p++)
-            *p = ossl_tolower(*p);
+            *p = (char)ossl_tolower(*p);
     }
     if (value) {
         tmpval = OPENSSL_strdup(value);
@@ -866,7 +866,7 @@ static int mime_hdr_addparam(MIME_HEADER *mhdr, const char *name, const char *va
             goto err;
     }
     /* Parameter values are case sensitive so leave as is */
-    mparam = OPENSSL_malloc(sizeof(*mparam));
+    mparam = (MIME_PARAM *)OPENSSL_malloc(sizeof(*mparam));
     if (mparam == NULL)
         goto err;
     mparam->param_name = tmpname;
@@ -951,9 +951,9 @@ static void mime_param_free(MIME_PARAM *param)
 static int mime_bound_check(char *line, int linelen, const char *bound, int blen)
 {
     if (linelen == -1)
-        linelen = strlen(line);
+        linelen = (int)strlen(line);
     if (blen == -1)
-        blen = strlen(bound);
+        blen = (int)strlen(bound);
     /* Quickly eliminate if line length too short */
     if (blen + 2 > linelen)
         return 0;

--- a/crypto/asn1/asn_moid.c
+++ b/crypto/asn1/asn_moid.c
@@ -83,7 +83,7 @@ static int do_create(const char *value, const char *name)
             p--;
         }
         p++;
-        if ((lntmp = OPENSSL_malloc((p - ln) + 1)) == NULL) {
+        if ((lntmp = (char *)OPENSSL_malloc((p - ln) + 1)) == NULL) {
             ASN1err(ASN1_F_DO_CREATE, ERR_R_MALLOC_FAILURE);
             return 0;
         }

--- a/crypto/asn1/asn_pack.c
+++ b/crypto/asn1/asn_pack.c
@@ -29,7 +29,7 @@ ASN1_STRING *ASN1_item_pack(void *obj, const ASN1_ITEM *it, ASN1_STRING **oct)
     OPENSSL_free(octmp->data);
     octmp->data = NULL;
 
-    if ((octmp->length = ASN1_item_i2d(obj, &octmp->data, it)) == 0) {
+    if ((octmp->length = ASN1_item_i2d((const ASN1_VALUE *)obj, &octmp->data, it)) == 0) {
         ASN1err(ASN1_F_ASN1_ITEM_PACK, ASN1_R_ENCODE_ERROR);
         goto err;
     }

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -100,7 +100,7 @@ const BIO_METHOD *BIO_f_asn1(void)
 
 static int asn1_bio_new(BIO *b)
 {
-    BIO_ASN1_BUF_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    BIO_ASN1_BUF_CTX *ctx = (BIO_ASN1_BUF_CTX *)OPENSSL_zalloc(sizeof(*ctx));
 
     if (ctx == NULL)
         return 0;
@@ -116,7 +116,7 @@ static int asn1_bio_new(BIO *b)
 
 static int asn1_bio_init(BIO_ASN1_BUF_CTX *ctx, int size)
 {
-    if ((ctx->buf = OPENSSL_malloc(size)) == NULL) {
+    if ((ctx->buf = (unsigned char *)OPENSSL_malloc(size)) == NULL) {
         ASN1err(ASN1_F_ASN1_BIO_INIT, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -134,7 +134,7 @@ static int asn1_bio_free(BIO *b)
     if (b == NULL)
         return 0;
 
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ASN1_BUF_CTX *)BIO_get_data(b);
     if (ctx == NULL)
         return 0;
 
@@ -153,7 +153,7 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
     unsigned char *p;
     BIO *next;
 
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ASN1_BUF_CTX *)BIO_get_data(b);
     next = BIO_next(b);
     if (in == NULL || inl < 0 || ctx == NULL || next == NULL)
         return 0;
@@ -297,7 +297,7 @@ static int asn1_bio_read(BIO *b, char *in, int inl)
 
 static int asn1_bio_puts(BIO *b, const char *str)
 {
-    return asn1_bio_write(b, str, strlen(str));
+    return asn1_bio_write(b, str, (int)strlen(str));
 }
 
 static int asn1_bio_gets(BIO *b, char *str, int size)
@@ -323,32 +323,32 @@ static long asn1_bio_ctrl(BIO *b, int cmd, long arg1, void *arg2)
     long ret = 1;
     BIO *next;
 
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ASN1_BUF_CTX *)BIO_get_data(b);
     if (ctx == NULL)
         return 0;
     next = BIO_next(b);
     switch (cmd) {
 
     case BIO_C_SET_PREFIX:
-        ex_func = arg2;
+        ex_func = (BIO_ASN1_EX_FUNCS *)arg2;
         ctx->prefix = ex_func->ex_func;
         ctx->prefix_free = ex_func->ex_free_func;
         break;
 
     case BIO_C_GET_PREFIX:
-        ex_func = arg2;
+        ex_func = (BIO_ASN1_EX_FUNCS *)arg2;
         ex_func->ex_func = ctx->prefix;
         ex_func->ex_free_func = ctx->prefix_free;
         break;
 
     case BIO_C_SET_SUFFIX:
-        ex_func = arg2;
+        ex_func = (BIO_ASN1_EX_FUNCS *)arg2;
         ctx->suffix = ex_func->ex_func;
         ctx->suffix_free = ex_func->ex_free_func;
         break;
 
     case BIO_C_GET_SUFFIX:
-        ex_func = arg2;
+        ex_func = (BIO_ASN1_EX_FUNCS *)arg2;
         ex_func->ex_func = ctx->suffix;
         ex_func->ex_free_func = ctx->suffix_free;
         break;

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -54,14 +54,14 @@ BIO *BIO_new_NDEF(BIO *out, ASN1_VALUE *val, const ASN1_ITEM *it)
 {
     NDEF_SUPPORT *ndef_aux = NULL;
     BIO *asn_bio = NULL;
-    const ASN1_AUX *aux = it->funcs;
+    const ASN1_AUX *aux = (const ASN1_AUX *)it->funcs;
     ASN1_STREAM_ARG sarg;
 
     if (!aux || !aux->asn1_cb) {
         ASN1err(ASN1_F_BIO_NEW_NDEF, ASN1_R_STREAMING_NOT_SUPPORTED);
         return NULL;
     }
-    ndef_aux = OPENSSL_zalloc(sizeof(*ndef_aux));
+    ndef_aux = (NDEF_SUPPORT *)OPENSSL_zalloc(sizeof(*ndef_aux));
     asn_bio = BIO_new(BIO_f_asn1());
     if (ndef_aux == NULL || asn_bio == NULL)
         goto err;
@@ -114,7 +114,7 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     ndef_aux = *(NDEF_SUPPORT **)parg;
 
     derlen = ASN1_item_ndef_i2d(ndef_aux->val, NULL, ndef_aux->it);
-    if ((p = OPENSSL_malloc(derlen)) == NULL) {
+    if ((p = (unsigned char *)OPENSSL_malloc(derlen)) == NULL) {
         ASN1err(ASN1_F_NDEF_PREFIX, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -126,7 +126,7 @@ static int ndef_prefix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     if (*ndef_aux->boundary == NULL)
         return 0;
 
-    *plen = *ndef_aux->boundary - *pbuf;
+    *plen = (int)(*ndef_aux->boundary - *pbuf);
 
     return 1;
 }
@@ -173,7 +173,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
 
     ndef_aux = *(NDEF_SUPPORT **)parg;
 
-    aux = ndef_aux->it->funcs;
+    aux = (const ASN1_AUX *)ndef_aux->it->funcs;
 
     /* Finalize structures */
     sarg.ndef_bio = ndef_aux->ndef_bio;
@@ -186,7 +186,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     derlen = ASN1_item_ndef_i2d(ndef_aux->val, NULL, ndef_aux->it);
     if (derlen < 0)
         return 0;
-    if ((p = OPENSSL_malloc(derlen)) == NULL) {
+    if ((p = (unsigned char *)OPENSSL_malloc(derlen)) == NULL) {
         ASN1err(ASN1_F_NDEF_SUFFIX, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -198,7 +198,7 @@ static int ndef_suffix(BIO *b, unsigned char **pbuf, int *plen, void *parg)
     if (*ndef_aux->boundary == NULL)
         return 0;
     *pbuf = *ndef_aux->boundary;
-    *plen = derlen - (*ndef_aux->boundary - ndef_aux->derbuf);
+    *plen = (int)(derlen - (*ndef_aux->boundary - ndef_aux->derbuf));
 
     return 1;
 }

--- a/crypto/asn1/evp_asn1.c
+++ b/crypto/asn1/evp_asn1.c
@@ -112,7 +112,7 @@ int ASN1_TYPE_get_int_octetstring(const ASN1_TYPE *a, long *num,
         goto err;
     }
 
-    atmp = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(asn1_int_oct), a);
+    atmp = (asn1_int_oct *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(asn1_int_oct), a);
 
     if (atmp == NULL)
         goto err;

--- a/crypto/asn1/f_int.c
+++ b/crypto/asn1/f_int.c
@@ -106,7 +106,7 @@ int a2i_ASN1_INTEGER(BIO *bp, ASN1_INTEGER *bs, char *buf, int size)
         }
         i /= 2;
         if (num + i > slen) {
-            sp = OPENSSL_clear_realloc(s, slen, num + i * 2);
+            sp = (unsigned char *)OPENSSL_clear_realloc(s, slen, num + i * 2);
             if (sp == NULL) {
                 ASN1err(ASN1_F_A2I_ASN1_INTEGER, ERR_R_MALLOC_FAILURE);
                 OPENSSL_free(s);

--- a/crypto/asn1/f_string.c
+++ b/crypto/asn1/f_string.c
@@ -97,7 +97,7 @@ int a2i_ASN1_STRING(BIO *bp, ASN1_STRING *bs, char *buf, int size)
         }
         i /= 2;
         if (num + i > slen) {
-            sp = OPENSSL_realloc(s, (unsigned int)num + i * 2);
+            sp = (unsigned char *)OPENSSL_realloc(s, (unsigned int)num + i * 2);
             if (sp == NULL) {
                 ASN1err(ASN1_F_A2I_ASN1_STRING, ERR_R_MALLOC_FAILURE);
                 OPENSSL_free(s);

--- a/crypto/asn1/i2d_pr.c
+++ b/crypto/asn1/i2d_pr.c
@@ -43,7 +43,7 @@ int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp)
             && OSSL_ENCODER_CTX_get_encoder(ctx) != NULL
             && OSSL_ENCODER_to_bio(ctx, out)
             && BIO_get_mem_ptr(out, &buf) > 0) {
-            ret = buf->length;
+            ret = (int)buf->length;
 
             if (pp != NULL) {
                 if (*pp == NULL) {

--- a/crypto/asn1/p5_pbe.c
+++ b/crypto/asn1/p5_pbe.c
@@ -45,7 +45,7 @@ int PKCS5_pbe_set0_algor(X509_ALGOR *algor, int alg, int iter,
     if (!saltlen)
         saltlen = PKCS5_SALT_LEN;
 
-    sstr = OPENSSL_malloc(saltlen);
+    sstr = (unsigned char *)OPENSSL_malloc(saltlen);
     if (sstr == NULL) {
         ASN1err(ASN1_F_PKCS5_PBE_SET0_ALGOR, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/asn1/p5_pbev2.c
+++ b/crypto/asn1/p5_pbev2.c
@@ -163,7 +163,7 @@ X509_ALGOR *PKCS5_pbkdf2_set(int iter, unsigned char *salt, int saltlen,
 
     if (saltlen == 0)
         saltlen = PKCS5_SALT_LEN;
-    if ((osalt->data = OPENSSL_malloc(saltlen)) == NULL)
+    if ((osalt->data = (unsigned char *)OPENSSL_malloc(saltlen)) == NULL)
         goto merr;
 
     osalt->length = saltlen;

--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -159,10 +159,10 @@ static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, size_t saltlen,
         saltlen = PKCS5_SALT_LEN;
 
     /* This will either copy salt or grow the buffer */
-    if (ASN1_STRING_set(sparam->salt, salt, saltlen) == 0)
+    if (ASN1_STRING_set(sparam->salt, salt, (int)saltlen) == 0)
         goto merr;
 
-    if (salt == NULL && RAND_bytes(sparam->salt->data, saltlen) <= 0)
+    if (salt == NULL && RAND_bytes(sparam->salt->data, (int)saltlen) <= 0)
         goto err;
 
     if (ASN1_INTEGER_set_uint64(sparam->costParameter, N) == 0)
@@ -227,7 +227,7 @@ int PKCS5_v2_scrypt_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
 
     /* Decode parameter */
 
-    sparam = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(SCRYPT_PARAMS), param);
+    sparam = (SCRYPT_PARAMS *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(SCRYPT_PARAMS), param);
 
     if (sparam == NULL) {
         EVPerr(EVP_F_PKCS5_V2_SCRYPT_KEYIVGEN, EVP_R_DECODE_ERROR);

--- a/crypto/asn1/t_pkey.c
+++ b/crypto/asn1/t_pkey.c
@@ -70,7 +70,7 @@ int ASN1_bn_print(BIO *bp, const char *number, const BIGNUM *num,
     }
 
     buflen = BN_num_bytes(num) + 1;
-    buf = tmp = OPENSSL_malloc(buflen);
+    buf = tmp = (unsigned char *)OPENSSL_malloc(buflen);
     if (buf == NULL)
         goto err;
     buf[0] = 0;

--- a/crypto/asn1/tasn_enc.c
+++ b/crypto/asn1/tasn_enc.c
@@ -62,7 +62,7 @@ static int asn1_item_flags_i2d(const ASN1_VALUE *val, unsigned char **out,
         len = ASN1_item_ex_i2d(&val, NULL, it, -1, flags);
         if (len <= 0)
             return len;
-        if ((buf = OPENSSL_malloc(len)) == NULL) {
+        if ((buf = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
             ASN1err(ASN1_F_ASN1_ITEM_FLAGS_I2D, ERR_R_MALLOC_FAILURE);
             return -1;
         }
@@ -86,7 +86,7 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
     const ASN1_TEMPLATE *tt = NULL;
     int i, seqcontlen, seqlen, ndef = 1;
     const ASN1_EXTERN_FUNCS *ef;
-    const ASN1_AUX *aux = it->funcs;
+    const ASN1_AUX *aux = (const ASN1_AUX *)it->funcs;
     ASN1_aux_const_cb *asn1_cb = NULL;
 
     if ((it->itype != ASN1_ITYPE_PRIMITIVE) && *pval == NULL)
@@ -126,7 +126,7 @@ int ASN1_item_ex_i2d(const ASN1_VALUE **pval, unsigned char **out,
 
     case ASN1_ITYPE_EXTERN:
         /* If new style i2d it does all the work */
-        ef = it->funcs;
+        ef = (const ASN1_EXTERN_FUNCS *)it->funcs;
         return ef->asn1_ex_i2d(pval, out, it, tag, aclass);
 
     case ASN1_ITYPE_NDEF_SEQUENCE:
@@ -359,7 +359,7 @@ typedef struct {
 
 static int der_cmp(const void *a, const void *b)
 {
-    const DER_ENC *d1 = a, *d2 = b;
+    const DER_ENC *d1 = (const DER_ENC *)a, *d2 = (const DER_ENC *)b;
     int cmplen, i;
     cmplen = (d1->length < d2->length) ? d1->length : d2->length;
     i = memcmp(d1->data, d2->data, cmplen);
@@ -384,11 +384,11 @@ static int asn1_set_seq_out(STACK_OF(const_ASN1_VALUE) *sk,
         if (sk_const_ASN1_VALUE_num(sk) < 2)
             do_sort = 0;
         else {
-            derlst = OPENSSL_malloc(sk_const_ASN1_VALUE_num(sk)
-                                    * sizeof(*derlst));
+            derlst = (DER_ENC *)OPENSSL_malloc(sk_const_ASN1_VALUE_num(sk)
+                                               * sizeof(*derlst));
             if (derlst == NULL)
                 return 0;
-            tmpdat = OPENSSL_malloc(skcontlen);
+            tmpdat = (unsigned char *)OPENSSL_malloc(skcontlen);
             if (tmpdat == NULL) {
                 OPENSSL_free(derlst);
                 return 0;
@@ -503,7 +503,7 @@ static int asn1_ex_i2c(const ASN1_VALUE **pval, unsigned char *cout, int *putype
     unsigned char c;
     int len;
     const ASN1_PRIMITIVE_FUNCS *pf;
-    pf = it->funcs;
+    pf = (const ASN1_PRIMITIVE_FUNCS *)it->funcs;
     if (pf && pf->prim_i2c)
         return pf->prim_i2c(pval, cout, putype, it);
 

--- a/crypto/asn1/tasn_fre.c
+++ b/crypto/asn1/tasn_fre.c
@@ -29,7 +29,7 @@ void asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
 {
     const ASN1_TEMPLATE *tt = NULL, *seqtt;
     const ASN1_EXTERN_FUNCS *ef;
-    const ASN1_AUX *aux = it->funcs;
+    const ASN1_AUX *aux = (const ASN1_AUX *)it->funcs;
     ASN1_aux_cb *asn1_cb;
     int i;
 
@@ -78,7 +78,7 @@ void asn1_item_embed_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
         break;
 
     case ASN1_ITYPE_EXTERN:
-        ef = it->funcs;
+        ef = (const ASN1_EXTERN_FUNCS *)it->funcs;
         if (ef && ef->asn1_ex_free)
             ef->asn1_ex_free(pval, it);
         break;
@@ -149,7 +149,7 @@ void asn1_primitive_free(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
 
     /* Special case: if 'it' is a primitive with a free_func, use that. */
     if (it) {
-        const ASN1_PRIMITIVE_FUNCS *pf = it->funcs;
+        const ASN1_PRIMITIVE_FUNCS *pf = (const ASN1_PRIMITIVE_FUNCS *)it->funcs;
 
         if (embed) {
             if (pf && pf->prim_clear) {

--- a/crypto/asn1/tasn_new.c
+++ b/crypto/asn1/tasn_new.c
@@ -43,7 +43,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
 {
     const ASN1_TEMPLATE *tt = NULL;
     const ASN1_EXTERN_FUNCS *ef;
-    const ASN1_AUX *aux = it->funcs;
+    const ASN1_AUX *aux = (const ASN1_AUX *)it->funcs;
     ASN1_aux_cb *asn1_cb;
     ASN1_VALUE **pseqval;
     int i;
@@ -55,7 +55,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
     switch (it->itype) {
 
     case ASN1_ITYPE_EXTERN:
-        ef = it->funcs;
+        ef = (const ASN1_EXTERN_FUNCS *)it->funcs;
         if (ef && ef->asn1_ex_new) {
             if (!ef->asn1_ex_new(pval, it))
                 goto memerr;
@@ -87,7 +87,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
         if (embed) {
             memset(*pval, 0, it->size);
         } else {
-            *pval = OPENSSL_zalloc(it->size);
+            *pval = (ASN1_VALUE *)OPENSSL_zalloc(it->size);
             if (*pval == NULL)
                 goto memerr;
         }
@@ -109,7 +109,7 @@ int asn1_item_embed_new(ASN1_VALUE **pval, const ASN1_ITEM *it, int embed)
         if (embed) {
             memset(*pval, 0, it->size);
         } else {
-            *pval = OPENSSL_zalloc(it->size);
+            *pval = (ASN1_VALUE *)OPENSSL_zalloc(it->size);
             if (*pval == NULL)
                 goto memerr;
         }
@@ -154,7 +154,7 @@ static void asn1_item_clear(ASN1_VALUE **pval, const ASN1_ITEM *it)
     switch (it->itype) {
 
     case ASN1_ITYPE_EXTERN:
-        ef = it->funcs;
+        ef = (const ASN1_EXTERN_FUNCS *)it->funcs;
         if (ef && ef->asn1_ex_clear)
             ef->asn1_ex_clear(pval, it);
         else
@@ -244,7 +244,7 @@ static int asn1_primitive_new(ASN1_VALUE **pval, const ASN1_ITEM *it,
         return 0;
 
     if (it->funcs) {
-        const ASN1_PRIMITIVE_FUNCS *pf = it->funcs;
+        const ASN1_PRIMITIVE_FUNCS *pf = (const ASN1_PRIMITIVE_FUNCS *)it->funcs;
         if (embed) {
             if (pf->prim_clear) {
                 pf->prim_clear(pval, it);
@@ -273,7 +273,7 @@ static int asn1_primitive_new(ASN1_VALUE **pval, const ASN1_ITEM *it,
         return 1;
 
     case V_ASN1_ANY:
-        if ((typ = OPENSSL_malloc(sizeof(*typ))) == NULL) {
+        if ((typ = (ASN1_TYPE *)OPENSSL_malloc(sizeof(*typ))) == NULL) {
             ASN1err(ASN1_F_ASN1_PRIMITIVE_NEW, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -305,7 +305,7 @@ static void asn1_primitive_clear(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
     int utype;
     if (it && it->funcs) {
-        const ASN1_PRIMITIVE_FUNCS *pf = it->funcs;
+        const ASN1_PRIMITIVE_FUNCS *pf = (const ASN1_PRIMITIVE_FUNCS *)it->funcs;
         if (pf->prim_clear)
             pf->prim_clear(pval, it);
         else

--- a/crypto/asn1/tasn_prn.c
+++ b/crypto/asn1/tasn_prn.c
@@ -36,7 +36,7 @@ ASN1_PCTX *ASN1_PCTX_new(void)
 {
     ASN1_PCTX *ret;
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (ASN1_PCTX *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1err(ASN1_F_ASN1_PCTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -139,7 +139,7 @@ static int asn1_item_print_ctx(BIO *out, const ASN1_VALUE **fld, int indent,
     const ASN1_TEMPLATE *tt;
     const ASN1_EXTERN_FUNCS *ef;
     const ASN1_VALUE **tmpfld;
-    const ASN1_AUX *aux = it->funcs;
+    const ASN1_AUX *aux = (const ASN1_AUX *)it->funcs;
     ASN1_aux_const_cb *asn1_cb = NULL;
     ASN1_PRINT_ARG parg;
     int i;
@@ -180,7 +180,7 @@ static int asn1_item_print_ctx(BIO *out, const ASN1_VALUE **fld, int indent,
         if (!nohdr && !asn1_print_fsname(out, indent, fname, sname, pctx))
             return 0;
         /* Use new style print routine if possible */
-        ef = it->funcs;
+        ef = (const ASN1_EXTERN_FUNCS *)it->funcs;
         if (ef && ef->asn1_ex_print) {
             i = ef->asn1_ex_print(out, fld, indent, "", pctx);
             if (!i)
@@ -440,7 +440,7 @@ static int asn1_primitive_print(BIO *out, const ASN1_VALUE **fld,
     int ret = 1, needlf = 1;
     const char *pname;
     const ASN1_PRIMITIVE_FUNCS *pf;
-    pf = it->funcs;
+    pf = (const ASN1_PRIMITIVE_FUNCS *)it->funcs;
     if (!asn1_print_fsname(out, indent, fname, sname, pctx))
         return 0;
     if (pf && pf->prim_print)

--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -28,14 +28,14 @@
 
 int asn1_get_choice_selector(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
-    int *sel = offset2ptr(*pval, it->utype);
+    int *sel = (int *)offset2ptr(*pval, it->utype);
 
     return *sel;
 }
 
 int asn1_get_choice_selector_const(const ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
-    int *sel = offset2ptr(*pval, it->utype);
+    int *sel = (int *)offset2ptr(*pval, it->utype);
 
     return *sel;
 }
@@ -49,7 +49,7 @@ int asn1_set_choice_selector(ASN1_VALUE **pval, int value,
 {
     int *sel, ret;
 
-    sel = offset2ptr(*pval, it->utype);
+    sel = (int *)offset2ptr(*pval, it->utype);
     ret = *sel;
     *sel = value;
     return ret;
@@ -74,11 +74,11 @@ int asn1_do_lock(ASN1_VALUE **pval, int op, const ASN1_ITEM *it)
     if ((it->itype != ASN1_ITYPE_SEQUENCE)
         && (it->itype != ASN1_ITYPE_NDEF_SEQUENCE))
         return 0;
-    aux = it->funcs;
+    aux = (const ASN1_AUX *)it->funcs;
     if (aux == NULL || (aux->flags & ASN1_AFLG_REFCOUNT) == 0)
         return 0;
-    lck = offset2ptr(*pval, aux->ref_offset);
-    lock = offset2ptr(*pval, aux->ref_lock);
+    lck = (CRYPTO_REF_COUNT *)offset2ptr(*pval, aux->ref_offset);
+    lock = (CRYPTO_RWLOCK **)offset2ptr(*pval, aux->ref_lock);
 
     switch (op) {
     case 0:
@@ -116,10 +116,10 @@ static ASN1_ENCODING *asn1_get_enc_ptr(ASN1_VALUE **pval, const ASN1_ITEM *it)
 
     if (pval == NULL || *pval == NULL)
         return NULL;
-    aux = it->funcs;
+    aux = (const ASN1_AUX *)it->funcs;
     if (aux == NULL || (aux->flags & ASN1_AFLG_ENCODING) == 0)
         return NULL;
-    return offset2ptr(*pval, aux->enc_offset);
+    return (ASN1_ENCODING *)offset2ptr(*pval, aux->enc_offset);
 }
 
 static const ASN1_ENCODING *asn1_get_const_enc_ptr(const ASN1_VALUE **pval,
@@ -129,10 +129,10 @@ static const ASN1_ENCODING *asn1_get_const_enc_ptr(const ASN1_VALUE **pval,
 
     if (pval == NULL || *pval == NULL)
         return NULL;
-    aux = it->funcs;
+    aux = (const ASN1_AUX *)it->funcs;
     if (aux == NULL || (aux->flags & ASN1_AFLG_ENCODING) == 0)
         return NULL;
-    return offset2ptr(*pval, aux->enc_offset);
+    return (const ASN1_ENCODING *)offset2ptr(*pval, aux->enc_offset);
 }
 
 void asn1_enc_init(ASN1_VALUE **pval, const ASN1_ITEM *it)
@@ -167,7 +167,7 @@ int asn1_enc_save(ASN1_VALUE **pval, const unsigned char *in, int inlen,
         return 1;
 
     OPENSSL_free(enc->enc);
-    if ((enc->enc = OPENSSL_malloc(inlen)) == NULL) {
+    if ((enc->enc = (unsigned char *)OPENSSL_malloc(inlen)) == NULL) {
         ASN1err(ASN1_F_ASN1_ENC_SAVE, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -197,7 +197,7 @@ int asn1_enc_restore(int *len, unsigned char **out, const ASN1_VALUE **pval,
 /* Given an ASN1_TEMPLATE get a pointer to a field */
 ASN1_VALUE **asn1_get_field_ptr(ASN1_VALUE **pval, const ASN1_TEMPLATE *tt)
 {
-    ASN1_VALUE **pvaltmp = offset2ptr(*pval, tt->offset);
+    ASN1_VALUE **pvaltmp = (ASN1_VALUE **)offset2ptr(*pval, tt->offset);
 
     /*
      * NOTE for BOOLEAN types the field is just a plain int so we can't
@@ -210,7 +210,7 @@ ASN1_VALUE **asn1_get_field_ptr(ASN1_VALUE **pval, const ASN1_TEMPLATE *tt)
 const ASN1_VALUE **asn1_get_const_field_ptr(const ASN1_VALUE **pval,
                                             const ASN1_TEMPLATE *tt)
 {
-    return offset2ptr(*pval, tt->offset);
+    return (const ASN1_VALUE **)offset2ptr(*pval, tt->offset);
 }
 
 /*
@@ -235,7 +235,7 @@ const ASN1_TEMPLATE *asn1_do_adb(const ASN1_VALUE *val,
     adb = ASN1_ADB_ptr(tt->item);
 
     /* Get the selector field */
-    sfld = offset2ptr(val, adb->offset);
+    sfld = (const ASN1_VALUE **)offset2ptr(val, adb->offset);
 
     /* Check if NULL */
     if (*sfld == NULL) {

--- a/crypto/asn1_dsa.c
+++ b/crypto/asn1_dsa.c
@@ -43,13 +43,13 @@ int encode_der_length(WPACKET *pkt, size_t cont_len)
 
     if (cont_len > 0xff) {
         if (!WPACKET_put_bytes_u8(pkt, 0x82)
-                || !WPACKET_put_bytes_u16(pkt, cont_len))
+                || !WPACKET_put_bytes_u16(pkt, (int)cont_len))
             return 0;
     } else {
         if (cont_len > 0x7f
                 && !WPACKET_put_bytes_u8(pkt, 0x81))
             return 0;
-        if (!WPACKET_put_bytes_u8(pkt, cont_len))
+        if (!WPACKET_put_bytes_u8(pkt, (int)cont_len))
             return 0;
     }
 

--- a/crypto/bio/b_dump.c
+++ b/crypto/bio/b_dump.c
@@ -28,7 +28,7 @@ int BIO_dump_cb(int (*cb) (const void *data, size_t len, void *u),
 int BIO_dump_indent_cb(int (*cb) (const void *data, size_t len, void *u),
                        void *u, const void *v, int len, int indent)
 {
-    const unsigned char *s = v;
+    const unsigned char *s = (const unsigned char *)v;
     int ret = 0;
     char buf[288 + 1];
     int i, j, rows, n;
@@ -110,7 +110,7 @@ int BIO_dump_indent_fp(FILE *fp, const void *s, int len, int indent)
 
 static int write_bio(const void *data, size_t len, void *bp)
 {
-    return BIO_write((BIO *)bp, (const char *)data, len);
+    return BIO_write((BIO *)bp, (const char *)data, (int)len);
 }
 
 int BIO_dump(BIO *bp, const void *s, int len)
@@ -126,7 +126,7 @@ int BIO_dump_indent(BIO *bp, const void *s, int len, int indent)
 int BIO_hex_string(BIO *out, int indent, int width, const void *data,
                    int datalen)
 {
-    const unsigned char *d = data;
+    const unsigned char *d = (const unsigned char *)data;
     int i, j = 0;
 
     if (datalen < 1)

--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -98,7 +98,8 @@ _dopr(char **sbuffer,
     size_t currlen;
 
     state = DP_S_DEFAULT;
-    flags = currlen = cflags = min = 0;
+    flags = cflags = min = 0;
+    currlen = 0;
     max = -1;
     ch = *format++;
 
@@ -303,7 +304,7 @@ _dopr(char **sbuffer,
                     if (buffer)
                         max = INT_MAX;
                     else
-                        max = *maxlen;
+                        max = (int)*maxlen;
                 }
                 if (!fmtstr(sbuffer, buffer, &currlen, maxlen, strvalue,
                             flags, min, max))
@@ -319,7 +320,7 @@ _dopr(char **sbuffer,
                 {
                     int *num;
                     num = va_arg(args, int *);
-                    *num = currlen;
+                    *num = (int)currlen;
                 }
                 break;
             case '%':
@@ -375,7 +376,7 @@ fmtstr(char **sbuffer,
 
     strln = OPENSSL_strnlen(value, max < 0 ? SIZE_MAX : (size_t)max);
 
-    padlen = min - strln;
+    padlen = (int)(min - strln);
     if (min < 0 || padlen < 0)
         padlen = 0;
     if (max >= 0) {
@@ -458,7 +459,7 @@ fmtint(char **sbuffer,
 
     zpadlen = max - place;
     spadlen =
-        min - OSSL_MAX(max, place) - (signvalue ? 1 : 0) - strlen(prefix);
+        (int)(min - OSSL_MAX(max, place) - (signvalue ? 1 : 0) - strlen(prefix));
     if (zpadlen < 0)
         zpadlen = 0;
     if (spadlen < 0)
@@ -823,7 +824,7 @@ doapr_outch(char **sbuffer,
 
         *maxlen += BUFFER_INC;
         if (*buffer == NULL) {
-            if ((*buffer = OPENSSL_malloc(*maxlen)) == NULL) {
+            if ((*buffer = (char *)OPENSSL_malloc(*maxlen)) == NULL) {
                 BIOerr(BIO_F_DOAPR_OUTCH, ERR_R_MALLOC_FAILURE);
                 return 0;
             }
@@ -835,7 +836,7 @@ doapr_outch(char **sbuffer,
             *sbuffer = NULL;
         } else {
             char *tmpbuf;
-            tmpbuf = OPENSSL_realloc(*buffer, *maxlen);
+            tmpbuf = (char *)OPENSSL_realloc(*buffer, *maxlen);
             if (tmpbuf == NULL)
                 return 0;
             *buffer = tmpbuf;

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -46,18 +46,18 @@ const BIO_METHOD *BIO_f_buffer(void)
 
 static int buffer_new(BIO *bi)
 {
-    BIO_F_BUFFER_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    BIO_F_BUFFER_CTX *ctx = (BIO_F_BUFFER_CTX *)OPENSSL_zalloc(sizeof(*ctx));
 
     if (ctx == NULL)
         return 0;
     ctx->ibuf_size = DEFAULT_BUFFER_SIZE;
-    ctx->ibuf = OPENSSL_malloc(DEFAULT_BUFFER_SIZE);
+    ctx->ibuf = (char *)OPENSSL_malloc(DEFAULT_BUFFER_SIZE);
     if (ctx->ibuf == NULL) {
         OPENSSL_free(ctx);
         return 0;
     }
     ctx->obuf_size = DEFAULT_BUFFER_SIZE;
-    ctx->obuf = OPENSSL_malloc(DEFAULT_BUFFER_SIZE);
+    ctx->obuf = (char *)OPENSSL_malloc(DEFAULT_BUFFER_SIZE);
     if (ctx->obuf == NULL) {
         OPENSSL_free(ctx->ibuf);
         OPENSSL_free(ctx);
@@ -289,7 +289,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_C_SET_BUFF_READ_DATA:
         if (num > ctx->ibuf_size) {
-            p1 = OPENSSL_malloc((int)num);
+            p1 = (char *)OPENSSL_malloc((int)num);
             if (p1 == NULL)
                 goto malloc_error;
             OPENSSL_free(ctx->ibuf);
@@ -318,12 +318,12 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         p1 = ctx->ibuf;
         p2 = ctx->obuf;
         if ((ibs > DEFAULT_BUFFER_SIZE) && (ibs != ctx->ibuf_size)) {
-            p1 = OPENSSL_malloc((int)num);
+            p1 = (char *)OPENSSL_malloc((int)num);
             if (p1 == NULL)
                 goto malloc_error;
         }
         if ((obs > DEFAULT_BUFFER_SIZE) && (obs != ctx->obuf_size)) {
-            p2 = OPENSSL_malloc((int)num);
+            p2 = (char *)OPENSSL_malloc((int)num);
             if (p2 == NULL) {
                 if (p1 != ctx->ibuf)
                     OPENSSL_free(p1);

--- a/crypto/bio/bf_prefix.c
+++ b/crypto/bio/bf_prefix.c
@@ -51,7 +51,7 @@ typedef struct prefix_ctx_st {
 
 static int prefix_create(BIO *b)
 {
-    PREFIX_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    PREFIX_CTX *ctx = (PREFIX_CTX *)OPENSSL_zalloc(sizeof(*ctx));
 
     if (ctx == NULL)
         return 0;
@@ -66,7 +66,7 @@ static int prefix_create(BIO *b)
 
 static int prefix_destroy(BIO *b)
 {
-    PREFIX_CTX *ctx = BIO_get_data(b);
+    PREFIX_CTX *ctx = (PREFIX_CTX *)BIO_get_data(b);
 
     OPENSSL_free(ctx->prefix);
     OPENSSL_free(ctx);
@@ -81,7 +81,7 @@ static int prefix_read(BIO *b, char *in, size_t size, size_t *numread)
 static int prefix_write(BIO *b, const char *out, size_t outl,
                         size_t *numwritten)
 {
-    PREFIX_CTX *ctx = BIO_get_data(b);
+    PREFIX_CTX *ctx = (PREFIX_CTX *)BIO_get_data(b);
 
     if (ctx == NULL)
         return 0;
@@ -151,7 +151,7 @@ static int prefix_write(BIO *b, const char *out, size_t outl,
 static long prefix_ctrl(BIO *b, int cmd, long num, void *ptr)
 {
     long ret = 0;
-    PREFIX_CTX *ctx = BIO_get_data(b);
+    PREFIX_CTX *ctx = (PREFIX_CTX *)BIO_get_data(b);
 
     if (ctx == NULL)
         return -1;

--- a/crypto/bio/bio_meth.c
+++ b/crypto/bio/bio_meth.c
@@ -35,7 +35,7 @@ int BIO_get_new_index(void)
 
 BIO_METHOD *BIO_meth_new(int type, const char *name)
 {
-    BIO_METHOD *biom = OPENSSL_zalloc(sizeof(BIO_METHOD));
+    BIO_METHOD *biom = (BIO_METHOD *)OPENSSL_zalloc(sizeof(BIO_METHOD));
 
     if (biom == NULL
             || (biom->name = OPENSSL_strdup(name)) == NULL) {

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -94,13 +94,13 @@ BIO *BIO_new_mem_buf(const void *buf, int len)
         BIOerr(BIO_F_BIO_NEW_MEM_BUF, BIO_R_NULL_PARAMETER);
         return NULL;
     }
-    sz = (len < 0) ? strlen(buf) : (size_t)len;
+    sz = (len < 0) ? strlen((const char *)buf) : (size_t)len;
     if ((ret = BIO_new(BIO_s_mem())) == NULL)
         return NULL;
     bb = (BIO_BUF_MEM *)ret->ptr;
     b = bb->buf;
     /* Cast away const and trust in the MEM_RDONLY flag. */
-    b->data = (void *)buf;
+    b->data = (char *)buf;
     b->length = sz;
     b->max = sz;
     *bb->readp = *bb->buf;
@@ -112,7 +112,7 @@ BIO *BIO_new_mem_buf(const void *buf, int len)
 
 static int mem_init(BIO *bi, unsigned long flags)
 {
-    BIO_BUF_MEM *bb = OPENSSL_zalloc(sizeof(*bb));
+    BIO_BUF_MEM *bb = (BIO_BUF_MEM *)OPENSSL_zalloc(sizeof(*bb));
 
     if (bb == NULL)
         return 0;
@@ -120,7 +120,7 @@ static int mem_init(BIO *bi, unsigned long flags)
         OPENSSL_free(bb);
         return 0;
     }
-    if ((bb->readp = OPENSSL_zalloc(sizeof(*bb->readp))) == NULL) {
+    if ((bb->readp = (BUF_MEM *)OPENSSL_zalloc(sizeof(*bb->readp))) == NULL) {
         BUF_MEM_free(bb->buf);
         OPENSSL_free(bb);
         return 0;
@@ -232,7 +232,7 @@ static int mem_write(BIO *b, const char *in, int inl)
     BIO_clear_retry_flags(b);
     if (inl == 0)
         return 0;
-    blen = bbm->readp->length;
+    blen = (int)bbm->readp->length;
     mem_buf_sync(b);
     if (BUF_MEM_grow_clean(bbm->buf, blen + inl) == 0)
         goto end;
@@ -305,7 +305,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_C_SET_BUF_MEM:
         mem_buf_free(b);
         b->shutdown = (int)num;
-        bbm->buf = ptr;
+        bbm->buf = (BUF_MEM *)ptr;
         *bbm->readp = *bbm->buf;
         break;
     case BIO_C_GET_BUF_MEM_PTR:
@@ -353,7 +353,7 @@ static int mem_gets(BIO *bp, char *buf, int size)
     if (bp->flags & BIO_FLAGS_MEM_RDONLY)
         bm = bbm->buf;
     BIO_clear_retry_flags(bp);
-    j = bm->length;
+    j = (int)bm->length;
     if ((size - 1) < j)
         j = size - 1;
     if (j <= 0) {

--- a/crypto/bn/bn_add.c
+++ b/crypto/bn/bn_add.c
@@ -114,7 +114,7 @@ int BN_uadd(BIGNUM *r, const BIGNUM *a, const BIGNUM *b)
         carry &= (t2 == 0);
     }
     *rp = carry;
-    r->top += carry;
+    r->top += (int)carry;
 
     r->neg = 0;
     bn_check_top(r);

--- a/crypto/bn/bn_asm.c
+++ b/crypto/bn/bn_asm.c
@@ -210,7 +210,7 @@ BN_ULONG bn_div_words(BN_ULONG h, BN_ULONG l, BN_ULONG d)
     int i, count = 2;
 
     if (d == 0)
-        return BN_MASK2;
+        return (BN_ULONG)BN_MASK2;
 
     i = BN_num_bits_word(d);
     assert((i == BN_BITS2) || (h <= (BN_ULONG)1 << i));

--- a/crypto/bn/bn_blind.c
+++ b/crypto/bn/bn_blind.c
@@ -33,7 +33,7 @@ BN_BLINDING *BN_BLINDING_new(const BIGNUM *A, const BIGNUM *Ai, BIGNUM *mod)
 
     bn_check_top(mod);
 
-    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+    if ((ret = (BN_BLINDING *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_BLINDING_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -188,7 +188,7 @@ int BN_BLINDING_invert_ex(BIGNUM *n, const BIGNUM *r, BN_BLINDING *b,
             }
             mask = (BN_ULONG)0 - ((rtop - ntop) >> (8 * sizeof(ntop) - 1));
             /* always true, if (rtop >= ntop) n->top = r->top; */
-            n->top = (int)(rtop & ~mask) | (ntop & mask);
+            n->top = (int)((int)(rtop & ~mask) | (ntop & mask));
             n->flags |= (BN_FLG_FIXED_TOP & ~mask);
         }
         ret = BN_mod_mul_montgomery(n, n, r, b->m_ctx, ctx);

--- a/crypto/bn/bn_conv.c
+++ b/crypto/bn/bn_conv.c
@@ -22,7 +22,7 @@ char *BN_bn2hex(const BIGNUM *a)
 
     if (BN_is_zero(a))
         return OPENSSL_strdup("0");
-    buf = OPENSSL_malloc(a->top * BN_BYTES * 2 + 2);
+    buf = (char *)OPENSSL_malloc(a->top * BN_BYTES * 2 + 2);
     if (buf == NULL) {
         BNerr(BN_F_BN_BN2HEX, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -68,8 +68,8 @@ char *BN_bn2dec(const BIGNUM *a)
     num = (i / 10 + i / 1000 + 1) + 1;
     tbytes = num + 3;   /* negative and terminator and one spare? */
     bn_data_num = num / BN_DEC_NUM + 1;
-    bn_data = OPENSSL_malloc(bn_data_num * sizeof(BN_ULONG));
-    buf = OPENSSL_malloc(tbytes);
+    bn_data = (BN_ULONG *)OPENSSL_malloc(bn_data_num * sizeof(BN_ULONG));
+    buf = (char *)OPENSSL_malloc(tbytes);
     if (buf == NULL || bn_data == NULL) {
         BNerr(BN_F_BN_BN2DEC, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -169,7 +169,7 @@ int BN_hex2bn(BIGNUM **bn, const char *a)
         l = 0;
         for (;;) {
             c = a[j - m];
-            k = OPENSSL_hexchar2int(c);
+            k = OPENSSL_hexchar2int((unsigned char)c);
             if (k < 0)
                 k = 0;          /* paranoia */
             l = (l << 4) | k;

--- a/crypto/bn/bn_ctx.c
+++ b/crypto/bn/bn_ctx.c
@@ -132,7 +132,7 @@ BN_CTX *BN_CTX_new_ex(OPENSSL_CTX *ctx)
 {
     BN_CTX *ret;
 
-    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+    if ((ret = (BN_CTX *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_CTX_NEW_EX, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -281,7 +281,7 @@ static int BN_STACK_push(BN_STACK *st, unsigned int idx)
             st->size ? (st->size * 3 / 2) : BN_CTX_START_FRAMES;
         unsigned int *newitems;
 
-        if ((newitems = OPENSSL_malloc(sizeof(*newitems) * newsize)) == NULL) {
+        if ((newitems = (unsigned int *)OPENSSL_malloc(sizeof(*newitems) * newsize)) == NULL) {
             BNerr(BN_F_BN_STACK_PUSH, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -335,7 +335,7 @@ static BIGNUM *BN_POOL_get(BN_POOL *p, int flag)
     if (p->used == p->size) {
         BN_POOL_ITEM *item;
 
-        if ((item = OPENSSL_malloc(sizeof(*item))) == NULL) {
+        if ((item = (BN_POOL_ITEM *)OPENSSL_malloc(sizeof(*item))) == NULL) {
             BNerr(BN_F_BN_POOL_GET, ERR_R_MALLOC_FAILURE);
             return NULL;
         }

--- a/crypto/bn/bn_div.c
+++ b/crypto/bn/bn_div.c
@@ -349,7 +349,7 @@ int bn_div_fixed_top(BIGNUM *dv, BIGNUM *rm, const BIGNUM *num,
         n0 = wnumtop[0];
         n1 = wnumtop[-1];
         if (n0 == d0)
-            q = BN_MASK2;
+            q = (BN_ULONG)BN_MASK2;
         else {                  /* n0 < d0 */
             BN_ULONG n2 = (wnumtop == wnum) ? 0 : wnumtop[-2];
 #  ifdef BN_LLONG

--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -715,11 +715,11 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
                                        numPowers ? (2 * top) : numPowers));
 #ifdef alloca
     if (powerbufLen < 3072)
-        powerbufFree =
+        powerbufFree = (unsigned char *)
             alloca(powerbufLen + MOD_EXP_CTIME_MIN_CACHE_LINE_WIDTH);
     else
 #endif
-        if ((powerbufFree =
+        if ((powerbufFree = (unsigned char *)
              OPENSSL_malloc(powerbufLen + MOD_EXP_CTIME_MIN_CACHE_LINE_WIDTH))
             == NULL)
         goto err;

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -471,7 +471,7 @@ int BN_GF2m_mod_mul(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     bn_check_top(a);
     bn_check_top(b);
     bn_check_top(p);
-    if ((arr = OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
+    if ((arr = (int *)OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
         goto err;
     ret = BN_GF2m_poly2arr(p, arr, max);
     if (!ret || ret > max) {
@@ -529,7 +529,7 @@ int BN_GF2m_mod_sqr(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
 
     bn_check_top(a);
     bn_check_top(p);
-    if ((arr = OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
+    if ((arr = (int *)OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
         goto err;
     ret = BN_GF2m_poly2arr(p, arr, max);
     if (!ret || ret > max) {
@@ -903,7 +903,7 @@ int BN_GF2m_mod_exp(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     bn_check_top(a);
     bn_check_top(b);
     bn_check_top(p);
-    if ((arr = OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
+    if ((arr = (int *)OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
         goto err;
     ret = BN_GF2m_poly2arr(p, arr, max);
     if (!ret || ret > max) {
@@ -962,7 +962,7 @@ int BN_GF2m_mod_sqrt(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
     int *arr = NULL;
     bn_check_top(a);
     bn_check_top(p);
-    if ((arr = OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
+    if ((arr = (int *)OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
         goto err;
     ret = BN_GF2m_poly2arr(p, arr, max);
     if (!ret || ret > max) {
@@ -1093,7 +1093,7 @@ int BN_GF2m_mod_solve_quad(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     int *arr = NULL;
     bn_check_top(a);
     bn_check_top(p);
-    if ((arr = OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
+    if ((arr = (int *)OPENSSL_malloc(sizeof(*arr) * max)) == NULL)
         goto err;
     ret = BN_GF2m_poly2arr(p, arr, max);
     if (!ret || ret > max) {

--- a/crypto/bn/bn_intern.c
+++ b/crypto/bn/bn_intern.c
@@ -28,7 +28,7 @@ signed char *bn_compute_wNAF(const BIGNUM *scalar, int w, size_t *ret_len)
     size_t len = 0, j;
 
     if (BN_is_zero(scalar)) {
-        r = OPENSSL_malloc(1);
+        r = (signed char *)OPENSSL_malloc(1);
         if (r == NULL) {
             BNerr(BN_F_BN_COMPUTE_WNAF, ERR_R_MALLOC_FAILURE);
             goto err;
@@ -57,11 +57,11 @@ signed char *bn_compute_wNAF(const BIGNUM *scalar, int w, size_t *ret_len)
     }
 
     len = BN_num_bits(scalar);
-    r = OPENSSL_malloc(len + 1); /*
-                                  * Modified wNAF may be one digit longer than binary representation
-                                  * (*ret_len will be set to the actual length, i.e. at most
-                                  * BN_num_bits(scalar) + 1)
-                                  */
+    r = (signed char *)OPENSSL_malloc(len + 1); /*
+                                                 * Modified wNAF may be one digit longer than binary representation
+                                                 * (*ret_len will be set to the actual length, i.e. at most
+                                                 * BN_num_bits(scalar) + 1)
+                                                 */
     if (r == NULL) {
         BNerr(BN_F_BN_COMPUTE_WNAF, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -115,10 +115,10 @@ signed char *bn_compute_wNAF(const BIGNUM *scalar, int w, size_t *ret_len)
             }
         }
 
-        r[j++] = sign * digit;
+        r[j++] = (signed char)(sign * digit);
 
         window_val >>= 1;
-        window_val += bit * BN_is_bit_set(scalar, j + w);
+        window_val += bit * BN_is_bit_set(scalar, (int)(j + w));
 
         if (window_val > next_bit) {
             BNerr(BN_F_BN_COMPUTE_WNAF, ERR_R_INTERNAL_ERROR);

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -244,7 +244,7 @@ BIGNUM *BN_new(void)
 {
     BIGNUM *ret;
 
-    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+    if ((ret = (BIGNUM *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -276,9 +276,9 @@ static BN_ULONG *bn_expand_internal(const BIGNUM *b, int words)
         return NULL;
     }
     if (BN_get_flags(b, BN_FLG_SECURE))
-        a = OPENSSL_secure_zalloc(words * sizeof(*a));
+        a = (BN_ULONG *)OPENSSL_secure_zalloc(words * sizeof(*a));
     else
-        a = OPENSSL_zalloc(words * sizeof(*a));
+        a = (BN_ULONG *)OPENSSL_zalloc(words * sizeof(*a));
     if (a == NULL) {
         BNerr(BN_F_BN_EXPAND_INTERNAL, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -410,7 +410,7 @@ void BN_clear(BIGNUM *a)
 BN_ULONG BN_get_word(const BIGNUM *a)
 {
     if (a->top > 1)
-        return BN_MASK2;
+        return (BN_ULONG)BN_MASK2;
     else if (a->top == 1)
         return a->d[0];
     /* a->top == 0 */
@@ -965,7 +965,7 @@ BN_GENCB *BN_GENCB_new(void)
 {
     BN_GENCB *ret;
 
-    if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL) {
+    if ((ret = (BN_GENCB *)OPENSSL_malloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_GENCB_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -53,11 +53,11 @@ int bn_mod_add_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     BN_ULONG carry, temp, mask, *rp, *tp = storage;
     const BN_ULONG *ap, *bp;
 
-    if (bn_wexpand(r, mtop) == NULL)
+    if (bn_wexpand(r, (int)mtop) == NULL)
         return 0;
 
     if (mtop > sizeof(storage) / sizeof(storage[0])
-        && (tp = OPENSSL_malloc(mtop * sizeof(BN_ULONG))) == NULL)
+        && (tp = (BN_ULONG *)OPENSSL_malloc(mtop * sizeof(BN_ULONG))) == NULL)
         return 0;
 
     ap = a->d != NULL ? a->d : tp;
@@ -77,12 +77,12 @@ int bn_mod_add_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
         bi += (i - b->dmax) >> (8 * sizeof(i) - 1);
     }
     rp = r->d;
-    carry -= bn_sub_words(rp, tp, m->d, mtop);
+    carry -= bn_sub_words(rp, tp, m->d, (int)mtop);
     for (i = 0; i < mtop; i++) {
         rp[i] = (carry & tp[i]) | (~carry & rp[i]);
         ((volatile BN_ULONG *)tp)[i] = 0;
     }
-    r->top = mtop;
+    r->top = (int)mtop;
     r->flags |= BN_FLG_FIXED_TOP;
     r->neg = 0;
 
@@ -132,7 +132,7 @@ int bn_mod_sub_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     BN_ULONG borrow, carry, ta, tb, mask, *rp;
     const BN_ULONG *ap, *bp;
 
-    if (bn_wexpand(r, mtop) == NULL)
+    if (bn_wexpand(r, (int)mtop) == NULL)
         return 0;
 
     rp = r->d;
@@ -168,7 +168,7 @@ int bn_mod_sub_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
         carry += (rp[i] < ta);
     }
 
-    r->top = mtop;
+    r->top = (int)mtop;
     r->flags |= BN_FLG_FIXED_TOP;
     r->neg = 0;
 

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -229,7 +229,7 @@ BN_MONT_CTX *BN_MONT_CTX_new(void)
 {
     BN_MONT_CTX *ret;
 
-    if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL) {
+    if ((ret = (BN_MONT_CTX *)OPENSSL_malloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_MONT_CTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -357,7 +357,7 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
                 goto err;
         } else {                /* if N mod word size == 1 */
 
-            if (!BN_set_word(Ri, BN_MASK2))
+            if (!BN_set_word(Ri, (BN_ULONG)BN_MASK2))
                 goto err;       /* Ri-- (mod word size) */
         }
         if (!BN_div(Ri, NULL, Ri, &tmod, ctx))

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -144,7 +144,7 @@ int BN_generate_prime_ex2(BIGNUM *ret, int bits, int safe,
         return 0;
     }
 
-    mods = OPENSSL_zalloc(sizeof(*mods) * NUMPRIMES);
+    mods = (prime_t *)OPENSSL_zalloc(sizeof(*mods) * NUMPRIMES);
     if (mods == NULL)
         goto err;
 

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -40,7 +40,7 @@ static int bnrand(BNRAND_FLAG flag, BIGNUM *rnd, int bits, int top, int bottom,
     bit = (bits - 1) % 8;
     mask = 0xff << (bit + 1);
 
-    buf = OPENSSL_malloc(bytes);
+    buf = (unsigned char *)OPENSSL_malloc(bytes);
     if (buf == NULL) {
         BNerr(BN_F_BNRAND, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -259,7 +259,7 @@ int BN_generate_dsa_nonce(BIGNUM *out, const BIGNUM *range,
     if (mdctx == NULL)
         goto err;
 
-    k_bytes = OPENSSL_malloc(num_k_bytes);
+    k_bytes = (unsigned char *)OPENSSL_malloc(num_k_bytes);
     if (k_bytes == NULL)
         goto err;
 

--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -21,7 +21,7 @@ BN_RECP_CTX *BN_RECP_CTX_new(void)
 {
     BN_RECP_CTX *ret;
 
-    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+    if ((ret = (BN_RECP_CTX *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         BNerr(BN_F_BN_RECP_CTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/bn/bn_shift.c
+++ b/crypto/bn/bn_shift.c
@@ -37,7 +37,7 @@ int BN_lshift1(BIGNUM *r, const BIGNUM *a)
         c = t >> (BN_BITS2 - 1);
     }
     *rp = c;
-    r->top += c;
+    r->top += (int)c;
     bn_check_top(r);
     return 1;
 }

--- a/crypto/bsearch.c
+++ b/crypto/bsearch.c
@@ -14,7 +14,7 @@ const void *ossl_bsearch(const void *key, const void *base, int num,
                          int size, int (*cmp) (const void *, const void *),
                          int flags)
 {
-    const char *base_ = base;
+    const char *base_ = (const char *)base;
     int l, h, i = 0, c = 0;
     const char *p = NULL;
 

--- a/crypto/buffer/buffer.c
+++ b/crypto/buffer/buffer.c
@@ -32,7 +32,7 @@ BUF_MEM *BUF_MEM_new(void)
 {
     BUF_MEM *ret;
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (BUF_MEM *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         BUFerr(BUF_F_BUF_MEM_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -59,7 +59,7 @@ static char *sec_alloc_realloc(BUF_MEM *str, size_t len)
 {
     char *ret;
 
-    ret = OPENSSL_secure_malloc(len);
+    ret = (char *)OPENSSL_secure_malloc(len);
     if (str->data != NULL) {
         if (ret != NULL) {
             memcpy(ret, str->data, str->length);
@@ -94,7 +94,7 @@ size_t BUF_MEM_grow(BUF_MEM *str, size_t len)
     if ((str->flags & BUF_MEM_FLAG_SECURE))
         ret = sec_alloc_realloc(str, n);
     else
-        ret = OPENSSL_realloc(str->data, n);
+        ret = (char *)OPENSSL_realloc(str->data, n);
     if (ret == NULL) {
         BUFerr(BUF_F_BUF_MEM_GROW, ERR_R_MALLOC_FAILURE);
         len = 0;
@@ -132,7 +132,7 @@ size_t BUF_MEM_grow_clean(BUF_MEM *str, size_t len)
     if ((str->flags & BUF_MEM_FLAG_SECURE))
         ret = sec_alloc_realloc(str, n);
     else
-        ret = OPENSSL_clear_realloc(str->data, str->max, n);
+        ret = (char *)OPENSSL_clear_realloc(str->data, str->max, n);
     if (ret == NULL) {
         BUFerr(BUF_F_BUF_MEM_GROW_CLEAN, ERR_R_MALLOC_FAILURE);
         len = 0;

--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -53,7 +53,7 @@ CMAC_CTX *CMAC_CTX_new(void)
 {
     CMAC_CTX *ctx;
 
-    if ((ctx = OPENSSL_malloc(sizeof(*ctx))) == NULL) {
+    if ((ctx = (CMAC_CTX *)OPENSSL_malloc(sizeof(*ctx))) == NULL) {
         CRYPTOerr(CRYPTO_F_CMAC_CTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -139,9 +139,9 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
         ctx->nlast_block = -1;
         if (!EVP_CIPHER_CTX_cipher(ctx->cctx))
             return 0;
-        if (!EVP_CIPHER_CTX_set_key_length(ctx->cctx, keylen))
+        if (!EVP_CIPHER_CTX_set_key_length(ctx->cctx, (int)keylen))
             return 0;
-        if (!EVP_EncryptInit_ex(ctx->cctx, NULL, NULL, key, zero_iv))
+        if (!EVP_EncryptInit_ex(ctx->cctx, NULL, NULL, (const unsigned char *)key, zero_iv))
             return 0;
         if ((bl = EVP_CIPHER_CTX_block_size(ctx->cctx)) < 0)
             return 0;
@@ -162,7 +162,7 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
 
 int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
 {
-    const unsigned char *data = in;
+    const unsigned char *data = (const unsigned char *)in;
     int bl;
 
     if (ctx->nlast_block == -1)
@@ -180,7 +180,7 @@ int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
             nleft = dlen;
         memcpy(ctx->last_block + ctx->nlast_block, data, nleft);
         dlen -= nleft;
-        ctx->nlast_block += nleft;
+        ctx->nlast_block += (int)nleft;
         /* If no more to process return */
         if (dlen == 0)
             return 1;
@@ -198,7 +198,7 @@ int CMAC_Update(CMAC_CTX *ctx, const void *in, size_t dlen)
     }
     /* Copy any data left to last block buffer */
     memcpy(ctx->last_block, data, dlen);
-    ctx->nlast_block = dlen;
+    ctx->nlast_block = (int)dlen;
     return 1;
 
 }

--- a/crypto/cms/cms_asn1.c
+++ b/crypto/cms/cms_asn1.c
@@ -293,7 +293,7 @@ ASN1_ADB(CMS_ContentInfo) = {
 static int cms_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                   void *exarg)
 {
-    ASN1_STREAM_ARG *sarg = exarg;
+    ASN1_STREAM_ARG *sarg = (ASN1_STREAM_ARG *)exarg;
     CMS_ContentInfo *cms = NULL;
     if (pval)
         cms = (CMS_ContentInfo *)*pval;

--- a/crypto/cms/cms_att.c
+++ b/crypto/cms/cms_att.c
@@ -103,7 +103,7 @@ int CMS_signed_add1_attr_by_OBJ(CMS_SignerInfo *si,
                                 const ASN1_OBJECT *obj, int type,
                                 const void *bytes, int len)
 {
-    if (X509at_add1_attr_by_OBJ(&si->signedAttrs, obj, type, bytes, len))
+    if (X509at_add1_attr_by_OBJ(&si->signedAttrs, obj, type, (const unsigned char *)bytes, len))
         return 1;
     return 0;
 }
@@ -111,7 +111,7 @@ int CMS_signed_add1_attr_by_OBJ(CMS_SignerInfo *si,
 int CMS_signed_add1_attr_by_NID(CMS_SignerInfo *si,
                                 int nid, int type, const void *bytes, int len)
 {
-    if (X509at_add1_attr_by_NID(&si->signedAttrs, nid, type, bytes, len))
+    if (X509at_add1_attr_by_NID(&si->signedAttrs, nid, type, (const unsigned char *)bytes, len))
         return 1;
     return 0;
 }
@@ -120,7 +120,7 @@ int CMS_signed_add1_attr_by_txt(CMS_SignerInfo *si,
                                 const char *attrname, int type,
                                 const void *bytes, int len)
 {
-    if (X509at_add1_attr_by_txt(&si->signedAttrs, attrname, type, bytes, len))
+    if (X509at_add1_attr_by_txt(&si->signedAttrs, attrname, type, (const unsigned char *)bytes, len))
         return 1;
     return 0;
 }
@@ -169,7 +169,7 @@ int CMS_unsigned_add1_attr_by_OBJ(CMS_SignerInfo *si,
                                   const ASN1_OBJECT *obj, int type,
                                   const void *bytes, int len)
 {
-    if (X509at_add1_attr_by_OBJ(&si->unsignedAttrs, obj, type, bytes, len))
+    if (X509at_add1_attr_by_OBJ(&si->unsignedAttrs, obj, type, (const unsigned char *)bytes, len))
         return 1;
     return 0;
 }
@@ -178,7 +178,7 @@ int CMS_unsigned_add1_attr_by_NID(CMS_SignerInfo *si,
                                   int nid, int type,
                                   const void *bytes, int len)
 {
-    if (X509at_add1_attr_by_NID(&si->unsignedAttrs, nid, type, bytes, len))
+    if (X509at_add1_attr_by_NID(&si->unsignedAttrs, nid, type, (const unsigned char *)bytes, len))
         return 1;
     return 0;
 }
@@ -188,7 +188,7 @@ int CMS_unsigned_add1_attr_by_txt(CMS_SignerInfo *si,
                                   const void *bytes, int len)
 {
     if (X509at_add1_attr_by_txt(&si->unsignedAttrs, attrname,
-                                type, bytes, len))
+                                type, (const unsigned char *)bytes, len))
         return 1;
     return 0;
 }

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -109,7 +109,7 @@ BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
 
     /* Generate random session key */
     if (!enc || !ec->key) {
-        tkey = OPENSSL_malloc(tkeylen);
+        tkey = (unsigned char *)OPENSSL_malloc(tkeylen);
         if (tkey == NULL) {
             CMSerr(CMS_F_CMS_ENCRYPTEDCONTENT_INIT_BIO, ERR_R_MALLOC_FAILURE);
             goto err;
@@ -131,7 +131,7 @@ BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
 
     if (ec->keylen != tkeylen) {
         /* If necessary set key length */
-        if (EVP_CIPHER_CTX_set_key_length(ctx, ec->keylen) <= 0) {
+        if (EVP_CIPHER_CTX_set_key_length(ctx, (int)ec->keylen) <= 0) {
             /*
              * Only reveal failure if debugging so we don't leak information
              * which may be useful in MMA.
@@ -203,7 +203,7 @@ int cms_EncryptedContent_init(CMS_EncryptedContentInfo *ec,
 {
     ec->cipher = cipher;
     if (key) {
-        if ((ec->key = OPENSSL_malloc(keylen)) == NULL) {
+        if ((ec->key = (unsigned char *)OPENSSL_malloc(keylen)) == NULL) {
             CMSerr(CMS_F_CMS_ENCRYPTEDCONTENT_INIT, ERR_R_MALLOC_FAILURE);
             return 0;
         }

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -485,7 +485,7 @@ static int cms_RecipientInfo_ktri_encrypt(const CMS_ContentInfo *cms,
     if (EVP_PKEY_encrypt(pctx, NULL, &eklen, ec->key, ec->keylen) <= 0)
         goto err;
 
-    ek = OPENSSL_malloc(eklen);
+    ek = (unsigned char *)OPENSSL_malloc(eklen);
 
     if (ek == NULL) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KTRI_ENCRYPT, ERR_R_MALLOC_FAILURE);
@@ -495,7 +495,7 @@ static int cms_RecipientInfo_ktri_encrypt(const CMS_ContentInfo *cms,
     if (EVP_PKEY_encrypt(pctx, ek, &eklen, ec->key, ec->keylen) <= 0)
         goto err;
 
-    ASN1_STRING_set0(ktri->encryptedKey, ek, eklen);
+    ASN1_STRING_set0(ktri->encryptedKey, ek, (int)eklen);
     ek = NULL;
 
     ret = 1;
@@ -720,7 +720,7 @@ CMS_RecipientInfo *CMS_add0_recipient_key(CMS_ContentInfo *cms, int nid,
     kekri->key = key;
     kekri->keylen = keylen;
 
-    ASN1_STRING_set0(kekri->kekid->keyIdentifier, id, idlen);
+    ASN1_STRING_set0(kekri->kekid->keyIdentifier, id, (int)idlen);
 
     kekri->kekid->date = date;
 
@@ -844,7 +844,7 @@ static int cms_RecipientInfo_kekri_encrypt(const CMS_ContentInfo *cms,
     }
 
     /* 8 byte prefix for AES wrap ciphers */
-    wkey = OPENSSL_malloc(ec->keylen + 8);
+    wkey = (unsigned char *)OPENSSL_malloc(ec->keylen + 8);
     if (wkey == NULL) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -858,7 +858,7 @@ static int cms_RecipientInfo_kekri_encrypt(const CMS_ContentInfo *cms,
 
     EVP_CIPHER_CTX_set_flags(ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
     if (!EVP_EncryptInit_ex(ctx, cipher, NULL, kekri->key, NULL)
-            || !EVP_EncryptUpdate(ctx, wkey, &wkeylen, ec->key, ec->keylen)
+            || !EVP_EncryptUpdate(ctx, wkey, &wkeylen, ec->key, (int)ec->keylen)
             || !EVP_EncryptFinal_ex(ctx, wkey + wkeylen, &outlen)) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_ENCRYPT, CMS_R_WRAP_ERROR);
         goto err;
@@ -929,7 +929,7 @@ static int cms_RecipientInfo_kekri_decrypt(CMS_ContentInfo *cms,
         goto err;
     }
 
-    ukey = OPENSSL_malloc(kekri->encryptedKey->length - 8);
+    ukey = (unsigned char *)OPENSSL_malloc(kekri->encryptedKey->length - 8);
     if (ukey == NULL) {
         CMSerr(CMS_F_CMS_RECIPIENTINFO_KEKRI_DECRYPT, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -32,11 +32,11 @@ int CMS_get1_ReceiptRequest(CMS_SignerInfo *si, CMS_ReceiptRequest **prr)
 
     if (prr != NULL)
         *prr = NULL;
-    str = CMS_signed_get0_data_by_OBJ(si, obj, -3, V_ASN1_SEQUENCE);
+    str = (ASN1_STRING *)CMS_signed_get0_data_by_OBJ(si, obj, -3, V_ASN1_SEQUENCE);
     if (str == NULL)
         return 0;
 
-    rr = ASN1_item_unpack(str, ASN1_ITEM_rptr(CMS_ReceiptRequest));
+    rr = (CMS_ReceiptRequest *)ASN1_item_unpack(str, ASN1_ITEM_rptr(CMS_ReceiptRequest));
     if (rr == NULL)
         return -1;
     if (prr != NULL)
@@ -285,7 +285,7 @@ int cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms)
         goto err;
     }
 
-    rct = ASN1_item_unpack(*pcont, ASN1_ITEM_rptr(CMS_Receipt));
+    rct = (CMS_Receipt *)ASN1_item_unpack(*pcont, ASN1_ITEM_rptr(CMS_Receipt));
 
     if (!rct) {
         CMSerr(CMS_F_CMS_RECEIPT_VERIFY, CMS_R_RECEIPT_DECODE_ERROR);
@@ -309,10 +309,10 @@ int cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms)
 
     /* Get msgSigDigest value and compare */
 
-    msig = CMS_signed_get0_data_by_OBJ(si,
-                                       OBJ_nid2obj
-                                       (NID_id_smime_aa_msgSigDigest), -3,
-                                       V_ASN1_OCTET_STRING);
+    msig = (ASN1_OCTET_STRING *)CMS_signed_get0_data_by_OBJ(si,
+                                                            OBJ_nid2obj
+                                                            (NID_id_smime_aa_msgSigDigest), -3,
+                                                            V_ASN1_OCTET_STRING);
 
     if (!msig) {
         CMSerr(CMS_F_CMS_RECEIPT_VERIFY, CMS_R_NO_MSGSIGDIGEST);
@@ -337,9 +337,9 @@ int cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms)
 
     /* Compare content types */
 
-    octype = CMS_signed_get0_data_by_OBJ(osi,
-                                         OBJ_nid2obj(NID_pkcs9_contentType),
-                                         -3, V_ASN1_OBJECT);
+    octype = (ASN1_OBJECT *)CMS_signed_get0_data_by_OBJ(osi,
+                                                        OBJ_nid2obj(NID_pkcs9_contentType),
+                                                        -3, V_ASN1_OBJECT);
     if (!octype) {
         CMSerr(CMS_F_CMS_RECEIPT_VERIFY, CMS_R_NO_CONTENT_TYPE);
         goto err;
@@ -397,9 +397,9 @@ ASN1_OCTET_STRING *cms_encode_Receipt(CMS_SignerInfo *si)
 
     /* Get original content type */
 
-    ctype = CMS_signed_get0_data_by_OBJ(si,
-                                        OBJ_nid2obj(NID_pkcs9_contentType),
-                                        -3, V_ASN1_OBJECT);
+    ctype = (ASN1_OBJECT *)CMS_signed_get0_data_by_OBJ(si,
+                                                       OBJ_nid2obj(NID_pkcs9_contentType),
+                                                       -3, V_ASN1_OBJECT);
     if (!ctype) {
         CMSerr(CMS_F_CMS_ENCODE_RECEIPT, CMS_R_NO_CONTENT_TYPE);
         goto err;
@@ -429,7 +429,7 @@ int cms_add1_signing_cert_v2(CMS_SignerInfo *si, ESS_SIGNING_CERT_V2 *sc)
 
     /* Add SigningCertificateV2 signed attribute to the signer info. */
     len = i2d_ESS_SIGNING_CERT_V2(sc, NULL);
-    if (len <= 0 || (pp = OPENSSL_malloc(len)) == NULL)
+    if (len <= 0 || (pp = (unsigned char *)OPENSSL_malloc(len)) == NULL)
         goto err;
     p = pp;
     i2d_ESS_SIGNING_CERT_V2(sc, &p);
@@ -461,7 +461,7 @@ int cms_add1_signing_cert(CMS_SignerInfo *si, ESS_SIGNING_CERT *sc)
 
     /* Add SigningCertificate signed attribute to the signer info. */
     len = i2d_ESS_SIGNING_CERT(sc, NULL);
-    if (len <= 0 || (pp = OPENSSL_malloc(len)) == NULL)
+    if (len <= 0 || (pp = (unsigned char *)OPENSSL_malloc(len)) == NULL)
         goto err;
     p = pp;
     i2d_ESS_SIGNING_CERT(sc, &p);

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -229,12 +229,12 @@ static int cms_kek_cipher(unsigned char **pout, size_t *poutlen,
     if (!EVP_CipherInit_ex(kari->ctx, NULL, NULL, kek, NULL, enc))
         goto err;
     /* obtain output length of ciphered key */
-    if (!EVP_CipherUpdate(kari->ctx, NULL, &outlen, in, inlen))
+    if (!EVP_CipherUpdate(kari->ctx, NULL, &outlen, in, (int)inlen))
         goto err;
-    out = OPENSSL_malloc(outlen);
+    out = (unsigned char *)OPENSSL_malloc(outlen);
     if (out == NULL)
         goto err;
-    if (!EVP_CipherUpdate(kari->ctx, out, &outlen, in, inlen))
+    if (!EVP_CipherUpdate(kari->ctx, out, &outlen, in, (int)inlen))
         goto err;
     *pout = out;
     *poutlen = (size_t)outlen;
@@ -451,7 +451,7 @@ static int cms_wrap_init(CMS_KeyAgreeRecipientInfo *kari,
     if ((EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_GET_WRAP_CIPHER) != 0) {
         /* TODO: make this not get a method we can call directly */
         ret = EVP_CIPHER_meth_get_ctrl(cipher)(NULL, EVP_CTRL_GET_WRAP_CIPHER,
-                                               0, &kekcipher);
+                                               0, (EVP_CIPHER *)&kekcipher);
         if (ret <= 0)
              return 0;
 
@@ -559,7 +559,7 @@ int cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
         if (!cms_kek_cipher(&enckey, &enckeylen, ec->key, ec->keylen,
                             kari, 1))
             return 0;
-        ASN1_STRING_set0(rek->encryptedKey, enckey, enckeylen);
+        ASN1_STRING_set0(rek->encryptedKey, enckey, (int)enckeylen);
     }
 
     return 1;

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -155,10 +155,10 @@ static int cms_copy_messageDigest(CMS_ContentInfo *cms, CMS_SignerInfo *si)
         if (OBJ_cmp(si->digestAlgorithm->algorithm,
                     sitmp->digestAlgorithm->algorithm))
             continue;
-        messageDigest = CMS_signed_get0_data_by_OBJ(sitmp,
-                                                    OBJ_nid2obj
-                                                    (NID_pkcs9_messageDigest),
-                                                    -3, V_ASN1_OCTET_STRING);
+        messageDigest = (ASN1_OCTET_STRING *)CMS_signed_get0_data_by_OBJ(sitmp,
+                                                                         OBJ_nid2obj
+                                                                         (NID_pkcs9_messageDigest),
+                                                                         -3, V_ASN1_OCTET_STRING);
         if (!messageDigest) {
             CMSerr(CMS_F_CMS_COPY_MESSAGEDIGEST,
                    CMS_R_ERROR_READING_MESSAGEDIGEST_ATTRIBUTE);
@@ -657,7 +657,7 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
         if (!EVP_DigestFinal_ex(mctx, md, &mdlen))
             goto err;
         siglen = EVP_PKEY_size(si->pkey);
-        sig = OPENSSL_malloc(siglen);
+        sig = (unsigned char *)OPENSSL_malloc(siglen);
         if (sig == NULL) {
             CMSerr(CMS_F_CMS_SIGNERINFO_CONTENT_SIGN, ERR_R_MALLOC_FAILURE);
             goto err;
@@ -666,7 +666,7 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
             OPENSSL_free(sig);
             goto err;
         }
-        ASN1_STRING_set0(si->signature, sig, siglen);
+        ASN1_STRING_set0(si->signature, sig, (int)siglen);
     } else {
         unsigned char *sig;
         unsigned int siglen;
@@ -769,7 +769,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
     if (EVP_DigestSignFinal(mctx, NULL, &siglen) <= 0)
         goto err;
     OPENSSL_free(abuf);
-    abuf = OPENSSL_malloc(siglen);
+    abuf = (unsigned char *)OPENSSL_malloc(siglen);
     if (abuf == NULL)
         goto err;
     if (EVP_DigestSignFinal(mctx, abuf, &siglen) <= 0)
@@ -795,7 +795,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
 
     EVP_MD_CTX_reset(mctx);
 
-    ASN1_STRING_set0(si->signature, abuf, siglen);
+    ASN1_STRING_set0(si->signature, abuf, (int)siglen);
 
     return 1;
 

--- a/crypto/comp/comp_lib.c
+++ b/crypto/comp/comp_lib.c
@@ -19,7 +19,7 @@ COMP_CTX *COMP_CTX_new(COMP_METHOD *meth)
 {
     COMP_CTX *ret;
 
-    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+    if ((ret = (COMP_CTX *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         COMPerr(COMP_F_COMP_CTX_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -183,10 +183,10 @@ CONF_VALUE *_CONF_new_section(CONF *conf, const char *section)
 
     if ((sk = sk_CONF_VALUE_new_null()) == NULL)
         goto err;
-    if ((v = OPENSSL_malloc(sizeof(*v))) == NULL)
+    if ((v = (CONF_VALUE *)OPENSSL_malloc(sizeof(*v))) == NULL)
         goto err;
     i = strlen(section) + 1;
-    if ((v->section = OPENSSL_malloc(i)) == NULL)
+    if ((v->section = (char *)OPENSSL_malloc(i)) == NULL)
         goto err;
 
     memcpy(v->section, section, i);

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -110,7 +110,7 @@ static CONF *def_create(CONF_METHOD *meth)
 {
     CONF *ret;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (CONF *)OPENSSL_malloc(sizeof(*ret));
     if (ret != NULL)
         if (meth->init(ret) == 0) {
             OPENSSL_free(ret);
@@ -241,7 +241,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
  read_retry:
         BIO_gets(in, p, CONFBUFSIZE - 1);
         p[CONFBUFSIZE - 1] = '\0';
-        ii = i = strlen(p);
+        ii = i = (int)strlen(p);
         if (i == 0 && !again) {
             /* the currently processed BIO is at EOF */
             BIO *parent;
@@ -417,7 +417,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 if (include_dir != NULL) {
                     size_t newlen = strlen(include_dir) + strlen(include) + 2;
 
-                    include_path = OPENSSL_malloc(newlen);
+                    include_path = (char *)OPENSSL_malloc(newlen);
                     OPENSSL_strlcpy(include_path, include_dir, newlen);
                     OPENSSL_strlcat(include_path, "/", newlen);
                     OPENSSL_strlcat(include_path, include, newlen);
@@ -466,7 +466,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
             start = eat_ws(conf, p);
             trim_ws(conf, start);
 
-            if ((v = OPENSSL_malloc(sizeof(*v))) == NULL) {
+            if ((v = (CONF_VALUE *)OPENSSL_malloc(sizeof(*v))) == NULL) {
                 CONFerr(CONF_F_DEF_LOAD_BIO, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
@@ -586,7 +586,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
     if ((buf = BUF_MEM_new()) == NULL)
         return 0;
 
-    len = strlen(from) + 1;
+    len = (int)(strlen(from) + 1);
     if (!BUF_MEM_grow(buf, len))
         goto err;
 
@@ -691,8 +691,8 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
              */
             p = _CONF_get_string(conf, cp, np);
             if (rrp != NULL)
-                *rrp = rr;
-            *rp = r;
+                *rrp = (char)rr;
+            *rp = (char)r;
             if (p == NULL) {
                 CONFerr(CONF_F_STR_COPY, CONF_R_VARIABLE_HAS_NO_VALUE);
                 goto err;
@@ -713,7 +713,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
              * Since we change the pointer 'from', we also have to change the
              * perceived length of the string it points at.  /RL
              */
-            len -= e - from;
+            len -= (int)(e - from);
             from = e;
 
             /*
@@ -721,7 +721,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from)
              * variable reference, we have to put back the character that was
              * replaced with a '\0'.  /RL
              */
-            *rp = r;
+            *rp = (char)r;
         } else
             buf->data[to++] = *(from++);
     }
@@ -795,7 +795,7 @@ static BIO *get_next_file(const char *path, OPENSSL_DIR_CTX **dirctx)
             BIO *bio;
 
             newlen = pathlen + namelen + 2;
-            newpath = OPENSSL_zalloc(newlen);
+            newpath = (char *)OPENSSL_zalloc(newlen);
             if (newpath == NULL) {
                 CONFerr(CONF_F_GET_NEXT_FILE, ERR_R_MALLOC_FAILURE);
                 break;

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -360,7 +360,7 @@ int NCONF_dump_bio(const CONF *conf, BIO *out)
  */
 OPENSSL_INIT_SETTINGS *OPENSSL_INIT_new(void)
 {
-    OPENSSL_INIT_SETTINGS *ret = malloc(sizeof(*ret));
+    OPENSSL_INIT_SETTINGS *ret = (OPENSSL_INIT_SETTINGS *)malloc(sizeof(*ret));
 
     if (ret == NULL)
         return NULL;

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -296,7 +296,7 @@ static CONF_MODULE *module_add(DSO *dso, const char *name,
         supported_modules = sk_CONF_MODULE_new_null();
     if (supported_modules == NULL)
         return NULL;
-    if ((tmod = OPENSSL_zalloc(sizeof(*tmod))) == NULL) {
+    if ((tmod = (CONF_MODULE *)OPENSSL_zalloc(sizeof(*tmod))) == NULL) {
         CONFerr(CONF_F_MODULE_ADD, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -333,9 +333,9 @@ static CONF_MODULE *module_find(const char *name)
     p = strrchr(name, '.');
 
     if (p)
-        nchar = p - name;
+        nchar = (int)(p - name);
     else
-        nchar = strlen(name);
+        nchar = (int)strlen(name);
 
     for (i = 0; i < sk_CONF_MODULE_num(supported_modules); i++) {
         tmod = sk_CONF_MODULE_value(supported_modules, i);
@@ -356,7 +356,7 @@ static int module_init(CONF_MODULE *pmod, const char *name, const char *value,
     CONF_IMODULE *imod = NULL;
 
     /* Otherwise add initialized module to list */
-    imod = OPENSSL_malloc(sizeof(*imod));
+    imod = (CONF_IMODULE *)OPENSSL_malloc(sizeof(*imod));
     if (imod == NULL)
         goto err;
 
@@ -553,7 +553,7 @@ char *CONF_get1_default_config_file(void)
     sep = "/";
 #endif
     size = strlen(t) + strlen(sep) + strlen(OPENSSL_CONF) + 1;
-    file = OPENSSL_malloc(size);
+    file = (char *)OPENSSL_malloc(size);
 
     if (file == NULL)
         return NULL;
@@ -599,7 +599,7 @@ int CONF_parse_list(const char *list_, int sep, int nospc,
                 while (isspace((unsigned char)*tmpend))
                     tmpend--;
             }
-            ret = list_cb(lstart, tmpend - lstart + 1, arg);
+            ret = list_cb(lstart, (int)(tmpend - lstart + 1), arg);
         }
         if (ret <= 0)
             return ret;

--- a/crypto/conf/conf_ssl.c
+++ b/crypto/conf/conf_ssl.c
@@ -77,7 +77,7 @@ static int ssl_module_init(CONF_IMODULE *md, const CONF *cnf)
     }
     cnt = sk_CONF_VALUE_num(cmd_lists);
     ssl_module_free(md);
-    ssl_names = OPENSSL_zalloc(sizeof(*ssl_names) * cnt);
+    ssl_names = (struct ssl_conf_name_st *)OPENSSL_zalloc(sizeof(*ssl_names) * cnt);
     if (ssl_names == NULL)
         goto err;
     ssl_names_count = cnt;
@@ -100,7 +100,7 @@ static int ssl_module_init(CONF_IMODULE *md, const CONF *cnf)
         if (ssl_name->name == NULL)
             goto err;
         cnt = sk_CONF_VALUE_num(cmds);
-        ssl_name->cmds = OPENSSL_zalloc(cnt * sizeof(struct ssl_conf_cmd_st));
+        ssl_name->cmds = (SSL_CONF_CMD *)OPENSSL_zalloc(cnt * sizeof(struct ssl_conf_cmd_st));
         if (ssl_name->cmds == NULL)
             goto err;
         ssl_name->cmd_count = cnt;

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -158,7 +158,7 @@ static int set_default_context(OPENSSL_CTX *defctx)
 
 OPENSSL_CTX *OPENSSL_CTX_new(void)
 {
-    OPENSSL_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    OPENSSL_CTX *ctx = (OPENSSL_CTX *)OPENSSL_zalloc(sizeof(*ctx));
 
     if (ctx != NULL && !context_init(ctx)) {
         OPENSSL_CTX_free(ctx);
@@ -227,7 +227,7 @@ static void openssl_ctx_generic_new(void *parent_ign, void *ptr_ign,
                                     CRYPTO_EX_DATA *ad, int index,
                                     long argl_ign, void *argp)
 {
-    const OPENSSL_CTX_METHOD *meth = argp;
+    const OPENSSL_CTX_METHOD *meth = (const OPENSSL_CTX_METHOD *)argp;
     void *ptr = meth->new_func(crypto_ex_data_get_openssl_ctx(ad));
 
     if (ptr != NULL)
@@ -237,7 +237,7 @@ static void openssl_ctx_generic_free(void *parent_ign, void *ptr,
                                      CRYPTO_EX_DATA *ad, int index,
                                      long argl_ign, void *argp)
 {
-    const OPENSSL_CTX_METHOD *meth = argp;
+    const OPENSSL_CTX_METHOD *meth = (const OPENSSL_CTX_METHOD *)argp;
 
     meth->free_func(ptr);
 }
@@ -357,7 +357,7 @@ int openssl_ctx_run_once(OPENSSL_CTX *ctx, unsigned int idx,
 int openssl_ctx_onfree(OPENSSL_CTX *ctx, openssl_ctx_onfree_fn onfreefn)
 {
     struct openssl_ctx_onfree_list_st *newonfree
-        = OPENSSL_malloc(sizeof(*newonfree));
+        = (struct openssl_ctx_onfree_list_st *)OPENSSL_malloc(sizeof(*newonfree));
 
     if (newonfree == NULL)
         return 0;

--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -26,7 +26,7 @@ struct algorithm_data_st {
 
 static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
 {
-    struct algorithm_data_st *data = cbdata;
+    struct algorithm_data_st *data = (struct algorithm_data_st *)cbdata;
     int no_store = 0;    /* Assume caching is ok */
     int first_operation = 1;
     int last_operation = OSSL_OP__HIGHEST;

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -64,7 +64,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
                                        const OSSL_ALGORITHM *algo,
                                        int no_store, void *cbdata)
 {
-    struct construct_data_st *data = cbdata;
+    struct construct_data_st *data = (struct construct_data_st *)cbdata;
     void *method = NULL;
 
     if ((method = data->mcm->construct(algo, provider, data->mcm_data))
@@ -113,7 +113,7 @@ void *ossl_method_construct(OPENSSL_CTX *libctx, int operation_id,
          * We have a temporary store to be able to easily search among new
          * items, or items that should find themselves in the global store.
          */
-        if ((cbdata.store = mcm->alloc_tmp_store(libctx)) == NULL)
+        if ((cbdata.store = (OSSL_METHOD_STORE *)mcm->alloc_tmp_store(libctx)) == NULL)
             goto fin;
 
         cbdata.libctx = libctx;

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -443,8 +443,8 @@ void OPENSSL_die(const char *message, const char *file, int line)
 int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len)
 {
     size_t i;
-    const volatile unsigned char *a = in_a;
-    const volatile unsigned char *b = in_b;
+    const volatile unsigned char *a = (const volatile unsigned char *)in_a;
+    const volatile unsigned char *b = (const volatile unsigned char *)in_b;
     unsigned char x = 0;
 
     for (i = 0; i < len; i++)

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -114,7 +114,7 @@ DH *d2i_DHxparams(DH **a, const unsigned char **pp, long length)
         /* The counter has a maximum value of 4 * numbits(p) - 1 */
         size_t counter = (size_t)BN_get_word(dhx->vparams->counter);
         ffc_params_set_validate_params(params, dhx->vparams->seed->data,
-                                       dhx->vparams->seed->length, counter);
+                                       dhx->vparams->seed->length, (int)counter);
         ASN1_BIT_STRING_free(dhx->vparams->seed);
         BN_free(dhx->vparams->counter);
         OPENSSL_free(dhx->vparams);

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -331,7 +331,7 @@ int dh_buf2key(DH *dh, const unsigned char *buf, size_t len)
     const BIGNUM *p;
     size_t p_size;
 
-    if ((pubkey = BN_bin2bn(buf, len, NULL)) == NULL)
+    if ((pubkey = BN_bin2bn(buf, (int)len, NULL)) == NULL)
         goto err;
     DH_get0_pqg(dh, &p, NULL, NULL);
     if (p == NULL || (p_size = BN_num_bytes(p)) == 0) {
@@ -375,7 +375,7 @@ size_t dh_key2buf(const DH *dh, unsigned char **pbuf_out, size_t size, int alloc
             if (size >= (size_t)p_size)
                 pbuf = *pbuf_out;
         } else {
-            pbuf = OPENSSL_malloc(p_size);
+            pbuf = (unsigned char *)OPENSSL_malloc(p_size);
         }
 
         if (pbuf == NULL) {

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -70,7 +70,7 @@ DH *dh_new_with_libctx(OPENSSL_CTX *libctx)
 
 static DH *dh_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 {
-    DH *ret = OPENSSL_zalloc(sizeof(*ret));
+    DH *ret = (DH *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         DHerr(0, ERR_R_MALLOC_FAILURE);

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -44,7 +44,7 @@ static int dsa_pub_decode(EVP_PKEY *pkey, const X509_PUBKEY *pubkey)
     X509_ALGOR_get0(NULL, &ptype, &pval, palg);
 
     if (ptype == V_ASN1_SEQUENCE) {
-        pstr = pval;
+        pstr = (const ASN1_STRING *)pval;
         pm = pstr->data;
         pmlen = pstr->length;
 
@@ -172,7 +172,7 @@ static int dsa_priv_decode(EVP_PKEY *pkey, const PKCS8_PRIV_KEY_INFO *p8)
     if (privkey->type == V_ASN1_NEG_INTEGER || ptype != V_ASN1_SEQUENCE)
         goto decerr;
 
-    pstr = pval;
+    pstr = (const ASN1_STRING *)pval;
     pm = pstr->data;
     pmlen = pstr->length;
     if ((dsa = d2i_DSAparams(NULL, &pm, pmlen)) == NULL)
@@ -470,7 +470,7 @@ static int dsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         if (arg1 == 0) {
             int snid, hnid;
             X509_ALGOR *alg1, *alg2;
-            PKCS7_SIGNER_INFO_get0_algs(arg2, NULL, &alg1, &alg2);
+            PKCS7_SIGNER_INFO_get0_algs((PKCS7_SIGNER_INFO *)arg2, NULL, &alg1, &alg2);
             if (alg1 == NULL || alg1->algorithm == NULL)
                 return -1;
             hnid = OBJ_obj2nid(alg1->algorithm);
@@ -486,7 +486,7 @@ static int dsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         if (arg1 == 0) {
             int snid, hnid;
             X509_ALGOR *alg1, *alg2;
-            CMS_SignerInfo_get0_algs(arg2, NULL, NULL, &alg1, &alg2);
+            CMS_SignerInfo_get0_algs((CMS_SignerInfo *)arg2, NULL, NULL, &alg1, &alg2);
             if (alg1 == NULL || alg1->algorithm == NULL)
                 return -1;
             hnid = OBJ_obj2nid(alg1->algorithm);
@@ -578,7 +578,7 @@ err:
 
 static int dsa_pkey_import_from(const OSSL_PARAM params[], void *vpctx)
 {
-    EVP_PKEY_CTX *pctx = vpctx;
+    EVP_PKEY_CTX *pctx = (EVP_PKEY_CTX *)vpctx;
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(pctx);
     DSA *dsa = dsa_new_with_ctx(pctx->libctx);
 

--- a/crypto/dsa/dsa_asn1.c
+++ b/crypto/dsa/dsa_asn1.c
@@ -68,5 +68,5 @@ IMPLEMENT_ASN1_ENCODE_FUNCTIONS_fname(DSA, DSAPublicKey, DSAPublicKey)
 
 DSA *DSAparams_dup(const DSA *dsa)
 {
-    return ASN1_item_dup(ASN1_ITEM_rptr(DSAparams), dsa);
+    return (DSA *)ASN1_item_dup(ASN1_ITEM_rptr(DSAparams), dsa);
 }

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -134,7 +134,7 @@ const DSA_METHOD *DSA_get_method(DSA *d)
 
 static DSA *dsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 {
-    DSA *ret = OPENSSL_zalloc(sizeof(*ret));
+    DSA *ret = (DSA *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         DSAerr(0, ERR_R_MALLOC_FAILURE);

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -37,7 +37,7 @@ typedef struct {
 
 static int pkey_dsa_init(EVP_PKEY_CTX *ctx)
 {
-    DSA_PKEY_CTX *dctx = OPENSSL_malloc(sizeof(*dctx));
+    DSA_PKEY_CTX *dctx = (DSA_PKEY_CTX *)OPENSSL_malloc(sizeof(*dctx));
 
     if (dctx == NULL)
         return 0;
@@ -59,8 +59,8 @@ static int pkey_dsa_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
 
     if (!pkey_dsa_init(dst))
         return 0;
-    sctx = src->data;
-    dctx = dst->data;
+    sctx = (DSA_PKEY_CTX *)src->data;
+    dctx = (DSA_PKEY_CTX *)dst->data;
     dctx->nbits = sctx->nbits;
     dctx->qbits = sctx->qbits;
     dctx->pmd = sctx->pmd;
@@ -70,7 +70,7 @@ static int pkey_dsa_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
 
 static void pkey_dsa_cleanup(EVP_PKEY_CTX *ctx)
 {
-    DSA_PKEY_CTX *dctx = ctx->data;
+    DSA_PKEY_CTX *dctx = (DSA_PKEY_CTX *)ctx->data;
     OPENSSL_free(dctx);
 }
 
@@ -80,13 +80,13 @@ static int pkey_dsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
 {
     int ret;
     unsigned int sltmp;
-    DSA_PKEY_CTX *dctx = ctx->data;
+    DSA_PKEY_CTX *dctx = (DSA_PKEY_CTX *)ctx->data;
     DSA *dsa = ctx->pkey->pkey.dsa;
 
     if (dctx->md != NULL && tbslen != (size_t)EVP_MD_size(dctx->md))
         return 0;
 
-    ret = DSA_sign(0, tbs, tbslen, sig, &sltmp, dsa);
+    ret = DSA_sign(0, tbs, (int)tbslen, sig, &sltmp, dsa);
 
     if (ret <= 0)
         return ret;
@@ -99,20 +99,20 @@ static int pkey_dsa_verify(EVP_PKEY_CTX *ctx,
                            const unsigned char *tbs, size_t tbslen)
 {
     int ret;
-    DSA_PKEY_CTX *dctx = ctx->data;
+    DSA_PKEY_CTX *dctx = (DSA_PKEY_CTX *)ctx->data;
     DSA *dsa = ctx->pkey->pkey.dsa;
 
     if (dctx->md != NULL && tbslen != (size_t)EVP_MD_size(dctx->md))
         return 0;
 
-    ret = DSA_verify(0, tbs, tbslen, sig, siglen, dsa);
+    ret = DSA_verify(0, tbs, (int)tbslen, sig, (int)siglen, dsa);
 
     return ret;
 }
 
 static int pkey_dsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 {
-    DSA_PKEY_CTX *dctx = ctx->data;
+    DSA_PKEY_CTX *dctx = (DSA_PKEY_CTX *)ctx->data;
 
     switch (type) {
     case EVP_PKEY_CTRL_DSA_PARAMGEN_BITS:
@@ -134,7 +134,7 @@ static int pkey_dsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             DSAerr(DSA_F_PKEY_DSA_CTRL, DSA_R_INVALID_DIGEST_TYPE);
             return 0;
         }
-        dctx->pmd = p2;
+        dctx->pmd = (const EVP_MD *)p2;
         return 1;
 
     case EVP_PKEY_CTRL_MD:
@@ -152,7 +152,7 @@ static int pkey_dsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             DSAerr(DSA_F_PKEY_DSA_CTRL, DSA_R_INVALID_DIGEST_TYPE);
             return 0;
         }
-        dctx->md = p2;
+        dctx->md = (const EVP_MD *)p2;
         return 1;
 
     case EVP_PKEY_CTRL_GET_MD:
@@ -201,7 +201,7 @@ static int pkey_dsa_ctrl_str(EVP_PKEY_CTX *ctx,
 static int pkey_dsa_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 {
     DSA *dsa = NULL;
-    DSA_PKEY_CTX *dctx = ctx->data;
+    DSA_PKEY_CTX *dctx = (DSA_PKEY_CTX *)ctx->data;
     BN_GENCB *pcb;
     int ret, res;
 

--- a/crypto/dsa/dsa_sign.c
+++ b/crypto/dsa/dsa_sign.c
@@ -33,7 +33,7 @@ int DSA_sign_setup(DSA *dsa, BN_CTX *ctx_in, BIGNUM **kinvp, BIGNUM **rp)
 
 DSA_SIG *DSA_SIG_new(void)
 {
-    DSA_SIG *sig = OPENSSL_zalloc(sizeof(*sig));
+    DSA_SIG *sig = (DSA_SIG *)OPENSSL_zalloc(sizeof(*sig));
     if (sig == NULL)
         DSAerr(DSA_F_DSA_SIG_NEW, ERR_R_MALLOC_FAILURE);
     return sig;

--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -2069,7 +2069,7 @@ static uint8_t equal(signed char b, signed char c)
     uint32_t y = x;      /* 0: yes; 1..255: no */
     y -= 1;              /* 4294967295: yes; 0..254: no */
     y >>= 31;            /* 1: yes; 0: no */
-    return y;
+    return (uint8_t)y;
 }
 
 static void cmov(ge_precomp *t, const ge_precomp *u, uint8_t b)
@@ -4200,7 +4200,7 @@ static uint8_t negative(signed char b)
     uint32_t x = b;
 
     x >>= 31; /* 1: yes; 0: no */
-    return x;
+    return (uint8_t)x;
 }
 
 static void table_select(ge_precomp *t, int pos, signed char b)

--- a/crypto/ec/curve448/curve448.c
+++ b/crypto/ec/curve448/curve448.c
@@ -400,7 +400,7 @@ c448_error_t x448_int(uint8_t out[X_PUBLIC_BYTES],
         if (t / 8 == 0)
             sb &= -(uint8_t)COFACTOR;
         else if (t == X_PRIVATE_BITS - 1)
-            sb = -1;
+            sb = (uint8_t)(-1);
 
         k_t = (sb >> (t % 8)) & 1;
         k_t = 0 - k_t;             /* set to all 0s or all 1s */

--- a/crypto/ec/curve448/scalar.c
+++ b/crypto/ec/curve448/scalar.c
@@ -214,7 +214,7 @@ void curve448_scalar_encode(unsigned char ser[C448_SCALAR_BYTES],
 
     for (i = 0; i < C448_SCALAR_LIMBS; i++) {
         for (j = 0; j < sizeof(c448_word_t); j++, k++)
-            ser[k] = s->limb[i] >> (8 * j);
+            ser[k] = (unsigned char)(s->limb[i] >> (8 * j));
     }
 }
 

--- a/crypto/ec/ec2_oct.c
+++ b/crypto/ec/ec2_oct.c
@@ -187,7 +187,7 @@ size_t ec_GF2m_simple_point2oct(const EC_GROUP *group, const EC_POINT *point,
         if (!EC_POINT_get_affine_coordinates(group, point, x, y, ctx))
             goto err;
 
-        buf[0] = form;
+        buf[0] = (unsigned char)form;
         if ((form != POINT_CONVERSION_UNCOMPRESSED) && !BN_is_zero(x)) {
             if (!group->meth->field_div(group, yxi, y, x, ctx))
                 goto err;
@@ -271,9 +271,9 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
         ECerr(EC_F_EC_GF2M_SIMPLE_OCT2POINT, EC_R_BUFFER_TOO_SMALL);
         return 0;
     }
-    form = buf[0];
+    form = (point_conversion_form_t)buf[0];
     y_bit = form & 1;
-    form = form & ~1U;
+    form = (point_conversion_form_t)(form & ~1U);
     if ((form != 0) && (form != POINT_CONVERSION_COMPRESSED)
         && (form != POINT_CONVERSION_UNCOMPRESSED)
         && (form != POINT_CONVERSION_HYBRID)) {
@@ -320,7 +320,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     if (yxi == NULL)
         goto err;
 
-    if (!BN_bin2bn(buf + 1, field_len, x))
+    if (!BN_bin2bn(buf + 1, (int)field_len, x))
         goto err;
     if (BN_num_bits(x) > m) {
         ECerr(EC_F_EC_GF2M_SIMPLE_OCT2POINT, EC_R_INVALID_ENCODING);
@@ -331,7 +331,7 @@ int ec_GF2m_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
         if (!EC_POINT_set_compressed_coordinates(group, point, x, y_bit, ctx))
             goto err;
     } else {
-        if (!BN_bin2bn(buf + 1 + field_len, field_len, y))
+        if (!BN_bin2bn(buf + 1 + field_len, (int)field_len, y))
             goto err;
         if (BN_num_bits(y) > m) {
             ECerr(EC_F_EC_GF2M_SIMPLE_OCT2POINT, EC_R_INVALID_ENCODING);

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3415,7 +3415,7 @@ int ec_curve_nid_from_params(const EC_GROUP *group, BN_CTX *ctx)
         param_len = len;
 
     /* Allocate space to store the padded data for (p, a, b, x, y, order)  */
-    param_bytes = OPENSSL_malloc(param_len * NUM_BN_FIELDS);
+    param_bytes = (unsigned char *)OPENSSL_malloc(param_len * NUM_BN_FIELDS);
     if (param_bytes == NULL)
         goto end;
 

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -882,7 +882,7 @@ size_t ec_key_simple_priv2oct(const EC_KEY *eckey,
 
     /* Octetstring may need leading zeros if BN is to short */
 
-    if (BN_bn2binpad(eckey->priv_key, buf, buf_len) == -1) {
+    if (BN_bn2binpad(eckey->priv_key, buf, (int)buf_len) == -1) {
         ECerr(EC_F_EC_KEY_SIMPLE_PRIV2OCT, EC_R_BUFFER_TOO_SMALL);
         return 0;
     }
@@ -914,7 +914,7 @@ int ec_key_simple_oct2priv(EC_KEY *eckey, const unsigned char *buf, size_t len)
         ECerr(EC_F_EC_KEY_SIMPLE_OCT2PRIV, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    eckey->priv_key = BN_bin2bn(buf, len, eckey->priv_key);
+    eckey->priv_key = BN_bin2bn(buf, (int)len, eckey->priv_key);
     if (eckey->priv_key == NULL) {
         ECerr(EC_F_EC_KEY_SIMPLE_OCT2PRIV, ERR_R_BN_LIB);
         return 0;
@@ -931,7 +931,7 @@ size_t EC_KEY_priv2buf(const EC_KEY *eckey, unsigned char **pbuf)
     len = EC_KEY_priv2oct(eckey, NULL, 0);
     if (len == 0)
         return 0;
-    if ((buf = OPENSSL_malloc(len)) == NULL) {
+    if ((buf = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
         ECerr(EC_F_EC_KEY_PRIV2BUF, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/ec/ec_kmeth.c
+++ b/crypto/ec/ec_kmeth.c
@@ -79,7 +79,7 @@ int EC_KEY_set_method(EC_KEY *key, const EC_KEY_METHOD *meth)
 EC_KEY *ec_key_new_method_int(OPENSSL_CTX *libctx, const char *propq,
                               ENGINE *engine)
 {
-    EC_KEY *ret = OPENSSL_zalloc(sizeof(*ret));
+    EC_KEY *ret = (EC_KEY *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         ECerr(EC_F_EC_KEY_NEW_METHOD_INT, ERR_R_MALLOC_FAILURE);
@@ -174,12 +174,12 @@ int ECDH_compute_key(void *out, size_t outlen, const EC_POINT *pub_key,
         memcpy(out, sec, outlen);
     }
     OPENSSL_clear_free(sec, seclen);
-    return outlen;
+    return (int)outlen;
 }
 
 EC_KEY_METHOD *EC_KEY_METHOD_new(const EC_KEY_METHOD *meth)
 {
-    EC_KEY_METHOD *ret = OPENSSL_zalloc(sizeof(*meth));
+    EC_KEY_METHOD *ret = (EC_KEY_METHOD *)OPENSSL_zalloc(sizeof(*meth));
 
     if (ret == NULL)
         return NULL;

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -40,7 +40,7 @@ EC_GROUP *ec_group_new_with_libctx(OPENSSL_CTX *libctx, const char *propq,
         return NULL;
     }
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (EC_GROUP *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ECerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -246,7 +246,7 @@ int EC_GROUP_copy(EC_GROUP *dest, const EC_GROUP *src)
 
     if (src->seed) {
         OPENSSL_free(dest->seed);
-        if ((dest->seed = OPENSSL_malloc(src->seed_len)) == NULL) {
+        if ((dest->seed = (unsigned char *)OPENSSL_malloc(src->seed_len)) == NULL) {
             ECerr(EC_F_EC_GROUP_COPY, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -528,7 +528,7 @@ size_t EC_GROUP_set_seed(EC_GROUP *group, const unsigned char *p, size_t len)
     if (!len || !p)
         return 1;
 
-    if ((group->seed = OPENSSL_malloc(len)) == NULL) {
+    if ((group->seed = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
         ECerr(EC_F_EC_GROUP_SET_SEED, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -722,7 +722,7 @@ EC_POINT *EC_POINT_new(const EC_GROUP *group)
         return NULL;
     }
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (EC_POINT *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ECerr(EC_F_EC_POINT_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/ec/ec_mult.c
+++ b/crypto/ec/ec_mult.c
@@ -55,7 +55,7 @@ static EC_PRE_COMP *ec_pre_comp_new(const EC_GROUP *group)
     if (!group)
         return NULL;
 
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (EC_PRE_COMP *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ECerr(EC_F_EC_PRE_COMP_NEW, ERR_R_MALLOC_FAILURE);
         return ret;
@@ -509,11 +509,11 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 
     totalnum = num + numblocks;
 
-    wsize = OPENSSL_malloc(totalnum * sizeof(wsize[0]));
-    wNAF_len = OPENSSL_malloc(totalnum * sizeof(wNAF_len[0]));
+    wsize = (size_t *)OPENSSL_malloc(totalnum * sizeof(wsize[0]));
+    wNAF_len = (size_t *)OPENSSL_malloc(totalnum * sizeof(wNAF_len[0]));
     /* include space for pivot */
-    wNAF = OPENSSL_malloc((totalnum + 1) * sizeof(wNAF[0]));
-    val_sub = OPENSSL_malloc(totalnum * sizeof(val_sub[0]));
+    wNAF = (signed char **)OPENSSL_malloc((totalnum + 1) * sizeof(wNAF[0]));
+    val_sub = (EC_POINT ***)OPENSSL_malloc(totalnum * sizeof(val_sub[0]));
 
     /* Ensure wNAF is initialised in case we end up going to err */
     if (wNAF != NULL)
@@ -537,7 +537,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
         num_val += (size_t)1 << (wsize[i] - 1);
         wNAF[i + 1] = NULL;     /* make sure we always have a pivot */
         wNAF[i] =
-            bn_compute_wNAF((i < num ? scalars[i] : scalar), wsize[i],
+            bn_compute_wNAF((i < num ? scalars[i] : scalar), (int)wsize[i],
                             &wNAF_len[i]);
         if (wNAF[i] == NULL)
             goto err;
@@ -567,7 +567,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
              * use the window size for which we have precomputation
              */
             wsize[num] = pre_comp->w;
-            tmp_wNAF = bn_compute_wNAF(scalar, wsize[num], &tmp_len);
+            tmp_wNAF = bn_compute_wNAF(scalar, (int)wsize[num], &tmp_len);
             if (!tmp_wNAF)
                 goto err;
 
@@ -630,7 +630,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
                         wNAF_len[i] = tmp_len;
 
                     wNAF[i + 1] = NULL;
-                    wNAF[i] = OPENSSL_malloc(wNAF_len[i]);
+                    wNAF[i] = (signed char *)OPENSSL_malloc(wNAF_len[i]);
                     if (wNAF[i] == NULL) {
                         ECerr(EC_F_EC_WNAF_MUL, ERR_R_MALLOC_FAILURE);
                         OPENSSL_free(tmp_wNAF);
@@ -659,7 +659,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
      * 'val_sub[i]' is a pointer to the subarray for the i-th point, or to a
      * subarray of 'pre_comp->points' if we already have precomputation.
      */
-    val = OPENSSL_malloc((num_val + 1) * sizeof(val[0]));
+    val = (EC_POINT **)OPENSSL_malloc((num_val + 1) * sizeof(val[0]));
     if (val == NULL) {
         ECerr(EC_F_EC_WNAF_MUL, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -718,7 +718,7 @@ int ec_wNAF_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *scalar,
 
     r_is_at_infinity = 1;
 
-    for (k = max_len - 1; k >= 0; k--) {
+    for (k = (int)(max_len - 1); k >= 0; k--) {
         if (!r_is_at_infinity) {
             if (!EC_POINT_dbl(group, r, r, ctx))
                 goto err;
@@ -889,7 +889,7 @@ int ec_wNAF_precompute_mult(EC_GROUP *group, BN_CTX *ctx)
     num = pre_points_per_block * numblocks; /* number of points to compute
                                              * and store */
 
-    points = OPENSSL_malloc(sizeof(*points) * (num + 1));
+    points = (EC_POINT **)OPENSSL_malloc(sizeof(*points) * (num + 1));
     if (points == NULL) {
         ECerr(EC_F_EC_WNAF_PRECOMPUTE_MULT, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/ec/ec_oct.c
+++ b/crypto/ec/ec_oct.c
@@ -142,7 +142,7 @@ size_t EC_POINT_point2buf(const EC_GROUP *group, const EC_POINT *point,
     len = EC_POINT_point2oct(group, point, form, NULL, 0, NULL);
     if (len == 0)
         return 0;
-    if ((buf = OPENSSL_malloc(len)) == NULL) {
+    if ((buf = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
         ECerr(EC_F_EC_POINT_POINT2BUF, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/ec/ec_print.c
+++ b/crypto/ec/ec_print.c
@@ -30,7 +30,7 @@ BIGNUM *EC_POINT_point2bn(const EC_GROUP *group,
     if (buf_len == 0)
         return NULL;
 
-    ret = BN_bin2bn(buf, buf_len, ret);
+    ret = BN_bin2bn(buf, (int)buf_len, ret);
 
     OPENSSL_free(buf);
 
@@ -46,12 +46,12 @@ EC_POINT *EC_POINT_bn2point(const EC_GROUP *group,
 
     if ((buf_len = BN_num_bytes(bn)) == 0)
         buf_len = 1;
-    if ((buf = OPENSSL_malloc(buf_len)) == NULL) {
+    if ((buf = (unsigned char *)OPENSSL_malloc(buf_len)) == NULL) {
         ECerr(EC_F_EC_POINT_BN2POINT, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
-    if (!BN_bn2binpad(bn, buf, buf_len)) {
+    if (!BN_bn2binpad(bn, buf, (int)buf_len)) {
         OPENSSL_free(buf);
         return NULL;
     }
@@ -91,7 +91,7 @@ char *EC_POINT_point2hex(const EC_GROUP *group,
     if (buf_len == 0)
         return NULL;
 
-    ret = OPENSSL_malloc(buf_len * 2 + 2);
+    ret = (char *)OPENSSL_malloc(buf_len * 2 + 2);
     if (ret == NULL) {
         OPENSSL_free(buf);
         return NULL;

--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -118,7 +118,7 @@ int ecdh_simple_compute_key(unsigned char **pout, size_t *poutlen,
         ECerr(EC_F_ECDH_SIMPLE_COMPUTE_KEY, ERR_R_INTERNAL_ERROR);
         goto err;
     }
-    if ((buf = OPENSSL_malloc(buflen)) == NULL) {
+    if ((buf = (unsigned char *)OPENSSL_malloc(buflen)) == NULL) {
         ECerr(EC_F_ECDH_SIMPLE_COMPUTE_KEY, ERR_R_MALLOC_FAILURE);
         goto err;
     }

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -92,27 +92,27 @@ int ec_GFp_mont_group_init(EC_GROUP *group)
 
 void ec_GFp_mont_group_finish(EC_GROUP *group)
 {
-    BN_MONT_CTX_free(group->field_data1);
+    BN_MONT_CTX_free((BN_MONT_CTX *)group->field_data1);
     group->field_data1 = NULL;
-    BN_free(group->field_data2);
+    BN_free((BIGNUM *)group->field_data2);
     group->field_data2 = NULL;
     ec_GFp_simple_group_finish(group);
 }
 
 void ec_GFp_mont_group_clear_finish(EC_GROUP *group)
 {
-    BN_MONT_CTX_free(group->field_data1);
+    BN_MONT_CTX_free((BN_MONT_CTX *)group->field_data1);
     group->field_data1 = NULL;
-    BN_clear_free(group->field_data2);
+    BN_clear_free((BIGNUM *)group->field_data2);
     group->field_data2 = NULL;
     ec_GFp_simple_group_clear_finish(group);
 }
 
 int ec_GFp_mont_group_copy(EC_GROUP *dest, const EC_GROUP *src)
 {
-    BN_MONT_CTX_free(dest->field_data1);
+    BN_MONT_CTX_free((BN_MONT_CTX *)dest->field_data1);
     dest->field_data1 = NULL;
-    BN_clear_free(dest->field_data2);
+    BN_clear_free((BIGNUM *)dest->field_data2);
     dest->field_data2 = NULL;
 
     if (!ec_GFp_simple_group_copy(dest, src))
@@ -122,11 +122,11 @@ int ec_GFp_mont_group_copy(EC_GROUP *dest, const EC_GROUP *src)
         dest->field_data1 = BN_MONT_CTX_new();
         if (dest->field_data1 == NULL)
             return 0;
-        if (!BN_MONT_CTX_copy(dest->field_data1, src->field_data1))
+        if (!BN_MONT_CTX_copy((BN_MONT_CTX *)dest->field_data1, (BN_MONT_CTX *)src->field_data1))
             goto err;
     }
     if (src->field_data2 != NULL) {
-        dest->field_data2 = BN_dup(src->field_data2);
+        dest->field_data2 = BN_dup((const BIGNUM *)src->field_data2);
         if (dest->field_data2 == NULL)
             goto err;
     }
@@ -134,7 +134,7 @@ int ec_GFp_mont_group_copy(EC_GROUP *dest, const EC_GROUP *src)
     return 1;
 
  err:
-    BN_MONT_CTX_free(dest->field_data1);
+    BN_MONT_CTX_free((BN_MONT_CTX *)dest->field_data1);
     dest->field_data1 = NULL;
     return 0;
 }
@@ -147,9 +147,9 @@ int ec_GFp_mont_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     BIGNUM *one = NULL;
     int ret = 0;
 
-    BN_MONT_CTX_free(group->field_data1);
+    BN_MONT_CTX_free((BN_MONT_CTX *)group->field_data1);
     group->field_data1 = NULL;
-    BN_free(group->field_data2);
+    BN_free((BIGNUM *)group->field_data2);
     group->field_data2 = NULL;
 
     if (ctx == NULL) {
@@ -179,9 +179,9 @@ int ec_GFp_mont_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     ret = ec_GFp_simple_group_set_curve(group, p, a, b, ctx);
 
     if (!ret) {
-        BN_MONT_CTX_free(group->field_data1);
+        BN_MONT_CTX_free((BN_MONT_CTX *)group->field_data1);
         group->field_data1 = NULL;
-        BN_free(group->field_data2);
+        BN_free((BIGNUM *)group->field_data2);
         group->field_data2 = NULL;
     }
 
@@ -200,7 +200,7 @@ int ec_GFp_mont_field_mul(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a,
         return 0;
     }
 
-    return BN_mod_mul_montgomery(r, a, b, group->field_data1, ctx);
+    return BN_mod_mul_montgomery(r, a, b, (BN_MONT_CTX *)group->field_data1, ctx);
 }
 
 int ec_GFp_mont_field_sqr(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a,
@@ -211,7 +211,7 @@ int ec_GFp_mont_field_sqr(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a,
         return 0;
     }
 
-    return BN_mod_mul_montgomery(r, a, a, group->field_data1, ctx);
+    return BN_mod_mul_montgomery(r, a, a, (BN_MONT_CTX *)group->field_data1, ctx);
 }
 
 /*-
@@ -246,7 +246,7 @@ int ec_GFp_mont_field_inv(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a,
      * Exponent e is public.
      * No need for scatter-gather or BN_FLG_CONSTTIME.
      */
-    if (!BN_mod_exp_mont(r, a, e, group->field, ctx, group->field_data1))
+    if (!BN_mod_exp_mont(r, a, e, group->field, ctx, (BN_MONT_CTX *)group->field_data1))
         goto err;
 
     /* throw an error on zero */
@@ -282,7 +282,7 @@ int ec_GFp_mont_field_decode(const EC_GROUP *group, BIGNUM *r,
         return 0;
     }
 
-    return BN_from_montgomery(r, a, group->field_data1, ctx);
+    return BN_from_montgomery(r, a, (BN_MONT_CTX *)group->field_data1, ctx);
 }
 
 int ec_GFp_mont_field_set_to_one(const EC_GROUP *group, BIGNUM *r,
@@ -293,7 +293,7 @@ int ec_GFp_mont_field_set_to_one(const EC_GROUP *group, BIGNUM *r,
         return 0;
     }
 
-    if (!BN_copy(r, group->field_data2))
+    if (!BN_copy(r, (const BIGNUM *)group->field_data2))
         return 0;
     return 1;
 }

--- a/crypto/ec/ecp_oct.c
+++ b/crypto/ec/ecp_oct.c
@@ -223,9 +223,9 @@ size_t ec_GFp_simple_point2oct(const EC_GROUP *group, const EC_POINT *point,
 
         if ((form == POINT_CONVERSION_COMPRESSED
              || form == POINT_CONVERSION_HYBRID) && BN_is_odd(y))
-            buf[0] = form + 1;
+            buf[0] = (unsigned char)(form + 1);
         else
-            buf[0] = form;
+            buf[0] = (unsigned char)form;
 
         i = 1;
 
@@ -292,9 +292,9 @@ int ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
         ECerr(EC_F_EC_GFP_SIMPLE_OCT2POINT, EC_R_BUFFER_TOO_SMALL);
         return 0;
     }
-    form = buf[0];
+    form = (point_conversion_form_t)buf[0];
     y_bit = form & 1;
-    form = form & ~1U;
+    form = (point_conversion_form_t)(form & ~1U);
     if ((form != 0) && (form != POINT_CONVERSION_COMPRESSED)
         && (form != POINT_CONVERSION_UNCOMPRESSED)
         && (form != POINT_CONVERSION_HYBRID)) {
@@ -337,7 +337,7 @@ int ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     if (y == NULL)
         goto err;
 
-    if (!BN_bin2bn(buf + 1, field_len, x))
+    if (!BN_bin2bn(buf + 1, (int)field_len, x))
         goto err;
     if (BN_ucmp(x, group->field) >= 0) {
         ECerr(EC_F_EC_GFP_SIMPLE_OCT2POINT, EC_R_INVALID_ENCODING);
@@ -348,7 +348,7 @@ int ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
         if (!EC_POINT_set_compressed_coordinates(group, point, x, y_bit, ctx))
             goto err;
     } else {
-        if (!BN_bin2bn(buf + 1 + field_len, field_len, y))
+        if (!BN_bin2bn(buf + 1 + field_len, (int)field_len, y))
             goto err;
         if (BN_ucmp(y, group->field) >= 0) {
             ECerr(EC_F_EC_GFP_SIMPLE_OCT2POINT, EC_R_INVALID_ENCODING);

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1228,7 +1228,7 @@ int ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
     if (tmp_Z == NULL)
         goto err;
 
-    prod_Z = OPENSSL_malloc(num * sizeof(prod_Z[0]));
+    prod_Z = (BIGNUM **)OPENSSL_malloc(num * sizeof(prod_Z[0]));
     if (prod_Z == NULL)
         goto err;
     for (i = 0; i < num; i++) {

--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -12,7 +12,7 @@
 
 ECX_KEY *ecx_key_new(OPENSSL_CTX *libctx, ECX_KEY_TYPE type, int haspubkey)
 {
-    ECX_KEY *ret = OPENSSL_zalloc(sizeof(*ret));
+    ECX_KEY *ret = (ECX_KEY *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL)
         return NULL;
@@ -78,7 +78,7 @@ int ecx_key_up_ref(ECX_KEY *key)
 
 unsigned char *ecx_key_allocate_privkey(ECX_KEY *key)
 {
-    key->privkey = OPENSSL_secure_zalloc(key->keylen);
+    key->privkey = (unsigned char *)OPENSSL_secure_zalloc(key->keylen);
 
     return key->privkey;
 }

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -111,7 +111,7 @@ static int ecx_pub_encode(X509_PUBKEY *pk, const EVP_PKEY *pkey)
         return 0;
     }
 
-    penc = OPENSSL_memdup(ecxkey->pubkey, KEYLEN(pkey));
+    penc = (unsigned char *)OPENSSL_memdup(ecxkey->pubkey, KEYLEN(pkey));
     if (penc == NULL) {
         ECerr(EC_F_ECX_PUB_ENCODE, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -299,14 +299,14 @@ static int ecx_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
     switch (op) {
 
     case ASN1_PKEY_CTRL_SET1_TLS_ENCPT:
-        return ecx_key_op(pkey, pkey->ameth->pkey_id, NULL, arg2, arg1,
+        return ecx_key_op(pkey, pkey->ameth->pkey_id, NULL, (const unsigned char *)arg2, arg1,
                           KEY_OP_PUBLIC, NULL, NULL);
 
     case ASN1_PKEY_CTRL_GET1_TLS_ENCPT:
         if (pkey->pkey.ecx != NULL) {
-            unsigned char **ppt = arg2;
+            unsigned char **ppt = (unsigned char **)arg2;
 
-            *ppt = OPENSSL_memdup(pkey->pkey.ecx->pubkey, KEYLEN(pkey));
+            *ppt = (unsigned char *)OPENSSL_memdup(pkey->pkey.ecx->pubkey, KEYLEN(pkey));
             if (*ppt != NULL)
                 return KEYLEN(pkey);
         }
@@ -336,13 +336,13 @@ static int ecx_set_priv_key(EVP_PKEY *pkey, const unsigned char *priv,
                             size_t len)
 {
     /* TODO(3.0): We should pass a libctx here */
-    return ecx_key_op(pkey, pkey->ameth->pkey_id, NULL, priv, len,
+    return ecx_key_op(pkey, pkey->ameth->pkey_id, NULL, priv, (int)len,
                        KEY_OP_PRIVATE, NULL, NULL);
 }
 
 static int ecx_set_pub_key(EVP_PKEY *pkey, const unsigned char *pub, size_t len)
 {
-    return ecx_key_op(pkey, pkey->ameth->pkey_id, NULL, pub, len,
+    return ecx_key_op(pkey, pkey->ameth->pkey_id, NULL, pub, (int)len,
                       KEY_OP_PUBLIC, NULL, NULL);
 }
 
@@ -437,7 +437,7 @@ static int ecx_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
 static int ecx_generic_import_from(const OSSL_PARAM params[], void *vpctx,
                                    int keytype)
 {
-    EVP_PKEY_CTX *pctx = vpctx;
+    EVP_PKEY_CTX *pctx = (EVP_PKEY_CTX *)vpctx;
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(pctx);
     ECX_KEY *ecx = ecx_key_new(pctx->libctx, KEYNID2TYPE(keytype), 0);
 

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -108,15 +108,15 @@ static int int_ctrl_helper(ENGINE *e, int cmd, long i, void *p,
         cdp++;
         return int_ctrl_cmd_is_null(cdp) ? 0 : cdp->cmd_num;
     case ENGINE_CTRL_GET_NAME_LEN_FROM_CMD:
-        return strlen(cdp->cmd_name);
+        return (int)strlen(cdp->cmd_name);
     case ENGINE_CTRL_GET_NAME_FROM_CMD:
-        return strlen(strcpy(s, cdp->cmd_name));
+        return (int)strlen(strcpy(s, cdp->cmd_name));
     case ENGINE_CTRL_GET_DESC_LEN_FROM_CMD:
-        return strlen(cdp->cmd_desc == NULL ? int_no_description
-                                            : cdp->cmd_desc);
+        return (int)strlen(cdp->cmd_desc == NULL ? int_no_description
+                                                 : cdp->cmd_desc);
     case ENGINE_CTRL_GET_DESC_FROM_CMD:
-        return strlen(strcpy(s, cdp->cmd_desc == NULL ? int_no_description
-                                                      : cdp->cmd_desc));
+        return (int)strlen(strcpy(s, cdp->cmd_desc == NULL ? int_no_description
+                                                           : cdp->cmd_desc));
     case ENGINE_CTRL_GET_CMD_FLAGS:
         return cdp->cmd_flags;
     }

--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -156,7 +156,7 @@ static void dynamic_data_ctx_free_func(void *parent, void *ptr,
  */
 static int dynamic_set_data_ctx(ENGINE *e, dynamic_data_ctx **ctx)
 {
-    dynamic_data_ctx *c = OPENSSL_zalloc(sizeof(*c));
+    dynamic_data_ctx *c = (dynamic_data_ctx *)OPENSSL_zalloc(sizeof(*c));
     int ret = 1;
 
     if (c == NULL) {
@@ -311,7 +311,7 @@ static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
             p = NULL;
         OPENSSL_free(ctx->DYNAMIC_LIBNAME);
         if (p)
-            ctx->DYNAMIC_LIBNAME = OPENSSL_strdup(p);
+            ctx->DYNAMIC_LIBNAME = OPENSSL_strdup((const char *)p);
         else
             ctx->DYNAMIC_LIBNAME = NULL;
         return (ctx->DYNAMIC_LIBNAME ? 1 : 0);
@@ -324,7 +324,7 @@ static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
             p = NULL;
         OPENSSL_free(ctx->engine_id);
         if (p)
-            ctx->engine_id = OPENSSL_strdup(p);
+            ctx->engine_id = OPENSSL_strdup((const char *)p);
         else
             ctx->engine_id = NULL;
         return (ctx->engine_id ? 1 : 0);
@@ -351,7 +351,7 @@ static int dynamic_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
             return 0;
         }
         {
-            char *tmp_str = OPENSSL_strdup(p);
+            char *tmp_str = OPENSSL_strdup((const char *)p);
             if (tmp_str == NULL) {
                 ENGINEerr(ENGINE_F_DYNAMIC_CTRL, ERR_R_MALLOC_FAILURE);
                 return 0;

--- a/crypto/engine/eng_fat.c
+++ b/crypto/engine/eng_fat.c
@@ -51,7 +51,7 @@ int ENGINE_set_default(ENGINE *e, unsigned int flags)
 
 static int int_def_cb(const char *alg, int len, void *arg)
 {
-    unsigned int *pflags = arg;
+    unsigned int *pflags = (unsigned int *)arg;
     if (alg == NULL)
         return 0;
     if (strncmp(alg, "ALL", len) == 0)

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -31,7 +31,7 @@ ENGINE *ENGINE_new(void)
     ENGINE *ret;
 
     if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)
-        || (ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+        || (ret = (ENGINE *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         ENGINEerr(ENGINE_F_ENGINE_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -125,7 +125,7 @@ static ENGINE_CLEANUP_ITEM *int_cleanup_item(ENGINE_CLEANUP_CB *cb)
 {
     ENGINE_CLEANUP_ITEM *item;
 
-    if ((item = OPENSSL_malloc(sizeof(*item))) == NULL) {
+    if ((item = (ENGINE_CLEANUP_ITEM *)OPENSSL_malloc(sizeof(*item))) == NULL) {
         ENGINEerr(ENGINE_F_INT_CLEANUP_ITEM, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -323,7 +323,7 @@ static int test_sha1_init(EVP_MD_CTX *ctx)
 # ifdef TEST_ENG_OPENSSL_SHA_P_INIT
     fprintf(stderr, "(TEST_ENG_OPENSSL_SHA) test_sha1_init() called\n");
 # endif
-    return SHA1_Init(EVP_MD_CTX_md_data(ctx));
+    return SHA1_Init((SHA_CTX *)EVP_MD_CTX_md_data(ctx));
 }
 
 static int test_sha1_update(EVP_MD_CTX *ctx, const void *data, size_t count)
@@ -331,7 +331,7 @@ static int test_sha1_update(EVP_MD_CTX *ctx, const void *data, size_t count)
 # ifdef TEST_ENG_OPENSSL_SHA_P_UPDATE
     fprintf(stderr, "(TEST_ENG_OPENSSL_SHA) test_sha1_update() called\n");
 # endif
-    return SHA1_Update(EVP_MD_CTX_md_data(ctx), data, count);
+    return SHA1_Update((SHA_CTX *)EVP_MD_CTX_md_data(ctx), data, count);
 }
 
 static int test_sha1_final(EVP_MD_CTX *ctx, unsigned char *md)
@@ -339,7 +339,7 @@ static int test_sha1_final(EVP_MD_CTX *ctx, unsigned char *md)
 # ifdef TEST_ENG_OPENSSL_SHA_P_FINAL
     fprintf(stderr, "(TEST_ENG_OPENSSL_SHA) test_sha1_final() called\n");
 # endif
-    return SHA1_Final(md, EVP_MD_CTX_md_data(ctx));
+    return SHA1_Final(md, (SHA_CTX *)EVP_MD_CTX_md_data(ctx));
 }
 
 static EVP_MD *sha1_md = NULL;

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -98,7 +98,7 @@ int engine_table_register(ENGINE_TABLE **table, ENGINE_CLEANUP_CB *cleanup,
         tmplate.nid = *nids;
         fnd = lh_ENGINE_PILE_retrieve(&(*table)->piles, &tmplate);
         if (!fnd) {
-            fnd = OPENSSL_malloc(sizeof(*fnd));
+            fnd = (ENGINE_PILE *)OPENSSL_malloc(sizeof(*fnd));
             if (fnd == NULL)
                 goto end;
             fnd->uptodate = 1;

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -167,7 +167,7 @@ typedef struct {
 
 static void look_str_cb(int nid, STACK_OF(ENGINE) *sk, ENGINE *def, void *arg)
 {
-    ENGINE_FIND_STR *lk = arg;
+    ENGINE_FIND_STR *lk = (ENGINE_FIND_STR *)arg;
     int i;
     if (lk->ameth)
         return;

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -597,7 +597,7 @@ const char *ERR_reason_error_string(unsigned long e)
 /* TODO(3.0): arg ignored for now */
 static void err_delete_thread_state(void *arg)
 {
-    ERR_STATE *state = CRYPTO_THREAD_get_local(&err_thread_local);
+    ERR_STATE *state = (ERR_STATE *)CRYPTO_THREAD_get_local(&err_thread_local);
     if (state == NULL)
         return;
 
@@ -634,7 +634,7 @@ ERR_STATE *err_get_state_int(void)
     if (!RUN_ONCE(&err_init, err_do_init))
         return NULL;
 
-    state = CRYPTO_THREAD_get_local(&err_thread_local);
+    state = (ERR_STATE *)CRYPTO_THREAD_get_local(&err_thread_local);
     if (state == (ERR_STATE*)-1)
         return NULL;
 
@@ -642,7 +642,7 @@ ERR_STATE *err_get_state_int(void)
         if (!CRYPTO_THREAD_set_local(&err_thread_local, (ERR_STATE*)-1))
             return NULL;
 
-        if ((state = OPENSSL_zalloc(sizeof(*state))) == NULL) {
+        if ((state = (ERR_STATE *)OPENSSL_zalloc(sizeof(*state))) == NULL) {
             CRYPTO_THREAD_set_local(&err_thread_local, NULL);
             return NULL;
         }
@@ -788,7 +788,7 @@ void ERR_add_error_vdata(int num, va_list args)
      */
     if ((es->err_data_flags[i] & flags) == flags) {
         str = es->err_data[i];
-        size = es->err_data_size[i];
+        size = (int)es->err_data_size[i];
 
         /*
          * To protect the string we just grabbed from tampering by other
@@ -799,7 +799,7 @@ void ERR_add_error_vdata(int num, va_list args)
          */
         es->err_data[i] = NULL;
         es->err_data_flags[i] = 0;
-    } else if ((str = OPENSSL_malloc(size = 81)) == NULL) {
+    } else if ((str = (char *)OPENSSL_malloc(size = 81)) == NULL) {
         return;
     } else {
         str[0] = '\0';
@@ -815,7 +815,7 @@ void ERR_add_error_vdata(int num, va_list args)
             char *p;
 
             size = len + 20;
-            p = OPENSSL_realloc(str, size);
+            p = (char *)OPENSSL_realloc(str, size);
             if (p == NULL) {
                 OPENSSL_free(str);
                 return;

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -82,7 +82,7 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
          * we have.
          */
         if (buf_size < ERR_MAX_DATA_SIZE
-            && (rbuf = OPENSSL_realloc(buf, ERR_MAX_DATA_SIZE)) != NULL) {
+            && (rbuf = (char *)OPENSSL_realloc(buf, ERR_MAX_DATA_SIZE)) != NULL) {
             buf = rbuf;
             buf_size = ERR_MAX_DATA_SIZE;
         }
@@ -100,7 +100,7 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
          * (According to documentation, realloc leaves the old buffer untouched
          * if it fails)
          */
-        if ((rbuf = OPENSSL_realloc(buf, printed_len + 1)) != NULL) {
+        if ((rbuf = (char *)OPENSSL_realloc(buf, printed_len + 1)) != NULL) {
             buf = rbuf;
             buf_size = printed_len + 1;
         }

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -56,7 +56,7 @@ static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
 static ossl_inline void err_set_data(ERR_STATE *es, size_t i,
                                      void *data, size_t datasz, int flags)
 {
-    es->err_data[i] = data;
+    es->err_data[i] = (char *)data;
     es->err_data_size[i] = datasz;
     es->err_data_flags[i] = flags;
 }

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -185,7 +185,7 @@ void ERR_add_error_mem_bio(const char *separator, BIO *bio)
 
 static int print_bio(const char *str, size_t len, void *bp)
 {
-    return BIO_write((BIO *)bp, str, len);
+    return BIO_write((BIO *)bp, str, (int)len);
 }
 
 void ERR_print_errors(BIO *bp)

--- a/crypto/ess/ess_lib.c
+++ b/crypto/ess/ess_lib.c
@@ -223,7 +223,7 @@ int ESS_SIGNING_CERT_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT *sc)
     int len;
 
     len = i2d_ESS_SIGNING_CERT(sc, NULL);
-    if ((pp = OPENSSL_malloc(len)) == NULL) {
+    if ((pp = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
         ESSerr(ESS_F_ESS_SIGNING_CERT_ADD, ERR_R_MALLOC_FAILURE);
         goto err;
     }
@@ -252,7 +252,7 @@ int ESS_SIGNING_CERT_V2_add(PKCS7_SIGNER_INFO *si,
     unsigned char *p, *pp = NULL;
     int len = i2d_ESS_SIGNING_CERT_V2(sc, NULL);
 
-    if ((pp = OPENSSL_malloc(len)) == NULL) {
+    if ((pp = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
         ESSerr(ESS_F_ESS_SIGNING_CERT_V2_ADD, ERR_R_MALLOC_FAILURE);
         goto err;
     }

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -70,7 +70,7 @@ static int b64_new(BIO *bi)
 {
     BIO_B64_CTX *ctx;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
+    if ((ctx = (BIO_B64_CTX *)OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
         EVPerr(EVP_F_B64_NEW, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -95,7 +95,7 @@ static int b64_free(BIO *a)
     if (a == NULL)
         return 0;
 
-    ctx = BIO_get_data(a);
+    ctx = (BIO_B64_CTX *)BIO_get_data(a);
     if (ctx == NULL)
         return 0;
 
@@ -210,13 +210,13 @@ static int b64_read(BIO *b, char *out, int outl)
 
                 k = EVP_DecodeUpdate(ctx->base64,
                                      (unsigned char *)ctx->buf,
-                                     &num, p, q - p);
+                                     &num, p, (int)(q - p));
                 if ((k <= 0) && (num == 0) && (ctx->start))
                     EVP_DecodeInit(ctx->base64);
                 else {
                     if (p != (unsigned char *)
                         &(ctx->tmp[0])) {
-                        i -= (p - (unsigned char *)
+                        i -= (int)(p - (unsigned char *)
                               &(ctx->tmp[0]));
                         for (x = 0; x < i; x++)
                             ctx->tmp[x] = p[x];
@@ -241,7 +241,7 @@ static int b64_read(BIO *b, char *out, int outl)
                         ctx->tmp_len = 0;
                     }
                 } else if (p != q) { /* finished on a '\n' */
-                    n = q - p;
+                    n = (int)(q - p);
                     for (ii = 0; ii < n; ii++)
                         ctx->tmp[ii] = p[ii];
                     ctx->tmp_len = n;
@@ -544,5 +544,5 @@ static long b64_callback_ctrl(BIO *b, int cmd, BIO_info_cb *fp)
 
 static int b64_puts(BIO *b, const char *str)
 {
-    return b64_write(b, str, strlen(str));
+    return b64_write(b, str, (int)strlen(str));
 }

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -65,7 +65,7 @@ static int enc_new(BIO *bi)
 {
     BIO_ENC_CTX *ctx;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
+    if ((ctx = (BIO_ENC_CTX *)OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
         EVPerr(EVP_F_ENC_NEW, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -91,7 +91,7 @@ static int enc_free(BIO *a)
     if (a == NULL)
         return 0;
 
-    b = BIO_get_data(a);
+    b = (BIO_ENC_CTX *)BIO_get_data(a);
     if (b == NULL)
         return 0;
 
@@ -111,7 +111,7 @@ static int enc_read(BIO *b, char *out, int outl)
 
     if (out == NULL)
         return 0;
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ENC_CTX *)BIO_get_data(b);
 
     next = BIO_next(b);
     if ((ctx == NULL) || (next == NULL))
@@ -152,7 +152,7 @@ static int enc_read(BIO *b, char *out, int outl)
             if (i > 0)
                 ctx->read_end += i;
         } else {
-            i = ctx->read_end - ctx->read_start;
+            i = (int)(ctx->read_end - ctx->read_start);
         }
 
         if (i <= 0) {
@@ -237,7 +237,7 @@ static int enc_write(BIO *b, const char *in, int inl)
     BIO_ENC_CTX *ctx;
     BIO *next;
 
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ENC_CTX *)BIO_get_data(b);
     next = BIO_next(b);
     if ((ctx == NULL) || (next == NULL))
         return 0;
@@ -300,7 +300,7 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
     EVP_CIPHER_CTX **c_ctx;
     BIO *next;
 
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ENC_CTX *)BIO_get_data(b);
     next = BIO_next(b);
     if (ctx == NULL)
         return 0;
@@ -371,7 +371,7 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;
-        dctx = BIO_get_data(dbio);
+        dctx = (BIO_ENC_CTX *)BIO_get_data(dbio);
         dctx->cipher = EVP_CIPHER_CTX_new();
         if (dctx->cipher == NULL)
             return 0;
@@ -402,7 +402,7 @@ int BIO_set_cipher(BIO *b, const EVP_CIPHER *c, const unsigned char *k,
     BIO_ENC_CTX *ctx;
     long (*callback) (struct bio_st *, int, const char *, int, long, long);
 
-    ctx = BIO_get_data(b);
+    ctx = (BIO_ENC_CTX *)BIO_get_data(b);
     if (ctx == NULL)
         return 0;
 

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -64,7 +64,7 @@ static int des_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 {
     BLOCK_CIPHER_ecb_loop()
         DES_ecb_encrypt((DES_cblock *)(in + i), (DES_cblock *)(out + i),
-                        EVP_CIPHER_CTX_get_cipher_data(ctx),
+                        (DES_key_schedule *)EVP_CIPHER_CTX_get_cipher_data(ctx),
                         EVP_CIPHER_CTX_encrypting(ctx));
     return 1;
 }
@@ -226,7 +226,7 @@ static int des_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         }
     }
 # endif
-    DES_set_key_unchecked(deskey, EVP_CIPHER_CTX_get_cipher_data(ctx));
+    DES_set_key_unchecked(deskey, (DES_key_schedule *)EVP_CIPHER_CTX_get_cipher_data(ctx));
     return 1;
 }
 
@@ -235,7 +235,7 @@ static int des_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 
     switch (type) {
     case EVP_CTRL_RAND_KEY:
-        if (RAND_priv_bytes(ptr, 8) <= 0)
+        if (RAND_priv_bytes((unsigned char *)ptr, 8) <= 0)
             return 0;
         DES_set_odd_parity((DES_cblock *)ptr);
         return 1;

--- a/crypto/evp/e_sm4.c
+++ b/crypto/evp/e_sm4.c
@@ -24,7 +24,7 @@ typedef struct {
 static int sm4_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                         const unsigned char *iv, int enc)
 {
-    SM4_set_key(key, EVP_CIPHER_CTX_get_cipher_data(ctx));
+    SM4_set_key(key, (SM4_KEY *)EVP_CIPHER_CTX_get_cipher_data(ctx));
     return 1;
 }
 

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -126,7 +126,7 @@ static unsigned char conv_ascii2bin(unsigned char a, const unsigned char *table)
 
 EVP_ENCODE_CTX *EVP_ENCODE_CTX_new(void)
 {
-    return OPENSSL_zalloc(sizeof(EVP_ENCODE_CTX));
+    return (EVP_ENCODE_CTX *)OPENSSL_zalloc(sizeof(EVP_ENCODE_CTX));
 }
 
 void EVP_ENCODE_CTX_free(EVP_ENCODE_CTX *ctx)
@@ -209,7 +209,7 @@ int EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
     if (inl != 0)
         memcpy(&(ctx->enc_data[0]), in, inl);
     ctx->num = inl;
-    *outl = total;
+    *outl = (int)total;
 
     return 1;
 }
@@ -329,7 +329,7 @@ int EVP_DecodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
 
     for (i = 0; i < inl; i++) {
         tmp = *(in++);
-        v = conv_ascii2bin(tmp, table);
+        v = (unsigned char)conv_ascii2bin((unsigned char)tmp, table);
         if (v == B64_ERROR) {
             rv = -1;
             goto end;
@@ -365,7 +365,7 @@ int EVP_DecodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
                 goto end;
             }
             OPENSSL_assert(n < (int)sizeof(ctx->enc_data));
-            d[n++] = tmp;
+            d[n++] = (unsigned char)tmp;
         }
 
         if (n == 64) {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -25,7 +25,7 @@
 
 static void evp_method_store_free(void *vstore)
 {
-    ossl_method_store_free(vstore);
+    ossl_method_store_free((OSSL_METHOD_STORE *)vstore);
 }
 
 static void *evp_method_store_new(OPENSSL_CTX *ctx)
@@ -67,13 +67,13 @@ static void *alloc_tmp_evp_method_store(OPENSSL_CTX *ctx)
  static void dealloc_tmp_evp_method_store(void *store)
 {
     if (store != NULL)
-        ossl_method_store_free(store);
+        ossl_method_store_free((OSSL_METHOD_STORE *)store);
 }
 
 static OSSL_METHOD_STORE *get_evp_method_store(OPENSSL_CTX *libctx)
 {
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_EVP_METHOD_STORE_INDEX,
-                                &evp_method_store_method);
+    return (OSSL_METHOD_STORE *)openssl_ctx_get_data(libctx, OPENSSL_CTX_EVP_METHOD_STORE_INDEX,
+                                                     &evp_method_store_method);
 }
 
 /*
@@ -98,7 +98,7 @@ static uint32_t evp_method_id(int name_id, unsigned int operation_id)
 static void *get_evp_method_from_store(OPENSSL_CTX *libctx, void *store,
                                        void *data)
 {
-    struct evp_method_data_st *methdata = data;
+    struct evp_method_data_st *methdata = (struct evp_method_data_st *)data;
     void *method = NULL;
     int name_id;
     uint32_t meth_id;
@@ -127,7 +127,7 @@ static void *get_evp_method_from_store(OPENSSL_CTX *libctx, void *store,
         && (store = get_evp_method_store(libctx)) == NULL)
         return NULL;
 
-    if (!ossl_method_store_fetch(store, meth_id, methdata->propquery,
+    if (!ossl_method_store_fetch((OSSL_METHOD_STORE *)store, meth_id, methdata->propquery,
                                  &method))
         return NULL;
     return method;
@@ -138,7 +138,7 @@ static int put_evp_method_in_store(OPENSSL_CTX *libctx, void *store,
                                    int operation_id, const char *names,
                                    const char *propdef, void *data)
 {
-    struct evp_method_data_st *methdata = data;
+    struct evp_method_data_st *methdata = (struct evp_method_data_st *)data;
     OSSL_NAMEMAP *namemap;
     int name_id;
     uint32_t meth_id;
@@ -165,7 +165,7 @@ static int put_evp_method_in_store(OPENSSL_CTX *libctx, void *store,
         && (store = get_evp_method_store(libctx)) == NULL)
         return 0;
 
-    return ossl_method_store_add(store, prov, meth_id, propdef, method,
+    return ossl_method_store_add((OSSL_METHOD_STORE *)store, prov, meth_id, propdef, method,
                                  methdata->refcnt_up_method,
                                  methdata->destruct_method);
 }
@@ -184,7 +184,7 @@ static void *construct_evp_method(const OSSL_ALGORITHM *algodef,
      * know that ossl_namemap_add_name() will return its corresponding
      * number.
      */
-    struct evp_method_data_st *methdata = data;
+    struct evp_method_data_st *methdata = (struct evp_method_data_st *)data;
     OPENSSL_CTX *libctx = ossl_provider_library_context(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     const char *names = algodef->algorithm_names;
@@ -210,7 +210,7 @@ static void *construct_evp_method(const OSSL_ALGORITHM *algodef,
 
 static void destruct_evp_method(void *method, void *data)
 {
-    struct evp_method_data_st *methdata = data;
+    struct evp_method_data_st *methdata = (struct evp_method_data_st *)data;
 
     methdata->destruct_method(method);
 }
@@ -483,7 +483,7 @@ struct do_all_data_st {
 static void do_one(OSSL_PROVIDER *provider, const OSSL_ALGORITHM *algo,
                    int no_store, void *vdata)
 {
-    struct do_all_data_st *data = vdata;
+    struct do_all_data_st *data = (struct do_all_data_st *)vdata;
     OPENSSL_CTX *libctx = ossl_provider_library_context(provider);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
     int name_id = ossl_namemap_add_names(namemap, 0, algo->algorithm_names,

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -136,7 +136,7 @@ int evp_cipher_param_to_asn1_ex(EVP_CIPHER_CTX *c, ASN1_TYPE *type,
         /* ... but, we should get a return size too! */
         if (OSSL_PARAM_modified(params)
             && params[0].return_size != 0
-            && (der = OPENSSL_malloc(params[0].return_size)) != NULL) {
+            && (der = (unsigned char *)OPENSSL_malloc(params[0].return_size)) != NULL) {
             params[0].data = der;
             params[0].data_size = params[0].return_size;
             OSSL_PARAM_set_all_unmodified(params);
@@ -144,7 +144,7 @@ int evp_cipher_param_to_asn1_ex(EVP_CIPHER_CTX *c, ASN1_TYPE *type,
             if (EVP_CIPHER_CTX_get_params(c, params)
                 && OSSL_PARAM_modified(params)
                 && d2i_ASN1_TYPE(&type, (const unsigned char **)&derp,
-                                 params[0].return_size) != NULL) {
+                                 (int)params[0].return_size) != NULL) {
                 ret = 1;
             }
             OPENSSL_free(der);
@@ -352,9 +352,9 @@ int evp_cipher_cache_constants(EVP_CIPHER *cipher)
         /* Provided implementations may have a custom cipher_cipher */
         if (cipher->prov != NULL && cipher->ccipher != NULL)
             flags |= EVP_CIPH_FLAG_CUSTOM_CIPHER;
-        cipher->block_size = blksz;
-        cipher->iv_len = ivlen;
-        cipher->key_len = keylen;
+        cipher->block_size = (int)blksz;
+        cipher->iv_len = (int)ivlen;
+        cipher->key_len = (int)keylen;
         cipher->flags = flags | mode;
     }
     return ok;

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -106,7 +106,7 @@ int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
     if (pass == NULL)
         passlen = 0;
     else if (passlen == -1)
-        passlen = strlen(pass);
+        passlen = (int)strlen(pass);
 
     if (cipher_nid == -1)
         cipher = NULL;
@@ -170,7 +170,7 @@ int EVP_PBE_alg_add_type(int pbe_type, int pbe_nid, int cipher_nid,
             goto err;
     }
 
-    if ((pbe_tmp = OPENSSL_malloc(sizeof(*pbe_tmp))) == NULL)
+    if ((pbe_tmp = (EVP_PBE_CTL *)OPENSSL_malloc(sizeof(*pbe_tmp))) == NULL)
         goto err;
 
     pbe_tmp->pbe_type = pbe_type;

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -18,7 +18,7 @@
 
 static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
 {
-    EVP_KEYEXCH *exchange = OPENSSL_zalloc(sizeof(EVP_KEYEXCH));
+    EVP_KEYEXCH *exchange = (EVP_KEYEXCH *)OPENSSL_zalloc(sizeof(EVP_KEYEXCH));
 
     if (exchange == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
@@ -169,10 +169,10 @@ OSSL_PROVIDER *EVP_KEYEXCH_provider(const EVP_KEYEXCH *exchange)
 EVP_KEYEXCH *EVP_KEYEXCH_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
-    return evp_generic_fetch(ctx, OSSL_OP_KEYEXCH, algorithm, properties,
-                             evp_keyexch_from_dispatch,
-                             (int (*)(void *))EVP_KEYEXCH_up_ref,
-                             (void (*)(void *))EVP_KEYEXCH_free);
+    return (EVP_KEYEXCH *)evp_generic_fetch(ctx, OSSL_OP_KEYEXCH, algorithm, properties,
+                                            evp_keyexch_from_dispatch,
+                                            (int (*)(void *))EVP_KEYEXCH_up_ref,
+                                            (void (*)(void *))EVP_KEYEXCH_free);
 }
 
 int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -30,7 +30,7 @@ EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf)
     if (kdf == NULL)
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(EVP_KDF_CTX));
+    ctx = (EVP_KDF_CTX *)OPENSSL_zalloc(sizeof(EVP_KDF_CTX));
     if (ctx == NULL
         || (ctx->data = kdf->newctx(ossl_provider_ctx(kdf->prov))) == NULL
         || !EVP_KDF_up_ref(kdf)) {
@@ -62,7 +62,7 @@ EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src)
     if (src == NULL || src->data == NULL || src->meth->dupctx == NULL)
         return NULL;
 
-    dst = OPENSSL_malloc(sizeof(*dst));
+    dst = (EVP_KDF_CTX *)OPENSSL_malloc(sizeof(*dst));
     if (dst == NULL) {
         EVPerr(EVP_F_EVP_KDF_CTX_DUP, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -43,7 +43,7 @@ static void *evp_kdf_new(void)
 {
     EVP_KDF *kdf = NULL;
 
-    if ((kdf = OPENSSL_zalloc(sizeof(*kdf))) == NULL
+    if ((kdf = (EVP_KDF *)OPENSSL_zalloc(sizeof(*kdf))) == NULL
         || (kdf->lock = CRYPTO_THREAD_lock_new()) == NULL) {
         OPENSSL_free(kdf);
         return NULL;
@@ -59,7 +59,7 @@ static void *evp_kdf_from_dispatch(int name_id,
     EVP_KDF *kdf = NULL;
     int fnkdfcnt = 0, fnctxcnt = 0;
 
-    if ((kdf = evp_kdf_new()) == NULL) {
+    if ((kdf = (EVP_KDF *)evp_kdf_new()) == NULL) {
         EVPerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -150,9 +150,9 @@ static void *evp_kdf_from_dispatch(int name_id,
 EVP_KDF *EVP_KDF_fetch(OPENSSL_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
-    return evp_generic_fetch(libctx, OSSL_OP_KDF, algorithm, properties,
-                             evp_kdf_from_dispatch, evp_kdf_up_ref,
-                             evp_kdf_free);
+    return (EVP_KDF *)evp_generic_fetch(libctx, OSSL_OP_KDF, algorithm, properties,
+                                        evp_kdf_from_dispatch, evp_kdf_up_ref,
+                                        evp_kdf_free);
 }
 
 int EVP_KDF_up_ref(EVP_KDF *kdf)

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -20,7 +20,7 @@ static void *keymgmt_new(void)
 {
     EVP_KEYMGMT *keymgmt = NULL;
 
-    if ((keymgmt = OPENSSL_zalloc(sizeof(*keymgmt))) == NULL
+    if ((keymgmt = (EVP_KEYMGMT *)OPENSSL_zalloc(sizeof(*keymgmt))) == NULL
         || (keymgmt->lock = CRYPTO_THREAD_lock_new()) == NULL) {
         EVP_KEYMGMT_free(keymgmt);
         EVPerr(0, ERR_R_MALLOC_FAILURE);
@@ -41,7 +41,7 @@ static void *keymgmt_from_dispatch(int name_id,
     int setgenparamfncnt = 0;
     int importfncnt = 0, exportfncnt = 0;
 
-    if ((keymgmt = keymgmt_new()) == NULL) {
+    if ((keymgmt = (EVP_KEYMGMT *)keymgmt_new()) == NULL) {
         EVP_KEYMGMT_free(keymgmt);
         return NULL;
     }
@@ -200,20 +200,20 @@ static void *keymgmt_from_dispatch(int name_id,
 EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OPENSSL_CTX *ctx, int name_id,
                                          const char *properties)
 {
-    return evp_generic_fetch_by_number(ctx,
-                                       OSSL_OP_KEYMGMT, name_id, properties,
-                                       keymgmt_from_dispatch,
-                                       (int (*)(void *))EVP_KEYMGMT_up_ref,
-                                       (void (*)(void *))EVP_KEYMGMT_free);
+    return (EVP_KEYMGMT *)evp_generic_fetch_by_number(ctx,
+                                                      OSSL_OP_KEYMGMT, name_id, properties,
+                                                      keymgmt_from_dispatch,
+                                                      (int (*)(void *))EVP_KEYMGMT_up_ref,
+                                                      (void (*)(void *))EVP_KEYMGMT_free);
 }
 
 EVP_KEYMGMT *EVP_KEYMGMT_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
-    return evp_generic_fetch(ctx, OSSL_OP_KEYMGMT, algorithm, properties,
-                             keymgmt_from_dispatch,
-                             (int (*)(void *))EVP_KEYMGMT_up_ref,
-                             (void (*)(void *))EVP_KEYMGMT_free);
+    return (EVP_KEYMGMT *)evp_generic_fetch(ctx, OSSL_OP_KEYMGMT, algorithm, properties,
+                                            keymgmt_from_dispatch,
+                                            (int (*)(void *))EVP_KEYMGMT_up_ref,
+                                            (void (*)(void *))EVP_KEYMGMT_free);
 }
 
 int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt)

--- a/crypto/evp/legacy_sha.c
+++ b/crypto/evp/legacy_sha.c
@@ -26,24 +26,24 @@
  * These only remain to support engines that can get these methods.
  * Hardware support for SHA3 has been removed from these legacy cases.
  */
-#define IMPLEMENT_LEGACY_EVP_MD_METH_SHA3(nm, fn, tag)                         \
-static int nm##_init(EVP_MD_CTX *ctx)                                          \
-{                                                                              \
-    return fn##_init(EVP_MD_CTX_md_data(ctx), tag, ctx->digest->md_size * 8);  \
-}                                                                              \
-static int nm##_update(EVP_MD_CTX *ctx, const void *data, size_t count)        \
-{                                                                              \
-    return fn##_update(EVP_MD_CTX_md_data(ctx), data, count);                  \
-}                                                                              \
-static int nm##_final(EVP_MD_CTX *ctx, unsigned char *md)                      \
-{                                                                              \
-    return fn##_final(md, EVP_MD_CTX_md_data(ctx));                            \
+#define IMPLEMENT_LEGACY_EVP_MD_METH_SHA3(nm, fn, tag)                                          \
+static int nm##_init(EVP_MD_CTX *ctx)                                                           \
+{                                                                                               \
+    return fn##_init((KECCAK1600_CTX *)EVP_MD_CTX_md_data(ctx), tag, ctx->digest->md_size * 8); \
+}                                                                                               \
+static int nm##_update(EVP_MD_CTX *ctx, const void *data, size_t count)                         \
+{                                                                                               \
+    return fn##_update((KECCAK1600_CTX *)EVP_MD_CTX_md_data(ctx), data, count);                 \
+}                                                                                               \
+static int nm##_final(EVP_MD_CTX *ctx, unsigned char *md)                                       \
+{                                                                                               \
+    return fn##_final(md, (KECCAK1600_CTX *)EVP_MD_CTX_md_data(ctx));                           \
 }
-#define IMPLEMENT_LEGACY_EVP_MD_METH_SHAKE(nm, fn, tag)                        \
-static int nm##_init(EVP_MD_CTX *ctx)                                          \
-{                                                                              \
-    return fn##_init(EVP_MD_CTX_md_data(ctx), tag, ctx->digest->md_size * 8);  \
-}                                                                              \
+#define IMPLEMENT_LEGACY_EVP_MD_METH_SHAKE(nm, fn, tag)                                         \
+static int nm##_init(EVP_MD_CTX *ctx)                                                           \
+{                                                                                               \
+    return fn##_init((KECCAK1600_CTX *)EVP_MD_CTX_md_data(ctx), tag, ctx->digest->md_size * 8); \
+}                                                                                               \
 
 #define sha512_224_Init    sha512_224_init
 #define sha512_256_Init    sha512_256_init
@@ -65,12 +65,12 @@ IMPLEMENT_LEGACY_EVP_MD_METH_SHAKE(shake, sha3, '\x1f')
 
 static int sha1_int_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
 {
-    return sha1_ctrl(ctx != NULL ? EVP_MD_CTX_md_data(ctx) : NULL, cmd, p1, p2);
+    return sha1_ctrl(ctx != NULL ? (SHA_CTX *)EVP_MD_CTX_md_data(ctx) : NULL, cmd, p1, p2);
 }
 
 static int shake_ctrl(EVP_MD_CTX *evp_ctx, int cmd, int p1, void *p2)
 {
-    KECCAK1600_CTX *ctx = evp_ctx->md_data;
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)evp_ctx->md_data;
 
     switch (cmd) {
     case EVP_MD_CTRL_XOF_LEN:

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -346,7 +346,7 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     }
 
     return pctx->op.sig.signature->digest_sign_update(pctx->op.sig.sigprovctx,
-                                                      data, dsize);
+                                                      (const unsigned char *)data, dsize);
 
  legacy:
     if (pctx != NULL) {
@@ -376,7 +376,7 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
     }
 
     return pctx->op.sig.signature->digest_verify_update(pctx->op.sig.sigprovctx,
-                                                        data, dsize);
+                                                        (const unsigned char *)data, dsize);
 
  legacy:
     if (pctx != NULL) {
@@ -540,7 +540,7 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
         vctx = 0;
     if (ctx->flags & EVP_MD_CTX_FLAG_FINALISE) {
         if (vctx)
-            r = pctx->pmeth->verifyctx(pctx, sig, siglen, ctx);
+            r = pctx->pmeth->verifyctx(pctx, sig, (int)siglen, ctx);
         else
             r = EVP_DigestFinal_ex(ctx, md, &mdlen);
     } else {
@@ -553,7 +553,7 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
         }
         if (vctx)
             r = tmp_ctx->pctx->pmeth->verifyctx(tmp_ctx->pctx,
-                                                sig, siglen, tmp_ctx);
+                                                sig, (int)siglen, tmp_ctx);
         else
             r = EVP_DigestFinal_ex(tmp_ctx, md, &mdlen);
         EVP_MD_CTX_free(tmp_ctx);

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -21,7 +21,7 @@
 
 EVP_MAC_CTX *EVP_MAC_CTX_new(EVP_MAC *mac)
 {
-    EVP_MAC_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_MAC_CTX));
+    EVP_MAC_CTX *ctx = (EVP_MAC_CTX *)OPENSSL_zalloc(sizeof(EVP_MAC_CTX));
 
     if (ctx == NULL
         || (ctx->data = mac->newctx(ossl_provider_ctx(mac->prov))) == NULL
@@ -55,7 +55,7 @@ EVP_MAC_CTX *EVP_MAC_CTX_dup(const EVP_MAC_CTX *src)
     if (src->data == NULL)
         return NULL;
 
-    dst = OPENSSL_malloc(sizeof(*dst));
+    dst = (EVP_MAC_CTX *)OPENSSL_malloc(sizeof(*dst));
     if (dst == NULL) {
         EVPerr(EVP_F_EVP_MAC_CTX_DUP, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -8,7 +8,7 @@
 
 static int evp_mac_up_ref(void *vmac)
 {
-    EVP_MAC *mac = vmac;
+    EVP_MAC *mac = (EVP_MAC *)vmac;
     int ref = 0;
 
     CRYPTO_UP_REF(&mac->refcnt, &ref, mac->lock);
@@ -17,7 +17,7 @@ static int evp_mac_up_ref(void *vmac)
 
 static void evp_mac_free(void *vmac)
 {
-    EVP_MAC *mac = vmac;
+    EVP_MAC *mac = (EVP_MAC *)vmac;
     int ref = 0;
 
     if (mac == NULL)
@@ -35,7 +35,7 @@ static void *evp_mac_new(void)
 {
     EVP_MAC *mac = NULL;
 
-    if ((mac = OPENSSL_zalloc(sizeof(*mac))) == NULL
+    if ((mac = (EVP_MAC *)OPENSSL_zalloc(sizeof(*mac))) == NULL
         || (mac->lock = CRYPTO_THREAD_lock_new()) == NULL) {
         evp_mac_free(mac);
         return NULL;
@@ -53,7 +53,7 @@ static void *evp_mac_from_dispatch(int name_id,
     EVP_MAC *mac = NULL;
     int fnmaccnt = 0, fnctxcnt = 0;
 
-    if ((mac = evp_mac_new()) == NULL) {
+    if ((mac = (EVP_MAC *)evp_mac_new()) == NULL) {
         EVPerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -152,9 +152,9 @@ static void *evp_mac_from_dispatch(int name_id,
 EVP_MAC *EVP_MAC_fetch(OPENSSL_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
-    return evp_generic_fetch(libctx, OSSL_OP_MAC, algorithm, properties,
-                             evp_mac_from_dispatch, evp_mac_up_ref,
-                             evp_mac_free);
+    return (EVP_MAC *)evp_generic_fetch(libctx, OSSL_OP_MAC, algorithm, properties,
+                                        evp_mac_from_dispatch, evp_mac_up_ref,
+                                        evp_mac_free);
 }
 
 int EVP_MAC_up_ref(EVP_MAC *mac)

--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -59,7 +59,7 @@ int EVP_add_digest(const EVP_MD *md)
 
 static void cipher_from_name(const char *name, void *data)
 {
-    const EVP_CIPHER **cipher = data;
+    const EVP_CIPHER **cipher = (const EVP_CIPHER **)data;
 
     if (*cipher != NULL)
         return;
@@ -97,14 +97,14 @@ const EVP_CIPHER *evp_get_cipherbyname_ex(OPENSSL_CTX *libctx, const char *name)
     if (id == 0)
         return NULL;
 
-    ossl_namemap_doall_names(namemap, id, cipher_from_name, &cp);
+    ossl_namemap_doall_names(namemap, id, cipher_from_name, (EVP_CIPHER *)&cp);
 
     return cp;
 }
 
 static void digest_from_name(const char *name, void *data)
 {
-    const EVP_MD **md = data;
+    const EVP_MD **md = (const EVP_MD **)data;
 
     if (*md != NULL)
         return;
@@ -142,7 +142,7 @@ const EVP_MD *evp_get_digestbyname_ex(OPENSSL_CTX *libctx, const char *name)
     if (id == 0)
         return NULL;
 
-    ossl_namemap_doall_names(namemap, id, digest_from_name, &dp);
+    ossl_namemap_doall_names(namemap, id, digest_from_name, (EVP_MD *)&dp);
 
     return dp;
 }
@@ -173,7 +173,7 @@ struct doall_cipher {
 
 static void do_all_cipher_fn(const OBJ_NAME *nm, void *arg)
 {
-    struct doall_cipher *dc = arg;
+    struct doall_cipher *dc = (struct doall_cipher *)arg;
     if (nm->alias)
         dc->fn(NULL, nm->name, nm->data, dc->arg);
     else
@@ -216,7 +216,7 @@ struct doall_md {
 
 static void do_all_md_fn(const OBJ_NAME *nm, void *arg)
 {
-    struct doall_md *dc = arg;
+    struct doall_md *dc = (struct doall_md *)arg;
     if (nm->alias)
         dc->fn(NULL, nm->name, nm->data, dc->arg);
     else

--- a/crypto/evp/p5_crpt.c
+++ b/crypto/evp/p5_crpt.c
@@ -42,7 +42,7 @@ int PKCS5_PBE_keyivgen(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
         return 0;
     }
 
-    pbe = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
+    pbe = (PBEPARAM *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
     if (pbe == NULL) {
         EVPerr(EVP_F_PKCS5_PBE_KEYIVGEN, EVP_R_DECODE_ERROR);
         return 0;
@@ -71,7 +71,7 @@ int PKCS5_PBE_keyivgen(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
     if (pass == NULL)
         passlen = 0;
     else if (passlen == -1)
-        passlen = strlen(pass);
+        passlen = (int)strlen(pass);
 
     ctx = EVP_MD_CTX_new();
     if (ctx == NULL) {

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -37,7 +37,7 @@ int pkcs5_pbkdf2_hmac_with_libctx(const char *pass, int passlen,
         pass = empty;
         passlen = 0;
     } else if (passlen == -1) {
-        passlen = strlen(pass);
+        passlen = (int)strlen(pass);
     }
     if (salt == NULL && saltlen == 0)
         salt = (unsigned char *)empty;
@@ -113,7 +113,7 @@ int PKCS5_v2_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
 
     int rv = 0;
 
-    pbe2 = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), param);
+    pbe2 = (PBE2PARAM *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), param);
     if (pbe2 == NULL) {
         EVPerr(EVP_F_PKCS5_V2_PBE_KEYIVGEN, EVP_R_DECODE_ERROR);
         goto err;
@@ -172,7 +172,7 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
 
     /* Decode parameter */
 
-    kdf = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBKDF2PARAM), param);
+    kdf = (PBKDF2PARAM *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBKDF2PARAM), param);
 
     if (kdf == NULL) {
         EVPerr(EVP_F_PKCS5_V2_PBKDF2_KEYIVGEN, EVP_R_DECODE_ERROR);

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -714,7 +714,7 @@ int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key)
 
 #ifndef OPENSSL_NO_EC
     if (EVP_PKEY_type(type) == EVP_PKEY_EC) {
-        const EC_GROUP *group = EC_KEY_get0_group(key);
+        const EC_GROUP *group = EC_KEY_get0_group((const EC_KEY *)key);
 
         if (group != NULL && EC_GROUP_get_curve_name(group) == NID_sm2)
             alias = EVP_PKEY_SM2;
@@ -747,7 +747,7 @@ const unsigned char *EVP_PKEY_get0_hmac(const EVP_PKEY *pkey, size_t *len)
         EVPerr(EVP_F_EVP_PKEY_GET0_HMAC, EVP_R_EXPECTING_AN_HMAC_KEY);
         return NULL;
     }
-    os = EVP_PKEY_get0(pkey);
+    os = (ASN1_OCTET_STRING *)EVP_PKEY_get0(pkey);
     *len = os->length;
     return os->data;
 }
@@ -760,7 +760,7 @@ const unsigned char *EVP_PKEY_get0_poly1305(const EVP_PKEY *pkey, size_t *len)
         EVPerr(EVP_F_EVP_PKEY_GET0_POLY1305, EVP_R_EXPECTING_A_POLY1305_KEY);
         return NULL;
     }
-    os = EVP_PKEY_get0(pkey);
+    os = (ASN1_OCTET_STRING *)EVP_PKEY_get0(pkey);
     *len = os->length;
     return os->data;
 }
@@ -775,7 +775,7 @@ const unsigned char *EVP_PKEY_get0_siphash(const EVP_PKEY *pkey, size_t *len)
         EVPerr(EVP_F_EVP_PKEY_GET0_SIPHASH, EVP_R_EXPECTING_A_SIPHASH_KEY);
         return NULL;
     }
-    os = EVP_PKEY_get0(pkey);
+    os = (ASN1_OCTET_STRING *)EVP_PKEY_get0(pkey);
     *len = os->length;
     return os->data;
 }
@@ -1320,7 +1320,7 @@ int EVP_PKEY_set1_tls_encodedpoint(EVP_PKEY *pkey,
 
     if (ptlen > INT_MAX)
         return 0;
-    if (evp_pkey_asn1_ctrl(pkey, ASN1_PKEY_CTRL_SET1_TLS_ENCPT, ptlen,
+    if (evp_pkey_asn1_ctrl(pkey, ASN1_PKEY_CTRL_SET1_TLS_ENCPT, (int)ptlen,
                            (void *)pt) <= 0)
         return 0;
     return 1;
@@ -1381,7 +1381,7 @@ static int evp_pkey_reset_unlocked(EVP_PKEY *pk)
 
 EVP_PKEY *EVP_PKEY_new(void)
 {
-    EVP_PKEY *ret = OPENSSL_zalloc(sizeof(*ret));
+    EVP_PKEY *ret = (EVP_PKEY *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         EVPerr(EVP_F_EVP_PKEY_NEW, ERR_R_MALLOC_FAILURE);
@@ -1533,7 +1533,7 @@ static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
 #ifndef FIPS_MODULE
 static void find_ameth(const char *name, void *data)
 {
-    const char **str = data;
+    const char **str = (const char **)data;
 
     /*
      * The error messages from pkey_set_type() are uninteresting here,
@@ -1541,7 +1541,7 @@ static void find_ameth(const char *name, void *data)
      */
     ERR_set_mark();
 
-    if (pkey_set_type(NULL, NULL, EVP_PKEY_NONE, name, strlen(name),
+    if (pkey_set_type(NULL, NULL, EVP_PKEY_NONE, name, (int)strlen(name),
                       NULL)) {
         if (str[0] == NULL)
             str[0] = name;
@@ -1986,7 +1986,7 @@ int EVP_PKEY_get_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM **bn)
          * If it failed because the buffer was too small then allocate the
          * required buffer size and retry.
          */
-        buf = OPENSSL_zalloc(buf_sz);
+        buf = (unsigned char *)OPENSSL_zalloc(buf_sz);
         if (buf == NULL)
             return 0;
         params[0].data = buf;

--- a/crypto/evp/p_sign.c
+++ b/crypto/evp/p_sign.c
@@ -55,7 +55,7 @@ int EVP_SignFinal_with_libctx(EVP_MD_CTX *ctx, unsigned char *sigret,
         goto err;
     if (EVP_PKEY_sign(pkctx, sigret, &sltmp, m, m_len) <= 0)
         goto err;
-    *siglen = sltmp;
+    *siglen = (unsigned int)sltmp;
     i = 1;
  err:
     EVP_PKEY_CTX_free(pkctx);

--- a/crypto/evp/pmeth_fn.c
+++ b/crypto/evp/pmeth_fn.c
@@ -245,7 +245,7 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
 
 static EVP_ASYM_CIPHER *evp_asym_cipher_new(OSSL_PROVIDER *prov)
 {
-    EVP_ASYM_CIPHER *cipher = OPENSSL_zalloc(sizeof(EVP_ASYM_CIPHER));
+    EVP_ASYM_CIPHER *cipher = (EVP_ASYM_CIPHER *)OPENSSL_zalloc(sizeof(EVP_ASYM_CIPHER));
 
     if (cipher == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
@@ -408,10 +408,10 @@ OSSL_PROVIDER *EVP_ASYM_CIPHER_provider(const EVP_ASYM_CIPHER *cipher)
 EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                        const char *properties)
 {
-    return evp_generic_fetch(ctx, OSSL_OP_ASYM_CIPHER, algorithm, properties,
-                             evp_asym_cipher_from_dispatch,
-                             (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
-                             (void (*)(void *))EVP_ASYM_CIPHER_free);
+    return (EVP_ASYM_CIPHER *)evp_generic_fetch(ctx, OSSL_OP_ASYM_CIPHER, algorithm, properties,
+                                                evp_asym_cipher_from_dispatch,
+                                                (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
+                                                (void (*)(void *))EVP_ASYM_CIPHER_free);
 }
 
 int EVP_ASYM_CIPHER_is_a(const EVP_ASYM_CIPHER *cipher, const char *name)

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -116,7 +116,7 @@ int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx)
 
 static int ossl_callback_to_pkey_gencb(const OSSL_PARAM params[], void *arg)
 {
-    EVP_PKEY_CTX *ctx = arg;
+    EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)arg;
     const OSSL_PARAM *param = NULL;
     int p = -1, n = -1;
 
@@ -323,7 +323,7 @@ EVP_PKEY_gen_cb *EVP_PKEY_CTX_get_cb(EVP_PKEY_CTX *ctx)
 
 static int trans_cb(int a, int b, BN_GENCB *gcb)
 {
-    EVP_PKEY_CTX *ctx = BN_GENCB_get_arg(gcb);
+    EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)BN_GENCB_get_arg(gcb);
     ctx->keygen_info[0] = a;
     ctx->keygen_info[1] = b;
     return ctx->pkey_gencb(ctx);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -120,7 +120,7 @@ EVP_PKEY_METHOD *EVP_PKEY_meth_new(int id, int flags)
 {
     EVP_PKEY_METHOD *pmeth;
 
-    pmeth = OPENSSL_zalloc(sizeof(*pmeth));
+    pmeth = (EVP_PKEY_METHOD *)OPENSSL_zalloc(sizeof(*pmeth));
     if (pmeth == NULL) {
         EVPerr(EVP_F_EVP_PKEY_METH_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -329,7 +329,7 @@ static EVP_PKEY_CTX *int_ctx_new(OPENSSL_CTX *libctx,
     if (pmeth == NULL && keymgmt == NULL) {
         EVPerr(EVP_F_INT_CTX_NEW, EVP_R_UNSUPPORTED_ALGORITHM);
     } else {
-        ret = OPENSSL_zalloc(sizeof(*ret));
+        ret = (EVP_PKEY_CTX *)OPENSSL_zalloc(sizeof(*ret));
         if (ret == NULL)
             EVPerr(EVP_F_INT_CTX_NEW, ERR_R_MALLOC_FAILURE);
     }
@@ -489,7 +489,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
         return 0;
     }
 # endif
-    rctx = OPENSSL_zalloc(sizeof(*rctx));
+    rctx = (EVP_PKEY_CTX *)OPENSSL_zalloc(sizeof(*rctx));
     if (rctx == NULL) {
         EVPerr(EVP_F_EVP_PKEY_CTX_DUP, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -633,7 +633,7 @@ const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx)
     idx -= OSSL_NELEM(standard_methods);
     if (idx >= (size_t)sk_EVP_PKEY_METHOD_num(app_pkey_methods))
         return NULL;
-    return sk_EVP_PKEY_METHOD_value(app_pkey_methods, idx);
+    return sk_EVP_PKEY_METHOD_value(app_pkey_methods, (int)idx);
 }
 #endif
 
@@ -1269,28 +1269,28 @@ static int legacy_ctrl_to_param(EVP_PKEY_CTX *ctx, int keytype, int optype,
                 return EVP_PKEY_CTX_set_ecdh_kdf_type(ctx, p1);
             }
         case EVP_PKEY_CTRL_GET_EC_KDF_MD:
-            return EVP_PKEY_CTX_get_ecdh_kdf_md(ctx, p2);
+            return EVP_PKEY_CTX_get_ecdh_kdf_md(ctx, (const EVP_MD **)p2);
         case EVP_PKEY_CTRL_EC_KDF_MD:
-            return EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, p2);
+            return EVP_PKEY_CTX_set_ecdh_kdf_md(ctx, (EVP_MD *)p2);
         case EVP_PKEY_CTRL_GET_EC_KDF_OUTLEN:
-            return EVP_PKEY_CTX_get_ecdh_kdf_outlen(ctx, p2);
+            return EVP_PKEY_CTX_get_ecdh_kdf_outlen(ctx, (int *)p2);
         case EVP_PKEY_CTRL_EC_KDF_OUTLEN:
             return EVP_PKEY_CTX_set_ecdh_kdf_outlen(ctx, p1);
         case EVP_PKEY_CTRL_GET_EC_KDF_UKM:
-            return EVP_PKEY_CTX_get0_ecdh_kdf_ukm(ctx, p2);
+            return EVP_PKEY_CTX_get0_ecdh_kdf_ukm(ctx, (unsigned char **)p2);
         case EVP_PKEY_CTRL_EC_KDF_UKM:
-            return EVP_PKEY_CTX_set0_ecdh_kdf_ukm(ctx, p2, p1);
+            return EVP_PKEY_CTX_set0_ecdh_kdf_ukm(ctx, (unsigned char *)p2, p1);
         }
     }
 # endif
     if (keytype == EVP_PKEY_RSA) {
         switch (cmd) {
         case EVP_PKEY_CTRL_RSA_OAEP_MD:
-            return EVP_PKEY_CTX_set_rsa_oaep_md(ctx, p2);
+            return EVP_PKEY_CTX_set_rsa_oaep_md(ctx, (const EVP_MD *)p2);
         case EVP_PKEY_CTRL_GET_RSA_OAEP_MD:
-            return EVP_PKEY_CTX_get_rsa_oaep_md(ctx, p2);
+            return EVP_PKEY_CTX_get_rsa_oaep_md(ctx, (const EVP_MD **)p2);
         case EVP_PKEY_CTRL_RSA_MGF1_MD:
-            return EVP_PKEY_CTX_set_rsa_oaep_md(ctx, p2);
+            return EVP_PKEY_CTX_set_rsa_oaep_md(ctx, (const EVP_MD *)p2);
         case EVP_PKEY_CTRL_RSA_OAEP_LABEL:
             return EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, p2, p1);
         case EVP_PKEY_CTRL_GET_RSA_OAEP_LABEL:
@@ -1298,7 +1298,7 @@ static int legacy_ctrl_to_param(EVP_PKEY_CTX *ctx, int keytype, int optype,
         case EVP_PKEY_CTRL_RSA_KEYGEN_BITS:
             return EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, p1);
         case EVP_PKEY_CTRL_RSA_KEYGEN_PUBEXP:
-            return EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, p2);
+            return EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, (BIGNUM *)p2);
         case EVP_PKEY_CTRL_RSA_KEYGEN_PRIMES:
             return EVP_PKEY_CTX_set_rsa_keygen_primes(ctx, p1);
         }
@@ -1370,19 +1370,19 @@ static int legacy_ctrl_to_param(EVP_PKEY_CTX *ctx, int keytype, int optype,
         }
         switch (cmd) {
         case EVP_PKEY_CTRL_MD:
-            return EVP_PKEY_CTX_set_signature_md(ctx, p2);
+            return EVP_PKEY_CTX_set_signature_md(ctx, (const EVP_MD *)p2);
         case EVP_PKEY_CTRL_GET_MD:
-            return EVP_PKEY_CTX_get_signature_md(ctx, p2);
+            return EVP_PKEY_CTX_get_signature_md(ctx, (const EVP_MD **)p2);
         case EVP_PKEY_CTRL_RSA_PADDING:
             return EVP_PKEY_CTX_set_rsa_padding(ctx, p1);
         case EVP_PKEY_CTRL_GET_RSA_PADDING:
-            return EVP_PKEY_CTX_get_rsa_padding(ctx, p2);
+            return EVP_PKEY_CTX_get_rsa_padding(ctx, (int *)p2);
         case EVP_PKEY_CTRL_GET_RSA_MGF1_MD:
-            return EVP_PKEY_CTX_get_rsa_oaep_md(ctx, p2);
+            return EVP_PKEY_CTX_get_rsa_oaep_md(ctx, (const EVP_MD **)p2);
         case EVP_PKEY_CTRL_RSA_PSS_SALTLEN:
             return EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, p1);
         case EVP_PKEY_CTRL_GET_RSA_PSS_SALTLEN:
-            return EVP_PKEY_CTX_get_rsa_pss_saltlen(ctx, p2);
+            return EVP_PKEY_CTX_get_rsa_pss_saltlen(ctx, (int *)p2);
         case EVP_PKEY_CTRL_PKCS7_ENCRYPT:
         case EVP_PKEY_CTRL_PKCS7_DECRYPT:
 # ifndef OPENSSL_NO_CMS
@@ -1739,7 +1739,7 @@ int EVP_PKEY_CTX_str2ctrl(EVP_PKEY_CTX *ctx, int cmd, const char *str)
     len = strlen(str);
     if (len > INT_MAX)
         return -1;
-    return ctx->pmeth->ctrl(ctx, cmd, len, (void *)str);
+    return ctx->pmeth->ctrl(ctx, cmd, (int)len, (void *)str);
 }
 
 int EVP_PKEY_CTX_hex2ctrl(EVP_PKEY_CTX *ctx, int cmd, const char *hex)

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -18,7 +18,7 @@
 
 static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
 {
-    EVP_SIGNATURE *signature = OPENSSL_zalloc(sizeof(EVP_SIGNATURE));
+    EVP_SIGNATURE *signature = (EVP_SIGNATURE *)OPENSSL_zalloc(sizeof(EVP_SIGNATURE));
 
     if (signature == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
@@ -301,10 +301,10 @@ OSSL_PROVIDER *EVP_SIGNATURE_provider(const EVP_SIGNATURE *signature)
 EVP_SIGNATURE *EVP_SIGNATURE_fetch(OPENSSL_CTX *ctx, const char *algorithm,
                                    const char *properties)
 {
-    return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
-                             evp_signature_from_dispatch,
-                             (int (*)(void *))EVP_SIGNATURE_up_ref,
-                             (void (*)(void *))EVP_SIGNATURE_free);
+    return (EVP_SIGNATURE *)evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
+                                              evp_signature_from_dispatch,
+                                              (int (*)(void *))EVP_SIGNATURE_up_ref,
+                                              (void (*)(void *))EVP_SIGNATURE_free);
 }
 
 int EVP_SIGNATURE_is_a(const EVP_SIGNATURE *signature, const char *name)

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -227,7 +227,7 @@ int crypto_new_ex_data_ex(OPENSSL_CTX *ctx, int class_index, void *obj,
         if (mx < (int)OSSL_NELEM(stack))
             storage = stack;
         else
-            storage = OPENSSL_malloc(sizeof(*storage) * mx);
+            storage = (EX_CALLBACK **)OPENSSL_malloc(sizeof(*storage) * mx);
         if (storage != NULL)
             for (i = 0; i < mx; i++)
                 storage[i] = sk_EX_CALLBACK_value(ip->meth, i);
@@ -291,7 +291,7 @@ int CRYPTO_dup_ex_data(int class_index, CRYPTO_EX_DATA *to,
         if (mx < (int)OSSL_NELEM(stack))
             storage = stack;
         else
-            storage = OPENSSL_malloc(sizeof(*storage) * mx);
+            storage = (EX_CALLBACK **)OPENSSL_malloc(sizeof(*storage) * mx);
         if (storage != NULL)
             for (i = 0; i < mx; i++)
                 storage[i] = sk_EX_CALLBACK_value(ip->meth, i);
@@ -356,7 +356,7 @@ void CRYPTO_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
         if (mx < (int)OSSL_NELEM(stack))
             storage = stack;
         else
-            storage = OPENSSL_malloc(sizeof(*storage) * mx);
+            storage = (EX_CALLBACK **)OPENSSL_malloc(sizeof(*storage) * mx);
         if (storage != NULL)
             for (i = 0; i < mx; i++)
                 storage[i] = sk_EX_CALLBACK_value(ip->meth, i);

--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -86,7 +86,7 @@ int ffc_params_set_seed(FFC_PARAMS *params,
     }
 
     if (seed != NULL && seedlen > 0) {
-        params->seed = OPENSSL_memdup(seed, seedlen);
+        params->seed = (unsigned char *)OPENSSL_memdup(seed, seedlen);
         if (params->seed == NULL)
             return 0;
         params->seedlen = seedlen;
@@ -185,7 +185,7 @@ int ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
     OPENSSL_free(dst->seed);
     dst->seedlen = src->seedlen;
     if (src->seed != NULL) {
-        dst->seed = OPENSSL_memdup(src->seed, src->seedlen);
+        dst->seed = (unsigned char *)OPENSSL_memdup(src->seed, src->seedlen);
         if  (dst->seed == NULL)
             return 0;
     } else {

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -612,7 +612,7 @@ int ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
         goto err;
     }
 
-    seed_tmp = OPENSSL_malloc(seedlen);
+    seed_tmp = (unsigned char *)OPENSSL_malloc(seedlen);
     if (seed_tmp == NULL)
         goto err;
 
@@ -623,13 +623,13 @@ int ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
             goto err;
         }
         /* if the seed is not supplied then alloc a seed buffer */
-        seed = OPENSSL_malloc(seedlen);
+        seed = (unsigned char *)OPENSSL_malloc(seedlen);
         if (seed == NULL)
             goto err;
     }
 
     /* A.1.1.2 Step (11): max loop count = 4L - 1 */
-    counter = 4 * L - 1;
+    counter = (int)(4 * L - 1);
     /* Validation requires the counter to be supplied */
     if (verify) {
         /* A.1.1.3 Step (4) : if (counter > (4L -1)) return INVALID */
@@ -645,10 +645,10 @@ int ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
      * A.1.1.3 Step (10)
      * n = floor(L / hash_outlen) - 1
      */
-    n = (L - 1 ) / (mdsize << 3);
+    n = (int)((L - 1 ) / (mdsize << 3));
 
     /* Calculate 2^(L-1): Used in step A.1.1.2 Step (11.3) */
-    if (!BN_lshift(test, BN_value_one(), L - 1))
+    if (!BN_lshift(test, BN_value_one(), (int)(L - 1)))
         goto err;
 
     for (;;) {
@@ -666,7 +666,7 @@ int ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
             goto err;
 
         memcpy(seed_tmp, seed, seedlen);
-        r = generate_p(ctx, md, counter, n, seed_tmp, seedlen, q, p, L,
+        r = generate_p(ctx, md, counter, n, seed_tmp, seedlen, q, p, (int)L,
                        cb, &pcounter, res);
         if (r > 0)
             break; /* found p */
@@ -858,7 +858,7 @@ int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
     if (test == NULL)
         goto err;
 
-    if (!BN_lshift(test, BN_value_one(), L - 1))
+    if (!BN_lshift(test, BN_value_one(), (int)(L - 1)))
         goto err;
 
     if (!verify) {
@@ -904,8 +904,8 @@ int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
             goto err;
 
         /* step 6 */
-        n = (L - 1) / 160;
-        counter = 4 * L - 1; /* Was 4096 */
+        n = (int)((L - 1) / 160);
+        counter = (int)(4 * L - 1); /* Was 4096 */
         /* Validation requires the counter to be supplied */
         if (verify) {
             if (params->pcounter > counter) {
@@ -915,7 +915,7 @@ int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
             counter = params->pcounter;
         }
 
-        rv = generate_p(ctx, md, counter, n, buf, qsize, q, p, L, cb,
+        rv = generate_p(ctx, md, counter, n, buf, qsize, q, p, (int)L, cb,
                         &pcounter, res);
         if (rv > 0)
             break; /* found it */

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -142,7 +142,7 @@ size_t HMAC_size(const HMAC_CTX *ctx)
 
 HMAC_CTX *HMAC_CTX_new(void)
 {
-    HMAC_CTX *ctx = OPENSSL_zalloc(sizeof(HMAC_CTX));
+    HMAC_CTX *ctx = (HMAC_CTX *)OPENSSL_zalloc(sizeof(HMAC_CTX));
 
     if (ctx != NULL) {
         if (!HMAC_CTX_reset(ctx)) {

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -654,7 +654,7 @@ int OPENSSL_atexit(void (*handler)(void))
     }
 #endif
 
-    if ((newhand = OPENSSL_malloc(sizeof(*newhand))) == NULL) {
+    if ((newhand = (OPENSSL_INIT_STOP *)OPENSSL_malloc(sizeof(*newhand))) == NULL) {
         CRYPTOerr(CRYPTO_F_OPENSSL_ATEXIT, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -52,7 +52,7 @@ static CRYPTO_ONCE tevent_register_runonce = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE_STATIC(create_global_tevent_register)
 {
-    glob_tevent_reg = OPENSSL_zalloc(sizeof(*glob_tevent_reg));
+    glob_tevent_reg = (GLOBAL_TEVENT_REGISTER *)OPENSSL_zalloc(sizeof(*glob_tevent_reg));
     if (glob_tevent_reg == NULL)
         return 0;
 
@@ -88,12 +88,12 @@ static void init_thread_stop(void *arg, THREAD_EVENT_HANDLER **hands);
 static THREAD_EVENT_HANDLER **
 init_get_thread_local(CRYPTO_THREAD_LOCAL *local, int alloc, int keep)
 {
-    THREAD_EVENT_HANDLER **hands = CRYPTO_THREAD_get_local(local);
+    THREAD_EVENT_HANDLER **hands = (THREAD_EVENT_HANDLER **)CRYPTO_THREAD_get_local(local);
 
     if (alloc) {
         if (hands == NULL) {
 
-            if ((hands = OPENSSL_zalloc(sizeof(*hands))) == NULL)
+            if ((hands = (THREAD_EVENT_HANDLER **)OPENSSL_zalloc(sizeof(*hands))) == NULL)
                 return NULL;
 
             if (!CRYPTO_THREAD_set_local(local, hands)) {
@@ -188,7 +188,7 @@ static void init_thread_remove_handlers(THREAD_EVENT_HANDLER **handsin)
 static void init_thread_destructor(void *hands)
 {
     init_thread_stop(NULL, (THREAD_EVENT_HANDLER **)hands);
-    init_thread_remove_handlers(hands);
+    init_thread_remove_handlers((THREAD_EVENT_HANDLER **)hands);
     OPENSSL_free(hands);
 }
 
@@ -365,7 +365,7 @@ int ossl_init_thread_start(const void *index, void *arg,
     }
 #endif
 
-    hand = OPENSSL_malloc(sizeof(*hand));
+    hand = (THREAD_EVENT_HANDLER *)OPENSSL_malloc(sizeof(*hand));
     if (hand == NULL)
         return 0;
 

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -48,7 +48,7 @@ OPENSSL_LHASH *OPENSSL_LH_new(OPENSSL_LH_HASHFUNC h, OPENSSL_LH_COMPFUNC c)
 {
     OPENSSL_LHASH *ret;
 
-    if ((ret = OPENSSL_zalloc(sizeof(*ret))) == NULL) {
+    if ((ret = (OPENSSL_LHASH *)OPENSSL_zalloc(sizeof(*ret))) == NULL) {
         /*
          * Do not set the error code, because the ERR code uses LHASH
          * and we want to avoid possible endless error loop.
@@ -56,7 +56,7 @@ OPENSSL_LHASH *OPENSSL_LH_new(OPENSSL_LH_HASHFUNC h, OPENSSL_LH_COMPFUNC c)
          */
         return NULL;
     }
-    if ((ret->b = OPENSSL_zalloc(sizeof(*ret->b) * MIN_NODES)) == NULL)
+    if ((ret->b = (OPENSSL_LH_NODE **)OPENSSL_zalloc(sizeof(*ret->b) * MIN_NODES)) == NULL)
         goto err;
     ret->comp = ((c == NULL) ? (OPENSSL_LH_COMPFUNC)strcmp : c);
     ret->hash = ((h == NULL) ? (OPENSSL_LH_HASHFUNC)OPENSSL_LH_strhash : h);
@@ -115,7 +115,7 @@ void *OPENSSL_LH_insert(OPENSSL_LHASH *lh, void *data)
     rn = getrn(lh, data, &hash);
 
     if (*rn == NULL) {
-        if ((nn = OPENSSL_malloc(sizeof(*nn))) == NULL) {
+        if ((nn = (OPENSSL_LH_NODE *)OPENSSL_malloc(sizeof(*nn))) == NULL) {
             lh->error++;
             return NULL;
         }
@@ -231,7 +231,7 @@ static int expand(OPENSSL_LHASH *lh)
     pmax = lh->pmax;
     if (p + 1 >= pmax) {
         j = nni * 2;
-        n = OPENSSL_realloc(lh->b, sizeof(OPENSSL_LH_NODE *) * j);
+        n = (OPENSSL_LH_NODE **)OPENSSL_realloc(lh->b, sizeof(OPENSSL_LH_NODE *) * j);
         if (n == NULL) {
             lh->error++;
             return 0;
@@ -273,8 +273,8 @@ static void contract(OPENSSL_LHASH *lh)
     np = lh->b[lh->p + lh->pmax - 1];
     lh->b[lh->p + lh->pmax - 1] = NULL; /* 24/07-92 - eay - weird but :-( */
     if (lh->p == 0) {
-        n = OPENSSL_realloc(lh->b,
-                            (unsigned int)(sizeof(OPENSSL_LH_NODE *) * lh->pmax));
+        n = (OPENSSL_LH_NODE **)OPENSSL_realloc(lh->b,
+                                                (unsigned int)(sizeof(OPENSSL_LH_NODE *) * lh->pmax));
         if (n == NULL) {
             /* fputs("realloc error in lhash",stderr); */
             lh->error++;

--- a/crypto/md4/md4_dgst.c
+++ b/crypto/md4/md4_dgst.c
@@ -42,7 +42,7 @@ int MD4_Init(MD4_CTX *c)
 # endif
 void md4_block_data_order(MD4_CTX *c, const void *data_, size_t num)
 {
-    const unsigned char *data = data_;
+    const unsigned char *data = (const unsigned char *)data_;
     register unsigned MD32_REG_T A, B, C, D, l;
 # ifndef MD32_XARRAY
     /* See comment in crypto/sha/sha_local.h for details. */

--- a/crypto/modes/ccm128.c
+++ b/crypto/modes/ccm128.c
@@ -151,7 +151,8 @@ int CRYPTO_ccm128_encrypt(CCM128_CONTEXT *ctx,
     if (!(flags0 & 0x40))
         (*block) (ctx->nonce.c, ctx->cmac.c, key), ctx->blocks++;
 
-    ctx->nonce.c[0] = L = flags0 & 7;
+    ctx->nonce.c[0] = flags0 & 7;
+    L = flags0 & 7;
     for (n = 0, i = 15 - L; i < 15; ++i) {
         n |= ctx->nonce.c[i];
         ctx->nonce.c[i] = 0;
@@ -235,7 +236,8 @@ int CRYPTO_ccm128_decrypt(CCM128_CONTEXT *ctx,
     if (!(flags0 & 0x40))
         (*block) (ctx->nonce.c, ctx->cmac.c, key);
 
-    ctx->nonce.c[0] = L = flags0 & 7;
+    ctx->nonce.c[0] = flags0 & 7;
+    L = flags0 & 7;
     for (n = 0, i = 15 - L; i < 15; ++i) {
         n |= ctx->nonce.c[i];
         ctx->nonce.c[i] = 0;
@@ -324,7 +326,8 @@ int CRYPTO_ccm128_encrypt_ccm64(CCM128_CONTEXT *ctx,
     if (!(flags0 & 0x40))
         (*block) (ctx->nonce.c, ctx->cmac.c, key), ctx->blocks++;
 
-    ctx->nonce.c[0] = L = flags0 & 7;
+    ctx->nonce.c[0] = flags0 & 7;
+    L = flags0 & 7;
     for (n = 0, i = 15 - L; i < 15; ++i) {
         n |= ctx->nonce.c[i];
         ctx->nonce.c[i] = 0;
@@ -388,7 +391,8 @@ int CRYPTO_ccm128_decrypt_ccm64(CCM128_CONTEXT *ctx,
     if (!(flags0 & 0x40))
         (*block) (ctx->nonce.c, ctx->cmac.c, key);
 
-    ctx->nonce.c[0] = L = flags0 & 7;
+    ctx->nonce.c[0] = flags0 & 7;
+    L = flags0 & 7;
     for (n = 0, i = 15 - L; i < 15; ++i) {
         n |= ctx->nonce.c[i];
         ctx->nonce.c[i] = 0;

--- a/crypto/modes/ocb128.c
+++ b/crypto/modes/ocb128.c
@@ -113,7 +113,7 @@ static OCB_BLOCK *ocb_lookup_l(OCB128_CONTEXT *ctx, size_t idx)
         tmp_ptr = OPENSSL_realloc(ctx->l, ctx->max_l_index * sizeof(OCB_BLOCK));
         if (tmp_ptr == NULL) /* prevent ctx->l from being clobbered */
             return NULL;
-        ctx->l = tmp_ptr;
+        ctx->l = (OCB_BLOCK *)tmp_ptr;
     }
     while (l_index < idx) {
         ocb_double(ctx->l + l_index, ctx->l + l_index + 1);
@@ -134,7 +134,7 @@ OCB128_CONTEXT *CRYPTO_ocb128_new(void *keyenc, void *keydec,
     OCB128_CONTEXT *octx;
     int ret;
 
-    if ((octx = OPENSSL_malloc(sizeof(*octx))) != NULL) {
+    if ((octx = (OCB128_CONTEXT *)OPENSSL_malloc(sizeof(*octx))) != NULL) {
         ret = CRYPTO_ocb128_init(octx, keyenc, keydec, encrypt, decrypt,
                                  stream);
         if (ret)
@@ -155,7 +155,7 @@ int CRYPTO_ocb128_init(OCB128_CONTEXT *ctx, void *keyenc, void *keydec,
     memset(ctx, 0, sizeof(*ctx));
     ctx->l_index = 0;
     ctx->max_l_index = 5;
-    if ((ctx->l = OPENSSL_malloc(ctx->max_l_index * 16)) == NULL) {
+    if ((ctx->l = (OCB_BLOCK *)OPENSSL_malloc(ctx->max_l_index * 16)) == NULL) {
         CRYPTOerr(CRYPTO_F_CRYPTO_OCB128_INIT, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -202,7 +202,7 @@ int CRYPTO_ocb128_copy_ctx(OCB128_CONTEXT *dest, OCB128_CONTEXT *src,
     if (keydec)
         dest->keydec = keydec;
     if (src->l) {
-        if ((dest->l = OPENSSL_malloc(src->max_l_index * 16)) == NULL) {
+        if ((dest->l = (OCB_BLOCK *)OPENSSL_malloc(src->max_l_index * 16)) == NULL) {
             CRYPTOerr(CRYPTO_F_CRYPTO_OCB128_COPY_CTX, ERR_R_MALLOC_FAILURE);
             return 0;
         }

--- a/crypto/modes/siv128.c
+++ b/crypto/modes/siv128.c
@@ -147,7 +147,7 @@ SIV128_CONTEXT *CRYPTO_siv128_new(const unsigned char *key, int klen,
     SIV128_CONTEXT *ctx;
     int ret;
 
-    if ((ctx = OPENSSL_malloc(sizeof(*ctx))) != NULL) {
+    if ((ctx = (SIV128_CONTEXT *)OPENSSL_malloc(sizeof(*ctx))) != NULL) {
         ret = CRYPTO_siv128_init(ctx, key, klen, cbc, ctr, libctx, propq);
         if (ret)
             return ctx;
@@ -291,7 +291,7 @@ int CRYPTO_siv128_encrypt(SIV128_CONTEXT *ctx,
     if (!siv128_do_encrypt(ctx->cipher_ctx, out, in, len, &q))
         return 0;
     ctx->final_ret = 0;
-    return len;
+    return (int)len;
 }
 
 /*
@@ -327,7 +327,7 @@ int CRYPTO_siv128_decrypt(SIV128_CONTEXT *ctx,
         return 0;
     }
     ctx->final_ret = 0;
-    return len;
+    return (int)len;
 }
 
 /*

--- a/crypto/modes/wrap128.c
+++ b/crypto/modes/wrap128.c
@@ -227,7 +227,7 @@ size_t CRYPTO_128_wrap_pad(void *key, const unsigned char *icv,
     } else {
         memmove(out, in, inlen);
         memset(out + inlen, 0, padding_len); /* Section 4.1 step 1 */
-        ret = CRYPTO_128_wrap(key, aiv, out, out, padded_len, block);
+        ret = (int)CRYPTO_128_wrap(key, aiv, out, out, padded_len, block);
     }
 
     return ret;

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -21,7 +21,7 @@ char *CRYPTO_strdup(const char *str, const char* file, int line)
 
     if (str == NULL)
         return NULL;
-    ret = CRYPTO_malloc(strlen(str) + 1, file, line);
+    ret = (char *)CRYPTO_malloc(strlen(str) + 1, file, line);
     if (ret != NULL)
         strcpy(ret, str);
     return ret;
@@ -37,7 +37,7 @@ char *CRYPTO_strndup(const char *str, size_t s, const char* file, int line)
 
     maxlen = OPENSSL_strnlen(str, s);
 
-    ret = CRYPTO_malloc(maxlen + 1, file, line);
+    ret = (char *)CRYPTO_malloc(maxlen + 1, file, line);
     if (ret) {
         memcpy(ret, str, maxlen);
         ret[maxlen] = CH_ZERO;
@@ -188,7 +188,7 @@ unsigned char *openssl_hexstr2buf_sep(const char *str, long *buflen,
     size_t buf_n, tmp_buflen;
 
     buf_n = strlen(str) >> 1;
-    if ((buf = OPENSSL_malloc(buf_n)) == NULL) {
+    if ((buf = (unsigned char *)OPENSSL_malloc(buf_n)) == NULL) {
         CRYPTOerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -260,10 +260,10 @@ char *openssl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep)
     size_t tmp_n;
 
     if (buflen == 0)
-        return OPENSSL_zalloc(1);
+        return (char *)OPENSSL_zalloc(1);
 
     tmp_n = (sep != CH_ZERO) ? buflen * 3 : 1 + buflen * 2;
-    if ((tmp = OPENSSL_malloc(tmp_n)) == NULL) {
+    if ((tmp = (char *)OPENSSL_malloc(tmp_n)) == NULL) {
         CRYPTOerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/objects/o_names.c
+++ b/crypto/objects/o_names.c
@@ -97,7 +97,7 @@ int OBJ_NAME_new_index(unsigned long (*hash_func) (const char *),
     ret = names_type_num;
     names_type_num++;
     for (i = sk_NAME_FUNCS_num(name_funcs_stack); i < names_type_num; i++) {
-        name_funcs = OPENSSL_zalloc(sizeof(*name_funcs));
+        name_funcs = (NAME_FUNCS *)OPENSSL_zalloc(sizeof(*name_funcs));
         if (name_funcs == NULL) {
             OBJerr(OBJ_F_OBJ_NAME_NEW_INDEX, ERR_R_MALLOC_FAILURE);
             ret = 0;
@@ -206,7 +206,7 @@ int OBJ_NAME_add(const char *name, int type, const char *data)
     alias = type & OBJ_NAME_ALIAS;
     type &= ~OBJ_NAME_ALIAS;
 
-    onp = OPENSSL_malloc(sizeof(*onp));
+    onp = (OBJ_NAME *)OPENSSL_malloc(sizeof(*onp));
     if (onp == NULL) {
         /* ERROR */
         goto unlock;
@@ -316,7 +316,7 @@ struct doall_sorted {
 
 static void do_all_sorted_fn(const OBJ_NAME *name, void *d_)
 {
-    struct doall_sorted *d = d_;
+    struct doall_sorted *d = (struct doall_sorted *)d_;
 
     if (name->type != d->type)
         return;
@@ -326,8 +326,8 @@ static void do_all_sorted_fn(const OBJ_NAME *name, void *d_)
 
 static int do_all_sorted_cmp(const void *n1_, const void *n2_)
 {
-    const OBJ_NAME *const *n1 = n1_;
-    const OBJ_NAME *const *n2 = n2_;
+    const OBJ_NAME *const *n1 = (const OBJ_NAME *const *)n1_;
+    const OBJ_NAME *const *n2 = (const OBJ_NAME *const *)n2_;
 
     return strcmp((*n1)->name, (*n2)->name);
 }
@@ -340,7 +340,7 @@ void OBJ_NAME_do_all_sorted(int type,
     int n;
 
     d.type = type;
-    d.names =
+    d.names = (const OBJ_NAME **)
         OPENSSL_malloc(sizeof(*d.names) * lh_OBJ_NAME_num_items(names_lh));
     /* Really should return an error if !d.names...but its a void function! */
     if (d.names != NULL) {

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -182,16 +182,16 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
             return 0;
     if ((o = OBJ_dup(obj)) == NULL)
         goto err;
-    if ((ao[ADDED_NID] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+    if ((ao[ADDED_NID] = (ADDED_OBJ *)OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
         goto err2;
     if ((o->length != 0) && (obj->data != NULL))
-        if ((ao[ADDED_DATA] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+        if ((ao[ADDED_DATA] = (ADDED_OBJ *)OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
             goto err2;
     if (o->sn != NULL)
-        if ((ao[ADDED_SNAME] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+        if ((ao[ADDED_SNAME] = (ADDED_OBJ *)OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
             goto err2;
     if (o->ln != NULL)
-        if ((ao[ADDED_LNAME] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+        if ((ao[ADDED_LNAME] = (ADDED_OBJ *)OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
             goto err2;
 
     for (i = ADDED_DATA; i <= ADDED_NID; i++) {
@@ -392,7 +392,7 @@ ASN1_OBJECT *OBJ_txt2obj(const char *s, int no_name)
     if (j < 0)
         return NULL;
 
-    if ((buf = OPENSSL_malloc(j)) == NULL) {
+    if ((buf = (unsigned char *)OPENSSL_malloc(j)) == NULL) {
         OBJerr(OBJ_F_OBJ_TXT2OBJ, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -432,7 +432,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
         if (s) {
             if (buf)
                 OPENSSL_strlcpy(buf, s, buf_len);
-            n = strlen(s);
+            n = (int)strlen(s);
             return n;
         }
     }
@@ -486,7 +486,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
                 l -= (long)(i * 40);
             }
             if (buf && (buf_len > 1)) {
-                *buf++ = i + '0';
+                *buf++ = (char)(i + '0');
                 *buf = '\0';
                 buf_len--;
             }
@@ -498,7 +498,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             bndec = BN_bn2dec(bl);
             if (!bndec)
                 goto err;
-            i = strlen(bndec);
+            i = (int)strlen(bndec);
             if (buf) {
                 if (buf_len > 1) {
                     *buf++ = '.';
@@ -519,7 +519,7 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
             OPENSSL_free(bndec);
         } else {
             BIO_snprintf(tbuf, sizeof(tbuf), ".%lu", l);
-            i = strlen(tbuf);
+            i = (int)strlen(tbuf);
             if (buf && (buf_len > 0)) {
                 OPENSSL_strlcpy(buf, tbuf, buf_len);
                 if (i > buf_len) {
@@ -612,7 +612,7 @@ const void *OBJ_bsearch_ex_(const void *key, const void *base, int num,
                             int (*cmp) (const void *, const void *),
                             int flags)
 {
-    const char *p = ossl_bsearch(key, base, num, size, cmp, flags);
+    const char *p = (const char *)ossl_bsearch(key, base, num, size, cmp, flags);
 
 #ifdef CHARSET_EBCDIC
     /*

--- a/crypto/objects/obj_lib.c
+++ b/crypto/objects/obj_lib.c
@@ -35,7 +35,7 @@ ASN1_OBJECT *OBJ_dup(const ASN1_OBJECT *o)
                            ASN1_OBJECT_FLAG_DYNAMIC_STRINGS |
                            ASN1_OBJECT_FLAG_DYNAMIC_DATA);
 
-    if (o->length > 0 && (r->data = OPENSSL_memdup(o->data, o->length)) == NULL)
+    if (o->length > 0 && (r->data = (const unsigned char *)OPENSSL_memdup(o->data, o->length)) == NULL)
         goto err;
 
     r->length = o->length;

--- a/crypto/objects/obj_xref.c
+++ b/crypto/objects/obj_xref.c
@@ -103,7 +103,7 @@ int OBJ_add_sigid(int signid, int dig_id, int pkey_id)
         sigx_app = sk_nid_triple_new(sigx_cmp);
     if (sigx_app == NULL)
         return 0;
-    if ((ntr = OPENSSL_malloc(sizeof(*ntr))) == NULL) {
+    if ((ntr = (nid_triple *)OPENSSL_malloc(sizeof(*ntr))) == NULL) {
         OBJerr(OBJ_F_OBJ_ADD_SIGID, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/ocsp/v3_ocsp.c
+++ b/crypto/ocsp/v3_ocsp.c
@@ -110,7 +110,7 @@ const X509V3_EXT_METHOD v3_ocsp_serviceloc = {
 static int i2r_ocsp_crlid(const X509V3_EXT_METHOD *method, void *in, BIO *bp,
                           int ind)
 {
-    OCSP_CRLID *a = in;
+    OCSP_CRLID *a = (OCSP_CRLID *)in;
     if (a->crlUrl) {
         if (BIO_printf(bp, "%*scrlUrl: ", ind, "") <= 0)
             goto err;
@@ -145,7 +145,7 @@ static int i2r_ocsp_acutoff(const X509V3_EXT_METHOD *method, void *cutoff,
 {
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
-    if (!ASN1_GENERALIZEDTIME_print(bp, cutoff))
+    if (!ASN1_GENERALIZEDTIME_print(bp, (const ASN1_GENERALIZEDTIME *)cutoff))
         return 0;
     return 1;
 }
@@ -155,7 +155,7 @@ static int i2r_object(const X509V3_EXT_METHOD *method, void *oid, BIO *bp,
 {
     if (BIO_printf(bp, "%*s", ind, "") <= 0)
         return 0;
-    if (i2a_ASN1_OBJECT(bp, oid) <= 0)
+    if (i2a_ASN1_OBJECT(bp, (const ASN1_OBJECT *)oid) <= 0)
         return 0;
     return 1;
 }
@@ -172,7 +172,7 @@ static void *ocsp_nonce_new(void)
 
 static int i2d_ocsp_nonce(const void *a, unsigned char **pp)
 {
-    const ASN1_OCTET_STRING *os = a;
+    const ASN1_OCTET_STRING *os = (const ASN1_OCTET_STRING *)a;
     if (pp) {
         memcpy(*pp, os->data, os->length);
         *pp += os->length;
@@ -183,7 +183,7 @@ static int i2d_ocsp_nonce(const void *a, unsigned char **pp)
 static void *d2i_ocsp_nonce(void *a, const unsigned char **pp, long length)
 {
     ASN1_OCTET_STRING *os, **pos;
-    pos = a;
+    pos = (ASN1_OCTET_STRING **)a;
     if (pos == NULL || *pos == NULL) {
         os = ASN1_OCTET_STRING_new();
         if (os == NULL)
@@ -209,7 +209,7 @@ static void *d2i_ocsp_nonce(void *a, const unsigned char **pp, long length)
 
 static void ocsp_nonce_free(void *a)
 {
-    ASN1_OCTET_STRING_free(a);
+    ASN1_OCTET_STRING_free((ASN1_OCTET_STRING *)a);
 }
 
 static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
@@ -217,7 +217,7 @@ static int i2r_ocsp_nonce(const X509V3_EXT_METHOD *method, void *nonce,
 {
     if (BIO_printf(out, "%*s", indent, "") <= 0)
         return 0;
-    if (i2a_ASN1_STRING(out, nonce, V_ASN1_OCTET_STRING) <= 0)
+    if (i2a_ASN1_STRING(out, (const ASN1_STRING *)nonce, V_ASN1_OCTET_STRING) <= 0)
         return 0;
     return 1;
 }
@@ -240,7 +240,7 @@ static int i2r_ocsp_serviceloc(const X509V3_EXT_METHOD *method, void *in,
                                BIO *bp, int ind)
 {
     int i;
-    OCSP_SERVICELOC *a = in;
+    OCSP_SERVICELOC *a = (OCSP_SERVICELOC *)in;
     ACCESS_DESCRIPTION *ad;
 
     if (BIO_printf(bp, "%*sIssuer: ", ind, "") <= 0)

--- a/crypto/packet.c
+++ b/crypto/packet.c
@@ -104,7 +104,7 @@ static int wpacket_intern_init_len(WPACKET *pkt, size_t lenbytes)
     pkt->curr = 0;
     pkt->written = 0;
 
-    if ((pkt->subs = OPENSSL_zalloc(sizeof(*pkt->subs))) == NULL) {
+    if ((pkt->subs = (WPACKET_SUB *)OPENSSL_zalloc(sizeof(*pkt->subs))) == NULL) {
         SSLerr(SSL_F_WPACKET_INTERN_INIT_LEN, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -351,7 +351,7 @@ int WPACKET_start_sub_packet_len__(WPACKET *pkt, size_t lenbytes)
     if (lenbytes > 0 && pkt->endfirst)
         return 0;
 
-    if ((sub = OPENSSL_zalloc(sizeof(*sub))) == NULL) {
+    if ((sub = (WPACKET_SUB *)OPENSSL_zalloc(sizeof(*sub))) == NULL) {
         SSLerr(SSL_F_WPACKET_START_SUB_PACKET_LEN__, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -65,7 +65,7 @@ static OSSL_PARAM_BLD_DEF *param_push(OSSL_PARAM_BLD *bld, const char *key,
                                       int size, size_t alloc, int type,
                                       int secure)
 {
-    OSSL_PARAM_BLD_DEF *pd = OPENSSL_zalloc(sizeof(*pd));
+    OSSL_PARAM_BLD_DEF *pd = (OSSL_PARAM_BLD_DEF *)OPENSSL_zalloc(sizeof(*pd));
 
     if (pd == NULL) {
         CRYPTOerr(CRYPTO_F_PARAM_PUSH, ERR_R_MALLOC_FAILURE);
@@ -89,7 +89,7 @@ static OSSL_PARAM_BLD_DEF *param_push(OSSL_PARAM_BLD *bld, const char *key,
 static int param_push_num(OSSL_PARAM_BLD *bld, const char *key,
                           void *num, size_t size, int type)
 {
-    OSSL_PARAM_BLD_DEF *pd = param_push(bld, key, size, size, type, 0);
+    OSSL_PARAM_BLD_DEF *pd = param_push(bld, key, (int)size, size, type, 0);
 
     if (pd == NULL)
         return 0;
@@ -103,7 +103,7 @@ static int param_push_num(OSSL_PARAM_BLD *bld, const char *key,
 
 OSSL_PARAM_BLD *OSSL_PARAM_BLD_new(void)
 {
-    OSSL_PARAM_BLD *r = OPENSSL_zalloc(sizeof(OSSL_PARAM_BLD));
+    OSSL_PARAM_BLD *r = (OSSL_PARAM_BLD *)OPENSSL_zalloc(sizeof(OSSL_PARAM_BLD));
 
     if (r != NULL) {
         r->params = sk_OSSL_PARAM_BLD_DEF_new_null();
@@ -229,7 +229,7 @@ int OSSL_PARAM_BLD_push_BN_pad(OSSL_PARAM_BLD *bld, const char *key,
         if (BN_get_flags(bn, BN_FLG_SECURE) == BN_FLG_SECURE)
             secure = 1;
     }
-    pd = param_push(bld, key, sz, sz, OSSL_PARAM_UNSIGNED_INTEGER, secure);
+    pd = param_push(bld, key, (int)sz, sz, OSSL_PARAM_UNSIGNED_INTEGER, secure);
     if (pd == NULL)
         return 0;
     pd->bn = bn;
@@ -248,7 +248,7 @@ int OSSL_PARAM_BLD_push_utf8_string(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_UTF8_STRING, 0);
+    pd = param_push(bld, key, (int)bsize, bsize, OSSL_PARAM_UTF8_STRING, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -267,7 +267,7 @@ int OSSL_PARAM_BLD_push_utf8_ptr(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, sizeof(buf), OSSL_PARAM_UTF8_PTR, 0);
+    pd = param_push(bld, key, (int)bsize, sizeof(buf), OSSL_PARAM_UTF8_PTR, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -284,7 +284,7 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, bsize, OSSL_PARAM_OCTET_STRING, 0);
+    pd = param_push(bld, key, (int)bsize, bsize, OSSL_PARAM_OCTET_STRING, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -301,7 +301,7 @@ int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
                   CRYPTO_R_STRING_TOO_LONG);
         return 0;
     }
-    pd = param_push(bld, key, bsize, sizeof(buf), OSSL_PARAM_OCTET_PTR, 0);
+    pd = param_push(bld, key, (int)bsize, sizeof(buf), OSSL_PARAM_OCTET_PTR, 0);
     if (pd == NULL)
         return 0;
     pd->string = buf;
@@ -333,7 +333,7 @@ static OSSL_PARAM *param_bld_convert(OSSL_PARAM_BLD *bld, OSSL_PARAM *param,
         param[i].data = p;
         if (pd->bn != NULL) {
             /* BIGNUM */
-            BN_bn2nativepad(pd->bn, (unsigned char *)p, pd->size);
+            BN_bn2nativepad(pd->bn, (unsigned char *)p, (int)pd->size);
         } else if (pd->type == OSSL_PARAM_OCTET_PTR
                    || pd->type == OSSL_PARAM_UTF8_PTR) {
             /* PTR */
@@ -366,14 +366,14 @@ OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld)
     const size_t ss = ALIGN_SIZE * bld->secure_blocks;
 
     if (ss > 0) {
-        s = OPENSSL_secure_malloc(ss);
+        s = (OSSL_PARAM_BLD_BLOCK *)OPENSSL_secure_malloc(ss);
         if (s == NULL) {
             CRYPTOerr(CRYPTO_F_OSSL_PARAM_BLD_TO_PARAM,
                       CRYPTO_R_SECURE_MALLOC_FAILURE);
             return NULL;
         }
     }
-    params = OPENSSL_malloc(total);
+    params = (OSSL_PARAM *)OPENSSL_malloc(total);
     if (params == NULL) {
         CRYPTOerr(CRYPTO_F_OSSL_PARAM_BLD_TO_PARAM, ERR_R_MALLOC_FAILURE);
         OPENSSL_secure_free(s);

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -653,7 +653,7 @@ int OSSL_PARAM_get_BN(const OSSL_PARAM *p, BIGNUM **val)
         || p->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
         return 0;
 
-    b = BN_native2bn(p->data, (int)p->data_size, *val);
+    b = BN_native2bn((const unsigned char *)p->data, (int)p->data_size, *val);
     if (b != NULL) {
         *val = b;
         return 1;
@@ -681,7 +681,7 @@ int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val)
         return 1;
     if (p->data_size >= bytes) {
         p->return_size = p->data_size;
-        return BN_bn2nativepad(val, p->data, p->data_size) >= 0;
+        return BN_bn2nativepad(val, (unsigned char *)p->data, (int)p->data_size) >= 0;
     }
     return 0;
 }
@@ -822,7 +822,7 @@ static int get_string_internal(const OSSL_PARAM *p, void **val, size_t max_len,
         return 1;
 
     if (*val == NULL) {
-        char *const q = OPENSSL_malloc(sz > 0 ? sz : 1);
+        char *const q = (char *const)OPENSSL_malloc(sz > 0 ? sz : 1);
 
         if (q == NULL)
             return 0;

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -121,7 +121,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
                 }
             */
 
-            BN_bn2nativepad(tmpbn, buf, buf_n);
+            BN_bn2nativepad(tmpbn, (unsigned char *)buf, (int)buf_n);
 
             /*
              * 2s complement negate, part two.
@@ -134,18 +134,18 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
                 unsigned char *cp;
                 size_t i = buf_n;
 
-                for (cp = buf; i-- > 0; cp++)
+                for (cp = (unsigned char *)buf; i-- > 0; cp++)
                     *cp ^= 0xFF;
             }
             break;
         case OSSL_PARAM_UTF8_STRING:
-            strncpy(buf, value, buf_n);
+            strncpy((char *)buf, value, buf_n);
             break;
         case OSSL_PARAM_OCTET_STRING:
             if (ishex) {
                 size_t l = 0;
 
-                if (!OPENSSL_hexstr2buf_ex(buf, buf_n, &l, value))
+                if (!OPENSSL_hexstr2buf_ex((unsigned char *)buf, buf_n, &l, value))
                     return 0;
             } else {
                 memcpy(buf, value, buf_n);

--- a/crypto/pem/pem_info.c
+++ b/crypto/pem/pem_info.c
@@ -210,11 +210,11 @@ STACK_OF(X509_INFO)
                     goto err;
                 p = data;
                 if (ptype) {
-                    if (!d2i_PrivateKey(ptype, pp, &p, len)) {
+                    if (!d2i_PrivateKey(ptype, (EVP_PKEY **)pp, &p, len)) {
                         PEMerr(0, ERR_R_ASN1_LIB);
                         goto err;
                     }
-                } else if (d2i(pp, &p, len) == NULL) {
+                } else if (d2i((void **)pp, &p, len) == NULL) {
                     PEMerr(0, ERR_R_ASN1_LIB);
                     goto err;
                 }

--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -30,8 +30,8 @@
     ret = 1;                                                            \
     if (kstr == NULL && cb == NULL) {                                   \
         if (u != NULL) {                                                \
-            kstr = u;                                                   \
-            klen = strlen(u);                                           \
+            kstr = (const unsigned char *)u;                            \
+            klen = (int)strlen((const char *)u);                        \
         } else {                                                        \
             cb = PEM_def_callback;                                      \
         }                                                               \

--- a/crypto/pem/pem_oth.c
+++ b/crypto/pem/pem_oth.c
@@ -28,7 +28,7 @@ void *PEM_ASN1_read_bio(d2i_of_void *d2i, const char *name, BIO *bp, void **x,
     if (!PEM_bytes_read_bio(&data, &len, NULL, name, bp, cb, u))
         return NULL;
     p = data;
-    ret = d2i(x, &p, len);
+    ret = (char *)d2i(x, &p, len);
     if (ret == NULL)
         PEMerr(PEM_F_PEM_ASN1_READ_BIO, ERR_R_ASN1_LIB);
     OPENSSL_free(data);

--- a/crypto/pem/pem_sign.c
+++ b/crypto/pem/pem_sign.c
@@ -32,7 +32,7 @@ int PEM_SignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
     int i, ret = 0;
     unsigned int m_len;
 
-    m = OPENSSL_malloc(EVP_PKEY_size(pkey));
+    m = (unsigned char *)OPENSSL_malloc(EVP_PKEY_size(pkey));
     if (m == NULL) {
         PEMerr(PEM_F_PEM_SIGNFINAL, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -226,7 +226,7 @@ EVP_PKEY *ossl_b2i_bio(BIO *in, int *ispub)
         PEMerr(0, PEM_R_HEADER_TOO_LONG);
         return NULL;
     }
-    buf = OPENSSL_malloc(length);
+    buf = (unsigned char *)OPENSSL_malloc(length);
     if (buf == NULL) {
         PEMerr(0, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -461,7 +461,7 @@ static int do_i2b(unsigned char **out, const EVP_PKEY *pk, int ispub)
     if (*out)
         p = *out;
     else {
-        if ((p = OPENSSL_malloc(outlen)) == NULL) {
+        if ((p = (unsigned char *)OPENSSL_malloc(outlen)) == NULL) {
             PEMerr(PEM_F_DO_I2B, ERR_R_MALLOC_FAILURE);
             return -1;
         }
@@ -708,7 +708,7 @@ static EVP_PKEY *do_PVK_body(const unsigned char **in,
             PEMerr(PEM_F_DO_PVK_BODY, PEM_R_BAD_PASSWORD_READ);
             goto err;
         }
-        enctmp = OPENSSL_malloc(keylen + 8);
+        enctmp = (unsigned char *)OPENSSL_malloc(keylen + 8);
         if (enctmp == NULL) {
             PEMerr(PEM_F_DO_PVK_BODY, ERR_R_MALLOC_FAILURE);
             goto err;
@@ -777,7 +777,7 @@ EVP_PKEY *b2i_PVK_bio(BIO *in, pem_password_cb *cb, void *u)
     if (!ossl_do_PVK_header(&p, 24, 0, &saltlen, &keylen))
         return 0;
     buflen = (int)keylen + saltlen;
-    buf = OPENSSL_malloc(buflen);
+    buf = (unsigned char *)OPENSSL_malloc(buflen);
     if (buf == NULL) {
         PEMerr(PEM_F_B2I_PVK_BIO, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -811,7 +811,7 @@ static int i2b_PVK(unsigned char **out, const EVP_PKEY *pk, int enclevel,
     if (*out != NULL) {
         p = *out;
     } else {
-        start = p = OPENSSL_malloc(outlen);
+        start = p = (unsigned char *)OPENSSL_malloc(outlen);
         if (p == NULL) {
             PEMerr(PEM_F_I2B_PVK, ERR_R_MALLOC_FAILURE);
             return -1;

--- a/crypto/pkcs12/p12_add.c
+++ b/crypto/pkcs12/p12_add.c
@@ -76,7 +76,7 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7data(PKCS7 *p7)
                   PKCS12_R_CONTENT_TYPE_NOT_DATA);
         return NULL;
     }
-    return ASN1_item_unpack(p7->d.data, ASN1_ITEM_rptr(PKCS12_SAFEBAGS));
+    return (STACK_OF(PKCS12_SAFEBAG) *)ASN1_item_unpack(p7->d.data, ASN1_ITEM_rptr(PKCS12_SAFEBAGS));
 }
 
 /* Turn a stack of SAFEBAGS into a PKCS#7 encrypted data ContentInfo */
@@ -132,10 +132,10 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7encdata(PKCS7 *p7, const char *pass,
 {
     if (!PKCS7_type_is_encrypted(p7))
         return NULL;
-    return PKCS12_item_decrypt_d2i(p7->d.encrypted->enc_data->algorithm,
-                                   ASN1_ITEM_rptr(PKCS12_SAFEBAGS),
-                                   pass, passlen,
-                                   p7->d.encrypted->enc_data->enc_data, 1);
+    return (STACK_OF(PKCS12_SAFEBAG) *)PKCS12_item_decrypt_d2i(p7->d.encrypted->enc_data->algorithm,
+                                                               ASN1_ITEM_rptr(PKCS12_SAFEBAGS),
+                                                               pass, passlen,
+                                                               p7->d.encrypted->enc_data->enc_data, 1);
 }
 
 PKCS8_PRIV_KEY_INFO *PKCS12_decrypt_skey(const PKCS12_SAFEBAG *bag,
@@ -159,6 +159,6 @@ STACK_OF(PKCS7) *PKCS12_unpack_authsafes(const PKCS12 *p12)
                   PKCS12_R_CONTENT_TYPE_NOT_DATA);
         return NULL;
     }
-    return ASN1_item_unpack(p12->authsafes->d.data,
-                            ASN1_ITEM_rptr(PKCS12_AUTHSAFES));
+    return (STACK_OF(PKCS7) *)ASN1_item_unpack(p12->authsafes->d.data,
+                                               ASN1_ITEM_rptr(PKCS12_AUTHSAFES));
 }

--- a/crypto/pkcs12/p12_crpt.c
+++ b/crypto/pkcs12/p12_crpt.c
@@ -38,7 +38,7 @@ int PKCS12_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
 
     /* Extract useful info from parameter */
 
-    pbe = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
+    pbe = (PBEPARAM *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
     if (pbe == NULL) {
         PKCS12err(PKCS12_F_PKCS12_PBE_KEYIVGEN, PKCS12_R_DECODE_ERROR);
         return 0;

--- a/crypto/pkcs12/p12_decr.c
+++ b/crypto/pkcs12/p12_decr.c
@@ -69,7 +69,7 @@ unsigned char *PKCS12_pbe_crypt(const X509_ALGOR *algor,
         }
     }
 
-    if ((out = OPENSSL_malloc(max_out_len)) == NULL) {
+    if ((out = (unsigned char *)OPENSSL_malloc(max_out_len)) == NULL) {
         PKCS12err(PKCS12_F_PKCS12_PBE_CRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
     }
@@ -163,7 +163,7 @@ ASN1_OCTET_STRING *PKCS12_item_i2d_encrypt(X509_ALGOR *algor,
         PKCS12err(PKCS12_F_PKCS12_ITEM_I2D_ENCRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
     }
-    inlen = ASN1_item_i2d(obj, &in, it);
+    inlen = ASN1_item_i2d((const ASN1_VALUE *)obj, &in, it);
     if (!in) {
         PKCS12err(PKCS12_F_PKCS12_ITEM_I2D_ENCRYPT, PKCS12_R_ENCODE_ERROR);
         goto err;

--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -231,7 +231,7 @@ int PKCS12_setup_mac(PKCS12 *p12, int iter, unsigned char *salt, int saltlen,
     }
     if (!saltlen)
         saltlen = PKCS12_SALT_LEN;
-    if ((p12->mac->salt->data = OPENSSL_malloc(saltlen)) == NULL) {
+    if ((p12->mac->salt->data = (unsigned char *)OPENSSL_malloc(saltlen)) == NULL) {
         PKCS12err(PKCS12_F_PKCS12_SETUP_MAC, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/pkcs12/p12_p8d.c
+++ b/crypto/pkcs12/p12_p8d.c
@@ -17,7 +17,7 @@ PKCS8_PRIV_KEY_INFO *PKCS8_decrypt(const X509_SIG *p8, const char *pass,
     const X509_ALGOR *dalg;
     const ASN1_OCTET_STRING *doct;
     X509_SIG_get0(p8, &dalg, &doct);
-    return PKCS12_item_decrypt_d2i(dalg,
-                                   ASN1_ITEM_rptr(PKCS8_PRIV_KEY_INFO), pass,
-                                   passlen, doct, 1);
+    return (PKCS8_PRIV_KEY_INFO *)PKCS12_item_decrypt_d2i(dalg,
+                                                          ASN1_ITEM_rptr(PKCS8_PRIV_KEY_INFO), pass,
+                                                          passlen, doct, 1);
 }

--- a/crypto/pkcs12/p12_p8e.c
+++ b/crypto/pkcs12/p12_p8e.c
@@ -55,7 +55,7 @@ X509_SIG *PKCS8_set0_pbe(const char *pass, int passlen,
         return NULL;
     }
 
-    p8 = OPENSSL_zalloc(sizeof(*p8));
+    p8 = (X509_SIG *)OPENSSL_zalloc(sizeof(*p8));
 
     if (p8 == NULL) {
         PKCS12err(PKCS12_F_PKCS8_SET0_PBE, ERR_R_MALLOC_FAILURE);

--- a/crypto/pkcs12/p12_sbag.c
+++ b/crypto/pkcs12/p12_sbag.c
@@ -87,8 +87,8 @@ X509 *PKCS12_SAFEBAG_get1_cert(const PKCS12_SAFEBAG *bag)
         return NULL;
     if (OBJ_obj2nid(bag->value.bag->type) != NID_x509Certificate)
         return NULL;
-    return ASN1_item_unpack(bag->value.bag->value.octet,
-                            ASN1_ITEM_rptr(X509));
+    return (X509 *)ASN1_item_unpack(bag->value.bag->value.octet,
+                                    ASN1_ITEM_rptr(X509));
 }
 
 X509_CRL *PKCS12_SAFEBAG_get1_crl(const PKCS12_SAFEBAG *bag)
@@ -97,8 +97,8 @@ X509_CRL *PKCS12_SAFEBAG_get1_crl(const PKCS12_SAFEBAG *bag)
         return NULL;
     if (OBJ_obj2nid(bag->value.bag->type) != NID_x509Crl)
         return NULL;
-    return ASN1_item_unpack(bag->value.bag->value.octet,
-                            ASN1_ITEM_rptr(X509_CRL));
+    return (X509_CRL *)ASN1_item_unpack(bag->value.bag->value.octet,
+                                        ASN1_ITEM_rptr(X509_CRL));
 }
 
 PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_cert(X509 *x509)

--- a/crypto/pkcs12/p12_utl.c
+++ b/crypto/pkcs12/p12_utl.c
@@ -20,9 +20,9 @@ unsigned char *OPENSSL_asc2uni(const char *asc, int asclen,
     unsigned char *unitmp;
 
     if (asclen == -1)
-        asclen = strlen(asc);
+        asclen = (int)strlen(asc);
     ulen = asclen * 2 + 2;
-    if ((unitmp = OPENSSL_malloc(ulen)) == NULL) {
+    if ((unitmp = (unsigned char *)OPENSSL_malloc(ulen)) == NULL) {
         PKCS12err(PKCS12_F_OPENSSL_ASC2UNI, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -52,7 +52,7 @@ char *OPENSSL_uni2asc(const unsigned char *uni, int unilen)
     if (!unilen || uni[unilen - 1])
         asclen++;
     uni++;
-    if ((asctmp = OPENSSL_malloc(asclen)) == NULL) {
+    if ((asctmp = (char *)OPENSSL_malloc(asclen)) == NULL) {
         PKCS12err(PKCS12_F_OPENSSL_UNI2ASC, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -79,7 +79,7 @@ unsigned char *OPENSSL_utf82uni(const char *asc, int asclen,
     unsigned long utf32chr = 0;
 
     if (asclen == -1)
-        asclen = strlen(asc);
+        asclen = (int)strlen(asc);
 
     for (ulen = 0, i = 0; i < asclen; i += j) {
         j = UTF8_getc((const unsigned char *)asc+i, asclen-i, &utf32chr);
@@ -114,7 +114,7 @@ unsigned char *OPENSSL_utf82uni(const char *asc, int asclen,
 
     ulen += 2;  /* for trailing UTF16 zero */
 
-    if ((ret = OPENSSL_malloc(ulen)) == NULL) {
+    if ((ret = (unsigned char *)OPENSSL_malloc(ulen)) == NULL) {
         PKCS12err(PKCS12_F_OPENSSL_UTF82UNI, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -199,7 +199,7 @@ char *OPENSSL_uni2utf8(const unsigned char *uni, int unilen)
     if (!unilen || (uni[unilen-2]||uni[unilen - 1]))
         asclen++;
 
-    if ((asctmp = OPENSSL_malloc(asclen)) == NULL) {
+    if ((asctmp = (char *)OPENSSL_malloc(asclen)) == NULL) {
         PKCS12err(PKCS12_F_OPENSSL_UNI2UTF8, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -233,7 +233,7 @@ int i2d_PKCS12_fp(FILE *fp, const PKCS12 *p12)
 
 PKCS12 *d2i_PKCS12_bio(BIO *bp, PKCS12 **p12)
 {
-    return ASN1_item_d2i_bio(ASN1_ITEM_rptr(PKCS12), bp, p12);
+    return (PKCS12 *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(PKCS12), bp, p12);
 }
 
 #ifndef OPENSSL_NO_STDIO

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -33,7 +33,7 @@ ASN1_ADB(PKCS7) = {
 static int pk7_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                   void *exarg)
 {
-    ASN1_STREAM_ARG *sarg = exarg;
+    ASN1_STREAM_ARG *sarg = (ASN1_STREAM_ARG *)exarg;
     PKCS7 **pp7 = (PKCS7 **)pval;
 
     switch (operation) {

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -129,7 +129,7 @@ static int pkcs7_encode_rinfo(PKCS7_RECIP_INFO *ri,
     if (EVP_PKEY_encrypt(pctx, NULL, &eklen, key, keylen) <= 0)
         goto err;
 
-    ek = OPENSSL_malloc(eklen);
+    ek = (unsigned char *)OPENSSL_malloc(eklen);
 
     if (ek == NULL) {
         PKCS7err(PKCS7_F_PKCS7_ENCODE_RINFO, ERR_R_MALLOC_FAILURE);
@@ -139,7 +139,7 @@ static int pkcs7_encode_rinfo(PKCS7_RECIP_INFO *ri,
     if (EVP_PKEY_encrypt(pctx, ek, &eklen, key, keylen) <= 0)
         goto err;
 
-    ASN1_STRING_set0(ri->enc_key, ek, eklen);
+    ASN1_STRING_set0(ri->enc_key, ek, (int)eklen);
     ek = NULL;
 
     ret = 1;
@@ -178,7 +178,7 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
                          ri->enc_key->data, ri->enc_key->length) <= 0)
         goto err;
 
-    ek = OPENSSL_malloc(eklen);
+    ek = (unsigned char *)OPENSSL_malloc(eklen);
 
     if (ek == NULL) {
         PKCS7err(PKCS7_F_PKCS7_DECRYPT_RINFO, ERR_R_MALLOC_FAILURE);
@@ -198,7 +198,7 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
 
     OPENSSL_clear_free(*pek, *peklen);
     *pek = ek;
-    *peklen = eklen;
+    *peklen = (int)eklen;
 
  err:
     EVP_PKEY_CTX_free(pctx);
@@ -599,7 +599,7 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
         if (len <= 0)
             goto err;
         tkeylen = (size_t)len;
-        tkey = OPENSSL_malloc(tkeylen);
+        tkey = (unsigned char *)OPENSSL_malloc(tkeylen);
         if (tkey == NULL)
             goto err;
         if (EVP_CIPHER_CTX_rand_key(evp_ctx, tkey) <= 0)
@@ -843,7 +843,7 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
                 unsigned char *abuf = NULL;
                 unsigned int abuflen;
                 abuflen = EVP_PKEY_size(si->pkey);
-                abuf = OPENSSL_malloc(abuflen);
+                abuf = (unsigned char *)OPENSSL_malloc(abuflen);
                 if (abuf == NULL)
                     goto err;
 
@@ -958,7 +958,7 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
     abuf = NULL;
     if (EVP_DigestSignFinal(mctx, NULL, &siglen) <= 0)
         goto err;
-    abuf = OPENSSL_malloc(siglen);
+    abuf = (unsigned char *)OPENSSL_malloc(siglen);
     if (abuf == NULL)
         goto err;
     if (EVP_DigestSignFinal(mctx, abuf, &siglen) <= 0)
@@ -990,7 +990,7 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
 
     EVP_MD_CTX_free(mctx);
 
-    ASN1_STRING_set0(si->enc_digest, abuf, siglen);
+    ASN1_STRING_set0(si->enc_digest, abuf, (int)siglen);
 
     return 1;
 

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -48,7 +48,7 @@ static void property_defn_free(PROPERTY_DEFN_ELEM *elem)
 
 static void property_defns_free(void *vproperty_defns)
 {
-    LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns = vproperty_defns;
+    LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns = (LHASH_OF(PROPERTY_DEFN_ELEM) *)vproperty_defns;
 
     if (property_defns != NULL) {
         lh_PROPERTY_DEFN_ELEM_doall(property_defns,
@@ -71,8 +71,8 @@ OSSL_PROPERTY_LIST *ossl_prop_defn_get(OPENSSL_CTX *ctx, const char *prop)
     PROPERTY_DEFN_ELEM elem, *r;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
-    property_defns = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_DEFN_INDEX,
-                                          &property_defns_method);
+    property_defns = (LHASH_OF(PROPERTY_DEFN_ELEM) *)openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_DEFN_INDEX,
+                                                                          &property_defns_method);
     if (property_defns == NULL)
         return NULL;
 
@@ -88,8 +88,8 @@ int ossl_prop_defn_set(OPENSSL_CTX *ctx, const char *prop,
     size_t len;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
-    property_defns = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_DEFN_INDEX,
-                                          &property_defns_method);
+    property_defns = (LHASH_OF(PROPERTY_DEFN_ELEM) *)openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_DEFN_INDEX,
+                                                                          &property_defns_method);
     if (property_defns == NULL)
         return 0;
 
@@ -102,7 +102,7 @@ int ossl_prop_defn_set(OPENSSL_CTX *ctx, const char *prop,
         return 1;
     }
     len = strlen(prop);
-    p = OPENSSL_malloc(sizeof(*p) + len);
+    p = (PROPERTY_DEFN_ELEM *)OPENSSL_malloc(sizeof(*p) + len);
     if (p != NULL) {
         p->prop = p->body;
         p->defn = pl;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -176,7 +176,7 @@ OSSL_METHOD_STORE *ossl_method_store_new(OPENSSL_CTX *ctx)
 {
     OSSL_METHOD_STORE *res;
 
-    res = OPENSSL_zalloc(sizeof(*res));
+    res = (OSSL_METHOD_STORE *)OPENSSL_zalloc(sizeof(*res));
     if (res != NULL) {
         res->ctx = ctx;
         if ((res->algs = ossl_sa_ALGORITHM_new()) == NULL) {
@@ -228,7 +228,7 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
         properties = "";
 
     /* Create new entry */
-    impl = OPENSSL_malloc(sizeof(*impl));
+    impl = (IMPLEMENTATION *)OPENSSL_malloc(sizeof(*impl));
     if (impl == NULL)
         return 0;
     impl->method.method = method;
@@ -257,7 +257,7 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
 
     alg = ossl_method_store_retrieve(store, nid);
     if (alg == NULL) {
-        if ((alg = OPENSSL_zalloc(sizeof(*alg))) == NULL
+        if ((alg = (ALGORITHM *)OPENSSL_zalloc(sizeof(*alg))) == NULL
                 || (alg->impls = sk_IMPLEMENTATION_new_null()) == NULL
                 || (alg->cache = lh_QUERY_new(&query_hash, &query_cmp)) == NULL)
             goto err;
@@ -555,7 +555,7 @@ int ossl_method_store_cache_set(OSSL_METHOD_STORE *store, int nid,
         }
         goto end;
     }
-    p = OPENSSL_malloc(sizeof(*p) + (len = strlen(prop_query)));
+    p = (QUERY *)OPENSSL_malloc(sizeof(*p) + (len = strlen(prop_query)));
     if (p != NULL) {
         p->query = p->body;
         p->method.method = method;

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -97,7 +97,7 @@ static int parse_name(OPENSSL_CTX *ctx, const char *t[], int create,
         }
         do {
             if (i < sizeof(name) - 1)
-                name[i++] = ossl_tolower(*s);
+                name[i++] = (char)ossl_tolower(*s);
             else
                 err = 1;
         } while (*++s == '_' || ossl_isalnum(*s));
@@ -230,7 +230,7 @@ static int parse_unquoted(OPENSSL_CTX *ctx, const char *t[],
         return 0;
     while (ossl_isprint(*s) && !ossl_isspace(*s) && *s != ',') {
         if (i < sizeof(v) - 1)
-            v[i++] = ossl_tolower(*s);
+            v[i++] = (char)ossl_tolower(*s);
         else
             err = 1;
         s++;
@@ -311,8 +311,8 @@ static OSSL_PROPERTY_LIST *stack_to_property_list(STACK_OF(PROPERTY_DEFINITION)
     OSSL_PROPERTY_LIST *r;
     int i;
 
-    r = OPENSSL_malloc(sizeof(*r)
-                       + (n <= 0 ? 0 : n - 1) * sizeof(r->properties[0]));
+    r = (OSSL_PROPERTY_LIST *)OPENSSL_malloc(sizeof(*r)
+                                             + (n <= 0 ? 0 : n - 1) * sizeof(r->properties[0]));
     if (r != NULL) {
         sk_PROPERTY_DEFINITION_sort(sk);
 
@@ -342,7 +342,7 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OPENSSL_CTX *ctx, const char *defn)
     while (!done) {
         const char *start = s;
 
-        prop = OPENSSL_malloc(sizeof(*prop));
+        prop = (PROPERTY_DEFINITION *)OPENSSL_malloc(sizeof(*prop));
         if (prop == NULL)
             goto err;
         memset(&prop->v, 0, sizeof(prop->v));
@@ -398,7 +398,7 @@ OSSL_PROPERTY_LIST *ossl_parse_query(OPENSSL_CTX *ctx, const char *s)
     s = skip_space(s);
     done = *s == '\0';
     while (!done) {
-        prop = OPENSSL_malloc(sizeof(*prop));
+        prop = (PROPERTY_DEFINITION *)OPENSSL_malloc(sizeof(*prop));
         if (prop == NULL)
             goto err;
         memset(&prop->v, 0, sizeof(prop->v));
@@ -563,8 +563,8 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
     int i, j, n;
     const int t = a->n + b->n;
 
-    r = OPENSSL_malloc(sizeof(*r)
-                       + (t == 0 ? 0 : t - 1) * sizeof(r->properties[0]));
+    r = (OSSL_PROPERTY_LIST *)OPENSSL_malloc(sizeof(*r)
+                                             + (t == 0 ? 0 : t - 1) * sizeof(r->properties[0]));
     if (r == NULL)
         return NULL;
 
@@ -586,7 +586,7 @@ OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
     }
     r->n = n;
     if (n != t)
-        r = OPENSSL_realloc(r, sizeof(*r) + (n - 1) * sizeof(r->properties[0]));
+        r = (OSSL_PROPERTY_LIST *)OPENSSL_realloc(r, sizeof(*r) + (n - 1) * sizeof(r->properties[0]));
     return r;
 }
 

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -69,7 +69,7 @@ static void property_table_free(PROP_TABLE **pt)
 
 static void property_string_data_free(void *vpropdata)
 {
-    PROPERTY_STRING_DATA *propdata = vpropdata;
+    PROPERTY_STRING_DATA *propdata = (PROPERTY_STRING_DATA *)vpropdata;
 
     if (propdata == NULL)
         return;
@@ -82,7 +82,7 @@ static void property_string_data_free(void *vpropdata)
 }
 
 static void *property_string_data_new(OPENSSL_CTX *ctx) {
-    PROPERTY_STRING_DATA *propdata = OPENSSL_zalloc(sizeof(*propdata));
+    PROPERTY_STRING_DATA *propdata = (PROPERTY_STRING_DATA *)OPENSSL_zalloc(sizeof(*propdata));
 
     if (propdata == NULL)
         return NULL;
@@ -113,7 +113,7 @@ static PROPERTY_STRING *new_property_string(const char *s,
                                             OSSL_PROPERTY_IDX *pidx)
 {
     const size_t l = strlen(s);
-    PROPERTY_STRING *ps = OPENSSL_malloc(sizeof(*ps) + l);
+    PROPERTY_STRING *ps = (PROPERTY_STRING *)OPENSSL_malloc(sizeof(*ps) + l);
 
     if (ps != NULL) {
         memcpy(ps->body, s, l + 1);
@@ -151,8 +151,8 @@ OSSL_PROPERTY_IDX ossl_property_name(OPENSSL_CTX *ctx, const char *s,
                                      int create)
 {
     PROPERTY_STRING_DATA *propdata
-        = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_STRING_INDEX,
-                               &property_string_data_method);
+        = (PROPERTY_STRING_DATA *)openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_STRING_INDEX,
+                                                       &property_string_data_method);
 
     if (propdata == NULL)
         return 0;
@@ -165,8 +165,8 @@ OSSL_PROPERTY_IDX ossl_property_value(OPENSSL_CTX *ctx, const char *s,
                                       int create)
 {
     PROPERTY_STRING_DATA *propdata
-        = openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_STRING_INDEX,
-                               &property_string_data_method);
+        = (PROPERTY_STRING_DATA *)openssl_ctx_get_data(ctx, OPENSSL_CTX_PROPERTY_STRING_INDEX,
+                                                       &property_string_data_method);
 
     if (propdata == NULL)
         return 0;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -128,7 +128,7 @@ static void provider_deactivate_free(OSSL_PROVIDER *prov)
 
 static void provider_store_free(void *vstore)
 {
-    struct provider_store_st *store = vstore;
+    struct provider_store_st *store = (struct provider_store_st *)vstore;
 
     if (store == NULL)
         return;
@@ -140,7 +140,7 @@ static void provider_store_free(void *vstore)
 
 static void *provider_store_new(OPENSSL_CTX *ctx)
 {
-    struct provider_store_st *store = OPENSSL_zalloc(sizeof(*store));
+    struct provider_store_st *store = (struct provider_store_st *)OPENSSL_zalloc(sizeof(*store));
     const struct predefined_providers_st *p = NULL;
 
     if (store == NULL
@@ -188,8 +188,8 @@ static struct provider_store_st *get_provider_store(OPENSSL_CTX *libctx)
 {
     struct provider_store_st *store = NULL;
 
-    store = openssl_ctx_get_data(libctx, OPENSSL_CTX_PROVIDER_STORE_INDEX,
-                                 &provider_store_method);
+    store = (struct provider_store_st *)openssl_ctx_get_data(libctx, OPENSSL_CTX_PROVIDER_STORE_INDEX,
+                                                             &provider_store_method);
     if (store == NULL)
         CRYPTOerr(CRYPTO_F_GET_PROVIDER_STORE, ERR_R_INTERNAL_ERROR);
     return store;
@@ -247,7 +247,7 @@ static OSSL_PROVIDER *provider_new(const char *name,
 {
     OSSL_PROVIDER *prov = NULL;
 
-    if ((prov = OPENSSL_zalloc(sizeof(*prov))) == NULL
+    if ((prov = (OSSL_PROVIDER *)OPENSSL_zalloc(sizeof(*prov))) == NULL
 #ifndef HAVE_ATOMICS
         || (prov->refcnt_lock = CRYPTO_THREAD_lock_new()) == NULL
 #endif
@@ -399,7 +399,7 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov,
 {
     INFOPAIR *pair = NULL;
 
-    if ((pair = OPENSSL_zalloc(sizeof(*pair))) != NULL
+    if ((pair = (INFOPAIR *)OPENSSL_zalloc(sizeof(*pair))) != NULL
         && (prov->parameters != NULL
             || (prov->parameters = sk_INFOPAIR_new_null()) != NULL)
         && (pair->name = OPENSSL_strdup(name)) != NULL
@@ -602,7 +602,7 @@ static int provider_activate(OSSL_PROVIDER *prov)
         cnt++;                   /* One for the terminating item */
 
         /* Allocate one extra item for the "library" name */
-        prov->error_strings =
+        prov->error_strings = (ERR_STRING_DATA *)
             OPENSSL_zalloc(sizeof(ERR_STRING_DATA) * (cnt + 1));
         if (prov->error_strings == NULL)
             return 0;
@@ -618,7 +618,7 @@ static int provider_activate(OSSL_PROVIDER *prov)
          */
         for (cnt2 = 1; cnt2 <= cnt; cnt2++) {
             prov->error_strings[cnt2].error = (int)reasonstrings[cnt2-1].id;
-            prov->error_strings[cnt2].string = reasonstrings[cnt2-1].ptr;
+            prov->error_strings[cnt2].string = (const char *)reasonstrings[cnt2-1].ptr;
         }
 
         ERR_load_strings(prov->error_lib, prov->error_strings);

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -126,7 +126,7 @@ int RAND_poll(void)
 
         if (meth->add == NULL
             || meth->add(rand_pool_buffer(pool),
-                         rand_pool_length(pool),
+                         (int)rand_pool_length(pool),
                          (rand_pool_entropy(pool) / 8.0)) == 0)
             goto err;
 

--- a/crypto/rc2/rc2_skey.c
+++ b/crypto/rc2/rc2_skey.c
@@ -77,7 +77,7 @@ void RC2_set_key(RC2_KEY *key, int len, const unsigned char *data, int bits)
     j = 0;
     for (i = len; i < 128; i++, j++) {
         d = key_table[(k[j] + d) & 0xff];
-        k[i] = d;
+        k[i] = (unsigned char)d;
     }
 
     /* hmm.... key reduction to 'bits' bits */
@@ -87,10 +87,10 @@ void RC2_set_key(RC2_KEY *key, int len, const unsigned char *data, int bits)
     c = (0xff >> (-bits & 0x07));
 
     d = key_table[k[i] & c];
-    k[i] = d;
+    k[i] = (unsigned char)d;
     while (i--) {
         d = key_table[k[i + j] ^ d];
-        k[i] = d;
+        k[i] = (unsigned char)d;
     }
 
     /* copy from bytes into RC2_INT's */

--- a/crypto/rc4/rc4_enc.c
+++ b/crypto/rc4/rc4_enc.c
@@ -41,7 +41,7 @@ void RC4(RC4_KEY *key, size_t len, const unsigned char *indata,
                 y=(tx+y)&0xff; \
                 d[x]=ty=d[y]; \
                 d[y]=tx; \
-                (out) = d[(tx+ty)&0xff]^ (in);
+                (out) = (unsigned char)(d[(tx+ty)&0xff]^ (in));
 
     i = len >> 3;
     if (i) {

--- a/crypto/ripemd/rmd_dgst.c
+++ b/crypto/ripemd/rmd_dgst.c
@@ -41,7 +41,7 @@ int RIPEMD160_Init(RIPEMD160_CTX *c)
 # endif
 void ripemd160_block_data_order(RIPEMD160_CTX *ctx, const void *p, size_t num)
 {
-    const unsigned char *data = p;
+    const unsigned char *data = (const unsigned char *)p;
     register unsigned MD32_REG_T A, B, C, D, E;
     unsigned MD32_REG_T a, b, c, d, e, l;
 # ifndef MD32_XARRAY

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -255,8 +255,8 @@ static X509_ALGOR *rsa_mgf1_decode(X509_ALGOR *alg)
 {
     if (OBJ_obj2nid(alg->algorithm) != NID_mgf1)
         return NULL;
-    return ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(X509_ALGOR),
-                                     alg->parameter);
+    return (X509_ALGOR *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(X509_ALGOR),
+                                                   alg->parameter);
 }
 
 static int rsa_pss_param_print(BIO *bp, int pss_key, RSA_PSS_PARAMS *pss,
@@ -459,8 +459,8 @@ static RSA_PSS_PARAMS *rsa_pss_decode(const X509_ALGOR *alg)
 {
     RSA_PSS_PARAMS *pss;
 
-    pss = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(RSA_PSS_PARAMS),
-                                    alg->parameter);
+    pss = (RSA_PSS_PARAMS *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(RSA_PSS_PARAMS),
+                                                      alg->parameter);
 
     if (pss == NULL)
         return NULL;
@@ -506,30 +506,30 @@ static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     case ASN1_PKEY_CTRL_PKCS7_SIGN:
         if (arg1 == 0)
-            PKCS7_SIGNER_INFO_get0_algs(arg2, NULL, NULL, &alg);
+            PKCS7_SIGNER_INFO_get0_algs((PKCS7_SIGNER_INFO *)arg2, NULL, NULL, &alg);
         break;
 
     case ASN1_PKEY_CTRL_PKCS7_ENCRYPT:
         if (pkey_is_pss(pkey))
             return -2;
         if (arg1 == 0)
-            PKCS7_RECIP_INFO_get0_alg(arg2, &alg);
+            PKCS7_RECIP_INFO_get0_alg((PKCS7_RECIP_INFO *)arg2, &alg);
         break;
 #ifndef OPENSSL_NO_CMS
     case ASN1_PKEY_CTRL_CMS_SIGN:
         if (arg1 == 0)
-            return rsa_cms_sign(arg2);
+            return rsa_cms_sign((CMS_SignerInfo *)arg2);
         else if (arg1 == 1)
-            return rsa_cms_verify(arg2);
+            return rsa_cms_verify((CMS_SignerInfo *)arg2);
         break;
 
     case ASN1_PKEY_CTRL_CMS_ENVELOPE:
         if (pkey_is_pss(pkey))
             return -2;
         if (arg1 == 0)
-            return rsa_cms_encrypt(arg2);
+            return rsa_cms_encrypt((CMS_RecipientInfo *)arg2);
         else if (arg1 == 1)
-            return rsa_cms_decrypt(arg2);
+            return rsa_cms_decrypt((CMS_RecipientInfo *)arg2);
         break;
 
     case ASN1_PKEY_CTRL_CMS_RI_TYPE:
@@ -1011,8 +1011,8 @@ static RSA_OAEP_PARAMS *rsa_oaep_decode(const X509_ALGOR *alg)
 {
     RSA_OAEP_PARAMS *oaep;
 
-    oaep = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(RSA_OAEP_PARAMS),
-                                     alg->parameter);
+    oaep = (RSA_OAEP_PARAMS *)ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(RSA_OAEP_PARAMS),
+                                                        alg->parameter);
 
     if (oaep == NULL)
         return NULL;

--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -118,10 +118,10 @@ IMPLEMENT_ASN1_ENCODE_FUNCTIONS_fname(RSA, RSAPublicKey, RSAPublicKey)
 
 RSA *RSAPublicKey_dup(const RSA *rsa)
 {
-    return ASN1_item_dup(ASN1_ITEM_rptr(RSAPublicKey), rsa);
+    return (RSA *)ASN1_item_dup(ASN1_ITEM_rptr(RSAPublicKey), rsa);
 }
 
 RSA *RSAPrivateKey_dup(const RSA *rsa)
 {
-    return ASN1_item_dup(ASN1_ITEM_rptr(RSAPrivateKey), rsa);
+    return (RSA *)ASN1_item_dup(ASN1_ITEM_rptr(RSAPrivateKey), rsa);
 }

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -490,7 +490,7 @@ static int rsa_keygen_pairwise_test(RSA *rsa, OSSL_CALLBACK *cb, void *cbarg)
                            OSSL_SELF_TEST_DESC_PCT_RSA_PKCS1);
 
     ciphertxt_len = RSA_size(rsa);
-    ciphertxt = OPENSSL_zalloc(ciphertxt_len);
+    ciphertxt = (unsigned char *)OPENSSL_zalloc(ciphertxt_len);
     if (ciphertxt == NULL)
         goto err;
 

--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -73,7 +73,7 @@ RSA *rsa_new_with_ctx(OPENSSL_CTX *libctx)
 
 static RSA *rsa_new_intern(ENGINE *engine, OPENSSL_CTX *libctx)
 {
-    RSA *ret = OPENSSL_zalloc(sizeof(*ret));
+    RSA *ret = (RSA *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         RSAerr(0, ERR_R_MALLOC_FAILURE);
@@ -746,7 +746,7 @@ int rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
                 goto err;
 
             /* Using rsa_multip_info_new() is wasteful, so allocate directly */
-            if ((pinfo = OPENSSL_zalloc(sizeof(*pinfo))) == NULL) {
+            if ((pinfo = (RSA_PRIME_INFO *)OPENSSL_zalloc(sizeof(*pinfo))) == NULL) {
                 ERR_raise(ERR_LIB_RSA, ERR_R_MALLOC_FAILURE);
                 goto err;
             }

--- a/crypto/rsa/rsa_mp.c
+++ b/crypto/rsa/rsa_mp.c
@@ -33,7 +33,7 @@ RSA_PRIME_INFO *rsa_multip_info_new(void)
     RSA_PRIME_INFO *pinfo;
 
     /* create a RSA_PRIME_INFO structure */
-    if ((pinfo = OPENSSL_zalloc(sizeof(RSA_PRIME_INFO))) == NULL) {
+    if ((pinfo = (RSA_PRIME_INFO *)OPENSSL_zalloc(sizeof(RSA_PRIME_INFO))) == NULL) {
         RSAerr(RSA_F_RSA_MULTIP_INFO_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
     }

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -109,7 +109,7 @@ int rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(OPENSSL_CTX *libctx,
         goto err;
 
     dbmask_len = emlen - mdlen;
-    dbmask = OPENSSL_malloc(dbmask_len);
+    dbmask = (unsigned char *)OPENSSL_malloc(dbmask_len);
     if (dbmask == NULL) {
         RSAerr(0, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -202,13 +202,13 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     }
 
     dblen = num - mdlen - 1;
-    db = OPENSSL_malloc(dblen);
+    db = (unsigned char *)OPENSSL_malloc(dblen);
     if (db == NULL) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1, ERR_R_MALLOC_FAILURE);
         goto cleanup;
     }
 
-    em = OPENSSL_malloc(num);
+    em = (unsigned char *)OPENSSL_malloc(num);
     if (em == NULL) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1,
                ERR_R_MALLOC_FAILURE);
@@ -296,11 +296,11 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
     for (msg_index = 1; msg_index < dblen - mdlen - 1; msg_index <<= 1) {
         mask = ~constant_time_eq(msg_index & (dblen - mdlen - 1 - mlen), 0);
         for (i = mdlen + 1; i < dblen - msg_index; i++)
-            db[i] = constant_time_select_8(mask, db[i + msg_index], db[i]);
+            db[i] = constant_time_select_8((unsigned char)mask, db[i + msg_index], db[i]);
     }
     for (i = 0; i < tlen; i++) {
         mask = good & constant_time_lt(i, mlen);
-        to[i] = constant_time_select_8(mask, db[i + mdlen + 1], to[i]);
+        to[i] = constant_time_select_8((unsigned char)mask, db[i + mdlen + 1], to[i]);
     }
 
 #ifndef FIPS_MODULE

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -103,7 +103,7 @@ static int rsa_ossl_public_encrypt(int flen, const unsigned char *from,
     f = BN_CTX_get(ctx);
     ret = BN_CTX_get(ctx);
     num = BN_num_bytes(rsa->n);
-    buf = OPENSSL_malloc(num);
+    buf = (unsigned char *)OPENSSL_malloc(num);
     if (ret == NULL || buf == NULL) {
         RSAerr(RSA_F_RSA_OSSL_PUBLIC_ENCRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -264,7 +264,7 @@ static int rsa_ossl_private_encrypt(int flen, const unsigned char *from,
     f = BN_CTX_get(ctx);
     ret = BN_CTX_get(ctx);
     num = BN_num_bytes(rsa->n);
-    buf = OPENSSL_malloc(num);
+    buf = (unsigned char *)OPENSSL_malloc(num);
     if (ret == NULL || buf == NULL) {
         RSAerr(RSA_F_RSA_OSSL_PRIVATE_ENCRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -398,7 +398,7 @@ static int rsa_ossl_private_decrypt(int flen, const unsigned char *from,
     f = BN_CTX_get(ctx);
     ret = BN_CTX_get(ctx);
     num = BN_num_bytes(rsa->n);
-    buf = OPENSSL_malloc(num);
+    buf = (unsigned char *)OPENSSL_malloc(num);
     if (ret == NULL || buf == NULL) {
         RSAerr(RSA_F_RSA_OSSL_PRIVATE_DECRYPT, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -554,7 +554,7 @@ static int rsa_ossl_public_decrypt(int flen, const unsigned char *from,
     f = BN_CTX_get(ctx);
     ret = BN_CTX_get(ctx);
     num = BN_num_bytes(rsa->n);
-    buf = OPENSSL_malloc(num);
+    buf = (unsigned char *)OPENSSL_malloc(num);
     if (ret == NULL || buf == NULL) {
         RSAerr(RSA_F_RSA_OSSL_PUBLIC_DECRYPT, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -192,7 +192,7 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
         return -1;
     }
 
-    em = OPENSSL_malloc(num);
+    em = (unsigned char *)OPENSSL_malloc(num);
     if (em == NULL) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_PKCS1_TYPE_2, ERR_R_MALLOC_FAILURE);
         return -1;
@@ -257,11 +257,11 @@ int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
     for (msg_index = 1; msg_index < num - RSA_PKCS1_PADDING_SIZE; msg_index <<= 1) {
         mask = ~constant_time_eq(msg_index & (num - RSA_PKCS1_PADDING_SIZE - mlen), 0);
         for (i = RSA_PKCS1_PADDING_SIZE; i < num - msg_index; i++)
-            em[i] = constant_time_select_8(mask, em[i + msg_index], em[i]);
+            em[i] = constant_time_select_8((unsigned char)mask, em[i + msg_index], em[i]);
     }
     for (i = 0; i < tlen; i++) {
         mask = good & constant_time_lt(i, mlen);
-        to[i] = constant_time_select_8(mask, em[i + RSA_PKCS1_PADDING_SIZE], to[i]);
+        to[i] = constant_time_select_8((unsigned char)mask, em[i + RSA_PKCS1_PADDING_SIZE], to[i]);
     }
 
     OPENSSL_clear_free(em, num);
@@ -382,7 +382,7 @@ int rsa_padding_check_PKCS1_type_2_TLS(OPENSSL_CTX *libctx, unsigned char *to,
      */
     for (i = 0; i < SSL_MAX_MASTER_KEY_LENGTH; i++) {
         to[i] =
-            constant_time_select_8(good,
+            constant_time_select_8((unsigned char)good,
                                    from[flen - SSL_MAX_MASTER_KEY_LENGTH + i],
                                    rand_premaster_secret[i]);
     }

--- a/crypto/rsa/rsa_pmeth.c
+++ b/crypto/rsa/rsa_pmeth.c
@@ -59,7 +59,7 @@ typedef struct {
 
 static int pkey_rsa_init(EVP_PKEY_CTX *ctx)
 {
-    RSA_PKEY_CTX *rctx = OPENSSL_zalloc(sizeof(*rctx));
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)OPENSSL_zalloc(sizeof(*rctx));
 
     if (rctx == NULL)
         return 0;
@@ -85,8 +85,8 @@ static int pkey_rsa_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
 
     if (!pkey_rsa_init(dst))
         return 0;
-    sctx = src->data;
-    dctx = dst->data;
+    sctx = (RSA_PKEY_CTX *)src->data;
+    dctx = (RSA_PKEY_CTX *)dst->data;
     dctx->nbits = sctx->nbits;
     if (sctx->pub_exp) {
         dctx->pub_exp = BN_dup(sctx->pub_exp);
@@ -99,7 +99,7 @@ static int pkey_rsa_copy(EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src)
     dctx->saltlen = sctx->saltlen;
     if (sctx->oaep_label) {
         OPENSSL_free(dctx->oaep_label);
-        dctx->oaep_label = OPENSSL_memdup(sctx->oaep_label, sctx->oaep_labellen);
+        dctx->oaep_label = (unsigned char *)OPENSSL_memdup(sctx->oaep_label, sctx->oaep_labellen);
         if (!dctx->oaep_label)
             return 0;
         dctx->oaep_labellen = sctx->oaep_labellen;
@@ -111,7 +111,7 @@ static int setup_tbuf(RSA_PKEY_CTX *ctx, EVP_PKEY_CTX *pk)
 {
     if (ctx->tbuf != NULL)
         return 1;
-    if ((ctx->tbuf = OPENSSL_malloc(RSA_size(pk->pkey->pkey.rsa))) == NULL) {
+    if ((ctx->tbuf = (unsigned char *)OPENSSL_malloc(RSA_size(pk->pkey->pkey.rsa))) == NULL) {
         RSAerr(RSA_F_SETUP_TBUF, ERR_R_MALLOC_FAILURE);
         return 0;
     }
@@ -120,7 +120,7 @@ static int setup_tbuf(RSA_PKEY_CTX *ctx, EVP_PKEY_CTX *pk)
 
 static void pkey_rsa_cleanup(EVP_PKEY_CTX *ctx)
 {
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
     if (rctx) {
         BN_free(rctx->pub_exp);
         OPENSSL_free(rctx->tbuf);
@@ -134,7 +134,7 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
                          size_t tbslen)
 {
     int ret;
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
     RSA *rsa = ctx->pkey->pkey.rsa;
 
     if (rctx->md) {
@@ -148,7 +148,7 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
             if (rctx->pad_mode != RSA_PKCS1_PADDING)
                 return -1;
             ret = RSA_sign_ASN1_OCTET_STRING(0,
-                                             tbs, tbslen, sig, &sltmp, rsa);
+                                             tbs, (unsigned int)tbslen, sig, &sltmp, rsa);
 
             if (ret <= 0)
                 return ret;
@@ -163,13 +163,13 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
                 return -1;
             }
             memcpy(rctx->tbuf, tbs, tbslen);
-            rctx->tbuf[tbslen] = RSA_X931_hash_id(EVP_MD_type(rctx->md));
-            ret = RSA_private_encrypt(tbslen + 1, rctx->tbuf,
+            rctx->tbuf[tbslen] = (unsigned char)RSA_X931_hash_id(EVP_MD_type(rctx->md));
+            ret = RSA_private_encrypt((int)(tbslen + 1), rctx->tbuf,
                                       sig, rsa, RSA_X931_PADDING);
         } else if (rctx->pad_mode == RSA_PKCS1_PADDING) {
             unsigned int sltmp;
             ret = RSA_sign(EVP_MD_type(rctx->md),
-                           tbs, tbslen, sig, &sltmp, rsa);
+                           tbs, (unsigned int)tbslen, sig, &sltmp, rsa);
             if (ret <= 0)
                 return ret;
             ret = sltmp;
@@ -187,7 +187,7 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
             return -1;
         }
     } else {
-        ret = RSA_private_encrypt(tbslen, tbs, sig, ctx->pkey->pkey.rsa,
+        ret = RSA_private_encrypt((int)tbslen, tbs, sig, ctx->pkey->pkey.rsa,
                                   rctx->pad_mode);
     }
     if (ret < 0)
@@ -201,13 +201,13 @@ static int pkey_rsa_verifyrecover(EVP_PKEY_CTX *ctx,
                                   const unsigned char *sig, size_t siglen)
 {
     int ret;
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
 
     if (rctx->md) {
         if (rctx->pad_mode == RSA_X931_PADDING) {
             if (!setup_tbuf(rctx, ctx))
                 return -1;
-            ret = RSA_public_decrypt(siglen, sig,
+            ret = RSA_public_decrypt((int)siglen, sig,
                                      rctx->tbuf, ctx->pkey->pkey.rsa,
                                      RSA_X931_PADDING);
             if (ret < 1)
@@ -232,12 +232,12 @@ static int pkey_rsa_verifyrecover(EVP_PKEY_CTX *ctx,
                                  sig, siglen, ctx->pkey->pkey.rsa);
             if (ret <= 0)
                 return 0;
-            ret = sltmp;
+            ret = (int)sltmp;
         } else {
             return -1;
         }
     } else {
-        ret = RSA_public_decrypt(siglen, sig, rout, ctx->pkey->pkey.rsa,
+        ret = RSA_public_decrypt((int)siglen, sig, rout, ctx->pkey->pkey.rsa,
                                  rctx->pad_mode);
     }
     if (ret < 0)
@@ -250,14 +250,14 @@ static int pkey_rsa_verify(EVP_PKEY_CTX *ctx,
                            const unsigned char *sig, size_t siglen,
                            const unsigned char *tbs, size_t tbslen)
 {
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
     RSA *rsa = ctx->pkey->pkey.rsa;
     size_t rslen;
 
     if (rctx->md) {
         if (rctx->pad_mode == RSA_PKCS1_PADDING)
-            return RSA_verify(EVP_MD_type(rctx->md), tbs, tbslen,
-                              sig, siglen, rsa);
+            return RSA_verify(EVP_MD_type(rctx->md), tbs, (unsigned int)tbslen,
+                              sig, (unsigned int)siglen, rsa);
         if (tbslen != (size_t)EVP_MD_size(rctx->md)) {
             RSAerr(RSA_F_PKEY_RSA_VERIFY, RSA_R_INVALID_DIGEST_LENGTH);
             return -1;
@@ -269,7 +269,7 @@ static int pkey_rsa_verify(EVP_PKEY_CTX *ctx,
             int ret;
             if (!setup_tbuf(rctx, ctx))
                 return -1;
-            ret = RSA_public_decrypt(siglen, sig, rctx->tbuf,
+            ret = RSA_public_decrypt((int)siglen, sig, rctx->tbuf,
                                      rsa, RSA_NO_PADDING);
             if (ret <= 0)
                 return 0;
@@ -285,7 +285,7 @@ static int pkey_rsa_verify(EVP_PKEY_CTX *ctx,
     } else {
         if (!setup_tbuf(rctx, ctx))
             return -1;
-        rslen = RSA_public_decrypt(siglen, sig, rctx->tbuf,
+        rslen = RSA_public_decrypt((int)siglen, sig, rctx->tbuf,
                                    rsa, rctx->pad_mode);
         if (rslen == 0)
             return 0;
@@ -303,22 +303,22 @@ static int pkey_rsa_encrypt(EVP_PKEY_CTX *ctx,
                             const unsigned char *in, size_t inlen)
 {
     int ret;
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
 
     if (rctx->pad_mode == RSA_PKCS1_OAEP_PADDING) {
         int klen = RSA_size(ctx->pkey->pkey.rsa);
         if (!setup_tbuf(rctx, ctx))
             return -1;
         if (!RSA_padding_add_PKCS1_OAEP_mgf1(rctx->tbuf, klen,
-                                             in, inlen,
+                                             in, (int)inlen,
                                              rctx->oaep_label,
-                                             rctx->oaep_labellen,
+                                             (int)rctx->oaep_labellen,
                                              rctx->md, rctx->mgf1md))
             return -1;
         ret = RSA_public_encrypt(klen, rctx->tbuf, out,
                                  ctx->pkey->pkey.rsa, RSA_NO_PADDING);
     } else {
-        ret = RSA_public_encrypt(inlen, in, out, ctx->pkey->pkey.rsa,
+        ret = RSA_public_encrypt((int)inlen, in, out, ctx->pkey->pkey.rsa,
                                  rctx->pad_mode);
     }
     if (ret < 0)
@@ -332,22 +332,22 @@ static int pkey_rsa_decrypt(EVP_PKEY_CTX *ctx,
                             const unsigned char *in, size_t inlen)
 {
     int ret;
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
 
     if (rctx->pad_mode == RSA_PKCS1_OAEP_PADDING) {
         if (!setup_tbuf(rctx, ctx))
             return -1;
-        ret = RSA_private_decrypt(inlen, in, rctx->tbuf,
+        ret = RSA_private_decrypt((int)inlen, in, rctx->tbuf,
                                   ctx->pkey->pkey.rsa, RSA_NO_PADDING);
         if (ret <= 0)
             return ret;
         ret = RSA_padding_check_PKCS1_OAEP_mgf1(out, ret, rctx->tbuf,
                                                 ret, ret,
                                                 rctx->oaep_label,
-                                                rctx->oaep_labellen,
+                                                (int)rctx->oaep_labellen,
                                                 rctx->md, rctx->mgf1md);
     } else {
-        ret = RSA_private_decrypt(inlen, in, out, ctx->pkey->pkey.rsa,
+        ret = RSA_private_decrypt((int)inlen, in, out, ctx->pkey->pkey.rsa,
                                   rctx->pad_mode);
     }
     *outlen = constant_time_select_s(constant_time_msb_s(ret), *outlen, ret);
@@ -408,7 +408,7 @@ static int check_padding_md(const EVP_MD *md, int padding)
 
 static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 {
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
 
     switch (type) {
     case EVP_PKEY_CTRL_RSA_PADDING:
@@ -484,7 +484,7 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             return -2;
         }
         BN_free(rctx->pub_exp);
-        rctx->pub_exp = p2;
+        rctx->pub_exp = (BIGNUM *)p2;
         return 1;
 
     case EVP_PKEY_CTRL_RSA_KEYGEN_PRIMES:
@@ -504,19 +504,19 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         if (type == EVP_PKEY_CTRL_GET_RSA_OAEP_MD)
             *(const EVP_MD **)p2 = rctx->md;
         else
-            rctx->md = p2;
+            rctx->md = (const EVP_MD *)p2;
         return 1;
 
     case EVP_PKEY_CTRL_MD:
-        if (!check_padding_md(p2, rctx->pad_mode))
+        if (!check_padding_md((const EVP_MD *)p2, rctx->pad_mode))
             return 0;
         if (rsa_pss_restricted(rctx)) {
-            if (EVP_MD_type(rctx->md) == EVP_MD_type(p2))
+            if (EVP_MD_type(rctx->md) == EVP_MD_type((const EVP_MD *)p2))
                 return 1;
             RSAerr(RSA_F_PKEY_RSA_CTRL, RSA_R_DIGEST_NOT_ALLOWED);
             return 0;
         }
-        rctx->md = p2;
+        rctx->md = (const EVP_MD *)p2;
         return 1;
 
     case EVP_PKEY_CTRL_GET_MD:
@@ -537,12 +537,12 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
                 *(const EVP_MD **)p2 = rctx->md;
         } else {
             if (rsa_pss_restricted(rctx)) {
-                if (EVP_MD_type(rctx->mgf1md) == EVP_MD_type(p2))
+                if (EVP_MD_type(rctx->mgf1md) == EVP_MD_type((const EVP_MD *)p2))
                     return 1;
                 RSAerr(RSA_F_PKEY_RSA_CTRL, RSA_R_MGF1_DIGEST_NOT_ALLOWED);
                 return 0;
             }
-            rctx->mgf1md = p2;
+            rctx->mgf1md = (const EVP_MD *)p2;
         }
         return 1;
 
@@ -553,7 +553,7 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
         }
         OPENSSL_free(rctx->oaep_label);
         if (p2 && p1 > 0) {
-            rctx->oaep_label = p2;
+            rctx->oaep_label = (unsigned char *)p2;
             rctx->oaep_labellen = p1;
         } else {
             rctx->oaep_label = NULL;
@@ -567,7 +567,7 @@ static int pkey_rsa_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
             return -2;
         }
         *(unsigned char **)p2 = rctx->oaep_label;
-        return rctx->oaep_labellen;
+        return (int)rctx->oaep_labellen;
 
     case EVP_PKEY_CTRL_DIGESTINIT:
     case EVP_PKEY_CTRL_PKCS7_SIGN:
@@ -711,7 +711,7 @@ static int pkey_rsa_ctrl_str(EVP_PKEY_CTX *ctx,
 /* Set PSS parameters when generating a key, if necessary */
 static int rsa_set_pss_param(RSA *rsa, EVP_PKEY_CTX *ctx)
 {
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
 
     if (!pkey_ctx_is_pss(ctx))
         return 1;
@@ -728,7 +728,7 @@ static int rsa_set_pss_param(RSA *rsa, EVP_PKEY_CTX *ctx)
 static int pkey_rsa_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 {
     RSA *rsa = NULL;
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
     BN_GENCB *pcb;
     int ret;
 
@@ -812,7 +812,7 @@ const EVP_PKEY_METHOD *rsa_pkey_method(void)
 static int pkey_pss_init(EVP_PKEY_CTX *ctx)
 {
     RSA *rsa;
-    RSA_PKEY_CTX *rctx = ctx->data;
+    RSA_PKEY_CTX *rctx = (RSA_PKEY_CTX *)ctx->data;
     const EVP_MD *md;
     const EVP_MD *mgf1md;
     int min_saltlen, max_saltlen;

--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -96,7 +96,7 @@ int RSA_verify_PKCS1_PSS_mgf1(RSA *rsa, const unsigned char *mHash,
     }
     maskedDBLen = emLen - hLen - 1;
     H = EM + maskedDBLen;
-    DB = OPENSSL_malloc(maskedDBLen);
+    DB = (unsigned char *)OPENSSL_malloc(maskedDBLen);
     if (DB == NULL) {
         RSAerr(RSA_F_RSA_VERIFY_PKCS1_PSS_MGF1, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -200,7 +200,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
         goto err;
     }
     if (sLen > 0) {
-        salt = OPENSSL_malloc(sLen);
+        salt = (unsigned char *)OPENSSL_malloc(sLen);
         if (salt == NULL) {
             RSAerr(RSA_F_RSA_PADDING_ADD_PKCS1_PSS_MGF1,
                    ERR_R_MALLOC_FAILURE);

--- a/crypto/rsa/rsa_saos.c
+++ b/crypto/rsa/rsa_saos.c
@@ -40,7 +40,7 @@ int RSA_sign_ASN1_OCTET_STRING(int type,
                RSA_R_DIGEST_TOO_BIG_FOR_RSA_KEY);
         return 0;
     }
-    s = OPENSSL_malloc((unsigned int)j + 1);
+    s = (unsigned char *)OPENSSL_malloc((unsigned int)j + 1);
     if (s == NULL) {
         RSAerr(RSA_F_RSA_SIGN_ASN1_OCTET_STRING, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -73,7 +73,7 @@ int RSA_verify_ASN1_OCTET_STRING(int dtype,
         return 0;
     }
 
-    s = OPENSSL_malloc((unsigned int)siglen);
+    s = (unsigned char *)OPENSSL_malloc((unsigned int)siglen);
     if (s == NULL) {
         RSAerr(RSA_F_RSA_VERIFY_ASN1_OCTET_STRING, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/rsa/rsa_sign.c
+++ b/crypto/rsa/rsa_sign.c
@@ -257,7 +257,7 @@ static int encode_pkcs1(unsigned char **out, size_t *out_len, int type,
         return 0;
     }
     dig_info_len = di_prefix_len + m_len;
-    dig_info = OPENSSL_malloc(dig_info_len);
+    dig_info = (unsigned char *)OPENSSL_malloc(dig_info_len);
     if (dig_info == NULL) {
         RSAerr(RSA_F_ENCODE_PKCS1, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -342,7 +342,7 @@ int int_rsa_verify(int type, const unsigned char *m, unsigned int m_len,
     }
 
     /* Recover the encoded digest. */
-    decrypt_buf = OPENSSL_malloc(siglen);
+    decrypt_buf = (unsigned char *)OPENSSL_malloc(siglen);
     if (decrypt_buf == NULL) {
         RSAerr(RSA_F_INT_RSA_VERIFY, ERR_R_MALLOC_FAILURE);
         goto err;

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -88,7 +88,7 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
         return -1;
     }
 
-    em = OPENSSL_malloc(num);
+    em = (unsigned char *)OPENSSL_malloc(num);
     if (em == NULL) {
         RSAerr(RSA_F_RSA_PADDING_CHECK_SSLV23, ERR_R_MALLOC_FAILURE);
         return -1;
@@ -168,11 +168,11 @@ int RSA_padding_check_SSLv23(unsigned char *to, int tlen,
     for (msg_index = 1; msg_index < num - RSA_PKCS1_PADDING_SIZE; msg_index <<= 1) {
         mask = ~constant_time_eq(msg_index & (num - RSA_PKCS1_PADDING_SIZE - mlen), 0);
         for (i = RSA_PKCS1_PADDING_SIZE; i < num - msg_index; i++)
-            em[i] = constant_time_select_8(mask, em[i + msg_index], em[i]);
+            em[i] = constant_time_select_8((unsigned char)mask, em[i + msg_index], em[i]);
     }
     for (i = 0; i < tlen; i++) {
         mask = good & constant_time_lt(i, mlen);
-        to[i] = constant_time_select_8(mask, em[i + RSA_PKCS1_PADDING_SIZE], to[i]);
+        to[i] = constant_time_select_8((unsigned char)mask, em[i + RSA_PKCS1_PADDING_SIZE], to[i]);
     }
 
     OPENSSL_clear_free(em, num);

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -35,7 +35,7 @@ static void *self_test_set_callback_new(OPENSSL_CTX *ctx)
 {
     SELF_TEST_CB *stcb;
 
-    stcb = OPENSSL_zalloc(sizeof(*stcb));
+    stcb = (SELF_TEST_CB *)OPENSSL_zalloc(sizeof(*stcb));
     return stcb;
 }
 
@@ -51,8 +51,8 @@ static const OPENSSL_CTX_METHOD self_test_set_callback_method = {
 
 static SELF_TEST_CB *get_self_test_callback(OPENSSL_CTX *libctx)
 {
-    return openssl_ctx_get_data(libctx, OPENSSL_CTX_SELF_TEST_CB_INDEX,
-                                &self_test_set_callback_method);
+    return (SELF_TEST_CB *)openssl_ctx_get_data(libctx, OPENSSL_CTX_SELF_TEST_CB_INDEX,
+                                                &self_test_set_callback_method);
 }
 
 #ifndef FIPS_MODULE
@@ -99,7 +99,7 @@ static void self_test_setparams(OSSL_SELF_TEST *st)
 
 OSSL_SELF_TEST *OSSL_SELF_TEST_new(OSSL_CALLBACK *cb, void *cbarg)
 {
-    OSSL_SELF_TEST *ret = OPENSSL_zalloc(sizeof(*ret));
+    OSSL_SELF_TEST *ret = (OSSL_SELF_TEST *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL)
         return NULL;

--- a/crypto/sha/sha256.c
+++ b/crypto/sha/sha256.c
@@ -256,7 +256,7 @@ static void sha256_block_data_order(SHA256_CTX *ctx, const void *in,
     unsigned MD32_REG_T a, b, c, d, e, f, g, h, s0, s1, T1;
     SHA_LONG X[16];
     int i;
-    const unsigned char *data = in;
+    const unsigned char *data = (const unsigned char *)in;
     DECLARE_IS_ENDIAN;
 
     while (num--) {

--- a/crypto/sha/sha3.c
+++ b/crypto/sha/sha3.c
@@ -44,7 +44,7 @@ int keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
 
 int sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len)
 {
-    const unsigned char *inp = _inp;
+    const unsigned char *inp = (const unsigned char *)_inp;
     size_t bsz = ctx->block_size;
     size_t num, rem;
 

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -516,7 +516,7 @@ static SHA_LONG64 __fastcall __pull64be(const void *x)
 static void sha512_block_data_order(SHA512_CTX *ctx, const void *in,
                                     size_t num)
 {
-    const SHA_LONG64 *W = in;
+    const SHA_LONG64 *W = (const SHA_LONG64 *)in;
     SHA_LONG64 A, E, T;
     SHA_LONG64 X[9 + 80], *F;
     int i;
@@ -659,7 +659,7 @@ static void sha512_block_data_order(SHA512_CTX *ctx, const void *in,
 static void sha512_block_data_order(SHA512_CTX *ctx, const void *in,
                                     size_t num)
 {
-    const SHA_LONG64 *W = in;
+    const SHA_LONG64 *W = (const SHA_LONG64 *)in;
     SHA_LONG64 a, b, c, d, e, f, g, h, s0, s1, T1;
     SHA_LONG64 X[16];
     int i;

--- a/crypto/sha/sha_local.h
+++ b/crypto/sha/sha_local.h
@@ -136,7 +136,7 @@ int HASH_INIT(SHA_CTX *c)
 # if !defined(SHA1_ASM)
 static void HASH_BLOCK_DATA_ORDER(SHA_CTX *c, const void *p, size_t num)
 {
-    const unsigned char *data = p;
+    const unsigned char *data = (const unsigned char *)p;
     register unsigned MD32_REG_T A, B, C, D, E, T, l;
 #  ifndef MD32_XARRAY
     unsigned MD32_REG_T XX0, XX1, XX2, XX3, XX4, XX5, XX6, XX7,

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -100,12 +100,12 @@ int SipHash_set_hash_size(SIPHASH *ctx, size_t hash_size)
      */
 
     /* Start by adjusting the stored size, to make things easier */
-    ctx->hash_size = siphash_adjust_hash_size(ctx->hash_size);
+    ctx->hash_size = (int)siphash_adjust_hash_size(ctx->hash_size);
 
     /* Now, adjust ctx->v1 if the old and the new size differ */
     if ((size_t)ctx->hash_size != hash_size) {
         ctx->v1 ^= 0xee;
-        ctx->hash_size = hash_size;
+        ctx->hash_size = (int)hash_size;
     }
     return 1;
 }
@@ -117,7 +117,7 @@ int SipHash_Init(SIPHASH *ctx, const unsigned char *k, int crounds, int drounds)
     uint64_t k1 = U8TO64_LE(k + 8);
 
     /* If the hash size wasn't set, i.e. is zero */
-    ctx->hash_size = siphash_adjust_hash_size(ctx->hash_size);
+    ctx->hash_size = (int)siphash_adjust_hash_size(ctx->hash_size);
 
     if (drounds == 0)
         drounds = SIPHASH_D_ROUNDS;
@@ -161,7 +161,7 @@ void SipHash_Update(SIPHASH *ctx, const unsigned char *in, size_t inlen)
         /* not enough to fill leavings */
         if (inlen < available) {
             memcpy(&ctx->leavings[ctx->len], in, inlen);
-            ctx->len += inlen;
+            ctx->len += (unsigned int)inlen;
             return;
         }
 

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -104,11 +104,11 @@ int sm2_ciphertext_size(const EC_KEY *key, const EVP_MD *digest, size_t msg_len,
         return 0;
 
     /* Integer and string are simple type; set constructed = 0, means primitive and definite length encoding. */
-    sz = 2 * ASN1_object_size(0, field_size + 1, V_ASN1_INTEGER)
+    sz = 2 * ASN1_object_size(0, (int)(field_size + 1), V_ASN1_INTEGER)
          + ASN1_object_size(0, md_size, V_ASN1_OCTET_STRING)
-         + ASN1_object_size(0, msg_len, V_ASN1_OCTET_STRING);
+         + ASN1_object_size(0, (int)msg_len, V_ASN1_OCTET_STRING);
     /* Sequence is structured type; set constructed = 1, means constructed and definite length encoding. */
-    *ct_size = ASN1_object_size(1, sz, V_ASN1_SEQUENCE);
+    *ct_size = ASN1_object_size(1, (int)sz, V_ASN1_SEQUENCE);
 
     return 1;
 }
@@ -177,8 +177,8 @@ int sm2_encrypt(const EC_KEY *key,
         goto done;
     }
 
-    x2y2 = OPENSSL_zalloc(2 * field_size);
-    C3 = OPENSSL_zalloc(C3_size);
+    x2y2 = (uint8_t *)OPENSSL_zalloc(2 * field_size);
+    C3 = (uint8_t *)OPENSSL_zalloc(C3_size);
 
     if (x2y2 == NULL || C3 == NULL) {
         SM2err(SM2_F_SM2_ENCRYPT, ERR_R_MALLOC_FAILURE);
@@ -200,13 +200,13 @@ int sm2_encrypt(const EC_KEY *key,
         goto done;
     }
 
-    if (BN_bn2binpad(x2, x2y2, field_size) < 0
-            || BN_bn2binpad(y2, x2y2 + field_size, field_size) < 0) {
+    if (BN_bn2binpad(x2, x2y2, (int)field_size) < 0
+            || BN_bn2binpad(y2, x2y2 + field_size, (int)field_size) < 0) {
         SM2err(SM2_F_SM2_ENCRYPT, ERR_R_INTERNAL_ERROR);
         goto done;
     }
 
-    msg_mask = OPENSSL_zalloc(msg_len);
+    msg_mask = (uint8_t *)OPENSSL_zalloc(msg_len);
     if (msg_mask == NULL) {
        SM2err(SM2_F_SM2_ENCRYPT, ERR_R_MALLOC_FAILURE);
        goto done;
@@ -246,7 +246,7 @@ int sm2_encrypt(const EC_KEY *key,
        goto done;
     }
     if (!ASN1_OCTET_STRING_set(ctext_struct.C3, C3, C3_size)
-            || !ASN1_OCTET_STRING_set(ctext_struct.C2, msg_mask, msg_len)) {
+            || !ASN1_OCTET_STRING_set(ctext_struct.C2, msg_mask, (int)msg_len)) {
         SM2err(SM2_F_SM2_ENCRYPT, ERR_R_INTERNAL_ERROR);
         goto done;
     }
@@ -305,7 +305,7 @@ int sm2_decrypt(const EC_KEY *key,
 
     memset(ptext_buf, 0xFF, *ptext_len);
 
-    sm2_ctext = d2i_SM2_Ciphertext(NULL, &ciphertext, ciphertext_len);
+    sm2_ctext = d2i_SM2_Ciphertext(NULL, &ciphertext, (long)ciphertext_len);
 
     if (sm2_ctext == NULL) {
         SM2err(SM2_F_SM2_DECRYPT, SM2_R_ASN1_ERROR);
@@ -336,9 +336,9 @@ int sm2_decrypt(const EC_KEY *key,
         goto done;
     }
 
-    msg_mask = OPENSSL_zalloc(msg_len);
-    x2y2 = OPENSSL_zalloc(2 * field_size);
-    computed_C3 = OPENSSL_zalloc(hash_size);
+    msg_mask = (uint8_t *)OPENSSL_zalloc(msg_len);
+    x2y2 = (uint8_t *)OPENSSL_zalloc(2 * field_size);
+    computed_C3 = (uint8_t *)OPENSSL_zalloc(hash_size);
 
     if (msg_mask == NULL || x2y2 == NULL || computed_C3 == NULL) {
         SM2err(SM2_F_SM2_DECRYPT, ERR_R_MALLOC_FAILURE);
@@ -360,8 +360,8 @@ int sm2_decrypt(const EC_KEY *key,
         goto done;
     }
 
-    if (BN_bn2binpad(x2, x2y2, field_size) < 0
-            || BN_bn2binpad(y2, x2y2 + field_size, field_size) < 0
+    if (BN_bn2binpad(x2, x2y2, (int)field_size) < 0
+            || BN_bn2binpad(y2, x2y2 + field_size, (int)field_size) < 0
             || !ecdh_KDF_X9_63(msg_mask, msg_len, x2y2, 2 * field_size, NULL, 0,
                                digest, libctx, propq)) {
         SM2err(SM2_F_SM2_DECRYPT, ERR_R_INTERNAL_ERROR);

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -98,7 +98,7 @@ int sm2_compute_z_digest(uint8_t *out,
     }
 
     p_bytes = BN_num_bytes(p);
-    buf = OPENSSL_zalloc(p_bytes);
+    buf = (uint8_t *)OPENSSL_zalloc(p_bytes);
     if (buf == NULL) {
         SM2err(SM2_F_SM2_COMPUTE_Z_DIGEST, ERR_R_MALLOC_FAILURE);
         goto done;
@@ -155,7 +155,7 @@ static BIGNUM *sm2_compute_msg_hash(const EVP_MD *digest,
         goto done;
     }
 
-    z = OPENSSL_zalloc(md_size);
+    z = (uint8_t *)OPENSSL_zalloc(md_size);
     if (hash == NULL || z == NULL) {
         SM2err(SM2_F_SM2_COMPUTE_MSG_HASH, ERR_R_MALLOC_FAILURE);
         goto done;

--- a/crypto/sm3/sm3.c
+++ b/crypto/sm3/sm3.c
@@ -28,7 +28,7 @@ int sm3_init(SM3_CTX *c)
 
 void sm3_block_data_order(SM3_CTX *ctx, const void *p, size_t num)
 {
-    const unsigned char *data = p;
+    const unsigned char *data = (const unsigned char *)p;
     register unsigned MD32_REG_T A, B, C, D, E, F, G, H;
 
     unsigned MD32_REG_T W00, W01, W02, W03, W04, W05, W06, W07,

--- a/crypto/sparse_array.c
+++ b/crypto/sparse_array.c
@@ -62,7 +62,7 @@ struct sparse_array_st {
 
 OPENSSL_SA *OPENSSL_SA_new(void)
 {
-    OPENSSL_SA *res = OPENSSL_zalloc(sizeof(*res));
+    OPENSSL_SA *res = (OPENSSL_SA *)OPENSSL_zalloc(sizeof(*res));
 
     return res;
 }
@@ -79,7 +79,7 @@ static void sa_doall(const OPENSSL_SA *sa, void (*node)(void **),
     nodes[0] = sa->nodes;
     while (l >= 0) {
         const int n = i[l];
-        void ** const p = nodes[l];
+        void ** const p = (void ** const)nodes[l];
 
         if (n >= SA_BLOCK_MAX) {
             if (p != NULL && node != NULL)
@@ -177,7 +177,7 @@ void *OPENSSL_SA_get(const OPENSSL_SA *sa, ossl_uintmax_t n)
 
 static ossl_inline void **alloc_node(void)
 {
-    return OPENSSL_zalloc(SA_BLOCK_MAX * sizeof(void *));
+    return (void **)OPENSSL_zalloc(SA_BLOCK_MAX * sizeof(void *));
 }
 
 int OPENSSL_SA_set(OPENSSL_SA *sa, ossl_uintmax_t posn, void *val)
@@ -208,7 +208,7 @@ int OPENSSL_SA_set(OPENSSL_SA *sa, ossl_uintmax_t posn, void *val)
         i = (posn >> (OPENSSL_SA_BLOCK_BITS * level)) & SA_BLOCK_MASK;
         if (p[i] == NULL && (p[i] = alloc_node()) == NULL)
             return 0;
-        p = p[i];
+        p = (void **)p[i];
     }
     p += posn & SA_BLOCK_MASK;
     if (val == NULL && *p != NULL)

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -45,7 +45,7 @@ OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *sk)
 {
     OPENSSL_STACK *ret;
 
-    if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL) {
+    if ((ret = (OPENSSL_STACK *)OPENSSL_malloc(sizeof(*ret))) == NULL) {
         CRYPTOerr(CRYPTO_F_OPENSSL_SK_DUP, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -60,9 +60,9 @@ OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *sk)
         return ret;
     }
     /* duplicate |sk->data| content */
-    if ((ret->data = OPENSSL_malloc(sizeof(*ret->data) * sk->num_alloc)) == NULL)
+    if ((ret->data = (const void **)OPENSSL_malloc(sizeof(*ret->data) * sk->num_alloc)) == NULL)
         goto err;
-    memcpy(ret->data, sk->data, sizeof(void *) * sk->num);
+    memcpy((void *)ret->data, (void *)sk->data, sizeof(void *) * sk->num);
     return ret;
  err:
     OPENSSL_sk_free(ret);
@@ -76,7 +76,7 @@ OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *sk,
     OPENSSL_STACK *ret;
     int i;
 
-    if ((ret = OPENSSL_malloc(sizeof(*ret))) == NULL) {
+    if ((ret = (OPENSSL_STACK *)OPENSSL_malloc(sizeof(*ret))) == NULL) {
         CRYPTOerr(CRYPTO_F_OPENSSL_SK_DEEP_COPY, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -92,7 +92,7 @@ OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *sk,
     }
 
     ret->num_alloc = sk->num > min_nodes ? sk->num : min_nodes;
-    ret->data = OPENSSL_zalloc(sizeof(*ret->data) * ret->num_alloc);
+    ret->data = (const void **)OPENSSL_zalloc(sizeof(*ret->data) * ret->num_alloc);
     if (ret->data == NULL) {
         OPENSSL_free(ret);
         return NULL;
@@ -176,7 +176,7 @@ static int sk_reserve(OPENSSL_STACK *st, int n, int exact)
          * At this point, |st->num_alloc| and |st->num| are 0;
          * so |num_alloc| value is |n| or |min_nodes| if greater than |n|.
          */
-        if ((st->data = OPENSSL_zalloc(sizeof(void *) * num_alloc)) == NULL) {
+        if ((st->data = (const void **)OPENSSL_zalloc(sizeof(void *) * num_alloc)) == NULL) {
             CRYPTOerr(CRYPTO_F_SK_RESERVE, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -194,7 +194,7 @@ static int sk_reserve(OPENSSL_STACK *st, int n, int exact)
         return 1;
     }
 
-    tmpdata = OPENSSL_realloc((void *)st->data, sizeof(void *) * num_alloc);
+    tmpdata = (const void **)OPENSSL_realloc((void *)st->data, sizeof(void *) * num_alloc);
     if (tmpdata == NULL)
         return 0;
 
@@ -205,7 +205,7 @@ static int sk_reserve(OPENSSL_STACK *st, int n, int exact)
 
 OPENSSL_STACK *OPENSSL_sk_new_reserve(OPENSSL_sk_compfunc c, int n)
 {
-    OPENSSL_STACK *st = OPENSSL_zalloc(sizeof(OPENSSL_STACK));
+    OPENSSL_STACK *st = (OPENSSL_STACK *)OPENSSL_zalloc(sizeof(OPENSSL_STACK));
 
     if (st == NULL)
         return NULL;
@@ -244,7 +244,7 @@ int OPENSSL_sk_insert(OPENSSL_STACK *st, const void *data, int loc)
     if ((loc >= st->num) || (loc < 0)) {
         st->data[st->num] = data;
     } else {
-        memmove(&st->data[loc + 1], &st->data[loc],
+        memmove((void *)&st->data[loc + 1], (void *)&st->data[loc],
                 sizeof(st->data[0]) * (st->num - loc));
         st->data[loc] = data;
     }
@@ -258,7 +258,7 @@ static ossl_inline void *internal_delete(OPENSSL_STACK *st, int loc)
     const void *ret = st->data[loc];
 
     if (loc != st->num - 1)
-         memmove(&st->data[loc], &st->data[loc + 1],
+         memmove((void *)&st->data[loc], (void *)&st->data[loc + 1],
                  sizeof(st->data[0]) * (st->num - loc - 1));
     st->num--;
 
@@ -301,7 +301,7 @@ static int internal_find(OPENSSL_STACK *st, const void *data,
 
     if (!st->sorted) {
         if (st->num > 1)
-            qsort(st->data, st->num, sizeof(void *), st->comp);
+            qsort((void *)st->data, st->num, sizeof(void *), st->comp);
         st->sorted = 1; /* empty or single-element stack is considered sorted */
     }
     if (data == NULL)
@@ -352,7 +352,7 @@ void OPENSSL_sk_zero(OPENSSL_STACK *st)
 {
     if (st == NULL || st->num == 0)
         return;
-    memset(st->data, 0, sizeof(*st->data) * st->num);
+    memset((void *)st->data, 0, sizeof(*st->data) * st->num);
     st->num = 0;
 }
 
@@ -372,7 +372,7 @@ void OPENSSL_sk_free(OPENSSL_STACK *st)
 {
     if (st == NULL)
         return;
-    OPENSSL_free(st->data);
+    OPENSSL_free((void *)st->data);
     OPENSSL_free(st);
 }
 
@@ -401,7 +401,7 @@ void OPENSSL_sk_sort(OPENSSL_STACK *st)
 {
     if (st != NULL && !st->sorted && st->comp != NULL) {
         if (st->num > 1)
-            qsort(st->data, st->num, sizeof(void *), st->comp);
+            qsort((void *)st->data, st->num, sizeof(void *), st->comp);
         st->sorted = 1; /* empty or single-element stack is considered sorted */
     }
 }

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -497,7 +497,7 @@ int OSSL_STORE_close(OSSL_STORE_CTX *ctx)
  */
 OSSL_STORE_INFO *OSSL_STORE_INFO_new(int type, void *data)
 {
-    OSSL_STORE_INFO *info = OPENSSL_zalloc(sizeof(*info));
+    OSSL_STORE_INFO *info = (OSSL_STORE_INFO *)OPENSSL_zalloc(sizeof(*info));
 
     if (info == NULL)
         return NULL;
@@ -806,7 +806,7 @@ int OSSL_STORE_supports_search(OSSL_STORE_CTX *ctx, int search_type)
 /* Search term constructors */
 OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_name(X509_NAME *name)
 {
-    OSSL_STORE_SEARCH *search = OPENSSL_zalloc(sizeof(*search));
+    OSSL_STORE_SEARCH *search = (OSSL_STORE_SEARCH *)OPENSSL_zalloc(sizeof(*search));
 
     if (search == NULL) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
@@ -821,7 +821,7 @@ OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_name(X509_NAME *name)
 OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_issuer_serial(X509_NAME *name,
                                                       const ASN1_INTEGER *serial)
 {
-    OSSL_STORE_SEARCH *search = OPENSSL_zalloc(sizeof(*search));
+    OSSL_STORE_SEARCH *search = (OSSL_STORE_SEARCH *)OPENSSL_zalloc(sizeof(*search));
 
     if (search == NULL) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
@@ -838,7 +838,7 @@ OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_key_fingerprint(const EVP_MD *digest,
                                                         const unsigned char
                                                         *bytes, size_t len)
 {
-    OSSL_STORE_SEARCH *search = OPENSSL_zalloc(sizeof(*search));
+    OSSL_STORE_SEARCH *search = (OSSL_STORE_SEARCH *)OPENSSL_zalloc(sizeof(*search));
 
     if (search == NULL) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
@@ -863,7 +863,7 @@ OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_key_fingerprint(const EVP_MD *digest,
 
 OSSL_STORE_SEARCH *OSSL_STORE_SEARCH_by_alias(const char *alias)
 {
-    OSSL_STORE_SEARCH *search = OPENSSL_zalloc(sizeof(*search));
+    OSSL_STORE_SEARCH *search = (OSSL_STORE_SEARCH *)OPENSSL_zalloc(sizeof(*search));
 
     if (search == NULL) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -214,15 +214,15 @@ int OSSL_STORE_register_loader(OSSL_STORE_LOADER *loader)
 
 const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
 {
-    OSSL_STORE_LOADER template;
+    OSSL_STORE_LOADER templateLoader;
     OSSL_STORE_LOADER *loader = NULL;
 
-    template.scheme = scheme;
-    template.open = NULL;
-    template.load = NULL;
-    template.eof = NULL;
-    template.close = NULL;
-    template.open_with_libctx = NULL;
+    templateLoader.scheme = scheme;
+    templateLoader.open = NULL;
+    templateLoader.load = NULL;
+    templateLoader.eof = NULL;
+    templateLoader.close = NULL;
+    templateLoader.open_with_libctx = NULL;
 
     if (!ossl_store_init_once())
         return NULL;
@@ -247,14 +247,14 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
 
 OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
 {
-    OSSL_STORE_LOADER template;
+    OSSL_STORE_LOADER templateLoader;
     OSSL_STORE_LOADER *loader = NULL;
 
-    template.scheme = scheme;
-    template.open = NULL;
-    template.load = NULL;
-    template.eof = NULL;
-    template.close = NULL;
+    templateLoader.scheme = scheme;
+    templateLoader.open = NULL;
+    templateLoader.load = NULL;
+    templateLoader.eof = NULL;
+    templateLoader.close = NULL;
 
     if (!RUN_ONCE(&registry_init, do_registry_init)) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
@@ -265,7 +265,7 @@ OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
     if (!ossl_store_register_init())
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_INTERNAL_ERROR);
     else if ((loader = lh_OSSL_STORE_LOADER_delete(loader_register,
-                                                   &template)) == NULL)
+                                                   &templateLoader)) == NULL)
         ERR_raise_data(ERR_LIB_OSSL_STORE, OSSL_STORE_R_UNREGISTERED_SCHEME,
                        "scheme=%s", scheme);
 

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -236,7 +236,7 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
     if (!ossl_store_register_init())
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_INTERNAL_ERROR);
     else if ((loader = lh_OSSL_STORE_LOADER_retrieve(loader_register,
-                                                     &template)) == NULL)
+                                                     &templateLoader)) == NULL)
         ERR_raise_data(ERR_LIB_OSSL_STORE, OSSL_STORE_R_UNREGISTERED_SCHEME,
                        "scheme=%s", scheme);
 

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -22,7 +22,7 @@ UI *UI_new(void)
 
 UI *UI_new_method(const UI_METHOD *method)
 {
-    UI *ret = OPENSSL_zalloc(sizeof(*ret));
+    UI *ret = (UI *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         UIerr(UI_F_UI_NEW_METHOD, ERR_R_MALLOC_FAILURE);
@@ -106,7 +106,7 @@ static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
     } else if ((type == UIT_PROMPT || type == UIT_VERIFY
                 || type == UIT_BOOLEAN) && result_buf == NULL) {
         UIerr(UI_F_GENERAL_ALLOCATE_PROMPT, UI_R_NO_RESULT_BUFFER);
-    } else if ((ret = OPENSSL_malloc(sizeof(*ret))) != NULL) {
+    } else if ((ret = (UI_STRING *)OPENSSL_malloc(sizeof(*ret))) != NULL) {
         ret->out_string = prompt;
         ret->flags = prompt_freeable ? OUT_STRING_FREEABLE : 0;
         ret->input_flags = input_flags;
@@ -369,12 +369,12 @@ char *UI_construct_prompt(UI *ui, const char *phrase_desc,
 
         if (phrase_desc == NULL)
             return NULL;
-        len = sizeof(prompt1) - 1 + strlen(phrase_desc);
+        len = (int)(sizeof(prompt1) - 1 + strlen(phrase_desc));
         if (object_name != NULL)
-            len += sizeof(prompt2) - 1 + strlen(object_name);
-        len += sizeof(prompt3) - 1;
+            len += (int)(sizeof(prompt2) - 1 + strlen(object_name));
+        len += (int)(sizeof(prompt3) - 1);
 
-        if ((prompt = OPENSSL_malloc(len + 1)) == NULL) {
+        if ((prompt = (char *)OPENSSL_malloc(len + 1)) == NULL) {
             UIerr(UI_F_UI_CONSTRUCT_PROMPT, ERR_R_MALLOC_FAILURE);
             return NULL;
         }
@@ -598,7 +598,7 @@ UI_METHOD *UI_create_method(const char *name)
 {
     UI_METHOD *ui_method = NULL;
 
-    if ((ui_method = OPENSSL_zalloc(sizeof(*ui_method))) == NULL
+    if ((ui_method = (UI_METHOD *)OPENSSL_zalloc(sizeof(*ui_method))) == NULL
         || (ui_method->name = OPENSSL_strdup(name)) == NULL
         || !CRYPTO_new_ex_data(CRYPTO_EX_INDEX_UI_METHOD, ui_method,
                                &ui_method->ex_data)) {
@@ -815,7 +815,7 @@ int UI_get_result_string_length(UI_STRING *uis)
     switch (uis->type) {
     case UIT_PROMPT:
     case UIT_VERIFY:
-        return uis->result_len;
+        return (int)uis->result_len;
     case UIT_NONE:
     case UIT_BOOLEAN:
     case UIT_INFO:
@@ -872,7 +872,7 @@ int UI_get_result_maxsize(UI_STRING *uis)
 
 int UI_set_result(UI *ui, UI_STRING *uis, const char *result)
 {
-    return UI_set_result_ex(ui, uis, result, strlen(result));
+    return UI_set_result_ex(ui, uis, result, (int)strlen(result));
 }
 
 int UI_set_result_ex(UI *ui, UI_STRING *uis, const char *result, int len)

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -105,7 +105,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
     case UIT_PROMPT:
         {
             char result[PEM_BUFSIZE + 1];
-            const struct pem_password_cb_data *data =
+            const struct pem_password_cb_data *data = (const struct pem_password_cb_data *)
                 UI_method_get_ex_data(UI_get_method(ui), ui_method_data_index);
             int maxsize = UI_get_result_maxsize(uis);
             int len = data->cb(result,
@@ -143,7 +143,7 @@ UI_METHOD *UI_UTIL_wrap_read_pem_callback(pem_password_cb *cb, int rwflag)
     struct pem_password_cb_data *data = NULL;
     UI_METHOD *ui_method = NULL;
 
-    if ((data = OPENSSL_zalloc(sizeof(*data))) == NULL
+    if ((data = (struct pem_password_cb_data *)OPENSSL_zalloc(sizeof(*data))) == NULL
         || (ui_method = UI_create_method("PEM password callback wrapper")) == NULL
         || UI_method_set_opener(ui_method, ui_open) < 0
         || UI_method_set_reader(ui_method, ui_read) < 0

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -76,7 +76,7 @@ int WHIRLPOOL_Update(WHIRLPOOL_CTX *c, const void *_inp, size_t bytes)
      * to care about excessive calls to WHIRLPOOL_BitUpdate...
      */
     size_t chunk = ((size_t)1) << (sizeof(size_t) * 8 - 4);
-    const unsigned char *inp = _inp;
+    const unsigned char *inp = (const unsigned char *)_inp;
 
     while (bytes >= chunk) {
         WHIRLPOOL_BitUpdate(c, inp, chunk * 8);
@@ -94,7 +94,7 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
     size_t n;
     unsigned int bitoff = c->bitoff,
         bitrem = bitoff % 8, inpgap = (8 - (unsigned int)bits % 8) & 7;
-    const unsigned char *inp = _inp;
+    const unsigned char *inp = (const unsigned char *)_inp;
 
     /*
      * This 256-bit increment procedure relies on the size_t being natural

--- a/crypto/x509/pcy_cache.c
+++ b/crypto/x509/pcy_cache.c
@@ -89,7 +89,7 @@ static int policy_cache_new(X509 *x)
 
     if (x->policy_cache != NULL)
         return 1;
-    cache = OPENSSL_malloc(sizeof(*cache));
+    cache = (X509_POLICY_CACHE *)OPENSSL_malloc(sizeof(*cache));
     if (cache == NULL) {
         X509V3err(X509V3_F_POLICY_CACHE_NEW, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -106,7 +106,7 @@ static int policy_cache_new(X509 *x)
      * Handle requireExplicitPolicy *first*. Need to process this even if we
      * don't have any policies.
      */
-    ext_pcons = X509_get_ext_d2i(x, NID_policy_constraints, &i, NULL);
+    ext_pcons = (POLICY_CONSTRAINTS *)X509_get_ext_d2i(x, NID_policy_constraints, &i, NULL);
 
     if (!ext_pcons) {
         if (i != -1)
@@ -125,7 +125,7 @@ static int policy_cache_new(X509 *x)
 
     /* Process CertificatePolicies */
 
-    ext_cpols = X509_get_ext_d2i(x, NID_certificate_policies, &i, NULL);
+    ext_cpols = (CERTIFICATEPOLICIES *)X509_get_ext_d2i(x, NID_certificate_policies, &i, NULL);
     /*
      * If no CertificatePolicies extension or problem decoding then there is
      * no point continuing because the valid policies will be NULL.
@@ -144,7 +144,7 @@ static int policy_cache_new(X509 *x)
     if (i <= 0)
         return i;
 
-    ext_pmaps = X509_get_ext_d2i(x, NID_policy_mappings, &i, NULL);
+    ext_pmaps = (POLICY_MAPPINGS *)X509_get_ext_d2i(x, NID_policy_mappings, &i, NULL);
 
     if (!ext_pmaps) {
         /* If not absent some problem with extension */
@@ -156,7 +156,7 @@ static int policy_cache_new(X509 *x)
             goto bad_cache;
     }
 
-    ext_any = X509_get_ext_d2i(x, NID_inhibit_any_policy, &i, NULL);
+    ext_any = (ASN1_INTEGER *)X509_get_ext_d2i(x, NID_inhibit_any_policy, &i, NULL);
 
     if (!ext_any) {
         if (i != -1)

--- a/crypto/x509/pcy_data.c
+++ b/crypto/x509/pcy_data.c
@@ -49,7 +49,7 @@ X509_POLICY_DATA *policy_data_new(POLICYINFO *policy,
             return NULL;
     } else
         id = NULL;
-    ret = OPENSSL_zalloc(sizeof(*ret));
+    ret = (X509_POLICY_DATA *)OPENSSL_zalloc(sizeof(*ret));
     if (ret == NULL) {
         ASN1_OBJECT_free(id);
         X509V3err(X509V3_F_POLICY_DATA_NEW, ERR_R_MALLOC_FAILURE);

--- a/crypto/x509/pcy_node.c
+++ b/crypto/x509/pcy_node.c
@@ -63,7 +63,7 @@ X509_POLICY_NODE *level_add_node(X509_POLICY_LEVEL *level,
 {
     X509_POLICY_NODE *node;
 
-    node = OPENSSL_zalloc(sizeof(*node));
+    node = (X509_POLICY_NODE *)OPENSSL_zalloc(sizeof(*node));
     if (node == NULL) {
         X509V3err(X509V3_F_LEVEL_ADD_NODE, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -158,7 +158,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
         return ret;
 
     /* If we get this far initialize the tree */
-    if ((tree = OPENSSL_zalloc(sizeof(*tree))) == NULL) {
+    if ((tree = (X509_POLICY_TREE *)OPENSSL_zalloc(sizeof(*tree))) == NULL) {
         X509V3err(X509V3_F_TREE_INIT, ERR_R_MALLOC_FAILURE);
         return X509_PCY_TREE_INTERNAL;
     }
@@ -170,7 +170,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
      * policies of anyPolicy.  (RFC 5280 has the TA at depth 0 and the leaf at
      * depth n, we have the leaf at depth 0 and the TA at depth n).
      */
-    if ((tree->levels = OPENSSL_zalloc(sizeof(*tree->levels)*(n+1))) == NULL) {
+    if ((tree->levels = (X509_POLICY_LEVEL *)OPENSSL_zalloc(sizeof(*tree->levels)*(n+1))) == NULL) {
         OPENSSL_free(tree);
         X509V3err(X509V3_F_TREE_INIT, ERR_R_MALLOC_FAILURE);
         return X509_PCY_TREE_INTERNAL;

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -236,7 +236,7 @@ int X509_ocspid_print(BIO *bp, X509 *x)
         goto err;
     subj = X509_get_subject_name(x);
     derlen = i2d_X509_NAME(subj, NULL);
-    if ((der = dertmp = OPENSSL_malloc(derlen)) == NULL)
+    if ((der = dertmp = (unsigned char *)OPENSSL_malloc(derlen)) == NULL)
         goto err;
     i2d_X509_NAME(subj, &dertmp);
 
@@ -394,18 +394,18 @@ int x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags)
     if (cert == NULL)
         return BIO_printf(bio, "    (no certificate)\n") > 0;
     if (BIO_printf(bio, "    certificate\n") <= 0
-            || !X509_print_ex(bio, cert, flags, ~X509_FLAG_NO_SUBJECT))
+            || !X509_print_ex(bio, cert, flags, (unsigned long)~X509_FLAG_NO_SUBJECT))
         return 0;
     if (X509_check_issued((X509 *)cert, cert) == X509_V_OK) {
         if (BIO_printf(bio, "        self-issued\n") <= 0)
             return 0;
     } else {
         if (BIO_printf(bio, " ") <= 0
-            || !X509_print_ex(bio, cert, flags, ~X509_FLAG_NO_ISSUER))
+            || !X509_print_ex(bio, cert, flags, (unsigned long)~X509_FLAG_NO_ISSUER))
             return 0;
     }
     if (!X509_print_ex(bio, cert, flags,
-                       ~(X509_FLAG_NO_SERIAL | X509_FLAG_NO_VALIDITY)))
+                        (unsigned long)~(X509_FLAG_NO_SERIAL | X509_FLAG_NO_VALIDITY)))
         return 0;
     if (X509_cmp_current_time(X509_get0_notBefore(cert)) > 0)
         if (BIO_printf(bio, "        not yet valid\n") <= 0)

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -200,7 +200,7 @@ static int i2r_IPAddressOrRanges(BIO *out,
 static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *method,
                             void *ext, BIO *out, int indent)
 {
-    const IPAddrBlocks *addr = ext;
+    const IPAddrBlocks *addr = (const IPAddrBlocks *)ext;
     int i;
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);
@@ -974,8 +974,8 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
             continue;
         }
 
-        i1 = strspn(s, addr_chars);
-        i2 = i1 + strspn(s + i1, " \t");
+        i1 = (int)strspn(s, addr_chars);
+        i2 = (int)(i1 + strspn(s + i1, " \t"));
         delim = s[i2++];
         s[i1] = '\0';
 
@@ -1000,8 +1000,8 @@ static void *v2i_IPAddrBlocks(const struct v3_ext_method *method,
             }
             break;
         case '-':
-            i1 = i2 + strspn(s + i2, " \t");
-            i2 = i1 + strspn(s + i1, addr_chars);
+            i1 = (int)(i2 + strspn(s + i2, " \t"));
+            i2 = (int)(i1 + strspn(s + i1, addr_chars));
             if (i1 == i2 || s[i2] != '\0') {
                 X509V3err(X509V3_F_V2I_IPADDRBLOCKS,
                           X509V3_R_EXTENSION_VALUE_ERROR);

--- a/crypto/x509/v3_akey.c
+++ b/crypto/x509/v3_akey.c
@@ -119,7 +119,7 @@ static AUTHORITY_KEYID *v2i_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     if (keyid) {
         i = X509_get_ext_by_NID(cert, NID_subject_key_identifier, -1);
         if ((i >= 0) && (ext = X509_get_ext(cert, i)))
-            ikeyid = X509V3_EXT_d2i(ext);
+            ikeyid = (ASN1_OCTET_STRING *)X509V3_EXT_d2i(ext);
         if (keyid == 2 && !ikeyid) {
             X509V3err(X509V3_F_V2I_AUTHORITY_KEYID,
                       X509V3_R_UNABLE_TO_GET_ISSUER_KEYID);

--- a/crypto/x509/v3_alt.c
+++ b/crypto/x509/v3_alt.c
@@ -335,7 +335,7 @@ static int copy_issuer(X509V3_CTX *ctx, GENERAL_NAMES *gens)
     if (i < 0)
         return 1;
     if ((ext = X509_get_ext(ctx->issuer_cert, i)) == NULL
-        || (ialt = X509V3_EXT_d2i(ext)) == NULL) {
+        || (ialt = (GENERAL_NAMES *)X509V3_EXT_d2i(ext)) == NULL) {
         X509V3err(X509V3_F_COPY_ISSUER, X509V3_R_ISSUER_DECODE_ERROR);
         goto err;
     }
@@ -565,7 +565,7 @@ GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
     if (is_string) {
         if ((gen->d.ia5 = ASN1_IA5STRING_new()) == NULL ||
             !ASN1_STRING_set(gen->d.ia5, (unsigned char *)value,
-                             strlen(value))) {
+                             (int)strlen(value))) {
             X509V3err(X509V3_F_A2I_GENERAL_NAME, ERR_R_MALLOC_FAILURE);
             goto err;
         }
@@ -637,7 +637,7 @@ static int do_othername(GENERAL_NAME *gen, const char *value, X509V3_CTX *ctx)
     ASN1_TYPE_free(gen->d.otherName->value);
     if ((gen->d.otherName->value = ASN1_generate_v3(p + 1, ctx)) == NULL)
         return 0;
-    objlen = p - value;
+    objlen = (int)(p - value);
     objtmp = OPENSSL_strndup(value, objlen);
     if (objtmp == NULL)
         return 0;

--- a/crypto/x509/v3_asid.c
+++ b/crypto/x509/v3_asid.c
@@ -110,7 +110,7 @@ static int i2r_ASIdentifierChoice(BIO *out,
 static int i2r_ASIdentifiers(const X509V3_EXT_METHOD *method,
                              void *ext, BIO *out, int indent)
 {
-    ASIdentifiers *asid = ext;
+    ASIdentifiers *asid = (ASIdentifiers *)ext;
     return (i2r_ASIdentifierChoice(out, asid->asnum, indent,
                                    "Autonomous System Numbers") &&
             i2r_ASIdentifierChoice(out, asid->rdi, indent,
@@ -446,7 +446,7 @@ static int ASIdentifierChoice_canonize(ASIdentifierChoice *choice)
             ASRange *r;
             switch (a->type) {
             case ASIdOrRange_id:
-                if ((r = OPENSSL_malloc(sizeof(*r))) == NULL) {
+                if ((r = (ASRange *)OPENSSL_malloc(sizeof(*r))) == NULL) {
                     X509V3err(X509V3_F_ASIDENTIFIERCHOICE_CANONIZE,
                               ERR_R_MALLOC_FAILURE);
                     goto done;
@@ -561,12 +561,12 @@ static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
         /*
          * Number, range, or mistake, pick it apart and figure out which.
          */
-        i1 = strspn(val->value, "0123456789");
+        i1 = (int)strspn(val->value, "0123456789");
         if (val->value[i1] == '\0') {
             is_range = 0;
         } else {
             is_range = 1;
-            i2 = i1 + strspn(val->value + i1, " \t");
+            i2 = (int)(i1 + strspn(val->value + i1, " \t"));
             if (val->value[i2] != '-') {
                 X509V3err(X509V3_F_V2I_ASIDENTIFIERS,
                           X509V3_R_INVALID_ASNUMBER);
@@ -574,8 +574,8 @@ static void *v2i_ASIdentifiers(const struct v3_ext_method *method,
                 goto err;
             }
             i2++;
-            i2 = i2 + strspn(val->value + i2, " \t");
-            i3 = i2 + strspn(val->value + i2, "0123456789");
+            i2 = (int)(i2 + strspn(val->value + i2, " \t"));
+            i3 = (int)(i2 + strspn(val->value + i2, "0123456789"));
             if (val->value[i3] != '\0') {
                 X509V3err(X509V3_F_V2I_ASIDENTIFIERS,
                           X509V3_R_INVALID_ASRANGE);

--- a/crypto/x509/v3_bitst.c
+++ b/crypto/x509/v3_bitst.c
@@ -48,7 +48,7 @@ STACK_OF(CONF_VALUE) *i2v_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
                                           STACK_OF(CONF_VALUE) *ret)
 {
     BIT_STRING_BITNAME *bnam;
-    for (bnam = method->usr_data; bnam->lname; bnam++) {
+    for (bnam = (BIT_STRING_BITNAME *)method->usr_data; bnam->lname; bnam++) {
         if (ASN1_BIT_STRING_get_bit(bits, bnam->bitnum))
             X509V3_add_value(bnam->lname, NULL, &ret);
     }
@@ -69,7 +69,7 @@ ASN1_BIT_STRING *v2i_ASN1_BIT_STRING(X509V3_EXT_METHOD *method,
     }
     for (i = 0; i < sk_CONF_VALUE_num(nval); i++) {
         val = sk_CONF_VALUE_value(nval, i);
-        for (bnam = method->usr_data; bnam->lname; bnam++) {
+        for (bnam = (BIT_STRING_BITNAME *)method->usr_data; bnam->lname; bnam++) {
             if (strcmp(bnam->sname, val->name) == 0
                 || strcmp(bnam->lname, val->name) == 0) {
                 if (!ASN1_BIT_STRING_set_bit(bs, bnam->bitnum, 1)) {

--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -130,7 +130,7 @@ static X509_EXTENSION *do_ext_nconf(CONF *conf, X509V3_CTX *ctx, int ext_nid,
 
     ext = do_ext_i2d(method, ext_nid, crit, ext_struc);
     if (method->it)
-        ASN1_item_free(ext_struc, ASN1_ITEM_ptr(method->it));
+        ASN1_item_free((ASN1_VALUE *)ext_struc, ASN1_ITEM_ptr(method->it));
     else
         method->ext_free(ext_struc);
     return ext;
@@ -149,14 +149,14 @@ static X509_EXTENSION *do_ext_i2d(const X509V3_EXT_METHOD *method,
     if (method->it) {
         ext_der = NULL;
         ext_len =
-            ASN1_item_i2d(ext_struc, &ext_der, ASN1_ITEM_ptr(method->it));
+            ASN1_item_i2d((const ASN1_VALUE *)ext_struc, &ext_der, ASN1_ITEM_ptr(method->it));
         if (ext_len < 0)
             goto merr;
     } else {
         unsigned char *p;
 
         ext_len = method->i2d(ext_struc, NULL);
-        if ((ext_der = OPENSSL_malloc(ext_len)) == NULL)
+        if ((ext_der = (unsigned char *)OPENSSL_malloc(ext_len)) == NULL)
             goto merr;
         p = ext_der;
         method->i2d(ext_struc, &p);
@@ -425,12 +425,12 @@ void X509V3_section_free(X509V3_CTX *ctx, STACK_OF(CONF_VALUE) *section)
 
 static char *nconf_get_string(void *db, const char *section, const char *value)
 {
-    return NCONF_get_string(db, section, value);
+    return NCONF_get_string((const CONF *)db, section, value);
 }
 
 static STACK_OF(CONF_VALUE) *nconf_get_section(void *db, const char *section)
 {
-    return NCONF_get_section(db, section);
+    return NCONF_get_section((const CONF *)db, section);
 }
 
 static X509V3_CONF_METHOD nconf_method = {
@@ -477,12 +477,12 @@ X509_EXTENSION *X509V3_EXT_conf_nid(LHASH_OF(CONF_VALUE) *conf,
 
 static char *conf_lhash_get_string(void *db, const char *section, const char *value)
 {
-    return CONF_get_string(db, section, value);
+    return CONF_get_string((LHASH_OF(CONF_VALUE) *)db, section, value);
 }
 
 static STACK_OF(CONF_VALUE) *conf_lhash_get_section(void *db, const char *section)
 {
-    return CONF_get_section(db, section);
+    return CONF_get_section((LHASH_OF(CONF_VALUE) *)db, section);
 }
 
 static X509V3_CONF_METHOD conf_lhash_method = {

--- a/crypto/x509/v3_cpols.c
+++ b/crypto/x509/v3_cpols.c
@@ -201,7 +201,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
             if ((qual->d.cpsuri = ASN1_IA5STRING_new()) == NULL)
                 goto merr;
             if (!ASN1_STRING_set(qual->d.cpsuri, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (!v3_name_cmp(cnf->name, "userNotice")) {
             STACK_OF(CONF_VALUE) *unot;
@@ -251,7 +251,7 @@ static int displaytext_get_tag_len(const char *tagstr)
 {
     char *colon = strchr(tagstr, ':');
 
-    return (colon == NULL) ? -1 : colon - tagstr;
+    return (colon == NULL) ? -1 : (int)(colon - tagstr);
 }
 
 static int displaytext_str2tag(const char *tagstr, unsigned int *tag_len)
@@ -309,7 +309,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
                 goto merr;
             if (tag_len != 0)
                 value += tag_len + 1;
-            len = strlen(value);
+            len = (int)strlen(value);
             if (!ASN1_STRING_set(not->exptext, value, len))
                 goto merr;
         } else if (strcmp(cnf->name, "organization") == 0) {
@@ -326,7 +326,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
             else
                 nref->organization->type = V_ASN1_VISIBLESTRING;
             if (!ASN1_STRING_set(nref->organization, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (strcmp(cnf->name, "noticeNumbers") == 0) {
             NOTICEREF *nref;

--- a/crypto/x509/v3_crld.c
+++ b/crypto/x509/v3_crld.c
@@ -437,7 +437,7 @@ static int print_distpoint(BIO *out, DIST_POINT_NAME *dpn, int indent)
 static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
                    int indent)
 {
-    ISSUING_DIST_POINT *idp = pidp;
+    ISSUING_DIST_POINT *idp = (ISSUING_DIST_POINT *)pidp;
     if (idp->distpoint)
         print_distpoint(out, idp->distpoint, indent);
     if (idp->onlyuser > 0)
@@ -461,7 +461,7 @@ static int i2r_idp(const X509V3_EXT_METHOD *method, void *pidp, BIO *out,
 static int i2r_crldp(const X509V3_EXT_METHOD *method, void *pcrldp, BIO *out,
                      int indent)
 {
-    STACK_OF(DIST_POINT) *crld = pcrldp;
+    STACK_OF(DIST_POINT) *crld = (STACK_OF(DIST_POINT) *)pcrldp;
     DIST_POINT *point;
     int i;
     for (i = 0; i < sk_DIST_POINT_num(crld); i++) {

--- a/crypto/x509/v3_enum.c
+++ b/crypto/x509/v3_enum.c
@@ -45,7 +45,7 @@ char *i2s_ASN1_ENUMERATED_TABLE(X509V3_EXT_METHOD *method,
     long strval;
 
     strval = ASN1_ENUMERATED_get(e);
-    for (enam = method->usr_data; enam->lname; enam++) {
+    for (enam = (ENUMERATED_NAMES *)method->usr_data; enam->lname; enam++) {
         if (strval == enam->bitnum)
             return OPENSSL_strdup(enam->lname);
     }

--- a/crypto/x509/v3_extku.c
+++ b/crypto/x509/v3_extku.c
@@ -54,7 +54,7 @@ static STACK_OF(CONF_VALUE) *i2v_EXTENDED_KEY_USAGE(const X509V3_EXT_METHOD
                                                     *method, void *a, STACK_OF(CONF_VALUE)
                                                     *ext_list)
 {
-    EXTENDED_KEY_USAGE *eku = a;
+    EXTENDED_KEY_USAGE *eku = (EXTENDED_KEY_USAGE *)a;
     int i;
     ASN1_OBJECT *obj;
     char obj_tmp[80];

--- a/crypto/x509/v3_genn.c
+++ b/crypto/x509/v3_genn.c
@@ -115,29 +115,29 @@ void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type, void *value)
     switch (type) {
     case GEN_X400:
     case GEN_EDIPARTY:
-        a->d.other = value;
+        a->d.other = (ASN1_TYPE *)value;
         break;
 
     case GEN_OTHERNAME:
-        a->d.otherName = value;
+        a->d.otherName = (OTHERNAME *)value;
         break;
 
     case GEN_EMAIL:
     case GEN_DNS:
     case GEN_URI:
-        a->d.ia5 = value;
+        a->d.ia5 = (ASN1_IA5STRING *)value;
         break;
 
     case GEN_DIRNAME:
-        a->d.dirn = value;
+        a->d.dirn = (X509_NAME *)value;
         break;
 
     case GEN_IPADD:
-        a->d.ip = value;
+        a->d.ip = (ASN1_OCTET_STRING *)value;
         break;
 
     case GEN_RID:
-        a->d.rid = value;
+        a->d.rid = (ASN1_OBJECT *)value;
         break;
     }
     a->type = type;

--- a/crypto/x509/v3_ia5.c
+++ b/crypto/x509/v3_ia5.c
@@ -31,7 +31,7 @@ char *i2s_ASN1_IA5STRING(X509V3_EXT_METHOD *method, ASN1_IA5STRING *ia5)
 
     if (ia5 == NULL || ia5->length == 0)
         return NULL;
-    if ((tmp = OPENSSL_malloc(ia5->length + 1)) == NULL) {
+    if ((tmp = (char *)OPENSSL_malloc(ia5->length + 1)) == NULL) {
         X509V3err(X509V3_F_I2S_ASN1_IA5STRING, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -51,7 +51,7 @@ ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
     }
     if ((ia5 = ASN1_IA5STRING_new()) == NULL)
         goto err;
-    if (!ASN1_STRING_set((ASN1_STRING *)ia5, str, strlen(str))) {
+    if (!ASN1_STRING_set((ASN1_STRING *)ia5, str, (int)strlen(str))) {
         ASN1_IA5STRING_free(ia5);
         return NULL;
     }

--- a/crypto/x509/v3_info.c
+++ b/crypto/x509/v3_info.c
@@ -78,8 +78,8 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
         tret = tmp;
         vtmp = sk_CONF_VALUE_value(tret, i);
         i2t_ASN1_OBJECT(objtmp, sizeof(objtmp), desc->method);
-        nlen = strlen(objtmp) + 3 + strlen(vtmp->name) + 1;
-        ntmp = OPENSSL_malloc(nlen);
+        nlen = (int)(strlen(objtmp) + 3 + strlen(vtmp->name) + 1);
+        ntmp = (char *)OPENSSL_malloc(nlen);
         if (ntmp == NULL)
             goto err;
         BIO_snprintf(ntmp, nlen, "%s - %s", objtmp, vtmp->name);
@@ -128,7 +128,7 @@ static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
                       X509V3_R_INVALID_SYNTAX);
             goto err;
         }
-        objlen = ptmp - cnf->name;
+        objlen = (int)(ptmp - cnf->name);
         ctmp.name = ptmp + 1;
         ctmp.value = cnf->value;
         if (!v2i_GENERAL_NAME_ex(acc->location, method, ctx, &ctmp, 0))

--- a/crypto/x509/v3_ist.c
+++ b/crypto/x509/v3_ist.c
@@ -55,7 +55,7 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
                 ISSUER_SIGN_TOOL_free(ist);
                 return NULL;
             }
-            ASN1_STRING_set(ist->signTool, cnf->value, strlen(cnf->value));
+            ASN1_STRING_set(ist->signTool, cnf->value, (int)strlen(cnf->value));
         } else if (strcmp(cnf->name, "cATool") == 0) {
             ist->cATool = ASN1_UTF8STRING_new();
             if (ist->cATool == NULL) {
@@ -63,7 +63,7 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
                 ISSUER_SIGN_TOOL_free(ist);
                 return NULL;
             }
-            ASN1_STRING_set(ist->cATool, cnf->value, strlen(cnf->value));
+            ASN1_STRING_set(ist->cATool, cnf->value, (int)strlen(cnf->value));
         } else if (strcmp(cnf->name, "signToolCert") == 0) {
             ist->signToolCert = ASN1_UTF8STRING_new();
             if (ist->signToolCert == NULL) {
@@ -71,7 +71,7 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
                 ISSUER_SIGN_TOOL_free(ist);
                 return NULL;
             }
-            ASN1_STRING_set(ist->signToolCert, cnf->value, strlen(cnf->value));
+            ASN1_STRING_set(ist->signToolCert, cnf->value, (int)strlen(cnf->value));
         } else if (strcmp(cnf->name, "cAToolCert") == 0) {
             ist->cAToolCert = ASN1_UTF8STRING_new();
             if (ist->cAToolCert == NULL) {
@@ -79,7 +79,7 @@ static ISSUER_SIGN_TOOL *v2i_issuer_sign_tool(X509V3_EXT_METHOD *method, X509V3_
                 ISSUER_SIGN_TOOL_free(ist);
                 return NULL;
             }
-            ASN1_STRING_set(ist->cAToolCert, cnf->value, strlen(cnf->value));
+            ASN1_STRING_set(ist->cAToolCert, cnf->value, (int)strlen(cnf->value));
         } else {
             X509V3err(X509V3_F_V2I_ISSUER_SIGN_TOOL, ERR_R_PASSED_INVALID_ARGUMENT);
             ISSUER_SIGN_TOOL_free(ist);

--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -92,7 +92,7 @@ int X509V3_EXT_add_alias(int nid_to, int nid_from)
         X509V3err(X509V3_F_X509V3_EXT_ADD_ALIAS, X509V3_R_EXTENSION_NOT_FOUND);
         return 0;
     }
-    if ((tmpext = OPENSSL_malloc(sizeof(*tmpext))) == NULL) {
+    if ((tmpext = (X509V3_EXT_METHOD *)OPENSSL_malloc(sizeof(*tmpext))) == NULL) {
         X509V3err(X509V3_F_X509V3_EXT_ADD_ALIAS, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -157,7 +157,7 @@ static void *v2i_NAME_CONSTRAINTS(const X509V3_EXT_METHOD *method,
 static int i2r_NAME_CONSTRAINTS(const X509V3_EXT_METHOD *method, void *a,
                                 BIO *bp, int ind)
 {
-    NAME_CONSTRAINTS *ncons = a;
+    NAME_CONSTRAINTS *ncons = (NAME_CONSTRAINTS *)a;
     do_i2r_name_constraints(method, ncons->permittedSubtrees,
                             bp, ind, "Permitted");
     if (ncons->permittedSubtrees && ncons->excludedSubtrees)
@@ -422,7 +422,7 @@ int NAME_CONSTRAINTS_check_CN(X509 *x, NAME_CONSTRAINTS *nc)
         if (idlen == 0)
             continue;
 
-        stmp.length = idlen;
+        stmp.length = (int)idlen;
         stmp.data = idval;
         r = nc_match(&gntmp, nc);
         OPENSSL_free(idval);
@@ -699,9 +699,9 @@ static int nc_uri(ASN1_IA5STRING *uri, ASN1_IA5STRING *base)
         p = strchr(hostptr, '/');
 
     if (p == NULL)
-        hostlen = strlen(hostptr);
+        hostlen = (int)strlen(hostptr);
     else
-        hostlen = p - hostptr;
+        hostlen = (int)(p - hostptr);
 
     if (hostlen == 0)
         return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;

--- a/crypto/x509/v3_pci.c
+++ b/crypto/x509/v3_pci.c
@@ -135,8 +135,8 @@ static int process_pci_value(CONF_VALUE *val,
                 goto err;
             }
 
-            tmp_data = OPENSSL_realloc((*policy)->data,
-                                       (*policy)->length + val_len + 1);
+            tmp_data = (unsigned char *)OPENSSL_realloc((*policy)->data,
+                                                        (*policy)->length + val_len + 1);
             if (tmp_data) {
                 (*policy)->data = tmp_data;
                 memcpy(&(*policy)->data[(*policy)->length],
@@ -171,8 +171,8 @@ static int process_pci_value(CONF_VALUE *val,
                 if (!n)
                     continue;
 
-                tmp_data = OPENSSL_realloc((*policy)->data,
-                                           (*policy)->length + n + 1);
+                tmp_data = (unsigned char *)OPENSSL_realloc((*policy)->data,
+                                                            (*policy)->length + n + 1);
 
                 if (!tmp_data) {
                     OPENSSL_free((*policy)->data);
@@ -198,9 +198,9 @@ static int process_pci_value(CONF_VALUE *val,
                 goto err;
             }
         } else if (strncmp(val->value, "text:", 5) == 0) {
-            val_len = strlen(val->value + 5);
-            tmp_data = OPENSSL_realloc((*policy)->data,
-                                       (*policy)->length + val_len + 1);
+            val_len = (int)strlen(val->value + 5);
+            tmp_data = (unsigned char *)OPENSSL_realloc((*policy)->data,
+                                                        (*policy)->length + val_len + 1);
             if (tmp_data) {
                 (*policy)->data = tmp_data;
                 memcpy(&(*policy)->data[(*policy)->length],

--- a/crypto/x509/v3_pcons.c
+++ b/crypto/x509/v3_pcons.c
@@ -44,7 +44,7 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_CONSTRAINTS(const X509V3_EXT_METHOD
                                                     *method, void *a, STACK_OF(CONF_VALUE)
                                                     *extlist)
 {
-    POLICY_CONSTRAINTS *pcons = a;
+    POLICY_CONSTRAINTS *pcons = (POLICY_CONSTRAINTS *)a;
     X509V3_add_value_int("Require Explicit Policy",
                          pcons->requireExplicitPolicy, &extlist);
     X509V3_add_value_int("Inhibit Policy Mapping",

--- a/crypto/x509/v3_pmaps.c
+++ b/crypto/x509/v3_pmaps.c
@@ -47,7 +47,7 @@ static STACK_OF(CONF_VALUE) *i2v_POLICY_MAPPINGS(const X509V3_EXT_METHOD
                                                  *method, void *a, STACK_OF(CONF_VALUE)
                                                  *ext_list)
 {
-    POLICY_MAPPINGS *pmaps = a;
+    POLICY_MAPPINGS *pmaps = (POLICY_MAPPINGS *)a;
     POLICY_MAPPING *pmap;
     int i;
     char obj_tmp1[80];

--- a/crypto/x509/v3_prn.c
+++ b/crypto/x509/v3_prn.c
@@ -130,7 +130,7 @@ int X509V3_EXT_print(BIO *out, X509_EXTENSION *ext, unsigned long flag,
     sk_CONF_VALUE_pop_free(nval, X509V3_conf_free);
     OPENSSL_free(value);
     if (method->it)
-        ASN1_item_free(ext_str, ASN1_ITEM_ptr(method->it));
+        ASN1_item_free((ASN1_VALUE *)ext_str, ASN1_ITEM_ptr(method->it));
     else
         method->ext_free(ext_str);
     return ok;

--- a/crypto/x509/v3_sxnet.c
+++ b/crypto/x509/v3_sxnet.c
@@ -146,7 +146,7 @@ int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *zone, const char *user,
         return 0;
     }
     if (userlen == -1)
-        userlen = strlen(user);
+        userlen = (int)strlen(user);
     if (userlen > 64) {
         X509V3err(X509V3_F_SXNET_ADD_ID_INTEGER, X509V3_R_USER_TOO_LONG);
         return 0;
@@ -167,7 +167,7 @@ int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *zone, const char *user,
     if ((id = SXNETID_new()) == NULL)
         goto err;
     if (userlen == -1)
-        userlen = strlen(user);
+        userlen = (int)strlen(user);
 
     if (!ASN1_OCTET_STRING_set(id->user, (const unsigned char *)user, userlen))
         goto err;

--- a/crypto/x509/v3_utf8.c
+++ b/crypto/x509/v3_utf8.c
@@ -36,7 +36,7 @@ char *i2s_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
         X509V3err(X509V3_F_I2S_ASN1_UTF8STRING, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    if ((tmp = OPENSSL_malloc(utf8->length + 1)) == NULL) {
+    if ((tmp = (char *)OPENSSL_malloc(utf8->length + 1)) == NULL) {
         X509V3err(X509V3_F_I2S_ASN1_UTF8STRING, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -57,7 +57,7 @@ ASN1_UTF8STRING *s2i_ASN1_UTF8STRING(X509V3_EXT_METHOD *method,
         X509V3err(X509V3_F_S2I_ASN1_UTF8STRING, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    if (!ASN1_STRING_set((ASN1_STRING *)utf8, str, strlen(str))) {
+    if (!ASN1_STRING_set((ASN1_STRING *)utf8, str, (int)strlen(str))) {
         X509V3err(X509V3_F_S2I_ASN1_UTF8STRING, ERR_R_MALLOC_FAILURE);
         ASN1_UTF8STRING_free(utf8);
         return NULL;

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -47,7 +47,7 @@ int X509V3_add_value(const char *name, const char *value,
         goto err;
     if (value && (tvalue = OPENSSL_strdup(value)) == NULL)
         goto err;
-    if ((vtmp = OPENSSL_malloc(sizeof(*vtmp))) == NULL)
+    if ((vtmp = (CONF_VALUE *)OPENSSL_malloc(sizeof(*vtmp))) == NULL)
         goto err;
     if (sk_allocated && (*extlist = sk_CONF_VALUE_new_null()) == NULL)
         goto err;
@@ -121,7 +121,7 @@ static char *bignum_to_string(const BIGNUM *bn)
         return NULL;
 
     len = strlen(tmp) + 3;
-    ret = OPENSSL_malloc(len);
+    ret = (char *)OPENSSL_malloc(len);
     if (ret == NULL) {
         X509V3err(X509V3_F_BIGNUM_TO_STRING, ERR_R_MALLOC_FAILURE);
         OPENSSL_free(tmp);
@@ -428,7 +428,7 @@ STACK_OF(OPENSSL_STRING) *X509_get1_email(X509 *x)
     GENERAL_NAMES *gens;
     STACK_OF(OPENSSL_STRING) *ret;
 
-    gens = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
+    gens = (GENERAL_NAMES *)X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
     ret = get_email(X509_get_subject_name(x), gens);
     sk_GENERAL_NAME_pop_free(gens, GENERAL_NAME_free);
     return ret;
@@ -440,7 +440,7 @@ STACK_OF(OPENSSL_STRING) *X509_get1_ocsp(X509 *x)
     STACK_OF(OPENSSL_STRING) *ret = NULL;
     int i;
 
-    info = X509_get_ext_d2i(x, NID_info_access, NULL, NULL);
+    info = (AUTHORITY_INFO_ACCESS *)X509_get_ext_d2i(x, NID_info_access, NULL, NULL);
     if (!info)
         return NULL;
     for (i = 0; i < sk_ACCESS_DESCRIPTION_num(info); i++) {
@@ -464,7 +464,7 @@ STACK_OF(OPENSSL_STRING) *X509_REQ_get1_email(X509_REQ *x)
     STACK_OF(OPENSSL_STRING) *ret;
 
     exts = X509_REQ_get_extensions(x);
-    gens = X509V3_get_d2i(exts, NID_subject_alt_name, NULL, NULL);
+    gens = (GENERAL_NAMES *)X509V3_get_d2i(exts, NID_subject_alt_name, NULL, NULL);
     ret = get_email(X509_REQ_get_subject_name(x), gens);
     sk_GENERAL_NAME_pop_free(gens, GENERAL_NAME_free);
     sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free);
@@ -865,7 +865,7 @@ static int do_x509_check(X509 *x, const char *chk, size_t chklen,
     if (chklen == 0)
         chklen = strlen(chk);
 
-    gens = X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
+    gens = (GENERAL_NAMES *)X509_get_ext_d2i(x, NID_subject_alt_name, NULL, NULL);
     if (gens) {
         for (i = 0; i < sk_GENERAL_NAME_num(gens); i++) {
             GENERAL_NAME *gen;
@@ -1110,10 +1110,10 @@ static int ipv4_from_asc(unsigned char *v4, const char *in)
     if ((a0 < 0) || (a0 > 255) || (a1 < 0) || (a1 > 255)
         || (a2 < 0) || (a2 > 255) || (a3 < 0) || (a3 > 255))
         return 0;
-    v4[0] = a0;
-    v4[1] = a1;
-    v4[2] = a2;
-    v4[3] = a3;
+    v4[0] = (unsigned char)a0;
+    v4[1] = (unsigned char)a1;
+    v4[2] = (unsigned char)a2;
+    v4[3] = (unsigned char)a3;
     return 1;
 }
 
@@ -1194,7 +1194,7 @@ static int ipv6_from_asc(unsigned char *v6, const char *in)
 
 static int ipv6_cb(const char *elem, int len, void *usr)
 {
-    IPV6_STAT *s = usr;
+    IPV6_STAT *s = (IPV6_STAT *)usr;
 
     /* Error if 16 bytes written */
     if (s->total == 16)
@@ -1248,8 +1248,8 @@ static int ipv6_hex(unsigned char *out, const char *in, int inlen)
             return 0;
         num |= (char)x;
     }
-    out[0] = num >> 8;
-    out[1] = num & 0xff;
+    out[0] = (unsigned char)(num >> 8);
+    out[1] = (unsigned char)(num & 0xff);
     return 1;
 }
 

--- a/crypto/x509/x509_att.c
+++ b/crypto/x509/x509_att.c
@@ -251,7 +251,7 @@ int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
     if (!attr)
         return 0;
     if (attrtype & MBSTRING_FLAG) {
-        stmp = ASN1_STRING_set_by_NID(NULL, data, len, attrtype,
+        stmp = ASN1_STRING_set_by_NID(NULL, (const unsigned char *)data, len, attrtype,
                                       OBJ_obj2nid(attr->object));
         if (!stmp) {
             X509err(X509_F_X509_ATTRIBUTE_SET1_DATA, ERR_R_ASN1_LIB);

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -17,7 +17,7 @@
 
 X509_LOOKUP *X509_LOOKUP_new(X509_LOOKUP_METHOD *method)
 {
-    X509_LOOKUP *ret = OPENSSL_zalloc(sizeof(*ret));
+    X509_LOOKUP *ret = (X509_LOOKUP *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         X509err(X509_F_X509_LOOKUP_NEW, ERR_R_MALLOC_FAILURE);
@@ -181,7 +181,7 @@ static int x509_object_cmp(const X509_OBJECT *const *a,
 
 X509_STORE *X509_STORE_new(void)
 {
-    X509_STORE *ret = OPENSSL_zalloc(sizeof(*ret));
+    X509_STORE *ret = (X509_STORE *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         X509err(0, ERR_R_MALLOC_FAILURE);
@@ -440,7 +440,7 @@ X509_LOOKUP_TYPE X509_OBJECT_get_type(const X509_OBJECT *a)
 
 X509_OBJECT *X509_OBJECT_new(void)
 {
-    X509_OBJECT *ret = OPENSSL_zalloc(sizeof(*ret));
+    X509_OBJECT *ret = (X509_OBJECT *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL) {
         X509err(X509_F_X509_OBJECT_NEW, ERR_R_MALLOC_FAILURE);

--- a/crypto/x509/x509_obj.c
+++ b/crypto/x509/x509_obj.c
@@ -68,7 +68,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             i2t_ASN1_OBJECT(tmp_buf, sizeof(tmp_buf), ne->object);
             s = tmp_buf;
         }
-        l1 = strlen(s);
+        l1 = (int)strlen(s);
 
         type = ne->value->type;
         num = ne->value->length;
@@ -152,7 +152,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             } else {
                 if (n == '/' || n == '+')
                     *(p++) = '\\';
-                *(p++) = n;
+                *(p++) = (char)n;
             }
 #else
             n = os_toascii[q[j]];

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -35,7 +35,7 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
     ri = &ret->req_info;
 
     ri->version->length = 1;
-    ri->version->data = OPENSSL_malloc(1);
+    ri->version->data = (unsigned char *)OPENSSL_malloc(1);
     if (ri->version->data == NULL)
         goto err;
     ri->version->data[0] = 0;   /* version == 0 */

--- a/crypto/x509/x509_trs.c
+++ b/crypto/x509/x509_trs.c
@@ -135,7 +135,7 @@ int X509_TRUST_add(int id, int flags, int (*ck) (X509_TRUST *, X509 *, int),
     idx = X509_TRUST_get_by_id(id);
     /* Need a new entry */
     if (idx == -1) {
-        if ((trtmp = OPENSSL_malloc(sizeof(*trtmp))) == NULL) {
+        if ((trtmp = (X509_TRUST *)OPENSSL_malloc(sizeof(*trtmp))) == NULL) {
             X509err(X509_F_X509_TRUST_ADD, ERR_R_MALLOC_FAILURE);
             return 0;
         }

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -83,7 +83,7 @@ X509_VERIFY_PARAM *X509_VERIFY_PARAM_new(void)
 {
     X509_VERIFY_PARAM *param;
 
-    param = OPENSSL_zalloc(sizeof(*param));
+    param = (X509_VERIFY_PARAM *)OPENSSL_zalloc(sizeof(*param));
     if (param == NULL) {
         X509err(X509_F_X509_VERIFY_PARAM_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -244,7 +244,7 @@ static int int_x509_param_set1(char **pdest, size_t *pdestlen,
         if (srclen == 0)
             srclen = strlen(src);
 
-        tmp = OPENSSL_malloc(srclen + 1);
+        tmp = (char *)OPENSSL_malloc(srclen + 1);
         if (tmp == NULL)
             return 0;
         memcpy(tmp, src, srclen);

--- a/crypto/x509/x509name.c
+++ b/crypto/x509/x509name.c
@@ -325,7 +325,7 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
                                       len, type,
                                       OBJ_obj2nid(ne->object)) ? 1 : 0;
     if (len < 0)
-        len = strlen((const char *)bytes);
+        len = (int)strlen((const char *)bytes);
     i = ASN1_STRING_set(ne->value, bytes, len);
     if (!i)
         return 0;

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -143,7 +143,7 @@ int i2d_X509_fp(FILE *fp, const X509 *x509)
 
 X509 *d2i_X509_bio(BIO *bp, X509 **x509)
 {
-    return ASN1_item_d2i_bio(ASN1_ITEM_rptr(X509), bp, x509);
+    return (X509 *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(X509), bp, x509);
 }
 
 int i2d_X509_bio(BIO *bp, const X509 *x509)
@@ -165,7 +165,7 @@ int i2d_X509_CRL_fp(FILE *fp, const X509_CRL *crl)
 
 X509_CRL *d2i_X509_CRL_bio(BIO *bp, X509_CRL **crl)
 {
-    return ASN1_item_d2i_bio(ASN1_ITEM_rptr(X509_CRL), bp, crl);
+    return (X509_CRL *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(X509_CRL), bp, crl);
 }
 
 int i2d_X509_CRL_bio(BIO *bp, const X509_CRL *crl)
@@ -219,7 +219,7 @@ int i2d_X509_REQ_fp(FILE *fp, const X509_REQ *req)
 
 X509_REQ *d2i_X509_REQ_bio(BIO *bp, X509_REQ **req)
 {
-    return ASN1_item_d2i_bio(ASN1_ITEM_rptr(X509_REQ), bp, req);
+    return (X509_REQ *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(X509_REQ), bp, req);
 }
 
 int i2d_X509_REQ_bio(BIO *bp, const X509_REQ *req)
@@ -265,7 +265,7 @@ int i2d_RSA_PUBKEY_fp(FILE *fp, const RSA *rsa)
 
 RSA *d2i_RSAPrivateKey_bio(BIO *bp, RSA **rsa)
 {
-    return ASN1_item_d2i_bio(ASN1_ITEM_rptr(RSAPrivateKey), bp, rsa);
+    return (RSA *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(RSAPrivateKey), bp, rsa);
 }
 
 int i2d_RSAPrivateKey_bio(BIO *bp, const RSA *rsa)
@@ -275,7 +275,7 @@ int i2d_RSAPrivateKey_bio(BIO *bp, const RSA *rsa)
 
 RSA *d2i_RSAPublicKey_bio(BIO *bp, RSA **rsa)
 {
-    return ASN1_item_d2i_bio(ASN1_ITEM_rptr(RSAPublicKey), bp, rsa);
+    return (RSA *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(RSAPublicKey), bp, rsa);
 }
 
 RSA *d2i_RSA_PUBKEY_bio(BIO *bp, RSA **rsa)
@@ -414,7 +414,7 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert)
     unsigned char hash[EVP_MAX_MD_SIZE];
     int md_NID;
     const EVP_MD *md = NULL;
-    ASN1_OCTET_STRING *new = NULL;
+    ASN1_OCTET_STRING *ret = NULL;
 
     if (cert == NULL) {
         X509err(0, ERR_R_PASSED_NULL_PARAMETER);
@@ -427,13 +427,13 @@ ASN1_OCTET_STRING *X509_digest_sig(const X509 *cert)
         return NULL;
     }
     if (!X509_digest(cert, md, hash, &len)
-            || (new = ASN1_OCTET_STRING_new()) == NULL)
+            || (ret = ASN1_OCTET_STRING_new()) == NULL)
         return NULL;
-    if (!(ASN1_OCTET_STRING_set(new, hash, len))) {
-        ASN1_OCTET_STRING_free(new);
+    if (!(ASN1_OCTET_STRING_set(ret, hash, len))) {
+        ASN1_OCTET_STRING_free(ret);
         return NULL;
     }
-    return new;
+    return ret;
 }
 
 int X509_CRL_digest(const X509_CRL *data, const EVP_MD *type,

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -94,8 +94,8 @@ static int crl_set_issuers(X509_CRL *crl)
         STACK_OF(X509_EXTENSION) *exts;
         ASN1_ENUMERATED *reason;
         X509_EXTENSION *ext;
-        gtmp = X509_REVOKED_get_ext_d2i(rev,
-                                        NID_certificate_issuer, &j, NULL);
+        gtmp = (GENERAL_NAMES *)X509_REVOKED_get_ext_d2i(rev,
+                                                         NID_certificate_issuer, &j, NULL);
         if (!gtmp && (j != -1)) {
             crl->flags |= EXFLAG_INVALID;
             return 1;
@@ -113,7 +113,7 @@ static int crl_set_issuers(X509_CRL *crl)
         }
         rev->issuer = gens;
 
-        reason = X509_REVOKED_get_ext_d2i(rev, NID_crl_reason, &j, NULL);
+        reason = (ASN1_ENUMERATED *)X509_REVOKED_get_ext_d2i(rev, NID_crl_reason, &j, NULL);
         if (!reason && (j != -1)) {
             crl->flags |= EXFLAG_INVALID;
             return 1;
@@ -186,9 +186,9 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
     case ASN1_OP_D2I_POST:
         if (!X509_CRL_digest(crl, EVP_sha1(), crl->sha1_hash, NULL))
             crl->flags |= EXFLAG_INVALID;
-        crl->idp = X509_CRL_get_ext_d2i(crl,
-                                        NID_issuing_distribution_point, &i,
-                                        NULL);
+        crl->idp = (ISSUING_DIST_POINT *)X509_CRL_get_ext_d2i(crl,
+                                                              NID_issuing_distribution_point, &i,
+                                                              NULL);
         if (crl->idp != NULL) {
             if (!setup_idp(crl, crl->idp))
                 crl->flags |= EXFLAG_INVALID;
@@ -197,20 +197,20 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
             crl->flags |= EXFLAG_INVALID;
         }
 
-        crl->akid = X509_CRL_get_ext_d2i(crl,
-                                         NID_authority_key_identifier, &i,
-                                         NULL);
+        crl->akid = (AUTHORITY_KEYID *)X509_CRL_get_ext_d2i(crl,
+                                                            NID_authority_key_identifier, &i,
+                                                            NULL);
         if (crl->akid == NULL && i != -1)
             crl->flags |= EXFLAG_INVALID;
 
-        crl->crl_number = X509_CRL_get_ext_d2i(crl,
-                                               NID_crl_number, &i, NULL);
+        crl->crl_number = (ASN1_INTEGER *)X509_CRL_get_ext_d2i(crl,
+                                                               NID_crl_number, &i, NULL);
         if (crl->crl_number == NULL && i != -1)
             crl->flags |= EXFLAG_INVALID;
 
-        crl->base_crl_number = X509_CRL_get_ext_d2i(crl,
-                                                    NID_delta_crl, &i,
-                                                    NULL);
+        crl->base_crl_number = (ASN1_INTEGER *)X509_CRL_get_ext_d2i(crl,
+                                                                    NID_delta_crl, &i,
+                                                                    NULL);
         if (crl->base_crl_number == NULL && i != -1)
             crl->flags |= EXFLAG_INVALID;
         /* Delta CRLs must have CRL number */
@@ -459,7 +459,7 @@ X509_CRL_METHOD *X509_CRL_METHOD_new(int (*crl_init) (X509_CRL *crl),
                                      int (*crl_verify) (X509_CRL *crl,
                                                         EVP_PKEY *pk))
 {
-    X509_CRL_METHOD *m = OPENSSL_malloc(sizeof(*m));
+    X509_CRL_METHOD *m = (X509_CRL_METHOD *)OPENSSL_malloc(sizeof(*m));
 
     if (m == NULL) {
         X509err(X509_F_X509_CRL_METHOD_NEW, ERR_R_MALLOC_FAILURE);

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -89,7 +89,7 @@ IMPLEMENT_ASN1_DUP_FUNCTION(X509_NAME)
 
 static int x509_name_ex_new(ASN1_VALUE **val, const ASN1_ITEM *it)
 {
-    X509_NAME *ret = OPENSSL_zalloc(sizeof(*ret));
+    X509_NAME *ret = (X509_NAME *)OPENSSL_zalloc(sizeof(*ret));
 
     if (ret == NULL)
         goto memerr;
@@ -222,7 +222,7 @@ static int x509_name_ex_i2d(const ASN1_VALUE **val, unsigned char **out,
         if (ret < 0)
             return ret;
     }
-    ret = a->bytes->length;
+    ret = (int)a->bytes->length;
     if (out != NULL) {
         memcpy(*out, a->bytes->data, ret);
         *out += ret;
@@ -358,7 +358,7 @@ static int x509_name_canon(X509_NAME *a)
         goto err;
     a->canon_enclen = len;
 
-    p = OPENSSL_malloc(a->canon_enclen);
+    p = (unsigned char *)OPENSSL_malloc(a->canon_enclen);
     if (p == NULL) {
         X509err(X509_F_X509_NAME_CANON, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -451,13 +451,13 @@ static int asn1_string_canon(ASN1_STRING *out, const ASN1_STRING *in)
             }
             while (ossl_isspace(*from));
         } else {
-            *to++ = ossl_tolower(*from);
+            *to++ = (unsigned char)ossl_tolower(*from);
             from++;
             i++;
         }
     }
 
-    out->length = to - out->data;
+    out->length = (int)(to - out->data);
 
     return 1;
 
@@ -518,7 +518,7 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
                                 (ossl_isupper(s[2]) && (s[3] == '='))
               ))) || (*s == '\0'))
         {
-            i = s - c;
+            i = (int)(s - c);
             if (BIO_write(bp, c, i) != i)
                 goto err;
             c = s + 1;          /* skip following slash */

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -314,7 +314,7 @@ int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp)
             && OSSL_ENCODER_CTX_get_encoder(ctx) != NULL
             && OSSL_ENCODER_to_bio(ctx, out)
             && BIO_get_mem_ptr(out, &buf) > 0) {
-            ret = buf->length;
+            ret = (int)buf->length;
 
             if (pp != NULL) {
                 if (*pp == NULL) {

--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -185,7 +185,7 @@ X509 *d2i_X509_AUX(X509 **a, const unsigned char **pp, long length)
     if (ret == NULL)
         return NULL;
     /* update length */
-    length -= q - *pp;
+    length -= (long)(q - *pp);
     if (length > 0 && !d2i_X509_CERT_AUX(&ret->aux, &q, length))
         goto err;
     *pp = q;
@@ -253,7 +253,7 @@ int i2d_X509_AUX(const X509 *a, unsigned char **pp)
         return length;
 
     /* Allocate requisite combined storage */
-    *pp = tmp = OPENSSL_malloc(length);
+    *pp = tmp = (unsigned char *)OPENSSL_malloc(length);
     if (tmp == NULL) {
         X509err(X509_F_I2D_X509_AUX, ERR_R_MALLOC_FAILURE);
         return -1;

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -73,7 +73,7 @@ static char *file_get_pass(const UI_METHOD *ui_method, char *pass,
         ATTICerr(0, ERR_R_MALLOC_FAILURE);
         pass = NULL;
     } else if (!UI_add_input_string(ui, prompt, UI_INPUT_FLAG_DEFAULT_PWD,
-                                    pass, 0, maxsize - 1)) {
+                                    pass, 0, (int)(maxsize - 1))) {
         ATTICerr(0, ERR_R_UI_LIB);
         pass = NULL;
     } else {
@@ -119,7 +119,7 @@ static int file_fill_pem_pass_data(struct pem_pass_data *pass_data,
 /* This is used anywhere a pem_password_cb is needed */
 static int file_get_pem_pass(char *buf, int num, int w, void *data)
 {
-    struct pem_pass_data *pass_data = data;
+    struct pem_pass_data *pass_data = (struct pem_pass_data *)data;
     char *pass = file_get_pass(pass_data->ui_method, buf, num,
                                pass_data->prompt_desc, pass_data->prompt_info,
                                pass_data->data);
@@ -303,7 +303,7 @@ static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
                                           const char *propq)
 {
     OSSL_STORE_INFO *store_info = NULL;
-    STACK_OF(OSSL_STORE_INFO) *ctx = *pctx;
+    STACK_OF(OSSL_STORE_INFO) *ctx = (STACK_OF(OSSL_STORE_INFO) *)*pctx;
 
     if (ctx == NULL) {
         /* Initial parsing */
@@ -313,7 +313,7 @@ static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
             /* No match, there is no PEM PKCS12 tag */
             return NULL;
 
-        if ((p12 = d2i_PKCS12(NULL, &blob, len)) != NULL) {
+        if ((p12 = d2i_PKCS12(NULL, &blob, (long)len)) != NULL) {
             char *pass = NULL;
             char tpass[PEM_BUFSIZE];
             EVP_PKEY *pkey = NULL;
@@ -400,14 +400,14 @@ static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
 
 static int eof_PKCS12(void *ctx_)
 {
-    STACK_OF(OSSL_STORE_INFO) *ctx = ctx_;
+    STACK_OF(OSSL_STORE_INFO) *ctx = (STACK_OF(OSSL_STORE_INFO) *)ctx_;
 
     return ctx == NULL || sk_OSSL_STORE_INFO_num(ctx) == 0;
 }
 
 static void destroy_ctx_PKCS12(void **pctx)
 {
-    STACK_OF(OSSL_STORE_INFO) *ctx = *pctx;
+    STACK_OF(OSSL_STORE_INFO) *ctx = (STACK_OF(OSSL_STORE_INFO) *)*pctx;
 
     sk_OSSL_STORE_INFO_pop_free(ctx, store_info_free);
     *pctx = NULL;
@@ -453,7 +453,7 @@ static OSSL_STORE_INFO *try_decode_PKCS8Encrypted(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((p8 = d2i_X509_SIG(NULL, &blob, len)) == NULL)
+    if ((p8 = d2i_X509_SIG(NULL, &blob, (long)len)) == NULL)
         return NULL;
 
     *matchcount = 1;
@@ -519,7 +519,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
     if (pem_name != NULL) {
         if (strcmp(pem_name, PEM_STRING_PKCS8INF) == 0) {
             PKCS8_PRIV_KEY_INFO *p8inf =
-                d2i_PKCS8_PRIV_KEY_INFO(NULL, &blob, len);
+                d2i_PKCS8_PRIV_KEY_INFO(NULL, &blob, (long)len);
 
             *matchcount = 1;
             if (p8inf != NULL)
@@ -535,7 +535,7 @@ static OSSL_STORE_INFO *try_decode_PrivateKey(const char *pem_name,
                 && EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, NULL, NULL,
                                            ameth)) {
                 *matchcount = 1;
-                pkey = d2i_PrivateKey_ex(pkey_id, NULL, &blob, len,
+                pkey = d2i_PrivateKey_ex(pkey_id, NULL, &blob, (long)len,
                                          libctx, propq);
             }
         }
@@ -651,7 +651,7 @@ static OSSL_STORE_INFO *try_decode_PUBKEY(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((pkey = d2i_PUBKEY(NULL, &blob, len)) != NULL) {
+    if ((pkey = d2i_PUBKEY(NULL, &blob, (long)len)) != NULL) {
         *matchcount = 1;
         store_info = OSSL_STORE_INFO_new_PUBKEY(pkey);
     }
@@ -782,7 +782,7 @@ static OSSL_STORE_INFO *try_decode_X509Certificate(const char *pem_name,
         return NULL;
 
     if ((d2i_X509_AUX(&cert, &blob, len)) != NULL
-        || (ignore_trusted && (d2i_X509(&cert, &blob, len)) != NULL)) {
+        || (ignore_trusted && (d2i_X509(&cert, &blob, (long)len)) != NULL)) {
         *matchcount = 1;
         store_info = OSSL_STORE_INFO_new_CERT(cert);
     }
@@ -821,7 +821,7 @@ static OSSL_STORE_INFO *try_decode_X509CRL(const char *pem_name,
         *matchcount = 1;
     }
 
-    if ((crl = d2i_X509_CRL(NULL, &blob, len)) != NULL) {
+    if ((crl = d2i_X509_CRL(NULL, &blob, (long)len)) != NULL) {
         *matchcount = 1;
         store_info = OSSL_STORE_INFO_new_CRL(crl);
     }
@@ -1023,7 +1023,7 @@ static OSSL_STORE_LOADER_CTX *file_open_with_libctx
 
     /* Successfully found a working path */
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (OSSL_STORE_LOADER_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx == NULL) {
         ATTICerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -1079,7 +1079,7 @@ static OSSL_STORE_LOADER_CTX *file_attach
 {
     OSSL_STORE_LOADER_CTX *ctx = NULL;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL
+    if ((ctx = (OSSL_STORE_LOADER_CTX *)OPENSSL_zalloc(sizeof(*ctx))) == NULL
         || (propq != NULL && (ctx->propq = OPENSSL_strdup(propq)) == NULL)) {
         ATTICerr(0, ERR_R_MALLOC_FAILURE);
         OSSL_STORE_LOADER_CTX_free(ctx);
@@ -1181,7 +1181,7 @@ static OSSL_STORE_INFO *file_load_try_decode(OSSL_STORE_LOADER_CTX *ctx,
     {
         size_t i = 0;
         void *handler_ctx = NULL;
-        const FILE_HANDLER **matching_handlers =
+        const FILE_HANDLER **matching_handlers = (const FILE_HANDLER **)
             OPENSSL_zalloc(sizeof(*matching_handlers)
                            * OSSL_NELEM(file_handlers));
 
@@ -1240,7 +1240,7 @@ static OSSL_STORE_INFO *file_load_try_decode(OSSL_STORE_LOADER_CTX *ctx,
             ctx->_.file.last_handler_ctx = handler_ctx;
         }
 
-        OPENSSL_free(matching_handlers);
+        OPENSSL_free((FILE_HANDLER **)matching_handlers);
     }
 
  err:
@@ -1448,7 +1448,7 @@ static int file_name_to_uri(OSSL_STORE_LOADER_CTX *ctx, const char *name,
         long calculated_length = strlen(ctx->uri) + strlen(pathsep)
             + strlen(name) + 1 /* \0 */;
 
-        *data = OPENSSL_zalloc(calculated_length);
+        *data = (char *)OPENSSL_zalloc(calculated_length);
         if (*data == NULL) {
             ATTICerr(0, ERR_R_MALLOC_FAILURE);
             return 0;

--- a/include/crypto/md32_common.h
+++ b/include/crypto/md32_common.h
@@ -127,7 +127,7 @@
 
 int HASH_UPDATE(HASH_CTX *c, const void *data_, size_t len)
 {
-    const unsigned char *data = data_;
+    const unsigned char *data = (const unsigned char *)data_;
     unsigned char *p;
     HASH_LONG l;
     size_t n;

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -426,7 +426,7 @@ __owur static ossl_inline int PACKET_memdup(const PACKET *pkt,
     if (length == 0)
         return 1;
 
-    *data = OPENSSL_memdup(pkt->curr, length);
+    *data = (unsigned char *)OPENSSL_memdup(pkt->curr, length);
     if (*data == NULL)
         return 0;
 

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -715,7 +715,7 @@ int ASN1_item_verify_with_libctx(const ASN1_ITEM *it, const X509_ALGOR *alg,
 
 # define M_ASN1_new_of(type) (type *)ASN1_item_new(ASN1_ITEM_rptr(type))
 # define M_ASN1_free_of(x, type) \
-                ASN1_item_free(CHECKED_PTR_OF(type, x), ASN1_ITEM_rptr(type))
+                ASN1_item_free((ASN1_VALUE *)CHECKED_PTR_OF(type, x), ASN1_ITEM_rptr(type))
 
 # ifndef OPENSSL_NO_STDIO
 void *ASN1_d2i_fp(void *(*xnew) (void), d2i_of_void *d2i, FILE *in, void **x);

--- a/include/openssl/asn1t.h.in
+++ b/include/openssl/asn1t.h.in
@@ -845,7 +845,7 @@ typedef struct ASN1_STREAM_ARG_st {
 # define IMPLEMENT_ASN1_DUP_FUNCTION(stname) \
         stname * stname##_dup(const stname *x) \
         { \
-        return ASN1_item_dup(ASN1_ITEM_rptr(stname), x); \
+        return (stname *)ASN1_item_dup(ASN1_ITEM_rptr(stname), x); \
         }
 
 # define IMPLEMENT_ASN1_PRINT_FUNCTION(stname) \

--- a/include/openssl/objects.h
+++ b/include/openssl/objects.h
@@ -121,8 +121,8 @@ const void *OBJ_bsearch_ex_(const void *key, const void *base, int num,
 # define IMPLEMENT_OBJ_BSEARCH_CMP_FN(type1, type2, nm)  \
   static int nm##_cmp_BSEARCH_CMP_FN(const void *a_, const void *b_)    \
       { \
-      type1 const *a = a_; \
-      type2 const *b = b_; \
+      type1 const *a = (type1 const *)a_; \
+      type2 const *b = (type2 const *)b_; \
       return nm##_cmp(a,b); \
       } \
   static type2 *OBJ_bsearch_##nm(type1 *key, type2 const *base, int num) \

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -87,11 +87,11 @@ extern "C" {
 #  endif
 # else
 
-#  define IMPLEMENT_PEM_read_fp(name, type, str, asn1)                  \
+#  define IMPLEMENT_PEM_read_fp(name, type, str, asn1)                      \
     type *PEM_read_##name(FILE *fp, type **x, pem_password_cb *cb, void *u) \
-    {                                                                   \
-        return PEM_ASN1_read((d2i_of_void *)d2i_##asn1, str, fp,        \
-                             (void **)x, cb, u);                        \
+    {                                                                       \
+        return (type *)PEM_ASN1_read((d2i_of_void *)d2i_##asn1, str, fp,    \
+                                     (void **)x, cb, u);                    \
     }
 
 #  define IMPLEMENT_PEM_write_fp(name, type, str, asn1)                 \
@@ -119,12 +119,12 @@ extern "C" {
 #  endif
 # endif
 
-# define IMPLEMENT_PEM_read_bio(name, type, str, asn1)                  \
-    type *PEM_read_bio_##name(BIO *bp, type **x,                        \
-                              pem_password_cb *cb, void *u)             \
-    {                                                                   \
-        return PEM_ASN1_read_bio((d2i_of_void *)d2i_##asn1, str, bp,    \
-                                 (void **)x, cb, u);                    \
+# define IMPLEMENT_PEM_read_bio(name, type, str, asn1)                          \
+    type *PEM_read_bio_##name(BIO *bp, type **x,                                \
+                              pem_password_cb *cb, void *u)                     \
+    {                                                                           \
+        return (type *)PEM_ASN1_read_bio((d2i_of_void *)d2i_##asn1, str, bp,    \
+                                         (void **)x, cb, u);                    \
     }
 
 # define IMPLEMENT_PEM_write_bio(name, type, str, asn1)                 \

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -43,7 +43,7 @@ static int load_common(const OSSL_PARAM params[], const char **propquery,
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        *propquery = p->data;
+        *propquery = (const char *)p->data;
     }
 
     *engine = NULL;
@@ -55,7 +55,7 @@ static int load_common(const OSSL_PARAM params[], const char **propquery,
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
         ENGINE_finish(*engine);
-        *engine = ENGINE_by_id(p->data);
+        *engine = ENGINE_by_id((const char *)p->data);
         if (*engine == NULL)
             return 0;
     }
@@ -81,11 +81,11 @@ int ossl_prov_cipher_load_from_params(PROV_CIPHER *pc,
 
     EVP_CIPHER_free(pc->alloc_cipher);
     ERR_set_mark();
-    pc->cipher = pc->alloc_cipher = EVP_CIPHER_fetch(ctx, p->data, propquery);
+    pc->cipher = pc->alloc_cipher = EVP_CIPHER_fetch(ctx, (const char *)p->data, propquery);
     /* TODO legacy stuff, to be removed */
 #ifndef FIPS_MODULE /* Inside the FIPS module, we don't support legacy ciphers */
     if (pc->cipher == NULL)
-        pc->cipher = EVP_get_cipherbyname(p->data);
+        pc->cipher = EVP_get_cipherbyname((const char *)p->data);
 #endif
     if (pc->cipher != NULL)
         ERR_pop_to_mark();
@@ -141,11 +141,11 @@ int ossl_prov_digest_load_from_params(PROV_DIGEST *pd,
 
     EVP_MD_free(pd->alloc_md);
     ERR_set_mark();
-    pd->md = pd->alloc_md = EVP_MD_fetch(ctx, p->data, propquery);
+    pd->md = pd->alloc_md = EVP_MD_fetch(ctx, (const char *)p->data, propquery);
     /* TODO legacy stuff, to be removed */
 #ifndef FIPS_MODULE /* Inside the FIPS module, we don't support legacy digests */
     if (pd->md == NULL)
-        pd->md = EVP_get_digestbyname(p->data);
+        pd->md = EVP_get_digestbyname((const char *)p->data);
 #endif
     if (pd->md != NULL)
         ERR_pop_to_mark();
@@ -244,13 +244,13 @@ int ossl_prov_macctx_load_from_params(EVP_MAC_CTX **macctx,
         && (p = OSSL_PARAM_locate_const(params, OSSL_ALG_PARAM_MAC)) != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        macname = p->data;
+        macname = (const char *)p->data;
     }
     if ((p = OSSL_PARAM_locate_const(params,
                                      OSSL_ALG_PARAM_PROPERTIES)) != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        properties = p->data;
+        properties = (const char *)p->data;
     }
 
     /* If we got a new mac name, we make a new EVP_MAC_CTX */

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -82,7 +82,7 @@ static void *rsa_newctx(void *provctx)
 
     if (!ossl_prov_is_running())
         return NULL;
-    prsactx = OPENSSL_zalloc(sizeof(PROV_RSA_CTX));
+    prsactx = (PROV_RSA_CTX *)OPENSSL_zalloc(sizeof(PROV_RSA_CTX));
     if (prsactx == NULL)
         return NULL;
     prsactx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
@@ -97,10 +97,10 @@ static int rsa_init(void *vprsactx, void *vrsa)
     if (!ossl_prov_is_running()
             || prsactx == NULL
             || vrsa == NULL
-            || !RSA_up_ref(vrsa))
+            || !RSA_up_ref((RSA *)vrsa))
         return 0;
     RSA_free(prsactx->rsa);
-    prsactx->rsa = vrsa;
+    prsactx->rsa = (RSA *)vrsa;
 
     switch (RSA_test_flags(prsactx->rsa, RSA_FLAG_TYPE_MASK)) {
     case RSA_FLAG_TYPE_RSA:
@@ -138,7 +138,7 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
         int rsasize = RSA_size(prsactx->rsa);
         unsigned char *tbuf;
 
-        if ((tbuf = OPENSSL_malloc(rsasize)) == NULL) {
+        if ((tbuf = (unsigned char *)OPENSSL_malloc(rsasize)) == NULL) {
             PROVerr(0, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -150,9 +150,9 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
         }
         ret =
             rsa_padding_add_PKCS1_OAEP_mgf1_with_libctx(prsactx->libctx, tbuf,
-                                                        rsasize, in, inlen,
+                                                        rsasize, in, (int)inlen,
                                                         prsactx->oaep_label,
-                                                        prsactx->oaep_labellen,
+                                                        (int)prsactx->oaep_labellen,
                                                         prsactx->oaep_md,
                                                         prsactx->mgf1_md);
 
@@ -164,7 +164,7 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
                                  RSA_NO_PADDING);
         OPENSSL_free(tbuf);
     } else {
-        ret = RSA_public_encrypt(inlen, in, out, prsactx->rsa,
+        ret = RSA_public_encrypt((int)inlen, in, out, prsactx->rsa,
                                  prsactx->pad_mode);
     }
     /* A ret value of 0 is not an error */
@@ -213,11 +213,11 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
             || prsactx->pad_mode == RSA_PKCS1_WITH_TLS_PADDING) {
         unsigned char *tbuf;
 
-        if ((tbuf = OPENSSL_malloc(len)) == NULL) {
+        if ((tbuf = (unsigned char *)OPENSSL_malloc(len)) == NULL) {
             PROVerr(0, ERR_R_MALLOC_FAILURE);
             return 0;
         }
-        ret = RSA_private_decrypt(inlen, in, tbuf, prsactx->rsa,
+        ret = RSA_private_decrypt((int)inlen, in, tbuf, prsactx->rsa,
                                   RSA_NO_PADDING);
         /*
          * With no padding then, on success ret should be len, otherwise an
@@ -236,10 +236,10 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
                     return 0;
                 }
             }
-            ret = RSA_padding_check_PKCS1_OAEP_mgf1(out, outsize, tbuf,
-                                                    len, len,
+            ret = RSA_padding_check_PKCS1_OAEP_mgf1(out, (int)outsize, tbuf,
+                                                    (int)len, (int)len,
                                                     prsactx->oaep_label,
-                                                    prsactx->oaep_labellen,
+                                                    (int)prsactx->oaep_labellen,
                                                     prsactx->oaep_md,
                                                     prsactx->mgf1_md);
         } else {
@@ -256,7 +256,7 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
         }
         OPENSSL_free(tbuf);
     } else {
-        ret = RSA_private_decrypt(inlen, in, out, prsactx->rsa,
+        ret = RSA_private_decrypt((int)inlen, in, out, prsactx->rsa,
                                   prsactx->pad_mode);
     }
     *outlen = constant_time_select_s(constant_time_msb_s(ret), *outlen, ret);
@@ -285,7 +285,7 @@ static void *rsa_dupctx(void *vprsactx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_RSA_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
 
@@ -333,7 +333,7 @@ static int rsa_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
 
                 for (i = 0; padding_item[i].id != 0; i++) {
                     if (prsactx->pad_mode == (int)padding_item[i].id) {
-                        word = padding_item[i].ptr;
+                        word = (const char *)padding_item[i].ptr;
                         break;
                     }
                 }
@@ -451,7 +451,7 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
                     return 0;
 
                 for (i = 0; padding_item[i].id != 0; i++) {
-                    if (strcmp(p->data, padding_item[i].ptr) == 0) {
+                    if (strcmp((const char *)p->data, (const char *)padding_item[i].ptr) == 0) {
                         pad_mode = padding_item[i].id;
                         break;
                     }

--- a/providers/implementations/ciphers/cipher_aes.c
+++ b/providers/implementations/ciphers/cipher_aes.c
@@ -39,7 +39,7 @@ static void *aes_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_AES_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -27,7 +27,7 @@ static void *aes_ccm_newctx(void *provctx, size_t keybits)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_AES_CCM_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         ccm_initctx(&ctx->base, keybits, PROV_AES_HW_ccm(keybits));
     return ctx;

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -27,7 +27,7 @@ static void *aes_gcm_newctx(void *provctx, size_t keybits)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_AES_GCM_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         gcm_initctx(provctx, &ctx->base, keybits, PROV_AES_HW_gcm(keybits), 8);
     return ctx;

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -305,7 +305,7 @@ static void *aes_ocb_newctx(void *provctx, size_t kbits, size_t blkbits,
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_AES_OCB_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL) {
         cipher_generic_initkey(ctx, kbits, blkbits, ivbits, mode, flags,
                                PROV_CIPHER_HW_aes_ocb(kbits), NULL);
@@ -333,7 +333,7 @@ static void *aes_ocb_dupctx(void *vctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_AES_OCB_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -33,7 +33,7 @@ static void *aes_siv_newctx(void *provctx, size_t keybits, unsigned int mode,
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_AES_SIV_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL) {
         ctx->taglen = SIV_LEN;
         ctx->mode = mode;
@@ -63,7 +63,7 @@ static void *siv_dupctx(void *vctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_AES_SIV_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -56,7 +56,7 @@ static void *aes_wrap_newctx(size_t kbits, size_t blkbits,
     if (!ossl_prov_is_running())
         return NULL;
 
-    wctx = OPENSSL_zalloc(sizeof(*wctx));
+    wctx = (PROV_AES_WRAP_CTX *)OPENSSL_zalloc(sizeof(*wctx));
     ctx = (PROV_CIPHER_CTX *)wctx;
     if (ctx != NULL) {
         cipher_generic_initkey(ctx, kbits, blkbits, ivbits, mode, flags,
@@ -150,14 +150,14 @@ static int aes_wrap_cipher_internal(void *vctx, unsigned char *out,
             if (pad)
                 inlen = (inlen + 7) / 8 * 8;
             /* 8 byte prefix */
-            return inlen + 8;
+            return (int)(inlen + 8);
         } else {
             /*
              * If not padding output will be exactly 8 bytes smaller than
              * input. If padding it will be at least 8 bytes smaller but we
              * don't know how much.
              */
-            return inlen - 8;
+            return (int)(inlen - 8);
         }
     }
 

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -111,7 +111,7 @@ static int aes_xts_dinit(void *vctx, const unsigned char *key, size_t keylen,
 static void *aes_xts_newctx(void *provctx, unsigned int mode, uint64_t flags,
                             size_t kbits, size_t blkbits, size_t ivbits)
 {
-    PROV_AES_XTS_CTX *ctx = OPENSSL_zalloc(sizeof(*ctx));
+    PROV_AES_XTS_CTX *ctx = (PROV_AES_XTS_CTX *)OPENSSL_zalloc(sizeof(*ctx));
 
     if (ctx != NULL) {
         cipher_generic_initkey(&ctx->base, kbits, blkbits, ivbits, mode, flags,
@@ -144,7 +144,7 @@ static void *aes_xts_dupctx(void *vctx)
         if (in->xts.key2 != &in->ks2)
             return NULL;
     }
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_AES_XTS_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_aria.c
+++ b/providers/implementations/ciphers/cipher_aria.c
@@ -32,7 +32,7 @@ static void *aria_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_ARIA_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_aria_ccm.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm.c
@@ -22,7 +22,7 @@ static void *aria_ccm_newctx(void *provctx, size_t keybits)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_ARIA_CCM_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         ccm_initctx(&ctx->base, keybits, PROV_ARIA_HW_ccm(keybits));
     return ctx;

--- a/providers/implementations/ciphers/cipher_aria_gcm.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm.c
@@ -20,7 +20,7 @@ static void *aria_gcm_newctx(void *provctx, size_t keybits)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_ARIA_GCM_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         gcm_initctx(provctx, &ctx->base, keybits, PROV_ARIA_HW_gcm(keybits), 4);
     return ctx;

--- a/providers/implementations/ciphers/cipher_blowfish.c
+++ b/providers/implementations/ciphers/cipher_blowfish.c
@@ -40,7 +40,7 @@ static void *blowfish_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_BLOWFISH_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_camellia.c
+++ b/providers/implementations/ciphers/cipher_camellia.c
@@ -38,7 +38,7 @@ static void *camellia_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_CAMELLIA_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_cast5.c
+++ b/providers/implementations/ciphers/cipher_cast5.c
@@ -41,7 +41,7 @@ static void *cast5_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_CAST_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -49,7 +49,7 @@ static void *chacha20_newctx(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_CHACHA20_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         chacha20_initctx(ctx);
     return ctx;

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -38,7 +38,7 @@ static void *des_newctx(void *provctx, size_t kbits, size_t blkbits,
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (PROV_DES_CTX *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         cipher_generic_initkey(ctx, kbits, blkbits, ivbits, mode, flags, hw,
                                provctx);
@@ -53,7 +53,7 @@ static void *des_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_DES_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -113,7 +113,7 @@ static int des_dinit(void *vctx, const unsigned char *key, size_t keylen,
 static int des_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
 {
 
-    DES_cblock *deskey = ptr;
+    DES_cblock *deskey = (DES_cblock *)ptr;
     size_t kl = ctx->keylen;
 
     if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl) <= 0)

--- a/providers/implementations/ciphers/cipher_idea.c
+++ b/providers/implementations/ciphers/cipher_idea.c
@@ -39,7 +39,7 @@ static void *idea_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_IDEA_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -45,7 +45,7 @@ static void *rc2_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_RC2_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -100,7 +100,7 @@ static int rc2_get_ctx_params(void *vctx, OSSL_PARAM params[])
         long num;
         int i;
         ASN1_TYPE *type;
-        unsigned char *d = p->data;
+        unsigned char *d = (unsigned char *)p->data;
         unsigned char **dd = d == NULL ? NULL : &d;
 
         if (p->data_type != OSSL_PARAM_OCTET_STRING) {
@@ -155,7 +155,7 @@ static int rc2_set_ctx_params(void *vctx, OSSL_PARAM params[])
     if (p != NULL) {
         ASN1_TYPE *type = NULL;
         long num = 0;
-        const unsigned char *d = p->data;
+        const unsigned char *d = (const unsigned char *)p->data;
         int ret = 1;
         unsigned char iv[16];
 
@@ -206,7 +206,7 @@ static void * alg##_##kbits##_##lcmode##_newctx(void *provctx)                 \
      PROV_##UCALG##_CTX *ctx;                                                  \
      if (!ossl_prov_is_running())                                               \
         return NULL;                                                           \
-     ctx = OPENSSL_zalloc(sizeof(*ctx));                                       \
+     ctx = (PROV_##UCALG##_CTX *)OPENSSL_zalloc(sizeof(*ctx));                 \
      if (ctx != NULL) {                                                        \
          cipher_generic_initkey(ctx, kbits, blkbits, ivbits,                   \
                                 EVP_CIPH_##UCMODE##_MODE, flags,               \

--- a/providers/implementations/ciphers/cipher_rc4.c
+++ b/providers/implementations/ciphers/cipher_rc4.c
@@ -41,7 +41,7 @@ static void *rc4_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_RC4_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -64,7 +64,7 @@ static void * alg##_##kbits##_newctx(void *provctx)                            \
      PROV_##UCALG##_CTX *ctx;                                                  \
      if (!ossl_prov_is_running())                                               \
         return NULL;                                                           \
-     ctx = OPENSSL_zalloc(sizeof(*ctx));                                       \
+     ctx = (PROV_##UCALG##_CTX *)OPENSSL_zalloc(sizeof(*ctx));                 \
      if (ctx != NULL) {                                                        \
          cipher_generic_initkey(ctx, kbits, blkbits, ivbits, 0, flags,         \
                                 PROV_CIPHER_HW_##alg(kbits), NULL);            \

--- a/providers/implementations/ciphers/cipher_seed.c
+++ b/providers/implementations/ciphers/cipher_seed.c
@@ -38,7 +38,7 @@ static void *seed_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_SEED_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_sm4.c
+++ b/providers/implementations/ciphers/cipher_sm4.c
@@ -32,7 +32,7 @@ static void *sm4_dupctx(void *ctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ret = OPENSSL_malloc(sizeof(*ret));
+    ret = (PROV_SM4_CTX *)OPENSSL_malloc(sizeof(*ret));
     if (ret == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -42,7 +42,7 @@ static int des_ede3_unwrap(PROV_CIPHER_CTX *ctx, unsigned char *out,
     if (inl < 24)
         return -1;
     if (out == NULL)
-        return inl - 16;
+        return (int)(inl - 16);
 
     memcpy(ctx->iv, wrap_iv, 8);
     /* Decrypt first block which will end up as icv */
@@ -70,7 +70,7 @@ static int des_ede3_unwrap(PROV_CIPHER_CTX *ctx, unsigned char *out,
     SHA1(out, inl - 16, sha1tmp);
 
     if (!CRYPTO_memcmp(sha1tmp, icv, 8))
-        rv = inl - 16;
+        rv = (int)(inl - 16);
     OPENSSL_cleanse(icv, 8);
     OPENSSL_cleanse(sha1tmp, SHA_DIGEST_LENGTH);
     OPENSSL_cleanse(iv, 8);
@@ -90,7 +90,7 @@ static int des_ede3_wrap(PROV_CIPHER_CTX *ctx, unsigned char *out,
     size_t len = inl + ivlen + icvlen;
 
     if (out == NULL)
-        return len;
+        return (int)len;
 
     /* Copy input to output buffer + 8 so we have space for IV */
     memmove(out + ivlen, in, inl);
@@ -107,7 +107,7 @@ static int des_ede3_wrap(PROV_CIPHER_CTX *ctx, unsigned char *out,
     BUF_reverse(out, NULL, len);
     memcpy(ctx->iv, wrap_iv, ivlen);
     ctx->hw->cipher(ctx, out, out, len);
-    return len;
+    return (int)len;
 }
 
 static int tdes_wrap_cipher_internal(PROV_CIPHER_CTX *ctx, unsigned char *out,

--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -46,7 +46,7 @@ static int ccm_tls_init(PROV_CCM_CTX *ctx, unsigned char *aad, size_t alen)
     ctx->buf[alen - 1] = (unsigned char)(len & 0xff);
 
     /* Extra padding: tag appended to record. */
-    return ctx->m;
+    return (int)ctx->m;
 }
 
 static int ccm_tls_iv_set_fixed(PROV_CCM_CTX *ctx, unsigned char *fixed,

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -357,7 +357,7 @@ int gcm_cipher(void *vctx,
  */
 static int gcm_iv_generate(PROV_GCM_CTX *ctx, int offset)
 {
-    int sz = ctx->ivlen - offset;
+    int sz = (int)(ctx->ivlen - offset);
 
     /* Must be at least 96 bits */
     if (sz <= 0 || ctx->ivlen < GCM_IV_DEFAULT_SIZE)
@@ -478,7 +478,7 @@ static int gcm_tls_iv_set_fixed(PROV_GCM_CTX *ctx, unsigned char *iv,
     if (len > 0)
         memcpy(ctx->iv, iv, len);
     if (ctx->enc
-        && RAND_bytes_ex(ctx->libctx, ctx->iv + len, ctx->ivlen - len) <= 0)
+        && RAND_bytes_ex(ctx->libctx, ctx->iv + len, (int)(ctx->ivlen - len)) <= 0)
             return 0;
     ctx->iv_gen = 1;
     ctx->iv_state = IV_STATE_BUFFERED;

--- a/providers/implementations/digests/blake2b_prov.c
+++ b/providers/implementations/digests/blake2b_prov.c
@@ -254,7 +254,7 @@ static void blake2b_compress(BLAKE2B_CTX *S,
 /* Absorb the input data into the hash state.  Always returns 1. */
 int blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen)
 {
-    const uint8_t *in = data;
+    const uint8_t *in = (const uint8_t *)data;
     size_t fill;
 
     /*
@@ -304,7 +304,7 @@ int blake2b_final(unsigned char *md, BLAKE2B_CTX *c)
 {
     uint8_t outbuffer[BLAKE2B_OUTBYTES] = {0};
     uint8_t *target = outbuffer;
-    int iter = (c->outlen + 7) / 8;
+    int iter = (int)((c->outlen + 7) / 8);
     int i;
 
     /* Avoid writing to the temporary buffer if possible */

--- a/providers/implementations/digests/blake2s_prov.c
+++ b/providers/implementations/digests/blake2s_prov.c
@@ -245,7 +245,7 @@ static void blake2s_compress(BLAKE2S_CTX *S,
 /* Absorb the input data into the hash state.  Always returns 1. */
 int blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen)
 {
-    const uint8_t *in = data;
+    const uint8_t *in = (const uint8_t *)data;
     size_t fill;
 
     /*
@@ -295,7 +295,7 @@ int blake2s_final(unsigned char *md, BLAKE2S_CTX *c)
 {
     uint8_t outbuffer[BLAKE2S_OUTBYTES] = {0};
     uint8_t *target = outbuffer;
-    int iter = (c->outlen + 3) / 4;
+    int iter = (int)((c->outlen + 3) / 4);
     int i;
 
     /* Avoid writing to the temporary buffer if possible */

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -56,7 +56,7 @@ static int keccak_init(void *vctx)
 
 static int keccak_update(void *vctx, const unsigned char *inp, size_t len)
 {
-    KECCAK1600_CTX *ctx = vctx;
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)vctx;
     const size_t bsz = ctx->block_size;
     size_t num, rem;
 
@@ -95,7 +95,7 @@ static int keccak_final(void *vctx, unsigned char *out, size_t *outl,
                         size_t outsz)
 {
     int ret = 1;
-    KECCAK1600_CTX *ctx = vctx;
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)vctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -111,7 +111,7 @@ static int keccak_final(void *vctx, unsigned char *out, size_t *outl,
  */
 static size_t generic_sha3_absorb(void *vctx, const void *inp, size_t len)
 {
-    KECCAK1600_CTX *ctx = vctx;
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)vctx;
 
     return SHA3_absorb(ctx->A, inp, len, ctx->block_size);
 }
@@ -193,8 +193,8 @@ static PROV_SHA3_METHOD shake_s390x_md =
 static OSSL_FUNC_digest_newctx_fn name##_newctx;                               \
 static void *name##_newctx(void *provctx)                                      \
 {                                                                              \
-    KECCAK1600_CTX *ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) \
-                                                : NULL;                        \
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)(ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) \
+                                                : NULL);                        \
                                                                                \
     if (ctx == NULL)                                                           \
         return NULL;                                                           \
@@ -207,8 +207,8 @@ static void *name##_newctx(void *provctx)                                      \
 static OSSL_FUNC_digest_newctx_fn uname##_newctx;                              \
 static void *uname##_newctx(void *provctx)                                     \
 {                                                                              \
-    KECCAK1600_CTX *ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) \
-                                                : NULL;                        \
+    KECCAK1600_CTX *ctx = (KECCAK1600_CTX *)(ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) \
+                                                : NULL);                        \
                                                                                \
     if (ctx == NULL)                                                           \
         return NULL;                                                           \
@@ -249,8 +249,8 @@ static void keccak_freectx(void *vctx)
 static void *keccak_dupctx(void *ctx)
 {
     KECCAK1600_CTX *in = (KECCAK1600_CTX *)ctx;
-    KECCAK1600_CTX *ret = ossl_prov_is_running() ? OPENSSL_malloc(sizeof(*ret))
-                                                : NULL;
+    KECCAK1600_CTX *ret = (KECCAK1600_CTX *)(ossl_prov_is_running() ? OPENSSL_malloc(sizeof(*ret))
+                                                : NULL);
 
     if (ret != NULL)
         *ret = *in;

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -83,7 +83,7 @@ static void *dh_newctx(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    pdhctx = OPENSSL_zalloc(sizeof(PROV_DH_CTX));
+    pdhctx = (PROV_DH_CTX *)OPENSSL_zalloc(sizeof(PROV_DH_CTX));
     if (pdhctx == NULL)
         return NULL;
     pdhctx->libctx = PROV_LIBRARY_CONTEXT_OF(provctx);
@@ -98,7 +98,7 @@ static int dh_init(void *vpdhctx, void *vdh)
     if (!ossl_prov_is_running()
             || pdhctx == NULL
             || vdh == NULL
-            || !DH_up_ref(vdh))
+            || !DH_up_ref((DH *)vdh))
         return 0;
     DH_free(pdhctx->dh);
     pdhctx->dh = vdh;
@@ -113,10 +113,10 @@ static int dh_set_peer(void *vpdhctx, void *vdh)
     if (!ossl_prov_is_running()
             || pdhctx == NULL
             || vdh == NULL
-            || !DH_up_ref(vdh))
+            || !DH_up_ref((DH *)vdh))
         return 0;
     DH_free(pdhctx->dhpeer);
-    pdhctx->dhpeer = vdh;
+    pdhctx->dhpeer = (DH *)vdh;
     return 1;
 }
 
@@ -236,7 +236,7 @@ static void *dh_dupctx(void *vpdhctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_DH_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
 

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -85,7 +85,7 @@ void *ecdh_newctx(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    pectx = OPENSSL_zalloc(sizeof(*pectx));
+    pectx = (PROV_ECDH_CTX *)OPENSSL_zalloc(sizeof(*pectx));
     if (pectx == NULL)
         return NULL;
 
@@ -104,10 +104,10 @@ int ecdh_init(void *vpecdhctx, void *vecdh)
     if (!ossl_prov_is_running()
             || pecdhctx == NULL
             || vecdh == NULL
-            || !EC_KEY_up_ref(vecdh))
+            || !EC_KEY_up_ref((EC_KEY *)vecdh))
         return 0;
     EC_KEY_free(pecdhctx->k);
-    pecdhctx->k = vecdh;
+    pecdhctx->k = (EC_KEY *)vecdh;
     pecdhctx->cofactor_mode = -1;
     pecdhctx->kdf_type = PROV_ECDH_KDF_NONE;
     return 1;
@@ -121,10 +121,10 @@ int ecdh_set_peer(void *vpecdhctx, void *vecdh)
     if (!ossl_prov_is_running()
             || pecdhctx == NULL
             || vecdh == NULL
-            || !EC_KEY_up_ref(vecdh))
+            || !EC_KEY_up_ref((EC_KEY *)vecdh))
         return 0;
     EC_KEY_free(pecdhctx->peerk);
-    pecdhctx->peerk = vecdh;
+    pecdhctx->peerk = (EC_KEY *)vecdh;
     return 1;
 }
 
@@ -151,7 +151,7 @@ void *ecdh_dupctx(void *vpecdhctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_ECDH_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
 
@@ -490,7 +490,7 @@ int ecdh_X9_63_kdf_derive(void *vpecdhctx, unsigned char *secret,
         return 0;
     if (!ecdh_plain_derive(vpecdhctx, NULL, &stmplen, 0))
         return 0;
-    if ((stmp = OPENSSL_secure_malloc(stmplen)) == NULL) {
+    if ((stmp = (unsigned char *)OPENSSL_secure_malloc(stmplen)) == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/providers/implementations/exchange/ecx_exch.c
+++ b/providers/implementations/exchange/ecx_exch.c
@@ -48,7 +48,7 @@ static void *ecx_newctx(void *provctx, size_t keylen)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(PROV_ECX_CTX));
+    ctx = (PROV_ECX_CTX *)OPENSSL_zalloc(sizeof(PROV_ECX_CTX));
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -72,7 +72,7 @@ static void *x448_newctx(void *provctx)
 static int ecx_init(void *vecxctx, void *vkey)
 {
     PROV_ECX_CTX *ecxctx = (PROV_ECX_CTX *)vecxctx;
-    ECX_KEY *key = vkey;
+    ECX_KEY *key = (ECX_KEY *)vkey;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -94,7 +94,7 @@ static int ecx_init(void *vecxctx, void *vkey)
 static int ecx_set_peer(void *vecxctx, void *vkey)
 {
     PROV_ECX_CTX *ecxctx = (PROV_ECX_CTX *)vecxctx;
-    ECX_KEY *key = vkey;
+    ECX_KEY *key = (ECX_KEY *)vkey;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -196,7 +196,7 @@ static void *ecx_dupctx(void *vecxctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_ECX_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -172,17 +172,17 @@ const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
 
 #define IMPLEMENT_generic_cipher_genfn(alg, UCALG, lcmode, UCMODE, flags,      \
                                        kbits, blkbits, ivbits, typ)            \
-static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lcmode##_get_params;     \
+static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lcmode##_get_params;   \
 static int alg##_##kbits##_##lcmode##_get_params(OSSL_PARAM params[])          \
 {                                                                              \
     return cipher_generic_get_params(params, EVP_CIPH_##UCMODE##_MODE, flags,  \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
-static OSSL_FUNC_cipher_newctx_fn alg##_##kbits##_##lcmode##_newctx;             \
+static OSSL_FUNC_cipher_newctx_fn alg##_##kbits##_##lcmode##_newctx;           \
 static void * alg##_##kbits##_##lcmode##_newctx(void *provctx)                 \
 {                                                                              \
-     PROV_##UCALG##_CTX *ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx))\
-                                                     : NULL;                   \
+     PROV_##UCALG##_CTX *ctx = (PROV_##UCALG##_CTX *)(ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx))\
+                                                     : NULL);                   \
      if (ctx != NULL) {                                                        \
          cipher_generic_initkey(ctx, kbits, blkbits, ivbits,                   \
                                 EVP_CIPH_##UCMODE##_MODE, flags,               \

--- a/providers/implementations/include/prov/digestcommon.h
+++ b/providers/implementations/include/prov/digestcommon.h
@@ -38,7 +38,7 @@ static OSSL_FUNC_digest_freectx_fn name##_freectx;                              
 static OSSL_FUNC_digest_dupctx_fn name##_dupctx;                                 \
 static void *name##_newctx(void *prov_ctx)                                     \
 {                                                                              \
-    CTX *ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) : NULL;    \
+    CTX *ctx = (CTX *)(ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) : NULL);    \
     return ctx;                                                                \
 }                                                                              \
 static void name##_freectx(void *vctx)                                         \

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -74,7 +74,7 @@ static void *kdf_hkdf_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
+    if ((ctx = (KDF_HKDF *)OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
     else
         ctx->provctx = provctx;
@@ -163,7 +163,7 @@ static int kdf_hkdf_derive(void *vctx, unsigned char *key, size_t keylen)
 static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KDF_HKDF *ctx = vctx;
+    KDF_HKDF *ctx = (KDF_HKDF *)vctx;
     OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     int n;
 
@@ -444,7 +444,7 @@ static int HKDF_Expand(const EVP_MD *evp_md,
 
     for (i = 1; i <= n; i++) {
         size_t copy_len;
-        const unsigned char ctr = i;
+        const unsigned char ctr = (const unsigned char)i;
 
         /* calc: T(i) = HMAC-Hash(PRK, T(i - 1) | info | i) */
         if (i > 1) {

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -103,7 +103,7 @@ static void *kbkdf_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (KBKDF *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -220,7 +220,7 @@ static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen)
         goto done;
     }
 
-    k_i = OPENSSL_zalloc(h);
+    k_i = (unsigned char *)OPENSSL_zalloc(h);
     if (k_i == NULL)
         goto done;
 

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -63,7 +63,7 @@ static void *krb5kdf_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
+    if ((ctx = (KRB5KDF_CTX *)OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
     ctx->provctx = provctx;
     return ctx;
@@ -131,7 +131,7 @@ static int krb5kdf_derive(void *vctx, unsigned char *key,
 static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KRB5KDF_CTX *ctx = vctx;
+    KRB5KDF_CTX *ctx = (KRB5KDF_CTX *)vctx;
     OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
 
     if (!ossl_prov_cipher_load_from_params(&ctx->cipher, params, provctx))
@@ -267,7 +267,7 @@ static void n_fold(unsigned char *block, unsigned int blocksize,
 
     /* Least Common Multiple of lengths: LCM(a,b)*/
     gcd = blocksize;
-    remainder = constant_len;
+    remainder = (unsigned int)constant_len;
     /* Calculate Great Common Divisor first GCD(a,b) */
     while (remainder != 0) {
         tmp = gcd % remainder;
@@ -275,7 +275,7 @@ static void n_fold(unsigned char *block, unsigned int blocksize,
         remainder = tmp;
     }
     /* resulting a is the GCD, LCM(a,b) = |a*b|/GCD(a,b) */
-    lcm = blocksize * constant_len / gcd;
+    lcm = (unsigned int)(blocksize * constant_len / gcd);
 
     /* now spread out the bits */
     memset(block, 0, blocksize);
@@ -289,7 +289,7 @@ static void n_fold(unsigned char *block, unsigned int blocksize,
         b = l % blocksize;
         /* Our virtual s buffer is R = L/K long (K = constant_len) */
         /* So we rotate backwards from R-1 to 0 (none) rotations */
-        rotbits = 13 * (l / constant_len);
+        rotbits = (unsigned int)(13 * (l / constant_len));
         /* find the byte on s where rotbits falls onto */
         rbyte = l - (rotbits / 8);
         /* calculate how much shift on that byte */

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -70,7 +70,7 @@ static void *kdf_pbkdf2_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (KDF_PBKDF2 *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -127,7 +127,7 @@ static int pbkdf2_set_membuf(unsigned char **buffer, size_t *buflen,
 {
     OPENSSL_clear_free(*buffer, *buflen);
     if (p->data_size == 0) {
-        if ((*buffer = OPENSSL_malloc(1)) == NULL) {
+        if ((*buffer = (unsigned char *)OPENSSL_malloc(1)) == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -167,7 +167,7 @@ static int kdf_pbkdf2_derive(void *vctx, unsigned char *key,
 static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KDF_PBKDF2 *ctx = vctx;
+    KDF_PBKDF2 *ctx = (KDF_PBKDF2 *)vctx;
     OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     int pkcs5;
     uint64_t iter, min_iter;
@@ -308,7 +308,7 @@ static int pbkdf2_derive(const char *pass, size_t passlen,
     if (hctx_tpl == NULL)
         return 0;
     p = key;
-    tkeylen = keylen;
+    tkeylen = (int)keylen;
     if (!HMAC_Init_ex(hctx_tpl, pass, passlen, digest, NULL))
         goto err;
     hctx = HMAC_CTX_new();

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -60,7 +60,7 @@ static void *kdf_scrypt_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (KDF_SCRYPT *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -114,7 +114,7 @@ static int scrypt_set_membuf(unsigned char **buffer, size_t *buflen,
 {
     OPENSSL_clear_free(*buffer, *buflen);
     if (p->data_size == 0) {
-        if ((*buffer = OPENSSL_malloc(1)) == NULL) {
+        if ((*buffer = (unsigned char *)OPENSSL_malloc(1)) == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -158,7 +158,7 @@ static int is_power_of_two(uint64_t value)
 static int kdf_scrypt_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KDF_SCRYPT *ctx = vctx;
+    KDF_SCRYPT *ctx = (KDF_SCRYPT *)vctx;
     uint64_t u64_value;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_PASSWORD)) != NULL)
@@ -447,7 +447,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
     if (key == NULL)
         return 1;
 
-    B = OPENSSL_malloc((size_t)(Blen + Vlen));
+    B = (unsigned char *)OPENSSL_malloc((size_t)(Blen + Vlen));
     if (B == NULL) {
         EVPerr(EVP_F_SCRYPT_ALG, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -57,7 +57,7 @@ static void *kdf_sshkdf_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
+    if ((ctx = (KDF_SSHKDF *)OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
     ctx->provctx = provctx;
     return ctx;
@@ -133,7 +133,7 @@ static int kdf_sshkdf_derive(void *vctx, unsigned char *key,
 static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KDF_SSHKDF *ctx = vctx;
+    KDF_SSHKDF *ctx = (KDF_SSHKDF *)vctx;
     OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     int t;
 

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -195,7 +195,7 @@ static int kmac_init(EVP_MAC_CTX *ctx, const unsigned char *custom,
      * alloc a buffer for this case.
      */
     if (kmac_out_len > EVP_MAX_MD_SIZE) {
-        *out = OPENSSL_zalloc(kmac_out_len);
+        *out = (unsigned char *)OPENSSL_zalloc(kmac_out_len);
         if (*out == NULL)
             return 0;
     }
@@ -297,7 +297,7 @@ static void *sskdf_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
+    if ((ctx = (KDF_SSKDF *)OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
     ctx->provctx = provctx;
     return ctx;
@@ -400,7 +400,7 @@ static int sskdf_derive(void *vctx, unsigned char *key, size_t keylen)
         }
         /* If no salt is set then use a default_salt of zeros */
         if (ctx->salt == NULL || ctx->salt_len <= 0) {
-            ctx->salt = OPENSSL_zalloc(default_salt_len);
+            ctx->salt = (unsigned char *)OPENSSL_zalloc(default_salt_len);
             if (ctx->salt == NULL) {
                 ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
                 return 0;
@@ -456,7 +456,7 @@ static int x963kdf_derive(void *vctx, unsigned char *key, size_t keylen)
 static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KDF_SSKDF *ctx = vctx;
+    KDF_SSKDF *ctx = (KDF_SSKDF *)vctx;
     OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     size_t sz;
 

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -102,7 +102,7 @@ static void *kdf_tls1_prf_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
+    if ((ctx = (TLS1_PRF *)OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
     ctx->provctx = provctx;
     return ctx;
@@ -161,7 +161,7 @@ static int kdf_tls1_prf_derive(void *vctx, unsigned char *key,
 static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    TLS1_PRF *ctx = vctx;
+    TLS1_PRF *ctx = (TLS1_PRF *)vctx;
     OPENSSL_CTX *libctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL) {
@@ -382,7 +382,7 @@ static int tls1_prf_alg(EVP_MAC_CTX *mdctx, EVP_MAC_CTX *sha1ctx,
                              seed, seed_len, out, olen))
             return 0;
 
-        if ((tmp = OPENSSL_malloc(olen)) == NULL) {
+        if ((tmp = (unsigned char *)OPENSSL_malloc(olen)) == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             return 0;
         }

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -280,7 +280,7 @@ static void *x942kdf_new(void *provctx)
     if (!ossl_prov_is_running())
         return 0;
 
-    if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
+    if ((ctx = (KDF_X942 *)OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
     ctx->provctx = provctx;
     return ctx;
@@ -382,7 +382,7 @@ static int x942kdf_derive(void *vctx, unsigned char *key, size_t keylen)
 static int x942kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *p;
-    KDF_X942 *ctx = vctx;
+    KDF_X942 *ctx = (KDF_X942 *)vctx;
     OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(ctx->provctx);
     size_t id;
 

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -159,12 +159,12 @@ static void *dhx_newdata(void *provctx)
 
 static void dh_freedata(void *keydata)
 {
-    DH_free(keydata);
+    DH_free((DH *)keydata);
 }
 
 static int dh_has(void *keydata, int selection)
 {
-    DH *dh = keydata;
+    DH *dh = (DH *)keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && dh != NULL) {
@@ -183,8 +183,8 @@ static int dh_has(void *keydata, int selection)
 
 static int dh_match(const void *keydata1, const void *keydata2, int selection)
 {
-    const DH *dh1 = keydata1;
-    const DH *dh2 = keydata2;
+    const DH *dh1 = (const DH *)keydata1;
+    const DH *dh2 = (const DH *)keydata2;
     int ok = 1;
 
     if (!ossl_prov_is_running())
@@ -205,7 +205,7 @@ static int dh_match(const void *keydata1, const void *keydata2, int selection)
 
 static int dh_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
-    DH *dh = keydata;
+    DH *dh = (DH *)keydata;
     int ok = 1;
 
     if (!ossl_prov_is_running() || dh == NULL)
@@ -226,7 +226,7 @@ static int dh_import(void *keydata, int selection, const OSSL_PARAM params[])
 static int dh_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
                      void *cbarg)
 {
-    DH *dh = keydata;
+    DH *dh = (DH *)keydata;
     OSSL_PARAM_BLD *tmpl = NULL;
     OSSL_PARAM *params = NULL;
     int ok = 1;
@@ -316,7 +316,7 @@ static const OSSL_PARAM *dh_export_types(int selection)
 
 static ossl_inline int dh_get_params(void *key, OSSL_PARAM params[])
 {
-    DH *dh = key;
+    DH *dh = (DH *)key;
     OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS)) != NULL
@@ -369,7 +369,7 @@ static const OSSL_PARAM *dh_settable_params(void *provctx)
 
 static int dh_set_params(void *key, const OSSL_PARAM params[])
 {
-    DH *dh = key;
+    DH *dh = (DH *)key;
     const OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_TLS_ENCODED_PT);
@@ -404,7 +404,7 @@ static int dh_validate_private(DH *dh)
 
 static int dh_validate(void *keydata, int selection)
 {
-    DH *dh = keydata;
+    DH *dh = (DH *)keydata;
     int ok = 0;
 
     if (!ossl_prov_is_running())
@@ -469,7 +469,7 @@ static void *dhx_gen_init(void *provctx, int selection)
 static int dh_gen_set_template(void *genctx, void *templ)
 {
     struct dh_gen_ctx *gctx = genctx;
-    DH *dh = templ;
+    DH *dh = (DH *)templ;
 
     if (!ossl_prov_is_running() || gctx == NULL || dh == NULL)
         return 0;
@@ -494,7 +494,7 @@ static int dh_set_gen_seed(struct dh_gen_ctx *gctx, unsigned char *seed,
 
 static int dh_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
-    struct dh_gen_ctx *gctx = genctx;
+    struct dh_gen_ctx *gctx = (struct dh_gen_ctx *)genctx;
     const OSSL_PARAM *p;
 
     if (gctx == NULL)
@@ -593,7 +593,7 @@ static int dh_gencb(int p, int n, BN_GENCB *cb)
 static void *dh_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
     int ret = 0;
-    struct dh_gen_ctx *gctx = genctx;
+    struct dh_gen_ctx *gctx = (struct dh_gen_ctx *)genctx;
     DH *dh = NULL;
     BN_GENCB *gencb = NULL;
     FFC_PARAMS *ffc;
@@ -684,7 +684,7 @@ end:
 
 static void dh_gen_cleanup(void *genctx)
 {
-    struct dh_gen_ctx *gctx = genctx;
+    struct dh_gen_ctx *gctx = (struct dh_gen_ctx *)genctx;
 
     if (gctx == NULL)
         return;

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -118,12 +118,12 @@ static void *dsa_newdata(void *provctx)
 
 static void dsa_freedata(void *keydata)
 {
-    DSA_free(keydata);
+    DSA_free((DSA *)keydata);
 }
 
 static int dsa_has(void *keydata, int selection)
 {
-    DSA *dsa = keydata;
+    DSA *dsa = (DSA *)keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && dsa != NULL) {
@@ -142,8 +142,8 @@ static int dsa_has(void *keydata, int selection)
 
 static int dsa_match(const void *keydata1, const void *keydata2, int selection)
 {
-    const DSA *dsa1 = keydata1;
-    const DSA *dsa2 = keydata2;
+    const DSA *dsa1 = (const DSA *)keydata1;
+    const DSA *dsa2 = (const DSA *)keydata2;
     int ok = 1;
 
     if (!ossl_prov_is_running())
@@ -166,7 +166,7 @@ static int dsa_match(const void *keydata1, const void *keydata2, int selection)
 
 static int dsa_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
-    DSA *dsa = keydata;
+    DSA *dsa = (DSA *)keydata;
     int ok = 1;
 
     if (!ossl_prov_is_running() || dsa == NULL)
@@ -186,7 +186,7 @@ static int dsa_import(void *keydata, int selection, const OSSL_PARAM params[])
 static int dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
                       void *cbarg)
 {
-    DSA *dsa = keydata;
+    DSA *dsa = (DSA *)keydata;
     OSSL_PARAM_BLD *tmpl = OSSL_PARAM_BLD_new();
     OSSL_PARAM *params = NULL;
     int ok = 1;
@@ -270,7 +270,7 @@ static const OSSL_PARAM *dsa_export_types(int selection)
 
 static ossl_inline int dsa_get_params(void *key, OSSL_PARAM params[])
 {
-    DSA *dsa = key;
+    DSA *dsa = (DSA *)key;
     OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS)) != NULL
@@ -336,7 +336,7 @@ static int dsa_validate_private(DSA *dsa)
 
 static int dsa_validate(void *keydata, int selection)
 {
-    DSA *dsa = keydata;
+    DSA *dsa = (DSA *)keydata;
     int ok = 0;
 
     if (!ossl_prov_is_running())
@@ -384,7 +384,7 @@ static void *dsa_gen_init(void *provctx, int selection)
 
 static int dsa_gen_set_template(void *genctx, void *templ)
 {
-    struct dsa_gen_ctx *gctx = genctx;
+    struct dsa_gen_ctx *gctx = (struct dsa_gen_ctx *)genctx;
     DSA *dsa = templ;
 
     if (!ossl_prov_is_running() || gctx == NULL || dsa == NULL)
@@ -410,7 +410,7 @@ static int dsa_set_gen_seed(struct dsa_gen_ctx *gctx, unsigned char *seed,
 
 static int dsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
-    struct dsa_gen_ctx *gctx = genctx;
+    struct dsa_gen_ctx *gctx = (struct dsa_gen_ctx *)genctx;
     const OSSL_PARAM *p;
 
     if (gctx == NULL)
@@ -492,7 +492,7 @@ static int dsa_gencb(int p, int n, BN_GENCB *cb)
 
 static void *dsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct dsa_gen_ctx *gctx = genctx;
+    struct dsa_gen_ctx *gctx = (struct dsa_gen_ctx *)genctx;
     DSA *dsa = NULL;
     BN_GENCB *gencb = NULL;
     int ret = 0;
@@ -559,7 +559,7 @@ end:
 
 static void dsa_gen_cleanup(void *genctx)
 {
-    struct dsa_gen_ctx *gctx = genctx;
+    struct dsa_gen_ctx *gctx = (struct dsa_gen_ctx *)genctx;
 
     if (gctx == NULL)
         return;

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -220,13 +220,13 @@ void *ec_newdata(void *provctx)
 static
 void ec_freedata(void *keydata)
 {
-    EC_KEY_free(keydata);
+    EC_KEY_free((EC_KEY *)keydata);
 }
 
 static
 int ec_has(void *keydata, int selection)
 {
-    EC_KEY *ec = keydata;
+    EC_KEY *ec = (EC_KEY *)keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && ec != NULL) {
@@ -250,8 +250,8 @@ int ec_has(void *keydata, int selection)
 
 static int ec_match(const void *keydata1, const void *keydata2, int selection)
 {
-    const EC_KEY *ec1 = keydata1;
-    const EC_KEY *ec2 = keydata2;
+    const EC_KEY *ec1 = (const EC_KEY *)keydata1;
+    const EC_KEY *ec2 = (const EC_KEY *)keydata2;
     const EC_GROUP *group_a = EC_KEY_get0_group(ec1);
     const EC_GROUP *group_b = EC_KEY_get0_group(ec2);
     BN_CTX *ctx = BN_CTX_new_ex(ec_key_get_libctx(ec1));
@@ -282,7 +282,7 @@ static int ec_match(const void *keydata1, const void *keydata2, int selection)
 static
 int ec_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
-    EC_KEY *ec = keydata;
+    EC_KEY *ec = (EC_KEY *)keydata;
     int ok = 1;
 
     if (!ossl_prov_is_running() || ec == NULL)
@@ -325,7 +325,7 @@ static
 int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
               void *cbarg)
 {
-    EC_KEY *ec = keydata;
+    EC_KEY *ec = (EC_KEY *)keydata;
     OSSL_PARAM_BLD *tmpl = NULL;
     OSSL_PARAM *params = NULL;
     unsigned char *pub_key = NULL, *genbuf = NULL;
@@ -659,7 +659,7 @@ const OSSL_PARAM *ec_settable_params(void *provctx)
 static
 int ec_set_params(void *key, const OSSL_PARAM params[])
 {
-    EC_KEY *eck = key;
+    EC_KEY *eck = (EC_KEY *)key;
     const OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_TLS_ENCODED_PT);
@@ -682,7 +682,7 @@ int ec_set_params(void *key, const OSSL_PARAM params[])
 static
 int ec_validate(void *keydata, int selection)
 {
-    EC_KEY *eck = keydata;
+    EC_KEY *eck = (EC_KEY *)keydata;
     int ok = 0;
     BN_CTX *ctx = BN_CTX_new_ex(ec_key_get_libctx(eck));
 
@@ -739,7 +739,7 @@ static void *ec_gen_init(void *provctx, int selection)
 
 static int ec_gen_set_group(void *genctx, const EC_GROUP *src)
 {
-    struct ec_gen_ctx *gctx = genctx;
+    struct ec_gen_ctx *gctx = (struct ec_gen_ctx *)genctx;
     EC_GROUP *group;
 
     group = EC_GROUP_dup(src);
@@ -754,7 +754,7 @@ static int ec_gen_set_group(void *genctx, const EC_GROUP *src)
 
 static int ec_gen_set_template(void *genctx, void *templ)
 {
-    struct ec_gen_ctx *gctx = genctx;
+    struct ec_gen_ctx *gctx = (struct ec_gen_ctx *)genctx;
     EC_KEY *ec = templ;
     const EC_GROUP *ec_group;
 
@@ -936,7 +936,7 @@ static int ec_gen_assign_group(EC_KEY *ec, EC_GROUP *group)
  */
 static void *ec_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct ec_gen_ctx *gctx = genctx;
+    struct ec_gen_ctx *gctx = (struct ec_gen_ctx *)genctx;
     EC_KEY *ec = NULL;
     int ret = 0;
 
@@ -977,7 +977,7 @@ err:
 
 static void ec_gen_cleanup(void *genctx)
 {
-    struct ec_gen_ctx *gctx = genctx;
+    struct ec_gen_ctx *gctx = (struct ec_gen_ctx *)genctx;
 
     if (gctx == NULL)
         return;

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -110,7 +110,7 @@ static void *ed448_new_key(void *provctx)
 
 static int ecx_has(void *keydata, int selection)
 {
-    ECX_KEY *key = keydata;
+    ECX_KEY *key = (ECX_KEY *)keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && key != NULL) {
@@ -131,8 +131,8 @@ static int ecx_has(void *keydata, int selection)
 
 static int ecx_match(const void *keydata1, const void *keydata2, int selection)
 {
-    const ECX_KEY *key1 = keydata1;
-    const ECX_KEY *key2 = keydata2;
+    const ECX_KEY *key1 = (const ECX_KEY *)keydata1;
+    const ECX_KEY *key2 = (const ECX_KEY *)keydata2;
     int ok = 1;
 
     if (!ossl_prov_is_running())
@@ -164,7 +164,7 @@ static int ecx_match(const void *keydata1, const void *keydata2, int selection)
 
 static int ecx_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
-    ECX_KEY *key = keydata;
+    ECX_KEY *key = (ECX_KEY *)keydata;
     int ok = 1;
     int include_private = 0;
 
@@ -203,7 +203,7 @@ static int key_to_params(ECX_KEY *key, OSSL_PARAM_BLD *tmpl,
 static int ecx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
                       void *cbarg)
 {
-    ECX_KEY *key = keydata;
+    ECX_KEY *key = (ECX_KEY *)keydata;
     OSSL_PARAM_BLD *tmpl;
     OSSL_PARAM *params = NULL;
     int ret = 0;
@@ -248,7 +248,7 @@ static const OSSL_PARAM *ecx_imexport_types(int selection)
 static int ecx_get_params(void *key, OSSL_PARAM params[], int bits, int secbits,
                           int size)
 {
-    ECX_KEY *ecx = key;
+    ECX_KEY *ecx = (ECX_KEY *)key;
     OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_BITS)) != NULL
@@ -347,7 +347,7 @@ static const OSSL_PARAM *ed448_gettable_params(void *provctx)
 
 static int ecx_set_params(void *key, const OSSL_PARAM params[])
 {
-    ECX_KEY *ecxkey = key;
+    ECX_KEY *ecxkey = (ECX_KEY *)key;
     const OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_TLS_ENCODED_PT);
@@ -453,7 +453,7 @@ static void *ed448_gen_init(void *provctx, int selection)
 
 static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
-    struct ecx_gen_ctx *gctx = genctx;
+    struct ecx_gen_ctx *gctx = (struct ecx_gen_ctx *)genctx;
     const OSSL_PARAM *p;
 
     if (gctx == NULL)
@@ -551,7 +551,7 @@ err:
 
 static void *x25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct ecx_gen_ctx *gctx = genctx;
+    struct ecx_gen_ctx *gctx = (struct ecx_gen_ctx *)genctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -565,7 +565,7 @@ static void *x25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
 static void *x448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct ecx_gen_ctx *gctx = genctx;
+    struct ecx_gen_ctx *gctx = (struct ecx_gen_ctx *)genctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -579,7 +579,7 @@ static void *x448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
 static void *ed25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct ecx_gen_ctx *gctx = genctx;
+    struct ecx_gen_ctx *gctx = (struct ecx_gen_ctx *)genctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -596,7 +596,7 @@ static void *ed25519_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
 static void *ed448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct ecx_gen_ctx *gctx = genctx;
+    struct ecx_gen_ctx *gctx = (struct ecx_gen_ctx *)genctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -612,7 +612,7 @@ static void *ed448_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
 static void ecx_gen_cleanup(void *genctx)
 {
-    struct ecx_gen_ctx *gctx = genctx;
+    struct ecx_gen_ctx *gctx = (struct ecx_gen_ctx *)genctx;
 
     OPENSSL_free(gctx);
 }

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -105,12 +105,12 @@ static void *rsapss_newdata(void *provctx)
 
 static void rsa_freedata(void *keydata)
 {
-    RSA_free(keydata);
+    RSA_free((RSA *)keydata);
 }
 
 static int rsa_has(void *keydata, int selection)
 {
-    RSA *rsa = keydata;
+    RSA *rsa = (RSA *)keydata;
     int ok = 0;
 
     if (rsa != NULL && ossl_prov_is_running()) {
@@ -132,8 +132,8 @@ static int rsa_has(void *keydata, int selection)
 
 static int rsa_match(const void *keydata1, const void *keydata2, int selection)
 {
-    const RSA *rsa1 = keydata1;
-    const RSA *rsa2 = keydata2;
+    const RSA *rsa1 = (const RSA *)keydata1;
+    const RSA *rsa2 = (const RSA *)keydata2;
     int ok = 1;
 
     if (!ossl_prov_is_running())
@@ -150,7 +150,7 @@ static int rsa_match(const void *keydata1, const void *keydata2, int selection)
 
 static int rsa_import(void *keydata, int selection, const OSSL_PARAM params[])
 {
-    RSA *rsa = keydata;
+    RSA *rsa = (RSA *)keydata;
     int rsa_type;
     int ok = 1;
 
@@ -176,7 +176,7 @@ static int rsa_import(void *keydata, int selection, const OSSL_PARAM params[])
 static int rsa_export(void *keydata, int selection,
                       OSSL_CALLBACK *param_callback, void *cbarg)
 {
-    RSA *rsa = keydata;
+    RSA *rsa = (RSA *)keydata;
     const RSA_PSS_PARAMS_30 *pss_params = rsa_get0_pss_params_30(rsa);
     OSSL_PARAM_BLD *tmpl;
     OSSL_PARAM *params = NULL;
@@ -296,7 +296,7 @@ static const OSSL_PARAM *rsa_export_types(int selection)
 
 static int rsa_get_params(void *key, OSSL_PARAM params[])
 {
-    RSA *rsa = key;
+    RSA *rsa = (RSA *)key;
     const RSA_PSS_PARAMS_30 *pss_params = rsa_get0_pss_params_30(rsa);
     int rsa_type = RSA_test_flags(rsa, RSA_FLAG_TYPE_MASK);
     OSSL_PARAM *p;
@@ -359,7 +359,7 @@ static const OSSL_PARAM *rsa_gettable_params(void *provctx)
 
 static int rsa_validate(void *keydata, int selection)
 {
-    RSA *rsa = keydata;
+    RSA *rsa = (RSA *)keydata;
     int ok = 0;
 
     if (!ossl_prov_is_running())
@@ -405,7 +405,7 @@ struct rsa_gen_ctx {
 
 static int rsa_gencb(int p, int n, BN_GENCB *cb)
 {
-    struct rsa_gen_ctx *gctx = BN_GENCB_get_arg(cb);
+    struct rsa_gen_ctx *gctx = (struct rsa_gen_ctx *)BN_GENCB_get_arg(cb);
     OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_int(OSSL_GEN_PARAM_POTENTIAL, &p);
@@ -424,7 +424,7 @@ static void *gen_init(void *provctx, int selection, int rsa_type)
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
         return NULL;
 
-    if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL) {
+    if ((gctx = (struct rsa_gen_ctx *)OPENSSL_zalloc(sizeof(*gctx))) != NULL) {
         gctx->libctx = libctx;
         if ((gctx->pub_exp = BN_new()) == NULL
             || !BN_set_word(gctx->pub_exp, RSA_F4)) {
@@ -457,7 +457,7 @@ static void *rsapss_gen_init(void *provctx, int selection)
  */
 static int rsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
-    struct rsa_gen_ctx *gctx = genctx;
+    struct rsa_gen_ctx *gctx = (struct rsa_gen_ctx *)genctx;
     const OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_RSA_BITS)) != NULL
@@ -520,7 +520,7 @@ static const OSSL_PARAM *rsapss_gen_settable_params(void *provctx)
 
 static void *rsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
-    struct rsa_gen_ctx *gctx = genctx;
+    struct rsa_gen_ctx *gctx = (struct rsa_gen_ctx *)genctx;
     RSA *rsa = NULL, *rsa_tmp = NULL;
     BN_GENCB *gencb = NULL;
 
@@ -582,7 +582,7 @@ static void *rsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
 static void rsa_gen_cleanup(void *genctx)
 {
-    struct rsa_gen_ctx *gctx = genctx;
+    struct rsa_gen_ctx *gctx = (struct rsa_gen_ctx *)genctx;
 
     if (gctx == NULL)
         return;

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -48,7 +48,7 @@ static void *blake2_mac_new(void *unused_provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    macctx = OPENSSL_zalloc(sizeof(*macctx));
+    macctx = (struct blake2_mac_data_st *)OPENSSL_zalloc(sizeof(*macctx));
     if (macctx != NULL) {
         BLAKE2_PARAM_INIT(&macctx->params);
         /* ctx initialization is deferred to BLAKE2b_Init() */
@@ -59,12 +59,12 @@ static void *blake2_mac_new(void *unused_provctx)
 static void *blake2_mac_dup(void *vsrc)
 {
     struct blake2_mac_data_st *dst;
-    struct blake2_mac_data_st *src = vsrc;
+    struct blake2_mac_data_st *src = (struct blake2_mac_data_st *)vsrc;
 
     if (!ossl_prov_is_running())
         return NULL;
 
-    dst = OPENSSL_zalloc(sizeof(*dst));
+    dst = (struct blake2_mac_data_st *)OPENSSL_zalloc(sizeof(*dst));
     if (dst == NULL)
         return NULL;
 
@@ -74,7 +74,7 @@ static void *blake2_mac_dup(void *vsrc)
 
 static void blake2_mac_free(void *vmacctx)
 {
-    struct blake2_mac_data_st *macctx = vmacctx;
+    struct blake2_mac_data_st *macctx = (struct blake2_mac_data_st *)vmacctx;
 
     if (macctx != NULL) {
         OPENSSL_cleanse(macctx->key, sizeof(macctx->key));
@@ -84,7 +84,7 @@ static void blake2_mac_free(void *vmacctx)
 
 static int blake2_mac_init(void *vmacctx)
 {
-    struct blake2_mac_data_st *macctx = vmacctx;
+    struct blake2_mac_data_st *macctx = (struct blake2_mac_data_st *)vmacctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -101,7 +101,7 @@ static int blake2_mac_init(void *vmacctx)
 static int blake2_mac_update(void *vmacctx,
                              const unsigned char *data, size_t datalen)
 {
-    struct blake2_mac_data_st *macctx = vmacctx;
+    struct blake2_mac_data_st *macctx = (struct blake2_mac_data_st *)vmacctx;
 
     if (datalen == 0)
         return 1;
@@ -113,7 +113,7 @@ static int blake2_mac_final(void *vmacctx,
                             unsigned char *out, size_t *outl,
                             size_t outsize)
 {
-    struct blake2_mac_data_st *macctx = vmacctx;
+    struct blake2_mac_data_st *macctx = (struct blake2_mac_data_st *)vmacctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -158,7 +158,7 @@ static const OSSL_PARAM *blake2_mac_settable_ctx_params(ossl_unused void *p_ctx)
  */
 static int blake2_mac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
-    struct blake2_mac_data_st *macctx = vmacctx;
+    struct blake2_mac_data_st *macctx = (struct blake2_mac_data_st *)vmacctx;
     const OSSL_PARAM *p;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_SIZE)) != NULL) {
@@ -216,7 +216,7 @@ static int blake2_mac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 
 static size_t blake2_mac_size(void *vmacctx)
 {
-    struct blake2_mac_data_st *macctx = vmacctx;
+    struct blake2_mac_data_st *macctx = (struct blake2_mac_data_st *)vmacctx;
 
     return macctx->params.digest_length;
 }

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -56,7 +56,7 @@ static void *cmac_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((macctx = OPENSSL_zalloc(sizeof(*macctx))) == NULL
+    if ((macctx = (struct cmac_data_st *)OPENSSL_zalloc(sizeof(*macctx))) == NULL
         || (macctx->ctx = CMAC_CTX_new()) == NULL) {
         OPENSSL_free(macctx);
         macctx = NULL;
@@ -69,7 +69,7 @@ static void *cmac_new(void *provctx)
 
 static void cmac_free(void *vmacctx)
 {
-    struct cmac_data_st *macctx = vmacctx;
+    struct cmac_data_st *macctx = (struct cmac_data_st *)vmacctx;
 
     if (macctx != NULL) {
         CMAC_CTX_free(macctx->ctx);
@@ -80,13 +80,13 @@ static void cmac_free(void *vmacctx)
 
 static void *cmac_dup(void *vsrc)
 {
-    struct cmac_data_st *src = vsrc;
+    struct cmac_data_st *src = (struct cmac_data_st *)vsrc;
     struct cmac_data_st *dst;
 
     if (!ossl_prov_is_running())
         return NULL;
 
-    dst = cmac_new(src->provctx);
+    dst = (struct cmac_data_st *)cmac_new(src->provctx);
     if (!CMAC_CTX_copy(dst->ctx, src->ctx)
         || !ossl_prov_cipher_copy(&dst->cipher, &src->cipher)) {
         cmac_free(dst);
@@ -97,14 +97,14 @@ static void *cmac_dup(void *vsrc)
 
 static size_t cmac_size(void *vmacctx)
 {
-    struct cmac_data_st *macctx = vmacctx;
+    struct cmac_data_st *macctx = (struct cmac_data_st *)vmacctx;
 
     return EVP_CIPHER_CTX_block_size(CMAC_CTX_get0_cipher_ctx(macctx->ctx));
 }
 
 static int cmac_init(void *vmacctx)
 {
-    struct cmac_data_st *macctx = vmacctx;
+    struct cmac_data_st *macctx = (struct cmac_data_st *)vmacctx;
     int rv;
 
     if (!ossl_prov_is_running())
@@ -121,7 +121,7 @@ static int cmac_init(void *vmacctx)
 static int cmac_update(void *vmacctx, const unsigned char *data,
                        size_t datalen)
 {
-    struct cmac_data_st *macctx = vmacctx;
+    struct cmac_data_st *macctx = (struct cmac_data_st *)vmacctx;
 
     return CMAC_Update(macctx->ctx, data, datalen);
 }
@@ -129,7 +129,7 @@ static int cmac_update(void *vmacctx, const unsigned char *data,
 static int cmac_final(void *vmacctx, unsigned char *out, size_t *outl,
                       size_t outsize)
 {
-    struct cmac_data_st *macctx = vmacctx;
+    struct cmac_data_st *macctx = (struct cmac_data_st *)vmacctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -172,7 +172,7 @@ static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *provctx)
  */
 static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
-    struct cmac_data_st *macctx = vmacctx;
+    struct cmac_data_st *macctx = (struct cmac_data_st *)vmacctx;
     OPENSSL_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
     const OSSL_PARAM *p;
 

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -49,7 +49,7 @@ static size_t gmac_size(void);
 
 static void gmac_free(void *vmacctx)
 {
-    struct gmac_data_st *macctx = vmacctx;
+    struct gmac_data_st *macctx = (struct gmac_data_st *)vmacctx;
 
     if (macctx != NULL) {
         EVP_CIPHER_CTX_free(macctx->ctx);
@@ -65,7 +65,7 @@ static void *gmac_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((macctx = OPENSSL_zalloc(sizeof(*macctx))) == NULL
+    if ((macctx = (struct gmac_data_st *)OPENSSL_zalloc(sizeof(*macctx))) == NULL
         || (macctx->ctx = EVP_CIPHER_CTX_new()) == NULL) {
         gmac_free(macctx);
         return NULL;
@@ -77,13 +77,13 @@ static void *gmac_new(void *provctx)
 
 static void *gmac_dup(void *vsrc)
 {
-    struct gmac_data_st *src = vsrc;
+    struct gmac_data_st *src = (struct gmac_data_st *)vsrc;
     struct gmac_data_st *dst;
 
     if (!ossl_prov_is_running())
         return NULL;
 
-    dst = gmac_new(src->provctx);
+    dst = (struct gmac_data_st *)gmac_new(src->provctx);
     if (dst == NULL)
         return NULL;
 
@@ -103,7 +103,7 @@ static int gmac_init(void *vmacctx)
 static int gmac_update(void *vmacctx, const unsigned char *data,
                        size_t datalen)
 {
-    struct gmac_data_st *macctx = vmacctx;
+    struct gmac_data_st *macctx = (struct gmac_data_st *)vmacctx;
     EVP_CIPHER_CTX *ctx = macctx->ctx;
     int outlen;
 
@@ -122,7 +122,7 @@ static int gmac_update(void *vmacctx, const unsigned char *data,
 static int gmac_final(void *vmacctx, unsigned char *out, size_t *outl,
                       size_t outsize)
 {
-    struct gmac_data_st *macctx = vmacctx;
+    struct gmac_data_st *macctx = (struct gmac_data_st *)vmacctx;
     int hlen = 0;
 
     if (!ossl_prov_is_running())
@@ -182,7 +182,7 @@ static const OSSL_PARAM *gmac_settable_ctx_params(ossl_unused void *provctx)
  */
 static int gmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
-    struct gmac_data_st *macctx = vmacctx;
+    struct gmac_data_st *macctx = (struct gmac_data_st *)vmacctx;
     EVP_CIPHER_CTX *ctx = macctx->ctx;
     OPENSSL_CTX *provctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
     const OSSL_PARAM *p;

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -80,7 +80,7 @@ static void *hmac_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((macctx = OPENSSL_zalloc(sizeof(*macctx))) == NULL
+    if ((macctx = (struct hmac_data_st *)OPENSSL_zalloc(sizeof(*macctx))) == NULL
         || (macctx->ctx = HMAC_CTX_new()) == NULL) {
         OPENSSL_free(macctx);
         return NULL;
@@ -93,7 +93,7 @@ static void *hmac_new(void *provctx)
 
 static void hmac_free(void *vmacctx)
 {
-    struct hmac_data_st *macctx = vmacctx;
+    struct hmac_data_st *macctx = (struct hmac_data_st *)vmacctx;
 
     if (macctx != NULL) {
         HMAC_CTX_free(macctx->ctx);
@@ -105,13 +105,13 @@ static void hmac_free(void *vmacctx)
 
 static void *hmac_dup(void *vsrc)
 {
-    struct hmac_data_st *src = vsrc;
+    struct hmac_data_st *src = (struct hmac_data_st *)vsrc;
     struct hmac_data_st *dst;
     HMAC_CTX *ctx;
 
     if (!ossl_prov_is_running())
         return NULL;
-    dst = hmac_new(src->provctx);
+    dst = (struct hmac_data_st *)hmac_new(src->provctx);
     if (dst == NULL)
         return NULL;
 
@@ -139,14 +139,14 @@ static void *hmac_dup(void *vsrc)
 
 static size_t hmac_size(void *vmacctx)
 {
-    struct hmac_data_st *macctx = vmacctx;
+    struct hmac_data_st *macctx = (struct hmac_data_st *)vmacctx;
 
     return HMAC_size(macctx->ctx);
 }
 
 static int hmac_init(void *vmacctx)
 {
-    struct hmac_data_st *macctx = vmacctx;
+    struct hmac_data_st *macctx = (struct hmac_data_st *)vmacctx;
     const EVP_MD *digest;
     int rv = 1;
 
@@ -165,7 +165,7 @@ static int hmac_init(void *vmacctx)
 static int hmac_update(void *vmacctx, const unsigned char *data,
                        size_t datalen)
 {
-    struct hmac_data_st *macctx = vmacctx;
+    struct hmac_data_st *macctx = (struct hmac_data_st *)vmacctx;
 
     if (macctx->tls_data_size > 0) {
         /* We're doing a TLS HMAC */
@@ -200,7 +200,7 @@ static int hmac_final(void *vmacctx, unsigned char *out, size_t *outl,
                       size_t outsize)
 {
     unsigned int hlen;
-    struct hmac_data_st *macctx = vmacctx;
+    struct hmac_data_st *macctx = (struct hmac_data_st *)vmacctx;
 
     if (!ossl_prov_is_running())
         return 0;
@@ -255,7 +255,7 @@ static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *provctx)
  */
 static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
 {
-    struct hmac_data_st *macctx = vmacctx;
+    struct hmac_data_st *macctx = (struct hmac_data_st *)vmacctx;
     OPENSSL_CTX *ctx = PROV_LIBRARY_CONTEXT_OF(macctx->provctx);
     const OSSL_PARAM *p;
 

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -139,7 +139,7 @@ static int kmac_bytepad_encode_key(unsigned char *out, int *out_len,
 
 static void kmac_free(void *vmacctx)
 {
-    struct kmac_data_st *kctx = vmacctx;
+    struct kmac_data_st *kctx = (struct kmac_data_st *)vmacctx;
 
     if (kctx != NULL) {
         EVP_MD_CTX_free(kctx->ctx);
@@ -162,7 +162,7 @@ static struct kmac_data_st *kmac_new(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    if ((kctx = OPENSSL_zalloc(sizeof(*kctx))) == NULL
+    if ((kctx = (struct kmac_data_st *)OPENSSL_zalloc(sizeof(*kctx))) == NULL
             || (kctx->ctx = EVP_MD_CTX_new()) == NULL) {
         kmac_free(kctx);
         return NULL;
@@ -209,13 +209,13 @@ static void *kmac256_new(void *provctx)
 
 static void *kmac_dup(void *vsrc)
 {
-    struct kmac_data_st *src = vsrc;
+    struct kmac_data_st *src = (struct kmac_data_st *)vsrc;
     struct kmac_data_st *dst;
 
     if (!ossl_prov_is_running())
         return NULL;
 
-    dst = kmac_new(src->provctx);
+    dst = (struct kmac_data_st *)kmac_new(src->provctx);
     if (dst == NULL)
         return NULL;
 
@@ -242,7 +242,7 @@ static void *kmac_dup(void *vsrc)
  */
 static int kmac_init(void *vmacctx)
 {
-    struct kmac_data_st *kctx = vmacctx;
+    struct kmac_data_st *kctx = (struct kmac_data_st *)vmacctx;
     EVP_MD_CTX *ctx = kctx->ctx;
     unsigned char out[KMAC_MAX_BLOCKSIZE];
     int out_len, block_len;
@@ -280,7 +280,7 @@ static int kmac_init(void *vmacctx)
 
 static size_t kmac_size(void *vmacctx)
 {
-    struct kmac_data_st *kctx = vmacctx;
+    struct kmac_data_st *kctx = (struct kmac_data_st *)vmacctx;
 
     return kctx->out_len;
 }
@@ -288,7 +288,7 @@ static size_t kmac_size(void *vmacctx)
 static int kmac_update(void *vmacctx, const unsigned char *data,
                        size_t datalen)
 {
-    struct kmac_data_st *kctx = vmacctx;
+    struct kmac_data_st *kctx = (struct kmac_data_st *)vmacctx;
 
     return EVP_DigestUpdate(kctx->ctx, data, datalen);
 }
@@ -296,7 +296,7 @@ static int kmac_update(void *vmacctx, const unsigned char *data,
 static int kmac_final(void *vmacctx, unsigned char *out, size_t *outl,
                       size_t outsize)
 {
-    struct kmac_data_st *kctx = vmacctx;
+    struct kmac_data_st *kctx = (struct kmac_data_st *)vmacctx;
     EVP_MD_CTX *ctx = kctx->ctx;
     int lbits, len;
     unsigned char encoded_outlen[KMAC_MAX_ENCODED_HEADER_LEN];
@@ -306,7 +306,7 @@ static int kmac_final(void *vmacctx, unsigned char *out, size_t *outl,
         return 0;
 
     /* KMAC XOF mode sets the encoded length to 0 */
-    lbits = (kctx->xof_mode ? 0 : (kctx->out_len * 8));
+    lbits = (int)(kctx->xof_mode ? 0 : (kctx->out_len * 8));
 
     ok = right_encode(encoded_outlen, &len, lbits)
         && EVP_DigestUpdate(ctx, encoded_outlen, len)
@@ -357,7 +357,7 @@ static const OSSL_PARAM *kmac_settable_ctx_params(ossl_unused void *provctx)
  */
 static int kmac_set_ctx_params(void *vmacctx, const OSSL_PARAM *params)
 {
-    struct kmac_data_st *kctx = vmacctx;
+    struct kmac_data_st *kctx = (struct kmac_data_st *)vmacctx;
     const OSSL_PARAM *p;
     const EVP_MD *digest = ossl_prov_digest_md(&kctx->digest);
 
@@ -459,7 +459,7 @@ static int encode_string(unsigned char *out, int *out_len,
         if (len > 0xFF)
             return 0;
 
-        out[0] = len;
+        out[0] = (unsigned char)len;
         for (i = len; i > 0; --i) {
             out[i] = (bits & 0xFF);
             bits >>= 8;
@@ -488,7 +488,7 @@ static int bytepad(unsigned char *out, int *out_len,
 
     /* Left encoded w */
     *p++ = 1;
-    *p++ = w;
+    *p++ = (unsigned char)w;
     /* || in1 */
     memcpy(p, in1, in1_len);
     p += in1_len;
@@ -498,7 +498,7 @@ static int bytepad(unsigned char *out, int *out_len,
         p += in2_len;
     }
     /* Figure out the pad size (divisible by w) */
-    len = p - out;
+    len = (int)(p - out);
     while (len > sz) {
         sz += w;
     }

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -54,7 +54,7 @@ static void *siphash_new(void *provctx)
 
     if (!ossl_prov_is_running())
         return NULL;
-    ctx = OPENSSL_zalloc(sizeof(*ctx));
+    ctx = (struct siphash_data_st *)OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
         ctx->provctx = provctx;
     return ctx;
@@ -67,12 +67,12 @@ static void siphash_free(void *vmacctx)
 
 static void *siphash_dup(void *vsrc)
 {
-    struct siphash_data_st *ssrc = vsrc;
+    struct siphash_data_st *ssrc = (struct siphash_data_st *)vsrc;
     struct siphash_data_st *sdst;
 
     if (!ossl_prov_is_running())
         return NULL;
-    sdst = siphash_new(ssrc->provctx);
+    sdst = (struct siphash_data_st *)siphash_new(ssrc->provctx);
     if (sdst == NULL)
         return NULL;
 
@@ -82,7 +82,7 @@ static void *siphash_dup(void *vsrc)
 
 static size_t siphash_size(void *vmacctx)
 {
-    struct siphash_data_st *ctx = vmacctx;
+    struct siphash_data_st *ctx = (struct siphash_data_st *)vmacctx;
 
     return SipHash_hash_size(&ctx->siphash);
 }
@@ -96,7 +96,7 @@ static int siphash_init(void *vmacctx)
 static int siphash_update(void *vmacctx, const unsigned char *data,
                        size_t datalen)
 {
-    struct siphash_data_st *ctx = vmacctx;
+    struct siphash_data_st *ctx = (struct siphash_data_st *)vmacctx;
 
     if (datalen == 0)
         return 1;
@@ -108,7 +108,7 @@ static int siphash_update(void *vmacctx, const unsigned char *data,
 static int siphash_final(void *vmacctx, unsigned char *out, size_t *outl,
                          size_t outsize)
 {
-    struct siphash_data_st *ctx = vmacctx;
+    struct siphash_data_st *ctx = (struct siphash_data_st *)vmacctx;
     size_t hlen = siphash_size(ctx);
 
     if (!ossl_prov_is_running() || outsize < hlen)
@@ -149,7 +149,7 @@ static const OSSL_PARAM *siphash_settable_params(void *provctx)
 
 static int siphash_set_params(void *vmacctx, const OSSL_PARAM *params)
 {
-    struct siphash_data_st *ctx = vmacctx;
+    struct siphash_data_st *ctx = (struct siphash_data_st *)vmacctx;
     const OSSL_PARAM *p = NULL;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_SIZE)) != NULL) {

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -139,7 +139,7 @@ static void *dsa_newctx(void *provctx, const char *propq)
     if (!ossl_prov_is_running())
         return NULL;
 
-    pdsactx = OPENSSL_zalloc(sizeof(PROV_DSA_CTX));
+    pdsactx = (PROV_DSA_CTX *)OPENSSL_zalloc(sizeof(PROV_DSA_CTX));
     if (pdsactx == NULL)
         return NULL;
 
@@ -372,7 +372,7 @@ static void *dsa_dupctx(void *vpdsactx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_DSA_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
 

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -101,7 +101,7 @@ static void *ecdsa_newctx(void *provctx, const char *propq)
     if (!ossl_prov_is_running())
         return NULL;
 
-    ctx = OPENSSL_zalloc(sizeof(PROV_ECDSA_CTX));
+    ctx = (PROV_ECDSA_CTX *)OPENSSL_zalloc(sizeof(PROV_ECDSA_CTX));
     if (ctx == NULL)
         return NULL;
 
@@ -351,7 +351,7 @@ static void *ecdsa_dupctx(void *vctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_ECDSA_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
 

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -43,7 +43,7 @@ static void *eddsa_newctx(void *provctx, const char *propq_unused)
     if (!ossl_prov_is_running())
         return NULL;
 
-    peddsactx = OPENSSL_zalloc(sizeof(PROV_EDDSA_CTX));
+    peddsactx = (PROV_EDDSA_CTX *)OPENSSL_zalloc(sizeof(PROV_EDDSA_CTX));
     if (peddsactx == NULL) {
         PROVerr(0, ERR_R_MALLOC_FAILURE);
         return NULL;
@@ -179,7 +179,7 @@ static void *eddsa_dupctx(void *vpeddsactx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    dstctx = (PROV_EDDSA_CTX *)OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
         return NULL;
 

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -949,7 +949,7 @@ static int rsa_get_ctx_params(void *vprsactx, OSSL_PARAM *params)
 
                 for (i = 0; padding_item[i].id != 0; i++) {
                     if (prsactx->pad_mode == (int)padding_item[i].id) {
-                        word = padding_item[i].ptr;
+                        word = (const char *)padding_item[i].ptr;
                         break;
                     }
                 }


### PR DESCRIPTION
This pull request contains no functional changes.

The following changes are made.

First, do not use C++ keywords "template" or "new" in source code.

Second, use explicit casts from (void ptr) to ([anything] ptr) and from (const [anything] ptr) to ([anything] ptr).

Third, use explicit casts when downsizing integers, e.g. from size_t to int or int to char.

The first two issues result in a compiler error when using Visual Studio 2019 with C++.  There is no way to disable this error; the code simply doesn't compile.

The third issue issues a compiler warning, but the warning can be disabled.

Note: This commit makes no attempt to fix *all* such issues in OpenSSL.
Getting to an issue-free state would be hopelessly short-lived due to constant codebase churn.
The only way to maintain such a state would be if a CI loop build to prevent such issues from being introduced.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
