### PR TITLE
FIX strncpy warning in apps/cmp.c.

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1839,7 +1839,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         CMP_err("missing -tls_used option since -server URL indicates https");
         goto err;
     }
-    strncpy(server_port, port, sizeof(server_port));
+    BIO_snprintf(server_port, sizeof(server_port), "%s", port);
     used_path = opt_path != NULL ? opt_path : path;
     if (!OSSL_CMP_CTX_set1_server(ctx, server)
             || !OSSL_CMP_CTX_set_serverPort(ctx, portnum)


### PR DESCRIPTION
bugfix: #12872

strncpy here has compiling warning of -Wstringop-truncation, change into BIO_snprintf as before.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
