### PR TITLE
STORE: clear err after ossl_store_get0_loader_int

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -930,17 +930,11 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
         scheme = "file";
 
     OSSL_TRACE1(STORE, "Looking up scheme %s\n", scheme);
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     ERR_set_mark();
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     if ((loader = ossl_store_get0_loader_int(scheme)) != NULL)
         loader_ctx = loader->attach(loader, bp, libctx, propq,
                                     ui_method, ui_data);
-    /*
-     * ossl_store_get0_loader_int will will raise an error if the loader for
-     * the scheme cannot be retrieved. This error is cleared as the code below
-     * will try to fetch the loader from the provider.
-     */
-    ERR_pop_to_mark();
 #endif
     if (loader == NULL
         && (fetched_loader =
@@ -970,24 +964,36 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
         loader = fetched_loader;
     }
 
-    if (loader_ctx == NULL)
+    if (loader_ctx == NULL) {
+        ERR_clear_last_mark();
         return NULL;
+    }
 
     if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL) {
+        ERR_clear_last_mark();
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
     if (ui_method != NULL
         && !ossl_pw_set_ui_method(&ctx->pwdata, ui_method, ui_data)) {
+        ERR_clear_last_mark();
         OPENSSL_free(ctx);
         return NULL;
     }
+
     ctx->fetched_loader = fetched_loader;
     ctx->loader = loader;
     ctx->loader_ctx = loader_ctx;
     ctx->post_process = post_process;
     ctx->post_process_data = post_process_data;
+
+    /*
+     * ossl_store_get0_loader_int will raise an error if the loader for the
+     * the scheme cannot be retrieved. But if a loader was successfully
+     * fetched then we remove this error from the error stack.
+     */
+    ERR_pop_to_mark();
 
     return ctx;
 }

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -931,9 +931,16 @@ OSSL_STORE_CTX *OSSL_STORE_attach(BIO *bp, const char *scheme,
 
     OSSL_TRACE1(STORE, "Looking up scheme %s\n", scheme);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
+    ERR_set_mark();
     if ((loader = ossl_store_get0_loader_int(scheme)) != NULL)
         loader_ctx = loader->attach(loader, bp, libctx, propq,
                                     ui_method, ui_data);
+    /*
+     * ossl_store_get0_loader_int will will raise an error if the loader for
+     * the scheme cannot be retrieved. This error is cleared as the code below
+     * will try to fetch the loader from the provider.
+     */
+    ERR_pop_to_mark();
 #endif
     if (loader == NULL
         && (fetched_loader =

--- a/test/ossl_store_test.c
+++ b/test/ossl_store_test.c
@@ -132,6 +132,35 @@ static int test_store_get_params(int idx)
     return 1;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+/*
+ * This test verifies that calling OSSL_STORE_ATTACH does not set an
+ * "unregistered scheme" error when called.
+ */
+static int test_store_attach_unregistered_scheme(void)
+{
+    int ret;
+    OSSL_STORE_CTX *store_ctx;
+    OSSL_PROVIDER *provider;
+    OPENSSL_CTX *libctx;
+    BIO *bio;
+    libctx = OPENSSL_CTX_new();
+    provider = OSSL_PROVIDER_load(libctx, "default");
+    bio = BIO_new_file("test/certs/sm2-root.crt", "r");
+
+    ret = TEST_ptr(store_ctx = OSSL_STORE_attach(bio, "file", libctx, NULL,
+                                                 NULL, NULL, NULL, NULL)) &&
+          TEST_int_ne(ERR_GET_LIB(ERR_peek_error()), ERR_LIB_OSSL_STORE) &&
+          TEST_int_ne(ERR_GET_REASON(ERR_peek_error()),
+                      OSSL_STORE_R_UNREGISTERED_SCHEME);
+
+    BIO_free(bio);
+    OSSL_STORE_close(store_ctx);
+    OSSL_PROVIDER_unload(provider);
+    OPENSSL_CTX_free(libctx);
+    return ret;
+}
+#endif
 
 const OPTIONS *test_get_options(void)
 {
@@ -172,5 +201,8 @@ int setup_tests(void)
     ADD_TEST(test_store_open);
     ADD_TEST(test_store_search_by_key_fingerprint_fail);
     ADD_ALL_TESTS(test_store_get_params, 3);
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+    ADD_TEST(test_store_attach_unregistered_scheme);
+#endif
     return 1;
 }

--- a/test/ossl_store_test.c
+++ b/test/ossl_store_test.c
@@ -132,7 +132,6 @@ static int test_store_get_params(int idx)
     return 1;
 }
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
 /*
  * This test verifies that calling OSSL_STORE_ATTACH does not set an
  * "unregistered scheme" error when called.
@@ -160,7 +159,6 @@ static int test_store_attach_unregistered_scheme(void)
     OPENSSL_CTX_free(libctx);
     return ret;
 }
-#endif
 
 const OPTIONS *test_get_options(void)
 {
@@ -201,8 +199,6 @@ int setup_tests(void)
     ADD_TEST(test_store_open);
     ADD_TEST(test_store_search_by_key_fingerprint_fail);
     ADD_ALL_TESTS(test_store_get_params, 3);
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_TEST(test_store_attach_unregistered_scheme);
-#endif
     return 1;
 }

--- a/test/ossl_store_test.c
+++ b/test/ossl_store_test.c
@@ -141,9 +141,9 @@ static int test_store_attach_unregistered_scheme(void)
     int ret;
     OSSL_STORE_CTX *store_ctx;
     OSSL_PROVIDER *provider;
-    OPENSSL_CTX *libctx;
+    OSSL_LIB_CTX *libctx;
     BIO *bio;
-    libctx = OPENSSL_CTX_new();
+    libctx = OSSL_LIB_CTX_new();
     provider = OSSL_PROVIDER_load(libctx, "default");
     bio = BIO_new_file("test/certs/sm2-root.crt", "r");
 
@@ -156,7 +156,7 @@ static int test_store_attach_unregistered_scheme(void)
     BIO_free(bio);
     OSSL_STORE_close(store_ctx);
     OSSL_PROVIDER_unload(provider);
-    OPENSSL_CTX_free(libctx);
+    OSSL_LIB_CTX_free(libctx);
     return ret;
 }
 


### PR DESCRIPTION
This commit clears the error that might have been set when
`ossl_store_get0_loader_int` has been called as it will try to retrieve
a loader for the scheme on an empty store, which will cause the error
`OSSL_STORE_R_UNREGISTERED_SCHEME` to be set. This code path will be
taken when `OPENSSL_NO_DEPRECATED_3_0` is not defined.

The motivation for this after returning from
`ossl_store_get0_loader_int`, `OSSL_STORE_attach` will continue and try to
fetch a `OSSL_STORE_LOADER` from the provider.

We ran into this when upgrading Node.js to OpenSSL 3.0 and I've tried to reproduce the issue in `test/ossl_store_test.c`.

##### Checklist
- [x] tests are added or updated
