### PR TITLE
Deprecate ASN1_STRING_length_set in OpenSSL 3.0.

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -387,10 +387,12 @@ int ASN1_STRING_length(const ASN1_STRING *x)
     return x->length;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 void ASN1_STRING_length_set(ASN1_STRING *x, int len)
 {
     x->length = len;
 }
+#endif
 
 int ASN1_STRING_type(const ASN1_STRING *x)
 {

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -539,7 +539,7 @@ int ASN1_STRING_cmp(const ASN1_STRING *a, const ASN1_STRING *b);
 int ASN1_STRING_set(ASN1_STRING *str, const void *data, int len);
 void ASN1_STRING_set0(ASN1_STRING *str, void *data, int len);
 int ASN1_STRING_length(const ASN1_STRING *x);
-void ASN1_STRING_length_set(ASN1_STRING *x, int n);
+DEPRECATEDIN_3_0(void ASN1_STRING_length_set(ASN1_STRING *x, int n))
 int ASN1_STRING_type(const ASN1_STRING *x);
 DEPRECATEDIN_1_1_0(unsigned char *ASN1_STRING_data(ASN1_STRING *x))
 const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1813,7 +1813,7 @@ BIO_next                                1855	3_0_0	EXIST::FUNCTION:
 ASN1_STRING_set_default_mask_asc        1856	3_0_0	EXIST::FUNCTION:
 X509_CRL_new                            1857	3_0_0	EXIST::FUNCTION:
 i2b_PrivateKey_bio                      1858	3_0_0	EXIST::FUNCTION:DSA
-ASN1_STRING_length_set                  1859	3_0_0	EXIST::FUNCTION:
+ASN1_STRING_length_set                  1859	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 PEM_write_PKCS8                         1860	3_0_0	EXIST::FUNCTION:STDIO
 PKCS7_digest_from_attributes            1861	3_0_0	EXIST::FUNCTION:
 EC_GROUP_set_curve_GFp                  1862	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC


### PR DESCRIPTION
Closes #12885.

I mostly parroted what I found of existing deprecations. Let me know if I missed a step.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
   - n/a. `ASN1_STRING_length_set` wasn't documented anyway
- [x] tests are added or updated
   - n/a. Not changing `ASN1_STRING_length_set` itself, and it didn't seem like deprecations themselves have anything to test?