### PR TITLE
EVP: Enforce that EVP_PKEY_set_alias_type() only works with legacy keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,17 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Deprecated EVP_PKEY_set_alias_type().  Because SM2 EVP_PKEYs had unusual
+   properties and weren't recognised as such, but as usual ECC keys, this
+   function was previously needed as a workaround to switch on SM2
+   functionality.  With OpenSSL 3.0, this key type is internally recognised
+   as such, and the workaround is no longer needed.
+   
+   Functionality is still retain as it is, but will only work with EVP_PKEYs
+   with a legacy internal key.
+   
+   *Richard Levitte*
+
  * Changed all "STACK" functions to be macros instead of inline functions. Macro
    parameters are still checked for type safety at compile time via helper
    inline functions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ OpenSSL 3.0
 
    Functionality is still retained as it is, but will only work with
    EVP_PKEYs with a legacy internal key.
-   
+
    *Richard Levitte*
 
  * Changed all "STACK" functions to be macros instead of inline functions. Macro

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,14 +23,12 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
- * Deprecated EVP_PKEY_set_alias_type().  Because SM2 EVP_PKEYs had unusual
-   properties and weren't recognised as such, but as usual ECC keys, this
-   function was previously needed as a workaround to switch on SM2
-   functionality.  With OpenSSL 3.0, this key type is internally recognised
-   as such, and the workaround is no longer needed.
-   
-   Functionality is still retain as it is, but will only work with EVP_PKEYs
-   with a legacy internal key.
+ * Deprecated EVP_PKEY_set_alias_type().  This function was previously
+   needed as a workaround to recognise SM2 keys.  With OpenSSL 3.0, this key
+   type is internally recognised so the workaround is no longer needed.
+
+   Functionality is still retained as it is, but will only work with
+   EVP_PKEYs with a legacy internal key.
    
    *Richard Levitte*
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -665,6 +665,11 @@ int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len)
 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type)
 {
     if (!evp_pkey_is_legacy(pkey)) {
+        const char *name = OBJ_nid2sn(type);
+
+        if (name != NULL && EVP_PKEY_is_a(pkey, name))
+            return 1;
+
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
         return 0;
     }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -661,8 +661,14 @@ int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len)
     return pkey_set_type(pkey, NULL, EVP_PKEY_NONE, str, len, NULL);
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type)
 {
+    if (!evp_pkey_is_legacy(pkey)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+        return 0;
+    }
+
     if (pkey->type == type) {
         return 1; /* it already is that type */
     }
@@ -679,6 +685,7 @@ int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type)
     pkey->type = type;
     return 1;
 }
+#endif
 
 # ifndef OPENSSL_NO_ENGINE
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e)

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -67,10 +67,15 @@ EVP_PKEY_set1_engine, EVP_PKEY_get0_engine - EVP_PKEY assignment functions
  int EVP_PKEY_id(const EVP_PKEY *pkey);
  int EVP_PKEY_base_id(const EVP_PKEY *pkey);
  int EVP_PKEY_type(int type);
- int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 
  ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
  int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *engine);
+
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
+ int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 
 =head1 DESCRIPTION
 
@@ -193,6 +198,10 @@ algorithms with EVP_PKEY_set_alias_type:
 =head1 SEE ALSO
 
 L<EVP_PKEY_new(3)>, L<SM2(7)>
+
+=head1 HISTORY
+
+EVP_PKEY_set_alias_type() was deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1202,7 +1202,7 @@ int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
 int EVP_PKEY_set_type(EVP_PKEY *pkey, int type);
 int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len);
 int EVP_PKEY_set_type_by_keymgmt(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt);
-int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
+DEPRECATEDIN_3_0(int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type))
 # ifndef OPENSSL_NO_ENGINE
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e);
 ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -34,14 +34,6 @@
 #include "crypto/evp.h"
 #include "../e_os.h" /* strcasecmp */
 
-#ifndef OPENSSL_NO_SM2
-/*
- * TODO(3.0) remove when provider SM2 keymgmt is implemented and
- * EVP_PKEY_set_alias_type() works with provider-native keys.
- */
-# define TMP_SM2_HACK
-#endif
-
 static OPENSSL_CTX *testctx = NULL;
 
 /*
@@ -954,12 +946,7 @@ static int test_EVP_SM2_verify(void)
     if (!TEST_true(pkey != NULL))
         goto done;
 
-#ifdef TMP_SM2_HACK
-    if (!TEST_ptr(EVP_PKEY_get0(pkey)))
-        goto done;
-#endif
-
-    if (!TEST_true(EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)))
+    if (!TEST_true(EVP_PKEY_is_a(pkey, "SM2")))
         goto done;
 
     if (!TEST_ptr(mctx = EVP_MD_CTX_new()))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4394,7 +4394,7 @@ EVP_PKEY_get_raw_public_key             4518	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_raw_private_key            4519	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_set_get_priv_key          4520	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_set_get_pub_key           4521	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_set_alias_type                 4522	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_set_alias_type                 4522	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 RAND_keep_random_devices_open           4523	3_0_0	EXIST::FUNCTION:
 EC_POINT_set_compressed_coordinates     4524	3_0_0	EXIST::FUNCTION:EC
 EC_POINT_set_affine_coordinates         4525	3_0_0	EXIST::FUNCTION:EC


### PR DESCRIPTION
This also deprecates the function, as it is not necessary any more,
and should fall out of use.
