### PR TITLE
Revert two renamings backported from master

### DIFF
--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -288,7 +288,7 @@ seed the DRBG.
 Specify the minimum and maximum number of bytes of personalisation string
 that can be used with the DRBG.
 
-=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_CTR>) <unsigned integer>
+=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
 Specifies the number of times the DRBG has been seeded or reseeded.
 

--- a/doc/man7/EVP_RAND-CTR-DRBG.pod
+++ b/doc/man7/EVP_RAND-CTR-DRBG.pod
@@ -42,7 +42,7 @@ The supported parameters are:
 
 =item "max_adinlen" (B<OSSL_DRBG_PARAM_MAX_ADINLEN>) <unsigned integer>
 
-=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_CTR>) <unsigned integer>
+=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
 =item "properties" (B<OSSL_DRBG_PARAM_PROPERTIES>) <UTF8 string>
 

--- a/doc/man7/EVP_RAND-HASH-DRBG.pod
+++ b/doc/man7/EVP_RAND-HASH-DRBG.pod
@@ -42,7 +42,7 @@ The supported parameters are:
 
 =item "max_adinlen" (B<OSSL_DRBG_PARAM_MAX_ADINLEN>) <unsigned integer>
 
-=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_CTR>) <unsigned integer>
+=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
 =item "properties" (B<OSSL_DRBG_PARAM_PROPERTIES>) <UTF8 string>
 

--- a/doc/man7/EVP_RAND-HMAC-DRBG.pod
+++ b/doc/man7/EVP_RAND-HMAC-DRBG.pod
@@ -42,7 +42,7 @@ The supported parameters are:
 
 =item "max_adinlen" (B<OSSL_DRBG_PARAM_MAX_ADINLEN>) <unsigned integer>
 
-=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_CTR>) <unsigned integer>
+=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
 =item "properties" (B<OSSL_DRBG_PARAM_PROPERTIES>) <UTF8 string>
 

--- a/doc/man7/EVP_RAND-TEST-RAND.pod
+++ b/doc/man7/EVP_RAND-TEST-RAND.pod
@@ -44,7 +44,7 @@ These parameter works as described in L<EVP_RAND(3)/PARAMETERS>.
 
 =item "max_adinlen" (B<OSSL_DRBG_PARAM_MAX_ADINLEN>) <unsigned integer>
 
-=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_CTR>) <unsigned integer>
+=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
 These parameters work as described in L<EVP_RAND(3)/PARAMETERS>, except that
 they can all be set as well as read.

--- a/doc/man7/provider-rand.pod
+++ b/doc/man7/provider-rand.pod
@@ -208,7 +208,7 @@ instantiate the DRBG.
 Specify the minimum and maximum number of bytes of personalisation string
 that can be used with the DRBG.
 
-=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_CTR>) <unsigned integer>
+=item "reseed_counter" (B<OSSL_DRBG_PARAM_RESEED_COUNTER>) <unsigned integer>
 
 Specifies the number of times the DRBG has been seeded or reseeded.
 

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -227,7 +227,7 @@ extern "C" {
 #define OSSL_DRBG_PARAM_MAX_NONCELEN            "max_noncelen"
 #define OSSL_DRBG_PARAM_MAX_PERSLEN             "max_perslen"
 #define OSSL_DRBG_PARAM_MAX_ADINLEN             "max_adinlen"
-#define OSSL_DRBG_PARAM_RESEED_CTR              "reseed_counter"
+#define OSSL_DRBG_PARAM_RESEED_COUNTER          "reseed_counter"
 #define OSSL_DRBG_PARAM_RESEED_TIME             "reseed_time"
 #define OSSL_DRBG_PARAM_PROPERTIES              OSSL_ALG_PARAM_PROPERTIES
 #define OSSL_DRBG_PARAM_DIGEST                  OSSL_ALG_PARAM_DIGEST

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -323,7 +323,7 @@ static int drbg_hash_generate(PROV_DRBG *drbg,
 {
     PROV_DRBG_HASH *hash = (PROV_DRBG_HASH *)drbg->data;
     unsigned char counter[4];
-    int reseed_counter = drbg->reseed_gen_counter;
+    int reseed_counter = drbg->generate_counter;
 
     counter[0] = (unsigned char)((reseed_counter >> 24) & 0xff);
     counter[1] = (unsigned char)((reseed_counter >> 16) & 0xff);

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -150,7 +150,7 @@ struct prov_drbg_st {
      * (Starts at 1). This value is the reseed_counter as defined in
      * NIST SP 800-90Ar1
      */
-    unsigned int reseed_gen_counter;
+    unsigned int generate_counter;
     /*
      * Maximum number of generate requests until a reseed is required.
      * This value is ignored if it is zero.
@@ -252,7 +252,7 @@ int drbg_set_ctx_params(PROV_DRBG *drbg, const OSSL_PARAM params[]);
     OSSL_PARAM_size_t(OSSL_DRBG_PARAM_MAX_NONCELEN, NULL),              \
     OSSL_PARAM_size_t(OSSL_DRBG_PARAM_MAX_PERSLEN, NULL),               \
     OSSL_PARAM_size_t(OSSL_DRBG_PARAM_MAX_ADINLEN, NULL),               \
-    OSSL_PARAM_uint(OSSL_DRBG_PARAM_RESEED_CTR, NULL),                  \
+    OSSL_PARAM_uint(OSSL_DRBG_PARAM_RESEED_COUNTER, NULL),                  \
     OSSL_PARAM_time_t(OSSL_DRBG_PARAM_RESEED_TIME, NULL),               \
     OSSL_PARAM_uint(OSSL_DRBG_PARAM_RESEED_REQUESTS, NULL),             \
     OSSL_PARAM_uint64(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL, NULL)

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -236,7 +236,7 @@ static int test_rng_set_ctx_params(void *vdrbg, const OSSL_PARAM params[])
         t->nonce_len = size;
     }
 
-    p = OSSL_PARAM_locate_const(params, OSSL_DRBG_PARAM_RESEED_CTR);
+    p = OSSL_PARAM_locate_const(params, OSSL_DRBG_PARAM_RESEED_COUNTER);
     if (p != NULL) {
         if (!OSSL_PARAM_get_uint(p, &uint))
             return 0;
@@ -277,7 +277,7 @@ static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *provctx)
         OSSL_PARAM_size_t(OSSL_DRBG_PARAM_MAX_NONCELEN, NULL),
         OSSL_PARAM_size_t(OSSL_DRBG_PARAM_MAX_PERSLEN, NULL),
         OSSL_PARAM_size_t(OSSL_DRBG_PARAM_MAX_ADINLEN, NULL),
-        OSSL_PARAM_uint(OSSL_DRBG_PARAM_RESEED_CTR, NULL),
+        OSSL_PARAM_uint(OSSL_DRBG_PARAM_RESEED_COUNTER, NULL),
         OSSL_PARAM_time_t(OSSL_DRBG_PARAM_RESEED_TIME, NULL),
         OSSL_PARAM_DRBG_SETTABLE_CTX_COMMON,
         OSSL_PARAM_END


### PR DESCRIPTION
The original names were more intuitive: the generate_counter counts the number of generate requests, and the reseed_counter counts the number of reseedings (of the principal DRBG).

    reseed_gen_counter  -> generate_counter
    reseed_prop_counter -> reseed_counter

This is the anologue to commit 8380f453ec81d9172b94a82c3592f78f1a612046 on the 1.1.1 stable branch. The only difference is that the second renaming has already been reverted on the master branch.

_(This is the part of #12871 which needs to be merged before beta1)_