### PR TITLE
Streamline/Rationalize HPE NonStop Configuration

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -46,8 +46,8 @@
     'nonstop-archenv-mips-guardian' => {
         template         => 1,
         defines          => ['NO_GETPID'],
-        cflags           => ['-Wtarget=tns/r', '-Wsystype=guardian'],
-        lflags           => ['-Wld="-set systype guardian"'],
+        cflags           => '-Wtarget=tns/r -Wsystype=guardian',
+        lflags           => '-Wld="-set systype guardian"',
         shared_target    => 'nonstop-mips-guardian',
     },
 
@@ -55,8 +55,8 @@
     'nonstop-archenv-itanium-guardian' => {
         template         => 1,
         defines          => ['NO_GETPID', '_TANDEM_ARCH=2'],
-        cflags           => ['-Wtarget=tns/e', '-Wsystype=guardian'],
-        lflags           => ['-Weld="-set systype guardian"'],
+        cflags           => '-Wtarget=tns/e -Wsystype=guardian',
+        lflags           => '-Weld="-set systype guardian"',
         shared_target    => 'nonstop-itanium-guardian',
     },
 
@@ -64,77 +64,77 @@
     'nonstop-archenv-x86_64-guardian' => {
         template         => 1,
         defines          => ['NO_GETPID', '_TANDEM_ARCH=3'],
-        cflags           => ['-Wtarget=tns/x', '-Wsystype=guardian'],
-        lflags           => ['-Wxld="-set systype guardian"'],
+        cflags           => '-Wtarget=tns/x -Wsystype=guardian',
+        lflags           => '-Wxld="-set systype guardian"',
         shared_target    => 'nonstop-x86-guardian',
     },
 
     # MIPS + oss (unused but present for convenience):
     'nonstop-archenv-mips-oss' => {
         template         => 1,
-        cflags           => ['-Wtarget=tns/r', '-Wsystype=oss'],
-        lflags           => ['-Wld="-set systype oss"'],
+        cflags           => '-Wtarget=tns/r -Wsystype=oss',
+        lflags           => '-Wld="-set systype oss"',
         shared_target    => 'nonstop-mips-oss',
     },
     # Itanium + oss:
     'nonstop-archenv-itanium-oss' => {
         template         => 1,
         defines          => ['_TANDEM_ARCH=2'],
-        cflags           => ['-Wtarget=tns/e', '-Wsystype=oss'],
-        lflags           => ['-Weld="-set systype oss"'],
+        cflags           => '-Wtarget=tns/e -Wsystype=oss',
+        lflags           => '-Weld="-set systype oss"',
         shared_target    => 'nonstop-itanium-oss',
     },
     # x86_64 + oss:
     'nonstop-archenv-x86_64-oss' => {
         template         => 1,
         defines          => ['_TANDEM_ARCH=3'],
-        cflags           => ['-Wtarget=tns/x', '-Wsystype=oss'],
-        lflags           => ['-Wxld="-set systype oss"'],
+        cflags           => '-Wtarget=tns/x -Wsystype=oss',
+        lflags           => '-Wxld="-set systype oss"',
         shared_target    => 'nonstop-x86-oss',
     },
 
     # Size variants
     'nonstop-ilp32' => {
         template         => 1,
-        cflags           => ['-Wilp32'],
+        cflags           => '-Wilp32',
         bn_ops           => 'THIRTY_TWO_BIT',
     },
     'nonstop-lp64-itanium' => {
         template         => 1,
-        cflags           => ['-Wlp64'],
+        cflags           => '-Wlp64',
         bn_ops           => 'SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR',
     },
     'nonstop-lp64-x86_64' => {
         template         => 1,
-        cflags           => ['-Wlp64'],
-        lflags           => ['-Wxld="-set data_model lp64"'],
+        cflags           => '-Wlp64',
+        lflags           => '-Wxld="-set data_model lp64"',
         bn_ops           => 'SIXTY_FOUR_BIT',
     },
 
     # Float variants
     'nonstop-nfloat-mips' => {
         template         => 1,
-        lflags           => ['-Wld="-set floattype neutral_float"'],
+        lflags           => '-Wld="-set floattype neutral_float"',
     },
     'nonstop-tfloat-mips' => {
         template         => 1,
-        lflags           => ['-Wld="-set floattype tandem_float"'],
+        lflags           => '-Wld="-set floattype tandem_float"',
     },
     'nonstop-nfloat-itanium' => {
         template         => 1,
-        lflags           => ['-Weld="-set floattype neutral_float"'],
+        lflags           => '-Weld="-set floattype neutral_float"',
     },
     'nonstop-tfloat-itanium' => {
         template         => 1,
-        lflags           => ['-Weld="-set floattype tandem_float"'],
+        lflags           => '-Weld="-set floattype tandem_float"',
     },
     'nonstop-nfloat-x86_64' => {
         template         => 1,
-        lflags           => ['-Wxld="-set floattype neutral_float"'],
+        lflags           => '-Wxld="-set floattype neutral_float"',
     },
     'nonstop-tfloat-x86_64' => {
         template         => 1,
-        lflags           => ['-Wxld="-set floattype tandem_float"'],
+        lflags           => '-Wxld="-set floattype tandem_float"',
     },
 
     ######################################################################
@@ -143,13 +143,13 @@
         template         => 1,
         defines          => ['_PUT_MODEL_',
                              '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
-        ex_libs          => ['-lput'],
+        ex_libs          => '-lput',
     },
     'nonstop-model-spt' => {
         template         => 1,
         defines          => ['_SPT_MODEL_',
                              '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
-        ex_libs          => ['-lspt'],
+        ex_libs          => '-lspt',
     },
 
     # Additional floss model that can be combined with any of the other models.
@@ -159,7 +159,7 @@
         template         => 1,
         defines          => ['OPENSSL_TANDEM_FLOSS'],
         includes         => ['/usr/local/include'],
-        ex_libs          => ['-lfloss'],
+        ex_libs          => '-lfloss',
     },
 
     ######################################################################

--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -16,6 +16,8 @@
                                 '_TANDEM_SOURCE',
                                 'B_ENDIAN'),
         perl             => '/usr/bin/perl',
+        shared_target    => 'self',
+        shared_extension => ".so",
         ex_libs          => add('-lrld'),
         enable           => ['egd'],
         dso_scheme       => 'DLFCN',
@@ -48,7 +50,7 @@
         defines          => ['NO_GETPID'],
         cflags           => '-Wtarget=tns/r -Wsystype=guardian',
         lflags           => '-Wld="-set systype guardian"',
-        shared_target    => 'nonstop-mips-guardian',
+        shared_ldflag    => '-Wshared -Wld="-export_all -soname $(@:lib%.so=%)"',
     },
 
     # Itanium + guardian:
@@ -57,7 +59,7 @@
         defines          => ['NO_GETPID', '_TANDEM_ARCH=2'],
         cflags           => '-Wtarget=tns/e -Wsystype=guardian',
         lflags           => '-Weld="-set systype guardian"',
-        shared_target    => 'nonstop-itanium-guardian',
+        shared_ldflag    => '-Wshared -Weld="-export_all -soname $(@:lib%.so=%)"',
     },
 
     # x86 + guardian:
@@ -66,7 +68,7 @@
         defines          => ['NO_GETPID', '_TANDEM_ARCH=3'],
         cflags           => '-Wtarget=tns/x -Wsystype=guardian',
         lflags           => '-Wxld="-set systype guardian"',
-        shared_target    => 'nonstop-x86-guardian',
+        shared_ldflag    => '-Wshared -Wxld="-export_all -soname $(@:lib%.so=%)"',
     },
 
     # MIPS + oss (unused but present for convenience):
@@ -74,7 +76,7 @@
         template         => 1,
         cflags           => '-Wtarget=tns/r -Wsystype=oss',
         lflags           => '-Wld="-set systype oss"',
-        shared_target    => 'nonstop-mips-oss',
+        shared_ldflag    => '-Wshared -Wld="-export_all"',
     },
     # Itanium + oss:
     'nonstop-archenv-itanium-oss' => {
@@ -82,7 +84,7 @@
         defines          => ['_TANDEM_ARCH=2'],
         cflags           => '-Wtarget=tns/e -Wsystype=oss',
         lflags           => '-Weld="-set systype oss"',
-        shared_target    => 'nonstop-itanium-oss',
+        shared_ldflag    => '-Wshared -Weld="-export_all"',
     },
     # x86_64 + oss:
     'nonstop-archenv-x86_64-oss' => {
@@ -90,7 +92,7 @@
         defines          => ['_TANDEM_ARCH=3'],
         cflags           => '-Wtarget=tns/x -Wsystype=oss',
         lflags           => '-Wxld="-set systype oss"',
-        shared_target    => 'nonstop-x86-oss',
+        shared_ldflag    => '-Wshared -Wxld="-export_all"',
     },
 
     # Size variants

--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -19,7 +19,7 @@
         ex_libs          => add('-lrld'),
         enable           => ['egd'],
         dso_scheme       => 'DLFCN',
-        sys_id           => 'tandem',
+        sys_id           => 'TANDEM',
     },
 
     ######################################################################

--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -191,7 +191,6 @@
                               'nonstop-archenv-x86_64-oss',
                               'nonstop-lp64-x86_64', 'nonstop-nfloat-x86_64',
                               'nonstop-model-put' ],
-        defines          => add('__TANDEM'),
     },
     'nonstop-nsx_spt' => {
         inherit_from     => [ 'nonstop-common',
@@ -225,7 +224,6 @@
                               'nonstop-archenv-itanium-oss',
                               'nonstop-ilp32', 'nonstop-nfloat-itanium',
                               'nonstop-model-floss' ],
-        defines          => add('__TANDEM'),
         disable          => ['threads'],
     },
     'nonstop-nse_put' => {

--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -1,176 +1,272 @@
 #### Nonstop configurations
-    "nonstop-common" => {
-        inherit_from     => [ "BASE_unix" ],
+    # Common for all
+    'nonstop-common' => {
+        inherit_from     => [ 'BASE_unix' ],
         template         => 1,
-        cc               => "c99",
-        cflags           => add_before(picker(debug   => "-g -O0",
-                                              release => "-g -O2") ,"-Wextensions -Wnowarn=203,220,272,734,770,1506 -Wbuild_neutral_library"),
-        perl             => "/usr/bin/perl",
-        lflags           => "-lrld",
-        shared_target    => "self",
-        shared_cflag     => "",
-        shared_ldflag    => "-Wshared",
-        shared_extension => ".so",
-        enable           => ["egd"],
-        dso_scheme       => "DLFCN",
-    },
-    "nonstop-nsx" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -I/usr/local/include") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -I/usr/local/include") },
-        lflags           => sub { join(" ",@_,"-lfloss -Wxld='-set floattype neutral_float' -Wsystype=oss") },
-        shared_ldflag    => sub { join(" ",@_,"-lfloss -Wxld='-export_all -set floattype neutral_float -set systype oss' -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "OPENSSL_TANDEM_FLOSS"],
-        disable          => ["threads"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nsx_put" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose") },
-        lflags           => sub { join(" ",@_,"-lput") },
-        shared_ldflag    => sub { join(" ",@_,"-Wxld='-export_all -set floattype neutral_float -set systype oss' -lput -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_PUT_MODEL_","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_ENABLE_FLOSS_THREADS", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nsx_64" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wlp64 -Wverbose") },
-        shared_cflag     => sub { join(" ",@_,"-Wlp64 -Wverbose") },
-        lflags           => sub { join(" ",@_,"-lfloss -Wlp64") },
-        shared_ldflag    => sub { join(" ",@_,"-lfloss -Wxld='-export_all -set data_model lp64 -set floattype neutral_float -set systype oss' -Wlp64 -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "OPENSSL_TANDEM_FLOSS"],
-        disable          => ["threads"],
-        bn_ops           => "SIXTY_FOUR_BIT",
-    },
-    "nonstop-nsx_64_put" => {
-        inherit_from     => [ "nonstop-common" ],
-        shared_cflag     => sub { join(" ",@_,"-Wlp64 -Wverbose -Wtarget=tns/x") },
-        cflags           => sub { join(" ",@_,"-Wlp64 -Wverbose -Wtarget=tns/x") },
-        lflags           => sub { join(" ",@_,"-Wxld='-set floattype neutral_float -set systype oss' -Wlp64 -lput -Wsystype=oss") },
-        shared_ldflag    => sub { join(" ",@_,"-Wxld='-export_all -set data_model lp64'") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_PUT_MODEL_","_TANDEM_ARCH=3","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_ENABLE_FLOSS_THREADS","__TANDEM", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM"],
-        bn_ops           => "SIXTY_FOUR_BIT",
-    },
-    "nonstop-nsx_spt" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/x") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/x") },
-        lflags           => sub { join(" ",@_,"-lspt -Wextensions") },
-        shared_ldflag    => sub { join(" ",@_,"-Wxld='-export_all -set floattype neutral_float -set systype oss' -lspt -Wextensions -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_SPT_MODEL_","_THREAD_SUPPORT_FUNCTIONS","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nsx_spt_floss" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-I/usr/local/include -Wverbose -Wtarget=tns/x") },
-        shared_cflag     => sub { join(" ",@_,"-I/usr/local/include -Wverbose -Wtarget=tns/x") },
-        lflags           => sub { join(" ",@_,"-lfloss -lspt -Wextensions") },
-        shared_ldflag    => sub { join(" ",@_,"-lfloss -Wxld='-export_all -set floattype neutral_float -set systype oss' -lspt -Wextensions -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_SPT_MODEL_","_THREAD_SUPPORT_FUNCTIONS","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM","OPENSSL_TANDEM_FLOSS"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nsx_g" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/x") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/x") },
-        lflags           => sub { join(" ",@_,"-Wsystype=guardian -Wxld='-set systype guardian -set floattype neutral_float'") },
-        shared_ldflag    => sub { join(" ",@_,"-Wxld='-export_all -set floattype neutral_float -soname \$\(\@:lib%.so=%\)  -set systype guardian' -Wsystype=guardian") },
-        #shared_extension => " ",
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "NO_GETPID"],
-        disable          => ["threads"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nsx_g_tandem" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/x") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/x") },
-        lflags           => sub { join(" ",@_,"-Wsystype=guardian -Wxld='-set systype guardian -set floattype tandem_float'") },
-        shared_ldflag    => sub { join(" ",@_,"-Wxld='-export_all -set floattype tandem_float -soname \$\(\@:lib%.so=%\)  -set systype guardian' -Wsystype=guardian") },
-        #shared_extension => " ",
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "NO_GETPID"],
-        disable          => ["threads"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nsv" => {
-        inherit_from     => [ "nonstop-nsx" ],
-    },
-    "nonstop-nse" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e -I/usr/local/include") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e -I/usr/local/include") },
-        lflags           => sub { join(" ",@_,"-lfloss") },
-        shared_ldflag    => sub { join(" ",@_,"-lfloss -Weld='-export_all -set floattype neutral_float -set systype oss' -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_TANDEM_ARCH=2","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","__TANDEM", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "OPENSSL_TANDEM_FLOSS"],
-        disable          => ["threads"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nse_put" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-lput") },
-        shared_ldflag    => sub { join(" ",@_,"-Weld='-export_all -set floattype neutral_float -set systype oss' -lput -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_PUT_MODEL_","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_ENABLE_FLOSS_THREADS", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nse_64" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wlp64 -Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wlp64 -Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-lfloss -Wlp64") },
-        shared_ldflag    => sub { join(" ",@_,"-lfloss -Weld='-export_all -set data_model lp64  -set floattype neutral_float -set systype oss' -Wlp64 -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "OPENSSL_TANDEM_FLOSS"],
-        disable          => ["threads"],
-        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR",
-    },
-    "nonstop-nse_64_put" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wlp64 -Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wlp64 -Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-lput -Wlp64") },
-        shared_ldflag    => sub { join(" ",@_,"-Weld='-export_all -set data_model lp64 -set floattype neutral_float -set systype oss' -Wlp64 -lput -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_PUT_MODEL_","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1","_ENABLE_FLOSS_THREADS", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM"],
-        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR",
-    },
-    "nonstop-nse_spt" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-lspt -Wextensions") },
-        shared_ldflag    => sub { join(" ",@_,"-Weld='-export_all -set floattype neutral_float -set systype oss' -lspt -Wextensions -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_SPT_MODEL_","_THREAD_SUPPORT_FUNCTIONS","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nse_spt_floss" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-lfloss -lspt -Wextensions") },
-        shared_ldflag    => sub { join(" ",@_,"-lfloss -Weld='-export_all -set floattype neutral_float -set systype oss' -lspt -Wextensions -Wsystype=oss") },
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_REENTRANT", "_SPT_MODEL_","_THREAD_SUPPORT_FUNCTIONS","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "OPENSSL_TANDEM_FLOSS"],
-        bn_ops           => "THIRTY_TWO_BIT",
-    },
-    "nonstop-nse_g" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-Wsystype=guardian -Weld='-set systype guardian'") },
-        shared_ldflag    => sub { join(" ",@_,"-Weld='-set systype guardian -export_all -set floattype neutral_float -soname \$\(\@:lib%.so=%\)' -Wsystype=guardian") },
-        #shared_extension => " ",
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "NO_GETPID"],
-        disable          => ["threads"],
-        bn_ops           => "THIRTY_TWO_BIT",
+        cc               => 'c99',
+        cflags           => add_before(picker(debug   => '-g -O0',
+                                              release => '-g -O2'),
+                                       '-Wextensions',
+                                       '-Wnowarn=203,220,272,734,770,1506',
+                                       '-Wbuild_neutral_library',
+                                       '-Wverbose'),
+        defines          => add('OPENSSL_VPROC=$(OPENSSL_VPROC)',
+                                '_XOPEN_SOURCE',
+                                '_XOPEN_SOURCE_EXTENDED=1',
+                                '_TANDEM_SOURCE',
+                                'B_ENDIAN'),
+        perl             => '/usr/bin/perl',
+        ex_libs          => add('-lrld'),
+        enable           => ['egd'],
+        dso_scheme       => 'DLFCN',
+        sys_id           => 'tandem',
     },
 
-    "nonstop-nse_g_tandem" => {
-        inherit_from     => [ "nonstop-common" ],
-        cflags           => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        shared_cflag     => sub { join(" ",@_,"-Wverbose -Wtarget=tns/e") },
-        lflags           => sub { join(" ",@_,"-Wsystype=guardian -Weld='-set systype guardian -set floattype tandem_float'") },
-        shared_ldflag    => sub { join(" ",@_,"-Wsystype=guardian -Weld='-set systype guardian -export_all -set floattype tandem_float -soname \$\(\@:lib%.so=%\)'") },
-        #shared_extension => " ",
-        defines          => ["OPENSSL_VPROC=\$(OPENSSL_VPROC)","_XOPEN_SOURCE","_XOPEN_SOURCE_EXTENDED=1", "_TANDEM_SOURCE", "B_ENDIAN", "OPENSSL_SYSNAME_TANDEM", "NO_GETPID"],
-        disable          => ["threads"],
-        bn_ops           => "THIRTY_TWO_BIT",
+    ######################################################################
+    # Additional variant settings, to be combined with nonstop-common
+    # Note that these do not inherit anything.  However, the diverse values
+    # are merged with other entries in an 'inherit_from'.
+    #
+    # These combine:
+    # - System architecture (MIPS, Itanium, or x86)
+    # - Execution environment (oss [default] or guardian)
+    #
+    # Unfortunately, they can't be separated into independent templates, because
+    # a number of the above are encoded as different linkers, and by consequence,
+    # different c99 linker flags (-Wld, -Weld, and -Wxld)
+    #
+    # In addition, the are modifiers for:
+    # - Size of long + pointer (ilp32 [default] and lp64)
+    # - Float type (neutral and tandem)
+    #
+    # Unfortunately, because the float types affect the linker settings, those
+    # are divided per system architecture
+    #
+    # MIPS + guardian (unused but present for convenience):
+    'nonstop-archenv-mips-guardian' => {
+        template         => 1,
+        defines          => ['NO_GETPID'],
+        cflags           => ['-Wtarget=tns/r', '-Wsystype=guardian'],
+        lflags           => ['-Wld="-set systype guardian"'],
+        shared_target    => 'nonstop-mips-guardian',
+    },
+
+    # Itanium + guardian:
+    'nonstop-archenv-itanium-guardian' => {
+        template         => 1,
+        defines          => ['NO_GETPID', '_TANDEM_ARCH=2'],
+        cflags           => ['-Wtarget=tns/e', '-Wsystype=guardian'],
+        lflags           => ['-Weld="-set systype guardian"'],
+        shared_target    => 'nonstop-itanium-guardian',
+    },
+
+    # x86 + guardian:
+    'nonstop-archenv-x86_64-guardian' => {
+        template         => 1,
+        defines          => ['NO_GETPID', '_TANDEM_ARCH=3'],
+        cflags           => ['-Wtarget=tns/x', '-Wsystype=guardian'],
+        lflags           => ['-Wxld="-set systype guardian"'],
+        shared_target    => 'nonstop-x86-guardian',
+    },
+
+    # MIPS + oss (unused but present for convenience):
+    'nonstop-archenv-mips-oss' => {
+        template         => 1,
+        cflags           => ['-Wtarget=tns/r', '-Wsystype=oss'],
+        lflags           => ['-Wld="-set systype oss"'],
+        shared_target    => 'nonstop-mips-oss',
+    },
+    # Itanium + oss:
+    'nonstop-archenv-itanium-oss' => {
+        template         => 1,
+        defines          => ['_TANDEM_ARCH=2'],
+        cflags           => ['-Wtarget=tns/e', '-Wsystype=oss'],
+        lflags           => ['-Weld="-set systype oss"'],
+        shared_target    => 'nonstop-itanium-oss',
+    },
+    # x86_64 + oss:
+    'nonstop-archenv-x86_64-oss' => {
+        template         => 1,
+        defines          => ['_TANDEM_ARCH=3'],
+        cflags           => ['-Wtarget=tns/x', '-Wsystype=oss'],
+        lflags           => ['-Wxld="-set systype oss"'],
+        shared_target    => 'nonstop-x86-oss',
+    },
+
+    # Size variants
+    'nonstop-ilp32' => {
+        template         => 1,
+        cflags           => ['-Wilp32'],
+        bn_ops           => 'THIRTY_TWO_BIT',
+    },
+    'nonstop-lp64-itanium' => {
+        template         => 1,
+        cflags           => ['-Wlp64'],
+        bn_ops           => 'SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR',
+    },
+    'nonstop-lp64-x86_64' => {
+        template         => 1,
+        cflags           => ['-Wlp64'],
+        lflags           => ['-Wxld="-set data_model lp64"'],
+        bn_ops           => 'SIXTY_FOUR_BIT',
+    },
+
+    # Float variants
+    'nonstop-nfloat-mips' => {
+        template         => 1,
+        lflags           => ['-Wld="-set floattype neutral_float"'],
+    },
+    'nonstop-tfloat-mips' => {
+        template         => 1,
+        lflags           => ['-Wld="-set floattype tandem_float"'],
+    },
+    'nonstop-nfloat-itanium' => {
+        template         => 1,
+        lflags           => ['-Weld="-set floattype neutral_float"'],
+    },
+    'nonstop-tfloat-itanium' => {
+        template         => 1,
+        lflags           => ['-Weld="-set floattype tandem_float"'],
+    },
+    'nonstop-nfloat-x86_64' => {
+        template         => 1,
+        lflags           => ['-Wxld="-set floattype neutral_float"'],
+    },
+    'nonstop-tfloat-x86_64' => {
+        template         => 1,
+        lflags           => ['-Wxld="-set floattype tandem_float"'],
+    },
+
+    ######################################################################
+    # Build models
+    'nonstop-model-put' => {
+        template         => 1,
+        defines          => ['_PUT_MODEL_',
+                             '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
+        ex_libs          => ['-lput'],
+    },
+    'nonstop-model-spt' => {
+        template         => 1,
+        defines          => ['_SPT_MODEL_',
+                             '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
+        ex_libs          => ['-lspt'],
+    },
+
+    # Additional floss model that can be combined with any of the other models.
+    # If used without any of the other models, the entry that does so must
+    # disable threads.
+    'nonstop-model-floss' => {
+        template         => 1,
+        defines          => ['OPENSSL_TANDEM_FLOSS'],
+        includes         => ['/usr/local/include'],
+        ex_libs          => ['-lfloss'],
+    },
+
+    ######################################################################
+    # Now for the entried themselves, let's combine things!
+    'nonstop-nsx' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-x86_64',
+                              'nonstop-model-floss' ],
+        disable          => ['threads'],
+    },
+    'nonstop-nsx_put' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-x86_64',
+                              'nonstop-model-put' ],
+    },
+    'nonstop-nsx_64' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss',
+                              'nonstop-lp64-x86_64', 'nonstop-nfloat-x86_64',
+                              'nonstop-model-floss' ],
+        disable          => ['threads'],
+    },
+    'nonstop-nsx_64_put' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss',
+                              'nonstop-lp64-x86_64', 'nonstop-nfloat-x86_64',
+                              'nonstop-model-put' ],
+        defines          => add('__TANDEM'),
+    },
+    'nonstop-nsx_spt' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss', 
+                              'nonstop-ilp32', 'nonstop-nfloat-x86_64',
+                              'nonstop-model-spt' ],
+    },
+    'nonstop-nsx_spt_floss' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-x86_64',
+                              'nonstop-model-floss', 'nonstop-model-spt'],
+    },
+    'nonstop-nsx_g' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-guardian',
+                              'nonstop-ilp32', 'nonstop-nfloat-x86_64' ],
+        disable          => ['threads'],
+    },
+    'nonstop-nsx_g_tandem' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-x86_64-guardian',
+                              'nonstop-ilp32', 'nonstop-tfloat-x86_64' ],
+        disable          => ['threads'],
+    },
+    'nonstop-nsv' => {
+        inherit_from     => [ 'nonstop-nsx' ],
+    },
+    'nonstop-nse' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-itanium',
+                              'nonstop-model-floss' ],
+        defines          => add('__TANDEM'),
+        disable          => ['threads'],
+    },
+    'nonstop-nse_put' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-itanium',
+                              'nonstop-model-put' ],
+    },
+    'nonstop-nse_64' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-oss',
+                              'nonstop-lp64-itanium', 'nonstop-nfloat-itanium',
+                              'nonstop-model-floss' ],
+        disable          => ['threads'],
+    },
+    'nonstop-nse_64_put' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-oss',
+                              'nonstop-lp64-itanium', 'nonstop-nfloat-itanium',
+                              'nonstop-model-put' ],
+    },
+    'nonstop-nse_spt' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-itanium',
+                              'nonstop-model-spt' ],
+    },
+    'nonstop-nse_spt_floss' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-oss',
+                              'nonstop-ilp32', 'nonstop-nfloat-itanium',
+                              'nonstop-model-floss', 'nonstop-model-spt' ],
+    },
+    'nonstop-nse_g' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-guardian',
+                              'nonstop-ilp32', 'nonstop-nfloat-itanium' ],
+        disable          => ['threads'],
+    },
+
+    'nonstop-nse_g_tandem' => {
+        inherit_from     => [ 'nonstop-common',
+                              'nonstop-archenv-itanium-guardian',
+                              'nonstop-ilp32', 'nonstop-tfloat-itanium' ],
+        disable          => ['threads'],
     },

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -90,28 +90,4 @@ my %shared_info;
             shared_sonameflag => "-Wl,-h,",
         };
     },
-    'nonstop-mips-oss-shared' => {
-        shared_ldflag         => '-Wshared -Wld="-export_all"',
-        shared_extension      => ".so",
-    },
-    'nonstop-itanium-oss-shared' => {
-        shared_ldflag         => '-Wshared -Weld="-export_all"',
-        shared_extension      => ".so",
-    },
-    'nonstop-x86-oss-shared' => {
-        shared_ldflag         => '-Wshared -Wxld="-export_all"',
-        shared_extension      => ".so",
-    },
-    'nonstop-mips-guardian-shared' => {
-        shared_ldflag         => '-Wshared -Wld="-export_all -soname $(@:lib%.so=%)"',
-        shared_extension      => ".so",
-    },
-    'nonstop-itanium-guardian-shared' => {
-        shared_ldflag         => '-Wshared -Weld="-export_all -soname $(@:lib%.so=%)"',
-        shared_extension      => ".so",
-    },
-    'nonstop-x86-guardian-shared' => {
-        shared_ldflag         => '-Wshared -Wxld="-export_all -soname $(@:lib%.so=%)"',
-        shared_extension      => ".so",
-    },
 );

--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -90,4 +90,28 @@ my %shared_info;
             shared_sonameflag => "-Wl,-h,",
         };
     },
+    'nonstop-mips-oss-shared' => {
+        shared_ldflag         => '-Wshared -Wld="-export_all"',
+        shared_extension      => ".so",
+    },
+    'nonstop-itanium-oss-shared' => {
+        shared_ldflag         => '-Wshared -Weld="-export_all"',
+        shared_extension      => ".so",
+    },
+    'nonstop-x86-oss-shared' => {
+        shared_ldflag         => '-Wshared -Wxld="-export_all"',
+        shared_extension      => ".so",
+    },
+    'nonstop-mips-guardian-shared' => {
+        shared_ldflag         => '-Wshared -Wld="-export_all -soname $(@:lib%.so=%)"',
+        shared_extension      => ".so",
+    },
+    'nonstop-itanium-guardian-shared' => {
+        shared_ldflag         => '-Wshared -Weld="-export_all -soname $(@:lib%.so=%)"',
+        shared_extension      => ".so",
+    },
+    'nonstop-x86-guardian-shared' => {
+        shared_ldflag         => '-Wshared -Wxld="-export_all -soname $(@:lib%.so=%)"',
+        shared_extension      => ".so",
+    },
 );

--- a/Configure
+++ b/Configure
@@ -3162,6 +3162,8 @@ sub print_table_entry
         "loutflag",
         "ex_libs",
         "bn_ops",
+        "enable",
+        "disable",
         "poly1035_asm_src",
         "thread_scheme",
         "perlasm_scheme",

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -26,7 +26,7 @@
 #ifndef W_OK
 # ifdef OPENSSL_SYS_VMS
 #  include <unistd.h>
-# elif !defined(OPENSSL_SYS_VXWORKS) && !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYSNAME_TANDEM)
+# elif !defined(OPENSSL_SYS_VXWORKS) && !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_TANDEM)
 #  include <sys/file.h>
 # endif
 #endif

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2410,7 +2410,7 @@ int raw_write_stdout(const void *buf, int siz)
     else
         return -1;
 }
-#elif defined(OPENSSL_SYSNAME_TANDEM) && defined(OPENSSL_THREADS) && defined(_SPT_MODEL_)
+#elif defined(OPENSSL_SYS_TANDEM) && defined(OPENSSL_THREADS) && defined(_SPT_MODEL_)
 # if defined(__TANDEM)
 #  if defined(OPENSSL_TANDEM_FLOSS)
 #   include <floss.h(floss_write)>

--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -54,7 +54,7 @@ struct sockaddr_un {
 # include <string.h>
 # include <errno.h>
 
-# if defined(OPENSSL_SYSNAME_TANDEM)
+# if defined(OPENSSL_SYS_TANDEM)
 /*
  * HPNS:
  *
@@ -125,7 +125,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
         return -1;
     strcpy(addr.sun_path, path);
     i = offsetof(struct sockaddr_un, sun_path) + strlen(path);
-#if defined(OPENSSL_SYSNAME_TANDEM)
+#if defined(OPENSSL_SYS_TANDEM)
     fd = hpns_socket(AF_UNIX, SOCK_STREAM, 0, AF_UNIX_COMPATIBILITY);
 #else
     fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -158,7 +158,7 @@ int RAND_query_egd_bytes(const char *path, unsigned char *buf, int bytes)
             /* No error, try again */
             break;
         default:
-# if defined(OPENSSL_SYSNAME_TANDEM)
+# if defined(OPENSSL_SYS_TANDEM)
             if (hpns_connect_attempt == 0) {
                 /* try the other kind of AF_UNIX socket */
                 close(fd);

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -145,7 +145,7 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  define closesocket(s)              close(s)
 #  define readsocket(s,b,n)           read((s),(b),(n))
 #  define writesocket(s,b,n)          write((s),(char *)(b),(n))
-# elif defined(OPENSSL_SYSNAME_TANDEM)
+# elif defined(OPENSSL_SYS_TANDEM)
 #  if defined(OPENSSL_TANDEM_FLOSS)
 #   include <floss.h(floss_read, floss_write)>
 #   define readsocket(s,b,n)       floss_read((s),(b),(n))


### PR DESCRIPTION
Using inheritance, the NonStop configuration entries become quite small, and we don't copy values all over the place.

Fixes #12858