### PR TITLE
Fix AES_XTS on x86-64 platforms with BSAES and VPAES support.

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -66,15 +66,18 @@ static int cipher_hw_aes_xts_generic_initkey(PROV_CIPHER_CTX *ctx,
     if (BSAES_CAPABLE) {
         stream_enc = bsaes_xts_encrypt;
         stream_dec = bsaes_xts_decrypt;
-    }
+    } else
 #endif /* BSAES_CAPABLE */
-
 #ifdef VPAES_CAPABLE
     if (VPAES_CAPABLE) {
         XTS_SET_KEY_FN(vpaes_set_encrypt_key, vpaes_set_decrypt_key,
                        vpaes_encrypt, vpaes_decrypt, stream_enc, stream_dec);
+        return 1;
     } else
 #endif /* VPAES_CAPABLE */
+    {
+        (void)0;
+    }
     {
         XTS_SET_KEY_FN(AES_set_encrypt_key, AES_set_decrypt_key,
                        AES_encrypt, AES_decrypt, stream_enc, stream_dec);


### PR DESCRIPTION
Fixes #11622
Fixes #12378

Due to a missing else it was setting up the stream for BSAES and then using this incorrect stream with VPAES.
The correct behaviour is not to use VPAES at all in this case.
Also note that the original code in e_aes could set up VPAES and then would overwrite it with the generic implementation.
On a machine that supported both BSAES and VPAES the code was changed locally to force it to run both cases to verify
both paths produce the correct known answers.

Debugged using mageia 7.1, but is also highly likely to fix FreeBSD also.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
