### PR TITLE
rand: reference count the EVP_RAND contexts.

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -69,6 +69,9 @@ struct evp_kdf_ctx_st {
 struct evp_rand_ctx_st {
     EVP_RAND *meth;             /* Method structure */
     void *data;                 /* Algorithm-specific data */
+    EVP_RAND_CTX *parent;       /* Parent EVP_RAND or NULL if none */
+    CRYPTO_REF_COUNT refcnt;    /* Context reference count */
+    CRYPTO_RWLOCK *refcnt_lock;
 } /* EVP_RAND_CTX */ ;
 
 struct evp_keymgmt_st {

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -85,6 +85,7 @@ cryptographically secure random bytes.
 B<EVP_RAND> is a type that holds the implementation of a RAND.
 
 B<EVP_RAND_CTX> is a context type that holds the algorithm inputs.
+B<EVP_RAND_CTX> structures are reference counted.
 
 =head2 Algorithm implementation fetching
 


### PR DESCRIPTION
This prevents a context being destroyed before a dependent child context is.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
