### PR TITLE
Configurations/unix-Makefile.tmpl: make cleanup kinder

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -518,13 +518,13 @@ clean: libclean
 	$(RM) $(MANDOCS1) $(MANDOCS3) $(MANDOCS5) $(MANDOCS7)
 	$(RM) $(PROGRAMS) $(TESTPROGS) $(MODULES) $(SCRIPTS)
 	$(RM) $(GENERATED_MANDATORY) $(GENERATED)
-	-$(RM) `find . -name '*{- platform->depext() -}' \! -name '.*' \! -type d -print`
-	-$(RM) `find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -print`
+	-find . -name '*{- platform->depext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
+	-find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
 	$(RM) core
 	$(RM) tags TAGS doc-nits cmd-nits md-nits
 	$(RM) -r test/test-runs
 	$(RM) openssl.pc libcrypto.pc libssl.pc
-	-$(RM) `find . -type l \! -name '.*' -print`
+	-find . -type l \! -name '.*' -exec $(RM) {} \;
 	$(RM) $(TARFILE)
 
 distclean: clean


### PR DESCRIPTION
The removal of certain types of files we structured like this:

    -$(RM) `find . {{options}} -print`

This isn't very kind for shells with limited command line lengths
(even when that limit is generous, in our case), so we rewrite those
like this:

    -find . {{options}} -exec $(RM) {} \;

Fixes #12938