### PR TITLE
DOC: remove OPENSSL_CTX from OSSL_DECODER_CTX_new

### DIFF
--- a/doc/man3/OSSL_DECODER_CTX.pod
+++ b/doc/man3/OSSL_DECODER_CTX.pod
@@ -15,7 +15,7 @@ OSSL_DECODER_CTX_free
 
  typedef struct ossl_decoder_ctx_st OSSL_DECODER_CTX;
 
- OSSL_DECODER_CTX *OSSL_DECODER_CTX_new(OPENSSL_CTX *libctx);
+ OSSL_DECODER_CTX *OSSL_DECODER_CTX_new(void);
  const OSSL_PARAM *OSSL_DECODER_settable_ctx_params(OSSL_DECODER *decoder);
  int OSSL_DECODER_CTX_set_params(OSSL_DECODER_CTX *ctx,
                                  const OSSL_PARAM params[]);


### PR DESCRIPTION
This commit changes the man page for OSSL_DECODER_CTX_new by removing
the OPENSSL_CTX parameter which matches the declaration in decoder.h.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
