### PR TITLE
util/mkerr.h: Restore header file rename

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -437,6 +437,7 @@ foreach my $lib ( keys %errorfile ) {
     # Rewrite the header file
 
     my $hfile = $hinc{$lib};
+    $hfile =~ s/.h$/err.h/ if $internal;
     open( OUT, ">$hfile" ) || die "Can't write to $hfile, $!,";
     print OUT <<"EOF";
 /*


### PR DESCRIPTION
With '-internal', we commonly write the reason code macros to header
file renamed 'name.h' to 'nameerr.h'.  That renaming was removed by
mistake, this restores it.

Fixes #12891
