### PR TITLE
Improve app SYNOPSIS on empty engine_synopsis; align CMP app option order

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -71,9 +71,9 @@ typedef enum {
 /* message transfer */
 static char *opt_server = NULL;
 static char server_port[32] = { '\0' };
+static char *opt_path = NULL;
 static char *opt_proxy = NULL;
 static char *opt_no_proxy = NULL;
-static char *opt_path = NULL;
 static int opt_msg_timeout = -1;
 static int opt_total_timeout = -1;
 
@@ -206,7 +206,7 @@ typedef enum OPTION_choice {
 
     OPT_OLDCERT, OPT_REVREASON,
 
-    OPT_SERVER, OPT_PROXY, OPT_NO_PROXY, OPT_PATH,
+    OPT_SERVER, OPT_PATH, OPT_PROXY, OPT_NO_PROXY,
     OPT_MSG_TIMEOUT, OPT_TOTAL_TIMEOUT,
 
     OPT_TRUSTED, OPT_UNTRUSTED, OPT_SRVCERT,
@@ -231,8 +231,9 @@ typedef enum OPTION_choice {
 
     OPT_BATCH, OPT_REPEAT,
     OPT_REQIN, OPT_REQIN_NEW_TID, OPT_REQOUT, OPT_RSPIN, OPT_RSPOUT,
+    OPT_USE_MOCK_SRV,
 
-    OPT_USE_MOCK_SRV, OPT_PORT, OPT_MAX_MSGS,
+    OPT_PORT, OPT_MAX_MSGS,
     OPT_SRV_REF, OPT_SRV_SECRET,
     OPT_SRV_CERT, OPT_SRV_KEY, OPT_SRV_KEYPASS,
     OPT_SRV_TRUSTED, OPT_SRV_UNTRUSTED,
@@ -332,14 +333,14 @@ const OPTIONS cmp_options[] = {
      "[http[s]://]address[:port][/path] of CMP server. Default port 80 or 443."},
     {OPT_MORE_STR, 0, 0,
      "address may be a DNS name or an IP address; path can be overridden by -path"},
+    {"path", OPT_PATH, 's',
+     "HTTP path (aka CMP alias) at the CMP server. Default from -server, else \"/\""},
     {"proxy", OPT_PROXY, 's',
      "[http[s]://]address[:port][/path] of HTTP(S) proxy to use; path is ignored"},
     {"no_proxy", OPT_NO_PROXY, 's',
      "List of addresses of servers not to use HTTP(S) proxy for"},
     {OPT_MORE_STR, 0, 0,
      "Default from environment variable 'no_proxy', else 'NO_PROXY', else none"},
-    {"path", OPT_PATH, 's',
-     "HTTP path (aka CMP alias) at the CMP server. Default from -server, else \"/\""},
     {"msg_timeout", OPT_MSG_TIMEOUT, 'n',
      "Timeout per CMP message round trip (or 0 for none). Default 120 seconds"},
     {"total_timeout", OPT_TOTAL_TIMEOUT, 'n',

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -62,8 +62,7 @@ B<openssl> B<ca>
 [B<-rand_serial>]
 [B<-multivalue-rdn>]
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<certreq>...]
 
 =for openssl ifdef engine

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -35,9 +35,6 @@ Certificate enrollment options:
 [B<-popo> I<number>]
 [B<-csr> I<filename>]
 [B<-out_trusted> I<filenames>]
-[B<-verify_hostname> I<cn>]
-[B<-verify_ip> I<ip>]
-[B<-verify_email> I<email>]
 [B<-implicit_confirm>]
 [B<-disable_confirm>]
 [B<-certout> I<filename>]
@@ -140,33 +137,7 @@ Mock server options:
 
 Certificate verification options, for both CMP and TLS:
 
-[B<-policy> I<arg>]
-[B<-purpose> I<purpose>]
-[B<-verify_name> I<name>]
-[B<-verify_depth> I<num>]
-[B<-auth_level> I<level>]
-[B<-attime> I<timestamp>]
-[B<-ignore_critical>]
-[B<-issuer_checks>]
-[B<-policy_check>]
-[B<-explicit_policy>]
-[B<-inhibit_any>]
-[B<-inhibit_map>]
-[B<-x509_strict>]
-[B<-extended_crl>]
-[B<-use_deltas>]
-[B<-policy_print>]
-[B<-check_ss_sig>]
-[B<-crl_check>]
-[B<-crl_check_all>]
-[B<-trusted_first>]
-[B<-suiteB_128_only>]
-[B<-suiteB_128>]
-[B<-suiteB_192>]
-[B<-partial_chain>]
-[B<-no_alt_chains>]
-[B<-no_check_time>]
-[B<-allow_proxy_certs>]
+{- $OpenSSL::safe::opt_v_synopsis -}
 
 =head1 DESCRIPTION
 
@@ -378,23 +349,9 @@ Multiple filenames may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Each source may contain multiple certificates.
 
-=item B<-verify_hostname> I<name>
-
-When verification of the newly enrolled certificate is enabled (with the
-B<-out_trusted> option), check if any DNS Subject Alternative Name (or if no
-DNS SAN is included, the Common Name in the subject) equals the given B<name>.
-
-=item B<-verify_ip> I<ip>
-
-When verification of the newly enrolled certificate is enabled (with the
-B<-out_trusted> option), check if there is
-an IP address Subject Alternative Name matching the given IP address.
-
-=item B<-verify_email> I<email>
-
-When verification of the newly enrolled certificate is enabled (with the
-B<-out_trusted> option), check if there is
-an email address Subject Alternative Name matching the given email address.
+The certificate verification options
+B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
+only affect the certificate verification enabled via this option.
 
 =item B<-implicit_confirm>
 
@@ -511,7 +468,7 @@ When verifying signature-based protection of CMP response messages,
 these are the CA certificate(s) to trust while checking certificate chains
 during CMP server authentication.
 This option gives more flexibility than the B<-srvcert> option because the
-protection certificate is not pinned but may be any certificate
+server-side CMP signer certificate is not pinned but may be any certificate
 for which a chain to one of the given trusted certificates can be constructed.
 
 If no B<-trusted>, B<-srvcert>, and B<-secret> option is given
@@ -520,6 +477,10 @@ then protected response messages from the server are not authenticated.
 Multiple filenames may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Each source may contain multiple certificates.
+
+The certificate verification options
+B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
+have no effect on the certificate verification enabled via this option.
 
 =item B<-untrusted> I<sources>
 
@@ -666,12 +627,16 @@ is included in the extraCerts field in signature-protected request messages.
 =item B<-own_trusted> I<filenames>
 
 If this list of certificates is provided then the chain built for
-the CMP signer certificate given with the B<-cert> option is verified
-using the given certificates as trust anchors.
+the client-side CMP signer certificate given with the B<-cert> option
+is verified using the given certificates as trust anchors.
 
 Multiple filenames may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Each source may contain multiple certificates.
+
+The certificate verification options
+B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
+have no effect on the certificate verification enabled via this option.
 
 =item B<-key> I<filename>
 
@@ -808,6 +773,10 @@ Multiple filenames may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Each source may contain multiple certificates.
 
+The certificate verification options
+B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
+have no effect on the certificate verification enabled via this option.
+
 =item B<-tls_host> I<name>
 
 Address to be checked during hostname validation. 
@@ -913,6 +882,10 @@ Server private key (and cert) file pass phrase source.
 
 Trusted certificates for client authentication.
 
+The certificate verification options
+B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
+have no effect on the certificate verification enabled via this option.
+
 =item B<-srv_untrusted> I<filenames>
 
 Intermediate CA certs that may be useful when verifying client certificates.
@@ -991,21 +964,11 @@ Accept RAVERIFED as proof-of-possession (POPO).
 
 =over 4
 
-=item B<-policy>, B<-purpose>, B<-verify_name>, B<-verify_depth>,
-B<-attime>,
-B<-ignore_critical>, B<-issuer_checks>,
-B<-policy_check>,
-B<-explicit_policy>, B<-inhibit_any>, B<-inhibit_map>,
-B<-x509_strict>, B<-extended_crl>, B<-use_deltas>,
-B<-policy_print>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
-B<-trusted_first>,
-B<-suiteB_128_only>, B<-suiteB_128>, B<-suiteB_192>,
-B<-partial_chain>, B<-no_alt_chains>, B<-no_check_time>,
-B<-auth_level>,
-B<-allow_proxy_certs>
+{- $OpenSSL::safe::opt_v_item -}
 
-Set various options of certificate chain verification.
-See L<openssl(1)/Verification Options> for details.
+The certificate verification options
+B<-verify_hostname>, B<-verify_ip>, and B<-verify_email>
+only affect the certificate verification enabled via the B<-out_trusted> option.
 
 =back
 

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-openssl-cmp - client for the Certificate Management Protocol (CMP, RFC 4210)
+openssl-cmp - Certificate Management Protocol (CMP, RFC 4210) application
 
 =head1 SYNOPSIS
 
@@ -11,38 +11,15 @@ B<openssl> B<cmp>
 [B<-help>]
 [B<-config> I<filename>]
 [B<-section> I<names>]
+[B<-verbosity> I<level>]
 
-[B<-server> I<[http[s]://]address[:port][/path]>]
-[B<-proxy> I<[http[s]://]address[:port][/path]>]
-[B<-no_proxy> I<addresses>]
-[B<-path> I<remote_path>]
-[B<-msg_timeout> I<seconds>]
-[B<-total_timeout> I<seconds>]
+Generic message options:
 
-[B<-trusted> I<filenames>]
-[B<-untrusted> I<sources>]
-[B<-srvcert> I<filename>]
-[B<-recipient> I<name>]
-[B<-expect_sender> I<name>]
-[B<-ignore_keyusage>]
-[B<-unprotected_errors>]
-[B<-extracertsout> I<filename>]
-[B<-cacertsout> I<filename>]
-
-[B<-ref> I<value>]
-[B<-secret> I<arg>]
-[B<-cert> I<filename>]
-[B<-own_trusted> I<filenames>]
-[B<-key> I<filename>]
-[B<-keypass> I<arg>]
-[B<-digest> I<name>]
-[B<-mac> I<name>]
-[B<-extracerts> I<sources>]
-[B<-unprotected_requests>]
-
-[B<-cmd> I<ir|cr|kur|p10cr|rr|genm>]
+[B<-cmd> I<i r|cr|kur|p10cr|rr|genm>]
 [B<-infotype> I<name>]
 [B<-geninfo> I<OID:int:N>]
+
+Certificate enrollment options:
 
 [B<-newkey> I<filename>]
 [B<-newkeypass> I<arg>]
@@ -66,14 +43,53 @@ B<openssl> B<cmp>
 [B<-certout> I<filename>]
 [B<-chainout> I<filename>]
 
+Certificate enrollment and revocation options:
+
 [B<-oldcert> I<filename>]
 [B<-revreason> I<number>]
+
+Message transfer options:
+
+[B<-server> I<[http[s]://]address[:port][/path]>]
+[B<-path> I<remote_path>]
+[B<-proxy> I<[http[s]://]address[:port][/path]>]
+[B<-no_proxy> I<addresses>]
+[B<-msg_timeout> I<seconds>]
+[B<-total_timeout> I<seconds>]
+
+Server authentication options:
+
+[B<-trusted> I<filenames>]
+[B<-untrusted> I<sources>]
+[B<-srvcert> I<filename>]
+[B<-recipient> I<name>]
+[B<-expect_sender> I<name>]
+[B<-ignore_keyusage>]
+[B<-unprotected_errors>]
+[B<-extracertsout> I<filename>]
+[B<-cacertsout> I<filename>]
+
+Client authentication options:
+
+[B<-ref> I<value>]
+[B<-secret> I<arg>]
+[B<-cert> I<filename>]
+[B<-own_trusted> I<filenames>]
+[B<-key> I<filename>]
+[B<-keypass> I<arg>]
+[B<-digest> I<name>]
+[B<-mac> I<name>]
+[B<-extracerts> I<sources>]
+[B<-unprotected_requests>]
+
+Credentials format options:
 
 [B<-certform> I<PEM|DER>]
 [B<-keyform> I<PEM|DER|P12|ENGINE>]
 [B<-otherpass> I<arg>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+
+TLS connection options:
 
 [B<-tls_used>]
 [B<-tls_cert> I<filename>]
@@ -83,7 +99,8 @@ B<openssl> B<cmp>
 [B<-tls_trusted> I<filenames>]
 [B<-tls_host> I<name>]
 
-[B<-verbosity> I<level>]
+Client-side debugging options:
+
 [B<-batch>]
 [B<-repeat> I<number>]
 [B<-reqin>] I<filenames>
@@ -92,6 +109,36 @@ B<openssl> B<cmp>
 [B<-rspin>] I<filenames>
 [B<-rspout>] I<filenames>
 [B<-use_mock_srv>]
+
+Mock server options:
+
+[B<-port> I<number>]
+[B<-max_msgs> I<number>]
+[B<-srv_ref> I<value>]
+[B<-srv_secret> I<arg>]
+[B<-srv_cert> I<filename>]
+[B<-srv_key> I<filename>]
+[B<-srv_keypass> I<arg>]
+[B<-srv_trusted> I<filenames>]
+[B<-srv_untrusted> I<filenames>]
+[B<-rsp_cert> I<filename>]
+[B<-rsp_extracerts> I<filenames>]
+[B<-rsp_capubs> I<filenames>]
+[B<-poll_count> I<number>]
+[B<-check_after> I<number>]
+[B<-grant_implicitconf>]
+[B<-pkistatus> I<number>]
+[B<-failure> I<number>]
+[B<-failurebits> I<number>]
+[B<-statusstring> I<arg>]
+[B<-send_error>]
+[B<-send_unprotected>]
+[B<-send_unprot_err>]
+[B<-accept_unprotected>]
+[B<-accept_unprot_err>]
+[B<-accept_raverified>]
+
+Certificate verification options, for both CMP and TLS:
 
 [B<-policy> I<arg>]
 [B<-purpose> I<purpose>]
@@ -120,32 +167,6 @@ B<openssl> B<cmp>
 [B<-no_alt_chains>]
 [B<-no_check_time>]
 [B<-allow_proxy_certs>]
-
-[B<-port> I<number>]
-[B<-max_msgs> I<number>]
-[B<-srv_ref> I<value>]
-[B<-srv_secret> I<arg>]
-[B<-srv_cert> I<filename>]
-[B<-srv_key> I<filename>]
-[B<-srv_keypass> I<arg>]
-[B<-srv_trusted> I<filenames>]
-[B<-srv_untrusted> I<filenames>]
-[B<-rsp_cert> I<filename>]
-[B<-rsp_extracerts> I<filenames>]
-[B<-rsp_capubs> I<filenames>]
-[B<-poll_count> I<number>]
-[B<-check_after> I<number>]
-[B<-grant_implicitconf>]
-[B<-pkistatus> I<number>]
-[B<-failure> I<number>]
-[B<-failurebits> I<number>]
-[B<-statusstring> I<arg>]
-[B<-send_error>]
-[B<-send_unprotected>]
-[B<-send_unprot_err>]
-[B<-accept_unprotected>]
-[B<-accept_unprot_err>]
-[B<-accept_raverified>]
 
 =head1 DESCRIPTION
 
@@ -181,8 +202,14 @@ Contents of sections named later may override contents of sections named before.
 In any case, as usual, the C<[default]> section and finally the unnamed
 section (as far as present) can provide per-option fallback values.
 
-=back
+=item B<-verbosity> I<level>
 
+Level of verbosity for logging, error output, etc.
+0 = EMERG, 1 = ALERT, 2 = CRIT, 3 = ERR, 4 = WARN, 5 = NOTE,
+6 = INFO, 7 = DEBUG, 8 = TRACE.
+Defaults to 6 = INFO.
+
+=back
 
 =head2 Generic message options
 
@@ -239,8 +266,7 @@ e.g., C<1.2.3.4:int:56789>.
 
 =back
 
-
-=head2 Certificate request options
+=head2 Certificate enrollment options
 
 =over 4
 
@@ -391,8 +417,7 @@ The file where the chain of the newly enrolled certificate should be saved.
 
 =back
 
-
-=head2 Certificate revocation options
+=head2 Certificate enrollment and revocation options
 
 =over 4
 
@@ -431,7 +456,6 @@ Reason numbers defined in RFC 5280 are:
 
 =back
 
-
 =head2 Message transfer options
 
 =over 4
@@ -442,6 +466,11 @@ The IP address or DNS hostname and optionally port (defaulting to 80 or 443)
 of the CMP server to connect to using HTTP(S) transport.
 The optional I<http://> or I<https://> prefix is ignored.
 If a path is included it provides the default value for the B<-path> option.
+
+=item B<-path> I<remote_path>
+
+HTTP path at the CMP server (aka CMP alias) to use for POST requests.
+Defaults to any path given with B<-server>, else C<"/">.
 
 =item B<-proxy> I<[http[s]://]address[:port][/path]>
 
@@ -458,11 +487,6 @@ not to use an HTTP(S) proxy for, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Default is from the environment variable C<no_proxy> if set, else C<NO_PROXY>.
 
-=item B<-path> I<remote_path>
-
-HTTP path at the CMP server (aka CMP alias) to use for POST requests.
-Defaults to any path given with B<-server>, else C<"/">.
-
 =item B<-msg_timeout> I<seconds>
 
 Number of seconds (or 0 for infinite) a CMP request-response message round trip
@@ -476,7 +500,6 @@ including attempts polling for certificates on C<waiting> PKIStatus.
 Default is 0 (infinite).
 
 =back
-
 
 =head2 Server authentication options
 
@@ -601,7 +624,6 @@ the last received certificate response (i.e., IP, CP, or KUP) message.
 
 =back
 
-
 =head2 Client authentication options
 
 =over 4
@@ -699,7 +721,6 @@ Send messages without CMP-level protection.
 
 =back
 
-
 =head2 Credentials format options
 
 =over 4
@@ -746,8 +767,7 @@ C<-key engine:pkcs11:object=my-private-key;type=private;pin-value=1234>
 
 =back
 
-
-=head2 TLS options
+=head2 TLS connection options
 
 =over 4
 
@@ -796,17 +816,9 @@ If not given it defaults to the B<-server> address.
 
 =back
 
-
 =head2 Client-side debugging options
 
 =over 4
-
-=item B<-verbosity> I<level>
-
-Level of verbosity for logging, error output, etc.
-0 = EMERG, 1 = ALERT, 2 = CRIT, 3 = ERR, 4 = WARN, 5 = NOTE,
-6 = INFO, 7 = DEBUG, 8 = TRACE.
-Defaults to 6 = INFO.
 
 =item B<-batch>
 
@@ -861,31 +873,7 @@ This works at API level, bypassing HTTP transport.
 
 =back
 
-
-=head2 Certificate verification options, for both CMP and TLS
-
-=over 4
-
-=item B<-policy>, B<-purpose>, B<-verify_name>, B<-verify_depth>,
-B<-attime>,
-B<-ignore_critical>, B<-issuer_checks>,
-B<-policy_check>,
-B<-explicit_policy>, B<-inhibit_any>, B<-inhibit_map>,
-B<-x509_strict>, B<-extended_crl>, B<-use_deltas>,
-B<-policy_print>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
-B<-trusted_first>,
-B<-suiteB_128_only>, B<-suiteB_128>, B<-suiteB_192>,
-B<-partial_chain>, B<-no_alt_chains>, B<-no_check_time>,
-B<-auth_level>,
-B<-allow_proxy_certs>
-
-Set various options of certificate chain verification.
-See L<openssl(1)/Verification Options> for details.
-
-=back
-
-
-=head2 Mock server options, for testing purposes only
+=head2 Mock server options
 
 =over 4
 
@@ -949,7 +937,6 @@ Number of times the client must poll before receiving a certificate.
 
 The checkAfter value (number of seconds to wait) to include in poll response.
 
-
 =item B<-grant_implicitconf>
 
 Grant implicit confirmation of newly enrolled certificate.
@@ -1000,6 +987,27 @@ Accept RAVERIFED as proof-of-possession (POPO).
 
 =back
 
+=head2 Certificate verification options, for both CMP and TLS
+
+=over 4
+
+=item B<-policy>, B<-purpose>, B<-verify_name>, B<-verify_depth>,
+B<-attime>,
+B<-ignore_critical>, B<-issuer_checks>,
+B<-policy_check>,
+B<-explicit_policy>, B<-inhibit_any>, B<-inhibit_map>,
+B<-x509_strict>, B<-extended_crl>, B<-use_deltas>,
+B<-policy_print>, B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,
+B<-trusted_first>,
+B<-suiteB_128_only>, B<-suiteB_128>, B<-suiteB_192>,
+B<-partial_chain>, B<-no_alt_chains>, B<-no_check_time>,
+B<-auth_level>,
+B<-allow_proxy_certs>
+
+Set various options of certificate chain verification.
+See L<openssl(1)/Verification Options> for details.
+
+=back
 
 =head1 NOTES
 
@@ -1012,7 +1020,6 @@ In this case the client will reject them, and thus their contents are not shown
 although they usually contain hints that would be helpful for diagnostics.
 For assisting in such cases the CMP client offers a workaround via the
 B<-unprotected_errors> option, which allows accepting such negative messages.
-
 
 =head1 EXAMPLES
 
@@ -1113,12 +1120,11 @@ In below command line usage examples the C<\> at line ends is just used
 for formatting; each of the command invocations should be on a single line.
 
   openssl genrsa -out cl_key.pem
-  openssl cmp -cmd ir -server 127.0.0.1:80 -path pkix/ \
+  openssl cmp -cmd ir -server 127.0.0.1:80/pkix/ \
     -ref 1234 -secret pass:1234-5678-1234-5678 \
     -recipient "/CN=CMPserver" \
     -newkey cl_key.pem -subject "/CN=MyName" \
     -cacertsout capubs.pem -certout cl_cert.pem
-
 
 =head2 Certificate update
 
@@ -1129,7 +1135,7 @@ for its own authentication.
 Then it can start using the new cert and key.
 
   openssl genrsa -out cl_key_new.pem
-  openssl cmp -cmd kur -server 127.0.0.1:80 -path pkix/ \
+  openssl cmp -cmd kur -server 127.0.0.1:80/pkix/ \
     -trusted capubs.pem \
     -cert cl_cert.pem -key cl_key.pem \
     -newkey cl_key_new.pem -certout cl_cert.pem
@@ -1137,16 +1143,14 @@ Then it can start using the new cert and key.
 
 This command sequence can be repated as often as needed.
 
-
 =head2 Requesting information from CMP server
 
 Requesting "all relevant information" with an empty General Message.
 This prints information about all received ITAV B<infoType>s to stdout.
 
-  openssl cmp -cmd genm -server 127.0.0.1 -path pkix/ \
+  openssl cmp -cmd genm -server 127.0.0.1/pkix/ \
     -ref 1234 -secret pass:1234-5678-1234-5678 \
     -recipient "/CN=CMPserver"
-
 
 =head2 Using a custom configuration file
 

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -81,8 +81,7 @@ B<openssl> B<cms>
 {- $OpenSSL::safe::opt_v_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}
 [I<recipient-cert> ...]
 

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -29,8 +29,7 @@ B<openssl> B<dgst>|I<digest>
 [B<-mac> I<alg>]
 [B<-macopt> I<nm>:I<v>]
 [B<-fips-fingerprint>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- output_off() if $disabled{"deprecated-3.0"}; ""
+{- $OpenSSL::safe::opt_engine_synopsis -}{- output_off() if $disabled{"deprecated-3.0"}; ""
 -}[B<-engine_impl> I<id>]{-
   output_on() if $disabled{"deprecated-3.0"}; "" -}
 {- $OpenSSL::safe::opt_r_synopsis -}

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -21,8 +21,7 @@ B<openssl dhparam>
 [B<-2>]
 [B<-3>]
 [B<-5>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [I<numbits>]
 

--- a/doc/man1/openssl-dsa.pod.in
+++ b/doc/man1/openssl-dsa.pod.in
@@ -36,8 +36,7 @@ B<openssl> B<dsa>
 [B<-modulus>]
 [B<-pubin>]
 [B<-pubout>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef pvk-string pvk-weak pvk-none engine
 

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -19,8 +19,7 @@ B<openssl dsaparam>
 [B<-genkey>]
 [B<-verbose>]
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<numbits>]
 
 =head1 DESCRIPTION

--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -31,8 +31,7 @@ B<openssl> B<ec>
 [B<-param_enc> I<arg>]
 [B<-no_public>]
 [B<-check>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -24,8 +24,7 @@ B<openssl ecparam>
 [B<-param_enc> I<arg>]
 [B<-no_seed>]
 [B<-genkey>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -38,8 +38,7 @@ B<openssl> B<enc>|I<cipher>
 [B<-v>]
 [B<-debug>]
 [B<-none>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef z engine ciphers

--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -25,8 +25,7 @@ B<openssl> B<gendsa>
 [B<-idea>]
 [B<-verbose>]
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<paramfile>]
 
 =for openssl ifdef engine

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -22,8 +22,7 @@ B<openssl> B<genpkey>
 [B<-pkeyopt> I<opt>:I<value>]
 [B<-genparam>]
 [B<-text>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}
 
 =for openssl ifdef engine

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -30,8 +30,7 @@ B<openssl> B<genrsa>
 [B<-verbose>]
 [B<-traditional>]
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [B<numbits>]
 
 =for openssl ifdef engine 3

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -60,8 +60,7 @@ B<openssl> B<pkcs12>
 [B<-CSP> I<name>]
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 

--- a/doc/man1/openssl-pkcs7.pod.in
+++ b/doc/man1/openssl-pkcs7.pod.in
@@ -21,8 +21,7 @@ B<openssl> B<pkcs7>
 [B<-print_certs>]
 [B<-text>]
 [B<-noout>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -28,8 +28,7 @@ B<openssl> B<pkcs8>
 [B<-scrypt_r> I<r>]
 [B<-scrypt_p> I<p>]
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine scrypt scrypt_N scrypt_r scrypt_p
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -30,8 +30,7 @@ B<openssl> B<pkey>
 [B<-pubcheck>]
 [B<-ec_conv_form> I<arg>]
 [B<-ec_param_enc> I<arg>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 

--- a/doc/man1/openssl-pkeyparam.pod.in
+++ b/doc/man1/openssl-pkeyparam.pod.in
@@ -18,8 +18,7 @@ B<openssl> B<pkeyparam>
 [B<-text>]
 [B<-noout>]
 [B<-check>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -34,8 +34,7 @@ B<openssl> B<pkeyutl>
 [B<-pkeyopt_passin> I<opt>[:I<passarg>]]
 [B<-hexdump>]
 [B<-asn1parse>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-[B<-engine_impl>]
+{- $OpenSSL::safe::opt_engine_synopsis -}[B<-engine_impl>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -12,8 +12,7 @@ B<openssl rand>
 [B<-out> I<file>]
 [B<-base64>]
 [B<-hex>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 I<num>
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -51,8 +51,7 @@ B<openssl> B<req>
 [B<-verbose>]
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine keygen_engine
 

--- a/doc/man1/openssl-rsa.pod.in
+++ b/doc/man1/openssl-rsa.pod.in
@@ -40,8 +40,7 @@ B<openssl> B<rsa>
 [B<-pubout>]
 [B<-RSAPublicKey_in>]
 [B<-RSAPublicKey_out>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef pvk-strong pvk-weak pvk-none engine
 

--- a/doc/man1/openssl-rsautl.pod.in
+++ b/doc/man1/openssl-rsautl.pod.in
@@ -31,8 +31,7 @@ B<openssl> B<rsautl>
 [B<-raw>]
 [B<-hexdump>]
 [B<-asn1parse>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -121,8 +121,7 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_s_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-[B<-ssl_client_engine> I<id>]
+{- $OpenSSL::safe::opt_engine_synopsis -}[B<-ssl_client_engine> I<id>]
 {- $OpenSSL::safe::opt_v_synopsis -}
 [I<host>:I<port>]
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -142,8 +142,7 @@ B<openssl> B<s_server>
 {- $OpenSSL::safe::opt_x_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef unix 4 6 unlink no_dhe nextprotoneg use_srtp engine
 

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -46,8 +46,7 @@ B<openssl> B<smime>
 [B<-stream>]
 [B<-md> I<digest>]
 {- $OpenSSL::safe::opt_trust_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_v_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}

--- a/doc/man1/openssl-speed.pod.in
+++ b/doc/man1/openssl-speed.pod.in
@@ -24,8 +24,7 @@ B<openssl speed>
 [B<-bytes> I<num>]
 [B<-mr>]
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<algorithm> ...]
 
 =for openssl ifdef hmac cmac multi async_jobs engine

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -24,8 +24,7 @@ B<openssl> B<spkac>
 [B<-spksect> I<section>]
 [B<-noout>]
 [B<-verify>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 

--- a/doc/man1/openssl-srp.pod.in
+++ b/doc/man1/openssl-srp.pod.in
@@ -21,8 +21,7 @@ B<openssl srp>
 [B<-userinfo> I<text>]
 [B<-passin> I<arg>]
 [B<-passout> I<arg>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [I<user> ...]
 

--- a/doc/man1/openssl-storeutl.pod.in
+++ b/doc/man1/openssl-storeutl.pod.in
@@ -27,8 +27,7 @@ B<openssl> B<storeutl>
 [B<-alias> I<arg>]
 [B<-fingerprint> I<arg>]
 [B<-I<digest>>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 I<uri> ...
 
 =head1 DESCRIPTION

--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -41,8 +41,7 @@ B<-reply>
 [B<-out> I<response.tsr>]
 [B<-token_out>]
 [B<-text>]
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 B<openssl> B<ts>
 B<-verify>

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -18,8 +18,7 @@ B<openssl> B<verify>
 [B<-vfyopt> I<nm>:I<v>]
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_v_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_v_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [B<-->]
 [I<certificate> ...]

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -75,8 +75,7 @@ B<openssl> B<x509>
 [B<-preserve_dates>]
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine subject_hash_old issuer_hash_old
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -1029,18 +1029,18 @@ B<-verify_depth> limit.
 
 =item B<-verify_email> I<email>
 
-Verify if I<email> matches the email address in Subject Alternative Name or
-the email in the subject Distinguished Name.
+Verify if I<email> matches any email address in a Subject Alternative Name or
+(if no SAN is included) the email address in the subject Distinguished Name.
 
 =item B<-verify_hostname> I<hostname>
 
-Verify if I<hostname> matches DNS name in Subject Alternative Name or
-Common Name in the subject certificate.
+Verify if I<hostname> matches any DNS name in a Subject Alternative Name or
+(if no SAN is included) the Common Name in the subject Distinguished Name.
 
 =item B<-verify_ip> I<ip>
 
-Verify if I<ip> matches the IP address in Subject Alternative Name of
-the subject certificate.
+Verify if I<ip> matches any IP address in a Subject Alternative Name or
+(if no SAN is included) the Common Name in the subject Distinguished Name.
 
 =item B<-verify_name> I<name>
 

--- a/doc/perlvars.pm
+++ b/doc/perlvars.pm
@@ -41,7 +41,7 @@ $OpenSSL::safe::opt_v_synopsis = ""
 . "[B<-verify_ip> I<ip>]\n"
 . "[B<-verify_name> I<name>]\n"
 . "[B<-x509_strict>]\n"
-. "[B<-issuer_checks>]\n";
+. "[B<-issuer_checks>]";
 $OpenSSL::safe::opt_v_item = ""
 . "=item B<-allow_proxy_certs>, B<-attime>, B<-no_check_time>,\n"
 . "B<-check_ss_sig>, B<-crl_check>, B<-crl_check_all>,\n"
@@ -103,7 +103,7 @@ $OpenSSL::safe::opt_provider_item = ""
 
 # Configuration option
 $OpenSSL::safe::opt_config_synopsis = ""
-. "[B<-config> I<configfile>]\n";
+. "[B<-config> I<configfile>]";
 $OpenSSL::safe::opt_config_item = ""
 . "=item B<-config> I<configfile>\n"
 . "\n"
@@ -114,7 +114,7 @@ $OpenSSL::safe::opt_engine_synopsis = "";
 $OpenSSL::safe::opt_engine_item = "";
 if (!$disabled{"deprecated-3.0"}) {
   $OpenSSL::safe::opt_engine_synopsis = ""
-  . "[B<-engine> I<id>]";
+  . "[B<-engine> I<id>]\n";
   $OpenSSL::safe::opt_engine_item = ""
   . "=item B<-engine> I<id>\n"
   . "\n"


### PR DESCRIPTION
This is a follow-up on https://github.com/openssl/openssl/pull/12924#issuecomment-695179026.

I found that explicit and implicit empty lines within the SYNOPSIS section of POD files cause layout errors
because they are (mis-)interpreted as the start of a new command (with its own options).

This causes trouble in all apps having `-engine` options, which are disabled by default.
As a workaround I removed the newline after each occurrence of 
`{- $OpenSSL::safe::opt_engine_synopsis -}`

I would have liked to structure the large list of CMP app options by having a newline or even better an intermediate header before each group of options, but apparently there is no possibility to influence the layout within a SYNOPSIS section, not even by using escape/control symbols (which are not recognized for some reason).
I nevertheless added some sort of header texts and would be inclined to accept the sub-optimal layout there.

Moreover, I improved the alignment of the order of the CMP app options.

- [x] documentation is added or updated
